### PR TITLE
EVG-5872 dogfooding spawn containers

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -163,7 +163,6 @@ func (ch *CreateHost) ValidateDocker() error {
 		(ch.Registry.Username == "" && ch.Registry.Password != "") {
 		catcher.New("username and password must both be set or unset")
 	}
-
 	return catcher.Resolve()
 }
 

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -15,7 +15,7 @@ const (
 	ScopeBuild                      = "build"
 	DefaultSetupTimeoutSecs         = 600
 	DefaultTeardownTimeoutSecs      = 21600
-	DefaultContainerWaitTimeoutSecs = 900
+	DefaultContainerWaitTimeoutSecs = 600
 	DefaultPollFrequency            = 30
 )
 

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -15,7 +15,7 @@ const (
 	ScopeBuild                      = "build"
 	DefaultSetupTimeoutSecs         = 600
 	DefaultTeardownTimeoutSecs      = 21600
-	DefaultContainerWaitTimeoutSecs = 600
+	DefaultContainerWaitTimeoutSecs = 900
 	DefaultPollFrequency            = 30
 )
 

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -75,7 +75,7 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 	// Create container
 	if err = m.client.CreateContainer(ctx, parentHost, h); err != nil {
 		err = errors.Wrapf(err, "Failed to create container for host '%s'", h.Id)
-		grip.Error(message.WrapError(err, message.Fields{
+		grip.Info(message.WrapError(err, message.Fields{
 			"message": "spawn container host failed",
 			"host":    h.Id,
 		}))
@@ -98,7 +98,7 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 		if err2 := m.client.RemoveContainer(ctx, parentHost, h.Id); err2 != nil {
 			err = errors.Wrapf(err, "Unable to cleanup: %+v", err2)
 		}
-		grip.Error(message.WrapError(err, message.Fields{
+		grip.Info(message.WrapError(err, message.Fields{
 			"message": "start container host failed",
 			"host":    h.Id,
 		}))
@@ -107,7 +107,7 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 
 	grip.Info(message.Fields{
 		"message": "created and started Docker container",
-		"host":    h,
+		"host":    h.Id,
 	})
 	event.LogHostStarted(h.Id)
 

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -88,6 +88,11 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 		})
 		return nil, err
 	}
+	grip.Info(message.Fields{
+		"message": "in spawn host, check ext_identifier",
+		"host":    h,
+		"purpose": "dogfooding",
+	})
 
 	if err = h.SetAgentRevision(evergreen.BuildRevision); err != nil {
 		return nil, errors.Wrapf(err, "error setting agent revision on host %s", h.Id)
@@ -115,7 +120,9 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 
 	grip.Info(message.Fields{
 		"message":   "created and started Docker container",
-		"container": h.Id,
+		"host":      h,
+		"purpose":   "dogfooding", // only remove this and next line
+		"operation": "check ext_identifier",
 	})
 	event.LogHostStarted(h.Id)
 

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -336,6 +336,7 @@ func (m *dockerManager) GetContainerImage(ctx context.Context, parent *host.Host
 	grip.Info(message.Fields{
 		"operation": "EnsureImageDownloaded",
 		"details":   "total",
+		"image":     image,
 		"duration":  time.Since(start),
 		"span":      time.Since(start).String(),
 	})

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -119,10 +119,8 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 	}
 
 	grip.Info(message.Fields{
-		"message":   "created and started Docker container",
-		"host":      h,
-		"purpose":   "dogfooding", // only remove this and next line
-		"operation": "check ext_identifier",
+		"message": "created and started Docker container",
+		"host":    h,
 	})
 	event.LogHostStarted(h.Id)
 

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -75,11 +75,10 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 	// Create container
 	if err = m.client.CreateContainer(ctx, parentHost, h); err != nil {
 		err = errors.Wrapf(err, "Failed to create container for host '%s'", h.Id)
-		grip.Error(message.Fields{
+		grip.Error(message.WrapError(err, message.Fields{
 			"message": "spawn container host failed",
 			"host":    h.Id,
-			"error":   err.Error(),
-		})
+		}))
 		return nil, err
 	}
 
@@ -99,11 +98,10 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 		if err2 := m.client.RemoveContainer(ctx, parentHost, h.Id); err2 != nil {
 			err = errors.Wrapf(err, "Unable to cleanup: %+v", err2)
 		}
-		grip.Error(message.Fields{
+		grip.Error(message.WrapError(err, message.Fields{
 			"message": "start container host failed",
 			"host":    h.Id,
-			"error":   err.Error(),
-		})
+		}))
 		return nil, err
 	}
 

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -48,12 +48,6 @@ func (*dockerManager) GetSettings() ProviderSettings {
 
 // SpawnHost creates and starts a new Docker container
 func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, error) {
-	grip.Info(message.Fields{
-		"message": "attempting to spawn host",
-		"host":    h.Id,
-		"parent":  h.ParentID,
-		"purpose": "dogfooding",
-	})
 	if h.Distro.Provider != evergreen.ProviderNameDocker {
 		return nil, errors.Errorf("Can't spawn instance of %s for distro %s: provider is %s",
 			evergreen.ProviderNameDocker, h.Distro.Id, h.Distro.Provider)
@@ -80,7 +74,7 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 
 	// Create container
 	if err = m.client.CreateContainer(ctx, parentHost, h); err != nil {
-		err = errors.Wrapf(err, "Failed to create container for host '%s'", hostIP)
+		err = errors.Wrapf(err, "Failed to create container for host '%s'", h.Id)
 		grip.Error(message.Fields{
 			"message": "spawn container host failed",
 			"host":    h.Id,
@@ -88,11 +82,6 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 		})
 		return nil, err
 	}
-	grip.Info(message.Fields{
-		"message": "in spawn host, check ext_identifier",
-		"host":    h,
-		"purpose": "dogfooding",
-	})
 
 	if err = h.SetAgentRevision(evergreen.BuildRevision); err != nil {
 		return nil, errors.Wrapf(err, "error setting agent revision on host %s", h.Id)

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -414,9 +414,13 @@ func (c *dockerClientImpl) GetDockerLogs(ctx context.Context, containerID string
 }
 
 func (c *dockerClientImpl) GetDockerStatus(ctx context.Context, containerID string, parent *host.Host) (*ContainerStatus, error) {
+	notRunningStatuses := []string{evergreen.HostUninitialized, evergreen.HostBuilding, evergreen.HostProvisioning, evergreen.HostStarting}
+	if util.StringSliceContains(notRunningStatuses, parent.Status) {
+		return &ContainerStatus{HasStarted: false}, nil
+	}
 	container, err := c.GetContainer(ctx, parent, containerID)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if strings.Contains(err.Error(), "No such container") {
 			return &ContainerStatus{HasStarted: false}, nil
 		}
 		return nil, errors.Wrapf(err, "Error getting container %s", containerID)

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -329,7 +329,10 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 
 	// Extract image name from url
 	baseName := path.Base(containerHost.DockerOptions.Image)
-	provisionedImage := fmt.Sprintf(provisionedImageTag, strings.TrimSuffix(baseName, filepath.Ext(baseName)))
+	provisionedImage := strings.TrimSuffix(baseName, filepath.Ext(baseName))
+	if !containerHost.DockerOptions.SkipImageBuild {
+		provisionedImage = fmt.Sprintf(provisionedImageTag, provisionedImage)
+	}
 
 	agentCmdParts := []string{containerHost.DockerOptions.Command}
 	if containerHost.DockerOptions.Command == "" {

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -414,8 +414,7 @@ func (c *dockerClientImpl) GetDockerLogs(ctx context.Context, containerID string
 }
 
 func (c *dockerClientImpl) GetDockerStatus(ctx context.Context, containerID string, parent *host.Host) (*ContainerStatus, error) {
-	notRunningStatuses := []string{evergreen.HostUninitialized, evergreen.HostBuilding, evergreen.HostProvisioning, evergreen.HostStarting}
-	if util.StringSliceContains(notRunningStatuses, parent.Status) {
+	if util.StringSliceContains(evergreen.NotRunningStatus, parent.Status) {
 		return &ContainerStatus{HasStarted: false}, nil
 	}
 	container, err := c.GetContainer(ctx, parent, containerID)

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -428,11 +428,6 @@ func (c *dockerClientImpl) GetDockerStatus(ctx context.Context, containerID stri
 		HasStarted: true,
 		IsRunning:  container.State.Running,
 	}
-	grip.Info(message.Fields{
-		"message":   "getDockerStatus",
-		"status":    status,
-		"operation": "dogfooding",
-	})
 	return &status, nil
 }
 

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -386,16 +386,22 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 	info, err := dockerClient.ContainerCreate(ctx, containerConf, hostConf, networkConf, containerHost.Id)
 	if err != nil {
 		err = errors.Wrapf(err, "Docker create API call failed for container '%s'", containerHost.Id)
-		grip.Info(message.Fields{
-			"message": "failed to create container",
-			"error":   err.Error(),
-			"host":    containerHost,
-			"purpose": "dogfooding",
-		})
 		grip.Error(err)
 		return err
 	}
+	grip.Info(message.Fields{
+		"message": "created container (before assigning ext. identifier)",
+		"info":    info,
+		"host":    containerHost,
+		"purpose": "dogfooding",
+	})
 	containerHost.ExternalIdentifier = info.ID
+	grip.Info(message.Fields{
+		"message": "created container (after assigning ext. identifier)",
+		"info":    info,
+		"host":    containerHost,
+		"purpose": "dogfooding",
+	})
 	grip.Info(msg)
 
 	return nil

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -374,7 +374,6 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 	containerConf := &container.Config{
 		Cmd:   agentCmdParts,
 		Image: provisionedImage,
-		User:  containerHost.Distro.User,
 	}
 	networkConf := &network.NetworkingConfig{}
 	hostConf := &container.HostConfig{}
@@ -384,19 +383,11 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 	})
 
 	// Build container
-	info, err := dockerClient.ContainerCreate(ctx, containerConf, hostConf, networkConf, containerHost.Id)
-	if err != nil {
+	if _, err := dockerClient.ContainerCreate(ctx, containerConf, hostConf, networkConf, containerHost.Id); err != nil {
 		err = errors.Wrapf(err, "Docker create API call failed for container '%s'", containerHost.Id)
 		grip.Error(err)
 		return err
 	}
-	containerHost.ExternalIdentifier = info.ID
-	grip.Info(message.Fields{
-		"message": "created container",
-		"info":    info,
-		"host":    containerHost,
-		"purpose": "dogfooding",
-	})
 	grip.Info(msg)
 
 	return nil

--- a/cloud/docker_mock.go
+++ b/cloud/docker_mock.go
@@ -102,10 +102,6 @@ func (c *dockerClientMock) GetContainer(context.Context, *host.Host, string) (*t
 }
 
 func (c *dockerClientMock) GetDockerLogs(_ context.Context, containerID string, _ *host.Host, _ types.ContainerLogsOptions) (io.Reader, error) {
-	if containerID == "" { // container not started yet
-		return nil, errors.New("Failed to generate docker client")
-	}
-
 	return bytes.NewBufferString("this is a log message"), nil
 }
 

--- a/command/host_create.go
+++ b/command/host_create.go
@@ -122,6 +122,7 @@ func (c *createHost) waitForLogs(ctx context.Context, comm client.Communicator, 
 			logger.Task().Infof("context finished waiting for host %s to exit", hostID)
 			return nil
 		case <-pollTicker.C:
+			logger.Task().Info("tick -- check for logs")
 			batchEnd := time.Now()
 			status, err := comm.GetDockerStatus(ctx, hostID)
 			if err != nil {

--- a/command/host_create.go
+++ b/command/host_create.go
@@ -122,7 +122,6 @@ func (c *createHost) waitForLogs(ctx context.Context, comm client.Communicator, 
 			logger.Task().Infof("context finished waiting for host %s to exit", hostID)
 			return nil
 		case <-pollTicker.C:
-			logger.Task().Info("tick -- check for logs")
 			batchEnd := time.Now()
 			status, err := comm.GetDockerStatus(ctx, hostID)
 			if err != nil {

--- a/globals.go
+++ b/globals.go
@@ -323,6 +323,14 @@ var (
 		HostDecommissioned,
 	}
 
+	// NotRunningStatus is a list of host statuses from before the host starts running.
+	NotRunningStatus = []string{
+		HostUninitialized,
+		HostBuilding,
+		HostProvisioning,
+		HostStarting,
+	}
+
 	// Hosts in "initializing" status aren't actually running yet:
 	// they're just intents, so this list omits that value.
 	ActiveStatus = []string{

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -567,6 +567,23 @@ func FindOneId(id string) (*Host, error) {
 	return FindOne(ById(id))
 }
 
+func FindOneByIdOrTag(id string) (*Host, error) {
+	query := db.Query(bson.M{
+		TagKey: id,
+	})
+	host, err := FindOne(query) // try to find by tag
+	if err != nil {
+		return nil, err
+	}
+	if host == nil {
+		host, err = FindOneId(id)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return host, nil
+}
+
 // Find gets all Hosts for the given query.
 func Find(query db.Q) ([]Host, error) {
 	hosts := []Host{}

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -576,7 +576,7 @@ func FindOneByIdOrTag(id string) (*Host, error) {
 	})
 	host, err := FindOne(query) // try to find by tag
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error finding '%s' by _id or tag field")
 	}
 	return host, nil
 }

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -567,6 +567,8 @@ func FindOneId(id string) (*Host, error) {
 	return FindOne(ById(id))
 }
 
+// FindOneByIdOrTag finds a host where the given id is stored in either the _id or tag field.
+// (The tag field is used for the id from the host's original intent host.)
 func FindOneByIdOrTag(id string) (*Host, error) {
 	query := db.Query(bson.M{
 		"$or": []bson.M{

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -569,17 +569,14 @@ func FindOneId(id string) (*Host, error) {
 
 func FindOneByIdOrTag(id string) (*Host, error) {
 	query := db.Query(bson.M{
-		TagKey: id,
+		"$or": []bson.M{
+			bson.M{TagKey: id},
+			bson.M{IdKey: id},
+		},
 	})
 	host, err := FindOne(query) // try to find by tag
 	if err != nil {
 		return nil, err
-	}
-	if host == nil {
-		host, err = FindOneId(id)
-		if err != nil {
-			return nil, err
-		}
 	}
 	return host, nil
 }

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -953,9 +953,10 @@ func (h *Host) GetContainers() ([]Host, error) {
 	if !h.HasContainers {
 		return nil, errors.New("Host does not host containers")
 	}
-	query := db.Query(bson.M{
-		ParentIDKey: h.Id,
-	})
+	query := db.Query(bson.M{"$or": []bson.M{
+		{ParentIDKey: h.Id},
+		{ParentIDKey: h.Tag},
+	}})
 	hosts, err := Find(query)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error finding containers")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -30,7 +30,7 @@ type Host struct {
 	Provider string        `bson:"host_type" json:"host_type"`
 	IP       string        `bson:"ip_address" json:"ip_address"`
 
-	// secondary (external) identifier for the host (the containerID for containers)
+	// secondary (external) identifier for the host
 	ExternalIdentifier string `bson:"ext_identifier" json:"ext_identifier"`
 
 	// physical location of host

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -971,21 +971,12 @@ func (h *Host) GetParent() (*Host, error) {
 	if h.ParentID == "" {
 		return nil, errors.New("Host does not have a parent")
 	}
-	query := db.Query(bson.M{
-		TagKey: h.ParentID,
-	})
-	host, err := FindOne(query) // try to find by tag
+	host, err := FindOneByIdOrTag(h.ParentID)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error finding parent")
 	}
 	if host == nil {
-		host, err = FindOneId(h.ParentID)
-		if err != nil {
-			return nil, errors.Wrap(err, "Error finding parent")
-		}
-		if host == nil {
-			return nil, errors.New("Parent not found")
-		}
+		return nil, errors.New("Parent not found")
 	}
 	if !host.HasContainers {
 		return nil, errors.New("Host found is not a parent")

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -3,9 +3,6 @@ package host
 import (
 	"time"
 
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/util"
@@ -116,10 +113,6 @@ func generateParentCreateOptions(pool *evergreen.ContainerPool) CreateOptions {
 
 func InsertParentIntentsAndGetNumHostsToSpawn(pool *evergreen.ContainerPool, newHostsNeeded int, ignoreMaxHosts bool) ([]Host, int, error) {
 	// find all running parents with the specified container pool
-	grip.Info(message.Fields{
-		"containers_needed": newHostsNeeded,
-		"message":           "about to spawn parents",
-	})
 	numNewParentsToSpawn, newHostsNeeded, err := getNumNewParentsAndHostsToSpawn(pool, newHostsNeeded, ignoreMaxHosts)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "error getting number of parents to spawn")

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -89,6 +89,11 @@ func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, host
 			containersToCreate = newContainersNeeded
 		}
 		for i := 0; i < containersToCreate; i++ {
+			grip.Info(message.Fields{
+				"distro":  d.Id,
+				"parent":  parent.ParentHost.Id,
+				"message": "container host intent",
+			})
 			hostOptions.ParentID = parent.ParentHost.Id
 			containerHostIntents = append(containerHostIntents, *NewIntent(d, d.GenerateName(), d.Provider, hostOptions))
 		}

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -74,12 +74,6 @@ func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, host
 		return nil, errors.Wrap(err, "Could not find number of containers on each parent")
 	}
 	containerHostIntents := make([]Host, 0)
-	grip.Info(message.Fields{
-		"distro":           d.Id,
-		"num_parents":      len(parents),
-		"container_needed": newContainersNeeded,
-		"message":          "generating container host intents",
-	})
 	for _, parent := range parents {
 		// find out how many more containers this parent can fit
 		containerSpace := parent.ParentHost.ContainerPoolSettings.MaxContainers - parent.NumContainers
@@ -89,13 +83,6 @@ func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, host
 			containersToCreate = newContainersNeeded
 		}
 		for i := 0; i < containersToCreate; i++ {
-			grip.Info(message.Fields{
-				"distro":  d.Id,
-				"parent":  parent.ParentHost.Id,
-				"purpose": "dogfooding",
-				"message": "container host intent",
-				"image":   hostOptions.DockerOptions.Image,
-			})
 			hostOptions.ParentID = parent.ParentHost.Id
 			containerHostIntents = append(containerHostIntents, *NewIntent(d, d.GenerateName(), d.Provider, hostOptions))
 		}
@@ -150,10 +137,5 @@ func InsertParentIntentsAndGetNumHostsToSpawn(pool *evergreen.ContainerPool, new
 	if err = InsertMany(newParentHosts); err != nil {
 		return nil, 0, errors.Wrap(err, "error inserting new parent hosts")
 	}
-	grip.Info(message.Fields{
-		"new_parents":       len(newParentHosts),
-		"containers_needed": newHostsNeeded,
-		"message":           "generating container host intents",
-	})
 	return newParentHosts, newHostsNeeded, nil
 }

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -92,7 +92,9 @@ func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, host
 			grip.Info(message.Fields{
 				"distro":  d.Id,
 				"parent":  parent.ParentHost.Id,
+				"purpose": "dogfooding",
 				"message": "container host intent",
+				"image":   hostOptions.DockerOptions.Image,
 			})
 			hostOptions.ParentID = parent.ParentHost.Id
 			containerHostIntents = append(containerHostIntents, *NewIntent(d, d.GenerateName(), d.Provider, hostOptions))

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mongodb/grip/message"
@@ -185,8 +187,11 @@ func makeDockerIntentHost(taskID, userID string, createHost apimodels.CreateHost
 	}
 
 	method := distro.DockerImageBuildTypeImport
-	// not a URL
-	if path.Base(createHost.Image) == createHost.Image {
+
+	base := path.Base(createHost.Image)
+	hasPrefix := strings.HasPrefix(base, "http")
+	filepathExt := filepath.Ext(createHost.Image)
+	if filepathExt == "" && !hasPrefix { // not a url
 		method = distro.DockerImageBuildTypePull
 	}
 

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/mongodb/grip/message"
+
 	"github.com/docker/docker/api/types"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -56,7 +58,6 @@ func (dc *DBCreateHostConnector) CreateHostsFromTask(t *task.Task, user user.DBU
 	if t == nil {
 		return errors.New("no task to create hosts from")
 	}
-
 	keyVal, err := user.GetPublicKey(keyNameOrVal)
 	if err != nil {
 		keyVal = keyNameOrVal
@@ -155,6 +156,11 @@ func createHostFromCommand(cmd model.PluginCommandConf) (*apimodels.CreateHost, 
 }
 
 func (dc *DBCreateHostConnector) MakeIntentHost(taskID, userID, publicKey string, createHost apimodels.CreateHost) (*host.Host, error) {
+	grip.Info(message.Fields{
+		"message":  "making intent host",
+		"task":     taskID,
+		"provider": createHost.CloudProvider,
+	})
 	if createHost.CloudProvider == evergreen.ProviderNameDocker {
 		return makeDockerIntentHost(taskID, userID, createHost)
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mongodb/grip/message"
-
 	"github.com/docker/docker/api/types"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -158,11 +156,6 @@ func createHostFromCommand(cmd model.PluginCommandConf) (*apimodels.CreateHost, 
 }
 
 func (dc *DBCreateHostConnector) MakeIntentHost(taskID, userID, publicKey string, createHost apimodels.CreateHost) (*host.Host, error) {
-	grip.Info(message.Fields{
-		"message":  "making intent host",
-		"task":     taskID,
-		"provider": createHost.CloudProvider,
-	})
 	if createHost.CloudProvider == evergreen.ProviderNameDocker {
 		return makeDockerIntentHost(taskID, userID, createHost)
 	}

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -240,7 +240,7 @@ tasks:
   commands:
   - command: host.create
     params:
-      image: my-image
+      image: docker.io/library/hello-world
       distro: distro
       command: echo hi
       provider: docker
@@ -301,7 +301,8 @@ buildvariants:
 	require.Len(createdHosts, 1)
 	h := createdHosts[0]
 	assert.Equal("me", h.StartedBy)
-	assert.Equal("my-image", h.DockerOptions.Image)
+	assert.Equal("docker.io/library/hello-world", h.DockerOptions.Image)
 	assert.Equal("echo hi", h.DockerOptions.Command)
 	assert.Empty("", h.ExternalIdentifier)
+	assert.Equal(distro.DockerImageBuildTypePull, h.DockerOptions.Method)
 }

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -66,9 +66,8 @@ func TestListHostsForTask(t *testing.T) {
 			},
 		},
 		{
-			Id:                 "7",
-			ExternalIdentifier: "container-1234",
-			Status:             evergreen.HostRunning,
+			Id:     "7",
+			Status: evergreen.HostRunning,
 			SpawnOptions: host.SpawnOptions{
 				TaskID: "task_1",
 			},
@@ -86,7 +85,6 @@ func TestListHostsForTask(t *testing.T) {
 	require.Len(found, 3)
 	assert.Equal("4.com", found[0].Host)
 	assert.Equal("1.com", found[1].Host)
-	assert.Equal("container-1234", found[2].ExternalIdentifier)
 	assert.Equal("abcd:1234:459c:2d00:cfe4:843b:1d60:8e47", found[1].IP)
 }
 
@@ -303,6 +301,5 @@ buildvariants:
 	assert.Equal("me", h.StartedBy)
 	assert.Equal("docker.io/library/hello-world", h.DockerOptions.Image)
 	assert.Equal("echo hi", h.DockerOptions.Command)
-	assert.Empty("", h.ExternalIdentifier)
 	assert.Equal(distro.DockerImageBuildTypePull, h.DockerOptions.Method)
 }

--- a/rest/model/createhost.go
+++ b/rest/model/createhost.go
@@ -2,8 +2,6 @@ package model
 
 import (
 	"github.com/evergreen-ci/evergreen/model/host"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -23,12 +21,6 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case host.Host:
 		// container
-		grip.Info(message.Fields{
-			"message":   "created container (in host.Host)",
-			"host":      v,
-			"purpose":   "dogfooding",
-			"operation": "host.list",
-		})
 		if v.ParentID != "" {
 			createHost.HostID = v.Id
 			createHost.ContainerID = v.ExternalIdentifier
@@ -42,12 +34,6 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 		createHost.IP = v.IP
 		createHost.InstanceID = v.ExternalIdentifier
 	case *host.Host:
-		grip.Info(message.Fields{
-			"message":   "created container (in *host.Host)",
-			"host":      v,
-			"purpose":   "dogfooding",
-			"operation": "host.list",
-		})
 		// container
 		if v.ParentID != "" {
 			createHost.HostID = v.Id

--- a/rest/model/createhost.go
+++ b/rest/model/createhost.go
@@ -2,26 +2,33 @@ package model
 
 import (
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
 type CreateHost struct {
-	DNSName    string `json:"dns_name"`
-	IP         string `json:"ip_address"`
-	InstanceID string `json:"instance_id"`
+	DNSName    string `json:"dns_name,omitempty"`
+	IP         string `json:"ip_address,omitempty"`
+	InstanceID string `json:"instance_id,omitempty"`
 
-	HostID      string `json:"host_id"`
-	ContainerID string `json:"container_id"`
-	ParentID    string `json:"parent_id"`
-	Image       string `json:"image"`
-	Command     string `json:"command"`
-	Port        int    `json:"port"`
+	HostID      string `json:"host_id,omitempty"`
+	ContainerID string `json:"container_id,omitempty"`
+	ParentID    string `json:"parent_id,omitempty"`
+	Image       string `json:"image,omitempty"`
+	Command     string `json:"command,omitempty"`
 }
 
 func (createHost *CreateHost) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case host.Host:
 		// container
+		grip.Info(message.Fields{
+			"message":   "created container (in host.Host)",
+			"host":      v,
+			"purpose":   "dogfooding",
+			"operation": "host.list",
+		})
 		if v.ParentID != "" {
 			createHost.HostID = v.Id
 			createHost.ContainerID = v.ExternalIdentifier
@@ -35,6 +42,12 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 		createHost.IP = v.IP
 		createHost.InstanceID = v.ExternalIdentifier
 	case *host.Host:
+		grip.Info(message.Fields{
+			"message":   "created container (in *host.Host)",
+			"host":      v,
+			"purpose":   "dogfooding",
+			"operation": "host.list",
+		})
 		// container
 		if v.ParentID != "" {
 			createHost.HostID = v.Id

--- a/rest/model/createhost.go
+++ b/rest/model/createhost.go
@@ -10,11 +10,10 @@ type CreateHost struct {
 	IP         string `json:"ip_address,omitempty"`
 	InstanceID string `json:"instance_id,omitempty"`
 
-	HostID      string `json:"host_id,omitempty"`
-	ContainerID string `json:"container_id,omitempty"`
-	ParentID    string `json:"parent_id,omitempty"`
-	Image       string `json:"image,omitempty"`
-	Command     string `json:"command,omitempty"`
+	HostID   string `json:"host_id,omitempty"`
+	ParentID string `json:"parent_id,omitempty"`
+	Image    string `json:"image,omitempty"`
+	Command  string `json:"command,omitempty"`
 }
 
 func (createHost *CreateHost) BuildFromService(h interface{}) error {
@@ -23,7 +22,6 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 		// container
 		if v.ParentID != "" {
 			createHost.HostID = v.Id
-			createHost.ContainerID = v.ExternalIdentifier
 			createHost.ParentID = v.ParentID
 			createHost.Image = v.DockerOptions.Image
 			createHost.Command = v.DockerOptions.Command
@@ -37,7 +35,6 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 		// container
 		if v.ParentID != "" {
 			createHost.HostID = v.Id
-			createHost.ContainerID = v.ExternalIdentifier
 			createHost.ParentID = v.ParentID
 			createHost.Image = v.DockerOptions.Image
 			createHost.Command = v.DockerOptions.Command

--- a/rest/model/createhost.go
+++ b/rest/model/createhost.go
@@ -6,14 +6,14 @@ import (
 )
 
 type CreateHost struct {
-	DNSName    string `json:"dns_name,omitempty"`
-	IP         string `json:"ip_address,omitempty"`
-	InstanceID string `json:"instance_id,omitempty"`
+	DNSName    APIString `json:"dns_name"`
+	IP         APIString `json:"ip_address"`
+	InstanceID APIString `json:"instance_id"`
 
-	HostID   string `json:"host_id,omitempty"`
-	ParentID string `json:"parent_id,omitempty"`
-	Image    string `json:"image,omitempty"`
-	Command  string `json:"command,omitempty"`
+	HostID   APIString `json:"host_id"`
+	ParentID APIString `json:"parent_id"`
+	Image    APIString `json:"image"`
+	Command  APIString `json:"command"`
 }
 
 func (createHost *CreateHost) BuildFromService(h interface{}) error {
@@ -21,29 +21,29 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 	case host.Host:
 		// container
 		if v.ParentID != "" {
-			createHost.HostID = v.Id
-			createHost.ParentID = v.ParentID
-			createHost.Image = v.DockerOptions.Image
-			createHost.Command = v.DockerOptions.Command
+			createHost.HostID = ToAPIString(v.Id)
+			createHost.ParentID = ToAPIString(v.ParentID)
+			createHost.Image = ToAPIString(v.DockerOptions.Image)
+			createHost.Command = ToAPIString(v.DockerOptions.Command)
 			return nil
 		}
-		createHost.DNSName = v.Host
-		createHost.InstanceID = v.Id
-		createHost.IP = v.IP
-		createHost.InstanceID = v.ExternalIdentifier
+		createHost.DNSName = ToAPIString(v.Host)
+		createHost.InstanceID = ToAPIString(v.Id)
+		createHost.IP = ToAPIString(v.IP)
+		createHost.InstanceID = ToAPIString(v.ExternalIdentifier)
 	case *host.Host:
 		// container
 		if v.ParentID != "" {
-			createHost.HostID = v.Id
-			createHost.ParentID = v.ParentID
-			createHost.Image = v.DockerOptions.Image
-			createHost.Command = v.DockerOptions.Command
+			createHost.HostID = ToAPIString(v.Id)
+			createHost.ParentID = ToAPIString(v.ParentID)
+			createHost.Image = ToAPIString(v.DockerOptions.Image)
+			createHost.Command = ToAPIString(v.DockerOptions.Command)
 			return nil
 		}
-		createHost.DNSName = v.Host
-		createHost.InstanceID = v.Id
-		createHost.IP = v.IP
-		createHost.InstanceID = v.ExternalIdentifier
+		createHost.DNSName = ToAPIString(v.Host)
+		createHost.InstanceID = ToAPIString(v.Id)
+		createHost.IP = ToAPIString(v.IP)
+		createHost.InstanceID = ToAPIString(v.ExternalIdentifier)
 	default:
 		return errors.Errorf("Invalid type passed to *CreateHost.BuildFromService (%T)", h)
 	}

--- a/rest/model/createhost_test.go
+++ b/rest/model/createhost_test.go
@@ -17,9 +17,9 @@ func TestCreateHostBuildFromService(t *testing.T) {
 	c := &CreateHost{}
 	err := c.BuildFromService(h)
 	assert.NoError(err)
-	assert.Equal(c.DNSName, h.Host)
-	assert.Equal(c.InstanceID, h.ExternalIdentifier)
-	assert.Equal(c.IP, h.IP)
+	assert.Equal(FromAPIString(c.DNSName), h.Host)
+	assert.Equal(FromAPIString(c.InstanceID), h.ExternalIdentifier)
+	assert.Equal(FromAPIString(c.IP), h.IP)
 }
 
 func TestCreateHostBuildFromServiceWithContainer(t *testing.T) {
@@ -35,10 +35,10 @@ func TestCreateHostBuildFromServiceWithContainer(t *testing.T) {
 	c := &CreateHost{}
 	err := c.BuildFromService(h)
 	assert.NoError(err)
-	assert.Equal(c.Image, h.DockerOptions.Image)
-	assert.Equal(c.Command, h.DockerOptions.Command)
-	assert.Equal(c.ParentID, h.ParentID)
+	assert.Equal(FromAPIString(c.Image), h.DockerOptions.Image)
+	assert.Equal(FromAPIString(c.Command), h.DockerOptions.Command)
+	assert.Equal(FromAPIString(c.ParentID), h.ParentID)
 
-	assert.Empty(c.DNSName)
-	assert.Empty(c.InstanceID)
+	assert.Nil(c.DNSName)
+	assert.Nil(c.InstanceID)
 }

--- a/rest/model/createhost_test.go
+++ b/rest/model/createhost_test.go
@@ -25,9 +25,8 @@ func TestCreateHostBuildFromService(t *testing.T) {
 func TestCreateHostBuildFromServiceWithContainer(t *testing.T) {
 	assert := assert.New(t)
 	h := host.Host{
-		Id:                 "i-1234",
-		ExternalIdentifier: "container-1234",
-		ParentID:           "i-5678",
+		Id:       "i-1234",
+		ParentID: "i-5678",
 		DockerOptions: host.DockerOptions{
 			Image:   "my-image",
 			Command: "echo hi",
@@ -38,7 +37,6 @@ func TestCreateHostBuildFromServiceWithContainer(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(c.Image, h.DockerOptions.Image)
 	assert.Equal(c.Command, h.DockerOptions.Command)
-	assert.Equal(c.ContainerID, h.ExternalIdentifier)
 	assert.Equal(c.ParentID, h.ParentID)
 
 	assert.Empty(c.DNSName)

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -82,9 +82,6 @@ func (h *hostCreateHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.NewJSONErrorResponse(errors.Wrap(err, "error getting settings config"))
 		}
 
-		if distro.ContainerPool == "" {
-			return gimlet.NewJSONErrorResponse(errors.New("provided distro has no container pool"))
-		}
 		containerPool := settings.ContainerPools.GetContainerPool(distro.ContainerPool)
 		if containerPool == nil {
 			return gimlet.NewJSONErrorResponse(errors.Errorf("container pool '%s' not found", distro.ContainerPool))

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -82,6 +82,9 @@ func (h *hostCreateHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.NewJSONErrorResponse(errors.Wrap(err, "error getting settings config"))
 		}
 
+		if distro.ContainerPool == "" {
+			return gimlet.NewJSONErrorResponse(errors.New("provided distro has no container pool"))
+		}
 		containerPool := settings.ContainerPools.GetContainerPool(distro.ContainerPool)
 		if containerPool == nil {
 			return gimlet.NewJSONErrorResponse(errors.Errorf("container pool '%s' not found", distro.ContainerPool))

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -18,7 +18,6 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -151,11 +150,6 @@ func (h *hostListHandler) Run(ctx context.Context) gimlet.Responder {
 	catcher := grip.NewBasicCatcher()
 	results := make([]model.Model, len(hosts))
 	for i := range hosts {
-		grip.Info(message.Fields{
-			"host":      hosts[i],
-			"purpose":   "dogfooding",
-			"operation": "host.list",
-		})
 		createHost := model.CreateHost{}
 		if err := createHost.BuildFromService(&hosts[i]); err != nil {
 			catcher.Add(errors.Wrap(err, "error building api host from service"))
@@ -265,7 +259,7 @@ func (h *containerLogsHandler) Run(ctx context.Context) gimlet.Responder {
 	} else {
 		options.ShowStdout = true
 	}
-	logs, err := h.sc.GetDockerLogs(ctx, h.host.ExternalIdentifier, parent, settings, options)
+	logs, err := h.sc.GetDockerLogs(ctx, h.host.Id, parent, settings, options)
 	if err != nil {
 		return gimlet.NewJSONErrorResponse(errors.Wrap(err, "error getting docker logs"))
 	}
@@ -319,7 +313,7 @@ func (h *containerStatusHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.NewJSONErrorResponse(errors.Wrap(err, "error getting settings config"))
 	}
-	status, err := h.sc.GetDockerStatus(ctx, h.host.ExternalIdentifier, parent, settings)
+	status, err := h.sc.GetDockerStatus(ctx, h.host.Id, parent, settings)
 	if err != nil {
 		return gimlet.NewJSONErrorResponse(errors.Wrap(err, "error getting docker status"))
 	}

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -150,6 +151,11 @@ func (h *hostListHandler) Run(ctx context.Context) gimlet.Responder {
 	catcher := grip.NewBasicCatcher()
 	results := make([]model.Model, len(hosts))
 	for i := range hosts {
+		grip.Info(message.Fields{
+			"host":      hosts[i],
+			"purpose":   "dogfooding",
+			"operation": "host.list",
+		})
 		createHost := model.CreateHost{}
 		if err := createHost.BuildFromService(&hosts[i]); err != nil {
 			catcher.Add(errors.Wrap(err, "error building api host from service"))

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -273,7 +273,6 @@ func TestGetDockerLogs(t *testing.T) {
 	}
 	h, err := handler.sc.MakeIntentHost("task-id", "", "", c)
 	assert.NotEmpty(h.ParentID)
-	h.ExternalIdentifier = "my-container"
 	require.NoError(err)
 	require.NoError(h.Insert())
 
@@ -431,7 +430,6 @@ func TestGetDockerStatus(t *testing.T) {
 	}
 	h, err := handler.sc.MakeIntentHost("task-id", "", "", c)
 	assert.NotEmpty(h.ParentID)
-	h.ExternalIdentifier = "my-container"
 	require.NoError(err)
 	require.NoError(h.Insert())
 

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -332,64 +332,6 @@ func TestGetDockerLogs(t *testing.T) {
 
 }
 
-func TestGetDockerLogsError(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	require.NoError(db.ClearCollections(distro.Collection, host.Collection, task.Collection))
-	handler := containerLogsHandler{
-		sc: &data.MockConnector{},
-	}
-	parent := distro.Distro{Id: "parent-distro", PoolSize: 3, Provider: evergreen.ProviderNameMock}
-	require.NoError(parent.Insert())
-
-	pool := &evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 2}
-	parentHost := &host.Host{
-		Id:                    "host1",
-		Host:                  "host",
-		User:                  "user",
-		Distro:                distro.Distro{Id: "parent-distro"},
-		Status:                evergreen.HostRunning,
-		HasContainers:         true,
-		ContainerPoolSettings: pool,
-	}
-	require.NoError(parentHost.Insert())
-
-	d := distro.Distro{Id: "distro", Provider: evergreen.ProviderNameMock, ContainerPool: "test-pool"}
-	require.NoError(d.Insert())
-
-	myTask := task.Task{
-		Id:      "task-id",
-		BuildId: "build-id",
-	}
-	require.NoError(myTask.Insert())
-	c := apimodels.CreateHost{
-		CloudProvider: apimodels.ProviderDocker,
-		NumHosts:      "1",
-		Distro:        "distro",
-		Image:         "my-image",
-		Command:       "echo hello",
-	}
-	h, err := handler.sc.MakeIntentHost("task-id", "", "", c)
-	assert.NotEmpty(h.ParentID)
-	require.NoError(err)
-	require.NoError(h.Insert())
-
-	url := fmt.Sprintf("/hosts/%s/logs/output", h.Id)
-
-	request, err := http.NewRequest("GET", url, bytes.NewReader(nil))
-	assert.NoError(err)
-
-	options := map[string]string{"host_id": h.Id}
-	request = gimlet.SetURLVars(request, options)
-
-	assert.NoError(handler.Parse(context.Background(), request))
-	assert.Equal(h.Id, handler.host.Id)
-
-	res := handler.Run(context.Background())
-	require.NotNil(res)
-	assert.Equal(http.StatusBadRequest, res.Status())
-}
-
 func TestGetDockerStatus(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/service/host.go
+++ b/service/host.go
@@ -44,7 +44,7 @@ type uiParams struct {
 func (uis *UIServer) hostPage(w http.ResponseWriter, r *http.Request) {
 	id := gimlet.GetVars(r)["host_id"]
 
-	h, err := host.FindOne(host.ById(id))
+	h, err := host.FindOneByIdOrTag(id)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/units/building_container_image.go
+++ b/units/building_container_image.go
@@ -134,6 +134,13 @@ func (j *buildingContainerImageJob) Run(ctx context.Context) {
 
 	err = containerMgr.GetContainerImage(ctx, j.parent, j.DockerOptions)
 	if err != nil {
+		grip.Info(message.Fields{
+			"message":   "error getting container image",
+			"operation": "image",
+			"job":       j.ID(),
+			"image":     j.DockerOptions.Image,
+			"error":     err.Error(),
+		})
 		j.AddError(errors.Wrap(err, "error building and downloading container image"))
 		return
 	}
@@ -141,6 +148,12 @@ func (j *buildingContainerImageJob) Run(ctx context.Context) {
 		j.parent.ContainerImages = make(map[string]bool)
 	}
 	j.parent.ContainerImages[j.DockerOptions.Image] = true
+	grip.Info(message.Fields{
+		"message":   "setting image in parent",
+		"operation": "image",
+		"job":       j.ID(),
+		"image":     j.DockerOptions.Image,
+	})
 	_, err = j.parent.Upsert()
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "error upserting parent %s", j.parent.Id))

--- a/units/building_container_image.go
+++ b/units/building_container_image.go
@@ -80,6 +80,9 @@ func (j *buildingContainerImageJob) Run(ctx context.Context) {
 	if j.parent == nil {
 		j.parent, err = host.FindOneByIdOrTag(j.ParentID)
 		j.AddError(err)
+		if j.parent == nil {
+			j.AddError(errors.Errorf("parent %s not found", j.ParentID))
+		}
 	}
 	if j.env == nil {
 		j.env = evergreen.GetEnvironment()

--- a/units/crons.go
+++ b/units/crons.go
@@ -627,7 +627,7 @@ func PopulateHostCreationJobs(env evergreen.Environment, part int) amboy.QueueOp
 				break
 			}
 
-			catcher.Add(queue.Put(NewHostCreateJob(env, h, ts, 1, 0)))
+			catcher.Add(queue.Put(NewHostCreateJob(env, h, ts, 1, 0, false)))
 		}
 
 		return catcher.Resolve()

--- a/units/host_monitoring_container_state.go
+++ b/units/host_monitoring_container_state.go
@@ -70,6 +70,9 @@ func (j *hostMonitorContainerStateJob) Run(ctx context.Context) {
 	if j.host == nil {
 		j.host, err = host.FindOneId(j.HostID)
 		j.AddError(err)
+		if j.host == nil {
+			j.AddError(errors.Errorf("unable to retrieve host %s", j.HostID))
+		}
 	}
 	if j.env == nil {
 		j.env = evergreen.GetEnvironment()

--- a/units/host_monitoring_container_state.go
+++ b/units/host_monitoring_container_state.go
@@ -119,7 +119,7 @@ func (j *hostMonitorContainerStateJob) Run(ctx context.Context) {
 	// Docker, remove container from Docker and mark it as terminated
 	for _, container := range containersFromDB {
 		if container.Status == evergreen.HostRunning || container.Status == evergreen.HostDecommissioned {
-			if !isRunningInDocker[container.Id] {
+			if !isRunningInDocker[container.Id] && !container.SpawnOptions.SpawnedByTask {
 				if err := containerMgr.TerminateInstance(ctx, &container, evergreen.User); err != nil {
 					j.AddError(errors.Wrap(err, "error terminating instance on Docker"))
 					j.AddError(container.SetTerminated(evergreen.User))

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -82,6 +82,9 @@ func (j *hostMonitorExternalStateCheckJob) Run(ctx context.Context) {
 		if err != nil {
 			j.AddError(err)
 			return
+		} else if j.host == nil {
+			j.AddError(errors.Errorf("unable to retrieve host %s", j.HostID))
+			return
 		}
 	}
 

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -76,6 +76,9 @@ func (j *idleHostJob) Run(ctx context.Context) {
 		j.AddError(err)
 		if err != nil {
 			return
+		} else if j.host == nil {
+			j.AddError(errors.Errorf("unable to retrieve host %s", j.HostID))
+			return
 		}
 	}
 	if j.env == nil {

--- a/units/host_monitoring_last_container_finish_time.go
+++ b/units/host_monitoring_last_container_finish_time.go
@@ -56,9 +56,11 @@ func (j *lastContainerFinishTimeJob) Run(ctx context.Context) {
 
 	// update last container finish time for each host with containers
 	for _, time := range times {
-		h, err := host.FindOneId(time.Id)
+		h, err := host.FindOneByIdOrTag(time.Id)
 		if err != nil {
 			j.AddError(err)
+			continue
+		} else if h == nil {
 			continue
 		}
 		j.AddError(h.UpdateLastContainerFinishTime(time.FinishTime))

--- a/units/oldest_image_removal.go
+++ b/units/oldest_image_removal.go
@@ -70,6 +70,9 @@ func (j *oldestImageRemovalJob) Run(ctx context.Context) {
 	if j.host == nil {
 		j.host, err = host.FindOneId(j.HostID)
 		j.AddError(err)
+		if j.host == nil {
+			j.AddError(errors.Errorf("unable to retrieve host %s", j.HostID))
+		}
 	}
 	if j.env == nil {
 		j.env = evergreen.GetEnvironment()

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -156,8 +156,19 @@ func (j *createHostJob) Run(ctx context.Context) {
 			MaxTime: j.host.SpawnOptions.TimeoutSetup.Sub(j.start),
 		})
 	}
-
-	j.AddError(j.createHost(ctx))
+	err = j.createHost(ctx)
+	j.AddError(err)
+	if err != nil {
+		grip.Info(message.Fields{
+			"host_id":  j.HostID,
+			"attempt":  j.CurrentAttempt,
+			"distro":   j.host.Distro,
+			"error":    err.Error(),
+			"job":      j.ID(),
+			"provider": j.host.Provider,
+			"message":  "error provisioning host",
+		})
+	}
 }
 
 func (j *createHostJob) createHost(ctx context.Context) error {

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -98,7 +98,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 	}
 
 	if j.host == nil {
-		j.host, err = host.FindOneId(j.HostID)
+		j.host, err = host.FindOneByIdOrTag(j.HostID)
 		if err != nil {
 			j.AddError(err)
 			return

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -222,7 +222,12 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 			return nil
 		}
 	}
-
+	grip.Info(message.Fields{
+		"message": "image is ready",
+		"job":     j.ID(),
+		"host":    j.HostID,
+		"image":   j.host.DockerOptions.Image,
+	})
 	if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {
 		return errors.Wrapf(err, "error spawning host %s", j.host.Id)
 	}
@@ -306,14 +311,7 @@ func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 		return false, errors.Wrapf(err, "problem getting parent for '%s'", j.host.Id)
 	}
 	if parent == nil {
-		grip.Error(message.Fields{
-			"error":     err.Error(),
-			"message":   "parent is empty",
-			"host":      j.host.Id,
-			"parent":    j.host.ParentID,
-			"operation": "spawning new parents",
-		})
-		return false, errors.Wrapf(err, "problem getting parent for '%s'", j.host.Id)
+		return false, errors.Wrapf(err, "parent for '%s' does not exist", j.host.Id)
 	}
 
 	if parent.Status == evergreen.HostUninitialized || parent.Status == evergreen.HostBuilding {

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -208,13 +208,6 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	// SpawnHost returns, but NOT as as initializing hosts that could still be
 	// spawned by Evergreen.
 	if err = j.host.SetStatus(evergreen.HostBuilding, evergreen.User, ""); err != nil {
-		grip.Info(message.Fields{
-			"message": "error setting status",
-			"purpose": "dogfooding",
-			"hostid":  j.host.Id,
-			"job":     j.ID(),
-			"error":   err.Error(),
-		})
 		return errors.Wrapf(err, "problem setting host %s status to building", j.host.Id)
 	}
 
@@ -226,26 +219,11 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		j.MaxAttempts = maxPollAttempts
 		ready, err = j.isImageBuilt(ctx)
 		if err != nil {
-			grip.Info(message.Fields{
-				"message": "error building image",
-				"purpose": "dogfooding",
-				"job":     j.ID(),
-				"host":    j.HostID,
-				"image":   j.host.DockerOptions.Image,
-				"error":   err.Error(),
-			})
 			return errors.Wrap(err, "problem building container image")
 		}
 		if !ready {
 			return nil
 		}
-		grip.Info(message.Fields{
-			"message": "image is ready",
-			"purpose": "dogfooding",
-			"job":     j.ID(),
-			"host":    j.HostID,
-			"image":   j.host.DockerOptions.Image,
-		})
 	}
 
 	if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -215,14 +215,6 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	}
 
 	if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {
-		grip.Info(message.Fields{
-			"message": "error spawning host",
-			"purpose": "dogfooding",
-			"job":     j.ID(),
-			"host":    j.HostID,
-			"image":   j.host.DockerOptions.Image,
-			"error":   err.Error(),
-		})
 		return errors.Wrapf(err, "error spawning host %s", j.host.Id)
 	}
 
@@ -305,13 +297,6 @@ func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 		return false, errors.Wrapf(err, "problem getting parent for '%s'", j.host.Id)
 	}
 	if parent == nil {
-		grip.Info(message.Fields{
-			"message": "parent doesn't exist yet",
-			"purpose": "dogfooding",
-			"host":    j.host.Id,
-			"job":     j.ID(),
-			"image":   j.host.DockerOptions.Image,
-		})
 		return false, errors.Wrapf(err, "parent for '%s' does not exist", j.host.Id)
 	}
 
@@ -324,12 +309,6 @@ func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 
 	//  If the image is not already present on the parent, run job to build the new image
 	if j.BuildImageStarted == false {
-		grip.Info(message.Fields{
-			"message": "creating container image job",
-			"purpose": "dogfooding",
-			"host":    j.host.Id,
-			"job":     j.ID(),
-		})
 		j.BuildImageStarted = true
 		buildingContainerJob := NewBuildingContainerImageJob(j.env, parent, j.host.DockerOptions, j.host.Provider)
 		err = j.env.RemoteQueue().Put(buildingContainerJob)

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -318,6 +318,13 @@ func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 		return false, errors.Errorf("parent for host '%s' not running", j.host.Id)
 	}
 	if ok := parent.ContainerImages[j.host.DockerOptions.Image]; ok {
+		grip.Info(message.Fields{
+			"message": "found image in parent",
+			"host":    j.host.Id,
+			"job":     j.ID(),
+			"distro":  j.host.Distro.Id,
+			"image":   j.host.DockerOptions.Image,
+		})
 		return true, nil
 	}
 

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -160,18 +160,6 @@ func (j *createHostJob) Run(ctx context.Context) {
 	}
 	err = j.createHost(ctx)
 	j.AddError(err)
-	if err != nil {
-		grip.Info(message.Fields{
-			"host_id":   j.HostID,
-			"parent_id": j.host.ParentID,
-			"attempt":   j.CurrentAttempt,
-			"distro":    j.host.Distro,
-			"error":     err.Error(),
-			"job":       j.ID(),
-			"provider":  j.host.Provider,
-			"message":   "error provisioning host",
-		})
-	}
 }
 
 func (j *createHostJob) createHost(ctx context.Context) error {
@@ -331,13 +319,6 @@ func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 		return false, errors.Errorf("parent for host '%s' not running", j.host.Id)
 	}
 	if ok := parent.ContainerImages[j.host.DockerOptions.Image]; ok {
-		grip.Info(message.Fields{
-			"message": "found image in parent",
-			"purpose": "dogfooding",
-			"host":    j.host.Id,
-			"job":     j.ID(),
-			"image":   j.host.DockerOptions.Image,
-		})
 		return true, nil
 	}
 

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -159,8 +159,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 			MaxTime: j.host.SpawnOptions.TimeoutSetup.Sub(j.start),
 		})
 	}
-	err = j.createHost(ctx)
-	j.AddError(err)
+	j.AddError(j.createHost(ctx))
 }
 
 func (j *createHostJob) createHost(ctx context.Context) error {

--- a/units/stats_host_idle.go
+++ b/units/stats_host_idle.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -94,6 +96,9 @@ func (j *collectHostIdleDataJob) Run(ctx context.Context) {
 	if j.host == nil {
 		j.host, err = host.FindOneId(j.HostID)
 		j.AddError(err)
+		if j.host == nil {
+			j.AddError(errors.Errorf("unable to retrieve host %s", j.HostID))
+		}
 	}
 
 	if j.task == nil && j.TaskID != "" {

--- a/units/stats_host_idle.go
+++ b/units/stats_host_idle.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -19,6 +17,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
 )
 
 const collectHostIdleDataJobName = "collect-host-idle-data"


### PR DESCRIPTION
Work in progress--couple small details left to work out/test. This is an overview of the logic changes made, if anyone would like to code review this draft:
* parentID stored in host intent will not persist 
* Container pool validated in the wrong spot
* NewBuildingContainerJob wasn’t getting hit, because was relying on CurrentAttempts, and should retry
* Change method of determining import or pull
* External Identifier not necessary