### PR TITLE
EVG-2971 New Evergreen projects should have webhooks/webhook repotracker enabled by default

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -156,6 +156,8 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location) 
           $scope.refreshTrackedProjects(data.AllProjects);
           $scope.loadProject(data.ProjectId);
           $scope.newProject = {};
+          $scope.settingsFormData.setup_github_hook = true;
+          $scope.settingsFormData.tracks_push_events = true;
         },
         function(resp){
           console.log("error creating project: " + resp.status);

--- a/service/project.go
+++ b/service/project.go
@@ -306,6 +306,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				// don't kill it here, sometimes people change
 				// Evergreen to track a personal branch,
 				// one that we have no access to
+				projectRef.TracksPushEvents = false
 
 			} else {
 				hook := model.GithubHook{


### PR DESCRIPTION
Note that this silently enabled webhooks and tracks push events when "add project" is used. If the hook can't be created, it logs it but still allows for project creation