### PR TITLE
EVG-6800 skip docker test on docker

### DIFF
--- a/cloud/docker_integration_test.go
+++ b/cloud/docker_integration_test.go
@@ -25,7 +25,8 @@ type DockerIntegrationSuite struct {
 
 func TestDockerIntegrationSuite(t *testing.T) {
 	dns := os.Getenv("DOCKER_HOST")
-	if dns == "" {
+	isRunningOnDocker := os.Getenv("IS_DOCKER")
+	if dns == "" || isRunningOnDocker == "true" {
 		t.Skip()
 	}
 	settings := testutil.TestConfig()


### PR DESCRIPTION
I couldn't figure out what network settings are preventing this from working, but communicating with other docker containers from a docker container is not something we care about so I'm going to skip this test