### PR TITLE
EVG-5577: Commit queue set-module

### DIFF
--- a/command/git.go
+++ b/command/git.go
@@ -17,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/rest/client"
 	"github.com/evergreen-ci/evergreen/subprocess"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip/level"
@@ -136,8 +137,7 @@ func (c *gitFetchProject) buildCloneCommand(conf *model.TaskConfig) ([]string, e
 	gitCommands = append(gitCommands, cloneCmd...)
 
 	if conf.GithubPatchData.PRNumber != 0 {
-		branchName := fmt.Sprintf("evg-pr-test-%s", util.RandomString())
-		var ref, commitToTest string
+		var ref, commitToTest, branchName string
 		if conf.Task.IsMergeRequest() {
 			// GitHub creates a ref at refs/pull/[pr number]/merge
 			// pointing to the test merge commit they generate
@@ -145,11 +145,13 @@ func (c *gitFetchProject) buildCloneCommand(conf *model.TaskConfig) ([]string, e
 			// and: https://docs.travis-ci.com/user/pull-requests/#my-pull-request-isnt-being-built
 			ref = "merge"
 			commitToTest = conf.GithubPatchData.MergeCommitSHA
+			branchName = fmt.Sprintf("evg-merge-test-%s", util.RandomString())
 		} else {
 			// Github creates a ref called refs/pull/[pr number]/head
 			// that provides the entire tree of changes, including merges
 			ref = "head"
 			commitToTest = conf.GithubPatchData.HeadHash
+			branchName = fmt.Sprintf("evg-pr-test-%s", util.RandomString())
 		}
 		gitCommands = append(gitCommands, []string{
 			fmt.Sprintf(`git fetch origin "pull/%d/%s:%s"`, conf.GithubPatchData.PRNumber, ref, branchName),
@@ -165,7 +167,7 @@ func (c *gitFetchProject) buildCloneCommand(conf *model.TaskConfig) ([]string, e
 	return gitCommands, nil
 }
 
-func (c *gitFetchProject) buildModuleCloneCommand(cloneURI, owner, repo, moduleBase, ref string) ([]string, error) {
+func (c *gitFetchProject) buildModuleCloneCommand(cloneURI, owner, repo, moduleBase, ref, requester string, modulePatch *patch.ModulePatch) ([]string, error) {
 	if cloneURI == "" {
 		return nil, errors.New("empty repository URI")
 	}
@@ -207,7 +209,17 @@ func (c *gitFetchProject) buildModuleCloneCommand(cloneURI, owner, repo, moduleB
 		}
 		gitCommands = append(gitCommands, cmds...)
 	}
-	gitCommands = append(gitCommands, fmt.Sprintf("git checkout '%s'", ref))
+
+	if requester == evergreen.MergeTestRequester && modulePatch != nil && modulePatch.PatchSet.Patch != "" {
+		branchName := fmt.Sprintf("evg-merge-test-%s", util.RandomString())
+		gitCommands = append(gitCommands,
+			fmt.Sprintf(`git fetch origin "pull/%s/merge:%s"`, modulePatch.PatchSet.Patch, branchName),
+			fmt.Sprintf("git checkout '%s'", branchName),
+			fmt.Sprintf("git reset --hard %s", modulePatch.Githash),
+		)
+	} else {
+		gitCommands = append(gitCommands, fmt.Sprintf("git checkout '%s'", ref))
+	}
 
 	return gitCommands, nil
 }
@@ -262,6 +274,17 @@ func (c *gitFetchProject) Execute(ctx context.Context,
 		return errors.Wrap(err, "problem running fetch command")
 	}
 
+	var p *patch.Patch
+	if evergreen.IsPatchRequester(conf.Task.Requester) {
+		logger.Execution().Info("Fetching patch.")
+		p, err = comm.GetTaskPatch(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret})
+		if err != nil {
+			err = errors.Wrap(err, "Failed to get patch")
+			logger.Execution().Error(err.Error())
+			return err
+		}
+	}
+
 	// Fetch source for the modules
 	for _, moduleName := range conf.BuildVariant.Modules {
 		if ctx.Err() != nil {
@@ -291,13 +314,33 @@ func (c *gitFetchProject) Execute(ctx context.Context,
 				revision = module.Branch
 			}
 		}
-		owner, repo := parseGitUrl(module.Repo, logger)
+		owner, repo, err := thirdparty.ParseGitUrl(module.Repo)
+		if err != nil {
+			logger.Execution().Error(err.Error())
+		}
 		if owner == "" || repo == "" {
 			continue
 		}
 
+		var modulePatch *patch.ModulePatch
+		if p != nil {
+			// find module among the patch's Patches
+			moduleIndex := -1
+			for i, modulePatch := range p.Patches {
+				if modulePatch.ModuleName == moduleName {
+					moduleIndex = i
+					break
+				}
+			}
+			// not found
+			if moduleIndex == -1 {
+				logger.Execution().Errorf("module '%s' not found in patch", moduleName)
+				continue
+			}
+		}
+
 		var moduleCmds []string
-		moduleCmds, err = c.buildModuleCloneCommand(module.Repo, owner, repo, moduleBase, revision)
+		moduleCmds, err = c.buildModuleCloneCommand(module.Repo, owner, repo, moduleBase, revision, conf.Task.Requester, modulePatch)
 		if err != nil {
 			return err
 		}
@@ -319,72 +362,21 @@ func (c *gitFetchProject) Execute(ctx context.Context,
 	}
 
 	//Apply patches if necessary
-	if conf.Task.Requester != evergreen.PatchVersionRequester {
-		return nil
-	}
+	if conf.Task.Requester == evergreen.PatchVersionRequester {
+		if err = c.getPatchContents(ctx, comm, logger, conf, p); err != nil {
+			err = errors.Wrap(err, "Failed to get patch contents")
+			logger.Execution().Errorf(err.Error())
+			return err
+		}
 
-	logger.Execution().Info("Fetching patch.")
-	patch, err := comm.GetTaskPatch(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret})
-	if err != nil {
-		err = errors.Wrap(err, "Failed to get patch")
-		logger.Execution().Error(err.Error())
-		return err
-	}
-
-	if err = c.getPatchContents(ctx, comm, logger, conf, patch); err != nil {
-		err = errors.Wrap(err, "Failed to get patch contents")
-		logger.Execution().Errorf(err.Error())
-		return err
-	}
-
-	if err = c.applyPatch(ctx, logger, conf, patch); err != nil {
-		err = errors.Wrap(err, "Failed to apply patch")
-		logger.Execution().Infof(err.Error())
-		return err
+		if err = c.applyPatch(ctx, logger, conf, p); err != nil {
+			err = errors.Wrap(err, "Failed to apply patch")
+			logger.Execution().Infof(err.Error())
+			return err
+		}
 	}
 
 	return nil
-}
-
-func parseGitUrl(url string, logger client.LoggerProducer) (string, string) {
-	var owner string
-	var repo string
-	httpsPrefix := "https://"
-	if strings.HasPrefix(url, httpsPrefix) {
-		url = strings.TrimPrefix(url, httpsPrefix)
-		split := strings.Split(url, "/")
-		if len(split) != 3 {
-			logger.Execution().Errorf("Invalid module format '%s'", url)
-			return "", ""
-		}
-		owner = split[1]
-		splitRepo := strings.Split(split[2], ".")
-		if len(splitRepo) != 2 {
-			logger.Execution().Errorf("Invalid module format '%s'", url)
-			return "", ""
-		}
-		repo = splitRepo[0]
-	} else {
-		splitModule := strings.Split(url, ":")
-		if len(splitModule) != 2 {
-			logger.Execution().Errorf("Invalid module format '%s'", url)
-			return "", ""
-		}
-		splitOwner := strings.Split(splitModule[1], "/")
-		if len(splitOwner) != 2 {
-			logger.Execution().Errorf("Invalid module format '%s'", url)
-			return "", ""
-		}
-		owner = splitOwner[0]
-		splitRepo := strings.Split(splitOwner[1], ".")
-		if len(splitRepo) != 2 {
-			logger.Execution().Errorf("Invalid module format '%s'", url)
-			return "", ""
-		}
-		repo = splitRepo[0]
-	}
-
-	return owner, repo
 }
 
 // getPatchContents() dereferences any patch files that are stored externally, fetching them from

--- a/command/git.go
+++ b/command/git.go
@@ -314,7 +314,8 @@ func (c *gitFetchProject) Execute(ctx context.Context,
 				revision = module.Branch
 			}
 		}
-		owner, repo, err := thirdparty.ParseGitUrl(module.Repo)
+		var owner, repo string
+		owner, repo, err = thirdparty.ParseGitUrl(module.Repo)
 		if err != nil {
 			logger.Execution().Error(err.Error())
 		}

--- a/command/git.go
+++ b/command/git.go
@@ -333,17 +333,11 @@ func (c *gitFetchProject) Execute(ctx context.Context,
 		var modulePatch *patch.ModulePatch
 		if p != nil {
 			// find module among the patch's Patches
-			moduleIndex := -1
-			for i, modulePatch := range p.Patches {
-				if modulePatch.ModuleName == moduleName {
-					moduleIndex = i
+			for i := range p.Patches {
+				if p.Patches[i].ModuleName == moduleName {
+					modulePatch = &p.Patches[i]
 					break
 				}
-			}
-			// not found
-			if moduleIndex == -1 {
-				logger.Execution().Errorf("module '%s' not found in patch", moduleName)
-				continue
 			}
 		}
 

--- a/command/git.go
+++ b/command/git.go
@@ -364,13 +364,13 @@ func (c *gitFetchProject) Execute(ctx context.Context,
 	if conf.Task.Requester == evergreen.PatchVersionRequester {
 		if err = c.getPatchContents(ctx, comm, logger, conf, p); err != nil {
 			err = errors.Wrap(err, "Failed to get patch contents")
-			logger.Execution().Errorf(err.Error())
+			logger.Execution().Error(err.Error())
 			return err
 		}
 
 		if err = c.applyPatch(ctx, logger, conf, p); err != nil {
 			err = errors.Wrap(err, "Failed to apply patch")
-			logger.Execution().Infof(err.Error())
+			logger.Execution().Error(err.Error())
 			return err
 		}
 	}

--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -1,7 +1,6 @@
 package commitqueue
 
 import (
-	"encoding/json"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -103,26 +102,4 @@ func ClearAllCommitQueues() (int, error) {
 	}
 
 	return clearedCount, nil
-}
-
-type CommentData struct {
-	Modules []Module `json:"modules"`
-}
-
-func GetCommentData(comment string) (CommentData, error) {
-	data := CommentData{}
-
-	// trim comment until the first '{'
-	posOpening := strings.Index(comment, "{")
-	// no data was included with the comment string
-	if posOpening == -1 {
-		return data, nil
-	}
-
-	commentDataString := comment[posOpening:]
-	if err := json.Unmarshal([]byte(commentDataString), &data); err != nil {
-		return data, errors.Wrap(err, "can't parse comment for data")
-	}
-
-	return data, nil
 }

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -164,29 +164,6 @@ func (s *CommitQueueSuite) TestCommentTrigger() {
 	s.False(TriggersCommitQueue(action, comment))
 }
 
-func (s *CommitQueueSuite) TestGetCommentData() {
-	var mods []Module
-	comment := "1234"
-	data, err := GetCommentData(comment)
-	s.NoError(err)
-	s.Equal(mods, data.Modules)
-
-	comment = `2345 {"don't_care_field":"don't_care"}`
-	data, err = GetCommentData(comment)
-	s.NoError(err)
-	s.Equal(mods, data.Modules)
-
-	comment = `2345 {"modules":[{"module":"test_module", "issue":"5678"}]}`
-	data, err = GetCommentData(comment)
-	s.NoError(err)
-	s.Equal([]Module{
-		Module{
-			Module: "test_module",
-			Issue:  "5678",
-		},
-	}, data.Modules)
-}
-
 // Duplicated here from testutil to avoid import cycle
 // (evergreen package requires github_pr_sender and testutil requires evergreen)
 type settings struct {

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -67,10 +67,10 @@ func (s *CommitQueueSuite) TestNext() {
 	s.NoError(s.q.Enqueue(sampleCommitQueueItem))
 	s.Len(s.q.Queue, 1)
 
-	s.q.SetProcessing(true)
+	s.NoError(s.q.SetProcessing(true))
 	s.Nil(s.q.Next())
 
-	s.q.SetProcessing(false)
+	s.NoError(s.q.SetProcessing(false))
 	s.NotNil(s.q.Next())
 	s.Equal(s.q.Next().Issue, "c123")
 }
@@ -105,9 +105,11 @@ func (s *CommitQueueSuite) TestRemoveOne() {
 	s.Equal("c123", items[0].Issue)
 	s.Equal("e345", items[1].Issue)
 
-	s.q.SetProcessing(true)
+	s.NoError(s.q.SetProcessing(true))
 	s.Nil(s.q.Next())
-	s.q.Remove("c123")
+	found, err = s.q.Remove("c123")
+	s.True(found)
+	s.NoError(err)
 	s.NotNil(s.q.Next())
 	s.Equal(s.q.Next().Issue, "e345")
 }

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -18,6 +18,16 @@ type CommitQueueSuite struct {
 	q *CommitQueue
 }
 
+var sampleCommitQueueItem = CommitQueueItem{
+	Issue: "c123",
+	Modules: []Module{
+		Module{
+			Module: "test_module",
+			Issue:  "d234",
+		},
+	},
+}
+
 func TestCommitQueueSuite(t *testing.T) {
 	s := new(CommitQueueSuite)
 	suite.Run(t, s)
@@ -40,36 +50,39 @@ func (s *CommitQueueSuite) SetupTest() {
 }
 
 func (s *CommitQueueSuite) TestEnqueue() {
-	s.NoError(s.q.Enqueue("c123"))
-	s.False(s.q.IsEmpty())
-	s.Equal("c123", s.q.Next())
+	s.NoError(s.q.Enqueue(sampleCommitQueueItem))
+	s.Len(s.q.Queue, 1)
+	s.Equal("c123", s.q.Next().Issue)
 	s.NotEqual(-1, s.q.findItem("c123"))
 
 	// Persisted to db
 	dbq, err := FindOneId("mci")
 	s.NoError(err)
-	s.False(dbq.IsEmpty())
-	s.Equal("c123", dbq.Next())
+	s.Len(dbq.Queue, 1)
+	s.Equal(sampleCommitQueueItem, *dbq.Next())
 	s.NotEqual(-1, dbq.findItem("c123"))
 }
 
-func (s *CommitQueueSuite) TestAll() {
-	s.Require().NoError(s.q.Enqueue("c123"))
-	s.Require().NoError(s.q.Enqueue("d234"))
-	s.Require().NoError(s.q.Enqueue("e345"))
+func (s *CommitQueueSuite) TestNext() {
+	s.NoError(s.q.Enqueue(sampleCommitQueueItem))
+	s.Len(s.q.Queue, 1)
 
-	items := s.q.All()
-	s.Len(items, 3)
-	s.Equal("c123", items[0])
-	s.Equal("d234", items[1])
-	s.Equal("e345", items[2])
+	s.q.SetProcessing(true)
+	s.Nil(s.q.Next())
+
+	s.q.SetProcessing(false)
+	s.NotNil(s.q.Next())
+	s.Equal(s.q.Next().Issue, "c123")
 }
 
 func (s *CommitQueueSuite) TestRemoveOne() {
-	s.Require().NoError(s.q.Enqueue("c123"))
-	s.Require().NoError(s.q.Enqueue("d234"))
-	s.Require().NoError(s.q.Enqueue("e345"))
-	s.Require().Len(s.q.All(), 3)
+	item := sampleCommitQueueItem
+	s.Require().NoError(s.q.Enqueue(item))
+	item.Issue = "d234"
+	s.Require().NoError(s.q.Enqueue(item))
+	item.Issue = "e345"
+	s.Require().NoError(s.q.Enqueue(item))
+	s.Require().Len(s.q.Queue, 3)
 
 	found, err := s.q.Remove("not_here")
 	s.NoError(err)
@@ -78,30 +91,40 @@ func (s *CommitQueueSuite) TestRemoveOne() {
 	found, err = s.q.Remove("d234")
 	s.NoError(err)
 	s.True(found)
-	items := s.q.All()
+	items := s.q.Queue
 	s.Len(items, 2)
 	// Still in order
-	s.Equal("c123", items[0])
-	s.Equal("e345", items[1])
+	s.Equal("c123", items[0].Issue)
+	s.Equal("e345", items[1].Issue)
 
 	// Persisted to db
 	dbq, err := FindOneId("mci")
 	s.NoError(err)
-	items = dbq.All()
+	items = dbq.Queue
 	s.Len(items, 2)
-	s.Equal("c123", items[0])
-	s.Equal("e345", items[1])
+	s.Equal("c123", items[0].Issue)
+	s.Equal("e345", items[1].Issue)
+
+	s.q.SetProcessing(true)
+	s.Nil(s.q.Next())
+	s.q.Remove("c123")
+	s.NotNil(s.q.Next())
+	s.Equal(s.q.Next().Issue, "e345")
 }
 
 func (s *CommitQueueSuite) TestClearAll() {
-	s.Require().NoError(s.q.Enqueue("c123"))
-	s.Require().NoError(s.q.Enqueue("d234"))
-	s.Require().NoError(s.q.Enqueue("e345"))
-	s.Require().Len(s.q.All(), 3)
+	item := sampleCommitQueueItem
+	s.Require().NoError(s.q.Enqueue(item))
+	item.Issue = "d234"
+	s.Require().NoError(s.q.Enqueue(item))
+	item.Issue = "e345"
+	s.Require().NoError(s.q.Enqueue(item))
+	s.Require().Len(s.q.Queue, 3)
+	s.Require().Len(s.q.Queue, 3)
 
 	q := &CommitQueue{
 		ProjectID: "logkeeper",
-		Queue:     []string{},
+		Queue:     []CommitQueueItem{},
 	}
 	s.Require().NoError(InsertQueue(q))
 
@@ -112,14 +135,16 @@ func (s *CommitQueueSuite) TestClearAll() {
 
 	s.q, err = FindOneId("mci")
 	s.NoError(err)
-	s.Empty(s.q.All())
+	s.Empty(s.q.Queue)
 	q, err = FindOneId("logkeeper")
 	s.NoError(err)
-	s.Empty(q.All())
+	s.Empty(q.Queue)
 
 	// both have contents
-	s.Require().NoError(s.q.Enqueue("c1234"))
-	s.Require().NoError(q.Enqueue("d234"))
+	item.Issue = "c1234"
+	s.Require().NoError(s.q.Enqueue(item))
+	item.Issue = "d234"
+	s.Require().NoError(q.Enqueue(item))
 	clearedCount, err = ClearAllCommitQueues()
 	s.NoError(err)
 	s.Equal(2, clearedCount)
@@ -137,6 +162,31 @@ func (s *CommitQueueSuite) TestCommentTrigger() {
 	s.False(TriggersCommitQueue(action, comment))
 }
 
+func (s *CommitQueueSuite) TestGetCommentData() {
+	var mods []Module
+	comment := "1234"
+	data, err := GetCommentData(comment)
+	s.NoError(err)
+	s.Equal(mods, data.Modules)
+
+	comment = `2345 {"don't_care_field":"don't_care"}`
+	data, err = GetCommentData(comment)
+	s.NoError(err)
+	s.Equal(mods, data.Modules)
+
+	comment = `2345 {"modules":[{"module":"test_module", "issue":"5678"}]}`
+	data, err = GetCommentData(comment)
+	s.NoError(err)
+	s.Equal([]Module{
+		Module{
+			Module: "test_module",
+			Issue:  "5678",
+		},
+	}, data.Modules)
+}
+
+// Duplicated here from testutil to avoid import cycle
+// (evergreen package requires github_pr_sender and testutil requires evergreen)
 type settings struct {
 	Database dbSettings `yaml:"database"`
 }
@@ -154,8 +204,6 @@ type writeConcern struct {
 	J        bool   `yaml:"j"`
 }
 
-// Duplicated here from testutil to avoid import cycle
-// (evergreen package requires github_pr_sender and testutil requires evergreen)
 func getDBSessionFactory() (*db.SessionFactory, error) {
 	evgHome := os.Getenv("EVGHOME")
 	testDir := "config_test"

--- a/model/commitqueue/github_pr_sender_test.go
+++ b/model/commitqueue/github_pr_sender_test.go
@@ -25,7 +25,14 @@ func (s *GitHubPRSenderSuite) SetupTest() {
 	s.NoError(db.ClearCollections(Collection))
 	cq := &CommitQueue{
 		ProjectID: "mci",
-		Queue:     []string{"1", "2"},
+		Queue: []CommitQueueItem{
+			CommitQueueItem{
+				Issue: "1",
+			},
+			CommitQueueItem{
+				Issue: "2",
+			},
+		},
 	}
 	s.NoError(InsertQueue(cq))
 }
@@ -53,5 +60,5 @@ func (s *GitHubPRSenderSuite) TestDequeueFromCommitQueue() {
 	s.NoError(dequeueFromCommitQueue("mci", 1))
 	cq, err := FindOneId("mci")
 	s.NoError(err)
-	s.Equal("2", cq.Next())
+	s.Equal("2", cq.Next().Issue)
 }

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -186,12 +186,3 @@ func ByGithubPRAndCreatedBefore(t time.Time, owner, repo string, prNumber int) d
 		bsonutil.GetDottedKeyName(githubPatchDataKey, githubPatchPRNumberKey):  prNumber,
 	})
 }
-
-func FindOneByGithubPRNumAndMergeCommitSHA(prNumber int, mergeCommitSHA string) (*Patch, error) {
-	q := db.Query(bson.M{
-		bsonutil.GetDottedKeyName(githubPatchDataKey, githubPatchPRNumberKey):  prNumber,
-		bsonutil.GetDottedKeyName(githubPatchDataKey, githubMergeCommitSHAKey): mergeCommitSHA,
-	})
-
-	return FindOne(q)
-}

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -95,7 +95,13 @@ func listCommitQueue(ctx context.Context, client client.Communicator, projectID 
 	grip.Infof("Project: %s\n", restModel.FromAPIString(cq.ProjectID))
 	grip.Infof("Queue Length: %d\n", len(cq.Queue))
 	for i, item := range cq.Queue {
-		grip.Infof("\t%d: %s\n", i+1, restModel.FromAPIString(item))
+		grip.Infof("\t%d: %s\n", i+1, restModel.FromAPIString(item.Issue))
+		if len(item.Modules) > 0 {
+			grip.Info("\tModules:\n")
+			for j, module := range item.Modules {
+				grip.Infof("\t\t%d: %s (%s)\n", j+1, restModel.FromAPIString(module.Module), restModel.FromAPIString(module.Issue))
+			}
+		}
 	}
 
 	return nil

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -70,7 +70,17 @@ func (s *CommitQueueSuite) TestListContents() {
 	s.Require().NoError(db.ClearCollections(commitqueue.Collection))
 	cq := &commitqueue.CommitQueue{
 		ProjectID: "mci",
-		Queue:     []string{"123", "456", "789"},
+		Queue: []commitqueue.CommitQueueItem{
+			commitqueue.CommitQueueItem{
+				Issue: "123",
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "456",
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "789",
+			},
+		},
 	}
 	s.Require().NoError(commitqueue.InsertQueue(cq))
 
@@ -90,11 +100,63 @@ func (s *CommitQueueSuite) TestListContents() {
 	s.Contains(stringOut, "3: 789")
 }
 
+func (s *CommitQueueSuite) TestListContentsWithModule() {
+	s.Require().NoError(db.ClearCollections(commitqueue.Collection))
+	cq := &commitqueue.CommitQueue{
+		ProjectID: "mci",
+		Queue: []commitqueue.CommitQueueItem{
+			commitqueue.CommitQueueItem{
+				Issue: "123",
+				Modules: []commitqueue.Module{
+					commitqueue.Module{
+						Module: "test_module",
+						Issue:  "1234",
+					},
+				},
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "456",
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "789",
+			},
+		},
+	}
+	s.Require().NoError(commitqueue.InsertQueue(cq))
+
+	origStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	s.NoError(grip.SetSender(send.MakePlainLogger()))
+	s.NoError(listCommitQueue(s.ctx, s.client, "mci"))
+	s.NoError(w.Close())
+	os.Stdout = origStdout
+	out, _ := ioutil.ReadAll(r)
+	stringOut := string(out[:])
+
+	s.Contains(stringOut, "Project: mci")
+	s.Contains(stringOut, "1: 123")
+	s.Contains(stringOut, "Modules:")
+	s.Contains(stringOut, "1: test_module (1234)")
+	s.Contains(stringOut, "2: 456")
+	s.Contains(stringOut, "3: 789")
+}
+
 func (s *CommitQueueSuite) TestDeleteCommitQueueItem() {
 	s.Require().NoError(db.ClearCollections(commitqueue.Collection, model.ProjectRefCollection))
 	cq := &commitqueue.CommitQueue{
 		ProjectID: "mci",
-		Queue:     []string{"123", "456", "789"},
+		Queue: []commitqueue.CommitQueueItem{
+			commitqueue.CommitQueueItem{
+				Issue: "123",
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "456",
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "789",
+			},
+		},
 	}
 	s.Require().NoError(commitqueue.InsertQueue(cq))
 	projectRef := model.ProjectRef{

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -560,8 +560,25 @@ func (c *Mock) CreateVersionFromConfig(ctx context.Context, project, message str
 func (c *Mock) GetCommitQueue(ctx context.Context, projectID string) (*model.APICommitQueue, error) {
 	return &model.APICommitQueue{
 		ProjectID: model.ToAPIString("mci"),
-		Queue: []model.APIString{
-			model.ToAPIString("123"), model.ToAPIString("456"), model.ToAPIString("789"),
+		Queue: []model.APICommitQueueItem{
+			model.APICommitQueueItem{
+				Issue: model.ToAPIString("123"),
+				Modules: []model.APIModule{
+					model.APIModule{
+						Module: model.ToAPIString("test_module"),
+						Issue:  model.ToAPIString("345"),
+					},
+				},
+			},
+			model.APICommitQueueItem{
+				Issue: model.ToAPIString("345"),
+				Modules: []model.APIModule{
+					model.APIModule{
+						Module: model.ToAPIString("test_module2"),
+						Issue:  model.ToAPIString("567"),
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -151,7 +151,9 @@ func (pc *MockCommitQueueConnector) EnqueueItem(owner, repo, baseBranch string, 
 	}
 
 	apiItem := restModel.APICommitQueueItem{}
-	apiItem.BuildFromService(item)
+	if err := apiItem.BuildFromService(item); err != nil {
+		return errors.Wrap(err, "can't build API commit queue item from db model")
+	}
 
 	queueID := owner + "." + repo + "." + baseBranch
 	pc.Queue[queueID] = append(pc.Queue[queueID], apiItem)

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -45,13 +45,13 @@ func (s *CommitQueueSuite) SetupTest() {
 
 func (s *CommitQueueSuite) TestEnqueue() {
 	s.ctx = &DBConnector{}
-	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "1234"))
+	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1234"}))
 
 	q, err := commitqueue.FindOneId("mci")
 	s.NoError(err)
 
 	if s.Len(q.Queue, 1) {
-		s.Equal(q.Queue[0], "1234")
+		s.Equal(q.Queue[0].Issue, "1234")
 	}
 }
 
@@ -64,9 +64,9 @@ func (s *CommitQueueSuite) TestFindCommitQueueByID() {
 
 func (s *CommitQueueSuite) TestCommitQueueRemoveItem() {
 	s.ctx = &DBConnector{}
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "1"))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "2"))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "3"))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "2"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "3"}))
 
 	found, err := s.ctx.CommitQueueRemoveItem("mci", "not_here")
 	s.NoError(err)
@@ -77,15 +77,15 @@ func (s *CommitQueueSuite) TestCommitQueueRemoveItem() {
 	s.True(found)
 	cq, err := s.ctx.FindCommitQueueByID("mci")
 	s.NoError(err)
-	s.Equal(restModel.ToAPIString("2"), cq.Queue[0])
-	s.Equal(restModel.ToAPIString("3"), cq.Queue[1])
+	s.Equal(restModel.ToAPIString("2"), cq.Queue[0].Issue)
+	s.Equal(restModel.ToAPIString("3"), cq.Queue[1].Issue)
 }
 
 func (s *CommitQueueSuite) TestCommitQueueClearAll() {
 	s.ctx = &DBConnector{}
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "12"))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "34"))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "56"))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "12"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "34"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "56"}))
 
 	q := &commitqueue.CommitQueue{ProjectID: "logkeeper"}
 	s.Require().NoError(commitqueue.InsertQueue(q))
@@ -96,8 +96,8 @@ func (s *CommitQueueSuite) TestCommitQueueClearAll() {
 	s.Equal(1, clearedCount)
 
 	// both queues have items
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "12"))
-	s.NoError(q.Enqueue("78"))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "12"}))
+	s.NoError(q.Enqueue(commitqueue.CommitQueueItem{Issue: "78"}))
 	clearedCount, err = s.ctx.CommitQueueClearAll()
 	s.NoError(err)
 	s.Equal(2, clearedCount)
@@ -140,30 +140,30 @@ func (s *CommitQueueSuite) TestMockGetGitHubPR() {
 
 func (s *CommitQueueSuite) TestMockEnqueue() {
 	s.ctx = &MockConnector{}
-	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "1234"))
+	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1234"}))
 
 	conn := s.ctx.(*MockConnector)
 	q, ok := conn.MockCommitQueueConnector.Queue["evergreen-ci.evergreen.master"]
 	if s.True(ok) && s.Len(q, 1) {
-		s.Equal(restModel.ToAPIString("1234"), q[0])
+		s.Equal(restModel.ToAPIString("1234"), q[0].Issue)
 	}
 }
 
 func (s *CommitQueueSuite) TestMockFindCommitQueueByID() {
 	s.ctx = &MockConnector{}
-	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "1234"))
+	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1234"}))
 
 	cq, err := s.ctx.FindCommitQueueByID("evergreen-ci.evergreen.master")
 	s.NoError(err)
 	s.Equal(restModel.ToAPIString("evergreen-ci.evergreen.master"), cq.ProjectID)
-	s.Equal([]restModel.APIString{restModel.ToAPIString("1234")}, cq.Queue)
+	s.Equal(restModel.ToAPIString("1234"), cq.Queue[0].Issue)
 }
 
 func (s *CommitQueueSuite) TestMockCommitQueueRemoveItem() {
 	s.ctx = &MockConnector{}
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "1"))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "2"))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "3"))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "2"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "3"}))
 
 	found, err := s.ctx.CommitQueueRemoveItem("evergreen-ci.evergreen.master", "not_here")
 	s.NoError(err)
