### PR TITLE
EVG-6300: hide unresponsive modal on restart task failure

### DIFF
--- a/public/static/js/task_admin.js
+++ b/public/static/js/task_admin.js
@@ -38,6 +38,15 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
         }
     }
 
+    function doModalFailure(message, data, reload){
+        $scope.closeAdminModal();
+        if (reload) {
+          $window.location.reload();
+        } else {
+          notifier.pushNotification(message, 'notifyHeader', 'error');
+        }
+    }
+
 	$scope.abort = function() {
         taskRestService.takeActionOnTask(
             $scope.taskId,
@@ -66,6 +75,7 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
                 },
                 error: function(resp) {
                     notifier.pushNotification('Error restarting: ' + resp.data,'errorModal');
+                    doModalFailure("Error restarting: " + resp.data, resp.data, $scope.task.display_only);
                 }
             }
         );

--- a/public/static/js/task_admin.js
+++ b/public/static/js/task_admin.js
@@ -38,13 +38,9 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
         }
     }
 
-    function doModalFailure(message, data, reload){
+    function doModalFailure(message){
         $scope.closeAdminModal();
-        if (reload) {
-          $window.location.reload();
-        } else {
-          notifier.pushNotification(message, 'notifyHeader', 'error');
-        }
+        notifier.pushNotification(message, 'notifyHeader', 'error');
     }
 
 	$scope.abort = function() {

--- a/public/static/js/task_admin.js
+++ b/public/static/js/task_admin.js
@@ -71,7 +71,7 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
                 },
                 error: function(resp) {
                     notifier.pushNotification('Error restarting: ' + resp.data,'errorModal');
-                    doModalFailure("Error restarting: " + resp.data, resp.data, $scope.task.display_only);
+                    doModalFailure("Error restarting: " + resp.data);
                 }
             }
         );


### PR DESCRIPTION
When restarting a task fails, the modify task modal is closed and the error is displayed at the top of the window as a notification. This fix has been verified in staging. 