### PR TITLE
 EVG-5152: create job to prepare container images before SpawnHost

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -63,6 +63,8 @@ type ContainerManager interface {
 	RemoveOldestImage(ctx context.Context, h *host.Host) error
 	// CalculateImageSpaceUsage returns the total space taken up by docker images on a specified host
 	CalculateImageSpaceUsage(ctx context.Context, h *host.Host) (int64, error)
+	// BuildContainerImage downloads and builds a container image onto parent specified by URL
+	BuildContainerImage(ctx context.Context, parent *host.Host, url string) error
 }
 
 // CostCalculator is an interface for cloud providers that can estimate what a span of time on a

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -328,3 +328,25 @@ func (m *dockerManager) CostForDuration(ctx context.Context, h *host.Host, start
 
 	return cost / numContainers, nil
 }
+
+// BuildContainerImage downloads and buils a container image onto parent specified
+// by URL and returns this URL
+func (m *dockerManager) BuildContainerImage(ctx context.Context, parent *host.Host, url string) error {
+	if !parent.HasContainers {
+		return errors.Errorf("Error provisioning image: '%s' is not a parent", parent.Id)
+	}
+
+	// Import correct base image if not already on host.
+	image, err := m.client.EnsureImageDownloaded(ctx, parent, url)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to ensure that image '%s' is on host '%s'", url, parent.Id)
+	}
+
+	// Build image containing Evergreen executable.
+	_, err = m.client.BuildImageWithAgent(ctx, parent, image)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to build image '%s' with agent on host '%s'", url, parent.Id)
+	}
+
+	return nil
+}

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -231,16 +231,7 @@ func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, h *host.Host
 	return provisionedImage, nil
 }
 
-// CreateContainer creates a new Docker container that runs an SSH daemon, and binds the
-// container's SSH port to another port on the host machine. The preloaded Docker image
-// must satisfy the following constraints:
-//     1. The image must have the sshd binary in order to start the SSH daemon. On Ubuntu
-//        14.04, you can get it with `apt-get update && apt-get install -y openssh-server`.
-//     2. The image must execute the SSH daemon without detaching on startup. On Ubuntu
-//        14.04, this command is `/usr/sbin/sshd -D`.
-//     3. The image must have the same ~/.ssh/authorized_keys file as the host machine
-//        in order to allow users with SSH access to the host machine to have SSH access
-//        to the container.
+// CreateContainer creates a new Docker container with Evergreen agent.
 func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, containerHost *host.Host, settings *dockerSettings) error {
 	dockerClient, err := c.generateClient(parentHost)
 	if err != nil {

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -249,7 +249,7 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 
 	// Extract image name from url
 	baseName := path.Base(settings.ImageURL)
-	provisionedImage := strings.TrimSuffix(baseName, filepath.Ext(baseName))
+	provisionedImage := fmt.Sprintf(provisionedImageTag, strings.TrimSuffix(baseName, filepath.Ext(baseName)))
 
 	// Build path to Evergreen executable.
 	pathToExecutable := filepath.Join("root", "evergreen")

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -247,17 +247,9 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 		return errors.Wrap(err, "Failed to generate docker client")
 	}
 
-	// Import correct base image if not already on host.
-	image, err := c.EnsureImageDownloaded(ctx, parentHost, settings.ImageURL)
-	if err != nil {
-		return errors.Wrapf(err, "Unable to ensure that image '%s' is on host '%s'", settings.ImageURL, parentHost.Id)
-	}
-
-	// Build image containing Evergreen executable.
-	provisionedImage, err := c.BuildImageWithAgent(ctx, parentHost, image)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to build image %s with agent on host '%s'", image, parentHost.Id)
-	}
+	// Extract image name from url
+	baseName := path.Base(settings.ImageURL)
+	provisionedImage := strings.TrimSuffix(baseName, filepath.Ext(baseName))
 
 	// Build path to Evergreen executable.
 	pathToExecutable := filepath.Join("root", "evergreen")

--- a/model/host/counters.go
+++ b/model/host/counters.go
@@ -81,6 +81,30 @@ func (h *Host) IncAgentDeployAttempt() error {
 	return nil
 }
 