@@ -174,17 +174,17 @@ func (s *CommitQueueSuite) TestMockCommitQueueRemoveItem() {
 	s.True(found)
 	cq, err := s.ctx.FindCommitQueueByID("evergreen-ci.evergreen.master")
 	s.NoError(err)
-	s.Equal(restModel.ToAPIString("2"), cq.Queue[0])
-	s.Equal(restModel.ToAPIString("3"), cq.Queue[1])
+	s.Equal(restModel.ToAPIString("2"), cq.Queue[0].Issue)
+	s.Equal(restModel.ToAPIString("3"), cq.Queue[1].Issue)
 }
 
 func (s *CommitQueueSuite) TestMockCommitQueueClearAll() {
 	s.ctx = &MockConnector{}
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "12"))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", "34"))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "12"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "34"}))
 
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "logkeeper", "master", "56"))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "logkeeper", "master", "78"))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "logkeeper", "master", commitqueue.CommitQueueItem{Issue: "56"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "logkeeper", "master", commitqueue.CommitQueueItem{Issue: "78"}))
 
 	clearedCount, err := s.ctx.CommitQueueClearAll()
 	s.NoError(err)

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -45,7 +45,7 @@ func (s *CommitQueueSuite) SetupTest() {
 
 func (s *CommitQueueSuite) TestEnqueue() {
 	s.ctx = &DBConnector{}
-	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1234"}))
+	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("1234")}))
 
 	q, err := commitqueue.FindOneId("mci")
 	s.NoError(err)
