### PR TITLE
EVG-5812: Remove items from queue that would block

### DIFF
--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -111,6 +111,15 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 	nextItemInt, err := strconv.Atoi(nextItem)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "can't parse next item \"%s\" as int", nextItem))
+		_, err2 := cq.Remove(nextItem)
+		j.AddError(errors.Wrapf(err2, "error dequeuing item '%s'", nextItem))
+		grip.Error(message.WrapError(err, message.Fields{
+			"job":     commitQueueJobName,
+			"source":  "commit queue",
+			"project": j.QueueID,
+			"item":    nextItem,
+			"message": "next item can't be parsed as an int",
+		}))
 		return
 	}
 
@@ -124,11 +133,27 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 	pr, err := thirdparty.GetGithubPullRequest(ctx, githubToken, projectRef.Owner, projectRef.Repo, nextItemInt)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "can't get PR from GitHub"))
+		grip.Error(message.WrapError(err, message.Fields{
+			"job":     commitQueueJobName,
+			"source":  "commit queue",
+			"project": j.QueueID,
+			"item":    nextItem,
+			"message": "can't get PR from GitHub",
+		}))
 		return
 	}
 
 	if err = validatePR(pr); err != nil {
 		j.AddError(errors.Wrap(err, "invalid PR"))
+		_, err2 := cq.Remove(nextItem)
+		j.AddError(errors.Wrapf(err2, "error dequeuing item '%s'", nextItem))
+		grip.Error(message.WrapError(err, message.Fields{
+			"job":     commitQueueJobName,
+			"source":  "commit queue",
+			"project": j.QueueID,
+			"item":    nextItem,
+			"message": "invalid PR",
+		})
 		return
 	}
 
@@ -161,6 +186,16 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 	v, err := makeVersion(ctx, githubToken, projectRef.Identifier, pr)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "can't make version"))
+		j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't make version", ""))
+		_, err2 := cq.Remove(nextItem)
+		j.AddError(errors.Wrapf(err2, "error dequeuing item '%s'", nextItem))
+		grip.Error(message.WrapError(err, message.Fields{
+			"job":     commitQueueJobName,
+			"source":  "commit queue",
+			"project": j.QueueID,
+			"item":    nextItem,
+			"message": "can't make version",
+		})
 		return
 	}
 
@@ -172,6 +207,14 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 	err = subscribeMerge(projectRef, pr, v.Id)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "can't subscribe GitHub PR merge to version"))
+		j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't start merge", ""))
+		grip.Error(message.WrapError(err, message.Fields{
+			"job":     commitQueueJobName,
+			"source":  "commit queue",
+			"project": j.QueueID,
+			"item":    nextItem,
+			"message": "can't subscribe for merge sender",
+		})
 	}
 
 	grip.Info(message.Fields{

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -153,7 +153,7 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 			"project": j.QueueID,
 			"item":    nextItem,
 			"message": "invalid PR",
-		})
+		}))
 		return
 	}
 
@@ -195,7 +195,7 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 			"project": j.QueueID,
 			"item":    nextItem,
 			"message": "can't make version",
-		})
+		}))
 		return
 	}
 
@@ -214,7 +214,7 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 			"project": j.QueueID,
 			"item":    nextItem,
 			"message": "can't subscribe for merge sender",
-		})
+		}))
 	}
 
 	grip.Info(message.Fields{


### PR DESCRIPTION
Brian talked me out of making a timeout to remove stuck items from the queue in favor of more aggressive error handling to keep them from getting stuck in the first place.

The rule I followed here was that if an error is likely to be a problem for everything on the queue (e.g. we aren't getting a response back from GitHub when we ask for more information about a PR) then we log the error and let the queue block (instead of emptying the queue) whereas if the problem is likely specifically for this item (e.g. the item can't be parsed as an int) then we log the error and remove it from the queue.