### PR TITLE
EVG-6517 Do not return config error if another job has run

### DIFF
--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -82,7 +82,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 			return errors.Wrapf(versionErr, "problem finding version %s", v.Id)
 		}
 		if versionFromDB == nil {
-			return errors.Wrap(versionErrors.Errorf("could not find version %s", v.Id))
+			return errors.Errorf("could not find version %s", v.Id)
 		}
 		// If the config update number has been updated, then another task has raced with us.
 		// The error is therefore not an actual configuration problem but instead a symptom


### PR DESCRIPTION
It's possible for a config error to be returned if another job has called
g.Save(). In that case, we should not return the error. This case is equivalent
to g.Save() returning mongo.ErrNoDocuments and should therefore return the same
value.