### PR TITLE
EVG-6169: fix aliases for patch-file command

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-05-13"
+	ClientVersion = "2019-05-20"
 )
 
 // ConfigSection defines a sub-document in the evegreen config

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -133,6 +133,7 @@ func PatchFile() cli.Command {
 				Project:     c.String(projectFlagName),
 				Variants:    c.StringSlice(variantsFlagName),
 				Tasks:       c.StringSlice(tasksFlagName),
+				Alias:       c.String(patchAliasFlagName),
 				SkipConfirm: c.Bool(yesFlagName),
 				Description: c.String(patchDescriptionFlagName),
 				Finalize:    c.Bool(patchFinalizeFlagName),


### PR DESCRIPTION
Aliases were not being read in from the command line.