### PR TITLE
EVG-2735 Add Pipeline for detecting duplicate Versions

### DIFF
--- a/model/version/version.go
+++ b/model/version/version.go
@@ -89,7 +89,7 @@ type DuplicateVersions struct {
 
 func FindDuplicateVersions(since time.Time) ([]DuplicateVersions, error) {
 	pipeline := []bson.M{
-		bson.M{
+		{
 			"$match": bson.M{
 				RequesterKey: evergreen.RepotrackerVersionRequester,
 				CreateTimeKey: bson.M{
@@ -97,7 +97,7 @@ func FindDuplicateVersions(since time.Time) ([]DuplicateVersions, error) {
 				},
 			},
 		},
-		bson.M{
+		{
 			"$group": bson.M{
 				"_id": bson.M{
 					"project_id": "$" + IdentifierKey,
@@ -111,7 +111,7 @@ func FindDuplicateVersions(since time.Time) ([]DuplicateVersions, error) {
 				},
 			},
 		},
-		bson.M{
+		{
 			"$match": bson.M{
 				"count": bson.M{
 					"$gt": 1,

--- a/model/version/version_test.go
+++ b/model/version/version_test.go
@@ -1,0 +1,119 @@
+package version
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/stretchr/testify/suite"
+)
+
+type testFindDuplicateVersionsSuite struct {
+	suite.Suite
+}
+
+func TestFindDuplicateVersions(t *testing.T) {
+	suite.Run(t, new(testFindDuplicateVersionsSuite))
+}
+
+func (s *testFindDuplicateVersionsSuite) SetupSuite() {
+	testConfig := testutil.TestConfig()
+	db.SetGlobalSessionProvider(testConfig.SessionFactory())
+}
+
+func (s *testFindDuplicateVersionsSuite) SetupTest() {
+	s.NoError(db.ClearCollections(Collection))
+
+	versions := []Version{
+		{
+			Id:         "project_-1",
+			Identifier: "project",
+			Revision:   "96aeacfdb9667bb3905925768a1f240012d5735f",
+			Requester:  evergreen.RepotrackerVersionRequester,
+			CreateTime: time.Time{}.Add(-time.Hour),
+		},
+		{
+			Id:         "project_0",
+			Identifier: "project",
+			Revision:   "96aeacfdb9667bb3905925768a1f240012d5735f",
+			Requester:  evergreen.RepotrackerVersionRequester,
+			CreateTime: time.Now(),
+		},
+		{
+			Id:         "project_patch_0",
+			Identifier: "project",
+			Revision:   "96aeacfdb9667bb3905925768a1f240012d5735f",
+			Requester:  evergreen.PatchVersionRequester,
+			CreateTime: time.Now(),
+		},
+		{
+			Id:         "project_patch_1",
+			Identifier: "project",
+			Revision:   "96aeacfdb9667bb3905925768a1f240012d5735f",
+			Requester:  evergreen.PatchVersionRequester,
+			CreateTime: time.Now(),
+		},
+		{
+			Id:         "project_1",
+			Identifier: "project",
+			Revision:   "96aeacfdb9667bb3905925768a1f240012d5735f",
+			Requester:  evergreen.RepotrackerVersionRequester,
+			CreateTime: time.Now(),
+		},
+		{
+			Id:         "project2_0",
+			Identifier: "project2",
+			Revision:   "96aeacfdb9667bb3905925768a1f240012d5735f",
+			Requester:  evergreen.RepotrackerVersionRequester,
+			CreateTime: time.Now(),
+		},
+		{
+			Id:         "project2_1",
+			Identifier: "project2",
+			Revision:   "96aeacfdb9667bb3905925768a1f240012d5735f",
+			Requester:  evergreen.RepotrackerVersionRequester,
+			CreateTime: time.Now(),
+		},
+		{
+			Id:         "project3_0",
+			Identifier: "project3",
+			Revision:   "96aeacfdb9667bb3905925768a1f240012d5735f",
+			Requester:  evergreen.RepotrackerVersionRequester,
+			CreateTime: time.Now(),
+		},
+	}
+	for _, v := range versions {
+		s.NoError(v.Insert())
+	}
+}
+
+func (s *testFindDuplicateVersionsSuite) TestIt() {
+	versions, err := FindDuplicateVersions(time.Time{})
+	s.NoError(err)
+	s.Len(versions, 2)
+
+	for _, dv := range versions {
+		if dv.ID.ProjectID == "project2" {
+			s.Equal("96aeacfdb9667bb3905925768a1f240012d5735f", dv.ID.Hash)
+			for _, v := range dv.Versions {
+				s.Equal(evergreen.RepotrackerVersionRequester, v.Requester)
+				s.True(v.CreateTime.After(time.Time{}))
+				s.True(strings.HasPrefix(v.Id, "project2_"))
+			}
+
+		} else if dv.ID.ProjectID == "project" {
+			s.Equal("96aeacfdb9667bb3905925768a1f240012d5735f", dv.ID.Hash)
+			for _, v := range dv.Versions {
+				s.Equal(evergreen.RepotrackerVersionRequester, v.Requester)
+				s.True(v.CreateTime.After(time.Time{}))
+				s.True(strings.HasPrefix(v.Id, "project_"))
+			}
+
+		} else {
+			s.T().Fail()
+		}
+	}
+}

--- a/scripts/indexes.js
+++ b/scripts/indexes.js
@@ -88,6 +88,7 @@ db.versions.ensureIndex({ "builds" : 1 })
 db.versions.ensureIndex({ "identifier" : 1, "r" : 1, "order" : 1 })
 db.versions.ensureIndex({ "branch" : 1, "gitspec" : 1 })
 db.versions.ensureIndex({ "versions.build_variant_status.build_variant" : 1, "versions.build_variant_status.activated" : 1, "r": 1 })
+db.versions.ensureIndex({ "create_time": 1, "r": 1  })
 
 //======alerts=======//
 db.alerts.ensureIndex({ "queue_status" : 1 })

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -467,13 +467,7 @@ tasks:
     name: test-model
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
-    name: test-model-patch
-  - <<: *run-go-test-suite-with-mongodb
-    tags: ["db", "test"]
     name: test-model-artifact
-  - <<: *run-go-test-suite-with-mongodb
-    tags: ["db", "test"]
-    name: test-model-host
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
     name: test-model-build
@@ -482,7 +476,22 @@ tasks:
     name: test-model-event
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
+    name: test-model-host
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
+    name: test-model-patch
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
     name: test-model-task
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
+    name: test-model-testresult
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
+    name: test-model-user
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
+    name: test-model-version
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
     name: test-plugin
@@ -580,9 +589,6 @@ tasks:
     name: race-model
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "race"]
-    name: race-model-patch
-  - <<: *run-go-test-suite-with-mongodb
-    tags: ["db", "race"]
     name: race-model-artifact
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "race"]
@@ -596,6 +602,9 @@ tasks:
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "race"]
     name: race-model-task
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "race"]
+    name: race-model-version
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "race"]
     name: race-rest-data
@@ -644,17 +653,35 @@ tasks:
   - <<: *run-lint
     name: lint-model
   - <<: *run-lint
+    name: lint-model-alert
+  - <<: *run-lint
+    name: lint-model-alertrecord
+  - <<: *run-lint
     name: lint-model-artifact
   - <<: *run-lint
     name: lint-model-build
   - <<: *run-lint
+    name: lint-model-distro
+  - <<: *run-lint
     name: lint-model-event
   - <<: *run-lint
+    name: lint-model-grid
+  - <<: *run-lint
     name: lint-model-host
+  - <<: *run-lint
+    name: lint-model-manifest
   - <<: *run-lint
     name: lint-model-patch
   - <<: *run-lint
     name: lint-model-task
+  - <<: *run-lint
+    name: lint-model-testresult
+  - <<: *run-lint
+    name: lint-model-testutil
+  - <<: *run-lint
+    name: lint-model-user
+  - <<: *run-lint
+    name: lint-model-version
   - <<: *run-lint
     name: lint-monitor
   - <<: *run-lint


### PR DESCRIPTION
I haven't written any code to find duplicate tasks/builds since we must have duplicate versions in order to have duplicate tasks and builds. This is done in lieu of EVG-2468