### PR TITLE
EVG-6206 use task db in v1 getRecentVersions

### DIFF
--- a/model/build/db.go
+++ b/model/build/db.go
@@ -234,6 +234,11 @@ func FindOneId(id string) (*Build, error) {
 	return FindOne(ById(id))
 }
 
+func FindBuildsByVersions(versionIds []string) ([]Build, error) {
+	return Find(ByVersions(versionIds).
+		WithFields(BuildVariantKey, DisplayNameKey, TasksKey, VersionKey))
+}
+
 // Find returns all builds that satisfy the query.
 func Find(query db.Q) ([]Build, error) {
 	builds := []Build{}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -164,6 +164,11 @@ func ByVersion(version string) db.Q {
 	})
 }
 
+// ByVersion produces a query that returns tasks for the given version.
+func ByVersions(versions []string) db.Q {
+	return db.Query(bson.M{VersionKey: bson.M{"$in": versions}})
+}
+
 // ByIdsBuildIdAndStatus creates a query to return tasks with a certain build id and statuses
 func ByIdsBuildAndStatus(taskIds []string, buildId string, statuses []string) db.Q {
 	return db.Query(bson.M{

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -817,6 +817,11 @@ func FindAllTasksFromVersionWithDependencies(versionId string) ([]Task, error) {
 	return tasks, nil
 }
 
+func FindTasksFromVersions(versionIds []string) ([]Task, error) {
+	return Find(ByVersions(versionIds).
+		WithFields(IdKey, DisplayNameKey, StatusKey, TimeTakenKey, VersionKey, BuildVariantKey))
+}
+
 func FindAllTaskIDsFromBuild(buildId string) ([]string, error) {
 	q := db.Query(bson.M{BuildIdKey: buildId}).WithFields(IdKey)
 	return findAllTaskIDs(q)

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -173,6 +173,22 @@ func VersionByMostRecentSystemRequester(projectId string) db.Q {
 	).Sort([]string{"-" + VersionRevisionOrderNumberKey})
 }
 
+// if startOrder is specified, only returns older versions (i.e. with a smaller revision number)
+func VersionBySystemRequesterOrdered(projectId string, startOrder int) db.Q {
+	q := bson.M{
+		VersionRequesterKey: bson.M{
+			"$in": evergreen.SystemVersionRequesterTypes,
+		},
+		VersionIdentifierKey: projectId,
+	}
+	if startOrder > 0 {
+		q[VersionRevisionOrderNumberKey] = bson.M{
+			"$lt": startOrder,
+		}
+	}
+	return db.Query(q).Sort([]string{"-" + VersionRevisionOrderNumberKey})
+}
+
 // ByMostRecentNonIgnored finds all non-ignored versions within a project,
 // ordered by most recently created to oldest.
 func VersionByMostRecentNonIgnored(projectId string) db.Q {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -59,8 +59,7 @@ type Connector interface {
 
 	// FindTasksByBuildId is a method to find a set of tasks which all have the same
 	// BuildId. It takes the buildId being queried for as its first parameter,
-	// as well as a taskId and limit for paginating through the results.
-	// It returns a list of tasks which match.
+	// as well as a taskId, status, and limit for paginating through the results.
 	FindTasksByBuildId(string, string, string, int, int) ([]task.Task, error)
 
 	// FindBuildById is a method to find the build matching the same BuildId.

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -182,7 +182,6 @@ func (restapi restAPI) getRecentVersions(w http.ResponseWriter, r *http.Request)
 			Revision: version.Revision,
 			Message:  version.Message,
 			Builds:   make(versionByBuild),
-			//Tasks:    make(versionStatusByTask),
 		}
 
 		result.Versions = append(result.Versions, versionInfo)

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
@@ -63,11 +64,12 @@ type restVersion struct {
 }
 
 type versionLessInfo struct {
-	Id       string         `json:"version_id"`
-	Author   string         `json:"author"`
-	Revision string         `json:"revision"`
-	Message  string         `json:"message"`
-	Builds   versionByBuild `json:"builds"`
+	Id       string              `json:"version_id"`
+	Author   string              `json:"author"`
+	Revision string              `json:"revision"`
+	Message  string              `json:"message"`
+	Builds   versionByBuild      `json:"builds"`
+	Tasks    versionStatusByTask `json:"tasks"`
 }
 
 type versionStatus struct {
@@ -79,12 +81,9 @@ type versionStatus struct {
 type versionByBuild map[string]versionBuildInfo
 
 type versionBuildInfo struct {
-	Id    string               `json:"build_id"`
-	Name  string               `json:"name"`
-	Tasks versionByBuildByTask `json:"tasks"`
+	Id   string `json:"build_id"`
+	Name string `json:"name"`
 }
-
-type versionByBuildByTask map[string]versionStatus
 
 type versionStatusByTask map[string]versionStatus
 
@@ -118,14 +117,25 @@ func copyVersion(srcVersion *model.Version, destVersion *restVersion) {
 // Returns a JSON response of an array with the NumRecentVersions
 // most recent versions (sorted on commit order number descending).
 func (restapi restAPI) getRecentVersions(w http.ResponseWriter, r *http.Request) {
+	var err error
 	projectId := gimlet.GetVars(r)["project_id"]
 	limit := r.FormValue("limit")
+	startStr := r.FormValue("start")
+	start := 0
+	if startStr != "" {
+		start, err = strconv.Atoi(startStr)
+		if err != nil {
+			gimlet.WriteJSONError(w, responseError{Message: "'start' query parameter must be a valid integer"})
+			return
+		}
+		if start < 0 {
+			gimlet.WriteJSONError(w, responseError{Message: "'start' must be a non-negative integer"})
+			return
+		}
+	}
 
-	var l int
-	var err error
-	if limit == "" {
-		l = NumRecentVersions
-	} else {
+	l := NumRecentVersions
+	if limit != "" {
 		l, err = strconv.Atoi(limit)
 		if err != nil {
 			msg := fmt.Sprintf("Error parsing %s as an integer", limit)
@@ -133,8 +143,9 @@ func (restapi restAPI) getRecentVersions(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-	versions, err := model.VersionFind(model.VersionByMostRecentSystemRequester(projectId).Limit(l))
 
+	// add one to limit to determine if a new page is necessary
+	versions, err := model.VersionFind(model.VersionBySystemRequesterOrdered(projectId, start).Limit(l + 1))
 	if err != nil {
 		msg := fmt.Sprintf("Error finding recent versions of project '%v'", projectId)
 		grip.Errorf("%v: %+v", msg, err)
@@ -142,33 +153,26 @@ func (restapi restAPI) getRecentVersions(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	nextPageStart := ""
+	// save the ID for the next page version, and remove this version from results
+	if len(versions) > l {
+		nextPageStart = strconv.Itoa(versions[len(versions)-1].RevisionOrderNumber)
+		versions = versions[:len(versions)-1]
+	}
 	// Create a slice of version ids to find all relevant builds
 	versionIds := make([]string, 0, len(versions))
 
 	// Cache the order of versions in a map for lookup by their id
 	versionIdx := make(map[string]int, len(versions))
-
 	for i, version := range versions {
 		versionIds = append(versionIds, version.Id)
 		versionIdx[version.Id] = i
-	}
-
-	// Find all builds corresponding the set of version ids
-	builds, err := build.Find(
-		build.ByVersions(versionIds).
-			WithFields(build.BuildVariantKey, build.DisplayNameKey, build.TasksKey, build.VersionKey))
-	if err != nil {
-		msg := fmt.Sprintf("Error finding recent versions of project '%v'", projectId)
-		grip.Errorf("%v: %+v", msg, err)
-		gimlet.WriteJSONInternalError(w, responseError{Message: msg})
-		return
 	}
 
 	result := recentVersionsContent{
 		Project:  projectId,
 		Versions: make([]versionLessInfo, 0, len(versions)),
 	}
-
 	for _, version := range versions {
 		versionInfo := versionLessInfo{
 			Id:       version.Id,
@@ -176,31 +180,72 @@ func (restapi restAPI) getRecentVersions(w http.ResponseWriter, r *http.Request)
 			Revision: version.Revision,
 			Message:  version.Message,
 			Builds:   make(versionByBuild),
+			Tasks:    make(versionStatusByTask),
 		}
 
 		result.Versions = append(result.Versions, versionInfo)
 	}
-
-	for _, build := range builds {
-		buildInfo := versionBuildInfo{
-			Id:    build.Id,
-			Name:  build.DisplayName,
-			Tasks: make(versionByBuildByTask, len(build.Tasks)),
-		}
-
-		for _, task := range build.Tasks {
-			buildInfo.Tasks[task.DisplayName] = versionStatus{
-				Id:        task.Id,
-				Status:    task.Status,
-				TimeTaken: task.TimeTaken,
-			}
-		}
-
-		versionInfo := result.Versions[versionIdx[build.Version]]
-		versionInfo.Builds[build.BuildVariant] = buildInfo
+	// Find all builds/tasks corresponding the set of version ids
+	if err = result.populateBuildsAndTasks(versionIds, versionIdx); err != nil {
+		msg := fmt.Sprintf("Error populating builds/tasks for recent versions of project '%v'", projectId)
+		grip.Errorf("%v: %+v", msg, err)
+		gimlet.WriteJSONInternalError(w, responseError{Message: msg})
 	}
 
+	// create a page header
+	if nextPageStart != "" {
+		responder := gimlet.NewResponseBuilder()
+		err = responder.SetPages(&gimlet.ResponsePages{
+			Next: &gimlet.Page{
+				Relation:        "next",
+				LimitQueryParam: "limit",
+				KeyQueryParam:   "start",
+				BaseURL:         restapi.GetSettings().ApiUrl,
+				Key:             nextPageStart,
+				Limit:           l,
+			},
+		})
+		if err != nil {
+			msg := "error setting pages"
+			grip.Errorf("%v: %+v", msg, err)
+			gimlet.WriteJSONInternalError(w, responseError{Message: msg})
+		}
+		w.Header().Set("Link", responder.Pages().GetLinks(r.URL.String()))
+	}
 	gimlet.WriteJSON(w, result)
+}
+
+func (r *recentVersionsContent) populateBuildsAndTasks(versionIds []string, versionIdx map[string]int) error {
+	builds, err := build.Find(
+		build.ByVersions(versionIds).
+			WithFields(build.BuildVariantKey, build.DisplayNameKey, build.TasksKey, build.VersionKey))
+	if err != nil {
+		return errors.Wrap(err, "Error finding recent versions")
+	}
+	tasks, err := task.Find(task.ByVersions(versionIds).
+		WithFields(task.IdKey, task.DisplayNameKey, task.StatusKey, task.TimeTakenKey, task.VersionKey))
+	if err != nil {
+		return errors.Wrap(err, "Error finding recent tasks for recent versions")
+	}
+
+	for _, b := range builds {
+		buildInfo := versionBuildInfo{
+			Id:   b.Id,
+			Name: b.DisplayName,
+		}
+		versionInfo := r.Versions[versionIdx[b.Version]]
+		versionInfo.Builds[b.BuildVariant] = buildInfo
+	}
+	for _, t := range tasks {
+		taskInfo := versionStatus{
+			Id:        t.Id,
+			Status:    t.Status,
+			TimeTaken: t.TimeTaken,
+		}
+		versionInfo := r.Versions[versionIdx[t.Version]]
+		versionInfo.Tasks[t.DisplayName] = taskInfo
+	}
+	return nil
 }
 
 // Returns a JSON response with the marshaled output of the version

--- a/service/rest_version_test.go
+++ b/service/rest_version_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/task"
 	modelutil "github.com/evergreen-ci/evergreen/model/testutil"
 	serviceutil "github.com/evergreen-ci/evergreen/service/testutil"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -56,8 +57,7 @@ func TestGetRecentVersions(t *testing.T) {
 	require.NoError(t, err, "Error loading local config render")
 
 	Convey("When finding recent versions", t, func() {
-		require.NoError(t, db.ClearCollections(model.VersionCollection, build.Collection),
-			"Error clearing '%v' collection", model.VersionCollection)
+		require.NoError(t, db.ClearCollections(model.VersionCollection, build.Collection, task.Collection))
 
 		projectName := "project_test"
 
@@ -67,6 +67,7 @@ func TestGetRecentVersions(t *testing.T) {
 		So(projectName, ShouldNotEqual, otherProjectName) // sanity-check
 
 		buildIdPreface := "build-id-for-version%v"
+		taskIdPreface := "task-id-for-version%v"
 
 		So(NumRecentVersions, ShouldBeGreaterThan, 0)
 		versions := make([]*model.Version, 0, NumRecentVersions)
@@ -114,12 +115,7 @@ func TestGetRecentVersions(t *testing.T) {
 		So(otherVersion.Insert(), ShouldBeNil)
 
 		builds := make([]*build.Build, 0, NumRecentVersions)
-		task := build.TaskCache{
-			Id:          "some-task-id",
-			DisplayName: "some-task-name",
-			Status:      "success",
-			TimeTaken:   time.Duration(100 * time.Millisecond),
-		}
+		tasks := make([]*task.Task, 0, NumRecentVersions)
 
 		for i := 0; i < NumRecentVersions; i++ {
 			build := &build.Build{
@@ -127,10 +123,19 @@ func TestGetRecentVersions(t *testing.T) {
 				Version:      versions[i].Id,
 				BuildVariant: "some-build-variant",
 				DisplayName:  "Some Build Variant",
-				Tasks:        []build.TaskCache{task},
 			}
 			So(build.Insert(), ShouldBeNil)
 			builds = append(builds, build)
+
+			task := &task.Task{
+				Id:          fmt.Sprintf(taskIdPreface, i),
+				Version:     versions[i].Id,
+				DisplayName: "some-task-name",
+				Status:      "success",
+				TimeTaken:   time.Duration(100 * time.Millisecond),
+			}
+			So(task.Insert(), ShouldBeNil)
+			tasks = append(tasks, task)
 		}
 
 		url := "/rest/v1/projects/" + projectName + "/versions"
@@ -142,13 +147,16 @@ func TestGetRecentVersions(t *testing.T) {
 		// Need match variables to be set so can call mux.Vars(request)
 		// in the actual handler function
 		router.ServeHTTP(response, request)
-
 		So(response.Code, ShouldEqual, http.StatusOK)
 
 		Convey("response should match contents of database", func() {
 			var jsonBody map[string]interface{}
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
+			link := response.Header().Get("Link")
+			So(link, ShouldNotBeEmpty)
+			So(link, ShouldContainSubstring, "/versions")
+			So(link, ShouldContainSubstring, "limit=10&start=0")
 
 			var rawJsonBody map[string]*json.RawMessage
 			err = json.Unmarshal(response.Body.Bytes(), &rawJsonBody)
@@ -183,20 +191,20 @@ func TestGetRecentVersions(t *testing.T) {
 				So(jsonBuild["build_id"], ShouldEqual, builds[i].Id)
 				So(jsonBuild["name"], ShouldEqual, builds[i].DisplayName)
 
-				_jsonTasks, ok := jsonBuild["tasks"]
+				_jsonTasks, ok := jsonVersion["tasks"]
 				So(ok, ShouldBeTrue)
 				jsonTasks, ok := _jsonTasks.(map[string]interface{})
 				So(ok, ShouldBeTrue)
 				So(len(jsonTasks), ShouldEqual, 1)
 
-				_jsonTask, ok := jsonTasks[task.DisplayName]
+				_jsonTask, ok := jsonTasks[tasks[i].DisplayName]
 				So(ok, ShouldBeTrue)
 				jsonTask, ok := _jsonTask.(map[string]interface{})
 				So(ok, ShouldBeTrue)
 
-				So(jsonTask["task_id"], ShouldEqual, task.Id)
-				So(jsonTask["status"], ShouldEqual, task.Status)
-				So(jsonTask["time_taken"], ShouldEqual, task.TimeTaken)
+				So(jsonTask["task_id"], ShouldEqual, tasks[i].Id)
+				So(jsonTask["status"], ShouldEqual, tasks[i].Status)
+				So(jsonTask["time_taken"], ShouldEqual, tasks[i].TimeTaken)
 			}
 		})
 	})

--- a/service/rest_version_test.go
+++ b/service/rest_version_test.go
@@ -128,11 +128,12 @@ func TestGetRecentVersions(t *testing.T) {
 			builds = append(builds, build)
 
 			task := &task.Task{
-				Id:          fmt.Sprintf(taskIdPreface, i),
-				Version:     versions[i].Id,
-				DisplayName: "some-task-name",
-				Status:      "success",
-				TimeTaken:   time.Duration(100 * time.Millisecond),
+				Id:           fmt.Sprintf(taskIdPreface, i),
+				Version:      versions[i].Id,
+				DisplayName:  "some-task-name",
+				Status:       "success",
+				TimeTaken:    time.Duration(100 * time.Millisecond),
+				BuildVariant: build.BuildVariant,
 			}
 			So(task.Insert(), ShouldBeNil)
 			tasks = append(tasks, task)
@@ -191,7 +192,7 @@ func TestGetRecentVersions(t *testing.T) {
 				So(jsonBuild["build_id"], ShouldEqual, builds[i].Id)
 				So(jsonBuild["name"], ShouldEqual, builds[i].DisplayName)
 
-				_jsonTasks, ok := jsonVersion["tasks"]
+				_jsonTasks, ok := jsonBuild["tasks"]
 				So(ok, ShouldBeTrue)
 				jsonTasks, ok := _jsonTasks.(map[string]interface{})
 				So(ok, ShouldBeTrue)


### PR DESCRIPTION
Currently, the v1 endpoint to get recent versions returns tasks by build using the task cache. This change gives dependable task data (since apparently the task cache is buggy), and allows for pagination.

Note the ticket description for this isn't right, the solution described isn't what cloud needed.

Has been tested in staging.