### PR TITLE
EVG-6764 simplify updating cache in generate.tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -480,6 +480,15 @@ func RefreshTasksCache(buildId string) error {
 	return errors.WithStack(build.SetTasksCache(buildId, cache))
 }
 
+func mergeTasksCache(buildID string, oldTasks []task.Task, newTasks task.Tasks) error {
+	allTasks := oldTasks
+	for _, newTask := range newTasks {
+		allTasks = append(allTasks, *newTask)
+	}
+	cache := CreateTasksCache(allTasks)
+	return errors.WithStack(build.SetTasksCache(buildID, cache))
+}
+
 // AddTasksToBuild creates the tasks for the given build of a project
 func AddTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *Version, taskNames []string,
 	displayNames []string, generatedBy string, tasksInBuild []task.Task, distroAliases map[string][]string) (*build.Build, error) {
@@ -502,7 +511,7 @@ func AddTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 	}
 
 	// update the build to hold the new tasks
-	if err := RefreshTasksCache(b.Id); err != nil {
+	if err := mergeTasksCache(b.Id, tasksInBuild, tasks); err != nil {
 		return nil, errors.Wrapf(err, "error updating task cache for '%s'", b.Id)
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -449,16 +449,13 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 			return err
 		}
 		if err = build.UpdateCachedTask(t.DisplayTask, t.TimeTaken); err != nil {
-			b, findErr := build.FindOneId(t.BuildId)
 			grip.Error(message.WrapError(err, message.Fields{
-				"message":     "failed to update cached display task",
-				"function":    "MarkEnd",
-				"build_id":    t.DisplayTask.BuildId,
-				"task_id":     t.DisplayTask.Id,
-				"status":      t.DisplayTask.Status,
-				"time_taken":  t.TimeTaken,
-				"build_cache": b.Tasks,
-				"find_err":    findErr,
+				"message":    "failed to update cached display task",
+				"function":   "MarkEnd",
+				"build_id":   t.DisplayTask.BuildId,
+				"task_id":    t.DisplayTask.Id,
+				"status":     t.DisplayTask.Status,
+				"time_taken": t.TimeTaken,
 			}))
 		}
 		if err = checkResetDisplayTask(t.DisplayTask); err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -860,19 +860,14 @@ func updateDisplayTaskAndCache(t *task.Task) error {
 		return errors.Wrap(err, "error updating display task")
 	}
 	err = build.UpdateCachedTask(t.DisplayTask, 0)
-	if err != nil {
-		b, findErr := build.FindOneId(t.BuildId)
-		grip.Error(message.WrapError(err, message.Fields{
-			"message":      "failed to update cached display task",
-			"function":     "updateDisplayTaskAndCache",
-			"build_id":     t.BuildId,
-			"task_id":      t.Id,
-			"display_task": t.DisplayTask.Id,
-			"status":       t.Status,
-			"build_cache":  b.Tasks,
-			"find_err":     findErr,
-		}))
-	}
+	grip.Error(message.WrapError(err, message.Fields{
+		"message":      "failed to update cached display task",
+		"function":     "updateDisplayTaskAndCache",
+		"build_id":     t.BuildId,
+		"task_id":      t.Id,
+		"display_task": t.DisplayTask.Id,
+		"status":       t.Status,
+	}))
 	return nil
 }
 


### PR DESCRIPTION
I'm not sure what exactly is the cause of the errors still, but this removes a place when we're unnecessarily reading our own write