### PR TITLE
EVG-5946 clarify all dependencies validator

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -196,22 +196,27 @@ func CheckProjectConfigurationIsValid(project *model.Project) error {
 }
 
 // ensure that if any task spec references 'model.AllDependencies', it
-// references no other dependency
+// references no other dependency within the variant
 func checkAllDependenciesSpec(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
 	for _, task := range project.Tasks {
+		coveredVariants := map[string]bool{}
 		if len(task.DependsOn) > 1 {
 			for _, dependency := range task.DependsOn {
 				if dependency.Name == model.AllDependencies {
-					errs = append(errs,
-						ValidationError{
-							Message: fmt.Sprintf("task '%v' in project '%v' "+
-								"contains the all dependencies (%v)' "+
-								"specification and other explicit dependencies",
-								project.Identifier, task.Name,
-								model.AllDependencies),
-						},
-					)
+					// incorrect if no variant specified or this variant has already been covered
+					if dependency.Variant == "" || coveredVariants[dependency.Variant] {
+						errs = append(errs,
+							ValidationError{
+								Message: fmt.Sprintf("task '%v' in project '%v' "+
+									"contains the all dependencies (%v)' "+
+									"specification and other explicit dependencies",
+									task.Name, project.Identifier,
+									model.AllDependencies),
+							},
+						)
+					}
+					coveredVariants[dependency.Variant] = true
 				}
 			}
 		}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -208,9 +208,9 @@ func checkAllDependenciesSpec(project *model.Project) ValidationErrors {
 					if dependency.Variant == "" || coveredVariants[dependency.Variant] {
 						errs = append(errs,
 							ValidationError{
-								Message: fmt.Sprintf("task '%v' in project '%v' "+
-									"contains the all dependencies (%v)' "+
-									"specification and other explicit dependencies",
+								Message: fmt.Sprintf("task '%s' in project '%s' "+
+									"contains the all dependencies (%s)' "+
+									"specification and other explicit dependencies or duplicate variants",
 									task.Name, project.Identifier,
 									model.AllDependencies),
 							},

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -848,6 +848,27 @@ func TestCheckAllDependenciesSpec(t *testing.T) {
 			}
 			So(checkAllDependenciesSpec(project), ShouldResemble, ValidationErrors{})
 		})
+		Convey("if a task references all dependencies on multiple variants, no error should "+
+			" be returned", func() {
+			project := &model.Project{
+				Tasks: []model.ProjectTask{
+					{
+						Name: "coverage",
+						DependsOn: []model.TaskUnitDependency{
+							{
+								Name:    "*",
+								Variant: "ubuntu1604",
+							},
+							{
+								Name:    "*",
+								Variant: "coverage",
+							},
+						},
+					},
+				},
+			}
+			So(checkAllDependenciesSpec(project), ShouldResemble, ValidationErrors{})
+		})
 	})
 }
 


### PR DESCRIPTION
For context, the verifyTaskDependencies validator covers most cases relating to coverage but it doesn't case specially for "*", which is the purpose of the all dependencies validator. 

This validator should consider that you can specify all tasks per variant, and thus multiple dependencies specifying all tasks may still be valid.