### PR TITLE
EVG-6511: use distro-based home directory instead of '~' for all commands

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (h *Host) SetupCommand() string {
-	cmd := fmt.Sprintf("%s host setup", filepath.Join("~", h.Distro.BinaryName()))
+	cmd := fmt.Sprintf("%s host setup", filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()))
 
 	if h.Distro.SetupAsSudo {
 		cmd += " --setup_as_sudo"
@@ -38,7 +38,7 @@ func (h *Host) SetupCommand() string {
 
 // TearDownCommand returns a command for running a teardown script on a host.
 func (h *Host) TearDownCommand() string {
-	return fmt.Sprintf("%s host teardown", filepath.Join("~", h.Distro.BinaryName()))
+	return fmt.Sprintf("%s host teardown", filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()))
 }
 
 // TearDownCommandOverSSH returns a command for running a teardown script on a host. This command
@@ -82,7 +82,8 @@ func (h *Host) CurlCommandWithRetry(settings *evergreen.Settings, numRetries, ma
 	if numRetries != 0 && maxRetrySecs != 0 {
 		retryArgs = " " + curlRetryArgs(numRetries, maxRetrySecs)
 	}
-	return fmt.Sprintf("cd ~ && curl -LO '%s'%s && chmod +x %s",
+	return fmt.Sprintf("cd %s && curl -LO '%s'%s && chmod +x %s",
+		h.Distro.HomeDir(),
 		h.ClientURL(settings),
 		retryArgs,
 		h.Distro.BinaryName(),
@@ -258,12 +259,6 @@ func (h *Host) RestartJasperCommand(config evergreen.HostJasperConfig) string {
 func (h *Host) jasperServiceCommand(config evergreen.HostJasperConfig, subCmd string, args ...string) string {
 	cmd := append(jaspercli.BuildServiceCommand(h.jasperBinaryFilePath(config)), subCmd, jaspercli.RPCService)
 	cmd = append(cmd, args...)
-	// cmd := fmt.Sprintf("%s %s %s %s",
-	//     strings.Join(jaspercli.BuildServiceCommand(h.jasperBinaryFilePath(config)), " "),
-	//     subCmd,
-	//     jaspercli.RPCService,
-	//     strings.Join(args, " "),
-	// )
 	// Jasper service commands need elevated privileges to execute. On Windows,
 	// this is assuming that the command is already being run by Administrator.
 	if !h.Distro.IsWindows() {
@@ -570,7 +565,7 @@ func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) 
 // agentMonitorCommand returns the slice of arguments used to start the
 // agent monitor.
 func (h *Host) agentMonitorCommand(settings *evergreen.Settings) []string {
-	binary := filepath.Join("~", h.Distro.BinaryName())
+	binary := filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName())
 	clientPath := filepath.Join(h.Distro.ClientDir, h.Distro.BinaryName())
 
 	return []string{
@@ -621,8 +616,8 @@ func (h *Host) SetupSpawnHostCommand(settings *evergreen.Settings) (string, erro
 		return "", errors.New("missing spawn host owner")
 	}
 
-	binaryPath := filepath.Join("~", h.Distro.BinaryName())
-	binDir := filepath.Join("~", "cli_bin")
+	binaryPath := filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName())
+	binDir := filepath.Join(h.Distro.HomeDir(), "cli_bin")
 	confPath := filepath.Join(binDir, ".evergreen.yml")
 
 	owner, err := user.FindOne(user.ById(h.ProvisionOptions.OwnerId))
@@ -653,7 +648,7 @@ func (h *Host) SetupSpawnHostCommand(settings *evergreen.Settings) (string, erro
 		fmt.Sprintf("mkdir -m 777 -p %s", binDir),
 		fmt.Sprintf("echo '%s' > %s", confJSON, confPath),
 		fmt.Sprintf("cp %s %s", binaryPath, binDir),
-		fmt.Sprintf("(echo 'PATH=${PATH}:%s' >> ~/.profile || true; echo 'PATH=${PATH}:%s' >> ~/.bash_profile || true)", binDir, binDir),
+		fmt.Sprintf("(echo 'PATH=${PATH}:%s' >> %s/.profile || true; echo 'PATH=${PATH}:%s' >> %s/.bash_profile || true)", binDir, h.Distro.HomeDir(), binDir, h.Distro.HomeDir()),
 	}, " && ")
 
 	script := setupBinDirCmds

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -30,30 +30,30 @@ import (
 
 func TestCurlCommand(t *testing.T) {
 	assert := assert.New(t)
-	h := &Host{Distro: distro.Distro{Arch: distro.ArchWindowsAmd64}}
+	h := &Host{Distro: distro.Distro{Arch: distro.ArchWindowsAmd64, User: "user"}}
 	settings := &evergreen.Settings{
 		Ui:                evergreen.UIConfig{Url: "www.example.com"},
 		ClientBinariesDir: "clients",
 	}
-	expected := "cd ~ && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' && chmod +x evergreen.exe"
+	expected := "cd /home/user && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' && chmod +x evergreen.exe"
 	assert.Equal(expected, h.CurlCommand(settings))
 
-	h = &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64}}
-	expected = "cd ~ && curl -LO 'www.example.com/clients/linux_amd64/evergreen' && chmod +x evergreen"
+	h = &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64, User: "user"}}
+	expected = "cd /home/user && curl -LO 'www.example.com/clients/linux_amd64/evergreen' && chmod +x evergreen"
 	assert.Equal(expected, h.CurlCommand(settings))
 }
 
 func TestCurlCommandWithRetry(t *testing.T) {
-	h := &Host{Distro: distro.Distro{Arch: distro.ArchWindowsAmd64}}
+	h := &Host{Distro: distro.Distro{Arch: distro.ArchWindowsAmd64, User: "user"}}
 	settings := &evergreen.Settings{
 		Ui:                evergreen.UIConfig{Url: "www.example.com"},
 		ClientBinariesDir: "clients",
 	}
-	expected := "cd ~ && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10 && chmod +x evergreen.exe"
+	expected := "cd /home/user && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10 && chmod +x evergreen.exe"
 	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, 5, 10))
 
-	h = &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64}}
-	expected = "cd ~ && curl -LO 'www.example.com/clients/linux_amd64/evergreen' --retry 5 --retry-max-time 10 && chmod +x evergreen"
+	h = &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64, User: "user"}}
+	expected = "cd /home/user && curl -LO 'www.example.com/clients/linux_amd64/evergreen' --retry 5 --retry-max-time 10 && chmod +x evergreen"
 	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, 5, 10))
 }
 
