### PR TITLE
EVG-6547: reduce AWS API calls

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -739,6 +739,8 @@ func (m *ec2Manager) OnUp(ctx context.Context, h *host.Host) error {
 	defer m.client.Close()
 
 	instanceID := h.Id
+	tags := makeTags(h)
+
 	if isHostSpot(h) {
 		instanceID, err = m.client.GetSpotInstanceId(ctx, h)
 		if err != nil {
@@ -753,10 +755,9 @@ func (m *ec2Manager) OnUp(ctx context.Context, h *host.Host) error {
 		if instanceID == "" {
 			return errors.WithStack(errors.New("spot instance does not yet have an instanceId"))
 		}
-	}
 
-	tags := makeTags(h)
-	tags["spot"] = "true" // mark this as a spot instance
+		tags["spot"] = "true" // mark this as a spot instance
+	}
 
 	volumeIDs, err := m.client.GetVolumeIDs(ctx, h)
 	if err != nil {

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -747,8 +747,8 @@ func (c *awsClientImpl) GetVolumeIDs(ctx context.Context, h *host.Host) ([]strin
 }
 
 func (c *awsClientImpl) GetPublicDNSName(ctx context.Context, h *host.Host) (string, error) {
-	if h.PublicDNSName != "" {
-		return h.PublicDNSName, nil
+	if h.Host != "" {
+		return h.Host, nil
 	}
 
 	id, err := c.getHostInstanceID(ctx, h)
@@ -839,7 +839,7 @@ func (c *awsClientMock) DescribeInstances(ctx context.Context, input *ec2.Descri
 			&ec2.Reservation{
 				Instances: []*ec2.Instance{
 					&ec2.Instance{
-						InstanceId:   aws.String("instance_id"),
+						InstanceId:   input.InstanceIds[0],
 						InstanceType: aws.String("instance_type"),
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
@@ -854,6 +854,14 @@ func (c *awsClientMock) DescribeInstances(ctx context.Context, input *ec2.Descri
 						},
 						Placement: &ec2.Placement{
 							AvailabilityZone: aws.String("us-east-1a"),
+						},
+						LaunchTime: aws.Time(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)),
+						BlockDeviceMappings: []*ec2.InstanceBlockDeviceMapping{
+							&ec2.InstanceBlockDeviceMapping{
+								Ebs: &ec2.EbsInstanceBlockDevice{
+									VolumeId: aws.String("volume_id"),
+								},
+							},
 						},
 					},
 				},
@@ -1100,19 +1108,19 @@ func (c *awsClientMock) SetTags(ctx context.Context, resources []string, h *host
 }
 
 func (c *awsClientMock) GetVolumeIDs(ctx context.Context, h *host.Host) ([]string, error) {
-	if h.VolumeIDs != nil {
+	if len(h.VolumeIDs) != 0 {
 		return h.VolumeIDs, nil
 	}
 
-	return []string{}, nil
+	return []string{"volume_id"}, nil
 }
 
 func (c *awsClientMock) GetPublicDNSName(ctx context.Context, h *host.Host) (string, error) {
-	if h.PublicDNSName != "" {
-		return h.PublicDNSName, nil
+	if h.Host != "" {
+		return h.Host, nil
 	}
 
-	return "", nil
+	return "public_dns_name", nil
 }
 
 func makeAWSLogMessage(name, client string, args interface{}) message.Fields {

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -957,7 +957,14 @@ func (c *awsClientMock) CancelSpotInstanceRequests(ctx context.Context, input *e
 // DescribeVolumes is a mock for ec2.DescribeVolumes.
 func (c *awsClientMock) DescribeVolumes(ctx context.Context, input *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
 	c.DescribeVolumesInput = input
-	return &ec2.DescribeVolumesOutput{}, nil
+	return &ec2.DescribeVolumesOutput{
+		Volumes: []*ec2.Volume{
+			&ec2.Volume{
+				VolumeId: input.VolumeIds[0],
+				Size:     aws.Int64(10),
+			},
+		},
+	}, nil
 }
 
 // DescribeSpotPriceHistory is a mock for ec2.DescribeSpotPriceHistory.
@@ -1017,6 +1024,14 @@ func (c *awsClientMock) GetInstanceInfo(ctx context.Context, id string) (*ec2.In
 	}
 	instance.State = &ec2.InstanceState{}
 	instance.State.Name = aws.String("running")
+	instance.BlockDeviceMappings = []*ec2.InstanceBlockDeviceMapping{
+		&ec2.InstanceBlockDeviceMapping{
+			Ebs: &ec2.EbsInstanceBlockDevice{
+				VolumeId: aws.String("volume_id"),
+			},
+		},
+	}
+	instance.LaunchTime = aws.Time(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
 	return instance, nil
 }
 
@@ -1092,7 +1107,7 @@ func (c *awsClientMock) GetVolumeIDs(ctx context.Context, h *host.Host) ([]strin
 	return []string{}, nil
 }
 
-func (c *awsClientMock) GetPublicDNSName(h *host.Host) (string, error) {
+func (c *awsClientMock) GetPublicDNSName(ctx context.Context, h *host.Host) (string, error) {
 	if h.PublicDNSName != "" {
 		return h.PublicDNSName, nil
 	}

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -43,11 +43,21 @@ func TestFleet(t *testing.T) {
 			mockClient := m.client.(*awsClientMock)
 			assert.Len(t, mockClient.DescribeInstancesInput.InstanceIds, 1)
 			assert.Equal(t, "instance_id", *mockClient.DescribeInstancesInput.InstanceIds[0])
+
+			assert.Equal(t, "us-east-1a", h.Zone)
+			hDb, err := host.FindOneId("h1")
+			assert.NoError(t, err)
+			assert.Equal(t, "us-east-1a", hDb.Zone)
 		},
 		"GetInstanceStatus": func(*testing.T) {
 			status, err := m.GetInstanceStatus(context.Background(), h)
 			assert.NoError(t, err)
 			assert.Equal(t, StatusRunning, status)
+
+			assert.Equal(t, "us-east-1a", h.Zone)
+			hDb, err := host.FindOneId("h1")
+			assert.NoError(t, err)
+			assert.Equal(t, "us-east-1a", hDb.Zone)
 		},
 		"TerminateInstance": func(*testing.T) {
 			assert.NoError(t, m.TerminateInstance(context.Background(), h, "evergreen"))
@@ -64,17 +74,9 @@ func TestFleet(t *testing.T) {
 			dnsName, err := m.GetDNSName(context.Background(), h)
 			assert.NoError(t, err)
 			assert.Equal(t, "public_dns_name", dnsName)
-
-			assert.Equal(t, "us-east-1a", h.Zone)
-			hDb, err := host.FindOneId("h1")
-			assert.NoError(t, err)
-			assert.Equal(t, "us-east-1a", hDb.Zone)
 		},
 		"SpawnFleetSpotHost": func(*testing.T) {
-			resources, err := m.spawnFleetSpotHost(context.Background(), &host.Host{}, &EC2ProviderSettings{}, []*ec2.LaunchTemplateBlockDeviceMappingRequest{})
-			assert.NoError(t, err)
-			assert.Len(t, resources, 1)
-			assert.Equal(t, "i-12345", resources[0])
+			assert.NoError(t, m.spawnFleetSpotHost(context.Background(), &host.Host{}, &EC2ProviderSettings{}, []*ec2.LaunchTemplateBlockDeviceMappingRequest{}))
 
 			mockClient := m.client.(*awsClientMock)
 			assert.Equal(t, "templateID", *mockClient.DeleteLaunchTemplateInput.LaunchTemplateId)

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -32,7 +32,7 @@ func TestFleet(t *testing.T) {
 			assert.Equal(t, "i-12345", h.Id)
 		},
 		"GetInstanceStatuses": func(*testing.T) {
-			hosts := []host.Host{{Id: "instance_id"}}
+			hosts := []host.Host{*h}
 
 			statuses, err := m.GetInstanceStatuses(context.Background(), hosts)
 			assert.NoError(t, err)
@@ -42,9 +42,8 @@ func TestFleet(t *testing.T) {
 
 			mockClient := m.client.(*awsClientMock)
 			assert.Len(t, mockClient.DescribeInstancesInput.InstanceIds, 1)
-			assert.Equal(t, "instance_id", *mockClient.DescribeInstancesInput.InstanceIds[0])
+			assert.Equal(t, "h1", *mockClient.DescribeInstancesInput.InstanceIds[0])
 
-			assert.Equal(t, "us-east-1a", h.Zone)
 			hDb, err := host.FindOneId("h1")
 			assert.NoError(t, err)
 			assert.Equal(t, "us-east-1a", hDb.Zone)

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
@@ -90,32 +88,7 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 	assert.NoError(err)
 	assert.Len(foundHosts, 1)
 	assert.NoError(m.OnUp(ctx, h))
-	foundHost := foundHosts[0]
-	out, err := m.client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-		InstanceIds: []*string{aws.String(foundHost.Id)},
-	})
-	assert.NoError(err)
-	tags := out.Reservations[0].Instances[0].Tags
-	requiredTags := map[string]string{
-		"start-time":        "",
-		"expire-on":         "",
-		"owner":             "",
-		"mode":              "",
-		"name":              "",
-		"evergreen-service": "",
-		"distro":            "",
-	}
-	for i := range tags {
-		key := *tags[i].Key
-		val := *tags[i].Value
-		requiredTags[key] = val
-	}
-	delete(requiredTags, "username")
-	assert.Equal("test_distro", requiredTags["distro"])
-	assert.Equal("mci", requiredTags["owner"])
-	for requiredKey, requiredValue := range requiredTags {
-		assert.NotEmptyf(requiredValue, "%s is empty", requiredKey)
-	}
+
 	assert.NoError(m.TerminateInstance(ctx, h, evergreen.User))
 	foundHosts, err = host.Find(host.IsTerminated)
 	assert.NoError(err)

--- a/cloud/ec2_price.go
+++ b/cloud/ec2_price.go
@@ -444,31 +444,23 @@ func getVolumeSize(ctx context.Context, client AWSClient, h *host.Host) (int64, 
 	if h.VolumeTotalSize != 0 {
 		return h.VolumeTotalSize, nil
 	}
-	instanceID := h.Id
-	if h.ExternalIdentifier != "" {
-		instanceID = h.ExternalIdentifier
-	}
-	instance, err := client.GetInstanceInfo(ctx, instanceID)
+
+	volumeIDs, err := client.GetVolumeIDs(ctx, h)
 	if err != nil {
-		return 0, errors.Wrap(err, "error getting instance info")
+		return 0, errors.Wrapf(err, "can't get volume IDs for '%s'", h.Id)
 	}
-	devices := instance.BlockDeviceMappings
+	vols, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		VolumeIds: aws.StringSlice(volumeIDs),
+	})
+	if err != nil {
+		return 0, errors.Wrap(err, "error describing volumes")
+	}
+
 	var totalSize int64
-	if len(devices) > 0 {
-		volumeIds := []*string{}
-		for i := range devices {
-			volumeIds = append(volumeIds, devices[i].Ebs.VolumeId)
-		}
-		vols, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
-			VolumeIds: volumeIds,
-		})
-		if err != nil {
-			return 0, errors.Wrap(err, "error describing volumes")
-		}
-		for _, v := range vols.Volumes {
-			totalSize = totalSize + *v.Size
-		}
+	for _, v := range vols.Volumes {
+		totalSize += *v.Size
 	}
+
 	return totalSize, nil
 }
 

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -321,6 +321,9 @@ func (s *EC2Suite) TestSpawnHostClassicOnDemand() {
 }
 
 func (s *EC2Suite) TestSpawnHostVPCOnDemand() {
+	pkgCachingPriceFetcher.ec2Prices = map[odInfo]float64{
+		odInfo{"Linux", "instanceType", "US East (N. Virginia)"}: .1,
+	}
 	h := &host.Host{}
 	h.Distro.Id = "distro_id"
 	h.Distro.Provider = evergreen.ProviderNameEc2OnDemand

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -231,6 +231,13 @@ func expandUserData(userData string, expansions map[string]string) (string, erro
 func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, client AWSClient) error {
 	h.Zone = *instance.Placement.AvailabilityZone
 	h.StartTime = *instance.LaunchTime
+	h.PublicDNSName = *instance.PublicDnsName
+
+	volumeIDs := []string{}
+	for _, device := range instance.BlockDeviceMappings {
+		volumeIDs = append(volumeIDs, *device.Ebs.VolumeId)
+	}
+	h.VolumeIDs = volumeIDs
 
 	var err error
 	h.VolumeTotalSize, err = getVolumeSize(ctx, client, h)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -231,7 +231,7 @@ func expandUserData(userData string, expansions map[string]string) (string, erro
 func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, client AWSClient) error {
 	h.Zone = *instance.Placement.AvailabilityZone
 	h.StartTime = *instance.LaunchTime
-	h.PublicDNSName = *instance.PublicDnsName
+	h.Host = *instance.PublicDnsName
 
 	volumeIDs := []string{}
 	for _, device := range instance.BlockDeviceMappings {

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -61,7 +61,6 @@ var (
 	InstanceTypeKey              = bsonutil.MustHaveTag(Host{}, "InstanceType")
 	VolumeSizeKey                = bsonutil.MustHaveTag(Host{}, "VolumeTotalSize")
 	VolumeIDsKey                 = bsonutil.MustHaveTag(Host{}, "VolumeIDs")
-	PublicDNSNameKey             = bsonutil.MustHaveTag(Host{}, "PublicDNSName")
 	NotificationsKey             = bsonutil.MustHaveTag(Host{}, "Notifications")
 	LastCommunicationTimeKey     = bsonutil.MustHaveTag(Host{}, "LastCommunicationTime")
 	UserHostKey                  = bsonutil.MustHaveTag(Host{}, "UserHost")

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -60,6 +60,8 @@ var (
 	StartedByKey                 = bsonutil.MustHaveTag(Host{}, "StartedBy")
 	InstanceTypeKey              = bsonutil.MustHaveTag(Host{}, "InstanceType")
 	VolumeSizeKey                = bsonutil.MustHaveTag(Host{}, "VolumeTotalSize")
+	VolumeIDsKey                 = bsonutil.MustHaveTag(Host{}, "VolumeIDs")
+	PublicDNSNameKey             = bsonutil.MustHaveTag(Host{}, "PublicDNSName")
 	NotificationsKey             = bsonutil.MustHaveTag(Host{}, "Notifications")
 	LastCommunicationTimeKey     = bsonutil.MustHaveTag(Host{}, "LastCommunicationTime")
 	UserHostKey                  = bsonutil.MustHaveTag(Host{}, "UserHost")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -103,7 +103,7 @@ type Host struct {
 	// for ec2 dynamic hosts, the total size of the volumes requested, in GiB
 	VolumeTotalSize int64 `bson:"volume_total_size" json:"volume_total_size,omitempty"`
 
-	VolumeIDs []string `bson:"volume_ids,omitempty" json"volume_ids,omitempty"`
+	VolumeIDs []string `bson:"volume_ids,omitempty" json:"volume_ids,omitempty"`
 
 	// stores information on expiration notifications for spawn hosts
 	Notifications map[string]bool `bson:"notifications,omitempty" json:"notifications,omitempty"`

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -103,8 +103,7 @@ type Host struct {
 	// for ec2 dynamic hosts, the total size of the volumes requested, in GiB
 	VolumeTotalSize int64 `bson:"volume_total_size" json:"volume_total_size,omitempty"`
 
-	VolumeIDs     []string `bson:"volume_ids,omitempty" json"volume_ids,omitempty"`
-	PublicDNSName string   `bson:"public_dns_name,omitempty" json:"public_dns_name,omitempty"`
+	VolumeIDs []string `bson:"volume_ids,omitempty" json"volume_ids,omitempty"`
 
 	// stores information on expiration notifications for spawn hosts
 	Notifications map[string]bool `bson:"notifications,omitempty" json:"notifications,omitempty"`
@@ -500,7 +499,6 @@ func (h *Host) SetIPv6Address(ipv6Address string) error {
 	err := UpdateOne(
 		bson.M{
 			IdKey: h.Id,
-			IPKey: "",
 		},
 		bson.M{
 			"$set": bson.M{
@@ -872,11 +870,11 @@ func (h *Host) CacheHostData() error {
 		},
 		bson.M{
 			"$set": bson.M{
-				ZoneKey:          h.Zone,
-				StartTimeKey:     h.StartTime,
-				VolumeSizeKey:    h.VolumeTotalSize,
-				VolumeIDsKey:     h.VolumeIDs,
-				PublicDNSNameKey: h.PublicDNSName,
+				ZoneKey:       h.Zone,
+				StartTimeKey:  h.StartTime,
+				VolumeSizeKey: h.VolumeTotalSize,
+				VolumeIDsKey:  h.VolumeIDs,
+				DNSKey:        h.Host,
 			},
 		},
 	)

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -103,8 +103,8 @@ type Host struct {
 	// for ec2 dynamic hosts, the total size of the volumes requested, in GiB
 	VolumeTotalSize int64 `bson:"volume_total_size" json:"volume_total_size,omitempty"`
 
-	VolumeIDs     []string `bson:"volume_ids" json"volume_ids"`
-	PublicDNSName string   `bson:"public_dns_name" json:"public_dns_name"`
+	VolumeIDs     []string `bson:"volume_ids,omitempty" json"volume_ids,omitempty"`
+	PublicDNSName string   `bson:"public_dns_name,omitempty" json:"public_dns_name,omitempty"`
 
 	// stores information on expiration notifications for spawn hosts
 	Notifications map[string]bool `bson:"notifications,omitempty" json:"notifications,omitempty"`

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -103,6 +103,9 @@ type Host struct {
 	// for ec2 dynamic hosts, the total size of the volumes requested, in GiB
 	VolumeTotalSize int64 `bson:"volume_total_size" json:"volume_total_size,omitempty"`
 
+	VolumeIDs     []string `bson:"volume_ids" json"volume_ids"`
+	PublicDNSName string   `bson:"public_dns_name" json:"public_dns_name"`
+
 	// stores information on expiration notifications for spawn hosts
 	Notifications map[string]bool `bson:"notifications,omitempty" json:"notifications,omitempty"`
 
@@ -869,9 +872,11 @@ func (h *Host) CacheHostData() error {
 		},
 		bson.M{
 			"$set": bson.M{
-				ZoneKey:       h.Zone,
-				StartTimeKey:  h.StartTime,
-				VolumeSizeKey: h.VolumeTotalSize,
+				ZoneKey:          h.Zone,
+				StartTimeKey:     h.StartTime,
+				VolumeSizeKey:    h.VolumeTotalSize,
+				VolumeIDsKey:     h.VolumeIDs,
+				PublicDNSNameKey: h.PublicDNSName,
 			},
 		},
 	)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -342,8 +342,8 @@ func TestHostSetIPv6Address(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(host.IP, ipv6Address)
 
-	// if the host is already updated, no new updates should work
-	assert.Error(host.SetIPv6Address(ipv6Address2))
+	// if the host is already updated, new updates should work
+	assert.NoError(host.SetIPv6Address(ipv6Address2))
 	assert.Equal(host.IP, ipv6Address)
 
 	host, err = FindOne(ById(host.Id))

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -344,11 +344,11 @@ func TestHostSetIPv6Address(t *testing.T) {
 
 	// if the host is already updated, new updates should work
 	assert.NoError(host.SetIPv6Address(ipv6Address2))
-	assert.Equal(host.IP, ipv6Address)
+	assert.Equal(host.IP, ipv6Address2)
 
 	host, err = FindOne(ById(host.Id))
 	assert.NoError(err)
-	assert.Equal(host.IP, ipv6Address)
+	assert.Equal(host.IP, ipv6Address2)
 }
 
 func TestMarkAsProvisioned(t *testing.T) {


### PR DESCRIPTION
- The most common API call is `DescribeInstances`. Cache the response for a batch of instances and remove multiple calls for each individual instance. Also move tagging to `OnUp` for on-demand hosts and Fleet spot hosts so we can avoid making a call for each on-demand/Fleet host and be consistent about when we tag instances (spot instances are tagged `OnUp`).
- In second place is `DescribeSpotInstanceRequests`. Previously we would call this repeatedly until Spot instances transitioned to running. Now, once a spot instance request has been fulfilled cache the instance id and stop making this call.