### PR TITLE
EVG-6333 improve commit-queue list

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-06-12"
+	ClientVersion = "2019-07-11"
 )
 
 // ConfigSection defines a sub-document in the evegreen config

--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -26,6 +26,7 @@ func (m *Module) UnmarshalBSON(in []byte) error { return mgobson.Unmarshal(in, m
 
 type CommitQueueItem struct {
 	Issue   string   `bson:"issue"`
+	Version string   `bson:"version,omitempty"`
 	Modules []Module `bson:"modules"`
 }
 
@@ -86,6 +87,10 @@ func (q *CommitQueue) Remove(issue string) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+func (q *CommitQueue) UpdateVersion(item CommitQueueItem) error {
+	return errors.Wrapf(addVersionID(q.ProjectID, item), "error updating version")
 }
 
 func (q *CommitQueue) FindItem(issue string) int {

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -62,6 +62,23 @@ func (s *CommitQueueSuite) TestEnqueue() {
 	s.NotEqual(-1, dbq.FindItem("c123"))
 }
 
+func (s *CommitQueueSuite) TestUpdateVersion() {
+	_, err := s.q.Enqueue(sampleCommitQueueItem)
+	s.NoError(err)
+
+	item := s.q.Next()
+	s.Equal("c123", item.Issue)
+	s.Equal("", s.q.Next().Version)
+	item.Version = "my_version"
+	s.NoError(s.q.UpdateVersion(*item))
+	s.Equal("my_version", s.q.Next().Version)
+
+	dbq, err := FindOneId("mci")
+	s.NoError(err)
+	s.Len(dbq.Queue, 1)
+	s.Equal(item, dbq.Next())
+}
+
 func (s *CommitQueueSuite) TestNext() {
 	pos, err := s.q.Enqueue(sampleCommitQueueItem)
 	s.NoError(err)

--- a/model/commitqueue/db.go
+++ b/model/commitqueue/db.go
@@ -16,6 +16,7 @@ var (
 	QueueKey      = bsonutil.MustHaveTag(CommitQueue{}, "Queue")
 	ProcessingKey = bsonutil.MustHaveTag(CommitQueue{}, "Processing")
 	IssueKey      = bsonutil.MustHaveTag(CommitQueueItem{}, "Issue")
+	VersionKey    = bsonutil.MustHaveTag(CommitQueueItem{}, "Version")
 )
 
 func updateOne(query interface{}, update interface{}) error {
@@ -63,6 +64,17 @@ func add(id string, queue []CommitQueueItem, item CommitQueueItem) error {
 	}
 
 	return err
+}
+
+func addVersionID(id string, item CommitQueueItem) error {
+	return updateOne(
+		bson.M{
+			IdKey: id,
+			bsonutil.GetDottedKeyName(QueueKey, IssueKey): item.Issue,
+		},
+		bson.M{
+			"$set": bson.M{bsonutil.GetDottedKeyName(QueueKey, "$", VersionKey): item.Version},
+		})
 }
 
 func remove(id, issue string) error {

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -187,7 +187,7 @@ func listCommitQueue(ctx context.Context, client client.Communicator, rc *legacy
 	if err != nil {
 		return err
 	}
-	projectRef, err := rc.GetProjectRef(projectID) // rc versus ac?
+	projectRef, err := rc.GetProjectRef(projectID)
 	if err != nil {
 		return errors.Wrapf(err, "can't find project for queue id '%s'", projectID)
 	}
@@ -216,10 +216,10 @@ func listCommitQueue(ctx context.Context, client client.Communicator, rc *legacy
 
 func listPRCommitQueueItem(ctx context.Context, item restModel.APICommitQueueItem, projectRef *model.ProjectRef, uiServerHost string) {
 	prDisplay := `
-        PR # : %s
-         URL : %s
+           PR # : %s
+            URL : %s
 `
-	prDisplayVersion := "       Build : %s/version/%s"
+	prDisplayVersion := "          Build : %s/version/%s"
 
 	issue := restModel.FromAPIString(item.Issue)
 	url := fmt.Sprintf("https://github.com/%s/%s/pull/%s", projectRef.Owner, projectRef.Repo, issue)
@@ -248,10 +248,12 @@ func listCLICommitQueueItem(ctx context.Context, item restModel.APICommitQueueIt
 
 func listModules(item restModel.APICommitQueueItem) {
 	if len(item.Modules) > 0 {
-		grip.Info("\tModules:\n")
+		grip.Infof("\tModules :")
+
 		for j, module := range item.Modules {
 			grip.Infof("\t\t%d: %s (%s)\n", j+1, restModel.FromAPIString(module.Module), restModel.FromAPIString(module.Issue))
 		}
+		grip.Info("\n")
 	}
 }
 

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -98,14 +98,7 @@ func (s *CommitQueueSuite) TestListContentsForCLI() {
 	cq := &commitqueue.CommitQueue{ProjectID: "mci"}
 	s.Require().NoError(commitqueue.InsertQueue(cq))
 
-	pos, err := cq.Enqueue(commitqueue.CommitQueueItem{
-		Issue: p1.Id.Hex(),
-		Modules: []commitqueue.Module{
-			commitqueue.Module{
-				Module: "test_module",
-				Issue:  "1234",
-			},
-		}})
+	pos, err := cq.Enqueue(commitqueue.CommitQueueItem{Issue: p1.Id.Hex()})
 	s.NoError(err)
 	s.Equal(1, pos)
 	pos, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: p2.Id.Hex()})

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -98,7 +98,14 @@ func (s *CommitQueueSuite) TestListContentsForCLI() {
 	cq := &commitqueue.CommitQueue{ProjectID: "mci"}
 	s.Require().NoError(commitqueue.InsertQueue(cq))
 
-	pos, err := cq.Enqueue(commitqueue.CommitQueueItem{Issue: p1.Id.Hex()})
+	pos, err := cq.Enqueue(commitqueue.CommitQueueItem{
+		Issue: p1.Id.Hex(),
+		Modules: []commitqueue.Module{
+			commitqueue.Module{
+				Module: "test_module",
+				Issue:  "1234",
+			},
+		}})
 	s.NoError(err)
 	s.Equal(1, pos)
 	pos, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: p2.Id.Hex()})
@@ -233,7 +240,7 @@ func (s *CommitQueueSuite) TestListContentsWithModule() {
 
 	s.Contains(stringOut, "Project: mci")
 	s.Contains(stringOut, "PR # : 123")
-	s.Contains(stringOut, "Modules:")
+	s.Contains(stringOut, "Modules :")
 	s.Contains(stringOut, "1: test_module (1234)")
 	s.Contains(stringOut, "PR # : 456")
 	s.Contains(stringOut, "PR # : 789")

--- a/operations/http.go
+++ b/operations/http.go
@@ -197,7 +197,7 @@ func (ac *legacyClient) GetPatch(patchId string) (*patch.Patch, error) {
 		return nil, NewAPIError(resp)
 	}
 	apiModel := &restModel.APIPatch{}
-	if err := util.ReadJSONInto(resp.Body, apiModel); err != nil {
+	if err = util.ReadJSONInto(resp.Body, apiModel); err != nil {
 		return nil, err
 	}
 	i, err := apiModel.ToService()

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -325,7 +325,6 @@ func validatePatchSize(diff *localDiff, allowLarge bool) error {
 func getPatchDisplay(p *patch.Patch, summarize bool, uiHost string) (string, error) {
 	var out bytes.Buffer
 	var url string
-
 	if p.Activated {
 		url = uiHost + "/version/" + p.Id.Hex()
 	} else {

--- a/rest/model/commit_queue.go
+++ b/rest/model/commit_queue.go
@@ -14,6 +14,7 @@ type APICommitQueue struct {
 
 type APICommitQueueItem struct {
 	Issue   APIString   `json:"issue"`
+	Version APIString   `json:"version"`
 	Modules []APIModule `json:"modules"`
 }
 
@@ -54,6 +55,7 @@ func (item *APICommitQueueItem) BuildFromService(h interface{}) error {
 		return errors.Errorf("incorrect type '%T' when converting commit queue item", h)
 	}
 	item.Issue = ToAPIString(cqItemService.Issue)
+	item.Version = ToAPIString(cqItemService.Version)
 	for _, module := range cqItemService.Modules {
 		item.Modules = append(item.Modules, APIModule{
 			Module: ToAPIString(module.Module),
@@ -66,7 +68,8 @@ func (item *APICommitQueueItem) BuildFromService(h interface{}) error {
 
 func (item *APICommitQueueItem) ToService() (interface{}, error) {
 	serviceItem := commitqueue.CommitQueueItem{
-		Issue: FromAPIString(item.Issue),
+		Issue:   FromAPIString(item.Issue),
+		Version: FromAPIString(item.Version),
 	}
 	for _, module := range item.Modules {
 		serviceModule := commitqueue.Module{

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -68,8 +68,8 @@ func TestAPIPatch(t *testing.T) {
 	assert.Equal(p.Version, FromAPIString(a.Version))
 	assert.Equal(p.Status, FromAPIString(a.Status))
 	assert.Zero(time.Time(a.CreateTime).Sub(p.CreateTime))
-	assert.Equal(-time.Hour, time.Time(a.StartTime).Sub(p.StartTime))
-	assert.Equal(-2*time.Hour, time.Time(a.FinishTime).Sub(p.FinishTime))
+	assert.Equal(-time.Hour, time.Time(a.CreateTime).Sub(p.StartTime))
+	assert.Equal(-2*time.Hour, time.Time(a.CreateTime).Sub(p.FinishTime))
 	for i, variant := range a.Variants {
 		assert.Equal(p.BuildVariants[i], FromAPIString(variant))
 	}

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -131,7 +131,6 @@ func getPatchFromRequest(r *http.Request) (*patch.Patch, error) {
 	if existingPatch == nil {
 		return nil, errors.Errorf("no existing request with id: %v", patchIdStr)
 	}
-
 	return existingPatch, nil
 }
 

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -218,7 +218,10 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 		j.dequeue(cq, nextItem)
 		j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't make patch", ""))
 	}
-
+	nextItem.Version = patchDoc.Id.Hex()
+	if err := cq.UpdateVersion(*nextItem); err != nil {
+		j.logError(err, "problem saving version", nextItem)
+	}
 	v, err := model.FinalizePatch(ctx, patchDoc, evergreen.MergeTestRequester, githubToken)
 	if err != nil {
 		j.logError(err, "can't finalize patch", nextItem)

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -219,7 +219,7 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 		j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't make patch", ""))
 	}
 	nextItem.Version = patchDoc.Id.Hex()
-	if err := cq.UpdateVersion(*nextItem); err != nil {
+	if err = cq.UpdateVersion(*nextItem); err != nil {
 		j.logError(err, "problem saving version", nextItem)
 	}
 	v, err := model.FinalizePatch(ctx, patchDoc, evergreen.MergeTestRequester, githubToken)


### PR DESCRIPTION
Example PR output:
```Project: mci
Type of queue: PR
Owner: evergreen-ci
Repo: evergreen
Queue Length: 3
1:

           PR # : 123
            URL : https://github.com/evergreen-ci/evergreen/pull/123
          Build : http://dev-evg.mongodb.com/version/my_version

	Modules :
		1: test_module (1234)

2:

           PR # : 456
            URL : https://github.com/evergreen-ci/evergreen/pull/456

```

Example CLI Output:
```Project: mci
Type of queue: CLI
Queue Length: 3
1:

	     ID : 5d2760467561cc2f577f7794
	Created : 2019-07-11 16:13:58.845 +0000 UTC
    Description : fix things
	  Build : http://dev-evg.mongodb.com/version/5d2760467561cc2f577f7794
	 Status : dispatched
      Finalized : Yes

	Modules :
		1: test_module (1234)

```
