### PR TITLE
EVG-5456 continue on error when creating versions in repotracker

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -190,7 +190,6 @@ func (repoTracker *RepoTracker) FetchRevisions(ctx context.Context) error {
 // This function is idempotent with regard to storing the same version multiple times.
 func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []model.Revision) error {
 	var newestVersion *version.Version
-	var err error
 	ref := repoTracker.ProjectRef
 	for i := len(revisions) - 1; i >= 0; i-- {
 		revision := revisions[i].Revision
@@ -303,7 +302,7 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 		newestVersion = v
 	}
 	if newestVersion != nil {
-		err = model.UpdateLastRevision(newestVersion.Identifier, newestVersion.Revision)
+		err := model.UpdateLastRevision(newestVersion.Identifier, newestVersion.Revision)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "problem updating last revision for repository",

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -168,14 +168,16 @@ func (repoTracker *RepoTracker) FetchRevisions(ctx context.Context) error {
 			}))
 			return errors.WithStack(err)
 		}
-		err = model.UpdateLastRevision(lastVersion.Identifier, lastVersion.Revision)
-		if err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"message": "problem updating last revision for repository",
-				"project": projectRef,
-				"runner":  RunnerName,
-			}))
-			return errors.WithStack(err)
+		if lastVersion != nil {
+			err = model.UpdateLastRevision(lastVersion.Identifier, lastVersion.Revision)
+			if err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"message": "problem updating last revision for repository",
+					"project": projectRef,
+					"runner":  RunnerName,
+				}))
+				return errors.WithStack(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
The error in this case was a duplicate key when inserting a task