### PR TITLE
EVG-6159: restart system failed tasks

### DIFF
--- a/model/build/task_cache_test.go
+++ b/model/build/task_cache_test.go
@@ -5,7 +5,9 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,20 +28,33 @@ func TestUpdateCachedTask(t *testing.T) {
 	assert.NoError(b.Insert())
 
 	//test that invalid inputs error
-	assert.Error(UpdateCachedTask("", b.Tasks[0].Id, evergreen.TaskDispatched, 0))
-	assert.Error(UpdateCachedTask(b.Id, "", evergreen.TaskDispatched, 0))
-	assert.Error(UpdateCachedTask(b.Id, b.Tasks[0].Id, "", 0))
+	assert.Error(UpdateCachedTask(nil, 0))
+	assert.Error(UpdateCachedTask(&task.Task{Id: "", BuildId: "build1", Status: evergreen.TaskUndispatched}, 0))
+	assert.Error(UpdateCachedTask(&task.Task{Id: "task1", BuildId: "", Status: evergreen.TaskUndispatched}, 0))
+	assert.Error(UpdateCachedTask(&task.Task{Id: "task1", BuildId: "build1", Status: ""}, 0))
 
 	// test that status updates work correctly
-	assert.NoError(UpdateCachedTask(b.Id, b.Tasks[0].Id, evergreen.TaskDispatched, 0))
+	assert.NoError(UpdateCachedTask(&task.Task{Id: "task1", BuildId: "build1", Status: evergreen.TaskDispatched}, 0))
 	dbBuild, err := FindOne(ById(b.Id))
 	assert.NoError(err)
 	assert.NotNil(dbBuild)
 	assert.Equal(evergreen.TaskDispatched, dbBuild.Tasks[0].Status)
 
+	// test that failure details updates work correctly
+	assert.NoError(UpdateCachedTask(&task.Task{
+		Id:      "task1",
+		BuildId: "build1",
+		Status:  evergreen.TaskFailed,
+		Details: apimodels.TaskEndDetail{Status: evergreen.TaskFailed, Type: evergreen.CommandTypeSystem},
+	}, 0))
+	dbBuild, err = FindOne(ById(b.Id))
+	assert.NoError(err)
+	assert.NotNil(dbBuild)
+	assert.Equal(evergreen.CommandTypeSystem, dbBuild.Tasks[0].StatusDetails.Type)
+
 	// test that incrementing time taken works correctly
-	assert.NoError(UpdateCachedTask(b.Id, b.Tasks[0].Id, evergreen.TaskSucceeded, 1*time.Second))
-	assert.NoError(UpdateCachedTask(b.Id, b.Tasks[0].Id, evergreen.TaskSucceeded, 3*time.Second))
+	assert.NoError(UpdateCachedTask(&task.Task{Id: "task1", BuildId: "build1", Status: evergreen.TaskSucceeded}, 1*time.Second))
+	assert.NoError(UpdateCachedTask(&task.Task{Id: "task1", BuildId: "build1", Status: evergreen.TaskSucceeded}, 3*time.Second))
 	dbBuild, err = FindOne(ById(b.Id))
 	assert.NoError(err)
 	assert.NotNil(dbBuild)

--- a/model/task/sorter.go
+++ b/model/task/sorter.go
@@ -25,7 +25,7 @@ func (t Tasks) InsertUnordered() error {
 	return db.InsertManyUnordered(Collection, t.getPayload()...)
 }
 
-type ByPriority []string
+type ByPriority []Task
 
 func (p ByPriority) Len() int           { return len(p) }
 func (p ByPriority) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/model/task/sorter.go
+++ b/model/task/sorter.go
@@ -27,6 +27,8 @@ func (t Tasks) InsertUnordered() error {
 
 type ByPriority []Task
 
-func (p ByPriority) Len() int           { return len(p) }
-func (p ByPriority) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p ByPriority) Less(i, j int) bool { return displayTaskPriority(p[i]) < displayTaskPriority(p[j]) }
+func (p ByPriority) Len() int      { return len(p) }
+func (p ByPriority) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p ByPriority) Less(i, j int) bool {
+	return p[i].displayTaskPriority() < p[j].displayTaskPriority()
+}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -769,28 +769,28 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 
 }
 
