### PR TITLE
EVG-5844 Never exit with a task group task

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -474,9 +474,7 @@ func (s *AgentSuite) TestPrepareNextTask() {
 		},
 	}
 	tc.taskDirectory = "task_directory"
-	var exit bool
-	tc, exit = s.a.prepareNextTask(context.Background(), nextTask, tc)
-	s.False(exit)
+	tc = s.a.prepareNextTask(context.Background(), nextTask, tc)
 	s.True(tc.runGroupSetup, "if the next task is not in a group, runGroupSetup should be true")
 	s.Equal("", tc.taskGroup)
 	s.Empty(tc.taskDirectory)
@@ -491,17 +489,10 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	}
 	tc.logger = s.a.comm.GetLoggerProducer(context.Background(), s.tc.task, nil)
 	tc.taskDirectory = "task_directory"
-	tc, exit = s.a.prepareNextTask(context.Background(), nextTask, tc)
-	s.False(exit)
+	tc = s.a.prepareNextTask(context.Background(), nextTask, tc)
 	s.False(tc.runGroupSetup, "if the next task is in the same group as the previous task, runGroupSetup should be false")
 	s.Equal("foo", tc.taskGroup)
 	s.Equal("task_directory", tc.taskDirectory)
-
-	nextTask.NewAgent = true
-	tc, exit = s.a.prepareNextTask(context.Background(), nextTask, tc)
-	s.True(exit, "if NewAgent is true and we're in a task group, exit should be true")
-	s.Equal(&taskContext{}, tc, "if NewAgent is true and we're in a task group, the task context should be empty")
-	nextTask.NewAgent = false // reset NewAgent
 
 	nextTask.TaskGroup = "foo"
 	tc.taskGroup = "foo"
@@ -513,8 +504,7 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	}
 	tc.logger = s.a.comm.GetLoggerProducer(context.Background(), s.tc.task, nil)
 	tc.taskDirectory = "task_directory"
-	tc, exit = s.a.prepareNextTask(context.Background(), nextTask, tc)
-	s.False(exit)
+	tc = s.a.prepareNextTask(context.Background(), nextTask, tc)
 	s.True(tc.runGroupSetup, "if the next task is a different group from the previous task, runGroupSetup should be true")
 	s.Equal("foo", tc.taskGroup)
 	s.Empty(tc.taskDirectory)
@@ -528,8 +518,7 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	nextTask.TaskGroup = "bar"
 	tc.taskGroup = "foo"
 	tc.taskDirectory = "task_directory"
-	tc, exit = s.a.prepareNextTask(context.Background(), nextTask, tc)
-	s.False(exit)
+	tc = s.a.prepareNextTask(context.Background(), nextTask, tc)
 	s.True(tc.runGroupSetup, "if the next task is in a different group from the previous task, runGroupSetup should be true")
 	s.Equal("bar", tc.taskGroup)
 	s.Empty(tc.taskDirectory)
@@ -546,8 +535,7 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	nextTask.Build = "build_id_2"
 	tc.taskGroup = "bar"
 	tc.taskDirectory = "task_directory"