@@ -64,9 +64,9 @@ func (s *CommitQueueSuite) TestFindCommitQueueByID() {
 
 func (s *CommitQueueSuite) TestCommitQueueRemoveItem() {
 	s.ctx = &DBConnector{}
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1"}))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "2"}))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "3"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("1")}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("2")}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("3")}))
 
 	found, err := s.ctx.CommitQueueRemoveItem("mci", "not_here")
 	s.NoError(err)
@@ -83,9 +83,9 @@ func (s *CommitQueueSuite) TestCommitQueueRemoveItem() {
 
 func (s *CommitQueueSuite) TestCommitQueueClearAll() {
 	s.ctx = &DBConnector{}
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "12"}))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "34"}))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "56"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("12")}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("34")}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("56")}))
 
 	q := &commitqueue.CommitQueue{ProjectID: "logkeeper"}
 	s.Require().NoError(commitqueue.InsertQueue(q))
@@ -96,7 +96,7 @@ func (s *CommitQueueSuite) TestCommitQueueClearAll() {
 	s.Equal(1, clearedCount)
 
 	// both queues have items
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "12"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("12")}))
 	s.NoError(q.Enqueue(commitqueue.CommitQueueItem{Issue: "78"}))
 	clearedCount, err = s.ctx.CommitQueueClearAll()
 	s.NoError(err)
