### PR TITLE
EVG-6517 Support generate.tasks across deploys

### DIFF
--- a/command/generate.go
+++ b/command/generate.go
@@ -100,7 +100,7 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 				return false, nil
 			}
 			return true, errors.New("task generation unfinished")
-		}, 250, time.Second, 15*time.Second)
+		}, 500, time.Second, 15*time.Second)
 	if err != nil {
 		return errors.WithMessage(err, "problem polling for generate tasks job")
 	}

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateEncluosingDirectory(t *testing.T) {
+func TestCreateEnclosingDirectory(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -68,6 +68,8 @@ var (
 	GenerateTaskKey         = bsonutil.MustHaveTag(Task{}, "GenerateTask")
 	GeneratedTasksKey       = bsonutil.MustHaveTag(Task{}, "GeneratedTasks")
 	GeneratedByKey          = bsonutil.MustHaveTag(Task{}, "GeneratedBy")
+	GeneratedJSONKey        = bsonutil.MustHaveTag(Task{}, "GeneratedJSON")
+	GenerateTasksErrorKey   = bsonutil.MustHaveTag(Task{}, "GenerateTasksError")
 	ResetWhenFinishedKey    = bsonutil.MustHaveTag(Task{}, "ResetWhenFinished")
 	LogsKey                 = bsonutil.MustHaveTag(Task{}, "Logs")
 	CommitQueueMergeKey     = bsonutil.MustHaveTag(Task{}, "CommitQueueMerge")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -82,7 +83,7 @@ type Task struct {
 
 	// only relevant if the task is runnin.  the time of the last heartbeat
 	// sent back by the agent
-	LastHeartbeat time.Time `bson:"last_heartbeat"`
+	LastHeartbeat time.Time `bson:"last_heartbeat" json:"last_heartbeat"`
 
 	// used to indicate whether task should be scheduled to run
 	Activated            bool         `bson:"activated" json:"activated"`
@@ -156,6 +157,10 @@ type Task struct {
 	GeneratedTasks bool `bson:"generated_tasks,omitempty" json:"generated_tasks,omitempty"`
 	// GeneratedBy, if present, is the ID of the task that generated this task.
 	GeneratedBy string `bson:"generated_by,omitempty" json:"generated_by,omitempty"`
+	// GeneratedJSON is the the configuration information to create new tasks from.
+	GeneratedJSON []json.RawMessage `bson:"generate_json,omitempty" json:"generate_json,omitempty"`
+	// GenerateTasksError any encountered while generating tasks.
+	GenerateTasksError string `bson:"generate_error,omitempty" json:"generate_error,omitempty"`
 
 	// Fields set if triggered by an upstream build
 	TriggerID    string `bson:"trigger_id,omitempty" json:"trigger_id,omitempty"`
@@ -578,15 +583,65 @@ func (t *Task) MarkAsUndispatched() error {
 }
 
 // MarkGeneratedTasks marks that the task has generated tasks.
-func (t *Task) MarkGeneratedTasks() error {
-	t.GeneratedTasks = true
+func MarkGeneratedTasks(taskID string) error {
 	return UpdateOne(
 		bson.M{
-			IdKey: t.Id,
+			IdKey: taskID,
 		},
 		bson.M{
 			"$set": bson.M{
 				GeneratedTasksKey: true,
+			},
+		},
+	)
+}
+
+func GenerateNotRun() ([]Task, error) {
+	const maxGenerateTimeAgo = 2 * time.Hour
+	return FindAll(db.Query(bson.M{
+		StatusKey:         evergreen.TaskStarted,                              // task is running
+		StartTimeKey:      bson.M{"$gt": time.Now().Add(-maxGenerateTimeAgo)}, // ignore older tasks, just in case
+		GenerateTaskKey:   true,                                               // task contains generate.tasks command
+		GeneratedTasksKey: bson.M{"$exists": false},                           // generate.tasks has not yet run
+		GeneratedJSONKey:  bson.M{"$exists": true},                            // config has been posted by generate.tasks command
+	}))
+}
+
+// SetGeneratedJSON sets JSON data to generate tasks from.
+func (t *Task) SetGeneratedJSON(json []json.RawMessage) error {
+	if len(t.GeneratedJSON) > 0 {
+		return nil
+	}
+	t.GeneratedJSON = json
+	return UpdateOne(
+		bson.M{
+			IdKey: t.Id,
+			// If this field already is set, something has gone wrong.
+			GeneratedJSONKey: bson.M{"$exists": false},
+		},
+		bson.M{
+			"$set": bson.M{
+				GeneratedJSONKey: json,
+			},
+		},
+	)
+}
+
+// SetGenerateTasksError sets any error encountered during generate tasks.
+func (t *Task) SetGenerateTasksError(err error) error {
+	if err == nil {
+		return nil
+	}
+	t.GenerateTasksError = err.Error()
+	return UpdateOne(
+		bson.M{
+			IdKey: t.Id,
+			// If this field already is set, something has gone wrong.
+			GenerateTasksErrorKey: bson.M{"$exists": false},
+		},
+		bson.M{
+			"$set": bson.M{
+				GenerateTasksErrorKey: err.Error(),
 			},
 		},
 	)

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/queue"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -60,14 +58,6 @@ func TestGenerateExecute(t *testing.T) {
 	r := h.Run(context.Background())
 	assert.Equal(t, r.Data(), struct{}{})
 	assert.Equal(t, r.Status(), http.StatusOK)
-}
-
-func localConstructor(ctx context.Context) (amboy.Queue, error) {
-	return queue.NewLocalLimitedSize(1, 1048), nil
-}
-
-func remoteConstructor(ctx context.Context) (queue.Remote, error) {
-	return queue.NewRemoteUnordered(1), nil
 }
 
 func TestGeneratePollParse(t *testing.T) {

--- a/units/crons.go
+++ b/units/crons.go
@@ -701,7 +701,7 @@ func PopulateGenerateTasksJobs(env evergreen.Environment) amboy.QueueOperation {
 
 		versions := map[string]amboy.Queue{}
 
-		ts := util.RoundPartOfMinute(0).Format(tsFormat)
+		ts := util.RoundPartOfMinute(20).Format(tsFormat)
 		group := env.RemoteQueueGroup()
 		for _, t := range tasks {
 			if q, ok = versions[t.Version]; !ok {

--- a/units/crons.go
+++ b/units/crons.go
@@ -709,6 +709,7 @@ func PopulateGenerateTasksJobs(env evergreen.Environment) amboy.QueueOperation {
 				if err != nil {
 					return errors.Wrapf(err, "problem getting queue for version %s", t.Version)
 				}
+				versions[t.Version] = q
 			}
 			catcher.Add(q.Put(ctx, NewGenerateTasksJob(t.Id, ts)))
 		}

--- a/units/crons.go
+++ b/units/crons.go
@@ -705,7 +705,7 @@ func PopulateGenerateTasksJobs(env evergreen.Environment) amboy.QueueOperation {
 		group := env.RemoteQueueGroup()
 		for _, t := range tasks {
 			if q, ok = versions[t.Version]; !ok {
-				q, err = group.Get(context.TODO(), t.Version)
+				q, err = group.Get(ctx, t.Version)
 				if err != nil {
 					return errors.Wrapf(err, "problem getting queue for version %s", t.Version)
 				}

--- a/units/crons.go
+++ b/units/crons.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/amboy"
 	adb "github.com/mongodb/anser/db"
@@ -683,6 +684,36 @@ func PopulateAgentDeployJobs(env evergreen.Environment) amboy.QueueOperation {
 		return catcher.Resolve()
 	}
 
+}
+
+// PopulateGenerateTasksJobs poulates generate.tasks jobs for tasks that have started running their generate.tasks command.
+func PopulateGenerateTasksJobs(env evergreen.Environment) amboy.QueueOperation {
+	return func(ctx context.Context, _ amboy.Queue) error {
+		var q amboy.Queue
+		var ok bool
+		var err error
+
+		catcher := grip.NewBasicCatcher()
+		tasks, err := task.GenerateNotRun()
+		if err != nil {
+			return errors.Wrap(err, "problem getting tasks that need generators run")
+		}
+
+		versions := map[string]amboy.Queue{}
+
+		ts := util.RoundPartOfMinute(0).Format(tsFormat)
+		group := env.RemoteQueueGroup()
+		for _, t := range tasks {
+			if q, ok = versions[t.Version]; !ok {
+				q, err = group.Get(context.TODO(), t.Version)
+				if err != nil {
+					return errors.Wrapf(err, "problem getting queue for version %s", t.Version)
+				}
+			}
+			catcher.Add(q.Put(ctx, NewGenerateTasksJob(t.Id, ts)))
+		}
+		return catcher.Resolve()
+	}
 }
 
 // PopulateAgentMonitorDeployJobs enqueues the jobs to deploy the agent monitor

--- a/units/crons_remote_fifteen_second.go
+++ b/units/crons_remote_fifteen_second.go
@@ -55,6 +55,7 @@ func (j *cronsRemoteFifteenSecondJob) Run(ctx context.Context) {
 		PopulateAgentDeployJobs(j.env),
 		PopulateAgentMonitorDeployJobs(j.env),
 		PopulateUserDataDoneJobs(j.env),
+		PopulateGenerateTasksJobs(j.env),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -133,7 +133,7 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 		"task":          t.Id,
 		"version":       t.Version,
 	})
-	grip.Error(!adb.ResultsNotFound(err), message.WrapError(err, message.Fields{
+	grip.ErrorWhen(!adb.ResultsNotFound(err), message.WrapError(err, message.Fields{
 		"message":       "generate.tasks finished",
 		"duration_secs": time.Since(start).Seconds(),
 		"task":          t.Id,

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -88,7 +88,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 
 	// Don't use the job's context, because it's better to finish than to exit early after a
 	// SIGTERM from a deploy. This should maybe be a context with timeout.
-	err = g.Save(context.TODO(), p, v, t, pm)
+	err = g.Save(context.Background(), p, v, t, pm)
 
 	// If the version has changed there was a race. Another generator will try again.
 	if err != nil && adb.ResultsNotFound(err) {
@@ -133,7 +133,7 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 		"task":          t.Id,
 		"version":       t.Version,
 	})
-	grip.ErrorWhen(err != nil, message.WrapError(err, message.Fields{
+	grip.Error(!adb.ResultsNotFound(err), message.WrapError(err, message.Fields{
 		"message":       "generate.tasks finished",
 		"duration_secs": time.Since(start).Seconds(),
 		"task":          t.Id,

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/evergreen/validator"
-	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
@@ -32,8 +29,7 @@ func init() {
 
 type generateTasksJob struct {
 	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
-	TaskID   string            `bson:"task_id" json:"task_id" yaml:"task_id"`
-	JSON     []json.RawMessage `bson:"json" json:"json" yaml:"json"`
+	TaskID   string `bson:"task_id" json:"task_id" yaml:"task_id"`
 }
 
 func makeGenerateTaskJob() *generateTasksJob {
@@ -50,75 +46,89 @@ func makeGenerateTaskJob() *generateTasksJob {
 	return j
 }
 
-func NewGenerateTasksJob(id string, json []json.RawMessage) amboy.Job {
+func NewGenerateTasksJob(id string, ts string) amboy.Job {
 	j := makeGenerateTaskJob()
 	j.TaskID = id
-	j.JSON = json
 
-	j.SetID(fmt.Sprintf("%s-%s", generateTasksJobName, id))
+	j.SetID(fmt.Sprintf("%s-%s-%s", generateTasksJobName, id, ts))
 	return j
+}
+
+func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
+	t, err := task.FindOneId(j.TaskID)
+	if err != nil {
+		return errors.Wrapf(err, "problem finding task %s", j.TaskID)
+	}
+	if t == nil {
+		return errors.Errorf("task %s does not exist", j.TaskID)
+	}
+	if t.GeneratedTasks {
+		grip.Debug(message.Fields{
+			"message": "attempted to generate tasks, but generator already ran for this task",
+			"task":    t.Id,
+			"version": t.Version,
+		})
+		return nil
+	}
+
+	projects, err := parseProjects(t.GeneratedJSON)
+	if err != nil {
+		return errors.Wrap(err, "error parsing JSON from `generate.tasks`")
+	}
+	g := model.MergeGeneratedProjects(projects)
+	g.TaskID = j.TaskID
+
+	p, v, t, pm, err := g.NewVersion()
+	if err != nil {
+		return errors.Wrap(err, "problem creating new version")
+	}
+	if err = validator.CheckProjectConfigurationIsValid(p); err != nil {
+		return errors.Wrap(err, "project configuration was invalid")
+	}
+
+	// Don't use the job's context, because it's better to finish than to exit early after a
+	// SIGTERM from a deploy. This should maybe be a context with timeout.
+	err = g.Save(context.TODO(), p, v, t, pm)
+
+	// If the version has changed return nil because there was a race. Another generator will try again.
+	if err != nil && adb.ResultsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Wrap(err, "error updating config in `generate.tasks`")
+	}
+	return nil
 }
 
 func (j *generateTasksJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 	start := time.Now()
 
-	projects, err := parseProjects(j.JSON)
+	t, err := task.FindOneId(j.TaskID)
 	if err != nil {
-		j.AddError(errors.Wrap(err, "error parsing JSON from `generate.tasks`"))
-		return
+		j.AddError(errors.Wrapf(err, "problem finding task %s", j.TaskID))
 	}
-	g := model.MergeGeneratedProjects(projects)
-	g.TaskID = j.TaskID
+	if t == nil {
+		j.AddError(errors.Errorf("task %s does not exist", j.TaskID))
+	}
 
-	var attempt int
-	err = util.Retry(
-		ctx,
-		func() (bool, error) {
-			attemptStart := time.Now()
-			attempt++
-
-			t, err := task.FindOneId(j.TaskID)
-			if err != nil {
-				return false, err
-			}
-			if t == nil {
-				return false, errors.Errorf("unable to find task %s", g.TaskID)
-			}
-			if t.GeneratedTasks {
-				return false, nil // already generated tasks, noop
-			}
-			p, v, t, pm, err := g.NewVersion() // nolint
-			if err != nil {
-				return false, err
-			}
-			if err = validator.CheckProjectConfigurationIsValid(p); err != nil {
-				return false, err
-			}
-			err = g.Save(ctx, p, v, t, pm)
-			if err != nil && adb.ResultsNotFound(err) {
-				return true, gimlet.ErrorResponse{
-					StatusCode: http.StatusInternalServerError,
-					Message:    errors.Wrap(err, "error updating config in `generate.tasks`").Error(),
-				}
-			}
-			if err = t.MarkGeneratedTasks(); err != nil {
-				return true, gimlet.ErrorResponse{
-					StatusCode: http.StatusInternalServerError,
-					Message:    errors.Wrapf(err, "problem marking task '%s' as having generated tasks", t.Id).Error(),
-				}
-			}
-			grip.Info(message.Fields{
-				"message":               "generate.tasks succeeded",
-				"attempt":               attempt,
-				"attempt_duration_secs": time.Since(attemptStart).Seconds(),
-				"total_duration_secs":   time.Since(start).Seconds(),
-				"task":                  t.Id,
-				"version":               t.Version,
-			})
-			return false, nil
-		}, 100, time.Second, 15*time.Second)
+	err = j.generate(ctx, t)
 	j.AddError(err)
+	j.AddError(t.SetGenerateTasksError(err))
+	j.AddError(task.MarkGeneratedTasks(j.TaskID))
+
+	grip.InfoWhen(err == nil, message.Fields{
+		"message":       "generate.tasks finished",
+		"duration_secs": time.Since(start).Seconds(),
+		"task":          t.Id,
+		"version":       t.Version,
+	})
+	grip.ErrorWhen(err != nil, message.WrapError(err, message.Fields{
+		"message":       "generate.tasks finished",
+		"duration_secs": time.Since(start).Seconds(),
+		"task":          t.Id,
+		"version":       t.Version,
+	}))
 }
 
 func parseProjects(jsonBytes []json.RawMessage) ([]model.GeneratedProject, error) {

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -184,7 +184,7 @@ func TestGenerateTasks(t *testing.T) {
 		require.NoError(d.Insert())
 	}
 	require.NoError(sampleTask.Insert())
-	j := NewGenerateTasksJob("sample_task", 1)
+	j := NewGenerateTasksJob("sample_task", "1")
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 	tasks := []task.Task{}

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -165,11 +165,12 @@ func TestGenerateTasks(t *testing.T) {
 	}
 	require.NoError(sampleBuild.Insert())
 	sampleTask := task.Task{
-		Id:          "sample_task",
-		Version:     "sample_version",
-		BuildId:     "sample_build_id",
-		Project:     "mci",
-		DisplayName: "sample_task",
+		Id:            "sample_task",
+		Version:       "sample_version",
+		BuildId:       "sample_build_id",
+		Project:       "mci",
+		DisplayName:   "sample_task",
+		GeneratedJSON: sampleGeneratedProject,
 	}
 	sampleDistros := []distro.Distro{
 		distro.Distro{
@@ -183,7 +184,7 @@ func TestGenerateTasks(t *testing.T) {
 		require.NoError(d.Insert())
 	}
 	require.NoError(sampleTask.Insert())
-	j := NewGenerateTasksJob("sample_task", sampleGeneratedProject)
+	j := NewGenerateTasksJob("sample_task", 1)
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 	tasks := []task.Task{}


### PR DESCRIPTION
This removes retries from the generate.tasks job in favor of a background job that populates generate.tasks jobs based on a query. The query looks for tasks that contain a generate.tasks command and that are running. It creates a generate.tasks job for each of those. If any those jobs fail due to a race, they will not error. A new job will be created to try again 15 seconds later.