### PR TITLE
EVG-6162: pass through a ResultsNotFound error

### DIFF
--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -177,7 +177,7 @@ func (s *CommitQueueSuite) TestCommentTrigger() {
 }
 
 func (s *CommitQueueSuite) TestFindOneId() {
-	db.ClearCollections(Collection)
+	s.NoError(db.ClearCollections(Collection))
 	cq := &CommitQueue{ProjectID: "mci"}
 	s.NoError(InsertQueue(cq))
 

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/db"
 	_ "github.com/evergreen-ci/evergreen/testutil"
+	adb "github.com/mongodb/anser/db"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -173,4 +174,18 @@ func (s *CommitQueueSuite) TestCommentTrigger() {
 
 	action = "deleted"
 	s.False(TriggersCommitQueue(action, comment))
+}
+
+func (s *CommitQueueSuite) TestFindOneId() {
+	db.ClearCollections(Collection)
+	cq := &CommitQueue{ProjectID: "mci"}
+	s.NoError(InsertQueue(cq))
+
+	_, err := FindOneId("mci")
+	s.NoError(err)
+	s.Equal("mci", cq.ProjectID)
+
+	_, err = FindOneId("not_here")
+	s.Error(err)
+	s.True(adb.ResultsNotFound(err))
 }

--- a/model/commitqueue/db.go
+++ b/model/commitqueue/db.go
@@ -42,10 +42,6 @@ func findOne(query db.Q) (*CommitQueue, error) {
 	queue := &CommitQueue{}
 	err := db.FindOneQ(Collection, query, &queue)
 
-	if adb.ResultsNotFound(err) {
-		return nil, nil
-	}
-
 	return queue, err
 }
 


### PR DESCRIPTION
When a project enables the commit queue and a commit queue doesn't yet exist we insert a commit queue into the database.
The check for whether or not a commit queue exists assumes an error is returned when no documents match the query but the error was being swallowed.