### PR TITLE
EVG-6021 fix display tasks appearing yellow when blocked on themselves

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -689,7 +689,7 @@ func FindOneOldNoMerge(query db.Q) (*Task, error) {
 // FindOneOldNoMergeByIdAndExecution finds a task from the old tasks collection without test results.
 func FindOneOldNoMergeByIdAndExecution(id string, execution int) (*Task, error) {
 	query := db.Query(bson.M{
-		IdKey:        id,
+		OldTaskIdKey: id,
 		ExecutionKey: execution,
 	})
 	return FindOneOldNoMerge(query)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1530,9 +1530,7 @@ func (t *Task) BlockedState(tasksWithDeps []Task) (string, error) {
 	if t.DisplayOnly {
 		return t.blockedStateForDisplayTask(tasksWithDeps)
 	}
-	if len(t.DependsOn) == 0 {
-		return "", nil
-	}
+
 	return t.blockedStatePrivate()
 }
 
@@ -1600,6 +1598,16 @@ func (t *Task) blockedStateForDisplayTask(tasksWithDeps []Task) (string, error) 
 		}
 	}
 	return state, nil
+}
+func (t *Task) IsBlockedStateForExecTask(tasksWithDeps []Task) (bool, error) {
+	etState, err := t.BlockedState(tasksWithDeps)
+	if err != nil {
+		return false, errors.Wrap(err, "error finding blocked state")
+	}
+	if etState == taskBlocked {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (t *Task) CircularDependencies() error {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1599,7 +1599,7 @@ func (t *Task) blockedStateForDisplayTask(tasksWithDeps []Task) (string, error) 
 	}
 	return state, nil
 }
-func (t *Task) IsBlockedStateForExecTask(tasksWithDeps []Task) (bool, error) {
+func (t *Task) IsBlocked(tasksWithDeps []Task) (bool, error) {
 	etState, err := t.BlockedState(tasksWithDeps)
 	if err != nil {
 		return false, errors.Wrap(err, "error finding blocked state")

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -960,6 +960,35 @@ func TestBlockedState(t *testing.T) {
 	assert.Equal("blocked", state)
 }
 
+func TestBlockedStateForExecTasks(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(Collection))
+	task1 := Task{
+		Id:             "task1",
+		Activated:      true,
+		Status:         evergreen.TaskStarted,
+		ExecutionTasks: []string{"exec0", "exec1"},
+	}
+	assert.NoError(task1.Insert())
+	task2 := Task{
+		Id:        "exec0",
+		Status:    evergreen.TaskFailed,
+		TimeTaken: 2 * time.Minute,
+	}
+	assert.NoError(task2.Insert())
+	task3 := Task{
+		Id: "exec1",
+		DependsOn: []Dependency{
+			{TaskId: "exec0", Status: evergreen.TaskSucceeded},
+		},
+		Status: evergreen.TaskUndispatched,
+	}
+	assert.NoError(task3.Insert())
+	isBlocked, err := task3.IsBlockedStateForExecTask(nil)
+	assert.NoError(err)
+	assert.True(isBlocked)
+}
+
 func TestCircularDependency(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -979,6 +979,13 @@ func TestTaskIsBlocked(t *testing.T) {
 	isBlocked, err := task2.IsBlocked(nil)
 	assert.NoError(err)
 	assert.True(isBlocked)
+
+	assert.NoError(UpdateOne(
+		bson.M{IdKey: task1.Id},
+		bson.M{"$set": bson.M{StatusKey: evergreen.TaskSucceeded}}))
+	isBlocked, err = task2.IsBlocked(nil)
+	assert.NoError(err)
+	assert.False(isBlocked)
 }
 
 func TestTaskIsBlockedOnOutsideTask(t *testing.T) {
@@ -1001,6 +1008,13 @@ func TestTaskIsBlockedOnOutsideTask(t *testing.T) {
 	isBlocked, err := task1.IsBlocked(nil)
 	assert.NoError(err)
 	assert.True(isBlocked)
+
+	assert.NoError(UpdateOne(
+		bson.M{IdKey: task2.Id},
+		bson.M{"$set": bson.M{StatusKey: evergreen.TaskSucceeded}}))
+	isBlocked, err = task1.IsBlocked(nil)
+	assert.NoError(err)
+	assert.False(isBlocked)
 }
 
 func TestCircularDependency(t *testing.T) {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1014,7 +1014,8 @@ func UpdateDisplayTask(t *task.Task) error {
 			isBlocked, err = execTask.IsBlocked(tasksWithDeps)
 			if err != nil {
 				return errors.Wrap(err, "error determining if state blocked for execution task")
-			} else if isBlocked {
+			}
+			if isBlocked {
 				blockedTasks++
 			}
 		}
@@ -1032,6 +1033,16 @@ func UpdateDisplayTask(t *task.Task) error {
 			endTime = execTask.FinishTime
 		}
 	}
+
+	grip.Debug(message.Fields{
+		"message":            "updating display task",
+		"task_id":            t.Id,
+		"has_finished_tasks": hasFinishedTasks,
+		"has_failed_tasks":   hasFailedTasks,
+		"blocked_tasks":      blockedTasks,
+		"unfinished_tasks":   unfinishedTasks,
+		"num_exec_tasks":     len(execTasks),
+	})
 
 	if hasFailedTasks && (unfinishedTasks == blockedTasks) && len(statuses) > 0 {
 		// if display task has a failed task and all unfinished tasks are blocked, update status

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -609,10 +609,10 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 			return errors.WithStack(err)
 		}
 		if displayTask != nil {
-			if err := UpdateDisplayTask(displayTask); err != nil {
+			if err = UpdateDisplayTask(displayTask); err != nil {
 				return errors.Wrap(errors.WithStack(err), "error updating display task")
 			}
-			if err := build.UpdateCachedTask(displayTask.BuildId, displayTask.Id, displayTask.Status, 0); err != nil {
+			if err = build.UpdateCachedTask(displayTask.BuildId, displayTask.Id, displayTask.Status, 0); err != nil {
 				return errors.Wrap(errors.WithStack(err), "error updating cached display task")
 			}
 			t = *displayTask
@@ -1010,9 +1010,10 @@ func UpdateDisplayTask(t *task.Task) error {
 			}
 		} else if execTask.IsDispatchable() {
 			unfinishedTasks++
-			isBlocked, err := execTask.IsBlockedStateForExecTask(tasksWithDeps)
+			var isBlocked bool
+			isBlocked, err = execTask.IsBlockedStateForExecTask(tasksWithDeps)
 			if err != nil {
-				return errors.Wrap(err, "error determining if state blocked for execuction task")
+				return errors.Wrap(err, "error determining if state blocked for execution task")
 			} else if isBlocked {
 				blockedTasks++
 			}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1011,7 +1011,7 @@ func UpdateDisplayTask(t *task.Task) error {
 		} else if execTask.IsDispatchable() {
 			unfinishedTasks++
 			var isBlocked bool
-			isBlocked, err = execTask.IsBlockedStateForExecTask(tasksWithDeps)
+			isBlocked, err = execTask.IsBlocked(tasksWithDeps)
 			if err != nil {
 				return errors.Wrap(err, "error determining if state blocked for execution task")
 			} else if isBlocked {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 var (
@@ -2336,6 +2337,111 @@ func TestDisplayTaskDelayedRestart(t *testing.T) {
 	oldTask, err := task.FindOneOld(task.ById("dt_0"))
 	assert.NoError(err)
 	assert.NotNil(oldTask)
+}
+
+func TestDisplayTaskBlocked(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(task.Collection, ProjectRefCollection, distro.Collection, build.Collection))
+	dt := task.Task{
+		Id:             "task",
+		BuildId:        "build",
+		Activated:      true,
+		DisplayOnly:    true,
+		Status:         evergreen.TaskStarted,
+		ExecutionTasks: []string{"exec0", "exec1"},
+	}
+	assert.NoError(dt.Insert())
+	task2 := task.Task{
+		Id:        "exec0",
+		BuildId:   "build",
+		Activated: true,
+		Status:    evergreen.TaskFailed,
+		TimeTaken: 2 * time.Minute,
+	}
+	assert.NoError(task2.Insert())
+	task3 := task.Task{
+		Id:        "exec1",
+		BuildId:   "build",
+		Activated: true,
+		DependsOn: []task.Dependency{
+			{TaskId: "exec0", Status: evergreen.TaskSucceeded},
+		},
+		Status: evergreen.TaskUndispatched,
+	}
+	assert.NoError(task3.Insert())
+	b := build.Build{
+		Id: "build",
+		Tasks: []build.TaskCache{
+			{Id: "task", Status: evergreen.TaskStarted, Activated: true},
+		},
+	}
+	assert.NoError(b.Insert())
+
+	assert.NoError(UpdateDisplayTask(&dt))
+	dbTask, err := task.FindOne(task.ById(dt.Id))
+	assert.NoError(err)
+	assert.Equal(evergreen.TaskFailed, dbTask.Status)
+}
+
+func TestDisplayTaskBlockedOnOutsideTask(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(task.Collection, ProjectRefCollection, distro.Collection, build.Collection))
+	dt := task.Task{
+		Id:             "task",
+		BuildId:        "build",
+		Activated:      true,
+		DisplayOnly:    true,
+		Status:         evergreen.TaskStarted,
+		ExecutionTasks: []string{"exec0", "exec1"},
+	}
+	assert.NoError(dt.Insert())
+	task2 := task.Task{
+		Id:        "exec0",
+		BuildId:   "build",
+		Activated: true,
+		Status:    evergreen.TaskSucceeded,
+		TimeTaken: 2 * time.Minute,
+	}
+	assert.NoError(task2.Insert())
+	task3 := task.Task{
+		Id:        "exec1",
+		BuildId:   "build",
+		Activated: true,
+		DependsOn: []task.Dependency{
+			{TaskId: "exec2", Status: evergreen.TaskSucceeded},
+		},
+		Status: evergreen.TaskUndispatched,
+	}
+	assert.NoError(task3.Insert())
+	task4 := task.Task{
+		Id:        "exec2",
+		BuildId:   "build",
+		Activated: true,
+		Status:    evergreen.TaskFailed,
+	}
+	assert.NoError(task4.Insert())
+	b := build.Build{
+		Id: "build",
+		Tasks: []build.TaskCache{
+			{Id: "task", Status: evergreen.TaskStarted, Activated: true},
+		},
+	}
+	assert.NoError(b.Insert())
+
+	assert.NoError(UpdateDisplayTask(&dt))
+	dbTask, err := task.FindOne(task.ById(dt.Id))
+	assert.NoError(err)
+	assert.NotEqual(evergreen.TaskFailed, dbTask.Status) // not failed because no other task has failed
+
+	task2.Status = evergreen.TaskFailed
+	assert.NoError(task.UpdateOne(
+		bson.M{task.IdKey: task2.Id},
+		bson.M{"$set": bson.M{task.StatusKey: evergreen.TaskFailed}}))
+
+	assert.NoError(UpdateDisplayTask(&dt))
+	dbTask, err = task.FindOne(task.ById(dt.Id))
+	assert.NoError(err)
+	assert.Equal(evergreen.TaskFailed, dbTask.Status)
 }
 
 func TestEvalStepback(t *testing.T) {

--- a/public/static/js/filters/filters.common.js
+++ b/public/static/js/filters/filters.common.js
@@ -276,13 +276,7 @@ filters.common.filter('conditional', function() {
       return task;
     }
     var cls = task.status;
-    if (task.status == 'undispatched' || (task.display_only && task.task_waiting)) {
-      if (!task.activated) {
-        cls = 'inactive';
-      } else {
-        cls = 'unstarted';
-      }
-    } else if (task.status == 'started') {
+    if (task.status == 'started') {
       cls = 'started';
     } else if (task.status == 'success') {
       cls = 'success';
@@ -307,6 +301,12 @@ filters.common.filter('conditional', function() {
           }
         }
       }
+    } else if (task.status == 'undispatched' || (task.display_only && task.task_waiting)) {
+        if (!task.activated) {
+            cls = 'inactive';
+        } else {
+            cls = 'unstarted';
+        }
     }
     return cls;
   }
@@ -314,9 +314,6 @@ filters.common.filter('conditional', function() {
 
 .filter('statusLabel', function() {
   return function(task) {
-    if (task.task_waiting && !task.override_dependencies) {
-      return task.task_waiting;
-    }
     if (task.status == 'started') {
       return 'started';
     } else if (task.status == 'undispatched' && task.activated) {
@@ -360,6 +357,9 @@ filters.common.filter('conditional', function() {
         }
         return 'failed';
       }
+    }
+    if (task.task_waiting && !task.override_dependencies) {
+        return task.task_waiting;
     }
     return task.status;
   }


### PR DESCRIPTION
When execution tasks depend on a previous execution task succeeding (which has failed), they will block indefinitely and thus the overall task will appear yellow as Started instead of red as Failed.

Approach: if there exists failed tasks and all unfinished tasks are blocked, then update the status as failed.