### PR TITLE
EVG-6486 stricter check for a build failing

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -611,7 +611,7 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 		now = time.Now()
 
 		// update the build's status when a test task isn't successful
-		if t.Status != evergreen.TaskSucceeded {
+		if evergreen.IsFailedTaskStatus(t.Status) {
 			err = b.UpdateStatus(evergreen.BuildFailed)
 			if err != nil {
 				err = errors.Wrap(err, "Error updating build status")


### PR DESCRIPTION
I couldn't figure out what was happening exactly, but some scenario was incorrectly marking a build failed, and this is the only spot that it could be