### PR TITLE
EVG-6257: add merge task to task group

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -156,6 +156,9 @@ const (
 	TaskOrderingPatchFirst    = "patchfirst"
 
 	CommitQueueAlias = "__commit_queue"
+	MergeTaskVariant = "commit-queue-merge"
+	MergeTaskName    = "merge-patch"
+	MergeTaskGroup   = "merge_task_group"
 
 	MaxTeardownGroupTimeoutSecs = 30 * 60
 

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -507,11 +507,11 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error
 	}
 
 	mergeBuildVariant := model.BuildVariant{
-		Name:        "commit-queue-merge",
+		Name:        evergreen.MergeTaskVariant,
 		DisplayName: "Commit Queue Merge",
 		RunOn:       []string{settings.CommitQueue.MergeTaskDistro},
 		Tasks: []model.BuildVariantTaskUnit{
-			{Name: "merge-patch"},
+			{Name: evergreen.MergeTaskName},
 		},
 	}
 
@@ -530,7 +530,7 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error
 	}
 
 	mergeTask := model.ProjectTask{
-		Name: "merge-patch",
+		Name: evergreen.MergeTaskName,
 		Commands: []model.PluginCommandConf{
 			{
 				Command: "git.get_project",
@@ -551,8 +551,16 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error
 		DependsOn: dependencies,
 	}
 
+	// Define as part of a task group with no pre to skip
+	// running a project's pre before the merge task
+	mergeTaskGroup := model.TaskGroup{
+		Name:  evergreen.MergeTaskGroup,
+		Tasks: []string{evergreen.MergeTaskName},
+	}
+
 	project.BuildVariants = append(project.BuildVariants, mergeBuildVariant)
 	project.Tasks = append(project.Tasks, mergeTask)
+	project.TaskGroups = append(project.TaskGroups, mergeTaskGroup)
 
 	validationErrors := validator.CheckProjectSyntax(project)
 	if len(validationErrors) != 0 {

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -200,7 +200,7 @@ func (s *commitQueueSuite) TestAddMergeTaskAndVariant() {
 	s.Require().Len(project.Tasks, 1)
 	s.Equal(evergreen.MergeTaskName, project.Tasks[0].Name)
 	s.Require().Len(project.TaskGroups, 1)
-	s.Equal(evergreen.MergeTaskGroup, project.TaskGroups[0])
+	s.Equal(evergreen.MergeTaskGroup, project.TaskGroups[0].Name)
 }
 
 func (s *commitQueueSuite) TestSetDefaultNotification() {

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -191,14 +191,16 @@ func (s *commitQueueSuite) TestAddMergeTaskAndVariant() {
 	s.NoError(addMergeTaskAndVariant(patchDoc, project))
 
 	s.Require().Len(patchDoc.BuildVariants, 1)
-	s.Equal("commit-queue-merge", patchDoc.BuildVariants[0])
+	s.Equal(evergreen.MergeTaskVariant, patchDoc.BuildVariants[0])
 	s.Require().Len(patchDoc.Tasks, 1)
-	s.Equal("merge-patch", patchDoc.Tasks[0])
+	s.Equal(evergreen.MergeTaskName, patchDoc.Tasks[0])
 
 	s.Require().Len(project.BuildVariants, 1)
-	s.Equal("commit-queue-merge", project.BuildVariants[0].Name)
+	s.Equal(evergreen.MergeTaskVariant, project.BuildVariants[0].Name)
 	s.Require().Len(project.Tasks, 1)
-	s.Equal("merge-patch", project.Tasks[0].Name)
+	s.Equal(evergreen.MergeTaskName, project.Tasks[0].Name)
+	s.Require().Len(project.TaskGroups, 1)
+	s.Equal(evergreen.MergeTaskGroup, project.TaskGroups[0])
 }
 
 func (s *commitQueueSuite) TestSetDefaultNotification() {


### PR DESCRIPTION
Prevent pre from running before merge tasks by packaging the task in a task group by itself and not defining a pre for the task group. 
This works since a task group's pre takes precedence over the project's pre.