### PR TITLE
EVG-6823: specify tasks in the same way as variants for patches

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-10-04"
+	ClientVersion = "2019-10-10"
 )
 
 // ConfigSection defines a sub-document in the evegreen config

--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-08-27"
+	ClientVersion = "2019-10-04"
 )
 
 // ConfigSection defines a sub-document in the evegreen config

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -134,7 +134,7 @@ func TestCLIFetchSource(t *testing.T) {
 			patchData:   testPatch,
 			description: "sample patch",
 			base:        "3c7bfeb82d492dc453e7431be664539c35b5db4b",
-			variants:    "all",
+			variants:    []string{"all"},
 			tasks:       []string{"all"},
 			finalize:    false,
 		}
@@ -370,7 +370,7 @@ func TestCLIFunctions(t *testing.T) {
 					patchData:   testPatch,
 					description: "sample patch",
 					base:        "3c7bfeb82d492dc453e7431be664539c35b5db4b",
-					variants:    "all",
+					variants:    []string{"all"},
 					tasks:       []string{"all"},
 					finalize:    false,
 				}
@@ -434,7 +434,7 @@ func TestCLIFunctions(t *testing.T) {
 					patchData:   testPatch,
 					description: "sample patch",
 					base:        "3c7bfeb82d492dc453e7431be664539c35b5db4b",
-					variants:    "all",
+					variants:    []string{"all"},
 					tasks:       []string{},
 					finalize:    false,
 				}
@@ -448,7 +448,7 @@ func TestCLIFunctions(t *testing.T) {
 					patchData:   testPatch,
 					description: "sample patch #2",
 					base:        "3c7bfeb82d492dc453e7431be664539c35b5db4b",
-					variants:    "osx-108",
+					variants:    []string{"osx-108"},
 					tasks:       []string{"failing_test"},
 					finalize:    false,
 				}
@@ -491,7 +491,7 @@ func TestCLIFunctions(t *testing.T) {
 					patchData:   emptyPatch,
 					description: "sample patch",
 					base:        "3c7bfeb82d492dc453e7431be664539c35b5db4b",
-					variants:    "all",
+					variants:    []string{"all"},
 					tasks:       []string{"all"},
 					finalize:    false}
 
@@ -561,7 +561,7 @@ func TestCLIFunctions(t *testing.T) {
 					patchData:   testPatch,
 					description: "sample patch #2",
 					base:        "3c7bfeb82d492dc453e7431be664539c35b5db4b",
-					variants:    "all",
+					variants:    []string{"all"},
 					tasks:       []string{"failing_test"},
 					finalize:    false,
 				}
@@ -590,7 +590,7 @@ func TestCLIFunctions(t *testing.T) {
 					patchData:   testPatch,
 					description: "sample patch #2",
 					base:        "3c7bfeb82d492dc453e7431be664539c35b5db4b",
-					variants:    "osx-108",
+					variants:    []string{"osx-108"},
 					tasks:       []string{"all"},
 					finalize:    false,
 				}

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -86,7 +86,7 @@ func addLargeFlag(flags ...cli.Flag) []cli.Flag {
 func addTasksFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.StringSliceFlag{
 		Name:  joinFlagNames(tasksFlagName, "t"),
-		Usage: "task name(s)",
+		Usage: "task names",
 	})
 }
 
@@ -100,7 +100,7 @@ func adminFlagFlag(flags ...cli.Flag) []cli.Flag {
 func addVariantsFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.StringSliceFlag{
 		Name:  joinFlagNames(variantsFlagName, "v"),
-		Usage: "variant name(s)",
+		Usage: "variant names",
 	})
 }
 

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -86,7 +86,7 @@ func addLargeFlag(flags ...cli.Flag) []cli.Flag {
 func addTasksFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.StringSliceFlag{
 		Name:  joinFlagNames(tasksFlagName, "t"),
-		Usage: "task name",
+		Usage: "task name(s)",
 	})
 }
 

