### PR TITLE
EVG-5221 update exec timeout for smoke tasks

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -97,6 +97,10 @@ variables:
   - &run-smoke-test
     name: smoke
     commands:
+      - command: timeout.update
+        params:
+          exec_timeout_secs: 900
+          timeout_secs: 900
       - func: get-project
       - func: set-up-mongodb
       - func: run-make


### PR DESCRIPTION
this is just a stopgap to fail our tests early on docker until I fix them (they're timing out after 6 hours currently)