### PR TITLE
EVG-1083 raise DefaultLogMessages to 100

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -273,7 +273,7 @@ type taskHistoryPageData struct {
 }
 
 // the task's most recent log messages
-const DefaultLogMessages = 20 // passed as a limit, so 0 means don't limit
+const DefaultLogMessages = 100 // passed as a limit, so 0 means don't limit
 
 const AllLogsType = "ALL"
 


### PR DESCRIPTION
I haven't tested so I'm not sure if this will actually do what it seems to. But it if does, I'd appreciate merging this. A large percent of interesting messages happen higher than 20 lines above the bottom. If 100 is too high, 50 would probably also cover many cases.