### PR TITLE
EVG-6257: Avoid Pre for Commit Queue Merge

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -601,15 +601,16 @@ func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project) []BuildVariant
 			Name: t,
 			// IsGroup is not persisted, and indicates here that the
 			// task is a member of a task group.
-			IsGroup:         true,
-			GroupName:       in.Name,
-			Patchable:       in.Patchable,
-			Priority:        in.Priority,
-			DependsOn:       in.DependsOn,
-			Requires:        in.Requires,
-			Distros:         in.Distros,
-			ExecTimeoutSecs: in.ExecTimeoutSecs,
-			Stepback:        in.Stepback,
+			IsGroup:          true,
+			GroupName:        in.Name,
+			Patchable:        in.Patchable,
+			Priority:         in.Priority,
+			DependsOn:        in.DependsOn,
+			Requires:         in.Requires,
+			Distros:          in.Distros,
+			ExecTimeoutSecs:  in.ExecTimeoutSecs,
+			Stepback:         in.Stepback,
+			CommitQueueMerge: in.CommitQueueMerge,
 		}
 		bvt.Populate(taskMap[t])
 		tasks = append(tasks, bvt)

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -508,7 +508,7 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error
 		RunOn:       []string{settings.CommitQueue.MergeTaskDistro},
 		Tasks: []model.BuildVariantTaskUnit{
 			{
-				Name:             evergreen.MergeTaskName,
+				Name:             evergreen.MergeTaskGroup,
 				CommitQueueMerge: true,
 			},
 		},

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -553,8 +553,9 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error
 	// Define as part of a task group with no pre to skip
 	// running a project's pre before the merge task
 	mergeTaskGroup := model.TaskGroup{
-		Name:  evergreen.MergeTaskGroup,
-		Tasks: []string{evergreen.MergeTaskName},
+		Name:     evergreen.MergeTaskGroup,
+		Tasks:    []string{evergreen.MergeTaskName},
+		MaxHosts: 1,
 	}
 
 	project.BuildVariants = append(project.BuildVariants, mergeBuildVariant)


### PR DESCRIPTION
#2421 adds a commit queue merge task to a task group to avoid running pre.

However:
- MaxHosts was not set so it wasn't treated as a task group. 
- The build variant was defined with the merge task itself instead of the task group.
- The CommitQueueMerge label on tasks wasn't being propagated forward for task groups.