### PR TITLE
EVG-2944 Use correct requester for manually authorised patches

### DIFF
--- a/service/patch.go
+++ b/service/patch.go
@@ -202,7 +202,11 @@ func (uis *UIServer) schedulePatch(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		ver, err := model.FinalizePatch(projCtx.Patch, evergreen.PatchVersionRequester, githubOauthToken)
+		requester := evergreen.PatchVersionRequester
+		if projCtx.Patch.IsGithubPRPatch() {
+			requester = evergreen.GithubPRRequester
+		}
+		ver, err := model.FinalizePatch(projCtx.Patch, requester, githubOauthToken)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError,
 				errors.Wrap(err, "Error finalizing patch"))


### PR DESCRIPTION
when manually authorizing patches, it set the wrong requester, which prevented status updates from happening.