-func displayTaskPriority(status string) int {
-	switch status {
-	case evergreen.TaskStarted:
-		return 10
-	case evergreen.TaskUndispatched:
-		return 40
+func displayTaskPriority(t Task) int {
+	switch t.ResultStatus() {
 	case evergreen.TaskFailed:
-		return 50
+		return 10
 	case evergreen.TaskTestTimedOut:
-		return 60
+		return 20
 	case evergreen.TaskSystemFailed:
-		return 70
+		return 30
 	case evergreen.TaskSystemTimedOut:
-		return 80
+		return 40
 	case evergreen.TaskSystemUnresponse:
-		return 90
+		return 50
 	case evergreen.TaskSetupFailed:
-		return 95
+		return 60
 	case evergreen.TaskSucceeded:
-		return 100
+		return 70
 	case evergreen.TaskInactive:
-		return 110
+		return 80
+	case evergreen.TaskStarted:
+		return 90
+	case evergreen.TaskUndispatched:
+		return 100
 	}
 	return 1000
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -769,7 +769,7 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 
 }
 
-func displayTaskPriority(t Task) int {
+func (t *Task) displayTaskPriority() int {
 	switch t.ResultStatus() {
 	case evergreen.TaskFailed:
 		return 10

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1065,7 +1065,7 @@ func UpdateDisplayTask(t *task.Task) error {
 			hasUnfinishedTasks = true
 		}
 		// the display task's status will be the highest priority of its exec tasks
-		statuses = append(statuses, execTask.ResultStatus())
+		statuses = append(statuses, execTask.Status)
 
 		// add up the duration of the execution tasks as the cumulative time taken
 		timeTaken += execTask.TimeTaken

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -427,7 +427,7 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 		if err = UpdateDisplayTask(t.DisplayTask); err != nil {
 			return err
 		}
-		if err = build.UpdateCachedTask(t.DisplayTask.BuildId, t.DisplayTask.Id, t.DisplayTask.Status, t.TimeTaken); err != nil {
+		if err = build.UpdateCachedTask(t, t.TimeTaken); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":    "failed to update cached display task",
 				"function":   "MarkEnd",
@@ -584,7 +584,7 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 			if err = UpdateDisplayTask(displayTask); err != nil {
 				return errors.Wrap(errors.WithStack(err), "error updating display task")
 			}
-			if err = build.UpdateCachedTask(displayTask.BuildId, displayTask.Id, displayTask.Status, 0); err != nil {
+			if err = build.UpdateCachedTask(displayTask, 0); err != nil {
 				return errors.Wrap(errors.WithStack(err), "error updating cached display task")
 			}
 			t = *displayTask
@@ -875,7 +875,7 @@ func updateDisplayTaskAndCache(t *task.Task) error {
 	if err != nil {
 		return errors.Wrap(err, "error updating display task")
 	}
-	return build.UpdateCachedTask(t.DisplayTask.BuildId, t.DisplayTask.Id, t.DisplayTask.Status, 0)
+	return build.UpdateCachedTask(t.DisplayTask, 0)
 }
 
 type RestartTaskOptions struct {
@@ -1002,7 +1002,7 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 	if err = t.MarkSystemFailed(); err != nil {
 		return errors.Wrap(err, "problem marking task failed")
 	}
-	if err := build.UpdateCachedTask(t.BuildId, t.Id, t.Status, 0); err != nil {
+	if err := build.UpdateCachedTask(t, 0); err != nil {
 		return errors.Wrap(err, "problem resetting cached task")
 	}
 
@@ -1037,16 +1037,15 @@ func UpdateDisplayTask(t *task.Task) error {
 	if !t.DisplayOnly {
 		return fmt.Errorf("%s is not a display task", t.Id)
 	}
-	statuses := []string{}
+
 	var timeTaken time.Duration
-	var status string
+	var statusTask task.Task
 	wasFinished := t.IsFinished()
 	execTasks, err := task.Find(task.ByIds(t.ExecutionTasks))
 	if err != nil {
 		return errors.Wrap(err, "error retrieving execution tasks")
 	}
 	hasFinishedTasks := false
-	hasFailedTasks := false
 	hasUnfinishedTasks := false
 	startTime := time.Unix(1<<62, 0)
 	endTime := util.ZeroTime
@@ -1058,14 +1057,10 @@ func UpdateDisplayTask(t *task.Task) error {
 
 		if execTask.IsFinished() {
 			hasFinishedTasks = true
-			if evergreen.IsFailedTaskStatus(execTask.Status) {
-				hasFailedTasks = true
-			}
-		} else if execTask.IsDispatchable() {
+		}
+		if execTask.IsDispatchable() {
 			hasUnfinishedTasks = true
 		}
-		// the display task's status will be the highest priority of its exec tasks
-		statuses = append(statuses, execTask.Status)
 
 		// add up the duration of the execution tasks as the cumulative time taken
 		timeTaken += execTask.TimeTaken
@@ -1079,25 +1074,20 @@ func UpdateDisplayTask(t *task.Task) error {
 		}
 	}
 
-	if hasFailedTasks {
-		// if display task has a failed task, update status
-		sort.Sort(task.ByPriority(statuses))
-		status = statuses[0]
-	} else if hasFinishedTasks && hasUnfinishedTasks {
+	sort.Sort(task.ByPriority(execTasks))
+	statusTask = execTasks[0]
+	if statusTask.Status != evergreen.TaskFailed && (hasFinishedTasks && hasUnfinishedTasks) {
 		// if the display task has a mix of finished and unfinished tasks, the status
 		// will be "started"
-		status = evergreen.TaskStarted
-	} else if len(statuses) > 0 {
-		// the status of the display task will be the status of its constituent task
-		// that is logically the most exclusive
-		sort.Sort(task.ByPriority(statuses))
-		status = statuses[0]
+		statusTask.Status = evergreen.TaskStarted
+		statusTask.Details = apimodels.TaskEndDetail{}
 	}
 
 	update := bson.M{
-		task.StatusKey:    status,
+		task.StatusKey:    statusTask.Status,
 		task.ActivatedKey: t.Activated,
 		task.TimeTakenKey: timeTaken,
+		task.DetailsKey:   statusTask.Details,
 	}
 	if startTime != time.Unix(1<<62, 0) {
 		update[task.StartTimeKey] = startTime
@@ -1117,10 +1107,11 @@ func UpdateDisplayTask(t *task.Task) error {
 		return errors.Wrap(err, "error updating display task")
 	}
 
-	t.Status = status
+	t.Status = statusTask.Status
+	t.Details = statusTask.Details
 	t.TimeTaken = timeTaken
 	if !wasFinished && t.IsFinished() {
-		event.LogDisplayTaskFinished(t.Id, t.Execution, t.Status)
+		event.LogDisplayTaskFinished(t.Id, t.Execution, t.ResultStatus())
 		if t.ResetWhenFinished {
 
 			details := &apimodels.TaskEndDetail{

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2225,8 +2225,12 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	}
 	assert.NoError(dt2.Insert())
 	task1 := task.Task{
-		Id:         "task1",
-		Status:     evergreen.TaskFailed,
+		Id:     "task1",
+		Status: evergreen.TaskFailed,
+		Details: apimodels.TaskEndDetail{
+			Status: evergreen.TaskFailed,
+			Type:   evergreen.CommandTypeSetup,
+		},
 		TimeTaken:  3 * time.Minute,
 		StartTime:  time.Date(2000, 0, 0, 1, 1, 1, 0, time.Local),
 		FinishTime: time.Date(2000, 0, 0, 1, 9, 1, 0, time.Local),

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2359,85 +2359,65 @@ func TestDisplayTaskDelayedRestart(t *testing.T) {
 
 func TestDisplayTaskFailedExecTasks(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.ClearCollections(task.Collection, ProjectRefCollection, distro.Collection, build.Collection))
+	assert.NoError(db.ClearCollections(task.Collection))
 	dt := task.Task{
 		Id:             "task",
-		BuildId:        "build",
-		Activated:      true,
 		DisplayOnly:    true,
-		Status:         evergreen.TaskStarted,
+		Status:         evergreen.TaskUndispatched,
 		ExecutionTasks: []string{"exec0", "exec1"},
 	}
 	assert.NoError(dt.Insert())
-	task2 := task.Task{
+	execTask0 := task.Task{
 		Id:        "exec0",
-		BuildId:   "build",
 		Activated: true,
 		Status:    evergreen.TaskFailed,
-	}
-	assert.NoError(task2.Insert())
-	task3 := task.Task{
-		Id:        "exec1",
-		BuildId:   "build",
-		Activated: true,
-		DependsOn: []task.Dependency{
-			{TaskId: "exec0", Status: evergreen.TaskSucceeded},
-		},
-		Status: evergreen.TaskUndispatched,
-	}
-	assert.NoError(task3.Insert())
-	b := build.Build{
-		Id: "build",
-		Tasks: []build.TaskCache{
-			{Id: "task", Status: evergreen.TaskStarted, Activated: true},
-		},
-	}
-	assert.NoError(b.Insert())
+		Details: apimodels.TaskEndDetail{
+			Status: evergreen.TaskFailed,
+			Type:   evergreen.CommandTypeSystem,
+		}}
+	assert.NoError(execTask0.Insert())
+
+	execTask1 := task.Task{Id: "exec1", Status: evergreen.TaskUndispatched}
+	assert.NoError(execTask1.Insert())
 
 	assert.NoError(UpdateDisplayTask(&dt))
 	dbTask, err := task.FindOne(task.ById(dt.Id))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskFailed, dbTask.Status)
+	assert.Equal(evergreen.CommandTypeSystem, dbTask.Details.Type)
+	assert.True(dbTask.Activated)
 }
 
 func TestDisplayTaskFailedAndSucceededExecTasks(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.ClearCollections(task.Collection, ProjectRefCollection, distro.Collection, build.Collection))
+	assert.NoError(db.ClearCollections(task.Collection))
 	dt := task.Task{
 		Id:             "task",
-		BuildId:        "build",
-		Activated:      true,
 		DisplayOnly:    true,
-		Status:         evergreen.TaskStarted,
+		Status:         evergreen.TaskUndispatched,
 		ExecutionTasks: []string{"exec0", "exec1"},
 	}
 	assert.NoError(dt.Insert())
-	task2 := task.Task{
+	execTask0 := task.Task{
 		Id:        "exec0",
-		BuildId:   "build",
 		Activated: true,
 		Status:    evergreen.TaskFailed,
-	}
-	assert.NoError(task2.Insert())
-	task3 := task.Task{
-		Id:        "exec1",
-		BuildId:   "build",
-		Activated: true,
-		Status:    evergreen.TaskSucceeded,
-	}
-	assert.NoError(task3.Insert())
-	b := build.Build{
-		Id: "build",
-		Tasks: []build.TaskCache{
-			{Id: "task", Status: evergreen.TaskStarted, Activated: true},
+		Details: apimodels.TaskEndDetail{
+			Status: evergreen.TaskFailed,
+			Type:   evergreen.CommandTypeSetup,
 		},
 	}
-	assert.NoError(b.Insert())
+	assert.NoError(execTask0.Insert())
+
+	execTask1 := task.Task{Id: "exec1", Activated: true, Status: evergreen.TaskSucceeded}
+	assert.NoError(execTask1.Insert())
 
 	assert.NoError(UpdateDisplayTask(&dt))
 	dbTask, err := task.FindOne(task.ById(dt.Id))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskFailed, dbTask.Status)
+	assert.Equal(evergreen.CommandTypeSetup, dbTask.Details.Type)
+	assert.True(dbTask.Activated)
 }
 
 func TestEvalStepback(t *testing.T) {


### PR DESCRIPTION
Restarting tasks checks that the status is a finished status (either "failed" or "succeeded"). However, for display tasks if an execution task system-failed the status would be "system-failed", so it would not be restarted.
This PR is to make exec task and display task statuses consistent.