### PR TITLE
EVG-6782 Don't dereference a nil project

### DIFF
--- a/service/timeline.go
+++ b/service/timeline.go
@@ -115,14 +115,9 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 	} else {
 		projectID := gimlet.GetVars(r)["project_id"]
 		project, err := projCtx.GetProject()
-		if err != nil {
+		if err != nil || project == nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err,
 				"Error fetching project %v", projectID))
-			return
-		}
-		if project == nil {
-			uis.LoggedError(w, r, http.StatusNotFound, errors.Wrapf(err,
-				"Could not find project %v", projectID))
 			return
 		}
 		patches, err = patch.Find(patch.ByProject(project.Identifier).

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -93,10 +93,16 @@ func (uis *UIServer) patchTimelineWrapper(author string, w http.ResponseWriter, 
 
 func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
+	projRef, err := projCtx.GetProjectRef()
+	if err != nil {
+		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err,
+			"Error fetching project ref from context"))
+		return
+	}
 	project, err := projCtx.GetProject()
 	if err != nil || project == nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err,
-			"Error fetching project for %v", project.Identifier))
+			"Error fetching project for %v", projRef.Identifier))
 		return
 	}
 

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -113,11 +113,16 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		project_id := gimlet.GetVars(r)["project_id"]
+		projectID := gimlet.GetVars(r)["project_id"]
 		project, err := projCtx.GetProject()
-		if err != nil || project == nil {
+		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err,
-				"Error fetching project for %v", project_id))
+				"Error fetching project %v", projectID))
+			return
+		}
+		if project == nil {
+			uis.LoggedError(w, r, http.StatusNotFound, errors.Wrapf(err,
+				"Could not find project %v", projectID))
 			return
 		}
 		patches, err = patch.Find(patch.ByProject(project.Identifier).

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -93,18 +93,6 @@ func (uis *UIServer) patchTimelineWrapper(author string, w http.ResponseWriter, 
 
 func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
-	projRef, err := projCtx.GetProjectRef()
-	if err != nil {
-		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err,
-			"Error fetching project ref from context"))
-		return
-	}
-	project, err := projCtx.GetProject()
-	if err != nil || project == nil {
-		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err,
-			"Error fetching project for %v", projRef.Identifier))
-		return
-	}
 
 	pageNum, err := strconv.Atoi(r.FormValue("page"))
 	if err != nil {
@@ -119,16 +107,28 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 			Project(patch.ExcludePatchDiff).
 			Sort([]string{"-" + patch.CreateTimeKey}).
 			Skip(skip).Limit(DefaultLimit))
+		if err != nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err,
+				"Error fetching patches for user %v", user))
+			return
+		}
 	} else {
+		project_id := gimlet.GetVars(r)["project_id"]
+		project, err := projCtx.GetProject()
+		if err != nil || project == nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err,
+				"Error fetching project for %v", project_id))
+			return
+		}
 		patches, err = patch.Find(patch.ByProject(project.Identifier).
 			Sort([]string{"-" + patch.CreateTimeKey}).
 			Project(patch.ExcludePatchDiff).
 			Skip(skip).Limit(DefaultLimit))
-	}
-	if err != nil {
-		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err,
-			"Error fetching patches for %v", project.Identifier))
-		return
+		if err != nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err,
+				"Error fetching patches for project %v", project.Identifier))
+			return
+		}
 	}
 
 	versionIds := make([]string, 0, len(patches))


### PR DESCRIPTION
Fixes issue where Evergreen was trying to dereference a project pointer for an error message in the case where the project was nil. Now it just gets the project ref ahead of time (which is just cached in the context) to be able to access the identifier even if GetProject fails!