### PR TITLE
EVG-5412 Prevent usage of '|' in task, distro and variant names

### DIFF
--- a/validator/distro_validator_test.go
+++ b/validator/distro_validator_test.go
@@ -264,6 +264,19 @@ func TestEnsureNonZeroID(t *testing.T) {
 	assert.Nil(ensureHasNonZeroID(ctx, &distro.Distro{Id: " "}, conf))
 }
 
+func TestEnsureNoUnauthorizedCharacters(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert.NotNil(ensureHasNoUnauthorizedCharacters(ctx, &distro.Distro{Id: "|distro"}, conf))
+	assert.NotNil(ensureHasNoUnauthorizedCharacters(ctx, &distro.Distro{Id: "distro|"}, conf))
+	assert.NotNil(ensureHasNoUnauthorizedCharacters(ctx, &distro.Distro{Id: "dist|ro"}, conf))
+
+	assert.Nil(ensureHasNonZeroID(ctx, &distro.Distro{Id: "distro"}, conf))
+}
+
 func TestEnsureValidContainerPool(t *testing.T) {
 	assert := assert.New(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -571,6 +571,21 @@ func TestVerifyTaskRequirements(t *testing.T) {
 	})
 }
 
+func TestValidateTaskNames(t *testing.T) {
+	Convey("When a task name contains unauthorized characters, an error should be returned", t, func() {
+		project := &model.Project{
+			Tasks: []model.ProjectTask{
+				{Name: "task|"},
+				{Name: "|task"},
+				{Name: "ta|sk"},
+				{Name: "task"},
+			},
+		}
+		validationResults := validateTaskNames(project)
+		So(len(validationResults), ShouldEqual, 3)
+	})
+}
+
 func TestValidateBVNames(t *testing.T) {
 	Convey("When validating a project's build variants' names", t, func() {
 		Convey("if any variant has a duplicate entry, an error should be returned", func() {
@@ -632,6 +647,19 @@ func TestValidateBVNames(t *testing.T) {
 				},
 			}
 			So(validateBVNames(project), ShouldResemble, ValidationErrors{})
+		})
+
+		Convey("if a buildvariant name contains unauthorized characters, an error should be returned", func() {
+			project := &model.Project{
+				BuildVariants: []model.BuildVariant{
+					{Name: "|linux"},
+					{Name: "linux|"},
+					{Name: "wind|ows"},
+					{Name: "windows"},
+				},
+			}
+			So(validateBVNames(project), ShouldNotResemble, ValidationErrors{})
+			So(len(validateBVNames(project)), ShouldEqual, 3)
 		})
 	})
 }


### PR DESCRIPTION
We want to use the '|' character as a separator for the start_at key when querying test/task statistics. This would assume the character does not appear in test, task, variant and distro names.