### PR TITLE
EVG-5770 spawn ipv6 host from tasks

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -81,6 +81,7 @@ type CreateHost struct {
 	Distro          string      `mapstructure:"distro" json:"distro" plugin:"expand"`
 	EBSDevices      []EbsDevice `mapstructure:"ebs_block_device" json:"ebs_block_device" plugin:"expand"`
 	InstanceType    string      `mapstructure:"instance_type" json:"instance_type" plugin:"expand"`
+	IPv6            bool        `mapstructure:"ipv6" json:"ipv6"`
 	Region          string      `mapstructure:"region" json:"region" plugin:"expand"`
 	SecurityGroups  []string    `mapstructure:"security_group_ids" json:"security_group_ids" plugin:"expand"`
 	Spot            bool        `mapstructure:"spot" json:"spot"`

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -187,8 +187,7 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 			},
 		}
 		if ec2Settings.IPv6 {
-			input.NetworkInterfaces[0].SetIpv6AddressCount(1)
-			input.NetworkInterfaces[0].SetAssociatePublicIpAddress(false)
+			input.NetworkInterfaces[0].SetIpv6AddressCount(1).SetAssociatePublicIpAddress(false)
 		}
 	} else {
 		input.SecurityGroups = ec2Settings.getSecurityGroups()
@@ -310,8 +309,7 @@ func (m *ec2Manager) spawnSpotHost(ctx context.Context, h *host.Host, ec2Setting
 			},
 		}
 		if ec2Settings.IPv6 {
-			spotRequest.LaunchSpecification.NetworkInterfaces[0].SetIpv6AddressCount(1)
-			spotRequest.LaunchSpecification.NetworkInterfaces[0].SetAssociatePublicIpAddress(false)
+			spotRequest.LaunchSpecification.NetworkInterfaces[0].SetIpv6AddressCount(1).SetAssociatePublicIpAddress(false)
 		}
 	} else {
 		spotRequest.LaunchSpecification.SecurityGroups = ec2Settings.getSecurityGroups()
@@ -930,23 +928,20 @@ func (m *ec2Manager) retrieveInstance(ctx context.Context, h *host.Host) (*ec2.I
 func (m *ec2Manager) GetDNSName(ctx context.Context, h *host.Host) (string, error) {
 	instance, err := m.retrieveInstance(ctx, h)
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err, "error retrieving instance")
 	}
-
 	// set IPv6 address, if applicable
 	for _, networkInterface := range instance.NetworkInterfaces {
 		if len(networkInterface.Ipv6Addresses) > 0 {
 			err = h.SetIPv6Address(*networkInterface.Ipv6Addresses[0].Ipv6Address)
 			if err != nil {
-				return "", err
+				return "", errors.Wrap(err, "error setting ipv6 address")
 			}
 			break
 		}
 	}
 	return *instance.PublicDnsName, nil
 }
