### PR TITLE
EVG-6892: check for external termination when checking timed out task

### DIFF
--- a/model/event/host_event_agent_deploy.go
+++ b/model/event/host_event_agent_deploy.go
@@ -111,7 +111,10 @@ func (m *RecentHostAgentDeploys) String() string {
 ////////////////////////////////////////////////////////////////////////
 //
 // Predicates to support error checking during the agent deploy process
-func (m *RecentHostAgentDeploys) LastAttemptFailed() bool { return m.Last == EventHostAgentDeployFailed }
+func (m *RecentHostAgentDeploys) LastAttemptFailed() bool {
+	return m.Last == EventHostAgentDeployFailed || m.Last == EventHostAgentMonitorDeployFailed
+}
+
 func (m *RecentHostAgentDeploys) AllAttemptsFailed() bool {
 	return m.Count > 0 && m.Success == 0 && m.HostStatusChanged == 0
 }

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -96,7 +96,7 @@ func (j *hostMonitorExternalStateCheckJob) Run(ctx context.Context) {
 	j.AddError(err)
 }
 
-// handleExternallyTerminatedHost will check if a host from a dynamic provider has been termimated
+// handleExternallyTerminatedHost will check if a host from a dynamic provider has been terminated
 // and clean up the host if it has. Returns true if the host has been externally terminated
 func handleExternallyTerminatedHost(ctx context.Context, id string, env evergreen.Environment, h *host.Host) (bool, error) {
 	if h.Provider == evergreen.ProviderNameStatic {

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -77,6 +77,8 @@ func (j *taskExecutionTimeoutJob) Run(ctx context.Context) {
 		j.AddError(err)
 		return
 	}
+	env := evergreen.GetEnvironment()
+
 	if flags.MonitorDisabled {
 		grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
 			"message":   "monitor is disabled",
@@ -86,7 +88,7 @@ func (j *taskExecutionTimeoutJob) Run(ctx context.Context) {
 		})
 		return
 	}
-	defer j.tryRequeue(ctx)
+	defer j.tryRequeue(ctx, env)
 
 	t, err := task.FindOneId(j.Task)
 	if err != nil {
@@ -111,7 +113,7 @@ func (j *taskExecutionTimeoutJob) Run(ctx context.Context) {
 		"host":      t.HostId,
 	}
 
-	err = cleanUpTimedOutTask(t)
+	err = cleanUpTimedOutTask(ctx, env, j.ID(), t)
 	if err != nil {
 		grip.Warning(message.WrapError(err, msg))
 		j.AddError(err)
@@ -121,7 +123,7 @@ func (j *taskExecutionTimeoutJob) Run(ctx context.Context) {
 	grip.Debug(msg)
 }
 
-func (j *taskExecutionTimeoutJob) tryRequeue(ctx context.Context) {
+func (j *taskExecutionTimeoutJob) tryRequeue(ctx context.Context, env evergreen.Environment) {
 	if j.successful || j.Attempt >= maxAttempts {
 		return
 	}
@@ -130,7 +132,7 @@ func (j *taskExecutionTimeoutJob) tryRequeue(ctx context.Context) {
 	newJob.UpdateTimeInfo(amboy.JobTimeInfo{
 		WaitUntil: time.Now().Add(time.Minute),
 	})
-	err := evergreen.GetEnvironment().RemoteQueue().Put(ctx, newJob)
+	err := env.RemoteQueue().Put(ctx, newJob)
 	grip.Error(message.WrapError(err, message.Fields{
 		"message":  "failed to requeue task timeout job",
 		"task":     j.Task,
@@ -141,7 +143,7 @@ func (j *taskExecutionTimeoutJob) tryRequeue(ctx context.Context) {
 }
 
 // function to clean up a single task
-func cleanUpTimedOutTask(t *task.Task) error {
+func cleanUpTimedOutTask(ctx context.Context, env evergreen.Environment, id string, t *task.Task) error {
 	// get the host for the task
 	host, err := host.FindOne(host.ById(t.HostId))
 	if err != nil {
@@ -178,6 +180,18 @@ func cleanUpTimedOutTask(t *task.Task) error {
 
 	// if the host still has the task as its running task, clear it.
 	if host.RunningTask == t.Id {
+		// Check if the host was externally terminated. When the running task is
+		// cleared on the host, an agent or agent moniitor deploy might run,
+		// which updates the LCT and prevents detection of external termination
+		// until the deploy job runs out of retries.
+		if _, err = handleExternallyTerminatedHost(ctx, id, env, host); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "could not check host with timed out task for external termination",
+				"host":    host.Id,
+				"op_id":   id,
+			}))
+		}
+
 		// clear out the host's running task
 		if err = host.ClearRunningAndSetLastTask(t); err != nil {
 			return errors.Wrapf(err, "error clearing running task %s from host %s", t.Id, host.Id)

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -28,7 +29,7 @@ func TestCleanupTask(t *testing.T) {
 		Convey("an error should be thrown if the passed-in projects slice"+
 			" does not contain the task's project", func() {
 
-			err := cleanUpTimedOutTask(ctx, env, "", &task.Task{
+			err := cleanUpTimedOutTask(ctx, env, t.Name(), &task.Task{
 				Project: "proj",
 			})
 			So(err, ShouldNotBeNil)
@@ -60,8 +61,13 @@ func TestCleanupTask(t *testing.T) {
 				host := &host.Host{
 					Id:          "h1",
 					RunningTask: "t1",
+					Provider:    evergreen.ProviderNameMock,
+					Status:      evergreen.HostRunning,
 				}
 				So(host.Insert(), ShouldBeNil)
+				cloud.GetMockProvider().Set(host.Id, cloud.MockInstance{
+					Status: cloud.StatusRunning,
+				})
 
 				b := &build.Build{
 					Id:      "b1",
@@ -76,7 +82,7 @@ func TestCleanupTask(t *testing.T) {
 				So(v.Insert(), ShouldBeNil)
 
 				// cleaning up the task should work
-				So(cleanUpTimedOutTask(ctx, env, "", newTask), ShouldBeNil)
+				So(cleanUpTimedOutTask(ctx, env, t.Name(), newTask), ShouldBeNil)
 
 				// refresh the task - it should be reset
 				newTask, err := task.FindOne(task.ById("t1"))
@@ -118,7 +124,7 @@ func TestCleanupTask(t *testing.T) {
 					}
 					So(b.Insert(), ShouldBeNil)
 
-					So(cleanUpTimedOutTask(ctx, env, "", et1), ShouldBeNil)
+					So(cleanUpTimedOutTask(ctx, env, t.Name(), et1), ShouldBeNil)
 					et1, err := task.FindOneId(et1.Id)
 					So(err, ShouldBeNil)
 					So(et1.Status, ShouldEqual, evergreen.TaskFailed)
@@ -129,8 +135,12 @@ func TestCleanupTask(t *testing.T) {
 				})
 			})
 
-			Convey("the running task field on the task's host should be"+
-				" reset", func() {
+			Convey("given a running host running a task", func() {
+				require.NoError(t, db.ClearCollections(task.Collection), "error clearing tasks collection")
+				require.NoError(t, db.ClearCollections(host.Collection), "error clearing hosts collection")
+				require.NoError(t, db.ClearCollections(build.Collection), "error clearing builds collection")
+				require.NoError(t, db.ClearCollections(task.OldCollection), "error clearing old tasks collection")
+				require.NoError(t, db.ClearCollections(model.VersionCollection), "error clearing versions collection")
 
 				newTask := &task.Task{
 					Id:       "t1",
@@ -145,6 +155,8 @@ func TestCleanupTask(t *testing.T) {
 				h := &host.Host{
 					Id:          "h1",
 					RunningTask: "t1",
+					Provider:    evergreen.ProviderNameMock,
+					Status:      evergreen.HostRunning,
 				}
 				So(h.Insert(), ShouldBeNil)
 
@@ -158,15 +170,33 @@ func TestCleanupTask(t *testing.T) {
 				v := &model.Version{Id: "v1"}
 				So(v.Insert(), ShouldBeNil)
 
-				// cleaning up the task should work
-				So(cleanUpTimedOutTask(ctx, env, "", newTask), ShouldBeNil)
+				Convey("a running host should have its running task cleared", func() {
+					cloud.GetMockProvider().Set(h.Id, cloud.MockInstance{
+						Status: cloud.StatusRunning,
+					})
 
-				// refresh the host, make sure its running task field has
-				// been reset
-				h, err := host.FindOne(host.ById("h1"))
-				So(err, ShouldBeNil)
-				So(h.RunningTask, ShouldEqual, "")
+					// cleaning up the task should work
+					So(cleanUpTimedOutTask(ctx, env, t.Name(), newTask), ShouldBeNil)
 
+					// refresh the host, make sure its running task field has
+					// been reset
+					h, err := host.FindOne(host.ById("h1"))
+					So(err, ShouldBeNil)
+					So(h.RunningTask, ShouldEqual, "")
+
+				})
+				Convey("an externally terminated host should be marked terminated and its task should be reset", func() {
+					cloud.GetMockProvider().Set(h.Id, cloud.MockInstance{
+						Status: cloud.StatusTerminated,
+					})
+
+					So(cleanUpTimedOutTask(ctx, env, t.Name(), newTask), ShouldBeNil)
+
+					h, err := host.FindOneId("h1")
+					So(err, ShouldBeNil)
+					So(h.RunningTask, ShouldEqual, "")
+					So(h.Status, ShouldEqual, evergreen.HostTerminated)
+				})
 			})
 		})
 	})


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6892

This fixes an issue where a spot host was reclaimed by AWS and it did not run the external termination detection job due to a race, which caused lots of failed agent monitor deploys to a host that was terminated in AWS but the app server thought was running.

The running task was cleared by the task execution timeout job without verifying if the host was still alive. Since the LCT had elapsed and the host had no running task, the app server attempted to deploy the agent monitor (which updates the LCT) before it could check for external termination. Both are populated depending on the LCT.

## Changes
* Manually check for an externally terminated host before the task is cleared.
* Fix an issue where the agent monitor deploy job wouldn't terminate a host after all attempts were used.