### PR TITLE
EVG-6426 generated tasks for commit queue patches

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -173,7 +173,7 @@ func (g *GeneratedProject) Save(ctx context.Context, p *Project, v *Version, t *
 		return errors.Wrapf(err, "error updating version %s", v.Id)
 	}
 
-	if t.CommitQueueMerge {
+	if v.Requester == evergreen.MergeTestRequester {
 		if err = v.UpdateMergeTaskDependencies(p); err != nil {
 			return errors.Wrap(err, "error updating merge task")
 		}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -8,7 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const LoadProjectError = "load project error(s)"
@@ -325,16 +325,17 @@ func (pbv *parserBV) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // parserBVTaskUnit is a helper type storing intermediary variant task configurations.
 type parserBVTaskUnit struct {
-	Name            string             `yaml:"name,omitempty"`
-	Patchable       *bool              `yaml:"patchable,omitempty"`
-	PatchOnly       *bool              `yaml:"patch_only,omitempty"`
-	Priority        int64              `yaml:"priority,omitempty"`
-	DependsOn       parserDependencies `yaml:"depends_on,omitempty"`
-	Requires        taskSelectors      `yaml:"requires,omitempty"`
-	ExecTimeoutSecs int                `yaml:"exec_timeout_secs,omitempty"`
-	Stepback        *bool              `yaml:"stepback,omitempty"`
-	Distros         parserStringSlice  `yaml:"distros,omitempty"`
-	RunOn           parserStringSlice  `yaml:"run_on,omitempty"` // Alias for "Distros" TODO: deprecate Distros
+	Name             string             `yaml:"name,omitempty"`
+	Patchable        *bool              `yaml:"patchable,omitempty"`
+	PatchOnly        *bool              `yaml:"patch_only,omitempty"`
+	Priority         int64              `yaml:"priority,omitempty"`
+	DependsOn        parserDependencies `yaml:"depends_on,omitempty"`
+	Requires         taskSelectors      `yaml:"requires,omitempty"`
+	ExecTimeoutSecs  int                `yaml:"exec_timeout_secs,omitempty"`
+	Stepback         *bool              `yaml:"stepback,omitempty"`
+	Distros          parserStringSlice  `yaml:"distros,omitempty"`
+	RunOn            parserStringSlice  `yaml:"run_on,omitempty"` // Alias for "Distros" TODO: deprecate Distros
+	CommitQueueMerge bool               `yaml:"commit_queue_merge,omitempty"`
 }
 
 // UnmarshalYAML allows the YAML parser to read both a single selector string or
@@ -410,7 +411,7 @@ func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(interface{}) error) e
 }
 
 // LoadProjectInto loads the raw data from the config file into project
-// and sets the project's identifier field to identifier. Tags are evaluateed.
+// and sets the project's identifier field to identifier. Tags are evaluated.
 func LoadProjectInto(data []byte, identifier string, project *Project) error {
 	p, errs := projectFromYAML(data)
 	if len(errs) > 0 {
@@ -740,13 +741,14 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 			// create a new task by copying the task that selected it,
 			// so we can preserve the "Variant" and "Status" field.
 			t := BuildVariantTaskUnit{
-				Name:            name,
-				Patchable:       pt.Patchable,
-				PatchOnly:       pt.PatchOnly,
-				Priority:        pt.Priority,
-				ExecTimeoutSecs: pt.ExecTimeoutSecs,
-				Stepback:        pt.Stepback,
-				Distros:         pt.Distros,
+				Name:             name,
+				Patchable:        pt.Patchable,
+				PatchOnly:        pt.PatchOnly,
+				Priority:         pt.Priority,
+				ExecTimeoutSecs:  pt.ExecTimeoutSecs,
+				Stepback:         pt.Stepback,
+				Distros:          pt.Distros,
+				CommitQueueMerge: pt.CommitQueueMerge,
 			}
 
 			// Task-level dependencies in the variant override variant-level dependencies

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -309,6 +309,23 @@ buildvariants:
 			So(p, ShouldBeNil)
 			So(len(errs), ShouldEqual, 1)
 		})
+		Convey("a file with a commit queue merge task should parse", func() {
+			single := `
+buildvariants:
+- name: "v1"
+  tasks:
+  - name: "t1"
+    commit_queue_merge: true
+`
+			p, errs := createIntermediateProject([]byte(single))
+			So(p, ShouldNotBeNil)
+			So(len(errs), ShouldEqual, 0)
+			bv := p.BuildVariants[0]
+			So(bv.Name, ShouldEqual, "v1")
+			So(len(bv.Tasks), ShouldEqual, 1)
+			So(bv.Tasks[0].Name, ShouldEqual, "t1")
+			So(bv.Tasks[0].CommitQueueMerge, ShouldBeTrue)
+		})
 	})
 }
 
