### PR TITLE
EVG-6229, EVG-6238: stop agent monitor during host health checks in API server

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -131,6 +131,8 @@ const (
 	AgentAPIVersion  = 2
 	APIRoutePrefixV2 = "/rest/v2"
 
+	AgentMonitorTag = "agent-monitor"
+
 	DegradedLoggingPercent = 10
 
 	SetupScriptName     = "setup.sh"

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -721,11 +721,13 @@ func (h *Host) JasperCommunication() bool {
 	return h.Distro.CommunicationMethod == distro.CommunicationMethodSSH || h.Distro.CommunicationMethod == distro.CommunicationMethodRPC
 }
 
-// SetNeedsAgentDeploy indicates that the host's agent needs to be deployed.
+// SetNeedsAgentDeploy indicates that the host's agent or agent monitor needs
+// to be deployed.
 func (h *Host) SetNeedsAgentDeploy(needsDeploy bool) error {
 	if h.LegacyBootstrap() {
 		return errors.Wrap(h.SetNeedsNewAgent(needsDeploy), "error setting host needs new agent")
 	}
+
 	return errors.Wrap(h.SetNeedsNewAgentMonitor(needsDeploy), "error setting host needs new agent monitor")
 }
 

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -16,6 +17,8 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/google/shlex"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/mongodb/jasper"
 	jaspercli "github.com/mongodb/jasper/cli"
 	"github.com/mongodb/jasper/rpc"
@@ -511,12 +514,48 @@ func (h *Host) StartAgentMonitorRequest(settings *evergreen.Settings) (string, e
 	}
 
 	input := jaspercli.CommandInput{
-		Commands:      [][]string{h.agentMonitorCommand(settings)},
-		CreateOptions: jasper.CreateOptions{Environment: buildAgentEnv(settings)},
-		Background:    true,
+		Commands: [][]string{h.agentMonitorCommand(settings)},
+		CreateOptions: jasper.CreateOptions{
+			Environment: buildAgentEnv(settings),
+			Tags:        []string{evergreen.AgentMonitorTag},
+		},
+		Background: true,
 	}
 
 	return h.buildLocalJasperClientRequest(settings.HostJasper, jaspercli.CreateCommand, input)
+}
+
+// StopAgentMonitor stops the agent monitor on the host via its Jasper service.
+// On legacy hosts, this is a no-op.
+func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) error {
+	if h.LegacyBootstrap() {
+		return nil
+	}
+
+	client, err := h.JasperClient(ctx, env)
+	if err != nil {
+		return errors.Wrap(err, "could not get a Jasper client")
+	}
+
+	procs, err := client.Group(ctx, evergreen.AgentMonitorTag)
+	if err != nil {
+		return errors.Wrapf(err, "could not get processes with tag %s", evergreen.AgentMonitorTag)
+	}
+
+	grip.WarningWhen(len(procs) != 1, message.Fields{
+		"message": fmt.Sprintf("host should be running exactly one agent monitor, but found %d", len(procs)),
+		"host":    h.Id,
+		"distro":  h.Distro.Id,
+	})
+
+	catcher := grip.NewBasicCatcher()
+	for _, proc := range procs {
+		if proc.Running(ctx) {
+			catcher.Add(errors.Wrapf(proc.Signal(ctx, syscall.SIGTERM), "problem signalling process with ID %s", proc.ID()))
+		}
+	}
+
+	return catcher.Resolve()
 }
 
 // agentMonitorCommand returns the slice of arguments used to start the

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -542,7 +542,7 @@ func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) 
 		return errors.Wrapf(err, "could not get processes with tag %s", evergreen.AgentMonitorTag)
 	}
 
