### PR TITLE
EVG-5949: check that logger is non-nil before checking if it's closed

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -295,7 +295,6 @@ func (a *Agent) runTask(ctx context.Context, cancel context.CancelFunc, tc *task
 		"task_secret": tc.task.Secret,
 	})
 
-	// Defers are LIFO. We cancel all agent task threads, then any procs started by the agent, then remove the task directory.
 	defer a.killProcs(tc, false)
 	defer cancel()
 
@@ -395,6 +394,8 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string) 
 		tc.logger.Task().Errorf("Programmer error: Invalid task status %s", detail.Status)
 	}
 
+	a.killProcs(tc, false)
+
 	tc.logger.Execution().Infof("Sending final status as: %v", detail.Status)
 	if err = tc.logger.Close(); err != nil {
 		grip.Errorf("Error closing logger: %v", err)
@@ -471,15 +472,23 @@ func (a *Agent) runPostGroupCommands(ctx context.Context, tc *taskContext) {
 
 func (a *Agent) killProcs(tc *taskContext, ignoreTaskGroupCheck bool) {
 	if a.shouldKill(tc, ignoreTaskGroupCheck) {
-		grip.Infof("cleaning up processes for task: %s", tc.task.ID)
-
 		if tc.task.ID != "" {
+			if tc.logger != nil && !tc.logger.Closed() {
+				tc.logger.Task().Infof("cleaning up processes for task: %s", tc.task.ID)
+			} else {
+				grip.Infof("cleaning up processes for task: %s", tc.task.ID)
+			}
 			if err := subprocess.KillSpawnedProcs(tc.task.ID, tc.logger.Task()); err != nil {
 				msg := fmt.Sprintf("Error cleaning up spawned processes (agent-exit): %v", err)
 				grip.Critical(msg)
 			}
 		}
-		grip.Infof("processes cleaned up for task %s", tc.task.ID)
+
+		if tc.logger != nil && !tc.logger.Closed() {
+			tc.logger.Task().Infof("cleaned up processes for task: %s", tc.task.ID)
+		} else {
+			grip.Infof("cleaned up processes for task: %s", tc.task.ID)
+		}
 	}
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-5949

This is the same logging change as [EVG-5882](https://github.com/evergreen-ci/evergreen/pull/2082) but it checks if `tc.logger != nil` before checking the logger closed status.