### PR TITLE
EVG-6456 allow specifying login domain

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -31,7 +31,11 @@ func LoadUserManager(authConfig evergreen.AuthConfig) (gimlet.UserManager, bool,
 		return manager, false, nil
 	}
 	if authConfig.Github != nil {
-		domain := evergreen.GetEnvironment().Settings().Ui.LoginDomain
+		var domain string
+		env := evergreen.GetEnvironment()
+		if env != nil {
+			domain = env.Settings().Ui.LoginDomain
+		}
 		manager, err = NewGithubUserManager(authConfig.Github, domain)
 		if err != nil {
 			return nil, false, errors.Wrap(err, "problem setting up github authentication")

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -31,7 +31,8 @@ func LoadUserManager(authConfig evergreen.AuthConfig) (gimlet.UserManager, bool,
 		return manager, false, nil
 	}
 	if authConfig.Github != nil {
-		manager, err = NewGithubUserManager(authConfig.Github)
+		domain := evergreen.GetEnvironment().Settings().Ui.LoginDomain
+		manager, err = NewGithubUserManager(authConfig.Github, domain)
 		if err != nil {
 			return nil, false, errors.Wrap(err, "problem setting up github authentication")
 		}
@@ -41,12 +42,13 @@ func LoadUserManager(authConfig evergreen.AuthConfig) (gimlet.UserManager, bool,
 }
 
 // SetLoginToken sets the token in the session cookie for authentication.
-func SetLoginToken(token string, w http.ResponseWriter) {
+func SetLoginToken(token, domain string, w http.ResponseWriter) {
 	authTokenCookie := &http.Cookie{
 		Name:     evergreen.AuthTokenCookie,
 		Value:    token,
 		HttpOnly: true,
 		Path:     "/",
+		Domain:   domain,
 		Expires:  time.Now().Add(365 * 24 * time.Hour),
 	}
 	http.SetCookie(w, authTokenCookie)

--- a/auth/github.go
+++ b/auth/github.go
@@ -37,18 +37,26 @@ type GithubUserManager struct {
 	AuthorizedUsers        []string
 	AuthorizedOrganization string
 	Salt                   string
+	LoginDomain            string
 }
 
 // NewGithubUserManager initializes a GithubUserManager with a Salt as randomly generated string used in Github
 // authentication
-func NewGithubUserManager(g *evergreen.GithubAuthConfig) (gimlet.UserManager, error) {
+func NewGithubUserManager(g *evergreen.GithubAuthConfig, loginDomain string) (gimlet.UserManager, error) {
 	if g.ClientId == "" {
 		return nil, errors.New("no client id for config")
 	}
 	if g.ClientSecret == "" {
 		return nil, errors.New("no client secret for config given")
 	}
-	return &GithubUserManager{g.ClientId, g.ClientSecret, g.Users, g.Organization, util.RandomString()}, nil
+	return &GithubUserManager{
+		ClientId:               g.ClientId,
+		ClientSecret:           g.ClientSecret,
+		AuthorizedUsers:        g.Users,
+		AuthorizedOrganization: g.Organization,
+		Salt:                   util.RandomString(),
+		LoginDomain:            loginDomain,
+	}, nil
 }
 
 // GetUserByToken sends the token to Github and gets back a user and optionally an organization.
@@ -142,7 +150,7 @@ func (gum *GithubUserManager) GetLoginCallbackHandler() http.HandlerFunc {
 			grip.Errorf("Error sending code and authentication info to Github: %+v", err)
 			return
 		}
-		SetLoginToken(githubResponse.AccessToken, w)
+		SetLoginToken(githubResponse.AccessToken, gum.LoginDomain, w)
 		http.Redirect(w, r, redirect, http.StatusFound)
 	}
 }

--- a/config_ui.go
+++ b/config_ui.go
@@ -21,6 +21,7 @@ type UIConfig struct {
 	CacheTemplates bool     `bson:"cache_templates" json:"cache_templates" yaml:"cachetemplates"` // Cache results of template compilation
 	CsrfKey        string   `bson:"csrf_key" json:"csrf_key" yaml:"csrfkey"`                      // 32-byte key used to generate tokens that validate UI requests
 	CORSOrigins    []string `bson:"cors_origins" json:"cors_origins" yaml:"cors_origins"`         // allowed request origins for some UI Routes
+	LoginDomain    string   `bson:"login_domain" json:"login_domain" yaml:"login_domain"`         // domain for the login cookie (defaults to domain of app)
 }
 
 func (c *UIConfig) SectionId() string { return "ui" }
@@ -62,6 +63,7 @@ func (c *UIConfig) Set() error {
 			"cache_templates":  c.CacheTemplates,
 			"csrf_key":         c.CsrfKey,
 			"cors_origins":     c.CORSOrigins,
+			"login_domain":     c.LoginDomain,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/glide.lock
+++ b/glide.lock
@@ -116,7 +116,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: 6cc2541dc7dbad9c3472dc16de975270d60ee9de
   - name: github.com/evergreen-ci/gimlet
-    version: 882654393fa14b76e9b2b66f48b39edd2f8b0460
+    version: 89a2b9939febcabe169dd6a4dfc6ffc62b7beba8
   - name: github.com/evergreen-ci/shrub
     version: 32e668cd99410328bf6659e55671c11a6c727d9a
   - name: github.com/evergreen-ci/pail

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1317,6 +1317,7 @@ type APIUIConfig struct {
 	CacheTemplates bool      `json:"cache_templates"`
 	CsrfKey        APIString `json:"csrf_key"`
 	CORSOrigins    []string  `json:"cors_origins"`
+	LoginDomain    APIString `json:"login_domain"`
 }
 
 func (a *APIUIConfig) BuildFromService(h interface{}) error {
@@ -1331,6 +1332,7 @@ func (a *APIUIConfig) BuildFromService(h interface{}) error {
 		a.CacheTemplates = v.CacheTemplates
 		a.CsrfKey = ToAPIString(v.CsrfKey)
 		a.CORSOrigins = v.CORSOrigins
+		a.LoginDomain = ToAPIString(v.LoginDomain)
 	default:
 		return errors.Errorf("%T is not a supported type", h)
 	}
@@ -1348,6 +1350,7 @@ func (a *APIUIConfig) ToService() (interface{}, error) {
 		CacheTemplates: a.CacheTemplates,
 		CsrfKey:        FromAPIString(a.CsrfKey),
 		CORSOrigins:    a.CORSOrigins,
+		LoginDomain:    FromAPIString(a.LoginDomain),
 	}, nil
 }
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -653,6 +653,10 @@ Admin Settings
 										md-select-on-focus></textarea>
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
+										<label>Login Domain</label>
+										<input type="text" ng-model="Settings.ui.login_domain">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<md-checkbox ng-model="Settings.ui.cache_templates">
 											Cache templates
 										</md-checkbox>

--- a/service/ui.go
+++ b/service/ui.go
@@ -95,6 +95,7 @@ func NewUIServer(settings *evergreen.Settings, queue amboy.Queue, home string, f
 			CookieName:     evergreen.AuthTokenCookie,
 			CookieTTL:      365 * 24 * time.Hour,
 			CookiePath:     "/",
+			CookieDomain:   settings.Ui.LoginDomain,
 		},
 	}
 
@@ -246,9 +247,9 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 
 	app.AddRoute("/timeline/{project_id}").Wrap(needsContext).Handler(uis.timeline).Get()
 	app.AddRoute("/timeline").Wrap(needsContext).Handler(uis.timeline).Get()
-	app.AddRoute("/json/timeline/{project_id}").Wrap(needsContext, needsLogin, allowsCORS).Handler(uis.timelineJson).Get()
-	app.AddRoute("/json/patches/project/{project_id}").Wrap(needsContext, needsLogin, allowsCORS).Handler(uis.patchTimelineJson).Get()
-	app.AddRoute("/json/patches/user/{user_id}").Wrap(needsContext, needsLogin, allowsCORS).Handler(uis.patchTimelineJson).Get()
+	app.AddRoute("/json/timeline/{project_id}").Wrap(needsContext, allowsCORS, needsLogin).Handler(uis.timelineJson).Get()
+	app.AddRoute("/json/patches/project/{project_id}").Wrap(needsContext, allowsCORS, needsLogin).Handler(uis.patchTimelineJson).Get()
+	app.AddRoute("/json/patches/user/{user_id}").Wrap(needsContext, allowsCORS, needsLogin).Handler(uis.patchTimelineJson).Get()
 
 	// Grid page
 	app.AddRoute("/grid").Wrap(needsContext).Handler(uis.grid).Get()

--- a/vendor/github.com/evergreen-ci/gimlet/middleware_auth_user.go
+++ b/vendor/github.com/evergreen-ci/gimlet/middleware_auth_user.go
@@ -21,6 +21,7 @@ type UserMiddlewareConfiguration struct {
 	CookieName      string
 	CookiePath      string
 	CookieTTL       time.Duration
+	CookieDomain    string
 }
 
 // Validate ensures that the UserMiddlewareConfiguration is correct
@@ -66,6 +67,7 @@ func (umc UserMiddlewareConfiguration) AttachCookie(token string, rw http.Respon
 		Value:    token,
 		HttpOnly: true,
 		Expires:  time.Now().Add(umc.CookieTTL),
+		Domain:   umc.CookieDomain,
 	})
 }
 


### PR DESCRIPTION
- Allow configuration of the domain of the login cookie
- Fix an unrelated bug where the patch UI routes don't send CORS headers if not authenticated (no functional difference, but you get a less weird error)