### PR TITLE
EVG-6618 Support tags for spawn hosts

### DIFF
--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -173,6 +173,11 @@ func makeTags(intentHost *host.Host) map[string]string {
 		"expire-on":         expireOn,
 	}
 
+	// add InstanceTags specified by user
+	for key, value := range intentHost.InstanceTags {
+		tags[key] = value
+	}
+
 	if intentHost.UserHost {
 		tags["mode"] = "testing"
 	}

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -44,6 +44,7 @@ type SpawnOptions struct {
 	PublicKey        string
 	TaskId           string
 	Owner            *user.DBUser
+	InstanceTags     map[string]string
 }
 
 // Validate returns an instance of BadOptionsErr if the SpawnOptions object contains invalid
@@ -136,6 +137,7 @@ func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 		UserName:           so.UserName,
 		ExpirationDuration: &expiration,
 		UserHost:           true,
+		InstanceTags:       so.InstanceTags,
 	}
 
 	intentHost := host.NewIntent(d, d.GenerateName(), d.Provider, hostOptions)

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -83,6 +83,7 @@ var (
 	ContainerPoolSettingsKey     = bsonutil.MustHaveTag(Host{}, "ContainerPoolSettings")
 	RunningTeardownForTaskKey    = bsonutil.MustHaveTag(Host{}, "RunningTeardownForTask")
 	RunningTeardownSinceKey      = bsonutil.MustHaveTag(Host{}, "RunningTeardownSince")
+	InstanceTagsKey              = bsonutil.MustHaveTag(Host{}, "InstanceTags")
 	SpawnOptionsTaskIDKey        = bsonutil.MustHaveTag(SpawnOptions{}, "TaskID")
 	SpawnOptionsBuildIDKey       = bsonutil.MustHaveTag(SpawnOptions{}, "BuildID")
 	SpawnOptionsTimeoutKey       = bsonutil.MustHaveTag(SpawnOptions{}, "TimeoutTeardown")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -139,6 +139,9 @@ type Host struct {
 
 	// DockerOptions stores information for creating a container with a specific image and command
 	DockerOptions DockerOptions `bson:"docker_options,omitempty" json:"docker_options,omitempty"`
+
+	// InstanceTags stores user-specified tags for instances
+	InstanceTags map[string]string `bson:"instance_tags,omitempty" json:"instance_tags,omitempty"`
 }
 
 func (h *Host) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(h) }

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -22,6 +22,7 @@ type CreateOptions struct {
 	ContainerPoolSettings *evergreen.ContainerPool
 	SpawnOptions          SpawnOptions
 	DockerOptions         DockerOptions
+	InstanceTags          map[string]string
 }
 
 // NewIntent creates an IntentHost using the given host settings. An IntentHost is a host that
