### PR TITLE
EVG-6472: return next even if processing

### DIFF
--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -61,7 +61,7 @@ func (q *CommitQueue) Enqueue(item CommitQueueItem) (int, error) {
 }
 
 func (q *CommitQueue) Next() *CommitQueueItem {
-	if len(q.Queue) == 0 || q.Processing {
+	if len(q.Queue) == 0 {
 		return nil
 	}
 

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -125,7 +125,6 @@ func (s *CommitQueueSuite) TestRemoveOne() {
 	s.Equal("e345", items[1].Issue)
 
 	s.NoError(s.q.SetProcessing(true))
-	s.Nil(s.q.Next())
 	found, err = s.q.Remove("c123")
 	s.True(found)
 	s.NoError(err)

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -84,11 +84,6 @@ func (s *CommitQueueSuite) TestNext() {
 	s.NoError(err)
 	s.Equal(1, pos)
 	s.Len(s.q.Queue, 1)
-
-	s.NoError(s.q.SetProcessing(true))
-	s.Nil(s.q.Next())
-
-	s.NoError(s.q.SetProcessing(false))
 	s.Require().NotNil(s.q.Next())
 	s.Equal(s.q.Next().Issue, "c123")
 }
@@ -136,6 +131,7 @@ func (s *CommitQueueSuite) TestRemoveOne() {
 	s.NoError(err)
 	s.NotNil(s.q.Next())
 	s.Equal(s.q.Next().Issue, "e345")
+	s.False(s.q.Processing)
 }
 
 func (s *CommitQueueSuite) TestClearAll() {

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -80,7 +80,7 @@ func (s *CommitQueueSuite) TestCommitQueueRemoveItem() {
 	s.Require().NoError(err)
 	s.Require().Equal(3, pos)
 
-	s.queue.SetProcessing(true)
+	s.NoError(s.queue.SetProcessing(true))
 
 	found, err := s.ctx.CommitQueueRemoveItem("mci", "not_here")
 	s.NoError(err)

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -80,6 +80,8 @@ func (s *CommitQueueSuite) TestCommitQueueRemoveItem() {
 	s.Require().NoError(err)
 	s.Require().Equal(3, pos)
 
+	s.queue.SetProcessing(true)
+
 	found, err := s.ctx.CommitQueueRemoveItem("mci", "not_here")
 	s.NoError(err)
 	s.False(found)

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -113,7 +113,7 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 		return
 	}
 	nextItem := cq.Next()
-	if nextItem == nil {
+	if nextItem == nil || cq.Processing {
 		return
 	}
 	j.AddError(errors.Wrap(cq.SetProcessing(true), "can't set processing to true"))


### PR DESCRIPTION
#2501 introduced a panic if an item is removed from the commit queue while the commit queue is processing. If the queue is processing `head := queue.Next()` returned nil, so

https://github.com/evergreen-ci/evergreen/blob/492da7edcc398ed23a87da9785dbcb3d02afae49/rest/data/commit_queue.go#L87
panicked.
