### PR TITLE
EVG-2371: scale doesnt allow large numbers, the hover label truncates

### DIFF
--- a/public/static/plugins/perf/js/trend_chart.js
+++ b/public/static/plugins/perf/js/trend_chart.js
@@ -14,7 +14,7 @@ mciModule.factory('PerfChartService', function() {
       top: 12,
       right: 50,
       bottom: 60,
-      left: 80
+      left: 120
     },
     points: {
       focusedR: 4.5,
@@ -593,7 +593,23 @@ var drawSingleTrendChart = function(params) {
     })
 
     focusedText
-      .attr('y', function(d, i) { return opsLabelsY[i] })
+      .attr({'y': function(d, i) { return opsLabelsY[i] },
+             transform: function(){
+               // center the text for the last 20 items
+               var x = 0;
+               if(series){
+                 var percent = idx * 100.0 /  series.length;
+                 if(percent< 33){
+                   x = 0;
+                 } else if ( percent >= 33 && percent < 66) {
+                   x = -(cfg.focus.labelOffset.x + this.getBBox().width / 2);
+                 } else {
+                   x = -(cfg.focus.labelOffset.x + this.getBBox().width);
+                 }
+               }
+               return d3Translate(x, 0)
+             }}
+           )
       .text(function (d, i) {
         var value = values[i];
         var absolute = Math.abs(value);

--- a/public/static/plugins/perf/js/trend_chart.js
+++ b/public/static/plugins/perf/js/trend_chart.js
@@ -594,15 +594,15 @@ var drawSingleTrendChart = function(params) {
 
     focusedText
       .attr({y: function(d, i) { return opsLabelsY[i] },
-             transform: function(){
+             transform: function() {
                // transform the hover text location based on the list index
                var x = 0;
                if (series) {
                  x = (cfg.focus.labelOffset.x + this.getBBox().width) * idx / series.length
                }
                return d3Translate(-x, 0)
-             }}
-           )
+             }
+      })
       .text(function (d, i) {
         var value = values[i];
         var absolute = Math.abs(value);

--- a/public/static/plugins/perf/js/trend_chart.js
+++ b/public/static/plugins/perf/js/trend_chart.js
@@ -595,7 +595,10 @@ var drawSingleTrendChart = function(params) {
     focusedText
       .attr({'y': function(d, i) { return opsLabelsY[i] },
              transform: function(){
-               // center the text for the last 20 items
+               // transform the hover text location to:
+               //   1. right align the left 33% 
+               //   2. center align the middle 33%
+               //   3. left align the right 33%
                var x = 0;
                if(series){
                  var percent = idx * 100.0 /  series.length;

--- a/public/static/plugins/perf/js/trend_chart.js
+++ b/public/static/plugins/perf/js/trend_chart.js
@@ -603,7 +603,7 @@ var drawSingleTrendChart = function(params) {
                return d3Translate(-x, 0)
              }
       })
-      .text(function (d, i) {
+      .text(function(d, i) {
         var value = values[i];
         var absolute = Math.abs(value);
         if (absolute == 0) {

--- a/public/static/plugins/perf/js/trend_chart.js
+++ b/public/static/plugins/perf/js/trend_chart.js
@@ -593,11 +593,11 @@ var drawSingleTrendChart = function(params) {
     })
 
     focusedText
-      .attr({'y': function(d, i) { return opsLabelsY[i] },
-             'transform': function(){
+      .attr({y: function(d, i) { return opsLabelsY[i] },
+             transform: function(){
                // transform the hover text location based on the list index
                var x = 0;
-               if(series){
+               if (series) {
                  x = (cfg.focus.labelOffset.x + this.getBBox().width) * idx / series.length
                }
                return d3Translate(-x, 0)

--- a/public/static/plugins/perf/js/trend_chart.js
+++ b/public/static/plugins/perf/js/trend_chart.js
@@ -594,34 +594,24 @@ var drawSingleTrendChart = function(params) {
 
     focusedText
       .attr({'y': function(d, i) { return opsLabelsY[i] },
-             transform: function(){
-               // transform the hover text location to:
-               //   1. right align the left 33% 
-               //   2. center align the middle 33%
-               //   3. left align the right 33%
+             'transform': function(){
+               // transform the hover text location based on the list index
                var x = 0;
                if(series){
-                 var percent = idx * 100.0 /  series.length;
-                 if(percent< 33){
-                   x = 0;
-                 } else if ( percent >= 33 && percent < 66) {
-                   x = -(cfg.focus.labelOffset.x + this.getBBox().width / 2);
-                 } else {
-                   x = -(cfg.focus.labelOffset.x + this.getBBox().width);
-                 }
+                 x = (cfg.focus.labelOffset.x + this.getBBox().width) * idx / series.length
                }
-               return d3Translate(x, 0)
+               return d3Translate(-x, 0)
              }}
            )
       .text(function (d, i) {
         var value = values[i];
         var absolute = Math.abs(value);
-        if ( absolute == 0) {
+        if (absolute == 0) {
           return "0";
-        } else if ( absolute < 1) {
-          if ( absolute >= .1) {
+        } else if (absolute < 1) {
+          if (absolute >= .1) {
             return cfg.formatters.digits_1(value);
-          }  else if ( absolute >= .01) {
+          }  else if (absolute >= .01) {
             return cfg.formatters.digits_2(value);
           } else {
             return cfg.formatters.digits_3(value);


### PR DESCRIPTION
The old behavior can be seen in the following:

![old](https://user-images.githubusercontent.com/22506/37463121-2584f3d6-284c-11e8-9af1-6c0911609f69.gif)

As you can see the current behavior truncates on both the left and the right. 

The new behavior fixed both these issues:

![new](https://user-images.githubusercontent.com/22506/37463142-36bf77e8-284c-11e8-8b71-4ff92fb7f859.gif)

Left margin of 120 is to allow for even larger scale values. It is also possible to reduce the right margin, but in this case the graph appears off center.  