### PR TITLE
EVG-6517 Don't generate tasks if the generator is not running

### DIFF
--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/validator"
@@ -59,6 +60,14 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	if t.GeneratedTasks {
 		grip.Debug(message.Fields{
 			"message": "attempted to generate tasks, but generator already ran for this task",
+			"task":    t.Id,
+			"version": t.Version,
+		})
+		return nil
+	}
+	if t.Status != evergreen.TaskStarted {
+		grip.Debug(message.Fields{
+			"message": "task is not running, not generating tasks",
 			"task":    t.Id,
 			"version": t.Version,
 		})

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -171,6 +172,7 @@ func TestGenerateTasks(t *testing.T) {
 		Project:       "mci",
 		DisplayName:   "sample_task",
 		GeneratedJSON: sampleGeneratedProject,
+		Status:        evergreen.TaskStarted,
 	}
 	sampleDistros := []distro.Distro{
 		distro.Distro{


### PR DESCRIPTION
If a task is aborted or timed out, there may still be generate jobs in the
queue. However, they should not run. In the former case, the user has indicated
that they don't want them to run by aborting the task. In the latter case, if
the generated tasks end up in a display task with the generator, then that task
will be purple or red even if all the generated tasks succeed. The user may
restart this task, causing not just the generator, but all the other tasks to
reexecute.