### PR TITLE
EVG-1732 Add auth to list projects endpoint

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -413,12 +413,9 @@ func FindPeriodicProjects() ([]ProjectRef, error) {
 
 // FindProjectRefs returns limit refs starting at project identifier key
 // in the sortDir direction
-func FindProjectRefs(key string, limit int, sortDir int, isAuthenticated bool) ([]ProjectRef, error) {
+func FindProjectRefs(key string, limit int, sortDir int) ([]ProjectRef, error) {
 	projectRefs := []ProjectRef{}
 	filter := bson.M{}
-	if !isAuthenticated {
-		filter[ProjectRefPrivateKey] = false
-	}
 	sortSpec := ProjectIdentifierKey
 
 	if sortDir < 0 {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -100,7 +100,7 @@ type Connector interface {
 	// UpdateProjectRevision updates the given project's revision
 	UpdateProjectRevision(string, string) error
 	// FindProjects is a method to find projects as ordered by name
-	FindProjects(string, int, int, bool) ([]model.ProjectRef, error)
+	FindProjects(string, int, int) ([]model.ProjectRef, error)
 	// FindProjectByBranch is a method to find the projectref given a branch name.
 	FindProjectByBranch(string) (*model.ProjectRef, error)
 	GetProjectWithCommitQueueByOwnerRepoAndBranch(string, string, string) (*model.ProjectRef, error)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -139,8 +139,8 @@ func (pc *DBProjectConnector) UpdateProjectRevision(projectID, revision string) 
 }
 
 // FindProjects queries the backing database for the specified projects
-func (pc *DBProjectConnector) FindProjects(key string, limit int, sortDir int, isAuthenticated bool) ([]model.ProjectRef, error) {
-	projects, err := model.FindProjectRefs(key, limit, sortDir, isAuthenticated)
+func (pc *DBProjectConnector) FindProjects(key string, limit int, sortDir int) ([]model.ProjectRef, error) {
+	projects, err := model.FindProjectRefs(key, limit, sortDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "problem fetching projects starting at project '%s'", key)
 	}
@@ -258,13 +258,12 @@ type MockProjectConnector struct {
 
 // FindProjects queries the cached projects slice for the matching projects.
 // Assumes CachedProjects is sorted in alphabetical order of project identifier.
-func (pc *MockProjectConnector) FindProjects(key string, limit int, sortDir int, isAuthenticated bool) ([]model.ProjectRef, error) {
+func (pc *MockProjectConnector) FindProjects(key string, limit int, sortDir int) ([]model.ProjectRef, error) {
 	projects := []model.ProjectRef{}
 	if sortDir > 0 {
 		for i := 0; i < len(pc.CachedProjects); i++ {
 			p := pc.CachedProjects[i]
-			visible := isAuthenticated || (!isAuthenticated && !p.Private)
-			if p.Identifier >= key && visible {
+			if p.Identifier >= key {
 				projects = append(projects, p)
 				if len(projects) == limit {
 					break
@@ -274,8 +273,7 @@ func (pc *MockProjectConnector) FindProjects(key string, limit int, sortDir int,
 	} else {
 		for i := len(pc.CachedProjects) - 1; i >= 0; i-- {
 			p := pc.CachedProjects[i]
-			visible := isAuthenticated || (!isAuthenticated && !p.Private)
-			if p.Identifier < key && visible {
+			if p.Identifier < key {
 				projects = append(projects, p)
 				if len(projects) == limit {
 					break

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -255,8 +255,7 @@ func (s *ProjectConnectorGetSuite) TearDownSuite() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooManyAsc() {
-	isAuthenticated := false
-	projects, err := s.ctx.FindProjects("", 7, 1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("", 7, 1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 3)
@@ -271,8 +270,7 @@ func (s *ProjectConnectorGetSuite) TestFetchTooManyAsc() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooManyAscAuth() {
-	isAuthenticated := true
-	projects, err := s.ctx.FindProjects("", 7, 1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("", 7, 1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 6)
@@ -287,8 +285,7 @@ func (s *ProjectConnectorGetSuite) TestFetchTooManyAscAuth() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooManyDesc() {
-	isAuthenticated := false
-	projects, err := s.ctx.FindProjects("zzz", 7, -1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("zzz", 7, -1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 3)
@@ -303,8 +300,7 @@ func (s *ProjectConnectorGetSuite) TestFetchTooManyDesc() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooManyDescAuth() {
-	isAuthenticated := true
-	projects, err := s.ctx.FindProjects("zzz", 7, -1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("zzz", 7, -1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 6)
@@ -319,8 +315,7 @@ func (s *ProjectConnectorGetSuite) TestFetchTooManyDescAuth() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchExactNumber() {
-	isAuthenticated := false
-	projects, err := s.ctx.FindProjects("", 3, 1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("", 3, 1)
 	s.NoError(err)
 	s.NotNil(projects)
 
@@ -335,8 +330,7 @@ func (s *ProjectConnectorGetSuite) TestFetchExactNumber() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchExactNumberAuth() {
-	isAuthenticated := true
-	projects, err := s.ctx.FindProjects("", 6, 1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("", 6, 1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 6)
@@ -351,8 +345,7 @@ func (s *ProjectConnectorGetSuite) TestFetchExactNumberAuth() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooFewAsc() {
-	isAuthenticated := false
-	projects, err := s.ctx.FindProjects("", 2, 1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("", 2, 1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 2)
@@ -365,8 +358,7 @@ func (s *ProjectConnectorGetSuite) TestFetchTooFewAsc() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooFewAscAuth() {
-	isAuthenticated := true
-	projects, err := s.ctx.FindProjects("", 2, 1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("", 2, 1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 2)
@@ -379,8 +371,7 @@ func (s *ProjectConnectorGetSuite) TestFetchTooFewAscAuth() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooFewDesc() {
-	isAuthenticated := false
-	projects, err := s.ctx.FindProjects("zzz", 2, -1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("zzz", 2, -1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 2)
@@ -393,8 +384,7 @@ func (s *ProjectConnectorGetSuite) TestFetchTooFewDesc() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooFewDescAuth() {
-	isAuthenticated := true
-	projects, err := s.ctx.FindProjects("zzz", 2, -1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("zzz", 2, -1)
 	s.NoError(err)
 	s.NotNil(projects)
 
@@ -407,8 +397,7 @@ func (s *ProjectConnectorGetSuite) TestFetchTooFewDescAuth() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundAsc() {
-	isAuthenticated := false
-	projects, err := s.ctx.FindProjects("projectB", 1, 1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("projectB", 1, 1)
 	s.NoError(err)
 	s.Len(projects, 1)
 	s.Equal("projectD", projects[0].Identifier)
@@ -416,8 +405,7 @@ func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundAsc() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundAscAuth() {
-	isAuthenticated := true
-	projects, err := s.ctx.FindProjects("projectB", 1, 1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("projectB", 1, 1)
 	s.NoError(err)
 	s.Len(projects, 1)
 	s.Equal("projectB", projects[0].Identifier)
@@ -425,8 +413,7 @@ func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundAscAuth() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundDesc() {
-	isAuthenticated := false
-	projects, err := s.ctx.FindProjects("projectD", 1, -1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("projectD", 1, -1)
 	s.NoError(err)
 	s.Len(projects, 1)
 	s.Equal("projectA", projects[0].Identifier)
@@ -434,8 +421,7 @@ func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundDesc() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundDescAuth() {
-	isAuthenticated := true
-	projects, err := s.ctx.FindProjects("projectD", 1, -1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("projectD", 1, -1)
 	s.NoError(err)
 	s.Len(projects, 1)
 	s.Equal("projectC", projects[0].Identifier)
@@ -443,15 +429,13 @@ func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundDescAuth() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchKeyOutOfBoundAsc() {
-	isAuthenticated := false
-	projects, err := s.ctx.FindProjects("zzz", 1, 1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("zzz", 1, 1)
 	s.NoError(err)
 	s.Len(projects, 0)
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchKeyOutOfBoundDesc() {
-	isAuthenticated := false
-	projects, err := s.ctx.FindProjects("aaa", 1, -1, isAuthenticated)
+	projects, err := s.ctx.FindProjects("aaa", 1, -1)
 	s.NoError(err)
 	s.Len(projects, 0)
 }

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -258,90 +258,21 @@ func (s *ProjectConnectorGetSuite) TestFetchTooManyAsc() {
 	projects, err := s.ctx.FindProjects("", 7, 1)
 	s.NoError(err)
 	s.NotNil(projects)
-	s.Len(projects, 3)
-
-	s.Equal("projectA", projects[0].Identifier)
-	s.Equal("projectD", projects[1].Identifier)
-	s.Equal("projectE", projects[2].Identifier)
-
-	s.False(projects[0].Private)
-	s.False(projects[1].Private)
-	s.False(projects[2].Private)
-}
-
-func (s *ProjectConnectorGetSuite) TestFetchTooManyAscAuth() {
-	projects, err := s.ctx.FindProjects("", 7, 1)
-	s.NoError(err)
-	s.NotNil(projects)
 	s.Len(projects, 6)
-
-	s.Equal("projectA", projects[0].Identifier)
-	s.Equal("projectB", projects[1].Identifier)
-	s.Equal("projectC", projects[2].Identifier)
-
-	s.False(projects[0].Private)
-	s.True(projects[1].Private)
-	s.True(projects[2].Private)
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooManyDesc() {
 	projects, err := s.ctx.FindProjects("zzz", 7, -1)
 	s.NoError(err)
 	s.NotNil(projects)
-	s.Len(projects, 3)
-
-	s.Equal("projectE", projects[0].Identifier)
-	s.Equal("projectD", projects[1].Identifier)
-	s.Equal("projectA", projects[2].Identifier)
-
-	s.False(projects[0].Private)
-	s.False(projects[1].Private)
-	s.False(projects[2].Private)
-}
-
-func (s *ProjectConnectorGetSuite) TestFetchTooManyDescAuth() {
-	projects, err := s.ctx.FindProjects("zzz", 7, -1)
-	s.NoError(err)
-	s.NotNil(projects)
 	s.Len(projects, 6)
-
-	s.Equal("projectF", projects[0].Identifier)
-	s.Equal("projectE", projects[1].Identifier)
-	s.Equal("projectD", projects[2].Identifier)
-
-	s.True(projects[0].Private)
-	s.False(projects[1].Private)
-	s.False(projects[2].Private)
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchExactNumber() {
 	projects, err := s.ctx.FindProjects("", 3, 1)
 	s.NoError(err)
 	s.NotNil(projects)
-
 	s.Len(projects, 3)
-	s.Equal("projectA", projects[0].Identifier)
-	s.Equal("projectD", projects[1].Identifier)
-	s.Equal("projectE", projects[2].Identifier)
-
-	s.False(projects[0].Private)
-	s.False(projects[1].Private)
-	s.False(projects[2].Private)
-}
-
-func (s *ProjectConnectorGetSuite) TestFetchExactNumberAuth() {
-	projects, err := s.ctx.FindProjects("", 6, 1)
-	s.NoError(err)
-	s.NotNil(projects)
-	s.Len(projects, 6)
-
-	s.Equal("projectA", projects[0].Identifier)
-	s.Equal("projectB", projects[1].Identifier)
-	s.Equal("projectC", projects[2].Identifier)
-
-	s.False(projects[0].Private)
-	s.True(projects[1].Private)
-	s.True(projects[2].Private)
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooFewAsc() {
@@ -349,25 +280,6 @@ func (s *ProjectConnectorGetSuite) TestFetchTooFewAsc() {
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 2)
-
-	s.Equal("projectA", projects[0].Identifier)
-	s.Equal("projectD", projects[1].Identifier)
-
-	s.False(projects[0].Private)
-	s.False(projects[1].Private)
-}
-
-func (s *ProjectConnectorGetSuite) TestFetchTooFewAscAuth() {
-	projects, err := s.ctx.FindProjects("", 2, 1)
-	s.NoError(err)
-	s.NotNil(projects)
-	s.Len(projects, 2)
-
-	s.Equal("projectA", projects[0].Identifier)
-	s.Equal("projectB", projects[1].Identifier)
-
-	s.False(projects[0].Private)
-	s.True(projects[1].Private)
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchTooFewDesc() {
@@ -375,57 +287,18 @@ func (s *ProjectConnectorGetSuite) TestFetchTooFewDesc() {
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 2)
-
-	s.Equal("projectE", projects[0].Identifier)
-	s.Equal("projectD", projects[1].Identifier)
-
-	s.False(projects[0].Private)
-	s.False(projects[1].Private)
-}
-
-func (s *ProjectConnectorGetSuite) TestFetchTooFewDescAuth() {
-	projects, err := s.ctx.FindProjects("zzz", 2, -1)
-	s.NoError(err)
-	s.NotNil(projects)
-
-	s.Len(projects, 2)
-	s.Equal("projectF", projects[0].Identifier)
-	s.Equal("projectE", projects[1].Identifier)
-
-	s.True(projects[0].Private)
-	s.False(projects[1].Private)
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundAsc() {
 	projects, err := s.ctx.FindProjects("projectB", 1, 1)
 	s.NoError(err)
 	s.Len(projects, 1)
-	s.Equal("projectD", projects[0].Identifier)
-	s.False(projects[0].Private)
-}
-
-func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundAscAuth() {
-	projects, err := s.ctx.FindProjects("projectB", 1, 1)
-	s.NoError(err)
-	s.Len(projects, 1)
-	s.Equal("projectB", projects[0].Identifier)
-	s.True(projects[0].Private)
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundDesc() {
 	projects, err := s.ctx.FindProjects("projectD", 1, -1)
 	s.NoError(err)
 	s.Len(projects, 1)
-	s.Equal("projectA", projects[0].Identifier)
-	s.False(projects[0].Private)
-}
-
-func (s *ProjectConnectorGetSuite) TestFetchKeyWithinBoundDescAuth() {
-	projects, err := s.ctx.FindProjects("projectD", 1, -1)
-	s.NoError(err)
-	s.Len(projects, 1)
-	s.Equal("projectC", projects[0].Identifier)
-	s.True(projects[0].Private)
 }
 
 func (s *ProjectConnectorGetSuite) TestFetchKeyOutOfBoundAsc() {
@@ -454,7 +327,6 @@ func (s *ProjectConnectorGetSuite) TestGetProjectWithCommitQueueByOwnerRepoAndBr
 	projRef, err = s.ctx.GetProjectWithCommitQueueByOwnerRepoAndBranch("evergreen-ci", "evergreen", "master")
 	s.NoError(err)
 	s.NotNil(projRef)
-	s.Equal("projectB", projRef.Identifier)
 }
 
 func (s *ProjectConnectorGetSuite) TestFindProjectVarsById() {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -58,12 +58,7 @@ func (p *projectGetHandler) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (p *projectGetHandler) Run(ctx context.Context) gimlet.Responder {
-	isAuthenticated := false
-	if p.user != nil {
-		isAuthenticated = true
-	}
-
-	projects, err := p.sc.FindProjects(p.key, p.limit+1, 1, isAuthenticated)
+	projects, err := p.sc.FindProjects(p.key, p.limit+1, 1)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Database error"))
 	}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -96,7 +96,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/patches/{patch_id}").Version(2).Patch().Wrap(checkUser).RouteHandler(makeChangePatchStatus(sc))
 	app.AddRoute("/patches/{patch_id}/abort").Version(2).Post().Wrap(checkUser).RouteHandler(makeAbortPatch(sc))
 	app.AddRoute("/patches/{patch_id}/restart").Version(2).Post().Wrap(checkUser).RouteHandler(makeRestartPatch(sc))
-	app.AddRoute("/projects").Version(2).Get().RouteHandler(makeFetchProjectsRoute(sc))
+	app.AddRoute("/projects").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchProjectsRoute(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Put().Wrap(superUser).RouteHandler(makePutProjectByID(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Get().Wrap(checkUser, addProject, checkProjectAdmin).RouteHandler(makeGetProjectByID(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Patch().Wrap(checkUser, addProject, checkProjectAdmin).RouteHandler(makePatchProjectByID(sc))


### PR DESCRIPTION
Previously we showed public projects to non-authed users in the rest v2 API.
However, triggers should probably not be visible, since they can reference
private projects. Instead of handling this in the APIProjectRef struct, which is
used by other projects, I opted for making the list projects endpoint private,
since there's no reason for non-authed users to use this endpoint.