### PR TITLE
EVG-6230: manage Jasper credentials on host creation and deletion

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -203,7 +203,7 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 	}
 
 	if err := m.bootstrapUserData(ctx, evergreen.GetEnvironment(), h, ec2Settings); err != nil {
-		return nil, errors.Wrap("could not add bootstrap script to user data")
+		return nil, errors.Wrap(err, "could not add bootstrap script to user data")
 	}
 
 	if ec2Settings.UserData != "" {
@@ -1072,15 +1072,12 @@ func (m *ec2Manager) bootstrapUserData(ctx context.Context, env evergreen.Enviro
 		return nil
 	}
 
-	// kim: TODO: modify credentials generation to be based on
-	// JasperCredentialsID since the host id will change to the spawn host's ID
-	// instead of the intent host ID.
 	creds, err := h.GenerateJasperCredentials(ctx, env)
 	if err != nil {
 		return errors.Wrap(err, "problem generating Jasper credentials for host")
 	}
 
-	commands, err := h.BootstrapScript(m.settings.JasperConfig, creds)
+	commands, err := h.BootstrapScript(m.settings.HostJasper, creds)
 	if err != nil {
 		return errors.Wrap(err, "could not generate user data bootstrap script")
 	}

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -202,7 +202,7 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		ec2Settings.UserData = expanded
 	}
 
