### PR TITLE
EVG-6682 Track commit queue length and item wait time

### DIFF
--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -2,6 +2,7 @@ package commitqueue
 
 import (
 	"strings"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/mongodb/grip/level"
@@ -25,9 +26,10 @@ func (m *Module) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(m) }
 func (m *Module) UnmarshalBSON(in []byte) error { return mgobson.Unmarshal(in, m) }
 
 type CommitQueueItem struct {
-	Issue   string   `bson:"issue"`
-	Version string   `bson:"version,omitempty"`
-	Modules []Module `bson:"modules"`
+	Issue       string    `bson:"issue"`
+	Version     string    `bson:"version,omitempty"`
+	EnqueueTime time.Time `bson:"enqueue_time"`
+	Modules     []Module  `bson:"modules"`
 }
 
 func (i *CommitQueueItem) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(i) }
@@ -56,6 +58,7 @@ func (q *CommitQueue) Enqueue(item CommitQueueItem) (int, error) {
 		return 0, errors.Wrapf(err, "can't add '%s' to queue '%s'", item.Issue, q.ProjectID)
 	}
 
+	item.EnqueueTime = time.Now()
 	q.Queue = append(q.Queue, item)
 	return len(q.Queue), nil
 }

--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -5,7 +5,9 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/send"
 	"github.com/pkg/errors"
 	mgobson "gopkg.in/mgo.v2/bson"
@@ -58,6 +60,13 @@ func (q *CommitQueue) Enqueue(item CommitQueueItem) (int, error) {
 	if err := add(q.ProjectID, q.Queue, item); err != nil {
 		return 0, errors.Wrapf(err, "can't add '%s' to queue '%s'", item.Issue, q.ProjectID)
 	}
+	grip.Info(message.Fields{
+		"source":       "commit queue",
+		"item_id":      item.Issue,
+		"project_id":   q.ProjectID,
+		"queue_length": len(q.Queue),
+		"message":      "enqueued commit queue item",
+	})
 
 	q.Queue = append(q.Queue, item)
 	return len(q.Queue), nil

--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -54,11 +54,11 @@ func (q *CommitQueue) Enqueue(item CommitQueueItem) (int, error) {
 		return position + 1, errors.New("item already in queue")
 	}
 
+	item.EnqueueTime = time.Now()
 	if err := add(q.ProjectID, q.Queue, item); err != nil {
 		return 0, errors.Wrapf(err, "can't add '%s' to queue '%s'", item.Issue, q.ProjectID)
 	}
 
-	item.EnqueueTime = time.Now()
 	q.Queue = append(q.Queue, item)
 	return len(q.Queue), nil
 }

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -3,7 +3,6 @@ package commitqueue
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -62,7 +61,7 @@ func (s *CommitQueueSuite) TestEnqueue() {
 	s.Equal(sampleCommitQueueItem.Issue, dbq.Next().Issue)
 
 	// Ensure EnqueueTime set
-	s.WithinDuration(time.Now(), dbq.Next().EnqueueTime, 10*time.Minute)
+	s.False(dbq.Next().EnqueueTime.IsZero())
 
 	s.NotEqual(-1, dbq.FindItem("c123"))
 }

--- a/model/commitqueue/db.go
+++ b/model/commitqueue/db.go
@@ -13,11 +13,12 @@ const Collection = "commit_queue"
 
 var (
 	// bson fields for the CommitQueue struct
-	IdKey         = bsonutil.MustHaveTag(CommitQueue{}, "ProjectID")
-	QueueKey      = bsonutil.MustHaveTag(CommitQueue{}, "Queue")
-	ProcessingKey = bsonutil.MustHaveTag(CommitQueue{}, "Processing")
-	IssueKey      = bsonutil.MustHaveTag(CommitQueueItem{}, "Issue")
-	VersionKey    = bsonutil.MustHaveTag(CommitQueueItem{}, "Version")
+	IdKey          = bsonutil.MustHaveTag(CommitQueue{}, "ProjectID")
+	QueueKey       = bsonutil.MustHaveTag(CommitQueue{}, "Queue")
+	ProcessingKey  = bsonutil.MustHaveTag(CommitQueue{}, "Processing")
+	IssueKey       = bsonutil.MustHaveTag(CommitQueueItem{}, "Issue")
+	VersionKey     = bsonutil.MustHaveTag(CommitQueueItem{}, "Version")
+	EnqueueTimeKey = bsonutil.MustHaveTag(CommitQueueItem{}, "EnqueueTime")
 )
 
 func updateOne(query interface{}, update interface{}) error {

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -120,7 +120,8 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 	grip.Info(message.Fields{
 		"source":       "commit queue",
 		"job_id":       j.ID(),
-		"item":         nextItem,
+		"item_id":      nextItem.Issue,
+		"project_id":   cq.ProjectID,
 		"time_waiting": timeWaiting.Seconds(),
 		"queue_length": len(cq.Queue),
 		"message":      "dequeued commit queue item",

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -121,7 +121,7 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 		"source":       "commit queue",
 		"job_id":       j.ID(),
 		"item":         nextItem,
-		"time_waiting": timeWaiting,
+		"time_waiting": timeWaiting.Seconds(),
 		"queue_length": len(cq.Queue),
 		"message":      "dequeued commit queue item",
 	})

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -113,6 +114,17 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 		return
 	}
 	j.AddError(errors.Wrap(cq.SetProcessing(true), "can't set processing to true"))
+
+	// log time waiting in queue
+	timeWaiting := time.Now().Sub(nextItem.EnqueueTime)
+	grip.Info(message.Fields{
+		"source":       "commit queue",
+		"job_id":       j.ID(),
+		"item":         nextItem,
+		"time_waiting": timeWaiting,
+		"queue_length": len(cq.Queue),
+		"message":      "dequeued commit queue item",
+	})
 
 	conf := j.env.Settings()
 	githubToken, err := conf.GetGithubOauthToken()


### PR DESCRIPTION
This adds a EnqueueTime field to each commit queue item that is set when the item is added to the queue. The commitQueueJob now logs how long an item had been waiting in the queue (at the time it is popped), in addition to the current length of the commit queue.