### PR TITLE
EVG-1930 verify that ImageImport has succeeded

### DIFF
--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -85,15 +85,17 @@ func (c *dockerClientImpl) generateClient(h *host.Host) (*docker.Client, error) 
 	return c.client, nil
 }
 
+// changeTimeout changes the timeout of dockerClient's internal httpClient and
+// returns a new docker.Client with the updated timeout
 func (c *dockerClientImpl) changeTimeout(h *host.Host, newTimeout time.Duration) (*docker.Client, error) {
-	c.client = nil
+	var err error
 	c.httpClient.Timeout = newTimeout
-	dockerClient, err := c.generateClient(h)
+	c.client, err = c.generateClient(h)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate docker client")
 	}
 
-	return dockerClient, nil
+	return c.client, nil
 }
 
 // Init sets the Docker API version to use for API calls to the Docker client.

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -105,7 +105,10 @@ func (c *dockerClientImpl) Init(apiVersion string) error {
 // EnsureImageDownloaded checks if the image in s3 specified by the URL already exists,
 // and if not, creates a new image from the remote tarball.
 func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, h *host.Host, url string) (string, error) {
-	const maxImageInspectAttempts = 40
+	const (
+		maxImageInspectAttempts = 40
+		retryInterval           = 15 * time.Second
+	)
 
 	dockerClient, err := c.generateClient(h)
 	if err != nil {
@@ -155,7 +158,7 @@ func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, h *host.Ho
 							"attempts": i,
 						})
 						grip.Info(msg)
-						timer.Reset(15 * time.Second)
+						timer.Reset(retryInterval)
 						continue
 					}
 					return "", errors.Wrapf(err, "Error verifying whether image import for %s succeeded", url)

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -362,8 +362,6 @@ func (c *dockerClientImpl) ListContainers(ctx context.Context, h *host.Host) ([]
 // ListImages lists all images on the specified host machine.
 func (c *dockerClientImpl) ListImages(ctx context.Context, h *host.Host) ([]types.ImageSummary, error) {
 	dockerClient, err := c.generateClient(h)
-	grip.Info(*c.httpClient)
-	grip.Info(c.httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate docker client")
 	}


### PR DESCRIPTION
EnsureImageDownloaded now runs ImageInspect periodically after an ImageImport call to ensure that an image has actually been downloaded to the parent host. Also, makeDockerLogMessage now wraps other log data with the name of the API call and the parent host ID.