### PR TITLE
EVG-6877 add setting to expire login token

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/mongodb/grip"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/util"
@@ -47,6 +49,20 @@ func LoadUserManager(authConfig evergreen.AuthConfig) (gimlet.UserManager, bool,
 
 // SetLoginToken sets the token in the session cookie for authentication.
 func SetLoginToken(token, domain string, w http.ResponseWriter) {
+	settings, err := evergreen.GetConfig()
+	if err != nil {
+		grip.Error(err)
+	}
+	if settings.Ui.ExpireLoginCookieDomain != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     evergreen.AuthTokenCookie,
+			Value:    "",
+			Path:     "/",
+			HttpOnly: true,
+			Expires:  time.Now().Add(-1 * time.Hour),
+			Domain:   settings.Ui.ExpireLoginCookieDomain,
+		})
+	}
 	authTokenCookie := &http.Cookie{
 		Name:     evergreen.AuthTokenCookie,
 		Value:    token,

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,12 +4,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/mongodb/grip"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
 

--- a/config_ui.go
+++ b/config_ui.go
@@ -12,16 +12,17 @@ import (
 
 // UIConfig holds relevant settings for the UI server.
 type UIConfig struct {
-	Url            string   `bson:"url" json:"url" yaml:"url"`
-	HelpUrl        string   `bson:"help_url" json:"help_url" yaml:"helpurl"`
-	UIv2Url        string   `bson:"uiv2_url" json:"uiv2_url" yaml:"uiv2_url"`
-	HttpListenAddr string   `bson:"http_listen_addr" json:"http_listen_addr" yaml:"httplistenaddr"`
-	Secret         string   `bson:"secret" json:"secret" yaml:"secret"`                           // Secret to encrypt session storage
-	DefaultProject string   `bson:"default_project" json:"default_project" yaml:"defaultproject"` // Default project to assume when none specified
-	CacheTemplates bool     `bson:"cache_templates" json:"cache_templates" yaml:"cachetemplates"` // Cache results of template compilation
-	CsrfKey        string   `bson:"csrf_key" json:"csrf_key" yaml:"csrfkey"`                      // 32-byte key used to generate tokens that validate UI requests
-	CORSOrigins    []string `bson:"cors_origins" json:"cors_origins" yaml:"cors_origins"`         // allowed request origins for some UI Routes
-	LoginDomain    string   `bson:"login_domain" json:"login_domain" yaml:"login_domain"`         // domain for the login cookie (defaults to domain of app)
+	Url                     string   `bson:"url" json:"url" yaml:"url"`
+	HelpUrl                 string   `bson:"help_url" json:"help_url" yaml:"helpurl"`
+	UIv2Url                 string   `bson:"uiv2_url" json:"uiv2_url" yaml:"uiv2_url"`
+	HttpListenAddr          string   `bson:"http_listen_addr" json:"http_listen_addr" yaml:"httplistenaddr"`
+	Secret                  string   `bson:"secret" json:"secret" yaml:"secret"`                           // Secret to encrypt session storage
+	DefaultProject          string   `bson:"default_project" json:"default_project" yaml:"defaultproject"` // Default project to assume when none specified
+	CacheTemplates          bool     `bson:"cache_templates" json:"cache_templates" yaml:"cachetemplates"` // Cache results of template compilation
+	CsrfKey                 string   `bson:"csrf_key" json:"csrf_key" yaml:"csrfkey"`                      // 32-byte key used to generate tokens that validate UI requests
+	CORSOrigins             []string `bson:"cors_origins" json:"cors_origins" yaml:"cors_origins"`         // allowed request origins for some UI Routes
+	LoginDomain             string   `bson:"login_domain" json:"login_domain" yaml:"login_domain"`         // domain for the login cookie (defaults to domain of app)
+	ExpireLoginCookieDomain string   `bson:"expire_domain" json:"expire_domain" yaml:"expire_domain"`      // expire login token for this domain when the user logs in
 }
 
 func (c *UIConfig) SectionId() string { return "ui" }
@@ -64,6 +65,7 @@ func (c *UIConfig) Set() error {
 			"csrf_key":         c.CsrfKey,
 			"cors_origins":     c.CORSOrigins,
 			"login_domain":     c.LoginDomain,
+			"expire_domain":    c.ExpireLoginCookieDomain,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1329,16 +1329,17 @@ func (a *APISplunkConnectionInfo) ToService() (interface{}, error) {
 }
 
 type APIUIConfig struct {
-	Url            APIString `json:"url"`
-	HelpUrl        APIString `json:"help_url"`
-	UIv2Url        APIString `json:"uiv2_url"`
-	HttpListenAddr APIString `json:"http_listen_addr"`
-	Secret         APIString `json:"secret"`
-	DefaultProject APIString `json:"default_project"`
-	CacheTemplates bool      `json:"cache_templates"`
-	CsrfKey        APIString `json:"csrf_key"`
-	CORSOrigins    []string  `json:"cors_origins"`
-	LoginDomain    APIString `json:"login_domain"`
+	Url                     APIString `json:"url"`
+	HelpUrl                 APIString `json:"help_url"`
+	UIv2Url                 APIString `json:"uiv2_url"`
+	HttpListenAddr          APIString `json:"http_listen_addr"`
+	Secret                  APIString `json:"secret"`
+	DefaultProject          APIString `json:"default_project"`
+	CacheTemplates          bool      `json:"cache_templates"`
+	CsrfKey                 APIString `json:"csrf_key"`
+	CORSOrigins             []string  `json:"cors_origins"`
+	LoginDomain             APIString `json:"login_domain"`
+	ExpireLoginCookieDomain APIString `json:"expire_domain"`
 }
 
 func (a *APIUIConfig) BuildFromService(h interface{}) error {
@@ -1354,6 +1355,7 @@ func (a *APIUIConfig) BuildFromService(h interface{}) error {
 		a.CsrfKey = ToAPIString(v.CsrfKey)
 		a.CORSOrigins = v.CORSOrigins
 		a.LoginDomain = ToAPIString(v.LoginDomain)
+		a.ExpireLoginCookieDomain = ToAPIString(v.ExpireLoginCookieDomain)
 	default:
 		return errors.Errorf("%T is not a supported type", h)
 	}
@@ -1362,16 +1364,17 @@ func (a *APIUIConfig) BuildFromService(h interface{}) error {
 
 func (a *APIUIConfig) ToService() (interface{}, error) {
 	return evergreen.UIConfig{
-		Url:            FromAPIString(a.Url),
-		HelpUrl:        FromAPIString(a.HelpUrl),
-		UIv2Url:        FromAPIString(a.UIv2Url),
-		HttpListenAddr: FromAPIString(a.HttpListenAddr),
-		Secret:         FromAPIString(a.Secret),
-		DefaultProject: FromAPIString(a.DefaultProject),
-		CacheTemplates: a.CacheTemplates,
-		CsrfKey:        FromAPIString(a.CsrfKey),
-		CORSOrigins:    a.CORSOrigins,
-		LoginDomain:    FromAPIString(a.LoginDomain),
+		Url:                     FromAPIString(a.Url),
+		HelpUrl:                 FromAPIString(a.HelpUrl),
+		UIv2Url:                 FromAPIString(a.UIv2Url),
+		HttpListenAddr:          FromAPIString(a.HttpListenAddr),
+		Secret:                  FromAPIString(a.Secret),
+		DefaultProject:          FromAPIString(a.DefaultProject),
+		CacheTemplates:          a.CacheTemplates,
+		CsrfKey:                 FromAPIString(a.CsrfKey),
+		CORSOrigins:             a.CORSOrigins,
+		LoginDomain:             FromAPIString(a.LoginDomain),
+		ExpireLoginCookieDomain: FromAPIString(a.ExpireLoginCookieDomain),
 	}, nil
 }
 

--- a/service/user.go
+++ b/service/user.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
@@ -47,6 +48,16 @@ func (uis *UIServer) login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if uis.Settings.Ui.ExpireLoginCookieDomain != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     evergreen.AuthTokenCookie,
+			Value:    "",
+			Path:     "/",
+			HttpOnly: true,
+			Expires:  time.Now().Add(-1 * time.Hour),
+			Domain:   uis.Settings.Ui.ExpireLoginCookieDomain,
+		})
+	}
 	uis.umconf.AttachCookie(token, w)
 	gimlet.WriteJSON(w, map[string]string{})
 }
@@ -80,6 +91,16 @@ func (uis *UIServer) userGetKey(w http.ResponseWriter, r *http.Request) {
 			StatusCode: http.StatusUnauthorized,
 		}))
 		return
+	}
+	if uis.Settings.Ui.ExpireLoginCookieDomain != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     evergreen.AuthTokenCookie,
+			Value:    "",
+			Path:     "/",
+			HttpOnly: true,
+			Expires:  time.Now().Add(-1 * time.Hour),
+			Domain:   uis.Settings.Ui.ExpireLoginCookieDomain,
+		})
 	}
 	uis.umconf.AttachCookie(token, w)
 


### PR DESCRIPTION
This adds a configuration setting that will expire the login cookie for a specific domain upon login. It's intentionally not added to the UI since it really shouldn't be used (and maybe should be removed in the future)