### PR TITLE
EVG-6790: set splunk token for Jasper as a file instead of string flag

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -249,7 +249,7 @@ func (h *Host) ForceReinstallJasperCommand(settings *evergreen.Settings) string 
 	if settings.Splunk.Populated() {
 		params = append(params,
 			fmt.Sprintf("--splunk_url=%s", settings.Splunk.ServerURL),
-			fmt.Sprintf("--splunk_token=%s", settings.Splunk.Token),
+			fmt.Sprintf("--splunk_token_path=%s", h.splunkTokenFilePath()),
 		)
 		if settings.Splunk.Channel != "" {
 			params = append(params, fmt.Sprintf("--splunk_channel=%s", settings.Splunk.Channel))
@@ -329,7 +329,7 @@ func (h *Host) jasperBinaryFilePath(config evergreen.HostJasperConfig) string {
 func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *rpc.Credentials, preJasperSetup, postJasperSetup []string) (string, error) {
 	bashCmds := append([]string{"set -o errexit"}, preJasperSetup...)
 
-	writeCredentialsCmd, err := h.WriteJasperCredentialsFileCommand(creds)
+	writeCredentialsCmd, err := h.WriteJasperCredentialsFilesCommands(settings, creds)
 	if err != nil {
 		return "", errors.Wrap(err, "could not build command to write Jasper credentials file")
 	}
@@ -383,16 +383,37 @@ func (h *Host) buildLocalJasperClientRequest(config evergreen.HostJasperConfig, 
 }
 
 // WriteJasperCredentialsFileCommand builds the command to write the Jasper
-// credentials to a file.
-func (h *Host) WriteJasperCredentialsFileCommand(creds *rpc.Credentials) (string, error) {
+// credentials and Splunk credentials to files.
+func (h *Host) WriteJasperCredentialsFilesCommands(settings *evergreen.Settings, creds *rpc.Credentials) (string, error) {
 	if h.Distro.BootstrapSettings.JasperCredentialsPath == "" {
 		return "", errors.New("cannot write Jasper credentials without a credentials file path")
 	}
+
 	exportedCreds, err := creds.Export()
 	if err != nil {
 		return "", errors.Wrap(err, "problem exporting credentials to file format")
 	}
-	return fmt.Sprintf("mkdir -m 777 -p \"%s\" && cat > '%s' <<EOF\n%s\nEOF", filepath.Dir(h.Distro.BootstrapSettings.JasperCredentialsPath), h.Distro.BootstrapSettings.JasperCredentialsPath, exportedCreds), nil
+	writeFileContentCmd := func(path, content string) string {
+		return fmt.Sprintf("echo '%s' > '%s'", content, path)
+	}
+
+	cmds := []string{
+		fmt.Sprintf("mkdir -m 777 -p \"%s\"", filepath.Dir(h.Distro.BootstrapSettings.JasperCredentialsPath)),
+		writeFileContentCmd(h.Distro.BootstrapSettings.JasperCredentialsPath, string(exportedCreds)),
+	}
+
+	if settings.Splunk.Populated() {
+		cmds = append(cmds, writeFileContentCmd(h.splunkTokenFilePath(), settings.Splunk.Token))
+	}
+
+	return strings.Join(cmds, " && "), nil
+}
+
+func (h *Host) splunkTokenFilePath() string {
+	if h.Distro.BootstrapSettings.JasperCredentialsPath == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(h.Distro.BootstrapSettings.JasperCredentialsPath), "splunk.txt")
 }
 
 // RunJasperProcess makes a request to the host's Jasper service to create the

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -229,7 +229,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 
 			creds, err := newMockCredentials()
 			require.NoError(t, err)
-			writeCredentialsCmd, err := h.WriteJasperCredentialsFilesCommands(settings, creds)
+			writeCredentialsCmd, err := h.WriteJasperCredentialsFilesCommands(settings.Splunk, creds)
 			require.NoError(t, err)
 
 			expectedCmds = append(expectedCmds, writeCredentialsCmd, h.ForceReinstallJasperCommand(settings))
@@ -270,11 +270,11 @@ func TestJasperCommandsWindows(t *testing.T) {
 			for testName, testCase := range map[string]func(t *testing.T, h *Host, settings *evergreen.Settings){
 				"WithoutJasperCredentialsPath": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 					h.Distro.BootstrapSettings.JasperCredentialsPath = ""
-					_, err := h.WriteJasperCredentialsFilesCommands(settings, creds)
+					_, err := h.WriteJasperCredentialsFilesCommands(settings.Splunk, creds)
 					assert.Error(t, err)
 				},
 				"WithJasperCredentialsPath": func(t *testing.T, h *Host, settings *evergreen.Settings) {
-					cmd, err := h.WriteJasperCredentialsFilesCommands(settings, creds)
+					cmd, err := h.WriteJasperCredentialsFilesCommands(settings.Splunk, creds)
 					require.NoError(t, err)
 
 					expectedCreds, err := creds.Export()
@@ -284,7 +284,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 				"WithSplunkCredentials": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 					settings.Splunk.Token = "token"
 					settings.Splunk.ServerURL = "splunk_url"
-					cmd, err := h.WriteJasperCredentialsFilesCommands(settings, creds)
+					cmd, err := h.WriteJasperCredentialsFilesCommands(settings.Splunk, creds)
 					require.NoError(t, err)
 
 					expectedCreds, err := creds.Export()

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -150,7 +150,7 @@ func TestJasperCommands(t *testing.T) {
 			settings.Splunk.Token = "token"
 
 			cmd := h.ForceReinstallJasperCommand(settings)
-			expected := "sudo /foo/jasper_cli jasper service force-reinstall rpc --host=0.0.0.0 --port=12345 --creds_path=/bar/bat.txt --user=user --splunk_url=url --splunk_token=token"
+			expected := "sudo /foo/jasper_cli jasper service force-reinstall rpc --host=0.0.0.0 --port=12345 --creds_path=/bar/bat.txt --user=user --splunk_url=url --splunk_token_path=/bar/splunk.txt"
 			assert.Equal(t, expected, cmd)
 
 			settings.Splunk.Channel = "channel"

--- a/units/jasper_deploy.go
+++ b/units/jasper_deploy.go
@@ -131,7 +131,7 @@ func (j *jasperDeployJob) Run(ctx context.Context) {
 		return
 	}
 
-	writeCredentialsCmd, err := j.host.WriteJasperCredentialsFileCommand(creds)
+	writeCredentialsCmd, err := j.host.WriteJasperCredentialsFilesCommands(j.settings, creds)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "could not build command to write Jasper credentials file",

--- a/units/jasper_deploy.go
+++ b/units/jasper_deploy.go
@@ -131,7 +131,7 @@ func (j *jasperDeployJob) Run(ctx context.Context) {
 		return
 	}
 
-	writeCredentialsCmd, err := j.host.WriteJasperCredentialsFilesCommands(j.settings, creds)
+	writeCredentialsCmd, err := j.host.WriteJasperCredentialsFilesCommands(j.settings.Splunk, creds)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "could not build command to write Jasper credentials file",

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -267,7 +267,7 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 		})
 		return nil
 	case distro.BootstrapMethodSSH:
-		if err = j.setupJasper(ctx); err != nil {
+		if err = j.setupJasper(ctx, settings); err != nil {
 			return errors.Wrapf(err, "error putting Jasper on host '%s'", targetHost.Id)
 		}
 	}
@@ -336,7 +336,7 @@ func (j *setupHostJob) putJasperCredentials(ctx context.Context, settings *everg
 		return errors.Wrap(err, "could not generate Jasper credentials for host")
 	}
 
-	writeCmd, err := j.host.WriteJasperCredentialsFilesCommands(creds, settings)
+	writeCmd, err := j.host.WriteJasperCredentialsFilesCommands(settings, creds)
 	if err != nil {
 		return errors.Wrap(err, "could not get command to write Jasper credentials file")
 	}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -299,7 +299,7 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 // setupJasper sets up the Jasper service on the host by putting the credentials
 // on the host, downloading the latest version of Jasper, and restarting the
 // Jasper service.
-func (j *setupHostJob) setupJasper(ctx context.Context) error {
+func (j *setupHostJob) setupJasper(ctx context.Context, settings *evergreen.Settings) error {
 	cloudHost, err := cloud.GetCloudHost(ctx, j.host, j.env.Settings())
 	if err != nil {
 		return errors.Wrapf(err, "failed to get cloud host for %s", j.host.Id)
@@ -310,7 +310,7 @@ func (j *setupHostJob) setupJasper(ctx context.Context) error {
 		return errors.Wrapf(err, "error getting ssh options for host %s", j.host.Id)
 	}
 
-	if err := j.putJasperCredentials(ctx, sshOptions); err != nil {
+	if err := j.putJasperCredentials(ctx, settings, sshOptions); err != nil {
 		return errors.Wrap(err, "error putting Jasper credentials on remote host")
 	}
 
@@ -330,13 +330,13 @@ func (j *setupHostJob) setupJasper(ctx context.Context) error {
 
 // putJasperCredentials creates Jasper credentials for the host and puts the
 // credentials file on the host.
-func (j *setupHostJob) putJasperCredentials(ctx context.Context, sshOptions []string) error {
+func (j *setupHostJob) putJasperCredentials(ctx context.Context, settings *evergreen.Settings, sshOptions []string) error {
 	creds, err := j.host.GenerateJasperCredentials(ctx)
 	if err != nil {
 		return errors.Wrap(err, "could not generate Jasper credentials for host")
 	}
 
-	writeCmd, err := j.host.WriteJasperCredentialsFileCommand(creds)
+	writeCmd, err := j.host.WriteJasperCredentialsFilesCommands(creds, settings)
 	if err != nil {
 		return errors.Wrap(err, "could not get command to write Jasper credentials file")
 	}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -336,7 +336,7 @@ func (j *setupHostJob) putJasperCredentials(ctx context.Context, settings *everg
 		return errors.Wrap(err, "could not generate Jasper credentials for host")
 	}
 
-	writeCmd, err := j.host.WriteJasperCredentialsFilesCommands(settings, creds)
+	writeCmd, err := j.host.WriteJasperCredentialsFilesCommands(settings.Splunk, creds)
 	if err != nil {
 		return errors.Wrap(err, "could not get command to write Jasper credentials file")
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6790