### PR TITLE
EVG-6365 fix data formatting issue, filter on project in perf plugin

### DIFF
--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -729,7 +729,8 @@ mciModule.controller('PerfController', function PerfController(
       });
     }
 
-    let historyPromise = $http.get(cedarApp + "/rest/v1/perf/task_name/" + $scope.task.display_name + "?variant=" + $scope.task.build_variant).then(
+    let historyPromise = $http.get(cedarApp + "/rest/v1/perf/task_name/" + $scope.task.display_name + 
+    "?variant=" + $scope.task.build_variant + "&project=" + $scope.task.branch).then(
       function(resp) {
         let converted = $filter("expandedHistoryConverter")(resp.data, $scope.task.execution);
         trendDataSuccess(converted);

--- a/public/static/js/filters/filters.common.js
+++ b/public/static/js/filters/filters.common.js
@@ -33,6 +33,9 @@ var bannerText = function() {
 }
 
 var convertSingleTest = function(test, execution) {
+  if (execution && test.info.execution !== execution) {
+    return null;
+  }
   let output = {
     data: {
       "results": []
@@ -51,9 +54,6 @@ var convertSingleTest = function(test, execution) {
     if (versionParts.length > 1) {
       output.revision = versionParts[versionParts.length - 1];
     }
-  }
-  if (execution && test.info.execution !== execution) {
-    return output;
   }
   var result = {};
   var threads
@@ -477,7 +477,9 @@ filters.common.filter('conditional', function() {
 
     _.each(data, function(test) {
       let singleTest = convertSingleTest(test, execution);
-      output.data.results = output.data.results.concat(singleTest.data.results);
+      if (singleTest) {
+        output.data.results = output.data.results.concat(singleTest.data.results);
+      }
     })
 
     return output;


### PR DESCRIPTION
- Previously when converting cedar data, we could have empty entries if the task had multiple execution
- Cedar didn't have a way to filter based on project before, which would cause it to return data from (for example) the 4.2 branch when viewing a sys-perf task