### PR TITLE
EVG-3389: s3Copy.copy command should accept a permissions argument

### DIFF
--- a/apimodels/s3copy.go
+++ b/apimodels/s3copy.go
@@ -11,4 +11,5 @@ type S3CopyRequest struct {
 	S3DestinationBucket string `json:"s3_destination_bucket"`
 	S3DestinationPath   string `json:"s3_destination_path"`
 	S3DisplayName       string `json:"display_name"`
+	S3Permissions       string `json:"s3_permissions"`
 }

--- a/command/s3_copy.go
+++ b/command/s3_copy.go
@@ -42,7 +42,7 @@ type s3CopyFile struct {
 	// Permissions is the ACL to apply to the copied file. See:
 	//  http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
 	// for some examples.
-	Permissions string `mapstructure:"permissions"`
+	Permissions string `mapstructure:"permissions" plugin:"expand"`
 
 	// BuildVariants is a slice of build variants for which
 	// a specified file is to be copied. An empty slice indicates it is to be

--- a/command/s3_copy.go
+++ b/command/s3_copy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/artifact"
@@ -37,6 +38,11 @@ type s3CopyFile struct {
 	//  path: linux-64/x86_64/artifact.tgz
 	Source      s3Loc `mapstructure:"source" plugin:"expand"`
 	Destination s3Loc `mapstructure:"destination" plugin:"expand"`
+
+	// Permissions is the ACL to apply to the copied file. See:
+	//  http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+	// for some examples.
+	Permissions string `mapstructure:"permissions"`
 
 	// BuildVariants is a slice of build variants for which
 	// a specified file is to be copied. An empty slice indicates it is to be
@@ -98,6 +104,9 @@ func (c *s3copy) validateParams() error {
 		}
 		if s3CopyFile.Destination.Path == "" {
 			return errors.New("s3 destination path cannot be blank")
+		}
+		if s3CopyFile.Permissions == "" {
+			s3CopyFile.Permissions = s3.BucketCannedACLPublicRead
 		}
 
 		err := validateS3BucketName(s3CopyFile.Source.Bucket)

--- a/command/s3_put.go
+++ b/command/s3_put.go
@@ -44,7 +44,7 @@ type s3put struct {
 	// Bucket is the s3 bucket to use when storing the desired file
 	Bucket string `mapstructure:"bucket" plugin:"expand"`
 
-	// Permission is the ACL to apply to the uploaded file. See:
+	// Permissions is the ACL to apply to the uploaded file. See:
 	//  http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
 	// for some examples.
 	Permissions string `mapstructure:"permissions"`

--- a/model/s3copy.go
+++ b/model/s3copy.go
@@ -11,4 +11,5 @@ type S3CopyRequest struct {
 	S3DestinationBucket string `json:"s3_destination_bucket"`
 	S3DestinationPath   string `json:"s3_destination_path"`
 	S3DisplayName       string `json:"display_name"`
+	S3Permissions       string `json:"s3_permissions"`
 }

--- a/service/api_plugin_s3copy.go
+++ b/service/api_plugin_s3copy.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/util"

--- a/service/api_plugin_s3copy.go
+++ b/service/api_plugin_s3copy.go
@@ -87,7 +87,7 @@ func (as *APIServer) s3copyPlugin(w http.ResponseWriter, r *http.Request) {
 		Credentials: pail.CreateAWSCredentials(s3CopyReq.AwsKey, s3CopyReq.AwsSecret, ""),
 		Region:      region,
 		Name:        s3CopyReq.S3SourceBucket,
-		Permission:  s3.BucketCannedACLPublicRead,
+		Permission:  s3CopyReq.S3Permissions,
 	}
 	srcBucket, err := pail.NewS3MultiPartBucket(srcOpts)
 	if err != nil {
@@ -97,7 +97,7 @@ func (as *APIServer) s3copyPlugin(w http.ResponseWriter, r *http.Request) {
 		Credentials: pail.CreateAWSCredentials(s3CopyReq.AwsKey, s3CopyReq.AwsSecret, ""),
 		Region:      region,
 		Name:        s3CopyReq.S3DestinationBucket,
-		Permission:  s3.BucketCannedACLPublicRead,
+		Permission:  s3CopyReq.S3Permissions,
 	}
 	destBucket, err := pail.NewS3MultiPartBucket(destOpts)
 	if err != nil {


### PR DESCRIPTION
The only thing I did not do that the ticket requested was copy the permissions of the filed being copied. This would break code where they are expecting files to have public-read permissions when copied over (public-read is the default).