### PR TITLE
EVG-6892: do not require caching to succeed in order to call GetInstanceStatus

### DIFF
--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -171,17 +171,24 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 	}
 	defer m.client.Close()
 
-	instance, err := m.getInstance(ctx, h)
+	instance, err := m.client.GetInstanceInfo(ctx, h.Id)
 	if err != nil {
-		return status, errors.Wrapf(err, "can't get instance status")
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":       "error getting instance info",
+			"host":          h.Id,
+			"host_provider": h.Distro.Provider,
+			"distro":        h.Distro.Id,
+		}))
+		return status, errors.Wrap(err, "error getting instance info")
 	}
 
+	if instance.State == nil || instance.State.Name == nil || *instance.State.Name == "" {
+		return status, errors.New("state name is missing")
+	}
 	status = ec2StatusToEvergreenStatus(*instance.State.Name)
 	if status == StatusRunning {
 		// cache instance information so we can make fewer calls to AWS's API
-		if err = cacheHostData(ctx, h, instance, m.client); err != nil {
-			return status, errors.Wrapf(err, "can't update host '%s'", h.Id)
-		}
+		grip.Warning(errors.Wrapf(cacheHostData(ctx, h, instance, m.client), "can't update host '%s'", h.Id))
 	}
 
 	return status, nil
@@ -303,25 +310,6 @@ func (m *ec2FleetManager) GetSSHOptions(h *host.Host, keyName string) ([]string,
 
 func (m *ec2FleetManager) TimeTilNextPayment(h *host.Host) time.Duration {
 	return timeTilNextEC2Payment(h)
-}
-
-func (m *ec2FleetManager) getInstance(ctx context.Context, h *host.Host) (*ec2.Instance, error) {
-	instance, err := m.client.GetInstanceInfo(ctx, h.Id)
-	if err != nil {
-		grip.Error(message.WrapError(err, message.Fields{
-			"message":       "error getting instance info",
-			"host":          h.Id,
-			"host_provider": h.Distro.Provider,
-			"distro":        h.Distro.Id,
-		}))
-		return nil, errors.Wrap(err, "error getting instance info")
-	}
-
-	if err = validateEc2InstanceInfoResponse(instance); err != nil {
-		return nil, errors.Wrap(err, "invalid instance info response")
-	}
-
-	return instance, nil
 }
 
 func (m *ec2FleetManager) spawnFleetSpotHost(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings, blockDevices []*ec2.LaunchTemplateBlockDeviceMappingRequest) error {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -188,7 +188,10 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 	status = ec2StatusToEvergreenStatus(*instance.State.Name)
 	if status == StatusRunning {
 		// cache instance information so we can make fewer calls to AWS's API
-		grip.Warning(errors.Wrapf(cacheHostData(ctx, h, instance, m.client), "can't update host '%s'", h.Id))
+		grip.Error(message.WrapError(cacheHostData(ctx, h, instance, m.client), message.Fields{
+			"message": "can't update host cached data",
+			"host":    h.Id,
+		}))
 	}
 
 	return status, nil

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -426,28 +426,6 @@ func validateEc2DescribeInstancesOutput(describeInstancesResponse *ec2aws.Descri
 	return catcher.Resolve()
 }
 
-func validateEc2InstanceInfoResponse(instance *ec2aws.Instance) error {
-	if instance == nil {
-		return errors.New("instance is nil")
-	}
-
-	catcher := grip.NewBasicCatcher()
-	if instance.Placement == nil || instance.Placement.AvailabilityZone == nil || len(*instance.Placement.AvailabilityZone) == 0 {
-		catcher.Add(errors.New("AZ is missing"))
-	}
-	if instance.LaunchTime == nil {
-		catcher.Add(errors.New("launch time is nil"))
-	}
-	if instance.PublicDnsName == nil || len(*instance.PublicDnsName) == 0 {
-		catcher.Add(errors.New("dns name is missing"))
-	}
-	if instance.State == nil || instance.State.Name == nil || len(*instance.State.Name) == 0 {
-		catcher.Add(errors.New("state name is missing"))
-	}
-
-	return catcher.Resolve()
-}
-
 func validateEc2DescribeSubnetsOutput(describeSubnetsOutput *ec2aws.DescribeSubnetsOutput) error {
 	if describeSubnetsOutput == nil {
 		return errors.New("describe subnets response is nil")


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6892

The only field that the fleet manager actually needs in `(*ec2FleetManager).GetInstanceStatus()` to return a value is `(*ec2.Instance).State.Name`. Other fields in the response from `(*awsClientImpl).GetInstanceInfo()` (such as PublicDnsName) are not guaranteed to be populated, especially if the host is already terminated on the AWS side. Furthermore, these fields are only needed for caching host data, so don't require validation of optional AWS response fields and only warn if caching fails in `(*ec2FleetManager).GetInstanceStatus()`.