### PR TITLE
EVG-5826 fix log link in emails

### DIFF
--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -378,7 +378,7 @@ func makeCommonPayload(sub *event.Subscription, selectors []event.Selector,
 
 	data.Headers = makeHeaders(selectors)
 	data.SubscriptionID = sub.ID
-	data.FailedTests, err = getFailedTestsFromTemplate(data.Task)
+	data.FailedTests, err = getFailedTestsFromTemplate(*data.Task)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting failed tests")
 	}
@@ -428,7 +428,7 @@ func makeCommonPayload(sub *event.Subscription, selectors []event.Selector,
 	return nil, errors.Errorf("unknown type: '%s'", sub.Subscriber.Type)
 }
 
-func getFailedTestsFromTemplate(t *task.Task) ([]task.TestResult, error) {
+func getFailedTestsFromTemplate(t task.Task) ([]task.TestResult, error) {
 	settings, err := evergreen.GetConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "problem getting evergreen config")
@@ -437,8 +437,9 @@ func getFailedTestsFromTemplate(t *task.Task) ([]task.TestResult, error) {
 	result := []task.TestResult{}
 	for i := range t.LocalTestResults {
 		if t.LocalTestResults[i].Status == evergreen.TestFailedStatus {
-			result = append(result, t.LocalTestResults[i])
-			result[len(result)-1].URL = settings.Ui.Url + t.LocalTestResults[i].URL
+			testResult := t.LocalTestResults[i]
+			testResult.URL = settings.Ui.Url + testResult.URL
+			result = append(result, testResult)
 		}
 	}
 	return result, nil

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -378,9 +378,11 @@ func makeCommonPayload(sub *event.Subscription, selectors []event.Selector,
 
 	data.Headers = makeHeaders(selectors)
 	data.SubscriptionID = sub.ID
-	data.FailedTests, err = getFailedTestsFromTemplate(*data.Task)
-	if err != nil {
-		return nil, errors.Wrap(err, "error getting failed tests")
+	if data.Task != nil {
+		data.FailedTests, err = getFailedTestsFromTemplate(*data.Task)
+		if err != nil {
+			return nil, errors.Wrap(err, "error getting failed tests")
+		}
 	}
 
 	switch sub.Subscriber.Type {

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -367,7 +367,7 @@ func truncateString(s string, capacity int) (string, string) {
 
 func makeCommonPayload(sub *event.Subscription, selectors []event.Selector,
 	data *commonTemplateData) (interface{}, error) {
-
+	var err error
 	selectors = append(selectors, event.Selector{
 		Type: "trigger",
 		Data: sub.Trigger,
@@ -378,13 +378,9 @@ func makeCommonPayload(sub *event.Subscription, selectors []event.Selector,
 
 	data.Headers = makeHeaders(selectors)
 	data.SubscriptionID = sub.ID
-
-	if data.Task != nil {
-		for i := range data.Task.LocalTestResults {
-			if data.Task.LocalTestResults[i].Status == evergreen.TestFailedStatus {
-				data.FailedTests = append(data.FailedTests, data.Task.LocalTestResults[i])
-			}
-		}
+	data.FailedTests, err = getFailedTestsFromTemplate(data.Task)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting failed tests")
 	}
 
 	switch sub.Subscriber.Type {
@@ -430,6 +426,22 @@ func makeCommonPayload(sub *event.Subscription, selectors []event.Selector,
 	}
 
 	return nil, errors.Errorf("unknown type: '%s'", sub.Subscriber.Type)
+}
+
+func getFailedTestsFromTemplate(t *task.Task) ([]task.TestResult, error) {
+	settings, err := evergreen.GetConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "problem getting evergreen config")
+	}
+
+	result := []task.TestResult{}
+	for i := range t.LocalTestResults {
+		if t.LocalTestResults[i].Status == evergreen.TestFailedStatus {
+			result = append(result, t.LocalTestResults[i])
+			result[len(result)-1].URL = settings.Ui.Url + t.LocalTestResults[i].URL
+		}
+	}
+	return result, nil
 }
 
 func taskLink(uiBase string, taskID string, execution int) string {

--- a/trigger/payloads_test.go
+++ b/trigger/payloads_test.go
@@ -138,7 +138,7 @@ func (s *payloadSuite) TestGetFailedTestsFromTemplate() {
 		URL:    "/test_log/success",
 		Status: evergreen.TestSucceededStatus,
 	}
-	t := &task.Task{
+	t := task.Task{
 		Id:          "taskid",
 		DisplayName: "thetask",
 		Details: apimodels.TaskEndDetail{

--- a/trigger/payloads_test.go
+++ b/trigger/payloads_test.go
@@ -146,11 +146,14 @@ func (s *payloadSuite) TestGetFailedTestsFromTemplate() {
 		},
 		LocalTestResults: []task.TestResult{test1, test2},
 	}
+	settings, err := evergreen.GetConfig()
+	s.NoError(err)
+	s.Require().NotNil(settings)
 
 	tr, err := getFailedTestsFromTemplate(t)
 	s.NoError(err)
 	s.Require().Len(tr, 1)
-	s.Equal(tr[0].URL, "https://evergreen.mongodb.com/test_log/failed")
+	s.Equal(tr[0].URL, settings.Ui.Url+test1.URL)
 	s.NotEqual(tr[0].URL, test1.URL)
 }
 

--- a/trigger/payloads_test.go
+++ b/trigger/payloads_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -126,6 +127,31 @@ func (s *payloadSuite) TestSlack() {
 
 	s.Equal("The patch <https://example.com/patch/1234|display-1234> in 'test' has failed!", m.Body)
 	s.Empty(m.Attachments)
+}
+
+func (s *payloadSuite) TestGetFailedTestsFromTemplate() {
+	test1 := task.TestResult{
+		URL:    "/test_log/failed",
+		Status: evergreen.TestFailedStatus,
+	}
+	test2 := task.TestResult{
+		URL:    "/test_log/success",
+		Status: evergreen.TestSucceededStatus,
+	}
+	t := &task.Task{
+		Id:          "taskid",
+		DisplayName: "thetask",
+		Details: apimodels.TaskEndDetail{
+			TimedOut: false,
+		},
+		LocalTestResults: []task.TestResult{test1, test2},
+	}
+
+	tr, err := getFailedTestsFromTemplate(t)
+	s.NoError(err)
+	s.Require().Len(tr, 1)
+	s.Equal(tr[0].URL, "https://evergreen.mongodb.com/test_log/failed")
+	s.NotEqual(tr[0].URL, test1.URL)
 }
 
 func TestTruncateString(t *testing.T) {


### PR DESCRIPTION
Add URL base from evergreen config before transferring failed tests from the task to the template.