### PR TITLE
Fix log when process is not cleaned up

### DIFF
--- a/util/subtree_linux.go
+++ b/util/subtree_linux.go
@@ -93,8 +93,8 @@ func cleanup(key string, logger grip.Journaler) error {
 	}
 
 	// Log each process that was not cleaned up
-	for pid := range pids {
-		logger.Infof("Failed to clean up process &d", pid)
+	for _, pid := range pids {
+		logger.Infof("Failed to clean up process %d", pid)
 	}
 
 	return nil


### PR DESCRIPTION
Noticed while looking into an unrelated patch failure:
```
 [2019/10/03 16:36:38.649] cleaning up processes for task: motor_main__ssl~nossl_tox_env~synchro_os~ubuntu_test_4.2_replica_set_patch_a88316b8fd06bfca05503d98a24e424ffd69f623_5d96820961837d0adbcb0b01_19_10_03_23_19_45
 [2019/10/03 16:36:38.650] Killed process 4000
 [2019/10/03 16:36:38.650] Killed process 4097
 [2019/10/03 16:36:38.650] Killed process 4321
 [2019/10/03 16:36:38.650] Killed process 4322
 [2019/10/03 16:36:38.650] Killed process 4323
 [2019/10/03 16:36:38.652] Failed to clean up process &d%!(EXTRA int=0)
 [2019/10/03 16:36:38.652] Failed to clean up process &d%!(EXTRA int=1)
 [2019/10/03 16:36:38.652] Failed to clean up process &d%!(EXTRA int=2)
 [2019/10/03 16:36:38.652] Failed to clean up process &d%!(EXTRA int=3)
 [2019/10/03 16:36:38.652] Failed to clean up process &d%!(EXTRA int=4)
 [2019/10/03 16:36:38.652] Failed to clean up process &d%!(EXTRA int=5)
 [2019/10/03 16:36:38.652] Failed to clean up process &d%!(EXTRA int=6)
 [2019/10/03 16:36:38.652] Failed to clean up process &d%!(EXTRA int=7)
```
Caused by: https://jira.mongodb.org/browse/EVG-6437