### PR TITLE
EVG-5843: Add sort to tasks for build aggregation

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -10,7 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/pkg/errors"
-	"gopkg.in/mgo.v2"
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -509,6 +509,10 @@ func TasksByBuildIdPipeline(buildId, taskId, taskStatus string,
 			IdKey:      bson.M{sortOperator: taskId},
 		}},
 	}
+
+	// sort the tasks before limiting to get the next [limit] tasks
+	pipeline = append(pipeline, bson.M{"$sort": bson.M{IdKey: sortDir}})
+
 	if taskStatus != "" {
 		statusMatch := bson.M{
 			"$match": bson.M{StatusKey: taskStatus},

--- a/rest/data/task_test.go
+++ b/rest/data/task_test.go
@@ -202,9 +202,11 @@ func (s *TaskConnectorFetchByBuildSuite) TestFindByBuildAndStatus() {
 
 			s.Equal((s.numTasks-startAt)-i*sort, len(foundTasks))
 			for ix, t := range foundTasks {
-				index := ix
+				var index int
 				if sort > 0 {
-					index += i
+					index = i + ix
+				} else {
+					index = (len(foundTasks) - 1) - ix
 				}
 				s.Equal(tids[index], t.Id)
 			}


### PR DESCRIPTION
Pagination is done by taking the next _limit_ number of tasks greater than or equal to the key provided and giving a key for the next page as the _limit+1_ task. If the tasks are not sorted the _limit+1_ task will likely not be the correct key.

Deploying this will require replacing the build_id index on the database with a composite index of build_id and _id so the match/sort stages can be done efficiently.