### PR TITLE
EVG-6147 restart test-timed-out tasks

### DIFF
--- a/public/static/app/common/RestartUtil.js
+++ b/public/static/app/common/RestartUtil.js
@@ -11,7 +11,7 @@ mciModule.factory('RestartUtil', function($filter) {
       },
       FAILURES: {
         name: 'Failures',
-        matches: function(task) { return task.status == 'failed' }
+        matches: function(task) { return task.status == 'failed' || task.status == 'test-timed-out'}
       },
       SYSTEM_FAILURES: {
         name: 'System Failures',


### PR DESCRIPTION
When trying to restart all failed tasks in a version, we weren't checking the Test Timed Out status, which is still a failure.