### PR TITLE
 EVG-3822 Create new status after initializing and before starting

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -14,6 +14,7 @@ const (
 	HostRunning         = "running"
 	HostTerminated      = "terminated"
 	HostUninitialized   = "initializing"
+	HostSpawning        = "spawning"
 	HostStarting        = "starting"
 	HostProvisioning    = "provisioning"
 	HostProvisionFailed = "provision failed"
@@ -236,6 +237,7 @@ var (
 	UphostStatus = []string{
 		HostRunning,
 		HostUninitialized,
+		HostSpawning,
 		HostStarting,
 		HostProvisioning,
 		HostProvisionFailed,

--- a/globals.go
+++ b/globals.go
@@ -14,7 +14,7 @@ const (
 	HostRunning         = "running"
 	HostTerminated      = "terminated"
 	HostUninitialized   = "initializing"
-	HostSpawning        = "spawning"
+	HostBuilding        = "building"
 	HostStarting        = "starting"
 	HostProvisioning    = "provisioning"
 	HostProvisionFailed = "provision failed"
@@ -237,7 +237,7 @@ var (
 	UphostStatus = []string{
 		HostRunning,
 		HostUninitialized,
-		HostSpawning,
+		HostBuilding,
 		HostStarting,
 		HostProvisioning,
 		HostProvisionFailed,

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -416,10 +416,18 @@ func NeedsNewAgent(currentTime time.Time) db.Q {
 // host intents for *all* distros.
 func RemoveStaleInitializing(distroID string) error {
 	query := bson.M{
-		StatusKey:     evergreen.HostUninitialized,
-		UserHostKey:   false,
-		CreateTimeKey: bson.M{"$lt": time.Now().Add(-3 * time.Minute)},
-		ProviderKey:   bson.M{"$in": evergreen.ProviderSpawnable},
+		UserHostKey: false,
+		ProviderKey: bson.M{"$in": evergreen.ProviderSpawnable},
+		"$or": []bson.M{
+			{
+				StatusKey:     evergreen.HostUninitialized,
+				CreateTimeKey: bson.M{"$lt": time.Now().Add(-3 * time.Minute)},
+			},
+			{
+				StatusKey:     evergreen.HostSpawning,
+				CreateTimeKey: bson.M{"$lt": time.Now().Add(-15 * time.Minute)},
+			},
+		},
 	}
 
 	if distroID != "" {

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -409,8 +409,9 @@ func NeedsNewAgent(currentTime time.Time) db.Q {
 	})
 }
 
-// Removes host intents that have been been pending for more than 3
-// minutes for the specified distro.
+// Removes host intents that have been been uninitialized for more than 3
+// minutes or spawning (but not started) for more than 15 minutes for the
+// specified distro.
 //
 // If you pass the empty string as a distroID, it will remove stale
 // host intents for *all* distros.

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -425,7 +425,7 @@ func RemoveStaleInitializing(distroID string) error {
 				CreateTimeKey: bson.M{"$lt": time.Now().Add(-3 * time.Minute)},
 			},
 			{
-				StatusKey:     evergreen.HostSpawning,
+				StatusKey:     evergreen.HostBuilding,
 				CreateTimeKey: bson.M{"$lt": time.Now().Add(-15 * time.Minute)},
 			},
 		},

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2422,3 +2422,90 @@ func TestCountUphostParents(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(2, numUphostParents)
 }
+
+func TestRemoveStaleInitializing(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.Clear(Collection))
+
+	now := time.Now()
+	distro1 := distro.Distro{Id: "distro1"}
+	distro2 := distro.Distro{Id: "distro2"}
+
+	hosts := []Host{
+		{
+			Id:           "host1",
+			Distro:       distro1,
+			Status:       evergreen.HostUninitialized,
+			CreationTime: now.Add(-1 * time.Minute),
+			UserHost:     false,
+			Provider:     evergreen.ProviderNameEc2Auto,
+		},
+		{
+			Id:           "host2",
+			Distro:       distro1,
+			Status:       evergreen.HostUninitialized,
+			CreationTime: now.Add(-5 * time.Minute),
+			UserHost:     false,
+			Provider:     evergreen.ProviderNameEc2Auto,
+		},
+		{
+			Id:           "host3",
+			Distro:       distro1,
+			Status:       evergreen.HostUninitialized,
+			CreationTime: now.Add(-5 * time.Minute),
+			UserHost:     false,
+			Provider:     evergreen.ProviderNameStatic,
+		},
+		{
+			Id:           "host4",
+			Distro:       distro2,
+			Status:       evergreen.HostUninitialized,
+			CreationTime: now.Add(-5 * time.Minute),
+			UserHost:     false,
+			Provider:     evergreen.ProviderNameEc2Auto,
+		},
+		{
+			Id:           "host5",
+			Distro:       distro1,
+			Status:       evergreen.HostSpawning,
+			CreationTime: now.Add(-5 * time.Minute),
+			UserHost:     false,
+			Provider:     evergreen.ProviderNameEc2Auto,
+		},
+		{
+			Id:           "host6",
+			Distro:       distro1,
+			Status:       evergreen.HostSpawning,
+			CreationTime: now.Add(-30 * time.Minute),
+			UserHost:     false,
+			Provider:     evergreen.ProviderNameEc2Auto,
+		},
+		{
+			Id:           "host7",
+			Distro:       distro2,
+			Status:       evergreen.HostRunning,
+			CreationTime: now.Add(-30 * time.Minute),
+			UserHost:     false,
+			Provider:     evergreen.ProviderNameEc2Auto,
+		},
+	}
+
+	for i, _ := range hosts {
+		hosts[i].Insert()
+	}
+
+	err := RemoveStaleInitializing(distro1.Id)
+	assert.NoError(err)
+
+	numHosts, err := Count(All)
+	assert.NoError(err)
+	assert.Equal(5, numHosts)
+
+	err = RemoveStaleInitializing(distro2.Id)
+	assert.NoError(err)
+
+	numHosts, err = Count(All)
+	assert.NoError(err)
+	assert.Equal(4, numHosts)
+
+}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2467,7 +2467,7 @@ func TestRemoveStaleInitializing(t *testing.T) {
 		{
 			Id:           "host5",
 			Distro:       distro1,
-			Status:       evergreen.HostSpawning,
+			Status:       evergreen.HostBuilding,
 			CreationTime: now.Add(-5 * time.Minute),
 			UserHost:     false,
 			Provider:     evergreen.ProviderNameEc2Auto,
@@ -2475,7 +2475,7 @@ func TestRemoveStaleInitializing(t *testing.T) {
 		{
 			Id:           "host6",
 			Distro:       distro1,
-			Status:       evergreen.HostSpawning,
+			Status:       evergreen.HostBuilding,
 			CreationTime: now.Add(-30 * time.Minute),
 			UserHost:     false,
 			Provider:     evergreen.ProviderNameEc2Auto,

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2491,7 +2491,7 @@ func TestRemoveStaleInitializing(t *testing.T) {
 	}
 
 	for i, _ := range hosts {
-		hosts[i].Insert()
+		assert.NoError(hosts[i].Insert())
 	}
 
 	err := RemoveStaleInitializing(distro1.Id)

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -135,7 +135,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	if j.CurrentAttempt == 1 {
 		intentHost, err := host.FindOneId(j.HostID)
 		if err != nil {
-			return errors.Wrapf(err, "problem removing intent host '%s'", j.HostID)
+			return errors.Wrapf(err, "problem retrieving intent host '%s'", j.HostID)
 		}
 		if err := intentHost.Remove(); err != nil {
 			grip.Notice(message.WrapError(err, message.Fields{

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -122,11 +122,12 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		return errors.Wrapf(errIgnorableCreateHost, "problem getting cloud provider for host '%s' [%s]", j.host.Id, err.Error())
 	}
 
+	defer j.tryRequeue(ctx)
+
 	if err := j.host.SetStatus(evergreen.HostSpawning, evergreen.User, ""); err != nil {
 		return errors.Wrapf(err, "problem setting host %s status to spawning", j.host.Id)
 	}
 
-	defer j.tryRequeue(ctx)
 	if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {
 		return errors.Wrapf(err, "error spawning host %s", j.host.Id)
 	}

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -124,8 +124,8 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 
 	defer j.tryRequeue(ctx)
 
-	if err := j.host.SetStatus(evergreen.HostSpawning, evergreen.User, ""); err != nil {
-		return errors.Wrapf(err, "problem setting host %s status to spawning", j.host.Id)
+	if err := j.host.SetStatus(evergreen.HostBuilding, evergreen.User, ""); err != nil {
+		return errors.Wrapf(err, "problem setting host %s status to building", j.host.Id)
 	}
 
 	if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -123,7 +123,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	}
 
 	if err := j.host.SetStatus(evergreen.HostSpawning, evergreen.User, ""); err != nil {
-		return errors.Wrapf(err, "problem setting container %s status to spawning", j.host.Id)
+		return errors.Wrapf(err, "problem setting host %s status to spawning", j.host.Id)
 	}
 
 	defer j.tryRequeue(ctx)
@@ -131,7 +131,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		return errors.Wrapf(err, "error spawning host %s", j.host.Id)
 	}
 
-	// On the first attempt, remove the intent host
+	// On the first attempt, remove the intent host to insert started host
 	if j.CurrentAttempt == 1 {
 		intentHost, err := host.FindOneId(j.HostID)
 		if err != nil {

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -122,7 +122,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		return errors.Wrapf(errIgnorableCreateHost, "problem getting cloud provider for host '%s' [%s]", j.host.Id, err.Error())
 	}
 
-	if err := j.host.SetStatus(evergreen.HostSpawning, evergreen.User, "container status: spawning"); err != nil {
+	if err := j.host.SetStatus(evergreen.HostSpawning, evergreen.User, ""); err != nil {
 		return errors.Wrapf(err, "problem setting container %s status to spawning", j.host.Id)
 	}
 


### PR DESCRIPTION
Previously, the intent document is removed before SpawnHost is called and the host document is reinserted as starting only after SpawnHost returns. This is a problem for containers, since SpawnHost can take even a few minutes to return (if the parent has to download and build new container images). In such cases, the scheduler will continue to create new container intent documents.

This adds a new HostSpawning status after the intent doc is picked up by Hostinit but before SpawnHost returns. This prevents the Scheduler from creating redundant container intent docs or removing container intent documents while containers are Spawning. 