### PR TITLE
EVG-5771: Enable GitHub webhooks automatically

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -19,7 +19,6 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
   $scope.modalOpen = false;
   $scope.newProject = {};
   $scope.newProjectMessage="";
-  $scope.NewBlankProject = false;
 
   $scope.repoChanged = false;
   $scope.repoChange = function() {
@@ -241,7 +240,6 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
           $scope.loadProject(data.ProjectId);
           $scope.newProject = {};
           $scope.settingsFormData.tracks_push_events = true;
-          $scope.NewBlankProject = true;
         },
         function(resp){
           console.log("error creating project: " + resp.status);
@@ -423,7 +421,6 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
         $scope.settingsFormData.force_repotracker_run = false;
         $scope.loadProject($scope.settingsFormData.identifier)
         $scope.isDirty = false;
-        $scope.NewBlankProject = false;
       },
       function(resp) {
         $scope.saveMessage = "Couldn't save project: " + resp.data.error;

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -19,6 +19,7 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
   $scope.modalOpen = false;
   $scope.newProject = {};
   $scope.newProjectMessage="";
+  $scope.NewBlankProject = false;
 
   $scope.repoChanged = false;
   $scope.repoChange = function() {

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -240,6 +240,7 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
           $scope.loadProject(data.ProjectId);
           $scope.newProject = {};
           $scope.settingsFormData.tracks_push_events = true;
+          $scope.NewBlankProject = true;
         },
         function(resp){
           console.log("error creating project: " + resp.status);
@@ -421,6 +422,7 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
         $scope.settingsFormData.force_repotracker_run = false;
         $scope.loadProject($scope.settingsFormData.identifier)
         $scope.isDirty = false;
+        $scope.NewBlankProject = false;
       },
       function(resp) {
         $scope.saveMessage = "Couldn't save project: " + resp.data.error;

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -214,7 +214,6 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
         function(resp) {
           var data_put = resp.data;
           item = Object.assign({}, $scope.settingsFormData);
-          item.setup_github_hook = false;
           item.pr_testing_enabled = false;
           item.commit_queue.enabled = false;
           item.enabled = false;
@@ -240,7 +239,6 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
           $scope.refreshTrackedProjects(data.AllProjects);
           $scope.loadProject(data.ProjectId);
           $scope.newProject = {};
-          $scope.settingsFormData.setup_github_hook = true;
           $scope.settingsFormData.tracks_push_events = true;
         },
         function(resp){
@@ -263,7 +261,7 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
         }
         $scope.projectVars = data.ProjectVars.vars || {};
         $scope.privateVars = data.ProjectVars.private_vars || {};
-        $scope.githubHookID = data.github_hook.hook_id || 0;
+        $scope.github_webhooks_enabled = data.github_webhooks_enabled;
         $scope.prTestingConflicts = data.pr_testing_conflicting_refs || [];
         $scope.prTestingEnabled = data.ProjectRef.pr_testing_enabled || false;
         $scope.commitQueueConflicts = data.commit_queue_conflicting_refs || [];
@@ -298,7 +296,6 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
           alert_config: $scope.projectRef.alert_config || {},
           repotracker_error: $scope.projectRef.repotracker_error || {},
           admins : $scope.projectRef.admins || [],
-          setup_github_hook: $scope.githubHookID != 0,
           tracks_push_events: data.ProjectRef.tracks_push_events || false,
           pr_testing_enabled: data.ProjectRef.pr_testing_enabled || false,
           commit_queue: data.ProjectRef.commit_queue || {},

--- a/service/project.go
+++ b/service/project.go
@@ -261,9 +261,9 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				"owner":   responseRef.Owner,
 				"repo":    responseRef.Repo,
 			}))
