### PR TITLE
EVG-6558: explicitly set timeout on dialing into Jasper service

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -429,6 +429,8 @@ func (h *Host) StartJasperProcess(ctx context.Context, env evergreen.Environment
 	return nil
 }
 
+const jasperDialTimeout = 15 * time.Second
+
 // JasperClient returns a remote client that communicates with this host's
 // Jasper service.
 func (h *Host) JasperClient(ctx context.Context, env evergreen.Environment) (jasper.RemoteClient, error) {
@@ -485,7 +487,7 @@ func (h *Host) JasperClient(ctx context.Context, env evergreen.Environment) (jas
 				return nil, errors.Wrapf(err, "could not resolve Jasper service address at '%s'", addrStr)
 			}
 
-			dialCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+			dialCtx, cancel := context.WithTimeout(ctx, jasperDialTimeout)
 			defer cancel()
 
 			return rpc.NewClient(dialCtx, serviceAddr, creds)

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -485,7 +485,10 @@ func (h *Host) JasperClient(ctx context.Context, env evergreen.Environment) (jas
 				return nil, errors.Wrapf(err, "could not resolve Jasper service address at '%s'", addrStr)
 			}
 
-			return rpc.NewClient(ctx, serviceAddr, creds)
+			dialCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+			defer cancel()
+
+			return rpc.NewClient(dialCtx, serviceAddr, creds)
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6558

If we don't do this, the dial blocks until the caller's context (e.g. agent monitor deploy job context) cancels.