### PR TITLE
EVG-6173 Add comment explaining distro pool size

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -19,7 +19,6 @@ type Distro struct {
 	Aliases           []string                `bson:"aliases,omitempty" json:"aliases,omitempty" mapstructure:"aliases,omitempty"`
 	Arch              string                  `bson:"arch" json:"arch,omitempty" mapstructure:"arch,omitempty"`
 	WorkDir           string                  `bson:"work_dir" json:"work_dir,omitempty" mapstructure:"work_dir,omitempty"`
-	PoolSize          int                     `bson:"pool_size,omitempty" json:"pool_size,omitempty" mapstructure:"pool_size,omitempty" yaml:"poolsize"`
 	Provider          string                  `bson:"provider" json:"provider,omitempty" mapstructure:"provider,omitempty"`
 	ProviderSettings  *map[string]interface{} `bson:"settings" json:"settings,omitempty" mapstructure:"settings,omitempty"`
 	SetupAsSudo       bool                    `bson:"setup_as_sudo,omitempty" json:"setup_as_sudo,omitempty" mapstructure:"setup_as_sudo,omitempty"`
@@ -36,6 +35,9 @@ type Distro struct {
 	ContainerPool     string                  `bson:"container_pool,omitempty" json:"container_pool,omitempty" mapstructure:"container_pool,omitempty"`
 	PlannerSettings   PlannerSettings         `bson:"planner_settings" json:"planner_settings,omitempty" mapstructure:"planner_settings,omitempty"`
 	FinderSettings    FinderSettings          `bson:"finder_settings" json:"finder_settings,omitempty" mapstructure:"finder_settings,omitempty"`
+
+	// PoolSize is the maximum allowed number of hosts running this distro
+	PoolSize int `bson:"pool_size,omitempty" json:"pool_size,omitempty" mapstructure:"pool_size,omitempty" yaml:"poolsize"`
 }
 
 // BootstrapSettings encapsulates all settings related to bootstrapping hosts.


### PR DESCRIPTION
This addresses https://jira.mongodb.org/browse/EVG-6173.

It seemed like the container pool in which ubuntu1604-test hosts are spawned was maxing out at 8 hosts, even though it seemed like archlinux-parent's PoolSize (reflected in the UI as "Maximum number of hosts allowed:") was set at 10.

However, this isn't really a bug. PoolSize is not related to container pools -- it's the max number of running hosts allowed with a certain distro at a time. The number of containers spawned on a parent host is determined by the MaxContainers field of the container pool specified by the container distro (confusing, I know). This is set in the admin config, not the distro document. In our case, MaxContainers is correctly set to 8.

No changes made except adding a clarifying comment to the distro PoolSize field.