### PR TITLE
EVG-2793 Dates are wrong/out-of-sequence

### DIFF
--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -54,7 +54,7 @@ func githubCommitToRevision(repoCommit *github.RepositoryCommit) model.Revision 
 		AuthorEmail:     *repoCommit.Commit.Author.Email,
 		RevisionMessage: *repoCommit.Commit.Message,
 		Revision:        *repoCommit.SHA,
-		CreateTime:      *repoCommit.Commit.Author.Date,
+		CreateTime:      *repoCommit.Commit.Committer.Date,
 	}
 }
 
@@ -140,7 +140,8 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(
 				commit.Commit.Author.Email == nil ||
 				commit.Commit.Message == nil ||
 				commit.SHA == nil ||
-				commit.Commit.Author.Date == nil {
+				commit.Commit.Committer == nil ||
+				commit.Commit.Committer.Date == nil {
 				return nil, errors.Errorf("github returned commit history with missing information for url: %s", commitURL)
 			}
 


### PR DESCRIPTION
Although the recent date change works fine for our squash-and-merge based workflow, it leads to out-of-sequence dates for versions in mongodb master. Here's a screenshot of commits made today:
![image](https://user-images.githubusercontent.com/1666322/36287435-d5a53d3c-1282-11e8-9d92-2d36d98710b0.png)

We'd expect these all to have todays date, corresponding to the push to master, but actually have the commit date.