### PR TITLE
EVG-1618 Ensuring 'view logs' link in task failure email is correct

### DIFF
--- a/alerts/templates/email/task_fail.html
+++ b/alerts/templates/email/task_fail.html
@@ -30,7 +30,7 @@
         <tr><td colspan="2" height="10"></td></tr>
         <tr>
           <td width="90%">
-            <a href="{{ .URL }}" style="font-family:Arial,sans-serif;font-weight:normal;font-size:13px;color:#006cbc" class="link">view logs</a>
+            <a href="{{$.Settings.Ui.Url}}/{{ .URL }}" style="font-family:Arial,sans-serif;font-weight:normal;font-size:13px;color:#006cbc" class="link">view logs</a>
           </td>
           <td>&nbsp;</td>
         </tr>


### PR DESCRIPTION
Please sanity check this - it's my first PR to EVG. 