### PR TITLE
EVG-6517 Noop earlier for generate.tasks

### DIFF
--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -78,7 +78,7 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 			attemptStart := time.Now()
 			attempt++
 
-			t, err := task.FindOneId(g.TaskID)
+			t, err := task.FindOneId(j.TaskID)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
We should noop as early as possible in the retry loop for generate.tasks.
Currently we noop late enough that an amboy multiple-execution bug can cause one
of the jobs to error, causing tasks to turn purple.