### PR TITLE
EVG-6024 add UI control to show / hide rejects. The default hides rejected data.

### DIFF
--- a/public/static/app/common/constants.js
+++ b/public/static/app/common/constants.js
@@ -32,7 +32,14 @@ mciModule
         threadLevelMode: {
           type: String,
           default: 'maxonly',
-        }
+        },
+        // Filter Rejected Points, defaults to on.
+        rejectMode: {
+          enabled: {
+            type: Boolean,
+            default: true,
+          },
+        },
       },
     },
   })

--- a/service/templates/task_perf_data.html
+++ b/service/templates/task_perf_data.html
@@ -329,6 +329,11 @@
                            aria-label="origin">
                   Origin
                 </md-switch>
+                <md-switch ng-model="rangeModel.rejectMode"
+                           ng-click="$event.stopPropagation()"
+                           aria-label="origin">
+                  Reject
+                </md-switch>
               </md-fab-actions>
             </md-toolbar>
           </md-fab-toolbar>


### PR DESCRIPTION
I couldn't test the rendering of the new toggle locally, but I did test the functionality by cross wiring origin mode to show / hide rejects. 