### PR TITLE
EVG-6228 all project routes should return projectRefs

### DIFF
--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -101,7 +101,7 @@ func (p *projectGetHandler) Run(ctx context.Context) gimlet.Responder {
 	projects = projects[:lastIndex]
 
 	for _, proj := range projects {
-		projectModel := &model.APIProject{}
+		projectModel := &model.APIProjectRef{}
 		if err = projectModel.BuildFromService(proj); err != nil {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 				Message:    "problem converting project document",
@@ -482,7 +482,7 @@ func (h *projectIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
-	projectModel := &model.APIProject{}
+	projectModel := &model.APIProjectRef{}
 
 	if err = projectModel.BuildFromService(project); err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -278,7 +278,7 @@ func (s *ProjectGetByIDSuite) TestRunExistingId() {
 	s.NotNil(resp.Data())
 	s.Equal(resp.Status(), http.StatusOK)
 
-	s.Equal(model.ToAPIString("dimoxinil"), resp.Data().(*model.APIProject).Identifier)
+	s.Equal(model.ToAPIString("dimoxinil"), resp.Data().(*model.APIProjectRef).Identifier)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -337,7 +337,7 @@ func (s *ProjectGetSuite) TestPaginatorShouldReturnResultsIfDataExists() {
 	payload := resp.Data().([]interface{})
 
 	s.Len(payload, 1)
-	s.Equal(model.ToAPIString("projectC"), (payload[0]).(*model.APIProject).Identifier)
+	s.Equal(model.ToAPIString("projectC"), (payload[0]).(*model.APIProjectRef).Identifier)
 
 	pageData := resp.Pages()
 	s.Nil(pageData.Prev)
@@ -355,8 +355,8 @@ func (s *ProjectGetSuite) TestPaginatorShouldReturnEmptyResultsIfDataIsEmpty() {
 	payload := resp.Data().([]interface{})
 
 	s.Len(payload, 6)
-	s.Equal(model.ToAPIString("projectA"), (payload[0]).(*model.APIProject).Identifier, payload[0])
-	s.Equal(model.ToAPIString("projectB"), (payload[1]).(*model.APIProject).Identifier, payload[1])
+	s.Equal(model.ToAPIString("projectA"), (payload[0]).(*model.APIProjectRef).Identifier, payload[0])
+	s.Equal(model.ToAPIString("projectB"), (payload[1]).(*model.APIProjectRef).Identifier, payload[1])
 
 	s.Nil(resp.Pages())
 }


### PR DESCRIPTION
Tiny fix I'm throwing on my documentation ticket. In some routes we're using ProjectRefs but building APIProjects, which loses information and is inconsistent.