### PR TITLE
EVG-2074 Fix idle timeout

### DIFF
--- a/agent/background.go
+++ b/agent/background.go
@@ -73,6 +73,7 @@ func (a *Agent) startIdleTimeoutWatch(ctx context.Context, tc *taskContext, idle
 			if !timer.Stop() {
 				<-timer.C
 			}
+			idleTimeoutInterval = d
 			timer.Reset(d)
 		case <-ctx.Done():
 			grip.Info("Idle timeout watch canceled")

--- a/rest/client/sender.go
+++ b/rest/client/sender.go
@@ -81,8 +81,10 @@ backgroundSender:
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			s.flush(ctx, buffer)
-			buffer = []apimodels.LogMessage{}
+			if len(buffer) > 0 {
+				s.flush(ctx, buffer)
+				buffer = []apimodels.LogMessage{}
+			}
 			timer.Reset(bufferTime)
 		case m := <-s.pipe:
 			buffer = append(buffer, s.convertMessage(m))


### PR DESCRIPTION
- Stop flush from updating the last message time.
- Update the idleTimeoutInterval before resetting the timer.