### PR TITLE
EVG-3222 add UI element for createhost reproduction

### DIFF
--- a/public/static/js/services/rest.js
+++ b/public/static/js/services/rest.js
@@ -241,6 +241,7 @@ mciServices.rest.factory('mciSpawnRestService', ['mciBaseRestService', function(
         config.data['key_name'] = spawnInfo.spawnKey.name;
         config.data['public_key'] = spawnInfo.spawnKey.key;
         config.data['userdata'] = spawnInfo.userData;
+        config.data['use_task_config'] = spawnInfo.useTaskConfig;
         baseSvc.putResource(resource, [], config, callbacks);
     };
 

--- a/public/static/js/spawned_hosts.js
+++ b/public/static/js/spawned_hosts.js
@@ -16,6 +16,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope','$window', '$timeout', 'mciSp
     $scope.hostExtensionLengths = {};
     $scope.maxHostsPerUser = $window.maxHostsPerUser;
     $scope.spawnReqSent = false;
+    $scope.useTaskConfig = false;
 
     // max of 7 days time to expiration
     $scope.maxHoursToExpiration = 24*7;
@@ -146,6 +147,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope','$window', '$timeout', 'mciSp
       $scope.spawnInfo.spawnKey = $scope.selectedKey;
       $scope.spawnInfo.saveKey = $scope.saveKey;
       $scope.spawnInfo.userData = $scope.userdata;
+      $scope.spawnInfo.useTaskConfig = $scope.useTaskConfig;
       if($scope.spawnTaskChecked && !!$scope.spawnTask){
         $scope.spawnInfo.task_id = $scope.spawnTask.id;
       }

--- a/public/static/partials/user_host_options.html
+++ b/public/static/partials/user_host_options.html
@@ -72,7 +72,11 @@
     </div>
     <div class="spawn-task-options" ng-show="!!spawnTask">
       <input type="checkbox" ng-model="$parent.spawnTaskChecked">
-      Load data for <strong>[[spawnTask.display_name]]</strong> on <strong>[[spawnTask.build_variant]]</strong> @ <strong class="mono">[[spawnTask.gitspec | limitTo:5]]</strong> onto host at startup
+        Load data for <strong>[[spawnTask.display_name]]</strong> on <strong>[[spawnTask.build_variant]]</strong> @ <strong class="mono">[[spawnTask.gitspec | limitTo:5]]</strong> onto host at startup
+      </input>
+      <br/>
+      <input type="checkbox" ng-model="$parent.useTaskConfig">
+        Also start any hosts this task started (if applicable)
       </input>
     </div>
     <div>


### PR DESCRIPTION
I didn't see a field in the task document that tells me whether the task spawned any hosts, but if there is one then the checkbox can be hidden if not applicable

![image](https://user-images.githubusercontent.com/29384396/43847008-a16a2a88-9afd-11e8-9aeb-d563d58b785a.png)