-	tc, exit = s.a.prepareNextTask(context.Background(), nextTask, tc)
-	s.False(exit)
+	tc = s.a.prepareNextTask(context.Background(), nextTask, tc)
 	s.True(tc.runGroupSetup, "if the next task in the same version but a different build, runSetupGroup should be true")
 	s.Equal("bar", tc.taskGroup)
 	s.Empty(tc.taskDirectory)

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -71,15 +71,7 @@ type NextTaskResponse struct {
 	TaskGroup  string `json:"task_group,omitempty"`
 	Version    string `json:"version,omitempty"`
 	Build      string `json:"build,omitempty"`
-	// ShouldExit indicates that something has gone wrong, so the agent
-	// should exit immediately when it receives this message. ShouldExit can
-	// interrupt a task group.
-	ShouldExit bool `json:"should_exit,omitempty"`
-	// NewAgent indicates a new agent available, so the agent should exit
-	// gracefully. Practically speaking, this means that if the agent is
-	// currently in a task group, it should only exit when it has finished
-	// the task group.
-	NewAgent bool `json:"new_agent,omitempty"`
+	ShouldExit bool   `json:"should_exit,omitempty"`
 }
 
 // EndTaskResponse is what is returned when the task ends

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -392,7 +392,7 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 	var response apimodels.NextTaskResponse
 	var err error
 	if checkHostHealth(h) {
-		if err := h.SetNeedsNewAgent(true); err != nil {
+		if err = h.SetNeedsNewAgent(true); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"host":      h.Id,
 				"operation": "next_task",

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -108,8 +108,8 @@ func checkHostHealth(h *host.Host) bool {
 	return false
 }
 
-// checkAgentRevision checks that the agent revision is current.
-func checkAgentRevision(h *host.Host) bool {
+// agentRevisionIsOld checks that the agent revision is current.
+func agentRevisionIsOld(h *host.Host) bool {
 	if h.AgentRevision != evergreen.BuildRevision {
 		grip.Info(message.Fields{
 			"message":        "agent has wrong revision, so it should exit",
@@ -389,7 +389,8 @@ func assignNextAvailableTask(taskQueue *model.TaskQueue, currentHost *host.Host)
 // and popping the next task off the task queue.
 func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 	h := MustHaveHost(r)
-	response := apimodels.NextTaskResponse{}
+	var response apimodels.NextTaskResponse
+	var err error
 	if checkHostHealth(h) {
 		if err := h.SetNeedsNewAgent(true); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
@@ -406,59 +407,10 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 		gimlet.WriteJSON(w, response)
 		return
 	}
-	if checkAgentRevision(h) {
-		details := &apimodels.GetNextTaskDetails{}
-		if err := util.ReadJSONInto(util.NewRequestReader(r), details); err != nil {
-			if innerErr := h.SetNeedsNewAgent(true); innerErr != nil {
-				grip.Error(message.WrapError(innerErr, message.Fields{
-					"host":      h.Id,
-					"operation": "next_task",
-					"message":   "problem indicating that host needs new agent",
-					"source":    "database error",
-					"revision":  evergreen.BuildRevision,
-				}))
-				gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(innerErr))
-				return
-			}
-			grip.Info(message.WrapError(err, message.Fields{
-				"host":          h.Id,
-				"operation":     "next_task",
-				"message":       "unable to unmarshal next task details, so updating agent",
-				"host_revision": h.AgentRevision,
-				"revision":      evergreen.BuildRevision,
-			}))
-			response.ShouldExit = true
-			gimlet.WriteJSON(w, response)
-			return
-		}
-		if details.TaskGroup == "" {
-			if err := h.SetNeedsNewAgent(true); err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"host":      h.Id,
-					"operation": "next_task",
-					"message":   "problem indicating that host needs new agent",
-					"source":    "database error",
-					"revision":  evergreen.BuildRevision,
-				}))
-				gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
-				return
-			}
-			if err := h.ClearRunningTask(); err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"host":      h.Id,
-					"operation": "next_task",
-					"message":   "problem unsetting running task",
-					"source":    "database error",
-					"revision":  evergreen.BuildRevision,
-				}))
-				gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
-				return
-			}
-			response.ShouldExit = true
-			gimlet.WriteJSON(w, response)
-			return
-		}
-		response.NewAgent = true
+	var agentExit bool
+	response, agentExit = handleOldAgentRevision(response, h, w, r)
+	if agentExit {
+		return
 	}
 
 	flags, err := evergreen.GetServiceFlags()
