### PR TITLE
EVG-5347: expedite linting

### DIFF
--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -31,6 +31,7 @@ const (
 // directory. First, it tries diffing changed files against the merge base. If
 // there are no changes, this is not a patch build, so it diffs HEAD against HEAD~.
 func whatChanged() ([]string, error) {
+	return []string{}, nil
 	mergeBaseCmd := exec.Command("git", "merge-base", "master@{upstream}", "HEAD")
 	base, err := mergeBaseCmd.Output()
 	if err != nil {

--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -20,7 +20,7 @@ const (
 	lintVariant       = "lint"
 	lintGroup         = "lint-group"
 	commitMaxHosts    = 4
-	patchMaxHosts     = 2
+	patchMaxHosts     = 1
 	evergreenLintTask = "evergreen"
 	jsonFilename      = "bin/generate-lint.json"
 	scriptsDir        = "scripts"

--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -20,7 +20,7 @@ const (
 	lintVariant       = "lint"
 	lintGroup         = "lint-group"
 	commitMaxHosts    = 4
-	patchMaxHosts     = 1
+	patchMaxHosts     = 2
 	evergreenLintTask = "evergreen"
 	jsonFilename      = "bin/generate-lint.json"
 	scriptsDir        = "scripts"

--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -31,7 +31,6 @@ const (
 // directory. First, it tries diffing changed files against the merge base. If
 // there are no changes, this is not a patch build, so it diffs HEAD against HEAD~.
 func whatChanged() ([]string, error) {
-	return []string{}, nil
 	mergeBaseCmd := exec.Command("git", "merge-base", "master@{upstream}", "HEAD")
 	base, err := mergeBaseCmd.Output()
 	if err != nil {

--- a/makefile
+++ b/makefile
@@ -51,7 +51,7 @@ endif
 #   separately. This is a temporary solution: eventually we should
 #   vendorize all of these dependencies.
 lintDeps := github.com/alecthomas/gometalinter
-lintDeps += github.com/evergreen-ci/evg-lint/...
+lintDeps += github.com/evergreen-ci/evg-lint
 #   include test files and give linters 40s to run to avoid timeouts
 lintArgs := --tests --deadline=10m --vendor --aggregate --sort=line
 lintArgs += --vendored-linters --enable-gc
@@ -63,6 +63,7 @@ lintArgs += --disable="varcheck" --disable="structcheck" --disable="aligncheck"
 lintArgs += --skip="$(buildDir)" --skip="scripts" --skip="$(gopath)"
 #  add and configure additional linters
 lintArgs += --enable="misspell" # --enable="lll" --line-length=100
+lintArgs += --disable="megacheck" --enable="unused" --enable="gosimple"
 #  suppress some lint errors (logging methods could return errors, and error checking in defers.)
 lintArgs += --exclude=".*([mM]ock.*ator|modadvapi32|osSUSE) is unused \((deadcode|unused|megacheck)\)$$"
 lintArgs += --exclude="error return value not checked \((defer .*|fmt.Fprint.*) \(errcheck\)$$"

--- a/makefile
+++ b/makefile
@@ -51,7 +51,7 @@ endif
 #   separately. This is a temporary solution: eventually we should
 #   vendorize all of these dependencies.
 lintDeps := github.com/alecthomas/gometalinter
-lintDeps += github.com/evergreen-ci/evg-lint
+lintDeps += github.com/evergreen-ci/evg-lint/...
 #   include test files and give linters 40s to run to avoid timeouts
 lintArgs := --tests --deadline=10m --vendor --aggregate --sort=line
 lintArgs += --vendored-linters --enable-gc


### PR DESCRIPTION
This turns of staticcheck (for now), the longpull for it in the
context of megacheck slows everything down. 

I have a pull request that should let us turn it back on.