### PR TITLE
EVG-6751 Make hourly cron

### DIFF
--- a/operations/service.go
+++ b/operations/service.go
@@ -89,9 +89,9 @@ func startSystemCronJobs(ctx context.Context, env evergreen.Environment) error {
 	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), 15*time.Minute, util.RoundPartOfHour(15), opts, func(ctx context.Context, queue amboy.Queue) error {
 		return errors.WithStack(queue.Put(ctx, units.NewCronRemoteFifteenMinuteJob()))
 	})
-	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), 24*time.Hour, util.RoundPartOfDay(0), opts, units.PopulateJasperDeployJobs(env))
-
-	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), 3*time.Hour, util.RoundPartOfHour(0), opts, units.PopulateCacheHistoricalTestDataJob(6))
+	amboy.IntervalQueueOperation(ctx, env.RemoteQueue(), time.Hour, util.RoundPartOfDay(1), opts, func(ctx context.Context, queue amboy.Queue) error {
+		return errors.WithStack(queue.Put(ctx, units.NewCronRemoteHourJob()))
+	})
 
 	////////////////////////////////////////////////////////////////////////
 	//

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -37,7 +37,7 @@ func NewCronRemoteHourJob() amboy.Job {
 		},
 	}
 	j.SetDependency(dependency.NewAlways())
-	j.SetID(fmt.Sprintf("%s.%s", cronsRemoteHourJobName, util.RoundPartOfHour(15).Format(tsFormat)))
+	j.SetID(fmt.Sprintf("%s.%s", cronsRemoteHourJobName, util.RoundPartOfHour(0).Format(tsFormat)))
 	return j
 }
 

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -1,0 +1,73 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/dependency"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+)
+
+const cronsRemoteHourJobName = "crons-remote-hour"
+
+func init() {
+	registry.AddJobType(cronsRemoteHourJobName, NewCronRemoteHourJob)
+}
+
+type cronsRemoteHourJob struct {
+	job.Base   `bson:"job_base" json:"job_base" yaml:"job_base"`
+	ErrorCount int `bson:"error_count" json:"error_count" yaml:"error_count"`
+	env        evergreen.Environment
+}
+
+func NewCronRemoteHourJob() amboy.Job {
+	j := &cronsRemoteHourJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    cronsRemoteHourJobName,
+				Version: 0,
+			},
+		},
+	}
+	j.SetDependency(dependency.NewAlways())
+	j.SetID(fmt.Sprintf("%s.%s", cronsRemoteHourJobName, util.RoundPartOfHour(15).Format(tsFormat)))
+	return j
+}
+
+func (j *cronsRemoteHourJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+
+	ops := []amboy.QueueOperation{
+		PopulateCacheHistoricalTestDataJob(6),
+		PopulateJasperDeployJobs(j.env),
+	}
+
+	queue := j.env.RemoteQueue()
+	catcher := grip.NewBasicCatcher()
+	for _, op := range ops {
+		if ctx.Err() != nil {
+			j.AddError(errors.New("operation aborted"))
+		}
+
+		catcher.Add(op(ctx, queue))
+	}
+	j.ErrorCount = catcher.Len()
+
+	grip.Debug(message.Fields{
+		"queue": "service",
+		"id":    j.ID(),
+		"type":  j.Type().Name,
+		"num":   len(ops),
+		"errs":  j.ErrorCount,
+	})
+}


### PR DESCRIPTION
This makes an hourly cron and adds the cache historical test data and the jasper
deploy jobs to it. We currently have a fifteen-minute but nothing on an hourly
cadence.