### PR TITLE
EVG-6808: run agent with bash login setup

### DIFF
--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -42,6 +42,12 @@ var (
 	BootstrapSettingsJasperCredentialsPathKey = bsonutil.MustHaveTag(BootstrapSettings{}, "JasperCredentialsPath")
 	BootstrapSettingsServiceUserKey           = bsonutil.MustHaveTag(BootstrapSettings{}, "ServiceUser")
 	BootstrapSettingsShellPathKey             = bsonutil.MustHaveTag(BootstrapSettings{}, "ShellPath")
+	BootstrapSettingsResourceLimitsKey        = bsonutil.MustHaveTag(BootstrapSettings{}, "ResourceLimits")
+
+	ResourceLimitsNumFilesKey        = bsonutil.MustHaveTag(ResourceLimits{}, "NumFiles")
+	ResourceLimitsNumProcessesKey    = bsonutil.MustHaveTag(ResourceLimits{}, "NumProcesses")
+	ResourceLimitsVirtualMemoryKBKey = bsonutil.MustHaveTag(ResourceLimits{}, "VirtualMemoryKB")
+	ResourceLimitsLockedMemoryKBKey  = bsonutil.MustHaveTag(ResourceLimits{}, "LockedMemoryKB")
 )
 
 const Collection = "distro"

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -49,6 +49,16 @@ type BootstrapSettings struct {
 	JasperCredentialsPath string `json:"jasper_credentials_path,omitempty" bson:"jasper_credentials_path,omitempty" mapstructure:"jasper_credentials_path,omitempty"`
 	ServiceUser           string `bson:"service_user,omitempty" json:"service_user,omitempty" mapstructure:"service_user,omitempty"`
 	ShellPath             string `bson:"shell_path,omitempty" json:"shell_path,omitempty" mapstructure:"shell_path,omitempty"`
+	// kim: TODO: distro UI settings
+	ResourceLimits ResourceLimits `bson:"resource_limits,omitempty" json:"resource_limits,omitempty" mapstructure:"resource_limits,omitempty"`
+}
+
+// ResourceLimits represents resource limits in Linux.
+type ResourceLimits struct {
+	NumProcs        int
+	NumOpenFiles    int
+	VirtualMemoryKB int
+	MemoryLockedKB  int
 }
 
 // Validate checks if all of the bootstrap settings are valid for legacy or

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -42,27 +42,26 @@ type Distro struct {
 
 // BootstrapSettings encapsulates all settings related to bootstrapping hosts.
 type BootstrapSettings struct {
-	Method                string `bson:"method" json:"method" mapstructure:"method"`
-	Communication         string `bson:"communication,omitempty" json:"communication,omitempty" mapstructure:"communication,omitempty"`
-	ClientDir             string `bson:"client_dir,omitempty" json:"client_dir,omitempty" mapstructure:"client_dir,omitempty"`
-	JasperBinaryDir       string `bson:"jasper_binary_dir,omitempty" json:"jasper_binary_dir,omitempty" mapstructure:"jasper_binary_dir,omitempty"`
-	JasperCredentialsPath string `json:"jasper_credentials_path,omitempty" bson:"jasper_credentials_path,omitempty" mapstructure:"jasper_credentials_path,omitempty"`
-	ServiceUser           string `bson:"service_user,omitempty" json:"service_user,omitempty" mapstructure:"service_user,omitempty"`
-	ShellPath             string `bson:"shell_path,omitempty" json:"shell_path,omitempty" mapstructure:"shell_path,omitempty"`
-	// kim: TODO: distro UI settings
-	ResourceLimits ResourceLimits `bson:"resource_limits,omitempty" json:"resource_limits,omitempty" mapstructure:"resource_limits,omitempty"`
+	Method                string         `bson:"method" json:"method" mapstructure:"method"`
+	Communication         string         `bson:"communication,omitempty" json:"communication,omitempty" mapstructure:"communication,omitempty"`
+	ClientDir             string         `bson:"client_dir,omitempty" json:"client_dir,omitempty" mapstructure:"client_dir,omitempty"`
+	JasperBinaryDir       string         `bson:"jasper_binary_dir,omitempty" json:"jasper_binary_dir,omitempty" mapstructure:"jasper_binary_dir,omitempty"`
+	JasperCredentialsPath string         `json:"jasper_credentials_path,omitempty" bson:"jasper_credentials_path,omitempty" mapstructure:"jasper_credentials_path,omitempty"`
+	ServiceUser           string         `bson:"service_user,omitempty" json:"service_user,omitempty" mapstructure:"service_user,omitempty"`
+	ShellPath             string         `bson:"shell_path,omitempty" json:"shell_path,omitempty" mapstructure:"shell_path,omitempty"`
+	ResourceLimits        ResourceLimits `bson:"resource_limits,omitempty" json:"resource_limits,omitempty" mapstructure:"resource_limits,omitempty"`
 }
 
 // ResourceLimits represents resource limits in Linux.
 type ResourceLimits struct {
-	NumProcs        int
-	NumOpenFiles    int
-	VirtualMemoryKB int
-	MemoryLockedKB  int
+	NumFiles        int `bson:"num_files,omitempty" json:"num_files,omitempty" mapstructure:"num_files,omitempty"`
+	NumProcesses    int `bson:"num_processes,omitempty" json:"num_processes,omitempty" mapstructure:"num_processes,omitempty"`
+	LockedMemoryKB  int `bson:"locked_memory,omitempty" json:"locked_memory,omitempty" mapstructure:"locked_memory,omitempty"`
+	VirtualMemoryKB int `bson:"virtual_memory,omitempty" json:"virtual_memory,omitempty" mapstructure:"virtual_memory,omitempty"`
 }
 
-// Validate checks if all of the bootstrap settings are valid for legacy or
-// non-legacy bootstrapping.
+// ValidateBootstrapSettings checks if all of the bootstrap settings are valid
+// for legacy or non-legacy bootstrapping.
 func (d *Distro) ValidateBootstrapSettings() error {
 	catcher := grip.NewBasicCatcher()
 	if !util.StringSliceContains(validBootstrapMethods, d.BootstrapSettings.Method) {
@@ -103,6 +102,11 @@ func (d *Distro) ValidateBootstrapSettings() error {
 	catcher.NewWhen(d.IsWindows() && d.BootstrapSettings.ServiceUser == "", "service user cannot be empty for non-legacy Windows bootstrapping")
 
 	catcher.NewWhen(d.IsWindows() && d.BootstrapSettings.ShellPath == "", "shell path cannot be empty for non-legacy Windows bootstrapping")
+
+	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.NumFiles < -1, "max number of files should be a positive number or -1")
+	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.NumProcesses < -1, "max number of files should be a positive number or -1")
+	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.LockedMemoryKB < -1, "max locked memory should be a positive number or -1")
+	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.VirtualMemoryKB < -1, "max virtual memory should be a positive number or -1")
 
 	return catcher.Resolve()
 }
