### PR TITLE
EVG-6317: check hosts for external termination

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -21,6 +21,8 @@ const (
 	HostQuarantined     = "quarantined"
 	HostDecommissioned  = "decommissioned"
 
+	HostExternalUserName = "external"
+
 	HostStatusSuccess = "success"
 	HostStatusFailed  = "failed"
 

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -92,58 +92,66 @@ func (j *hostMonitorExternalStateCheckJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	settings := j.env.Settings()
+	_, err = CheckExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
+	j.AddError(err)
+}
 
-	cloudHost, err := cloud.GetCloudHost(ctx, j.host, settings)
+func CheckExternallyTerminatedHost(ctx context.Context, id string, env evergreen.Environment, h *host.Host) (bool, error) {
+	settings := env.Settings()
+	cloudHost, err := cloud.GetCloudHost(ctx, h, settings)
 	if err != nil {
-		j.AddError(errors.Wrapf(err, "error getting cloud host for host %s", j.host.Id))
-		return
+		return false, errors.Wrapf(err, "error getting cloud host for host %s", h.Id)
 	}
-
 	cloudStatus, err := cloudHost.GetInstanceStatus(ctx)
 	if err != nil {
-		j.AddError(errors.Wrapf(err, "error getting cloud status for host %s", j.HostID))
-		return
+		return false, errors.Wrapf(err, "error getting cloud status for host %s", h.Id)
 	}
 
 	switch cloudStatus {
 	case cloud.StatusRunning:
-		if j.host.Status != evergreen.HostRunning {
+		if h.Status != evergreen.HostRunning {
 			grip.Info(message.Fields{
-				"op":      hostMonitorExternalStateCheckName,
-				"op_id":   j.ID(),
-				"message": "found running host, with incorrect status ",
-				"status":  j.host.Status,
-				"host":    j.HostID,
-				"distro":  j.host.Distro.Id,
+				"op_id":   id,
+				"message": "found running host with incorrect status",
+				"status":  h.Status,
+				"host":    h.Id,
+				"distro":  h.Distro.Id,
 			})
-
-			j.AddError(errors.Wrapf(j.host.MarkReachable(), "error updating reachability for host %s", j.HostID))
+			return false, errors.Wrapf(h.MarkReachable(), "error updating reachability for host %s", h.Id)
 		}
+		return false, nil
 	case cloud.StatusTerminated:
 		grip.Info(message.Fields{
-			"op":      hostMonitorExternalStateCheckName,
-			"op_id":   j.ID(),
+			"op_id":   id,
 			"message": "host terminated externally",
-			"host":    j.HostID,
-			"distro":  j.host.Distro.Id,
+			"host":    h.Id,
+			"distro":  h.Distro.Id,
 		})
 
-		j.AddError(model.ClearAndResetStrandedTask(j.host))
+		if err = model.ClearAndResetStrandedTask(h); err != nil {
+			return false, errors.Wrap(err, "can't clear stranded tasks")
+		}
 
-		event.LogHostTerminatedExternally(j.HostID)
+		event.LogHostTerminatedExternally(h.Id)
 
 		// the instance was terminated from outside our control
-		j.AddError(errors.Wrapf(j.host.SetTerminated(evergreen.HostExternalUserName), "error setting host %s terminated", j.HostID))
+		err = h.SetTerminated(evergreen.HostExternalUserName)
+		grip.Error(message.WrapError(err, message.Fields{
+			"op_id":   id,
+			"message": "error setting host status to terminated in db",
+			"host":    h.Id,
+			"distro":  h.Distro.Id,
+		}))
+		return true, errors.Wrapf(err, "error setting host %s terminated", h.Id)
 	default:
 		grip.Warning(message.Fields{
 			"message":      "host found with unexpected status",
-			"op":           hostMonitorExternalStateCheckName,
-			"op_id":        j.ID(),
-			"host":         j.HostID,
-			"distro":       j.host.Distro.Id,
-			"host_status":  j.host.Status,
+			"op_id":        id,
+			"host":         h.Id,
+			"distro":       h.Distro.Id,
+			"host_status":  h.Status,
 			"cloud_status": cloudStatus,
 		})
+		return false, errors.Errorf("unexpected host status '%s'", cloudStatus)
 	}
 }

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -134,7 +134,7 @@ func (j *hostMonitorExternalStateCheckJob) Run(ctx context.Context) {
 		event.LogHostTerminatedExternally(j.HostID)
 
 		// the instance was terminated from outside our control
-		j.AddError(errors.Wrapf(j.host.SetTerminated("external"), "error setting host %s terminated", j.HostID))
+		j.AddError(errors.Wrapf(j.host.SetTerminated(evergreen.HostExternalUserName), "error setting host %s terminated", j.HostID))
 	default:
 		grip.Warning(message.Fields{
 			"message":      "host found with unexpected status",

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -92,11 +92,17 @@ func (j *hostMonitorExternalStateCheckJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	_, err = CheckExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
+	_, err = HandleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
 	j.AddError(err)
 }
 
-func CheckExternallyTerminatedHost(ctx context.Context, id string, env evergreen.Environment, h *host.Host) (bool, error) {
+// HandleExternallyTerminatedHost will check if a host from a dynamic provider has been termimated
+// and clean up the host if it has. Returns true if the host has been externally terminated
+func HandleExternallyTerminatedHost(ctx context.Context, id string, env evergreen.Environment, h *host.Host) (bool, error) {
+	if h.Provider != evergreen.ProviderNameStatic {
+		return false, nil
+	}
+
 	settings := env.Settings()
 	cloudHost, err := cloud.GetCloudHost(ctx, h, settings)
 	if err != nil {

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -92,13 +92,13 @@ func (j *hostMonitorExternalStateCheckJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	_, err = HandleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
+	_, err = handleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
 	j.AddError(err)
 }
 
-// HandleExternallyTerminatedHost will check if a host from a dynamic provider has been termimated
+// handleExternallyTerminatedHost will check if a host from a dynamic provider has been termimated
 // and clean up the host if it has. Returns true if the host has been externally terminated
-func HandleExternallyTerminatedHost(ctx context.Context, id string, env evergreen.Environment, h *host.Host) (bool, error) {
+func handleExternallyTerminatedHost(ctx context.Context, id string, env evergreen.Environment, h *host.Host) (bool, error) {
 	if h.Provider == evergreen.ProviderNameStatic {
 		return false, nil
 	}

--- a/units/host_monitoring_external_termination_test.go
+++ b/units/host_monitoring_external_termination_test.go
@@ -60,24 +60,20 @@ func TestHostMonitoringCheckJob(t *testing.T) {
 	assert.Equal(host1.Status, evergreen.HostTerminated)
 }
 
-func TestCheckExternallyTerminatedHost(t *testing.T) {
+func TestHandleExternallyTerminatedHost(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(host.Collection))
 
 	mockCloud := cloud.GetMockProvider()
 	mockCloud.Reset()
 	m1 := cloud.MockInstance{
-		IsUp:           true,
-		IsSSHReachable: true,
-		Status:         cloud.StatusTerminated,
+		Status: cloud.StatusTerminated,
 	}
 	mockCloud.Set("h1", m1)
 
 	h := &host.Host{
-		Id:                    "h1",
-		LastCommunicationTime: time.Now().Add(-15 * time.Minute),
-		Status:                evergreen.HostRunning,
-		Provider:              evergreen.ProviderNameMock,
-		StartedBy:             evergreen.User,
+		Id:       "h1",
+		Status:   evergreen.HostRunning,
+		Provider: evergreen.ProviderNameMock,
 	}
 	require.NoError(t, h.Insert())
 

--- a/units/host_monitoring_external_termination_test.go
+++ b/units/host_monitoring_external_termination_test.go
@@ -86,7 +86,7 @@ func TestCheckExternallyTerminatedHost(t *testing.T) {
 		EvergreenSettings: testConfig,
 	}
 
-	terminated, err := CheckExternallyTerminatedHost(context.Background(), "", env, h)
+	terminated, err := HandleExternallyTerminatedHost(context.Background(), "", env, h)
 	assert.True(t, terminated)
 	assert.NoError(t, err)
 

--- a/units/host_monitoring_external_termination_test.go
+++ b/units/host_monitoring_external_termination_test.go
@@ -82,7 +82,7 @@ func TestHandleExternallyTerminatedHost(t *testing.T) {
 		EvergreenSettings: testConfig,
 	}
 
-	terminated, err := HandleExternallyTerminatedHost(context.Background(), "", env, h)
+	terminated, err := handleExternallyTerminatedHost(context.Background(), "", env, h)
 	assert.True(t, terminated)
 	assert.NoError(t, err)
 

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -150,7 +150,7 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 	}
 
 	if stat.LastAttemptFailed() && stat.AllAttemptsFailed() && stat.Count >= agentPutRetries {
-		externallyTerminated, err := HandleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
+		externallyTerminated, err := handleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
 		j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
 		if externallyTerminated {
 			return

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -152,7 +152,7 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 	if stat.LastAttemptFailed() && stat.AllAttemptsFailed() && stat.Count >= agentPutRetries {
 		externallyTerminated, err := HandleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
 		j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
-		if err != nil && externallyTerminated {
+		if externallyTerminated {
 			return
 		}
 

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -151,12 +151,10 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 
 	if stat.LastAttemptFailed() && stat.AllAttemptsFailed() && stat.Count >= agentPutRetries {
 		if j.host.Provider != evergreen.ProviderNameStatic {
-			externallyTerminated, err := CheckExternallyTerminated(ctx, j.env, j.host)
+			externallyTerminated, err := CheckExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
 			if err != nil {
 				j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
 			} else if externallyTerminated {
-				j.AddError(errors.Wrapf(j.host.SetTerminated(evergreen.HostExternalUserName), "can't set host %s to terminated", j.HostID))
-				event.LogHostTerminatedExternally(j.HostID)
 				return
 			}
 		}
@@ -384,23 +382,4 @@ func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *everg
 	event.LogHostAgentDeployed(hostObj.Id)
 
 	return nil
-}
-
-func CheckExternallyTerminated(ctx context.Context, env evergreen.Environment, h *host.Host) (bool, error) {
-	settings := env.Settings()
-	cloudHost, err := cloud.GetCloudHost(ctx, h, settings)
-	if err != nil {
-		return false, errors.Wrapf(err, "error getting cloud host for host %s", h.Id)
-	}
-
-	cloudStatus, err := cloudHost.GetInstanceStatus(ctx)
-	if err != nil {
-		return false, errors.Wrapf(err, "error getting cloud status for host %s", h.Id)
-	}
-
-	if cloudStatus == cloud.StatusTerminated {
-		return true, nil
-	}
-
-	return false, nil
 }

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -174,7 +174,7 @@ func (j *agentMonitorDeployJob) hostDown() bool {
 // disableHost changes the host so that it is down and enqueues a job to
 // terminate it.
 func (j *agentMonitorDeployJob) disableHost(ctx context.Context, reason string) error {
-	externallyTerminated, err := HandleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
+	externallyTerminated, err := handleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
 	j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
 	if externallyTerminated {
 		return nil

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -174,13 +174,10 @@ func (j *agentMonitorDeployJob) hostDown() bool {
 // disableHost changes the host so that it is down and enqueues a job to
 // terminate it.
 func (j *agentMonitorDeployJob) disableHost(ctx context.Context, reason string) error {
-	if j.host.Provider != evergreen.ProviderNameStatic {
-		externallyTerminated, err := CheckExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
-		if err != nil {
-			j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
-		} else if externallyTerminated {
-			return nil
-		}
+	externallyTerminated, err := HandleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
+	j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
+	if err != nil && externallyTerminated {
+		return nil
 	}
 
 	if err := j.host.DisablePoisonedHost(reason); err != nil {

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -176,7 +176,7 @@ func (j *agentMonitorDeployJob) hostDown() bool {
 func (j *agentMonitorDeployJob) disableHost(ctx context.Context, reason string) error {
 	externallyTerminated, err := HandleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
 	j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
-	if err != nil && externallyTerminated {
+	if externallyTerminated {
 		return nil
 	}
 

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
-	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -176,13 +175,10 @@ func (j *agentMonitorDeployJob) hostDown() bool {
 // terminate it.
 func (j *agentMonitorDeployJob) disableHost(ctx context.Context, reason string) error {
 	if j.host.Provider != evergreen.ProviderNameStatic {
-		externallyTerminated, err := CheckExternallyTerminated(ctx, j.env, j.host)
+		externallyTerminated, err := CheckExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
 		if err != nil {
 			j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
 		} else if externallyTerminated {
-			j.AddError(errors.Wrapf(j.host.SetTerminated(evergreen.HostExternalUserName), "can't set host %s to terminated", j.HostID))
-			event.LogHostTerminatedExternally(j.HostID)
-			j.AddError(model.ClearAndResetStrandedTask(j.host))
 			return nil
 		}
 	}


### PR DESCRIPTION
Hosts that we can't deploy agents or agent monitors to are marked as terminated without checking if the reason we couldn't deploy to them was that the host had already been externally terminated. In the event this happens before the external termination monitor job runs we never find out the problem was external termination.
This PR is to check if hosts were externally terminated before decommissioning them.