### PR TITLE
EVG-3541: look for a task name ending with _WT if the current task name is not found

### DIFF
--- a/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
+++ b/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
@@ -346,6 +346,12 @@ mciModule.factory('PerfDiscoveryDataService', function(
                 buildName: task.buildName,
                 taskName: task.taskName,
               })
+              // the name may have been changed to remove '_WT'
+              if (!baseline)
+                baseline = _.findWhere(promise.baselineTasks, {
+                  buildName: task.buildName,
+                  taskName: task.taskName + '_WT',
+                })
               // Skip items with no baseline results
               if (!baseline) return null
 


### PR DESCRIPTION
I am not convinced that this is a full fix, but it seems to be enough to get more tasks on the perf discovery page.