### PR TITLE
EVG-6188 add route to copy project

### DIFF
--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/pkg/errors"
 )
 
 // DBAliasConnector is a struct that implements the Alias related methods
@@ -20,6 +21,20 @@ func (d *DBAliasConnector) FindProjectAliases(projectId string) ([]model.Project
 	return aliases, nil
 }
 
+// CopyProjectAliases finds the aliases for a given project and inserts them for the new project.
+func (d *DBAliasConnector) CopyProjectAliases(oldProjectId, newProjectId string) error {
+	aliases, err := d.FindProjectAliases(oldProjectId)
+	if err != nil {
+		return errors.Wrapf(err, "error finding aliases for project '%s'", oldProjectId)
+	}
+	if aliases != nil {
+		if err = model.UpsertAliasesForProject(aliases, newProjectId); err != nil {
+			return errors.Wrapf(err, "error inserting aliases for project '%s'", newProjectId)
+		}
+	}
+	return nil
+}
+
 // MockAliasConnector is a struct that implements mock versions of
 // Alias-related methods for testing.
 type MockAliasConnector struct{}
@@ -27,4 +42,8 @@ type MockAliasConnector struct{}
 // FindAllAliases is a mock implementation for testing.
 func (d *MockAliasConnector) FindProjectAliases(projectId string) ([]model.ProjectAlias, error) {
 	return nil, nil
+}
+
+func (d *MockAliasConnector) CopyProjectAliases(oldProjectId, newProjectId string) error {
+	return nil
 }

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -3,10 +3,9 @@ package data
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/stretchr/testify/suite"
 )
 
 type AliasSuite struct {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -79,10 +79,11 @@ type Connector interface {
 
 	// Find project variables matching given projectId.
 	FindProjectVarsById(string) (*restModel.APIProjectVars, error)
-	// UpdateProjectVars updates the project using the variables given in the model,
-	// and additionally accepts a list of variables to remove.
+	// UpdateProjectVars updates the project using the variables given in the model.
 	// If successful, updates the given projectVars with the updated projectVars.
 	UpdateProjectVars(string, *restModel.APIProjectVars) error
+	// CopyProjectVars copies the variables for the first project to the second
+	CopyProjectVars(string, string) error
 
 	// Find the project matching the given ProjectId.
 	FindProjectById(string) (*model.ProjectRef, error)
@@ -218,6 +219,8 @@ type Connector interface {
 
 	// FindProjectAliases queries the database to find all aliases.
 	FindProjectAliases(string) ([]model.ProjectAlias, error)
+	// CopyProjectAliases copies aliases from the first project for the second project.
+	CopyProjectAliases(string, string) error
 
 	// TriggerRepotracker creates an amboy job to get the commits from a
 	// Github Push Event

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -276,7 +276,6 @@ func (pc *MockProjectConnector) CopyProjectVars(oldProjectId, newProjectId strin
 			newVars.Vars = v.Vars
 			newVars.PrivateVars = v.PrivateVars
 			pc.CachedVars = append(pc.CachedVars, &newVars)
-			fmt.Println("len: ", len(pc.CachedVars))
 			return nil
 		}
 	}

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -499,3 +499,15 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 	//unsuccessful update
 	s.Error(s.ctx.UpdateProjectVars("not-an-id", &newVars))
 }
+
+func (s *ProjectConnectorGetSuite) TestCopyProjectVars() {
+	s.NoError(s.ctx.CopyProjectVars(projectId, "project-copy"))
+	origProj, err := s.ctx.FindProjectVarsById(projectId)
+	s.NoError(err)
+
+	newProj, err := s.ctx.FindProjectVarsById("project-copy")
+	s.NoError(err)
+
+	s.Equal(origProj.PrivateVars, newProj.PrivateVars)
+	s.Equal(origProj.Vars, newProj.Vars)
+}

--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -56,9 +56,11 @@ func (p *projectCopyHandler) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 
-	// copy project
+	// copy project, disable necessary settings
 	projectToCopy.Identifier = p.newProjectId
 	projectToCopy.Enabled = false
+	projectToCopy.PRTestingEnabled = false
+	projectToCopy.CommitQueue.Enabled = false
 	if err = p.sc.CreateProject(projectToCopy); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error creating project for id '%s'", p.newProjectId))
 	}

