### PR TITLE
EVG-5958 remove flaky image pull test

### DIFF
--- a/cloud/docker_integration_test.go
+++ b/cloud/docker_integration_test.go
@@ -1,5 +1,6 @@
 package cloud
 
+/*
 import (
 	"context"
 	"os"
@@ -71,3 +72,4 @@ func (s *DockerIntegrationSuite) TestImagePull() {
 	grip.Info(images)
 	s.Contains(images[0].RepoTags, "hello-world:latest")
 }
+*/

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -223,22 +223,22 @@ functions:
         working_dir: gopath/src/github.com/evergreen-ci/evergreen
         command: make check-mongod
   setup-docker-host:
-    - command: host.create
-      type: setup
-      params:
-        distro: archlinux-parent
-        provider: ec2
-        retries: 3
-        scope: build
-        security_group_ids:
-          - sg-097bff6dd0d1d31d0
-    - command: host.list
-      type: setup
-      params:
-        wait: true
-        timeout_seconds: 900
-        num_hosts: 1
-        path: gopath/src/github.com/evergreen-ci/evergreen/spawned_hosts.json
+#    - command: host.create
+#      type: setup
+#      params:
+#        distro: archlinux-parent
+#        provider: ec2
+#        retries: 3
+#        scope: build
+#        security_group_ids:
+#          - sg-097bff6dd0d1d31d0
+#    - command: host.list
+#      type: setup
+#      params:
+#        wait: true
+#        timeout_seconds: 900
+#        num_hosts: 1
+#        path: gopath/src/github.com/evergreen-ci/evergreen/spawned_hosts.json
     - command: subprocess.exec
       type: setup
       params:


### PR DESCRIPTION
This test is flaky because we can't always ensure that docker is up on the parent. It's possible that why this occasionally takes so long should be investigated separately, but the test itself doesn't verify much functionality and is more reliably tested locally. 