### PR TITLE
EVG-5207: create containers only on parents with space

### DIFF
--- a/scheduler/duration_based_host_allocator.go
+++ b/scheduler/duration_based_host_allocator.go
@@ -18,7 +18,7 @@ import (
 const (
 	// maximum turnaround we want to maintain for all hosts for a given distro
 	MaxDurationPerDistroHost               = 30 * time.Minute
-	MaxDurationPerDistroHostWithContainers = 5 * time.Minute
+	MaxDurationPerDistroHostWithContainers = 2 * time.Minute
 
 	// for distro queues with tasks that appear on other queues, this constant
 	// indicates the fraction of the total duration of shared tasks that we want

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -314,11 +314,6 @@ func getNumContainersOnParents(d distro.Distro) ([]containersOnParents, error) {
 					parentHost:    parent,
 					numContainers: len(currentContainers),
 				})
-			grip.Info(message.Fields{
-				"operation":     "scheduling",
-				"parentHost":    parent.Id,
-				"numContainers": len(currentContainers),
-			})
 		}
 	}
 	return numContainersOnParents, nil

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -52,6 +52,11 @@ type newParentsNeededParams struct {
 	numUphostParents, numContainersNeeded, numExistingContainers, maxContainers int
 }
 
+type containersOnParents struct {
+	parentHost    host.Host
+	numContainers int
+}
+
 func (s *distroSchedueler) scheduleDistro(distroId string, runnableTasksForDistro []task.Task, versions map[string]version.Version) distroSchedulerResult {
 	res := distroSchedulerResult{
 		distroId: distroId,
@@ -212,15 +217,21 @@ func spawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 		newHostsNeeded = containerCapacity(len(currentParents), len(existingContainers), newHostsNeeded, pool.MaxContainers)
 	}
 
-	// host.create intent documents for non-parent hosts
-	for i := 0; i < newHostsNeeded; i++ {
-		intent, err := getIntentHost(d)
+	// create intent documents for container hosts
+	if d.ContainerPool != "" {
+		containerIntents, err := generateContainerHostIntents(d, newHostsNeeded)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "error generating container intent hosts")
 		}
-
-		hostsSpawned = append(hostsSpawned, *intent)
-
+		hostsSpawned = append(hostsSpawned, containerIntents...)
+	} else { // create intent documents for regular hosts
+		for i := 0; i < newHostsNeeded; i++ {
+			intent, err := generateIntentHost(d)
+			if err != nil {
+				return nil, errors.Wrap(err, "error generating intent host")
+			}
+			hostsSpawned = append(hostsSpawned, *intent)
+		}
 	}
 
 	if err := host.InsertMany(hostsSpawned); err != nil {
@@ -238,26 +249,37 @@ func spawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 	return hostsSpawned, nil
 }
 
