### PR TITLE
EVG-6327 truncate filenames without modifying extensions

### DIFF
--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -471,12 +471,13 @@ func fileNameWithIndex(filename string, index int) string {
 func truncateFilename(fileName string) string {
 	if len(fileName) > fileNameMaxLength {
 		parts := strings.Split(fileName, ".")
-		if len(parts) > 0 {
-			toTruncate := len(fileName) - fileNameMaxLength
-			newEndIdx := len(parts[0]) - toTruncate
-			parts[0] = parts[0][0:newEndIdx]
-			fileName = strings.Join(parts, ".")
+		if len(parts) == 0 {
+			return fileName
 		}
+		toTruncate := len(fileName) - fileNameMaxLength
+		newEndIdx := len(parts[0]) - toTruncate
+		parts[0] = parts[0][0:newEndIdx]
+		fileName = strings.Join(parts, ".")
 	}
 	return fileName
 }

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -29,6 +29,7 @@ import (
 )
 
 const defaultCloneDepth = 500
+const fileNameMaxLength = 250
 
 func Fetch() cli.Command {
 	const (
@@ -63,7 +64,7 @@ func Fetch() cli.Command {
 			},
 			cli.BoolFlag{
 				Name:  artifactsFlagName,
-				Usage: "fetch artifats for the task and all of its recursive dependents",
+				Usage: "fetch artifacts for the task and all of its recursive dependents",
 			},
 			cli.BoolFlag{
 				Name:  shallowFlagName,
@@ -466,6 +467,20 @@ func fileNameWithIndex(filename string, index int) string {
 	return fmt.Sprintf("%s_(%d).%s", parts[0], index-1, strings.Join(parts[1:], "."))
 }
 
+// truncateFilename truncates the filename (minus any extensions) so the entire filename length is less than the max
+func truncateFilename(fileName string) string {
+	if len(fileName) > fileNameMaxLength {
+		parts := strings.Split(fileName, ".")
+		if len(parts) > 0 {
+			toTruncate := len(fileName) - fileNameMaxLength
+			newEndIdx := len(parts[0]) - toTruncate
+			parts[0] = parts[0][0:newEndIdx]
+			fileName = strings.Join(parts, ".")
+		}
+	}
+	return fileName
+}
+
 // downloadUrls pulls a set of artifacts from the given channel and downloads them, using up to
 // the given number of workers in parallel. The given root directory determines the base location
 // where all the artifact files will be downloaded to.
@@ -506,10 +521,7 @@ func downloadUrls(root string, urls chan artifactDownload, workers int) error {
 					}
 				}
 
-				fileName := filepath.Join(folder, justFile)
-				if len(fileName) > 250 {
-					fileName = fileName[0:249]
-				}
+				fileName := truncateFilename(filepath.Join(folder, justFile))
 				fileNamesUsed.Lock()
 				for {
 					fileNamesUsed.nameCounts[fileName]++

--- a/operations/fetch_test.go
+++ b/operations/fetch_test.go
@@ -3,6 +3,7 @@ package operations
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -70,4 +71,14 @@ func runCloneTest(t *testing.T, opts cloneOptions, pass bool) {
 		return
 	}
 	assert.NoError(t, clone(opts))
+}
+
+func TestTruncateName(t *testing.T) {
+	fileName := strings.Repeat("a", 300) + ".tar.gz"
+	newName := truncateFilename(fileName)
+	assert.NotEqual(t, newName, fileName)
+	assert.Len(t, newName, 250)
+	assert.Equal(t, strings.Repeat("a", 243)+".tar.gz", newName)
+
+	assert.Equal(t, newName, truncateFilename(newName))
 }


### PR DESCRIPTION
We still need to truncate filenames (see EVG-5649) but we should not truncate file extensions, because then users cannot download the files without renaming.