### PR TITLE
EVG-6081: default to legacy SSH if not specified in UI server

### DIFF
--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -169,6 +169,9 @@ func (apiDistro *APIDistro) ToService() (interface{}, error) {
 	d.Teardown = FromAPIString(apiDistro.Teardown)
 	d.User = FromAPIString(apiDistro.User)
 	d.BootstrapMethod = FromAPIString(apiDistro.BootstrapMethod)
+	if d.BootstrapMethod == "" {
+		d.BootstrapMethod = distro.BootstrapMethodLegacySSH
+	}
 	d.SSHKey = FromAPIString(apiDistro.SSHKey)
 	d.SSHOptions = apiDistro.SSHOptions
 	d.SpawnAllowed = apiDistro.UserSpawnAllowed

--- a/service/distros.go
+++ b/service/distros.go
@@ -81,14 +81,18 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newDistro := oldDistro
-
 	// attempt to unmarshal data into distros field for type validation
 	if err = json.Unmarshal(b, &newDistro); err != nil {
 		message := fmt.Sprintf("error unmarshaling request: %v", err)
 		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
 		http.Error(w, message, http.StatusBadRequest)
 		return
+	}
+
+	newDistro := oldDistro
+
+	if newDistro.BootstrapMethod == "" {
+		newDistro.BootstrapMethod = distro.BootstrapMethodLegacySSH
 	}
 
 	// check that the resulting distro is valid

--- a/service/distros.go
+++ b/service/distros.go
@@ -81,6 +81,8 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	newDistro := oldDistro
+
 	// attempt to unmarshal data into distros field for type validation
 	if err = json.Unmarshal(b, &newDistro); err != nil {
 		message := fmt.Sprintf("error unmarshaling request: %v", err)
@@ -88,8 +90,6 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusBadRequest)
 		return
 	}
-
-	newDistro := oldDistro
 
 	if newDistro.BootstrapMethod == "" {
 		newDistro.BootstrapMethod = distro.BootstrapMethodLegacySSH


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6081

I assumed that only the UI page would use the `(*UIServer).modifyDistro()` method (`POST /distros/{distro_id}`), but apparently build uses it to update their AMIs as well.