@@ -51,6 +52,7 @@ func NewIntent(d distro.Distro, instanceName, provider string, options CreateOpt
 		ContainerPoolSettings: options.ContainerPoolSettings,
 		SpawnOptions:          options.SpawnOptions,
 		DockerOptions:         options.DockerOptions,
+		InstanceTags:          options.InstanceTags,
 	}
 
 	if options.ExpirationDuration != nil {

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -77,7 +77,7 @@ func hostCreate() cli.Command {
 				Name:  joinFlagNames(scriptFlagName, "s"),
 				Usage: "path to userdata script to run",
 			},
-			cli.StringFlag{
+			cli.StringSliceFlag{
 				Name:  joinFlagNames(tagFlagName, "t"),
 				Usage: "key=value pair representing an instance tag, with one pair per flag",
 			},
@@ -122,11 +122,11 @@ func hostCreate() cli.Command {
 			}
 
 			host, err := client.CreateSpawnHost(ctx, spawnRequest)
-			if host == nil {
-				return errors.New("Unable to create a spawn host. Double check that the params and .evergreen.yml are correct")
-			}
 			if err != nil {
 				return errors.Wrap(err, "problem contacting evergreen service")
+			}
+			if host == nil {
+				return errors.New("Unable to create a spawn host. Double check that the params and .evergreen.yml are correct")
 			}
 
 			grip.Infof("Spawn host created with ID '%s'. Visit the hosts page in Evergreen to check on its status.", model.FromAPIString(host.Id))

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/evergreen-ci/evergreen/cloud"
+
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -104,7 +106,13 @@ func hostCreate() cli.Command {
 				return errors.Wrap(err, "problem generating tags")
 			}
 
-			host, err := client.CreateSpawnHost(ctx, distro, key, script, tags)
+			spawnOptions := cloud.SpawnOptions{
+				DistroId:     distro,
+				PublicKey:    key,
+				InstanceTags: tags,
+			}
+
+			host, err := client.CreateSpawnHost(ctx, spawnOptions, script)
 			if host == nil {
 				return errors.New("Unable to create a spawn host. Double check that the params and .evergreen.yml are correct")
 			}

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -20,7 +19,7 @@ const (
 // makeAWSTags creates and validates a map of supplied instance tags
 func makeAWSTags(tagSlice []string) (map[string]string, error) {
 	catcher := grip.NewBasicCatcher()
-	var tags = make(map[string]string)
+	tags := make(map[string]string)
 	for _, tagString := range tagSlice {
 		pair := strings.Split(tagString, "=")
 		if len(pair) != 2 {
@@ -115,13 +114,14 @@ func hostCreate() cli.Command {
 				return errors.Wrap(err, "problem generating tags")
 			}
 
-			spawnOptions := cloud.SpawnOptions{
-				DistroId:     distro,
-				PublicKey:    key,
+			spawnRequest := &model.HostPostRequest{
+				DistroID:     distro,
+				KeyName:      key,
+				UserData:     script,
 				InstanceTags: tags,
 			}
 
-			host, err := client.CreateSpawnHost(ctx, spawnOptions, script)
+			host, err := client.CreateSpawnHost(ctx, spawnRequest)
 			if host == nil {
 				return errors.New("Unable to create a spawn host. Double check that the params and .evergreen.yml are correct")
 			}

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -12,6 +12,11 @@ import (
 	"github.com/urfave/cli"
 )
 
+const (
+	MaxTagKeyLength   = 128
+	MaxTagValueLength = 256
+)
+
 // makeAWSTags creates and validates a map of supplied instance tags
 func makeAWSTags(tagSlice []string) (map[string]string, error) {
 	catcher := grip.NewBasicCatcher()
@@ -27,11 +32,11 @@ func makeAWSTags(tagSlice []string) (map[string]string, error) {
 		value := pair[1]
 
 		// AWS tag key must contain no more than 128 characters
-		if len(key) > 128 {
+		if len(key) > MaxTagKeyLength {
 			catcher.Add(errors.Errorf("key '%s' is longer than 128 characters", key))
 		}
 		// AWS tag value must contain no more than 256 characters
-		if len(value) > 256 {
+		if len(value) > MaxTagValueLength {
 			catcher.Add(errors.Errorf("value '%s' is longer than 256 characters", value))
 		}
 		// tag prefix aws: is reserved
@@ -42,7 +47,11 @@ func makeAWSTags(tagSlice []string) (map[string]string, error) {
 		tags[key] = value
 	}
 
-	return tags, catcher.Resolve()
+	if catcher.HasErrors() {
+		return nil, catcher.Resolve()
+	}
+
+	return tags, nil
 }
 
 func hostCreate() cli.Command {

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -114,7 +114,7 @@ func hostCreate() cli.Command {
 				return errors.Wrap(err, "problem generating tags")
 			}
 
-			spawnRequest := &model.HostPostRequest{
+			spawnRequest := &model.HostRequestOptions{
 				DistroID:     distro,
 				KeyName:      key,
 				UserData:     script,

--- a/operations/host_test.go
+++ b/operations/host_test.go
@@ -117,40 +117,41 @@ func TestHostTeardownScript(t *testing.T) {
 }
 
 func TestMakeAWSTags(t *testing.T) {
-	assert := assert.New(t)
-
-	tagSlice := []string{"key1=value1", "key2=value2"}
-	tags, err := makeAWSTags(tagSlice)
-	assert.Equal(tags, map[string]string{
-		"key1": "value1",
-		"key2": "value2",
+	t.Run("OK", func(t *testing.T) {
+		tagSlice := []string{"key1=value1", "key2=value2"}
+		tags, err := makeAWSTags(tagSlice)
+		assert.Equal(t, tags, map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		})
+		assert.NoError(t, err)
 	})
-	assert.NoError(err)
-
-	// Problem parsing flag
-	tagSlice = []string{"key1=value1", "incorrect"}
-	tags, err = makeAWSTags(tagSlice)
-	assert.Nil(tags)
-	assert.EqualError(err, "problem parsing tag 'incorrect'")
-
-	// Key too long
-	badKey := strings.Repeat("a", 129)
-	tagSlice = []string{"key1=value", fmt.Sprintf("%s=value2", badKey)}
-	tags, err = makeAWSTags(tagSlice)
-	assert.Nil(tags)
-	assert.EqualError(err, fmt.Sprintf("key '%s' is longer than 128 characters", badKey))
-
-	// Value too long
-	badValue := strings.Repeat("a", 257)
-	tagSlice = []string{"key1=value2", fmt.Sprintf("key2=%s", badValue)}
-	tags, err = makeAWSTags(tagSlice)
-	assert.Nil(tags)
-	assert.EqualError(err, fmt.Sprintf("value '%s' is longer than 256 characters", badValue))
-
-	// Reserved prefix used
-	badPrefix := "aws:"
-	tagSlice = []string{"key1=value1", fmt.Sprintf("%skey2=value2", badPrefix)}
-	tags, err = makeAWSTags(tagSlice)
-	assert.Nil(tags)
-	assert.EqualError(err, fmt.Sprintf("illegal tag prefix '%s'", badPrefix))
+	t.Run("ParsingError", func(t *testing.T) {
+		badTag := "incorrect"
+		tagSlice := []string{"key1=value1", badTag}
+		tags, err := makeAWSTags(tagSlice)
+		assert.Nil(t, tags)
+		assert.EqualError(t, err, fmt.Sprintf("problem parsing tag '%s'", badTag))
+	})
+	t.Run("LongKey", func(t *testing.T) {
+		badKey := strings.Repeat("a", 129)
+		tagSlice := []string{"key1=value", fmt.Sprintf("%s=value2", badKey)}
+		tags, err := makeAWSTags(tagSlice)
+		assert.Nil(t, tags)
+		assert.EqualError(t, err, fmt.Sprintf("key '%s' is longer than 128 characters", badKey))
+	})
+	t.Run("LongValue", func(t *testing.T) {
+		badValue := strings.Repeat("a", 257)
+		tagSlice := []string{"key1=value2", fmt.Sprintf("key2=%s", badValue)}
+		tags, err := makeAWSTags(tagSlice)
+		assert.Nil(t, tags)
+		assert.EqualError(t, err, fmt.Sprintf("value '%s' is longer than 256 characters", badValue))
+	})
+	t.Run("BadPrefix", func(t *testing.T) {
+		badPrefix := "aws:"
+		tagSlice := []string{"key1=value1", fmt.Sprintf("%skey2=value2", badPrefix)}
+		tags, err := makeAWSTags(tagSlice)
+		assert.Nil(t, tags)
+		assert.EqualError(t, err, fmt.Sprintf("illegal tag prefix '%s'", badPrefix))
+	})
 }

--- a/operations/host_test.go
+++ b/operations/host_test.go
@@ -2,8 +2,10 @@ package operations
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -112,4 +114,43 @@ func TestHostTeardownScript(t *testing.T) {
 	err = runHostTeardownScript(ctx)
 	assert.Error(err)
 
+}
+
+func TestMakeAWSTags(t *testing.T) {
+	assert := assert.New(t)
+
+	tagSlice := []string{"key1=value1", "key2=value2"}
+	tags, err := makeAWSTags(tagSlice)
+	assert.Equal(tags, map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	})
+	assert.NoError(err)
+
+	// Problem parsing flag
+	tagSlice = []string{"key1=value1", "incorrect"}
+	tags, err = makeAWSTags(tagSlice)
+	assert.Nil(tags)
+	assert.EqualError(err, "problem parsing tag \"incorrect\"")
+
+	// Key too long
+	badKey := strings.Repeat("a", 129)
+	tagSlice = []string{"key1=value", fmt.Sprintf("%s=value2", badKey)}
+	tags, err = makeAWSTags(tagSlice)
+	assert.Nil(tags)
+	assert.EqualError(err, fmt.Sprintf("key \"%s\" is longer than 128 characters", badKey))
+
+	// Value too long
+	badValue := strings.Repeat("a", 257)
+	tagSlice = []string{"key1=value2", fmt.Sprintf("key2=%s", badValue)}
+	tags, err = makeAWSTags(tagSlice)
+	assert.Nil(tags)
+	assert.EqualError(err, fmt.Sprintf("value \"%s\" is longer than 256 characters", badValue))
+
+	// Reserved prefix used
+	badPrefix := "aws:"
+	tagSlice = []string{"key1=value1", fmt.Sprintf("%skey2=value2", badPrefix)}
+	tags, err = makeAWSTags(tagSlice)
+	assert.Nil(tags)
+	assert.EqualError(err, fmt.Sprintf("illegal tag prefix \"%s\"", badPrefix))
 }

--- a/operations/host_test.go
+++ b/operations/host_test.go
@@ -130,23 +130,27 @@ func TestMakeAWSTags(t *testing.T) {
 	// Problem parsing flag
 	tagSlice = []string{"key1=value1", "incorrect"}
 	tags, err = makeAWSTags(tagSlice)
+	assert.Nil(tags)
 	assert.EqualError(err, "problem parsing tag 'incorrect'")
 
 	// Key too long
 	badKey := strings.Repeat("a", 129)
 	tagSlice = []string{"key1=value", fmt.Sprintf("%s=value2", badKey)}
 	tags, err = makeAWSTags(tagSlice)
+	assert.Nil(tags)
 	assert.EqualError(err, fmt.Sprintf("key '%s' is longer than 128 characters", badKey))
 
 	// Value too long
 	badValue := strings.Repeat("a", 257)
 	tagSlice = []string{"key1=value2", fmt.Sprintf("key2=%s", badValue)}
 	tags, err = makeAWSTags(tagSlice)
+	assert.Nil(tags)
 	assert.EqualError(err, fmt.Sprintf("value '%s' is longer than 256 characters", badValue))
 
 	// Reserved prefix used
 	badPrefix := "aws:"
 	tagSlice = []string{"key1=value1", fmt.Sprintf("%skey2=value2", badPrefix)}
 	tags, err = makeAWSTags(tagSlice)
+	assert.Nil(tags)
 	assert.EqualError(err, fmt.Sprintf("illegal tag prefix '%s'", badPrefix))
 }

--- a/operations/host_test.go
+++ b/operations/host_test.go
@@ -130,27 +130,23 @@ func TestMakeAWSTags(t *testing.T) {
 	// Problem parsing flag
 	tagSlice = []string{"key1=value1", "incorrect"}
 	tags, err = makeAWSTags(tagSlice)
-	assert.Nil(tags)
-	assert.EqualError(err, "problem parsing tag \"incorrect\"")
+	assert.EqualError(err, "problem parsing tag 'incorrect'")
 
 	// Key too long
 	badKey := strings.Repeat("a", 129)
 	tagSlice = []string{"key1=value", fmt.Sprintf("%s=value2", badKey)}
 	tags, err = makeAWSTags(tagSlice)
-	assert.Nil(tags)
-	assert.EqualError(err, fmt.Sprintf("key \"%s\" is longer than 128 characters", badKey))
+	assert.EqualError(err, fmt.Sprintf("key '%s' is longer than 128 characters", badKey))
 
 	// Value too long
 	badValue := strings.Repeat("a", 257)
 	tagSlice = []string{"key1=value2", fmt.Sprintf("key2=%s", badValue)}
 	tags, err = makeAWSTags(tagSlice)
-	assert.Nil(tags)
-	assert.EqualError(err, fmt.Sprintf("value \"%s\" is longer than 256 characters", badValue))
+	assert.EqualError(err, fmt.Sprintf("value '%s' is longer than 256 characters", badValue))
 
 	// Reserved prefix used
 	badPrefix := "aws:"
 	tagSlice = []string{"key1=value1", fmt.Sprintf("%skey2=value2", badPrefix)}
 	tags, err = makeAWSTags(tagSlice)
-	assert.Nil(tags)
-	assert.EqualError(err, fmt.Sprintf("illegal tag prefix \"%s\"", badPrefix))
+	assert.EqualError(err, fmt.Sprintf("illegal tag prefix '%s'", badPrefix))
 }

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -138,7 +138,7 @@ type Communicator interface {
 
 	// Spawnhost methods
 	//
-	CreateSpawnHost(context.Context, cloud.SpawnOptions, string) (*restmodel.APIHost, error)
+	CreateSpawnHost(context.Context, *restmodel.HostPostRequest) (*restmodel.APIHost, error)
 	TerminateSpawnHost(context.Context, string) error
 	ChangeSpawnHostPassword(context.Context, string, string) error
 	ExtendSpawnHostExpiration(context.Context, string, int) error

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -138,7 +138,7 @@ type Communicator interface {
 
 	// Spawnhost methods
 	//
-	CreateSpawnHost(context.Context, *restmodel.HostPostRequest) (*restmodel.APIHost, error)
+	CreateSpawnHost(context.Context, *restmodel.HostRequestOptions) (*restmodel.APIHost, error)
 	TerminateSpawnHost(context.Context, string) error
 	ChangeSpawnHostPassword(context.Context, string, string) error
 	ExtendSpawnHostExpiration(context.Context, string, int) error

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -138,7 +138,7 @@ type Communicator interface {
 
 	// Spawnhost methods
 	//
-	CreateSpawnHost(context.Context, string, string, string) (*restmodel.APIHost, error)
+	CreateSpawnHost(context.Context, string, string, string, map[string]string) (*restmodel.APIHost, error)
 	TerminateSpawnHost(context.Context, string) error
 	ChangeSpawnHostPassword(context.Context, string, string) error
 	ExtendSpawnHostExpiration(context.Context, string, int) error

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -138,7 +138,7 @@ type Communicator interface {
 
 	// Spawnhost methods
 	//
-	CreateSpawnHost(context.Context, string, string, string, map[string]string) (*restmodel.APIHost, error)
+	CreateSpawnHost(context.Context, cloud.SpawnOptions, string) (*restmodel.APIHost, error)
 	TerminateSpawnHost(context.Context, string) error
 	ChangeSpawnHostPassword(context.Context, string, string) error
 	ExtendSpawnHostExpiration(context.Context, string, int) error

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -335,7 +335,7 @@ func (c *Mock) GetTaskPatch(ctx context.Context, td TaskData) (*patchmodel.Patch
 // GetHostsByUser will return an array with a single mock host
 func (c *Mock) GetHostsByUser(ctx context.Context, user string) ([]*model.APIHost, error) {
 	hosts := make([]*model.APIHost, 1)
-	spawnRequest := &model.HostPostRequest{
+	spawnRequest := &model.HostRequestOptions{
 		DistroID:     "mock_distro",
 		KeyName:      "mock_key",
 		UserData:     "",
@@ -347,7 +347,7 @@ func (c *Mock) GetHostsByUser(ctx context.Context, user string) ([]*model.APIHos
 }
 
 // CreateSpawnHost will return a mock host that would have been intended
-func (*Mock) CreateSpawnHost(ctx context.Context, spawnRequest *model.HostPostRequest) (*model.APIHost, error) {
+func (*Mock) CreateSpawnHost(ctx context.Context, spawnRequest *model.HostRequestOptions) (*model.APIHost, error) {
 	mockHost := &model.APIHost{
 		Id:      model.ToAPIString("mock_host_id"),
 		HostURL: model.ToAPIString("mock_url"),
@@ -380,7 +380,7 @@ func (*Mock) ExtendSpawnHostExpiration(context.Context, string, int) error {
 // GetHosts will return an array with a single mock host
 func (c *Mock) GetHosts(ctx context.Context, f func([]*model.APIHost) error) error {
 	hosts := make([]*model.APIHost, 1)
-	spawnRequest := &model.HostPostRequest{
+	spawnRequest := &model.HostRequestOptions{
 		DistroID:     "mock_distro",
 		KeyName:      "mock_key",
 		UserData:     "",

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -335,13 +335,13 @@ func (c *Mock) GetTaskPatch(ctx context.Context, td TaskData) (*patchmodel.Patch
 // GetHostsByUser will return an array with a single mock host
 func (c *Mock) GetHostsByUser(ctx context.Context, user string) ([]*model.APIHost, error) {
 	hosts := make([]*model.APIHost, 1)
-	host, _ := c.CreateSpawnHost(ctx, "mock_distro", "mock_key", "")
+	host, _ := c.CreateSpawnHost(ctx, "mock_distro", "mock_key", "", nil)
 	hosts = append(hosts, host)
 	return hosts, nil
 }
 
 // CreateSpawnHost will return a mock host that would have been intended
-func (*Mock) CreateSpawnHost(ctx context.Context, distroID, keyName, userData string) (*model.APIHost, error) {
+func (*Mock) CreateSpawnHost(ctx context.Context, distroID, keyName, userData string, tags map[string]string) (*model.APIHost, error) {
 	mockHost := &model.APIHost{
 		Id:      model.ToAPIString("mock_host_id"),
 		HostURL: model.ToAPIString("mock_url"),
@@ -373,7 +373,7 @@ func (*Mock) ExtendSpawnHostExpiration(context.Context, string, int) error {
 // GetHosts will return an array with a single mock host
 func (c *Mock) GetHosts(ctx context.Context, f func([]*model.APIHost) error) error {
 	hosts := make([]*model.APIHost, 1)
-	host, _ := c.CreateSpawnHost(ctx, "mock_distro", "mock_key", "")
+	host, _ := c.CreateSpawnHost(ctx, "mock_distro", "mock_key", "", nil)
 	hosts = append(hosts, host)
 	err := f(hosts)
 	return err

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -335,25 +335,31 @@ func (c *Mock) GetTaskPatch(ctx context.Context, td TaskData) (*patchmodel.Patch
 // GetHostsByUser will return an array with a single mock host
 func (c *Mock) GetHostsByUser(ctx context.Context, user string) ([]*model.APIHost, error) {
 	hosts := make([]*model.APIHost, 1)
-	host, _ := c.CreateSpawnHost(ctx, "mock_distro", "mock_key", "", nil)
+	spawnOptions := cloud.SpawnOptions{
+		DistroId:     "mock_distro",
+		PublicKey:    "mock_key",
+		InstanceTags: nil,
+	}
+	host, _ := c.CreateSpawnHost(ctx, spawnOptions, "")
 	hosts = append(hosts, host)
 	return hosts, nil
 }
 
 // CreateSpawnHost will return a mock host that would have been intended
-func (*Mock) CreateSpawnHost(ctx context.Context, distroID, keyName, userData string, tags map[string]string) (*model.APIHost, error) {
+func (*Mock) CreateSpawnHost(ctx context.Context, spawnOptions cloud.SpawnOptions, userData string) (*model.APIHost, error) {
 	mockHost := &model.APIHost{
 		Id:      model.ToAPIString("mock_host_id"),
 		HostURL: model.ToAPIString("mock_url"),
 		Distro: model.DistroInfo{
-			Id:       model.ToAPIString(distroID),
+			Id:       model.ToAPIString(spawnOptions.DistroId),
 			Provider: model.ToAPIString(evergreen.ProviderNameMock),
 		},
-		Type:        model.ToAPIString("mock_type"),
-		Status:      model.ToAPIString(evergreen.HostUninitialized),
-		StartedBy:   model.ToAPIString("mock_user"),
-		UserHost:    true,
-		Provisioned: false,
+		Type:         model.ToAPIString("mock_type"),
+		Status:       model.ToAPIString(evergreen.HostUninitialized),
+		StartedBy:    model.ToAPIString("mock_user"),
+		UserHost:     true,
+		Provisioned:  false,
+		InstanceTags: spawnOptions.InstanceTags,
 	}
 	return mockHost, nil
 }
@@ -373,7 +379,12 @@ func (*Mock) ExtendSpawnHostExpiration(context.Context, string, int) error {
 // GetHosts will return an array with a single mock host
 func (c *Mock) GetHosts(ctx context.Context, f func([]*model.APIHost) error) error {
 	hosts := make([]*model.APIHost, 1)
-	host, _ := c.CreateSpawnHost(ctx, "mock_distro", "mock_key", "", nil)
+	spawnOptions := cloud.SpawnOptions{
+		DistroId:     "mock_distro",
+		PublicKey:    "mock_key",
+		InstanceTags: nil,
+	}
+	host, _ := c.CreateSpawnHost(ctx, spawnOptions, "")
 	hosts = append(hosts, host)
 	err := f(hosts)
 	return err

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -335,23 +335,24 @@ func (c *Mock) GetTaskPatch(ctx context.Context, td TaskData) (*patchmodel.Patch
 // GetHostsByUser will return an array with a single mock host
 func (c *Mock) GetHostsByUser(ctx context.Context, user string) ([]*model.APIHost, error) {
 	hosts := make([]*model.APIHost, 1)
-	spawnOptions := cloud.SpawnOptions{
-		DistroId:     "mock_distro",
-		PublicKey:    "mock_key",
+	spawnRequest := &model.HostPostRequest{
+		DistroID:     "mock_distro",
+		KeyName:      "mock_key",
+		UserData:     "",
 		InstanceTags: nil,
 	}
-	host, _ := c.CreateSpawnHost(ctx, spawnOptions, "")
+	host, _ := c.CreateSpawnHost(ctx, spawnRequest)
 	hosts = append(hosts, host)
 	return hosts, nil
 }
 
 // CreateSpawnHost will return a mock host that would have been intended
-func (*Mock) CreateSpawnHost(ctx context.Context, spawnOptions cloud.SpawnOptions, userData string) (*model.APIHost, error) {
+func (*Mock) CreateSpawnHost(ctx context.Context, spawnRequest *model.HostPostRequest) (*model.APIHost, error) {
 	mockHost := &model.APIHost{
 		Id:      model.ToAPIString("mock_host_id"),
 		HostURL: model.ToAPIString("mock_url"),
 		Distro: model.DistroInfo{
-			Id:       model.ToAPIString(spawnOptions.DistroId),
+			Id:       model.ToAPIString(spawnRequest.DistroID),
 			Provider: model.ToAPIString(evergreen.ProviderNameMock),
 		},
 		Type:         model.ToAPIString("mock_type"),
@@ -359,7 +360,7 @@ func (*Mock) CreateSpawnHost(ctx context.Context, spawnOptions cloud.SpawnOption
 		StartedBy:    model.ToAPIString("mock_user"),
 		UserHost:     true,
 		Provisioned:  false,
-		InstanceTags: spawnOptions.InstanceTags,
+		InstanceTags: spawnRequest.InstanceTags,
 	}
 	return mockHost, nil
 }
@@ -379,12 +380,13 @@ func (*Mock) ExtendSpawnHostExpiration(context.Context, string, int) error {
 // GetHosts will return an array with a single mock host
 func (c *Mock) GetHosts(ctx context.Context, f func([]*model.APIHost) error) error {
 	hosts := make([]*model.APIHost, 1)
-	spawnOptions := cloud.SpawnOptions{
-		DistroId:     "mock_distro",
-		PublicKey:    "mock_key",
+	spawnRequest := &model.HostPostRequest{
+		DistroID:     "mock_distro",
+		KeyName:      "mock_key",
+		UserData:     "",
 		InstanceTags: nil,
 	}
-	host, _ := c.CreateSpawnHost(ctx, spawnOptions, "")
+	host, _ := c.CreateSpawnHost(ctx, spawnRequest)
 	hosts = append(hosts, host)
 	err := f(hosts)
 	return err

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -63,7 +63,7 @@ func (*communicatorImpl) SetHostStatus()   {}
 func (*communicatorImpl) SetHostStatuses() {}
 
 // CreateSpawnHost will insert an intent host into the DB that will be spawned later by the runner
-func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, spawnRequest *model.HostPostRequest) (*model.APIHost, error) {
+func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, spawnRequest *model.HostRequestOptions) (*model.APIHost, error) {
 
 	info := requestInfo{
 		method:  post,

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -63,12 +63,12 @@ func (*communicatorImpl) SetHostStatus()   {}
 func (*communicatorImpl) SetHostStatuses() {}
 
 // CreateSpawnHost will insert an intent host into the DB that will be spawned later by the runner
-func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, distroID, keyName, userData string, tags map[string]string) (*model.APIHost, error) {
+func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, options cloud.SpawnOptions, userData string) (*model.APIHost, error) {
 	spawnRequest := &model.HostPostRequest{
-		DistroID:     distroID,
-		KeyName:      keyName,
+		DistroID:     options.DistroId,
+		KeyName:      options.PublicKey,
 		UserData:     userData,
-		InstanceTags: tags,
+		InstanceTags: options.InstanceTags,
 	}
 	info := requestInfo{
 		method:  post,

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -63,11 +63,12 @@ func (*communicatorImpl) SetHostStatus()   {}
 func (*communicatorImpl) SetHostStatuses() {}
 
 // CreateSpawnHost will insert an intent host into the DB that will be spawned later by the runner
-func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, distroID, keyName, userData string) (*model.APIHost, error) {
+func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, distroID, keyName, userData string, tags map[string]string) (*model.APIHost, error) {
 	spawnRequest := &model.HostPostRequest{
-		DistroID: distroID,
-		KeyName:  keyName,
-		UserData: userData,
+		DistroID:     distroID,
+		KeyName:      keyName,
+		UserData:     userData,
+		InstanceTags: tags,
 	}
 	info := requestInfo{
 		method:  post,

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -63,13 +63,8 @@ func (*communicatorImpl) SetHostStatus()   {}
 func (*communicatorImpl) SetHostStatuses() {}
 
 // CreateSpawnHost will insert an intent host into the DB that will be spawned later by the runner
-func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, options cloud.SpawnOptions, userData string) (*model.APIHost, error) {
-	spawnRequest := &model.HostPostRequest{
-		DistroID:     options.DistroId,
-		KeyName:      options.PublicKey,
-		UserData:     userData,
-		InstanceTags: options.InstanceTags,
-	}
+func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, spawnRequest *model.HostPostRequest) (*model.APIHost, error) {
+
 	info := requestInfo{
 		method:  post,
 		path:    "hosts",

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -62,6 +62,7 @@ func (dbc *DBConnector) FindHostByIdWithOwner(hostID string, user gimlet.User) (
 func (hc *DBHostConnector) NewIntentHost(spawnOptions cloud.SpawnOptions, userData string) (*host.Host, error) {
 	spawnOptions.UserName = spawnOptions.Owner.Username()
 
+	// Get key value if PublicKey is a name
 	keyVal, err := spawnOptions.Owner.GetPublicKey(spawnOptions.PublicKey)
 	if err != nil {
 		keyVal = spawnOptions.PublicKey
@@ -69,6 +70,8 @@ func (hc *DBHostConnector) NewIntentHost(spawnOptions cloud.SpawnOptions, userDa
 	if keyVal == "" {
 		return nil, errors.New("invalid key")
 	}
+	spawnOptions.PublicKey = keyVal
+
 	var providerSettings *map[string]interface{}
 	if userData != "" {
 		var d distro.Distro
@@ -90,7 +93,6 @@ func (hc *DBHostConnector) NewIntentHost(spawnOptions cloud.SpawnOptions, userDa
 	if err := intentHost.Insert(); err != nil {
 		return nil, err
 	}
-
 	return intentHost, nil
 }
 
@@ -116,7 +118,7 @@ func (hc *DBHostConnector) CheckHostSecret(r *http.Request) (int, error) {
 }
 
 // MockHostConnector is a struct that implements the Host related methods
-// from the Connector through interactions with he backing database.
+// from the Connector through interactions with the backing database.
 type MockHostConnector struct {
 	CachedHosts []host.Host
 }

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -90,6 +90,7 @@ func (hc *DBHostConnector) NewIntentHost(options *restmodel.HostRequestOptions, 
 		PublicKey:        keyVal,
 		TaskId:           options.TaskID,
 		Owner:            user,
+		InstanceTags:     options.InstanceTags,
 	}
 
 	intentHost, err := cloud.CreateSpawnHost(spawnOptions)
@@ -209,6 +210,7 @@ func (hc *MockHostConnector) NewIntentHost(options *restmodel.HostRequestOptions
 		PublicKey:        keyVal,
 		TaskId:           options.TaskID,
 		Owner:            user,
+		InstanceTags:     options.InstanceTags,
 	}
 
 	intentHost, err := cloud.CreateSpawnHost(spawnOptions)

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -61,7 +61,7 @@ func (dbc *DBConnector) FindHostByIdWithOwner(hostID string, user gimlet.User) (
 
 // NewIntentHost is a method to insert an intent host given a distro and a public key
 // The public key can be the name of a saved key or the actual key string
-func (hc *DBHostConnector) NewIntentHost(options *restmodel.HostPostRequest, user *user.DBUser) (*host.Host, error) {
+func (hc *DBHostConnector) NewIntentHost(options *restmodel.HostRequestOptions, user *user.DBUser) (*host.Host, error) {
 
 	// Get key value if PublicKey is a name
 	keyVal, err := user.GetPublicKey(options.KeyName)
@@ -199,7 +199,7 @@ func (hc *MockHostConnector) FindHostById(id string) (*host.Host, error) {
 
 // NewIntentHost is a method to mock "insert" an intent host given a distro and a public key
 // The public key can be the name of a saved key or the actual key string
-func (hc *MockHostConnector) NewIntentHost(options *restmodel.HostPostRequest, user *user.DBUser) (*host.Host, error) {
+func (hc *MockHostConnector) NewIntentHost(options *restmodel.HostRequestOptions, user *user.DBUser) (*host.Host, error) {
 	keyVal := strings.Join([]string{"ssh-rsa", base64.StdEncoding.EncodeToString([]byte("foo"))}, " ")
 
 	spawnOptions := cloud.SpawnOptions{

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -60,7 +60,7 @@ func (dbc *DBConnector) FindHostByIdWithOwner(hostID string, user gimlet.User) (
 
 // NewIntentHost is a method to insert an intent host given a distro and a public key
 // The public key can be the name of a saved key or the actual key string
-func (hc *DBHostConnector) NewIntentHost(distroID, keyNameOrVal, taskID, userData string, user *user.DBUser) (*host.Host, error) {
+func (hc *DBHostConnector) NewIntentHost(distroID, keyNameOrVal, taskID, userData string, instanceTags map[string]string, user *user.DBUser) (*host.Host, error) {
 	keyVal, err := user.GetPublicKey(keyNameOrVal)
 	if err != nil {
 		keyVal = keyNameOrVal
@@ -86,6 +86,7 @@ func (hc *DBHostConnector) NewIntentHost(distroID, keyNameOrVal, taskID, userDat
 		PublicKey:        keyVal,
 		TaskId:           taskID,
 		Owner:            user,
+		InstanceTags:     instanceTags,
 	}
 
 	intentHost, err := cloud.CreateSpawnHost(spawnOptions)
@@ -196,7 +197,7 @@ func (hc *MockHostConnector) FindHostById(id string) (*host.Host, error) {
 
 // NewIntentHost is a method to mock "insert" an intent host given a distro and a public key
 // The public key can be the name of a saved key or the actual key string
-func (hc *MockHostConnector) NewIntentHost(distroID, keyNameOrVal, taskID, userData string, user *user.DBUser) (*host.Host, error) {
+func (hc *MockHostConnector) NewIntentHost(distroID, keyNameOrVal, taskID, userData string, tags map[string]string, user *user.DBUser) (*host.Host, error) {
 	keyVal := strings.Join([]string{"ssh-rsa", base64.StdEncoding.EncodeToString([]byte("foo"))}, " ")
 
 	spawnOptions := cloud.SpawnOptions{
@@ -206,6 +207,7 @@ func (hc *MockHostConnector) NewIntentHost(distroID, keyNameOrVal, taskID, userD
 		PublicKey:        keyVal,
 		TaskId:           taskID,
 		Owner:            user,
+		InstanceTags:     tags,
 	}
 
 	intentHost, err := cloud.CreateSpawnHost(spawnOptions)

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/cloud"
-
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -207,7 +207,7 @@ func (s *HostConnectorSuite) TestSpawnHost() {
 	})
 	s.NoError(testUser.Insert())
 
-	options := &restmodel.HostPostRequest{
+	options := &restmodel.HostRequestOptions{
 		DistroID:     testDistroID,
 		TaskID:       "",
 		KeyName:      testPublicKeyName,

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
+	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/stretchr/testify/suite"
 )
@@ -207,14 +207,15 @@ func (s *HostConnectorSuite) TestSpawnHost() {
 	})
 	s.NoError(testUser.Insert())
 
-	spawnOptions := cloud.SpawnOptions{
-		DistroId:     testDistroID,
-		PublicKey:    testPublicKeyName,
-		TaskId:       "",
+	options := &restmodel.HostPostRequest{
+		DistroID:     testDistroID,
+		TaskID:       "",
+		KeyName:      testPublicKeyName,
+		UserData:     "",
 		InstanceTags: nil,
-		Owner:        testUser,
 	}
-	intentHost, err := (&DBHostConnector{}).NewIntentHost(spawnOptions, "")
+
+	intentHost, err := (&DBHostConnector{}).NewIntentHost(options, testUser)
 	s.NotNil(intentHost)
 	s.NoError(err)
 	foundHost, err := host.FindOne(host.ById(intentHost.Id))

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -206,7 +206,7 @@ func (s *HostConnectorSuite) TestSpawnHost() {
 	})
 	s.NoError(testUser.Insert())
 
-	intentHost, err := (&DBHostConnector{}).NewIntentHost(testDistroID, testPublicKeyName, "", "", testUser)
+	intentHost, err := (&DBHostConnector{}).NewIntentHost(testDistroID, testPublicKeyName, "", "", nil, testUser)
 	s.NotNil(intentHost)
 	s.NoError(err)
 	foundHost, err := host.FindOne(host.ById(intentHost.Id))

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/cloud"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
@@ -206,7 +208,14 @@ func (s *HostConnectorSuite) TestSpawnHost() {
 	})
 	s.NoError(testUser.Insert())
 
-	intentHost, err := (&DBHostConnector{}).NewIntentHost(testDistroID, testPublicKeyName, "", "", nil, testUser)
+	spawnOptions := cloud.SpawnOptions{
+		DistroId:     testDistroID,
+		PublicKey:    testPublicKeyName,
+		TaskId:       "",
+		InstanceTags: nil,
+		Owner:        testUser,
+	}
+	intentHost, err := (&DBHostConnector{}).NewIntentHost(spawnOptions, "")
 	s.NotNil(intentHost)
 	s.NoError(err)
 	foundHost, err := host.FindOne(host.ById(intentHost.Id))

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -136,7 +136,7 @@ type Connector interface {
 	FindHostByIdWithOwner(string, gimlet.User) (*host.Host, error)
 
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
-	NewIntentHost(string, string, string, string, *user.DBUser) (*host.Host, error)
+	NewIntentHost(string, string, string, string, map[string]string, *user.DBUser) (*host.Host, error)
 
 	// FetchContext is a method to fetch a context given a series of identifiers.
 	FetchContext(string, string, string, string, string) (model.Context, error)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -136,7 +136,7 @@ type Connector interface {
 	FindHostByIdWithOwner(string, gimlet.User) (*host.Host, error)
 
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
-	NewIntentHost(cloud.SpawnOptions, string) (*host.Host, error)
+	NewIntentHost(*restModel.HostPostRequest, *user.DBUser) (*host.Host, error)
 
 	// FetchContext is a method to fetch a context given a series of identifiers.
 	FetchContext(string, string, string, string, string) (model.Context, error)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -136,7 +136,7 @@ type Connector interface {
 	FindHostByIdWithOwner(string, gimlet.User) (*host.Host, error)
 
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
-	NewIntentHost(string, string, string, string, map[string]string, *user.DBUser) (*host.Host, error)
+	NewIntentHost(cloud.SpawnOptions, string) (*host.Host, error)
 
 	// FetchContext is a method to fetch a context given a series of identifiers.
 	FetchContext(string, string, string, string, string) (model.Context, error)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -136,7 +136,7 @@ type Connector interface {
 	FindHostByIdWithOwner(string, gimlet.User) (*host.Host, error)
 
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
-	NewIntentHost(*restModel.HostPostRequest, *user.DBUser) (*host.Host, error)
+	NewIntentHost(*restModel.HostRequestOptions, *user.DBUser) (*host.Host, error)
 
 	// FetchContext is a method to fetch a context given a series of identifiers.
 	FetchContext(string, string, string, string, string) (model.Context, error)

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -22,7 +22,7 @@ type APIHost struct {
 }
 
 // HostPostRequest is a struct that holds the format of a POST request to /hosts
-type HostPostRequest struct {
+type HostRequestOptions struct {
 	DistroID     string            `json:"distro"`
 	TaskID       string            `json:"task"`
 	KeyName      string            `json:"keyname"`

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -8,16 +8,17 @@ import (
 
 // APIHost is the model to be returned by the API whenever hosts are fetched.
 type APIHost struct {
-	Id          APIString  `json:"host_id"`
-	HostURL     APIString  `json:"host_url"`
-	Distro      DistroInfo `json:"distro"`
-	Provisioned bool       `json:"provisioned"`
-	StartedBy   APIString  `json:"started_by"`
-	Type        APIString  `json:"host_type"`
-	User        APIString  `json:"user"`
-	Status      APIString  `json:"status"`
-	RunningTask taskInfo   `json:"running_task"`
-	UserHost    bool       `json:"user_host"`
+	Id           APIString         `json:"host_id"`
+	HostURL      APIString         `json:"host_url"`
+	Distro       DistroInfo        `json:"distro"`
+	Provisioned  bool              `json:"provisioned"`
+	StartedBy    APIString         `json:"started_by"`
+	Type         APIString         `json:"host_type"`
+	User         APIString         `json:"user"`
+	Status       APIString         `json:"status"`
+	RunningTask  taskInfo          `json:"running_task"`
+	UserHost     bool              `json:"user_host"`
+	InstanceTags map[string]string `json:"instance_tags"`
 }
 
 // HostPostRequest is a struct that holds the format of a POST request to /hosts
@@ -25,7 +26,7 @@ type HostPostRequest struct {
 	DistroID     string            `json:"distro"`
 	KeyName      string            `json:"keyname"`
 	UserData     string            `json:"userdata"`
-	InstanceTags map[string]string `json:"instancetags"`
+	InstanceTags map[string]string `json:"instance_tags"`
 }
 
 type DistroInfo struct {
@@ -88,6 +89,7 @@ func (apiHost *APIHost) buildFromHostStruct(h interface{}) error {
 	apiHost.User = ToAPIString(v.User)
 	apiHost.Status = ToAPIString(v.Status)
 	apiHost.UserHost = v.UserHost
+	apiHost.InstanceTags = v.InstanceTags
 
 	imageId, err := v.Distro.GetImageID()
 	if err != nil {

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -22,9 +22,10 @@ type APIHost struct {
 
 // HostPostRequest is a struct that holds the format of a POST request to /hosts
 type HostPostRequest struct {
-	DistroID string `json:"distro"`
-	KeyName  string `json:"keyname"`
-	UserData string `json:"userdata"`
+	DistroID     string            `json:"distro"`
+	KeyName      string            `json:"keyname"`
+	UserData     string            `json:"userdata"`
+	InstanceTags map[string]string `json:"instancetags`
 }
 
 type DistroInfo struct {

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -25,7 +25,7 @@ type HostPostRequest struct {
 	DistroID     string            `json:"distro"`
 	KeyName      string            `json:"keyname"`
 	UserData     string            `json:"userdata"`
-	InstanceTags map[string]string `json:"instancetags`
+	InstanceTags map[string]string `json:"instancetags"`
 }
 
 type DistroInfo struct {

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -24,6 +24,7 @@ type APIHost struct {
 // HostPostRequest is a struct that holds the format of a POST request to /hosts
 type HostPostRequest struct {
 	DistroID     string            `json:"distro"`
+	TaskID       string            `json:"task"`
 	KeyName      string            `json:"keyname"`
 	UserData     string            `json:"userdata"`
 	InstanceTags map[string]string `json:"instance_tags"`

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -28,7 +28,7 @@ type hostPostHandler struct {
 	Distro       string            `json:"distro"`
 	KeyName      string            `json:"keyname"`
 	UserData     string            `json:"userdata"`
-	InstanceTags map[string]string `json:"instancetags"`
+	InstanceTags map[string]string `json:"instance_tags"`
 
 	sc data.Connector
 }
@@ -46,7 +46,15 @@ func (hph *hostPostHandler) Parse(ctx context.Context, r *http.Request) error {
 func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
 
-	intentHost, err := hph.sc.NewIntentHost(hph.Distro, hph.KeyName, hph.Task, hph.UserData, hph.InstanceTags, user)
+	options := cloud.SpawnOptions{
+		DistroId:     hph.Distro,
+		PublicKey:    hph.KeyName,
+		TaskId:       hph.Task,
+		Owner:        user,
+		InstanceTags: hph.InstanceTags,
+	}
+
+	intentHost, err := hph.sc.NewIntentHost(options, hph.UserData)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "error spawning host"))
 	}

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -46,7 +46,7 @@ func (hph *hostPostHandler) Parse(ctx context.Context, r *http.Request) error {
 func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
 
-	options := &model.HostPostRequest{
+	options := &model.HostRequestOptions{
 		DistroID:     hph.Distro,
 		TaskID:       hph.Task,
 		KeyName:      hph.KeyName,

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -46,15 +46,15 @@ func (hph *hostPostHandler) Parse(ctx context.Context, r *http.Request) error {
 func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
 
-	options := cloud.SpawnOptions{
-		DistroId:     hph.Distro,
-		PublicKey:    hph.KeyName,
-		TaskId:       hph.Task,
-		Owner:        user,
+	options := &model.HostPostRequest{
+		DistroID:     hph.Distro,
+		TaskID:       hph.Task,
+		KeyName:      hph.KeyName,
+		UserData:     hph.UserData,
 		InstanceTags: hph.InstanceTags,
 	}
 
-	intentHost, err := hph.sc.NewIntentHost(options, hph.UserData)
+	intentHost, err := hph.sc.NewIntentHost(options, user)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "error spawning host"))
 	}

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -24,10 +24,11 @@ func makeSpawnHostCreateRoute(sc data.Connector) gimlet.RouteHandler {
 }
 
 type hostPostHandler struct {
-	Task     string `json:"task_id"`
-	Distro   string `json:"distro"`
-	KeyName  string `json:"keyname"`
-	UserData string `json:"userdata"`
+	Task         string            `json:"task_id"`
+	Distro       string            `json:"distro"`
+	KeyName      string            `json:"keyname"`
+	UserData     string            `json:"userdata"`
+	InstanceTags map[string]string `json:"instancetags"`
 
 	sc data.Connector
 }
@@ -45,7 +46,7 @@ func (hph *hostPostHandler) Parse(ctx context.Context, r *http.Request) error {
 func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
 
-	intentHost, err := hph.sc.NewIntentHost(hph.Distro, hph.KeyName, hph.Task, hph.UserData, user)
+	intentHost, err := hph.sc.NewIntentHost(hph.Distro, hph.KeyName, hph.Task, hph.UserData, hph.InstanceTags, user)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "error spawning host"))
 	}

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -64,5 +64,4 @@ func TestHostPostHandler(t *testing.T) {
 
 	h2 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[2]
 	assert.Equal(map[string]string{"key": "value"}, h2.InstanceTags)
-
 }

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -44,9 +44,25 @@ func TestHostPostHandler(t *testing.T) {
 	assert.NotNil(resp)
 	assert.Equal(http.StatusOK, resp.Status())
 
-	assert.Len(h.sc.(*data.MockConnector).MockHostConnector.CachedHosts, 2)
-	d0 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[0].Distro
+	h.InstanceTags = map[string]string{
+		"key": "value",
+	}
+	resp = h.Run(ctx)
+	assert.NotNil(resp)
+	assert.Equal(http.StatusOK, resp.Status())
+
+	assert.Len(h.sc.(*data.MockConnector).MockHostConnector.CachedHosts, 3)
+	h0 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[0]
+	d0 := h0.Distro
 	assert.Empty((*d0.ProviderSettings)["user_data"])
-	d1 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[1].Distro
+	assert.Empty(h0.InstanceTags)
+
+	h1 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[1]
+	d1 := h1.Distro
 	assert.Equal("my script", (*d1.ProviderSettings)["user_data"].(string))
+	assert.Empty(h1.InstanceTags)
+
+	h2 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[2]
+	assert.Equal(map[string]string{"key": "value"}, h2.InstanceTags)
+
 }

--- a/service/api_spawn.go
+++ b/service/api_spawn.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
@@ -60,14 +61,14 @@ func (as *APIServer) requestHost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hc := &data.DBHostConnector{}
-	spawnOptions := cloud.SpawnOptions{
-		DistroId:     hostRequest.Distro,
-		PublicKey:    hostRequest.PublicKey,
-		TaskId:       "",
-		Owner:        user,
+	options := &model.HostPostRequest{
+		DistroID:     hostRequest.Distro,
+		KeyName:      hostRequest.PublicKey,
+		TaskID:       "",
+		UserData:     "",
 		InstanceTags: nil,
 	}
-	spawnHost, err := hc.NewIntentHost(spawnOptions, "")
+	spawnHost, err := hc.NewIntentHost(options, user)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/service/api_spawn.go
+++ b/service/api_spawn.go
@@ -60,7 +60,14 @@ func (as *APIServer) requestHost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hc := &data.DBHostConnector{}
-	spawnHost, err := hc.NewIntentHost(hostRequest.Distro, hostRequest.PublicKey, "", "", nil, user)
+	spawnOptions := cloud.SpawnOptions{
+		DistroId:     hostRequest.Distro,
+		PublicKey:    hostRequest.PublicKey,
+		TaskId:       "",
+		Owner:        user,
+		InstanceTags: nil,
+	}
+	spawnHost, err := hc.NewIntentHost(spawnOptions, "")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/service/api_spawn.go
+++ b/service/api_spawn.go
@@ -61,7 +61,7 @@ func (as *APIServer) requestHost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hc := &data.DBHostConnector{}
-	options := &model.HostPostRequest{
+	options := &model.HostRequestOptions{
 		DistroID:     hostRequest.Distro,
 		KeyName:      hostRequest.PublicKey,
 		TaskID:       "",

--- a/service/api_spawn.go
+++ b/service/api_spawn.go
@@ -60,7 +60,7 @@ func (as *APIServer) requestHost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hc := &data.DBHostConnector{}
-	spawnHost, err := hc.NewIntentHost(hostRequest.Distro, hostRequest.PublicKey, "", "", user)
+	spawnHost, err := hc.NewIntentHost(hostRequest.Distro, hostRequest.PublicKey, "", "", nil, user)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -108,7 +108,7 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 		SaveKey       bool              `json:"save_key"`
 		UserData      string            `json:"userdata"`
 		UseTaskConfig bool              `json:"use_task_config"`
-		InstanceTags  map[string]string `json:"instancetags"`
+		InstanceTags  map[string]string `json:"instance_tags"`
 	}{}
 
 	err := util.ReadJSONInto(util.NewRequestReader(r), &putParams)
@@ -126,7 +126,14 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 		PushFlash(uis.CookieStore, r, w, NewSuccessFlash("Public key successfully saved."))
 	}
 	hc := &data.DBConnector{}
-	spawnHost, err := hc.NewIntentHost(putParams.Distro, putParams.PublicKey, putParams.Task, putParams.UserData, putParams.InstanceTags, authedUser)
+	spawnOptions := cloud.SpawnOptions{
+		DistroId:     putParams.Distro,
+		PublicKey:    putParams.PublicKey,
+		TaskId:       putParams.Task,
+		Owner:        authedUser,
+		InstanceTags: nil,
+	}
+	spawnHost, err := hc.NewIntentHost(spawnOptions, putParams.UserData)
 
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Error spawning host"))

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -126,7 +126,7 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 		PushFlash(uis.CookieStore, r, w, NewSuccessFlash("Public key successfully saved."))
 	}
 	hc := &data.DBConnector{}
-	options := &restModel.HostPostRequest{
+	options := &restModel.HostRequestOptions{
 		DistroID:     putParams.Distro,
 		KeyName:      putParams.PublicKey,
 		TaskID:       putParams.Task,

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -101,13 +101,14 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 	authedUser := MustHaveUser(r)
 
 	putParams := struct {
-		Task          string `json:"task_id"`
-		Distro        string `json:"distro"`
-		KeyName       string `json:"key_name"`
-		PublicKey     string `json:"public_key"`
-		SaveKey       bool   `json:"save_key"`
-		UserData      string `json:"userdata"`
-		UseTaskConfig bool   `json:"use_task_config"`
+		Task          string            `json:"task_id"`
+		Distro        string            `json:"distro"`
+		KeyName       string            `json:"key_name"`
+		PublicKey     string            `json:"public_key"`
+		SaveKey       bool              `json:"save_key"`
+		UserData      string            `json:"userdata"`
+		UseTaskConfig bool              `json:"use_task_config"`
+		InstanceTags  map[string]string `json:"instancetags"`
 	}{}
 
 	err := util.ReadJSONInto(util.NewRequestReader(r), &putParams)
@@ -125,7 +126,7 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 		PushFlash(uis.CookieStore, r, w, NewSuccessFlash("Public key successfully saved."))
 	}
 	hc := &data.DBConnector{}
-	spawnHost, err := hc.NewIntentHost(putParams.Distro, putParams.PublicKey, putParams.Task, putParams.UserData, authedUser)
+	spawnHost, err := hc.NewIntentHost(putParams.Distro, putParams.PublicKey, putParams.Task, putParams.UserData, putParams.InstanceTags, authedUser)
 
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Error spawning host"))

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -126,14 +126,14 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 		PushFlash(uis.CookieStore, r, w, NewSuccessFlash("Public key successfully saved."))
 	}
 	hc := &data.DBConnector{}
-	spawnOptions := cloud.SpawnOptions{
-		DistroId:     putParams.Distro,
-		PublicKey:    putParams.PublicKey,
-		TaskId:       putParams.Task,
-		Owner:        authedUser,
-		InstanceTags: nil,
+	options := &restModel.HostPostRequest{
+		DistroID:     putParams.Distro,
+		KeyName:      putParams.PublicKey,
+		TaskID:       putParams.Task,
+		UserData:     putParams.UserData,
+		InstanceTags: putParams.InstanceTags,
 	}
-	spawnHost, err := hc.NewIntentHost(spawnOptions, putParams.UserData)
+	spawnHost, err := hc.NewIntentHost(options, authedUser)
 
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Error spawning host"))


### PR DESCRIPTION
Made changes that allow users to add for AWS instances from the commandline using the following syntax:

evergreen host create -t key1=value1 -t key2=value2 [arguments...]

The are then stored in a map[string]string in a new InstanceTags field in the host document. I changed the makeTags(host) function in ec2_util.go to add these tags to the AWSClient.

Would appreciate feedback on how I could test my changes behind putting this in staging and seeing if tags entered through the commandline end up in host documents.