### PR TITLE
EVG-6269 unmarshal params into separate fields

### DIFF
--- a/command/registry.go
+++ b/command/registry.go
@@ -177,12 +177,7 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		}
 
 		cmd := factory()
-		params, err := c.ResolveParams()
-		if err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-		if err = cmd.ParseParams(params); err != nil {
+		if err := cmd.ParseParams(c.Params); err != nil {
 			errs = append(errs, errors.Wrapf(err, "problem parsing input of %s (%s)", c.Command, c.DisplayName).Error())
 			continue
 		}

--- a/command/registry.go
+++ b/command/registry.go
@@ -135,7 +135,6 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		parsed []model.PluginCommandConf
 		out    []Command
 		errs   []string
-		err    error
 	)
 
 	if name := commandInfo.Function; name != "" {
@@ -178,7 +177,12 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		}
 
 		cmd := factory()
-		if err = cmd.ParseParams(c.Params); err != nil {
+		params, err := c.ResolveParams()
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		if err = cmd.ParseParams(params); err != nil {
 			errs = append(errs, errors.Wrapf(err, "problem parsing input of %s (%s)", c.Command, c.DisplayName).Error())
 			continue
 		}

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -314,22 +314,22 @@ func (s *GenerateSuite) TestParseProjectFromJSON() {
 	s.Contains(g.Functions, "echo-hi")
 	s.Equal("shell.exec", g.Functions["echo-hi"].List()[0].Command)
 
-	params, err := g.Functions["echo-hi"].List()[0].ResolveParams()
+	params, err := g.Functions["echo-hi"].List()[0].resolveParams()
 	s.Require().NoError(err)
 	s.Equal("echo hi", params["script"])
 
-	params, err = g.Functions["echo-bye"].List()[0].ResolveParams()
+	params, err = g.Functions["echo-bye"].List()[0].resolveParams()
 	s.Require().NoError(err)
 	s.Equal("echo bye", params["script"])
 
-	params, err = g.Functions["echo-bye"].List()[1].ResolveParams()
+	params, err = g.Functions["echo-bye"].List()[1].resolveParams()
 	s.Require().NoError(err)
 	s.Equal("echo bye again", params["script"])
 
 	s.Len(g.Tasks, 1)
 	s.Equal("git.get_project", g.Tasks[0].Commands[0].Command)
 
-	params, err = g.Tasks[0].Commands[0].ResolveParams()
+	params, err = g.Tasks[0].Commands[0].resolveParams()
 	s.NoError(err)
 	s.Equal("src", params["directory"])
 	s.Equal("echo-hi", g.Tasks[0].Commands[1].Function)

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -34,7 +34,7 @@ var (
 				DependsOn: []parserDependency{
 					{TaskSelector: taskSelector{
 						Name:    "a-depended-on-task",
-						Variant: &variantSelector{stringSelector: "*"},
+						Variant: &variantSelector{StringSelector: "*"},
 					}},
 				},
 			},
@@ -313,13 +313,25 @@ func (s *GenerateSuite) TestParseProjectFromJSON() {
 	s.Len(g.Functions, 2)
 	s.Contains(g.Functions, "echo-hi")
 	s.Equal("shell.exec", g.Functions["echo-hi"].List()[0].Command)
-	s.Equal("echo hi", g.Functions["echo-hi"].List()[0].Params["script"])
-	s.Equal("echo bye", g.Functions["echo-bye"].List()[0].Params["script"])
-	s.Equal("echo bye again", g.Functions["echo-bye"].List()[1].Params["script"])
+
+	params, err := g.Functions["echo-hi"].List()[0].ResolveParams()
+	s.Require().NoError(err)
+	s.Equal("echo hi", params["script"])
+
+	params, err = g.Functions["echo-bye"].List()[0].ResolveParams()
+	s.Require().NoError(err)
+	s.Equal("echo bye", params["script"])
+
+	params, err = g.Functions["echo-bye"].List()[1].ResolveParams()
+	s.Require().NoError(err)
+	s.Equal("echo bye again", params["script"])
 
 	s.Len(g.Tasks, 1)
 	s.Equal("git.get_project", g.Tasks[0].Commands[0].Command)
-	s.Equal("src", g.Tasks[0].Commands[0].Params["directory"])
+
+	params, err = g.Tasks[0].Commands[0].ResolveParams()
+	s.NoError(err)
+	s.Equal("src", params["directory"])
 	s.Equal("echo-hi", g.Tasks[0].Commands[1].Function)
 	s.Equal("test", g.Tasks[0].Name)
 

--- a/model/project.go
+++ b/model/project.go
@@ -18,7 +18,8 @@ import (
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	ignore "github.com/sabhiram/go-git-ignore"
+	"github.com/sabhiram/go-git-ignore"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -261,13 +262,78 @@ type PluginCommandConf struct {
 	// TimeoutSecs indicates the maximum duration the command is allowed to run for.
 	TimeoutSecs int `yaml:"timeout_secs,omitempty" bson:"timeout_secs"`
 
-	// Params are used to supply configuratiion specific information.
-	Params map[string]interface{} `yaml:"params,omitempty" bson:"params"`
+	// Params are used to supply configuration specific information.
+	// map[string]interface{} is stored as a JSON string.
+	Params map[string]interface{} `yaml:"-" bson:"-"`
+
+	// YAML string of Params to store in database
+	ParamsYAML string `yaml:"params,omitempty" bson:"params"`
 
 	// Vars defines variables that can be used within commands.
 	Vars map[string]string `yaml:"vars,omitempty" bson:"vars"`
 
 	Loggers *LoggerConfig `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
+}
+
+func (p *PluginCommandConf) ResolveParams() (map[string]interface{}, error) {
+	out := map[string]interface{}{}
+	if p == nil {
+		return out, nil
+	}
+	if len(p.Params) > 0 {
+		return p.Params, nil
+	}
+	if err := yaml.Unmarshal([]byte(p.ParamsYAML), &out); err != nil {
+		return nil, errors.Wrapf(err, "error unmarshalling params")
+	}
+	p.Params = out
+	return out, nil
+}
+
+func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	temp := struct {
+		Function    string            `yaml:"func,omitempty" bson:"func"`
+		Type        string            `yaml:"type,omitempty" bson:"type"`
+		DisplayName string            `yaml:"display_name,omitempty" bson:"display_name"`
+		Command     string            `yaml:"command,omitempty" bson:"command"`
+		Variants    []string          `yaml:"variants,omitempty" bson:"variants"`
+		TimeoutSecs int               `yaml:"timeout_secs,omitempty" bson:"timeout_secs"`
+		Params      interface{}       `yaml:"params,omitempty" bson:"params"`
+		Vars        map[string]string `yaml:"vars,omitempty" bson:"vars"`
+		Loggers     *LoggerConfig     `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
+	}{}
+
+	if err := unmarshal(&temp); err != nil {
+		return errors.Wrap(err, "error unmarshalling into temp structure")
+	}
+	c.Function = temp.Function
+	c.Type = temp.Type
+	c.DisplayName = temp.DisplayName
+	c.Command = temp.Command
+	c.Variants = temp.Variants
+	c.TimeoutSecs = temp.TimeoutSecs
+	c.Vars = temp.Vars
+	c.Loggers = temp.Loggers
+
+	return c.unmarshalParams(temp.Params)
+}
+
+func (c *PluginCommandConf) unmarshalParams(params interface{}) error {
+	switch v := params.(type) {
+	case string:
+		c.ParamsYAML = v
+	case map[interface{}]interface{}:
+		bytes, err := yaml.Marshal(v)
+		if err != nil {
+			return errors.Wrap(err, "error marshalling params into yaml")
+		}
+		c.ParamsYAML = string(bytes)
+		c.Params = map[string]interface{}{}
+		for key, val := range v {
+			c.Params[fmt.Sprintf("%v", key)] = val
+		}
+	}
+	return nil
 }
 
 type ArtifactInstructions struct {
@@ -276,8 +342,8 @@ type ArtifactInstructions struct {
 }
 
 type YAMLCommandSet struct {
-	SingleCommand *PluginCommandConf
-	MultiCommand  []PluginCommandConf
+	SingleCommand *PluginCommandConf  `bson:"single_command"`
+	MultiCommand  []PluginCommandConf `bson:"multi_command"`
 }
 
 func (c *YAMLCommandSet) List() []PluginCommandConf {

--- a/model/project.go
+++ b/model/project.go
@@ -316,6 +316,7 @@ func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(interface{}) error) err
 	c.Vars = temp.Vars
 	c.Loggers = temp.Loggers
 	c.ParamsYAML = temp.ParamsYAML
+	c.Params = temp.Params
 
 	return c.unmarshalParams()
 }

--- a/model/project_matrix.go
+++ b/model/project_matrix.go
@@ -45,9 +45,9 @@ type matrix struct {
 
 // matrixAxis represents one axis of a matrix definition.
 type matrixAxis struct {
-	Id          string      `yaml:"id"`
-	DisplayName string      `yaml:"display_name"`
-	Values      []axisValue `yaml:"values"`
+	Id          string      `yaml:"id" bson:"id"`
+	DisplayName string      `yaml:"display_name" bson:"display_name"`
+	Values      []axisValue `yaml:"values" bson:"values"`
 }
 
 // find returns the axisValue with the given name.
@@ -63,14 +63,14 @@ func (ma matrixAxis) find(id string) (axisValue, error) {
 // axisValues make up the "points" along a matrix axis. Values are
 // combined during matrix evaluation to produce new variants.
 type axisValue struct {
-	Id          string            `yaml:"id"`
-	DisplayName string            `yaml:"display_name"`
-	Variables   util.Expansions   `yaml:"variables"`
-	RunOn       parserStringSlice `yaml:"run_on"`
-	Tags        parserStringSlice `yaml:"tags"`
-	Modules     parserStringSlice `yaml:"modules"`
-	BatchTime   *int              `yaml:"batchtime"`
-	Stepback    *bool             `yaml:"stepback"`
+	Id          string            `yaml:"id" bson:"id"`
+	DisplayName string            `yaml:"display_name" bson:"display_name"`
+	Variables   util.Expansions   `yaml:"variables" bson:"variables"`
+	RunOn       parserStringSlice `yaml:"run_on" bson:"run_on"`
+	Tags        parserStringSlice `yaml:"tags" bson:"tags"`
+	Modules     parserStringSlice `yaml:"modules" bson:"modules"`
+	BatchTime   *int              `yaml:"batchtime" bson:"batchtime"`
+	Stepback    *bool             `yaml:"stepback" bson:"stepback"`
 }
 
 // helper methods for tag selectors
@@ -531,21 +531,21 @@ func expandTaskSelector(ts taskSelector, exp util.Expansions) (taskSelector, err
 	}
 	newTS.Name = newName
 	if v := ts.Variant; v != nil {
-		if len(v.matrixSelector) > 0 {
-			newMS, err := expandMatrixDefinition(v.matrixSelector, exp)
+		if len(v.MatrixSelector) > 0 {
+			newMS, err := expandMatrixDefinition(v.MatrixSelector, exp)
 			if err != nil {
 				return newTS, errors.Wrap(err, "expanding variant")
 			}
 			newTS.Variant = &variantSelector{
-				matrixSelector: newMS,
+				MatrixSelector: newMS,
 			}
 		} else {
-			selector, err := exp.ExpandString(v.stringSelector)
+			selector, err := exp.ExpandString(v.StringSelector)
 			if err != nil {
 				return newTS, errors.Wrap(err, "expanding variant")
 			}
 			newTS.Variant = &variantSelector{
-				stringSelector: selector,
+				StringSelector: selector,
 			}
 		}
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -107,6 +107,20 @@ type parserTask struct {
 	Stepback        *bool               `yaml:"stepback,omitempty"`
 }
 
+func (pp *parserProject) MarshalYAML() (interface{}, error) {
+	for i, pt := range pp.Tasks {
+		for j, cmd := range pt.Commands {
+			params, err := cmd.resolveParams()
+			if err != nil {
+				return nil, errors.Wrapf(err, "error marshalling commands for task")
+			}
+			pp.Tasks[i].Commands[j].Params = params
+		}
+	}
+
+	return pp, nil
+}
+
 type displayTask struct {
 	Name           string   `yaml:"name,omitempty"`
 	ExecutionTasks []string `yaml:"execution_tasks,omitempty"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -8,7 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 const LoadProjectError = "load project error(s)"
@@ -39,33 +39,33 @@ const LoadProjectError = "load project error(s)"
 // configuration YAML. It implements the Unmarshaler interface
 // to allow for flexible handling.
 type parserProject struct {
-	Enabled         bool                       `yaml:"enabled,omitempty"`
-	Stepback        bool                       `yaml:"stepback,omitempty"`
-	IgnorePreError  bool                       `yaml:"ignore_pre_err,omitempty"`
-	BatchTime       int                        `yaml:"batchtime,omitempty"`
-	Owner           string                     `yaml:"owner,omitempty"`
-	Repo            string                     `yaml:"repo,omitempty"`
-	RemotePath      string                     `yaml:"remote_path,omitempty"`
-	RepoKind        string                     `yaml:"repokind,omitempty"`
-	Branch          string                     `yaml:"branch,omitempty"`
-	Identifier      string                     `yaml:"identifier,omitempty"`
-	DisplayName     string                     `yaml:"display_name,omitempty"`
-	CommandType     string                     `yaml:"command_type,omitempty"`
-	Ignore          parserStringSlice          `yaml:"ignore,omitempty"`
-	Pre             *YAMLCommandSet            `yaml:"pre,omitempty"`
-	Post            *YAMLCommandSet            `yaml:"post,omitempty"`
-	Timeout         *YAMLCommandSet            `yaml:"timeout,omitempty"`
-	CallbackTimeout int                        `yaml:"callback_timeout_secs,omitempty"`
-	Modules         []Module                   `yaml:"modules,omitempty"`
-	BuildVariants   []parserBV                 `yaml:"buildvariants,omitempty"`
-	Functions       map[string]*YAMLCommandSet `yaml:"functions,omitempty"`
-	TaskGroups      []parserTaskGroup          `yaml:"task_groups,omitempty"`
-	Tasks           []parserTask               `yaml:"tasks,omitempty"`
-	ExecTimeoutSecs int                        `yaml:"exec_timeout_secs,omitempty"`
-	Loggers         *LoggerConfig              `yaml:"loggers,omitempty"`
+	Enabled         bool                       `yaml:"enabled,omitempty" bson:"enabled,omitempty"`
+	Stepback        bool                       `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	IgnorePreError  bool                       `yaml:"ignore_pre_err,omitempty" bson:"ignore_pre_err,omitempty"`
+	BatchTime       int                        `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
+	Owner           string                     `yaml:"owner,omitempty" bson:"owner,omitempty"`
+	Repo            string                     `yaml:"repo,omitempty" bson:"repo,omitempty"`
+	RemotePath      string                     `yaml:"remote_path,omitempty" bson:"remote_path,omitempty"`
+	RepoKind        string                     `yaml:"repokind,omitempty" bson:"repokind,omitempty"`
+	Branch          string                     `yaml:"branch,omitempty" bson:"branch,omitempty"`
+	Identifier      string                     `yaml:"identifier,omitempty" bson:"identifier,omitempty"`
+	DisplayName     string                     `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
+	CommandType     string                     `yaml:"command_type,omitempty" bson:"command_type,omitempty"`
+	Ignore          parserStringSlice          `yaml:"ignore,omitempty" bson:"ignore,omitempty"`
+	Pre             *YAMLCommandSet            `yaml:"pre,omitempty" bson:"pre,omitempty"`
+	Post            *YAMLCommandSet            `yaml:"post,omitempty" bson:"post,omitempty"`
+	Timeout         *YAMLCommandSet            `yaml:"timeout,omitempty" bson:"timeout,omitempty"`
+	CallbackTimeout int                        `yaml:"callback_timeout_secs,omitempty" bson:"callback_timeout_secs,omitempty"`
+	Modules         []Module                   `yaml:"modules,omitempty" bson:"modules,omitempty"`
+	BuildVariants   []parserBV                 `yaml:"buildvariants,omitempty" bson:"buildvariants,omitempty"`
+	Functions       map[string]*YAMLCommandSet `yaml:"functions,omitempty" bson:"functions,omitempty"`
+	TaskGroups      []parserTaskGroup          `yaml:"task_groups,omitempty" bson:"task_groups,omitempty"`
+	Tasks           []parserTask               `yaml:"tasks,omitempty" bson:"tasks,omitempty"`
+	ExecTimeoutSecs int                        `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
+	Loggers         *LoggerConfig              `yaml:"loggers,omitempty" bson:"loggers:omitempty"`
 
 	// Matrix code
-	Axes []matrixAxis `yaml:"axes,omitempty"`
+	Axes []matrixAxis `yaml:"axes,omitempty" bson:"axes,omitempty"`
 }
 
 type parserTaskGroup struct {
@@ -165,7 +165,7 @@ func (pd *parserDependency) UnmarshalYAML(unmarshal func(interface{}) error) err
 // in the context of dependencies and requirements fields. //TODO no export?
 type taskSelector struct {
 	Name    string           `yaml:"name,omitempty"`
-	Variant *variantSelector `yaml:"variant,omitempty"`
+	Variant *variantSelector `yaml:"variant,omitempty" bson:"variant"`
 }
 
 // TaskSelectors is a helper type for parsing arrays of TaskSelector.
@@ -174,8 +174,8 @@ type taskSelectors []taskSelector
 // VariantSelector handles the selection of a variant, either by a id/tag selector
 // or by matching against matrix axis values.
 type variantSelector struct {
-	stringSelector string
-	matrixSelector matrixDefinition
+	StringSelector string           `yaml:"string_selector" bson:"string_selector"`
+	MatrixSelector matrixDefinition `yaml:"matrix_selector" bson:"matrix_selector"`
 }
 
 // UnmarshalYAML allows variants to be referenced as single selector strings or
@@ -186,7 +186,7 @@ func (vs *variantSelector) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	var onlySelector string
 	if err := unmarshal(&onlySelector); err == nil {
 		if onlySelector != "" {
-			vs.stringSelector = onlySelector
+			vs.StringSelector = onlySelector
 			return nil
 		}
 	}
@@ -198,17 +198,17 @@ func (vs *variantSelector) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	if len(md) == 0 {
 		return errors.New("variant selector must not be empty")
 	}
-	vs.matrixSelector = md
+	vs.MatrixSelector = md
 	return nil
 }
 
 func (vs *variantSelector) MarshalYAML() (interface{}, error) {
-	if vs == nil || vs.stringSelector == "" {
+	if vs == nil || vs.StringSelector == "" {
 		return nil, nil
 	}
 	// Note: Generate tasks will not work with matrix variant selectors,
 	// since this will only marshal the string part of a variant selector.
-	return vs.stringSelector, nil
+	return vs.StringSelector, nil
 }
 
 // UnmarshalYAML reads YAML into an array of TaskSelector. It will

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -10,12 +10,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/testutil"
+	yaml "gopkg.in/yaml.v2"
+
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 // ShouldContainResembling tests whether a slice contains an element that DeepEquals
@@ -1226,93 +1229,16 @@ functions:
       env:
         CLIENT_URL: https://s3.amazonaws.com/mciuploads/evergreen/${task_id}/evergreen-ci/evergreen/clients/${goos}_${goarch}/evergreen
 `
-	paramsYAML := `
-  - command: myCommand
-    params:
-      env:
-        ${MY_KEY}: my-value
-        ${MY_NUMS}:
-        - 1
-        - 2
-        - 3`
 
 	for name, test := range map[string]func(t *testing.T){
 		"simpleYaml": func(t *testing.T) {
-			pp, errs := createIntermediateProject([]byte(simpleYml))
-			yamlToCompare, err := yaml.Marshal(pp)
-			assert.NoError(t, err)
-
-			assert.Len(t, errs, 0)
-			v := Version{
-				Id:            "my-version",
-				ParserProject: pp,
-				Config:        string(yamlToCompare),
-			}
-			assert.NoError(t, v.Insert())
-			newV, err := VersionFindOneId(v.Id)
-			assert.NoError(t, err)
-			require.NotNil(t, newV)
-			require.NotNil(t, newV.ParserProject)
-			require.Len(t, newV.ParserProject.Tasks, 1)
-			require.Len(t, newV.ParserProject.Tasks[0].Commands, 1)
-			assert.NotEmpty(t, newV.ParserProject.Tasks[0].Commands[0].Params)
-			assert.NotEmpty(t, newV.ParserProject.Tasks[0].Commands[0].ParamsYAML)
-
-			params := map[string]interface{}{}
-			assert.NoError(t, yaml.Unmarshal([]byte(newV.ParserProject.Tasks[0].Commands[0].ParamsYAML), &params))
-			val := params["env"]
-			env, ok := val.(map[interface{}]interface{})
-			assert.True(t, ok)
-			assert.Len(t, env, 2)
-			val1 := env["${MY_KEY}"]
-			val2 := env["${MY_NUMS}"]
-			assert.Equal(t, "my-value", fmt.Sprintf("%s", val1))
-			assert.Len(t, val2, 3)
-			assert.True(t, bytes.Contains([]byte(newV.Config), []byte(paramsYAML)))
+			assert.NoError(t, checkProjectPersists([]byte(simpleYml)))
 		},
 		"self-tests.yml": func(t *testing.T) {
 			filepath := filepath.Join(testutil.GetDirectoryOfFile(), "..", "self-tests.yml")
 			yml, err := ioutil.ReadFile(filepath)
 			assert.NoError(t, err)
-
-			pp, errs := createIntermediateProject([]byte(yml))
-			yamlToCompare, err := yaml.Marshal(pp)
-			assert.NoError(t, err)
-
-			assert.Len(t, errs, 0)
-			v := Version{
-				Id:            "my-version",
-				ParserProject: pp,
-				Config:        string(yamlToCompare),
-			}
-			assert.NoError(t, v.Insert())
-			newV, err := VersionFindOneId(v.Id)
-			assert.NoError(t, err)
-			require.NotNil(t, newV)
-			require.NotNil(t, newV.ParserProject)
-			require.NotNil(t, newV.ParserProject.Post)
-			cmds := newV.ParserProject.Post.List()
-			require.Len(t, cmds, 3)
-			assert.Equal(t, cmds[1].Command, "s3.put")
-			assert.NotEmpty(t, cmds[1].ParamsYAML)
-			assert.NotEmpty(t, cmds[1].Params)
-			params := map[string]interface{}{}
-			assert.NoError(t, yaml.Unmarshal([]byte(cmds[1].ParamsYAML), &params))
-			assert.Len(t, params, 8)
-			assert.Equal(t, params["aws_key"], "${aws_key}")
-
-			commandParams := `
-    aws_key: ${aws_key}
-    aws_secret: ${aws_secret}
-    bucket: mciuploads
-    content_type: text/html
-    display_name: '(html) coverage:'
-    local_files_include_filter:
-    - gopath/src/github.com/evergreen-ci/evergreen/bin/output.*.coverage.html
-    permissions: public-read
-    remote_file: evergreen/${task_id}/
-`
-			assert.True(t, bytes.Contains([]byte(newV.Config), []byte(commandParams)))
+			assert.NoError(t, checkProjectPersists(yml))
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -1320,5 +1246,39 @@ functions:
 			test(t)
 		})
 	}
+}
 
+func checkProjectPersists(yml []byte) error {
+	pp, errs := createIntermediateProject(yml)
+	catcher := grip.NewBasicCatcher()
+	for _, err := range errs {
+		catcher.Add(err)
+	}
+	if catcher.HasErrors() {
+		return catcher.Resolve()
+	}
+	yamlToCompare, err := yaml.Marshal(pp)
+	if err != nil {
+		return errors.Wrapf(err, "error marshalling original project")
+	}
+
+	v := Version{
+		Id:            "my-version",
+		ParserProject: pp,
+	}
+	if err = v.Insert(); err != nil {
+		return errors.Wrapf(err, "error inserting version")
+	}
+	newV, err := VersionFindOneId(v.Id)
+	if err != nil {
+		return errors.Wrapf(err, "error finding version")
+	}
+	newYaml, err := yaml.Marshal(newV.ParserProject)
+	if err != nil {
+		return errors.Wrapf(err, "error marshalling database project")
+	}
+	if !bytes.Equal(newYaml, yamlToCompare) {
+		return errors.New("yamls not equal")
+	}
+	return nil
 }

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -372,11 +372,11 @@ func (v *variantSelectorEvaluator) evalSelector(vs *variantSelector) ([]string, 
 	if vs == nil {
 		return nil, errors.New("empty selector")
 	}
-	if vs.matrixSelector != nil {
-		evaluatedSelector, errs := vs.matrixSelector.evaluatedCopy(v.axisEval)
+	if vs.MatrixSelector != nil {
+		evaluatedSelector, errs := vs.MatrixSelector.evaluatedCopy(v.axisEval)
 		if len(errs) > 0 {
 			return nil, errors.Errorf(
-				"errors evaluating variant selector %v: %v", vs.matrixSelector, errs)
+				"errors evaluating variant selector %v: %v", vs.MatrixSelector, errs)
 		}
 		results := []string{}
 		// this could be sped up considerably with caching, but I doubt we'll need to
@@ -386,11 +386,11 @@ func (v *variantSelectorEvaluator) evalSelector(vs *variantSelector) ([]string, 
 			}
 		}
 		if len(results) == 0 {
-			return nil, errors.Errorf("variant selector %v returns no variants", vs.matrixSelector)
+			return nil, errors.Errorf("variant selector %v returns no variants", vs.MatrixSelector)
 		}
 		return results, nil
 	}
-	results, err := v.tagEval.evalSelector(ParseSelector(vs.stringSelector))
+	results, err := v.tagEval.evalSelector(ParseSelector(vs.StringSelector))
 	if err != nil {
 		return nil, errors.Wrap(err, "variant tag selector")
 	}

--- a/model/project_selector_test.go
+++ b/model/project_selector_test.go
@@ -261,7 +261,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 		Convey("and a set of variant selectors", func() {
 			Convey("a single-cell matrix selector should return one variant", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{"iron"},
 						"temp":     []string{"0"},
 					},
@@ -273,7 +273,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a 2x2 matrix selector should return four variants", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{"iron", "wood"},
 						"temp":     []string{"0", "100"},
 					},
@@ -288,7 +288,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a *x* matrix selector should return all variants", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{"*"},
 						"temp":     []string{"*"},
 					},
@@ -299,7 +299,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a tagged matrix selector should return all axis-tagged variants", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{".metal"},
 						"temp":     []string{".hot"},
 					},
@@ -312,7 +312,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("an empty matrix selector should error", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{},
+					MatrixSelector: matrixDefinition{},
 				}
 				v, err := vse.evalSelector(vs)
 				So(err, ShouldNotBeNil)
@@ -320,7 +320,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a matrix selector with nonexistent axes should fail", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"wow": []string{"neat"},
 					},
 				}
@@ -330,7 +330,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a matrix selector with nonexistent selectors should fail", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{".neat"},
 					},
 				}
@@ -340,7 +340,7 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 			})
 			Convey("a matrix selector with invalid selectors should fail", func() {
 				vs := &variantSelector{
-					matrixSelector: matrixDefinition{
+					MatrixSelector: matrixDefinition{
 						"material": []string{""},
 					},
 				}

--- a/model/version.go
+++ b/model/version.go
@@ -24,6 +24,7 @@ type Version struct {
 	Message             string               `bson:"message" json:"message,omitempty"`
 	Status              string               `bson:"status" json:"status,omitempty"`
 	RevisionOrderNumber int                  `bson:"order,omitempty" json:"order,omitempty"`
+	ParserProject       *parserProject       `bson:"project" json:"project,omitempty"`
 	Config              string               `bson:"config" json:"config,omitempty"`
 	ConfigUpdateNumber  int                  `bson:"config_number" json:"config_number,omitempty"`
 	Ignored             bool                 `bson:"ignored" json:"ignored"`

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -29,6 +29,7 @@ var (
 	VersionBuildVariantsKey       = bsonutil.MustHaveTag(Version{}, "BuildVariants")
 	VersionRevisionOrderNumberKey = bsonutil.MustHaveTag(Version{}, "RevisionOrderNumber")
 	VersionRequesterKey           = bsonutil.MustHaveTag(Version{}, "Requester")
+	VersionProjectKey             = bsonutil.MustHaveTag(Version{}, "ParserProject")
 	VersionConfigKey              = bsonutil.MustHaveTag(Version{}, "Config")
 	VersionConfigNumberKey        = bsonutil.MustHaveTag(Version{}, "ConfigUpdateNumber")
 	VersionIgnoredKey             = bsonutil.MustHaveTag(Version{}, "Ignored")

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -150,8 +150,7 @@ buildvariants:
 	assert.NoError(settings.Set())
 	dc := DBCreateHostConnector{}
 
-	err := dc.CreateHostsFromTask(&t1, user.DBUser{Id: "me"}, "")
-	assert.NoError(err)
+	assert.NoError(dc.CreateHostsFromTask(&t1, user.DBUser{Id: "me"}, ""))
 
 	createdHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)


### PR DESCRIPTION
So, before I did this "clever" thing in my unmarshaller where I cased on the type of Params (if this was the first time we saw the project, Params was map[string]interface{}, but after that would be a YAML string). This wasn't safe with rollbacks and outdated agents, as the old marshaller didn't know what to do with this yaml string.

Instead, we should keep Params and ParamsYAML entirely separate, and keep them both updated. Specifically we need Params so unmarshalling from the config string works; this will be corrupted in the database. This now makes TestParserProjectPersists fail--not sure if there's a good way to make these yamls match (the messed up Params makes them different). I had an idea we could set all Params to nil when re-marshalling, but that approach seemed to require many Marshallers.

Let me know if this doesn't make sense, and obviously we should find some way to seriously test this.