### PR TITLE
EVG-3661 generate host secret for Docker container hosts

### DIFF
--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -190,6 +190,13 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, h *host.Host, na
 		pathToExecutable += ".exe"
 	}
 
+	// Generate the host secret for container if none exists.
+	if h.Secret == "" {
+		if err = h.CreateSecret(); err != nil {
+			return errors.Wrapf(err, "creating secret for %s", h.Id)
+		}
+	}
+
 	// Build Evergreen agent command.
 	agentCmdParts := []string{
 		pathToExecutable,


### PR DESCRIPTION
Tiny change -- just generating a host secret for the new container before starting the agent. This is necessary because the "evergreen agent" command requires a non-empty host secret flag.