### PR TITLE
EVG-2273: update slack logging

### DIFF
--- a/config.go
+++ b/config.go
@@ -391,7 +391,7 @@ func (s *Settings) GetSender() (send.Sender, error) {
 			if err = sender.SetErrorHandler(send.ErrorHandlerFromSender(fallback)); err != nil {
 				return nil, errors.Wrap(err, "problem setting error handler")
 			}
-			senders = append(senders, send.NewBufferedSender(sender, 10*time.Second, 3))
+			senders = append(senders, sender)
 		}
 		grip.Warning(errors.Wrap(err, "problem setting up slack alert logger"))
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -9,8 +9,6 @@ imports:
     version: 1358eff22f0dd0c54fc521042cc607f6ff4b531a
     subpackages:
       - context
-  - name: github.com/pkg/sftp
-    version: 506297c9013d2893d5c5daaa9155e7333a1c58de
   - name: github.com/vaughan0/go-ini
     version: a98ad7ee00ec53921f08832bc06ecf7fd600e6a1
   - name: github.com/10gen/goamz # github.com/goamz/goamz
@@ -111,7 +109,7 @@ imports:
     version: d8f5ea21b9295e315e612b4bcf4bedea93454d4d
 
   - name: github.com/mongodb/grip
-    version: d18f59a65e9fd93872ebae7657af07c32be6b3f7
+    version: d4bea6d9c27d435df70e20c8a97a8e86a84acc02
   - name: github.com/mongodb/anser
     version: bb062a07cc15212d7fdb578481ac45a01acc185b
   - name: github.com/mongodb/amboy

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,9 +4,6 @@ import:
     subpackages:
       - ssh
   - package: golang.org/x/net
-    subpackages:
-      - context
-  - package: github.com/pkg/sftp
   - package: github.com/vaughan0/go-ini
   - package: github.com/10gen/goamz/
     subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,9 +1,9 @@
 package: github.com/evergreen-ci/evergreen
 import:
   - package: golang.org/x/crypto
-    subpackages:
-      - ssh
   - package: golang.org/x/net
+  - package: golang.org/x/oauth2
+  - package: golang.org/x/sys/windows
   - package: github.com/vaughan0/go-ini
   - package: github.com/10gen/goamz/
     subpackages:
@@ -48,8 +48,6 @@ import:
     subpackages:
       - compute
   - package: github.com/vmware/govmomi
-  - package: golang.org/x/oauth2
-  - package: golang.org/x/sys/windows
   - package: github.com/mongodb/anser
   - package: github.com/mongodb/amboy
   - package: github.com/tychoish/tarjan

