### PR TITLE
EVG-6087 handle other metrics on trend charts

### DIFF
--- a/public/static/app/perf/TestSample.js
+++ b/public/static/app/perf/TestSample.js
@@ -33,7 +33,7 @@ mciModule.factory('TestSample', function() {
     // Returns only the keys that have results stored in them
     this.resultKeys = function(testName){
       var testInfo = this.resultForTest(testName);
-      return _.pluck(_(testInfo.results).pairs().filter(function(x){return typeof(x[1]) == "object" && "ops_per_sec" in x[1]}), 0)
+      return _.pluck(_(testInfo.results).pairs().filter(function(x){return typeof(x[1]) == "object"}), 0)
     }
 
     this.threadsVsOps = function(testName) {
@@ -61,7 +61,7 @@ mciModule.factory('TestSample', function() {
       );
     }
 
-    this.maxThroughputForTest = function(testName){
+    this.maxThroughputForTest = function(testName, metric){
       if(!_.has(this._maxes, testName)){
         var d = this.resultForTest(testName);
         if(!d){
@@ -70,7 +70,7 @@ mciModule.factory('TestSample', function() {
         this._maxes[testName] = _.max(
           _.filter(
             _.pluck(
-              _.values(d.results), 'ops_per_sec'
+              _.values(d.results), metric
             ), numericFilter
           )
         );

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -39,6 +39,7 @@ mciModule.controller('PerfController', function PerfController(
   $scope.perfTagData = {}
   $scope.compareForm = {}
   $scope.savedCompares = []
+  $scope.trendResults = [];
   $scope.jiraHost = $window.jiraHost
 
   $scope.isGraphHidden = function(k){
@@ -301,7 +302,9 @@ mciModule.controller('PerfController', function PerfController(
       if(compareSamples){
         for(var j=0;j<compareSamples.length;j++){
           var compareSeries = compareSamples[j].threadsVsOps(testName);
-          series.push(compareSeries);
+          if (compareSeries) {
+            series.push(compareSeries);
+          }
         }
       }
 
@@ -329,7 +332,13 @@ mciModule.controller('PerfController', function PerfController(
         .data(series)
         .enter().append("g")
         .style("fill", function(d, i) { return z(i); })
-        .attr("transform", function(d, i) { return "translate(" + x1(i) + ",0)"; });
+        .attr("transform", function(d, i) { 
+          let x = x1(i);
+          if (Number.isNaN(x)) {
+            x = 0;
+          }
+          return "translate(" + x + ",0)"; 
+        });
 
       bar.selectAll("rect")
         .data(function(d){return d})
@@ -524,41 +533,30 @@ mciModule.controller('PerfController', function PerfController(
     $scope.addComparisonForm({hash:hash}, true)
   }
 
-  $scope.updateCompares = function(){
-  }
-
   $scope.redrawGraphs = function(){
       setTimeout(function(){
+        $scope.hideEmptyGraphs();
         drawTrendGraph($scope);
         drawDetailGraph($scope.perfSample, $scope.comparePerfSamples, $scope.task.id, $scope.metricSelect.value.key);
       }, 0)
   }
 
-  $scope.enumerateMetrics = function(results) {
-    const metricNames = {
-      "avgDuration": "Average Duration",
-      "avgWorkers": "Average Workers",
-      "throughputOps": "Throughput Ops",
-      "throughputSize": "Throughput Size",
-      "errorRate": "Error Rate",
-      "latency": "Latency",
-      "totalTime": "Total Time",
-      "totalFailures": "Total Failures",
-      "totalErrors": "Total Errors",
-      "totalOperations": "Total Ops",
-      "totalSize": "Total Size",
-      "totalSamples": "Total Samples"
-    };
-
-    var metrics = {};
-    _.each(results, function(result) {
-      _.each(result.rollups.stats, function(metric) {
-        metrics[metric.name] = metricNames[metric.name] ? metricNames[metric.name]:metric.name;
+  $scope.hideEmptyGraphs = function() {
+    let tests = $scope.perfSample && $scope.perfSample.sample && $scope.perfSample.sample.data && $scope.perfSample.sample.data.results;
+    let metric = $scope.metricSelect.value.key;
+    if (tests) {
+      $scope.hiddenGraphs = {};
+      _.each(tests, function(test) {
+        let hasMetric = false;
+        _.each(test.results, function(metrics, threadLevel) {
+          if (metrics[metric]) {
+            hasMetric = true;
+          }
+        })
+        if (!hasMetric) {
+          $scope.hiddenGraphs[test.name] = true;
+        }
       })
-    })
-
-    for (var metric in metrics) {
-      $scope.metricSelect.options = $scope.metricSelect.options.concat({key: metric, name: metrics[metric]});
     }
   }
 
@@ -659,53 +657,66 @@ mciModule.controller('PerfController', function PerfController(
       $scope.buildFailures = data
     });
 
+    let trendDataSuccess = function(data) {
+      promise.then(function(results){
+        $scope.trendResults = $scope.trendResults.concat(data);
+        const whitelist = results.whitelist;
+
+        const outliers = results.points;
+        let rejects = outliers.rejects;
+
+        $scope.allTrendSamples = new TrendSamples($scope.trendResults);
+        // Default filtered to all.
+        $scope.filteredTrendSamples = $scope.allTrendSamples;
+        if(rejects.length) {
+          rejects = _.filter(rejects, function(doc){
+            const matched = _.find(whitelist, _.pick(doc, 'revision', 'project', 'variant', 'task'));
+            return _.isUndefined(matched);
+          });
+          const filtered = _.reject(data, doc => _.contains(rejects, doc.task_id));
+          if (rejects.length != filtered.length) {
+            $scope.filteredTrendSamples = new TrendSamples(filtered);
+          }
+        }
+        $scope.metricSelect.options = $scope.metricSelect.options.concat(
+          _.map(
+            _.without($scope.allTrendSamples.metrics, $scope.metricSelect.default.key), d => ({key: d, name: d}))
+        );
+
+        // Some copy pasted checks
+        if ($scope.conf.enabled){
+          if ($location.hash().length > 0) {
+            try {
+              if ('metric' in hashparsed) {
+                $scope.metricSelect.value = _.findWhere(
+                  $scope.metricSelect.options, {key: hashparsed.metric}
+                ) || $scope.metricSelect.default
+              }
+            } catch (e) {}
+          }
+        }
+      })
+    };
+
     // Populate the trend data
-    const chartDataQ = $http.get("/plugin/json/history/" + $scope.task.id + "/perf").then(
+    let expandedHistoryPromise = $http.get(cedarApp + "/rest/v1/perf/task_name/" + $scope.task.display_name).then(
       function(resp) {
-        promise.then(function(results){
-          const whitelist = results.whitelist;
-
-          const outliers = results.points;
-          let rejects = outliers.rejects;
-
-          $scope.allTrendSamples = new TrendSamples(resp.data);
-          // Default filtered to all.
-          $scope.filteredTrendSamples = $scope.allTrendSamples;
-          if(rejects.length) {
-            rejects = _.filter(rejects, function(doc){
-              const matched = _.find(whitelist, _.pick(doc, 'revision', 'project', 'variant', 'task'));
-              return _.isUndefined(matched);
-            });
-            const filtered = _.reject(resp.data, doc => _.contains(rejects, doc.task_id));
-            if (rejects.length != filtered.length) {
-              $scope.filteredTrendSamples = new TrendSamples(filtered);
-            }
-          }
-          $scope.metricSelect.options = $scope.metricSelect.options.concat(
-            _.map(
-              _.without($scope.allTrendSamples.metrics, $scope.metricSelect.default.key), d => ({key: d, name: d}))
-          );
-
-          // Some copy pasted checks
-          if ($scope.conf.enabled){
-            if ($location.hash().length > 0) {
-              try {
-                if ('metric' in hashparsed) {
-                  $scope.metricSelect.value = _.findWhere(
-                    $scope.metricSelect.options, {key: hashparsed.metric}
-                  ) || $scope.metricSelect.default
-                }
-              } catch (e) {}
-            }
-          }
-        })
-      });
+        let converted = $filter("expandedMetricConverter")(resp.data, $scope.task.execution);
+        trendDataSuccess([converted]);
+      }
+    )
+    let legacyHistoryPromise = $http.get("/plugin/json/history/" + $scope.task.id + "/perf").then(function(resp){
+      trendDataSuccess(resp.data);
+    });
 
     // Once trend chart data and change points get loaded
-    $q.all([chartDataQ, changePointsQ.catch(), buildFailuresQ.catch()])
-      .then(function() {
-        setTimeout(drawTrendGraph, 0, $scope);
-      })
+    var onHistoryRetrieved = function() {
+      $scope.hideEmptyGraphs();
+      //TODO: the 500 ms setTimeout is to work around an ordering inconsistency with $q.all. Need trendDataSuccess to run before drawTrendGraph
+      setTimeout(drawTrendGraph, 500, $scope);
+    };
+    $q.all([expandedHistoryPromise, legacyHistoryPromise, changePointsQ.catch(), buildFailuresQ.catch()])
+      .then(onHistoryRetrieved, onHistoryRetrieved);
   }
 
   if ($scope.conf.enabled){
@@ -745,7 +756,6 @@ mciModule.controller('PerfController', function PerfController(
       function(resp) {
         var formatted = $filter("expandedMetricConverter")(resp.data, $scope.task.execution);
         $scope.perfSample = new TestSample(formatted);
-        $scope.enumerateMetrics(resp.data);
         $http.get("/plugin/json/task/" + $scope.task.id + "/perf/").then((resp) => legacySuccess(formatted, resp),legacyError);
       }, function(error){
         console.log(error);

--- a/public/static/app/perf/trend_chart.js
+++ b/public/static/app/perf/trend_chart.js
@@ -77,8 +77,7 @@ mciModule.factory('DrawPerfTrendChart', function (
     for (var i = 0; i < cfg.knownLevelsCount; i++) colors(i);
 
     var ops = _.pluck(series, cfg.valueAttr);
-    var opsValues = _.pluck(series, 'ops_per_sec_values');
-    var avgOpsPerSec = d3.mean(ops)
+    var opsValues = _.pluck(series, cfg.valueAttr + "_values");
 
     // Currently selcted revision item index
     var currentItemIdx = _.findIndex(series, function(d) {
@@ -126,7 +125,7 @@ mciModule.factory('DrawPerfTrendChart', function (
     // Depend on threadMode, key, activeLevelNames, cfg
     function getCompValues(compSample) {
       if (threadMode == MAXONLY) {
-        return [compSample.maxThroughputForTest(key)]
+        return [compSample.maxThroughputForTest(key, cfg.valueAttr)]
       } else { // All thread levels mode
         var testResult = compSample.resultForTest(key)
         if (testResult) {
@@ -233,7 +232,7 @@ mciModule.factory('DrawPerfTrendChart', function (
       // including undefined values for missing data
       return _.map(activeLevelNames, function(d) {
         var result = _.findWhere(sample.threadResults, {threadLevel: d})
-        return result && result[cfg.valueAttr]
+        return result && (result[cfg.valueAttr]);
       })
     }
 
@@ -243,9 +242,9 @@ mciModule.factory('DrawPerfTrendChart', function (
           if (threadMode == MAXONLY) {
             // In maxonly mode levels contain single (max) item
             // Extract just one ops item
-            return d.threadResults[maxLevelIdx][cfg.valueAttr]
+            return d.threadResults[maxLevelIdx][cfg.valueAttr];
           } else {
-            return getOpsValues(d)
+            return getOpsValues(d);
           }
         })
       )
@@ -322,12 +321,12 @@ mciModule.factory('DrawPerfTrendChart', function (
       var maxline = d3.svg.line()
         .defined(_.identity)
         .x(function(d, i) { return xScale(i) })
-        .y(function(d) { return yScale(d3.max(d.ops_per_sec_values)) })
+        .y(function(d) { return yScale(d3.max(d[cfg.valueAttr + "_values"])) })
 
       var minline = d3.svg.line()
         .defined(_.identity)
         .x(function(d, i) { return xScale(i) })
-        .y(function(d) { return yScale(d3.min(d.ops_per_sec_values)) })
+        .y(function(d) { return yScale(d3.min(d[cfg.valueAttr + "_values"])) })
     }
 
     // Y Axis

--- a/public/static/js/filters/filters.common.js
+++ b/public/static/js/filters/filters.common.js
@@ -433,7 +433,7 @@ filters.common.filter('conditional', function() {
         threads = test.info.args.thread_level;
       } else {
         _.each(test.rollups.stats, function (stat) {
-          if (stat.name === "avgWorkers") {
+          if (stat.name === "WorkersMin") {
             threads = stat.val;
           }
         });

--- a/service/templates/task_perf_data.html
+++ b/service/templates/task_perf_data.html
@@ -184,7 +184,7 @@
       background-color: rgb(0,0,0);
     }
     md-switch.md-default-theme.md-checked .md-thumb, md-switch.md-checked .md-thumb {
-      background-color: rgb(92,184,92); // green;//rgb(255,64,129);
+      background-color: rgb(92,184,92);
     }
     md-switch.md-default-theme.md-checked .md-bar, md-switch.md-checked .md-bar {
       background-color: rgba(92,184,92,0.5);
@@ -287,11 +287,11 @@
         </tr>
         <tr ng-repeat="test in perfSample.testNames()" ng-class="{odd:$odd}">
           <td>[[test]]</td>
-          <td ng-repeat="k in perfSample.threads()">[[perfSample.resultForTest(test).results[k].ops_per_sec | number:0]]</td>
-          <td>[[perfSample.maxThroughputForTest(test) | number:0]]</td>
-          <td ng-repeat="comparison in comparePerfSamples">[[comparison.maxThroughputForTest(test) | number:0]]</td>
-          <td ng-repeat="comparison in comparePerfSamples" ng-style="{backgroundColor:percentToColor(100*percentDiff(perfSample.maxThroughputForTest(test),comparison.maxThroughputForTest(test)))}">
-            [[100*percentDiff(perfSample.maxThroughputForTest(test),comparison.maxThroughputForTest(test)) | number:2]]%
+          <td ng-repeat="k in perfSample.threads()">[[perfSample.resultForTest(test).results[k][metricSelect.value.key] | number:0]]</td>
+          <td>[[perfSample.maxThroughputForTest(test, metricSelect.value.key) | number:0]]</td>
+          <td ng-repeat="comparison in comparePerfSamples">[[comparison.maxThroughputForTest(test, metricSelect.value.key) | number:0]]</td>
+          <td ng-repeat="comparison in comparePerfSamples" ng-style="{backgroundColor:percentToColor(100*percentDiff(perfSample.maxThroughputForTest(test, metricSelect.value.key),comparison.maxThroughputForTest(test, metricSelect.value.key)))}">
+            [[100*percentDiff(perfSample.maxThroughputForTest(test, metricSelect.value.key),comparison.maxThroughputForTest(test, metricSelect.value.key)) | number:2]]%
           </td>
         </tr>
       </table>
@@ -365,8 +365,8 @@
           <div class="col-lg-1 perf-trendchart-sidebar">
               <div class="mono"><a ng-href="/task/[[hoverSamples[k].task_id]]">[[hoverSamples[k].revision | limitTo : 7]]</a></div>
               <div>[[dateLabel]]</div>
-              ops/s:&nbsp;
-              <b>[[hoverSamples[k].ops_per_sec | number:0]]</b>
+              [[metricSelect.value.key]]:&nbsp;
+              <b>[[hoverSamples[k][metricSelect.value.key] | number:0]]</b>
               <div>
                 bfs:&nbsp;
                 <span ng-repeat="bf in bfs">
@@ -402,9 +402,9 @@
                     metric has no data
                   </span>
                   <span ng-if="hoverSamples[k][metricSelect.value.key] != undefined"
-                        ng-style="{backgroundColor: percentToColor(100 * percentDiff(hoverSamples[k].ops_per_sec, compareSamp.maxThroughputForTest(k)))}"
+                        ng-style="{backgroundColor: percentToColor(100 * percentDiff(hoverSamples[k][metricSelect.value.key], compareSamp.maxThroughputForTest(k, metricSelect.value.key)))}"
                   >
-                    [[100*percentDiff(hoverSamples[k][metricSelect.value.key], compareSamp.maxThroughputForTest(k)) | number:1]]%
+                    [[100*percentDiff(hoverSamples[k][metricSelect.value.key], compareSamp.maxThroughputForTest(k, metricSelect.value.key)) | number:1]]%
                     vs [[compareSamp.getLegendName()]]
                   <span>
                 </b>


### PR DESCRIPTION
This is the parts that could be done without MAKE-762. Metrics that are not ops/s should be handled appropriately on the trend charts now, though things that require commit data (x axis, hovering, comparisons) don't yet work for expanded metrics

<img width="1148" alt="Screen Shot 2019-05-09 at 11 08 09 AM" src="https://user-images.githubusercontent.com/29384396/57464617-072cc900-724b-11e9-9925-01fd698f9c58.png">
