### PR TITLE
EVG-5998, EVG-5999, EVG-6044: Add legacy SSH/Jasper bootstrap option to distro UI and REST.

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -335,15 +335,6 @@ var (
 		PlannerVersionTunable,
 	}
 
-	// ValidBootstrapMethods is the set of of valid methods to bootstrap the
-	// host.
-	ValidBootstrapMethods = []string{
-		BootstrapMethodLegacySSH,
-		BootstrapMethodSSH,
-		BootstrapMethodPreconfiguredImage,
-		BootstrapMethodUserData,
-	}
-
 	// constant arrays for db update logic
 	AbortableStatuses = []string{TaskStarted, TaskDispatched}
 	CompletedStatuses = []string{TaskSucceeded, TaskFailed}

--- a/globals.go
+++ b/globals.go
@@ -137,6 +137,12 @@ const (
 	PlannerVersionTunable = "tunable"
 
 	CommitQueueAlias = "__commit_queue"
+
+	// Bootstrapping mechanisms
+	BootstrapMethodLegacySSH          = "legacy-ssh"
+	BootstrapMethodSSH                = "ssh"
+	BootstrapMethodPreconfiguredImage = "preconfigured-image"
+	BootstrapMethodUserData           = "user-data"
 )
 
 func IsFinishedTaskStatus(status string) bool {
@@ -327,6 +333,15 @@ var (
 	ValidPlannerVersions = []string{
 		PlannerVersionLegacy,
 		PlannerVersionTunable,
+	}
+
+	// ValidBootstrapMethods is the set of of valid methods to bootstrap the
+	// host.
+	ValidBootstrapMethods = []string{
+		BootstrapMethodLegacySSH,
+		BootstrapMethodSSH,
+		BootstrapMethodPreconfiguredImage,
+		BootstrapMethodUserData,
 	}
 
 	// constant arrays for db update logic

--- a/globals.go
+++ b/globals.go
@@ -137,12 +137,6 @@ const (
 	PlannerVersionTunable = "tunable"
 
 	CommitQueueAlias = "__commit_queue"
-
-	// Bootstrapping mechanisms
-	BootstrapMethodLegacySSH          = "legacy-ssh"
-	BootstrapMethodSSH                = "ssh"
-	BootstrapMethodPreconfiguredImage = "preconfigured-image"
-	BootstrapMethodUserData           = "user-data"
 )
 
 func IsFinishedTaskStatus(status string) bool {

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -19,6 +19,7 @@ var (
 	UserKey             = bsonutil.MustHaveTag(Distro{}, "User")
 	SSHKeyKey           = bsonutil.MustHaveTag(Distro{}, "SSHKey")
 	SSHOptionsKey       = bsonutil.MustHaveTag(Distro{}, "SSHOptions")
+	BootstrapMethod     = bsonutil.MustHaveTag(Distro{}, "BootstrapMethod")
 	WorkDirKey          = bsonutil.MustHaveTag(Distro{}, "WorkDir")
 	SpawnAllowedKey     = bsonutil.MustHaveTag(Distro{}, "SpawnAllowed")
 	ExpansionsKey       = bsonutil.MustHaveTag(Distro{}, "Expansions")

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -185,6 +185,15 @@ func ValidateContainerPoolDistros(s *evergreen.Settings) error {
 	return errors.WithStack(catcher.Resolve())
 }
 
+func ValidateBootstrapMethod(method string) error {
+	switch method {
+	case evergreen.BootstrapMethodLegacySSH, evergreen.BootstrapMethodSSH, evergreen.BootstrapMethodPreconfiguredImage, evergreen.BootstrapMethodUserData:
+		return nil
+	default:
+		return errors.New(fmt.Sprintf("'%s' is not a valid bootstrap method", method))
+	}
+}
+
 // GetDistroIds returns a slice of distro IDs for the given group of distros
 func (distros DistroGroup) GetDistroIds() []string {
 	var ids []string

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -25,6 +25,7 @@ type Distro struct {
 	Setup            string                  `bson:"setup,omitempty" json:"setup,omitempty" mapstructure:"setup,omitempty"`
 	Teardown         string                  `bson:"teardown,omitempty" json:"teardown,omitempty" mapstructure:"teardown,omitempty"`
 	User             string                  `bson:"user,omitempty" json:"user,omitempty" mapstructure:"user,omitempty"`
+	BootstrapMethod  string                  `bson:"bootstrap_method,omitempty" json:"bootstrap_method,omitempty" mapstructure:"bootstrap_method,omitempty"`
 	SSHKey           string                  `bson:"ssh_key,omitempty" json:"ssh_key,omitempty" mapstructure:"ssh_key,omitempty"`
 	SSHOptions       []string                `bson:"ssh_options,omitempty" json:"ssh_options,omitempty" mapstructure:"ssh_options,omitempty"`
 	SpawnAllowed     bool                    `bson:"spawn_allowed" json:"spawn_allowed,omitempty" mapstructure:"spawn_allowed,omitempty"`

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -61,6 +61,14 @@ const (
 	DockerImageBuildTypePull   = "pull"
 )
 
+const (
+	// Bootstrapping mechanisms
+	BootstrapMethodLegacySSH          = "legacy-ssh"
+	BootstrapMethodSSH                = "ssh"
+	BootstrapMethodPreconfiguredImage = "preconfigured-image"
+	BootstrapMethodUserData           = "user-data"
+)
+
 // Seed the random number generator for creating distro names
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -185,12 +193,14 @@ func ValidateContainerPoolDistros(s *evergreen.Settings) error {
 	return errors.WithStack(catcher.Resolve())
 }
 
+// ValidateBootstrapMethod ensure that the bootstrap mechanism is one of the
+// supported methods.
 func ValidateBootstrapMethod(method string) error {
 	switch method {
-	case evergreen.BootstrapMethodLegacySSH, evergreen.BootstrapMethodSSH, evergreen.BootstrapMethodPreconfiguredImage, evergreen.BootstrapMethodUserData:
+	case BootstrapMethodLegacySSH, BootstrapMethodSSH, BootstrapMethodPreconfiguredImage, BootstrapMethodUserData:
 		return nil
 	default:
-		return errors.New(fmt.Sprintf("'%s' is not a valid bootstrap method", method))
+		return fmt.Errorf("'%s' is not a valid bootstrap method", method)
 	}
 }
 

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -11,6 +11,8 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
     $scope.distros[i].planner_settings = $scope.distros[i].planner_settings || {}
     $scope.distros[i].planner_settings.minimum_hosts = $scope.distros[i].planner_settings.minimum_hosts || 0;
     $scope.distros[i].planner_settings.version = $scope.distros[i].planner_settings.version || "legacy";
+    $scope.distros[i].bootstrap_method = $scope.distros[i].bootstrap_method || 'legacy-ssh';
+    $scope.distros[i].bootstrap_method = $scope.distros[i].bootstrap_method || 'legacy-ssh';
   }
 
   $scope.planner_versions = [{
@@ -77,6 +79,21 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
   }, {
     'id': 'solaris_amd64',
     'display': 'Solaris 64-bit'
+  }];
+
+  $scope.bootstrapMethods = [{
+      'id': 'legacy-ssh',
+      'display': 'Legacy SSH'
+    }, {
+      'id': 'ssh',
+      'display': 'SSH'
+    }, {
+      'id': 'preconfigured-image',
+      'display': 'Preconfigured Image'
+    }, {
+      'id': 'user-data',
+      'display': 'User Data'
+    }, {
   }];
 
   $scope.ids = [];
@@ -301,6 +318,7 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
 	'_id': 'new distro',
 	'arch': 'linux_amd64',
 	'provider': 'ec2',
+    'bootstrap_method': 'legacy',
 	'settings': {},
 	'new': true,
       };
@@ -331,6 +349,7 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
 	'setup': $scope.activeDistro.user_data,
 	'pool_size': $scope.activeDistro.pool_size,
 	'setup_as_sudo' : $scope.activeDistro.setup_as_sudo,
+    'bootstrap_method': $scope.activeDistro.bootstrap_method,
 
       }
       newDistro.settings = _.clone($scope.activeDistro.settings);
@@ -460,6 +479,12 @@ mciModule.filter("versionDisplay", function() {
     return scope.getKeyDisplay('planner_versions', version);
   }
 });
+
+mciModule.filter('bootstrapMethodDisplay', function() {
+  return function(bootstrapMethod, scope) {
+    return scope.getKeyDisplay('bootstrapMethods', bootstrapMethod);
+  }
+})
 
 mciModule.directive('unique', function() {
   return {

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -112,8 +112,8 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
       // If the distro exists, load it.
       var distro = $scope.getDistroById(distroHash);
       if (distro) {
-	$scope.activeDistro = distro;
-	return;
+    $scope.activeDistro = distro;
+    return;
       }
     }
     // Default to the first distro.
@@ -127,7 +127,7 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
 
   $scope.getDistroById = function(id) {
     return _.find($scope.distros, function(distro) {
-	return distro._id === id;
+    return distro._id === id;
     });
   };
 
@@ -144,8 +144,8 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
 
     for (var i = 0; i < keys.length; i++) {
       $scope.keys.push({
-	name: keys[i],
-	location: $window.keys[keys[i]],
+    name: keys[i],
+    location: $window.keys[keys[i]],
       });
     }
   };
@@ -161,7 +161,7 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
   $scope.getKeyDisplay = function(key, display) {
     for (var i = 0; i < $scope[key].length; i++) {
       if ($scope[key][i].id === display) {
-	return $scope[key][i].display;
+    return $scope[key][i].display;
       }
     }
     return display;
@@ -266,30 +266,30 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
   $scope.saveConfiguration = function() {
     if ($scope.activeDistro.new) {
       mciDistroRestService.addDistro(
-	$scope.activeDistro, {
-	  success: function(resp) {
-	    $window.location.reload(true);
-	  },
-	  error: function(resp) {
-	    $window.location.reload(true);
-	    console.log(resp.data.error);
-	  }
-	}
+    $scope.activeDistro, {
+      success: function(resp) {
+        $window.location.reload(true);
+      },
+      error: function(resp) {
+        $window.location.reload(true);
+        console.log(resp.data.error);
+      }
+    }
       );
     } else {
       mciDistroRestService.modifyDistro(
-	$scope.activeDistro._id,
-	$scope.activeDistro,
-	$scope.shouldDeco,
-	{
-	  success: function(resp) {
-	    $window.location.reload(true);
-	  },
-	  error: function(resp) {
-	    $window.location.reload(true);
-	    console.log(resp.data.error);
-	  }
-	}
+    $scope.activeDistro._id,
+    $scope.activeDistro,
+    $scope.shouldDeco,
+    {
+      success: function(resp) {
+        $window.location.reload(true);
+      },
+      error: function(resp) {
+        $window.location.reload(true);
+        console.log(resp.data.error);
+      }
+    }
       );
     }
     // this will reset the location hash to the new one in case the _id is changed.
@@ -301,13 +301,13 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
       $scope.activeDistro._id,
       $scope.shouldDeco,
       {
-	success: function(resp) {
-	  $window.location.reload(true);
-	},
-	error: function(resp) {
-	  $window.location.reload(true);
-	  console.log(resp.data.error);
-	}
+    success: function(resp) {
+      $window.location.reload(true);
+    },
+    error: function(resp) {
+      $window.location.reload(true);
+      console.log(resp.data.error);
+    }
       }
     );
   };
@@ -315,16 +315,16 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
   $scope.newDistro = function() {
     if (!$scope.hasNew) {
       var defaultOptions = {
-	'_id': 'new distro',
-	'arch': 'linux_amd64',
-	'provider': 'ec2',
+    '_id': 'new distro',
+    'arch': 'linux_amd64',
+    'provider': 'ec2',
     'bootstrap_method': 'legacy',
-	'settings': {},
-	'new': true,
+    'settings': {},
+    'new': true,
       };
 
       if ($scope.keys.length != 0) {
-	defaultOptions.ssh_key = $scope.keys[0].name;
+    defaultOptions.ssh_key = $scope.keys[0].name;
       }
       $scope.distros.unshift(defaultOptions);
       $scope.hasNew = true;
@@ -337,18 +337,18 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
   $scope.copyDistro = function(){
     if (!$scope.hasNew) {
       var newDistro = {
-	'arch': $scope.activeDistro.arch,
-	'work_dir': $scope.activeDistro.work_dir,
-	'provider': $scope.activeDistro.provider,
-	'new': true,
-	'user': $scope.activeDistro.user,
-	'ssh_key': $scope.activeDistro.ssh_key,
-	'ssh_options': $scope.activeDistro.ssh_options,
-	'setup': $scope.activeDistro.setup,
-	'setup': $scope.activeDistro.teardown,
-	'setup': $scope.activeDistro.user_data,
-	'pool_size': $scope.activeDistro.pool_size,
-	'setup_as_sudo' : $scope.activeDistro.setup_as_sudo,
+    'arch': $scope.activeDistro.arch,
+    'work_dir': $scope.activeDistro.work_dir,
+    'provider': $scope.activeDistro.provider,
+    'new': true,
+    'user': $scope.activeDistro.user,
+    'ssh_key': $scope.activeDistro.ssh_key,
+    'ssh_options': $scope.activeDistro.ssh_options,
+    'setup': $scope.activeDistro.setup,
+    'setup': $scope.activeDistro.teardown,
+    'setup': $scope.activeDistro.user_data,
+    'pool_size': $scope.activeDistro.pool_size,
+    'setup_as_sudo' : $scope.activeDistro.setup_as_sudo,
     'bootstrap_method': $scope.activeDistro.bootstrap_method,
 
       }
@@ -372,25 +372,25 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
 
     if (option === 'removeDistro') {
       if (modal.data('bs.modal').isShown) {
-	$scope.modalOpen = true;
+    $scope.modalOpen = true;
       } else {
-	$scope.modalOpen = false;
+    $scope.modalOpen = false;
       }
     }
 
     $(document).keyup(function(ev) {
       if ($scope.modalOpen && ev.keyCode === 13) {
-	if ($scope.confirmationOption === 'removeDistro') {
-	  $scope.removeConfiguration();
-	  $('#admin-modal').modal('hide');
-	}
+    if ($scope.confirmationOption === 'removeDistro') {
+      $scope.removeConfiguration();
+      $('#admin-modal').modal('hide');
+    }
       }
     });
   }
 
   $scope.checkPortRange = function(min, max) {
     if ($scope.form.portRange.minPort.$invalid || $scope.form.portRange.maxPort.$invalid) {
-	return false
+    return false
     }
     return (!min && !max) || (min >= 0 && min <= max);
   }
@@ -431,9 +431,9 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
     // if a security group is in a vpc it needs to be the id which starts with 'subnet-'
     $scope.validSubnetId = function(){
       if ($scope.activeDistro){
-	if ($scope.activeDistro.settings.is_vpc) {
-	  return $scope.activeDistro.settings.subnet_id.substring(0,7) == 'subnet-';
-	}
+    if ($scope.activeDistro.settings.is_vpc) {
+      return $scope.activeDistro.settings.subnet_id.substring(0,7) == 'subnet-';
+    }
       }
       return true
     };
@@ -491,14 +491,14 @@ mciModule.directive('unique', function() {
     require: 'ngModel',
     link: function(scope, elm, attrs, ctrl) {
       ctrl.$parsers.unshift(function(value) {
-	var valid = scope.isUnique(value);
-	ctrl.$setValidity('unique', valid);
-	return value;
+    var valid = scope.isUnique(value);
+    ctrl.$setValidity('unique', valid);
+    return value;
       });
       ctrl.$formatters.unshift(function(value) {
-	var valid = scope.isUnique(value);
-	ctrl.$setValidity('unique', valid);
-	return value;
+    var valid = scope.isUnique(value);
+    ctrl.$setValidity('unique', valid);
+    return value;
       });
     }
   };

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -84,6 +84,7 @@ type APIDistro struct {
 	Setup            APIString              `json:"setup"`
 	Teardown         APIString              `json:"teardown"`
 	User             APIString              `json:"user"`
+	BootstrapMethod  APIString              `json:"bootstrap_method"`
 	SSHKey           APIString              `json:"ssh_key"`
 	SSHOptions       []string               `json:"ssh_options"`
 	Expansions       []APIExpansion         `json:"expansions"`
@@ -125,6 +126,10 @@ func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
 	apiDistro.Setup = ToAPIString(d.Setup)
 	apiDistro.Teardown = ToAPIString(d.Teardown)
 	apiDistro.User = ToAPIString(d.User)
+	if d.BootstrapMethod == "" {
+		d.BootstrapMethod = evergreen.BootstrapMethodLegacySSH
+	}
+	apiDistro.BootstrapMethod = ToAPIString(d.BootstrapMethod)
 	apiDistro.SSHKey = ToAPIString(d.SSHKey)
 	apiDistro.Disabled = d.Disabled
 	apiDistro.ContainerPool = ToAPIString(d.ContainerPool)
@@ -163,6 +168,7 @@ func (apiDistro *APIDistro) ToService() (interface{}, error) {
 	d.Setup = FromAPIString(apiDistro.Setup)
 	d.Teardown = FromAPIString(apiDistro.Teardown)
 	d.User = FromAPIString(apiDistro.User)
+	d.BootstrapMethod = FromAPIString(apiDistro.BootstrapMethod)
 	d.SSHKey = FromAPIString(apiDistro.SSHKey)
 	d.SSHOptions = apiDistro.SSHOptions
 	d.SpawnAllowed = apiDistro.UserSpawnAllowed

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -127,7 +127,7 @@ func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
 	apiDistro.Teardown = ToAPIString(d.Teardown)
 	apiDistro.User = ToAPIString(d.User)
 	if d.BootstrapMethod == "" {
-		d.BootstrapMethod = evergreen.BootstrapMethodLegacySSH
+		d.BootstrapMethod = distro.BootstrapMethodLegacySSH
 	}
 	apiDistro.BootstrapMethod = ToAPIString(d.BootstrapMethod)
 	apiDistro.SSHKey = ToAPIString(d.SSHKey)

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -267,7 +267,7 @@ func (h *distroIDPutHandler) Run(ctx context.Context) gimlet.Responder {
 		PlannerSettings: model.APIPlannerSettings{
 			Version: model.ToAPIString(evergreen.PlannerVersionLegacy),
 		},
-		BootstrapMethod: model.ToAPIString(evergreen.BootstrapMethodLegacySSH),
+		BootstrapMethod: model.ToAPIString(distro.BootstrapMethodLegacySSH),
 	}
 	if err = json.Unmarshal(h.body, apiDistro); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "API error while unmarshalling JSON"))

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -267,6 +267,7 @@ func (h *distroIDPutHandler) Run(ctx context.Context) gimlet.Responder {
 		PlannerSettings: model.APIPlannerSettings{
 			Version: model.ToAPIString(evergreen.PlannerVersionLegacy),
 		},
+		BootstrapMethod: model.ToAPIString(evergreen.BootstrapMethodLegacySSH),
 	}
 	if err = json.Unmarshal(h.body, apiDistro); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "API error while unmarshalling JSON"))

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -273,7 +273,7 @@ func (s *DistroByIDSuite) SetupSuite() {
 					MainlineFirst:          false,
 					PatchFirst:             true,
 				},
-				BootstrapMethod: evergreen.BootstrapMethodLegacySSH,
+				BootstrapMethod: distro.BootstrapMethodLegacySSH,
 			},
 			{Id: "distro2"},
 		},
@@ -311,7 +311,7 @@ func (s *DistroByIDSuite) TestFindByIdFound() {
 	s.Equal(7, d.PlannerSettings.PatchZipperFactor)
 	s.Equal(false, d.PlannerSettings.MainlineFirst)
 	s.Equal(true, d.PlannerSettings.PatchFirst)
-	s.Equal(d.BootstrapMethod, model.ToAPIString(evergreen.BootstrapMethodLegacySSH))
+	s.Equal(d.BootstrapMethod, model.ToAPIString(distro.BootstrapMethodLegacySSH))
 }
 
 func (s *DistroByIDSuite) TestFindByIdFail() {
@@ -937,7 +937,7 @@ func (s *DistroPatchByIDSuite) TestRunValidBootstrapMethod() {
 
 	apiDistro, ok := (resp.Data()).(*model.APIDistro)
 	s.Require().True(ok)
-	s.Equal(model.ToAPIString(evergreen.BootstrapMethodLegacySSH), apiDistro.BootstrapMethod)
+	s.Equal(model.ToAPIString(distro.BootstrapMethodLegacySSH), apiDistro.BootstrapMethod)
 }
 
 func (s *DistroPatchByIDSuite) TestRunInvalidBootstrapMethod() {
@@ -1032,7 +1032,7 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 	s.Equal(apiDistro.SetupAsSudo, false)
 	s.Equal(apiDistro.Setup, model.ToAPIString("~Set-up script"))
 	s.Equal(apiDistro.Teardown, model.ToAPIString("~Tear-down script"))
-	s.Equal(model.ToAPIString(evergreen.BootstrapMethodLegacySSH), apiDistro.BootstrapMethod)
+	s.Equal(model.ToAPIString(distro.BootstrapMethodLegacySSH), apiDistro.BootstrapMethod)
 	s.Equal(apiDistro.User, model.ToAPIString("~root"))
 	s.Equal(apiDistro.SSHKey, model.ToAPIString("~SSH string"))
 	s.Equal(apiDistro.SSHOptions, []string{"~StrictHostKeyChecking=no", "~BatchMode=no", "~ConnectTimeout=10"})

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -415,7 +415,7 @@ func (s *DistroPutSuite) TestRunNewWithInValidEntity() {
 	err := (resp.Data()).(gimlet.ErrorResponse)
 	s.Contains(err.Message, "ERROR: distro 'ssh_key' cannot be blank")
 	s.Contains(err.Message, "ERROR: invalid distro.planner_settings.version 'invalid' for distro 'distro4'")
-	s.Contains(err.Message, "ERROR: invalid bootstrap method")
+	s.Contains(err.Message, "ERROR: 'foo' is not a valid bootstrap method")
 }
 
 func (s *DistroPutSuite) TestRunNewConflictingName() {

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -415,7 +415,7 @@ func (s *DistroPutSuite) TestRunNewWithInValidEntity() {
 	err := (resp.Data()).(gimlet.ErrorResponse)
 	s.Contains(err.Message, "ERROR: distro 'ssh_key' cannot be blank")
 	s.Contains(err.Message, "ERROR: invalid distro.planner_settings.version 'invalid' for distro 'distro4'")
-	s.Contains(err.Message, "ERROR: 'foo' is not a valid bootstrap method")
+	s.Contains(err.Message, "ERROR: error validating bootstrap method: 'foo' is not a valid bootstrap method")
 }
 
 func (s *DistroPutSuite) TestRunNewConflictingName() {

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -518,6 +518,18 @@ Evergreen - Distros
             user is required</div><br>
         </div>
         <div class="dropdown">
+          <span class="distro-menu-title">Bootstrap Method:</span>
+            <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true" ng-disabled="readOnly">
+              <strong class="distro-menu-item">[[ activeDistro.bootstrap_method | bootstrapMethodDisplay:this]]<span class="fa fa-caret-down"></span></strong>
+            </button>
+            <ul class="dropdown-menu" style="margin-left: 125px; align: left" role="menu">
+              <li required name="bootstrapMethodForm" ng-click="form.$setDirty();activeDistro.bootstrap_method = bootstrapMethod.id" ng-repeat="bootstrapMethod in bootstrapMethods"
+                role="presentation"><a role="menuitem" tabindex="-1">[[bootstrapMethod.display]]</a></li>
+            </ul>
+        </div>
+        <br />
+        <div class="icon fa fa-warning distro-error" ng-show="form.bootstrapMethodForm.$dirty && form.bootstrapMethodForm.$invalid || bootstrapMethodForm.$error.required">Bootstrap method is required</div>
+        <div class="dropdown">
           <span class="distro-menu-title">SSH Key:</span>
           <button class="btn btn-default dropdown-toggle" ng-disabled="readOnly" type="button" data-toggle="dropdown">
             <strong class="distro-menu-item">[[activeDistro.ssh_key]]<span class="fa fa-caret-down"></span></strong>

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -71,7 +71,7 @@ Evergreen - Distros
                 ng-disabled="readOnly">
                 <strong class="distro-menu-item">[[activeDistro.arch | archDisplay:this]]<span class="fa fa-caret-down"></span></strong>
               </button>
-              <ul class="dropdown-menu" style="margin-left: 125px; align: left;" role="menu">
+              <ul class="dropdown-menu" style="margin-left: 125px" role="menu">
                 <li ng-click="form.$setDirty();setKeyValue('arch', arch.id)" required name="agentArch" ng-repeat="arch in architectures | orderBy:'display'"
                   role="presentation"><a role="menuitem" tabindex="-1">[[arch.display]]</a></li>
               </ul>
@@ -93,7 +93,7 @@ Evergreen - Distros
               <button class="btn btn-default dropdown-toggle" ng-disabled="readOnly" type="button" data-toggle="dropdown">
                 <strong class="distro-menu-item">[[activeDistro.provider | providerDisplay:this]]<span class="fa fa-caret-down"></span></strong>
               </button>
-              <ul class="dropdown-menu" role="menu" style="margin-left: 60px; align: left;">
+              <ul class="dropdown-menu" role="menu" style="margin-left: 60px">
                 <li ng-click="form.$setDirty();setKeyValue('provider', provider.id)" required name="providerForm"
                   ng-repeat="provider in providers" role="presentation"><a role="menuitem" tabindex="-1">[[provider.display]]</a></li>
               </ul>
@@ -466,7 +466,7 @@ Evergreen - Distros
                 ng-disabled="readOnly">
                   <strong class="distro-menu-item">[[ activeDistro.planner_settings.version | versionDisplay:this]]<span class="fa fa-caret-down"></span></strong>
                 </button>
-                <ul class="dropdown-menu" style="margin-left: 125px; align: left;" role="menu">
+                <ul class="dropdown-menu" style="margin-left: 125px" role="menu">
                   <li required name="plannerVersion" ng-click="form.$setDirty();activeDistro.planner_settings.version = version.id" ng-repeat="version in planner_versions"
                     role="presentation"><a role="menuitem" tabindex="-1">[[version.display]]</a></li>
                 </ul>
@@ -520,9 +520,9 @@ Evergreen - Distros
         <div class="dropdown">
           <span class="distro-menu-title">Bootstrap Method:</span>
             <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true" ng-disabled="readOnly">
-              <strong class="distro-menu-item">[[ activeDistro.bootstrap_method | bootstrapMethodDisplay:this]]<span class="fa fa-caret-down"></span></strong>
+              <strong class="distro-menu-item">[[activeDistro.bootstrap_method | bootstrapMethodDisplay:this]]<span class="fa fa-caret-down"></span></strong>
             </button>
-            <ul class="dropdown-menu" style="margin-left: 125px; align: left" role="menu">
+            <ul class="dropdown-menu" style="margin-left: 125px" role="menu">
               <li required name="bootstrapMethodForm" ng-click="form.$setDirty();activeDistro.bootstrap_method = bootstrapMethod.id" ng-repeat="bootstrapMethod in bootstrapMethods"
                 role="presentation"><a role="menuitem" tabindex="-1">[[bootstrapMethod.display]]</a></li>
             </ul>
@@ -534,7 +534,7 @@ Evergreen - Distros
           <button class="btn btn-default dropdown-toggle" ng-disabled="readOnly" type="button" data-toggle="dropdown">
             <strong class="distro-menu-item">[[activeDistro.ssh_key]]<span class="fa fa-caret-down"></span></strong>
           </button>
-          <ul class="dropdown-menu" role="menu" style="margin-left: 63px; align: left;">
+          <ul class="dropdown-menu" role="menu" style="margin-left: 63px">
             <li required name="sshKeyForm" ng-click="form.$setDirty();setKeyValue('ssh_key', key.name)" ng-repeat="key in keys"
               role="presentation"><a role="menuitem" tabindex="-1">[[key.name]] - [[key.location]]</a></li>
           </ul>

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -487,8 +487,6 @@ Evergreen - Distros
             <div class="icon fa fa-warning distro-error" ng-show="form.minimumHosts.$dirty && form.minimumHosts.$error.required || form.minimumHosts.$invalid">Numeric pool size is required</div>
           </div>
           <div ng-form name="hostProviderForm" ng-show="activeDistro.provider == 'static'">
-             <label class="distro-label">Hosts<span ng-show="activeDistro.settings.hosts && activeDistro.settings.hosts.length != 0">([[activeDistro.settings.hosts.length]])</span>:</label>
-          <div ng-form name="hostProviderForm" ng-show="activeDistro.provider == 'static'">
             <label class="distro-label">Hosts<span ng-show="activeDistro.settings.hosts && activeDistro.settings.hosts.length != 0">([[activeDistro.settings.hosts.length]])</span>:</label>
             <div id="hosts-table" class="distro-table-scroll">
               <table style="margin-left: -8px;" class="table distro-table" ng-show="activeDistro.settings.hosts">

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -26,6 +26,7 @@ var distroSyntaxValidators = []distroValidator{
 	ensureValidExpansions,
 	ensureStaticHostsAreNotSpawnable,
 	ensureValidContainerPool,
+	ensureValidBootstrapMethod,
 	ensureHasNoUnauthorizedCharacters,
 	ensureHasValidPlannerVersion,
 }
@@ -164,6 +165,13 @@ func ensureValidSSHOptions(ctx context.Context, d *distro.Distro, s *evergreen.S
 		if o == "" {
 			return ValidationErrors{{Error, fmt.Sprintf("distro cannot be blank SSH option")}}
 		}
+	}
+	return nil
+}
+
+func ensureValidBootstrapMethod(ctx context.Context, d *distro.Distro, s *evergreen.Settings) ValidationErrors {
+	if !util.StringSliceContains(evergreen.ValidBootstrapMethods, d.BootstrapMethod) {
+		return ValidationErrors{{Level: Error, Message: fmt.Sprintf("invalid bootstrap method")}}
 	}
 	return nil
 }

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -170,8 +171,8 @@ func ensureValidSSHOptions(ctx context.Context, d *distro.Distro, s *evergreen.S
 }
 
 func ensureValidBootstrapMethod(ctx context.Context, d *distro.Distro, s *evergreen.Settings) ValidationErrors {
-	if !util.StringSliceContains(evergreen.ValidBootstrapMethods, d.BootstrapMethod) {
-		return ValidationErrors{{Level: Error, Message: fmt.Sprintf("invalid bootstrap method")}}
+	if err := distro.ValidateBootstrapMethod(d.BootstrapMethod); err != nil {
+		return ValidationErrors{{Level: Error, Message: errors.Wrap(err, "error validating bootstrap method").Error()}}
 	}
 	return nil
 }

--- a/validator/distro_validator_test.go
+++ b/validator/distro_validator_test.go
@@ -38,6 +38,7 @@ func TestCheckDistro(t *testing.T) {
 				PlannerSettings: distro.PlannerSettings{
 					Version: evergreen.PlannerVersionTunable,
 				},
+				BootstrapMethod: evergreen.BootstrapMethodLegacySSH,
 			}
 			verrs, err := CheckDistro(ctx, d, conf, true)
 			So(err, ShouldBeNil)
@@ -54,6 +55,7 @@ func TestCheckDistro(t *testing.T) {
 					"security_group_ids": []string{"a"},
 					"mount_points":       nil,
 				},
+				BootstrapMethod: evergreen.BootstrapMethodLegacySSH,
 			}
 			// simulate duplicate id
 			dupe := distro.Distro{Id: "a"}
@@ -76,6 +78,7 @@ func TestCheckDistro(t *testing.T) {
 				PlannerSettings: distro.PlannerSettings{
 					Version: evergreen.PlannerVersionTunable,
 				},
+				BootstrapMethod: evergreen.BootstrapMethodLegacySSH,
 			}
 			verrs, err := CheckDistro(ctx, d, conf, false)
 			So(err, ShouldBeNil)
@@ -92,6 +95,7 @@ func TestCheckDistro(t *testing.T) {
 					"security_group_ids": []string{"a"},
 					"mount_points":       nil,
 				},
+				BootstrapMethod: evergreen.BootstrapMethodLegacySSH,
 			}
 			verrs, err := CheckDistro(ctx, d, conf, false)
 			So(err, ShouldBeNil)
@@ -337,4 +341,18 @@ func TestEnsureValidContainerPool(t *testing.T) {
 		"distro container pool does not exist"}})
 	err = ensureValidContainerPool(ctx, d4, conf)
 	assert.Nil(err)
+}
+
+func TestEnsureValidBootstrapMethod(t *testing.T) {
+	ctx := context.Background()
+	for _, bootstrapMethod := range []string{
+		evergreen.BootstrapMethodLegacySSH,
+		evergreen.BootstrapMethodSSH,
+		evergreen.BootstrapMethodPreconfiguredImage,
+		evergreen.BootstrapMethodUserData,
+	} {
+		assert.Nil(t, ensureValidBootstrapMethod(ctx, &distro.Distro{BootstrapMethod: bootstrapMethod}, &evergreen.Settings{}))
+	}
+	assert.NotNil(t, ensureValidBootstrapMethod(ctx, &distro.Distro{BootstrapMethod: "foobar"}, &evergreen.Settings{}))
+	assert.NotNil(t, ensureValidBootstrapMethod(ctx, &distro.Distro{BootstrapMethod: ""}, &evergreen.Settings{}))
 }

--- a/validator/distro_validator_test.go
+++ b/validator/distro_validator_test.go
@@ -38,7 +38,7 @@ func TestCheckDistro(t *testing.T) {
 				PlannerSettings: distro.PlannerSettings{
 					Version: evergreen.PlannerVersionTunable,
 				},
-				BootstrapMethod: evergreen.BootstrapMethodLegacySSH,
+				BootstrapMethod: distro.BootstrapMethodLegacySSH,
 			}
 			verrs, err := CheckDistro(ctx, d, conf, true)
 			So(err, ShouldBeNil)
@@ -55,7 +55,7 @@ func TestCheckDistro(t *testing.T) {
 					"security_group_ids": []string{"a"},
 					"mount_points":       nil,
 				},
-				BootstrapMethod: evergreen.BootstrapMethodLegacySSH,
+				BootstrapMethod: distro.BootstrapMethodLegacySSH,
 			}
 			// simulate duplicate id
 			dupe := distro.Distro{Id: "a"}
@@ -78,7 +78,7 @@ func TestCheckDistro(t *testing.T) {
 				PlannerSettings: distro.PlannerSettings{
 					Version: evergreen.PlannerVersionTunable,
 				},
-				BootstrapMethod: evergreen.BootstrapMethodLegacySSH,
+				BootstrapMethod: distro.BootstrapMethodLegacySSH,
 			}
 			verrs, err := CheckDistro(ctx, d, conf, false)
 			So(err, ShouldBeNil)
@@ -95,7 +95,7 @@ func TestCheckDistro(t *testing.T) {
 					"security_group_ids": []string{"a"},
 					"mount_points":       nil,
 				},
-				BootstrapMethod: evergreen.BootstrapMethodLegacySSH,
+				BootstrapMethod: distro.BootstrapMethodLegacySSH,
 			}
 			verrs, err := CheckDistro(ctx, d, conf, false)
 			So(err, ShouldBeNil)
