### PR TITLE
EVG-6142: omit uncommitted changes by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-05-03"
+	ClientVersion = "2019-05-13"
 )
 
 // ConfigSection defines a sub-document in the evegreen config

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -26,6 +26,7 @@ const (
 	messageFlagName       = "message"
 	activeFlagName        = "active"
 	refFlagName           = "ref"
+	workingChangesFlag    = "include-working"
 
 	anserDryRunFlagName      = "dry-run"
 	anserLimitFlagName       = "limit"
@@ -208,6 +209,13 @@ func addRefFlag(flags ...cli.Flag) []cli.Flag {
 		Name:  refFlagName,
 		Usage: "diff with `REF`",
 		Value: "HEAD",
+	})
+}
+
+func addWorkingChangesFlag(flags ...cli.Flag) []cli.Flag {
+	return append(flags, cli.BoolFlag{
+		Name:  workingChangesFlag,
+		Usage: "include non-committed changes",
 	})
 }
 

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -9,24 +9,24 @@ import (
 )
 
 const (
-	confFlagName          = "conf"
-	overwriteConfFlagName = "overwrite"
-	adminFlagsFlagName    = "flags"
-	pathFlagName          = "path"
-	projectFlagName       = "project"
-	variantsFlagName      = "variants"
-	patchIDFlagName       = "patch"
-	moduleFlagName        = "module"
-	yesFlagName           = "yes"
-	tasksFlagName         = "tasks"
-	largeFlagName         = "large"
-	hostFlagName          = "host"
-	startTimeFlagName     = "time"
-	limitFlagName         = "limit"
-	messageFlagName       = "message"
-	activeFlagName        = "active"
-	refFlagName           = "ref"
-	workingChangesFlag    = "include-working"
+	confFlagName           = "conf"
+	overwriteConfFlagName  = "overwrite"
+	adminFlagsFlagName     = "flags"
+	pathFlagName           = "path"
+	projectFlagName        = "project"
+	variantsFlagName       = "variants"
+	patchIDFlagName        = "patch"
+	moduleFlagName         = "module"
+	yesFlagName            = "yes"
+	tasksFlagName          = "tasks"
+	largeFlagName          = "large"
+	hostFlagName           = "host"
+	startTimeFlagName      = "time"
+	limitFlagName          = "limit"
+	messageFlagName        = "message"
+	activeFlagName         = "active"
+	refFlagName            = "ref"
+	uncommittedChangesFlag = "uncommitted"
 
 	anserDryRunFlagName      = "dry-run"
 	anserLimitFlagName       = "limit"
@@ -212,10 +212,10 @@ func addRefFlag(flags ...cli.Flag) []cli.Flag {
 	})
 }
 
-func addWorkingChangesFlag(flags ...cli.Flag) []cli.Flag {
+func addUncommittedChangesFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.BoolFlag{
-		Name:  workingChangesFlag,
-		Usage: "include non-committed changes",
+		Name:  joinFlagNames(uncommittedChangesFlag, "u"),
+		Usage: "include uncommitted changes",
 	})
 }
 

