### PR TITLE
EVG-3507 fix bugs in container state consistency job

### DIFF
--- a/units/host_monitoring_container_state_test.go
+++ b/units/host_monitoring_container_state_test.go
@@ -40,9 +40,15 @@ func TestHostMonitoringContainerStateJob(t *testing.T) {
 		Status:   evergreen.HostRunning,
 		ParentID: "parent-1",
 	}
+	h4 := &host.Host{
+		Id:       "container-3",
+		Status:   evergreen.HostUninitialized,
+		ParentID: "parent-1",
+	}
 	assert.NoError(h1.Insert())
 	assert.NoError(h2.Insert())
 	assert.NoError(h3.Insert())
+	assert.NoError(h4.Insert())
 
 	j := NewHostMonitorContainerStateJob(env, h1, evergreen.ProviderNameDockerMock, "job-1")
 	assert.False(j.Status().Completed)
@@ -59,4 +65,8 @@ func TestHostMonitoringContainerStateJob(t *testing.T) {
 	container2, err := host.FindOne(host.ById("container-2"))
 	assert.NoError(err)
 	assert.Equal(evergreen.HostTerminated, container2.Status)
+
+	container3, err := host.FindOne(host.ById("container-3"))
+	assert.NoError(err)
+	assert.Equal(evergreen.HostUninitialized, container3.Status)
 }


### PR DESCRIPTION
This makes two changes to the container state consistency job in order to fix bugs discovered in E2E testing.

- Exports the provider name in the job. This was not previously exported, which meant that the job tried to retrieve a "" cloud manager whenever it ran.
- Only terminates not running in Docker that are running or decommissioned in the DB. Previously, the job would terminate any containers not running in Docker (including host documents that were still initializing).
