### PR TITLE
EVG-5717: fix UI bug when adding subscriptions

### DIFF
--- a/public/static/js/build.js
+++ b/public/static/js/build.js
@@ -70,7 +70,6 @@ mciModule.controller('BuildViewController', function($scope, $http, $timeout, $r
   $scope.loading = false;
   $scope.lastUpdate = null;
   $scope.jiraHost = $window.jiraHost;
-  $scope.subscriptions = [];
   $scope.hide_add_subscription = true;
   $scope.triggers = [
     {
@@ -139,12 +138,11 @@ mciModule.controller('BuildViewController', function($scope, $http, $timeout, $r
       }else {
         addInSelectorsAndOwnerType(data, "build", "build", $scope.build.Build._id);
       }
-      $scope.subscriptions.push(data);
-      $scope.saveSubscriptions();
+      $scope.saveSubscription(data);
     });
   };
 
-  $scope.saveSubscriptions = function() {
+  $scope.saveSubscription = function(subscription) {
     var success = function() {
       $mdToast.show({
         templateUrl: "/static/partials/subscription_confirmation_toast.html",
@@ -154,7 +152,7 @@ mciModule.controller('BuildViewController', function($scope, $http, $timeout, $r
     var failure = function(resp) {
       notificationService.pushNotification('Error saving subscriptions: ' + resp.data.error, 'notifyHeader');
     };
-    mciSubscriptionsService.post($scope.subscriptions, { success: success, error: failure });
+    mciSubscriptionsService.post([subscription], { success: success, error: failure });
   }
 
   $scope.setBuild = function(build) {

--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -268,7 +268,6 @@ mciModule.controller('TaskHistoryDrawerCtrl', function($scope, $window, $locatio
         $scope.taskHost = $window.taskHost;
         $scope.jiraHost = $window.jiraHost;
         $scope.isAdmin = $window.isAdmin;
-        $scope.subscriptions = [];
 
         $scope.triggers = [
           {
@@ -312,12 +311,11 @@ mciModule.controller('TaskHistoryDrawerCtrl', function($scope, $window, $locatio
 
           $mdDialog.show(promise).then(function(data){
             addSelectorsAndOwnerType(data, "task", $scope.task.id);
-            $scope.subscriptions.push(data);
-            $scope.saveSubscriptions();
+            $scope.saveSubscription(data);
           });
         };
 
-        $scope.saveSubscriptions = function() {
+        $scope.saveSubscription = function(subscription) {
           var success = function() {
             $mdToast.show({
               templateUrl: "/static/partials/subscription_confirmation_toast.html",
@@ -327,7 +325,7 @@ mciModule.controller('TaskHistoryDrawerCtrl', function($scope, $window, $locatio
           var failure = function(resp) {
             notificationService.pushNotification('Error saving subscriptions: ' + resp.data.error, 'errorHeader');
           };
-          mciSubscriptionsService.post($scope.subscriptions, { success: success, error: failure });
+          mciSubscriptionsService.post([subscription], { success: success, error: failure });
         }
 
         $scope.overrideDependencies = function() {

--- a/public/static/js/version.js
+++ b/public/static/js/version.js
@@ -7,7 +7,6 @@ mciModule.controller('VersionController', function($scope, $rootScope, $location
   $scope.tab = 0
   $scope.version = {};
   $scope.taskStatuses = {};
-  $scope.subscriptions = [];
   $scope.triggers = [
     {
       trigger: "outcome",
@@ -104,12 +103,11 @@ mciModule.controller('VersionController', function($scope, $rootScope, $location
       }else {
         addInSelectorsAndOwnerType(data, "version", "version", $scope.version.Version.id);
       }
-      $scope.subscriptions.push(data);
-      $scope.saveSubscriptions();
+      $scope.saveSubscription(data);
     });
   };
 
-  $scope.saveSubscriptions = function() {
+  $scope.saveSubscription = function(subscription) {
     var success = function() {
       $mdToast.show({
         templateUrl: "/static/partials/subscription_confirmation_toast.html",
@@ -119,7 +117,7 @@ mciModule.controller('VersionController', function($scope, $rootScope, $location
     var failure = function(resp) {
       notifier.pushNotification('Error saving subscriptions: ' + resp.data.error, 'notifyHeader');
     };
-    mciSubscriptionsService.post($scope.subscriptions, { success: success, error: failure });
+    mciSubscriptionsService.post([subscription], { success: success, error: failure });
   }
 
   $rootScope.$on("version_updated", function(e, newVersion){


### PR DESCRIPTION
Duplicate subscriptions were being posted if the user created more than one subscription without refreshing the page.
By removing the list and posting one subscription at a time we avoid duplicate subscriptions.