### PR TITLE
EVG-6022 correct the ordering of concurrent versions

### DIFF
--- a/service/task_history.go
+++ b/service/task_history.go
@@ -429,10 +429,10 @@ func getVersionsInWindow(wt, projectID string, radius int, center *model.Version
 // or after the center, indicated by "before", and sorted backwards in time
 func surroundingVersions(center *model.Version, projectID string, versionsToFetch int, before bool) ([]model.Version, error) {
 	direction := "$gt"
-	sortOn := []string{model.VersionCreateTimeKey, model.VersionRevisionKey}
+	sortOn := []string{model.VersionRevisionOrderNumberKey}
 	if before {
 		direction = "$lt"
-		sortOn = []string{"-" + model.VersionCreateTimeKey, "-" + model.VersionRevisionKey}
+		sortOn = []string{"-" + model.VersionRevisionOrderNumberKey}
 	}
 
 	versions, err := model.VersionFind(
@@ -441,10 +441,7 @@ func surroundingVersions(center *model.Version, projectID string, versionsToFetc
 			model.VersionRequesterKey: bson.M{
 				"$in": evergreen.SystemVersionRequesterTypes,
 			},
-			"$or": []bson.M{
-				{model.VersionCreateTimeKey: bson.M{direction: center.CreateTime}},
-				{model.VersionCreateTimeKey: center.CreateTime, model.VersionRevisionKey: bson.M{direction: center.Revision}},
-			},
+			model.VersionRevisionOrderNumberKey: bson.M{direction: center.RevisionOrderNumber},
 		}).WithFields(
 			model.VersionRevisionOrderNumberKey,
 			model.VersionRevisionKey,

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -427,43 +427,23 @@ func getVersionsInWindow(wt, projectID string, radius int, center *model.Version
 
 // Helper to query the versions collection for versions created before
 // or after the center, indicated by "before", and sorted backwards in time
-func surroundingVersions(center *model.Version, projectId string, versionsToFetch int, before bool) ([]model.Version, error) {
+func surroundingVersions(center *model.Version, projectID string, versionsToFetch int, before bool) ([]model.Version, error) {
 	direction := "$gt"
-	sortOn := []string{model.VersionCreateTimeKey}
+	sortOn := []string{model.VersionCreateTimeKey, model.VersionRevisionKey}
 	if before {
 		direction = "$lt"
-		sortOn = []string{"-" + model.VersionCreateTimeKey}
+		sortOn = []string{"-" + model.VersionCreateTimeKey, "-" + model.VersionRevisionKey}
 	}
 
-	// fetch other concurrent versions
-	concurrentVersions, err := model.VersionFind(
-		db.Query(bson.M{
-			model.VersionIdentifierKey: projectId,
-			model.VersionCreateTimeKey: center.CreateTime,
-			model.VersionRequesterKey: bson.M{
-				"$in": evergreen.SystemVersionRequesterTypes,
-			},
-			model.VersionRevisionKey: bson.M{direction: center.Revision},
-		}).WithFields(
-			model.VersionRevisionOrderNumberKey,
-			model.VersionRevisionKey,
-			model.VersionMessageKey,
-			model.VersionCreateTimeKey,
-			model.VersionErrorsKey,
-			model.VersionWarningsKey,
-			model.VersionIgnoredKey,
-		).Limit(versionsToFetch))
-	if err != nil {
-		return nil, errors.Wrap(err, "can't get concurrent versions")
-	}
-
-	// fetch consecutive versions
 	versions, err := model.VersionFind(
 		db.Query(bson.M{
-			model.VersionIdentifierKey: projectId,
-			model.VersionCreateTimeKey: bson.M{direction: center.CreateTime},
+			model.VersionIdentifierKey: projectID,
 			model.VersionRequesterKey: bson.M{
 				"$in": evergreen.SystemVersionRequesterTypes,
+			},
+			"$or": []bson.M{
+				{model.VersionCreateTimeKey: bson.M{direction: center.CreateTime}},
+				{model.VersionCreateTimeKey: center.CreateTime, model.VersionRevisionKey: bson.M{direction: center.Revision}},
 			},
 		}).WithFields(
 			model.VersionRevisionOrderNumberKey,
@@ -473,19 +453,19 @@ func surroundingVersions(center *model.Version, projectId string, versionsToFetc
 			model.VersionErrorsKey,
 			model.VersionWarningsKey,
 			model.VersionIgnoredKey,
-		).Sort(sortOn).Limit(versionsToFetch - len(concurrentVersions)))
+		).Sort(sortOn).Limit(versionsToFetch))
 	if err != nil {
-		return nil, errors.Wrap(err, "can't get consecutive versions")
+		return nil, errors.Wrap(err, "can't get surrounding versions")
 	}
 
-	if before {
-		return append(concurrentVersions, versions...), nil
+	if !before {
+		// reverse versions
+		for begin, end := 0, len(versions)-1; begin < end; begin, end = begin+1, end-1 {
+			versions[begin], versions[end] = versions[end], versions[begin]
+		}
 	}
-	// reverse versions
-	for begin, end := 0, len(versions)-1; begin < end; begin, end = begin+1, end-1 {
-		versions[begin], versions[end] = versions[end], versions[begin]
-	}
-	return append(versions, concurrentVersions...), nil
+
+	return versions, nil
 }
 
 // Given a task name and a slice of versions, return the appropriate sibling

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -429,10 +429,10 @@ func getVersionsInWindow(wt, projectID string, radius int, center *model.Version
 // or after the center, indicated by "before", and sorted backwards in time
 func surroundingVersions(center *model.Version, projectID string, versionsToFetch int, before bool) ([]model.Version, error) {
 	direction := "$gt"
-	sortOn := []string{model.VersionCreateTimeKey, model.VersionRevisionKey}
+	sortOn := []string{model.VersionCreateTimeKey, model.VersionRevisionOrderNumberKey}
 	if before {
 		direction = "$lt"
-		sortOn = []string{"-" + model.VersionCreateTimeKey, "-" + model.VersionRevisionKey}
+		sortOn = []string{"-" + model.VersionCreateTimeKey, "-" + model.VersionRevisionOrderNumberKey}
 	}
 
 	versions, err := model.VersionFind(
@@ -443,7 +443,7 @@ func surroundingVersions(center *model.Version, projectID string, versionsToFetc
 			},
 			"$or": []bson.M{
 				{model.VersionCreateTimeKey: bson.M{direction: center.CreateTime}},
-				{model.VersionCreateTimeKey: center.CreateTime, model.VersionRevisionKey: bson.M{direction: center.Revision}},
+				{model.VersionCreateTimeKey: center.CreateTime, model.VersionRevisionOrderNumberKey: bson.M{direction: center.RevisionOrderNumber}},
 			},
 		}).WithFields(
 			model.VersionRevisionOrderNumberKey,

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -429,10 +429,10 @@ func getVersionsInWindow(wt, projectID string, radius int, center *model.Version
 // or after the center, indicated by "before", and sorted backwards in time
 func surroundingVersions(center *model.Version, projectID string, versionsToFetch int, before bool) ([]model.Version, error) {
 	direction := "$gt"
-	sortOn := []string{model.VersionRevisionOrderNumberKey}
+	sortOn := []string{model.VersionCreateTimeKey, model.VersionRevisionKey}
 	if before {
 		direction = "$lt"
-		sortOn = []string{"-" + model.VersionRevisionOrderNumberKey}
+		sortOn = []string{"-" + model.VersionCreateTimeKey, "-" + model.VersionRevisionKey}
 	}
 
 	versions, err := model.VersionFind(
@@ -441,7 +441,10 @@ func surroundingVersions(center *model.Version, projectID string, versionsToFetc
 			model.VersionRequesterKey: bson.M{
 				"$in": evergreen.SystemVersionRequesterTypes,
 			},
-			model.VersionRevisionOrderNumberKey: bson.M{direction: center.RevisionOrderNumber},
+			"$or": []bson.M{
+				{model.VersionCreateTimeKey: bson.M{direction: center.CreateTime}},
+				{model.VersionCreateTimeKey: center.CreateTime, model.VersionRevisionKey: bson.M{direction: center.Revision}},
+			},
 		}).WithFields(
 			model.VersionRevisionOrderNumberKey,
 			model.VersionRevisionKey,

--- a/service/task_history_test.go
+++ b/service/task_history_test.go
@@ -34,11 +34,11 @@ func (s *TaskHistorySuite) SetupTest() {
 		// backwards in time, in descending order
 		now = now.Add(-time.Minute)
 		version := model.Version{
-			Id:         fmt.Sprintf("after_%d", i),
-			Revision:   "cccc",
-			CreateTime: now,
-			Identifier: s.projectID,
-			Requester:  evergreen.RepotrackerVersionRequester,
+			Id:                  fmt.Sprintf("after_%d", i),
+			RevisionOrderNumber: 101 - i,
+			CreateTime:          now,
+			Identifier:          s.projectID,
+			Requester:           evergreen.RepotrackerVersionRequester,
 		}
 		s.versionsAfter = append(s.versionsAfter, version)
 		s.NoError(version.Insert())
@@ -47,21 +47,21 @@ func (s *TaskHistorySuite) SetupTest() {
 	// Middle version with the same createTime as the last version in versionsBefore
 	// and the first version in versionsAfter
 	s.middleVersion = model.Version{
-		Id:         "middle",
-		Revision:   "bbbb",
-		CreateTime: now,
-		Identifier: s.projectID,
-		Requester:  evergreen.RepotrackerVersionRequester,
+		Id:                  "middle",
+		RevisionOrderNumber: 51,
+		CreateTime:          now,
+		Identifier:          s.projectID,
+		Requester:           evergreen.RepotrackerVersionRequester,
 	}
 	s.NoError(s.middleVersion.Insert())
 
 	for i := 0; i < 50; i++ {
 		version := model.Version{
-			Id:         fmt.Sprintf("before_%d", i),
-			Revision:   "aaaa",
-			CreateTime: now,
-			Identifier: s.projectID,
-			Requester:  evergreen.RepotrackerVersionRequester,
+			Id:                  fmt.Sprintf("before_%d", i),
+			RevisionOrderNumber: 50 - i,
+			CreateTime:          now,
+			Identifier:          s.projectID,
+			Requester:           evergreen.RepotrackerVersionRequester,
 		}
 		s.versionsBefore = append(s.versionsBefore, version)
 		s.NoError(version.Insert())
@@ -93,7 +93,7 @@ func (s *TaskHistorySuite) TestSurroundingVersions() {
 	s.NoError(err)
 	s.Require().Len(versionsAfter, radius)
 	for i, version := range versionsAfter {
-		s.Equal("cccc", version.Revision)
+		s.True(version.RevisionOrderNumber > s.middleVersion.RevisionOrderNumber)
 		// compare to the last _radius_ elements in s.versionsAfter
 		s.True(version.CreateTime.Equal(s.versionsAfter[(len(s.versionsAfter)-radius)+i].CreateTime))
 	}
@@ -102,7 +102,7 @@ func (s *TaskHistorySuite) TestSurroundingVersions() {
 	s.NoError(err)
 	s.Len(versionsBefore, radius)
 	for i, version := range versionsBefore {
-		s.Equal("aaaa", version.Revision)
+		s.True(version.RevisionOrderNumber < s.middleVersion.RevisionOrderNumber)
 		s.True(version.CreateTime.Equal(s.versionsBefore[i].CreateTime))
 	}
 }
@@ -112,17 +112,17 @@ func (s *TaskHistorySuite) TestSurroundingVersionsSort() {
 	s.NoError(err)
 	s.Require().Len(versionsAfter, 2)
 	// sorted ascending, then reversed
-	s.Equal("cccc", versionsAfter[0].Revision)
+	s.Equal(52, versionsAfter[0].RevisionOrderNumber)
 	s.Equal("after_49", versionsAfter[0].Id)
-	s.Equal("bbbb", versionsAfter[1].Revision)
+	s.Equal(51, versionsAfter[1].RevisionOrderNumber)
 	s.Equal("middle", versionsAfter[1].Id)
 
 	versionsBefore, err := surroundingVersions(&s.versionsAfter[49], s.projectID, 2, true)
 	s.NoError(err)
 	s.Require().Len(versionsBefore, 2)
 	// sorted descending
-	s.Equal("bbbb", versionsBefore[0].Revision)
+	s.Equal(51, versionsBefore[0].RevisionOrderNumber)
 	s.Equal("middle", versionsBefore[0].Id)
-	s.Equal("aaaa", versionsBefore[1].Revision)
+	s.Equal(50, versionsBefore[1].RevisionOrderNumber)
 	s.Equal("before_0", versionsBefore[1].Id)
 }

--- a/service/task_history_test.go
+++ b/service/task_history_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -15,7 +16,6 @@ type TaskHistorySuite struct {
 	versionsBefore []model.Version
 	middleVersion  model.Version
 	versionsAfter  []model.Version
-	radius         int
 	projectID      string
 }
 
@@ -29,67 +29,100 @@ func (s *TaskHistorySuite) SetupSuite() {
 
 func (s *TaskHistorySuite) SetupTest() {
 	s.NoError(db.ClearCollections(model.VersionCollection))
-	for i := 0; i < 25; i++ {
+	now := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	for i := 0; i < 50; i++ {
+		// backwards in time, in descending order
+		now = now.Add(-time.Minute)
 		version := model.Version{
-			Id:                  fmt.Sprintf("version_%d", i),
-			RevisionOrderNumber: i + 1,
-			Identifier:          s.projectID,
-			Requester:           evergreen.RepotrackerVersionRequester,
+			Id:         fmt.Sprintf("after_%d", i),
+			Revision:   "cccc",
+			CreateTime: now,
+			Identifier: s.projectID,
+			Requester:  evergreen.RepotrackerVersionRequester,
 		}
-		s.versionsBefore = append([]model.Version{version}, s.versionsBefore...)
+		s.versionsAfter = append(s.versionsAfter, version)
 		s.NoError(version.Insert())
 	}
 
+	// Middle version with the same createTime as the last version in versionsBefore
+	// and the first version in versionsAfter
 	s.middleVersion = model.Version{
-		Id:                  "middle",
-		RevisionOrderNumber: 26,
-		Identifier:          s.projectID,
-		Requester:           evergreen.RepotrackerVersionRequester,
+		Id:         "middle",
+		Revision:   "bbbb",
+		CreateTime: now,
+		Identifier: s.projectID,
+		Requester:  evergreen.RepotrackerVersionRequester,
 	}
 	s.NoError(s.middleVersion.Insert())
 
-	for i := 26; i < 51; i++ {
+	for i := 0; i < 50; i++ {
 		version := model.Version{
-			Id:                  fmt.Sprintf("version_%d", i),
-			RevisionOrderNumber: i + 1,
-			Identifier:          s.projectID,
-			Requester:           evergreen.RepotrackerVersionRequester,
+			Id:         fmt.Sprintf("before_%d", i),
+			Revision:   "aaaa",
+			CreateTime: now,
+			Identifier: s.projectID,
+			Requester:  evergreen.RepotrackerVersionRequester,
 		}
-		s.versionsAfter = append([]model.Version{version}, s.versionsAfter...)
+		s.versionsBefore = append(s.versionsBefore, version)
 		s.NoError(version.Insert())
-	}
 
-	s.radius = 25
+		now = now.Add(-time.Minute)
+	}
 }
 
 func (s *TaskHistorySuite) TestGetVersionsInWindow() {
-	versions, err := getVersionsInWindow("surround", s.projectID, s.radius, &s.middleVersion)
+	radius := 20
+	versions, err := getVersionsInWindow("surround", s.projectID, radius, &s.middleVersion)
 	s.Require().NoError(err)
-	s.Require().Len(versions, (2*s.radius)+1)
 
-	for i := 0; i < s.radius; i++ {
-		s.Equal(s.versionsAfter[i].Id, versions[i].Id)
+	for i := 0; i < radius; i++ {
+		// compare to the last _radius_ elements in s.versionsAfter
+		s.True(versions[i].CreateTime.Equal(s.versionsAfter[(len(s.versionsAfter))-radius+i].CreateTime))
 	}
 
-	s.Equal(s.middleVersion.Id, versions[s.radius].Id)
+	s.True(s.middleVersion.CreateTime.Equal(versions[radius].CreateTime))
 
-	for i := 0; i < s.radius; i++ {
-		s.Equal(s.versionsBefore[i].Id, versions[i+(s.radius+1)].Id)
+	for i := 0; i < radius; i++ {
+		s.True(versions[i+(1+radius)].CreateTime.Equal(s.versionsBefore[i].CreateTime))
 	}
 }
 
 func (s *TaskHistorySuite) TestSurroundingVersions() {
-	versionsAfter, err := surroundingVersions(&s.middleVersion, s.projectID, s.radius, false)
+	radius := 20
+	versionsAfter, err := surroundingVersions(&s.middleVersion, s.projectID, radius, false)
 	s.NoError(err)
-	s.Require().Len(versionsAfter, s.radius)
+	s.Require().Len(versionsAfter, radius)
 	for i, version := range versionsAfter {
-		s.Equal(s.versionsAfter[i].Id, version.Id)
+		s.Equal("cccc", version.Revision)
+		// compare to the last _radius_ elements in s.versionsAfter
+		s.True(version.CreateTime.Equal(s.versionsAfter[(len(s.versionsAfter)-radius)+i].CreateTime))
 	}
 
-	versionsBefore, err := surroundingVersions(&s.middleVersion, s.projectID, s.radius, true)
+	versionsBefore, err := surroundingVersions(&s.middleVersion, s.projectID, radius, true)
 	s.NoError(err)
-	s.Len(versionsBefore, s.radius)
+	s.Len(versionsBefore, radius)
 	for i, version := range versionsBefore {
-		s.Equal(s.versionsBefore[i].Id, version.Id)
+		s.Equal("aaaa", version.Revision)
+		s.True(version.CreateTime.Equal(s.versionsBefore[i].CreateTime))
 	}
+}
+
+func (s *TaskHistorySuite) TestSurroundingVersionsSort() {
+	versionsAfter, err := surroundingVersions(&s.versionsBefore[0], s.projectID, 2, false)
+	s.NoError(err)
+	s.Require().Len(versionsAfter, 2)
+	// sorted ascending, then reversed
+	s.Equal("cccc", versionsAfter[0].Revision)
+	s.Equal("after_49", versionsAfter[0].Id)
+	s.Equal("bbbb", versionsAfter[1].Revision)
+	s.Equal("middle", versionsAfter[1].Id)
+
+	versionsBefore, err := surroundingVersions(&s.versionsAfter[49], s.projectID, 2, true)
+	s.NoError(err)
+	s.Require().Len(versionsBefore, 2)
+	// sorted descending
+	s.Equal("bbbb", versionsBefore[0].Revision)
+	s.Equal("middle", versionsBefore[0].Id)
+	s.Equal("aaaa", versionsBefore[1].Revision)
+	s.Equal("before_0", versionsBefore[1].Id)
 }


### PR DESCRIPTION
Add a secondary sort on revision for versions with equal create time.
In the process, simplify the logic by consolidating the concurrent and consecutive queries into a single query.

Will need to discuss how the new query uses the index.