### PR TITLE
EVG-5219: remove port and typo from distro UIs

### DIFF
--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -69,7 +69,7 @@ func (c *dockerClientImpl) generateClient(h *host.Host) (*docker.Client, error) 
 	// Create a Docker client to wrap Docker API calls. The Docker TCP endpoint must
 	// be exposed and available for requests at the client port on the host machine.
 	var err error
-	endpoint := fmt.Sprintf("tcp://%s:%v", h.Host, h.ContainerPoolSettings.Port)
+	endpoint := fmt.Sprintf("tcp://%s", h.Host)
 	c.client, err = docker.NewClient(endpoint, c.apiVersion, c.httpClient, nil)
 	if err != nil {
 		grip.Error(message.Fields{

--- a/config_containerpools.go
+++ b/config_containerpools.go
@@ -14,8 +14,6 @@ type ContainerPool struct {
 	Id string `bson:"id" json:"id" yaml:"id"`
 	// Maximum number of containers per parent host with this container pool
 	MaxContainers int `bson:"max_containers" json:"max_containers" yaml:"max_containers"`
-	// Port number to start at for SSH connections
-	Port uint16 `bson:"port" json:"port" yaml:"port"`
 }
 
 type ContainerPoolsConfig struct {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -782,7 +782,6 @@ type APIContainerPool struct {
 	Distro        APIString `json:"distro"`
 	Id            APIString `json:"id"`
 	MaxContainers int       `json:"max_containers"`
-	Port          uint16    `json:"port"`
 }
 
 func (a *APIContainerPool) BuildFromService(h interface{}) error {
@@ -791,7 +790,6 @@ func (a *APIContainerPool) BuildFromService(h interface{}) error {
 		a.Distro = ToAPIString(v.Distro)
 		a.Id = ToAPIString(v.Id)
 		a.MaxContainers = v.MaxContainers
-		a.Port = v.Port
 	default:
 		return errors.Errorf("%T is not a supported type", h)
 	}
@@ -803,7 +801,6 @@ func (a *APIContainerPool) ToService() (interface{}, error) {
 		Distro:        FromAPIString(a.Distro),
 		Id:            FromAPIString(a.Id),
 		MaxContainers: a.MaxContainers,
-		Port:          a.Port,
 	}, nil
 }
 

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -55,7 +55,7 @@ Evergreen - Distros
       <input required ng-readonly="!activeDistro.new" id="identifier" name="id" type="text" class="form-control" ng-model="activeDistro._id" placeholder="Unique identifier for this distro">
       <label class="icon fa fa-warning distro-error" ng-show="form.id.$error.required">Distro identifier is required<br></label>
       <label class="icon fa fa-warning distro-error" ng-show="form.id.$dirty && form.id.$error.unsique || (activeDistro.new && form.id.$error.unique)">Distro identifier already exists</label>
-      <label class="icon fa fa-warning" ng-show="containerPoolDistros.indexOf(activeDistro._id) >= 0">Distro is a container pool, so it is cannot be spawned for tasks.</label>
+      <label class="icon fa fa-warning" ng-show="containerPoolDistros.indexOf(activeDistro._id) >= 0">Distro is a container pool, so it cannot be spawned for tasks.</label>
     </div>
     <br>
 

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -88,7 +88,6 @@ func MockConfig() *evergreen.Settings {
 					Distro:        "valid-distro",
 					Id:            "test-pool-1",
 					MaxContainers: 100,
-					Port:          9999,
 				},
 			},
 		},


### PR DESCRIPTION
The warning message in `archlinux-packer` had a typo, and we do not use `Port` in `archlinux-docker` anymore, so I've removed it completely. 