### PR TITLE
EVG-6242: commit queue module merge order

### DIFF
--- a/command/git_push.go
+++ b/command/git_push.go
@@ -75,7 +75,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		return errors.Errorf("tip of branch '%s' has moved. Expecting '%s', but found '%s'", conf.ProjectRef.Branch, p.Githash, headSHA)
 	}
 
-	// get author information
+	// get commit information
 	taskData := client.TaskData{
 		ID:     conf.Task.Id,
 		Secret: conf.Task.Secret,
@@ -84,17 +84,10 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 	if err != nil {
 		return errors.Wrapf(err, "can't get author information for user '%s'", p.Author)
 	}
-
-	logger.Execution().Info("Pushing patch")
 	params := pushParams{
-		directory:   c.Directory,
 		authorName:  restModel.FromAPIString(u.DisplayName),
 		authorEmail: restModel.FromAPIString(u.Email),
 		description: p.Description,
-		branch:      conf.ProjectRef.Branch,
-	}
-	if err = c.pushPatch(ctx, logger, params); err != nil {
-		return errors.Wrap(err, "can't push patch")
 	}
 
 	// push module patches
@@ -124,6 +117,14 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		if err = c.pushPatch(ctx, logger, params); err != nil {
 			return errors.Wrap(err, "can't push module patch")
 		}
+	}
+
+	// Push main patch
+	logger.Execution().Info("Pushing patch")
+	params.directory = c.Directory
+	params.branch = conf.ProjectRef.Branch
+	if err = c.pushPatch(ctx, logger, params); err != nil {
+		return errors.Wrap(err, "can't push patch")
 	}
 
 	return nil

--- a/command/git_push.go
+++ b/command/git_push.go
@@ -96,7 +96,8 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 			continue
 		}
 
-		module, err := conf.Project.GetModuleByName(modulePatch.ModuleName)
+		var module *model.Module
+		module, err = conf.Project.GetModuleByName(modulePatch.ModuleName)
 		if err != nil {
 			logger.Execution().Errorf("No module found for %s", modulePatch.ModuleName)
 			continue

--- a/model/commitqueue/github_pr_message_test.go
+++ b/model/commitqueue/github_pr_message_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/mongodb/grip/level"
 	"github.com/stretchr/testify/assert"
 )
