### PR TITLE
EVG-5785: Return an empty response for a build with no tasks

### DIFF
--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -56,19 +56,6 @@ func (tc *DBTaskConnector) FindTasksByBuildId(buildId, taskId, status string, li
 	if err != nil {
 		return []task.Task{}, err
 	}
-	if len(res) == 0 {
-		var message string
-		if status != "" {
-			message = fmt.Sprintf("tasks from build '%s' with status '%s' "+
-				"not found", buildId, status)
-		} else {
-			message = fmt.Sprintf("tasks from build '%s' not found", buildId)
-		}
-		return []task.Task{}, gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    message,
-		}
-	}
 
 	if taskId != "" {
 		found := false

--- a/rest/data/task_test.go
+++ b/rest/data/task_test.go
@@ -242,13 +242,8 @@ func (s *TaskConnectorFetchByBuildSuite) TestFindFromMiddleTaskFail() {
 
 func (s *TaskConnectorFetchByBuildSuite) TestFindFromMiddleBuildFail() {
 	foundTests, err := s.ctx.FindTasksByBuildId("fake_build", "", "", 0, 1)
-	s.Error(err)
+	s.NoError(err)
 	s.Equal(0, len(foundTests))
-
-	s.IsType(gimlet.ErrorResponse{}, err)
-	apiErr, ok := err.(gimlet.ErrorResponse)
-	s.True(ok)
-	s.Equal(http.StatusNotFound, apiErr.StatusCode)
 }
 func (s *TaskConnectorFetchByBuildSuite) TestFindEmptyTaskId() {
 	buildId := "build_0"


### PR DESCRIPTION
Used to return a 404, which is appropriate if the client asks for a specific task but not when the user asks for an empty list 