### PR TITLE
EVG-6256: set commit queue patch priority

### DIFF
--- a/config_commitqueue.go
+++ b/config_commitqueue.go
@@ -12,12 +12,14 @@ type CommitQueueConfig struct {
 	MergeTaskDistro string `yaml:"merge_task_distro" bson:"merge_task_distro" json:"merge_task_distro"`
 	CommitterName   string `yaml:"committer_name" bson:"committer_name" json:"committer_name"`
 	CommitterEmail  string `yaml:"committer_email" bson:"committer_email" json:"committer_email"`
+	TaskPriority    int    `yaml:"task_priority" bson:"task_priority" json:"task_priority"`
 }
 
 var (
 	mergeTaskDistroKey = bsonutil.MustHaveTag(CommitQueueConfig{}, "MergeTaskDistro")
 	committerNameKey   = bsonutil.MustHaveTag(CommitQueueConfig{}, "CommitterName")
 	committerEmailKey  = bsonutil.MustHaveTag(CommitQueueConfig{}, "CommitterEmail")
+	taskPriorityKey    = bsonutil.MustHaveTag(CommitQueueConfig{}, "TaskPriority")
 )
 
 func (c *CommitQueueConfig) SectionId() string { return "commit_queue" }
@@ -56,6 +58,7 @@ func (c *CommitQueueConfig) Set() error {
 			mergeTaskDistroKey: c.MergeTaskDistro,
 			committerNameKey:   c.CommitterName,
 			committerEmailKey:  c.CommitterEmail,
+			taskPriorityKey:    c.TaskPriority,
 		},
 	}, options.Update().SetUpsert(true))
 	return errors.Wrapf(err, "error updating section %s", c.SectionId())

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -565,7 +565,7 @@ Admin Settings
 										</md-card-content>
 									</md-card>
 
-									<md-card flex=50 id="commit_queue">
+									<md-card flex=100 id="commit_queue">
 											<md-card-title>
 												<md-card-title-text>
 													<span>Commit Queue</span>
@@ -583,7 +583,11 @@ Admin Settings
 												<md-input-container class="control" style="width:45%;">
 														<label>Committer Email</label>
 														<input type="text" ng-model="Settings.commit_queue.committer_email">
-													</md-input-container>
+												</md-input-container>
+												<md-input-container class="control" style="width:45%;">
+													<label>Task Priority</label>
+													<input type="number" min="1" ng-model="Settings.commit_queue.task_priority">
+												</md-input-container>
 												<button ng-click="clearCommitQueues()" class="md-raised md-button">Clear Commit Queues</button>
 											</md-card-content>
 									</md-card>


### PR DESCRIPTION
Give an admin the ability to speed up commit queue processing by setting a higher priority for commit queue tasks.