### PR TITLE
EVG-6405: extra submodule

### DIFF
--- a/command/git_push.go
+++ b/command/git_push.go
@@ -96,10 +96,12 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		if modulePatch.ModuleName == "" {
 			continue
 		}
-		if len(modulePatch.PatchSet.Patch) == 0 {
+
+		if len(modulePatch.PatchSet.Summary) == 0 {
 			logger.Execution().Info("Skipping empty patch file...")
 			continue
 		}
+
 		var module *model.Module
 		module, err = conf.Project.GetModuleByName(modulePatch.ModuleName)
 		if err != nil {
@@ -136,7 +138,8 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		if modulePatch.ModuleName != "" {
 			continue
 		}
-		if len(modulePatch.PatchSet.Patch) == 0 {
+
+		if len(modulePatch.PatchSet.Summary) == 0 {
 			logger.Execution().Info("Skipping empty patch file...")
 			continue
 		}

--- a/command/git_push.go
+++ b/command/git_push.go
@@ -84,6 +84,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 	if err != nil {
 		return errors.Wrapf(err, "can't get author information for user '%s'", p.Author)
 	}
+
 	params := pushParams{
 		authorName:  restModel.FromAPIString(u.DisplayName),
 		authorEmail: restModel.FromAPIString(u.Email),
@@ -95,7 +96,10 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		if modulePatch.ModuleName == "" {
 			continue
 		}
-
+		if len(modulePatch.PatchSet.Patch) == 0 {
+			logger.Execution().Info("Skipping empty patch file...")
+			continue
+		}
 		var module *model.Module
 		module, err = conf.Project.GetModuleByName(modulePatch.ModuleName)
 		if err != nil {
@@ -115,17 +119,40 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		logger.Execution().Infof("Pushing patch for module %s", module.Name)
 		params.directory = filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory, moduleBase))
 		params.branch = module.Branch
+
+		// File list
+		params.files = make([]string, 0, len(modulePatch.PatchSet.Summary))
+		for _, summary := range modulePatch.PatchSet.Summary {
+			params.files = append(params.files, summary.Name)
+		}
+
 		if err = c.pushPatch(ctx, logger, params); err != nil {
 			return errors.Wrap(err, "can't push module patch")
 		}
 	}
 
 	// Push main patch
-	logger.Execution().Info("Pushing patch")
-	params.directory = filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory))
-	params.branch = conf.ProjectRef.Branch
-	if err = c.pushPatch(ctx, logger, params); err != nil {
-		return errors.Wrap(err, "can't push patch")
+	for _, modulePatch := range p.Patches {
+		if modulePatch.ModuleName != "" {
+			continue
+		}
+		if len(modulePatch.PatchSet.Patch) == 0 {
+			logger.Execution().Info("Skipping empty patch file...")
+			continue
+		}
+
+		// File list
+		params.files = make([]string, 0, len(modulePatch.PatchSet.Summary))
+		for _, summary := range modulePatch.PatchSet.Summary {
+			params.files = append(params.files, summary.Name)
+		}
+
+		logger.Execution().Info("Pushing patch")
+		params.directory = filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory))
+		params.branch = conf.ProjectRef.Branch
+		if err = c.pushPatch(ctx, logger, params); err != nil {
+			return errors.Wrap(err, "can't push patch")
+		}
 	}
 
 	return nil
