### PR TITLE
EVG-6167: update/reinstall Jasper service via SSH

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -149,6 +149,8 @@ const (
 	CommitQueueAlias = "__commit_queue"
 
 	MaxTeardownGroupTimeoutSecs = 30 * 60
+
+	DefaultJasperPort = 2385
 )
 
 func IsFinishedTaskStatus(status string) bool {

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -170,7 +170,7 @@ func (h *Host) FetchAndReinstallJasperCommand(config evergreen.JasperConfig) str
 // new configuration, and restart the service.
 func (h *Host) ForceReinstallJasperCommand(config evergreen.JasperConfig) string {
 	port := config.Port
-	if config.Port == 0 {
+	if port == 0 {
 		port = evergreen.DefaultJasperPort
 	}
 	return h.jasperServiceCommand(config, "force-reinstall", fmt.Sprintf("--port=%d", port))

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -156,7 +156,38 @@ func initSystemCommand() string {
 	`
 }
 
-// FetchJasperCommands builds the command to download and extract the Jasper
+// FetchAndReinstallJasperCommand returns the command to fetch Jasper and
+// restart the service with the latest version.
+func (h *Host) FetchAndReinstallJasperCommand(config evergreen.JasperConfig) string {
+	return strings.Join([]string{
+		h.FetchJasperCommand(config),
+		h.ForceReinstallJasperCommand(config),
+	}, " && ")
+}
+
+// ForceReinstallJasperCommand returns the command to stop the Jasper service,
+// delete the current Jasper service configuration (if it exists), install the
+// new configuration, and restart the service.
+func (h *Host) ForceReinstallJasperCommand(config evergreen.JasperConfig) string {
+	port := config.Port
+	if config.Port == 0 {
+		port = evergreen.DefaultJasperPort
+	}
+	return h.jasperServiceCommand(config, "force-reinstall", fmt.Sprintf("--port=%d", port))
+}
+
+func (h *Host) jasperServiceCommand(config evergreen.JasperConfig, subCmd string, args ...string) string {
+	binaryPath := filepath.Join(h.Distro.CuratorDir, h.jasperExtractedFileName(config))
+	cmd := fmt.Sprintf("%s jasper service %s rpc %s", binaryPath, subCmd, strings.Join(args, " "))
+	// Jasper service commands need elevated privileges to execute. On Windows,
+	// this is assuming that the command is already being run by Administrator.
+	if !h.Distro.IsWindows() {
+		cmd = "sudo " + cmd
+	}
+	return cmd
+}
+
+// FetchJasperCommand builds the command to download and extract the Jasper
 // binary into the distro-specific binary directory.
 func (h *Host) FetchJasperCommand(config evergreen.JasperConfig) string {
 	return strings.Join(h.fetchJasperCommands(config), " && ")

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -69,6 +69,16 @@ func TestJasperCommands(t *testing.T) {
 				assert.Contains(t, script, expectedCmd)
 			}
 		},
+		"ForceReinstallJasperCommand": func(t *testing.T, h *Host, config evergreen.JasperConfig) {
+			cmd := h.ForceReinstallJasperCommand(config)
+			assert.Equal(t, "sudo /foo/jasper_cli jasper service force-reinstall rpc --port=12345", cmd)
+		},
+		"ForceReinstallJasperCommandNoPort": func(t *testing.T, h *Host, config evergreen.JasperConfig) {
+			config.Port = 0
+			cmd := h.ForceReinstallJasperCommand(config)
+			assert.Equal(t, fmt.Sprintf("sudo /foo/jasper_cli jasper service force-reinstall rpc --port=%d", evergreen.DefaultJasperPort), cmd)
+		},
+		// "": func(t *testing.T, h *Host, config evergreen.JasperConfig) {},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			h := &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64, CuratorDir: "/foo"}}
@@ -77,6 +87,7 @@ func TestJasperCommands(t *testing.T) {
 				DownloadFileName: "download_file",
 				URL:              "www.example.com",
 				Version:          "abc123",
+				Port:             12345,
 			}
 			testCase(t, h, config)
 		})
@@ -130,6 +141,15 @@ func TestJasperCommandsWindows(t *testing.T) {
 				assert.Contains(t, script, expectedCmd)
 			}
 		},
+		"ForceReinstallJasperCommand": func(t *testing.T, h *Host, config evergreen.JasperConfig) {
+			cmd := h.ForceReinstallJasperCommand(config)
+			assert.Equal(t, "/foo/jasper_cli.exe jasper service force-reinstall rpc --port=12345", cmd)
+		},
+		"ForceReinstallJasperCommandNoPort": func(t *testing.T, h *Host, config evergreen.JasperConfig) {
+			config.Port = 0
+			cmd := h.ForceReinstallJasperCommand(config)
+			assert.Equal(t, fmt.Sprintf("/foo/jasper_cli.exe jasper service force-reinstall rpc --port=%d", evergreen.DefaultJasperPort), cmd)
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			h := &Host{Distro: distro.Distro{Arch: distro.ArchWindowsAmd64, CuratorDir: "/foo"}}
@@ -138,6 +158,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 				DownloadFileName: "download_file",
 				URL:              "www.example.com",
 				Version:          "abc123",
+				Port:             12345,
 			}
 			testCase(t, h, config)
 		})

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -63,7 +63,6 @@ type monitor struct {
 
 const (
 	defaultMonitorPort        = defaultAgentStatusPort - 1
-	defaultJasperPort         = defaultMonitorPort - 1
 	defaultMaxRequestDelay    = 30 * time.Second
 	defaultMaxRequestAttempts = 10
 
@@ -116,7 +115,7 @@ func agentMonitor() cli.Command {
 			},
 			cli.IntFlag{
 				Name:  jasperPortFlagName,
-				Value: defaultJasperPort,
+				Value: evergreen.DefaultJasperPort,
 				Usage: "the port that is running the Jasper RPC service",
 			},
 			cli.IntFlag{

--- a/operations/agent_monitor_test.go
+++ b/operations/agent_monitor_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/rpc"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ func TestAgentMonitorWithJasper(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	jasperPort := defaultJasperPort
+	jasperPort := evergreen.DefaultJasperPort
 	port := defaultMonitorPort
 	manager, err := jasper.NewLocalManager(false)
 	require.NoError(t, err)

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -224,7 +224,7 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 	}
 
 	if targetHost.Distro.BootstrapMethod == distro.BootstrapMethodSSH {
-		if err = j.fetchJasper(ctx); err != nil {
+		if err = j.setupJasper(ctx); err != nil {
 			return errors.Wrapf(err, "error putting Jasper on host '%s'", targetHost.Id)
 		}
 	}
@@ -253,8 +253,9 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 	return nil
 }
 
-// fetchJasper places the Jasper CLI on the host via SSH.
-func (j *setupHostJob) fetchJasper(ctx context.Context) error {
+// setupJasper sets up the Jasper service on the host by downloading the latest
+// version of Jasper and restarting the Jasper service.
+func (j *setupHostJob) setupJasper(ctx context.Context) error {
 	d, err := distro.FindOne(distro.ById(j.host.Distro.Id))
 	if err != nil {
 		grip.Error(message.WrapError(j.host.SetUnprovisioned(), message.Fields{
@@ -269,6 +270,12 @@ func (j *setupHostJob) fetchJasper(ctx context.Context) error {
 
 	cloudHost, err := cloud.GetCloudHost(ctx, j.host, j.env.Settings())
 	if err != nil {
+		grip.Error(message.WrapError(j.host.SetUnprovisioned(), message.Fields{
+			"operation": "setting host unprovisioned",
+			"distro":    j.host.Distro.Id,
+			"job":       j.ID(),
+			"host":      j.host.Id,
+		}))
 		return errors.Wrapf(err, "failed to get cloud host for %s", j.host.Id)
 	}
 
@@ -283,7 +290,7 @@ func (j *setupHostJob) fetchJasper(ctx context.Context) error {
 		return errors.Wrapf(err, "error getting ssh options for host %s", j.host.Id)
 	}
 
-	if err := j.doFetchJasper(ctx, sshOptions); err != nil {
+	if err := j.doFetchAndReinstallJasper(ctx, sshOptions); err != nil {
 		grip.Error(message.WrapError(j.host.SetUnprovisioned(), message.Fields{
 			"operation": "setting host unprovisioned",
 			"distro":    j.host.Distro.Id,
@@ -302,11 +309,12 @@ func (j *setupHostJob) fetchJasper(ctx context.Context) error {
 	return nil
 }
 
-// doFetchJasper runs the command over that downloads the Jasper binary.
-func (j *setupHostJob) doFetchJasper(ctx context.Context, sshOptions []string) error {
-	cmd := j.host.FetchJasperCommand(j.env.Settings().JasperConfig)
+// doFetchAndReinstallJasper runs the SSH command over that downloads the latest
+// Jasper binary and restarts the service.
+func (j *setupHostJob) doFetchAndReinstallJasper(ctx context.Context, sshOptions []string) error {
+	cmd := j.host.FetchAndReinstallJasperCommand(j.env.Settings().JasperConfig)
 	if logs, err := j.host.RunSSHCommand(ctx, cmd, sshOptions); err != nil {
-		return errors.Wrapf(err, "error fetching Jasper binary on remote host: command returned %s", logs)
+		return errors.Wrapf(err, "error while fetching Jasper binary and installing service on remote host: command returned %s", logs)
 	}
 	return nil
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6167

When bootstrapping via non-legacy SSH, update host's curator binary to latest version and restart service with the new version and config.