### PR TITLE
EVG-5994: Fix time taken and makespan in UI

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1696,3 +1696,26 @@ func (t *Task) IsBlockedDisplayTask() bool {
 	}
 	return blockedState == taskBlocked
 }
+
+// GetTimeSpent returns the total time_taken and makespan of tasks
+// tasks should not include display tasks so they aren't double counted
+func GetTimeSpent(tasks []Task) (time.Duration, time.Duration) {
+	var timeTaken time.Duration
+	earliestStartTime := util.MaxTime
+	latestFinishTime := util.ZeroTime
+	for _, t := range tasks {
+		timeTaken += t.TimeTaken
+		if !util.IsZeroTime(t.StartTime) && t.StartTime.Before(earliestStartTime) {
+			earliestStartTime = t.StartTime
+		}
+		if t.FinishTime.After(latestFinishTime) {
+			latestFinishTime = t.FinishTime
+		}
+	}
+
+	if earliestStartTime == util.MaxTime || latestFinishTime == util.ZeroTime {
+		return 0, 0
+	}
+
+	return timeTaken, latestFinishTime.Sub(earliestStartTime)
+}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1167,3 +1167,38 @@ func TestFindVariantsWithTask(t *testing.T) {
 	assert.Equal(bvs[0], "bv2")
 	assert.Equal(bvs[1], "bv1")
 }
+
+func TestGetTimeSpent(t *testing.T) {
+	assert := assert.New(t)
+	referenceTime := time.Unix(1136239445, 0)
+	tasks := []Task{
+		{
+			StartTime:  referenceTime,
+			FinishTime: referenceTime.Add(time.Hour),
+			TimeTaken:  time.Hour,
+		},
+		{
+			StartTime:  referenceTime,
+			FinishTime: referenceTime.Add(2 * time.Hour),
+			TimeTaken:  2 * time.Hour,
+		},
+		{
+			StartTime:  referenceTime,
+			FinishTime: util.ZeroTime,
+			TimeTaken:  0,
+		},
+		{
+			StartTime:  util.ZeroTime,
+			FinishTime: util.ZeroTime,
+			TimeTaken:  0,
+		},
+	}
+
+	timeTaken, makespan := GetTimeSpent(tasks)
+	assert.Equal(3*time.Hour, timeTaken)
+	assert.Equal(2*time.Hour, makespan)
+
+	timeTaken, makespan = GetTimeSpent(tasks[2:])
+	assert.EqualValues(0, timeTaken)
+	assert.EqualValues(0, makespan)
+}

