### PR TITLE
EVG-2244 Fix race-rest-route test

### DIFF
--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -35,6 +35,7 @@ func (s *GithubWebhookRouteSuite) SetupSuite() {
 	s.NoError(err)
 	s.NotNil(evergreen.GetEnvironment().Settings())
 	s.NotNil(evergreen.GetEnvironment().Settings().Api)
+	s.NotEmpty(evergreen.GetEnvironment().Settings().Api.GithubWebhookSecret)
 }
 
 func (s *GithubWebhookRouteSuite) TearDownSuite() {

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -468,8 +468,8 @@ tasks:
   - <<: *run-go-test-suite-with-mongodb
     tags: ["race", "db"]
     name: race-units
-  - <<: *run-go-test-suite
-    tags: ["nodb", "race"]
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "race"]
     name: race-rest-route
   - <<: *run-go-test-suite
     tags: ["nodb", "race"]


### PR DESCRIPTION
'*-with-mongodb' needed because environment config sets up amboy queues and requires the database.