### PR TITLE
EVG-2091 improve performance of hosts page

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/pkg/errors"
@@ -460,6 +461,24 @@ func statsByDistroPipeline() []bson.M {
 				"count":             1,
 				"num_tasks_running": bson.M{"$size": "$tasks"},
 				"_id":               0,
+			},
+		},
+	}
+}
+
+// QueryWithFullTaskPipeline returns a pipeline to match hosts and embeds the
+// task document within the host, if it's running a task
+func QueryWithFullTaskPipeline(match bson.M) []bson.M {
+	return []bson.M{
+		{
+			"$match": match,
+		},
+		{
+			"$lookup": bson.M{
+				"from":         task.Collection,
+				"localField":   RunningTaskKey,
+				"foreignField": task.IdKey,
+				"as":           "task_full",
 			},
 		},
 	}

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -481,5 +481,11 @@ func QueryWithFullTaskPipeline(match bson.M) []bson.M {
 				"as":           "task_full",
 			},
 		},
+		{
+			"$unwind": bson.M{
+				"path": "$task_full",
+				"preserveNullAndEmptyArrays": true,
+			},
+		},
 	}
 }

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -35,6 +36,8 @@ type Host struct {
 
 	// the task that is currently running on the host
 	RunningTask string `bson:"running_task,omitempty" json:"running_task,omitempty"`
+	// the full task struct that is running on the host (only populated by certain aggregations)
+	RunningTaskFull []task.Task `bson:"task_full,omitempty" json:"task_full,omitempty"`
 
 	// the pid of the task that is currently running on the host
 	Pid string `bson:"pid" json:"pid"`

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -37,7 +37,7 @@ type Host struct {
 	// the task that is currently running on the host
 	RunningTask string `bson:"running_task,omitempty" json:"running_task,omitempty"`
 	// the full task struct that is running on the host (only populated by certain aggregations)
-	RunningTaskFull []task.Task `bson:"task_full,omitempty" json:"task_full,omitempty"`
+	RunningTaskFull *task.Task `bson:"task_full,omitempty" json:"task_full,omitempty"`
 
 	// the pid of the task that is currently running on the host
 	Pid string `bson:"pid" json:"pid"`

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -980,7 +980,7 @@ func TestHostFindingWithTask(t *testing.T) {
 	assert.NoError(err)
 
 	assert.Equal(3, len(hosts))
-	assert.Equal(task1.Id, hosts[0].RunningTaskFull[0].Id)
-	assert.Equal(task2.Id, hosts[1].RunningTaskFull[0].Id)
-	assert.Equal(0, len(hosts[2].RunningTaskFull))
+	assert.Equal(task1.Id, hosts[0].RunningTaskFull.Id)
+	assert.Equal(task2.Id, hosts[1].RunningTaskFull.Id)
+	assert.Nil(hosts[2].RunningTaskFull)
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -931,4 +932,55 @@ func TestHostStats(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestHostFindingWithTask(t *testing.T) {
+	testutil.HandleTestingErr(db.ClearCollections(Collection, task.Collection), t, "error clearing collections")
+	assert := assert.New(t)
+	task1 := task.Task{
+		Id: "task1",
+	}
+	task2 := task.Task{
+		Id: "task2",
+	}
+	task3 := task.Task{
+		Id: "task3",
+	}
+	host1 := Host{
+		Id:          "host1",
+		RunningTask: task1.Id,
+		Status:      evergreen.HostRunning,
+	}
+	host2 := Host{
+		Id:          "host2",
+		RunningTask: task2.Id,
+		Status:      evergreen.HostRunning,
+	}
+	host3 := Host{
+		Id:          "host3",
+		RunningTask: "",
+		Status:      evergreen.HostRunning,
+	}
+	host4 := Host{
+		Id:     "host4",
+		Status: evergreen.HostTerminated,
+	}
+	assert.NoError(task1.Insert())
+	assert.NoError(task2.Insert())
+	assert.NoError(task3.Insert())
+	assert.NoError(host1.Insert())
+	assert.NoError(host2.Insert())
+	assert.NoError(host3.Insert())
+	assert.NoError(host4.Insert())
+
+	var hosts []Host
+	err := db.Aggregate(Collection, QueryWithFullTaskPipeline(
+		bson.M{StatusKey: bson.M{"$ne": evergreen.HostTerminated}}),
+		&hosts)
+	assert.NoError(err)
+
+	assert.Equal(3, len(hosts))
+	assert.Equal(task1.Id, hosts[0].RunningTaskFull[0].Id)
+	assert.Equal(task2.Id, hosts[1].RunningTaskFull[0].Id)
+	assert.Equal(0, len(hosts[2].RunningTaskFull))
 }

--- a/public/static/js/hosts.js
+++ b/public/static/js/hosts.js
@@ -73,6 +73,7 @@ mciModule.controller('HostsCtrl', function($scope, $filter, $window, $location) 
   $scope.filter = {
     hosts : filterOpts[2] || ''
   };
+  $scope.filterText = $scope.filter.hosts;
   $scope.selectAll = false;
   $scope.filteredHosts = $scope.hosts;
 
@@ -128,10 +129,6 @@ mciModule.controller('HostsCtrl', function($scope, $filter, $window, $location) 
     $scope.hosts.push(host);
   });
 
-  $scope.selectedHosts = function() {
-    return $filter('filter')($scope.hosts, {checked: true});
-  };
-
   $scope.toggleHostCheck = function(host) {
     host.checked = !host.checked;
   };
@@ -151,6 +148,12 @@ mciModule.controller('HostsCtrl', function($scope, $filter, $window, $location) 
         $scope.filteredHosts[idx].checked = val;
     }
   };
+
+  $scope.onFilterKeyUp = function(event) {
+    if (event.key === "Enter") {
+      $scope.filter.hosts = $scope.filterText;
+    }
+  }
 
   $scope.$watch('hosts', function(hosts) {
     $scope.hostCount = 0;

--- a/public/static/js/hosts.js
+++ b/public/static/js/hosts.js
@@ -149,7 +149,7 @@ mciModule.controller('HostsCtrl', function($scope, $filter, $window, $location) 
     }
   };
 
-  $scope.onFilterKeyUp = function(event) {
+  $scope.onFilterKeyDown = function(event) {
     if (event.key === "Enter") {
       $scope.filter.hosts = $scope.filterText;
     }

--- a/service/models.go
+++ b/service/models.go
@@ -356,8 +356,8 @@ func getHostsData(includeSpawnedHosts bool) (*hostsData, error) {
 
 		uiHosts[idx] = host
 		// get the task running on this host
-		if dbHost.RunningTaskFull != nil && len(dbHost.RunningTaskFull) > 0 {
-			uiHosts[idx].RunningTask = &dbHost.RunningTaskFull[0]
+		if dbHost.RunningTaskFull != nil {
+			uiHosts[idx].RunningTask = dbHost.RunningTaskFull
 		}
 		uiHosts[idx].IdleTime = host.Host.IdleTime().Seconds()
 	}

--- a/service/models.go
+++ b/service/models.go
@@ -329,18 +329,23 @@ func getHostsData(includeSpawnedHosts bool) (*hostsData, error) {
 	// get all of the hosts
 	var dbHosts []host.Host
 	var err error
+	var query bson.M
 	if includeSpawnedHosts {
-		dbHosts, err = host.Find(host.IsRunning)
+		query = bson.M{host.StatusKey: bson.M{"$ne": evergreen.HostTerminated}}
 	} else {
-		dbHosts, err = host.Find(host.ByUserWithRunningStatus(evergreen.User))
+		query = bson.M{
+			host.StartedByKey: evergreen.User,
+			host.StatusKey:    bson.M{"$ne": evergreen.HostTerminated},
+		}
 	}
-
+	err = db.Aggregate(host.Collection, host.QueryWithFullTaskPipeline(query), &dbHosts)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
 	// convert the hosts to the ui models
 	uiHosts := make([]uiHost, len(dbHosts))
+
 	for idx, dbHost := range dbHosts {
 		// we only need the distro id for the hosts page
 		dbHost.Distro = distro.Distro{Id: dbHost.Distro.Id}
@@ -351,14 +356,8 @@ func getHostsData(includeSpawnedHosts bool) (*hostsData, error) {
 
 		uiHosts[idx] = host
 		// get the task running on this host
-		if dbHost.RunningTask != "" {
-			t, err := task.FindOne(task.ById(dbHost.RunningTask))
-			if err != nil {
-				return nil, errors.WithStack(err)
-			}
-			grip.ErrorWhenf(t == nil, "Hosts page could not find task %s for host %s",
-				dbHost.RunningTask, dbHost.Id)
-			uiHosts[idx].RunningTask = t
+		if dbHost.RunningTaskFull != nil && len(dbHost.RunningTaskFull) > 0 {
+			uiHosts[idx].RunningTask = &dbHost.RunningTaskFull[0]
 		}
 		uiHosts[idx].IdleTime = host.Host.IdleTime().Seconds()
 	}

--- a/service/templates/hosts.html
+++ b/service/templates/hosts.html
@@ -22,7 +22,7 @@ Evergreen - Hosts
     <!-- the filter inputs -->
     <form class="form-inline header-form" role="form">
       <div class="form-group">
-        <input class="form-control input-sm" type="text" ng-keyup="clearSelectAll()" ng-model="filter.hosts" placeholder="Filter hosts..." />
+        <input class="form-control input-sm" type="text" ng-keyup="onFilterKeyUp($event)" ng-model="filterText" placeholder="Filter hosts..." />
       </div>
 
       <div class="checkbox">

--- a/service/templates/hosts.html
+++ b/service/templates/hosts.html
@@ -22,7 +22,7 @@ Evergreen - Hosts
     <!-- the filter inputs -->
     <form class="form-inline header-form" role="form">
       <div class="form-group">
-        <input class="form-control input-sm" type="text" ng-keyup="onFilterKeyUp($event)" ng-model="filterText" placeholder="Filter hosts..." />
+        <input class="form-control input-sm" type="text" ng-keydown="onFilterKeyDown($event)" ng-model="filterText" placeholder="Filter hosts..." />
       </div>
 
       <div class="checkbox">


### PR DESCRIPTION
The 2 changes are:
- Instead of running 1 db query per host that's running a task to get the task data, get all of it in 1 aggregation
- Stop filtering hosts as you type and instead filter once you hit enter