@@ -274,6 +278,10 @@ func (d *Distro) IsWindows() bool {
 	// XXX: if this is-windows check is updated, make sure to also update
 	// public/static/js/spawned_hosts.js as well
 	return strings.Contains(d.Arch, "windows")
+}
+
+func (d *Distro) IsLinux() bool {
+	return strings.Contains(d.Arch, "linux")
 }
 
 func (d *Distro) Platform() (string, string) {

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -268,17 +268,19 @@ func (h *Host) ForceReinstallJasperCommand(settings *evergreen.Settings) string 
 		}
 	}
 
-	if numProcs := h.Distro.BootstrapSettings.ResourceLimits.NumProcs; numProcs != 0 {
-		params = append(params, fmt.Sprintf("--limit_nprocs=%d", numProcs))
-	}
-	if numFiles := h.Distro.BootstrapSettings.ResourceLimits.NumOpenFiles; numFiles != 0 {
-		params = append(params, fmt.Sprintf("--limit_nfiles=%d", numFiles))
-	}
-	if vMem := h.Distro.BootstrapSettings.ResourceLimits.VirtualMemoryKB; vMem != 0 {
-		params = append(params, fmt.Sprintf("--limit_vmem=%d", vMem))
-	}
-	if memLocked := h.Distro.BootstrapSettings.ResourceLimits.MemoryLockedKB; memLocked != 0 {
-		params = append(params, fmt.Sprintf("--limit_memlock=%d", memLocked))
+	if os, _ := h.Distro.Platform(); os == "linux" {
+		if numProcs := h.Distro.BootstrapSettings.ResourceLimits.NumProcesses; numProcs != 0 {
+			params = append(params, fmt.Sprintf("--limit_num_procs=%d", numProcs))
+		}
+		if numFiles := h.Distro.BootstrapSettings.ResourceLimits.NumFiles; numFiles != 0 {
+			params = append(params, fmt.Sprintf("--limit_num_files=%d", numFiles))
+		}
+		if lockedMem := h.Distro.BootstrapSettings.ResourceLimits.LockedMemoryKB; lockedMem != 0 {
+			params = append(params, fmt.Sprintf("--limit_locked_memory=%d", lockedMem))
+		}
+		if virtualMem := h.Distro.BootstrapSettings.ResourceLimits.VirtualMemoryKB; virtualMem != 0 {
+			params = append(params, fmt.Sprintf("--limit_virtual_memory=%d", virtualMem))
+		}
 	}
 
 	return h.jasperServiceCommand(settings.HostJasper, jcli.ForceReinstallCommand, params...)

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -268,6 +268,19 @@ func (h *Host) ForceReinstallJasperCommand(settings *evergreen.Settings) string 
 		}
 	}
 
