### PR TITLE
EVG-6017 remove incorrect comment

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -76,9 +76,8 @@ type Host struct {
 	LastTaskCompletedTime time.Time `bson:"last_task_completed_time" json:"last_task_completed_time"`
 	LastCommunicationTime time.Time `bson:"last_communication" json:"last_communication"`
 
-	Status    string `bson:"status" json:"status"`
-	StartedBy string `bson:"started_by" json:"started_by"`
-	// UserHost is always false, and will be removed
+	Status        string `bson:"status" json:"status"`
+	StartedBy     string `bson:"started_by" json:"started_by"`
 	UserHost      bool   `bson:"user_host" json:"user_host"`
 	AgentRevision string `bson:"agent_revision" json:"agent_revision"`
 	NeedsNewAgent bool   `bson:"needs_agent" json:"needs_agent"`

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -76,8 +76,9 @@ type Host struct {
 	LastTaskCompletedTime time.Time `bson:"last_task_completed_time" json:"last_task_completed_time"`
 	LastCommunicationTime time.Time `bson:"last_communication" json:"last_communication"`
 
-	Status        string `bson:"status" json:"status"`
-	StartedBy     string `bson:"started_by" json:"started_by"`
+	Status    string `bson:"status" json:"status"`
+	StartedBy string `bson:"started_by" json:"started_by"`
+	// True if this host was created manually by a user (i.e. with spawnhost)
 	UserHost      bool   `bson:"user_host" json:"user_host"`
 	AgentRevision string `bson:"agent_revision" json:"agent_revision"`
 	NeedsNewAgent bool   `bson:"needs_agent" json:"needs_agent"`


### PR DESCRIPTION
This ticket was made off of the assumption that UserHost is always set to false as stated in the comment, because RemoveStaleInitializing filters by UserHost (in order to not remove intent hosts spawned by tasks or users). However, UserHost can be set to true, and so this comment should be removed to avoid future confusion.