### PR TITLE
EVG-6755 reset all blocked tasks

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1836,7 +1836,9 @@ func (t *Task) UpdateUnblockedDependencies() error {
 		if err = blockedTask.MarkUnattainableDependency(t, false); err != nil {
 			return errors.Wrap(err, "error marking dependency attainable")
 		}
-		return errors.WithStack(blockedTask.UpdateUnblockedDependencies())
+		if err = blockedTask.UpdateUnblockedDependencies(); err != nil {
+			return errors.WithStack(err)
+		}
 	}
 
 	return nil

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1308,8 +1308,8 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 			Id: "t2",
 			DependsOn: []Dependency{
 				{
-					TaskId:       "t1",
-					Unattainable: false,
+					TaskId:       "t0",
+					Unattainable: true,
 				},
 			},
 			Status: evergreen.TaskUndispatched,
@@ -1319,6 +1319,16 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 			DependsOn: []Dependency{
 				{
 					TaskId:       "t2",
+					Unattainable: false,
+				},
+			},
+			Status: evergreen.TaskUndispatched,
+		},
+		{
+			Id: "t4",
+			DependsOn: []Dependency{
+				{
+					TaskId:       "t3",
 					Unattainable: true,
 				},
 			},
@@ -1337,10 +1347,13 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 	dbTask2, err := FindOneId(tasks[2].Id)
 	assert.NoError(err)
 	assert.False(dbTask2.DependsOn[0].Unattainable)
-	// We don't traverse past the t2 which was already unattainable == false
 	dbTask3, err := FindOneId(tasks[3].Id)
 	assert.NoError(err)
-	assert.True(dbTask3.DependsOn[0].Unattainable)
+	assert.False(dbTask3.DependsOn[0].Unattainable)
+	// We don't traverse past the t3 which was already unattainable == false
+	dbTask4, err := FindOneId(tasks[4].Id)
+	assert.NoError(err)
+	assert.True(dbTask4.DependsOn[0].Unattainable)
 }
 
 func TestFindAllUnmarkedBlockedDependencies(t *testing.T) {


### PR DESCRIPTION
The loop was ending on the first iteration so only one blocked dependency was actually cleared every time the task was reset.