### PR TITLE
EVG-5757 (fix) Task Timing - use bv tasks insetad of prj tasks

### DIFF
--- a/public/static/js/task_timing.test.js
+++ b/public/static/js/task_timing.test.js
@@ -5,7 +5,7 @@ describe('TaskTimingControllerTest', function() {
 
   const $window = {
     activeProject: {
-      task_names: ['T_A', 'T_C', 'T_D'],
+      task_names: ['T_C', 'T_D', 'T_NonExistent'],
       build_variants: [{
         name: 'BV_A',
         task_names: ['T_A', 'T_C'],
@@ -19,12 +19,14 @@ describe('TaskTimingControllerTest', function() {
         display_tasks: [],
       }, {
         name: 'BV_C',
+        task_names: ['T_X'],
         display_tasks: [{
           name: 'T_X',
           execution_tasks: ['T_C']
         }]
       }, {
         name: 'BV_D',
+        task_names: ['T_X'],
         display_tasks: [{
           name: 'T_X',
           execution_tasks: ['T_C']


### PR DESCRIPTION
It seem that project tasks set is not equal to all bv tasks set (Probably, bug in the model or some sort of a 'feature')