### PR TITLE
EVG-5658 (feat) Signal Processing - persistent filtering settings

### DIFF
--- a/public/static/app/common/Settings.test.js
+++ b/public/static/app/common/Settings.test.js
@@ -14,13 +14,14 @@ describe('SettingsTest', function() {
     }, [])
 
     tree.param = value
-    expect(tree.param).toBe(value)
+    expect(tree.param).toEqual(value)
   }
 
   it('can store different param types', function() {
     typeCheck(Number, 1)
     typeCheck(Boolean, true)
     typeCheck(String, 'a')
+    typeCheck(Object, {data: 'value'})
     typeCheck(undefined, 'a')
   })
 
@@ -32,6 +33,17 @@ describe('SettingsTest', function() {
     expect(tree.param).toBe('Default')
     // Ensure the value was set to localStorage
     expect(localStorage.getItem('param')).toBe('Default')
+  })
+
+  it('respect and restores deault value for Object type', function() {
+    var tree = Settings._buildSettingsTree({
+      param: {
+        type: Object,
+        default: {initial: 'value'},
+      }
+    }, [])
+
+    expect(tree.param).toEqual({initial: 'value'})
   })
 
   it('actually uses localStorage', function() {
@@ -48,6 +60,7 @@ describe('SettingsTest', function() {
 
   it('ensures all settings are known', function() {
     var knownSettings = [
+      'perf.signalProcessing.persistentFiltering',
       'perf.trendchart.originMode.enabled',
       'perf.trendchart.linearMode.enabled',
       'perf.trendchart.threadLevelMode',

--- a/public/static/app/common/constants.js
+++ b/public/static/app/common/constants.js
@@ -9,6 +9,13 @@ mciModule
   .constant('SETTING_DEFS', {
     GLOBAL_PREFIX: 'mciSetting',
     perf: {
+      signalProcessing: {
+        persistentFiltering: {
+          type: Object,
+          default: {}, // actually, we could store defaults here
+                       // but there are some compute-time params
+        },
+      },
       trendchart: {
         linearMode: {
           enabled: {


### PR DESCRIPTION
* Persistent filtering settings for Signal Processing page (plugin -> performance baron)
* `Settings` service accepts `Object` type