### PR TITLE
EVG-6679 better integration of manifest and git.get_project

### DIFF
--- a/command/git_test.go
+++ b/command/git_test.go
@@ -627,8 +627,7 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 	s.Equal("git reset --hard 1234abcd", cmds[6])
 }
 
-func (s *GitGetProjectSuite) TestCorrectModuleRevision() {
-	// using set-module
+func (s *GitGetProjectSuite) TestCorrectModuleRevisionSetModule() {
 	const correctHash = "b27779f856b211ffaf97cbc124b7082a20ea8bc0"
 	conf := s.modelData2.TaskConfig
 	ctx := context.WithValue(context.Background(), "patch", &patch.Patch{
@@ -677,8 +676,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevision() {
 	s.True(foundMsg)
 }
 
-func (s *GitGetProjectSuite) TestCorrectModuleRevision2() {
-	// using manifest
+func (s *GitGetProjectSuite) TestCorrectModuleRevisionManifest() {
 	const correctHash = "3585388b1591dfca47ac26a5b9a564ec8f138a5e"
 	conf := s.modelData2.TaskConfig
 	conf.Expansions.Put(moduleExpansionName("sample"), correctHash)

--- a/command/git_test.go
+++ b/command/git_test.go
@@ -628,12 +628,14 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 }
 
 func (s *GitGetProjectSuite) TestCorrectModuleRevision() {
+	// using set-module
+	const correctHash = "b27779f856b211ffaf97cbc124b7082a20ea8bc0"
 	conf := s.modelData2.TaskConfig
 	ctx := context.WithValue(context.Background(), "patch", &patch.Patch{
 		Patches: []patch.ModulePatch{
 			{
 				ModuleName: "sample",
-				Githash:    "b27779f856b211ffaf97cbc124b7082a20ea8bc0",
+				Githash:    correctHash,
 			},
 		},
 	})
@@ -661,7 +663,62 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevision() {
 	err = cmd.Run()
 	s.NoError(err)
 	ref := strings.Trim(out.String(), "\n")
-	s.Equal("b27779f856b211ffaf97cbc124b7082a20ea8bc0", ref) // this revision is defined in the patch, returned by GetTaskPatch
+	s.Equal(correctHash, ref) // this revision is defined in the patch, returned by GetTaskPatch
+	s.NoError(logger.Close())
+	toCheck := `Using revision/ref 'b27779f856b211ffaf97cbc124b7082a20ea8bc0' for module 'sample' (reason: specified in set-module)`
+	foundMsg := false
+	for _, task := range comm.GetMockMessages() {
+		for _, msg := range task {
+			if msg.Message == toCheck {
+				foundMsg = true
+			}
+		}
+	}
+	s.True(foundMsg)
+}
+
+func (s *GitGetProjectSuite) TestCorrectModuleRevision2() {
+	// using manifest
+	const correctHash = "3585388b1591dfca47ac26a5b9a564ec8f138a5e"
+	conf := s.modelData2.TaskConfig
+	conf.Expansions.Put(moduleExpansionName("sample"), correctHash)
+	ctx := context.Background()
+	comm := client.NewMock("http://localhost.com")
+	logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+	s.NoError(err)
+
+	for _, task := range conf.Project.Tasks {
+		s.NotEqual(len(task.Commands), 0)
+		for _, command := range task.Commands {
+			var pluginCmds []Command
+			pluginCmds, err = Render(command, conf.Project.Functions)
+			s.NoError(err)
+			s.NotNil(pluginCmds)
+			pluginCmds[0].SetJasperManager(s.jasper)
+			err = pluginCmds[0].Execute(ctx, comm, logger, conf)
+			s.NoError(err)
+		}
+	}
+
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = conf.WorkDir + "/src/module/sample/"
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err = cmd.Run()
+	s.NoError(err)
+	ref := strings.Trim(out.String(), "\n")
+	s.Equal(correctHash, ref)
+	s.NoError(logger.Close())
+	toCheck := `Using revision/ref '3585388b1591dfca47ac26a5b9a564ec8f138a5e' for module 'sample' (reason: from manifest)`
+	foundMsg := false
+	for _, task := range comm.GetMockMessages() {
+		for _, msg := range task {
+			if msg.Message == toCheck {
+				foundMsg = true
+			}
+		}
+	}
+	s.True(foundMsg)
 }
 
 func (s *GitGetProjectSuite) TestIsMailboxPatch() {

--- a/command/manifest.go
+++ b/command/manifest.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+func moduleExpansionName(module string) string { return fmt.Sprintf("%s_rev", module) }
+
 // manifestLoad
 type manifestLoad struct{ base }
 
@@ -37,7 +39,7 @@ func (c *manifestLoad) Load(ctx context.Context,
 		}
 
 		// put the url for the module in the expansions
-		conf.Expansions.Put(fmt.Sprintf("%v_rev", moduleName), manifest.Modules[moduleName].Revision)
+		conf.Expansions.Put(moduleExpansionName(moduleName), manifest.Modules[moduleName].Revision)
 	}
 
 	logger.Execution().Info("manifest loaded successfully")


### PR DESCRIPTION
- Teach git.get_project about the module expansions manifest.load sets
- Add the module githash specified by the manifest to git.get_project's checks (so that users don't need to add it as a param to git.get_project anymore)
- Add logging of what module ref we're using and why