### PR TITLE
EVG-6446 fix patch route

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -521,7 +521,7 @@ func (t TriggerDefinition) Validate(parentProject string) error {
 		return errors.Wrapf(err, "error finding upstream project %s", t.Project)
 	}
 	if upstreamProject == nil {
-		return errors.Errorf("project %s not found", t.Project)
+		return errors.Errorf("project '%s' not found", t.Project)
 	}
 	if upstreamProject.Identifier == parentProject {
 		return errors.New("a project cannot trigger itself")

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -121,6 +121,9 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 	setUpdate := bson.M{}
 	unsetUpdate := bson.M{}
 	update := bson.M{}
+	if len(projectVars.Vars) == 0 && len(projectVars.PrivateVars) == 0 && len(varsToDelete) == 0 {
+		return nil, nil
+	}
 	for key, val := range projectVars.Vars {
 		setUpdate[bsonutil.GetDottedKeyName(projectVarsMapKey, key)] = val
 	}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -333,7 +333,9 @@ func (pc *MockProjectConnector) UpdateProjectVars(projectId string, varsModel *r
 				cachedVars.Vars[key] = val
 			}
 			for key, val := range varsModel.PrivateVars {
-				cachedVars.PrivateVars[key] = val
+				if val {
+					cachedVars.PrivateVars[key] = val // don't unredact existing variables
+				}
 			}
 			for _, varToDelete := range varsModel.VarsToDelete {
 				delete(cachedVars.Vars, varToDelete)

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -489,12 +489,12 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 		VarsToDelete: varsToDelete,
 	}
 	s.NoError(s.ctx.UpdateProjectVars(projectId, &newVars))
-	s.Equal(newVars.Vars["b"], "2")
+	s.Equal(newVars.Vars["b"], "") // can't unredact previously redacted  variables
 	s.Equal(newVars.Vars["c"], "")
 	_, ok := newVars.Vars["a"]
 	s.False(ok)
 
-	s.Equal(newVars.PrivateVars["b"], false)
+	s.Equal(newVars.PrivateVars["b"], true)
 	s.Equal(newVars.PrivateVars["c"], true)
 	_, ok = newVars.PrivateVars["a"]
 	s.False(ok)

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -75,8 +75,11 @@ type APITriggerDefinition struct {
 	BuildVariantRegex APIString `json:"variant_regex"`
 	TaskRegex         APIString `json:"task_regex"`
 	Status            APIString `json:"status"`
+	DateCutoff        *int      `json:"date_cutoff"`
 	ConfigFile        APIString `json:"config_file"`
+	GenerateFile      APIString `json:"generate_file"`
 	Command           APIString `json:"command"`
+	Alias             APIString `json:"alias"`
 }
 
 type APICommitQueueParams struct {
@@ -131,6 +134,7 @@ type APIProjectRef struct {
 	Tracked              bool                 `json:"tracked"`
 	PatchingDisabled     bool                 `json:"patching_disabled"`
 	Admins               []APIString          `json:"admins"`
+	DeleteAdmins         []APIString          `json:"delete_admins,omitempty"`
 	NotifyOnBuildFailure bool                 `json:"notify_on_failure"`
 
 	Revision            APIString              `json:"revision"`
@@ -138,7 +142,7 @@ type APIProjectRef struct {
 	Aliases             []APIProjectAlias      `json:"aliases"`
 	Variables           APIProjectVars         `json:"variables"`
 	Subscriptions       []APISubscription      `json:"subscriptions"`
-	DeleteSubscriptions []APIString            `json:"delete_subscriptions"`
+	DeleteSubscriptions []APIString            `json:"delete_subscriptions,omitempty"`
 }
 
 // ToService returns a service layer ProjectRef using the data from APIProjectRef
@@ -188,7 +192,10 @@ func (p *APIProjectRef) ToService() (interface{}, error) {
 			TaskRegex:         FromAPIString(t.TaskRegex),
 			Status:            FromAPIString(t.Status),
 			ConfigFile:        FromAPIString(t.ConfigFile),
+			GenerateFile:      FromAPIString(t.GenerateFile),
 			Command:           FromAPIString(t.Command),
+			Alias:             FromAPIString(t.Alias),
+			DateCutoff:        t.DateCutoff,
 		})
 	}
 	projectRef.Triggers = triggers
@@ -250,7 +257,10 @@ func (p *APIProjectRef) BuildFromService(v interface{}) error {
 			TaskRegex:         ToAPIString(t.TaskRegex),
 			Status:            ToAPIString(t.Status),
 			ConfigFile:        ToAPIString(t.ConfigFile),
+			GenerateFile:      ToAPIString(t.GenerateFile),
 			Command:           ToAPIString(t.Command),
+			Alias:             ToAPIString(t.Alias),
+			DateCutoff:        t.DateCutoff,
 		})
 	}
 	p.Triggers = triggers

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -108,7 +108,7 @@ func (p *APIProjectVars) ToService() (interface{}, error) {
 	}
 	return &model.ProjectVars{
 		Vars:        p.Vars,
-		PrivateVars: p.PrivateVars,
+		PrivateVars: privateVars,
 	}, nil
 }
 

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -392,7 +392,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		j := units.NewRepotrackerJob(fmt.Sprintf("catchup-%s", ts), h.projectID)
 
 		queue := evergreen.GetEnvironment().RemoteQueue()
-		if err := queue.Put(ctx, j); err != nil {
+		if err = queue.Put(ctx, j); err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "problem creating catchup job"))
 		}
 	}


### PR DESCRIPTION
Some things that were bad:

* Not all fields from Triggers were being converted.
* Admins and Triggers updates would over-write existing.
* No way to delete admins.
* Could un-redact private variables. (maybe you should still be able to do this via route, but not possible via front-end so?)
* PATCH returned only a partially updated document which was really confusing. To return the fully updated document involves doing everything in GET again basically, which doesn't seem necessary for every slight modification.