### PR TITLE
EVG-6141: fix set-module ref flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-04-30"
+	ClientVersion = "2019-05-03"
 )
 
 // ConfigSection defines a sub-document in the evegreen config

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -206,7 +206,7 @@ func addDbSettingsFlags(flags ...cli.Flag) []cli.Flag {
 func addRefFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.StringFlag{
 		Name:  refFlagName,
-		Usage: "diff with `REF`, ignoring working tree changes",
+		Usage: "diff with `REF`",
 		Value: "HEAD",
 	})
 }

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -18,10 +18,14 @@ func PatchSetModule() cli.Command {
 		Name:    "patch-set-module",
 		Aliases: []string{"set-module"},
 		Usage:   "update or add module to an existing patch",
-		Flags: mergeFlagSlices(addPatchIDFlag(), addPathFlag(), addModuleFlag(), addRefFlag(), addYesFlag(
+		Flags: mergeFlagSlices(addPatchIDFlag(), addPathFlag(), addModuleFlag(), addYesFlag(
 			cli.BoolFlag{
 				Name:  largeFlagName,
 				Usage: "enable submitting larger patches (>16MB)",
+			},
+			cli.StringFlag{
+				Name:  refFlagName,
+				Usage: "diff with `REF`, ignoring working tree changes",
 			})),
 		Before: mergeBeforeFuncs(requirePatchIDFlag, requireModuleFlag),
 		Action: func(c *cli.Context) error {


### PR DESCRIPTION
the `addRefFlag()` function sets a default value for the --ref flag (HEAD), so when it's not specified on the command line it is not "" (which would include changes to the working tree) but rather "HEAD"