### PR TITLE
EVG-6427 consider paused cq items on patch page

### DIFF
--- a/service/patch.go
+++ b/service/patch.go
@@ -89,10 +89,6 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 		}
 		if cq != nil {
 			commitQueuePosition = cq.FindItem(projCtx.Patch.Id.Hex())
-			// if CLI commit queue, an item not on the queue may be paused
-			if commitQueuePosition < 0 && projCtx.ProjectRef.CommitQueue.PatchType != commitqueue.CLIPatchType {
-				uis.LoggedError(w, r, http.StatusNotFound, errors.New("item not on commit queue"))
-			}
 		}
 	}
 

--- a/service/patch.go
+++ b/service/patch.go
@@ -83,16 +83,16 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 	commitQueuePosition := 0
 	if projCtx.Patch.Alias == evergreen.CommitQueueAlias {
 		cq, err := commitqueue.FindOneId(project.Identifier)
+		// still display patch page if problem finding commit queue
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error finding commit queue"))
 		}
-		if cq == nil {
-			uis.LoggedError(w, r, http.StatusNotFound, errors.New("commit queue not found"))
-		}
-		commitQueuePosition = cq.FindItem(projCtx.Patch.Id.Hex())
-		// if CLI commit queue, an item not on the queue may be paused
-		if commitQueuePosition < 0 && projCtx.ProjectRef.CommitQueue.PatchType != commitqueue.CLIPatchType {
-			uis.LoggedError(w, r, http.StatusNotFound, errors.New("item not on commit queue"))
+		if cq != nil {
+			commitQueuePosition = cq.FindItem(projCtx.Patch.Id.Hex())
+			// if CLI commit queue, an item not on the queue may be paused
+			if commitQueuePosition < 0 && projCtx.ProjectRef.CommitQueue.PatchType != commitqueue.CLIPatchType {
+				uis.LoggedError(w, r, http.StatusNotFound, errors.New("item not on commit queue"))
+			}
 		}
 	}
 

--- a/service/templates/patch_version.html
+++ b/service/templates/patch_version.html
@@ -32,7 +32,7 @@ Evergreen - Configure Patch
         <h3>This patch is at position [[commitQueuePosition]] in the commit queue.</h3>
       </div>
       <div ng-show="commitQueuePosition < 0">
-        <h3>This patch is not on the queue (may be paused).</h3>
+        <h3>This patch is not on the queue (paused or deleted).</h3>
       </div>
     </div>
   </div>

--- a/service/templates/patch_version.html
+++ b/service/templates/patch_version.html
@@ -28,7 +28,12 @@ Evergreen - Configure Patch
       <a href="/version/[[patch.Version]]">View Existing Tasks&hellip;</a>
     </div>
     <div ng-show="patch.Version.length == 0">
-      <h3>This patch is at position [[commitQueuePosition]] in the commit queue.</h3>
+      <div ng-show="commitQueuePosition >= 0">
+        <h3>This patch is at position [[commitQueuePosition]] in the commit queue.</h3>
+      </div>
+      <div ng-show="commitQueuePosition < 0">
+        <h3>This patch is not on the queue (may be paused).</h3>
+      </div>
     </div>
   </div>
   <div ng-show="patch.Alias != '__commit_queue'">


### PR DESCRIPTION
I'm not sure if there's an intelligent way to know if an item is paused--only a CLI item can be paused, so we should error if the item isn't found for other cq types (assuming that other types could ever have patch pages). Otherwise print a message that it could be paused. The front end component needs to be verified in staging.