### PR TITLE
EVG-6255: update module githashes for commit queue patches

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -349,6 +349,7 @@ func (p *Patch) UpdateGithashProjectAndTasks() error {
 	update := bson.M{
 		"$set": bson.M{
 			GithashKey:       p.Githash,
+			PatchesKey:       p.Patches,
 			PatchedConfigKey: p.PatchedConfig,
 			VariantsTasksKey: p.VariantsTasks,
 			BuildVariantsKey: p.BuildVariants,

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -175,6 +175,7 @@ func (s *patchSuite) TestUpdateGithashProjectAndTasks() {
 	s.Empty(patch.PatchedConfig)
 
 	patch.Githash = "abcdef"
+	patch.Patches = []ModulePatch{{Githash: "abcdef"}}
 	patch.Tasks = append(patch.Tasks, "task1")
 	patch.BuildVariants = append(patch.BuildVariants, "bv1")
 	patch.PatchedConfig = "config"
@@ -191,6 +192,9 @@ func (s *patchSuite) TestUpdateGithashProjectAndTasks() {
 
 	s.Equal("abcdef", dbPatch.Githash)
 	s.Equal("config", dbPatch.PatchedConfig)
+
+	s.Require().Len(dbPatch.Patches, 1)
+	s.Equal("abcdef", dbPatch.Patches[0].Githash)
 
 	s.Require().NotEmpty(patch.Tasks)
 	s.Equal("task1", dbPatch.Tasks[0])

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -218,6 +218,11 @@ func (as *APIServer) updatePatchModule(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	if p.Version != "" && p.Alias == evergreen.CommitQueueAlias {
+		as.LoggedError(w, r, http.StatusBadRequest, errors.New("can't update modules for in-flight commit queue tests"))
+		return
+	}
+
 	if err = p.UpdateModulePatch(modulePatch); err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return


### PR DESCRIPTION
In the CLI commit queue the githashes within a patch's modules were not being updated to the latest hashes.
If a patch was merged while an item was already enqueued the second item's merge would fail since git.get_project does a hard reset to each module's githash before applying a patch. 