### PR TITLE
EVG-5895 move creating/assigning parents out of scheduler

### DIFF
--- a/cloud/cloud_host.go
+++ b/cloud/cloud_host.go
@@ -2,26 +2,10 @@ package cloud
 
 import (
 	"context"
-	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
 )
-
-// HostOptions is a struct of options that are commonly passed around when creating a
-// new cloud host.
-type HostOptions struct {
-	ProvisionOptions   *host.ProvisionOptions
-	ExpirationDuration *time.Duration
-	UserName           string
-	UserHost           bool
-
-	HasContainers         bool
-	ParentID              string
-	ContainerPoolSettings *evergreen.ContainerPool
-	SpawnOptions          host.SpawnOptions
-	DockerOptions         host.DockerOptions
-}
 
 //CloudHost is a provider-agnostic host object that delegates methods
 //like status checks, ssh options, DNS name checks, termination, etc. to the

--- a/cloud/cloud_intent.go
+++ b/cloud/cloud_intent.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/pkg/errors"
 )
 
 // NewIntent creates an IntentHost using the given host settings. An IntentHost is a host that
@@ -45,5 +46,74 @@ func NewIntent(d distro.Distro, instanceName, provider string, options HostOptio
 		intentHost.ProvisionOptions = options.ProvisionOptions
 	}
 	return intentHost
+}
 
+// GenerateContainerHostIntents generates container intent documents by going
+// through available parents and packing on the parents with longest expected
+// finish time
+func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, hostOptions HostOptions) ([]host.Host, error) {
+	parents, err := host.GetNumContainersOnParents(d)
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not find number of containers on each parent")
+	}
+	containerHostIntents := make([]host.Host, 0)
+
+	for _, parent := range parents {
+		// find out how many more containers this parent can fit
+		containerSpace := parent.ParentHost.ContainerPoolSettings.MaxContainers - parent.NumContainers
+		containersToCreate := containerSpace
+		// only create containers as many as we need
+		if newContainersNeeded < containerSpace {
+			containersToCreate = newContainersNeeded
+		}
+		for i := 0; i < containersToCreate; i++ {
+			hostOptions.ParentID = parent.ParentHost.Id
+			containerHostIntents = append(containerHostIntents, *NewIntent(d, d.GenerateName(), d.Provider, hostOptions))
+		}
+		newContainersNeeded -= containersToCreate
+		if newContainersNeeded == 0 {
+			return containerHostIntents, nil
+		}
+	}
+	return containerHostIntents, nil
+}
+
+// createParents creates host intent documents for each parent
+func createParents(parent distro.Distro, numNewParents int, pool *evergreen.ContainerPool) []host.Host {
+	hostsSpawned := make([]host.Host, numNewParents)
+
+	for idx := range hostsSpawned {
+		hostsSpawned[idx] = *NewIntent(parent, parent.GenerateName(), parent.Provider, generateParentHostOptions(pool))
+	}
+	return hostsSpawned
+}
+
+// generateParentHostOptions generates host options for a parent host
+func generateParentHostOptions(pool *evergreen.ContainerPool) HostOptions {
+	options := HostOptions{
+		HasContainers:         true,
+		UserName:              evergreen.User,
+		ContainerPoolSettings: pool,
+	}
+	return options
+}
+
+func CreateParentIntentsAndHostsToSpawn(pool *evergreen.ContainerPool, newHostsNeeded int) ([]host.Host, int, error) {
+	// find all running parents with the specified container pool
+
+	numNewParentsToSpawn, newHostsNeeded, err := host.GetNumNewParentsAndHostsToSpawn(pool, newHostsNeeded)
+	if err != nil {
+		return []host.Host{}, 0, errors.Wrap(err, "error getting number of parents to spawn")
+	}
+	newParentHosts := []host.Host{}
+	if numNewParentsToSpawn > 0 {
+		// get parent distro from pool
+		parentDistro, err := distro.FindOne(distro.ById(pool.Distro))
+		if err != nil {
+			return nil, 0, errors.Wrap(err, "error find parent distro")
+		}
+		newParentHosts = createParents(parentDistro, numNewParentsToSpawn, pool)
+	}
+
+	return newParentHosts, newHostsNeeded, nil
 }

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -19,7 +19,7 @@ type DockerSuite struct {
 	client     DockerClient
 	manager    *dockerManager
 	distro     distro.Distro
-	hostOpts   host.HostOptions
+	hostOpts   host.CreateOptions
 	parentHost host.Host
 	suite.Suite
 }
@@ -53,7 +53,7 @@ func (s *DockerSuite) SetupTest() {
 		Host:          "host",
 		HasContainers: true,
 	}
