### PR TITLE
 EVG-6241: Make search filter for test results case insensitive

### DIFF
--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -404,9 +404,10 @@ mciModule.controller('TaskHistoryDrawerCtrl', function($scope, $window, $locatio
       $scope.filterTests = function() {
         if ($scope.task.searchField != "") {
           $scope.task.filtered_results = []
+          let searchValue = $scope.task.searchField.toLowerCase();
           $scope.task.test_results.forEach(function(result){
-            let name = result.test_result.display_name;
-            if(name.includes($scope.task.searchField)) {
+            let name = result.test_result.display_name.toLowerCase();
+            if(name.includes(searchValue)) {
               $scope.task.filtered_results.push(result);
             }
           });

--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -404,10 +404,9 @@ mciModule.controller('TaskHistoryDrawerCtrl', function($scope, $window, $locatio
       $scope.filterTests = function() {
         if ($scope.task.searchField != "") {
           $scope.task.filtered_results = []
-          let searchValue = $scope.task.searchField.toLowerCase();
           $scope.task.test_results.forEach(function(result){
-            let name = result.test_result.display_name.toLowerCase();
-            if(name.includes(searchValue)) {
+            let name = result.test_result.display_name;
+            if(name.includes($scope.task.searchField)) {
               $scope.task.filtered_results.push(result);
             }
           });


### PR DESCRIPTION
Updated the search filter on the task page to be case insensitive, because the other filter boxes in Evergreen are case insensitive. 