### PR TITLE
EVG-6099: remove check for commit message

### DIFF
--- a/model/commitqueue/github_pr_message.go
+++ b/model/commitqueue/github_pr_message.go
@@ -45,9 +45,6 @@ func (p *GithubMergePR) Valid() error {
 	if len(p.Repo) == 0 {
 		catcher.Add(errors.New("Repo can't be empty"))
 	}
-	if len(p.CommitMessage) == 0 {
-		catcher.Add(errors.New("Commit message can't be empty"))
-	}
 	if len(p.Ref) == 0 {
 		catcher.Add(errors.New("Ref can't be empty"))
 	}

--- a/model/commitqueue/github_pr_message_test.go
+++ b/model/commitqueue/github_pr_message_test.go
@@ -33,22 +33,20 @@ func TestGithubMergePRMessageValidator(t *testing.T) {
 	assert := assert.New(t)
 
 	missingPRNum := GithubMergePR{
-		ProjectID:     "mci",
-		Owner:         "evergreen-ci",
-		Repo:          "evergreen",
-		Ref:           "deadbeef",
-		CommitMessage: "merged by cq",
+		ProjectID: "mci",
+		Owner:     "evergreen-ci",
+		Repo:      "evergreen",
+		Ref:       "deadbeef",
 	}
 	c := NewGithubMergePRMessage(level.Info, missingPRNum)
 	assert.False(c.Loggable())
 
 	missingMergeMethod := GithubMergePR{
-		ProjectID:     "mci",
-		Owner:         "evergreen-ci",
-		Repo:          "evergreen",
-		Ref:           "deadbeef",
-		CommitMessage: "merged by cq",
-		PRNum:         1,
+		ProjectID: "mci",
+		Owner:     "evergreen-ci",
+		Repo:      "evergreen",
+		Ref:       "deadbeef",
+		PRNum:     1,
 	}
 	c = NewGithubMergePRMessage(level.Info, missingMergeMethod)
 	assert.True(c.Loggable())


### PR DESCRIPTION
The default commit queue PR commit message was removed in #2179 but the check for a message was not. It never really made sense to require one anyway.