### PR TITLE
EVG-6641 store untranslated projects for versions/patches

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -108,24 +108,25 @@ func IncludePatchDependencies(project *Project, tvpairs []TVPair) []TVPair {
 }
 
 // GetPatchedProject creates and validates a project created by fetching latest commit information from GitHub
-// and applying the patch to the latest remote configuration. The error returned can be a validation error.
-func GetPatchedProject(ctx context.Context, p *patch.Patch, githubOauthToken string) (*Project, error) {
+// and applying the patch to the latest remote configuration. Also returns the condensed yaml string for storage.
+// The error returned can be a validation error.
+func GetPatchedProject(ctx context.Context, p *patch.Patch, githubOauthToken string) (*Project, string, error) {
 	if p.Version != "" {
-		return nil, errors.Errorf("Patch %v already finalized", p.Version)
+		return nil, "", errors.Errorf("Patch %v already finalized", p.Version)
 	}
 
 	projectRef, err := FindOneProjectRef(p.Project)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, "", errors.WithStack(err)
 	}
 
 	project := &Project{}
 	// if the patched config exists, use that as the project file bytes.
 	if p.PatchedConfig != "" {
 		if err = LoadProjectInto([]byte(p.PatchedConfig), projectRef.Identifier, project); err != nil {
-			return nil, errors.WithStack(err)
+			return nil, "", errors.WithStack(err)
 		}
-		return project, nil
+		return project, p.PatchedConfig, nil
 	}
 
 	var cancel context.CancelFunc
@@ -150,14 +151,14 @@ func GetPatchedProject(ctx context.Context, p *patch.Patch, githubOauthToken str
 		// we try to apply the diff and proceed.
 		if !(p.ConfigChanged(projectRef.RemotePath) && thirdparty.IsFileNotFound(err)) {
 			// return an error if the github error is network/auth-related or we aren't patching the config
-			return nil, errors.Wrapf(err, "Could not get github file at '%s/%s'@%s: %s", projectRef.Owner,
+			return nil, "", errors.Wrapf(err, "Could not get github file at '%s/%s'@%s: %s", projectRef.Owner,
 				projectRef.Repo, projectRef.RemotePath, hash)
 		}
 	} else {
 		// we successfully got the project file in base64, so we decode it
 		projectFileBytes, err = base64.StdEncoding.DecodeString(*githubFile.Content)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Could not decode github file at '%s/%s'@%s: %s", projectRef.Owner,
+			return nil, "", errors.Wrapf(err, "Could not decode github file at '%s/%s'@%s: %s", projectRef.Owner,
 				projectRef.Repo, projectRef.RemotePath, hash)
 		}
 	}
@@ -166,15 +167,15 @@ func GetPatchedProject(ctx context.Context, p *patch.Patch, githubOauthToken str
 	if !(p.IsGithubPRPatch() || p.IsPRMergePatch()) && p.ConfigChanged(projectRef.RemotePath) {
 		projectFileBytes, err = MakePatchedConfig(ctx, env, p, projectRef.RemotePath, string(projectFileBytes))
 		if err != nil {
-			return nil, errors.Wrapf(err, "Could not patch remote configuration file")
+			return nil, "", errors.Wrapf(err, "Could not patch remote configuration file")
 		}
 	}
 
 	if err := LoadProjectInto(projectFileBytes, projectRef.Identifier, project); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, "", errors.WithStack(err)
 	}
 
-	return project, nil
+	return project, string(projectFileBytes), nil
 }
 
 // MakePatchedConfig takes in the path to a remote configuration a stringified version

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -26,7 +26,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	mgobson "gopkg.in/mgo.v2/bson"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -167,8 +166,9 @@ func TestGetPatchedProject(t *testing.T) {
 				configPatch := resetPatchSetup(t, configFilePath)
 				token, err := patchTestConfig.GetGithubOauthToken()
 				So(err, ShouldBeNil)
-				project, err := GetPatchedProject(ctx, configPatch, token)
+				project, projectYaml, err := GetPatchedProject(ctx, configPatch, token)
 				So(err, ShouldBeNil)
+				So(projectYaml, ShouldNotBeEmpty)
 				So(project, ShouldNotBeNil)
 			})
 
@@ -176,8 +176,9 @@ func TestGetPatchedProject(t *testing.T) {
 				configPatch := resetProjectlessPatchSetup(t)
 				token, err := patchTestConfig.GetGithubOauthToken()
 				So(err, ShouldBeNil)
-				project, err := GetPatchedProject(ctx, configPatch, token)
+				project, projectYaml, err := GetPatchedProject(ctx, configPatch, token)
 				So(err, ShouldBeNil)
+				So(projectYaml, ShouldNotBeEmpty)
 				So(project, ShouldNotBeNil)
 			})
 
