### PR TITLE
EVG-3426 Scale task cost calculations for containers

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -68,7 +68,7 @@ type ContainerManager interface {
 // CostCalculator is an interface for cloud providers that can estimate what a span of time on a
 // given host costs.
 type CostCalculator interface {
-	CostForDuration(context.Context, *host.Host, time.Time, time.Time) (float64, error)
+	CostForDuration(context.Context, *host.Host, time.Time, time.Time, *evergreen.Settings) (float64, error)
 }
 
 // BatchManager is an interface for cloud providers that support batch operations.

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -908,7 +908,7 @@ func cloudStatusFromSpotStatus(state string) CloudStatus {
 	}
 }
 
-func (m *ec2Manager) CostForDuration(ctx context.Context, h *host.Host, start, end time.Time) (float64, error) {
+func (m *ec2Manager) CostForDuration(ctx context.Context, h *host.Host, start, end time.Time, s *evergreen.Settings) (float64, error) {
 	if end.Before(start) || util.IsZeroTime(start) || util.IsZeroTime(end) {
 		return 0, errors.New("task timing data is malformed")
 	}

--- a/cloud/gce_costs.go
+++ b/cloud/gce_costs.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/pkg/errors"
@@ -94,7 +95,7 @@ func (m *gceManager) TimeTilNextPayment(h *host.Host) time.Duration {
 // platforms (e.g. Skylake VMs), premium images (e.g. SUSE), networks, etc.
 //
 // Source: https://cloud.google.com/compute/pricing
-func (m *gceManager) CostForDuration(h *host.Host, start, end time.Time) (float64, error) {
+func (m *gceManager) CostForDuration(h *host.Host, start, end time.Time, s *evergreen.Settings) (float64, error) {
 	// Sanity check.
 	if end.Before(start) || util.IsZeroTime(start) || util.IsZeroTime(end) {
 		return 0, errors.New("task timing data is malformed")

--- a/cloud/gce_costs_test.go
+++ b/cloud/gce_costs_test.go
@@ -5,6 +5,7 @@ package cloud
 import (
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
 )
 
@@ -127,14 +128,15 @@ func (s *GCESuite) TestCostForDuration() {
 	start := time.Now()
 	end := time.Now()
 	h := &host.Host{Id: "id"}
+	settings := &evergreen.Settings{}
 
 	// end before start
-	cost, err := s.manager.CostForDuration(h, end, start)
+	cost, err := s.manager.CostForDuration(h, end, start, settings)
 	s.Error(err)
 	s.Zero(cost)
 
 	// valid input
-	cost, err = s.manager.CostForDuration(h, start, end)
+	cost, err = s.manager.CostForDuration(h, start, end, settings)
 	s.NoError(err)
 	s.NotZero(cost)
 }

--- a/units/stats_host_idle.go
+++ b/units/stats_host_idle.go
@@ -128,7 +128,7 @@ func (j *collectHostIdleDataJob) Run(ctx context.Context) {
 	}
 
 	if calc, ok := j.manager.(cloud.CostCalculator); ok {
-		cost, err = calc.CostForDuration(ctx, j.host, j.StartTime, j.FinishTime)
+		cost, err = calc.CostForDuration(ctx, j.host, j.StartTime, j.FinishTime, j.settings)
 		if err != nil {
 			j.AddError(err)
 		}

--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -103,7 +103,7 @@ func (j *collectTaskEndDataJob) Run(ctx context.Context) {
 		grip.Error(message.WrapErrorf(err, "Error loading provider for host %s cost calculation", j.task.HostId))
 	} else {
 		if calc, ok := manager.(cloud.CostCalculator); ok {
-			cost, err = calc.CostForDuration(ctx, j.host, j.task.StartTime, j.task.FinishTime)
+			cost, err = calc.CostForDuration(ctx, j.host, j.task.StartTime, j.task.FinishTime, settings)
 			if err != nil {
 				j.AddError(err)
 			} else {


### PR DESCRIPTION
This implements the CostCalculator interface for the Docker cloud provider by adding a new CostForDuration function. It essentially calculates the cost over the interval for the container's parent, and then divides that figure by a rough estimate of how many containers were running over the same interval. This estimate currently is the average of the number of containers on that parent at the start and end of the task.