### PR TITLE
EVG-5824 stop displaying '(removed)' on variants

### DIFF
--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -155,15 +155,14 @@ func (vc *DBVersionConnector) GetVersionsAndVariants(skip, numVersionElements in
 			for _, b := range buildsInVersion {
 				displayName := buildVariantMappings[b.BuildVariant]
 				if displayName == "" {
-					displayName = b.BuildVariant + " (removed)"
+					displayName = b.BuildVariant
 				}
 				buildVariants = append(buildVariants, displayName)
 
 				buildVariant := buildVariantMappings[b.BuildVariant]
 
 				if buildVariant == "" {
-					buildVariant = b.BuildVariant +
-						" (removed)"
+					buildVariant = b.BuildVariant
 				}
 
 				if _, ok := buildList[b.BuildVariant]; !ok {

--- a/service/waterfall.go
+++ b/service/waterfall.go
@@ -262,8 +262,7 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 				}
 
 				if buildVariant.DisplayName == "" {
-					buildVariant.DisplayName = b.BuildVariant +
-						" (removed)"
+					buildVariant.DisplayName = b.BuildVariant
 				}
 
 				// The version is marked active if there are any
@@ -401,7 +400,7 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 	for name := range bvSet {
 		displayName := buildVariantMappings[name]
 		if displayName == "" {
-			displayName = name + " (removed)"
+			displayName = name
 		}
 		buildVariants = append(buildVariants, waterfallBuildVariant{Id: name, DisplayName: displayName})
 	}
@@ -519,7 +518,7 @@ func countOnPreviousPage(skip int, numVersionElements int, project *model.Projec
 					bvDisplayName := buildVariantMappings[b.BuildVariant]
 
 					if bvDisplayName == "" {
-						bvDisplayName = b.BuildVariant + " (removed)"
+						bvDisplayName = b.BuildVariant
 					}
 
 					// When versions is active and variane query matches


### PR DESCRIPTION
My initial plan was to more rigorously differentiate between triggered builds, but that went down a rabbit hole of lots of changes so I'm just going to do this for the waterfall