### PR TITLE
EVG-6190 modify patch route

### DIFF
--- a/model/github_hook.go
+++ b/model/github_hook.go
@@ -65,7 +65,7 @@ func FindGithubHook(owner, repo string) (*GithubHook, error) {
 	return hook, nil
 }
 
-func SetupNewGithubHook(settings evergreen.Settings, owner string, repo string) (*GithubHook, error) {
+func SetupNewGithubHook(ctx context.Context, settings evergreen.Settings, owner string, repo string) (*GithubHook, error) {
 	token, err := settings.GetGithubOauthToken()
 	if err != nil {
 		return nil, err
@@ -91,13 +91,12 @@ func SetupNewGithubHook(settings evergreen.Settings, owner string, repo string) 
 			"insecure_ssl": github.String("0"),
 		},
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	newCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	resp := &github.Response{}
 	respHook := &github.Hook{}
-	respHook, resp, err = client.Repositories.CreateHook(ctx, owner, repo, &hookObj)
+	respHook, resp, err = client.Repositories.CreateHook(newCtx, owner, repo, &hookObj)
 	if err != nil {
 		return nil, err
 	}

--- a/model/github_hook.go
+++ b/model/github_hook.go
@@ -1,9 +1,16 @@
 package model
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/google/go-github/github"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
 	"go.mongodb.org/mongo-driver/bson"
@@ -55,5 +62,53 @@ func FindGithubHook(owner, repo string) (*GithubHook, error) {
 		return nil, err
 	}
 
+	return hook, nil
+}
+
+func SetupNewGithubHook(settings evergreen.Settings, owner string, repo string) (*GithubHook, error) {
+	token, err := settings.GetGithubOauthToken()
+	if err != nil {
+		return nil, err
+	}
+	if settings.Api.GithubWebhookSecret == "" {
+		return nil, errors.New("Evergreen is not configured for Github Webhooks")
+	}
+
+	httpClient, err := util.GetOAuth2HTTPClient(token)
+	if err != nil {
+		return nil, err
+	}
+	defer util.PutHTTPClient(httpClient)
+	client := github.NewClient(httpClient)
+	hookObj := github.Hook{
+		Name:   github.String("web"),
+		Active: github.Bool(true),
+		Events: []string{"*"},
+		Config: map[string]interface{}{
+			"url":          github.String(fmt.Sprintf("%s/rest/v2/hooks/github", settings.ApiUrl)),
+			"content_type": github.String("json"),
+			"secret":       github.String(settings.Api.GithubWebhookSecret),
+			"insecure_ssl": github.String("0"),
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp := &github.Response{}
+	respHook := &github.Hook{}
+	respHook, resp, err = client.Repositories.CreateHook(ctx, owner, repo, &hookObj)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated || respHook == nil || respHook.ID == nil {
+		return nil, errors.New("unexpected data from github")
+	}
+	hook := &GithubHook{
+		HookID: *respHook.ID,
+		Owner:  owner,
+		Repo:   repo,
+	}
 	return hook, nil
 }

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -189,6 +189,42 @@ func TestFindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t *testing.T) {
 	assert.NotNil(projectRef)
 }
 
+func TestCanEnableCommitQueue(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	require.NoError(db.Clear(ProjectRefCollection))
+	doc := &ProjectRef{
+		Owner:      "mongodb",
+		Repo:       "mci",
+		Branch:     "master",
+		RepoKind:   "github",
+		Identifier: "mci",
+		CommitQueue: CommitQueueParams{
+			Enabled: true,
+		},
+	}
+	require.NoError(doc.Insert())
+	ok, err := doc.CanEnableCommitQueue()
+	assert.NoError(err)
+	assert.True(ok)
+
+	doc2 := &ProjectRef{
+		Owner:      "mongodb",
+		Repo:       "mci",
+		Branch:     "master",
+		RepoKind:   "github",
+		Identifier: "not-mci",
+		CommitQueue: CommitQueueParams{
+			Enabled: false,
+		},
+	}
+	require.NoError(doc2.Insert())
+	ok, err = doc2.CanEnableCommitQueue()
+	assert.NoError(err)
+	assert.False(ok)
+}
+
 func TestFindProjectRefsWithCommitQueueEnabled(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -145,6 +145,7 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 		adb.Change{
 			Update:    update,
 			ReturnNew: true,
+			Upsert:    true,
 		},
 		projectVars,
 	)

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -92,7 +92,7 @@ func TestProjectVarsFindAndModify(t *testing.T) {
 
 	newVars.Id = "234"
 	info, err = newVars.FindAndModify(varsToDelete)
-	assert.Error(err)
+	assert.NoError(err) // should upsert
 }
 
 func TestRedactPrivateVars(t *testing.T) {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -92,9 +92,9 @@ type Connector interface {
 
 	// EnableWebhooks creates a webhook for the project's owner/repo if one does not exist.
 	// If unable to setup the new webhook, returns false but no error.
-	EnableWebhooks(*model.ProjectRef) (bool, error)
+	EnableWebhooks(context.Context, *model.ProjectRef) (bool, error)
 	// EnablePRTesting determines if PR testing can be enabled for the given project.
-	EnablePRTesting(projectRef *model.ProjectRef) error
+	EnablePRTesting(*model.ProjectRef) error
 
 	// FindProjects is a method to find projects as ordered by name
 	FindProjects(string, int, int, bool) ([]model.ProjectRef, error)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -90,6 +90,12 @@ type Connector interface {
 	CreateProject(projectRef *model.ProjectRef) error
 	UpdateProject(projectRef *model.ProjectRef) error
 
+	// EnableWebhooks creates a webhook for the project's owner/repo if one does not exist.
+	// If unable to setup the new webhook, returns false but no error.
+	EnableWebhooks(*model.ProjectRef) (bool, error)
+	// EnablePRTesting determines if PR testing can be enabled for the given project.
+	EnablePRTesting(projectRef *model.ProjectRef) error
+
 	// FindProjects is a method to find projects as ordered by name
 	FindProjects(string, int, int, bool) ([]model.ProjectRef, error)
 	// FindProjectByBranch is a method to find the projectref given a branch name.
@@ -254,6 +260,7 @@ type Connector interface {
 	GetGitHubPR(context.Context, string, string, int) (*github.PullRequest, error)
 	EnqueueItem(string, restModel.APICommitQueueItem) (int, error)
 	FindCommitQueueByID(string) (*restModel.APICommitQueue, error)
+	EnableCommitQueue(*model.ProjectRef, model.CommitQueueParams) error
 	CommitQueueRemoveItem(string, string) (bool, error)
 	CommitQueueClearAll() (int, error)
 	IsAuthorizedToPatchAndMerge(context.Context, *evergreen.Settings, UserRepoInfo) (bool, error)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -5,10 +5,14 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
+	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -50,6 +54,79 @@ func (pc *DBProjectConnector) UpdateProject(projectRef *model.ProjectRef) error 
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    fmt.Sprintf("project with id '%s' was not updated", projectRef.Identifier),
+		}
+	}
+	return nil
+}
+
+// EnableWebhooks returns true if a hook for the given owner/repo exists or was inserted.
+func (pc *DBProjectConnector) EnableWebhooks(projectRef *model.ProjectRef) (bool, error) {
+	hook, err := model.FindGithubHook(projectRef.Owner, projectRef.Repo)
+	if err != nil {
+		return false, errors.Wrapf(err, "Database error finding github hook for project '%s'", projectRef.Identifier)
+	}
+	if hook != nil {
+		return true, nil
+	}
+
+	settings, err := evergreen.GetConfig()
+	if err != nil {
+		return true, errors.Wrap(err, "error finding evergreen settings")
+	}
+
+	hook, err = model.SetupNewGithubHook(*settings, projectRef.Owner, projectRef.Repo)
+	if err != nil {
+		// don't return error:
+		// sometimes people change a project to track a personal
+		// branch we don't have access to
+		grip.Error(message.WrapError(err, message.Fields{
+			"source":  "patch project",
+			"message": "can't setup webhook",
+			"project": projectRef.Identifier,
+			"owner":   projectRef.Owner,
+			"repo":    projectRef.Repo,
+		}))
+		projectRef.TracksPushEvents = false
+		return false, nil
+	}
+
+	if err = hook.Insert(); err != nil {
+		return false, errors.Wrapf(err, "error inserting new webhook for project '%s'", projectRef.Identifier)
+	}
+	return true, nil
+}
+
+func (pc *DBProjectConnector) EnablePRTesting(projectRef *model.ProjectRef) error {
+	conflictingRefs, err := model.FindProjectRefsByRepoAndBranch(projectRef.Owner, projectRef.Repo, projectRef.Branch)
+	if err != nil {
+		return errors.Wrap(err, "error finding project refs")
+	}
+	for _, ref := range conflictingRefs {
+		if ref.PRTestingEnabled && ref.Identifier != projectRef.Identifier {
+			return errors.Errorf("Cannot enable PR Testing in this repo, must disable in other projects first")
+		}
+	}
+	return nil
+}
+
+func (pc *DBProjectConnector) EnableCommitQueue(projectRef *model.ProjectRef, commitQueueParams model.CommitQueueParams) error {
+	resultRef, err := model.FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(projectRef.Owner, projectRef.Repo, projectRef.Branch)
+	if err != nil && !adb.ResultsNotFound(err) {
+		return errors.Wrapf(err, "")
+	}
+	if resultRef != nil && resultRef.CommitQueue.Enabled && resultRef.Identifier != projectRef.Identifier {
+		return errors.Errorf("Cannot enable Commit Queue in this repo, must disable in other projects first")
+	}
+
+	_, err = commitqueue.FindOneId(projectRef.Identifier)
+	if err != nil {
+		if adb.ResultsNotFound(err) {
+			cq := &commitqueue.CommitQueue{ProjectID: projectRef.Identifier}
+			if err = commitqueue.InsertQueue(cq); err != nil {
+				return errors.Wrapf(err, "problem inserting new commit queue")
+			}
+		} else {
+			return errors.Wrapf(err, "database error finding commit queue")
 		}
 	}
 	return nil
@@ -271,4 +348,15 @@ func (pc *MockProjectConnector) GetProjectWithCommitQueueByOwnerRepoAndBranch(ow
 	}
 
 	return nil, errors.Errorf("can't query for projectRef %s/%s tracking %s", owner, repo, branch)
+}
+func (pc *MockProjectConnector) EnableWebhooks(projectRef *model.ProjectRef) (bool, error) {
+	return false, nil
+}
+
+func (pc *MockProjectConnector) EnableCommitQueue(projectRef *model.ProjectRef, commitQueueParams model.CommitQueueParams) error {
+	return nil
+}
+
+func (pc *MockProjectConnector) EnablePRTesting(projectRef *model.ProjectRef) error {
+	return nil
 }

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -330,10 +330,11 @@ func (pc *MockProjectConnector) UpdateProjectVars(projectId string, varsModel *r
 			return nil
 		}
 	}
-	return gimlet.ErrorResponse{
-		StatusCode: http.StatusNotFound,
-		Message:    fmt.Sprintf("variables for project '%s' not found", projectId),
-	}
+	tempVars.Vars = varsModel.Vars
+	tempVars.PrivateVars = varsModel.PrivateVars
+	tempVars.Id = projectId
+	pc.CachedVars = append(pc.CachedVars, &tempVars)
+	return nil
 }
 
 func (pc *MockProjectConnector) GetProjectEventLog(id string, before time.Time, n int) ([]restModel.APIProjectEvent, error) {

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -496,6 +496,6 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 	_, ok = newVars.PrivateVars["a"]
 	s.False(ok)
 
-	//unsuccessful update
-	s.Error(s.ctx.UpdateProjectVars("not-an-id", &newVars))
+	// successful upsert
+	s.NoError(s.ctx.UpdateProjectVars("not-an-id", &newVars))
 }

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -274,7 +274,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 
 	if dbProjectRef.Enabled {
 		var hasHook bool
-		hasHook, err = h.sc.EnableWebhooks(dbProjectRef)
+		hasHook, err = h.sc.EnableWebhooks(ctx, dbProjectRef)
 		if err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Error enabling webhooks for project '%s'", h.projectID))
 		}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -278,10 +278,9 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Error enabling webhooks for project '%s'", h.projectID))
 		}
