### PR TITLE
EVG-5960: use the unattainable field to determine if a task is blocked

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -60,6 +60,9 @@ const (
 	TaskTestTimedOut = "test-timed-out"
 	TaskSetupFailed  = "setup-failed"
 
+	TaskBlocked = "blocked"
+	TaskPending = "pending"
+
 	// Task Command Types
 	CommandTypeTest   = "test"
 	CommandTypeSystem = "system"

--- a/globals.go
+++ b/globals.go
@@ -60,8 +60,8 @@ const (
 	TaskTestTimedOut = "test-timed-out"
 	TaskSetupFailed  = "setup-failed"
 
-	TaskBlocked = "blocked"
-	TaskPending = "pending"
+	TaskStatusBlocked = "blocked"
+	TaskStatusPending = "pending"
 
 	// Task Command Types
 	CommandTypeTest   = "test"

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -81,7 +81,7 @@ func (b *Build) IsFinished() bool {
 //
 // returns boolean to indicate if tasks are complete, string with either BuildFailed or
 // BuildSucceded. The string is only valid when the boolean is true
-func (b *Build) AllUnblockedTasksFinished(tasksWithDeps []task.Task) (bool, string, error) {
+func (b *Build) AllUnblockedTasksFinished() (bool, string, error) {
 	if !b.Activated {
 		return false, b.Status, nil
 	}
@@ -99,18 +99,10 @@ func (b *Build) AllUnblockedTasksFinished(tasksWithDeps []task.Task) (bool, stri
 			if !t.Activated {
 				continue
 			}
-			var blockedStatus string
-			blockedStatus, err = t.BlockedState(tasksWithDeps)
-			if err != nil {
-				return false, status, err
-			}
-			if blockedStatus != "blocked" {
+			if t.Blocked() {
 				allFinished = false
 			}
 		}
-	}
-	if allFinished && err != nil {
-		return false, status, err
 	}
 
 	return allFinished, status, nil

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -99,7 +99,7 @@ func (b *Build) AllUnblockedTasksFinished() (bool, string, error) {
 			if !t.Activated {
 				continue
 			}
-			if t.Blocked() {
+			if !t.Blocked() {
 				allFinished = false
 			}
 		}

--- a/model/build/build_test.go
+++ b/model/build/build_test.go
@@ -575,19 +575,19 @@ func TestAllTasksFinished(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	assert.False(b.AllUnblockedTasksFinished(nil))
+	assert.False(b.AllUnblockedTasksFinished())
 
 	assert.NoError(tasks[0].MarkFailed())
-	assert.False(b.AllUnblockedTasksFinished(nil))
+	assert.False(b.AllUnblockedTasksFinished())
 
 	assert.NoError(tasks[1].MarkFailed())
-	assert.False(b.AllUnblockedTasksFinished(nil))
+	assert.False(b.AllUnblockedTasksFinished())
 
 	assert.NoError(tasks[2].MarkFailed())
-	assert.False(b.AllUnblockedTasksFinished(nil))
+	assert.False(b.AllUnblockedTasksFinished())
 
 	assert.NoError(tasks[3].MarkFailed())
-	assert.True(b.AllUnblockedTasksFinished(nil))
+	assert.True(b.AllUnblockedTasksFinished())
 
 	// Only one activated task
 	require.NoError(t, db.ClearCollections(task.Collection), "error clearing collection")
@@ -614,9 +614,9 @@ func TestAllTasksFinished(t *testing.T) {
 	for _, task := range tasks {
 		assert.NoError(task.Insert())
 	}
-	assert.False(b.AllUnblockedTasksFinished(nil))
+	assert.False(b.AllUnblockedTasksFinished())
 	assert.NoError(tasks[0].MarkFailed())
-	assert.True(b.AllUnblockedTasksFinished(nil))
+	assert.True(b.AllUnblockedTasksFinished())
 
 	// Build is finished
 	require.NoError(t, db.ClearCollections(task.Collection), "error clearing collection")
@@ -627,7 +627,7 @@ func TestAllTasksFinished(t *testing.T) {
 		Activated: false,
 	}
 	assert.NoError(task1.Insert())
-	complete, status, err := b.AllUnblockedTasksFinished(nil)
+	complete, status, err := b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.True(complete)
 	assert.Equal(status, evergreen.BuildFailed)
@@ -683,13 +683,13 @@ func TestAllTasksFinished(t *testing.T) {
 	assert.NoError(d0.Insert())
 	assert.NoError(e0.Insert())
 	assert.NoError(e1.Insert())
-	complete, _, err = b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.True(complete)
 
 	// inactive build should not be complete
 	b.Activated = false
-	complete, _, err = b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.False(complete)
 }

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -206,7 +206,6 @@ func MarkVersionCompleted(versionId string, finishTime time.Time, updates *Statu
 	buildsWithAllActiveTasksComplete := 0
 	activeBuilds := 0
 	finished := true
-	tasksWithDeps, err := task.FindAllTasksFromVersionWithDependencies(versionId)
 	if err != nil {
 		return errors.Wrap(err, "error finding tasks with dependencies")
 	}
@@ -215,7 +214,7 @@ func MarkVersionCompleted(versionId string, finishTime time.Time, updates *Statu
 		if b.Activated {
 			activeBuilds++
 		}
-		complete, buildStatus, err := b.AllUnblockedTasksFinished(tasksWithDeps)
+		complete, buildStatus, err := b.AllUnblockedTasksFinished()
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -470,8 +470,12 @@ func scheduleableTasksQuery() bson.M {
 	return bson.M{
 		ActivatedKey: true,
 		StatusKey:    evergreen.TaskUndispatched,
+
 		//Filter out blacklisted tasks
 		PriorityKey: bson.M{"$gte": 0},
+
+		//Filter tasks containing unattainable dependencies
+		bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey): bson.M{"$ne": true},
 	}
 }
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1690,7 +1690,7 @@ func (t *Task) Blocked() bool {
 
 func (t *Task) BlockedState() (string, error) {
 	if t.Blocked() {
-		return evergreen.TaskBlocked, nil
+		return evergreen.TaskStatusBlocked, nil
 	}
 
 	for _, dep := range t.DependsOn {
@@ -1699,7 +1699,7 @@ func (t *Task) BlockedState() (string, error) {
 			return "", errors.Wrapf(err, "can't get dependent task '%s'", dep.TaskId)
 		}
 		if !t.satisfiesDependency(depTask) {
-			return evergreen.TaskPending, nil
+			return evergreen.TaskStatusPending, nil
 		}
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -23,8 +23,7 @@ import (
 )
 
 const (
-	edgesKey = "edges"
-	taskKey  = "task"
+	dependencyKey = "dependencies"
 
 	// tasks should be unscheduled after ~a week
 	UnschedulableThreshold = 7 * 24 * time.Hour
@@ -40,9 +39,6 @@ const (
 
 	// length of time to cache the expected duration in the task document
 	predictionTTL = 8 * time.Hour
-
-	taskBlocked = "blocked"
-	taskPending = "pending"
 )
 
 var (
@@ -313,7 +309,7 @@ func (t *Task) satisfiesDependency(depTask *Task) bool {
 			case evergreen.TaskFailed:
 				return depTask.Status == evergreen.TaskFailed
 			case AllStatuses:
-				return depTask.Status == evergreen.TaskFailed || depTask.Status == evergreen.TaskSucceeded
+				return depTask.Status == evergreen.TaskFailed || depTask.Status == evergreen.TaskSucceeded || depTask.Blocked()
 			}
 		}
 	}
@@ -375,7 +371,7 @@ func (t *Task) DependenciesMet(depCaches map[string]Task) (bool, error) {
 	}
 
 	if len(depIdsToQueryFor) > 0 {
-		newDeps, err := Find(ByIds(depIdsToQueryFor).WithFields(StatusKey))
+		newDeps, err := Find(ByIds(depIdsToQueryFor).WithFields(StatusKey, DependsOnKey))
 		if err != nil {
 			return false, err
 		}
@@ -1337,8 +1333,6 @@ func FindSchedulableForAlias(id string) ([]Task, error) {
 }
 
 func FindRunnable(distroID string, removeDeps bool) ([]Task, error) {
-	expectedStatuses := []string{evergreen.TaskSucceeded, evergreen.TaskFailed, ""}
-
 	match := scheduleableTasksQuery()
 	if distroID != "" {
 		match[DistroIdKey] = distroID
@@ -1362,48 +1356,74 @@ func FindRunnable(distroID string, removeDeps bool) ([]Task, error) {
 			"startWith":        "$" + DependsOnKey + "." + IdKey,
 			"connectFromField": DependsOnKey + "." + IdKey,
 			"connectToField":   IdKey,
-			"as":               edgesKey,
+			"as":               dependencyKey,
 			// restrict graphLookup to only direct dependencies
 			"maxDepth": 0,
-			"restrictSearchWithMatch": bson.M{
-				StatusKey: bson.M{
-					"$in": expectedStatuses,
+		},
+	}
+
+	unwindDependencies := bson.M{
+		"$unwind": bson.M{
+			"path":                       "$" + dependencyKey,
+			"preserveNullAndEmptyArrays": true,
+		},
+	}
+
+	unwindDependsOn := bson.M{
+		"$unwind": bson.M{
+			"path":                       "$" + DependsOnKey,
+			"preserveNullAndEmptyArrays": true,
+		},
+	}
+
+	matchIds := bson.M{
+		"$match": bson.M{
+			"$expr": bson.M{"$eq": bson.A{"$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyTaskIdKey), "$" + bsonutil.GetDottedKeyName(dependencyKey, IdKey)}},
+		},
+	}
+
+	projectSatisfied := bson.M{
+		"$addFields": bson.M{
+			"satisfied_dependencies": bson.M{
+				"$cond": bson.A{
+					bson.M{
+						"$or": []bson.M{
+							{"$eq": bson.A{"$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyStatusKey), "$" + bsonutil.GetDottedKeyName(dependencyKey, StatusKey)}},
+							{"$and": []bson.M{
+								{"$eq": bson.A{"$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyStatusKey), "*"}},
+								{"$or": []bson.M{
+									{"$in": bson.A{"$" + bsonutil.GetDottedKeyName(dependencyKey, StatusKey), CompletedStatuses}},
+									{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(dependencyKey, DependsOnKey, DependencyUnattainableKey)},
+								}},
+							}},
+						},
+					},
+					true,
+					false,
 				},
 			},
 		},
 	}
 
-	reshapeTasksAndEdges := bson.M{
-		"$project": bson.M{
-			edgesKey + "." + IdKey:     1,
-			edgesKey + "." + StatusKey: 1,
-			taskKey:                    "$$ROOT",
+	regroupTasks := bson.M{
+		"$group": bson.M{
+			"_id":           "$_id",
+			"satisfied_set": bson.M{"$addToSet": "$satisfied_dependencies"},
+			"root":          bson.M{"$first": "$$ROOT"},
 		},
 	}
 
-	removeEdgesFromTask := bson.M{
-		"$project": bson.M{
-			taskKey + "." + edgesKey: 0,
-		},
-	}
-
-	redactUnrunnableTasks := bson.M{
+	redactUnsatisfiedDependencies := bson.M{
 		"$redact": bson.M{
-			"$cond": bson.M{
-				"if": bson.M{
-					"$setEquals": []string{"$" + taskKey + "." + DependsOnKey, "$" + edgesKey},
-				},
-				"then": "$$KEEP",
-				"else": "$$PRUNE",
+			"$cond": bson.A{
+				bson.M{"$allElementsTrue": "$satisfied_set"},
+				"$$KEEP",
+				"$$PRUNE",
 			},
 		},
 	}
 
-	replaceRoot := bson.M{
-		"$replaceRoot": bson.M{
-			"newRoot": "$" + taskKey,
-		},
-	}
+	replaceRoot := bson.M{"$replaceRoot": bson.M{"newRoot": "$root"}}
 
 	joinProjectRef := bson.M{
 		"$lookup": bson.M{
@@ -1414,7 +1434,7 @@ func FindRunnable(distroID string, removeDeps bool) ([]Task, error) {
 		},
 	}
 
-	filterDisabledProejcts := bson.M{
+	filterDisabledProjects := bson.M{
 		"$match": bson.M{
 			"project_ref.0." + "enabled": true,
 		},
@@ -1445,16 +1465,19 @@ func FindRunnable(distroID string, removeDeps bool) ([]Task, error) {
 
 	if removeDeps {
 		pipeline = append(pipeline,
-			reshapeTasksAndEdges,
-			removeEdgesFromTask,
-			redactUnrunnableTasks,
+			unwindDependencies,
+			unwindDependsOn,
+			matchIds,
+			projectSatisfied,
+			regroupTasks,
+			redactUnsatisfiedDependencies,
 			replaceRoot,
 		)
 	}
 
 	pipeline = append(pipeline,
 		joinProjectRef,
-		filterDisabledProejcts,
+		filterDisabledProjects,
 		filterPatchingDisabledProjects,
 		removeProjectRef,
 	)
@@ -1654,77 +1677,33 @@ func (t *Task) GetJQL(searchProjects []string) string {
 	return fmt.Sprintf(jqlBFQuery, strings.Join(searchProjects, ", "), jqlClause)
 }
 
-// BlockedState returns "blocked," "pending" (unsatisfied dependencies,
-// but unblocked), or "" (runnable) to represent the state of the task
-// with respect to its dependencies
-func (t *Task) BlockedState(tasksWithDeps []Task) (string, error) {
-	if t.DisplayOnly {
-		return t.blockedStateForDisplayTask(tasksWithDeps)
-	}
-
-	return t.blockedStatePrivate()
-}
-
-func (t *Task) blockedStatePrivate() (string, error) {
-	if len(t.DependsOn) == 0 {
-		return "", nil
-	}
-	dependencyIDs := []string{}
-	for _, d := range t.DependsOn {
-		dependencyIDs = append(dependencyIDs, d.TaskId)
-	}
-	dependentTasks, err := Find(ByIds(dependencyIDs).WithFields(DisplayNameKey, StatusKey,
-		ActivatedKey, BuildVariantKey, DetailsKey, DependsOnKey))
-	if err != nil {
-		return "", errors.Wrap(err, "error finding dependencies")
-	}
-	taskMap := map[string]*Task{}
-	for i := range dependentTasks {
-		taskMap[dependentTasks[i].Id] = &dependentTasks[i]
-	}
+// Blocked returns if a task cannot run given the state of the task
+func (t *Task) Blocked() bool {
 	for _, dependency := range t.DependsOn {
-		depTask := taskMap[dependency.TaskId]
-		if depTask == nil {
-			continue
-		}
-		state, err := depTask.blockedStatePrivate()
-		if err != nil {
-			return "", err
-		}
-		if state == taskBlocked {
-			return taskBlocked, nil
-		} else if depTask.Status == evergreen.TaskSucceeded || depTask.Status == evergreen.TaskFailed {
-			if depTask.Status != dependency.Status && dependency.Status != AllStatuses {
-				return taskBlocked, nil
-			}
-		} else {
-			return taskPending, nil
+		if dependency.Unattainable {
+			return true
 		}
 	}
-	return "", nil
+
+	return false
 }
 
-func (t *Task) blockedStateForDisplayTask(tasksWithDeps []Task) (string, error) {
-	execTasks, err := Find(ByIds(t.ExecutionTasks))
-	if err != nil {
-		return "", errors.Wrap(err, "error finding execution tasks")
+func (t *Task) BlockedState() (string, error) {
+	if t.Blocked() {
+		return evergreen.TaskBlocked, nil
 	}
-	if len(execTasks) == 0 {
-		return "", nil
-	}
-	state := ""
-	for _, execTask := range execTasks {
-		etState, err := execTask.BlockedState(tasksWithDeps)
+
+	for _, dep := range t.DependsOn {
+		depTask, err := FindOne(ById(dep.TaskId).WithFields(StatusKey, DependsOnKey))
 		if err != nil {
-			return "", errors.Wrap(err, "error finding blocked state")
+			return "", errors.Wrapf(err, "can't get dependent task '%s'", dep.TaskId)
 		}
-		if etState == taskBlocked {
-			return taskBlocked, nil
-		} else if etState == taskPending {
-			state = taskPending
+		if !t.satisfiesDependency(depTask) {
+			return evergreen.TaskPending, nil
 		}
 	}
-	return state, nil
+
+	return "", nil
 }
 
 func (t *Task) CircularDependencies() error {
@@ -1752,31 +1731,13 @@ func (t *Task) CircularDependencies() error {
 	return catcher.Resolve()
 }
 
-func (t *Task) IsBlockedDisplayTask() bool {
-	if !t.DisplayOnly {
-		return false
-	}
-
-	tasksWithDeps, err := FindAllTasksFromVersionWithDependencies(t.Version)
-	if err != nil {
-		grip.Error(message.WrapError(err, "error finding tasks with dependencies"))
-		return false
-	}
-	blockedState, err := t.BlockedState(tasksWithDeps)
-	if err != nil {
-		grip.Error(message.WrapError(err, "error determining blocked state"))
-		return false
-	}
-	return blockedState == taskBlocked
-}
-
 func (t *Task) findAllUnmarkedBlockedDependencies() ([]Task, error) {
 	okStatusSet := []string{AllStatuses, t.Status}
 	query := db.Query(bson.M{
 		DependsOnKey: bson.M{"$elemMatch": bson.M{
 			DependencyTaskIdKey:       t.Id,
 			DependencyStatusKey:       bson.M{"$nin": okStatusSet},
-			DependencyUnattainableKey: bson.M{"$ne": true},
+			DependencyUnattainableKey: false,
 		},
 		}})
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1909,7 +1909,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.False(updates.VersionComplete)
 	b, err := build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err := b.AllUnblockedTasksFinished(nil)
+	complete, _, err := b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.False(complete)
 
@@ -1921,7 +1921,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.False(updates.VersionComplete)
 	b, err = build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err = b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.False(complete)
 
@@ -1933,7 +1933,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.False(updates.VersionComplete)
 	b, err = build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err = b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.False(complete)
 
@@ -1947,7 +1947,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.True(updates.VersionComplete)
 	b, err = build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err = b.AllUnblockedTasksFinished(nil)
+	complete, _, err = b.AllUnblockedTasksFinished()
 	assert.NoError(err)
 	assert.True(complete)
 
@@ -2029,7 +2029,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	assert.True(updates.VersionComplete)
 	b, err := build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err := b.AllUnblockedTasksFinished(nil)
+	complete, _, err := b.AllUnblockedTasksFinished()
 	assert.True(complete)
 	assert.NoError(err)
 	assert.True(b.IsFinished())
@@ -2111,7 +2111,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 	assert.True(updates.VersionComplete)
 	b, err := build.FindOneId(buildID)
 	assert.NoError(err)
-	complete, _, err := b.AllUnblockedTasksFinished(nil)
+	complete, _, err := b.AllUnblockedTasksFinished()
 	assert.True(complete)
 	assert.NoError(err)
 	assert.True(b.IsFinished())

--- a/scheduler/task_finder.go
+++ b/scheduler/task_finder.go
@@ -142,7 +142,7 @@ func AlternateTaskFinder(d distro.Distro) ([]task.Task, error) {
 		taskIds = append(taskIds, t)
 	}
 
-	tasksToCache, err := task.Find(task.ByIds(taskIds).WithFields(task.StatusKey))
+	tasksToCache, err := task.Find(task.ByIds(taskIds).WithFields(task.StatusKey, task.DependsOnKey))
 	if err != nil {
 		return nil, errors.Wrap(err, "problem finding task dependencies")
 	}
@@ -243,7 +243,7 @@ func ParallelTaskFinder(d distro.Distro) ([]task.Task, error) {
 		go func() {
 			defer wg.Done()
 			for id := range toLookup {
-				nt, err := task.FindOneIdWithFields(id, task.StatusKey)
+				nt, err := task.FindOneIdWithFields(id, task.StatusKey, task.DependsOnKey)
 				catcher.Add(err)
 				if nt == nil {
 					continue

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -266,6 +266,10 @@ func (s *TaskFinderComparisonSuite) SetupTest() {
 	})
 }
 
+func (s *TaskFinderComparisonSuite) TearDownTest() {
+	s.NoError(db.Clear(task.Collection))
+}
+
 func (s *TaskFinderComparisonSuite) TestFindRunnableHostsIsIdentical() {
 	idsOldMethod := []string{}
 	for _, task := range s.oldRunnableTasks {

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -79,12 +79,14 @@ func (s *TaskFinderSuite) TearDownSuite() {
 }
 
 func (s *TaskFinderSuite) SetupTest() {
-	taskIds := []string{"t1", "t2", "t3", "t4", "t5"}
+	taskIds := []string{"t0", "t1", "t2", "t3", "t4", "t5"}
 	s.tasks = []task.Task{
 		{Id: taskIds[0], Status: evergreen.TaskUndispatched, Activated: true, Project: "exists", CreateTime: time.Now()},
 		{Id: taskIds[1], Status: evergreen.TaskUndispatched, Activated: true, Project: "exists", CreateTime: time.Now()},
 		{Id: taskIds[2], Status: evergreen.TaskUndispatched, Activated: true, Project: "exists", CreateTime: time.Now()},
-		{Id: taskIds[3], Status: evergreen.TaskUndispatched, Activated: true, Priority: -1, Project: "exists", CreateTime: time.Now()},
+		{Id: taskIds[3], Status: evergreen.TaskUndispatched, Activated: true, Project: "exists", CreateTime: time.Now()},
+		{Id: taskIds[4], Status: evergreen.TaskUndispatched, Activated: true, Project: "exists", CreateTime: time.Now()},
+		{Id: taskIds[5], Status: evergreen.TaskUndispatched, Activated: true, Priority: -1, Project: "exists", CreateTime: time.Now()},
 	}
 
 	depTaskIds := []string{"td1", "td2"}
@@ -118,35 +120,47 @@ func (s *TaskFinderSuite) TestNoRunnableTasksReturnsEmptySlice() {
 
 func (s *TaskFinderSuite) TestInactiveTasksNeverReturned() {
 	// insert the tasks, setting one to inactive
-	s.tasks[2].Activated = false
+	s.tasks[4].Activated = false
 	s.insertTasks()
 
-	// finding the runnable tasks should return two tasks
+	// finding the runnable tasks should return four tasks
 	runnableTasks, err := s.FindRunnableTasks(s.distro)
 	s.NoError(err)
-	s.Len(runnableTasks, 2)
+	s.Len(runnableTasks, 4)
 }
 
 func (s *TaskFinderSuite) TestTasksWithUnsatisfiedDependenciesNeverReturned() {
-	// edit the dependency tasks, setting one to have finished
-	// successfully and one to have finished unsuccessfully
+	// edit the dependency tasks, setting one to have not finished
+	// and one to have failed
 	s.depTasks[0].Status = evergreen.TaskFailed
-	s.depTasks[1].Status = evergreen.TaskSucceeded
+	s.depTasks[1].Status = evergreen.TaskUndispatched
+	s.depTasks[1].DependsOn = []task.Dependency{
+		{
+			TaskId:       "none",
+			Status:       "*",
+			Unattainable: true,
+		},
+	}
 
-	// edit the tasks, setting one to have unmet dependencies, one to
-	// have no dependencies, and one to have successfully met
-	// dependencies
-	s.tasks[0].DependsOn = []task.Dependency{}
+	// Matching dependency - runnable
+	s.tasks[0].DependsOn = []task.Dependency{{TaskId: s.depTasks[0].Id, Status: evergreen.TaskFailed}}
+	// Not matching - not runnable
 	s.tasks[1].DependsOn = []task.Dependency{{TaskId: s.depTasks[0].Id, Status: evergreen.TaskSucceeded}}
-	s.tasks[2].DependsOn = []task.Dependency{{TaskId: s.depTasks[1].Id, Status: evergreen.TaskSucceeded}}
+	// Dependent task 1 is blocked and status is "*" - runnable.
+	// Also demonstrates two satisfied dependencies
+	s.tasks[2].DependsOn = []task.Dependency{{TaskId: s.depTasks[1].Id, Status: "*"}, {TaskId: s.depTasks[0].Id, Status: "*"}}
+	// * status matches any finished status - runnable
+	s.tasks[3].DependsOn = []task.Dependency{{TaskId: s.depTasks[0].Id, Status: "*"}}
 
 	s.insertTasks()
 
-	// finding the runnable tasks should return two tasks (the one with
-	// no dependencies and the one with successfully met dependencies
 	runnableTasks, err := s.FindRunnableTasks(s.distro)
 	s.NoError(err)
-	s.Len(runnableTasks, 2)
+	s.Len(runnableTasks, 4)
+	expectedRunnableTasks := []string{"t0", "t2", "t3", "t4"}
+	for _, t := range runnableTasks {
+		s.Contains(expectedRunnableTasks, t.Id)
+	}
 }
 
 type TaskFinderComparisonSuite struct {
@@ -250,10 +264,6 @@ func (s *TaskFinderComparisonSuite) SetupTest() {
 		"parallel":    s4dur.String(),
 		"pipeline":    s2dur.String(),
 	})
-}
-
-func (s *TaskFinderComparisonSuite) TearDownTest() {
-	s.NoError(db.Clear(task.Collection))
 }
 
 func (s *TaskFinderComparisonSuite) TestFindRunnableHostsIsIdentical() {
@@ -494,7 +504,7 @@ func makeRandomSubTasks(statuses []string, parentTasks *[]task.Task) []task.Task
 		dependsOn := []task.Dependency{
 			task.Dependency{
 				TaskId: parentTask.Id,
-				Status: parentTask.Status,
+				Status: getRandomDependsOnStatus(),
 			},
 		}
 
@@ -504,7 +514,7 @@ func makeRandomSubTasks(statuses []string, parentTasks *[]task.Task) []task.Task
 			dependsOn = append(dependsOn,
 				task.Dependency{
 					TaskId: (*parentTasks)[anotherParent].Id,
-					Status: (*parentTasks)[anotherParent].Status,
+					Status: getRandomDependsOnStatus(),
 				},
 			)
 		}
@@ -525,6 +535,11 @@ func makeRandomSubTasks(statuses []string, parentTasks *[]task.Task) []task.Task
 	}
 
 	return depTasks
+}
+
+func getRandomDependsOnStatus() string {
+	dependsOnStatuses := []string{evergreen.TaskSucceeded, evergreen.TaskFailed, task.AllStatuses}
+	return dependsOnStatuses[rand.Intn(len(dependsOnStatuses))]
 }
 
 func hugeString(suffix string) string {

--- a/service/task.go
+++ b/service/task.go
@@ -456,12 +456,12 @@ func getTaskDependencies(t *task.Task) ([]uiDep, string, error) {
 	if err = t.CircularDependencies(); err != nil {
 		return nil, "", err
 	}
-	status, err := t.BlockedState(nil)
+	state, err := t.BlockedState()
 	if err != nil {
-		return nil, "", err
+		return nil, "", errors.Wrap(err, "can't get blocked state")
 	}
 
-	return uiDependencies, status, nil
+	return uiDependencies, state, nil
 }
 
 // async handler for polling the task log


### PR DESCRIPTION
The second of two PRs (first was #2591) to add cached dependency status to tasks.
This PR uses the cached status to determine if a task is blocked.