### PR TITLE
EVG-6055: add function to check Linux host's init system

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -49,8 +49,6 @@ type PlannerSettings struct {
 
 type DistroGroup []Distro
 
-type ValidateFormat string
-
 type Expansion struct {
 	Key   string `bson:"key,omitempty" json:"key,omitempty"`
 	Value string `bson:"value,omitempty" json:"value,omitempty"`
@@ -59,9 +57,7 @@ type Expansion struct {
 const (
 	DockerImageBuildTypeImport = "import"
 	DockerImageBuildTypePull   = "pull"
-)
 
-const (
 	// Bootstrapping mechanisms
 	BootstrapMethodLegacySSH          = "legacy-ssh"
 	BootstrapMethodSSH                = "ssh"
@@ -106,6 +102,11 @@ func (d *Distro) IsWindows() bool {
 	// XXX: if this is-windows check is updated, make sure to also update
 	// public/static/js/spawned_hosts.js as well
 	return strings.Contains(d.Arch, "windows")
+}
+
+func (d *Distro) Platform() (string, string) {
+	osAndArch := strings.Split(d.Arch, "_")
+	return osAndArch[0], osAndArch[1]
 }
 
 func (d *Distro) IsEphemeral() bool {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -687,7 +687,6 @@ func (h *Host) CacheHostData() error {
 	_, err := UpsertOne(
 		bson.M{
 			IdKey: h.Id,
-			IdKey: h.Id,
 		},
 		bson.M{
 			"$set": bson.M{

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -196,6 +196,11 @@ type ContainersOnParents struct {
 
 const (
 	MaxLCTInterval = 5 * time.Minute
+
+	// Potential init systems supported by a Linux host.
+	InitSystemSystemd = "systemd"
+	InitSystemSysV    = "sysv"
+	InitSystemUpstart = "upstart"
 )
 
 func (h *Host) GetTaskGroupString() string {
@@ -681,6 +686,7 @@ func (h *Host) Upsert() (*adb.ChangeInfo, error) {
 func (h *Host) CacheHostData() error {
 	_, err := UpsertOne(
 		bson.M{
+			IdKey: h.Id,
 			IdKey: h.Id,
 		},
 		bson.M{

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -75,7 +75,7 @@ const (
 func (h *Host) GetSSHInfo() (*util.StaticHostInfo, error) {
 	hostInfo, err := util.ParseSSHInfo(h.Host)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing ssh info %v", h.Host)
+		return nil, errors.Wrapf(err, "error parsing ssh info %s", h.Host)
 	}
 	if hostInfo.User == "" {
 		hostInfo.User = h.User
@@ -113,7 +113,7 @@ func (h *Host) RunSSHCommand(ctx context.Context, cmd string, sshOptions []strin
 func (h *Host) InitSystem(ctx context.Context, sshOptions []string) (string, error) {
 	logs, err := h.RunSSHCommand(ctx, initSystemCommand(), sshOptions)
 	if err != nil {
-		return "", errors.Wrapf(err, "init system command returned: %v", logs)
+		return "", errors.Wrapf(err, "init system command returned: %s", logs)
 	}
 
 	if strings.Contains(logs, InitSystemSystemd) {
@@ -124,25 +124,13 @@ func (h *Host) InitSystem(ctx context.Context, sshOptions []string) (string, err
 		return InitSystemUpstart, nil
 	}
 
-	return "", errors.Errorf("could not determine init system: init system command returned: %v", logs)
+	return "", errors.Errorf("could not determine init system: init system command returned: %s", logs)
 }
 
 // initSystemCommand returns the string command to determine a Linux host's
 // init system. If it succeeds, it returns the init system as a string.
 func initSystemCommand() string {
 	return `
-	if type rpm >/dev/null 2>&1; then
-		if rpm -qf /sbin/init 2>/dev/null | grep -i 'systemd' >/dev/null 2>&1; then
-			echo 'systemd';
-			exit 0;
-		elif rpm -qf /sbin/init 2>/dev/null | grep -i 'upstart' >/dev/null 2>&1; then
-			echo 'upstart';
-			exit 0;
-		elif rpm -qf /sbin/init 2>/dev/null | grep -i 'sysv' >/dev/null 2>&1; then
-			echo 'sysv';
-			exit 0;
-		fi
-	fi
 	if [[ -x /sbin/init ]] && /sbin/init --version 2>/dev/null | grep -i 'upstart' >/dev/null 2>&1; then
 		echo 'upstart';
 		exit 0;


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6055

This is currently unused because it's just in preparation for Jasper being started as a service when it's being started over SSH.