### PR TITLE
EVG-6568 load only necessary data

### DIFF
--- a/public/static/js/patches.js
+++ b/public/static/js/patches.js
@@ -19,7 +19,7 @@ mciModule.controller('PatchesController', function($scope, $filter, $http, $wind
 
   $scope.loadCurrentPage = function() {
     $scope.loading = true;
-    $scope.uiPatches = [];
+    $scope.patches = [];
     $scope.patchesError = null;
 
     var params = {
@@ -31,21 +31,21 @@ mciModule.controller('PatchesController', function($scope, $filter, $http, $wind
     function(resp) {
       var data = resp.data;
       $scope.loading = false;
-      $scope.versionsMap = data['VersionsMap'];
-      $scope.uiPatches = data['UIPatches'];
+      $scope.buildsMap = data['BuildsMap'];
+      $scope.patches = data['UIPatches'];
 
-      _.each($scope.uiPatches, function(patch) {
-          patch.canEdit = ($window.user.Id === patch.Patch.Author ) || $window.isSuperUser
+      _.each($scope.patches, function(patch) {
+          patch.canEdit = ($window.user.Id === patch.Author ) || $window.isSuperUser
       });
 
-      _.each($scope.versionsMap, function(version) {
-        _.each(version.Builds, function(build) {
+      _.each($scope.buildsMap, function(buildArray) {
+        _.each(buildArray, function(build) {
           build.taskResults = [];
-          _.each(build.Tasks, function(task) {
+          _.each(build.tasks, function(task) {
             build.taskResults.push({
-              link: '/task/' + task.Task.id,
-              tooltip: task.Task.display_name,
-              'class': $filter('statusFilter')(task.Task),
+              link: '/task/' + task.id,
+              tooltip: task.display_name,
+              'class': $filter('statusFilter')(task),
             });
           });
         });

--- a/service/models.go
+++ b/service/models.go
@@ -100,42 +100,6 @@ type uiTask struct {
 	ExpectedDuration time.Duration `json:"expected_duration"`
 }
 
-func PopulateUIVersion(version *model.Version) (*uiVersion, error) {
-	buildIds := version.BuildIds
-	dbBuilds, err := build.Find(build.ByIds(buildIds))
-	if err != nil {
-		return nil, err
-	}
-
-	buildsMap := make(map[string]build.Build)
-	for _, dbBuild := range dbBuilds {
-		buildsMap[dbBuild.Id] = dbBuild
-	}
-
-	uiBuilds := make([]uiBuild, len(dbBuilds))
-	for buildIdx, build := range dbBuilds {
-		b := buildsMap[build.Id]
-		buildAsUI := uiBuild{Build: b}
-
-		//Use the build's task cache, instead of querying for each individual task.
-		uiTasks := make([]uiTask, len(b.Tasks))
-		for i, t := range b.Tasks {
-			uiTasks[i] = uiTask{
-				Task: task.Task{
-					Id:          t.Id,
-					Status:      t.Status,
-					Details:     t.StatusDetails,
-					DisplayName: t.DisplayName,
-				},
-			}
-		}
-
-		buildAsUI.Tasks = uiTasks
-		uiBuilds[buildIdx] = buildAsUI
-	}
-	return &uiVersion{Version: (*version), Builds: uiBuilds}, nil
-}
-
 ///////////////////////////////////////////////////////////////////////////
 //// Functions to create and populate the models
 ///////////////////////////////////////////////////////////////////////////

--- a/service/templates/patches.html
+++ b/service/templates/patches.html
@@ -28,7 +28,7 @@ Evergreen - Patches
       Error loading data from server: [[patchesError]]
     </div>
 
-    <div  ng-if="uiPatches.length > 0"
+    <div  ng-if="patches.length > 0"
           class="btn-group btn-group-sm pagination-fixed">
       <span ng-if="currentPage > 0">
         <a  class="btn btn-default"
@@ -47,41 +47,41 @@ Evergreen - Patches
     </div>
   </header>
 
-  <div ng-repeat="patch in uiPatches">
-    <span ng-if="patch.Patch.Version">
-      <a ng-href="/version/[[patch.Patch.Version]]">Activated</a>
+  <div ng-repeat="patch in patches">
+    <span ng-if="patch.version">
+      <a ng-href="/version/[[patch.version]]">Activated</a>
         <span ng-show="patch.canEdit">
         [&nbsp;
-        <a ng-href="/patch/[[patch.Patch.Id]]" class="semi-muted">
+        <a ng-href="/patch/[[patch.id]]" class="semi-muted">
           Reconfigure
         </a>
         &nbsp;]
       </span>
     </span>
-    <span ng-if="!patch.Patch.Version">
-      <a ng-href="/patch/[[patch.Patch.Id]]" class="btn btn-info btn-sm">
+    <span ng-if="!patch.version">
+      <a ng-href="/patch/[[patch.id]]" class="btn btn-info btn-sm">
         Configure
       </a>
     </span>
 
     <span>
       Patch from
-      <b><a ng-href="/patches/user/[[patch.Patch.Author]]">[[patch.Patch.Author]]</a></b>
-      at [[patch.Patch.CreateTime | convertDateToUserTimezone:userTz:"MM/DD/YY h:mma"]]
-      on [[patch.Patch.Project]] applied to
-      <a ng-href="/version/[[patch.BaseVersionId]]">
-        [[patch.Patch.Githash | limitTo:7]]
+      <b><a ng-href="/patches/user/[[patch.author]]">[[patch.author]]</a></b>
+      at [[patch.create_time | convertDateToUserTimezone:userTz:"MM/DD/YY h:mma"]]
+      on [[patch.project]] applied to
+      <a ng-href="/version/[[patch.base_version_id]]">
+        [[patch.githash | limitTo:7]]
       </a>
     </span>
 
-    <div ng-if="patch.Patch.Description">
-      <strong>[[patch.Patch.Description | limitTo:140]]</strong>
+    <div ng-if="patch.description">
+      <strong>[[patch.description | limitTo:140]]</strong>
     </div>
 
-    <ul ng-if="patch.Patch.Version">
-      <li ng-repeat="build in versionsMap[patch.Patch.Version].Builds | orderBy:'Build.display_name'" class="timeline-build">
-        <a id="[[build.Build._id]]" class="build-link" ng-class="build.Build.tasks | buildStatus" ng-href="/build/[[build.Build._id]]">
-          [[build.Build.display_name]]
+    <ul ng-if="patch.version">
+      <li ng-repeat="build in buildsMap[patch.version] | orderBy:'display_name'" class="timeline-build">
+        <a id="[[build.id]]" class="build-link" ng-class="build.tasks | buildStatus" ng-href="/build/[[build.id]]">
+          [[build.display_name]]
         </a>
         <div class="tasks-list patches" results-bar="build.taskResults">
         </div>
@@ -89,7 +89,7 @@ Evergreen - Patches
     </ul>
   </div>
 
-  <div ng-if="(!uiPatches || uiPatches.length === 0) && !loading">
+  <div ng-if="(!patches || patches.length === 0) && !loading">
     <p>There are no patches on this project</p>
   </div>
 </div>

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -4,12 +4,38 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
 )
+
+type PatchInfo struct {
+	Id            string    `json:"id"`
+	Version       string    `json:"version"`
+	Author        string    `json:"author"`
+	CreateTime    time.Time `json:"create_time"`
+	Project       string    `json:"project"`
+	Description   string    `json:"description"`
+	Githash       string    `json:"githash"`
+	BaseVersionId string    `json:"base_version_id"`
+}
+
+type BuildInfo struct {
+	Id          string     `json:"id"`
+	DisplayName string     `json:"display_name"`
+	Tasks       []TaskInfo `json:"tasks"`
+}
+type TaskInfo struct {
+	Id          string                  `json:"id"`
+	DisplayName string                  `json:"display_name"`
+	Status      string                  `json:"status"`
+	Details     apimodels.TaskEndDetail `json:"status_details"`
+}
 
 func (uis *UIServer) timelineJson(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
@@ -100,7 +126,7 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 	}
 
 	versionIds := make([]string, 0, len(patches))
-	uiPatches := make([]uiPatch, 0, len(patches))
+	uiPatches := make([]PatchInfo, 0, len(patches))
 	for _, patch := range patches {
 		if patch.Version != "" {
 			versionIds = append(versionIds, patch.Version)
@@ -115,8 +141,17 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 		if baseVersion != nil {
 			baseVersionId = baseVersion.Id
 		}
-		patch.Patches = nil
-		uiPatches = append(uiPatches, uiPatch{Patch: patch, BaseVersionId: baseVersionId})
+
+		uiPatches = append(uiPatches, PatchInfo{
+			Id:            patch.Id.Hex(),
+			Version:       patch.Version,
+			Author:        patch.Author,
+			CreateTime:    patch.CreateTime,
+			Project:       patch.Project,
+			Description:   patch.Description,
+			Githash:       patch.Githash,
+			BaseVersionId: baseVersionId,
+		})
 	}
 	versions, err := model.VersionFind(model.VersionByIds(versionIds).WithoutFields(model.VersionConfigKey))
 	if err != nil {
@@ -124,21 +159,48 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	versionsMap := map[string]*uiVersion{}
+	buildsMap := map[string][]BuildInfo{}
 	for _, version := range versions {
-		versionUI, err := PopulateUIVersion(&version)
+		builds, err := getBuildInfo(version.BuildIds)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}
-		versionsMap[version.Id] = versionUI
+		buildsMap[version.Id] = builds
 	}
 
 	data := struct {
-		VersionsMap map[string]*uiVersion
-		UIPatches   []uiPatch
-		PageNum     int
-	}{versionsMap, uiPatches, pageNum}
+		BuildsMap map[string][]BuildInfo
+		UIPatches []PatchInfo
+		PageNum   int
+	}{buildsMap, uiPatches, pageNum}
 
 	gimlet.WriteJSON(w, data)
+}
+
+func getBuildInfo(buildIds []string) ([]BuildInfo, error) {
+	dbBuilds, err := build.Find(build.ByIds(buildIds))
+	if err != nil {
+		return nil, errors.Wrap(err, "can't get builds")
+	}
+
+	builds := make([]BuildInfo, 0, len(dbBuilds))
+	for _, dbBuild := range dbBuilds {
+		tasks := make([]TaskInfo, 0, len(dbBuild.Tasks))
+		for _, task := range dbBuild.Tasks {
+			tasks = append(tasks, TaskInfo{
+				Id:          task.Id,
+				DisplayName: task.DisplayName,
+				Status:      task.Status,
+				Details:     task.StatusDetails,
+			})
+		}
+		builds = append(builds, BuildInfo{
+			Id:          dbBuild.Id,
+			DisplayName: dbBuild.DisplayName,
+			Tasks:       tasks,
+		})
+	}
+
+	return builds, nil
 }


### PR DESCRIPTION
The new and old patches pages load a lot of unnecessary data which causes slow load times for users with large builds. This PR is to pass only the required data.
Goes with https://github.com/evergreen-ci/spruce/pull/24 and https://github.com/evergreen-ci/evergreen.js/pull/10