@@ -443,7 +460,7 @@ func TestTranslateBuildVariants(t *testing.T) {
 			pp.BuildVariants = []parserBV{{
 				Name: "v1",
 				Tasks: parserBVTaskUnits{
-					{Name: "t1"},
+					{Name: "t1", CommitQueueMerge: true},
 					{Name: ".z", DependsOn: parserDependencies{
 						{TaskSelector: taskSelector{Name: ".b"}}}},
 					{Name: "* !t1 !t2", Requires: taskSelectors{{Name: "!.a"}}},
@@ -457,6 +474,7 @@ func TestTranslateBuildVariants(t *testing.T) {
 			So(bvts[0].Name, ShouldEqual, "t1")
 			So(bvts[1].Name, ShouldEqual, "t2")
 			So(bvts[2].Name, ShouldEqual, "t3")
+			So(bvts[0].CommitQueueMerge, ShouldBeTrue)
 			So(bvts[1].DependsOn[0].Name, ShouldEqual, "t3")
 			So(bvts[2].Requires[0].Name, ShouldEqual, "t1")
 		})

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1861,7 +1861,7 @@ func (t *Task) UpdateDependencies(dependsOn []Dependency) error {
 			DependsOnKey: t.DependsOn,
 		},
 		bson.M{
-			"$set": bson.M{DependsOnKey: dependsOn},
+			"$push": bson.M{DependsOnKey: bson.M{"$each": dependsOn}},
 		},
 	)
 	if err != nil {
@@ -1871,7 +1871,7 @@ func (t *Task) UpdateDependencies(dependsOn []Dependency) error {
 		return errors.Wrap(err, "can't update dependencies")
 	}
 
-	t.DependsOn = dependsOn
+	t.DependsOn = append(t.DependsOn, dependsOn...)
 
 	return nil
 }

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1447,27 +1447,20 @@ func TestUpdateDependencies(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	t1 := &Task{
 		Id:        "t1",
-		DependsOn: []Dependency{},
+		DependsOn: []Dependency{{TaskId: "t2"}},
 	}
 	assert.NoError(t, t1.Insert())
 
-	dependsOn := []Dependency{
-		{
-			TaskId: "t2",
-		},
-	}
+	dependsOn := []Dependency{{TaskId: "t3"}}
 	assert.NoError(t, t1.UpdateDependencies(dependsOn))
-	assert.Len(t, t1.DependsOn, 1)
+	assert.Len(t, t1.DependsOn, 2)
 	dbT1, err := FindOneId("t1")
 	assert.NoError(t, err)
-	assert.Len(t, dbT1.DependsOn, 1)
+	assert.Len(t, dbT1.DependsOn, 2)
 
 	// If the task is out of sync with the db the update fails
-	t1.DependsOn = []Dependency{
-		{TaskId: "t3"},
-	}
+	t1.DependsOn = []Dependency{{TaskId: "t4"}}
 	assert.Error(t, t1.UpdateDependencies(dependsOn))
-
 }
 
 func TestDisplayTaskCache(t *testing.T) {

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -129,6 +129,13 @@ func TestUpdateMergeTaskDependencies(t *testing.T) {
 
 	mergeTask := task.Task{
 		Id: taskID,
+		DependsOn: []task.Dependency{
+			{
+				TaskId:       "t2",
+				Status:       evergreen.TaskSucceeded,
+				Unattainable: true,
+			},
+		},
 	}
 	assert.NoError(t, mergeTask.Insert())
 
@@ -144,7 +151,8 @@ func TestUpdateMergeTaskDependencies(t *testing.T) {
 
 	tDb, err := task.FindOneId(taskID)
 	assert.NoError(t, err)
-	require.Len(t, tDb.DependsOn, 1)
+	require.Len(t, tDb.DependsOn, 2)
+	assert.True(t, tDb.DependsOn[0].Unattainable)
 }
 
 func TestFindLastPeriodicBuild(t *testing.T) {


### PR DESCRIPTION
- #2404 was supposed to allow a commit queue merge to depend on generated tasks, but they weren't being added as dependencies because we were checking if the generating task was the actual merge task as opposed to checking that it's in a commit queue patch.
- The way dependencies were supposed to have been added would have rebuilt the merge task's dependencies array, wiping out the cached blocked status. 
- The merge task's CommitQueueMerge field wasn't being set because it was not plumbed through the project parsing. This field is still used elsewhere.