### PR TITLE
EVG-3692 Start agent in containers as user specified in distro

### DIFF
--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -24,6 +24,8 @@ type dockerManager struct {
 type dockerSettings struct {
 	// ImageURL is the url of the Docker image to use when building the container.
 	ImageURL string `mapstructure:"image_url" json:"image_url" bson:"image_url"`
+	// User is the user that runs the Evergreen agent in the container.
+	User string `mapstructure:"user" json:"user" bson:"user"`
 }
 
 // nolint
@@ -36,6 +38,9 @@ var (
 func (settings *dockerSettings) Validate() error {
 	if settings.ImageURL == "" {
 		return errors.New("ImageURL must not be blank")
+	}
+	if settings.User == "" {
+		return errors.New("User must not be blank")
 	}
 
 	return nil
@@ -60,6 +65,7 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 			return nil, errors.Wrapf(err, "Error decoding params for distro '%s'", h.Distro.Id)
 		}
 	}
+	settings.User = h.Distro.User
 
 	// get parent of host
 	parent, err := h.GetParent()

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -256,6 +256,7 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, h *host.Host, na
 		},
 		Cmd:   agentCmdParts,
 		Image: provisionedImage,
+		User:  settings.User,
 	}
 	networkConf := &network.NetworkingConfig{}
 

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -49,6 +49,7 @@ func (s *DockerSuite) SetupTest() {
 			"image_url": "http://0.0.0.0:8000/docker_image.tgz",
 			"pool_id":   "pool_id",
 		},
+		User: "root",
 	}
 	s.parentHost = host.Host{
 		Id:            "parent",
@@ -69,12 +70,21 @@ func (s *DockerSuite) TestValidateSettings() {
 	// all required settings are provided
 	settingsOk := &dockerSettings{
 		ImageURL: "http://0.0.0.0:8000/docker_image.tgz",
+		User:     "root",
 	}
 	s.NoError(settingsOk.Validate())
 
 	// error when missing image url
-	settingsNoImageURL := &dockerSettings{}
-	s.Error(settingsNoImageURL.Validate())
+	settingsNoImageURL := &dockerSettings{
+		User: "root",
+	}
+	s.EqualError(settingsNoImageURL.Validate(), "ImageURL must not be blank")
+
+	// error when missing user
+	settingsNoUser := &dockerSettings{
+		ImageURL: "http://0.0.0.0:8000/docker_image.tgz",
+	}
+	s.EqualError(settingsNoUser.Validate(), "User must not be blank")
 }
 
 func (s *DockerSuite) TestConfigureAPICall() {


### PR DESCRIPTION
Keeps distro-specified user in Docker settings. This allows Evergreen to configure new containers so that the Evergreen agent runs as the correct user on the remote machine. 