### PR TITLE
EVG-1720: change a single host status patch

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -298,6 +298,19 @@ var (
 		HostProvisionFailed,
 	}
 
+	// Set of host status values that can be user set via the API
+	ValidUserSetStatus = []string{
+		HostRunning,
+		HostTerminated,
+		HostUninitialized,
+		HostBuilding,
+		HostStarting,
+		HostProvisioning,
+		HostProvisionFailed,
+		HostQuarantined,
+		HostDecommissioned,
+	}
+
 	// constant arrays for db update logic
 	AbortableStatuses = []string{TaskStarted, TaskDispatched}
 	CompletedStatuses = []string{TaskSucceeded, TaskFailed}

--- a/globals.go
+++ b/globals.go
@@ -302,11 +302,6 @@ var (
 	ValidUserSetStatus = []string{
 		HostRunning,
 		HostTerminated,
-		HostUninitialized,
-		HostBuilding,
-		HostStarting,
-		HostProvisioning,
-		HostProvisionFailed,
 		HostQuarantined,
 		HostDecommissioned,
 	}

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -21,7 +21,7 @@ import (
 // PATCH /rest/v2/hosts/{host_id}
 
 type hostChangeStatusHandler struct {
-	Status string `json:"status"`
+	Status string
 	hostId string
 	sc     data.Connector
 }
@@ -58,7 +58,7 @@ func (h *hostChangeStatusHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
 	foundHost, err := h.sc.FindHostById(h.hostId)
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "Database error"))
+		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "database error"))
 	}
 
 	if err = h.sc.SetHostStatus(foundHost, h.Status, user.Username()); err != nil {
@@ -66,8 +66,8 @@ func (h *hostChangeStatusHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	host := &model.APIHost{}
-	if err = host.BuildFromService(*foundHost); err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Database error"))
+	if err = host.BuildFromService(foundHost); err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "API model error"))
 	}
 
 	return gimlet.NewJSONResponse(host)

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -21,7 +21,7 @@ import (
 // PATCH /rest/v2/hosts/{host_id}
 
 type hostChangeStatusHandler struct {
-	status string `json:"status"`
+	Status string `json:"status"`
 	hostId string
 	sc     data.Connector
 }

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -21,7 +21,7 @@ import (
 // PATCH /rest/v2/hosts/{host_id}
 
 type hostChangeStatusHandler struct {
-	Status string `json:"status"`
+	status string `json:"status"`
 	hostId string
 	sc     data.Connector
 }

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -61,7 +61,7 @@ func (h *hostChangeStatusHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "Database error"))
 	}
 
-	if err := h.sc.SetHostStatus(foundHost, h.Status, user.Username()); err != nil {
+	if err = h.sc.SetHostStatus(foundHost, h.Status, user.Username()); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Database error"))
 	}
 

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -56,13 +56,33 @@ func (h *hostChangeStatusHandler) Parse(ctx context.Context, r *http.Request) er
 
 func (h *hostChangeStatusHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
-	foundHost, err := h.sc.FindHostById(h.hostId)
+	foundHost, err := h.sc.FindHostByIdWithOwner(h.hostId, user)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "database error"))
 	}
 
