### PR TITLE
 EVG-3728: create parent intent documents using container pool distro

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -314,11 +314,11 @@ func containerCapacity(numCurrentParents, numCurrentContainers, numContainersToS
 }
 
 // createParents creates host intent documents for each parent
-func createParents(d distro.Distro, numNewParents int, pool *evergreen.ContainerPool) []host.Host {
+func createParents(parent distro.Distro, numNewParents int, pool *evergreen.ContainerPool) []host.Host {
 	hostsSpawned := make([]host.Host, numNewParents)
 
 	for idx := range hostsSpawned {
-		hostsSpawned[idx] = *cloud.NewIntent(d, d.GenerateName(), d.Provider, generateParentHostOptions(pool))
+		hostsSpawned[idx] = *cloud.NewIntent(parent, parent.GenerateName(), parent.Provider, generateParentHostOptions(pool))
 	}
 
 	return hostsSpawned

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -555,7 +555,7 @@ func (s *SchedulerSuite) TestSpawnContainersStatic() {
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
 	numNewParents := numNewParentsNeeded(len(currentParents), 4, len(existingContainers), pool.MaxContainers)
-	numNewParentsToSpawn, err := parentCapacity(d, numNewParents, len(currentParents), pool)
+	numNewParentsToSpawn, err := parentCapacity(parent, numNewParents, len(currentParents), pool)
 	s.NoError(err)
 	s.Equal(0, numNewParentsToSpawn)
 	s.Len(newHostsSpawned, 3)


### PR DESCRIPTION
Scheduler was originally creating parents based on a container distro instead of looking at the parent distro set in the container pool. 