### PR TITLE
EVG-3692 move user out of Docker settings struct

### DIFF
--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -24,8 +24,6 @@ type dockerManager struct {
 type dockerSettings struct {
 	// ImageURL is the url of the Docker image to use when building the container.
 	ImageURL string `mapstructure:"image_url" json:"image_url" bson:"image_url"`
-	// User is the user that runs the Evergreen agent in the container.
-	User string `mapstructure:"user" json:"user" bson:"user"`
 }
 
 // nolint
@@ -38,9 +36,6 @@ var (
 func (settings *dockerSettings) Validate() error {
 	if settings.ImageURL == "" {
 		return errors.New("ImageURL must not be blank")
-	}
-	if settings.User == "" {
-		return errors.New("User must not be blank")
 	}
 
 	return nil
@@ -65,7 +60,6 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 			return nil, errors.Wrapf(err, "Error decoding params for distro '%s'", h.Distro.Id)
 		}
 	}
-	settings.User = h.Distro.User
 
 	// get parent of host
 	parent, err := h.GetParent()
@@ -89,7 +83,7 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 	})
 
 	// Create container
-	if err := m.client.CreateContainer(ctx, parent, h.Id, settings); err != nil {
+	if err := m.client.CreateContainer(ctx, parent, h.Id, h.Distro.User, settings); err != nil {
 		err = errors.Wrapf(err, "Failed to create container for host '%s'", hostIP)
 		grip.Error(err)
 		return nil, err

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -29,7 +29,7 @@ type dockerClient interface {
 	Init(string) error
 	EnsureImageDownloaded(context.Context, *host.Host, string) (string, error)
 	BuildImageWithAgent(context.Context, *host.Host, string) (string, error)
-	CreateContainer(context.Context, *host.Host, string, *dockerSettings) error
+	CreateContainer(context.Context, *host.Host, string, string, *dockerSettings) error
 	GetContainer(context.Context, *host.Host, string) (*types.ContainerJSON, error)
 	ListContainers(context.Context, *host.Host) ([]types.Container, error)
 	RemoveImage(context.Context, *host.Host, string) error
@@ -193,7 +193,7 @@ func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, h *host.Host
 //     3. The image must have the same ~/.ssh/authorized_keys file as the host machine
 //        in order to allow users with SSH access to the host machine to have SSH access
 //        to the container.
-func (c *dockerClientImpl) CreateContainer(ctx context.Context, h *host.Host, name string, settings *dockerSettings) error {
+func (c *dockerClientImpl) CreateContainer(ctx context.Context, h *host.Host, name, user string, settings *dockerSettings) error {
 	dockerClient, err := c.generateClient(h)
 	if err != nil {
 		return errors.Wrap(err, "Failed to generate docker client")
@@ -256,7 +256,7 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, h *host.Host, na
 		},
 		Cmd:   agentCmdParts,
 		Image: provisionedImage,
-		User:  settings.User,
+		User:  user,
 	}
 	networkConf := &network.NetworkingConfig{}
 

--- a/cloud/docker_mock.go
+++ b/cloud/docker_mock.go
@@ -54,7 +54,7 @@ func (c *dockerClientMock) BuildImageWithAgent(context.Context, *host.Host, stri
 	return fmt.Sprintf(provisionedImageTag, c.baseImage), nil
 }
 
-func (c *dockerClientMock) CreateContainer(context.Context, *host.Host, string, *dockerSettings) error {
+func (c *dockerClientMock) CreateContainer(context.Context, *host.Host, string, string, *dockerSettings) error {
 	if c.failCreate {
 		return errors.New("failed to create container")
 	}

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -70,21 +70,12 @@ func (s *DockerSuite) TestValidateSettings() {
 	// all required settings are provided
 	settingsOk := &dockerSettings{
 		ImageURL: "http://0.0.0.0:8000/docker_image.tgz",
-		User:     "root",
 	}
 	s.NoError(settingsOk.Validate())
 
 	// error when missing image url
-	settingsNoImageURL := &dockerSettings{
-		User: "root",
-	}
+	settingsNoImageURL := &dockerSettings{}
 	s.EqualError(settingsNoImageURL.Validate(), "ImageURL must not be blank")
-
-	// error when missing user
-	settingsNoUser := &dockerSettings{
-		ImageURL: "http://0.0.0.0:8000/docker_image.tgz",
-	}
-	s.EqualError(settingsNoUser.Validate(), "User must not be blank")
 }
 
 func (s *DockerSuite) TestConfigureAPICall() {


### PR DESCRIPTION
Having the user in the dockerSettings struct causes an issue, because the Validate() function is called when creating a new distro and my changes made it so that user is only added to dockerSettings when Spawnhost is called. We figured the best way to fix this is to pass user as a string to CreateContainer. 