### PR TITLE
EVG-2661 separate database from rest of config in evergreen service

### DIFF
--- a/config.go
+++ b/config.go
@@ -789,7 +789,6 @@ type Settings struct {
 	Splunk             send.SplunkConnectionInfo `yaml:"splunk" bson:"splunk" json:"splunk"`
 	SuperUsers         []string                  `yaml:"superusers" bson:"superusers" json:"superusers"`
 	Ui                 UIConfig                  `yaml:"ui" bson:"ui" json:"ui" id:"ui"`
-	WriteConcern       WriteConcern              `yaml:"write_concern"`
 }
 
 func (c *Settings) SectionId() string { return configDocID }
@@ -1128,13 +1127,17 @@ func (s *Settings) GetSender(env Environment) (send.Sender, error) {
 // SessionFactory creates a usable SessionFactory from
 // the Evergreen settings.
 func (settings *Settings) SessionFactory() *legacyDB.SessionFactory {
+	return CreateSession(settings.Database)
+}
+
+func CreateSession(settings DBSettings) *legacyDB.SessionFactory {
 	safety := mgo.Safe{}
-	safety.W = settings.Database.WriteConcernSettings.W
-	safety.WMode = settings.Database.WriteConcernSettings.WMode
-	safety.WTimeout = settings.Database.WriteConcernSettings.WTimeout
-	safety.FSync = settings.Database.WriteConcernSettings.FSync
-	safety.J = settings.Database.WriteConcernSettings.J
-	return legacyDB.NewSessionFactory(settings.Database.Url, settings.Database.DB, settings.Database.SSL, safety, defaultMgoDialTimeout)
+	safety.W = settings.WriteConcernSettings.W
+	safety.WMode = settings.WriteConcernSettings.WMode
+	safety.WTimeout = settings.WriteConcernSettings.WTimeout
+	safety.FSync = settings.WriteConcernSettings.FSync
+	safety.J = settings.WriteConcernSettings.J
+	return legacyDB.NewSessionFactory(settings.Url, settings.DB, settings.SSL, safety, defaultMgoDialTimeout)
 }
 
 func (s *Settings) GetGithubOauthToken() (string, error) {

--- a/environment.go
+++ b/environment.go
@@ -90,7 +90,7 @@ func (e *envState) Configure(ctx context.Context, confPath string, db *DBSetting
 		return errors.New("cannot reconfigre a configured environment")
 	}
 
-	if db != nil {
+	if db != nil && confPath == "" {
 		e.initDB(*db)
 	}
 	if err := e.initSettings(confPath); err != nil {

--- a/environment.go
+++ b/environment.go
@@ -48,7 +48,7 @@ type Environment interface {
 	// that the queues have been started, there was no issue
 	// establishing a connection to the database, and that the
 	// local and remote queues have started.
-	Configure(context.Context, string) error
+	Configure(context.Context, string, *DBSettings) error
 
 	// Returns the settings object. The settings object is not
 	// necessarily safe for concurrent access.
@@ -79,7 +79,9 @@ type envState struct {
 	clientConfig *ClientConfig
 }
 
-func (e *envState) Configure(ctx context.Context, confPath string) error {
+// Configure requires that either the path or DB is sent so that it can construct the
+// evergreen settings. If both are sent, the settings will be from the file
+func (e *envState) Configure(ctx context.Context, confPath string, db *DBSettings) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -88,13 +90,20 @@ func (e *envState) Configure(ctx context.Context, confPath string) error {
 		return errors.New("cannot reconfigre a configured environment")
 	}
 
+	if db != nil {
+		e.initDB(*db)
+	}
 	if err := e.initSettings(confPath); err != nil {
 		return errors.WithStack(err)
 	}
+	if db != nil {
+		e.settings.Database = *db
+	}
 
 	catcher := grip.NewBasicCatcher()
-
-	catcher.Add(e.initDB())
+	if e.session == nil {
+		catcher.Add(e.initDB(e.settings.Database))
+	}
 	catcher.Add(e.createQueues(ctx))
 	catcher.Extend(e.initQueues(ctx))
 	catcher.Add(e.initClientConfig())
@@ -104,19 +113,27 @@ func (e *envState) Configure(ctx context.Context, confPath string) error {
 }
 
 func (e *envState) initSettings(path string) error {
-	// read configuration from the file and validate.
-	// at some point this should just be read from the database at
-	// a later stage, and populated with default values if it
-	// isn't in the db.
+	// read configuration from either the file or DB and validate
+	// if the file path is blank, the DB session must be configured already
 
 	var err error
 
 	if e.settings == nil {
 		// this helps us test the validate method
-		e.settings, err = NewSettings(path)
-		if err != nil {
-			return errors.Wrap(err, "problem getting settings")
+		if path != "" {
+			e.settings, err = NewSettings(path)
+			if err != nil {
+				return errors.Wrap(err, "problem getting settings from file")
+			}
+		} else {
+			e.settings, err = GetConfig()
+			if err != nil {
+				return errors.Wrap(err, "problem getting settings from DB")
+			}
 		}
+	}
+	if e.settings == nil {
+		return errors.New("unable to get settings from file and DB")
 	}
 
 	if err = e.settings.Validate(); err != nil {
@@ -126,7 +143,7 @@ func (e *envState) initSettings(path string) error {
 	return nil
 }
 
-func (e *envState) initDB() error {
+func (e *envState) initDB(settings DBSettings) error {
 	if legacyDB.HasGlobalSessionProvider() {
 		grip.Warning("database session configured; reconfiguring")
 	}
@@ -135,7 +152,7 @@ func (e *envState) initDB() error {
 	// legacy session factory mechanism. in the future the
 	// environment can and should be the only provider of database
 	// sessions.
-	sf := e.settings.SessionFactory()
+	sf := CreateSession(settings)
 	legacyDB.SetGlobalSessionProvider(sf)
 
 	var err error

--- a/environment.go
+++ b/environment.go
@@ -96,7 +96,7 @@ func (e *envState) Configure(ctx context.Context, confPath string, db *DBSetting
 	if err := e.initSettings(confPath); err != nil {
 		return errors.WithStack(err)
 	}
-	if db != nil {
+	if db != nil && confPath == "" {
 		e.settings.Database = *db
 	}
 

--- a/environment_test.go
+++ b/environment_test.go
@@ -109,6 +109,6 @@ func (s *EnvironmentSuite) TestDbOverride() {
 	s.NoError(err)
 	db := settings.Database
 	db.DB = "other_db"
-	s.NoError(s.env.Configure(ctx, s.path, &db))
+	s.NoError(s.env.Configure(ctx, "", &db))
 	s.Equal("other_db", s.env.settings.Database.DB)
 }

--- a/environment_test.go
+++ b/environment_test.go
@@ -43,17 +43,8 @@ func (s *EnvironmentSuite) TestLoadingConfig() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s.NoError(s.env.Configure(ctx, s.path))
-	s.Error(s.env.Configure(ctx, s.path))
-}
-
-func (s *EnvironmentSuite) TestLoadingConfigErrorsIfFileDoesNotExist() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	s.Error(s.env.Configure(ctx, ""))
-
-	s.Error(s.env.Configure(ctx, s.path+"-DOES-NOT-EXIST"))
+	s.NoError(s.env.Configure(ctx, s.path, nil))
+	s.Error(s.env.Configure(ctx, s.path, nil))
 }
 
 func (s *EnvironmentSuite) TestConfigErrorsIfCannotValidateConfig() {
@@ -106,4 +97,18 @@ func (s *EnvironmentSuite) TestGetClientConfig() {
 	s.Equal("z80", cb[1].Arch)
 	s.Equal("linux", cb[1].OS)
 	s.Equal("https://example.com/clients/linux_z80_obviouslynotherealone/evergreen", cb[1].URL)
+}
+
+func (s *EnvironmentSuite) TestDbOverride() {
+	s.shouldSkip()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	settings, err := NewSettings(s.path)
+	s.NoError(err)
+	db := settings.Database
+	db.DB = "other_db"
+	s.NoError(s.env.Configure(ctx, s.path, &db))
+	s.Equal("other_db", s.env.settings.Database.DB)
 }

--- a/globals.go
+++ b/globals.go
@@ -142,6 +142,8 @@ const (
 
 const (
 	DefaultServiceConfigurationFileName = "/etc/mci_settings.yml"
+	DefaultDatabaseUrl                  = "localhost:27017"
+	DefaultDatabaseName                 = "mci"
 
 	// database and config directory, set to the testing version by default for safety
 	NotificationsFile = "mci-notifications.yml"

--- a/globals.go
+++ b/globals.go
@@ -82,6 +82,7 @@ const (
 	LogmessageCurrentVersion  = LogmessageFormatTimestamp
 
 	EvergreenHome = "EVGHOME"
+	MongodbUrl    = "MONGO_URL"
 
 	// Special logging output targets
 	LocalLoggingOverride          = "LOCAL"

--- a/migrations/anser_test.go
+++ b/migrations/anser_test.go
@@ -29,7 +29,7 @@ func TestAnserBasicPlaceholder(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	assert.NoError(evgEnv.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings)))
+	assert.NoError(evgEnv.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 
 	opts := Options{
 		Database: "mci_test",

--- a/migrations/github_hook_test.go
+++ b/migrations/github_hook_test.go
@@ -47,7 +47,7 @@ func TestGithubHookMigration(t *testing.T) {
 		cancel:   cancel,
 	}
 
-	require.NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings)))
+	require.NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 	require.NoError(s.env.LocalQueue().Start(ctx))
 
 	anser.ResetEnvironment()

--- a/migrations/project_aliases_test.go
+++ b/migrations/project_aliases_test.go
@@ -43,7 +43,7 @@ func TestProjectAliasMigration(t *testing.T) {
 		cancel:   cancel,
 	}
 
-	require.NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings)))
+	require.NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 	require.NoError(s.env.LocalQueue().Start(ctx))
 
 	anser.ResetEnvironment()

--- a/migrations/zero_date_fix_test.go
+++ b/migrations/zero_date_fix_test.go
@@ -61,7 +61,7 @@ func TestFixZeroDateMigration(t *testing.T) {
 		cancel:   cancel,
 	}
 
-	require.NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings)))
+	require.NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 	require.NoError(s.env.LocalQueue().Start(ctx))
 	s.env.Settings().Credentials = testConfig.Credentials
 

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -27,11 +27,14 @@ type Environment struct {
 	mu                sync.RWMutex
 }
 
-func (e *Environment) Configure(ctx context.Context, path string) error {
+func (e *Environment) Configure(ctx context.Context, path string, db *evergreen.DBSettings) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	e.EvergreenSettings = testutil.TestConfig()
+	if db != nil {
+		e.EvergreenSettings.Database = *db
+	}
 	e.DBSession = anserMock.NewSession()
 	e.Driver = queue.NewPriorityDriver()
 

--- a/monitor/hosts_test.go
+++ b/monitor/hosts_test.go
@@ -22,7 +22,7 @@ func TestTerminateHosts(t *testing.T) {
 	defer cancel()
 
 	env := &mock.Environment{}
-	assert.NoError(env.Configure(ctx, ""))
+	assert.NoError(env.Configure(ctx, "", nil))
 	assert.NoError(env.Local.Start(ctx))
 
 	// test that trying to terminate a host that does not exist is handled gracecfully

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -114,7 +114,7 @@ func TestCLIFetchSource(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	assert.NoError(t, evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings)))
+	assert.NoError(t, evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 
 	testutil.ConfigureIntegrationTest(t, testConfig, "TestCLIFetchSource")
 	evergreen.GetEnvironment().Settings().Credentials = testConfig.Credentials
@@ -181,7 +181,7 @@ func TestCLIFetchArtifacts(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	assert.NoError(t, evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings)))
+	assert.NoError(t, evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 
 	testutil.ConfigureIntegrationTest(t, testConfig, "TestCLIFetchArtifacts")
 	evergreen.GetEnvironment().Settings().Credentials = testConfig.Credentials
@@ -302,14 +302,14 @@ func TestCLITestHistory(t *testing.T) {
 					EndTime:   float64(endTime.Unix()),
 				}
 				t := task.Task{
-					Id:           fmt.Sprintf("task_%v", i),
-					Project:      project,
-					DisplayName:  fmt.Sprintf("testTask_%v", i%3),
-					Revision:     fmt.Sprintf("%vversion%v", revisionBeginning, i%3),
-					Version:      fmt.Sprintf("version%v", i%3),
-					BuildVariant: "osx",
-					Status:       evergreen.TaskFailed,
-					LocalTestResults:  []task.TestResult{passingResult, failedResult},
+					Id:               fmt.Sprintf("task_%v", i),
+					Project:          project,
+					DisplayName:      fmt.Sprintf("testTask_%v", i%3),
+					Revision:         fmt.Sprintf("%vversion%v", revisionBeginning, i%3),
+					Version:          fmt.Sprintf("version%v", i%3),
+					BuildVariant:     "osx",
+					Status:           evergreen.TaskFailed,
+					LocalTestResults: []task.TestResult{passingResult, failedResult},
 				}
 				So(t.Insert(), ShouldBeNil)
 			}

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -26,6 +26,15 @@ const (
 	anserTargetFlagName  = "target"
 	anserWorkersFlagName = "workers"
 	anserPeriodFlagName  = "period"
+
+	dbUrlFlagName        = "url"
+	dbSslFlagName        = "ssl"
+	dbNameFlagName       = "db"
+	dbWriteNumFlagName   = "w"
+	dbWmodeFlagName      = "wmode"
+	dbWTimeoutFlagName   = "wtimeout"
+	dbFsyncFlagName      = "fsync"
+	dbJournalAckFlagName = "j"
 )
 
 func joinFlagNames(ids ...string) string { return strings.Join(ids, ", ") }
@@ -48,7 +57,7 @@ func serviceConfigFlags(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.StringFlag{
 		Name:  joinFlagNames(confFlagName, "config", "c"),
 		Usage: "path to the service configuration file",
-		Value: evergreen.DefaultServiceConfigurationFileName,
+		Value: evergreen.DefaultServiceConfigurationFileName, // TODO: remove once everything is passing an explicit file
 	})
 }
 
@@ -142,6 +151,41 @@ func addMigrationRuntimeFlags(flags ...cli.Flag) []cli.Flag {
 			Value: time.Minute,
 		})
 
+}
+
+func addDbSettingsFlags(flags ...cli.Flag) []cli.Flag {
+	return append(flags,
+		cli.StringFlag{
+			Name:  dbUrlFlagName,
+			Usage: "Database URL(s). For a replica set, list all members separated by a comma.",
+			Value: evergreen.DefaultDatabaseUrl,
+		},
+		cli.BoolFlag{
+			Name:  dbSslFlagName,
+			Usage: "True to use SSL in the DB connection",
+		},
+		cli.StringFlag{
+			Name:  dbNameFlagName,
+			Usage: "Database name",
+			Value: evergreen.DefaultDatabaseName,
+		},
+		cli.IntFlag{
+			Name:  dbWriteNumFlagName,
+			Usage: "Number of mongod instances that need to acknowledge a write",
+		},
+		cli.StringFlag{
+			Name:  dbWmodeFlagName,
+			Usage: "Write mode. Only valid values are blank or 'majority'",
+		},
+		cli.BoolFlag{
+			Name:  dbFsyncFlagName,
+			Usage: "True if pending writes should flush to disk",
+		},
+		cli.BoolFlag{
+			Name:  dbJournalAckFlagName,
+			Usage: "True if the journal must acknowledge writes",
+		},
+	)
 }
 
 func mergeFlagSlices(in ...[]cli.Flag) []cli.Flag {

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -27,14 +27,12 @@ const (
 	anserWorkersFlagName = "workers"
 	anserPeriodFlagName  = "period"
 
-	dbUrlFlagName        = "url"
-	dbSslFlagName        = "ssl"
-	dbNameFlagName       = "db"
-	dbWriteNumFlagName   = "w"
-	dbWmodeFlagName      = "wmode"
-	dbWTimeoutFlagName   = "wtimeout"
-	dbFsyncFlagName      = "fsync"
-	dbJournalAckFlagName = "j"
+	dbUrlFlagName      = "url"
+	dbSslFlagName      = "ssl"
+	dbNameFlagName     = "db"
+	dbWriteNumFlagName = "w"
+	dbWmodeFlagName    = "wmode"
+	dbWTimeoutFlagName = "wtimeout"
 )
 
 func joinFlagNames(ids ...string) string { return strings.Join(ids, ", ") }
@@ -175,14 +173,6 @@ func addDbSettingsFlags(flags ...cli.Flag) []cli.Flag {
 		cli.StringFlag{
 			Name:  dbWmodeFlagName,
 			Usage: "Write mode. Only valid values are blank or 'majority'",
-		},
-		cli.BoolFlag{
-			Name:  dbFsyncFlagName,
-			Usage: "True if pending writes should flush to disk",
-		},
-		cli.BoolFlag{
-			Name:  dbJournalAckFlagName,
-			Usage: "True if the journal must acknowledge writes",
 		},
 	)
 }

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -57,7 +57,6 @@ func serviceConfigFlags(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.StringFlag{
 		Name:  joinFlagNames(confFlagName, "config", "c"),
 		Usage: "path to the service configuration file",
-		Value: evergreen.DefaultServiceConfigurationFileName, // TODO: remove once everything is passing an explicit file
 	})
 }
 

--- a/operations/service.go
+++ b/operations/service.go
@@ -1,6 +1,8 @@
 package operations
 
 import (
+	"os"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/urfave/cli"
 )
@@ -36,15 +38,18 @@ func parseDB(c *cli.Context) *evergreen.DBSettings {
 	if c == nil {
 		return nil
 	}
+	url := c.String(dbUrlFlagName)
+	envUrl := os.Getenv(evergreen.MongodbUrl)
+	if url == evergreen.DefaultDatabaseUrl && envUrl != "" {
+		url = envUrl
+	}
 	return &evergreen.DBSettings{
-		Url: c.String(dbUrlFlagName),
+		Url: url,
 		SSL: c.Bool(dbSslFlagName),
 		DB:  c.String(dbNameFlagName),
 		WriteConcernSettings: evergreen.WriteConcern{
 			W:     c.Int(dbWriteNumFlagName),
 			WMode: c.String(dbWmodeFlagName),
-			FSync: c.Bool(dbFsyncFlagName),
-			J:     c.Bool(dbJournalAckFlagName),
 		},
 	}
 }

--- a/operations/service.go
+++ b/operations/service.go
@@ -1,6 +1,9 @@
 package operations
 
-import "github.com/urfave/cli"
+import (
+	"github.com/evergreen-ci/evergreen"
+	"github.com/urfave/cli"
+)
 
 func Service() cli.Command {
 	return cli.Command{
@@ -25,6 +28,23 @@ func deploy() cli.Command {
 			smokeStartEvergreen(),
 			smokeTestEndpoints(),
 			fetchAllProjectConfigs(),
+		},
+	}
+}
+
+func parseDB(c *cli.Context) *evergreen.DBSettings {
+	if c == nil {
+		return nil
+	}
+	return &evergreen.DBSettings{
+		Url: c.String(dbUrlFlagName),
+		SSL: c.Bool(dbSslFlagName),
+		DB:  c.String(dbNameFlagName),
+		WriteConcernSettings: evergreen.WriteConcern{
+			W:     c.Int(dbWriteNumFlagName),
+			WMode: c.String(dbWmodeFlagName),
+			FSync: c.Bool(dbFsyncFlagName),
+			J:     c.Bool(dbJournalAckFlagName),
 		},
 	}
 }

--- a/operations/service_deploy_migration.go
+++ b/operations/service_deploy_migration.go
@@ -24,7 +24,7 @@ func deployMigration() cli.Command {
 			defer cancel()
 
 			env := evergreen.GetEnvironment()
-			err := env.Configure(ctx, c.String(confFlagName))
+			err := env.Configure(ctx, c.String(confFlagName), nil)
 
 			grip.CatchEmergencyFatal(errors.Wrap(err, "problem configuring application environment"))
 			settings := env.Settings()
@@ -70,7 +70,7 @@ func deployDataTransforms() cli.Command {
 			defer cancel()
 
 			env := evergreen.GetEnvironment()
-			err := env.Configure(ctx, confPath)
+			err := env.Configure(ctx, confPath, nil)
 			if err != nil {
 				return errors.Wrap(err, "problem configuring application environment")
 			}

--- a/operations/service_web.go
+++ b/operations/service_web.go
@@ -32,15 +32,14 @@ func startWebService() cli.Command {
 	return cli.Command{
 		Name:  "web",
 		Usage: "start web services for API and UI",
-		Flags: serviceConfigFlags(),
+		Flags: mergeFlagSlices(serviceConfigFlags(), addDbSettingsFlags()),
 		Action: func(c *cli.Context) error {
 			confPath := c.String(confFlagName)
-			// TODO: ensure that there is a database set
-
+			db := parseDB(c)
 			ctx, cancel := context.WithCancel(context.Background())
 
 			env := evergreen.GetEnvironment()
-			grip.CatchEmergencyFatal(errors.Wrap(env.Configure(ctx, confPath), "problem configuring application environment"))
+			grip.CatchEmergencyFatal(errors.Wrap(env.Configure(ctx, confPath, db), "problem configuring application environment"))
 
 			settings := env.Settings()
 			sender, err := settings.GetSender(env)

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -99,7 +99,7 @@ func TestMockConnectorSuite(t *testing.T) {
 
 func (s *AdminDataSuite) SetupSuite() {
 	s.env = &mock.Environment{}
-	s.Require().NoError(s.env.Configure(context.Background(), ""))
+	s.Require().NoError(s.env.Configure(context.Background(), "", nil))
 	s.Require().NoError(s.env.Local.Start(context.Background()))
 }
 

--- a/rest/data/cli_update_test.go
+++ b/rest/data/cli_update_test.go
@@ -26,7 +26,7 @@ func TestUpdateConnector(t *testing.T) {
 	s.setup = func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		s.cancel = cancel
-		s.NoError(evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings)))
+		s.NoError(evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 
 		s.NoError(db.ClearCollections(evergreen.ConfigCollection))
 	}

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -39,7 +39,7 @@ type GithubWebhookRouteSuite struct {
 func (s *GithubWebhookRouteSuite) SetupSuite() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.canceler = cancel
-	err := evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings))
+	err := evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil)
 	s.NoError(err)
 	s.NotNil(evergreen.GetEnvironment().Settings())
 	s.NotNil(evergreen.GetEnvironment().Settings().Api)

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -35,7 +35,7 @@ func (s *githubStatusUpdateSuite) SetupSuite() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
-	s.Require().NoError(evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings)))
+	s.Require().NoError(evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 }
 
 func (s *githubStatusUpdateSuite) TearDownSuite() {

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -57,7 +57,7 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
-	s.Require().NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings)))
+	s.Require().NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), "TestPatchIntentUnitsSuite")
 
 	s.NotNil(s.env.Settings())

--- a/units/repotracker_test.go
+++ b/units/repotracker_test.go
@@ -26,7 +26,7 @@ func (s *repotrackerJobSuite) SetupTest() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
-	s.Require().NoError(evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings)))
+	s.Require().NoError(evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 	s.NoError(db.ClearCollections(model.ProjectRefCollection))
 
 }

--- a/units/stats_test.go
+++ b/units/stats_test.go
@@ -30,7 +30,7 @@ func (s *StatUnitsSuite) SetupTest() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
-	s.Require().NoError(s.env.Configure(ctx, ""))
+	s.Require().NoError(s.env.Configure(ctx, "", nil))
 }
 
 func (s *StatUnitsSuite) TestAmboyStatsCollector() {


### PR DESCRIPTION
This change is non-functional until I resolve the TODO comment, but to do that I first need to make sure the evergreen config we have in chef explicitly has the /etc/mci_settings file set

BUILD-4576

It looks like we already have that set, so I've removed the default