### PR TITLE
EVG-6143: pass real sender to GitHub merge sender

### DIFF
--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -131,8 +131,11 @@ func SetupEnv(env evergreen.Environment) error {
 	if err == nil && len(githubToken) > 0 {
 		ctx, _ := env.Context()
 		// Github PR Merge
-		var sender send.Sender
-		sender, err = NewGithubPRLogger(ctx, "evergreen", githubToken, sender)
+		githubStatusSender, err := env.GetSender(evergreen.SenderGithubStatus)
+		if err != nil {
+			return errors.Wrap(err, "can't get github status sender")
+		}
+		sender, err := NewGithubPRLogger(ctx, "evergreen", githubToken, githubStatusSender)
 		if err != nil {
 			return errors.Wrap(err, "Failed to setup github merge logger")
 		}
@@ -152,9 +155,9 @@ func SetupEnv(env evergreen.Environment) error {
 		if err = env.SetSender(evergreen.SenderCommitQueueDequeue, sender); err != nil {
 			return errors.WithStack(err)
 		}
-	}
 
-	evergreen.SetEnvironment(env)
+		evergreen.SetEnvironment(env)
+	}
 
 	return nil
 }


### PR DESCRIPTION
A panic occurred when the GitHub merge sender tried to send a message using the GitHub status sender. This happened because when it was instantiated a nil interface was passed in as the GitHub status sender.
This PR is to pass the actual sender.