### PR TITLE
EVG-2408 Extend Rest v2 API to include patch alias

### DIFF
--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -144,6 +144,7 @@ func (c *cliIntent) NewPatch() *Patch {
 		Githash:       c.BaseHash,
 		Status:        evergreen.PatchCreated,
 		BuildVariants: c.BuildVariants,
+		Alias:         c.Alias,
 		Tasks:         c.Tasks,
 		Patches: []ModulePatch{
 			{

--- a/model/patch/cli_intent_test.go
+++ b/model/patch/cli_intent_test.go
@@ -150,3 +150,33 @@ func findCliIntents(processed bool) ([]*cliIntent, error) {
 	}
 	return intents, nil
 }
+
+func (s *CliIntentSuite) TestNewPatch() {
+	intent, err := NewCliIntent(s.user, s.projectID, s.hash, s.module, s.patchContent, s.description, true, s.variants, s.tasks, s.alias)
+	s.NoError(err)
+	s.NotNil(intent)
+
+	patchDoc := intent.NewPatch()
+	s.NotNil(patchDoc)
+	s.Zero(patchDoc.Id)
+	s.Equal(s.description, patchDoc.Description)
+	s.Equal(s.projectID, patchDoc.Project)
+	s.Equal(s.hash, patchDoc.Githash)
+	s.Zero(patchDoc.PatchNumber)
+	s.Empty(patchDoc.Version)
+	s.Equal(evergreen.PatchCreated, patchDoc.Status)
+	s.Zero(patchDoc.CreateTime)
+	s.Zero(patchDoc.StartTime)
+	s.Zero(patchDoc.FinishTime)
+	s.Equal(s.variants, patchDoc.BuildVariants)
+	s.Equal(s.tasks, patchDoc.Tasks)
+	s.Empty(patchDoc.VariantsTasks)
+	s.Len(patchDoc.Patches, 1)
+	s.Equal(s.module, patchDoc.Patches[0].ModuleName)
+	s.Equal(s.hash, patchDoc.Patches[0].Githash)
+	s.Zero(patchDoc.Patches[0].PatchSet)
+	s.False(patchDoc.Activated)
+	s.Empty(patchDoc.PatchedConfig)
+	s.Equal(s.alias, patchDoc.Alias)
+	s.Zero(patchDoc.GithubPatchData)
+}

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -245,6 +245,7 @@ func (g *githubIntent) NewPatch() *Patch {
 	pullURL := fmt.Sprintf("https://github.com/%s/pull/%d", g.BaseRepoName, g.PRNumber)
 	patchDoc := &Patch{
 		Id:          bson.NewObjectId(),
+		Alias:       GithubAlias,
 		Description: fmt.Sprintf("'%s' pull request #%d by %s: %s (%s)", g.BaseRepoName, g.PRNumber, g.User, g.Title, pullURL),
 		Author:      evergreen.GithubPatchUser,
 		Status:      evergreen.PatchCreated,

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -164,23 +164,40 @@ func (s *GithubSuite) TestSetProcessed() {
 	s.Equal(GithubIntentType, intents[0].GetType())
 }
 
-func (s *GithubSuite) FindUnprocessedGithubIntents() {
+func (s *GithubSuite) TestFindUnprocessedGithubIntents() {
 	intents := []githubIntent{
 		githubIntent{
-			Processed: true,
+			DocumentID: bson.NewObjectId(),
+			IntentType: GithubIntentType,
+			Processed:  true,
 		},
 		githubIntent{
-			Processed: true,
+			DocumentID: bson.NewObjectId(),
+			IntentType: GithubIntentType,
+			Processed:  true,
 		},
 		githubIntent{
-			Processed: true,
+			DocumentID: bson.NewObjectId(),
+			IntentType: GithubIntentType,
+			Processed:  true,
 		},
 		githubIntent{
-			Processed: true,
+			DocumentID: bson.NewObjectId(),
+			IntentType: GithubIntentType,
+			Processed:  true,
 		},
-		githubIntent{},
-		githubIntent{},
-		githubIntent{},
+		githubIntent{
+			DocumentID: bson.NewObjectId(),
+			IntentType: GithubIntentType,
+		},
+		githubIntent{
+			DocumentID: bson.NewObjectId(),
+			IntentType: GithubIntentType,
+		},
+		githubIntent{
+			DocumentID: bson.NewObjectId(),
+			IntentType: GithubIntentType,
+		},
 	}
 
 	for _, intent := range intents {
@@ -190,4 +207,38 @@ func (s *GithubSuite) FindUnprocessedGithubIntents() {
 	found, err := FindUnprocessedGithubIntents()
 	s.NoError(err)
 	s.Len(found, 3)
+}
+
+func (s *GithubSuite) TestNewPatch() {
+	intent, err := NewGithubIntent("4", testutil.NewGithubPREvent(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.url, s.title))
+	s.NoError(err)
+	s.NotNil(intent)
+
+	patchDoc := intent.NewPatch()
+	s.NotNil(patchDoc)
+	s.NotZero(patchDoc.Id)
+	s.Equal("'evergreen-ci/evergreen' pull request #5 by octocat: Art of Pull Requests (https://github.com/evergreen-ci/evergreen/pull/5)", patchDoc.Description)
+	s.Empty(patchDoc.Project)
+	s.Empty(patchDoc.Githash)
+	s.Zero(patchDoc.PatchNumber)
+	s.Empty(patchDoc.Version)
+	s.Equal(evergreen.PatchCreated, patchDoc.Status)
+	s.Zero(patchDoc.CreateTime)
+	s.Zero(patchDoc.StartTime)
+	s.Zero(patchDoc.FinishTime)
+	s.Empty(patchDoc.BuildVariants)
+	s.Empty(patchDoc.Tasks)
+	s.Empty(patchDoc.VariantsTasks)
+	s.Empty(patchDoc.Patches)
+	s.False(patchDoc.Activated)
+	s.Empty(patchDoc.PatchedConfig)
+	s.Equal(GithubAlias, patchDoc.Alias)
+	s.Equal(5, patchDoc.GithubPatchData.PRNumber)
+	s.Equal("evergreen-ci", patchDoc.GithubPatchData.BaseOwner)
+	s.Equal("evergreen", patchDoc.GithubPatchData.BaseRepo)
+	s.Equal("octocat", patchDoc.GithubPatchData.HeadOwner)
+	s.Equal("evergreen", patchDoc.GithubPatchData.HeadRepo)
+	s.Equal("67da19930b1b18d346477e99a8e18094a672f48a", patchDoc.GithubPatchData.HeadHash)
+	s.Equal("octocat", patchDoc.GithubPatchData.Author)
+	s.Equal("https://www.example.com/1.diff", patchDoc.GithubPatchData.DiffURL)
 }

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -44,6 +44,7 @@ type Patch struct {
 	Patches         []ModulePatch  `bson:"patches"`
 	Activated       bool           `bson:"activated"`
 	PatchedConfig   string         `bson:"patched_config"`
+	Alias           string         `bson:"alias"`
 	GithubPatchData GithubPatch    `bson:"github_patch_data,omitempty"`
 }
 

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -9,23 +9,24 @@ import (
 
 // APIPatch is the model to be returned by the API whenever patches are fetched.
 type APIPatch struct {
-	Id            APIString     `json:"patch_id"`
-	Description   APIString     `json:"description"`
-	ProjectId     APIString     `json:"project_id"`
-	Branch        APIString     `json:"branch"`
-	Githash       APIString     `json:"git_hash"`
-	PatchNumber   int           `json:"patch_number"`
-	Author        APIString     `json:"author"`
-	Status        APIString     `json:"status"`
-	CreateTime    APITime       `json:"create_time"`
-	StartTime     APITime       `json:"start_time"`
-	FinishTime    APITime       `json:"finish_time"`
-	Variants      []APIString   `json:"builds"`
-	Tasks         []APIString   `json:"tasks"`
-	VariantsTasks []variantTask `json:"variants_tasks"`
-	Activated     bool          `json:"activated"`
+	Id              APIString     `json:"patch_id"`
+	Description     APIString     `json:"description"`
+	ProjectId       APIString     `json:"project_id"`
+	Branch          APIString     `json:"branch"`
+	Githash         APIString     `json:"git_hash"`
+	PatchNumber     int           `json:"patch_number"`
+	Author          APIString     `json:"author"`
+	Version         APIString     `json:"version"`
+	Status          APIString     `json:"status"`
+	CreateTime      APITime       `json:"create_time"`
+	StartTime       APITime       `json:"start_time"`
+	FinishTime      APITime       `json:"finish_time"`
+	Variants        []APIString   `json:"builds"`
+	Tasks           []APIString   `json:"tasks"`
+	VariantsTasks   []variantTask `json:"variants_tasks"`
+	Activated       bool          `json:"activated"`
+	GithubPatchData githubPatch   `json:"github_patch_data,omitempty"`
 }
-
 type variantTask struct {
 	Name  APIString   `json:"name"`
 	Tasks []APIString `json:"tasks"`
@@ -44,6 +45,7 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 	apiPatch.Githash = APIString(v.Githash)
 	apiPatch.PatchNumber = v.PatchNumber
 	apiPatch.Author = APIString(v.Author)
+	apiPatch.Version = APIString(v.Version)
 	apiPatch.Status = APIString(v.Status)
 	apiPatch.CreateTime = NewTime(v.CreateTime)
 	apiPatch.StartTime = NewTime(v.CreateTime)
@@ -71,10 +73,45 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 	}
 	apiPatch.VariantsTasks = variantTasks
 	apiPatch.Activated = v.Activated
-	return nil
+	apiPatch.GithubPatchData = githubPatch{}
+	err := apiPatch.GithubPatchData.BuildFromService(v.GithubPatchData)
+	return err
 }
 
 // ToService converts a service layer patch using the data from APIPatch
 func (apiPatch *APIPatch) ToService() (interface{}, error) {
 	return nil, errors.New("not implemented for read-only route")
+}
+
+type githubPatch struct {
+	PRNumber  int       `json:"pr_number"`
+	BaseOwner APIString `json:"base_owner"`
+	BaseRepo  APIString `json:"base_repo"`
+	HeadOwner APIString `json:"head_owner"`
+	HeadRepo  APIString `json:"head_repo"`
+	HeadHash  APIString `json:"head_hash"`
+	Author    APIString `json:"author"`
+	DiffURL   APIString `json:"diff_url"`
+}
+
+// BuildFromService converts from service level structs to an APIPatch
+func (g *githubPatch) BuildFromService(h interface{}) error {
+	v, ok := h.(patch.GithubPatch)
+	if !ok {
+		return fmt.Errorf("incorrect type when fetching converting github patch type")
+	}
+	g.PRNumber = v.PRNumber
+	g.BaseOwner = APIString(v.BaseOwner)
+	g.BaseRepo = APIString(v.BaseRepo)
+	g.HeadOwner = APIString(v.HeadOwner)
+	g.HeadRepo = APIString(v.HeadRepo)
+	g.HeadHash = APIString(v.HeadHash)
+	g.Author = APIString(v.Author)
+	g.DiffURL = APIString(v.DiffURL)
+	return nil
+}
+
+// ToService converts a service layer patch using the data from APIPatch
+func (g *githubPatch) ToService() (interface{}, error) {
+	return nil, errors.New("(*githubPatch) ToService not implemented for read-only route")
 }

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -25,6 +25,7 @@ type APIPatch struct {
 	Tasks           []APIString   `json:"tasks"`
 	VariantsTasks   []variantTask `json:"variants_tasks"`
 	Activated       bool          `json:"activated"`
+	Alias           APIString     `json:"alias,omitempty"`
 	GithubPatchData githubPatch   `json:"github_patch_data,omitempty"`
 }
 type variantTask struct {

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -1,8 +1,6 @@
 package model
 
 import (
-	"fmt"
-
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/pkg/errors"
 )
@@ -37,7 +35,7 @@ type variantTask struct {
 func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 	v, ok := h.(patch.Patch)
 	if !ok {
-		return fmt.Errorf("incorrect type when fetching converting patch type")
+		return errors.New("incorrect type when fetching converting patch type")
 	}
 	apiPatch.Id = APIString(v.Id.Hex())
 	apiPatch.Description = APIString(v.Description)
@@ -75,8 +73,7 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 	apiPatch.VariantsTasks = variantTasks
 	apiPatch.Activated = v.Activated
 	apiPatch.GithubPatchData = githubPatch{}
-	err := apiPatch.GithubPatchData.BuildFromService(v.GithubPatchData)
-	return err
+	return errors.WithStack(apiPatch.GithubPatchData.BuildFromService(v.GithubPatchData))
 }
 
 // ToService converts a service layer patch using the data from APIPatch
@@ -99,7 +96,7 @@ type githubPatch struct {
 func (g *githubPatch) BuildFromService(h interface{}) error {
 	v, ok := h.(patch.GithubPatch)
 	if !ok {
-		return fmt.Errorf("incorrect type when fetching converting github patch type")
+		return errors.New("incorrect type when fetching converting github patch type")
 	}
 	g.PRNumber = v.PRNumber
 	g.BaseOwner = APIString(v.BaseOwner)

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestAPIPatch(t *testing.T) {
-	baseTime := time.Now().Round(0).Truncate(0)
 	assert := assert.New(t) //nolint
+	baseTime := time.Now()
 	p := patch.Patch{
 		Id:            bson.NewObjectId(),
 		Description:   "test",

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/patch"
-	"github.com/k0kubun/pp"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -77,7 +76,6 @@ func TestAPIPatch(t *testing.T) {
 	for i, task := range a.Tasks {
 		assert.Equal(p.Tasks[i], string(task))
 	}
-	pp.Println(p.VariantsTasks, a.VariantsTasks)
 	for i, vt := range a.VariantsTasks {
 		assert.Equal(p.VariantsTasks[i].Variant, string(vt.Name))
 

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -1,0 +1,114 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/k0kubun/pp"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/mgo.v2/bson"
+)
+
+func TestAPIPatch(t *testing.T) {
+	baseTime := time.Now().Round(0).Truncate(0)
+	assert := assert.New(t) //nolint
+	p := patch.Patch{
+		Id:            bson.NewObjectId(),
+		Description:   "test",
+		Project:       "mci",
+		Githash:       "hash",
+		PatchNumber:   9000,
+		Author:        "root",
+		Version:       "version_1",
+		Status:        evergreen.PatchCreated,
+		CreateTime:    baseTime,
+		StartTime:     baseTime.Add(time.Hour),
+		FinishTime:    baseTime.Add(2 * time.Hour),
+		BuildVariants: []string{"bv1", "bv2"},
+		Tasks:         []string{"t1", "t2"},
+		VariantsTasks: []patch.VariantTasks{
+			patch.VariantTasks{
+				Variant: "bv1",
+				Tasks:   []string{"t1"},
+			},
+			patch.VariantTasks{
+				Variant: "bv2",
+				Tasks:   []string{"t2"},
+			},
+		},
+		Patches: []patch.ModulePatch{
+			patch.ModulePatch{},
+		},
+		Activated:     true,
+		PatchedConfig: "config",
+		GithubPatchData: patch.GithubPatch{
+			PRNumber:  123,
+			BaseOwner: "evergreen-ci",
+			BaseRepo:  "evergreen",
+			HeadOwner: "octocat",
+			HeadRepo:  "evergreen",
+			HeadHash:  "hash",
+			Author:    "octocat",
+			DiffURL:   "https://github.com/evergreen-ci/evergreen/pull/123.diff",
+		},
+	}
+
+	a := APIPatch{}
+	err := a.BuildFromService(p)
+	assert.NoError(err)
+
+	assert.Equal(p.Id.Hex(), string(a.Id))
+	assert.Equal(p.Description, string(a.Description))
+	assert.Equal(p.Project, string(a.ProjectId))
+	assert.Equal(p.Project, string(a.Branch))
+	assert.Equal(p.Githash, string(a.Githash))
+	assert.Equal(p.PatchNumber, a.PatchNumber)
+	assert.Equal(p.Author, string(a.Author))
+	assert.Equal(p.Version, string(a.Version))
+	assert.Equal(p.Status, string(a.Status))
+	assert.Zero(time.Time(a.CreateTime).Sub(p.CreateTime))
+	assert.Equal(-time.Hour, time.Time(a.StartTime).Sub(p.StartTime))
+	assert.Equal(-2*time.Hour, time.Time(a.FinishTime).Sub(p.FinishTime))
+	for i, variant := range a.Variants {
+		assert.Equal(p.BuildVariants[i], string(variant))
+	}
+	for i, task := range a.Tasks {
+		assert.Equal(p.Tasks[i], string(task))
+	}
+	pp.Println(p.VariantsTasks, a.VariantsTasks)
+	for i, vt := range a.VariantsTasks {
+		assert.Equal(p.VariantsTasks[i].Variant, string(vt.Name))
+
+		for i2, task := range vt.Tasks {
+			assert.Equal(a.Tasks[i2], task)
+		}
+	}
+	assert.NotZero(a.GithubPatchData)
+}
+
+func TestGithubPatch(t *testing.T) {
+	assert := assert.New(t) //nolint
+	p := patch.GithubPatch{
+		PRNumber:  123,
+		BaseOwner: "evergreen-ci",
+		BaseRepo:  "evergreen",
+		HeadOwner: "octocat",
+		HeadRepo:  "evergreen",
+		HeadHash:  "hash",
+		Author:    "octocat",
+		DiffURL:   "https://github.com/evergreen-ci/evergreen/pull/123.diff",
+	}
+	a := githubPatch{}
+	err := a.BuildFromService(p)
+	assert.NoError(err)
+	assert.Equal(123, a.PRNumber)
+	assert.Equal("evergreen-ci", string(a.BaseOwner))
+	assert.Equal("evergreen", string(a.BaseRepo))
+	assert.Equal("octocat", string(a.HeadOwner))
+	assert.Equal("evergreen", string(a.HeadRepo))
+	assert.Equal("hash", string(a.HeadHash))
+	assert.Equal("octocat", string(a.Author))
+	assert.Equal("https://github.com/evergreen-ci/evergreen/pull/123.diff", string(a.DiffURL))
+}


### PR DESCRIPTION
Per discussion with @tychoish, APIPatch has been extended to include Alias, as well as the underlying patch data.