### PR TITLE
EVG-6233: store task group index in tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -660,7 +660,6 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 		}
 		// get the task spec out of the project
 		taskSpec := project.GetSpecForTask(task.Name)
-
 		// sanity check that the config isn't malformed
 		if taskSpec.Name != "" {
 			task.Populate(taskSpec)
@@ -976,12 +975,12 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 		CommitQueueMerge:    buildVarTask.CommitQueueMerge,
 	}
 	if buildVarTask.IsGroup {
-		t.TaskGroup = buildVarTask.GroupName
 		tg := project.FindTaskGroup(buildVarTask.GroupName)
 		if tg == nil {
 			return nil, errors.Errorf("unable to find task group %s in project %s", buildVarTask.GroupName, project.Identifier)
 		}
-		t.TaskGroupMaxHosts = tg.MaxHosts
+
+		tg.InjectInfo(t)
 	}
 	return t, nil
 }

--- a/model/project.go
+++ b/model/project.go
@@ -1375,3 +1375,15 @@ func FetchVersionsAndAssociatedBuilds(project *Project, skip int, numVersions in
 
 	return versionsFromDB, buildsByVersion, nil
 }
+
+func (tg *TaskGroup) InjectInfo(t *task.Task) {
+	t.TaskGroup = tg.Name
+	t.TaskGroupMaxHosts = tg.MaxHosts
+
+	for idx, n := range tg.Tasks {
+		if n == t.DisplayName {
+			t.TaskGroupOrder = idx
+			break
+		}
+	}
+}

--- a/model/project.go
+++ b/model/project.go
@@ -1382,7 +1382,7 @@ func (tg *TaskGroup) InjectInfo(t *task.Task) {
 
 	for idx, n := range tg.Tasks {
 		if n == t.DisplayName {
-			t.TaskGroupOrder = idx
+			t.TaskGroupOrder = idx + 1
 			break
 		}
 	}

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1194,3 +1194,40 @@ func TestLoggerConfigValidate(t *testing.T) {
 	}
 	assert.EqualError(config.IsValid(), "invalid system logger config: Splunk logger requires a server URL\nSplunk logger requires a token")
 }
