### PR TITLE
EVG-6794 log host termination reason in many places

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -35,7 +35,7 @@ type Manager interface {
 	GetInstanceStatus(context.Context, *host.Host) (CloudStatus, error)
 
 	// TerminateInstance destroys the host in the underlying provider
-	TerminateInstance(context.Context, *host.Host, string) error
+	TerminateInstance(context.Context, *host.Host, string, string) error
 
 	// StopInstance stops an instance.
 	StopInstance(context.Context, *host.Host, string) error

--- a/cloud/cloud_host.go
+++ b/cloud/cloud_host.go
@@ -39,8 +39,8 @@ func (cloudHost *CloudHost) IsUp(ctx context.Context) (bool, error) {
 	return cloudHost.CloudMgr.IsUp(ctx, cloudHost.Host)
 }
 
-func (cloudHost *CloudHost) TerminateInstance(ctx context.Context, user string) error {
-	return cloudHost.CloudMgr.TerminateInstance(ctx, cloudHost.Host, user)
+func (cloudHost *CloudHost) TerminateInstance(ctx context.Context, user, reason string) error {
+	return cloudHost.CloudMgr.TerminateInstance(ctx, cloudHost.Host, user, reason)
 }
 
 func (cloudHost *CloudHost) StopInstance(ctx context.Context, user string) error {

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -141,7 +141,7 @@ func (m *dockerManager) GetDNSName(ctx context.Context, h *host.Host) (string, e
 }
 
 //TerminateInstance destroys a container.
-func (m *dockerManager) TerminateInstance(ctx context.Context, h *host.Host, user string) error {
+func (m *dockerManager) TerminateInstance(ctx context.Context, h *host.Host, user, reason string) error {
 	if h.Status == evergreen.HostTerminated {
 		err := errors.Errorf("Can not terminate %s - already marked as terminated!", h.Id)
 		grip.Error(err)
@@ -164,7 +164,7 @@ func (m *dockerManager) TerminateInstance(ctx context.Context, h *host.Host, use
 	})
 
 	// Set the host status as terminated and update its termination time
-	return h.Terminate(user)
+	return h.Terminate(user, reason)
 }
 
 func (m *dockerManager) StopInstance(ctx context.Context, host *host.Host, user string) error {

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -133,10 +133,10 @@ func (s *DockerSuite) TestTerminateInstanceAPICall() {
 	s.True(ok)
 	s.False(mock.failRemove)
 
-	s.NoError(s.manager.TerminateInstance(ctx, hostA, evergreen.User))
+	s.NoError(s.manager.TerminateInstance(ctx, hostA, evergreen.User, ""))
 
 	mock.failRemove = true
-	s.Error(s.manager.TerminateInstance(ctx, hostB, evergreen.User))
+	s.Error(s.manager.TerminateInstance(ctx, hostB, evergreen.User, ""))
 }
 
 func (s *DockerSuite) TestTerminateInstanceDB() {
@@ -157,7 +157,7 @@ func (s *DockerSuite) TestTerminateInstanceDB() {
 	s.NoError(err)
 
 	// Terminate the instance - check the host is terminated in DB.
-	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User)
+	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User, "")
 	s.NoError(err)
 
 	dbHost, err = host.FindOne(host.ById(myHost.Id))

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -165,7 +165,7 @@ func (s *DockerSuite) TestTerminateInstanceDB() {
 	s.NoError(err)
 
 	// Terminate again - check we cannot remove twice.
-	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User)
+	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User, "")
 	s.Error(err)
 }
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -795,12 +795,12 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		}
 		// the spot request wasn't fulfilled, so don't attempt to terminate in ec2
 		if instanceId == "" {
-			return errors.Wrap(h.Terminate(user, ""), "failed to terminate instance in db")
+			return errors.Wrap(h.Terminate(user, "spot request was not fulfilled"), "failed to terminate instance in db")
 		}
 	}
 
 	if !strings.HasPrefix(instanceId, "i-") {
-		return errors.Wrap(h.Terminate(user, ""), "failed to terminate instance in db")
+		return errors.Wrap(h.Terminate(user, fmt.Sprintf("detected invalid instance ID %s", instanceId)), "failed to terminate instance in db")
 	}
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []*string{aws.String(instanceId)},

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -754,7 +754,7 @@ func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cloud
 }
 
 // TerminateInstance terminates the EC2 instance.
