### PR TITLE
EVG-6131: add default email notifications

### DIFF
--- a/service/templates/notifications.html
+++ b/service/templates/notifications.html
@@ -54,7 +54,7 @@ Notifications Preferences
                   <md-radio-group layout="row" style="width:100%" ng-model="settings.notifications.spawn_host_outcome" md-no-ink="true">
                     <md-radio-button value="email"></md-radio-button>
                     <md-radio-button value="slack" ng-disabled='!settings.slack_username || settings.slack_username == ""'></md-radio-button>
-                    <md-radio-button value=""></md-radio-button>
+                    <md-radio-button value="none"></md-radio-button>
                   </md-radio-group>
                 </td>
               </tr>
@@ -64,7 +64,7 @@ Notifications Preferences
                   <md-radio-group layout="row" style="width:100%" ng-model="settings.notifications.spawn_host_expiration" md-no-ink="true">
                     <md-radio-button value="email"></md-radio-button>
                     <md-radio-button value="slack" ng-disabled='!settings.slack_username || settings.slack_username == ""'></md-radio-button>
-                    <md-radio-button value=""></md-radio-button>
+                    <md-radio-button value="none"></md-radio-button>
                   </md-radio-group>
                 </td>
               </tr>
@@ -74,7 +74,7 @@ Notifications Preferences
                   <md-radio-group layout="row" style="width:100%" ng-model="settings.notifications.build_break" md-no-ink="true">
                     <md-radio-button value="email"></md-radio-button>
                     <md-radio-button value="slack" ng-disabled='!settings.slack_username || settings.slack_username == ""'></md-radio-button>
-                    <md-radio-button value=""></md-radio-button>
+                    <md-radio-button value="none"></md-radio-button>
                   </md-radio-group>
                 </td>
               </tr>
@@ -84,7 +84,7 @@ Notifications Preferences
                   <md-radio-group layout="row" style="width:100%" ng-model="settings.notifications.commit_queue" md-no-ink="true">
                     <md-radio-button value="email"></md-radio-button>
                     <md-radio-button value="slack" ng-disabled='!settings.slack_username || settings.slack_username == ""'></md-radio-button>
-                    <md-radio-button value=""></md-radio-button>
+                    <md-radio-button value="none"></md-radio-button>
                   </md-radio-group>
                 </td>
               </tr>

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -288,7 +288,7 @@ func (j *commitQueueJob) processCLIPatchItem(ctx context.Context, cq *commitqueu
 	subscriber := event.NewCommitQueueDequeueSubscriber()
 
 	patchSub := event.NewPatchOutcomeSubscription(nextItem.Issue, subscriber)
-	if err := patchSub.Upsert(); err != nil {
+	if err = patchSub.Upsert(); err != nil {
 		j.logError(err, "failed to insert patch subscription", nextItem)
 		j.dequeue(cq, nextItem)
 	}

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -565,6 +565,9 @@ func setDefaultNotification(username string) error {
 	if err != nil {
 		return errors.Wrap(err, "can't get user")
 	}
+	if u == nil {
+		return errors.Errorf("no matching user for %s", username)
+	}
 
 	// The user has never saved their notification settings
 	if u.Settings.Notifications.CommitQueue == "" {

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/validator"
 	"github.com/google/go-github/github"
@@ -292,6 +293,9 @@ func (j *commitQueueJob) processCLIPatchItem(ctx context.Context, cq *commitqueu
 		j.dequeue(cq, nextItem)
 	}
 
+	if err = setDefaultNotification(patchDoc.Author); err != nil {
+		j.logError(err, "failed to set default notification", nextItem)
+	}
 	event.LogCommitQueueStartTestEvent(v.Id)
 }
 
@@ -552,6 +556,29 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error
 	patchDoc.PatchedConfig = string(yamlBytes)
 	patchDoc.BuildVariants = append(patchDoc.BuildVariants, "commit-queue-merge")
 	patchDoc.Tasks = append(patchDoc.Tasks, "merge-patch")
+
+	return nil
+}
+
+func setDefaultNotification(username string) error {
+	u, err := user.FindOneById(username)
+	if err != nil {
+		return errors.Wrap(err, "can't get user")
+	}
+
+	// The user has never saved their notification settings
+	if u.Settings.Notifications.CommitQueue == "" {
+		u.Settings.Notifications.CommitQueue = user.PreferenceEmail
+		commitQueueSubscriber := event.NewEmailSubscriber(u.Email())
+		commitQueueSubscription, err := event.CreateOrUpdateImplicitSubscription(event.ImplicitSubscriptionCommitQueue,
+			"", commitQueueSubscriber, u.Id)
+		if err != nil {
+			return errors.Wrap(err, "can't create default email subscription")
+		}
+		u.Settings.Notifications.CommitQueueID = commitQueueSubscription.ID
+
+		return model.SaveUserSettings(u.Id, u.Settings)
+	}
 
 	return nil
 }


### PR DESCRIPTION
If a user hasn't set up their commit queue notification setting they will be opted in to email notifications when they submit a patch to the commit queue.