### PR TITLE
EVG-6163 serialize some trend chart queries

### DIFF
--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -703,6 +703,7 @@ mciModule.controller('PerfController', function PerfController(
     let getLegactHistory = function() {
       $http.get("/plugin/json/history/" + $scope.task.id + "/perf").then(function(resp){
         trendDataSuccess(resp.data);
+        $q.all([historyPromise, changePointsQ.catch(), buildFailuresQ.catch()]).then(onHistoryRetrieved, onHistoryRetrieved);
       }, function() {
         if (!$scope.allTrendSamples) {
           $scope.allTrendSamples = new TrendSamples([]);
@@ -728,8 +729,6 @@ mciModule.controller('PerfController', function PerfController(
       $scope.hideEmptyGraphs();
       setTimeout(drawTrendGraph, 0, $scope);
     };
-    $q.all([historyPromise, changePointsQ.catch(), buildFailuresQ.catch()])
-      .then(onHistoryRetrieved, onHistoryRetrieved);
   }
 
   if ($scope.conf.enabled){


### PR DESCRIPTION
I'm not sure that this is the entirety of the problem, but weird ordering issues with angular's $q will definitely cause the graphs to not show (and bugsnag shows occurrences of this)