### PR TITLE
EVG-6596: remove `git add` from git.push

### DIFF
--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -71,7 +71,6 @@ func TestGitPush(t *testing.T) {
 			commands := []string{
 				"git checkout master",
 				"git rev-parse HEAD",
-				`git add "hello.txt"`,
 				`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit --file - --author="evergreen <evergreen@mongodb.com>"`,
 				"git push origin master",
 			}
@@ -98,7 +97,6 @@ func TestGitPush(t *testing.T) {
 				directory:     c.Directory,
 				authorName:    "baxterthehacker",
 				authorEmail:   "baxter@thehacker.com",
-				files:         []string{"hello.txt"},
 				commitMessage: "testing 123",
 				branch:        "master",
 				token:         token,
@@ -106,7 +104,6 @@ func TestGitPush(t *testing.T) {
 
 			assert.NoError(t, c.pushPatch(context.Background(), logger, params))
 			commands := []string{
-				`git add "hello.txt"`,
 				`git -c "user.name=octocat" -c "user.email=octocat@github.com" commit --file - --author="baxterthehacker <baxter@thehacker.com>"`,
 				"git push origin master",
 			}

--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -190,6 +190,7 @@ func TestGitPush(t *testing.T) {
 			}
 		},
 	} {
+		c.DryRun = false
 		t.Run(name, test)
 	}
 }

--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -140,7 +140,7 @@ func TestGitPush(t *testing.T) {
 			createRepoCommands := []string{
 				`git init`,
 				`git add --all`,
-				`git commit -m "testing..."`,
+				`git -c "user.name=baxterthehacker" -c "user.email=baxter@thehacker.com" commit -m "testing..."`,
 			}
 			cmd := jpm.CreateCommand(ctx).Directory(repoDir).Append(createRepoCommands...)
 			require.NoError(t, cmd.Run(ctx))


### PR DESCRIPTION
Because git.get_project applies changes to the index (with the `--index` option) it's not necessary to run `git add` in git.push. Additionally, `git add` returns an error on removed files that have already been added to the index and the merge task aborts.