### PR TITLE
EVG-3423 add jobs updating last container finish time for parent hosts

### DIFF
--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -7,7 +7,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -496,9 +496,10 @@ func lastContainerFinishTimePipeline() []bson.M {
 	const output string = "finish_time"
 	return []bson.M{
 		{
-			// matches all containers
+			// matches all running containers
 			"$match": bson.M{
 				ParentIDKey: bson.M{"$exists": true},
+				StatusKey:   evergreen.HostRunning,
 			},
 		},
 		{

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -749,14 +749,15 @@ func CountInactiveHostsByProvider() ([]InactiveHostCounts, error) {
 	return counts, nil
 }
 
-// FindAllContainers finds all the containers
-func FindAllContainers() ([]Host, error) {
+// FindAllRunningContainers finds all running containers
+func FindAllRunningContainers() ([]Host, error) {
 	query := db.Query(bson.M{
+		StatusKey:      evergreen.HostRunning,
 		ContainerIDKey: bson.M{"$exists": true},
 	})
 	hosts, err := Find(query)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error finding containers")
+		return nil, errors.Wrap(err, "Error finding running containers")
 	}
 
 	return hosts, nil

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -776,6 +776,22 @@ func FindAllRunningParents() ([]Host, error) {
 	return hosts, nil
 }
 
+// FindAllRunningParentsOrdered finds all running hosts with child containers,
+// sorted in order of soonest  to latest LastContainerFinishTime
+func FindAllRunningParentsOrdered() ([]Host, error) {
+	query := db.Query(bson.M{
+		StatusKey:        evergreen.HostRunning,
+		HasContainersKey: true,
+	})
+	querySorted := query.Sort([]string{LastContainerFinishTimeKey})
+	hosts, err := Find(querySorted)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error finding ordered running parents")
+	}
+
+	return hosts, nil
+}
+
 // GetContainers finds all the containers belonging to this host
 // errors if this host is not a parent
 func (h *Host) GetContainers() ([]Host, error) {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -814,21 +814,7 @@ func (h *Host) GetParent() (*Host, error) {
 	return host, nil
 }
 
-// AggregateLastContainerFinishTimes returns the latest finish time for each host with containers
-// errors if aggregation fails
-func AggregateLastContainerFinishTimes() ([]FinishTime, error) {
-
-	var times []FinishTime
-	err := db.Aggregate(Collection, lastContainerFinishTimePipeline(), &times)
-	if err != nil {
-		return nil, errors.Wrap(err, "error aggregating parent finish times")
-	}
-	return times, nil
-
-}
-
-// updateLastContainerFinishTime updates latest finish time for a host with containers
-// errors if update operation fails
+// UpdateLastContainerFinishTime updates latest finish time for a host with containers
 func (h *Host) UpdateLastContainerFinishTime(t time.Time) error {
 
 	selector := bson.M{

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -783,9 +783,8 @@ func FindAllRunningParentsOrdered() ([]Host, error) {
 	query := db.Query(bson.M{
 		StatusKey:        evergreen.HostRunning,
 		HasContainersKey: true,
-	})
-	querySorted := query.Sort([]string{LastContainerFinishTimeKey})
-	hosts, err := Find(querySorted)
+	}).Sort([]string{LastContainerFinishTimeKey})
+	hosts, err := Find(query)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error finding ordered running parents")
 	}
@@ -844,8 +843,7 @@ func (h *Host) UpdateLastContainerFinishTime(t time.Time) error {
 		},
 	}
 
-	err := UpdateOne(selector, update)
-	if err != nil {
+	if err := UpdateOne(selector, update); err != nil {
 		return errors.Wrapf(err, "error updating finish time for host %s", h.Id)
 	}
 

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1052,7 +1052,7 @@ func TestInactiveHostCountPipeline(t *testing.T) {
 	}
 }
 
-func TestFindAllContainers(t *testing.T) {
+func TestFindAllRunningContainers(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 
@@ -1121,12 +1121,12 @@ func TestFindAllContainers(t *testing.T) {
 	assert.NoError(host7.Insert())
 	assert.NoError(host8.Insert())
 
-	containers, err := FindAllContainers()
+	containers, err := FindAllRunningContainers()
 	assert.NoError(err)
-	assert.Equal(5, len(containers))
+	assert.Equal(2, len(containers))
 }
 
-func TestFindAllContainersEmpty(t *testing.T) {
+func TestFindAllRunningContainersEmpty(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 
@@ -1185,7 +1185,7 @@ func TestFindAllContainersEmpty(t *testing.T) {
 	assert.NoError(host7.Insert())
 	assert.NoError(host8.Insert())
 
-	containers, err := FindAllContainers()
+	containers, err := FindAllRunningContainers()
 	assert.NoError(err)
 	assert.Empty(containers)
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1640,8 +1640,7 @@ func TestLastContainerFinishTimePipeline(t *testing.T) {
 	assert.NoError(t6.Insert())
 
 	var out []FinishTime
-	var results map[string]time.Time
-	results = make(map[string]time.Time)
+	var results = make(map[string]time.Time)
 
 	err := db.Aggregate(Collection, lastContainerFinishTimePipeline(), &out)
 	assert.NoError(err)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1272,16 +1272,14 @@ func TestFindAllRunningParentsOrdered(t *testing.T) {
 		LastContainerFinishTime: time.Now().Add(10 * time.Minute),
 	}
 	host2 := &Host{
-		Id:                      "host2",
-		Distro:                  distro.Distro{Id: d1},
-		Status:                  evergreen.HostStarting,
-		LastContainerFinishTime: time.Now().Add(10 * time.Minute),
+		Id:     "host2",
+		Distro: distro.Distro{Id: d1},
+		Status: evergreen.HostStarting,
 	}
 	host3 := &Host{
-		Id:                      "host3",
-		Distro:                  distro.Distro{Id: d1},
-		Status:                  evergreen.HostTerminated,
-		LastContainerFinishTime: time.Now().Add(10 * time.Minute),
+		Id:     "host3",
+		Distro: distro.Distro{Id: d1},
+		Status: evergreen.HostTerminated,
 	}
 	host4 := &Host{
 		Id:                      "host4",
@@ -1298,10 +1296,9 @@ func TestFindAllRunningParentsOrdered(t *testing.T) {
 		LastContainerFinishTime: time.Now().Add(5 * time.Minute),
 	}
 	host6 := &Host{
-		Id:                      "host6",
-		Distro:                  distro.Distro{Id: d2},
-		Status:                  evergreen.HostProvisioning,
-		LastContainerFinishTime: time.Now().Add(20 * time.Minute),
+		Id:     "host6",
+		Distro: distro.Distro{Id: d2},
+		Status: evergreen.HostProvisioning,
 	}
 	host7 := &Host{
 		Id:                      "host7",

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1251,9 +1251,80 @@ func TestFindAllRunningParents(t *testing.T) {
 	assert.NoError(host7.Insert())
 	assert.NoError(host8.Insert())
 
-	containers, err := FindAllRunningParents()
+	hosts, err := FindAllRunningParents()
 	assert.NoError(err)
-	assert.Equal(3, len(containers))
+	assert.Equal(3, len(hosts))
+
+}
+
+func TestFindAllRunningParentsOrdered(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(Collection))
+
+	const d1 = "distro1"
+	const d2 = "distro2"
+
+	host1 := &Host{
+		Id:                      "host1",
+		Distro:                  distro.Distro{Id: d1},
+		Status:                  evergreen.HostRunning,
+		HasContainers:           true,
+		LastContainerFinishTime: time.Now().Add(10 * time.Minute),
+	}
+	host2 := &Host{
+		Id:                      "host2",
+		Distro:                  distro.Distro{Id: d1},
+		Status:                  evergreen.HostStarting,
+		LastContainerFinishTime: time.Now().Add(10 * time.Minute),
+	}
+	host3 := &Host{
+		Id:                      "host3",
+		Distro:                  distro.Distro{Id: d1},
+		Status:                  evergreen.HostTerminated,
+		LastContainerFinishTime: time.Now().Add(10 * time.Minute),
+	}
+	host4 := &Host{
+		Id:                      "host4",
+		Distro:                  distro.Distro{Id: d1},
+		Status:                  evergreen.HostRunning,
+		HasContainers:           true,
+		LastContainerFinishTime: time.Now().Add(30 * time.Minute),
+	}
+	host5 := &Host{
+		Id:                      "host5",
+		Distro:                  distro.Distro{Id: d2},
+		Status:                  evergreen.HostRunning,
+		HasContainers:           true,
+		LastContainerFinishTime: time.Now().Add(5 * time.Minute),
+	}
+	host6 := &Host{
+		Id:                      "host6",
+		Distro:                  distro.Distro{Id: d2},
+		Status:                  evergreen.HostProvisioning,
+		LastContainerFinishTime: time.Now().Add(20 * time.Minute),
+	}
+	host7 := &Host{
+		Id:                      "host7",
+		Distro:                  distro.Distro{Id: d2},
+		Status:                  evergreen.HostRunning,
+		HasContainers:           true,
+		LastContainerFinishTime: time.Now().Add(15 * time.Minute),
+	}
+
+	assert.NoError(host1.Insert())
+	assert.NoError(host2.Insert())
+	assert.NoError(host3.Insert())
+	assert.NoError(host4.Insert())
+	assert.NoError(host5.Insert())
+	assert.NoError(host6.Insert())
+	assert.NoError(host7.Insert())
+
+	hosts, err := FindAllRunningParentsOrdered()
+	assert.NoError(err)
+	assert.Equal(hosts[0].Id, host5.Id)
+	assert.Equal(hosts[1].Id, host1.Id)
+	assert.Equal(hosts[2].Id, host7.Id)
+	assert.Equal(hosts[3].Id, host4.Id)
 
 }
 

--- a/operations/service.go
+++ b/operations/service.go
@@ -81,7 +81,8 @@ func startSystemCronJobs(ctx context.Context, env evergreen.Environment) {
 		units.PopulateHostMonitoring(env),
 		units.PopulateTaskMonitoring(),
 		units.PopulateEventAlertProcessing(1),
-		units.PopulateBackgroundStatsJobs(env, 0)))
+		units.PopulateBackgroundStatsJobs(env, 0))),
+		units.PopulateLastContainerFinishTimeJobs(env,)
 
 	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), 15*time.Second, time.Now(), opts, amboy.GroupQueueOperationFactory(
 		units.PopulateHostSetupJobs(env, 0),

--- a/operations/service.go
+++ b/operations/service.go
@@ -82,7 +82,7 @@ func startSystemCronJobs(ctx context.Context, env evergreen.Environment) {
 		units.PopulateTaskMonitoring(),
 		units.PopulateEventAlertProcessing(1),
 		units.PopulateBackgroundStatsJobs(env, 0),
-		units.PopulateLastContainerFinishTimeJobs(env)))
+		units.PopulateLastContainerFinishTimeJobs()))
 
 	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), 15*time.Second, time.Now(), opts, amboy.GroupQueueOperationFactory(
 		units.PopulateHostSetupJobs(env, 0),

--- a/operations/service.go
+++ b/operations/service.go
@@ -81,8 +81,8 @@ func startSystemCronJobs(ctx context.Context, env evergreen.Environment) {
 		units.PopulateHostMonitoring(env),
 		units.PopulateTaskMonitoring(),
 		units.PopulateEventAlertProcessing(1),
-		units.PopulateBackgroundStatsJobs(env, 0))),
-		units.PopulateLastContainerFinishTimeJobs(env,)
+		units.PopulateBackgroundStatsJobs(env, 0),
+		units.PopulateLastContainerFinishTimeJobs(env)))
 
 	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), 15*time.Second, time.Now(), opts, amboy.GroupQueueOperationFactory(
 		units.PopulateHostSetupJobs(env, 0),

--- a/units/crons.go
+++ b/units/crons.go
@@ -309,25 +309,12 @@ func PopulateIdleHostJobs(env evergreen.Environment) amboy.QueueOperation {
 	}
 }
 
