### PR TITLE
EVG-2362 Fix test-command on OS X

### DIFF
--- a/command/shell_test.go
+++ b/command/shell_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,69 +13,85 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/client"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
-	. "github.com/smartystreets/goconvey/convey"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
+type shellExecuteCommandSuite struct {
+	suite.Suite
+	cancel func()
+	conf   *model.TaskConfig
+	comm   client.Communicator
+	logger client.LoggerProducer
+	ctx    context.Context
+
+	shells []string
+}
+
 func TestShellExecuteCommand(t *testing.T) {
-	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
+	suite.Run(t, new(shellExecuteCommandSuite))
+}
+
+func (s *shellExecuteCommandSuite) SetupTest() {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+
+	s.comm = client.NewMock("http://localhost.com")
+	s.conf = &model.TaskConfig{Expansions: &util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
+	s.logger = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret})
+
+	s.shells = []string{"bash", "python", "sh"}
+
+	if runtime.GOOS != "windows" {
+		s.shells = append(s.shells, "/bin/sh", "/bin/bash", "/usr/bin/python")
+	}
+}
+
+func (s *shellExecuteCommandSuite) TearDownTest() {
+	s.cancel()
+}
+
+func (s *shellExecuteCommandSuite) TestWorksWithEmptyShell() {
+	cmd := &shellExec{WorkingDir: testutil.GetDirectoryOfFile()}
+	s.Empty(cmd.Shell)
+	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
+}
+
+func (s *shellExecuteCommandSuite) TestShellIsntChangedDuringExecution() {
+	for _, sh := range s.shells {
+		cmd := &shellExec{Shell: sh, WorkingDir: testutil.GetDirectoryOfFile()}
+
+		s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
+		s.Equal(sh, cmd.Shell)
+	}
+}
+
+func (s *shellExecuteCommandSuite) TestUnsetWorkedDirectoryFails() {
+	cmd := &shellExec{}
+	s.Error(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
+}
+
+func (s *shellExecuteCommandSuite) TestErrorIfWorkingDirectoryDoesntExist() {
+	path := "foo/bar/baz"
+	_, err := os.Stat(path)
+	s.Error(err)
+	s.True(os.IsNotExist(err))
+
+	_, err = os.Stat(filepath.Join(s.conf.WorkDir))
+	s.Error(err)
+	s.True(os.IsNotExist(err))
+
+	cmd := &shellExec{WorkingDir: path}
+	s.Error(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
+}
+
+func (s *shellExecuteCommandSuite) TestCancellingContextShouldCancelCommand() {
+	cmd := &shellExec{
+		Script:     "sleep 10",
+		WorkingDir: testutil.GetDirectoryOfFile(),
+	}
+	ctx, cancel := context.WithTimeout(s.ctx, time.Millisecond)
 	defer cancel()
-	comm := client.NewMock("http://localhost.com")
-	conf := &model.TaskConfig{Expansions: &util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
-	logger := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret})
 
-	Convey("With a shell command", t, func() {
-
-		Convey("if unset, default is determined by local command", func() {
-			cmd := &shellExec{WorkingDir: testutil.GetDirectoryOfFile()}
-			So(cmd.Execute(ctx, comm, logger, conf), ShouldBeNil)
-			So(cmd.Shell, ShouldEqual, "")
-		})
-
-		shells := []string{"bash", "python", "sh"}
-
-		if runtime.GOOS != "windows" {
-			shells = append(shells, "/bin/sh", "/bin/bash", "/usr/bin/python")
-		}
-
-		for _, sh := range shells {
-			Convey(fmt.Sprintf("when set, %s is not overwritten during execution", sh), func() {
-				cmd := &shellExec{Shell: sh, WorkingDir: testutil.GetDirectoryOfFile()}
-				So(cmd.Execute(ctx, comm, logger, conf), ShouldBeNil)
-				So(cmd.Shell, ShouldEqual, sh)
-			})
-		}
-
-		Convey("command should error if working directory is unset", func() {
-			cmd := &shellExec{}
-			So(cmd.Execute(ctx, comm, logger, conf), ShouldNotBeNil)
-		})
-
-		Convey("command should error if working directory does not exist", func() {
-			path := "foo/bar/baz"
-			_, err := os.Stat(path)
-			So(os.IsNotExist(err), ShouldBeTrue)
-			_, err = os.Stat(filepath.Join(conf.WorkDir))
-			So(os.IsNotExist(err), ShouldBeTrue)
-
-			cmd := &shellExec{WorkingDir: path}
-			So(cmd.Execute(ctx, comm, logger, conf), ShouldNotBeNil)
-
-		})
-
-		Convey("canceling the context should cancel the command", func() {
-			cmd := &shellExec{
-				Script:     "sleep 10",
-				WorkingDir: testutil.GetDirectoryOfFile(),
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-			defer cancel()
-
-			err := cmd.Execute(ctx, comm, logger, conf)
-			assert.Contains(err.Error(), "shell command interrupted")
-			assert.NotContains(err.Error(), "error while stopping process")
-		})
-
-	})
+	err := cmd.Execute(ctx, s.comm, s.logger, s.conf)
+	s.Contains("shell command interrupted", err.Error())
+	s.NotContains("error while stopping process", err.Error())
 }

--- a/command/shell_test.go
+++ b/command/shell_test.go
@@ -85,7 +85,7 @@ func (s *shellExecuteCommandSuite) TestErrorIfWorkingDirectoryDoesntExist() {
 
 func (s *shellExecuteCommandSuite) TestCancellingContextShouldCancelCommand() {
 	cmd := &shellExec{
-		Script:     "sleep 10",
+		Script:     "sleep 60",
 		WorkingDir: testutil.GetDirectoryOfFile(),
 	}
 	ctx, cancel := context.WithTimeout(s.ctx, time.Millisecond)


### PR DESCRIPTION
extended sleep duration to 60 seconds; grip's collect all processes on OS X take ~30-40 seconds