### PR TITLE
EVG-3155 Github Patch intents are being created for projects which don't have pr testing enabled

### DIFF
--- a/rest/data/patch_intent.go
+++ b/rest/data/patch_intent.go
@@ -3,6 +3,7 @@ package data
 import (
 	"net/http"
 
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/rest"
 	"github.com/evergreen-ci/evergreen/units"
@@ -16,6 +17,22 @@ import (
 type DBPatchIntentConnector struct{}
 
 func (p *DBPatchIntentConnector) AddPatchIntent(intent patch.Intent, queue amboy.Queue) error {
+	patchDoc := intent.NewPatch()
+	projectRef, err := model.FindOneProjectRefByRepoAndBranchWithPRTesting(patchDoc.GithubPatchData.BaseOwner,
+		patchDoc.GithubPatchData.BaseRepo, patchDoc.GithubPatchData.BaseBranch)
+	if err != nil {
+		return &rest.APIError{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "failed to fetch project_ref",
+		}
+	}
+	if projectRef == nil {
+		return &rest.APIError{
+			StatusCode: http.StatusUnprocessableEntity,
+			Message:    "cannot map pull request to project",
+		}
+	}
+
 	if err := intent.Insert(); err != nil {
 		return &rest.APIError{
 			StatusCode: http.StatusInternalServerError,

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -441,14 +441,6 @@ func (j *patchIntentProcessor) buildGithubPatchDoc(ctx context.Context, patchDoc
 			patchDoc.GithubPatchData.BaseBranch)
 	}
 
-	projectVars, err := model.FindOneProjectVars(projectRef.Identifier)
-	if err != nil {
-		return false, errors.Wrapf(err, "Could not find project vars for project '%s'", projectRef.Identifier)
-	}
-	if projectVars == nil {
-		return false, errors.Errorf("Could not find project vars for project '%s'", projectRef.Identifier)
-	}
-
 	isMember, err := authAndFetchPRMergeBase(ctx, patchDoc, mustBeMemberOfOrg,
 		patchDoc.GithubPatchData.Author, githubOauthToken)
 	if err != nil {


### PR DESCRIPTION
I'm deleting the block in patch_intents.go because I found out that its value was unused while comparing the logic to patch intents.