### PR TITLE
EVG-6100 logging in GetLogs and small route fixes

### DIFF
--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -75,6 +75,9 @@ func GetDockerClient(s *evergreen.Settings) DockerClient {
 // machine. The Docker client must be exposed and available for requests at the
 // client port 3369 on the host machine.
 func (c *dockerClientImpl) generateClient(h *host.Host) (*docker.Client, error) {
+	if h == nil {
+		return nil, errors.New("host cannot be nil")
+	}
 	if h.Host == "" {
 		return nil, errors.New("HostIP must not be blank")
 	}
@@ -391,14 +394,17 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 // GetDockerLogs returns output logs or error logs, based on the given options.
 // This assumes the container is not using TTY.
 func (c *dockerClientImpl) GetDockerLogs(ctx context.Context, containerID string, parent *host.Host, options types.ContainerLogsOptions) (io.Reader, error) {
-	grip.Debug(message.Fields{
-		"message":       "at the start of GetDockerLogs",
-		"operation":     "docker logs",
-		"ticket":        "EVG-6100",
-		"host":          containerID,
-		"options":       options,
-		"parent_status": parent.Status,
-	})
+	if parent != nil {
+		grip.Debug(message.Fields{
+			"message":       "at the start of GetDockerLogs",
+			"operation":     "docker logs",
+			"ticket":        "EVG-6100",
+			"host":          containerID,
+			"options":       options,
+			"parent_status": parent.Status,
+		})
+	}
+
 	dockerClient, err := c.generateClient(parent)
 	if err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -391,12 +391,32 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 // GetDockerLogs returns output logs or error logs, based on the given options.
 // This assumes the container is not using TTY.
 func (c *dockerClientImpl) GetDockerLogs(ctx context.Context, containerID string, parent *host.Host, options types.ContainerLogsOptions) (io.Reader, error) {
+	grip.Debug(message.Fields{
+		"message":       "at the start of GetDockerLogs",
+		"operation":     "docker logs",
+		"ticket":        "EVG-6100",
+		"host":          containerID,
+		"options":       options,
+		"parent_status": parent.Status,
+	})
 	dockerClient, err := c.generateClient(parent)
 	if err != nil {
+		grip.Debug(message.WrapError(err, message.Fields{
+			"message":   "problem generating client",
+			"operation": "docker logs",
+			"ticket":    "EVG-6100",
+			"host":      containerID,
+		}))
 		return nil, errors.Wrap(err, "Failed to generate docker client")
 	}
 	stream, err := dockerClient.ContainerLogs(ctx, containerID, options)
 	if err != nil {
+		grip.Debug(message.WrapError(err, message.Fields{
+			"message":   "problem getting docker logs",
+			"operation": "docker logs",
+			"ticket":    "EVG-6100",
+			"host":      containerID,
+		}))
 		return nil, errors.Wrapf(err, "Docker logs API call failed for container %s", containerID)
 	}
 	tempout := &bytes.Buffer{}
@@ -404,6 +424,12 @@ func (c *dockerClientImpl) GetDockerLogs(ctx context.Context, containerID string
 
 	_, err = stdcopy.StdCopy(tempout, temperr, stream)
 	if err != nil {
+		grip.Debug(message.WrapError(err, message.Fields{
+			"message":   "problem copying stream from docker logs",
+			"operation": "docker logs",
+			"ticket":    "EVG-6100",
+			"host":      containerID,
+		}))
 		return nil, errors.Wrapf(err, "Error copying stream for container %s", containerID)
 	}
 

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -831,7 +831,7 @@ func (c *communicatorImpl) GetDockerStatus(ctx context.Context, hostID string) (
 }
 
 func (c *communicatorImpl) GetDockerLogs(ctx context.Context, hostID string, startTime time.Time, endTime time.Time, isError bool) ([]byte, error) {
-	path := fmt.Sprintf("/host/%s/logs", hostID)
+	path := fmt.Sprintf("/hosts/%s/logs", hostID)
 	if isError {
 		path = fmt.Sprintf("%s/error", path)
 	} else {

--- a/units/host_monitoring_container_state.go
+++ b/units/host_monitoring_container_state.go
@@ -119,7 +119,7 @@ func (j *hostMonitorContainerStateJob) Run(ctx context.Context) {
 	// Docker, remove container from Docker and mark it as terminated
 	for _, container := range containersFromDB {
 		if container.Status == evergreen.HostRunning || container.Status == evergreen.HostDecommissioned {
-			if !isRunningInDocker[container.Id] && !container.SpawnOptions.SpawnedByTask {
+			if !container.SpawnOptions.SpawnedByTask && !isRunningInDocker[container.Id] {
 				if err := containerMgr.TerminateInstance(ctx, &container, evergreen.User); err != nil {
 					j.AddError(errors.Wrap(err, "error terminating instance on Docker"))
 					j.AddError(container.SetTerminated(evergreen.User))

--- a/units/host_monitoring_parent_decommission.go
+++ b/units/host_monitoring_parent_decommission.go
@@ -107,7 +107,7 @@ func (j *parentDecommissionJob) Run(ctx context.Context) {
 		}
 
 		for _, c := range containersToDeco {
-			if c.Status == evergreen.HostRunning {
+			if c.Status == evergreen.HostRunning && !c.SpawnOptions.SpawnedByTask {
 				j.AddError(c.SetDecommissioned(evergreen.User, ""))
 				continue
 			}

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -117,6 +117,12 @@ func (j *cloudHostReadyJob) Run(ctx context.Context) {
 func setCloudHostStatus(ctx context.Context, m cloud.Manager, h host.Host, hostStatus cloud.CloudStatus) error {
 	switch hostStatus {
 	case cloud.StatusFailed:
+		grip.Debug(message.Fields{
+			"ticket":     "EVG-6100",
+			"message":    "host status",
+			"host":       h,
+			"hostStatus": hostStatus.String(),
+		})
 		return errors.Wrap(m.TerminateInstance(ctx, &h, evergreen.User), "error terminating instance")
 	case cloud.StatusRunning:
 		return errors.Wrap(h.SetProvisioning(), "error setting host to provisioning")


### PR DESCRIPTION
Typo in routes... Still getting errors that the communicator for whatever reason isn't able to parse, so I added logging to GetDockerLogs to figure out what's happening.