@@ -137,9 +164,16 @@ type pushParams struct {
 	authorEmail string
 	description string
 	branch      string
+	files       []string
 }
 
 func (c *gitPush) pushPatch(ctx context.Context, logger client.LoggerProducer, p pushParams) error {
+	commands := []string{}
+	for _, file := range p.files {
+		commands = append(commands, `git add "%s"`, file)
+		logger.Execution().Debugf(`git add "%s"`, file)
+	}
+
 	author := fmt.Sprintf("%s <%s>", p.authorName, p.authorEmail)
 	commitCommand := fmt.Sprintf("git "+
 		`-c "user.name=%s" `+
@@ -148,11 +182,7 @@ func (c *gitPush) pushPatch(ctx context.Context, logger client.LoggerProducer, p
 		`--author="%s"`,
 		c.CommitterName, c.CommitterEmail, p.description, author)
 	logger.Execution().Debugf("git commit command: %s", commitCommand)
-
-	commands := []string{
-		"git add -A",
-		commitCommand,
-	}
+	commands = append(commands, commitCommand)
 
 	if !c.DryRun {
 		pushCommand := fmt.Sprintf("git push origin %s", p.branch)

--- a/command/git_push.go
+++ b/command/git_push.go
@@ -98,7 +98,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		}
 
 		if len(modulePatch.PatchSet.Summary) == 0 {
-			logger.Execution().Info("Skipping empty patch file...")
+			logger.Execution().Infof("Skipping empty patch for module '%s'", modulePatch.ModuleName)
 			continue
 		}
 
@@ -140,7 +140,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		}
 
 		if len(modulePatch.PatchSet.Summary) == 0 {
-			logger.Execution().Info("Skipping empty patch file...")
+			logger.Execution().Info("Skipping empty main patch")
 			continue
 		}
 

--- a/command/git_push.go
+++ b/command/git_push.go
@@ -98,7 +98,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		}
 
 		if len(modulePatch.PatchSet.Summary) == 0 {
-			logger.Execution().Infof("Skipping empty patch for module '%s'", modulePatch.ModuleName)
+			logger.Execution().Infof("Skipping empty patch for module '%s' on patch ID '%s'", modulePatch.ModuleName, p.Id.Hex())
 			continue
 		}
 
@@ -140,7 +140,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		}
 
 		if len(modulePatch.PatchSet.Summary) == 0 {
-			logger.Execution().Info("Skipping empty main patch")
+			logger.Execution().Infof("Skipping empty main patch on patch id '%s'", p.Id.Hex())
 			continue
 		}
 

