### PR TITLE
EVG-6736: add test-model-credentials task

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,6 +7,7 @@ packages := $(name) agent operations cloud command db util plugin units
 packages += thirdparty auth scheduler model validator service monitor repotracker
 packages += model-patch model-artifact model-host model-build model-event model-task model-user model-distro model-manifest model-testresult
 packages += model-grid rest-client rest-data rest-route rest-model migrations trigger model-alertrecord model-notification model-stats model-reliability
+packages += model-credentials
 lintOnlyPackages := testutil model-manifest
 orgPath := github.com/evergreen-ci
 projectPath := $(orgPath)/$(name)

--- a/model/credentials/credentials_test.go
+++ b/model/credentials/credentials_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const defaultTestTimeout = 5 * time.Second
+const defaultTestTimeout = 10 * time.Second
 
 func TestForJasperClient(t *testing.T) {
 	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T){

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -431,6 +431,9 @@ tasks:
     name: test-model-build
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
+    name: test-model-credentials
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
     name: test-model-event
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6736

* Add test-model-credentials.
* Increase test timeout for slow hosts.