### PR TITLE
EVG-6649 Don't time out while debugging

### DIFF
--- a/makefile
+++ b/makefile
@@ -372,10 +372,8 @@ dlvArgs += -test.race
 endif
 ifneq (,$(TEST_TIMEOUT))
 testArgs += -timeout=$(TEST_TIMEOUT)
-dlvArgs += -test.timeout=$(TEST_TIMEOUT)
 else
 testArgs += -timeout=10m
-dlvArgs += -test.timeout=10m
 endif
 #  targets to run any tests in the top-level package
 $(buildDir):


### PR DESCRIPTION
Timeouts make sense for tests, since they can hang. While debugging though,
there should be no timeout. Currently it is not possible to have a debugging
session longer than 10 minutes. This commit removes that limitation.