-	s.hostOpts = host.HostOptions{
+	s.hostOpts = host.CreateOptions{
 		ParentID: "parent",
 		DockerOptions: host.DockerOptions{
 			Image: "http://0.0.0.0:8000/docker_image.tgz",
@@ -199,7 +199,7 @@ func (s *DockerSuite) TestSpawnInvalidSettings() {
 	s.Error(err)
 	s.Nil(h)
 
-	emptyHostOpts := host.HostOptions{}
+	emptyHostOpts := host.CreateOptions{}
 	h = host.NewIntent(s.distro, s.distro.GenerateName(), dProviderName.Provider, emptyHostOpts)
 	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -19,7 +19,7 @@ type DockerSuite struct {
 	client     DockerClient
 	manager    *dockerManager
 	distro     distro.Distro
-	hostOpts   HostOptions
+	hostOpts   host.HostOptions
 	parentHost host.Host
 	suite.Suite
 }
@@ -53,7 +53,7 @@ func (s *DockerSuite) SetupTest() {
 		Host:          "host",
 		HasContainers: true,
 	}
-	s.hostOpts = HostOptions{
+	s.hostOpts = host.HostOptions{
 		ParentID: "parent",
 		DockerOptions: host.DockerOptions{
 			Image: "http://0.0.0.0:8000/docker_image.tgz",
@@ -115,7 +115,7 @@ func (s *DockerSuite) TestTerminateInstanceAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hostA := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostA := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	s.NoError(hostA.Insert())
 	hostA, err := s.manager.SpawnHost(ctx, hostA)
 	s.NoError(err)
@@ -123,7 +123,7 @@ func (s *DockerSuite) TestTerminateInstanceAPICall() {
 	_, err = hostA.Upsert()
 	s.NoError(err)
 
-	hostB := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostB := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	s.NoError(hostB.Insert())
 	hostB, err = s.manager.SpawnHost(ctx, hostB)
 	s.NoError(err)
@@ -146,7 +146,7 @@ func (s *DockerSuite) TestTerminateInstanceDB() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	myHost := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	myHost := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	s.NoError(myHost.Insert())
 	myHost, err := s.manager.SpawnHost(ctx, myHost)
 	s.NotNil(myHost)
@@ -194,16 +194,16 @@ func (s *DockerSuite) TestSpawnInvalidSettings() {
 	defer cancel()
 
 	dProviderName := distro.Distro{Provider: "ec2"}
-	host := NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
-	host, err := s.manager.SpawnHost(ctx, host)
+	h := host.NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
+	h, err := s.manager.SpawnHost(ctx, h)
 	s.Error(err)
-	s.Nil(host)
+	s.Nil(h)
 
-	emptyHostOpts := HostOptions{}
-	host = NewIntent(s.distro, s.distro.GenerateName(), dProviderName.Provider, emptyHostOpts)
-	host, err = s.manager.SpawnHost(ctx, host)
+	emptyHostOpts := host.HostOptions{}
+	h = host.NewIntent(s.distro, s.distro.GenerateName(), dProviderName.Provider, emptyHostOpts)
+	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
-	s.Nil(host)
+	s.Nil(h)
 }
 
 func (s *DockerSuite) TestSpawnDuplicateHostID() {
@@ -212,13 +212,13 @@ func (s *DockerSuite) TestSpawnDuplicateHostID() {
 
 	// SpawnInstance should generate a unique ID for each instance, even
 	// when using the same distro. Otherwise the DB would return an error.
-	hostOne := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostOne := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	s.NoError(hostOne.Insert())
 	hostOne, err := s.manager.SpawnHost(ctx, hostOne)
 	s.NoError(err)
 	s.NotNil(hostOne)
 
-	hostTwo := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostTwo := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	s.NoError(hostTwo.Insert())
 	hostTwo, err = s.manager.SpawnHost(ctx, hostTwo)
 	s.NoError(err)
@@ -233,18 +233,18 @@ func (s *DockerSuite) TestSpawnCreateAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	host := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
-	s.NoError(host.Insert())
-	host, err := s.manager.SpawnHost(ctx, host)
+	h := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	s.NoError(h.Insert())
+	h, err := s.manager.SpawnHost(ctx, h)
 	s.NoError(err)
-	s.NotNil(host)
+	s.NotNil(h)
 
 	mock.failCreate = true
-	host = NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
-	s.NoError(host.Insert())
-	host, err = s.manager.SpawnHost(ctx, host)
+	h = host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	s.NoError(h.Insert())
+	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
-	s.Nil(host)
+	s.Nil(h)
 }
 
 func (s *DockerSuite) TestSpawnStartRemoveAPICall() {
@@ -255,19 +255,19 @@ func (s *DockerSuite) TestSpawnStartRemoveAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	host := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
-	s.NoError(host.Insert())
-	h, err := s.manager.SpawnHost(ctx, host)
+	intent := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	s.NoError(intent.Insert())
+	h, err := s.manager.SpawnHost(ctx, intent)
 	s.NoError(err)
 	s.NotNil(h)
 
 	mock.failStart = true
-	h, err = s.manager.SpawnHost(ctx, host)
+	h, err = s.manager.SpawnHost(ctx, intent)
 	s.Error(err)
 	s.Nil(h)
 
 	mock.failRemove = true
-	h, err = s.manager.SpawnHost(ctx, host)
+	h, err = s.manager.SpawnHost(ctx, intent)
 	s.Error(err)
 	s.Nil(h)
 }
@@ -291,10 +291,10 @@ func (s *DockerSuite) TestSpawnDoesNotPanic() {
 
 	delete(*s.distro.ProviderSettings, "image_url")
 
-	host := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	intent := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 
 	s.NotPanics(func() {
-		_, err := s.manager.SpawnHost(ctx, host)
+		_, err := s.manager.SpawnHost(ctx, intent)
 		s.Error(err)
 	})
 }

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -79,7 +79,7 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 
 	d := fetchTestDistro()
 	d.Provider = evergreen.ProviderNameEc2OnDemand
-	h := host.NewIntent(d, d.GenerateName(), d.Provider, host.HostOptions{
+	h := host.NewIntent(d, d.GenerateName(), d.Provider, host.CreateOptions{
 		UserName: evergreen.User,
 		UserHost: false,
 	})
@@ -146,7 +146,7 @@ func TestSpawnEC2InstanceSpot(t *testing.T) {
 	require.NoError(m.client.Create(m.credentials, defaultRegion))
 	d := fetchTestDistro()
 	d.Provider = evergreen.ProviderNameEc2Spot
-	h := host.NewIntent(d, d.GenerateName(), d.Provider, host.HostOptions{
+	h := host.NewIntent(d, d.GenerateName(), d.Provider, host.CreateOptions{
 		UserName: evergreen.User,
 		UserHost: false,
 	})

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -79,7 +79,7 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 
 	d := fetchTestDistro()
 	d.Provider = evergreen.ProviderNameEc2OnDemand
-	h := NewIntent(d, d.GenerateName(), d.Provider, HostOptions{
+	h := host.NewIntent(d, d.GenerateName(), d.Provider, host.HostOptions{
 		UserName: evergreen.User,
 		UserHost: false,
 	})
@@ -146,7 +146,7 @@ func TestSpawnEC2InstanceSpot(t *testing.T) {
 	require.NoError(m.client.Create(m.credentials, defaultRegion))
 	d := fetchTestDistro()
 	d.Provider = evergreen.ProviderNameEc2Spot
-	h := NewIntent(d, d.GenerateName(), d.Provider, HostOptions{
+	h := host.NewIntent(d, d.GenerateName(), d.Provider, host.HostOptions{
 		UserName: evergreen.User,
 		UserHost: false,
 	})

--- a/cloud/gce_test.go
+++ b/cloud/gce_test.go
@@ -21,7 +21,7 @@ type GCESuite struct {
 	client   gceClient
 	manager  *gceManager
 	distro   distro.Distro
-	hostOpts host.HostOptions
+	hostOpts host.CreateOptions
 	suite.Suite
 }
 
@@ -52,7 +52,7 @@ func (s *GCESuite) SetupTest() {
 			"network_tags":  []string{"abc", "def", "ghi"},
 		},
 	}
-	s.hostOpts = host.HostOptions{}
+	s.hostOpts = host.CreateOptions{}
 }
 
 func (s *GCESuite) TestValidateSettings() {
@@ -381,7 +381,7 @@ func (s *GCESuite) TestSpawnAPICall() {
 			"disk_size_gb":  10,
 		},
 	}
-	opts := host.HostOptions{}
+	opts := host.CreateOptions{}
 
 	mock, ok := s.client.(*gceClientMock)
 	s.True(ok)

--- a/cloud/gce_test.go
+++ b/cloud/gce_test.go
@@ -21,7 +21,7 @@ type GCESuite struct {
 	client   gceClient
 	manager  *gceManager
 	distro   distro.Distro
-	hostOpts HostOptions
+	hostOpts host.HostOptions
 	suite.Suite
 }
 
@@ -52,7 +52,7 @@ func (s *GCESuite) SetupTest() {
 			"network_tags":  []string{"abc", "def", "ghi"},
 		},
 	}
-	s.hostOpts = HostOptions{}
+	s.hostOpts = host.HostOptions{}
 }
 
 func (s *GCESuite) TestValidateSettings() {
@@ -216,14 +216,14 @@ func (s *GCESuite) TestTerminateInstanceAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hostA := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostA := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostA, err := s.manager.SpawnHost(ctx, hostA)
 	s.NotNil(hostA)
 	s.NoError(err)
 	_, err = hostA.Upsert()
 	s.NoError(err)
 
-	hostB := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostB := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostB, err = s.manager.SpawnHost(ctx, hostB)
 	s.NotNil(hostB)
 	s.NoError(err)
@@ -245,7 +245,7 @@ func (s *GCESuite) TestTerminateInstanceDB() {
 	defer cancel()
 
 	// Spawn the instance - check the host is not terminated in DB.
-	myHost := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	myHost := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	myHost, err := s.manager.SpawnHost(ctx, myHost)
 	s.NotNil(myHost)
 	s.NoError(err)
@@ -329,14 +329,14 @@ func (s *GCESuite) TestSpawnInvalidSettings() {
 
 	var err error
 	dProviderName := distro.Distro{Provider: "ec2"}
-	h := NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
+	h := host.NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
 	s.NotNil(h)
 	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
 	s.Nil(h)
 
 	dSettingsNone := distro.Distro{Provider: "gce"}
-	h = NewIntent(dSettingsNone, dSettingsNone.GenerateName(), dSettingsNone.Provider, s.hostOpts)
+	h = host.NewIntent(dSettingsNone, dSettingsNone.GenerateName(), dSettingsNone.Provider, s.hostOpts)
 	s.NotNil(h)
 	h, err = s.manager.SpawnHost(ctx, h)
 	s.Nil(h)
@@ -346,7 +346,7 @@ func (s *GCESuite) TestSpawnInvalidSettings() {
 		Provider:         "gce",
 		ProviderSettings: &map[string]interface{}{"instance_type": ""},
 	}
-	h = NewIntent(dSettingsInvalid, dSettingsInvalid.GenerateName(), dSettingsInvalid.Provider, s.hostOpts)
+	h = host.NewIntent(dSettingsInvalid, dSettingsInvalid.GenerateName(), dSettingsInvalid.Provider, s.hostOpts)
 	s.NotNil(h)
 	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
@@ -359,12 +359,12 @@ func (s *GCESuite) TestSpawnDuplicateHostID() {
 
 	// SpawnInstance should generate a unique ID for each instance, even
 	// when using the same distro. Otherwise the DB would return an error.
-	hostOne := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostOne := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostOne, err := s.manager.SpawnHost(ctx, hostOne)
 	s.NoError(err)
 	s.NotNil(hostOne)
 
-	hostTwo := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostTwo := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostTwo, err = s.manager.SpawnHost(ctx, hostTwo)
 	s.NoError(err)
 	s.NotNil(hostTwo)
@@ -381,7 +381,7 @@ func (s *GCESuite) TestSpawnAPICall() {
 			"disk_size_gb":  10,
 		},
 	}
-	opts := HostOptions{}
+	opts := host.HostOptions{}
 
 	mock, ok := s.client.(*gceClientMock)
 	s.True(ok)
@@ -390,13 +390,13 @@ func (s *GCESuite) TestSpawnAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	h := NewIntent(dist, dist.GenerateName(), dist.Provider, opts)
+	h := host.NewIntent(dist, dist.GenerateName(), dist.Provider, opts)
 	h, err := s.manager.SpawnHost(ctx, h)
 	s.NoError(err)
 	s.NotNil(h)
 
 	mock.failCreate = true
-	h = NewIntent(dist, dist.GenerateName(), dist.Provider, opts)
+	h = host.NewIntent(dist, dist.GenerateName(), dist.Provider, opts)
 	s.NotNil(h)
 	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)

--- a/cloud/openstack_test.go
+++ b/cloud/openstack_test.go
@@ -17,7 +17,7 @@ type OpenStackSuite struct {
 	keyname  string
 	manager  *openStackManager
 	distro   distro.Distro
-	hostOpts host.HostOptions
+	hostOpts host.CreateOptions
 	suite.Suite
 }
 
@@ -47,7 +47,7 @@ func (s *OpenStackSuite) SetupTest() {
 			"security_group": "group",
 		},
 	}
-	s.hostOpts = host.HostOptions{}
+	s.hostOpts = host.CreateOptions{}
 }
 
 func (s *OpenStackSuite) TestValidateSettings() {

--- a/cloud/openstack_test.go
+++ b/cloud/openstack_test.go
@@ -17,7 +17,7 @@ type OpenStackSuite struct {
 	keyname  string
 	manager  *openStackManager
 	distro   distro.Distro
-	hostOpts HostOptions
+	hostOpts host.HostOptions
 	suite.Suite
 }
 
@@ -47,7 +47,7 @@ func (s *OpenStackSuite) SetupTest() {
 			"security_group": "group",
 		},
 	}
-	s.hostOpts = HostOptions{}
+	s.hostOpts = host.HostOptions{}
 }
 
 func (s *OpenStackSuite) TestValidateSettings() {
@@ -158,14 +158,14 @@ func (s *OpenStackSuite) TestTerminateInstanceAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hostA := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostA := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostA, err := s.manager.SpawnHost(ctx, hostA)
 	s.NotNil(hostA)
 	s.NoError(err)
 	_, err = hostA.Upsert()
 	s.NoError(err)
 
-	hostB := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostB := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostB, err = s.manager.SpawnHost(ctx, hostB)
 	s.NotNil(hostB)
 	s.NoError(err)
@@ -187,7 +187,7 @@ func (s *OpenStackSuite) TestTerminateInstanceDB() {
 	defer cancel()
 
 	// Spawn the instance - check the host is not terminated in DB.
-	myHost := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	myHost := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	myHost, err := s.manager.SpawnHost(ctx, myHost)
 	s.NotNil(myHost)
 	s.NoError(err)
@@ -249,27 +249,27 @@ func (s *OpenStackSuite) TestSpawnInvalidSettings() {
 
 	var err error
 	dProviderName := distro.Distro{Provider: "ec2"}
-	host := NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
-	s.NotNil(host)
-	host, err = s.manager.SpawnHost(ctx, host)
+	h := host.NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
+	s.NotNil(h)
+	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
-	s.Nil(host)
+	s.Nil(h)
 
 	dSettingsNone := distro.Distro{Provider: "openstack"}
-	host = NewIntent(dSettingsNone, dSettingsNone.GenerateName(), dSettingsNone.Provider, s.hostOpts)
-	host, err = s.manager.SpawnHost(ctx, host)
+	h = host.NewIntent(dSettingsNone, dSettingsNone.GenerateName(), dSettingsNone.Provider, s.hostOpts)
+	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
-	s.Nil(host)
+	s.Nil(h)
 
 	dSettingsInvalid := distro.Distro{
 		Provider:         "openstack",
 		ProviderSettings: &map[string]interface{}{"image_name": ""},
 	}
-	host = NewIntent(dSettingsInvalid, dSettingsInvalid.GenerateName(), dSettingsInvalid.Provider, s.hostOpts)
-	s.NotNil(host)
-	host, err = s.manager.SpawnHost(ctx, host)
+	h = host.NewIntent(dSettingsInvalid, dSettingsInvalid.GenerateName(), dSettingsInvalid.Provider, s.hostOpts)
+	s.NotNil(h)
+	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
-	s.Nil(host)
+	s.Nil(h)
 }
 
 func (s *OpenStackSuite) TestSpawnDuplicateHostID() {
@@ -278,7 +278,7 @@ func (s *OpenStackSuite) TestSpawnDuplicateHostID() {
 
 	// SpawnInstance should generate a unique ID for each instance, even
 	// when using the same distro. Otherwise the DB would return an error.
-	hostOne := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostOne := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 
 	hostOne, err := s.manager.SpawnHost(ctx, hostOne)
 	s.NoError(err)
@@ -286,7 +286,7 @@ func (s *OpenStackSuite) TestSpawnDuplicateHostID() {
 	_, err = hostOne.Upsert()
 	s.NoError(err)
 
-	hostTwo := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostTwo := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostTwo, err = s.manager.SpawnHost(ctx, hostTwo)
 	s.NoError(err)
 	s.NotNil(hostTwo)
@@ -313,19 +313,19 @@ func (s *OpenStackSuite) TestSpawnAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	host := NewIntent(dist, dist.GenerateName(), dist.Provider, s.hostOpts)
-	host, err := s.manager.SpawnHost(ctx, host)
+	h := host.NewIntent(dist, dist.GenerateName(), dist.Provider, s.hostOpts)
+	h, err := s.manager.SpawnHost(ctx, h)
 	s.NoError(err)
-	s.NotNil(host)
-	_, err = host.Upsert()
+	s.NotNil(h)
+	_, err = h.Upsert()
 	s.NoError(err)
 
 	mock.failCreate = true
-	host = NewIntent(dist, dist.GenerateName(), dist.Provider, s.hostOpts)
+	h = host.NewIntent(dist, dist.GenerateName(), dist.Provider, s.hostOpts)
 
-	host, err = s.manager.SpawnHost(ctx, host)
+	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
-	s.Nil(host)
+	s.Nil(h)
 }
 
 func (s *OpenStackSuite) TestUtilToEvgStatus() {

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -131,7 +131,7 @@ func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 		OwnerId: so.Owner.Id,
 	}
 	expiration := DefaultSpawnHostExpiration
-	hostOptions := host.HostOptions{
+	hostOptions := host.CreateOptions{
 		ProvisionOptions:   provisionOptions,
 		UserName:           so.UserName,
 		ExpirationDuration: &expiration,

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -131,14 +131,14 @@ func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 		OwnerId: so.Owner.Id,
 	}
 	expiration := DefaultSpawnHostExpiration
-	hostOptions := HostOptions{
+	hostOptions := host.HostOptions{
 		ProvisionOptions:   provisionOptions,
 		UserName:           so.UserName,
 		ExpirationDuration: &expiration,
 		UserHost:           true,
 	}
 
-	intentHost := NewIntent(d, d.GenerateName(), d.Provider, hostOptions)
+	intentHost := host.NewIntent(d, d.GenerateName(), d.Provider, hostOptions)
 	if intentHost == nil { // theoretically this should not happen
 		return nil, errors.New("unable to intent host: NewIntent did not return a host")
 	}

--- a/cloud/vsphere_test.go
+++ b/cloud/vsphere_test.go
@@ -19,7 +19,7 @@ type VSphereSuite struct {
 	client   vsphereClient
 	manager  *vsphereManager
 	distro   distro.Distro
-	hostOpts host.HostOptions
+	hostOpts host.CreateOptions
 	suite.Suite
 }
 
@@ -45,7 +45,7 @@ func (s *VSphereSuite) SetupTest() {
 			"template": "macos-1012",
 		},
 	}
-	s.hostOpts = host.HostOptions{}
+	s.hostOpts = host.CreateOptions{}
 }
 
 func (s *VSphereSuite) TestValidateSettings() {

--- a/cloud/vsphere_test.go
+++ b/cloud/vsphere_test.go
@@ -19,7 +19,7 @@ type VSphereSuite struct {
 	client   vsphereClient
 	manager  *vsphereManager
 	distro   distro.Distro
-	hostOpts HostOptions
+	hostOpts host.HostOptions
 	suite.Suite
 }
 
@@ -45,7 +45,7 @@ func (s *VSphereSuite) SetupTest() {
 			"template": "macos-1012",
 		},
 	}
-	s.hostOpts = HostOptions{}
+	s.hostOpts = host.HostOptions{}
 }
 
 func (s *VSphereSuite) TestValidateSettings() {
@@ -145,14 +145,14 @@ func (s *VSphereSuite) TestTerminateInstanceAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hostA := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostA := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostA, err := s.manager.SpawnHost(ctx, hostA)
 	s.NotNil(hostA)
 	s.NoError(err)
 	err = hostA.Insert()
 	s.NoError(err)
 
-	hostB := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostB := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostB, err = s.manager.SpawnHost(ctx, hostB)
 	s.NotNil(hostB)
 	s.NoError(err)
@@ -174,7 +174,7 @@ func (s *VSphereSuite) TestTerminateInstanceDB() {
 	defer cancel()
 
 	// Spawn the instance - check the host is not terminated in DB.
-	myHost := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	myHost := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	err := myHost.Insert()
 	s.NoError(err)
 	myHost, err = s.manager.SpawnHost(ctx, myHost)
@@ -235,26 +235,26 @@ func (s *VSphereSuite) TestSpawnInvalidSettings() {
 	defer cancel()
 
 	dProviderName := distro.Distro{Provider: "ec2"}
-	host := NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
-	s.NotNil(host)
-	host, err := s.manager.SpawnHost(ctx, host)
+	h := host.NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
+	s.NotNil(h)
+	h, err := s.manager.SpawnHost(ctx, h)
 	s.Error(err)
-	s.Nil(host)
+	s.Nil(h)
 
 	dSettingsNone := distro.Distro{Provider: "vsphere"}
-	host = NewIntent(dSettingsNone, dSettingsNone.GenerateName(), dSettingsNone.Provider, s.hostOpts)
-	host, err = s.manager.SpawnHost(ctx, host)
+	h = host.NewIntent(dSettingsNone, dSettingsNone.GenerateName(), dSettingsNone.Provider, s.hostOpts)
+	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
-	s.Nil(host)
+	s.Nil(h)
 
 	dSettingsInvalid := distro.Distro{
 		Provider:         "vsphere",
 		ProviderSettings: &map[string]interface{}{"template": ""},
 	}
-	host = NewIntent(dSettingsInvalid, dSettingsInvalid.GenerateName(), dSettingsInvalid.Provider, s.hostOpts)
-	host, err = s.manager.SpawnHost(ctx, host)
+	h = host.NewIntent(dSettingsInvalid, dSettingsInvalid.GenerateName(), dSettingsInvalid.Provider, s.hostOpts)
+	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
-	s.Nil(host)
+	s.Nil(h)
 }
 
 func (s *VSphereSuite) TestSpawnDuplicateHostID() {
@@ -263,12 +263,12 @@ func (s *VSphereSuite) TestSpawnDuplicateHostID() {
 
 	// SpawnInstance should generate a unique ID for each instance, even
 	// when using the same distro. Otherwise the DB would return an error.
-	hostOne := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostOne := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostOne, err := s.manager.SpawnHost(ctx, hostOne)
 	s.NoError(err)
 	s.NotNil(hostOne)
 
-	hostTwo := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	hostTwo := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
 	hostTwo, err = s.manager.SpawnHost(ctx, hostTwo)
 	s.NoError(err)
 	s.NotNil(hostTwo)
@@ -282,14 +282,14 @@ func (s *VSphereSuite) TestSpawnAPICall() {
 	s.True(ok)
 	s.False(mock.failCreate)
 
-	host := NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
-	host, err := s.manager.SpawnHost(ctx, host)
+	h := host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	h, err := s.manager.SpawnHost(ctx, h)
 	s.NoError(err)
-	s.NotNil(host)
+	s.NotNil(h)
 
 	mock.failCreate = true
-	host = NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
-	_, err = s.manager.SpawnHost(ctx, host)
+	h = host.NewIntent(s.distro, s.distro.GenerateName(), s.distro.Provider, s.hostOpts)
+	_, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
 }
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1144,6 +1144,12 @@ func GetNumContainersOnParents(d distro.Distro) ([]ContainersOnParents, error) {
 					ParentHost:    parent,
 					NumContainers: len(currentContainers),
 				})
+			grip.Info(message.Fields{
+				"operation":                "spawning new parents",
+				"parent":                   parent.Id,
+				"num_containers_on_parent": len(currentContainers),
+				"message":                  "uphost parent to assign to containers",
+			})
 		}
 	}
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1152,12 +1152,6 @@ func GetNumContainersOnParents(d distro.Distro) ([]ContainersOnParents, error) {
 					ParentHost:    parent,
 					NumContainers: len(currentContainers),
 				})
-			grip.Info(message.Fields{
-				"operation":                "spawning new parents",
-				"parent":                   parent.Id,
-				"num_containers_on_parent": len(currentContainers),
-				"message":                  "uphost parent to assign to containers",
-			})
 		}
 	}
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -933,13 +933,21 @@ func (h *Host) GetParent() (*Host, error) {
 	if h.ParentID == "" {
 		return nil, errors.New("Host does not have a parent")
 	}
-
-	host, err := FindOneId(h.ParentID)
+	query := db.Query(bson.M{
+		TagKey: h.ParentID,
+	})
+	host, err := FindOne(query) // try to find by tag
 	if err != nil {
 		return nil, errors.Wrap(err, "Error finding parent")
 	}
 	if host == nil {
-		return nil, errors.New("Parent not found")
+		host, err = FindOneId(h.ParentID)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error finding parent")
+		}
+		if host == nil {
+			return nil, errors.New("Parent not found")
+		}
 	}
 	if !host.HasContainers {
 		return nil, errors.New("Host found is not a parent")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1146,6 +1146,7 @@ func GetNumContainersOnParents(d distro.Distro) ([]ContainersOnParents, error) {
 				})
 		}
 	}
+
 	return numContainersOnParents, nil
 }
 

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -9,9 +9,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// HostOptions is a struct of options that are commonly passed around when creating a
+// CreateOptions is a struct of options that are commonly passed around when creating a
 // new cloud host.
-type HostOptions struct {
+type CreateOptions struct {
 	ProvisionOptions   *ProvisionOptions
 	ExpirationDuration *time.Duration
 	UserName           string
@@ -27,8 +27,8 @@ type HostOptions struct {
 // NewIntent creates an IntentHost using the given host settings. An IntentHost is a host that
 // does not exist yet but is intended to be picked up by the hostinit package and started. This
 // function takes distro information, the name of the instance, the provider of the instance and
-// a HostOptions and returns an IntentHost.
-func NewIntent(d distro.Distro, instanceName, provider string, options HostOptions) *Host {
+// a CreateOptions and returns an IntentHost.
+func NewIntent(d distro.Distro, instanceName, provider string, options CreateOptions) *Host {
 	creationTime := time.Now()
 	// proactively write all possible information pertaining
 	// to the host we want to create. this way, if we are unable
@@ -65,7 +65,7 @@ func NewIntent(d distro.Distro, instanceName, provider string, options HostOptio
 // GenerateContainerHostIntents generates container intent documents by going
 // through available parents and packing on the parents with longest expected
 // finish time
-func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, hostOptions HostOptions) ([]Host, error) {
+func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, hostOptions CreateOptions) ([]Host, error) {
 	parents, err := GetNumContainersOnParents(d)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not find number of containers on each parent")
@@ -97,14 +97,14 @@ func createParents(parent distro.Distro, numNewParents int, pool *evergreen.Cont
 	hostsSpawned := make([]Host, numNewParents)
 
 	for idx := range hostsSpawned {
-		hostsSpawned[idx] = *NewIntent(parent, parent.GenerateName(), parent.Provider, generateParentHostOptions(pool))
+		hostsSpawned[idx] = *NewIntent(parent, parent.GenerateName(), parent.Provider, generateParentCreateOptions(pool))
 	}
 	return hostsSpawned
 }
 
-// generateParentHostOptions generates host options for a parent host
-func generateParentHostOptions(pool *evergreen.ContainerPool) HostOptions {
-	options := HostOptions{
+// generateParentCreateOptions generates host options for a parent host
+func generateParentCreateOptions(pool *evergreen.ContainerPool) CreateOptions {
+	options := CreateOptions{
 		HasContainers:         true,
 		UserName:              evergreen.User,
 		ContainerPoolSettings: pool,

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -3,9 +3,6 @@ package host
 import (
 	"time"
 
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/util"
@@ -73,12 +70,6 @@ func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, host
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not find number of containers on each parent")
 	}
-	grip.Info(message.Fields{
-		"new_containers_needed": newContainersNeeded,
-		"num_parents":           len(parents),
-		"distro":                d.Id,
-		"operation":             "spawning new parents",
-	})
 	containerHostIntents := make([]Host, 0)
 
 	for _, parent := range parents {
@@ -92,12 +83,6 @@ func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, host
 		for i := 0; i < containersToCreate; i++ {
 			hostOptions.ParentID = parent.ParentHost.Id
 			containerHostIntents = append(containerHostIntents, *NewIntent(d, d.GenerateName(), d.Provider, hostOptions))
-			grip.Info(message.Fields{
-				"message":   "creating container host intent",
-				"parent_id": parent.ParentHost.Id,
-				"distro":    d.Id,
-				"operation": "spawning new parents",
-			})
 		}
 		newContainersNeeded -= containersToCreate
 		if newContainersNeeded == 0 {
@@ -113,12 +98,6 @@ func createParents(parent distro.Distro, numNewParents int, pool *evergreen.Cont
 
 	for idx := range hostsSpawned {
 		hostsSpawned[idx] = *NewIntent(parent, parent.GenerateName(), parent.Provider, generateParentCreateOptions(pool))
-		grip.Info(message.Fields{
-			"message":   "adding parent",
-			"parent_id": hostsSpawned[idx].Id,
-			"operation": "spawning new parents",
-			"distro":    parent.Id,
-		})
 	}
 	return hostsSpawned
 }
@@ -150,11 +129,6 @@ func InsertParentIntentsAndGetNumHostsToSpawn(pool *evergreen.ContainerPool, new
 	}
 	newParentHosts := createParents(parentDistro, numNewParentsToSpawn, pool)
 	if err = InsertMany(newParentHosts); err != nil {
-		grip.Error(message.Fields{
-			"operation": "spawning new parents",
-			"error":     err,
-			"message":   "error inserting new parent hosts",
-		})
 		return nil, 0, errors.Wrap(err, "error inserting new parent hosts")
 	}
 	return newParentHosts, newHostsNeeded, nil

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -1,26 +1,40 @@
-package cloud
+package host
 
 import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
-	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/pkg/errors"
 )
+
+// HostOptions is a struct of options that are commonly passed around when creating a
+// new cloud host.
+type HostOptions struct {
+	ProvisionOptions   *ProvisionOptions
+	ExpirationDuration *time.Duration
+	UserName           string
+	UserHost           bool
+
+	HasContainers         bool
+	ParentID              string
+	ContainerPoolSettings *evergreen.ContainerPool
+	SpawnOptions          SpawnOptions
+	DockerOptions         DockerOptions
+}
 
 // NewIntent creates an IntentHost using the given host settings. An IntentHost is a host that
 // does not exist yet but is intended to be picked up by the hostinit package and started. This
 // function takes distro information, the name of the instance, the provider of the instance and
 // a HostOptions and returns an IntentHost.
-func NewIntent(d distro.Distro, instanceName, provider string, options HostOptions) *host.Host {
+func NewIntent(d distro.Distro, instanceName, provider string, options HostOptions) *Host {
 	creationTime := time.Now()
 	// proactively write all possible information pertaining
 	// to the host we want to create. this way, if we are unable
 	// to start it or record its instance id, we have a way of knowing
 	// something went wrong - and what
-	intentHost := &host.Host{
+	intentHost := &Host{
 		Id:                    instanceName,
 		User:                  d.User,
 		Distro:                d,
@@ -51,12 +65,12 @@ func NewIntent(d distro.Distro, instanceName, provider string, options HostOptio
 // GenerateContainerHostIntents generates container intent documents by going
 // through available parents and packing on the parents with longest expected
 // finish time
-func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, hostOptions HostOptions) ([]host.Host, error) {
-	parents, err := host.GetNumContainersOnParents(d)
+func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, hostOptions HostOptions) ([]Host, error) {
+	parents, err := GetNumContainersOnParents(d)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not find number of containers on each parent")
 	}
-	containerHostIntents := make([]host.Host, 0)
+	containerHostIntents := make([]Host, 0)
 
 	for _, parent := range parents {
 		// find out how many more containers this parent can fit
@@ -79,8 +93,8 @@ func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, host
 }
 
 // createParents creates host intent documents for each parent
-func createParents(parent distro.Distro, numNewParents int, pool *evergreen.ContainerPool) []host.Host {
-	hostsSpawned := make([]host.Host, numNewParents)
+func createParents(parent distro.Distro, numNewParents int, pool *evergreen.ContainerPool) []Host {
+	hostsSpawned := make([]Host, numNewParents)
 
 	for idx := range hostsSpawned {
 		hostsSpawned[idx] = *NewIntent(parent, parent.GenerateName(), parent.Provider, generateParentHostOptions(pool))
@@ -98,14 +112,14 @@ func generateParentHostOptions(pool *evergreen.ContainerPool) HostOptions {
 	return options
 }
 
-func CreateParentIntentsAndHostsToSpawn(pool *evergreen.ContainerPool, newHostsNeeded int) ([]host.Host, int, error) {
+func CreateParentIntentsAndNumHostsToSpawn(pool *evergreen.ContainerPool, newHostsNeeded int, useParentCapacity bool) ([]Host, int, error) {
 	// find all running parents with the specified container pool
 
-	numNewParentsToSpawn, newHostsNeeded, err := host.GetNumNewParentsAndHostsToSpawn(pool, newHostsNeeded)
+	numNewParentsToSpawn, newHostsNeeded, err := getNumNewParentsAndHostsToSpawn(pool, newHostsNeeded, useParentCapacity)
 	if err != nil {
-		return []host.Host{}, 0, errors.Wrap(err, "error getting number of parents to spawn")
+		return []Host{}, 0, errors.Wrap(err, "error getting number of parents to spawn")
 	}
-	newParentHosts := []host.Host{}
+	newParentHosts := []Host{}
 	if numNewParentsToSpawn > 0 {
 		// get parent distro from pool
 		parentDistro, err := distro.FindOne(distro.ById(pool.Distro))

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2134,11 +2134,11 @@ func TestFindAllRunningParentsByContainerPool(t *testing.T) {
 	assert.NoError(host2.Insert())
 	assert.NoError(host3.Insert())
 
-	hosts, err := FindAllRunningParentsByContainerPool("test-pool")
+	hosts, err := findAllRunningParentsByContainerPool("test-pool")
 	assert.NoError(err)
 	assert.Equal([]Host{*host1}, hosts)
 
-	hosts, err = FindAllRunningParentsByContainerPool("missing-test-pool")
+	hosts, err = findAllRunningParentsByContainerPool("missing-test-pool")
 	assert.NoError(err)
 	assert.Empty(hosts)
 
@@ -2510,7 +2510,7 @@ func TestCountUphostParents(t *testing.T) {
 	assert.NoError(h4.Insert())
 	assert.NoError(h5.Insert())
 
-	numUphostParents, err := CountUphostParentsByContainerPool("test-pool")
+	numUphostParents, err := countUphostParentsByContainerPool("test-pool")
 	assert.NoError(err)
 	assert.Equal(2, numUphostParents)
 }
@@ -2740,9 +2740,9 @@ func TestNumNewParentsNeeded(t *testing.T) {
 	assert.NoError(host3.Insert())
 	assert.NoError(host4.Insert())
 
-	currentParents, err := FindAllRunningParentsByContainerPool(d.ContainerPool)
+	currentParents, err := findAllRunningParentsByContainerPool(d.ContainerPool)
 	assert.NoError(err)
-	numUphostParents, err := CountUphostParentsByContainerPool("test-pool")
+	numUphostParents, err := countUphostParentsByContainerPool("test-pool")
 	assert.NoError(err)
 	existingContainers, err := HostGroup(currentParents).FindRunningContainersOnParents()
 	assert.NoError(err)
@@ -2791,9 +2791,9 @@ func TestNumNewParentsNeeded2(t *testing.T) {
 	assert.NoError(host2.Insert())
 	assert.NoError(host3.Insert())
 
-	currentParents, err := FindAllRunningParentsByContainerPool(d.ContainerPool)
+	currentParents, err := findAllRunningParentsByContainerPool(d.ContainerPool)
 	assert.NoError(err)
-	numUphostParents, err := CountUphostParentsByContainerPool("test-pool")
+	numUphostParents, err := countUphostParentsByContainerPool("test-pool")
 	assert.NoError(err)
 	existingContainers, err := HostGroup(currentParents).FindRunningContainersOnParents()
 	assert.NoError(err)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2698,3 +2698,248 @@ func TestStaleRunningTasksAgg(t *testing.T) {
 	assert.Equal(staleTask.Id, tasks[0].Id)
 	assert.Equal(staleTask.Execution, tasks[0].Execution)
 }
+
+func TestNumNewParentsNeeded(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections("hosts", "distro", "tasks"))
+
+	d := distro.Distro{Id: "distro", PoolSize: 3, Provider: evergreen.ProviderNameMock,
+		ContainerPool: "test-pool"}
+	pool := &evergreen.ContainerPool{Distro: "distro", Id: "test-pool", MaxContainers: 2}
+	host1 := &Host{
+		Id:                    "host1",
+		Host:                  "host",
+		User:                  "user",
+		Distro:                distro.Distro{Id: "parent-distro"},
+		Status:                evergreen.HostRunning,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
+	}
+	host2 := &Host{
+		Id:       "host2",
+		Distro:   d,
+		Status:   evergreen.HostRunning,
+		ParentID: "host1",
+	}
+	host3 := &Host{
+		Id:       "host3",
+		Distro:   d,
+		Status:   evergreen.HostRunning,
+		ParentID: "host1",
+	}
+	host4 := &Host{
+		Id:                    "host4",
+		Distro:                d,
+		Status:                evergreen.HostUninitialized,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
+	}
+
+	assert.NoError(host1.Insert())
+	assert.NoError(host2.Insert())
+	assert.NoError(host3.Insert())
+	assert.NoError(host4.Insert())
+
+	currentParents, err := FindAllRunningParentsByContainerPool(d.ContainerPool)
+	assert.NoError(err)
+	numUphostParents, err := CountUphostParentsByContainerPool("test-pool")
+	assert.NoError(err)
+	existingContainers, err := HostGroup(currentParents).FindRunningContainersOnParents()
+	assert.NoError(err)
+
+	parentsParams := newParentsNeededParams{
+		numUphostParents:      numUphostParents,
+		numContainersNeeded:   1,
+		numExistingContainers: len(existingContainers),
+		maxContainers:         pool.MaxContainers,
+	}
+	num := numNewParentsNeeded(parentsParams)
+	assert.Equal(0, num)
+}
+
+func TestNumNewParentsNeeded2(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections("hosts", "distro", "tasks"))
+
+	d := distro.Distro{Id: "distro", PoolSize: 3, Provider: evergreen.ProviderNameMock,
+		ContainerPool: "test-pool"}
+	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 3}
+
+	host1 := &Host{
+		Id:                    "host1",
+		Host:                  "host",
+		User:                  "user",
+		Distro:                distro.Distro{Id: "parent-distro"},
+		Status:                evergreen.HostRunning,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
+	}
+	host2 := &Host{
+		Id:       "host2",
+		Distro:   d,
+		Status:   evergreen.HostRunning,
+		ParentID: "host1",
+	}
+	host3 := &Host{
+		Id:       "host3",
+		Distro:   d,
+		Status:   evergreen.HostTerminated,
+		ParentID: "host1",
+	}
+
+	assert.NoError(host1.Insert())
+	assert.NoError(host2.Insert())
+	assert.NoError(host3.Insert())
+
+	currentParents, err := FindAllRunningParentsByContainerPool(d.ContainerPool)
+	assert.NoError(err)
+	numUphostParents, err := CountUphostParentsByContainerPool("test-pool")
+	assert.NoError(err)
+	existingContainers, err := HostGroup(currentParents).FindRunningContainersOnParents()
+	assert.NoError(err)
+
+	parentsParams := newParentsNeededParams{
+		numUphostParents:      numUphostParents,
+		numContainersNeeded:   1,
+		numExistingContainers: len(existingContainers),
+		maxContainers:         pool.MaxContainers,
+	}
+	num := numNewParentsNeeded(parentsParams)
+	assert.Equal(0, num)
+}
+
+func TestFindAvailableParent(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections("hosts", "distro", "tasks"))
+
+	d := distro.Distro{Id: "distro", PoolSize: 3, Provider: evergreen.ProviderNameMock,
+		ContainerPool: "test-pool"}
+	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 2}
+	durationOne := 20 * time.Minute
+	durationTwo := 30 * time.Minute
+
+	host1 := &Host{
+		Id:                    "host1",
+		Host:                  "host",
+		User:                  "user",
+		Distro:                distro.Distro{Id: "parent-distro"},
+		Status:                evergreen.HostRunning,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
+	}
+	host2 := &Host{
+		Id:                    "host2",
+		Distro:                distro.Distro{Id: "parent-distro"},
+		Status:                evergreen.HostRunning,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
+	}
+	host3 := &Host{
+		Id:          "host3",
+		Distro:      d,
+		Status:      evergreen.HostRunning,
+		ParentID:    "host1",
+		RunningTask: "task1",
+	}
+	host4 := &Host{
+		Id:          "host4",
+		Distro:      d,
+		Status:      evergreen.HostRunning,
+		ParentID:    "host2",
+		RunningTask: "task2",
+	}
+	task1 := task.Task{
+		Id: "task1",
+		DurationPrediction: util.CachedDurationValue{
+			Value: durationOne,
+		},
+		BuildVariant: "bv1",
+		StartTime:    time.Now(),
+	}
+	task2 := task.Task{
+		Id: "task2",
+		DurationPrediction: util.CachedDurationValue{
+			Value: durationTwo,
+		},
+		BuildVariant: "bv1",
+		StartTime:    time.Now(),
+	}
+	assert.NoError(d.Insert())
+	assert.NoError(host1.Insert())
+	assert.NoError(host2.Insert())
+	assert.NoError(host3.Insert())
+	assert.NoError(host4.Insert())
+	assert.NoError(task1.Insert())
+	assert.NoError(task2.Insert())
+
+	availableParent, err := GetNumContainersOnParents(d)
+	assert.NoError(err)
+
+	assert.Equal(2, len(availableParent))
+}
+
+func TestFindNoAvailableParent(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections("hosts", "distro", "tasks"))
+
+	d := distro.Distro{Id: "distro", PoolSize: 3, Provider: evergreen.ProviderNameMock}
+	pool := &evergreen.ContainerPool{Distro: "distro", Id: "test-pool", MaxContainers: 1}
+	durationOne := 20 * time.Minute
+	durationTwo := 30 * time.Minute
+
+	host1 := &Host{
+		Id:                    "host1",
+		Host:                  "host",
+		User:                  "user",
+		Distro:                distro.Distro{Id: "distro"},
+		Status:                evergreen.HostRunning,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
+	}
+	host2 := &Host{
+		Id:                    "host2",
+		Distro:                distro.Distro{Id: "distro"},
+		Status:                evergreen.HostRunning,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
+	}
+	host3 := &Host{
+		Id:          "host3",
+		Distro:      distro.Distro{Id: "distro", ContainerPool: "test-pool"},
+		Status:      evergreen.HostRunning,
+		ParentID:    "host1",
+		RunningTask: "task1",
+	}
+	host4 := &Host{
+		Id:          "host4",
+		Distro:      distro.Distro{Id: "distro", ContainerPool: "test-pool"},
+		Status:      evergreen.HostRunning,
+		ParentID:    "host2",
+		RunningTask: "task2",
+	}
+	task1 := task.Task{
+		Id: "task1",
+		DurationPrediction: util.CachedDurationValue{
+			Value: durationOne,
+		}, BuildVariant: "bv1",
+		StartTime: time.Now(),
+	}
+	task2 := task.Task{
+		Id: "task2",
+		DurationPrediction: util.CachedDurationValue{
+			Value: durationTwo,
+		}, BuildVariant: "bv1",
+		StartTime: time.Now(),
+	}
+	assert.NoError(d.Insert())
+	assert.NoError(host1.Insert())
+	assert.NoError(host2.Insert())
+	assert.NoError(host3.Insert())
+	assert.NoError(host4.Insert())
+	assert.NoError(task1.Insert())
+	assert.NoError(task2.Insert())
+
+	availableParent, err := GetNumContainersOnParents(d)
+	assert.NoError(err)
+	assert.Equal(0, len(availableParent))
+}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -281,8 +281,8 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	return host.NewIntent(d, d.GenerateName(), provider, *options), nil
 }
 
-func getAgentOptions(taskID, userID string, createHost apimodels.CreateHost) (*host.HostOptions, error) {
-	options := host.HostOptions{}
+func getAgentOptions(taskID, userID string, createHost apimodels.CreateHost) (*host.CreateOptions, error) {
+	options := host.CreateOptions{}
 	if userID != "" {
 		options.UserName = userID
 		options.UserHost = true

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/cloud"
@@ -195,7 +194,14 @@ func makeDockerIntentHost(taskID, userID string, createHost apimodels.CreateHost
 		SkipImageBuild:   true,
 	}
 
-	return cloud.NewIntent(d, d.GenerateName(), d.Provider, *options), nil
+	hostIntents, err := cloud.GenerateContainerHostIntents(d, 1, *options)
+	if err != nil {
+		return nil, errors.Wrap(err, "error generating host intent")
+	}
+	if len(hostIntents) != 1 {
+		return nil, errors.New("no parents available for new host intent")
+	}
+	return &hostIntents[0], nil
 
 }
 

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -194,12 +194,12 @@ func makeDockerIntentHost(taskID, userID string, createHost apimodels.CreateHost
 		SkipImageBuild:   true,
 	}
 
-	hostIntents, err := cloud.GenerateContainerHostIntents(d, 1, *options)
+	hostIntents, err := host.GenerateContainerHostIntents(d, 1, *options)
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating host intent")
 	}
 	if len(hostIntents) != 1 {
-		return nil, errors.New("no parents available for new host intent")
+		return nil, errors.New("Programmer error: should have created one new container")
 	}
 	return &hostIntents[0], nil
 
@@ -278,11 +278,11 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		return nil, errors.Wrap(err, "error making host options for EC2")
 	}
 
-	return cloud.NewIntent(d, d.GenerateName(), provider, *options), nil
+	return host.NewIntent(d, d.GenerateName(), provider, *options), nil
 }
 
-func getAgentOptions(taskID, userID string, createHost apimodels.CreateHost) (*cloud.HostOptions, error) {
-	options := cloud.HostOptions{}
+func getAgentOptions(taskID, userID string, createHost apimodels.CreateHost) (*host.HostOptions, error) {
+	options := host.HostOptions{}
 	if userID != "" {
 		options.UserName = userID
 		options.UserHost = true

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -252,6 +252,7 @@ buildvariants:
   tasks:
   - name: t1
 `
+
 	v1 := model.Version{
 		Id:         "v1",
 		Config:     versionYaml,
@@ -263,10 +264,25 @@ buildvariants:
 		RunningTask: t1.Id,
 	}
 	assert.NoError(h1.Insert())
-	d := distro.Distro{
-		Id: "distro",
+
+	parent := distro.Distro{Id: "parent-distro", PoolSize: 3, Provider: evergreen.ProviderNameMock}
+	require.NoError(parent.Insert())
+
+	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 2}
+	parentHost := &host.Host{
+		Id:                    "host1",
+		Host:                  "host",
+		User:                  "user",
+		Distro:                distro.Distro{Id: "parent-distro"},
+		Status:                evergreen.HostRunning,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
 	}
-	assert.NoError(d.Insert())
+	require.NoError(parentHost.Insert())
+
+	d := distro.Distro{Id: "distro", Provider: evergreen.ProviderNameMock, ContainerPool: "test-pool"}
+	require.NoError(d.Insert())
+
 	p := model.ProjectRef{
 		Identifier: "p",
 	}

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -77,7 +77,6 @@ func (h *hostCreateHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.NewJSONErrorResponse(errors.Wrapf(err, "error getting distro %s", h.createHost.Distro))
 	}
 	if distro.ContainerPool != "" && h.createHost.CloudProvider == evergreen.ProviderNameDocker {
-		var parents []host.Host
 		settings, err := evergreen.GetConfig()
 		if err != nil {
 			return gimlet.NewJSONErrorResponse(errors.Wrap(err, "error getting settings config"))
@@ -88,11 +87,10 @@ func (h *hostCreateHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.NewJSONErrorResponse(errors.Errorf("container pool %s not found", distro.ContainerPool))
 		}
 
-		parents, numHosts, err = host.CreateParentIntentsAndNumHostsToSpawn(containerPool, 1, false)
+		_, numHosts, err = host.InsertParentIntentsAndGetNumHostsToSpawn(containerPool, 1, true)
 		if err != nil {
-			return gimlet.NewJSONErrorResponse(errors.Wrap(err, "error getting parent intents and number of hosts to spawn"))
+			return gimlet.NewJSONErrorResponse(errors.Wrap(err, "error creating parent intents and number of hosts to spawn"))
 		}
-		hosts = append(hosts, parents...)
 	}
 
 	ids := []string{}

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
-	"github.com/evergreen-ci/evergreen/cloud"
 	dbModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -89,7 +88,7 @@ func (h *hostCreateHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.NewJSONErrorResponse(errors.Errorf("container pool %s not found", distro.ContainerPool))
 		}
 
-		parents, numHosts, err = cloud.CreateParentIntentsAndHostsToSpawn(containerPool, 1)
+		parents, numHosts, err = host.CreateParentIntentsAndNumHostsToSpawn(containerPool, 1, false)
 		if err != nil {
 			return gimlet.NewJSONErrorResponse(errors.Wrap(err, "error getting parent intents and number of hosts to spawn"))
 		}

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -276,6 +276,8 @@ func TestGetDockerLogs(t *testing.T) {
 		Command:       "echo hello",
 	}
 	h, err := handler.sc.MakeIntentHost("task-id", "", "", c)
+	assert.NotEmpty(h.ParentID)
+	h.ExternalIdentifier = "my-container"
 	require.NoError(err)
 	require.NoError(h.Insert())
 
@@ -342,35 +344,40 @@ func TestGetDockerLogsError(t *testing.T) {
 	handler := containerLogsHandler{
 		sc: &data.MockConnector{},
 	}
+	parent := distro.Distro{Id: "parent-distro", PoolSize: 3, Provider: evergreen.ProviderNameMock}
+	require.NoError(parent.Insert())
 
-	d := distro.Distro{
-		Id: "archlinux-test",
-		ProviderSettings: &map[string]interface{}{
-			"ami": "ami-123456",
-		},
+	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 2}
+	parentHost := &host.Host{
+		Id:                    "host1",
+		Host:                  "host",
+		User:                  "user",
+		Distro:                distro.Distro{Id: "parent-distro"},
+		Status:                evergreen.HostRunning,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
 	}
+	require.NoError(parentHost.Insert())
+
+	d := distro.Distro{Id: "distro", Provider: evergreen.ProviderNameMock, ContainerPool: "test-pool"}
 	require.NoError(d.Insert())
+
 	myTask := task.Task{
 		Id:      "task-id",
 		BuildId: "build-id",
 	}
 	require.NoError(myTask.Insert())
-
-	h, err := handler.sc.MakeIntentHost("task-id", "", "", apimodels.CreateHost{
-		Distro:        "archlinux-test",
-		CloudProvider: "docker",
+	c := apimodels.CreateHost{
+		CloudProvider: apimodels.ProviderDocker,
 		NumHosts:      "1",
-		Scope:         "task",
-	})
-	require.NoError(err)
-	h.ParentID = "parent"
-	require.NoError(h.Insert())
-
-	parent := host.Host{
-		Id:            "parent",
-		HasContainers: true,
+		Distro:        "distro",
+		Image:         "my-image",
+		Command:       "echo hello",
 	}
-	require.NoError(parent.Insert())
+	h, err := handler.sc.MakeIntentHost("task-id", "", "", c)
+	assert.NotEmpty(h.ParentID)
+	require.NoError(err)
+	require.NoError(h.Insert())
 
 	url := fmt.Sprintf("/hosts/%s/logs/output", h.Id)
 
@@ -397,35 +404,41 @@ func TestGetDockerStatus(t *testing.T) {
 		sc: &data.MockConnector{},
 	}
 
-	d := distro.Distro{
-		Id: "archlinux-test",
-		ProviderSettings: &map[string]interface{}{
-			"ami": "ami-123456",
-		},
+	parent := distro.Distro{Id: "parent-distro", PoolSize: 3, Provider: evergreen.ProviderNameMock}
+	require.NoError(parent.Insert())
+
+	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 2}
+	parentHost := &host.Host{
+		Id:                    "host1",
+		Host:                  "host",
+		User:                  "user",
+		Distro:                distro.Distro{Id: "parent-distro"},
+		Status:                evergreen.HostRunning,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
 	}
+	require.NoError(parentHost.Insert())
+
+	d := distro.Distro{Id: "distro", Provider: evergreen.ProviderNameMock, ContainerPool: "test-pool"}
 	require.NoError(d.Insert())
+
 	myTask := task.Task{
 		Id:      "task-id",
 		BuildId: "build-id",
 	}
 	require.NoError(myTask.Insert())
-
-	h, err := handler.sc.MakeIntentHost("task-id", "", "", apimodels.CreateHost{
-		Distro:        "archlinux-test",
-		CloudProvider: "docker",
+	c := apimodels.CreateHost{
+		CloudProvider: apimodels.ProviderDocker,
 		NumHosts:      "1",
-		Scope:         "task",
-	})
-	require.NoError(err)
-	h.ParentID = "parent"
-	h.ExternalIdentifier = "my-container"
-	require.NoError(h.Insert())
-
-	parent := host.Host{
-		Id:            "parent",
-		HasContainers: true,
+		Distro:        "distro",
+		Image:         "my-image",
+		Command:       "echo hello",
 	}
-	require.NoError(parent.Insert())
+	h, err := handler.sc.MakeIntentHost("task-id", "", "", c)
+	assert.NotEmpty(h.ParentID)
+	h.ExternalIdentifier = "my-container"
+	require.NoError(err)
+	require.NoError(h.Insert())
 
 	url := fmt.Sprintf("/hosts/%s/logs/status", h.Id)
 	options := map[string]string{"host_id": h.Id}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -149,17 +149,15 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 		return nil, errors.New("scheduling run canceled")
 	}
 
-	// if distro is container distro, check if there are enough parent hosts to
-	// support new containers
+	// if distro is container distro, check if there are enough parent hosts to support new containers
+	var newParentHosts []host.Host
 	if pool != nil {
 		var err error
-		var newParentHosts []host.Host
 		// only want to spawn amount of parents allowed based on pool size
-		newParentHosts, numHostsToSpawn, err = host.CreateParentIntentsAndNumHostsToSpawn(pool, newHostsNeeded, true)
+		newParentHosts, numHostsToSpawn, err = host.InsertParentIntentsAndGetNumHostsToSpawn(pool, newHostsNeeded, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not generate new parents hosts needed")
 		}
-		hostsSpawned = append(hostsSpawned, newParentHosts...)
 		if len(newParentHosts) > 0 {
 			grip.Info(message.Fields{
 				"runner":          RunnerName,
@@ -205,7 +203,7 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 		"duration_secs": time.Since(startTime).Seconds(),
 		"num_hosts":     len(hostsSpawned),
 	})
-
+	hostsSpawned = append(hostsSpawned, newParentHosts...)
 	return hostsSpawned, nil
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -173,7 +173,7 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 
 	// create intent documents for container hosts
 	if d.ContainerPool != "" {
-		hostOptions, err := getHostOptionsFromDistro(d)
+		hostOptions, err := getCreateOptionsFromDistro(d)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error getting docker options from distro %s", d.Id)
 		}
@@ -207,12 +207,12 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 	return hostsSpawned, nil
 }
 
-func getHostOptionsFromDistro(d distro.Distro) (*host.HostOptions, error) {
+func getCreateOptionsFromDistro(d distro.Distro) (*host.CreateOptions, error) {
 	dockerOptions, err := getDockerOptionsFromProviderSettings(*d.ProviderSettings)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error getting docker options from distro %s", d.Id)
 	}
-	hostOptions := host.HostOptions{
+	hostOptions := host.CreateOptions{
 		UserName:      evergreen.User,
 		DockerOptions: *dockerOptions,
 	}
@@ -234,7 +234,7 @@ func getDockerOptionsFromProviderSettings(settings map[string]interface{}) (*hos
 
 // generateIntentHost creates a host intent document for a regular host
 func generateIntentHost(d distro.Distro) (*host.Host, error) {
-	hostOptions := host.HostOptions{
+	hostOptions := host.CreateOptions{
 		UserName: evergreen.User,
 	}
 	return host.NewIntent(d, d.GenerateName(), d.Provider, hostOptions), nil

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -135,7 +135,14 @@ func GetDistroQueueInfo(tasks []task.Task, maxDurationThreshold time.Duration) m
 // distro -> number of hosts to spawn for the distro.
 // Returns a map of distro -> hosts spawned, and an error if one occurs.
 func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *evergreen.ContainerPool) ([]host.Host, error) {
-
+	if newHostsNeeded > 0 {
+		grip.Info(message.Fields{
+			"runner":       RunnerName,
+			"distro":       d.Id,
+			"hosts_needed": newHostsNeeded,
+			"operation":    "spawning new parents",
+		})
+	}
 	startTime := time.Now()
 
 	if newHostsNeeded == 0 {
@@ -203,7 +210,7 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 		"duration_secs": time.Since(startTime).Seconds(),
 		"num_hosts":     len(hostsSpawned),
 	})
-	hostsSpawned = append(hostsSpawned, newParentHosts...)
+	hostsSpawned = append(newParentHosts, hostsSpawned...)
 	return hostsSpawned, nil
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -135,14 +135,6 @@ func GetDistroQueueInfo(tasks []task.Task, maxDurationThreshold time.Duration) m
 // distro -> number of hosts to spawn for the distro.
 // Returns a map of distro -> hosts spawned, and an error if one occurs.
 func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *evergreen.ContainerPool) ([]host.Host, error) {
-	if newHostsNeeded > 0 {
-		grip.Info(message.Fields{
-			"runner":       RunnerName,
-			"distro":       d.Id,
-			"hosts_needed": newHostsNeeded,
-			"operation":    "spawning new parents",
-		})
-	}
 	startTime := time.Now()
 
 	if newHostsNeeded == 0 {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"context"
-	"math"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -37,15 +36,6 @@ type distroScheduler struct {
 	runtimeID string
 	TaskPrioritizer
 	TaskQueuePersister
-}
-
-type newParentsNeededParams struct {
-	numUphostParents, numContainersNeeded, numExistingContainers, maxContainers int
-}
-
-type containersOnParents struct {
-	parentHost    host.Host
-	numContainers int
 }
 
 func (s *distroScheduler) scheduleDistro(distroID string, runnableTasksForDistro []task.Task, versions map[string]model.Version, maxDurationThreshold time.Duration) (
@@ -152,12 +142,8 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 	if newHostsNeeded == 0 {
 		return []host.Host{}, nil
 	}
-
-	// loop over the distros, spawning up the appropriate number of hosts
-	// for each distro
-
+	numHostsToSpawn := newHostsNeeded
 	hostsSpawned := []host.Host{}
-
 	distroStartTime := time.Now()
 
 	if ctx.Err() != nil {
@@ -167,73 +153,40 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 	// if distro is container distro, check if there are enough parent hosts to
 	// support new containers
 	if pool != nil {
-		// find all running parents with the specified container pool
-		currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not find running parents")
-		}
-
-		// find all child containers running on those parents
-		existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
-		if err != nil {
-			return nil, errors.Wrap(err, "could not find running containers")
-		}
-
-		// find all uphost parent intent documents
-		numUphostParents, err := host.CountUphostParentsByContainerPool(pool.Id)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not count uphost parents")
-		}
-
-		// create numParentsNeededParams struct
-		parentsParams := newParentsNeededParams{
-			numUphostParents:      numUphostParents,
-			numContainersNeeded:   newHostsNeeded,
-			numExistingContainers: len(existingContainers),
-			maxContainers:         pool.MaxContainers,
-		}
-		// compute number of parents needed
-		numNewParents := numNewParentsNeeded(parentsParams)
-
-		// get parent distro from pool
-		parentDistro, err := distro.FindOne(distro.ById(pool.Distro))
-		if err != nil {
-			return nil, errors.Wrap(err, "error find parent distro")
-		}
-
+		var err error
+		var newParentHosts []host.Host
 		// only want to spawn amount of parents allowed based on pool size
-		numNewParentsToSpawn, err := parentCapacity(parentDistro, numNewParents, len(currentParents), pool)
+		newParentHosts, numHostsToSpawn, err = cloud.CreateParentIntentsAndHostsToSpawn(pool, newHostsNeeded)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not calculate number of parents needed to spawn")
+			return nil, errors.Wrap(err, "could not generate new parents hosts needed")
 		}
-		// create parent host intent documents
-		if numNewParentsToSpawn > 0 {
-			hostsSpawned = append(hostsSpawned, createParents(parentDistro, numNewParentsToSpawn, pool)...)
-
+		hostsSpawned = append(hostsSpawned, newParentHosts...)
+		if len(newParentHosts) > 0 {
 			grip.Info(message.Fields{
 				"runner":          RunnerName,
 				"distro":          d.Id,
 				"pool":            pool.Id,
 				"pool_distro":     pool.Distro,
-				"num_new_parents": numNewParentsToSpawn,
+				"num_new_parents": len(newParentHosts),
 				"operation":       "spawning new parents",
 				"duration_secs":   time.Since(distroStartTime).Seconds(),
 			})
 		}
-
-		// only want to spawn amount of containers we can fit on currently running parents
-		newHostsNeeded = containerCapacity(len(currentParents), len(existingContainers), newHostsNeeded, pool.MaxContainers)
 	}
 
 	// create intent documents for container hosts
 	if d.ContainerPool != "" {
-		containerIntents, err := generateContainerHostIntents(d, newHostsNeeded)
+		hostOptions, err := getHostOptionsFromDistro(d)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Error getting docker options from distro %s", d.Id)
+		}
+		containerIntents, err := cloud.GenerateContainerHostIntents(d, numHostsToSpawn, *hostOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "error generating container intent hosts")
 		}
 		hostsSpawned = append(hostsSpawned, containerIntents...)
 	} else { // create intent documents for regular hosts
-		for i := 0; i < newHostsNeeded; i++ {
+		for i := 0; i < numHostsToSpawn; i++ {
 			intent, err := generateIntentHost(d)
 			if err != nil {
 				return nil, errors.Wrap(err, "error generating intent host")
@@ -257,45 +210,16 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 	return hostsSpawned, nil
 }
 
-// generateContainerHostIntents generates container intent documents by going
-// through available parents and packing on the parents with longest expected
-// finish time
-func generateContainerHostIntents(d distro.Distro, newContainersNeeded int) ([]host.Host, error) {
-	parents, err := getNumContainersOnParents(d)
-	if err != nil {
-		return nil, errors.Wrap(err, "Could not find number of containers on each parent")
-	}
-	containerHostIntents := make([]host.Host, 0)
-
-	// Decode provider settings from distro settings
+func getHostOptionsFromDistro(d distro.Distro) (*cloud.HostOptions, error) {
 	dockerOptions, err := getDockerOptionsFromProviderSettings(*d.ProviderSettings)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error getting docker options from distro %s", d.Id)
 	}
-
-	for _, parent := range parents {
-		// find out how many more containers this parent can fit
-		containerSpace := parent.parentHost.ContainerPoolSettings.MaxContainers - parent.numContainers
-		containersToCreate := containerSpace
-		// only create containers as many as we need
-		if newContainersNeeded < containerSpace {
-			containersToCreate = newContainersNeeded
-		}
-		for i := 0; i < containersToCreate; i++ {
-			hostOptions := cloud.HostOptions{
-				ParentID:      parent.parentHost.Id,
-				UserName:      evergreen.User,
-				DockerOptions: *dockerOptions,
-			}
-
-			containerHostIntents = append(containerHostIntents, *cloud.NewIntent(d, d.GenerateName(), d.Provider, hostOptions))
-		}
-		newContainersNeeded -= containersToCreate
-		if newContainersNeeded == 0 {
-			return containerHostIntents, nil
-		}
+	hostOptions := cloud.HostOptions{
+		UserName:      evergreen.User,
+		DockerOptions: *dockerOptions,
 	}
-	return containerHostIntents, nil
+	return &hostOptions, nil
 }
 
 func getDockerOptionsFromProviderSettings(settings map[string]interface{}) (*host.DockerOptions, error) {
@@ -309,100 +233,6 @@ func getDockerOptionsFromProviderSettings(settings map[string]interface{}) (*hos
 		return nil, errors.New("docker image cannot be empty")
 	}
 	return dockerOptions, nil
-}
-
-// generateParentHostOptions generates host options for a parent host
-func generateParentHostOptions(pool *evergreen.ContainerPool) cloud.HostOptions {
-	options := cloud.HostOptions{
-		HasContainers:         true,
-		UserName:              evergreen.User,
-		ContainerPoolSettings: pool,
-	}
-	return options
-}
-
-// getNumContainersOnParents returns a slice of parents and their respective
-// number of current containers currently running in order of longest expected
-// finish time
-func getNumContainersOnParents(d distro.Distro) ([]containersOnParents, error) {
-	allParents, err := host.FindAllRunningParentsByContainerPool(d.ContainerPool)
-	if err != nil {
-		return nil, errors.Wrap(err, "Could not find running parent hosts")
-	}
-
-	numContainersOnParents := make([]containersOnParents, 0)
-	// parents come in sorted order from soonest to latest expected finish time
-	for i := len(allParents) - 1; i >= 0; i-- {
-		parent := allParents[i]
-		currentContainers, err := parent.GetContainers()
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not find containers for parent %s", parent.Id)
-		}
-		if len(currentContainers) < parent.ContainerPoolSettings.MaxContainers {
-			numContainersOnParents = append(numContainersOnParents,
-				containersOnParents{
-					parentHost:    parent,
-					numContainers: len(currentContainers),
-				})
-		}
-	}
-	return numContainersOnParents, nil
-}
-
-// numNewParentsNeeded returns the number of additional parents needed to
-// accommodate new containers
-func numNewParentsNeeded(params newParentsNeededParams) int {
-	if params.numUphostParents*params.maxContainers < params.numExistingContainers+params.numContainersNeeded {
-		numTotalNewParents := int(math.Ceil(float64(params.numContainersNeeded) / float64(params.maxContainers)))
-		if numTotalNewParents < 0 {
-			return 0
-		}
-		return numTotalNewParents
-	}
-	return 0
-}
-
-// parentCapacity calculates number of new parents to create
-// checks to make sure we do not create more parents than allowed
-func parentCapacity(parent distro.Distro, numNewParents, numCurrentParents int, pool *evergreen.ContainerPool) (int, error) {
-	if parent.Provider == evergreen.ProviderNameStatic {
-		return 0, nil
-	}
-	// if there are already maximum numbers of parents running, do not spawn
-	// any more parents
-	if numCurrentParents >= parent.PoolSize {
-		numNewParents = 0
-	}
-	// if adding all new parents results in more parents than allowed, only add
-	// enough parents to fill to capacity
-	if numNewParents+numCurrentParents > parent.PoolSize {
-		numNewParents = parent.PoolSize - numCurrentParents
-	}
-	return numNewParents, nil
-}
-
-// containerCapacity calculates how many containers to make
-// checks to make sure we do not create more containers than can fit currently
-func containerCapacity(numCurrentParents, numCurrentContainers, numContainersToSpawn, maxContainers int) int {
-	if numContainersToSpawn < 0 {
-		return 0
-	}
-	numAvailableContainers := numCurrentParents*maxContainers - numCurrentContainers
-	if numContainersToSpawn > numAvailableContainers {
-		return numAvailableContainers
-	}
-	return numContainersToSpawn
-}
-
-// createParents creates host intent documents for each parent
-func createParents(parent distro.Distro, numNewParents int, pool *evergreen.ContainerPool) []host.Host {
-	hostsSpawned := make([]host.Host, numNewParents)
-
-	for idx := range hostsSpawned {
-		hostsSpawned[idx] = *cloud.NewIntent(parent, parent.GenerateName(), parent.Provider, generateParentHostOptions(pool))
-	}
-
-	return hostsSpawned
 }
 
 // generateIntentHost creates a host intent document for a regular host

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -156,7 +155,7 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 		var err error
 		var newParentHosts []host.Host
 		// only want to spawn amount of parents allowed based on pool size
-		newParentHosts, numHostsToSpawn, err = cloud.CreateParentIntentsAndHostsToSpawn(pool, newHostsNeeded)
+		newParentHosts, numHostsToSpawn, err = host.CreateParentIntentsAndNumHostsToSpawn(pool, newHostsNeeded, true)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not generate new parents hosts needed")
 		}
@@ -180,7 +179,7 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error getting docker options from distro %s", d.Id)
 		}
-		containerIntents, err := cloud.GenerateContainerHostIntents(d, numHostsToSpawn, *hostOptions)
+		containerIntents, err := host.GenerateContainerHostIntents(d, numHostsToSpawn, *hostOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "error generating container intent hosts")
 		}
@@ -210,12 +209,12 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 	return hostsSpawned, nil
 }
 
-func getHostOptionsFromDistro(d distro.Distro) (*cloud.HostOptions, error) {
+func getHostOptionsFromDistro(d distro.Distro) (*host.HostOptions, error) {
 	dockerOptions, err := getDockerOptionsFromProviderSettings(*d.ProviderSettings)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error getting docker options from distro %s", d.Id)
 	}
-	hostOptions := cloud.HostOptions{
+	hostOptions := host.HostOptions{
 		UserName:      evergreen.User,
 		DockerOptions: *dockerOptions,
 	}
@@ -237,10 +236,10 @@ func getDockerOptionsFromProviderSettings(settings map[string]interface{}) (*hos
 
 // generateIntentHost creates a host intent document for a regular host
 func generateIntentHost(d distro.Distro) (*host.Host, error) {
-	hostOptions := cloud.HostOptions{
+	hostOptions := host.HostOptions{
 		UserName: evergreen.User,
 	}
-	return cloud.NewIntent(d, d.GenerateName(), d.Provider, hostOptions), nil
+	return host.NewIntent(d, d.GenerateName(), d.Provider, hostOptions), nil
 }
 
 // pass 'allDistros' or the empty string to unchedule all distros.

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -3,16 +3,13 @@ package scheduler
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
-	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
-	"github.com/evergreen-ci/evergreen/util"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/suite"
 )
@@ -74,109 +71,6 @@ func TestSpawnHosts(t *testing.T) {
 	})
 }
 
-func (s *SchedulerSuite) TestNumNewParentsNeeded() {
-	d := distro.Distro{Id: "distro", PoolSize: 3, Provider: evergreen.ProviderNameMock,
-		ContainerPool: "test-pool"}
-	pool := &evergreen.ContainerPool{Distro: "distro", Id: "test-pool", MaxContainers: 2}
-	host1 := &host.Host{
-		Id:                    "host1",
-		Host:                  "host",
-		User:                  "user",
-		Distro:                distro.Distro{Id: "parent-distro"},
-		Status:                evergreen.HostRunning,
-		HasContainers:         true,
-		ContainerPoolSettings: pool,
-	}
-	host2 := &host.Host{
-		Id:       "host2",
-		Distro:   d,
-		Status:   evergreen.HostRunning,
-		ParentID: "host1",
-	}
-	host3 := &host.Host{
-		Id:       "host3",
-		Distro:   d,
-		Status:   evergreen.HostRunning,
-		ParentID: "host1",
-	}
-	host4 := &host.Host{
-		Id:                    "host4",
-		Distro:                d,
-		Status:                evergreen.HostUninitialized,
-		HasContainers:         true,
-		ContainerPoolSettings: pool,
-	}
-
-	s.NoError(host1.Insert())
-	s.NoError(host2.Insert())
-	s.NoError(host3.Insert())
-	s.NoError(host4.Insert())
-
-	currentParents, err := host.FindAllRunningParentsByContainerPool(d.ContainerPool)
-	s.NoError(err)
-	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
-	s.NoError(err)
-	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
-	s.NoError(err)
-
-	parentsParams := newParentsNeededParams{
-		numUphostParents:      numUphostParents,
-		numContainersNeeded:   1,
-		numExistingContainers: len(existingContainers),
-		maxContainers:         pool.MaxContainers,
-	}
-	num := numNewParentsNeeded(parentsParams)
-	s.Equal(0, num)
-}
-
-func (s *SchedulerSuite) TestNumNewParentsNeeded2() {
-	d := distro.Distro{Id: "distro", PoolSize: 3, Provider: evergreen.ProviderNameMock,
-		ContainerPool: "test-pool"}
-	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 3}
-
-	host1 := &host.Host{
-		Id:                    "host1",
-		Host:                  "host",
-		User:                  "user",
-		Distro:                distro.Distro{Id: "parent-distro"},
-		Status:                evergreen.HostRunning,
-		HasContainers:         true,
-		ContainerPoolSettings: pool,
-	}
-	host2 := &host.Host{
-		Id:       "host2",
-		Distro:   d,
-		Status:   evergreen.HostRunning,
-		ParentID: "host1",
-	}
-	host3 := &host.Host{
-		Id:       "host3",
-		Distro:   d,
-		Status:   evergreen.HostTerminated,
-		ParentID: "host1",
-	}
-
-	s.NoError(host1.Insert())
-	s.NoError(host2.Insert())
-	s.NoError(host3.Insert())
-
-	currentParents, err := host.FindAllRunningParentsByContainerPool(d.ContainerPool)
-	s.NoError(err)
-	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
-	s.NoError(err)
-	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
-	s.NoError(err)
-
-	parentsParams := newParentsNeededParams{
-		numUphostParents:      numUphostParents,
-		numContainersNeeded:   1,
-		numExistingContainers: len(existingContainers),
-		maxContainers:         pool.MaxContainers,
-	}
-	num := numNewParentsNeeded(parentsParams)
-	s.Equal(0, num)
-}
-
 func (s *SchedulerSuite) TestSpawnHostsParents() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -213,22 +107,6 @@ func (s *SchedulerSuite) TestSpawnHostsParents() {
 	s.NoError(host1.Insert())
 	s.NoError(host2.Insert())
 	s.NoError(host3.Insert())
-
-	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
-	s.NoError(err)
-	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
-	s.NoError(err)
-	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
-	s.NoError(err)
-
-	parentsParams := newParentsNeededParams{
-		numUphostParents:      numUphostParents,
-		numContainersNeeded:   1,
-		numExistingContainers: len(existingContainers),
-		maxContainers:         pool.MaxContainers,
-	}
-	num := numNewParentsNeeded(parentsParams)
-	s.Equal(1, num)
 
 	newHostsSpawned, err := SpawnHosts(ctx, d, 1, pool)
 	s.NoError(err)
@@ -287,24 +165,9 @@ func (s *SchedulerSuite) TestSpawnHostsContainers() {
 	newHostsSpawned, err := SpawnHosts(ctx, d, 1, pool)
 	s.NoError(err)
 
-	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
-	s.NoError(err)
-	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
-	s.NoError(err)
-	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
-	s.NoError(err)
-
-	parentsParams := newParentsNeededParams{
-		numUphostParents:      numUphostParents,
-		numContainersNeeded:   1,
-		numExistingContainers: len(existingContainers),
-		maxContainers:         pool.MaxContainers,
-	}
-	num := numNewParentsNeeded(parentsParams)
-	s.Equal(0, num)
-
 	s.Require().Equal(1, len(newHostsSpawned))
 	s.NotEmpty(newHostsSpawned[0].ParentID)
+	s.False(newHostsSpawned[0].HasContainers)
 }
 
 func (s *SchedulerSuite) TestSpawnHostsParentsAndSomeContainers() {
@@ -344,22 +207,6 @@ func (s *SchedulerSuite) TestSpawnHostsParentsAndSomeContainers() {
 	s.NoError(host1.Insert())
 	s.NoError(host2.Insert())
 	s.NoError(host3.Insert())
-
-	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
-	s.NoError(err)
-	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
-	s.NoError(err)
-	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
-	s.NoError(err)
-
-	parentsParams := newParentsNeededParams{
-		numUphostParents:      numUphostParents,
-		numContainersNeeded:   3,
-		numExistingContainers: len(existingContainers),
-		maxContainers:         pool.MaxContainers,
-	}
-	num := numNewParentsNeeded(parentsParams)
-	s.Equal(1, num)
 
 	newHostsSpawned, err := SpawnHosts(ctx, d, 3, pool)
 	s.NoError(err)
@@ -411,154 +258,9 @@ func (s *SchedulerSuite) TestSpawnHostsMaximumCapacity() {
 	newHostsSpawned, err := SpawnHosts(ctx, d, 2, pool)
 	s.NoError(err)
 
-	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
-	s.NoError(err)
-	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
-	s.NoError(err)
-	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
-	s.NoError(err)
-
-	parentsParams := newParentsNeededParams{
-		numUphostParents:      numUphostParents,
-		numContainersNeeded:   2,
-		numExistingContainers: len(existingContainers),
-		maxContainers:         pool.MaxContainers,
-	}
-	num := numNewParentsNeeded(parentsParams)
-	s.Equal(1, num)
-
 	s.Require().Len(newHostsSpawned, 1)
 	s.NotEmpty(newHostsSpawned[0].ParentID)
-}
-
-func (s *SchedulerSuite) TestFindAvailableParent() {
-	d := distro.Distro{Id: "distro", PoolSize: 3, Provider: evergreen.ProviderNameMock,
-		ContainerPool: "test-pool"}
-	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 2}
-	durationOne := 20 * time.Minute
-	durationTwo := 30 * time.Minute
-
-	host1 := &host.Host{
-		Id:                    "host1",
-		Host:                  "host",
-		User:                  "user",
-		Distro:                distro.Distro{Id: "parent-distro"},
-		Status:                evergreen.HostRunning,
-		HasContainers:         true,
-		ContainerPoolSettings: pool,
-	}
-	host2 := &host.Host{
-		Id:                    "host2",
-		Distro:                distro.Distro{Id: "parent-distro"},
-		Status:                evergreen.HostRunning,
-		HasContainers:         true,
-		ContainerPoolSettings: pool,
-	}
-	host3 := &host.Host{
-		Id:          "host3",
-		Distro:      d,
-		Status:      evergreen.HostRunning,
-		ParentID:    "host1",
-		RunningTask: "task1",
-	}
-	host4 := &host.Host{
-		Id:          "host4",
-		Distro:      d,
-		Status:      evergreen.HostRunning,
-		ParentID:    "host2",
-		RunningTask: "task2",
-	}
-	task1 := task.Task{
-		Id: "task1",
-		DurationPrediction: util.CachedDurationValue{
-			Value: durationOne,
-		},
-		BuildVariant: "bv1",
-		StartTime:    time.Now(),
-	}
-	task2 := task.Task{
-		Id: "task2",
-		DurationPrediction: util.CachedDurationValue{
-			Value: durationTwo,
-		},
-		BuildVariant: "bv1",
-		StartTime:    time.Now(),
-	}
-	s.NoError(d.Insert())
-	s.NoError(host1.Insert())
-	s.NoError(host2.Insert())
-	s.NoError(host3.Insert())
-	s.NoError(host4.Insert())
-	s.NoError(task1.Insert())
-	s.NoError(task2.Insert())
-
-	availableParent, err := getNumContainersOnParents(d)
-	s.NoError(err)
-
-	s.Equal(2, len(availableParent))
-}
-
-func (s *SchedulerSuite) TestFindNoAvailableParent() {
-	d := distro.Distro{Id: "distro", PoolSize: 3, Provider: evergreen.ProviderNameMock}
-	pool := &evergreen.ContainerPool{Distro: "distro", Id: "test-pool", MaxContainers: 1}
-	durationOne := 20 * time.Minute
-	durationTwo := 30 * time.Minute
-
-	host1 := &host.Host{
-		Id:                    "host1",
-		Host:                  "host",
-		User:                  "user",
-		Distro:                distro.Distro{Id: "distro"},
-		Status:                evergreen.HostRunning,
-		HasContainers:         true,
-		ContainerPoolSettings: pool,
-	}
-	host2 := &host.Host{
-		Id:                    "host2",
-		Distro:                distro.Distro{Id: "distro"},
-		Status:                evergreen.HostRunning,
-		HasContainers:         true,
-		ContainerPoolSettings: pool,
-	}
-	host3 := &host.Host{
-		Id:          "host3",
-		Distro:      distro.Distro{Id: "distro", ContainerPool: "test-pool"},
-		Status:      evergreen.HostRunning,
-		ParentID:    "host1",
-		RunningTask: "task1",
-	}
-	host4 := &host.Host{
-		Id:          "host4",
-		Distro:      distro.Distro{Id: "distro", ContainerPool: "test-pool"},
-		Status:      evergreen.HostRunning,
-		ParentID:    "host2",
-		RunningTask: "task2",
-	}
-	task1 := task.Task{
-		Id: "task1",
-		DurationPrediction: util.CachedDurationValue{
-			Value: durationOne,
-		}, BuildVariant: "bv1",
-		StartTime: time.Now(),
-	}
-	task2 := task.Task{
-		Id: "task2",
-		DurationPrediction: util.CachedDurationValue{
-			Value: durationTwo,
-		}, BuildVariant: "bv1",
-		StartTime: time.Now(),
-	}
-	s.NoError(d.Insert())
-	s.NoError(host1.Insert())
-	s.NoError(host2.Insert())
-	s.NoError(host3.Insert())
-	s.NoError(host4.Insert())
-	s.NoError(task1.Insert())
-	s.NoError(task2.Insert())
-
-	availableParent, err := getNumContainersOnParents(d)
-	s.NoError(err)
-	s.Equal(0, len(availableParent))
+	s.False(newHostsSpawned[0].HasContainers)
 }
 
 func (s *SchedulerSuite) TestSpawnContainersStatic() {
@@ -617,25 +319,6 @@ func (s *SchedulerSuite) TestSpawnContainersStatic() {
 
 	newHostsSpawned, err := SpawnHosts(ctx, d, 4, pool)
 	s.NoError(err)
-
-	currentParents, err := host.FindAllRunningParentsByContainerPool(pool.Id)
-	s.NoError(err)
-	s.Equal(3, len(currentParents))
-	numUphostParents, err := host.CountUphostParentsByContainerPool("test-pool")
-	s.NoError(err)
-	existingContainers, err := host.HostGroup(currentParents).FindRunningContainersOnParents()
-	s.NoError(err)
-
-	parentsParams := newParentsNeededParams{
-		numUphostParents:      numUphostParents,
-		numContainersNeeded:   4,
-		numExistingContainers: len(existingContainers),
-		maxContainers:         pool.MaxContainers,
-	}
-	numNewParents := numNewParentsNeeded(parentsParams)
-	numNewParentsToSpawn, err := parentCapacity(parent, numNewParents, len(currentParents), pool)
-	s.NoError(err)
-	s.Equal(0, numNewParentsToSpawn)
 	s.Len(newHostsSpawned, 3)
 
 	for _, h := range newHostsSpawned {

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -114,7 +114,7 @@ func (s *SchedulerSuite) TestSpawnHostsParents() {
 	parents := 0
 	children := 0
 	for _, h := range newHostsSpawned {
-		if s.True(h.HasContainers) {
+		if h.HasContainers {
 			parents++
 		} else if s.NotEmpty(h.ParentID) {
 			children++
@@ -122,7 +122,7 @@ func (s *SchedulerSuite) TestSpawnHostsParents() {
 	}
 
 	s.Equal(1, parents)
-	s.Equal(0, children)
+	s.Equal(1, children)
 }
 
 func (s *SchedulerSuite) TestSpawnHostsContainers() {
@@ -178,7 +178,7 @@ func (s *SchedulerSuite) TestSpawnHostsParentsAndSomeContainers() {
 	providerSettings["image_url"] = "my-image"
 	d := distro.Distro{Id: "distro", Provider: evergreen.ProviderNameMock, ContainerPool: "test-pool",
 		ProviderSettings: &providerSettings}
-	parent := distro.Distro{Id: "parent-distro", PoolSize: 3, Provider: evergreen.ProviderNameMock}
+	parent := distro.Distro{Id: "parent-distro", PoolSize: 2, Provider: evergreen.ProviderNameMock}
 
 	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 3}
 	host1 := &host.Host{
@@ -208,9 +208,10 @@ func (s *SchedulerSuite) TestSpawnHostsParentsAndSomeContainers() {
 	s.NoError(host2.Insert())
 	s.NoError(host3.Insert())
 
-	newHostsSpawned, err := SpawnHosts(ctx, d, 3, pool)
+	newHostsSpawned, err := SpawnHosts(ctx, d, 5, pool)
 	s.NoError(err)
-	s.Equal(2, len(newHostsSpawned))
+	// 1 parent, 3 children on new parent, 1 child on old parent
+	s.Equal(5, len(newHostsSpawned))
 
 	parents := 0
 	children := 0
@@ -223,7 +224,7 @@ func (s *SchedulerSuite) TestSpawnHostsParentsAndSomeContainers() {
 		}
 	}
 
-	s.Equal(1, children)
+	s.Equal(4, children)
 	s.Equal(1, parents)
 }
 

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -158,7 +158,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	// terminate containers in DB if parent already terminated
 	if j.host.ParentID != "" {
 		var parent *host.Host
-		parent, err = host.FindOneId(j.host.ParentID)
+		parent, err = j.host.GetParent()
 		if err != nil {
 			j.AddError(errors.Wrapf(err, "problem finding parent of '%s'", j.host.Id))
 			return

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -255,17 +255,6 @@ func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergre
 func (j *agentDeployJob) prepRemoteHost(ctx context.Context, hostObj host.Host, sshOptions []string, settings *evergreen.Settings) error {
 	// copy over the correct agent binary to the remote host
 	if logs, err := hostObj.RunSSHCommand(ctx, hostObj.CurlCommand(settings.Ui.Url), sshOptions); err != nil {
-		grip.Error(message.WrapError(err, message.Fields{
-			"message":             "error running SSH command",
-			"host_id":             hostObj.Id,
-			"host_tag":            hostObj.Tag,
-			"external_identifier": hostObj.ExternalIdentifier,
-			"distro":              hostObj.Distro.Id,
-			"parent":              hostObj.ParentID,
-			"has_containers":      hostObj.HasContainers,
-			"status":              hostObj.Status,
-			"command":             hostObj.CurlCommand(settings.Ui.Url),
-		}))
 		return errors.Wrapf(err, "error downloading agent binary on remote host: %s", logs)
 	}
 

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -255,6 +255,17 @@ func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergre
 func (j *agentDeployJob) prepRemoteHost(ctx context.Context, hostObj host.Host, sshOptions []string, settings *evergreen.Settings) error {
 	// copy over the correct agent binary to the remote host
 	if logs, err := hostObj.RunSSHCommand(ctx, hostObj.CurlCommand(settings.Ui.Url), sshOptions); err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":             "error running SSH command",
+			"host_id":             hostObj.Id,
+			"host_tag":            hostObj.Tag,
+			"external_identifier": hostObj.ExternalIdentifier,
+			"distro":              hostObj.Distro.Id,
+			"parent":              hostObj.ParentID,
+			"has_containers":      hostObj.HasContainers,
+			"status":              hostObj.Status,
+			"command":             hostObj.CurlCommand(settings.Ui.Url),
+		}))
 		return errors.Wrapf(err, "error downloading agent binary on remote host: %s", logs)
 	}
 

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -292,19 +292,12 @@ func (j *createHostJob) shouldRetryCreateHost(ctx context.Context) bool {
 func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 	parent, err := j.host.GetParent()
 	if err != nil {
-		grip.Error(message.Fields{
-			"error":     err.Error(),
-			"message":   "problem getting parent",
-			"host":      j.host.Id,
-			"parent":    j.host.ParentID,
-			"operation": "spawning new parents",
-		})
 		return false, errors.Wrapf(err, "problem getting parent for '%s'", j.host.Id)
 	}
 	if parent == nil {
 		grip.Error(message.Fields{
 			"error":     err.Error(),
-			"message":   "parent is emptyt",
+			"message":   "parent is empty",
 			"host":      j.host.Id,
 			"parent":    j.host.ParentID,
 			"operation": "spawning new parents",

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -301,6 +301,16 @@ func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 		})
 		return false, errors.Wrapf(err, "problem getting parent for '%s'", j.host.Id)
 	}
+	if parent == nil {
+		grip.Error(message.Fields{
+			"error":     err.Error(),
+			"message":   "parent is emptyt",
+			"host":      j.host.Id,
+			"parent":    j.host.ParentID,
+			"operation": "spawning new parents",
+		})
+		return false, errors.Wrapf(err, "problem getting parent for '%s'", j.host.Id)
+	}
 
 	if parent.Status == evergreen.HostUninitialized || parent.Status == evergreen.HostBuilding {
 		return false, errors.Errorf("parent for host '%s' not running", j.host.Id)


### PR DESCRIPTION
Moves the logic of creating/assigning parents out of scheduler into host and cloud, and calls this in both scheduler and hostCreate. Note that a lot of this code isn't new, just moved.