### PR TITLE
EVG-5823 repotracker inserts tasks in a transaction

### DIFF
--- a/makefile
+++ b/makefile
@@ -392,8 +392,10 @@ mongodb/.get-mongodb:
 get-mongodb: mongodb/.get-mongodb
 	@touch $<
 start-mongod: mongodb/.get-mongodb
-	./mongodb/mongod --dbpath ./mongodb/db_files
+	./mongodb/mongod --dbpath ./mongodb/db_files --port 27017 --replSet evg --bind_ip localhost --smallfiles --oplogSize 10
 	@echo "waiting for mongod to start up"
+init-rs: mongodb/.get-mongodb
+	./mongodb/mongo --eval 'rs.initiate()'
 check-mongod: mongodb/.get-mongodb
 	./mongodb/mongo --nodb --eval "assert.soon(function(x){try{var d = new Mongo(\"localhost:27017\"); return true}catch(e){return false}}, \"timed out connecting\")"
 	@echo "mongod is up"

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -561,7 +562,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	g.TaskID = "task_that_called_generate_task"
 	p, v, t, pm, prevConfig, err := g.NewVersion()
 	s.NoError(err)
-	s.NoError(g.Save(p, v, t, pm, prevConfig))
+	s.NoError(g.Save(context.Background(), p, v, t, pm, prevConfig))
 	builds, err := build.Find(db.Query(bson.M{}))
 	s.NoError(err)
 	tasks := []task.Task{}
@@ -623,7 +624,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 	g.TaskID = "task_that_called_generate_task"
 	p, v, t, pm, prevConfig, err := g.NewVersion()
 	s.NoError(err)
-	s.NoError(g.Save(p, v, t, pm, prevConfig))
+	s.NoError(g.Save(context.Background(), p, v, t, pm, prevConfig))
 	tasks := []task.Task{}
 	err = db.FindAllQ(task.Collection, db.Query(bson.M{}), &tasks)
 	s.NoError(err)
@@ -668,7 +669,7 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 	g.TaskID = "task_that_called_generate_task"
 	p, v, t, pm, prevConfig, err := g.NewVersion()
 	s.Require().NoError(err)
-	s.NoError(g.Save(p, v, t, pm, prevConfig))
+	s.NoError(g.Save(context.Background(), p, v, t, pm, prevConfig))
 
 	tasks := []task.Task{}
 	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{}), &tasks))

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1,11 +1,14 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -450,7 +453,7 @@ func RefreshTasksCache(buildId string) error {
 }
 
 // AddTasksToBuild creates the tasks for the given build of a project
