### PR TITLE
EVG-2438: add toolbar for origin / zoom and linear / log modes.

### DIFF
--- a/public/static/plugins/perf/js/perf.js
+++ b/public/static/plugins/perf/js/perf.js
@@ -36,6 +36,7 @@ mciModule.controller('PerfController', function PerfController(
   }, function() {});
   */
 
+  $scope.showToolbar = false
   $scope.hiddenGraphs = {}
   $scope.compareItemList = []
   $scope.perfTagData = {}
@@ -118,6 +119,28 @@ mciModule.controller('PerfController', function PerfController(
   $scope.project = $window.project;
   $scope.compareHash = "ss";
   $scope.comparePerfSamples = [];
+
+  // Linear or Log Scale
+  $scope.scaleModel = {
+    name: 'Linear',
+    linearMode: true
+  }
+  $scope.rangeModel = {
+    name: 'Origin',
+    originMode: false
+  }
+
+  $scope.$watch('scaleModel.linearMode', function(oldVal, newVal) {
+    // Force comparison by value
+    if (oldVal === newVal) return;
+    $scope.redrawGraphs()
+  })
+
+  $scope.$watch('rangeModel.originMode', function(oldVal, newVal) {
+    // Force comparison by value
+    if (oldVal === newVal) return;
+    $scope.redrawGraphs()
+  })
 
   $scope.$watch('threadLevelsRadio.value', function(oldVal, newVal) {
     // Force comparison by value
@@ -690,7 +713,11 @@ var drawTrendGraph = function(scope, PerfChartService) {
       scope: scope,
       containerId: containerId,
       compareSamples: compareSamples,
-      threadMode: scope.threadLevelsRadio.value
+      threadMode: scope.threadLevelsRadio.value,
+      linearMode: scope.scaleModel.linearMode,
+      originMode: scope.rangeModel.originMode
     });
+    scope.showToolbar = true
   }
+
 }

--- a/public/static/plugins/perf/js/trend_chart.js
+++ b/public/static/plugins/perf/js/trend_chart.js
@@ -60,6 +60,13 @@ mciModule.factory('PerfChartService', function() {
       128: { colorId: 8 },
       256: { colorId: 6 },
       512: { colorId: 7 },
+    },
+    formatters: {
+      large: d3.format(',.0f'), // grouped thousands, no significant digits
+      digits_1: d3.format('.01f'), // floating point 1 digits
+      digits_2: d3.format('.03f'), // floating point 3 digits
+      digits_3: d3.format('.03f'), // floating point 3 digits
+      si: d3.format(',s'), // si notation
     }
   };
 
@@ -148,7 +155,9 @@ var drawSingleTrendChart = function(params) {
       scope = params.scope,
       containerId = params.containerId,
       compareSamples = params.compareSamples,
-      threadMode = params.threadMode;
+      threadMode = params.threadMode,
+      linearMode = params.linearMode,
+      originMode = params.originMode;
 
   var cfg = PerfChartService.cfg;
   document.getElementById(containerId).innerHTML = '';
@@ -225,17 +234,12 @@ var drawSingleTrendChart = function(params) {
   var multiSeriesMax = d3.max(flatOpsValues)
 
   var compareMax = 0
-  if (compareSamples) {
+  if (compareSamples && compareSamples.length) {
     compareMax = _.chain(compareSamples)
       .map(function(d) { return d.maxThroughputForTest(key) })
       .max()
       .value()
   }
-
-  // If the upper and lower y-axis values are very close to the average
-  // (within 10%) add extra padding to the upper and lower bounds of the graph for display
-  var yAxisUpperBound = d3.max([compareMax, multiSeriesMax, multiSeriesAvg * 1.1])
-  var yAxisLowerBound = d3.min([multiSeriesMin, multiSeriesAvg * .9])
 
   // Calculate X Ticks values
   var idxStep = (series.length / cfg.xAxis.maxTicks + 2) | 0
@@ -243,20 +247,61 @@ var drawSingleTrendChart = function(params) {
     return i % idxStep == 0
   })
 
-  // create extra padding if seriesMax
-  var yScale = d3.scale.linear()
-    .domain([yAxisLowerBound, yAxisUpperBound])
-    .range([cfg.effectiveHeight, 0]);
 
   var xScale = d3.scale.linear()
     .domain([0, ops.length - 1])
     .range([0, cfg.effectiveWidth]);
 
-  var yAxis = d3.svg.axis()
-    .scale(yScale)
-    .orient('left')
-    .ticks(cfg.yAxis.ticks);
 
+  // Zoomed mode / linear scale is default.
+  // If the upper and lower y-axis values are very close to the average (within 10%)
+  // add extra padding to the upper and lower bounds of the graph for display.
+  var yAxisUpperBound = d3.max([compareMax, multiSeriesMax, multiSeriesAvg * 1.1]);
+  var yAxisLowerBound = originMode ? 0 : d3.min([multiSeriesMin, multiSeriesAvg * .9]);
+  var yScale = d3.scale.linear();
+
+  // Create a log based scale, remove any 0 values (log(0) is infinity).
+  if (!linearMode) {
+    yScale = d3.scale.log()
+    if (yAxisUpperBound == 0) {
+      yAxisUpperBound = 1e-1;
+    }
+    if (yAxisLowerBound == 0 ) {
+      yAxisLowerBound = 1e-1;
+    }
+  }
+
+  // We assume values are either all negative or all positive (around 0).
+  // If the average is less than 0 then swap values and negate the
+  // upper bound.
+  if (multiSeriesAvg < 0) {
+    if (!linearMode) {
+      yAxisUpperBound = -yAxisUpperBound;
+    }
+    yAxisLowerBound = d3.min([multiSeriesMin, multiSeriesAvg * 1.1]);
+  }
+
+  yScale = yScale.clamp(true)
+    .domain([yAxisLowerBound, yAxisUpperBound])
+    .range([cfg.effectiveHeight, 0]).nice(5);
+  var yAxis = d3.svg.axis()
+      .scale(yScale)
+      .orient('left')
+      .ticks(cfg.yAxis.ticks, function(d) {
+        var val = Math.abs(d)
+        if (val == 0) {
+          return "0"
+        }
+        if (val < 1) {
+          if ( val >= .1) {
+            return cfg.formatters.digits_1(d);
+          } else {
+            return cfg.formatters.digits_2(d);
+          }
+        } else{
+          return cfg.formatters.si(d);
+        }
+      })
   // ## CHART STRUCTURE ##
 
   // multi line
@@ -284,6 +329,7 @@ var drawSingleTrendChart = function(params) {
       class: 'axis',
       transform: d3Translate(cfg.margin.left - cfg.yAxis.gap, cfg.margin.top)
     })
+    .transition()
     .call(yAxis);
 
   var getIdx = function(d) { return _.findIndex(series, d) }
@@ -544,7 +590,22 @@ var drawSingleTrendChart = function(params) {
 
     focusedText
       .attr('y', function(d, i) { return opsLabelsY[i] })
-      .text(function (d, i) { return d3.format(',.0f')(values[i])})
+      .text(function (d, i) {
+        var val = Math.abs(values[i]);
+        if ( val == 0) {
+          return "0";
+        } else if ( Math.abs(val) < 1) {
+          if ( val >= .1) {
+            return cfg.formatters.digits_1(val);
+          }  else if ( val >= .01) {
+            return cfg.formatters.digits_2(val);
+          } else {
+            return cfg.formatters.digits_3(val);
+          }
+        } else{
+          return cfg.formatters.large(val);
+        }
+      });
 
     focusedLine.attr({
       y2: yScale(maxOps),

--- a/public/static/plugins/perf/js/trend_chart.js
+++ b/public/static/plugins/perf/js/trend_chart.js
@@ -64,7 +64,7 @@ mciModule.factory('PerfChartService', function() {
     formatters: {
       large: d3.format(',.0f'), // grouped thousands, no significant digits
       digits_1: d3.format('.01f'), // floating point 1 digits
-      digits_2: d3.format('.03f'), // floating point 3 digits
+      digits_2: d3.format('.02f'), // floating point 2 digits
       digits_3: d3.format('.03f'), // floating point 3 digits
       si: d3.format(',s'), // si notation
     }
@@ -287,19 +287,19 @@ var drawSingleTrendChart = function(params) {
   var yAxis = d3.svg.axis()
       .scale(yScale)
       .orient('left')
-      .ticks(cfg.yAxis.ticks, function(d) {
-        var val = Math.abs(d)
-        if (val == 0) {
+      .ticks(cfg.yAxis.ticks, function(value) {
+        var absolute = Math.abs(value)
+        if (absolute == 0) {
           return "0"
         }
-        if (val < 1) {
-          if ( val >= .1) {
-            return cfg.formatters.digits_1(d);
+        if (absolute < 1) {
+          if ( absolute >= .1) {
+            return cfg.formatters.digits_1(value);
           } else {
-            return cfg.formatters.digits_2(d);
+            return cfg.formatters.digits_2(value);
           }
         } else{
-          return cfg.formatters.si(d);
+          return cfg.formatters.si(value);
         }
       })
   // ## CHART STRUCTURE ##
@@ -591,19 +591,20 @@ var drawSingleTrendChart = function(params) {
     focusedText
       .attr('y', function(d, i) { return opsLabelsY[i] })
       .text(function (d, i) {
-        var val = Math.abs(values[i]);
-        if ( val == 0) {
+        var value = values[i];
+        var absolute = Math.abs(value);
+        if ( absolute == 0) {
           return "0";
-        } else if ( Math.abs(val) < 1) {
-          if ( val >= .1) {
-            return cfg.formatters.digits_1(val);
+        } else if ( absolute < 1) {
+          if ( absolute >= .1) {
+            return cfg.formatters.digits_1(value);
           }  else if ( val >= .01) {
-            return cfg.formatters.digits_2(val);
+            return cfg.formatters.digits_2(value);
           } else {
-            return cfg.formatters.digits_3(val);
+            return cfg.formatters.digits_3(value);
           }
         } else{
-          return cfg.formatters.large(val);
+          return cfg.formatters.large(value);
         }
       });
 

--- a/service/templates/task_perf_data.html
+++ b/service/templates/task_perf_data.html
@@ -160,7 +160,28 @@
       white-space: nowrap;
       font-size:.8em;
     }
+    div > .toolbar {
+      position: fixed;
+      bottom: 0;
+      right: 0;
+      left: 0;
+      z-index: 999;
+      // background: rgba(0,0,0,.44);
+      padding: 0 1% 0 0;
+      display: block;
+    }
 
+    .md-button.md-primary.md-fab,
+    .md-button.md-default-theme.md-primary.md-raised,
+    .md-button.md-primary.md-raised {
+      background-color: rgb(0,0,0);
+    }
+    md-switch.md-default-theme.md-checked .md-thumb, md-switch.md-checked .md-thumb {
+      background-color: rgb(92,184,92); // green;//rgb(255,64,129);
+    }
+    md-switch.md-default-theme.md-checked .md-bar, md-switch.md-checked .md-bar {
+      background-color: rgba(92,184,92,0.5);
+    }
   </style>
   <div class="panel perf-panel" ng-if="conf.enabled && !!perfSample">
     <div class="pull-right text-right">
@@ -249,6 +270,41 @@
       </table>
     </div>
     <div ng-show="perftab==2">
+      <div class="toolbar" name="toolbar" ng-show="showToolbar">
+        <div class="lock-size" layout="row" layout-align="end end">
+          <md-fab-toolbar
+            md-open="toolBar.isOpen"
+            ng-hide="toolBar.hidden"
+            ng-mouseenter="toolBar.isOpen=true"
+            ng-mouseleave="toolBar.isOpen=false"
+            md-direction="left">
+            <md-fab-trigger class="align-with-text">
+              <md-button aria-label="menu"
+                         class="md-fab md-primary">
+                <md-icon>build</md-icon>
+              </md-button>
+            </md-fab-trigger>
+
+            <md-toolbar>
+              <md-fab-actions class="md-toolbar-tools">
+                <md-button aria-label="comment" class="md-icon-button">
+                  <md-icon>build</md-icon>
+                </md-button>
+                <md-switch ng-model="scaleModel.linearMode"
+                           ng-click="$event.stopPropagation()"
+                           aria-label="Linear" style='margin-left:10px'>
+                  Linear
+                </md-switch>
+                <md-switch ng-model="rangeModel.originMode"
+                           ng-click="$event.stopPropagation()"
+                           aria-label="origin">
+                  Origin
+                </md-switch>
+              </md-fab-actions>
+            </md-toolbar>
+          </md-fab-toolbar>
+        </div>
+      </div>
       <h5>Thread Levels:</h5>
       <div>
         <div ng-repeat="option in threadLevelsRadio.options">


### PR DESCRIPTION
EVG-2609: fixed precision on labels for numbers less than 1.

It seems to work on chromium / firefox / safari and Edge. Evergreen doesn't seem to work on explorer. 