### PR TITLE
EVG-6624 Modify instance type for spawn hosts

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -540,19 +540,6 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, changes host.
 		return err
 	}
 
-	// Change instance type
-	if changes.InstanceType != "" {
-		_, err = m.client.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
-			InstanceId: aws.String(h.Id),
-			InstanceType: &ec2.AttributeValue{
-				Value: aws.String(changes.InstanceType),
-			},
-		})
-		if err != nil {
-			return errors.Wrapf(err, "error changing instance type for '%s'", h.Id)
-		}
-	}
-
 	// Delete tags
 	if len(changes.DeleteInstanceTags) > 0 {
 		deleteTagSlice := []*ec2.Tag{}
@@ -583,6 +570,19 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, changes host.
 		})
 		if err != nil {
 			return errors.Wrapf(err, "error creating tags for '%s'", h.Id)
+		}
+	}
+
+	// Change instance type
+	if changes.InstanceType != "" {
+		_, err = m.client.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
+			InstanceId: aws.String(h.Id),
+			InstanceType: &ec2.AttributeValue{
+				Value: aws.String(changes.InstanceType),
+			},
+		})
+		if err != nil {
+			return errors.Wrapf(err, "error changing instance type for '%s'", h.Id)
 		}
 	}
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -442,7 +442,9 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 	if h.InstanceType != "" {
 		ec2Settings.InstanceType = h.InstanceType
 	} else {
-		h.SetInstanceType(ec2Settings.InstanceType)
+		if err = h.SetInstanceType(ec2Settings.InstanceType); err != nil {
+			return nil, errors.Wrap(err, "error setting instance type")
+		}
 	}
 	provider, err := m.getProvider(ctx, h, ec2Settings)
 	if err != nil {
@@ -554,7 +556,8 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, changes host.
 		if err != nil {
 			return errors.Wrapf(err, "error deleting tags using client for '%s'", h.Id)
 		}
-		if err = h.DeleteTags(changes.DeleteInstanceTags); err != nil {
+		h.DeleteTags(changes.DeleteInstanceTags)
+		if err = h.SetTags(); err != nil {
 			return errors.Wrapf(err, "error deleting tags in db for '%s'", h.Id)
 		}
 	}
@@ -574,7 +577,8 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, changes host.
 		if err != nil {
 			return errors.Wrapf(err, "error creating tags using client for '%s'", h.Id)
 		}
-		if err = h.AddTags(changes.AddInstanceTags); err != nil {
+		h.AddTags(changes.AddInstanceTags)
+		if err = h.SetTags(); err != nil {
 			return errors.Wrapf(err, "error creating tags in db for '%s'", h.Id)
 		}
 	}

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -438,7 +438,6 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 	if err != nil {
 		return nil, errors.Wrap(err, "error making block device mappings")
 	}
-
 	if h.InstanceType != "" {
 		ec2Settings.InstanceType = h.InstanceType
 	} else {

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -552,7 +552,10 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, changes host.
 			Tags:      deleteTagSlice,
 		})
 		if err != nil {
-			return errors.Wrapf(err, "error deleting tags for '%s'", h.Id)
+			return errors.Wrapf(err, "error deleting tags using client for '%s'", h.Id)
+		}
+		if err = h.DeleteTags(changes.DeleteInstanceTags); err != nil {
+			return errors.Wrapf(err, "error deleting tags in db for '%s'", h.Id)
 		}
 	}
 
@@ -569,7 +572,10 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, changes host.
 			Tags:      createTagSlice,
 		})
 		if err != nil {
-			return errors.Wrapf(err, "error creating tags for '%s'", h.Id)
+			return errors.Wrapf(err, "error creating tags using client for '%s'", h.Id)
+		}
+		if err = h.AddTags(changes.AddInstanceTags); err != nil {
+			return errors.Wrapf(err, "error creating tags in db for '%s'", h.Id)
 		}
 	}
 
