### PR TITLE
EVG-5846: fix task history panel

### DIFF
--- a/service/task_history.go
+++ b/service/task_history.go
@@ -385,11 +385,10 @@ func (uis *UIServer) taskHistoryDrawer(w http.ResponseWriter, r *http.Request) {
 
 func getVersionsInWindow(wt, projectId string, radius int,
 	center *model.Version) ([]model.Version, error) {
-	referenceTime := center.CreateTime
 	if wt == beforeWindow {
-		return makeVersionsQuery(referenceTime, projectId, radius, true)
+		return makeVersionsQuery(center, projectId, radius, true)
 	} else if wt == afterWindow {
-		after, err := makeVersionsQuery(referenceTime, projectId, radius, false)
+		after, err := makeVersionsQuery(center, projectId, radius, false)
 		if err != nil {
 			return nil, err
 		}
@@ -399,11 +398,11 @@ func getVersionsInWindow(wt, projectId string, radius int,
 		}
 		return after, nil
 	}
-	before, err := makeVersionsQuery(referenceTime, projectId, radius, true)
+	before, err := makeVersionsQuery(center, projectId, radius, true)
 	if err != nil {
 		return nil, err
 	}
-	after, err := makeVersionsQuery(referenceTime, projectId, radius, false)
+	after, err := makeVersionsQuery(center, projectId, radius, false)
 	if err != nil {
 		return nil, err
 	}
@@ -419,11 +418,11 @@ func getVersionsInWindow(wt, projectId string, radius int,
 // Helper to make the appropriate query to the versions collection for what
 // we will need.  "before" indicates whether to fetch versions before or
 // after the passed-in task.
-func makeVersionsQuery(referenceTime time.Time, projectId string, versionsToFetch int, before bool) ([]model.Version, error) {
+func makeVersionsQuery(v *model.Version, projectId string, versionsToFetch int, before bool) ([]model.Version, error) {
 	// decide how the versions we want relative to the task's revision order number
-	ronQuery := bson.M{"$gt": referenceTime}
+	ronQuery := bson.M{"$gte": v.CreateTime, "$gt": v.Revision}
 	if before {
-		ronQuery = bson.M{"$lt": referenceTime}
+		ronQuery = bson.M{"$lte": v.CreateTime, "$lt": v.Revision}
 	}
 
 	// switch how to sort the versions

--- a/service/task_history_test.go
+++ b/service/task_history_test.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/stretchr/testify/suite"
+)
+
+type TaskHistorySuite struct {
+	suite.Suite
+	versionsBefore []model.Version
+	middleVersion  model.Version
+	versionsAfter  []model.Version
+	projectID      string
+}
+
+func TestTaskHistory(t *testing.T) {
+	suite.Run(t, new(TaskHistorySuite))
+}
+
+func (s *TaskHistorySuite) SetupSuite() {
+	db.SetGlobalSessionProvider(testutil.TestConfig().SessionFactory())
+	s.projectID = "mci"
+}
+
+func (s *TaskHistorySuite) SetupTest() {
+	s.NoError(db.ClearCollections(model.VersionCollection))
+	now := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	for i := 0; i < 50; i++ {
+		now = now.Add(time.Minute)
+		version := model.Version{
+			Id:         util.RandomString(),
+			Revision:   "aaaa",
+			CreateTime: now,
+			Identifier: s.projectID,
+			Requester:  evergreen.RepotrackerVersionRequester,
+		}
+		s.versionsBefore = append(s.versionsBefore, version)
+		s.NoError(version.Insert())
+	}
+
+	// Middle version with the same createTime as the last version in versionsBefore
+	// and the first version in versionsAfter
+	s.middleVersion = model.Version{
+		Id:         util.RandomString(),
+		Revision:   "bbbb",
+		CreateTime: now,
+		Identifier: s.projectID,
+		Requester:  evergreen.RepotrackerVersionRequester,
+	}
+	s.NoError(s.middleVersion.Insert())
+
+	for i := 0; i < 50; i++ {
+		version := model.Version{
+			Id:         util.RandomString(),
+			Revision:   "cccc",
+			CreateTime: now,
+			Identifier: s.projectID,
+			Requester:  evergreen.RepotrackerVersionRequester,
+		}
+		s.versionsAfter = append(s.versionsAfter, version)
+		s.NoError(version.Insert())
+
+		now = now.Add(time.Minute)
+	}
+}
+
+func (s *TaskHistorySuite) TestGetVersionsInWindow() {
+	radius := 20
+	versions, err := getVersionsInWindow("surround", s.projectID, radius, &s.middleVersion)
+	s.NoError(err)
+
+	for i := 0; i < radius; i++ {
+		s.True(versions[i].CreateTime.Equal(s.versionsAfter[(radius-1)-i].CreateTime))
+	}
+
+	s.True(s.middleVersion.CreateTime.Equal(versions[radius].CreateTime))
+
+	for i := 0; i < radius; i++ {
+		s.True(versions[i+(1+radius)].CreateTime.Equal(s.versionsBefore[(len(s.versionsBefore)-1)-i].CreateTime))
+	}
+}
+
+func (s *TaskHistorySuite) TestMakeVersionsQuery() {
+	versionsAfter, err := makeVersionsQuery(&s.middleVersion, s.projectID, 20, false)
+	s.NoError(err)
+	s.Len(versionsAfter, 20)
+	for i, version := range versionsAfter {
+		s.Equal("cccc", version.Revision)
+		s.True(version.CreateTime.Equal(s.versionsAfter[i].CreateTime))
+	}
+
+	versionsBefore, err := makeVersionsQuery(&s.middleVersion, s.projectID, 20, true)
+	s.NoError(err)
+	s.Len(versionsBefore, 20)
+	for i, version := range versionsBefore {
+		s.Equal("aaaa", version.Revision)
+		s.True(version.CreateTime.Equal(s.versionsBefore[len(s.versionsBefore)-(i+1)].CreateTime))
+	}
+}

--- a/service/task_history_test.go
+++ b/service/task_history_test.go
@@ -88,17 +88,18 @@ func (s *TaskHistorySuite) TestGetVersionsInWindow() {
 }
 
 func (s *TaskHistorySuite) TestMakeVersionsQuery() {
-	versionsAfter, err := makeVersionsQuery(&s.middleVersion, s.projectID, 20, false)
+	radius := 20
+	versionsAfter, err := makeVersionsQuery(&s.middleVersion, s.projectID, radius, false)
 	s.NoError(err)
-	s.Len(versionsAfter, 20)
+	s.Len(versionsAfter, radius)
 	for i, version := range versionsAfter {
 		s.Equal("cccc", version.Revision)
 		s.True(version.CreateTime.Equal(s.versionsAfter[i].CreateTime))
 	}
 
-	versionsBefore, err := makeVersionsQuery(&s.middleVersion, s.projectID, 20, true)
+	versionsBefore, err := makeVersionsQuery(&s.middleVersion, s.projectID, radius, true)
 	s.NoError(err)
-	s.Len(versionsBefore, 20)
+	s.Len(versionsBefore, radius)
 	for i, version := range versionsBefore {
 		s.Equal("aaaa", version.Revision)
 		s.True(version.CreateTime.Equal(s.versionsBefore[len(s.versionsBefore)-(i+1)].CreateTime))


### PR DESCRIPTION
When more than one version have equal create_time we leave out versions with a matching create_time from the task history since we're querying for $lt and $gt the middle version, but not equal.
(create_time is set for repotracker versions to the commit time reported by GitHub which has second precision so collision is not terribly difficult)

The solution was to match on $gte and $lte the middle version, but if it's equal than it must be $gt and $lt a second field which is guaranteed to be unique. The commit SHA was chosen as the second field because it's unique.

**Before deploying this PR** we should evaluate how to update the project_id:requester:create_time compound index to include the gitspec field.