### PR TITLE
EVG-6779 don't do reads within repotracker transaction

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -730,6 +730,9 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 	buildsToCreate := []interface{}{}
 	tasksToCreate := task.Tasks{}
 	for _, buildvariant := range project.BuildVariants {
+		if ctx.Err() != nil {
+			return errors.Wrapf(err, "aborting version creation for version %s", v.Id)
+		}
 		if buildvariant.Disabled {
 			continue
 		}
@@ -737,7 +740,10 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 		if len(aliases) > 0 {
 			match, err = aliases.HasMatchingVariant(buildvariant.Name, buildvariant.Tags)
 			if err != nil {
-				grip.Error(err)
+				grip.Error(message.WrapError(err, message.Fields{
+					"message": "error checking project aliases",
+					"version": v.Id,
+				}))
 				continue
 			}
 			if !match {
@@ -759,6 +765,7 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "error creating build",
+				"version": v.Id,
 			}))
 			continue
 		}

--- a/scripts/indexes.js
+++ b/scripts/indexes.js
@@ -96,7 +96,9 @@ db.old_tasks.ensureIndex({ "branch": 1, "r" : 1, "status" : 1})
 db.old_tasks.ensureIndex({ "branch": 1, "r" : 1, "build_variant" : 1})
 db.old_tasks.ensureIndex({ "old_task_id": 1})
 db.old_tasks.ensureIndex({ "branch": 1, "finish_time": 1})
-db.old_tasks.createIndex({ "execution_tasks": 1})0
+db.old_tasks.createIndex({ "execution_tasks": 1})
+
+//======versions======//
 db.versions.ensureIndex({ "order" : 1 })
 db.versions.ensureIndex({ "builds" : 1 })
 db.versions.ensureIndex({ "identifier" : 1, "r" : 1, "order" : 1 })
@@ -104,6 +106,7 @@ db.versions.ensureIndex({ "branch" : 1, "gitspec" : 1 })
 db.versions.ensureIndex({ "versions.build_variant_status.build_variant" : 1, "versions.build_variant_status.activated" : 1, "r": 1 })
 db.versions.ensureIndex({ "identifier" : 1, "r" : 1, "create_time" : 1 })
 db.versions.createIndex({ "project": 1, "periodic_build_id": 1, "create_time": -1 }, {"partialFilterExpression": { "periodic_build_id": { "$exists": true}}})
+db.versions.createIndex({ "identifier": 1, "order": 1 })
 
 //======alerts=======//
 db.alerts.ensureIndex({ "queue_status" : 1 })


### PR DESCRIPTION
- Create a copy of the function that creates builds/tasks, but does not insert them
- Have the existing function wrap the copy above
- Change the repotracker to hold all the builds/tasks/version it needs to create for a version in memory, then insert them at the end in a transaction