### PR TITLE
EVG-6859: retry agent deploy job without waiting for MaxLCT to elapse

### DIFF
--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -98,7 +98,7 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 	}
 	if util.StringSliceContains(evergreen.DownHostStatus, j.host.Status) {
 		grip.Debug(message.Fields{
-			"host_id": j.host.Id,
+			"host":    j.host.Id,
 			"status":  j.host.Status,
 			"message": "host already down, not attempting to deploy agent",
 		})
@@ -130,6 +130,40 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 	}
 	defer func() {
 		if j.HasErrors() {
+			var noRetries bool
+			noRetries, err = j.checkNoRetries()
+			if err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"message": "could not check whether host can retry agent deploy",
+					"host":    j.host.Id,
+					"distro":  j.host.Distro.Id,
+					"job":     j.ID(),
+				}))
+				j.AddError(err)
+			} else if noRetries {
+				var externallyTerminated bool
+				externallyTerminated, err = handleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
+				j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
+				if externallyTerminated {
+					return
+				}
+
+				if disableErr := j.host.DisablePoisonedHost(fmt.Sprintf("failed %d times to put agent on host", agentPutRetries)); disableErr != nil {
+					j.AddError(errors.Wrapf(disableErr, "error terminating host %s", j.host.Id))
+					return
+				}
+
+				job := NewDecoHostNotifyJob(j.env, j.host, nil, "error starting agent on host")
+				grip.Error(message.WrapError(j.env.RemoteQueue().Put(ctx, job),
+					message.Fields{
+						"message": fmt.Sprintf("tried %d times to put agent on host", agentPutRetries),
+						"host":    j.host.Id,
+						"distro":  j.host.Distro,
+					}))
+
+				return
+			}
+
 			if err = j.host.SetNeedsNewAgent(true); err != nil {
 				grip.Info(message.WrapError(err, message.Fields{
 					"distro":  j.host.Distro,
@@ -142,33 +176,6 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 	}()
 
 	j.AddError(j.startAgentOnHost(ctx, settings, *j.host))
-
-	stat, err := event.GetRecentAgentDeployStatuses(j.HostID, agentPutRetries)
-	j.AddError(err)
-	if err != nil {
-		return
-	}
-
-	if stat.LastAttemptFailed() && stat.AllAttemptsFailed() && stat.Count >= agentPutRetries {
-		externallyTerminated, err := handleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
-		j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
-		if externallyTerminated {
-			return
-		}
-
-		if disableErr := j.host.DisablePoisonedHost(fmt.Sprintf("failed %d times to put agent on host", agentPutRetries)); disableErr != nil {
-			j.AddError(errors.Wrapf(disableErr, "error terminating host %s", j.host.Id))
-			return
-		}
-
-		job := NewDecoHostNotifyJob(j.env, j.host, nil, "error starting agent on host")
-		grip.Error(message.WrapError(j.env.RemoteQueue().Put(ctx, job),
-			message.Fields{
-				"message": fmt.Sprintf("tried %d times to put agent on host", agentPutRetries),
-				"host_id": j.host.Id,
-				"distro":  j.host.Distro,
-			}))
-	}
 }
 
 // SSHTimeout defines the timeout for the SSH commands in this package.
@@ -207,7 +214,6 @@ func (j *agentDeployJob) getHostMessage(h host.Host) message.Fields {
 // preparation on the remote machine, then kicks off the agent process on the
 // machine. Returns an error if any step along the way fails.
 func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergreen.Settings, hostObj host.Host) error {
-
 	// get the host's SSH options
 	cloudHost, err := cloud.GetCloudHost(ctx, &hostObj, j.env)
 	if err != nil {
@@ -228,7 +234,9 @@ func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergre
 	grip.Info(message.Fields{
 		"runner":  "taskrunner",
 		"message": "prepping host for agent",
-		"host":    hostObj.Id})
+		"host":    hostObj.Id,
+		"job":     j.ID(),
+	})
 	if err = j.prepRemoteHost(ctx, hostObj, sshOptions, settings); err != nil {
 		event.LogHostAgentDeployFailed(hostObj.Id, err)
 		grip.Info(message.Fields{
@@ -237,7 +245,7 @@ func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergre
 			"job":     j.ID(),
 			"error":   err.Error(),
 		})
-		return nil
+		return errors.Wrap(err, "could not prep remote host")
 	}
 
 	grip.Info(message.Fields{"runner": "taskrunner", "message": "prepping host finished successfully", "host": hostObj.Id})
@@ -272,6 +280,13 @@ func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergre
 func (j *agentDeployJob) prepRemoteHost(ctx context.Context, hostObj host.Host, sshOptions []string, settings *evergreen.Settings) error {
 	// copy over the correct agent binary to the remote host
 	if logs, err := hostObj.RunSSHCommand(ctx, hostObj.CurlCommand(settings), sshOptions); err != nil {
+		event.LogHostAgentDeployFailed(hostObj.Id, err)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "error fetching agent",
+			"host":    hostObj.Id,
+			"job":     j.ID(),
+			"logs":    logs,
+		}))
 		return errors.Wrapf(err, "error downloading agent binary on remote host: %s", logs)
 	}
 
