### PR TITLE
EVG-6093: report config unmarshal error as a GitHub status

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -8,8 +8,10 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
+
+const LoadProjectError = "load project error(s)"
 
 // This file contains the infrastructure for turning a YAML project configuration
 // into a usable Project struct. A basic overview of the project parsing process is:
@@ -408,10 +410,7 @@ func LoadProjectInto(data []byte, identifier string, project *Project) error {
 			}
 			buf.WriteString(e.Error())
 		}
-		if len(errs) > 1 {
-			return errors.Errorf("project errors: %v", buf.String())
-		}
-		return errors.Errorf("project error: %v", buf.String())
+		return errors.Errorf("%s: %s", LoadProjectError, buf.String())
 	}
 	*project = *p
 	project.Identifier = identifier

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -211,6 +211,9 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		if strings.Contains(err.Error(), thirdparty.Github502Error) {
 			j.gitHubError = GitHubInternalError
 		}
+		if strings.Contains(err.Error(), model.LoadProjectError) {
+			j.gitHubError = InvalidConfig
+		}
 		return errors.Wrap(err, "can't get patched config")
 	}
 	errs := validator.CheckProjectSyntax(project)


### PR DESCRIPTION
Although a status is sent to GitHub for project validation errors, only a generic error would be sent if the project file couldn't be unmarshaled. 
This will send the invalid project validation error to GitHub.