### PR TITLE
EVG-90: remove global lock

### DIFF
--- a/db/lock.go
+++ b/db/lock.go
@@ -8,9 +8,8 @@ import (
 )
 
 const (
-	LockCollection = "lock"
-	GlobalLockId   = "global"
-	LockTimeout    = time.Minute * 8
+	lockCollection = "lock"
+	lockTimeout    = 8 * time.Minute
 )
 
 // Lock represents a lock stored in the database, for synchronization.
@@ -21,20 +20,20 @@ type Lock struct {
 	LockedAt time.Time `bson:"locked_at"`
 }
 
-// WaitTillAcquireGlobalLock "spins" on acquiring the given database lock,
+// WaitTillAcquireLock "spins" on acquiring the given database lock,
 // for the process id, until timeoutMS. Returns whether or not the lock was
 // acquired.
-func WaitTillAcquireGlobalLock(id string, timeoutMS time.Duration) (bool, error) {
+func WaitTillAcquireLock(id string) (bool, error) {
 	startTime := time.Now()
 	for {
 		// if the timeout has been reached, we failed to get the lock
 		currTime := time.Now()
-		if startTime.Add(timeoutMS * time.Millisecond).Before(currTime) {
+		if startTime.Add(lockTimeout).Before(currTime) {
 			return false, nil
 		}
 
 		// attempt to get the lock
-		acquired, err := AcquireGlobalLock(id)
+		acquired, err := AcquireLock(id)
 		if err != nil {
 			return false, err
 		}
@@ -43,7 +42,7 @@ func WaitTillAcquireGlobalLock(id string, timeoutMS time.Duration) (bool, error)
 		}
 
 		// sleep
-		time.Sleep(1000 * time.Millisecond)
+		time.Sleep(time.Second)
 	}
 }
 
@@ -58,21 +57,23 @@ func setDocumentLocked(id string, upsert bool) (bool, error) {
 	// for findAndModify-ing the lock
 
 	// timeout to check for
-	timeoutThreshold := time.Now().Add(-LockTimeout)
+	timeoutThreshold := time.Now().Add(-lockTimeout)
 
 	// construct the selector for the following cases:
 	// 1. lock is not held by anyone
 	// 2. lock is held but has timed out
 	selector := bson.M{
-		"_id": GlobalLockId,
-		"$or": []bson.M{{"locked": false}, {"locked_at": bson.M{"$lte": timeoutThreshold}}},
+		"_id": id,
+		"$or": []bson.M{
+			{"locked": false},
+			{"locked_at": bson.M{"$lte": timeoutThreshold}},
+		},
 	}
 
 	// change to apply to document
 	change := mgo.Change{
 		Update: bson.M{"$set": bson.M{
 			"locked":    true,
-			"locked_by": id,
 			"locked_at": time.Now(),
 		}},
 		Upsert:    upsert,
@@ -82,7 +83,7 @@ func setDocumentLocked(id string, upsert bool) (bool, error) {
 	lock := Lock{}
 
 	// gets the lock if we can
-	_, err = db.C(LockCollection).Find(selector).Apply(change, &lock)
+	_, err = db.C(lockCollection).Find(selector).Apply(change, &lock)
 
 	if err != nil {
 		return false, err
@@ -90,10 +91,10 @@ func setDocumentLocked(id string, upsert bool) (bool, error) {
 	return lock.Locked, nil
 }
 
-// AcquireGlobalLock attempts to acquire the global lock if
+// AcquireLock attempts to acquire the specified lock if
 // no one has it or it's timed out. Returns a boolean indicating
 // whether the lock was acquired.
-func AcquireGlobalLock(id string) (bool, error) {
+func AcquireLock(id string) (bool, error) {
 	acquired, err := setDocumentLocked(id, false)
 
 	if err == mgo.ErrNotFound {
@@ -113,8 +114,8 @@ func AcquireGlobalLock(id string) (bool, error) {
 	return acquired, err
 }
 
-// ReleaseGlobalLock relinquishes the global lock for the given id.
-func ReleaseGlobalLock(id string) error {
+// ReleaseLock relinquishes the lock for the given id.
+func ReleaseLock(id string) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		return err
@@ -122,8 +123,8 @@ func ReleaseGlobalLock(id string) error {
 	defer session.Close()
 
 	// will return mgo.ErrNotFound if the lock expired
-	return db.C(LockCollection).Update(
-		bson.M{"_id": GlobalLockId, "locked_by": id},
+	return db.C(lockCollection).Update(
+		bson.M{"_id": id},
 		bson.M{"$set": bson.M{"locked": false}},
 	)
 }

--- a/db/lock.go
+++ b/db/lock.go
@@ -16,13 +16,12 @@ const (
 type Lock struct {
 	Id       string    `bson:"_id"`
 	Locked   bool      `bson:"locked"`
-	LockedBy string    `bson:"locked_by"`
 	LockedAt time.Time `bson:"locked_at"`
 }
 
 // WaitTillAcquireLock "spins" on acquiring the given database lock,
-// for the process id, until timeoutMS. Returns whether or not the lock was
-// acquired.
+// for the process id, until the lock times out. Returns whether or
+// not the lock was acquired.
 func WaitTillAcquireLock(id string) (bool, error) {
 	startTime := time.Now()
 	for {

--- a/repotracker/runner.go
+++ b/repotracker/runner.go
@@ -111,7 +111,7 @@ func runRepoTracker(config *evergreen.Settings) error {
 		"num":     remaining,
 	})
 
-	lockAcquired, err := db.WaitTillAcquireGlobalLock(RunnerName, db.LockTimeout)
+	lockAcquired, err := db.WaitTillAcquireLock(RunnerName)
 	if err != nil {
 		return errors.Wrap(err, "Error acquiring global lock")
 	}
@@ -121,7 +121,7 @@ func runRepoTracker(config *evergreen.Settings) error {
 	}
 
 	defer func() {
-		if err = db.ReleaseGlobalLock(RunnerName); err != nil {
+		if err = db.ReleaseLock(RunnerName); err != nil {
 			grip.Error(message.Fields{
 				"runner":  RunnerName,
 				"message": "Error releasing global lock",


### PR DESCRIPTION
This builds heavily on top of the pending PR #423, which accounts for
much of its noise, if you can just look at the changes in the second
commit that might be useful. 

For some time now the only DB lock is used by the repotracker and its
not a global lock (indeed it only prevents multiple runs of the
repotracker from occuring at the same time.) While that's not possible
within a single binary given the current mode of operation, it might
be possible if there were two runner intances at a time, so it makes
sense to leave this around for now. 

This PR just clarifies the code to match the current state of
reality.