### PR TITLE
EVG-6546: API server should accept host ID if it matches Jasper credentials ID

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -476,6 +476,17 @@ func ByIds(ids []string) db.Q {
 	})
 }
 
+// FindByJasperCredentialsID finds a host with the given Jasper credentials ID.
+func FindOneByJasperCredentialsID(id string) (*Host, error) {
+	h := &Host{}
+	query := bson.M{JasperCredentialsIDKey: id}
+	err := db.FindOne(Collection, query, db.NoProjection, db.NoSort, h)
+	if adb.ResultsNotFound(err) {
+		return nil, err
+	}
+	return h, err
+}
+
 // ByRunningTaskId returns a host running the task with the given id.
 func ByRunningTaskId(taskId string) db.Q {
 	return db.Query(bson.D{{Key: RunningTaskKey, Value: taskId}})

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -480,11 +480,10 @@ func ByIds(ids []string) db.Q {
 func FindOneByJasperCredentialsID(id string) (*Host, error) {
 	h := &Host{}
 	query := bson.M{JasperCredentialsIDKey: id}
-	err := db.FindOne(Collection, query, db.NoProjection, db.NoSort, h)
-	if adb.ResultsNotFound(err) {
-		return nil, err
+	if err := db.FindOne(Collection, query, db.NoProjection, db.NoSort, h); err != nil {
+		return nil, errors.Wrapf(err, "could not find host with Jasper credentials ID '%s'", id)
 	}
-	return h, err
+	return h, nil
 }
 
 // ByRunningTaskId returns a host running the task with the given id.
@@ -744,7 +743,7 @@ func FindOneByIdOrTag(id string) (*Host, error) {
 	})
 	host, err := FindOne(query) // try to find by tag
 	if err != nil {
-		return nil, errors.Wrap(err, "error finding '%s' by _id or tag field")
+		return nil, errors.Wrapf(err, "error finding '%s' by _id or tag field", id)
 	}
 	return host, nil
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3370,3 +3370,30 @@ func TestGetNumNewParentsWithInitializingParentAndHost(t *testing.T) {
 	assert.Equal(2, parents)
 	assert.Equal(4, hosts)
 }
+
+func TestFindOneByJasperCredentialsID(t *testing.T) {
+	id := "id"
+	for testName, testCase := range map[string]func(t *testing.T, h *Host){
+		"FailsWithoutJasperCredentialsID": func(t *testing.T, h *Host) {
+			h.Id = id
+			dbHost, err := FindOneByJasperCredentialsID(id)
+			assert.Error(t, err)
+			assert.Nil(t, dbHost)
+		},
+		"FindsHostWithJasperCredentialsID": func(t *testing.T, h *Host) {
+			h.JasperCredentialsID = id
+			require.NoError(t, h.Insert())
+			dbHost, err := FindOneByJasperCredentialsID(id)
+			require.NoError(t, err)
+			assert.Equal(t, dbHost, h)
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			require.NoError(t, db.Clear(Collection))
+			defer func() {
+				assert.NoError(t, db.Clear(Collection))
+			}()
+			testCase(t, &Host{})
+		})
+	}
+}

--- a/model/validate_test.go
+++ b/model/validate_test.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -37,4 +39,106 @@ func TestBadHostTaskRelationship(t *testing.T) {
 	runningTask.Status = evergreen.TaskDispatched
 	require.NoError(runningTask.Insert())
 	assert.False(badHostTaskRelationship(h, k), "false if task is dispatched")
+}
+
+func TestValidateHost(t *testing.T) {
+	hostID := "host_id"
+	secret := "secret"
+	taskID := "task_id"
+
+	for testName, testCase := range map[string]func(t *testing.T, h *host.Host, tsk *task.Task, header http.Header){
+		"PassesWithValidHostAndTask": func(t *testing.T, h *host.Host, tsk *task.Task, header http.Header) {
+			require.NoError(t, h.Insert())
+
+			req := &http.Request{Header: header}
+			req = req.WithContext(context.WithValue(context.Background(), ApiTaskKey, tsk))
+
+			validatedHost, status, err := ValidateHost(hostID, req)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, status)
+			assert.Equal(t, h, validatedHost)
+		},
+		"PassesIfHostHasValidJasperCredentialsID": func(t *testing.T, h *host.Host, tsk *task.Task, header http.Header) {
+			h.Id = ""
+			require.NoError(t, h.Insert())
+
+			req := &http.Request{Header: header}
+			req = req.WithContext(context.WithValue(context.Background(), ApiTaskKey, tsk))
+
+			validatedHost, status, err := ValidateHost(hostID, req)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, status)
+			assert.Equal(t, h, validatedHost)
+		},
+		"FailsWithoutSecret": func(t *testing.T, h *host.Host, tsk *task.Task, header http.Header) {
+			require.NoError(t, h.Insert())
+
+			header.Del(evergreen.HostSecretHeader)
+			req := &http.Request{Header: header}
+			req = req.WithContext(context.WithValue(context.Background(), ApiTaskKey, tsk))
+
+			validatedHost, status, err := ValidateHost(hostID, req)
+			assert.Error(t, err)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Nil(t, validatedHost)
+		},
+		"FailsWithMismatchedSecret": func(t *testing.T, h *host.Host, tsk *task.Task, header http.Header) {
+			require.NoError(t, h.Insert())
+
+			header.Set(evergreen.HostSecretHeader, "invalid_secret")
+			req := &http.Request{Header: header}
+			req = req.WithContext(context.WithValue(context.Background(), ApiTaskKey, tsk))
+
+			validatedHost, status, err := ValidateHost(hostID, req)
+			assert.Error(t, err)
+			assert.Equal(t, http.StatusUnauthorized, status)
+			assert.Nil(t, validatedHost)
+		},
+		"FailsWithoutMatchingID": func(t *testing.T, h *host.Host, tsk *task.Task, header http.Header) {
+			require.NoError(t, h.Insert())
+
+			header.Del(evergreen.HostHeader)
+			req := &http.Request{Header: header}
+			req = req.WithContext(context.WithValue(context.Background(), ApiTaskKey, tsk))
+
+			validatedHost, status, err := ValidateHost("", req)
+			assert.Error(t, err)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Nil(t, validatedHost)
+		},
+		"FailsWithoutMatchingTask": func(t *testing.T, h *host.Host, tsk *task.Task, header http.Header) {
+			h.RunningTask = "foo"
+			require.NoError(t, h.Insert())
+
+			req := &http.Request{Header: header}
+			req = req.WithContext(context.WithValue(context.Background(), ApiTaskKey, tsk))
+
+			validatedHost, status, err := ValidateHost(hostID, req)
+			assert.Error(t, err)
+			assert.Equal(t, http.StatusConflict, status)
+			assert.Nil(t, validatedHost)
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(host.Collection))
+			defer func() {
+				assert.NoError(t, db.ClearCollections(host.Collection))
+			}()
+
+			h := &host.Host{
+				Id:                  hostID,
+				RunningTask:         taskID,
+				Secret:              secret,
+				JasperCredentialsID: hostID,
+			}
+
+			tsk := &task.Task{Id: taskID}
+
+			header := http.Header{}
+			header.Add(evergreen.HostHeader, hostID)
+			header.Add(evergreen.HostSecretHeader, secret)
+
+			testCase(t, h, tsk, header)
+		})
+	}
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6546

If the host ID given in the agent request doesn't match a host ID in the database (because it was given the intent host ID when started through user data), try to match it against `Host.JasperCredentialsID`.