-	if err = h.sc.SetHostStatus(foundHost, h.Status, user.Username()); err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Database error"))
+	if foundHost.Status == evergreen.HostTerminated {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintf("Host %s is terminated; its status cannot be changed ", foundHost.Id),
+		})
+	}
+
+	if h.Status == evergreen.HostTerminated {
+		if err := h.sc.TerminateHost(ctx, foundHost, user.Id); err != nil {
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusInternalServerError,
+				Message:    err.Error(),
+			})
+		}
+
+	} else {
+		if err := h.sc.SetHostStatus(foundHost, h.Status, user.Id); err != nil {
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusInternalServerError,
+				Message:    err.Error(),
+			})
+		}
 	}
 
 	host := &model.APIHost{}

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -69,7 +69,7 @@ func (h *hostChangeStatusHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	if h.Status == evergreen.HostTerminated {
-		if err := h.sc.TerminateHost(ctx, foundHost, user.Id); err != nil {
+		if err = h.sc.TerminateHost(ctx, foundHost, user.Id); err != nil {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 				StatusCode: http.StatusInternalServerError,
 				Message:    err.Error(),
@@ -77,7 +77,7 @@ func (h *hostChangeStatusHandler) Run(ctx context.Context) gimlet.Responder {
 		}
 
 	} else {
-		if err := h.sc.SetHostStatus(foundHost, h.Status, user.Id); err != nil {
+		if err = h.sc.SetHostStatus(foundHost, h.Status, user.Id); err != nil {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 				StatusCode: http.StatusInternalServerError,
 				Message:    err.Error(),

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -231,7 +231,7 @@ func (s *hostTerminateHostHandlerSuite) TestSuperUserCanTerminateAnyHost() {
 
 	resp := h.Run(ctx)
 	s.Equal(http.StatusOK, resp.Status())
-
+	s.Equal(evergreen.HostTerminated, s.sc.CachedHosts[2].Status)
 }
 
 func (s *hostTerminateHostHandlerSuite) TestRegularUserCannotTerminateAnyHost() {

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -69,6 +69,17 @@ func (s *HostChangeStatusSuite) TestParseMissingStatus() {
 	s.EqualError(err, "Argument read error: error attempting to unmarshal into *route.hostChangeStatusHandler: unexpected end of JSON input")
 }
 
+func (s *HostChangeStatusSuite) TestRunHostValidStatusChange() {
+	h := s.route.Factory().(*hostChangeStatusHandler)
+	h.hostId = "host4"
+	h.Status = evergreen.HostTerminated
+
+	ctx := context.Background()
+	ctx = gimlet.AttachUser(ctx, s.sc.MockUserConnector.CachedUsers["user0"])
+	res := h.Run(ctx)
+	s.Equal(http.StatusOK, res.Status())
+}
+
 func (s *HostChangeStatusSuite) TestRunHostNotStartedByUser() {
 	h := s.route.Factory().(*hostChangeStatusHandler)
 	h.hostId = "host4"
@@ -88,7 +99,7 @@ func (s *HostChangeStatusSuite) TestRunSuperUserSetStatusAnyHost() {
 	ctx := context.Background()
 	ctx = gimlet.AttachUser(ctx, s.sc.MockUserConnector.CachedUsers["root"])
 	res := h.Run(ctx)
-	s.NotEqual(http.StatusOK, res.Status())
+	s.Equal(http.StatusOK, res.Status())
 }
 
 func (s *HostChangeStatusSuite) TestRunTerminatedOnTerminatedHost() {

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -22,7 +22,6 @@ import (
 type HostChangeStatusSuite struct {
 	route *hostChangeStatusHandler
 	sc    *data.MockConnector
-	data  data.MockHostConnector
 
 	suite.Suite
 }

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -49,6 +49,7 @@ func AttachHandler(app *gimlet.APIApp, queue amboy.Queue, URL string, superUsers
 	app.AddRoute("/hosts").Version(2).Get().RouteHandler(makeFetchHosts(sc))
 	app.AddRoute("/hosts").Version(2).Post().Wrap(checkUser).RouteHandler(makeSpawnHostCreateRoute(sc))
 	app.AddRoute("/hosts/{host_id}").Version(2).Get().RouteHandler(makeGetHostByID(sc))
+	app.AddRoute("/hosts/{host_id}").Version(2).Patch().Wrap(checkUser).RouteHandler(makeChangeHostStatus(sc))
 	app.AddRoute("/hosts/{host_id}/change_password").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostChangePassword(sc))
 	app.AddRoute("/hosts/{host_id}/extend_expiration").Version(2).Post().Wrap(checkUser).RouteHandler(makeExtendHostExpiration(sc))
 	app.AddRoute("/hosts/{host_id}/terminate").Version(2).Post().Wrap(checkUser).RouteHandler(makeTerminateHostRoute(sc))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -49,7 +49,7 @@ func AttachHandler(app *gimlet.APIApp, queue amboy.Queue, URL string, superUsers
 	app.AddRoute("/hosts").Version(2).Get().RouteHandler(makeFetchHosts(sc))
 	app.AddRoute("/hosts").Version(2).Post().Wrap(checkUser).RouteHandler(makeSpawnHostCreateRoute(sc))
 	app.AddRoute("/hosts/{host_id}").Version(2).Get().RouteHandler(makeGetHostByID(sc))
-	app.AddRoute("/hosts/{host_id}").Version(2).Patch().Wrap(superUser).RouteHandler(makeChangeHostStatus(sc))
+	app.AddRoute("/hosts/{host_id}").Version(2).Patch().Wrap(checkUser).RouteHandler(makeChangeHostStatus(sc))
 	app.AddRoute("/hosts/{host_id}/change_password").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostChangePassword(sc))
 	app.AddRoute("/hosts/{host_id}/extend_expiration").Version(2).Post().Wrap(checkUser).RouteHandler(makeExtendHostExpiration(sc))
 	app.AddRoute("/hosts/{host_id}/terminate").Version(2).Post().Wrap(checkUser).RouteHandler(makeTerminateHostRoute(sc))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -49,7 +49,7 @@ func AttachHandler(app *gimlet.APIApp, queue amboy.Queue, URL string, superUsers
 	app.AddRoute("/hosts").Version(2).Get().RouteHandler(makeFetchHosts(sc))
 	app.AddRoute("/hosts").Version(2).Post().Wrap(checkUser).RouteHandler(makeSpawnHostCreateRoute(sc))
 	app.AddRoute("/hosts/{host_id}").Version(2).Get().RouteHandler(makeGetHostByID(sc))
-	app.AddRoute("/hosts/{host_id}").Version(2).Patch().Wrap(checkUser).RouteHandler(makeChangeHostStatus(sc))
+	app.AddRoute("/hosts/{host_id}").Version(2).Patch().Wrap(superUser).RouteHandler(makeChangeHostStatus(sc))
 	app.AddRoute("/hosts/{host_id}/change_password").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostChangePassword(sc))
 	app.AddRoute("/hosts/{host_id}/extend_expiration").Version(2).Post().Wrap(checkUser).RouteHandler(makeExtendHostExpiration(sc))
 	app.AddRoute("/hosts/{host_id}/terminate").Version(2).Post().Wrap(checkUser).RouteHandler(makeTerminateHostRoute(sc))


### PR DESCRIPTION
Which of these are not valid user set states and should be removed from globals.go? 

ValidUserSetStatus = []string{
  HostRunning,
  HostTerminated,
  HostUninitialized,
  HostBuilding,
  HostStarting,
  HostProvisioning,
  HostProvisionFailed,
  HostQuarantined,
  HostDecommissioned,
}