### PR TITLE
EVG-6668 prevent notifications for system unresponsive and stranded tasks

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -71,6 +71,10 @@ const (
 	CommandTypeSystem = "system"
 	CommandTypeSetup  = "setup"
 
+	// Task descriptions
+	TaskDescriptionHeartbeat = "heartbeat"
+	TaskDescriptionStranded = "stranded"
+
 	// Task Statuses that are currently used only by the UI, and in tests
 	// (these may be used in old tasks)
 	TaskSystemUnresponse = "system-unresponsive"

--- a/model/build/build_test.go
+++ b/model/build/build_test.go
@@ -739,7 +739,7 @@ func TestBuildSetCachedTaskFinished(t *testing.T) {
 
 	detail := apimodels.TaskEndDetail{
 		Status: evergreen.TaskFailed,
-		Type:   "system",
+		Type:   evergreen.CommandTypeSystem,
 	}
 	timeTaken := 10 * time.Minute
 

--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -510,11 +510,11 @@ func getDailyTaskStatsPipeline(projectId string, requester string, start time.Ti
 				bson.M{"$ne": Array{bsonutil.GetDottedKeyName(taskDetailsKeyRef, task.TaskEndDetailTimedOut), true}}}}),
 			DbTaskStatsNumSystemFailedKey: makeSum(bson.M{"$and": Array{
 				bson.M{"$eq": Array{taskStatusKeyRef, "failed"}},
-				bson.M{"$eq": Array{bsonutil.GetDottedKeyName(taskDetailsKeyRef, task.TaskEndDetailType), "system"}},
+				bson.M{"$eq": Array{bsonutil.GetDottedKeyName(taskDetailsKeyRef, task.TaskEndDetailType), evergreen.CommandTypeSystem}},
 				bson.M{"$ne": Array{bsonutil.GetDottedKeyName(taskDetailsKeyRef, task.TaskEndDetailTimedOut), true}}}}),
 			DbTaskStatsNumSetupFailedKey: makeSum(bson.M{"$and": Array{
 				bson.M{"$eq": Array{taskStatusKeyRef, "failed"}},
-				bson.M{"$eq": Array{bsonutil.GetDottedKeyName(taskDetailsKeyRef, task.TaskEndDetailType), "setup"}},
+				bson.M{"$eq": Array{bsonutil.GetDottedKeyName(taskDetailsKeyRef, task.TaskEndDetailType), evergreen.CommandTypeSetup}},
 				bson.M{"$ne": Array{bsonutil.GetDottedKeyName(taskDetailsKeyRef, task.TaskEndDetailTimedOut), true}}}}),
 			DbTaskStatsAvgDurationSuccessKey: bson.M{"$avg": bson.M{"$cond": bson.M{"if": bson.M{"$eq": Array{taskStatusKeyRef, "success"}},
 				"then": "$time_taken", "else": "IGNORE"}}}}},