-func AddTasksToBuild(b *build.Build, project *Project, v *Version, taskNames []string,
+func AddTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *Version, taskNames []string,
 	displayNames []string, generatedBy string, tasksInBuild []task.Task) (*build.Build, error) {
 	// find the build variant for this project/build
 	buildVariant := project.FindBuildVariant(b.BuildVariant)
@@ -466,7 +469,7 @@ func AddTasksToBuild(b *build.Build, project *Project, v *Version, taskNames []s
 		return nil, errors.Wrapf(err, "error creating tasks for build '%s'", b.Id)
 	}
 
-	if err = tasks.InsertUnordered(); err != nil {
+	if err = tasks.InsertUnordered(ctx); err != nil {
 		return nil, errors.Wrapf(err, "error inserting tasks for build '%s'", b.Id)
 	}
 
@@ -480,17 +483,18 @@ func AddTasksToBuild(b *build.Build, project *Project, v *Version, taskNames []s
 
 // BuildCreateArgs is the set of parameters used in CreateBuildFromVersion
 type BuildCreateArgs struct {
-	Project      Project        // project to create the build for
-	Version      Version        // the version the build belong to
-	TaskIDs      TaskIdConfig   // pre-generated IDs for the tasks to be created
-	BuildName    string         // name of the buildvariant
-	Activated    bool           // true if the build should be scheduled
-	TaskNames    []string       // names of tasks to create (used in patches). Will create all if nil
-	DisplayNames []string       // names of display tasks to create (used in patches). Will create all if nil
-	GeneratedBy  string         // ID of the task that generated this build
-	SourceRev    string         // githash of the revision that triggered this build
-	DefinitionID string         // definition ID of the trigger used to create this build
-	Aliases      ProjectAliases // project aliases to use to filter tasks created
+	Project      Project              // project to create the build for
+	Version      Version              // the version the build belong to
+	TaskIDs      TaskIdConfig         // pre-generated IDs for the tasks to be created
+	BuildName    string               // name of the buildvariant
+	Activated    bool                 // true if the build should be scheduled
+	TaskNames    []string             // names of tasks to create (used in patches). Will create all if nil
+	DisplayNames []string             // names of display tasks to create (used in patches). Will create all if nil
+	GeneratedBy  string               // ID of the task that generated this build
+	SourceRev    string               // githash of the revision that triggered this build
+	DefinitionID string               // definition ID of the trigger used to create this build
+	Aliases      ProjectAliases       // project aliases to use to filter tasks created
+	Session      mongo.SessionContext // session context to use for transactions
 }
 
 // CreateBuildFromVersion creates a build given all of the necessary information
@@ -556,7 +560,7 @@ func CreateBuildFromVersion(args BuildCreateArgs) (string, error) {
 		return "", errors.Wrapf(err, "error creating tasks for build %s", b.Id)
 	}
 
-	if err = tasksForBuild.InsertUnordered(); err != nil {
+	if err = tasksForBuild.InsertUnordered(args.Session); err != nil {
 		return "", errors.Wrapf(err, "error inserting task for build '%s'", buildId)
 	}
 
@@ -571,8 +575,8 @@ func CreateBuildFromVersion(args BuildCreateArgs) (string, error) {
 	b.Tasks = CreateTasksCache(tasks)
 
 	// insert the build
-	err = b.Insert()
-	if err != nil && !db.IsDuplicateKey(err) {
+	_, err = evergreen.GetEnvironment().DB().Collection(build.Collection).InsertOne(args.Session, b)
+	if err != nil {
 		return "", errors.Wrapf(err, "error inserting build %v", b.Id)
 	}
 
@@ -1245,7 +1249,7 @@ func AddNewBuilds(activated bool, v *Version, p *Project, tasks TaskVariantPairs
 
 // Given a version and set of variant/task pairs, creates any tasks that don't exist yet,
 // within the set of already existing builds.
-func AddNewTasks(activated bool, v *Version, p *Project, pairs TaskVariantPairs, generatedBy string) error {
+func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pairs TaskVariantPairs, generatedBy string) error {
 	if v.BuildIds == nil {
 		return nil
 	}
@@ -1289,7 +1293,7 @@ func AddNewTasks(activated bool, v *Version, p *Project, pairs TaskVariantPairs,
 			continue
 		}
 		// Add the new set of tasks to the build.
-		if _, err = AddTasksToBuild(&b, p, v, tasksToAdd, displayTasksToAdd, generatedBy, tasksInBuild); err != nil {
+		if _, err = AddTasksToBuild(ctx, &b, p, v, tasksToAdd, displayTasksToAdd, generatedBy, tasksInBuild); err != nil {
 			return err
 		}
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1036,16 +1036,6 @@ func createDisplayTask(id string, displayName string, execTasks []string,
 	return t, nil
 }
 
-// DeleteBuild removes any record of the build by removing it and all of the tasks that
-// are a part of it from the database.
-func DeleteBuild(id string) error {
-	err := task.RemoveAllWithBuild(id)
-	if err != nil && err != mgo.ErrNotFound {
-		return errors.WithStack(err)
-	}
-	return errors.WithStack(build.Remove(id))
-}
-
 // sortTasks topologically sorts the tasks by dependency, grouping tasks with common dependencies,
 // and alphabetically sorting within groups.
 // All tasks with cross-variant dependencies are at the far right.

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1321,23 +1321,6 @@ func TestDeletingBuild(t *testing.T) {
 				BuildId: "blech",
 			}
 			So(nonMatchingTask.Insert(), ShouldBeNil)
-
-			// delete the build, make sure only it and its tasks are deleted
-
-			So(DeleteBuild(b.Id), ShouldBeNil)
-
-			var err error
-			b, err = build.FindOne(build.ById(b.Id))
-			So(err, ShouldBeNil)
-			So(b, ShouldBeNil)
-
-			matchingTasks, err := task.Find(task.ByBuildId("build"))
-			So(err, ShouldBeNil)
-			So(len(matchingTasks), ShouldEqual, 0)
-
-			nonMatchingTask, err = task.FindOne(task.ById(nonMatchingTask.Id))
-			So(err, ShouldBeNil)
-			So(nonMatchingTask, ShouldNotBeNil)
 		})
 	})
 }

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -90,8 +90,8 @@ func AddNewBuildsForPatch(p *patch.Patch, patchVersion *Version, project *Projec
 
 // Given a patch version and set of variant/task pairs, creates any tasks that don't exist yet,
 // within the set of already existing builds.
-func AddNewTasksForPatch(p *patch.Patch, patchVersion *Version, project *Project, pairs TaskVariantPairs) error {
-	return AddNewTasks(p.Activated, patchVersion, project, pairs, "")
+func AddNewTasksForPatch(ctx context.Context, p *patch.Patch, patchVersion *Version, project *Project, pairs TaskVariantPairs) error {
+	return AddNewTasks(ctx, p.Activated, patchVersion, project, pairs, "")
 }
 
 // IncludePatchDependencies takes a project and a slice of variant/task pairs names

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -659,7 +659,7 @@ func TestAddNewPatch(t *testing.T) {
 	assert.Equal(dbBuild.Tasks[0].DisplayName, "displaytask1")
 	assert.Equal(dbBuild.Tasks[1].DisplayName, "task3")
 
-	assert.NoError(AddNewTasksForPatch(p, v, proj, tasks))
+	assert.NoError(AddNewTasksForPatch(context.Background(), p, v, proj, tasks))
 	dbTasks, err := task.FindWithDisplayTasks(task.ByBuildId(dbBuild.Id))
 	assert.NoError(err)
 	assert.NotNil(dbBuild)
@@ -729,7 +729,7 @@ func TestAddNewPatchWithMissingBaseVersion(t *testing.T) {
 	assert.Equal(dbBuild.Tasks[0].DisplayName, "displaytask1")
 	assert.Equal(dbBuild.Tasks[1].DisplayName, "task3")
 
-	assert.NoError(AddNewTasksForPatch(p, v, proj, tasks))
+	assert.NoError(AddNewTasksForPatch(context.Background(), p, v, proj, tasks))
 	dbTasks, err := task.FindWithDisplayTasks(task.ByBuildId(dbBuild.Id))
 	assert.NoError(err)
 	assert.NotNil(dbBuild)

--- a/model/task/sorter.go
+++ b/model/task/sorter.go
@@ -1,6 +1,11 @@
 package task
 
-import "github.com/evergreen-ci/evergreen/db"
+import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+)
 
 type Tasks []*Task
 
@@ -21,8 +26,9 @@ func (t Tasks) Insert() error {
 	return db.InsertMany(Collection, t.getPayload()...)
 }
 
-func (t Tasks) InsertUnordered() error {
-	return db.InsertManyUnordered(Collection, t.getPayload()...)
+func (t Tasks) InsertUnordered(ctx context.Context) error {
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).InsertMany(ctx, t.getPayload())
+	return err
 }
 
 type ByPriority []string

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -1051,7 +1052,7 @@ func TestBulkInsert(t *testing.T) {
 		Version: "version",
 	}
 	tasks := Tasks{&t1, &t2, &t3}
-	assert.NoError(tasks.InsertUnordered())
+	assert.NoError(tasks.InsertUnordered(context.Background()))
 	dbTasks, err := Find(ByVersion("version"))
 	assert.NoError(err)
 	assert.Len(dbTasks, 3)

--- a/repotracker/github_poller_test.go
+++ b/repotracker/github_poller_test.go
@@ -8,8 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
+
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/google/go-github/github"
@@ -93,6 +97,18 @@ func dropTestDB(t *testing.T) {
 	defer session.Close()
 	require.NoError(t, session.DB(testConfig.Database.DB).DropDatabase(),
 		"Error dropping test database")
+	createTaskCollections()
+}
+
+func createTaskCollections() {
+	cmd := map[string]string{
+		"create": task.Collection,
+	}
+	_ = evergreen.GetEnvironment().DB().RunCommand(nil, cmd)
+	cmd["create"] = build.Collection
+	_ = evergreen.GetEnvironment().DB().RunCommand(nil, cmd)
+	cmd["create"] = model.VersionCollection
+	_ = evergreen.GetEnvironment().DB().RunCommand(nil, cmd)
 }
 
 func TestGetRevisionsSinceWithPaging(t *testing.T) {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -765,7 +765,10 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 			var lastActivated *model.Version
 			lastActivated, err = model.VersionFindOne(model.VersionByLastVariantActivation(ref.Identifier, buildvariant.Name))
 			if err != nil {
-				return errors.Wrap(err, "problem getting activatation time for variant")
+				grip.Error(message.WrapError(err, message.Fields{
+					"message": "error finding last activated",
+					"version": v.Id,
+				}))
 			}
 
 			var lastActivation *time.Time

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -750,12 +750,15 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 			var buildId string
 			buildId, err = model.CreateBuildFromVersion(args)
 			if err != nil {
-				grip.Notice(message.WrapError(sessCtx.AbortTransaction(sessCtx), message.Fields{
-					"message": "aborting transaction",
-					"cause":   "can't insert build items",
-					"variant": buildvariant.Name,
-					"version": v.Id,
-				}))
+				abortErr := sessCtx.AbortTransaction(sessCtx)
+				grip.Notice(message.Fields{
+					"message":    "aborting transaction",
+					"cause":      "can't insert build items",
+					"variant":    buildvariant.Name,
+					"version":    v.Id,
+					"insert_err": err.Error(),
+					"abort_err":  abortErr.Error(),
+				})
 				return errors.Wrapf(err, "error inserting build %s", buildId)
 			}
 
@@ -802,11 +805,14 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 
 		_, err = evergreen.GetEnvironment().DB().Collection(model.VersionCollection).InsertOne(sessCtx, v)
 		if err != nil {
-			grip.Notice(message.WrapError(sessCtx.AbortTransaction(sessCtx), message.Fields{
-				"message": "aborting transaction",
-				"cause":   "can't insert version",
-				"version": v.Id,
-			}))
+			abortErr := sessCtx.AbortTransaction(sessCtx)
+			grip.Notice(message.Fields{
+				"message":    "aborting transaction",
+				"cause":      "can't insert version",
+				"version":    v.Id,
+				"insert_err": err.Error(),
+				"abort_err":  abortErr.Error(),
+			})
 			return errors.Wrapf(err, "error inserting version %s", v.Id)
 		}
 		err = sessCtx.CommitTransaction(sessCtx)

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -3,11 +3,11 @@ package repotracker
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
+	"go.mongodb.org/mongo-driver/mongo"
+
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/manifest"
@@ -299,7 +299,7 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 		metadata := VersionMetadata{
 			Revision: revisions[i],
 		}
-		v, err := CreateVersionFromConfig(ref, project, metadata, ignore, versionErrs)
+		v, err := CreateVersionFromConfig(ctx, ref, project, metadata, ignore, versionErrs)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error creating version",
@@ -569,7 +569,8 @@ func CreateManifest(v model.Version, proj *model.Project, branch string, setting
 	return newManifest, errors.Wrap(err, "error inserting manifest")
 }
 
-func CreateVersionFromConfig(ref *model.ProjectRef, config *model.Project, metadata VersionMetadata, ignore bool, versionErrs *VersionErrors) (*model.Version, error) {
+func CreateVersionFromConfig(ctx context.Context, ref *model.ProjectRef, config *model.Project,
+	metadata VersionMetadata, ignore bool, versionErrs *VersionErrors) (*model.Version, error) {
 	if ref == nil || config == nil {
 		return nil, errors.New("project ref and project cannot be nil")
 	}
@@ -614,8 +615,15 @@ func CreateVersionFromConfig(ref *model.ProjectRef, config *model.Project, metad
 			return v, errors.Wrap(v.Insert(), "error inserting version")
 		}
 	}
+	var aliases model.ProjectAliases
+	if metadata.Alias != "" {
+		aliases, err = model.FindAliasInProject(ref.Identifier, metadata.Alias)
+		if err != nil {
+			return v, errors.Wrap(err, "error finding project alias")
+		}
+	}
 
-	return v, errors.Wrap(createVersionItems(v, ref, metadata, config), "error creating version items")
+	return v, errors.Wrap(createVersionItems(ctx, v, ref, metadata, config, aliases), "error creating version items")
 }
 
 // shellVersionFromRevision populates a new Version with metadata from a model.Revision.
@@ -666,12 +674,16 @@ func shellVersionFromRevision(ref *model.ProjectRef, metadata VersionMetadata) (
 			v.RevisionOrderNumber = num
 		}
 	} else {
-		v.Id = util.CleanName(fmt.Sprintf("%s_%s", ref.String(), metadata.Revision.Revision))
+		v.Id = makeVersionId(ref.String(), metadata.Revision.Revision)
 	}
 	if u != nil {
 		v.AuthorID = u.Id
 	}
 	return v, nil
+}
+
+func makeVersionId(project, revision string) string {
+	return util.CleanName(fmt.Sprintf("%s_%s", project, revision))
 }
 
 // Verifies that the given revision order number is higher than the latest number stored for the project.
@@ -693,130 +705,121 @@ func sanityCheckOrderNum(revOrderNum int, projectId, revision string) error {
 
 // createVersionItems populates and stores all the tasks and builds for a version according to
 // the given project config.
-func createVersionItems(v *model.Version, ref *model.ProjectRef, metadata VersionMetadata, project *model.Project) error {
-	// generate all task Ids so that we can easily reference them for dependencies
-	sourceRev := ""
-	if metadata.SourceVersion != nil {
-		sourceRev = metadata.SourceVersion.Revision
-	}
-	var aliases model.ProjectAliases
-	var err error
-	if metadata.Alias != "" {
-		aliases, err = model.FindAliasInProject(ref.Identifier, metadata.Alias)
-		if err != nil {
-			return errors.Wrap(err, "error finding project alias")
-		}
-	}
-	taskIds := model.NewTaskIdTable(project, v, sourceRev, metadata.DefinitionID)
+func createVersionItems(ctx context.Context, v *model.Version, ref *model.ProjectRef, metadata VersionMetadata, project *model.Project, aliases model.ProjectAliases) error {
+	client := evergreen.GetEnvironment().Client()
 
-	// create all builds for the version
-	for _, buildvariant := range project.BuildVariants {
-		if buildvariant.Disabled {
-			continue
+	return client.UseSession(ctx, func(sessCtx mongo.SessionContext) error {
+		// generate all task Ids so that we can easily reference them for dependencies
+		sourceRev := ""
+		if metadata.SourceVersion != nil {
+			sourceRev = metadata.SourceVersion.Revision
 		}
-		var match bool
-		if len(aliases) > 0 {
-			match, err = aliases.HasMatchingVariant(buildvariant.Name)
-			if err != nil {
-				grip.Error(err)
+		taskIds := model.NewTaskIdTable(project, v, sourceRev, metadata.DefinitionID)
+
+		err := sessCtx.StartTransaction()
+		if err != nil {
+			return errors.Wrap(err, "error starting transaction")
+		}
+		// create all builds for the version
+		for _, buildvariant := range project.BuildVariants {
+			if buildvariant.Disabled {
 				continue
 			}
-			if !match {
-				continue
-			}
-		}
-		args := model.BuildCreateArgs{
-			Project:      *project,
-			Version:      *v,
-			TaskIDs:      taskIds,
-			BuildName:    buildvariant.Name,
-			Activated:    false,
-			SourceRev:    sourceRev,
-			DefinitionID: metadata.DefinitionID,
-			Aliases:      aliases,
-		}
-		var buildId string
-		buildId, err = model.CreateBuildFromVersion(args)
-		if err != nil {
-			if metadata.TriggerID == "" || !strings.Contains(err.Error(), "E11000") {
-				grip.Error(message.WrapError(err, message.Fields{
-					"message": "error inserting build",
-					"version": v.Id,
-					"variant": buildvariant.DisplayName,
-				}))
-			}
-			continue
-		}
-
-		var lastActivated *model.Version
-		lastActivated, err = model.VersionFindOne(model.VersionByLastVariantActivation(ref.Identifier, buildvariant.Name))
-		if err != nil {
-			return errors.Wrap(err, "problem getting activatation time for variant")
-		}
-
-		var lastActivation *time.Time
-		if lastActivated != nil {
-			for _, buildStatus := range lastActivated.BuildVariants {
-				if buildStatus.BuildVariant == buildvariant.Name && buildStatus.Activated {
-					lastActivation = &buildStatus.ActivateAt
-					break
+			var match bool
+			if len(aliases) > 0 {
+				match, err = aliases.HasMatchingVariant(buildvariant.Name)
+				if err != nil {
+					grip.Error(err)
+					continue
+				}
+				if !match {
+					continue
 				}
 			}
-		}
-
-		var activateAt time.Time
-		if lastActivation == nil {
-			// if we don't have a last activation time then prepare to activate it immediately.
-			activateAt = time.Now()
-		} else {
-			activateAt = lastActivation.Add(time.Minute * time.Duration(ref.GetBatchTime(&buildvariant)))
-		}
-
-		grip.Debug(message.Fields{
-			"message": "activating build",
-			"name":    buildvariant.Name,
-			"project": ref.Identifier,
-			"version": v.Id,
-			"time":    activateAt,
-			"runner":  RunnerName,
-		})
-		v.BuildIds = append(v.BuildIds, buildId)
-		v.BuildVariants = append(v.BuildVariants, model.VersionBuildStatus{
-			BuildVariant: buildvariant.Name,
-			Activated:    false,
-			ActivateAt:   activateAt,
-			BuildId:      buildId,
-		})
-	}
-
-	err = v.Insert()
-	if err != nil {
-		if db.IsDuplicateKey(err) {
-			return nil
-		}
-		grip.Critical(message.WrapError(err, message.Fields{
-			"message": "problem inserting version",
-			"runner":  RunnerName,
-			"id":      v.Id,
-		}))
-		for _, buildStatus := range v.BuildVariants {
-			if buildErr := model.DeleteBuild(buildStatus.BuildId); buildErr != nil {
-				grip.Error(message.WrapError(buildErr, message.Fields{
-					"message":    "issue deleting build",
-					"runner":     RunnerName,
-					"version_id": v.Id,
-					"build_id":   buildStatus.BuildId,
-				}))
+			args := model.BuildCreateArgs{
+				Project:      *project,
+				Version:      *v,
+				TaskIDs:      taskIds,
+				BuildName:    buildvariant.Name,
+				Activated:    false,
+				SourceRev:    sourceRev,
+				DefinitionID: metadata.DefinitionID,
+				Aliases:      aliases,
+				Session:      sessCtx,
 			}
+			var buildId string
+			buildId, err = model.CreateBuildFromVersion(args)
+			if err != nil {
+				grip.Notice(message.WrapError(sessCtx.AbortTransaction(sessCtx), message.Fields{
+					"message": "aborting transaction",
+					"cause":   "can't insert build items",
+					"variant": buildvariant.Name,
+					"version": v.Id,
+				}))
+				return errors.Wrapf(err, "error inserting build %s", buildId)
+			}
+
+			var lastActivated *model.Version
+			lastActivated, err = model.VersionFindOne(model.VersionByLastVariantActivation(ref.Identifier, buildvariant.Name))
+			if err != nil {
+				return errors.Wrap(err, "problem getting activatation time for variant")
+			}
+
+			var lastActivation *time.Time
+			if lastActivated != nil {
+				for _, buildStatus := range lastActivated.BuildVariants {
+					if buildStatus.BuildVariant == buildvariant.Name && buildStatus.Activated {
+						lastActivation = &buildStatus.ActivateAt
+						break
+					}
+				}
+			}
+
+			var activateAt time.Time
+			if lastActivation == nil {
+				// if we don't have a last activation time then prepare to activate it immediately.
+				activateAt = time.Now()
+			} else {
+				activateAt = lastActivation.Add(time.Minute * time.Duration(ref.GetBatchTime(&buildvariant)))
+			}
+
+			grip.Debug(message.Fields{
+				"message": "activating build",
+				"name":    buildvariant.Name,
+				"project": ref.Identifier,
+				"version": v.Id,
+				"time":    activateAt,
+				"runner":  RunnerName,
+			})
+			v.BuildIds = append(v.BuildIds, buildId)
+			v.BuildVariants = append(v.BuildVariants, model.VersionBuildStatus{
+				BuildVariant: buildvariant.Name,
+				Activated:    false,
+				ActivateAt:   activateAt,
+				BuildId:      buildId,
+			})
 		}
-		return errors.WithStack(err)
-	}
-	grip.Info(message.Fields{
-		"message": "successfully created version",
-		"version": v.Id,
-		"hash":    v.Revision,
-		"project": v.Branch,
-		"runner":  RunnerName,
+
+		_, err = evergreen.GetEnvironment().DB().Collection(model.VersionCollection).InsertOne(sessCtx, v)
+		if err != nil {
+			grip.Notice(message.WrapError(sessCtx.AbortTransaction(sessCtx), message.Fields{
+				"message": "aborting transaction",
+				"cause":   "can't insert version",
+				"version": v.Id,
+			}))
+			return errors.Wrapf(err, "error inserting version %s", v.Id)
+		}
+		err = sessCtx.CommitTransaction(sessCtx)
+		if err != nil {
+			return errors.Wrapf(err, "error committing transaction for version %s", v.Id)
+		}
+		grip.Info(message.Fields{
+			"message": "successfully created version",
+			"version": v.Id,
+			"hash":    v.Revision,
+			"project": v.Branch,
+			"runner":  RunnerName,
+		})
+		return nil
 	})
-	return nil
 }

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -820,6 +820,10 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 		}
 		err = sessCtx.CommitTransaction(sessCtx)
 		if err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "unable to commit transaction",
+				"version": v.Id,
+			}))
 			return errors.Wrapf(err, "error committing transaction for version %s", v.Id)
 		}
 		grip.Info(message.Fields{

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -92,7 +92,7 @@ type Connector interface {
 	// GetVersionsAndVariants returns recent versions for a project
 	GetVersionsAndVariants(int, int, *model.Project) (*restModel.VersionVariantData, error)
 	GetProjectEventLog(string, time.Time, int) ([]restModel.APIProjectEvent, error)
-	CreateVersionFromConfig(string, []byte, *user.DBUser, string, bool) (*model.Version, error)
+	CreateVersionFromConfig(context.Context, string, []byte, *user.DBUser, string, bool) (*model.Version, error)
 
 	// FindByProjectAndCommit is a method to find a set of tasks which ran as part of
 	// certain version in a project. It takes the projectId, commit hash, and a taskId

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -306,7 +307,7 @@ func addFailedAndStartedTests(rows map[string]restModel.BuildList, failedAndStar
 	return nil
 }
 
-func (vc *DBVersionConnector) CreateVersionFromConfig(projectID string, config []byte, user *user.DBUser, message string, active bool) (*model.Version, error) {
+func (vc *DBVersionConnector) CreateVersionFromConfig(ctx context.Context, projectID string, config []byte, user *user.DBUser, message string, active bool) (*model.Version, error) {
 	ref, err := model.FindOneProjectRef(projectID)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
@@ -333,7 +334,7 @@ func (vc *DBVersionConnector) CreateVersionFromConfig(projectID string, config [
 		User:    user,
 		Message: message,
 	}
-	newVersion, err := repotracker.CreateVersionFromConfig(ref, project, metadata, false, nil)
+	newVersion, err := repotracker.CreateVersionFromConfig(ctx, ref, project, metadata, false, nil)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
@@ -430,6 +431,6 @@ func (mvc *MockVersionConnector) GetVersionsAndVariants(skip, numVersionElements
 	return nil, nil
 }
 
-func (mvc *MockVersionConnector) CreateVersionFromConfig(projectID string, config []byte, user *user.DBUser, message string, active bool) (*model.Version, error) {
+func (mvc *MockVersionConnector) CreateVersionFromConfig(ctx context.Context, projectID string, config []byte, user *user.DBUser, message string, active bool) (*model.Version, error) {
 	return nil, nil
 }

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -429,7 +430,7 @@ func TestCreateVersionFromConfig(t *testing.T) {
 		}`
 
 	dc := DBVersionConnector{}
-	newVersion, err := dc.CreateVersionFromConfig(ref.Identifier, []byte(config1), &u, "my message", true)
+	newVersion, err := dc.CreateVersionFromConfig(context.Background(), ref.Identifier, []byte(config1), &u, "my message", true)
 	assert.NoError(err)
 	assert.Equal("my message", newVersion.Message)
 	assert.Equal(evergreen.VersionCreated, newVersion.Status)
@@ -460,7 +461,7 @@ tasks:
 - name: t1
 `
 
-	newVersion, err = dc.CreateVersionFromConfig(ref.Identifier, []byte(config2), &u, "message 2", true)
+	newVersion, err = dc.CreateVersionFromConfig(context.Background(), ref.Identifier, []byte(config2), &u, "message 2", true)
 	assert.NoError(err)
 	assert.Equal("message 2", newVersion.Message)
 	assert.Equal(evergreen.VersionCreated, newVersion.Status)

--- a/rest/route/version_create.go
+++ b/rest/route/version_create.go
@@ -42,7 +42,7 @@ func (h *versionCreateHandler) Parse(ctx context.Context, r *http.Request) error
 
 func (h *versionCreateHandler) Run(ctx context.Context) gimlet.Responder {
 	u := gimlet.GetUser(ctx).(*user.DBUser)
-	newVersion, err := h.sc.CreateVersionFromConfig(h.ProjectID, h.Config, u, h.Message, h.Active)
+	newVersion, err := h.sc.CreateVersionFromConfig(ctx, h.ProjectID, h.Config, u, h.Message, h.Active)
 	if err != nil {
 		return gimlet.NewJSONErrorResponse(err)
 	}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -70,7 +70,7 @@ variables:
     name: test
     commands:
       - func: get-project
-      - func: set-up-credentials
+      - func: setup-credentials
       - func: run-make
         vars:
           target: revendor
@@ -80,8 +80,8 @@ variables:
     name: test
     commands:
       - func: get-project
-      - func: set-up-credentials
-      - func: set-up-mongodb
+      - func: setup-credentials
+      - func: setup-mongodb
 #      - func: setup-docker-host
       - func: run-make
         vars:
@@ -94,8 +94,8 @@ variables:
     name: test
     commands:
       - func: get-project
-      - func: set-up-credentials
-      - func: set-up-mongodb
+      - func: setup-credentials
+      - func: setup-mongodb
       - func: run-make
         vars:
           target: revendor
@@ -109,7 +109,7 @@ variables:
           exec_timeout_secs: 900
           timeout_secs: 900
       - func: get-project
-      - func: set-up-mongodb
+      - func: setup-mongodb
       - func: run-make
         vars: { target: "set-var" }
       - func: run-make
@@ -187,7 +187,7 @@ functions:
         VENDOR_PKG: "github.com/${trigger_repo_owner}/${trigger_repo_name}"
         VENDOR_REVISION: ${trigger_revision}
         XC_BUILD: ${xc_build}
-  set-up-credentials:
+  setup-credentials:
     command: subprocess.exec
     type: setup
     params:
@@ -202,7 +202,7 @@ functions:
         AWS_KEY: ${aws_key}
         AWS_SECRET: ${aws_secret}
       command: bash scripts/setup-credentials.sh
-  set-up-mongodb:
+  setup-mongodb:
     - command: subprocess.exec
       type: setup
       params:
@@ -222,6 +222,11 @@ functions:
       params:
         working_dir: gopath/src/github.com/evergreen-ci/evergreen
         command: make check-mongod
+    - command: subprocess.exec
+      type: setup
+      params:
+        working_dir: gopath/src/github.com/evergreen-ci/evergreen/
+        command: make init-rs
 #  setup-docker-host:
 #    - command: host.create
 #      type: setup
@@ -280,8 +285,8 @@ tasks:
     tags: [ "report" ]
     commands:
       - func: get-project
-      - func: set-up-credentials
-      - func: set-up-mongodb
+      - func: setup-credentials
+      - func: setup-mongodb
       - func: run-make
         vars:
           target: "coverage-html"

--- a/service/patch.go
+++ b/service/patch.go
@@ -172,7 +172,7 @@ func (uis *UIServer) schedulePatch(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// First add new tasks to existing builds, if necessary
-		err = model.AddNewTasksForPatch(projCtx.Patch, projCtx.Version, project, tasks)
+		err = model.AddNewTasksForPatch(context.Background(), projCtx.Patch, projCtx.Version, project, tasks)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError,
 				errors.Wrapf(err, "Error creating new tasks for version `%s`", projCtx.Version.Id))

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -51,7 +51,7 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 	}
 
 	// create version
-	v, err := repotracker.CreateVersionFromConfig(&args.DownstreamProject, config, metadata, false, nil)
+	v, err := repotracker.CreateVersionFromConfig(context.Background(), &args.DownstreamProject, config, metadata, false, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating version")
 	}

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -81,7 +81,7 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 			if err = validator.CheckProjectConfigurationIsValid(p); err != nil {
 				return false, err
 			}
-			err = g.Save(p, v, t, pm, prevConfig)
+			err = g.Save(ctx, p, v, t, pm, prevConfig)
 			if err != nil && adb.ResultsNotFound(err) {
 				return true, gimlet.ErrorResponse{
 					StatusCode: http.StatusInternalServerError,


### PR DESCRIPTION
Inserting version, build, and task documents are in the same transaction which will abort if any errors (including non-db errors potentially). All db tests now run with a single node replica set which doesn't seem to add any noticeable overhead