### PR TITLE
EVG-3730: check uninitialized parent documents before inserting new ones

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1020,6 +1020,15 @@ func FindAllRunningParentsByContainerPool(poolId string) ([]Host, error) {
 	return Find(query)
 }
 
+// CountUninitializedParents returns the number of initializing parent host intent documents
+func CountUninitializedParents() (int, error) {
+	query := db.Query(bson.M{
+		HasContainersKey: true,
+		StatusKey:        evergreen.HostUninitialized,
+	})
+	return Count(query)
+}
+
 func InsertMany(hosts []Host) error {
 	docs := make([]interface{}, len(hosts))
 	for idx := range hosts {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1022,11 +1022,10 @@ func FindAllRunningParentsByContainerPool(poolId string) ([]Host, error) {
 
 // CountUninitializedParents returns the number of initializing parent host intent documents
 func CountUninitializedParents() (int, error) {
-	query := db.Query(bson.M{
+	return db.Count(Collection, bson.M{
 		HasContainersKey: true,
 		StatusKey:        evergreen.HostUninitialized,
 	})
-	return Count(query)
 }
 
 func InsertMany(hosts []Host) error {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1020,10 +1020,12 @@ func FindAllRunningParentsByContainerPool(poolId string) ([]Host, error) {
 }
 
 // CountUphostParents returns the number of initializing parent host intent documents
-func CountUphostParents() (int, error) {
+func CountUphostParentsByContainerPool(poolId string) (int, error) {
+	hostContainerPoolId := bsonutil.GetDottedKeyName(ContainerPoolSettingsKey, evergreen.ContainerPoolIdKey)
 	return db.Count(Collection, bson.M{
-		HasContainersKey: true,
-		StatusKey:        bson.M{"$in": evergreen.UphostStatus},
+		HasContainersKey:    true,
+		StatusKey:           bson.M{"$in": evergreen.UphostStatus},
+		hostContainerPoolId: poolId,
 	})
 }
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1019,7 +1019,7 @@ func FindAllRunningParentsByContainerPool(poolId string) ([]Host, error) {
 	return Find(query)
 }
 
-// CountUninitializedParents returns the number of initializing parent host intent documents
+// CountUphostParents returns the number of initializing parent host intent documents
 func CountUphostParents() (int, error) {
 	return db.Count(Collection, bson.M{
 		HasContainersKey: true,

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1020,10 +1020,10 @@ func FindAllRunningParentsByContainerPool(poolId string) ([]Host, error) {
 }
 
 // CountUninitializedParents returns the number of initializing parent host intent documents
-func CountUninitializedParents() (int, error) {
+func CountUphostParents() (int, error) {
 	return db.Count(Collection, bson.M{
 		HasContainersKey: true,
-		StatusKey:        evergreen.HostUninitialized,
+		StatusKey:        bson.M{"$in": evergreen.UphostStatus},
 	})
 }
 

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2352,3 +2352,44 @@ func TestEstimateNumContainersForDuration(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(2.0, estimate2)
 }
+
+func TestCountUninitializedParents(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(Collection))
+
+	h1 := Host{
+		Id:            "h1",
+		Status:        evergreen.HostRunning,
+		HasContainers: true,
+	}
+	h2 := Host{
+		Id:            "h2",
+		Status:        evergreen.HostUninitialized,
+		HasContainers: true,
+	}
+	h3 := Host{
+		Id:            "h3",
+		Status:        evergreen.HostRunning,
+		HasContainers: true,
+	}
+	h4 := Host{
+		Id:            "h4",
+		Status:        evergreen.HostUninitialized,
+		HasContainers: true,
+	}
+	h5 := Host{
+		Id:       "h5",
+		Status:   evergreen.HostUninitialized,
+		ParentID: "h1",
+	}
+
+	assert.NoError(h1.Insert())
+	assert.NoError(h2.Insert())
+	assert.NoError(h3.Insert())
+	assert.NoError(h4.Insert())
+	assert.NoError(h5.Insert())
+
+	numUninitializedParents, err := CountUninitializedParents()
+	assert.NoError(err)
+	assert.Equal(2, numUninitializedParents)
+}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2388,11 +2388,21 @@ func TestCountUphostParents(t *testing.T) {
 		Id:            "h2",
 		Status:        evergreen.HostUninitialized,
 		HasContainers: true,
+		ContainerPoolSettings: &evergreen.ContainerPool{
+			Distro:        "d1",
+			Id:            "test-pool",
+			MaxContainers: 100,
+		},
 	}
 	h3 := Host{
 		Id:            "h3",
 		Status:        evergreen.HostRunning,
 		HasContainers: true,
+		ContainerPoolSettings: &evergreen.ContainerPool{
+			Distro:        "d1",
+			Id:            "test-pool",
+			MaxContainers: 100,
+		},
 	}
 	h4 := Host{
 		Id:            "h4",
@@ -2411,7 +2421,7 @@ func TestCountUphostParents(t *testing.T) {
 	assert.NoError(h4.Insert())
 	assert.NoError(h5.Insert())
 
-	numUphostParents, err := CountUphostParents()
+	numUphostParents, err := CountUphostParentsByContainerPool("test-pool")
 	assert.NoError(err)
-	assert.Equal(4, numUphostParents)
+	assert.Equal(2, numUphostParents)
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2375,7 +2375,7 @@ func TestFindTerminatedHostsRunningTasksQuery(t *testing.T) {
 	})
 }
 
-func TestCountUninitializedParents(t *testing.T) {
+func TestCountUphostParents(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 
@@ -2411,7 +2411,7 @@ func TestCountUninitializedParents(t *testing.T) {
 	assert.NoError(h4.Insert())
 	assert.NoError(h5.Insert())
 
-	numUninitializedParents, err := CountUninitializedParents()
+	numUphostParents, err := CountUphostParents()
 	assert.NoError(err)
-	assert.Equal(2, numUninitializedParents)
+	assert.Equal(4, numUphostParents)
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -165,7 +165,7 @@ func spawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 		}
 
 		// find all uphost parent intent documents
-		numUphostParents, err := host.CountUphostParents()
+		numUphostParents, err := host.CountUphostParentsByContainerPool(pool.Id)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not count uphost parents")
 		}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -293,7 +293,6 @@ func findAvailableParent(d distro.Distro) (host.Host, error) {
 // accommodate new containers
 func numNewParentsNeeded(params newParentsNeededParams) int {
 	if params.numUphostParents*params.maxContainers < params.numExistingContainers+params.numContainersNeeded {
-		// subtract numUninitializedParents because they will soon come up as parents we can use
 		numTotalNewParents := int(math.Ceil(float64(params.numContainersNeeded) / float64(params.maxContainers)))
 		if numTotalNewParents < 0 {
 			return 0

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -118,7 +118,14 @@ func (s *SchedulerSuite) TestNumNewParentsNeeded() {
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
 
-	num := numNewParentsNeeded(len(currentParents), numUninitializedParents, 1, len(existingContainers), pool.MaxContainers)
+	parentsParams := newParentsNeededParams{
+		numCurrentParents:       len(currentParents),
+		numUninitializedParents: numUninitializedParents,
+		numContainersNeeded:     1,
+		numExistingContainers:   len(existingContainers),
+		maxContainers:           pool.MaxContainers,
+	}
+	num := numNewParentsNeeded(parentsParams)
 	s.Equal(0, num)
 }
 
@@ -160,7 +167,14 @@ func (s *SchedulerSuite) TestNumNewParentsNeeded2() {
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
 
-	num := numNewParentsNeeded(len(currentParents), numUninitializedParents, 1, len(existingContainers), pool.MaxContainers)
+	parentsParams := newParentsNeededParams{
+		numCurrentParents:       len(currentParents),
+		numUninitializedParents: numUninitializedParents,
+		numContainersNeeded:     1,
+		numExistingContainers:   len(existingContainers),
+		maxContainers:           pool.MaxContainers,
+	}
+	num := numNewParentsNeeded(parentsParams)
 	s.Equal(0, num)
 }
 
@@ -205,7 +219,15 @@ func (s *SchedulerSuite) TestSpawnHostsParents() {
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
-	num := numNewParentsNeeded(len(currentParents), numUninitializedParents, 1, len(existingContainers), pool.MaxContainers)
+
+	parentsParams := newParentsNeededParams{
+		numCurrentParents:       len(currentParents),
+		numUninitializedParents: numUninitializedParents,
+		numContainersNeeded:     1,
+		numExistingContainers:   len(existingContainers),
+		maxContainers:           pool.MaxContainers,
+	}
+	num := numNewParentsNeeded(parentsParams)
 	s.Equal(1, num)
 
 	newHostsSpawned, err := spawnHosts(ctx, d, 1, pool)
@@ -270,7 +292,15 @@ func (s *SchedulerSuite) TestSpawnHostsContainers() {
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
-	num := numNewParentsNeeded(len(currentParents), numUninitializedParents, 1, len(existingContainers), pool.MaxContainers)
+
+	parentsParams := newParentsNeededParams{
+		numCurrentParents:       len(currentParents),
+		numUninitializedParents: numUninitializedParents,
+		numContainersNeeded:     1,
+		numExistingContainers:   len(existingContainers),
+		maxContainers:           pool.MaxContainers,
+	}
+	num := numNewParentsNeeded(parentsParams)
 	s.Equal(0, num)
 
 	s.Equal(1, len(newHostsSpawned))
@@ -318,7 +348,15 @@ func (s *SchedulerSuite) TestSpawnHostsParentsAndSomeContainers() {
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
-	num := numNewParentsNeeded(len(currentParents), numUninitializedParents, 3, len(existingContainers), pool.MaxContainers)
+
+	parentsParams := newParentsNeededParams{
+		numCurrentParents:       len(currentParents),
+		numUninitializedParents: numUninitializedParents,
+		numContainersNeeded:     3,
+		numExistingContainers:   len(existingContainers),
+		maxContainers:           pool.MaxContainers,
+	}
+	num := numNewParentsNeeded(parentsParams)
 	s.Equal(1, num)
 
 	newHostsSpawned, err := spawnHosts(ctx, d, 3, pool)
@@ -375,7 +413,15 @@ func (s *SchedulerSuite) TestSpawnHostsMaximumCapacity() {
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
-	num := numNewParentsNeeded(len(currentParents), numUninitializedParents, 2, len(existingContainers), pool.MaxContainers)
+
+	parentsParams := newParentsNeededParams{
+		numCurrentParents:       len(currentParents),
+		numUninitializedParents: numUninitializedParents,
+		numContainersNeeded:     2,
+		numExistingContainers:   len(existingContainers),
+		maxContainers:           pool.MaxContainers,
+	}
+	num := numNewParentsNeeded(parentsParams)
 	s.Equal(1, num)
 
 	s.Len(newHostsSpawned, 1)
@@ -574,7 +620,15 @@ func (s *SchedulerSuite) TestSpawnContainersStatic() {
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
-	numNewParents := numNewParentsNeeded(len(currentParents), numUninitializedParents, 4, len(existingContainers), pool.MaxContainers)
+
+	parentsParams := newParentsNeededParams{
+		numCurrentParents:       len(currentParents),
+		numUninitializedParents: numUninitializedParents,
+		numContainersNeeded:     4,
+		numExistingContainers:   len(existingContainers),
+		maxContainers:           pool.MaxContainers,
+	}
+	numNewParents := numNewParentsNeeded(parentsParams)
 	numNewParentsToSpawn, err := parentCapacity(parent, numNewParents, len(currentParents), pool)
 	s.NoError(err)
 	s.Equal(0, numNewParentsToSpawn)

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -100,10 +100,11 @@ func (s *SchedulerSuite) TestNumNewParentsNeeded() {
 		ParentID: "host1",
 	}
 	host4 := &host.Host{
-		Id:            "host4",
-		Distro:        d,
-		Status:        evergreen.HostUninitialized,
-		HasContainers: true,
+		Id:                    "host4",
+		Distro:                d,
+		Status:                evergreen.HostUninitialized,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
 	}
 
 	s.NoError(host1.Insert())
@@ -113,7 +114,7 @@ func (s *SchedulerSuite) TestNumNewParentsNeeded() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(d.ContainerPool)
 	s.NoError(err)
-	numUphostParents, err := host.CountUphostParents()
+	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
@@ -161,7 +162,7 @@ func (s *SchedulerSuite) TestNumNewParentsNeeded2() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(d.ContainerPool)
 	s.NoError(err)
-	numUphostParents, err := host.CountUphostParents()
+	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
@@ -213,7 +214,7 @@ func (s *SchedulerSuite) TestSpawnHostsParents() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
 	s.NoError(err)
-	numUphostParents, err := host.CountUphostParents()
+	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
@@ -285,7 +286,7 @@ func (s *SchedulerSuite) TestSpawnHostsContainers() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
 	s.NoError(err)
-	numUphostParents, err := host.CountUphostParents()
+	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
@@ -340,7 +341,7 @@ func (s *SchedulerSuite) TestSpawnHostsParentsAndSomeContainers() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
 	s.NoError(err)
-	numUphostParents, err := host.CountUphostParents()
+	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
@@ -404,7 +405,7 @@ func (s *SchedulerSuite) TestSpawnHostsMaximumCapacity() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
 	s.NoError(err)
-	numUphostParents, err := host.CountUphostParents()
+	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
@@ -610,7 +611,7 @@ func (s *SchedulerSuite) TestSpawnContainersStatic() {
 	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
 	s.NoError(err)
 	s.Equal(3, len(currentParents))
-	numUphostParents, err := host.CountUphostParents()
+	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -113,17 +113,16 @@ func (s *SchedulerSuite) TestNumNewParentsNeeded() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(d.ContainerPool)
 	s.NoError(err)
-	numUninitializedParents, err := host.CountUninitializedParents()
+	numUphostParents, err := host.CountUphostParents()
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
 
 	parentsParams := newParentsNeededParams{
-		numCurrentParents:       len(currentParents),
-		numUninitializedParents: numUninitializedParents,
-		numContainersNeeded:     1,
-		numExistingContainers:   len(existingContainers),
-		maxContainers:           pool.MaxContainers,
+		numUphostParents:      numUphostParents,
+		numContainersNeeded:   1,
+		numExistingContainers: len(existingContainers),
+		maxContainers:         pool.MaxContainers,
 	}
 	num := numNewParentsNeeded(parentsParams)
 	s.Equal(0, num)
@@ -162,17 +161,16 @@ func (s *SchedulerSuite) TestNumNewParentsNeeded2() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(d.ContainerPool)
 	s.NoError(err)
-	numUninitializedParents, err := host.CountUninitializedParents()
+	numUphostParents, err := host.CountUphostParents()
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
 
 	parentsParams := newParentsNeededParams{
-		numCurrentParents:       len(currentParents),
-		numUninitializedParents: numUninitializedParents,
-		numContainersNeeded:     1,
-		numExistingContainers:   len(existingContainers),
-		maxContainers:           pool.MaxContainers,
+		numUphostParents:      numUphostParents,
+		numContainersNeeded:   1,
+		numExistingContainers: len(existingContainers),
+		maxContainers:         pool.MaxContainers,
 	}
 	num := numNewParentsNeeded(parentsParams)
 	s.Equal(0, num)
@@ -215,17 +213,16 @@ func (s *SchedulerSuite) TestSpawnHostsParents() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
 	s.NoError(err)
-	numUninitializedParents, err := host.CountUninitializedParents()
+	numUphostParents, err := host.CountUphostParents()
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
 
 	parentsParams := newParentsNeededParams{
-		numCurrentParents:       len(currentParents),
-		numUninitializedParents: numUninitializedParents,
-		numContainersNeeded:     1,
-		numExistingContainers:   len(existingContainers),
-		maxContainers:           pool.MaxContainers,
+		numUphostParents:      numUphostParents,
+		numContainersNeeded:   1,
+		numExistingContainers: len(existingContainers),
+		maxContainers:         pool.MaxContainers,
 	}
 	num := numNewParentsNeeded(parentsParams)
 	s.Equal(1, num)
@@ -288,17 +285,16 @@ func (s *SchedulerSuite) TestSpawnHostsContainers() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
 	s.NoError(err)
-	numUninitializedParents, err := host.CountUninitializedParents()
+	numUphostParents, err := host.CountUphostParents()
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
 
 	parentsParams := newParentsNeededParams{
-		numCurrentParents:       len(currentParents),
-		numUninitializedParents: numUninitializedParents,
-		numContainersNeeded:     1,
-		numExistingContainers:   len(existingContainers),
-		maxContainers:           pool.MaxContainers,
+		numUphostParents:      numUphostParents,
+		numContainersNeeded:   1,
+		numExistingContainers: len(existingContainers),
+		maxContainers:         pool.MaxContainers,
 	}
 	num := numNewParentsNeeded(parentsParams)
 	s.Equal(0, num)
@@ -344,17 +340,16 @@ func (s *SchedulerSuite) TestSpawnHostsParentsAndSomeContainers() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
 	s.NoError(err)
-	numUninitializedParents, err := host.CountUninitializedParents()
+	numUphostParents, err := host.CountUphostParents()
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
 
 	parentsParams := newParentsNeededParams{
-		numCurrentParents:       len(currentParents),
-		numUninitializedParents: numUninitializedParents,
-		numContainersNeeded:     3,
-		numExistingContainers:   len(existingContainers),
-		maxContainers:           pool.MaxContainers,
+		numUphostParents:      numUphostParents,
+		numContainersNeeded:   3,
+		numExistingContainers: len(existingContainers),
+		maxContainers:         pool.MaxContainers,
 	}
 	num := numNewParentsNeeded(parentsParams)
 	s.Equal(1, num)
@@ -409,17 +404,16 @@ func (s *SchedulerSuite) TestSpawnHostsMaximumCapacity() {
 
 	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
 	s.NoError(err)
-	numUninitializedParents, err := host.CountUninitializedParents()
+	numUphostParents, err := host.CountUphostParents()
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
 
 	parentsParams := newParentsNeededParams{
-		numCurrentParents:       len(currentParents),
-		numUninitializedParents: numUninitializedParents,
-		numContainersNeeded:     2,
-		numExistingContainers:   len(existingContainers),
-		maxContainers:           pool.MaxContainers,
+		numUphostParents:      numUphostParents,
+		numContainersNeeded:   2,
+		numExistingContainers: len(existingContainers),
+		maxContainers:         pool.MaxContainers,
 	}
 	num := numNewParentsNeeded(parentsParams)
 	s.Equal(1, num)
@@ -616,17 +610,16 @@ func (s *SchedulerSuite) TestSpawnContainersStatic() {
 	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
 	s.NoError(err)
 	s.Equal(3, len(currentParents))
-	numUninitializedParents, err := host.CountUninitializedParents()
+	numUphostParents, err := host.CountUphostParents()
 	s.NoError(err)
 	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
 	s.NoError(err)
 
 	parentsParams := newParentsNeededParams{
-		numCurrentParents:       len(currentParents),
-		numUninitializedParents: numUninitializedParents,
-		numContainersNeeded:     4,
-		numExistingContainers:   len(existingContainers),
-		maxContainers:           pool.MaxContainers,
+		numUphostParents:      numUphostParents,
+		numContainersNeeded:   4,
+		numExistingContainers: len(existingContainers),
+		maxContainers:         pool.MaxContainers,
 	}
 	numNewParents := numNewParentsNeeded(parentsParams)
 	numNewParentsToSpawn, err := parentCapacity(parent, numNewParents, len(currentParents), pool)


### PR DESCRIPTION
Scheduler currently does not check the number of parent hosts that are about to come up when calculating how many new parents are needed. 

