### PR TITLE
EVG-6645 commit queue race

### DIFF
--- a/command/git_patch_test.go
+++ b/command/git_patch_test.go
@@ -156,14 +156,18 @@ func TestGetPatchCommands(t *testing.T) {
 		},
 	}
 
-	cmds := getPatchCommands(modulePatch, "/teapot", "/tmp/bestest.patch")
+	cmds := getPatchCommands(modulePatch, &model.TaskConfig{Task: &task.Task{}}, "/teapot", "/tmp/bestest.patch")
 
 	assert.Len(cmds, 5)
 	assert.Equal("cd '/teapot'", cmds[3])
 	assert.Equal("git reset --hard 'a4aa03d0472d8503380479b76aef96c044182822'", cmds[4])
 
 	modulePatch.PatchSet.Patch = "bestest code"
-	cmds = getPatchCommands(modulePatch, "/teapot", "/tmp/bestest.patch")
+	cmds = getPatchCommands(modulePatch, &model.TaskConfig{Task: &task.Task{}}, "/teapot", "/tmp/bestest.patch")
 	assert.Len(cmds, 6)
 	assert.Equal("git apply --stat '/tmp/bestest.patch' || true", cmds[5])
+
+	cmds = getPatchCommands(modulePatch, &model.TaskConfig{Task: &task.Task{Requester: evergreen.MergeTestRequester}}, "/teapot", "/tmp/bestest.patch")
+	assert.Len(cmds, 5)
+	assert.Equal("git apply --stat '/tmp/bestest.patch' || true", cmds[4])
 }

--- a/model/commitqueue/db.go
+++ b/model/commitqueue/db.go
@@ -42,7 +42,7 @@ func FindOneId(id string) (*CommitQueue, error) {
 
 func findOne(query db.Q) (*CommitQueue, error) {
 	queue := &CommitQueue{}
-	err := db.FindOneQ(Collection, query, &queue)
+	err := db.FindOneQ(Collection, query, queue)
 
 	return queue, err
 }


### PR DESCRIPTION
A backup of jobs caused two commit queue jobs to run at the same time. This caused a race where two patches were created for a single item on the queue. Although the cause of the race is still unclear, this PR adds a separate Amboy queue group for commit queue jobs so they won't get backed up.

Additionally, since `git.get_project` calls `git reset --hard` to the hash in the patch, the `git.push` task's check for head not having changed since we began running was ineffective.