### PR TITLE
EVG-5989: add export cli tool

### DIFF
--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -57,6 +57,7 @@ func buildApp() *cli.App {
 		operations.LastGreen(),
 		operations.Subscriptions(),
 		operations.CommitQueue(),
+		operations.Export(),
 
 		// Patch creation and management commands (top-level)
 		operations.Patch(),

--- a/config.go
+++ b/config.go
@@ -24,7 +24,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-03-22"
+	ClientVersion = "2019-04-01"
 
 	errNotFound = "not found"
 )

--- a/config.go
+++ b/config.go
@@ -24,7 +24,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-04-01"
+	ClientVersion = "2019-04-04"
 
 	errNotFound = "not found"
 )

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -204,13 +204,16 @@ func ByAfterRevision(project, buildVariant string, revision int) db.Q {
 }
 
 // ByRecentlyFinished builds a query that returns all builds for a given project
-// that are versions (not patches), that have finished.
-func ByRecentlyFinished(limit int) db.Q {
+// that are versions (not patches), that have finished and have non-zero
+// makespans.
+func ByRecentlyFinishedWithMakespans(limit int) db.Q {
 	return db.Query(bson.M{
 		RequesterKey: bson.M{
 			"$in": evergreen.SystemVersionRequesterTypes,
 		},
-		StatusKey: bson.M{"$in": evergreen.CompletedStatuses},
+		PredictedMakespanKey: bson.M{"$gt": 0},
+		ActualMakespanKey:    bson.M{"$gt": 0},
+		StatusKey:            bson.M{"$in": evergreen.CompletedStatuses},
 	}).Sort([]string{RevisionOrderNumberKey}).Limit(limit)
 }
 

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -333,6 +333,7 @@ func revert() cli.Command {
 			}
 			client := conf.GetRestCommunicator(ctx)
 			defer client.Close()
+
 			err = client.RevertSettings(ctx, guid)
 			if err != nil {
 				return err

--- a/operations/admin_all_configs.go
+++ b/operations/admin_all_configs.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"io/ioutil"
 
 	"github.com/mongodb/grip"
@@ -28,10 +29,16 @@ func fetchAllProjectConfigs() cli.Command {
 		Action: func(c *cli.Context) error {
 			includeDisabled := c.BoolT(includeDisabledFlagName)
 
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			settings, err := NewClientSettings(c.GlobalString("config"))
 			if err != nil {
 				return err
 			}
+
+			client := settings.GetRestCommunicator(ctx)
+			defer client.Close()
 
 			ac, rc, err := settings.getLegacyClients()
 			if err != nil {

--- a/operations/admin_all_configs.go
+++ b/operations/admin_all_configs.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"context"
 	"io/ioutil"
 
 	"github.com/mongodb/grip"
@@ -29,15 +28,10 @@ func fetchAllProjectConfigs() cli.Command {
 		Action: func(c *cli.Context) error {
 			includeDisabled := c.BoolT(includeDisabledFlagName)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			settings, err := NewClientSettings(c.GlobalString("config"))
 			if err != nil {
 				return err
 			}
-
-			_ = settings.GetRestCommunicator(ctx)
 
 			ac, rc, err := settings.getLegacyClients()
 			if err != nil {

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -51,9 +51,7 @@ func listQueue() cli.Command {
 				return errors.Wrap(err, "problem loading configuration")
 			}
 			client := conf.GetRestCommunicator(ctx)
-			if err != nil {
-				return errors.Wrap(err, "problem accessing evergreen service")
-			}
+			defer client.Close()
 
 			return listCommitQueue(ctx, client, projectID)
 		},
@@ -85,9 +83,7 @@ func deleteItem() cli.Command {
 				return errors.Wrap(err, "problem loading configuration")
 			}
 			client := conf.GetRestCommunicator(ctx)
-			if err != nil {
-				return errors.Wrap(err, "problem accessing evergreen service")
-			}
+			defer client.Close()
 
 			return deleteCommitQueueItem(ctx, client, projectID, item)
 		},
@@ -142,9 +138,7 @@ func mergeCommand() cli.Command {
 			}
 
 			client := conf.GetRestCommunicator(ctx)
-			if err != nil {
-				return errors.Wrap(err, "problem accessing evergreen service")
-			}
+			defer client.Close()
 
 			return params.mergeBranch(ctx, conf, client, ac)
 		},

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -64,6 +64,7 @@ func (s *CommitQueueSuite) SetupSuite() {
 
 func (s *CommitQueueSuite) TearDownSuite() {
 	s.server.Close()
+	s.client.Close()
 }
 
 func (s *CommitQueueSuite) TestListContents() {

--- a/operations/export.go
+++ b/operations/export.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"context"
 	"io"
 
 	"github.com/evergreen-ci/evergreen/util"
@@ -79,15 +78,10 @@ func Export() cli.Command {
 			distro := c.String(distroFlagName)
 			filePath := c.String(pathFlagName)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
-
-			_ = conf.GetRestCommunicator(ctx)
 
 			_, rc, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/export.go
+++ b/operations/export.go
@@ -70,7 +70,7 @@ func Export() cli.Command {
 			requireStringFlag(pathFlagName)),
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().String(confFlagName)
-			isCSV := c.Bool(jsonFlagName)
+			isCSV := !c.Bool(jsonFlagName)
 			statType := c.String(statFlagName)
 			granularity := c.String(granularityFlagName)
 			days := c.Int(daysFlagName)

--- a/operations/export.go
+++ b/operations/export.go
@@ -24,9 +24,9 @@ func Export() cli.Command {
 		granularityFlagName = "granularity"
 		jsonFlagName        = "json"
 
-		statHostUtilization   = "host"
-		statSecheduledToStart = "avg"
-		statOptimalMakespan   = "makespan"
+		statHostUtilization  = "host"
+		statScheduledToStart = "avg"
+		statOptimalMakespan  = "makespan"
 	)
 
 	return cli.Command{
@@ -65,7 +65,7 @@ func Export() cli.Command {
 			requireStringValueChoices(granularityFlagName,
 				[]string{granularityDays, granularityHours, granularityMinutes, granularitySeconds}),
 			requireStringValueChoices(statFlagName,
-				[]string{statHostUtilization, statSecheduledToStart, statOptimalMakespan}),
+				[]string{statHostUtilization, statScheduledToStart, statOptimalMakespan}),
 			requireIntValueBetween(daysFlagName, 1, 30),
 			requireStringFlag(pathFlagName)),
 		Action: func(c *cli.Context) error {
@@ -101,7 +101,7 @@ func Export() cli.Command {
 				if err != nil {
 					return err
 				}
-			case statSecheduledToStart:
+			case statScheduledToStart:
 				if distro == "" {
 					return errors.New("cannot have empty distro id")
 				}

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -94,10 +95,16 @@ func Fetch() cli.Command {
 			noPatch := c.Bool(noPatchFlagName)
 			shallow := c.Bool(shallowFlagName)
 
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
+
+			client := conf.GetRestCommunicator(ctx)
+			defer client.Close()
 
 			ac, rc, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -95,15 +94,10 @@ func Fetch() cli.Command {
 			noPatch := c.Bool(noPatchFlagName)
 			shallow := c.Bool(shallowFlagName)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
-
-			_ = conf.GetRestCommunicator(ctx)
 
 			ac, rc, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/http_test.go
+++ b/operations/http_test.go
@@ -38,6 +38,7 @@ func (s *CliHttpTestSuite) TestV2Client() {
 
 	settings, err := NewClientSettings(testFileName)
 	client := settings.GetRestCommunicator(ctx)
+	defer client.Close()
 	if s.NoError(err) {
 		s.NotNil(client)
 		s.NotNil(settings)

--- a/operations/last_green.go
+++ b/operations/last_green.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"os"
 	"text/template"
 
@@ -27,10 +28,16 @@ func LastGreen() cli.Command {
 			variants := c.StringSlice(variantsFlagName)
 			project := c.String(projectFlagName)
 
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
+
+			client := conf.GetRestCommunicator(ctx)
+			defer client.Close()
 
 			_, rc, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/last_green.go
+++ b/operations/last_green.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"context"
 	"os"
 	"text/template"
 
@@ -28,15 +27,10 @@ func LastGreen() cli.Command {
 			variants := c.StringSlice(variantsFlagName)
 			project := c.String(projectFlagName)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
-
-			_ = conf.GetRestCommunicator(ctx)
 
 			_, rc, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/list.go
+++ b/operations/list.go
@@ -87,8 +87,6 @@ func listProjects(ctx context.Context, confPath string) error {
 		return errors.Wrap(err, "problem loading configuration")
 	}
 
-	_ = conf.GetRestCommunicator(ctx)
-
 	ac, _, err := conf.getLegacyClients()
 	if err != nil {
 		return errors.Wrap(err, "problem accessing evergreen service")
@@ -127,7 +125,6 @@ func listVariants(ctx context.Context, confPath, project, filename string) error
 	if err != nil {
 		return errors.Wrap(err, "problem loading configuration")
 	}
-	_ = conf.GetRestCommunicator(ctx)
 
 	var variants []model.BuildVariant
 	if project != "" {
@@ -177,7 +174,6 @@ func listTasks(ctx context.Context, confPath, project, filename string) error {
 	if err != nil {
 		return errors.Wrap(err, "problem loading configuration")
 	}
-	_ = conf.GetRestCommunicator(ctx)
 
 	var tasks []model.ProjectTask
 	if project != "" {
@@ -216,6 +212,7 @@ func listAliases(ctx context.Context, confPath, project, filename string) error 
 		return errors.Wrap(err, "problem loading configuration")
 	}
 	comm := conf.GetRestCommunicator(ctx)
+	defer comm.Close()
 
 	var aliases []model.ProjectAlias
 
@@ -252,6 +249,7 @@ func listDistros(ctx context.Context, confPath string, onlyUserSpawnable bool) e
 		return errors.Wrap(err, "problem loading configuration")
 	}
 	client := conf.GetRestCommunicator(ctx)
+	defer client.Close()
 
 	distros, err := client.GetDistrosList(ctx)
 	if err != nil {

--- a/operations/list.go
+++ b/operations/list.go
@@ -86,6 +86,8 @@ func listProjects(ctx context.Context, confPath string) error {
 	if err != nil {
 		return errors.Wrap(err, "problem loading configuration")
 	}
+	client := conf.GetRestCommunicator(ctx)
+	defer client.Close()
 
 	ac, _, err := conf.getLegacyClients()
 	if err != nil {
@@ -125,6 +127,8 @@ func listVariants(ctx context.Context, confPath, project, filename string) error
 	if err != nil {
 		return errors.Wrap(err, "problem loading configuration")
 	}
+	client := conf.GetRestCommunicator(ctx)
+	defer client.Close()
 
 	var variants []model.BuildVariant
 	if project != "" {
@@ -174,6 +178,8 @@ func listTasks(ctx context.Context, confPath, project, filename string) error {
 	if err != nil {
 		return errors.Wrap(err, "problem loading configuration")
 	}
+	client := conf.GetRestCommunicator(ctx)
+	defer client.Close()
 
 	var tasks []model.ProjectTask
 	if project != "" {

--- a/operations/model.go
+++ b/operations/model.go
@@ -127,6 +127,8 @@ func (s *ClientSettings) Write(fn string) error {
 	return errors.Wrap(ioutil.WriteFile(fn, yamlData, 0644), "could not write file")
 }
 
+// GetRestCommunicator returns a client for communicating with the API server.
+// Callers are responsible for calling (Communicator).Close() when finished with the client.
 func (s *ClientSettings) GetRestCommunicator(ctx context.Context) client.Communicator {
 	c := client.NewCommunicator(s.APIServerHost)
 

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -73,6 +73,7 @@ func Patch() cli.Command {
 			}
 
 			comm := conf.GetRestCommunicator(ctx)
+			defer comm.Close()
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {
@@ -139,6 +140,7 @@ func PatchFile() cli.Command {
 			}
 
 			comm := conf.GetRestCommunicator(ctx)
+			defer comm.Close()
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/patch_cancel.go
+++ b/operations/patch_cancel.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -18,15 +17,10 @@ func PatchCancel() cli.Command {
 			confPath := c.Parent().String(confFlagName)
 			patchID := c.String(patchIDFlagName)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
-
-			_ = conf.GetRestCommunicator(ctx)
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/patch_cancel.go
+++ b/operations/patch_cancel.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -17,10 +18,16 @@ func PatchCancel() cli.Command {
 			confPath := c.Parent().String(confFlagName)
 			patchID := c.String(patchIDFlagName)
 
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
+
+			client := conf.GetRestCommunicator(ctx)
+			defer client.Close()
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/patch_finalize.go
+++ b/operations/patch_finalize.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -17,10 +18,16 @@ func PatchFinalize() cli.Command {
 			confPath := c.Parent().String(confFlagName)
 			patchID := c.String(patchIDFlagName)
 
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
+
+			client := conf.GetRestCommunicator(ctx)
+			defer client.Close()
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/patch_finalize.go
+++ b/operations/patch_finalize.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -18,15 +17,10 @@ func PatchFinalize() cli.Command {
 			confPath := c.Parent().String(confFlagName)
 			patchID := c.String(patchIDFlagName)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
-
-			_ = conf.GetRestCommunicator(ctx)
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/patch_list.go
+++ b/operations/patch_list.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -31,10 +32,16 @@ func PatchList() cli.Command {
 			number := c.Int(numberFlagName)
 			showSummary := c.Bool(showSummaryFlagName)
 
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
+
+			client := conf.GetRestCommunicator(ctx)
+			defer client.Close()
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/patch_list.go
+++ b/operations/patch_list.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -32,15 +31,10 @@ func PatchList() cli.Command {
 			number := c.Int(numberFlagName)
 			showSummary := c.Bool(showSummaryFlagName)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
-
-			_ = conf.GetRestCommunicator(ctx)
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -34,15 +33,10 @@ func PatchSetModule() cli.Command {
 			committedOnly := c.Bool(committedFlagName)
 			args := c.Args()
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
-
-			_ = conf.GetRestCommunicator(ctx)
 
 			ac, rc, err := conf.getLegacyClients()
 			if err != nil {
@@ -126,15 +120,10 @@ func PatchRemoveModule() cli.Command {
 			patchID := c.String(patchIDFlagName)
 			module := c.String(moduleFlagName)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
-
-			_ = conf.GetRestCommunicator(ctx)
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -33,10 +34,16 @@ func PatchSetModule() cli.Command {
 			committedOnly := c.Bool(committedFlagName)
 			args := c.Args()
 
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
+
+			client := conf.GetRestCommunicator(ctx)
+			defer client.Close()
 
 			ac, rc, err := conf.getLegacyClients()
 			if err != nil {
@@ -120,10 +127,16 @@ func PatchRemoveModule() cli.Command {
 			patchID := c.String(patchIDFlagName)
 			module := c.String(moduleFlagName)
 
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
+
+			client := conf.GetRestCommunicator(ctx)
+			defer client.Close()
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/subscriptions.go
+++ b/operations/subscriptions.go
@@ -33,8 +33,9 @@ func subscriptionsList() cli.Command {
 				return errors.Wrap(err, "problem loading configuration")
 			}
 
-			com := conf.GetRestCommunicator(ctx)
-			subs, err := com.GetSubscriptions(ctx)
+			comm := conf.GetRestCommunicator(ctx)
+			defer comm.Close()
+			subs, err := comm.GetSubscriptions(ctx)
 			if err != nil {
 				return errors.Wrap(err, "error fetching subscriptions")
 			}

--- a/operations/update.go
+++ b/operations/update.go
@@ -54,6 +54,7 @@ func Update() cli.Command {
 			}
 
 			client := conf.GetRestCommunicator(ctx)
+			defer client.Close()
 
 			update, err := checkUpdate(client, false, forceUpdate)
 			if err != nil {

--- a/operations/validate.go
+++ b/operations/validate.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -21,10 +22,16 @@ func Validate() cli.Command {
 			confPath := c.Parent().String(confFlagName)
 			path := c.String(pathFlagName)
 
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
+
+			client := conf.GetRestCommunicator(ctx)
+			defer client.Close()
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/operations/validate.go
+++ b/operations/validate.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -22,15 +21,10 @@ func Validate() cli.Command {
 			confPath := c.Parent().String(confFlagName)
 			path := c.String(pathFlagName)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
-
-			_ = conf.GetRestCommunicator(ctx)
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {

--- a/service/rest_stats.go
+++ b/service/rest_stats.go
@@ -39,7 +39,7 @@ type restMakespanStats struct {
 // getMakespanRatios returns a list of MakespanRatio structs that contain
 // the actual and predicted makespans for a certain number of recent builds.
 func getMakespanRatios(numberBuilds int) ([]restMakespanStats, error) {
-	builds, err := build.Find(build.ByRecentlyFinished(numberBuilds))
+	builds, err := build.Find(build.ByRecentlyFinishedWithMakespans(numberBuilds))
 	if err != nil {
 		return nil, err
 	}

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -63,6 +63,7 @@ func (uis *UIServer) schedulerHostUtilization(w http.ResponseWriter, r *http.Req
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	gimlet.WriteJSON(w, bucketData)
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-5989

## Changes
* Re-added `evergreen export` subcommand.
* Removed unused `Communicator`s and added `Close()` to unclosed `Communicators`.

## Known Issues
* The endpoints that export requests usually return "200 OK" but sometimes return "500 Internal Server Error" (especially `/rest/v1/scheduler/host_utilization`), seemingly because of some timeout on the server side. I've tested this with the cli, curl, and my browser and it happens sporadically.