### PR TITLE
EVG-6894 fix TestGetGithubPullRequestDiff

### DIFF
--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -676,24 +675,19 @@ func GetGithubPullRequest(ctx context.Context, token, baseOwner, baseRepo string
 	return pr, nil
 }
 
-// GetGithubDiff downloads a diff from a Github Pull Request diff. This function
-// does not use go-github because this operation is not supported
+// GetGithubPullRequestDiff downloads a diff from a Github Pull Request diff
 func GetGithubPullRequestDiff(ctx context.Context, token string, gh patch.GithubPatch) (string, []patch.Summary, error) {
 	all := rehttp.RetryAll(rehttp.RetryMaxRetries(NumGithubRetries-1), githubShouldRetryWith404s)
-	client, err := util.GetRetryableOauth2HTTPClient(token, all, util.RehttpDelay(GithubSleepTimeSecs, NumGithubRetries))
+	httpClient, err := util.GetRetryableOauth2HTTPClient(token, all, util.RehttpDelay(GithubSleepTimeSecs, NumGithubRetries))
 	if err != nil {
-		return "", nil, errors.Wrap(err, "error getting http client")
+		return "", nil, errors.Wrap(err, "can't get client")
 	}
-	defer util.PutHTTPClient(client)
+	defer util.PutHTTPClient(httpClient)
+	client := github.NewClient(httpClient)
 
-	req, err := http.NewRequest("GET", buildPatchURL(gh), nil)
+	diff, _, err := client.PullRequests.GetRaw(ctx, gh.BaseOwner, gh.BaseRepo, gh.PRNumber, github.RawOptions{Type: github.Diff})
 	if err != nil {
-		return "", nil, errors.Wrap(err, "failed to create github request")
-	}
-
-	diff, err := doGithubRequest(client, req, githubAcceptDiff)
-	if err != nil {
-		return "", nil, errors.Wrap(err, "failed to fetch diff from github")
+		return "", nil, err
 	}
 
 	summaries, err := GetPatchSummaries(diff)
@@ -702,45 +696,6 @@ func GetGithubPullRequestDiff(ctx context.Context, token string, gh patch.Github
 	}
 
 	return diff, summaries, nil
-}
-
-func doGithubRequest(client *http.Client, req *http.Request, accept string) (string, error) {
-	req.Header.Del("Accept")
-	req.Header.Add("Accept", accept)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to fetch data from github")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("Expected 200 OK, got %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
-	}
-
-	if resp.ContentLength > patch.SizeLimit || resp.ContentLength == 0 {
-		return "", errors.Errorf("Patch contents must be at least 1 byte and no greater than %d bytes; was %d bytes",
-			patch.SizeLimit, resp.ContentLength)
-	}
-
-	bytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to read response body from github response")
-	}
-
-	return string(bytes), nil
-}
-
-// buildPatchURL creates a URL to enable downloading patch files through the
-// Github API
-func buildPatchURL(gp patch.GithubPatch) string {
-	url := &url.URL{
-		Scheme: "https",
-		Host:   "api.github.com",
-		Path: fmt.Sprintf("/repos/%s/%s/pulls/%d.diff", gp.BaseOwner,
-			gp.BaseRepo, gp.PRNumber),
-	}
-
-	return url.String()
 }
 
 func ValidatePR(pr *github.PullRequest) error {

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -32,8 +32,6 @@ const (
 	GithubAPIStatusGood  = "good"
 
 	Github502Error = "502 Server Error"
-
-	githubAcceptDiff = "application/vnd.github.v3.diff"
 )
 
 func githubShouldRetry(attempt rehttp.Attempt) bool {

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -216,16 +216,12 @@ func (s *githubSuite) TestGetGithubPullRequestDiff() {
 		BaseOwner:  "evergreen-ci",
 		BaseRepo:   "evergreen",
 		BaseBranch: "master",
-		HeadOwner:  "richardsamuels",
-		HeadRepo:   "evergreen",
-		HeadHash:   "something",
-		Author:     "richardsamuels",
 	}
 
 	diff, summaries, err := GetGithubPullRequestDiff(s.ctx, s.token, p)
 	s.NoError(err)
 	s.Len(summaries, 2)
-	s.Len(diff, 1470)
+	s.Contains(diff, "diff --git a/cli/host.go b/cli/host.go")
 }
 
 func TestVerifyGithubAPILimitHeader(t *testing.T) {
@@ -270,21 +266,6 @@ func verifyGithubAPILimitHeader(header http.Header) (int64, error) {
 	}
 
 	return rem, nil
-}
-
-func TestBuildPatchURL(t *testing.T) {
-	assert := assert.New(t)
-	p := patch.GithubPatch{
-		PRNumber:   448,
-		BaseOwner:  "evergreen-ci",
-		BaseRepo:   "evergreen",
-		BaseBranch: "master",
-		HeadOwner:  "richardsamuels",
-		HeadRepo:   "evergreen",
-		HeadHash:   "something",
-		Author:     "richardsamuels",
-	}
-	assert.Equal("https://api.github.com/repos/evergreen-ci/evergreen/pulls/448.diff", buildPatchURL(p))
 }
 
 func TestValidatePR(t *testing.T) {


### PR DESCRIPTION
The `TestGetGithubPullRequestDiff` test has been intermittently broken on Evergreen's waterfall. The test had been relying on the diff being a set number of characters, but sometimes the commit SHA is abbreviated with 9 digits and sometimes with 10 (only recently with 10).
```
$ diff attempt1.txt attempt2.txt
2c2
< index c661de2f91..f188a4d7ac 100644
---
> index c661de2f9..f188a4d7a 100644
28c28
< index 27186d2dcc..216f7a099e 100644
---
> index 27186d2dc..216f7a099 100644
```

Also took the opportunity to use go-github for getting the diff.