-func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user string) error {
+func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, reason string) error {
 	// terminate the instance
 	if h.Status == evergreen.HostTerminated {
 		err := errors.Errorf("Can not terminate %s - already marked as "+
@@ -795,12 +795,12 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user s
 		}
 		// the spot request wasn't fulfilled, so don't attempt to terminate in ec2
 		if instanceId == "" {
-			return errors.Wrap(h.Terminate(user), "failed to terminate instance in db")
+			return errors.Wrap(h.Terminate(user, ""), "failed to terminate instance in db")
 		}
 	}
 
 	if !strings.HasPrefix(instanceId, "i-") {
-		return errors.Wrap(h.Terminate(user), "failed to terminate instance in db")
+		return errors.Wrap(h.Terminate(user, ""), "failed to terminate instance in db")
 	}
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []*string{aws.String(instanceId)},
@@ -827,7 +827,7 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user s
 		})
 	}
 
-	return errors.Wrap(h.Terminate(user), "failed to terminate instance in db")
+	return errors.Wrap(h.Terminate(user, reason), "failed to terminate instance in db")
 }
 
 // StopInstance stops a running EC2 instance.
@@ -949,7 +949,7 @@ func (m *ec2Manager) cancelSpotRequest(ctx context.Context, h *host.Host) (strin
 	if err != nil {
 		if ec2err, ok := err.(awserr.Error); ok {
 			if ec2err.Code() == EC2ErrorSpotRequestNotFound {
-				return "", h.Terminate(evergreen.User)
+				return "", h.Terminate(evergreen.User, "unable to find spot request")
 			}
 		}
 		grip.Error(message.WrapError(err, message.Fields{
@@ -965,7 +965,7 @@ func (m *ec2Manager) cancelSpotRequest(ctx context.Context, h *host.Host) (strin
 	}); err != nil {
 		if ec2err, ok := err.(awserr.Error); ok {
 			if ec2err.Code() == EC2ErrorSpotRequestNotFound {
-				return "", h.Terminate(evergreen.User)
+				return "", h.Terminate(evergreen.User, "unable to find spot request")
 			}
 		}
 		grip.Error(message.Fields{

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -190,7 +190,7 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 	return status, nil
 }
 
-func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, user string) error {
+func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, user, reason string) error {
 	if h.Status == evergreen.HostTerminated {
 		return errors.Errorf("Can not terminate %s - already marked as terminated!", h.Id)
 	}
@@ -234,7 +234,7 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		})
 	}
 
-	return errors.Wrap(h.Terminate(user), "failed to terminate instance in db")
+	return errors.Wrap(h.Terminate(user, reason), "failed to terminate instance in db")
 }
 
 // StopInstance should do nothing for EC2 Fleet.

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -69,7 +69,7 @@ func TestFleet(t *testing.T) {
 			assert.Equal(t, "us-east-1a", hDb.Zone)
 		},
 		"TerminateInstance": func(*testing.T) {
-			assert.NoError(t, m.TerminateInstance(context.Background(), h, "evergreen"))
+			assert.NoError(t, m.TerminateInstance(context.Background(), h, "evergreen", ""))
 
 			mockClient := m.client.(*awsClientMock)
 			assert.Len(t, mockClient.TerminateInstancesInput.InstanceIds, 1)

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -89,7 +89,7 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 	assert.Len(foundHosts, 1)
 	assert.NoError(m.OnUp(ctx, h))
 
-	assert.NoError(m.TerminateInstance(ctx, h, evergreen.User))
+	assert.NoError(m.TerminateInstance(ctx, h, evergreen.User, ""))
 	foundHosts, err = host.Find(host.IsTerminated)
 	assert.NoError(err)
 	assert.Len(foundHosts, 1)
@@ -131,7 +131,7 @@ func TestSpawnEC2InstanceSpot(t *testing.T) {
 	foundHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)
 	assert.Len(foundHosts, 1)
-	assert.NoError(m.TerminateInstance(ctx, h, evergreen.User))
+	assert.NoError(m.TerminateInstance(ctx, h, evergreen.User, ""))
 	foundHosts, err = host.Find(host.IsTerminated)
 	assert.NoError(err)
 	assert.Len(foundHosts, 1)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -682,7 +682,7 @@ func (s *EC2Suite) TestTerminateInstance() {
 	defer cancel()
 
 	s.NoError(s.h.Insert())
-	s.NoError(s.onDemandManager.TerminateInstance(ctx, s.h, evergreen.User))
+	s.NoError(s.onDemandManager.TerminateInstance(ctx, s.h, evergreen.User, ""))
 	found, err := host.FindOne(host.ById("h1"))
 	s.Equal(evergreen.HostTerminated, found.Status)
 	s.NoError(err)
@@ -703,7 +703,7 @@ func (s *EC2Suite) TestTerminateInstanceWithUserDataBootstrappedHost() {
 		_, err = s.h.JasperCredentials(ctx)
 		s.Require().NoError(err)
 
-		s.NoError(s.onDemandManager.TerminateInstance(ctx, s.h, evergreen.User))
+		s.NoError(s.onDemandManager.TerminateInstance(ctx, s.h, evergreen.User, ""))
 
 		_, err = s.h.JasperCredentials(ctx)
 		s.Error(err)

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -172,7 +172,7 @@ func (m *gceManager) GetInstanceStatus(ctx context.Context, host *host.Host) (Cl
 }
 
 // TerminateInstance requests a server previously provisioned to be removed.
-func (m *gceManager) TerminateInstance(ctx context.Context, host *host.Host, user string) error {
+func (m *gceManager) TerminateInstance(ctx context.Context, host *host.Host, user, reason string) error {
 	if host.Status == evergreen.HostTerminated {
 		err := errors.Errorf("Can not terminate %s - already marked as terminated!", host.Id)
 		grip.Error(err)
@@ -184,7 +184,7 @@ func (m *gceManager) TerminateInstance(ctx context.Context, host *host.Host, use
 	}
 
 	// Set the host status as terminated and update its termination time
-	return host.Terminate(user)
+	return host.Terminate(user, reason)
 }
 
 func (m *gceManager) StopInstance(ctx context.Context, host *host.Host, user string) error {

--- a/cloud/gce_test.go
+++ b/cloud/gce_test.go
@@ -228,10 +228,10 @@ func (s *GCESuite) TestTerminateInstanceAPICall() {
 	s.True(ok)
 	s.False(mock.failDelete)
 
-	s.NoError(s.manager.TerminateInstance(ctx, hostA, evergreen.User))
+	s.NoError(s.manager.TerminateInstance(ctx, hostA, evergreen.User, ""))
 
 	mock.failDelete = true
-	s.Error(s.manager.TerminateInstance(ctx, hostB, evergreen.User))
+	s.Error(s.manager.TerminateInstance(ctx, hostB, evergreen.User, ""))
 }
 
 func (s *GCESuite) TestTerminateInstanceDB() {
@@ -251,7 +251,7 @@ func (s *GCESuite) TestTerminateInstanceDB() {
 	s.NoError(err)
 
 	// Terminate the instance - check the host is terminated in DB.
-	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User)
+	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User, "")
 	s.NoError(err)
 
 	dbHost, err = host.FindOne(host.ById(myHost.Id))
@@ -259,7 +259,7 @@ func (s *GCESuite) TestTerminateInstanceDB() {
 	s.NoError(err)
 
 	// Terminate again - check we cannot remove twice.
-	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User)
+	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User, "")
 	s.Error(err)
 }
 

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -215,7 +215,7 @@ func (_ *mockManager) Validate() error {
 }
 
 // terminate an instance
-func (mockMgr *mockManager) TerminateInstance(ctx context.Context, host *host.Host, user string) error {
+func (mockMgr *mockManager) TerminateInstance(ctx context.Context, host *host.Host, user, reason string) error {
 	l := mockMgr.mutex
 	l.Lock()
 	defer l.Unlock()
@@ -230,7 +230,7 @@ func (mockMgr *mockManager) TerminateInstance(ctx context.Context, host *host.Ho
 	instance.Status = StatusTerminated
 	mockMgr.Instances[host.Id] = instance
 
-	return errors.WithStack(host.Terminate(user))
+	return errors.WithStack(host.Terminate(user, reason))
 }
 
 func (mockMgr *mockManager) StopInstance(ctx context.Context, host *host.Host, user string) error {

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -147,7 +147,7 @@ func (m *openStackManager) GetInstanceStatus(ctx context.Context, host *host.Hos
 }
 
 // TerminateInstance requests a server previously provisioned to be removed.
-func (m *openStackManager) TerminateInstance(ctx context.Context, host *host.Host, user string) error {
+func (m *openStackManager) TerminateInstance(ctx context.Context, host *host.Host, user, reason string) error {
 	if host.Status == evergreen.HostTerminated {
 		err := errors.Errorf("Can not terminate %s - already marked as terminated!", host.Id)
 		grip.Error(err)
@@ -159,7 +159,7 @@ func (m *openStackManager) TerminateInstance(ctx context.Context, host *host.Hos
 	}
 
 	// Set the host status as terminated and update its termination time
-	return errors.WithStack(host.Terminate(user))
+	return errors.WithStack(host.Terminate(user, reason))
 }
 
 func (m *openStackManager) StopInstance(ctx context.Context, host *host.Host, user string) error {

--- a/cloud/openstack_test.go
+++ b/cloud/openstack_test.go
@@ -170,10 +170,10 @@ func (s *OpenStackSuite) TestTerminateInstanceAPICall() {
 	s.True(ok)
 	s.False(mock.failDelete)
 
-	s.NoError(s.manager.TerminateInstance(ctx, hostA, evergreen.User))
+	s.NoError(s.manager.TerminateInstance(ctx, hostA, evergreen.User, ""))
 
 	mock.failDelete = true
-	s.Error(s.manager.TerminateInstance(ctx, hostB, evergreen.User))
+	s.Error(s.manager.TerminateInstance(ctx, hostB, evergreen.User, ""))
 }
 
 func (s *OpenStackSuite) TestTerminateInstanceDB() {
@@ -194,7 +194,7 @@ func (s *OpenStackSuite) TestTerminateInstanceDB() {
 	s.NoError(err)
 
 	// Terminate the instance - check the host is terminated in DB.
-	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User)
+	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User, "")
 	s.NoError(err)
 
 	dbHost, err = host.FindOne(host.ById(myHost.Id))
@@ -202,7 +202,7 @@ func (s *OpenStackSuite) TestTerminateInstanceDB() {
 	s.NoError(err)
 
 	// Terminate again - check we cannot remove twice.
-	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User)
+	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User, "")
 	s.Error(err)
 }
 

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -216,18 +216,18 @@ func constructPwdUpdateCommand(ctx context.Context, env evergreen.Environment, h
 		Append(fmt.Sprintf("echo -e \"%s\" | passwd", password)), nil
 }
 
-func TerminateSpawnHost(ctx context.Context, host *host.Host, settings *evergreen.Settings, user string) error {
+func TerminateSpawnHost(ctx context.Context, host *host.Host, settings *evergreen.Settings, user, reason string) error {
 	if host.Status == evergreen.HostTerminated {
 		return errors.New("Host is already terminated")
 	}
 	if host.Status == evergreen.HostUninitialized {
-		return host.SetTerminated(user)
+		return host.SetTerminated(user, "host never started")
 	}
 	cloudHost, err := GetCloudHost(ctx, host, settings)
 	if err != nil {
 		return err
 	}
-	if err = cloudHost.TerminateInstance(ctx, user); err != nil {
+	if err = cloudHost.TerminateInstance(ctx, user, reason); err != nil {
 		return err
 	}
 	return nil

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -59,10 +59,10 @@ func (staticMgr *staticManager) GetDNSName(ctx context.Context, host *host.Host)
 }
 
 // terminate an instance
-func (staticMgr *staticManager) TerminateInstance(ctx context.Context, host *host.Host, user string) error {
+func (staticMgr *staticManager) TerminateInstance(ctx context.Context, host *host.Host, user, reason string) error {
 	// a decommissioned static host will be removed from the database
 	if host.Status == evergreen.HostDecommissioned {
-		event.LogHostStatusChanged(host.Id, host.Status, evergreen.HostDecommissioned, evergreen.User, "")
+		event.LogHostStatusChanged(host.Id, host.Status, evergreen.HostDecommissioned, evergreen.User, reason)
 		grip.Debugf("Removing decommissioned %s static host (%s)", host.Distro, host.Host)
 		if err := host.Remove(); err != nil {
 			grip.Errorf("Error removing decommissioned %s static host (%s): %+v",

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -139,7 +139,7 @@ func (m *vsphereManager) GetInstanceStatus(ctx context.Context, host *host.Host)
 }
 
 // TerminateInstance requests a server previously provisioned to be removed.
-func (m *vsphereManager) TerminateInstance(ctx context.Context, host *host.Host, user string) error {
+func (m *vsphereManager) TerminateInstance(ctx context.Context, host *host.Host, user, reason string) error {
 	if host.Status == evergreen.HostTerminated {
 		err := errors.Errorf("Can not terminate %s - already marked as terminated!", host.Id)
 		grip.Error(err)
@@ -151,7 +151,7 @@ func (m *vsphereManager) TerminateInstance(ctx context.Context, host *host.Host,
 	}
 
 	// Set the host status as terminated and update its termination time
-	if err := host.Terminate(user); err != nil {
+	if err := host.Terminate(user, reason); err != nil {
 		return errors.Wrapf(err, "could not terminate host %s in db", host.Id)
 	}
 

--- a/cloud/vsphere_test.go
+++ b/cloud/vsphere_test.go
@@ -157,10 +157,10 @@ func (s *VSphereSuite) TestTerminateInstanceAPICall() {
 	s.True(ok)
 	s.False(mock.failDelete)
 
-	s.NoError(s.manager.TerminateInstance(ctx, hostA, evergreen.User))
+	s.NoError(s.manager.TerminateInstance(ctx, hostA, evergreen.User, ""))
 
 	mock.failDelete = true
-	s.Error(s.manager.TerminateInstance(ctx, hostB, evergreen.User))
+	s.Error(s.manager.TerminateInstance(ctx, hostB, evergreen.User, ""))
 }
 
 func (s *VSphereSuite) TestTerminateInstanceDB() {
@@ -180,7 +180,7 @@ func (s *VSphereSuite) TestTerminateInstanceDB() {
 	s.NoError(err)
 
 	// Terminate the instance - check the host is terminated in DB.
-	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User)
+	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User, "")
 	s.NoError(err)
 
 	dbHost, err = host.FindOne(host.ById(myHost.Id))
@@ -188,7 +188,7 @@ func (s *VSphereSuite) TestTerminateInstanceDB() {
 	s.NoError(err)
 
 	// Terminate again - check we cannot remove twice.
-	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User)
+	err = s.manager.TerminateInstance(ctx, myHost, evergreen.User, "")
 	s.Error(err)
 }
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -354,8 +354,8 @@ func (h *Host) SetRunning(user string) error {
 	return h.SetStatus(evergreen.HostRunning, user, "")
 }
 
-func (h *Host) SetTerminated(user string) error {
-	return h.SetStatus(evergreen.HostTerminated, user, "")
+func (h *Host) SetTerminated(user, reason string) error {
+	return h.SetStatus(evergreen.HostTerminated, user, reason)
 }
 
 func (h *Host) SetStopping(user string) error {
@@ -508,8 +508,8 @@ func (h *Host) ResetLastCommunicated() error {
 	return nil
 }
 
-func (h *Host) Terminate(user string) error {
-	err := h.SetTerminated(user)
+func (h *Host) Terminate(user, reason string) error {
+	err := h.SetTerminated(user, reason)
 	if err != nil {
 		return err
 	}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -274,7 +274,7 @@ func TestSetHostTerminated(t *testing.T) {
 			" termination time in both the in-memory and database copies of"+
 			" the host", func() {
 
-			So(host.Terminate(evergreen.User), ShouldBeNil)
+			So(host.Terminate(evergreen.User, ""), ShouldBeNil)
 			So(host.Status, ShouldEqual, evergreen.HostTerminated)
 			So(host.TerminationTime.IsZero(), ShouldBeFalse)
 

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -122,7 +122,7 @@ func (hc *DBHostConnector) SetHostExpirationTime(host *host.Host, newExp time.Ti
 }
 
 func (hc *DBHostConnector) TerminateHost(ctx context.Context, host *host.Host, user string) error {
-	return errors.WithStack(cloud.TerminateSpawnHost(ctx, host, evergreen.GetEnvironment().Settings(), user))
+	return errors.WithStack(cloud.TerminateSpawnHost(ctx, host, evergreen.GetEnvironment().Settings(), user, "terminated via REST API"))
 }
 
 func (hc *DBHostConnector) CheckHostSecret(r *http.Request) (int, error) {

--- a/service/api_spawn.go
+++ b/service/api_spawn.go
@@ -150,7 +150,7 @@ func (as *APIServer) modifyHost(w http.ResponseWriter, r *http.Request) {
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}
-		if err = cloudHost.TerminateInstance(ctx, user.Username()); err != nil {
+		if err = cloudHost.TerminateInstance(ctx, user.Username(), fmt.Sprintf("terminated via API by %s", user.Username())); err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Failed to terminate spawn host"))
 			return
 		}

--- a/service/host_helpers.go
+++ b/service/host_helpers.go
@@ -56,7 +56,7 @@ func modifyHostStatus(queue amboy.Queue, h *host.Host, opts *uiParams, u *user.D
 				}
 			}
 
-			if err := queue.Put(ctx, units.NewHostTerminationJob(env, *h, true)); err != nil {
+			if err := queue.Put(ctx, units.NewHostTerminationJob(env, *h, true, fmt.Sprintf("terminated by %s", u.Username()))); err != nil {
 				return "", gimlet.ErrorResponse{
 					StatusCode: http.StatusInternalServerError,
 					Message:    HostTerminationQueueingError,

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -211,7 +211,7 @@ func (uis *UIServer) modifySpawnHost(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel = context.WithCancel(r.Context())
 		defer cancel()
 
-		if err := cloud.TerminateSpawnHost(ctx, h, env.Settings(), u.Id); err != nil {
+		if err := cloud.TerminateSpawnHost(ctx, h, env.Settings(), u.Id, fmt.Sprintf("terminated via UI by %s", u.Username())); err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}

--- a/units/crons.go
+++ b/units/crons.go
@@ -262,7 +262,7 @@ func PopulateHostTerminationJobs(env evergreen.Environment) amboy.QueueOperation
 		catcher.Add(err)
 
 		for _, h := range hosts {
-			catcher.Add(queue.Put(ctx, NewHostTerminationJob(env, h, true)))
+			catcher.Add(queue.Put(ctx, NewHostTerminationJob(env, h, true, "host is expired, decommissioned, or failed to provision")))
 		}
 
 		hosts, err = host.AllHostsSpawnedByTasksToTerminate()
@@ -274,7 +274,7 @@ func PopulateHostTerminationJobs(env evergreen.Environment) amboy.QueueOperation
 		catcher.Add(err)
 
 		for _, h := range hosts {
-			catcher.Add(queue.Put(ctx, NewHostTerminationJob(env, h, true)))
+			catcher.Add(queue.Put(ctx, NewHostTerminationJob(env, h, true, "host spawned by task has gone out of scope")))
 		}
 
 		return catcher.Resolve()

--- a/units/host_monitoring_container_state.go
+++ b/units/host_monitoring_container_state.go
@@ -124,9 +124,9 @@ func (j *hostMonitorContainerStateJob) Run(ctx context.Context) {
 	for _, container := range containersFromDB {
 		if container.Status == evergreen.HostRunning || container.Status == evergreen.HostDecommissioned {
 			if !container.SpawnOptions.SpawnedByTask && !isRunningInDocker[container.Id] {
-				if err := containerMgr.TerminateInstance(ctx, &container, evergreen.User); err != nil {
+				if err := containerMgr.TerminateInstance(ctx, &container, evergreen.User, "container not actually running"); err != nil {
 					j.AddError(errors.Wrap(err, "error terminating instance on Docker"))
-					j.AddError(container.SetTerminated(evergreen.User))
+					j.AddError(container.SetTerminated(evergreen.User, "container not actually running"))
 				}
 			}
 		}

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -138,7 +138,7 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 
 		// the instance was terminated from outside our control
 		catcher := grip.NewBasicCatcher()
-		err = h.SetTerminated(evergreen.HostExternalUserName)
+		err = h.SetTerminated(evergreen.HostExternalUserName, "terminated externally")
 		catcher.Add(err)
 		grip.Error(message.WrapError(err, message.Fields{
 			"op_id":   id,

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -153,7 +153,7 @@ func (j *idleHostJob) Run(ctx context.Context) {
 	// if we haven't heard from the host or it's been idle for longer than the cutoff, we should terminate
 	if communicationTime >= idleThreshold || idleTime >= idleThreshold {
 		j.Terminated = true
-		tjob := NewHostTerminationJob(j.env, *j.host, false)
+		tjob := NewHostTerminationJob(j.env, *j.host, false, "host is idle or unreachable")
 		queue := j.env.RemoteQueue()
 		j.AddError(queue.Put(ctx, tjob))
 	}

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -122,7 +122,7 @@ func setCloudHostStatus(ctx context.Context, m cloud.Manager, h host.Host, hostS
 			"host":       h,
 			"hostStatus": hostStatus.String(),
 		})
-		return errors.Wrap(m.TerminateInstance(ctx, &h, evergreen.User), "error terminating instance")
+		return errors.Wrap(m.TerminateInstance(ctx, &h, evergreen.User, "cloud provider reported host failed to start"), "error terminating instance")
 	case cloud.StatusRunning:
 		return errors.Wrap(h.SetProvisioning(), "error setting host to provisioning")
 	}

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -32,6 +32,7 @@ func init() {
 
 type hostTerminationJob struct {
 	HostID          string `bson:"host_id" json:"host_id"`
+	Reason          string `bson:"reason,omitempty" json:"reason,omitempty"`
 	TerminateIfBusy bool   `bson:"terminate_if_busy" json:"terminate_if_busy"`
 	job.Base        `bson:"metadata" json:"metadata"`
 
@@ -53,12 +54,13 @@ func makeHostTerminationJob() *hostTerminationJob {
 	return j
 }
 
-func NewHostTerminationJob(env evergreen.Environment, h host.Host, terminateIfBusy bool) amboy.Job {
+func NewHostTerminationJob(env evergreen.Environment, h host.Host, terminateIfBusy bool, reason string) amboy.Job {
 	j := makeHostTerminationJob()
 	j.host = &h
 	j.HostID = h.Id
 	j.env = env
 	j.TerminateIfBusy = terminateIfBusy
+	j.Reason = reason
 	j.SetPriority(2)
 	ts := util.RoundPartOfHour(2).Format(tsFormat)
 	j.SetID(fmt.Sprintf("%s.%s.%s", hostTerminationJobName, j.HostID, ts))
@@ -124,7 +126,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 
 	// host may still be an intent host
 	if j.host.Status == evergreen.HostUninitialized {
-		if err = j.host.Terminate(evergreen.User); err != nil {
+		if err = j.host.Terminate(evergreen.User, j.Reason); err != nil {
 			j.AddError(errors.Wrap(err, "problem terminating intent host in db"))
 			grip.Error(message.WrapError(err, message.Fields{
 				"host":     j.host.Id,
@@ -203,7 +205,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			return
 		}
 		if parent.Status == evergreen.HostTerminated {
-			if err = j.host.Terminate(evergreen.User); err != nil {
+			if err = j.host.Terminate(evergreen.User, "parent was already terminated"); err != nil {
 				j.AddError(errors.Wrap(err, "problem terminating container in db"))
 				grip.Error(message.WrapError(err, message.Fields{
 					"host":     j.host.Id,
@@ -218,7 +220,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	} else if prevStatus == evergreen.HostBuilding {
 		// If the host is not a container and is building, this means the host is an intent
 		// host, and should be terminated in the database, and not in the cloud manager.
-		if err = j.host.Terminate(evergreen.User); err != nil {
+		if err = j.host.Terminate(evergreen.User, "host was never started"); err != nil {
 			// It is possible that the provisioning-create-host job has removed the
 			// intent host from the database before this job got to it. If so, there is
 			// nothing to terminate with a cloud manager, since if there is a
@@ -273,7 +275,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		}))
 
 		if !util.StringSliceContains(evergreen.UpHostStatus, prevStatus) {
-			if err := j.host.Terminate(evergreen.User); err != nil {
+			if err := j.host.Terminate(evergreen.User, "unable to get cloud status for host"); err != nil {
 				j.AddError(err)
 			}
 			return
@@ -291,7 +293,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			"message":  "attempted to terminated an already terminated host",
 			"theory":   "external termination",
 		})
-		if err := j.host.Terminate(evergreen.User); err != nil {
+		if err := j.host.Terminate(evergreen.User, "cloud provider indicated host was terminated"); err != nil {
 			j.AddError(errors.Wrap(err, "problem terminating host in db"))
 			grip.Error(message.WrapError(err, message.Fields{
 				"host":     j.host.Id,
@@ -313,7 +315,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		}))
 	}
 
-	if err := cloudHost.TerminateInstance(ctx, evergreen.User); err != nil {
+	if err := cloudHost.TerminateInstance(ctx, evergreen.User, j.Reason); err != nil {
 		j.AddError(err)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":  "problem terminating host",

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -236,7 +236,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	if err != nil {
 		terminateCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		grip.Error(message.WrapError(cloudManager.TerminateInstance(terminateCtx, j.host, evergreen.User), message.Fields{
+		grip.Error(message.WrapError(cloudManager.TerminateInstance(terminateCtx, j.host, evergreen.User, "hit database error trying to create host"), message.Fields{
 			"message":     "problem terminating instance after cloud host was spawned",
 			"intent_host": j.HostID,
 			"host":        j.host.Id,
@@ -256,7 +256,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	} else if err := intentHost.Remove(); err != nil {
 		terminateCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		grip.Error(message.WrapError(cloudManager.TerminateInstance(terminateCtx, j.host, evergreen.User), message.Fields{
+		grip.Error(message.WrapError(cloudManager.TerminateInstance(terminateCtx, j.host, evergreen.User, "hit database error trying to update host"), message.Fields{
 			"message":     "problem terminating instance after cloud host was spawned",
 			"host":        j.host.Id,
 			"intent_host": j.HostID,
@@ -284,7 +284,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	if err := j.host.Insert(); err != nil {
 		terminateCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		grip.Error(message.WrapError(cloudManager.TerminateInstance(terminateCtx, j.host, evergreen.User), message.Fields{
+		grip.Error(message.WrapError(cloudManager.TerminateInstance(terminateCtx, j.host, evergreen.User, "hit database error trying to update host"), message.Fields{
 			"message": "problem terminating instance after cloud host was spawned",
 			"host":    j.host.Id,
 			"distro":  j.host.Distro.Id,


### PR DESCRIPTION
There is already a field which displays extra data in the host event log, so this plumbs comments from a variety of places into that field