### PR TITLE
EVG-6284: log when a new agent version is deployed by the agent monitor

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -139,7 +139,10 @@ LOOP:
 			grip.Info("agent loop canceled")
 			return nil
 		case <-timer.C:
-			nextTask, err := a.comm.GetNextTask(ctx, &apimodels.GetNextTaskDetails{TaskGroup: tc.taskGroup})
+			nextTask, err := a.comm.GetNextTask(ctx, &apimodels.GetNextTaskDetails{
+				TaskGroup:     tc.taskGroup,
+				AgentRevision: evergreen.BuildRevision,
+			})
 			if err != nil {
 				// task secret doesn't match, get another task
 				if errors.Cause(err) == client.HTTPConflictError {

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -58,7 +58,8 @@ type TaskEndDetails struct {
 }
 
 type GetNextTaskDetails struct {
-	TaskGroup string `json:"task_group"`
+	TaskGroup     string `json:"task_group"`
+	AgentRevision string `json:"agent_revision"`
 }
 
 // ExpansionVars is a map of expansion variables for a project.

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -118,7 +118,7 @@ func checkHostHealth(h *host.Host) bool {
 // agentRevisionIsOld checks that the agent revision is current.
 func agentRevisionIsOld(h *host.Host) bool {
 	if h.AgentRevision != evergreen.BuildRevision {
-		grip.Info(message.Fields{
+		grip.InfoWhen(h.LegacyBootstrap(), message.Fields{
 			"message":        "agent has wrong revision, so it should exit",
 			"host_revision":  h.AgentRevision,
 			"agent_revision": evergreen.BuildRevision,
@@ -132,7 +132,6 @@ func agentRevisionIsOld(h *host.Host) bool {
 // It then acquires the lock, and with it, marks tasks as finished or inactive if aborted.
 // If the task is a patch, it will alert the users based on failures
 // It also updates the expected task duration of the task for scheduling.
-// NOTE this should eventually become the default code path.
 func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	finishTime := time.Now()
 
@@ -635,6 +634,26 @@ func handleOldAgentRevision(response apimodels.NextTaskResponse, h *host.Host, w
 			gimlet.WriteJSON(w, response)
 			return apimodels.NextTaskResponse{}, true
 		}
+
+		// Non-legacy hosts deploying agents via the agent monitor may be
+		// running an agent on the current revision, but the database host has
+		// yet to be updated.
+		if !h.LegacyBootstrap() && details.AgentRevision != h.AgentRevision {
+			if err := h.SetAgentRevision(details.AgentRevision); err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"message":       "problem updating host agent revision",
+					"operation":     "next_task",
+					"host":          h.Id,
+					"source":        "database error",
+					"host_revision": details.AgentRevision,
+					"revsision":     evergreen.BuildRevision,
+				}))
+			} else {
+				event.LogHostAgentDeployed(h.Id)
+				return response, false
+			}
+		}
+
 		if details.TaskGroup == "" {
 			if err := h.SetNeedsNewAgent(true); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -639,19 +639,19 @@ func handleOldAgentRevision(response apimodels.NextTaskResponse, h *host.Host, w
 		// running an agent on the current revision, but the database host has
 		// yet to be updated.
 		if !h.LegacyBootstrap() && details.AgentRevision != h.AgentRevision {
-			if err := h.SetAgentRevision(details.AgentRevision); err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"message":       "problem updating host agent revision",
-					"operation":     "next_task",
-					"host":          h.Id,
-					"source":        "database error",
-					"host_revision": details.AgentRevision,
-					"revsision":     evergreen.BuildRevision,
-				}))
-			} else {
+			err := h.SetAgentRevision(details.AgentRevision)
+			if err == nil {
 				event.LogHostAgentDeployed(h.Id)
 				return response, false
 			}
+			grip.Error(message.WrapError(err, message.Fields{
+				"message":       "problem updating host agent revision",
+				"operation":     "next_task",
+				"host":          h.Id,
+				"source":        "database error",
+				"host_revision": details.AgentRevision,
+				"revsision":     evergreen.BuildRevision,
+			}))
 		}
 
 		if details.TaskGroup == "" {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6284

* Agent sends its current revision with request to `GetNextTask` endpoint to handle agent monitor downloading the latest agent version instead of the agent deploy job.
* On non-legacy hosts, logs host event indicating new agent is deployed when the agent's request has up-to-date revision but the database host is outdated.