### PR TITLE
EVG-3124 correctly restart display tasks as part of a build

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -218,9 +218,6 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 		if err = t.Archive(); err != nil {
 			return errors.Wrap(err, "failed to archive task")
 		}
-		if t.DisplayOnly {
-			restartIds = append(restartIds, t.ExecutionTasks...)
-		}
 	}
 
 	if abortInProgress {
@@ -305,11 +302,6 @@ func RestartBuild(buildId string, taskIds []string, abortInProgress bool, caller
 				return errors.Wrapf(err,
 					"Restarting build %v failed, could not task.reset on task",
 					buildId, t.Id)
-			}
-		}
-		if t.DisplayOnly {
-			if err = task.ResetTasks(t.ExecutionTasks); err != nil {
-				return errors.WithStack(err)
 			}
 		}
 	}


### PR DESCRIPTION
The problem was that restarting a build/version checks to see if the task was already scheduled by looking at its dispatch time. Display tasks have no dispatch time because they are never dispatch, so I am now setting the field to the time its first task was dispatched