### PR TITLE
EVG-5731: Fix degraded mode flags in UI

### DIFF
--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1,9 +1,6 @@
 {{define "scripts"}}
 <script>
-	window.auth_is_ldap = {
-		{.AuthIsLDAP
-		}
-	};
+	window.auth_is_ldap = {{.AuthIsLDAP}};
 </script>
 <script src="{{Static "js" "admin.js"}}?hash={{ BuildRevision }}"></script>
 <script type="text/javascript" src="{{Static "thirdparty" "js-yaml.min.js"}}?hash={{ BuildRevision }}"></script>
@@ -124,7 +121,7 @@ Admin Settings
 											<tr>
 												<td>Dispatch tasks</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.task_dispatch_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.task_dispatch_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -133,7 +130,7 @@ Admin Settings
 											<tr>
 												<td>Create and provision hosts</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.hostinit_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.hostinit_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -142,7 +139,7 @@ Admin Settings
 											<tr>
 												<td>Monitor hosts and tasks</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.monitor_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.monitor_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -151,7 +148,7 @@ Admin Settings
 											<tr>
 												<td>Alert for spawn host expiration</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.alerts_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.alerts_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -160,7 +157,7 @@ Admin Settings
 											<tr>
 												<td>Start agents on hosts</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.agent_start_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.agent_start_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -169,7 +166,7 @@ Admin Settings
 											<tr>
 												<td>Track GitHub repositories</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.repotracker_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.repotracker_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -178,7 +175,7 @@ Admin Settings
 											<tr>
 												<td>Schedule tasks</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.scheduler_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.scheduler_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -187,7 +184,7 @@ Admin Settings
 											<tr>
 												<td>Test GitHub pull requests</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.github_pr_testing_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.github_pr_testing_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -196,7 +193,7 @@ Admin Settings
 											<tr>
 												<td>Update CLI</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.cli_updates_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.cli_updates_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -205,7 +202,7 @@ Admin Settings
 											<tr>
 												<td>Collect background statistics</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.background_stats_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.background_stats_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -214,7 +211,7 @@ Admin Settings
 											<tr>
 												<td>Persist task and test logs</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.task_logging_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.task_logging_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -223,7 +220,7 @@ Admin Settings
 											<tr>
 												<td>Cache historical statistics</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.cache_stats_job_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.cache_stats_job_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -235,7 +232,7 @@ Admin Settings
 											<tr>
 												<td>Process notification events</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.event_processing_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.event_processing_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -244,7 +241,7 @@ Admin Settings
 											<tr>
 												<td>Send JIRA notifications</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.jira_notifications_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.jira_notifications_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -253,7 +250,7 @@ Admin Settings
 											<tr>
 												<td>Send Slack notifications</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.slack_notifications_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.slack_notifications_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -262,7 +259,7 @@ Admin Settings
 											<tr>
 												<td>Send Email notifications</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.email_notifications_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.email_notifications_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -271,7 +268,7 @@ Admin Settings
 											<tr>
 												<td>Send Webhook notifications</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.webhook_notifications_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.webhook_notifications_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>
@@ -280,7 +277,7 @@ Admin Settings
 											<tr>
 												<td>Send Github PR status notifications</td>
 												<td colspan="2">
-													<md-radio-group data-ng-model="Settings.service_flags.github_status_api_disabled">
+													<md-radio-group data-ng-model="Settings.service_flags.github_status_api_disabled" layout="row">
 														<md-radio-button data-ng-value="false"></md-radio-button>
 														<md-radio-button data-ng-value="true"></md-radio-button>
 													</md-radio-group>


### PR DESCRIPTION
The previous commit caused the radio buttons to be on top of one another instead of side-by-side.
Through experimentation I determined the change that caused this was adding whitespace between the button elements. It's not clear to me why this caused the bug. Regardless, setting the layout to row is a better way to express what we're trying to do.