### PR TITLE
EVG-6359: fix CLI commit queue merge for modules

### DIFF
--- a/command/git_push.go
+++ b/command/git_push.go
@@ -59,7 +59,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 	checkoutCommand := fmt.Sprintf("git checkout %s", conf.ProjectRef.Branch)
 	logger.Execution().Debugf("git checkout command %s", checkoutCommand)
 	jpm := c.JasperManager()
-	cmd := jpm.CreateCommand(ctx).Directory(c.Directory).Append(checkoutCommand).
+	cmd := jpm.CreateCommand(ctx).Directory(filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory))).Append(checkoutCommand).
 		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Task().GetSender())
 	if err = cmd.Run(ctx); err != nil {
 		return errors.Wrapf(err, "can't checkout '%s' branch", conf.ProjectRef.Branch)
@@ -106,7 +106,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 
 		checkoutCommand = fmt.Sprintf("git checkout %s", module.Branch)
 		logger.Execution().Debugf("git checkout command: %s", checkoutCommand)
-		cmd := jpm.CreateCommand(ctx).Directory(moduleBase).Append(checkoutCommand).
+		cmd := jpm.CreateCommand(ctx).Directory(filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory, moduleBase))).Append(checkoutCommand).
 			SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Task().GetSender())
 		if err = cmd.Run(ctx); err != nil {
 			return errors.Wrapf(err, "can't checkout '%s' branch", module.Branch)
@@ -122,7 +122,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 
 	// Push main patch
 	logger.Execution().Info("Pushing patch")
-	params.directory = c.Directory
+	params.directory = filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory))
 	params.branch = conf.ProjectRef.Branch
 	if err = c.pushPatch(ctx, logger, params); err != nil {
 		return errors.Wrap(err, "can't push patch")

--- a/command/git_push.go
+++ b/command/git_push.go
@@ -67,7 +67,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 
 	// fail the merge if HEAD has moved
 	logger.Execution().Info("Checking HEAD")
-	headSHA, err := c.revParse(ctx, logger, "HEAD")
+	headSHA, err := c.revParse(ctx, conf, logger, "HEAD")
 	if err != nil {
 		return errors.Wrap(err, "can't get SHA for HEAD")
 	}
@@ -113,7 +113,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		}
 
 		logger.Execution().Infof("Pushing patch for module %s", module.Name)
-		params.directory = moduleBase
+		params.directory = filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory, moduleBase))
 		params.branch = module.Branch
 		if err = c.pushPatch(ctx, logger, params); err != nil {
 			return errors.Wrap(err, "can't push module patch")
@@ -167,7 +167,7 @@ func (c *gitPush) pushPatch(ctx context.Context, logger client.LoggerProducer, p
 	return errors.Wrap(cmd.Run(ctx), "can't run push commands")
 }
 
-func (c *gitPush) revParse(ctx context.Context, logger client.LoggerProducer, ref string) (string, error) {
+func (c *gitPush) revParse(ctx context.Context, conf *model.TaskConfig, logger client.LoggerProducer, ref string) (string, error) {
 	stdout := noopWriteCloser{
 		&bytes.Buffer{},
 	}
@@ -175,7 +175,7 @@ func (c *gitPush) revParse(ctx context.Context, logger client.LoggerProducer, re
 
 	revParseCommand := fmt.Sprintf("git rev-parse %s", ref)
 	logger.Execution().Debugf("git rev-parse command: %s", revParseCommand)
-	cmd := jpm.CreateCommand(ctx).Directory(c.Directory).Append(revParseCommand).SetOutputWriter(stdout).
+	cmd := jpm.CreateCommand(ctx).Directory(filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory))).Append(revParseCommand).SetOutputWriter(stdout).
 		SetErrorSender(level.Error, logger.Task().GetSender())
 
 	if err := cmd.Run(ctx); err != nil {

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -504,7 +504,9 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error
 
 	modules := make([]string, 0, len(patchDoc.Patches))
 	for _, module := range patchDoc.Patches {
-		modules = append(modules, module.ModuleName)
+		if module.ModuleName != "" {
+			modules = append(modules, module.ModuleName)
+		}
 	}
 
 	mergeBuildVariant := model.BuildVariant{
@@ -541,13 +543,13 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error
 				Command: "git.get_project",
 				Type:    evergreen.CommandTypeSetup,
 				Params: map[string]interface{}{
-					"directory": "${workdir}/src",
+					"directory": "src",
 				},
 			},
 			{
 				Command: "git.push",
 				Params: map[string]interface{}{
-					"directory":       "${workdir}/src",
+					"directory":       "src",
 					"committer_name":  settings.CommitQueue.CommitterName,
 					"committer_email": settings.CommitQueue.CommitterEmail,
 				},

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -502,6 +502,11 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error
 		return errors.Wrap(err, "error retrieving Evergreen config")
 	}
 
+	modules := make([]string, 0, len(patchDoc.Patches))
+	for _, module := range patchDoc.Patches {
+		modules = append(modules, module.ModuleName)
+	}
+
 	mergeBuildVariant := model.BuildVariant{
 		Name:        evergreen.MergeTaskVariant,
 		DisplayName: "Commit Queue Merge",
@@ -512,6 +517,7 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error
 				CommitQueueMerge: true,
 			},
 		},
+		Modules: modules,
 	}
 
 	// Merge task depends on all commit queue tasks matching the alias


### PR DESCRIPTION
Starting directory was not set correctly for merge commands.
Additionally, modules were not included in the merge buildVariant.