-	if err := m.bootstrapUserData(ctx, env, h, ec2Settings); err != nil {
+	if err := m.bootstrapUserData(ctx, evergreen.GetEnvironment(), h, ec2Settings); err != nil {
 		return nil, errors.Wrap("could not add bootstrap script to user data")
 	}
 
@@ -333,8 +333,8 @@ func (m *ec2Manager) spawnSpotHost(ctx context.Context, h *host.Host, ec2Setting
 		spotRequest.LaunchSpecification.UserData = &userData
 	}
 
-	if err := m.bootstrapUserData(ctx, env, h, ec2Settings); err != nil {
-		return errors.Wrap(err, "could not add bootstrap script to user data")
+	if err := m.bootstrapUserData(ctx, evergreen.GetEnvironment(), h, ec2Settings); err != nil {
+		return nil, errors.Wrap(err, "could not add bootstrap script to user data")
 	}
 
 	grip.Debug(message.Fields{

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -81,7 +81,6 @@ func (s *EC2Suite) SetupTest() {
 
 	s.Require().NoError(db.ClearCollections(credentials.Collection))
 	s.Require().NoError(credentials.Bootstrap(s.env))
-
 }
 
 func (s *EC2Suite) TearDownTest() {

--- a/cloud/user_data_test.go
+++ b/cloud/user_data_test.go
@@ -2,11 +2,21 @@ package cloud
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"mime/multipart"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model/credentials"
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -106,4 +116,72 @@ func TestMakeMultipartUserData(t *testing.T) {
 	assert.False(t, strings.Contains(res, fileOne))
 	assert.Contains(t, res, fileTwo)
 	assert.Contains(t, res, userData)
+}
+
+func withBootstrapEnv(t *testing.T, fn func(env evergreen.Environment)) {
+	env := &mock.Environment{}
+	var cancel context.CancelFunc
+	env.EnvContext, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, env.Configure(env.EnvContext, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	env.Settings().DomainName = "test"
+
+	require.NoError(t, db.ClearCollections(credentials.Collection, host.Collection))
+	defer func() {
+		assert.NoError(t, db.ClearCollections(credentials.Collection, host.Collection))
+	}()
+	require.NoError(t, credentials.Bootstrap(env))
+	fn(env)
+}
+
+func TestBootstrapUserData(t *testing.T) {
+	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, env evergreen.Environment, h *host.Host){
+		"PassesWithoutCustomuserData": func(ctx context.Context, t *testing.T, env evergreen.Environment, h *host.Host) {
+			userData, err := bootstrapUserData(ctx, env, h, "")
+			require.NoError(t, err)
+			assert.NotEmpty(t, userData)
+
+			assert.Equal(t, h.JasperCredentialsID, h.Id)
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, h.Id, dbHost.JasperCredentialsID)
+
+			creds, err := h.JasperCredentials(ctx, env)
+			require.NoError(t, err)
+			assert.NotNil(t, creds)
+		},
+		"PassesWithCustomUserData": func(ctx context.Context, t *testing.T, env evergreen.Environment, h *host.Host) {
+			customUserData := "#!/bin/bash\necho 'foobar'"
+			userData, err := bootstrapUserData(ctx, env, h, customUserData)
+			require.NoError(t, err)
+			assert.NotEmpty(t, userData)
+			assert.True(t, len(userData) > len(customUserData))
+
+			assert.Equal(t, h.JasperCredentialsID, h.Id)
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, h.Id, dbHost.JasperCredentialsID)
+
+			creds, err := h.JasperCredentials(ctx, env)
+			require.NoError(t, err)
+			assert.NotNil(t, creds)
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			withBootstrapEnv(t, func(env evergreen.Environment) {
+				h := &host.Host{Id: "host", Distro: distro.Distro{
+					Arch:                  distro.ArchLinuxAmd64,
+					BootstrapMethod:       distro.BootstrapMethodUserData,
+					JasperCredentialsPath: "/bar",
+				}}
+				require.NoError(t, h.Insert())
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				testCase(ctx, t, env, h)
+			})
+		})
+	}
 }

--- a/cloud/user_data_test.go
+++ b/cloud/user_data_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"mime/multipart"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -16,7 +15,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/credentials"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -124,7 +122,7 @@ func withBootstrapEnv(t *testing.T, fn func(env evergreen.Environment)) {
 	env.EnvContext, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	require.NoError(t, env.Configure(env.EnvContext, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	require.NoError(t, env.Configure(env.EnvContext, "", nil))
 	env.Settings().DomainName = "test"
 
 	require.NoError(t, db.ClearCollections(credentials.Collection, host.Collection))

--- a/model/credentials/db.go
+++ b/model/credentials/db.go
@@ -67,7 +67,7 @@ func Bootstrap(env evergreen.Environment) error {
 
 func validateBootstrapped() error {
 	if serviceName == "" {
-		return errors.New("%s collection has not been bootstrapped", Collection)
+		return errors.Errorf("%s collection has not been bootstrapped", Collection)
 	}
 	return nil
 }

--- a/model/credentials/db.go
+++ b/model/credentials/db.go
@@ -65,13 +65,6 @@ func Bootstrap(env evergreen.Environment) error {
 	return nil
 }
 
-func validateBootstrapped() error {
-	if serviceName == "" {
-		return errors.Errorf("%s collection has not been bootstrapped", Collection)
-	}
-	return nil
-}
-
 func mongoConfig(settings *evergreen.Settings) *certdepot.MongoDBOptions {
 	return &certdepot.MongoDBOptions{
 		MongoDBURI:     settings.Database.Url,

--- a/model/credentials/db.go
+++ b/model/credentials/db.go
@@ -20,10 +20,7 @@ const (
 	defaultExpiration = 30 * 24 * time.Hour // 1 month
 )
 
-var (
-	serviceName        string
-	errNotBootstrapped = errors.Errorf("%s collection has not been bootstrapped", Collection)
-)
+var serviceName string
 
 // Bootstrap performs one-time initialization of the credentials collection with
 // the certificate authority and service certificate. In order to perform
@@ -70,7 +67,7 @@ func Bootstrap(env evergreen.Environment) error {
 
 func validateBootstrapped() error {
 	if serviceName == "" {
-		return errNotBootstrapped
+		return errors.New("%s collection has not been bootstrapped", Collection)
 	}
 	return nil
 }
@@ -102,10 +99,6 @@ func deleteIfExists(dpt certdepot.Depot, tags ...*depot.Tag) error {
 // name. If the credentials already exist, this will overwrite the existing
 // credentials.
 func SaveCredentials(ctx context.Context, env evergreen.Environment, name string, creds *rpc.Credentials) error {
-	if err := validateBootstrapped(); err != nil {
-		return err
-	}
-
 	dpt, err := getDepot(ctx, env)
 	if err != nil {
 		return errors.Wrap(err, "could not get depot")
@@ -128,10 +121,6 @@ func SaveCredentials(ctx context.Context, env evergreen.Environment, name string
 // database. This is not idempotent, so separate calls with the same inputs will
 // return different credentials.
 func GenerateInMemory(ctx context.Context, env evergreen.Environment, name string) (*rpc.Credentials, error) {
-	if err := validateBootstrapped(); err != nil {
-		return nil, err
-	}
-
 	opts := certdepot.CertificateOptions{
 		CA:         CAName,
 		CommonName: name,
@@ -174,10 +163,6 @@ func GenerateInMemory(ctx context.Context, env evergreen.Environment, name strin
 
 // FindByID gets the credentials for the given name.
 func FindByID(ctx context.Context, env evergreen.Environment, name string) (*rpc.Credentials, error) {
-	if err := validateBootstrapped(); err != nil {
-		return nil, err
-	}
-
 	dpt, err := getDepot(ctx, env)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get depot")
@@ -203,10 +188,6 @@ func FindByID(ctx context.Context, env evergreen.Environment, name string) (*rpc
 
 // DeleteCredentials removes the credentials from the database.
 func DeleteCredentials(ctx context.Context, env evergreen.Environment, name string) error {
-	if err := validateBootstrapped(); err != nil {
-		return err
-	}
-
 	dpt, err := getDepot(ctx, env)
 	if err != nil {
 		return errors.Wrap(err, "could not get depot")

--- a/model/credentials/db_test.go
+++ b/model/credentials/db_test.go
@@ -2,14 +2,12 @@ package credentials
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/mock"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/mongodb/jasper/rpc"
 	"github.com/pkg/errors"
 	"github.com/square/certstrap/depot"
@@ -20,7 +18,7 @@ import (
 func setupEnv(ctx context.Context) (*mock.Environment, error) {
 	env := &mock.Environment{}
 
-	if err := env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil); err != nil {
+	if err := env.Configure(ctx, "", nil); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return env, nil

--- a/model/credentials/db_test.go
+++ b/model/credentials/db_test.go
@@ -30,48 +30,6 @@ func newMockCredentials(caCrt []byte) (*rpc.Credentials, error) {
 	return rpc.NewCredentials(caCrt, []byte("bar"), []byte("bat"))
 }
 
-func TestBootstrapRequired(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	name := "name"
-
-	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, env evergreen.Environment){
-		"SaveCredentials": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
-			creds, err := newMockCredentials([]byte("foo"))
-			require.NoError(t, err)
-			err = SaveCredentials(ctx, env, name, creds)
-			require.Error(t, err)
-			assert.Contains(t, errNotBootstrapped.Error(), err.Error())
-		},
-		"GenerateInMemory": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
-			_, err := GenerateInMemory(ctx, env, name)
-			require.Error(t, err)
-			assert.Contains(t, errNotBootstrapped.Error(), err.Error())
-		},
-		"FindByID": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
-			_, err := FindByID(ctx, env, name)
-			require.Error(t, err)
-			assert.Contains(t, errNotBootstrapped.Error(), err.Error())
-		},
-		"DeleteCredentials": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
-			err := DeleteCredentials(ctx, env, name)
-			require.Error(t, err)
-			assert.Contains(t, errNotBootstrapped.Error(), err.Error())
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			env, err := setupEnv(ctx)
-
-			tctx, cancel := context.WithTimeout(ctx, time.Second)
-			defer cancel()
-
-			require.NoError(t, err)
-			testCase(tctx, t, env)
-		})
-	}
-}
-
 func TestDBOperations(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -338,7 +338,9 @@ func Provisioning() db.Q {
 }
 
 func FindByFirstProvisioningAttempt() ([]Host, error) {
+	bootstrapKey := bsonutil.GetDottedKeyName(DistroKey, distro.BootstrapMethodKey)
 	return Find(db.Query(bson.M{
+		bootstrapKey:         bson.M{"$ne": distro.BootstrapMethodUserData},
 		ProvisionAttemptsKey: 0,
 		StatusKey:            evergreen.HostProvisioning,
 	}))

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -54,6 +54,7 @@ var (
 	AgentRevisionKey             = bsonutil.MustHaveTag(Host{}, "AgentRevision")
 	NeedsNewAgentKey             = bsonutil.MustHaveTag(Host{}, "NeedsNewAgent")
 	NeedsNewAgentMonitorKey      = bsonutil.MustHaveTag(Host{}, "NeedsNewAgentMonitor")
+	JasperCredentialsIDKey       = bsonutil.MustHaveTag(Host{}, "JasperCredentialsID")
 	StartedByKey                 = bsonutil.MustHaveTag(Host{}, "StartedBy")
 	InstanceTypeKey              = bsonutil.MustHaveTag(Host{}, "InstanceType")
 	VolumeSizeKey                = bsonutil.MustHaveTag(Host{}, "VolumeTotalSize")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -357,18 +357,6 @@ func (h *Host) GenerateJasperCredentials(ctx context.Context, env evergreen.Envi
 	return credentials.GenerateInMemory(ctx, env, h.JasperCredentialsID)
 }
 
-// UpdateJasperCredentialsID set's the ID for the host's Jasper credentials.
-func (h *Host) UpdateJasperCredentialsID(id string) error {
-	if err := UpdateOne(
-		bson.M{IdKey: h.Id},
-		bson.M{"$set": bson.M{JasperCredentialsIDKey: id}},
-	); err != nil {
-		return err
-	}
-	h.JasperCredentialsID = id
-	return nil
-}
-
 // SaveJasperCredentials saves the given Jasper credentials in the database for
 // the host.
 func (h *Host) SaveJasperCredentials(ctx context.Context, env evergreen.Environment, creds *rpc.Credentials) error {
@@ -381,10 +369,19 @@ func (h *Host) SaveJasperCredentials(ctx context.Context, env evergreen.Environm
 // DeleteJasperCredentials deletes the Jasper credentials for the host and
 // updates the host both in memory and in the database.
 func (h *Host) DeleteJasperCredentials(ctx context.Context, env evergreen.Environment) error {
-	if h.JasperCredentialsID == "" {
-		return errCredsNotGenerated
-	}
 	return credentials.DeleteCredentials(ctx, env, h.JasperCredentialsID)
+}
+
+// UpdateJasperCredentialsID sets the ID of the host's Jasper credentials.
+func (h *Host) UpdateJasperCredentialsID(id string) error {
+	if err := UpdateOne(
+		bson.M{IdKey: h.Id},
+		bson.M{"$set": bson.M{JasperCredentialsIDKey: id}},
+	); err != nil {
+		return err
+	}
+	h.JasperCredentialsID = id
+	return nil
 }
 
 // UpdateLastCommunicated sets the host's last communication time to the current time.

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -336,13 +336,8 @@ func (h *Host) CreateSecret() error {
 	return nil
 }
 
-var errCredsNotGenerated = errors.New("cannot get Jasper credentials since they have not been generated yet for this host")
-
 // JasperCredentials gets the Jasper credentials from the database.
 func (h *Host) JasperCredentials(ctx context.Context, env evergreen.Environment) (*rpc.Credentials, error) {
-	if h.JasperCredentialsID == "" {
-		return nil, errCredsNotGenerated
-	}
 	return credentials.FindByID(ctx, env, h.JasperCredentialsID)
 }
 
@@ -361,7 +356,7 @@ func (h *Host) GenerateJasperCredentials(ctx context.Context, env evergreen.Envi
 // the host.
 func (h *Host) SaveJasperCredentials(ctx context.Context, env evergreen.Environment, creds *rpc.Credentials) error {
 	if h.JasperCredentialsID == "" {
-		return errCredsNotGenerated
+		return errors.New("Jasper credentials ID is empty")
 	}
 	return credentials.SaveCredentials(ctx, env, h.JasperCredentialsID, creds)
 }

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -86,6 +86,9 @@ type Host struct {
 	AgentRevision        string `bson:"agent_revision" json:"agent_revision"`
 	NeedsNewAgent        bool   `bson:"needs_agent" json:"needs_agent"`
 	NeedsNewAgentMonitor bool   `bson:"needs_agent_monitor" json:"needs_agent_monitor"`
+	// JasperCredentialsID is used to match hosts to their Jasper credentials
+	// for non-legacy hosts.
+	JasperCredentialsID string `bson:"jasper_credentials_id" json:"jasper_credentials_id"`
 
 	// for ec2 dynamic hosts, the instance type requested
 	InstanceType string `bson:"instance_type" json:"instance_type,omitempty"`

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/mongodb/jasper/rpc"
 	"github.com/pkg/errors"
 )
 
@@ -174,7 +175,13 @@ func (h *Host) ForceReinstallJasperCommand(config evergreen.HostJasperConfig) st
 	if port == 0 {
 		port = evergreen.DefaultJasperPort
 	}
-	return h.jasperServiceCommand(config, "force-reinstall", fmt.Sprintf("--port=%d", port))
+
+	params := []string{fmt.Sprintf("--port=%d", port)}
+	if h.Distro.JasperCredentialsPath != "" {
+		params = append(params, fmt.Sprintf("--creds_path=%s", h.Distro.JasperCredentialsPath))
+	}
+
+	return h.jasperServiceCommand(config, "force-reinstall", params...)
 }
 
 func (h *Host) jasperServiceCommand(config evergreen.HostJasperConfig, subCmd string, args ...string) string {
@@ -229,10 +236,16 @@ func (h *Host) jasperBinaryFileName(config evergreen.HostJasperConfig) string {
 }
 
 // BootstrapScript creates the user data script to bootstrap the host.
-func (h *Host) BootstrapScript(config evergreen.HostJasperConfig) string {
+func (h *Host) BootstrapScript(config evergreen.JasperConfig, creds *rpc.Credentials) (string, error) {
+	writeCredentialsCmd, err := h.writeJasperCredentialsFileCommand(config, creds)
+	if err != nil {
+		return "", errors.Wrap(err, "could not build command to write Jasper credentials file ")
+	}
+
 	if h.Distro.IsWindows() {
 		cmds := []string{
 			h.FetchJasperCommandWithPath(config, "/bin"),
+			writeCredentialsCmd,
 			h.ForceReinstallJasperCommand(config),
 		}
 		// PowerShell nested quotation marks are handled by using two quotation
@@ -246,10 +259,26 @@ func (h *Host) BootstrapScript(config evergreen.HostJasperConfig) string {
 			fmt.Sprintf("%s -c '%s'", h.Distro.ShellPath, quotedCmds),
 			"</powershell>",
 		}
-		return strings.Join(commands, "\r\n")
+		return strings.Join(commands, "\r\n"), nil
 	}
+	return strings.Join([]string{"#!/bin/bash",
+		h.FetchJasperCommand(config),
+		writeCredentialsCmd,
+		h.ForceReinstallJasperCommand(config),
+	}, "\n"), nil
+}
 
-	return strings.Join([]string{"#!/bin/bash", h.FetchJasperCommand(config), h.ForceReinstallJasperCommand(config)}, "\n")
+// writeJasperCredentialsCommand builds the command to write the Jasper
+// credentials to a file.
+func (h *Host) writeJasperCredentialsFileCommand(config evergreen.JasperConfig, creds *rpc.Credentials) (string, error) {
+	if h.Distro.JasperCredentialsPath == "" {
+		return "", errors.New("cannot write Jasper credentials without a credentials file path")
+	}
+	exportedCreds, err := creds.Export()
+	if err != nil {
+		return "", errors.Wrap(err, "problem exporting credentials to file format")
+	}
+	return fmt.Sprintf("cat > %s <<EOF\n%s\n", h.Distro.JasperCredentialsPath, exportedCreds), nil
 }
 
 // RunSSHJasperRequest runs the command to make a request to the host's

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -171,12 +171,7 @@ func (h *Host) FetchAndReinstallJasperCommand(config evergreen.HostJasperConfig)
 // delete the current Jasper service configuration (if it exists), install the
 // new configuration, and restart the service.
 func (h *Host) ForceReinstallJasperCommand(config evergreen.HostJasperConfig) string {
-	port := config.Port
-	if port == 0 {
-		port = evergreen.DefaultJasperPort
-	}
-
-	params := []string{fmt.Sprintf("--port=%d", port)}
+	params := []string{fmt.Sprintf("--port=%d", config.Port)}
 	if h.Distro.JasperCredentialsPath != "" {
 		params = append(params, fmt.Sprintf("--creds_path=%s", h.Distro.JasperCredentialsPath))
 	}
@@ -236,7 +231,7 @@ func (h *Host) jasperBinaryFileName(config evergreen.HostJasperConfig) string {
 }
 
 // BootstrapScript creates the user data script to bootstrap the host.
-func (h *Host) BootstrapScript(config evergreen.JasperConfig, creds *rpc.Credentials) (string, error) {
+func (h *Host) BootstrapScript(config evergreen.HostJasperConfig, creds *rpc.Credentials) (string, error) {
 	writeCredentialsCmd, err := h.writeJasperCredentialsFileCommand(config, creds)
 	if err != nil {
 		return "", errors.Wrap(err, "could not build command to write Jasper credentials file ")
@@ -270,7 +265,7 @@ func (h *Host) BootstrapScript(config evergreen.JasperConfig, creds *rpc.Credent
 
 // writeJasperCredentialsCommand builds the command to write the Jasper
 // credentials to a file.
-func (h *Host) writeJasperCredentialsFileCommand(config evergreen.JasperConfig, creds *rpc.Credentials) (string, error) {
+func (h *Host) writeJasperCredentialsFileCommand(config evergreen.HostJasperConfig, creds *rpc.Credentials) (string, error) {
 	if h.Distro.JasperCredentialsPath == "" {
 		return "", errors.New("cannot write Jasper credentials without a credentials file path")
 	}
@@ -278,7 +273,7 @@ func (h *Host) writeJasperCredentialsFileCommand(config evergreen.JasperConfig, 
 	if err != nil {
 		return "", errors.Wrap(err, "problem exporting credentials to file format")
 	}
-	return fmt.Sprintf("cat > %s <<EOF\n%s\n", h.Distro.JasperCredentialsPath, exportedCreds), nil
+	return fmt.Sprintf("cat > %s <<EOF\n%s\nEOF", h.Distro.JasperCredentialsPath, exportedCreds), nil
 }
 
 // RunSSHJasperRequest runs the command to make a request to the host's

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -161,6 +161,19 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		j.AddError(fmt.Errorf("could not find host %s for job %s", j.HostID, j.TaskID))
 		return
 	}
+
+	// kim: TODO: wait for EVG-6231 merge.
+	if err := j.host.DeleteJasperCredentials(ctx, j.env); err != nil {
+		j.AddError(err)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":  "problem deleting Jasper credentials",
+			"host":     j.host.Id,
+			"provider": j.host.Distro.Provider,
+			"job":      j.ID(),
+		}))
+		return
+	}
+
 	// check if running task has been assigned since status changed
 	if j.host.RunningTask != "" {
 		if j.TerminateIfBusy {

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -95,6 +95,18 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		return
 	}
 
+	// kim: TODO: wait for EVG-6231 merge.
+	if err := j.host.DeleteJasperCredentials(ctx, j.env); err != nil {
+		j.AddError(err)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":  "problem deleting Jasper credentials",
+			"host":     j.host.Id,
+			"provider": j.host.Distro.Provider,
+			"job":      j.ID(),
+		}))
+		return
+	}
+
 	// we may be running these jobs on hosts that are already
 	// terminated.
 	grip.InfoWhen(j.host.Status == evergreen.HostTerminated,
@@ -159,18 +171,6 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	}
 	if j.host == nil {
 		j.AddError(fmt.Errorf("could not find host %s for job %s", j.HostID, j.TaskID))
-		return
-	}
-
-	// kim: TODO: wait for EVG-6231 merge.
-	if err := j.host.DeleteJasperCredentials(ctx, j.env); err != nil {
-		j.AddError(err)
-		grip.Error(message.WrapError(err, message.Fields{
-			"message":  "problem deleting Jasper credentials",
-			"host":     j.host.Id,
-			"provider": j.host.Distro.Provider,
-			"job":      j.ID(),
-		}))
 		return
 	}
 

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -95,7 +95,6 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		return
 	}
 
-	// kim: TODO: wait for EVG-6231 merge.
 	if err := j.host.DeleteJasperCredentials(ctx, j.env); err != nil {
 		j.AddError(err)
 		grip.Error(message.WrapError(err, message.Fields{

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -95,7 +95,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		return
 	}
 
-	if err := j.host.DeleteJasperCredentials(ctx, j.env); err != nil {
+	if err = j.host.DeleteJasperCredentials(ctx, j.env); err != nil {
 		j.AddError(err)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":  "problem deleting Jasper credentials",

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -96,7 +96,9 @@ func TestHostCosts(t *testing.T) {
 	}
 	assert.NoError(t1.Insert())
 
-	j := NewHostTerminationJob(&mock.Environment{}, *h, true)
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx, "", nil))
+	j := NewHostTerminationJob(env, *h, true)
 	j.Run(ctx)
 	assert.NoError(j.Error())
 	dbHost, err := host.FindOne(host.ById(h.Id))

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -253,8 +253,9 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 	return nil
 }
 
-// setupJasper sets up the Jasper service on the host by downloading the latest
-// version of Jasper and restarting the Jasper service.
+// setupJasper sets up the Jasper service on the host by putting the credentials
+// on the host, downloading the latest version of Jasper, and restarting the
+// Jasper service.
 func (j *setupHostJob) setupJasper(ctx context.Context) error {
 	d, err := distro.FindOne(distro.ById(j.host.Distro.Id))
 	if err != nil {
@@ -290,6 +291,17 @@ func (j *setupHostJob) setupJasper(ctx context.Context) error {
 		return errors.Wrapf(err, "error getting ssh options for host %s", j.host.Id)
 	}
 
+	creds, err := j.putJasperCredentials(ctx, j.host.Distro.JasperCredentialsPath, sshOptions)
+	if err != nil {
+		grip.Error(message.WrapError(j.host.SetUnprovisioned(), message.Fields{
+			"operation": "setting host unprovisioned",
+			"distro":    j.host.Distro.Id,
+			"job":       j.ID(),
+			"host":      j.host.Id,
+		}))
+		return errors.Wrap(err, "error putting Jasper credentials on remote host")
+	}
+
 	if err := j.doFetchAndReinstallJasper(ctx, sshOptions); err != nil {
 		grip.Error(message.WrapError(j.host.SetUnprovisioned(), message.Fields{
 			"operation": "setting host unprovisioned",
@@ -306,6 +318,84 @@ func (j *setupHostJob) setupJasper(ctx context.Context) error {
 		"job":     j.ID(),
 		"distro":  j.host.Distro.Id,
 	})
+
+	return nil
+}
+
+// putJasperCredentials creates Jasper credentials for the host and puts the
+// credentials file on the host.
+func (j *setupHostJob) putJasperCredentials(ctx context.Context, fileName string, sshOptions []string) error {
+	creds, err := j.host.GenerateJasperCredentials(ctx, j.env)
+	if err != nil {
+		return errors.Wrap(err, "could not generate Jasper credentials for host")
+	}
+
+	hostInfo, err := j.host.GetSSHInfo()
+	if err != nil {
+		return errors.Wrap(err, "could not get SSH info for host")
+	}
+	exportedCreds, err := creds.Export()
+	if err != nil {
+		return errors.Wrap(err, "could not export Jasper credentials")
+	}
+
+	file, err := ioutil.TempFile("", fileName)
+	if err != nil {
+		return errors.Wrap(err, "error creating temporary script file")
+	}
+	if err = os.Chmod(file.Name(), 0644); err != nil {
+		return errors.Wrap(err, "error setting file permissions")
+	}
+	defer func() {
+		errMsg := message.Fields{
+			"job":       j.ID(),
+			"operation": "cleaning up after copying credentials",
+			"file":      file.Name(),
+			"distro":    j.host.Distro.Id,
+			"host":      j.host.Id,
+		}
+		grip.Error(message.WrapError(file.Close(), errMsg))
+		grip.Error(message.WrapError(os.Remove(file.Name()), errMsg))
+	}()
+
+	if _, err = io.WriteString(file, exportedCreds); err != nil {
+		return errors.Wrap(err, "error writing local credentials")
+	}
+
+	scpCmdOut := &util.CappedWriter{
+		Buffer:   &bytes.Buffer{},
+		MaxBytes: 1024 * 1024,
+	}
+	scpArgs := buildScpCommand(file.Name(), fileName, hostInfo, hostInfo.User, sshOptions)
+
+	scpCmd := j.env.JasperManager().CreateCommand(ctx).Add(scpArgs).
+		RedirectErrorToOutput(true).SetOutputWriter(scpCmdOut)
+
+	ctx, cancel := context.WithTimeout(ctx, scpTimeout)
+	defer cancel()
+
+	if err = scpCmd.Run(ctx); err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "problem copying credentials to host",
+			"job":     j.ID(),
+			"command": strings.Join(scpArgs, " "),
+			"distro":  j.host.Distro.Id,
+			"host":    j.host.Id,
+			"output":  scpCmdOut.String(),
+		}))
+		return errors.Wrap(err, "error copying credentials to remote machine")
+	}
+
+	if err := j.host.SaveCredentials(creds); err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "problem saving host credentials",
+			"job":     j.ID(),
+			"distro":  j.host.Distro.Id,
+			"host":    j.host.Id,
+		}))
+		return errors.Wrap(err, "error saving credentials")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6230

* Create Jasper credentials when host is first started up.
    * For user data, this is before the host is spawned.
    * For all others, this is in the provisioning setup host job.
* Delete Jasper credentials when host is terminated.