### PR TITLE
EVG-3680: generate unique names for S3 integration tests

### DIFF
--- a/thirdparty/s3_test.go
+++ b/thirdparty/s3_test.go
@@ -32,12 +32,12 @@ func TestPutS3File(t *testing.T) {
 	}
 
 	uniqueID := util.RandomString()
-	sourceURL += uniqueID
-	err = PutS3File(auth, tempfile.Name(), sourceURL, "application/x-tar", "public-read")
+	source := sourceURL + uniqueID
+	err = PutS3File(auth, tempfile.Name(), source, "application/x-tar", "public-read")
 	assert.NoError(err)
 
 	// get s3 file and read contents
-	rc, err := GetS3File(auth, sourceURL)
+	rc, err := GetS3File(auth, source)
 	assert.NoError(err)
 	data, err := ioutil.ReadAll(rc)
 	defer rc.Close()
@@ -59,15 +59,15 @@ func TestPutS3FileMultiPart(t *testing.T) {
 	}
 
 	uniqueID := util.RandomString()
-	sourceURL += uniqueID
-	downloadURL += uniqueID
-	err = PutS3File(auth, "bigfile.test0", sourceURL, "application/x-tar", "public-read")
+	source := sourceURL + uniqueID
+	download := downloadURL + uniqueID
+	err = PutS3File(auth, "bigfile.test0", source, "application/x-tar", "public-read")
 	if !assert.NoError(err) {
 		return
 	}
 
 	// get s3 file and read contents
-	rc, err := GetS3File(auth, sourceURL)
+	rc, err := GetS3File(auth, source)
 	if !assert.NoError(err) {
 		return
 	}
@@ -77,7 +77,7 @@ func TestPutS3FileMultiPart(t *testing.T) {
 	assert.Equal(6000000, len(data))
 
 	// download file directly
-	resp, err := http.Get(downloadURL)
+	resp, err := http.Get(download)
 	assert.NoError(err)
 	assert.Equal(http.StatusOK, resp.StatusCode)
 }
@@ -99,13 +99,13 @@ func TestLegacyGetS3FileWithLegacyPut(t *testing.T) {
 	}
 
 	uniqueID := util.RandomString()
-	sourceURL += uniqueID
-	downloadURL += uniqueID
-	err = legacyPutS3File(auth, tempfile.Name(), sourceURL, "application/x-tar", "public-read")
+	source := sourceURL + uniqueID
+	download := downloadURL + uniqueID
+	err = legacyPutS3File(auth, tempfile.Name(), source, "application/x-tar", "public-read")
 	assert.NoError(err)
 
 	// get s3 file and read contents
-	rc, err := legacyGetS3File(auth, sourceURL)
+	rc, err := legacyGetS3File(auth, source)
 	assert.NoError(err)
 	data, err := ioutil.ReadAll(rc)
 	defer rc.Close()
@@ -113,7 +113,7 @@ func TestLegacyGetS3FileWithLegacyPut(t *testing.T) {
 	assert.Equal(randStr, string(data[:]))
 
 	// download file directly
-	resp, err := http.Get(downloadURL)
+	resp, err := http.Get(download)
 	assert.NoError(err)
 	defer resp.Body.Close()
 	data, err = ioutil.ReadAll(resp.Body)

--- a/thirdparty/s3_test.go
+++ b/thirdparty/s3_test.go
@@ -32,11 +32,12 @@ func TestPutS3File(t *testing.T) {
 	}
 
 	uniqueID := util.RandomString()
-	err = PutS3File(auth, tempfile.Name(), sourceURL+uniqueID, "application/x-tar", "public-read")
+	sourceURL += uniqueID
+	err = PutS3File(auth, tempfile.Name(), sourceURL, "application/x-tar", "public-read")
 	assert.NoError(err)
 
 	// get s3 file and read contents
-	rc, err := GetS3File(auth, sourceURL+uniqueID)
+	rc, err := GetS3File(auth, sourceURL)
 	assert.NoError(err)
 	data, err := ioutil.ReadAll(rc)
 	defer rc.Close()
@@ -58,13 +59,15 @@ func TestPutS3FileMultiPart(t *testing.T) {
 	}
 
 	uniqueID := util.RandomString()
-	err = PutS3File(auth, "bigfile.test0", sourceURL+uniqueID, "application/x-tar", "public-read")
+	sourceURL += uniqueID
+	downloadURL += uniqueID
+	err = PutS3File(auth, "bigfile.test0", sourceURL, "application/x-tar", "public-read")
 	if !assert.NoError(err) {
 		return
 	}
 
 	// get s3 file and read contents
-	rc, err := GetS3File(auth, sourceURL+uniqueID)
+	rc, err := GetS3File(auth, sourceURL)
 	if !assert.NoError(err) {
 		return
 	}
@@ -74,7 +77,7 @@ func TestPutS3FileMultiPart(t *testing.T) {
 	assert.Equal(6000000, len(data))
 
 	// download file directly
-	resp, err := http.Get(downloadURL + uniqueID)
+	resp, err := http.Get(downloadURL)
 	assert.NoError(err)
 	assert.Equal(http.StatusOK, resp.StatusCode)
 }
@@ -96,11 +99,13 @@ func TestLegacyGetS3FileWithLegacyPut(t *testing.T) {
 	}
 
 	uniqueID := util.RandomString()
-	err = legacyPutS3File(auth, tempfile.Name(), sourceURL+uniqueID, "application/x-tar", "public-read")
+	sourceURL += uniqueID
+	downloadURL += uniqueID
+	err = legacyPutS3File(auth, tempfile.Name(), sourceURL, "application/x-tar", "public-read")
 	assert.NoError(err)
 
 	// get s3 file and read contents
-	rc, err := legacyGetS3File(auth, sourceURL+uniqueID)
+	rc, err := legacyGetS3File(auth, sourceURL)
 	assert.NoError(err)
 	data, err := ioutil.ReadAll(rc)
 	defer rc.Close()
@@ -108,7 +113,7 @@ func TestLegacyGetS3FileWithLegacyPut(t *testing.T) {
 	assert.Equal(randStr, string(data[:]))
 
 	// download file directly
-	resp, err := http.Get(downloadURL + uniqueID)
+	resp, err := http.Get(downloadURL)
 	assert.NoError(err)
 	defer resp.Body.Close()
 	data, err = ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Instead of using the same URLs each time https://github.com/evergreen-ci/evergreen/blob/414a2b6371ac0712153316792c13115e433d1a54/thirdparty/s3_test.go#L14-L15, generate unique names like so: 
```
sourceURL   = "s3://build-push-testing/test/source/<random-string>"
downloadURL = "https://s3.amazonaws.com/build-push-testing/test/source/<same-random-string>"
```