### PR TITLE
EVG-6376 enforce project permissions in some routes

### DIFF
--- a/auth/user.go
+++ b/auth/user.go
@@ -1,5 +1,9 @@
 package auth
 
+import (
+	"github.com/evergreen-ci/gimlet"
+)
+
 type simpleUser struct {
 	UserId       string
 	Name         string
@@ -8,10 +12,10 @@ type simpleUser struct {
 	SiteRoles    []string
 }
 
-func (u *simpleUser) DisplayName() string                             { return u.Name }
-func (u *simpleUser) Email() string                                   { return u.EmailAddress }
-func (u *simpleUser) Username() string                                { return u.UserId }
-func (u *simpleUser) IsNil() bool                                     { return u == nil }
-func (u *simpleUser) GetAPIKey() string                               { return u.APIKey }
-func (u *simpleUser) Roles() []string                                 { out := []string{}; copy(out, u.SiteRoles); return out }
-func (u *simpleUser) HasPermission(string, string, int) (bool, error) { return true, nil }
+func (u *simpleUser) DisplayName() string                               { return u.Name }
+func (u *simpleUser) Email() string                                     { return u.EmailAddress }
+func (u *simpleUser) Username() string                                  { return u.UserId }
+func (u *simpleUser) IsNil() bool                                       { return u == nil }
+func (u *simpleUser) GetAPIKey() string                                 { return u.APIKey }
+func (u *simpleUser) Roles() []string                                   { out := []string{}; copy(out, u.SiteRoles); return out }
+func (u *simpleUser) HasPermission(gimlet.PermissionOpts) (bool, error) { return true, nil }

--- a/glide.lock
+++ b/glide.lock
@@ -116,7 +116,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: 6cc2541dc7dbad9c3472dc16de975270d60ee9de
   - name: github.com/evergreen-ci/gimlet
-    version: 89a2b9939febcabe169dd6a4dfc6ffc62b7beba8
+    version: 8ac93572158994c5a69c3ac6085c1cf7c3172deb
   - name: github.com/evergreen-ci/shrub
     version: 32e668cd99410328bf6659e55671c11a6c727d9a
   - name: github.com/evergreen-ci/pail

--- a/globals.go
+++ b/globals.go
@@ -471,8 +471,18 @@ func IsGitHubPatchRequester(requester string) bool {
 	return requester == GithubPRRequester || requester == MergeTestRequester
 }
 
-// Registered permissions
-const AclCheckingIsEnabled = false
+// Permissions-related constants
+var AclCheckingIsEnabled = false
+
+type PermissionLevel interface {
+	String() string
+	Value() int
+}
+type ProjectSettingsPermission int
+type ProjectVariablesPermission int
+type TasksPermission int
+type PatchPermission int
+type LogsPermission int
 
 const (
 	PermissionProjectSettings  = "project_settings"
@@ -481,21 +491,90 @@ const (
 	PermissionPatches          = "project_patches"
 	PermissionLogs             = "project_logs"
 
-	ProjectSettingsEdit  = 20
-	ProjectSettingsView  = 10
-	ProjectSettingsNone  = 0
-	ProjectVariablesEdit = 20
-	ProjectVariablesView = 10
-	ProjectVariablesNone = 0
-	TasksAdmin           = 30
-	TasksBasic           = 20
-	TasksView            = 10
-	TasksNone            = 0
-	PatchSubmit          = 10
-	PatchNone            = 0
-	LogsView             = 10
-	LogsNone             = 0
+	ProjectSettingsEdit  ProjectSettingsPermission  = 20
+	ProjectSettingsView  ProjectSettingsPermission  = 10
+	ProjectSettingsNone  ProjectSettingsPermission  = 0
+	ProjectVariablesEdit ProjectVariablesPermission = 20
+	ProjectVariablesView ProjectVariablesPermission = 10
+	ProjectVariablesNone ProjectVariablesPermission = 0
+	TasksAdmin           TasksPermission            = 30
+	TasksBasic           TasksPermission            = 20
+	TasksView            TasksPermission            = 10
+	TasksNone            TasksPermission            = 0
+	PatchSubmit          PatchPermission            = 10
+	PatchNone            PatchPermission            = 0
+	LogsView             LogsPermission             = 10
+	LogsNone             LogsPermission             = 0
 )
+
+func (p ProjectSettingsPermission) String() string {
+	switch p {
+	case ProjectSettingsEdit:
+		return "Edit project settings"
+	case ProjectSettingsView:
+		return "View project settings"
+	case ProjectSettingsNone:
+		return "No project settings permissions"
+	}
+	return ""
+}
+func (p ProjectSettingsPermission) Value() int {
+	return int(p)
+}
+func (p ProjectVariablesPermission) String() string {
+	switch p {
+	case ProjectVariablesEdit:
+		return "Edit project variables"
+	case ProjectVariablesView:
+		return "View project variables"
+	case ProjectVariablesNone:
+		return "No project variables permissions"
+	}
+	return ""
+}
+func (p ProjectVariablesPermission) Value() int {
+	return int(p)
+}
+func (p TasksPermission) String() string {
+	switch p {
+	case TasksAdmin:
+		return "Full tasks permissions"
+	case TasksBasic:
+		return "Basic modifications to tasks"
+	case TasksView:
+		return "View tasks"
+	case TasksNone:
+		return "Not able to view or edit tasks"
+	}
+	return ""
+}
+func (p TasksPermission) Value() int {
+	return int(p)
+}
+func (p PatchPermission) String() string {
+	switch p {
+	case PatchSubmit:
+		return "Submit and edit patches"
+	case PatchNone:
+		return "Not able to view or submit patches"
+	}
+	return ""
+}
+func (p PatchPermission) Value() int {
+	return int(p)
+}
+func (p LogsPermission) String() string {
+	switch p {
+	case LogsView:
+		return "View logs"
+	case LogsNone:
+		return "Not able to view logs"
+	}
+	return ""
+}
+func (p LogsPermission) Value() int {
+	return int(p)
+}
 
 var projectPermissions = []string{
 	PermissionProjectSettings,

--- a/globals.go
+++ b/globals.go
@@ -472,12 +472,29 @@ func IsGitHubPatchRequester(requester string) bool {
 }
 
 // Registered permissions
+const AclCheckingIsEnabled = false
+
 const (
 	PermissionProjectSettings  = "project_settings"
 	PermissionProjectVariables = "project_variables"
 	PermissionTasks            = "project_tasks"
 	PermissionPatches          = "project_patches"
 	PermissionLogs             = "project_logs"
+
+	ProjectSettingsEdit  = 20
+	ProjectSettingsView  = 10
+	ProjectSettingsNone  = 0
+	ProjectVariablesEdit = 20
+	ProjectVariablesView = 10
+	ProjectVariablesNone = 0
+	TasksAdmin           = 30
+	TasksBasic           = 20
+	TasksView            = 10
+	TasksNone            = 0
+	PatchSubmit          = 10
+	PatchNone            = 0
+	LogsView             = 10
+	LogsNone             = 0
 )
 
 var projectPermissions = []string{

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"errors"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -272,4 +273,15 @@ func Remove(id string) error {
 		Collection,
 		bson.M{IdKey: id},
 	)
+}
+
+func FindProjectForBuild(buildID string) (string, error) {
+	b, err := FindOne(ById(buildID).Project(bson.M{ProjectKey: 1}))
+	if err != nil {
+		return "", err
+	}
+	if b == nil {
+		return "", errors.New("build not found")
+	}
+	return b.Project, nil
 }

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	mgobson "gopkg.in/mgo.v2/bson"
 )
@@ -208,4 +209,15 @@ func ByGithubPRAndCreatedBefore(t time.Time, owner, repo string, prNumber int) d
 		bsonutil.GetDottedKeyName(githubPatchDataKey, githubPatchBaseRepoKey):  repo,
 		bsonutil.GetDottedKeyName(githubPatchDataKey, githubPatchPRNumberKey):  prNumber,
 	})
