### PR TITLE
EVG-6744: remove legacy EC2 provider name

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -97,7 +97,7 @@ func GetManager(ctx context.Context, mgrOpts ManagerOpts, settings *evergreen.Se
 		provider = &staticManager{}
 	case evergreen.ProviderNameMock:
 		provider = makeMockManager()
-	case evergreen.ProviderNameEc2Legacy, evergreen.ProviderNameEc2OnDemand:
+	case evergreen.ProviderNameEc2OnDemand:
 		provider = NewEC2Manager(&EC2ManagerOptions{client: &awsClientImpl{}, provider: onDemandProvider, region: mgrOpts.Region})
 	case evergreen.ProviderNameEc2Spot:
 		provider = NewEC2Manager(&EC2ManagerOptions{client: &awsClientImpl{}, provider: spotProvider, region: mgrOpts.Region})

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/testutil"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ func TestGetManager(t *testing.T) {
 	Convey("GetManager() should return non-nil for all valid provider names", t, func() {
 
 		Convey("EC2Auto should be returned for ec2-auto provider name", func() {
-			mgrOpts := ManagerOpts{Provider: "ec2", Region: ""}
+			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameEc2Auto, Region: ""}
 			cloudMgr, err := GetManager(ctx, mgrOpts, testutil.TestConfig())
 			So(cloudMgr, ShouldNotBeNil)
 			So(err, ShouldBeNil)
@@ -23,15 +24,15 @@ func TestGetManager(t *testing.T) {
 		})
 
 		Convey("EC2Spot should be returned for ec2-spot provider name", func() {
-			mgrOpts := ManagerOpts{Provider: "ec2-spot", Region: ""}
+			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameEc2Spot, Region: ""}
 			cloudMgr, err := GetManager(ctx, mgrOpts, testutil.TestConfig())
 			So(cloudMgr, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(cloudMgr, ShouldHaveSameTypeAs, &ec2Manager{})
 		})
 
-		Convey("EC2 should be returned for ec2 provider name", func() {
-			mgrOpts := ManagerOpts{Provider: "ec2-ondemand", Region: ""}
+		Convey("EC2OnDemand should be returned for ec2-ondemand provider name", func() {
+			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameEc2OnDemand, Region: ""}
 			cloudMgr, err := GetManager(ctx, mgrOpts, testutil.TestConfig())
 			So(cloudMgr, ShouldNotBeNil)
 			So(err, ShouldBeNil)
@@ -39,7 +40,7 @@ func TestGetManager(t *testing.T) {
 		})
 
 		Convey("Static should be returned for static provider name", func() {
-			mgrOpts := ManagerOpts{Provider: "static", Region: ""}
+			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameStatic, Region: ""}
 			cloudMgr, err := GetManager(ctx, mgrOpts, testutil.TestConfig())
 			So(cloudMgr, ShouldNotBeNil)
 			So(err, ShouldBeNil)
@@ -47,7 +48,7 @@ func TestGetManager(t *testing.T) {
 		})
 
 		Convey("Mock should be returned for mock provider name", func() {
-			mgrOpts := ManagerOpts{Provider: "mock", Region: ""}
+			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameMock, Region: ""}
 			cloudMgr, err := GetManager(ctx, mgrOpts, testutil.TestConfig())
 			So(cloudMgr, ShouldNotBeNil)
 			So(err, ShouldBeNil)

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -40,7 +40,7 @@ func (s *DockerSuite) SetupTest() {
 	}
 	s.distro = distro.Distro{
 		Id:       "d",
-		Provider: "docker",
+		Provider: evergreen.ProviderNameDocker,
 		ProviderSettings: &map[string]interface{}{
 			"pool_id": "pool_id",
 		},
@@ -191,7 +191,7 @@ func (s *DockerSuite) TestSpawnInvalidSettings() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dProviderName := distro.Distro{Provider: "ec2"}
+	dProviderName := distro.Distro{Provider: evergreen.ProviderNameEc2Auto}
 	h := host.NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
 	h, err := s.manager.SpawnHost(ctx, h)
 	s.Error(err)

--- a/cloud/gce_test.go
+++ b/cloud/gce_test.go
@@ -322,7 +322,7 @@ func (s *GCESuite) TestSpawnInvalidSettings() {
 	defer cancel()
 
 	var err error
-	dProviderName := distro.Distro{Provider: "ec2"}
+	dProviderName := distro.Distro{Provider: evergreen.ProviderNameEc2Auto}
 	h := host.NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
 	s.NotNil(h)
 	h, err = s.manager.SpawnHost(ctx, h)

--- a/cloud/openstack_test.go
+++ b/cloud/openstack_test.go
@@ -33,7 +33,7 @@ func (s *OpenStackSuite) SetupTest() {
 
 	s.distro = distro.Distro{
 		Id:       "host",
-		Provider: "openstack",
+		Provider: evergreen.ProviderNameOpenstack,
 		ProviderSettings: &map[string]interface{}{
 			"image_name":     "image",
 			"flavor_name":    "flavor",
@@ -242,21 +242,21 @@ func (s *OpenStackSuite) TestSpawnInvalidSettings() {
 	defer cancel()
 
 	var err error
-	dProviderName := distro.Distro{Provider: "ec2"}
+	dProviderName := distro.Distro{Provider: evergreen.ProviderNameEc2Auto}
 	h := host.NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
 	s.NotNil(h)
 	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
 	s.Nil(h)
 
-	dSettingsNone := distro.Distro{Provider: "openstack"}
+	dSettingsNone := distro.Distro{Provider: evergreen.ProviderNameOpenstack}
 	h = host.NewIntent(dSettingsNone, dSettingsNone.GenerateName(), dSettingsNone.Provider, s.hostOpts)
 	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
 	s.Nil(h)
 
 	dSettingsInvalid := distro.Distro{
-		Provider:         "openstack",
+		Provider:         evergreen.ProviderNameOpenstack,
 		ProviderSettings: &map[string]interface{}{"image_name": ""},
 	}
 	h = host.NewIntent(dSettingsInvalid, dSettingsInvalid.GenerateName(), dSettingsInvalid.Provider, s.hostOpts)
@@ -291,7 +291,7 @@ func (s *OpenStackSuite) TestSpawnDuplicateHostID() {
 func (s *OpenStackSuite) TestSpawnAPICall() {
 	dist := distro.Distro{
 		Id:       "id",
-		Provider: "openstack",
+		Provider: evergreen.ProviderNameOpenstack,
 		ProviderSettings: &map[string]interface{}{
 			"image_name":     "image",
 			"flavor_name":    "flavor",

--- a/cloud/vsphere_test.go
+++ b/cloud/vsphere_test.go
@@ -34,7 +34,7 @@ func (s *VSphereSuite) SetupTest() {
 	}
 	s.distro = distro.Distro{
 		Id:       "host",
-		Provider: "vsphere",
+		Provider: evergreen.ProviderNameVsphere,
 		ProviderSettings: &map[string]interface{}{
 			"template": "macos-1012",
 		},
@@ -228,21 +228,21 @@ func (s *VSphereSuite) TestSpawnInvalidSettings() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dProviderName := distro.Distro{Provider: "ec2"}
+	dProviderName := distro.Distro{Provider: evergreen.ProviderNameEc2Auto}
 	h := host.NewIntent(dProviderName, dProviderName.GenerateName(), dProviderName.Provider, s.hostOpts)
 	s.NotNil(h)
 	h, err := s.manager.SpawnHost(ctx, h)
 	s.Error(err)
 	s.Nil(h)
 
-	dSettingsNone := distro.Distro{Provider: "vsphere"}
+	dSettingsNone := distro.Distro{Provider: evergreen.ProviderNameVsphere}
 	h = host.NewIntent(dSettingsNone, dSettingsNone.GenerateName(), dSettingsNone.Provider, s.hostOpts)
 	h, err = s.manager.SpawnHost(ctx, h)
 	s.Error(err)
 	s.Nil(h)
 
 	dSettingsInvalid := distro.Distro{
-		Provider:         "vsphere",
+		Provider:         evergreen.ProviderNameVsphere,
 		ProviderSettings: &map[string]interface{}{"template": ""},
 	}
 	h = host.NewIntent(dSettingsInvalid, dSettingsInvalid.GenerateName(), dSettingsInvalid.Provider, s.hostOpts)

--- a/globals.go
+++ b/globals.go
@@ -236,16 +236,12 @@ const (
 
 	// Default EC2 region where hosts should be spawned
 	DefaultEC2Region = "us-east-1"
-
-	// TODO: This can be removed when no more hosts with provider ec2 are running.
-	ProviderNameEc2Legacy = "ec2"
 )
 
 var (
 	// Providers where hosts can be created and terminated automatically.
 	ProviderSpawnable = []string{
 		ProviderNameDocker,
-		ProviderNameEc2Legacy,
 		ProviderNameEc2OnDemand,
 		ProviderNameEc2Spot,
 		ProviderNameEc2Auto,

--- a/model/host/stats_test.go
+++ b/model/host/stats_test.go
@@ -16,7 +16,7 @@ func insertTestDocuments() error {
 			Status: evergreen.HostRunning,
 			Distro: distro.Distro{
 				Id:       "debian",
-				Provider: "ec2",
+				Provider: evergreen.ProviderNameEc2Auto,
 			},
 			RunningTask: "foo",
 		},
@@ -25,7 +25,7 @@ func insertTestDocuments() error {
 			Status: evergreen.HostRunning,
 			Distro: distro.Distro{
 				Id:       "redhat",
-				Provider: "ec2",
+				Provider: evergreen.ProviderNameEc2Auto,
 			},
 			RunningTask: "bar",
 		},
@@ -34,7 +34,7 @@ func insertTestDocuments() error {
 			Status: evergreen.HostRunning,
 			Distro: distro.Distro{
 				Id:       "debian",
-				Provider: "ec2",
+				Provider: evergreen.ProviderNameEc2Auto,
 			},
 			RunningTask: "foo-foo",
 		},
@@ -43,7 +43,7 @@ func insertTestDocuments() error {
 			Status: evergreen.HostRunning,
 			Distro: distro.Distro{
 				Id:       "redhat",
-				Provider: "ec2-spot",
+				Provider: evergreen.ProviderNameEc2Spot,
 			},
 		},
 		Host{
@@ -51,7 +51,7 @@ func insertTestDocuments() error {
 			Status: evergreen.HostUninitialized,
 			Distro: distro.Distro{
 				Id:       "foo",
-				Provider: "ec2",
+				Provider: evergreen.ProviderNameEc2Auto,
 			},
 		},
 		Host{
@@ -78,8 +78,8 @@ func TestHostStatsByProvider(t *testing.T) {
 	assert.Len(result, 3, "%+v", result)
 
 	rmap := result.Map()
-	assert.Equal(1, rmap["ec2-spot"])
-	assert.Equal(3, rmap["ec2"])
+	assert.Equal(1, rmap[evergreen.ProviderNameEc2Spot])
+	assert.Equal(3, rmap[evergreen.ProviderNameEc2Auto])
 
 	alt, err := GetProviderCounts()
 	assert.NoError(err)

--- a/model/scheduler_stats_test.go
+++ b/model/scheduler_stats_test.go
@@ -133,31 +133,31 @@ func TestCreateHostBuckets(t *testing.T) {
 		bucketSize := time.Duration(10) * time.Second
 
 		// -20 -> 20
-		beforeStartHost := host.Host{Id: "beforeStartHost", CreationTime: now.Add(time.Duration(-20) * time.Second), TerminationTime: now.Add(time.Duration(20) * time.Second), Provider: "ec2"}
+		beforeStartHost := host.Host{Id: "beforeStartHost", CreationTime: now.Add(time.Duration(-20) * time.Second), TerminationTime: now.Add(time.Duration(20) * time.Second), Provider: evergreen.ProviderNameEc2Auto}
 		So(beforeStartHost.Insert(), ShouldBeNil)
 
 		// 80 -> 120
-		afterEndHost := host.Host{Id: "afterEndHost", CreationTime: now.Add(time.Duration(80) * time.Second), TerminationTime: now.Add(time.Duration(120) * time.Second), Provider: "ec2"}
+		afterEndHost := host.Host{Id: "afterEndHost", CreationTime: now.Add(time.Duration(80) * time.Second), TerminationTime: now.Add(time.Duration(120) * time.Second), Provider: evergreen.ProviderNameEc2Auto}
 		So(afterEndHost.Insert(), ShouldBeNil)
 
 		// 20 -> 40
-		h1 := host.Host{Id: "h1", CreationTime: now.Add(time.Duration(20) * time.Second), TerminationTime: now.Add(time.Duration(40) * time.Second), Provider: "ec2"}
+		h1 := host.Host{Id: "h1", CreationTime: now.Add(time.Duration(20) * time.Second), TerminationTime: now.Add(time.Duration(40) * time.Second), Provider: evergreen.ProviderNameEc2Auto}
 		So(h1.Insert(), ShouldBeNil)
 
 		// 10 -> 80
-		h2 := host.Host{Id: "h2", CreationTime: now.Add(time.Duration(10) * time.Second), TerminationTime: now.Add(time.Duration(80) * time.Second), Provider: "ec2"}
+		h2 := host.Host{Id: "h2", CreationTime: now.Add(time.Duration(10) * time.Second), TerminationTime: now.Add(time.Duration(80) * time.Second), Provider: evergreen.ProviderNameEc2Auto}
 		So(h2.Insert(), ShouldBeNil)
 
 		// 20 ->
-		h3 := host.Host{Id: "h3", CreationTime: now.Add(time.Duration(20) * time.Second), TerminationTime: util.ZeroTime, Provider: "ec2", Status: evergreen.HostRunning}
+		h3 := host.Host{Id: "h3", CreationTime: now.Add(time.Duration(20) * time.Second), TerminationTime: util.ZeroTime, Provider: evergreen.ProviderNameEc2Auto, Status: evergreen.HostRunning}
 		So(h3.Insert(), ShouldBeNil)
 
 		// 5 -> 7
-		sameBucket := host.Host{Id: "sameBucket", CreationTime: now.Add(time.Duration(5) * time.Second), TerminationTime: now.Add(time.Duration(7) * time.Second), Provider: "ec2"}
+		sameBucket := host.Host{Id: "sameBucket", CreationTime: now.Add(time.Duration(5) * time.Second), TerminationTime: now.Add(time.Duration(7) * time.Second), Provider: evergreen.ProviderNameEc2Auto}
 		So(sameBucket.Insert(), ShouldBeNil)
 
 		// 5 -> 30
-		h4 := host.Host{Id: "h4", CreationTime: now.Add(time.Duration(5) * time.Second), TerminationTime: now.Add(time.Duration(30) * time.Second), Provider: "ec2"}
+		h4 := host.Host{Id: "h4", CreationTime: now.Add(time.Duration(5) * time.Second), TerminationTime: now.Add(time.Duration(30) * time.Second), Provider: evergreen.ProviderNameEc2Auto}
 		So(h4.Insert(), ShouldBeNil)
 
 		Convey("for three buckets of 10 seconds, should only retrieve pertinent host docs", func() {

--- a/scheduler/deficit_based_host_allocator_test.go
+++ b/scheduler/deficit_based_host_allocator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -22,7 +23,7 @@ func TestDeficitBasedHostAllocator(t *testing.T) {
 		" determining the number of new hosts to spin up...", t, func() {
 		runningTaskIds = []string{"t1", "t2", "t3", "t4", "t5"}
 		hostIds = []string{"h1", "h2", "h3", "h4", "h5"}
-		dist = distro.Distro{Provider: "ec2"}
+		dist = distro.Distro{Provider: evergreen.ProviderNameEc2Auto}
 
 		Convey("if there are no tasks to run, no new hosts should be needed",
 			func() {
@@ -205,7 +206,7 @@ func TestDeficitBasedHostAllocator(t *testing.T) {
 				{Id: hostIds[0]},
 			}
 			dist.PoolSize = 20
-			dist.Provider = "static"
+			dist.Provider = evergreen.ProviderNameStatic
 
 			distroQueueInfo := model.DistroQueueInfo{
 				Length: 3,


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6744

None of the distros use this setting anymore.