### PR TITLE
EVG-5979 fix job collision logging

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -97,7 +97,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 
 	// we may be running these jobs on hosts that are already
 	// terminated.
-	grip.InfoWhen(!util.StringSliceContains(evergreen.UpHostStatus, j.host.Status),
+	grip.InfoWhen(j.host.Status == evergreen.HostTerminated,
 		message.Fields{
 			"host":     j.host.Id,
 			"provider": j.host.Distro.Provider,


### PR DESCRIPTION
We don't want to log if status is decommissioned either--really terminated is the only status we should care about here.