### PR TITLE
EVG-6649 Use config from version if available

### DIFF
--- a/model/context.go
+++ b/model/context.go
@@ -79,7 +79,7 @@ func (ctx *Context) GetProject() (*Project, error) {
 		return nil, errors.Wrap(err, "problem finding project")
 	}
 
-	ctx.project, err = FindProject("", pref)
+	ctx.project, err = FindLastKnownGoodProject(pref.Identifier)
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding project")
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -30,7 +30,6 @@ type ProjectRef struct {
 	RemotePath         string `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
 	Identifier         string `bson:"identifier" json:"identifier" yaml:"identifier"`
 	DisplayName        string `bson:"display_name" json:"display_name" yaml:"display_name"`
-	LocalConfig        string `bson:"local_config" json:"local_config" yaml:"local_config"`
 	DeactivatePrevious bool   `bson:"deactivate_previous" json:"deactivate_previous" yaml:"deactivate_previous"`
 
 	// TracksPushEvents, if true indicates that Repotracker is triggered by
@@ -137,7 +136,6 @@ var (
 	ProjectRefDeactivatePreviousKey = bsonutil.MustHaveTag(ProjectRef{}, "DeactivatePrevious")
 	ProjectRefRemotePathKey         = bsonutil.MustHaveTag(ProjectRef{}, "RemotePath")
 	ProjectRefTrackedKey            = bsonutil.MustHaveTag(ProjectRef{}, "Tracked")
-	ProjectRefLocalConfig           = bsonutil.MustHaveTag(ProjectRef{}, "LocalConfig")
 	ProjectRefRepotrackerError      = bsonutil.MustHaveTag(ProjectRef{}, "RepotrackerError")
 	ProjectRefFilesIgnoredFromCache = bsonutil.MustHaveTag(ProjectRef{}, "FilesIgnoredFromCache")
 	ProjectRefDisabledStatsCache    = bsonutil.MustHaveTag(ProjectRef{}, "DisabledStatsCache")
@@ -470,7 +468,6 @@ func (projectRef *ProjectRef) Upsert() error {
 				ProjectRefTrackedKey:            projectRef.Tracked,
 				ProjectRefRemotePathKey:         projectRef.RemotePath,
 				ProjectRefTrackedKey:            projectRef.Tracked,
-				ProjectRefLocalConfig:           projectRef.LocalConfig,
 				ProjectRefRepotrackerError:      projectRef.RepotrackerError,
 				ProjectRefFilesIgnoredFromCache: projectRef.FilesIgnoredFromCache,
 				ProjectRefDisabledStatsCache:    projectRef.DisabledStatsCache,

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -23,18 +23,11 @@ import (
 func TestFindProject(t *testing.T) {
 
 	Convey("When finding a project", t, func() {
-
-		Convey("an error should be thrown if the project ref is nil", func() {
-			project, err := FindProject("", nil)
-			So(err, ShouldNotBeNil)
-			So(project, ShouldBeNil)
-		})
-
 		Convey("an error should be thrown if the project ref's identifier is nil", func() {
 			projRef := &ProjectRef{
 				Identifier: "",
 			}
-			project, err := FindProject("", projRef)
+			project, err := FindLastKnownGoodProject(projRef.Identifier)
 			So(err, ShouldNotBeNil)
 			So(project, ShouldBeNil)
 		})
@@ -56,7 +49,7 @@ func TestFindProject(t *testing.T) {
 				Branch:     "fakebranch",
 			}
 			require.NoError(t, v.Insert(), "failed to insert test version: %v", v)
-			_, err := FindProject("", p)
+			_, err := FindLastKnownGoodProject(p.Identifier)
 			So(err, ShouldBeNil)
 
 		})

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -332,7 +332,7 @@ func getStepback(taskId string) (bool, error) {
 		return false, errors.Wrapf(err, "problem finding task %s", taskId)
 	}
 
-	project, err := FindProjectFromTask(t)
+	project, err := FindProjectFromVersionID(t.Version)
 	if err != nil {
 		return false, errors.WithStack(err)
 	}
@@ -844,18 +844,7 @@ func doRestartFailedTasks(tasks []task.Task, user string, results RestartResults
 	var tasksErrored []string
 
 	for _, t := range tasks {
-		projectRef, err := FindOneProjectRef(t.Project)
-		if err != nil {
-			tasksErrored = append(tasksErrored, t.Id)
-			grip.Error(message.Fields{
-				"task":    t.Id,
-				"status":  "failed",
-				"message": "error retrieving project ref",
-				"error":   err.Error(),
-			})
-			continue
-		}
-		p, err := FindProject(t.Revision, projectRef)
+		p, err := FindProjectFromVersionID(t.Version)
 		if err != nil || p == nil {
 			tasksErrored = append(tasksErrored, t.Id)
 			grip.Error(message.Fields{

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -612,6 +612,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 				Activated:   false,
 				BuildId:     b.Id,
 				Project:     "sample",
+				Version:     b.Version,
 			}
 			ref := &ProjectRef{
 				Identifier: "sample",
@@ -812,6 +813,7 @@ func TestMarkEnd(t *testing.T) {
 		BuildId:     b.Id,
 		Project:     "sample",
 		Status:      evergreen.TaskStarted,
+		Version:     b.Version,
 	}
 
 	b.Tasks = []build.TaskCache{
@@ -909,6 +911,7 @@ func TestTryResetTask(t *testing.T) {
 				Execution:   1,
 				Project:     "sample",
 				Status:      evergreen.TaskSucceeded,
+				Version:     b.Version,
 			}
 			otherTask := &task.Task{
 				Id:          "testtwo",
@@ -918,6 +921,7 @@ func TestTryResetTask(t *testing.T) {
 				Execution:   1,
 				Project:     "sample",
 				Status:      evergreen.TaskSucceeded,
+				Version:     b.Version,
 			}
 			detail := &apimodels.TaskEndDetail{
 				Status: evergreen.TaskFailed,
@@ -986,6 +990,7 @@ func TestTryResetTask(t *testing.T) {
 				Execution:   evergreen.MaxTaskExecution,
 				Project:     "sample",
 				Status:      evergreen.TaskSucceeded,
+				Version:     b.Version,
 			}
 			detail := &apimodels.TaskEndDetail{
 				Status: evergreen.TaskFailed,
@@ -998,6 +1003,7 @@ func TestTryResetTask(t *testing.T) {
 				Execution:   evergreen.MaxTaskExecution,
 				Project:     "sample",
 				Status:      evergreen.TaskSucceeded,
+				Version:     b.Version,
 			}
 			b.Tasks = []build.TaskCache{
 				{
@@ -1058,6 +1064,7 @@ func TestTryResetTask(t *testing.T) {
 			Status:         evergreen.TaskSucceeded,
 			DisplayOnly:    true,
 			ExecutionTasks: []string{"execTask"},
+			Version:        b.Version,
 		}
 		So(dt.Insert(), ShouldBeNil)
 		t1 := &task.Task{
@@ -1065,6 +1072,7 @@ func TestTryResetTask(t *testing.T) {
 			Activated: true,
 			BuildId:   b.Id,
 			Status:    evergreen.TaskSucceeded,
+			Version:   b.Version,
 		}
 		So(t1.Insert(), ShouldBeNil)
 
@@ -1364,7 +1372,11 @@ func TestMarkDispatched(t *testing.T) {
 }
 
 func TestGetStepback(t *testing.T) {
-	config := `
+	Convey("When the project has a stepback policy set to true", t, func() {
+		require.NoError(t, db.ClearCollections(ProjectRefCollection, task.Collection, build.Collection, VersionCollection),
+			"Error clearing collections")
+
+		config := `
 stepback: true
 tasks:
  - name: true
@@ -1378,20 +1390,14 @@ buildvariants:
  - name: sbfalse
    stepback: false
 `
-
-	Convey("When the project has a stepback policy set to true", t, func() {
-		require.NoError(t, db.ClearCollections(ProjectRefCollection, task.Collection, build.Collection, VersionCollection),
-			"Error clearing collections")
-
-		ref := &ProjectRef{
-			Identifier:  "sample",
-			LocalConfig: config,
+		ver := &Version{
+			Id:     "version_id",
+			Config: config,
 		}
-
-		So(ref.Insert(), ShouldBeNil)
+		So(ver.Insert(), ShouldBeNil)
 
 		Convey("if the task does not override the setting", func() {
-			testTask := &task.Task{Id: "t1", DisplayName: "nil", Project: "sample"}
+			testTask := &task.Task{Id: "t1", DisplayName: "nil", Project: "sample", Version: ver.Id}
 			So(testTask.Insert(), ShouldBeNil)
 			Convey("then the value should be true", func() {
 				val, err := getStepback(testTask.Id)
@@ -1401,7 +1407,7 @@ buildvariants:
 		})
 
 		Convey("if the task overrides the setting with true", func() {
-			testTask := &task.Task{Id: "t2", DisplayName: "true", Project: "sample"}
+			testTask := &task.Task{Id: "t2", DisplayName: "true", Project: "sample", Version: ver.Id}
 			So(testTask.Insert(), ShouldBeNil)
 			Convey("then the value should be true", func() {
 				val, err := getStepback(testTask.Id)
@@ -1411,7 +1417,7 @@ buildvariants:
 		})
 
 		Convey("if the task overrides the setting with false", func() {
-			testTask := &task.Task{Id: "t3", DisplayName: "false", Project: "sample"}
+			testTask := &task.Task{Id: "t3", DisplayName: "false", Project: "sample", Version: ver.Id}
 			So(testTask.Insert(), ShouldBeNil)
 			Convey("then the value should be false", func() {
 				val, err := getStepback(testTask.Id)
@@ -1421,7 +1427,7 @@ buildvariants:
 		})
 
 		Convey("if the buildvariant does not override the setting", func() {
-			testTask := &task.Task{Id: "t4", DisplayName: "bvnil", BuildVariant: "sbnil", Project: "sample"}
+			testTask := &task.Task{Id: "t4", DisplayName: "bvnil", BuildVariant: "sbnil", Project: "sample", Version: ver.Id}
 			So(testTask.Insert(), ShouldBeNil)
 			Convey("then the value should be true", func() {
 				val, err := getStepback(testTask.Id)
@@ -1431,7 +1437,7 @@ buildvariants:
 		})
 
 		Convey("if the buildvariant overrides the setting with true", func() {
-			testTask := &task.Task{Id: "t5", DisplayName: "bvtrue", BuildVariant: "sbtrue", Project: "sample"}
+			testTask := &task.Task{Id: "t5", DisplayName: "bvtrue", BuildVariant: "sbtrue", Project: "sample", Version: ver.Id}
 			So(testTask.Insert(), ShouldBeNil)
 			Convey("then the value should be true", func() {
 				val, err := getStepback(testTask.Id)
@@ -1441,7 +1447,7 @@ buildvariants:
 		})
 
 		Convey("if the buildvariant overrides the setting with false", func() {
-			testTask := &task.Task{Id: "t6", DisplayName: "bvfalse", BuildVariant: "sbfalse", Project: "sample"}
+			testTask := &task.Task{Id: "t6", DisplayName: "bvfalse", BuildVariant: "sbfalse", Project: "sample", Version: ver.Id}
 			So(testTask.Insert(), ShouldBeNil)
 			Convey("then the value should be false", func() {
 				val, err := getStepback(testTask.Id)
@@ -1476,6 +1482,7 @@ func TestFailedTaskRestart(t *testing.T) {
 		StartTime: time.Date(2017, time.June, 12, 12, 0, 0, 0, time.Local),
 		Status:    evergreen.TaskFailed,
 		Details:   apimodels.TaskEndDetail{Type: evergreen.CommandTypeSystem},
+		Version:   b.Version,
 	}
 	testTask2 := &task.Task{
 		Id:        "taskThatSucceeded",
@@ -1485,6 +1492,7 @@ func TestFailedTaskRestart(t *testing.T) {
 		Project:   "sample",
 		StartTime: time.Date(2017, time.June, 12, 12, 0, 0, 0, time.Local),
 		Status:    evergreen.TaskSucceeded,
+		Version:   b.Version,
 	}
 	testTask3 := &task.Task{
 		Id:        "taskOutsideOfTimeRange",
@@ -1495,6 +1503,7 @@ func TestFailedTaskRestart(t *testing.T) {
 		StartTime: time.Date(2017, time.June, 11, 12, 0, 0, 0, time.Local),
 		Status:    evergreen.TaskFailed,
 		Details:   apimodels.TaskEndDetail{Type: "test"},
+		Version:   b.Version,
 	}
 	testTask4 := &task.Task{
 		Id:        "setupFailed",
@@ -1505,6 +1514,7 @@ func TestFailedTaskRestart(t *testing.T) {
 		StartTime: time.Date(2017, time.June, 12, 12, 0, 0, 0, time.Local),
 		Status:    evergreen.TaskFailed,
 		Details:   apimodels.TaskEndDetail{Type: "setup"},
+		Version:   b.Version,
 	}
 	p := &ProjectRef{
 		Identifier: "sample",
@@ -1807,6 +1817,12 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 		Identifier: "sample",
 	}
 	require.NoError(ref.Insert())
+	v := &Version{
+		Id:         "sample_version",
+		Identifier: "sample",
+		Requester:  evergreen.RepotrackerVersionRequester,
+	}
+	require.NoError(v.Insert())
 
 	buildID := "buildtest"
 	testTask := &task.Task{
@@ -1817,6 +1833,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 		Project:     "sample",
 		Status:      evergreen.TaskStarted,
 		StartTime:   time.Now().Add(-time.Hour),
+		Version:     v.Id,
 	}
 	assert.NoError(testTask.Insert())
 	anotherTask := &task.Task{
@@ -1827,6 +1844,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 		Project:     "sample",
 		Status:      evergreen.TaskStarted,
 		StartTime:   time.Now().Add(-time.Hour),
+		Version:     v.Id,
 	}
 	assert.NoError(anotherTask.Insert())
 	displayTask := &task.Task{
@@ -1839,6 +1857,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 		Status:         evergreen.TaskStarted,
 		StartTime:      time.Now().Add(-time.Hour),
 		ExecutionTasks: []string{"exe0", "exe1"},
+		Version:        v.Id,
 	}
 	assert.NoError(displayTask.Insert())
 	exeTask0 := &task.Task{
@@ -1849,6 +1868,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 		Project:     "sample",
 		Status:      evergreen.TaskStarted,
 		StartTime:   time.Now().Add(-time.Hour),
+		Version:     v.Id,
 	}
 	assert.True(exeTask0.IsPartOfDisplay())
 	assert.NoError(exeTask0.Insert())
@@ -1860,6 +1880,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 		Project:     "sample",
 		Status:      evergreen.TaskStarted,
 		StartTime:   time.Now().Add(-time.Hour),
+		Version:     v.Id,
 	}
 	assert.True(exeTask1.IsPartOfDisplay())
 	assert.NoError(exeTask1.Insert())
@@ -1890,7 +1911,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	require.NoError(b.Insert())
 	assert.False(b.IsFinished())
 
-	v := &Version{
+	v = &Version{
 		Id:     b.Version,
 		Status: evergreen.VersionStarted,
 	}
@@ -1961,6 +1982,11 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	require := require.New(t)
 
 	require.NoError(db.ClearCollections(task.Collection, build.Collection, VersionCollection, event.AllLogCollection))
+	v := &Version{
+		Id:        "sample_version",
+		Requester: evergreen.RepotrackerVersionRequester,
+	}
+	require.NoError(v.Insert())
 
 	buildID := "buildtest"
 	testTask := task.Task{
@@ -1971,6 +1997,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 		Project:     "sample",
 		Status:      evergreen.TaskStarted,
 		StartTime:   time.Now().Add(-time.Hour),
+		Version:     v.Id,
 	}
 	require.NoError(testTask.Insert())
 	anotherTask := task.Task{
@@ -1987,6 +2014,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 				Status: evergreen.TaskSucceeded,
 			},
 		},
+		Version: v.Id,
 	}
 	require.NoError(anotherTask.Insert())
 
@@ -2011,7 +2039,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	}
 	require.NoError(b.Insert())
 
-	v := &Version{
+	v = &Version{
 		Id:     b.Version,
 		Status: evergreen.VersionStarted,
 	}
@@ -2045,6 +2073,12 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 
 	require.NoError(db.ClearCollections(task.Collection, build.Collection, VersionCollection, event.AllLogCollection))
 
+	v := &Version{
+		Id:        "sample_version",
+		Requester: evergreen.RepotrackerVersionRequester,
+	}
+	require.NoError(v.Insert())
+
 	buildID := "buildtest"
 	testTask := task.Task{
 		Id:          "testone",
@@ -2054,6 +2088,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 		Project:     "sample",
 		Status:      evergreen.TaskStarted,
 		StartTime:   time.Now().Add(-time.Hour),
+		Version:     v.Id,
 	}
 	require.NoError(testTask.Insert())
 	anotherTask := task.Task{
@@ -2070,6 +2105,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 				Status: evergreen.TaskSucceeded,
 			},
 		},
+		Version: v.Id,
 	}
 	require.NoError(anotherTask.Insert())
 
@@ -2093,7 +2129,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 	}
 	require.NoError(b.Insert())
 
-	v := &Version{
+	v = &Version{
 		Id:     b.Version,
 		Status: evergreen.VersionStarted,
 	}
@@ -2430,7 +2466,7 @@ func TestDisplayTaskFailedAndSucceededExecTasks(t *testing.T) {
 
 func TestEvalStepback(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.ClearCollections(task.Collection, ProjectRefCollection, distro.Collection, build.Collection))
+	assert.NoError(db.ClearCollections(task.Collection, ProjectRefCollection, distro.Collection, build.Collection, VersionCollection))
 	yml := `
 stepback: true
 buildvariants:
@@ -2444,14 +2480,19 @@ tasks:
 - name: generator
   `
 	proj := ProjectRef{
-		Identifier:  "proj",
-		LocalConfig: yml,
+		Identifier: "proj",
 	}
-	assert.NoError(proj.Insert())
+	require.NoError(t, proj.Insert())
 	d := distro.Distro{
 		Id: "distro",
 	}
-	assert.NoError(d.Insert())
+	require.NoError(t, d.Insert())
+	v := Version{
+		Id:        "sample_version",
+		Config:    yml,
+		Requester: evergreen.RepotrackerVersionRequester,
+	}
+	require.NoError(t, v.Insert())
 	stepbackTask := task.Task{
 		Id:                  "t2",
 		BuildId:             "b2",
@@ -2463,6 +2504,7 @@ tasks:
 		RevisionOrderNumber: 2,
 		DispatchTime:        util.ZeroTime,
 		Requester:           evergreen.RepotrackerVersionRequester,
+		Version:             v.Id,
 	}
 	assert.NoError(stepbackTask.Insert())
 	b2 := build.Build{
@@ -2481,6 +2523,7 @@ tasks:
 		Activated:           true,
 		RevisionOrderNumber: 3,
 		Requester:           evergreen.RepotrackerVersionRequester,
+		Version:             v.Id,
 	}
 	assert.NoError(finishedTask.Insert())
 	b3 := build.Build{
@@ -2507,6 +2550,7 @@ tasks:
 		Activated:           true,
 		RevisionOrderNumber: 1,
 		Requester:           evergreen.RepotrackerVersionRequester,
+		Version:             v.Id,
 	}
 	assert.NoError(prevComplete.Insert())
 	b1 := build.Build{
@@ -2531,6 +2575,7 @@ tasks:
 		Activated:           true,
 		RevisionOrderNumber: 1,
 		Requester:           evergreen.RepotrackerVersionRequester,
+		Version:             v.Id,
 	}
 	assert.NoError(prevComplete.Insert())
 	stepbackTask = task.Task{
@@ -2544,6 +2589,7 @@ tasks:
 		RevisionOrderNumber: 4,
 		DispatchTime:        util.ZeroTime,
 		Requester:           evergreen.RepotrackerVersionRequester,
+		Version:             v.Id,
 	}
 	assert.NoError(stepbackTask.Insert())
 	b4 := build.Build{
@@ -2563,6 +2609,7 @@ tasks:
 		RevisionOrderNumber: 5,
 		DispatchTime:        util.ZeroTime,
 		Requester:           evergreen.RepotrackerVersionRequester,
+		Version:             v.Id,
 	}
 	assert.NoError(generator.Insert())
 	generated := task.Task{
@@ -2577,6 +2624,7 @@ tasks:
 		GeneratedBy:         "g5",
 		DispatchTime:        util.ZeroTime,
 		Requester:           evergreen.RepotrackerVersionRequester,
+		Version:             v.Id,
 	}
 	assert.NoError(generated.Insert())
 	b5 := build.Build{

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -228,7 +228,7 @@ func BlockTaskGroupTasks(taskID string) error {
 		return errors.Errorf("found nil task %s", taskID)
 	}
 
-	p, err := FindProjectFromTask(t)
+	p, err := FindProjectFromVersionID(t.Version)
 	if err != nil {
 		return errors.Wrapf(err, "problem getting project for task %s", t.Id)
 	}

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -23,8 +23,6 @@ const (
 	TaskAliasQueuesCollection = "task_alias_queues"
 )
 
-const useModernDequeueOp = true
-
 type TaskGroupInfo struct {
 	Name                  string        `bson:"name" json:"name"`
 	Count                 int           `bson:"count" json:"count"`

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -23,7 +23,7 @@ const (
 	TaskAliasQueuesCollection = "task_alias_queues"
 )
 
-var useModernDequeueOp = true
+const useModernDequeueOp = true
 
 type TaskGroupInfo struct {
 	Name                  string        `bson:"name" json:"name"`
@@ -622,14 +622,6 @@ outer:
 }
 
 func dequeue(taskId, distroId string) error {
-	if useModernDequeueOp {
-		return dequeueUpdate(taskId, distroId)
-	} else {
-		return legacyDequeueUpdate(taskId, distroId)
-	}
-}
-
-func dequeueUpdate(taskId, distroId string) error {
 	itemKey := bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemIdKey)
 
 	return errors.WithStack(db.Update(
@@ -641,22 +633,6 @@ func dequeueUpdate(taskId, distroId string) error {
 		bson.M{
 			"$set": bson.M{
 				taskQueueQueueKey + ".$." + taskQueueItemIsDispatchedKey: true,
-			},
-		},
-	))
-}
-
-func legacyDequeueUpdate(taskId, distroId string) error {
-	return errors.WithStack(db.Update(
-		TaskQueuesCollection,
-		bson.M{
-			taskQueueDistroKey: distroId,
-		},
-		bson.M{
-			"$pull": bson.M{
-				taskQueueQueueKey: bson.M{
-					taskQueueItemIdKey: taskId,
-				},
 			},
 		},
 	))

--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -204,10 +204,9 @@ tasks:
 - name: one
 `
 	v := Version{
-		Identifier: "a",
-		Revision:   "b",
-		Requester:  evergreen.RepotrackerVersionRequester,
-		Config:     yml,
+		Id:        "b",
+		Requester: evergreen.RepotrackerVersionRequester,
+		Config:    yml,
 	}
 	require.NoError(v.Insert())
 	tasks := []task.Task{
@@ -248,13 +247,18 @@ tasks:
 			Length: 1,
 		},
 	))
+	queue, err := LoadTaskQueue("distro_1")
+	assert.NoError(err)
+	assert.NotNil(queue)
+
 	assert.NoError(BlockTaskGroupTasks("task_id_1"))
 	found, err := task.FindOneId("one_1")
 	assert.NoError(err)
 	assert.Equal("task_id_1", found.DependsOn[0].TaskId)
-	queue, err := LoadTaskQueue("distro_1")
+
+	queue, err = LoadTaskQueue("distro_1")
 	assert.NoError(err)
-	assert.Len(queue.Queue, 0)
+	assert.Nil(queue)
 }
 
 func TestBlockTaskGroupTasksFailsWithCircularDependencies(t *testing.T) {

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -75,17 +75,26 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 
 	// Create the ref for the project
 	projectRef := &model.ProjectRef{
-		Identifier:  project.DisplayName,
-		Owner:       project.Owner,
-		Repo:        project.Repo,
-		RepoKind:    project.RepoKind,
-		Branch:      project.Branch,
-		Enabled:     project.Enabled,
-		BatchTime:   project.BatchTime,
-		LocalConfig: string(projectConfig),
+		Identifier: project.DisplayName,
+		Owner:      project.Owner,
+		Repo:       project.Repo,
+		RepoKind:   project.RepoKind,
+		Branch:     project.Branch,
+		Enabled:    project.Enabled,
+		BatchTime:  project.BatchTime,
 	}
 	if err = projectRef.Insert(); err != nil {
 		return nil, errors.Wrap(err, "failed to insert projectRef")
+	}
+
+	version := &model.Version{
+		Id:         "sample_version",
+		Identifier: project.DisplayName,
+		Requester:  evergreen.RepotrackerVersionRequester,
+		Config:     string(projectConfig),
+	}
+	if err = version.Insert(); err != nil {
+		return nil, errors.Wrap(err, "failed to insert version")
 	}
 
 	// Save the project variables

--- a/model/testutil/integration_test_setup.go
+++ b/model/testutil/integration_test_setup.go
@@ -43,8 +43,6 @@ func CreateTestLocalConfig(testSettings *evergreen.Settings, projectName, projec
 		return err
 	}
 
-	projectRef.LocalConfig = string(data)
-
 	return projectRef.Upsert()
 }
 

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -77,17 +77,24 @@ func setupCLITestHarness() cliTestHarness {
 	So(err, ShouldBeNil)
 
 	projectRef := &model.ProjectRef{
-		Identifier:  "sample",
-		Owner:       "evergreen-ci",
-		Repo:        "sample",
-		RepoKind:    "github",
-		Branch:      "master",
-		RemotePath:  "evergreen.yml",
-		LocalConfig: string(localConfBytes),
-		Enabled:     true,
-		BatchTime:   180,
+		Identifier: "sample",
+		Owner:      "evergreen-ci",
+		Repo:       "sample",
+		RepoKind:   "github",
+		Branch:     "master",
+		RemotePath: "evergreen.yml",
+		Enabled:    true,
+		BatchTime:  180,
 	}
 	So(projectRef.Insert(), ShouldBeNil)
+
+	version := &model.Version{
+		Id:         "sample_version",
+		Identifier: "sample",
+		Config:     string(localConfBytes),
+		Requester:  evergreen.RepotrackerVersionRequester,
+	}
+	So(version.Insert(), ShouldBeNil)
 
 	d := distro.Distro{Id: "localtestdistro"}
 	So(d.Insert(), ShouldBeNil)

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -359,11 +359,6 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 // project file. An erroneous project file may be returned along with an error.
 func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision string) (*model.Project, error) {
 	projectRef := repoTracker.ProjectRef
-	if projectRef.LocalConfig != "" {
-		// return the Local config from the project Ref.
-		p, err := model.FindProject("", projectRef)
-		return p, err
-	}
 	project, err := repoTracker.GetRemoteConfig(ctx, revision)
 	if err != nil {
 		// Only create a stub version on API request errors that pertain

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -126,7 +126,6 @@ type APIProjectRef struct {
 	RemotePath           APIString            `json:"remote_path"`
 	Identifier           APIString            `json:"identifier"`
 	DisplayName          APIString            `json:"display_name"`
-	LocalConfig          APIString            `json:"local_config"`
 	DeactivatePrevious   bool                 `json:"deactivate_previous"`
 	TracksPushEvents     bool                 `json:"tracks_push_events"`
 	PRTestingEnabled     bool                 `json:"pr_testing_enabled"`
@@ -164,7 +163,6 @@ func (p *APIProjectRef) ToService() (interface{}, error) {
 		RemotePath:           FromAPIString(p.RemotePath),
 		Identifier:           FromAPIString(p.Identifier),
 		DisplayName:          FromAPIString(p.DisplayName),
-		LocalConfig:          FromAPIString(p.LocalConfig),
 		DeactivatePrevious:   p.DeactivatePrevious,
 		TracksPushEvents:     p.TracksPushEvents,
 		PRTestingEnabled:     p.PRTestingEnabled,
@@ -230,7 +228,6 @@ func (p *APIProjectRef) BuildFromService(v interface{}) error {
 	p.RemotePath = ToAPIString(projectRef.RemotePath)
 	p.Identifier = ToAPIString(projectRef.Identifier)
 	p.DisplayName = ToAPIString(projectRef.DisplayName)
-	p.LocalConfig = ToAPIString(projectRef.LocalConfig)
 	p.DeactivatePrevious = projectRef.DeactivatePrevious
 	p.TracksPushEvents = projectRef.TracksPushEvents
 	p.PRTestingEnabled = projectRef.PRTestingEnabled

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -175,7 +175,7 @@ func (h *versionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	proj, err := dbModel.FindProject("", projRef)
+	proj, err := dbModel.FindLastKnownGoodProject(projRef.Identifier)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -356,7 +356,6 @@ func getMockProjectsConnector() *data.MockConnector {
 					RemotePath:         "evergreen.yml",
 					Identifier:         "dimoxinil",
 					DisplayName:        "Dimoxinil",
-					LocalConfig:        "",
 					DeactivatePrevious: false,
 					TracksPushEvents:   false,
 					PRTestingEnabled:   false,

--- a/service/api.go
+++ b/service/api.go
@@ -136,7 +136,7 @@ func (as *APIServer) checkProject(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		p, err := model.FindProject("", projectRef)
+		p, err := model.FindLastKnownGoodProject(projectRef.Identifier)
 		if err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError,
 				errors.Wrap(err, "Error getting patch"))

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -172,7 +172,7 @@ func (as *APIServer) updatePatchModule(w http.ResponseWriter, r *http.Request) {
 		as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err, "Error getting project ref with id %v", p.Project))
 		return
 	}
-	project, err := model.FindProject("", projectRef)
+	project, err := model.FindLastKnownGoodProject(projectRef.Identifier)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Error getting patch"))
 		return

--- a/service/rest_project_test.go
+++ b/service/rest_project_test.go
@@ -45,11 +45,10 @@ func TestProjectRoutes(t *testing.T) {
 
 		publicId := "pub"
 		public := &model.ProjectRef{
-			Identifier:  publicId,
-			Enabled:     true,
-			Repo:        "repo1",
-			LocalConfig: "buildvariants:\n - name: ubuntu",
-			Admins:      []string{},
+			Identifier: publicId,
+			Enabled:    true,
+			Repo:       "repo1",
+			Admins:     []string{},
 		}
 		So(public.Insert(), ShouldBeNil)
 

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -165,7 +165,7 @@ func (uis *UIServer) variantHistory(w http.ResponseWriter, r *http.Request) {
 		grip.WarningWhen(beforeCommit == nil, "'before' was specified but query returned nil")
 	}
 
-	project, err := model.FindProject("", projCtx.ProjectRef)
+	project, err := model.FindLastKnownGoodProject(projCtx.ProjectRef.Identifier)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/service/ui_plugin_perfdash.go
+++ b/service/ui_plugin_perfdash.go
@@ -42,7 +42,7 @@ func perfDashGetTasksForVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	project, err := model.FindProject(v.Revision, projectRef)
+	project, err := model.FindProjectFromVersionID(v.Revision)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/service/ui_plugin_perfdash.go
+++ b/service/ui_plugin_perfdash.go
@@ -42,7 +42,7 @@ func perfDashGetTasksForVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	project, err := model.FindProjectFromVersionID(v.Revision)
+	project, err := model.FindProjectFromVersionID(v.Id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
This refactors finding a project into 2 separate functions. If a version is
available, use the config from that version. Otherwise, find the latest good
version. That is, where previously we had called model.FindProject("", ref), use
model.FindLastKnownGoodProject(ref), and where we had previously called
model.FindProject, call model.FindProjectFromTask, call
model.FindProjectFromVersionID(t.Version).

This also removes LocalConfig as a concept completely, since this is not used in
code, only in tests.