### PR TITLE
EVG-6212 fix panic

### DIFF
--- a/model/task_config.go
+++ b/model/task_config.go
@@ -103,6 +103,8 @@ func (c *TaskConfig) GetWorkingDirectory(dir string) (string, error) {
 
 	if stat, err := os.Stat(dir); os.IsNotExist(err) {
 		return "", errors.Errorf("directory %s does not exist", dir)
+	} else if err != nil || stat == nil {
+		return "", errors.Wrapf(err, "error retrieving file info for %s", dir)
 	} else if !stat.IsDir() {
 		return "", errors.Errorf("path %s is not a directory", dir)
 	}


### PR DESCRIPTION
Verify that an error (besides "does not exist) is not given for stat (checking if stat is nil for good measure).