### PR TITLE
Use the name of the executed binary in the warning message

### DIFF
--- a/cli/update.go
+++ b/cli/update.go
@@ -148,9 +148,9 @@ func notifyUserUpdate(ac *APIClient) {
 	update, err := checkUpdate(ac, true)
 	if update.needsUpdate && err == nil {
 		if runtime.GOOS == "windows" {
-			fmt.Println("A new version is available. Run 'evergreen get-update' to fetch it.")
+			fmt.Printf("A new version is available. Run '%s get-update' to fetch it.\n", os.Args[0])
 		} else {
-			fmt.Println("A new version is available. Run 'evergreen get-update --install' to download and install it.")
+			fmt.Printf("A new version is available. Run '%s get-update --install' to download and install it.\n", os.Args[0])
 		}
 	}
 }


### PR DESCRIPTION
My binary name was evergreen-patch and I was littlebit confused what exactly it was asking me to upgrade when it told me to run "evergreen get-update" as I had no "evergreen" binary :)