### PR TITLE
EVG-5321 Include task name in build baron plugin JQL search

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1568,12 +1568,8 @@ func (t *Task) GetJQL(searchProjects []string) string {
 			jqlParts = append(jqlParts, fmt.Sprintf("text~\"%v\"", util.EscapeJQLReservedChars(fileParts[len(fileParts)-1])))
 		}
 	}
-	if jqlParts != nil {
-		jqlClause = strings.Join(jqlParts, " or ")
-	} else {
-		jqlClause = fmt.Sprintf("text~\"%v\"", util.EscapeJQLReservedChars(t.DisplayName))
-	}
-
+	jqlParts = append(jqlParts, fmt.Sprintf("text~\"%v\"", util.EscapeJQLReservedChars(t.DisplayName)))
+	jqlClause = strings.Join(jqlParts, " or ")
 	return fmt.Sprintf(jqlBFQuery, strings.Join(searchProjects, ", "), jqlClause)
 }
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1167,3 +1167,26 @@ func TestFindVariantsWithTask(t *testing.T) {
 	assert.Equal(bvs[0], "bv2")
 	assert.Equal(bvs[1], "bv1")
 }
+
+func TestGetJQL(t *testing.T) {
+	testResults := []TestResult{
+		{
+			Status:   evergreen.TestFailedStatus,
+			TestFile: "firstTestFile",
+		},
+		{
+			Status:   evergreen.TestFailedStatus,
+			TestFile: "secondTestFile",
+		},
+		{
+			Status:   evergreen.TestSucceededStatus,
+			TestFile: "thirdTestFIle",
+		},
+	}
+	task := &Task{
+		LocalTestResults: testResults,
+		DisplayName:      "taskName",
+	}
+	jql := task.GetJQL([]string{"ONE", "TWO"})
+	assert.Equal(t, "(project in (ONE, TWO)) and ( text~\"firstTestFile\" or text~\"secondTestFile\" or text~\"taskName\" ) order by updatedDate desc", jql)
+}

--- a/service/ui_plugin_build_baron.go
+++ b/service/ui_plugin_build_baron.go
@@ -392,7 +392,7 @@ type jiraSuggest struct {
 func (js *jiraSuggest) Suggest(ctx context.Context, t *task.Task) ([]thirdparty.JiraTicket, error) {
 	jql := t.GetJQL(js.bbProj.TicketSearchProjects)
 
-	results, err := js.jiraHandler.JQLSearch(jql, 0, -1)
+	results, err := js.jiraHandler.JQLSearch(jql, 0, 100)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds the task name to the build baron plugin JQL search because there were
cases where tickets were not returned. To avoid returning very large numbers of
tickets to the user, this also limits the results to 100.