### PR TITLE
EVG-6039: break down recent_tasks by distro or project

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -616,14 +616,14 @@ func GetRecentTasks(period time.Duration) ([]Task, error) {
 	return tasks, nil
 }
 
-type StatusPair struct {
-	Status string `bson:"status"`
-	Name   string `bson:"name"`
+type Stat struct {
+	Name  string `bson:"name"`
+	Count int    `bson:"count"`
 }
 
 type StatusItem struct {
-	Pair  StatusPair `bson:"pair"`
-	Count int        `bson:"count"`
+	Status string `bson:"status"`
+	Stats  []Stat `bson:"stats"`
 }
 
 func GetRecentTaskStats(period time.Duration, nameKey string) ([]StatusItem, error) {
@@ -641,10 +641,14 @@ func GetRecentTaskStats(period time.Duration, nameKey string) ([]StatusItem, err
 		{"$sort": bson.M{
 			"count": -1,
 		}},
+		{"$group": bson.M{
+			"_id":   "$_id.status",
+			"stats": bson.M{"$push": bson.M{"name": "$_id.name", "count": "$count"}},
+		}},
 		{"$project": bson.M{
-			"_id":   0,
-			"pair":  "$_id",
-			"count": 1,
+			"_id":    0,
+			"status": "$_id",
+			"stats":  1,
 		}},
 	}
 

--- a/model/task/results.go
+++ b/model/task/results.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"encoding/json"
+	"reflect"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -132,4 +133,39 @@ func FilterTasksOnStatus(tasks []Task, statuses ...string) []Task {
 	}
 
 	return out
+}
+
+type Result struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+type ResultCountList struct {
+	Total              []Result `json:"total"`
+	Inactive           []Result `json:"inactive"`
+	Unstarted          []Result `json:"unstarted"`
+	Started            []Result `json:"started"`
+	Succeeded          []Result `json:"succeeded"`
+	Failed             []Result `json:"failed"`
+	SetupFailed        []Result `json:"setup-failed"`
+	SystemFailed       []Result `json:"system-failed"`
+	SystemUnresponsive []Result `json:"system-unresponsive"`
+	SystemTimedOut     []Result `json:"system-timed-out"`
+	TestTimedOut       []Result `json:"test-timed-out"`
+}
+
+func GetResultCountList(results []StatsList) ResultCountList {
+	list := ResultCountList{}
+	listVal := reflect.ValueOf(&list).Elem()
+	listType := listVal.Type()
+	for i := 0; i < listVal.NumField(); i++ {
+		tag, _ := listType.Field(i).Tag.Lookup("json")
+		for _, result := range results {
+			if result.Status == tag {
+				listVal.Field(i).Set(reflect.ValueOf(result.Stats))
+				break
+			}
+		}
+	}
+
+	return list
 }

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -190,6 +190,8 @@ type Connector interface {
 
 	// FindRecentTasks finds tasks that have recently finished.
 	FindRecentTasks(int) ([]task.Task, *task.ResultCounts, error)
+	FindRecentTaskListDistro(int) (*task.ResultCountList, error)
+	FindRecentTaskListProject(int) (*task.ResultCountList, error)
 	// GetHostStatsByDistro returns host stats broken down by distro
 	GetHostStatsByDistro() ([]host.StatsByDistro, error)
 

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -190,8 +190,8 @@ type Connector interface {
 
 	// FindRecentTasks finds tasks that have recently finished.
 	FindRecentTasks(int) ([]task.Task, *task.ResultCounts, error)
-	FindRecentTaskListDistro(int) (*task.ResultCountList, error)
-	FindRecentTaskListProject(int) (*task.ResultCountList, error)
+	FindRecentTaskListDistro(int) (*restModel.APIRecentTaskStatsList, error)
+	FindRecentTaskListProject(int) (*restModel.APIRecentTaskStatsList, error)
 	// GetHostStatsByDistro returns host stats broken down by distro
 	GetHostStatsByDistro() ([]host.StatsByDistro, error)
 

--- a/rest/model/status.go
+++ b/rest/model/status.go
@@ -68,73 +68,19 @@ func (s *APIStatList) BuildFromService(h interface{}) error {
 	return nil
 }
 
-type APIRecentTaskStatsList struct {
-	Total              APIStatList `json:"total"`
-	Inactive           APIStatList `json:"inactive"`
-	Unstarted          APIStatList `json:"unstarted"`
-	Started            APIStatList `json:"started"`
-	Succeeded          APIStatList `json:"succeeded"`
-	Failed             APIStatList `json:"failed"`
-	SetupFailed        APIStatList `json:"setup-failed"`
-	SystemFailed       APIStatList `json:"system-failed"`
-	SystemUnresponsive APIStatList `json:"system-unresponsive"`
-	SystemTimedOut     APIStatList `json:"system-timed-out"`
-	TestTimedOut       APIStatList `json:"test-timed-out"`
-}
+type APIRecentTaskStatsList map[string][]APIStat
 
 func (s *APIRecentTaskStatsList) BuildFromService(h interface{}) error {
 	catcher := grip.NewBasicCatcher()
 	switch v := h.(type) {
-	case task.ResultCountList:
-		apiList := APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.Total))
-		s.Total = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.Inactive))
-		s.Inactive = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.Unstarted))
-		s.Unstarted = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.Started))
-		s.Started = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.Succeeded))
-		s.Succeeded = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.Failed))
-		s.Failed = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.SetupFailed))
-		s.SetupFailed = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.SystemFailed))
-		s.SystemFailed = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.SystemUnresponsive))
-		s.SystemUnresponsive = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.SetupFailed))
-		s.SetupFailed = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.Unstarted))
-		s.SystemTimedOut = apiList
-
-		apiList = APIStatList{}
-		catcher.Add(apiList.BuildFromService(v.TestTimedOut))
-		s.TestTimedOut = apiList
+	case map[string][]task.Stat:
+		for status, stat := range v {
+			list := APIStatList{}
+			catcher.Add(list.BuildFromService(stat))
+			(*s)[status] = list
+		}
 	default:
