### PR TITLE
EVG-6354 don't activate dependencies for tasks with OverrideDependencies set

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -37,12 +37,14 @@ func SetActiveState(taskId string, caller string, active bool) error {
 		return errors.Errorf("task '%s' not found", taskId)
 	}
 	if active {
-		// if the task is being activated, make sure to activate all of the task's
-		// dependencies as well
-		for _, dep := range t.DependsOn {
-			if err = SetActiveState(dep.TaskId, caller, true); err != nil {
-				return errors.Wrapf(err, "error activating dependency for %v with id %v",
-					taskId, dep.TaskId)
+		// if the task is being activated and it doesn't override its dependencies
+		// activate the task's dependencies as well
+		if !t.OverrideDependencies {
+			for _, dep := range t.DependsOn {
+				if err = SetActiveState(dep.TaskId, caller, true); err != nil {
+					return errors.Wrapf(err, "error activating dependency for %v with id %v",
+						taskId, dep.TaskId)
+				}
 			}
 		}
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -199,6 +199,19 @@ func TestSetActiveState(t *testing.T) {
 			})
 
 		})
+
+		Convey("activating a task with override dependencies set should not activate the tasks it depends on", func() {
+			So(testTask.SetOverrideDependencies(userName), ShouldBeNil)
+
+			So(SetActiveState(testTask.Id, userName, true), ShouldBeNil)
+			depTask, err := task.FindOne(task.ById(dep1.Id))
+			So(err, ShouldBeNil)
+			So(depTask.Activated, ShouldBeFalse)
+
+			depTask, err = task.FindOne(task.ById(dep2.Id))
+			So(err, ShouldBeNil)
+			So(depTask.Activated, ShouldBeFalse)
+		})
 	})
 
 	Convey("with a task that is part of a display task", t, func() {


### PR DESCRIPTION
If a task has override dependencies set there's no reason to activate its dependencies when it's activated.