### PR TITLE
EVG-6539: sort dispatchable task group tasks in the dag scheduler

### DIFF
--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -114,6 +114,7 @@ var (
 	// bson fields for the individual task queue items
 	taskQueueItemIdKey            = bsonutil.MustHaveTag(TaskQueueItem{}, "Id")
 	taskQueueItemIsDispatchedKey  = bsonutil.MustHaveTag(TaskQueueItem{}, "IsDispatched")
+	taskQueueItemGroupIndexKey    = bsonutil.MustHaveTag(TaskQueueItem{}, "GroupIndex")
 	taskQueueItemDisplayNameKey   = bsonutil.MustHaveTag(TaskQueueItem{}, "DisplayName")
 	taskQueueItemGroupKey         = bsonutil.MustHaveTag(TaskQueueItem{}, "Group")
 	taskQueueItemGroupMaxHostsKey = bsonutil.MustHaveTag(TaskQueueItem{}, "GroupMaxHosts")
@@ -418,6 +419,7 @@ func findTaskQueueForDistro(q taskQueueQuery) (*TaskQueue, error) {
 						taskQueueItemDisplayNameKey:   "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemDisplayNameKey),
 						taskQueueItemGroupKey:         "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemGroupKey),
 						taskQueueItemGroupMaxHostsKey: "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemGroupMaxHostsKey),
+						taskQueueItemGroupIndexKey:    "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemGroupIndexKey),
 						taskQueueItemVersionKey:       "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemVersionKey),
 						taskQueueItemBuildVariantKey:  "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemBuildVariantKey),
 						taskQueueItemConKey:           "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemConKey),

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -90,6 +90,7 @@ type TaskQueueItem struct {
 	DisplayName         string        `bson:"display_name" json:"display_name"`
 	Group               string        `bson:"group_name" json:"group_name"`
 	GroupMaxHosts       int           `bson:"group_max_hosts,omitempty" json:"group_max_hosts,omitempty"`
+	GroupIndex          int           `bson:"group_index,omitempty" json:"group_indexa,omitempty"`
 	Version             string        `bson:"version" json:"version"`
 	BuildVariant        string        `bson:"build_variant" json:"build_variant"`
 	RevisionOrderNumber int           `bson:"order" json:"order"`

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -171,6 +171,10 @@ func (t *basicCachedDAGDispatcherImpl) rebuild(items []TaskQueueItem) error {
 		}
 	}
 
+	for _, su := range t.taskGroups {
+		sort.SliceStable(su.tasks, func(i, j int) bool { return su.tasks[i].GroupIndex < su.tasks[j].GroupIndex })
+	}
+
 	// Add edges for task dependencies
 	for _, item := range items {
 		for _, dependency := range item.Dependencies {

--- a/scheduler/task_queue_persister.go
+++ b/scheduler/task_queue_persister.go
@@ -31,6 +31,7 @@ func PersistTaskQueue(distro string, tasks []task.Task, distroQueueInfo model.Di
 			Priority:            t.Priority,
 			Group:               t.TaskGroup,
 			GroupMaxHosts:       t.TaskGroupMaxHosts,
+			GroupIndex:          t.TaskGroupOrder,
 			Version:             t.Version,
 			Dependencies:        dependencies,
 		})


### PR DESCRIPTION
We've been populating the order of a task in a task group for a while in order to make sure that the order of tasks are correct.