### PR TITLE
EVG-6240 add support for subscriptions, refactor revision

### DIFF
--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -111,7 +111,7 @@ func (s *Subscriber) Validate() error {
 		catcher.Add(errors.Errorf("%s is not a valid subscriber type", s.Type))
 	}
 	if s.Target == nil {
-		catcher.Add(errors.New("type is required for subscriber"))
+		catcher.Add(errors.New("target is required for subscriber"))
 	}
 	return catcher.Resolve()
 }

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -50,7 +50,22 @@ const (
 	ImplicitSubscriptionBuildBreak                    = "build-break"
 	ImplicitSubscriptionSpawnhostExpiration           = "spawnhost-expiration"
 	ImplicitSubscriptionSpawnHostOutcome              = "spawnhost-outcome"
-	ImplicitSubscriptionCommitQueue                   = "commit-queue"
+
+	ImplicitSubscriptionCommitQueue = "commit-queue"
+	ObjectTask                      = "task"
+	ObjectVersion                   = "version"
+	ObjectBuild                     = "build"
+	ObjectHost                      = "host"
+	ObjectPatch                     = "patch"
+
+	TriggerOutcome                = "outcome"
+	TriggerFailure                = "failure"
+	TriggerSuccess                = "success"
+	TriggerRegression             = "regression"
+	TriggerExceedsDuration        = "exceeds-duration"
+	TriggerRuntimeChangeByPercent = "runtime-change"
+	TriggerExpiration             = "expiration"
+	TriggerPatchStarted           = "started"
 )
 
 type Subscription struct {
@@ -105,6 +120,19 @@ type Selector struct {
 	Type string `bson:"type"`
 	Data string `bson:"data"`
 }
+
+const (
+	SelectorObject       = "object"
+	SelectorID           = "id"
+	SelectorProject      = "project"
+	SelectorOwner        = "owner"
+	SelectorRequester    = "requester"
+	SelectorStatus       = "status"
+	SelectorDisplayName  = "display-name"
+	SelectorBuildVariant = "build-variant"
+	SelectorInVersion    = "in-version"
+	SelectorInBuild      = "in-build"
+)
 
 // FindSubscriptions finds all subscriptions of matching resourceType, and whose
 // selectors match the selectors slice
@@ -248,9 +276,9 @@ func RemoveSubscription(id string) error {
 
 func IsSubscriptionAllowed(sub Subscription) (bool, string) {
 	for _, selector := range sub.Selectors {
-		if selector.Type == "object" {
-			if selector.Data == "build" || selector.Data == "version" || selector.Data == "task" {
-				if sub.Subscriber.Type == "jira-issue" || sub.Subscriber.Type == "evergreen-webhook" {
+		if selector.Type == SelectorObject {
+			if selector.Data == ObjectBuild || selector.Data == ObjectVersion || selector.Data == ObjectTask {
+				if sub.Subscriber.Type == JIRAIssueSubscriberType || sub.Subscriber.Type == EvergreenWebhookSubscriberType {
 					return false, fmt.Sprintf("Cannot notify by %s for %s", sub.Subscriber.Type, selector.Data)
 				}
 			}
@@ -407,10 +435,6 @@ func IsValidOwnerType(in string) bool {
 	}
 }
 
-const (
-	triggerOutcome = "outcome"
-)
-
 func CreateOrUpdateImplicitSubscription(resourceType string, id string,
 	subscriber Subscriber, user string) (*Subscription, error) {
 	var err error
@@ -466,7 +490,7 @@ func NewSubscriptionByID(resourceType, trigger, id string, sub Subscriber) Subsc
 		Trigger:      trigger,
 		Selectors: []Selector{
 			{
-				Type: "id",
+				Type: SelectorID,
 				Data: id,
 			},
 		},
@@ -475,29 +499,29 @@ func NewSubscriptionByID(resourceType, trigger, id string, sub Subscriber) Subsc
 }
 
 func NewPatchOutcomeSubscription(id string, sub Subscriber) Subscription {
-	return NewSubscriptionByID(ResourceTypePatch, triggerOutcome, id, sub)
+	return NewSubscriptionByID(ResourceTypePatch, TriggerOutcome, id, sub)
 }
 
 func NewPatchOutcomeSubscriptionByOwner(owner string, sub Subscriber) Subscription {
-	return NewSubscriptionByOwner(owner, sub, ResourceTypePatch, triggerOutcome)
+	return NewSubscriptionByOwner(owner, sub, ResourceTypePatch, TriggerOutcome)
 }
 
 func NewBuildBreakSubscriptionByOwner(owner string, sub Subscriber) Subscription {
 	return Subscription{
 		ID:           mgobson.NewObjectId().Hex(),
 		ResourceType: ResourceTypeTask,
-		Trigger:      "build-break",
+		Trigger:      ImplicitSubscriptionBuildBreak,
 		Selectors: []Selector{
 			{
-				Type: "owner",
+				Type: SelectorOwner,
 				Data: owner,
 			},
 			{
-				Type: "object",
-				Data: "task",
+				Type: SelectorObject,
+				Data: ObjectTask,
 			},
 			{
-				Type: "requester",
+				Type: SelectorRequester,
 				Data: evergreen.RepotrackerVersionRequester,
 			},
 		},
@@ -506,7 +530,7 @@ func NewBuildBreakSubscriptionByOwner(owner string, sub Subscriber) Subscription
 }
 
 func NewSpawnhostExpirationSubscription(owner string, sub Subscriber) Subscription {
-	return NewSubscriptionByOwner(owner, sub, ResourceTypeHost, "expiration")
+	return NewSubscriptionByOwner(owner, sub, ResourceTypeHost, TriggerExpiration)
 }
 
 func NewSubscriptionByOwner(owner string, sub Subscriber, resourceType, trigger string) Subscription {
@@ -516,7 +540,7 @@ func NewSubscriptionByOwner(owner string, sub Subscriber, resourceType, trigger 
 		Trigger:      trigger,
 		Selectors: []Selector{
 			{
-				Type: "owner",
+				Type: SelectorOwner,
 				Data: owner,
 			},
 		},
@@ -527,10 +551,10 @@ func NewSubscriptionByOwner(owner string, sub Subscriber, resourceType, trigger 
 func NewBuildOutcomeSubscriptionByVersion(versionID string, sub Subscriber) Subscription {
 	return Subscription{
 		ResourceType: ResourceTypeBuild,
-		Trigger:      triggerOutcome,
+		Trigger:      TriggerOutcome,
 		Selectors: []Selector{
 			{
-				Type: "in-version",
+				Type: SelectorInVersion,
 				Data: versionID,
 			},
 		},
@@ -541,14 +565,14 @@ func NewBuildOutcomeSubscriptionByVersion(versionID string, sub Subscriber) Subs
 func NewSpawnHostOutcomeByOwner(owner string, sub Subscriber) Subscription {
 	return Subscription{
 		ResourceType: ResourceTypeHost,
-		Trigger:      triggerOutcome,
+		Trigger:      TriggerOutcome,
 		Selectors: []Selector{
 			{
-				Type: "object",
-				Data: "host",
+				Type: SelectorObject,
+				Data: ObjectHost,
 			},
 			{
-				Type: "owner",
+				Type: SelectorOwner,
 				Data: owner,
 			},
 		},
@@ -557,5 +581,5 @@ func NewSpawnHostOutcomeByOwner(owner string, sub Subscriber) Subscription {
 }
 
 func NewCommitQueueSubscriptionByOwner(owner string, sub Subscriber) Subscription {
-	return NewSubscriptionByOwner(owner, sub, ResourceTypeCommitQueue, triggerOutcome)
+	return NewSubscriptionByOwner(owner, sub, ResourceTypeCommitQueue, TriggerOutcome)
 }

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -246,10 +246,10 @@ type Connector interface {
 	GeneratePoll(context.Context, string, amboy.QueueGroup) (bool, []string, error)
 
 	// SaveSubscriptions saves a set of notification subscriptions
-	SaveSubscriptions([]event.Subscription) error
+	SaveSubscriptions(string, []restModel.APISubscription) error
 	// GetSubscriptions returns the subscriptions that belong to a user
 	GetSubscriptions(string, event.OwnerType) ([]restModel.APISubscription, error)
-	DeleteSubscription(id string) error
+	DeleteSubscriptions(string, []string) error
 	// CopyProjectSubscriptions copies subscriptions from the first project for the second project.
 	CopyProjectSubscriptions(string, string) error
 

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
+	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	mgobson "gopkg.in/mgo.v2/bson"
@@ -72,6 +73,152 @@ func TestGetSubscriptions(t *testing.T) {
 	apiSubs, err = c.GetSubscriptions("", event.OwnerTypePerson)
 	assert.EqualError(err, "400 (Bad Request): no subscription owner provided")
 	assert.Len(apiSubs, 0)
+}
+
+func TestSaveProjectSubscriptions(t *testing.T) {
+	c := &DBSubscriptionConnector{}
+	for name, test := range map[string]func(t *testing.T, subs []restModel.APISubscription){
+		"InvalidSubscription": func(t *testing.T, subs []restModel.APISubscription) {
+			subs[0].RegexSelectors[0].Data = restModel.ToAPIString("")
+			assert.Error(t, c.SaveSubscriptions("me", []restModel.APISubscription{subs[0]}))
+		},
+		"ValidSubscription": func(t *testing.T, subs []restModel.APISubscription) {
+			assert.NoError(t, c.SaveSubscriptions("me", []restModel.APISubscription{subs[0]}))
+		},
+		"ModifyExistingSubscription": func(t *testing.T, subs []restModel.APISubscription) {
+			newData := restModel.ToAPIString("5678")
+			subs[1].Selectors[0].Data = newData
+			assert.NoError(t, c.SaveSubscriptions("my-project", []restModel.APISubscription{subs[1]}))
+
+			dbSubs, err := c.GetSubscriptions("my-project", event.OwnerTypeProject)
+			assert.NoError(t, err)
+			require.Len(t, dbSubs, 1)
+			require.Equal(t, dbSubs[0].Selectors[0].Data, newData)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.NoError(t, db.ClearCollections(event.SubscriptionsCollection))
+			subs := []event.Subscription{
+				{
+					ID:           mgobson.NewObjectId().Hex(),
+					Owner:        "my-project",
+					OwnerType:    event.OwnerTypeProject,
+					ResourceType: "PATCH",
+					Trigger:      "outcome",
+					Selectors: []event.Selector{
+						{
+							Type: "id",
+							Data: "1234",
+						},
+					},
+					Subscriber: event.Subscriber{
+						Type:   event.EmailSubscriberType,
+						Target: "a@domain.invalid",
+					},
+				},
+				{
+					ID:           mgobson.NewObjectId().Hex(),
+					Owner:        "not-my-project",
+					OwnerType:    event.OwnerTypeProject,
+					ResourceType: "PATCH",
+					Trigger:      "outcome",
+					Selectors: []event.Selector{
+						{
+							Type: "id",
+							Data: "1234",
+						},
+					},
+					Subscriber: event.Subscriber{
+						Type:   event.EmailSubscriberType,
+						Target: "a@domain.invalid",
+					},
+				},
+			}
+			newSubscription := restModel.APISubscription{
+				ResourceType: restModel.ToAPIString(event.ResourceTypeTask),
+				Trigger:      restModel.ToAPIString("outcome"),
+				Owner:        restModel.ToAPIString("me"),
+				OwnerType:    restModel.ToAPIString(string(event.OwnerTypePerson)),
+				RegexSelectors: []restModel.APISelector{
+					{
+						Type: restModel.ToAPIString("object"),
+						Data: restModel.ToAPIString("object_data"),
+					},
+				},
+				Subscriber: restModel.APISubscriber{
+					Type:   restModel.ToAPIString(event.EmailSubscriberType),
+					Target: "a@domain.invalid",
+				},
+			}
+			for _, sub := range subs {
+				assert.NoError(t, sub.Upsert())
+			}
+			existingSub := restModel.APISubscription{}
+			assert.NoError(t, existingSub.BuildFromService(subs[0]))
+			test(t, []restModel.APISubscription{newSubscription, existingSub})
+		})
+	}
+}
+
+func TestDeleteProjectSubscriptions(t *testing.T) {
+	c := &DBSubscriptionConnector{}
+	for name, test := range map[string]func(t *testing.T, ids []string){
+		"InvalidOwner": func(t *testing.T, ids []string) {
+			assert.Error(t, c.DeleteSubscriptions("my-project", ids))
+		},
+		"ValidOwner": func(t *testing.T, ids []string) {
+			assert.NoError(t, c.DeleteSubscriptions("my-project", []string{ids[0]}))
+			subs, err := event.FindSubscriptionsByOwner("my-project", event.OwnerTypeProject)
+			assert.NoError(t, err)
+			assert.Len(t, subs, 0)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.NoError(t, db.ClearCollections(event.SubscriptionsCollection))
+			subs := []event.Subscription{
+				{
+					ID:           mgobson.NewObjectId().Hex(),
+					Owner:        "my-project",
+					OwnerType:    event.OwnerTypeProject,
+					ResourceType: "PATCH",
+					Trigger:      "outcome",
+					Selectors: []event.Selector{
+						{
+							Type: "id",
+							Data: "1234",
+						},
+					},
+					Subscriber: event.Subscriber{
+						Type:   event.EmailSubscriberType,
+						Target: "a@domain.invalid",
+					},
+				},
+				{
+					ID:           mgobson.NewObjectId().Hex(),
+					Owner:        "not-my-project",
+					OwnerType:    event.OwnerTypeProject,
+					ResourceType: "PATCH",
+					Trigger:      "outcome",
+					Selectors: []event.Selector{
+						{
+							Type: "id",
+							Data: "1234",
+						},
+					},
+					Subscriber: event.Subscriber{
+						Type:   event.EmailSubscriberType,
+						Target: "a@domain.invalid",
+					},
+				},
+			}
+			toDelete := []string{}
+			for _, sub := range subs {
+				assert.NoError(t, sub.Upsert())
+				toDelete = append(toDelete, sub.ID)
+			}
+			test(t, toDelete)
+		})
+	}
 }
 
 func TestCopyProjectSubscriptions(t *testing.T) {

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -133,9 +133,12 @@ type APIProjectRef struct {
 	Admins               []APIString          `json:"admins"`
 	NotifyOnBuildFailure bool                 `json:"notify_on_failure"`
 
-	Triggers  []APITriggerDefinition `json:"triggers"`
-	Aliases   []APIProjectAlias      `json:"aliases"`
-	Variables APIProjectVars         `json:"variables"`
+	Revision            APIString              `json:"revision"`
+	Triggers            []APITriggerDefinition `json:"triggers"`
+	Aliases             []APIProjectAlias      `json:"aliases"`
+	Variables           APIProjectVars         `json:"variables"`
+	Subscriptions       []APISubscription      `json:"subscriptions"`
+	DeleteSubscriptions []APIString            `json:"delete_subscriptions"`
 }
 
 // ToService returns a service layer ProjectRef using the data from APIProjectRef

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -43,7 +43,6 @@ func (s *ProjectPatchByIDSuite) TestParse() {
 	err := s.rm.Parse(ctx, req)
 	s.NoError(err)
 	s.Equal(json, s.rm.(*projectIDPatchHandler).body)
-	s.Equal("my-revision", s.rm.(*projectIDPatchHandler).revision)
 }
 
 func (s *ProjectPatchByIDSuite) TestRunInValidIdentifierChange() {
@@ -75,10 +74,9 @@ func (s *ProjectPatchByIDSuite) TestRunInvalidNonExistingId() {
 
 func (s *ProjectPatchByIDSuite) TestRunValid() {
 	ctx := context.Background()
-	json := []byte(`{"enabled": true, "variables": {"vars_to_delete": ["apple"]} }`)
+	json := []byte(`{"enabled": true, "revision": "my_revision", "variables": {"vars_to_delete": ["apple"]} }`)
 	h := s.rm.(*projectIDPatchHandler)
 	h.projectID = "dimoxinil"
-	h.revision = "my-revision"
 	h.body = json
 	resp := s.rm.Run(ctx)
 	s.NotNil(resp)

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -111,7 +111,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/status/recent_tasks").Version(2).Get().RouteHandler(makeRecentTaskStatusHandler(sc))
 	app.AddRoute("/subscriptions").Version(2).Delete().Wrap(checkUser).RouteHandler(makeDeleteSubscription(sc))
 	app.AddRoute("/subscriptions").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchSubscription(sc))
-	app.AddRoute("/subscriptions").Version(2).Post().Wrap(checkUser).RouteHandler(makeSetSubscrition(sc))
+	app.AddRoute("/subscriptions").Version(2).Post().Wrap(checkUser).RouteHandler(makeSetSubscription(sc))
 	app.AddRoute("/tasks/{task_id}").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetTaskRoute(sc))
 	app.AddRoute("/tasks/{task_id}").Version(2).Patch().Wrap(checkUser, addProject).RouteHandler(makeModifyTaskRoute(sc))
 	app.AddRoute("/tasks/{task_id}/abort").Version(2).Post().Wrap(checkUser).RouteHandler(makeTaskAbortHandler(sc))

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -16,10 +16,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	objectBuild = "build"
-)
-
 func init() {
 	registry.registerEventHandler(event.ResourceTypeBuild, event.BuildStateChange, makeBuildTriggers)
 }
@@ -102,11 +98,11 @@ type buildTriggers struct {
 func makeBuildTriggers() eventHandler {
 	t := &buildTriggers{}
 	t.base.triggers = map[string]trigger{
-		triggerOutcome:                t.buildOutcome,
-		triggerFailure:                t.buildFailure,
-		triggerSuccess:                t.buildSuccess,
-		triggerExceedsDuration:        t.buildExceedsDuration,
-		triggerRuntimeChangeByPercent: t.buildRuntimeChange,
+		event.TriggerOutcome:                t.buildOutcome,
+		event.TriggerFailure:                t.buildFailure,
+		event.TriggerSuccess:                t.buildSuccess,
+		event.TriggerExceedsDuration:        t.buildExceedsDuration,
+		event.TriggerRuntimeChangeByPercent: t.buildRuntimeChange,
 	}
 	return t
 }
@@ -138,37 +134,37 @@ func (t *buildTriggers) Fetch(e *event.EventLogEntry) error {
 func (t *buildTriggers) Selectors() []event.Selector {
 	selectors := []event.Selector{
 		{
-			Type: selectorID,
+			Type: event.SelectorID,
 			Data: t.build.Id,
 		},
 		{
-			Type: selectorObject,
-			Data: objectBuild,
+			Type: event.SelectorObject,
+			Data: event.ObjectBuild,
 		},
 		{
-			Type: selectorProject,
+			Type: event.SelectorProject,
 			Data: t.build.Project,
 		},
 		{
-			Type: selectorRequester,
+			Type: event.SelectorRequester,
 			Data: t.build.Requester,
 		},
 		{
-			Type: selectorInVersion,
+			Type: event.SelectorInVersion,
 			Data: t.build.Version,
 		},
 		{
-			Type: selectorDisplayName,
+			Type: event.SelectorDisplayName,
 			Data: t.build.DisplayName,
 		},
 		{
-			Type: selectorBuildVariant,
+			Type: event.SelectorBuildVariant,
 			Data: t.build.BuildVariant,
 		},
 	}
 	if t.build.Requester == evergreen.TriggerRequester {
 		selectors = append(selectors, event.Selector{
-			Type: selectorRequester,
+			Type: event.SelectorRequester,
 			Data: evergreen.RepotrackerVersionRequester,
 		})
 	}
@@ -259,7 +255,7 @@ func (t *buildTriggers) makeData(sub *event.Subscription, pastTenseOverride stri
 		EventID:         t.event.ID,
 		SubscriptionID:  sub.ID,
 		DisplayName:     t.build.DisplayName,
-		Object:          objectBuild,
+		Object:          event.ObjectBuild,
 		Project:         t.build.Project,
 		URL:             buildLink(t.uiConfig.Url, t.build.Id),
 		PastTenseStatus: t.data.Status,

--- a/trigger/build_test.go
+++ b/trigger/build_test.go
@@ -63,13 +63,13 @@ func (s *buildSuite) SetupTest() {
 	}
 
 	s.subs = []event.Subscription{
-		event.NewSubscriptionByID(event.ResourceTypeBuild, triggerOutcome, s.event.ResourceId, apiSub),
-		event.NewSubscriptionByID(event.ResourceTypeBuild, triggerSuccess, s.event.ResourceId, apiSub),
-		event.NewSubscriptionByID(event.ResourceTypeBuild, triggerFailure, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeBuild, event.TriggerOutcome, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeBuild, event.TriggerSuccess, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeBuild, event.TriggerFailure, s.event.ResourceId, apiSub),
 		{
 			ID:           mgobson.NewObjectId().Hex(),
 			ResourceType: event.ResourceTypeBuild,
-			Trigger:      triggerExceedsDuration,
+			Trigger:      event.TriggerExceedsDuration,
 			Selectors: []event.Selector{
 				{
 					Type: "id",
@@ -88,7 +88,7 @@ func (s *buildSuite) SetupTest() {
 		{
 			ID:           mgobson.NewObjectId().Hex(),
 			ResourceType: event.ResourceTypeBuild,
-			Trigger:      triggerRuntimeChangeByPercent,
+			Trigger:      event.TriggerRuntimeChangeByPercent,
 			Selectors: []event.Selector{
 				{
 					Type: "id",

--- a/trigger/commit_queue.go
+++ b/trigger/commit_queue.go
@@ -29,7 +29,7 @@ type commitQueueTriggers struct {
 func makeCommitQueueTriggers() eventHandler {
 	t := &commitQueueTriggers{}
 	t.base.triggers = map[string]trigger{
-		triggerOutcome: t.commitQueueOutcome,
+		event.TriggerOutcome: t.commitQueueOutcome,
 	}
 	return t
 }
@@ -62,7 +62,7 @@ func (t *commitQueueTriggers) Fetch(e *event.EventLogEntry) error {
 func (t *commitQueueTriggers) Selectors() []event.Selector {
 	return []event.Selector{
 		{
-			Type: selectorOwner,
+			Type: event.SelectorOwner,
 			Data: t.patch.Author,
 		},
 	}

--- a/trigger/common.go
+++ b/trigger/common.go
@@ -6,26 +6,6 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 )
 
-const (
-	selectorID           = "id"
-	selectorObject       = "object"
-	selectorProject      = "project"
-	selectorOwner        = "owner"
-	selectorRequester    = "requester"
-	selectorStatus       = "status"
-	selectorDisplayName  = "display-name"
-	selectorBuildVariant = "build-variant"
-	selectorInVersion    = "in-version"
-	selectorInBuild      = "in-build"
-
-	triggerOutcome                = "outcome"
-	triggerFailure                = "failure"
-	triggerSuccess                = "success"
-	triggerRegression             = "regression"
-	triggerExceedsDuration        = "exceeds-duration"
-	triggerRuntimeChangeByPercent = "runtime-change"
-)
-
 func runtimeExceedsThreshold(threshold, prevDuration, thisDuration float64) (bool, float64) {
 	ratio := thisDuration / prevDuration
 	if !util.IsFiniteNumericFloat(ratio) {

--- a/trigger/host.go
+++ b/trigger/host.go
@@ -19,9 +19,6 @@ func init() {
 }
 
 const (
-	objectHost        = "host"
-	triggerExpiration = "expiration"
-
 	// notification templates
 	expiringHostTitle = `{{.Distro}} host termination reminder`
 	expiringHostBody  = `Your {{.Distro}} host with id {{.ID}} will be terminated at {{.ExpirationTime}}. Visit {{.URL}} to extend its lifetime.`
@@ -63,15 +60,15 @@ func (t *hostBase) Fetch(e *event.EventLogEntry) error {
 func (t *hostBase) Selectors() []event.Selector {
 	return []event.Selector{
 		{
-			Type: selectorID,
+			Type: event.SelectorID,
 			Data: t.host.Id,
 		},
 		{
-			Type: selectorObject,
-			Data: objectHost,
+			Type: event.SelectorObject,
+			Data: event.ObjectHost,
 		},
 		{
-			Type: selectorOwner,
+			Type: event.SelectorOwner,
 			Data: t.host.StartedBy,
 		},
 	}
@@ -87,7 +84,7 @@ type hostTemplateData struct {
 func makeHostTriggers() eventHandler {
 	t := &hostTriggers{}
 	t.hostBase.base.triggers = map[string]trigger{
-		triggerExpiration: t.hostExpiration,
+		event.TriggerExpiration: t.hostExpiration,
 	}
 
 	return t

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -23,7 +23,7 @@ type spawnHostTriggers struct {
 func makeSpawnHostTriggers() eventHandler {
 	t := &spawnHostTriggers{}
 	t.triggers = map[string]trigger{
-		triggerOutcome: t.hostSpawnOutcome,
+		event.TriggerOutcome: t.hostSpawnOutcome,
 	}
 	return t
 }

--- a/trigger/host_spawn_test.go
+++ b/trigger/host_spawn_test.go
@@ -52,7 +52,7 @@ func (s *spawnHostTriggersSuite) TestSuccessfulSpawn() {
 	s.NoError(s.t.Fetch(&s.e))
 
 	sub := event.Subscription{
-		Trigger:    triggerOutcome,
+		Trigger:    event.TriggerOutcome,
 		Subscriber: event.NewSlackSubscriber("@test.user"),
 	}
 
@@ -92,7 +92,7 @@ func (s *spawnHostTriggersSuite) TestFailedSpawn() {
 	s.NoError(s.t.Fetch(&s.e))
 
 	sub := event.Subscription{
-		Trigger:    triggerOutcome,
+		Trigger:    event.TriggerOutcome,
 		Subscriber: event.NewSlackSubscriber("@test.user"),
 	}
 

--- a/trigger/host_test.go
+++ b/trigger/host_test.go
@@ -46,7 +46,7 @@ func (s *hostSuite) SetupTest() {
 	}
 
 	s.subs = []event.Subscription{
-		event.NewSubscriptionByID(event.ResourceTypeHost, triggerExpiration, s.t.host.Id, event.Subscriber{
+		event.NewSubscriptionByID(event.ResourceTypeHost, event.TriggerExpiration, s.t.host.Id, event.Subscriber{
 			Type:   event.EmailSubscriberType,
 			Target: "foo@bar.com",
 		}),

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -13,11 +13,6 @@ import (
 	mgobson "gopkg.in/mgo.v2/bson"
 )
 
-const (
-	objectPatch         = "patch"
-	triggerPatchStarted = "started"
-)
-
 type patchTriggers struct {
 	event    *event.EventLogEntry
 	data     *event.PatchEventData
@@ -30,10 +25,10 @@ type patchTriggers struct {
 func makePatchTriggers() eventHandler {
 	t := &patchTriggers{}
 	t.base.triggers = map[string]trigger{
-		triggerOutcome:      t.patchOutcome,
-		triggerFailure:      t.patchFailure,
-		triggerSuccess:      t.patchSuccess,
-		triggerPatchStarted: t.patchStarted,
+		event.TriggerOutcome:      t.patchOutcome,
+		event.TriggerFailure:      t.patchFailure,
+		event.TriggerSuccess:      t.patchSuccess,
+		event.TriggerPatchStarted: t.patchStarted,
 	}
 	return t
 }
@@ -66,23 +61,23 @@ func (t *patchTriggers) Fetch(e *event.EventLogEntry) error {
 func (t *patchTriggers) Selectors() []event.Selector {
 	return []event.Selector{
 		{
-			Type: selectorID,
+			Type: event.SelectorID,
 			Data: t.patch.Id.Hex(),
 		},
 		{
-			Type: selectorObject,
-			Data: objectPatch,
+			Type: event.SelectorObject,
+			Data: event.ObjectPatch,
 		},
 		{
-			Type: selectorProject,
+			Type: event.SelectorProject,
 			Data: t.patch.Project,
 		},
 		{
-			Type: selectorOwner,
+			Type: event.SelectorOwner,
 			Data: t.patch.Author,
 		},
 		{
-			Type: selectorStatus,
+			Type: event.SelectorStatus,
 			Data: t.patch.Status,
 		},
 	}
@@ -132,7 +127,7 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 		SubscriptionID:    sub.ID,
 		DisplayName:       t.patch.Id.Hex(),
 		Description:       t.patch.Description,
-		Object:            objectPatch,
+		Object:            event.ObjectPatch,
 		Project:           t.patch.Project,
 		URL:               fmt.Sprintf("%s/version/%s", t.uiConfig.Url, t.patch.Version),
 		PastTenseStatus:   t.data.Status,

--- a/trigger/patch_test.go
+++ b/trigger/patch_test.go
@@ -75,9 +75,9 @@ func (s *patchSuite) SetupTest() {
 	}
 
 	s.subs = []event.Subscription{
-		event.NewSubscriptionByID(event.ResourceTypePatch, triggerOutcome, s.event.ResourceId, apiSub),
-		event.NewSubscriptionByID(event.ResourceTypePatch, triggerSuccess, s.event.ResourceId, apiSub),
-		event.NewSubscriptionByID(event.ResourceTypePatch, triggerFailure, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypePatch, event.TriggerOutcome, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypePatch, event.TriggerSuccess, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypePatch, event.TriggerFailure, s.event.ResourceId, apiSub),
 	}
 
 	for i := range s.subs {

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -372,7 +372,7 @@ func makeCommonPayload(sub *event.Subscription, selectors []event.Selector,
 		Type: "trigger",
 		Data: sub.Trigger,
 	}, event.Selector{
-		Type: selectorStatus,
+		Type: event.SelectorStatus,
 		Data: data.PastTenseStatus,
 	})
 

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -29,7 +29,6 @@ func init() {
 }
 
 const (
-	objectTask                               = "task"
 	triggerTaskFirstFailureInBuild           = "first-failure-in-build"
 	triggerTaskFirstFailureInVersion         = "first-failure-in-version"
 	triggerTaskFirstFailureInVersionWithName = "first-failure-in-version-with-name"
@@ -43,15 +42,15 @@ func makeTaskTriggers() eventHandler {
 		oldTestResults: map[string]*task.TestResult{},
 	}
 	t.base.triggers = map[string]trigger{
-		triggerOutcome:                           t.taskOutcome,
-		triggerFailure:                           t.taskFailure,
-		triggerSuccess:                           t.taskSuccess,
+		event.TriggerOutcome:                     t.taskOutcome,
+		event.TriggerFailure:                     t.taskFailure,
+		event.TriggerSuccess:                     t.taskSuccess,
+		event.TriggerExceedsDuration:             t.taskExceedsDuration,
+		event.TriggerRuntimeChangeByPercent:      t.taskRuntimeChange,
+		event.TriggerRegression:                  t.taskRegression,
 		triggerTaskFirstFailureInBuild:           t.taskFirstFailureInBuild,
 		triggerTaskFirstFailureInVersion:         t.taskFirstFailureInVersion,
 		triggerTaskFirstFailureInVersionWithName: t.taskFirstFailureInVersionWithName,
-		triggerExceedsDuration:                   t.taskExceedsDuration,
-		triggerRuntimeChangeByPercent:            t.taskRuntimeChange,
-		triggerRegression:                        t.taskRegression,
 		triggerTaskRegressionByTest:              t.taskRegressionByTest,
 		triggerBuildBreak:                        t.buildBreak,
 	}
@@ -191,43 +190,43 @@ func (t *taskTriggers) Fetch(e *event.EventLogEntry) error {
 func (t *taskTriggers) Selectors() []event.Selector {
 	selectors := []event.Selector{
 		{
-			Type: selectorID,
+			Type: event.SelectorID,
 			Data: t.task.Id,
 		},
 		{
-			Type: selectorObject,
-			Data: objectTask,
+			Type: event.SelectorObject,
+			Data: event.ObjectTask,
 		},
 		{
-			Type: selectorProject,
+			Type: event.SelectorProject,
 			Data: t.task.Project,
 		},
 		{
-			Type: selectorInVersion,
+			Type: event.SelectorInVersion,
 			Data: t.task.Version,
 		},
 		{
-			Type: selectorInBuild,
+			Type: event.SelectorInBuild,
 			Data: t.task.BuildId,
 		},
 		{
-			Type: selectorDisplayName,
+			Type: event.SelectorDisplayName,
 			Data: t.task.DisplayName,
 		},
 		{
-			Type: selectorRequester,
+			Type: event.SelectorRequester,
 			Data: t.task.Requester,
 		},
 	}
 	if t.task.Requester == evergreen.TriggerRequester {
 		selectors = append(selectors, event.Selector{
-			Type: selectorRequester,
+			Type: event.SelectorRequester,
 			Data: evergreen.RepotrackerVersionRequester,
 		})
 	}
 	if t.version != nil && t.version.AuthorID != "" {
 		selectors = append(selectors, event.Selector{
-			Type: selectorOwner,
+			Type: event.SelectorOwner,
 			Data: t.version.AuthorID,
 		})
 	}

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -199,13 +199,13 @@ func (s *taskSuite) SetupTest() {
 	}
 
 	s.subs = []event.Subscription{
-		event.NewSubscriptionByID(event.ResourceTypeTask, triggerOutcome, s.event.ResourceId, apiSub),
-		event.NewSubscriptionByID(event.ResourceTypeTask, triggerSuccess, s.event.ResourceId, apiSub),
-		event.NewSubscriptionByID(event.ResourceTypeTask, triggerFailure, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeTask, event.TriggerOutcome, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeTask, event.TriggerSuccess, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeTask, event.TriggerFailure, s.event.ResourceId, apiSub),
 		{
 			ID:           mgobson.NewObjectId().Hex(),
 			ResourceType: event.ResourceTypeTask,
-			Trigger:      triggerExceedsDuration,
+			Trigger:      event.TriggerExceedsDuration,
 			Selectors: []event.Selector{
 				{
 					Type: "id",
@@ -224,7 +224,7 @@ func (s *taskSuite) SetupTest() {
 		{
 			ID:           mgobson.NewObjectId().Hex(),
 			ResourceType: event.ResourceTypeTask,
-			Trigger:      triggerRuntimeChangeByPercent,
+			Trigger:      event.TriggerRuntimeChangeByPercent,
 			Selectors: []event.Selector{
 				{
 					Type: "id",
@@ -243,7 +243,7 @@ func (s *taskSuite) SetupTest() {
 		{
 			ID:           mgobson.NewObjectId().Hex(),
 			ResourceType: event.ResourceTypeTask,
-			Trigger:      triggerRuntimeChangeByPercent,
+			Trigger:      event.TriggerRuntimeChangeByPercent,
 			Selectors: []event.Selector{
 				{
 					Type: "project",
@@ -260,7 +260,7 @@ func (s *taskSuite) SetupTest() {
 			},
 			RegexSelectors: []event.Selector{
 				{
-					Type: selectorDisplayName,
+					Type: event.SelectorDisplayName,
 					Data: "test-display-name",
 				},
 			},
@@ -297,7 +297,7 @@ func (s *taskSuite) TestTriggerEvent() {
 	sub := &event.Subscription{
 		ID:           mgobson.NewObjectId().Hex(),
 		ResourceType: event.ResourceTypeTask,
-		Trigger:      triggerOutcome,
+		Trigger:      event.TriggerOutcome,
 		Selectors: []event.Selector{
 			{
 				Type: "id",
@@ -882,7 +882,7 @@ func (s *taskSuite) TestRegressionByTestWithRegex() {
 		Trigger:      triggerTaskRegressionByTest,
 		Selectors: []event.Selector{
 			{
-				Type: selectorProject,
+				Type: event.SelectorProject,
 				Data: "myproj",
 			},
 		},

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -16,10 +16,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	objectVersion = "version"
-)
-
 func init() {
 	registry.registerEventHandler(event.ResourceTypeVersion, event.VersionStateChange, makeVersionTriggers)
 }
@@ -36,12 +32,12 @@ type versionTriggers struct {
 func makeVersionTriggers() eventHandler {
 	t := &versionTriggers{}
 	t.base.triggers = map[string]trigger{
-		triggerOutcome:                t.versionOutcome,
-		triggerFailure:                t.versionFailure,
-		triggerSuccess:                t.versionSuccess,
-		triggerRegression:             t.versionRegression,
-		triggerExceedsDuration:        t.versionExceedsDuration,
-		triggerRuntimeChangeByPercent: t.versionRuntimeChange,
+		event.TriggerOutcome:                t.versionOutcome,
+		event.TriggerFailure:                t.versionFailure,
+		event.TriggerSuccess:                t.versionSuccess,
+		event.TriggerRegression:             t.versionRegression,
+		event.TriggerExceedsDuration:        t.versionExceedsDuration,
+		event.TriggerRuntimeChangeByPercent: t.versionRuntimeChange,
 	}
 	return t
 }
@@ -73,30 +69,30 @@ func (t *versionTriggers) Fetch(e *event.EventLogEntry) error {
 func (t *versionTriggers) Selectors() []event.Selector {
 	selectors := []event.Selector{
 		{
-			Type: selectorID,
+			Type: event.SelectorID,
 			Data: t.version.Id,
 		},
 		{
-			Type: selectorProject,
+			Type: event.SelectorProject,
 			Data: t.version.Identifier,
 		},
 		{
-			Type: selectorObject,
-			Data: objectVersion,
+			Type: event.SelectorObject,
+			Data: event.ObjectVersion,
 		},
 		{
-			Type: selectorRequester,
+			Type: event.SelectorRequester,
 			Data: t.version.Requester,
 		},
 	}
 	if t.version.Requester == evergreen.TriggerRequester {
 		selectors = append(selectors, event.Selector{
-			Type: selectorRequester,
+			Type: event.SelectorRequester,
 			Data: evergreen.RepotrackerVersionRequester,
 		})
 	}
 	if t.version.AuthorID != "" {
-		selectors = append(selectors, event.Selector{Type: selectorOwner, Data: t.version.AuthorID})
+		selectors = append(selectors, event.Selector{Type: event.SelectorOwner, Data: t.version.AuthorID})
 	}
 	return selectors
 }
@@ -112,7 +108,7 @@ func (t *versionTriggers) makeData(sub *event.Subscription, pastTenseOverride st
 		EventID:         t.event.ID,
 		SubscriptionID:  sub.ID,
 		DisplayName:     t.version.Id,
-		Object:          objectVersion,
+		Object:          event.ObjectVersion,
 		Project:         t.version.Identifier,
 		URL:             versionLink(t.uiConfig.Url, t.version.Id),
 		PastTenseStatus: t.data.Status,

--- a/trigger/version_test.go
+++ b/trigger/version_test.go
@@ -66,14 +66,14 @@ func (s *VersionSuite) SetupTest() {
 	}
 
 	s.subs = []event.Subscription{
-		event.NewSubscriptionByID(event.ResourceTypeVersion, triggerOutcome, s.event.ResourceId, apiSub),
-		event.NewSubscriptionByID(event.ResourceTypeVersion, triggerSuccess, s.event.ResourceId, apiSub),
-		event.NewSubscriptionByID(event.ResourceTypeVersion, triggerFailure, s.event.ResourceId, apiSub),
-		event.NewSubscriptionByID(event.ResourceTypeVersion, triggerRegression, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeVersion, event.TriggerOutcome, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeVersion, event.TriggerSuccess, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeVersion, event.TriggerFailure, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeVersion, event.TriggerRegression, s.event.ResourceId, apiSub),
 		{
 			ID:           mgobson.NewObjectId().Hex(),
 			ResourceType: event.ResourceTypeVersion,
-			Trigger:      triggerExceedsDuration,
+			Trigger:      event.TriggerExceedsDuration,
 			Selectors: []event.Selector{
 				{
 					Type: "id",
@@ -92,7 +92,7 @@ func (s *VersionSuite) SetupTest() {
 		{
 			ID:           mgobson.NewObjectId().Hex(),
 			ResourceType: event.ResourceTypeVersion,
-			Trigger:      triggerRuntimeChangeByPercent,
+			Trigger:      event.TriggerRuntimeChangeByPercent,
 			Selectors: []event.Selector{
 				{
 					Type: "id",


### PR DESCRIPTION
We already had some functionality for subscriptions, but to avoid lots of repeated code there's some refactoring. Also moved revision from a query parameter to a field in the APIProjectRef.