### PR TITLE
EVG-6517 Increase maxGenerateTimeAgo

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -602,7 +602,7 @@ func MarkGeneratedTasks(taskID string, errorToSet error) error {
 }
 
 func GenerateNotRun() ([]Task, error) {
-	const maxGenerateTimeAgo = 2 * time.Hour
+	const maxGenerateTimeAgo = 24 * time.Hour
 	return FindAll(db.Query(bson.M{
 		StatusKey:         evergreen.TaskStarted,                              // task is running
 		StartTimeKey:      bson.M{"$gt": time.Now().Add(-maxGenerateTimeAgo)}, // ignore older tasks, just in case


### PR DESCRIPTION
It's possible for a large number of jobs to take longer than 2 hours to run. To
be conservative, we should run jobs that are significantly older than this.
Increasing the timeout to 1 day is a nice balance between ignoring tasks that
might somehow have become stuck in the started state but providing enough buffer
that there aren't generate.tasks jobs that get stuck in the queue. With a 2-hour
timeout, there were some slow queries against that collection.