### PR TITLE
EVG-5896: remove check for unset activated time

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -604,10 +604,7 @@ func UnscheduleStaleUnderwaterTasks(distroID string) (int, error) {
 		query[DistroIdKey] = distroID
 	}
 
-	query["$and"] = []bson.M{
-		{ActivatedTimeKey: bson.M{"$lte": time.Now().Add(-UnschedulableThreshold)}},
-		{ActivatedTimeKey: bson.M{"$gt": util.ZeroTime}},
-	}
+	query[ActivatedTimeKey] = bson.M{"$lte": time.Now().Add(-UnschedulableThreshold)}
 
 	update := bson.M{
 		"$set": bson.M{

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1059,3 +1059,23 @@ func TestBulkInsert(t *testing.T) {
 		assert.Equal("version", dbTask.Version)
 	}
 }
+
+func TestUnscheduleStaleUnderwaterTasks(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(Collection))
+	t1 := Task{
+		Id:            "t1",
+		Status:        evergreen.TaskUndispatched,
+		Activated:     true,
+		Priority:      0,
+		ActivatedTime: time.Time{},
+	}
+	assert.NoError(t1.Insert())
+
+	_, err := UnscheduleStaleUnderwaterTasks("")
+	assert.NoError(err)
+	dbTask, err := FindOneId("t1")
+	assert.NoError(err)
+	assert.False(dbTask.Activated)
+	assert.EqualValues(-1, dbTask.Priority)
+}


### PR DESCRIPTION
Tasks older than the threshold were still being scheduled. We were filtering out tasks with an unset activated time so those were still being scheduled.
The activated time is fixed since #2184 and #2218 so that any activated task will have an activated time. We could do nothing, but I suggest removing the now superfluous check for unset activated time.