### PR TITLE
EVG-6270 handle updates better

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -267,7 +267,7 @@ func (a *Agent) fetchProjectConfig(ctx context.Context, tc *taskContext) error {
 		return errors.Wrap(err, "error getting version")
 	}
 	project := &model.Project{}
-	err = model.LoadProjectInto([]byte(v.Config), v.Identifier, project)
+	_, err = model.LoadProjectInto([]byte(v.Config), v.Identifier, project)
 	if err != nil {
 		return errors.Wrapf(err, "error reading project config")
 	}

--- a/agent/command.go
+++ b/agent/command.go
@@ -29,7 +29,6 @@ func (a *Agent) runCommands(ctx context.Context, tc *taskContext, commands []mod
 			grip.Error("runCommands canceled")
 			return errors.New("runCommands canceled")
 		}
-
 		cmds, err = command.Render(commandInfo, tc.taskConfig.Project.Functions)
 		if err != nil {
 			tc.logger.Task().Errorf("Couldn't parse plugin command '%v': %v", commandInfo.Command, err)

--- a/globals.go
+++ b/globals.go
@@ -177,6 +177,9 @@ const (
 
 	DefaultJasperPort          = 2385
 	GlobalGitHubTokenExpansion = "global_github_oauth_token"
+
+	// TODO: remove this when degrading YAML
+	UseParserProject = false
 )
 
 func IsFinishedTaskStatus(status string) bool {

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -313,20 +314,13 @@ func (s *GenerateSuite) TestParseProjectFromJSON() {
 	s.Len(g.Functions, 2)
 	s.Contains(g.Functions, "echo-hi")
 	s.Equal("shell.exec", g.Functions["echo-hi"].List()[0].Command)
-
-	s.Require().NoError(g.Functions["echo-hi"].List()[0].resolveParams())
 	s.Equal("echo hi", g.Functions["echo-hi"].List()[0].Params["script"])
-
-	s.Require().NoError(g.Functions["echo-bye"].List()[0].resolveParams())
 	s.Equal("echo bye", g.Functions["echo-bye"].List()[0].Params["script"])
-
-	s.Require().NoError(g.Functions["echo-bye"].List()[1].resolveParams())
 	s.Equal("echo bye again", g.Functions["echo-bye"].List()[1].Params["script"])
 
 	s.Len(g.Tasks, 1)
 	s.Equal("git.get_project", g.Tasks[0].Commands[0].Command)
 
-	s.Require().NoError(g.Tasks[0].Commands[0].resolveParams())
 	s.Equal("src", g.Tasks[0].Commands[0].Params["directory"])
 	s.Equal("echo-hi", g.Tasks[0].Commands[1].Function)
 	s.Equal("test", g.Tasks[0].Name)
@@ -519,31 +513,58 @@ func (s *GenerateSuite) TestValidateNoRecursiveGenerateTasks() {
 
 func (s *GenerateSuite) TestAddGeneratedProjectToConfig() {
 	p := &Project{}
-	err := LoadProjectInto([]byte(sampleProjYml), "", p)
+	pp, err := LoadProjectInto([]byte(sampleProjYml), "", p)
 	s.NoError(err)
 	cachedProject := cacheProjectData(p)
 	g := sampleGeneratedProject
-	config, err := g.addGeneratedProjectToConfig(sampleProjYml, cachedProject)
+	newPP, newConfig, err := g.addGeneratedProjectToConfig(pp, cachedProject)
 	s.NoError(err)
-	s.Contains(config, "say-hi")
-	s.Contains(config, "new_task")
-	s.Contains(config, "a_variant")
-	s.Contains(config, "new_buildvariant")
-	s.Contains(config, "a_function")
-	s.Contains(config, "new_function")
-	s.Contains(config, "say-bye")
-	s.Contains(config, "my_display_task_new_variant")
-	s.Contains(config, "my_display_task_old_variant")
+	s.NotEmpty(newPP)
+	s.NotNil(newConfig)
+	s.Require().Len(newPP.Tasks, 6)
+	s.Require().Len(newPP.BuildVariants, 3)
+	s.Require().Len(newPP.Functions, 2)
+	s.Equal(newPP.Tasks[0].Name, "say-hi")
+	s.Equal(newPP.Tasks[1].Name, "say-bye")
+	s.Equal(newPP.Tasks[2].Name, "a-depended-on-task")
+	s.Equal(newPP.Tasks[3].Name, "task_that_has_dependencies")
+	s.Equal(newPP.Tasks[4].Name, "new_task")
+	s.Equal(newPP.Tasks[5].Name, "another_task")
 
-	config, err = g.addGeneratedProjectToConfig(sampleProjYmlNoFunctions, cachedProject)
+	s.Equal(newPP.BuildVariants[0].Name, "a_variant")
+	s.Require().Len(newPP.BuildVariants[0].DisplayTasks, 1)
+	s.Equal(newPP.BuildVariants[0].DisplayTasks[0].Name, "my_display_task_old_variant")
+
+	s.Equal(newPP.BuildVariants[1].Name, "new_buildvariant")
+	s.Len(newPP.BuildVariants[1].DisplayTasks, 0)
+
+	s.Equal(newPP.BuildVariants[2].Name, "another_variant")
+	s.Require().Len(newPP.BuildVariants[2].DisplayTasks, 1)
+	s.Equal(newPP.BuildVariants[2].DisplayTasks[0].Name, "my_display_task_new_variant")
+
+	_, ok := newPP.Functions["a_function"]
+	s.True(ok)
+	_, ok = newPP.Functions["new_function"]
+	s.True(ok)
+
+	// verify addGeneratedProjectToConfig returned the updated config
+	ppConfig, err := yaml.Marshal(newPP)
 	s.NoError(err)
-	s.Contains(config, "say-hi")
-	s.Contains(config, "new_task")
-	s.Contains(config, "a_variant")
-	s.Contains(config, "new_buildvariant")
-	s.Contains(config, "say-bye")
-	s.Contains(config, "my_display_task_new_variant")
-	s.Contains(config, "my_display_task_old_variant")
+	s.Equal(newConfig, string(ppConfig))
+
+	pp, err = LoadProjectInto([]byte(sampleProjYmlNoFunctions), "", p)
+	s.NoError(err)
+	newPP, newConfig, err = g.addGeneratedProjectToConfig(pp, cachedProject)
+	s.NoError(err)
+	s.NotEmpty(newConfig)
+	s.NotNil(newPP)
+	s.Require().Len(newPP.Tasks, 5)
+	s.Require().Len(newPP.BuildVariants, 3)
+	s.Len(newPP.Functions, 1)
+	s.Equal(newPP.Tasks[0].Name, "say-hi")
+	s.Equal(newPP.Tasks[1].Name, "say-bye")
+	s.Equal(newPP.Tasks[3].Name, "new_task")
+
 }
 
 func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1237,10 +1237,10 @@ func TestCreateTaskGroup(t *testing.T) {
     - name: example_task_group
     - name: example_task_3
   `
-	proj, errs := projectFromYAML([]byte(projYml))
-	proj.Identifier = "test"
+	proj := &Project{}
+	pp, err := LoadProjectInto([]byte(projYml), "test", proj)
 	assert.NotNil(proj)
-	assert.Empty(errs)
+	assert.NoError(err)
 	v := &Version{
 		Id:                  "versionId",
 		CreateTime:          time.Now(),
@@ -1253,7 +1253,8 @@ func TestCreateTaskGroup(t *testing.T) {
 				Activated:    false,
 			},
 		},
-		Config: projYml,
+		ParserProject: pp,
+		Config:        projYml,
 	}
 	table := NewTaskIdTable(proj, v, "", "")
 

--- a/model/matrix_smoke_test.go
+++ b/model/matrix_smoke_test.go
@@ -51,7 +51,7 @@ func TestPythonMatrixIntegration(t *testing.T) {
 			"testdata", "matrix_python.yml"))
 		So(err, ShouldBeNil)
 		Convey("the project should parse properly", func() {
-			err := LoadProjectInto(bytes, "python", &p)
+			_, err := LoadProjectInto(bytes, "python", &p)
 			So(err, ShouldBeNil)
 			Convey("and contain the correct variants", func() {
 				So(len(p.BuildVariants), ShouldEqual, (2*2*4 - 4))
@@ -108,7 +108,7 @@ func TestDepsMatrixIntegration(t *testing.T) {
 			"testdata", "matrix_deps.yml"))
 		So(err, ShouldBeNil)
 		Convey("the project should parse properly", func() {
-			err := LoadProjectInto(bytes, "deps", &p)
+			_, err := LoadProjectInto(bytes, "deps", &p)
 			So(err, ShouldBeNil)
 			Convey("and contain the correct variants", func() {
 				So(len(p.BuildVariants), ShouldEqual, (1 + 3*3))

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -307,7 +307,8 @@ func TestMakePatchedConfig(t *testing.T) {
 			So(projectData, ShouldNotBeNil)
 
 			project := &Project{}
-			So(LoadProjectInto(projectData, "", project), ShouldBeNil)
+			_, err = LoadProjectInto(projectData, "", project)
+			So(err, ShouldBeNil)
 			So(len(project.Tasks), ShouldEqual, 2)
 		})
 		Convey("an empty base config should be patched correctly", func() {
@@ -328,7 +329,8 @@ func TestMakePatchedConfig(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			project := &Project{}
-			So(LoadProjectInto(projectData, "", project), ShouldBeNil)
+			_, err = LoadProjectInto(projectData, "", project)
+			So(err, ShouldBeNil)
 			So(project, ShouldNotBeNil)
 
 			So(len(project.Tasks), ShouldEqual, 1)

--- a/model/project.go
+++ b/model/project.go
@@ -263,7 +263,6 @@ type PluginCommandConf struct {
 	TimeoutSecs int `yaml:"timeout_secs,omitempty" bson:"timeout_secs"`
 
 	// Params are used to supply configuration specific information.
-	// map[string]interface{} is stored as a JSON string.
 	Params map[string]interface{} `yaml:"params,omitempty" bson:"params"`
 
 	// YAML string of Params to store in database
@@ -848,8 +847,7 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 	for _, e := range h.Distro.Expansions {
 		expansions.Put(e.Key, e.Value)
 	}
-	proj := &Project{}
-	err = LoadProjectInto([]byte(v.Config), t.Project, proj)
+	proj, err := LoadProjectFromVersion(v, t.Project, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "error unmarshaling project")
 	}
@@ -928,6 +926,7 @@ func (p *Project) FindTaskGroup(name string) *TaskGroup {
 }
 
 // GetTaskGroup returns the task group for a given task from its project
+// Only called by agent so we don't save project to database
 func GetTaskGroup(taskGroup string, tc *TaskConfig) (*TaskGroup, error) {
 	if tc == nil {
 		return nil, errors.New("unable to get task group: TaskConfig is nil")
@@ -941,8 +940,8 @@ func GetTaskGroup(taskGroup string, tc *TaskConfig) (*TaskGroup, error) {
 	if tc.Version == nil {
 		return nil, errors.New("version is nil")
 	}
-	var p Project
-	if err := LoadProjectInto([]byte(tc.Version.Config), tc.Task.Project, &p); err != nil {
+	p, err := LoadProjectFromVersion(tc.Version, tc.Task.Project, false)
+	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving project for task group")
 	}
 	if taskGroup == "" {
@@ -987,8 +986,7 @@ func FindProjectFromVersionID(versionStr string) (*Project, error) {
 		return nil, errors.Errorf("nil version returned for version '%s'", versionStr)
 	}
 
-	project := &Project{}
-	err = LoadProjectInto([]byte(ver.Config), ver.Identifier, project)
+	project, err := LoadProjectFromVersion(ver, ver.Identifier, true)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to load project config for version %s", versionStr)
 	}
@@ -1041,15 +1039,15 @@ func FindProject(revision string, projectRef *ProjectRef) (*Project, error) {
 			// for new repositories, we don't want to error out when we don't have
 			// any versions stored in the database so we default to the skeletal
 			// information we already have from the project file on disk
-			err = LoadProjectInto([]byte(lastGoodVersion.Config), projectRef.Identifier, project)
+			project, err = LoadProjectFromVersion(lastGoodVersion, projectRef.Identifier, true)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Error loading project from "+
-					"last good version for project, %s", lastGoodVersion.Identifier)
+					"last good version for project '%s'", lastGoodVersion.Identifier)
 			}
 		} else {
 			// Check to see if there is a local configuration in the project ref
 			if projectRef.LocalConfig != "" {
-				err = LoadProjectInto([]byte(projectRef.LocalConfig), projectRef.Identifier, project)
+				_, err = LoadProjectInto([]byte(projectRef.LocalConfig), projectRef.Identifier, project)
 				if err != nil {
 					return nil, errors.Wrapf(err, "Error loading local config for project ref, %s", projectRef.Identifier)
 				}
@@ -1069,8 +1067,8 @@ func FindProject(revision string, projectRef *ProjectRef) (*Project, error) {
 			return project, nil
 		}
 
-		project = &Project{}
-		if err = LoadProjectInto([]byte(v.Config), projectRef.Identifier, project); err != nil {
+		project, err = LoadProjectFromVersion(v, projectRef.Identifier, true)
+		if err != nil {
 			return nil, errors.Wrap(err, "Error loading project from version")
 		}
 	}

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -41,8 +41,8 @@ buildvariants:
       set:
         tags: "gotcha_boy"
 `
-			p, errs := createIntermediateProject([]byte(axes))
-			So(errs, ShouldBeNil)
+			p, err := createIntermediateProject([]byte(axes))
+			So(err, ShouldBeNil)
 			axis := p.Axes[0]
 			So(axis.Id, ShouldEqual, "os")
 			So(axis.DisplayName, ShouldEqual, "Operating System")
@@ -77,8 +77,8 @@ buildvariants:
     - blue
     - green
 `
-			p, errs := createIntermediateProject([]byte(simple))
-			So(errs, ShouldBeNil)
+			p, err := createIntermediateProject([]byte(simple))
+			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].matrix
 			So(m1, ShouldResemble, matrix{
@@ -108,8 +108,8 @@ buildvariants:
 - name: "single_variant"
   tasks: "*"
 `
-			p, errs := createIntermediateProject([]byte(simple))
-			So(errs, ShouldBeNil)
+			p, err := createIntermediateProject([]byte(simple))
+			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].matrix
 			So(m1.Id, ShouldEqual, "test")

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1,13 +1,15 @@
 package model
 
 import (
-	"bytes"
 	"fmt"
 	"reflect"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	mgobson "gopkg.in/mgo.v2/bson"
 	"gopkg.in/yaml.v2"
 )
 
@@ -16,8 +18,8 @@ const LoadProjectError = "load project error(s)"
 // This file contains the infrastructure for turning a YAML project configuration
 // into a usable Project struct. A basic overview of the project parsing process is:
 //
-// First, the YAML bytes are unmarshalled into an intermediary parserProject.
-// The parserProject's internal types define custom YAML unmarshal hooks, allowing
+// First, the YAML bytes are unmarshalled into an intermediary ParserProject.
+// The ParserProject's internal types define custom YAML unmarshal hooks, allowing
 // users to do things like offer a single definition where we expect a list, e.g.
 //   `tags: "single_tag"` instead of the more verbose `tags: ["single_tag"]`
 // or refer to task by a single selector. Custom YAML handling allows us to
@@ -35,10 +37,10 @@ const LoadProjectError = "load project error(s)"
 // Code outside of this file should never have to consider selectors or parser* types
 // when handling project code.
 
-// parserProject serves as an intermediary struct for parsing project
+// ParserProject serves as an intermediary struct for parsing project
 // configuration YAML. It implements the Unmarshaler interface
 // to allow for flexible handling.
-type parserProject struct {
+type ParserProject struct {
 	Enabled           bool                       `yaml:"enabled,omitempty" bson:"enabled,omitempty"`
 	Stepback          bool                       `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
 	PreErrorFailsTask bool                       `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
@@ -107,7 +109,11 @@ type parserTask struct {
 	Stepback        *bool               `yaml:"stepback,omitempty"`
 }
 
-func (pp *parserProject) MarshalYAML() (interface{}, error) {
+func (pp *ParserProject) MarshalBSON() ([]byte, error) {
+	return mgobson.Marshal(pp)
+}
+
+func (pp *ParserProject) MarshalYAML() (interface{}, error) {
 	for i, pt := range pp.Tasks {
 		for j := range pt.Commands {
 			if err := pp.Tasks[i].Commands[j].resolveParams(); err != nil {
@@ -409,45 +415,61 @@ func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(interface{}) error) e
 	return nil
 }
 
-// LoadProjectInto loads the raw data from the config file into project
-// and sets the project's identifier field to identifier. Tags are evaluateed.
-func LoadProjectInto(data []byte, identifier string, project *Project) error {
-	p, errs := projectFromYAML(data)
-	if len(errs) > 0 {
-		// create a human-readable error list
-		buf := bytes.Buffer{}
-		for _, e := range errs {
-			if len(errs) > 1 {
-				buf.WriteString("\n\t") //only newline if we have multiple errs
-			}
-			buf.WriteString(e.Error())
-		}
-		return errors.Errorf("%s: %s", LoadProjectError, buf.String())
+// LoadProjectFromVersion returns the project for a version, either from the parser project or the config string.
+// If read from the config string and shouldSave is set, the resulting parser project will be saved.
+func LoadProjectFromVersion(v *Version, identifier string, shouldSave bool) (*Project, error) {
+	if evergreen.UseParserProject && v.ParserProject != nil {
+		v.ParserProject.Identifier = identifier
+		return translateProject(v.ParserProject)
 	}
-	*project = *p
-	project.Identifier = identifier
-	return nil
+
+	if v.Config == "" {
+		return nil, errors.New("version has no config")
+	}
+	p := &Project{}
+	pp, err := LoadProjectInto([]byte(v.Config), identifier, p)
+	if err != nil {
+		return nil, errors.Wrap(err, "error loading project")
+	}
+	if shouldSave {
+		if err := UpdateVersionProject(v.Id, v.ConfigUpdateNumber, pp); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"project":       identifier,
+				"version":       v.Id,
+				"config_number": v.ConfigUpdateNumber,
+				"message":       "error updating version's project",
+			}))
+			return nil, errors.Wrap(err, "error updating version with project")
+		}
+	}
+	v.ParserProject = pp
+	return p, nil
 }
 
-// projectFromYAML reads and evaluates project YAML, returning a project and warnings and
-// errors encountered during parsing or evaluation.
-func projectFromYAML(yml []byte) (*Project, []error) {
-	intermediateProject, errs := createIntermediateProject(yml)
-	if len(errs) > 0 {
-		return nil, errs
+// LoadProjectInto loads the raw data from the config file into project
+// and sets the project's identifier field to identifier. Tags are evaluated. Returns the intermediate step.
+// If reading from a version config, LoadProjectFromVersion should be used to persist the resulting parser project.
+func LoadProjectInto(data []byte, identifier string, project *Project) (*ParserProject, error) {
+	intermediateProject, err := createIntermediateProject(data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating parser project")
 	}
-	p, errs := translateProject(intermediateProject)
-	return p, errs
+
+	// return project even with errors
+	p, err := translateProject(intermediateProject)
+	*project = *p
+	project.Identifier = identifier
+	return intermediateProject, errors.Wrap(err, "error translating project")
 }
 
 // createIntermediateProject marshals the supplied YAML into our
 // intermediate project representation (i.e. before selectors or
 // matrix logic has been evaluated).
-func createIntermediateProject(yml []byte) (*parserProject, []error) {
-	p := &parserProject{}
+func createIntermediateProject(yml []byte) (*ParserProject, error) {
+	p := &ParserProject{}
 	err := yaml.Unmarshal(yml, p)
 	if err != nil {
-		return nil, []error{err}
+		return nil, errors.Wrap(err, "error unmarshalling into parser project")
 	}
 	if p.Functions == nil {
 		p.Functions = map[string]*YAMLCommandSet{}
@@ -459,7 +481,7 @@ func createIntermediateProject(yml []byte) (*parserProject, []error) {
 // translateProject converts our intermediate project representation into
 // the Project type that Evergreen actually uses. Errors are added to
 // pp.errors and pp.warnings and must be checked separately.
-func translateProject(pp *parserProject) (*Project, []error) {
+func translateProject(pp *ParserProject) (*Project, error) {
 	// Transfer top level fields
 	proj := &Project{
 		Enabled:           pp.Enabled,
@@ -484,20 +506,21 @@ func translateProject(pp *parserProject) (*Project, []error) {
 		ExecTimeoutSecs:   pp.ExecTimeoutSecs,
 		Loggers:           pp.Loggers,
 	}
+	catcher := grip.NewBasicCatcher()
 	tse := NewParserTaskSelectorEvaluator(pp.Tasks)
 	tgse := newTaskGroupSelectorEvaluator(pp.TaskGroups)
 	ase := NewAxisSelectorEvaluator(pp.Axes)
 	regularBVs, matrices := sieveMatrixVariants(pp.BuildVariants)
-	var evalErrs, errs []error
+	var errs []error
 	matrixVariants, errs := buildMatrixVariants(pp.Axes, ase, matrices)
-	evalErrs = append(evalErrs, errs...)
+	catcher.Extend(errs)
 	pp.BuildVariants = append(regularBVs, matrixVariants...)
 	vse := NewVariantSelectorEvaluator(pp.BuildVariants, ase)
 	proj.Tasks, proj.TaskGroups, errs = evaluateTaskUnits(tse, tgse, vse, pp.Tasks, pp.TaskGroups)
-	evalErrs = append(evalErrs, errs...)
+	catcher.Extend(errs)
 	proj.BuildVariants, errs = evaluateBuildVariants(tse, tgse, vse, pp.BuildVariants, pp.Tasks, proj.TaskGroups)
-	evalErrs = append(evalErrs, errs...)
-	return proj, evalErrs
+	catcher.Extend(errs)
+	return proj, errors.Wrap(catcher.Resolve(), LoadProjectError)
 }
 
 // sieveMatrixVariants takes a set of parserBVs and groups them into regular

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -439,7 +439,7 @@ func LoadProjectFromVersion(v *Version, identifier string, shouldSave bool) (*Pr
 				"config_number": v.ConfigUpdateNumber,
 				"message":       "error updating version's project",
 			}))
-			return p, nil
+			return nil, errors.Wrap(err, "error updating version with project")
 		}
 	}
 	v.ParserProject = pp

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -439,7 +439,7 @@ func LoadProjectFromVersion(v *Version, identifier string, shouldSave bool) (*Pr
 				"config_number": v.ConfigUpdateNumber,
 				"message":       "error updating version's project",
 			}))
-			return nil, errors.Wrap(err, "error updating version with project")
+			return p, nil
 		}
 	}
 	v.ParserProject = pp

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -42,6 +42,7 @@ func TestFindProject(t *testing.T) {
 		Convey("if the project file exists and is valid, the project spec within"+
 			"should be unmarshalled and returned", func() {
 			v := &Version{
+				Id:         "my_version",
 				Owner:      "fakeowner",
 				Repo:       "fakerepo",
 				Branch:     "fakebranch",
@@ -267,12 +268,14 @@ task_groups:
   - example_task_1
   - example_task_2
 `
-	proj, errs := projectFromYAML([]byte(projYml))
+	proj := &Project{}
+	pp, err := LoadProjectInto([]byte(projYml), "id", proj)
 	assert.NotNil(proj)
-	assert.Empty(errs)
+	assert.NoError(err)
 	v := Version{
-		Id:     "v1",
-		Config: projYml,
+		Id:            "v1",
+		ParserProject: pp,
+		Config:        projYml,
 	}
 	t1 := task.Task{
 		Id:        "t1",
@@ -1061,11 +1064,11 @@ tasks:
   depends_on:
     - name: dist-test
 `
-	intermediate, errs := createIntermediateProject([]byte(projYml))
-	s.Len(errs, 0)
+	intermediate, err := createIntermediateProject([]byte(projYml))
+	s.NoError(err)
 	marshaled, err := yaml.Marshal(intermediate)
 	s.NoError(err)
-	unmarshaled := parserProject{}
+	unmarshaled := ParserProject{}
 	s.NoError(yaml.Unmarshal(marshaled, &unmarshaled))
 }
 

--- a/model/task_config.go
+++ b/model/task_config.go
@@ -124,8 +124,7 @@ func MakeConfigFromTask(t *task.Task) (*TaskConfig, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding distro")
 	}
-	proj := &Project{}
-	err = LoadProjectInto([]byte(v.Config), v.Identifier, proj)
+	proj, err := LoadProjectFromVersion(v, v.Identifier, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "error loading project")
 	}

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -219,7 +219,6 @@ func BlockTaskGroupTasks(taskID string) error {
 	if tg == nil {
 		return errors.Errorf("unable to find task group '%s' for task '%s'", t.TaskGroup, taskID)
 	}
-
 	indexOfTask := -1
 	for i, tgTask := range tg.Tasks {
 		if t.DisplayName == tgTask {
@@ -238,7 +237,6 @@ func BlockTaskGroupTasks(taskID string) error {
 	if err != nil {
 		catcher.Add(errors.Wrapf(err, "problem finding tasks %s", strings.Join(taskNamesToBlock, ", ")))
 	}
-
 	if err := ValidateNewGraph(t, tasksToBlock); err != nil {
 		return errors.Wrap(err, "problem validating proposed dependencies")
 	}

--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/mgo.v2/bson"
 )
 
 var (
@@ -204,6 +205,7 @@ tasks:
 - name: one
 `
 	v := Version{
+		Id:         bson.NewObjectId().Hex(),
 		Identifier: "a",
 		Revision:   "b",
 		Requester:  evergreen.RepotrackerVersionRequester,
@@ -251,9 +253,12 @@ tasks:
 	assert.NoError(BlockTaskGroupTasks("task_id_1"))
 	found, err := task.FindOneId("one_1")
 	assert.NoError(err)
+	require.NotNil(found)
+	require.NotEmpty(found.DependsOn)
 	assert.Equal("task_id_1", found.DependsOn[0].TaskId)
 	queue, err := LoadTaskQueue("distro_1")
 	assert.NoError(err)
+	require.NotNil(queue)
 	assert.Len(queue.Queue, 0)
 }
 

--- a/model/version.go
+++ b/model/version.go
@@ -24,7 +24,7 @@ type Version struct {
 	Message             string               `bson:"message" json:"message,omitempty"`
 	Status              string               `bson:"status" json:"status,omitempty"`
 	RevisionOrderNumber int                  `bson:"order,omitempty" json:"order,omitempty"`
-	ParserProject       *parserProject       `bson:"project" json:"project,omitempty"`
+	ParserProject       *ParserProject       `bson:"project" json:"project,omitempty"`
 	Config              string               `bson:"config" json:"config,omitempty"`
 	ConfigUpdateNumber  int                  `bson:"config_number" json:"config_number,omitempty"`
 	Ignored             bool                 `bson:"ignored" json:"ignored"`

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -280,8 +280,11 @@ func UpdateVersionProject(versionID string, versionNumber int, pp *ParserProject
 	}
 	return errors.Wrap(VersionUpdateOne(
 		bson.M{
-			VersionIdKey:           versionID,
-			VersionConfigNumberKey: versionNumber,
+			VersionIdKey: versionID,
+			"$or": []bson.M{
+				bson.M{VersionConfigNumberKey: bson.M{"$exists": false}},
+				bson.M{VersionConfigNumberKey: versionNumber},
+			},
 		},
 		bson.M{
 			"$set": bson.M{

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -269,6 +270,24 @@ func VersionUpdateOne(query interface{}, update interface{}) error {
 		query,
 		update,
 	)
+}
+
+// UpdateVersionProject updates the ParserProject field for the version.
+// Note this does not increment the config update number, as we are not changing the used config, simply updating a new field.
+func UpdateVersionProject(versionID string, versionNumber int, pp *ParserProject) error {
+	if versionID == "" {
+		return errors.New("no version ID given")
+	}
+	return errors.Wrap(VersionUpdateOne(
+		bson.M{
+			VersionIdKey:           versionID,
+			VersionConfigNumberKey: versionNumber,
+		},
+		bson.M{
+			"$set": bson.M{
+				VersionProjectKey: pp,
+			},
+		}), "error updating version")
 }
 
 func AddSatisfiedTrigger(versionID, definitionID string) error {

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -40,7 +40,7 @@ func Evaluate() cli.Command {
 			}
 
 			p := &model.Project{}
-			err = model.LoadProjectInto(configBytes, "", p)
+			_, err = model.LoadProjectInto(configBytes, "", p)
 			if err != nil {
 				return errors.Wrap(err, "error loading project")
 			}

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -152,7 +152,6 @@ func fetchSource(ctx context.Context, ac, rc *legacyClient, comm client.Communic
 	if task == nil {
 		return errors.New("task not found.")
 	}
-
 	config, err := rc.GetConfig(task.Version)
 	if err != nil {
 		return err

--- a/operations/list.go
+++ b/operations/list.go
@@ -293,8 +293,7 @@ func loadLocalConfig(filepath string) (*model.Project, error) {
 	}
 
 	project := &model.Project{}
-	err = model.LoadProjectInto(configBytes, "", project)
-	if err != nil {
+	if _, err = model.LoadProjectInto(configBytes, "", project); err != nil {
 		return nil, errors.Wrap(err, "error loading project")
 	}
 

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -58,7 +58,7 @@ func githubCommitToRevision(repoCommit *github.RepositoryCommit) model.Revision 
 
 // GetRemoteConfig fetches the contents of a remote github repository's
 // configuration data as at a given revision
-func (gRepoPoller *GithubRepositoryPoller) GetRemoteConfig(ctx context.Context, projectFileRevision string) (projectConfig *model.Project, err error) {
+func (gRepoPoller *GithubRepositoryPoller) GetRemoteConfig(ctx context.Context, projectFileRevision string) (*model.Project, *model.ParserProject, error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -70,21 +70,22 @@ func (gRepoPoller *GithubRepositoryPoller) GetRemoteConfig(ctx context.Context, 
 		projectRef.Owner, projectRef.Repo, projectRef.RemotePath,
 		projectFileRevision)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	projectFileBytes, err := base64.StdEncoding.DecodeString(*githubFile.Content)
 	if err != nil {
-		return nil, thirdparty.FileDecodeError{Message: err.Error()}
+		return nil, nil, thirdparty.FileDecodeError{Message: err.Error()}
 	}
 
-	projectConfig = &model.Project{}
-	err = model.LoadProjectInto(projectFileBytes, projectRef.Identifier, projectConfig)
+	projectConfig := &model.Project{}
+	pp, err := model.LoadProjectInto(projectFileBytes, projectRef.Identifier, projectConfig)
+
 	if err != nil {
-		return nil, thirdparty.YAMLFormatError{Message: err.Error()}
+		return nil, nil, thirdparty.YAMLFormatError{Message: err.Error()}
 	}
 
-	return projectConfig, nil
+	return projectConfig, pp, nil
 }
 
 // GetRemoteConfig fetches the contents of a remote github repository's

--- a/repotracker/github_poller_test.go
+++ b/repotracker/github_poller_test.go
@@ -220,23 +220,23 @@ func TestGetRemoteConfig(t *testing.T) {
 
 			Convey("The config file at the requested revision should be "+
 				"exactly what is returned", func() {
-				projectConfig, err := self.GetRemoteConfig(ctx, firstRemoteConfigRef)
+				projectConfig, _, err := self.GetRemoteConfig(ctx, firstRemoteConfigRef)
 				require.NoError(t, err, "Error fetching github "+
 					"configuration file")
 				So(projectConfig, ShouldNotBeNil)
 				So(len(projectConfig.Tasks), ShouldEqual, 0)
-				projectConfig, err = self.GetRemoteConfig(ctx, secondRemoteConfigRef)
+				projectConfig, _, err = self.GetRemoteConfig(ctx, secondRemoteConfigRef)
 				require.NoError(t, err, "Error fetching github "+
 					"configuration file")
 				So(projectConfig, ShouldNotBeNil)
 				So(len(projectConfig.Tasks), ShouldEqual, 1)
 			})
 			Convey("an invalid revision should return an error", func() {
-				_, err := self.GetRemoteConfig(ctx, "firstRemoteConfRef")
+				_, _, err := self.GetRemoteConfig(ctx, "firstRemoteConfRef")
 				So(err, ShouldNotBeNil)
 			})
 			Convey("an invalid project configuration should error out", func() {
-				_, err := self.GetRemoteConfig(ctx, badRemoteConfigRef)
+				_, _, err := self.GetRemoteConfig(ctx, badRemoteConfigRef)
 				So(err, ShouldNotBeNil)
 			})
 		})

--- a/repotracker/mock_poller.go
+++ b/repotracker/mock_poller.go
@@ -42,17 +42,17 @@ func (d *mockRepoPoller) GetChangedFiles(_ context.Context, commitRevision strin
 	return nil, nil
 }
 
-func (d *mockRepoPoller) GetRemoteConfig(_ context.Context, revision string) (*model.Project, error) {
+func (d *mockRepoPoller) GetRemoteConfig(_ context.Context, revision string) (*model.Project, *model.ParserProject, error) {
 	d.ConfigGets++
 	if d.nextError != nil {
-		return nil, d.clearError()
+		return nil, nil, d.clearError()
 	}
 	if d.badDistro != "" {
 		// change the target distros if we've called addBadDistro, creating a validation warning
 		d.project.BuildVariants[0].RunOn = append(d.project.BuildVariants[0].RunOn, d.badDistro)
 		d.badDistro = ""
 	}
-	return d.project, nil
+	return d.project, nil, nil
 }
 
 func (d *mockRepoPoller) GetRevisionsSince(revision string, maxRevisionsToSearch int) ([]model.Revision, error) {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -61,12 +61,46 @@ type VersionMetadata struct {
 	PeriodicBuildID     string
 }
 
+type ProjectInfo struct {
+	Ref                 *model.ProjectRef
+	Project             *model.Project
+	IntermediateProject *model.ParserProject
+}
+
+func (p *ProjectInfo) notPopulated() bool {
+	return p.Ref == nil || p.Project == nil
+}
+
+// PopulateVersion updates the version's ParserProject if we have or can create it
+func (p *ProjectInfo) populateVersion(v *model.Version) error {
+	if evergreen.UseParserProject && p.IntermediateProject != nil {
+		config, err := yaml.Marshal(p.IntermediateProject)
+		if err != nil {
+			return errors.Wrap(err, "error marshalling intermediate project")
+		}
+		v.Config = string(config)
+		v.ParserProject = p.IntermediateProject
+		return nil
+	}
+	config, err := yaml.Marshal(p.Project)
+	if err != nil {
+		return errors.Wrap(err, "error marshaling config")
+	}
+	pp, err := model.LoadProjectInto(config, p.Ref.Identifier, p.Project)
+	if err != nil {
+		return errors.Wrap(err, "error creating parser project")
+	}
+	v.Config = string(config)
+	v.ParserProject = pp
+	return nil
+}
+
 // The RepoPoller interface specifies behavior required of all repository poller
 // implementations
 type RepoPoller interface {
 	// Fetches the contents of a remote repository's configuration data as at
 	// the given revision.
-	GetRemoteConfig(ctx context.Context, revision string) (*model.Project, error)
+	GetRemoteConfig(ctx context.Context, revision string) (*model.Project, *model.ParserProject, error)
 
 	// Fetches a list of all filepaths modified by a given revision.
 	GetChangedFiles(ctx context.Context, revision string) ([]string, error)
@@ -236,7 +270,7 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 		}
 
 		var versionErrs *VersionErrors
-		project, err := repoTracker.GetProjectConfig(ctx, revision)
+		project, intermediateProject, err := repoTracker.GetProjectConfig(ctx, revision)
 		if err != nil {
 			// this is an error that implies the file is invalid - create a version and store the error
 			projErr, isProjErr := err.(projectConfigError)
@@ -300,7 +334,12 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 		metadata := VersionMetadata{
 			Revision: revisions[i],
 		}
-		v, err := CreateVersionFromConfig(ctx, ref, project, metadata, ignore, versionErrs)
+		projectInfo := &ProjectInfo{
+			Ref:                 ref,
+			Project:             project,
+			IntermediateProject: intermediateProject,
+		}
+		v, err := CreateVersionFromConfig(ctx, projectInfo, metadata, ignore, versionErrs)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error creating version",
@@ -350,14 +389,14 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 // returning a remote config if the project references a remote repository
 // configuration file - via the Identifier. Otherwise it defaults to the local
 // project file. An erroneous project file may be returned along with an error.
-func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision string) (*model.Project, error) {
+func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision string) (*model.Project, *model.ParserProject, error) {
 	projectRef := repoTracker.ProjectRef
 	if projectRef.LocalConfig != "" {
 		// return the Local config from the project Ref.
 		p, err := model.FindProject("", projectRef)
-		return p, err
+		return p, nil, err
 	}
-	project, err := repoTracker.GetRemoteConfig(ctx, revision)
+	projectConfig, intermediateProj, err := repoTracker.GetRemoteConfig(ctx, revision)
 	if err != nil {
 		// Only create a stub version on API request errors that pertain
 		// to actually fetching a config. Those errors currently include:
@@ -379,7 +418,7 @@ func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision s
 			})
 
 			grip.Error(message.WrapError(err, msg))
-			return nil, projectConfigError{Errors: []string{msg.String()}, Warnings: nil}
+			return nil, nil, projectConfigError{Errors: []string{msg.String()}, Warnings: nil}
 		}
 		// If we get here then we have an infrastructural error - e.g.
 		// a thirdparty.APIUnmarshalError (indicating perhaps an API has
@@ -410,9 +449,9 @@ func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision s
 			"lastRevision": lastRevision,
 		}))
 
-		return nil, err
+		return nil, nil, err
 	}
-	return project, nil
+	return projectConfig, intermediateProj, nil
 }
 
 // AddBuildBreakSubscriptions will subscribe admins of a project to a version if no one
@@ -570,29 +609,28 @@ func CreateManifest(v model.Version, proj *model.Project, branch string, setting
 	return newManifest, errors.Wrap(err, "error inserting manifest")
 }
 
-func CreateVersionFromConfig(ctx context.Context, ref *model.ProjectRef, config *model.Project,
+func CreateVersionFromConfig(ctx context.Context, projectInfo *ProjectInfo,
 	metadata VersionMetadata, ignore bool, versionErrs *VersionErrors) (*model.Version, error) {
-	if ref == nil || config == nil {
+	if projectInfo.notPopulated() {
 		return nil, errors.New("project ref and project cannot be nil")
 	}
 
 	// create a version document
-	v, err := shellVersionFromRevision(ref, metadata)
+	v, err := shellVersionFromRevision(projectInfo.Ref, metadata)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shell version")
 	}
-	if err = sanityCheckOrderNum(v.RevisionOrderNumber, ref.Identifier, metadata.Revision.Revision); err != nil {
+	if err = sanityCheckOrderNum(v.RevisionOrderNumber, projectInfo.Ref.Identifier, metadata.Revision.Revision); err != nil {
 		return nil, errors.Wrap(err, "inconsistent version order")
 	}
-	configYaml, err := yaml.Marshal(config)
-	if err != nil {
-		return nil, errors.Wrap(err, "error marshaling config")
+
+	if err = projectInfo.populateVersion(v); err != nil {
+		return nil, errors.Wrap(err, "problem updating version project")
 	}
-	v.Config = string(configYaml)
 	v.Ignored = ignore
 
 	// validate the project
-	verrs := validator.CheckProjectSyntax(config)
+	verrs := validator.CheckProjectSyntax(projectInfo.Project)
 	if len(verrs) > 0 || versionErrs != nil {
 		// We have syntax errors in the project.
 		// Format them, as we need to store + display them to the user
@@ -618,13 +656,13 @@ func CreateVersionFromConfig(ctx context.Context, ref *model.ProjectRef, config 
 	}
 	var aliases model.ProjectAliases
 	if metadata.Alias != "" {
-		aliases, err = model.FindAliasInProject(ref.Identifier, metadata.Alias)
+		aliases, err = model.FindAliasInProject(projectInfo.Ref.Identifier, metadata.Alias)
 		if err != nil {
 			return v, errors.Wrap(err, "error finding project alias")
 		}
 	}
 
-	return v, errors.Wrap(createVersionItems(ctx, v, ref, metadata, config, aliases), "error creating version items")
+	return v, errors.Wrap(createVersionItems(ctx, v, projectInfo.Ref, metadata, projectInfo.Project, aliases), "error creating version items")
 }
 
 // shellVersionFromRevision populates a new Version with metadata from a model.Revision.

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -655,9 +655,14 @@ tasks:
 - name: task2
 `
 	p := &model.Project{}
-	err := model.LoadProjectInto([]byte(configYml), s.ref.Identifier, p)
+	pp, err := model.LoadProjectInto([]byte(configYml), s.ref.Identifier, p)
 	s.NoError(err)
-	v, err := CreateVersionFromConfig(context.Background(), s.ref, p, VersionMetadata{Revision: *s.rev, SourceVersion: s.sourceVersion}, false, nil)
+	projectInfo := &ProjectInfo{
+		Ref:                 s.ref,
+		IntermediateProject: pp,
+		Project:             p,
+	}
+	v, err := CreateVersionFromConfig(context.Background(), projectInfo, VersionMetadata{Revision: *s.rev, SourceVersion: s.sourceVersion}, false, nil)
 	s.NoError(err)
 	s.Require().NotNil(v)
 
@@ -689,9 +694,14 @@ tasks:
 - name: task2
 `
 	p := &model.Project{}
-	err := model.LoadProjectInto([]byte(configYml), s.ref.Identifier, p)
+	pp, err := model.LoadProjectInto([]byte(configYml), s.ref.Identifier, p)
 	s.NoError(err)
-	v, err := CreateVersionFromConfig(context.Background(), s.ref, p, VersionMetadata{Revision: *s.rev}, false, nil)
+	projectInfo := &ProjectInfo{
+		Ref:                 s.ref,
+		IntermediateProject: pp,
+		Project:             p,
+	}
+	v, err := CreateVersionFromConfig(context.Background(), projectInfo, VersionMetadata{Revision: *s.rev}, false, nil)
 	s.NoError(err)
 	s.Require().NotNil(v)
 
@@ -722,13 +732,18 @@ tasks:
 - name: task2
 `
 	p := &model.Project{}
-	err := model.LoadProjectInto([]byte(configYml), s.ref.Identifier, p)
+	pp, err := model.LoadProjectInto([]byte(configYml), s.ref.Identifier, p)
 	s.NoError(err)
 	vErrs := VersionErrors{
 		Errors:   []string{"err1"},
 		Warnings: []string{"warn1", "warn2"},
 	}
-	v, err := CreateVersionFromConfig(context.Background(), s.ref, p, VersionMetadata{Revision: *s.rev}, false, &vErrs)
+	projectInfo := &ProjectInfo{
+		Ref:                 s.ref,
+		IntermediateProject: pp,
+		Project:             p,
+	}
+	v, err := CreateVersionFromConfig(context.Background(), projectInfo, VersionMetadata{Revision: *s.rev}, false, &vErrs)
 	s.NoError(err)
 	s.Require().NotNil(v)
 
@@ -752,16 +767,21 @@ tasks:
 - name: task2
 `
 	p := &model.Project{}
-	err := model.LoadProjectInto([]byte(configYml), s.ref.Identifier, p)
+	pp, err := model.LoadProjectInto([]byte(configYml), s.ref.Identifier, p)
 	s.NoError(err)
-
+	s.NotNil(pp)
 	//force a duplicate key error with the version
 	v := &model.Version{
 		Id: makeVersionId(s.ref.String(), s.rev.Revision),
 	}
 	s.NoError(v.Insert())
 
-	v, err = CreateVersionFromConfig(context.Background(), s.ref, p, VersionMetadata{Revision: *s.rev, SourceVersion: s.sourceVersion}, false, nil)
+	projectInfo := &ProjectInfo{
+		Ref:                 s.ref,
+		IntermediateProject: pp,
+		Project:             p,
+	}
+	v, err = CreateVersionFromConfig(context.Background(), projectInfo, VersionMetadata{Revision: *s.rev, SourceVersion: s.sourceVersion}, false, nil)
 	s.Error(err)
 
 	tasks, err := task.Find(task.ByVersion(v.Id))

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -322,7 +322,7 @@ func (vc *DBVersionConnector) CreateVersionFromConfig(ctx context.Context, proje
 		}
 	}
 	project := &model.Project{}
-	err = model.LoadProjectInto(config, projectID, project)
+	intermediateProject, err := model.LoadProjectInto(config, projectID, project)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -334,7 +334,12 @@ func (vc *DBVersionConnector) CreateVersionFromConfig(ctx context.Context, proje
 		User:    user,
 		Message: message,
 	}
-	newVersion, err := repotracker.CreateVersionFromConfig(ctx, ref, project, metadata, false, nil)
+	projectInfo := &repotracker.ProjectInfo{
+		Ref:                 ref,
+		Project:             project,
+		IntermediateProject: intermediateProject,
+	}
+	newVersion, err := repotracker.CreateVersionFromConfig(ctx, projectInfo, metadata, false, nil)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -437,6 +437,10 @@ func TestCreateVersionFromConfig(t *testing.T) {
 	assert.Equal(ref.Identifier, newVersion.Identifier)
 	assert.Equal(6, newVersion.RevisionOrderNumber)
 	assert.Equal(evergreen.AdHocRequester, newVersion.Requester)
+	assert.NotNil(newVersion.ParserProject)
+	assert.True(newVersion.ParserProject.Stepback)
+	assert.Len(newVersion.ParserProject.Tasks, 1)
+	assert.Len(newVersion.ParserProject.BuildVariants, 1)
 	assert.NotEmpty(newVersion.Config)
 
 	b, err := build.FindOneId(newVersion.BuildIds[0])
@@ -468,6 +472,9 @@ tasks:
 	assert.Equal(ref.Identifier, newVersion.Identifier)
 	assert.Equal(7, newVersion.RevisionOrderNumber)
 	assert.Equal(evergreen.AdHocRequester, newVersion.Requester)
+	assert.NotNil(newVersion.ParserProject)
+	assert.True(newVersion.ParserProject.Stepback)
+	assert.Len(newVersion.ParserProject.BuildVariants, 1)
 	assert.NotEmpty(newVersion.Config)
 
 	b, err = build.FindOneId(newVersion.BuildIds[0])

--- a/scheduler/setup_funcs.go
+++ b/scheduler/setup_funcs.go
@@ -6,11 +6,12 @@ import (
 	"sort"
 	"sync"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // Function run before sorting all the tasks.  Used to fetch and store
@@ -47,8 +48,29 @@ func cacheTaskGroups(comparator *CmpBasedTaskComparator) error {
 	comparator.projects = make(map[string]project)
 	for _, v := range comparator.versions {
 		p := project{}
-		if err := yaml.Unmarshal([]byte(v.Config), &p); err != nil {
-			return errors.Wrapf(err, "error unmarshalling task groups from version %s", v.Id)
+		if v.ParserProject != nil {
+			p.TaskGroups = make([]model.TaskGroup, len(v.ParserProject.TaskGroups))
+			for i, tg := range v.ParserProject.TaskGroups {
+				newTG := model.TaskGroup{
+					Name:                  tg.Name,
+					MaxHosts:              tg.MaxHosts,
+					SetupGroupFailTask:    tg.SetupGroupFailTask,
+					SetupGroupTimeoutSecs: tg.SetupGroupTimeoutSecs,
+					SetupGroup:            tg.SetupGroup,
+					TeardownGroup:         tg.TeardownGroup,
+					SetupTask:             tg.SetupTask,
+					TeardownTask:          tg.TeardownTask,
+					Timeout:               tg.Timeout,
+					Tasks:                 tg.Tasks,
+					Tags:                  tg.Tags,
+					ShareProcs:            tg.ShareProcs,
+				}
+				p.TaskGroups[i] = newTG
+			}
+		} else {
+			if err := yaml.Unmarshal([]byte(v.Config), &p); err != nil {
+				return errors.Wrapf(err, "error unmarshalling task groups from version %s", v.Id)
+			}
 		}
 		comparator.projects[v.Id] = p
 	}

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -393,7 +393,6 @@ func (as *APIServer) listPatchModules(w http.ResponseWriter, r *http.Request) {
 	for m := range mods {
 		data.Modules = append(data.Modules, m)
 	}
-
 	gimlet.WriteJSON(w, &data)
 }
 

--- a/service/api_patch_test.go
+++ b/service/api_patch_test.go
@@ -89,7 +89,6 @@ func TestPatchListModulesEndPoints(t *testing.T) {
 				Project string   `json:"project"`
 				Modules []string `json:"modules"`
 			}{}
-
 			err = util.ReadJSONInto(resp.Body, &data)
 			So(err, ShouldBeNil)
 			So(len(data.Modules), ShouldEqual, 2)

--- a/service/api_plugin_manifest.go
+++ b/service/api_plugin_manifest.go
@@ -40,8 +40,8 @@ func (as *APIServer) manifestLoadHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	project := &model.Project{}
-	err = model.LoadProjectInto([]byte(v.Config), v.Identifier, project)
+	var project *model.Project
+	project, err = model.LoadProjectFromVersion(v, v.Identifier, true)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrap(err, "error loading project from version"))
 		return

--- a/service/middleware_helpers_current.go
+++ b/service/middleware_helpers_current.go
@@ -16,7 +16,7 @@ func setAPIHostContext(r *http.Request, h *host.Host) *http.Request {
 func setAPITaskContext(r *http.Request, t *task.Task) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), model.ApiTaskKey, t))
 }
-func setProjectReftContext(r *http.Request, p *model.ProjectRef) *http.Request {
+func setProjectRefContext(r *http.Request, p *model.ProjectRef) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), model.ApiProjectRefKey, p))
 }
 func setProjectContext(r *http.Request, p *model.Project) *http.Request {

--- a/service/patch.go
+++ b/service/patch.go
@@ -53,7 +53,7 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 
 	// Unmarshal the patch's project config so that it is always up to date with the configuration file in the project
 	project := &model.Project{}
-	if err := model.LoadProjectInto([]byte(projCtx.Patch.PatchedConfig), projCtx.Patch.Project, project); err != nil {
+	if _, err := model.LoadProjectInto([]byte(projCtx.Patch.PatchedConfig), projCtx.Patch.Project, project); err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Error unmarshaling project config"))
 	}
 
@@ -124,7 +124,7 @@ func (uis *UIServer) schedulePatch(w http.ResponseWriter, r *http.Request) {
 
 	// Unmarshal the project config and set it in the project context
 	project := &model.Project{}
-	if err = model.LoadProjectInto([]byte(projCtx.Patch.PatchedConfig), projCtx.Patch.Project, project); err != nil {
+	if _, err = model.LoadProjectInto([]byte(projCtx.Patch.PatchedConfig), projCtx.Patch.Project, project); err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Errorf("Error unmarshaling project config: %v", err))
 	}
 

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"gopkg.in/yaml.v2"
 )
 
 const NumRecentVersions = 10
@@ -234,7 +235,19 @@ func (restapi restAPI) getVersionConfig(w http.ResponseWriter, r *http.Request) 
 	}
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, err := w.Write([]byte(projCtx.Version.Config))
+
+	var config []byte
+	var err error
+	if projCtx.Version.ParserProject != nil {
+		config, err = yaml.Marshal(projCtx.Version.ParserProject)
+		if err != nil {
+			gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "problem marshalling project"})
+		}
+	} else {
+		config = []byte(projCtx.Version.Config)
+	}
+
+	_, err = w.Write(config)
 	grip.Warning(errors.Wrap(err, "problem writing response"))
 }
 

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -324,7 +324,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 		assert.Equal(upstreamTask.Id, v.TriggerID)
 		assert.Equal("task", v.TriggerType)
 		assert.Equal(e.ID, v.TriggerEvent)
-		assert.NotEmpty(v.Config)
+		assert.NotNil(v.ParserProject)
 	}
 	builds, err := build.Find(build.ByVersion(downstreamVersions[0].Id))
 	assert.NoError(err)

--- a/trigger/project_triggers_test.go
+++ b/trigger/project_triggers_test.go
@@ -57,8 +57,10 @@ func TestMakeDownstreamConfigFromFile(t *testing.T) {
 		Owner:      "evergreen-ci",
 		Repo:       "evergreen",
 	}
-	proj, err := makeDownstreamConfigFromFile(ref, "trigger/testdata/downstream_config.yml")
+	proj, pp, err := makeDownstreamConfigFromFile(ref, "trigger/testdata/downstream_config.yml")
 	assert.NoError(err)
+	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.Equal(ref.Identifier, proj.Identifier)
 	assert.Len(proj.Tasks, 2)
 	assert.Equal("task1", proj.Tasks[0].Name)

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -210,20 +210,22 @@ func TestGenerateTasks(t *testing.T) {
 	// Make sure first project was not changed
 	v, err := model.VersionFindOneId("random_version")
 	assert.NoError(err)
-	p := model.Project{}
-	err = model.LoadProjectInto([]byte(v.Config), "mci", &p)
+	p, err := model.LoadProjectFromVersion(v, "mci", true)
 	assert.NoError(err)
+	require.NotNil(p)
 	assert.Len(p.Tasks, 2)
+	require.Len(p.BuildVariants, 2)
 	assert.Len(p.BuildVariants[0].Tasks, 1)
 	assert.Len(p.BuildVariants[1].Tasks, 2)
 
 	// Verify second project was changed
 	v, err = model.VersionFindOneId("sample_version")
 	assert.NoError(err)
-	p = model.Project{}
-	err = model.LoadProjectInto([]byte(v.Config), "mci", &p)
+	p, err = model.LoadProjectFromVersion(v, "mci", true)
 	assert.NoError(err)
+	require.NotNil(p)
 	assert.Len(p.Tasks, 4)
+	require.Len(p.BuildVariants, 2)
 	assert.Len(p.BuildVariants[0].Tasks, 1)
 	assert.Len(p.BuildVariants[1].Tasks, 4)
 	assert.Len(p.TaskGroups, 1)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -360,7 +360,7 @@ func (s *PatchIntentUnitsSuite) verifyVersionDoc(patchDoc *patch.Patch, expected
 	s.Zero(versionDoc.FinishTime)
 	s.Equal(s.hash, versionDoc.Revision)
 	s.Equal(patchDoc.Description, versionDoc.Message)
-	s.NotZero(versionDoc.Config)
+	s.NotEmpty(versionDoc.ParserProject)
 	s.Equal(s.user, versionDoc.Author)
 	s.Len(versionDoc.BuildIds, 4)
 

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1687,8 +1687,9 @@ func TestTaskGroupValidation(t *testing.T) {
     - name: example_task_group
   `
 	var proj model.Project
-	err := model.LoadProjectInto([]byte(duplicateYml), "", &proj)
+	pp, err := model.LoadProjectInto([]byte(duplicateYml), "", &proj)
 	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.NoError(err)
 	validationErrs := validateTaskGroups(&proj)
 	assert.Len(validationErrs, 1)
@@ -1708,8 +1709,9 @@ func TestTaskGroupValidation(t *testing.T) {
     tasks:
     - name: foo
   `
-	err = model.LoadProjectInto([]byte(duplicateTaskYml), "", &proj)
+	pp, err = model.LoadProjectInto([]byte(duplicateTaskYml), "", &proj)
 	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.NoError(err)
 	validationErrs = validateTaskGroups(&proj)
 	assert.Len(validationErrs, 1)
@@ -1736,8 +1738,9 @@ buildvariants:
   tasks:
   - name: example_task_group
 `
-	err = model.LoadProjectInto([]byte(attachInGroupTeardownYml), "", &proj)
+	pp, err = model.LoadProjectInto([]byte(attachInGroupTeardownYml), "", &proj)
 	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.NoError(err)
 	validationErrs = validateTaskGroups(&proj)
 	assert.Len(validationErrs, 1)
@@ -1761,8 +1764,9 @@ buildvariants:
   tasks:
   - name: example_task_group
 `
-	err = model.LoadProjectInto([]byte(largeMaxHostYml), "", &proj)
+	pp, err = model.LoadProjectInto([]byte(largeMaxHostYml), "", &proj)
 	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.NoError(err)
 	validationErrs = checkTaskGroups(&proj)
 	assert.Len(validationErrs, 1)
@@ -1804,9 +1808,10 @@ buildvariants:
   - name: example_task_group
 `
 	proj := model.Project{}
-	err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
+	pp, err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
 	assert.NotNil(proj)
-	assert.Empty(err)
+	assert.NotNil(pp)
+	assert.NoError(err)
 	assert.Len(proj.TaskGroups, 1)
 	tg := proj.TaskGroups[0]
 	assert.Equal("example_task_group", tg.Name)
@@ -1846,9 +1851,10 @@ buildvariants:
   - name: example_task_group
 `
 	proj := model.Project{}
-	err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
+	pp, err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
 	assert.NotNil(proj)
-	assert.Empty(err)
+	assert.NotNil(pp)
+	assert.NoError(err)
 	assert.Len(proj.TaskGroups, 1)
 	tg := proj.TaskGroups[0]
 	assert.Equal("example_task_group", tg.Name)
@@ -1892,8 +1898,9 @@ buildvariants:
     - two
 `
 	proj := model.Project{}
-	err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
+	pp, err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
 	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.NoError(err)
 
 	proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks = append(proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks,
@@ -1924,8 +1931,9 @@ func TestValidateCreateHosts(t *testing.T) {
     - name: t_1
   `
 	var p model.Project
-	err := model.LoadProjectInto([]byte(yml), "id", &p)
+	pp, err := model.LoadProjectInto([]byte(yml), "id", &p)
 	require.NoError(err)
+	require.NotNil(pp)
 	errs := validateCreateHosts(&p)
 	assert.Len(errs, 0)
 
@@ -1943,8 +1951,9 @@ func TestValidateCreateHosts(t *testing.T) {
     tasks:
     - name: t_1
   `
-	err = model.LoadProjectInto([]byte(yml), "id", &p)
+	pp, err = model.LoadProjectInto([]byte(yml), "id", &p)
 	require.NoError(err)
+	require.NotNil(pp)
 	errs = validateCreateHosts(&p)
 	assert.Len(errs, 1)
 
@@ -2021,8 +2030,9 @@ func TestValidateCreateHosts(t *testing.T) {
     - name: t_10
     - name: t_11
   `
-	err = model.LoadProjectInto([]byte(yml), "id", &p)
+	pp, err = model.LoadProjectInto([]byte(yml), "id", &p)
 	require.NoError(err)
+	require.NotNil(pp)
 	errs = validateCreateHosts(&p)
 	assert.Len(errs, 1)
 }
@@ -2045,8 +2055,9 @@ func TestDuplicateTaskInBV(t *testing.T) {
     - t1
   `
 	var p model.Project
-	err := model.LoadProjectInto([]byte(yml), "", &p)
+	pp, err := model.LoadProjectInto([]byte(yml), "", &p)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs := validateDuplicateTaskDefinition(&p)
 	assert.Len(errs, 1)
 	assert.Contains(errs[0].Message, "task 't1' in 'bv' is listed more than once")
@@ -2065,8 +2076,9 @@ func TestDuplicateTaskInBV(t *testing.T) {
     - t1
     - tg1
   `
-	err = model.LoadProjectInto([]byte(yml), "", &p)
+	pp, err = model.LoadProjectInto([]byte(yml), "", &p)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs = validateDuplicateTaskDefinition(&p)
 	assert.Len(errs, 1)
 	assert.Contains(errs[0].Message, "task 't1' in 'bv' is listed more than once")
@@ -2088,8 +2100,9 @@ func TestDuplicateTaskInBV(t *testing.T) {
     - tg1
     - tg2
   `
-	err = model.LoadProjectInto([]byte(yml), "", &p)
+	pp, err = model.LoadProjectInto([]byte(yml), "", &p)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs = validateDuplicateTaskDefinition(&p)
 	assert.Len(errs, 1)
 	assert.Contains(errs[0].Message, "task 't1' in 'bv' is listed more than once")
@@ -2114,8 +2127,9 @@ tasks:
       - type: commandLogger
 `
 	project := &model.Project{}
-	err := model.LoadProjectInto([]byte(yml), "", project)
+	pp, err := model.LoadProjectInto([]byte(yml), "", project)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs := checkLoggerConfig(project)
 	assert.Contains(errs.String(), "error in project-level logger config: invalid agent logger config: Splunk logger requires a server URL")
 	assert.Contains(errs.String(), "invalid task logger config: somethingElse is not a valid log sender")
@@ -2132,8 +2146,9 @@ tasks:
     `
 
 	project = &model.Project{}
-	err = model.LoadProjectInto([]byte(yml), "", project)
+	pp, err = model.LoadProjectInto([]byte(yml), "", project)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs = checkLoggerConfig(project)
 	assert.Len(errs, 0)
 }
@@ -2167,9 +2182,10 @@ buildvariants:
   - name: two
 `
 	proj := model.Project{}
-	err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
+	pp, err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
 	assert.NotNil(proj)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs := CheckProjectSyntax(&proj)
 	assert.Len(errs, 1, "one warning was found")
 	assert.NoError(CheckProjectConfigurationIsValid(&proj), "no errors are reported because they are warnings")


### PR DESCRIPTION
Only the second commit needs review.

An error in updating the version shouldn't actually return an error because we're still able to get the project. 