### PR TITLE
EVG-6827 catch unprocessed notifications

### DIFF
--- a/model/notification/db.go
+++ b/model/notification/db.go
@@ -152,6 +152,12 @@ func FindByEventID(id string) ([]Notification, error) {
 	return notifications, err
 }
 
+func FindUnprocessed() ([]Notification, error) {
+	notifications := []Notification{}
+	err := db.FindAllQ(Collection, db.Query(bson.M{sentAtKey: bson.M{"$exists": false}}), &notifications)
+	return notifications, err
+}
+
 func byID(id string) db.Q {
 	return db.Query(bson.M{
 		idKey: id,

--- a/model/notification/db.go
+++ b/model/notification/db.go
@@ -155,14 +155,8 @@ func FindByEventID(id string) ([]Notification, error) {
 func FindUnprocessed() ([]Notification, error) {
 	notifications := []Notification{}
 	err := db.FindAllQ(Collection, db.Query(bson.M{sentAtKey: bson.M{"$exists": false}}), &notifications)
-	if err != nil {
-		if adb.ResultsNotFound(err) {
-			return nil, nil
-		}
-		return nil, errors.Wrap(err, "can't query for unprocessed notifications")
-	}
 
-	return notifications, nil
+	return notifications, errors.Wrap(err, "can't query for unprocessed notifications")
 }
 
 func byID(id string) db.Q {

--- a/model/notification/db.go
+++ b/model/notification/db.go
@@ -155,7 +155,14 @@ func FindByEventID(id string) ([]Notification, error) {
 func FindUnprocessed() ([]Notification, error) {
 	notifications := []Notification{}
 	err := db.FindAllQ(Collection, db.Query(bson.M{sentAtKey: bson.M{"$exists": false}}), &notifications)
-	return notifications, err
+	if err != nil {
+		if adb.ResultsNotFound(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "can't query for unprocessed notifications")
+	}
+
+	return notifications, nil
 }
 
 func byID(id string) db.Q {

--- a/model/notification/notification_test.go
+++ b/model/notification/notification_test.go
@@ -406,3 +406,16 @@ func (s *notificationSuite) TestCollectUnsentNotificationStats() {
 		s.Equal(1, int(f.Int()))
 	}
 }
+
+func (s *notificationSuite) TestFindUnprocessed() {
+	s.n.ID = "unsent"
+	s.NoError(db.Insert(Collection, s.n))
+	s.n.ID = "sent"
+	s.n.SentAt = time.Now()
+	s.NoError(db.Insert(Collection, s.n))
+
+	unprocessedNotifications, err := FindUnprocessed()
+	s.NoError(err)
+	s.Len(unprocessedNotifications, 1)
+	s.Equal("unsent", unprocessedNotifications[0].ID)
+}

--- a/units/event_metajob.go
+++ b/units/event_metajob.go
@@ -246,9 +246,6 @@ func (j *eventMetaJob) dispatchUnprocessedNotifications(ctx context.Context) err
 	if err != nil {
 		return errors.Wrap(err, "can't find unprocessed notifications")
 	}
-	if unprocessedNotifications == nil {
-		return nil
-	}
 
 	return j.dispatch(ctx, unprocessedNotifications)
 }

--- a/units/event_metajob.go
+++ b/units/event_metajob.go
@@ -246,6 +246,9 @@ func (j *eventMetaJob) dispatchUnprocessedNotifications(ctx context.Context) err
 	if err != nil {
 		return errors.Wrap(err, "can't find unprocessed notifications")
 	}
+	if unprocessedNotifications == nil {
+		return nil
+	}
 
 	return j.dispatch(ctx, unprocessedNotifications)
 }

--- a/units/event_send.go
+++ b/units/event_send.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
@@ -96,6 +97,11 @@ func (j *eventNotificationJob) Run(_ context.Context) {
 
 	if err = j.checkDegradedMode(n); err != nil {
 		j.AddError(n.MarkError(err))
+		return
+	}
+
+	if !util.IsZeroTime(n.SentAt) {
+		j.AddError(errors.Errorf("notification '%s' has already been processed", n.ID))
 		return
 	}
 


### PR DESCRIPTION
If the `event_metajob` dropped a notification after marking the event as processed the notification was never sent.
Adding a step to the `event_metajob` to catch dropped notifications will make sure all notifications that make it to the database are sent.