@@ -140,7 +140,7 @@ func (s *CommitQueueSuite) TestMockGetGitHubPR() {
 
 func (s *CommitQueueSuite) TestMockEnqueue() {
 	s.ctx = &MockConnector{}
-	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1234"}))
+	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("1234")}))
 
 	conn := s.ctx.(*MockConnector)
 	q, ok := conn.MockCommitQueueConnector.Queue["evergreen-ci.evergreen.master"]
@@ -151,7 +151,7 @@ func (s *CommitQueueSuite) TestMockEnqueue() {
 
 func (s *CommitQueueSuite) TestMockFindCommitQueueByID() {
 	s.ctx = &MockConnector{}
-	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1234"}))
+	s.NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("1234")}))
 
 	cq, err := s.ctx.FindCommitQueueByID("evergreen-ci.evergreen.master")
 	s.NoError(err)
@@ -161,9 +161,9 @@ func (s *CommitQueueSuite) TestMockFindCommitQueueByID() {
 
 func (s *CommitQueueSuite) TestMockCommitQueueRemoveItem() {
 	s.ctx = &MockConnector{}
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1"}))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "2"}))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "3"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("1")}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("2")}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("3")}))
 
 	found, err := s.ctx.CommitQueueRemoveItem("evergreen-ci.evergreen.master", "not_here")
 	s.NoError(err)
@@ -180,11 +180,11 @@ func (s *CommitQueueSuite) TestMockCommitQueueRemoveItem() {
 
 func (s *CommitQueueSuite) TestMockCommitQueueClearAll() {
 	s.ctx = &MockConnector{}
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "12"}))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "34"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("12")}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "evergreen", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("34")}))
 
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "logkeeper", "master", commitqueue.CommitQueueItem{Issue: "56"}))
-	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "logkeeper", "master", commitqueue.CommitQueueItem{Issue: "78"}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "logkeeper", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("56")}))
+	s.Require().NoError(s.ctx.EnqueueItem("evergreen-ci", "logkeeper", "master", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("78")}))
 
 	clearedCount, err := s.ctx.CommitQueueClearAll()
 	s.NoError(err)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -231,7 +232,7 @@ type Connector interface {
 
 	// Commit queue methods
 	GetGitHubPR(context.Context, string, string, int) (*github.PullRequest, error)
-	EnqueueItem(string, string, string, string) error
+	EnqueueItem(string, string, string, commitqueue.CommitQueueItem) error
 	FindCommitQueueByID(string) (*restModel.APICommitQueue, error)
 	CommitQueueRemoveItem(string, string) (bool, error)
 	CommitQueueClearAll() (int, error)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
-	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -232,7 +231,7 @@ type Connector interface {
 
 	// Commit queue methods
 	GetGitHubPR(context.Context, string, string, int) (*github.PullRequest, error)
-	EnqueueItem(string, string, string, commitqueue.CommitQueueItem) error
+	EnqueueItem(string, string, string, restModel.APICommitQueueItem) error
 	FindCommitQueueByID(string) (*restModel.APICommitQueue, error)
 	CommitQueueRemoveItem(string, string) (bool, error)
 	CommitQueueClearAll() (int, error)

--- a/rest/model/commit_queue.go
+++ b/rest/model/commit_queue.go
@@ -29,7 +29,9 @@ func (cq *APICommitQueue) BuildFromService(h interface{}) error {
 	cq.ProjectID = ToAPIString(cqService.ProjectID)
 	for _, item := range cqService.Queue {
 		cqItem := APICommitQueueItem{}
-		cqItem.BuildFromService(item)
+		if err := cqItem.BuildFromService(item); err != nil {
+			return errors.Wrap(err, "can't build API commit queue item from db model")
+		}
 		cq.Queue = append(cq.Queue, cqItem)
 	}
 

--- a/rest/model/commit_queue.go
+++ b/rest/model/commit_queue.go
@@ -6,8 +6,18 @@ import (
 )
 
 type APICommitQueue struct {
-	ProjectID APIString   `json:"queue_id"`
-	Queue     []APIString `json:"queue"`
+	ProjectID APIString            `json:"queue_id"`
+	Queue     []APICommitQueueItem `json:"queue"`
+}
+
+type APICommitQueueItem struct {
+	Issue   APIString   `json:"issue"`
+	Modules []APIModule `json:"modules"`
+}
+
+type APIModule struct {
+	Module APIString `json:"module"`
+	Issue  APIString `json:"issue"`
 }
 
 func (cq *APICommitQueue) BuildFromService(h interface{}) error {
@@ -18,12 +28,34 @@ func (cq *APICommitQueue) BuildFromService(h interface{}) error {
 
 	cq.ProjectID = ToAPIString(cqService.ProjectID)
 	for _, item := range cqService.Queue {
-		cq.Queue = append(cq.Queue, ToAPIString(item))
+		cqItem := APICommitQueueItem{}
+		cqItem.BuildFromService(item)
+		cq.Queue = append(cq.Queue, cqItem)
 	}
 
 	return nil
 }
 
 func (cq *APICommitQueue) ToService() (interface{}, error) {
+	return nil, errors.New("not implemented for read-only route")
+}
+
+func (item *APICommitQueueItem) BuildFromService(h interface{}) error {
+	cqItemService, ok := h.(commitqueue.CommitQueueItem)
+	if !ok {
+		return errors.Errorf("incorrect type '%T' when converting commit queue item", h)
+	}
+	item.Issue = ToAPIString(cqItemService.Issue)
+	for _, module := range cqItemService.Modules {
+		item.Modules = append(item.Modules, APIModule{
+			Module: ToAPIString(module.Module),
+			Issue:  ToAPIString(module.Issue),
+		})
+	}
+
+	return nil
+}
+
+func (item *APICommitQueueItem) ToService() (interface{}, error) {
 	return nil, errors.New("not implemented for read-only route")
 }

--- a/rest/model/commit_queue.go
+++ b/rest/model/commit_queue.go
@@ -77,18 +77,13 @@ func (item *APICommitQueueItem) ToService() (interface{}, error) {
 func ParseGitHubCommentModules(comment string) []APIModule {
 	modules := []APIModule{}
 
-	r := regexp.MustCompile(`^evergreen merge.+(?P<modules>(--modules|-m)\s+\[\w+:\d+(\s*,\s*\w+:\d+)*\]).*$`)
-	if !r.MatchString(comment) {
-		return modules
-	}
-	moduleSubstring := r.FindStringSubmatch(comment)[1]
-	moduleRegexp := regexp.MustCompile(`(\w+):(\d+)`)
-	moduleMatches := moduleRegexp.FindAllStringSubmatch(moduleSubstring, -1)
+	r := regexp.MustCompile(`(?:--module|-m)\s+(\w+):(\d+)`)
+	moduleSlices := r.FindAllStringSubmatch(comment, -1)
 
-	for _, match := range moduleMatches {
+	for _, moduleSlice := range moduleSlices {
 		modules = append(modules, APIModule{
-			Module: ToAPIString(match[1]),
-			Issue:  ToAPIString(match[2]),
+			Module: ToAPIString(moduleSlice[1]),
+			Issue:  ToAPIString(moduleSlice[2]),
 		})
 	}
 

--- a/rest/model/commit_queue_test.go
+++ b/rest/model/commit_queue_test.go
@@ -11,13 +11,32 @@ func TestCommitQueueBuildFromService(t *testing.T) {
 	assert := assert.New(t)
 	cq := commitqueue.CommitQueue{
 		ProjectID: "mci",
-		Queue:     []string{"1", "2", "3"},
+		Queue: []commitqueue.CommitQueueItem{
+			commitqueue.CommitQueueItem{
+				Issue: "1",
+				Modules: []commitqueue.Module{
+					commitqueue.Module{
+						Module: "test_module",
+						Issue:  "2",
+					},
+				},
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "2",
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "3",
+			},
+		},
 	}
 
 	cqAPI := APICommitQueue{}
 	assert.NoError(cqAPI.BuildFromService(cq))
 	assert.Equal(cq.ProjectID, FromAPIString(cqAPI.ProjectID))
-	for i, item := range cq.Queue {
-		assert.Equal(item, FromAPIString(cqAPI.Queue[i]))
+	assert.Equal(len(cqAPI.Queue), len(cq.Queue))
+	for i := range cq.Queue {
+		assert.Equal(cq.Queue[i].Issue, FromAPIString(cqAPI.Queue[i].Issue))
 	}
+	assert.Equal(cq.Queue[0].Modules[0].Module, FromAPIString(cqAPI.Queue[0].Modules[0].Module))
+	assert.Equal(cq.Queue[0].Modules[0].Issue, FromAPIString(cqAPI.Queue[0].Modules[0].Issue))
 }

--- a/rest/model/commit_queue_test.go
+++ b/rest/model/commit_queue_test.go
@@ -40,3 +40,41 @@ func TestCommitQueueBuildFromService(t *testing.T) {
 	assert.Equal(cq.Queue[0].Modules[0].Module, FromAPIString(cqAPI.Queue[0].Modules[0].Module))
 	assert.Equal(cq.Queue[0].Modules[0].Issue, FromAPIString(cqAPI.Queue[0].Modules[0].Issue))
 }
+
+func TestParseGitHubCommentModules(t *testing.T) {
+	assert := assert.New(t)
+
+	comment := "evergreen merge"
+	modules := ParseGitHubCommentModules(comment)
+	assert.Len(modules, 0)
+
+	comment = "evergreen merge --unknown-option blah_blah"
+	modules = ParseGitHubCommentModules(comment)
+	assert.Len(modules, 0)
+
+	comment = "evergreen merge --unknown-option blah_blah --modules [module1:1234]"
+	modules = ParseGitHubCommentModules(comment)
+	assert.Len(modules, 1)
+	assert.Equal(ToAPIString("module1"), modules[0].Module)
+	assert.Equal(ToAPIString("1234"), modules[0].Issue)
+
+	comment = "evergreen merge --modules [module1:1234 , module2:3456,module3:5678]"
+	modules = ParseGitHubCommentModules(comment)
+	assert.Len(modules, 3)
+	assert.Equal(ToAPIString("module1"), modules[0].Module)
+	assert.Equal(ToAPIString("1234"), modules[0].Issue)
+	assert.Equal(ToAPIString("module2"), modules[1].Module)
+	assert.Equal(ToAPIString("3456"), modules[1].Issue)
+	assert.Equal(ToAPIString("module3"), modules[2].Module)
+	assert.Equal(ToAPIString("5678"), modules[2].Issue)
+
+	comment = "evergreen merge -m [module1:1234]"
+	modules = ParseGitHubCommentModules(comment)
+	assert.Len(modules, 1)
+	assert.Equal(ToAPIString("module1"), modules[0].Module)
+	assert.Equal(ToAPIString("1234"), modules[0].Issue)
+
+	comment = "evergreen merge -m []"
+	modules = ParseGitHubCommentModules(comment)
+	assert.Len(modules, 0)
+}

--- a/rest/model/commit_queue_test.go
+++ b/rest/model/commit_queue_test.go
@@ -52,13 +52,13 @@ func TestParseGitHubCommentModules(t *testing.T) {
 	modules = ParseGitHubCommentModules(comment)
 	assert.Len(modules, 0)
 
-	comment = "evergreen merge --unknown-option blah_blah --modules [module1:1234]"
+	comment = "evergreen merge --unknown-option blah_blah --module module1:1234"
 	modules = ParseGitHubCommentModules(comment)
 	assert.Len(modules, 1)
 	assert.Equal(ToAPIString("module1"), modules[0].Module)
 	assert.Equal(ToAPIString("1234"), modules[0].Issue)
 
-	comment = "evergreen merge --modules [module1:1234 , module2:3456,module3:5678]"
+	comment = "evergreen merge --module module1:1234 -m  module2:3456 --module module3:5678"
 	modules = ParseGitHubCommentModules(comment)
 	assert.Len(modules, 3)
 	assert.Equal(ToAPIString("module1"), modules[0].Module)
@@ -68,13 +68,13 @@ func TestParseGitHubCommentModules(t *testing.T) {
 	assert.Equal(ToAPIString("module3"), modules[2].Module)
 	assert.Equal(ToAPIString("5678"), modules[2].Issue)
 
-	comment = "evergreen merge -m [module1:1234]"
+	comment = "evergreen merge -m module1:1234"
 	modules = ParseGitHubCommentModules(comment)
 	assert.Len(modules, 1)
 	assert.Equal(ToAPIString("module1"), modules[0].Module)
 	assert.Equal(ToAPIString("1234"), modules[0].Issue)
 
-	comment = "evergreen merge -m []"
+	comment = "evergreen merge -m"
 	modules = ParseGitHubCommentModules(comment)
 	assert.Len(modules, 0)
 }

--- a/rest/route/commit_queue_test.go
+++ b/rest/route/commit_queue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/stretchr/testify/suite"
@@ -28,21 +29,46 @@ func (s *CommitQueueSuite) SetupTest() {
 func (s *CommitQueueSuite) TestGetCommitQueue() {
 	route := makeGetCommitQueueItems(s.sc).(*commitQueueGetHandler)
 	route.project = "evergreen-ci.evergreen.master"
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", "1"))
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", "2"))
+	s.NoError(s.sc.EnqueueItem(
+		"evergreen-ci",
+		"evergreen",
+		"master",
+		commitqueue.CommitQueueItem{
+			Issue: "1",
+			Modules: []commitqueue.Module{
+				commitqueue.Module{
+					Module: "test_module",
+					Issue:  "1234",
+				},
+			},
+		}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "2"}))
 
 	response := route.Run(context.Background())
 	s.Equal(200, response.Status())
 	s.Equal(&model.APICommitQueue{
 		ProjectID: model.ToAPIString("evergreen-ci.evergreen.master"),
-		Queue:     []model.APIString{model.ToAPIString("1"), model.ToAPIString("2")},
+		Queue: []model.APICommitQueueItem{
+			model.APICommitQueueItem{
+				Issue: model.ToAPIString("1"),
+				Modules: []model.APIModule{
+					model.APIModule{
+						Module: model.ToAPIString("test_module"),
+						Issue:  model.ToAPIString("1234"),
+					},
+				},
+			},
+			model.APICommitQueueItem{
+				Issue: model.ToAPIString("2"),
+			},
+		},
 	}, response.Data())
 }
 
 func (s *CommitQueueSuite) TestDeleteItem() {
 	route := makeDeleteCommitQueueItems(s.sc).(*commitQueueDeleteItemHandler)
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", "1"))
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", "2"))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1"}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "2"}))
 	route.project = "evergreen-ci.evergreen.master"
 
 	// Valid delete
@@ -63,10 +89,10 @@ func (s *CommitQueueSuite) TestDeleteItem() {
 
 func (s *CommitQueueSuite) TestClearAll() {
 	route := makeClearCommitQueuesHandler(s.sc).(*commitQueueClearAllHandler)
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", "12"))
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", "23"))
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "logkeeper", "master", "45"))
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "logkeeper", "master", "56"))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "12"}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "23"}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "logkeeper", "master", commitqueue.CommitQueueItem{Issue: "34"}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "logkeeper", "master", commitqueue.CommitQueueItem{Issue: "45"}))
 
 	response := route.Run(context.Background())
 	s.Equal(200, response.Status())