@@ -191,8 +192,9 @@ func TestGetPatchedProject(t *testing.T) {
 
 				token, err := patchTestConfig.GetGithubOauthToken()
 				So(err, ShouldBeNil)
-				project, err := GetPatchedProject(ctx, configPatch, token)
+				project, projectYaml, err := GetPatchedProject(ctx, configPatch, token)
 				So(err, ShouldBeNil)
+				So(projectYaml, ShouldNotBeEmpty)
 				So(project, ShouldNotBeNil)
 			})
 
@@ -215,11 +217,10 @@ func TestFinalizePatch(t *testing.T) {
 			Convey("a patched config should drive version creation", func() {
 				token, err := patchTestConfig.GetGithubOauthToken()
 				So(err, ShouldBeNil)
-				project, err := GetPatchedProject(ctx, configPatch, token)
+				project, projectYaml, err := GetPatchedProject(ctx, configPatch, token)
 				So(err, ShouldBeNil)
-				yamlBytes, err := yaml.Marshal(project)
-				So(err, ShouldBeNil)
-				configPatch.PatchedConfig = string(yamlBytes)
+				So(project, ShouldNotBeNil)
+				configPatch.PatchedConfig = projectYaml
 				token, err = patchTestConfig.GetGithubOauthToken()
 				So(err, ShouldBeNil)
 				version, err := FinalizePatch(ctx, configPatch, evergreen.PatchVersionRequester, token)
@@ -241,11 +242,10 @@ func TestFinalizePatch(t *testing.T) {
 				configPatch := resetPatchSetup(t, patchedConfigFile)
 				token, err := patchTestConfig.GetGithubOauthToken()
 				So(err, ShouldBeNil)
-				project, err := GetPatchedProject(ctx, configPatch, token)
+				project, projectYaml, err := GetPatchedProject(ctx, configPatch, token)
+				So(project, ShouldNotBeNil)
 				So(err, ShouldBeNil)
-				yamlBytes, err := yaml.Marshal(project)
-				So(err, ShouldBeNil)
-				configPatch.PatchedConfig = string(yamlBytes)
+				configPatch.PatchedConfig = projectYaml
 				token, err = patchTestConfig.GetGithubOauthToken()
 				So(err, ShouldBeNil)
 				version, err := FinalizePatch(ctx, configPatch, evergreen.PatchVersionRequester, token)

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -488,15 +488,19 @@ func translateProject(pp *parserProject) (*Project, []error) {
 	tgse := newTaskGroupSelectorEvaluator(pp.TaskGroups)
 	ase := NewAxisSelectorEvaluator(pp.Axes)
 	regularBVs, matrices := sieveMatrixVariants(pp.BuildVariants)
+
 	var evalErrs, errs []error
 	matrixVariants, errs := buildMatrixVariants(pp.Axes, ase, matrices)
 	evalErrs = append(evalErrs, errs...)
-	pp.BuildVariants = append(regularBVs, matrixVariants...)
-	vse := NewVariantSelectorEvaluator(pp.BuildVariants, ase)
+	buildVariants := append(regularBVs, matrixVariants...)
+	vse := NewVariantSelectorEvaluator(buildVariants, ase)
+
 	proj.Tasks, proj.TaskGroups, errs = evaluateTaskUnits(tse, tgse, vse, pp.Tasks, pp.TaskGroups)
 	evalErrs = append(evalErrs, errs...)
-	proj.BuildVariants, errs = evaluateBuildVariants(tse, tgse, vse, pp.BuildVariants, pp.Tasks, proj.TaskGroups)
+
+	proj.BuildVariants, errs = evaluateBuildVariants(tse, tgse, vse, buildVariants, pp.Tasks, proj.TaskGroups)
 	evalErrs = append(evalErrs, errs...)
+
 	return proj, evalErrs
 }
 
@@ -589,6 +593,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			Tags:        pbv.Tags,
 		}
 		bv.Tasks, errs = evaluateBVTasks(tse, tgse, vse, pbv)
+
 		// evaluate any rules passed in during matrix construction
 		for _, r := range pbv.matrixRules {
 			// remove_tasks removes all tasks with matching names
@@ -610,6 +615,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 				}
 				bv.Tasks = prunedTasks
 			}
+
 			// add_tasks adds the given BuildVariantTasks, returning errors for any collisions
 			if len(r.AddTasks) > 0 {
 				// cache existing tasks so we can check for duplicates
@@ -619,6 +625,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 				}
 
 				var added []BuildVariantTaskUnit
+				// TODO: this might also be a mistake but unsure how to duplicate
 				pbv.Tasks = r.AddTasks
 				added, errs = evaluateBVTasks(tse, tgse, vse, pbv)
 				evalErrs = append(evalErrs, errs...)
@@ -637,23 +644,11 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			}
 		}
 
