### PR TITLE
EVG 6114 fix workdir for git-ignore style globbing

### DIFF
--- a/command/results_gotest.go
+++ b/command/results_gotest.go
@@ -44,7 +44,6 @@ func (c *goTestResults) ParseParams(params map[string]interface{}) error {
 // back to the server.
 func (c *goTestResults) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *model.TaskConfig) error {
-
 	if err := util.ExpandValues(c, conf.Expansions); err != nil {
 		err = errors.Wrap(err, "error expanding params")
 		logger.Task().Errorf("Error parsing goTest files: %+v", err)
@@ -117,16 +116,13 @@ func (c *goTestResults) Execute(ctx context.Context,
 // AllOutputFiles creates a list of all test output files that will be parsed, by expanding
 // all of the file patterns specified to the command.
 func (c *goTestResults) allOutputFiles() ([]string, error) {
-
-	outputFiles := []string{}
-
-	// walk through all specified file patterns
-	for _, pattern := range c.Files {
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			return nil, errors.Wrap(err, "error expanding file patterns")
-		}
-		outputFiles = append(outputFiles, matches...)
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, errors.Wrap(err, "error retrieving working directory path")
+	}
+	outputFiles, err := getFilePaths(dir, c.Files)
+	if err != nil {
+		return nil, errors.Wrap(err, "error expanding file patterns")
 	}
 
 	// uniquify the list
@@ -140,7 +136,6 @@ func (c *goTestResults) allOutputFiles() ([]string, error) {
 	}
 
 	return outputFiles, nil
-
 }
 
 // ParseTestOutputFiles parses all of the files that are passed in, and returns the

--- a/command/results_gotest.go
+++ b/command/results_gotest.go
@@ -50,13 +50,8 @@ func (c *goTestResults) Execute(ctx context.Context,
 		return err
 	}
 
-	// make sure the file patterns are relative to the task's working directory
-	for idx, file := range c.Files {
-		c.Files[idx] = filepath.Join(conf.WorkDir, file)
-	}
-
 	// will be all files containing test results
-	outputFiles, err := c.allOutputFiles()
+	outputFiles, err := c.allOutputFiles(conf.WorkDir)
 	if err != nil {
 		return errors.Wrap(err, "error obtaining names of output files")
 	}
@@ -115,12 +110,8 @@ func (c *goTestResults) Execute(ctx context.Context,
 
 // AllOutputFiles creates a list of all test output files that will be parsed, by expanding
 // all of the file patterns specified to the command.
-func (c *goTestResults) allOutputFiles() ([]string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return nil, errors.Wrap(err, "error retrieving working directory path")
-	}
-	outputFiles, err := getFilePaths(dir, c.Files)
+func (c *goTestResults) allOutputFiles(workDir string) ([]string, error) {
+	outputFiles, err := getFilePaths(workDir, c.Files)
 	if err != nil {
 		return nil, errors.Wrap(err, "error expanding file patterns")
 	}

--- a/command/results_xunit.go
+++ b/command/results_xunit.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -84,20 +86,39 @@ func (c *xunitResults) Execute(ctx context.Context,
 // getFilePaths is a helper function that returns a slice of all absolute paths
 // which match the given file path parameters.
 func getFilePaths(workDir string, files []string) ([]string, error) {
-	catcher := grip.NewBasicCatcher()
-	out := []string{}
-
-	for _, fileSpec := range files {
-		paths, err := filepath.Glob(filepath.Join(workDir, fileSpec))
-		catcher.Add(err)
-		out = append(out, paths...)
+	filePatterns := expandFilePatterns(files)
+	paths, err := util.BuildFileList(workDir, filePatterns...)
+	if err != nil {
+		return nil, errors.Wrap(err, "incorrect file specifications")
 	}
-
-	if catcher.HasErrors() {
-		return nil, errors.Wrapf(catcher.Resolve(), "%d incorrect file specifications", catcher.Len())
+	for i, path := range paths {
+		paths[i] = filepath.Join(workDir, path)
 	}
+	return paths, nil
+}
 
-	return out, nil
+// this specifically cases on patterns like *[!12] that match any character except those in the given set
+func expandFilePatterns(files []string) []string {
+	res := []string{}
+	for _, file := range files {
+
+		pieces := strings.Split(file, "[!")
+		if len(pieces) <= 1 || !strings.Contains(pieces[1], "]") {
+			res = append(res, file)
+			continue
+		}
+		suffix := strings.Split(pieces[1], "]")[1]
+		newFilesToIgnore := []string{fmt.Sprintf("%s*%s", pieces[0], suffix)}
+		for _, char := range strings.Split(pieces[1], "") { // get the characters to ignore
+			if char == "]" {
+				break
+			}
+			newFilePattern := fmt.Sprintf("!%s*%s*%s", pieces[0], char, suffix)
+			newFilesToIgnore = append(newFilesToIgnore, newFilePattern)
+		}
+		res = append(res, newFilesToIgnore...)
+	}
+	return res
 }
 
 func (c *xunitResults) parseAndUploadResults(ctx context.Context, conf *model.TaskConfig,

--- a/command/testdata/xunit/junit_12.xml
+++ b/command/testdata/xunit/junit_12.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.mongodb.operation.InsertOperationSpecification" tests="18" skipped="0" failures="0" errors="0" timestamp="2016-05-16T15:55:01" hostname="jeff.fios-router.home" time="1.112">
+    <properties/>
+    <testcase name="should return correct result" classname="com.mongodb.operation.InsertOperationSpecification" time="0.051"/>
+    <system-out><![CDATA[out message]]></system-out>
+    <system-err><![CDATA[error message]]></system-err>
+</testsuite>

--- a/util/file.go
+++ b/util/file.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	ignore "github.com/sabhiram/go-git-ignore"
+	"github.com/sabhiram/go-git-ignore"
 )
 
 // FileExists returns true if 'path' exists.


### PR DESCRIPTION
Only the second commit needs to be looked at. This change was using the wrong working directory, and shouldn't join it with the filepath before running util.BuildFileList. This change passes the smoke tests in a patch.