### PR TITLE
EVG-6159: make display task status consistent with exec tasks

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1065,7 +1065,7 @@ func UpdateDisplayTask(t *task.Task) error {
 			hasUnfinishedTasks = true
 		}
 		// the display task's status will be the highest priority of its exec tasks
-		statuses = append(statuses, execTask.ResultStatus())
+		statuses = append(statuses, execTask.Status)
 
 		// add up the duration of the execution tasks as the cumulative time taken
 		timeTaken += execTask.TimeTaken

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2225,8 +2225,12 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	}
 	assert.NoError(dt2.Insert())
 	task1 := task.Task{
-		Id:         "task1",
-		Status:     evergreen.TaskFailed,
+		Id:     "task1",
+		Status: evergreen.TaskFailed,
+		Details: apimodels.TaskEndDetail{
+			Status: evergreen.TaskFailed,
+			Type:   evergreen.CommandTypeSetup,
+		},
 		TimeTaken:  3 * time.Minute,
 		StartTime:  time.Date(2000, 0, 0, 1, 1, 1, 0, time.Local),
 		FinishTime: time.Date(2000, 0, 0, 1, 9, 1, 0, time.Local),


### PR DESCRIPTION
Restarting tasks checks that the status is a finished status (either "failed" or "succeeded"). However, for display tasks if an execution task system-failed the status would be "system-failed", so it would not be restarted.
This PR is to make exec task and display task statuses consistent.