@@ -285,10 +300,11 @@ func (j *agentDeployJob) prepRemoteHost(ctx context.Context, hostObj host.Host, 
 
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error running setup script",
-			"host_id": hostObj.Id,
-			"distro":  hostObj.Distro.Id,
 			"runner":  "taskrunner",
+			"host":    hostObj.Id,
+			"distro":  hostObj.Distro.Id,
 			"logs":    logs,
+			"job":     j.ID(),
 		}))
 
 		// there is no guarantee setup scripts are idempotent, so we terminate the host if the setup script fails
@@ -300,7 +316,7 @@ func (j *agentDeployJob) prepRemoteHost(ctx context.Context, hostObj host.Host, 
 		grip.Error(message.WrapError(j.env.RemoteQueue().Put(ctx, job),
 			message.Fields{
 				"message": fmt.Sprintf("tried %d times to put agent on host", agentPutRetries),
-				"host_id": hostObj.Id,
+				"host":    hostObj.Id,
 				"distro":  hostObj.Distro,
 			}))
 
@@ -379,4 +395,13 @@ func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *everg
 	event.LogHostAgentDeployed(hostObj.Id)
 
 	return nil
+}
+
+func (j *agentDeployJob) checkNoRetries() (bool, error) {
+	stat, err := event.GetRecentAgentDeployStatuses(j.HostID, agentPutRetries)
+	if err != nil {
+		return false, errors.Wrap(err, "could not get recent agent deploy statuses")
+	}
+
+	return stat.LastAttemptFailed() && stat.AllAttemptsFailed() && stat.Count >= agentPutRetries, nil
 }

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -122,8 +122,21 @@ func (j *agentMonitorDeployJob) Run(ctx context.Context) {
 			var noRetries bool
 			noRetries, err = j.checkNoRetries()
 			if err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"message": "could not check whether host can retry agent monitor deploy",
+					"host":    j.host.Id,
+					"distro":  j.host.Distro.Id,
+					"job":     j.ID(),
+				}))
 				j.AddError(err)
 			} else if noRetries {
+				var externallyTerminated bool
+				externallyTerminated, err = handleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
+				j.AddError(errors.Wrapf(err, "can't check if host %s was externally terminated", j.host.Id))
+				if externallyTerminated {
+					return
+				}
+
 				if err = j.disableHost(ctx, fmt.Sprintf("failed %d times to put agent monitor on host", agentMonitorPutRetries)); err != nil {
 					j.AddError(errors.Wrapf(err, "error marking host %s for termination", j.host.Id))
 					return
@@ -163,12 +176,6 @@ func (j *agentMonitorDeployJob) hostDown() bool {
 // disableHost changes the host so that it is down and enqueues a job to
 // terminate it.
 func (j *agentMonitorDeployJob) disableHost(ctx context.Context, reason string) error {
-	externallyTerminated, err := handleExternallyTerminatedHost(ctx, j.ID(), j.env, j.host)
-	j.AddError(errors.Wrapf(err, "can't check if host '%s' was externally terminated", j.HostID))
-	if externallyTerminated {
-		return nil
-	}
-
 	if err := j.host.DisablePoisonedHost(reason); err != nil {
 		return errors.Wrapf(err, "error terminating host %s", j.host.Id)
 	}
@@ -186,7 +193,7 @@ func (j *agentMonitorDeployJob) disableHost(ctx context.Context, reason string) 
 // checkNoRetries checks if the job has exhausted the maximum allowed attempts
 // to deploy the agent monitor.
 func (j *agentMonitorDeployJob) checkNoRetries() (bool, error) {
-	stat, err := event.GetRecentAgentMonitorDeployStatuses(j.HostID, agentMonitorPutRetries)
+	stat, err := event.GetRecentAgentMonitorDeployStatuses(j.host.Id, agentMonitorPutRetries)
 	if err != nil {
 		return false, errors.Wrap(err, "could not get recent agent monitor deploy statuses")
 	}
@@ -239,16 +246,18 @@ func (j *agentMonitorDeployJob) runSetupScript(ctx context.Context, settings *ev
 	}
 	output, err := j.host.RunJasperProcess(ctx, j.env, opts)
 	if err != nil {
+		reason := "error running setup script on host"
 		grip.Error(message.WrapError(err, message.Fields{
-			"message":       "error running setup script on host",
-			"host":          j.host.Id,
-			"distro":        j.host.Distro.Id,
-			"output":        output,
-			"communication": j.host.Distro.BootstrapSettings.Communication,
-			"job":           j.ID(),
+			"message": reason,
+			"host":    j.host.Id,
+			"distro":  j.host.Distro.Id,
+			"logs":    output,
+			"job":     j.ID(),
 		}))
-
-		return err
+		catcher := grip.NewBasicCatcher()
+		catcher.Wrapf(err, "%s: %s", reason, output)
+		catcher.Wrap(j.disableHost(ctx, reason), "failed to disable host after setup script failed")
+		return catcher.Resolve()
 	}
 
 	return nil

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -119,6 +119,10 @@ func (j *agentMonitorDeployJob) Run(ctx context.Context) {
 		if j.HasErrors() {
 			event.LogHostAgentMonitorDeployFailed(j.host.Id, j.Error())
 
+			if j.host.Status != evergreen.HostRunning {
+				return
+			}
+
 			var noRetries bool
 			noRetries, err = j.checkNoRetries()
 			if err != nil {

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -184,7 +184,8 @@ func cleanUpTimedOutTask(ctx context.Context, env evergreen.Environment, id stri
 		// cleared on the host, an agent or agent moniitor deploy might run,
 		// which updates the LCT and prevents detection of external termination
 		// until the deploy job runs out of retries.
-		terminated, err := handleExternallyTerminatedHost(ctx, id, env, host)
+		var terminated bool
+		terminated, err = handleExternallyTerminatedHost(ctx, id, env, host)
 		if err != nil {
 			return errors.Wrap(err, "could not check host with timed out task for external termination")
 		}

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -180,7 +180,8 @@ func TestCleanupTask(t *testing.T) {
 
 					// refresh the host, make sure its running task field has
 					// been reset
-					h, err := host.FindOne(host.ById("h1"))
+					var err error
+					h, err = host.FindOne(host.ById("h1"))
 					So(err, ShouldBeNil)
 					So(h.RunningTask, ShouldEqual, "")
 
@@ -192,7 +193,8 @@ func TestCleanupTask(t *testing.T) {
 
 					So(cleanUpTimedOutTask(ctx, env, t.Name(), newTask), ShouldBeNil)
 
-					h, err := host.FindOneId("h1")
+					var err error
+					h, err = host.FindOneId("h1")
 					So(err, ShouldBeNil)
 					So(h.RunningTask, ShouldEqual, "")
 					So(h.Status, ShouldEqual, evergreen.HostTerminated)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6859

* If the agent deploy failed while curling the agent binary over SSH, don't wait until MaxLCT (5 mins) to elapse before attempting redeploy.
* This might increase the provisioning error rate if the hosts are really slow at starting up sshd since it will try the agent deploy job more often.
* Agent monitor deploy job now decommissions host if setup script fails.