### PR TITLE
EVG-6739 recurse on task groups for patch dependencies

### DIFF
--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -598,19 +598,22 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 			BuildId: "generate_build",
 		},
 		{
-			Id:      "say-hi-task-id",
-			Version: "version_that_called_generate_task",
-			BuildId: "sample_build",
+			Id:          "say-hi-task-id",
+			Version:     "version_that_called_generate_task",
+			BuildId:     "sample_build",
+			DisplayName: "say-hi",
 		},
 		{
-			Id:      "say-bye-task-id",
-			Version: "version_that_called_generate_task",
-			BuildId: "sample_build",
+			Id:          "say-bye-task-id",
+			Version:     "version_that_called_generate_task",
+			BuildId:     "sample_build",
+			DisplayName: "say-bye",
 		},
 		{
-			Id:      "say_something_else",
-			Version: "version_that_called_generate_task",
-			BuildId: "sample_build",
+			Id:          "say_something_else",
+			Version:     "version_that_called_generate_task",
+			BuildId:     "sample_build",
+			DisplayName: "say_something_else",
 		},
 	}
 	for _, t := range tasksThatExist {

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -572,9 +572,28 @@ func TestIncludePatchDependencies(t *testing.T) {
 			So(len(pairs), ShouldEqual, 0)
 		})
 	})
+	Convey("With a task that depends on task groups", t, func() {
+		p := &Project{
+			Tasks: []ProjectTask{
+				{Name: "a", DependsOn: []TaskUnitDependency{{Name: "*", Variant: "*"}}},
+				{Name: "b"},
+			},
+			TaskGroups: []TaskGroup{
+				{Name: "task-group", Tasks: []string{"b"}},
+			},
+			BuildVariants: []BuildVariant{
+				{Name: "variant-with-group", Tasks: []BuildVariantTaskUnit{{Name: "task-group"}}},
+				{Name: "initial-variant", Tasks: []BuildVariantTaskUnit{{Name: "a"}}},
+			},
+		}
+
+		initDep := TVPair{TaskName: "a", Variant: "initial-variant"}
+		pairs := IncludePatchDependencies(p, []TVPair{initDep})
+		So(pairs, ShouldHaveLength, 2)
+		So(initDep, ShouldBeIn, pairs)
+	})
 
 }
-
 func TestVariantTasksToTVPairs(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Our current dependencies checker didn't consider that the given task itself could be a task group, which caused FindTaskForVariant to return nil. Instead we want FindTaskForVariant (and subsequent work) to be called on each task for the group.