-
 		// verify enabling PR testing valid
 		if dbProjectRef.PRTestingEnabled {
-			if hasHook {
+			if !hasHook {
 				return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 					StatusCode: http.StatusBadRequest,
 					Message:    "Cannot enable PR Testing in this repo, must enable GitHub webhooks first",
@@ -305,7 +304,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 			})
 		}
 		if commitQueueParams.Enabled {
-			if hasHook {
+			if !hasHook {
 				gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 					StatusCode: http.StatusBadRequest,
 					Message:    "Cannot enable commit queue in this repo, must enable GitHub webhooks first",

--- a/rest/route/project_vars_test.go
+++ b/rest/route/project_vars_test.go
@@ -97,9 +97,9 @@ func (s *PatchVarsSuite) TestRunNonExistingId() {
 	ctx := context.Background()
 	s.route.projectID = "non-existent"
 
+	// upsert
 	resp := s.route.Run(ctx)
-	s.NotNil(resp.Data())
-	s.NotEqual(resp.Status(), http.StatusOK)
+	s.Equal(resp.Status(), http.StatusOK)
 }
 
 func (s *PatchVarsSuite) TestRunExistingId() {

--- a/service/project.go
+++ b/service/project.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -250,7 +251,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	}
 	origGithubWebhookEnabled := (hook != nil)
 	if hook == nil {
-		hook, err = model.SetupNewGithubHook(uis.Settings, responseRef.Owner, responseRef.Repo)
+		hook, err = model.SetupNewGithubHook(context.Background(), uis.Settings, responseRef.Owner, responseRef.Repo)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"source":  "project edit",


### PR DESCRIPTION
Originally our projects patch route merely updated the document in the DB, whereas an update from the UI verifies input, creates a webhook, and enables PR testing and the commit queue.

This version of the PR has no tests, because I'm not sure the best way to test the webhooks piece of this code (which is the main consideration). Would we want to put it in staging and hit the route to verify? Or is it enough if the existing UI route proves unbroken since the logic is the same?