### PR TITLE
EVG-5212 clear reset flag on display tasks

### DIFF
--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1650,7 +1650,7 @@ func resetTaskData() error {
 	if err := displayTask.Insert(); err != nil {
 		return err
 	}
-	if err := displayTask.UpdateDisplayTask(); err != nil {
+	if err := UpdateDisplayTask(displayTask); err != nil {
 		return err
 	}
 	return nil

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -64,6 +64,7 @@ var (
 	TaskGroupKey            = bsonutil.MustHaveTag(Task{}, "TaskGroup")
 	GenerateTaskKey         = bsonutil.MustHaveTag(Task{}, "GenerateTask")
 	GeneratedByKey          = bsonutil.MustHaveTag(Task{}, "GeneratedBy")
+	ResetWhenFinishedKey    = bsonutil.MustHaveTag(Task{}, "ResetWhenFinished")
 
 	// BSON fields for the test result struct
 	TestResultStatusKey    = bsonutil.MustHaveTag(TestResult{}, "Status")

--- a/model/task/sorter.go
+++ b/model/task/sorter.go
@@ -25,8 +25,8 @@ func (t Tasks) InsertUnordered() error {
 	return db.InsertManyUnordered(Collection, t.getPayload()...)
 }
 
-type byPriority []string
+type ByPriority []string
 
-func (p byPriority) Len() int           { return len(p) }
-func (p byPriority) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p byPriority) Less(i, j int) bool { return displayTaskPriority(p[i]) < displayTaskPriority(p[j]) }
+func (p ByPriority) Len() int           { return len(p) }
+func (p ByPriority) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p ByPriority) Less(i, j int) bool { return displayTaskPriority(p[i]) < displayTaskPriority(p[j]) }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3,7 +3,6 @@ package task
 import (
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -133,9 +132,10 @@ type Task struct {
 	LocalTestResults []TestResult `bson:"-" json:"test_results"`
 
 	// display task fields
-	DisplayOnly    bool     `bson:"display_only,omitempty" json:"display_only,omitempty"`
-	ExecutionTasks []string `bson:"execution_tasks,omitempty" json:"execution_tasks,omitempty"`
-	DisplayTask    *Task    `bson:"-" json:"-"` // this is a local pointer from an exec to display task
+	DisplayOnly       bool     `bson:"display_only,omitempty" json:"display_only,omitempty"`
+	ExecutionTasks    []string `bson:"execution_tasks,omitempty" json:"execution_tasks,omitempty"`
+	ResetWhenFinished bool     `bson:"reset_when_finished,omitempty" json:"reset_when_finished,omitempty"`
+	DisplayTask       *Task    `bson:"-" json:"-"` // this is a local pointer from an exec to display task
 
 	// GenerateTask indicates that the task generates other tasks, which the
 	// scheduler will use to prioritize this task.
@@ -751,100 +751,6 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 
 }
 
-func (t *Task) UpdateDisplayTask() error {
-	if !t.DisplayOnly {
-		return fmt.Errorf("%s is not a display task", t.Id)
-	}
-
-	statuses := []string{}
-	var timeTaken time.Duration
-	var status string
-	wasFinished := t.IsFinished()
-	execTasks, err := Find(ByIds(t.ExecutionTasks))
-	if err != nil {
-		return errors.Wrap(err, "error retrieving execution tasks")
-	}
-	hasFinishedTasks := false
-	hasUnfinishedTasks := false
-	startTime := time.Unix(1<<62, 0)
-	endTime := util.ZeroTime
-	for _, execTask := range execTasks {
-		// if any of the execution tasks are scheduled, the display task is too
-		if execTask.Activated {
-			t.Activated = true
-		}
-
-		if execTask.IsFinished() {
-			hasFinishedTasks = true
-		} else if execTask.IsDispatchable() {
-			hasUnfinishedTasks = true
-		}
-
-		// the display task's status will be the highest priority of its exec tasks
-		statuses = append(statuses, execTask.ResultStatus())
-
-		// add up the duration of the execution tasks as the cumulative time taken
-		timeTaken += execTask.TimeTaken
-
-		// set the start/end time of the display task as the earliest/latest task
-		if execTask.StartTime.Before(startTime) {
-			startTime = execTask.StartTime
-		}
-		if execTask.FinishTime.After(endTime) {
-			endTime = execTask.FinishTime
-		}
-	}
-
-	if hasFinishedTasks && hasUnfinishedTasks {
-		// if the display task has a mix of finished and unfinished tasks, the status
-		// will be "started"
-		status = evergreen.TaskStarted
-	} else if len(statuses) > 0 {
-		// the status of the display task will be the status of its constituent task
-		// that is logically the most exclusive
-		sort.Sort(byPriority(statuses))
-		status = statuses[0]
-	}
-
-	grip.InfoWhen(status == evergreen.TaskUndispatched && t.DispatchTime != util.ZeroTime, message.Fields{
-		"lookhere":                      "evg-3345",
-		"message":                       "update display tasks",
-		"task_id":                       t.Id,
-		"status":                        status,
-		"dispatch_time_is_go_zero_time": t.DispatchTime.IsZero(),
-	})
-
-	update := bson.M{
-		StatusKey:    status,
-		ActivatedKey: t.Activated,
-		TimeTakenKey: timeTaken,
-	}
-	if startTime != time.Unix(1<<62, 0) {
-		update[StartTimeKey] = startTime
-	}
-	if endTime != util.ZeroTime && !hasUnfinishedTasks {
-		update[FinishTimeKey] = endTime
-	}
-
-	err = UpdateOne(
-		bson.M{
-			IdKey: t.Id,
-		},
-		bson.M{
-			"$set": update,
-		})
-	if err != nil {
-		return errors.Wrap(err, "error updating display task")
-	}
-
-	t.Status = status
-	t.TimeTaken = timeTaken
-	if !wasFinished && t.IsFinished() {
-		event.LogDisplayTaskFinished(t.Id, t.Execution, t.Status)
-	}
-	return nil
-}
-
 func displayTaskPriority(status string) int {
 	switch status {
 	case evergreen.TaskStarted:
@@ -1318,6 +1224,27 @@ func (t *Task) GetTestResultsForDisplayTask() ([]TestResult, error) {
 		return nil, errors.Wrap(err, "error merging test results for display task")
 	}
 	return tasks[0].LocalTestResults, nil
+}
+
+func (t *Task) SetResetWhenFinished(detail *apimodels.TaskEndDetail) error {
+	if !t.DisplayOnly {
+		return errors.Errorf("%s is not a display task", t.Id)
+	}
+	t.ResetWhenFinished = true
+	if detail != nil {
+		t.Details = *detail
+	}
+	return UpdateOne(
+		bson.M{
+			IdKey: t.Id,
+		},
+		bson.M{
+			"$set": bson.M{
+				ResetWhenFinishedKey: true,
+				DetailsKey:           detail,
+			},
+		},
+	)
 }
 
 // MergeTestResultsBulk takes a slice of task structs and returns the slice with

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -797,6 +797,7 @@ func (t *Task) Reset() error {
 	t.StartTime = util.ZeroTime
 	t.ScheduledTime = util.ZeroTime
 	t.FinishTime = util.ZeroTime
+	t.ResetWhenFinished = false
 	reset := bson.M{
 		"$set": bson.M{
 			ActivatedKey:     true,
@@ -808,7 +809,8 @@ func (t *Task) Reset() error {
 			FinishTimeKey:    util.ZeroTime,
 		},
 		"$unset": bson.M{
-			DetailsKey: "",
+			DetailsKey:           "",
+			ResetWhenFinishedKey: "",
 		},
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -16,6 +17,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type StatusChanges struct {
@@ -89,7 +91,7 @@ func SetActiveState(taskId string, caller string, active bool) error {
 	}
 
 	if t.IsPartOfDisplay() {
-		return updateDisplayTask(t)
+		return updateDisplayTaskAndCache(t)
 	}
 
 	return errors.WithStack(build.SetCachedTaskActivated(t.BuildId, taskId, active))
@@ -228,9 +230,6 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 		event.LogTaskRestarted(t.Id, t.Execution, origin)
 	}
 
-	if t.DisplayOnly {
-		return t.UpdateDisplayTask()
-	}
 	return errors.WithStack(err)
 }
 
@@ -409,7 +408,7 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 	event.LogTaskFinished(t.Id, t.Execution, t.HostId, status)
 
 	if t.IsPartOfDisplay() {
-		if err = t.DisplayTask.UpdateDisplayTask(); err != nil {
+		if err = UpdateDisplayTask(t.DisplayTask); err != nil {
 			return err
 		}
 		if err = build.UpdateCachedTask(t.DisplayTask.BuildId, t.DisplayTask.Id, t.DisplayTask.Status, t.TimeTaken); err != nil {
@@ -534,7 +533,7 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 				return err
 			}
 			if displayTask != nil {
-				err = displayTask.UpdateDisplayTask()
+				err = UpdateDisplayTask(displayTask)
 				if err != nil {
 					return err
 				}
@@ -700,7 +699,7 @@ func MarkStart(t *task.Task, updates *StatusChanges) error {
 	}
 
 	if t.IsPartOfDisplay() {
-		return updateDisplayTask(t)
+		return updateDisplayTaskAndCache(t)
 	}
 
 	// update the cached version of the task, in its build document
@@ -716,7 +715,7 @@ func MarkTaskUndispatched(t *task.Task) error {
 	event.LogTaskUndispatched(t.Id, t.Execution, t.HostId)
 
 	if t.IsPartOfDisplay() {
-		return updateDisplayTask(t)
+		return updateDisplayTaskAndCache(t)
 	}
 
 	// update the cached version of the task in its related build document
@@ -736,7 +735,7 @@ func MarkTaskDispatched(t *task.Task, hostId, distroId string) error {
 	event.LogTaskDispatched(t.Id, t.Execution, hostId)
 
 	if t.IsPartOfDisplay() {
-		return updateDisplayTask(t)
+		return updateDisplayTaskAndCache(t)
 	}
 
 	// update the cached version of the task in its related build document
@@ -746,8 +745,8 @@ func MarkTaskDispatched(t *task.Task, hostId, distroId string) error {
 	return nil
 }
 
-func updateDisplayTask(t *task.Task) error {
-	err := t.DisplayTask.UpdateDisplayTask()
+func updateDisplayTaskAndCache(t *task.Task) error {
+	err := UpdateDisplayTask(t.DisplayTask)
 	if err != nil {
 		return errors.Wrap(err, "error updating display task")
 	}
@@ -880,11 +879,112 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 	}
 
 	if time.Since(t.StartTime) < task.UnschedulableThreshold {
-		return errors.Wrap(TryResetTask(t.Id, "mci", evergreen.MonitorPackage, &apimodels.TaskEndDetail{
+		detail := &apimodels.TaskEndDetail{
 			Status: evergreen.TaskFailed,
 			Type:   "system",
-		}), "problem resetting task")
+		}
+		if t.IsPartOfDisplay() {
+			return t.DisplayTask.SetResetWhenFinished(detail)
+		}
+		return errors.Wrap(TryResetTask(t.Id, "mci", evergreen.MonitorPackage, detail), "problem resetting task")
 	}
 
+	return nil
+}
+
+func UpdateDisplayTask(t *task.Task) error {
+	if !t.DisplayOnly {
+		return fmt.Errorf("%s is not a display task", t.Id)
+	}
+
+	statuses := []string{}
+	var timeTaken time.Duration
+	var status string
+	wasFinished := t.IsFinished()
+	execTasks, err := task.Find(task.ByIds(t.ExecutionTasks))
+	if err != nil {
+		return errors.Wrap(err, "error retrieving execution tasks")
+	}
+	hasFinishedTasks := false
+	hasUnfinishedTasks := false
+	startTime := time.Unix(1<<62, 0)
+	endTime := util.ZeroTime
+	for _, execTask := range execTasks {
+		// if any of the execution tasks are scheduled, the display task is too
+		if execTask.Activated {
+			t.Activated = true
+		}
+
+		if execTask.IsFinished() {
+			hasFinishedTasks = true
+		} else if execTask.IsDispatchable() {
+			hasUnfinishedTasks = true
+		}
+
+		// the display task's status will be the highest priority of its exec tasks
+		statuses = append(statuses, execTask.ResultStatus())
+
+		// add up the duration of the execution tasks as the cumulative time taken
+		timeTaken += execTask.TimeTaken
+
+		// set the start/end time of the display task as the earliest/latest task
+		if execTask.StartTime.Before(startTime) {
+			startTime = execTask.StartTime
+		}
+		if execTask.FinishTime.After(endTime) {
+			endTime = execTask.FinishTime
+		}
+	}
+
+	if hasFinishedTasks && hasUnfinishedTasks {
+		// if the display task has a mix of finished and unfinished tasks, the status
+		// will be "started"
+		status = evergreen.TaskStarted
+	} else if len(statuses) > 0 {
+		// the status of the display task will be the status of its constituent task
+		// that is logically the most exclusive
+		sort.Sort(task.ByPriority(statuses))
+		status = statuses[0]
+	}
+
+	grip.InfoWhen(status == evergreen.TaskUndispatched && t.DispatchTime != util.ZeroTime, message.Fields{
+		"lookhere":                      "evg-3345",
+		"message":                       "update display tasks",
+		"task_id":                       t.Id,
+		"status":                        status,
+		"dispatch_time_is_go_zero_time": t.DispatchTime.IsZero(),
+	})
+
+	update := bson.M{
+		task.StatusKey:    status,
+		task.ActivatedKey: t.Activated,
+		task.TimeTakenKey: timeTaken,
+	}
+	if startTime != time.Unix(1<<62, 0) {
+		update[task.StartTimeKey] = startTime
+	}
+	if endTime != util.ZeroTime && !hasUnfinishedTasks {
+		update[task.FinishTimeKey] = endTime
+	}
+
+	err = task.UpdateOne(
+		bson.M{
+			task.IdKey: t.Id,
+		},
+		bson.M{
+			"$set": update,
+		})
+	if err != nil {
+		return errors.Wrap(err, "error updating display task")
+	}
+
+	t.Status = status
+	t.TimeTaken = timeTaken
+	if !wasFinished && t.IsFinished() {
+		event.LogDisplayTaskFinished(t.Id, t.Execution, t.Status)
+		if t.ResetWhenFinished {
+			return errors.Wrap(TryResetTask(t.Id, evergreen.User, evergreen.User, &t.Details), "error resetting display task")
+		}
+	}
 	return nil
 }

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/version"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -1036,7 +1037,7 @@ func TestTryResetTask(t *testing.T) {
 		So(t1FromDb.Status, ShouldEqual, evergreen.TaskUndispatched)
 		dtFromDb, err := task.FindOne(task.ById(dt.Id))
 		So(err, ShouldBeNil)
-		So(dtFromDb.Status, ShouldEqual, evergreen.TaskUnstarted)
+		So(dtFromDb.Status, ShouldEqual, evergreen.TaskUndispatched)
 		dbBuild, err := build.FindOne(build.ById(b.Id))
 		So(err, ShouldBeNil)
 		So(dbBuild.Tasks[0].Status, ShouldEqual, evergreen.TaskUndispatched)
@@ -1935,4 +1936,166 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	assert.True(complete)
 	assert.NoError(err)
 	assert.True(b.IsFinished())
+}
+
+func TestDisplayTaskUpdates(t *testing.T) {
+	testutil.HandleTestingErr(db.ClearCollections(task.Collection, event.AllLogCollection), t, "error clearing collection")
+	assert := assert.New(t)
+	dt := task.Task{
+		Id:          "dt",
+		DisplayOnly: true,
+		Status:      evergreen.TaskUndispatched,
+		Activated:   false,
+		ExecutionTasks: []string{
+			"task1",
+			"task2",
+			"task3",
+			"task4",
+		},
+	}
+	assert.NoError(dt.Insert())
+	dt2 := task.Task{
+		Id:          "dt2",
+		DisplayOnly: true,
+		Status:      evergreen.TaskUndispatched,
+		Activated:   false,
+		ExecutionTasks: []string{
+			"task5",
+			"task6",
+		},
+	}
+	assert.NoError(dt2.Insert())
+	task1 := task.Task{
+		Id:         "task1",
+		Status:     evergreen.TaskFailed,
+		TimeTaken:  3 * time.Minute,
+		StartTime:  time.Date(2000, 0, 0, 1, 1, 1, 0, time.Local),
+		FinishTime: time.Date(2000, 0, 0, 1, 9, 1, 0, time.Local),
+	}
+	assert.NoError(task1.Insert())
+	task2 := task.Task{
+		Id:         "task2",
+		Status:     evergreen.TaskSucceeded,
+		TimeTaken:  2 * time.Minute,
+		StartTime:  time.Date(2000, 0, 0, 0, 30, 0, 0, time.Local), // this should end up as the start time for dt1
+		FinishTime: time.Date(2000, 0, 0, 1, 0, 5, 0, time.Local),
+	}
+	assert.NoError(task2.Insert())
+	task3 := task.Task{
+		Id:         "task3",
+		Activated:  true,
+		Status:     evergreen.TaskSystemUnresponse,
+		TimeTaken:  5 * time.Minute,
+		StartTime:  time.Date(2000, 0, 0, 0, 44, 0, 0, time.Local),
+		FinishTime: time.Date(2000, 0, 0, 1, 0, 1, 0, time.Local),
+	}
+	assert.NoError(task3.Insert())
+	task4 := task.Task{
+		Id:         "task4",
+		Activated:  true,
+		Status:     evergreen.TaskSystemUnresponse,
+		TimeTaken:  1 * time.Minute,
+		StartTime:  time.Date(2000, 0, 0, 1, 0, 20, 0, time.Local),
+		FinishTime: time.Date(2000, 0, 0, 1, 22, 0, 0, time.Local), // this should end up as the end time for dt1
+	}
+	assert.NoError(task4.Insert())
+	task5 := task.Task{
+		Id:        "task5",
+		Activated: true,
+		Status:    evergreen.TaskUndispatched,
+	}
+	assert.NoError(task5.Insert())
+	task6 := task.Task{
+		Id:        "task6",
+		Activated: true,
+		Status:    evergreen.TaskSucceeded,
+	}
+	assert.NoError(task6.Insert())
+
+	// test that updating the status + activated from execution tasks works
+	assert.NoError(UpdateDisplayTask(&dt))
+	dbTask, err := task.FindOne(task.ById(dt.Id))
+	assert.NoError(err)
+	assert.NotNil(dbTask)
+	assert.Equal(evergreen.TaskFailed, dbTask.Status)
+	assert.True(dbTask.Activated)
+	assert.Equal(11*time.Minute, dbTask.TimeTaken)
+	assert.Equal(task2.StartTime, dbTask.StartTime)
+	assert.Equal(task4.FinishTime, dbTask.FinishTime)
+
+	// test that you can't update an execution task
+	assert.Error(UpdateDisplayTask(&task1))
+
+	// test that a display task with a finished + unstarted task is "scheduled"
+	assert.NoError(UpdateDisplayTask(&dt2))
+	dbTask, err = task.FindOne(task.ById(dt2.Id))
+	assert.NoError(err)
+	assert.NotNil(dbTask)
+	assert.Equal(evergreen.TaskStarted, dbTask.Status)
+
+	// check that the updates above logged an event for the first one
+	events, err := event.Find(event.AllLogCollection, event.TaskEventsForId(dt.Id))
+	assert.NoError(err)
+	assert.Len(events, 1)
+	events, err = event.Find(event.AllLogCollection, event.TaskEventsForId(dt2.Id))
+	assert.NoError(err)
+	assert.Len(events, 0)
+}
+
+func TestDisplayTaskDelayedRestart(t *testing.T) {
+	testutil.HandleTestingErr(db.ClearCollections(task.Collection, task.OldCollection, build.Collection), t, "error clearing collection")
+	assert := assert.New(t)
+	dt := task.Task{
+		Id:          "dt",
+		DisplayOnly: true,
+		Status:      evergreen.TaskStarted,
+		Activated:   true,
+		BuildId:     "b",
+		ExecutionTasks: []string{
+			"task1",
+			"task2",
+		},
+	}
+	assert.NoError(dt.Insert())
+	task1 := task.Task{
+		Id:      "task1",
+		BuildId: "b",
+		Status:  evergreen.TaskSucceeded,
+	}
+	assert.NoError(task1.Insert())
+	task2 := task.Task{
+		Id:      "task2",
+		BuildId: "b",
+		Status:  evergreen.TaskSucceeded,
+	}
+	assert.NoError(task2.Insert())
+	b := build.Build{
+		Id: "b",
+		Tasks: []build.TaskCache{
+			{Id: "dt", Status: evergreen.TaskStarted, Activated: true},
+		},
+	}
+	assert.NoError(b.Insert())
+
+	// request that the task restarts when it's done
+	detail := &apimodels.TaskEndDetail{
+		Description: "foo",
+		Type:        evergreen.CommandTypeTest,
+		Status:      evergreen.TaskSucceeded,
+	}
+	assert.NoError(dt.SetResetWhenFinished(detail))
+	dbTask, err := task.FindOne(task.ById(dt.Id))
+	assert.NoError(err)
+	assert.Equal(detail.Description, dbTask.Details.Description)
+	assert.True(dbTask.ResetWhenFinished)
+	assert.Equal(evergreen.TaskStarted, dbTask.Status)
+
+	// end the final task so that it restarts
+	assert.NoError(UpdateDisplayTask(&dt))
+	dbTask, err = task.FindOne(task.ById(dt.Id))
+	assert.NoError(err)
+	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
+	oldTask, err := task.FindOneOld(task.ById("dt_0"))
+	assert.NoError(err)
+	assert.Equal(detail.Description, oldTask.Details.Description)
 }

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -80,7 +80,6 @@ func (j *taskExecutionTimeoutJob) Run(ctx context.Context) {
 		return
 	}
 
-	displayTasksRestarted := map[string]bool{}
 	for _, task := range tasks {
 		msg := message.Fields{
 			"operation": j.Type().Name,
@@ -89,7 +88,7 @@ func (j *taskExecutionTimeoutJob) Run(ctx context.Context) {
 			"host":      task.HostId,
 		}
 
-		if err := cleanUpTimedOutTask(task, displayTasksRestarted); err != nil {
+		if err := cleanUpTimedOutTask(task); err != nil {
 			grip.Warning(message.WrapError(err, msg))
 			j.AddError(err)
 			continue
@@ -106,7 +105,7 @@ func (j *taskExecutionTimeoutJob) Run(ctx context.Context) {
 }
 
 // function to clean up a single task
-func cleanUpTimedOutTask(t task.Task, displayTasksRestarted map[string]bool) error {
+func cleanUpTimedOutTask(t task.Task) error {
 	// get tlhe host for the task
 	host, err := host.FindOne(host.ById(t.HostId))
 	if err != nil {
@@ -141,17 +140,8 @@ func cleanUpTimedOutTask(t task.Task, displayTasksRestarted map[string]bool) err
 	}
 
 	// try to reset the task
-	taskID := t.Id
 	if t.IsPartOfDisplay() {
-		if displayTasksRestarted[taskID] {
-			return nil // already restarted this display task this run
-		}
-		taskID = t.DisplayTask.Id
-		displayTasksRestarted[taskID] = true
+		return t.DisplayTask.SetResetWhenFinished(detail)
 	}
-	if err := model.TryResetTask(taskID, "", "monitor", detail); err != nil {
-		return errors.Wrapf(err, "error trying to reset task %s", t.Id)
-	}
-
-	return nil
+	return errors.Wrapf(model.TryResetTask(t.Id, "", "monitor", detail), "error trying to reset task %s", t.Id)
 }


### PR DESCRIPTION
The first commit is undoing a revert, the second is a change that I forgot to make in the original commit