+func (h *Host) IncContainerBuildAttempt() error {
+	query := bson.M{
+		IdKey: h.Id,
+	}
+
+	change := mgo.Change{
+		ReturnNew: true,
+		Update: bson.M{
+			"$inc": bson.M{ContainerBuildAttempt: 1},
+		},
+	}
+
+	info, err := db.FindAndModify(Collection, query, []string{}, change, h)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if info.Updated != 1 {
+		return errors.Errorf("could not find host document to update, %s", h.Id)
+	}
+
+	return nil
+}
+
 func (h *Host) IncIdleTime(dur time.Duration) error {
 	if dur < 0 {
 		return errors.Errorf("cannot increment by a negative duration value [%s]", dur)

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -68,6 +68,7 @@ var (
 	TotalIdleTimeKey           = bsonutil.MustHaveTag(Host{}, "TotalIdleTime")
 	HasContainersKey           = bsonutil.MustHaveTag(Host{}, "HasContainers")
 	ParentIDKey                = bsonutil.MustHaveTag(Host{}, "ParentID")
+	ContainerImagesKey         = bsonutil.MustHaveTag(Host{}, "ContainerImages")
 	LastContainerFinishTimeKey = bsonutil.MustHaveTag(Host{}, "LastContainerFinishTime")
 	SpawnOptionsKey            = bsonutil.MustHaveTag(Host{}, "SpawnOptions")
 	ContainerPoolSettingsKey   = bsonutil.MustHaveTag(Host{}, "ContainerPoolSettings")
@@ -412,7 +413,7 @@ func NeedsNewAgent(currentTime time.Time) db.Q {
 }
 
 // Removes host intents that have been been uninitialized for more than 3
-// minutes or spawning (but not started) for more than 15 minutes for the
+// minutes or spawning (but not started) for more than 20 minutes for the
 // specified distro.
 //
 // If you pass the empty string as a distroID, it will remove stale
@@ -428,7 +429,7 @@ func RemoveStaleInitializing(distroID string) error {
 			},
 			{
 				StatusKey:     evergreen.HostBuilding,
-				CreateTimeKey: bson.M{"$lt": time.Now().Add(-15 * time.Minute)},
+				CreateTimeKey: bson.M{"$lt": time.Now().Add(-20 * time.Minute)},
 			},
 		},
 	}

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -69,6 +69,7 @@ var (
 	HasContainersKey           = bsonutil.MustHaveTag(Host{}, "HasContainers")
 	ParentIDKey                = bsonutil.MustHaveTag(Host{}, "ParentID")
 	ContainerImagesKey         = bsonutil.MustHaveTag(Host{}, "ContainerImages")
+	ContainerBuildAttempt      = bsonutil.MustHaveTag(Host{}, "ContainerBuildAttempt")
 	LastContainerFinishTimeKey = bsonutil.MustHaveTag(Host{}, "LastContainerFinishTime")
 	SpawnOptionsKey            = bsonutil.MustHaveTag(Host{}, "SpawnOptions")
 	ContainerPoolSettingsKey   = bsonutil.MustHaveTag(Host{}, "ContainerPoolSettings")

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -413,7 +413,7 @@ func NeedsNewAgent(currentTime time.Time) db.Q {
 }
 
 // Removes host intents that have been been uninitialized for more than 3
-// minutes or spawning (but not started) for more than 20 minutes for the
+// minutes or spawning (but not started) for more than 15 minutes for the
 // specified distro.
 //
 // If you pass the empty string as a distroID, it will remove stale
@@ -429,7 +429,7 @@ func RemoveStaleInitializing(distroID string) error {
 			},
 			{
 				StatusKey:     evergreen.HostBuilding,
-				CreateTimeKey: bson.M{"$lt": time.Now().Add(-20 * time.Minute)},
+				CreateTimeKey: bson.M{"$lt": time.Now().Add(-15 * time.Minute)},
 			},
 		},
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -106,6 +106,7 @@ type Host struct {
 	LastContainerFinishTime time.Time `bson:"last_container_finish_time,omitempty" json:"last_container_finish_time,omitempty"`
 	// ContainerPoolSettings
 	ContainerPoolSettings *evergreen.ContainerPool `bson:"container_pool_settings,omitempty" json:"container_pool_settings,omitempty"`
+	ContainerBuildAttempt int                      `bson:"container_build_attempt" json:"container_build_attempt"`
 
 	// SpawnOptions holds data which the monitor uses to determine when to terminate hosts spawned by tasks.
 	SpawnOptions SpawnOptions `bson:"spawn_options,omitempty" json:"spawn_options,omitempty"`

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -592,6 +592,7 @@ func (h *Host) Upsert() (*mgo.ChangeInfo, error) {
 				ProvisionOptionsKey:  h.ProvisionOptions,
 				StartTimeKey:         h.StartTime,
 				HasContainersKey:     h.HasContainers,
+				ContainerImagesKey:   h.ContainerImages,
 			},
 			"$setOnInsert": bson.M{
 				StatusKey:     h.Status,

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -98,6 +98,8 @@ type Host struct {
 	// managed containers require different information based on host type
 	// True if this host is a parent of containers
 	HasContainers bool `bson:"has_containers,omitempty" json:"has_containers,omitempty"`
+	// stores URLs of container images already downloaded on a parent
+	ContainerImages map[string]bool `bson:"container_images,omitempty" json:"container_images,omitempty"`
 	// stores the ID of the host a container is on
 	ParentID string `bson:"parent_id,omitempty" json:"parent_id,omitempty"`
 	// stores last expected finish time among all containers on the host

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -857,6 +857,7 @@ func TestHostUpsert(t *testing.T) {
 			LoadCLI: true,
 			TaskId:  "task_id",
 		},
+		ContainerImages: map[string]bool{},
 	}
 
 	// test inserting new host

--- a/units/building_container_image.go
+++ b/units/building_container_image.go
@@ -1,0 +1,113 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/dependency"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/pkg/errors"
+)
+
+const buildingContainerImageJobName = "building-container-image"
+
+func init() {
+	registry.AddJobType(buildingContainerImageJobName, func() amboy.Job {
+		return makeBuildingContainerImageJob()
+	})
+}
+
+type buildingContainerImageJob struct {
+	ParentID string `bson:"parent_id" json:"parent_id" yaml:"parent_id"`
+	job.Base `bson:"base" json:"base" yaml:"base"`
+	ImageURL string `bson:"image_url" json:"image_url" yaml:"image_url"`
+	Provider string `bson:"provider" json:"provider" yaml:"provider"`
+
+	// cache
+	parent   *host.Host
+	env      evergreen.Environment
+	settings *evergreen.Settings
+}
+
+func makeBuildingContainerImageJob() *buildingContainerImageJob {
+	j := &buildingContainerImageJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    buildingContainerImageJobName,
+				Version: 0,
+			},
+		},
+	}
+
+	j.SetDependency(dependency.NewAlways())
+	return j
+}
+
+func NewBuildingContainerImageJob(env evergreen.Environment, h *host.Host, imageURL, providerName string) amboy.Job {
+	job := makeBuildingContainerImageJob()
+
+	job.parent = h
+	job.ImageURL = imageURL
+	job.ParentID = h.Id
+	job.Provider = providerName
+
+	job.SetID(fmt.Sprintf("%s.%s.%s", buildingContainerImageJobName, job.ParentID, job.ImageURL))
+
+	return job
+}
+
+func (j *buildingContainerImageJob) Run(ctx context.Context) {
+	var cancel context.CancelFunc
+
+	ctx, cancel = context.WithCancel(ctx)
+	defer cancel()
+	defer j.MarkComplete()
+
+	var err error
+	if j.parent == nil {
+		j.parent, err = host.FindOneId(j.ParentID)
+		j.AddError(err)
+	}
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+	if j.settings == nil {
+		j.settings = j.env.Settings()
+	}
+
+	if j.HasErrors() {
+		return
+	}
+
+	// Get cloud manager
+	mgr, err := cloud.GetManager(ctx, j.Provider, j.settings)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "error getting Docker manager"))
+		return
+	}
+	containerMgr, err := cloud.ConvertContainerManager(mgr)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "error getting Docker manager"))
+		return
+	}
+
+	err = containerMgr.BuildContainerImage(ctx, j.parent, j.ImageURL)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "error building and downloading container image"))
+		return
+	}
+	if j.parent.ContainerImages == nil {
+		j.parent.ContainerImages = make(map[string]bool)
+	}
+	j.parent.ContainerImages[j.ImageURL] = true
+	_, err = j.parent.Upsert()
+	if err != nil {
+		j.AddError(errors.Wrapf(err, "error upserting parent %s", j.parent.Id))
+		return
+	}
+}