--- a/rest/route/commit_queue_test.go
+++ b/rest/route/commit_queue_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/stretchr/testify/suite"
@@ -33,16 +32,16 @@ func (s *CommitQueueSuite) TestGetCommitQueue() {
 		"evergreen-ci",
 		"evergreen",
 		"master",
-		commitqueue.CommitQueueItem{
-			Issue: "1",
-			Modules: []commitqueue.Module{
-				commitqueue.Module{
-					Module: "test_module",
-					Issue:  "1234",
+		model.APICommitQueueItem{
+			Issue: model.ToAPIString("1"),
+			Modules: []model.APIModule{
+				model.APIModule{
+					Module: model.ToAPIString("test_module"),
+					Issue:  model.ToAPIString("1234"),
 				},
 			},
 		}))
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "2"}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", model.APICommitQueueItem{Issue: model.ToAPIString("2")}))
 
 	response := route.Run(context.Background())
 	s.Equal(200, response.Status())
@@ -67,8 +66,8 @@ func (s *CommitQueueSuite) TestGetCommitQueue() {
 
 func (s *CommitQueueSuite) TestDeleteItem() {
 	route := makeDeleteCommitQueueItems(s.sc).(*commitQueueDeleteItemHandler)
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "1"}))
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "2"}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", model.APICommitQueueItem{Issue: model.ToAPIString("1")}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", model.APICommitQueueItem{Issue: model.ToAPIString("2")}))
 	route.project = "evergreen-ci.evergreen.master"
 
 	// Valid delete
