### PR TITLE
EVG-5922: fix destination of github status messages

### DIFF
--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -141,12 +141,16 @@ type MockCommitQueueConnector struct {
 func (pc *MockCommitQueueConnector) GetGitHubPR(ctx context.Context, owner, repo string, PRNum int) (*github.PullRequest, error) {
 	userID := 1234
 	ref := "master"
+	sha := "abcdef1234"
 	return &github.PullRequest{
 		User: &github.User{
 			ID: &userID,
 		},
 		Base: &github.PullRequestBranch{
 			Ref: &ref,
+		},
+		Head: &github.PullRequestBranch{
+			SHA: &sha,
 		},
 	}, nil
 }


### PR DESCRIPTION
Upon queueing, the commit queue sends a status to the GitHub PR indicating the PR is on the queue.

GitHub displays the statuses of the commit at the tip of the branch being merged in, so the API call needs to reference the SHA of that commit.