### PR TITLE
EVG-6276: dequeue closed PRs from the commit queue

### DIFF
--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -291,7 +291,8 @@ func (s *GithubWebhookRouteSuite) TestTryDequeueCommitQueueItemForPR() {
 	s.NoError(s.h.tryDequeueCommitQueueItemForPR(pr))
 
 	// try dequeue works when an item matches
-	s.sc.EnqueueItem("bth", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("1")})
+	_, err := s.sc.EnqueueItem("bth", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("1")})
+	s.NoError(err)
 	s.NoError(s.h.tryDequeueCommitQueueItemForPR(pr))
 	queue, err := s.sc.FindCommitQueueByID("bth")
 	s.NoError(err)


### PR DESCRIPTION
When a PR is closed (merged or otherwise) Evergreen deactivates any undispatched tasks in patches running for the PR. If this happens to a PR at the head of a commit queue the version will never finish and the item will block the queue until it is manually removed.

This PR is to remove an item from the commit queue when the item's PR is closed.