### PR TITLE
EVG-2719 Do not apply patches with --whitespace=fix

### DIFF
--- a/command/git.go
+++ b/command/git.go
@@ -387,7 +387,7 @@ func getApplyCommand(patchFile string) (string, error) {
 		return fmt.Sprintf(`git -c "user.name=Evergreen Agent" -c "user.email=no-reply@evergreen.mongodb.com" am < '%s'`, patchFile), nil
 	}
 
-	return fmt.Sprintf("git apply --binary --whitespace=fix --index < '%s'", patchFile), nil
+	return fmt.Sprintf("git apply --binary --index < '%s'", patchFile), nil
 }
 
 // getPatchCommands, given a module patch of a patch, will return the appropriate list of commands that


### PR DESCRIPTION
- Staging patch created from windows: https://evergreen-staging.corp.mongodb.com/version/5b16cc0bb237362c41d7e4dc
- Staging patch created from OS X: https://evergreen-staging.corp.mongodb.com/version/5b16cdc897b1d35f01dc4ede

This patch contained whitespace changes and was successfully applied. Note that lint should have failed in the above patches, but it didn't because we don't run gofmt through our linter.
Additionally, I've confirmed that we can apply patches made in OS X, on Windows/OSX/Linux and create a patch from windows (with whitespace changes) and apply them on Windows/OSX/Linux 