### PR TITLE
EVG-1726: add task finder feature flag, alternate implementations

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	legacyDB "github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/send"
 	"github.com/pkg/errors"
@@ -132,8 +133,8 @@ type SMTPConfig struct {
 
 // SchedulerConfig holds relevant settings for the scheduler process.
 type SchedulerConfig struct {
-	MergeToggle         int  `yaml:"mergetoggle"`
-	UseLegacyTaskFinder bool `yaml:"use_legacy_task_finder"`
+	MergeToggle int    `yaml:"mergetoggle"`
+	TaskFinder  string `yaml:"task_finder"`
 }
 
 // TaskRunnerConfig holds logging settings for the scheduler process.
@@ -424,6 +425,23 @@ var configValidationRules = []configValidator{
 	func(settings *Settings) error {
 		if settings.ClientBinariesDir == "" {
 			settings.ClientBinariesDir = ClientDirectory
+		}
+		return nil
+	},
+
+	func(settings *Settings) error {
+		finders := []string{"legacy", "alternate", "parallel", "pipeline"}
+
+		if settings.Scheduler.TaskFinder == "" {
+			// default to alternate
+			settings.Scheduler.TaskFinder = finders[0]
+			return nil
+		}
+
+		if !util.SliceContains(finders, settings.Scheduler.TaskFinder) {
+			return errors.Errorf("supported finders are %s; %s is not supported",
+				finders, settings.Scheduler.TaskFinder)
+
 		}
 		return nil
 	},

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -611,6 +611,21 @@ func FindOne(query db.Q) (*Task, error) {
 	return task, err
 }
 
+func FindOneId(id string) (*Task, error) {
+	task := &Task{}
+	query := db.Query(bson.M{IdKey: id})
+	err := db.FindOneQ(Collection, query, task)
+
+	if err == mgo.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "")
+	}
+
+	return task, nil
+}
+
 // FindOneOld returns one task from the old tasks collection that satisfies the query.
 func FindOneOld(query db.Q) (*Task, error) {
 	task := &Task{}
@@ -648,10 +663,10 @@ func Find(query db.Q) ([]Task, error) {
 		return nil, nil
 	}
 	// for i, task := range tasks {
-	// 	if err = task.MergeNewTestResults(); err != nil {
-	// 		return nil, errors.Wrap(err, "error merging new test results")
-	// 	}
-	// 	tasks[i] = task
+	//	if err = task.MergeNewTestResults(); err != nil {
+	//		return nil, errors.Wrap(err, "error merging new test results")
+	//	}
+	//	tasks[i] = task
 	// }
 	return tasks, err
 }

--- a/scheduler/runner.go
+++ b/scheduler/runner.go
@@ -49,10 +49,18 @@ func (r *Runner) Run(ctx context.Context, config *evergreen.Settings) error {
 		&DBTaskDurationEstimator{},
 		&DBTaskQueuePersister{},
 		&DurationBasedHostAllocator{},
-		FindRunnableTasks,
+		LegacyFindRunnableTasks,
 	}
