### PR TITLE
EVG-6638 display trend graphs where a thread level has 0 values

### DIFF
--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -231,7 +231,9 @@ $http.get(templateUrl).success(function(template) {
     for (var i = 0; i < tests.length; i++) {
       var key = tests[i];
       var series = _.filter(trendSamples.seriesByName[key] || [], function (sample) {
-        return sample[scope.metricSelect.value.key];
+        return _.some(sample.threadResults, (singleResult) => {
+          return singleResult[scope.metricSelect.value.key];
+        });
       });
       var containerId = 'perf-trendchart-' + cleanId(taskId) + '-' + i;
       var cps = scope.changePoints || {};


### PR DESCRIPTION
Fixed a problem caused by EVG-6420 where if a data set has all 0 values for the lowest thread count, we think that it has no data at all and don't draw the graph. I verified that this doesn't re-break EVG-6420