### PR TITLE
EVG-6530 do not error in webhook if cq item/projectRef not found

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -357,10 +357,12 @@ func FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(owner, repo, branch st
 		db.NoSort,
 		projRef,
 	)
+	if adb.ResultsNotFound(err) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't query for project with commit queue. owner: %s, repo: %s, branch: %s", owner, repo, branch)
 	}
-
 	return projRef, nil
 }
 
@@ -440,7 +442,7 @@ func FindProjectRefs(key string, limit int, sortDir int, isAuthenticated bool) (
 
 func (projectRef *ProjectRef) CanEnableCommitQueue() (bool, error) {
 	resultRef, err := FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(projectRef.Owner, projectRef.Repo, projectRef.Branch)
-	if err != nil && !adb.ResultsNotFound(err) {
+	if err != nil {
 		return false, errors.Wrapf(err, "database error finding project by repo and branch")
 	}
 	if resultRef != nil && resultRef.Identifier != projectRef.Identifier {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -162,7 +162,7 @@ func TestFindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t *testing.T) {
 	require.NoError(db.Clear(ProjectRefCollection))
 
 	projectRef, err := FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch("mongodb", "mci", "master")
-	assert.Error(err)
+	assert.NoError(err)
 	assert.Nil(projectRef)
 
 	doc := &ProjectRef{
@@ -178,7 +178,7 @@ func TestFindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t *testing.T) {
 	require.NoError(doc.Insert())
 
 	projectRef, err = FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch("mongodb", "mci", "master")
-	assert.Error(err)
+	assert.NoError(err)
 	assert.Nil(projectRef)
 
 	doc.CommitQueue.Enabled = true

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -93,6 +93,19 @@ func (pc *DBCommitQueueConnector) CommitQueueRemoveItem(id, item string) (bool, 
 	return removed, nil
 }
 
+func (pc *DBCommitQueueConnector) IsItemOnCommitQueue(id, item string) (bool, error) {
+	cq, err := commitqueue.FindOneId(id)
+	if err != nil {
+		return false, errors.Wrapf(err, "can't get commit queue for id '%s'", id)
+	}
+
+	pos := cq.FindItem(item)
+	if pos >= 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
 func (pc *DBCommitQueueConnector) CommitQueueClearAll() (int, error) {
 	return commitqueue.ClearAllCommitQueues()
 }
@@ -247,6 +260,13 @@ func (pc *MockCommitQueueConnector) CommitQueueRemoveItem(id, item string) (bool
 	}
 
 	return false, nil
+}
+
+func (pc *MockCommitQueueConnector) IsItemOnCommitQueue(id, item string) (bool, error) {
+	if _, ok := pc.Queue[id]; !ok {
+		return false, nil
+	}
+	return true, nil
 }
 
 func (pc *MockCommitQueueConnector) CommitQueueClearAll() (int, error) {

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -263,10 +263,16 @@ func (pc *MockCommitQueueConnector) CommitQueueRemoveItem(id, item string) (bool
 }
 
 func (pc *MockCommitQueueConnector) IsItemOnCommitQueue(id, item string) (bool, error) {
-	if _, ok := pc.Queue[id]; !ok {
-		return false, nil
+	queue, ok := pc.Queue[id]
+	if !ok {
+		return false, errors.Errorf("can't get commit queue for id '%s'", id)
 	}
-	return true, nil
+	for _, queueItem := range queue {
+		if restModel.FromAPIString(queueItem.Issue) == item {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (pc *MockCommitQueueConnector) CommitQueueClearAll() (int, error) {

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -95,6 +95,25 @@ func (s *CommitQueueSuite) TestCommitQueueRemoveItem() {
 	s.Equal(restModel.ToAPIString("3"), cq.Queue[1].Issue)
 }
 
+func (s *CommitQueueSuite) TestIsItemOnCommitQueue() {
+	s.ctx = &DBConnector{}
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("1")})
+	s.Require().NoError(err)
+	s.Require().Equal(1, pos)
+
+	exists, err := s.ctx.IsItemOnCommitQueue("mci", "1")
+	s.NoError(err)
+	s.True(exists)
+
+	exists, err = s.ctx.IsItemOnCommitQueue("mci", "2")
+	s.NoError(err)
+	s.False(exists)
+
+	exists, err = s.ctx.IsItemOnCommitQueue("not-a-project", "1")
+	s.Error(err)
+	s.False(exists)
+}
+
 func (s *CommitQueueSuite) TestCommitQueueClearAll() {
 	s.ctx = &DBConnector{}
 	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("12")})

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -310,6 +310,25 @@ func (s *CommitQueueSuite) TestMockCommitQueueRemoveItem() {
 	s.Equal(restModel.ToAPIString("3"), cq.Queue[1].Issue)
 }
 
+func (s *CommitQueueSuite) TestMockIsItemOnCommitQueue() {
+	s.ctx = &MockConnector{}
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("1")})
+	s.Require().NoError(err)
+	s.Require().Equal(1, pos)
+
+	exists, err := s.ctx.IsItemOnCommitQueue("mci", "1")
+	s.NoError(err)
+	s.True(exists)
+
+	exists, err = s.ctx.IsItemOnCommitQueue("mci", "2")
+	s.NoError(err)
+	s.False(exists)
+
+	exists, err = s.ctx.IsItemOnCommitQueue("not-a-project", "1")
+	s.Error(err)
+	s.False(exists)
+}
+
 func (s *CommitQueueSuite) TestMockCommitQueueClearAll() {
 	s.ctx = &MockConnector{}
 	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToAPIString("12")})

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -280,6 +280,7 @@ type Connector interface {
 	FindCommitQueueByID(string) (*restModel.APICommitQueue, error)
 	EnableCommitQueue(*model.ProjectRef, model.CommitQueueParams) error
 	CommitQueueRemoveItem(string, string) (bool, error)
+	IsItemOnCommitQueue(string, string) (bool, error)
 	CommitQueueClearAll() (int, error)
 	IsAuthorizedToPatchAndMerge(context.Context, *evergreen.Settings, UserRepoInfo) (bool, error)
 

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -15,7 +15,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"gopkg.in/mgo.v2"
 )
 
 // DBProjectConnector is a struct that implements the Project related methods
@@ -400,7 +399,7 @@ func (pc *MockProjectConnector) GetProjectWithCommitQueueByOwnerRepoAndBranch(ow
 		}
 	}
 
-	return nil, errors.Wrapf(mgo.ErrNotFound, "can't query for projectRef %s/%s tracking %s", owner, repo, branch)
+	return nil, errors.Wrapf(errors.New("not found"), "can't query for projectRef %s/%s tracking %s", owner, repo, branch)
 }
 func (pc *MockProjectConnector) EnableWebhooks(ctx context.Context, projectRef *model.ProjectRef) (bool, error) {
 	return false, nil

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"gopkg.in/mgo.v2"
 )
 
 // DBProjectConnector is a struct that implements the Project related methods
@@ -399,7 +400,7 @@ func (pc *MockProjectConnector) GetProjectWithCommitQueueByOwnerRepoAndBranch(ow
 		}
 	}
 
-	return nil, errors.Errorf("can't query for projectRef %s/%s tracking %s", owner, repo, branch)
+	return nil, errors.Wrapf(mgo.ErrNotFound, "can't query for projectRef %s/%s tracking %s", owner, repo, branch)
 }
 func (pc *MockProjectConnector) EnableWebhooks(ctx context.Context, projectRef *model.ProjectRef) (bool, error) {
 	return false, nil

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -394,12 +394,11 @@ func (pc *MockProjectConnector) GetProjectEventLog(id string, before time.Time, 
 
 func (pc *MockProjectConnector) GetProjectWithCommitQueueByOwnerRepoAndBranch(owner, repo, branch string) (*model.ProjectRef, error) {
 	for _, p := range pc.CachedProjects {
-		if p.Owner == owner && p.Repo == repo && p.Branch == branch {
+		if p.Owner == owner && p.Repo == repo && p.Branch == branch && p.CommitQueue.Enabled == true {
 			return &p, nil
 		}
 	}
-
-	return nil, errors.Wrapf(errors.New("not found"), "can't query for projectRef %s/%s tracking %s", owner, repo, branch)
+	return nil, nil
 }
 func (pc *MockProjectConnector) EnableWebhooks(ctx context.Context, projectRef *model.ProjectRef) (bool, error) {
 	return false, nil

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -464,10 +464,12 @@ func (s *ProjectConnectorGetSuite) TestGetProjectEvents() {
 
 func (s *ProjectConnectorGetSuite) TestGetProjectWithCommitQueueByOwnerRepoAndBranch() {
 	projRef, err := s.ctx.GetProjectWithCommitQueueByOwnerRepoAndBranch("octocat", "hello-world", "master")
-	s.Error(err)
+	s.NoError(err)
+	s.Nil(projRef)
 
 	projRef, err = s.ctx.GetProjectWithCommitQueueByOwnerRepoAndBranch("evergreen-ci", "evergreen", "master")
 	s.NoError(err)
+	s.NotNil(projRef)
 	s.Equal("projectB", projRef.Identifier)
 }
 

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -361,7 +361,11 @@ func (gh *githubHookApi) tryDequeueCommitQueueItemForPR(pr *github.PullRequest) 
 		return nil
 	}
 
-	if exists, _ := gh.sc.IsItemOnCommitQueue(projRef.Identifier, strconv.Itoa(*pr.Number)); !exists {
+	exists, err := gh.sc.IsItemOnCommitQueue(projRef.Identifier, strconv.Itoa(*pr.Number))
+	if err != nil {
+		return errors.Wrapf(err, "can't determine if item is on commit queue %s", projRef.Identifier)
+	}
+	if !exists {
 		return nil
 	}
 

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -286,6 +286,11 @@ func (s *GithubWebhookRouteSuite) TestTryDequeueCommitQueueItemForPR() {
 	// try dequeue errors if the PR is missing information (PR number)
 	s.Error(s.h.tryDequeueCommitQueueItemForPR(pr))
 
+	// try dequeue returns no error if there is no matching item
+	newNumber := 2
+	pr.Number = &newNumber
+	s.NoError(s.h.tryDequeueCommitQueueItemForPR(pr))
+
 	pr.Number = &number
 	// try dequeue returns no errors if there is no matching queue
 	s.NoError(s.h.tryDequeueCommitQueueItemForPR(pr))
@@ -298,7 +303,7 @@ func (s *GithubWebhookRouteSuite) TestTryDequeueCommitQueueItemForPR() {
 	s.NoError(err)
 	s.Empty(queue.Queue)
 
-	// try dequeue errors if no projectRef matches the PR
+	// try dequeue returns no error if no projectRef matches the PR
 	owner = "octocat"
-	s.Error(s.h.tryDequeueCommitQueueItemForPR(pr))
+	s.NoError(s.h.tryDequeueCommitQueueItemForPR(pr))
 }

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -79,6 +79,11 @@ func (s *GithubWebhookRouteSuite) SetupTest() {
 				},
 			},
 		},
+		MockCommitQueueConnector: data.MockCommitQueueConnector{
+			Queue: map[string][]restModel.APICommitQueueItem{
+				"bth": []restModel.APICommitQueueItem{},
+			},
+		},
 	}
 
 	s.rm = makeGithubHooksRoute(s.sc, s.queue, []byte(s.conf.Api.GithubWebhookSecret), evergreen.GetEnvironment().Settings())

--- a/service/project.go
+++ b/service/project.go
@@ -314,7 +314,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	if commitQueueParams.Enabled {
 		var projRef *model.ProjectRef
 		projRef, err = model.FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(responseRef.Owner, responseRef.Repo, responseRef.Branch)
-		if err != nil && !adb.ResultsNotFound(err) {
+		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}


### PR DESCRIPTION
Commit queue item doesn't necessarily exist, so we should only return an error if there's a database error or if there's an actual issue removing an item that exists.

(Note: slightly awkward error hardcoding. Alternatively we could store these errors as constants, or not have TryDequeue return an error when there's an issue removing an existing item, although that feels overly simplistic)