@@ -475,47 +427,7 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 
 	// if there is already a task assigned to the host send back that task
 	if h.RunningTask != "" {
-		var t *task.Task
-		t, err = task.FindOne(task.ById(h.RunningTask))
-		if err != nil {
-			err = errors.Wrapf(err, "error getting running task %s", h.RunningTask)
-			grip.Error(err)
-			gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
-			return
-		}
-
-		// if the task can be dispatched and activated dispatch it
-		if t.IsDispatchable() {
-			err = errors.WithStack(model.MarkTaskDispatched(t, h.Id, h.Distro.Id))
-			if err != nil {
-				grip.Error(errors.Wrapf(err, "error while marking task %s as dispatched for host %s", t.Id, h.Id))
-				gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
-				return
-			}
-		}
-		// if the task is activated return that task
-		if t.Activated {
-			setNextTask(t, &response)
-			gimlet.WriteJSON(w, response)
-			return
-		}
-		// the task is not activated so the host's running task should be unset
-		// so it can retrieve a new task.
-		if err = h.ClearRunningTask(); err != nil {
-			err = errors.WithStack(err)
-			grip.Error(err)
-			gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
-			return
-		}
-
-		// return an empty
-		grip.Info(message.Fields{
-			"op":      "next_task",
-			"message": "unset running task field for inactive task on host",
-			"host_id": h.Id,
-			"task_id": t.Id,
-		})
-		gimlet.WriteJSON(w, response)
+		sendBackRunningTask(h, response, w)
 		return
 	}
 
@@ -572,6 +484,110 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 		"host_id": h.Id,
 	})
 	gimlet.WriteJSON(w, response)
+}
+
+func handleOldAgentRevision(response apimodels.NextTaskResponse, h *host.Host, w http.ResponseWriter, r *http.Request) (apimodels.NextTaskResponse, bool) {
+	if agentRevisionIsOld(h) {
+		details := &apimodels.GetNextTaskDetails{}
+		if err := util.ReadJSONInto(util.NewRequestReader(r), details); err != nil {
+			if innerErr := h.SetNeedsNewAgent(true); innerErr != nil {
+				grip.Error(message.WrapError(innerErr, message.Fields{
+					"host":      h.Id,
+					"operation": "next_task",
+					"message":   "problem indicating that host needs new agent",
+					"source":    "database error",
+					"revision":  evergreen.BuildRevision,
+				}))
+				gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(innerErr))
+				return apimodels.NextTaskResponse{}, true
+			}
+			grip.Info(message.WrapError(err, message.Fields{
+				"host":          h.Id,
+				"operation":     "next_task",
+				"message":       "unable to unmarshal next task details, so updating agent",
+				"host_revision": h.AgentRevision,
+				"revision":      evergreen.BuildRevision,
+			}))
+			response.ShouldExit = true
+			gimlet.WriteJSON(w, response)
+			return apimodels.NextTaskResponse{}, true
+		}
+		if details.TaskGroup == "" {
+			if err := h.SetNeedsNewAgent(true); err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"host":      h.Id,
+					"operation": "next_task",
+					"message":   "problem indicating that host needs new agent",
+					"source":    "database error",
+					"revision":  evergreen.BuildRevision,
+				}))
+				gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
+				return apimodels.NextTaskResponse{}, true
+
+			}
+			if err := h.ClearRunningTask(); err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"host":      h.Id,
+					"operation": "next_task",
+					"message":   "problem unsetting running task",
+					"source":    "database error",
+					"revision":  evergreen.BuildRevision,
+				}))
+				gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
+				return apimodels.NextTaskResponse{}, true
+			}
+			response.ShouldExit = true
+			gimlet.WriteJSON(w, response)
+			return apimodels.NextTaskResponse{}, true
+		}
+	}
+	return response, false
+}
+
+func sendBackRunningTask(h *host.Host, response apimodels.NextTaskResponse, w http.ResponseWriter) {
+	var err error
+	var t *task.Task
+	t, err = task.FindOne(task.ById(h.RunningTask))
+	if err != nil {
+		err = errors.Wrapf(err, "error getting running task %s", h.RunningTask)
+		grip.Error(err)
+		gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
+		return
+	}
+
+	// if the task can be dispatched and activated dispatch it
+	if t.IsDispatchable() {
+		err = errors.WithStack(model.MarkTaskDispatched(t, h.Id, h.Distro.Id))
+		if err != nil {
+			grip.Error(errors.Wrapf(err, "error while marking task %s as dispatched for host %s", t.Id, h.Id))
+			gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
+			return
+		}
+	}
+	// if the task is activated return that task
+	if t.Activated {
+		setNextTask(t, &response)
+		gimlet.WriteJSON(w, response)
+		return
+	}
+	// the task is not activated so the host's running task should be unset
+	// so it can retrieve a new task.
+	if err = h.ClearRunningTask(); err != nil {
+		err = errors.WithStack(err)
+		grip.Error(err)
+		gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
+		return
+	}
+
+	// return an empty
+	grip.Info(message.Fields{
+		"op":      "next_task",
+		"message": "unset running task field for inactive task on host",
+		"host_id": h.Id,
+		"task_id": t.Id,
+	})
+	gimlet.WriteJSON(w, response)
+	return
 }
 
 func setNextTask(t *task.Task, response *apimodels.NextTaskResponse) {

--- a/service/api_task_test.go
+++ b/service/api_task_test.go
@@ -550,7 +550,7 @@ func TestCheckHostHealth(t *testing.T) {
 		shouldExit = checkHostHealth(h)
 		So(shouldExit, ShouldBeTrue)
 		Convey("With a host that is running but has a different revision", func() {
-			shouldExit := checkAgentRevision(h)
+			shouldExit := agentRevisionIsOld(h)
 			So(shouldExit, ShouldBeTrue)
 		})
 	})

