### PR TITLE
EVG-6309 support variant tags in aliases

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -661,7 +661,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 
 	for _, task := range buildVariant.Tasks {
 		if aliases != nil {
-			match, err := aliases.HasMatchingTask(buildVariant.Name, project.FindProjectTask(task.Name))
+			match, err := aliases.HasMatchingTask(buildVariant.Name, buildVariant.Tags, project.FindProjectTask(task.Name))
 			if err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"message": "error creating tasks with alias filter",

--- a/model/project.go
+++ b/model/project.go
@@ -1374,13 +1374,12 @@ func (p *Project) BuildProjectTVPairsWithAlias(alias string) ([]TVPair, []TVPair
 		}
 
 		for _, variant := range p.BuildVariants {
-			if variantRegex.MatchString(variant.Name) {
+			if isValidRegexOrTag(variant.Name, v.Variant, variant.Tags, v.VariantTags, variantRegex) {
 				for _, task := range p.Tasks {
 					if task.Patchable != nil && !(*task.Patchable) {
 						continue
 					}
-					if !((v.Task != "" && taskRegex.MatchString(task.Name)) ||
-						(len(v.Tags) > 0 && len(util.StringSliceIntersection(task.Tags, v.Tags)) > 0)) {
+					if !isValidRegexOrTag(task.Name, v.Task, task.Tags, v.TaskTags, taskRegex) {
 						continue
 					}
 

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -760,6 +760,7 @@ func (s *projectSuite) TestAliasResolution() {
 	s.Require().Len(pairs, 2)
 	s.Equal("bv_2/a_task_1", pairs[0].String())
 	s.Equal("bv_2/a_task_2", pairs[1].String())
+	s.Empty(displayTaskPairs)
 }
 
 func (s *projectSuite) TestBuildProjectTVPairs() {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -488,7 +488,7 @@ func (s *projectSuite) SetupTest() {
 			ProjectID: "project",
 			Alias:     "aTags",
 			Variant:   ".*",
-			Tags:      []string{"a"},
+			TaskTags:  []string{"a"},
 		},
 		{
 			ProjectID: "project",
@@ -512,7 +512,13 @@ func (s *projectSuite) SetupTest() {
 			ProjectID: "project",
 			Alias:     "part_of_memes",
 			Variant:   "bv_1",
-			Tags:      []string{"part_of_memes"},
+			TaskTags:  []string{"part_of_memes"},
+		},
+		{
+			ProjectID:   "project",
+			Alias:       "even_bvs",
+			VariantTags: []string{"even"},
+			TaskTags:    []string{"a"},
 		},
 	}
 	for _, alias := range s.aliases {
@@ -576,6 +582,7 @@ func (s *projectSuite) SetupTest() {
 			},
 			{
 				Name: "bv_2",
+				Tags: []string{"even"},
 				Tasks: []BuildVariantTaskUnit{
 					{
 						Name: "a_task_1",
@@ -747,6 +754,12 @@ func (s *projectSuite) TestAliasResolution() {
 	s.Require().Len(pairs, 1)
 	s.Equal("bv_3/disabled_task", pairs[0].String())
 	s.Empty(displayTaskPairs)
+
+	pairs, displayTaskPairs, err = s.project.BuildProjectTVPairsWithAlias(s.aliases[8].Alias)
+	s.NoError(err)
+	s.Require().Len(pairs, 2)
+	s.Equal("bv_2/a_task_1", pairs[0].String())
+	s.Equal("bv_2/a_task_2", pairs[1].String())
 }
 
 func (s *projectSuite) TestBuildProjectTVPairs() {

--- a/operations/list.go
+++ b/operations/list.go
@@ -242,7 +242,8 @@ func listAliases(ctx context.Context, confPath, project, filename string) error 
 
 	for _, alias := range aliases {
 		if alias.Alias != patch.GithubAlias {
-			fmt.Printf("%s\t%s\t%s\t%s\n", alias.Alias, alias.Variant, alias.Task, strings.Join(alias.Tags, ", "))
+			fmt.Printf("%s\t%s\t%s\t%s\t%s\n", alias.Alias, alias.Variant, strings.Join(alias.VariantTags, ","),
+				alias.Task, strings.Join(alias.TaskTags, ", "))
 		}
 	}
 

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -486,7 +486,7 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
 
   $scope.addPatchAlias = function() {
     if (!$scope.validPatchAlias($scope.patch_alias)){
-      $scope.invalidPatchAliasMessage = "A patch alias must have an alias name, variant regex, and exactly one of task regex or tag"
+      $scope.invalidPatchAliasMessage = "A patch alias must have an alias name, exactly one of variant regex or tag, and exactly one of task regex or tag"
       return
     }
     item = Object.assign({}, $scope.patch_alias)
@@ -650,8 +650,8 @@ mciModule.controller('ProjectCtrl', function($scope, $window, $http, $location, 
   }
 
   $scope.validPatchDefinition = function(alias){
-    // variant AND (task XOR tags)
-    return alias && alias.variant && (Boolean(alias.task) != !_.isEmpty(alias.tags))
+    // (variant XOR variant_tags) AND (task XOR tags)
+    return alias && (Boolean(alias.variant) != !_.isEmpty(alias.variant_tags)) && (Boolean(alias.task) != !_.isEmpty(alias.tags))
   }
 
   $scope.validPatchAlias = function(alias){

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -768,7 +768,7 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 			}
 			var match bool
 			if len(aliases) > 0 {
-				match, err = aliases.HasMatchingVariant(buildvariant.Name)
+				match, err = aliases.HasMatchingVariant(buildvariant.Name, buildvariant.Tags)
 				if err != nil {
 					grip.Error(err)
 					continue

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -32,12 +32,13 @@ type APIProjectVars struct {
 }
 
 type APIProjectAlias struct {
-	Alias   APIString   `json:"alias"`
-	Variant APIString   `json:"variant"`
-	Task    APIString   `json:"task"`
-	Tags    []APIString `json:"tags,omitempty"`
-	Delete  bool        `json:"delete,omitempty"`
-	ID      APIString   `json:"_id,omitempty"`
+	Alias       APIString   `json:"alias"`
+	Variant     APIString   `json:"variant"`
+	Task        APIString   `json:"task"`
+	VariantTags []APIString `json:"variant_tags,omitempty"`
+	TaskTags    []APIString `json:"tags,omitempty"`
+	Delete      bool        `json:"delete,omitempty"`
+	ID          APIString   `json:"_id,omitempty"`
 }
 
 func (e *APIProjectEvent) BuildFromService(h interface{}) error {
@@ -124,16 +125,21 @@ func (p *APIProjectVars) BuildFromService(h interface{}) error {
 }
 
 func (a *APIProjectAlias) ToService() (interface{}, error) {
-	tags := []string{}
-	for _, tag := range a.Tags {
-		tags = append(tags, FromAPIString(tag))
+	taskTags := []string{}
+	variantTags := []string{}
+	for _, tag := range a.TaskTags {
+		taskTags = append(taskTags, FromAPIString(tag))
+	}
+	for _, tag := range a.VariantTags {
+		variantTags = append(variantTags, FromAPIString(tag))
 	}
 
 	res := model.ProjectAlias{
-		Alias:   FromAPIString(a.Alias),
-		Task:    FromAPIString(a.Task),
-		Variant: FromAPIString(a.Variant),
-		Tags:    tags,
+		Alias:       FromAPIString(a.Alias),
+		Task:        FromAPIString(a.Task),
+		Variant:     FromAPIString(a.Variant),
+		TaskTags:    taskTags,
+		VariantTags: variantTags,
 	}
 	if model.IsValidId(FromAPIString(a.ID)) {
 		res.ID = model.NewId(FromAPIString(a.ID))
@@ -144,24 +150,34 @@ func (a *APIProjectAlias) ToService() (interface{}, error) {
 func (a *APIProjectAlias) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case *model.ProjectAlias:
-		APITags := []APIString{}
-		for _, tag := range v.Tags {
-			APITags = append(APITags, ToAPIString(tag))
+		APITaskTags := []APIString{}
+		APIVariantTags := []APIString{}
+		for _, tag := range v.TaskTags {
+			APITaskTags = append(APITaskTags, ToAPIString(tag))
+		}
+		for _, tag := range v.VariantTags {
+			APIVariantTags = append(APIVariantTags, ToAPIString(tag))
 		}
 		a.Alias = ToAPIString(v.Alias)
 		a.Variant = ToAPIString(v.Variant)
 		a.Task = ToAPIString(v.Task)
-		a.Tags = APITags
+		a.VariantTags = APIVariantTags
+		a.TaskTags = APITaskTags
 		a.ID = ToAPIString(v.ID.Hex())
 	case model.ProjectAlias:
-		APITags := []APIString{}
-		for _, tag := range v.Tags {
-			APITags = append(APITags, ToAPIString(tag))
+		APITaskTags := []APIString{}
+		APIVariantTags := []APIString{}
+		for _, tag := range v.TaskTags {
+			APITaskTags = append(APITaskTags, ToAPIString(tag))
+		}
+		for _, tag := range v.VariantTags {
+			APIVariantTags = append(APIVariantTags, ToAPIString(tag))
 		}
 		a.Alias = ToAPIString(v.Alias)
 		a.Variant = ToAPIString(v.Variant)
 		a.Task = ToAPIString(v.Task)
-		a.Tags = APITags
+		a.VariantTags = APIVariantTags
+		a.TaskTags = APITaskTags
 		a.ID = ToAPIString(v.ID.Hex())
 	default:
 		return errors.New("Invalid type of argument")
@@ -172,15 +188,20 @@ func (a *APIProjectAlias) BuildFromService(h interface{}) error {
 func DbProjectAliasesToRestModel(aliases []model.ProjectAlias) []APIProjectAlias {
 	result := []APIProjectAlias{}
 	for _, alias := range aliases {
-		APITags := []APIString{}
-		for _, tag := range alias.Tags {
-			APITags = append(APITags, ToAPIString(tag))
+		APITaskTags := []APIString{}
+		APIVariantTags := []APIString{}
+		for _, tag := range alias.TaskTags {
+			APITaskTags = append(APITaskTags, ToAPIString(tag))
+		}
+		for _, tag := range alias.VariantTags {
+			APIVariantTags = append(APIVariantTags, ToAPIString(tag))
 		}
 		apiAlias := APIProjectAlias{
-			Alias:   ToAPIString(alias.Alias),
-			Variant: ToAPIString(alias.Variant),
-			Task:    ToAPIString(alias.Task),
-			Tags:    APITags,
+			Alias:       ToAPIString(alias.Alias),
+			Variant:     ToAPIString(alias.Variant),
+			Task:        ToAPIString(alias.Task),
+			TaskTags:    APITaskTags,
+			VariantTags: APIVariantTags,
 		}
 		result = append(result, apiAlias)
 	}

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -125,21 +125,12 @@ func (p *APIProjectVars) BuildFromService(h interface{}) error {
 }
 
 func (a *APIProjectAlias) ToService() (interface{}, error) {
-	taskTags := []string{}
-	variantTags := []string{}
-	for _, tag := range a.TaskTags {
-		taskTags = append(taskTags, FromAPIString(tag))
-	}
-	for _, tag := range a.VariantTags {
-		variantTags = append(variantTags, FromAPIString(tag))
-	}
-
 	res := model.ProjectAlias{
 		Alias:       FromAPIString(a.Alias),
 		Task:        FromAPIString(a.Task),
 		Variant:     FromAPIString(a.Variant),
-		TaskTags:    taskTags,
-		VariantTags: variantTags,
+		TaskTags:    FromAPIStringList(a.TaskTags),
+		VariantTags: FromAPIStringList(a.VariantTags),
 	}
 	if model.IsValidId(FromAPIString(a.ID)) {
 		res.ID = model.NewId(FromAPIString(a.ID))
@@ -150,14 +141,9 @@ func (a *APIProjectAlias) ToService() (interface{}, error) {
 func (a *APIProjectAlias) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case *model.ProjectAlias:
-		APITaskTags := []APIString{}
-		APIVariantTags := []APIString{}
-		for _, tag := range v.TaskTags {
-			APITaskTags = append(APITaskTags, ToAPIString(tag))
-		}
-		for _, tag := range v.VariantTags {
-			APIVariantTags = append(APIVariantTags, ToAPIString(tag))
-		}
+		APITaskTags := ToAPIStringList(v.TaskTags)
+		APIVariantTags := ToAPIStringList(v.VariantTags)
+
 		a.Alias = ToAPIString(v.Alias)
 		a.Variant = ToAPIString(v.Variant)
 		a.Task = ToAPIString(v.Task)
@@ -165,14 +151,9 @@ func (a *APIProjectAlias) BuildFromService(h interface{}) error {
 		a.TaskTags = APITaskTags
 		a.ID = ToAPIString(v.ID.Hex())
 	case model.ProjectAlias:
-		APITaskTags := []APIString{}
-		APIVariantTags := []APIString{}
-		for _, tag := range v.TaskTags {
-			APITaskTags = append(APITaskTags, ToAPIString(tag))
-		}
-		for _, tag := range v.VariantTags {
-			APIVariantTags = append(APIVariantTags, ToAPIString(tag))
-		}
+		APITaskTags := ToAPIStringList(v.TaskTags)
+		APIVariantTags := ToAPIStringList(v.VariantTags)
+
 		a.Alias = ToAPIString(v.Alias)
 		a.Variant = ToAPIString(v.Variant)
 		a.Task = ToAPIString(v.Task)
@@ -188,20 +169,12 @@ func (a *APIProjectAlias) BuildFromService(h interface{}) error {
 func DbProjectAliasesToRestModel(aliases []model.ProjectAlias) []APIProjectAlias {
 	result := []APIProjectAlias{}
 	for _, alias := range aliases {
-		APITaskTags := []APIString{}
-		APIVariantTags := []APIString{}
-		for _, tag := range alias.TaskTags {
-			APITaskTags = append(APITaskTags, ToAPIString(tag))
-		}
-		for _, tag := range alias.VariantTags {
-			APIVariantTags = append(APIVariantTags, ToAPIString(tag))
-		}
 		apiAlias := APIProjectAlias{
 			Alias:       ToAPIString(alias.Alias),
 			Variant:     ToAPIString(alias.Variant),
 			Task:        ToAPIString(alias.Task),
-			TaskTags:    APITaskTags,
-			VariantTags: APIVariantTags,
+			TaskTags:    ToAPIStringList(alias.TaskTags),
+			VariantTags: ToAPIStringList(alias.VariantTags),
 		}
 		result = append(result, apiAlias)
 	}

--- a/rest/model/project_event_test.go
+++ b/rest/model/project_event_test.go
@@ -165,9 +165,13 @@ func checkAliases(suite *ProjectEventSuite, in []model.ProjectAlias, out []APIPr
 		suite.Equal(alias.Variant, FromAPIString(out[i].Variant))
 		suite.Equal(alias.Task, FromAPIString(out[i].Task))
 
-		suite.Require().Equal(len(alias.Tags), len(out[i].Tags))
-		for j, tag := range alias.Tags {
-			suite.Equal(tag, out[i].Tags[j])
+		suite.Require().Equal(len(alias.TaskTags), len(out[i].TaskTags))
+		suite.Require().Equal(len(alias.VariantTags), len(out[i].VariantTags))
+		for j, tag := range alias.TaskTags {
+			suite.Equal(tag, out[i].TaskTags[j])
+		}
+		for j, tag := range alias.VariantTags {
+			suite.Equal(tag, out[i].VariantTags[j])
 		}
 	}
 }

--- a/rest/model/string.go
+++ b/rest/model/string.go
@@ -12,3 +12,19 @@ func FromAPIString(in APIString) string {
 	}
 	return *in
 }
+
+func ToAPIStringList(in []string) []APIString {
+	res := []APIString{}
+	for _, each := range in {
+		res = append(res, ToAPIString(each))
+	}
+	return res
+}
+
+func FromAPIStringList(in []APIString) []string {
+	res := []string{}
+	for _, each := range in {
+		res = append(res, FromAPIString(each))
+	}
+	return res
+}

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -483,6 +483,7 @@ Evergreen Projects
           <div id="patch-aliases-list-header" class="form-group">
             <div class="col-lg-2"> <label class="control-label"> Alias </label> </div>
             <div class="col-lg-2"> <label class="control-label"> Variant Regex </label> </div>
+            <div class="col-lg-2"> <label class="control-label"> Variant Tags </label> </div>
             <div class="col-lg-2"> <label class="control-label"> Task Regex </label> </div>
             <div class="col-lg-2"> <label class="control-label"> Task Tags </label> </div>
             <div class="col-lg-2"></div>
@@ -494,6 +495,9 @@ Evergreen Projects
             </div>
             <div class="col-lg-2">
               <input class="form-control" ng-model="obj.variant" type="text" placeholder="variant regex">
+            </div>
+            <div class="col-lg-2">
+              <tag-input klass="form-control" items="obj.variant_tags" />
             </div>
             <div class="col-lg-2">
               <input class="form-control" ng-model="obj.task" type="text" placeholder="task regex">
@@ -516,12 +520,15 @@ Evergreen Projects
               <input ng-model="patch_alias.variant" class="form-control" type="text" placeholder="variant regex">
             </div>
             <div class="col-lg-2">
+              <tag-input klass="form-control" items="patch_alias.variant_tags" placeholder="tags (comma-delimited)" />
+            </div>
+            <div class="col-lg-2">
               <input ng-model="patch_alias.task" class="form-control" type="text" placeholder="task regex">
             </div>
             <div class="col-lg-2">
               <tag-input klass="form-control" items="patch_alias.tags" placeholder="tags (comma-delimited)" />
             </div>
-            <div class="col-lg-4">
+            <div class="col-lg-2">
               <button class="plus-button btn btn-primary " ng-disabled="!validPatchAlias(patch_alias)" type="button" ng-click="addPatchAlias()">
                 <i class="fa fa-plus"></i>
               </button>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -476,7 +476,7 @@ Evergreen Projects
           <div class="form-group">
             <div class="col-header col-lg-6 form-control-static">
               <h3>Patch Aliases</h3>
-              <div class="muted small">Specify aliases to use with the CLI. Aliases may be specified multiple times. The result will be their union. All regular expressions must be valid Golang regular expressions. Task regexes and tags will use their union, if specified. Use an alias with the --alias flag to the CLI patch command.</div>
+              <div class="muted small">Specify aliases to use with the CLI. Aliases may be specified multiple times. The result will be their union. All regular expressions must be valid Golang regular expressions. Must specify exactly one of the regex or tag field, for both tasks and variants. Use an alias with the --alias flag to the CLI patch command.</div>
             </div>
           </div>
 


### PR DESCRIPTION
New alias rule: valid if (a task regex XOR a task tag) AND (a variant regex XOR a variant tag)

Also involves a UI change to add variant tags.