--- a/public/static/js/build.js
+++ b/public/static/js/build.js
@@ -1,5 +1,4 @@
 mciModule.controller('BuildVariantHistoryController', function($scope, $http, $filter, $timeout, $window) {
-  var nsPerMs = 1000000
   $scope.userTz = $window.userTz;
   $scope.builds = [];
   $scope.buildId = "";
@@ -66,6 +65,7 @@ mciModule.controller('BuildVariantHistoryController', function($scope, $http, $f
 
 
 mciModule.controller('BuildViewController', function($scope, $http, $timeout, $rootScope, mciTime, $window, $mdDialog, mciSubscriptionsService, notificationService, $mdToast) {
+  var nsPerMs = 1000000
   $scope.build = {};
   $scope.computed = {};
   $scope.loading = false;
@@ -249,9 +249,13 @@ mciModule.controller('BuildViewController', function($scope, $http, $timeout, $r
       }
     )
 
-    $scope.totalTimeMS = _.reduce(_.pluck(finishedOnly, "Task"), function(x, y){return x.time_taken+y.time_taken}, 0) / nsPerMs;
+
+    $scope.totalTimeMS = _.reduce(
+      _.map(finishedOnly,
+        function(x) {return x.Task.time_taken}), 
+      function(x, y){return x+y}, 0) / nsPerMs;
     };
-    
+
     $rootScope.$on("build_updated", function(e, newBuild){
       newBuild.PatchInfo = $scope.build.PatchInfo
       $scope.setBuild(newBuild);

--- a/public/static/js/build.js
+++ b/public/static/js/build.js
@@ -250,7 +250,8 @@ mciModule.controller('BuildViewController', function($scope, $http, $timeout, $r
     )
 
     $scope.totalTimeMS = _.reduce(_.pluck(finishedOnly, "Task"), function(x, y){return x.time_taken+y.time_taken}, 0) / nsPerMs;
-
+    };
+    
     $rootScope.$on("build_updated", function(e, newBuild){
       newBuild.PatchInfo = $scope.build.PatchInfo
       $scope.setBuild(newBuild);

--- a/public/static/js/build.js
+++ b/public/static/js/build.js
@@ -227,43 +227,18 @@ mciModule.controller('BuildViewController', function($scope, $http, $timeout, $r
 
     $scope.lastUpdate = mciTime.now();
 
-    //calculate makespan and total processing time for the build
+    $scope.makeSpanMS = build.makespan / nsPerMs;
+    $scope.totalTimeMS = build.time_taken / nsPerMs;
+  };
 
-    // filter function to remove zero times from a list of times
-    var nonZeroTimeFilter = function(y){return (+y) != (+new Date(0))}
-
-    // extract the start an end times for the tasks in the build, discarding the zero times
-    var taskStartTimes = _.filter(build.Tasks.map(function(x){return new Date(x.Task.start_time)}).sort(dateSorter), nonZeroTimeFilter)
-    var taskEndTimes = _.filter(build.Tasks.map(function(x){return  new Date(x.Task.finish_time)}).sort(dateSorter), nonZeroTimeFilter)
-
-    //  calculate the makespan by taking the difference of the first start time and last end time
-    if(taskStartTimes.length == 0 || taskEndTimes.length == 0) {
-      $scope.makeSpanMS = 0
-    }else {
-      $scope.makeSpanMS = taskEndTimes[taskEndTimes.length-1] - taskStartTimes[0]
-    }
-
-    var finishedOnly = _.filter(build.Tasks,
-      function(x){
-        return new Date(x.Task.start_time) > new Date(0) && new Date(x.Task.finish_time) > new Date(0)
-      }
-    )
-
-
-    $scope.totalTimeMS = _.reduce(
-      _.map(finishedOnly,
-        function(x) {return x.Task.time_taken}), 
-      function(x, y){return x+y}, 0) / nsPerMs;
-    };
-
-    $rootScope.$on("build_updated", function(e, newBuild){
-      newBuild.PatchInfo = $scope.build.PatchInfo
-      $scope.setBuild(newBuild);
-    });
-
-
-    $scope.setBuild($window.build);
-
-    $scope.plugins = $window.plugins
-
+  $rootScope.$on("build_updated", function(e, newBuild){
+    newBuild.PatchInfo = $scope.build.PatchInfo
+    $scope.setBuild(newBuild);
   });
+
+
+  $scope.setBuild($window.build);
+
+  $scope.plugins = $window.plugins
+
+});

--- a/public/static/js/build.js
+++ b/public/static/js/build.js
@@ -1,4 +1,5 @@
 mciModule.controller('BuildVariantHistoryController', function($scope, $http, $filter, $timeout, $window) {
+  var nsPerMs = 1000000
   $scope.userTz = $window.userTz;
   $scope.builds = [];
   $scope.buildId = "";
@@ -247,12 +248,8 @@ mciModule.controller('BuildViewController', function($scope, $http, $timeout, $r
         return new Date(x.Task.start_time) > new Date(0) && new Date(x.Task.finish_time) > new Date(0)
       }
     )
-    $scope.totalTimeMS = _.reduce(
-      _.map(finishedOnly,
-        function(x){return new Date(x.Task.finish_time) - new Date(x.Task.start_time)}),
-        function(sum, el){return sum+el},
-        0)
-    };
+
+    $scope.totalTimeMS = _.reduce(_.pluck(finishedOnly, "Task"), function(x, y){return x.time_taken+y.time_taken}, 0) / nsPerMs;
 
     $rootScope.$on("build_updated", function(e, newBuild){
       newBuild.PatchInfo = $scope.build.PatchInfo

--- a/public/static/js/version.js
+++ b/public/static/js/version.js
@@ -192,21 +192,13 @@ mciModule.controller('VersionController', function($scope, $rootScope, $location
       return task.status == "success" || task.status == "failed"
     });
     var taskStartTimes = _.filter(_.pluck(tasks, "start_time").map(function(x){return new Date(x)}), nonZeroTimeFilter).sort(dateSorter);
-    var taskEndTimes = _.filter(tasks.map(function(x){
-        if(x.time_taken == 0 || +new Date(x.start_time) == +new Date(0)){
-            return new Date(0);
-        }else{
-            return new Date((+new Date(x.start_time)) + (x.time_taken/nsPerMs));
-        }
-    }), nonZeroTimeFilter).sort(dateSorter);
+    var taskEndTimes = _.filter(_.pluck(tasks, "finish_time").map(function(x){return new Date(x)}), nonZeroTimeFilter).sort(dateSorter);
 
     if(taskStartTimes.length == 0 || taskEndTimes.length == 0) {
         $scope.makeSpanMS = 0;
     }else {
         $scope.makeSpanMS = taskEndTimes[taskEndTimes.length-1] - taskStartTimes[0];
     }
-
-    $scope.makeSpanMS = taskEndTimes[taskEndTimes.length-1] - taskStartTimes[0];
 
     var availableTasks = _.filter(tasks, function(t){
       return +new Date(t.start_time) != +new Date(0);

--- a/public/static/js/version.js
+++ b/public/static/js/version.js
@@ -185,26 +185,8 @@ mciModule.controller('VersionController', function($scope, $rootScope, $location
     $scope.taskNames = Object.keys(taskNames).sort()
     $scope.lastUpdate = $now.now();
 
-    //calculate makespan and total processing time for the version
-    var nonZeroTimeFilter = function(y){return (+y) != (+new Date(0))};
-
-    var tasks = _.filter(version.Builds.map(function(x){ return _.pluck(x['Tasks'] || [], "Task") }).reduce(function(x,y){return x.concat(y)}, []), function(task){
-      return task.status == "success" || task.status == "failed"
-    });
-    var taskStartTimes = _.filter(_.pluck(tasks, "start_time").map(function(x){return new Date(x)}), nonZeroTimeFilter).sort(dateSorter);
-    var taskEndTimes = _.filter(_.pluck(tasks, "finish_time").map(function(x){return new Date(x)}), nonZeroTimeFilter).sort(dateSorter);
-
-    if(taskStartTimes.length == 0 || taskEndTimes.length == 0) {
-        $scope.makeSpanMS = 0;
-    }else {
-        $scope.makeSpanMS = taskEndTimes[taskEndTimes.length-1] - taskStartTimes[0];
-    }
-
-    var availableTasks = _.filter(tasks, function(t){
-      return +new Date(t.start_time) != +new Date(0);
-    })
-
-    $scope.totalTimeMS = _.reduce(_.pluck(availableTasks, "time_taken"), function(x, y){return x+y}, 0) / nsPerMs;
+    $scope.makeSpanMS = version.makespan / nsPerMs
+    $scope.totalTimeMS = version.time_taken / nsPerMs;
   };
 
   $scope.getGridLink = function(bv, test) {

--- a/service/models.go
+++ b/service/models.go
@@ -40,6 +40,8 @@ type uiVersion struct {
 	RepoOwner    string          `json:"repo_owner"`
 	Repo         string          `json:"repo_name"`
 	UpstreamData *uiUpstreamData `json:"upstream,omitempty"`
+	TimeTaken    time.Duration   `json:"time_taken"`
+	Makespan     time.Duration   `json:"makespan"`
 }
 
 type uiUpstreamData struct {
@@ -76,6 +78,8 @@ type uiBuild struct {
 	PatchInfo       *uiPatch `json:",omitempty"`
 	Tasks           []uiTask
 	Elapsed         time.Duration
+	TimeTaken       time.Duration `json:"time_taken"`
+	Makespan        time.Duration `json:"makespan"`
 	CurrentTime     int64
 	RepoOwner       string               `json:"repo_owner"`
 	Repo            string               `json:"repo_name"`

--- a/service/version.go
+++ b/service/version.go
@@ -168,7 +168,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 					"task_id": t.Id,
 					"version": projCtx.Version.Id,
 					"request": gimlet.GetRequestID(ctx),
-					"message": "version references task that does not exist",
+					"message": "build references task that does not exist",
 				})
 			}
 			uiTasks = append(uiTasks, uiT)

--- a/service/version.go
+++ b/service/version.go
@@ -153,7 +153,8 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 					DisplayName: t.DisplayName,
 				}}
 
-			taskFromDb, err := task.FindOne(task.ById(t.Id).WithFields(task.FinishTimeKey, task.ExpectedDurationKey))
+			var taskFromDb *task.Task
+			taskFromDb, err = task.FindOne(task.ById(t.Id).WithFields(task.FinishTimeKey, task.ExpectedDurationKey))
 			if err != nil {
 				uis.LoggedError(w, r, http.StatusInternalServerError, err)
 				return

--- a/util/time.go
+++ b/util/time.go
@@ -8,6 +8,9 @@ import (
 // ZeroTime represents 0 in epoch time
 var ZeroTime time.Time = time.Unix(0, 0)
 
+// MaxTime represents the latest useful golang date (219248499-12-06 15:30:07.999999999 +0000 UTC)
+var MaxTime time.Time = time.Unix(1<<63-62135596801, 999999999)
+
 // IsZeroTime checks that a time is either equal to golang ZeroTime or
 // UTC ZeroTime.
 func IsZeroTime(t time.Time) bool {


### PR DESCRIPTION
The UI was miscalculating the time taken for builds and the makespan for versions.
Both of these were the result of assumptions about tasks that didn't hold for display tasks since execution tasks run in parallel so `time_taken != finish_time - start_time`.