### PR TITLE
EVG-5878 create new patch alias for copied projects

### DIFF
--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -135,6 +135,23 @@ func (s *ProjectAliasSuite) TestFindAliasInProject() {
 	s.Len(found, 2)
 }
 
+func (s *ProjectAliasSuite) TestUpsertAliasesForProject() {
+	for _, a := range s.aliases {
+		a.ProjectID = "old-project"
+		s.NoError(a.Upsert())
+	}
+	s.NoError(UpsertAliasesForProject(s.aliases, "new-project"))
+
+	found, err := FindAliasesForProject("new-project")
+	s.NoError(err)
+	s.Len(found, 10)
+
+	// verify old aliases not overwritten
+	found, err = FindAliasesForProject("old-project")
+	s.NoError(err)
+	s.Len(found, 10)
+}
+
 func TestMatching(t *testing.T) {
 	assert := assert.New(t)
 	aliases := ProjectAliases{

--- a/service/project.go
+++ b/service/project.go
@@ -467,7 +467,10 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectAliases = append(projectAliases, responseRef.CommitQueueAliases...)
 	projectAliases = append(projectAliases, responseRef.PatchAliases...)
 	for i := range projectAliases {
-		projectAliases[i].ProjectID = id
+		if projectAliases[i].ProjectID != id { // new project, so we need a new document (new ID)
+			projectAliases[i].ProjectID = id
+			projectAliases[i].ID = ""
+		}
 		catcher.Add(projectAliases[i].Upsert())
 	}
 

--- a/service/project.go
+++ b/service/project.go
@@ -466,13 +466,8 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectAliases = append(projectAliases, responseRef.GitHubAliases...)
 	projectAliases = append(projectAliases, responseRef.CommitQueueAliases...)
 	projectAliases = append(projectAliases, responseRef.PatchAliases...)
-	for i := range projectAliases {
-		if projectAliases[i].ProjectID != id { // new project, so we need a new document (new ID)
-			projectAliases[i].ProjectID = id
-			projectAliases[i].ID = ""
-		}
-		catcher.Add(projectAliases[i].Upsert())
-	}
+
+	catcher.Add(model.UpsertAliasesForProject(projectAliases, id))
 
 	for _, alias := range responseRef.DeleteAliases {
 		catcher.Add(model.RemoveProjectAlias(alias))


### PR DESCRIPTION
Before when we upserted we were modifying the current project's patch aliases to have the new project ID, which is why they "disappeared" for the current project. We should be adding a new alias document.