### PR TITLE
EVG-5867 support starting containers without agent

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -64,7 +64,7 @@ type ContainerManager interface {
 	// CalculateImageSpaceUsage returns the total space taken up by docker images on a specified host
 	CalculateImageSpaceUsage(ctx context.Context, h *host.Host) (int64, error)
 	// BuildContainerImage downloads and builds a container image onto parent specified by URL
-	BuildContainerImage(ctx context.Context, parent *host.Host, settings ContainerImageSettings) error
+	BuildContainerImage(ctx context.Context, parent *host.Host, options host.DockerOptions) error
 }
 
 // CostCalculator is an interface for cloud providers that can estimate what a span of time on a

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -63,8 +63,8 @@ type ContainerManager interface {
 	RemoveOldestImage(ctx context.Context, h *host.Host) error
 	// CalculateImageSpaceUsage returns the total space taken up by docker images on a specified host
 	CalculateImageSpaceUsage(ctx context.Context, h *host.Host) (int64, error)
-	// BuildContainerImage downloads and builds a container image onto parent specified by URL
-	BuildContainerImage(ctx context.Context, parent *host.Host, options host.DockerOptions) error
+	// GetContainerImage downloads a container image onto parent specified by URL, and builds evergreen agent unless otherwise specified
+	GetContainerImage(ctx context.Context, parent *host.Host, options host.DockerOptions) error
 }
 
 // CostCalculator is an interface for cloud providers that can estimate what a span of time on a

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -2,13 +2,13 @@ package cloud
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
-	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -60,12 +60,8 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 			evergreen.ProviderNameDocker, h.Distro.Id, h.Distro.Provider)
 	}
 
-	// Decode provider settings from distro settings
-	settings := &dockerSettings{}
-	if h.Distro.ProviderSettings != nil {
-		if err := mapstructure.Decode(h.Distro.ProviderSettings, settings); err != nil {
-			return nil, errors.Wrapf(err, "Error decoding params for distro '%s'", h.Distro.Id)
-		}
+	if h.DockerOptions.Image == "" {
+		return nil, errors.New(fmt.Sprintf("Docker image empty for host '%s'", h.Id))
 	}
 
 	// get parent of host
@@ -78,19 +74,15 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 		return nil, errors.Wrapf(err, "Error getting host IP for parent host %s", parentHost.Id)
 	}
 
-	if err = settings.Validate(); err != nil {
-		return nil, errors.Wrapf(err, "Invalid Docker settings for host '%s'", h.Id)
-	}
-
 	grip.Info(message.Fields{
 		"message":   "decoded Docker container settings",
 		"container": h.Id,
 		"host_ip":   hostIP,
-		"image_url": settings.ImageURL,
+		"image_url": h.DockerOptions.Image,
 	})
 
 	// Create container