-	if config.Scheduler.UseLegacyTaskFinder {
+
+	switch config.Scheduler.TaskFinder {
+	case "parallel":
+		schedulerInstance.FindRunnableTasks = ParallelTaskFinder
+	case "legacy":
 		schedulerInstance.FindRunnableTasks = LegacyFindRunnableTasks
+	case "pipeline":
+		schedulerInstance.FindRunnableTasks = FindRunnableTasks
+	case "alternate":
+		schedulerInstance.FindRunnableTasks = AlternateTaskFinder
 	}
 
 	if err := schedulerInstance.Schedule(ctx); err != nil {

--- a/scheduler/task_finder.go
+++ b/scheduler/task_finder.go
@@ -1,6 +1,8 @@
 package scheduler
 
 import (
+	"sync"
+
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
 )
@@ -35,4 +37,105 @@ func LegacyFindRunnableTasks() ([]task.Task, error) {
 	}
 
 	return runnableTasks, nil
+}
+
+func AlternateTaskFinder() ([]task.Task, error) {
+	undispatchedTasks, err := task.Find(task.IsUndispatched)
+	if err != nil {
+		return nil, err
+	}
+
+	cache := make(map[string]task.Task)
+	lookupSet := make(map[string]struct{})
+	catcher := grip.NewBasicCatcher()
+
+	for _, t := range undispatchedTasks {
+		cache[t.Id] = t
+		for _, dep := range t.DependsOn {
+			lookupSet[dep.TaskId] = struct{}{}
+		}
+	}
+
+	for t := range lookupSet {
+		if _, ok := cache[t]; ok {
+			continue
+		}
+		nt, err := task.FindOneId(t)
+		catcher.Add(err)
+		if nt == nil {
+			continue
+		}
+		cache[t] = *nt
+	}
+
+	runnabletasks := []task.Task{}
+	for _, t := range undispatchedTasks {
+		depsMet, err := t.DependenciesMet(cache)
+		catcher.Add(err)
+		if depsMet {
+			runnabletasks = append(runnabletasks, t)
+		}
+	}
+	grip.Info(catcher.Resolve())
+
+	return runnabletasks, nil
+}
+
+func ParallelTaskFinder() ([]task.Task, error) {
+	undispatchedTasks, err := task.Find(task.IsUndispatched)
+	if err != nil {
+		return nil, err
+	}
+
+	cache := make(map[string]task.Task)
+	catcher := grip.NewBasicCatcher()
+	lookupSet := make(map[string]struct{})
+	for _, t := range undispatchedTasks {
+		cache[t.Id] = t
+		for _, dep := range t.DependsOn {
+			lookupSet[dep.TaskId] = struct{}{}
+		}
+	}
+
+	results := make(chan *task.Task, len(lookupSet))
+	toLookup := make(chan string, len(lookupSet))
+	for t := range lookupSet {
+		toLookup <- t
+	}
+	close(toLookup)
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for id := range toLookup {
+				nt, err := task.FindOneId(id)
+				catcher.Add(err)
+				if nt == nil {
+					continue
+				}
+				results <- nt
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	for t := range results {
+		cache[t.Id] = *t
+	}
+
+	runnabletasks := []task.Task{}
+	for _, t := range undispatchedTasks {
+		depsMet, err := t.DependenciesMet(cache)
+		catcher.Add(err)
+		if depsMet {
+			runnabletasks = append(runnabletasks, t)
+		}
+	}
+	grip.Info(catcher.Resolve())
+
+	return runnabletasks, nil
 }

--- a/scheduler/task_finder.go
+++ b/scheduler/task_finder.go
@@ -105,7 +105,7 @@ func ParallelTaskFinder() ([]task.Task, error) {
 	close(toLookup)
 
 	wg := &sync.WaitGroup{}
-	for i := 0; i < 16; i++ {
+	for i := 0; i < 8; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/smartystreets/goconvey/convey/reporting"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -20,6 +23,7 @@ var taskFinderTestConf = testutil.TestConfig()
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
+	reporting.QuietMode()
 }
 
 type TaskFinderSuite struct {
@@ -39,6 +43,19 @@ func TestDBTaskFinder(t *testing.T) {
 func TestLegacyDBTaskFinder(t *testing.T) {
 	s := new(TaskFinderSuite)
 	s.FindRunnableTasks = LegacyFindRunnableTasks
+	suite.Run(t, s)
+}
+
+func TestAlternativeTaskFinder(t *testing.T) {
+	s := new(TaskFinderSuite)
+	s.FindRunnableTasks = AlternateTaskFinder
+
+	suite.Run(t, s)
+}
+
+func TestParallelTaskFinder(t *testing.T) {
+	s := new(TaskFinderSuite)
+	s.FindRunnableTasks = ParallelTaskFinder
 
 	suite.Run(t, s)
 }
@@ -120,6 +137,56 @@ type TaskFinderComparisonSuite struct {
 	tasks            []task.Task
 	oldRunnableTasks []task.Task
 	newRunnableTasks []task.Task
+	altRunnableTasks []task.Task
+	pllRunnableTasks []task.Task
+}
+
+func (s *TaskFinderComparisonSuite) SetupTest() {
+	session, _, _ := db.GetGlobalSessionFactory().GetSession()
+	s.NotNil(session)
+	s.NoError(db.Clear(task.Collection))
+
+	s.tasks = s.tasksGenerator()
+	s.NotEmpty(s.tasks)
+	for _, task := range s.tasks {
+		task.BuildVariant = "aBuildVariant"
+		task.Tags = []string{"tag1", "tag2"}
+		s.NoError(task.Insert())
+	}
+
+	var err error
+
+	s2start := time.Now()
+	s.newRunnableTasks, err = FindRunnableTasks()
+	s2dur := time.Since(s2start)
+	s.NoError(err)
+
+	s1start := time.Now()
+	s.oldRunnableTasks, err = LegacyFindRunnableTasks()
+	s1dur := time.Since(s1start)
+	s.NoError(err)
+
+	s3start := time.Now()
+	s.altRunnableTasks, err = AlternateTaskFinder()
+	s3dur := time.Since(s3start)
+	s.NoError(err)
+
+	s4start := time.Now()
+	s.pllRunnableTasks, err = ParallelTaskFinder()
+	s4dur := time.Since(s4start)
+	s.NoError(err)
+
+	grip.Notice(message.Fields{
+		"length":      len(s.tasks),
+		"legacy":      s1dur.String(),
+		"pipeline":    s2dur.String(),
+		"alternative": s3dur.String(),
+		"parallel":    s4dur.String(),
+	})
+}
+
+func (s *TaskFinderComparisonSuite) TearDownTest() {
+	s.NoError(db.Clear(task.Collection))
 }
 
 func (s *TaskFinderComparisonSuite) TestFindRunnableHostsIsIdentical() {
@@ -133,107 +200,44 @@ func (s *TaskFinderComparisonSuite) TestFindRunnableHostsIsIdentical() {
 		idsNewMethod = append(idsNewMethod, task.Id)
 	}
 
+	idsAltMethod := []string{}
+	for _, task := range s.altRunnableTasks {
+		idsAltMethod = append(idsAltMethod, task.Id)
+	}
+
+	idsPllMethod := []string{}
+	for _, task := range s.pllRunnableTasks {
+		idsPllMethod = append(idsPllMethod, task.Id)
+	}
+
 	sort.Strings(idsOldMethod)
 	sort.Strings(idsNewMethod)
+	sort.Strings(idsAltMethod)
+	sort.Strings(idsPllMethod)
 
-	s.Equal(idsOldMethod, idsNewMethod,
-		fmt.Sprintf("Failed to find identical runnable tasks; input tasks were: %+v\n", s.tasks))
+	s.Equal(idsOldMethod, idsNewMethod, "old (legacy) and new (database) methods did not match")
+	s.Equal(idsOldMethod, idsAltMethod, "old (legacy) and new (altimpl) methods did not match")
+	s.Equal(idsNewMethod, idsAltMethod, "new (database) and new (altimpl) methods did not match")
+	s.Equal(idsNewMethod, idsPllMethod, "new (database) and new (parallel) methods did not match")
 }
 
-func makeRandomTasks() []task.Task {
-	tasks := []task.Task{}
-	statuses := []string{
-		evergreen.TaskStarted,
-		evergreen.TaskUnstarted,
-		evergreen.TaskUndispatched,
-		evergreen.TaskDispatched,
-		evergreen.TaskFailed,
-		evergreen.TaskSucceeded,
-		evergreen.TaskInactive,
-		evergreen.TaskSystemFailed,
-		evergreen.TaskTimedOut,
-		evergreen.TaskSystemUnresponse,
-		evergreen.TaskSystemTimedOut,
-		evergreen.TaskTestTimedOut,
-		evergreen.TaskConflict,
+func (s *TaskFinderComparisonSuite) TestCheckThatTaskIsPopulated() {
+	for _, task := range s.oldRunnableTasks {
+		s.Equal(task.BuildVariant, "aBuildVariant")
+		s.Equal(task.Tags, []string{"tag1", "tag2"})
 	}
-
-	numTasks := rand.Intn(10) + 1
-
-	for i := 0; i < numTasks; i++ {
-		// pick a random status
-		statusIndex := rand.Intn(len(statuses))
-		id := "task" + strconv.Itoa(i)
-		tasks = append(tasks, task.Task{
-			Id:        id,
-			Status:    statuses[statusIndex],
-			Activated: true,
-		})
+	for _, task := range s.newRunnableTasks {
+		s.Equal(task.BuildVariant, "aBuildVariant")
+		s.Equal(task.Tags, []string{"tag1", "tag2"})
 	}
-
-	subTasks := [][]task.Task{makeRandomSubTasks(statuses, &tasks)}
-
-	depth := rand.Intn(3) + 1
-
-	for i := 0; i < depth; i++ {
-		subTasks = append(subTasks, makeRandomSubTasks(statuses, &subTasks[i]))
+	for _, task := range s.altRunnableTasks {
+		s.Equal(task.BuildVariant, "aBuildVariant")
+		s.Equal(task.Tags, []string{"tag1", "tag2"})
 	}
-
-	for i, _ := range subTasks {
-		tasks = append(tasks, subTasks[i]...)
+	for _, task := range s.pllRunnableTasks {
+		s.Equal(task.BuildVariant, "aBuildVariant")
+		s.Equal(task.Tags, []string{"tag1", "tag2"})
 	}
-
-	return tasks
-}
-
-func pickSubtaskStatus(statuses []string, dependsOn []task.Dependency) string {
-	// If any task that a task depends on is undispatched, this task must be
-	// undispatched
-	for _, dep := range dependsOn {
-		if dep.Status == evergreen.TaskUndispatched {
-			return evergreen.TaskUndispatched
-		}
-	}
-	return dependsOn[rand.Intn(len(dependsOn))].Status
-}
-
-// Add random set of dependencies to each task in parentTasks
-func makeRandomSubTasks(statuses []string, parentTasks *[]task.Task) []task.Task {
-	depTasks := []task.Task{}
-	for i, parentTask := range *parentTasks {
-		dependsOn := []task.Dependency{
-			task.Dependency{
-				TaskId: parentTask.Id,
-				Status: parentTask.Status,
-			},
-		}
-
-		// Pick another parent at random
-		anotherParent := rand.Intn(len(*parentTasks))
-		if anotherParent != i {
-			dependsOn = append(dependsOn,
-				task.Dependency{
-					TaskId: (*parentTasks)[anotherParent].Id,
-					Status: (*parentTasks)[anotherParent].Status,
-				},
-			)
-		}
-
-		numDeps := rand.Intn(4)
-		for i := 0; i < numDeps; i++ {
-			childId := parentTask.Id + "-child" + strconv.Itoa(i)
-
-			depTasks = append(depTasks, task.Task{
-				Id:        childId,
-				Activated: true,
-				Status:    pickSubtaskStatus(statuses, dependsOn),
-				DependsOn: dependsOn,
-			})
-
-		}
-	}
-
-	return depTasks
 }
 
 func TestCompareTaskRunnersWithFuzzyTasks(t *testing.T) {
@@ -325,40 +329,99 @@ func TestCompareTaskRunnersWithStaticTasks(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func (s *TaskFinderComparisonSuite) SetupTest() {
-	session, _, _ := db.GetGlobalSessionFactory().GetSession()
-	s.NotNil(session)
-	s.NoError(db.Clear(task.Collection))
-
-	s.tasks = s.tasksGenerator()
-	s.NotEmpty(s.tasks)
-	for _, task := range s.tasks {
-		task.BuildVariant = "aBuildVariant"
-		task.Tags = []string{"tag1", "tag2"}
-		s.NoError(task.Insert())
+func makeRandomTasks() []task.Task {
+	tasks := []task.Task{}
+	statuses := []string{
+		evergreen.TaskStarted,
+		evergreen.TaskUnstarted,
+		evergreen.TaskUndispatched,
+		evergreen.TaskDispatched,
+		evergreen.TaskFailed,
+		evergreen.TaskSucceeded,
+		evergreen.TaskInactive,
+		evergreen.TaskSystemFailed,
+		evergreen.TaskTimedOut,
+		evergreen.TaskSystemUnresponse,
+		evergreen.TaskSystemTimedOut,
+		evergreen.TaskTestTimedOut,
+		evergreen.TaskConflict,
 	}
 
-	var err error
+	numTasks := rand.Intn(20) + 20
+	for i := 0; i < numTasks; i++ {
+		// pick a random status
+		statusIndex := rand.Intn(len(statuses))
+		id := "task" + strconv.Itoa(i)
+		tasks = append(tasks, task.Task{
+			Id:        id,
+			Status:    statuses[statusIndex],
+			Activated: true,
+		})
+	}
 
-	s.oldRunnableTasks, err = LegacyFindRunnableTasks()
-	s.NoError(err)
-	s.newRunnableTasks, err = FindRunnableTasks()
-	s.NoError(err)
+	subTasks := [][]task.Task{makeRandomSubTasks(statuses, &tasks)}
+
+	depth := rand.Intn(6) + 1
+
+	for i := 0; i < depth; i++ {
+		subTasks = append(subTasks, makeRandomSubTasks(statuses, &subTasks[i]))
+	}
+
+	for i, _ := range subTasks {
+		tasks = append(tasks, subTasks[i]...)
+	}
+
+	return tasks
 }
 
-func (s *TaskFinderComparisonSuite) TearDownTest() {
-	s.NoError(db.Clear(task.Collection))
+func pickSubtaskStatus(statuses []string, dependsOn []task.Dependency) string {
+	// If any task that a task depends on is undispatched, this task must be
+	// undispatched
+	for _, dep := range dependsOn {
+		if dep.Status == evergreen.TaskUndispatched {
+			return evergreen.TaskUndispatched
+		}
+	}
+	return dependsOn[rand.Intn(len(dependsOn))].Status
 }
 
-func (s *TaskFinderComparisonSuite) TestCheckThatTaskIsPopulated() {
-	for _, task := range s.oldRunnableTasks {
-		s.Equal(task.BuildVariant, "aBuildVariant")
-		s.Equal(task.Tags, []string{"tag1", "tag2"})
+// Add random set of dependencies to each task in parentTasks
+func makeRandomSubTasks(statuses []string, parentTasks *[]task.Task) []task.Task {
+	depTasks := []task.Task{}
+	for i, parentTask := range *parentTasks {
+		dependsOn := []task.Dependency{
+			task.Dependency{
+				TaskId: parentTask.Id,
+				Status: parentTask.Status,
+			},
+		}
+
+		// Pick another parent at random
+		anotherParent := rand.Intn(len(*parentTasks))
+		if anotherParent != i {
+			dependsOn = append(dependsOn,
+				task.Dependency{
+					TaskId: (*parentTasks)[anotherParent].Id,
+					Status: (*parentTasks)[anotherParent].Status,
+				},
+			)
+		}
+
+		numDeps := rand.Intn(8)
+		for i := 0; i < numDeps; i++ {
+			childId := parentTask.Id + "-child" + strconv.Itoa(i)
+
+			depTasks = append(depTasks, task.Task{
+				Id:        childId,
+				Activated: true,
+				Status:    pickSubtaskStatus(statuses, dependsOn),
+				DependsOn: dependsOn,
+			})
+
+		}
 	}
-	for _, task := range s.newRunnableTasks {
-		s.Equal(task.BuildVariant, "aBuildVariant")
-		s.Equal(task.Tags, []string{"tag1", "tag2"})
-	}
+
+	return depTasks
 }
 
 func hugeString(suffix string) string {


### PR DESCRIPTION
I was curious about the performance of this operation, and so wanted
to see what the impacts/factors were, and then I accidentally wrote
two application-level implementations, with some interesting results: 

The test suite reports on the relative runtimes (as in [this
run](https://evergreen.mongodb.com/task/mci_ubuntu1604_test_scheduler_patch_b7f54713a78a6484aa3d025f11876c11b876ff20_59eaaa042a60ed09f70096aa_17_10_21_01_59_50)),
e.g: 

    === RUN   TestCompareTaskRunnersWithFuzzyTasks
    [test.scheduler] 2017/10/21 02:03:19 [p=notice]: [alternative='6.559450433s' legacy='14.361323113s' length='243488' parallel='7.093386369s' pipeline='23.457452001s']
    [test.scheduler] 2017/10/21 02:03:22 [p=notice]: [alternative='4.936629ms' legacy='5.982618ms' length='459' parallel='3.552666ms' pipeline='9.111964ms']
    --- PASS: TestCompareTaskRunnersWithFuzzyTasks (99.61s)
    === RUN   TestCompareTaskRunnersWithStaticTasks
    [test.scheduler] 2017/10/21 02:03:22 [p=notice]: [alternative='609.597µs' legacy='683.382µs' length='7' parallel='539.723µs' pipeline='1.010247ms']
	[test.scheduler] 2017/10/21 02:03:22 [p=notice]: [alternative='587.676µs' legacy='655.771µs' length='7' parallel='514.328µs' pipeline='1.010464ms']
	--- PASS: TestCompareTaskRunnersWithStaticTasks (0.01s)
	=== RUN   TestCompareTaskRunnersWithHugeTasks
	[test.scheduler] 2017/10/21 02:03:23 [p=notice]: [alternative='18.900957ms' legacy='3.199201ms' length='6' parallel='12.457948ms' pipeline='71.326111ms']
	[test.scheduler] 2017/10/21 02:03:23 [p=notice]: [alternative='15.630503ms' legacy='4.308009ms' length='6' parallel='10.798911ms' pipeline='19.295949ms']
	--- PASS: TestCompareTaskRunnersWithHugeTasks (1.17s)

There are some important caveats: 

- the tests do not run with any indexes on the tasks collection (or
  any other,) which probably makes the runtime of the pipeline variant
  much longer than it would be, even relatively (it's of course true
  that the other operations mostly use the _id index.)
- the legacy implementation probably wins in the case with the "huge"
  task becasue there's a slice of structs (not pointers) of task
  documents that's passed around, and the legacy implementation
  (likely) avoids a copy. We could probably work to get rid of that
  copy to good effect.