### PR TITLE
EVG-6230: manage lifetime of Jasper credentials on host creation and deletion

### DIFF
--- a/cloud/user_data_test.go
+++ b/cloud/user_data_test.go
@@ -2,11 +2,19 @@ package cloud
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"mime/multipart"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model/credentials"
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -106,4 +114,72 @@ func TestMakeMultipartUserData(t *testing.T) {
 	assert.False(t, strings.Contains(res, fileOne))
 	assert.Contains(t, res, fileTwo)
 	assert.Contains(t, res, userData)
+}
+
+func withBootstrapEnv(t *testing.T, fn func(env evergreen.Environment)) {
+	env := &mock.Environment{}
+	var cancel context.CancelFunc
+	env.EnvContext, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, env.Configure(env.EnvContext, "", nil))
+	env.Settings().DomainName = "test"
+
+	require.NoError(t, db.ClearCollections(credentials.Collection, host.Collection))
+	defer func() {
+		assert.NoError(t, db.ClearCollections(credentials.Collection, host.Collection))
+	}()
+	require.NoError(t, credentials.Bootstrap(env))
+	fn(env)
+}
+
+func TestBootstrapUserData(t *testing.T) {
+	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, env evergreen.Environment, h *host.Host){
+		"PassesWithoutCustomuserData": func(ctx context.Context, t *testing.T, env evergreen.Environment, h *host.Host) {
+			userData, err := bootstrapUserData(ctx, env, h, "")
+			require.NoError(t, err)
+			assert.NotEmpty(t, userData)
+
+			assert.Equal(t, h.JasperCredentialsID, h.Id)
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, h.Id, dbHost.JasperCredentialsID)
+
+			creds, err := h.JasperCredentials(ctx, env)
+			require.NoError(t, err)
+			assert.NotNil(t, creds)
+		},
+		"PassesWithCustomUserData": func(ctx context.Context, t *testing.T, env evergreen.Environment, h *host.Host) {
+			customUserData := "#!/bin/bash\necho 'foobar'"
+			userData, err := bootstrapUserData(ctx, env, h, customUserData)
+			require.NoError(t, err)
+			assert.NotEmpty(t, userData)
+			assert.True(t, len(userData) > len(customUserData))
+
+			assert.Equal(t, h.JasperCredentialsID, h.Id)
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, h.Id, dbHost.JasperCredentialsID)
+
+			creds, err := h.JasperCredentials(ctx, env)
+			require.NoError(t, err)
+			assert.NotNil(t, creds)
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			withBootstrapEnv(t, func(env evergreen.Environment) {
+				h := &host.Host{Id: "host", Distro: distro.Distro{
+					Arch:                  distro.ArchLinuxAmd64,
+					BootstrapMethod:       distro.BootstrapMethodUserData,
+					JasperCredentialsPath: "/bar",
+				}}
+				require.NoError(t, h.Insert())
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				testCase(ctx, t, env, h)
+			})
+		})
+	}
 }

--- a/model/credentials/db.go
+++ b/model/credentials/db.go
@@ -20,10 +20,7 @@ const (
 	defaultExpiration = 30 * 24 * time.Hour // 1 month
 )
 
-var (
-	serviceName        string
-	errNotBootstrapped = errors.Errorf("%s collection has not been bootstrapped", Collection)
-)
+var serviceName string
 
 // Bootstrap performs one-time initialization of the credentials collection with
 // the certificate authority and service certificate. In order to perform
@@ -68,13 +65,6 @@ func Bootstrap(env evergreen.Environment) error {
 	return nil
 }
 
