### PR TITLE
EVG-2734 Evergreen cannot apply mailbox-style patches which create new files, and moves them in a later commit

### DIFF
--- a/command/git.go
+++ b/command/git.go
@@ -357,6 +357,9 @@ func isMailboxPatch(patchFile string) (bool, error) {
 	return strings.HasPrefix(line, "From "), nil
 }
 
+// getApplyCommand determines the patch type. If the patch is a mailbox-style
+// patch, it uses git-am (see https://git-scm.com/docs/git-am), otherwise
+// it uses git apply
 func getApplyCommand(patchFile string) (string, error) {
 	isMBP, err := isMailboxPatch(patchFile)
 	if err != nil {
@@ -367,7 +370,7 @@ func getApplyCommand(patchFile string) (string, error) {
 		return fmt.Sprintf("git am < '%s'", patchFile), nil
 	}
 
-	return fmt.Sprintf("git apply --binary --whitespace=fix --index < '%v'", patchFile), nil
+	return fmt.Sprintf("git apply --binary --whitespace=fix --index < '%s'", patchFile), nil
 }
 
 // getPatchCommands, given a module patch of a patch, will return the appropriate list of commands that

--- a/command/git.go
+++ b/command/git.go
@@ -1,11 +1,13 @@
 package command
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -334,8 +336,42 @@ func (c *gitFetchProject) getPatchContents(ctx context.Context, comm client.Comm
 	return nil
 }
 
+// isMailboxPatch checks if the first line of a patch file
+// has "From ". If so, it's assumed to be a mailbox-style patch, otherwise
+// it's a diff
+func isMailboxPatch(patchFile string) (bool, error) {
+	file, err := os.Open(patchFile)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to read patch file")
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+
+	var line string
+	line, err = reader.ReadString('\n')
+	if err != nil {
+		return false, errors.Wrap(err, "failed to buffer patch line 1")
+	}
+
+	return strings.HasPrefix(line, "From "), nil
+}
+
+func getApplyCommand(patchFile string) (string, error) {
+	isMBP, err := isMailboxPatch(patchFile)
+	if err != nil {
+		return "", errors.Wrap(err, "can't check patch type")
+	}
+
+	if isMBP {
+		return fmt.Sprintf("git am < '%s'", patchFile), nil
+	}
+
+	return fmt.Sprintf("git apply --binary --whitespace=fix --index < '%v'", patchFile), nil
+}
+
 // getPatchCommands, given a module patch of a patch, will return the appropriate list of commands that
-// need to be executed. If the patch is empty it will not apply the patch.
+// need to be executed, except for apply. If the patch is empty it will not apply the patch.
 func getPatchCommands(modulePatch patch.ModulePatch, dir, patchPath string) []string {
 	patchCommands := []string{
 		fmt.Sprintf("set -o xtrace"),
@@ -349,7 +385,6 @@ func getPatchCommands(modulePatch patch.ModulePatch, dir, patchPath string) []st
 	}
 	return append(patchCommands, []string{
 		fmt.Sprintf("git apply --stat '%v' || true", patchPath),
-		fmt.Sprintf("git apply --binary --whitespace=fix --index < '%v'", patchPath),
 	}...)
 }
 
@@ -413,6 +448,12 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 
 		// this applies the patch using the patch files in the temp directory
 		patchCommandStrings := getPatchCommands(patchPart, dir, tempAbsPath)
+		applyCommand, err := getApplyCommand(tempAbsPath)
+		if err != nil {
+			logger.Execution().Error("Could not to determine patch type")
+			return errors.WithStack(err)
+		}
+		patchCommandStrings = append(patchCommandStrings, applyCommand)
 		cmdsJoined := strings.Join(patchCommandStrings, "\n")
 
 		patchCmd := subprocess.NewLocalCommand(cmdsJoined, conf.WorkDir, "bash", nil, true)

--- a/command/git.go
+++ b/command/git.go
@@ -346,13 +346,11 @@ func isMailboxPatch(patchFile string) (bool, error) {
 	}
 	defer file.Close()
 
-	reader := bufio.NewReader(file)
-
-	var line string
-	line, err = reader.ReadString('\n')
-	if err != nil {
-		return false, errors.Wrap(err, "failed to buffer patch line 1")
+	scanner := bufio.NewScanner(file)
+	if !scanner.Scan() {
+		return false, errors.New("patch file appears to be empty")
 	}
+	line := scanner.Text()
 
 	return strings.HasPrefix(line, "From "), nil
 }

--- a/command/git_patch_test.go
+++ b/command/git_patch_test.go
@@ -153,7 +153,6 @@ func TestGetPatchCommands(t *testing.T) {
 
 	modulePatch.PatchSet.Patch = "bestest code"
 	cmds = getPatchCommands(modulePatch, "/teapot", "/tmp/bestest.patch")
-	assert.Len(cmds, 7)
+	assert.Len(cmds, 6)
 	assert.Equal("git apply --stat '/tmp/bestest.patch' || true", cmds[5])
-	assert.Equal("git apply --binary --whitespace=fix --index < '/tmp/bestest.patch'", cmds[6])
 }

--- a/command/git_test.go
+++ b/command/git_test.go
@@ -274,6 +274,11 @@ func (s *GitGetProjectSuite) TestIsMailboxPatch() {
 	isMBP, err = isMailboxPatch(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "test.diff"))
 	s.NoError(err)
 	s.False(isMBP)
+
+	isMBP, err = isMailboxPatch(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "emptyfile.txt"))
+	s.Error(err)
+	s.Equal("patch file appears to be empty", err.Error())
+	s.False(isMBP)
 }
 
 func (s *GitGetProjectSuite) TearDownSuite() {

--- a/command/git_test.go
+++ b/command/git_test.go
@@ -262,6 +262,20 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 	s.Equal("GIT_ASKPASS='true' git -c 'credential.https://github.com.username=GITHUBTOKEN' clone 'https://github.com/deafgoat/mci_test.git' 'module'", cmds[4])
 }
 