--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -1,0 +1,79 @@
+package route
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/pkg/errors"
+)
+
+////////////////////////////////////////////////////////////////////////
+//
+// POST /rest/v2/projects/{project_id}/copy
+
+type projectCopyHandler struct {
+	oldProjectId string
+	newProjectId string
+	sc           data.Connector
+}
+
+func makeCopyProject(sc data.Connector) gimlet.RouteHandler {
+	return &projectCopyHandler{
+		sc: sc,
+	}
+}
+
+func (p *projectCopyHandler) Factory() gimlet.RouteHandler {
+	return &projectCopyHandler{
+		sc: p.sc,
+	}
+}
+
+func (p *projectCopyHandler) Parse(ctx context.Context, r *http.Request) error {
+	p.oldProjectId = gimlet.GetVars(r)["project_id"]
+	p.newProjectId = r.FormValue("new_project")
+	return nil
+}
+
+func (p *projectCopyHandler) Run(ctx context.Context) gimlet.Responder {
+	projectToCopy, err := p.sc.FindProjectById(p.oldProjectId)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error finding project '%s'", p.oldProjectId))
+	}
+
+	// verify project with new ID doesn't exist
+	_, err = p.sc.FindProjectById(p.newProjectId)
+	if err == nil {
+		return gimlet.MakeJSONErrorResponder(errors.Errorf("Project '%s' already exists", p.newProjectId))
+	}
+	if err != nil {
+		apiErr := err.(gimlet.ErrorResponse)
+		if apiErr.StatusCode != http.StatusNotFound {
+			return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error finding project '%s'", p.newProjectId))
+		}
+	}
+
+	// copy project
+	projectToCopy.Identifier = p.newProjectId
+	projectToCopy.Enabled = false
+	if err = p.sc.CreateProject(projectToCopy); err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error creating project for id '%s'", p.newProjectId))
+	}
+	apiProjectRef := &model.APIProjectRef{}
+	if err = apiProjectRef.BuildFromService(*projectToCopy); err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "error building API project from service"))
+	}
+
+	// copy variables and aliases
+	if err = p.sc.CopyProjectVars(p.oldProjectId, p.newProjectId); err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error copying project vars from project '%s'", p.oldProjectId))
+	}
+	if err = p.sc.CopyProjectAliases(p.oldProjectId, p.newProjectId); err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error copying aliases from project '%s'", p.oldProjectId))
+	}
+
+	return gimlet.NewJSONResponse(apiProjectRef)
+}

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -1,0 +1,103 @@
+package route
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/rest/data"
+	restmodel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProjectCopySuite struct {
+	data  data.MockProjectConnector
+	sc    *data.MockConnector
+	route *projectCopyHandler
+
+	suite.Suite
+}
+
+func TestProjectCopySuite(t *testing.T) {
+	suite.Run(t, new(ProjectCopySuite))
+}
+
+func (s *ProjectCopySuite) SetupSuite() {
+	s.data = data.MockProjectConnector{
+		CachedProjects: []model.ProjectRef{
+			{
+				Identifier: "projectA",
+				Branch:     "abcd",
+				Enabled:    true,
+				Admins:     []string{"my-user"},
+			},
+			{
+				Identifier: "projectB",
+				Branch:     "bcde",
+				Enabled:    true,
+				Admins:     []string{"my-user"},
+			},
+		},
+		CachedVars: []*model.ProjectVars{
+			{
+				Id:          "projectA",
+				Vars:        map[string]string{"a": "1", "b": "2"},
+				PrivateVars: map[string]bool{"b": true},
+			},
+		},
+	}
+
+	s.sc = &data.MockConnector{
+		URL:                  "https://evergreen.example.net",
+		MockProjectConnector: s.data,
+	}
+}
+
+func (s *ProjectCopySuite) SetupTest() {
+	s.route = &projectCopyHandler{sc: s.sc}
+}
+
+func (s *ProjectCopySuite) TestParse() {
+	ctx := context.Background()
+	request, err := http.NewRequest("POST", "/projects/projectA/copy?new_project=projectB", nil)
+	options := map[string]string{"project_id": "projectA"}
+	request = gimlet.SetURLVars(request, options)
+	s.NoError(err)
+	s.NoError(s.route.Parse(ctx, request))
+	s.Equal("projectA", s.route.oldProjectId)
+	s.Equal("projectB", s.route.newProjectId)
+}
+
+func (s *ProjectCopySuite) TestCopyToExistingProjectFails() {
+	ctx := context.Background()
+	s.route.oldProjectId = "projectA"
+	s.route.newProjectId = "projectB"
+	resp := s.route.Run(ctx)
+	s.NotNil(resp)
+	s.Equal(http.StatusBadRequest, resp.Status())
+}
+
+func (s *ProjectCopySuite) TestCopyToNewProject() {
+	ctx := context.Background()
+	s.route.oldProjectId = "projectA"
+	s.route.newProjectId = "projectC"
+	resp := s.route.Run(ctx)
+	s.NotNil(resp)
+	s.Equal(http.StatusOK, resp.Status())
+
+	newProject := resp.Data().(*restmodel.APIProjectRef)
+	s.Equal("projectC", restmodel.FromAPIString(newProject.Identifier))
+	s.Equal("abcd", restmodel.FromAPIString(newProject.Branch))
+	s.False(newProject.Enabled)
+	s.Require().Len(newProject.Admins, 1)
+	s.Equal("my-user", restmodel.FromAPIString(newProject.Admins[0]))
+
+	res, err := s.route.sc.FindProjectById("projectC")
+	s.NoError(err)
+	s.NotNil(res)
+	res, err = s.route.sc.FindProjectById("projectA")
+	s.NoError(err)
+	s.NotNil(res)
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -96,6 +96,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}").Version(2).Patch().Wrap(checkUser, addProject, checkProjectAdmin).RouteHandler(makePatchProjectByID(sc))
 	app.AddRoute("/projects/{project_id}/variables").Version(2).Get().Wrap(checkUser, addProject, checkProjectAdmin).RouteHandler(makeGetVariablesByProject(sc))
 	app.AddRoute("/projects/{project_id}/variables").Version(2).Patch().Wrap(checkUser, addProject, checkProjectAdmin).RouteHandler(makePatchVariablesByProject(sc))
+	app.AddRoute("/projects/{project_id}/copy").Version(2).Post().Wrap(checkUser, addProject, checkProjectAdmin).RouteHandler(makeCopyProject(sc))
 	app.AddRoute("/projects/{project_id}/events").Version(2).Get().Wrap(checkUser, addProject, checkProjectAdmin).RouteHandler(makeFetchProjectEvents(sc))
 	app.AddRoute("/projects/{project_id}/patches").Version(2).Get().Wrap(checkUser).RouteHandler(makePatchesByProjectRoute(sc))
 	app.AddRoute("/projects/{project_id}/versions/tasks").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchProjectTasks(sc))


### PR DESCRIPTION
Add route to create a copy of a project. Only available to project admins. Copies project, variables, and aliases, and the new project is disabled.

_Note:_ some project variable things aren't tested to avoid repeated code with EVG-6189. Will rebase on that and add these tests before merging.