-func validateBootstrapped() error {
-	if serviceName == "" {
-		return errNotBootstrapped
-	}
-	return nil
-}
-
 func mongoConfig(settings *evergreen.Settings) *certdepot.MongoDBOptions {
 	return &certdepot.MongoDBOptions{
 		MongoDBURI:     settings.Database.Url,
@@ -102,10 +92,6 @@ func deleteIfExists(dpt certdepot.Depot, tags ...*depot.Tag) error {
 // name. If the credentials already exist, this will overwrite the existing
 // credentials.
 func SaveCredentials(ctx context.Context, env evergreen.Environment, name string, creds *rpc.Credentials) error {
-	if err := validateBootstrapped(); err != nil {
-		return err
-	}
-
 	dpt, err := getDepot(ctx, env)
 	if err != nil {
 		return errors.Wrap(err, "could not get depot")
@@ -128,10 +114,6 @@ func SaveCredentials(ctx context.Context, env evergreen.Environment, name string
 // database. This is not idempotent, so separate calls with the same inputs will
 // return different credentials.
 func GenerateInMemory(ctx context.Context, env evergreen.Environment, name string) (*rpc.Credentials, error) {
-	if err := validateBootstrapped(); err != nil {
-		return nil, err
-	}
-
 	opts := certdepot.CertificateOptions{
 		CA:         CAName,
 		CommonName: name,
@@ -174,10 +156,6 @@ func GenerateInMemory(ctx context.Context, env evergreen.Environment, name strin
 
 // FindByID gets the credentials for the given name.
 func FindByID(ctx context.Context, env evergreen.Environment, name string) (*rpc.Credentials, error) {
-	if err := validateBootstrapped(); err != nil {
-		return nil, err
-	}
-
 	dpt, err := getDepot(ctx, env)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get depot")
@@ -203,10 +181,6 @@ func FindByID(ctx context.Context, env evergreen.Environment, name string) (*rpc
 
 // DeleteCredentials removes the credentials from the database.
 func DeleteCredentials(ctx context.Context, env evergreen.Environment, name string) error {
-	if err := validateBootstrapped(); err != nil {
-		return err
-	}
-
 	dpt, err := getDepot(ctx, env)
 	if err != nil {
 		return errors.Wrap(err, "could not get depot")

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -54,6 +54,7 @@ var (
 	AgentRevisionKey             = bsonutil.MustHaveTag(Host{}, "AgentRevision")
 	NeedsNewAgentKey             = bsonutil.MustHaveTag(Host{}, "NeedsNewAgent")
 	NeedsNewAgentMonitorKey      = bsonutil.MustHaveTag(Host{}, "NeedsNewAgentMonitor")
+	JasperCredentialsIDKey       = bsonutil.MustHaveTag(Host{}, "JasperCredentialsID")
 	StartedByKey                 = bsonutil.MustHaveTag(Host{}, "StartedBy")
 	InstanceTypeKey              = bsonutil.MustHaveTag(Host{}, "InstanceType")
 	VolumeSizeKey                = bsonutil.MustHaveTag(Host{}, "VolumeTotalSize")
@@ -338,7 +339,9 @@ func Provisioning() db.Q {
 }
 
 func FindByFirstProvisioningAttempt() ([]Host, error) {
+	bootstrapKey := bsonutil.GetDottedKeyName(DistroKey, distro.BootstrapMethodKey)
 	return Find(db.Query(bson.M{
+		bootstrapKey:         bson.M{"$ne": distro.BootstrapMethodUserData},
 		ProvisionAttemptsKey: 0,
 		StatusKey:            evergreen.HostProvisioning,
 	}))

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -87,6 +87,10 @@ type Host struct {
 	NeedsNewAgent        bool   `bson:"needs_agent" json:"needs_agent"`
 	NeedsNewAgentMonitor bool   `bson:"needs_agent_monitor" json:"needs_agent_monitor"`
 
+	// JasperCredentialsID is used to match hosts to their Jasper credentials
+	// for non-legacy hosts.
+	JasperCredentialsID string `bson:"jasper_credentials_id" json:"jasper_credentials_id"`
+
 	// for ec2 dynamic hosts, the instance type requested
 	InstanceType string `bson:"instance_type" json:"instance_type,omitempty"`
 	// for ec2 dynamic hosts, the total size of the volumes requested, in GiB
@@ -334,25 +338,45 @@ func (h *Host) CreateSecret() error {
 
 // JasperCredentials gets the Jasper credentials from the database.
 func (h *Host) JasperCredentials(ctx context.Context, env evergreen.Environment) (*rpc.Credentials, error) {
-	return credentials.FindByID(ctx, env, h.Id)
+	return credentials.FindByID(ctx, env, h.JasperCredentialsID)
 }
 
 // GenerateJasperCredentials creates the Jasper credentials for the given host
 // without saving them to the database.
 func (h *Host) GenerateJasperCredentials(ctx context.Context, env evergreen.Environment) (*rpc.Credentials, error) {
-	return credentials.GenerateInMemory(ctx, env, h.Id)
+	if h.JasperCredentialsID == "" {
+		if err := h.UpdateJasperCredentialsID(h.Id); err != nil {
+			return nil, errors.Wrap(err, "problem setting Jasper credentials ID")
+		}
+	}
+	return credentials.GenerateInMemory(ctx, env, h.JasperCredentialsID)
 }
 
 // SaveJasperCredentials saves the given Jasper credentials in the database for
 // the host.
 func (h *Host) SaveJasperCredentials(ctx context.Context, env evergreen.Environment, creds *rpc.Credentials) error {
-	return credentials.SaveCredentials(ctx, env, h.Id, creds)
+	if h.JasperCredentialsID == "" {
+		return errors.New("Jasper credentials ID is empty")
+	}
+	return credentials.SaveCredentials(ctx, env, h.JasperCredentialsID, creds)
 }
 
 // DeleteJasperCredentials deletes the Jasper credentials for the host and
 // updates the host both in memory and in the database.
 func (h *Host) DeleteJasperCredentials(ctx context.Context, env evergreen.Environment) error {
-	return credentials.DeleteCredentials(ctx, env, h.Id)
+	return credentials.DeleteCredentials(ctx, env, h.JasperCredentialsID)
+}
+
+// UpdateJasperCredentialsID sets the ID of the host's Jasper credentials.
+func (h *Host) UpdateJasperCredentialsID(id string) error {
+	if err := UpdateOne(
+		bson.M{IdKey: h.Id},
+		bson.M{"$set": bson.M{JasperCredentialsIDKey: id}},
+	); err != nil {
+		return err
+	}
+	h.JasperCredentialsID = id
+	return nil
 }
 
 // UpdateLastCommunicated sets the host's last communication time to the current time.

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/credentials"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/mongodb/jasper/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,8 +30,12 @@ func TestCurlCommand(t *testing.T) {
 	assert.Equal(expected, h.CurlCommand(url))
 }
 
+func newMockCredentials() (*rpc.Credentials, error) {
+	return rpc.NewCredentials([]byte("foo"), []byte("bar"), []byte("bat"))
+}
+
 func TestJasperCommands(t *testing.T) {
-	for testName, testCase := range map[string]func(t *testing.T, h *Host, config evergreen.HostJasperConfig){
+	for opName, opCase := range map[string]func(t *testing.T, h *Host, config evergreen.HostJasperConfig){
 		"VerifyBaseFetchCommands": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {
 			expectedCmds := []string{
 				"cd \"/foo\"",
@@ -54,7 +61,7 @@ func TestJasperCommands(t *testing.T) {
 			path := "/bar"
 			expectedCmds := h.fetchJasperCommands(config)
 			for i := range expectedCmds {
-				expectedCmds[i] = "PATH=/bar " + expectedCmds[i]
+				expectedCmds[i] = fmt.Sprintf("PATH=%s ", path) + expectedCmds[i]
 			}
 			cmds := h.FetchJasperCommandWithPath(config, path)
 			for _, expectedCmd := range expectedCmds {
@@ -63,7 +70,10 @@ func TestJasperCommands(t *testing.T) {
 		},
 		"BootstrapScript": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {
 			expectedCmds := []string{h.FetchJasperCommand(config), h.ForceReinstallJasperCommand(config)}
-			script := h.BootstrapScript(config)
+			creds, err := newMockCredentials()
+			require.NoError(t, err)
+			script, err := h.BootstrapScript(config, creds)
+			require.NoError(t, err)
 			assert.True(t, strings.HasPrefix(script, "#!/bin/bash"))
 			for _, expectedCmd := range expectedCmds {
 				assert.Contains(t, script, expectedCmd)
@@ -71,17 +81,16 @@ func TestJasperCommands(t *testing.T) {
 		},
 		"ForceReinstallJasperCommand": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {
 			cmd := h.ForceReinstallJasperCommand(config)
-			assert.Equal(t, "sudo /foo/jasper_cli jasper service force-reinstall rpc --port=12345", cmd)
+			assert.Equal(t, "sudo /foo/jasper_cli jasper service force-reinstall rpc --port=12345 --creds_path=/bar", cmd)
 		},
-		"ForceReinstallJasperCommandNoPort": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {
-			config.Port = 0
-			cmd := h.ForceReinstallJasperCommand(config)
-			assert.Equal(t, fmt.Sprintf("sudo /foo/jasper_cli jasper service force-reinstall rpc --port=%d", evergreen.DefaultJasperPort), cmd)
-		},
-		// "": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {},
+		// "": func(t *testing.T, h *Host, config evergreen.JasperConfig) {},
 	} {
-		t.Run(testName, func(t *testing.T) {
-			h := &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64, CuratorDir: "/foo"}}
+		t.Run(opName, func(t *testing.T) {
+			h := &Host{Distro: distro.Distro{
+				Arch:                  distro.ArchLinuxAmd64,
+				CuratorDir:            "/foo",
+				JasperCredentialsPath: "/bar",
+			}}
 			config := evergreen.HostJasperConfig{
 				BinaryName:       "jasper_cli",
 				DownloadFileName: "download_file",
@@ -89,13 +98,13 @@ func TestJasperCommands(t *testing.T) {
 				Version:          "abc123",
 				Port:             12345,
 			}
-			testCase(t, h, config)
+			opCase(t, h, config)
 		})
 	}
 }
 
 func TestJasperCommandsWindows(t *testing.T) {
-	for testName, testCase := range map[string]func(t *testing.T, h *Host, config evergreen.HostJasperConfig){
+	for opName, opCase := range map[string]func(t *testing.T, h *Host, config evergreen.HostJasperConfig){
 		"VerifyBaseFetchCommands": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {
 			expectedCmds := []string{
 				"cd \"/foo\"",
@@ -118,8 +127,8 @@ func TestJasperCommandsWindows(t *testing.T) {
 			}
 		},
 		"FetchJasperCommandWithPath": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {
+			path := "/bar"
 			expectedCmds := h.fetchJasperCommands(config)
-			path := "/bin"
 			for i := range expectedCmds {
 				expectedCmds[i] = fmt.Sprintf("PATH=%s ", path) + expectedCmds[i]
 			}
@@ -135,7 +144,10 @@ func TestJasperCommandsWindows(t *testing.T) {
 				expectedCmds[i] = strings.Replace(fmt.Sprintf("PATH=%s ", path)+expectedCmds[i], "'", "''", -1)
 			}
 			expectedCmds = append(expectedCmds, h.ForceReinstallJasperCommand(config))
-			script := h.BootstrapScript(config)
+			creds, err := newMockCredentials()
+			require.NoError(t, err)
+			script, err := h.BootstrapScript(config, creds)
+			require.NoError(t, err)
 			assert.True(t, strings.HasPrefix(script, "<powershell>"))
 			assert.True(t, strings.HasSuffix(script, "</powershell>"))
 			for _, expectedCmd := range expectedCmds {
@@ -144,16 +156,53 @@ func TestJasperCommandsWindows(t *testing.T) {
 		},
 		"ForceReinstallJasperCommand": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {
 			cmd := h.ForceReinstallJasperCommand(config)
-			assert.Equal(t, "/foo/jasper_cli.exe jasper service force-reinstall rpc --port=12345", cmd)
+			assert.Equal(t, "/foo/jasper_cli.exe jasper service force-reinstall rpc --port=12345 --creds_path=/bar", cmd)
 		},
-		"ForceReinstallJasperCommandNoPort": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {
-			config.Port = 0
-			cmd := h.ForceReinstallJasperCommand(config)
-			assert.Equal(t, fmt.Sprintf("/foo/jasper_cli.exe jasper service force-reinstall rpc --port=%d", evergreen.DefaultJasperPort), cmd)
+		"WriteJasperCredentialsFileCommand": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {
+			creds, err := newMockCredentials()
+			require.NoError(t, err)
+			path := h.Distro.JasperCredentialsPath
+
+			for testName, testCase := range map[string]func(t *testing.T){
+				"WithoutJasperCredentialsPath": func(t *testing.T) {
+					h.Distro.JasperCredentialsPath = ""
+					_, err := h.writeJasperCredentialsFileCommand(config, creds)
+					assert.Error(t, err)
+				},
+				"WithJasperCredentialsPath": func(t *testing.T) {
+					cmd, err := h.writeJasperCredentialsFileCommand(config, creds)
+					require.NoError(t, err)
+
+					expectedCreds, err := creds.Export()
+					require.NoError(t, err)
+					assert.Equal(t, fmt.Sprintf("cat > /bar <<EOF\n%s\nEOF", expectedCreds), cmd)
+				},
+			} {
+				t.Run(testName, func(t *testing.T) {
+					h.Distro.JasperCredentialsPath = path
+					require.NoError(t, db.ClearCollections(credentials.Collection))
+					defer func() {
+						assert.NoError(t, db.ClearCollections(credentials.Collection))
+					}()
+					testCase(t)
+				})
+			}
+		},
+		"WriteJasperCredentialsFileCommandNoDistroPath": func(t *testing.T, h *Host, config evergreen.HostJasperConfig) {
+			creds, err := rpc.NewCredentials([]byte("foo"), []byte("bar"), []byte("bat"))
+			require.NoError(t, err)
+
+			h.Distro.JasperCredentialsPath = ""
+			_, err = h.writeJasperCredentialsFileCommand(config, creds)
+			assert.Error(t, err)
 		},
 	} {
-		t.Run(testName, func(t *testing.T) {
-			h := &Host{Distro: distro.Distro{Arch: distro.ArchWindowsAmd64, CuratorDir: "/foo"}}
+		t.Run(opName, func(t *testing.T) {
+			h := &Host{Distro: distro.Distro{
+				Arch:                  distro.ArchWindowsAmd64,
+				CuratorDir:            "/foo",
+				JasperCredentialsPath: "/bar",
+			}}
 			config := evergreen.HostJasperConfig{
 				BinaryName:       "jasper_cli",
 				DownloadFileName: "download_file",
@@ -161,7 +210,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 				Version:          "abc123",
 				Port:             12345,
 			}
-			testCase(t, h, config)
+			opCase(t, h, config)
 		})
 	}
 

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -81,6 +81,9 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			return
 		}
 	}
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
 
 	if !j.host.IsEphemeral() {
 		grip.Notice(message.Fields{
@@ -233,10 +236,6 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			}))
 		}
 		return
-	}
-
-	if j.env == nil {
-		j.env = evergreen.GetEnvironment()
 	}
 
 	settings := j.env.Settings()

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -95,6 +95,17 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		return
 	}
 
+	if err = j.host.DeleteJasperCredentials(ctx, j.env); err != nil {
+		j.AddError(err)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":  "problem deleting Jasper credentials",
+			"host":     j.host.Id,
+			"provider": j.host.Distro.Provider,
+			"job":      j.ID(),
+		}))
+		return
+	}
+
 	// we may be running these jobs on hosts that are already
 	// terminated.
 	grip.InfoWhen(j.host.Status == evergreen.HostTerminated,
@@ -161,6 +172,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		j.AddError(fmt.Errorf("could not find host %s for job %s", j.HostID, j.TaskID))
 		return
 	}
+
 	// check if running task has been assigned since status changed
 	if j.host.RunningTask != "" {
 		if j.TerminateIfBusy {

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -96,7 +96,9 @@ func TestHostCosts(t *testing.T) {
 	}
 	assert.NoError(t1.Insert())
 
-	j := NewHostTerminationJob(&mock.Environment{}, *h, true)
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx, "", nil))
+	j := NewHostTerminationJob(env, *h, true)
 	j.Run(ctx)
 	assert.NoError(j.Error())
 	dbHost, err := host.FindOne(host.ById(h.Id))


### PR DESCRIPTION
Host termination job didn't populate the env field until after `DeleteJasperCredentials()`, which requires an environment. I moved the logic to set j.env up.