### PR TITLE
EVG-5332 (fix) Trendchart - display current commit for MAXONLY mode

### DIFF
--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -199,9 +199,9 @@ mciModule.controller('PerfController', function PerfController(
         threadMode: scope.threadLevelsRadio.value,
         linearMode: scope.scaleModel.linearMode,
         originMode: scope.rangeModel.originMode
-      });
-      scope.showToolbar = true
+      })
     }
+    scope.showToolbar = true
   }
 
   // converts a percentage to a color. Higher -> greener, Lower -> redder.

--- a/public/static/app/perf/trend_chart.js
+++ b/public/static/app/perf/trend_chart.js
@@ -672,7 +672,11 @@ mciModule.factory('DrawPerfTrendChart', function (
       // Current revision marker
       var commitCircle = chartG
         .selectAll('circle.current')
-        .data(threadLevelsForSample(series[currentItemIdx], activeLevels))
+        .data(
+          threadMode == MAXONLY
+            ? activeLevels
+            : threadLevelsForSample(series[currentItemIdx], activeLevels)
+        )
 
       commitCircle
         .enter()


### PR DESCRIPTION
![trendchart-current-commit-maxonly](https://user-images.githubusercontent.com/1101771/50081597-f3cb8380-01ff-11e9-8501-082bb12fbd9b.png)
