### PR TITLE
EVG-6865: support Windows user data

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -111,7 +111,7 @@ func CreateSpawnHost(so SpawnOptions) (*host.Host, error) {
 	}
 
 	// modify the setup script to add the user's public key
-	d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", so.PublicKey, filepath.Join(d.BootstrapSettings.RootDir, d.HomeDir(), ".ssh", "authorized_keys"))
+	d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", so.PublicKey, filepath.Join(d.HomeDir(), ".ssh", "authorized_keys"))
 
 	// fake out replacing spot instances with on-demand equivalents
 	if d.Provider == evergreen.ProviderNameEc2Spot || d.Provider == evergreen.ProviderNameEc2Fleet {

--- a/cloud/user_data.go
+++ b/cloud/user_data.go
@@ -137,7 +137,7 @@ func bootstrapUserData(ctx context.Context, env evergreen.Environment, h *host.H
 	}
 	settings := env.Settings()
 
-	fetchClient := h.CurlCommandWithRetry(settings, h.Distro.BootstrapSettings.JasperBinaryDir, host.CurlDefaultNumRetries, host.CurlDefaultMaxSecs)
+	fetchClient := h.CurlCommandWithRetry(settings, host.CurlDefaultNumRetries, host.CurlDefaultMaxSecs)
 
 	var postFetchClient string
 	var err error
@@ -164,7 +164,7 @@ func bootstrapUserData(ctx context.Context, env evergreen.Environment, h *host.H
 	}
 
 	bootstrapScript, err := h.BootstrapScript(settings, creds,
-		[]string{fetchClient, postFetchClient, markDone},
+		[]string{fetchClient, h.SetupCommand(), postFetchClient, markDone},
 	)
 	if err != nil {
 		return customScript, errors.Wrap(err, "could not generate user data bootstrap script")

--- a/cloud/user_data.go
+++ b/cloud/user_data.go
@@ -137,14 +137,10 @@ func bootstrapUserData(ctx context.Context, env evergreen.Environment, h *host.H
 	}
 	settings := env.Settings()
 
-	setupScript, err := h.SetupScriptCommands(settings)
-	if err != nil {
-		return "", errors.Wrap(err, "error creating setup script for user data")
-	}
-
-	fetchClient := h.CurlCommandWithRetry(settings, host.CurlDefaultNumRetries, host.CurlDefaultMaxSecs)
+	fetchClient := h.CurlCommandWithRetry(settings, h.Distro.BootstrapSettings.JasperBinaryDir, host.CurlDefaultNumRetries, host.CurlDefaultMaxSecs)
 
 	var postFetchClient string
+	var err error
 	if h.StartedBy == evergreen.User {
 		// Start the host with an agent monitor to run tasks.
 		if postFetchClient, err = h.StartAgentMonitorRequest(settings); err != nil {
@@ -168,7 +164,6 @@ func bootstrapUserData(ctx context.Context, env evergreen.Environment, h *host.H
 	}
 
 	bootstrapScript, err := h.BootstrapScript(settings, creds,
-		[]string{setupScript},
 		[]string{fetchClient, postFetchClient, markDone},
 	)
 	if err != nil {

--- a/cloud/user_data_test.go
+++ b/cloud/user_data_test.go
@@ -126,10 +126,6 @@ func TestBootstrapUserData(t *testing.T) {
 			userData, err := bootstrapUserData(ctx, env, h, "")
 			require.NoError(t, err)
 
-			cmd, err := h.SetupScriptCommands(env.Settings())
-			require.NoError(t, err)
-			assert.Contains(t, userData, cmd)
-
 			cmd = h.CurlCommandWithRetry(env.Settings(), host.CurlDefaultNumRetries, host.CurlDefaultMaxSecs)
 			require.NoError(t, err)
 			assert.Contains(t, userData, cmd)
@@ -150,10 +146,6 @@ func TestBootstrapUserData(t *testing.T) {
 			h.StartedBy = ""
 			userData, err := bootstrapUserData(ctx, env, h, "")
 			require.NoError(t, err)
-
-			cmd, err := h.SetupScriptCommands(env.Settings())
-			require.NoError(t, err)
-			assert.Contains(t, userData, cmd)
 
 			cmd = h.CurlCommandWithRetry(env.Settings(), host.CurlDefaultNumRetries, host.CurlDefaultMaxSecs)
 			require.NoError(t, err)

--- a/cloud/user_data_test.go
+++ b/cloud/user_data_test.go
@@ -126,8 +126,7 @@ func TestBootstrapUserData(t *testing.T) {
 			userData, err := bootstrapUserData(ctx, env, h, "")
 			require.NoError(t, err)
 
-			cmd = h.CurlCommandWithRetry(env.Settings(), host.CurlDefaultNumRetries, host.CurlDefaultMaxSecs)
-			require.NoError(t, err)
+			cmd := h.CurlCommandWithRetry(env.Settings(), host.CurlDefaultNumRetries, host.CurlDefaultMaxSecs)
 			assert.Contains(t, userData, cmd)
 
 			cmd, err = h.StartAgentMonitorRequest(env.Settings())
@@ -147,8 +146,7 @@ func TestBootstrapUserData(t *testing.T) {
 			userData, err := bootstrapUserData(ctx, env, h, "")
 			require.NoError(t, err)
 
-			cmd = h.CurlCommandWithRetry(env.Settings(), host.CurlDefaultNumRetries, host.CurlDefaultMaxSecs)
-			require.NoError(t, err)
+			cmd := h.CurlCommandWithRetry(env.Settings(), host.CurlDefaultNumRetries, host.CurlDefaultMaxSecs)
 			assert.Contains(t, userData, cmd)
 
 			cmd, err = h.StartAgentMonitorRequest(env.Settings())

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -370,7 +370,7 @@ func (h *Host) jasperBinaryFilePath(config evergreen.HostJasperConfig) string {
 }
 
 // BootstrapScript creates the user data script to bootstrap the host.
-func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *rpc.Credentials, postJasperSetup []string) (string, error) {
+func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Credentials, postJasperSetup []string) (string, error) {
 	bashPrefix := []string{"set -o errexit", "set -o verbose"}
 
 	if h.Distro.IsWindows() {
@@ -603,7 +603,7 @@ func writeToFileCommand(path, content string, overwrite bool) string {
 
 // bufferedWriteJasperCredentialsFilesCommandsBuffered is the same as
 // WriteJasperCredentialsFilesCommands but writes with multiple commands.
-func (h *Host) bufferedWriteJasperCredentialsFilesCommands(splunk send.SplunkConnectionInfo, creds *rpc.Credentials) ([]string, error) {
+func (h *Host) bufferedWriteJasperCredentialsFilesCommands(splunk send.SplunkConnectionInfo, creds *certdepot.Credentials) ([]string, error) {
 	if h.Distro.BootstrapSettings.JasperCredentialsPath == "" {
 		return nil, errors.New("cannot write Jasper credentials without a credentials file path")
 	}

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -408,7 +408,7 @@ func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Cr
 			"</powershell>",
 		)
 
-		return strings.Join(powershellCmds, "\r\n"), nil
+		return strings.Join(powershellCmds, "\n"), nil
 	}
 
 	setupScriptCmds, err := h.setupScriptCommands(settings)
@@ -598,7 +598,7 @@ func writeToFileCommand(path, content string, overwrite bool) string {
 	} else {
 		redirect = ">>"
 	}
-	return fmt.Sprintf("echo -n '%s' %s '%s'", content, redirect, path)
+	return fmt.Sprintf("echo -n '%s' %s %s", content, redirect, path)
 }
 
 // bufferedWriteJasperCredentialsFilesCommandsBuffered is the same as

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -289,7 +289,7 @@ func (h *Host) ForceReinstallJasperCommand(settings *evergreen.Settings) string 
 	if settings.Splunk.Populated() {
 		params = append(params,
 			fmt.Sprintf("--splunk_url=%s", settings.Splunk.ServerURL),
-			fmt.Sprintf("--splunk_token_path=%s", h.splunkTokenFilePath()),
+			fmt.Sprintf("--splunk_token_path=%s", filepath.Join(h.Distro.BootstrapSettings.RootDir, h.splunkTokenFilePath())),
 		)
 		if settings.Splunk.Channel != "" {
 			params = append(params, fmt.Sprintf("--splunk_channel=%s", settings.Splunk.Channel))
@@ -619,7 +619,7 @@ func (h *Host) splunkTokenFilePath() string {
 	if h.Distro.BootstrapSettings.JasperCredentialsPath == "" {
 		return ""
 	}
-	return filepath.Join(h.Distro.BootstrapSettings.RootDir, filepath.Dir(h.Distro.BootstrapSettings.JasperCredentialsPath), "splunk.txt")
+	return filepath.Join(filepath.Dir(h.Distro.BootstrapSettings.JasperCredentialsPath), "splunk.txt")
 }
 
 // RunJasperProcess makes a request to the host's Jasper service to create the

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -220,7 +220,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 		"BootstrapScript": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			require.NoError(t, h.Insert())
 
-			setupScriptCmds, err := h.fileSetupScriptCommands(settings)
+			writeSetupScriptCmds, err := h.writeSetupScriptCommands(settings)
 			require.NoError(t, err)
 
 			setupUserCmds, err := h.SetupServiceUserCommands()
@@ -245,7 +245,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 			script, err := h.BootstrapScript(settings, creds, expectedPostCmds)
 			require.NoError(t, err)
 
-			expectedPreCmds := append([]string{setupUserCmds}, setupScriptCmds...)
+			expectedPreCmds := append([]string{setupUserCmds}, writeSetupScriptCmds...)
 
 			assert.True(t, strings.HasPrefix(script, "<powershell>"))
 			assert.True(t, strings.HasSuffix(script, "</powershell>"))

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -54,11 +54,11 @@ func TestCurlCommandWithRetry(t *testing.T) {
 		ClientBinariesDir: "clients",
 	}
 	expected := "cd /home/user && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10 && chmod +x evergreen.exe"
-	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, 5, 10))
+	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, h.Distro.HomeDir(), 5, 10))
 
 	h = &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64, User: "user"}}
 	expected = "cd /home/user && curl -LO 'www.example.com/clients/linux_amd64/evergreen' --retry 5 --retry-max-time 10 && chmod +x evergreen"
-	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, 5, 10))
+	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, h.Distro.HomeDir(), 5, 10))
 }
 
 func TestClientURL(t *testing.T) {
@@ -80,8 +80,8 @@ func TestJasperCommands(t *testing.T) {
 	for opName, opCase := range map[string]func(t *testing.T, h *Host, settings *evergreen.Settings){
 		"VerifyBaseFetchCommands": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			expectedCmds := []string{
-				"mkdir -m 777 -p \"/foo\"",
-				"cd \"/foo\"",
+				"mkdir -m 777 -p /foo",
+				"cd /foo",
 				fmt.Sprintf("curl -LO 'www.example.com/download_file-linux-amd64-abc123.tar.gz' --retry %d --retry-max-time %d", CurlDefaultNumRetries, CurlDefaultMaxSecs),
 				"tar xzf 'download_file-linux-amd64-abc123.tar.gz'",
 				"chmod +x 'jasper_cli'",
@@ -101,14 +101,16 @@ func TestJasperCommands(t *testing.T) {
 			}
 		},
 		"BootstrapScript": func(t *testing.T, h *Host, settings *evergreen.Settings) {
+			setupScript, err := h.setupScriptCommands(settings)
+			require.NoError(t, err)
+			expectedPreCmds := []string{setupScript}
 			expectedCmds := []string{h.FetchJasperCommand(settings.HostJasper), h.ForceReinstallJasperCommand(settings)}
-			expectedPreCmds := []string{"foo", "bar"}
 			expectedPostCmds := []string{"bat", "baz"}
 
 			creds, err := newMockCredentials()
 			require.NoError(t, err)
 
-			script, err := h.BootstrapScript(settings, creds, expectedPreCmds, expectedPostCmds)
+			script, err := h.BootstrapScript(settings, creds, expectedPostCmds)
 			require.NoError(t, err)
 
 			assert.True(t, strings.HasPrefix(script, "#!/bin/bash"))
@@ -116,19 +118,19 @@ func TestJasperCommands(t *testing.T) {
 			currPos := 0
 			for _, expectedCmd := range expectedPreCmds {
 				offset := strings.Index(script[currPos:], expectedCmd)
-				require.NotEqual(t, offset, -1)
+				require.NotEqual(t, -1, offset, fmt.Sprintf("missing %s", expectedCmd))
 				currPos += offset + len(expectedCmd)
 			}
 
 			for _, expectedCmd := range expectedCmds {
 				offset := strings.Index(script[currPos:], expectedCmd)
-				require.NotEqual(t, -1, offset)
+				require.NotEqual(t, -1, offset, fmt.Sprintf("missing %s", expectedCmd))
 				currPos += offset + len(expectedCmd)
 			}
 
 			for _, expectedCmd := range expectedPostCmds {
 				offset := strings.Index(script[currPos:], expectedCmd)
-				require.NotEqual(t, -1, offset)
+				require.NotEqual(t, -1, offset, fmt.Sprintf("missing %s", expectedCmd))
 				currPos += offset + len(expectedCmd)
 			}
 		},
@@ -195,8 +197,8 @@ func TestJasperCommandsWindows(t *testing.T) {
 	for opName, opCase := range map[string]func(t *testing.T, h *Host, settings *evergreen.Settings){
 		"VerifyBaseFetchCommands": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			expectedCmds := []string{
-				"mkdir -m 777 -p \"/foo\"",
-				"cd \"/foo\"",
+				"mkdir -m 777 -p /foo",
+				"cd /foo",
 				fmt.Sprintf("curl -LO 'www.example.com/download_file-windows-amd64-abc123.tar.gz' --retry %d --retry-max-time %d", CurlDefaultNumRetries, CurlDefaultMaxSecs),
 				"tar xzf 'download_file-windows-amd64-abc123.tar.gz'",
 				"chmod +x 'jasper_cli.exe'",
@@ -218,15 +220,17 @@ func TestJasperCommandsWindows(t *testing.T) {
 		"BootstrapScript": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			require.NoError(t, h.Insert())
 
+			setupScriptCmds, err := h.fileSetupScriptCommands(settings)
+			require.NoError(t, err)
+
 			setupUserCmds, err := h.SetupServiceUserCommands()
 			require.NoError(t, err)
 
-			expectedPreCmds := []string{"preCmd1", "preCmd2"}
 			expectedPostCmds := []string{"postCmd1", "postCmd2"}
 
 			creds, err := newMockCredentials()
 			require.NoError(t, err)
-			writeCredentialsCmd, err := h.WriteJasperCredentialsFilesCommandsBuffered(settings.Splunk, creds)
+			writeCredentialsCmd, err := h.bufferedWriteJasperCredentialsFilesCommands(settings.Splunk, creds)
 			require.NoError(t, err)
 
 			expectedCmds := append(writeCredentialsCmd,
@@ -238,10 +242,10 @@ func TestJasperCommandsWindows(t *testing.T) {
 				expectedCmds[i] = util.PowerShellQuotedString(expectedCmds[i])
 			}
 
-			script, err := h.BootstrapScript(settings, creds, expectedPreCmds, expectedPostCmds)
+			script, err := h.BootstrapScript(settings, creds, expectedPostCmds)
 			require.NoError(t, err)
 
-			expectedPreCmds = append([]string{setupUserCmds}, expectedPreCmds...)
+			expectedPreCmds := append([]string{setupUserCmds}, setupScriptCmds...)
 
 			assert.True(t, strings.HasPrefix(script, "<powershell>"))
 			assert.True(t, strings.HasSuffix(script, "</powershell>"))
@@ -249,19 +253,19 @@ func TestJasperCommandsWindows(t *testing.T) {
 			currPos := 0
 			for _, expectedCmd := range expectedPreCmds {
 				offset := strings.Index(script[currPos:], expectedCmd)
-				require.NotEqual(t, -1, offset)
+				require.NotEqual(t, -1, offset, fmt.Sprintf("missing %s", expectedCmd))
 				currPos += offset + len(expectedCmd)
 			}
 
 			for _, expectedCmd := range expectedCmds {
 				offset := strings.Index(script[currPos:], expectedCmd)
-				require.NotEqual(t, -1, offset)
+				require.NotEqual(t, -1, offset, fmt.Sprintf("missing %s", expectedCmd))
 				currPos += offset + len(expectedCmd)
 			}
 
 			for _, expectedCmd := range expectedPostCmds {
 				offset := strings.Index(script[currPos:], expectedCmd)
-				require.NotEqual(t, -1, offset)
+				require.NotEqual(t, -1, offset, fmt.Sprintf("missing %s", expectedCmd))
 				currPos += offset + len(expectedCmd)
 			}
 		},
@@ -293,7 +297,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 
 					expectedCreds, err := creds.Export()
 					require.NoError(t, err)
-					assert.Equal(t, fmt.Sprintf("mkdir -m 777 -p \"/bar\" && echo '%s' > '/bar/bat.txt'", expectedCreds), cmd)
+					assert.Equal(t, fmt.Sprintf("mkdir -m 777 -p /bar && echo '%s' > '/bar/bat.txt'", expectedCreds), cmd)
 				},
 				"WithSplunkCredentials": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 					settings.Splunk.Token = "token"
@@ -303,7 +307,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 
 					expectedCreds, err := creds.Export()
 					require.NoError(t, err)
-					assert.Equal(t, fmt.Sprintf("mkdir -m 777 -p \"/bar\" && echo '%s' > '/bar/bat.txt' && echo '%s' > '/bar/splunk.txt'", expectedCreds, settings.Splunk.Token), cmd)
+					assert.Equal(t, fmt.Sprintf("mkdir -m 777 -p /bar && echo '%s' > '/bar/bat.txt' && echo '%s' > '/bar/splunk.txt'", expectedCreds, settings.Splunk.Token), cmd)
 				},
 			} {
 				t.Run(testName, func(t *testing.T) {
@@ -333,7 +337,8 @@ func TestJasperCommandsWindows(t *testing.T) {
 					ShellPath:             "/bin/bash",
 					ServiceUser:           "service-user",
 				},
-				User: "user",
+				Setup: "#!/bin/bash\necho hello",
+				User:  "user",
 			}}
 			settings := &evergreen.Settings{
 				HostJasper: evergreen.HostJasperConfig{
@@ -602,51 +607,6 @@ func TestBuildLocalJasperClientRequest(t *testing.T) {
 	assert.Contains(t, cmd[index:], "--service=rpc")
 	assert.Contains(t, cmd[index:], fmt.Sprintf("--port=%d", config.Port))
 	assert.Contains(t, cmd[index:], fmt.Sprintf("--creds_path=%s", h.Distro.BootstrapSettings.JasperCredentialsPath))
-}
-
-func TestSetupScriptCommands(t *testing.T) {
-	for testName, testCase := range map[string]func(t *testing.T, h *Host, settings *evergreen.Settings){
-		"ReturnsEmptyWithoutSetup": func(t *testing.T, h *Host, settings *evergreen.Settings) {
-			cmds, err := h.SetupScriptCommands(settings)
-			require.NoError(t, err)
-			assert.Empty(t, cmds)
-		},
-		"ReturnsEmptyIfSpawnedByTask": func(t *testing.T, h *Host, settings *evergreen.Settings) {
-			h.SpawnOptions.SpawnedByTask = true
-			cmds, err := h.SetupScriptCommands(settings)
-			require.NoError(t, err)
-			assert.Empty(t, cmds)
-		},
-		"ReturnsUnmodifiedWithoutExpansions": func(t *testing.T, h *Host, settings *evergreen.Settings) {
-			h.Distro.Setup = "foo"
-			cmds, err := h.SetupScriptCommands(settings)
-			require.NoError(t, err)
-			assert.Equal(t, h.Distro.Setup, cmds)
-		},
-		"ReturnsExpandedWithValidExpansions": func(t *testing.T, h *Host, settings *evergreen.Settings) {
-			key := "foo"
-			h.Distro.Setup = fmt.Sprintf("${%s}", key)
-			settings.Expansions = map[string]string{
-				key: "bar",
-			}
-			cmds, err := h.SetupScriptCommands(settings)
-			require.NoError(t, err)
-			assert.Equal(t, settings.Expansions[key], cmds)
-		},
-		"FailsWithInvalidSetup": func(t *testing.T, h *Host, settings *evergreen.Settings) {
-			key := "foo"
-			h.Distro.Setup = "${" + key
-			settings.Expansions = map[string]string{
-				key: "bar",
-			}
-			_, err := h.SetupScriptCommands(settings)
-			assert.Error(t, err)
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			testCase(t, &Host{Id: "test"}, &evergreen.Settings{})
-		})
-	}
 }
 
 func TestStartAgentMonitorRequest(t *testing.T) {

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -54,11 +54,11 @@ func TestCurlCommandWithRetry(t *testing.T) {
 		ClientBinariesDir: "clients",
 	}
 	expected := "cd /home/user && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10 && chmod +x evergreen.exe"
-	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, h.Distro.HomeDir(), 5, 10))
+	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, 5, 10))
 
 	h = &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64, User: "user"}}
 	expected = "cd /home/user && curl -LO 'www.example.com/clients/linux_amd64/evergreen' --retry 5 --retry-max-time 10 && chmod +x evergreen"
-	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, h.Distro.HomeDir(), 5, 10))
+	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, 5, 10))
 }
 
 func TestClientURL(t *testing.T) {

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -86,7 +87,11 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 		return
 	}
 
