### PR TITLE
EVG-5411: Initialize files_ignored_from_cache if needed

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -182,6 +182,9 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
 
   // addCacheIgnoreFile adds a file pattern to the settingsFormData's list of ignored cache files
   $scope.addCacheIgnoreFile = function(){
+    if (!$scope.settingsFormData.files_ignored_from_cache) {
+      $scope.settingsFormData.files_ignored_from_cache = [];
+    }
     $scope.settingsFormData.files_ignored_from_cache.push($scope.cache_ignore_file_pattern);
     $scope.cache_ignore_file_pattern = "";
   };


### PR DESCRIPTION
I noticed a problem with the UI code I added earlier. If a project does not already have any "files_ignored_from_cache", it hits an error when attempted to add one.

This change will initialize that value if it is the first time adding to that value.