### PR TITLE
EVG-6745 allow override deps for blocked tasks

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -477,7 +477,10 @@ func scheduleableTasksQuery() bson.M {
 		PriorityKey: bson.M{"$gte": 0},
 
 		//Filter tasks containing unattainable dependencies
-		bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey): bson.M{"$ne": true},
+		"$or": []bson.M{
+			{bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey): bson.M{"$ne": true}},
+			{OverrideDependenciesKey: true},
+		},
 	}
 }
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1466,11 +1466,11 @@ func TestUnattainableScheduleableTasksQuery(t *testing.T) {
 			DependsOn: []Dependency{
 				{
 					TaskId:       "t10",
-					Unattainable: true,
+					Unattainable: false,
 				},
 				{
 					TaskId:       "t11",
-					Unattainable: false,
+					Unattainable: true,
 				},
 			},
 			Priority: 0,
@@ -1498,9 +1498,11 @@ func TestUnattainableScheduleableTasksQuery(t *testing.T) {
 			Priority:  0,
 			DependsOn: []Dependency{
 				{
-					TaskId: "t10",
+					TaskId:       "t10",
+					Unattainable: true,
 				},
 			},
+			OverrideDependencies: true,
 		},
 	}
 	for _, task := range tasks {


### PR DESCRIPTION
Although overriding dependencies makes all dependencies satisfied, blocked tasks were not up for consideration by the scheduler since they were excluded by the scheduleableTasksQuery.