### PR TITLE
EVG-1656 Add time zone entry for United Kingdom and Ireland

### DIFF
--- a/public/static/js/settings.js
+++ b/public/static/js/settings.js
@@ -15,6 +15,7 @@ mciModule.controller('SettingsCtrl', ['$scope', '$http', '$window', 'notificatio
     {str: "Fernando de Noronha", value: "America/Noronha"},
     {str: "Cape Verde", value: "Atlantic/Cape_Verde"},
     {str: "Iceland", value: "Atlantic/Reykjavik"},
+    {str: "United Kingdom, Ireland", value: "Europe/London"},
     {str: "Central European Time, Nigeria", value: "Europe/Rome"},
     {str: "Egypt, Israel, Romania", value: "Europe/Bucharest"},
     {str: "Ethiopia, Iraq, Yemen", value: "Asia/Baghdad"},


### PR DESCRIPTION
It is very useful to have Evergreen at least being able to report times in time
zones where we have employees, and both the UK and Dublin were missing.
Although they historically did not keep the same time, they do now, so putting
them both under Europe/London works.