### PR TITLE
EVG-3480 remove unnecessary distro collection insert

### DIFF
--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -60,11 +60,10 @@ func (s *DockerSuite) SetupTest() {
 		ParentID: "parent",
 	}
 	s.NoError(s.parentHost.Insert())
-	s.NoError(s.distro.Insert())
 }
 
 func (s *DockerSuite) TearDownTest() {
-	s.NoError(db.ClearCollections(host.Collection, distro.Collection))
+	s.NoError(db.Clear(host.Collection))
 }
 func (s *DockerSuite) TestValidateSettings() {
 	// all required settings are provided


### PR DESCRIPTION
This was causing errors when repeatedly running a single test in the TestDockerSuite. We never use the inserted distro in any queries, so it makes sense to remove it.