@@ -582,7 +588,10 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, changes host.
 			},
 		})
 		if err != nil {
-			return errors.Wrapf(err, "error changing instance type for '%s'", h.Id)
+			return errors.Wrapf(err, "error changing instance type using client for '%s'", h.Id)
+		}
+		if err = h.SetInstanceType(changes.InstanceType); err != nil {
+			return errors.Wrapf(err, "error changing instance type in db for '%s'", h.Id)
 		}
 	}
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -213,6 +213,8 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 
 	if h.InstanceType != "" {
 		input.InstanceType = aws.String(h.InstanceType)
+	} else {
+		h.SetInstanceType(ec2Settings.InstanceType)
 	}
 
 	if ec2Settings.IsVpc {

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -441,9 +441,7 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 	if h.InstanceType != "" {
 		ec2Settings.InstanceType = h.InstanceType
 	} else {
-		if err = h.SetInstanceType(ec2Settings.InstanceType); err != nil {
-			return nil, errors.Wrap(err, "error setting instance type")
-		}
+		h.InstanceType = ec2Settings.InstanceType
 	}
 	provider, err := m.getProvider(ctx, h, ec2Settings)
 	if err != nil {

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -542,6 +542,19 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, changes host.
 		return err
 	}
 
+	// Change instance type
+	if changes.InstanceType != "" {
+		_, err = m.client.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
+			InstanceId: aws.String(h.Id),
+			InstanceType: &ec2.AttributeValue{
+				Value: aws.String(changes.InstanceType),
+			},
+		})
+		if err != nil {
+			return errors.Wrapf(err, "error changing instance type for '%s'", h.Id)
+		}
+	}
+
 	// Delete tags
 	if len(changes.DeleteInstanceTags) > 0 {
 		deleteTagSlice := []*ec2.Tag{}

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -583,10 +583,6 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, changes host.
 
 	// Add tags
 	if len(changes.AddInstanceTags) > 0 {
-		if h.Status != evergreen.HostStopped {
-			return errors.Errorf("cannot modify instance type - host '%s' is not stopped", h.Id)
-		}
-
 		createTagSlice := []*ec2.Tag{}
 		for _, tag := range changes.AddInstanceTags {
 			key := tag.Key

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -211,6 +211,10 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		BlockDeviceMappings: blockDevices,
 	}
 
+	if h.InstanceType != "" {
+		input.InstanceType = aws.String(h.InstanceType)
+	}
+
 	if ec2Settings.IsVpc {
 		input.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{
 			&ec2.InstanceNetworkInterfaceSpecification{

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -211,12 +211,6 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		BlockDeviceMappings: blockDevices,
 	}
 
-	if h.InstanceType != "" {
-		input.InstanceType = aws.String(h.InstanceType)
-	} else {
-		h.SetInstanceType(ec2Settings.InstanceType)
-	}
-
 	if ec2Settings.IsVpc {
 		input.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{
 			&ec2.InstanceNetworkInterfaceSpecification{
@@ -444,8 +438,12 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 	if err != nil {
 		return nil, errors.Wrap(err, "error making block device mappings")
 	}
-	h.InstanceType = ec2Settings.InstanceType
 
+	if h.InstanceType != "" {
+		ec2Settings.InstanceType = h.InstanceType
+	} else {
+		h.SetInstanceType(ec2Settings.InstanceType)
+	}
 	provider, err := m.getProvider(ctx, h, ec2Settings)
 	if err != nil {
 		msg := "error getting provider"

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -901,6 +901,7 @@ type awsClientMock struct { //nolint
 	*ec2.DescribeInstancesInput
 	*ec2.CreateTagsInput
 	*ec2.DeleteTagsInput
+	*ec2.ModifyInstanceAttributeInput
 	*ec2.TerminateInstancesInput
 	*ec2.StopInstancesInput
 	*ec2.StartInstancesInput
@@ -998,6 +999,11 @@ func (c *awsClientMock) CreateTags(ctx context.Context, input *ec2.CreateTagsInp
 // DeleteTags is a mock for ec2.DeleteTags.
 func (c *awsClientMock) DeleteTags(ctx context.Context, input *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
 	c.DeleteTagsInput = input
+	return nil, nil
+}
+
+func (c *awsClientMock) ModifyInstanceAttribute(ctx context.Context, input *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
+	c.ModifyInstanceAttributeInput = input
 	return nil, nil
 }
 

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -77,14 +77,12 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 
 	d := fetchTestDistro()
 	d.Provider = evergreen.ProviderNameEc2OnDemand
-	intent := host.NewIntent(d, d.GenerateName(), d.Provider, host.CreateOptions{
+	h := host.NewIntent(d, d.GenerateName(), d.Provider, host.CreateOptions{
 		UserName: evergreen.User,
 		UserHost: false,
 	})
-	assert.NoError(intent.Insert())
-	h, err := m.SpawnHost(ctx, intent)
+	h, err := m.SpawnHost(ctx, h)
 	assert.NoError(err)
-	assert.NoError(intent.Remove())
 	assert.NoError(h.Insert())
 	foundHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)
@@ -123,14 +121,12 @@ func TestSpawnEC2InstanceSpot(t *testing.T) {
 	require.NoError(m.client.Create(m.credentials, defaultRegion))
 	d := fetchTestDistro()
 	d.Provider = evergreen.ProviderNameEc2Spot
-	intent := host.NewIntent(d, d.GenerateName(), d.Provider, host.CreateOptions{
+	h := host.NewIntent(d, d.GenerateName(), d.Provider, host.CreateOptions{
 		UserName: evergreen.User,
 		UserHost: false,
 	})
-	assert.NoError(intent.Insert())
-	h, err := m.SpawnHost(ctx, intent)
+	h, err := m.SpawnHost(ctx, h)
 	assert.NoError(err)
-	assert.NoError(intent.Remove())
 	assert.NoError(h.Insert())
 	foundHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -77,13 +77,15 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 
 	d := fetchTestDistro()
 	d.Provider = evergreen.ProviderNameEc2OnDemand
-	h := host.NewIntent(d, d.GenerateName(), d.Provider, host.CreateOptions{
+	intent := host.NewIntent(d, d.GenerateName(), d.Provider, host.CreateOptions{
 		UserName: evergreen.User,
 		UserHost: false,
 	})
-	assert.NoError(h.Insert())
-	h, err := m.SpawnHost(ctx, h)
+	assert.NoError(intent.Insert())
+	h, err := m.SpawnHost(ctx, intent)
 	assert.NoError(err)
+	assert.NoError(intent.Remove())
+	assert.NoError(h.Insert())
 	foundHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)
 	assert.Len(foundHosts, 1)
@@ -121,13 +123,15 @@ func TestSpawnEC2InstanceSpot(t *testing.T) {
 	require.NoError(m.client.Create(m.credentials, defaultRegion))
 	d := fetchTestDistro()
 	d.Provider = evergreen.ProviderNameEc2Spot
-	h := host.NewIntent(d, d.GenerateName(), d.Provider, host.CreateOptions{
+	intent := host.NewIntent(d, d.GenerateName(), d.Provider, host.CreateOptions{
 		UserName: evergreen.User,
 		UserHost: false,
 	})
-	assert.NoError(h.Insert())
-	h, err := m.SpawnHost(ctx, h)
+	assert.NoError(intent.Insert())
+	h, err := m.SpawnHost(ctx, intent)
 	assert.NoError(err)
+	assert.NoError(intent.Remove())
+	assert.NoError(h.Insert())
 	foundHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)
 	assert.Len(foundHosts, 1)

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -82,7 +82,7 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 		UserHost: false,
 	})
 	assert.NoError(h.Insert())
-	_, err := m.SpawnHost(ctx, h)
+	h, err := m.SpawnHost(ctx, h)
 	assert.NoError(err)
 	foundHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)
@@ -126,7 +126,7 @@ func TestSpawnEC2InstanceSpot(t *testing.T) {
 		UserHost: false,
 	})
 	assert.NoError(h.Insert())
-	_, err := m.SpawnHost(ctx, h)
+	h, err := m.SpawnHost(ctx, h)
 	assert.NoError(err)
 	foundHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -81,9 +81,9 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 		UserName: evergreen.User,
 		UserHost: false,
 	})
-	h, err := m.SpawnHost(ctx, h)
-	assert.NoError(err)
 	assert.NoError(h.Insert())
+	_, err := m.SpawnHost(ctx, h)
+	assert.NoError(err)
 	foundHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)
 	assert.Len(foundHosts, 1)
@@ -125,9 +125,9 @@ func TestSpawnEC2InstanceSpot(t *testing.T) {
 		UserName: evergreen.User,
 		UserHost: false,
 	})
-	h, err := m.SpawnHost(ctx, h)
-	assert.NoError(err)
 	assert.NoError(h.Insert())
+	_, err := m.SpawnHost(ctx, h)
+	assert.NoError(err)
 	foundHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)
 	assert.Len(foundHosts, 1)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -615,7 +615,6 @@ func (s *EC2Suite) TestSpawnHostForTask() {
 }
 
 func (s *EC2Suite) TestModifyHost() {
-	s.Require().NoError(s.h.Insert())
 	changes := host.HostModifyOptions{
 		AddInstanceTags: []host.Tag{
 			host.Tag{
@@ -631,6 +630,13 @@ func (s *EC2Suite) TestModifyHost() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	s.h.Status = evergreen.HostRunning
+	s.Require().NoError(s.h.Insert())
+	s.Error(s.onDemandManager.ModifyHost(ctx, s.h, changes))
+	s.Require().NoError(s.h.Remove())
+
+	s.h.Status = evergreen.HostStopped
+	s.Require().NoError(s.h.Insert())
 	s.NoError(s.onDemandManager.ModifyHost(ctx, s.h, changes))
 	found, err := host.FindOne(host.ById(s.h.Id))
 	s.NoError(err)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -107,6 +107,13 @@ func (s *EC2Suite) SetupTest() {
 	s.h = &host.Host{
 		Id:     "h1",
 		Distro: s.distro,
+		InstanceTags: []host.Tag{
+			host.Tag{
+				Key:           "key-1",
+				Value:         "val-1",
+				CanBeModified: true,
+			},
+		},
 	}
 }
 
@@ -362,6 +369,7 @@ func (s *EC2Suite) TestSpawnHostClassicOnDemand() {
 		"subnet_id":          "subnet-123456",
 		"user_data":          someUserData,
 	}
+	s.Require().NoError(s.h.Insert())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -408,6 +416,7 @@ func (s *EC2Suite) TestSpawnHostVPCOnDemand() {
 		"is_vpc":             true,
 		"user_data":          someUserData,
 	}
+	s.Require().NoError(h.Insert())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -450,6 +459,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpot() {
 		"subnet_id":          "subnet-123456",
 		"user_data":          someUserData,
 	}
+	s.Require().NoError(h.Insert())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -493,6 +503,7 @@ func (s *EC2Suite) TestSpawnHostVPCSpot() {
 		"is_vpc":             true,
 		"user_data":          someUserData,
 	}
+	s.Require().NoError(h.Insert())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -535,6 +546,7 @@ func (s *EC2Suite) TestNoKeyAndNotSpawnHostForTaskShouldFail() {
 		"is_vpc":             true,
 		"user_data":          someUserData,
 	}
+	s.Require().NoError(h.Insert())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -568,6 +580,7 @@ func (s *EC2Suite) TestSpawnHostForTask() {
 	h.SpawnOptions.TaskID = "task_1"
 	h.StartedBy = "task_1"
 	h.SpawnOptions.SpawnedByTask = true
+	s.Require().NoError(h.Insert())
 	s.Require().NoError(t.Insert())
 	newVars := &model.ProjectVars{
 		Id: project,
@@ -600,6 +613,31 @@ func (s *EC2Suite) TestSpawnHostForTask() {
 	s.Nil(runInput.SubnetId)
 	s.Equal(base64OfSomeUserData, *runInput.UserData)
 }
+
+func (s *EC2Suite) TestModifyHost() {
+	s.Require().NoError(s.h.Insert())
+	changes := host.HostModifyOptions{
+		AddInstanceTags: []host.Tag{
+			host.Tag{
+				Key:           "key-2",
+				Value:         "val-2",
+				CanBeModified: true,
+			},
+		},
+		DeleteInstanceTags: []string{"key-1"},
+		InstanceType:       "instance-type-2",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.NoError(s.onDemandManager.ModifyHost(ctx, s.h, changes))
+	found, err := host.FindOne(host.ById(s.h.Id))
+	s.NoError(err)
+	s.Equal([]host.Tag{host.Tag{Key: "key-2", Value: "val-2", CanBeModified: true}}, found.InstanceTags)
+	s.Equal(changes.InstanceType, found.InstanceType)
+}
+
 func (s *EC2Suite) TestGetInstanceStatus() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -151,20 +151,22 @@ func (mockMgr *mockManager) ModifyHost(ctx context.Context, host *host.Host, cha
 	if !ok {
 		return errors.Errorf("unable to fetch host: %s", host.Id)
 	}
-	if err = host.AddTags(changes.AddInstanceTags); err != nil {
-		return errors.Errorf("error ")
+	host.AddTags(changes.AddInstanceTags)
+	if err := host.SetTags(); err != nil {
+		return errors.Errorf("error adding tags in db")
 	}
 	instance.Tags = host.InstanceTags
 	mockMgr.Instances[host.Id] = instance
 
-	if err = host.DeleteTags(changes.DeleteInstanceTags); err != nil {
-		return errors.Errorf("error ")
+	host.DeleteTags(changes.DeleteInstanceTags)
+	if err := host.SetTags(); err != nil {
+		return errors.Errorf("error deleting tags in db")
 	}
 	instance.Tags = host.InstanceTags
 	mockMgr.Instances[host.Id] = instance
 
 	if err = host.SetInstanceType(changes.InstanceType); err != nil {
-		return errors.Errorf("error ")
+		return errors.Errorf("error setting instance type in db")
 	}
 	instance.Type = host.InstanceType
 	mockMgr.Instances[host.Id] = instance

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -30,6 +30,8 @@ type MockInstance struct {
 	TimeTilNextPayment time.Duration
 	DNSName            string
 	OnUpRan            bool
+	Tags               []host.Tag
+	Type               string
 }
 
 type MockProvider interface {
@@ -140,7 +142,33 @@ func (mockMgr *mockManager) SpawnHost(ctx context.Context, h *host.Host) (*host.
 	return h, nil
 }
 
-func (mockMgr *mockManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {
+func (mockMgr *mockManager) ModifyHost(ctx context.Context, host *host.Host, changes host.HostModifyOptions) error {
+	l := mockMgr.mutex
+	l.Lock()
+	defer l.Unlock()
+	var err error
+	instance, ok := mockMgr.Instances[host.Id]
+	if !ok {
+		return errors.Errorf("unable to fetch host: %s", host.Id)
+	}
+	if err = host.AddTags(changes.AddInstanceTags); err != nil {
+		return errors.Errorf("error ")
+	}
+	instance.Tags = host.InstanceTags
+	mockMgr.Instances[host.Id] = instance
+
+	if err = host.DeleteTags(changes.DeleteInstanceTags); err != nil {
+		return errors.Errorf("error ")
+	}
+	instance.Tags = host.InstanceTags
+	mockMgr.Instances[host.Id] = instance
+
+	if err = host.SetInstanceType(changes.InstanceType); err != nil {
+		return errors.Errorf("error ")
+	}
+	instance.Type = host.InstanceType
+	mockMgr.Instances[host.Id] = instance
+
 	return nil
 }
 

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -151,25 +151,32 @@ func (mockMgr *mockManager) ModifyHost(ctx context.Context, host *host.Host, cha
 	if !ok {
 		return errors.Errorf("unable to fetch host: %s", host.Id)
 	}
-	host.AddTags(changes.AddInstanceTags)
-	if err := host.SetTags(); err != nil {
-		return errors.Errorf("error adding tags in db")
-	}
-	instance.Tags = host.InstanceTags
-	mockMgr.Instances[host.Id] = instance
 
-	host.DeleteTags(changes.DeleteInstanceTags)
-	if err := host.SetTags(); err != nil {
-		return errors.Errorf("error deleting tags in db")
+	if len(changes.AddInstanceTags) > 0 {
+		host.AddTags(changes.AddInstanceTags)
+		instance.Tags = host.InstanceTags
+		mockMgr.Instances[host.Id] = instance
+		if err := host.SetTags(); err != nil {
+			return errors.Errorf("error adding tags in db")
+		}
 	}
-	instance.Tags = host.InstanceTags
-	mockMgr.Instances[host.Id] = instance
 
-	if err = host.SetInstanceType(changes.InstanceType); err != nil {
-		return errors.Errorf("error setting instance type in db")
+	if len(changes.DeleteInstanceTags) > 0 {
+		instance.Tags = host.InstanceTags
+		mockMgr.Instances[host.Id] = instance
+		host.DeleteTags(changes.DeleteInstanceTags)
+		if err := host.SetTags(); err != nil {
+			return errors.Errorf("error deleting tags in db")
+		}
 	}
-	instance.Type = host.InstanceType
-	mockMgr.Instances[host.Id] = instance
+
+	if changes.InstanceType != "" {
+		instance.Type = host.InstanceType
+		mockMgr.Instances[host.Id] = instance
+		if err = host.SetInstanceType(changes.InstanceType); err != nil {
+			return errors.Errorf("error setting instance type in db")
+		}
+	}
 
 	return nil
 }

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -45,6 +45,7 @@ type SpawnOptions struct {
 	TaskId           string
 	Owner            *user.DBUser
 	InstanceTags     []host.Tag
+	InstanceType     string
 }
 
 // Validate returns an instance of BadOptionsErr if the SpawnOptions object contains invalid

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -139,6 +139,7 @@ func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 		ExpirationDuration: &expiration,
 		UserHost:           true,
 		InstanceTags:       so.InstanceTags,
+		InstanceType:       so.InstanceType,
 	}
 
 	intentHost := host.NewIntent(d, d.GenerateName(), d.Provider, hostOptions)

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1729,3 +1729,14 @@ func (h *Host) SetTags() error {
 		},
 	)
 }
+
+// SetInstanceType
+func (h *Host) SetInstanceType(instanceType string) error {
+	err := UpdateOne(bson.M{IdKey: h.Id},
+		bson.M{"$set": bson.M{InstanceTypeKey: instanceType}})
+	if err != nil {
+		return err
+	}
+	h.InstanceType = instanceType
+	return nil
+}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1677,7 +1677,7 @@ func StaleRunningTaskIDs(staleness time.Duration) ([]task.Task, error) {
 
 // AddTags adds the specified tags to the host document, or modifies
 // an existing tag if it can be modified.
-func (h *Host) AddTags(tags []Tag) error {
+func (h *Host) AddTags(tags []Tag) {
 	for _, new := range tags {
 		found := false
 		for i, old := range h.InstanceTags {
@@ -1691,12 +1691,11 @@ func (h *Host) AddTags(tags []Tag) error {
 			h.InstanceTags = append(h.InstanceTags, new)
 		}
 	}
-	return h.SetTags()
 }
 
 // DeleteTags removes tags specified by their keys, only if those
 // keys are allowed to be deleted.
-func (h *Host) DeleteTags(keys []string) error {
+func (h *Host) DeleteTags(keys []string) {
 	for _, key := range keys {
 		for i, tag := range h.InstanceTags {
 			if tag.Key == key && tag.CanBeModified {
@@ -1705,7 +1704,6 @@ func (h *Host) DeleteTags(keys []string) error {
 			}
 		}
 	}
-	return h.SetTags()
 }
 
 // SetTags updates the host's instance tags in the database.

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1681,9 +1681,11 @@ func (h *Host) AddTags(tags []Tag) {
 	for _, new := range tags {
 		found := false
 		for i, old := range h.InstanceTags {
-			if old.Key == new.Key && old.CanBeModified {
-				h.InstanceTags[i] = new
+			if old.Key == new.Key {
 				found = true
+				if old.CanBeModified {
+					h.InstanceTags[i] = new
+				}
 				break
 			}
 		}
@@ -1722,8 +1724,16 @@ func (h *Host) SetTags() error {
 
 // SetInstanceType updates the host's instance type in the database.
 func (h *Host) SetInstanceType(instanceType string) error {
-	err := UpdateOne(bson.M{IdKey: h.Id},
-		bson.M{"$set": bson.M{InstanceTypeKey: instanceType}})
+	err := UpdateOne(
+		bson.M{
+			IdKey: h.Id,
+		},
+		bson.M{
+			"$set": bson.M{
+				InstanceTypeKey: instanceType,
+			},
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -23,6 +23,7 @@ type CreateOptions struct {
 	SpawnOptions          SpawnOptions
 	DockerOptions         DockerOptions
 	InstanceTags          []Tag
+	InstanceType          string
 }
 
 // NewIntent creates an IntentHost using the given host settings. An IntentHost is a host that
@@ -53,6 +54,7 @@ func NewIntent(d distro.Distro, instanceName, provider string, options CreateOpt
 		SpawnOptions:          options.SpawnOptions,
 		DockerOptions:         options.DockerOptions,
 		InstanceTags:          options.InstanceTags,
+		InstanceType:          options.InstanceType,
 	}
 
 	if options.ExpirationDuration != nil {

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3602,50 +3602,57 @@ func TestFindOneByJasperCredentialsID(t *testing.T) {
 }
 
 func TestAddTags(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(Collection))
-	h := &Host{
+	h := Host{
 		Id: "id",
 		InstanceTags: []Tag{
-			Tag{Key: "key1", Value: "val1", CanBeModified: true},
-			Tag{Key: "key2", Value: "val2", CanBeModified: true},
+			Tag{Key: "key-1", Value: "val-1", CanBeModified: true},
+			Tag{Key: "key-2", Value: "val-2", CanBeModified: true},
 		},
 	}
-	assert.NoError(t, h.Insert())
-
 	tagsToAdd := []Tag{
-		Tag{Key: "key2", Value: "valNew", CanBeModified: true},
-		Tag{Key: "key3", Value: "val3", CanBeModified: true},
+		Tag{Key: "key-2", Value: "val-new", CanBeModified: true},
+		Tag{Key: "key-3", Value: "val-3", CanBeModified: true},
 	}
-
-	assert.NoError(t, h.AddTags(tagsToAdd))
-	foundHost, err := FindOneId(h.Id)
-	assert.NoError(t, err)
+	h.AddTags(tagsToAdd)
 	assert.Equal(t, []Tag{
-		Tag{Key: "key1", Value: "val1", CanBeModified: true},
-		Tag{Key: "key2", Value: "valNew", CanBeModified: true},
-		Tag{Key: "key3", Value: "val3", CanBeModified: true},
-	}, foundHost.InstanceTags)
+		Tag{Key: "key-1", Value: "val-1", CanBeModified: true},
+		Tag{Key: "key-2", Value: "val-new", CanBeModified: true},
+		Tag{Key: "key-3", Value: "val-3", CanBeModified: true},
+	}, h.InstanceTags)
 }
 
 func TestDeleteTags(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(Collection))
-	h := &Host{
+	h := Host{
 		Id: "id",
 		InstanceTags: []Tag{
-			Tag{Key: "key1", Value: "val1", CanBeModified: true},
-			Tag{Key: "key2", Value: "val2", CanBeModified: true},
+			Tag{Key: "key-1", Value: "val-1", CanBeModified: true},
+			Tag{Key: "key-2", Value: "val-2", CanBeModified: true},
+		},
+	}
+	tagsToDelete := []string{"key-1"}
+	h.DeleteTags(tagsToDelete)
+	assert.Equal(t, []Tag{
+		Tag{Key: "key-2", Value: "val-2", CanBeModified: true},
+	}, h.InstanceTags)
+}
+
+func TestSetTags(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
+	h := Host{
+		Id: "id",
+		InstanceTags: []Tag{
+			Tag{Key: "key-1", Value: "val-1", CanBeModified: true},
+			Tag{Key: "key-2", Value: "val-2", CanBeModified: true},
 		},
 	}
 	assert.NoError(t, h.Insert())
-
-	tagsToDelete := []string{"key1"}
-
-	assert.NoError(t, h.DeleteTags(tagsToDelete))
+	h.InstanceTags = []Tag{
+		Tag{Key: "key-3", Value: "val-3", CanBeModified: true},
+	}
+	assert.NoError(t, h.SetTags())
 	foundHost, err := FindOneId(h.Id)
 	assert.NoError(t, err)
-	assert.Equal(t, []Tag{
-		Tag{Key: "key2", Value: "val2", CanBeModified: true},
-	}, foundHost.InstanceTags)
+	assert.Equal(t, h.InstanceTags, foundHost.InstanceTags)
 }
 
 func TestSetInstanceType(t *testing.T) {
@@ -3655,9 +3662,7 @@ func TestSetInstanceType(t *testing.T) {
 		InstanceType: "old-instance-type",
 	}
 	assert.NoError(t, h.Insert())
-
 	newInstanceType := "new-instance-type"
-
 	assert.NoError(t, h.SetInstanceType(newInstanceType))
 	foundHost, err := FindOneId(h.Id)
 	assert.NoError(t, err)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3605,16 +3605,19 @@ func TestAddTags(t *testing.T) {
 	h := Host{
 		Id: "id",
 		InstanceTags: []Tag{
+			Tag{Key: "key-fixed", Value: "val-fixed", CanBeModified: false},
 			Tag{Key: "key-1", Value: "val-1", CanBeModified: true},
 			Tag{Key: "key-2", Value: "val-2", CanBeModified: true},
 		},
 	}
 	tagsToAdd := []Tag{
+		Tag{Key: "key-fixed", Value: "val-new", CanBeModified: false},
 		Tag{Key: "key-2", Value: "val-new", CanBeModified: true},
 		Tag{Key: "key-3", Value: "val-3", CanBeModified: true},
 	}
 	h.AddTags(tagsToAdd)
 	assert.Equal(t, []Tag{
+		Tag{Key: "key-fixed", Value: "val-fixed", CanBeModified: false},
 		Tag{Key: "key-1", Value: "val-1", CanBeModified: true},
 		Tag{Key: "key-2", Value: "val-new", CanBeModified: true},
 		Tag{Key: "key-3", Value: "val-3", CanBeModified: true},
@@ -3625,13 +3628,15 @@ func TestDeleteTags(t *testing.T) {
 	h := Host{
 		Id: "id",
 		InstanceTags: []Tag{
+			Tag{Key: "key-fixed", Value: "val-fixed", CanBeModified: false},
 			Tag{Key: "key-1", Value: "val-1", CanBeModified: true},
 			Tag{Key: "key-2", Value: "val-2", CanBeModified: true},
 		},
 	}
-	tagsToDelete := []string{"key-1"}
+	tagsToDelete := []string{"key-fixed", "key-1"}
 	h.DeleteTags(tagsToDelete)
 	assert.Equal(t, []Tag{
+		Tag{Key: "key-fixed", Value: "val-fixed", CanBeModified: false},
 		Tag{Key: "key-2", Value: "val-2", CanBeModified: true},
 	}, h.InstanceTags)
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3601,7 +3601,7 @@ func TestFindOneByJasperCredentialsID(t *testing.T) {
 	}
 }
 
-func TestModifySpawnHost(t *testing.T) {
+func TestAddTags(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	h := &Host{
 		Id: "id",
@@ -3612,18 +3612,54 @@ func TestModifySpawnHost(t *testing.T) {
 	}
 	assert.NoError(t, h.Insert())
 
-	changes := HostModifyOptions{
-		AddInstanceTags: []Tag{
-			Tag{Key: "key2", Value: "valNew", CanBeModified: true},
-			Tag{Key: "key3", Value: "val3", CanBeModified: true},
-		},
-		DeleteInstanceTags: []string{"key1"},
-	}
-	assert.NoError(t, h.ModifySpawnHost(changes))
-	modifiedHost, err := FindOneId(h.Id)
-	assert.NoError(t, err)
-	assert.Equal(t, []Tag{
+	tagsToAdd := []Tag{
 		Tag{Key: "key2", Value: "valNew", CanBeModified: true},
 		Tag{Key: "key3", Value: "val3", CanBeModified: true},
-	}, modifiedHost.InstanceTags)
+	}
+
+	assert.NoError(t, h.AddTags(tagsToAdd))
+	foundHost, err := FindOneId(h.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, []Tag{
+		Tag{Key: "key1", Value: "val1", CanBeModified: true},
+		Tag{Key: "key2", Value: "valNew", CanBeModified: true},
+		Tag{Key: "key3", Value: "val3", CanBeModified: true},
+	}, foundHost.InstanceTags)
+}
+
+func TestDeleteTags(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
+	h := &Host{
+		Id: "id",
+		InstanceTags: []Tag{
+			Tag{Key: "key1", Value: "val1", CanBeModified: true},
+			Tag{Key: "key2", Value: "val2", CanBeModified: true},
+		},
+	}
+	assert.NoError(t, h.Insert())
+
+	tagsToDelete := []string{"key1"}
+
+	assert.NoError(t, h.DeleteTags(tagsToDelete))
+	foundHost, err := FindOneId(h.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, []Tag{
+		Tag{Key: "key2", Value: "val2", CanBeModified: true},
+	}, foundHost.InstanceTags)
+}
+
+func TestSetInstanceType(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
+	h := &Host{
+		Id:           "id",
+		InstanceType: "old-instance-type",
+	}
+	assert.NoError(t, h.Insert())
+
+	newInstanceType := "new-instance-type"
+
+	assert.NoError(t, h.SetInstanceType(newInstanceType))
+	foundHost, err := FindOneId(h.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, newInstanceType, foundHost.InstanceType)
 }

--- a/operations/before.go
+++ b/operations/before.go
@@ -194,10 +194,10 @@ func requireAtLeastOneBool(flags ...string) cli.BeforeFunc {
 	}
 }
 
-func requireAtLeastOneStringSlice(flags ...string) cli.BeforeFunc {
+func requireAtLeastOneFlag(flags ...string) cli.BeforeFunc {
 	return func(c *cli.Context) error {
 		for idx := range flags {
-			if len(c.StringSlice(flags[idx])) > 0 {
+			if c.IsSet(flags[idx]) {
 				return nil
 			}
 		}

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -62,10 +62,11 @@ func makeAWSTags(tagSlice []string) ([]host.Tag, error) {
 
 func hostCreate() cli.Command {
 	const (
-		distroFlagName = "distro"
-		keyFlagName    = "key"
-		scriptFlagName = "script"
-		tagFlagName    = "tag"
+		distroFlagName       = "distro"
+		keyFlagName          = "key"
+		scriptFlagName       = "script"
+		tagFlagName          = "tag"
+		instanceTypeFlagName = "type"
 	)
 
 	return cli.Command{
@@ -84,6 +85,10 @@ func hostCreate() cli.Command {
 				Name:  joinFlagNames(scriptFlagName, "s"),
 				Usage: "path to userdata script to run",
 			},
+			cli.StringFlag{
+				Name:  joinFlagNames(instanceTypeFlagName, "i"),
+				Usage: "name of an instance type",
+			},
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(tagFlagName, "t"),
 				Usage: "key=value pair representing an instance tag, with one pair per flag",
@@ -95,6 +100,7 @@ func hostCreate() cli.Command {
 			key := c.String(keyFlagName)
 			fn := c.String(scriptFlagName)
 			tagSlice := c.StringSlice(tagFlagName)
+			instanceType := c.String(instanceTypeFlagName)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -126,6 +132,7 @@ func hostCreate() cli.Command {
 				KeyName:      key,
 				UserData:     script,
 				InstanceTags: tags,
+				InstanceType: instanceType,
 			}
 
 			host, err := client.CreateSpawnHost(ctx, spawnRequest)

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -152,14 +152,19 @@ func hostCreate() cli.Command {
 
 func hostModify() cli.Command {
 	const (
-		addTagFlagName    = "tag"
-		deleteTagFlagName = "delete-tag"
+		addTagFlagName       = "tag"
+		deleteTagFlagName    = "delete-tag"
+		instanceTypeFlagName = "type"
 	)
 
 	return cli.Command{
 		Name:  "modify",
 		Usage: "modify an existing host",
 		Flags: addHostFlag(
+			cli.StringFlag{
+				Name:  joinFlagNames(instanceTypeFlagName, "i"),
+				Usage: "name of an instance type",
+			},
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(addTagFlagName, "t"),
 				Usage: "key=value pair representing an instance tag, with one pair per flag",
@@ -175,6 +180,7 @@ func hostModify() cli.Command {
 			hostID := c.String(hostFlagName)
 			addTagSlice := c.StringSlice(addTagFlagName)
 			deleteTagSlice := c.StringSlice(deleteTagFlagName)
+			instanceType := c.String(instanceTypeFlagName)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -194,6 +200,7 @@ func hostModify() cli.Command {
 			hostChanges := host.HostModifyOptions{
 				AddInstanceTags:    addTags,
 				DeleteInstanceTags: deleteTagSlice,
+				InstanceType:       instanceType,
 			}
 			err = client.ModifySpawnHost(ctx, hostID, hostChanges)
 			if err != nil {

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -161,10 +161,6 @@ func hostModify() cli.Command {
 		Name:  "modify",
 		Usage: "modify an existing host",
 		Flags: addHostFlag(
-			cli.StringFlag{
-				Name:  joinFlagNames(instanceTypeFlagName, "i"),
-				Usage: "name of an instance type",
-			},
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(addTagFlagName, "t"),
 				Usage: "key=value pair representing an instance tag, with one pair per flag",
@@ -173,8 +169,12 @@ func hostModify() cli.Command {
 				Name:  joinFlagNames(deleteTagFlagName, "d"),
 				Usage: "key of a single tag to be deleted",
 			},
+			cli.StringFlag{
+				Name:  joinFlagNames(instanceTypeFlagName, "i"),
+				Usage: "name of an instance type",
+			},
 		),
-		Before: mergeBeforeFuncs(setPlainLogger, requireHostFlag, requireAtLeastOneStringSlice(addTagFlagName, deleteTagFlagName)),
+		Before: mergeBeforeFuncs(setPlainLogger, requireHostFlag, requireAtLeastOneFlag(addTagFlagName, deleteTagFlagName, instanceTypeFlagName)),
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().Parent().String(confFlagName)
 			hostID := c.String(hostFlagName)

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -341,6 +341,7 @@ func (c *Mock) GetHostsByUser(ctx context.Context, user string) ([]*model.APIHos
 		KeyName:      "mock_key",
 		UserData:     "",
 		InstanceTags: nil,
+		InstanceType: "mock_type",
 	}
 	host, _ := c.CreateSpawnHost(ctx, spawnRequest)
 	hosts = append(hosts, host)
@@ -362,6 +363,7 @@ func (*Mock) CreateSpawnHost(ctx context.Context, spawnRequest *model.HostReques
 		UserHost:     true,
 		Provisioned:  false,
 		InstanceTags: spawnRequest.InstanceTags,
+		InstanceType: model.ToAPIString(spawnRequest.InstanceType),
 	}
 	return mockHost, nil
 }
@@ -398,6 +400,7 @@ func (c *Mock) GetHosts(ctx context.Context, f func([]*model.APIHost) error) err
 		KeyName:      "mock_key",
 		UserData:     "",
 		InstanceTags: nil,
+		InstanceType: "mock_type",
 	}
 	host, _ := c.CreateSpawnHost(ctx, spawnRequest)
 	hosts = append(hosts, host)

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -226,6 +226,7 @@ func (hc *MockHostConnector) NewIntentHost(options *restmodel.HostRequestOptions
 		TaskId:           options.TaskID,
 		Owner:            user,
 		InstanceTags:     options.InstanceTags,
+		InstanceType:     options.InstanceType,
 	}
 
 	intentHost, err := cloud.CreateSpawnHost(spawnOptions)

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -95,6 +95,7 @@ func (hc *DBHostConnector) NewIntentHost(options *restmodel.HostRequestOptions, 
 		TaskId:           options.TaskID,
 		Owner:            user,
 		InstanceTags:     options.InstanceTags,
+		InstanceType:     options.InstanceType,
 	}
 
 	intentHost, err := cloud.CreateSpawnHost(spawnOptions)

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -208,6 +208,7 @@ func (s *HostConnectorSuite) TestSpawnHost() {
 	const testPublicKeyName = "testPubKey"
 	const testUserID = "TestSpawnHostUser"
 	const testUserAPIKey = "testApiKey"
+	const testInstanceType = "testInstanceType"
 
 	distro := &distro.Distro{
 		Id:           testDistroID,
@@ -230,6 +231,7 @@ func (s *HostConnectorSuite) TestSpawnHost() {
 		KeyName:      testPublicKeyName,
 		UserData:     "",
 		InstanceTags: nil,
+		InstanceType: testInstanceType,
 	}
 
 	intentHost, err := (&DBHostConnector{}).NewIntentHost(options, testUser)

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -30,6 +30,7 @@ type HostRequestOptions struct {
 	KeyName      string     `json:"keyname"`
 	UserData     string     `json:"userdata"`
 	InstanceTags []host.Tag `json:"instance_tags"`
+	InstanceType string     `json:"instance_type"`
 }
 
 type DistroInfo struct {

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -21,6 +21,7 @@ type APIHost struct {
 	RunningTask  taskInfo   `json:"running_task"`
 	UserHost     bool       `json:"user_host"`
 	InstanceTags []host.Tag `json:"instance_tags"`
+	InstanceType APIString  `json:"instance_type"`
 }
 
 // HostPostRequest is a struct that holds the format of a POST request to /hosts
@@ -94,6 +95,7 @@ func (apiHost *APIHost) buildFromHostStruct(h interface{}) error {
 	apiHost.Status = ToAPIString(v.Status)
 	apiHost.UserHost = v.UserHost
 	apiHost.InstanceTags = v.InstanceTags
+	apiHost.InstanceType = ToAPIString(v.InstanceType)
 
 	imageId, err := v.Distro.GetImageID()
 	if err != nil {

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -127,6 +127,7 @@ type hostModifyHandler struct {
 
 	AddInstanceTags    []host.Tag
 	DeleteInstanceTags []string
+	InstanceType       string
 }
 
 func makeHostModifyRouteManager(sc data.Connector) gimlet.RouteHandler {
@@ -173,6 +174,7 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 	changes := host.HostModifyOptions{
 		AddInstanceTags:    h.AddInstanceTags,
 		DeleteInstanceTags: h.DeleteInstanceTags,
+		InstanceType:       h.InstanceType,
 	}
 	ts := util.RoundPartOfMinute(1).Format(tsFormat)
 	modifyJob := units.NewSpawnhostModifyJob(foundHost, changes, ts)

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -170,6 +170,11 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Invalid tag modifications"))
 	}
 
+	// Ensure instance type changes only requested for stopped hosts
+	if h.InstanceType != "" && foundHost.Status != evergreen.HostStopped {
+		return gimlet.MakeJSONErrorResponder(errors.New("Host must be stopped to modify instance type"))
+	}
+
 	// Create new spawnhost modify job
 	changes := host.HostModifyOptions{
 		AddInstanceTags:    h.AddInstanceTags,

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -35,6 +35,7 @@ type hostPostHandler struct {
 	KeyName      string     `json:"keyname"`
 	UserData     string     `json:"userdata"`
 	InstanceTags []host.Tag `json:"instance_tags"`
+	InstanceType string     `json:"instance_type"`
 
 	sc data.Connector
 }
@@ -58,6 +59,7 @@ func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 		KeyName:      hph.KeyName,
 		UserData:     hph.UserData,
 		InstanceTags: hph.InstanceTags,
+		InstanceType: hph.InstanceType,
 	}
 
 	intentHost, err := hph.sc.NewIntentHost(options, user)

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -55,19 +55,30 @@ func TestHostPostHandler(t *testing.T) {
 	assert.NotNil(resp)
 	assert.Equal(http.StatusOK, resp.Status())
 
-	assert.Len(h.sc.(*data.MockConnector).MockHostConnector.CachedHosts, 3)
+	h.InstanceType = "test_instance_type"
+	resp = h.Run(ctx)
+	assert.NotNil(resp)
+	assert.Equal(http.StatusOK, resp.Status())
+
+	assert.Len(h.sc.(*data.MockConnector).MockHostConnector.CachedHosts, 4)
 	h0 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[0]
 	d0 := h0.Distro
 	assert.Empty((*d0.ProviderSettings)["user_data"])
 	assert.Empty(h0.InstanceTags)
+	assert.Empty(h0.InstanceType)
 
 	h1 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[1]
 	d1 := h1.Distro
 	assert.Equal("my script", (*d1.ProviderSettings)["user_data"].(string))
 	assert.Empty(h1.InstanceTags)
+	assert.Empty(h1.InstanceType)
 
 	h2 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[2]
 	assert.Equal([]host.Tag{host.Tag{Key: "key", Value: "value", CanBeModified: true}}, h2.InstanceTags)
+	assert.Empty(h2.InstanceType)
+
+	h3 := h.sc.(*data.MockConnector).MockHostConnector.CachedHosts[3]
+	assert.Equal("test_instance_type", h3.InstanceType)
 }
 
 func TestHostStopHandler(t *testing.T) {

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -81,10 +81,11 @@ func TestHostPaginator(t *testing.T) {
 							Provider: model.ToAPIString(evergreen.ProviderNameMock),
 							ImageId:  model.ToAPIString(""),
 						},
-						StartedBy: model.ToAPIString(""),
-						Type:      model.ToAPIString(""),
-						User:      model.ToAPIString(""),
-						Status:    model.ToAPIString(""),
+						StartedBy:    model.ToAPIString(""),
+						Type:         model.ToAPIString(""),
+						User:         model.ToAPIString(""),
+						Status:       model.ToAPIString(""),
+						InstanceType: model.ToAPIString(""),
 					}
 					expectedHosts = append(expectedHosts, nextModelHost)
 				}
@@ -119,10 +120,11 @@ func TestHostPaginator(t *testing.T) {
 							Provider: model.ToAPIString(evergreen.ProviderNameMock),
 							ImageId:  model.ToAPIString(""),
 						},
-						StartedBy: model.ToAPIString(""),
-						Type:      model.ToAPIString(""),
-						User:      model.ToAPIString(""),
-						Status:    model.ToAPIString(""),
+						StartedBy:    model.ToAPIString(""),
+						Type:         model.ToAPIString(""),
+						User:         model.ToAPIString(""),
+						Status:       model.ToAPIString(""),
+						InstanceType: model.ToAPIString(""),
 					}
 					expectedHosts = append(expectedHosts, nextModelHost)
 				}
@@ -158,10 +160,11 @@ func TestHostPaginator(t *testing.T) {
 							Provider: model.ToAPIString(evergreen.ProviderNameMock),
 							ImageId:  model.ToAPIString(""),
 						},
-						StartedBy: model.ToAPIString(""),
-						Type:      model.ToAPIString(""),
-						User:      model.ToAPIString(""),
-						Status:    model.ToAPIString(""),
+						StartedBy:    model.ToAPIString(""),
+						Type:         model.ToAPIString(""),
+						User:         model.ToAPIString(""),
+						Status:       model.ToAPIString(""),
+						InstanceType: model.ToAPIString(""),
 					}
 					expectedHosts = append(expectedHosts, nextModelHost)
 				}
@@ -196,10 +199,11 @@ func TestHostPaginator(t *testing.T) {
 							Provider: model.ToAPIString(evergreen.ProviderNameMock),
 							ImageId:  model.ToAPIString(""),
 						},
-						StartedBy: model.ToAPIString(""),
-						Type:      model.ToAPIString(""),
-						User:      model.ToAPIString(""),
-						Status:    model.ToAPIString(""),
+						StartedBy:    model.ToAPIString(""),
+						Type:         model.ToAPIString(""),
+						User:         model.ToAPIString(""),
+						Status:       model.ToAPIString(""),
+						InstanceType: model.ToAPIString(""),
 					}
 					expectedHosts = append(expectedHosts, nextModelHost)
 				}

--- a/service/api_spawn.go
+++ b/service/api_spawn.go
@@ -67,6 +67,7 @@ func (as *APIServer) requestHost(w http.ResponseWriter, r *http.Request) {
 		TaskID:       "",
 		UserData:     "",
 		InstanceTags: nil,
+		InstanceType: "",
 	}
 	spawnHost, err := hc.NewIntentHost(options, user)
 	if err != nil {

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -108,6 +108,7 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 		UserData      string     `json:"userdata"`
 		UseTaskConfig bool       `json:"use_task_config"`
 		InstanceTags  []host.Tag `json:"instance_tags"`
+		InstanceType  string     `json:"instance_type"`
 	}{}
 
 	err := util.ReadJSONInto(util.NewRequestReader(r), &putParams)
@@ -131,6 +132,7 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 		TaskID:       putParams.Task,
 		UserData:     putParams.UserData,
 		InstanceTags: putParams.InstanceTags,
+		InstanceType: putParams.InstanceType,
 	}
 	spawnHost, err := hc.NewIntentHost(options, authedUser)
 

--- a/units/spawnhost_modify.go
+++ b/units/spawnhost_modify.go
@@ -98,11 +98,5 @@ func (j *spawnhostModifyJob) Run(ctx context.Context) {
 		return
 	}
 
-	// Push changes to the database
-	if err := j.host.ModifySpawnHost(j.ModifyOptions); err != nil {
-		j.AddError(errors.Wrap(err, "error updating spawnhost in database after modify"))
-		return
-	}
-
 	return
 }


### PR DESCRIPTION
**Waiting on EVG-6627 (start/stop hosts) because instance type can only be modified on stopped hosts.**

EC2 hosts are normally spawned with the instance type specified in the distro's provider settings. These changes allow users to override this by specifying an instance type when creating a spawn host:

> evergreen host create --type <INSTANCE_TYPE>

Users can also change the instance type of an existing stopped host:

> evergreen host modify --host <HOST_ID> --type <INSTANCE_TYPE>