### PR TITLE
EVG-6903: remove cloud manager GetSSHOptions

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -55,10 +55,6 @@ type Manager interface {
 	// GetDNSName returns the DNS name of a host.
 	GetDNSName(context.Context, *host.Host) (string, error)
 
-	// GetSSHOptions generates the command line args to be passed to ssh to
-	// allow connection to the machine
-	GetSSHOptions(*host.Host, string) ([]string, error)
-
 	// TimeTilNextPayment returns how long there is until the next payment
 	// is due for a particular host
 	TimeTilNextPayment(*host.Host) time.Duration

--- a/cloud/cloud_host.go
+++ b/cloud/cloud_host.go
@@ -62,7 +62,3 @@ func (cloudHost *CloudHost) GetInstanceStatus(ctx context.Context) (CloudStatus,
 func (cloudHost *CloudHost) GetDNSName(ctx context.Context) (string, error) {
 	return cloudHost.CloudMgr.GetDNSName(ctx, cloudHost.Host)
 }
-
-func (cloudHost *CloudHost) GetSSHOptions() ([]string, error) {
-	return cloudHost.CloudMgr.GetSSHOptions(cloudHost.Host, cloudHost.KeyPath)
-}

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -211,20 +211,6 @@ func (m *dockerManager) OnUp(context.Context, *host.Host) error {
 	return nil
 }
 
-//GetSSHOptions returns an array of default SSH options for connecting to a
-//container.
-func (m *dockerManager) GetSSHOptions(h *host.Host, keyPath string) ([]string, error) {
-	if keyPath == "" {
-		return []string{}, errors.New("No key specified for Docker host")
-	}
-
-	opts := []string{"-i", keyPath}
-	for _, opt := range h.Distro.SSHOptions {
-		opts = append(opts, "-o", opt)
-	}
-	return opts, nil
-}
-
 // TimeTilNextPayment returns the amount of time until the next payment is due
 // for the host. For Docker this is not relevant.
 func (m *dockerManager) TimeTilNextPayment(_ *host.Host) time.Duration {

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -172,24 +172,6 @@ func (s *DockerSuite) TestTerminateInstanceDB() {
 	s.Error(err)
 }
 
-func (s *DockerSuite) TestGetSSHOptions() {
-	opt := "Option"
-	keyname := "key"
-	host := &host.Host{
-		Distro: distro.Distro{
-			SSHOptions: []string{opt},
-		},
-	}
-
-	opts, err := s.manager.GetSSHOptions(host, "")
-	s.Error(err)
-	s.Empty(opts)
-
-	opts, err = s.manager.GetSSHOptions(host, keyname)
-	s.NoError(err)
-	s.Equal([]string{"-i", keyname, "-o", opt}, opts)
-}
-
 func (s *DockerSuite) TestSpawnInvalidSettings() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1086,11 +1086,6 @@ func (m *ec2Manager) GetDNSName(ctx context.Context, h *host.Host) (string, erro
 	return m.client.GetPublicDNSName(ctx, h)
 }
 
-// GetSSHOptions returns the command-line args to pass to SSH.
-func (m *ec2Manager) GetSSHOptions(h *host.Host, keyName string) ([]string, error) {
-	return h.GetSSHOptions(keyName)
-}
-
 // TimeTilNextPayment returns how long until the next payment is due for a host.
 func (m *ec2Manager) TimeTilNextPayment(host *host.Host) time.Duration {
 	return timeTilNextEC2Payment(host)

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -297,10 +297,6 @@ func (m *ec2FleetManager) GetDNSName(ctx context.Context, h *host.Host) (string,
 	return m.client.GetPublicDNSName(ctx, h)
 }
 
-func (m *ec2FleetManager) GetSSHOptions(h *host.Host, keyName string) ([]string, error) {
-	return h.GetSSHOptions(keyName)
-}
-
 func (m *ec2FleetManager) TimeTilNextPayment(h *host.Host) time.Duration {
 	return timeTilNextEC2Payment(h)
 }

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -228,18 +228,3 @@ func (m *gceManager) GetDNSName(ctx context.Context, host *host.Host) (string, e
 
 	return configs[0].NatIP, nil
 }
-
-// GetSSHOptions generates the command line args to be passed to SSH to allow connection
-// to the machine.
-func (m *gceManager) GetSSHOptions(host *host.Host, keyPath string) ([]string, error) {
-	if keyPath == "" {
-		return []string{}, errors.New("No key specified for host")
-	}
-
-	opts := []string{"-i", keyPath}
-	for _, opt := range host.Distro.SSHOptions {
-		opts = append(opts, "-o", opt)
-	}
-
-	return opts, nil
-}

--- a/cloud/gce_test.go
+++ b/cloud/gce_test.go
@@ -299,24 +299,6 @@ func (s *GCESuite) TestGetDNSNameNetwork() {
 	s.Empty(dns)
 }
 
-func (s *GCESuite) TestGetSSHOptions() {
-	opt := "Option"
-	keyname := "key"
-	host := &host.Host{
-		Distro: distro.Distro{
-			SSHOptions: []string{opt},
-		},
-	}
-
-	opts, err := s.manager.GetSSHOptions(host, "")
-	s.Error(err)
-	s.Empty(opts)
-
-	opts, err = s.manager.GetSSHOptions(host, keyname)
-	s.NoError(err)
-	s.Equal([]string{"-i", keyname, "-o", opt}, opts)
-}
-
 func (s *GCESuite) TestSpawnInvalidSettings() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -310,17 +310,6 @@ func (mockMgr *mockManager) OnUp(ctx context.Context, host *host.Host) error {
 	return nil
 }
 
-func (mockMgr *mockManager) GetSSHOptions(host *host.Host, keyPath string) ([]string, error) {
-	l := mockMgr.mutex
-	l.RLock()
-	instance, ok := mockMgr.Instances[host.Id]
-	l.RUnlock()
-	if !ok {
-		return []string{}, errors.Errorf("unable to fetch host: %s", host.Id)
-	}
-	return instance.SSHOptions, nil
-}
-
 func (mockMgr *mockManager) TimeTilNextPayment(host *host.Host) time.Duration {
 	l := mockMgr.mutex
 	l.RLock()

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -220,21 +220,6 @@ func (m *openStackManager) GetDNSName(ctx context.Context, host *host.Host) (str
 	return "", errors.Errorf("could not find IP for host %s", host.Id)
 }
 
-// GetSSHOptions generates the command line args to be passed to SSH to allow connection
-// to the machine.
-func (m *openStackManager) GetSSHOptions(host *host.Host, keyPath string) ([]string, error) {
-	if keyPath == "" {
-		return []string{}, errors.New("No key specified for host")
-	}
-
-	opts := []string{"-i", keyPath}
-	for _, opt := range host.Distro.SSHOptions {
-		opts = append(opts, "-o", opt)
-	}
-
-	return opts, nil
-}
-
 // TimeTilNextPayment always returns 0. The OpenStack dashboard requires third-party
 // plugins for billing, monitoring, and other management tools.
 func (m *openStackManager) TimeTilNextPayment(host *host.Host) time.Duration {

--- a/cloud/openstack_test.go
+++ b/cloud/openstack_test.go
@@ -224,19 +224,6 @@ func (s *OpenStackSuite) TestGetDNSNameAPICall() {
 	s.Empty(dns)
 }
 
-func (s *OpenStackSuite) TestGetSSHOptions() {
-	opt := "Option"
-	host := &host.Host{
-		Distro: distro.Distro{
-			SSHOptions: []string{opt},
-		},
-	}
-
-	opts, err := s.manager.GetSSHOptions(host, s.keyname)
-	s.NoError(err)
-	s.Equal([]string{"-i", s.keyname, "-o", opt}, opts)
-}
-
 func (s *OpenStackSuite) TestSpawnInvalidSettings() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -200,7 +200,7 @@ func constructPwdUpdateCommand(ctx context.Context, env evergreen.Environment, h
 		return nil, errors.WithStack(err)
 	}
 
-	sshOptions, err := cloudHost.GetSSHOptions()
+	sshOptions, err := hostObj.GetSSHOptions(env.Settings())
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -190,11 +190,6 @@ func SetHostRDPPassword(ctx context.Context, env evergreen.Environment, host *ho
 // constructPwdUpdateCommand returns a RemoteCommand struct used to
 // set the RDP password on a remote windows machine.
 func constructPwdUpdateCommand(ctx context.Context, env evergreen.Environment, hostObj *host.Host, password string) (*jasper.Command, error) {
-	cloudHost, err := GetCloudHost(ctx, hostObj, env)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
 	hostInfo, err := hostObj.GetSSHInfo()
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -99,16 +99,6 @@ func (staticMgr *staticManager) OnUp(context.Context, *host.Host) error {
 	return nil
 }
 
-func (staticMgr *staticManager) GetSSHOptions(h *host.Host, keyPath string) (opts []string, err error) {
-	if keyPath != "" {
-		opts = append(opts, "-i", keyPath)
-	}
-	for _, opt := range h.Distro.SSHOptions {
-		opts = append(opts, "-o", opt)
-	}
-	return opts, nil
-}
-
 // determine how long until a payment is due for the host. static hosts always
 // return 0 for this number
 func (staticMgr *staticManager) TimeTilNextPayment(host *host.Host) time.Duration {

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -192,21 +192,6 @@ func (m *vsphereManager) GetDNSName(ctx context.Context, h *host.Host) (string, 
 	return ip, nil
 }
 
-// GetSSHOptions generates the command line args to be
-// passed to SSH to allow connection to the machine.
-func (m *vsphereManager) GetSSHOptions(host *host.Host, keyPath string) ([]string, error) {
-	if keyPath == "" {
-		return []string{}, errors.Errorf("No key specified for host %s", host.Id)
-	}
-
-	opts := []string{"-i", keyPath}
-	for _, opt := range host.Distro.SSHOptions {
-		opts = append(opts, "-o", opt)
-	}
-
-	return opts, nil
-}
-
 // TimeTilNextPayment ...
 // TODO: implement payment information for vSphere
 func (m *vsphereManager) TimeTilNextPayment(host *host.Host) time.Duration {

--- a/cloud/vsphere_test.go
+++ b/cloud/vsphere_test.go
@@ -210,20 +210,6 @@ func (s *VSphereSuite) TestGetDNSNameAPICall() {
 	s.Empty(dns)
 }
 
-func (s *VSphereSuite) TestGetSSHOptions() {
-	opt := "Option"
-	keyname := "key"
-	host := &host.Host{
-		Distro: distro.Distro{
-			SSHOptions: []string{opt},
-		},
-	}
-
-	opts, err := s.manager.GetSSHOptions(host, keyname)
-	s.NoError(err)
-	s.Equal([]string{"-i", keyname, "-o", opt}, opts)
-}
-
 func (s *VSphereSuite) TestSpawnInvalidSettings() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -140,7 +140,8 @@ func (h *Host) GetSSHInfo() (*util.StaticHostInfo, error) {
 // single distro-level SSH key name corresponding to an existing SSH key file on
 // the app servers. We should be able to handle multiple keys configured in
 // admin settings rather than from a file name in distro settings.
-func (h *Host) GetSSHOptions(keyPath string) ([]string, error) {
+func (h *Host) GetSSHOptions(settings *evergreen.Settings) ([]string, error) {
+	keyPath := settings.Keys[h.Distro.SSHKey]
 	if keyPath == "" {
 		return nil, errors.New("no SSH key specified for host")
 	}
@@ -716,7 +717,7 @@ func (h *Host) JasperClient(ctx context.Context, env evergreen.Environment) (jas
 			if err != nil {
 				return nil, errors.Wrap(err, "could not get host's SSH info")
 			}
-			sshOpts, err := h.GetSSHOptions(settings.Keys[h.Distro.SSHKey])
+			sshOpts, err := h.GetSSHOptions(settings)
 			if err != nil {
 				return nil, errors.Wrap(err, "could not get host's SSH options")
 			}

--- a/units/host_execute.go
+++ b/units/host_execute.go
@@ -82,7 +82,7 @@ func (j *hostExecuteJob) Run(ctx context.Context) {
 		return
 	}
 
-	sshOptions, err := j.host.GetSSHOptions(j.env.Settings().Keys[j.host.Distro.SSHKey])
+	sshOptions, err := j.host.GetSSHOptions(j.env.Settings())
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "could not get ssh options",

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -307,7 +307,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		return
 	}
 
-	if err := j.runHostTeardown(ctx, cloudHost); err != nil {
+	if err := j.runHostTeardown(ctx, settings); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"job_type": j.Type().Name,
 			"message":  "Error running teardown script",
@@ -360,14 +360,14 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	}
 }
 
-func (j *hostTerminationJob) runHostTeardown(ctx context.Context, cloudHost *cloud.CloudHost) error {
+func (j *hostTerminationJob) runHostTeardown(ctx context.Context, settings *evergreen.Settings) error {
 	if j.host.Distro.Teardown == "" ||
 		j.host.Status == evergreen.HostProvisionFailed ||
 		j.host.SpawnOptions.SpawnedByTask {
 		return nil
 	}
 
-	sshOptions, err := cloudHost.GetSSHOptions()
+	sshOptions, err := j.host.GetSSHOptions(settings)
 	if err != nil {
 		return errors.Wrapf(err, "error getting ssh options for host %s", j.host.Id)
 	}

--- a/units/jasper_deploy.go
+++ b/units/jasper_deploy.go
@@ -241,7 +241,7 @@ func (j *jasperDeployJob) Run(ctx context.Context) {
 			return
 		}
 	} else {
-		sshOpts, err := j.host.GetSSHOptions(j.settings.Keys[j.host.Distro.SSHKey])
+		sshOpts, err := j.host.GetSSHOptions(j.settings)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "could not get SSH options",

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -209,10 +208,6 @@ func (j *agentDeployJob) getHostMessage(h host.Host) message.Fields {
 func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergreen.Settings, hostObj host.Host) error {
 
 	// get the host's SSH options
-	cloudHost, err := cloud.GetCloudHost(ctx, &hostObj, j.env)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to get cloud host for %s", hostObj.Id)
-	}
 	sshOptions, err := hostObj.GetSSHOptions(settings)
 	if err != nil {
 		return errors.Wrapf(err, "Error getting ssh options for host %s", hostObj.Id)

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -213,7 +213,7 @@ func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergre
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get cloud host for %s", hostObj.Id)
 	}
-	sshOptions, err := cloudHost.GetSSHOptions()
+	sshOptions, err := hostObj.GetSSHOptions(settings)
 	if err != nil {
 		return errors.Wrapf(err, "Error getting ssh options for host %s", hostObj.Id)
 	}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -304,12 +304,7 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 // on the host, downloading the latest version of Jasper, and restarting the
 // Jasper service.
 func (j *setupHostJob) setupJasper(ctx context.Context, settings *evergreen.Settings) error {
-	cloudHost, err := cloud.GetCloudHost(ctx, j.host, j.env)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get cloud host for %s", j.host.Id)
-	}
-
-	sshOptions, err := cloudHost.GetSSHOptions()
+	sshOptions, err := j.host.GetSSHOptions(settings)
 	if err != nil {
 		return errors.Wrapf(err, "error getting ssh options for host %s", j.host.Id)
 	}
@@ -589,18 +584,7 @@ func (j *setupHostJob) provisionHost(ctx context.Context, h *host.Host, settings
 			return errors.Wrapf(err, "Failed to load client binary onto host %s: %+v", h.Id, err)
 		}
 
-		cloudHost, err := cloud.GetCloudHost(ctx, h, j.env)
-		if err != nil {
-			grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
-				"operation": "setting host unprovisioned",
-				"job":       j.ID(),
-				"distro":    h.Distro.Id,
-				"host":      h.Id,
-			}))
-
-			return errors.Wrapf(err, "Failed to get cloud host for %s", h.Id)
-		}
-		sshOptions, err := cloudHost.GetSSHOptions()
+		sshOptions, err := h.GetSSHOptions(settings)
 		if err != nil {
 			grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
 				"operation": "setting host unprovisioned",
@@ -713,11 +697,7 @@ func (j *setupHostJob) loadClient(ctx context.Context, target *host.Host, settin
 		return nil, errors.Wrapf(err, "error parsing ssh info %s", target.Host)
 	}
 
-	cloudHost, err := cloud.GetCloudHost(ctx, target, j.env)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to get cloud host for %s", target.Id)
-	}
-	sshOptions, err := cloudHost.GetSSHOptions()
+	sshOptions, err := target.GetSSHOptions(settings)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error getting ssh options for host %v", target.Id)
 	}
@@ -816,11 +796,7 @@ func (j *setupHostJob) fetchRemoteTaskData(ctx context.Context, taskId, cliPath,
 		return errors.Wrapf(err, "error parsing ssh info %s", target.Host)
 	}
 
-	cloudHost, err := cloud.GetCloudHost(ctx, target, j.env)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to get cloud host for %v", target.Id)
-	}
-	sshOptions, err := cloudHost.GetSSHOptions()
+	sshOptions, err := target.GetSSHOptions(settings)
 	if err != nil {
 		return errors.Wrapf(err, "Error getting ssh options for host %v", target.Id)
 	}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -472,11 +472,7 @@ func (j *setupHostJob) copyScript(ctx context.Context, settings *evergreen.Setti
 		return errors.Wrap(err, "error writing local script")
 	}
 
-	cloudHost, err := cloud.GetCloudHost(ctx, target, j.env)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get cloud host for %s", target.Id)
-	}
-	sshOptions, err := cloudHost.GetSSHOptions()
+	sshOptions, err := target.GetSSHOptions(settings)
 	if err != nil {
 		return errors.Wrapf(err, "error getting ssh options for host %v", target.Id)
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6903

Use `host.Host.GetSSHOptions()` instead since all the GetSSHOptions implementations were identical anyways.