--- a/operations/model.go
+++ b/operations/model.go
@@ -20,12 +20,11 @@ import (
 const localConfigPath = ".evergreen.local.yml"
 
 type ClientProjectConf struct {
-	Name           string   `json:"name" yaml:"name,omitempty"`
-	Default        bool     `json:"default" yaml:"default,omitempty"`
-	Alias          string   `json:"alias" yaml:"alias,omitempty"`
-	Variants       []string `json:"variants" yaml:"variants,omitempty"`
-	Tasks          []string `json:"tasks" yaml:"tasks,omitempty"`
-	IncludeWorking bool     `json:"include_working" yaml:"include_working,omitempty"`
+	Name     string   `json:"name" yaml:"name,omitempty"`
+	Default  bool     `json:"default" yaml:"default,omitempty"`
+	Alias    string   `json:"alias" yaml:"alias,omitempty"`
+	Variants []string `json:"variants" yaml:"variants,omitempty"`
+	Tasks    []string `json:"tasks" yaml:"tasks,omitempty"`
 }
 
 func findConfigFilePath(fn string) (string, error) {
@@ -68,13 +67,14 @@ func findConfigFilePath(fn string) (string, error) {
 // located at ~/.evergreen.yml
 // If you change the JSON tags, you must also change an anonymous struct in hostinit/setup.go
 type ClientSettings struct {
-	APIServerHost string              `json:"api_server_host" yaml:"api_server_host,omitempty"`
-	UIServerHost  string              `json:"ui_server_host" yaml:"ui_server_host,omitempty"`
-	APIKey        string              `json:"api_key" yaml:"api_key,omitempty"`
-	User          string              `json:"user" yaml:"user,omitempty"`
-	Projects      []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
-	Admin         ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`
-	LoadedFrom    string              `json:"-" yaml:"-"`
+	APIServerHost      string              `json:"api_server_host" yaml:"api_server_host,omitempty"`
+	UIServerHost       string              `json:"ui_server_host" yaml:"ui_server_host,omitempty"`
+	APIKey             string              `json:"api_key" yaml:"api_key,omitempty"`
+	User               string              `json:"user" yaml:"user,omitempty"`
+	UncommittedChanges bool                `json:"patch_uncommitted_changes" yaml:"patch_uncommitted_changes,omitempty"`
+	Projects           []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
+	Admin              ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`
+	LoadedFrom         string              `json:"-" yaml:"-"`
 }
 
 func NewClientSettings(fn string) (*ClientSettings, error) {
@@ -292,13 +292,4 @@ func (s *ClientSettings) SetDefaultProject(name string) {
 			Tasks:    []string{},
 		})
 	}
-}
-
-func (s *ClientSettings) FindDefaultWorkingTree(project string) bool {
-	for _, p := range s.Projects {
-		if p.Name == project {
-			return p.IncludeWorking
-		}
-	}
-	return false
 }

--- a/operations/model.go
+++ b/operations/model.go
@@ -20,11 +20,12 @@ import (
 const localConfigPath = ".evergreen.local.yml"
 
 type ClientProjectConf struct {
-	Name     string   `json:"name" yaml:"name,omitempty"`
-	Default  bool     `json:"default" yaml:"default,omitempty"`
-	Alias    string   `json:"alias" yaml:"alias,omitempty"`
-	Variants []string `json:"variants" yaml:"variants,omitempty"`
-	Tasks    []string `json:"tasks" yaml:"tasks,omitempty"`
+	Name           string   `json:"name" yaml:"name,omitempty"`
+	Default        bool     `json:"default" yaml:"default,omitempty"`
+	Alias          string   `json:"alias" yaml:"alias,omitempty"`
+	Variants       []string `json:"variants" yaml:"variants,omitempty"`
+	Tasks          []string `json:"tasks" yaml:"tasks,omitempty"`
+	IncludeWorking bool     `json:"include_working" yaml:"include_working,omitempty"`
 }
 
 func findConfigFilePath(fn string) (string, error) {
@@ -291,4 +292,13 @@ func (s *ClientSettings) SetDefaultProject(name string) {
 			Tasks:    []string{},
 		})
 	}
+}
+
+func (s *ClientSettings) FindDefaultWorkingTree(project string) bool {
+	for _, p := range s.Projects {
+		if p.Name == project {
+			return p.IncludeWorking
+		}
+	}
+	return false
 }

--- a/operations/model_test.go
+++ b/operations/model_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindDefaultAlias(t *testing.T) {
@@ -189,4 +190,35 @@ projects:
 			},
 		},
 	}, *localClientSettings)
+}
+
+func TestLoadWorkingChangesFromFile(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	tmpdir, err := ioutil.TempDir("", "clientsettings")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpdir)
+	globalTestConfigPath := filepath.Join(tmpdir, ".evergreen.test.yml")
+
+	// Working tree : true
+	fileContents := `projects:
+- name: mci
+  default: true
+  include_working: true`
+	require.NoError(ioutil.WriteFile(globalTestConfigPath, []byte(fileContents), 0644))
+	conf, err := NewClientSettings(globalTestConfigPath)
+	require.NoError(err)
+
+	assert.True(conf.FindDefaultWorkingTree("mci"))
+
+	// Working tree: false
+	fileContents = `projects:
+- name: mci
+  default: true`
+	require.NoError(ioutil.WriteFile(globalTestConfigPath, []byte(fileContents), 0644))
+	conf, err = NewClientSettings(globalTestConfigPath)
+	require.NoError(err)
+
+	assert.False(conf.FindDefaultWorkingTree("mci"))
 }