@@ -11,13 +12,18 @@ import (
 func TestGithubPRMerge(t *testing.T) {
 	assert := assert.New(t)
 	pr := GithubMergePR{
-		ProjectID:     "mci",
-		Owner:         "evergreen-ci",
-		Repo:          "evergreen",
-		Ref:           "deadbeef",
-		CommitMessage: "merged by cq",
-		PRNum:         1,
-		Status:        evergreen.PatchFailed,
+		ProjectID: "mci",
+		PRs: []event.PRInfo{
+			{
+				Owner:       "evergreen-ci",
+				Repo:        "evergreen",
+				Ref:         "deadbeef",
+				CommitTitle: "PR (#1)",
+				PRNum:       1,
+			},
+		},
+		Item:   "1",
+		Status: evergreen.PatchFailed,
 	}
 	c := NewGithubMergePRMessage(level.Info, pr)
 	assert.NotNil(c)
@@ -28,28 +34,40 @@ func TestGithubPRMerge(t *testing.T) {
 
 	assert.Equal(pr, *raw)
 
-	assert.Equal("Merge Pull Request #1 (Ref: deadbeef) on evergreen-ci/evergreen: merged by cq", c.String())
+	assert.Equal("GitHub commit queue merge '1'", c.String())
 }
 
 func TestGithubMergePRMessageValidator(t *testing.T) {
 	assert := assert.New(t)
 
 	missingPRNum := GithubMergePR{
-		ProjectID: "mci",
-		Owner:     "evergreen-ci",
-		Repo:      "evergreen",
-		Ref:       "deadbeef",
+		ProjectID:   "mci",
+		Status:      evergreen.PatchSucceeded,
+		Item:        "1",
+		MergeMethod: githubMergeMethodSquash,
+		PRs: []event.PRInfo{
+			{
+				Owner: "evergreen-ci",
+				Repo:  "evergreen",
+				Ref:   "deadbeef",
+			},
+		},
 	}
 	c := NewGithubMergePRMessage(level.Info, missingPRNum)
 	assert.False(c.Loggable())
 
 	missingMergeMethod := GithubMergePR{
 		ProjectID: "mci",
-		Owner:     "evergreen-ci",
-		Repo:      "evergreen",
-		Ref:       "deadbeef",
-		PRNum:     1,
-		Status:    evergreen.PatchFailed,
+		Status:    evergreen.PatchSucceeded,
+		Item:      "1",
+		PRs: []event.PRInfo{
+			{
+				Owner: "evergreen-ci",
+				Repo:  "evergreen",
+				Ref:   "deadbeef",
+				PRNum: 1,
+			},
+		},
 	}
 	c = NewGithubMergePRMessage(level.Info, missingMergeMethod)
 	assert.True(c.Loggable())

--- a/model/commitqueue/github_pr_sender.go
+++ b/model/commitqueue/github_pr_sender.go
@@ -3,7 +3,6 @@ package commitqueue
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -78,59 +77,58 @@ func (s *githubPRLogger) Send(m message.Composer) {
 		return
 	}
 
-	s.sendPatchResult(msg)
+	for _, pr := range msg.PRs {
+		s.sendPatchResult(msg, pr)
+	}
+
 	if !(msg.Status == evergreen.PatchSucceeded) {
 		s.ErrorHandler(errors.New("not proceeding with merge for failed patch"), m)
-		if msg.ProjectID != "" {
-			event.LogCommitQueueConcludeTest(msg.PatchID, evergreen.MergeTestFailed)
-			s.ErrorHandler(dequeueFromCommitQueue(msg.ProjectID, msg.PRNum), m)
-		}
+		event.LogCommitQueueConcludeTest(msg.PatchID, evergreen.MergeTestFailed)
+		s.ErrorHandler(dequeueFromCommitQueue(msg.ProjectID, msg.Item), m)
+
 		return
 	}
 
-	mergeOpts := &github.PullRequestOptions{
-		MergeMethod: msg.MergeMethod,
-		CommitTitle: msg.CommitTitle,
-		SHA:         msg.Ref,
-	}
-
-	// do the merge
-	ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
-	defer cancel()
-	res, _, err := s.prService.Merge(ctx, msg.Owner, msg.Repo, msg.PRNum, msg.CommitMessage, mergeOpts)
-
-	if err != nil {
-		s.ErrorHandler(errors.Wrap(err, "can't access GitHub merge API"), m)
-		// don't send status to GitHub since we can't access their API anyway...
-	}
-
-	// send the result to github
-	// only send if the merge was not successful since
-	// GitHub won't display statuses received after the PR has been merged
-	if !res.GetMerged() {
-		s.ErrorHandler(s.sendMergeFailedStatus(res.GetMessage(), msg), m)
-	}
-
-	// Module merges are sent with the empty string as the projectID
-	// Wait for the main PR to be merged to dequeue
-	if msg.ProjectID != "" {
-		if res.GetMerged() {
-			event.LogCommitQueueConcludeTest(msg.PatchID, evergreen.MergeTestSucceeded)
-		} else {
-			event.LogCommitQueueConcludeTest(msg.PatchID, evergreen.MergeTestFailed)
+	for i, pr := range msg.PRs {
+		mergeOpts := &github.PullRequestOptions{
+			MergeMethod: msg.MergeMethod,
+			CommitTitle: pr.CommitTitle,
+			SHA:         pr.Ref,
 		}
-		s.ErrorHandler(dequeueFromCommitQueue(msg.ProjectID, msg.PRNum), m)
+
+		// do the merge
+		ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
+		defer cancel()
+		res, _, err := s.prService.Merge(ctx, pr.Owner, pr.Repo, pr.PRNum, "", mergeOpts)
+
+		if err != nil {
+			s.ErrorHandler(errors.Wrap(err, "can't access GitHub merge API"), m)
+			// don't send status to GitHub since we can't access their API anyway...
+		}
+
+		if !res.GetMerged() {
+			s.ErrorHandler(s.sendMergeFailedStatus(res.GetMessage(), pr), m)
+			for j := i + 1; j < len(msg.PRs); j++ {
+				s.ErrorHandler(s.sendMergeFailedStatus("aborted", msg.PRs[j]), m)
+			}
+			event.LogCommitQueueConcludeTest(msg.PatchID, evergreen.MergeTestFailed)
+			s.ErrorHandler(dequeueFromCommitQueue(msg.ProjectID, msg.Item), m)
+			return
+		}
 	}
+
+	event.LogCommitQueueConcludeTest(msg.PatchID, evergreen.MergeTestSucceeded)
+	s.ErrorHandler(dequeueFromCommitQueue(msg.ProjectID, msg.Item), m)
 }
 
-func (s *githubPRLogger) sendMergeFailedStatus(githubMessage string, msg *GithubMergePR) error {
+func (s *githubPRLogger) sendMergeFailedStatus(githubMessage string, pr event.PRInfo) error {
 	state := message.GithubStateFailure
 	description := fmt.Sprintf("merge failed: %s", githubMessage)
 
 	status := message.GithubStatus{
-		Owner:       msg.Owner,
-		Repo:        msg.Repo,
-		Ref:         msg.Ref,
+		Owner:       pr.Owner,
+		Repo:        pr.Repo,
+		Ref:         pr.Ref,
 		Context:     Context,
 		State:       state,
 		Description: description,
@@ -141,7 +139,7 @@ func (s *githubPRLogger) sendMergeFailedStatus(githubMessage string, msg *Github
 	return nil
 }
 
-func (s *githubPRLogger) sendPatchResult(msg *GithubMergePR) {
+func (s *githubPRLogger) sendPatchResult(msg *GithubMergePR, pr event.PRInfo) {
 	var state message.GithubState
 	var description string
 	if msg.Status == evergreen.PatchSucceeded {
@@ -153,9 +151,9 @@ func (s *githubPRLogger) sendPatchResult(msg *GithubMergePR) {
 	}
 
 	status := message.GithubStatus{
-		Owner:       msg.Owner,
-		Repo:        msg.Repo,
-		Ref:         msg.Ref,
+		Owner:       pr.Owner,
+		Repo:        pr.Repo,
+		Ref:         pr.Ref,
 		Context:     Context,
 		State:       state,
 		Description: description,
@@ -166,16 +164,16 @@ func (s *githubPRLogger) sendPatchResult(msg *GithubMergePR) {
 	s.statusSender.Send(c)
 }
 
-func dequeueFromCommitQueue(projectID string, PRNum int) error {
+func dequeueFromCommitQueue(projectID string, item string) error {
 	cq, err := FindOneId(projectID)
 	if err != nil {
-		return errors.Wrapf(err, "can't find commit queue for %s", projectID)
+		return errors.Wrapf(err, "can't find commit queue for '%s'", projectID)
 	}
-	found, err := cq.Remove(strconv.Itoa(PRNum))
+	found, err := cq.Remove(item)
 	if err != nil {
-		return errors.Wrapf(err, "can't dequeue %d from commit queue", PRNum)
+		return errors.Wrapf(err, "can't dequeue '%s' from commit queue", item)
 	} else if !found {
-		return errors.Errorf("item %d did not exist on the queue", PRNum)
+		return errors.Errorf("item '%s' did not exist on the queue", item)
 	}
 
 	return nil

--- a/model/commitqueue/github_pr_sender.go
+++ b/model/commitqueue/github_pr_sender.go
@@ -89,6 +89,8 @@ func (s *githubPRLogger) Send(m message.Composer) {
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(s.ctx, time.Duration(len(msg.PRs)*10)*time.Second)
+	defer cancel()
 	for i, pr := range msg.PRs {
 		mergeOpts := &github.PullRequestOptions{
 			MergeMethod: msg.MergeMethod,
@@ -97,8 +99,6 @@ func (s *githubPRLogger) Send(m message.Composer) {
 		}
 
 		// do the merge
-		ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
-		defer cancel()
 		res, _, err := s.prService.Merge(ctx, pr.Owner, pr.Repo, pr.PRNum, "", mergeOpts)
 
 		if err != nil {

--- a/model/commitqueue/github_pr_sender_test.go
+++ b/model/commitqueue/github_pr_sender_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/mongodb/grip/level"
 	"github.com/stretchr/testify/suite"
 )
@@ -41,13 +42,18 @@ func (s *GitHubPRSenderSuite) TestGithubPRLogger() {
 	s.NoError(err)
 
 	msg := GithubMergePR{
-		Status:        evergreen.PatchSucceeded,
-		ProjectID:     "mci",
-		Owner:         "evergreen-ci",
-		Repo:          "evergreen",
-		Ref:           "deadbeef",
-		CommitMessage: "merged by cq",
-		PRNum:         1,
+		Status:    evergreen.PatchSucceeded,
+		ProjectID: "mci",
+		Item:      "1",
+		PRs: []event.PRInfo{
+			{
+				Owner:       "evergreen-ci",
+				Repo:        "evergreen",
+				Ref:         "deadbeef",
+				CommitTitle: "PR (#1)",
+				PRNum:       1,
+			},
+		},
 	}
 	c := NewGithubMergePRMessage(level.Info, msg)
 	ghPRLogger.Send(c)
@@ -55,7 +61,7 @@ func (s *GitHubPRSenderSuite) TestGithubPRLogger() {
 }
 
 func (s *GitHubPRSenderSuite) TestDequeueFromCommitQueue() {
-	s.NoError(dequeueFromCommitQueue("mci", 1))
+	s.NoError(dequeueFromCommitQueue("mci", "1"))
 	cq, err := FindOneId("mci")
 	s.NoError(err)
 	s.Equal("2", cq.Next().Issue)

--- a/model/event/commit_queue_event.go
+++ b/model/event/commit_queue_event.go
@@ -18,6 +18,14 @@ const (
 	CommitQueueConcludeTest = "CONCLUDE_TEST"
 )
 
+type PRInfo struct {
+	Owner       string `bson:"owner"`
+	Repo        string `bson:"repo"`
+	Ref         string `bson:"ref"`
+	PRNum       int    `bson:"pr_number"`
+	CommitTitle string `bson:"commit_title"`
+}
+
 func logCommitQueueEvent(patchID, eventType string, data *CommitQueueEventData) {
 	event := EventLogEntry{
 		Timestamp:    time.Now().Truncate(0).Round(time.Millisecond),

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -149,24 +149,24 @@ func (s *GithubPullRequestSubscriber) String() string {
 }
 
 type GithubMergeSubscriber struct {
-	Owner         string `bson:"owner"`
-	Repo          string `bson:"repo"`
-	PRNumber      int    `bson:"pr_number"`
-	Ref           string `bson:"ref"`
-	CommitMessage string `bson:"commit_message"`
-	MergeMethod   string `bson:"merge_method"`
-	CommitTitle   string `bson:"commit_title"`
+	PRs         []PRInfo `bson:"prs"`
+	Item        string   `bson:"item"`
+	MergeMethod string   `bson:"merge_method"`
 }
 
 func (s *GithubMergeSubscriber) String() string {
+	if len(s.PRs) == 0 {
+		return "No PRs"
+	}
+
 	return fmt.Sprintf("%s-%s-%d-%s-%s-%s-%s",
-		s.Owner,
-		s.Repo,
-		s.PRNumber,
-		s.Ref,
-		s.CommitMessage,
+		s.PRs[len(s.PRs)-1].Owner,
+		s.PRs[len(s.PRs)-1].Repo,
+		s.PRs[len(s.PRs)-1].PRNum,
+		s.PRs[len(s.PRs)-1].Ref,
+		s.PRs[len(s.PRs)-1].CommitTitle,
 		s.MergeMethod,
-		s.CommitTitle,
+		s.Item,
 	)
 }
 

--- a/model/event/subscribers_test.go
+++ b/model/event/subscribers_test.go
@@ -29,13 +29,17 @@ func TestSubscribers(t *testing.T) {
 		{
 			Type: GithubMergeSubscriberType,
 			Target: &GithubMergeSubscriber{
-				Owner:         "evergreen-ci",
-				Repo:          "evergreen",
-				PRNumber:      9001,
-				Ref:           "deadbeef",
-				CommitMessage: "abcd",
-				MergeMethod:   "squash",
-				CommitTitle:   "efgh",
+				PRs: []PRInfo{
+					{
+						Owner:       "evergreen-ci",
+						Repo:        "evergreen",
+						PRNum:       9001,
+						Ref:         "deadbeef",
+						CommitTitle: "abcd",
+					},
+				},
+				MergeMethod: "squash",
+				Item:        "9001",
 			},
 		},
 		{
@@ -62,7 +66,7 @@ func TestSubscribers(t *testing.T) {
 		},
 	}
 	expected := []string{"github_pull_request-evergreen-ci-evergreen-9001-sadasdkjsad",
-		"github-merge-evergreen-ci-evergreen-9001-deadbeef-abcd-squash-efgh",
+		"github-merge-evergreen-ci-evergreen-9001-deadbeef-abcd-squash-9001",
 		"evergreen-webhook-https://example.com", "email-hi@example.com",
 		"jira-issue-BF-Fail", "jira-comment-BF-1234"}
 	for i := range subs {

--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -193,13 +193,9 @@ func (n *Notification) Composer() (message.Composer, error) {
 		if !ok || payload == nil {
 			return nil, errors.New("github-merge payload is invalid")
 		}
-		payload.Owner = sub.Owner
-		payload.Repo = sub.Repo
-		payload.CommitMessage = sub.CommitMessage
-		payload.CommitTitle = sub.CommitTitle
-		payload.Ref = sub.Ref
-		payload.PRNum = sub.PRNumber
+		payload.PRs = sub.PRs
 		payload.MergeMethod = sub.MergeMethod
+		payload.Item = sub.Item
 
 		return commitqueue.NewGithubMergePRMessage(level.Notice, *payload), nil
 

--- a/rest/model/subscriber_test.go
+++ b/rest/model/subscriber_test.go
@@ -51,13 +51,17 @@ func TestSubscriberModelsGithubStatusAPI(t *testing.T) {
 func TestSubscriberModelsGithubMerge(t *testing.T) {
 	assert := assert.New(t)
 	target := event.GithubMergeSubscriber{
-		Owner:         "me",
-		Repo:          "mine",
-		PRNumber:      5,
-		Ref:           "deadbeef",
-		CommitMessage: "abcd",
-		MergeMethod:   "squash",
-		CommitTitle:   "merged by evergreen",
+		PRs: []event.PRInfo{
+			{
+				Owner:       "me",
+				Repo:        "mine",
+				PRNum:       5,
+				Ref:         "deadbeef",
+				CommitTitle: "PR (#5)",
+			},
+		},
+		MergeMethod: "squash",
+		Item:        "5",
 	}
 	subscriber := event.Subscriber{
 		Type:   event.GithubMergeSubscriberType,
@@ -79,13 +83,17 @@ func TestSubscriberModelsGithubMerge(t *testing.T) {
 	incoming := APISubscriber{
 		Type: ToAPIString(event.GithubMergeSubscriberType),
 		Target: map[string]interface{}{
-			"owner":          "me",
-			"repo":           "mine",
-			"pr_number":      5,
-			"ref":            "deadbeef",
-			"commit_message": "abcd",
-			"merge_method":   "squash",
-			"commit_title":   "merged by evergreen",
+			"prs": []map[string]interface{}{
+				{
+					"owner":        "me",
+					"repo":         "mine",
+					"pr_number":    5,
+					"ref":          "deadbeef",
+					"commit_title": "PR (#5)",
+				},
+			},
+			"merge_method": "squash",
+			"item":         "5",
 		},
 	}
 

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -226,13 +226,11 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 		j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't finalize patch", ""))
 	}
 
-	dequeue, err = subscribeGitHubPRs(pr, modulePRs, projectRef, v.Id)
+	err = subscribeGitHubPRs(pr, modulePRs, projectRef, v.Id)
 	if err != nil {
 		j.logError(err, "can't subscribe for PR merge", nextItem)
-		if dequeue {
-			j.dequeue(cq, nextItem)
-			j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't sign up merge", v.Id))
-		}
+		j.dequeue(cq, nextItem)
+		j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't sign up merge", v.Id))
 	}
 
 	j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStatePending, "preparing to test merge", v.Id))
@@ -453,15 +451,29 @@ func sendCommitQueueGithubStatus(env evergreen.Environment, pr *github.PullReque
 	return nil
 }
 
-func subscribeMerge(projectID, owner, repo, mergeMethod, patchID string, pr *github.PullRequest) error {
-	commitTitle := *pr.Title + fmt.Sprintf(" (#%d)", *pr.Number)
-	mergeSubscriber := event.NewGithubMergeSubscriber(event.GithubMergeSubscriber{
-		Owner:       owner,
-		Repo:        repo,
-		PRNumber:    *pr.Number,
+func subscribeGitHubPRs(pr *github.PullRequest, modulePRs []*github.PullRequest, projectRef *model.ProjectRef, patchID string) error {
+	prs := make([]event.PRInfo, 0, len(modulePRs)+1)
+	for _, modulePR := range modulePRs {
+		prs = append(prs, event.PRInfo{
+			Owner:       modulePR.Base.Repo.Owner.GetLogin(),
+			Repo:        *modulePR.Base.Repo.Name,
+			Ref:         *modulePR.Head.SHA,
+			PRNum:       *modulePR.Number,
+			CommitTitle: fmt.Sprintf("%s (#%d)", *modulePR.Title, *modulePR.Number),
+		})
+	}
+	prs = append(prs, event.PRInfo{
+		Owner:       projectRef.Owner,
+		Repo:        projectRef.Repo,
 		Ref:         *pr.Head.SHA,
-		MergeMethod: mergeMethod,
-		CommitTitle: commitTitle,
+		PRNum:       *pr.Number,
+		CommitTitle: fmt.Sprintf("%s (#%d)", *pr.Title, *pr.Number),
+	})
+
+	mergeSubscriber := event.NewGithubMergeSubscriber(event.GithubMergeSubscriber{
+		PRs:         prs,
+		Item:        strconv.Itoa(*pr.Number),
+		MergeMethod: projectRef.CommitQueue.MergeMethod,
 	})
 	patchSub := event.NewPatchOutcomeSubscription(patchID, mergeSubscriber)
 	if err := patchSub.Upsert(); err != nil {
@@ -469,22 +481,6 @@ func subscribeMerge(projectID, owner, repo, mergeMethod, patchID string, pr *git
 	}
 
 	return nil
-}
-
-func subscribeGitHubPRs(pr *github.PullRequest, modulePRs []*github.PullRequest, projectRef *model.ProjectRef, versionID string) (bool, error) {
-	err := subscribeMerge(projectRef.Identifier, projectRef.Owner, projectRef.Repo, projectRef.CommitQueue.MergeMethod, versionID, pr)
-	if err != nil {
-		return true, errors.Wrapf(err, "can't subscribe to merge main pr")
-	}
-
-	for _, modulePR := range modulePRs {
-		err = subscribeMerge("", modulePR.Base.Repo.Owner.GetLogin(), *modulePR.Base.Repo.Name, projectRef.CommitQueue.MergeMethod, versionID, modulePR)
-		if err != nil {
-			return false, errors.Wrapf(err, "can't subscribe to merge module %s pr", *modulePR.Base.Repo.Name)
-		}
-	}
-
-	return false, nil
 }
 
 func validateBranch(branch *github.Branch) error {

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -102,7 +102,7 @@ func (s *commitQueueSuite) TestNewCommitQueueJob() {
 
 func (s *commitQueueSuite) TestSubscribeMerge() {
 	s.NoError(db.ClearCollections(event.SubscriptionsCollection))
-	s.NoError(subscribeMerge(s.projectRef.Identifier, s.projectRef.Owner, s.projectRef.Repo, "squash", "abcdef", s.pr))
+	s.NoError(subscribeGitHubPRs(s.pr, nil, s.projectRef, "abcdef"))
 
 	selectors := []event.Selector{
 		event.Selector{
@@ -120,9 +120,10 @@ func (s *commitQueueSuite) TestSubscribeMerge() {
 	s.Equal(event.ResourceTypePatch, subscription.ResourceType)
 	target, ok := subscription.Subscriber.Target.(*event.GithubMergeSubscriber)
 	s.True(ok)
-	s.Equal(s.projectRef.Owner, target.Owner)
-	s.Equal(s.projectRef.Repo, target.Repo)
-	s.Equal(s.pr.GetTitle()+fmt.Sprintf(" (#%d)", *s.pr.Number), target.CommitTitle)
+	s.Require().Len(target.PRs, 1)
+	s.Equal(s.projectRef.Owner, target.PRs[0].Owner)
+	s.Equal(s.projectRef.Repo, target.PRs[0].Repo)
+	s.Equal(fmt.Sprintf("%s (#%d)", s.pr.GetTitle(), *s.pr.Number), target.PRs[0].CommitTitle)
 }
 
 func (s *commitQueueSuite) TestWritePatchInfo() {

--- a/units/event_send_test.go
+++ b/units/event_send_test.go
@@ -135,10 +135,16 @@ func (s *eventNotificationSuite) SetupTest() {
 			Subscriber: event.Subscriber{
 				Type: event.GithubMergeSubscriberType,
 				Target: event.GithubMergeSubscriber{
-					Owner:         "evergreen-ci",
-					Repo:          "evergreen",
-					PRNumber:      1234,
-					CommitMessage: "merged your PR",
+					PRs: []event.PRInfo{
+						{
+							Owner:       "evergreen-ci",
+							Repo:        "evergreen",
+							PRNum:       1234,
+							CommitTitle: "PR (#1234)",
+						},
+					},
+					Item:        "1234",
+					MergeMethod: "squash",
 				},
 			},
 			Payload: commitqueue.GithubMergePR{},


### PR DESCRIPTION
The commit queue needs to merge modules before the main repo so the manifest will be correct when it runs for the main repo.

The changes for each version of the commit queue are each in their own commit. 
The PR commit queue required an architectural change: instead of creating separate subscriptions for each PR there is one subscription for the entire item and the same message merges all the PRs. This way the merge order can be controlled.