### PR TITLE
EVG-6083 add tooltip to variant names on version page

### DIFF
--- a/service/templates/version.html
+++ b/service/templates/version.html
@@ -159,6 +159,9 @@ Evergreen - Version {{Trunc .Version.Version.Revision 10}}
             </div>
              <div ng-repeat="build in version.Builds | orderBy:'Build.display_name'" class="col-lg-4">
                <h4 class="one-liner" style="margin-bottom: 5px;">
+                <md-tooltip md-direction="top" style="padding-top:0; margin-top:0;">
+                  [[build.Build.display_name]]
+                </md-tooltip>
                  <a ng-href="/build/[[build.Build._id]]" class="semi-muted">[[build.Build.display_name]]</a>
                </h4>
                    <build-grid build="build" collapsed="collapsed"></build-grid>


### PR DESCRIPTION
<img width="851" alt="Screen Shot 2019-05-30 at 10 04 01 AM" src="https://user-images.githubusercontent.com/29384396/58638288-746bd100-82c2-11e9-87c0-5769fed9c723.png">