@@ -346,10 +346,10 @@ func TestEnsureValidContainerPool(t *testing.T) {
 func TestEnsureValidBootstrapMethod(t *testing.T) {
 	ctx := context.Background()
 	for _, bootstrapMethod := range []string{
-		evergreen.BootstrapMethodLegacySSH,
-		evergreen.BootstrapMethodSSH,
-		evergreen.BootstrapMethodPreconfiguredImage,
-		evergreen.BootstrapMethodUserData,
+		distro.BootstrapMethodLegacySSH,
+		distro.BootstrapMethodSSH,
+		distro.BootstrapMethodPreconfiguredImage,
+		distro.BootstrapMethodUserData,
 	} {
 		assert.Nil(t, ensureValidBootstrapMethod(ctx, &distro.Distro{BootstrapMethod: bootstrapMethod}, &evergreen.Settings{}))
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-5998
https://jira.mongodb.org/browse/EVG-5999
https://jira.mongodb.org/browse/EVG-6044

* Added an option to the UI to configure provisioning.

If somebody wants to suggest a better name for the field than `BootstrapMethod`, let me know because I don't love it.

<img width="1211" alt="Screen Shot 2019-04-04 at 11 11 31 AM" src="https://user-images.githubusercontent.com/8785663/55566923-a568c480-56ca-11e9-86d6-dc8d99e64979.png">