### PR TITLE
EVG-6473: handle arbitrary commit messages

### DIFF
--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -61,7 +61,7 @@ func TestGitPush(t *testing.T) {
 				"git checkout master",
 				"git rev-parse HEAD",
 				`git add "hello.txt"`,
-				`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit -m "testing 123" --author="evergreen <evergreen@mongodb.com>"`,
+				`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit --file - --author="evergreen <evergreen@mongodb.com>"`,
 				"git push origin master",
 			}
 
@@ -88,7 +88,7 @@ func TestGitPush(t *testing.T) {
 			assert.NoError(t, c.pushPatch(context.Background(), logger, params))
 			commands := []string{
 				`git add "hello.txt"`,
-				`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit -m "testing 123" --author="baxterthehacker <baxter@thehacker.com>"`,
+				`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit --file - --author="baxterthehacker <baxter@thehacker.com>"`,
 				"git push origin master",
 			}
 			require.Len(t, manager.Procs, len(commands))

--- a/model/repository_test.go
+++ b/model/repository_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -58,6 +59,7 @@ func TestGetNewRevisionOrderNumber(t *testing.T) {
 }
 
 func TestUpdateLastRevision(t *testing.T) {
+	require.NoError(t, db.Clear(RepositoriesCollection))
 	for name, test := range map[string]func(*testing.T, string, string){
 		"InvalidProject": func(t *testing.T, project string, revision string) {
 			assert.Error(t, UpdateLastRevision(project, revision))

--- a/model/repository_test.go
+++ b/model/repository_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -59,7 +58,6 @@ func TestGetNewRevisionOrderNumber(t *testing.T) {
 }
 
 func TestUpdateLastRevision(t *testing.T) {
-	require.NoError(t, db.Clear(RepositoriesCollection))
 	for name, test := range map[string]func(*testing.T, string, string){
 		"InvalidProject": func(t *testing.T, project string, revision string) {
 			assert.Error(t, UpdateLastRevision(project, revision))


### PR DESCRIPTION
Pass the commit message through stdin with the `--file -` option.
I wanted to avoid passing the message to stdin of every git command, so I split up the commands.