### PR TITLE
EVG-5960: add unattainable field to task dependencies

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -866,7 +866,12 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 				newTask.DependsOn = append(newTask.DependsOn, newDeps...)
 			}
 		}
-		newTask.DisplayTask = displayTasks[newTask.DisplayName]
+
+		// Display tasks depend on all exec task dependencies
+		if displayTask, ok := displayTasks[newTask.DisplayName]; ok {
+			displayTask.DependsOn = append(displayTask.DependsOn, newTask.DependsOn...)
+			newTask.DisplayTask = displayTask
+		}
 
 		newTask.GeneratedBy = generatedBy
 		// append the task to the list of the created tasks

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -92,6 +92,13 @@ var (
 	TaskEndDetailDescription = bsonutil.MustHaveTag(apimodels.TaskEndDetail{}, "Description")
 )
 
+var (
+	// BSON fields for task dependency struct
+	DependencyTaskIdKey       = bsonutil.MustHaveTag(Dependency{}, "TaskId")
+	DependencyStatusKey       = bsonutil.MustHaveTag(Dependency{}, "Status")
+	DependencyUnattainableKey = bsonutil.MustHaveTag(Dependency{}, "Unattainable")
+)
+
 // Queries
 
 // All returns all tasks.

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -26,11 +26,11 @@ var (
 )
 
 var depTaskIds = []Dependency{
-	{"td1", evergreen.TaskSucceeded},
-	{"td2", evergreen.TaskSucceeded},
-	{"td3", ""}, // Default == "success"
-	{"td4", evergreen.TaskFailed},
-	{"td5", AllStatuses},
+	{TaskId: "td1", Status: evergreen.TaskSucceeded},
+	{TaskId: "td2", Status: evergreen.TaskSucceeded},
+	{TaskId: "td3", Status: ""}, // Default == "success"
+	{TaskId: "td4", Status: evergreen.TaskFailed},
+	{TaskId: "td5", Status: AllStatuses},
 }
 
 // update statuses of test tasks in the db