-func PopulateLastContainerFinishTimeJobs(env evergreen.Environment) amboy.QueueOperation {
+func PopulateLastContainerFinishTimeJobs() amboy.QueueOperation {
 	return func(queue amboy.Queue) error {
-		flags, err := evergreen.GetServiceFlags()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		if flags.MonitorDisabled {
-			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
-				"message": "monitor is disabled",
-				"impact":  "not submitting updating last container finish times",
-				"mode":    "degraded",
-			})
-			return nil
-		}
 
 		catcher := grip.NewBasicCatcher()
 		ts := util.RoundPartOfHour(1).Format(tsFormat)
-		err = queue.Put(NewLastContainerFinishTimeJob(env, ts))
+		err := queue.Put(NewLastContainerFinishTimeJob(ts))
 		catcher.Add(err)
 
 		return catcher.Resolve()

--- a/units/crons.go
+++ b/units/crons.go
@@ -309,6 +309,31 @@ func PopulateIdleHostJobs(env evergreen.Environment) amboy.QueueOperation {
 	}
 }
 
+func PopulateLastContainerFinishTimeJobs(env evergreen.Environment) amboy.QueueOperation {
+	return func(queue amboy.Queue) error {
+		flags, err := evergreen.GetServiceFlags()
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		if flags.MonitorDisabled {
+			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
+				"message": "monitor is disabled",
+				"impact":  "not submitting updating last container finish times",
+				"mode":    "degraded",
+			})
+			return nil
+		}
+
+		catcher := grip.NewBasicCatcher()
+		ts := util.RoundPartOfHour(1).Format(tsFormat)
+		err = queue.Put(NewLastContainerFinishTimeJob(env, ts))
+		catcher.Add(err)
+
+		return catcher.Resolve()
+	}
+}
+
 func PopulateSchedulerJobs(env evergreen.Environment) amboy.QueueOperation {
 	return func(queue amboy.Queue) error {
 		flags, err := evergreen.GetServiceFlags()

--- a/units/crons.go
+++ b/units/crons.go
@@ -311,7 +311,6 @@ func PopulateIdleHostJobs(env evergreen.Environment) amboy.QueueOperation {
 
 func PopulateLastContainerFinishTimeJobs() amboy.QueueOperation {
 	return func(queue amboy.Queue) error {
-
 		catcher := grip.NewBasicCatcher()
 		ts := util.RoundPartOfHour(1).Format(tsFormat)
 		err := queue.Put(NewLastContainerFinishTimeJob(ts))

--- a/units/host_monitoring_last_container_finish_time.go
+++ b/units/host_monitoring_last_container_finish_time.go
@@ -1,0 +1,77 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/dependency"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+)
+
+const (
+	lastContainerFinishTimeJobName = "last-container-finish-time"
+)
+
+func init() {
+	registry.AddJobType(lastContainerFinishTimeJobName, func() amboy.Job {
+		return makeIdleHostJob()
+	})
+
+}
+
+type lastContainerFinishTimeJob struct {
+	job.Base   `bson:"metadata" json:"metadata" yaml:"metadata"`
+	Terminated bool `bson:"terminated" json:"terminated" yaml:"terminated"`
+
+	env      evergreen.Environment
+	settings *evergreen.Settings
+}
+
+func makeLastContainerFinishTimeJob() *lastContainerFinishTimeJob {
+	j := &lastContainerFinishTimeJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    lastContainerFinishTimeJobName,
+				Version: 0,
+			},
+		},
+	}
+	j.SetDependency(dependency.NewAlways())
+
+	return j
+}
+
+func NewLastContainerFinishTimeJob(env evergreen.Environment, id string) amboy.Job {
+	j := makeLastContainerFinishTimeJob()
+
+	j.SetID(fmt.Sprintf("%s.%s", lastContainerFinishTimeJobName, id))
+	return j
+}
+
+func (j *lastContainerFinishTimeJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+
+	if j.settings == nil {
+		j.settings = j.env.Settings()
+	}
+
+	// get pairs of host ID and finish time for each host with containers
+	times, err := host.AggregateLastContainerFinishTimes()
+	j.AddError(err)
+
+	// update last container finish time for each host with containers
+	for _, time := range times {
+		h, err := host.FindOneId(time.Id)
+		j.AddError(err)
+		err = h.UpdateLastContainerFinishTime(time.FinishTime)
+		j.AddError(err)
+	}
+}

--- a/units/host_monitoring_last_container_finish_time_test.go
+++ b/units/host_monitoring_last_container_finish_time_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -22,10 +21,6 @@ func TestLastContainerFinishTimeJob(t *testing.T) {
 	assert := assert.New(t)
 	testConfig := testutil.TestConfig()
 	db.SetGlobalSessionProvider(testConfig.SessionFactory())
-
-	env := &mock.Environment{
-		EvergreenSettings: testConfig,
-	}
 
 	mockCloud := cloud.GetMockProvider()
 	mockCloud.Reset()
@@ -78,7 +73,7 @@ func TestLastContainerFinishTimeJob(t *testing.T) {
 	}
 	assert.NoError(t2.Insert())
 
-	j := NewLastContainerFinishTimeJob(env, "one")
+	j := NewLastContainerFinishTimeJob("one")
 	assert.False(j.Status().Completed)
 
 	j.Run(context.Background())

--- a/units/host_monitoring_last_container_finish_time_test.go
+++ b/units/host_monitoring_last_container_finish_time_test.go
@@ -1,0 +1,94 @@
+package units
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/util"
+)
+
+func TestLastContainerFinishTimeJob(t *testing.T) {
+
+	assert := assert.New(t)
+	testConfig := testutil.TestConfig()
+	db.SetGlobalSessionProvider(testConfig.SessionFactory())
+
+	env := &mock.Environment{
+		EvergreenSettings: testConfig,
+	}
+
+	mockCloud := cloud.GetMockProvider()
+	mockCloud.Reset()
+
+	startTimeOne := time.Now()
+	startTimeTwo := time.Now().Add(-10 * time.Minute)
+	durationOne := 5 * time.Minute
+	durationTwo := 30 * time.Minute
+
+	testutil.HandleTestingErr(db.Clear(host.Collection), t, "error clearing %v collections", host.Collection)
+	testutil.HandleTestingErr(db.Clear(task.Collection), t, "Error clearing '%v' collection", task.Collection)
+
+	// this host p1 is the parent of hosts h1 and h2 below
+	p1 := &host.Host{
+		Id:            "p1",
+		Status:        evergreen.HostRunning,
+		HasContainers: true,
+	}
+	assert.NoError(p1.Insert())
+
+	h1 := &host.Host{
+		Id:          "h1",
+		Status:      evergreen.HostRunning,
+		ParentID:    "p1",
+		RunningTask: "t1",
+	}
+	assert.NoError(h1.Insert())
+	h2 := &host.Host{
+		Id:          "h2",
+		Status:      evergreen.HostRunning,
+		ParentID:    "p1",
+		RunningTask: "t2",
+	}
+	assert.NoError(h2.Insert())
+
+	t1 := &task.Task{
+		Id: "t1",
+		DurationPrediction: util.CachedDurationValue{
+			Value: durationOne,
+		},
+		StartTime: startTimeOne,
+	}
+	assert.NoError(t1.Insert())
+	t2 := &task.Task{
+		Id: "t2",
+		DurationPrediction: util.CachedDurationValue{
+			Value: durationTwo,
+		},
+		StartTime: startTimeTwo,
+	}
+	assert.NoError(t2.Insert())
+
+	j := NewLastContainerFinishTimeJob(env, "one")
+	assert.False(j.Status().Completed)
+
+	j.Run(context.Background())
+
+	assert.NoError(j.Error())
+	assert.True(j.Status().Completed)
+
+	// should return parent host with LastContainerFinishTime sent to the later FinishTime
+	parent1, err := host.FindOne(host.ById("p1"))
+	assert.NoError(err)
+	assert.WithinDuration(startTimeTwo.Add(durationTwo), parent1.LastContainerFinishTime, time.Millisecond)
+
+}


### PR DESCRIPTION
Implemented first part of ticket -- creating necessary jobs, model updates, and functions to compute and cache last container finish time for all hosts with containers.