### PR TITLE
EVG-6288: Spawn spot hosts with AWS Fleet API

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -285,7 +285,11 @@ func (m *ec2Manager) spawnSpotHost(ctx context.Context, h *host.Host, ec2Setting
 		if templateID != nil {
 			// Delete launch template
 			_, err := m.client.DeleteLaunchTemplate(ctx, &ec2.DeleteLaunchTemplateInput{LaunchTemplateId: templateID})
-			grip.ErrorWhen(err != nil, errors.Wrap(err, "can't delete launch template"))
+			grip.Error(message.WrapError(err, message.Fields{
+				"message":  "can't delete launch template",
+				"host":     h.Id,
+				"template": *templateID,
+			}))
 		}
 	}()
 
@@ -355,9 +359,9 @@ func (m *ec2Manager) spawnSpotHost(ctx context.Context, h *host.Host, ec2Setting
 		},
 		TargetCapacitySpecification: &ec2.TargetCapacitySpecificationRequest{
 			TotalTargetCapacity:       aws.Int64(1),
-			DefaultTargetCapacityType: aws.String("spot"),
+			DefaultTargetCapacityType: aws.String(ec2.DefaultTargetCapacityTypeSpot),
 		},
-		Type: aws.String("instant"),
+		Type: aws.String(ec2.FleetTypeInstant),
 	}
 	createFleetResponse, err := m.client.CreateFleet(ctx, createFleetInput)
 	if err != nil {

--- a/cloud/ec2_cost_test.go
+++ b/cloud/ec2_cost_test.go
@@ -387,15 +387,13 @@ func (s *CostIntegrationSuite) TestGetProviderAuto() {
 
 	settings.InstanceType = "m4.large"
 	settings.IsVpc = true
-	m4LargeSpot, az, err := pkgCachingPriceFetcher.getLatestLowestSpotCostForInstance(ctx, s.m.client, settings, getOsName(h))
-	s.Contains(az, "us-east")
+	m4LargeSpot, err := pkgCachingPriceFetcher.getLatestLowestSpotCostForInstance(ctx, s.m.client, settings, getOsName(h))
 	s.True(m4LargeSpot > 0)
 	s.NoError(err)
 
 	settings.InstanceType = "t2.micro"
 	settings.IsVpc = true
-	t2MicroSpot, az, err := pkgCachingPriceFetcher.getLatestLowestSpotCostForInstance(ctx, s.m.client, settings, getOsName(h))
-	s.Contains(az, "us-east")
+	t2MicroSpot, err := pkgCachingPriceFetcher.getLatestLowestSpotCostForInstance(ctx, s.m.client, settings, getOsName(h))
 	s.True(t2MicroSpot > 0)
 	s.NoError(err)
 

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -34,7 +34,6 @@ var (
 	IPKey                        = bsonutil.MustHaveTag(Host{}, "IP")
 	ProvisionedKey               = bsonutil.MustHaveTag(Host{}, "Provisioned")
 	ProvisionTimeKey             = bsonutil.MustHaveTag(Host{}, "ProvisionTime")
-	ExtIdKey                     = bsonutil.MustHaveTag(Host{}, "ExternalIdentifier")
 	RunningTaskKey               = bsonutil.MustHaveTag(Host{}, "RunningTask")
 	RunningTaskGroupKey          = bsonutil.MustHaveTag(Host{}, "RunningTaskGroup")
 	RunningTaskBuildVariantKey   = bsonutil.MustHaveTag(Host{}, "RunningTaskBuildVariant")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -33,9 +33,6 @@ type Host struct {
 	Provider string        `bson:"host_type" json:"host_type"`
 	IP       string        `bson:"ip_address" json:"ip_address"`
 
-	// secondary (external) identifier for the host
-	ExternalIdentifier string `bson:"ext_identifier" json:"ext_identifier"`
-
 	// physical location of host
 	Project string `bson:"project" json:"project"`
 	Zone    string `bson:"zone" json:"zone"`
@@ -910,13 +907,6 @@ func (h *Host) DisablePoisonedHost(logs string) error {
 	}
 
 	return errors.WithStack(h.SetDecommissioned(evergreen.User, logs))
-}
-
-func (h *Host) SetExtId() error {
-	return UpdateOne(
-		bson.M{IdKey: h.Id},
-		bson.M{"$set": bson.M{ExtIdKey: h.ExternalIdentifier}},
-	)
 }
 
 // SetRunningTeardownGroup marks the host as running teardown_group for a task group, no-oping if it's already set to the same task

--- a/rest/model/createhost.go
+++ b/rest/model/createhost.go
@@ -30,7 +30,6 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 		createHost.DNSName = ToAPIString(v.Host)
 		createHost.InstanceID = ToAPIString(v.Id)
 		createHost.IP = ToAPIString(v.IP)
-		createHost.InstanceID = ToAPIString(v.ExternalIdentifier)
 	case *host.Host:
 		// container
 		if v.ParentID != "" {
@@ -43,7 +42,6 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 		createHost.DNSName = ToAPIString(v.Host)
 		createHost.InstanceID = ToAPIString(v.Id)
 		createHost.IP = ToAPIString(v.IP)
-		createHost.InstanceID = ToAPIString(v.ExternalIdentifier)
 	default:
 		return errors.Errorf("Invalid type passed to *CreateHost.BuildFromService (%T)", h)
 	}

--- a/rest/model/createhost_test.go
+++ b/rest/model/createhost_test.go
@@ -10,15 +10,15 @@ import (
 func TestCreateHostBuildFromService(t *testing.T) {
 	assert := assert.New(t)
 	h := host.Host{
-		Host:               "foo.com",
-		ExternalIdentifier: "sir-123",
-		IP:                 "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47",
+		Id:   "i-123456",
+		Host: "foo.com",
+		IP:   "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47",
 	}
 	c := &CreateHost{}
 	err := c.BuildFromService(h)
 	assert.NoError(err)
 	assert.Equal(FromAPIString(c.DNSName), h.Host)
-	assert.Equal(FromAPIString(c.InstanceID), h.ExternalIdentifier)
+	assert.Equal(FromAPIString(c.InstanceID), h.Id)
 	assert.Equal(FromAPIString(c.IP), h.IP)
 }
 


### PR DESCRIPTION
The AWS Fleet API immediately gets the cheapest spot instance available. This way:
- we don't ask for the cheapest instances only to find out they aren't available and have to restart. 
- since the instances are returned immediately, this reduces code complexity needed to support the spot instance request lifecycle.

Some concerns:
- our EC2 Auto finds the cheaper of the lowest cost spot instance and the on-demand price. Since AWS Fleet will not give us _any_ hosts when the cost of the cheapest available spot hosts is >= on-demand hosts if the cheapest **reported** spot hosts are cheaper than on-demand but the cheapest **available** spot hosts are more expensive we will keep trying to get a spot host and failing.
- Deploying these changes will strand all the spot instance requests in progress at the time, since we will fail to get their status and update the host's id/status. Spot instances already running will not be affected.
