### PR TITLE
EVG-6134 scheduler parent calculation correction

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1236,19 +1236,19 @@ func getNumNewParentsAndHostsToSpawn(pool *evergreen.ContainerPool, newHostsNeed
 // numNewParentsNeeded returns the number of additional parents needed to
 // accommodate new containers
 func numNewParentsNeeded(params newParentsNeededParams) int {
-	numPossibleContainers := params.numExistingParents * params.maxContainers
-	numPossibleContainersNeeded := params.numExistingContainers + params.numContainersNeeded
-	numAvailableContainers := numPossibleContainers - params.numExistingContainers
+	existingCapacity := params.numExistingParents * params.maxContainers
+	newCapacityNeeded := params.numContainersNeeded - (existingCapacity - params.numExistingContainers)
 
 	// if we don't have enough space, calculate new parents
-	if numPossibleContainers < numPossibleContainersNeeded {
-		numTotalNewParents := int(math.Ceil(float64(params.numContainersNeeded-numAvailableContainers) / float64(params.maxContainers)))
+	if newCapacityNeeded > 0 {
+		numTotalNewParents := int(math.Ceil(float64(newCapacityNeeded) / float64(params.maxContainers)))
 		if numTotalNewParents < 0 {
 			return 0
 		}
 		return numTotalNewParents
 	}
 	return 0
+
 }
 
 // containerCapacity calculates how many containers to make

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -5,8 +5,6 @@ import (
 	"math"
 	"time"
 
-	"gopkg.in/mgo.v2"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
@@ -1182,7 +1180,7 @@ func GetNumContainersOnParents(d distro.Distro) ([]ContainersOnParents, error) {
 	for i := len(allParents) - 1; i >= 0; i-- {
 		parent := allParents[i]
 		currentContainers, err := parent.GetContainers()
-		if err != nil && err != mgo.ErrNotFound {
+		if err != nil && !adb.ResultsNotFound(err) {
 			return nil, errors.Wrapf(err, "Problem finding containers for parent %s", parent.Id)
 		}
 		if len(currentContainers) < parent.ContainerPoolSettings.MaxContainers {

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1958,7 +1958,7 @@ func TestCountContainersOnParents(t *testing.T) {
 	assert.Equal(c6, 0)
 }
 
-func TestFindRunningContainersOnParents(t *testing.T) {
+func TestFindUphostContainersOnParents(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 
@@ -1999,17 +1999,17 @@ func TestFindRunningContainersOnParents(t *testing.T) {
 	assert.NoError(h5.Insert())
 	assert.NoError(h6.Insert())
 
-	hosts1, err := HostGroup{h1, h2, h3}.FindRunningContainersOnParents()
+	hosts1, err := HostGroup{h1, h2, h3}.FindUphostContainersOnParents()
 	assert.NoError(err)
 	assert.Equal([]Host{h4, h5}, hosts1)
 
 	// Parents have no containers
-	hosts2, err := HostGroup{h3}.FindRunningContainersOnParents()
+	hosts2, err := HostGroup{h3}.FindUphostContainersOnParents()
 	assert.NoError(err)
 	assert.Empty(hosts2)
 
 	// Parents are actually containers
-	hosts3, err := HostGroup{h4, h5, h6}.FindRunningContainersOnParents()
+	hosts3, err := HostGroup{h4, h5, h6}.FindUphostContainersOnParents()
 	assert.NoError(err)
 	assert.Empty(hosts3)
 
@@ -2098,7 +2098,7 @@ func TestFindAllRunningParentsByDistro(t *testing.T) {
 	assert.Equal(2, len(parents))
 }
 
-func TestFindAllRunningParentsByContainerPool(t *testing.T) {
+func TestFindUphostParentsByContainerPool(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 
@@ -2130,11 +2130,11 @@ func TestFindAllRunningParentsByContainerPool(t *testing.T) {
 	assert.NoError(host2.Insert())
 	assert.NoError(host3.Insert())
 
-	hosts, err := findAllRunningParentsByContainerPool("test-pool")
+	hosts, err := findUphostParentsByContainerPool("test-pool")
 	assert.NoError(err)
 	assert.Equal([]Host{*host1}, hosts)
 
-	hosts, err = findAllRunningParentsByContainerPool("missing-test-pool")
+	hosts, err = findUphostParentsByContainerPool("missing-test-pool")
 	assert.NoError(err)
 	assert.Empty(hosts)
 
@@ -2460,7 +2460,7 @@ func TestFindTerminatedHostsRunningTasksQuery(t *testing.T) {
 	})
 }
 
-func TestCountAndFindUphostParents(t *testing.T) {
+func TestFindUphostParents(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 
@@ -2505,10 +2505,6 @@ func TestCountAndFindUphostParents(t *testing.T) {
 	assert.NoError(h3.Insert())
 	assert.NoError(h4.Insert())
 	assert.NoError(h5.Insert())
-
-	numUphostParents, err := countUphostParentsByContainerPool("test-pool")
-	assert.NoError(err)
-	assert.Equal(2, numUphostParents)
 
 	uphostParents, err := findUphostParentsByContainerPool("test-pool")
 	assert.NoError(err)
@@ -2769,20 +2765,17 @@ func TestNumNewParentsNeeded(t *testing.T) {
 	assert.NoError(host3.Insert())
 	assert.NoError(host4.Insert())
 
-	currentParents, err := findAllRunningParentsByContainerPool(d.ContainerPool)
+	existingParents, err := findUphostParentsByContainerPool(d.ContainerPool)
 	assert.NoError(err)
-	assert.Len(currentParents, 1)
-	numUphostParents, err := countUphostParentsByContainerPool("test-pool")
-	assert.NoError(err)
-	assert.Equal(2, numUphostParents)
-	existingContainers, err := HostGroup(currentParents).FindRunningContainersOnParents()
+	assert.Len(existingParents, 2)
+	existingContainers, err := HostGroup(existingParents).FindUphostContainersOnParents()
 	assert.NoError(err)
 	assert.Len(existingContainers, 2)
 
 	parentsParams := newParentsNeededParams{
-		numUphostParents:      numUphostParents,
-		numContainersNeeded:   4,
+		numExistingParents:    len(existingParents),
 		numExistingContainers: len(existingContainers),
+		numContainersNeeded:   4,
 		maxContainers:         pool.MaxContainers,
 	}
 	num := numNewParentsNeeded(parentsParams)
@@ -2823,17 +2816,15 @@ func TestNumNewParentsNeeded2(t *testing.T) {
 	assert.NoError(host2.Insert())
 	assert.NoError(host3.Insert())
 
-	currentParents, err := findAllRunningParentsByContainerPool(d.ContainerPool)
+	existingParents, err := findUphostParentsByContainerPool(d.ContainerPool)
 	assert.NoError(err)
-	numUphostParents, err := countUphostParentsByContainerPool("test-pool")
-	assert.NoError(err)
-	existingContainers, err := HostGroup(currentParents).FindRunningContainersOnParents()
+	existingContainers, err := HostGroup(existingParents).FindUphostContainersOnParents()
 	assert.NoError(err)
 
 	parentsParams := newParentsNeededParams{
-		numUphostParents:      numUphostParents,
-		numContainersNeeded:   1,
+		numExistingParents:    len(existingParents),
 		numExistingContainers: len(existingContainers),
+		numContainersNeeded:   1,
 		maxContainers:         pool.MaxContainers,
 	}
 	num := numNewParentsNeeded(parentsParams)
@@ -3020,5 +3011,42 @@ func TestGetNumNewParentsAndHostsToSpawn(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(2, parents)
 	assert.Equal(3, hosts)
+}
 
+func TestGetNumNewParentsWithInitializingParentAndHost(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections("hosts", "distro", "tasks"))
+
+	d := distro.Distro{Id: "distro", PoolSize: 2, Provider: evergreen.ProviderNameMock}
+	pool := &evergreen.ContainerPool{Distro: "distro", Id: "test-pool", MaxContainers: 2}
+
+	host1 := &Host{
+		Id:                    "host1",
+		Host:                  "host",
+		User:                  "user",
+		Distro:                distro.Distro{Id: "distro"},
+		Status:                evergreen.HostUninitialized,
+		HasContainers:         true,
+		ContainerPoolSettings: pool,
+	}
+	container := &Host{
+		Id:          "container",
+		Distro:      distro.Distro{Id: "distro", ContainerPool: "test-pool"},
+		Status:      evergreen.HostUninitialized,
+		ParentID:    "host1",
+		RunningTask: "task1",
+	}
+	assert.NoError(d.Insert())
+	assert.NoError(host1.Insert())
+	assert.NoError(container.Insert())
+
+	parents, hosts, err := getNumNewParentsAndHostsToSpawn(pool, 4, false)
+	assert.NoError(err)
+	assert.Equal(1, parents) // need two parents, but can only spawn 1
+	assert.Equal(3, hosts)   // should consider the uninitialized container as taking up capacity
+
+	parents, hosts, err = getNumNewParentsAndHostsToSpawn(pool, 4, true)
+	assert.NoError(err)
+	assert.Equal(2, parents)
+	assert.Equal(4, hosts)
 }


### PR DESCRIPTION
The original algorithm mistakenly ignored uninitialized parents (making newly created parents useless). 

EVG-5895 fixes this in some places; however, these changes didn’t account for uninitialized containers also being ignored. We still want to consider these uninitialized containers in our calculations so we don't overload an uninitialized parent.

NOTE: this might not be the whole problem? But it's the main one I'm seeing, and would be relevant eventually.
