### PR TITLE
EVG-2134 revert to <1.6.0 angular location hash settings

### DIFF
--- a/public/static/js/mci_module.js
+++ b/public/static/js/mci_module.js
@@ -381,4 +381,6 @@ var mciModule = angular.module('MCI', [
   return $time;
 }]).config(['$compileProvider', function ($compileProvider) {
   //$compileProvider.debugInfoEnabled(false);
+}]).config(['$locationProvider', function($locationProvider) {
+  $locationProvider.hashPrefix('');
 }]);


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/41211875/angularjs-1-6-0-latest-now-routes-not-working