### PR TITLE
 EVG-6249 copy subscriptions in API route and from UI

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -220,6 +220,9 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
           item.pr_testing_enabled = false;
           item.commit_queue.enabled = false;
           item.enabled = false;
+          item.subscriptions = _.filter($scope.subscriptions, function(d) {
+                return !d.changed;
+            });
           $http.post('/project/' + $scope.newProject.identifier, item).then(
             function(resp) {
               $scope.refreshTrackedProjects(data_put.AllProjects);

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -248,6 +248,8 @@ type Connector interface {
 	// GetSubscriptions returns the subscriptions that belong to a user
 	GetSubscriptions(string, event.OwnerType) ([]restModel.APISubscription, error)
 	DeleteSubscription(id string) error
+	// CopyProjectSubscriptions copies subscriptions from the first project for the second project.
+	CopyProjectSubscriptions(string, string) error
 
 	// Notifications
 	GetNotificationsStats() (*restModel.APIEventStats, error)

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -50,12 +50,12 @@ func (dc *DBSubscriptionConnector) DeleteSubscription(id string) error {
 }
 
 func (dc *DBSubscriptionConnector) CopyProjectSubscriptions(oldProject, newProject string) error {
-	catcher := grip.NewBasicCatcher()
 	subs, err := event.FindSubscriptionsByOwner(oldProject, event.OwnerTypeProject)
 	if err != nil {
 		return errors.Wrapf(err, "error finding subscription for project '%s'", oldProject)
 	}
 
+	catcher := grip.NewBasicCatcher()
 	for _, sub := range subs {
 		sub.Owner = newProject
 		sub.ID = ""

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	mgobson "gopkg.in/mgo.v2/bson"
 )
 
@@ -71,4 +72,77 @@ func TestGetSubscriptions(t *testing.T) {
 	apiSubs, err = c.GetSubscriptions("", event.OwnerTypePerson)
 	assert.EqualError(err, "400 (Bad Request): no subscription owner provided")
 	assert.Len(apiSubs, 0)
+}
+
+func TestCopyProjectSubscriptions(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	assert.NoError(db.ClearCollections(event.SubscriptionsCollection))
+
+	subs := []event.Subscription{
+		{
+			ID:           mgobson.NewObjectId().Hex(),
+			Owner:        "my-project",
+			OwnerType:    event.OwnerTypeProject,
+			ResourceType: "PATCH",
+			Trigger:      "outcome",
+			Selectors: []event.Selector{
+				{
+					Type: "id",
+					Data: "1234",
+				},
+			},
+			Subscriber: event.Subscriber{
+				Type:   event.EmailSubscriberType,
+				Target: "a@domain.invalid",
+			},
+		},
+		{
+			ID:           mgobson.NewObjectId().Hex(),
+			Owner:        "not-my-project",
+			OwnerType:    event.OwnerTypeProject,
+			ResourceType: "PATCH",
+			Trigger:      "outcome",
+			Selectors: []event.Selector{
+				{
+					Type: "id",
+					Data: "1234",
+				},
+			},
+			Subscriber: event.Subscriber{
+				Type:   event.EmailSubscriberType,
+				Target: "a@domain.invalid",
+			},
+		},
+	}
+	for _, sub := range subs {
+		assert.NoError(sub.Upsert())
+	}
+	c := &DBSubscriptionConnector{}
+
+	for name, test := range map[string]func(t *testing.T){
+		"FromNonExistentProject": func(t *testing.T) {
+			assert.NoError(c.CopyProjectSubscriptions("not-a-project", "my-new-project"))
+			apiSubs, err := event.FindSubscriptionsByOwner("my-new-project", event.OwnerTypeProject)
+			assert.NoError(err)
+			require.Len(apiSubs, 0)
+		},
+		"FromExistentProject": func(t *testing.T) {
+			assert.NoError(c.CopyProjectSubscriptions("my-project", "my-newest-project"))
+			apiSubs, err := event.FindSubscriptionsByOwner("my-project", event.OwnerTypeProject)
+			assert.NoError(err)
+			require.Len(apiSubs, 1)
+			assert.Equal(subs[0].ID, apiSubs[0].ID)
+
+			apiSubs, err = event.FindSubscriptionsByOwner("my-newest-project", event.OwnerTypeProject)
+			assert.NoError(err)
+			require.Len(apiSubs, 1)
+			assert.NotEqual(subs[0].ID, apiSubs[0].ID)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			test(t)
+		})
+	}
+
 }

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -75,9 +75,7 @@ func TestGetSubscriptions(t *testing.T) {
 }
 
 func TestCopyProjectSubscriptions(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	assert.NoError(db.ClearCollections(event.SubscriptionsCollection))
+	assert.NoError(t, db.ClearCollections(event.SubscriptionsCollection))
 
 	subs := []event.Subscription{
 		{
@@ -116,28 +114,28 @@ func TestCopyProjectSubscriptions(t *testing.T) {
 		},
 	}
 	for _, sub := range subs {
-		assert.NoError(sub.Upsert())
+		assert.NoError(t, sub.Upsert())
 	}
 	c := &DBSubscriptionConnector{}
 
 	for name, test := range map[string]func(t *testing.T){
 		"FromNonExistentProject": func(t *testing.T) {
-			assert.NoError(c.CopyProjectSubscriptions("not-a-project", "my-new-project"))
+			assert.NoError(t, c.CopyProjectSubscriptions("not-a-project", "my-new-project"))
 			apiSubs, err := event.FindSubscriptionsByOwner("my-new-project", event.OwnerTypeProject)
-			assert.NoError(err)
-			require.Len(apiSubs, 0)
+			assert.NoError(t, err)
+			require.Len(t, apiSubs, 0)
 		},
 		"FromExistentProject": func(t *testing.T) {
-			assert.NoError(c.CopyProjectSubscriptions("my-project", "my-newest-project"))
+			assert.NoError(t, c.CopyProjectSubscriptions("my-project", "my-newest-project"))
 			apiSubs, err := event.FindSubscriptionsByOwner("my-project", event.OwnerTypeProject)
-			assert.NoError(err)
-			require.Len(apiSubs, 1)
-			assert.Equal(subs[0].ID, apiSubs[0].ID)
+			assert.NoError(t, err)
+			require.Len(t, apiSubs, 1)
+			assert.Equal(t, subs[0].ID, apiSubs[0].ID)
 
 			apiSubs, err = event.FindSubscriptionsByOwner("my-newest-project", event.OwnerTypeProject)
-			assert.NoError(err)
-			require.Len(apiSubs, 1)
-			assert.NotEqual(subs[0].ID, apiSubs[0].ID)
+			assert.NoError(t, err)
+			require.Len(t, apiSubs, 1)
+			assert.NotEqual(t, subs[0].ID, apiSubs[0].ID)
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -78,12 +78,15 @@ func (p *projectCopyHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "error building API project from service"))
 	}
 
-	// copy variables and aliases
+	// copy variables, aliases, and subscriptions
 	if err = p.sc.CopyProjectVars(p.oldProjectId, p.newProjectId); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error copying project vars from project '%s'", p.oldProjectId))
 	}
 	if err = p.sc.CopyProjectAliases(p.oldProjectId, p.newProjectId); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error copying aliases from project '%s'", p.oldProjectId))
+	}
+	if err = p.sc.CopyProjectSubscriptions(p.oldProjectId, p.newProjectId); err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error copying subscriptions from project '%s'", p.oldProjectId))
 	}
 
 	return gimlet.NewJSONResponse(apiProjectRef)

--- a/service/project.go
+++ b/service/project.go
@@ -415,7 +415,10 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			},
 		}
 		subscription.OwnerType = event.OwnerTypeProject
-		subscription.Owner = projectRef.Identifier
+		if subscription.Owner != projectRef.Identifier {
+			subscription.Owner = projectRef.Identifier
+			subscription.ID = ""
+		}
 		if !trigger.ValidateTrigger(subscription.ResourceType, subscription.Trigger) {
 			catcher.Add(errors.Errorf("subscription type/trigger is invalid: %s/%s", subscription.ResourceType, subscription.Trigger))
 			continue


### PR DESCRIPTION
Current UI doesn't add subscriptions to the form data before copying project, and also doesn't change the ID (so would only update, not insert new subscriptions). This fix is verified in staging.