### PR TITLE
EVG-5931: Commit Queue merge command

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -135,6 +135,8 @@ const (
 
 	PlannerVersionLegacy  = "legacy"
 	PlannerVersionTunable = "tunable"
+
+	CommitQueueAlias = "__commit_queue"
 )
 
 func IsFinishedTaskStatus(status string) bool {

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -158,7 +158,7 @@ func (s *patchSuite) TestMakeMergePatch() {
 		MergeCommitSHA: &shaTemp,
 	}
 
-	p, err := MakeMergePatch(pr, "mci", "__commit_queue")
+	p, err := MakeMergePatch(pr, "mci", evergreen.CommitQueueAlias)
 	s.NoError(err)
 	s.Equal("mci", p.Project)
 	s.Equal(evergreen.PatchCreated, p.Status)

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/evergreen-ci/evergreen/rest/client"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
@@ -205,6 +206,17 @@ func (p *mergeParams) mergeBranch(ctx context.Context, confPath string) error {
 	}
 
 	if p.id == "" {
+		if p.projectID == "" {
+			p.projectID = conf.FindDefaultProject()
+		} else {
+			if conf.FindDefaultProject() == "" &&
+				!p.skipConfirm && confirm(fmt.Sprintf("Make %v your default project?", p.projectID), true) {
+				conf.SetDefaultProject(p.projectID)
+				if err := conf.Write(""); err != nil {
+					grip.Warningf("warning - failed to set default project: %v\n", err)
+				}
+			}
+		}
 		if p.projectID == "" {
 			return errors.New("no project identifier provided")
 		}

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -116,9 +116,6 @@ func mergeCommand() cli.Command {
 				Usage: "description for the patch",
 			},
 		)),
-		Before: mergeBeforeFuncs(
-			setPlainLogger,
-		),
 		Action: func(c *cli.Context) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -179,3 +179,32 @@ func (s *CommitQueueSuite) TestDeleteCommitQueueItem() {
 
 	s.Contains(stringOut, "Item '123' deleted")
 }
+
+// func (s *CommitQueueSuite) TestMergeBranch() {
+// 	origStdout := os.Stdout
+// 	r, w, _ := os.Pipe()
+// 	os.Stdout = w
+// 	s.NoError(grip.SetSender(send.MakePlainLogger()))
+
+// 	id, err := uploadPatches(context.Background(), s.client, "mci", "mbox formatted patch")
+
+// 	s.NoError(w.Close())
+// 	out, _ := ioutil.ReadAll(r)
+// 	stringOut := string(out[:])
+
+// 	s.NoError(err)
+// 	s.Contains(stringOut, "Item ID is '")
+
+// 	r, w, _ = os.Pipe()
+// 	os.Stdout = w
+
+// 	err = enqueueItem(context.Background(), s.client, id)
+
+// 	s.NoError(w.Close())
+// 	os.Stdout = origStdout
+// 	out, _ = ioutil.ReadAll(r)
+// 	stringOut = string(out[:])
+
+// 	s.NoError(err)
+// 	s.Contains(stringOut, "Queue position is '")
+// }

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -179,32 +179,3 @@ func (s *CommitQueueSuite) TestDeleteCommitQueueItem() {
 
 	s.Contains(stringOut, "Item '123' deleted")
 }
-
-// func (s *CommitQueueSuite) TestMergeBranch() {
-// 	origStdout := os.Stdout
-// 	r, w, _ := os.Pipe()
-// 	os.Stdout = w
-// 	s.NoError(grip.SetSender(send.MakePlainLogger()))
-
-// 	id, err := uploadPatches(context.Background(), s.client, "mci", "mbox formatted patch")
-
-// 	s.NoError(w.Close())
-// 	out, _ := ioutil.ReadAll(r)
-// 	stringOut := string(out[:])
-
-// 	s.NoError(err)
-// 	s.Contains(stringOut, "Item ID is '")
-
-// 	r, w, _ = os.Pipe()
-// 	os.Stdout = w
-
-// 	err = enqueueItem(context.Background(), s.client, id)
-
-// 	s.NoError(w.Close())
-// 	os.Stdout = origStdout
-// 	out, _ = ioutil.ReadAll(r)
-// 	stringOut = string(out[:])
-
-// 	s.NoError(err)
-// 	s.Contains(stringOut, "Queue position is '")
-// }

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -89,7 +89,8 @@ func Patch() cli.Command {
 				return err
 			}
 
-			return params.createPatch(ac, conf, diffData)
+			_, err = params.createPatch(ac, conf, diffData)
+			return err
 		},
 	}
 }
