### PR TITLE
EVG-6502: stop tagging spot instance requests

### DIFF
--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -365,23 +365,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpot() {
 	s.Equal("sg-123456", *requestInput.LaunchSpecification.SecurityGroups[0])
 	s.Nil(requestInput.LaunchSpecification.SecurityGroupIds)
 	s.Nil(requestInput.LaunchSpecification.SubnetId)
-	tagsInput := *mock.CreateTagsInput
-	s.Equal("instance_id", *tagsInput.Resources[0])
-	s.Len(tagsInput.Tags, 8)
-	var foundInstanceName bool
-	var foundDistroID bool
-	for _, tag := range tagsInput.Tags {
-		if *tag.Key == "name" {
-			foundInstanceName = true
-			s.Equal(*tag.Value, "instance_id")
-		}
-		if *tag.Key == "distro" {
-			foundDistroID = true
-			s.Equal(*tag.Value, "distro_id")
-		}
-	}
-	s.True(foundInstanceName)
-	s.True(foundDistroID)
+	s.Nil(mock.CreateTagsInput)
 	s.Equal(base64OfSomeUserData, *requestInput.LaunchSpecification.UserData)
 }
 
@@ -421,23 +405,7 @@ func (s *EC2Suite) TestSpawnHostVPCSpot() {
 	s.Nil(requestInput.LaunchSpecification.SecurityGroupIds)
 	s.Nil(requestInput.LaunchSpecification.SecurityGroups)
 	s.Nil(requestInput.LaunchSpecification.SubnetId)
-	tagsInput := *mock.CreateTagsInput
-	s.Equal("instance_id", *tagsInput.Resources[0])
-	s.Len(tagsInput.Tags, 8)
-	var foundInstanceName bool
-	var foundDistroID bool
-	for _, tag := range tagsInput.Tags {
-		if *tag.Key == "name" {
-			foundInstanceName = true
-			s.Equal(*tag.Value, "instance_id")
-		}
-		if *tag.Key == "distro" {
-			foundDistroID = true
-			s.Equal(*tag.Value, "distro_id")
-		}
-	}
-	s.True(foundInstanceName)
-	s.True(foundDistroID)
+	s.Nil(mock.CreateTagsInput)
 	s.Equal(base64OfSomeUserData, *requestInput.LaunchSpecification.UserData)
 }
 


### PR DESCRIPTION
Many times when trying to tag a spot instance request (sir) right after creating it AWS returns an error that the sir doesn't exist. Since retry logic is built into the AWS client tagging eventually succeeds, but API calls are wasted.
The problem seems to be that the AWS API is only [eventually consistent](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#eventual-consistency).

Since tagging sirs isn't really necessary as long as the instance that gets created for them is tagged (tags on sirs don't propagate to the instances that get created for them) this PR is to stop tagging them.