### PR TITLE
EVG-5412 Update StartAt semantic

### DIFF
--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -735,20 +735,20 @@ func buildTestPaginationOrBranches(filter *StatsFilter) []bson.M {
 	case GroupByTest:
 		fields = []paginationField{
 			{Field: dbTestStatsIdDateKeyFull, Operator: dateOperator, Value: filter.StartAt.Date},
-			{Field: dbTestStatsIdTestFileKeyFull, Operator: "$gt", Value: filter.StartAt.Test},
+			{Field: dbTestStatsIdTestFileKeyFull, Operator: "$gte", Value: filter.StartAt.Test},
 		}
 	case GroupByTask:
 		fields = []paginationField{
 			{Field: dbTestStatsIdDateKeyFull, Operator: dateOperator, Value: filter.StartAt.Date},
 			{Field: dbTestStatsIdTaskNameKeyFull, Operator: "$gt", Value: filter.StartAt.Task},
-			{Field: dbTestStatsIdTestFileKeyFull, Operator: "$gt", Value: filter.StartAt.Test},
+			{Field: dbTestStatsIdTestFileKeyFull, Operator: "$gte", Value: filter.StartAt.Test},
 		}
 	case GroupByVariant:
 		fields = []paginationField{
 			{Field: dbTestStatsIdDateKeyFull, Operator: dateOperator, Value: filter.StartAt.Date},
 			{Field: dbTestStatsIdBuildVariantKeyFull, Operator: "$gt", Value: filter.StartAt.BuildVariant},
 			{Field: dbTestStatsIdTaskNameKeyFull, Operator: "$gt", Value: filter.StartAt.Task},
-			{Field: dbTestStatsIdTestFileKeyFull, Operator: "$gt", Value: filter.StartAt.Test},
+			{Field: dbTestStatsIdTestFileKeyFull, Operator: "$gte", Value: filter.StartAt.Test},
 		}
 	case GroupByDistro:
 		fields = []paginationField{
@@ -756,7 +756,7 @@ func buildTestPaginationOrBranches(filter *StatsFilter) []bson.M {
 			{Field: dbTestStatsIdBuildVariantKeyFull, Operator: "$gt", Value: filter.StartAt.BuildVariant},
 			{Field: dbTestStatsIdTaskNameKeyFull, Operator: "$gt", Value: filter.StartAt.Task},
 			{Field: dbTestStatsIdTestFileKeyFull, Operator: "$gt", Value: filter.StartAt.Test},
-			{Field: dbTestStatsIdDistroKeyFull, Operator: "$gt", Value: filter.StartAt.Distro},
+			{Field: dbTestStatsIdDistroKeyFull, Operator: "$gte", Value: filter.StartAt.Distro},
 		}
 	}
 
@@ -848,20 +848,20 @@ func buildTaskPaginationOrBranches(filter *StatsFilter) []bson.M {
 	case GroupByTask:
 		fields = []paginationField{
 			{Field: dbTaskStatsIdDateKeyFull, Operator: dateOperator, Value: filter.StartAt.Date},
-			{Field: dbTaskStatsIdTaskNameKeyFull, Operator: "$gt", Value: filter.StartAt.Task},
+			{Field: dbTaskStatsIdTaskNameKeyFull, Operator: "$gte", Value: filter.StartAt.Task},
 		}
 	case GroupByVariant:
 		fields = []paginationField{
 			{Field: dbTaskStatsIdDateKeyFull, Operator: dateOperator, Value: filter.StartAt.Date},
 			{Field: dbTaskStatsIdBuildVariantKeyFull, Operator: "$gt", Value: filter.StartAt.BuildVariant},
-			{Field: dbTaskStatsIdTaskNameKeyFull, Operator: "$gt", Value: filter.StartAt.Task},
+			{Field: dbTaskStatsIdTaskNameKeyFull, Operator: "$gte", Value: filter.StartAt.Task},
 		}
 	case GroupByDistro:
 		fields = []paginationField{
 			{Field: dbTaskStatsIdDateKeyFull, Operator: dateOperator, Value: filter.StartAt.Date},
 			{Field: dbTaskStatsIdBuildVariantKeyFull, Operator: "$gt", Value: filter.StartAt.BuildVariant},
 			{Field: dbTaskStatsIdTaskNameKeyFull, Operator: "$gt", Value: filter.StartAt.Task},
-			{Field: dbTaskStatsIdDistroKeyFull, Operator: "$gt", Value: filter.StartAt.Distro},
+			{Field: dbTaskStatsIdDistroKeyFull, Operator: "$gte", Value: filter.StartAt.Distro},
 		}
 	}
 

--- a/model/stats/query.go
+++ b/model/stats/query.go
@@ -59,6 +59,31 @@ type StartAt struct {
 	Distro       string
 }
 
+// StartAtFromTestStats creates a StartAt that can be used to resume a test stats query.
+// Using the returned StartAt the given TestStats will be the first result.
+func StartAtFromTestStats(testStats *TestStats) StartAt {
+	startAt := StartAt{
+		Date:         testStats.Date,
+		BuildVariant: testStats.BuildVariant,
+		Task:         testStats.TaskName,
+		Test:         testStats.TestFile,
+		Distro:       testStats.Distro,
+	}
+	return startAt
+}
+
+// StartAtFromTaskStats creates a StartAt that can be used to resume a task stats query.
+// Using the returned StartAt the given TaskStats will be the first result.
+func StartAtFromTaskStats(taskStats *TaskStats) StartAt {
+	startAt := StartAt{
+		Date:         taskStats.Date,
+		BuildVariant: taskStats.BuildVariant,
+		Task:         taskStats.TaskName,
+		Distro:       taskStats.Distro,
+	}
+	return startAt
+}
+
 // validateCommon validates that the StartAt struct is valid for use with test stats.
 func (s *StartAt) validateCommon(groupBy GroupBy) error {
 	catcher := grip.NewBasicCatcher()

--- a/model/stats/query_test.go
+++ b/model/stats/query_test.go
@@ -549,24 +549,26 @@ func (s *statsQuerySuite) TestGetTestStatsPagination() {
 
 	s.baseTestFilter.Project = "p2"
 	s.baseTestFilter.Tests = nil
-	s.baseTestFilter.Limit = 2
+	s.baseTestFilter.Limit = 3
 	s.baseTestFilter.GroupBy = GroupByDistro
 
 	docs, err := GetTestStats(&s.baseTestFilter)
 	require.NoError(err)
-	require.Len(docs, 2)
+	require.Len(docs, 3)
 	// expecting the results ordered by date/variant/task/test/distro
 	s.checkTestStats(docs[0], "test4", "task1", "v1", "d2", day1, 1, 1, float64(1))
 	s.checkTestStats(docs[1], "test6", "task1", "v1", "d1", day1, 1, 1, float64(1))
+	s.checkTestStats(docs[2], "test2", "task2", "v1", "d1", day1, 1, 1, float64(1))
 
-	s.baseTestFilter.StartAt = &StartAt{Date: day1, Test: "test6", Task: "task1", BuildVariant: "v1", Distro: "d1"}
+	s.baseTestFilter.StartAt = &StartAt{Date: day1, Test: "test2", Task: "task2", BuildVariant: "v1", Distro: "d1"}
 	docs, err = GetTestStats(&s.baseTestFilter)
 	require.NoError(err)
-	require.Len(docs, 2)
+	require.Len(docs, 3)
 	s.checkTestStats(docs[0], "test2", "task2", "v1", "d1", day1, 1, 1, float64(1))
 	s.checkTestStats(docs[1], "test5", "task1", "v2", "d1", day1, 1, 1, float64(1))
+	s.checkTestStats(docs[2], "test1", "task2", "v2", "d1", day1, 1, 1, float64(1))
 
-	s.baseTestFilter.StartAt = &StartAt{Date: day1, Test: "test5", Task: "task1", BuildVariant: "v2", Distro: "d1"}
+	s.baseTestFilter.StartAt = &StartAt{Date: day1, Test: "test1", Task: "task2", BuildVariant: "v2", Distro: "d1"}
 	docs, err = GetTestStats(&s.baseTestFilter)
 	require.NoError(err)
 	require.Len(docs, 2)
@@ -586,21 +588,23 @@ func (s *statsQuerySuite) TestGetTestStatsPaginationGroupByTest() {
 
 	s.baseTestFilter.Project = "p2"
 	s.baseTestFilter.Tests = nil
-	s.baseTestFilter.Limit = 2
+	s.baseTestFilter.Limit = 3
 	s.baseTestFilter.GroupBy = GroupByTest
 
 	docs, err := GetTestStats(&s.baseTestFilter)
 	require.NoError(err)
-	require.Len(docs, 2)
+	require.Len(docs, 3)
 	s.checkTestStats(docs[0], "test1", "", "", "", day1, 1, 1, float64(1))
 	s.checkTestStats(docs[1], "test2", "", "", "", day1, 1, 1, float64(1))
+	s.checkTestStats(docs[2], "test3", "", "", "", day1, 1, 1, float64(1))
 
-	s.baseTestFilter.StartAt = &StartAt{Date: day1, Test: "test2"}
+	s.baseTestFilter.StartAt = &StartAt{Date: day1, Test: "test3"}
 	docs, err = GetTestStats(&s.baseTestFilter)
 	require.NoError(err)
-	require.Len(docs, 2)
+	require.Len(docs, 3)
 	s.checkTestStats(docs[0], "test3", "", "", "", day1, 1, 1, float64(1))
 	s.checkTestStats(docs[1], "test4", "", "", "", day1, 1, 1, float64(1))
+	s.checkTestStats(docs[2], "test5", "", "", "", day1, 1, 1, float64(1))
 }
 
 func (s *statsQuerySuite) TestGetTaskStatsEmptyCollection() {
@@ -766,24 +770,26 @@ func (s *statsQuerySuite) TestGetTaskStatsPagination() {
 
 	s.baseTaskFilter.Project = "p2"
 	s.baseTaskFilter.Tasks = []string{"task1", "task2", "task3", "task4", "task5", "task6"}
-	s.baseTaskFilter.Limit = 2
+	s.baseTaskFilter.Limit = 3
 
 	docs, err := GetTaskStats(&s.baseTaskFilter)
 	require.NoError(err)
-	require.Len(docs, 2)
+	require.Len(docs, 3)
 	// expecting the results ordered by date/variant/task/test/distro
 	s.checkTaskStats(docs[0], "task4", "v1", "d2", day1, 1, 1, 1, 0, 0, 0, float64(10))
 	s.checkTaskStats(docs[1], "task5", "v1", "d1", day1, 1, 1, 1, 0, 0, 0, float64(10))
+	s.checkTaskStats(docs[2], "task6", "v1", "d1", day1, 1, 1, 1, 0, 0, 0, float64(10))
 
-	s.baseTaskFilter.StartAt = &StartAt{Date: day1, Task: "task5", BuildVariant: "v1", Distro: "d1"}
+	s.baseTaskFilter.StartAt = &StartAt{Date: day1, Task: "task6", BuildVariant: "v1", Distro: "d1"}
 
 	docs, err = GetTaskStats(&s.baseTaskFilter)
 	require.NoError(err)
-	require.Len(docs, 2)
+	require.Len(docs, 3)
 	s.checkTaskStats(docs[0], "task6", "v1", "d1", day1, 1, 1, 1, 0, 0, 0, float64(10))
 	s.checkTaskStats(docs[1], "task1", "v2", "d2", day1, 1, 1, 1, 0, 0, 0, float64(10))
+	s.checkTaskStats(docs[2], "task2", "v2", "d1", day1, 1, 1, 1, 0, 0, 0, float64(10))
 
-	s.baseTaskFilter.StartAt = &StartAt{Date: day1, Task: "task1", BuildVariant: "v2", Distro: "d2"}
+	s.baseTaskFilter.StartAt = &StartAt{Date: day1, Task: "task2", BuildVariant: "v2", Distro: "d1"}
 
 	docs, err = GetTaskStats(&s.baseTaskFilter)
 	require.NoError(err)
@@ -804,22 +810,24 @@ func (s *statsQuerySuite) TestGetTaskStatsPaginationGroupByTask() {
 
 	s.baseTaskFilter.Project = "p2"
 	s.baseTaskFilter.Tasks = []string{"task1", "task2", "task3", "task4", "task5", "task6"}
-	s.baseTaskFilter.Limit = 2
+	s.baseTaskFilter.Limit = 3
 	s.baseTaskFilter.GroupBy = GroupByTask
 
 	docs, err := GetTaskStats(&s.baseTaskFilter)
 	require.NoError(err)
-	require.Len(docs, 2)
+	require.Len(docs, 3)
 	s.checkTaskStats(docs[0], "task1", "", "", day1, 1, 1, 1, 0, 0, 0, float64(10))
 	s.checkTaskStats(docs[1], "task2", "", "", day1, 1, 1, 1, 0, 0, 0, float64(10))
+	s.checkTaskStats(docs[2], "task3", "", "", day1, 1, 1, 1, 0, 0, 0, float64(10))
 
-	s.baseTaskFilter.StartAt = &StartAt{Date: day1, Task: "task2"}
+	s.baseTaskFilter.StartAt = &StartAt{Date: day1, Task: "task3"}
 
 	docs, err = GetTaskStats(&s.baseTaskFilter)
 	require.NoError(err)
-	require.Len(docs, 2)
+	require.Len(docs, 3)
 	s.checkTaskStats(docs[0], "task3", "", "", day1, 1, 1, 1, 0, 0, 0, float64(10))
 	s.checkTaskStats(docs[1], "task4", "", "", day1, 1, 1, 1, 0, 0, 0, float64(10))
+	s.checkTaskStats(docs[2], "task5", "", "", day1, 1, 1, 1, 0, 0, 0, float64(10))
 }
 
 func (s *statsQuerySuite) checkTestStats(stats TestStats, test, task, variant, distro string, date time.Time, numPass, numFail int, avgDuration float64) {


### PR DESCRIPTION
When querying test and task statistics the semantic was to resume **after** the document corresponding to the StartAt. With this change we resume **at** the document.