### PR TITLE
EVG-5858: add PR number to commit title

### DIFF
--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -453,6 +453,7 @@ func sendCommitQueueGithubStatus(env evergreen.Environment, pr *github.PullReque
 }
 
 func subscribeMerge(projectID, owner, repo, mergeMethod, patchID string, pr *github.PullRequest) error {
+	commitTitle := *pr.Title + fmt.Sprintf(" (#%s)", *pr.Number)
 	mergeSubscriber := event.NewGithubMergeSubscriber(event.GithubMergeSubscriber{
 		Owner:       owner,
 		Repo:        repo,


### PR DESCRIPTION
Make the commit queue's commit titles consistent with titles created by GitHub