### PR TITLE
EVG-6815: run setup script as either shell or powershell

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -120,7 +120,7 @@ func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 	}
 
 	// modify the setup script to add the user's public key
-	d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", so.PublicKey, filepath.Join(d.RootDir, d.HomeDir(), ".ssh", "authorized_keys"))
+	d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", so.PublicKey, filepath.Join(d.BootstrapSettings.RootDir, d.HomeDir(), ".ssh", "authorized_keys"))
 
 	// fake out replacing spot instances with on-demand equivalents
 	if d.Provider == evergreen.ProviderNameEc2Spot || d.Provider == evergreen.ProviderNameEc2Fleet {

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -119,7 +119,7 @@ func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 	}
 
 	// modify the setup script to add the user's public key
-	d.Setup += fmt.Sprintf("\necho \"\n%v\" >> ~%v/.ssh/authorized_keys\n", so.PublicKey, d.User)
+	d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s/.ssh/authorized_keys\n", so.PublicKey, d.HomeDir())
 
 	// fake out replacing spot instances with on-demand equivalents
 	if d.Provider == evergreen.ProviderNameEc2Spot || d.Provider == evergreen.ProviderNameEc2Fleet {

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -103,7 +103,7 @@ func (so *SpawnOptions) validate() error {
 	return nil
 }
 
-// CreateHost spawns a host with the given options.
+// CreateSpawnHost spawns a host with the given options.
 func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 	if err := so.validate(); err != nil {
 		return nil, errors.WithStack(err)

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -119,7 +120,7 @@ func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 	}
 
 	// modify the setup script to add the user's public key
-	d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s/.ssh/authorized_keys\n", so.PublicKey, d.HomeDir())
+	d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", so.PublicKey, filepath.Join(d.RootDir, d.HomeDir(), ".ssh", "authorized_keys"))
 
 	// fake out replacing spot instances with on-demand equivalents
 	if d.Provider == evergreen.ProviderNameEc2Spot || d.Provider == evergreen.ProviderNameEc2Fleet {

--- a/globals.go
+++ b/globals.go
@@ -146,9 +146,11 @@ const (
 
 	DegradedLoggingPercent = 10
 
-	SetupScriptName     = "setup.sh"
-	TempSetupScriptName = "setup-temp.sh"
-	TeardownScriptName  = "teardown.sh"
+	SetupScriptName               = "setup.sh"
+	TempSetupScriptName           = "setup-temp.sh"
+	PowerShellSetupScriptName     = "setup.ps1"
+	PowerShellTempSetupScriptName = "setup-temp.ps1"
+	TeardownScriptName            = "teardown.sh"
 
 	RoutePaginatorNextPageHeaderKey = "Link"
 

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -25,7 +25,6 @@ var (
 	BootstrapSettingsKey = bsonutil.MustHaveTag(Distro{}, "BootstrapSettings")
 	CloneMethodKey       = bsonutil.MustHaveTag(Distro{}, "CloneMethod")
 	WorkDirKey           = bsonutil.MustHaveTag(Distro{}, "WorkDir")
-	RootDirKey           = bsonutil.MustHaveTag(Distro{}, "RootDir")
 	SpawnAllowedKey      = bsonutil.MustHaveTag(Distro{}, "SpawnAllowed")
 	ExpansionsKey        = bsonutil.MustHaveTag(Distro{}, "Expansions")
 	DisabledKey          = bsonutil.MustHaveTag(Distro{}, "Disabled")
@@ -43,6 +42,7 @@ var (
 	BootstrapSettingsJasperCredentialsPathKey = bsonutil.MustHaveTag(BootstrapSettings{}, "JasperCredentialsPath")
 	BootstrapSettingsServiceUserKey           = bsonutil.MustHaveTag(BootstrapSettings{}, "ServiceUser")
 	BootstrapSettingsShellPathKey             = bsonutil.MustHaveTag(BootstrapSettings{}, "ShellPath")
+	BootstrapSettingsRootDirKey               = bsonutil.MustHaveTag(BootstrapSettings{}, "RootDir")
 	BootstrapSettingsResourceLimitsKey        = bsonutil.MustHaveTag(BootstrapSettings{}, "ResourceLimits")
 
 	ResourceLimitsNumFilesKey        = bsonutil.MustHaveTag(ResourceLimits{}, "NumFiles")

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -25,6 +25,7 @@ var (
 	BootstrapSettingsKey = bsonutil.MustHaveTag(Distro{}, "BootstrapSettings")
 	CloneMethodKey       = bsonutil.MustHaveTag(Distro{}, "CloneMethod")
 	WorkDirKey           = bsonutil.MustHaveTag(Distro{}, "WorkDir")
+	RootDirKey           = bsonutil.MustHaveTag(Distro{}, "RootDir")
 	SpawnAllowedKey      = bsonutil.MustHaveTag(Distro{}, "SpawnAllowed")
 	ExpansionsKey        = bsonutil.MustHaveTag(Distro{}, "Expansions")
 	DisabledKey          = bsonutil.MustHaveTag(Distro{}, "Disabled")

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -277,9 +277,9 @@ func (d *Distro) MaxDurationPerHost() time.Duration {
 	return evergreen.MaxDurationPerDistroHost
 }
 
-// PowerShellSetup returns whether or not the setup script is a powershell
+// IsPowerShellSetup returns whether or not the setup script is a powershell
 // script.
-func (d *Distro) PowerShellSetup() bool {
+func (d *Distro) IsPowerShellSetup() bool {
 	script := bytes.NewBufferString(d.Setup)
 	header, err := script.ReadString('\n')
 	grip.WarningWhen(err != nil, message.WrapError(err, message.Fields{

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -21,7 +21,6 @@ type Distro struct {
 	Aliases           []string                `bson:"aliases,omitempty" json:"aliases,omitempty" mapstructure:"aliases,omitempty"`
 	Arch              string                  `bson:"arch" json:"arch,omitempty" mapstructure:"arch,omitempty"`
 	WorkDir           string                  `bson:"work_dir" json:"work_dir,omitempty" mapstructure:"work_dir,omitempty"`
-	RootDir           string                  `bson:"root_dir,omitempty" json:"root_dir,omitempty" mapstructure:"root_dir,omitempty"`
 	Provider          string                  `bson:"provider" json:"provider,omitempty" mapstructure:"provider,omitempty"`
 	ProviderSettings  *map[string]interface{} `bson:"settings" json:"settings,omitempty" mapstructure:"settings,omitempty"`
 	SetupAsSudo       bool                    `bson:"setup_as_sudo,omitempty" json:"setup_as_sudo,omitempty" mapstructure:"setup_as_sudo,omitempty"`
@@ -45,14 +44,22 @@ type Distro struct {
 
 // BootstrapSettings encapsulates all settings related to bootstrapping hosts.
 type BootstrapSettings struct {
-	Method                string         `bson:"method" json:"method" mapstructure:"method"`
-	Communication         string         `bson:"communication,omitempty" json:"communication,omitempty" mapstructure:"communication,omitempty"`
-	ClientDir             string         `bson:"client_dir,omitempty" json:"client_dir,omitempty" mapstructure:"client_dir,omitempty"`
-	JasperBinaryDir       string         `bson:"jasper_binary_dir,omitempty" json:"jasper_binary_dir,omitempty" mapstructure:"jasper_binary_dir,omitempty"`
-	JasperCredentialsPath string         `json:"jasper_credentials_path,omitempty" bson:"jasper_credentials_path,omitempty" mapstructure:"jasper_credentials_path,omitempty"`
-	ServiceUser           string         `bson:"service_user,omitempty" json:"service_user,omitempty" mapstructure:"service_user,omitempty"`
-	ShellPath             string         `bson:"shell_path,omitempty" json:"shell_path,omitempty" mapstructure:"shell_path,omitempty"`
-	ResourceLimits        ResourceLimits `bson:"resource_limits,omitempty" json:"resource_limits,omitempty" mapstructure:"resource_limits,omitempty"`
+	// Required
+	Method        string `bson:"method" json:"method" mapstructure:"method"`
+	Communication string `bson:"communication,omitempty" json:"communication,omitempty" mapstructure:"communication,omitempty"`
+
+	// Required for new provisioning
+	ClientDir             string `bson:"client_dir,omitempty" json:"client_dir,omitempty" mapstructure:"client_dir,omitempty"`
+	JasperBinaryDir       string `bson:"jasper_binary_dir,omitempty" json:"jasper_binary_dir,omitempty" mapstructure:"jasper_binary_dir,omitempty"`
+	JasperCredentialsPath string `json:"jasper_credentials_path,omitempty" bson:"jasper_credentials_path,omitempty" mapstructure:"jasper_credentials_path,omitempty"`
+
+	// Windows-specific
+	ServiceUser string `bson:"service_user,omitempty" json:"service_user,omitempty" mapstructure:"service_user,omitempty"`
+	ShellPath   string `bson:"shell_path,omitempty" json:"shell_path,omitempty" mapstructure:"shell_path,omitempty"`
+	RootDir     string `bson:"root_dir,omitempty" json:"root_dir,omitempty" mapstructure:"root_dir,omitempty"`
+
+	// Linux-specific
+	ResourceLimits ResourceLimits `bson:"resource_limits,omitempty" json:"resource_limits,omitempty" mapstructure:"resource_limits,omitempty"`
 }
 
 // ResourceLimits represents resource limits in Linux.

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -110,8 +110,8 @@ func (d *Distro) ValidateBootstrapSettings() error {
 	}
 
 	catcher.NewWhen(d.IsWindows() && d.BootstrapSettings.ServiceUser == "", "service user cannot be empty for non-legacy Windows bootstrapping")
-
 	catcher.NewWhen(d.IsWindows() && d.BootstrapSettings.ShellPath == "", "shell path cannot be empty for non-legacy Windows bootstrapping")
+	catcher.NewWhen(d.IsWindows() && d.BootstrapSettings.RootDir == "", "root directory cannot be empty for non-legacy Windows bootstrapping")
 
 	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.NumFiles < -1, "max number of files should be a positive number or -1")
 	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.NumProcesses < -1, "max number of files should be a positive number or -1")

--- a/operations/host_setup.go
+++ b/operations/host_setup.go
@@ -50,7 +50,7 @@ func runSetupScript(ctx context.Context, wd string, setupAsSudo bool) error {
 		return runScript(ctx, wd, evergreen.SetupScriptName, evergreen.TempSetupScriptName, cmd, setupAsSudo)
 	} else if _, err = os.Stat(evergreen.PowerShellSetupScriptName); err == nil {
 		cmd := exec.CommandContext(ctx, "powershell", "./"+evergreen.PowerShellTempSetupScriptName)
-		return runScript(ctx, wd, evergreen.PowerShellSetupScriptName, evergreen.PowerShellTempSetupScriptName, cmd, sudo)
+		return runScript(ctx, wd, evergreen.PowerShellSetupScriptName, evergreen.PowerShellTempSetupScriptName, cmd, setupAsSudo)
 	}
 	return nil
 }
@@ -59,6 +59,7 @@ func runScript(ctx context.Context, wd, scriptFileName, tempFileName string, run
 	if err := os.Rename(scriptFileName, tempFileName); os.IsNotExist(err) {
 		return nil
 	}
+
 	chmod := host.ChmodCommandWithSudo(ctx, tempFileName, sudo)
 	out, err := chmod.CombinedOutput()
 	if err != nil {

--- a/operations/host_setup.go
+++ b/operations/host_setup.go
@@ -48,7 +48,7 @@ func runSetupScript(ctx context.Context, wd string, setupAsSudo bool) error {
 	if err == nil {
 		return runScript(ctx, wd, evergreen.SetupScriptName, evergreen.TempSetupScriptName, setupAsSudo)
 	} else if _, err = os.Stat(evergreen.PowerShellSetupScriptName); err == nil {
-		return runScript(ctx, wd, evergreen.PowerShellSetupScriptName, evergreen.TempPowerShellSetupScriptName, setupAsSudo)
+		return runPowerShellScript(ctx, wd, evergreen.PowerShellSetupScriptName, evergreen.TempPowerShellSetupScriptName)
 	}
 	return nil
 }
@@ -65,14 +65,31 @@ func runScript(ctx context.Context, wd, scriptFileName, tempFileName string, sud
 
 	catcher := grip.NewSimpleCatcher()
 
-	var cmd *exec.Cmd
-	if sudo {
-		cmd = exec.CommandContext(ctx, "sudo", "./"+tempFileName)
-	} else {
-		cmd = exec.CommandContext(ctx, "./"+tempFileName)
-	}
-	out, err = cmd.CombinedOutput()
+	cmd := host.ShCommandWithSudo(ctx, tempFileName, sudo)
 
+	out, err = cmd.CombinedOutput()
+	catcher.Add(err)
+
+	grip.Warning(os.MkdirAll(wd, 0777))
+
+	return errors.Wrap(catcher.Resolve(), string(out))
+}
+
+func runPowerShellScript(ctx context.Context, wd, scriptFileName, tempFileName string) error {
+	if err := os.Rename(scriptFileName, tempFileName); os.IsNotExist(err) {
+		return nil
+	}
+	chmod := host.ChmodCommandWithSudo(ctx, tempFileName, false)
+	out, err := chmod.CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, string(out))
+	}
+
+	catcher := grip.NewSimpleCatcher()
+
+	cmd := exec.CommandContext(ctx, "powershell", "./"+tempFileName)
+
+	out, err = cmd.CombinedOutput()
 	catcher.Add(err)
 	// kim: TODO: uncomment this line when the script works 100%.
 	// catcher.Add(os.Remove(tempFile))

--- a/operations/host_setup.go
+++ b/operations/host_setup.go
@@ -70,6 +70,7 @@ func runScript(ctx context.Context, wd, scriptFileName, tempFileName string, run
 
 	out, err = runScript.CombinedOutput()
 	catcher.Add(err)
+	catcher.Add(os.Remove(tempFileName))
 
 	grip.Warning(os.MkdirAll(wd, 0777))
 

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -233,7 +233,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	d.Provider = provider
 
 	if publicKey != "" {
-		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> ~%s/.ssh/authorized_keys\n", publicKey, d.User)
+		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s/.ssh/authorized_keys\n", publicKey, d.HomeDir())
 	}
 
 	// set provider settings

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -234,7 +234,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 
 	if publicKey != "" {
 		keyPath := filepath.Join(d.HomeDir(), ".ssh", "authorized_keys")
-		if !h.LegacyBootstrap() {
+		if d.BootstrapSettings.Method != distro.BootstrapMethodLegacySSH {
 			keyPath = d.BootstrapSettings.RootDir + keyPath
 		}
 		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", publicKey, keyPath)

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -233,7 +233,11 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	d.Provider = provider
 
 	if publicKey != "" {
-		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", publicKey, filepath.Join(d.RootDir, d.HomeDir(), ".ssh", "authorized_keys"))
+		keyPath := filepath.Join(d.HomeDir(), ".ssh", "authorized_keys")
+		if !h.LegacyBootstrap() {
+			keyPath = d.BootstrapSettings.RootDir + keyPath
+		}
+		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", publicKey, keyPath)
 	}
 
 	// set provider settings

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -233,7 +233,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	d.Provider = provider
 
 	if publicKey != "" {
-		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s/.ssh/authorized_keys\n", publicKey, d.HomeDir())
+		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", publicKey, filepath.Join(d.RootDir, d.HomeDir(), ".ssh", "authorized_keys"))
 	}
 
 	// set provider settings

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -206,6 +206,7 @@ type APIDistro struct {
 	ImageID           APIString              `json:"image_id"`
 	Arch              APIString              `json:"arch"`
 	WorkDir           APIString              `json:"work_dir"`
+	RootDir           APIString              `json:"root_dir"`
 	PoolSize          int                    `json:"pool_size"`
 	SetupAsSudo       bool                   `json:"setup_as_sudo"`
 	Setup             APIString              `json:"setup"`
@@ -251,6 +252,7 @@ func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
 	}
 	apiDistro.Arch = ToAPIString(d.Arch)
 	apiDistro.WorkDir = ToAPIString(d.WorkDir)
+	apiDistro.RooDir = ToAPIString(d.RootDir)
 	apiDistro.PoolSize = d.PoolSize
 	apiDistro.SetupAsSudo = d.SetupAsSudo
 	apiDistro.Setup = ToAPIString(d.Setup)
@@ -300,6 +302,7 @@ func (apiDistro *APIDistro) ToService() (interface{}, error) {
 	d.Aliases = apiDistro.Aliases
 	d.Arch = FromAPIString(apiDistro.Arch)
 	d.WorkDir = FromAPIString(apiDistro.WorkDir)
+	d.RootDir = FromAPIString(apiDistro.RootDir)
 	d.PoolSize = apiDistro.PoolSize
 	d.Provider = FromAPIString(apiDistro.Provider)
 	if apiDistro.ProviderSettings != nil {

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -166,10 +166,10 @@ func (s *APIBootstrapSettings) BuildFromService(h interface{}) error {
 	s.ShellPath = ToAPIString(settings.ShellPath)
 	s.RootDir = ToAPIString(settings.RootDir)
 
-	s.ResourceLimits.NumFiles = s.ResourceLimits.NumFiles
-	s.ResourceLimits.NumProcesses = s.ResourceLimits.NumProcesses
-	s.ResourceLimits.LockedMemoryKB = s.ResourceLimits.LockedMemoryKB
-	s.ResourceLimits.VirtualMemoryKB = s.ResourceLimits.VirtualMemoryKB
+	s.ResourceLimits.NumFiles = settings.ResourceLimits.NumFiles
+	s.ResourceLimits.NumProcesses = settings.ResourceLimits.NumProcesses
+	s.ResourceLimits.LockedMemoryKB = settings.ResourceLimits.LockedMemoryKB
+	s.ResourceLimits.VirtualMemoryKB = settings.ResourceLimits.VirtualMemoryKB
 
 	return nil
 }

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -127,6 +127,7 @@ type APIBootstrapSettings struct {
 	JasperCredentialsPath APIString         `json:"jasper_credentials_path"`
 	ServiceUser           APIString         `json:"service_user"`
 	ShellPath             APIString         `json:"shell_path"`
+	RootDir               APIString         `json:"root_dir"`
 	ResourceLimits        APIResourceLimits `json:"resource_limits"`
 }
 
@@ -163,6 +164,12 @@ func (s *APIBootstrapSettings) BuildFromService(h interface{}) error {
 	s.JasperCredentialsPath = ToAPIString(settings.JasperCredentialsPath)
 	s.ServiceUser = ToAPIString(settings.ServiceUser)
 	s.ShellPath = ToAPIString(settings.ShellPath)
+	s.RootDir = ToAPIString(settings.RootDir)
+
+	s.ResourceLimits.NumFiles = s.ResourceLimits.NumFiles
+	s.ResourceLimits.NumProcesses = s.ResourceLimits.NumProcesses
+	s.ResourceLimits.LockedMemoryKB = s.ResourceLimits.LockedMemoryKB
+	s.ResourceLimits.VirtualMemoryKB = s.ResourceLimits.VirtualMemoryKB
 
 	return nil
 }
@@ -184,6 +191,7 @@ func (s *APIBootstrapSettings) ToService() (interface{}, error) {
 	settings.JasperCredentialsPath = FromAPIString(s.JasperCredentialsPath)
 	settings.ServiceUser = FromAPIString(s.ServiceUser)
 	settings.ShellPath = FromAPIString(s.ShellPath)
+	settings.RootDir = FromAPIString(s.RootDir)
 
 	settings.ResourceLimits.NumFiles = s.ResourceLimits.NumFiles
 	settings.ResourceLimits.NumProcesses = s.ResourceLimits.NumProcesses
@@ -206,7 +214,6 @@ type APIDistro struct {
 	ImageID           APIString              `json:"image_id"`
 	Arch              APIString              `json:"arch"`
 	WorkDir           APIString              `json:"work_dir"`
-	RootDir           APIString              `json:"root_dir"`
 	PoolSize          int                    `json:"pool_size"`
 	SetupAsSudo       bool                   `json:"setup_as_sudo"`
 	Setup             APIString              `json:"setup"`
@@ -252,7 +259,6 @@ func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
 	}
 	apiDistro.Arch = ToAPIString(d.Arch)
 	apiDistro.WorkDir = ToAPIString(d.WorkDir)
-	apiDistro.RootDir = ToAPIString(d.RootDir)
 	apiDistro.PoolSize = d.PoolSize
 	apiDistro.SetupAsSudo = d.SetupAsSudo
 	apiDistro.Setup = ToAPIString(d.Setup)
@@ -302,7 +308,6 @@ func (apiDistro *APIDistro) ToService() (interface{}, error) {
 	d.Aliases = apiDistro.Aliases
 	d.Arch = FromAPIString(apiDistro.Arch)
 	d.WorkDir = FromAPIString(apiDistro.WorkDir)
-	d.RootDir = FromAPIString(apiDistro.RootDir)
 	d.PoolSize = apiDistro.PoolSize
 	d.Provider = FromAPIString(apiDistro.Provider)
 	if apiDistro.ProviderSettings != nil {

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -252,7 +252,7 @@ func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
 	}
 	apiDistro.Arch = ToAPIString(d.Arch)
 	apiDistro.WorkDir = ToAPIString(d.WorkDir)
-	apiDistro.RooDir = ToAPIString(d.RootDir)
+	apiDistro.RootDir = ToAPIString(d.RootDir)
 	apiDistro.PoolSize = d.PoolSize
 	apiDistro.SetupAsSudo = d.SetupAsSudo
 	apiDistro.Setup = ToAPIString(d.Setup)

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1091,8 +1091,8 @@ func (s *DistroPatchByIDSuite) TestRunValidNonLegacyBootstrapSettings() {
 			"jasper_credentials_path": "/jasper_credentials_path",
 			"shell_path": "/shell_path",
 			"root_dir": "/root_dir"
-		}}`,
-		distro.BootstrapMethodUserData, distro.CommunicationMethodSSH))
+		}
+	}`, distro.BootstrapMethodUserData, distro.CommunicationMethodSSH))
 	h := s.rm.(*distroIDPatchHandler)
 	h.distroID = "fedora8"
 	h.body = json
@@ -1102,13 +1102,13 @@ func (s *DistroPatchByIDSuite) TestRunValidNonLegacyBootstrapSettings() {
 	s.Equal(http.StatusOK, resp.Status())
 	apiDistro, ok := (resp.Data()).(*model.APIDistro)
 	s.Require().True(ok)
-	s.Equal(distro.BootstrapMethodUserData, apiDistro.BootstrapSettings.Method)
-	s.Equal(distro.CommunicationMethodSSH, apiDistro.BootstrapSettings.Communication)
-	s.Equal("/client_dir", apiDistro.BootstrapSettings.ClientDir)
-	s.Equal("/jasper_binary_dir", apiDistro.BootstrapSettings.JasperBinaryDir)
-	s.Equal("/jasper_credentials_path", apiDistro.BootstrapSettings.JasperCredentialsPath)
-	s.Equal("/shell_path", apiDistro.BootstrapSettings.ShellPath)
-	s.Equal("/root_dir", apiDistro.BootstrapSettings.RootDir)
+	s.Equal(model.ToAPIString(distro.BootstrapMethodUserData), apiDistro.BootstrapSettings.Method)
+	s.Equal(model.ToAPIString(distro.CommunicationMethodSSH), apiDistro.BootstrapSettings.Communication)
+	s.Equal(model.ToAPIString("/client_dir"), apiDistro.BootstrapSettings.ClientDir)
+	s.Equal(model.ToAPIString("/jasper_binary_dir"), apiDistro.BootstrapSettings.JasperBinaryDir)
+	s.Equal(model.ToAPIString("/jasper_credentials_path"), apiDistro.BootstrapSettings.JasperCredentialsPath)
+	s.Equal(model.ToAPIString("/shell_path"), apiDistro.BootstrapSettings.ShellPath)
+	s.Equal(model.ToAPIString("/root_dir"), apiDistro.BootstrapSettings.RootDir)
 }
 
 func (s *DistroPatchByIDSuite) TestRunValidCloneMethod() {

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -583,6 +583,7 @@ func (s *DistroPatchByIDSuite) SetupTest() {
 				Id:       "fedora8",
 				Arch:     "linux_amd64",
 				WorkDir:  "/data/mci",
+				RootDir:  "/root/dir",
 				PoolSize: 30,
 				Provider: "mock",
 				ProviderSettings: &map[string]interface{}{
@@ -728,6 +729,22 @@ func (s *DistroPatchByIDSuite) TestRunValidWorkDir() {
 	apiDistro, ok := (resp.Data()).(*model.APIDistro)
 	s.Require().True(ok)
 	s.Equal(apiDistro.WorkDir, model.ToAPIString("/tmp"))
+}
+
+func (s *DistroPatchByIDSuite) TestRunValidRootDir() {
+	ctx := context.Background()
+	json := []byte(`{"root_dir": "/new/root/dir"}`)
+	h := s.rm.(*distroIDPatchHandler)
+	h.distroID = "fedora8"
+	h.body = json
+
+	resp := s.rm.Run(ctx)
+	s.NotNil(resp.Data())
+	s.Equal(resp.Status(), http.StatusOK)
+
+	apiDistro, ok := (resp.Data()).(*model.APIDistro)
+	s.Require().True(ok)
+	s.Equal(apiDistro.RootDir, model.ToAPIString("/new/root/dir"))
 }
 
 func (s *DistroPatchByIDSuite) TestRunValidPoolSize() {
@@ -1131,6 +1148,7 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 		`{
 				"arch" : "linux_amd64",
 				"work_dir" : "~/data/mci",
+				"root_dir" : "/new/root/dir",
 				"pool_size" : 20,
 				"provider" : "mock",
 				"settings" : {
@@ -1205,6 +1223,7 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 	s.Equal(apiDistro.Disabled, false)
 	s.Equal(apiDistro.Name, model.ToAPIString("fedora8"))
 	s.Equal(apiDistro.WorkDir, model.ToAPIString("~/data/mci"))
+	s.Equal(apiDistro.RootDir, model.ToAPIString("/new/root/dir"))
 	s.Equal(apiDistro.PoolSize, 20)
 	s.Equal(apiDistro.Provider, model.ToAPIString("mock"))
 
@@ -1269,6 +1288,7 @@ func getMockDistrosConnector() *data.MockConnector {
 					Id:       "fedora8",
 					Arch:     "linux_amd64",
 					WorkDir:  "/data/mci",
+					RootDir:  "/root/dir",
 					PoolSize: 30,
 					Provider: "mock",
 					ProviderSettings: &map[string]interface{}{

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1090,7 +1090,7 @@ func (s *DistroPatchByIDSuite) TestRunValidNonLegacyBootstrapSettings() {
 			"jasper_binary_dir": "/jasper_binary_dir",
 			"jasper_credentials_path": "/jasper_credentials_path",
 			"shell_path": "/shell_path",
-			"root_dir": "/root_dir",
+			"root_dir": "/root_dir"
 		}}`,
 		distro.BootstrapMethodUserData, distro.CommunicationMethodSSH))
 	h := s.rm.(*distroIDPatchHandler)

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -679,7 +679,7 @@ Evergreen - Distros
             <label class="distro-label">Root Directory:</label>
             <input required name="rootDir" type="text" class="form-control" ng-model="activeDistro.bootstrap_settings.root_dir"
               placeholder="Native path to root directory" ng-readonly="readOnly">
-            <div class="icon fa fa-warning distro-error" ng-show="form.rootDir.$invalid"> Shell path is required</div><br />
+            <div class="icon fa fa-warning distro-error" ng-show="form.rootDir.$invalid"> Root directory is required</div><br />
           </div>
           <div ng-show="isLinux() && isNonLegacyProvisioning()">
 			<label class="distro-label">Resource Limits:</label><br />

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -110,6 +110,11 @@ Evergreen - Distros
               <div class="icon fa fa-warning distro-error" ng-show="form.workDir.$dirty && form.workDir.$error.required || form.workDir.$invalid">Working
                 Directory is required</div>
             </div>
+            <div>
+              <label class="distro-label">Root Directory:</label>
+              <input required name="rootDir" type="text" class="form-control" ng-model="activeDistro.root_dir"
+                placeholder="Native path to file system root directory" ng-readonly="readOnly">
+            </div>
           </div>
           <br>
           <div class="panel-body panel panel-default">

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -110,11 +110,6 @@ Evergreen - Distros
               <div class="icon fa fa-warning distro-error" ng-show="form.workDir.$dirty && form.workDir.$error.required || form.workDir.$invalid">Working
                 Directory is required</div>
             </div>
-            <div>
-              <label class="distro-label">Root Directory:</label>
-              <input required name="rootDir" type="text" class="form-control" ng-model="activeDistro.root_dir"
-                placeholder="Native path to file system root directory" ng-readonly="readOnly">
-            </div>
           </div>
           <br>
           <div class="panel-body panel panel-default">
@@ -676,13 +671,15 @@ Evergreen - Distros
               ng-readonly="readOnly" name="serviceUser"
               class="form-control" ng-model="activeDistro.bootstrap_settings.service_user" placeholder="Username for setting up Evergreen services">
             <div class="icon fa fa-warning distro-error" ng-show="form.serviceUser.$invalid"> Service user is required</div><br />
-          </div>
-          <div ng-show="isWindows() && isNonLegacyProvisioning()">
             <label class="distro-label">Shell Path:</label>
             <input type="text" ng-required="isWindows() && isNonLegacyProvisioning()"
               ng-readonly="readOnly" name="shellPath"
               class="form-control" ng-model="activeDistro.bootstrap_settings.shell_path" placeholder="Absolute native path to the shell binary file (bash)">
             <div class="icon fa fa-warning distro-error" ng-show="form.shellPath.$invalid"> Shell path is required</div><br />
+            <label class="distro-label">Root Directory:</label>
+            <input required name="rootDir" type="text" class="form-control" ng-model="activeDistro.bootstrap_settings.root_dir"
+              placeholder="Native path to root directory" ng-readonly="readOnly">
+            <div class="icon fa fa-warning distro-error" ng-show="form.rootDir.$invalid"> Shell path is required</div><br />
           </div>
           <div ng-show="isLinux() && isNonLegacyProvisioning()">
 			<label class="distro-label">Resource Limits:</label><br />

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -626,6 +626,18 @@ func (j *setupHostJob) provisionHost(ctx context.Context, h *host.Host, settings
 		grip.Infof("Running setup script for spawn host %s", h.Id)
 		// run the setup script with the agent
 		if logs, err := h.RunSSHCommand(ctx, h.SetupCommand(), sshOptions); err != nil {
+			// kim: TODO: remove this once testing is done
+			// grip.Error(message.WrapError(err, message.Fields{
+			//     "message": "kim: failed to run setup script on host",
+			//     "host":    h.Id,
+			//     "distro":  h.Distro.Id,
+			//     "logs":    logs,
+			//     "job":     j.ID(),
+			// }))
+			// if err := h.MarkAsProvisioned(); err != nil {
+			//     return errors.Wrapf(err, "error marking host %s as provisioned", h.Id)
+			// }
+			// return nil
 			grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
 				"operation": "setting host unprovisioned",
 				"host":      h.Id,

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -279,14 +279,7 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 
 	if targetHost.Distro.Setup != "" {
 		scriptName := evergreen.SetupScriptName
-		script := bytes.NewBufferString(targetHost.Distro.Setup)
-		header, err := script.ReadString('\n')
-		grip.WarningWhen(err != nil, message.WrapError(err, message.Fields{
-			"message": "setup script does not specify which shell should execute the script",
-			"distro":  targetHost.Distro.Id,
-			"job":     j.ID(),
-		}))
-		if strings.Contains(header, "powershell") {
+		if targetHost.Distro.PowerShellSetup() {
 			scriptName = evergreen.PowerShellSetupScriptName
 		}
 		err = j.copyScript(ctx, settings, targetHost, filepath.Join("~", scriptName), targetHost.Distro.Setup)

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -263,7 +263,7 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 			"provider":                targetHost.Provider,
 			"attempts":                targetHost.ProvisionAttempts,
 			"job":                     j.ID(),
-			"provision_duration_secs": time.Now().Sub(targetHost.CreationTime).Seconds(),
+			"provision_duration_secs": time.Since(targetHost.CreationTime).Seconds(),
 		})
 		return nil
 	case distro.BootstrapMethodSSH:
@@ -278,7 +278,18 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 	}
 
 	if targetHost.Distro.Setup != "" {
-		err = j.copyScript(ctx, settings, targetHost, filepath.Join("~", evergreen.SetupScriptName), targetHost.Distro.Setup)
+		scriptName := evergreen.SetupScriptName
+		script := bytes.NewBufferString(targetHost.Distro.Setup)
+		header, err := script.ReadString('\n')
+		grip.WarningWhen(err != nil, message.WrapError(err, message.Fields{
+			"message": "setup script does not specify which shell should execute the script",
+			"distro":  targetHost.Distro.Id,
+			"job":     j.ID(),
+		}))
+		if strings.Contains(header, "powershell") {
+			scriptName = evergreen.PowerShellSetupScriptName
+		}
+		err = j.copyScript(ctx, settings, targetHost, filepath.Join("~", scriptName), targetHost.Distro.Setup)
 		if err != nil {
 			return errors.Wrapf(err, "error copying setup script %v to host %v",
 				evergreen.SetupScriptName, targetHost.Id)

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -627,25 +627,25 @@ func (j *setupHostJob) provisionHost(ctx context.Context, h *host.Host, settings
 		// run the setup script with the agent
 		if logs, err := h.RunSSHCommand(ctx, h.SetupCommand(), sshOptions); err != nil {
 			// kim: TODO: remove this once testing is done
-			// grip.Error(message.WrapError(err, message.Fields{
-			//     "message": "kim: failed to run setup script on host",
-			//     "host":    h.Id,
-			//     "distro":  h.Distro.Id,
-			//     "logs":    logs,
-			//     "job":     j.ID(),
-			// }))
-			// if err := h.MarkAsProvisioned(); err != nil {
-			//     return errors.Wrapf(err, "error marking host %s as provisioned", h.Id)
-			// }
-			// return nil
-			grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
-				"operation": "setting host unprovisioned",
-				"host":      h.Id,
-				"distro":    h.Distro.Id,
-				"job":       j.ID(),
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "kim: failed to run setup script on host",
+				"host":    h.Id,
+				"distro":  h.Distro.Id,
+				"logs":    logs,
+				"job":     j.ID(),
 			}))
-			event.LogProvisionFailed(h.Id, logs)
-			return errors.Wrapf(err, "error running setup script on remote host: %s", logs)
+			if err := h.MarkAsProvisioned(); err != nil {
+				return errors.Wrapf(err, "error marking host %s as provisioned", h.Id)
+			}
+			return nil
+			// grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
+			//     "operation": "setting host unprovisioned",
+			//     "host":      h.Id,
+			//     "distro":    h.Distro.Id,
+			//     "job":       j.ID(),
+			// }))
+			// event.LogProvisionFailed(h.Id, logs)
+			// return errors.Wrapf(err, "error running setup script on remote host: %s", logs)
 		}
 
 		if h.ProvisionOptions.OwnerId != "" && len(h.ProvisionOptions.TaskId) > 0 {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6815

* SCP and run the setup script depending on the contents of the header line (e.g. `#!/bin/bash` or `#!/usr/bin/env powershell`).
* PowerShell requires that scripts have the .ps1 extension instead of .sh.
* Spawn hosts need to edit setup script to copy SSH keys so PowerShell needs to know the path to the Cygwin file system (`BootstrapSettings.RootDir`).