### PR TITLE
EVG-6162: include commit queue changes in project events

### DIFF
--- a/service/project.go
+++ b/service/project.go
@@ -180,6 +180,8 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	origProjectRef := *projectRef
+
 	responseRef := struct {
 		Identifier         string                         `json:"identifier"`
 		DisplayName        string                         `json:"display_name"`
@@ -347,7 +349,6 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	projectRef.CommitQueue = commitQueueParams
 
 	catcher := grip.NewSimpleCatcher()
 	for i, trigger := range responseRef.Triggers {
@@ -360,8 +361,6 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusBadRequest, catcher.Resolve())
 		return
 	}
-
-	origProjectRef := *projectRef
 
 	projectRef.DisplayName = responseRef.DisplayName
 	projectRef.RemotePath = responseRef.RemotePath
@@ -376,6 +375,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectRef.Identifier = id
 	projectRef.TracksPushEvents = responseRef.TracksPushEvents
 	projectRef.PRTestingEnabled = responseRef.PRTestingEnabled
+	projectRef.CommitQueue = commitQueueParams
 	projectRef.PatchingDisabled = responseRef.PatchingDisabled
 	projectRef.NotifyOnBuildFailure = responseRef.NotifyOnBuildFailure
 	projectRef.Triggers = responseRef.Triggers


### PR DESCRIPTION
While investigating EVG-6162 it was challenging to track down changes to a project's commit queue because the changes weren't appearing in the project's event log (EVG-5405).
The changes were being made to the projectRef before the original projectRef was preserved.