### PR TITLE
EVG-6555: fix feedback submission on patch page opt in

### DIFF
--- a/public/static/js/settings.js
+++ b/public/static/js/settings.js
@@ -122,14 +122,25 @@ mciModule.controller('SettingsCtrl', ['$scope', '$http', '$window', 'notificatio
       notifier.pushNotification("Please fill out all required fields before submitting",'errorHeader');
       return;
     }
-    data = {
-        timezone: new_tz,
-        use_spruce_options: use_spruce_options,
-        spruce_feedback: formatFeedback(spruce_feedback),
-        github_user: {
-            last_known_as: $scope.github_user,
-        }
-    };
+    var data = {};
+    if ($scope.opt_in_initially_checked && && !use_spruce_options.patch_page) {
+      data = {
+          timezone: new_tz,
+          use_spruce_options: use_spruce_options,
+          spruce_feedback: formatFeedback(spruce_feedback),
+          github_user: {
+              last_known_as: $scope.github_user,
+          }
+      };
+    } else {
+      data = {
+          timezone: new_tz,
+          use_spruce_options: use_spruce_options,
+          github_user: {
+              last_known_as: $scope.github_user,
+          }
+      };
+    }
     var success = function() {
       window.location.reload();
     };

--- a/public/static/js/settings.js
+++ b/public/static/js/settings.js
@@ -122,24 +122,15 @@ mciModule.controller('SettingsCtrl', ['$scope', '$http', '$window', 'notificatio
       notifier.pushNotification("Please fill out all required fields before submitting",'errorHeader');
       return;
     }
-    var data = {};
+    data = {
+        timezone: new_tz,
+        use_spruce_options: use_spruce_options,
+        github_user: {
+            last_known_as: $scope.github_user,
+        }
+    };
     if ($scope.opt_in_initially_checked && !use_spruce_options.patch_page) {
-      data = {
-          timezone: new_tz,
-          use_spruce_options: use_spruce_options,
-          spruce_feedback: formatFeedback(spruce_feedback),
-          github_user: {
-              last_known_as: $scope.github_user,
-          }
-      };
-    } else {
-      data = {
-          timezone: new_tz,
-          use_spruce_options: use_spruce_options,
-          github_user: {
-              last_known_as: $scope.github_user,
-          }
-      };
+      data.spruce_feedback = formatFeedback(spruce_feedback);
     }
     var success = function() {
       window.location.reload();

--- a/public/static/js/settings.js
+++ b/public/static/js/settings.js
@@ -123,7 +123,7 @@ mciModule.controller('SettingsCtrl', ['$scope', '$http', '$window', 'notificatio
       return;
     }
     var data = {};
-    if ($scope.opt_in_initially_checked && && !use_spruce_options.patch_page) {
+    if ($scope.opt_in_initially_checked && !use_spruce_options.patch_page) {
       data = {
           timezone: new_tz,
           use_spruce_options: use_spruce_options,


### PR DESCRIPTION
This piece of code has been modified so that it only sends formatted feedback if the opt in box was checked initially, but was not checked at the time the user hit "save."