### PR TITLE
EVG-6791 refresh cached project config

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -121,7 +121,7 @@ func GetPatchedProject(ctx context.Context, p *patch.Patch, githubOauthToken str
 		return nil, "", errors.WithStack(err)
 	}
 	if projectRef == nil {
-		return nil, "", errors.Errorf("no project exists with identifier '%s")
+		return nil, "", errors.Errorf("no project exists with identifier '%s", p.Project)
 	}
 
 	project := &Project{}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -120,6 +120,9 @@ func GetPatchedProject(ctx context.Context, p *patch.Patch, githubOauthToken str
 	if err != nil {
 		return nil, "", errors.WithStack(err)
 	}
+	if projectRef == nil {
+		return nil, "", errors.Errorf("no project exists with identifier '%s")
+	}
 
 	project := &Project{}
 	// if the patched config exists, use that as the project file bytes.

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -267,16 +267,9 @@ func (j *commitQueueJob) processCLIPatchItem(ctx context.Context, cq *commitqueu
 		return
 	}
 
-	project, _, err := model.GetPatchedProject(ctx, patchDoc, githubToken)
+	project, err := updatePatch(ctx, githubToken, projectRef, patchDoc)
 	if err != nil {
-		j.logError(err, "can't get updated project config", nextItem)
-		j.dequeue(cq, nextItem)
-		return
-	}
-
-	err = updateGithashes(ctx, githubToken, projectRef, project, patchDoc)
-	if err != nil {
-		j.logError(err, "can't update githashes", nextItem)
+		j.logError(err, "can't update patch", nextItem)
 		j.dequeue(cq, nextItem)
 		return
 	}
@@ -632,17 +625,25 @@ func setDefaultNotification(username string) error {
 	return nil
 }
 
-func updateGithashes(ctx context.Context, githubToken string, projectRef *model.ProjectRef, project *model.Project, patchDoc *patch.Patch) error {
+func updatePatch(ctx context.Context, githubToken string, projectRef *model.ProjectRef, patchDoc *patch.Patch) (*model.Project, error) {
 	branch, err := thirdparty.GetBranchEvent(ctx, githubToken, projectRef.Owner, projectRef.Repo, projectRef.Branch)
 	if err != nil {
-		return errors.Wrap(err, "can't get branch")
+		return nil, errors.Wrap(err, "can't get branch")
 	}
 	if err = validateBranch(branch); err != nil {
-		return errors.Wrap(err, "GitHub returned invalid branch")
+		return nil, errors.Wrap(err, "GitHub returned invalid branch")
 	}
 
 	sha := *branch.Commit.SHA
 	patchDoc.Githash = sha
+
+	// Refresh the cached project config
+	patchDoc.PatchedConfig = ""
+	project, projectYaml, err := model.GetPatchedProject(ctx, patchDoc, githubToken)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't get updated project config")
+	}
+	patchDoc.PatchedConfig = projectYaml
 
 	// Update module githashes
 	for i, mod := range patchDoc.Patches {
@@ -653,23 +654,23 @@ func updateGithashes(ctx context.Context, githubToken string, projectRef *model.
 
 		module, err := project.GetModuleByName(mod.ModuleName)
 		if err != nil {
-			return errors.Wrapf(err, "can't get module for module name '%s'", mod.ModuleName)
+			return nil, errors.Wrapf(err, "can't get module for module name '%s'", mod.ModuleName)
 		}
 		owner, repo, err := thirdparty.ParseGitUrl(module.Repo)
 		if err != nil {
-			return errors.Wrapf(err, "module '%s' misconfigured (malformed URL)", mod.ModuleName)
+			return nil, errors.Wrapf(err, "module '%s' misconfigured (malformed URL)", mod.ModuleName)
 		}
 
 		branch, err = thirdparty.GetBranchEvent(ctx, githubToken, owner, repo, module.Branch)
 		if err != nil {
-			return errors.Wrap(err, "can't get branch")
+			return nil, errors.Wrap(err, "can't get branch")
 		}
 		if err = validateBranch(branch); err != nil {
-			return errors.Wrap(err, "GitHub returned invalid branch")
+			return nil, errors.Wrap(err, "GitHub returned invalid branch")
 		}
 
 		patchDoc.Patches[i].Githash = *branch.Commit.SHA
 	}
 
-	return nil
+	return project, nil
 }


### PR DESCRIPTION
The commit queue was not actually updating the project config with HEAD's since the project was updated before the githash of the patch was updated.