### PR TITLE
EVG-6437 Log if a process is not cleaned up between tasks

### DIFF
--- a/util/subtree_linux.go
+++ b/util/subtree_linux.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	processCleanupAttempts   = 10
-	processCleanupTimeoutMin = 1 * time.Second
-	processCleanupTimeoutMax = 10 * time.Minute
+	processCleanupAttempts   = 5
+	processCleanupTimeoutMin = 100 * time.Millisecond
+	processCleanupTimeoutMax = 1 * time.Second
+	contextTimeout           = 10 * time.Second
 )
 
 func TrackProcess(key string, pid int, logger grip.Journaler) {
@@ -69,7 +70,7 @@ func cleanup(key string, logger grip.Journaler) error {
 	}
 
 	// Retry listing processes until all have successfully exited
-	ctx := context.Background()
+	ctx := context.WithTimeout(context.Background(), contextTimeout)
 	err = Retry(
 		ctx,
 		func() (bool, error) {

--- a/util/subtree_linux.go
+++ b/util/subtree_linux.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 )
 
@@ -77,7 +78,7 @@ func cleanup(key string, logger grip.Journaler) error {
 			if err != nil {
 				return false, err
 			}
-			if len(pids == 0) {
+			if len(pids) == 0 {
 				return false, nil
 			}
 			return true, nil

--- a/util/subtree_linux.go
+++ b/util/subtree_linux.go
@@ -61,7 +61,7 @@ func cleanup(key string, logger grip.Journaler) error {
 			p := os.Process{}
 			p.Pid = pid
 			if err := p.Kill(); err != nil {
-				logger.Infof("Killing %d failed: %v", pid, err)
+				logger.Infof("killing %d failed: %v", pid, err)
 			} else {
 				logger.Infof("Killed process %d", pid)
 			}

--- a/util/subtree_linux.go
+++ b/util/subtree_linux.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 )
 
@@ -71,7 +70,7 @@ func cleanup(key string, logger grip.Journaler) error {
 
 	// Retry listing processes until all have successfully exited
 	ctx := context.Background()
-	err = util.Retry(
+	err = Retry(
 		ctx,
 		func() (bool, error) {
 			pids, err = listProc()

--- a/util/subtree_linux.go
+++ b/util/subtree_linux.go
@@ -77,7 +77,7 @@ func cleanup(key string, logger grip.Journaler) error {
 			if err != nil {
 				return false, err
 			}
-			if len(remainingPids == 0) {
+			if len(pids == 0) {
 				return false, nil
 			}
 			return true, nil

--- a/util/subtree_linux.go
+++ b/util/subtree_linux.go
@@ -65,7 +65,6 @@ func cleanup(key string, logger grip.Journaler) error {
 			} else {
 				logger.Infof("Killed process %d", pid)
 			}
-			remainingPids[pid] = true
 		}
 	}
 
@@ -74,15 +73,9 @@ func cleanup(key string, logger grip.Journaler) error {
 	err = util.Retry(
 		ctx,
 		func() (bool, error) {
-			pids, err := listProc()
+			pids, err = listProc()
 			if err != nil {
 				return false, err
-			}
-			for _, pid := range pids {
-				if remainingPids[pid] {
-					delete(remainingPids, pid)
-					logger.Infof("Successfully cleaned up process %d", pid)
-				}
 			}
 			if len(remainingPids == 0) {
 				return false, nil
@@ -98,7 +91,7 @@ func cleanup(key string, logger grip.Journaler) error {
 	}
 
 	// Log each process that was not cleaned up
-	for pid := range remainingPids {
+	for pid := range pids {
 		logger.Infof("Failed to clean up process &d", pid)
 	}
 

--- a/util/subtree_linux.go
+++ b/util/subtree_linux.go
@@ -70,7 +70,8 @@ func cleanup(key string, logger grip.Journaler) error {
 	}
 
 	// Retry listing processes until all have successfully exited
-	ctx := context.WithTimeout(context.Background(), contextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
 	err = Retry(
 		ctx,
 		func() (bool, error) {

--- a/util/subtree_linux.go
+++ b/util/subtree_linux.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	processCleanupAttempts   = 5
+	processCleanupAttempts   = 10
 	processCleanupTimeoutMin = 100 * time.Millisecond
 	processCleanupTimeoutMax = 1 * time.Second
 	contextTimeout           = 10 * time.Second


### PR DESCRIPTION
Check whether all processes have successfully exited after kill is called, and adds to the log for each process that is not cleaned up after a certain amount of time. Uses util.Retry so that the program can continue quickly in most cases where processes immediately exit. 

If anyone has opinions about the timeout constants, I'd love to hear them.