### PR TITLE
EVG-3087 Convert existing Github PR Status API code to use event driven notifications

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -105,7 +105,7 @@ imports:
     version: 6f45313302b9c56850fc17f99e40caebce98c716
 
   - name: github.com/mongodb/grip
-    version: f8496c37ea87fe700d8e8bcac511547096f22afc
+    version: 84eda94505ee7e274b10ffd43e48f6c0e3173788
   - name: github.com/mongodb/anser
     version: a39cb2703e7f53a0d46f17a785d25f85fa19923a
   - name: github.com/mongodb/amboy

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -311,10 +311,14 @@ func IsValidOwnerType(in string) bool {
 	}
 }
 
+const (
+	triggerOutcome = "outcome"
+)
+
 func NewPatchOutcomeSubscription(id string, sub Subscriber) Subscription {
 	return Subscription{
 		Type:    ResourceTypePatch,
-		Trigger: "outcome",
+		Trigger: triggerOutcome,
 		Selectors: []Selector{
 			{
 				Type: "id",
@@ -329,7 +333,7 @@ func NewPatchOutcomeSubscriptionByOwner(owner string, sub Subscriber) Subscripti
 	return Subscription{
 		ID:      bson.NewObjectId(),
 		Type:    ResourceTypePatch,
-		Trigger: "outcome",
+		Trigger: triggerOutcome,
 		Selectors: []Selector{
 			{
 				Type: "owner",
@@ -343,7 +347,7 @@ func NewPatchOutcomeSubscriptionByOwner(owner string, sub Subscriber) Subscripti
 func NewBuildOutcomeSubscriptionByVersion(versionID string, sub Subscriber) Subscription {
 	return Subscription{
 		Type:    ResourceTypeBuild,
-		Trigger: "outcome",
+		Trigger: triggerOutcome,
 		Selectors: []Selector{
 			{
 				Type: "in-version",

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -347,7 +347,7 @@ func NewBuildOutcomeSubscriptionByVersion(versionID string, sub Subscriber) Subs
 		Selectors: []Selector{
 			{
 				Type: "in-version",
-				Data: id,
+				Data: versionID,
 			},
 		},
 		Subscriber: sub,

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -340,13 +340,13 @@ func NewPatchOutcomeSubscriptionByOwner(owner string, sub Subscriber) Subscripti
 	}
 }
 
-func NewBuildOutcomeSubscription(id string, sub Subscriber) Subscription {
+func NewBuildOutcomeSubscriptionByVersion(versionID string, sub Subscriber) Subscription {
 	return Subscription{
 		Type:    ResourceTypeBuild,
 		Trigger: "outcome",
 		Selectors: []Selector{
 			{
-				Type: "id",
+				Type: "in-version",
 				Data: id,
 			},
 		},

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -339,3 +339,17 @@ func NewPatchOutcomeSubscriptionByOwner(owner string, sub Subscriber) Subscripti
 		Subscriber: sub,
 	}
 }
+
+func NewBuildOutcomeSubscription(id string, sub Subscriber) Subscription {
+	return Subscription{
+		Type:    ResourceTypeBuild,
+		Trigger: "outcome",
+		Selectors: []Selector{
+			{
+				Type: "id",
+				Data: id,
+			},
+		},
+		Subscriber: sub,
+	}
+}

--- a/model/trigger/build.go
+++ b/model/trigger/build.go
@@ -88,7 +88,7 @@ func generatorFromBuild(triggerName string, b *build.Build) (*notificationGenera
 		PastTenseStatus:   b.Status,
 		apiModel:          &api,
 		githubState:       message.GithubStateFailure,
-		githubDescription: TaskStatusToDesc(b),
+		githubDescription: taskStatusToDesc(b),
 	}
 	if b.Status == evergreen.BuildSucceeded {
 		data.githubState = message.GithubStateSuccess
@@ -134,8 +134,7 @@ func buildSuccess(e *event.EventLogEntry, b *build.Build) (*notificationGenerato
 	return gen, err
 }
 
-// TODO: EVG-3087 stop using this in units and make it private
-func TaskStatusToDesc(b *build.Build) string {
+func taskStatusToDesc(b *build.Build) string {
 	success := 0
 	failed := 0
 	systemError := 0

--- a/model/trigger/build.go
+++ b/model/trigger/build.go
@@ -65,6 +65,10 @@ func buildSelectors(b *build.Build) []event.Selector {
 			Type: selectorProject,
 			Data: b.Project,
 		},
+		{
+			Type: selectorInVersion,
+			Data: b.Version,
+		},
 	}
 }
 

--- a/model/trigger/build.go
+++ b/model/trigger/build.go
@@ -91,6 +91,7 @@ func generatorFromBuild(triggerName string, b *build.Build) (*notificationGenera
 		URL:               fmt.Sprintf("%s/build/%s", ui.Url, b.Id),
 		PastTenseStatus:   b.Status,
 		apiModel:          &api,
+		githubContext:     fmt.Sprintf("evergreen/%s", b.BuildVariant),
 		githubState:       message.GithubStateFailure,
 		githubDescription: taskStatusToDesc(b),
 	}

--- a/model/trigger/patch.go
+++ b/model/trigger/patch.go
@@ -145,7 +145,7 @@ func patchSuccess(e *event.PatchEventData, p *patch.Patch) (*notificationGenerat
 	return generatorFromPatch(name, p, e.Status)
 }
 
-func patchStarted(e *event.EventLogEntry, p *patch.Patch) (*notificationGenerator, error) {
+func patchStarted(e *event.PatchEventData, p *patch.Patch) (*notificationGenerator, error) {
 	const name = "started"
 
 	if e.Status != evergreen.PatchStarted {

--- a/model/trigger/patch_test.go
+++ b/model/trigger/patch_test.go
@@ -213,28 +213,6 @@ func (s *patchSuite) TestPatchOutcome() {
 	})
 }
 
-func (s *patchSuite) TestPatchCreated() {
-	gen, err := patchCreated(&s.event, &s.patch)
-	s.Nil(err)
-	s.Nil(gen)
-
-	s.patch.Status = evergreen.PatchCreated
-	gen, err = patchCreated(&s.event, &s.patch)
-	s.Nil(err)
-	s.Require().NotNil(gen)
-	s.Require().NotNil(gen.githubStatusAPI)
-	s.Contains(gen.selectors, event.Selector{
-		Type: "trigger",
-		Data: "created",
-	})
-
-	s.Equal("created", gen.triggerName)
-	s.Equal("evergreen", gen.githubStatusAPI.Context)
-	s.Equal(message.GithubStatePending, gen.githubStatusAPI.State)
-	s.Equal("preparing to run tasks", gen.githubStatusAPI.Description)
-	s.Equal("https://evergreen.mongodb.com/version/5aeb4514f27e4f9984646d97", gen.githubStatusAPI.URL)
-}
-
 func (s *patchSuite) TestPatchStarted() {
 	gen, err := patchStarted(&s.event, &s.patch)
 	s.Nil(err)

--- a/model/trigger/payloads.go
+++ b/model/trigger/payloads.go
@@ -36,6 +36,7 @@ type commonTemplateData struct {
 	Headers         http.Header
 
 	apiModel          restModel.Model
+	githubContext     string
 	githubState       message.GithubState
 	githubDescription string
 }
@@ -248,6 +249,9 @@ func makeCommonGenerator(triggerName string, selectors []event.Selector,
 			State:       data.githubState,
 			URL:         data.URL,
 			Description: data.githubDescription,
+		}
+		if len(data.githubContext) != 0 {
+			gen.githubStatusAPI.Context = data.githubContext
 		}
 	}
 

--- a/model/trigger/payloads.go
+++ b/model/trigger/payloads.go
@@ -23,7 +23,6 @@ const (
 	selectorObject    = "object"
 	selectorProject   = "project"
 	selectorOwner     = "owner"
-	selectorStatus    = "status"
 	selectorRequester = "requester"
 	selectorStatus    = "status"
 	selectorInVersion = "in-version"

--- a/model/trigger/payloads.go
+++ b/model/trigger/payloads.go
@@ -22,6 +22,8 @@ const (
 	selectorID      = "id"
 	selectorObject  = "object"
 	selectorProject = "project"
+	selectorOwner   = "owner"
+	selectorStatus  = "status"
 )
 
 type commonTemplateData struct {

--- a/model/trigger/payloads.go
+++ b/model/trigger/payloads.go
@@ -19,11 +19,12 @@ import (
 const (
 	evergreenHeaderPrefix = "X-Evergreen-"
 
-	selectorID      = "id"
-	selectorObject  = "object"
-	selectorProject = "project"
-	selectorOwner   = "owner"
-	selectorStatus  = "status"
+	selectorID        = "id"
+	selectorObject    = "object"
+	selectorProject   = "project"
+	selectorOwner     = "owner"
+	selectorStatus    = "status"
+	selectorInVersion = "in-version"
 )
 
 type commonTemplateData struct {

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -54,13 +54,6 @@ func (as *APIServer) StartTask(w http.ResponseWriter, r *http.Request) {
 	if len(updates.BuildNewStatus) != 0 {
 		event.LogBuildStateChangeEvent(t.BuildId, updates.BuildNewStatus)
 	}
-	if t.Requester == evergreen.GithubPRRequester && updates.PatchNewStatus == evergreen.PatchStarted {
-		job := units.NewGithubStatusUpdateJobForNewPatch(t.Version)
-		if err = as.queue.Put(job); err != nil {
-			as.LoggedError(w, r, http.StatusInternalServerError, errors.New("error queuing github status api update"))
-			return
-		}
-	}
 
 	h, err := host.FindOne(host.ByRunningTaskId(t.Id))
 	if err != nil {

--- a/service/patch.go
+++ b/service/patch.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
@@ -219,8 +218,6 @@ func (uis *UIServer) schedulePatch(w http.ResponseWriter, r *http.Request) {
 				errors.Wrap(err, "Error finalizing patch"))
 			return
 		}
-
-		event.LogPatchStateChangeEvent(projCtx.Patch.Id.Hex(), projCtx.Patch.Status)
 
 		PushFlash(uis.CookieStore, r, w, NewSuccessFlash("Patch builds are scheduled."))
 		gimlet.WriteJSON(w, struct {

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -109,6 +109,9 @@ func (j *githubStatusUpdateJob) preamble() error {
 		return err
 	}
 	j.urlBase = uiConfig.Url
+	if len(j.urlBase) == 0 {
+		return errors.New("UI URL is empty")
+	}
 
 	if j.sender == nil {
 		var err error

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -278,7 +278,7 @@ func (s *githubStatusUpdateSuite) TestWithGithub() {
 	s.Require().NotNil(lastStatus.Context)
 	s.Require().NotNil(lastStatus.TargetURL)
 
-	s.Equal(githubStatusFailure, *lastStatus.State)
+	s.Equal("failure", *lastStatus.State)
 	s.Equal("finished in 10m0s", *lastStatus.Description)
 	s.Equal("evergreen", *lastStatus.Context)
 	s.Equal(fmt.Sprintf("http://example.com/version/%s", s.patchDoc.Version), *lastStatus.TargetURL)

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -212,6 +212,11 @@ func (s *githubStatusUpdateSuite) TestPreamble() {
 	s.NotEmpty(j.urlBase)
 	s.NotNil(j.sender)
 	s.Equal(s.env, j.env)
+
+	uiConfig := evergreen.UIConfig{}
+	s.NoError(uiConfig.Set())
+
+	s.EqualError(j.preamble(), "UI URL is empty")
 }
 
 func (s *githubStatusUpdateSuite) TestWithGithub() {

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -10,22 +10,27 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/google/go-github/github"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/oauth2"
 	"gopkg.in/mgo.v2/bson"
 )
 
 type githubStatusUpdateSuite struct {
-	suite.Suite
+	env        *mock.Environment
 	patchDoc   *patch.Patch
 	buildDoc   *build.Build
 	cancel     context.CancelFunc
 	testConfig *evergreen.Settings
+
+	suite.Suite
 }
 
 func TestGithubStatusUpdate(t *testing.T) {
@@ -33,20 +38,22 @@ func TestGithubStatusUpdate(t *testing.T) {
 }
 
 func (s *githubStatusUpdateSuite) SetupSuite() {
-	evergreen.ResetEnvironment()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	s.cancel = cancel
-	s.Require().NoError(evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
-}
-
-func (s *githubStatusUpdateSuite) TearDownSuite() {
-	s.cancel()
-	evergreen.ResetEnvironment()
+	testConfig := testutil.TestConfig()
+	db.SetGlobalSessionProvider(testConfig.SessionFactory())
 }
 
 func (s *githubStatusUpdateSuite) SetupTest() {
-	s.NoError(db.ClearCollections(evergreen.ConfigCollection, patch.Collection, patch.IntentCollection, model.ProjectRefCollection))
+	s.NoError(db.ClearCollections(evergreen.ConfigCollection, patch.Collection, patch.IntentCollection, model.ProjectRefCollection, evergreen.ConfigCollection))
+
+	uiConfig := evergreen.UIConfig{}
+	uiConfig.Url = "https://example.com"
+	s.Require().NoError(uiConfig.Set())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+
+	s.env = &mock.Environment{}
+	s.Require().NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
 
 	startTime := time.Now().Truncate(time.Millisecond)
 	id := bson.NewObjectId()
@@ -77,18 +84,25 @@ func (s *githubStatusUpdateSuite) SetupTest() {
 	s.NoError(s.buildDoc.Insert())
 }
 
+func (s *githubStatusUpdateSuite) TearDownTest() {
+	s.cancel()
+	evergreen.ResetEnvironment()
+}
+
 func (s *githubStatusUpdateSuite) TestRunInDegradedMode() {
 	flags := evergreen.ServiceFlags{
 		GithubStatusAPIDisabled: true,
 	}
 	s.Require().NoError(evergreen.SetServiceFlags(flags))
 
-	job := NewGithubStatusUpdateJobForNewPatch(s.patchDoc.Version)
+	job, ok := NewGithubStatusUpdateJobForNewPatch(s.patchDoc.Version).(*githubStatusUpdateJob)
+	s.Require().NotNil(job)
+	s.Require().True(ok)
+	job.env = s.env
 	job.Run(context.Background())
 
 	s.Error(job.Error())
 	s.Contains(job.Error().Error(), "github status updates are disabled, not updating status")
-	s.NoError(db.Clear(evergreen.ConfigCollection))
 }
 
 func (s *githubStatusUpdateSuite) TestForPatchCreated() {
@@ -100,19 +114,20 @@ func (s *githubStatusUpdateSuite) TestForPatchCreated() {
 	s.Require().NotNil(job)
 	s.Require().True(ok)
 	s.Require().Equal(githubUpdateTypeNewPatch, job.UpdateType)
+	job.env = s.env
+	job.Run(context.Background())
+	s.False(job.HasErrors())
 
-	status := githubStatus{}
-	s.NoError(job.fetch(&status))
+	status := s.msgToStatus(s.env.InternalSender)
 
 	s.Equal("evergreen-ci", status.Owner)
 	s.Equal("evergreen", status.Repo)
-	s.Equal(448, status.PRNumber)
 	s.Equal("776f608b5b12cd27b8d931c8ee4ca0c13f857299", status.Ref)
 
-	s.Equal(fmt.Sprintf("/version/%s", s.patchDoc.Version), status.URLPath)
+	s.Equal(fmt.Sprintf("https://example.com/version/%s", s.patchDoc.Version), status.URL)
 	s.Equal("preparing to run tasks", status.Description)
 	s.Equal("evergreen", status.Context)
-	s.Equal("pending", status.State)
+	s.Equal(message.GithubStatePending, status.State)
 }
 
 func (s *githubStatusUpdateSuite) TestForBadConfig() {
@@ -136,19 +151,20 @@ func (s *githubStatusUpdateSuite) TestForBadConfig() {
 	s.Require().NotNil(job)
 	s.Require().True(ok)
 	s.Require().Equal(githubUpdateTypeBadConfig, job.UpdateType)
+	job.env = s.env
+	job.Run(context.Background())
+	s.False(job.HasErrors())
 
-	status := githubStatus{}
-	s.NoError(job.fetch(&status))
+	status := s.msgToStatus(s.env.InternalSender)
 
 	s.Equal("evergreen-ci", status.Owner)
 	s.Equal("evergreen", status.Repo)
-	s.Equal(448, status.PRNumber)
 	s.Equal("776f608b5b12cd27b8d931c8ee4ca0c13f857299", status.Ref)
 
-	s.Equal("/waterfall/mci", status.URLPath)
+	s.Equal("https://example.com/waterfall/mci", status.URL)
 	s.Equal("project config was invalid", status.Description)
 	s.Equal("evergreen", status.Context)
-	s.Equal("failure", status.State)
+	s.Equal(message.GithubStateFailure, status.State)
 }
 
 func (s *githubStatusUpdateSuite) TestRequestForAuth() {
@@ -160,19 +176,42 @@ func (s *githubStatusUpdateSuite) TestRequestForAuth() {
 	s.Require().NotNil(job)
 	s.Require().True(ok)
 	s.Require().Equal(githubUpdateTypeRequestAuth, job.UpdateType)
+	job.env = s.env
+	job.Run(context.Background())
+	s.False(job.HasErrors())
 
-	status := githubStatus{}
-	s.NoError(job.fetch(&status))
+	status := s.msgToStatus(s.env.InternalSender)
 
 	s.Equal("evergreen-ci", status.Owner)
 	s.Equal("evergreen", status.Repo)
-	s.Equal(448, status.PRNumber)
 	s.Equal("776f608b5b12cd27b8d931c8ee4ca0c13f857299", status.Ref)
 
-	s.Equal(fmt.Sprintf("/patch/%s", s.patchDoc.Version), status.URLPath)
+	s.Equal(fmt.Sprintf("https://example.com/patch/%s", s.patchDoc.Version), status.URL)
 	s.Equal("patch must be manually authorized", status.Description)
 	s.Equal("evergreen", status.Context)
-	s.Equal("failure", status.State)
+	s.Equal(message.GithubStateFailure, status.State)
+}
+
+func (s *githubStatusUpdateSuite) msgToStatus(sender *send.InternalSender) *message.GithubStatus {
+	msg, ok := sender.GetMessageSafe()
+	s.Require().True(ok)
+	raw := msg.Message
+	s.Require().NotNil(raw)
+	status, ok := raw.Raw().(*message.GithubStatus)
+	s.Require().True(ok)
+
+	return status
+}
+
+func (s *githubStatusUpdateSuite) TestPreamble() {
+	j := makeGithubStatusUpdateJob()
+	j.env = s.env
+	s.Require().NotNil(j)
+	s.NoError(j.preamble())
+	s.NotNil(j.env)
+	s.NotEmpty(j.urlBase)
+	s.NotNil(j.sender)
+	s.Equal(s.env, j.env)
 }
 
 func (s *githubStatusUpdateSuite) TestWithGithub() {
@@ -181,6 +220,14 @@ func (s *githubStatusUpdateSuite) TestWithGithub() {
 	// this test in the suite will fail after the 1000th time).
 	// It's still useful for manual testing
 	s.T().Skip("Github Status API is limited")
+	evergreen.ResetEnvironment()
+	s.cancel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+
+	s.Require().NoError(evergreen.GetEnvironment().Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+
 	testutil.ConfigureIntegrationTest(s.T(), s.testConfig, "TestWithGithub")
 	evergreen.GetEnvironment().Settings().Credentials = s.testConfig.Credentials
 	evergreen.GetEnvironment().Settings().Ui.Url = "http://example.com"
@@ -210,7 +257,7 @@ func (s *githubStatusUpdateSuite) TestWithGithub() {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token[1]},
 	)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	tc := oauth2.NewClient(ctx, ts)
 	client := github.NewClient(tc)

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -122,7 +122,7 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 			update = NewGithubStatusUpdateJobForExternalPatch(patchDoc.Id.Hex())
 
 		} else {
-			update = NewGithubStatusUpdateJobForPatchWithVersion(patchDoc.Version)
+			update = NewGithubStatusUpdateJobForNewPatch(patchDoc.Id.Hex())
 		}
 		update.Run(ctx)
 		j.AddError(update.Error())

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -265,9 +265,10 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 			PRNumber: patchDoc.GithubPatchData.PRNumber,
 			Ref:      patchDoc.GithubPatchData.HeadHash,
 		})
-		sub := event.NewPatchOutcomeSubscription(j.PatchID.Hex(), ghSub)
-		j.AddError(sub.Upsert())
-		// TODO After EVG:3081 add build subscriptions
+		patchSub := event.NewPatchOutcomeSubscription(j.PatchID.Hex(), ghSub)
+		j.AddError(patchSub.Upsert())
+		buildSub := event.NewBuildOutcomeSubscription(j.PatchID.Hex(), ghSub)
+		j.AddError(buildSub.Upsert())
 	}
 
 	if canFinalize && j.intent.ShouldFinalizePatch() {

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -293,11 +293,12 @@ func (s *PatchIntentUnitsSuite) TestProcessGithubPatchIntent() {
 		s.Require().True(ok)
 
 		s.EqualValues(ghSub.Target, *target)
-		s.Equal(patchDoc.Id.Hex(), out[i].Selectors[0].Data)
 		if out[i].Type == event.ResourceTypePatch {
+			s.Equal(patchDoc.Id.Hex(), out[i].Selectors[0].Data)
 			foundPatch = true
 		}
 		if out[i].Type == event.ResourceTypeBuild {
+			s.NotEqual(patchDoc.Id.Hex(), out[i].Selectors[0].Data)
 			foundBuild = true
 		}
 	}

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -298,7 +298,7 @@ func (s *PatchIntentUnitsSuite) TestProcessGithubPatchIntent() {
 			foundPatch = true
 		}
 		if out[i].Type == event.ResourceTypeBuild {
-			s.NotEqual(patchDoc.Id.Hex(), out[i].Selectors[0].Data)
+			s.Equal(patchDoc.Version, out[i].Selectors[0].Data)
 			foundBuild = true
 		}
 	}

--- a/vendor/github.com/mongodb/grip/send/github_status.go
+++ b/vendor/github.com/mongodb/grip/send/github_status.go
@@ -129,7 +129,7 @@ func (s *githubStatusMessageLogger) githubMessageFieldsToStatus(m *message.Field
 	status := &github.RepoStatus{
 		State:       state,
 		Context:     context,
-		URL:         URL,
+		TargetURL:   URL,
 		Description: description,
 	}
 
@@ -152,9 +152,9 @@ func githubStatusMessagePayloadToRepoStatus(c *message.GithubStatus) *github.Rep
 	}
 
 	s := &github.RepoStatus{
-		Context: github.String(c.Context),
-		State:   github.String(string(c.State)),
-		URL:     github.String(c.URL),
+		Context:   github.String(c.Context),
+		State:     github.String(string(c.State)),
+		TargetURL: github.String(c.URL),
 	}
 	if len(c.Description) > 0 {
 		s.Description = github.String(c.Description)


### PR DESCRIPTION
The remaining code in units/github_status_api can't be fully integrated into event driven notifications.

Bad config -> no patch is created.

For Auth request and patch pending, putting these into Event driven notifications risks out of order notifications, and users will not receive any immediate feedback that Evergreen has been notified about the PR.