### PR TITLE
EVG-5785: remove check for empty response

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -114,7 +114,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: 484dad3e7eb8f9823afa861b35ba643208df9136
   - name: github.com/evergreen-ci/gimlet
-    version: e4d488310cb0e4e016efa9e5552a2d34861b8094
+    version: 73add5f53c69eec63e51ce885177067f6d25bd10
   - name: github.com/evergreen-ci/shrub
     version: 32e668cd99410328bf6659e55671c11a6c727d9a
   - name: github.com/evergreen-ci/pail

--- a/rest/route/task.go
+++ b/rest/route/task.go
@@ -189,17 +189,6 @@ func (h *projectTaskGetHandler) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 
-	// Consistent response regardless data existence
-	respData := resp.Data()
-	switch d := respData.(type) {
-	case []interface{}:
-		if len(d) == 0 {
-			// make([]int, 0) is used to force searilization of empty array as [] in JSON
-			// Type (`int`) doesn't matter and could be any, since the array is empty
-			return gimlet.NewJSONResponse(make([]int, 0))
-		}
-	}
-
 	return resp
 }
 

--- a/vendor/github.com/evergreen-ci/gimlet/framework_response.go
+++ b/vendor/github.com/evergreen-ci/gimlet/framework_response.go
@@ -74,6 +74,7 @@ func NewResponseBuilder() Responder {
 	return &responseBuilder{
 		status: http.StatusOK,
 		format: JSON,
+		data:   []interface{}{},
 	}
 }
 
@@ -110,7 +111,7 @@ func (r *responseBuilder) Pages() *ResponsePages { return r.pages }
 
 func (r *responseBuilder) AddData(d interface{}) error {
 	if d == nil {
-		return errors.New("cannot  data to responder")
+		return errors.New("cannot add nil data to responder")
 	}
 
 	r.data = append(r.data, d)


### PR DESCRIPTION
Companion to gimlet PR 23 (https://github.com/evergreen-ci/gimlet/pull/23).
The error handling here is no longer necessary.