### PR TITLE
EVG-5826 fix log link for testresults

### DIFF
--- a/model/test_log.go
+++ b/model/test_log.go
@@ -103,6 +103,7 @@ func (self *TestLog) URL() string {
 			"operation": "set test url",
 			"task":      self.Task,
 		}))
+		return ""
 	}
 	return fmt.Sprintf("%v/test_log/%v/%v/%v",
 		settings.Ui.Url,

--- a/model/test_log.go
+++ b/model/test_log.go
@@ -3,9 +3,12 @@ package model
 import (
 	"fmt"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	mgobson "gopkg.in/mgo.v2/bson"
@@ -93,7 +96,16 @@ func (self *TestLog) Validate() error {
 // URL returns the path to access the log based on its current fields.
 // Does not error if fields are not set.
 func (self *TestLog) URL() string {
-	return fmt.Sprintf("/test_log/%v/%v/%v",
+	settings, err := evergreen.GetConfig()
+	if err != nil {
+		grip.Debug(message.WrapError(err, message.Fields{
+			"message":   "error getting config",
+			"operation": "set test url",
+			"task":      self.Task,
+		}))
+	}
+	return fmt.Sprintf("%v/test_log/%v/%v/%v",
+		settings.Ui.Url,
 		self.Task,
 		self.TaskExecution,
 		self.Name,


### PR DESCRIPTION
Currently the log link is "http://test_log/..." when it should be "http://evergreen.mongodb.com/test_log/.."