### PR TITLE
EVG-6050: fix activated field in cached task

### DIFF
--- a/model/build/build.go
+++ b/model/build/build.go
@@ -90,13 +90,13 @@ func (b *Build) AllUnblockedTasksFinished(tasksWithDeps []task.Task) (bool, stri
 	status := evergreen.BuildSucceeded
 	catcher := grip.NewSimpleCatcher()
 	for i := range b.Tasks {
-		if !b.Tasks[i].Activated {
-			continue
-		}
 		if evergreen.IsFailedTaskStatus(b.Tasks[i].Status) {
 			status = evergreen.BuildFailed
 		}
 		if !evergreen.IsFinishedTaskStatus(b.Tasks[i].Status) {
+			if !b.Tasks[i].Activated {
+				continue
+			}
 			t, err := task.FindOneNoMerge(task.ById(b.Tasks[i].Id))
 			if err != nil {
 				return false, status, err

--- a/model/build/build_test.go
+++ b/model/build/build_test.go
@@ -607,6 +607,18 @@ func TestAllTasksFinished(t *testing.T) {
 		{
 			Id:        "t0",
 			Status:    evergreen.TaskFailed,
+			Activated: false,
+		},
+	}
+	complete, status, err := b.AllUnblockedTasksFinished(nil)
+	assert.NoError(err)
+	assert.True(complete)
+	assert.Equal(status, evergreen.BuildFailed)
+
+	b.Tasks = []TaskCache{
+		{
+			Id:        "t0",
+			Status:    evergreen.TaskFailed,
 			Activated: true,
 		},
 		{
@@ -665,7 +677,7 @@ func TestAllTasksFinished(t *testing.T) {
 	assert.NoError(d0.Insert())
 	assert.NoError(e0.Insert())
 	assert.NoError(e1.Insert())
-	complete, _, err := b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished(nil)
 	assert.NoError(err)
 	assert.True(complete)
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -135,6 +135,10 @@ func resetTask(taskId, caller string) error {
 		return errors.WithStack(err)
 	}
 
+	if err = build.SetCachedTaskActivated(t.BuildId, t.Id, true); err != nil {
+		return errors.WithStack(err)
+	}
+
 	// update the cached version of the task, in its build document
 	if err = build.ResetCachedTask(t.BuildId, t.Id); err != nil {
 		return errors.WithStack(err)


### PR DESCRIPTION
The logged status of a patch is derived from the outcome of `AllUnblockedTasksFinished`. Since an aborted task is deactivated, when the task completes and calls `endTask` the patch is logged as succeeding since the function assumes a deactivated task has not failed. The logged status is the status reported to the user, so slack notifications for deactivated tasks were said to be successful.

The activated status checked is from the cached task, which was not being updated when the task was restarted. Therefore it was reported successful each subsequent time the task was restarted.

This PR is to only assume deactivated tasks are okay if the task isn't complete and to update the cached task's activated field on restart.