### PR TITLE
EVG-226 remove sorting by compile and push from js

### DIFF
--- a/public/static/js/version.js
+++ b/public/static/js/version.js
@@ -82,11 +82,7 @@ function VersionController($scope, $location, $http, $filter, $now, $window) {
       }
       $scope.taskGrid[version.Builds[i].Build.display_name] = row;
     }
-    $scope.taskNames = Object.keys(taskNames).sort(function(a, b) {
-      if (a == 'compile' || b == 'push') return -1;
-      if (a == 'push' || b == 'compile') return 1;
-      return a.localeCompare(b);
-    })
+    $scope.taskNames = Object.keys(taskNames).sort()
     $scope.lastUpdate = $now.now();
   };
 

--- a/public/static/js/waterfall.js
+++ b/public/static/js/waterfall.js
@@ -215,18 +215,6 @@ mciModule
         scope.failed = 0;
         scope.succeeded = 0;
         if (scope.build.tasks) {
-          scope.build.tasks.sort(function(a, b) {
-              if (a.display_name == "compile") {
-                return -1
-              } else if (a.display_name == "push") {
-                return 1
-              } else if (b.display_name == "compile") {
-                return 1
-              } else if (b.display_name == "push") {
-                return -1
-              }
-              return a.display_name.localeCompare(b.display_name)
-            })
             // compute the number of failed and succeeded tasks
           for (var i = 0; i < scope.build.tasks.length; i++) {
             switch (scope.build.tasks[i].status) {


### PR DESCRIPTION
Do not deploy until recent task caches are sorted by dependency.