### PR TITLE
EVG-6888 pipe through components and labels for JIRA issues

### DIFF
--- a/config_jira_notifications.go
+++ b/config_jira_notifications.go
@@ -60,8 +60,22 @@ func (c *JIRANotificationsConfig) Set() error {
 
 func (c *JIRANotificationsConfig) ValidateAndDefault() error {
 	catcher := grip.NewSimpleCatcher()
+	projectSet := make(map[string]bool)
 	for _, project := range c.CustomFields {
+		if projectSet[project.Project] {
+			catcher.Add(errors.Errorf("duplicate project key '%s'", project.Project))
+			continue
+		}
+		projectSet[project.Project] = true
+
+		fieldSet := make(map[string]bool)
 		for _, field := range project.Fields {
+			if fieldSet[field.Field] {
+				catcher.Add(errors.Errorf("duplicate field key '%s' in project '%s'", field.Field, project.Project))
+				continue
+			}
+			fieldSet[field.Field] = true
+
 			_, err := template.New(fmt.Sprintf("%s-%s", project.Project, field.Field)).Parse(field.Template)
 			catcher.Add(err)
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -586,7 +586,7 @@ func (s *AdminSuite) TestContainerPoolsConfig() {
 
 func (s *AdminSuite) TestJIRANotificationsConfig() {
 	c := JIRANotificationsConfig{
-		CustomFields: JIRACustomFieldsByProject{
+		CustomFields: []JIRANotificationsProject{
 			{
 				Project: "this",
 				Fields: []JIRANotificationsCustomField{
@@ -605,7 +605,7 @@ func (s *AdminSuite) TestJIRANotificationsConfig() {
 		s.NoError(c.ValidateAndDefault())
 	})
 
-	c.CustomFields = JIRACustomFieldsByProject{
+	c.CustomFields = []JIRANotificationsProject{
 		{
 			Project: "EVG",
 			Fields: []JIRANotificationsCustomField{
@@ -616,27 +616,17 @@ func (s *AdminSuite) TestJIRANotificationsConfig() {
 			},
 		},
 	}
-	m, err := c.CustomFields.ToMap()
-	s.NoError(err)
-	s.Require().Len(m, 1)
-	s.Require().Len(m["EVG"], 1)
-
 	s.Require().NoError(c.Set())
 
 	c = JIRANotificationsConfig{}
 	s.Require().NoError(c.Get(s.env))
 	s.NoError(c.ValidateAndDefault())
-	m, err = c.CustomFields.ToMap()
-	s.NoError(err)
-	s.Require().Len(m, 1)
-	s.Require().Len(m["EVG"], 1)
-	s.Equal("magical{{.Template.Expansion}}", m["EVG"]["customfield_12345"])
-	s.NoError(c.ValidateAndDefault())
+	s.Len(c.CustomFields, 1)
 
 	c = JIRANotificationsConfig{}
 	s.NoError(c.Set())
 	s.NoError(c.ValidateAndDefault())
-	c.CustomFields = JIRACustomFieldsByProject{
+	c.CustomFields = []JIRANotificationsProject{
 		{
 			Project: "this",
 			Fields: []JIRANotificationsCustomField{

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -375,23 +375,49 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
       return;
     }
     if (!$scope.Settings.jira_notifications.custom_fields[value]) {
-      $scope.Settings.jira_notifications.custom_fields[value] = {};
+      $scope.Settings.jira_notifications.custom_fields[value] = {fields: {}, components: [], labels: []};
     }
     delete $scope.jiraMapping.newProject;
   }
   $scope.addJIRAFieldToProject = function(project) {
     var field = $scope.jiraMapping.newField[project];
-    if (!field || $scope.Settings.jira_notifications.custom_fields[project][field]) {
+    
+    if ($scope.Settings.jira_notifications.custom_fields[project].fields == null) {
+      $scope.Settings.jira_notifications.custom_fields[project].fields = {}
+    }
+
+    if (!field || $scope.Settings.jira_notifications.custom_fields[project].fields[field]) {
         return;
     }
-    $scope.Settings.jira_notifications.custom_fields[project][field] = "{FIXME}";
+
+    $scope.Settings.jira_notifications.custom_fields[project].fields[field] = "{FIXME}";
     delete $scope.jiraMapping.newField[project];
   }
   $scope.deleteJIRAFieldFromProject = function(project, field) {
     if (!field) {
         return;
     }
-    delete $scope.Settings.jira_notifications.custom_fields[project][field];
+    delete $scope.Settings.jira_notifications.custom_fields[project].fields[field];
+  }
+  $scope.removeComponent = function(project, component) {
+    var index = $scope.Settings.jira_notifications.custom_fields[project].components.indexOf(component);
+    $scope.Settings.jira_notifications.custom_fields[project].components.splice(index, 1);
+  }
+  $scope.removeLabel = function(project, label) {
+    var index = $scope.Settings.jira_notifications.custom_fields[project].labels.indexOf(label);
+    $scope.Settings.jira_notifications.custom_fields[project].labels.splice(index, 1);
+  }
+  $scope.addComponent = function(project) {
+    if ($scope.Settings.jira_notifications.custom_fields[project].components == null) {
+      $scope.Settings.jira_notifications.custom_fields[project].components = [];
+    }
+    $scope.Settings.jira_notifications.custom_fields[project].components.push("");
+  }
+  $scope.addLabel = function(project) {
+    if ($scope.Settings.jira_notifications.custom_fields[project].labels == null) {
+      $scope.Settings.jira_notifications.custom_fields[project].labels = [];
+    }
+    $scope.Settings.jira_notifications.custom_fields[project].labels.push("");
   }
 
   $scope.jiraMapping = {};

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -273,16 +273,20 @@ func TestAPIJIRANotificationsConfig(t *testing.T) {
 	assert.Nil(dbModel.CustomFields)
 
 	api = APIJIRANotificationsConfig{
-		CustomFields: map[string]map[string]string{
-			"EVG": map[string]string{
-				"customfield_12345": "{{.Something}}",
-				"customfield_12346": "{{.SomethingElse}}",
-				"components":        "component0,component1",
+		CustomFields: map[string]APIJIRANotificationsProject{
+			"EVG": APIJIRANotificationsProject{
+				Fields: map[string]string{
+					"customfield_12345": "{{.Something}}",
+					"customfield_12346": "{{.SomethingElse}}",
+				},
+				Components: []string{"component0", "component1"},
 			},
-			"GVE": map[string]string{
-				"customfield_54321": "{{.SomethingElser}}",
-				"customfield_54322": "{{.SomethingEvenElser}}",
-				"labels":            "label0,label1",
+			"GVE": APIJIRANotificationsProject{
+				Fields: map[string]string{
+					"customfield_54321": "{{.SomethingElser}}",
+					"customfield_54322": "{{.SomethingEvenElser}}",
+				},
+				Labels: []string{"label0", "label1"},
 			},
 		},
 	}

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1397,41 +1397,86 @@ Admin Settings
 							<md-card flex=100 id="jira_notifications">
 								<md-card-title>
 									<md-card-title-text>
-										<span>JIRA Notifications Custom Field Mappings</span>
+										<span>JIRA Notifications Fields</span>
 									</md-card-title-text>
 									<md-button ng-click="clearSection('jira_notifications')">
 										<i class="fa fa-trash"></i>
 									</md-button>
 								</md-card-title>
 								<md-card-content>
-									<div ng-repeat="(project, fields) in Settings.jira_notifications.custom_fields">
+									<div ng-repeat="(projectName, project) in Settings.jira_notifications.custom_fields">
 										<div>
-											<span>JIRA Project: [[project]]</span>
+											<span>JIRA Project: [[projectName]]</span>
 											<span>
-												<md-button ng-click="deleteJIRAProject(project)">
+												<md-button ng-click="deleteJIRAProject(projectName)">
 													<i class="fa fa-trash"></i>
 												</md-button>
 											</span>
 										</div>
-										<span ng-repeat="(fieldName, tmpl) in fields">
-											<md-input-container class="control" style="width: 200px;">
-												<label>[[fieldName]]</label>
-												<input type="text" ng-model="Settings.jira_notifications.custom_fields[project][fieldName]">
-											</md-input-container>
-											<md-button ng-click="deleteJIRAFieldFromProject(project, fieldName)">
-												<i class="fa fa-trash"></i>
-											</md-button>
-										</span>
 										<div>
-											<md-input-container class="control" style="width:45%;">
-												<label>Add new field</label>
-												<input type="text" default="ABC" ng-model="jiraMapping.newField[project]" />
-											</md-input-container>
-											<md-button ng-click="addJIRAFieldToProject(project)">
-												<i class="fa fa-plus"></i>
-											</md-button>
+											<label>Components</label>
+											<div>
+											  <table style="margin-left: -8px;">
+												<tbody ng-repeat="component in project.components track by $index">
+												  <tr>
+													<td style="padding-left: 10px;">
+														<input type="text" ng-model="Settings.jira_notifications.custom_fields[projectName].components[$index]" class="form-control">
+													</td>
+													<td>
+													  <a ng-click="removeComponent(projectName, component)">
+														<i class="fa fa-trash"></i>
+													  </a>
+													</td>
+												  </tr>
+												</tbody>
+											  </table>
+											</div>
+											<button type="button" class="md-raised md-button" ng-click="addComponent(projectName)"><i class="fa fa-plus"></i>Add Component</button>
 										</div>
-										<hr />
+										<div>
+											<label>Labels</label>
+											<div>
+											  <table style="margin-left: -8px;">
+												<tbody ng-repeat="label in project.labels track by $index">
+												  <tr>
+													<td style="padding-left: 10px;">
+														<input type="text" ng-model="Settings.jira_notifications.custom_fields[projectName].labels[$index]" class="form-control">
+													</td>
+													<td>
+													  <a ng-click="removeLabel(projectName, label)">
+														<i class="fa fa-trash"></i>
+													  </a>
+													</td>
+												  </tr>
+												</tbody>
+											  </table>
+											</div>
+											<button type="button" class="md-raised md-button" ng-click="addLabel(projectName)"><i class="fa fa-plus"></i>Add Label</button>
+										</div>
+										<div>
+											<label>Custom Fields</label>
+											<div>
+												<span ng-repeat="(fieldName, tmpl) in project.fields">
+													<md-input-container class="control" style="width: 200px;">
+														<label>[[fieldName]]</label>
+														<input type="text" ng-model="Settings.jira_notifications.custom_fields[projectName].fields[fieldName]">
+													</md-input-container>
+													<md-button ng-click="deleteJIRAFieldFromProject(projectName, fieldName)">
+														<i class="fa fa-trash"></i>
+													</md-button>
+												</span>
+											</div>
+											<div>
+												<md-input-container class="control" style="width:45%;">
+													<label>Add new custom field</label>
+													<input type="text" default="ABC" ng-model="jiraMapping.newField[projectName]" />
+												</md-input-container>
+												<md-button ng-click="addJIRAFieldToProject(projectName)">
+													<i class="fa fa-plus"></i>
+												</md-button>
+											</div>
+											<hr />
+										</div>
 									</div>
 									<div>
 										<md-input-container class="control" style="width: 200px;">


### PR DESCRIPTION
Since components and labels are sent to JIRA as lists they can't be specified with the existing custom JIRA fields admin setting because that will just send JIRA a string. Allow an admin to specify components and labels for JIRA issues as comma separated lists.

Move some conversion logic into the rest model.