### PR TITLE
EVG-6669 Handle malformed AWS DescribeInstances response

### DIFF
--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -408,21 +408,12 @@ func validateEc2DescribeInstancesOutput(describeInstancesResponse *ec2aws.Descri
 		if len(reservation.Instances) == 0 {
 			catcher.Add(errors.New("reservation missing instance"))
 		} else {
-			if reservation.Instances[0].InstanceId == nil {
-				catcher.Add(errors.New("instance missing instance id"))
-			}
-			if reservation.Instances[0].State == nil || reservation.Instances[0].State.Name == nil || len(*reservation.Instances[0].State.Name) == 0 {
-				catcher.Add(errors.New("instance missing state name"))
-			}
-			if reservation.Instances[0].Placement == nil || reservation.Instances[0].Placement.AvailabilityZone == nil {
-				catcher.Add(errors.New("instance missing availability zone"))
-			}
-			if reservation.Instances[0].LaunchTime == nil {
-				catcher.Add(errors.New("instance missing launch time"))
-			}
-			if reservation.Instances[0].PublicDnsName == nil {
-				catcher.Add(errors.New("instance missing dns name"))
-			}
+			instance := reservation.Instances[0]
+			catcher.NewWhen(instance.InstanceId == nil, "instance missing instance id")
+			catcher.NewWhen(instance.State == nil || instance.State.Name == nil || len(*instance.State.Name) == 0, "instance missing state name")
+			catcher.NewWhen(instance.Placement == nil || instance.Placement.AvailabilityZone == nil, "instance missing availability zone")
+			catcher.NewWhen(instance.LaunchTime == nil, "instance missing launch time")
+			catcher.NewWhen(instance.PublicDnsName == nil, "instance missing dns name")
 		}
 	}
 

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -414,8 +414,16 @@ func validateEc2DescribeInstancesOutput(describeInstancesResponse *ec2aws.Descri
 			if reservation.Instances[0].State == nil || reservation.Instances[0].State.Name == nil || len(*reservation.Instances[0].State.Name) == 0 {
 				catcher.Add(errors.New("instance missing state name"))
 			}
+			if reservation.Instances[0].Placement == nil || reservation.Instances[0].Placement.AvailabilityZone == nil {
+				catcher.Add(errors.New("instance missing availability zone"))
+			}
+			if reservation.Instances[0].LaunchTime == nil {
+				catcher.Add(errors.New("instance missing launch time"))
+			}
+			if reservation.Instances[0].PublicDnsName == nil {
+				catcher.Add(errors.New("instance missing dns name"))
+			}
 		}
-
 	}
 
 	return catcher.Resolve()

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -238,6 +238,15 @@ func expandUserData(userData string, expansions map[string]string) (string, erro
 }
 
 func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, client AWSClient) error {
+	if instance.Placement == nil || instance.Placement.AvailabilityZone == nil {
+		return errors.New("instance missing availability zone")
+	}
+	if instance.LaunchTime == nil {
+		return errors.New("instance missing launch time")
+	}
+	if instance.PublicDnsName == nil {
+		return errors.New("instance missing public dns name")
+	}
 	h.Zone = *instance.Placement.AvailabilityZone
 	h.StartTime = *instance.LaunchTime
 	h.Host = *instance.PublicDnsName
@@ -411,9 +420,6 @@ func validateEc2DescribeInstancesOutput(describeInstancesResponse *ec2aws.Descri
 			instance := reservation.Instances[0]
 			catcher.NewWhen(instance.InstanceId == nil, "instance missing instance id")
 			catcher.NewWhen(instance.State == nil || instance.State.Name == nil || len(*instance.State.Name) == 0, "instance missing state name")
-			catcher.NewWhen(instance.Placement == nil || instance.Placement.AvailabilityZone == nil, "instance missing availability zone")
-			catcher.NewWhen(instance.LaunchTime == nil, "instance missing launch time")
-			catcher.NewWhen(instance.PublicDnsName == nil, "instance missing dns name")
 		}
 	}
 


### PR DESCRIPTION
Adds validation to GetInstanceStatuses that ensures that the response from m.client.DescribeInstances is properly formed. Should prevent panics.

See https://jira.mongodb.org/browse/EVG-6669 for the problem.