### PR TITLE
EVG-6786 Display updated expiration time in client time zone

### DIFF
--- a/service/spawn.go
+++ b/service/spawn.go
@@ -293,8 +293,12 @@ func (uis *UIServer) modifySpawnHost(w http.ResponseWriter, r *http.Request) {
 			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Error extending host expiration time"))
 			return
 		}
+		loc, err := time.LoadLocation(u.Settings.Timezone)
+		if err != nil || loc == nil {
+			loc = time.UTC
+		}
 		PushFlash(uis.CookieStore, r, w, NewSuccessFlash(fmt.Sprintf("Host expiration successfully set to %s",
-			futureExpiration.Format(time.RFC822))))
+			futureExpiration.In(loc).Format(time.RFC822))))
 		gimlet.WriteJSON(w, "Successfully extended host expiration time")
 		return
 


### PR DESCRIPTION
When a user updates the expiration of a spawn host using the Evergreen UI, the confirmation message now shows the updated expiration time in the user's own timezone specified by their user settings. The message defaults to UTC if the timezone field is improperly set for whatever reason.

<img width="963" alt="Screen Shot 2019-10-03 at 3 50 57 PM" src="https://user-images.githubusercontent.com/23161985/66159271-a638cf80-e5f5-11e9-8f3f-80f5bfaf6bdf.png">