+	if numProcs := h.Distro.BootstrapSettings.ResourceLimits.NumProcs; numProcs != 0 {
+		params = append(params, fmt.Sprintf("--limit_nprocs=%d", numProcs))
+	}
+	if numFiles := h.Distro.BootstrapSettings.ResourceLimits.NumOpenFiles; numFiles != 0 {
+		params = append(params, fmt.Sprintf("--limit_nfiles=%d", numFiles))
+	}
+	if vMem := h.Distro.BootstrapSettings.ResourceLimits.VirtualMemoryKB; vMem != 0 {
+		params = append(params, fmt.Sprintf("--limit_vmem=%d", vMem))
+	}
+	if memLocked := h.Distro.BootstrapSettings.ResourceLimits.MemoryLockedKB; memLocked != 0 {
+		params = append(params, fmt.Sprintf("--limit_memlock=%d", memLocked))
+	}
+
 	return h.jasperServiceCommand(settings.HostJasper, jcli.ForceReinstallCommand, params...)
 }
 

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -143,19 +143,31 @@ func TestJasperCommands(t *testing.T) {
 		},
 		"ForceReinstallJasperCommand": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			cmd := h.ForceReinstallJasperCommand(settings)
-			assert.Equal(t, "sudo /foo/jasper_cli jasper service force-reinstall rpc --host=0.0.0.0 --port=12345 --creds_path=/bar/bat.txt --user=user", cmd)
+			assert.True(t, strings.HasPrefix(cmd, "sudo /foo/jasper_cli jasper service force-reinstall rpc"))
+			assert.Contains(t, cmd, "--host=0.0.0.0")
+			assert.Contains(t, cmd, fmt.Sprintf("--port=%d", settings.HostJasper.Port))
+			assert.Contains(t, cmd, fmt.Sprintf("--creds_path=%s", h.Distro.BootstrapSettings.JasperCredentialsPath))
+			assert.Contains(t, cmd, fmt.Sprintf("--user=%s", h.Distro.User), cmd)
+			assert.Contains(t, cmd, fmt.Sprintf("--limit_num_procs=%d", h.Distro.BootstrapSettings.ResourceLimits.NumProcesses))
+			assert.Contains(t, cmd, fmt.Sprintf("--limit_num_files=%d", h.Distro.BootstrapSettings.ResourceLimits.NumFiles))
+			assert.Contains(t, cmd, fmt.Sprintf("--limit_virtual_memory=%d", h.Distro.BootstrapSettings.ResourceLimits.VirtualMemoryKB))
+			assert.Contains(t, cmd, fmt.Sprintf("--limit_locked_memory=%d", h.Distro.BootstrapSettings.ResourceLimits.LockedMemoryKB))
 		},
 		"ForceReinstallJasperCommandWithSplunkLogging": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			settings.Splunk.ServerURL = "url"
 			settings.Splunk.Token = "token"
