### PR TITLE
EVG-6666 Put provisioning-create-host in its own queue

### DIFF
--- a/operations/service.go
+++ b/operations/service.go
@@ -90,8 +90,8 @@ func startSystemCronJobs(ctx context.Context, env evergreen.Environment) error {
 		return errors.WithStack(queue.Put(ctx, units.NewCronRemoteFifteenMinuteJob()))
 	})
 	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), 24*time.Hour, util.RoundPartOfDay(0), opts, units.PopulateJasperDeployJobs(env))
+
 	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), 3*time.Hour, util.RoundPartOfHour(0), opts, units.PopulateCacheHistoricalTestDataJob(6))
-	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), time.Minute, util.RoundPartOfMinute(0), opts, units.PopulateHostCreationJobs(env, 0))
 
 	////////////////////////////////////////////////////////////////////////
 	//

--- a/operations/service.go
+++ b/operations/service.go
@@ -90,8 +90,8 @@ func startSystemCronJobs(ctx context.Context, env evergreen.Environment) error {
 		return errors.WithStack(queue.Put(ctx, units.NewCronRemoteFifteenMinuteJob()))
 	})
 	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), 24*time.Hour, util.RoundPartOfDay(0), opts, units.PopulateJasperDeployJobs(env))
-
 	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), 3*time.Hour, util.RoundPartOfHour(0), opts, units.PopulateCacheHistoricalTestDataJob(6))
+	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), time.Minute, util.RoundPartOfMinute(0), opts, units.PopulateHostCreationJobs(env, 0))
 
 	////////////////////////////////////////////////////////////////////////
 	//

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -48,7 +48,6 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 	}
 
 	ops := []amboy.QueueOperation{
-		PopulateHostCreationJobs(j.env, 0),
 		PopulateIdleHostJobs(j.env),
 		PopulateHostTerminationJobs(j.env),
 		PopulateHostMonitoring(j.env),

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -76,11 +76,9 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 	hcqueue, err := j.env.RemoteQueueGroup().Get(hcctx, "service.host.create")
 	if err != nil {
 		j.AddError(errors.Wrap(err, "error getting host create queue"))
+		return
 	}
-	if ctx.Err() != nil {
-		j.AddError(errors.New("operation aborted"))
-	}
-	catcher.Add(PopulateHostCreationJobs(j.env, 0)(hcctx, hcqueue))
+	catcher.Add(PopulateHostCreationJobs(j.env, 0)(ctx, hcqueue))
 
 	j.ErrorCount = catcher.Len()
 

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -80,8 +80,7 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 	if ctx.Err() != nil {
 		j.AddError(errors.New("operation aborted"))
 	}
-	op := amboy.QueueOperation(PopulateHostCreationJobs(j.env, 0))
-	catcher.Add(op(hcctx, hcqueue))
+	catcher.Add(PopulateHostCreationJobs(j.env, 0)(hcctx, hcqueue))
 
 	j.ErrorCount = catcher.Len()
 

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -75,7 +75,7 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 	hcctx, _ := j.env.Context()
 	hcqueue, err := j.env.RemoteQueueGroup().Get(hcctx, "service.host.create")
 	if err != nil {
-		j.AddError(errors.Wrap(err, "error creating host create queue"))
+		j.AddError(errors.Wrap(err, "error getting host create queue"))
 	}
 	if ctx.Err() != nil {
 		j.AddError(errors.New("operation aborted"))


### PR DESCRIPTION
This pull request just moves provisioning create host jobs to their own queue so other jobs don't get blocked behind them. Sam walked me through most of these simple changes. 