+func (s *GitGetProjectSuite) TestIsMailboxPatch() {
+	isMBP, err := isMailboxPatch(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "filethatdoesntexist.txt"))
+	s.Error(err)
+	s.False(isMBP)
+
+	isMBP, err = isMailboxPatch(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "test.patch"))
+	s.NoError(err)
+	s.True(isMBP)
+
+	isMBP, err = isMailboxPatch(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "test.diff"))
+	s.NoError(err)
+	s.False(isMBP)
+}
+
 func (s *GitGetProjectSuite) TearDownSuite() {
 	if s.modelData1.TaskConfig != nil {
 		s.NoError(os.RemoveAll(s.modelData1.TaskConfig.WorkDir))

--- a/command/testdata/test.diff
+++ b/command/testdata/test.diff
@@ -1,0 +1,4 @@
+diff --git a/migrations/anser.go b/migrations/anser.go
+index e11ae935..116da030 100644
+--- a/migrations/anser.go
++++ b/migrations/anser.go

--- a/command/testdata/test.patch
+++ b/command/testdata/test.patch
@@ -1,0 +1,4 @@
+From a6ea924030b26c1976f78d88ac8575a43fa2b57a Mon Sep 17 00:00:00 2001
+From: Richard Samuels <richard.samuels@mongodb.com>
+Date: Fri, 9 Feb 2018 13:31:15 -0500
+Subject: [PATCH 01/14] add hooks model


### PR DESCRIPTION
Concerns:
1. Submodules. I recall a Cloud project that applied a diff that included changes to a submodule. I imagine this might break that.
2. I've omitted --whitespace=fix from the mailbox style patch apply since this only affects Github PRs. CLI patches will remain unaffected. 

Notes:
--binary is implied for git-am. There is no equivalent of --index for git-am.
