### PR TITLE
EVG-6793: no-op the agent until the app server is done provisioning

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -603,8 +603,9 @@ func (h *Host) UpdateProvisioningToRunning() error {
 
 	if err := UpdateOne(
 		bson.M{
-			IdKey:     h.Id,
-			StatusKey: evergreen.HostProvisioning,
+			IdKey:          h.Id,
+			StatusKey:      evergreen.HostProvisioning,
+			ProvisionedKey: true,
 		},
 		bson.M{"$set": bson.M{StatusKey: evergreen.HostRunning}},
 	); err != nil {

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -828,6 +828,10 @@ func (h *Host) SetUserDataHostProvisioned() error {
 		return nil
 	}
 
+	if !h.Provisioned {
+		return nil
+	}
+
 	if err := h.UpdateProvisioningToRunning(); err != nil {
 		return errors.Wrapf(err, "could not mark host %s as done provisioning itself and now running", h.Id)
 	}

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -484,6 +484,13 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
+	// The agent may start before the host has been fully provisioned by the app
+	// server, so no-op until the app server is done provisioning.
+	if !h.Provisioned {
+		gimlet.WriteJSON(w, apimodels.NextTaskResponse{})
+		return
+	}
+
 	if h.AgentStartTime.IsZero() {
 		if err := h.SetAgentStartTime(); err != nil {
 			grip.Warning(message.WrapError(err, message.Fields{


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6793

The agent might start and set the host as running before the provisioning setup host job has run successfully (this can cause a host to be terminated since the app server didn't finish provisoining). The Provisioned key will be set once the host has run the setup host job.