--- a/units/building_container_image_test.go
+++ b/units/building_container_image_test.go
@@ -1,0 +1,55 @@
+package units
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildingContainerImageJob(t *testing.T) {
+	assert := assert.New(t)
+	testConfig := testutil.TestConfig()
+	db.SetGlobalSessionProvider(testConfig.SessionFactory())
+
+	assert.NoError(db.Clear(host.Collection))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := evergreen.GetEnvironment()
+	assert.NoError(env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+
+	h1 := &host.Host{
+		Id:            "parent-1",
+		Status:        evergreen.HostRunning,
+		HasContainers: true,
+	}
+	h2 := &host.Host{
+		Id:       "container-1",
+		Status:   evergreen.HostRunning,
+		ParentID: "parent-1",
+	}
+	h3 := &host.Host{
+		Id:       "container-2",
+		Status:   evergreen.HostRunning,
+		ParentID: "parent-1",
+	}
+	assert.NoError(h1.Insert())
+	assert.NoError(h2.Insert())
+	assert.NoError(h3.Insert())
+
+	j := NewBuildingContainerImageJob(env, h1, "image-url", evergreen.ProviderNameDockerMock)
+	assert.False(j.Status().Completed)
+
+	j.Run(context.Background())
+
+	assert.NoError(j.Error())
+	assert.True(j.Status().Completed)
+
+}

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -17,7 +17,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-const createHostJobName = "provisioning-create-host"
+const (
+	createHostJobName = "provisioning-create-host"
+	// For container build
+	maxPollAttempts = 50
+	pollInterval    = 15 * time.Second
+)
 
 func init() {
 	registry.AddJobType(createHostJobName, func() amboy.Job {
@@ -134,6 +139,16 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		return errors.Wrapf(err, "problem setting host %s status to building", j.host.Id)
 	}
 
+	// Containers should wait on image builds, checking to see if the parent
+	// already has the image. If it does not, it should download it and wait
+	// on the job until it is finished downloading.
+	if j.host.ParentID != "" {
+		err := j.waitForContainerImageBuild(ctx)
+		if err != nil {
+			return errors.Wrap(err, "problem building container image")
+		}
+	}
+
 	if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {
 		return errors.Wrapf(err, "error spawning host %s", j.host.Id)
 	}
@@ -205,4 +220,42 @@ func (j *createHostJob) shouldRetryCreateHost(ctx context.Context) bool {
 	return j.CurrentAttempt < j.MaxAttempts &&
 		j.host.Status != evergreen.HostStarting &&
 		ctx.Err() == nil
+}
+
+func (j *createHostJob) waitForContainerImageBuild(ctx context.Context) error {
+	parent, err := host.FindOneId(j.host.ParentID)
+	if err != nil {
+		return errors.Wrapf(err, "problem getting parent for '%s'", j.host.Id)
+	}
+	imageURL := (*j.host.Distro.ProviderSettings)["image_url"].(string)
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	var ok bool
+	// Continuously poll DB to see if image is ready
+retryLoop:
+	for i := 0; i < maxPollAttempts; i++ {
+		select {
+		case <-ctx.Done():
+			return errors.New("building container image cancelled")
+		case <-timer.C:
+			if ok = parent.ContainerImages[imageURL]; !ok {
+				//  If the image is not already present on the parent, run job to build
+				// the new image
+				if i == 0 {
+					buildingContainerJob := NewBuildingContainerImageJob(j.env, j.host, imageURL, j.host.Provider)
+					j.AddError(j.env.RemoteQueue().Put(buildingContainerJob))
+				}
+				timer.Reset(pollInterval)
+				continue
+			}
+			// Image is present on parent, can move on to SpawnHost
+			break retryLoop
+		}
+	}
+	if !ok {
+		return errors.Errorf("Verifying image ready for '%s' timed out", imageURL)
+	}
+	return nil
 }

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -245,7 +245,10 @@ retryLoop:
 				// the new image
 				if i == 0 {
 					buildingContainerJob := NewBuildingContainerImageJob(j.env, parent, imageURL, j.host.Provider)
-					j.AddError(j.env.RemoteQueue().Put(buildingContainerJob))
+					grip.Debug(message.Fields{
+						"error":   j.env.RemoteQueue().Put(buildingContainerJob),
+						"message": "Duplicate key being added to job to block building containers",
+					})
 				}
 				timer.Reset(pollInterval)
 				continue


### PR DESCRIPTION
Closed old PR (https://github.com/evergreen-ci/evergreen/pull/1513) because it was too messy with various local commits that attempted to fix Docker errors with Thomas's refactor (https://github.com/evergreen-ci/evergreen/commit/dd558974ec67f6aad7509badcd5847bf0fb3f7c5). 

`BuildingContainerImageJob` makes is so that when many containers come up on the same parent, they do not all try to download the same image. Parents will hold a map of ready container images. This also separates out the downloading and building of the images, blocking until the provisioned image is ready on each container. 
This job retries 5 times (arbitrary number, can be changed) before finally giving up and terminating the parent. This is necessary because if the parent stays up, containers will continue to try to build on it when it is not possible. 

I will also be reverting Thomas's refactor because it brings in more unexplained Docker errors. 