-	grip.ErrorWhen(len(procs) != 1, message.Fields{
+	grip.WarningWhen(len(procs) != 1, message.Fields{
 		"message": fmt.Sprintf("host should be running exactly one agent monitor, but found %d", len(procs)),
 		"host":    h.Id,
 		"distro":  h.Distro.Id,
@@ -551,7 +551,7 @@ func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) 
 	catcher := grip.NewBasicCatcher()
 	for _, proc := range procs {
 		if proc.Running(ctx) {
-			catcher.Add(errors.Wrapf(proc.Signal(ctx, syscall.SIGTERM), "problem signalling process with ID %s", proc.ID()))
+			catcher.Wrapf(proc.Signal(ctx, syscall.SIGTERM), "problem signalling process with ID %s", proc.ID())
 		}
 	}
 

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -525,8 +525,8 @@ func (h *Host) StartAgentMonitorRequest(settings *evergreen.Settings) (string, e
 	return h.buildLocalJasperClientRequest(settings.HostJasper, jaspercli.CreateCommand, input)
 }
 
-// StopAgentMonitor stops the agent monitor on the host via its Jasper service.
-// On legacy hosts, this is a no-op.
+// StopAgentMonitor stops the agent monitor (if it is running) on the host via
+// its Jasper service . On legacy hosts, this is a no-op.
 func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) error {
 	if h.LegacyBootstrap() {
 		return nil
@@ -542,7 +542,7 @@ func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) 
 		return errors.Wrapf(err, "could not get processes with tag %s", evergreen.AgentMonitorTag)
 	}
 
-	grip.WarningWhen(len(procs) != 1, message.Fields{
+	grip.ErrorWhen(len(procs) != 1, message.Fields{
 		"message": fmt.Sprintf("host should be running exactly one agent monitor, but found %d", len(procs)),
 		"host":    h.Id,
 		"distro":  h.Distro.Id,

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -239,7 +239,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	if checkHostHealth(currentHost) {
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
-		if err := currentHost.StopAgentMonitor(ctx, env); err != nil {
+		if err = currentHost.StopAgentMonitor(ctx, env); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":   "problem stopping agent monitor",
 				"host":      currentHost.Id,
@@ -280,7 +280,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
-		if err := currentHost.StopAgentMonitor(ctx, env); err != nil {
+		if err = currentHost.StopAgentMonitor(ctx, env); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":   "problem stopping agent monitor",
 				"host":      currentHost.Id,
@@ -555,7 +555,7 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 		env := evergreen.GetEnvironment()
 		stopAgentMonitor = true
-		if err := h.StopAgentMonitor(ctx, env); err != nil {
+		if err = h.StopAgentMonitor(ctx, env); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":   "problem stopping agent monitor",
 				"host":      h.Id,

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -263,7 +263,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	if event.AllRecentHostEventsMatchStatus(currentHost.Id, consecutiveSystemFailureThreshold, evergreen.TaskSystemFailed) {
 		msg := "host encountered consecutive system failures"
 		if currentHost.Provider != evergreen.ProviderNameStatic {
-			err := currentHost.DisablePoisonedHost(msg)
+			err = currentHost.DisablePoisonedHost(msg)
 
 			job := units.NewDecoHostNotifyJob(env, currentHost, err, msg)
 			grip.Critical(message.WrapError(as.queue.Put(r.Context(), job),

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -298,6 +298,7 @@ func (j *agentMonitorDeployJob) agentMonitorOptions(settings *evergreen.Settings
 	return &jasper.CreateOptions{
 		Args:        agentMonitorParams,
 		Environment: j.agentEnv(settings),
+		Tags:        []string{evergreen.AgentMonitorTag},
 	}
 }
 


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/EVG-6229
https://jira.mongodb.org/browse/EVG-6238

* **EVG-6229**: If the API server does a host health check and it is not running, stop the host's agent monitor before sending response telling the agent to exit.
* **EVG-6238**: If host eventually enters the running state again. (e.g. static hosts are unquarantined), the agent monitor deploy job should automatically run because either `NeedsNewAgentMonitor` flag is set or `MaxLCTInterval` is elapsed.