### PR TITLE
EVG-5146 don't error for triggers not in registry

### DIFF
--- a/trigger/interface.go
+++ b/trigger/interface.go
@@ -3,7 +3,6 @@ package trigger
 import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
-	"github.com/pkg/errors"
 )
 
 // `eventHandlerFactory`s create `eventHandler`s capable of validating triggers
@@ -35,9 +34,9 @@ type base struct {
 }
 
 func (b *base) Process(sub *event.Subscription) (*notification.Notification, error) {
-	f, ok := b.triggers[sub.Trigger]
-	if !ok {
-		return nil, errors.Errorf("unknown trigger: '%s'", sub.Trigger)
+	f, found := b.triggers[sub.Trigger]
+	if !found {
+		return nil, nil
 	}
 
 	return f(sub)


### PR DESCRIPTION
Spawn host and host expiration have different handlers registered, but the same selectors. That means that when processing 1 type of events subscriptions for the other will be found, which causes this error. I don't think there's any need to error here, since it's either going to be programmer error or this scenario