### PR TITLE
EVG-6773 remove unscheduled versions from commit queue

### DIFF
--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -175,6 +175,15 @@ func (s *subscriptionsSuite) TestFind() {
 	s.NoError(err)
 	s.Empty(subs)
 
+	subs, err = FindSubscriptions("type1", []Selector{
+		{
+			Type: "data",
+			Data: "nothing_matches",
+		},
+	})
+	s.NoError(err)
+	s.Empty(subs)
+
 	subs, err = FindSubscriptions("type2", []Selector{
 		{
 			Type: "data",

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/build"
-	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/patch"
@@ -21,7 +20,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -175,83 +174,6 @@ func AbortVersion(versionId, caller string) error {
 	if len(ids) > 0 {
 		event.LogManyTaskAbortRequests(ids, caller)
 	}
-	return nil
-}
-
-func RemoveCommitQueueItem(projectId, item string) (bool, error) {
-	cq, err := commitqueue.FindOneId(projectId)
-	if err != nil {
-		return false, errors.Wrapf(err, "can't get commit queue for id '%s'", projectId)
-	}
-
-	head := cq.Next()
-	removed, err := cq.Remove(item)
-	if err != nil {
-		return removed, errors.Wrapf(err, "can't remove item '%s' from queue '%s'", item, projectId)
-	}
-
-	if removed && head.Issue == item {
-		if err = preventMergeForItem(projectId, head); err != nil {
-			return removed, errors.Wrapf(err, "can't prevent merge for item '%s' on queue '%s'", item, projectId)
-		}
-	}
-	return removed, nil
-}
-
-func preventMergeForItem(projectID string, item *commitqueue.CommitQueueItem) error {
-	projectRef, err := FindOneProjectRef(projectID)
-	if err != nil {
-		return errors.Wrapf(err, "can't find projectRef for '%s'", projectID)
-	}
-	if projectRef == nil {
-		return errors.Errorf("can't find project ref for '%s'", projectID)
-	}
-
-	if projectRef.CommitQueue.PatchType == commitqueue.PRPatchType && item.Version != "" {
-		if err = clearVersionPatchSubscriber(item.Version, event.GithubMergeSubscriberType); err != nil {
-			return errors.Wrap(err, "can't clear subscriptions")
-		}
-	}
-
-	if projectRef.CommitQueue.PatchType == commitqueue.CLIPatchType {
-		version, err := VersionFindOneId(item.Issue)
-		if err != nil {
-			return errors.Wrapf(err, "can't find patch '%s'", item.Issue)
-		}
-		if version != nil {
-			if err = clearVersionPatchSubscriber(version.Id, event.CommitQueueDequeueSubscriberType); err != nil {
-				return errors.Wrap(err, "can't clear subscriptions")
-			}
-
-			// Blacklist the merge task
-			mergeTask, err := task.FindMergeTaskForVersion(version.Id)
-			if err != nil {
-				return errors.Wrapf(err, "can't find merge task for '%s'", version.Id)
-			}
-			err = mergeTask.SetPriority(-1, evergreen.User)
-			if err != nil {
-				return errors.Wrap(err, "can't blacklist merge task")
-			}
-		}
-	}
-
-	return nil
-}
-
-func clearVersionPatchSubscriber(versionID, subscriberType string) error {
-	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: versionID}})
-	if err != nil {
-		return errors.Wrapf(err, "can't find subscription to patch '%s'", versionID)
-	}
-	for _, subscription := range subscriptions {
-		if subscription.Subscriber.Type == subscriberType {
-			err = event.RemoveSubscription(subscription.ID)
-			if err != nil {
-				return errors.Wrapf(err, "can't remove subscription for '%s', type '%s'", versionID, subscriberType)
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/patch"
@@ -174,6 +175,83 @@ func AbortVersion(versionId, caller string) error {
 	if len(ids) > 0 {
 		event.LogManyTaskAbortRequests(ids, caller)
 	}
+	return nil
+}
+
+func RemoveCommitQueueItem(projectId, item string) (bool, error) {
+	cq, err := commitqueue.FindOneId(projectId)
+	if err != nil {
+		return false, errors.Wrapf(err, "can't get commit queue for id '%s'", projectId)
+	}
+
+	head := cq.Next()
+	removed, err := cq.Remove(item)
+	if err != nil {
+		return removed, errors.Wrapf(err, "can't remove item '%s' from queue '%s'", item, projectId)
+	}
+
+	if removed && head.Issue == item {
+		if err = preventMergeForItem(projectId, head); err != nil {
+			return removed, errors.Wrapf(err, "can't prevent merge for item '%s' on queue '%s'", item, projectId)
+		}
+	}
+	return removed, nil
+}
+
+func preventMergeForItem(projectID string, item *commitqueue.CommitQueueItem) error {
+	projectRef, err := FindOneProjectRef(projectID)
+	if err != nil {
+		return errors.Wrapf(err, "can't find projectRef for '%s'", projectID)
+	}
+	if projectRef == nil {
+		return errors.Errorf("can't find project ref for '%s'", projectID)
+	}
+
+	if projectRef.CommitQueue.PatchType == commitqueue.PRPatchType && item.Version != "" {
+		if err = clearVersionPatchSubscriber(item.Version, event.GithubMergeSubscriberType); err != nil {
+			return errors.Wrap(err, "can't clear subscriptions")
+		}
+	}
+
+	if projectRef.CommitQueue.PatchType == commitqueue.CLIPatchType {
+		version, err := VersionFindOneId(item.Issue)
+		if err != nil {
+			return errors.Wrapf(err, "can't find patch '%s'", item.Issue)
+		}
+		if version != nil {
+			if err = clearVersionPatchSubscriber(version.Id, event.CommitQueueDequeueSubscriberType); err != nil {
+				return errors.Wrap(err, "can't clear subscriptions")
+			}
+
+			// Blacklist the merge task
+			mergeTask, err := task.FindMergeTaskForVersion(version.Id)
+			if err != nil {
+				return errors.Wrapf(err, "can't find merge task for '%s'", version.Id)
+			}
+			err = mergeTask.SetPriority(-1, evergreen.User)
+			if err != nil {
+				return errors.Wrap(err, "can't blacklist merge task")
+			}
+		}
+	}
+
+	return nil
+}
+
+func clearVersionPatchSubscriber(versionID, subscriberType string) error {
+	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: versionID}})
+	if err != nil {
+		return errors.Wrapf(err, "can't find subscription to patch '%s'", versionID)
+	}
+	for _, subscription := range subscriptions {
+		if subscription.Subscriber.Type == subscriberType {
+			err = event.RemoveSubscription(subscription.ID)
+			if err != nil {
+				return errors.Wrapf(err, "can't remove subscription for '%s', type '%s'", versionID, subscriberType)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/build"
-	"github.com/evergreen-ci/evergreen/model/commitqueue"
-	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/util"
 	. "github.com/smartystreets/goconvey/convey"
@@ -281,105 +279,6 @@ func TestBuildMarkAborted(t *testing.T) {
 			})
 		})
 	})
-}
-
-func TestPreventMergeForItemPR(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(event.SubscriptionsCollection, commitqueue.Collection, ProjectRefCollection))
-	projectRef := &ProjectRef{
-		Identifier: "mci",
-		Owner:      "evergreen-ci",
-		Repo:       "evergreen",
-		Branch:     "master",
-		CommitQueue: CommitQueueParams{
-			Enabled:   true,
-			PatchType: commitqueue.PRPatchType,
-		},
-	}
-	require.NoError(t, projectRef.Insert())
-	cq := &commitqueue.CommitQueue{ProjectID: "mci"}
-	require.NoError(t, commitqueue.InsertQueue(cq))
-
-	patchID := "abcdef012345"
-	patchSub := event.NewPatchOutcomeSubscription(patchID, event.NewGithubMergeSubscriber(event.GithubMergeSubscriber{}))
-	require.NoError(t, patchSub.Upsert())
-
-	item := commitqueue.CommitQueueItem{
-		Issue:   "1234",
-		Version: patchID,
-	}
-	_, err := cq.Enqueue(item)
-	require.NoError(t, err)
-
-	assert.NoError(t, preventMergeForItem(projectRef.Identifier, &item))
-	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: item.Version}})
-	assert.NoError(t, err)
-	assert.Empty(t, subscriptions)
-}
-
-func TestPreventMergeForItemCLI(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(event.SubscriptionsCollection, task.Collection, VersionCollection, commitqueue.Collection, ProjectRefCollection))
-	projectRef := &ProjectRef{
-		Identifier: "mci",
-		Owner:      "evergreen-ci",
-		Repo:       "evergreen",
-		Branch:     "master",
-		CommitQueue: CommitQueueParams{
-			Enabled:   true,
-			PatchType: commitqueue.CLIPatchType,
-		},
-	}
-	require.NoError(t, projectRef.Insert())
-	cq := &commitqueue.CommitQueue{ProjectID: "mci"}
-	require.NoError(t, commitqueue.InsertQueue(cq))
-
-	patchID := "abcdef012345"
-	patchSub := event.NewPatchOutcomeSubscription(patchID, event.NewCommitQueueDequeueSubscriber())
-	require.NoError(t, patchSub.Upsert())
-
-	item := commitqueue.CommitQueueItem{
-		Issue: patchID,
-	}
-	_, err := cq.Enqueue(item)
-	require.NoError(t, err)
-
-	mergeTask := &task.Task{Id: "t1", CommitQueueMerge: true, Version: patchID}
-	require.NoError(t, mergeTask.Insert())
-
-	// Without a corresponding version
-	assert.NoError(t, preventMergeForItem(projectRef.Identifier, &item))
-	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
-	assert.NoError(t, err)
-	assert.NotEmpty(t, subscriptions)
-
-	mergeTask, err = task.FindOneId("t1")
-	assert.NoError(t, err)
-	assert.Equal(t, int64(0), mergeTask.Priority)
-
-	// With a corresponding version
-	version := Version{Id: patchID}
-	require.NoError(t, version.Insert())
-
-	assert.NoError(t, preventMergeForItem(projectRef.Identifier, &item))
-	subscriptions, err = event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
-	assert.NoError(t, err)
-	assert.Empty(t, subscriptions)
-
-	mergeTask, err = task.FindOneId("t1")
-	assert.NoError(t, err)
-	assert.Equal(t, int64(-1), mergeTask.Priority)
-}
-
-func TestClearVersionPatchSubscriber(t *testing.T) {
-	require.NoError(t, db.Clear(event.SubscriptionsCollection))
-
-	patchID := "abcdef012345"
-	patchSub := event.NewPatchOutcomeSubscription(patchID, event.NewCommitQueueDequeueSubscriber())
-	assert.NoError(t, patchSub.Upsert())
-
-	assert.NoError(t, clearVersionPatchSubscriber(patchID, event.CommitQueueDequeueSubscriberType))
-	subs, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
-	assert.NoError(t, err)
-	assert.Empty(t, subs)
 }
 
 func TestBuildSetActivated(t *testing.T) {

--- a/public/static/js/build_admin.js
+++ b/public/static/js/build_admin.js
@@ -34,7 +34,7 @@ mciModule.controller('AdminOptionsCtrl', [
                 success: function(resp) {
                     var data = resp.data;
                     var message = "Build aborted" +
-                        ($scope.build.requester === "merge_test" ? " and version removed from commit queue." : ".");
+                        ($scope.build.Build.r === "merge_test" ? " and version removed from commit queue." : ".");
                     $scope.closeAdminModal();
                     $rootScope.$broadcast("build_updated", data);
                     notifier.pushNotification(message, 'notifyHeader', 'success');
@@ -99,7 +99,7 @@ mciModule.controller('AdminOptionsCtrl', [
                     $scope.closeAdminModal();
                     $rootScope.$broadcast("build_updated", data);
                     var notifyString = "Build marked as " + (active ? "scheduled" : "unscheduled") +
-                        (!active && $scope.build.requester === "merge_test" ? " and version removed from commit queue." : ".") +
+                        (!active && $scope.build.r === "merge_test" ? " and version removed from commit queue." : ".") +
                         (abort ? "\n In progress tasks will be aborted." : "");
                     notifier.pushNotification(notifyString, 'notifyHeader', 'success');
                 },

--- a/public/static/js/build_admin.js
+++ b/public/static/js/build_admin.js
@@ -165,6 +165,9 @@ mciModule.directive('adminAbortBuild', function() {
     '<div class="row">' +
       '<div class="col-lg-12">' +
         'Abort all tasks for current build?' +
+        '<div ng-show="build.r === merge_test">' +
+            'This will remove the version from the commit queue.' +
+        '</div>' +
         '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +
         '<button type="button" class="btn btn-primary" style="float: right; margin-right: 10px;" ng-click="abort()">Yes</button>' +
       '</div>' +
@@ -193,7 +196,7 @@ mciModule.directive('adminUnscheduleBuild', function() {
     '<div class="row">' +
       '<div class="col-lg-12">' +
         'Unschedule current build?' +
-        '<div ng-show="build.r === "merge_test">' +
+        '<div ng-show="build.r === merge_test">' +
             'This will remove the version from the commit queue.' +
         '</div>' +
         '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +

--- a/public/static/js/build_admin.js
+++ b/public/static/js/build_admin.js
@@ -33,9 +33,11 @@ mciModule.controller('AdminOptionsCtrl', [
             {
                 success: function(resp) {
                     var data = resp.data;
+                    var message = "Build aborted" +
+                        ($scope.build.requester === "merge_test" ? " and version removed from commit queue." : ".");
                     $scope.closeAdminModal();
                     $rootScope.$broadcast("build_updated", data);
-                    notifier.pushNotification("Build aborted.", 'notifyHeader', 'success');
+                    notifier.pushNotification(message, 'notifyHeader', 'success');
                 },
                 error: function(resp) {
                     notifier.pushNotification('Error aborting build: ' + resp.data,'errorModal');
@@ -96,7 +98,9 @@ mciModule.controller('AdminOptionsCtrl', [
                     var data = resp.data;
                     $scope.closeAdminModal();
                     $rootScope.$broadcast("build_updated", data);
-                    var notifyString = "Build marked as " + (active ? "scheduled." : "unscheduled.");
+                    var notifyString = "Build marked as " + (active ? "scheduled" : "unscheduled") +
+                        (!active && $scope.build.requester === "merge_test" ? " and version removed from commit queue." : ".") +
+                        (abort ? "\n In progress tasks will be aborted." : "");
                     notifier.pushNotification(notifyString, 'notifyHeader', 'success');
                 },
                 error: function(resp) {
@@ -189,6 +193,9 @@ mciModule.directive('adminUnscheduleBuild', function() {
     '<div class="row">' +
       '<div class="col-lg-12">' +
         'Unschedule current build?' +
+        '<div ng-show="build.requester === "merge_test">' +
+            'This will remove the version from the commit queue.' +
+        '</div>' +
         '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +
         '<button type="button" class="btn btn-primary" style="float: right; margin-right: 10px;" ng-click="setActive(false)">Yes</button>' +
         '<div style="margin-top: 6px;">' +

--- a/public/static/js/build_admin.js
+++ b/public/static/js/build_admin.js
@@ -34,7 +34,7 @@ mciModule.controller('AdminOptionsCtrl', [
                 success: function(resp) {
                     var data = resp.data;
                     var message = "Build aborted" +
-                        ($scope.build.Build.r === "merge_test" ? " and version removed from commit queue." : ".");
+                        ($scope.build.r === "merge_test" ? " and version removed from commit queue." : ".");
                     $scope.closeAdminModal();
                     $rootScope.$broadcast("build_updated", data);
                     notifier.pushNotification(message, 'notifyHeader', 'success');
@@ -193,7 +193,7 @@ mciModule.directive('adminUnscheduleBuild', function() {
     '<div class="row">' +
       '<div class="col-lg-12">' +
         'Unschedule current build?' +
-        '<div ng-show="build.requester === "merge_test">' +
+        '<div ng-show="build.r === "merge_test">' +
             'This will remove the version from the commit queue.' +
         '</div>' +
         '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +

--- a/public/static/js/task_admin.js
+++ b/public/static/js/task_admin.js
@@ -50,7 +50,9 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
             {},
             {
                 success: function(resp) {
-                    doModalSuccess("Task aborted.", resp.data, $scope.task.display_only);
+                    var message = "Task aborted" +
+                        ($scope.task.requester === "merge_test" ? " and version removed from commit queue." : ".")
+                    doModalSuccess(message, resp.data, $scope.task.display_only);
                 },
                 error: function(resp) {
                     notifier.pushNotification('Error aborting: ' + resp.data.error,'errorModal');
@@ -102,7 +104,10 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
             {
                 success: function(resp) {
                     var data = resp.data;
-                    doModalSuccess("Task marked as " + (active ? "scheduled." : "unscheduled."), data, $scope.task.display_only);
+                    var message = "Task marked as " + (active ? "scheduled" : "unscheduled") +
+                        (!active && $scope.task.requester === "merge_test" ? " and version removed from commit queue." : ".") +
+
+                        doModalSuccess(message, data, $scope.task.display_only);
                 },
                 error: function(resp) {
                     notifier.pushNotification('Error setting active = ' + active + ': ' + resp.data,'errorModal');
@@ -169,6 +174,9 @@ mciModule.directive('adminAbortTask', function() {
     '<div class="row">' +
       '<div class="col-lg-12">' +
         'Abort current task?' +
+        '<div ng-show="task.requester === "merge_test">' +
+            'This will remove version from the commit queue.' +
+        '</div>' +
         '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +
         '<button type="button" class="btn btn-primary" style="float: right; margin-right: 10px;" ng-click="abort()">Yes</button>' +
       '</div>' +
@@ -197,6 +205,9 @@ mciModule.directive('adminUnscheduleTask', function() {
     '<div class="row">' +
       '<div class="col-lg-12">' +
         'Unschedule current task?' +
+        '<div ng-show="task.requester === "merge_test">' +
+            'This will remove version from the commit queue.' +
+        '</div>' +
         '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +
         '<button type="button" class="btn btn-primary" style="float: right; margin-right: 10px;" ng-click="setActive(false)">Yes</button>' +
       '</div>' +

--- a/public/static/js/task_admin.js
+++ b/public/static/js/task_admin.js
@@ -51,7 +51,7 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
             {
                 success: function(resp) {
                     var message = "Task aborted" +
-                        ($scope.task.Task.r === "merge_test" ? " and version removed from commit queue." : ".")
+                        ($scope.task.r === "merge_test" ? " and version removed from commit queue." : ".")
                     doModalSuccess(message, resp.data, $scope.task.display_only);
                 },
                 error: function(resp) {
@@ -105,9 +105,8 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
                 success: function(resp) {
                     var data = resp.data;
                     var message = "Task marked as " + (active ? "scheduled" : "unscheduled") +
-                        (!active && $scope.task.r  === "merge_test" ? " and version removed from commit queue." : ".") +
-
-                        doModalSuccess(message, data, $scope.task.display_only);
+                        (!active && $scope.task.r  === "merge_test" ? " and version removed from commit queue." : ".");
+                    doModalSuccess(message, data, $scope.task.display_only);
                 },
                 error: function(resp) {
                     notifier.pushNotification('Error setting active = ' + active + ': ' + resp.data,'errorModal');
@@ -174,7 +173,7 @@ mciModule.directive('adminAbortTask', function() {
     '<div class="row">' +
       '<div class="col-lg-12">' +
         'Abort current task?' +
-        '<div ng-show="task.requester === "merge_test">' +
+        '<div ng-show="task.r === "merge_test">' +
             'This will remove version from the commit queue.' +
         '</div>' +
         '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +
@@ -205,7 +204,7 @@ mciModule.directive('adminUnscheduleTask', function() {
     '<div class="row">' +
       '<div class="col-lg-12">' +
         'Unschedule current task?' +
-        '<div ng-show="task.requester === "merge_test">' +
+        '<div ng-show="task.r=== "merge_test">' +
             'This will remove version from the commit queue.' +
         '</div>' +
         '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +

--- a/public/static/js/task_admin.js
+++ b/public/static/js/task_admin.js
@@ -51,7 +51,7 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
             {
                 success: function(resp) {
                     var message = "Task aborted" +
-                        ($scope.task.requester === "merge_test" ? " and version removed from commit queue." : ".")
+                        ($scope.task.Task.r === "merge_test" ? " and version removed from commit queue." : ".")
                     doModalSuccess(message, resp.data, $scope.task.display_only);
                 },
                 error: function(resp) {
@@ -105,7 +105,7 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
                 success: function(resp) {
                     var data = resp.data;
                     var message = "Task marked as " + (active ? "scheduled" : "unscheduled") +
-                        (!active && $scope.task.requester === "merge_test" ? " and version removed from commit queue." : ".") +
+                        (!active && $scope.task.r  === "merge_test" ? " and version removed from commit queue." : ".") +
 
                         doModalSuccess(message, data, $scope.task.display_only);
                 },

--- a/public/static/js/task_admin.js
+++ b/public/static/js/task_admin.js
@@ -173,7 +173,7 @@ mciModule.directive('adminAbortTask', function() {
     '<div class="row">' +
       '<div class="col-lg-12">' +
         'Abort current task?' +
-        '<div ng-show="task.r === "merge_test">' +
+        '<div ng-show="task.r === merge_test">' +
             'This will remove version from the commit queue.' +
         '</div>' +
         '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +
@@ -204,7 +204,7 @@ mciModule.directive('adminUnscheduleTask', function() {
     '<div class="row">' +
       '<div class="col-lg-12">' +
         'Unschedule current task?' +
-        '<div ng-show="task.r=== "merge_test">' +
+        '<div ng-show="task.r === merge_test">' +
             'This will remove version from the commit queue.' +
         '</div>' +
         '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +

--- a/public/static/js/version_admin.js
+++ b/public/static/js/version_admin.js
@@ -194,7 +194,7 @@ mciModule.directive('adminUnscheduleAll', function() {
       '<div class="col-lg-12">' +
         '<div>' +
           'Unschedule all tasks?' +
-            '<div ng-show="version.requester === "merge_test">' +
+            '<div ng-show="version.requester === merge_test">' +
                 'This will remove version from the commit queue.' +
             '</div>' +
         '</div>' +

--- a/public/static/js/version_admin.js
+++ b/public/static/js/version_admin.js
@@ -76,7 +76,7 @@ mciModule.controller('AdminOptionsCtrl', [
                     $scope.closeAdminModal()
                     $rootScope.$broadcast("version_updated", data)
                     notifier.pushNotification(
-                      "Version " + (active ? "scheduled." : "unscheduled") +
+                      "Version " + (active ? "scheduled" : "unscheduled") +
                       (!active && $scope.version.Version.requester === "merge_test" ? " and removed from commit queue." : ".") +
                       (abort ? "\n In progress tasks will be aborted." : "")
                       ,
@@ -195,7 +195,8 @@ mciModule.directive('adminUnscheduleAll', function() {
         '<div>' +
           'Unschedule all tasks?' +
             '<div ng-show="version.requester === "merge_test">' +
-            'This will remove version from the commit queue.' +
+                'This will remove version from the commit queue.' +
+            '</div>' +
         '</div>' +
           '<div style="float:right">' +
             '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +

--- a/public/static/js/version_admin.js
+++ b/public/static/js/version_admin.js
@@ -76,8 +76,10 @@ mciModule.controller('AdminOptionsCtrl', [
                     $scope.closeAdminModal()
                     $rootScope.$broadcast("version_updated", data)
                     notifier.pushNotification(
-                      "Version " + (active ? "scheduled." : "unscheduled.") +
-                      (abort ? "\n In progress tasks will be aborted." : ""),
+                      "Version " + (active ? "scheduled." : "unscheduled") +
+                      (!active && $scope.version.Version.requester === "merge_test" ? " and removed from commit queue." : ".") +
+                      (abort ? "\n In progress tasks will be aborted." : "")
+                      ,
                       'notifyHeader', 'success');
                 },
                 error: function(jqXHR, status, errorThrown) {

--- a/public/static/js/version_admin.js
+++ b/public/static/js/version_admin.js
@@ -82,8 +82,8 @@ mciModule.controller('AdminOptionsCtrl', [
                       ,
                       'notifyHeader', 'success');
                 },
-                error: function(jqXHR, status, errorThrown) {
-                    notifier.pushNotification('Error setting version activation: ' + resp.data.error,'errorModal');
+                error: function(resp) {
+                    notifier.pushNotification('Error setting version activation: ' + resp.data,'errorModal');
                 }
             }
         );
@@ -101,8 +101,8 @@ mciModule.controller('AdminOptionsCtrl', [
                     var msg = "Priority for version set to " + newPriority + "."
                     notifier.pushNotification(msg, 'notifyHeader', 'success');
                 },
-                error: function(jqXHR, status, errorThrown) {
-                    notifier.pushNotification('Error changing priority: ' + resp.data.error,'errorModal');
+                error: function(resp) {
+                    notifier.pushNotification('Error changing priority: ' + resp.data,'errorModal');
                 }
             }
         );
@@ -197,15 +197,13 @@ mciModule.directive('adminUnscheduleAll', function() {
             '<div ng-show="version.requester === merge_test">' +
                 'This will remove version from the commit queue.' +
             '</div>' +
-        '</div>' +
-          '<div style="float:right">' +
             '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +
             '<button type="button" class="btn btn-primary" style="float: right; margin-right: 10px;" ng-click="updateScheduled(false)">Yes</button>' +
+            '<div style="margin-top: 6px;">' +
+                '<input type="checkbox" id="passed" name="passed" ng-model="adminOptionVals.abort" class="ng-valid ng-dirty"> ' +
+                '<label for="passed" style="font-weight:normal;">Abort tasks that have already started</label>' +
+            '</div>' +
         '</div>' +
-      '</div>' +
-      '<div styl="float:right">' +
-        '<input type="checkbox" id="passed" name="passed" ng-model="adminOptionVals.abort" class="ng-valid ng-dirty"> ' +
-        '<label for="passed" style="font-weight:normal;font-size:.8em;">  Abort tasks that have already started</label>' +
       '</div>' +
     '</div>'
   }

--- a/public/static/js/version_admin.js
+++ b/public/static/js/version_admin.js
@@ -194,6 +194,9 @@ mciModule.directive('adminUnscheduleAll', function() {
       '<div class="col-lg-12">' +
         '<div>' +
           'Unschedule all tasks?' +
+            '<div ng-show="version.requester === "merge_test">' +
+            'This will remove version from the commit queue.' +
+        '</div>' +
           '<div style="float:right">' +
             '<button type="button" class="btn btn-danger" style="float: right;" data-dismiss="modal">Cancel</button>' +
             '<button type="button" class="btn btn-primary" style="float: right; margin-right: 10px;" ng-click="updateScheduled(false)">Yes</button>' +

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
-	"github.com/evergreen-ci/evergreen/model/event"
-	"github.com/evergreen-ci/evergreen/model/task"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/suite"
@@ -167,85 +165,6 @@ func (s *CommitQueueSuite) TestIsAuthorizedToPatchAndMerge() {
 	authorized, err = s.ctx.IsAuthorizedToPatchAndMerge(ctx, s.settings, args)
 	s.NoError(err)
 	s.False(authorized)
-}
-
-func (s *CommitQueueSuite) TestPreventMergeForItemPR() {
-	s.NoError(db.ClearCollections(event.SubscriptionsCollection))
-
-	s.projectRef.CommitQueue.PatchType = commitqueue.PRPatchType
-	s.NoError(s.projectRef.Upsert())
-
-	patchID := "abcdef012345"
-	patchSub := event.NewPatchOutcomeSubscription(patchID, event.NewGithubMergeSubscriber(event.GithubMergeSubscriber{}))
-	s.Require().NoError(patchSub.Upsert())
-
-	item := commitqueue.CommitQueueItem{
-		Issue:   "1234",
-		Version: patchID,
-	}
-	_, err := s.queue.Enqueue(item)
-	s.Require().NoError(err)
-
-	s.NoError(preventMergeForItem(s.projectRef.Identifier, &item))
-	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: item.Version}})
-	s.NoError(err)
-	s.Empty(subscriptions)
-}
-
-func (s *CommitQueueSuite) TestPreventMergeForItemCLI() {
-	s.NoError(db.ClearCollections(event.SubscriptionsCollection, task.Collection, model.VersionCollection))
-
-	s.projectRef.CommitQueue.PatchType = commitqueue.CLIPatchType
-	s.NoError(s.projectRef.Upsert())
-
-	patchID := "abcdef012345"
-	patchSub := event.NewPatchOutcomeSubscription(patchID, event.NewCommitQueueDequeueSubscriber())
-	s.Require().NoError(patchSub.Upsert())
-
-	item := commitqueue.CommitQueueItem{
-		Issue: patchID,
-	}
-	_, err := s.queue.Enqueue(item)
-	s.Require().NoError(err)
-
-	mergeTask := &task.Task{Id: "t1", CommitQueueMerge: true, Version: patchID}
-	s.Require().NoError(mergeTask.Insert())
-
-	// Without a corresponding version
-	s.NoError(preventMergeForItem(s.projectRef.Identifier, &item))
-	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
-	s.NoError(err)
-	s.NotEmpty(subscriptions)
-
-	mergeTask, err = task.FindOneId("t1")
-	s.NoError(err)
-	s.Equal(int64(0), mergeTask.Priority)
-
-	// With a corresponding version
-	version := model.Version{Id: patchID}
-	s.Require().NoError(version.Insert())
-
-	s.NoError(preventMergeForItem(s.projectRef.Identifier, &item))
-	subscriptions, err = event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
-	s.NoError(err)
-	s.Empty(subscriptions)
-
-	mergeTask, err = task.FindOneId("t1")
-	s.NoError(err)
-	s.Equal(int64(-1), mergeTask.Priority)
-}
-
-func (s *CommitQueueSuite) TestClearVersionPatchSubscriber() {
-	s.Require().NoError(db.Clear(event.SubscriptionsCollection))
-
-	patchID := "abcdef012345"
-	patchSub := event.NewPatchOutcomeSubscription(patchID, event.NewCommitQueueDequeueSubscriber())
-	s.Require().NoError(patchSub.Upsert())
-
-	s.NoError(clearVersionPatchSubscriber(patchID, event.CommitQueueDequeueSubscriberType))
-	subs, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
-	s.NoError(err)
-	s.Empty(subs)
 }
 
 func (s *CommitQueueSuite) TestMockGetGitHubPR() {

--- a/service/version.go
+++ b/service/version.go
@@ -252,6 +252,12 @@ func (uis *UIServer) modifyVersion(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
+			if projCtx.ProjectRef.CommitQueue.Enabled {
+				_, err := model.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier, projCtx.Version.Id)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			}
 		}
 		if err = model.SetVersionActivation(projCtx.Version.Id, jsonMap.Active, user.Id); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/service/version.go
+++ b/service/version.go
@@ -258,7 +258,7 @@ func (uis *UIServer) modifyVersion(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		if !jsonMap.Active && projCtx.ProjectRef.CommitQueue.Enabled {
+		if !jsonMap.Active && projCtx.Version.Requester == evergreen.MergeTestRequester {
 			_, err := commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
 				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Version.Id, true)
 			if err != nil {


### PR DESCRIPTION
Most of this PR is moving "remove from commit queue" code from rest/data to model for use in service.