### PR TITLE
EVG-5960: cache blocked status

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -57,6 +57,9 @@ const (
 	TaskTestTimedOut = "test-timed-out"
 	TaskSetupFailed  = "setup-failed"
 
+	TaskBlocked = "blocked"
+	TaskPending = "pending"
+
 	// Task Command Types
 	CommandTypeTest   = "test"
 	CommandTypeSystem = "system"

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -81,7 +81,7 @@ func (b *Build) IsFinished() bool {
 //
 // returns boolean to indicate if tasks are complete, string with either BuildFailed or
 // BuildSucceded. The string is only valid when the boolean is true
-func (b *Build) AllUnblockedTasksFinished(tasksWithDeps []task.Task) (bool, string, error) {
+func (b *Build) AllUnblockedTasksFinished() (bool, string, error) {
 	if !b.Activated {
 		return false, b.Status, nil
 	}
@@ -99,18 +99,10 @@ func (b *Build) AllUnblockedTasksFinished(tasksWithDeps []task.Task) (bool, stri
 			if !t.Activated {
 				continue
 			}
-			var blockedStatus string
-			blockedStatus, err = t.BlockedState(tasksWithDeps)
-			if err != nil {
-				return false, status, err
-			}
-			if blockedStatus != "blocked" {
+			if !t.Blocked() {
 				allFinished = false
 			}
 		}
-	}
-	if allFinished && err != nil {
-		return false, status, err
 	}
 
 	return allFinished, status, nil

--- a/model/build/build_test.go
+++ b/model/build/build_test.go
@@ -575,19 +575,19 @@ func TestAllTasksFinished(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	assert.False(b.AllUnblockedTasksFinished(nil))
+	assert.False(b.AllUnblockedTasksFinished())
 
 	assert.NoError(tasks[0].MarkFailed())
-	assert.False(b.AllUnblockedTasksFinished(nil))
+	assert.False(b.AllUnblockedTasksFinished())
 
 	assert.NoError(tasks[1].MarkFailed())
-	assert.False(b.AllUnblockedTasksFinished(nil))
+	assert.False(b.AllUnblockedTasksFinished())
 
 	assert.NoError(tasks[2].MarkFailed())
-	assert.False(b.AllUnblockedTasksFinished(nil))
+	assert.False(b.AllUnblockedTasksFinished())
 
 	assert.NoError(tasks[3].MarkFailed())
-	assert.True(b.AllUnblockedTasksFinished(nil))
+	assert.True(b.AllUnblockedTasksFinished())
 
 	// Only one activated task
 	require.NoError(t, db.ClearCollections(task.Collection), "error clearing collection")
@@ -614,9 +614,9 @@ func TestAllTasksFinished(t *testing.T) {
 	for _, task := range tasks {
 		assert.NoError(task.Insert())
 	}
-	assert.False(b.AllUnblockedTasksFinished(nil))
+	assert.False(b.AllUnblockedTasksFinished())
 	assert.NoError(tasks[0].MarkFailed())
-	assert.True(b.AllUnblockedTasksFinished(nil))
+	assert.True(b.AllUnblockedTasksFinished())
 
 	// Build is finished
 	require.NoError(t, db.ClearCollections(task.Collection), "error clearing collection")
@@ -627,7 +627,7 @@ func TestAllTasksFinished(t *testing.T) {
 		Activated: false,
 	}
 	assert.NoError(task1.Insert())
-	complete, status, err := b.AllUnblockedTasksFinished(nil)
+	complete, status, err := b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.True(complete)
 	assert.Equal(status, evergreen.BuildFailed)
@@ -683,13 +683,13 @@ func TestAllTasksFinished(t *testing.T) {
 	assert.NoError(d0.Insert())
 	assert.NoError(e0.Insert())
 	assert.NoError(e1.Insert())
-	complete, _, err = b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.True(complete)
 
 	// inactive build should not be complete
 	b.Activated = false
-	complete, _, err = b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.False(complete)
 }

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -29,6 +29,7 @@ const (
 	AllDependencies = "*"
 	AllVariants     = "*"
 	AllStatuses     = "*"
+	AnyStatus       = "any"
 )
 
 // cacheFromTask is helper for creating a build.TaskCache from a real Task model.
@@ -188,7 +189,6 @@ func MarkVersionCompleted(versionId string, finishTime time.Time, updates *Statu
 	buildsWithAllActiveTasksComplete := 0
 	activeBuilds := 0
 	finished := true
-	tasksWithDeps, err := task.FindAllTasksFromVersionWithDependencies(versionId)
 	if err != nil {
 		return errors.Wrap(err, "error finding tasks with dependencies")
 	}
@@ -196,7 +196,7 @@ func MarkVersionCompleted(versionId string, finishTime time.Time, updates *Statu
 		if b.Activated {
 			activeBuilds += 1
 		}
-		complete, buildStatus, err := b.AllUnblockedTasksFinished(tasksWithDeps)
+		complete, buildStatus, err := b.AllUnblockedTasksFinished()
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -868,6 +868,10 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 				newTask.DependsOn = append(newTask.DependsOn, newDeps...)
 			}
 		}
+
+		// Display tasks depend on all exec task dependencies
+		displayTasks[newTask.DisplayName].DependsOn = append(displayTasks[newTask.DisplayName].DependsOn, newTask.DependsOn...)
+
 		newTask.DisplayTask = displayTasks[newTask.DisplayName]
 
 		newTask.GeneratedBy = generatedBy

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -29,7 +29,6 @@ const (
 	AllDependencies = "*"
 	AllVariants     = "*"
 	AllStatuses     = "*"
-	AnyStatus       = "any"
 )
 
 // cacheFromTask is helper for creating a build.TaskCache from a real Task model.

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -870,9 +870,10 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 		}
 
 		// Display tasks depend on all exec task dependencies
-		displayTasks[newTask.DisplayName].DependsOn = append(displayTasks[newTask.DisplayName].DependsOn, newTask.DependsOn...)
-
-		newTask.DisplayTask = displayTasks[newTask.DisplayName]
+		if displayTask, ok := displayTasks[newTask.DisplayName]; ok {
+			displayTask.DependsOn = append(displayTask.DependsOn, newTask.DependsOn...)
+			newTask.DisplayTask = displayTask
+		}
 
 		newTask.GeneratedBy = generatedBy
 		// append the task to the list of the created tasks

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -948,33 +948,6 @@ func FindWithDisplayTasks(query db.Q) ([]Task, error) {
 	return tasks, err
 }
 
-func FindAllUnmarkedBlockedDependencies(t *Task, blocked bool) ([]Task, error) {
-	okStatusSet := []string{AnyStatus}
-	if !blocked {
-		okStatusSet = append(okStatusSet, t.Status, AllStatuses)
-	}
-	query := db.Query(bson.M{
-		DependsOnKey: bson.M{"$elemMatch": bson.M{
-			DependencyTaskIdKey:       t.Id,
-			DependencyStatusKey:       bson.M{"$nin": okStatusSet},
-			DependencyUnattainableKey: false,
-		},
-		}})
-
-	return FindAll(query)
-}
-
-func FindAllMarkedUnattainableDependencies(t *Task) ([]Task, error) {
-	query := db.Query(bson.M{
-		DependsOnKey: bson.M{"$elemMatch": bson.M{
-			DependencyTaskIdKey:       t.Id,
-			DependencyUnattainableKey: true,
-		},
-		}})
-
-	return FindAll(query)
-}
-
 // UpdateOne updates one task.
 func UpdateOne(query interface{}, update interface{}) error {
 	return db.Update(

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -337,7 +337,7 @@ func (t *Task) DependenciesMet(depCaches map[string]Task) (bool, error) {
 	}
 
 	if len(depIdsToQueryFor) > 0 {
-		newDeps, err := Find(ByIds(depIdsToQueryFor).WithFields(StatusKey))
+		newDeps, err := Find(ByIds(depIdsToQueryFor).WithFields(StatusKey, DependsOnKey))
 		if err != nil {
 			return false, err
 		}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1036,11 +1036,11 @@ func (t *Task) MarkUnscheduled() error {
 
 }
 
-func (t *Task) MarkUnattainableDependency(dependecy *Task, unattainable bool) error {
+func (t *Task) MarkUnattainableDependency(dependency *Task, unattainable bool) error {
 	return UpdateOne(
 		bson.M{
 			IdKey: t.Id,
-			bsonutil.GetDottedKeyName(DependsOnKey, DependencyTaskIdKey): dependecy.Id,
+			bsonutil.GetDottedKeyName(DependsOnKey, DependencyTaskIdKey): dependency.Id,
 		},
 		bson.M{
 			"$set": bson.M{bsonutil.GetDottedKeyName(DependsOnKey, "$", DependencyUnattainableKey): unattainable},

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -23,7 +23,6 @@ import (
 
 const (
 	dependencyKey = "dependencies"
-	taskKey       = "task"
 
 	// tasks should be unscheduled after ~a week
 	UnschedulableThreshold = 7 * 24 * time.Hour

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1044,7 +1044,7 @@ func (t *Task) MarkUnattainableDependency(dependecy *Task, unattainable bool) er
 			bsonutil.GetDottedKeyName(DependsOnKey, DependencyTaskIdKey): dependecy.Id,
 		},
 		bson.M{
-			bsonutil.GetDottedKeyName(DependsOnKey, "$", DependencyUnattainableKey): unattainable,
+			"$set": bson.M{bsonutil.GetDottedKeyName(DependsOnKey, "$", DependencyUnattainableKey): unattainable},
 		},
 	)
 }

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1366,11 +1366,11 @@ func TestFindAllUnmarkedBlockedDependencies(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	deps, err := FindAllUnmarkedBlockedDependencies(t1, false)
+	deps, err := t1.FindAllUnmarkedBlockedDependencies(false)
 	assert.NoError(err)
 	assert.Len(deps, 1)
 
-	deps, err = FindAllUnmarkedBlockedDependencies(t1, true)
+	deps, err = t1.FindAllUnmarkedBlockedDependencies(true)
 	assert.NoError(err)
 	assert.Len(deps, 3)
 }
@@ -1408,7 +1408,7 @@ func TestFindAllMarkedUnattainableDependencies(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	unattainableTasks, err := FindAllMarkedUnattainableDependencies(t1)
+	unattainableTasks, err := t1.FindAllMarkedUnattainableDependencies()
 	assert.NoError(err)
 	assert.Len(unattainableTasks, 1)
 }

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1372,7 +1372,7 @@ func TestFindAllUnmarkedBlockedDependencies(t *testing.T) {
 
 	deps, err = FindAllUnmarkedBlockedDependencies(t1, true)
 	assert.NoError(err)
-	assert.Len(deps, 2)
+	assert.Len(deps, 3)
 }
 
 func TestFindAllMarkedUnattainableDependencies(t *testing.T) {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1909,7 +1909,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.False(updates.VersionComplete)
 	b, err := build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err := b.AllUnblockedTasksFinished(nil)
+	complete, _, err := b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.False(complete)
 
@@ -1921,7 +1921,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.False(updates.VersionComplete)
 	b, err = build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err = b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.False(complete)
 
@@ -1933,7 +1933,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.False(updates.VersionComplete)
 	b, err = build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err = b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.False(complete)
 
@@ -1947,7 +1947,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.True(updates.VersionComplete)
 	b, err = build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err = b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.True(complete)
 
@@ -2029,7 +2029,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	assert.True(updates.VersionComplete)
 	b, err := build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err := b.AllUnblockedTasksFinished(nil)
+	complete, _, err := b.AllUnblockedTasksFinished()
 	assert.True(complete)
 	assert.NoError(err)
 	assert.True(b.IsFinished())
@@ -2111,7 +2111,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 	assert.True(updates.VersionComplete)
 	b, err := build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err := b.AllUnblockedTasksFinished(nil)
+	complete, _, err := b.AllUnblockedTasksFinished()
 	assert.True(complete)
 	assert.NoError(err)
 	assert.True(b.IsFinished())

--- a/scheduler/task_finder.go
+++ b/scheduler/task_finder.go
@@ -142,7 +142,7 @@ func AlternateTaskFinder(d distro.Distro) ([]task.Task, error) {
 		taskIds = append(taskIds, t)
 	}
 
-	tasksToCache, err := task.Find(task.ByIds(taskIds).WithFields(task.StatusKey))
+	tasksToCache, err := task.Find(task.ByIds(taskIds).WithFields(task.StatusKey, task.DependsOnKey))
 	if err != nil {
 		return nil, errors.Wrap(err, "problem finding task dependencies")
 	}
@@ -243,7 +243,7 @@ func ParallelTaskFinder(d distro.Distro) ([]task.Task, error) {
 		go func() {
 			defer wg.Done()
 			for id := range toLookup {
-				nt, err := task.FindOneIdWithFields(id, task.StatusKey)
+				nt, err := task.FindOneIdWithFields(id, task.StatusKey, task.DependsOnKey)
 				catcher.Add(err)
 				if nt == nil {
 					continue

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -136,6 +136,8 @@ func (s *TaskFinderSuite) TestTasksWithUnsatisfiedDependenciesNeverReturned() {
 	s.depTasks[1].Status = evergreen.TaskUndispatched
 	s.depTasks[1].DependsOn = []task.Dependency{
 		{
+			TaskId:       "none",
+			Status:       "*",
 			Unattainable: true,
 		},
 	}

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -256,10 +256,6 @@ func (s *TaskFinderComparisonSuite) SetupTest() {
 	})
 }
 
-func (s *TaskFinderComparisonSuite) TearDownTest() {
-	s.NoError(db.Clear(task.Collection))
-}
-
 func (s *TaskFinderComparisonSuite) TestFindRunnableHostsIsIdentical() {
 	idsOldMethod := []string{}
 	for _, task := range s.oldRunnableTasks {
@@ -498,7 +494,7 @@ func makeRandomSubTasks(statuses []string, parentTasks *[]task.Task) []task.Task
 		dependsOn := []task.Dependency{
 			task.Dependency{
 				TaskId: parentTask.Id,
-				Status: parentTask.Status,
+				Status: getRandomDependsOnStatus(),
 			},
 		}
 
@@ -508,7 +504,7 @@ func makeRandomSubTasks(statuses []string, parentTasks *[]task.Task) []task.Task
 			dependsOn = append(dependsOn,
 				task.Dependency{
 					TaskId: (*parentTasks)[anotherParent].Id,
-					Status: (*parentTasks)[anotherParent].Status,
+					Status: getRandomDependsOnStatus(),
 				},
 			)
 		}
@@ -529,6 +525,11 @@ func makeRandomSubTasks(statuses []string, parentTasks *[]task.Task) []task.Task
 	}
 
 	return depTasks
+}
+
+func getRandomDependsOnStatus() string {
+	dependsOnStatuses := []string{evergreen.TaskSucceeded, evergreen.TaskFailed, task.AnyStatus, task.AllStatuses}
+	return dependsOnStatuses[rand.Intn(len(dependsOnStatuses))]
 }
 
 func hugeString(suffix string) string {

--- a/service/task.go
+++ b/service/task.go
@@ -457,7 +457,12 @@ func getTaskDependencies(t *task.Task) ([]uiDep, string, error) {
 		return nil, "", err
 	}
 
-	return uiDependencies, t.BlockedState(), nil
+	state, err := t.BlockedState()
+	if err != nil {
+		return nil, "", errors.Wrap(err, "can't get blocked state")
+	}
+
+	return uiDependencies, state, nil
 }
 
 // async handler for polling the task log

--- a/service/task.go
+++ b/service/task.go
@@ -456,12 +456,8 @@ func getTaskDependencies(t *task.Task) ([]uiDep, string, error) {
 	if err = t.CircularDependencies(); err != nil {
 		return nil, "", err
 	}
-	status, err := t.BlockedState(nil)
-	if err != nil {
-		return nil, "", err
-	}
 
-	return uiDependencies, status, nil
+	return uiDependencies, t.BlockedState(), nil
 }
 
 // async handler for polling the task log


### PR DESCRIPTION
Cache a blocked status for tasks blocked on their dependencies so they can be:

1. Excluded from consideration by the scheduler.
2. Depended on, so tasks can run when their dependencies are blocked. Add a new depends_on keyword, "any"