### PR TITLE
EVG-6520: remove check for unchanged queue

### DIFF
--- a/model/commitqueue/db.go
+++ b/model/commitqueue/db.go
@@ -4,6 +4,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -53,13 +54,13 @@ func insert(q *CommitQueue) error {
 func add(id string, queue []CommitQueueItem, item CommitQueueItem) error {
 	err := updateOne(
 		bson.M{
-			IdKey:    id,
-			QueueKey: queue,
+			IdKey: id,
 		},
 		bson.M{"$push": bson.M{QueueKey: item}},
 	)
 
 	if adb.ResultsNotFound(err) {
+		grip.Error(errors.Wrapf(err, "update failed for queue '%s', %+v", id, queue))
 		return errors.New("queue has changed in the database")
 	}
 

--- a/model/commitqueue/db.go
+++ b/model/commitqueue/db.go
@@ -61,7 +61,7 @@ func add(id string, queue []CommitQueueItem, item CommitQueueItem) error {
 
 	if adb.ResultsNotFound(err) {
 		grip.Error(errors.Wrapf(err, "update failed for queue '%s', %+v", id, queue))
-		return errors.New("queue has changed in the database")
+		return errors.Errorf("update failed for queue '%s', %+v", id, queue)
 	}
 
 	return err


### PR DESCRIPTION
Checking the queue is unchanged is unnecessary since $push is an atomic operation.