--- a/operations/model_test.go
+++ b/operations/model_test.go
@@ -201,16 +201,13 @@ func TestLoadWorkingChangesFromFile(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 	globalTestConfigPath := filepath.Join(tmpdir, ".evergreen.test.yml")
 
-	// Working tree : true
-	fileContents := `projects:
-- name: mci
-  default: true
-  include_working: true`
+	//Uncommitted changes : true
+	fileContents := `patch_uncommitted_changes: true`
 	require.NoError(ioutil.WriteFile(globalTestConfigPath, []byte(fileContents), 0644))
 	conf, err := NewClientSettings(globalTestConfigPath)
 	require.NoError(err)
 
-	assert.True(conf.FindDefaultWorkingTree("mci"))
+	assert.True(conf.UncommittedChanges)
 
 	// Working tree: false
 	fileContents = `projects:
@@ -220,5 +217,5 @@ func TestLoadWorkingChangesFromFile(t *testing.T) {
 	conf, err = NewClientSettings(globalTestConfigPath)
 	require.NoError(err)
 
-	assert.False(conf.FindDefaultWorkingTree("mci"))
+	assert.False(conf.UncommittedChanges)
 }

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -66,21 +66,21 @@ func Patch() cli.Command {
 				Uncommitted: c.Bool(uncommittedChangesFlag),
 			}
 
-			uncommittedChanges, err := gitUncommittedChanges()
-			if err != nil {
-				return errors.Wrap(err, "can't test for uncommitted changes")
-			}
-
-			if !params.Uncommitted && uncommittedChanges {
-				grip.Infof("Uncommitted changes are omitted from patches by default.\nUse the '--%s' flag to include uncommitted changes.", uncommittedChangesFlag)
-			}
-
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
+			}
+
+			uncommittedChanges, err := gitUncommittedChanges()
+			if err != nil {
+				return errors.Wrap(err, "can't test for uncommitted changes")
+			}
+
+			if (!params.Uncommitted && !conf.UncommittedChanges) && uncommittedChanges {
+				grip.Infof("Uncommitted changes are omitted from patches by default.\nUse the '--%s, -u' flag or the 'patch_uncommitted_changes' field in the Evergreen yaml file to include uncommitted changes.", uncommittedChangesFlag)
 			}
 
 			comm := conf.GetRestCommunicator(ctx)

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -17,7 +17,7 @@ const (
 )
 
 func getPatchFlags(flags ...cli.Flag) []cli.Flag {
-	return mergeFlagSlices(addProjectFlag(flags...), addVariantsFlag(), addTasksFlag(), addLargeFlag(), addYesFlag(), addRefFlag(), addWorkingChangesFlag(
+	return mergeFlagSlices(addProjectFlag(flags...), addVariantsFlag(), addTasksFlag(), addLargeFlag(), addYesFlag(), addRefFlag(), addUncommittedChangesFlag(
 		cli.StringFlag{
 			Name:  joinFlagNames(patchDescriptionFlagName, "d"),
 			Usage: "description for the patch",
@@ -62,7 +62,7 @@ func Patch() cli.Command {
 				Large:       c.Bool(largeFlagName),
 				Alias:       c.String(patchAliasFlagName),
 				Ref:         c.String(refFlagName),
-				WorkingTree: c.Bool(workingChangesFlag),
+				Uncommitted: c.Bool(uncommittedChangesFlag),
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -17,7 +17,7 @@ const (
 )
 
 func getPatchFlags(flags ...cli.Flag) []cli.Flag {
-	return mergeFlagSlices(addProjectFlag(flags...), addVariantsFlag(), addTasksFlag(), addLargeFlag(), addYesFlag(
+	return mergeFlagSlices(addProjectFlag(flags...), addVariantsFlag(), addTasksFlag(), addLargeFlag(), addYesFlag(), addRefFlag(), addWorkingChangesFlag(
 		cli.StringFlag{
 			Name:  joinFlagNames(patchDescriptionFlagName, "d"),
 			Usage: "description for the patch",
@@ -37,10 +37,6 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 		cli.BoolFlag{
 			Name:  patchVerboseFlagName,
 			Usage: "show patch summary",
-		},
-		cli.StringFlag{
-			Name:  refFlagName,
-			Usage: "diff with `REF`, ignoring working tree changes",
 		}))
 }
 
@@ -66,6 +62,7 @@ func Patch() cli.Command {
 				Large:       c.Bool(largeFlagName),
 				Alias:       c.String(patchAliasFlagName),
 				Ref:         c.String(refFlagName),
+				WorkingTree: c.Bool(workingChangesFlag),
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -63,6 +64,10 @@ func Patch() cli.Command {
 				Alias:       c.String(patchAliasFlagName),
 				Ref:         c.String(refFlagName),
 				Uncommitted: c.Bool(uncommittedChangesFlag),
+			}
+
+			if !params.Uncommitted {
+				grip.Infof("Uncommitted changes are omitted from patches by default.\nUse the '--%s' flag to include uncommitted changes.", uncommittedChangesFlag)
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -66,7 +66,12 @@ func Patch() cli.Command {
 				Uncommitted: c.Bool(uncommittedChangesFlag),
 			}
 
-			if !params.Uncommitted {
+			uncommittedChanges, err := gitUncommittedChanges()
+			if err != nil {
+				return errors.Wrap(err, "can't test for uncommitted changes")
+			}
+
+			if !params.Uncommitted && uncommittedChanges {
 				grip.Infof("Uncommitted changes are omitted from patches by default.\nUse the '--%s' flag to include uncommitted changes.", uncommittedChangesFlag)
 			}
 

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -35,21 +35,21 @@ func PatchSetModule() cli.Command {
 			uncommittedOk := c.Bool(uncommittedChangesFlag)
 			args := c.Args()
 
-			uncommittedChanges, err := gitUncommittedChanges()
-			if err != nil {
-				return errors.Wrap(err, "can't test for uncommitted changes")
-			}
-
-			if !uncommittedOk && uncommittedChanges {
-				grip.Infof("Uncommitted changes are omitted from patches by default.\nUse the '--%s' flag to include uncommitted changes.", uncommittedChangesFlag)
-			}
-
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
+			}
+
+			uncommittedChanges, err := gitUncommittedChanges()
+			if err != nil {
+				return errors.Wrap(err, "can't test for uncommitted changes")
+			}
+
+			if (!uncommittedOk && !conf.UncommittedChanges) && uncommittedChanges {
+				grip.Infof("Uncommitted changes are omitted from patches by default.\nUse the '--%s, -u' flag or the 'patch_uncommitted_changes' field in the Evergreen yaml file to include uncommitted changes.", uncommittedChangesFlag)
 			}
 
 			client := conf.GetRestCommunicator(ctx)

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -18,14 +18,10 @@ func PatchSetModule() cli.Command {
 		Name:    "patch-set-module",
 		Aliases: []string{"set-module"},
 		Usage:   "update or add module to an existing patch",
-		Flags: mergeFlagSlices(addPatchIDFlag(), addPathFlag(), addModuleFlag(), addYesFlag(
+		Flags: mergeFlagSlices(addPatchIDFlag(), addPathFlag(), addModuleFlag(), addYesFlag(), addRefFlag(), addWorkingChangesFlag(
 			cli.BoolFlag{
 				Name:  largeFlagName,
 				Usage: "enable submitting larger patches (>16MB)",
-			},
-			cli.StringFlag{
-				Name:  refFlagName,
-				Usage: "diff with `REF`, ignoring working tree changes",
 			})),
 		Before: mergeBeforeFuncs(requirePatchIDFlag, requireModuleFlag),
 		Action: func(c *cli.Context) error {
@@ -36,6 +32,7 @@ func PatchSetModule() cli.Command {
 			skipConfirm := c.Bool(yesFlagName)
 			project := c.String(projectFlagName)
 			ref := c.String(refFlagName)
+			workingTree := c.Bool(workingChangesFlag)
 			args := c.Args()
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -72,6 +69,10 @@ func PatchSetModule() cli.Command {
 				}
 
 				return errors.Errorf("could not set specified module: \"%s\"", module)
+			}
+
+			if workingTree || conf.FindDefaultWorkingTree(proj.Identifier) {
+				ref = ""
 			}
 
 			// diff against the module branch.

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -32,10 +32,15 @@ func PatchSetModule() cli.Command {
 			skipConfirm := c.Bool(yesFlagName)
 			project := c.String(projectFlagName)
 			ref := c.String(refFlagName)
-			uncommitted := c.Bool(uncommittedChangesFlag)
+			uncommittedOk := c.Bool(uncommittedChangesFlag)
 			args := c.Args()
 
-			if !uncommitted {
+			uncommittedChanges, err := gitUncommittedChanges()
+			if err != nil {
+				return errors.Wrap(err, "can't test for uncommitted changes")
+			}
+
+			if !uncommittedOk && uncommittedChanges {
 				grip.Infof("Uncommitted changes are omitted from patches by default.\nUse the '--%s' flag to include uncommitted changes.", uncommittedChangesFlag)
 			}
 
@@ -75,7 +80,7 @@ func PatchSetModule() cli.Command {
 				return errors.Errorf("could not set specified module: \"%s\"", module)
 			}
 
-			if uncommitted || conf.UncommittedChanges {
+			if uncommittedOk || conf.UncommittedChanges {
 				ref = ""
 			}
 

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -35,6 +35,10 @@ func PatchSetModule() cli.Command {
 			uncommitted := c.Bool(uncommittedChangesFlag)
 			args := c.Args()
 
+			if !uncommitted {
+				grip.Infof("Uncommitted changes are omitted from patches by default.\nUse the '--%s' flag to include uncommitted changes.", uncommittedChangesFlag)
+			}
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -18,7 +18,7 @@ func PatchSetModule() cli.Command {
 		Name:    "patch-set-module",
 		Aliases: []string{"set-module"},
 		Usage:   "update or add module to an existing patch",
-		Flags: mergeFlagSlices(addPatchIDFlag(), addPathFlag(), addModuleFlag(), addYesFlag(), addRefFlag(), addWorkingChangesFlag(
+		Flags: mergeFlagSlices(addPatchIDFlag(), addPathFlag(), addModuleFlag(), addYesFlag(), addRefFlag(), addUncommittedChangesFlag(
 			cli.BoolFlag{
 				Name:  largeFlagName,
 				Usage: "enable submitting larger patches (>16MB)",
@@ -32,7 +32,7 @@ func PatchSetModule() cli.Command {
 			skipConfirm := c.Bool(yesFlagName)
 			project := c.String(projectFlagName)
 			ref := c.String(refFlagName)
-			workingTree := c.Bool(workingChangesFlag)
+			uncommitted := c.Bool(uncommittedChangesFlag)
 			args := c.Args()
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -71,7 +71,7 @@ func PatchSetModule() cli.Command {
 				return errors.Errorf("could not set specified module: \"%s\"", module)
 			}
 
-			if workingTree || conf.FindDefaultWorkingTree(proj.Identifier) {
+			if uncommitted || conf.UncommittedChanges {
 				ref = ""
 			}
 

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -59,6 +59,7 @@ type patchParams struct {
 	Browse      bool
 	Large       bool
 	ShowSummary bool
+	WorkingTree bool
 	Ref         string
 }
 
@@ -179,6 +180,10 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 
 	if err := p.loadTasks(conf); err != nil {
 		grip.Warningf("warning - failed to set default tasks: %v\n", err)
+	}
+
+	if p.WorkingTree || conf.FindDefaultWorkingTree(p.Project) {
+		p.Ref = ""
 	}
 
 	// Validate the project exists

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -417,6 +417,15 @@ func gitLog(base, ref string) (string, error) {
 	return gitCmd("log", args...)
 }
 
+func gitUncommittedChanges() (bool, error) {
+	args := "--porcelain"
+	out, err := gitCmd("status", args)
+	if err != nil {
+		return false, errors.Wrap(err, "can't run git status")
+	}
+	return len(out) != 0, nil
+}
+
 func gitCmd(cmdName string, gitArgs ...string) (string, error) {
 	args := make([]string, 0, 1+len(gitArgs))
 	args = append(args, cmdName)

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -59,7 +59,7 @@ type patchParams struct {
 	Browse      bool
 	Large       bool
 	ShowSummary bool
-	WorkingTree bool
+	Uncommitted bool
 	Ref         string
 }
 
@@ -182,7 +182,7 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 		grip.Warningf("warning - failed to set default tasks: %v\n", err)
 	}
 
-	if p.WorkingTree || conf.FindDefaultWorkingTree(p.Project) {
+	if p.Uncommitted || conf.UncommittedChanges {
 		p.Ref = ""
 	}
 


### PR DESCRIPTION
Reintroduce the changes from #2299 which were reverted in 457e3ec.
The changes not in the last PR begin with b0ae8c4.

The objectives relate to the warning message:
- If patch_uncommitted_changes is set in the user’s ~/.evergreen.yml, the cli shouldn’t print the warning message.
- The cli should mention both the long and short forms `--uncommitted` and `-u` in the warning message.
- The cli should mention setting patch_uncommitted_changes in the ~/.evergreen.yml in addition to mentioning the flag in the warning message.