--- a/model/task/results.go
+++ b/model/task/results.go
@@ -27,16 +27,16 @@ func (t *Task) ResultStatus() string {
 		status = evergreen.TaskSucceeded
 	} else if t.Status == evergreen.TaskFailed {
 		status = evergreen.TaskFailed
-		if t.Details.Type == "system" {
+		if t.Details.Type == evergreen.CommandTypeSystem {
 			status = evergreen.TaskSystemFailed
 			if t.Details.TimedOut {
-				if t.Details.Description == "heartbeat" {
+				if t.Details.Description == evergreen.TaskDescriptionHeartbeat {
 					status = evergreen.TaskSystemUnresponse
 				} else {
 					status = evergreen.TaskSystemTimedOut
 				}
 			}
-		} else if t.Details.Type == "setup" {
+		} else if t.Details.Type == evergreen.CommandTypeSetup {
 			status = evergreen.TaskSetupFailed
 		} else if t.Details.TimedOut {
 			status = evergreen.TaskTestTimedOut

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -43,8 +43,6 @@ const (
 )
 
 var (
-	AgentHeartbeat = "heartbeat"
-
 	// A regex that matches either / or \ for splitting directory paths
 	// on either windows or linux paths.
 	eitherSlash *regexp.Regexp = regexp.MustCompile(`[/\\]`)
@@ -1682,7 +1680,7 @@ func (tsc *TaskStatusCount) IncrementStatus(status string, statusDetails apimode
 	case evergreen.TaskSucceeded:
 		tsc.Succeeded++
 	case evergreen.TaskFailed, evergreen.TaskSetupFailed:
-		if statusDetails.TimedOut && statusDetails.Description == "heartbeat" {
+		if statusDetails.TimedOut && statusDetails.Description == evergreen.TaskDescriptionHeartbeat {
 			tsc.TimedOut++
 		} else {
 			tsc.Failed++

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -625,16 +625,16 @@ func TestTaskResultOutcome(t *testing.T) {
 	assert := assert.New(t)
 
 	tasks := []Task{
-		{Status: evergreen.TaskUndispatched, Activated: false},                                                                     // 0
-		{Status: evergreen.TaskUndispatched, Activated: true},                                                                      // 1
-		{Status: evergreen.TaskStarted},                                                                                            // 2
-		{Status: evergreen.TaskSucceeded},                                                                                          // 3
-		{Status: evergreen.TaskFailed},                                                                                             // 4
-		{Status: evergreen.TaskFailed, Details: apimodels.TaskEndDetail{Type: "system"}},                                           // 5
-		{Status: evergreen.TaskFailed, Details: apimodels.TaskEndDetail{Type: "system", TimedOut: true}},                           // 6
-		{Status: evergreen.TaskFailed, Details: apimodels.TaskEndDetail{Type: "system", TimedOut: true, Description: "heartbeat"}}, // 7
-		{Status: evergreen.TaskFailed, Details: apimodels.TaskEndDetail{TimedOut: true, Description: "heartbeat"}},                 // 8
-		{Status: evergreen.TaskSetupFailed, Details: apimodels.TaskEndDetail{Type: "setup"}},                                       // 5
+		{Status: evergreen.TaskUndispatched, Activated: false}, // 0
+		{Status: evergreen.TaskUndispatched, Activated: true},  // 1
+		{Status: evergreen.TaskStarted},                        // 2
+		{Status: evergreen.TaskSucceeded},                      // 3
+		{Status: evergreen.TaskFailed},                         // 4
+		{Status: evergreen.TaskFailed, Details: apimodels.TaskEndDetail{Type: evergreen.CommandTypeSystem}},                                                                  // 5
+		{Status: evergreen.TaskFailed, Details: apimodels.TaskEndDetail{Type: evergreen.CommandTypeSystem, TimedOut: true}},                                                  // 6
+		{Status: evergreen.TaskFailed, Details: apimodels.TaskEndDetail{Type: evergreen.CommandTypeSystem, TimedOut: true, Description: evergreen.TaskDescriptionHeartbeat}}, // 7
+		{Status: evergreen.TaskFailed, Details: apimodels.TaskEndDetail{TimedOut: true, Description: evergreen.TaskDescriptionHeartbeat}},                                    // 8
+		{Status: evergreen.TaskSetupFailed, Details: apimodels.TaskEndDetail{Type: evergreen.CommandTypeSetup}},                                                              // 5
 	}
 
 	out := GetResultCounts(tasks)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -855,7 +855,7 @@ func TestTaskStatusCount(t *testing.T) {
 	counts := TaskStatusCount{}
 	details := apimodels.TaskEndDetail{
 		TimedOut:    true,
-		Description: "heartbeat",
+		Description: evergreen.TaskDescriptionHeartbeat,
 	}
 	counts.IncrementStatus(evergreen.TaskSetupFailed, details)
 	counts.IncrementStatus(evergreen.TaskFailed, apimodels.TaskEndDetail{})

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -964,7 +964,7 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 	t.Details = apimodels.TaskEndDetail{
 		Description: evergreen.TaskDescriptionStranded,
 		Status:      evergreen.TaskFailed,
-		Type:        "system",
+		Type:        evergreen.CommandTypeSystem,
 	}
 
 	if err = t.MarkSystemFailed(); err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -961,6 +961,12 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 		return nil
 	}
 
+	t.Details = apimodels.TaskEndDetail{
+		Description: evergreen.TaskDescriptionStranded,
+		Status:      evergreen.TaskFailed,
+		Type:        "system",
+	}
+
 	if err = t.MarkSystemFailed(); err != nil {
 		return errors.Wrap(err, "problem marking task failed")
 	}
@@ -968,10 +974,6 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 		return errors.Wrap(err, "problem resetting cached task")
 	}
 
-	detail := &apimodels.TaskEndDetail{
-		Status: evergreen.TaskFailed,
-		Type:   "system",
-	}
 	if time.Since(t.ActivatedTime) > task.UnschedulableThreshold {
 		updates := StatusChanges{}
 		if t.DisplayOnly {
@@ -980,19 +982,19 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 				if err != nil {
 					return errors.Wrap(err, "error finding execution task")
 				}
-				if err = MarkEnd(execTask, evergreen.MonitorPackage, time.Now(), detail, false, &updates); err != nil {
+				if err = MarkEnd(execTask, evergreen.MonitorPackage, time.Now(), &t.Details, false, &updates); err != nil {
 					return errors.Wrap(err, "error marking execution task as ended")
 				}
 			}
 		}
-		return errors.WithStack(MarkEnd(t, evergreen.MonitorPackage, time.Now(), detail, false, &updates))
+		return errors.WithStack(MarkEnd(t, evergreen.MonitorPackage, time.Now(), &t.Details, false, &updates))
 	}
 
 	if t.IsPartOfDisplay() {
 		return t.DisplayTask.SetResetWhenFinished()
 	}
 
-	return errors.Wrap(TryResetTask(t.Id, "mci", evergreen.MonitorPackage, detail), "problem resetting task")
+	return errors.Wrap(TryResetTask(t.Id, "mci", evergreen.MonitorPackage, &t.Details), "problem resetting task")
 }
 
 func UpdateDisplayTask(t *task.Task) error {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2028,7 +2028,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 
 	details := &apimodels.TaskEndDetail{
 		Status: evergreen.TaskFailed,
-		Type:   "system",
+		Type:   evergreen.CommandTypeSystem,
 	}
 
 	updates := StatusChanges{}

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -287,9 +287,9 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 				Status:    evergreen.TaskFailed,
 				StatusDetails: apimodels.TaskEndDetail{
 					Status:      evergreen.TaskFailed,
-					Type:        "system",
+					Type:        evergreen.CommandTypeSystem,
 					TimedOut:    true,
-					Description: "heartbeat",
+					Description: evergreen.TaskDescriptionHeartbeat,
 				},
 			},
 			{

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -453,6 +453,12 @@ func isTaskRegression(sub *event.Subscription, t *task.Task) (bool, *alertrecord
 	if t.Status != evergreen.TaskFailed || !util.StringSliceContains(evergreen.SystemVersionRequesterTypes, t.Requester) {
 		return false, nil, nil
 	}
+
+	// Regressions are not actionable if they're caused by a host that was terminated or an agent that died
+	if t.Details.Description == evergreen.TaskDescriptionStranded || t.Details.Description == evergreen.TaskDescriptionHeartbeat {
+		return false, nil, nil
+	}
+
 	if !matchingFailureType(sub.TriggerData[keyFailureType], t.Details.Type) {
 		return false, nil, nil
 	}
@@ -851,6 +857,12 @@ func (t *taskTriggers) buildBreak(sub *event.Subscription) (*notification.Notifi
 	if t.task.Status != evergreen.TaskFailed || !util.StringSliceContains(evergreen.SystemVersionRequesterTypes, t.task.Requester) {
 		return nil, nil
 	}
+
+	// Regressions are not actionable if they're caused by a host that was terminated or an agent that died
+	if t.task.Details.Description == evergreen.TaskDescriptionStranded || t.task.Details.Description == evergreen.TaskDescriptionHeartbeat {
+		return nil, nil
+	}
+
 	if t.task.TriggerID != "" && sub.Owner != "" { // don't notify committer for a triggered build
 		return nil, nil
 	}

--- a/trigger/task_jira.go
+++ b/trigger/task_jira.go
@@ -102,7 +102,7 @@ func makeSpecificTaskStatus(t *task.Task) string {
 		return evergreen.TaskSucceeded
 	}
 	if t.Details.Type == evergreen.CommandTypeSystem {
-		if t.Details.TimedOut && t.Details.Description == "heartbeat" {
+		if t.Details.TimedOut && t.Details.Description == evergreen.TaskDescriptionHeartbeat {
 			return evergreen.TaskSystemUnresponse
 		}
 		if t.Details.TimedOut {

--- a/trigger/task_jira_test.go
+++ b/trigger/task_jira_test.go
@@ -495,7 +495,7 @@ func TestMakeSpecificTaskStatus(t *testing.T) {
 	doc.Details.TimedOut = true
 	assert.Equal(evergreen.TaskSystemTimedOut, makeSpecificTaskStatus(doc))
 
-	doc.Details.Description = "heartbeat"
+	doc.Details.Description = evergreen.TaskDescriptionHeartbeat
 	assert.Equal(evergreen.TaskSystemUnresponse, makeSpecificTaskStatus(doc))
 }
 
@@ -521,7 +521,7 @@ func TestMakeSummaryPrefix(t *testing.T) {
 	doc.Details.Type = evergreen.CommandTypeSystem
 	assert.Equal("System Timed Out: ", makeSummaryPrefix(doc, 0))
 
-	doc.Details.Description = "heartbeat"
+	doc.Details.Description = evergreen.TaskDescriptionHeartbeat
 	assert.Equal("System Unresponsive: ", makeSummaryPrefix(doc, 0))
 
 	doc.Details.TimedOut = false

--- a/trigger/task_jira_test.go
+++ b/trigger/task_jira_test.go
@@ -421,7 +421,7 @@ func TestCustomFields(t *testing.T) {
 				BuildVariant: "build12",
 				DisplayName:  taskName,
 				Details: apimodels.TaskEndDetail{
-					Type: "system",
+					Type: evergreen.CommandTypeSystem,
 				},
 				Project:  projectId,
 				Revision: versionRevision,

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -1138,18 +1138,25 @@ func (s *taskSuite) TestBuildBreak() {
 
 	// successful task should not trigger
 	s.task.Status = evergreen.TaskSucceeded
-	n, err := s.t.buildBreak(&s.subs[5])
+	n, err := s.t.buildBreak(&s.subs[6])
+	s.NoError(err)
+	s.Nil(n)
+
+	// system unresponsive shouldn't trigger
+	s.task.Status = evergreen.TaskFailed
+	s.task.Details.Description = evergreen.TaskDescriptionHeartbeat
+	n, err = s.t.buildBreak(&s.subs[6])
 	s.NoError(err)
 	s.Nil(n)
 
 	// task regression should trigger
-	s.task.Status = evergreen.TaskFailed
-	n, err = s.t.buildBreak(&s.subs[5])
+	s.task.Details.Description = ""
+	n, err = s.t.buildBreak(&s.subs[6])
 	s.NoError(err)
 	s.NotNil(n)
 
 	// another regression in the same version should not trigger
-	n, err = s.t.buildBreak(&s.subs[5])
+	n, err = s.t.buildBreak(&s.subs[6])
 	s.NoError(err)
 	s.Nil(n)
 }

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -185,7 +185,7 @@ func cleanUpTimedOutTask(t *task.Task) error {
 	}
 
 	detail := &apimodels.TaskEndDetail{
-		Description: task.AgentHeartbeat,
+		Description: evergreen.TaskDescriptionHeartbeat,
 		Type:        evergreen.CommandTypeSystem,
 		TimedOut:    true,
 		Status:      evergreen.TaskFailed,


### PR DESCRIPTION
Since system unresponsive and stranded tasks are always an Evergreen problem, it's incorrect for them to trigger build break and regression notifications.
Additionally, notifications for these events are annoying since the tasks are automatically restarted.