--- a/operations/http.go
+++ b/operations/http.go
@@ -391,15 +391,14 @@ func (ac *legacyClient) ListDistros() ([]distro.Distro, error) {
 // the patch object itself.
 func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, error) {
 	data := struct {
-		Description string `json:"desc"`
-		Project     string `json:"project"`
-		Patch       string `json:"patch"`
-		Githash     string `json:"githash"`
-		// kim: TODO: do the below TODO
-		Variants []string `json:"buildvariants"` //TODO make this an array
-		Tasks    []string `json:"tasks"`
-		Finalize bool     `json:"finalize"`
-		Alias    string   `json:"alias"`
+		Description string   `json:"desc"`
+		Project     string   `json:"project"`
+		Patch       string   `json:"patch"`
+		Githash     string   `json:"githash"`
+		Variants    []string `json:"buildvariants"`
+		Tasks       []string `json:"tasks"`
+		Finalize    bool     `json:"finalize"`
+		Alias       string   `json:"alias"`
 	}{
 		incomingPatch.description,
 		incomingPatch.projectId,

--- a/operations/http.go
+++ b/operations/http.go
@@ -391,11 +391,13 @@ func (ac *legacyClient) ListDistros() ([]distro.Distro, error) {
 // the patch object itself.
 func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, error) {
 	data := struct {
-		Description string   `json:"desc"`
-		Project     string   `json:"project"`
-		Patch       string   `json:"patch"`
-		Githash     string   `json:"githash"`
-		Variants    []string `json:"buildvariants"`
+		Description string `json:"desc"`
+		Project     string `json:"project"`
+		Patch       string `json:"patch"`
+		Githash     string `json:"githash"`
+		// TODO: remove this once users have been given enough time to update their binary versions.
+		Variants    string   `json:"buildvariants"`
+		VariantsNew []string `json:"buildvariants_new"`
 		Tasks       []string `json:"tasks"`
 		Finalize    bool     `json:"finalize"`
 		Alias       string   `json:"alias"`
@@ -404,7 +406,8 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		incomingPatch.projectId,
 		incomingPatch.patchData,
 		incomingPatch.base,
-		incomingPatch.variants,
+		strings.Join(incomingPatch.variants, ","),
+		incomingPatch.variantsNew,
 		incomingPatch.tasks,
 		incomingPatch.finalize,
 		incomingPatch.alias,

--- a/operations/http.go
+++ b/operations/http.go
@@ -407,7 +407,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		incomingPatch.patchData,
 		incomingPatch.base,
 		strings.Join(incomingPatch.variants, ","),
-		incomingPatch.variantsNew,
+		incomingPatch.variants,
 		incomingPatch.tasks,
 		incomingPatch.finalize,
 		incomingPatch.alias,

--- a/operations/http.go
+++ b/operations/http.go
@@ -391,14 +391,15 @@ func (ac *legacyClient) ListDistros() ([]distro.Distro, error) {
 // the patch object itself.
 func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, error) {
 	data := struct {
-		Description string   `json:"desc"`
-		Project     string   `json:"project"`
-		Patch       string   `json:"patch"`
-		Githash     string   `json:"githash"`
-		Variants    string   `json:"buildvariants"` //TODO make this an array
-		Tasks       []string `json:"tasks"`
-		Finalize    bool     `json:"finalize"`
-		Alias       string   `json:"alias"`
+		Description string `json:"desc"`
+		Project     string `json:"project"`
+		Patch       string `json:"patch"`
+		Githash     string `json:"githash"`
+		// kim: TODO: do the below TODO
+		Variants []string `json:"buildvariants"` //TODO make this an array
+		Tasks    []string `json:"tasks"`
+		Finalize bool     `json:"finalize"`
+		Alias    string   `json:"alias"`
 	}{
 		incomingPatch.description,
 		incomingPatch.projectId,

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -3,8 +3,8 @@ package operations
 import (
 	"context"
 	"io/ioutil"
-	"strings"
 
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -54,8 +54,8 @@ func Patch() cli.Command {
 			args := c.Args()
 			params := &patchParams{
 				Project:     c.String(projectFlagName),
-				Variants:    splitCommas(c.StringSlice(variantsFlagName)),
-				Tasks:       splitCommas(c.StringSlice(tasksFlagName)),
+				Variants:    util.SplitCommas(c.StringSlice(variantsFlagName)),
+				Tasks:       util.SplitCommas(c.StringSlice(tasksFlagName)),
 				SkipConfirm: c.Bool(yesFlagName),
 				Description: c.String(patchDescriptionFlagName),
 				Finalize:    c.Bool(patchFinalizeFlagName),
@@ -132,8 +132,8 @@ func PatchFile() cli.Command {
 			confPath := c.Parent().String(confFlagName)
 			params := &patchParams{
 				Project:     c.String(projectFlagName),
-				Variants:    splitCommas(c.StringSlice(variantsFlagName)),
-				Tasks:       splitCommas(c.StringSlice(tasksFlagName)),
+				Variants:    util.SplitCommas(c.StringSlice(variantsFlagName)),
+				Tasks:       util.SplitCommas(c.StringSlice(tasksFlagName)),
 				Alias:       c.String(patchAliasFlagName),
 				SkipConfirm: c.Bool(yesFlagName),
 				Description: c.String(patchDescriptionFlagName),
@@ -175,12 +175,4 @@ func PatchFile() cli.Command {
 			return err
 		},
 	}
-}
-
-func splitCommas(originals []string) []string {
-	splitted := []string{}
-	for _, original := range originals {
-		splitted = append(splitted, strings.Split(original, ",")...)
-	}
-	return splitted
 }

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -3,6 +3,7 @@ package operations
 import (
 	"context"
 	"io/ioutil"
+	"strings"
 
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -53,8 +54,8 @@ func Patch() cli.Command {
 			args := c.Args()
 			params := &patchParams{
 				Project:     c.String(projectFlagName),
-				Variants:    c.StringSlice(variantsFlagName),
-				Tasks:       c.StringSlice(tasksFlagName),
+				Variants:    splitCommas(c.StringSlice(variantsFlagName)),
+				Tasks:       splitSlices(c.StringSlice(tasksFlagName)),
 				SkipConfirm: c.Bool(yesFlagName),
 				Description: c.String(patchDescriptionFlagName),
 				Finalize:    c.Bool(patchFinalizeFlagName),
@@ -131,8 +132,8 @@ func PatchFile() cli.Command {
 			confPath := c.Parent().String(confFlagName)
 			params := &patchParams{
 				Project:     c.String(projectFlagName),
-				Variants:    c.StringSlice(variantsFlagName),
-				Tasks:       c.StringSlice(tasksFlagName),
+				Variants:    splitCommas(c.StringSlice(variantsFlagName)),
+				Tasks:       splitCommas(c.StringSlice(tasksFlagName)),
 				Alias:       c.String(patchAliasFlagName),
 				SkipConfirm: c.Bool(yesFlagName),
 				Description: c.String(patchDescriptionFlagName),
@@ -174,4 +175,12 @@ func PatchFile() cli.Command {
 			return err
 		},
 	}
+}
+
+func splitCommas(originals []string) []string {
+	splitted := []string{}
+	for _, original := range originals {
+		splitted = append(splitted, strings.Split(original, ",")...)
+	}
+	return splitted
 }

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -55,7 +55,7 @@ func Patch() cli.Command {
 			params := &patchParams{
 				Project:     c.String(projectFlagName),
 				Variants:    splitCommas(c.StringSlice(variantsFlagName)),
-				Tasks:       splitSlices(c.StringSlice(tasksFlagName)),
+				Tasks:       splitCommas(c.StringSlice(tasksFlagName)),
 				SkipConfirm: c.Bool(yesFlagName),
 				Description: c.String(patchDescriptionFlagName),
 				Finalize:    c.Bool(patchFinalizeFlagName),

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -70,9 +70,11 @@ type patchSubmission struct {
 	description string
 	base        string
 	alias       string
-	variants    string
-	tasks       []string
-	finalize    bool
+	// kim: TODO: remove
+	// variants    string
+	variants []string
+	tasks    []string
+	finalize bool
 }
 
 func (p *patchParams) createPatch(ac *legacyClient, conf *ClientSettings, diffData *localDiff) (*patch.Patch, error) {
@@ -94,16 +96,19 @@ func (p *patchParams) createPatch(ac *legacyClient, conf *ClientSettings, diffDa
 		}
 	}
 
-	variantsStr := strings.Join(p.Variants, ",")
+	// kim: TODO: remove
+	// variantsStr := strings.Join(p.Variants, ",")
 	patchSub := patchSubmission{
 		projectId:   p.Project,
 		patchData:   diffData.fullPatch,
 		description: p.Description,
 		base:        diffData.base,
-		variants:    variantsStr,
-		tasks:       p.Tasks,
-		finalize:    p.Finalize,
-		alias:       p.Alias,
+		// kim: TODO: remove
+		// variants:    variantsStr,
+		variants: p.Variants,
+		tasks:    p.Tasks,
+		finalize: p.Finalize,
+		alias:    p.Alias,
 	}
 
 	newPatch, err := ac.PutPatch(patchSub)

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -70,11 +70,9 @@ type patchSubmission struct {
 	description string
 	base        string
 	alias       string
-	// kim: TODO: remove
-	// variants    string
-	variants []string
-	tasks    []string
-	finalize bool
+	variants    []string
+	tasks       []string
+	finalize    bool
 }
 
 func (p *patchParams) createPatch(ac *legacyClient, conf *ClientSettings, diffData *localDiff) (*patch.Patch, error) {
@@ -96,19 +94,15 @@ func (p *patchParams) createPatch(ac *legacyClient, conf *ClientSettings, diffDa
 		}
 	}
 
-	// kim: TODO: remove
-	// variantsStr := strings.Join(p.Variants, ",")
 	patchSub := patchSubmission{
 		projectId:   p.Project,
 		patchData:   diffData.fullPatch,
 		description: p.Description,
 		base:        diffData.base,
-		// kim: TODO: remove
-		// variants:    variantsStr,
-		variants: p.Variants,
-		tasks:    p.Tasks,
-		finalize: p.Finalize,
-		alias:    p.Alias,
+		variants:    p.Variants,
+		tasks:       p.Tasks,
+		finalize:    p.Finalize,
+		alias:       p.Alias,
 	}
 
 	newPatch, err := ac.PutPatch(patchSub)

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -35,11 +35,13 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	dbUser := MustHaveUser(r)
 
 	data := struct {
-		Description string   `json:"desc"`
-		Project     string   `json:"project"`
-		Patch       string   `json:"patch"`
-		Githash     string   `json:"githash"`
-		Variants    string   `json:"buildvariants"`
+		Description string `json:"desc"`
+		Project     string `json:"project"`
+		Patch       string `json:"patch"`
+		Githash     string `json:"githash"`
+		// kim: TODO: remove
+		// Variants    string `json:"buildvariants"`
+		Variants    []string `json:"buildvariants"`
 		Tasks       []string `json:"tasks"`
 		Finalize    bool     `json:"finalize"`
 		Alias       string   `json:"alias"`
@@ -53,7 +55,8 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.New("Patch is too large"))
 		return
 	}
-	variants := strings.Split(data.Variants, ",")
+	// kim: TODO: remove
+	// variants := strings.Split(data.Variants, ",")
 
 	pref, err := model.FindOneProjectRef(data.Project)
 	if err != nil {
@@ -74,7 +77,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	intent, err := patch.NewCliIntent(dbUser.Id, data.Project, data.Githash, r.FormValue("module"), data.Patch, data.Description, data.Finalize, variants, data.Tasks, data.Alias)
+	intent, err := patch.NewCliIntent(dbUser.Id, data.Project, data.Githash, r.FormValue("module"), data.Patch, data.Description, data.Finalize, data.Variants, data.Tasks, data.Alias)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, err)
 		return

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -35,11 +35,14 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	dbUser := MustHaveUser(r)
 
 	data := struct {
-		Description string   `json:"desc"`
-		Project     string   `json:"project"`
-		Patch       string   `json:"patch"`
-		Githash     string   `json:"githash"`
-		Variants    []string `json:"buildvariants"`
+		Description string `json:"desc"`
+		Project     string `json:"project"`
+		Patch       string `json:"patch"`
+		Githash     string `json:"githash"`
+		// TODO: remove this once users have been given enough time to update
+		// their binary versions.
+		Variants    string   `json:"buildvariants"`
+		VariantsNew []string `json:"buildvariants_new"`
 		Tasks       []string `json:"tasks"`
 		Finalize    bool     `json:"finalize"`
 		Alias       string   `json:"alias"`
@@ -52,6 +55,10 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	if len(data.Patch) > patch.SizeLimit {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.New("Patch is too large"))
 		return
+	}
+	variants := strings.Split(data.Variants, ",")
+	if len(data.VariantsNew) != 0 {
+		variants = data.VariantsNew
 	}
 
 	pref, err := model.FindOneProjectRef(data.Project)
@@ -73,7 +80,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	intent, err := patch.NewCliIntent(dbUser.Id, data.Project, data.Githash, r.FormValue("module"), data.Patch, data.Description, data.Finalize, data.Variants, data.Tasks, data.Alias)
+	intent, err := patch.NewCliIntent(dbUser.Id, data.Project, data.Githash, r.FormValue("module"), data.Patch, data.Description, data.Finalize, variants, data.Tasks, data.Alias)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, err)
 		return

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -35,12 +35,10 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	dbUser := MustHaveUser(r)
 
 	data := struct {
-		Description string `json:"desc"`
-		Project     string `json:"project"`
-		Patch       string `json:"patch"`
-		Githash     string `json:"githash"`
-		// kim: TODO: remove
-		// Variants    string `json:"buildvariants"`
+		Description string   `json:"desc"`
+		Project     string   `json:"project"`
+		Patch       string   `json:"patch"`
+		Githash     string   `json:"githash"`
 		Variants    []string `json:"buildvariants"`
 		Tasks       []string `json:"tasks"`
 		Finalize    bool     `json:"finalize"`
@@ -55,8 +53,6 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.New("Patch is too large"))
 		return
 	}
-	// kim: TODO: remove
-	// variants := strings.Split(data.Variants, ",")
 
 	pref, err := model.FindOneProjectRef(data.Project)
 	if err != nil {

--- a/util/slice.go
+++ b/util/slice.go
@@ -1,5 +1,7 @@
 package util
 
+import "strings"
+
 // StringSliceContains determines if a string is in a slice
 func StringSliceContains(slice []string, item string) bool {
 	if len(slice) == 0 {
@@ -43,4 +45,14 @@ func UniqueStrings(slice []string) []string {
 		out = append(out, s)
 	}
 	return out
+}
+
+// SplitCommas returns the slice of strings after splitting each string by
+// commas.
+func SplitCommas(originals []string) []string {
+	splitted := []string{}
+	for _, original := range originals {
+		splitted = append(splitted, strings.Split(original, ",")...)
+	}
+	return splitted
 }

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringSliceIntersection(t *testing.T) {
@@ -32,4 +33,22 @@ func TestUniqueStrings(t *testing.T) {
 			So(out, ShouldResemble, []string{"a", "b", "c"})
 		})
 	})
+}
+
+func TestSplitCommas(t *testing.T) {
+	for testName, testCase := range map[string]func(t *testing.T){
+		"ReturnsUnmodifiedStringsWithoutCommas": func(t *testing.T) {
+			input := []string{"foo", "bar", "bat"}
+			assert.Equal(t, input, SplitCommas(input))
+		},
+		"ReturnsSplitCommaStrings": func(t *testing.T) {
+			input := []string{"foo,bar", "bat", "baz,qux,quux"}
+			expected := []string{"foo", "bar", "bat", "baz", "qux", "quux"}
+			assert.Equal(t, expected, SplitCommas(input))
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			testCase(t)
+		})
+	}
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6823

Somebody asked for the `--task` behavior to be the same as the `--variant` behavior, so this should do  that. For some reason, the variants are joined into a string on the client side, then split again on the server side, which allows specifying variants as a comma-separated list.

This change permits that behavior for tasks as well, but it also requires that all users update their evergreen binary, or else they will send the wrong payload (variants will be a string instead of string slice) to the server.