@@ -89,10 +88,10 @@ func (s *CommitQueueSuite) TestDeleteItem() {
 
 func (s *CommitQueueSuite) TestClearAll() {
 	route := makeClearCommitQueuesHandler(s.sc).(*commitQueueClearAllHandler)
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "12"}))
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", commitqueue.CommitQueueItem{Issue: "23"}))
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "logkeeper", "master", commitqueue.CommitQueueItem{Issue: "34"}))
-	s.NoError(s.sc.EnqueueItem("evergreen-ci", "logkeeper", "master", commitqueue.CommitQueueItem{Issue: "45"}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", model.APICommitQueueItem{Issue: model.ToAPIString("12")}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "evergreen", "master", model.APICommitQueueItem{Issue: model.ToAPIString("23")}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "logkeeper", "master", model.APICommitQueueItem{Issue: model.ToAPIString("34")}))
+	s.NoError(s.sc.EnqueueItem("evergreen-ci", "logkeeper", "master", model.APICommitQueueItem{Issue: model.ToAPIString("45")}))
 
 	response := route.Run(context.Background())
 	s.Equal(200, response.Status())

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -76,7 +76,7 @@ func (s *GithubWebhookRouteSuite) SetupTest() {
 	s.Len(s.pushBody, 7603)
 	s.commentBody, err = ioutil.ReadFile(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "comment_event.json"))
 	s.NoError(err)
-	s.Len(s.commentBody, 11470)
+	s.Len(s.commentBody, 11534)
 
 	var ok bool
 	s.h, ok = s.rm.Factory().(*githubHookApi)

--- a/rest/route/testdata/comment_event.json
+++ b/rest/route/testdata/comment_event.json
@@ -79,7 +79,7 @@
     "created_at": "2018-12-05T21:16:34Z",
     "updated_at": "2018-12-05T21:16:34Z",
     "author_association": "CONTRIBUTOR",
-    "body": "evergreen merge"
+    "body": "evergreen merge {\"modules\":[{\"module\":\"test_module\",\"issue\":\"1234\"}]}"
   },
   "repository": {
     "id": 35129377,

--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -134,3 +134,38 @@ func GetPatchSummaries(patchContent string) ([]patch.Summary, error) {
 	}
 	return summaries, nil
 }
+
+func ParseGitUrl(url string) (string, string, error) {
+	var owner, repo string
+	httpsPrefix := "https://"
+	if strings.HasPrefix(url, httpsPrefix) {
+		url = strings.TrimPrefix(url, httpsPrefix)
+		split := strings.Split(url, "/")
+		if len(split) != 3 {
+			return owner, repo, errors.Errorf("Invalid Git URL format '%s'", url)
+		}
+		owner = split[1]
+		splitRepo := strings.Split(split[2], ".")
+		if len(splitRepo) != 2 {
+			return owner, repo, errors.Errorf("Invalid Git URL format '%s'", url)
+		}
+		repo = splitRepo[0]
+	} else {
+		splitModule := strings.Split(url, ":")
+		if len(splitModule) != 2 {
+			return owner, repo, errors.Errorf("Invalid Git URL format '%s'", url)
+		}
+		splitOwner := strings.Split(splitModule[1], "/")
+		if len(splitOwner) != 2 {
+			return owner, repo, errors.Errorf("Invalid Git URL format '%s'", url)
+		}
+		owner = splitOwner[0]
+		splitRepo := strings.Split(splitOwner[1], ".")
+		if len(splitRepo) != 2 {
+			return owner, repo, errors.Errorf("Invalid Git URL format '%s'", url)
+		}
+		repo = splitRepo[0]
+	}
+
+	return owner, repo, nil
+}

--- a/thirdparty/git_test.go
+++ b/thirdparty/git_test.go
@@ -59,3 +59,31 @@ func TestGetPatchSummaries(t *testing.T) {
 	assert.Equal(0, summaries[2].Additions)
 	assert.Equal(0, summaries[2].Deletions)
 }
+
+func TestParseGitUrl(t *testing.T) {
+	assert := assert.New(t)
+
+	httpsUrl := "https://github.com/evergreen-ci/sample.git"
+	owner, repo, err := ParseGitUrl(httpsUrl)
+	assert.NoError(err)
+	assert.Equal("evergreen-ci", owner)
+	assert.Equal("sample", repo)
+
+	httpsUrl = "https://github.com/sample.git"
+	owner, repo, err = ParseGitUrl(httpsUrl)
+	assert.Error(err)
+	assert.Equal("", owner)
+	assert.Equal("", repo)
+
+	sshUrl := "git@github.com:evergreen-ci/sample.git"
+	owner, repo, err = ParseGitUrl(sshUrl)
+	assert.NoError(err)
+	assert.Equal("evergreen-ci", owner)
+	assert.Equal("sample", repo)
+
+	sshUrl = "git@github.com:evergreen-ci/sample"
+	owner, repo, err = ParseGitUrl(sshUrl)
+	assert.Error(err)
+	assert.Equal("evergreen-ci", owner)
+	assert.Equal("", repo)
+}

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -195,10 +195,10 @@ func (j *commitQueueJob) logError(err error, msg string, item *commitqueue.Commi
 	}
 	j.AddError(errors.Wrap(err, msg))
 	grip.Error(message.WrapError(err, message.Fields{
-		"job":     commitQueueJobName,
+		"job_id":  j.ID(),
 		"source":  "commit queue",
 		"project": j.QueueID,
-		"item":    *item,
+		"item":    item,
 		"message": msg,
 	}))
 }

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -67,11 +67,19 @@ func (s *commitQueueSuite) SetupTest() {
 
 	cq := &commitqueue.CommitQueue{
 		ProjectID: "mci",
-		Queue: []string{
-			"1",
-			"2",
-			"3",
-			"4",
+		Queue: []commitqueue.CommitQueueItem{
+			commitqueue.CommitQueueItem{
+				Issue: "1",
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "2",
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "3",
+			},
+			commitqueue.CommitQueueItem{
+				Issue: "4",
+			},
 		},
 	}
 	s.Require().NoError(commitqueue.InsertQueue(cq))
@@ -96,7 +104,7 @@ func (s *commitQueueSuite) TestValidatePR() {
 
 func (s *commitQueueSuite) TestSubscribeMerge() {
 	s.NoError(db.ClearCollections(event.SubscriptionsCollection))
-	s.NoError(subscribeMerge(s.projectRef, s.pr, "abcdef"))
+	s.NoError(subscribeMerge(s.projectRef.Identifier, s.projectRef.Owner, s.projectRef.Repo, "squash", "abcdef", s.pr))
 
 	selectors := []event.Selector{
 		event.Selector{
@@ -112,7 +120,6 @@ func (s *commitQueueSuite) TestSubscribeMerge() {
 
 	s.Equal(event.GithubMergeSubscriberType, subscription.Subscriber.Type)
 	s.Equal(event.ResourceTypePatch, subscription.ResourceType)
-	s.Equal(event.GithubMergeSubscriberType, subscription.Subscriber.Type)
 	target, ok := subscription.Subscriber.Target.(*event.GithubMergeSubscriber)
 	s.True(ok)
 	s.Equal(s.projectRef.Identifier, target.ProjectID)


### PR DESCRIPTION
Support adding a module patch to commit queue tests. "Patches" in this case are in the form of PRs against module repos.

To include a module PR with the main PR add a json doc to the evergreen merge comment. For example: `evergreen merge {"modules":[{"module":"test_module", "issue":"1234"}]}` where _1234_ is the PR number of the module _test_module_. Patches cannot be added after the `evergreen merge` comment is already started since commit queue patches are immediately finalized.

All PRs are checked out in the patch created to test the merge (the module PRs are checked out in the directories specified for the module in the config file). If the patch succeeds the main PR and all the module PRs are merged.