### PR TITLE
EVG-6269 omit 'empty' yamls

### DIFF
--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -314,24 +314,20 @@ func (s *GenerateSuite) TestParseProjectFromJSON() {
 	s.Contains(g.Functions, "echo-hi")
 	s.Equal("shell.exec", g.Functions["echo-hi"].List()[0].Command)
 
-	params, err := g.Functions["echo-hi"].List()[0].resolveParams()
-	s.Require().NoError(err)
-	s.Equal("echo hi", params["script"])
+	s.Require().NoError(g.Functions["echo-hi"].List()[0].resolveParams())
+	s.Equal("echo hi", g.Functions["echo-hi"].List()[0].Params["script"])
 
-	params, err = g.Functions["echo-bye"].List()[0].resolveParams()
-	s.Require().NoError(err)
-	s.Equal("echo bye", params["script"])
+	s.Require().NoError(g.Functions["echo-bye"].List()[0].resolveParams())
+	s.Equal("echo bye", g.Functions["echo-bye"].List()[0].Params["script"])
 
-	params, err = g.Functions["echo-bye"].List()[1].resolveParams()
-	s.Require().NoError(err)
-	s.Equal("echo bye again", params["script"])
+	s.Require().NoError(g.Functions["echo-bye"].List()[1].resolveParams())
+	s.Equal("echo bye again", g.Functions["echo-bye"].List()[1].Params["script"])
 
 	s.Len(g.Tasks, 1)
 	s.Equal("git.get_project", g.Tasks[0].Commands[0].Command)
 
-	params, err = g.Tasks[0].Commands[0].resolveParams()
-	s.NoError(err)
-	s.Equal("src", params["directory"])
+	s.Require().NoError(g.Tasks[0].Commands[0].resolveParams())
+	s.Equal("src", g.Tasks[0].Commands[0].Params["directory"])
 	s.Equal("echo-hi", g.Tasks[0].Commands[1].Function)
 	s.Equal("test", g.Tasks[0].Name)
 

--- a/model/project.go
+++ b/model/project.go
@@ -26,7 +26,6 @@ const (
 	// DefaultCommandType is a system configuration option that is used to
 	// differentiate between setup related commands and actual testing commands.
 	DefaultCommandType = evergreen.CommandTypeTest
-	Letters            = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 )
 
 type Project struct {
@@ -323,7 +322,7 @@ func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(interface{}) error) err
 // we maintain Params for backwards compatibility, but we read from YAML when available, as the
 // given params could be corrupted from the roundtrip
 func (c *PluginCommandConf) unmarshalParams() error {
-	if c.ParamsYAML != "" && !isEmptyYAML(c.ParamsYAML) {
+	if c.ParamsYAML != "" {
 		out := map[string]interface{}{}
 		if err := yaml.Unmarshal([]byte(c.ParamsYAML), &out); err != nil {
 			return errors.Wrapf(err, "error unmarshalling params from yaml")
@@ -339,10 +338,6 @@ func (c *PluginCommandConf) unmarshalParams() error {
 		c.ParamsYAML = string(bytes)
 	}
 	return nil
-}
-
-func isEmptyYAML(paramsYAML string) bool {
-	return !strings.ContainsAny(paramsYAML, Letters)
 }
 
 type ArtifactInstructions struct {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -109,12 +109,10 @@ type parserTask struct {
 
 func (pp *parserProject) MarshalYAML() (interface{}, error) {
 	for i, pt := range pp.Tasks {
-		for j, cmd := range pt.Commands {
-			params, err := cmd.resolveParams()
-			if err != nil {
+		for j := range pt.Commands {
+			if err := pp.Tasks[i].Commands[j].resolveParams(); err != nil {
 				return nil, errors.Wrapf(err, "error marshalling commands for task")
 			}
-			pp.Tasks[i].Commands[j].Params = params
 		}
 	}
 


### PR DESCRIPTION
While empty params maps are omitted with the omitempty tag, it doesn't work for paramsYAML as an empty marshalled paramsYAML is some variation of "| {}". Now, if paramsYAML doesn't contain any letters, we don't load Params (and similarly, if Params is empty, we don't set paramsYAML). Unrelated, there is also some minor refactoring of resolveParams.

This was tested with the server and cloud yamls. My only concern is that isEmptyYAML may be inefficient--I wanted it to not rely on Params as we may remove this variable.

(sorry if you saw weird emails about a different pull request, I pushed to the wrong branch.)