--- a/vendor/github.com/mongodb/grip/send/buffered.go
+++ b/vendor/github.com/mongodb/grip/send/buffered.go
@@ -118,6 +118,10 @@ func (s *bufferedSender) backgroundWorker(work <-chan []message.Composer, comple
 }
 
 func (s *bufferedSender) Send(msg message.Composer) {
+	if !s.Level().ShouldLog(msg) {
+		return
+	}
+
 	switch msg := msg.(type) {
 	case *message.GroupComposer:
 		for _, m := range msg.Messages() {

--- a/vendor/github.com/mongodb/grip/send/multi_test.go
+++ b/vendor/github.com/mongodb/grip/send/multi_test.go
@@ -1,0 +1,39 @@
+package send
+
+import (
+	"testing"
+
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiSenderRespectsLevel(t *testing.T) {
+	// this is a limited test to prevent
+	assert := assert.New(t) // nolint
+
+	mock, err := NewInternalLogger("mock", LevelInfo{Default: level.Critical, Threshold: level.Alert})
+	assert.NoError(err)
+	s := MakeErrorLogger()
+	s.SetName("mock2")
+	multi := NewConfiguredMultiSender(s, mock)
+
+	assert.Equal(mock.Len(), 0)
+	multi.Send(message.NewDefaultMessage(level.Info, "hello"))
+	assert.Equal(mock.Len(), 1)
+	m, ok := mock.GetMessageSafe()
+	assert.True(ok)
+	assert.False(m.Logged)
+
+	multi.Send(message.NewDefaultMessage(level.Alert, "hello"))
+	assert.Equal(mock.Len(), 1)
+	m, ok = mock.GetMessageSafe()
+	assert.True(ok)
+	assert.True(m.Logged)
+
+	multi.Send(message.NewDefaultMessage(level.Alert, "hello"))
+	assert.Equal(mock.Len(), 1)
+	m, ok = mock.GetMessageSafe()
+	assert.True(ok)
+	assert.True(m.Logged)
+}

--- a/vendor/github.com/mongodb/grip/send/slack_test.go
+++ b/vendor/github.com/mongodb/grip/send/slack_test.go
@@ -116,47 +116,55 @@ func (s *SlackSuite) TestGetParamsWithAttachementOptsDisabledLevelImpact() {
 	s.False(opts.Fields)
 	s.False(opts.BasicMetadata)
 
-	params := opts.getParams(message.NewString("foo"))
+	msg, params := opts.produceMessage(message.NewString("foo"))
 	s.Equal("good", params.Attachments[0].Color)
+	s.Equal("foo", msg)
 
 	for _, l := range []level.Priority{level.Emergency, level.Alert, level.Critical} {
-		params = opts.getParams(message.NewDefaultMessage(l, "foo"))
+		msg, params = opts.produceMessage(message.NewDefaultMessage(l, "foo"))
 		s.Equal("danger", params.Attachments[0].Color)
+		s.Equal("foo", msg)
 	}
 
 	for _, l := range []level.Priority{level.Warning, level.Notice} {
-		params = opts.getParams(message.NewDefaultMessage(l, "foo"))
+		msg, params = opts.produceMessage(message.NewDefaultMessage(l, "foo"))
 		s.Equal("warning", params.Attachments[0].Color)
+		s.Equal("foo", msg)
 	}
 
 	for _, l := range []level.Priority{level.Debug, level.Info, level.Trace} {
-		params = opts.getParams(message.NewDefaultMessage(l, "foo"))
+		msg, params = opts.produceMessage(message.NewDefaultMessage(l, "foo"))
 		s.Equal("good", params.Attachments[0].Color)
+		s.Equal("foo", msg)
 	}
 }
 
-func (s *SlackSuite) TestGetParamsWithBasicMetaDataEnabled() {
+func (s *SlackSuite) TestProduceMessageWithBasicMetaDataEnabled() {
 	opts := &SlackOptions{BasicMetadata: true}
 	s.False(opts.Fields)
 	s.True(opts.BasicMetadata)
 
-	params := opts.getParams(message.NewDefaultMessage(level.Alert, "foo"))
+	msg, params := opts.produceMessage(message.NewDefaultMessage(level.Alert, "foo"))
 	s.Equal("danger", params.Attachments[0].Color)
+	s.Equal("foo", msg)
 	s.Len(params.Attachments[0].Fields, 1)
 	s.True(strings.Contains(params.Attachments[0].Fallback, "priority=alert"), params.Attachments[0].Fallback)
 
 	opts.Hostname = "!"
-	params = opts.getParams(message.NewDefaultMessage(level.Alert, "foo"))
+	msg, params = opts.produceMessage(message.NewDefaultMessage(level.Alert, "foo"))
+	s.Equal("foo", msg)
 	s.Len(params.Attachments[0].Fields, 1)
 	s.False(strings.Contains(params.Attachments[0].Fallback, "host"), params.Attachments[0].Fallback)
 
 	opts.Hostname = "foo"
-	params = opts.getParams(message.NewDefaultMessage(level.Alert, "foo"))
+	msg, params = opts.produceMessage(message.NewDefaultMessage(level.Alert, "foo"))
+	s.Equal("foo", msg)
 	s.Len(params.Attachments[0].Fields, 2)
 	s.True(strings.Contains(params.Attachments[0].Fallback, "host=foo"), params.Attachments[0].Fallback)
 
 	opts.Name = "foo"
-	params = opts.getParams(message.NewDefaultMessage(level.Alert, "foo"))
+	msg, params = opts.produceMessage(message.NewDefaultMessage(level.Alert, "foo"))
+	s.Equal("foo", msg)
 	s.Len(params.Attachments[0].Fields, 3)
 	s.True(strings.Contains(params.Attachments[0].Fallback, "journal=foo"), params.Attachments[0].Fallback)
 }
@@ -171,29 +179,36 @@ func (s *SlackSuite) TestFieldsMessageTypeIntegration() {
 		"foo":     true,
 	}
 
-	params := opts.getParams(message.NewDefaultMessage(level.Alert, "foo"))
+	msg, params := opts.produceMessage(message.NewDefaultMessage(level.Alert, "foo"))
+	s.Equal("foo", msg)
 	s.Equal("danger", params.Attachments[0].Color)
 	s.Len(params.Attachments[0].Fields, 0)
 
 	// if the fields are nil, then we end up ignoring things, except the message
-	params = opts.getParams(message.NewFieldsMessage(level.Alert, "foo", message.Fields{}))
-	s.Len(params.Attachments[0].Fields, 0)
+	msg, params = opts.produceMessage(message.NewFieldsMessage(level.Alert, "foo", message.Fields{}))
+	s.Equal("", msg)
+	s.Len(params.Attachments[0].Fields, 1)
 
 	// when msg and the message match we ignore
-	params = opts.getParams(message.NewFieldsMessage(level.Alert, "foo", message.Fields{"msg": "foo"}))
-	s.Len(params.Attachments[0].Fields, 0)
-
-	params = opts.getParams(message.NewFieldsMessage(level.Alert, "foo", message.Fields{"foo": "bar"}))
+	msg, params = opts.produceMessage(message.NewFieldsMessage(level.Alert, "foo", message.Fields{"msg": "foo"}))
+	s.Equal("", msg)
 	s.Len(params.Attachments[0].Fields, 1)
 
-	params = opts.getParams(message.NewFieldsMessage(level.Alert, "foo", message.Fields{"other": "baz"}))
-	s.Len(params.Attachments[0].Fields, 1)
-
-	params = opts.getParams(message.NewFieldsMessage(level.Alert, "foo", message.Fields{"untracked": "false", "other": "bar"}))
-	s.Len(params.Attachments[0].Fields, 1)
-
-	params = opts.getParams(message.NewFieldsMessage(level.Alert, "foo", message.Fields{"foo": "false", "other": "bass"}))
+	msg, params = opts.produceMessage(message.NewFieldsMessage(level.Alert, "foo", message.Fields{"foo": "bar"}))
+	s.Equal("", msg)
 	s.Len(params.Attachments[0].Fields, 2)
+
+	msg, params = opts.produceMessage(message.NewFieldsMessage(level.Alert, "foo", message.Fields{"other": "baz"}))
+	s.Equal("", msg)
+	s.Len(params.Attachments[0].Fields, 2)
+
+	msg, params = opts.produceMessage(message.NewFieldsMessage(level.Alert, "foo", message.Fields{"untracked": "false", "other": "bar"}))
+	s.Equal("", msg)
+	s.Len(params.Attachments[0].Fields, 2)
+
+	msg, params = opts.produceMessage(message.NewFieldsMessage(level.Alert, "foo", message.Fields{"foo": "false", "other": "bass"}))
+	s.Equal("", msg)
+	s.Len(params.Attachments[0].Fields, 3)
 }
 
 func (s *SlackSuite) TestMockSenderWithMakeConstructor() {
@@ -274,4 +289,23 @@ func (s *SlackSuite) TestCreateMethodChangesClientState() {
 	s.Equal(base, new)
 	new.Create("foo")
 	s.NotEqual(base, new)
+}
+
+func (s *SlackSuite) TestSendMethodDoesIncorrectlyAllowTooLowMessages() {
+	sender, err := NewSlackLogger(s.opts, "foo", LevelInfo{level.Trace, level.Info})
+	s.NotNil(sender)
+	s.NoError(err)
+
+	mock, ok := s.opts.client.(*slackClientMock)
+	s.True(ok)
+	s.Equal(mock.numSent, 0)
+
+	sender.SetLevel(LevelInfo{Default: level.Critical, Threshold: level.Alert})
+	s.Equal(mock.numSent, 0)
+	sender.Send(message.NewDefaultMessage(level.Info, "hello"))
+	s.Equal(mock.numSent, 0)
+	sender.Send(message.NewDefaultMessage(level.Alert, "hello"))
+	s.Equal(mock.numSent, 1)
+	sender.Send(message.NewDefaultMessage(level.Alert, "hello"))
+	s.Equal(mock.numSent, 2)
 }


### PR DESCRIPTION
This commit has two main aspects, first it updates grip to have more
well-formed messages slack messages, without dupication and better
metadata. 

Second, it removes buffering of messages for the slack logger. This is
important because buffering was causing messages to get batched
together, which made it difficult to filter only the high priority levels.

As an aside this will return to our earlier practice of logging debug
messages to splunk, which was a regression introduced with the earlier
slack change.