@@ -296,7 +296,7 @@ func TestTaskSetPriority(t *testing.T) {
 		tasks := []Task{
 			{
 				Id:        "one",
-				DependsOn: []Dependency{{"two", ""}, {"three", ""}, {"four", ""}},
+				DependsOn: []Dependency{{TaskId: "two", Status: ""}, {TaskId: "three", Status: ""}, {TaskId: "four", Status: ""}},
 				Activated: true,
 			},
 			{
@@ -306,12 +306,12 @@ func TestTaskSetPriority(t *testing.T) {
 			},
 			{
 				Id:        "three",
-				DependsOn: []Dependency{{"five", ""}},
+				DependsOn: []Dependency{{TaskId: "five", Status: ""}},
 				Activated: true,
 			},
 			{
 				Id:        "four",
-				DependsOn: []Dependency{{"five", ""}},
+				DependsOn: []Dependency{{TaskId: "five", Status: ""}},
 				Activated: true,
 			},
 			{
@@ -1168,6 +1168,234 @@ func TestFindVariantsWithTask(t *testing.T) {
 	require.Len(t, bvs, 2)
 	assert.Equal(bvs[0], "bv2")
 	assert.Equal(bvs[1], "bv1")
+}
+
+func TestUpdateBlockedDependencies(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(Collection))
+
+	tasks := []Task{
+		{
+			Id:     "t0",
+			Status: evergreen.TaskFailed,
+		},
+		{
+			Id: "t1",
+			DependsOn: []Dependency{
+				{
+					TaskId: "t0",
+					Status: evergreen.TaskSucceeded,
+				},
+			},
+			Status: evergreen.TaskUndispatched,
+		},
+		{
+			Id: "t2",
+			DependsOn: []Dependency{
+				{
+					TaskId: "t1",
+					Status: evergreen.TaskSucceeded,
+				},
+			},
+			Status: evergreen.TaskUndispatched,
+		},
+		{
+			Id: "t3",
+			DependsOn: []Dependency{
+				{
+					TaskId:       "t2",
+					Status:       evergreen.TaskSucceeded,
+					Unattainable: true,
+				},
+			},
+			Status: evergreen.TaskUndispatched,
+		},
+		{
+			Id: "t4",
+			DependsOn: []Dependency{
+				{
+					TaskId: "t3",
+					Status: evergreen.TaskSucceeded,
+				},
+			},
+		},
+	}
+	for _, task := range tasks {
+		assert.NoError(task.Insert())
+	}
+
+	assert.NoError(tasks[0].UpdateBlockedDependencies(false))
+	dbTask1, err := FindOneId(tasks[1].Id)
+	assert.NoError(err)
+	assert.True(dbTask1.DependsOn[0].Unattainable)
+	dbTask2, err := FindOneId(tasks[2].Id)
+	assert.NoError(err)
+	assert.True(dbTask2.DependsOn[0].Unattainable)
+	dbTask3, err := FindOneId(tasks[3].Id)
+	assert.NoError(err)
+	assert.True(dbTask3.DependsOn[0].Unattainable)
+	// We don't traverse past t3 which was already unattainable == true
+	dbTask4, err := FindOneId(tasks[4].Id)
+	assert.NoError(err)
+	assert.False(dbTask4.DependsOn[0].Unattainable)
+}
+
+func TestUpdateUnblockedDependencies(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(Collection))
+
+	tasks := []Task{
+		{Id: "t0"},
+		{
+			Id: "t1",
+			DependsOn: []Dependency{
+				{
+					TaskId:       "t0",
+					Unattainable: true,
+				},
+			},
+			Status: evergreen.TaskUndispatched,
+		},
+		{
+			Id: "t2",
+			DependsOn: []Dependency{
+				{
+					TaskId:       "t1",
+					Unattainable: false,
+				},
+			},
+			Status: evergreen.TaskUndispatched,
+		},
+		{
+			Id: "t3",
+			DependsOn: []Dependency{
+				{
+					TaskId:       "t2",
+					Unattainable: true,
+				},
+			},
+			Status: evergreen.TaskUndispatched,
+		},
+	}
+
+	for _, task := range tasks {
+		assert.NoError(task.Insert())
+	}
+
+	assert.NoError(tasks[0].UpdateUnblockedDependencies())
+	dbTask1, err := FindOneId(tasks[1].Id)
+	assert.NoError(err)
+	assert.False(dbTask1.DependsOn[0].Unattainable)
+	dbTask2, err := FindOneId(tasks[2].Id)
+	assert.NoError(err)
+	assert.False(dbTask2.DependsOn[0].Unattainable)
+	// We don't traverse past the t2 which was already unattainable == false
+	dbTask3, err := FindOneId(tasks[3].Id)
+	assert.NoError(err)
+	assert.True(dbTask3.DependsOn[0].Unattainable)
+}
+
+func TestFindAllUnmarkedBlockedDependencies(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(Collection))
+
+	t1 := &Task{
+		Id:     "t1",
+		Status: evergreen.TaskFailed,
+	}
+
+	tasks := []Task{
+		{
+			Id: "t2",
+			DependsOn: []Dependency{
+				{
+					TaskId: "t1",
+					Status: "",
+				},
+			},
+		},
+		{
+			Id: "t3",
+			DependsOn: []Dependency{
+				{
+					TaskId: "t1",
+					Status: evergreen.TaskFailed,
+				},
+			},
+		},
+		{
+			Id: "t4",
+			DependsOn: []Dependency{
+				{
+					TaskId:       "t1",
+					Status:       "",
+					Unattainable: true,
+				},
+			},
+		},
+		{
+			Id: "t5",
+			DependsOn: []Dependency{
+				{
+					TaskId: "t1",
+					Status: evergreen.TaskFailed,
+				},
+				{
+					TaskId: "t2",
+					Status: "",
+				},
+			},
+		},
+	}
+	for _, task := range tasks {
+		assert.NoError(task.Insert())
+	}
+
+	deps, err := t1.FindAllUnmarkedBlockedDependencies(false)
+	assert.NoError(err)
+	assert.Len(deps, 1)
+
+	deps, err = t1.FindAllUnmarkedBlockedDependencies(true)
+	assert.NoError(err)
+	assert.Len(deps, 3)
+}
+
+func TestFindAllMarkedUnattainableDependencies(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(Collection))
+
+	t1 := &Task{Id: "t1"}
+	tasks := []Task{
+		{
+			Id: "t2",
+			DependsOn: []Dependency{
+				{
+					TaskId:       "t1",
+					Unattainable: true,
+				},
+			},
+		},
+		{
+			Id: "t3",
+			DependsOn: []Dependency{
+				{
+					TaskId: "t1",
+				},
+				{
+					TaskId:       "t2",
+					Unattainable: true,
+				},
+			},
+		},
+	}
+
+	for _, task := range tasks {
+		assert.NoError(task.Insert())
+	}
+
+	unattainableTasks, err := t1.FindAllMarkedUnattainableDependencies()
+	assert.NoError(err)
+	assert.Len(unattainableTasks, 1)
 }
 
 func TestGetTimeSpent(t *testing.T) {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -432,6 +432,11 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 	if err != nil {
 		return errors.Wrap(err, "could not mark task finished")
 	}
+
+	if err = t.UpdateBlockedDependencies(false); err != nil {
+		return errors.Wrap(err, "could not update blocked dependencies")
+	}
+
 	status := t.ResultStatus()
 	event.LogTaskFinished(t.Id, t.Execution, t.HostId, status)
 


### PR DESCRIPTION
In order to deploy the changes in #2344 the changes are separated into two PRs: this first PR adds the `Unattainable` field to task dependencies and updates it in `EndTask` and when a task is restarted.