### PR TITLE
EVG-6828 limit host requests to 16 at a time

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -838,10 +838,11 @@ func PopulateHostCreationJobs(env evergreen.Environment, part int) amboy.QueueOp
 				// frequently, lets not start too many all at
 				// once.
 
-				break
+				continue
 			}
 
 			catcher.Add(queue.Put(ctx, NewHostCreateJob(env, h, ts, 1, 0, false)))
+			submitted++
 		}
 
 		return catcher.Resolve()


### PR DESCRIPTION
Since the counter wasn't being incremented the limit wasn't being enforced.
Also, continue to create spawn hosts even after hitting the limit.