### PR TITLE
EVG-6114 support gitignore style globbing

### DIFF
--- a/command/results_gotest.go
+++ b/command/results_gotest.go
@@ -44,7 +44,6 @@ func (c *goTestResults) ParseParams(params map[string]interface{}) error {
 // back to the server.
 func (c *goTestResults) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *model.TaskConfig) error {
-
 	if err := util.ExpandValues(c, conf.Expansions); err != nil {
 		err = errors.Wrap(err, "error expanding params")
 		logger.Task().Errorf("Error parsing goTest files: %+v", err)
@@ -117,16 +116,13 @@ func (c *goTestResults) Execute(ctx context.Context,
 // AllOutputFiles creates a list of all test output files that will be parsed, by expanding
 // all of the file patterns specified to the command.
 func (c *goTestResults) allOutputFiles() ([]string, error) {
-
-	outputFiles := []string{}
-
-	// walk through all specified file patterns
-	for _, pattern := range c.Files {
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			return nil, errors.Wrap(err, "error expanding file patterns")
-		}
-		outputFiles = append(outputFiles, matches...)
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, errors.Wrap(err, "error retrieving working directory path")
+	}
+	outputFiles, err := getFilePaths(dir, c.Files)
+	if err != nil {
+		return nil, errors.Wrap(err, "error expanding file patterns")
 	}
 
 	// uniquify the list

--- a/command/results_gotest.go
+++ b/command/results_gotest.go
@@ -136,7 +136,6 @@ func (c *goTestResults) allOutputFiles() ([]string, error) {
 	}
 
 	return outputFiles, nil
-
 }
 
 // ParseTestOutputFiles parses all of the files that are passed in, and returns the

--- a/command/results_xunit_test.go
+++ b/command/results_xunit_test.go
@@ -210,7 +210,6 @@ func TestFilePathGetIgnoreGlobbing(t *testing.T) {
 
 	workdir = filepath.Join(testutil.GetDirectoryOfFile(), "testdata")
 	files = []string{"archive/**/testfile.txt"}
-	assert.NoError(err)
 	paths, err = getFilePaths(workdir, files)
 	assert.NoError(err)
 	assert.Len(paths, 5)
@@ -220,13 +219,13 @@ func TestFilePathGetIgnoreGlobbing(t *testing.T) {
 	}
 
 	files = []string{"archive/artifacts_*/**/testfile.txt"}
-	assert.NoError(err)
 	paths, err = getFilePaths(workdir, files)
+	assert.NoError(err)
 	assert.Len(paths, 3)
 
 	files = []string{"testfile.txt", "!artifacts_in/**/testfile.txt"}
-	assert.NoError(err)
 	paths, err = getFilePaths(workdir, files)
+	assert.NoError(err)
 	assert.Len(paths, 4)
 	assert.NotContains(paths, filepath.Join(workdir, "artifacts_in/dir1/dir2/testfile.txt"))
 }

--- a/command/results_xunit_test.go
+++ b/command/results_xunit_test.go
@@ -181,6 +181,52 @@ func TestFilePathGetIgnoreGlobbing(t *testing.T) {
 	files := []string{"*.xml", "!mocha.xml"}
 	paths, err := getFilePaths(workdir, files)
 	assert.NoError(err)
-	assert.Len(paths, 6)
+	assert.Len(paths, 7)
 	assert.NotContains(paths, filepath.Join(workdir, "mocha.xml"))
+
+	files = []string{"junit_[1-3].xml"}
+	paths, err = getFilePaths(workdir, files)
+	assert.NoError(err)
+	assert.Len(paths, 3)
+	assert.Contains(paths, filepath.Join(workdir, "junit_1.xml"))
+	assert.Contains(paths, filepath.Join(workdir, "junit_2.xml"))
+	assert.Contains(paths, filepath.Join(workdir, "junit_3.xml"))
+
+	files = []string{"junit_[!12].xml"}
+	paths, err = getFilePaths(workdir, files)
+	assert.NoError(err)
+	assert.Len(paths, 3)
+	assert.NotContains(paths, filepath.Join(workdir, "junit_1.xml"))
+	assert.NotContains(paths, filepath.Join(workdir, "junit_2.xml"))
+	assert.NotContains(paths, filepath.Join(workdir, "junit_12.xml"))
+
+	files = []string{"junit_[12].xml"}
+	paths, err = getFilePaths(workdir, files)
+	assert.NoError(err)
+	assert.Len(paths, 2)
+	assert.Contains(paths, filepath.Join(workdir, "junit_1.xml"))
+	assert.Contains(paths, filepath.Join(workdir, "junit_2.xml"))
+	assert.NotContains(paths, filepath.Join(workdir, "junit_12.xml"))
+
+	workdir = filepath.Join(testutil.GetDirectoryOfFile(), "testdata")
+	files = []string{"archive/**/testfile.txt"}
+	assert.NoError(err)
+	paths, err = getFilePaths(workdir, files)
+	assert.NoError(err)
+	assert.Len(paths, 5)
+	for _, path := range paths {
+		assert.Contains(path, "archive")
+		assert.Contains(path, "testfile.txt")
+	}
+
+	files = []string{"archive/artifacts_*/**/testfile.txt"}
+	assert.NoError(err)
+	paths, err = getFilePaths(workdir, files)
+	assert.Len(paths, 3)
+
+	files = []string{"testfile.txt", "!artifacts_in/**/testfile.txt"}
+	assert.NoError(err)
+	paths, err = getFilePaths(workdir, files)
+	assert.Len(paths, 4)
+	assert.NotContains(paths, filepath.Join(workdir, "artifacts_in/dir1/dir2/testfile.txt"))
 }

--- a/command/results_xunit_test.go
+++ b/command/results_xunit_test.go
@@ -174,3 +174,13 @@ func TestParseAndUpload(t *testing.T) {
 	}
 	assert.Equal(len(messagesToCheck), count)
 }
+
+func TestFilePathGetIgnoreGlobbing(t *testing.T) {
+	assert := assert.New(t)
+	workdir := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "xunit")
+	files := []string{"*.xml", "!mocha.xml"}
+	paths, err := getFilePaths(workdir, files)
+	assert.NoError(err)
+	assert.Len(paths, 6)
+	assert.NotContains(paths, filepath.Join(workdir, "mocha.xml"))
+}

--- a/command/testdata/xunit/junit_12.xml
+++ b/command/testdata/xunit/junit_12.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.mongodb.operation.InsertOperationSpecification" tests="18" skipped="0" failures="0" errors="0" timestamp="2016-05-16T15:55:01" hostname="jeff.fios-router.home" time="1.112">
+    <properties/>
+    <testcase name="should return correct result" classname="com.mongodb.operation.InsertOperationSpecification" time="0.051"/>
+    <system-out><![CDATA[out message]]></system-out>
+    <system-err><![CDATA[error message]]></system-err>
+</testsuite>

--- a/util/file.go
+++ b/util/file.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	ignore "github.com/sabhiram/go-git-ignore"
+	"github.com/sabhiram/go-git-ignore"
 )
 
 // FileExists returns true if 'path' exists.


### PR DESCRIPTION
FYI the function in results_gotest.go doesn't _have_ to call the function in results_xunit if that's bad organization, just didn't want to copy code. Also if you believe in test driven development (#controversial) the original code does fail the new test.