-		//resolve tags for display tasks
 		tgMap := map[string]TaskGroup{}
 		for _, tg := range tgs {
 			tgMap[tg.Name] = tg
 		}
 		dtse := newDisplayTaskSelectorEvaluator(bv, tasks, tgs, tgMap)
-		for i, dt := range pbv.DisplayTasks {
-			tasks := []string{}
-			for _, et := range dt.ExecutionTasks {
-				results, err := dtse.evalSelector(ParseSelector(et))
-				if err != nil {
-					errs = append(errs, err)
-				}
-				tasks = append(tasks, results...)
-			}
-			pbv.DisplayTasks[i].ExecutionTasks = tasks
-		}
 
 		// check that display tasks contain real tasks that are not duplicated
 		bvTasks := make(map[string]struct{})        // map of all execution tasks
@@ -667,13 +662,26 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 				bvTasks[t.Name] = struct{}{}
 			}
 		}
+
+		// save display task if it contains valid execution tasks
 		for _, dt := range pbv.DisplayTasks {
 			projectDt := DisplayTask{Name: dt.Name}
 			if _, exists := bvTasks[dt.Name]; exists {
 				errs = append(errs, fmt.Errorf("display task %s cannot have the same name as an execution task", dt.Name))
 				continue
 			}
+
+			//resolve tags for display tasks
+			tasks := []string{}
 			for _, et := range dt.ExecutionTasks {
+				results, err := dtse.evalSelector(ParseSelector(et))
+				if err != nil {
+					errs = append(errs, err)
+				}
+				tasks = append(tasks, results...)
+			}
+
+			for _, et := range tasks {
 				if _, exists := bvTasks[et]; !exists {
 					errs = append(errs, fmt.Errorf("display task %s contains execution task %s which does not exist in build variant", dt.Name, et))
 				} else {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -625,7 +625,6 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 				}
 
 				var added []BuildVariantTaskUnit
-				// TODO: this might also be a mistake but unsure how to duplicate
 				pbv.Tasks = r.AddTasks
 				added, errs = evaluateBVTasks(tse, tgse, vse, pbv)
 				evalErrs = append(evalErrs, errs...)

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 
@@ -789,6 +791,64 @@ tasks:
 	assert.NotNil(proj)
 	assert.Len(errs, 0)
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 2)
+	assert.Len(proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks, 2)
+	assert.Len(proj.BuildVariants[0].DisplayTasks[1].ExecutionTasks, 2)
+	assert.Equal("execTask1", proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks[0])
+	assert.Equal("execTask3", proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks[1])
+	assert.Equal("execTask2", proj.BuildVariants[0].DisplayTasks[1].ExecutionTasks[0])
+	assert.Equal("execTask4", proj.BuildVariants[0].DisplayTasks[1].ExecutionTasks[1])
+}
+
+func TestTranslateProjectDoesNotModifyParserProject(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// build variant display tasks
+	tagYml := `
+buildvariants:
+- name: "bv1"
+  tasks:
+  - name: execTask1
+  - name: execTask2
+  - name: execTask3
+  - name: execTask4
+  display_tasks:
+  - name: displayTaskOdd
+    execution_tasks:
+    - ".odd"
+  - name: displayTaskEven
+    execution_tasks:
+    - ".even"
+tasks:
+- name: execTask1
+  tags: [ "odd" ]
+- name: execTask2
+  tags: [ "even" ]
+- name: execTask3
+  tags: [ "odd" ]
+- name: execTask4
+  tags: [ "even" ]
+`
+	pp, errs := createIntermediateProject([]byte(tagYml))
+	assert.NotNil(pp)
+	assert.Len(errs, 0)
+	require.Len(pp.BuildVariants[0].DisplayTasks, 2)
+	assert.Len(pp.BuildVariants[0].DisplayTasks[0].ExecutionTasks, 1)
+	assert.Equal(".odd", pp.BuildVariants[0].DisplayTasks[0].ExecutionTasks[0])
+	assert.Len(pp.BuildVariants[0].DisplayTasks[1].ExecutionTasks, 1)
+	assert.Equal(".even", pp.BuildVariants[0].DisplayTasks[1].ExecutionTasks[0])
+
+	proj, errs := translateProject(pp)
+	assert.NotNil(proj)
+	assert.Len(errs, 0)
+	// assert parser project hasn't changed
+	require.Len(pp.BuildVariants[0].DisplayTasks, 2)
+	assert.Len(pp.BuildVariants[0].DisplayTasks[0].ExecutionTasks, 1)
+	assert.Equal(".odd", pp.BuildVariants[0].DisplayTasks[0].ExecutionTasks[0])
+	assert.Len(pp.BuildVariants[0].DisplayTasks[1].ExecutionTasks, 1)
+	assert.Equal(".even", pp.BuildVariants[0].DisplayTasks[1].ExecutionTasks[0])
+
+	//assert project is correct
+	require.Len(proj.BuildVariants[0].DisplayTasks, 2)
 	assert.Len(proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks, 2)
 	assert.Len(proj.BuildVariants[0].DisplayTasks[1].ExecutionTasks, 2)
 	assert.Equal("execTask1", proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks[0])

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -18,7 +18,6 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
 	mgobson "gopkg.in/mgo.v2/bson"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const formMimeType = "application/x-www-form-urlencoded"
@@ -324,20 +323,13 @@ func (as *APIServer) existingPatchRequest(w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		var project *model.Project
-		project, err = model.GetPatchedProject(ctx, p, githubOauthToken)
+		_, projectYaml, err := model.GetPatchedProject(ctx, p, githubOauthToken)
 		if err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}
 
-		var yamlBytes []byte
-		yamlBytes, err = yaml.Marshal(project)
-		if err != nil {
-			as.LoggedError(w, r, http.StatusInternalServerError, err)
-			return
-		}
-		p.PatchedConfig = string(yamlBytes)
+		p.PatchedConfig = projectYaml
 		_, err = model.FinalizePatch(ctx, p, evergreen.PatchVersionRequester, githubOauthToken)
 		if err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, err)

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -252,7 +252,7 @@ func (j *commitQueueJob) processCLIPatchItem(ctx context.Context, cq *commitqueu
 		return
 	}
 
