### PR TITLE
EVG-6616 Make expiration for spawn hosts configurable

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -600,8 +600,8 @@ func (m *ec2Manager) setNoExpiration(ctx context.Context, h *host.Host, noExpira
 }
 
 // extendExpiration extends a host's expiration time by the number of hours specified
-func (m *ec2Manager) extendExpiration(ctx context.Context, h *host.Host, hours int) error {
-	return errors.Wrapf(h.SetExpirationTime(h.ExpirationTime.Add(time.Duration(hours)*time.Hour)), "error extending expiration time in db for '%s'", h.Id)
+func (m *ec2Manager) extendExpiration(ctx context.Context, h *host.Host, extension time.Duration) error {
+	return errors.Wrapf(h.SetExpirationTime(h.ExpirationTime.Add(extension), "error extending expiration time in db for '%s'", h.Id)
 }
 
 // ModifyHost modifies a spawn host according to the changes specified by a HostModifyOptions struct.
@@ -639,8 +639,8 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, opts host.Hos
 	if opts.NoExpiration != nil {
 		catcher.Add(m.setNoExpiration(ctx, h, *opts.NoExpiration, resources))
 	}
-	if opts.ExpirationExtension != 0 {
-		catcher.Add(m.extendExpiration(ctx, h, opts.ExpirationExtension))
+	if opts.AddHours > 0 {
+		catcher.Add(m.extendExpiration(ctx, h, opts.AddHours))
 	}
 
 	return catcher.Resolve()

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -527,7 +527,7 @@ func (m *ec2Manager) getResources(ctx context.Context, h *host.Host) ([]string, 
 func (m *ec2Manager) addTags(ctx context.Context, h *host.Host, tags []host.Tag, resources []string) error {
 	createTagSlice := make([]*ec2.Tag, len(tags))
 	for i := range tags {
-		createTagSlice[i] = &ec2.Tag{Key: &tags[i].Key, Value: &tags[i].Value})
+		createTagSlice[i] = &ec2.Tag{Key: &tags[i].Key, Value: &tags[i].Value}
 	}
 	_, err := m.client.CreateTags(ctx, &ec2.CreateTagsInput{
 		Resources: aws.StringSlice(resources),

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -525,11 +525,9 @@ func (m *ec2Manager) getResources(ctx context.Context, h *host.Host) ([]string, 
 
 // addTags adds or updates the specified tags in the client and db
 func (m *ec2Manager) addTags(ctx context.Context, h *host.Host, tags []host.Tag, resources []string) error {
-	createTagSlice := []*ec2.Tag{}
-	for _, tag := range tags {
-		key := tag.Key
-		value := tag.Value
-		createTagSlice = append(createTagSlice, &ec2.Tag{Key: &key, Value: &value})
+	createTagSlice := make([]*ec2.Tag, len(tags))
+	for i := range tags {
+		createTagSlice[i] = &ec2.Tag{Key: &tags[i].Key, Value: &tags[i].Value})
 	}
 	_, err := m.client.CreateTags(ctx, &ec2.CreateTagsInput{
 		Resources: aws.StringSlice(resources),
@@ -545,10 +543,9 @@ func (m *ec2Manager) addTags(ctx context.Context, h *host.Host, tags []host.Tag,
 
 // deleteTags removes the specified tags by their keys in the client and db
 func (m *ec2Manager) deleteTags(ctx context.Context, h *host.Host, keys, resources []string) error {
-	deleteTagSlice := []*ec2.Tag{}
-	for _, delKey := range keys {
-		key := delKey
-		deleteTagSlice = append(deleteTagSlice, &ec2.Tag{Key: &key})
+	deleteTagSlice := make([]*ec2.Tag, len(keys))
+	for i := range keys {
+		deleteTagSlice[i] = &ec2.Tag{Key: &keys[i]}
 	}
 	_, err := m.client.DeleteTags(ctx, &ec2.DeleteTagsInput{
 		Resources: aws.StringSlice(resources),
@@ -583,7 +580,7 @@ func (m *ec2Manager) setNoExpiration(ctx context.Context, h *host.Host, noExpira
 	_, err := m.client.CreateTags(ctx, &ec2.CreateTagsInput{
 		Resources: aws.StringSlice(resources),
 		Tags: []*ec2.Tag{
-			&ec2.Tag{
+			{
 				Key:   aws.String("expire-on"),
 				Value: aws.String(expireOnValue),
 			},

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -601,7 +601,7 @@ func (m *ec2Manager) setNoExpiration(ctx context.Context, h *host.Host, noExpira
 
 // extendExpiration extends a host's expiration time by the number of hours specified
 func (m *ec2Manager) extendExpiration(ctx context.Context, h *host.Host, extension time.Duration) error {
-	return errors.Wrapf(h.SetExpirationTime(h.ExpirationTime.Add(extension), "error extending expiration time in db for '%s'", h.Id)
+	return errors.Wrapf(h.SetExpirationTime(h.ExpirationTime.Add(extension)), "error extending expiration time in db for '%s'", h.Id)
 }
 
 // ModifyHost modifies a spawn host according to the changes specified by a HostModifyOptions struct.

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -857,6 +857,7 @@ func (c *awsClientImpl) GetVolumeIDs(ctx context.Context, h *host.Host) ([]strin
 	for _, device := range instance.BlockDeviceMappings {
 		volumeIDs = append(volumeIDs, *device.Ebs.VolumeId)
 	}
+	h.VolumeIDs = volumeIDs
 
 	return volumeIDs, nil
 }

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -555,7 +555,8 @@ func validateEC2HostModifyOptions(h *host.Host, opts host.HostModifyOptions) err
 		return errors.New("host must be stopped to modify instance typed")
 	}
 	if h.ExpirationTime.Add(opts.AddHours).Sub(time.Now()) > MaxSpawnHostExpirationDurationHours {
-		return errors.New("")
+		return errors.Errorf("cannot extend host '%s' expiration by '%s' -- maximum host duration is limited to %s", h.Id, opts.AddHours.String(), MaxSpawnHostExpirationDurationHours.String())
 	}
+
 	return nil
 }

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -554,5 +554,8 @@ func validateEC2HostModifyOptions(h *host.Host, opts host.HostModifyOptions) err
 	if opts.InstanceType != "" && h.Status != evergreen.HostStopped {
 		return errors.New("host must be stopped to modify instance typed")
 	}
+	if h.ExpirationTime.Add(opts.AddHours).Sub(time.Now()) > MaxSpawnHostExpirationDurationHours {
+		return errors.New("")
+	}
 	return nil
 }

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -549,3 +549,10 @@ func GetEC2Key(region string, s *evergreen.Settings) (string, string, error) {
 
 	return key, secret, nil
 }
+
+func validateEC2HostModifyOptions(h *host.Host, opts host.HostModifyOptions) error {
+	if opts.InstanceType != "" && h.Status != evergreen.HostStopped {
+		return errors.New("host must be stopped to modify instance typed")
+	}
+	return nil
+}

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -178,6 +178,18 @@ func (mockMgr *mockManager) ModifyHost(ctx context.Context, host *host.Host, cha
 		}
 	}
 
+	if changes.NoExpiration != nil {
+		expireOnValue := expireInDays(30)
+		if *changes.NoExpiration {
+			if err = host.MarkShouldNotExpire(expireOnValue); err != nil {
+				return errors.Errorf("error setting no expiration in db")
+			}
+		}
+		if err = host.MarkShouldExpire(expireOnValue); err != nil {
+			return errors.Errorf("error setting expiration in db")
+		}
+	}
+
 	return nil
 }
 

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -46,6 +46,7 @@ type SpawnOptions struct {
 	Owner            *user.DBUser
 	InstanceTags     []host.Tag
 	InstanceType     string
+	NoExpiration     bool
 }
 
 // Validate returns an instance of BadOptionsErr if the SpawnOptions object contains invalid
@@ -140,6 +141,7 @@ func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 		UserHost:           true,
 		InstanceTags:       so.InstanceTags,
 		InstanceType:       so.InstanceType,
+		NoExpiration:       so.NoExpiration,
 	}
 
 	intentHost := host.NewIntent(d, d.GenerateName(), d.Provider, hostOptions)

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -33,6 +33,7 @@ var passwordRegexps = []*regexp.Regexp{
 const (
 	MaxSpawnHostsPerUser                = 3
 	DefaultSpawnHostExpiration          = 24 * time.Hour
+	SpawnHostNoExpirationDuration       = 7 * 24 * time.Hour
 	MaxSpawnHostExpirationDurationHours = 24 * time.Hour * 14
 )
 
@@ -134,6 +135,9 @@ func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 		OwnerId: so.Owner.Id,
 	}
 	expiration := DefaultSpawnHostExpiration
+	if so.NoExpiration {
+		expiration = SpawnHostNoExpirationDuration
+	}
 	hostOptions := host.CreateOptions{
 		ProvisionOptions:   provisionOptions,
 		UserName:           so.UserName,

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -45,6 +45,7 @@ var (
 	TaskDispatchTimeKey          = bsonutil.MustHaveTag(Host{}, "TaskDispatchTime")
 	CreateTimeKey                = bsonutil.MustHaveTag(Host{}, "CreationTime")
 	ExpirationTimeKey            = bsonutil.MustHaveTag(Host{}, "ExpirationTime")
+	NoExpirationKey              = bsonutil.MustHaveTag(Host{}, "NoExpiration")
 	TerminationTimeKey           = bsonutil.MustHaveTag(Host{}, "TerminationTime")
 	LTCTimeKey                   = bsonutil.MustHaveTag(Host{}, "LastTaskCompletedTime")
 	LTCTaskKey                   = bsonutil.MustHaveTag(Host{}, "LastTask")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -247,6 +247,9 @@ const (
 	InitSystemSystemd = "systemd"
 	InitSystemSysV    = "sysv"
 	InitSystemUpstart = "upstart"
+
+	// Max number of spawn hosts with no expiration for user
+	MaxSpawnhostsWithNoExpirationPerUser = 1
 )
 
 func (h *Host) GetTaskGroupString() string {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -233,11 +233,11 @@ type ContainersOnParents struct {
 }
 
 type HostModifyOptions struct {
-	AddInstanceTags     []Tag    // tags to add
-	DeleteInstanceTags  []string // tags to remove
-	InstanceType        string   // new instance type
-	NoExpiration        *bool    // whether host should never expire
-	ExpirationExtension int      // duration to extend expiration
+	AddInstanceTags    []Tag         // tags to add
+	DeleteInstanceTags []string      // tags to remove
+	InstanceType       string        // new instance type
+	NoExpiration       *bool         // whether host should never expire
+	AddHours           time.Duration // duration to extend expiration
 }
 
 const (

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -71,6 +71,7 @@ type Host struct {
 	// duplicate of the DispatchTime field in the above task
 	TaskDispatchTime time.Time `bson:"task_dispatch_time" json:"task_dispatch_time"`
 	ExpirationTime   time.Time `bson:"expiration_time,omitempty" json:"expiration_time"`
+	NoExpiration     bool      `bson:"no_expiration" json:"no_expiration"`
 
 	// creation is when the host document was inserted to the DB, start is when it was started on the cloud provider
 	CreationTime time.Time `bson:"creation_time" json:"creation_time"`
@@ -232,9 +233,11 @@ type ContainersOnParents struct {
 }
 
 type HostModifyOptions struct {
-	AddInstanceTags    []Tag
-	DeleteInstanceTags []string
-	InstanceType       string
+	AddInstanceTags     []Tag    // tags to add
+	DeleteInstanceTags  []string // tags to remove
+	InstanceType        string   // new instance type
+	NoExpiration        *bool    // whether host should never expire
+	ExpirationExtension int      // duration to extend expiration
 }
 
 const (
@@ -1677,36 +1680,46 @@ func StaleRunningTaskIDs(staleness time.Duration) ([]task.Task, error) {
 	return out, err
 }
 
-// AddTags adds the specified tags to the host document, or modifies
-// an existing tag if it can be modified.
-func (h *Host) AddTags(tags []Tag) {
-	for _, new := range tags {
-		found := false
-		for i, old := range h.InstanceTags {
-			if old.Key == new.Key {
-				found = true
-				if old.CanBeModified {
-					h.InstanceTags[i] = new
-				}
-				break
+func (h *Host) addTag(new Tag, hasPermissions bool) {
+	for i, old := range h.InstanceTags {
+		if old.Key == new.Key {
+			if old.CanBeModified || hasPermissions {
+				h.InstanceTags[i] = new
 			}
+			return
 		}
-		if !found {
-			h.InstanceTags = append(h.InstanceTags, new)
+	}
+	h.InstanceTags = append(h.InstanceTags, new)
+	return
+}
+
+func (h *Host) deleteTag(key string, hasPermissions bool) {
+	for i, old := range h.InstanceTags {
+		if old.Key == key {
+			if old.CanBeModified || hasPermissions {
+				h.InstanceTags = append(h.InstanceTags[:i], h.InstanceTags[i+1:]...)
+			}
+			return
 		}
+	}
+	return
+}
+
+// AddTags adds the specified tags to the host document, or modifies
+// an existing tag if it can be modified. Does not allow changes to
+// tags set by Evergreen.
+func (h *Host) AddTags(tags []Tag) {
+	for _, tag := range tags {
+		h.addTag(tag, false)
 	}
 }
 
 // DeleteTags removes tags specified by their keys, only if those
-// keys are allowed to be deleted.
+// keys are allowed to be deleted. Does not allow changes to tags
+// set by Evergreen.
 func (h *Host) DeleteTags(keys []string) {
 	for _, key := range keys {
-		for i, tag := range h.InstanceTags {
-			if tag.Key == key && tag.CanBeModified {
-				h.InstanceTags = append(h.InstanceTags[:i], h.InstanceTags[i+1:]...)
-				break
-			}
-		}
+		h.deleteTag(key, false)
 	}
 }
 
@@ -1741,4 +1754,75 @@ func (h *Host) SetInstanceType(instanceType string) error {
 	}
 	h.InstanceType = instanceType
 	return nil
+}
+
+// CountHostsWithNoExpirationByUser returns a count of all hosts associated
+// with a given users that are considered up and should never expire.
+func CountHostsWithNoExpirationByUser(user string) (int, error) {
+	query := db.Query(bson.M{
+		UserKey:         user,
+		NoExpirationKey: true,
+		StatusKey:       bson.M{"$in": evergreen.UpHostStatus},
+	})
+	return Count(query)
+}
+
+// FindHostsWithNoExpirationToExtend returns all hosts that are set to never
+// expire but have their expiration time within the next day and are still up.
+func FindHostsWithNoExpirationToExtend() ([]Host, error) {
+	query := db.Query(bson.M{
+		NoExpirationKey:   true,
+		StatusKey:         bson.M{"$in": evergreen.UpHostStatus},
+		ExpirationTimeKey: bson.M{"$lte": time.Now().Add(24 * time.Hour)},
+	})
+
+	return Find(query)
+}
+
+func makeExpireOnTag(expireOnValue string) Tag {
+	const expireOnKey = "expire-on"
+	return Tag{
+		Key:           expireOnKey,
+		Value:         expireOnValue,
+		CanBeModified: false,
+	}
+}
+
+// MarkShouldNotExpire marks a host as one that should not expire
+// and updates its expiration time to avoid early reaping.
+func (h *Host) MarkShouldNotExpire(expireOnValue string) error {
+	h.NoExpiration = true
+	h.ExpirationTime = time.Now().AddDate(0, 0, 7)
+	h.addTag(makeExpireOnTag(expireOnValue), true)
+	return UpdateOne(
+		bson.M{
+			IdKey: h.Id,
+		},
+		bson.M{
+			"$set": bson.M{
+				NoExpirationKey:   h.NoExpiration,
+				ExpirationTimeKey: h.ExpirationTime,
+				InstanceTagsKey:   h.InstanceTags,
+			},
+		},
+	)
+}
+
+// MarkShouldExpire resets a host's expiration to expire like
+// a normal spawn host, after 24 hours.
+func (h *Host) MarkShouldExpire(expireOnValue string) error {
+	h.NoExpiration = false
+	h.ExpirationTime = time.Now().Add(24 * time.Hour)
+	h.addTag(makeExpireOnTag(expireOnValue), true)
+	return UpdateOne(bson.M{
+		IdKey: h.Id,
+	},
+		bson.M{
+			"$set": bson.M{
+				NoExpirationKey:   h.NoExpiration,
+				ExpirationTimeKey: h.ExpirationTime,
+				InstanceTagsKey:   h.InstanceTags,
+			},
+		},
+	)
 }

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1759,21 +1759,22 @@ func (h *Host) SetInstanceType(instanceType string) error {
 	return nil
 }
 
-// CountHostsWithNoExpirationByUser returns a count of all hosts associated
+// CountSpawnhostsWithNoExpirationByUser returns a count of all hosts associated
 // with a given users that are considered up and should never expire.
-func CountHostsWithNoExpirationByUser(user string) (int, error) {
+func CountSpawnhostsWithNoExpirationByUser(user string) (int, error) {
 	query := db.Query(bson.M{
-		UserKey:         user,
+		StartedByKey:    user,
 		NoExpirationKey: true,
 		StatusKey:       bson.M{"$in": evergreen.UpHostStatus},
 	})
 	return Count(query)
 }
 
-// FindHostsWithNoExpirationToExtend returns all hosts that are set to never
+// FindSpawnhostsWithNoExpirationToExtend returns all hosts that are set to never
 // expire but have their expiration time within the next day and are still up.
-func FindHostsWithNoExpirationToExtend() ([]Host, error) {
+func FindSpawnhostsWithNoExpirationToExtend() ([]Host, error) {
 	query := db.Query(bson.M{
+		UserHostKey:       true,
 		NoExpirationKey:   true,
 		StatusKey:         bson.M{"$in": evergreen.UpHostStatus},
 		ExpirationTimeKey: bson.M{"$lte": time.Now().Add(24 * time.Hour)},

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -24,6 +24,7 @@ type CreateOptions struct {
 	DockerOptions         DockerOptions
 	InstanceTags          []Tag
 	InstanceType          string
+	NoExpiration          bool
 }
 
 // NewIntent creates an IntentHost using the given host settings. An IntentHost is a host that

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3677,31 +3677,31 @@ func TestSetInstanceType(t *testing.T) {
 func TestCountHostsWithNoExpirationByUser(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	hosts := []Host{
-		Host{
+		{
 			Id:           "host-1",
 			Status:       evergreen.HostRunning,
 			User:         "user-1",
 			NoExpiration: true,
 		},
-		Host{
+		{
 			Id:           "host-2",
 			Status:       evergreen.HostRunning,
 			User:         "user-1",
 			NoExpiration: false,
 		},
-		Host{
+		{
 			Id:           "host-3",
 			Status:       evergreen.HostTerminated,
 			User:         "user-1",
 			NoExpiration: true,
 		},
-		Host{
+		{
 			Id:           "host-4",
 			Status:       evergreen.HostRunning,
 			User:         "user-2",
 			NoExpiration: true,
 		},
-		Host{
+		{
 			Id:           "host-5",
 			Status:       evergreen.HostStarting,
 			User:         "user-2",
@@ -3725,25 +3725,25 @@ func TestCountHostsWithNoExpirationByUser(t *testing.T) {
 func TestFindHostsWithNoExpirationToExtend(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	hosts := []Host{
-		Host{
+		{
 			Id:             "host-1",
 			Status:         evergreen.HostRunning,
 			NoExpiration:   true,
 			ExpirationTime: time.Now(),
 		},
-		Host{
+		{
 			Id:             "host-2",
 			Status:         evergreen.HostRunning,
 			NoExpiration:   false,
 			ExpirationTime: time.Now(),
 		},
-		Host{
+		{
 			Id:             "host-3",
 			Status:         evergreen.HostTerminated,
 			NoExpiration:   true,
 			ExpirationTime: time.Now(),
 		},
-		Host{
+		{
 			Id:             "host-4",
 			Status:         evergreen.HostRunning,
 			NoExpiration:   true,

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3674,87 +3674,98 @@ func TestSetInstanceType(t *testing.T) {
 	assert.Equal(t, newInstanceType, foundHost.InstanceType)
 }
 
-func TestCountHostsWithNoExpirationByUser(t *testing.T) {
+func TestCountSpawnhostsWithNoExpirationByUser(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	hosts := []Host{
 		{
 			Id:           "host-1",
 			Status:       evergreen.HostRunning,
-			User:         "user-1",
+			StartedBy:    "user-1",
 			NoExpiration: true,
 		},
 		{
 			Id:           "host-2",
 			Status:       evergreen.HostRunning,
-			User:         "user-1",
+			StartedBy:    "user-1",
 			NoExpiration: false,
 		},
 		{
 			Id:           "host-3",
 			Status:       evergreen.HostTerminated,
-			User:         "user-1",
+			StartedBy:    "user-1",
 			NoExpiration: true,
 		},
 		{
 			Id:           "host-4",
 			Status:       evergreen.HostRunning,
-			User:         "user-2",
+			StartedBy:    "user-2",
 			NoExpiration: true,
 		},
 		{
 			Id:           "host-5",
 			Status:       evergreen.HostStarting,
-			User:         "user-2",
+			StartedBy:    "user-2",
 			NoExpiration: true,
 		},
 	}
 	for _, h := range hosts {
 		assert.NoError(t, h.Insert())
 	}
-	count, err := CountHostsWithNoExpirationByUser("user-1")
+	count, err := CountSpawnhostsWithNoExpirationByUser("user-1")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
-	count, err = CountHostsWithNoExpirationByUser("user-2")
+	count, err = CountSpawnhostsWithNoExpirationByUser("user-2")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, count)
-	count, err = CountHostsWithNoExpirationByUser("user-3")
+	count, err = CountSpawnhostsWithNoExpirationByUser("user-3")
 	assert.NoError(t, err)
 	assert.Equal(t, 0, count)
 }
 
-func TestFindHostsWithNoExpirationToExtend(t *testing.T) {
+func TestFindSpawnhostsWithNoExpirationToExtend(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	hosts := []Host{
 		{
 			Id:             "host-1",
+			UserHost:       true,
 			Status:         evergreen.HostRunning,
 			NoExpiration:   true,
 			ExpirationTime: time.Now(),
 		},
 		{
 			Id:             "host-2",
+			UserHost:       true,
 			Status:         evergreen.HostRunning,
 			NoExpiration:   false,
 			ExpirationTime: time.Now(),
 		},
 		{
 			Id:             "host-3",
+			UserHost:       true,
 			Status:         evergreen.HostTerminated,
 			NoExpiration:   true,
 			ExpirationTime: time.Now(),
 		},
 		{
 			Id:             "host-4",
+			UserHost:       true,
 			Status:         evergreen.HostRunning,
 			NoExpiration:   true,
 			ExpirationTime: time.Now().AddDate(1, 0, 0),
+		},
+		{
+			Id:             "host-5",
+			UserHost:       false,
+			Status:         evergreen.HostRunning,
+			NoExpiration:   true,
+			ExpirationTime: time.Now(),
 		},
 	}
 	for _, h := range hosts {
 		assert.NoError(t, h.Insert())
 	}
 
-	foundHosts, err := FindHostsWithNoExpirationToExtend()
+	foundHosts, err := FindSpawnhostsWithNoExpirationToExtend()
 	assert.NoError(t, err)
 	assert.Len(t, foundHosts, 1)
 	assert.Equal(t, "host-1", foundHosts[0].Id)

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -126,10 +126,12 @@ func addYesFlag(flags ...cli.Flag) []cli.Flag {
 }
 
 func addHostFlag(flags ...cli.Flag) []cli.Flag {
-	return append(flags, cli.StringFlag{
-		Name:  hostFlagName,
-		Usage: "specify the name of an evergreen host",
-	})
+	return append([]cli.Flag{
+		cli.StringFlag{
+			Name:  hostFlagName,
+			Usage: "specify `ID` of an evergreen host",
+		},
+	}, flags...)
 
 }
 

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"strings"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/model"
@@ -224,10 +225,10 @@ func hostModify() cli.Command {
 			}
 
 			hostChanges := host.HostModifyOptions{
-				AddInstanceTags:     addTags,
-				DeleteInstanceTags:  deleteTagSlice,
-				InstanceType:        instanceType,
-				ExpirationExtension: extension,
+				AddInstanceTags:    addTags,
+				DeleteInstanceTags: deleteTagSlice,
+				InstanceType:       instanceType,
+				AddHours:           time.Duration(extension) * time.Hour,
 			}
 
 			if noExpire {

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -155,6 +155,9 @@ func hostModify() cli.Command {
 		addTagFlagName       = "tag"
 		deleteTagFlagName    = "delete-tag"
 		instanceTypeFlagName = "type"
+		noExpireFlagName     = "no-expire"
+		expireFlagName       = "expire"
+		extendFlagName       = "extend"
 	)
 
 	return cli.Command{
@@ -163,24 +166,40 @@ func hostModify() cli.Command {
 		Flags: addHostFlag(
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(addTagFlagName, "t"),
-				Usage: "key=value pair representing an instance tag, with one pair per flag",
+				Usage: "add instance tag `KEY=VALUE`, one tag per flag",
 			},
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(deleteTagFlagName, "d"),
-				Usage: "key of a single tag to be deleted",
+				Usage: "delete instance tag `KEY`, one tag per flag",
 			},
 			cli.StringFlag{
 				Name:  joinFlagNames(instanceTypeFlagName, "i"),
-				Usage: "name of an instance type",
+				Usage: "change instance type to `TYPE`",
+			},
+			cli.IntFlag{
+				Name:  extendFlagName,
+				Usage: "extend the expiration of a spawn host by `HOURS`",
+			},
+			cli.BoolFlag{
+				Name:  noExpireFlagName,
+				Usage: "make host never expire",
+			},
+			cli.BoolFlag{
+				Name:  expireFlagName,
+				Usage: "make host expire like a normal spawn host, in 24 hours",
 			},
 		),
-		Before: mergeBeforeFuncs(setPlainLogger, requireHostFlag, requireAtLeastOneFlag(addTagFlagName, deleteTagFlagName, instanceTypeFlagName)),
+		Before: mergeBeforeFuncs(setPlainLogger, requireHostFlag, requireAtLeastOneFlag(
+			addTagFlagName, deleteTagFlagName, instanceTypeFlagName, expireFlagName, noExpireFlagName, extendFlagName)),
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().Parent().String(confFlagName)
 			hostID := c.String(hostFlagName)
 			addTagSlice := c.StringSlice(addTagFlagName)
 			deleteTagSlice := c.StringSlice(deleteTagFlagName)
 			instanceType := c.String(instanceTypeFlagName)
+			noExpire := c.Bool(noExpireFlagName)
+			expire := c.Bool(expireFlagName)
+			extension := c.Int(extendFlagName)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -198,10 +217,22 @@ func hostModify() cli.Command {
 			}
 
 			hostChanges := host.HostModifyOptions{
-				AddInstanceTags:    addTags,
-				DeleteInstanceTags: deleteTagSlice,
-				InstanceType:       instanceType,
+				AddInstanceTags:     addTags,
+				DeleteInstanceTags:  deleteTagSlice,
+				InstanceType:        instanceType,
+				ExpirationExtension: extension,
 			}
+
+			if noExpire {
+				noExpirationValue := true
+				hostChanges.NoExpiration = &noExpirationValue
+			} else if expire {
+				noExpirationValue := false
+				hostChanges.NoExpiration = &noExpirationValue
+			} else {
+				hostChanges.NoExpiration = nil
+			}
+
 			err = client.ModifySpawnHost(ctx, hostID, hostChanges)
 			if err != nil {
 				return err

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -67,6 +67,7 @@ func hostCreate() cli.Command {
 		scriptFlagName       = "script"
 		tagFlagName          = "tag"
 		instanceTypeFlagName = "type"
+		noExpireFlagName     = "no-expire"
 	)
 
 	return cli.Command{
@@ -93,6 +94,10 @@ func hostCreate() cli.Command {
 				Name:  joinFlagNames(tagFlagName, "t"),
 				Usage: "key=value pair representing an instance tag, with one pair per flag",
 			},
+			cli.BoolFlag{
+				Name:  noExpireFlagName,
+				Usage: "make host never expire",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().Parent().String(confFlagName)
@@ -101,6 +106,7 @@ func hostCreate() cli.Command {
 			fn := c.String(scriptFlagName)
 			tagSlice := c.StringSlice(tagFlagName)
 			instanceType := c.String(instanceTypeFlagName)
+			noExpire := c.Bool(noExpireFlagName)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -133,6 +139,7 @@ func hostCreate() cli.Command {
 				UserData:     script,
 				InstanceTags: tags,
 				InstanceType: instanceType,
+				NoExpiration: noExpire,
 			}
 
 			host, err := client.CreateSpawnHost(ctx, spawnRequest)

--- a/public/static/js/spawned_hosts.js
+++ b/public/static/js/spawned_hosts.js
@@ -56,9 +56,13 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope','$window', '$timeout', 'mciSp
               } else {
                 var uptime = moment().diff(host.creation_time, 'seconds');
                 host.uptime = moment.duration(uptime, 'seconds').humanize();
-                var expiretime = moment().diff(host.expiration_time, 'seconds');
                 if(+new Date(host.expiration_time) > +new Date("0001-01-01T00:00:00Z")){
-                  host.expires_in = moment.duration(expiretime, 'seconds').humanize();
+                  if (host.no_expiration) {
+                    host.expires_in = "never"
+                  } else {
+                    var expiretime = moment().diff(host.expiration_time, 'seconds');
+                    host.expires_in = moment.duration(expiretime, 'seconds').humanize();
+                  }
                   host.date_for_expiration = new Date(host.expiration_time);
                   host.time_for_expiration = new Date(host.expiration_time);
                 }

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -96,6 +96,7 @@ func (hc *DBHostConnector) NewIntentHost(options *restmodel.HostRequestOptions, 
 		Owner:            user,
 		InstanceTags:     options.InstanceTags,
 		InstanceType:     options.InstanceType,
+		NoExpiration:     options.NoExpiration,
 	}
 
 	intentHost, err := cloud.CreateSpawnHost(spawnOptions)

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -32,6 +32,7 @@ type HostRequestOptions struct {
 	UserData     string     `json:"userdata"`
 	InstanceTags []host.Tag `json:"instance_tags"`
 	InstanceType string     `json:"instance_type"`
+	NoExpiration bool       `json:"no_expiration"`
 }
 
 type DistroInfo struct {

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -125,11 +126,11 @@ type hostModifyHandler struct {
 	hostID string
 	sc     data.Connector
 
-	AddInstanceTags     []host.Tag
-	DeleteInstanceTags  []string
-	InstanceType        string
-	NoExpiration        *bool
-	ExpirationExtension int
+	AddInstanceTags    []host.Tag
+	DeleteInstanceTags []string
+	InstanceType       string
+	NoExpiration       *bool
+	AddHours           time.Duration
 }
 
 func makeHostModifyRouteManager(sc data.Connector) gimlet.RouteHandler {
@@ -188,11 +189,11 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 
 	// Create new spawnhost modify job
 	changes := host.HostModifyOptions{
-		AddInstanceTags:     h.AddInstanceTags,
-		DeleteInstanceTags:  h.DeleteInstanceTags,
-		InstanceType:        h.InstanceType,
-		NoExpiration:        h.NoExpiration,
-		ExpirationExtension: h.ExpirationExtension,
+		AddInstanceTags:    h.AddInstanceTags,
+		DeleteInstanceTags: h.DeleteInstanceTags,
+		InstanceType:       h.InstanceType,
+		NoExpiration:       h.NoExpiration,
+		AddHours:           h.AddHours,
 	}
 	ts := util.RoundPartOfMinute(1).Format(tsFormat)
 	modifyJob := units.NewSpawnhostModifyJob(foundHost, changes, ts)

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -125,9 +125,11 @@ type hostModifyHandler struct {
 	hostID string
 	sc     data.Connector
 
-	AddInstanceTags    []host.Tag
-	DeleteInstanceTags []string
-	InstanceType       string
+	AddInstanceTags     []host.Tag
+	DeleteInstanceTags  []string
+	InstanceType        string
+	NoExpiration        *bool
+	ExpirationExtension int
 }
 
 func makeHostModifyRouteManager(sc data.Connector) gimlet.RouteHandler {
@@ -177,9 +179,11 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 
 	// Create new spawnhost modify job
 	changes := host.HostModifyOptions{
-		AddInstanceTags:    h.AddInstanceTags,
-		DeleteInstanceTags: h.DeleteInstanceTags,
-		InstanceType:       h.InstanceType,
+		AddInstanceTags:     h.AddInstanceTags,
+		DeleteInstanceTags:  h.DeleteInstanceTags,
+		InstanceType:        h.InstanceType,
+		NoExpiration:        h.NoExpiration,
+		ExpirationExtension: h.ExpirationExtension,
 	}
 	ts := util.RoundPartOfMinute(1).Format(tsFormat)
 	modifyJob := units.NewSpawnhostModifyJob(foundHost, changes, ts)

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -179,7 +179,7 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	// Limit number of spawn hosts allowed with no expiration
-	count, err := host.CountHostsWithNoExpirationByUser(user.Id)
+	count, err := host.CountSpawnhostsWithNoExpirationByUser(user.Id)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error counting number of existing non-expiring hosts for '%s'", user.Id))
 	}

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -36,6 +36,7 @@ type hostPostHandler struct {
 	UserData     string     `json:"userdata"`
 	InstanceTags []host.Tag `json:"instance_tags"`
 	InstanceType string     `json:"instance_type"`
+	NoExpiration bool       `json:"no_expiration"`
 
 	sc data.Connector
 }
@@ -60,6 +61,7 @@ func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 		UserData:     hph.UserData,
 		InstanceTags: hph.InstanceTags,
 		InstanceType: hph.InstanceType,
+		NoExpiration: hph.NoExpiration,
 	}
 
 	intentHost, err := hph.sc.NewIntentHost(options, user)

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -29,6 +29,10 @@ func makeSpawnHostCreateRoute(sc data.Connector) gimlet.RouteHandler {
 	}
 }
 
+const (
+	MaxSpawnhostsWithNoExpiration = 1
+)
+
 type hostPostHandler struct {
 	Task         string     `json:"task_id"`
 	Distro       string     `json:"distro"`
@@ -53,6 +57,14 @@ func (hph *hostPostHandler) Parse(ctx context.Context, r *http.Request) error {
 
 func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
+
+	count, err := host.CountHostsWithNoExpirationByUser(user.Id)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error counting number of existing non-expiring hosts for '%s'", user.Id))
+	}
+	if hph.NoExpiration && count >= host.MaxSpawnhostsWithNoExpirationPerUser {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "cannot create any more non-expiring spawn hosts for '%s'", user.Id))
+	}
 
 	options := &model.HostRequestOptions{
 		DistroID:     hph.Distro,

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -58,7 +58,7 @@ func (hph *hostPostHandler) Parse(ctx context.Context, r *http.Request) error {
 func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
 
-	count, err := host.CountHostsWithNoExpirationByUser(user.Id)
+	count, err := host.CountSpawnhostsWithNoExpirationByUser(user.Id)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error counting number of existing non-expiring hosts for '%s'", user.Id))
 	}

--- a/units/crons.go
+++ b/units/crons.go
@@ -1022,7 +1022,7 @@ func PopulateCacheHistoricalTestDataJob(part int) amboy.QueueOperation {
 
 func PopulateSpawnhostExpirationCheckJob() amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
-		hosts, err := host.FindHostsWithNoExpirationToExtend()
+		hosts, err := host.FindSpawnhostsWithNoExpirationToExtend()
 		if err != nil {
 			return err
 		}

--- a/units/crons.go
+++ b/units/crons.go
@@ -1020,6 +1020,13 @@ func PopulateCacheHistoricalTestDataJob(part int) amboy.QueueOperation {
 	}
 }
 
+func PopulateSpawnhostExpirationCheckJob() amboy.QueueOperation {
+	return func(ctx context.Context, queue amboy.Queue) error {
+		ts := util.RoundPartOfHour(0).Format(tsFormat)
+		return queue.Put(ctx, NewSpawnhostExpirationCheckJob(ts))
+	}
+}
+
 func PopulateLocalQueueJobs(env evergreen.Environment) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
 		catcher := grip.NewBasicCatcher()

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -50,6 +50,7 @@ func (j *cronsRemoteHourJob) Run(ctx context.Context) {
 	ops := []amboy.QueueOperation{
 		PopulateCacheHistoricalTestDataJob(2),
 		PopulateJasperDeployJobs(j.env),
+		PopulateSpawnhostExpirationCheckJob(),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/spawnhost_expiration_check.go
+++ b/units/spawnhost_expiration_check.go
@@ -1,0 +1,83 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/dependency"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/pkg/errors"
+)
+
+const (
+	spawnhostExpirationCheckName = "spawnhost-expiration-check"
+)
+
+func init() {
+	registry.AddJobType(spawnhostExpirationCheckName,
+		func() amboy.Job { return makeSpawnhostExpirationCheckJob() })
+}
+
+type spawnhostExpirationCheckJob struct {
+	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
+
+	host *host.Host
+	env  evergreen.Environment
+}
+
+func makeSpawnhostExpirationCheckJob() *spawnhostExpirationCheckJob {
+	j := &spawnhostExpirationCheckJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    spawnhostExpirationCheckName,
+				Version: 0,
+			},
+		},
+	}
+	j.SetDependency(dependency.NewAlways())
+	return j
+}
+
+func NewSpawnhostExpirationCheckJob(ts string) amboy.Job {
+	j := makeSpawnhostExpirationCheckJob()
+	j.SetID(fmt.Sprintf("%s.%s", spawnhostExpirationCheckName, ts))
+	return j
+}
+
+func (j *spawnhostExpirationCheckJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+
+	hostsToExtend, err := host.FindHostsWithNoExpirationToExtend()
+	if err != nil {
+		j.AddError(err)
+		return
+	}
+
+	hostsByManager := cloud.GroupHostsByManager(hostsToExtend)
+	for mgrOpts, hosts := range hostsByManager {
+		cloudManager, err := cloud.GetManager(ctx, mgrOpts, j.env.Settings())
+		if err != nil {
+			j.AddError(errors.Wrap(err, "error getting cloud manager for spawnhost expiration check job"))
+			return
+		}
+		for _, h := range hosts {
+			noExpiration := true
+			if err := cloudManager.ModifyHost(ctx, &h, host.HostModifyOptions{NoExpiration: &noExpiration}); err != nil {
+				j.AddError(errors.Wrap(err, "error extending spawnhost expiration using cloud manager"))
+				return
+			}
+		}
+
+	}
+
+	return
+}

--- a/units/spawnhost_expiration_check_test.go
+++ b/units/spawnhost_expiration_check_test.go
@@ -1,0 +1,119 @@
+package units
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpawnhostExpirationCheckJob(t *testing.T) {
+	config := testutil.TestConfig()
+	assert.NoError(t, evergreen.UpdateConfig(config))
+	assert.NoError(t, db.ClearCollections(host.Collection))
+	mock := cloud.GetMockProvider()
+
+	distroRegion1 := distro.Distro{
+		Provider:         evergreen.ProviderNameMock,
+		ProviderSettings: &map[string]interface{}{"region": "region-1"},
+	}
+
+	distroRegion2 := distro.Distro{
+		Provider:         evergreen.ProviderNameMock,
+		ProviderSettings: &map[string]interface{}{"region": "region-2"},
+	}
+
+	h1 := host.Host{
+		Id:             "h1",
+		Status:         evergreen.HostRunning,
+		UserHost:       true,
+		Provider:       evergreen.ProviderNameMock,
+		Distro:         distroRegion1,
+		NoExpiration:   true,
+		ExpirationTime: time.Now(),
+	}
+	h2 := host.Host{
+		Id:             "h2",
+		Status:         evergreen.HostTerminated,
+		UserHost:       true,
+		Provider:       evergreen.ProviderNameMock,
+		Distro:         distroRegion1,
+		NoExpiration:   true,
+		ExpirationTime: time.Now(),
+	}
+	h3 := host.Host{
+		Id:             "h3",
+		Status:         evergreen.HostRunning,
+		UserHost:       true,
+		Provider:       evergreen.ProviderNameMock,
+		Distro:         distroRegion1,
+		NoExpiration:   false,
+		ExpirationTime: time.Now(),
+	}
+	h4 := host.Host{
+		Id:             "h4",
+		Status:         evergreen.HostRunning,
+		UserHost:       true,
+		Provider:       evergreen.ProviderNameMock,
+		Distro:         distroRegion1,
+		NoExpiration:   true,
+		ExpirationTime: time.Now().AddDate(1, 0, 0),
+	}
+	h5 := host.Host{
+		Id:             "h5",
+		Status:         evergreen.HostRunning,
+		UserHost:       true,
+		Provider:       evergreen.ProviderNameMock,
+		Distro:         distroRegion2,
+		NoExpiration:   true,
+		ExpirationTime: time.Now(),
+	}
+	assert.NoError(t, h1.Insert())
+	assert.NoError(t, h2.Insert())
+	assert.NoError(t, h3.Insert())
+	assert.NoError(t, h4.Insert())
+	assert.NoError(t, h5.Insert())
+
+	mock.Set(h1.Id, cloud.MockInstance{
+		Status: cloud.StatusRunning,
+	})
+	mock.Set(h5.Id, cloud.MockInstance{
+		Status: cloud.StatusRunning,
+	})
+
+	ts := util.RoundPartOfHour(0).Format(tsFormat)
+	j := NewSpawnhostExpirationCheckJob(ts)
+
+	j.Run(context.Background())
+	assert.NoError(t, j.Error())
+	assert.True(t, j.Status().Completed)
+
+	found, err := host.FindOneId(h1.Id)
+	assert.NoError(t, err)
+	assert.True(t, found.ExpirationTime.Sub(h1.ExpirationTime) > 0)
+
+	found, err = host.FindOneId(h2.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, h2.ExpirationTime.Truncate(time.Second), found.ExpirationTime.Truncate(time.Second))
+
+	found, err = host.FindOneId(h3.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, h3.ExpirationTime.Truncate(time.Second), found.ExpirationTime.Truncate(time.Second))
+
+	found, err = host.FindOneId(h4.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, h4.ExpirationTime.Truncate(time.Second), found.ExpirationTime.Truncate(time.Second))
+
+	found, err = host.FindOneId(h5.Id)
+	assert.NoError(t, err)
+	assert.True(t, found.ExpirationTime.Sub(h5.ExpirationTime) > 0)
+
+}

--- a/units/spawnhost_expiration_check_test.go
+++ b/units/spawnhost_expiration_check_test.go
@@ -21,99 +21,33 @@ func TestSpawnhostExpirationCheckJob(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(host.Collection))
 	mock := cloud.GetMockProvider()
 
-	distroRegion1 := distro.Distro{
-		Provider:         evergreen.ProviderNameMock,
-		ProviderSettings: &map[string]interface{}{"region": "region-1"},
+	h := host.Host{
+		Id:       "test-host",
+		Status:   evergreen.HostRunning,
+		UserHost: true,
+		Provider: evergreen.ProviderNameMock,
+		Distro: distro.Distro{
+			Provider: evergreen.ProviderNameMock,
+			ProviderSettings: &map[string]interface{}{
+				"region": "test-region",
+			},
+		},
+		NoExpiration:   true,
+		ExpirationTime: time.Now(),
 	}
 
-	distroRegion2 := distro.Distro{
-		Provider:         evergreen.ProviderNameMock,
-		ProviderSettings: &map[string]interface{}{"region": "region-2"},
-	}
-
-	h1 := host.Host{
-		Id:             "h1",
-		Status:         evergreen.HostRunning,
-		UserHost:       true,
-		Provider:       evergreen.ProviderNameMock,
-		Distro:         distroRegion1,
-		NoExpiration:   true,
-		ExpirationTime: time.Now(),
-	}
-	h2 := host.Host{
-		Id:             "h2",
-		Status:         evergreen.HostTerminated,
-		UserHost:       true,
-		Provider:       evergreen.ProviderNameMock,
-		Distro:         distroRegion1,
-		NoExpiration:   true,
-		ExpirationTime: time.Now(),
-	}
-	h3 := host.Host{
-		Id:             "h3",
-		Status:         evergreen.HostRunning,
-		UserHost:       true,
-		Provider:       evergreen.ProviderNameMock,
-		Distro:         distroRegion1,
-		NoExpiration:   false,
-		ExpirationTime: time.Now(),
-	}
-	h4 := host.Host{
-		Id:             "h4",
-		Status:         evergreen.HostRunning,
-		UserHost:       true,
-		Provider:       evergreen.ProviderNameMock,
-		Distro:         distroRegion1,
-		NoExpiration:   true,
-		ExpirationTime: time.Now().AddDate(1, 0, 0),
-	}
-	h5 := host.Host{
-		Id:             "h5",
-		Status:         evergreen.HostRunning,
-		UserHost:       true,
-		Provider:       evergreen.ProviderNameMock,
-		Distro:         distroRegion2,
-		NoExpiration:   true,
-		ExpirationTime: time.Now(),
-	}
-	assert.NoError(t, h1.Insert())
-	assert.NoError(t, h2.Insert())
-	assert.NoError(t, h3.Insert())
-	assert.NoError(t, h4.Insert())
-	assert.NoError(t, h5.Insert())
-
-	mock.Set(h1.Id, cloud.MockInstance{
-		Status: cloud.StatusRunning,
-	})
-	mock.Set(h5.Id, cloud.MockInstance{
+	assert.NoError(t, h.Insert())
+	mock.Set(h.Id, cloud.MockInstance{
 		Status: cloud.StatusRunning,
 	})
 
 	ts := util.RoundPartOfHour(0).Format(tsFormat)
-	j := NewSpawnhostExpirationCheckJob(ts)
-
+	j := NewSpawnhostExpirationCheckJob(ts, &h)
 	j.Run(context.Background())
 	assert.NoError(t, j.Error())
 	assert.True(t, j.Status().Completed)
 
-	found, err := host.FindOneId(h1.Id)
+	found, err := host.FindOneId(h.Id)
 	assert.NoError(t, err)
-	assert.True(t, found.ExpirationTime.Sub(h1.ExpirationTime) > 0)
-
-	found, err = host.FindOneId(h2.Id)
-	assert.NoError(t, err)
-	assert.Equal(t, h2.ExpirationTime.Truncate(time.Second), found.ExpirationTime.Truncate(time.Second))
-
-	found, err = host.FindOneId(h3.Id)
-	assert.NoError(t, err)
-	assert.Equal(t, h3.ExpirationTime.Truncate(time.Second), found.ExpirationTime.Truncate(time.Second))
-
-	found, err = host.FindOneId(h4.Id)
-	assert.NoError(t, err)
-	assert.Equal(t, h4.ExpirationTime.Truncate(time.Second), found.ExpirationTime.Truncate(time.Second))
-
-	found, err = host.FindOneId(h5.Id)
-	assert.NoError(t, err)
-	assert.True(t, found.ExpirationTime.Sub(h5.ExpirationTime) > 0)
-
+	assert.True(t, found.ExpirationTime.Sub(h.ExpirationTime) > 0)
 }


### PR DESCRIPTION
This PR adds a bunch of ways to configure the expiration time of spawn hosts, specifically allowing for spawn hosts that never expire. Here are the new things you can do!

To make a spawn host stick around indefinitely
> evergreen host modify --host ID --no-expire

The same option is available when creating spawn hosts
> evergreen host create --key KEY --distro DISTRO --no-expire

To make it a normal spawn host again that expires in 24 hours (not sure how often this will be used because you'd probably just terminate it)
> evergreen host modify --host ID --expire

To extend a host's expiration time (already exists in UI, not in CLI)
> evergreen host modify --host ID --extend HOURS

Essentially, a host that never expires has a new NoExpiration field set as true and has its ExpirationTime field pushed to a week into the future. A new spawnhost-expiration-check job that runs every hour finds spawn hosts that are set to expire and re-runs the no expiration modifications, which includes updating the "expire-on" that Evergreen's EC2 reaper uses to reap hosts that have been around for a while.

I made some changes to ModifyHost for EC2 hosts to use a catcher instead of returning early, allowing Evergreen to try to make all requested changes to the host (which should in theory either all succeed or, more rarely, all fail). I split up the different modifications (adding/removing tags, changing instance types, etc) into helper methods on the manager.

No major UI changes (that's a separate ticket) except for displaying "never" under Expires In on the Spawn Hosts page for hosts that should never expire.