### PR TITLE
EVG-6665 Create modify host command for spawn hosts

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -28,6 +28,9 @@ type Manager interface {
 	// provider's API.
 	SpawnHost(context.Context, *host.Host) (*host.Host, error)
 
+	// ModifyHost modifies an existing host
+	ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error
+
 	// get the status of an instance
 	GetInstanceStatus(context.Context, *host.Host) (CloudStatus, error)
 

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -32,7 +32,7 @@ var (
 	imageURLKey = bsonutil.MustHaveTag(dockerSettings{}, "ImageURL")
 )
 
-//Validate checks that the settings from the config file are sane.
+// Validate checks that the settings from the config file are sane.
 func (settings *dockerSettings) Validate() error {
 	if settings.ImageURL == "" {
 		return errors.New("Image must not be empty")
@@ -112,6 +112,10 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 	event.LogHostStarted(h.Id)
 
 	return h, nil
+}
+
+func (m *dockerManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {
+	return errors.New("can't modify instances with docker provider")
 }
 
 // GetInstanceStatus returns a universal status code representing the state

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -500,6 +500,15 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, changes host.
 
 	// note: deal with spot instances?
 	instanceID := h.Id
+	if isHostSpot(h) {
+		instanceID, err = m.client.GetSpotInstanceId(ctx, h)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get spot request info for %s", h.Id)
+		}
+		if instanceID == "" {
+			return errors.WithStack(errors.New("spot instance does not yet have an instanceId"))
+		}
+	}
 	volumeIDs, err := m.client.GetVolumeIDs(ctx, h)
 	if err != nil {
 		return errors.Wrapf(err, "can't get volume IDs for '%s'", h.Id)

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -752,6 +752,7 @@ func (c *awsClientImpl) SetTags(ctx context.Context, resources []string, h *host
 		"host":          h.Id,
 		"host_provider": h.Distro.Provider,
 		"distro":        h.Distro.Id,
+		"tags":          h.InstanceTags,
 	})
 
 	return nil

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1145,6 +1145,13 @@ func (c *awsClientMock) GetKey(ctx context.Context, h *host.Host) (string, error
 }
 
 func (c *awsClientMock) SetTags(ctx context.Context, resources []string, h *host.Host) error {
+	tagSlice := []*ec2.Tag{}
+	if _, err := c.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: aws.StringSlice(resources),
+		Tags:      tagSlice,
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -116,6 +116,10 @@ func (m *ec2FleetManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Ho
 	return h, nil
 }
 
+func (m *ec2FleetManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {
+	return errors.New("can't modify instances for ec2 fleet provider")
+}
+
 func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.Host) ([]CloudStatus, error) {
 	instanceIDs := make([]*string, 0, len(hosts))
 	for _, h := range hosts {

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -178,6 +178,10 @@ func makeTags(intentHost *host.Host) []host.Tag {
 		systemTags = append(systemTags, host.Tag{Key: "mode", Value: "testing", CanBeModified: false})
 	}
 
+	if isHostSpot(intentHost) {
+		systemTags = append(systemTags, host.Tag{Key: "spot", Value: "true", CanBeModified: false})
+	}
+
 	// Add Evergreen-generated tags to host object
 	intentHost.AddTags(systemTags)
 

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -134,9 +134,9 @@ func expireInDays(numDays int) string {
 	return time.Now().AddDate(0, 0, numDays).Format("2006-01-02")
 }
 
-//makeTags populates a map of tags based on a host object, which contain keys
-//for the user, owner, hostname, and if it's a spawnhost or not.
-func makeTags(intentHost *host.Host) map[string]string {
+// makeTags populates a slice of tags based on a host object, which contain keys
+// for the user, owner, hostname, and if it's a spawnhost or not.
+func makeTags(intentHost *host.Host) []host.Tag {
 	// get requester host name
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -163,26 +163,25 @@ func makeTags(intentHost *host.Host) map[string]string {
 		expireOn = expireInDays(spawnHostExpireDays)
 	}
 
-	tags := map[string]string{
-		"name":              intentHost.Id,
-		"distro":            intentHost.Distro.Id,
-		"evergreen-service": hostname,
-		"username":          username,
-		"owner":             intentHost.StartedBy,
-		"mode":              "production",
-		"start-time":        intentHost.CreationTime.Format(evergreen.NameTimeFormat),
-		"expire-on":         expireOn,
-	}
-
-	// add InstanceTags specified by user
-	for key, value := range intentHost.InstanceTags {
-		tags[key] = value
+	systemTags := []host.Tag{
+		host.Tag{Key: "name", Value: intentHost.Id, CanBeModified: false},
+		host.Tag{Key: "distro", Value: intentHost.Distro.Id, CanBeModified: false},
+		host.Tag{Key: "evergreen-service", Value: hostname, CanBeModified: false},
+		host.Tag{Key: "username", Value: username, CanBeModified: false},
+		host.Tag{Key: "owner", Value: intentHost.StartedBy, CanBeModified: false},
+		host.Tag{Key: "mode", Value: "production", CanBeModified: false},
+		host.Tag{Key: "start-time", Value: intentHost.CreationTime.Format(evergreen.NameTimeFormat), CanBeModified: false},
+		host.Tag{Key: "expire-in", Value: expireOn, CanBeModified: false},
 	}
 
 	if intentHost.UserHost {
-		tags["mode"] = "testing"
+		systemTags = append(systemTags, host.Tag{Key: "mode", Value: "testing", CanBeModified: false})
 	}
-	return tags
+
+	// Add Evergreen-generated tags to host object
+	intentHost.AddTags(systemTags)
+
+	return intentHost.InstanceTags
 }
 
 func timeTilNextEC2Payment(h *host.Host) time.Duration {

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -157,6 +157,10 @@ func (m *gceManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 	return h, nil
 }
 
+func (m *gceManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {
+	return errors.New("can't modify instances with gce provider")
+}
+
 // GetInstanceStatus gets the current operational status of the provisioned host,
 func (m *gceManager) GetInstanceStatus(ctx context.Context, host *host.Host) (CloudStatus, error) {
 	instance, err := m.client.GetInstance(host)

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -141,7 +141,7 @@ func (mockMgr *mockManager) SpawnHost(ctx context.Context, h *host.Host) (*host.
 }
 
 func (mockMgr *mockManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {
-	return errors.New("can't modify instances for mock provider")
+	return nil
 }
 
 // get the status of an instance

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -140,6 +140,10 @@ func (mockMgr *mockManager) SpawnHost(ctx context.Context, h *host.Host) (*host.
 	return h, nil
 }
 
+func (mockMgr *mockManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {
+	return errors.New("can't modify instances for mock provider")
+}
+
 // get the status of an instance
 func (mockMgr *mockManager) GetInstanceStatus(ctx context.Context, host *host.Host) (CloudStatus, error) {
 	l := mockMgr.mutex

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -132,6 +132,10 @@ func (m *openStackManager) SpawnHost(ctx context.Context, h *host.Host) (*host.H
 	return h, nil
 }
 
+func (m *openStackManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {
+	return errors.New("can't modify isntances with openstack provider")
+}
+
 // GetInstanceStatus gets the current operational status of the provisioned host,
 func (m *openStackManager) GetInstanceStatus(ctx context.Context, host *host.Host) (CloudStatus, error) {
 	server, err := m.client.GetInstance(host.Id)

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -133,7 +133,7 @@ func (m *openStackManager) SpawnHost(ctx context.Context, h *host.Host) (*host.H
 }
 
 func (m *openStackManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {
-	return errors.New("can't modify isntances with openstack provider")
+	return errors.New("can't modify instances with openstack provider")
 }
 
 // GetInstanceStatus gets the current operational status of the provisioned host,

--- a/cloud/openstack_util.go
+++ b/cloud/openstack_util.go
@@ -39,6 +39,14 @@ func getSpawnOptions(h *host.Host, s *openStackSettings) servers.CreateOpts {
 		ImageName:      s.ImageName,
 		FlavorName:     s.FlavorName,
 		SecurityGroups: []string{s.SecurityGroup},
-		Metadata:       makeTags(h),
+		Metadata:       makeMapFromTags(makeTags(h)),
 	}
+}
+
+func makeMapFromTags(tags []host.Tag) map[string]string {
+	new := make(map[string]string)
+	for _, tag := range tags {
+		new[tag.Key] = tag.Value
+	}
+	return new
 }

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -44,7 +44,7 @@ type SpawnOptions struct {
 	PublicKey        string
 	TaskId           string
 	Owner            *user.DBUser
-	InstanceTags     map[string]string
+	InstanceTags     []host.Tag
 }
 
 // Validate returns an instance of BadOptionsErr if the SpawnOptions object contains invalid

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -44,6 +44,10 @@ func (staticMgr *staticManager) SpawnHost(context.Context, *host.Host) (*host.Ho
 	return nil, errors.New("cannot start new instances with static provider")
 }
 
+func (staticMgr *staticManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {
+	return errors.New("cannot modify instances with static provider")
+}
+
 // get the status of an instance
 func (staticMgr *staticManager) GetInstanceStatus(ctx context.Context, host *host.Host) (CloudStatus, error) {
 	return StatusRunning, nil

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -123,6 +123,10 @@ func (m *vsphereManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Hos
 	return h, nil
 }
 
+func (m *vsphereManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {
+	return errors.New("can't modify instances for vsphere provider")
+}
+
 // GetInstanceStatus gets the current operational status of the provisioned host,
 func (m *vsphereManager) GetInstanceStatus(ctx context.Context, host *host.Host) (CloudStatus, error) {
 	state, err := m.client.GetPowerState(ctx, host)

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1670,7 +1670,9 @@ func StaleRunningTaskIDs(staleness time.Duration) ([]task.Task, error) {
 // in a HostModifyOptions struct.
 func (h *Host) ModifySpawnHost(opts HostModifyOptions) error {
 	h.DeleteTags(opts.DeleteInstanceTags)
+	grip.Info(h.InstanceTags)
 	h.AddTags(opts.AddInstanceTags)
+	grip.Info(h.InstanceTags)
 	if err := h.SetTags(); err != nil {
 		return errors.Wrap(err, "error modifying spawn host")
 	}
@@ -1681,13 +1683,17 @@ func (h *Host) ModifySpawnHost(opts HostModifyOptions) error {
 // an existing tag if it can be modified.
 func (h *Host) AddTags(tags []Tag) {
 	for _, new := range tags {
+		found := false
 		for i, old := range h.InstanceTags {
 			if old.Key == new.Key && old.CanBeModified {
 				h.InstanceTags[i] = new
+				found = true
 				break
 			}
 		}
-		h.InstanceTags = append(h.InstanceTags, new)
+		if !found {
+			h.InstanceTags = append(h.InstanceTags, new)
+		}
 	}
 }
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1670,9 +1670,7 @@ func StaleRunningTaskIDs(staleness time.Duration) ([]task.Task, error) {
 // in a HostModifyOptions struct.
 func (h *Host) ModifySpawnHost(opts HostModifyOptions) error {
 	h.DeleteTags(opts.DeleteInstanceTags)
-	grip.Info(h.InstanceTags)
 	h.AddTags(opts.AddInstanceTags)
-	grip.Info(h.InstanceTags)
 	if err := h.SetTags(); err != nil {
 		return errors.Wrap(err, "error modifying spawn host")
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1697,8 +1697,7 @@ func (h *Host) DeleteTags(keys []string) {
 	for _, key := range keys {
 		for i, tag := range h.InstanceTags {
 			if tag.Key == key && tag.CanBeModified {
-				h.InstanceTags[len(h.InstanceTags)-1], h.InstanceTags[i] = h.InstanceTags[i], h.InstanceTags[len(h.InstanceTags)-1]
-				h.InstanceTags = h.InstanceTags[:len(h.InstanceTags)-1]
+				h.InstanceTags = append(h.InstanceTags[:i], h.InstanceTags[i+1:]...)
 				break
 			}
 		}

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -22,7 +22,7 @@ type CreateOptions struct {
 	ContainerPoolSettings *evergreen.ContainerPool
 	SpawnOptions          SpawnOptions
 	DockerOptions         DockerOptions
-	InstanceTags          map[string]string
+	InstanceTags          []Tag
 }
 
 // NewIntent creates an IntentHost using the given host settings. An IntentHost is a host that

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3600,3 +3600,22 @@ func TestFindOneByJasperCredentialsID(t *testing.T) {
 		})
 	}
 }
+
+func TestModifySpawnHost(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
+
+	h := &Host{
+		Id: "id",
+		InstanceTags: map[string]string{"key1": "val1"}
+	}
+	assert.NoError(t, h.Insert())
+
+	changes := HostModifyOptions{
+		AddInstanceTags: map[string]string{"key2": "val2"},
+		DeleteInstanceTags: []string{"key1"},
+	}
+	assert.NoError(t, host.ModifySpawnHost(changes))
+	modifiedHost, err := FindOneId(h.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"key2": "val2"}, modifiedHost.InstanceTags)
+}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3603,19 +3603,27 @@ func TestFindOneByJasperCredentialsID(t *testing.T) {
 
 func TestModifySpawnHost(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
-
 	h := &Host{
-		Id:           "id",
-		InstanceTags: []Tag{Tag{Key: "key1", Value: "val1", CanBeModified: true}},
+		Id: "id",
+		InstanceTags: []Tag{
+			Tag{Key: "key1", Value: "val1", CanBeModified: true},
+			Tag{Key: "key2", Value: "val2", CanBeModified: true},
+		},
 	}
 	assert.NoError(t, h.Insert())
 
 	changes := HostModifyOptions{
-		AddInstanceTags:    []Tag{Tag{Key: "key2", Value: "val2", CanBeModified: true}},
+		AddInstanceTags: []Tag{
+			Tag{Key: "key2", Value: "valNew", CanBeModified: true},
+			Tag{Key: "key3", Value: "val3", CanBeModified: true},
+		},
 		DeleteInstanceTags: []string{"key1"},
 	}
 	assert.NoError(t, h.ModifySpawnHost(changes))
 	modifiedHost, err := FindOneId(h.Id)
 	assert.NoError(t, err)
-	assert.Equal(t, []Tag{Tag{Key: "key2", Value: "val2", CanBeModified: true}}, modifiedHost.InstanceTags)
+	assert.Equal(t, []Tag{
+		Tag{Key: "key2", Value: "valNew", CanBeModified: true},
+		Tag{Key: "key3", Value: "val3", CanBeModified: true},
+	}, modifiedHost.InstanceTags)
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3605,16 +3605,16 @@ func TestModifySpawnHost(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 
 	h := &Host{
-		Id: "id",
-		InstanceTags: map[string]string{"key1": "val1"}
+		Id:           "id",
+		InstanceTags: map[string]string{"key1": "val1"},
 	}
 	assert.NoError(t, h.Insert())
 
 	changes := HostModifyOptions{
-		AddInstanceTags: map[string]string{"key2": "val2"},
+		AddInstanceTags:    map[string]string{"key2": "val2"},
 		DeleteInstanceTags: []string{"key1"},
 	}
-	assert.NoError(t, host.ModifySpawnHost(changes))
+	assert.NoError(t, h.ModifySpawnHost(changes))
 	modifiedHost, err := FindOneId(h.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"key2": "val2"}, modifiedHost.InstanceTags)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3606,12 +3606,12 @@ func TestModifySpawnHost(t *testing.T) {
 
 	h := &Host{
 		Id:           "id",
-		InstanceTags: map[string]string{"key1": "val1"},
+		InstanceTags: []Tag{Tag{Key: "key1", Value: "val1", CanBeModified: true}},
 	}
 	assert.NoError(t, h.Insert())
 
 	changes := HostModifyOptions{
-		AddInstanceTags:    map[string]string{"key2": "val2"},
+		AddInstanceTags:    []Tag{Tag{Key: "key2", Value: "val2", CanBeModified: true}},
 		DeleteInstanceTags: []string{"key1"},
 	}
 	assert.NoError(t, h.ModifySpawnHost(changes))

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3617,5 +3617,5 @@ func TestModifySpawnHost(t *testing.T) {
 	assert.NoError(t, h.ModifySpawnHost(changes))
 	modifiedHost, err := FindOneId(h.Id)
 	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{"key2": "val2"}, modifiedHost.InstanceTags)
+	assert.Equal(t, []Tag{Tag{Key: "key2", Value: "val2", CanBeModified: true}}, modifiedHost.InstanceTags)
 }

--- a/operations/before.go
+++ b/operations/before.go
@@ -194,6 +194,19 @@ func requireAtLeastOneBool(flags ...string) cli.BeforeFunc {
 	}
 }
 
+func requireAtLeastOneStringSlice(flags ...string) cli.BeforeFunc {
+	return func(c *cli.Context) error {
+		for idx := range flags {
+			if len(c.StringSlice(flags[idx])) > 0 {
+				return nil
+			}
+		}
+
+		return errors.Errorf("must specify at least one of the following options: %s",
+			strings.Join(flags, ", "))
+	}
+}
+
 func mergeBeforeFuncs(ops ...func(c *cli.Context) error) cli.BeforeFunc {
 	return func(c *cli.Context) error {
 		catcher := grip.NewBasicCatcher()

--- a/operations/host.go
+++ b/operations/host.go
@@ -8,6 +8,7 @@ func Host() cli.Command {
 		Usage: "manage evergreen spawn and build hosts",
 		Subcommands: []cli.Command{
 			hostCreate(),
+			hostModify(),
 			hostlist(),
 			hostTerminate(),
 			hostSetup(),

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -162,6 +162,7 @@ func hostModify() cli.Command {
 				Usage: "key of a single tag to be deleted",
 			},
 		),
+		Before: mergeBeforeFuncs(setPlainLogger, requireHostFlag, requireAtLeastOneStringSlice(addTagFlagName, deleteTagFlagName)),
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().Parent().String(confFlagName)
 			hostID := c.String(hostFlagName)
@@ -187,10 +188,9 @@ func hostModify() cli.Command {
 				AddInstanceTags:    addTags,
 				DeleteInstanceTags: deleteTagSlice,
 			}
-
 			err = client.ModifySpawnHost(ctx, hostID, hostChanges)
 			if err != nil {
-				return errors.Wrap(err, "problem modifying spawn host")
+				return err
 			}
 
 			grip.Infof("Successfully queued changes to spawn host with ID '%s'.", hostID)

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -18,9 +18,9 @@ const (
 )
 
 // makeAWSTags creates and validates a map of supplied instance tags
-func makeAWSTags(tagSlice []string) (map[string]string, error) {
+func makeAWSTags(tagSlice []string) ([]host.Tag, error) {
 	catcher := grip.NewBasicCatcher()
-	tags := make(map[string]string)
+	tagsMap := make(map[string]string)
 	for _, tagString := range tagSlice {
 		pair := strings.Split(tagString, "=")
 		if len(pair) != 2 {
@@ -44,7 +44,13 @@ func makeAWSTags(tagSlice []string) (map[string]string, error) {
 			catcher.Add(errors.Errorf("illegal tag prefix 'aws:'"))
 		}
 
-		tags[key] = value
+		tagsMap[key] = value
+	}
+
+	// Make slice of host.Tag structs from map
+	tags := []host.Tag{}
+	for key, value := range tagsMap {
+		tags = append(tags, host.Tag{Key: key, Value: value, CanBeModified: true})
 	}
 
 	if catcher.HasErrors() {

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -187,6 +187,7 @@ func hostModify() cli.Command {
 				return errors.Wrap(err, "problem modifying spawn host")
 			}
 
+			grip.Infof("Successfully queued changes to spawn host with ID '%s'.", hostID)
 			return nil
 		},
 	}

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -137,10 +137,6 @@ func hostCreate() cli.Command {
 
 }
 
-type hostModifyOptions struct {
-	InstanceTags map[string]string
-}
-
 func hostModify() cli.Command {
 	const (
 		addTagFlagName    = "tag"
@@ -149,7 +145,7 @@ func hostModify() cli.Command {
 
 	return cli.Command{
 		Name:  "modify",
-		Usage: "modify a stopped host",
+		Usage: "modify an existing host",
 		Flags: addHostFlag(
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(addTagFlagName, "t"),

--- a/operations/host_test.go
+++ b/operations/host_test.go
@@ -120,9 +120,17 @@ func TestMakeAWSTags(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		tagSlice := []string{"key1=value1", "key2=value2"}
 		tags, err := makeAWSTags(tagSlice)
-		assert.Equal(t, tags, map[string]string{
-			"key1": "value1",
-			"key2": "value2",
+		assert.Equal(t, tags, []host.Tag{
+			host.Tag{
+				Key:           "key1",
+				Value:         "value1",
+				CanBeModified: true,
+			},
+			host.Tag{
+				Key:           "key2",
+				Value:         "value2",
+				CanBeModified: true,
+			},
 		})
 		assert.NoError(t, err)
 	})

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/manifest"
 	patchmodel "github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -139,6 +140,7 @@ type Communicator interface {
 	// Spawnhost methods
 	//
 	CreateSpawnHost(context.Context, *restmodel.HostRequestOptions) (*restmodel.APIHost, error)
+	ModifySpawnHost(context.Context, string, host.HostModifyOptions) error
 	TerminateSpawnHost(context.Context, string) error
 	ChangeSpawnHostPassword(context.Context, string, string) error
 	ExtendSpawnHostExpiration(context.Context, string, int) error

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -17,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/manifest"
 	patchmodel "github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -363,6 +364,10 @@ func (*Mock) CreateSpawnHost(ctx context.Context, spawnRequest *model.HostReques
 		InstanceTags: spawnRequest.InstanceTags,
 	}
 	return mockHost, nil
+}
+
+func (*Mock) ModifySpawnHost(ctx context.Context, hostID string, changes host.HostModifyOptions) error {
+	return errors.New("(*Mock) ModifySpawnHost is not implemented")
 }
 
 func (*Mock) TerminateSpawnHost(ctx context.Context, hostID string) error {

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -97,6 +97,8 @@ func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, spawnRequest *mo
 	return &spawnHostResp, nil
 }
 
+// ModifySpawnHost will start a job that updates the specified user-spawned host
+// with the modifications passed as a parameter.
 func (c *communicatorImpl) ModifySpawnHost(ctx context.Context, hostID string, changes host.HostModifyOptions) error {
 	info := requestInfo{
 		method:  patch,

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -8,26 +8,26 @@ import (
 
 // APIHost is the model to be returned by the API whenever hosts are fetched.
 type APIHost struct {
-	Id           APIString         `json:"host_id"`
-	HostURL      APIString         `json:"host_url"`
-	Distro       DistroInfo        `json:"distro"`
-	Provisioned  bool              `json:"provisioned"`
-	StartedBy    APIString         `json:"started_by"`
-	Type         APIString         `json:"host_type"`
-	User         APIString         `json:"user"`
-	Status       APIString         `json:"status"`
-	RunningTask  taskInfo          `json:"running_task"`
-	UserHost     bool              `json:"user_host"`
-	InstanceTags map[string]string `json:"instance_tags"`
+	Id           APIString  `json:"host_id"`
+	HostURL      APIString  `json:"host_url"`
+	Distro       DistroInfo `json:"distro"`
+	Provisioned  bool       `json:"provisioned"`
+	StartedBy    APIString  `json:"started_by"`
+	Type         APIString  `json:"host_type"`
+	User         APIString  `json:"user"`
+	Status       APIString  `json:"status"`
+	RunningTask  taskInfo   `json:"running_task"`
+	UserHost     bool       `json:"user_host"`
+	InstanceTags []host.Tag `json:"instance_tags"`
 }
 
 // HostPostRequest is a struct that holds the format of a POST request to /hosts
 type HostRequestOptions struct {
-	DistroID     string            `json:"distro"`
-	TaskID       string            `json:"task"`
-	KeyName      string            `json:"keyname"`
-	UserData     string            `json:"userdata"`
-	InstanceTags map[string]string `json:"instance_tags"`
+	DistroID     string     `json:"distro"`
+	TaskID       string     `json:"task"`
+	KeyName      string     `json:"keyname"`
+	UserData     string     `json:"userdata"`
+	InstanceTags []host.Tag `json:"instance_tags"`
 }
 
 type DistroInfo struct {

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -16,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -164,6 +166,8 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for find() by distro id '%s'", h.hostID))
 	}
 
+	grip.Info(message.Fields{"message": "found host", "host": foundHost})
+
 	// Check if tags are valid
 	if err := validateTags(foundHost, h.AddInstanceTags, h.DeleteInstanceTags); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Invalid tag modifications"))
@@ -174,7 +178,8 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 		AddInstanceTags:    h.AddInstanceTags,
 		DeleteInstanceTags: h.DeleteInstanceTags,
 	}
-	modifyJob := units.NewSpawnhostModifyJob(foundHost, changes)
+	ts := util.GetUTCSecond(time.Now()).Format(tsFormat)
+	modifyJob := units.NewSpawnhostModifyJob(foundHost, changes, ts)
 	if err = queue.Put(ctx, modifyJob); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Error creating spawnhost modify job"))
 	}

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -200,6 +200,11 @@ func validateTags(h *host.Host, toAdd []host.Tag, toDelete []string) error {
 		if ok && !old.CanBeModified {
 			catcher.Add(errors.Errorf("tag '%s' cannot be modified", tag.Key))
 		}
+
+		// Ensure that new tags can be modified (theoretically should always be the case).
+		if !tag.CanBeModified {
+			catcher.Add(errors.Errorf("programmer error: new tag '%s=%s' should be able to be modified", tag.Key, tag.Value))
+		}
 	}
 	return catcher.Resolve()
 }

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -178,35 +178,6 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewJSONResponse(struct{}{})
 }
 
-/*
-UNUSED HELPER METHOD -- this route previously modified the status of a single host
-func (h *hostModifyHandler) modifyHostStatus(ctx context.Context, foundHost *host.Host, user *user.DBUser) gimlet.Responder {
-	if foundHost.Status == evergreen.HostTerminated {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    fmt.Sprintf("Host '%s' is terminated; its status cannot be changed", foundHost.Id),
-		})
-	}
-
-	if h.Status == evergreen.HostTerminated {
-		if err := h.sc.TerminateHost(ctx, foundHost, user.Id); err != nil {
-			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-				StatusCode: http.StatusInternalServerError,
-				Message:    err.Error(),
-			})
-		}
-	} else {
-		if err := h.sc.SetHostStatus(foundHost, h.Status, user.Id); err != nil {
-			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-				StatusCode: http.StatusInternalServerError,
-				Message:    err.Error(),
-			})
-		}
-	}
-	return nil
-}
-*/
-
 ////////////////////////////////////////////////////////////////////////
 //
 // GET /rest/v2/hosts/{host_id}

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -17,7 +16,6 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -166,8 +164,6 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for find() by distro id '%s'", h.hostID))
 	}
 
-	grip.Info(message.Fields{"message": "found host", "host": foundHost})
-
 	// Check if tags are valid
 	if err := validateTags(foundHost, h.AddInstanceTags, h.DeleteInstanceTags); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Invalid tag modifications"))
@@ -178,7 +174,7 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 		AddInstanceTags:    h.AddInstanceTags,
 		DeleteInstanceTags: h.DeleteInstanceTags,
 	}
-	ts := util.GetUTCSecond(time.Now()).Format(tsFormat)
+	ts := util.RoundPartOfMinute(1).Format(tsFormat)
 	modifyJob := units.NewSpawnhostModifyJob(foundHost, changes, ts)
 	if err = queue.Put(ctx, modifyJob); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Error creating spawnhost modify job"))

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -8,9 +8,11 @@ import (
 	"strconv"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
@@ -118,25 +120,27 @@ func (h *hostsChangeStatusesHandler) Run(ctx context.Context) gimlet.Responder {
 //
 // PATCH /rest/v2/hosts/{host_id}
 
-type hostChangeStatusHandler struct {
-	Status string
+type hostModifyHandler struct {
 	hostID string
 	sc     data.Connector
+
+	AddInstanceTags    map[string]string
+	DeleteInstanceTags []string
 }
 
-func makeChangeHostStatus(sc data.Connector) gimlet.RouteHandler {
-	return &hostChangeStatusHandler{
+func makeHostModifyRouteManager(sc data.Connector) gimlet.RouteHandler {
+	return &hostModifyHandler{
 		sc: sc,
 	}
 }
 
-func (h *hostChangeStatusHandler) Factory() gimlet.RouteHandler {
-	return &hostChangeStatusHandler{
+func (h *hostModifyHandler) Factory() gimlet.RouteHandler {
+	return &hostModifyHandler{
 		sc: h.sc,
 	}
 }
 
-func (h *hostChangeStatusHandler) Parse(ctx context.Context, r *http.Request) error {
+func (h *hostModifyHandler) Parse(ctx context.Context, r *http.Request) error {
 	h.hostID = gimlet.GetVars(r)["host_id"]
 	body := util.NewRequestReader(r)
 	defer body.Close()
@@ -145,20 +149,38 @@ func (h *hostChangeStatusHandler) Parse(ctx context.Context, r *http.Request) er
 		return errors.Wrap(err, "Argument read error")
 	}
 
-	if !util.StringSliceContains(evergreen.ValidUserSetStatus, h.Status) {
-		return fmt.Errorf("Invalid host status '%s' for host '%s'", h.Status, h.hostID)
-	}
-
 	return nil
 }
 
-func (h *hostChangeStatusHandler) Run(ctx context.Context) gimlet.Responder {
+func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
+	env := evergreen.GetEnvironment()
+	queue := env.RemoteQueue()
+
+	// Find host to be modified
 	foundHost, err := h.sc.FindHostByIdWithOwner(h.hostID, user)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for find() by distro id '%s'", h.hostID))
 	}
 
+	changes := host.HostModifyOptions{
+		AddInstanceTags:    h.AddInstanceTags,
+		DeleteInstanceTags: h.DeleteInstanceTags,
+	}
+
+	// Create new spawnhost modify job
+	modifyJob := units.NewSpawnhostModifyJob(foundHost, changes)
+	err = queue.Put(ctx, modifyJob)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Error creating spawnhost modify job"))
+	}
+
+	return gimlet.NewJSONResponse(struct{}{})
+}
+
+/*
+UNUSED HELPER METHOD -- this route previously modified the status of a single host
+func (h *hostModifyHandler) modifyHostStatus(ctx context.Context, foundHost *host.Host, user *user.DBUser) gimlet.Responder {
 	if foundHost.Status == evergreen.HostTerminated {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -167,29 +189,23 @@ func (h *hostChangeStatusHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	if h.Status == evergreen.HostTerminated {
-		if err = h.sc.TerminateHost(ctx, foundHost, user.Id); err != nil {
+		if err := h.sc.TerminateHost(ctx, foundHost, user.Id); err != nil {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 				StatusCode: http.StatusInternalServerError,
 				Message:    err.Error(),
 			})
 		}
-
 	} else {
-		if err = h.sc.SetHostStatus(foundHost, h.Status, user.Id); err != nil {
+		if err := h.sc.SetHostStatus(foundHost, h.Status, user.Id); err != nil {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 				StatusCode: http.StatusInternalServerError,
 				Message:    err.Error(),
 			})
 		}
 	}
-
-	host := &model.APIHost{}
-	if err = host.BuildFromService(foundHost); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "API Error converting from host.Host to model.APIHost"))
-	}
-
-	return gimlet.NewJSONResponse(host)
+	return nil
 }
+*/
 
 ////////////////////////////////////////////////////////////////////////
 //

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -170,8 +170,7 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 
 	// Create new spawnhost modify job
 	modifyJob := units.NewSpawnhostModifyJob(foundHost, changes)
-	err = queue.Put(ctx, modifyJob)
-	if err != nil {
+	if err = queue.Put(ctx, modifyJob); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Error creating spawnhost modify job"))
 	}
 

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/util"
@@ -24,11 +25,11 @@ func makeSpawnHostCreateRoute(sc data.Connector) gimlet.RouteHandler {
 }
 
 type hostPostHandler struct {
-	Task         string            `json:"task_id"`
-	Distro       string            `json:"distro"`
-	KeyName      string            `json:"keyname"`
-	UserData     string            `json:"userdata"`
-	InstanceTags map[string]string `json:"instance_tags"`
+	Task         string     `json:"task_id"`
+	Distro       string     `json:"distro"`
+	KeyName      string     `json:"keyname"`
+	UserData     string     `json:"userdata"`
+	InstanceTags []host.Tag `json:"instance_tags"`
 
 	sc data.Connector
 }

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -44,8 +44,12 @@ func TestHostPostHandler(t *testing.T) {
 	assert.NotNil(resp)
 	assert.Equal(http.StatusOK, resp.Status())
 
-	h.InstanceTags = map[string]string{
-		"key": "value",
+	h.InstanceTags = []host.Tag{
+		host.Tag{
+			Key:           "key",
+			Value:         "value",
+			CanBeModified: true,
+		},
 	}
 	resp = h.Run(ctx)
 	assert.NotNil(resp)
@@ -63,5 +67,5 @@ func TestHostPostHandler(t *testing.T) {
 	assert.Empty(h1.InstanceTags)
 
 	h2 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[2]
-	assert.Equal(map[string]string{"key": "value"}, h2.InstanceTags)
+	assert.Equal([]host.Tag{host.Tag{Key: "key", Value: "value", CanBeModified: true}}, h2.InstanceTags)
 }

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -176,7 +176,7 @@ func (s *HostsChangeStatusesSuite) TestRunWithInvalidHost() {
 ////////////////////////////////////////////////////////////////////////
 
 type HostChangeStatusSuite struct {
-	route *hostChangeStatusHandler
+	route *hostModifyHandler
 	sc    *data.MockConnector
 
 	suite.Suite
@@ -188,7 +188,7 @@ func TestHostChangeStatusSuite(t *testing.T) {
 
 func (s *HostChangeStatusSuite) SetupTest() {
 	s.sc = getMockHostsConnector()
-	s.route = makeChangeHostStatus(s.sc).(*hostChangeStatusHandler)
+	s.route = makeHostModifyRouteManager(s.sc).(*hostModifyHandler)
 }
 
 func (s *HostChangeStatusSuite) TestParseValidStatus() {
@@ -222,11 +222,11 @@ func (s *HostChangeStatusSuite) TestParseMissingStatus() {
 	req, _ := http.NewRequest("PATCH", "http://example.com/api/rest/v2/hosts/host1", bytes.NewBuffer(json))
 	err := s.route.Parse(ctx, req)
 	s.Error(err)
-	s.EqualError(err, "Argument read error: error attempting to unmarshal into *route.hostChangeStatusHandler: unexpected end of JSON input")
+	s.EqualError(err, "Argument read error: error attempting to unmarshal into *route.hostModifyHandler: unexpected end of JSON input")
 }
 
 func (s *HostChangeStatusSuite) TestRunHostValidStatusChange() {
-	h := s.route.Factory().(*hostChangeStatusHandler)
+	h := s.route.Factory().(*hostModifyHandler)
 	h.hostID = "host4"
 	h.Status = evergreen.HostTerminated
 
@@ -237,7 +237,7 @@ func (s *HostChangeStatusSuite) TestRunHostValidStatusChange() {
 }
 
 func (s *HostChangeStatusSuite) TestRunHostNotStartedByUser() {
-	h := s.route.Factory().(*hostChangeStatusHandler)
+	h := s.route.Factory().(*hostModifyHandler)
 	h.hostID = "host4"
 	h.Status = evergreen.HostTerminated
 
@@ -248,7 +248,7 @@ func (s *HostChangeStatusSuite) TestRunHostNotStartedByUser() {
 }
 
 func (s *HostChangeStatusSuite) TestRunSuperUserSetStatusAnyHost() {
-	h := s.route.Factory().(*hostChangeStatusHandler)
+	h := s.route.Factory().(*hostModifyHandler)
 	h.hostID = "host4"
 	h.Status = evergreen.HostTerminated
 
@@ -259,7 +259,7 @@ func (s *HostChangeStatusSuite) TestRunSuperUserSetStatusAnyHost() {
 }
 
 func (s *HostChangeStatusSuite) TestRunTerminatedOnTerminatedHost() {
-	h := s.route.Factory().(*hostChangeStatusHandler)
+	h := s.route.Factory().(*hostModifyHandler)
 	h.hostID = "host1"
 	h.Status = evergreen.HostTerminated
 
@@ -270,7 +270,7 @@ func (s *HostChangeStatusSuite) TestRunTerminatedOnTerminatedHost() {
 }
 
 func (s *HostChangeStatusSuite) TestRunHostRunningOnTerminatedHost() {
-	h := s.route.Factory().(*hostChangeStatusHandler)
+	h := s.route.Factory().(*hostModifyHandler)
 	h.hostID = "host1"
 	h.Status = evergreen.HostRunning
 
@@ -281,7 +281,7 @@ func (s *HostChangeStatusSuite) TestRunHostRunningOnTerminatedHost() {
 }
 
 func (s *HostChangeStatusSuite) TestRunHostQuarantinedOnTerminatedHost() {
-	h := s.route.Factory().(*hostChangeStatusHandler)
+	h := s.route.Factory().(*hostModifyHandler)
 	h.hostID = "host1"
 	h.Status = evergreen.HostQuarantined
 
@@ -292,7 +292,7 @@ func (s *HostChangeStatusSuite) TestRunHostQuarantinedOnTerminatedHost() {
 }
 
 func (s *HostChangeStatusSuite) TestRunHostDecommissionedOnTerminatedHost() {
-	h := s.route.Factory().(*hostChangeStatusHandler)
+	h := s.route.Factory().(*hostModifyHandler)
 	h.hostID = "host1"
 	h.Status = evergreen.HostDecommissioned
 
@@ -303,7 +303,7 @@ func (s *HostChangeStatusSuite) TestRunHostDecommissionedOnTerminatedHost() {
 }
 
 func (s *HostChangeStatusSuite) TestRunWithInvalidHost() {
-	h := s.route.Factory().(*hostChangeStatusHandler)
+	h := s.route.Factory().(*hostModifyHandler)
 	h.hostID = "Doesn't exist"
 	h.Status = evergreen.HostDecommissioned
 

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -79,7 +79,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/hosts").Version(2).Post().Wrap(checkUser).RouteHandler(makeSpawnHostCreateRoute(sc))
 	app.AddRoute("/hosts").Version(2).Patch().Wrap(superUser).RouteHandler(makeChangeHostsStatuses(sc))
 	app.AddRoute("/hosts/{host_id}").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetHostByID(sc))
-	app.AddRoute("/hosts/{host_id}").Version(2).Patch().Wrap(checkUser).RouteHandler(makeChangeHostStatus(sc))
+	app.AddRoute("/hosts/{host_id}").Version(2).Patch().Wrap(checkUser).RouteHandler(makeHostModifyRouteManager(sc))
 	app.AddRoute("/hosts/{host_id}/change_password").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostChangePassword(sc, env))
 	app.AddRoute("/hosts/{host_id}/extend_expiration").Version(2).Post().Wrap(checkUser).RouteHandler(makeExtendHostExpiration(sc))
 	app.AddRoute("/hosts/{host_id}/terminate").Version(2).Post().Wrap(checkUser).RouteHandler(makeTerminateHostRoute(sc))

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -101,14 +101,14 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 	authedUser := MustHaveUser(r)
 
 	putParams := struct {
-		Task          string            `json:"task_id"`
-		Distro        string            `json:"distro"`
-		KeyName       string            `json:"key_name"`
-		PublicKey     string            `json:"public_key"`
-		SaveKey       bool              `json:"save_key"`
-		UserData      string            `json:"userdata"`
-		UseTaskConfig bool              `json:"use_task_config"`
-		InstanceTags  map[string]string `json:"instance_tags"`
+		Task          string     `json:"task_id"`
+		Distro        string     `json:"distro"`
+		KeyName       string     `json:"key_name"`
+		PublicKey     string     `json:"public_key"`
+		SaveKey       bool       `json:"save_key"`
+		UserData      string     `json:"userdata"`
+		UseTaskConfig bool       `json:"use_task_config"`
+		InstanceTags  []host.Tag `json:"instance_tags"`
 	}{}
 
 	err := util.ReadJSONInto(util.NewRequestReader(r), &putParams)

--- a/units/spawnhost_modify.go
+++ b/units/spawnhost_modify.go
@@ -1,0 +1,85 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/dependency"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/pkg/errors"
+)
+
+const (
+	spawnhostModifyName = "spawnhost-modify"
+)
+
+func init() {
+	registry.AddJobType(spawnhostModifyName,
+		func() amboy.Job { return makeSpawnhostModifyJob() })
+}
+
+type spawnhostModifyJob struct {
+	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
+	host     *host.Host
+	env      evergreen.Environment
+
+	changes host.HostModifyOptions
+}
+
+func makeSpawnhostModifyJob() *spawnhostModifyJob {
+	j := &spawnhostModifyJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    spawnhostModifyName,
+				Version: 0,
+			},
+		},
+	}
+	j.SetDependency(dependency.NewAlways())
+	return j
+}
+
+func NewSpawnhostModifyJob(h *host.Host, changes host.HostModifyOptions) amboy.Job {
+	j := makeSpawnhostModifyJob()
+	j.SetID(fmt.Sprintf("%s.%s", spawnhostModifyName, h.Id))
+	j.changes = changes
+	return j
+}
+
+func (j *spawnhostModifyJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+
+	mgrOpts := cloud.ManagerOpts{
+		Provider: j.host.Provider,
+		Region:   cloud.GetRegion(j.host.Distro),
+	}
+	cloudManager, err := cloud.GetManager(ctx, mgrOpts, j.env.Settings())
+	if err != nil {
+		j.AddError(errors.Wrap(err, "error getting cloud manager for spawnhost modify job"))
+		return
+	}
+
+	// Modify spawnhost using the cloud manager
+	if err := cloudManager.ModifyHost(ctx, j.host, j.changes); err != nil {
+		j.AddError(errors.Wrap(err, "error modifying spawnhost using cloud manager"))
+		return
+	}
+
+	// Push changes to the database
+	if err := j.host.ModifySpawnHost(j.changes); err != nil {
+		j.AddError(errors.Wrap(err, "error updating spawnhost in database after modify"))
+		return
+	}
+
+	return
+}

--- a/units/spawnhost_modify.go
+++ b/units/spawnhost_modify.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/evergreen-ci/evergreen"
-
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"

--- a/units/spawnhost_modify_test.go
+++ b/units/spawnhost_modify_test.go
@@ -1,0 +1,50 @@
+package units
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpawnhostModifyJob(t *testing.T) {
+	config := testutil.TestConfig()
+	assert.NoError(t, evergreen.UpdateConfig(config))
+	assert.NoError(t, db.ClearCollections(host.Collection))
+	h := host.Host{
+		Id:           "hostID",
+		Provider:     evergreen.ProviderNameMock,
+		InstanceTags: map[string]string{"key1": "value1"},
+		Distro:       distro.Distro{Provider: evergreen.ProviderNameMock},
+	}
+	assert.NoError(t, h.Insert())
+
+	changes := host.HostModifyOptions{
+		AddInstanceTags:    map[string]string{"key2": "value2"},
+		DeleteInstanceTags: []string{"key1"},
+	}
+
+	j := makeSpawnhostModifyJob()
+	j.host = &h
+	j.changes = changes
+
+	ctx := context.Background()
+	env := &mock.Environment{}
+	j.env = env
+	assert.NoError(t, env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+
+	j.Run(ctx)
+	assert.NoError(t, j.Error())
+	assert.True(t, j.Status().Completed)
+
+	modifiedHost, err := host.FindOneId(h.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"key2": "value2"}, modifiedHost.InstanceTags)
+}

--- a/units/spawnhost_modify_test.go
+++ b/units/spawnhost_modify_test.go
@@ -2,15 +2,15 @@ package units
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,16 +43,10 @@ func TestSpawnhostModifyJob(t *testing.T) {
 		DeleteInstanceTags: []string{"key1"},
 	}
 
-	j := makeSpawnhostModifyJob()
-	j.host = &h
-	j.changes = changes
+	ts := util.GetUTCSecond(time.Now()).Format(tsFormat)
+	j := NewSpawnhostModifyJob(&h, changes, ts)
 
-	ctx := context.Background()
-	env := &mock.Environment{}
-	j.env = env
-	assert.NoError(t, env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
-
-	j.Run(ctx)
+	j.Run(context.Background())
 	assert.NoError(t, j.Error())
 	assert.True(t, j.Status().Completed)
 

--- a/units/spawnhost_modify_test.go
+++ b/units/spawnhost_modify_test.go
@@ -19,15 +19,27 @@ func TestSpawnhostModifyJob(t *testing.T) {
 	assert.NoError(t, evergreen.UpdateConfig(config))
 	assert.NoError(t, db.ClearCollections(host.Collection))
 	h := host.Host{
-		Id:           "hostID",
-		Provider:     evergreen.ProviderNameMock,
-		InstanceTags: map[string]string{"key1": "value1"},
-		Distro:       distro.Distro{Provider: evergreen.ProviderNameMock},
+		Id:       "hostID",
+		Provider: evergreen.ProviderNameMock,
+		InstanceTags: []host.Tag{
+			host.Tag{
+				Key:           "key1",
+				Value:         "value1",
+				CanBeModified: true,
+			},
+		},
+		Distro: distro.Distro{Provider: evergreen.ProviderNameMock},
 	}
 	assert.NoError(t, h.Insert())
 
 	changes := host.HostModifyOptions{
-		AddInstanceTags:    map[string]string{"key2": "value2"},
+		AddInstanceTags: []host.Tag{
+			host.Tag{
+				Key:           "key2",
+				Value:         "value2",
+				CanBeModified: true,
+			},
+		},
 		DeleteInstanceTags: []string{"key1"},
 	}
 
@@ -46,5 +58,5 @@ func TestSpawnhostModifyJob(t *testing.T) {
 
 	modifiedHost, err := host.FindOneId(h.Id)
 	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{"key2": "value2"}, modifiedHost.InstanceTags)
+	assert.Equal(t, []host.Tag{host.Tag{Key: "key2", Value: "value2", CanBeModified: true}}, modifiedHost.InstanceTags)
 }

--- a/units/spawnhost_modify_test.go
+++ b/units/spawnhost_modify_test.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -43,7 +42,7 @@ func TestSpawnhostModifyJob(t *testing.T) {
 		DeleteInstanceTags: []string{"key1"},
 	}
 
-	ts := util.GetUTCSecond(time.Now()).Format(tsFormat)
+	ts := util.RoundPartOfMinute(1).Format(tsFormat)
 	j := NewSpawnhostModifyJob(&h, changes, ts)
 
 	j.Run(context.Background())

--- a/util/time.go
+++ b/util/time.go
@@ -130,14 +130,3 @@ func GetUTCHour(date time.Time) time.Time {
 	hour := date.Hour()
 	return time.Date(year, month, day, hour, 0, 0, 0, time.UTC)
 }
-
-func GetUTCSecond(date time.Time) time.Time {
-	// Convert to UTC.
-	date = date.In(time.UTC)
-	// Create a new time.Time for the beginning of the second.
-	year, month, day := date.Date()
-	hour := date.Hour()
-	minute := date.Minute()
-	second := date.Second()
-	return time.Date(year, month, day, hour, minute, second, 0, time.UTC)
-}

--- a/util/time.go
+++ b/util/time.go
@@ -130,3 +130,14 @@ func GetUTCHour(date time.Time) time.Time {
 	hour := date.Hour()
 	return time.Date(year, month, day, hour, 0, 0, 0, time.UTC)
 }
+
+func GetUTCSecond(date time.Time) time.Time {
+	// Convert to UTC.
+	date = date.In(time.UTC)
+	// Create a new time.Time for the beginning of the second.
+	year, month, day := date.Date()
+	hour := date.Hour()
+	minute := date.Minute()
+	second := date.Second()
+	return time.Date(year, month, day, hour, minute, second, 0, time.UTC)
+}


### PR DESCRIPTION
This creates a new modify host command for spawn host, that currently supports adding and removing tags with the following example command (and will eventually support changing instance sizes, types, etc):

evergreen host modify --host <HOST_ID> --delete-tag key1 --tag key2=value2 --tag key3=value3

This involved creating a new job triggered by a patch request to /hosts/hostID that calls a new ModifyHost method on the Cloud Manager, which is currently only implemented for EC2 instances.

Note: there was an existing hostChangeStatusHandler (separate from hostChangeStatusesHandler) on the patch route I wanted to use, and after discussing with Brian and determining that we don't use that route anywhere, we decided that we probably don't need to keep it around? Please let me know if there's reason to keep it.