### PR TITLE
EVG-6537: distro admin ui for tunable scheduler options

### DIFF
--- a/config_scheduler.go
+++ b/config_scheduler.go
@@ -19,7 +19,7 @@ type SchedulerConfig struct {
 	TargetTimeSeconds             int     `bson:"target_time_seconds" json:"target_time_seconds" mapstructure:"target_time_seconds"`
 	AcceptableHostIdleTimeSeconds int     `bson:"acceptable_host_idle_time_seconds" json:"acceptable_host_idle_time_seconds" mapstructure:"acceptable_host_idle_time_seconds"`
 	GroupVersions                 bool    `bson:"group_versions" json:"group_versions" mapstructure:"group_versions"`
-	PatchZipperFactor             int64   `bson:"patch_zipper_factor" json:"patch_zipper_factor" mapstructure:"patch_zipper_factor"`
+	PatchFactor                   int64   `bson:"patch_zipper_factor" json:"patch_factor" mapstructure:"patch_zipper_factor"`
 	TimeInQueueFactor             int64   `bson:"time_in_queue_factor" json:"time_in_queue_factor" mapstructure:"time_in_queue_factor"`
 	ExpectedRuntimeFactor         int64   `bson:"expected_runtime_factor" json:"expected_runtime_factor" mapstructure:"expected_runtime_factor"`
 }
