### PR TITLE
EVG-6662 remove -m alias for set module message flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-08-23"
+	ClientVersion = "2019-08-27"
 )
 
 // ConfigSection defines a sub-document in the evegreen config

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -155,7 +155,7 @@ func setModuleCommand() cli.Command {
 		Usage: "update or add module to an existing merge patch",
 		Flags: mergeFlagSlices(addLargeFlag(), addPatchIDFlag(), addModuleFlag(), addYesFlag(), addRefFlag(
 			cli.StringFlag{
-				Name:  joinFlagNames(messageFlagName, "m", "description", "d"),
+				Name:  joinFlagNames("description", "d"),
 				Usage: "commit message",
 			},
 		)),


### PR DESCRIPTION
Multiple -m flags for `evergreen commit-queue set-module` cause a panic.