+}
+
+func FindProjectForPatch(patchID mgobson.ObjectId) (string, error) {
+	p, err := FindOne(ById(patchID).Project(bson.M{ProjectKey: 1}))
+	if err != nil {
+		return "", err
+	}
+	if p == nil {
+		return "", errors.New("patch not found")
+	}
+	return p.Project, nil
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1031,3 +1031,14 @@ func Aggregate(pipeline []bson.M, results interface{}) error {
 func Count(query db.Q) (int, error) {
 	return db.CountQ(Collection, query)
 }
+
+func FindProjectForTask(taskID string) (string, error) {
+	t, err := FindOneNoMerge(ById(taskID).Project(bson.M{ProjectKey: 1}))
+	if err != nil {
+		return "", err
+	}
+	if t == nil {
+		return "", errors.New("task not found")
+	}
+	return t.Project, nil
+}

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -225,19 +225,19 @@ func (u *DBUser) RemoveRole(role string) error {
 	return nil
 }
 
-func (u *DBUser) HasPermission(resource, permission string, requiredLevel int) (bool, error) {
+func (u *DBUser) HasPermission(opts gimlet.PermissionOpts) (bool, error) {
 	roleManager := evergreen.GetEnvironment().RoleManager()
 	roles, err := roleManager.GetRoles(u.Roles())
 	if err != nil {
 		return false, errors.Wrap(err, "error getting roles")
 	}
-	roles, err = roleManager.FilterForResource(roles, resource)
+	roles, err = roleManager.FilterForResource(roles, opts.Resource, opts.ResourceType)
 	if err != nil {
 		return false, errors.Wrap(err, "error filtering resources")
 	}
 	for _, role := range roles {
-		level, hasPermission := role.Permissions[permission]
-		if hasPermission && level >= requiredLevel {
+		level, hasPermission := role.Permissions[opts.Permission]
+		if hasPermission && level >= opts.RequiredLevel {
 			return true, nil
 		}
 	}

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -406,32 +406,32 @@ func (s *UserTestSuite) TestHasPermission() {
 	u := s.users[0]
 
 	// no roles - no permission
-	hasPermission, err := u.HasPermission("resource1", "permission", 1)
+	hasPermission, err := u.HasPermission(gimlet.PermissionOpts{Resource: "resource1", Permission: "permission", RequiredLevel: 1})
 	s.NoError(err)
 	s.False(hasPermission)
 
 	// has a role with explicit permission to the resource
 	s.NoError(u.AddRole("r1p1"))
-	hasPermission, err = u.HasPermission("resource1", "permission", 1)
+	hasPermission, err = u.HasPermission(gimlet.PermissionOpts{Resource: "resource1", Permission: "permission", RequiredLevel: 1})
 	s.NoError(err)
 	s.True(hasPermission)
-	hasPermission, err = u.HasPermission("resource1", "permission", 0)
+	hasPermission, err = u.HasPermission(gimlet.PermissionOpts{Resource: "resource1", Permission: "permission", RequiredLevel: 0})
 	s.NoError(err)
 	s.True(hasPermission)
 
 	// role with insufficient permission but the right resource
-	hasPermission, err = u.HasPermission("resource1", "permission", 2)
+	hasPermission, err = u.HasPermission(gimlet.PermissionOpts{Resource: "resource1", Permission: "permission", RequiredLevel: 2})
 	s.NoError(err)
 	s.False(hasPermission)
 
 	// role with a parent scope
 	s.NoError(u.AddRole("r12p1"))
-	hasPermission, err = u.HasPermission("resource2", "permission", 1)
+	hasPermission, err = u.HasPermission(gimlet.PermissionOpts{Resource: "resource2", Permission: "permission", RequiredLevel: 1})
 	s.NoError(err)
 	s.True(hasPermission)
 
 	// role with no permission to the specified resource
-	hasPermission, err = u.HasPermission("resource4", "permission", 1)
+	hasPermission, err = u.HasPermission(gimlet.PermissionOpts{Resource: "resource4", Permission: "permission", RequiredLevel: 1})
 	s.NoError(err)
 	s.False(hasPermission)
 
@@ -439,7 +439,7 @@ func (s *UserTestSuite) TestHasPermission() {
 	s.NoError(u.RemoveRole("r1p1"))
 	s.NoError(u.RemoveRole("r12p1"))
 	s.NoError(u.AddRole("r1234p2"))
-	hasPermission, err = u.HasPermission("resource4", "permission", 2)
+	hasPermission, err = u.HasPermission(gimlet.PermissionOpts{Resource: "resource4", Permission: "permission", RequiredLevel: 2})
 	s.NoError(err)
 	s.True(hasPermission)
 }

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -309,4 +310,15 @@ func FindLastPeriodicBuild(projectID, definitionID string) (*Version, error) {
 	}
 
 	return &versions[0], nil
+}
+
+func FindProjectForVersion(versionID string) (string, error) {
+	v, err := VersionFindOne(VersionById(versionID).Project(bson.M{VersionIdentifierKey: 1}))
+	if err != nil {
+		return "", err
+	}
+	if v == nil {
+		return "", errors.New("version not found")
+	}
+	return v.Identifier, nil
 }

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -54,7 +54,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/admin/task_queue").Version(2).Delete().Wrap(superUser).RouteHandler(makeClearTaskQueueHandler(sc))
 	app.AddRoute("/admin/commit_queues").Version(2).Delete().Wrap(superUser).RouteHandler(makeClearCommitQueuesHandler(sc))
 	app.AddRoute("/alias/{name}").Version(2).Get().RouteHandler(makeFetchAliases(sc))
-	app.AddRoute("/builds/{build_id}").Version(2).Get().RouteHandler(makeGetBuildByID(sc))
+	app.AddRoute("/builds/{build_id}").Version(2).Get().Wrap(RequiresProjectPermission(evergreen.PermissionTasks, evergreen.TasksView)).RouteHandler(makeGetBuildByID(sc))
 	app.AddRoute("/builds/{build_id}").Version(2).Patch().Wrap(checkUser).RouteHandler(makeChangeStatusForBuild(sc))
 	app.AddRoute("/builds/{build_id}/abort").Version(2).Post().Wrap(checkUser).RouteHandler(makeAbortBuild(sc))
 	app.AddRoute("/builds/{build_id}/restart").Version(2).Post().Wrap(checkUser).RouteHandler(makeRestartBuild(sc))

--- a/service/api.go
+++ b/service/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/rest/route"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/evergreen/validator"
 	"github.com/evergreen-ci/gimlet"
@@ -505,7 +506,7 @@ func (as *APIServer) GetServiceApp() *gimlet.APIApp {
 	app.PrefixRoute("/patches").Route("/").Wrap(checkUser).Handler(as.submitPatch).Put()
 	app.PrefixRoute("/patches").Route("/mine").Wrap(checkUser).Handler(as.listPatches).Get()
 	app.PrefixRoute("/patches").Route("/{patchId:\\w+}").Wrap(checkUser).Handler(as.summarizePatch).Get()
-	app.PrefixRoute("/patches").Route("/{patchId:\\w+}").Wrap(checkUser).Handler(as.existingPatchRequest).Post()
+	app.PrefixRoute("/patches").Route("/{patchId:\\w+}").Wrap(checkUser, route.RequiresProjectPermission(evergreen.PermissionPatches, evergreen.PatchSubmit)).Handler(as.existingPatchRequest).Post()
 	app.PrefixRoute("/patches").Route("/{patchId:\\w+}/{projectId}/modules").Wrap(checkUser, checkProject).Handler(as.listPatchModules).Get()
 	app.PrefixRoute("/patches").Route("/{patchId:\\w+}/modules").Wrap(checkUser).Handler(as.deletePatchModule).Delete()
 	app.PrefixRoute("/patches").Route("/{patchId:\\w+}/modules").Wrap(checkUser).Handler(as.updatePatchModule).Post()

--- a/service/ui.go
+++ b/service/ui.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/plugin"
+	"github.com/evergreen-ci/evergreen/rest/route"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/gorilla/csrf"
@@ -241,7 +242,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	// Waterfall pages
 	app.AddRoute("/").Wrap(needsContext).Handler(uis.waterfallPage).Get()
 	app.AddRoute("/waterfall").Wrap(needsContext).Handler(uis.waterfallPage).Get()
-	app.AddRoute("/waterfall/{project_id}").Wrap(needsContext).Handler(uis.waterfallPage).Get()
+	app.AddRoute("/waterfall/{project_id}").Wrap(needsContext, route.RequiresProjectPermission(evergreen.PermissionTasks, evergreen.TasksView)).Handler(uis.waterfallPage).Get()
 
 	// Timeline page
 

--- a/thirdparty/github_models.go
+++ b/thirdparty/github_models.go
@@ -1,6 +1,9 @@
 package thirdparty
 
-import "github.com/pkg/errors"
+import (
+	"github.com/evergreen-ci/gimlet"
+	"github.com/pkg/errors"
+)
 
 type GithubLoginUser struct {
 	Login            string
@@ -18,7 +21,7 @@ func (u *GithubLoginUser) IsNil() bool         { return u == nil }
 func (u *GithubLoginUser) GetAPIKey() string   { return "" }
 func (u *GithubLoginUser) Roles() []string     { return []string{} }
 
-func (u *GithubLoginUser) HasPermission(string, string, int) (bool, error) {
+func (u *GithubLoginUser) HasPermission(gimlet.PermissionOpts) (bool, error) {
 	return false, errors.New("HasPermission has not been implemented for GithubLoginUser")
 }
 

--- a/util/strings.go
+++ b/util/strings.go
@@ -81,3 +81,16 @@ func GetSetDifference(a, b []string) []string {
 
 	return d
 }
+
+func CoalesceString(in ...string) string {
+	for _, str := range in {
+		if str != "" {
+			return str
+		}
+	}
+	return ""
+}
+
+func CoalesceStrings(inArray []string, inStrs ...string) string {
+	return CoalesceString(CoalesceString(inArray...), CoalesceString(inStrs...))
+}

--- a/util/strings_test.go
+++ b/util/strings_test.go
@@ -29,3 +29,12 @@ func TestGetSetDifference(t *testing.T) {
 	assert.Equal("one", difference[1])
 	assert.Equal("three", difference[2])
 }
+
+func TestCoalesce(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal("one", CoalesceString("", "one", "two"))
+	assert.Equal("one", CoalesceStrings([]string{"", ""}, "", "one", "two"))
+	assert.Equal("a", CoalesceStrings([]string{"", "a"}, "", "one", "two"))
+	assert.Equal("one", CoalesceStrings(nil, "", "one", "two"))
+	assert.Equal("", CoalesceStrings(nil, "", ""))
+}

--- a/vendor/github.com/evergreen-ci/gimlet/acl/roles_test.go
+++ b/vendor/github.com/evergreen-ci/gimlet/acl/roles_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestRoleRouteHandlers(t *testing.T) {
 	m := rolemanager.NewInMemoryRoleManager()
+	assert.NoError(t, m.RegisterPermissions([]string{"p1"}))
 	t.Run("TestRoleUpdate", testRoleUpdate(t, m))
 	t.Run("TestRoleRead", testRoleRead(t, m))
 }

--- a/vendor/github.com/evergreen-ci/gimlet/auth_interfaces.go
+++ b/vendor/github.com/evergreen-ci/gimlet/auth_interfaces.go
@@ -16,7 +16,15 @@ type User interface {
 	Username() string
 	GetAPIKey() string
 	Roles() []string
-	HasPermission(string, string, int) (bool, error)
+	HasPermission(PermissionOpts) (bool, error)
+}
+
+// PermissionOpts is the required data to be provided when asking if a user has permission for a resource
+type PermissionOpts struct {
+	Resource      string
+	ResourceType  string
+	Permission    string
+	RequiredLevel int
 }
 
 // Authenticator represents a service that answers specific
@@ -77,7 +85,7 @@ type RoleManager interface {
 	UpdateRole(Role) error
 
 	// FilterForResource takes a list of roles and returns the subset of those applicable for a certain resource
-	FilterForResource([]Role, string) ([]Role, error)
+	FilterForResource([]Role, string, string) ([]Role, error)
 
 	// AddScope adds a scope to the manager
 	AddScope(Scope) error

--- a/vendor/github.com/evergreen-ci/gimlet/auth_mock_test.go
+++ b/vendor/github.com/evergreen-ci/gimlet/auth_mock_test.go
@@ -38,7 +38,7 @@ func (u *MockUser) Username() string    { return u.ID }
 func (u *MockUser) IsNil() bool         { return u.ReportNil }
 func (u *MockUser) GetAPIKey() string   { return u.APIKey }
 func (u *MockUser) Roles() []string     { return u.RoleNames }
-func (u *MockUser) HasPermission(string, string, int) (bool, error) {
+func (u *MockUser) HasPermission(PermissionOpts) (bool, error) {
 	return true, nil
 }
 

--- a/vendor/github.com/evergreen-ci/gimlet/auth_user_basic.go
+++ b/vendor/github.com/evergreen-ci/gimlet/auth_user_basic.go
@@ -39,19 +39,19 @@ func (u *basicUser) Roles() []string {
 	copy(out, u.AccessRoles)
 	return out
 }
-func (u *basicUser) HasPermission(resource, permission string, requiredLevel int) (bool, error) {
+func (u *basicUser) HasPermission(opts PermissionOpts) (bool, error) {
 	roles, err := u.roleManager.GetRoles(u.Roles())
 	if err != nil {
 		return false, err
 	}
-	roles, err = u.roleManager.FilterForResource(roles, resource)
+	roles, err = u.roleManager.FilterForResource(roles, opts.Resource, opts.ResourceType)
 	if err != nil {
 		return false, err
 	}
 
 	for _, role := range roles {
-		level, hasPermission := role.Permissions[permission]
-		if hasPermission && level >= requiredLevel {
+		level, hasPermission := role.Permissions[opts.Permission]
+		if hasPermission && level >= opts.RequiredLevel {
 			return true, nil
 		}
 	}

--- a/vendor/github.com/evergreen-ci/gimlet/ldap/ldap_test.go
+++ b/vendor/github.com/evergreen-ci/gimlet/ldap/ldap_test.go
@@ -180,7 +180,7 @@ func (u *mockUser) Email() string       { return "" }
 func (u *mockUser) Username() string    { return u.name }
 func (u *mockUser) GetAPIKey() string   { return "" }
 func (u *mockUser) Roles() []string     { return []string{} }
-func (u *mockUser) HasPermission(string, string, int) (bool, error) {
+func (u *mockUser) HasPermission(gimlet.PermissionOpts) (bool, error) {
 	return true, nil
 }
 

--- a/vendor/github.com/evergreen-ci/gimlet/rolemanager/role_manager.go
+++ b/vendor/github.com/evergreen-ci/gimlet/rolemanager/role_manager.go
@@ -96,13 +96,14 @@ func (m *mongoBackedRoleManager) DeleteRole(id string) error {
 	return err
 }
 
-func (m *mongoBackedRoleManager) FilterForResource(roles []gimlet.Role, resource string) ([]gimlet.Role, error) {
+func (m *mongoBackedRoleManager) FilterForResource(roles []gimlet.Role, resource, resourceType string) ([]gimlet.Role, error) {
 	coll := m.client.Database(m.db).Collection(m.scopeColl)
 	ctx := context.Background()
 	pipeline := []bson.M{
 		{
 			"$match": bson.M{
 				"resources": resource,
+				"type":      resourceType,
 			},
 		},
 		{
@@ -219,9 +220,12 @@ func (m *inMemoryRoleManager) DeleteRole(id string) error {
 	return nil
 }
 
-func (m *inMemoryRoleManager) FilterForResource(roles []gimlet.Role, resource string) ([]gimlet.Role, error) {
+func (m *inMemoryRoleManager) FilterForResource(roles []gimlet.Role, resource, resourceType string) ([]gimlet.Role, error) {
 	scopes := map[string]bool{}
 	for _, scope := range m.scopes {
+		if scope.Type != resourceType {
+			continue
+		}
 		if stringSliceContains(scope.Resources, resource) {
 			toAdd := m.findScopesRecursive(scope)
 			for _, scopeID := range toAdd {

--- a/vendor/github.com/evergreen-ci/gimlet/rolemanager/role_manager_test.go
+++ b/vendor/github.com/evergreen-ci/gimlet/rolemanager/role_manager_test.go
@@ -2,9 +2,12 @@ package rolemanager
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/evergreen-ci/gimlet"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -56,29 +59,39 @@ func (s *RoleManagerSuite) SetupSuite() {
 		ID:          "1",
 		Resources:   []string{"resource1", "resource2"},
 		ParentScope: "3",
+		Type:        "project",
 	}
 	s.NoError(s.m.AddScope(scope1))
 	scope2 := gimlet.Scope{
 		ID:          "2",
 		Resources:   []string{"resource3"},
 		ParentScope: "3",
+		Type:        "project",
 	}
 	s.NoError(s.m.AddScope(scope2))
 	scope3 := gimlet.Scope{
 		ID:          "3",
 		ParentScope: "root",
+		Type:        "project",
 	}
 	s.NoError(s.m.AddScope(scope3))
 	scope4 := gimlet.Scope{
 		ID:          "4",
 		Resources:   []string{"resource4"},
 		ParentScope: "root",
+		Type:        "project",
 	}
 	s.NoError(s.m.AddScope(scope4))
 	root := gimlet.Scope{
-		ID: "root",
+		ID:   "root",
+		Type: "project",
 	}
 	s.NoError(s.m.AddScope(root))
+	wrongType := gimlet.Scope{
+		ID:   "wrongType",
+		Type: "foo",
+	}
+	s.NoError(s.m.AddScope(wrongType))
 
 	permissions := []string{"edit", "read"}
 	s.NoError(s.m.RegisterPermissions(permissions))
@@ -136,18 +149,96 @@ func (s *RoleManagerSuite) TestFilterForResource() {
 		Scope: "root",
 	}
 	s.NoError(s.m.UpdateRole(roleRoot))
-	allRoles := []gimlet.Role{role1, role2, role3, role4, roleRoot}
+	wrongType := gimlet.Role{
+		ID:    "wrong",
+		Scope: "wrongType",
+	}
+	s.NoError(s.m.UpdateRole(wrongType))
+	allRoles := []gimlet.Role{role1, role2, role3, role4, roleRoot, wrongType}
 
-	filtered, err := s.m.FilterForResource(allRoles, "resource1")
+	filtered, err := s.m.FilterForResource(allRoles, "resource1", "project")
 	s.NoError(err)
 	s.Equal([]gimlet.Role{role1, role3, roleRoot}, filtered)
-	filtered, err = s.m.FilterForResource(allRoles, "resource2")
+	filtered, err = s.m.FilterForResource(allRoles, "resource2", "project")
 	s.NoError(err)
 	s.Equal([]gimlet.Role{role1, role3, roleRoot}, filtered)
-	filtered, err = s.m.FilterForResource(allRoles, "resource3")
+	filtered, err = s.m.FilterForResource(allRoles, "resource3", "project")
 	s.NoError(err)
 	s.Equal([]gimlet.Role{role2, role3, roleRoot}, filtered)
-	filtered, err = s.m.FilterForResource(allRoles, "resource4")
+	filtered, err = s.m.FilterForResource(allRoles, "resource4", "project")
 	s.NoError(err)
 	s.Equal([]gimlet.Role{role4, roleRoot}, filtered)
+}
+
+func (s *RoleManagerSuite) TestRequiresPermissionMiddleware() {
+	//setup
+	counter := 0
+	counterFunc := func(rw http.ResponseWriter, r *http.Request) {
+		counter++
+		rw.WriteHeader(http.StatusOK)
+	}
+	role1 := gimlet.Role{
+		ID:          "r1",
+		Scope:       "1",
+		Permissions: map[string]int{"edit": 1},
+	}
+	s.NoError(s.m.UpdateRole(role1))
+	resourceLevels := []string{"resource_id"}
+	opts := gimlet.RequiresPermissionMiddlewareOpts{
+		RM:             s.m,
+		PermissionKey:  "edit",
+		ResourceType:   "project",
+		RequiredLevel:  1,
+		ResourceLevels: resourceLevels,
+	}
+	permissionMiddleware := gimlet.RequiresPermission(opts)
+	checkPermission := func(rw http.ResponseWriter, r *http.Request) {
+		permissionMiddleware.ServeHTTP(rw, r, counterFunc)
+	}
+	authenticator := gimlet.NewBasicAuthenticator(nil, nil)
+	user := gimlet.NewBasicUser("user", "name", "email", "password", "key", nil, false, s.m)
+	um, err := gimlet.NewBasicUserManager([]gimlet.User{user}, s.m)
+	s.NoError(err)
+	authHandler := gimlet.NewAuthenticationHandler(authenticator, um)
+	req := httptest.NewRequest("GET", "http://foo.com/bar", nil)
+	req = mux.SetURLVars(req, map[string]string{"resource_id": "resource1"})
+
+	// no user attached should 401
+	rw := httptest.NewRecorder()
+	authHandler.ServeHTTP(rw, req, checkPermission)
+	s.Equal(http.StatusUnauthorized, rw.Code)
+	s.Equal(0, counter)
+
+	// attach a user, but with no permissions yet
+	ctx := gimlet.AttachUser(req.Context(), user)
+	req = req.WithContext(ctx)
+	rw = httptest.NewRecorder()
+	authHandler.ServeHTTP(rw, req, checkPermission)
+	s.Equal(http.StatusUnauthorized, rw.Code)
+	s.Equal(0, counter)
+
+	// give user the right permissions
+	user = gimlet.NewBasicUser("user", "name", "email", "password", "key", []string{role1.ID}, false, s.m)
+	_, err = um.GetOrCreateUser(user)
+	s.NoError(err)
+	ctx = gimlet.AttachUser(req.Context(), user)
+	req = req.WithContext(ctx)
+	rw = httptest.NewRecorder()
+	authHandler.ServeHTTP(rw, req, checkPermission)
+	s.Equal(http.StatusOK, rw.Code)
+	s.Equal(1, counter)
+
+	// request for a resource the user doesn't have access to
+	rw = httptest.NewRecorder()
+	req = mux.SetURLVars(req, map[string]string{"resource_id": "resource3"})
+	authHandler.ServeHTTP(rw, req, checkPermission)
+	s.Equal(http.StatusUnauthorized, rw.Code)
+	s.Equal(1, counter)
+
+	// request for an unrelated endpoint that has incorrectly configured middleware
+	rw = httptest.NewRecorder()
+	req = mux.SetURLVars(req, map[string]string{})
+	authHandler.ServeHTTP(rw, req, checkPermission)
+	s.Equal(http.StatusUnauthorized, rw.Code)
+	s.Equal(1, counter)
 }

--- a/vendor/github.com/evergreen-ci/gimlet/user_service_basic.go
+++ b/vendor/github.com/evergreen-ci/gimlet/user_service_basic.go
@@ -14,11 +14,12 @@ import (
 // BasicUsers which is passed into the constructor.
 type BasicUserManager struct {
 	users []basicUser
+	rm    RoleManager
 }
 
 // NewBasicUserManager is a constructor to create a BasicUserManager from
 // a list of basic users. It requires a user created by NewBasicUser.
-func NewBasicUserManager(users []User) (UserManager, error) {
+func NewBasicUserManager(users []User, rm RoleManager) (UserManager, error) {
 	catcher := grip.NewBasicCatcher()
 	basicUsers := []basicUser{}
 	var bu *basicUser
@@ -33,7 +34,7 @@ func NewBasicUserManager(users []User) (UserManager, error) {
 	if catcher.HasErrors() {
 		return nil, catcher.Resolve()
 	}
-	return &BasicUserManager{basicUsers}, nil
+	return &BasicUserManager{users: basicUsers, rm: rm}, nil
 }
 
 // GetUserByToken does a find by creating a temporary token from the index of
@@ -109,6 +110,8 @@ func (um *BasicUserManager) GetOrCreateUser(u User) (User, error) {
 	newUser := &basicUser{
 		ID:           u.Username(),
 		EmailAddress: u.Email(),
+		AccessRoles:  u.Roles(),
+		roleManager:  um.rm,
 	}
 	um.users = append(um.users, *newUser)
 	return newUser, nil


### PR DESCRIPTION
To keep this short, adding this to all routes and an integration test will be in the next PR
- Create a middleware helper that takes various API variables and extracts the correct project scope
- Add the permission middleware to 1 route in each of the 3 API apps