### PR TITLE
EVG-5983: if building container image job fails, set parent to decommissioned

### DIFF
--- a/units/building_container_image.go
+++ b/units/building_container_image.go
@@ -120,9 +120,10 @@ func (j *buildingContainerImageJob) Run(ctx context.Context) {
 	}()
 
 	if j.parent.ContainerBuildAttempt >= containerBuildRetries {
-		j.AddError(errors.Wrapf(j.parent.SetTerminated(evergreen.User),
-			"failed 5 times to build and download image '%s' on parent '%s'", j.DockerOptions.Image, j.parent.Id))
-		grip.Warning(message.WrapError(j.Error(), message.Fields{
+		j.AddError(errors.Wrapf(j.parent.SetDecommissioned(evergreen.User, ""), "failed to set parent '%s' to decommissioned", j.parent.Id))
+		err = errors.Errorf("failed %d times to build and download image '%s' on parent '%s'", containerBuildRetries, j.DockerOptions.Image, j.parent.Id)
+		j.AddError(err)
+		grip.Warning(message.WrapError(err, message.Fields{
 			"message":   "building container image job failed",
 			"job_id":    j.ID(),
 			"host_id":   j.parent.Id,


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-5983

* Parent host is set to decommissioned instead of terminated to ensure underlying cloud host is terminated by host termination job.