### PR TITLE
EVG-6192 add revision parameter to PATCH projects

### DIFF
--- a/model/repository_test.go
+++ b/model/repository_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/db"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -54,4 +55,21 @@ func TestGetNewRevisionOrderNumber(t *testing.T) {
 		})
 
 	})
+}
+
+func TestUpdateLastRevision(t *testing.T) {
+	for name, test := range map[string]func(*testing.T, string, string){
+		"InvalidProject": func(t *testing.T, project string, revision string) {
+			assert.Error(t, UpdateLastRevision(project, revision))
+		},
+		"ValidProject": func(t *testing.T, project string, revision string) {
+			_, err := GetNewRevisionOrderNumber(project)
+			assert.NoError(t, err)
+			assert.NoError(t, UpdateLastRevision(project, revision))
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			test(t, "my-project", "my-revision")
+		})
+	}
 }

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -97,6 +97,8 @@ type Connector interface {
 	// EnablePRTesting determines if PR testing can be enabled for the given project.
 	EnablePRTesting(*model.ProjectRef) error
 
+	// UpdateProjectRevision updates the given project's revision
+	UpdateProjectRevision(string, string) error
 	// FindProjects is a method to find projects as ordered by name
 	FindProjects(string, int, int, bool) ([]model.ProjectRef, error)
 	// FindProjectByBranch is a method to find the projectref given a branch name.

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -130,6 +130,14 @@ func (pc *DBProjectConnector) EnableCommitQueue(projectRef *model.ProjectRef, co
 	return nil
 }
 
+func (pc *DBProjectConnector) UpdateProjectRevision(projectID, revision string) error {
+	if err := model.UpdateLastRevision(projectID, revision); err != nil {
+		return errors.Wrapf(err, "error updating revision for project '%s'", projectID)
+	}
+
+	return nil
+}
+
 // FindProjects queries the backing database for the specified projects
 func (pc *DBProjectConnector) FindProjects(key string, limit int, sortDir int, isAuthenticated bool) ([]model.ProjectRef, error) {
 	projects, err := model.FindProjectRefs(key, limit, sortDir, isAuthenticated)
@@ -380,5 +388,9 @@ func (pc *MockProjectConnector) EnableCommitQueue(projectRef *model.ProjectRef, 
 }
 
 func (pc *MockProjectConnector) EnablePRTesting(projectRef *model.ProjectRef) error {
+	return nil
+}
+
+func (pc *MockProjectConnector) UpdateProjectRevision(projectID, revision string) error {
 	return nil
 }

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -106,6 +106,9 @@ func TestProjectConnectorGetSuite(t *testing.T) {
 			if err := p.Insert(); err != nil {
 				return err
 			}
+			if _, err := model.GetNewRevisionOrderNumber(p.Identifier); err != nil {
+				return err
+			}
 		}
 
 		vars := &model.ProjectVars{

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -337,9 +337,11 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		if err = h.sc.UpdateProjectRevision(h.projectID, h.revision); err != nil {
 			return gimlet.MakeJSONErrorResponder(err)
 		}
-		dbProjectRef.RepotrackerError.Exists = false
-		dbProjectRef.RepotrackerError.InvalidRevision = ""
-		dbProjectRef.RepotrackerError.MergeBaseRevision = ""
+		dbProjectRef.RepotrackerError = &dbModel.RepositoryErrorDetails{
+			Exists:            false,
+			InvalidRevision:   "",
+			MergeBaseRevision: "",
+		}
 	}
 
 	if err = h.sc.UpdateProject(dbProjectRef); err != nil {
@@ -356,7 +358,6 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "problem creating catchup job"))
 		}
 	}
-
 	return gimlet.NewJSONResponse(apiProjectRef)
 }
 

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -8,15 +8,19 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/evergreen-ci/evergreen"
 	dbModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
