### PR TITLE
EVG-3727 Save container pool ID to correct distro field

### DIFF
--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -96,7 +96,7 @@ Evergreen - Distros
         </div>
         <div>
           <label class="distro-label">Pool ID:</label>
-          <select ng-readonly="readOnly" name="poolID" ng-model="activeDistro.settings.pool_id" ng-required="activeDistro.provider == 'docker'">
+          <select ng-readonly="readOnly" name="poolID" ng-model="activeDistro.container_pool" ng-required="activeDistro.provider == 'docker'">
             <option ng-repeat="pool in containerPoolIds" value=[[pool]]>[[pool]]</option>
           </select>
           <div ng-show="checkPoolID(form.poolID.$modelValue)">


### PR DESCRIPTION
Previously, the Pool ID field for container pool distros was being saved within provider settings. It should be stored in the distro.ContainerPool field.