-
-
 
 // GetSSHOptions returns the command-line args to pass to SSH.
 func (m *ec2Manager) GetSSHOptions(h *host.Host, keyName string) ([]string, error) {

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -21,6 +21,7 @@ import (
 )
 
 const defaultRegion = "us-east-1"
+const MockIPV6 = "1234::aba:asdf:a211:736"
 
 // AWSClient is a wrapper for aws-sdk-go so we can use a mock in testing.
 type AWSClient interface {
@@ -605,6 +606,8 @@ func (c *awsClientMock) DescribeInstances(ctx context.Context, input *ec2.Descri
 	if c.DescribeInstancesOutput != nil {
 		return c.DescribeInstancesOutput, nil
 	}
+	ipv6 := ec2.InstanceIpv6Address{}
+	ipv6.SetIpv6Address(MockIPV6)
 	return &ec2.DescribeInstancesOutput{
 		Reservations: []*ec2.Reservation{
 			&ec2.Reservation{
@@ -616,6 +619,13 @@ func (c *awsClientMock) DescribeInstances(ctx context.Context, input *ec2.Descri
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
 						PublicDnsName: aws.String("public_dns_name"),
+						NetworkInterfaces: []*ec2.InstanceNetworkInterface{
+							&ec2.InstanceNetworkInterface{
+								Ipv6Addresses: []*ec2.InstanceIpv6Address{
+									&ipv6,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -763,6 +773,15 @@ func (c *awsClientMock) GetInstanceInfo(ctx context.Context, id string) (*ec2.In
 	instance.InstanceType = aws.String("m3.4xlarge")
 	instance.LaunchTime = aws.Time(time.Now())
 	instance.PublicDnsName = aws.String("public_dns_name")
+	ipv6 := ec2.InstanceIpv6Address{}
+	ipv6.SetIpv6Address(MockIPV6)
+	instance.NetworkInterfaces = []*ec2.InstanceNetworkInterface{
+		&ec2.InstanceNetworkInterface{
+			Ipv6Addresses: []*ec2.InstanceIpv6Address{
+				&ipv6,
+			},
+		},
+	}
 	instance.State = &ec2.InstanceState{}
 	instance.State.Name = aws.String("running")
 	return instance, nil

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -21,7 +21,7 @@ import (
 )
 
 const defaultRegion = "us-east-1"
-const MockIPV6 = "1234::aba:asdf:a211:736"
+const MockIPV6 = "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47"
 
 // AWSClient is a wrapper for aws-sdk-go so we can use a mock in testing.
 type AWSClient interface {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -615,9 +615,13 @@ func (s *EC2Suite) TestOnUp() {
 }
 
 func (s *EC2Suite) TestGetDNSName() {
-	dns, err := s.onDemandManager.GetDNSName(context.Background(), &host.Host{Id: "instance_id"})
+	h := host.Host{Id: "instance_id"}
+	h.Insert()
+	dns, err := s.onDemandManager.GetDNSName(context.Background(), &h)
 	s.Equal("public_dns_name", dns)
 	s.NoError(err)
+
+	s.Equal(h.IPv6, MockIPV6)
 }
 
 func (s *EC2Suite) TestGetSSHOptionsEmptyKey() {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -616,12 +616,12 @@ func (s *EC2Suite) TestOnUp() {
 
 func (s *EC2Suite) TestGetDNSName() {
 	h := host.Host{Id: "instance_id"}
-	h.Insert()
+	s.Require().NoError(h.Insert())
 	dns, err := s.onDemandManager.GetDNSName(context.Background(), &h)
 	s.Equal("public_dns_name", dns)
 	s.NoError(err)
 
-	s.Equal(h.IPv6, MockIPV6)
+	s.Equal(h.IP, MockIPV6)
 }
 
 func (s *EC2Suite) TestGetSSHOptionsEmptyKey() {
@@ -712,6 +712,7 @@ func (s *EC2Suite) TestGetProvider() {
 
 func (s *EC2Suite) TestPersistInstanceId() {
 	h := &host.Host{Id: "instance_id"}
+	s.Require().NoError(h.Insert())
 	_, err := s.onDemandManager.GetDNSName(context.Background(), h)
 	s.NoError(err)
 	s.Equal("instance_id", h.ExternalIdentifier)

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -30,7 +30,7 @@ var (
 	TagKey                       = bsonutil.MustHaveTag(Host{}, "Tag")
 	DistroKey                    = bsonutil.MustHaveTag(Host{}, "Distro")
 	ProviderKey                  = bsonutil.MustHaveTag(Host{}, "Provider")
-	IPv6Key                      = bsonutil.MustHaveTag(Host{}, "IPv6")
+	IPKey                        = bsonutil.MustHaveTag(Host{}, "IP")
 	ProvisionedKey               = bsonutil.MustHaveTag(Host{}, "Provisioned")
 	ProvisionTimeKey             = bsonutil.MustHaveTag(Host{}, "ProvisionTime")
 	ExtIdKey                     = bsonutil.MustHaveTag(Host{}, "ExternalIdentifier")

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -30,6 +30,7 @@ var (
 	TagKey                       = bsonutil.MustHaveTag(Host{}, "Tag")
 	DistroKey                    = bsonutil.MustHaveTag(Host{}, "Distro")
 	ProviderKey                  = bsonutil.MustHaveTag(Host{}, "Provider")
+	IPv6Key                      = bsonutil.MustHaveTag(Host{}, "IPv6")
 	ProvisionedKey               = bsonutil.MustHaveTag(Host{}, "Provisioned")
 	ProvisionTimeKey             = bsonutil.MustHaveTag(Host{}, "ProvisionTime")
 	ExtIdKey                     = bsonutil.MustHaveTag(Host{}, "ExternalIdentifier")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -26,7 +26,7 @@ type Host struct {
 	Tag      string        `bson:"tag" json:"tag"`
 	Distro   distro.Distro `bson:"distro" json:"distro"`
 	Provider string        `bson:"host_type" json:"host_type"`
-	IPv6	 string		   `bson:"ipv6_address" json:"ipv6_address"`
+	IP       string        `bson:"ip_address" json:"ip_address"`
 
 	// secondary (external) identifier for the host
 	ExternalIdentifier string `bson:"ext_identifier" json:"ext_identifier"`
@@ -345,22 +345,22 @@ func (h *Host) SetDNSName(dnsName string) error {
 func (h *Host) SetIPv6Address(ipv6Address string) error {
 	err := UpdateOne(
 		bson.M{
-			IdKey:  h.Id,
-			IPv6Key: "",
+			IdKey: h.Id,
+			IPKey: "",
 		},
 		bson.M{
 			"$set": bson.M{
-				IPv6Key: ipv6Address,
+				IPKey: ipv6Address,
 			},
 		},
 	)
-	if err == nil {
-		h.IPv6 = ipv6Address
+
+	if err != nil {
+		return errors.Wrap(err, "error finding instance")
 	}
-	if err == mgo.ErrNotFound {
-		return nil
-	}
-	return err
+
+	h.IP = ipv6Address
+	return nil
 }
 
 func (h *Host) MarkAsProvisioned() error {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -26,6 +26,7 @@ type Host struct {
 	Tag      string        `bson:"tag" json:"tag"`
 	Distro   distro.Distro `bson:"distro" json:"distro"`
 	Provider string        `bson:"host_type" json:"host_type"`
+	IPv6	 string		   `bson:"ipv6_address" json:"ipv6_address"`
 
 	// secondary (external) identifier for the host
 	ExternalIdentifier string `bson:"ext_identifier" json:"ext_identifier"`
@@ -73,7 +74,7 @@ type Host struct {
 
 	Status    string `bson:"status" json:"status"`
 	StartedBy string `bson:"started_by" json:"started_by"`
-	// UserHost is alwayas false, and will be removed
+	// UserHost is always false, and will be removed
 	UserHost      bool   `bson:"user_host" json:"user_host"`
 	AgentRevision string `bson:"agent_revision" json:"agent_revision"`
 	NeedsNewAgent bool   `bson:"needs_agent" json:"needs_agent"`
@@ -334,6 +335,27 @@ func (h *Host) SetDNSName(dnsName string) error {
 	if err == nil {
 		h.Host = dnsName
 		event.LogHostDNSNameSet(h.Id, dnsName)
+	}
+	if err == mgo.ErrNotFound {
+		return nil
+	}
+	return err
+}
+
+func (h *Host) SetIPv6Address(ipv6Address string) error {
+	err := UpdateOne(
+		bson.M{
+			IdKey:  h.Id,
+			IPv6Key: "",
+		},
+		bson.M{
+			"$set": bson.M{
+				IPv6Key: ipv6Address,
+			},
+		},
+	)
+	if err == nil {
+		h.IPv6 = ipv6Address
 	}
 	if err == mgo.ErrNotFound {
 		return nil

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -325,40 +325,30 @@ func TestHostSetDNSName(t *testing.T) {
 }
 
 func TestHostSetIPv6Address(t *testing.T) {
-	var err error
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(Collection))
 
-	Convey("With a host", t, func() {
+	host := &Host{
+		Id: "hostOne",
+	}
+	assert.NoError(host.Insert())
 
-		testutil.HandleTestingErr(db.Clear(Collection), t, "Error"+
-			" clearing '%v' collection", Collection)
+	ipv6Address := "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47"
+	ipv6Address2 := "aaaa:1f18:459c:2d00:cfe4:843b:1d60:9999"
 
-		host := &Host{
-			Id: "hostOne",
-		}
+	assert.NoError(host.SetIPv6Address(ipv6Address))
+	assert.Equal(host.IP, ipv6Address)
+	host, err := FindOne(ById(host.Id))
+	assert.NoError(err)
+	assert.Equal(host.IP, ipv6Address)
 
-		So(host.Insert(), ShouldBeNil)
-		ipv6Address :=  "1234::aba:asdf:a211:736"
-		ipv6Address2 := "5678::bcb:asdf:a211:736"
+	// if the host is already updated, no new updates should work
+	assert.Error(host.SetIPv6Address(ipv6Address2))
+	assert.Equal(host.IP, ipv6Address)
 
-		Convey("setting the ipv6 address should update both the in-memory and"+
-			" database copies of the host", func() {
-
-			So(host.SetIPv6Address(ipv6Address), ShouldBeNil)
-			So(host.IPv6, ShouldEqual, ipv6Address)
-			host, err = FindOne(ById(host.Id))
-			So(err, ShouldBeNil)
-			So(host.IPv6, ShouldEqual, ipv6Address)
-
-			// if the host is already updated, no new updates should work
-			So(host.SetDNSName(ipv6Address2), ShouldBeNil)
-			So(host.IPv6, ShouldEqual, ipv6Address)
-
-			host, err = FindOne(ById(host.Id))
-			So(err, ShouldBeNil)
-			So(host.IPv6, ShouldEqual, ipv6Address)
-
-		})
-	})
+	host, err = FindOne(ById(host.Id))
+	assert.NoError(err)
+	assert.Equal(host.IP, ipv6Address)
 }
 
 func TestMarkAsProvisioned(t *testing.T) {

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -324,6 +324,43 @@ func TestHostSetDNSName(t *testing.T) {
 	})
 }
 
+func TestHostSetIPv6Address(t *testing.T) {
+	var err error
+
+	Convey("With a host", t, func() {
+
+		testutil.HandleTestingErr(db.Clear(Collection), t, "Error"+
+			" clearing '%v' collection", Collection)
+
+		host := &Host{
+			Id: "hostOne",
+		}
+
+		So(host.Insert(), ShouldBeNil)
+		ipv6Address :=  "1234::aba:asdf:a211:736"
+		ipv6Address2 := "5678::bcb:asdf:a211:736"
+
+		Convey("setting the ipv6 address should update both the in-memory and"+
+			" database copies of the host", func() {
+
+			So(host.SetIPv6Address(ipv6Address), ShouldBeNil)
+			So(host.IPv6, ShouldEqual, ipv6Address)
+			host, err = FindOne(ById(host.Id))
+			So(err, ShouldBeNil)
+			So(host.IPv6, ShouldEqual, ipv6Address)
+
+			// if the host is already updated, no new updates should work
+			So(host.SetDNSName(ipv6Address2), ShouldBeNil)
+			So(host.IPv6, ShouldEqual, ipv6Address)
+
+			host, err = FindOne(ById(host.Id))
+			So(err, ShouldBeNil)
+			So(host.IPv6, ShouldEqual, ipv6Address)
+
+		})
+	})
+}
+
 func TestMarkAsProvisioned(t *testing.T) {
 
 	Convey("With a host", t, func() {

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -212,6 +212,7 @@ func (dc *DBCreateHostConnector) MakeIntentHost(taskID, userID, publicKey string
 	if createHost.UserdataCommand != "" {
 		ec2Settings.UserData = createHost.UserdataCommand
 	}
+	ec2Settings.IPv6 = createHost.IPv6
 	ec2Settings.IsVpc = true // task-spawned hosts do not support ec2 classic
 	if err := mapstructure.Decode(ec2Settings, &d.ProviderSettings); err != nil {
 		return nil, errors.Wrap(err, "error marshaling provider settings")

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -25,6 +25,7 @@ func TestListHostsForTask(t *testing.T) {
 		{
 			Id:     "1",
 			Host:   "1.com",
+			IPv6: "1234::aba:asdf:a211:736",
 			Status: evergreen.HostRunning,
 			SpawnOptions: host.SpawnOptions{
 				TaskID: "task_1",
@@ -77,6 +78,7 @@ func TestListHostsForTask(t *testing.T) {
 	assert.Len(found, 2)
 	assert.Equal("4.com", found[0].Host)
 	assert.Equal("1.com", found[1].Host)
+	assert.Equal("1234::aba:asdf:a211:736", found[1].IPv6)
 }
 
 func TestCreateHostsFromTask(t *testing.T) {

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -25,7 +25,7 @@ func TestListHostsForTask(t *testing.T) {
 		{
 			Id:     "1",
 			Host:   "1.com",
-			IPv6: "1234::aba:asdf:a211:736",
+			IP: "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47",
 			Status: evergreen.HostRunning,
 			SpawnOptions: host.SpawnOptions{
 				TaskID: "task_1",
@@ -78,7 +78,7 @@ func TestListHostsForTask(t *testing.T) {
 	assert.Len(found, 2)
 	assert.Equal("4.com", found[0].Host)
 	assert.Equal("1.com", found[1].Host)
-	assert.Equal("1234::aba:asdf:a211:736", found[1].IPv6)
+	assert.Equal("abcd:1234:459c:2d00:cfe4:843b:1d60:8e47", found[1].IP)
 }
 
 func TestCreateHostsFromTask(t *testing.T) {

--- a/rest/model/createhost.go
+++ b/rest/model/createhost.go
@@ -7,7 +7,7 @@ import (
 
 type CreateHost struct {
 	DNSName    string `json:"dns_name"`
-	IPv6	   string `json:"ipv6_address"`
+	IP         string `json:"ip_address"`
 	InstanceID string `json:"instance_id"`
 }
 
@@ -16,12 +16,12 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 	case host.Host:
 		createHost.DNSName = v.Host
 		createHost.InstanceID = v.Id
-		createHost.IPv6 = v.IPv6
+		createHost.IP = v.IP
 		createHost.InstanceID = v.ExternalIdentifier
 	case *host.Host:
 		createHost.DNSName = v.Host
 		createHost.InstanceID = v.Id
-		createHost.IPv6 = v.IPv6
+		createHost.IP = v.IP
 		createHost.InstanceID = v.ExternalIdentifier
 	default:
 		return errors.Errorf("Invalid type passed to *CreateHost.BuildFromService (%T)", h)

--- a/rest/model/createhost.go
+++ b/rest/model/createhost.go
@@ -7,6 +7,7 @@ import (
 
 type CreateHost struct {
 	DNSName    string `json:"dns_name"`
+	IPv6	   string `json:"ipv6_address"`
 	InstanceID string `json:"instance_id"`
 }
 
@@ -15,15 +16,13 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 	case host.Host:
 		createHost.DNSName = v.Host
 		createHost.InstanceID = v.Id
-		if v.ExternalIdentifier != "" {
-			createHost.InstanceID = v.ExternalIdentifier
-		}
+		createHost.IPv6 = v.IPv6
+		createHost.InstanceID = v.ExternalIdentifier
 	case *host.Host:
 		createHost.DNSName = v.Host
 		createHost.InstanceID = v.Id
-		if v.ExternalIdentifier != "" {
-			createHost.InstanceID = v.ExternalIdentifier
-		}
+		createHost.IPv6 = v.IPv6
+		createHost.InstanceID = v.ExternalIdentifier
 	default:
 		return errors.Errorf("Invalid type passed to *CreateHost.BuildFromService (%T)", h)
 	}

--- a/rest/model/createhost_test.go
+++ b/rest/model/createhost_test.go
@@ -12,10 +12,12 @@ func TestCreateHostBuildFromService(t *testing.T) {
 	h := host.Host{
 		Host:               "foo.com",
 		ExternalIdentifier: "sir-123",
+		IPv6:               "1234::aba:asdf:a211:736",
 	}
 	c := &CreateHost{}
 	err := c.BuildFromService(h)
 	assert.NoError(err)
 	assert.Equal(c.DNSName, h.Host)
 	assert.Equal(c.InstanceID, h.ExternalIdentifier)
+	assert.Equal(c.IPv6, h.IPv6)
 }

--- a/rest/model/createhost_test.go
+++ b/rest/model/createhost_test.go
@@ -12,12 +12,12 @@ func TestCreateHostBuildFromService(t *testing.T) {
 	h := host.Host{
 		Host:               "foo.com",
 		ExternalIdentifier: "sir-123",
-		IPv6:               "1234::aba:asdf:a211:736",
+		IP:                 "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47",
 	}
 	c := &CreateHost{}
 	err := c.BuildFromService(h)
 	assert.NoError(err)
 	assert.Equal(c.DNSName, h.Host)
 	assert.Equal(c.InstanceID, h.ExternalIdentifier)
-	assert.Equal(c.IPv6, h.IPv6)
+	assert.Equal(c.IP, h.IP)
 }

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -185,7 +185,11 @@ func (j *setupHostJob) setDNSName(ctx context.Context, host *host.Host, cloudMgr
 
 	// sanity check for the host DNS name
 	if hostDNS == "" {
-		return errors.Errorf("instance %s is running but not returning a DNS name", host.Id)
+		// DNS name not required if IP address set
+		if host.IP != "" {
+			return nil
+		}
+		return errors.Errorf("instance %s is running but not returning a DNS name or IP address", host.Id)
 	}
 
 	// update the host's DNS name


### PR DESCRIPTION
This is a preliminary code review, assuming that setting the NetworkInterface to creating an IPv6 address will be enough. We don't yet know if there will still be a public DNS name when the NetworkInterface object specifies AssociatePublicIpAddress as false.