### PR TITLE
EVG-5858: add PR number to commit title

### DIFF
--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -453,13 +453,14 @@ func sendCommitQueueGithubStatus(env evergreen.Environment, pr *github.PullReque
 }
 
 func subscribeMerge(projectID, owner, repo, mergeMethod, patchID string, pr *github.PullRequest) error {
+	commitTitle := *pr.Title + fmt.Sprintf(" (#%d)", *pr.Number)
 	mergeSubscriber := event.NewGithubMergeSubscriber(event.GithubMergeSubscriber{
 		Owner:       owner,
 		Repo:        repo,
 		PRNumber:    *pr.Number,
 		Ref:         *pr.Head.SHA,
 		MergeMethod: mergeMethod,
-		CommitTitle: *pr.Title,
+		CommitTitle: commitTitle,
 	})
 	patchSub := event.NewPatchOutcomeSubscription(patchID, mergeSubscriber)
 	if err := patchSub.Upsert(); err != nil {

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -2,6 +2,7 @@ package units
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -114,7 +115,7 @@ func (s *commitQueueSuite) TestSubscribeMerge() {
 	s.True(ok)
 	s.Equal(s.projectRef.Owner, target.Owner)
 	s.Equal(s.projectRef.Repo, target.Repo)
-	s.Equal(s.pr.GetTitle(), target.CommitTitle)
+	s.Equal(s.pr.GetTitle()+fmt.Sprintf(" (#%d)", *s.pr.Number), target.CommitTitle)
 }
 
 func (s *commitQueueSuite) TestWritePatchInfo() {


### PR DESCRIPTION
Make the commit queue's commit titles consistent with GitHub's