### PR TITLE
EVG-6812 virtualize patch summary

### DIFF
--- a/public/static/partials/patch_diff.html
+++ b/public/static/partials/patch_diff.html
@@ -3,35 +3,37 @@
   <div ng-show="!diffs.length">
     <h3>No patch status available for this page</h3>
   </div>
-  <table class="table table-new" ng-show="diffs.length">
-    <thead>
-      <tr>
-        <th style="width:50px;">&nbsp;</th>
-        <th>[[type]]</th>
-        <th>Base</th>
-        <th>Patch</th>
-      </tr>
-    </thead>
-    <tr ng-repeat="diff in diffs | orderBy:['displayInfo.type', 'diff.patch.status', 'name', 'build_variant']">
-      <td class="text-center">
-        <i class="fa" ng-class="diff.displayInfo.icon"></i>
-      </td>
-      <td>
-        <a ng-href="[[diff.patchLink]]">
-          <span class="diff-name">[[diff.name]]</span>
-        </a>
-        <span class="extra-info">[[diff.build_variant]]</span>
-      </td>
-      <td>
-        <a ng-href="[[diff.originalLink]]" ng-if="[[diff.originalLink]]">
-          <span class="diffbox" ng-class="diff.diff.original | statusFilter"></span>
-        </a>
-      </td>
-      <td>
-        <a ng-href="[[diff.patchLink]]">
-          <span class="diffbox" ng-class="diff.diff.patch | statusFilter"></span>
-        </a>
-      </td>
-    </tr>
-  </table>
+  <md-virtual-repeat-container ng-show="diffs.length" style="width:100%;height:300px;">
+    <table class="table table-new">
+      <thead>
+        <tr>
+          <th style="width:50px;">&nbsp;</th>
+          <th>[[type]]</th>
+          <th>Base</th>
+          <th>Patch</th>
+        </tr>
+      </thead>
+        <tr md-virtual-repeat="diff in diffs | orderBy:['displayInfo.type', 'diff.patch.status', 'name', 'build_variant']">
+          <td class="text-center">
+            <i class="fa" ng-class="diff.displayInfo.icon"></i>
+          </td>
+          <td>
+            <a ng-href="[[diff.patchLink]]">
+              <span class="diff-name">[[diff.name]]</span>
+            </a>
+            <span class="extra-info">[[diff.build_variant]]</span>
+          </td>
+          <td>
+            <a ng-href="[[diff.originalLink]]" ng-if="[[diff.originalLink]]">
+              <span class="diffbox" ng-class="diff.diff.original | statusFilter"></span>
+            </a>
+          </td>
+          <td>
+            <a ng-href="[[diff.patchLink]]">
+              <span class="diffbox" ng-class="diff.diff.patch | statusFilter"></span>
+            </a>
+          </td>
+        </tr>
+    </table>
+  </md-virtual-repeat-container>
 </div>


### PR DESCRIPTION
We now do the same thing with the patch test summary as we do with the test results pane. View with whitespace changes disabled