### PR TITLE
EVG-6580: it's not possible to set min hosts in the UI unless a distro is set to tunable

### DIFF
--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -508,7 +508,7 @@ Evergreen - Distros
               <div class="icon fa fa-warning distro-error" ng-show="form.poolSize.$dirty && form.poolSize.$error.required ||
                 form.poolSize.$invalid ||
                 form.poolSize.$modelValue < 0 ||
-                form.poolSize.$modelValue % 1 != 0"> A non-negative integer value for Minimum Hosts/Pool Size is required
+                form.poolSize.$modelValue % 1 != 0"> A non-negative integer value for Maximum Hosts (a.k.a. Pool Size) is required
               </div>
             </div>
             <div>

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -501,24 +501,28 @@ Evergreen - Distros
             form.plannerSettingsVersion.$invalid">Planner Version is required
           </div>
           <div ng-show="activeDistro.provider != 'static' && activeDistro.provider != 'docker'">
+            <div>
               <label class="distro-label">Maximum number of hosts allowed:</label>
               <input ng-readonly="readOnly" type="number" ng-required="activeDistro.provider != 'static' && activeDistro.provider != 'docker'"
                 name="poolSize" class="form-control" ng-model="activeDistro.pool_size" ng-change="activeDistro.planner_settings.maximum_hosts=activeDistro.pool_size" placeholder="Max pool size e.g. 10">
-              <div class="icon fa fa-warning distro-error" ng-show="form.poolSize.$dirty && form.poolSize.$error.required || form.poolSize.$invalid">Numeric
-                pool size is required
+              <div class="icon fa fa-warning distro-error" ng-show="form.poolSize.$dirty && form.poolSize.$error.required ||
+                form.poolSize.$invalid ||
+                form.poolSize.$modelValue < 0 ||
+                form.poolSize.$modelValue % 1 != 0"> A non-negative integer value for Minimum Hosts/Pool Size is required
               </div>
-          </div>
-          <div ng-show="activeDistro.provider != 'static' && activeDistro.provider != 'docker' && activeDistro.planner_settings.version == 'tunable'">
+            </div>
             <div>
               <label class="distro-label">Minimum Hosts of host allowed:</label>
-              <input ng-readonly="readOnly" type="number" ng-required="activeDistro.planner_settings.version == 'tunable'"
+              <input ng-readonly="readOnly" type="number"
                 name="plannerSettingsMinimumHosts" class="form-control" ng-model="activeDistro.planner_settings.minimum_hosts" placeholder="Min pool size e.g. 0">
+              <div class="icon fa fa-warning distro-error" ng-show="form.plannerSettingsMinimumHosts.$dirty && form.plannerSettingsMinimumHosts.$error.required ||
+                form.plannerSettingsMinimumHosts.$invalid ||
+                form.plannerSettingsMinimumHosts.$modelValue < 0 ||
+                form.plannerSettingsMinimumHosts.$modelValue % 1 != 0"> A non-negative integer value for Minimum Hosts is required
+              </div>
             </div>
-            <div class="icon fa fa-warning distro-error" ng-show="form.plannerSettingsMinimumHosts.$dirty && form.plannerSettingsMinimumHosts.$error.required ||
-              form.plannerSettingsMinimumHosts.$invalid ||
-              form.plannerSettingsMinimumHosts.$modelValue < 0 ||
-              form.plannerSettingsMinimumHosts.$modelValue % 1 != 0"> A non-negative integer value for Minimum Hosts is required
-            </div>
+          </div>
+          <div ng-show="activeDistro.provider != 'static' && activeDistro.provider != 'docker' && activeDistro.planner_settings.version == 'tunable'">
             <div>
               <label class="distro-label">Target Time (sec):</label>
               <input ng-readonly="readOnly" type="number" ng-required="activeDistro.planner_settings.version == 'tunable'"


### PR DESCRIPTION
* `distro.planner_settings.minimum_hosts` should be Planner agnostic.  
* We use this lower bound when decided the number of idle hosts of a given distro that should be considered for termination; this is not Planner dependent.