### PR TITLE
EVG-5857: add diff to commit queue patches

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -370,6 +370,9 @@ func MakeMergePatch(pr *github.PullRequest, projectID, alias string) (*Patch, er
 		GithubPatchData: GithubPatch{
 			PRNumber:       pr.GetNumber(),
 			MergeCommitSHA: pr.GetMergeCommitSHA(),
+			BaseOwner:      pr.Base.User.GetLogin(),
+			BaseRepo:       pr.Base.Repo.GetName(),
+			BaseBranch:     pr.Base.GetRef(),
 		},
 	}
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -673,7 +673,7 @@ func GetGithubPullRequest(ctx context.Context, token, baseOwner, baseRepo string
 
 // GetGithubDiff downloads a diff from a Github Pull Request diff. This function
 // does not use go-github because this operation is not supported
-func GetGithubPullRequestDiff(ctx context.Context, token string, gh *patch.GithubPatch) (string, []patch.Summary, error) {
+func GetGithubPullRequestDiff(ctx context.Context, token string, gh patch.GithubPatch) (string, []patch.Summary, error) {
 	all := rehttp.RetryAll(rehttp.RetryMaxRetries(NumGithubRetries-1), githubShouldRetryWith404s)
 	client, err := util.GetRetryableOauth2HTTPClient(token, all, util.RehttpDelay(GithubSleepTimeSecs, NumGithubRetries))
 	if err != nil {
@@ -727,7 +727,7 @@ func doGithubRequest(client *http.Client, req *http.Request, accept string) (str
 
 // buildPatchURL creates a URL to enable downloading patch files through the
 // Github API
-func buildPatchURL(gp *patch.GithubPatch) string {
+func buildPatchURL(gp patch.GithubPatch) string {
 	url := &url.URL{
 		Scheme: "https",
 		Host:   "api.github.com",

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -737,3 +737,77 @@ func buildPatchURL(gp patch.GithubPatch) string {
 
 	return url.String()
 }
+
+func ValidatePR(pr *github.PullRequest) error {
+	if pr == nil {
+		return errors.New("No PR provided")
+	}
+
+	catcher := grip.NewSimpleCatcher()
+	if pr.GetMergeCommitSHA() == "" {
+		catcher.Add(errors.New("no merge commit SHA"))
+	}
+	if missingUserLogin(pr) {
+		catcher.Add(errors.New("no valid user"))
+	}
+	if missingBaseSHA(pr) {
+		catcher.Add(errors.New("no valid base SHA"))
+	}
+	if missingBaseRef(pr) {
+		catcher.Add(errors.New("no valid base ref"))
+	}
+	if missingBaseRepoName(pr) {
+		catcher.Add(errors.New("no valid base repo name"))
+	}
+	if missingBaseRepoFullName(pr) {
+		catcher.Add(errors.New("no valid base repo name"))
+	}
+	if missingBaseRepoOwnerLogin(pr) {
+		catcher.Add(errors.New("no valid base repo owner login"))
+	}
+	if missingHeadSHA(pr) {
+		catcher.Add(errors.New("no valid head SHA"))
+	}
+	if pr.GetNumber() == 0 {
+		catcher.Add(errors.New("no valid pr number"))
+	}
+	if pr.GetTitle() == "" {
+		catcher.Add(errors.New("no valid title"))
+	}
+	if pr.GetHTMLURL() == "" {
+		catcher.Add(errors.New("no valid HTML URL"))
+	}
+	if pr.Merged == nil {
+		catcher.Add(errors.New("no valid merged status"))
+	}
+
+	return catcher.Resolve()
+}
+
+func missingUserLogin(pr *github.PullRequest) bool {
+	return pr.User == nil || pr.User.GetLogin() == ""
+}
+
+func missingBaseSHA(pr *github.PullRequest) bool {
+	return pr.Base == nil || pr.Base.GetSHA() == ""
+}
+
+func missingBaseRef(pr *github.PullRequest) bool {
+	return pr.Base == nil || pr.Base.GetRef() == ""
+}
+
+func missingBaseRepoName(pr *github.PullRequest) bool {
+	return pr.Base == nil || pr.Base.Repo == nil || pr.Base.Repo.GetName() == "" || pr.Base.Repo.GetFullName() == ""
+}
+
+func missingBaseRepoFullName(pr *github.PullRequest) bool {
+	return pr.Base == nil || pr.Base.Repo == nil || pr.Base.Repo.GetFullName() == ""
+}
+
+func missingBaseRepoOwnerLogin(pr *github.PullRequest) bool {
+	return pr.Base == nil || pr.Base.Repo == nil || pr.Base.Repo.Owner == nil || pr.Base.Repo.Owner.GetLogin() == ""
+}
+
+func missingHeadSHA(pr *github.PullRequest) bool {
+	return pr.Head == nil || pr.Head.GetSHA() == ""
+}

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -187,7 +187,7 @@ func (s *githubSuite) TestGetGithubPullRequestDiff() {
 		Author:     "richardsamuels",
 	}
 
-	diff, summaries, err := GetGithubPullRequestDiff(s.ctx, s.token, &p)
+	diff, summaries, err := GetGithubPullRequestDiff(s.ctx, s.token, p)
 	s.NoError(err)
 	s.Len(summaries, 2)
 	s.Len(diff, 1470)
@@ -278,5 +278,5 @@ func TestBuildPatchURL(t *testing.T) {
 		HeadHash:   "something",
 		Author:     "richardsamuels",
 	}
-	assert.Equal("https://api.github.com/repos/evergreen-ci/evergreen/pulls/448.diff", buildPatchURL(&p))
+	assert.Equal("https://api.github.com/repos/evergreen-ci/evergreen/pulls/448.diff", buildPatchURL(p))
 }

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -2,7 +2,9 @@ package thirdparty
 
 import (
 	"context"
+	"io/ioutil"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -279,4 +282,27 @@ func TestBuildPatchURL(t *testing.T) {
 		Author:     "richardsamuels",
 	}
 	assert.Equal("https://api.github.com/repos/evergreen-ci/evergreen/pulls/448.diff", buildPatchURL(p))
+}
+
+func TestValidatePR(t *testing.T) {
+	assert := assert.New(t)
+
+	prBody, err := ioutil.ReadFile(filepath.Join(testutil.GetDirectoryOfFile(), "..", "units", "testdata", "pull_request.json"))
+	assert.NoError(err)
+	assert.Len(prBody, 24757)
+	webhookInterface, err := github.ParseWebHook("pull_request", prBody)
+	assert.NoError(err)
+	prEvent, ok := webhookInterface.(*github.PullRequestEvent)
+	assert.True(ok)
+	pr := prEvent.GetPullRequest()
+
+	assert.NoError(ValidatePR(pr))
+
+	mergeCommitSha := pr.MergeCommitSHA
+	pr.MergeCommitSHA = nil
+	assert.Error(ValidatePR(pr))
+	pr.MergeCommitSHA = mergeCommitSha
+
+	pr.Base = nil
+	assert.Error(ValidatePR(pr))
 }

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -235,7 +235,7 @@ func checkPR(ctx context.Context, githubToken, issue, owner, repo string) (*gith
 		return nil, false, errors.Wrap(err, "can't get PR from GitHub")
 	}
 
-	if err = validatePR(pr); err != nil {
+	if err = thirdparty.ValidatePR(pr); err != nil {
 		return nil, true, errors.Wrap(err, "GitHub returned an incomplete PR")
 	}
 
@@ -286,46 +286,6 @@ func getModules(ctx context.Context, githubToken string, nextItem *commitqueue.C
 	}
 
 	return modulePRs, modulePatches, false, nil
-}
-
-func validatePR(pr *github.PullRequest) error {
-	if pr == nil {
-		return errors.New("No PR provided")
-	}
-
-	catcher := grip.NewSimpleCatcher()
-	if pr.GetMergeCommitSHA() == "" {
-		catcher.Add(errors.New("no merge commit SHA"))
-	}
-	if pr.GetUser() == nil || pr.GetUser().GetLogin() == "" {
-		catcher.Add(errors.New("no valid user"))
-	}
-	if pr.GetBase() == nil || pr.GetBase().GetSHA() == "" || pr.GetBase().GetRef() == "" {
-		catcher.Add(errors.New("no valid base SHA"))
-	}
-	if pr.GetBase() == nil || pr.GetBase().GetRepo() == nil || pr.GetBase().GetRepo().GetName() == "" || pr.GetBase().GetRepo().GetFullName() == "" {
-		catcher.Add(errors.New("no valid base repo name"))
-	}
-	if pr.GetBase() == nil || pr.GetBase().GetRepo() == nil || pr.GetBase().GetRepo().GetOwner() == nil || pr.GetBase().GetRepo().GetOwner().GetLogin() == "" {
-		catcher.Add(errors.New("no valid base repo owner login"))
-	}
-	if pr.GetHead() == nil || pr.GetHead().GetSHA() == "" {
-		catcher.Add(errors.New("no valid head SHA"))
-	}
-	if pr.GetNumber() == 0 {
-		catcher.Add(errors.New("no valid pr number"))
-	}
-	if pr.GetTitle() == "" {
-		catcher.Add(errors.New("no valid title"))
-	}
-	if pr.GetHTMLURL() == "" {
-		catcher.Add(errors.New("no valid HTML URL"))
-	}
-	if pr.Merged == nil {
-		catcher.Add(errors.New("no valid merged status"))
-	}
-
-	return catcher.Resolve()
 }
 
 func getPatchInfo(ctx context.Context, githubToken string, patchDoc *patch.Patch) (string, []patch.Summary, *model.Project, error) {

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -153,5 +153,6 @@ func (s *commitQueueSuite) TestWritePatchInfo() {
 	s.NoError(err)
 	defer reader.Close()
 	bytes, err := ioutil.ReadAll(reader)
+	s.NoError(err)
 	s.Equal(patchContent, string(bytes))
 }

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -92,18 +92,6 @@ func (s *commitQueueSuite) TestNewCommitQueueJob() {
 	s.Equal("commit-queue:mci_job-1", job.ID())
 }
 
-func (s *commitQueueSuite) TestValidatePR() {
-	s.NoError(validatePR(s.pr))
-
-	mergeCommitSha := s.pr.MergeCommitSHA
-	s.pr.MergeCommitSHA = nil
-	s.Error(validatePR(s.pr))
-	s.pr.MergeCommitSHA = mergeCommitSha
-
-	s.pr.Base = nil
-	s.Error(validatePR(s.pr))
-}
-
 func (s *commitQueueSuite) TestSubscribeMerge() {
 	s.NoError(db.ClearCollections(event.SubscriptionsCollection))
 	s.NoError(subscribeMerge(s.projectRef.Identifier, s.projectRef.Owner, s.projectRef.Repo, "squash", "abcdef", s.pr))

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -391,7 +391,7 @@ func (j *patchIntentProcessor) buildGithubPatchDoc(ctx context.Context, patchDoc
 		return false, err
 	}
 
-	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(ctx, githubOauthToken, &patchDoc.GithubPatchData)
+	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(ctx, githubOauthToken, patchDoc.GithubPatchData)
 	if err != nil {
 		return isMember, err
 	}

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -199,7 +199,7 @@ func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntent() {
 	}
 	s.NoError(evergreen.SetServiceFlags(flags))
 
-	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(context.Background(), githubOauthToken, &s.githubPatchData)
+	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(context.Background(), githubOauthToken, s.githubPatchData)
 	s.NoError(err)
 	s.NotEmpty(patchContent)
 	s.NotEqual("{", patchContent[0])


### PR DESCRIPTION
Add the diff GiHub provides for a PR to the patch so it can be displayed in the UI.

For example:
![Screen Shot 2019-03-11 at 1 39 32 PM](https://user-images.githubusercontent.com/17027265/54144922-2d78e880-4403-11e9-966f-cc174b3b1836.png)