-// generateHostOptions generates host options based on what kind of host it is:
-// regular host or container
-func generateHostOptions(d distro.Distro) (cloud.HostOptions, error) {
-	if d.ContainerPool != "" {
-		parent, err := findAvailableParent(d)
-		if err != nil {
-			err = errors.Wrap(err, "Could not find available parent host")
-			return cloud.HostOptions{}, err
-		}
-		hostOptions := cloud.HostOptions{
-			ParentID: parent.Id,
-			UserName: evergreen.User,
-		}
-		return hostOptions, nil
+// generateContainerHostIntents generates container intent documents by going
+// through available parents and packing on the parents with longest expected
+// finish time
+func generateContainerHostIntents(d distro.Distro, newContainersNeeded int) ([]host.Host, error) {
+	parents, err := getNumContainersOnParents(d)
+	if err != nil {
+		err = errors.Wrap(err, "Could not find number of containers on each parent")
+		return nil, err
 	}
-
-	hostOptions := cloud.HostOptions{
-		UserName: evergreen.User,
+	containerHostIntents := make([]host.Host, 0)
+	for _, parent := range parents {
+		// find out how many more containers this parent can fit
+		containerSpace := parent.parentHost.ContainerPoolSettings.MaxContainers - parent.numContainers
+		containersToCreate := containerSpace
+		// only create containers as many as we need
+		if newContainersNeeded < containerSpace {
+			containersToCreate = newContainersNeeded
+		}
+		for i := 0; i < containersToCreate; i++ {
+			hostOptions := cloud.HostOptions{
+				ParentID: parent.parentHost.Id,
+				UserName: evergreen.User,
+			}
+			containerHostIntents = append(containerHostIntents, *cloud.NewIntent(d, d.GenerateName(), d.Provider, hostOptions))
+		}
+		newContainersNeeded -= containersToCreate
+		if newContainersNeeded == 0 {
+			return containerHostIntents, nil
+		}
 	}
-	return hostOptions, nil
+	return containerHostIntents, nil
 }
 
 // generateParentHostOptions generates host options for a parent host
@@ -269,26 +291,37 @@ func generateParentHostOptions(pool *evergreen.ContainerPool) cloud.HostOptions 
 	}
 }
 
-// FindAvailableParent finds a parent host that can accommodate container,
-// packing on parent that has task with longest expected finish time
-func findAvailableParent(d distro.Distro) (host.Host, error) {
+// getNumContainersOnParents returns a slice of parents and their respective
+// number of current containers currently running in order of longest expected
+// finish time
+func getNumContainersOnParents(d distro.Distro) ([]containersOnParents, error) {
 	allParents, err := host.FindAllRunningParentsByContainerPool(d.ContainerPool)
 	if err != nil {
-		return host.Host{}, errors.Wrap(err, "Could not find running parent hosts")
+		return nil, errors.Wrap(err, "Could not find running parent hosts")
 	}
 
+	numContainersOnParents := make([]containersOnParents, 0)
 	// parents come in sorted order from soonest to latest expected finish time
 	for i := len(allParents) - 1; i >= 0; i-- {
 		parent := allParents[i]
 		currentContainers, err := parent.GetContainers()
 		if err != nil {
-			return host.Host{}, errors.Wrapf(err, "Could not find containers for parent %s", parent.Id)
+			return nil, errors.Wrapf(err, "Could not find containers for parent %s", parent.Id)
 		}
 		if len(currentContainers) < parent.ContainerPoolSettings.MaxContainers {
-			return parent, nil
+			numContainersOnParents = append(numContainersOnParents,
+				containersOnParents{
+					parentHost:    parent,
+					numContainers: len(currentContainers),
+				})
+			grip.Info(message.Fields{
+				"operation":     "scheduling",
+				"parentHost":    parent.Id,
+				"numContainers": len(currentContainers),
+			})
 		}
 	}
-	return host.Host{}, errors.New("No available parent found for container")
+	return numContainersOnParents, nil
 }
 
 // numNewParentsNeeded returns the number of additional parents needed to
@@ -347,13 +380,11 @@ func createParents(parent distro.Distro, numNewParents int, pool *evergreen.Cont
 	return hostsSpawned
 }
 
-// insertIntent creates a host intent document for a regular host or container
-func getIntentHost(d distro.Distro) (*host.Host, error) {
-	hostOptions, err := generateHostOptions(d)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Could not generate host options for distro %s", d.Id)
+// generateIntentHost creates a host intent document for a regular host
+func generateIntentHost(d distro.Distro) (*host.Host, error) {
+	hostOptions := cloud.HostOptions{
+		UserName: evergreen.User,
 	}
-
 	return cloud.NewIntent(d, d.GenerateName(), d.Provider, hostOptions), nil
 }
 

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -484,10 +484,10 @@ func (s *SchedulerSuite) TestFindAvailableParent() {
 	s.NoError(task1.Insert())
 	s.NoError(task2.Insert())
 
-	availableParent, err := findAvailableParent(d)
+	availableParent, err := getNumContainersOnParents(d)
 	s.NoError(err)
 
-	s.Equal("host2", availableParent.Id)
+	s.Equal(2, len(availableParent))
 }
 
 func (s *SchedulerSuite) TestFindNoAvailableParent() {
@@ -548,9 +548,9 @@ func (s *SchedulerSuite) TestFindNoAvailableParent() {
 	s.NoError(task1.Insert())
 	s.NoError(task2.Insert())
 
-	availableParent, err := findAvailableParent(d)
-	s.EqualError(err, "No available parent found for container")
-	s.Empty(availableParent.Id)
+	availableParent, err := getNumContainersOnParents(d)
+	s.NoError(err)
+	s.Equal(0, len(availableParent))
 }
 
 func (s *SchedulerSuite) TestSpawnContainersStatic() {

--- a/scheduler/utilization_based_host_allocator_test.go
+++ b/scheduler/utilization_based_host_allocator_test.go
@@ -1124,7 +1124,7 @@ func (s *UtilizationAllocatorSuite) TestRealisticScenarioWithContainers2() {
 
 	hosts, err := UtilizationBasedHostAllocator(s.ctx, data)
 	s.NoError(err)
-	s.Equal(1, hosts)
+	s.Equal(3, hosts)
 }
 
 func (s *UtilizationAllocatorSuite) TestOnlyTaskGroupsOnlyScheduled() {

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -95,37 +95,39 @@ func (j *createHostJob) Run(ctx context.Context) {
 		}
 	}
 
-	numHosts, err := host.CountRunningHosts(j.host.Distro.Id)
-	if err != nil {
-		j.AddError(errors.Wrap(err, "problem getting count of existing pool size"))
-		return
-	}
+	if j.host.ParentID == "" {
+		numHosts, err := host.CountRunningHosts(j.host.Distro.Id)
+		if err != nil {
+			j.AddError(errors.Wrap(err, "problem getting count of existing pool size"))
+			return
+		}
 
-	if numHosts >= j.host.Distro.PoolSize {
-		grip.Info(message.Fields{
-			"host_id":   j.HostID,
-			"attempt":   j.CurrentAttempt,
-			"distro":    j.host.Distro.Id,
-			"job":       j.ID(),
-			"provider":  j.host.Provider,
-			"message":   "not provisioning host to respect maxhosts",
-			"max_hosts": j.host.Distro.PoolSize,
-		})
+		if numHosts >= j.host.Distro.PoolSize {
+			grip.Info(message.Fields{
+				"host_id":   j.HostID,
+				"attempt":   j.CurrentAttempt,
+				"distro":    j.host.Distro.Id,
+				"job":       j.ID(),
+				"provider":  j.host.Provider,
+				"message":   "not provisioning host to respect maxhosts",
+				"max_hosts": j.host.Distro.PoolSize,
+			})
 
-		err = errors.Wrap(j.host.Remove(), "problem removing host intent")
+			err = errors.Wrap(j.host.Remove(), "problem removing host intent")
 
-		j.AddError(err)
-		grip.Error(message.WrapError(err, message.Fields{
-			"host_id":  j.HostID,
-			"attempt":  j.CurrentAttempt,
-			"distro":   j.host.Distro,
-			"job":      j.ID(),
-			"provider": j.host.Provider,
-			"message":  "could not remove intent document",
-			"outcome":  "host pool may exceed maxhost limit",
-		}))
+			j.AddError(err)
+			grip.Error(message.WrapError(err, message.Fields{
+				"host_id":  j.HostID,
+				"attempt":  j.CurrentAttempt,
+				"distro":   j.host.Distro,
+				"job":      j.ID(),
+				"provider": j.host.Provider,
+				"message":  "could not remove intent document",
+				"outcome":  "host pool may exceed maxhost limit",
+			}))
 
-		return
+			return
+		}
 	}
 
 	if j.TimeInfo().MaxTime == 0 && !j.host.SpawnOptions.TimeoutSetup.IsZero() {


### PR DESCRIPTION
This fixes the problem where all the containers were being put on one parent because we were checking the DB for available parents before any of the containers knew about each other. Now, we check for how many more containers a parent can have by keeping its current number of containers in a slice. 

`MaxDurationPerDistroHostWithContainers` is an arbitrary number right now, but will affect some utilization based host allocator tests. 