### PR TITLE
EVG-6282: add distro option to set the directory where evergreen binary is downloaded

### DIFF
--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -24,6 +24,7 @@ var (
 	CloneMethod         = bsonutil.MustHaveTag(Distro{}, "CloneMethod")
 	ShellPath           = bsonutil.MustHaveTag(Distro{}, "ShellPath")
 	CuratorDir          = bsonutil.MustHaveTag(Distro{}, "CuratorDir")
+	ClientDir           = bsonutil.MustHaveTag(Distro{}, "ClientDir")
 	WorkDirKey          = bsonutil.MustHaveTag(Distro{}, "WorkDir")
 	SpawnAllowedKey     = bsonutil.MustHaveTag(Distro{}, "SpawnAllowed")
 	ExpansionsKey       = bsonutil.MustHaveTag(Distro{}, "Expansions")

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -30,6 +30,7 @@ type Distro struct {
 	CloneMethod         string                  `bson:"clone_method" json:"clone_method,omitempty" mapstructure:"clone_method,omitempty"`
 	ShellPath           string                  `bson:"shell_path" json:"shell_path" mapstructure:"shell_path,omitempty"`
 	CuratorDir          string                  `bson:"curator_dir" json:"curator_dir" mapstructure:"curator_dir,omitempty"`
+	ClientDir           string                  `bson:"client_dir" json:"client_dir" mapstructure:"client_dir,omitempty"`
 	SSHKey              string                  `bson:"ssh_key,omitempty" json:"ssh_key,omitempty" mapstructure:"ssh_key,omitempty"`
 	SSHOptions          []string                `bson:"ssh_options,omitempty" json:"ssh_options,omitempty" mapstructure:"ssh_options,omitempty"`
 	SpawnAllowed        bool                    `bson:"spawn_allowed" json:"spawn_allowed,omitempty" mapstructure:"spawn_allowed,omitempty"`

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -134,6 +134,7 @@ type APIDistro struct {
 	CloneMethod         APIString              `json:"clone_method"`
 	ShellPath           APIString              `json:"shell_path"`
 	CuratorDir          APIString              `json:"curator_dir"`
+	ClientDir           APIString              `json:"client_dir"`
 	SSHKey              APIString              `json:"ssh_key"`
 	SSHOptions          []string               `json:"ssh_options"`
 	Expansions          []APIExpansion         `json:"expansions"`
@@ -190,6 +191,7 @@ func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
 	apiDistro.CloneMethod = ToAPIString(d.CloneMethod)
 	apiDistro.ShellPath = ToAPIString(d.ShellPath)
 	apiDistro.CuratorDir = ToAPIString(d.CuratorDir)
+	apiDistro.ClientDir = ToAPIString(d.ClientDir)
 	apiDistro.SSHKey = ToAPIString(d.SSHKey)
 	apiDistro.Disabled = d.Disabled
 	apiDistro.ContainerPool = ToAPIString(d.ContainerPool)
@@ -247,6 +249,7 @@ func (apiDistro *APIDistro) ToService() (interface{}, error) {
 	}
 	d.ShellPath = FromAPIString(apiDistro.ShellPath)
 	d.CuratorDir = FromAPIString(apiDistro.CuratorDir)
+	d.ClientDir = FromAPIString(apiDistro.ClientDir)
 	d.SSHKey = FromAPIString(apiDistro.SSHKey)
 	d.SSHOptions = apiDistro.SSHOptions
 	d.SpawnAllowed = apiDistro.UserSpawnAllowed

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1110,7 +1110,7 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 				"clone_method": "legacy-ssh",
 				"shell_path": "/usr/bin/bash",
 				"curator_dir": "/usr/local/bin",
-				"client_dir": "/usr/bin"
+				"client_dir": "/usr/bin",
 				"ssh_key" : "~SSH string",
 				"ssh_options" : [
 					"~StrictHostKeyChecking=no",

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1110,6 +1110,7 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 				"clone_method": "legacy-ssh",
 				"shell_path": "/usr/bin/bash",
 				"curator_dir": "/usr/local/bin",
+				"client_dir": "/usr/bin"
 				"ssh_key" : "~SSH string",
 				"ssh_options" : [
 					"~StrictHostKeyChecking=no",
@@ -1171,6 +1172,7 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 	s.Equal(model.ToAPIString(distro.CloneMethodLegacySSH), apiDistro.CloneMethod)
 	s.Equal(model.ToAPIString("/usr/bin/bash"), apiDistro.ShellPath)
 	s.Equal(model.ToAPIString("/usr/local/bin"), apiDistro.CuratorDir)
+	s.Equal(model.ToAPIString("/usr/bin"), apiDistro.ClientDir)
 	s.Equal(apiDistro.User, model.ToAPIString("~root"))
 	s.Equal(apiDistro.SSHKey, model.ToAPIString("~SSH string"))
 	s.Equal(apiDistro.SSHOptions, []string{"~StrictHostKeyChecking=no", "~BatchMode=no", "~ConnectTimeout=10"})

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -594,7 +594,12 @@ Evergreen - Distros
         <div>
           <label class="distro-label">Curator Directory:</label>
           <input type="text" ng-readonly="readOnly" name="curatorDir"
-            class="form-control" ng-model="activeDistro.settings.curator_dir" placeholder="Absolute native path to the directory containing curator binary">
+            class="form-control" ng-model="activeDistro.settings.curator_dir" placeholder="Absolute native path to the directory of the curator binary">
+        </div>
+        <div>
+          <label class="distro-label">Client Directory:</label>
+          <input type="text" ng-readonly="readOnly" name="clientDir"
+            class="form-control" ng-model="activeDistro.settings.client_dir" placeholder="Absolute native path to the directory of the evergreen binary">
         </div>
         <div>
           <div>


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6282

New setting determines where the agent monitor installs the evergreen client for the agent.