### PR TITLE
EVG-2601 Patch alias does not support display tasks

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -946,6 +946,18 @@ func (p *Project) BuildProjectTVPairsWithAlias(alias string) ([]TVPair, error) {
 						pairs = append(pairs, TVPair{variant.Name, task.Name})
 					}
 				}
+
+				for _, displayTask := range variant.DisplayTasks {
+					if v.Task == "" || !taskRegex.MatchString(displayTask.Name) {
+						continue
+					}
+
+					for _, task := range displayTask.ExecutionTasks {
+						if p.FindTaskForVariant(task, variant.Name) != nil {
+							pairs = append(pairs, TVPair{variant.Name, task})
+						}
+					}
+				}
 			}
 		}
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -935,6 +935,9 @@ func (p *Project) BuildProjectTVPairsWithAlias(alias string) ([]TVPair, error) {
 					if ((v.Task != "" && taskRegex.MatchString(task.Name)) ||
 						(len(v.Tags) > 0 && len(util.StringSliceIntersection(task.Tags, v.Tags)) > 0)) &&
 						(p.FindTaskForVariant(task.Name, variant.Name) != nil) {
+						if task.Patchable != nil && !(*task.Patchable) {
+							continue
+						}
 						pairs = append(pairs, TVPair{variant.Name, task.Name})
 					}
 				}

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -459,7 +459,7 @@ func (s *projectSuite) SetupTest() {
 	s.vars = ProjectVars{
 		Id: "project",
 	}
-	s.NoError(s.vars.Insert())
+	s.Require().NoError(s.vars.Insert())
 
 	s.aliases = []ProjectAlias{
 		{
@@ -679,7 +679,7 @@ func (s *projectSuite) TestAliasResolution() {
 	// test for alias including disabled task
 	pairs, err = s.project.BuildProjectTVPairsWithAlias(s.aliases[6].Alias)
 	s.NoError(err)
-	s.Len(pairs, 1)
+	s.Require().Len(pairs, 1)
 	s.Equal("bv_3/disabled_task", pairs[0].String())
 }
 
@@ -695,7 +695,7 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Len(patchDoc.Tasks, 7)
 
-	// test all tasks expansion with named buildvariant
+	// test all tasks expansion with named buildvariant expands unnamed buildvariant
 	patchDoc.BuildVariants = []string{"bv_1"}
 	patchDoc.Tasks = []string{"all"}
 	patchDoc.VariantsTasks = []patch.VariantTasks{}

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -553,11 +553,15 @@ func (s *projectSuite) SetupTest() {
 					{
 						Name: "very_task",
 					},
+					{
+						Name:      "another_disabled_task",
+						Patchable: boolPtr(false),
+					},
 				},
 				DisplayTasks: []DisplayTask{
 					{
 						Name:           "memes",
-						ExecutionTasks: []string{"wow_task", "9001_task", "very_task"},
+						ExecutionTasks: []string{"wow_task", "9001_task", "very_task", "another_disabled_task"},
 					},
 				},
 			},
@@ -575,6 +579,10 @@ func (s *projectSuite) SetupTest() {
 					},
 					{
 						Name: "b_task_2",
+					},
+					{
+						Name:      "another_disabled_task",
+						Patchable: boolPtr(false),
 					},
 				},
 			},
@@ -616,6 +624,10 @@ func (s *projectSuite) SetupTest() {
 			},
 			{
 				Name: "disabled_task",
+			},
+			{
+				Name:      "another_disabled_task",
+				Patchable: boolPtr(false),
 			},
 		},
 	}
@@ -799,6 +811,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisabledBuildVariant() {
 	s.project.BuildProjectTVPairs(&patchDoc, "disabled_stuff")
 	s.Equal([]string{"bv_3"}, patchDoc.BuildVariants)
 	s.Equal([]string{"disabled_task"}, patchDoc.Tasks)
+	s.Require().Len(patchDoc.VariantsTasks, 1)
 	s.Equal("bv_3", patchDoc.VariantsTasks[0].Variant)
 	s.Equal([]string{"disabled_task"}, patchDoc.VariantsTasks[0].Tasks)
 	s.Empty(patchDoc.VariantsTasks[0].DisplayTasks)
@@ -811,6 +824,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisabledBuildVariant() {
 	s.project.BuildProjectTVPairs(&patchDoc, "")
 	s.Equal([]string{"bv_3"}, patchDoc.BuildVariants)
 	s.Equal([]string{"disabled_task"}, patchDoc.Tasks)
+	s.Require().Len(patchDoc.VariantsTasks, 1)
 	s.Equal("bv_3", patchDoc.VariantsTasks[0].Variant)
 	s.Equal([]string{"disabled_task"}, patchDoc.VariantsTasks[0].Tasks)
 	s.Empty(patchDoc.VariantsTasks[0].DisplayTasks)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -870,3 +870,35 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisplayTaskWithDependencies() 
 		}
 	}
 }
+
+func (s *projectSuite) TestBuildProjectTVPairsWithDisplayTaskWithOneExecutionTask() {
+	// TODO: See EVG-2722 this behaviour may be wrong
+	patchDoc := patch.Patch{
+		BuildVariants: []string{"bv_1"},
+		Tasks:         []string{"wow_task"},
+	}
+	s.project.BuildProjectTVPairs(&patchDoc, "")
+	s.Len(patchDoc.BuildVariants, 2)
+	s.Contains(patchDoc.BuildVariants, "bv_1")
+	s.Contains(patchDoc.BuildVariants, "bv_2")
+	s.Len(patchDoc.Tasks, 2)
+	s.Contains(patchDoc.Tasks, "wow_task")
+	s.Contains(patchDoc.Tasks, "a_task_1")
+	s.Require().Len(patchDoc.VariantsTasks, 2)
+	for _, vt := range patchDoc.VariantsTasks {
+		if vt.Variant == "bv_1" {
+			s.Require().Len(vt.Tasks, 2)
+			s.Contains(vt.Tasks, "a_task_1")
+			s.Contains(vt.Tasks, "wow_task")
+			s.Empty(vt.DisplayTasks, 1)
+
+		} else if vt.Variant == "bv_2" {
+			s.Require().Len(vt.Tasks, 1)
+			s.Contains(vt.Tasks, "a_task_1")
+			s.Empty(vt.DisplayTasks)
+
+		} else {
+			s.T().Fail()
+		}
+	}
+}


### PR DESCRIPTION
This brings partial support of display tasks to patch aliases. EVG-2722 has been created to track the remaining issues in display tasks.