### PR TITLE
EVG-6302: make commit queue CLI respect -c option

### DIFF
--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -123,7 +123,7 @@ func mergeCommand() cli.Command {
 				large:       c.Bool(largeFlagName),
 			}
 
-			conf, err := NewClientSettings(c.Parent().String(confFlagName))
+			conf, err := NewClientSettings(c.Parent().Parent().String(confFlagName))
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
@@ -159,7 +159,7 @@ func setModuleCommand() cli.Command {
 				skipConfirm: c.Bool(yesFlagName),
 			}
 
-			conf, err := NewClientSettings(c.Parent().String(confFlagName))
+			conf, err := NewClientSettings(c.Parent().Parent().String(confFlagName))
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}


### PR DESCRIPTION
The fixes in #2123 did not include the merge and set-module subcommands.