@@ -736,6 +736,7 @@ func TestSetupSpawnHostCommand(t *testing.T) {
 		Distro: distro.Distro{
 			Arch:    distro.ArchLinuxAmd64,
 			WorkDir: "/dir",
+			User:    "user",
 		},
 		ProvisionOptions: &ProvisionOptions{
 			OwnerId: user.Id,
@@ -753,13 +754,13 @@ func TestSetupSpawnHostCommand(t *testing.T) {
 	cmd, err := h.SetupSpawnHostCommand(settings)
 	require.NoError(t, err)
 
-	expected := `mkdir -m 777 -p ~/cli_bin && echo '{"api_key":"key","api_server_host":"www.example0.com/api","ui_server_host":"www.example1.com","user":"user"}' > ~/cli_bin/.evergreen.yml && cp ~/evergreen ~/cli_bin && (echo 'PATH=${PATH}:~/cli_bin' >> ~/.profile || true; echo 'PATH=${PATH}:~/cli_bin' >> ~/.bash_profile || true)`
+	expected := `mkdir -m 777 -p /home/user/cli_bin && echo '{"api_key":"key","api_server_host":"www.example0.com/api","ui_server_host":"www.example1.com","user":"user"}' > /home/user/cli_bin/.evergreen.yml && cp /home/user/evergreen /home/user/cli_bin && (echo 'PATH=${PATH}:/home/user/cli_bin' >> /home/user/.profile || true; echo 'PATH=${PATH}:/home/user/cli_bin' >> /home/user/.bash_profile || true)`
 	assert.Equal(t, expected, cmd)
 
 	h.ProvisionOptions.TaskId = "task_id"
 	cmd, err = h.SetupSpawnHostCommand(settings)
 	require.NoError(t, err)
-	expected += " && ~/evergreen -c ~/cli_bin/.evergreen.yml fetch -t task_id --source --artifacts --dir='/dir'"
+	expected += " && /home/user/evergreen -c /home/user/cli_bin/.evergreen.yml fetch -t task_id --source --artifacts --dir='/dir'"
 	assert.Equal(t, expected, cmd)
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6511

All the bash commands that use ~ for home directory (for the legacy and non-legacy host provisioning paths) now depend on `Distro.User` being set to find the home directory.