### PR TITLE
EVG-5221 run Evergreen self-tests with many containers

### DIFF
--- a/scripts/generate-lint.go
+++ b/scripts/generate-lint.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	lintPrefix        = "lint"
-	lintVariant       = "ubuntu1604"
+	lintVariant       = "archlinux-docker"
 	lintGroup         = "lint-group"
 	commitMaxHosts    = 4
 	patchMaxHosts     = 1

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -149,6 +149,7 @@ functions:
     type: setup
     params:
       directory: gopath/src/github.com/evergreen-ci/evergreen
+      token: "token f6be9f51e8796f00e2b72291b08bd1a8838c82d2"
   run-make:
     command: subprocess.exec
     params:
@@ -696,3 +697,19 @@ buildvariants:
         distros:
           - ubuntu1604-test
       - name: ".xc"
+
+  - name: archlinux-docker
+    display_name: Archlinux Docker
+    run_on:
+      - archlinux-docker
+    expansions:
+      goos: linux
+      gobin: /opt/go1.8/go/bin/go
+      goroot: /opt/go1.8/go
+      mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.4.tgz
+    tasks:
+      - name: "dist"
+      - name: ".smoke"
+      - name: ".test"
+      - name: "js-test"
+      - name: generate-lint

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -149,7 +149,7 @@ functions:
     type: setup
     params:
       directory: gopath/src/github.com/evergreen-ci/evergreen
-      token: "token f6be9f51e8796f00e2b72291b08bd1a8838c82d2"
+      token: ${github_token}
   run-make:
     command: subprocess.exec
     params:


### PR DESCRIPTION
This is how I've been running self-tests in staging (Most of the time though, I've just been running patches with `.test` and those all finish very quickly once the containers are up). When testing what is in this PR, `js-test`, `smoke-test-endpoints`, `smoke-test-task`, `test-command`, and `test-operations` fail. 

Things to note: 
- this changes the hard coded `lintVariant` to archlinux-docker
- you can check the Docker API calls in Splunk with the search `message="docker API call"` 
- containers are "building" for about 12 min before they come up as running. This is just how long the image import and download takes
- `make: go: Command not found` at the end of tasks 
- `smoke-test-endpoints` and `smoke-test-task` just seem to never finish, possibly looping forever
- parents have recently started taking longer to come up 
- `dial tcp: lookup evergreen-staging.corp.mongodb.com: no such host` error from building-container-image, but does not prevent images coming up 
- `Cannot connect to the Docker daemon at ... . Is the docker daemon running?` still sometimes comes up randomly 