### PR TITLE
EVG-6805: only invoke cygpath if gopath is defined

### DIFF
--- a/makefile
+++ b/makefile
@@ -49,7 +49,9 @@ karmaFlags := $(if $(KARMA_REPORTER),--reporters $(KARMA_REPORTER),)
 
 gopath := $(GOPATH)
 ifeq ($(OS),Windows_NT)
+ifneq (,$(gopath))
 gopath := $(shell cygpath -m $(gopath))
+endif
 endif
 
 # start linting configuration


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6805

This is mostly because I don't want to see the useless cygpath usage text in the task logs.