--- a/service/api_task_test.go
+++ b/service/api_task_test.go
@@ -391,7 +391,6 @@ func TestNextTask(t *testing.T) {
 				So(resp.Code, ShouldEqual, http.StatusOK)
 				So(json.NewDecoder(resp.Body).Decode(details), ShouldBeNil)
 				So(details.ShouldExit, ShouldEqual, true)
-				So(details.NewAgent, ShouldEqual, false)
 				So(sampleHost.SetAgentRevision(evergreen.BuildRevision), ShouldBeNil) // reset
 			})
 			Convey("with an out of date agent revision and a task group", func() {
@@ -402,7 +401,6 @@ func TestNextTask(t *testing.T) {
 				So(resp.Code, ShouldEqual, http.StatusOK)
 				So(json.NewDecoder(resp.Body).Decode(details), ShouldBeNil)
 				So(details.ShouldExit, ShouldEqual, false)
-				So(details.NewAgent, ShouldEqual, true)
 				So(sampleHost.SetAgentRevision(evergreen.BuildRevision), ShouldBeNil) // reset
 			})
 			Convey("with a host that already has a running task", func() {


### PR DESCRIPTION
The bug that this addresses is in the following sequence of events:
1. An agent calls /end, having finished a task.
2. The agent calls /next_task. It receives a new task and `newAgent`, which means that it should exit if it's safe to do so, i.e., it's not in a task group.
3. The server marks the new task as dispatched.
4. The agent checks to see if it's safe to exit. It is, because `nextTaskHasDifferentTaskGroupOrBuild` returns `true`. It then calls /next_task _again_, in order to ensure that the host is marked as needing a new agent. Then it exits.

The problem is that in order to find out if it's safe to exit, the agent must get a new task, but getting a new task causes that task to enter the dispatched state. At that point the server expects the agent to be running the task, but the agent has in fact just exited. This causes tasks to be marked system-unresponsive.

The solution below is simple: Never exit while running a task in a task group. This has the unfortunate side effect that hosts will not get a new agent until after they have finished running a task not in a task group. I hope we can fix this problem in the tunable scheduler epic.