### PR TITLE
EVG-6143: Fix commit-queue CLI

### DIFF
--- a/command/git_push.go
+++ b/command/git_push.go
@@ -21,9 +21,9 @@ type gitPush struct {
 	// The root directory (locally) that the code is checked out into.
 	// Must be a valid non-blank directory name.
 	Directory      string `yaml:"directory" plugin:"expand"`
-	DryRun         bool   `yaml:"dry_run"`
-	CommitterName  string `yaml:"committer_name"`
-	CommitterEmail string `yaml:"committer_email"`
+	DryRun         bool   `yaml:"dry_run" mapstructure:"dry_run"`
+	CommitterName  string `yaml:"committer_name" mapstructure:"committer_name"`
+	CommitterEmail string `yaml:"committer_email" mapstructure:"committer_email"`
 
 	base
 }


### PR DESCRIPTION
- The committer information was not getting passed through to the git.push task.
- The commit message was not being set to the branch name when not passed in.

Also, clarified the commit message flag.