### PR TITLE
EVG-5813: Add SHA check to merge options

### DIFF
--- a/model/commitqueue/github_pr_sender.go
+++ b/model/commitqueue/github_pr_sender.go
@@ -84,6 +84,7 @@ func (s *githubPRLogger) Send(m message.Composer) {
 	mergeOpts := &github.PullRequestOptions{
 		MergeMethod: msg.MergeMethod,
 		CommitTitle: msg.CommitTitle,
+		SHA:         msg.Ref,
 	}
 
 	// do the merge


### PR DESCRIPTION
Stop the merge from going through if HEAD of the PR is not the commit we tested.

This could happen if a user pushes a commit to a PR after we've already created a patch to test the commit queue item but before we go to merge.