### PR TITLE
EVG-6011 don't show rejected task data

### DIFF
--- a/plugin/perf.go
+++ b/plugin/perf.go
@@ -40,7 +40,6 @@ func (pp *PerfPlugin) GetPanelConfig() (*PanelConfig, error) {
 		Panels: []UIPanel{
 			{
 				Includes: []template.HTML{
-					`<script type="text/javascript" src="/static/app/common/PointsDataService.js"></script>`,
 					`<script type="text/javascript" src="/static/app/perf/trend_chart.js"></script>`,
 					`<script type="text/javascript" src="/static/app/perf/perf.js"></script>`,
 					`<script type="text/javascript" src="/static/app/perf/PerfChartService.js"></script>`,

--- a/plugin/perf.go
+++ b/plugin/perf.go
@@ -40,6 +40,7 @@ func (pp *PerfPlugin) GetPanelConfig() (*PanelConfig, error) {
 		Panels: []UIPanel{
 			{
 				Includes: []template.HTML{
+					`<script type="text/javascript" src="/static/app/common/PointsDataService.js"></script>`,
 					`<script type="text/javascript" src="/static/app/perf/trend_chart.js"></script>`,
 					`<script type="text/javascript" src="/static/app/perf/perf.js"></script>`,
 					`<script type="text/javascript" src="/static/app/perf/PerfChartService.js"></script>`,

--- a/public/static/app/common/PointsDataService.js
+++ b/public/static/app/common/PointsDataService.js
@@ -1,0 +1,35 @@
+/*
+ * This service contains functions which can access the points collection.
+ */
+mciModule.factory('PointsDataService', function($log, Stitch, STITCH_CONFIG) {
+  // Get a list of rejected points.
+  const getRejectedPointsQ = (project, variant, task, test) => {
+    test = test ? test : new stitch.BSON.BSONRegExp('^(fio|canary|iperf|NetworkBandwidth)');
+    return Stitch.use(STITCH_CONFIG.PERF).query(function(db) {
+      const query = {
+        project: project,
+        variant: variant,
+        task: task,
+        test: test,
+        $or : [
+          {'$and':[{ "rejected" : true }, { "outlier" : true }]},
+          {'$and':[{ "results.rejected" : true }, { "results.outlier" : true }]}]
+      };
+      return db
+        .db(STITCH_CONFIG.PERF.DB_PERF)
+        .collection(STITCH_CONFIG.PERF.COLL_POINTS)
+        .find(query)
+        .execute();
+    }).then(
+        function(docs) {
+          return _.chain(docs).pluck('task_id').uniq().value();
+        }, function(err) {
+          $log.error('Cannot load change points!', err);
+          return [] // Try to recover an error
+        })
+  } ;
+
+  return {
+    getRejectedPointsQ: getRejectedPointsQ,
+  }
+});

--- a/public/static/app/common/PointsDataService.js
+++ b/public/static/app/common/PointsDataService.js
@@ -24,8 +24,9 @@ mciModule.factory('PointsDataService', function($log, Stitch, STITCH_CONFIG) {
         function(docs) {
           return _.chain(docs).pluck('task_id').uniq().value();
         }, function(err) {
-          $log.error('Cannot load change points!', err);
-          return [] // Try to recover an error
+          // Try to gracefully handle an error.
+          $log.error('Cannot load rejected points!', err);
+          return [];
         })
   } ;
 

--- a/public/static/app/common/PointsDataService.test.js
+++ b/public/static/app/common/PointsDataService.test.js
@@ -1,0 +1,211 @@
+describe('PointsDataServiceSpec', function() {
+  beforeEach(module('MCI'));
+  function BSONRegExp(test) {
+    return test;
+  }
+
+  const project = 'sys-perf';
+  const variant = 'linux-standalone';
+  const task = 'bestbuy_agg';
+  const test_name = ' distinct_types_no_predicate-useAgg';
+  const db_perf = 'perf';
+  const coll_points = 'points';
+  const STITCH_CONFIG = {
+    PERF:{
+      DB_PERF: db_perf,
+      COLL_POINTS: coll_points
+    }
+  };
+
+  let service;
+  let $db;
+
+  describe('getRejectedPointsQ', () => {
+    beforeEach(function() {
+      module(function($provide) {
+        $window = {project: project};
+        db = {
+          db: () => db,
+          collection: () => db,
+          find: () => db,
+          execute: () => db,
+        };
+        Stitch = {
+          use: () => Stitch,
+          query: () => Stitch,
+          then: () => Stitch,
+        };
+
+        stitch = {BSON: {BSONRegExp: BSONRegExp}};
+        spyOn(stitch.BSON, 'BSONRegExp');
+
+        $provide.value('$window', $window);
+        $provide.value('Stitch', Stitch);
+        $provide.value('stitch', stitch);
+      });
+
+      inject(function($injector) {
+        service = $injector.get('PointsDataService');
+      })
+    });
+    describe('test param', () => {
+
+      it('should default to canaries', function() {
+        service.getRejectedPointsQ(project, variant, task);
+        expect(stitch.BSON.BSONRegExp).toHaveBeenCalledWith('^(fio|canary|iperf|NetworkBandwidth)');
+      });
+
+      it('should pass real value', function() {
+        service.getRejectedPointsQ(project, variant, task, test_name);
+        expect(stitch.BSON.BSONRegExp.callCount).toBe(undefined);
+      });
+
+    });
+  });
+
+  describe('query', () => {
+    beforeEach(function() {
+      module(function($provide) {
+        $window = {project: project};
+        $db = {
+          db: () => $db,
+          collection: () => $db,
+          find: () => $db,
+          execute: () => $db,
+          then: () => $db,
+        };
+        spyOn($db, 'db').and.callThrough();
+        spyOn($db, 'collection').and.callThrough();
+        spyOn($db, 'find').and.callThrough();
+        spyOn($db, 'execute').and.callThrough();
+
+        Stitch = {
+          use: () => Stitch,
+          query: (cb) => cb($db),
+          then: () => Stitch,
+        };
+        $provide.value('$window', $window);
+        $provide.value('Stitch', Stitch);
+        $provide.value('STITCH_CONFIG', STITCH_CONFIG);
+      });
+
+      inject(function($injector) {
+        service = $injector.get('PointsDataService');
+      })
+    });
+
+    describe('query handling', () => {
+
+      it('should default to canaries', function() {
+        service.getRejectedPointsQ(project, variant, task);
+        expect($db.db).toHaveBeenCalledWith(db_perf);
+        expect($db.collection).toHaveBeenCalledWith(coll_points);
+        expect($db.find).toHaveBeenCalledWith({
+          project: project,
+          variant: variant,
+          task: task,
+          test: new stitch.BSON.BSONRegExp('^(fio|canary|iperf|NetworkBandwidth)'),
+          $or : [
+            {'$and':[{ "rejected" : true }, { "outlier" : true }]},
+            {'$and':[{ "results.rejected" : true }, { "results.outlier" : true }]}]
+        });
+      });
+
+      it('should pass on value', function() {
+        service.getRejectedPointsQ(project, variant, task, test_name);
+        expect($db.db).toHaveBeenCalledWith(db_perf);
+        expect($db.collection).toHaveBeenCalledWith(coll_points);
+        expect($db.find).toHaveBeenCalledWith({
+          project: project,
+          variant: variant,
+          task: task,
+          test: test_name,
+          $or : [
+            {'$and':[{ "rejected" : true }, { "outlier" : true }]},
+            {'$and':[{ "results.rejected" : true }, { "results.outlier" : true }]}]
+        });
+      });
+
+    });
+  });
+
+  describe('points processing', () => {
+    describe('success', () => {
+      describe('no data', () => {
+        beforeEach(function() {
+          module(function($provide) {
+            $window = {project: project};
+
+            Stitch = {
+              use: () => Stitch,
+              query: () => Stitch,
+              then: (cb) => cb([]),
+            };
+            $provide.value('$window', $window);
+            $provide.value('Stitch', Stitch);
+          });
+
+          inject(function($injector) {
+            service = $injector.get('PointsDataService');
+          })
+        });
+
+        it('should return an empty array', function() {
+          expect(service.getRejectedPointsQ(project, variant, task)).toEqual([])
+        });
+      });
+      describe('with data', () => {
+        beforeEach(function() {
+          module(function($provide) {
+            $window = {project: project};
+
+            Stitch = {
+              use: () => Stitch,
+              query: () => Stitch,
+              then: (cb) => cb([
+                {task_id:'sys_perf_linux_standalone_bestbuy_agg_0a856820ba29e19dcba0979f71b11ae01f4be0f1_19_03_15_14_05_13'},
+                {task_id:'sys_perf_linux_standalone_bestbuy_agg_58ff5248610305a35403020077a4dbdcd0691ff0_19_03_17_21_34_54'},
+                {task_id:'sys_perf_linux_standalone_bestbuy_agg_0a856820ba29e19dcba0979f71b11ae01f4be0f1_19_03_15_14_05_13'}
+                ]),
+            };
+            $provide.value('$window', $window);
+            $provide.value('Stitch', Stitch);
+          });
+
+          inject(function($injector) {
+            service = $injector.get('PointsDataService');
+          })
+        });
+
+        it('should return uniq task ids', function() {
+          expect(service.getRejectedPointsQ(project, variant, task)).toEqual([
+            'sys_perf_linux_standalone_bestbuy_agg_0a856820ba29e19dcba0979f71b11ae01f4be0f1_19_03_15_14_05_13',
+            'sys_perf_linux_standalone_bestbuy_agg_58ff5248610305a35403020077a4dbdcd0691ff0_19_03_17_21_34_54'])
+        });
+      });
+    });
+    describe('failure', () => {
+      beforeEach(function() {
+        module(function($provide) {
+          $window = {project: project};
+
+          Stitch = {
+            use: () => Stitch,
+            query: () => Stitch,
+            then: (cb, err) => err('something went wrong!'),
+          };
+          $provide.value('$window', $window);
+          $provide.value('Stitch', Stitch);
+        });
+
+        inject(function($injector) {
+          service = $injector.get('PointsDataService');
+        })
+      });
+
+      it('should return an empty array', function() {
+        expect(service.getRejectedPointsQ(project, variant, task)).toEqual([]);
+      });
+    });
+  });
+});

--- a/public/static/app/common/constants.js
+++ b/public/static/app/common/constants.js
@@ -52,6 +52,7 @@ mciModule
       appId: 'evergreen_perf_plugin-wwdoa',
       // Assets associated with this instance
       DB_PERF: 'perf',
+      COLL_POINTS: 'points',
       COLL_CHANGE_POINTS: 'change_points',
       COLL_UNPROCESSED_POINTS: 'unprocessed_change_points',
       COLL_PROCESSED_POINTS: 'processed_change_points',

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -639,10 +639,7 @@ mciModule.controller('PerfController', function PerfController(
             getRejectedPointsQ.then(function(rejects){
               let data = resp.data;
               if(rejects.length){
-                data = _.reject(resp.data, function(doc) {
-                  // return  $scope.task.id != doc.task_id && _.contains(rejects, doc.task_id);
-                  return  _.contains(rejects, doc.task_id);
-                })
+                data = _.reject(resp.data, (doc) => _.contains(rejects, doc.task_id));
               }
               $scope.trendSamples = new TrendSamples(data);
               $scope.metricSelect.options = [$scope.metricSelect.default].concat(

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -551,31 +551,9 @@ mciModule.controller('PerfController', function PerfController(
         setTimeout(function(){drawDetailGraph($scope.perfSample, $scope.comparePerfSamples, $scope.task.id)},0);
 
         // Get a list of rejected points.
-        var getRejectedPointsQ = Stitch.use(STITCH_CONFIG.PERF).query(function(db) {
-          const query = {
-            project: $scope.task.branch,
-            task: $scope.task.display_name,
-            variant: $scope.task.build_variant,
-            test: new stitch.BSON.BSONRegExp("^(fio|canary|iperf|NetworkBandwidth)"),
-            $or : [
-              {'$and':[{ "rejected" : true }, { "outlier" : true }]},
-              {'$and':[{ "results.rejected" : true }, { "results.outlier" : true }]}]
-          }
-          return db
-            .db(STITCH_CONFIG.PERF.DB_PERF)
-            .collection(STITCH_CONFIG.PERF.COLL_POINTS)
-            .find(query)
-            .execute()
-        }).then(
-          function(docs) {
-            return _.chain(docs).
-              pluck('task_id').
-              uniq().
-              value()
-          }, function(err) {
-            $log.error('Cannot load change points!', err)
-            return [] // Try to recover an error
-          })
+        const getRejectedPointsQ = PointsDataService.getRejectedPointsQ($scope.task.branch,
+                                                                         $scope.task.build_variant,
+                                                                         $scope.task.display_name);
 
         // This code loads change points for current task from the mdb cloud
         var unprocessedPointsQ = Stitch.use(STITCH_CONFIG.PERF).query(function(db) {

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -657,9 +657,8 @@ mciModule.controller('PerfController', function PerfController(
                 if ($location.hash().length > 0) {
                   try {
                     if ('metric' in hashparsed) {
-                      let metric = hashparsed.metric
                       $scope.metricSelect.value = _.findWhere(
-                        $scope.metricSelect.options, {key: metric}
+                        $scope.metricSelect.options, {key: hashparsed.metric}
                       ) || $scope.metricSelect.default
                     }
                   } catch (e) {}

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -14,7 +14,7 @@ var findIndex = function(list, predicate) {
 mciModule.controller('PerfController', function PerfController(
   $scope, $window, $http, $location, $log, $q, ChangePointsService,
   DrawPerfTrendChart, PROCESSED_TYPE, Settings, Stitch, STITCH_CONFIG,
-  TestSample, TrendSamples
+  TestSample, TrendSamples, PointsDataService
 ) {
     /* for debugging
     $sce, $compile){

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -551,9 +551,9 @@ mciModule.controller('PerfController', function PerfController(
         setTimeout(function(){drawDetailGraph($scope.perfSample, $scope.comparePerfSamples, $scope.task.id)},0);
 
         // Get a list of rejected points.
-        const getRejectedPointsQ = PointsDataService.getRejectedPointsQ($scope.task.branch,
-                                                                         $scope.task.build_variant,
-                                                                         $scope.task.display_name);
+        const rejectedPointsPromise = PointsDataService.getRejectedPointsQ($scope.task.branch,
+                                                                           $scope.task.build_variant,
+                                                                           $scope.task.display_name);
 
         // This code loads change points for current task from the mdb cloud
         var unprocessedPointsQ = Stitch.use(STITCH_CONFIG.PERF).query(function(db) {
@@ -636,7 +636,7 @@ mciModule.controller('PerfController', function PerfController(
         // Populate the trend data
         var chartDataQ = $http.get("/plugin/json/history/" + $scope.task.id + "/perf").then(
           function(resp) {
-            getRejectedPointsQ.then(function(rejects){
+            rejectedPointsPromise.then(function(rejects){
               let data = resp.data;
               if(rejects.length){
                 data = _.reject(resp.data, (doc) => _.contains(rejects, doc.task_id));

--- a/public/static/app/perf/trend_chart.js
+++ b/public/static/app/perf/trend_chart.js
@@ -472,7 +472,7 @@ mciModule.factory('DrawPerfTrendChart', function (
       // Only set the current revision marker if the current
       // revision is found
       if (currentItemIdx != -1) {
-        var commitCircle = chartG
+        const commitCircle = chartG
             .selectAll('circle.current')
             .data(
               threadMode == MAXONLY

--- a/public/static/app/perf/trend_chart.js
+++ b/public/static/app/perf/trend_chart.js
@@ -469,18 +469,20 @@ mciModule.factory('DrawPerfTrendChart', function (
 
       lines.exit().remove()
 
-      // Current revision marker
-      var commitCircle = chartG
-        .selectAll('circle.current')
-        .data(
-          threadMode == MAXONLY
-            ? activeLevels
-            : threadLevelsForSample(series[currentItemIdx], activeLevels)
-        )
+      // Only set the current revision marker if the current
+      // revision is found
+      if (currentItemIdx != -1) {
+        var commitCircle = chartG
+            .selectAll('circle.current')
+            .data(
+              threadMode == MAXONLY
+                ? activeLevels
+                : threadLevelsForSample(series[currentItemIdx], activeLevels)
+            )
 
-      commitCircle
-        .enter()
-        .append('circle')
+        commitCircle
+          .enter()
+          .append('circle')
           .attr({
             class: 'point current',
             cx: xScale(currentItemIdx),
@@ -491,15 +493,16 @@ mciModule.factory('DrawPerfTrendChart', function (
             stroke: function(d) { return d.color },
           })
 
-      commitCircle
-        .transition()
-        .attr({
-          cy: function(level) {
-            return yScale(getValueFor(level)(series[currentItemIdx]))
-          }
-        })
+        commitCircle
+          .transition()
+          .attr({
+            cy: function(level) {
+              return yScale(getValueFor(level)(series[currentItemIdx]))
+            }
+          })
 
-      commitCircle.exit().remove()
+        commitCircle.exit().remove()
+      }
     }
 
     redrawLines()

--- a/service/templates/base_angular.html
+++ b/service/templates/base_angular.html
@@ -90,6 +90,7 @@
         <script type="text/javascript" src="/static/app/common/spinner.js?hash={{ BuildRevision }}"></script>
         <script type="text/javascript" src="/static/app/common/EvgUtil.js?hash={{ BuildRevision }}"></script>
         <script type="text/javascript" src="/static/app/common/RestartUtil.js?hash={{ BuildRevision }}"></script>
+        <script type="text/javascript" src="/static/app/common/PointsDataService.js?hash={{ BuildRevision }}"></script>
 
         <style type="text/css">
           #footer{ font-size:.8em; color:#888; }


### PR DESCRIPTION
I edited [19_03_15_14_05_13](https://evergreen.mongodb.com/task/sys_perf_linux_standalone_bestbuy_agg_0a856820ba29e19dcba0979f71b11ae01f4be0f1_19_03_15_14_05_13) to make it an outlier and rejected.

You can see in the following GIF that there is no current marker (yellow circle). Also if you watch the dates on the Right Hand Side, the 15th march is skipped (so it isn't being rendered).

![on](https://user-images.githubusercontent.com/22506/54993585-0ea95300-4fba-11e9-9773-d60c9dd5db39.gif)

[19_03_16_14_18_52](https://evergreen.mongodb.com/task/sys_perf_linux_standalone_bestbuy_agg_6161eb7b7aff5305b445dcdd20825f041b5e5a68_19_03_16_14_18_52) is the commit after the rejected task. 

Notice there is a current icon but the 15th March is still not displayed in the dates on the Right Hand Side. 

![after](https://user-images.githubusercontent.com/22506/54993598-179a2480-4fba-11e9-8ed3-7718625c0657.gif)