-			// don't kill it here, sometimes people change
-			// Evergreen to track a personal branch,
-			// one that we have no access to
+			// don't return here:
+			// sometimes people change a project to track a personal
+			// branch we don't have access to
 			projectRef.TracksPushEvents = false
 		} else {
 			hook := model.GithubHook{
@@ -275,9 +275,9 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				// A github hook as been created, but we couldn't
 				// save the hook ID in our database. This needs
 				// manual attention for clean up
-				grip.Alert(message.WrapError(err, message.Fields{
+				grip.Error(message.WrapError(err, message.Fields{
 					"source":  "project edit",
-					"message": "can't save hook",
+					"message": "can't save hook to db",
 					"project": id,
 					"owner":   responseRef.Owner,
 					"repo":    responseRef.Repo,

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -217,7 +217,7 @@ Evergreen Projects
               <div class="muted small">When checked, tasks from previous revisions will be unscheduled when the equivalent task in a newer commit finishes successfully.</div>
             </div>
           </div>
-          <div ng-show="githubHookID !== 0">
+          <div ng-show="$scope.github_webhooks_enabled">
             <div class="h3">Repotracker Settings</div>
             <div class="form-group">
                 <div class="col-lg-5 col-header">
@@ -235,7 +235,7 @@ Evergreen Projects
                     </div>
                 </div>
                 <br />
-                <div class="col-lg-8 col-header" ng-show="githubHookID !== 0">
+                <div class="col-lg-8 col-header">
                   <label class="control-label">Force run Repotracker on Save&nbsp;&nbsp;
                     <input type="checkbox" name="force_repotracker_run" ng-model="settingsFormData.force_repotracker_run" ng-checked="repoChanged" />
                   </label>
@@ -296,24 +296,17 @@ Evergreen Projects
           </div>
         </div>
 
-        <div class="variables" ng-show="isSuperUser">
+        <div class="variables">
           <div class="form-group">
-            <div class="col-header col-lg-6 form-control-static"> <h3> GitHub Webhook Installation </h3>
-                <div class="muted small" ng-show="githubHookID === 0">Github webhooks have not been enabled for this repository. In order to use Github Pull Request testing and the commit queue, tick the box below, and save the project to set up the webhook in this
-                repository.</div>
-                <div class="muted small" ng-show="githubHookID !== 0">Github webhooks are enabled!</div>
-            </div>
-          </div>
-
-          <div id="patch-variants-list" class="form-group">
-            <div class="col-lg-6">
-                <input type="checkbox" id="githubhook-checkbox" ng-disabled="githubHookID !== 0" ng-model="settingsFormData.setup_github_hook" />
-                <label for="githubhook-checkbox">Enable Github Webhooks</label>
+            <div class="col-header col-lg-6 form-control-static"> <h3> GitHub Webhooks </h3>
+                <div>
+                  [[ $scope.github_webhooks_enabled ? 'GitHub webhooks are enabled!' : 'GitHub webhooks have not been enabled for this repository. GitHub Pull Request testing and the commit queue are disabled' ]]
+                </div>
             </div>
           </div>
         </div>
 
-        <div class="variables" ng-show="githubHookID !== 0">
+        <div class="variables" ng-show="$scope.github_webhooks_enabled">
           <div class="form-group">
             <div class="col-header col-lg-6 form-control-static"> <h3> GitHub Pull Request Testing</h3> </div>
           </div>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -302,10 +302,13 @@ Evergreen Projects
                 <div ng-show="scope.github_webhooks_enabled">
                   GitHub webhooks are enabled.
                 </div>
-                <div class="project-error" ng-show="!scope.github_webhooks_enabled">
+                <div class="project-error" ng-show="!scope.github_webhooks_enabled && !scope.NewBlankProject">
                   <div>GitHub webhooks can not be enabled for this repository. GitHub Pull Request testing and the commit queue are disabled.</div>
                   <div>Please contact an administrator.</div>
                 </div>
+                <div class="project-error" ng-show="scope.NewBlankProject">
+                    <div>Set owner/repo combination and save to enable GitHub webhooks</div>
+                  </div>
             </div>
           </div>
         </div>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -302,13 +302,9 @@ Evergreen Projects
                 <div ng-show="scope.github_webhooks_enabled">
                   GitHub webhooks are enabled.
                 </div>
-                <div class="project-error" ng-show="!scope.github_webhooks_enabled && !scope.NewBlankProject">
-                  <div>GitHub webhooks cannot be enabled for this repository. GitHub Pull Request testing and the commit queue are disabled.</div>
-                  <div>Please contact an administrator.</div>
+                <div class="project-error" ng-show="!scope.github_webhooks_enabled">
+                  <div>GitHub Pull Request testing and the commit queue are disabled because web hooks are not enabled. Web hooks are enabled after saving with a repository and branch.</div>
                 </div>
-                <div class="project-error" ng-show="scope.NewBlankProject">
-                    <div>Set owner/repo combination and save to enable GitHub webhooks</div>
-                  </div>
             </div>
           </div>
         </div>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -299,8 +299,12 @@ Evergreen Projects
         <div class="variables">
           <div class="form-group">
             <div class="col-header col-lg-6 form-control-static"> <h3> GitHub Webhooks </h3>
-                <div>
-                  [[ $scope.github_webhooks_enabled ? 'GitHub webhooks are enabled!' : 'GitHub webhooks have not been enabled for this repository. GitHub Pull Request testing and the commit queue are disabled' ]]
+                <div ng-show="scope.github_webhooks_enabled">
+                  GitHub webhooks are enabled.
+                </div>
+                <div class="project-error" ng-show="!scope.github_webhooks_enabled">
+                  <div>GitHub webhooks can not be enabled for this repository. GitHub Pull Request testing and the commit queue are disabled.</div>
+                  <div>Please contact an administrator.</div>
                 </div>
             </div>
           </div>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -303,7 +303,7 @@ Evergreen Projects
                   GitHub webhooks are enabled.
                 </div>
                 <div class="project-error" ng-show="!scope.github_webhooks_enabled && !scope.NewBlankProject">
-                  <div>GitHub webhooks can not be enabled for this repository. GitHub Pull Request testing and the commit queue are disabled.</div>
+                  <div>GitHub webhooks cannot be enabled for this repository. GitHub Pull Request testing and the commit queue are disabled.</div>
                   <div>Please contact an administrator.</div>
                 </div>
                 <div class="project-error" ng-show="scope.NewBlankProject">


### PR DESCRIPTION
There was a checkbox on the projects page to enable webhooks for a repository (owner/repo pair). 

Since we almost always want webhooks (to support PR testing and commit queue) this PR is to enable it by default on save, and to display just the status on the projects page.