### PR TITLE
EVG-6133 prevent status from logging unnecessary errors

### DIFF
--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -422,7 +422,8 @@ func (c *dockerClientImpl) GetDockerStatus(ctx context.Context, containerID stri
 	}
 	container, err := c.GetContainer(ctx, parent, containerID)
 	if err != nil {
-		if strings.Contains(err.Error(), "No such container") {
+		if strings.Contains(err.Error(), "No such container") ||
+			strings.Contains(err.Error(), "Is the docker daemon running?") {
 			return &ContainerStatus{HasStarted: false}, nil
 		}
 		return nil, errors.Wrapf(err, "Error getting container %s", containerID)


### PR DESCRIPTION
Unable to replicate setup failures (I think it may have actually been a rebase issue). Did notice an extra case that should be handled by GetDockerStatus.