### PR TITLE
EVG-3468 Enable goimports in gometalinter

### DIFF
--- a/makefile
+++ b/makefile
@@ -67,6 +67,7 @@ lintArgs += --exclude=".* \(SA5001\) \(megacheck\)$$"
 lintArgs += --exclude="declaration of \"assert\" shadows declaration at .*_test.go:"
 lintArgs += --exclude="declaration of \"require\" shadows declaration at .*_test.go:"
 lintArgs += --linter="evg:$(gopath)/bin/evg-lint:PATH:LINE:COL:MESSAGE" --enable=evg
+lintArgs += --enable=goimports
 # end lint configuration
 
 

--- a/scripts/generate-lint.go
+++ b/scripts/generate-lint.go
@@ -29,6 +29,7 @@ const (
 // directory. First, it tries diffing changed files against the merge base. If
 // there are no changes, this is not a patch build, so it diffs HEAD against HEAD~.
 func whatChanged() ([]string, error) {
+	return nil, nil
 	mergeBaseCmd := exec.Command("git", "merge-base", "master@{upstream}", "HEAD")
 	base, err := mergeBaseCmd.Output()
 	if err != nil {
@@ -113,6 +114,7 @@ func generateTasks() (map[string][]map[string]interface{}, error) {
 		for _, p := range split {
 			if !strings.Contains(p, "vendor") && strings.Contains(p, "evergreen") {
 				if p == packagePrefix {
+					targets = append(targets, "evergreen")
 					continue
 				}
 				p = strings.TrimPrefix(p, packagePrefix)

--- a/scripts/generate-lint.go
+++ b/scripts/generate-lint.go
@@ -29,7 +29,6 @@ const (
 // directory. First, it tries diffing changed files against the merge base. If
 // there are no changes, this is not a patch build, so it diffs HEAD against HEAD~.
 func whatChanged() ([]string, error) {
-	return nil, nil
 	mergeBaseCmd := exec.Command("git", "merge-base", "master@{upstream}", "HEAD")
 	base, err := mergeBaseCmd.Output()
 	if err != nil {


### PR DESCRIPTION
Note, there is a temporary hack in scripts/generate-lint.go to force the lint to run on everything. I'll undo that before merge.