### PR TITLE
EVG-6293 min hosts not preserved for rhel70-stitch distro

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -162,9 +162,6 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 				HostsByDistroIdleHostsKey:         mgobson.M{"$push": bson.M{"$cond": []interface{}{mgobson.M{"$eq": []interface{}{"$running_task", mgobson.Undefined}}, "$$ROOT", mgobson.Undefined}}},
 			},
 		},
-		// {
-		// 	"$sort": mgobson.M{"_id": 1},
-		// },
 		{
 			"$project": mgobson.M{"_id": 0, HostsByDistroDistroIDKey: "$_id", HostsByDistroIdleHostsKey: 1, HostsByDistroRunningHostsCountKey: 1},
 		},

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -162,6 +162,9 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 				HostsByDistroIdleHostsKey:         mgobson.M{"$push": bson.M{"$cond": []interface{}{mgobson.M{"$eq": []interface{}{"$running_task", mgobson.Undefined}}, "$$ROOT", mgobson.Undefined}}},
 			},
 		},
+		// {
+		// 	"$sort": mgobson.M{"_id": 1},
+		// },
 		{
 			"$project": mgobson.M{"_id": 0, HostsByDistroDistroIDKey: "$_id", HostsByDistroIdleHostsKey: 1, HostsByDistroRunningHostsCountKey: 1},
 		},

--- a/units/crons.go
+++ b/units/crons.go
@@ -322,9 +322,16 @@ func PopulateIdleHostJobs(env evergreen.Environment) amboy.QueueOperation {
 			return fmt.Errorf("distro ids %s not found", strings.Join(invalidDistroIDs, ","))
 		}
 
-		for i, info := range distroHosts {
+		distrosMap := make(map[string]distro.Distro, len(distrosFound))
+		for i := range distrosFound {
+			d := distrosFound[i]
+			distrosMap[d.Id] = d
+		}
+
+		for _, info := range distroHosts {
+			distroID := info.DistroID
 			totalRunningHosts := info.RunningHostsCount
-			minimumHosts := distrosFound[i].PlannerSettings.MinimumHosts
+			minimumHosts := distrosMap[distroID].PlannerSettings.MinimumHosts
 			nIdleHosts := len(info.IdleHosts)
 
 			maxHostsToTerminate := totalRunningHosts - minimumHosts

--- a/units/crons.go
+++ b/units/crons.go
@@ -329,9 +329,8 @@ func PopulateIdleHostJobs(env evergreen.Environment) amboy.QueueOperation {
 		}
 
 		for _, info := range distroHosts {
-			distroID := info.DistroID
 			totalRunningHosts := info.RunningHostsCount
-			minimumHosts := distrosMap[distroID].PlannerSettings.MinimumHosts
+			minimumHosts := distrosMap[info.DistroID].PlannerSettings.MinimumHosts
 			nIdleHosts := len(info.IdleHosts)
 
 			maxHostsToTerminate := totalRunningHosts - minimumHosts


### PR DESCRIPTION
Now I remember why I had that second sort in the aggregation for `IdleEphemeralGroupedByDistroID()`