### PR TITLE
EVG-3188 Implement fmt.Stringer for APIString

### DIFF
--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -61,7 +61,7 @@ func hostCreate() cli.Command {
 				return errors.Wrap(err, "problem contacting evergreen service")
 			}
 
-			grip.Infof("Spawn host created with ID '%s'. Visit the hosts page in Evergreen to check on its status.", host.Id)
+			grip.Infof("Spawn host created with ID '%s'. Visit the hosts page in Evergreen to check on its status.", model.FromAPIString(host.Id))
 			return nil
 		},
 	}
@@ -129,7 +129,7 @@ func hostlist() cli.Command {
 
 func printHosts(hosts []*model.APIHost) error {
 	for _, h := range hosts {
-		grip.Infof("ID: %s; Distro: %s; Status: %s; Host name: %s; User: %s", h.Id, h.Distro.Id, h.Status, h.HostURL, h.User)
+		grip.Infof("ID: %s; Distro: %s; Status: %s; Host name: %s; User: %s", model.FromAPIString(h.Id), h.Distro.Id, h.Status, h.HostURL, h.User)
 	}
 	return nil
 }

--- a/rest/model/string.go
+++ b/rest/model/string.go
@@ -12,7 +12,3 @@ func FromAPIString(in APIString) string {
 	}
 	return *in
 }
-
-func (as APIString) String() string {
-	return string(as)
-}

--- a/rest/model/string.go
+++ b/rest/model/string.go
@@ -12,3 +12,7 @@ func FromAPIString(in APIString) string {
 	}
 	return *in
 }
+
+func (as APIString) String() string {
+	return string(as)
+}


### PR DESCRIPTION
This fixes printing errors when used in a format string such as:

```
			grip.Infof("Spawn host created with ID '%s'. Visit the hosts page in Evergreen to check on its status.", host.Id)
```

Now correctly prints:

```
evergreen-ci/evergreen master Δ ./clients/darwin_amd64/evergreen host create -d rhel70-small -k mathewrobinson
A new version is available. Run './clients/darwin_amd64/evergreen get-update --install' to download and install it.
[evergreen] 2018/04/20 12:45:00 [p=info]: Spawn host created with ID 'evg-rhel70-small-20180420164500-1674881231148019645'. Visit the hosts page in Evergreen to check on its status.
```