### PR TITLE
EVG-2779 close host monitoring channel when canceling

### DIFF
--- a/monitor/host_monitoring.go
+++ b/monitor/host_monitoring.go
@@ -86,6 +86,10 @@ func monitorReachability(ctx context.Context, settings *evergreen.Settings) []er
 	// check all of the hosts. continue on error so that other hosts can be
 	// checked successfully
 	for _, host := range hosts {
+		if ctx.Err() != nil {
+			close(hostsChan)
+			return append(errs, errors.New("host checks aborted"))
+		}
 		hostsChan <- host
 	}
 	close(hostsChan)


### PR DESCRIPTION
I believe line 89 of host_monitoring.go blocked because the channel was full, because the readers of the channel (line 63) all returned due to the context being canceled, but the channel was still open