### PR TITLE
EVG-5151 remove exposed port from Docker containers

### DIFF
--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -2,7 +2,6 @@ package cloud
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -114,29 +113,6 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 		"container": h.Id,
 	})
 	event.LogHostStarted(h.Id)
-
-	// Retrieve container details
-	newContainer, err := m.client.GetContainer(ctx, parentHost, h.Id)
-	if err != nil {
-		err = errors.Wrapf(err, "Docker inspect container API call failed for host '%s'", hostIP)
-		grip.Error(err)
-		return nil, err
-	}
-
-	hostPort, err := retrieveOpenPortBinding(newContainer)
-	if err != nil {
-		err = errors.Wrapf(err, "Container '%s' could not retrieve open ports", newContainer.ID)
-		grip.Error(err)
-		return nil, err
-	}
-	h.Host = fmt.Sprintf("%s:%s", hostIP, hostPort)
-
-	grip.Info(message.Fields{
-		"message":   "retrieved open port binding",
-		"container": h.Id,
-		"host_ip":   hostIP,
-		"host_port": hostPort,
-	})
 
 	return h, nil
 }

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -134,13 +134,10 @@ func (m *dockerManager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cl
 	return toEvgStatus(container.State), nil
 }
 
-//GetDNSName gets the DNS hostname of a container by reading it directly from
-//the Docker API
+// GetDNSName gets the DNS hostname of a container by reading it directly from
+// the Docker API
 func (m *dockerManager) GetDNSName(ctx context.Context, h *host.Host) (string, error) {
-	if h.Host == "" {
-		return "", errors.New("DNS name is empty")
-	}
-	return h.Host, nil
+	return "", nil
 }
 
 //TerminateInstance destroys a container.

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -134,8 +134,7 @@ func (m *dockerManager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cl
 	return toEvgStatus(container.State), nil
 }
 
-// GetDNSName gets the DNS hostname of a container by reading it directly from
-// the Docker API
+// GetDNSName does nothing, returning an empty string and no error.
 func (m *dockerManager) GetDNSName(ctx context.Context, h *host.Host) (string, error) {
 	return "", nil
 }

--- a/cloud/docker_util.go
+++ b/cloud/docker_util.go
@@ -3,78 +3,8 @@
 package cloud
 
 import (
-	"fmt"
-
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/go-connections/nat"
-	"github.com/evergreen-ci/evergreen/model/host"
-	"github.com/mongodb/grip"
-	"github.com/pkg/errors"
 )
-
-const (
-	// sshdPort exposed port (set to 22/tcp, default ssh port)
-	sshdPort nat.Port = "22/tcp"
-	// address to bind container sshd client to
-	bindIP = "localhost"
-)
-
-// makeHostConfig generates a host configuration struct that binds a container's SSH port
-// to an open port on the host machine. An open port must be in the port range specified
-// by the provider settings, but must not a port already being used by existing containers.
-// If no ports are available on the host machine, makeHostConfig errors.
-func makeHostConfig(h *host.Host, containers []types.Container) (*container.HostConfig, error) {
-	hostConfig := &container.HostConfig{}
-
-	reservedPorts := make(map[uint16]bool)
-	for _, c := range containers {
-		for _, p := range c.Ports {
-			reservedPorts[p.PublicPort] = true
-		}
-	}
-
-	// mark dockerd port as reserved
-	reservedPorts[h.ContainerPoolSettings.Port] = true
-
-	hostConfig.PortBindings = make(nat.PortMap)
-	for i := h.ContainerPoolSettings.Port; i <= h.ContainerPoolSettings.Port+uint16(h.ContainerPoolSettings.MaxContainers); i++ {
-		// if port is not already in use, bind it to sshd exposed container port
-		if !reservedPorts[i] {
-			hostConfig.PortBindings[sshdPort] = []nat.PortBinding{
-				{
-					HostIP:   bindIP,
-					HostPort: fmt.Sprintf("%d", i),
-				},
-			}
-			break
-		}
-	}
-
-	// If map is empty, no ports were available.
-	if len(hostConfig.PortBindings) == 0 {
-		err := errors.New("No available ports in specified range")
-		grip.Error(err)
-		return nil, err
-	}
-
-	return hostConfig, nil
-}
-
-// retrieveOpenPortBinding retrieves a port in the given container that is open to
-// SSH access from external connections.
-func retrieveOpenPortBinding(containerPtr *types.ContainerJSON) (string, error) {
-	exposedPorts := containerPtr.Config.ExposedPorts
-	ports := containerPtr.NetworkSettings.Ports
-
-	for k := range exposedPorts {
-		portBindings := ports[k]
-		if len(portBindings) > 0 {
-			return portBindings[0].HostPort, nil
-		}
-	}
-	return "", errors.New("No available ports")
-}
 
 // toEvgStatus converts a container state to an Evergreen cloud provider status.
 func toEvgStatus(s *types.ContainerState) CloudStatus {


### PR DESCRIPTION
Removes container port configuration from the Docker client and tests. We noticed that when multiple containers were trying to start at the same time, they all tried to bind to the same port and only one would be able to start successfully. We realized that these exposed ports are no longer necessary, since we do not directly SSH into the individual containers. The code supporting exposed ports can be safely removed.

Should we keep the utils, even if the Docker client no longer uses them?