### PR TITLE
EVG-6220: only clear aborted on restart

### DIFF
--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -372,6 +372,10 @@ func (s *taskSuite) TestAbortedTaskDoesNotNotify() {
 
 	s.task.Aborted = true
 	s.NoError(db.Update(task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+
+	// works even if the task is archived
+	s.task.Archive()
+
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)
 	s.Empty(n)

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -374,7 +374,7 @@ func (s *taskSuite) TestAbortedTaskDoesNotNotify() {
 	s.NoError(db.Update(task.Collection, bson.M{"_id": s.task.Id}, &s.task))
 
 	// works even if the task is archived
-	s.task.Archive()
+	s.NoError(s.task.Archive())
 
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)


### PR DESCRIPTION
Retake on #2395.
It's _necessary_ to clear Aborted on restart (Archive) so a restarted task isn't immediately aborted.
It's _okay_ to clear Aborted on restart because any previous iterations of the task still running (that haven't done a heartbeat since it's been aborted) will exit after the task has been reset since the secret has changed and the heartbeat will return a 409.