### PR TITLE
EVG-6619 generate device name before attaching volume

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1077,13 +1077,10 @@ func (m *ec2Manager) AttachVolume(ctx context.Context, h *host.Host, attachment 
 		return errors.Wrap(err, "error creating client")
 	}
 
+	// if no device name is provided, generate a unique device name
 	if attachment.DeviceName == "" {
 		deviceName := generateDeviceNameForVolume()
-		exists, err := host.HostExistsWithVolumeWithDeviceName(deviceName)
-		if err != nil {
-			return errors.Wrapf(err, "error querying for volume with device name")
-		}
-		if !exists {
+		if exists, _ := host.HostExistsWithVolumeWithDeviceName(deviceName); !exists {
 			attachment.DeviceName = deviceName
 		}
 	}

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1078,7 +1078,7 @@ func (m *ec2Manager) AttachVolume(ctx context.Context, h *host.Host, attachment 
 	}
 
 	// if no device name is provided, generate a unique device name
-	if attachment.DeviceName == "" {
+	for attachment.DeviceName == "" {
 		deviceName := generateDeviceNameForVolume()
 		if exists, _ := host.HostExistsWithVolumeWithDeviceName(deviceName); !exists {
 			attachment.DeviceName = deviceName

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1333,7 +1333,7 @@ func (s *EC2Suite) TestAttachVolume() {
 	host, err := host.FindOneId(s.h.Id)
 	s.NotNil(host)
 	s.NoError(err)
-	s.Contains(host.Volumes, newAttachment)
+	s.Contains(host.Volumes, *newAttachment)
 }
 
 func (s *EC2Suite) TestAttachVolumeGenerateDeviceName() {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1336,6 +1336,22 @@ func (s *EC2Suite) TestAttachVolume() {
 	s.Contains(host.Volumes, newAttachment)
 }
 
+func (s *EC2Suite) TestAttachVolumeGenerateDeviceName() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Require().NoError(s.h.Insert())
+	newAttachment := &host.VolumeAttachment{
+		VolumeID: "test-volume",
+	}
+
+	s.NoError(s.onDemandManager.AttachVolume(ctx, s.h, newAttachment))
+
+	s.Equal("test-volume", newAttachment.VolumeID)
+	s.NotEqual("", newAttachment.DeviceName)
+	s.Len(newAttachment.DeviceName, len("/dev/sdf1"))
+}
+
 func (s *EC2Suite) TestDetachVolume() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -304,7 +304,7 @@ func generateDeviceNameForVolume() string {
 	letters := "fghijklmnop"
 	rand.Seed(time.Now().Unix())
 
-	return fmt.Sprintf("/def/sd%c%d", letters[rand.Intn(len(letters))], rand.Intn(5)+1)
+	return fmt.Sprintf("/dev/sd%c%d", letters[rand.Intn(len(letters))], rand.Intn(5)+1)
 }
 
 func makeBlockDeviceMappings(mounts []MountPoint) ([]*ec2aws.BlockDeviceMapping, error) {

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -2,7 +2,9 @@ package cloud
 
 import (
 	"context"
+	"fmt"
 	"math"
+	"math/rand"
 	"os"
 	"os/user"
 	"regexp"
@@ -295,6 +297,14 @@ type Terms struct {
 			}
 		}
 	}
+}
+
+// format /dev/sd[f-p][1-6] taken from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
+func generateDeviceNameForVolume() string {
+	letters := "fghijklmnop"
+	rand.Seed(time.Now().Unix())
+
+	return fmt.Sprintf("/def/sd%c%d", letters[rand.Intn(len(letters))], rand.Intn(5)+1)
 }
 
 func makeBlockDeviceMappings(mounts []MountPoint) ([]*ec2aws.BlockDeviceMapping, error) {

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -95,6 +95,7 @@ var (
 	VolumeTypeKey                = bsonutil.MustHaveTag(Volume{}, "Type")
 	VolumeSizeKey                = bsonutil.MustHaveTag(Volume{}, "Size")
 	VolumeAttachmentIDKey        = bsonutil.MustHaveTag(VolumeAttachment{}, "VolumeID")
+	VolumeDeviceNameKey          = bsonutil.MustHaveTag(VolumeAttachment{}, "DeviceName")
 )
 
 var (
@@ -361,6 +362,20 @@ func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, erro
 		return 0, errors.Wrap(err, "error querying database for hosts")
 	}
 	return len(hosts), nil
+}
+
+func HostExistsWithVolumeWithDeviceName(deviceName string) (bool, error) {
+	q := db.Query(
+		bson.M{bsonutil.GetDottedKeyName(VolumesKey, VolumeDeviceNameKey): deviceName},
+	)
+
+	hosts, err := Find(q)
+	if err != nil {
+		return false, errors.Wrapf(err, "error querying database for host volumes")
+	}
+	hostExists := len(hosts) > 0
+	return hostExists, nil
+
 }
 
 // IsUninitialized is a query that returns all unstarted + uninitialized Evergreen hosts.

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -371,10 +371,7 @@ func (h *attachVolumeHandler) Parse(ctx context.Context, r *http.Request) error 
 	if h.attachment.VolumeID == "" {
 		return errors.New("must provide a volume ID")
 	}
-	// TODO: can modify once Evergreen generates device names
-	if h.attachment.DeviceName == "" {
-		return errors.New("must provide a device name to attach (recommended form: /dev/sd[f-p][1-6])")
-	}
+
 	var err error
 	h.hostID, err = validateID(gimlet.GetVars(r)["host_id"])
 	if err != nil {


### PR DESCRIPTION
Each volume must have a unique device name, which is recommended to be of the form `/dev/sd[f-p[1-6]`. This generates a device name if the device name isn't specified, and uses a device name assuming no other currently attached volume has that device name.