### PR TITLE
EVG-2499 Add button to project admin page to trigger "catchup run"

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -279,6 +279,7 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location) 
         $scope.saveMessage = "Settings Saved.";
         $scope.refreshTrackedProjects(data.AllProjects);
         $scope.settingsForm.$setPristine();
+        $scope.settingsFormData.force_repotracker_run = false;
         $scope.isDirty = false;
       },
       function(resp) {

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -197,7 +197,8 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location) 
           repotracker_error: $scope.projectRef.repotracker_error || {},
           admins : $scope.projectRef.admins || [],
           setup_github_hook: $scope.githubHookId != 0,
-          tracks_push_events: data.ProjectRef.tracks_push_events || false
+          tracks_push_events: data.ProjectRef.tracks_push_events || false,
+          force_repotracker_run: false
         };
         for (var i = 0; i < $scope.settingsFormData.patch_aliases.length; i++) {
           var alias = $scope.settingsFormData.patch_aliases[i];

--- a/rest/data/repotracker.go
+++ b/rest/data/repotracker.go
@@ -31,7 +31,7 @@ func (c *RepoTrackerConnector) TriggerRepotracker(q amboy.Queue, msgID string, e
 	if !ref.TracksPushEvents || !ref.Enabled {
 		return nil
 	}
-	if err := q.Put(units.NewRepotrackerJob(msgID, ref.Identifier)); err != nil {
+	if err := q.Put(units.NewRepotrackerJob(fmt.Sprintf("github-push-%s", msgID), ref.Identifier)); err != nil {
 		msg := "failed to add repotracker job to queue"
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": msg,

--- a/service/project.go
+++ b/service/project.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/alerts"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/google/go-github/github"
 	"github.com/gorilla/mux"
@@ -150,7 +151,8 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			Provider string                 `json:"provider"`
 			Settings map[string]interface{} `json:"settings"`
 		} `json:"alert_config"`
-		SetupGithubHook bool `json:"setup_github_hook"`
+		SetupGithubHook     bool `json:"setup_github_hook"`
+		ForceRepotrackerRun bool `json:"force_repotracker_run"`
 	}{}
 
 	if err = util.ReadJSONInto(util.NewRequestReader(r), &responseRef); err != nil {
@@ -233,6 +235,15 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			}
 			projectVars.GithubHookID = 0
 			projectRef.TracksPushEvents = false
+		}
+	}
+
+	if projectVars.GithubHookID != 0 && projectRef.TracksPushEvents &&
+		responseRef.ForceRepotrackerRun {
+		job := units.NewRepotrackerJob(util.RandomString(), projectRef.Identifier)
+		if err := uis.queue.Put(job); err != nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, err)
+			return
 		}
 	}
 

--- a/service/project.go
+++ b/service/project.go
@@ -241,7 +241,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 
 	if projectVars.GithubHookID != 0 && projectRef.TracksPushEvents &&
 		responseRef.ForceRepotrackerRun {
-		j := units.NewRepotrackerJob(fmt.Sprintf("%d", job.GetNumber()), projectRef.Identifier)
+		j := units.NewRepotrackerJob(fmt.Sprintf("ui-triggered-job-%d", job.GetNumber()), projectRef.Identifier)
 		if err := uis.queue.Put(j); err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return

--- a/service/project.go
+++ b/service/project.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/google/go-github/github"
 	"github.com/gorilla/mux"
+	"github.com/mongodb/amboy/job"
 	"github.com/pkg/errors"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -240,8 +241,8 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 
 	if projectVars.GithubHookID != 0 && projectRef.TracksPushEvents &&
 		responseRef.ForceRepotrackerRun {
-		job := units.NewRepotrackerJob(util.RandomString(), projectRef.Identifier)
-		if err := uis.queue.Put(job); err != nil {
+		j := units.NewRepotrackerJob(fmt.Sprintf("%d", job.GetNumber()), projectRef.Identifier)
+		if err := uis.queue.Put(j); err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -237,7 +237,7 @@ Evergreen Projects
                 <br />
                 <div class="col-lg-8 col-header" ng-show="settingsFormData.tracks_push_events === true">
                     <label class="control-label">Run Repotracker on Save&nbsp;&nbsp;
-                        <input type="checkbox" name="deactivate_previous" ng-model="settingsFormData.force_repotracker_run" />
+                        <input type="checkbox" name="force_repotracker_run" ng-model="settingsFormData.force_repotracker_run" />
                     </label>
                 </div>
             </div>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -214,7 +214,7 @@ Evergreen Projects
               <label class="control-label">Unschedule old tasks on success&nbsp;&nbsp;
                 <input type="checkbox" name="deactivate_previous" ng-model="settingsFormData.deactivate_previous"/>
               </label>
-              <div class="muted small">When checked, tasks from previous revisions will be unscheduled when the equivalent task in a newer commit finishes successfully.</div>
+              <div class="muted small">when checked, tasks from previous revisions will be unscheduled when the equivalent task in a newer commit finishes successfully.</div>
             </div>
           </div>
           <div ng-show="githubHookId !== 0">
@@ -233,6 +233,12 @@ Evergreen Projects
                         </label> <br>
                         <label class="muted col-lg-offset-1">Repotracker will be triggered from Github PushEvents sent via webhooks</label>
                     </div>
+                </div>
+                <br />
+                <div class="col-lg-8 col-header" ng-show="settingsFormData.tracks_push_events === true">
+                    <label class="control-label">Run Repotracker on Save&nbsp;&nbsp;
+                        <input type="checkbox" name="deactivate_previous" ng-model="settingsFormData.force_repotracker_run"/>
+                    </label>
                 </div>
             </div>
           </div>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -237,7 +237,7 @@ Evergreen Projects
                 <br />
                 <div class="col-lg-8 col-header" ng-show="settingsFormData.tracks_push_events === true">
                     <label class="control-label">Run Repotracker on Save&nbsp;&nbsp;
-                        <input type="checkbox" name="deactivate_previous" ng-model="settingsFormData.force_repotracker_run"/>
+                        <input type="checkbox" name="deactivate_previous" ng-model="settingsFormData.force_repotracker_run" />
                     </label>
                 </div>
             </div>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -214,7 +214,7 @@ Evergreen Projects
               <label class="control-label">Unschedule old tasks on success&nbsp;&nbsp;
                 <input type="checkbox" name="deactivate_previous" ng-model="settingsFormData.deactivate_previous"/>
               </label>
-              <div class="muted small">when checked, tasks from previous revisions will be unscheduled when the equivalent task in a newer commit finishes successfully.</div>
+              <div class="muted small">When checked, tasks from previous revisions will be unscheduled when the equivalent task in a newer commit finishes successfully.</div>
             </div>
           </div>
           <div ng-show="githubHookId !== 0">


### PR DESCRIPTION
Implemented as a checkbox in the ui admin page. It only shows up when the webhook is setup and the repository is setup to track push events. 

