### PR TITLE
EVG-5848: Check for Old Tasks

### DIFF
--- a/model/context.go
+++ b/model/context.go
@@ -87,7 +87,7 @@ func (ctx *Context) populateTaskBuildVersion(taskId, buildId, versionId string) 
 	// Fetch task if there's a task ID present; if we find one, populate build/version IDs from it
 	if len(taskId) > 0 {
 		ctx.Task, err = task.FindOne(task.ById(taskId))
-		if err != nil {
+		if err != nil || ctx.Task == nil {
 			// if no task found, see if this is an old task
 			var tasks []task.Task
 			tasks, err = task.FindOld(task.ById(taskId))


### PR DESCRIPTION
The context was not getting populated with tasks that had been archived as long as the query for a non-archived task was successful (even if it returned nil) since mgo.ErrNotFound was caught and handled further down the call stack. Therefore it was impossible to get the task page for an archived task.
When a user would click a link for an archived task (such as an execution task) they would get a 404.