-	if err = m.client.CreateContainer(ctx, parentHost, h, settings); err != nil {
+	if err = m.client.CreateContainer(ctx, parentHost, h); err != nil {
 		err = errors.Wrapf(err, "Failed to create container for host '%s'", hostIP)
 		grip.Error(err)
 		return nil, err
@@ -340,16 +332,16 @@ func (m *dockerManager) CostForDuration(ctx context.Context, h *host.Host, start
 
 // BuildContainerImage downloads and buils a container image onto parent specified
 // by URL and returns this URL
-func (m *dockerManager) BuildContainerImage(ctx context.Context, parent *host.Host, settings ContainerImageSettings) error {
+func (m *dockerManager) BuildContainerImage(ctx context.Context, parent *host.Host, options host.DockerOptions) error {
 	start := time.Now()
 	if !parent.HasContainers {
 		return errors.Errorf("Error provisioning image: '%s' is not a parent", parent.Id)
 	}
 
 	// Import correct base image if not already on host.
-	image, err := m.client.EnsureImageDownloaded(ctx, parent, settings)
+	image, err := m.client.EnsureImageDownloaded(ctx, parent, options)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to ensure that image '%s' is on host '%s'", settings.URL, parent.Id)
+		return errors.Wrapf(err, "Unable to ensure that image '%s' is on host '%s'", options.Image, parent.Id)
 	}
 	grip.Info(message.Fields{
 		"operation": "EnsureImageDownloaded",
@@ -358,10 +350,14 @@ func (m *dockerManager) BuildContainerImage(ctx context.Context, parent *host.Ho
 		"span":      time.Since(start).String(),
 	})
 
+	if options.SkipImageBuild {
+		return nil
+	}
+
 	// Build image containing Evergreen executable.
 	_, err = m.client.BuildImageWithAgent(ctx, parent, image)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to build image '%s' with agent on host '%s'", settings.URL, parent.Id)
+		return errors.Wrapf(err, "Failed to build image '%s' with agent on host '%s'", options.Image, parent.Id)
 	}
 	grip.Info(message.Fields{
 		"operation": "BuildImageWithAgent",

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -169,7 +169,7 @@ func (c *dockerClientImpl) EnsureImageDownloaded(ctx context.Context, h *host.Ho
 		} else if options.Method == distro.DockerImageBuildTypePull {
 			image := options.Image
 			if options.RegistryName != "" {
-				image = fmt.Sprintf("%s:%d/%s", options.RegistryName, h.ContainerPoolSettings.Port, imageName)
+				image = fmt.Sprintf("%s/%s", options.RegistryName, imageName)
 			}
 			err = c.pullImage(ctx, h, image, options.RegistryUsername, options.RegistryPassword)
 			grip.Info(message.Fields{

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -377,7 +377,7 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 		grip.Error(err)
 		return err
 	}
-	containerHost.ContainerId = info.ID
+	containerHost.ExternalIdentifier = info.ID
 	grip.Info(msg)
 
 	return nil

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -354,6 +354,7 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 			fmt.Sprintf("--working_directory=%s", containerHost.Distro.WorkDir),
 			"--cleanup",
 		}
+		containerHost.DockerOptions.Command = strings.Join(agentCmdParts, "\n")
 	}
 
 	// Populate container settings with command and new image.
@@ -370,11 +371,13 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 	})
 
 	// Build container
-	if _, err := dockerClient.ContainerCreate(ctx, containerConf, hostConf, networkConf, containerHost.Id); err != nil {
+	info, err := dockerClient.ContainerCreate(ctx, containerConf, hostConf, networkConf, containerHost.Id)
+	if err != nil {
 		err = errors.Wrapf(err, "Docker create API call failed for container '%s'", containerHost.Id)
 		grip.Error(err)
 		return err
 	}
+	containerHost.ContainerId = info.ID
 	grip.Info(msg)
 
 	return nil

--- a/cloud/docker_mock.go
+++ b/cloud/docker_mock.go
@@ -45,7 +45,7 @@ func (c *dockerClientMock) Init(string) error {
 	return nil
 }
 
-func (c *dockerClientMock) EnsureImageDownloaded(context.Context, *host.Host, ContainerImageSettings) (string, error) {
+func (c *dockerClientMock) EnsureImageDownloaded(context.Context, *host.Host, host.DockerOptions) (string, error) {
 	if c.failDownload {
 		return "", errors.New("failed to download image")
 	}
@@ -59,7 +59,7 @@ func (c *dockerClientMock) BuildImageWithAgent(context.Context, *host.Host, stri
 	return fmt.Sprintf(provisionedImageTag, c.baseImage), nil
 }
 
-func (c *dockerClientMock) CreateContainer(context.Context, *host.Host, *host.Host, *dockerSettings) error {
+func (c *dockerClientMock) CreateContainer(context.Context, *host.Host, *host.Host) error {
 	if c.failCreate {
 		return errors.New("failed to create container")
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -19,14 +19,15 @@ import (
 )
 
 type Host struct {
-	Id       string        `bson:"_id" json:"id"`
-	Host     string        `bson:"host_id" json:"host"`
-	User     string        `bson:"user" json:"user"`
-	Secret   string        `bson:"secret" json:"secret"`
-	Tag      string        `bson:"tag" json:"tag"`
-	Distro   distro.Distro `bson:"distro" json:"distro"`
-	Provider string        `bson:"host_type" json:"host_type"`
-	IP       string        `bson:"ip_address" json:"ip_address"`
+	Id          string        `bson:"_id" json:"id"`
+	ContainerId string        `bson:"container_id" json:"container_id"`
+	Host        string        `bson:"host_id" json:"host"`
+	User        string        `bson:"user" json:"user"`
+	Secret      string        `bson:"secret" json:"secret"`
+	Tag         string        `bson:"tag" json:"tag"`
+	Distro      distro.Distro `bson:"distro" json:"distro"`
+	Provider    string        `bson:"host_type" json:"host_type"`
+	IP          string        `bson:"ip_address" json:"ip_address"`
 
 	// secondary (external) identifier for the host
 	ExternalIdentifier string `bson:"ext_identifier" json:"ext_identifier"`

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -124,9 +124,9 @@ type HostGroup []Host
 // DockerOptions contains options for starting a container
 type DockerOptions struct {
 	// Optional parameters to define a registry name and authentication
-	RegistryName     string `bson:"registry_name,omitempty" json:"registry_name,omitempty"`
-	RegistryUsername string `mapstructure:"registry_username" bson:"registry_username,omitempty" json:"registry_username,omitempty"`
-	RegistryPassword string `mapstructure:"registry_password" bson:"registry_password,omitempty" json:"registry_password,omitempty"`
+	RegistryName     string `mapstructure:"docker_registry_name" bson:"docker_registry_name,omitempty" json:"docker_registry_name,omitempty"`
+	RegistryUsername string `mapstructure:"docker_registry_user" bson:"docker_registry_user,omitempty" json:"docker_registry_user,omitempty"`
+	RegistryPassword string `mapstructure:"docker_registry_pw" bson:"docker_registry_pw,omitempty" json:"docker_registry_pw,omitempty"`
 
 	// Image is required and specifies the image for the container.
 	// This can be a URL or an image base, to be combined with a registry.
@@ -134,9 +134,9 @@ type DockerOptions struct {
 	// Method is either "pull" or "import" and defines how to retrieve the image.
 	Method string `mapstructure:"build_type" bson:"build_type,omitempty" json:"build_type,omitempty"`
 	// Command is required and is the command to run on the docker.
-	Command string `bson:"command,omitempty" json:"command,omitempty"`
+	Command string `mapstructure:"command" bson:"command,omitempty" json:"command,omitempty"`
 	// If the container is created from host create, we want to skip building the image with agent
-	SkipImageBuild bool `bson:"skip_build,omitempty" json:"skip_build,omitempty"`
+	SkipImageBuild bool `mapstructure:"skip_build" bson:"skip_build,omitempty" json:"skip_build,omitempty"`
 }
 
 // ProvisionOptions is struct containing options about how a new host should be set up.

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -121,18 +121,22 @@ type Host struct {
 
 type HostGroup []Host
 
-// DockerOptions contains options for starting a container from host create
+// DockerOptions contains options for starting a container
 type DockerOptions struct {
 	// Optional parameters to define a registry name and authentication
 	RegistryName     string `bson:"registry_name,omitempty" json:"registry_name,omitempty"`
-	RegistryUsername string `bson:"registry_username,omitempty" json:"registry_username,omitempty"`
-	RegistryPassword string `bson:"registry_password,omitempty" json:"registry_password,omitempty"`
+	RegistryUsername string `mapstructure:"docker_registry_user" bson:"docker_registry_user,omitempty" json:"docker_registry_user,omitempty"`
+	RegistryPassword string `mapstructure:"docker_registry_pw" bson:"docker_registry_pw,omitempty" json:"docker_registry_pw,omitempty"`
 
 	// Image is required and specifies the image for the container.
 	// This can be a URL or an image base, to be combined with a registry.
-	Image string `bson:"image,omitempty" json:"image,omitempty"`
+	Image string `mapstructure:"image_url" bson:"image_url,omitempty" json:"image_url,omitempty"`
+	// Method is either "pull" or "import" and defines how to retrieve the image.
+	Method string `mapstructure:"build_type" bson:"build_type,omitempty" json:"build_type,omitempty"`
 	// Command is required and is the command to run on the docker.
 	Command string `bson:"command,omitempty" json:"command,omitempty"`
+	// If the container is created from host create, we want to skip building the image with agent
+	SkipImageBuild bool `bson:"skip_build,omitempty" json:"skip_build,omitempty"`
 }
 
 // ProvisionOptions is struct containing options about how a new host should be set up.

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -19,17 +19,16 @@ import (
 )
 
 type Host struct {
-	Id          string        `bson:"_id" json:"id"`
-	ContainerId string        `bson:"container_id" json:"container_id"`
-	Host        string        `bson:"host_id" json:"host"`
-	User        string        `bson:"user" json:"user"`
-	Secret      string        `bson:"secret" json:"secret"`
-	Tag         string        `bson:"tag" json:"tag"`
-	Distro      distro.Distro `bson:"distro" json:"distro"`
-	Provider    string        `bson:"host_type" json:"host_type"`
-	IP          string        `bson:"ip_address" json:"ip_address"`
+	Id       string        `bson:"_id" json:"id"`
+	Host     string        `bson:"host_id" json:"host"`
+	User     string        `bson:"user" json:"user"`
+	Secret   string        `bson:"secret" json:"secret"`
+	Tag      string        `bson:"tag" json:"tag"`
+	Distro   distro.Distro `bson:"distro" json:"distro"`
+	Provider string        `bson:"host_type" json:"host_type"`
+	IP       string        `bson:"ip_address" json:"ip_address"`
 
-	// secondary (external) identifier for the host
+	// secondary (external) identifier for the host (the containerID for containers)
 	ExternalIdentifier string `bson:"ext_identifier" json:"ext_identifier"`
 
 	// physical location of host
@@ -126,8 +125,8 @@ type HostGroup []Host
 type DockerOptions struct {
 	// Optional parameters to define a registry name and authentication
 	RegistryName     string `bson:"registry_name,omitempty" json:"registry_name,omitempty"`
-	RegistryUsername string `mapstructure:"docker_registry_user" bson:"docker_registry_user,omitempty" json:"docker_registry_user,omitempty"`
-	RegistryPassword string `mapstructure:"docker_registry_pw" bson:"docker_registry_pw,omitempty" json:"docker_registry_pw,omitempty"`
+	RegistryUsername string `mapstructure:"registry_username" bson:"registry_username,omitempty" json:"registry_username,omitempty"`
+	RegistryPassword string `mapstructure:"registry_password" bson:"registry_password,omitempty" json:"registry_password,omitempty"`
 
 	// Image is required and specifies the image for the container.
 	// This can be a URL or an image base, to be combined with a registry.

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -271,9 +271,6 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		return nil, errors.Wrap(err, "error making host options for EC2")
 	}
 
-	// TODO: EVG-5895 will assign the parent ID
-	options.ParentID = "placeholder"
-
 	return cloud.NewIntent(d, d.GenerateName(), provider, *options), nil
 }
 

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -181,8 +181,10 @@ func (s *SchedulerSuite) TestSpawnHostsParents() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	providerSettings := make(map[string]interface{})
+	providerSettings["image_url"] = "my-image"
 	d := distro.Distro{Id: "distro", Provider: evergreen.ProviderNameMock,
-		ContainerPool: "test-pool"}
+		ContainerPool: "test-pool", ProviderSettings: &providerSettings}
 	parent := distro.Distro{Id: "parent-distro", PoolSize: 3, Provider: evergreen.ProviderNameMock}
 	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 2}
 	host1 := &host.Host{
@@ -248,9 +250,10 @@ func (s *SchedulerSuite) TestSpawnHostsParents() {
 func (s *SchedulerSuite) TestSpawnHostsContainers() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
+	providerSettings := make(map[string]interface{})
+	providerSettings["image_url"] = "my-image"
 	d := distro.Distro{Id: "distro", Provider: evergreen.ProviderNameMock,
-		ContainerPool: "test-pool"}
+		ContainerPool: "test-pool", ProviderSettings: &providerSettings}
 	parent := distro.Distro{Id: "parent-distro", PoolSize: 3, Provider: evergreen.ProviderNameMock}
 
 	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 3}
@@ -300,7 +303,7 @@ func (s *SchedulerSuite) TestSpawnHostsContainers() {
 	num := numNewParentsNeeded(parentsParams)
 	s.Equal(0, num)
 
-	s.Equal(1, len(newHostsSpawned))
+	s.Require().Equal(1, len(newHostsSpawned))
 	s.NotEmpty(newHostsSpawned[0].ParentID)
 }
 
@@ -308,7 +311,10 @@ func (s *SchedulerSuite) TestSpawnHostsParentsAndSomeContainers() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	d := distro.Distro{Id: "distro", Provider: evergreen.ProviderNameMock, ContainerPool: "test-pool"}
+	providerSettings := make(map[string]interface{})
+	providerSettings["image_url"] = "my-image"
+	d := distro.Distro{Id: "distro", Provider: evergreen.ProviderNameMock, ContainerPool: "test-pool",
+		ProviderSettings: &providerSettings}
 	parent := distro.Distro{Id: "parent-distro", PoolSize: 3, Provider: evergreen.ProviderNameMock}
 
 	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 3}
@@ -378,8 +384,10 @@ func (s *SchedulerSuite) TestSpawnHostsMaximumCapacity() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	providerSettings := make(map[string]interface{})
+	providerSettings["image_url"] = "my-image"
 	d := distro.Distro{Id: "distro", PoolSize: 1, Provider: evergreen.ProviderNameMock,
-		ContainerPool: "test-pool"}
+		ContainerPool: "test-pool", ProviderSettings: &providerSettings}
 	pool := &evergreen.ContainerPool{Distro: "distro", Id: "test-pool", MaxContainers: 2}
 	host1 := &host.Host{
 		Id:                    "host1",
@@ -419,7 +427,7 @@ func (s *SchedulerSuite) TestSpawnHostsMaximumCapacity() {
 	num := numNewParentsNeeded(parentsParams)
 	s.Equal(1, num)
 
-	s.Len(newHostsSpawned, 1)
+	s.Require().Len(newHostsSpawned, 1)
 	s.NotEmpty(newHostsSpawned[0].ParentID)
 }
 
@@ -556,11 +564,13 @@ func (s *SchedulerSuite) TestFindNoAvailableParent() {
 func (s *SchedulerSuite) TestSpawnContainersStatic() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	providerSettings := make(map[string]interface{})
+	providerSettings["image_url"] = "my-image"
 
 	hosts := []cloud.StaticHost{{Name: "host1"}, {Name: "host2"}, {Name: "host3"}}
 	d := distro.Distro{Id: "distro", Provider: evergreen.ProviderNameDocker,
-		ContainerPool: "test-pool"}
-	parent := distro.Distro{Id: "parent-distro", Provider: evergreen.ProviderNameStatic}
+		ContainerPool: "test-pool", ProviderSettings: &providerSettings}
+	parent := distro.Distro{Id: "parent-distro", Provider: evergreen.ProviderNameStatic, ProviderSettings: &providerSettings}
 	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 1}
 
 	host1 := &host.Host{

--- a/units/building_container_image.go
+++ b/units/building_container_image.go
@@ -131,7 +131,7 @@ func (j *buildingContainerImageJob) Run(ctx context.Context) {
 		return
 	}
 
-	err = containerMgr.BuildContainerImage(ctx, j.parent, j.DockerOptions)
+	err = containerMgr.GetContainerImage(ctx, j.parent, j.DockerOptions)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "error building and downloading container image"))
 		return

--- a/units/building_container_image.go
+++ b/units/building_container_image.go
@@ -30,9 +30,9 @@ func init() {
 type buildingContainerImageJob struct {
 	job.Base `bson:"base"`
 
-	ParentID      string                       `bson:"parent_id"`
-	ImageSettings cloud.ContainerImageSettings `bson:"image_settings"`
-	Provider      string                       `bson:"provider"`
+	ParentID      string             `bson:"parent_id"`
+	DockerOptions host.DockerOptions `bson:"docker_options"`
+	Provider      string             `bson:"provider"`
 
 	// cache
 	parent   *host.Host
@@ -54,15 +54,15 @@ func makeBuildingContainerImageJob() *buildingContainerImageJob {
 	return j
 }
 
-func NewBuildingContainerImageJob(env evergreen.Environment, h *host.Host, imageSettings cloud.ContainerImageSettings, providerName string) amboy.Job {
+func NewBuildingContainerImageJob(env evergreen.Environment, h *host.Host, dockerOptions host.DockerOptions, providerName string) amboy.Job {
 	job := makeBuildingContainerImageJob()
 
 	job.parent = h
-	job.ImageSettings = imageSettings
+	job.DockerOptions = dockerOptions
 	job.ParentID = h.Id
 	job.Provider = providerName
 
-	job.SetID(fmt.Sprintf("%s.%s.attempt-%d.%s", buildingContainerImageJobName, job.ParentID, h.ContainerBuildAttempt, job.ImageSettings.URL))
+	job.SetID(fmt.Sprintf("%s.%s.attempt-%d.%s", buildingContainerImageJobName, job.ParentID, h.ContainerBuildAttempt, job.DockerOptions.Image))
 
 	return job
 }
@@ -115,7 +115,7 @@ func (j *buildingContainerImageJob) Run(ctx context.Context) {
 
 	if j.parent.ContainerBuildAttempt >= containerBuildRetries {
 		j.AddError(errors.Wrapf(j.parent.SetTerminated(evergreen.User),
-			"failed 5 times to build and download image '%s' on parent '%s'", j.ImageSettings.URL, j.parent.Id))
+			"failed 5 times to build and download image '%s' on parent '%s'", j.DockerOptions.Image, j.parent.Id))
 		return
 	}
 
@@ -131,7 +131,7 @@ func (j *buildingContainerImageJob) Run(ctx context.Context) {
 		return
 	}
 
-	err = containerMgr.BuildContainerImage(ctx, j.parent, j.ImageSettings)
+	err = containerMgr.BuildContainerImage(ctx, j.parent, j.DockerOptions)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "error building and downloading container image"))
 		return
@@ -139,7 +139,7 @@ func (j *buildingContainerImageJob) Run(ctx context.Context) {
 	if j.parent.ContainerImages == nil {
 		j.parent.ContainerImages = make(map[string]bool)
 	}
-	j.parent.ContainerImages[j.ImageSettings.URL] = true
+	j.parent.ContainerImages[j.DockerOptions.Image] = true
 	_, err = j.parent.Upsert()
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "error upserting parent %s", j.parent.Id))

--- a/units/building_container_image_test.go
+++ b/units/building_container_image_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -46,7 +45,7 @@ func TestBuildingContainerImageJob(t *testing.T) {
 	assert.NoError(h2.Insert())
 	assert.NoError(h3.Insert())
 
-	j := NewBuildingContainerImageJob(env, h1, cloud.ContainerImageSettings{URL: "image-url", Method: distro.DockerImageBuildTypeImport}, evergreen.ProviderNameDockerMock)
+	j := NewBuildingContainerImageJob(env, h1, host.DockerOptions{Image: "image-url", Method: distro.DockerImageBuildTypeImport}, evergreen.ProviderNameDockerMock)
 	assert.False(j.Status().Completed)
 
 	j.Run(context.Background())


### PR DESCRIPTION
For context, want containers started from host.create and scheduler to pipe through provisioning_create_host. Besides a placeholder for finding parents (which will be handled in a later ticket) this ticket covers the following:

- Determine if method for create.host containers is Import or Pull (based on format of image). https://docs.docker.com/engine/reference/commandline/pull/ “Pull from a different registry” is how I’m distinguishing this.
- Use h.DockerOptions instead of h.Distro.ProviderSettings in all cases (to unify scheduler and host.create). This changed NewBuildingContainerImageJob signature, verified this shouldn’t be a problem.
- Only use the evergreen agent command we've had previously if no command is given (which is required for host.create containers).
- Only build image if made by the scheduler. This assumes that the scheduler/host.create will never try to use the same image.