### PR TITLE
EVG-6220: prevent notifications for aborted tasks

### DIFF
--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -39,6 +39,7 @@ type TaskEventData struct {
 	UserId    string `bson:"u_id,omitempty" json:"user_id,omitempty"`
 	Status    string `bson:"s,omitempty" json:"status,omitempty"`
 	JiraIssue string `bson:"jira,omitempty" json:"jira,omitempty"`
+	Aborted   bool   `bson:"aborted", json:"aborted"`
 
 	Timestamp time.Time `bson:"ts,omitempty" json:"timestamp,omitempty"`
 	Priority  int64     `bson:"pri,omitempty" json:"priority,omitempty"`
@@ -114,8 +115,8 @@ func LogTaskStarted(taskId string, execution int) {
 	logTaskEvent(taskId, TaskStarted, TaskEventData{Execution: execution})
 }
 
-func LogTaskFinished(taskId string, execution int, hostId, status string) {
-	logTaskEvent(taskId, TaskFinished, TaskEventData{Execution: execution, Status: status})
+func LogTaskFinished(taskId string, execution int, hostId, status string, aborted bool) {
+	logTaskEvent(taskId, TaskFinished, TaskEventData{Execution: execution, Status: status, Aborted: aborted})
 	LogHostEvent(hostId, EventTaskFinished, HostEventData{TaskExecution: execution, TaskStatus: status, TaskId: taskId})
 }
 

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -39,7 +39,7 @@ type TaskEventData struct {
 	UserId    string `bson:"u_id,omitempty" json:"user_id,omitempty"`
 	Status    string `bson:"s,omitempty" json:"status,omitempty"`
 	JiraIssue string `bson:"jira,omitempty" json:"jira,omitempty"`
-	Aborted   bool   `bson:"aborted", json:"aborted"`
+	Aborted   bool   `bson:"aborted" json:"aborted"`
 
 	Timestamp time.Time `bson:"ts,omitempty" json:"timestamp,omitempty"`
 	Priority  int64     `bson:"pri,omitempty" json:"priority,omitempty"`

--- a/model/event/task_event_test.go
+++ b/model/event/task_event_test.go
@@ -36,7 +36,7 @@ func TestLoggingTaskEvents(t *testing.T) {
 			time.Sleep(1 * time.Millisecond)
 			LogTaskStarted(taskId, 1)
 			time.Sleep(1 * time.Millisecond)
-			LogTaskFinished(taskId, 1, hostId, evergreen.TaskSucceeded)
+			LogTaskFinished(taskId, 1, hostId, evergreen.TaskSucceeded, true)
 
 			eventsForTask, err := Find(AllLogCollection, TaskEventsInOrder(taskId))
 			So(err, ShouldEqual, nil)
@@ -105,6 +105,7 @@ func TestLoggingTaskEvents(t *testing.T) {
 			So(eventData.UserId, ShouldBeBlank)
 			So(eventData.Status, ShouldEqual, evergreen.TaskSucceeded)
 			So(eventData.Timestamp.IsZero(), ShouldBeTrue)
+			So(eventData.Aborted, ShouldBeTrue)
 		})
 	})
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -672,15 +672,15 @@ func (t *Task) MarkSystemFailed() error {
 }
 
 // SetAborted sets the abort field of task to aborted
-func (t *Task) SetAborted() error {
-	t.Aborted = true
+func (t *Task) SetAborted(aborted bool) error {
+	t.Aborted = aborted
 	return UpdateOne(
 		bson.M{
 			IdKey: t.Id,
 		},
 		bson.M{
 			"$set": bson.M{
-				AbortedKey: true,
+				AbortedKey: aborted,
 			},
 		},
 	)
@@ -741,7 +741,6 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 
 	t.TimeTaken = finishTime.Sub(t.StartTime)
 	t.Details = *detail
-	t.Aborted = false
 
 	grip.Debug(message.Fields{
 		"message":   "marking task finished",
@@ -762,9 +761,6 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 				DetailsKey:    t.Details,
 				StartTimeKey:  t.StartTime,
 				LogsKey:       detail.Logs,
-			},
-			"$unset": bson.M{
-				AbortedKey: "",
 			},
 		})
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -655,7 +655,7 @@ func (t *Task) MarkSystemFailed() error {
 		Type:   evergreen.CommandTypeSystem,
 	}
 
-	event.LogTaskFinished(t.Id, t.Execution, t.HostId, evergreen.TaskSystemFailed)
+	event.LogTaskFinished(t.Id, t.Execution, t.HostId, evergreen.TaskSystemFailed, false)
 
 	return UpdateOne(
 		bson.M{
@@ -741,6 +741,7 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 
 	t.TimeTaken = finishTime.Sub(t.StartTime)
 	t.Details = *detail
+	t.Aborted = false
 
 	grip.Debug(message.Fields{
 		"message":   "marking task finished",

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1204,14 +1204,13 @@ func TestGetTimeSpent(t *testing.T) {
 }
 
 func TestSetAborted(t *testing.T) {
-	assert := assert.New(t)
 	t1 := Task{Id: "t1"}
-	assert.NoError(t1.Insert())
+	assert.NoError(t, t1.Insert())
 
-	assert.NoError(t1.SetAborted(true))
-	assert.True(t1.Aborted)
+	assert.NoError(t, t1.SetAborted(true))
+	assert.True(t, t1.Aborted)
 
 	dbT1, err := FindOneId("t1")
-	assert.NoError(err)
-	assert.True(dbT1.Aborted)
+	require.NoError(t, err)
+	assert.True(t, dbT1.Aborted)
 }

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1202,3 +1202,16 @@ func TestGetTimeSpent(t *testing.T) {
 	assert.EqualValues(0, timeTaken)
 	assert.EqualValues(0, makespan)
 }
+
+func TestSetAborted(t *testing.T) {
+	assert := assert.New(t)
+	t1 := Task{Id: "t1"}
+	assert.NoError(t1.Insert())
+
+	assert.NoError(t1.SetAborted(true))
+	assert.True(t1.Aborted)
+
+	dbT1, err := FindOneId("t1")
+	assert.NoError(err)
+	assert.True(dbT1.Aborted)
+}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -415,13 +415,15 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 			"activated_by": t.ActivatedBy,
 		})
 	}
+
+	status := t.ResultStatus()
+	event.LogTaskFinished(t.Id, t.Execution, t.HostId, status, t.Aborted)
+
 	err := t.MarkEnd(finishTime, detail)
 
 	if err != nil {
 		return errors.Wrap(err, "could not mark task finished")
 	}
-	status := t.ResultStatus()
-	event.LogTaskFinished(t.Id, t.Execution, t.HostId, status)
 
 	if t.IsPartOfDisplay() {
 		if err = UpdateDisplayTask(t.DisplayTask); err != nil {

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -143,7 +143,7 @@ func (t *taskTriggers) Process(sub *event.Subscription) (*notification.Notificat
 	if t.task.DisplayOnly {
 		return nil, nil
 	}
-	if t.task.Aborted {
+	if t.data.Aborted {
 		return nil, nil
 	}
 

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -370,8 +370,10 @@ func (s *taskSuite) TestAbortedTaskDoesNotNotify() {
 	s.NoError(err)
 	s.NotEmpty(n)
 
-	s.task.Aborted = true
-	s.NoError(db.Update(task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	taskData := s.event.Data.(*event.TaskEventData)
+	taskData.Aborted = true
+	s.event.Data = taskData
+
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)
 	s.Empty(n)


### PR DESCRIPTION
The previous fix (#2319) didn't work because MarkEnd clears the Aborted field.