--- a/command/git_push.go
+++ b/command/git_push.go
@@ -173,7 +173,7 @@ type pushParams struct {
 func (c *gitPush) pushPatch(ctx context.Context, logger client.LoggerProducer, p pushParams) error {
 	commands := []string{}
 	for _, file := range p.files {
-		commands = append(commands, `git add "%s"`, file)
+		commands = append(commands, fmt.Sprintf(`git add "%s"`, file))
 		logger.Execution().Debugf(`git add "%s"`, file)
 	}
 

--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -25,12 +25,13 @@ func TestGitPush(t *testing.T) {
 	logger, err := comm.GetLoggerProducer(context.Background(), client.TaskData{}, nil)
 	require.NoError(t, err)
 
+	var splitCommand []string
 	for name, test := range map[string]func(*testing.T){
 		"Execute": func(*testing.T) {
 			manager := &jasper.MockManager{}
 			c.base.jasper = manager
 			manager.Create = func(opts *jasper.CreateOptions) jasper.MockProcess {
-				_, err := opts.Output.Output.Write([]byte("abcdef01345"))
+				_, err = opts.Output.Output.Write([]byte("abcdef01345"))
 				assert.NoError(t, err)
 				proc := jasper.MockProcess{}
 				proc.ProcInfo.Options = *opts
@@ -67,7 +68,7 @@ func TestGitPush(t *testing.T) {
 			require.Len(t, manager.Procs, len(commands))
 			for i, proc := range manager.Procs {
 				args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
-				splitCommand, err := shlex.Split(commands[i])
+				splitCommand, err = shlex.Split(commands[i])
 				assert.NoError(t, err)
 				assert.Equal(t, splitCommand, args)
 			}
@@ -93,7 +94,7 @@ func TestGitPush(t *testing.T) {
 			require.Len(t, manager.Procs, len(commands))
 			for i, proc := range manager.Procs {
 				args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
-				splitCommand, err := shlex.Split(commands[i])
+				splitCommand, err = shlex.Split(commands[i])
 				assert.NoError(t, err)
 				assert.Equal(t, splitCommand, args)
 			}
@@ -108,7 +109,7 @@ func TestGitPush(t *testing.T) {
 			require.Len(t, manager.Procs, len(commands))
 			for i, proc := range manager.Procs {
 				args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
-				splitCommand, err := shlex.Split(commands[i])
+				splitCommand, err = shlex.Split(commands[i])
 				assert.NoError(t, err)
 				assert.Equal(t, splitCommand, args)
 			}

--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -1,0 +1,79 @@
+package command
+
+import (
+	"context"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/google/shlex"
+	"github.com/mongodb/jasper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPushPatch(t *testing.T) {
+	manager := &jasper.MockManager{}
+	c := gitPush{
+		base:           base{jasper: manager},
+		Directory:      "src",
+		CommitterName:  "octocat",
+		CommitterEmail: "octocat@github.com",
+	}
+
+	comm := client.NewMock("http://localhost.com")
+	conf := &model.TaskConfig{Expansions: &util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
+	logger, err := comm.GetLoggerProducer(context.Background(), client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+	assert.NoError(t, err)
+
+	params := pushParams{
+		directory:   c.Directory,
+		authorName:  "baxterthehacker",
+		authorEmail: "baxter@thehacker.com",
+		files:       []string{"hello.txt"},
+		description: "testing 123",
+		branch:      "master",
+	}
+
+	assert.NoError(t, c.pushPatch(context.Background(), logger, params))
+	commands := []string{
+		`git add "hello.txt"`,
+		`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit -m "testing 123" --author="baxterthehacker <baxter@thehacker.com>"`,
+		"git push origin master",
+	}
+	assert.Len(t, manager.Procs, len(commands))
+	for i, proc := range manager.Procs {
+		args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
+		splitCommand, err := shlex.Split(commands[i])
+		assert.NoError(t, err)
+		assert.Equal(t, splitCommand, args)
+	}
+}
+
+func TestRevParse(t *testing.T) {
+	manager := &jasper.MockManager{}
+	c := gitPush{
+		base:           base{jasper: manager},
+		Directory:      "src",
+		CommitterName:  "octocat",
+		CommitterEmail: "octocat@github.com",
+	}
+
+	comm := client.NewMock("http://localhost.com")
+	conf := &model.TaskConfig{Expansions: &util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
+	logger, err := comm.GetLoggerProducer(context.Background(), client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+	assert.NoError(t, err)
+
+	_, err = c.revParse(context.Background(), conf, logger, "HEAD")
+	assert.NoError(t, err)
+	commands := []string{"git rev-parse HEAD"}
+
+	assert.Len(t, manager.Procs, len(commands))
+	for i, proc := range manager.Procs {
+		args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
+		splitCommand, err := shlex.Split(commands[i])
+		assert.NoError(t, err)
+		assert.Equal(t, splitCommand, args)
+	}
+}

--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -11,127 +11,109 @@ import (
 	"github.com/google/shlex"
 	"github.com/mongodb/jasper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestExecuteGitPush(t *testing.T) {
-	manager := &jasper.MockManager{
-		Create: func(opts *jasper.CreateOptions) jasper.MockProcess {
-			_, err := opts.Output.Output.Write([]byte("abcdef01345"))
-			assert.NoError(t, err)
-			proc := jasper.MockProcess{}
-			proc.ProcInfo.Options = *opts
-			return proc
-		},
-	}
+func TestGitPush(t *testing.T) {
 	c := gitPush{
-		base:           base{jasper: manager},
 		Directory:      "src",
 		CommitterName:  "octocat",
 		CommitterEmail: "octocat@github.com",
 	}
-
 	comm := client.NewMock("http://localhost.com")
 	conf := &model.TaskConfig{Task: &task.Task{}, ProjectRef: &model.ProjectRef{Branch: "master"}}
 	logger, err := comm.GetLoggerProducer(context.Background(), client.TaskData{}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	patch := &patch.Patch{
-		Patches: []patch.ModulePatch{
-			{
-				ModuleName: "",
-				PatchSet: patch.PatchSet{
-					Summary: []patch.Summary{
-						{
-							Name: "hello.txt",
+	for name, test := range map[string]func(*testing.T){
+		"Execute": func(*testing.T) {
+			manager := &jasper.MockManager{}
+			c.base.jasper = manager
+			manager.Create = func(opts *jasper.CreateOptions) jasper.MockProcess {
+				_, err := opts.Output.Output.Write([]byte("abcdef01345"))
+				assert.NoError(t, err)
+				proc := jasper.MockProcess{}
+				proc.ProcInfo.Options = *opts
+				return proc
+			}
+			patch := &patch.Patch{
+				Patches: []patch.ModulePatch{
+					{
+						ModuleName: "",
+						PatchSet: patch.PatchSet{
+							Summary: []patch.Summary{
+								{
+									Name: "hello.txt",
+								},
+							},
 						},
 					},
 				},
-			},
+				Githash:     "abcdef01345",
+				Description: "testing 123",
+			}
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, "patch", patch)
+			assert.NoError(t, c.Execute(ctx, comm, logger, conf))
+
+			commands := []string{
+				"git checkout master",
+				"git rev-parse HEAD",
+				`git add "hello.txt"`,
+				`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit -m "testing 123" --author="evergreen <evergreen@mongodb.com>"`,
+				"git push origin master",
+			}
+
+			require.Len(t, manager.Procs, len(commands))
+			for i, proc := range manager.Procs {
+				args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
+				splitCommand, err := shlex.Split(commands[i])
+				assert.NoError(t, err)
+				assert.Equal(t, splitCommand, args)
+			}
 		},
-		Githash:     "abcdef01345",
-		Description: "testing 123",
-	}
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, "patch", patch)
-	assert.NoError(t, c.Execute(ctx, comm, logger, conf))
+		"PushPatch": func(*testing.T) {
+			manager := &jasper.MockManager{}
+			c.base.jasper = manager
+			params := pushParams{
+				directory:   c.Directory,
+				authorName:  "baxterthehacker",
+				authorEmail: "baxter@thehacker.com",
+				files:       []string{"hello.txt"},
+				description: "testing 123",
+				branch:      "master",
+			}
 
-	commands := []string{
-		"git checkout master",
-		"git rev-parse HEAD",
-		`git add "hello.txt"`,
-		`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit -m "testing 123" --author="evergreen <evergreen@mongodb.com>"`,
-		"git push origin master",
-	}
+			assert.NoError(t, c.pushPatch(context.Background(), logger, params))
+			commands := []string{
+				`git add "hello.txt"`,
+				`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit -m "testing 123" --author="baxterthehacker <baxter@thehacker.com>"`,
+				"git push origin master",
+			}
+			require.Len(t, manager.Procs, len(commands))
+			for i, proc := range manager.Procs {
+				args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
+				splitCommand, err := shlex.Split(commands[i])
+				assert.NoError(t, err)
+				assert.Equal(t, splitCommand, args)
+			}
+		},
+		"RevParse": func(*testing.T) {
+			manager := &jasper.MockManager{}
+			c.base.jasper = manager
+			_, err = c.revParse(context.Background(), conf, logger, "HEAD")
+			assert.NoError(t, err)
+			commands := []string{"git rev-parse HEAD"}
 
-	assert.Len(t, manager.Procs, len(commands))
-	for i, proc := range manager.Procs {
-		args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
-		splitCommand, err := shlex.Split(commands[i])
-		assert.NoError(t, err)
-		assert.Equal(t, splitCommand, args)
-	}
-}
-
-func TestPushPatch(t *testing.T) {
-	manager := &jasper.MockManager{}
-	c := gitPush{
-		base:           base{jasper: manager},
-		Directory:      "src",
-		CommitterName:  "octocat",
-		CommitterEmail: "octocat@github.com",
-	}
-
-	comm := client.NewMock("http://localhost.com")
-	logger, err := comm.GetLoggerProducer(context.Background(), client.TaskData{}, nil)
-	assert.NoError(t, err)
-
-	params := pushParams{
-		directory:   c.Directory,
-		authorName:  "baxterthehacker",
-		authorEmail: "baxter@thehacker.com",
-		files:       []string{"hello.txt"},
-		description: "testing 123",
-		branch:      "master",
-	}
-
-	assert.NoError(t, c.pushPatch(context.Background(), logger, params))
-	commands := []string{
-		`git add "hello.txt"`,
-		`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit -m "testing 123" --author="baxterthehacker <baxter@thehacker.com>"`,
-		"git push origin master",
-	}
-	assert.Len(t, manager.Procs, len(commands))
-	for i, proc := range manager.Procs {
-		args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
-		splitCommand, err := shlex.Split(commands[i])
-		assert.NoError(t, err)
-		assert.Equal(t, splitCommand, args)
-	}
-}
-
-func TestRevParse(t *testing.T) {
-	manager := &jasper.MockManager{}
-	c := gitPush{
-		base:           base{jasper: manager},
-		Directory:      "src",
-		CommitterName:  "octocat",
-		CommitterEmail: "octocat@github.com",
-	}
-
-	comm := client.NewMock("http://localhost.com")
-	conf := &model.TaskConfig{Project: &model.Project{}}
-	logger, err := comm.GetLoggerProducer(context.Background(), client.TaskData{}, nil)
-	assert.NoError(t, err)
-
-	_, err = c.revParse(context.Background(), conf, logger, "HEAD")
-	assert.NoError(t, err)
-	commands := []string{"git rev-parse HEAD"}
-
-	assert.Len(t, manager.Procs, len(commands))
-	for i, proc := range manager.Procs {
-		args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
-		splitCommand, err := shlex.Split(commands[i])
-		assert.NoError(t, err)
-		assert.Equal(t, splitCommand, args)
+			require.Len(t, manager.Procs, len(commands))
+			for i, proc := range manager.Procs {
+				args := proc.(*jasper.MockProcess).ProcInfo.Options.Args
+				splitCommand, err := shlex.Split(commands[i])
+				assert.NoError(t, err)
+				assert.Equal(t, splitCommand, args)
+			}
+		},
+	} {
+		t.Run(name, test)
 	}
 }

--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -16,7 +16,8 @@ import (
 func TestExecuteGitPush(t *testing.T) {
 	manager := &jasper.MockManager{
 		Create: func(opts *jasper.CreateOptions) jasper.MockProcess {
-			opts.Output.Output.Write([]byte("abcdef01345"))
+			_, err := opts.Output.Output.Write([]byte("abcdef01345"))
+			assert.NoError(t, err)
 			proc := jasper.MockProcess{}
 			proc.ProcInfo.Options = *opts
 			return proc

--- a/command/git_test.go
+++ b/command/git_test.go
@@ -609,7 +609,7 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 
 func (s *GitGetProjectSuite) TestCorrectModuleRevision() {
 	conf := s.modelData2.TaskConfig
-	ctx := context.WithValue(context.Background(), "githash", "b27779f856b211ffaf97cbc124b7082a20ea8bc0")
+	ctx := context.WithValue(context.Background(), "patch", &patch.Patch{Githash: "b27779f856b211ffaf97cbc124b7082a20ea8bc0"})
 	comm := client.NewMock("http://localhost.com")
 	logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
 	s.NoError(err)

--- a/command/git_test.go
+++ b/command/git_test.go
@@ -609,7 +609,14 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 
 func (s *GitGetProjectSuite) TestCorrectModuleRevision() {
 	conf := s.modelData2.TaskConfig
-	ctx := context.WithValue(context.Background(), "patch", &patch.Patch{Githash: "b27779f856b211ffaf97cbc124b7082a20ea8bc0"})
+	ctx := context.WithValue(context.Background(), "patch", &patch.Patch{
+		Patches: []patch.ModulePatch{
+			{
+				ModuleName: "sample",
+				Githash:    "b27779f856b211ffaf97cbc124b7082a20ea8bc0",
+			},
+		},
+	})
 	comm := client.NewMock("http://localhost.com")
 	logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
 	s.NoError(err)

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -324,14 +324,12 @@ func (c *Mock) GetPatchFile(ctx context.Context, td TaskData, patchFileID string
 }
 
 func (c *Mock) GetTaskPatch(ctx context.Context, td TaskData) (*patchmodel.Patch, error) {
-	val, _ := ctx.Value("githash").(string)
-	p := &patchmodel.Patch{}
-	if val != "" {
-		p.Patches = []patchmodel.ModulePatch{
-			{ModuleName: "sample", Githash: val},
-		}
+	patch, ok := ctx.Value("patch").(*patchmodel.Patch)
+	if !ok {
+		return &patchmodel.Patch{}, nil
 	}
-	return p, nil
+
+	return patch, nil
 }
 
 // GetHostsByUser will return an array with a single mock host


### PR DESCRIPTION
Since modules can be (and often are) cloned within another repo, when the commit queue would `git add -A ` in the super-repo it would also add the module as a subproject.
This PR gets around this by specifying the files to add based on the patch summary stored in the patch.
Another bug fixed by this PR is that when there were only changes to the module the commit queue would nonetheless create an empty commit on the main repo. Now we check if the patch is empty before pushing a commit.