### PR TITLE
EVG-3455 Remove Undispatched status from task.IsFinished

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -226,10 +226,9 @@ func IsAbortable(t Task) bool {
 }
 
 // IsFinished returns true if the project is no longer running
-func (t Task) IsFinished() bool {
+func (t *Task) IsFinished() bool {
 	return t.Status == evergreen.TaskFailed ||
 		t.Status == evergreen.TaskSucceeded ||
-		(t.Status == evergreen.TaskUndispatched && !util.IsZeroTime(t.DispatchTime)) ||
 		t.Status == evergreen.TaskSystemFailed ||
 		t.Status == evergreen.TaskSystemTimedOut ||
 		t.Status == evergreen.TaskSystemUnresponse ||

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -527,6 +527,13 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 
 			// update the build's status when a test task isn't successful
 			if t.Status != evergreen.TaskSucceeded {
+				err = b.UpdateStatus(evergreen.BuildFailed)
+				if err != nil {
+					err = errors.Wrap(err, "Error updating build status")
+					grip.Error(err)
+					return err
+				}
+
 				failedTask = true
 				if t.DisplayName == evergreen.CompileStage {
 					buildComplete = true

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -477,17 +477,6 @@ func updateMakespans(b *build.Build) error {
 	return errors.WithStack(b.UpdateMakespans(depPath.TotalTime, CalculateActualMakespan(tasks)))
 }
 
-func isUnexpectedFailStatus(status string) bool {
-	isExpectedFailStatus := status == evergreen.TaskFailed ||
-		status == evergreen.TaskSucceeded ||
-		status == evergreen.TaskSystemFailed ||
-		status == evergreen.TaskSystemTimedOut ||
-		status == evergreen.TaskSystemUnresponse ||
-		status == evergreen.TaskTestTimedOut
-
-	return !isExpectedFailStatus
-}
-
 // UpdateBuildStatusForTask finds all the builds for a task and updates the
 // status of the build based on the task's status.
 func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) error {
@@ -524,15 +513,6 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 			if err != nil {
 				return err
 			}
-			grip.ErrorWhen(isUnexpectedFailStatus(t.Status), message.Fields{
-				"lookhere":           "evg-3455",
-				"task_id":            t.Id,
-				"task_status":        t.Status,
-				"task_dispatch_time": t.DispatchTime,
-				"task_is_display":    t.DisplayOnly,
-				"task_is_execution":  displayTask != nil,
-				"execution_tasks":    t.ExecutionTasks,
-			})
 			if displayTask != nil {
 				err = displayTask.UpdateDisplayTask()
 				if err != nil {
@@ -540,14 +520,6 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 				}
 				t = *displayTask
 				status = t.Status
-				grip.ErrorWhen(isUnexpectedFailStatus(t.Status), message.Fields{
-					"lookhere":           "evg-3455",
-					"task_id":            t.Id,
-					"task_status":        t.Status,
-					"task_dispatch_time": t.DispatchTime,
-					"task_is_display":    t.DisplayOnly,
-					"execution_tasks":    t.ExecutionTasks,
-				})
 				if t.IsFinished() {
 					continue
 				}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -504,45 +504,44 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 
 	// update the build's status based on tasks for this build
 	for _, t := range buildTasks {
-		if !t.IsFinished() {
-			continue
-		}
-		var displayTask *task.Task
-		status := ""
-		finishedTasks++
+		if t.IsFinished() {
+			var displayTask *task.Task
+			status := ""
+			finishedTasks++
 
-		displayTask, err = t.GetDisplayTask()
-		if err != nil {
-			return err
-		}
-		if displayTask != nil {
-			err = displayTask.UpdateDisplayTask()
+			displayTask, err = t.GetDisplayTask()
 			if err != nil {
 				return err
 			}
-			t = *displayTask
-			status = t.Status
-			if t.IsFinished() {
-				continue
+			if displayTask != nil {
+				err = displayTask.UpdateDisplayTask()
+				if err != nil {
+					return err
+				}
+				t = *displayTask
+				status = t.Status
+				if t.IsFinished() {
+					continue
+				}
 			}
-		}
 
-		// update the build's status when a test task isn't successful
-		if t.Status != evergreen.TaskSucceeded {
-			failedTask = true
-			if t.DisplayName == evergreen.CompileStage {
-				buildComplete = true
-				break
+			// update the build's status when a test task isn't successful
+			if t.Status != evergreen.TaskSucceeded {
+				failedTask = true
+				if t.DisplayName == evergreen.CompileStage {
+					buildComplete = true
+					break
+				}
 			}
-		}
 
-		// update the cached version of the task, in its build document
-		if status == "" {
-			status = t.Details.Status
-		}
-		err = build.SetCachedTaskFinished(t.BuildId, t.Id, status, &t.Details, t.TimeTaken)
-		if err != nil {
-			return fmt.Errorf("error updating build: %v", err.Error())
+			// update the cached version of the task, in its build document
+			if status == "" {
+				status = t.Details.Status
+			}
+			err = build.SetCachedTaskFinished(t.BuildId, t.Id, status, &t.Details, t.TimeTaken)
+			if err != nil {
+				return fmt.Errorf("error updating build: %v", err.Error())
+			}
 		}
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -504,51 +504,45 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 
 	// update the build's status based on tasks for this build
 	for _, t := range buildTasks {
-		if t.IsFinished() {
-			var displayTask *task.Task
-			status := ""
-			finishedTasks++
+		if !t.IsFinished() {
+			continue
+		}
+		var displayTask *task.Task
+		status := ""
+		finishedTasks++
 
-			displayTask, err = t.GetDisplayTask()
+		displayTask, err = t.GetDisplayTask()
+		if err != nil {
+			return err
+		}
+		if displayTask != nil {
+			err = displayTask.UpdateDisplayTask()
 			if err != nil {
 				return err
 			}
-			if displayTask != nil {
-				err = displayTask.UpdateDisplayTask()
-				if err != nil {
-					return err
-				}
-				t = *displayTask
-				status = t.Status
-				if t.IsFinished() {
-					continue
-				}
+			t = *displayTask
+			status = t.Status
+			if t.IsFinished() {
+				continue
 			}
+		}
 
-			// update the build's status when a test task isn't successful
-			if t.Status != evergreen.TaskSucceeded {
-				err = b.UpdateStatus(evergreen.BuildFailed)
-				if err != nil {
-					err = errors.Wrap(err, "Error updating build status")
-					grip.Error(err)
-					return err
-				}
+		// update the build's status when a test task isn't successful
+		if t.Status != evergreen.TaskSucceeded {
+			failedTask = true
+			if t.DisplayName == evergreen.CompileStage {
+				buildComplete = true
+				break
+			}
+		}
 
-				failedTask = true
-				if t.DisplayName == evergreen.CompileStage {
-					buildComplete = true
-					break
-				}
-			}
-
-			// update the cached version of the task, in its build document
-			if status == "" {
-				status = t.Details.Status
-			}
-			err = build.SetCachedTaskFinished(t.BuildId, t.Id, status, &t.Details, t.TimeTaken)
-			if err != nil {
-				return fmt.Errorf("error updating build: %v", err.Error())
-			}
+		// update the cached version of the task, in its build document
+		if status == "" {
+			status = t.Details.Status
+		}
+		err = build.SetCachedTaskFinished(t.BuildId, t.Id, status, &t.Details, t.TimeTaken)
+		if err != nil {
+			return fmt.Errorf("error updating build: %v", err.Error())
 		}
 	}
 


### PR DESCRIPTION
So here's the deal: our task model assumes that a status of failed or succeeded means the build is finished, which turn makes the version or patch as finished, but we mark builds as failed the second we see a non-successful task. 

In theory, this will fix things, but I need to throw this in staging to confirm. I also think I'll need to do a javascript/front end fix, so that builds with one failed task, and all others in progress are marked as failed.

Lastly, I removed the UndispatchedTime line because it no longer seems relevant, but I'll be doing some more investigation into that before merging.