### PR TITLE
EVG-5173: return containers by name instead of ID in GetContainers

### DIFF
--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -225,7 +226,12 @@ func (m *dockerManager) GetContainers(ctx context.Context, h *host.Host) ([]stri
 
 	ids := []string{}
 	for _, container := range containers {
-		ids = append(ids, container.ID)
+		name := container.Names[0]
+		// names have leading slashes
+		if strings.Contains(name, "/") {
+			name = name[1:len(name)]
+		}
+		ids = append(ids, name)
 	}
 
 	return ids, nil

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -227,10 +227,11 @@ func (m *dockerManager) GetContainers(ctx context.Context, h *host.Host) ([]stri
 	ids := []string{}
 	for _, container := range containers {
 		name := container.Names[0]
-		// names have leading slashes
-		if strings.Contains(name, "/") {
-			name = name[1:len(name)]
+		// names in Docker have leading slashes -- https://github.com/moby/moby/issues/6705
+		if !strings.HasPrefix(name, "/") {
+			return nil, errors.New("error reading container name")
 		}
+		name = name[1:len(name)]
 		ids = append(ids, name)
 	}
 

--- a/cloud/docker_mock.go
+++ b/cloud/docker_mock.go
@@ -102,6 +102,9 @@ func (c *dockerClientMock) ListContainers(context.Context, *host.Host) ([]types.
 			{PublicPort: 5000},
 			{PublicPort: 5001},
 		},
+		Names: []string{
+			"/container-1",
+		},
 	}
 	return []types.Container{container}, nil
 }


### PR DESCRIPTION
This affects how we decide which containers to set as terminated in our HostMonitorContainerStateJob. 