### PR TITLE
EVG-6268 catch race conditions when saving new config using an integer

### DIFF
--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -551,18 +551,20 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 		BuildVariant: "a_variant",
 	}
 	v := &Version{
-		Id:       "version_that_called_generate_task",
-		BuildIds: []string{"sample_build"},
-		Config:   sampleProjYml,
+		Id:                 "version_that_called_generate_task",
+		BuildIds:           []string{"sample_build"},
+		Config:             sampleProjYml,
+		ConfigUpdateNumber: 4,
 	}
 	s.NoError(sampleBuild.Insert())
 	s.NoError(v.Insert())
 
 	g := sampleGeneratedProject
 	g.TaskID = "task_that_called_generate_task"
-	p, v, t, pm, prevConfig, err := g.NewVersion()
+	p, v, t, pm, err := g.NewVersion()
 	s.NoError(err)
-	s.NoError(g.Save(context.Background(), p, v, t, pm, prevConfig))
+	s.NoError(g.Save(context.Background(), p, v, t, pm))
+	s.Equal(5, v.ConfigUpdateNumber)
 	builds, err := build.Find(db.Query(bson.M{}))
 	s.NoError(err)
 	tasks := []task.Task{}
@@ -622,9 +624,10 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 
 	g := sampleGeneratedProjectAddToBVOnly
 	g.TaskID = "task_that_called_generate_task"
-	p, v, t, pm, prevConfig, err := g.NewVersion()
+	p, v, t, pm, err := g.NewVersion()
 	s.NoError(err)
-	s.NoError(g.Save(context.Background(), p, v, t, pm, prevConfig))
+	s.NoError(g.Save(context.Background(), p, v, t, pm))
+	s.Equal(1, v.ConfigUpdateNumber)
 	tasks := []task.Task{}
 	err = db.FindAllQ(task.Collection, db.Query(bson.M{}), &tasks)
 	s.NoError(err)
@@ -667,9 +670,10 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 
 	g := smallGeneratedProject
 	g.TaskID = "task_that_called_generate_task"
-	p, v, t, pm, prevConfig, err := g.NewVersion()
+	p, v, t, pm, err := g.NewVersion()
 	s.Require().NoError(err)
-	s.NoError(g.Save(context.Background(), p, v, t, pm, prevConfig))
+	s.NoError(g.Save(context.Background(), p, v, t, pm))
+	s.Equal(1, v.ConfigUpdateNumber)
 
 	tasks := []task.Task{}
 	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{}), &tasks))

--- a/model/version.go
+++ b/model/version.go
@@ -25,6 +25,7 @@ type Version struct {
 	Status              string               `bson:"status" json:"status,omitempty"`
 	RevisionOrderNumber int                  `bson:"order,omitempty" json:"order,omitempty"`
 	Config              string               `bson:"config" json:"config,omitempty"`
+	ConfigUpdateNumber  int                  `bson:"config_number" json:"config_number,omitempty"`
 	Ignored             bool                 `bson:"ignored" json:"ignored"`
 	Owner               string               `bson:"owner_name" json:"owner_name,omitempty"`
 	Repo                string               `bson:"repo_name" json:"repo_name,omitempty"`

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -30,6 +30,7 @@ var (
 	VersionRevisionOrderNumberKey = bsonutil.MustHaveTag(Version{}, "RevisionOrderNumber")
 	VersionRequesterKey           = bsonutil.MustHaveTag(Version{}, "Requester")
 	VersionConfigKey              = bsonutil.MustHaveTag(Version{}, "Config")
+	VersionConfigNumberKey        = bsonutil.MustHaveTag(Version{}, "ConfigUpdateNumber")
 	VersionIgnoredKey             = bsonutil.MustHaveTag(Version{}, "Ignored")
 	VersionOwnerNameKey           = bsonutil.MustHaveTag(Version{}, "Owner")
 	VersionRepoKey                = bsonutil.MustHaveTag(Version{}, "Repo")

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -71,7 +71,7 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 	err = util.Retry(
 		ctx,
 		func() (bool, error) {
-			p, v, t, pm, prevConfig, err := g.NewVersion() // nolint
+			p, v, t, pm, err := g.NewVersion() // nolint
 			if err != nil {
 				return false, err
 			}
@@ -81,7 +81,7 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 			if err = validator.CheckProjectConfigurationIsValid(p); err != nil {
 				return false, err
 			}
-			err = g.Save(ctx, p, v, t, pm, prevConfig)
+			err = g.Save(ctx, p, v, t, pm)
 			if err != nil && adb.ResultsNotFound(err) {
 				return true, gimlet.ErrorResponse{
 					StatusCode: http.StatusInternalServerError,


### PR DESCRIPTION
Earlier we fixed this race condition by checking that the config string we were replacing was still the most recent config for the version. Rather than relying on this string, we should use an incrementing integer to keep track of the config version.