@@ -61,7 +61,7 @@ func (c *SchedulerConfig) Set() error {
 			"target_time_seconds":               c.TargetTimeSeconds,
 			"acceptable_host_idle_time_seconds": c.AcceptableHostIdleTimeSeconds,
 			"group_versions":                    c.GroupVersions,
-			"patch_zipper_factor":               c.PatchZipperFactor,
+			"patch_zipper_factor":               c.PatchFactor,
 			"task_ordering":                     c.TaskOrdering,
 		},
 	}, options.Update().SetUpsert(true))

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -102,7 +102,7 @@ type PlannerSettings struct {
 	AcceptableHostIdleTime time.Duration `bson:"acceptable_host_idle_time" json:"acceptable_host_idle_time" mapstructure:"acceptable_host_idle_time,omitempty"`
 	GroupVersions          *bool         `bson:"group_versions" json:"group_versions" mapstructure:"group_versions,omitempty"`
 	TaskOrdering           string        `bson:"task_ordering" json:"task_ordering" mapstructure:"task_ordering,omitempty"`
-	PatchZipperFactor      int64         `bson:"patch_zipper_factor" json:"patch_zipper_factor" mapstructure:"patch_zipper_factor"`
+	PatchFactor            int64         `bson:"patch_zipper_factor" json:"patch_factor" mapstructure:"patch_zipper_factor"`
 	TimeInQueueFactor      int64         `bson:"time_in_queue_factor" json:"time_in_queue_factor" mapstructure:"time_in_queue_factor"`
 	ExpectedRuntimeFactor  int64         `bson:"expected_runtime_factor" json:"expected_runtime_factor" mapstructure:"expected_runtime_factor"`
 
@@ -223,11 +223,11 @@ func (d *Distro) ShouldGroupVersions() bool {
 	return *d.PlannerSettings.GroupVersions
 }
 
-func (d *Distro) GetPatchZipperFactor() int64 {
-	if d.PlannerSettings.PatchZipperFactor <= 0 {
+func (d *Distro) GetPatchFactor() int64 {
+	if d.PlannerSettings.PatchFactor <= 0 {
 		return 1
 	}
-	return d.PlannerSettings.PatchZipperFactor
+	return d.PlannerSettings.PatchFactor
 }
 
 func (d *Distro) GetTimeInQueueFactor() int64 {
@@ -430,7 +430,7 @@ func (d *Distro) GetResolvedPlannerSettings(s *evergreen.Settings) (PlannerSetti
 		AcceptableHostIdleTime: ps.AcceptableHostIdleTime,
 		GroupVersions:          ps.GroupVersions,
 		TaskOrdering:           ps.TaskOrdering,
-		PatchZipperFactor:      ps.PatchZipperFactor,
+		PatchFactor:            ps.PatchFactor,
 		TimeInQueueFactor:      ps.TimeInQueueFactor,
 		ExpectedRuntimeFactor:  ps.ExpectedRuntimeFactor,
 		maxDurationPerHost:     evergreen.MaxDurationPerDistroHost,
@@ -472,8 +472,8 @@ func (d *Distro) GetResolvedPlannerSettings(s *evergreen.Settings) (PlannerSetti
 	if resolved.GroupVersions == nil {
 		resolved.GroupVersions = &config.GroupVersions
 	}
-	if resolved.PatchZipperFactor == 0 {
-		resolved.PatchZipperFactor = config.PatchZipperFactor
+	if resolved.PatchFactor == 0 {
+		resolved.PatchFactor = config.PatchFactor
 	}
 	if resolved.TimeInQueueFactor == 0 {
 		resolved.TimeInQueueFactor = config.TimeInQueueFactor

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -14,12 +14,13 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
     $scope.distros[i].planner_settings.maximum_hosts = $scope.distros[i].planner_settings.maximum_hosts || 0;
     $scope.distros[i].planner_settings.target_time = $scope.distros[i].planner_settings.target_time || 0;
     $scope.distros[i].planner_settings.acceptable_host_idle_time = $scope.distros[i].planner_settings.acceptable_host_idle_time || 0;
-    $scope.distros[i].planner_settings.patch_zipper_factor = $scope.distros[i].planner_settings.patch_zipper_factor || 0;
-    // Convert from nanoseconds (time.Duration) to seconds (UI display units)
+    $scope.distros[i].planner_settings.patch_factor = $scope.distros[i].planner_settings.patch_factor || 0;
+    $scope.distros[i].planner_settings.time_in_queue_factor = $scope.distros[i].planner_settings.time_in_queue_factor || 0;
+    $scope.distros[i].planner_settings.expected_runtime_factor = $scope.distros[i].planner_settings.expected_runtime_factor || 0;
+    // Convert from nanoseconds (time.Duration) to seconds (UI display units) for the relevant planner_settings' fields.
     if ($scope.distros[i].planner_settings.target_time > 0) {
       $scope.distros[i].planner_settings.target_time /= 1e9;
     }
-    // Convert from nanoseconds (time.Duration) to seconds (UI display units)
     if ($scope.distros[i].planner_settings.acceptable_host_idle_time > 0) {
       $scope.distros[i].planner_settings.acceptable_host_idle_time /= 1e9;
     }
@@ -314,11 +315,10 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
   }
 
   $scope.saveConfiguration = function() {
-    // Convert from UI display units (sec) to nanoseconds
+    // Convert from UI display units (seconds) to nanoseconds (time.Duration) for relevant planner_settings' fields.
     if($scope.activeDistro.planner_settings.target_time > 0) {
       $scope.activeDistro.planner_settings.target_time *= 1e9
     }
-    // Convert from UI display units (sec) to nanoseconds
     if($scope.activeDistro.planner_settings.acceptable_host_idle_time > 0) {
       $scope.activeDistro.planner_settings.acceptable_host_idle_time *= 1e9
     }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1063,9 +1063,9 @@ type APISchedulerConfig struct {
 	TargetTimeSeconds             int       `json:"target_time_seconds"`
 	AcceptableHostIdleTimeSeconds int       `json:"acceptable_host_idle_time_seconds"`
 	GroupVersions                 bool      `json:"group_versions"`
-	PatchZipperFactor             int64     `json:"patch_zipper_factor"`
+	PatchFactor                   int64     `json:"patch_factor"`
 	TimeInQueueFactor             int64     `json:"time_in_queue_factor"`
-	ExpectedRuntimeFactor         int64     `json:"expected_runtime_factor_factor"`
+	ExpectedRuntimeFactor         int64     `json:"expected_runtime_factor"`
 }
 
 func (a *APISchedulerConfig) BuildFromService(h interface{}) error {
@@ -1080,7 +1080,7 @@ func (a *APISchedulerConfig) BuildFromService(h interface{}) error {
 		a.TargetTimeSeconds = v.TargetTimeSeconds
 		a.AcceptableHostIdleTimeSeconds = v.AcceptableHostIdleTimeSeconds
 		a.GroupVersions = v.GroupVersions
-		a.PatchZipperFactor = v.PatchZipperFactor
+		a.PatchFactor = v.PatchFactor
 		a.TimeInQueueFactor = v.TimeInQueueFactor
 		a.ExpectedRuntimeFactor = v.ExpectedRuntimeFactor
 	default:
@@ -1100,7 +1100,7 @@ func (a *APISchedulerConfig) ToService() (interface{}, error) {
 		TargetTimeSeconds:             a.TargetTimeSeconds,
 		AcceptableHostIdleTimeSeconds: a.AcceptableHostIdleTimeSeconds,
 		GroupVersions:                 a.GroupVersions,
-		PatchZipperFactor:             a.PatchZipperFactor,
+		PatchFactor:                   a.PatchFactor,
 		ExpectedRuntimeFactor:         a.ExpectedRuntimeFactor,
 		TimeInQueueFactor:             a.TimeInQueueFactor,
 	}, nil

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -20,9 +20,9 @@ type APIPlannerSettings struct {
 	AcceptableHostIdleTime APIDuration `json:"acceptable_host_idle_time"`
 	GroupVersions          *bool       `json:"group_versions"`
 	TaskOrdering           APIString   `json:"task_ordering"`
-	PatchZipperFactor      int64       `json:"patch_zipper_factor"`
+	PatchFactor            int64       `json:"patch_factor"`
 	TimeInQueueFactor      int64       `json:"time_in_queue_factor"`
-	ExpectedRuntimeFactor  int64       `json:"expected_runtime_factor_factor"`
+	ExpectedRuntimeFactor  int64       `json:"expected_runtime_factor"`
 }
 
 // BuildFromService converts from service level distro.PlannerSetting to an APIPlannerSettings
@@ -48,7 +48,7 @@ func (s *APIPlannerSettings) BuildFromService(h interface{}) error {
 	s.AcceptableHostIdleTime = NewAPIDuration(settings.AcceptableHostIdleTime)
 	s.GroupVersions = settings.GroupVersions
 	s.TaskOrdering = ToAPIString(settings.TaskOrdering)
-	s.PatchZipperFactor = settings.PatchZipperFactor
+	s.PatchFactor = settings.PatchFactor
 	s.ExpectedRuntimeFactor = settings.ExpectedRuntimeFactor
 	s.TimeInQueueFactor = settings.TimeInQueueFactor
 
@@ -68,7 +68,7 @@ func (s *APIPlannerSettings) ToService() (interface{}, error) {
 	settings.AcceptableHostIdleTime = s.AcceptableHostIdleTime.ToDuration()
 	settings.GroupVersions = s.GroupVersions
 	settings.TaskOrdering = FromAPIString(s.TaskOrdering)
-	settings.PatchZipperFactor = s.PatchZipperFactor
+	settings.PatchFactor = s.PatchFactor
 	settings.TimeInQueueFactor = s.TimeInQueueFactor
 	settings.ExpectedRuntimeFactor = s.ExpectedRuntimeFactor
 

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -219,7 +219,7 @@ func (unit *Unit) RankValue() int64 {
 	}
 
 	if inPatch {
-		unit.cachedValue += unit.distro.GetPatchZipperFactor()
+		unit.cachedValue += unit.distro.GetPatchFactor()
 	}
 
 	if !anyNonGroupTasks {

--- a/scheduler/planner_test.go
+++ b/scheduler/planner_test.go
@@ -209,13 +209,13 @@ func TestPlanner(t *testing.T) {
 					t.Run("CLI", func(t *testing.T) {
 						unit := NewUnit(task.Task{Id: "foo", Requester: evergreen.PatchVersionRequester})
 						unit.SetDistro(&distro.Distro{})
-						unit.distro.PlannerSettings.PatchZipperFactor = 10
+						unit.distro.PlannerSettings.PatchFactor = 10
 						assert.EqualValues(t, 22, unit.RankValue())
 					})
 					t.Run("Github", func(t *testing.T) {
 						unit := NewUnit(task.Task{Id: "foo", Requester: evergreen.GithubPRRequester})
 						unit.SetDistro(&distro.Distro{})
-						unit.distro.PlannerSettings.PatchZipperFactor = 10
+						unit.distro.PlannerSettings.PatchFactor = 10
 						assert.EqualValues(t, 22, unit.RankValue())
 					})
 				})

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -515,15 +515,37 @@ Evergreen - Distros
               form.plannerSettingsAcceptableHostIdleTime.$modelValue % 1 != 0"> Acceptable Host Idle Time must a non-negative integer
             </div>
             <div>
-              <label class="distro-label">Patch Zipper Factor (0 to 100 inclusive):</label>
+              <label class="distro-label">Patch Factor (0 to 100 inclusive):</label>
               <input ng-readonly="readOnly" type="number" ng-required="activeDistro.planner_settings.version == 'tunable'"
-                name="plannerSettingsPatchZipperFactor" class="form-control" ng-model="activeDistro.planner_settings.patch_zipper_factor" placeholder="Set to 0 to use the its global default">
+                name="plannerSettingsPatchFactor" class="form-control" ng-model="activeDistro.planner_settings.patch_zipper_factor" placeholder="Set to 0 to use the its global default">
             </div>
-            <div class="icon fa fa-warning distro-error" ng-show="form.plannerSettingsPatchZipperFactor.$dirty && form.plannerSettingsPatchZipperFactor.$error.required ||
-              form.plannerSettingsPatchZipperFactor.$invalid ||
-              form.plannerSettingsPatchZipperFactor.$modelValue > 100 ||
-              form.plannerSettingsPatchZipperFactor.$modelValue < 0 ||
-              form.plannerSettingsPatchZipperFactor.$modelValue % 1 != 0"> Patch Zipper Factor must be an integer between 0 and 100
+            <div class="icon fa fa-warning distro-error" ng-show="form.plannerSettingsPatchFactor.$dirty && form.plannerSettingsPatchFactor.$error.required ||
+              form.plannerSettingsPatchFactor.$invalid ||
+              form.plannerSettingsPatchFactor.$modelValue > 100 ||
+              form.plannerSettingsPatchFactor.$modelValue < 0 ||
+              form.plannerSettingsPatchFactor.$modelValue % 1 != 0"> Patch Factor must be an integer between 0 and 100
+            </div>
+            <div>
+              <label class="distro-label">Time In Queue Factor (0 to 100 inclusive):</label>
+              <input ng-readonly="readOnly" type="number" ng-required="activeDistro.planner_settings.version == 'tunable'"
+                name="plannerSettingsTimeInQueueFactor" class="form-control" ng-model="activeDistro.planner_settings.time_in_queue_factor" placeholder="Set to 0 to use its global default">
+            </div>
+            <div class="icon fa fa-warning distro-error" ng-show="form.plannerSettingsTimeInQueueFactor.$dirty && form.plannerSettingsTimeInQueueFactor.$error.required ||
+              form.plannerSettingsTimeInQueueFactor.$invalid ||
+              form.plannerSettingsTimeInQueueFactor.$modelValue > 100 ||
+              form.plannerSettingsTimeInQueueFactor.$modelValue < 0 ||
+              form.plannerSettingsTimeInQueueFactor.$modelValue % 1 != 0"> Time In Queue Factor must be an integer between 0 and 100
+            </div>
+            <div>
+              <label class="distro-label">Expected Runtime Factor (0 to 100 inclusive):</label>
+              <input ng-readonly="readOnly" type="number" ng-required="activeDistro.planner_settings.version == 'tunable'"
+                name="plannerSettingsExpectedRuntimeFactor" class="form-control" ng-model="activeDistro.planner_settings.expected_runtime_factor" placeholder="Set to 0 to use its global default">
+            </div>
+            <div class="icon fa fa-warning distro-error" ng-show="form.plannerSettingsExpectedRuntimeFactor.$dirty && form.plannerSettingsExpectedRuntimeFactor.$error.required ||
+              form.plannerSettingsExpectedRuntimeFactor.$invalid ||
+              form.plannerSettingsExpectedRuntimeFactor.$modelValue > 100 ||
+              form.plannerSettingsExpectedRuntimeFactor.$modelValue < 0 ||
+              form.plannerSettingsExpectedRuntimeFactor.$modelValue % 1 != 0"> Time In Queue Factor must be an integer between 0 and 100
             </div>
             <br/>
             <div class="dropdown">

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -322,25 +322,24 @@ func ensureHasValidPlannerSettings(ctx context.Context, d *distro.Distro, s *eve
 			Level:   Error,
 		})
 	}
-	if ps.PatchZipperFactor < 0 || ps.PatchZipperFactor > 100 {
+	if ps.PatchFactor < 0 || ps.PatchFactor > 100 {
 		errs = append(errs, ValidationError{
-			Message: fmt.Sprintf("invalid planner_settings.patch_zipper_factor value of %d for distro '%s' - its value must be a non-negative integer between 0 and 100, inclusive", ps.PatchZipperFactor, d.Id),
+			Message: fmt.Sprintf("invalid planner_settings.patch_zipper_factor value of %d for distro '%s' - its value must be a non-negative integer between 0 and 100, inclusive", ps.PatchFactor, d.Id),
 			Level:   Error,
 		})
 	}
-	if ps.ExpectedRuntimeFactor < 0 {
+	if ps.TimeInQueueFactor < 0 || ps.TimeInQueueFactor > 100 {
 		errs = append(errs, ValidationError{
-			Message: fmt.Sprintf("invalid planner_settings.expected_runtime_factor value of %d for distro '%s' - its value must be a non-negative integer", ps.PatchZipperFactor, d.Id),
+			Message: fmt.Sprintf("invalid planner_settings.time_in_queue_factor value of %d for distro '%s' - its value must be a non-negative integer between 0 and 100, inclusive", ps.TimeInQueueFactor, d.Id),
 			Level:   Error,
 		})
 	}
-	if ps.TimeInQueueFactor < 0 {
+	if ps.ExpectedRuntimeFactor < 0 || ps.ExpectedRuntimeFactor > 100 {
 		errs = append(errs, ValidationError{
-			Message: fmt.Sprintf("invalid planner_settings.time_in_queue value of %d for distro '%s' - its value must be a non-negative integer", ps.PatchZipperFactor, d.Id),
+			Message: fmt.Sprintf("invalid planner_settings.expected_runtime_factor value of %d for distro '%s' - its value must be a non-negative integer between 0 and 100, inclusive", ps.ExpectedRuntimeFactor, d.Id),
 			Level:   Error,
 		})
 	}
-
 	if !util.StringSliceContains(evergreen.ValidTaskOrderings, ps.TaskOrdering) {
 		errs = append(errs, ValidationError{
 			Message: fmt.Sprintf("invalid planner_settings.task_ordering '%s' for distro '%s'", ps.TaskOrdering, d.Id),


### PR DESCRIPTION
- Wiring up the distro admin UI to edit/set/validate the new `PlannerSettings`' values `TimeInQueueFactor` and `ExpectedRuntimeFactor`.
- Renaming field names and associated references currently called `PatchZipperFactor` to `PatchFactor`.
