### PR TITLE
EVG-6269 persist parserProject

### DIFF
--- a/command/registry.go
+++ b/command/registry.go
@@ -178,7 +178,11 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		}
 
 		cmd := factory()
-		if err = cmd.ParseParams(c.Params); err != nil {
+		params, err := c.ResolveParams()
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
+		if err = cmd.ParseParams(params); err != nil {
 			errs = append(errs, errors.Wrapf(err, "problem parsing input of %s (%s)", c.Command, c.DisplayName).Error())
 			continue
 		}

--- a/command/registry.go
+++ b/command/registry.go
@@ -135,7 +135,6 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		parsed []model.PluginCommandConf
 		out    []Command
 		errs   []string
-		err    error
 	)
 
 	if name := commandInfo.Function; name != "" {
@@ -181,6 +180,7 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		params, err := c.ResolveParams()
 		if err != nil {
 			errs = append(errs, err.Error())
+			continue
 		}
 		if err = cmd.ParseParams(params); err != nil {
 			errs = append(errs, errors.Wrapf(err, "problem parsing input of %s (%s)", c.Command, c.DisplayName).Error())

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -313,13 +313,25 @@ func (s *GenerateSuite) TestParseProjectFromJSON() {
 	s.Len(g.Functions, 2)
 	s.Contains(g.Functions, "echo-hi")
 	s.Equal("shell.exec", g.Functions["echo-hi"].List()[0].Command)
-	s.Equal("echo hi", g.Functions["echo-hi"].List()[0].Params["script"])
-	s.Equal("echo bye", g.Functions["echo-bye"].List()[0].Params["script"])
-	s.Equal("echo bye again", g.Functions["echo-bye"].List()[1].Params["script"])
+
+	params, err := g.Functions["echo-hi"].List()[0].ResolveParams()
+	s.NoError(err)
+	s.Equal("echo hi", params["script"])
+
+	params, err = g.Functions["echo-bye"].List()[0].ResolveParams()
+	s.NoError(err)
+	s.Equal("echo bye", params["script"])
+
+	params, err = g.Functions["echo-bye"].List()[1].ResolveParams()
+	s.NoError(err)
+	s.Equal("echo bye again", params["script"])
 
 	s.Len(g.Tasks, 1)
 	s.Equal("git.get_project", g.Tasks[0].Commands[0].Command)
-	s.Equal("src", g.Tasks[0].Commands[0].Params["directory"])
+
+	params, err = g.Tasks[0].Commands[0].ResolveParams()
+	s.NoError(err)
+	s.Equal("src", params["directory"])
 	s.Equal("echo-hi", g.Tasks[0].Commands[1].Function)
 	s.Equal("test", g.Tasks[0].Name)
 

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -34,7 +34,7 @@ var (
 				DependsOn: []parserDependency{
 					{TaskSelector: taskSelector{
 						Name:    "a-depended-on-task",
-						Variant: &variantSelector{stringSelector: "*"},
+						Variant: &variantSelector{StringSelector: "*"},
 					}},
 				},
 			},

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -315,15 +315,15 @@ func (s *GenerateSuite) TestParseProjectFromJSON() {
 	s.Equal("shell.exec", g.Functions["echo-hi"].List()[0].Command)
 
 	params, err := g.Functions["echo-hi"].List()[0].ResolveParams()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("echo hi", params["script"])
 
 	params, err = g.Functions["echo-bye"].List()[0].ResolveParams()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("echo bye", params["script"])
 
 	params, err = g.Functions["echo-bye"].List()[1].ResolveParams()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("echo bye again", params["script"])
 
 	s.Len(g.Tasks, 1)

--- a/model/project.go
+++ b/model/project.go
@@ -276,8 +276,8 @@ type ArtifactInstructions struct {
 }
 
 type YAMLCommandSet struct {
-	SingleCommand *PluginCommandConf
-	MultiCommand  []PluginCommandConf
+	SingleCommand *PluginCommandConf  `bson:"single_command"`
+	MultiCommand  []PluginCommandConf `bson:"multi_command"`
 }
 
 func (c *YAMLCommandSet) List() []PluginCommandConf {

--- a/model/project.go
+++ b/model/project.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -284,7 +283,7 @@ func (p *PluginCommandConf) ResolveParams() (map[string]interface{}, error) {
 	if len(p.Params) > 0 {
 		return p.Params, nil
 	}
-	if err := json.Unmarshal([]byte(p.ParamsYAML), &out); err != nil {
+	if err := yaml.Unmarshal([]byte(p.ParamsYAML), &out); err != nil {
 		return nil, errors.Wrapf(err, "error unmarshalling params")
 	}
 	p.Params = out
@@ -331,7 +330,7 @@ func (c *PluginCommandConf) unmarshalParams(params interface{}) error {
 		c.ParamsYAML = string(bytes)
 		c.Params = map[string]interface{}{}
 		for key, val := range v {
-			c.Params[fmt.Sprintf("%v", key)] = fmt.Sprintf("%v", val)
+			c.Params[fmt.Sprintf("%v", key)] = val
 		}
 	}
 	return nil

--- a/model/project_matrix.go
+++ b/model/project_matrix.go
@@ -531,21 +531,21 @@ func expandTaskSelector(ts taskSelector, exp util.Expansions) (taskSelector, err
 	}
 	newTS.Name = newName
 	if v := ts.Variant; v != nil {
-		if len(v.matrixSelector) > 0 {
-			newMS, err := expandMatrixDefinition(v.matrixSelector, exp)
+		if len(v.MatrixSelector) > 0 {
+			newMS, err := expandMatrixDefinition(v.MatrixSelector, exp)
 			if err != nil {
 				return newTS, errors.Wrap(err, "expanding variant")
 			}
 			newTS.Variant = &variantSelector{
-				matrixSelector: newMS,
+				MatrixSelector: newMS,
 			}
 		} else {
-			selector, err := exp.ExpandString(v.stringSelector)
+			selector, err := exp.ExpandString(v.StringSelector)
 			if err != nil {
 				return newTS, errors.Wrap(err, "expanding variant")
 			}
 			newTS.Variant = &variantSelector{
-				stringSelector: selector,
+				StringSelector: selector,
 			}
 		}
 	}

--- a/model/project_matrix.go
+++ b/model/project_matrix.go
@@ -45,9 +45,9 @@ type matrix struct {
 
 // matrixAxis represents one axis of a matrix definition.
 type matrixAxis struct {
-	Id          string      `yaml:"id"`
-	DisplayName string      `yaml:"display_name"`
-	Values      []axisValue `yaml:"values"`
+	Id          string      `yaml:"id" bson:"id"`
+	DisplayName string      `yaml:"display_name" bson:"display_name"`
+	Values      []axisValue `yaml:"values" bson:"values"`
 }
 
 // find returns the axisValue with the given name.
@@ -63,14 +63,14 @@ func (ma matrixAxis) find(id string) (axisValue, error) {
 // axisValues make up the "points" along a matrix axis. Values are
 // combined during matrix evaluation to produce new variants.
 type axisValue struct {
-	Id          string            `yaml:"id"`
-	DisplayName string            `yaml:"display_name"`
-	Variables   util.Expansions   `yaml:"variables"`
-	RunOn       parserStringSlice `yaml:"run_on"`
-	Tags        parserStringSlice `yaml:"tags"`
-	Modules     parserStringSlice `yaml:"modules"`
-	BatchTime   *int              `yaml:"batchtime"`
-	Stepback    *bool             `yaml:"stepback"`
+	Id          string            `yaml:"id" bson:"id"`
+	DisplayName string            `yaml:"display_name" bson:"display_name"`
+	Variables   util.Expansions   `yaml:"variables" bson:"variables"`
+	RunOn       parserStringSlice `yaml:"run_on" bson:"run_on"`
+	Tags        parserStringSlice `yaml:"tags" bson:"tags"`
+	Modules     parserStringSlice `yaml:"modules" bson:"modules"`
+	BatchTime   *int              `yaml:"batchtime" bson:"batchtime"`
+	Stepback    *bool             `yaml:"stepback" bson:"stepback"`
 }
 
 // helper methods for tag selectors

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1236,7 +1236,13 @@ functions:
 			filepath := filepath.Join(testutil.GetDirectoryOfFile(), "..", "self-tests.yml")
 			yml, err := ioutil.ReadFile(filepath)
 			assert.NoError(t, err)
-			assert.NoError(t, checkProjectPersists([]byte(yml)))
+			assert.NoError(t, checkProjectPersists(yml))
+		},
+		"hostcreate.yml": func(t *testing.T) {
+			filepath := filepath.Join(testutil.GetDirectoryOfFile(), "..", "rest", "data", "temp.yml")
+			yml, err := ioutil.ReadFile(filepath)
+			assert.NoError(t, err)
+			assert.NoError(t, checkProjectPersists(yml))
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1238,12 +1238,6 @@ functions:
 			assert.NoError(t, err)
 			assert.NoError(t, checkProjectPersists(yml))
 		},
-		"hostcreate.yml": func(t *testing.T) {
-			filepath := filepath.Join(testutil.GetDirectoryOfFile(), "..", "rest", "data", "temp.yml")
-			yml, err := ioutil.ReadFile(filepath)
-			assert.NoError(t, err)
-			assert.NoError(t, checkProjectPersists(yml))
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.NoError(t, db.ClearCollections(VersionCollection))

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -372,11 +372,11 @@ func (v *variantSelectorEvaluator) evalSelector(vs *variantSelector) ([]string, 
 	if vs == nil {
 		return nil, errors.New("empty selector")
 	}
-	if vs.matrixSelector != nil {
-		evaluatedSelector, errs := vs.matrixSelector.evaluatedCopy(v.axisEval)
+	if vs.MatrixSelector != nil {
+		evaluatedSelector, errs := vs.MatrixSelector.evaluatedCopy(v.axisEval)
 		if len(errs) > 0 {
 			return nil, errors.Errorf(
-				"errors evaluating variant selector %v: %v", vs.matrixSelector, errs)
+				"errors evaluating variant selector %v: %v", vs.MatrixSelector, errs)
 		}
 		results := []string{}
 		// this could be sped up considerably with caching, but I doubt we'll need to
@@ -386,11 +386,11 @@ func (v *variantSelectorEvaluator) evalSelector(vs *variantSelector) ([]string, 
 			}
 		}
 		if len(results) == 0 {
-			return nil, errors.Errorf("variant selector %v returns no variants", vs.matrixSelector)
+			return nil, errors.Errorf("variant selector %v returns no variants", vs.MatrixSelector)
 		}
 		return results, nil
 	}
-	results, err := v.tagEval.evalSelector(ParseSelector(vs.stringSelector))
+	results, err := v.tagEval.evalSelector(ParseSelector(vs.StringSelector))
 	if err != nil {
 		return nil, errors.Wrap(err, "variant tag selector")
 	}

--- a/model/project_selector_test.go
+++ b/model/project_selector_test.go
@@ -261,7 +261,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 		Convey("and a set of variant selectors", func() {
 			Convey("a single-cell matrix selector should return one variant", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{"iron"},
 						"temp":     []string{"0"},
 					},
@@ -273,7 +273,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a 2x2 matrix selector should return four variants", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{"iron", "wood"},
 						"temp":     []string{"0", "100"},
 					},
@@ -288,7 +288,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a *x* matrix selector should return all variants", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{"*"},
 						"temp":     []string{"*"},
 					},
@@ -299,7 +299,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a tagged matrix selector should return all axis-tagged variants", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{".metal"},
 						"temp":     []string{".hot"},
 					},
@@ -312,7 +312,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("an empty matrix selector should error", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{},
+					MatrixSelector: matrixDefinition{},
 				}
 				v, err := vse.evalSelector(vs)
 				So(err, ShouldNotBeNil)
@@ -320,7 +320,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a matrix selector with nonexistent axes should fail", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"wow": []string{"neat"},
 					},
 				}
@@ -330,7 +330,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a matrix selector with nonexistent selectors should fail", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{".neat"},
 					},
 				}
@@ -340,7 +340,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a matrix selector with invalid selectors should fail", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{""},
 					},
 				}

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1065,7 +1065,7 @@ tasks:
 	s.Len(errs, 0)
 	marshaled, err := yaml.Marshal(intermediate)
 	s.NoError(err)
-	unmarshaled := parserProject{}
+	unmarshaled := ParserProject{}
 	s.NoError(yaml.Unmarshal(marshaled, &unmarshaled))
 }
 

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1065,7 +1065,7 @@ tasks:
 	s.Len(errs, 0)
 	marshaled, err := yaml.Marshal(intermediate)
 	s.NoError(err)
-	unmarshaled := ParserProject{}
+	unmarshaled := parserProject{}
 	s.NoError(yaml.Unmarshal(marshaled, &unmarshaled))
 }
 

--- a/model/version.go
+++ b/model/version.go
@@ -24,7 +24,7 @@ type Version struct {
 	Message             string               `bson:"message" json:"message,omitempty"`
 	Status              string               `bson:"status" json:"status,omitempty"`
 	RevisionOrderNumber int                  `bson:"order,omitempty" json:"order,omitempty"`
-	ParserProject       *ParserProject       `bson:"project" json:"project,omitempty"`
+	ParserProject       *parserProject       `bson:"project" json:"project,omitempty"`
 	Config              string               `bson:"config" json:"config,omitempty"`
 	ConfigUpdateNumber  int                  `bson:"config_number" json:"config_number,omitempty"`
 	Ignored             bool                 `bson:"ignored" json:"ignored"`

--- a/model/version.go
+++ b/model/version.go
@@ -24,6 +24,7 @@ type Version struct {
 	Message             string               `bson:"message" json:"message,omitempty"`
 	Status              string               `bson:"status" json:"status,omitempty"`
 	RevisionOrderNumber int                  `bson:"order,omitempty" json:"order,omitempty"`
+	ParserProject       *ParserProject       `bson:"project" json:"project,omitempty"`
 	Config              string               `bson:"config" json:"config,omitempty"`
 	ConfigUpdateNumber  int                  `bson:"config_number" json:"config_number,omitempty"`
 	Ignored             bool                 `bson:"ignored" json:"ignored"`

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -29,6 +29,7 @@ var (
 	VersionBuildVariantsKey       = bsonutil.MustHaveTag(Version{}, "BuildVariants")
 	VersionRevisionOrderNumberKey = bsonutil.MustHaveTag(Version{}, "RevisionOrderNumber")
 	VersionRequesterKey           = bsonutil.MustHaveTag(Version{}, "Requester")
+	VersionProjectKey             = bsonutil.MustHaveTag(Version{}, "ParserProject")
 	VersionConfigKey              = bsonutil.MustHaveTag(Version{}, "Config")
 	VersionConfigNumberKey        = bsonutil.MustHaveTag(Version{}, "ConfigUpdateNumber")
 	VersionIgnoredKey             = bsonutil.MustHaveTag(Version{}, "Ignored")

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -150,8 +150,7 @@ buildvariants:
 	assert.NoError(settings.Set())
 	dc := DBCreateHostConnector{}
 
-	err := dc.CreateHostsFromTask(&t1, user.DBUser{Id: "me"}, "")
-	assert.NoError(err)
+	assert.NoError(dc.CreateHostsFromTask(&t1, user.DBUser{Id: "me"}, ""))
 
 	createdHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)


### PR DESCRIPTION
The trick here is Params of PluginCommandConf, of type map[string]interface{}. This solution unmarshals the PluginCommandConf yaml into an intermediate structure to transform Params into a yaml string.