-	if output, err := j.host.RunJasperProcess(ctx, j.env, &options.Create{Args: []string{"ls", path}}); err != nil {
+	if output, err := j.host.RunJasperProcess(ctx, j.env, &options.Create{
+		Args: []string{
+			filepath.Join(j.host.Distro.BootstrapSettings.RootDir, j.host.Distro.BootstrapSettings.ShellPath),
+			"-l", "-c",
+			fmt.Sprintf("ls %s", path)}}); err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{
 			"message": "host was checked but is not yet ready",
 			"output":  output,

--- a/units/provisioning_user_data_done_test.go
+++ b/units/provisioning_user_data_done_test.go
@@ -2,6 +2,7 @@ package units
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -58,12 +59,9 @@ func TestUserDataDoneJob(t *testing.T) {
 			path, err := h.UserDataDoneFilePath()
 			require.NoError(t, err)
 
-			expectedCmd := []string{"ls", path}
+			expectedCmd := []string{h.Distro.BootstrapSettings.ShellPath, "-l", "-c", fmt.Sprintf("ls %s", path)}
 			require.Equal(t, len(expectedCmd), len(info.Options.Args))
-
-			for i := range expectedCmd {
-				assert.Equal(t, expectedCmd[i], info.Options.Args[i])
-			}
+			assert.Equal(t, expectedCmd, info.Options.Args)
 
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
@@ -88,6 +86,7 @@ func TestUserDataDoneJob(t *testing.T) {
 						Method:        distro.BootstrapMethodUserData,
 						Communication: distro.CommunicationMethodRPC,
 						ClientDir:     "/client_dir",
+						ShellPath:     "/shell_path",
 					},
 				},
 				Status:      evergreen.HostProvisioning,


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6865

* Windows user data can run tasks.
* Write setup script to file and run using `evergreen host setup`. For some reason, user data still mysteriously hangs while running scripts containing long lines, but `evergreen host setup` (which logically does the same thing) doesn't have this problem. I dunno.