### PR TITLE
EVG-2057 rewrite of test history query

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -894,6 +894,21 @@ func (t TestResult) convertToNewStyleTestResult() testresult.TestResult {
 	}
 }
 
+func ConvertToOld(in *testresult.TestResult) TestResult {
+	return TestResult{
+		Status:    in.Status,
+		TestFile:  in.TestFile,
+		URL:       in.URL,
+		URLRaw:    in.URLRaw,
+		LogId:     in.LogID,
+		LineNum:   in.LineNum,
+		ExitCode:  in.ExitCode,
+		StartTime: in.StartTime,
+		EndTime:   in.EndTime,
+		LogRaw:    in.LogRaw,
+	}
+}
+
 // MarkUnscheduled marks the task as undispatched and updates it in the database
 func (t *Task) MarkUnscheduled() error {
 	t.Status = evergreen.TaskUndispatched

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -750,7 +750,8 @@ func testHistoryV2Results(params *TestHistoryParameters) ([]task.Task, error) {
 				for t := range taskChan {
 					err = t.MergeNewTestResults()
 					if err != nil {
-						grip.Error(errors.Wrap(err, "error merging test results"))
+						grip.Error(errors.Wrapf(err, "error merging test results for task %s", t.Id))
+						continue
 					}
 					for j := len(t.LocalTestResults) - 1; j >= 0; j-- {
 						result := t.LocalTestResults[j]

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"fmt"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -26,6 +25,7 @@ const (
 	TaskTimeout       = "timeout"
 	TaskSystemFailure = "sysfail"
 	testResultsKey    = "test_results"
+	numQueryThreads   = 16
 )
 
 type taskHistoryIterator struct {
@@ -742,10 +742,9 @@ func testHistoryV2Results(params *TestHistoryParameters) ([]task.Task, error) {
 		}
 		close(taskChan)
 		wg := sync.WaitGroup{}
-		numWorkers := runtime.NumCPU()
-		wg.Add(numWorkers)
+		wg.Add(numQueryThreads)
 		resultChan := make(chan task.Task)
-		for i := 0; i < numWorkers; i++ {
+		for i := 0; i < numQueryThreads; i++ {
 			go func() {
 				defer wg.Done()
 				for t := range taskChan {

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -80,6 +81,7 @@ type TestHistoryResult struct {
 	TaskTimedOut    bool    `bson:"to"`
 	TaskDetailsType string  `bson:"tdt"`
 	LogId           string  `bson:"lid"`
+	Order           int     `bson:"order"`
 }
 
 // TestHistoryResult bson tags
@@ -106,19 +108,23 @@ var (
 // TestHistoryParameters are the parameters that are used
 // to retrieve Test Results.
 type TestHistoryParameters struct {
+	Sort  int `json:"sort"`
+	Limit int `json:"limit"`
+
+	// task parameters
 	Project         string    `json:"project"`
-	TestNames       []string  `json:"test_names"`
 	TaskNames       []string  `json:"task_names"`
 	BuildVariants   []string  `json:"variants"`
 	TaskStatuses    []string  `json:"task_statuses"`
-	TestStatuses    []string  `json:"test_statuses"`
 	BeforeRevision  string    `json:"before_revision"`
 	AfterRevision   string    `json:"after_revision"`
 	TaskRequestType string    `json:"task_request"`
 	BeforeDate      time.Time `json:"before_date"`
 	AfterDate       time.Time `json:"after_date"`
-	Sort            int       `json:"sort"`
-	Limit           int       `json:"limit"`
+
+	// test result parameters
+	TestNames    []string `json:"test_names"`
+	TestStatuses []string `json:"test_statuses"`
 }
 
 type TaskHistoryIterator interface {
@@ -431,6 +437,10 @@ func (t *TestHistoryParameters) validate() []string {
 	if t.Sort != -1 && t.Sort != 1 {
 		validationErrors = append(validationErrors, "sort parameter can only be -1 or 1")
 	}
+
+	if t.BeforeRevision == "" && t.AfterRevision == "" && t.Limit == 0 {
+		validationErrors = append(validationErrors, "must specify a range of revisions *or* a limit")
+	}
 	return validationErrors
 }
 
@@ -688,6 +698,206 @@ func buildTestHistoryQuery(testHistoryParameters *TestHistoryParameters) ([]bson
 	return pipeline, nil
 }
 
+func testHistoryV2Results(params *TestHistoryParameters) ([]task.Task, error) {
+	if params == nil {
+		return nil, errors.New("unable to determine parameters for test history query")
+	}
+	// run just the part of the query on the tasks collection to form our starting result set
+	tasksQuery, err := formQueryFromTasks(params)
+	if err != nil {
+		return nil, err
+	}
+	projection := bson.M{
+		task.DisplayNameKey:         1,
+		task.BuildVariantKey:        1,
+		task.StatusKey:              1,
+		task.RevisionKey:            1,
+		task.IdKey:                  1,
+		task.ExecutionKey:           1,
+		task.RevisionOrderNumberKey: 1,
+		task.OldTaskIdKey:           1,
+		task.StartTimeKey:           1,
+		task.FinishTimeKey:          1,
+		task.ProjectKey:             1,
+		task.DetailsKey:             1,
+	}
+	tasks, err := task.Find(db.Query(tasksQuery).Project(projection))
+	if err != nil {
+		return nil, err
+	}
+	oldTasks, err := task.FindOld(db.Query(tasksQuery).Project(projection))
+	if err != nil {
+		return nil, err
+	}
+	tasks = append(tasks, oldTasks...)
+
+	// to join the test results, merge test results for all the tasks...
+	if len(params.TestNames) == 0 {
+		for i, t := range tasks {
+			err = t.MergeNewTestResults()
+			if err != nil {
+				return nil, err
+			}
+			for j := len(t.LocalTestResults) - 1; j >= 0; j-- {
+				result := t.LocalTestResults[j]
+				if len(params.TestStatuses) > 0 && !util.StringSliceContains(params.TestStatuses, result.Status) {
+					t.LocalTestResults = append(t.LocalTestResults[:j], t.LocalTestResults[j+1:]...)
+				}
+			}
+			tasks[i] = t
+		}
+	} else { //... or if test names are specified, do a query on testresults and match up executions
+		testsQuery := formQueryFromTests(params)
+		results, err := testresult.Find(db.Query(testsQuery))
+		if err != nil {
+			return nil, err
+		}
+		for i := 0; i < len(results); i++ {
+			result := results[i]
+		taskLoop:
+			for j := 0; j < len(tasks); j++ {
+				t := tasks[j]
+				if result.TaskID == t.Id && result.Execution == t.Execution {
+					t.LocalTestResults = append(t.LocalTestResults, task.ConvertToOld(&result))
+					tasks[j] = t
+					break taskLoop
+				}
+			}
+		}
+	}
+
+	return tasks, nil
+}
+
+func formQueryFromTasks(params *TestHistoryParameters) (bson.M, error) {
+	query := bson.M{}
+	if len(params.TaskNames) > 0 {
+		query[task.DisplayNameKey] = bson.M{"$in": params.TaskNames}
+	}
+	if len(params.Project) > 0 {
+		query[task.ProjectKey] = params.Project
+	}
+	if len(params.TaskRequestType) > 0 {
+		query[task.RequesterKey] = params.TaskRequestType
+	}
+	if !util.IsZeroTime(params.BeforeDate) || !util.IsZeroTime(params.AfterDate) {
+		startTimeClause := bson.M{}
+		if !util.IsZeroTime(params.BeforeDate) {
+			startTimeClause["$lte"] = params.BeforeDate
+		}
+		if !util.IsZeroTime(params.AfterDate) {
+			startTimeClause["$gte"] = params.AfterDate
+		}
+		query[task.StartTimeKey] = startTimeClause
+	}
+	if len(params.BuildVariants) > 0 {
+		query[task.BuildVariantKey] = bson.M{"$in": params.BuildVariants}
+	}
+	statusQuery := formTaskStatusQuery(params)
+	if len(statusQuery) > 0 {
+		query["$or"] = statusQuery
+	}
+	revisionQuery, err := formRevisionQuery(params)
+	if err != nil {
+		return bson.M{}, err
+	}
+	if revisionQuery != nil {
+		query[task.RevisionOrderNumberKey] = *revisionQuery
+	}
+
+	return query, nil
+}
+
+func formQueryFromTests(params *TestHistoryParameters) bson.M {
+	query := bson.M{}
+	if len(params.TestNames) > 0 {
+		query[testresult.TestFileKey] = bson.M{"$in": params.TestNames}
+	}
+	if len(params.TestStatuses) > 0 {
+		query[testresult.StatusKey] = bson.M{"$in": params.TestStatuses}
+	}
+
+	return query
+}
+
+func formTaskStatusQuery(params *TestHistoryParameters) []bson.M {
+	// separate out pass/fail from timeouts and system failures
+	isTimeout := false
+	isSysFail := false
+	taskStatuses := []string{}
+	for _, status := range params.TaskStatuses {
+		switch status {
+		case TaskTimeout:
+			isTimeout = true
+		case TaskSystemFailure:
+			isSysFail = true
+		default:
+			taskStatuses = append(taskStatuses, status)
+		}
+	}
+	statusQuery := []bson.M{}
+
+	// if there are any pass/fail tasks create a query that isn't a timeout or a system failure.
+	if len(taskStatuses) > 0 {
+		statusQuery = append(statusQuery,
+			bson.M{
+				task.StatusKey: bson.M{"$in": taskStatuses},
+				task.DetailsKey + "." + task.TaskEndDetailTimedOut: bson.M{
+					"$ne": true,
+				},
+				task.DetailsKey + "." + task.TaskEndDetailType: bson.M{
+					"$ne": "system",
+				},
+			})
+	}
+
+	if isTimeout {
+		statusQuery = append(statusQuery, bson.M{
+			task.StatusKey:                                     evergreen.TaskFailed,
+			task.DetailsKey + "." + task.TaskEndDetailTimedOut: true,
+		})
+	}
+	if isSysFail {
+		statusQuery = append(statusQuery, bson.M{
+			task.StatusKey:                                 evergreen.TaskFailed,
+			task.DetailsKey + "." + task.TaskEndDetailType: "system",
+		})
+	}
+
+	return statusQuery
+}
+
+func formRevisionQuery(params *TestHistoryParameters) (*bson.M, error) {
+	if params.BeforeRevision == "" && params.AfterRevision == "" {
+		return nil, nil
+	}
+	revisionOrderNumberClause := bson.M{}
+	if params.BeforeRevision != "" {
+		v, err := version.FindOne(version.ByProjectIdAndRevision(params.Project,
+			params.BeforeRevision).WithFields(version.RevisionOrderNumberKey))
+		if err != nil {
+			return nil, err
+		}
+		if v == nil {
+			return nil, errors.Errorf("invalid revision : %v", params.BeforeRevision)
+		}
+		revisionOrderNumberClause["$lte"] = v.RevisionOrderNumber
+	}
+
+	if params.AfterRevision != "" {
+		v, err := version.FindOne(version.ByProjectIdAndRevision(params.Project,
+			params.AfterRevision).WithFields(version.RevisionOrderNumberKey))
+		if err != nil {
+			return nil, err
+		}
+		if v == nil {
+			return nil, errors.Errorf("invalid revision : %v", params.AfterRevision)
+		}
+		revisionOrderNumberClause["$gt"] = v.RevisionOrderNumber
+	}
+	return &revisionOrderNumberClause, nil
+}
+
 // GetTestHistory takes in test history parameters, validates them, and returns the test results according to those parameters.
 // It sets tasks failed and tests failed as default statuses if none are provided, and defaults to all tasks, tests,
 // and variants if those are not set.
@@ -707,4 +917,69 @@ func GetTestHistory(testHistoryParameters *TestHistoryParameters) ([]TestHistory
 		return nil, err
 	}
 	return mergeResults(aggTestResults, aggOldTestResults), nil
+}
+
+func GetTestHistoryV2(testHistoryParameters *TestHistoryParameters) ([]TestHistoryResult, error) {
+	var results []TestHistoryResult
+	tasks, err := testHistoryV2Results(testHistoryParameters)
+	if err != nil {
+		return nil, err
+	}
+	for _, t := range tasks {
+		for _, result := range t.LocalTestResults {
+			results = append(results, TestHistoryResult{
+				TaskId:          t.Id,
+				TaskName:        t.DisplayName,
+				TaskStatus:      t.Status,
+				Revision:        t.Revision,
+				Order:           t.RevisionOrderNumber,
+				Project:         t.Project,
+				BuildVariant:    t.BuildVariant,
+				Execution:       t.Execution,
+				OldTaskId:       t.OldTaskId,
+				TaskTimedOut:    t.Details.TimedOut,
+				TaskDetailsType: t.Details.Type,
+				TestFile:        result.TestFile,
+				TestStatus:      result.Status,
+				Url:             result.URL,
+				UrlRaw:          result.URLRaw,
+				LogId:           result.LogId,
+				StartTime:       result.StartTime,
+				EndTime:         result.EndTime,
+			})
+		}
+	}
+
+	sort.Sort(historyResultSorter(results))
+	limit := testHistoryParameters.Limit
+	var out []TestHistoryResult
+	if limit == 0 {
+		limit = len(results)
+	}
+	for i := range results {
+		index := i
+		if testHistoryParameters.Sort < 0 {
+			index = len(results) - i - 1
+		}
+		out = append(out, results[index])
+		if i >= limit-1 {
+			break
+		}
+	}
+
+	return out, nil
+}
+
+type historyResultSorter []TestHistoryResult
+
+func (h historyResultSorter) Len() int      { return len(h) }
+func (h historyResultSorter) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h historyResultSorter) Less(i, j int) bool {
+	if h[i].Order == h[j].Order {
+		if h[i].TaskId == h[j].TaskId {
+			return h[i].TestFile < h[j].TestFile
+		}
+		return h[i].TaskId < h[j].TaskId
+	}
+	return h[i].Order < h[j].Order
 }

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -2,8 +2,10 @@ package model
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -733,35 +735,61 @@ func testHistoryV2Results(params *TestHistoryParameters) ([]task.Task, error) {
 
 	// to join the test results, merge test results for all the tasks...
 	if len(params.TestNames) == 0 {
-		for i, t := range tasks {
-			err = t.MergeNewTestResults()
-			if err != nil {
-				return nil, err
-			}
-			for j := len(t.LocalTestResults) - 1; j >= 0; j-- {
-				result := t.LocalTestResults[j]
-				if len(params.TestStatuses) > 0 && !util.StringSliceContains(params.TestStatuses, result.Status) {
-					t.LocalTestResults = append(t.LocalTestResults[:j], t.LocalTestResults[j+1:]...)
-				}
-			}
-			tasks[i] = t
+		out := []task.Task{}
+		taskChan := make(chan task.Task, len(tasks))
+		for _, t := range tasks {
+			taskChan <- t
 		}
-	} else { //... or if test names are specified, do a query on testresults and match up executions
-		testsQuery := formQueryFromTests(params)
-		results, err := testresult.Find(db.Query(testsQuery))
-		if err != nil {
-			return nil, err
-		}
-		for i := 0; i < len(results); i++ {
-			result := results[i]
-		taskLoop:
-			for j := 0; j < len(tasks); j++ {
-				t := tasks[j]
-				if result.TaskID == t.Id && result.Execution == t.Execution {
-					t.LocalTestResults = append(t.LocalTestResults, task.ConvertToOld(&result))
-					tasks[j] = t
-					break taskLoop
+		close(taskChan)
+		wg := sync.WaitGroup{}
+		numWorkers := runtime.NumCPU()
+		wg.Add(numWorkers)
+		resultChan := make(chan task.Task)
+		for i := 0; i < numWorkers; i++ {
+			go func() {
+				defer wg.Done()
+				for t := range taskChan {
+					err = t.MergeNewTestResults()
+					if err != nil {
+						grip.Error(errors.Wrap(err, "error merging test results"))
+					}
+					for j := len(t.LocalTestResults) - 1; j >= 0; j-- {
+						result := t.LocalTestResults[j]
+						if len(params.TestStatuses) > 0 && !util.StringSliceContains(params.TestStatuses, result.Status) {
+							t.LocalTestResults = append(t.LocalTestResults[:j], t.LocalTestResults[j+1:]...)
+						}
+					}
+					resultChan <- t
 				}
+			}()
+		}
+		doneChan := make(chan bool)
+		go func() {
+			defer close(doneChan)
+			for t := range resultChan {
+				out = append(out, t)
+			}
+		}()
+		wg.Wait()
+		close(resultChan)
+		<-doneChan
+		return out, nil
+	}
+	//... or if test names are specified, do a query on testresults and match up executions
+	testsQuery := formQueryFromTests(params)
+	results, err := testresult.Find(db.Query(testsQuery))
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(results); i++ {
+		result := results[i]
+	taskLoop:
+		for j := 0; j < len(tasks); j++ {
+			t := tasks[j]
+			if result.TaskID == t.Id && result.Execution == t.Execution {
+				t.LocalTestResults = append(t.LocalTestResults, task.ConvertToOld(&result))
+				tasks[j] = t
+				break taskLoop
 			}
 		}
 	}

--- a/model/task_history_test.go
+++ b/model/task_history_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -12,7 +13,9 @@ import (
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/model/version"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/mongodb/grip"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -190,6 +193,7 @@ func TestSetDefaultsAndValidate(t *testing.T) {
 				Project:      "project",
 				TestNames:    []string{"test"},
 				TestStatuses: []string{evergreen.TestFailedStatus, evergreen.TestSucceededStatus},
+				Limit:        10,
 			}
 			So(len(params.TaskStatuses), ShouldEqual, 0)
 			So(params.SetDefaultsAndValidate(), ShouldBeNil)
@@ -202,6 +206,7 @@ func TestSetDefaultsAndValidate(t *testing.T) {
 				Project:      "project",
 				TestNames:    []string{"test"},
 				TaskStatuses: []string{evergreen.TaskFailed},
+				Limit:        10,
 			}
 			So(len(params.TestStatuses), ShouldEqual, 0)
 			So(params.SetDefaultsAndValidate(), ShouldBeNil)
@@ -644,7 +649,12 @@ func TestBuildTestHistoryQuery(t *testing.T) {
 }
 
 func TestGetTestHistory(t *testing.T) {
-	Convey("With a set of tasks and versions", t, func() {
+	assert := assert.New(t)
+	testFuncs := []func(*TestHistoryParameters) ([]TestHistoryResult, error){
+		GetTestHistory,
+		GetTestHistoryV2,
+	}
+	for _, testFunc := range testFuncs {
 		testutil.HandleTestingErr(db.ClearCollections(task.Collection, version.Collection, testresult.Collection),
 			t, "Error clearing task collections")
 		project := "proj"
@@ -657,7 +667,7 @@ func TestGetTestHistory(t *testing.T) {
 			Identifier:          project,
 			Requester:           evergreen.RepotrackerVersionRequester,
 		}
-		So(testVersion.Insert(), ShouldBeNil)
+		assert.NoError(testVersion.Insert())
 		testVersion2 := version.Version{
 			Id:                  "anotherVersion",
 			Revision:            "def",
@@ -665,7 +675,7 @@ func TestGetTestHistory(t *testing.T) {
 			Identifier:          project,
 			Requester:           evergreen.RepotrackerVersionRequester,
 		}
-		So(testVersion2.Insert(), ShouldBeNil)
+		assert.NoError(testVersion2.Insert())
 		testVersion3 := version.Version{
 			Id:                  "testV",
 			Revision:            "abcd",
@@ -673,7 +683,7 @@ func TestGetTestHistory(t *testing.T) {
 			Identifier:          project,
 			Requester:           evergreen.RepotrackerVersionRequester,
 		}
-		So(testVersion3.Insert(), ShouldBeNil)
+		assert.NoError(testVersion3.Insert())
 
 		task1 := task.Task{
 			Id:                  "task1",
@@ -684,7 +694,7 @@ func TestGetTestHistory(t *testing.T) {
 			RevisionOrderNumber: 1,
 			Status:              evergreen.TaskFailed,
 		}
-		So(task1.Insert(), ShouldBeNil)
+		assert.NoError(task1.Insert())
 		testresults1 := []testresult.TestResult{
 			testresult.TestResult{
 				Status:   evergreen.TestFailedStatus,
@@ -695,7 +705,7 @@ func TestGetTestHistory(t *testing.T) {
 				TestFile: "test2",
 			},
 		}
-		So(testresult.InsertManyByTaskIDAndExecution(testresults1, task1.Id, task1.Execution), ShouldBeNil)
+		assert.NoError(testresult.InsertManyByTaskIDAndExecution(testresults1, task1.Id, task1.Execution))
 		task2 := task.Task{
 			Id:                  "task2",
 			DisplayName:         "test",
@@ -705,7 +715,7 @@ func TestGetTestHistory(t *testing.T) {
 			RevisionOrderNumber: 2,
 			Status:              evergreen.TaskFailed,
 		}
-		So(task2.Insert(), ShouldBeNil)
+		assert.NoError(task2.Insert())
 		testresults2 := []testresult.TestResult{
 			testresult.TestResult{
 				Status:   evergreen.TestFailedStatus,
@@ -716,7 +726,7 @@ func TestGetTestHistory(t *testing.T) {
 				TestFile: "test2",
 			},
 		}
-		So(testresult.InsertManyByTaskIDAndExecution(testresults2, task2.Id, task2.Execution), ShouldBeNil)
+		assert.NoError(testresult.InsertManyByTaskIDAndExecution(testresults2, task2.Id, task2.Execution))
 		task3 := task.Task{
 			Id:                  "task3",
 			DisplayName:         "test2",
@@ -740,7 +750,7 @@ func TestGetTestHistory(t *testing.T) {
 				},
 			},
 		}
-		So(task3.Insert(), ShouldBeNil)
+		assert.NoError(task3.Insert())
 		testresults3 := []testresult.TestResult{
 			testresult.TestResult{
 				Status:   evergreen.TestFailedStatus,
@@ -755,317 +765,389 @@ func TestGetTestHistory(t *testing.T) {
 				TestFile: "test4",
 			},
 		}
-		So(testresult.InsertManyByTaskIDAndExecution(testresults3, task3.Id, task3.Execution), ShouldBeNil)
-		Convey("retrieving the task history with just a task name in the parameters should return relevant results", func() {
-			params := TestHistoryParameters{
-				TaskNames:    []string{"test"},
-				Project:      project,
-				Sort:         1,
-				TaskStatuses: []string{evergreen.TaskFailed},
-				TestStatuses: []string{evergreen.TestSucceededStatus, evergreen.TestFailedStatus},
-				Limit:        20,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(len(testResults), ShouldEqual, 4)
-			Convey("the order of the test results should be in sorted order", func() {
-				So(testResults[0].TaskId, ShouldEqual, "task1")
-				So(testResults[1].TaskId, ShouldEqual, "task1")
-				So(testResults[2].TaskId, ShouldEqual, "task2")
-				So(testResults[3].TaskId, ShouldEqual, "task2")
-			})
-			Convey("with a sort of -1, the order should be in reverse revision order number order", func() {
-				params.Sort = -1
-				testResults, err := GetTestHistory(&params)
-				So(err, ShouldBeNil)
-				So(len(testResults), ShouldEqual, 4)
-				Convey("the order of the test results should be in reverse revision number order", func() {
-					So(testResults[0].TaskId, ShouldEqual, "task2")
-					So(testResults[3].TaskId, ShouldEqual, "task1")
-				})
-			})
-		})
-		Convey("retrieving the task history for just a set of test names in the parameters should return relevant results", func() {
-			params := TestHistoryParameters{
-				TestNames: []string{"test1"},
-				Project:   project,
-				Limit:     20,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(len(testResults), ShouldEqual, 3)
-		})
-		Convey("including a filter on a before revision should return inclusive results", func() {
-			params := TestHistoryParameters{
-				TaskNames:      []string{"test"},
-				Project:        project,
-				Sort:           1,
-				BeforeRevision: testVersion2.Revision,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(len(testResults), ShouldEqual, 3)
-			So(testResults[0].TaskId, ShouldEqual, "task1")
-		})
-		Convey("including a filter on an after revision, should only return exclusive results", func() {
-			params := TestHistoryParameters{
-				TaskNames:     []string{"test"},
-				Project:       project,
-				Sort:          1,
-				AfterRevision: testVersion.Revision,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(len(testResults), ShouldEqual, 2)
-			So(testResults[0].TaskId, ShouldEqual, "task2")
-		})
-		Convey("including a filter on both before and after revision should return relevant results", func() {
-			params := TestHistoryParameters{
-				TaskNames:      []string{"test"},
-				Project:        project,
-				Sort:           1,
-				BeforeRevision: testVersion2.Revision,
-				AfterRevision:  testVersion.Revision,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(len(testResults), ShouldEqual, 2)
-			So(testResults[0].TaskId, ShouldEqual, "task2")
-		})
-		Convey("including a filter on a before start time should return relevant results", func() {
-			params := TestHistoryParameters{
-				TaskNames:  []string{"test"},
-				Project:    project,
-				BeforeDate: now.Add(time.Duration(15 * time.Minute)),
-				Limit:      20,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(len(testResults), ShouldEqual, 1)
-
-		})
-		Convey("including a filter on an after start time should return relevant results", func() {
-			params := TestHistoryParameters{
-				TaskNames: []string{"test"},
-				Project:   project,
-				AfterDate: now,
-				Limit:     20,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(len(testResults), ShouldEqual, 3)
-		})
-		Convey("including a filter on test status of 'silentfail' should return relevant results", func() {
-			params := TestHistoryParameters{
-				Project:      project,
-				TaskNames:    []string{"test2"},
-				TestStatuses: []string{evergreen.TestSilentlyFailedStatus},
-				Limit:        20,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(len(testResults), ShouldEqual, 1)
-		})
-		Convey("with a task with a different build variant,", func() {
-			anotherBV := task.Task{
-				Id:                  "task5",
-				DisplayName:         "test",
-				BuildVariant:        "bv2",
-				Project:             project,
-				StartTime:           now,
-				RevisionOrderNumber: 2,
-				Status:              evergreen.TaskFailed,
-			}
-			So(anotherBV.Insert(), ShouldBeNil)
-			anotherBVresults := []testresult.TestResult{
-				testresult.TestResult{
-					Status:   evergreen.TestFailedStatus,
-					TestFile: "test1",
-				},
-				testresult.TestResult{
-					Status:   evergreen.TestFailedStatus,
-					TestFile: "test2",
-				},
-			}
-			So(testresult.InsertManyByTaskIDAndExecution(anotherBVresults, anotherBV.Id, anotherBV.Execution), ShouldBeNil)
-			Convey("including a filter on build variant should only return test results with that build variant", func() {
-				params := TestHistoryParameters{
-					TaskNames:     []string{"test"},
-					Project:       project,
-					BuildVariants: []string{"bv2"},
-					Limit:         20,
-				}
-				So(params.SetDefaultsAndValidate(), ShouldBeNil)
-				testResults, err := GetTestHistory(&params)
-				So(err, ShouldBeNil)
-				So(len(testResults), ShouldEqual, 2)
-			})
-			Convey("not having the filter should return all results", func() {
-				params := TestHistoryParameters{
-					TaskNames: []string{"test"},
-					Project:   project,
-					Limit:     20,
-				}
-				So(params.SetDefaultsAndValidate(), ShouldBeNil)
-				testResults, err := GetTestHistory(&params)
-				So(err, ShouldBeNil)
-				So(len(testResults), ShouldEqual, 5)
-			})
-		})
-		Convey("using a task with no test results", func() {
-			noResults := task.Task{
-				Id:                  "noResults",
-				DisplayName:         "anothertest",
-				BuildVariant:        "bv2",
-				Project:             project,
-				StartTime:           now,
-				RevisionOrderNumber: 2,
-				Status:              evergreen.TaskFailed,
-			}
-			So(noResults.Insert(), ShouldBeNil)
-			params := TestHistoryParameters{
-				TaskNames: []string{"anothertest"},
-				Project:   project,
-				Limit:     20,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(testResults, ShouldBeEmpty)
-		})
-		Convey("with tasks with different ordered test results", func() {
-			diffOrder := task.Task{
-				Id:                  "anotherTaskId",
-				DisplayName:         "testTask",
-				Project:             project,
-				StartTime:           now,
-				RevisionOrderNumber: 2,
-				Status:              evergreen.TaskFailed,
-			}
-			So(diffOrder.Insert(), ShouldBeNil)
-			diffOrderResults := []testresult.TestResult{
-				testresult.TestResult{
-					Status:   evergreen.TestFailedStatus,
-					TestFile: "test2",
-				},
-				testresult.TestResult{
-					Status:   evergreen.TestFailedStatus,
-					TestFile: "test1",
-				},
-			}
-			So(testresult.InsertManyByTaskIDAndExecution(diffOrderResults, diffOrder.Id, diffOrder.Execution), ShouldBeNil)
-			diffOrder2 := task.Task{
-				Id:                  "anotherTaskId2",
-				DisplayName:         "testTask",
-				Project:             project,
-				StartTime:           now,
-				RevisionOrderNumber: 1,
-				Status:              evergreen.TaskFailed,
-			}
-			So(diffOrder2.Insert(), ShouldBeNil)
-			diffOrder2Results := []testresult.TestResult{
-				testresult.TestResult{
-					Status:   evergreen.TestFailedStatus,
-					TestFile: "test1",
-				},
-				testresult.TestResult{
-					Status:   evergreen.TestFailedStatus,
-					TestFile: "test2",
-				},
-			}
-			So(testresult.InsertManyByTaskIDAndExecution(diffOrder2Results, diffOrder2.Id, diffOrder2.Execution), ShouldBeNil)
-
-			Convey("the order of the tests should be the same", func() {
-				params := TestHistoryParameters{
-					TaskNames: []string{"testTask"},
-					Project:   project,
-					Limit:     20,
-				}
-				So(params.SetDefaultsAndValidate(), ShouldBeNil)
-				testResults, err := GetTestHistory(&params)
-				So(err, ShouldBeNil)
-				So(len(testResults), ShouldEqual, 4)
-				So(testResults[0].TaskId, ShouldEqual, "anotherTaskId")
-				So(testResults[0].TestFile, ShouldEqual, "test2")
-				So(testResults[1].TaskId, ShouldEqual, "anotherTaskId")
-				So(testResults[1].TestFile, ShouldEqual, "test1")
-				So(testResults[2].TaskId, ShouldEqual, "anotherTaskId2")
-				So(testResults[2].TestFile, ShouldEqual, "test2")
-				So(testResults[3].TaskId, ShouldEqual, "anotherTaskId2")
-				So(testResults[3].TestFile, ShouldEqual, "test1")
-			})
-
-		})
-		Convey("using test parameter with a task status with timeouts", func() {
-			timedOutTask := task.Task{
-				Id:                  "timeout",
-				DisplayName:         "test",
-				Project:             project,
-				StartTime:           now,
-				RevisionOrderNumber: 1,
-
-				Status: evergreen.TaskFailed,
-				Details: apimodels.TaskEndDetail{
-					TimedOut: true,
-				},
-			}
-			So(timedOutTask.Insert(), ShouldBeNil)
-			timedOutResults := testresult.TestResult{
+		assert.NoError(testresult.InsertManyByTaskIDAndExecution(testresults3, task3.Id, task3.Execution))
+		// retrieving the task history with just a task name in the parameters should return relevant results
+		params := TestHistoryParameters{
+			TaskNames:    []string{"test"},
+			Project:      project,
+			Sort:         1,
+			TaskStatuses: []string{evergreen.TaskFailed},
+			TestStatuses: []string{evergreen.TestSucceededStatus, evergreen.TestFailedStatus},
+			Limit:        20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err := testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 4)
+		// the order of the test results should be in sorted order
+		assert.Equal("task1", testResults[0].TaskId)
+		assert.Equal("task1", testResults[1].TaskId)
+		assert.Equal("task2", testResults[2].TaskId)
+		assert.Equal("task2", testResults[3].TaskId)
+		// with a sort of -1, the order should be in reverse revision order number order
+		params.Sort = -1
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 4)
+		//the order of the test results should be in reverse revision number order
+		assert.Equal("task2", testResults[0].TaskId)
+		assert.Equal("task1", testResults[3].TaskId)
+		// retrieving the task history for just a set of test names in the parameters should return relevant results
+		params = TestHistoryParameters{
+			TestNames: []string{"test1"},
+			Project:   project,
+			Limit:     20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 3)
+		// including a filter on a before revision should return inclusive results
+		params = TestHistoryParameters{
+			TaskNames:      []string{"test"},
+			Project:        project,
+			Sort:           1,
+			BeforeRevision: testVersion2.Revision,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 3)
+		assert.Equal("task1", testResults[0].TaskId)
+		// including a filter on an after revision, should only return exclusive results
+		params = TestHistoryParameters{
+			TaskNames:     []string{"test"},
+			Project:       project,
+			Sort:          1,
+			AfterRevision: testVersion.Revision,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 2)
+		assert.Equal("task2", testResults[0].TaskId)
+		// including a filter on both before and after revision should return relevant results
+		params = TestHistoryParameters{
+			TaskNames:      []string{"test"},
+			Project:        project,
+			Sort:           1,
+			BeforeRevision: testVersion2.Revision,
+			AfterRevision:  testVersion.Revision,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 2)
+		assert.Equal("task2", testResults[0].TaskId)
+		// including a filter on a before start time should return relevant results
+		params = TestHistoryParameters{
+			TaskNames:  []string{"test"},
+			Project:    project,
+			BeforeDate: now.Add(time.Duration(15 * time.Minute)),
+			Limit:      20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 1)
+		// including a filter on an after start time should return relevant results
+		params = TestHistoryParameters{
+			TaskNames: []string{"test"},
+			Project:   project,
+			AfterDate: now,
+			Limit:     20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 3)
+		// including a filter on test status of 'silentfail' should return relevant results
+		params = TestHistoryParameters{
+			Project:      project,
+			TaskNames:    []string{"test2"},
+			TestStatuses: []string{evergreen.TestSilentlyFailedStatus},
+			Limit:        20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 1)
+		// with a task with a different build variant
+		anotherBV := task.Task{
+			Id:                  "task5",
+			DisplayName:         "test",
+			BuildVariant:        "bv2",
+			Project:             project,
+			StartTime:           now,
+			RevisionOrderNumber: 2,
+			Status:              evergreen.TaskFailed,
+		}
+		assert.NoError(anotherBV.Insert())
+		anotherBVresults := []testresult.TestResult{
+			testresult.TestResult{
+				Status:   evergreen.TestFailedStatus,
+				TestFile: "test1",
+			},
+			testresult.TestResult{
 				Status:   evergreen.TestFailedStatus,
 				TestFile: "test2",
-			}
-			So(timedOutResults.InsertByTaskIDAndExecution(timedOutTask.Id, timedOutTask.Execution), ShouldBeNil)
-			params := TestHistoryParameters{
-				Project:      project,
-				TaskNames:    []string{"test"},
-				TaskStatuses: []string{TaskTimeout},
-				Limit:        20,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(len(testResults), ShouldEqual, 1)
-		})
-		Convey("using test parameter with a task status with system failures", func() {
-			systemFailureTask := task.Task{
-				Id:                  "systemfailed",
-				DisplayName:         "test",
-				Project:             project,
-				StartTime:           now,
-				RevisionOrderNumber: 1,
-
-				Status: evergreen.TaskFailed,
-				Details: apimodels.TaskEndDetail{
-					Type: "system",
-				},
-			}
-			So(systemFailureTask.Insert(), ShouldBeNil)
-			systemFailureResult := testresult.TestResult{
+			},
+		}
+		assert.NoError(testresult.InsertManyByTaskIDAndExecution(anotherBVresults, anotherBV.Id, anotherBV.Execution))
+		// including a filter on build variant should only return test results with that build variant
+		params = TestHistoryParameters{
+			TaskNames:     []string{"test"},
+			Project:       project,
+			BuildVariants: []string{"bv2"},
+			Limit:         20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 2)
+		// not having the filter should return all results
+		params = TestHistoryParameters{
+			TaskNames: []string{"test"},
+			Project:   project,
+			Limit:     20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 5)
+		// using a task with no test results
+		noResults := task.Task{
+			Id:                  "noResults",
+			DisplayName:         "anothertest",
+			BuildVariant:        "bv2",
+			Project:             project,
+			StartTime:           now,
+			RevisionOrderNumber: 2,
+			Status:              evergreen.TaskFailed,
+		}
+		assert.NoError(noResults.Insert())
+		params = TestHistoryParameters{
+			TaskNames: []string{"anothertest"},
+			Project:   project,
+			Limit:     20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Empty(testResults)
+		// with tasks with different ordered test results
+		diffOrder := task.Task{
+			Id:                  "anotherTaskId",
+			DisplayName:         "testTask",
+			Project:             project,
+			StartTime:           now,
+			RevisionOrderNumber: 2,
+			Status:              evergreen.TaskFailed,
+		}
+		assert.NoError(diffOrder.Insert())
+		diffOrderResults := []testresult.TestResult{
+			testresult.TestResult{
 				Status:   evergreen.TestFailedStatus,
 				TestFile: "test2",
-			}
-			So(systemFailureResult.InsertByTaskIDAndExecution(systemFailureTask.Id, systemFailureTask.Execution), ShouldBeNil)
-			params := TestHistoryParameters{
-				Project:      project,
-				TaskNames:    []string{"test"},
-				TaskStatuses: []string{TaskSystemFailure},
-				Limit:        20,
-			}
-			So(params.SetDefaultsAndValidate(), ShouldBeNil)
-			testResults, err := GetTestHistory(&params)
-			So(err, ShouldBeNil)
-			So(len(testResults), ShouldEqual, 1)
-			So(testResults[0].TestFile, ShouldEqual, "test2")
-			So(testResults[0].TaskDetailsType, ShouldEqual, "system")
-		})
+			},
+			testresult.TestResult{
+				Status:   evergreen.TestFailedStatus,
+				TestFile: "test1",
+			},
+		}
+		assert.NoError(testresult.InsertManyByTaskIDAndExecution(diffOrderResults, diffOrder.Id, diffOrder.Execution))
+		diffOrder2 := task.Task{
+			Id:                  "anotherTaskId2",
+			DisplayName:         "testTask",
+			Project:             project,
+			StartTime:           now,
+			RevisionOrderNumber: 1,
+			Status:              evergreen.TaskFailed,
+		}
+		assert.NoError(diffOrder2.Insert())
+		diffOrder2Results := []testresult.TestResult{
+			testresult.TestResult{
+				Status:   evergreen.TestFailedStatus,
+				TestFile: "test1",
+			},
+			testresult.TestResult{
+				Status:   evergreen.TestFailedStatus,
+				TestFile: "test2",
+			},
+		}
+		assert.NoError(testresult.InsertManyByTaskIDAndExecution(diffOrder2Results, diffOrder2.Id, diffOrder2.Execution))
 
-	})
+		// the order of the tests should be the same
+		params = TestHistoryParameters{
+			TaskNames: []string{"testTask"},
+			Project:   project,
+			Limit:     20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 4)
+		assert.Equal("anotherTaskId", testResults[0].TaskId)
+		assert.Equal("test2", testResults[0].TestFile)
+		assert.Equal("anotherTaskId", testResults[1].TaskId)
+		assert.Equal("test1", testResults[1].TestFile)
+		assert.Equal("anotherTaskId2", testResults[2].TaskId)
+		assert.Equal("test2", testResults[2].TestFile)
+		assert.Equal("anotherTaskId2", testResults[3].TaskId)
+		assert.Equal("test1", testResults[3].TestFile)
+		// using test parameter with a task status with timeouts
+		timedOutTask := task.Task{
+			Id:                  "timeout",
+			DisplayName:         "test",
+			Project:             project,
+			StartTime:           now,
+			RevisionOrderNumber: 1,
+
+			Status: evergreen.TaskFailed,
+			Details: apimodels.TaskEndDetail{
+				TimedOut: true,
+			},
+		}
+		assert.NoError(timedOutTask.Insert())
+		timedOutResults := testresult.TestResult{
+			Status:   evergreen.TestFailedStatus,
+			TestFile: "test2",
+		}
+		assert.NoError(timedOutResults.InsertByTaskIDAndExecution(timedOutTask.Id, timedOutTask.Execution))
+		params = TestHistoryParameters{
+			Project:      project,
+			TaskNames:    []string{"test"},
+			TaskStatuses: []string{TaskTimeout},
+			Limit:        20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 1)
+		// using test parameter with a task status with system failures
+		systemFailureTask := task.Task{
+			Id:                  "systemfailed",
+			DisplayName:         "test",
+			Project:             project,
+			StartTime:           now,
+			RevisionOrderNumber: 1,
+
+			Status: evergreen.TaskFailed,
+			Details: apimodels.TaskEndDetail{
+				Type: "system",
+			},
+		}
+		assert.NoError(systemFailureTask.Insert())
+		systemFailureResult := testresult.TestResult{
+			Status:   evergreen.TestFailedStatus,
+			TestFile: "test2",
+		}
+		assert.NoError(systemFailureResult.InsertByTaskIDAndExecution(systemFailureTask.Id, systemFailureTask.Execution))
+		params = TestHistoryParameters{
+			Project:      project,
+			TaskNames:    []string{"test"},
+			TaskStatuses: []string{TaskSystemFailure},
+			Limit:        20,
+		}
+		assert.NoError(params.SetDefaultsAndValidate())
+		testResults, err = testFunc(&params)
+		assert.NoError(err)
+		assert.Len(testResults, 1)
+		assert.Equal("test2", testResults[0].TestFile)
+		assert.Equal("system", testResults[0].TaskDetailsType)
+	}
+}
+
+func TestCompareQueryRunTimes(t *testing.T) {
+	assert := assert.New(t)
+	rand.Seed(time.Now().UnixNano())
+	numTasks := 1000  // # of tasks to insert into the db
+	maxNumTests := 50 // max # of tests per task to insert (randomized per task)
+	taskStatuses := []string{evergreen.TaskFailed, evergreen.TaskSucceeded}
+	testStatuses := []string{evergreen.TestFailedStatus, evergreen.TestSucceededStatus, evergreen.TestSkippedStatus, evergreen.TestSilentlyFailedStatus}
+	systemTypes := []string{"test", "system"}
+	testutil.HandleTestingErr(db.ClearCollections(task.Collection, version.Collection, testresult.Collection),
+		t, "Error clearing collections")
+	project := "proj"
+	now := time.Now()
+
+	testVersion := version.Version{
+		Id:                  "testVersion",
+		Revision:            "fgh",
+		RevisionOrderNumber: 1,
+		Identifier:          project,
+		Requester:           evergreen.RepotrackerVersionRequester,
+	}
+	assert.NoError(testVersion.Insert())
+	testVersion2 := version.Version{
+		Id:                  "anotherVersion",
+		Revision:            "def",
+		RevisionOrderNumber: 2,
+		Identifier:          project,
+		Requester:           evergreen.RepotrackerVersionRequester,
+	}
+	assert.NoError(testVersion2.Insert())
+	testVersion3 := version.Version{
+		Id:                  "testV",
+		Revision:            "abcd",
+		RevisionOrderNumber: 4,
+		Identifier:          project,
+		Requester:           evergreen.RepotrackerVersionRequester,
+	}
+	assert.NoError(testVersion3.Insert())
+
+	// insert tasks and tests
+	for i := 0; i < numTasks; i++ {
+		t := task.Task{
+			Id:                  fmt.Sprintf("task_%d", i),
+			DisplayName:         fmt.Sprintf("task_%d", i),
+			BuildVariant:        "osx",
+			Project:             project,
+			StartTime:           now,
+			RevisionOrderNumber: rand.Intn(100),
+			Execution:           0,
+			Status:              taskStatuses[rand.Intn(1)],
+			Details: apimodels.TaskEndDetail{
+				Type:     systemTypes[rand.Intn(1)],
+				TimedOut: (rand.Intn(1) == 1),
+			},
+		}
+
+		assert.NoError(t.Insert())
+		numTests := rand.Intn(maxNumTests)
+		tests := []testresult.TestResult{}
+		for j := 0; j < numTests; j++ {
+			tests = append(tests, testresult.TestResult{
+				TestFile: fmt.Sprintf("test_%d", j),
+				Status:   testStatuses[rand.Intn(3)],
+			})
+		}
+		assert.NoError(testresult.InsertManyByTaskIDAndExecution(tests, t.Id, t.Execution))
+	}
+	// test querying on task names
+	tasksToFind := []string{}
+	for i := 0; i < numTasks; i++ {
+		tasksToFind = append(tasksToFind, fmt.Sprintf("task_%d", i))
+	}
+	params := &TestHistoryParameters{
+		TaskNames: tasksToFind,
+		Project:   project,
+		Sort:      1,
+		Limit:     5000,
+	}
+	assert.NoError(params.SetDefaultsAndValidate())
+	startTime := time.Now()
+	resultsV1, err := GetTestHistory(params)
+	elapsedV1 := time.Since(startTime)
+	assert.NoError(err)
+	startTime = time.Now()
+	resultsV2, err := GetTestHistoryV2(params)
+	elapsedV2 := time.Since(startTime)
+	assert.NoError(err)
+	assert.Equal(len(resultsV1), len(resultsV2))
+	grip.Infof("elapsed time for aggregation test history query: %s", elapsedV1.String())
+	grip.Infof("elapsed time for non-aggregation test history query: %s", elapsedV2.String())
+
+	testutil.HandleTestingErr(db.ClearCollections(task.Collection, version.Collection, testresult.Collection),
+		t, "Error clearing collections")
 }

--- a/model/task_history_test.go
+++ b/model/task_history_test.go
@@ -1124,6 +1124,7 @@ func TestCompareQueryRunTimes(t *testing.T) {
 		}
 		assert.NoError(testresult.InsertManyByTaskIDAndExecution(tests, t.Id, t.Execution))
 	}
+
 	// test querying on task names
 	tasksToFind := []string{}
 	for i := 0; i < numTasks; i++ {
@@ -1145,8 +1146,32 @@ func TestCompareQueryRunTimes(t *testing.T) {
 	elapsedV2 := time.Since(startTime)
 	assert.NoError(err)
 	assert.Equal(len(resultsV1), len(resultsV2))
-	grip.Infof("elapsed time for aggregation test history query: %s", elapsedV1.String())
-	grip.Infof("elapsed time for non-aggregation test history query: %s", elapsedV2.String())
+	grip.Infof("elapsed time for aggregation test history query on task names: %s", elapsedV1.String())
+	grip.Infof("elapsed time for non-aggregation test history query on task names: %s", elapsedV2.String())
+
+	// test querying on test names
+	testsToFind := []string{}
+	for i := 0; i < maxNumTests; i++ {
+		testsToFind = append(tasksToFind, fmt.Sprintf("test_%d", i))
+	}
+	params = &TestHistoryParameters{
+		TestNames: testsToFind,
+		Project:   project,
+		Sort:      1,
+		Limit:     5000,
+	}
+	assert.NoError(params.SetDefaultsAndValidate())
+	startTime = time.Now()
+	resultsV1, err = GetTestHistory(params)
+	elapsedV1 = time.Since(startTime)
+	assert.NoError(err)
+	startTime = time.Now()
+	resultsV2, err = GetTestHistoryV2(params)
+	elapsedV2 = time.Since(startTime)
+	assert.NoError(err)
+	assert.Equal(len(resultsV1), len(resultsV2))
+	grip.Infof("elapsed time for aggregation test history query on test names: %s", elapsedV1.String())
+	grip.Infof("elapsed time for non-aggregation test history query on test names: %s", elapsedV2.String())
 
 	testutil.HandleTestingErr(db.ClearCollections(task.Collection, version.Collection, testresult.Collection),
 		t, "Error clearing collections")

--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -58,7 +58,7 @@ func FindByTaskIDAndExecution(taskID string, execution int) ([]TestResult, error
 		TaskIDKey:    0,
 		ExecutionKey: 0,
 	})
-	return find(q)
+	return Find(q)
 }
 
 // InsertByTaskIDAndExecution adds task metadata to a TestResult and then writes it to the database.
@@ -81,7 +81,7 @@ func InsertManyByTaskIDAndExecution(testResults []TestResult, taskID string, exe
 }
 
 // find returns all test results that satisfy the query. Returns an empty slice no tasks match.
-func find(query db.Q) ([]TestResult, error) {
+func Find(query db.Q) ([]TestResult, error) {
 	tests := []TestResult{}
 	err := db.FindAllQ(Collection, query, &tests)
 	return tests, err

--- a/service/rest_task_history.go
+++ b/service/rest_task_history.go
@@ -154,7 +154,7 @@ func (restapi restAPI) GetTestHistory(w http.ResponseWriter, r *http.Request) {
 		restapi.WriteJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	results, err := model.GetTestHistory(&params)
+	results, err := model.GetTestHistoryV2(&params)
 	if err != nil {
 		restapi.WriteJSON(w, http.StatusBadRequest, err.Error())
 		return


### PR DESCRIPTION
Running the timing comparison test, the new (non-aggregation) query is significantly slower than the old (aggregation) query, but it handles large test results that could potentially error the old one. Let me know if you think we need to rethink the approach