### PR TITLE
EVG-1930 docker manager should download new images

### DIFF
--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -22,20 +22,20 @@ type dockerManager struct {
 
 // ProviderSettings specifies the settings used to configure a host instance.
 type dockerSettings struct {
-	// ImageID is the Docker image ID already loaded on the host machine.
-	ImageID string `mapstructure:"image_name" json:"image_name" bson:"image_name"`
+	// ImageURL is the url of the Docker image to use when building the container.
+	ImageURL string `mapstructure:"image_url" json:"image_url" bson:"image_url"`
 }
 
 // nolint
 var (
 	// bson fields for the ProviderSettings struct
-	imageIDKey = bsonutil.MustHaveTag(dockerSettings{}, "ImageID")
+	imageURLKey = bsonutil.MustHaveTag(dockerSettings{}, "ImageURL")
 )
 
 //Validate checks that the settings from the config file are sane.
 func (settings *dockerSettings) Validate() error {
-	if settings.ImageID == "" {
-		return errors.New("ImageName must not be blank")
+	if settings.ImageURL == "" {
+		return errors.New("ImageURL must not be blank")
 	}
 
 	return nil
@@ -79,7 +79,7 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 		"message":   "decoded Docker container settings",
 		"container": h.Id,
 		"host_ip":   hostIP,
-		"image_id":  settings.ImageID,
+		"image_url": settings.ImageURL,
 	})
 
 	// Create container

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -191,7 +191,7 @@ func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, h *host.Host
 //     3. The image must have the same ~/.ssh/authorized_keys file as the host machine
 //        in order to allow users with SSH access to the host machine to have SSH access
 //        to the container.
-func (c *dockerClientImpl) CreateContainer(ctx context.Context, h *host.Host, name string, ds *dockerSettings) error {
+func (c *dockerClientImpl) CreateContainer(ctx context.Context, h *host.Host, name string, settings *dockerSettings) error {
 	dockerClient, err := c.generateClient(h)
 	if err != nil {
 		return errors.Wrap(err, "Failed to generate docker client")
@@ -210,7 +210,7 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, h *host.Host, na
 	}
 
 	// Import correct base image if not already on host.
-	image, err := c.EnsureImageDownloaded(ctx, h, ds.ImageID)
+	image, err := c.EnsureImageDownloaded(ctx, h, settings.ImageURL)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to ensure that image '%s' is on host '%s'", h.Id)
 	}
@@ -218,7 +218,7 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, h *host.Host, na
 	// Build image containing Evergreen executable.
 	provisionedImage, err := c.BuildImageWithAgent(ctx, h, image)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to build image %s with agent on host '%s'", ds.ImageID, h.Id)
+		return errors.Wrapf(err, "Failed to build image %s with agent on host '%s'", image, h.Id)
 	}
 
 	// Build path to Evergreen executable.

--- a/cloud/docker_mock.go
+++ b/cloud/docker_mock.go
@@ -15,13 +15,14 @@ import (
 
 type dockerClientMock struct {
 	// API call options
-	failInit   bool
-	failBuild  bool
-	failCreate bool
-	failGet    bool
-	failList   bool
-	failRemove bool
-	failStart  bool
+	failInit     bool
+	failDownload bool
+	failBuild    bool
+	failCreate   bool
+	failGet      bool
+	failList     bool
+	failRemove   bool
+	failStart    bool
 
 	// Other options
 	hasOpenPorts bool
@@ -39,11 +40,18 @@ func (c *dockerClientMock) Init(string) error {
 	return nil
 }
 
+func (c *dockerClientMock) EnsureImageDownloaded(context.Context, *host.Host, string) (string, error) {
+	if c.failDownload {
+		return "", errors.New("failed to download image")
+	}
+	return c.baseImage, nil
+}
+
 func (c *dockerClientMock) BuildImageWithAgent(context.Context, *host.Host, string) (string, error) {
 	if c.failBuild {
 		return "", errors.New("failed to build image with agent")
 	}
-	return c.baseImage, nil
+	return fmt.Sprintf(provisionedImageTag, c.baseImage), nil
 }
 
 func (c *dockerClientMock) CreateContainer(context.Context, *host.Host, string, *dockerSettings) error {

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -46,8 +46,8 @@ func (s *DockerSuite) SetupTest() {
 		Id:       "d",
 		Provider: "docker",
 		ProviderSettings: &map[string]interface{}{
-			"image_name": "docker_image",
-			"pool_id":    "pool_id",
+			"image_url": "http:0.0.0.0:8000/docker_image.tgz",
+			"pool_id":   "pool_id",
 		},
 	}
 	s.parentHost = host.Host{
@@ -68,13 +68,13 @@ func (s *DockerSuite) TearDownTest() {
 func (s *DockerSuite) TestValidateSettings() {
 	// all required settings are provided
 	settingsOk := &dockerSettings{
-		ImageID: "docker_image",
+		ImageURL: "0.0.0.0:8000/docker_image.tgz",
 	}
 	s.NoError(settingsOk.Validate())
 
-	// error when missing image id
-	settingsNoImageID := &dockerSettings{}
-	s.Error(settingsNoImageID.Validate())
+	// error when missing image url
+	settingsNoImageURL := &dockerSettings{}
+	s.Error(settingsNoImageURL.Validate())
 }
 
 func (s *DockerSuite) TestConfigureAPICall() {
@@ -437,7 +437,7 @@ func (s *DockerSuite) TestSpawnDoesNotPanic() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	delete(*s.distro.ProviderSettings, "image_name")
+	delete(*s.distro.ProviderSettings, "image_url")
 
 	host := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -46,7 +46,7 @@ func (s *DockerSuite) SetupTest() {
 		Id:       "d",
 		Provider: "docker",
 		ProviderSettings: &map[string]interface{}{
-			"image_url": "http:0.0.0.0:8000/docker_image.tgz",
+			"image_url": "http://0.0.0.0:8000/docker_image.tgz",
 			"pool_id":   "pool_id",
 		},
 	}
@@ -68,7 +68,7 @@ func (s *DockerSuite) TearDownTest() {
 func (s *DockerSuite) TestValidateSettings() {
 	// all required settings are provided
 	settingsOk := &dockerSettings{
-		ImageURL: "0.0.0.0:8000/docker_image.tgz",
+		ImageURL: "http://0.0.0.0:8000/docker_image.tgz",
 	}
 	s.NoError(settingsOk.Validate())
 

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -90,9 +90,9 @@ Evergreen - Distros
       </div>
       <div ng-show="activeDistro.provider == 'docker'">
         <div>
-    <label class="distro-label">Docker Image ID:</label>
-    <input type="text" ng-required="activeDistro.provider == 'docker'" name="imageName" class="form-control" ng-model="activeDistro.settings.image_name" placeholder="Docker image ID preloaded on host machine" ng-readonly="readOnly">
-    <div class="icon fa fa-warning distro-error" ng-show="form.imageName.$dirty && form.imageName.$error.required || form.imageName.$invalid">Image ID is required</div>
+    <label class="distro-label">Docker Image URL:</label>
+    <input type="text" ng-required="activeDistro.provider == 'docker'" name="imageUrl" class="form-control" ng-model="activeDistro.settings.image_url" placeholder="Docker image URL to import on host machine" ng-readonly="readOnly">
+    <div class="icon fa fa-warning distro-error" ng-show="form.imageUrl.$dirty && form.imageUrl.$error.required || form.imageUrl.$invalid">Image URL is required</div>
         </div>
         <div>
           <label class="distro-label">Pool ID:</label>


### PR DESCRIPTION
This PR adds EnsureImageDownloaded to the Docker client, which checks whether the image specified by the URL in the distro's provider settings is already present on the parent host, and imports the image from the URL if necessary.