### PR TITLE
EVG-6625 Display modify instance type for spawn hosts

### DIFF
--- a/cloud/cloud_host.go
+++ b/cloud/cloud_host.go
@@ -39,6 +39,10 @@ func (cloudHost *CloudHost) IsUp(ctx context.Context) (bool, error) {
 	return cloudHost.CloudMgr.IsUp(ctx, cloudHost.Host)
 }
 
+func (cloudHost *CloudHost) ModifyHost(ctx context.Context, opts host.HostModifyOptions) error {
+	return cloudHost.CloudMgr.ModifyHost(ctx, cloudHost.Host, opts)
+}
+
 func (cloudHost *CloudHost) TerminateInstance(ctx context.Context, user, reason string) error {
 	return cloudHost.CloudMgr.TerminateInstance(ctx, cloudHost.Host, user, reason)
 }

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -239,6 +239,17 @@ func TerminateSpawnHost(ctx context.Context, host *host.Host, settings *evergree
 	return nil
 }
 
+func ModifySpawnHost(ctx context.Context, host *host.Host, opts host.HostModifyOptions, settings *evergreen.Settings) error {
+	cloudHost, err := GetCloudHost(ctx, host, settings)
+	if err != nil {
+		return err
+	}
+	if err = cloudHost.ModifyHost(ctx, opts); err != nil {
+		return err
+	}
+	return nil
+}
+
 func MakeExtendedSpawnHostExpiration(host *host.Host, extendBy time.Duration) (time.Time, error) {
 	newExp := host.ExpirationTime.Add(extendBy)
 	remainingDuration := newExp.Sub(time.Now()) //nolint

--- a/public/static/js/services/rest.js
+++ b/public/static/js/services/rest.js
@@ -249,6 +249,14 @@ mciServices.rest.factory('mciSpawnRestService', ['mciBaseRestService', function(
         baseSvc.getResource(resource, action, config, callbacks);
     };
 
+    service.getAllowedInstanceTypes = function(action, provider, params, callbacks) {
+        var config = {
+            params: params
+        }
+        config.params['provider'] = provider
+        baseSvc.getResource(resource, action, config, callbacks);
+    }
+
     service.spawnHost = function(spawnInfo, data, callbacks) {
         var config = {
             data: data
@@ -291,6 +299,16 @@ mciServices.rest.factory('mciSpawnRestService', ['mciBaseRestService', function(
         config.data['expiration'] = newExpiration;
         baseSvc.postResource(resource, [], config, callbacks);
     };
+
+    service.updateInstanceType = function(action, hostId, newInstanceType, data, callbacks) {
+        var config = {
+            data: data
+        };
+        config.data['action'] = action;
+        config.data['host_id'] = hostId;
+        config.data['instance_type'] = newInstanceType;
+        baseSvc.postResource(resource, [], config, callbacks);
+    }
 
     return service;
 }]);

--- a/public/static/js/spawned_hosts.js
+++ b/public/static/js/spawned_hosts.js
@@ -219,7 +219,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope','$window', '$timeout', 'mciSp
 
     $scope.updateInstanceType = function() {
       // Do nothing if no instance type selected
-      if ($scope.selectedInstanceType.length == 0) {
+      if (!$scope.selectedInstanceType) {
         return
       }
       // Do nothing if host is not stopped

--- a/public/static/partials/user_host_details.html
+++ b/public/static/partials/user_host_details.html
@@ -61,7 +61,7 @@
             </md-button>
         </div>
       </section>
-      <section layout="row" flex style="white-space: nowrap">
+      <section layout="row" flex ng-show="curHostData.host_type == 'ec2-ondemand' && curHostData.instance_type != ''" style="white-space: nowrap">
         <div flex="85">
           <strong>Instance Type:</strong>
           <span class="dropdown">

--- a/public/static/partials/user_host_details.html
+++ b/public/static/partials/user_host_details.html
@@ -61,5 +61,31 @@
             </md-button>
         </div>
       </section>
+      <section layout="row" flex style="white-space: nowrap">
+        <div flex="85">
+          <strong>Instance Type:</strong>
+          <span class="dropdown">
+            <button class="btn btn-link btn-dropdown" data-toggle="dropdown" href="#" id="distro">
+              <strong>
+                [[selectedInstanceType]]
+                <span class="fa fa-caret-down"></span>
+              </strong>
+          </button>
+          <ul class="dropdown-menu" role="menu" aria-labelledby="distro">
+            <li role="presentation" class="dropdown-header">Instance types</li>
+            <li role="presentation" ng-repeat="instanceType in allowedInstanceTypes">
+              <a role="menuitem" ng-click="setInstanceType(instanceType)">
+                [[instanceType]]
+              </a>
+            </li>
+          </ul>
+          </span>
+        </div>
+        <div flex="15">
+          <md-button type="button" class="btn-info md-raised" style="top: 8px; float: right" ng-click="updateInstanceType()">
+            Update
+          </md-button>
+      </div>
+    </section>
   </div>
 </div>

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -125,9 +125,10 @@ func (apiHost *APIHost) ToService() (interface{}, error) {
 }
 
 type APISpawnHostModify struct {
-	Action     APIString `json:"action"`
-	HostID     APIString `json:"host_id"`
-	RDPPwd     APIString `json:"rdp_pwd"`
-	AddHours   APIString `json:"add_hours"`
-	Expiration time.Time `json:"expiration"`
+	Action       APIString `json:"action"`
+	HostID       APIString `json:"host_id"`
+	RDPPwd       APIString `json:"rdp_pwd"`
+	AddHours     APIString `json:"add_hours"`
+	Expiration   time.Time `json:"expiration"`
+	InstanceType APIString `json:"instance_type"`
 }

--- a/service/ui.go
+++ b/service/ui.go
@@ -345,6 +345,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/spawn/hosts").Wrap(needsLogin, needsContext).Handler(uis.getSpawnedHosts).Get()
 	app.AddRoute("/spawn/distros").Wrap(needsLogin, needsContext).Handler(uis.listSpawnableDistros).Get()
 	app.AddRoute("/spawn/keys").Wrap(needsLogin, needsContext).Handler(uis.getUserPublicKeys).Get()
+	app.AddRoute("/spawn/types").Wrap(needsLogin, needsContext).Handler(uis.getAllowedInstanceTypes).Get()
 
 	// User settings
 	app.AddRoute("/settings").Wrap(needsLogin, needsContext).Handler(uis.userSettingsPage).Get()


### PR DESCRIPTION
This pull request adds a drop down menu under where you can configure spawn host expiration time that allows you to select a new instance type for your spawn host. It populates the list of instance types from the admin settings (which allow you to whitelist instance types on a per-provider basis). You'll get an error banner if you try to change the instance type of a host that isn't stopped.

<img width="1439" alt="Screen Shot 2019-10-09 at 6 09 50 PM" src="https://user-images.githubusercontent.com/23161985/66524293-06c98000-eac0-11e9-91a9-3ba4021b7c0a.png">
