### PR TITLE
EVG-5975: make GOCACHE use an absolute path instead of relative path

### DIFF
--- a/cmd/build-cross-compile/build-cross-compile.go
+++ b/cmd/build-cross-compile/build-cross-compile.go
@@ -79,11 +79,16 @@ func main() {
 	ldfQuoted := fmt.Sprintf("-ldflags=\"%s\"", ldFlags)
 	cmd.Args = append(cmd.Args, ldf)
 
+	absDirectory, err := filepath.Abs(directory)
+	if err != nil {
+		fmt.Printf("problem building %s: %v\n", output, err)
+		os.Exit(1)
+	}
 	cmd.Env = []string{
 		"PATH=" + strings.Replace(os.Getenv("PATH"), `\`, `\\`, -1),
 		"GOPATH=" + strings.Replace(os.Getenv("GOPATH"), `\`, `\\`, -1),
 		"GOROOT=" + runtime.GOROOT(),
-		"GOCACHE=" + filepath.Join(directory, ".cache"),
+		"GOCACHE=" + filepath.Join(absDirectory, ".cache"),
 	}
 
 	if race && supportsRaceDetector(arch, system) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-5975

go1.12 requires an absolute path for GOCACHE.