-	project, err := model.GetPatchedProject(ctx, patchDoc, githubToken)
+	project, _, err := model.GetPatchedProject(ctx, patchDoc, githubToken)
 	if err != nil {
 		j.logError(err, "can't get updated project config", nextItem)
 		j.dequeue(cq, nextItem)
@@ -391,17 +391,12 @@ func getPatchInfo(ctx context.Context, githubToken string, patchDoc *patch.Patch
 	}
 
 	// fetch the latest config file
-	config, err := model.GetPatchedProject(ctx, patchDoc, githubToken)
+	config, projectYaml, err := model.GetPatchedProject(ctx, patchDoc, githubToken)
 	if err != nil {
 		return "", nil, nil, errors.Wrap(err, "can't get remote config file")
 	}
 
-	yamlBytes, err := yaml.Marshal(config)
-	if err != nil {
-		return "", nil, nil, errors.Wrap(err, "can't marshall remote config file")
-	}
-	patchDoc.PatchedConfig = string(yamlBytes)
-
+	patchDoc.PatchedConfig = projectYaml
 	return patchContent, summaries, config, nil
 }
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -26,7 +26,6 @@ import (
 	"github.com/mongodb/grip/sometimes"
 	"github.com/pkg/errors"
 	mgobson "gopkg.in/mgo.v2/bson"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -215,7 +214,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 
 	// Get and validate patched config
-	project, err := model.GetPatchedProject(ctx, patchDoc, githubOauthToken)
+	project, projectYaml, err := model.GetPatchedProject(ctx, patchDoc, githubOauthToken)
 	if err != nil {
 		if strings.Contains(err.Error(), thirdparty.Github502Error) {
 			j.gitHubError = GitHubInternalError
@@ -234,12 +233,8 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 			}
 		}
 	}
-	yamlBytes, err := yaml.Marshal(project)
-	if err != nil {
-		return errors.Wrap(err, "can't marshal patched config")
-	}
-	patchDoc.PatchedConfig = string(yamlBytes)
 
+	patchDoc.PatchedConfig = projectYaml
 	if patchDoc.Patches[0].ModuleName != "" {
 		// is there a module? validate it.
 		var module *model.Module


### PR DESCRIPTION
Some investigation has uncovered that 
1) execution tasks are destructively modified for parser projects, and
2) we store the expanded project in patches (and subsequent versions), where we should store just the parser project in the yaml. 