### PR TITLE
EVG-5148 add dockerClient.Close() method to return httpClient to pool

### DIFF
--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -261,7 +261,7 @@ func (m *dockerManager) canImageBeRemoved(ctx context.Context, h *host.Host, ima
 	}
 
 	for _, container := range containers {
-		if container.Image == imageID {
+		if container.ImageID == imageID {
 			return false, nil
 		}
 	}

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -70,7 +70,6 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 		"image_url": settings.ImageURL,
 	})
 
-	var err error
 	parentHost, err := h.GetParent()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error retrieving parent for host '%s'", h.Id)
@@ -125,7 +124,6 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 // GetInstanceStatus returns a universal status code representing the state
 // of a container.
 func (m *dockerManager) GetInstanceStatus(ctx context.Context, h *host.Host) (CloudStatus, error) {
-	var err error
 	parentHost, err := h.GetParent()
 	if err != nil {
 		return StatusUnknown, errors.Wrapf(err, "Error retrieving parent for host '%s'", h.Id)
@@ -151,7 +149,6 @@ func (m *dockerManager) GetDNSName(ctx context.Context, h *host.Host) (string, e
 
 //TerminateInstance destroys a container.
 func (m *dockerManager) TerminateInstance(ctx context.Context, h *host.Host, user string) error {
-	var err error
 	parentHost, err := h.GetParent()
 	if err != nil {
 		return errors.Wrapf(err, "Error retrieving parent for host '%s'", h.Id)

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -27,22 +27,26 @@ import (
 // The dockerClient interface wraps the Docker dockerClient interaction.
 type dockerClient interface {
 	Init(string) error
+
+	Create(*host.Host) error
 	Close()
-	EnsureImageDownloaded(context.Context, *host.Host, string) (string, error)
+
+	EnsureImageDownloaded(context.Context, string) (string, error)
 	BuildImageWithAgent(context.Context, *host.Host, string) (string, error)
-	CreateContainer(context.Context, *host.Host, *host.Host, *dockerSettings) error
-	GetContainer(context.Context, *host.Host, string) (*types.ContainerJSON, error)
-	ListContainers(context.Context, *host.Host) ([]types.Container, error)
-	RemoveImage(context.Context, *host.Host, string) error
-	RemoveContainer(context.Context, *host.Host, string) error
-	StartContainer(context.Context, *host.Host, string) error
-	ListImages(context.Context, *host.Host) ([]types.ImageSummary, error)
+	CreateContainer(context.Context, *host.Host, *dockerSettings) error
+	GetContainer(context.Context, string) (*types.ContainerJSON, error)
+	ListContainers(context.Context) ([]types.Container, error)
+	RemoveImage(context.Context, string) error
+	RemoveContainer(context.Context, string) error
+	StartContainer(context.Context, string) error
+	ListImages(context.Context) ([]types.ImageSummary, error)
 }
 
 type dockerClientImpl struct {
 	// apiVersion specifies the version of the Docker API.
 	apiVersion string
 	// httpDockerClient for making HTTP requests within the Docker dockerClient wrapper.
+	daemonHost        *host.Host
 	httpClient        *http.Client
 	client            *docker.Client
 	evergreenSettings *evergreen.Settings
@@ -54,85 +58,43 @@ const (
 	imageImportTimeout  = 10 * time.Minute
 )
 
-// generateClient generates a Docker client that can talk to the specified host
-// machine. The Docker client must be exposed and available for requests at the
-// client port 3369 on the host machine.
-func (c *dockerClientImpl) generateClient(h *host.Host) (*docker.Client, error) {
-	if h.Host == "" {
-		return nil, errors.New("HostIP must not be blank")
-	}
-
-	// Cache the *docker.Client in dockerClientImpl, return this client if
-	// httpClient exists and has not been returned to pool
-	if c.client != nil && c.httpClient != nil {
-		return c.client, nil
-	}
-
-	// Get new httpClient if dockerClient has none
-	if c.httpClient == nil {
-		err := c.getHTTPClient()
-		if err != nil {
-			return nil, errors.Wrap(err, "Error getting new HTTP client")
-		}
-	}
-
-	// Create a Docker client to wrap Docker API calls. The Docker TCP endpoint must
-	// be exposed and available for requests at the client port on the host machine.
-	var err error
-	endpoint := fmt.Sprintf("tcp://%s:%v", h.Host, h.ContainerPoolSettings.Port)
-	c.client, err = docker.NewClient(endpoint, c.apiVersion, c.httpClient, nil)
-	if err != nil {
-		grip.Error(message.Fields{
-			"message":     "Docker initialize client API call failed",
-			"error":       err,
-			"endpoint":    endpoint,
-			"api_version": c.apiVersion,
-		})
-		return nil, errors.Wrapf(err, "Docker initialize client API call failed at endpoint '%s'", endpoint)
-	}
-
-	return c.client, nil
-}
-
-// changeTimeout changes the timeout of dockerClient's internal httpClient and
-// returns a new docker.Client with the updated timeout
-func (c *dockerClientImpl) changeTimeout(h *host.Host, newTimeout time.Duration) (*docker.Client, error) {
-	if c.httpClient == nil {
-		return nil, errors.New("Error changing timeout: httpClient cannot be nil")
-	}
-
-	var err error
-	c.httpClient.Timeout = newTimeout
-	c.client, err = c.generateClient(h)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to generate docker client")
-	}
-
-	return c.client, nil
-}
-
-// getHTTPClient returns a new HTTP client from the pool capable of communicating
-// over TLS with a remote Docker daemon
-func (c *dockerClientImpl) getHTTPClient() error {
-	// Create HTTP client
-	c.httpClient = util.GetHTTPClient()
-
-	// Allow connections to Docker daemon with self-signed certificates
-	transport, ok := c.httpClient.Transport.(*http.Transport)
-	if !ok {
-		return errors.Errorf("Type assertion failed: type %T does not hold a *http.Transport", c.httpClient.Transport)
-	}
-	transport.TLSClientConfig.InsecureSkipVerify = true
-
-	return nil
-}
-
 // Init sets the Docker API version to use for API calls to the Docker client.
 func (c *dockerClientImpl) Init(apiVersion string) error {
 	if apiVersion == "" {
 		return errors.Errorf("Docker API version '%s' is invalid", apiVersion)
 	}
 	c.apiVersion = apiVersion
+
+	return nil
+}
+
+// Create generates a Docker client that can talk to the specified host
+// machine.
+func (c *dockerClientImpl) Create(h *host.Host) error {
+	// Do nothing if httpClient and dockerClient already generated
+	if c.client != nil && c.httpClient != nil {
+		return nil
+	}
+
+	// Validate Docker daemon host
+	if h.Host == "" {
+		return errors.New("HostIP must not be blank")
+	}
+	c.daemonHost = h
+
+	// Get new httpClient if dockerClient has none
+	if c.httpClient == nil {
+		err := c.generateHTTPClient()
+		if err != nil {
+			return errors.Wrap(err, "Error getting new HTTP client")
+		}
+	}
+
+	// Get new docker.Client
+	err := c.generateDockerClient()
+	if err != nil {
+		return errors.Wrap(err, "Error getting new Docker client")
+	}
 
 	return nil
 }
@@ -146,12 +108,65 @@ func (c *dockerClientImpl) Close() {
 	return
 }
 
+// changeTimeout changes the timeout of dockerClient's internal httpClient and
+// generates a new docker.Client with the updated timeout.
+func (c *dockerClientImpl) changeTimeout(newTimeout time.Duration) error {
+	if c.httpClient == nil {
+		return errors.New("Error changing timeout: httpClient cannot be nil")
+	}
+
+	c.httpClient.Timeout = newTimeout
+	err := c.generateDockerClient()
+	if err != nil {
+		return errors.Wrap(err, "Failed to generate docker client")
+	}
+
+	return nil
+}
+
+// generateHTTPClient gets a new HTTP client from the pool capable of communicating
+// over TLS with a remote Docker daemon
+func (c *dockerClientImpl) generateHTTPClient() error {
+	// Create HTTP client
+	c.httpClient = util.GetHTTPClient()
+
+	// Allow connections to Docker daemon with self-signed certificates
+	transport, ok := c.httpClient.Transport.(*http.Transport)
+	if !ok {
+		return errors.Errorf("Type assertion failed: type %T does not hold a *http.Transport", c.httpClient.Transport)
+	}
+	transport.TLSClientConfig.InsecureSkipVerify = true
+
+	return nil
+}
+
+// generateDockerClient generates a Docker client to wrap Docker API calls. The
+// Docker TCP endpoint must be exposed and available for requests at the client
+// port on the Docker daemon host machine.
+func (c *dockerClientImpl) generateDockerClient() error {
+	var err error
+	endpoint := fmt.Sprintf("tcp://%s:%v", c.daemonHost.Host, c.daemonHost.ContainerPoolSettings.Port)
+	c.client, err = docker.NewClient(endpoint, c.apiVersion, c.httpClient, nil)
+	if err != nil {
+		grip.Error(message.Fields{
+			"message":     "Docker initialize client API call failed",
+			"error":       err,
+			"endpoint":    endpoint,
+			"api_version": c.apiVersion,
+		})
+		return errors.Wrapf(err, "Docker initialize client API call failed at endpoint '%s'", endpoint)
+	}
+
+	return nil
+}
+
 // EnsureImageDownloaded checks if the image in s3 specified by the URL already exists,
 // and if not, creates a new image from the remote tarball.
-func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, h *host.Host, url string) (string, error) {
-	dockerClient, err := c.generateClient(h)
+func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, url string) (string, error) {
+	// Check that Docker client is properly configured
+	err := c.Create(c.daemonHost)
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to generate docker client")
+		return "", errors.Wrap(err, "Error generating Docker client")
 	}
 
 	// Extract image name from url
@@ -159,7 +174,7 @@ func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, h *host.Ho
 	imageName := strings.TrimSuffix(baseName, filepath.Ext(baseName))
 
 	// Check if image already exists on host
-	_, _, err = dockerClient.ImageInspectWithRaw(ctx, imageName)
+	_, _, err = c.client.ImageInspectWithRaw(ctx, imageName)
 	if err == nil {
 		// Image already exists
 		return imageName, nil
@@ -167,19 +182,19 @@ func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, h *host.Ho
 
 		// Extend http client timeout for ImageImport
 		normalTimeout := c.httpClient.Timeout
-		dockerClient, err := c.changeTimeout(h, imageImportTimeout)
+		err = c.changeTimeout(imageImportTimeout)
 		if err != nil {
 			return "", errors.Wrap(err, "Error changing http client timeout")
 		}
 
 		// Image does not exist, import from remote tarball
 		source := types.ImageImportSource{SourceName: url}
-		msg := makeDockerLogMessage("ImageImport", h.Id, message.Fields{
+		msg := makeDockerLogMessage("ImageImport", c.daemonHost.Id, message.Fields{
 			"source":     source,
 			"image_name": imageName,
 			"image_url":  url,
 		})
-		resp, err := dockerClient.ImageImport(ctx, source, imageName, types.ImageImportOptions{})
+		resp, err := c.client.ImageImport(ctx, source, imageName, types.ImageImportOptions{})
 		if err != nil {
 			return "", errors.Wrapf(err, "Error importing image from %s", url)
 		}
@@ -192,7 +207,7 @@ func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, h *host.Ho
 		}
 
 		// Reset http client timeout
-		_, err = c.changeTimeout(h, normalTimeout)
+		err = c.changeTimeout(normalTimeout)
 		if err != nil {
 			return "", errors.Wrap(err, "Error changing http client timeout")
 		}
@@ -205,19 +220,20 @@ func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, h *host.Ho
 
 // BuildImageWithAgent takes a base image and builds a new image on the specified
 // host from a Dockfile in the root directory, which adds the Evergreen binary
-func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, h *host.Host, baseImage string) (string, error) {
-	const dockerfileRoute = "dockerfile"
-
-	dockerClient, err := c.generateClient(h)
+func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, containerHost *host.Host, baseImage string) (string, error) {
+	// Check that Docker client is properly configured
+	err := c.Create(c.daemonHost)
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to generate docker client")
+		return "", errors.Wrap(err, "Error generating Docker client")
 	}
+
+	const dockerfileRoute = "dockerfile"
 
 	// modify tag for new image
 	provisionedImage := fmt.Sprintf(provisionedImageTag, baseImage)
 
-	executableSubPath := h.Distro.ExecutableSubPath()
-	binaryName := h.Distro.BinaryName()
+	executableSubPath := containerHost.Distro.ExecutableSubPath()
+	binaryName := containerHost.Distro.BinaryName()
 
 	// build dockerfile route
 	dockerfileUrl := strings.Join([]string{
@@ -238,13 +254,13 @@ func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, h *host.Host
 		Tags:          []string{provisionedImage},
 	}
 
-	msg := makeDockerLogMessage("ImageBuild", h.Id, message.Fields{
+	msg := makeDockerLogMessage("ImageBuild", c.daemonHost.Id, message.Fields{
 		"base_image":     options.BuildArgs["BASE_IMAGE"],
 		"dockerfile_url": options.RemoteContext,
 	})
 
 	// build the image
-	resp, err := dockerClient.ImageBuild(ctx, nil, options)
+	resp, err := c.client.ImageBuild(ctx, nil, options)
 	if err != nil {
 		return "", errors.Wrapf(err, "Error building Docker image from base image %s", baseImage)
 	}
@@ -270,27 +286,28 @@ func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, h *host.Host
 //     3. The image must have the same ~/.ssh/authorized_keys file as the host machine
 //        in order to allow users with SSH access to the host machine to have SSH access
 //        to the container.
-func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, containerHost *host.Host, settings *dockerSettings) error {
-	dockerClient, err := c.generateClient(parentHost)
+func (c *dockerClientImpl) CreateContainer(ctx context.Context, containerHost *host.Host, settings *dockerSettings) error {
+	// Check that Docker client is properly configured
+	err := c.Create(c.daemonHost)
 	if err != nil {
-		return errors.Wrap(err, "Failed to generate docker client")
+		return errors.Wrap(err, "Error generating Docker client")
 	}
 
 	// Import correct base image if not already on host.
-	image, err := c.EnsureImageDownloaded(ctx, parentHost, settings.ImageURL)
+	image, err := c.EnsureImageDownloaded(ctx, settings.ImageURL)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to ensure that image '%s' is on host '%s'", settings.ImageURL, parentHost.Id)
+		return errors.Wrapf(err, "Unable to ensure that image '%s' is on host '%s'", settings.ImageURL, c.daemonHost.Id)
 	}
 
 	// Build image containing Evergreen executable.
-	provisionedImage, err := c.BuildImageWithAgent(ctx, parentHost, image)
+	provisionedImage, err := c.BuildImageWithAgent(ctx, containerHost, image)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to build image %s with agent on host '%s'", image, parentHost.Id)
+		return errors.Wrapf(err, "Failed to build image %s with agent on host '%s'", image, c.daemonHost.Id)
 	}
 
 	// Build path to Evergreen executable.
 	pathToExecutable := filepath.Join("root", "evergreen")
-	if parentHost.Distro.IsWindows() {
+	if containerHost.Distro.IsWindows() {
 		pathToExecutable += ".exe"
 	}
 
@@ -322,12 +339,12 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 	networkConf := &network.NetworkingConfig{}
 	hostConf := &container.HostConfig{}
 
-	msg := makeDockerLogMessage("ContainerCreate", parentHost.Id, message.Fields{
+	msg := makeDockerLogMessage("ContainerCreate", c.daemonHost.Id, message.Fields{
 		"image": containerConf.Image,
 	})
 
 	// Build container
-	if _, err := dockerClient.ContainerCreate(ctx, containerConf, hostConf, networkConf, containerHost.Id); err != nil {
+	if _, err := c.client.ContainerCreate(ctx, containerConf, hostConf, networkConf, containerHost.Id); err != nil {
 		err = errors.Wrapf(err, "Docker create API call failed for container '%s'", containerHost.Id)
 		grip.Error(err)
 		return err
@@ -339,13 +356,14 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 
 // GetContainer returns low-level information on the Docker container with the
 // specified ID running on the specified host machine.
-func (c *dockerClientImpl) GetContainer(ctx context.Context, h *host.Host, containerID string) (*types.ContainerJSON, error) {
-	dockerClient, err := c.generateClient(h)
+func (c *dockerClientImpl) GetContainer(ctx context.Context, containerID string) (*types.ContainerJSON, error) {
+	// Check that Docker client is properly configured
+	err := c.Create(c.daemonHost)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to generate docker client")
+		return nil, errors.Wrap(err, "Error generating Docker client")
 	}
 
-	container, err := dockerClient.ContainerInspect(ctx, containerID)
+	container, err := c.client.ContainerInspect(ctx, containerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Docker inspect API call failed for container '%s'", containerID)
 	}
@@ -354,15 +372,16 @@ func (c *dockerClientImpl) GetContainer(ctx context.Context, h *host.Host, conta
 }
 
 // ListContainers lists all containers running on the specified host machine.
-func (c *dockerClientImpl) ListContainers(ctx context.Context, h *host.Host) ([]types.Container, error) {
-	dockerClient, err := c.generateClient(h)
+func (c *dockerClientImpl) ListContainers(ctx context.Context) ([]types.Container, error) {
+	// Check that Docker client is properly configured
+	err := c.Create(c.daemonHost)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to generate docker client")
+		return nil, errors.Wrap(err, "Error generating Docker client")
 	}
 
 	// Get all running containers
 	opts := types.ContainerListOptions{All: false}
-	containers, err := dockerClient.ContainerList(ctx, opts)
+	containers, err := c.client.ContainerList(ctx, opts)
 	if err != nil {
 		err = errors.Wrap(err, "Docker list API call failed")
 		grip.Error(err)
@@ -373,15 +392,16 @@ func (c *dockerClientImpl) ListContainers(ctx context.Context, h *host.Host) ([]
 }
 
 // ListImages lists all images on the specified host machine.
-func (c *dockerClientImpl) ListImages(ctx context.Context, h *host.Host) ([]types.ImageSummary, error) {
-	dockerClient, err := c.generateClient(h)
+func (c *dockerClientImpl) ListImages(ctx context.Context) ([]types.ImageSummary, error) {
+	// Check that Docker client is properly configured
+	err := c.Create(c.daemonHost)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to generate docker client")
+		return nil, errors.Wrap(err, "Error generating Docker client")
 	}
 
 	// Get all container images
 	opts := types.ImageListOptions{All: false}
-	images, err := dockerClient.ImageList(ctx, opts)
+	images, err := c.client.ImageList(ctx, opts)
 	if err != nil {
 		err = errors.Wrap(err, "Docker list API call failed")
 		return nil, err
@@ -391,14 +411,15 @@ func (c *dockerClientImpl) ListImages(ctx context.Context, h *host.Host) ([]type
 }
 
 // RemoveImage forcibly removes an image from its host machine
-func (c *dockerClientImpl) RemoveImage(ctx context.Context, h *host.Host, imageID string) error {
-	dockerClient, err := c.generateClient(h)
+func (c *dockerClientImpl) RemoveImage(ctx context.Context, imageID string) error {
+	// Check that Docker client is properly configured
+	err := c.Create(c.daemonHost)
 	if err != nil {
-		return errors.Wrap(err, "Failed to generate docker client")
+		return errors.Wrap(err, "Error generating Docker client")
 	}
 
 	opts := types.ImageRemoveOptions{Force: true}
-	removed, err := dockerClient.ImageRemove(ctx, imageID, opts)
+	removed, err := c.client.ImageRemove(ctx, imageID, opts)
 	if err != nil {
 		err = errors.Wrapf(err, "Failed to remove image '%s'", imageID)
 		return err
@@ -411,14 +432,14 @@ func (c *dockerClientImpl) RemoveImage(ctx context.Context, h *host.Host, imageI
 }
 
 // RemoveContainer forcibly removes a running or stopped container by ID from its host machine.
-func (c *dockerClientImpl) RemoveContainer(ctx context.Context, h *host.Host, containerID string) error {
-	dockerClient, err := c.generateClient(h)
+func (c *dockerClientImpl) RemoveContainer(ctx context.Context, containerID string) error {
+	err := c.Create(c.daemonHost)
 	if err != nil {
-		return errors.Wrap(err, "Failed to generate docker client")
+		return errors.Wrap(err, "Error generating Docker client")
 	}
 
 	opts := types.ContainerRemoveOptions{Force: true}
-	if err = dockerClient.ContainerRemove(ctx, containerID, opts); err != nil {
+	if err := c.client.ContainerRemove(ctx, containerID, opts); err != nil {
 		err = errors.Wrapf(err, "Failed to remove container '%s'", containerID)
 		grip.Error(err)
 		return err
@@ -428,14 +449,14 @@ func (c *dockerClientImpl) RemoveContainer(ctx context.Context, h *host.Host, co
 }
 
 // StartContainer starts a stopped or new container by ID on the host machine.
-func (c *dockerClientImpl) StartContainer(ctx context.Context, h *host.Host, containerID string) error {
-	dockerClient, err := c.generateClient(h)
+func (c *dockerClientImpl) StartContainer(ctx context.Context, containerID string) error {
+	err := c.Create(c.daemonHost)
 	if err != nil {
-		return errors.Wrap(err, "Failed to generate docker client")
+		return errors.Wrap(err, "Error generating Docker client")
 	}
 
 	opts := types.ContainerStartOptions{}
-	if err := dockerClient.ContainerStart(ctx, containerID, opts); err != nil {
+	if err := c.client.ContainerStart(ctx, containerID, opts); err != nil {
 		return errors.Wrapf(err, "Failed to start container %s", containerID)
 	}
 

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -63,12 +63,12 @@ func (c *dockerClientImpl) generateClient(h *host.Host) (*docker.Client, error) 
 	}
 
 	// Cache the *docker.Client in dockerClientImpl, return this client if
-	// httpClient has not been closed
+	// httpClient exists and has not been returned to pool
 	if c.client != nil && c.httpClient != nil {
 		return c.client, nil
 	}
 
-	// Get new HTTP client
+	// Get new httpClient if dockerClient has none
 	if c.httpClient == nil {
 		err := c.getHTTPClient()
 		if err != nil {
@@ -111,6 +111,8 @@ func (c *dockerClientImpl) changeTimeout(h *host.Host, newTimeout time.Duration)
 	return c.client, nil
 }
 
+// getHTTPClient returns a new HTTP client from the pool capable of communicating
+// over TLS with a remote Docker daemon
 func (c *dockerClientImpl) getHTTPClient() error {
 	// Create HTTP client
 	c.httpClient = util.GetHTTPClient()

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -163,18 +163,12 @@ func (c *dockerClientImpl) generateDockerClient() error {
 // EnsureImageDownloaded checks if the image in s3 specified by the URL already exists,
 // and if not, creates a new image from the remote tarball.
 func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, url string) (string, error) {
-	// Check that Docker client is properly configured
-	err := c.Create(c.daemonHost)
-	if err != nil {
-		return "", errors.Wrap(err, "Error generating Docker client")
-	}
-
 	// Extract image name from url
 	baseName := path.Base(url)
 	imageName := strings.TrimSuffix(baseName, filepath.Ext(baseName))
 
 	// Check if image already exists on host
-	_, _, err = c.client.ImageInspectWithRaw(ctx, imageName)
+	_, _, err := c.client.ImageInspectWithRaw(ctx, imageName)
 	if err == nil {
 		// Image already exists
 		return imageName, nil
@@ -221,12 +215,6 @@ func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, url string
 // BuildImageWithAgent takes a base image and builds a new image on the specified
 // host from a Dockfile in the root directory, which adds the Evergreen binary
 func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, containerHost *host.Host, baseImage string) (string, error) {
-	// Check that Docker client is properly configured
-	err := c.Create(c.daemonHost)
-	if err != nil {
-		return "", errors.Wrap(err, "Error generating Docker client")
-	}
-
 	const dockerfileRoute = "dockerfile"
 
 	// modify tag for new image
@@ -287,12 +275,6 @@ func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, containerHos
 //        in order to allow users with SSH access to the host machine to have SSH access
 //        to the container.
 func (c *dockerClientImpl) CreateContainer(ctx context.Context, containerHost *host.Host, settings *dockerSettings) error {
-	// Check that Docker client is properly configured
-	err := c.Create(c.daemonHost)
-	if err != nil {
-		return errors.Wrap(err, "Error generating Docker client")
-	}
-
 	// Import correct base image if not already on host.
 	image, err := c.EnsureImageDownloaded(ctx, settings.ImageURL)
 	if err != nil {
@@ -357,12 +339,6 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, containerHost *h
 // GetContainer returns low-level information on the Docker container with the
 // specified ID running on the specified host machine.
 func (c *dockerClientImpl) GetContainer(ctx context.Context, containerID string) (*types.ContainerJSON, error) {
-	// Check that Docker client is properly configured
-	err := c.Create(c.daemonHost)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error generating Docker client")
-	}
-
 	container, err := c.client.ContainerInspect(ctx, containerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Docker inspect API call failed for container '%s'", containerID)
@@ -373,12 +349,6 @@ func (c *dockerClientImpl) GetContainer(ctx context.Context, containerID string)
 
 // ListContainers lists all containers running on the specified host machine.
 func (c *dockerClientImpl) ListContainers(ctx context.Context) ([]types.Container, error) {
-	// Check that Docker client is properly configured
-	err := c.Create(c.daemonHost)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error generating Docker client")
-	}
-
 	// Get all running containers
 	opts := types.ContainerListOptions{All: false}
 	containers, err := c.client.ContainerList(ctx, opts)
@@ -393,12 +363,6 @@ func (c *dockerClientImpl) ListContainers(ctx context.Context) ([]types.Containe
 
 // ListImages lists all images on the specified host machine.
 func (c *dockerClientImpl) ListImages(ctx context.Context) ([]types.ImageSummary, error) {
-	// Check that Docker client is properly configured
-	err := c.Create(c.daemonHost)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error generating Docker client")
-	}
-
 	// Get all container images
 	opts := types.ImageListOptions{All: false}
 	images, err := c.client.ImageList(ctx, opts)
@@ -433,11 +397,6 @@ func (c *dockerClientImpl) RemoveImage(ctx context.Context, imageID string) erro
 
 // RemoveContainer forcibly removes a running or stopped container by ID from its host machine.
 func (c *dockerClientImpl) RemoveContainer(ctx context.Context, containerID string) error {
-	err := c.Create(c.daemonHost)
-	if err != nil {
-		return errors.Wrap(err, "Error generating Docker client")
-	}
-
 	opts := types.ContainerRemoveOptions{Force: true}
 	if err := c.client.ContainerRemove(ctx, containerID, opts); err != nil {
 		err = errors.Wrapf(err, "Failed to remove container '%s'", containerID)
@@ -450,11 +409,6 @@ func (c *dockerClientImpl) RemoveContainer(ctx context.Context, containerID stri
 
 // StartContainer starts a stopped or new container by ID on the host machine.
 func (c *dockerClientImpl) StartContainer(ctx context.Context, containerID string) error {
-	err := c.Create(c.daemonHost)
-	if err != nil {
-		return errors.Wrap(err, "Error generating Docker client")
-	}
-
 	opts := types.ContainerStartOptions{}
 	if err := c.client.ContainerStart(ctx, containerID, opts); err != nil {
 		return errors.Wrapf(err, "Failed to start container %s", containerID)

--- a/cloud/docker_mock.go
+++ b/cloud/docker_mock.go
@@ -40,6 +40,10 @@ func (c *dockerClientMock) Init(string) error {
 	return nil
 }
 
+func (c *dockerClientMock) Close() {
+	return
+}
+
 func (c *dockerClientMock) EnsureImageDownloaded(context.Context, *host.Host, string) (string, error) {
 	if c.failDownload {
 		return "", errors.New("failed to download image")

--- a/cloud/docker_mock.go
+++ b/cloud/docker_mock.go
@@ -40,11 +40,11 @@ func (c *dockerClientMock) Init(string) error {
 	return nil
 }
 
-func (c *dockerClientMock) Close() {
-	return
-}
+func (c *dockerClientMock) Create(*host.Host) error { return nil }
 
-func (c *dockerClientMock) EnsureImageDownloaded(context.Context, *host.Host, string) (string, error) {
+func (c *dockerClientMock) Close() { return }
+
+func (c *dockerClientMock) EnsureImageDownloaded(context.Context, string) (string, error) {
 	if c.failDownload {
 		return "", errors.New("failed to download image")
 	}
@@ -58,14 +58,14 @@ func (c *dockerClientMock) BuildImageWithAgent(context.Context, *host.Host, stri
 	return fmt.Sprintf(provisionedImageTag, c.baseImage), nil
 }
 
-func (c *dockerClientMock) CreateContainer(context.Context, *host.Host, *host.Host, *dockerSettings) error {
+func (c *dockerClientMock) CreateContainer(context.Context, *host.Host, *dockerSettings) error {
 	if c.failCreate {
 		return errors.New("failed to create container")
 	}
 	return nil
 }
 
-func (c *dockerClientMock) GetContainer(context.Context, *host.Host, string) (*types.ContainerJSON, error) {
+func (c *dockerClientMock) GetContainer(context.Context, string) (*types.ContainerJSON, error) {
 	if c.failGet {
 		return nil, errors.New("failed to inspect container")
 	}
@@ -96,7 +96,7 @@ func (c *dockerClientMock) GetContainer(context.Context, *host.Host, string) (*t
 	return container, nil
 }
 
-func (c *dockerClientMock) ListContainers(context.Context, *host.Host) ([]types.Container, error) {
+func (c *dockerClientMock) ListContainers(context.Context) ([]types.Container, error) {
 	if c.failList {
 		return nil, errors.New("failed to list containers")
 	}
@@ -110,14 +110,14 @@ func (c *dockerClientMock) ListContainers(context.Context, *host.Host) ([]types.
 	return []types.Container{container}, nil
 }
 
-func (c *dockerClientMock) RemoveContainer(context.Context, *host.Host, string) error {
+func (c *dockerClientMock) RemoveContainer(context.Context, string) error {
 	if c.failRemove {
 		return errors.New("failed to remove container")
 	}
 	return nil
 }
 
-func (c *dockerClientMock) ListImages(context.Context, *host.Host) ([]types.ImageSummary, error) {
+func (c *dockerClientMock) ListImages(context.Context) ([]types.ImageSummary, error) {
 	if c.failList {
 		return nil, errors.New("failed to list images")
 	}
@@ -135,14 +135,14 @@ func (c *dockerClientMock) ListImages(context.Context, *host.Host) ([]types.Imag
 	return []types.ImageSummary{image1, image2}, nil
 }
 
-func (c *dockerClientMock) RemoveImage(context.Context, *host.Host, string) error {
+func (c *dockerClientMock) RemoveImage(context.Context, string) error {
 	if c.failRemove {
 		return errors.New("failed to remove image")
 	}
 	return nil
 }
 
-func (c *dockerClientMock) StartContainer(context.Context, *host.Host, string) error {
+func (c *dockerClientMock) StartContainer(context.Context, string) error {
 	if c.failStart {
 		return errors.New("failed to start container")
 	}


### PR DESCRIPTION
Fixes *theoretical* memory leak by returning httpClient to the pool after it is used. The new Close() method is part of the Docker client, and only attempts to put the httpClient back if it is not already nil, in which case it was either never taken from the pool or already put back. Each method in the Docker cloud manager that uses the httpClient in a Docker client call now has "defer m.client.Close()" to make sure the httpClient is always put back.