### PR TITLE
EVG-6198: add logging to track unscheduled bvs

### DIFF
--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -221,12 +221,16 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 	}
 
 	if len(revisions) == 0 {
+		commitSHAs := make([]string, 0, len(commits))
+		for i := range commits {
+			commitSHAs = append(commitSHAs, commits[i].GetSHA())
+		}
 		grip.Info(message.Fields{
 			"source":        "github poller",
 			"message":       "no new revisions",
 			"last_revision": revision,
 			"project":       gRepoPoller.ProjectRef,
-			"commits":       commits,
+			"commits":       commitSHAs,
 		})
 	}
 

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -8,6 +8,8 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/google/go-github/github"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -216,6 +218,16 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 		}
 
 		return []model.Revision{}, revisionError
+	}
+
+	if len(revisions) == 0 {
+		grip.Info(message.Fields{
+			"source":        "github poller",
+			"message":       "no new revisions",
+			"last_revision": revision,
+			"project":       gRepoPoller.ProjectRef,
+			"commits":       commits,
+		})
 	}
 
 	return revisions, nil


### PR DESCRIPTION
Shed light on when the repotracker runs and picks up no revisions.