### PR TITLE
EVG-6789: create host job can leak hosts

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -280,8 +280,7 @@ func (h *Host) IsEphemeral() bool {
 
 func (h *Host) SetStatus(status, user string, logs string) error {
 	if h.Status == evergreen.HostTerminated {
-		msg := fmt.Sprintf("Refusing to mark host %v as"+
-			" %v because it is already terminated", h.Id, status)
+		msg := fmt.Sprintf("not changing the status of terminate host %s to %s", h.Id, status)
 		grip.Warning(msg)
 		return errors.New(msg)
 	}
@@ -305,7 +304,7 @@ func (h *Host) SetStatus(status, user string, logs string) error {
 // status in the database matches currentStatus.
 func (h *Host) SetStatusAtomically(newStatus, user string, logs string) error {
 	if h.Status == evergreen.HostTerminated {
-		msg := fmt.Sprintf("refusing to mark host %s as %s because it is already terminated", h.Id, newStatus)
+		msg := fmt.Sprintf("not changing the status of terminate host %s to %s", h.Id, newStatus)
 		grip.Warning(msg)
 		return errors.New(msg)
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -303,7 +303,7 @@ func (h *Host) SetStatus(status, user string, logs string) error {
 
 // SetStatusAtomically is the same as SetStatus but only updates the host if its
 // status in the database matches currentStatus.
-func (h *Host) SetStatusAtomically(newStatus, currentStatus, user string, logs string) error {
+func (h *Host) SetStatusAtomically(newStatus, user string, logs string) error {
 	if h.Status == evergreen.HostTerminated {
 		msg := fmt.Sprintf("refusing to mark host %s as %s because it is already terminated", h.Id, newStatus)
 		grip.Warning(msg)
@@ -313,7 +313,7 @@ func (h *Host) SetStatusAtomically(newStatus, currentStatus, user string, logs s
 	err := UpdateOne(
 		bson.M{
 			IdKey:     h.Id,
-			StatusKey: currentStatus,
+			StatusKey: h.Status,
 		},
 		bson.M{
 			"$set": bson.M{

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -278,11 +278,34 @@ func (h *Host) IsEphemeral() bool {
 	return util.StringSliceContains(evergreen.ProviderSpawnable, h.Provider)
 }
 
-// SetStatus updates the host status to newStatus as long as the current
-// database host's status matches the in-memory host's status.
-func (h *Host) SetStatus(newStatus, user string, logs string) error {
+func (h *Host) SetStatus(status, user string, logs string) error {
 	if h.Status == evergreen.HostTerminated {
-		msg := fmt.Sprintf("not changing the status of terminated host %s to %s", h.Id, newStatus)
+		msg := fmt.Sprintf("Refusing to mark host %v as"+
+			" %v because it is already terminated", h.Id, status)
+		grip.Warning(msg)
+		return errors.New(msg)
+	}
+
+	event.LogHostStatusChanged(h.Id, h.Status, status, user, logs)
+
+	h.Status = status
+	return UpdateOne(
+		bson.M{
+			IdKey: h.Id,
+		},
+		bson.M{
+			"$set": bson.M{
+				StatusKey: status,
+			},
+		},
+	)
+}
+
+// SetStatusAtomically is the same as SetStatus but only updates the host if its
+// status in the database matches currentStatus.
+func (h *Host) SetStatusAtomically(newStatus, currentStatus, user string, logs string) error {
+	if h.Status == evergreen.HostTerminated {
+		msg := fmt.Sprintf("refusing to mark host %s as %s because it is already terminated", h.Id, newStatus)
 		grip.Warning(msg)
 		return errors.New(msg)
 	}
@@ -290,7 +313,7 @@ func (h *Host) SetStatus(newStatus, user string, logs string) error {
 	err := UpdateOne(
 		bson.M{
 			IdKey:     h.Id,
-			StatusKey: h.Status,
+			StatusKey: currentStatus,
 		},
 		bson.M{
 			"$set": bson.M{

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -191,16 +191,13 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		return errors.Wrapf(errIgnorableCreateHost, "problem getting cloud provider for host '%s' [%s]", j.host.Id, err.Error())
 	}
 
-	if j.host.Status != evergreen.HostUninitialized {
-		return nil
-	}
 	// Set status temporarily to HostBuilding. Conventional hosts only stay in
 	// SpawnHost for a short period of time. Containers stay in SpawnHost for
 	// longer, since they may need to download container images and build them
 	// with the agent. This state allows intent documents to stay around until
 	// SpawnHost returns, but NOT as initializing hosts that could still be
 	// spawned by Evergreen.
-	if err = j.host.SetStatus(evergreen.HostBuilding, evergreen.User, ""); err != nil {
+	if err = j.host.SetStatusAtomically(evergreen.HostBuilding, evergreen.HostUninitialized, evergreen.User, ""); err != nil {
 		grip.Info(message.WrapError(err, message.Fields{
 			"message": "host could not be transitioned from initializing to building, so it may already be building",
 			"host":    j.host.Id,

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -191,13 +191,16 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		return errors.Wrapf(errIgnorableCreateHost, "problem getting cloud provider for host '%s' [%s]", j.host.Id, err.Error())
 	}
 
+	if j.host.Status != evergreen.HostUninitialized {
+		return nil
+	}
 	// Set status temporarily to HostBuilding. Conventional hosts only stay in
 	// SpawnHost for a short period of time. Containers stay in SpawnHost for
 	// longer, since they may need to download container images and build them
 	// with the agent. This state allows intent documents to stay around until
 	// SpawnHost returns, but NOT as initializing hosts that could still be
 	// spawned by Evergreen.
-	if err = j.host.SetStatusAtomically(evergreen.HostBuilding, evergreen.HostUninitialized, evergreen.User, ""); err != nil {
+	if err = j.host.SetStatus(evergreen.HostBuilding, evergreen.User, ""); err != nil {
 		grip.Info(message.WrapError(err, message.Fields{
 			"message": "host could not be transitioned from initializing to building, so it may already be building",
 			"host":    j.host.Id,

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -191,13 +191,16 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		return errors.Wrapf(errIgnorableCreateHost, "problem getting cloud provider for host '%s' [%s]", j.host.Id, err.Error())
 	}
 
+	if j.host.Status != evergreen.HostUninitialized {
+		return nil
+	}
 	// Set status temporarily to HostBuilding. Conventional hosts only stay in
 	// SpawnHost for a short period of time. Containers stay in SpawnHost for
 	// longer, since they may need to download container images and build them
 	// with the agent. This state allows intent documents to stay around until
 	// SpawnHost returns, but NOT as initializing hosts that could still be
 	// spawned by Evergreen.
-	if err = j.host.SetStatusAtomically(evergreen.HostBuilding, evergreen.HostUninitialized, evergreen.User, ""); err != nil {
+	if err = j.host.SetStatusAtomically(evergreen.HostBuilding, evergreen.User, ""); err != nil {
 		grip.Info(message.WrapError(err, message.Fields{
 			"message": "host could not be transitioned from initializing to building, so it may already be building",
 			"host":    j.host.Id,

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -228,7 +228,7 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 	}
 
 	if err = j.setDNSName(ctx, targetHost, cloudMgr, settings); err != nil {
-		return errors.Wrap(err, "error settings DNS name")
+		return errors.Wrap(err, "error setting DNS name")
 	}
 
 	// run the function scheduled for when the host is up
@@ -553,7 +553,6 @@ func (j *setupHostJob) provisionHost(ctx context.Context, h *host.Host, settings
 		}
 
 		event.LogProvisionFailed(h.Id, "")
-
 		// mark the host's provisioning as failed
 		grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
 			"operation": "setting host unprovisioned",


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6789

This fixes two problems:
1. Occasionally, multiple create host jobs run concurrently and spawn multiple hosts for a single intent document. I fixed this by atomically updating the host status from initializing to building (like what's currently done for the agent deploy job).
2. If the create host job successfully spawns a host but fails afterwards because it can't replace the intent host document with the real host document, terminate the cloud instance immediately.

Note on problem 2: instead of terminating as soon as the job fails, it's possible that we could try requeueing the create host job and reuse the already-spawned instance ID. However, this runs the risk of not having enough information to terminate the cloud instance since the host document could be deleted (`TerminateInstances` relies on some settings stored in the host document to delete instances).

I don't think the solution to 2 will waste many cloud hosts. According to Splunk, there were only 10-20 errors in the past month in the create host job after the host was already spawned.