-		return errors.Errorf("incorrect type when converting result count list (%T)", v)
+		return errors.Errorf("incorrect type when converting APIRecentTaskStatsList (%T)", v)
 	}
 
 	return catcher.Resolve()

--- a/rest/model/status.go
+++ b/rest/model/status.go
@@ -47,6 +47,71 @@ func (apiStatus *APIRecentTaskStats) ToService() (interface{}, error) {
 	return nil, errors.Errorf("ToService() is not implemented for APIRecentTaskStats")
 }
 
+type APIResult struct {
+	Name  APIString `json:"name"`
+	Count int       `json:"count"`
+}
+
+type APIRecentTaskStatsList struct {
+	Total              []APIResult `json:"total"`
+	Inactive           []APIResult `json:"inactive"`
+	Unstarted          []APIResult `json:"unstarted"`
+	Started            []APIResult `json:"started"`
+	Succeeded          []APIResult `json:"succeeded"`
+	Failed             []APIResult `json:"failed"`
+	SetupFailed        []APIResult `json:"setup-failed"`
+	SystemFailed       []APIResult `json:"system-failed"`
+	SystemUnresponsive []APIResult `json:"system-unresponsive"`
+	SystemTimedOut     []APIResult `json:"system-timed-out"`
+	TestTimedOut       []APIResult `json:"test-timed-out"`
+}
+
+func (s *APIRecentTaskStatsList) BuildFromService(h interface{}) error {
+	switch v := h.(type) {
+	case *task.ResultCountList:
+		for _, result := range v.Total {
+			s.Total = append(s.Total, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+		for _, result := range v.Inactive {
+			s.Inactive = append(s.Inactive, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+		for _, result := range v.Unstarted {
+			s.Unstarted = append(s.Unstarted, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+		for _, result := range v.Started {
+			s.Started = append(s.Started, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+		for _, result := range v.Succeeded {
+			s.Succeeded = append(s.Succeeded, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+		for _, result := range v.Failed {
+			s.Failed = append(s.Failed, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+		for _, result := range v.SetupFailed {
+			s.SetupFailed = append(s.SetupFailed, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+		for _, result := range v.SystemFailed {
+			s.SystemFailed = append(s.SystemFailed, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+		for _, result := range v.SystemUnresponsive {
+			s.SystemUnresponsive = append(s.SystemUnresponsive, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+		for _, result := range v.SystemTimedOut {
+			s.SystemTimedOut = append(s.SystemTimedOut, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+		for _, result := range v.TestTimedOut {
+			s.TestTimedOut = append(s.TestTimedOut, APIResult{Name: ToAPIString(result.Name), Count: result.Count})
+		}
+	default:
+		return errors.Errorf("incorrect type when converting result count list (%T)", v)
+	}
+	return nil
+}
+
+func (s *APIRecentTaskStatsList) ToService() (interface{}, error) {
+	return nil, errors.Errorf("ToService() is not implemented for APIRecentTaskStatsList")
+}
+
 // APIHostStatsByDistro is a slice of host stats for a distro
 // the 3 structs below are nested within it
 type APIHostStatsByDistro struct {

--- a/rest/model/status_test.go
+++ b/rest/model/status_test.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIRecentTaskStatsListBuildFromService(t *testing.T) {
+	assert := assert.New(t)
+	service := &task.ResultCountList{
+		Total:    []task.Result{{Name: "d1", Count: 5}, {Name: "d2", Count: 3}},
+		Inactive: []task.Result{{Name: "d1", Count: 3}, {Name: "d2", Count: 2}},
+		Failed:   []task.Result{{Name: "d1", Count: 2}, {Name: "d2", Count: 1}},
+	}
+
+	apiList := APIRecentTaskStatsList{}
+	assert.NoError(apiList.BuildFromService(service))
+	assert.Equal(ToAPIString("d1"), apiList.Total[0].Name)
+	assert.Equal(5, apiList.Total[0].Count)
+	assert.Equal(ToAPIString("d1"), apiList.Inactive[0].Name)
+	assert.Equal(3, apiList.Inactive[0].Count)
+	assert.Empty(apiList.Succeeded)
+}

--- a/rest/model/status_test.go
+++ b/rest/model/status_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestAPIRecentTaskStatsListBuildFromService(t *testing.T) {
 	assert := assert.New(t)
-	service := &task.ResultCountList{
-		Total:    []task.Result{{Name: "d1", Count: 5}, {Name: "d2", Count: 3}},
-		Inactive: []task.Result{{Name: "d1", Count: 3}, {Name: "d2", Count: 2}},
-		Failed:   []task.Result{{Name: "d1", Count: 2}, {Name: "d2", Count: 1}},
+	service := task.ResultCountList{
+		Total:    []task.Stat{{Name: "d1", Count: 5}, {Name: "d2", Count: 3}},
+		Inactive: []task.Stat{{Name: "d1", Count: 3}, {Name: "d2", Count: 2}},
+		Failed:   []task.Stat{{Name: "d1", Count: 2}, {Name: "d2", Count: 1}},
 	}
 
 	apiList := APIRecentTaskStatsList{}

--- a/rest/model/status_test.go
+++ b/rest/model/status_test.go
@@ -3,23 +3,23 @@ package model
 import (
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAPIRecentTaskStatsListBuildFromService(t *testing.T) {
 	assert := assert.New(t)
-	service := task.ResultCountList{
-		Total:    []task.Stat{{Name: "d1", Count: 5}, {Name: "d2", Count: 3}},
-		Inactive: []task.Stat{{Name: "d1", Count: 3}, {Name: "d2", Count: 2}},
-		Failed:   []task.Stat{{Name: "d1", Count: 2}, {Name: "d2", Count: 1}},
-	}
+	service := make(map[string][]task.Stat)
+	service["total"] = []task.Stat{{Name: "d1", Count: 5}, {Name: "d2", Count: 3}}
+	service[evergreen.TaskInactive] = []task.Stat{{Name: "d1", Count: 3}, {Name: "d2", Count: 2}}
+	service[evergreen.TaskFailed] = []task.Stat{{Name: "d1", Count: 2}, {Name: "d2", Count: 1}}
 
 	apiList := APIRecentTaskStatsList{}
 	assert.NoError(apiList.BuildFromService(service))
-	assert.Equal(ToAPIString("d1"), apiList.Total[0].Name)
-	assert.Equal(5, apiList.Total[0].Count)
-	assert.Equal(ToAPIString("d1"), apiList.Inactive[0].Name)
-	assert.Equal(3, apiList.Inactive[0].Count)
-	assert.Empty(apiList.Succeeded)
+	assert.Equal(ToAPIString("d1"), apiList["total"][0].Name)
+	assert.Equal(5, apiList["total"][0].Count)
+	assert.Equal(ToAPIString("d1"), apiList[evergreen.TaskInactive][0].Name)
+	assert.Equal(3, apiList[evergreen.TaskInactive][0].Count)
+	assert.Empty(apiList[evergreen.TaskSucceeded])
 }

--- a/rest/route/status.go
+++ b/rest/route/status.go
@@ -102,7 +102,7 @@ func (h *recentTasksGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	if h.byDistro || h.byProject {
-		var stats *task.ResultCountList
+		var stats *model.APIRecentTaskStatsList
 		if h.byDistro {
 			stats, err = h.sc.FindRecentTaskListDistro(h.minutes)
 		} else {
@@ -112,11 +112,7 @@ func (h *recentTasksGetHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONErrorResponder(err)
 		}
 
-		statsModel := &model.APIRecentTaskStatsList{}
-		if err = statsModel.BuildFromService(stats); err != nil {
-			return gimlet.MakeJSONErrorResponder(err)
-		}
-		return gimlet.NewJSONResponse(statsModel)
+		return gimlet.NewJSONResponse(stats)
 	}
 
 	statsModel := &model.APIRecentTaskStats{}

--- a/rest/route/status_test.go
+++ b/rest/route/status_test.go
@@ -67,18 +67,18 @@ func (s *StatusSuite) SetupSuite() {
 			SystemTimedOut:     9,
 			TestTimedOut:       10,
 		},
-		CachedResultCountList: &task.ResultCountList{
-			Total: []task.Result{
-				{Name: "d1", Count: 3},
-				{Name: "d2", Count: 2},
+		CachedResultCountList: &model.APIRecentTaskStatsList{
+			Total: model.APIStatList{
+				{Name: model.ToAPIString("d1"), Count: 3},
+				{Name: model.ToAPIString("d2"), Count: 2},
 			},
-			Inactive: []task.Result{
-				{Name: "d1", Count: 2},
-				{Name: "d2", Count: 1},
+			Inactive: model.APIStatList{
+				{Name: model.ToAPIString("d1"), Count: 2},
+				{Name: model.ToAPIString("d2"), Count: 1},
 			},
-			Succeeded: []task.Result{
-				{Name: "d1", Count: 1},
-				{Name: "d2", Count: 1},
+			Succeeded: model.APIStatList{
+				{Name: model.ToAPIString("d1"), Count: 1},
+				{Name: model.ToAPIString("d2"), Count: 1},
 			},
 		},
 	}

--- a/rest/route/status_test.go
+++ b/rest/route/status_test.go
@@ -68,15 +68,15 @@ func (s *StatusSuite) SetupSuite() {
 			TestTimedOut:       10,
 		},
 		CachedResultCountList: &model.APIRecentTaskStatsList{
-			Total: model.APIStatList{
+			"total": model.APIStatList{
 				{Name: model.ToAPIString("d1"), Count: 3},
 				{Name: model.ToAPIString("d2"), Count: 2},
 			},
-			Inactive: model.APIStatList{
+			evergreen.TaskInactive: model.APIStatList{
 				{Name: model.ToAPIString("d1"), Count: 2},
 				{Name: model.ToAPIString("d2"), Count: 1},
 			},
-			Succeeded: model.APIStatList{
+			evergreen.TaskSucceeded: model.APIStatList{
 				{Name: model.ToAPIString("d1"), Count: 1},
 				{Name: model.ToAPIString("d2"), Count: 1},
 			},
@@ -208,22 +208,22 @@ func (s *StatusSuite) TestExecuteByDistro() {
 	resp := s.h.Run(context.Background())
 	s.Equal(http.StatusOK, resp.Status())
 	s.NotNil(resp)
-	res := resp.Data().(*model.APIRecentTaskStatsList)
+	res := *resp.Data().(*model.APIRecentTaskStatsList)
 
-	s.Equal(model.ToAPIString("d1"), res.Total[0].Name)
-	s.Equal(3, res.Total[0].Count)
-	s.Equal(model.ToAPIString("d2"), res.Total[1].Name)
-	s.Equal(2, res.Total[1].Count)
+	s.Equal(model.ToAPIString("d1"), res["total"][0].Name)
+	s.Equal(3, res["total"][0].Count)
+	s.Equal(model.ToAPIString("d2"), res["total"][1].Name)
+	s.Equal(2, res["total"][1].Count)
 
-	s.Equal(model.ToAPIString("d1"), res.Inactive[0].Name)
-	s.Equal(2, res.Inactive[0].Count)
-	s.Equal(model.ToAPIString("d2"), res.Inactive[1].Name)
-	s.Equal(1, res.Inactive[1].Count)
+	s.Equal(model.ToAPIString("d1"), res[evergreen.TaskInactive][0].Name)
+	s.Equal(2, res[evergreen.TaskInactive][0].Count)
+	s.Equal(model.ToAPIString("d2"), res[evergreen.TaskInactive][1].Name)
+	s.Equal(1, res[evergreen.TaskInactive][1].Count)
 
-	s.Equal(model.ToAPIString("d1"), res.Succeeded[0].Name)
-	s.Equal(1, res.Succeeded[0].Count)
-	s.Equal(model.ToAPIString("d2"), res.Succeeded[1].Name)
-	s.Equal(1, res.Succeeded[1].Count)
+	s.Equal(model.ToAPIString("d1"), res[evergreen.TaskSucceeded][0].Name)
+	s.Equal(1, res[evergreen.TaskSucceeded][0].Count)
+	s.Equal(model.ToAPIString("d2"), res[evergreen.TaskSucceeded][1].Name)
+	s.Equal(1, res[evergreen.TaskSucceeded][1].Count)
 }
 
 func (s *StatusSuite) TaskTaskType() {


### PR DESCRIPTION
The recent_tasks endpoint shows the number tasks that have completed recently, broken down by status. This will break it down further by distro or project.