### PR TITLE
EVG-5848: display task links

### DIFF
--- a/model/context.go
+++ b/model/context.go
@@ -87,7 +87,7 @@ func (ctx *Context) populateTaskBuildVersion(taskId, buildId, versionId string) 
 	// Fetch task if there's a task ID present; if we find one, populate build/version IDs from it
 	if len(taskId) > 0 {
 		ctx.Task, err = task.FindOne(task.ById(taskId))
-		if err != nil {
+		if err != nil || ctx.Task == nil {
 			// if no task found, see if this is an old task
 			var tasks []task.Task
 			tasks, err = task.FindOld(task.ById(taskId))

--- a/service/task.go
+++ b/service/task.go
@@ -176,6 +176,8 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 			uis.LoggedError(w, r, http.StatusNotFound, errors.New("Error finding task or execution"))
 			return
 		}
+	} else {
+		execution = projCtx.Task.Execution
 	}
 
 	// Build a struct containing the subset of task data needed for display in the UI


### PR DESCRIPTION
Additional fix for display task links. This fixes the case where an execution number is not provided in the URL (to show the latest execution).
Reference PR #2072. This PR is to add commit 287baf3.