+
+const tsFormat = "2006-01-02.15-04-05"
 
 type projectGetHandler struct {
 	key   string
@@ -197,6 +201,7 @@ func (h *versionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 
 type projectIDPatchHandler struct {
 	projectID string
+	revision  string
 	body      []byte
 	sc        data.Connector
 }
@@ -216,7 +221,7 @@ func (h *projectIDPatchHandler) Factory() gimlet.RouteHandler {
 // Parse fetches the project's identifier from the http request.
 func (h *projectIDPatchHandler) Parse(ctx context.Context, r *http.Request) error {
 	h.projectID = gimlet.GetVars(r)["project_id"]
-
+	h.revision = r.URL.Query().Get("revision")
 	body := util.NewRequestReader(r)
 	defer body.Close()
 	b, err := ioutil.ReadAll(body)
@@ -328,8 +333,28 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(catcher.Resolve(), "error validating triggers"))
 	}
 
+	if h.revision != "" {
+		if err := h.sc.UpdateProjectRevision(h.projectID, h.revision); err != nil {
+			return gimlet.MakeJSONErrorResponder(err)
+		}
+		dbProjectRef.RepotrackerError.Exists = false
+		dbProjectRef.RepotrackerError.InvalidRevision = ""
+		dbProjectRef.RepotrackerError.MergeBaseRevision = ""
+	}
+
 	if err = h.sc.UpdateProject(dbProjectRef); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for update() by project id '%s'", h.projectID))
+	}
+
+	// run the repotracker for the project
+	if h.revision != "" {
+		ts := util.RoundPartOfHour(1).Format(tsFormat)
+		j := units.NewRepotrackerJob(fmt.Sprintf("catchup-%s", ts), h.projectID)
+
+		queue := evergreen.GetEnvironment().RemoteQueue()
+		if err := queue.Put(ctx, j); err != nil {
+			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "problem creating catchup job"))
+		}
 	}
 
 	return gimlet.NewJSONResponse(apiProjectRef)

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -334,7 +334,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	if h.revision != "" {
-		if err := h.sc.UpdateProjectRevision(h.projectID, h.revision); err != nil {
+		if err = h.sc.UpdateProjectRevision(h.projectID, h.revision); err != nil {
 			return gimlet.MakeJSONErrorResponder(err)
 		}
 		dbProjectRef.RepotrackerError.Exists = false

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -38,12 +38,13 @@ func (s *ProjectPatchByIDSuite) SetupTest() {
 
 func (s *ProjectPatchByIDSuite) TestParse() {
 	ctx := context.Background()
-	json := []byte(`{"private" : false}`)
-	req, _ := http.NewRequest("PATCH", "http://example.com/api/rest/v2/projects/dimoxinil", bytes.NewBuffer(json))
 
+	json := []byte(`{"private" : false}`)
+	req, _ := http.NewRequest("PATCH", "http://example.com/api/rest/v2/projects/dimoxinil?revision=my-revision", bytes.NewBuffer(json))
 	err := s.rm.Parse(ctx, req)
 	s.NoError(err)
 	s.Equal(json, s.rm.(*projectIDPatchHandler).body)
+	s.Equal("my-revision", s.rm.(*projectIDPatchHandler).revision)
 }
 
 func (s *ProjectPatchByIDSuite) TestRunInValidIdentifierChange() {

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -20,7 +20,6 @@ import (
 
 type ProjectPatchByIDSuite struct {
 	sc *data.MockConnector
-	// data data.MockProjectConnector
 	rm gimlet.RouteHandler
 
 	suite.Suite
@@ -55,7 +54,6 @@ func (s *ProjectPatchByIDSuite) TestRunInValidIdentifierChange() {
 	h.body = json
 
 	resp := s.rm.Run(ctx)
-	s.rm.Run(ctx)
 	s.NotNil(resp.Data())
 	s.Equal(resp.Status(), http.StatusForbidden)
 
@@ -71,9 +69,21 @@ func (s *ProjectPatchByIDSuite) TestRunInvalidNonExistingId() {
 	h.body = json
 
 	resp := s.rm.Run(ctx)
-	s.rm.Run(ctx)
 	s.NotNil(resp.Data())
 	s.Equal(resp.Status(), http.StatusNotFound)
+}
+
+func (s *ProjectPatchByIDSuite) TestRunValid() {
+	ctx := context.Background()
+	json := []byte(`{"enabled": true}`)
+	h := s.rm.(*projectIDPatchHandler)
+	h.projectID = "dimoxinil"
+	h.revision = "my-revision"
+	h.body = json
+	resp := s.rm.Run(ctx)
+	s.NotNil(resp)
+	s.NotNil(resp.Data())
+	s.Equal(resp.Status(), http.StatusOK)
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I originally made a separate route for this, but actually it's such a simple change I think a "revision" query parameter to the PATCH project route should be enough.