### PR TITLE
EVG-5865 add containers to host.list

### DIFF
--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -66,9 +66,9 @@ func TestListHostsForTask(t *testing.T) {
 			},
 		},
 		{
-			Id:          "7",
-			ContainerId: "container-1234",
-			Status:      evergreen.HostRunning,
+			Id:                 "7",
+			ExternalIdentifier: "container-1234",
+			Status:             evergreen.HostRunning,
 			SpawnOptions: host.SpawnOptions{
 				TaskID: "task_1",
 			},
@@ -86,7 +86,7 @@ func TestListHostsForTask(t *testing.T) {
 	require.Len(found, 3)
 	assert.Equal("4.com", found[0].Host)
 	assert.Equal("1.com", found[1].Host)
-	assert.Equal("container-1234", found[2].ContainerId)
+	assert.Equal("container-1234", found[2].ExternalIdentifier)
 	assert.Equal("abcd:1234:459c:2d00:cfe4:843b:1d60:8e47", found[1].IP)
 }
 

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -25,7 +25,7 @@ func TestListHostsForTask(t *testing.T) {
 		{
 			Id:     "1",
 			Host:   "1.com",
-			IP: "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47",
+			IP:     "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47",
 			Status: evergreen.HostRunning,
 			SpawnOptions: host.SpawnOptions{
 				TaskID: "task_1",
@@ -65,6 +65,14 @@ func TestListHostsForTask(t *testing.T) {
 				BuildID: "build_1",
 			},
 		},
+		{
+			Id:          "7",
+			ContainerId: "container-1234",
+			Status:      evergreen.HostRunning,
+			SpawnOptions: host.SpawnOptions{
+				TaskID: "task_1",
+			},
+		},
 	}
 	for i := range hosts {
 		require.NoError(hosts[i].Insert())
@@ -75,9 +83,10 @@ func TestListHostsForTask(t *testing.T) {
 	c := DBCreateHostConnector{}
 	found, err := c.ListHostsForTask("task_1")
 	assert.NoError(err)
-	assert.Len(found, 2)
+	require.Len(found, 3)
 	assert.Equal("4.com", found[0].Host)
 	assert.Equal("1.com", found[1].Host)
+	assert.Equal("container-1234", found[2].ContainerId)
 	assert.Equal("abcd:1234:459c:2d00:cfe4:843b:1d60:8e47", found[1].IP)
 }
 

--- a/rest/model/createhost.go
+++ b/rest/model/createhost.go
@@ -11,7 +11,7 @@ type CreateHost struct {
 	InstanceID string `json:"instance_id"`
 
 	ContainerID string `json:"container_id"`
-	Host        string `json:"host"`
+	ParentID    string `json:"parent_id"`
 	Image       string `json:"image"`
 	Command     string `json:"command"`
 	Port        int    `json:"port"`
@@ -23,12 +23,9 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 		// container
 		if v.ParentID != "" {
 			createHost.ContainerID = v.ExternalIdentifier
-			createHost.Host = v.Id
+			createHost.ParentID = v.ParentID
 			createHost.Image = v.DockerOptions.Image
 			createHost.Command = v.DockerOptions.Command
-			if v.ContainerPoolSettings != nil {
-				createHost.Port = int(v.ContainerPoolSettings.Port)
-			}
 			return nil
 		}
 		createHost.DNSName = v.Host
@@ -39,12 +36,9 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 		// container
 		if v.ParentID != "" {
 			createHost.ContainerID = v.ExternalIdentifier
-			createHost.Host = v.Id
+			createHost.ParentID = v.ParentID
 			createHost.Image = v.DockerOptions.Image
 			createHost.Command = v.DockerOptions.Command
-			if v.ContainerPoolSettings != nil {
-				createHost.Port = int(v.ContainerPoolSettings.Port)
-			}
 			return nil
 		}
 		createHost.DNSName = v.Host

--- a/rest/model/createhost.go
+++ b/rest/model/createhost.go
@@ -9,16 +9,44 @@ type CreateHost struct {
 	DNSName    string `json:"dns_name"`
 	IP         string `json:"ip_address"`
 	InstanceID string `json:"instance_id"`
+
+	ContainerID string `json:"container_id"`
+	Host        string `json:"host"`
+	Image       string `json:"image"`
+	Command     string `json:"command"`
+	Port        int    `json:"port"`
 }
 
 func (createHost *CreateHost) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case host.Host:
+		// container
+		if v.ParentID != "" {
+			createHost.ContainerID = v.ExternalIdentifier
+			createHost.Host = v.Id
+			createHost.Image = v.DockerOptions.Image
+			createHost.Command = v.DockerOptions.Command
+			if v.ContainerPoolSettings != nil {
+				createHost.Port = int(v.ContainerPoolSettings.Port)
+			}
+			return nil
+		}
 		createHost.DNSName = v.Host
 		createHost.InstanceID = v.Id
 		createHost.IP = v.IP
 		createHost.InstanceID = v.ExternalIdentifier
 	case *host.Host:
+		// container
+		if v.ParentID != "" {
+			createHost.ContainerID = v.ExternalIdentifier
+			createHost.Host = v.Id
+			createHost.Image = v.DockerOptions.Image
+			createHost.Command = v.DockerOptions.Command
+			if v.ContainerPoolSettings != nil {
+				createHost.Port = int(v.ContainerPoolSettings.Port)
+			}
+			return nil
+		}
 		createHost.DNSName = v.Host
 		createHost.InstanceID = v.Id
 		createHost.IP = v.IP

--- a/rest/model/createhost_test.go
+++ b/rest/model/createhost_test.go
@@ -39,7 +39,7 @@ func TestCreateHostBuildFromServiceWithContainer(t *testing.T) {
 	assert.Equal(c.Image, h.DockerOptions.Image)
 	assert.Equal(c.Command, h.DockerOptions.Command)
 	assert.Equal(c.ContainerID, h.ExternalIdentifier)
-	assert.Equal(c.Host, h.Id)
+	assert.Equal(c.ParentID, h.ParentID)
 
 	assert.Empty(c.DNSName)
 	assert.Empty(c.InstanceID)

--- a/rest/model/createhost_test.go
+++ b/rest/model/createhost_test.go
@@ -21,3 +21,26 @@ func TestCreateHostBuildFromService(t *testing.T) {
 	assert.Equal(c.InstanceID, h.ExternalIdentifier)
 	assert.Equal(c.IP, h.IP)
 }
+
+func TestCreateHostBuildFromServiceWithContainer(t *testing.T) {
+	assert := assert.New(t)
+	h := host.Host{
+		Id:                 "i-1234",
+		ExternalIdentifier: "container-1234",
+		ParentID:           "i-5678",
+		DockerOptions: host.DockerOptions{
+			Image:   "my-image",
+			Command: "echo hi",
+		},
+	}
+	c := &CreateHost{}
+	err := c.BuildFromService(h)
+	assert.NoError(err)
+	assert.Equal(c.Image, h.DockerOptions.Image)
+	assert.Equal(c.Command, h.DockerOptions.Command)
+	assert.Equal(c.ContainerID, h.ExternalIdentifier)
+	assert.Equal(c.Host, h.Id)
+
+	assert.Empty(c.DNSName)
+	assert.Empty(c.InstanceID)
+}


### PR DESCRIPTION
host.list response modeled after that in the technical design. I wonder however if there was a reason we use "host" for containers instead of "instance_id" as we do for non-containers (do we specifically want these outputs to be mutually exclusive?)