### PR TITLE
EVG-6738: ensure hosts provisioned with user data that fail to start agent are terminated

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -41,7 +41,7 @@ type Distro struct {
 // BootstrapSettings encapsulates all settings related to bootstrapping hosts.
 type BootstrapSettings struct {
 	Method                string `bson:"method" json:"method" mapstructure:"method"`
-	Communication         string `bson:"communcation,omitempty" json:"communication,omitempty" mapstructure:"communcation,omitempty"`
+	Communication         string `bson:"communication,omitempty" json:"communication,omitempty" mapstructure:"communication,omitempty"`
 	ClientDir             string `bson:"client_dir,omitempty" json:"client_dir,omitempty" mapstructure:"client_dir,omitempty"`
 	JasperBinaryDir       string `bson:"jasper_binary_dir,omitempty" json:"jasper_binary_dir,omitempty" mapstructure:"jasper_binary_dir,omitempty"`
 	JasperCredentialsPath string `json:"jasper_credentials_path,omitempty" bson:"jasper_credentials_path,omitempty" mapstructure:"jasper_credentials_path,omitempty"`

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -309,10 +309,13 @@ func allHostsSpawnedByFinishedBuilds() ([]Host, error) {
 // the given time.
 func ByUnprovisionedSince(threshold time.Time) db.Q {
 	return db.Query(bson.M{
-		ProvisionedKey: false,
-		CreateTimeKey:  bson.M{"$lte": threshold},
-		StatusKey:      bson.M{"$ne": evergreen.HostTerminated},
-		StartedByKey:   evergreen.User,
+		"$or": []bson.M{
+			bson.M{ProvisionedKey: false},
+			bson.M{StatusKey: evergreen.HostProvisioning},
+		},
+		CreateTimeKey: bson.M{"$lte": threshold},
+		StatusKey:     bson.M{"$ne": evergreen.HostTerminated},
+		StartedByKey:  evergreen.User,
 	})
 }
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1072,7 +1072,7 @@ func (h *Host) ClearRunningTeardownGroup() error {
 func FindHostsToTerminate() ([]Host, error) {
 	const (
 		// provisioningCutoff is the threshold to consider as too long for a host to take provisioning
-		provisioningCutoff = 10 * time.Minute
+		provisioningCutoff = 25 * time.Minute
 
 		// unreachableCutoff is the threshold to wait for an decommissioned host to become marked
 		// as reachable again before giving up and terminating it.

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1095,9 +1095,9 @@ func FindHostsToTerminate() ([]Host, error) {
 				StatusKey: evergreen.HostProvisionFailed,
 			},
 			{ // host.ByUnprovisionedSince
-				"$or": bson.M{
-					ProvisionedKey: false,
-					StatusKey:      evergreen.HostProvisioning,
+				"$or": []bson.M{
+					bson.M{ProvisionedKey: false},
+					bson.M{StatusKey: evergreen.HostProvisioning},
 				},
 				CreateTimeKey: bson.M{"$lte": now.Add(-provisioningCutoff)},
 				StatusKey:     bson.M{"$ne": evergreen.HostTerminated},

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1072,7 +1072,7 @@ func (h *Host) ClearRunningTeardownGroup() error {
 func FindHostsToTerminate() ([]Host, error) {
 	const (
 		// provisioningCutoff is the threshold to consider as too long for a host to take provisioning
-		provisioningCutoff = 25 * time.Minute
+		provisioningCutoff = 10 * time.Minute
 
 		// unreachableCutoff is the threshold to wait for an decommissioned host to become marked
 		// as reachable again before giving up and terminating it.

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1094,11 +1094,14 @@ func FindHostsToTerminate() ([]Host, error) {
 			{ // host.IsProvisioningFailure
 				StatusKey: evergreen.HostProvisionFailed,
 			},
-			{ // host.ByUnprovisonedSince
-				ProvisionedKey: false,
-				CreateTimeKey:  bson.M{"$lte": now.Add(-provisioningCutoff)},
-				StatusKey:      bson.M{"$ne": evergreen.HostTerminated},
-				StartedByKey:   evergreen.User,
+			{ // host.ByUnprovisionedSince
+				"$or": bson.M{
+					ProvisionedKey: false,
+					StatusKey:      evergreen.HostProvisioning,
+				},
+				CreateTimeKey: bson.M{"$lte": now.Add(-provisioningCutoff)},
+				StatusKey:     bson.M{"$ne": evergreen.HostTerminated},
+				StartedByKey:  evergreen.User,
 			},
 			{ // host.IsDecommissioned
 				RunningTaskKey: bson.M{"$exists": false},

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -884,5 +884,5 @@ func (j *setupHostJob) tryRequeue(ctx context.Context) {
 }
 
 func shouldRetryProvisioning(h *host.Host) bool {
-	return h.ProvisionAttempts <= provisionRetryLimit && h.Status == evergreen.HostProvisioning
+	return h.ProvisionAttempts <= provisionRetryLimit && h.Status == evergreen.HostProvisioning && !h.Provisioned
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6738

* Host termination find query checks for user data hosts that haven't provisioned within the cutoff.
* Prevent setup host job from retrying once and immediately no-oping for user data provisioning.
* I can't spell "communication".