### PR TITLE
EVG-2586 Fix patch cancellation

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -449,7 +449,6 @@ func AbortPatchesWithGithubPatchData(createdBefore time.Time, owner, repo string
 				}))
 				return errors.Wrap(err, "error aborting patch")
 			}
-
 		}
 	}
 

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -419,8 +419,10 @@ func CancelPatch(p *patch.Patch, caller string) error {
 	return errors.WithStack(patch.Remove(patch.ById(p.Id)))
 }
 
-// AbortPatchesWithGithubPatchData runs AbortPatch on patches created before
-// the given time, with the same pr number, and base repository
+// AbortPatchesWithGithubPatchData runs CancelPatch on patches created before
+// the given time, with the same pr number, and base repository. Tasks which
+// are abortable (see model/task.IsAbortable()) will be aborted, while
+// dispatched/running/completed tasks will not be affected
 func AbortPatchesWithGithubPatchData(createdBefore time.Time, owner, repo string, prNumber int) error {
 	patches, err := patch.Find(patch.ByGithubPRAndCreatedBefore(createdBefore, owner, repo, prNumber))
 	if err != nil {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -437,7 +437,7 @@ func AbortPatchesWithGithubPatchData(createdBefore time.Time, owner, repo string
 
 	for i, _ := range patches {
 		if patches[i].Version != "" {
-			if err = AbortVersion(patches[i].Version); err != nil {
+			if err = CancelPatch(&patches[i], evergreen.GithubPRRequester); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"source":         "github hook",
 					"created_before": createdBefore.String(),
@@ -449,6 +449,7 @@ func AbortPatchesWithGithubPatchData(createdBefore time.Time, owner, repo string
 				}))
 				return errors.Wrap(err, "error aborting patch")
 			}
+
 		}
 	}
 


### PR DESCRIPTION
Original bug was from leaving the "caller" param empty, not from using the CancelPatch function. Tested in staging.