+
+func TestInjectTaskGroupInfo(t *testing.T) {
+	tg := TaskGroup{
+		Name:     "group-one",
+		MaxHosts: 42,
+		Tasks:    []string{"one", "two"},
+	}
+
+	t.Run("PopulatedFirst", func(t *testing.T) {
+		tk := &task.Task{
+			DisplayName: "one",
+		}
+
+		tg.InjectInfo(tk)
+
+		assert.Equal(t, 42, tk.TaskGroupMaxHosts)
+		assert.Equal(t, 1, tk.TaskGroupOrder)
+	})
+	t.Run("PopulatedSecond", func(t *testing.T) {
+		tk := &task.Task{
+			DisplayName: "two",
+		}
+
+		tg.InjectInfo(tk)
+
+		assert.Equal(t, 42, tk.TaskGroupMaxHosts)
+		assert.Equal(t, 2, tk.TaskGroupOrder)
+	})
+	t.Run("Missed", func(t *testing.T) {
+		tk := &task.Task{}
+
+		tg.InjectInfo(tk)
+
+		assert.Equal(t, 42, tk.TaskGroupMaxHosts)
+		assert.Equal(t, 0, tk.TaskGroupOrder)
+	})
+}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -62,6 +62,8 @@ var (
 	ExecutionTasksKey       = bsonutil.MustHaveTag(Task{}, "ExecutionTasks")
 	DisplayOnlyKey          = bsonutil.MustHaveTag(Task{}, "DisplayOnly")
 	TaskGroupKey            = bsonutil.MustHaveTag(Task{}, "TaskGroup")
+	TaskGroupMaxHostsKey    = bsonutil.MustHaveTag(Task{}, "TaskGroupMaxHosts")
+	TaskGroupOrderKey       = bsonutil.MustHaveTag(Task{}, "TaskGroupOrder")
 	GenerateTaskKey         = bsonutil.MustHaveTag(Task{}, "GenerateTask")
 	GeneratedTasksKey       = bsonutil.MustHaveTag(Task{}, "GeneratedTasks")
 	GeneratedByKey          = bsonutil.MustHaveTag(Task{}, "GeneratedBy")

--- a/model/task/sorter.go
+++ b/model/task/sorter.go
@@ -22,6 +22,14 @@ func (t Tasks) getPayload() []interface{} {
 	return payload
 }
 
+func (t Tasks) Export() []Task {
+	out := make([]Task, len(t))
+	for idx := range t {
+		out[idx] = *t[idx]
+	}
+	return out
+}
+
 func (t Tasks) Insert() error {
 	return db.InsertMany(Collection, t.getPayload()...)
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1754,7 +1754,10 @@ func (t *Task) UpdateDependencies(dependsOn []Dependency) error {
 	return nil
 }
 
-func (t *Task) SetTaskGroupIndex(idx int) error {
-	t.TaskGroupOrder = idx
-	return errors.WithStack(UpdateOne(bson.M{IdKey: t.Id}, bson.M{"$set": bson.M{TaskGroupOrderKey: idx}}))
+func (t *Task) SetTaskGroupInfo() error {
+	return errors.WithStack(UpdateOne(bson.M{IdKey: t.Id},
+		bson.M{"$set": bson.M{
+			TaskGroupOrderKey:    t.TaskGroupOrder,
+			TaskGroupMaxHostsKey: t.TaskGroupMaxHosts,
+		}}))
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -76,6 +76,7 @@ type Task struct {
 	Priority          int64               `bson:"priority" json:"priority"`
 	TaskGroup         string              `bson:"task_group" json:"task_group"`
 	TaskGroupMaxHosts int                 `bson:"task_group_max_hosts,omitempty" json:"task_group_max_hosts,omitempty"`
+	TaskGroupOrder    int                 `bson:"task_group_order,omitempty" json:"task_group_order,omitempty"`
 	Logs              *apimodels.TaskLogs `bson:"logs,omitempty" json:"logs,omitempty"`
 
 	// only relevant if the task is runnin.  the time of the last heartbeat

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1753,3 +1753,8 @@ func (t *Task) UpdateDependencies(dependsOn []Dependency) error {
 
 	return nil
 }
+
+func (t *Task) SetTaskGroupIndex(idx int) error {
+	t.TaskGroupOrder = idx
+	return errors.WithStack(UpdateOne(bson.M{IdKey: t.Id}, bson.M{"$set": bson.M{TaskGroupOrderKey: idx}}))
+}

--- a/scheduler/setup_funcs.go
+++ b/scheduler/setup_funcs.go
@@ -47,7 +47,7 @@ OUTERLOOP:
 				if g.Name == t.TaskGroup {
 					for idx, tn := range g.Tasks {
 						if t.DisplayName == tn {
-							t.SetTaskGroupIndex(idx + 1)
+							catcher.Add(t.SetTaskGroupIndex(idx + 1))
 							continue OUTERLOOP
 						}
 					}

--- a/scheduler/setup_funcs.go
+++ b/scheduler/setup_funcs.go
@@ -47,7 +47,9 @@ OUTERLOOP:
 				if g.Name == t.TaskGroup {
 					for idx, tn := range g.Tasks {
 						if t.DisplayName == tn {
-							catcher.Add(t.SetTaskGroupIndex(idx + 1))
+							t.TaskGroupOrder = idx + 1
+							t.TaskGroupMaxHosts = g.MaxHosts
+							catcher.Add(t.SetTaskGroupInfo())
 							continue OUTERLOOP
 						}
 					}

--- a/scheduler/setup_funcs.go
+++ b/scheduler/setup_funcs.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -33,6 +34,31 @@ func cacheTaskGroups(comparator *CmpBasedTaskComparator) error {
 		comparator.projects[v.Id] = p
 	}
 	return nil
+}
+
+func backfillTaskGroups(comparator *CmpBasedTaskComparator) error {
+	catcher := grip.NewBasicCatcher()
+
+OUTERLOOP:
+	for _, t := range comparator.tasks {
+		if t.TaskGroup != "" && t.TaskGroupOrder == 0 {
+			proj := comparator.projects[t.Version]
+			for _, g := range proj.TaskGroups {
+				if g.Name == t.TaskGroup {
+					for idx, tn := range g.Tasks {
+						if t.DisplayName == tn {
+							t.SetTaskGroupIndex(idx + 1)
+							continue OUTERLOOP
+						}
+					}
+					catcher.Errorf("task '%s' is missing from task group '%s' in version '%s'",
+						t.DisplayName, t.TaskGroup, t.Version)
+				}
+			}
+		}
+	}
+
+	return catcher.Resolve()
 }
 
 // groupTaskGroups puts tasks that have the same build and task group next to

--- a/scheduler/task_prioritizer.go
+++ b/scheduler/task_prioritizer.go
@@ -54,6 +54,7 @@ func NewCmpBasedTaskComparator(id string) *CmpBasedTaskComparator {
 		setupFuncs: []sortSetupFunc{
 			cacheExpectedDurations,
 			cacheTaskGroups,
+			backfillTaskGroups,
 			groupTaskGroups,
 		},
 		comparators: []taskPriorityCmp{

--- a/scheduler/task_priority_cmp_test.go
+++ b/scheduler/task_priority_cmp_test.go
@@ -279,7 +279,7 @@ task_groups:
 func TestPrioritizeTasksWithSameTaskGroupsAndDifferentBuilds(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	require.NoError(db.ClearCollections(model.VersionCollection))
+	require.NoError(db.ClearCollections(model.VersionCollection, task.Collection))
 	yml := `
 task_groups:
 - name: example_task_group
@@ -299,7 +299,7 @@ task_groups:
 	}
 	versions["version_2"] = v
 	require.NoError(v.Insert())
-	tasks := []task.Task{
+	tasks := task.Tasks{
 		{
 			Id:          "task_1",
 			BuildId:     "build_1",
@@ -333,9 +333,11 @@ task_groups:
 			TaskGroup:   "example_task_group",
 		},
 	}
+	require.NoError(tasks.Insert())
+
 	prioritizer := &CmpBasedTaskPrioritizer{}
-	sorted, err := prioritizer.PrioritizeTasks("distro", tasks, versions)
-	assert.NoError(err)
+	sorted, err := prioritizer.PrioritizeTasks("distro", tasks.Export(), versions)
+	require.NoError(err)
 	assert.Equal("task_2", sorted[0].Id)
 	assert.Equal("task_3", sorted[1].Id)
 	assert.Equal("task_4", sorted[2].Id)


### PR DESCRIPTION
(going to write a test, in the model package of the new method on TaskGroup, but I want to run through the existing suites)