### PR TITLE
EVG-5970 add setup_group_timeout_secs

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -598,6 +598,43 @@ task_groups:
 	s.Equal("Finished running pre-task commands.", msgs[len(msgs)-1].Message)
 }
 
+func (s *AgentSuite) TestGroupPreGroupSetupTimeout() {
+	s.tc.taskGroup = "task_group_name"
+	s.tc.taskConfig = &model.TaskConfig{
+		BuildVariant: &model.BuildVariant{
+			Name: "buildvariant_id",
+		},
+		Task: &task.Task{
+			Id:        "task_id",
+			TaskGroup: "task_group_name",
+			Version:   versionId,
+		},
+		Project: &model.Project{},
+		WorkDir: s.tc.taskDirectory,
+	}
+	s.tc.taskGroup = "task_group_name"
+	projYml := `
+task_groups:
+- name: task_group_name
+  setup_group_timeout_secs: 3
+  setup_group_can_fail_task: true
+  setup_group:
+  - command: shell.exec
+    params:
+      script: "sleep 10"
+`
+	v := &model.Version{
+		Id:     versionId,
+		Config: projYml,
+	}
+	s.tc.taskConfig.Version = v
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := s.a.runPreTaskCommands(ctx, s.tc)
+	s.Error(err)
+	s.Contains(err.Error(), "context deadline exceeded")
+}
+
 func (s *AgentSuite) TestGroupPreGroupCommandsFail() {
 	s.tc.taskGroup = "task_group_name"
 	s.tc.taskConfig = &model.TaskConfig{

--- a/agent/command.go
+++ b/agent/command.go
@@ -14,8 +14,9 @@ import (
 )
 
 type runCommandsOptions struct {
-	isTaskCommands  bool
-	shouldSetupFail bool
+	isTaskCommands   bool
+	shouldSetupFail  bool
+	setupTimeoutSecs int
 }
 
 func (a *Agent) runCommands(ctx context.Context, tc *taskContext, commands []model.PluginCommandConf,

--- a/agent/task.go
+++ b/agent/task.go
@@ -148,6 +148,11 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 		}
 		if taskGroup.SetupGroup != nil {
 			opts.shouldSetupFail = taskGroup.SetupGroupFailTask
+			if taskGroup.SetupGroupTimeoutSecs > 0 {
+				fmt.Println("THIS SHOULD BE PRETTY SHORT")
+				ctx, cancel = context.WithTimeout(ctx, time.Duration(taskGroup.SetupGroupTimeoutSecs)*time.Second)
+				defer cancel()
+			}
 			err = a.runCommands(ctx, tc, taskGroup.SetupGroup.List(), opts)
 			if err != nil {
 				tc.logger.Execution().Error(errors.Wrap(err, "error running task setup group"))

--- a/agent/task.go
+++ b/agent/task.go
@@ -138,9 +138,8 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 	opts := runCommandsOptions{}
 
 	if tc.runGroupSetup {
+		var ctx2 context.Context
 		var cancel context.CancelFunc
-		ctx, cancel = a.withCallbackTimeout(ctx, tc)
-		defer cancel()
 		taskGroup, err := model.GetTaskGroup(tc.taskGroup, tc.taskConfig)
 		if err != nil {
 			tc.logger.Execution().Error(errors.Wrap(err, "error fetching task group for pre-group commands"))
@@ -149,11 +148,12 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 		if taskGroup.SetupGroup != nil {
 			opts.shouldSetupFail = taskGroup.SetupGroupFailTask
 			if taskGroup.SetupGroupTimeoutSecs > 0 {
-				fmt.Println("THIS SHOULD BE PRETTY SHORT")
-				ctx, cancel = context.WithTimeout(ctx, time.Duration(taskGroup.SetupGroupTimeoutSecs)*time.Second)
-				defer cancel()
+				ctx2, cancel = context.WithTimeout(ctx, time.Duration(taskGroup.SetupGroupTimeoutSecs)*time.Second)
+			} else {
+				ctx2, cancel = a.withCallbackTimeout(ctx, tc)
 			}
-			err = a.runCommands(ctx, tc, taskGroup.SetupGroup.List(), opts)
+			defer cancel()
+			err = a.runCommands(ctx2, tc, taskGroup.SetupGroup.List(), opts)
 			if err != nil {
 				tc.logger.Execution().Error(errors.Wrap(err, "error running task setup group"))
 				if taskGroup.SetupGroupFailTask {

--- a/model/project.go
+++ b/model/project.go
@@ -345,15 +345,16 @@ type TaskGroup struct {
 	Name string `yaml:"name" bson:"name"`
 
 	// data about the task group
-	MaxHosts           int             `yaml:"max_hosts" bson:"max_hosts"`
-	SetupGroupFailTask bool            `yaml:"setup_group_can_fail_task" bson:"setup_group_can_fail_task"`
-	SetupGroup         *YAMLCommandSet `yaml:"setup_group" bson:"setup_group"`
-	TeardownGroup      *YAMLCommandSet `yaml:"teardown_group" bson:"teardown_group"`
-	SetupTask          *YAMLCommandSet `yaml:"setup_task" bson:"setup_task"`
-	TeardownTask       *YAMLCommandSet `yaml:"teardown_task" bson:"teardown_task"`
-	Timeout            *YAMLCommandSet `yaml:"timeout,omitempty" bson:"timeout"`
-	Tasks              []string        `yaml:"tasks" bson:"tasks"`
-	Tags               []string        `yaml:"tags,omitempty" bson:"tags"`
+	MaxHosts              int             `yaml:"max_hosts" bson:"max_hosts"`
+	SetupGroupFailTask    bool            `yaml:"setup_group_can_fail_task" bson:"setup_group_can_fail_task"`
+	SetupGroupTimeoutSecs int             `yaml:"setup_group_timeout_secs" bson:"setup_group_timeout_secs"`
+	SetupGroup            *YAMLCommandSet `yaml:"setup_group" bson:"setup_group"`
+	TeardownGroup         *YAMLCommandSet `yaml:"teardown_group" bson:"teardown_group"`
+	SetupTask             *YAMLCommandSet `yaml:"setup_task" bson:"setup_task"`
+	TeardownTask          *YAMLCommandSet `yaml:"teardown_task" bson:"teardown_task"`
+	Timeout               *YAMLCommandSet `yaml:"timeout,omitempty" bson:"timeout"`
+	Tasks                 []string        `yaml:"tasks" bson:"tasks"`
+	Tags                  []string        `yaml:"tags,omitempty" bson:"tags"`
 	// ShareProcs causes processes to persist between task group tasks.
 	ShareProcs bool `yaml:"share_processes" bson:"share_processes"`
 }

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -66,24 +66,25 @@ type parserProject struct {
 }
 
 type parserTaskGroup struct {
-	Name               string             `yaml:"name,omitempty"`
-	Priority           int64              `yaml:"priority,omitempty"`
-	Patchable          *bool              `yaml:"patchable,omitempty"`
-	PatchOnly          *bool              `yaml:"patch_only,omitempty"`
-	ExecTimeoutSecs    int                `yaml:"exec_timeout_secs,omitempty"`
-	Stepback           *bool              `yaml:"stepback,omitempty"`
-	MaxHosts           int                `yaml:"max_hosts,omitempty"`
-	SetupGroupFailTask bool               `yaml:"setup_group_can_fail_task,omitempty"`
-	SetupGroup         *YAMLCommandSet    `yaml:"setup_group,omitempty"`
-	TeardownGroup      *YAMLCommandSet    `yaml:"teardown_group,omitempty"`
-	SetupTask          *YAMLCommandSet    `yaml:"setup_task,omitempty"`
-	TeardownTask       *YAMLCommandSet    `yaml:"teardown_task,omitempty"`
-	Timeout            *YAMLCommandSet    `yaml:"timeout,omitempty"`
-	Tasks              []string           `yaml:"tasks,omitempty"`
-	DependsOn          parserDependencies `yaml:"depends_on,omitempty"`
-	Requires           taskSelectors      `yaml:"requires,omitempty"`
-	Tags               parserStringSlice  `yaml:"tags,omitempty"`
-	ShareProcs         bool               `yaml:"share_processes,omitempty"`
+	Name                  string             `yaml:"name,omitempty"`
+	Priority              int64              `yaml:"priority,omitempty"`
+	Patchable             *bool              `yaml:"patchable,omitempty"`
+	PatchOnly             *bool              `yaml:"patch_only,omitempty"`
+	ExecTimeoutSecs       int                `yaml:"exec_timeout_secs,omitempty"`
+	Stepback              *bool              `yaml:"stepback,omitempty"`
+	MaxHosts              int                `yaml:"max_hosts,omitempty"`
+	SetupGroupFailTask    bool               `yaml:"setup_group_can_fail_task,omitempty"`
+	SetupGroupTimeoutSecs int                `yaml:"setup_group_timeout_secs,omitempty"`
+	SetupGroup            *YAMLCommandSet    `yaml:"setup_group,omitempty"`
+	TeardownGroup         *YAMLCommandSet    `yaml:"teardown_group,omitempty"`
+	SetupTask             *YAMLCommandSet    `yaml:"setup_task,omitempty"`
+	TeardownTask          *YAMLCommandSet    `yaml:"teardown_task,omitempty"`
+	Timeout               *YAMLCommandSet    `yaml:"timeout,omitempty"`
+	Tasks                 []string           `yaml:"tasks,omitempty"`
+	DependsOn             parserDependencies `yaml:"depends_on,omitempty"`
+	Requires              taskSelectors      `yaml:"requires,omitempty"`
+	Tags                  parserStringSlice  `yaml:"tags,omitempty"`
+	ShareProcs            bool               `yaml:"share_processes,omitempty"`
 }
 
 func (ptg *parserTaskGroup) name() string   { return ptg.Name }
@@ -525,16 +526,17 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 	}
 	for _, ptg := range tgs {
 		tg := TaskGroup{
-			Name:               ptg.Name,
-			SetupGroupFailTask: ptg.SetupGroupFailTask,
-			SetupGroup:         ptg.SetupGroup,
-			TeardownGroup:      ptg.TeardownGroup,
-			SetupTask:          ptg.SetupTask,
-			TeardownTask:       ptg.TeardownTask,
-			Tags:               ptg.Tags,
-			MaxHosts:           ptg.MaxHosts,
-			Timeout:            ptg.Timeout,
-			ShareProcs:         ptg.ShareProcs,
+			Name:                  ptg.Name,
+			SetupGroupFailTask:    ptg.SetupGroupFailTask,
+			SetupGroupTimeoutSecs: ptg.SetupGroupTimeoutSecs,
+			SetupGroup:            ptg.SetupGroup,
+			TeardownGroup:         ptg.TeardownGroup,
+			SetupTask:             ptg.SetupTask,
+			TeardownTask:          ptg.TeardownTask,
+			Tags:                  ptg.Tags,
+			MaxHosts:              ptg.MaxHosts,
+			Timeout:               ptg.Timeout,
+			ShareProcs:            ptg.ShareProcs,
 		}
 		if tg.MaxHosts < 1 {
 			tg.MaxHosts = 1

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -800,6 +800,7 @@ task_groups:
   share_processes: true
   max_hosts: 2
   setup_group_can_fail_task: true
+  setup_group_timeout_secs: 10
   setup_group:
   - command: shell.exec
     params:
@@ -832,6 +833,7 @@ buildvariants:
 	assert.Equal("example_task_group", tg.Name)
 	assert.Equal(2, tg.MaxHosts)
 	assert.Equal(true, tg.SetupGroupFailTask)
+	assert.Equal(10, tg.SetupGroupTimeoutSecs)
 	assert.Len(tg.Tasks, 2)
 	assert.Len(tg.SetupTask.List(), 1)
 	assert.Len(tg.SetupGroup.List(), 1)


### PR DESCRIPTION
Want users to be able to define their own timeout for setup_group. Note this still only gives an error if setup_group_can_fail_task is also set.