### PR TITLE
EVG-5846: task history missing

### DIFF
--- a/service/task_history.go
+++ b/service/task_history.go
@@ -383,66 +383,67 @@ func (uis *UIServer) taskHistoryDrawer(w http.ResponseWriter, r *http.Request) {
 	}{taskGroups})
 }
 
-func getVersionsInWindow(wt, projectId string, radius int,
-	center *model.Version) ([]model.Version, error) {
+// Get the versions for projectID within radius around the center version, sorted backwards in time
+// wt indicates the direction away from center
+func getVersionsInWindow(wt, projectID string, radius int, center *model.Version) ([]model.Version, error) {
 	if wt == beforeWindow {
-		return makeVersionsQuery(center, projectId, radius, true)
+		return surroundingVersions(center, projectID, radius, true)
 	} else if wt == afterWindow {
-		after, err := makeVersionsQuery(center, projectId, radius, false)
+		after, err := surroundingVersions(center, projectID, radius, false)
 		if err != nil {
 			return nil, err
 		}
-		// reverse the versions in "after" so that they're ordered backwards in time
-		for i, j := 0, len(after)-1; i < j; i, j = i+1, j-1 {
-			after[i], after[j] = after[j], after[i]
-		}
 		return after, nil
 	}
-	before, err := makeVersionsQuery(center, projectId, radius, true)
+	before, err := surroundingVersions(center, projectID, radius, true)
 	if err != nil {
 		return nil, err
 	}
-	after, err := makeVersionsQuery(center, projectId, radius, false)
+	after, err := surroundingVersions(center, projectID, radius, false)
 	if err != nil {
 		return nil, err
 	}
-	// reverse the versions in "after" so that they're ordered backwards in time
-	for i, j := 0, len(after)-1; i < j; i, j = i+1, j-1 {
-		after[i], after[j] = after[j], after[i]
-	}
-	after = append(after, *center)
-	after = append(after, before...)
-	return after, nil
+
+	return append(append(after, *center), before...), nil
 }
 
-// Helper to make the appropriate query to the versions collection for what
-// we will need.  "before" indicates whether to fetch versions before or
-// after the passed-in task.
-func makeVersionsQuery(v *model.Version, projectId string, versionsToFetch int, before bool) ([]model.Version, error) {
-	var orderOperator string
-	var sortVersions []string
+// Helper to query the versions collection for versions created before
+// or after the center, indicated by "before", and sorted backwards in time
+func surroundingVersions(center *model.Version, projectId string, versionsToFetch int, before bool) ([]model.Version, error) {
+	direction := "$gt"
+	sortOn := []string{model.VersionCreateTimeKey}
 	if before {
-		orderOperator = "$lt"
-		sortVersions = []string{"-" + model.VersionCreateTimeKey}
-	} else {
-		orderOperator = "$gt"
-		sortVersions = []string{model.VersionCreateTimeKey}
-	}
-	revisionWindowQuery := []bson.M{
-		{
-			model.VersionCreateTimeKey: bson.M{orderOperator: v.CreateTime},
-		},
-		{
-			model.VersionCreateTimeKey: bson.M{"$eq": v.CreateTime},
-			model.VersionRevisionKey:   bson.M{orderOperator: v.Revision},
-		},
+		direction = "$lt"
+		sortOn = []string{"-" + model.VersionCreateTimeKey}
 	}
 
-	// fetch the versions
-	return model.VersionFind(
+	// fetch other concurrent versions
+	concurrentVersions, err := model.VersionFind(
 		db.Query(bson.M{
 			model.VersionIdentifierKey: projectId,
-			"$or":                      revisionWindowQuery,
+			model.VersionCreateTimeKey: center.CreateTime,
+			model.VersionRequesterKey: bson.M{
+				"$in": evergreen.SystemVersionRequesterTypes,
+			},
+			model.VersionRevisionKey: bson.M{direction: center.Revision},
+		}).WithFields(
+			model.VersionRevisionOrderNumberKey,
+			model.VersionRevisionKey,
+			model.VersionMessageKey,
+			model.VersionCreateTimeKey,
+			model.VersionErrorsKey,
+			model.VersionWarningsKey,
+			model.VersionIgnoredKey,
+		).Limit(versionsToFetch))
+	if err != nil {
+		return nil, errors.Wrap(err, "can't get concurrent versions")
+	}
+
+	// fetch consecutive versions
+	versions, err := model.VersionFind(
+		db.Query(bson.M{
+			model.VersionIdentifierKey: projectId,
+			model.VersionCreateTimeKey: bson.M{direction: center.CreateTime},
 			model.VersionRequesterKey: bson.M{
 				"$in": evergreen.SystemVersionRequesterTypes,
 			},
@@ -454,7 +455,19 @@ func makeVersionsQuery(v *model.Version, projectId string, versionsToFetch int, 
 			model.VersionErrorsKey,
 			model.VersionWarningsKey,
 			model.VersionIgnoredKey,
-		).Sort(sortVersions).Limit(versionsToFetch))
+		).Sort(sortOn).Limit(versionsToFetch - len(concurrentVersions)))
+	if err != nil {
+		return nil, errors.Wrap(err, "can't get consecutive versions")
+	}
+
+	if before {
+		return append(concurrentVersions, versions...), nil
+	}
+	// reverse versions
+	for begin, end := 0, len(versions)-1; begin < end; begin, end = begin+1, end-1 {
+		versions[begin], versions[end] = versions[end], versions[begin]
+	}
+	return append(versions, concurrentVersions...), nil
 }
 
 // Given a task name and a slice of versions, return the appropriate sibling

--- a/service/task_history_test.go
+++ b/service/task_history_test.go
@@ -77,7 +77,7 @@ func (s *TaskHistorySuite) TestGetVersionsInWindow() {
 	s.NoError(err)
 
 	for i := 0; i < radius; i++ {
-		s.True(versions[i].CreateTime.Equal(s.versionsAfter[(radius-1)-i].CreateTime))
+		s.True(versions[i].CreateTime.Equal(s.versionsAfter[radius-(i+1)].CreateTime))
 	}
 
 	s.True(s.middleVersion.CreateTime.Equal(versions[radius].CreateTime))
@@ -87,17 +87,17 @@ func (s *TaskHistorySuite) TestGetVersionsInWindow() {
 	}
 }
 
-func (s *TaskHistorySuite) TestMakeVersionsQuery() {
+func (s *TaskHistorySuite) TestSurroundingVersions() {
 	radius := 20
-	versionsAfter, err := makeVersionsQuery(&s.middleVersion, s.projectID, radius, false)
+	versionsAfter, err := surroundingVersions(&s.middleVersion, s.projectID, radius, false)
 	s.NoError(err)
-	s.Len(versionsAfter, radius)
+	s.Require().Len(versionsAfter, radius)
 	for i, version := range versionsAfter {
 		s.Equal("cccc", version.Revision)
-		s.True(version.CreateTime.Equal(s.versionsAfter[i].CreateTime))
+		s.True(version.CreateTime.Equal(s.versionsAfter[radius-(i+1)].CreateTime))
 	}
 
-	versionsBefore, err := makeVersionsQuery(&s.middleVersion, s.projectID, radius, true)
+	versionsBefore, err := surroundingVersions(&s.middleVersion, s.projectID, radius, true)
 	s.NoError(err)
 	s.Len(versionsBefore, radius)
 	for i, version := range versionsBefore {


### PR DESCRIPTION
The query introduced in PR #2103 is slow because the sort doesn't use the index.
This PR returns to the previous query and adds a separate query for versions with matching create_time and the results are appended together in memory.
