### PR TITLE
EVG-3666 stop Evergreen from SSH-ing into host if teardown script empty

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -248,6 +248,10 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 }
 
 func runHostTeardown(ctx context.Context, h *host.Host, cloudHost *cloud.CloudHost) error {
+	if h.Distro.Teardown == "" {
+		return nil
+	}
+
 	sshOptions, err := cloudHost.GetSSHOptions()
 	if err != nil {
 		return errors.Wrapf(err, "error getting ssh options for host %s", h.Id)


### PR DESCRIPTION
This is an issue I noticed when investigating whether Evergreen already terminates idle containers. Currently, Evergreen does not check if the teardown script is empty before connecting to the host via SSH. This creates a lot of unnecessary overhead when there are no teardown scripts (which will be the case for containers).