@@ -155,7 +156,8 @@ func PatchFile() cli.Command {
 
 			diffData := &localDiff{string(fullPatch), "", "", base}
 
-			return params.createPatch(ac, conf, diffData)
+			_, err = params.createPatch(ac, conf, diffData)
+			return err
 		},
 	}
 }

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -170,6 +170,8 @@ type Communicator interface {
 	// Commit Queue
 	GetCommitQueue(ctx context.Context, projectID string) (*restmodel.APICommitQueue, error)
 	DeleteCommitQueueItem(ctx context.Context, projectID string, item string) error
+	UploadPatches(ctx context.Context, projectID, patches string) (string, error)
+	EnqueueItem(ctx context.Context, id string) (int, error)
 
 	// Notifications
 	SendNotification(ctx context.Context, notificationType string, data interface{}) error

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -170,7 +170,6 @@ type Communicator interface {
 	// Commit Queue
 	GetCommitQueue(ctx context.Context, projectID string) (*restmodel.APICommitQueue, error)
 	DeleteCommitQueueItem(ctx context.Context, projectID string, item string) error
-	UploadPatches(ctx context.Context, projectID, patches string) (string, error)
 	EnqueueItem(ctx context.Context, id string) (int, error)
 
 	// Notifications

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -586,15 +586,7 @@ func (c *Mock) DeleteCommitQueueItem(ctx context.Context, projectID, item string
 	return nil
 }
 
-func (c *Mock) UploadPatches(ctx context.Context, projectID, patches string) (string, error) {
-	return "abcdef", nil
-}
-
 func (c *Mock) EnqueueItem(ctx context.Context, id string) (int, error) {
-	if id != "abcdef" {
-		return 0, errors.New("error uploading patch")
-	}
-
 	return 1, nil
 }
 

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -586,6 +586,18 @@ func (c *Mock) DeleteCommitQueueItem(ctx context.Context, projectID, item string
 	return nil
 }
 
+func (c *Mock) UploadPatches(ctx context.Context, projectID, patches string) (string, error) {
+	return "abcdef", nil
+}
+
+func (c *Mock) EnqueueItem(ctx context.Context, id string) (int, error) {
+	if id != "abcdef" {
+		return 0, errors.New("error uploading patch")
+	}
+
+	return 1, nil
+}
+
 func (c *Mock) SendNotification(_ context.Context, _ string, _ interface{}) error {
 	return nil
 }

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -712,34 +712,6 @@ func (c *communicatorImpl) DeleteCommitQueueItem(ctx context.Context, projectID,
 	return nil
 }
 
-func (c *communicatorImpl) UploadPatches(ctx context.Context, projectID, patches string) (string, error) {
-	info := requestInfo{
-		method:  post,
-		version: apiVersion2,
-		path:    fmt.Sprintf("/commitqueue/patch_upload/%s", projectID),
-	}
-
-	resp, err := c.request(ctx, info, patches)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	bytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to read response")
-	}
-	if resp.StatusCode != http.StatusOK {
-		restErr := gimlet.ErrorResponse{}
-		if err = json.Unmarshal(bytes, &restErr); err != nil {
-			return "", errors.Errorf("received an error but was unable to parse: %s", string(bytes))
-		}
-
-		return "", restErr
-	}
-
-	return string(bytes), nil
-}
-
 func (c *communicatorImpl) EnqueueItem(ctx context.Context, id string) (int, error) {
 	info := requestInfo{
 		method:  put,

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -737,12 +736,12 @@ func (c *communicatorImpl) EnqueueItem(ctx context.Context, id string) (int, err
 		return 0, restErr
 	}
 
-	position, err := strconv.Atoi(string(bytes))
-	if err != nil {
-		return 0, errors.Wrapf(err, "can't interpret '%s' as int", string(bytes))
+	positionResp := model.APICommitQueuePosition{}
+	if err = util.ReadJSONInto(resp.Body, &positionResp); err != nil {
+		return 0, errors.Wrap(err, "error parsing position response")
 	}
 
-	return position, nil
+	return positionResp.Position, nil
 }
 
 func (c *communicatorImpl) SendNotification(ctx context.Context, notificationType string, data interface{}) error {

--- a/rest/model/commit_queue.go
+++ b/rest/model/commit_queue.go
@@ -22,6 +22,10 @@ type APIModule struct {
 	Issue  APIString `json:"issue"`
 }
 
+type APICommitQueuePosition struct {
+	Position int `json:"position"`
+}
+
 func (cq *APICommitQueue) BuildFromService(h interface{}) error {
 	cqService, ok := h.(commitqueue.CommitQueue)
 	if !ok {

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	commitQueueJobName = "commit-queue"
-	commitQueueAlias   = "__commit_queue"
 )
 
 func init() {
@@ -133,7 +132,7 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 		return
 	}
 
-	patchDoc, err := patch.MakeMergePatch(pr, projectRef.Identifier, commitQueueAlias)
+	patchDoc, err := patch.MakeMergePatch(pr, projectRef.Identifier, evergreen.CommitQueueAlias)
 	if err != nil {
 		j.logError(err, "can't make patch", nextItem)
 		j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't make patch", ""))


### PR DESCRIPTION
Theory of operation: 

1. an mbox formatted patch (which includes commit metadata) is uploaded as an unfinalized patch. 
2. the patch ID is enqueued on the project's commit queue.

steps 1 & 2 are severable (with the `--pause` option) to allow uploading modules to the patch before enqueuing (which is part of an upcoming ticket, [EVG-5932](https://jira.mongodb.org/browse/EVG-5932)).

Open question: do we want to allow passing in extra args to `git format-patch` as we do for `git diff` when creating patches?