+			settings.Splunk.Channel = "channel"
 
 			cmd := h.ForceReinstallJasperCommand(settings)
-			expected := "sudo /foo/jasper_cli jasper service force-reinstall rpc --host=0.0.0.0 --port=12345 --creds_path=/bar/bat.txt --user=user --splunk_url=url --splunk_token_path=/bar/splunk.txt"
-			assert.Equal(t, expected, cmd)
+			assert.True(t, strings.HasPrefix(cmd, "sudo /foo/jasper_cli jasper service force-reinstall rpc"))
 
-			settings.Splunk.Channel = "channel"
-			cmd = h.ForceReinstallJasperCommand(settings)
-			assert.Equal(t, expected+" --splunk_channel=channel", cmd)
+			assert.Contains(t, cmd, "--host=0.0.0.0")
+			assert.Contains(t, cmd, fmt.Sprintf("--port=%d", settings.HostJasper.Port))
+			assert.Contains(t, cmd, fmt.Sprintf("--creds_path=%s", h.Distro.BootstrapSettings.JasperCredentialsPath))
+			assert.Contains(t, cmd, fmt.Sprintf("--user=%s", h.Distro.User))
+			assert.Contains(t, cmd, fmt.Sprintf("--splunk_url=%s", settings.Splunk.ServerURL))
+			assert.Contains(t, cmd, fmt.Sprintf("--splunk_token_path=%s", h.splunkTokenFilePath()))
+			assert.Contains(t, cmd, fmt.Sprintf("--splunk_channel=%s", settings.Splunk.Channel))
 		},
 	} {
 		t.Run(opName, func(t *testing.T) {
@@ -165,6 +177,12 @@ func TestJasperCommands(t *testing.T) {
 					BootstrapSettings: distro.BootstrapSettings{
 						JasperBinaryDir:       "/foo",
 						JasperCredentialsPath: "/bar/bat.txt",
+						ResourceLimits: distro.ResourceLimits{
+							NumProcesses:    1,
+							NumFiles:        2,
+							LockedMemoryKB:  3,
+							VirtualMemoryKB: 4,
+						},
 					},
 					User: "user",
 				}}
@@ -263,8 +281,14 @@ func TestJasperCommandsWindows(t *testing.T) {
 			}
 		},
 		"ForceReinstallJasperCommand": func(t *testing.T, h *Host, settings *evergreen.Settings) {
+			require.NoError(t, h.CreateServicePassword())
 			cmd := h.ForceReinstallJasperCommand(settings)
-			assert.Equal(t, `/foo/jasper_cli.exe jasper service force-reinstall rpc --host=0.0.0.0 --port=12345 --creds_path=/bar/bat.txt --user=.\\\\service-user`, cmd)
+			assert.True(t, strings.HasPrefix(cmd, "/foo/jasper_cli.exe jasper service force-reinstall rpc"))
+			assert.Contains(t, cmd, "--host=0.0.0.0")
+			assert.Contains(t, cmd, fmt.Sprintf("--port=%d", settings.HostJasper.Port))
+			assert.Contains(t, cmd, fmt.Sprintf("--creds_path=%s", h.Distro.BootstrapSettings.JasperCredentialsPath))
+			assert.Contains(t, cmd, fmt.Sprintf(`--user=.\\\\%s`, h.Distro.BootstrapSettings.ServiceUser))
+			assert.Contains(t, cmd, fmt.Sprintf("--password=%s", h.ServicePassword))
 		},
 		"WriteJasperCredentialsFileCommand": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			creds, err := newMockCredentials()
@@ -583,8 +607,8 @@ func TestBuildLocalJasperClientRequest(t *testing.T) {
 	index += offset + len(expectedSubCmd)
 
 	assert.Contains(t, cmd[index:], "--service=rpc")
-	assert.Contains(t, cmd[index:], "--port=12345")
-	assert.Contains(t, cmd[index:], "--creds_path=/jasper/credentials.txt")
+	assert.Contains(t, cmd[index:], fmt.Sprintf("--port=%d", config.Port))
+	assert.Contains(t, cmd[index:], fmt.Sprintf("--creds_path=%s", h.Distro.BootstrapSettings.JasperCredentialsPath))
 }
 
 func TestSetupScriptCommands(t *testing.T) {

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -317,7 +317,7 @@ func (m *monitor) createAgentProcess(ctx context.Context, retry util.RetryArgs) 
 
 	if err = util.RetryWithArgs(ctx, func() (bool, error) {
 		cmd := m.jasperClient.CreateCommand(ctx).
-			Add(agentCmdArgs).
+			Add([]string{"bash", "-l", "-c", strings.Join(agentCmdArgs, " ")}).
 			SetOutputSender(level.Info, grip.GetSender()).
 			SetErrorSender(level.Error, grip.GetSender()).
 			Environment(env).

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -501,7 +501,11 @@ mciModule.controller('DistrosCtrl', function($scope, $window, $location, $anchor
   }
 
   $scope.isWindows = function() {
-    return $scope.activeDistro.arch.includes('windows')
+    return $scope.activeDistro.arch.includes('windows');
+  }
+
+  $scope.isLinux = function() {
+    return $scope.activeDistro.arch.includes('linux');
   }
 
   $scope.isNonLegacyProvisioning = function() {

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -120,13 +120,21 @@ func (s *APIFinderSettings) ToService() (interface{}, error) {
 // APIBootstrapSettings is the model to be returned by the API whenever distro.BootstrapSettings are fetched
 
 type APIBootstrapSettings struct {
-	Method                APIString `json:"method"`
-	Communication         APIString `json:"communication"`
-	ClientDir             APIString `json:"client_dir"`
-	JasperBinaryDir       APIString `json:"jasper_binary_dir"`
-	JasperCredentialsPath APIString `json:"jasper_credentials_path"`
-	ServiceUser           APIString `json:"service_user"`
-	ShellPath             APIString `json:"shell_path"`
+	Method                APIString         `json:"method"`
+	Communication         APIString         `json:"communication"`
+	ClientDir             APIString         `json:"client_dir"`
+	JasperBinaryDir       APIString         `json:"jasper_binary_dir"`
+	JasperCredentialsPath APIString         `json:"jasper_credentials_path"`
+	ServiceUser           APIString         `json:"service_user"`
+	ShellPath             APIString         `json:"shell_path"`
+	ResourceLimits        APIResourceLimits `json:"resource_limits"`
+}
+
+type APIResourceLimits struct {
+	NumFiles        int `json:"num_files"`
+	NumProcesses    int `json:"num_processes"`
+	LockedMemoryKB  int `json:"locked_memory"`
+	VirtualMemoryKB int `json:"virtual_memory"`
 }
 
 // BuildFromService converts from service level distro.BootstrapSettings to an
@@ -176,6 +184,11 @@ func (s *APIBootstrapSettings) ToService() (interface{}, error) {
 	settings.JasperCredentialsPath = FromAPIString(s.JasperCredentialsPath)
 	settings.ServiceUser = FromAPIString(s.ServiceUser)
 	settings.ShellPath = FromAPIString(s.ShellPath)
+
+	settings.ResourceLimits.NumFiles = s.ResourceLimits.NumFiles
+	settings.ResourceLimits.NumProcesses = s.ResourceLimits.NumProcesses
+	settings.ResourceLimits.LockedMemoryKB = s.ResourceLimits.LockedMemoryKB
+	settings.ResourceLimits.VirtualMemoryKB = s.ResourceLimits.VirtualMemoryKB
 
 	return settings, nil
 }

--- a/rest/model/distro_test.go
+++ b/rest/model/distro_test.go
@@ -62,6 +62,12 @@ func TestDistroToService(t *testing.T) {
 			JasperCredentialsPath: ToAPIString("/jasper_credentials_path"),
 			ServiceUser:           ToAPIString("service_user"),
 			ShellPath:             ToAPIString("/shell_path"),
+			ResourceLimits: APIResourceLimits{
+				NumFiles:        1,
+				NumProcesses:    2,
+				LockedMemoryKB:  3,
+				VirtualMemoryKB: 4,
+			},
 		},
 	}
 
@@ -79,6 +85,10 @@ func TestDistroToService(t *testing.T) {
 	assert.Equal(t, apiDistro.BootstrapSettings.JasperCredentialsPath, ToAPIString(d.BootstrapSettings.JasperCredentialsPath))
 	assert.Equal(t, apiDistro.BootstrapSettings.ServiceUser, ToAPIString(d.BootstrapSettings.ServiceUser))
 	assert.Equal(t, apiDistro.BootstrapSettings.ShellPath, ToAPIString(d.BootstrapSettings.ShellPath))
+	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.NumFiles, d.BootstrapSettings.ResourceLimits.NumFiles)
+	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.NumProcesses, d.BootstrapSettings.ResourceLimits.NumProcesses)
+	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.LockedMemoryKB, d.BootstrapSettings.ResourceLimits.LockedMemoryKB)
+	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.VirtualMemoryKB, d.BootstrapSettings.ResourceLimits.VirtualMemoryKB)
 }
 
 func TestDistroToServiceDefaults(t *testing.T) {

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1155,7 +1155,13 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 					"jasper_credentials_path": "/etc/credentials",
 					"client_dir": "/usr/bin",
 					"service_user": "service_user",
-					"shell_path": "/usr/bin/bash"
+					"shell_path": "/usr/bin/bash",
+					"resource_limits": {
+						"num_files": 1,
+						"num_processes": 2,
+						"locked_memory": 3,
+						"virtual_memory": 4
+					}
 				},
 				"clone_method": "legacy-ssh",
 				"ssh_key" : "~SSH string",
@@ -1222,6 +1228,10 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 	s.Equal(model.ToAPIString("/etc/credentials"), apiDistro.BootstrapSettings.JasperCredentialsPath)
 	s.Equal(model.ToAPIString("service_user"), apiDistro.BootstrapSettings.ServiceUser)
 	s.Equal(model.ToAPIString("/usr/bin/bash"), apiDistro.BootstrapSettings.ShellPath)
+	s.Equal(1, apiDistro.BootstrapSettings.ResourceLimits.NumFiles)
+	s.Equal(2, apiDistro.BootstrapSettings.ResourceLimits.NumProcesses)
+	s.Equal(3, apiDistro.BootstrapSettings.ResourceLimits.LockedMemoryKB)
+	s.Equal(4, apiDistro.BootstrapSettings.ResourceLimits.VirtualMemoryKB)
 	s.Equal(apiDistro.User, model.ToAPIString("~root"))
 	s.Equal(apiDistro.SSHKey, model.ToAPIString("~SSH string"))
 	s.Equal(apiDistro.SSHOptions, []string{"~StrictHostKeyChecking=no", "~BatchMode=no", "~ConnectTimeout=10"})

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -679,6 +679,33 @@ Evergreen - Distros
               class="form-control" ng-model="activeDistro.bootstrap_settings.shell_path" placeholder="Absolute native path to the shell binary file (bash)">
             <div class="icon fa fa-warning distro-error" ng-show="form.shellPath.$invalid"> Shell path is required</div><br />
           </div>
+          <div ng-show="isLinux() && isNonLegacyProvisioning()">
+			<label class="distro-label">Resource Limits:</label><br />
+			<label class="muted">Number of Files:</label>
+            <input type="number" ng-readonly="readOnly" name="numFiles"
+              class="form-control" ng-model="activeDistro.bootstrap_settings.resource_limits.num_files"
+			  placeholder="Max number of open file handles. Set -1 for unlimited"
+			  min="-1">
+            <div class="icon fa fa-warning distro-error" ng-show="form.numFiles.$invalid"> Invalid max open files</div><br />
+			<label class="muted">Number of Processes:</label>
+            <input type="number" ng-readonly="readOnly" name="numProcesses"
+              class="form-control" ng-model="activeDistro.bootstrap_settings.resource_limits.num_processes"
+			  placeholder="Max number of processes. Set -1 for unlimited"
+			  min="-1">
+            <div class="icon fa fa-warning distro-error" ng-show="form.numProcesses.$invalid"> Invalid max processes</div><br />
+			<label class="muted">Locked Memory:</label>
+            <input type="number" ng-readonly="readOnly" name="lockedMemoryKB"
+              class="form-control" ng-model="activeDistro.bootstrap_settings.resource_limits.locked_memory"
+			  placeholder="Max size (in KB) that can be locked into memory. Set -1 for unlimited"
+			  min="-1">
+            <div class="icon fa fa-warning distro-error" ng-show="form.lockedMemoryKB.$invalid"> Invalid max locked memory</div><br />
+			<label class="muted">Virtual Memory:</label>
+            <input type="number" ng-readonly="readOnly" name="virtualMemoryKB"
+              class="form-control" ng-model="activeDistro.bootstrap_settings.resource_limits.virtual_memory"
+			  placeholder="Max size (in KB) of available virtual memory. Set -1 for unlimited"
+			  min="-1">
+            <div class="icon fa fa-warning distro-error" ng-show="form.virtualMemory.$invalid"> Invalid max virtual memory</div><br />
+          </div>
         </div>
         <div>
           <label class="distro-label">User:</label>

--- a/validator/distro_validator_test.go
+++ b/validator/distro_validator_test.go
@@ -429,32 +429,92 @@ func TestEnsureValidBootstrapSettings(t *testing.T) {
 		}
 	}
 
-	s := nonLegacyBootstrapSettings()
-	s.Method = "foobar"
-	s.Communication = distro.CommunicationMethodLegacySSH
-	assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
-
-	s.Method = distro.BootstrapMethodLegacySSH
-	s.Communication = "foobar"
-	assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
-
-	s.Method = distro.BootstrapMethodLegacySSH
-	s.Communication = ""
-	assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
-
-	s.Method = ""
-	s.Communication = distro.CommunicationMethodLegacySSH
-	assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
-
-	s.Method = distro.BootstrapMethodSSH
-	s.Communication = ""
-	assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
-
-	s.Method = ""
-	s.Communication = distro.CommunicationMethodSSH
-	assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
-
-	assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: distro.BootstrapSettings{Method: distro.BootstrapMethodSSH, Communication: distro.CommunicationMethodSSH}}, &evergreen.Settings{}))
+	for testName, testCase := range map[string]func(t *testing.T, s distro.BootstrapSettings){
+		"InvalidBootstrapMethod": func(t *testing.T, s distro.BootstrapSettings) {
+			s.Method = "foobar"
+			s.Communication = distro.CommunicationMethodLegacySSH
+			assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
+		},
+		"InvalidCommunication": func(t *testing.T, s distro.BootstrapSettings) {
+			s.Method = distro.BootstrapMethodLegacySSH
+			s.Communication = "foobar"
+			assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
+		},
+		"UnspecifiedBootstrapMethodLegacyCommunication": func(t *testing.T, s distro.BootstrapSettings) {
+			s.Method = ""
+			s.Communication = distro.CommunicationMethodLegacySSH
+			assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
+		},
+		"UnspecifiedCommunicationLegacyBootstrapMethod": func(t *testing.T, s distro.BootstrapSettings) {
+			s.Method = distro.BootstrapMethodLegacySSH
+			s.Communication = ""
+			assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
+		},
+		"UnspecifiedCommunicationNonLegacyBootstrapMethod": func(t *testing.T, s distro.BootstrapSettings) {
+			s.Method = distro.BootstrapMethodSSH
+			s.Communication = ""
+			assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
+		},
+		"UnspecifiedBootstrapMethodNonLegacyCommunication": func(t *testing.T, s distro.BootstrapSettings) {
+			s.Method = ""
+			s.Communication = distro.CommunicationMethodSSH
+			assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: s}, &evergreen.Settings{}))
+		},
+		"WindowsNoShellPath": func(t *testing.T, s distro.BootstrapSettings) {
+			s.Method = distro.BootstrapMethodSSH
+			s.Communication = distro.CommunicationMethodSSH
+			s.ShellPath = ""
+			assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{Arch: distro.ArchWindowsAmd64, BootstrapSettings: s}, &evergreen.Settings{}))
+		},
+		"WindowsNoServiceUser": func(t *testing.T, s distro.BootstrapSettings) {
+			s.Method = distro.BootstrapMethodSSH
+			s.Communication = distro.CommunicationMethodSSH
+			s.ServiceUser = ""
+			assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{Arch: distro.ArchWindowsAmd64, BootstrapSettings: s}, &evergreen.Settings{}))
+		},
+		"ResourceLimits": func(t *testing.T, s distro.BootstrapSettings) {
+			for resourceTestName, resourceTestCase := range map[string]func(t *testing.T, s distro.BootstrapSettings){
+				"PositiveValues": func(t *testing.T, s distro.BootstrapSettings) {
+					s.ResourceLimits.NumFiles = 1
+					s.ResourceLimits.NumProcesses = 2
+					s.ResourceLimits.LockedMemoryKB = 3
+					s.ResourceLimits.VirtualMemoryKB = 4
+					assert.Nil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{Arch: distro.ArchLinuxAmd64, BootstrapSettings: s}, &evergreen.Settings{}))
+				},
+				"ZeroValues": func(t *testing.T, s distro.BootstrapSettings) {
+					s.ResourceLimits.NumFiles = 0
+					s.ResourceLimits.NumProcesses = 0
+					s.ResourceLimits.LockedMemoryKB = 0
+					s.ResourceLimits.VirtualMemoryKB = 0
+					assert.Nil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{Arch: distro.ArchLinuxAmd64, BootstrapSettings: s}, &evergreen.Settings{}))
+				},
+				"UnlimitedResources": func(t *testing.T, s distro.BootstrapSettings) {
+					s.ResourceLimits.NumFiles = -1
+					s.ResourceLimits.NumProcesses = -1
+					s.ResourceLimits.LockedMemoryKB = -1
+					s.ResourceLimits.VirtualMemoryKB = -1
+					assert.Nil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{Arch: distro.ArchLinuxAmd64, BootstrapSettings: s}, &evergreen.Settings{}))
+				},
+				"InvalidResourceLimits": func(t *testing.T, s distro.BootstrapSettings) {
+					s.ResourceLimits.NumFiles = -50
+					s.ResourceLimits.NumProcesses = -50
+					s.ResourceLimits.LockedMemoryKB = -50
+					s.ResourceLimits.VirtualMemoryKB = -50
+					assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{Arch: distro.ArchLinuxAmd64, BootstrapSettings: s}, &evergreen.Settings{}))
+				},
+			} {
+				t.Run(resourceTestName, func(t *testing.T) {
+					s.Method = distro.BootstrapMethodSSH
+					s.Communication = distro.CommunicationMethodSSH
+					resourceTestCase(t, s)
+				})
+			}
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			testCase(t, nonLegacyBootstrapSettings())
+		})
+	}
 }
 
 func TestEnsureValidCloneMethod(t *testing.T) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6808

`~/.bash_profile` sets some environment variables and ulimits expected by certain tasks.
1. The environment variables can be acquired just by running the agent within a login shell.
2. Ulimits can't exceed the limits of the spawning process and systemd processes don't obey the configuration in `/etc/security/limits.conf`. Since the Jasper service will run at different (often lower) ulimits by default than needed by the agent, we have to manually set limits in the service file. These can be set from the distro settings.