### PR TITLE
EVG-5821 fetch project vars earlier in agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -46,6 +46,7 @@ type Options struct {
 type taskContext struct {
 	currentCommand command.Command
 	expansions     util.Expansions
+	expVars        *apimodels.ExpansionVars
 	logger         client.LoggerProducer
 	logs           *apimodels.TaskLogs
 	statsCollector *StatsCollector
@@ -247,10 +248,16 @@ func (a *Agent) fetchProjectConfig(ctx context.Context, tc *taskContext) error {
 	if err != nil {
 		return errors.Wrap(err, "error getting expansions")
 	}
+	expVars, err := a.comm.FetchExpansionVars(ctx, tc.task)
+	if err != nil {
+		return errors.Wrap(err, "error getting project vars")
+	}
+	exp.Update(expVars.Vars)
 	tc.version = v
 	tc.taskModel = taskModel
 	tc.project = project
 	tc.expansions = exp
+	tc.expVars = expVars
 	return nil
 }
 


### PR DESCRIPTION
I had wanted to refactor the part of the agent that fetches the task config since I felt this change adds too much code duplication, but that refactor breaks many tests due to how the tests are setting up mock data and it was really nasty trying to untangle that. Let me know if you'd like me to revisit that