### PR TITLE
EVG-6912: fix EBS volume tests

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -511,10 +511,12 @@ func (m *ec2Manager) getResources(ctx context.Context, h *host.Host) ([]string, 
 			return nil, errors.WithStack(errors.New("spot instance does not yet have an instanceId"))
 		}
 	}
+
 	volumeIDs, err := m.client.GetVolumeIDs(ctx, h)
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't get volume IDs for '%s'", h.Id)
 	}
+
 	resources := []string{instanceID}
 	resources = append(resources, volumeIDs...)
 	return resources, nil

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -973,26 +973,7 @@ func (c *awsClientImpl) GetVolumeIDs(ctx context.Context, h *host.Host) ([]strin
 		if err != nil {
 			return nil, errors.Wrap(err, "error getting devices")
 		}
-		attachments := makeVolumeAttachments(devices)
-
-		volumeIDs := make([]string, 0, len(attachments))
-		for _, attachment := range attachments {
-			volumeIDs = append(volumeIDs, attachment.VolumeID)
-		}
-
-		volumes, err := c.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
-			VolumeIds: aws.StringSlice(volumeIDs),
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "error describing volumes")
-		}
-
-		var size int64
-		for _, v := range volumes.Volumes {
-			size += *v.Size
-		}
-
-		if err := h.SetVolumes(attachments, size); err != nil {
+		if err := h.SetVolumes(makeVolumeAttachments(devices)); err != nil {
 			return nil, errors.Wrap(err, "error saving host volumes")
 		}
 	}
@@ -1469,26 +1450,7 @@ func (c *awsClientMock) GetVolumeIDs(ctx context.Context, h *host.Host) ([]strin
 		if err != nil {
 			return nil, errors.Wrap(err, "error getting devices")
 		}
-		attachments := makeVolumeAttachments(devices)
-
-		volumeIDs := make([]string, 0, len(attachments))
-		for _, attachment := range attachments {
-			volumeIDs = append(volumeIDs, attachment.VolumeID)
-		}
-
-		volumes, err := c.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
-			VolumeIds: aws.StringSlice(volumeIDs),
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "error describing volumes")
-		}
-
-		var size int64
-		for _, v := range volumes.Volumes {
-			size += *v.Size
-		}
-
-		if err := h.SetVolumes(attachments, size); err != nil {
+		if err := h.SetVolumes(makeVolumeAttachments(devices)); err != nil {
 			return nil, errors.Wrap(err, "error setting host volumes")
 		}
 	}

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -973,7 +973,26 @@ func (c *awsClientImpl) GetVolumeIDs(ctx context.Context, h *host.Host) ([]strin
 		if err != nil {
 			return nil, errors.Wrap(err, "error getting devices")
 		}
-		if err := h.SetVolumes(makeVolumeAttachments(devices)); err != nil {
+		attachments := makeVolumeAttachments(devices)
+
+		volumeIDs := make([]string, 0, len(attachments))
+		for _, attachment := range attachments {
+			volumeIDs = append(volumeIDs, attachment.VolumeID)
+		}
+
+		volumes, err := c.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+			VolumeIds: aws.StringSlice(volumeIDs),
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "error describing volumes")
+		}
+
+		var size int64
+		for _, v := range volumes.Volumes {
+			size += *v.Size
+		}
+
+		if err := h.SetVolumes(attachments, size); err != nil {
 			return nil, errors.Wrap(err, "error saving host volumes")
 		}
 	}
@@ -1450,7 +1469,26 @@ func (c *awsClientMock) GetVolumeIDs(ctx context.Context, h *host.Host) ([]strin
 		if err != nil {
 			return nil, errors.Wrap(err, "error getting devices")
 		}
-		if err := h.SetVolumes(makeVolumeAttachments(devices)); err != nil {
+		attachments := makeVolumeAttachments(devices)
+
+		volumeIDs := make([]string, 0, len(attachments))
+		for _, attachment := range attachments {
+			volumeIDs = append(volumeIDs, attachment.VolumeID)
+		}
+
+		volumes, err := c.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+			VolumeIds: aws.StringSlice(volumeIDs),
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "error describing volumes")
+		}
+
+		var size int64
+		for _, v := range volumes.Volumes {
+			size += *v.Size
+		}
+
+		if err := h.SetVolumes(attachments, size); err != nil {
 			return nil, errors.Wrap(err, "error setting host volumes")
 		}
 	}

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -973,7 +973,9 @@ func (c *awsClientImpl) GetVolumeIDs(ctx context.Context, h *host.Host) ([]strin
 		if err != nil {
 			return nil, errors.Wrap(err, "error getting devices")
 		}
-		h.Volumes = makeVolumeAttachments(devices)
+		if err := h.SetVolumes(makeVolumeAttachments(devices)); err != nil {
+			return nil, errors.Wrap(err, "error saving host volumes")
+		}
 	}
 
 	// Get string slice of volume IDs
@@ -1443,12 +1445,14 @@ func (c *awsClientMock) GetInstanceBlockDevices(ctx context.Context, h *host.Hos
 }
 
 func (c *awsClientMock) GetVolumeIDs(ctx context.Context, h *host.Host) ([]string, error) {
-	if len(h.Volumes) != 0 {
-		volumeIDs := []string{}
-		for _, attachment := range h.Volumes {
-			volumeIDs = append(volumeIDs, attachment.VolumeID)
+	if h.Volumes == nil {
+		devices, err := c.GetInstanceBlockDevices(ctx, h)
+		if err != nil {
+			return nil, errors.Wrap(err, "error getting devices")
 		}
-		return volumeIDs, nil
+		if err := h.SetVolumes(makeVolumeAttachments(devices)); err != nil {
+			return nil, errors.Wrap(err, "error setting host volumes")
+		}
 	}
 
 	return []string{"volume_id"}, nil

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1353,6 +1353,7 @@ func (c *awsClientMock) GetInstanceInfo(ctx context.Context, id string) (*ec2.In
 			Ebs: &ec2.EbsInstanceBlockDevice{
 				VolumeId: aws.String("volume_id"),
 			},
+			DeviceName: aws.String("device_name"),
 		},
 	}
 	instance.LaunchTime = aws.Time(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
@@ -1442,7 +1443,7 @@ func (c *awsClientMock) GetInstanceBlockDevices(ctx context.Context, h *host.Hos
 }
 
 func (c *awsClientMock) GetVolumeIDs(ctx context.Context, h *host.Host) ([]string, error) {
-	if len(h.Volumes) == 0 {
+	if len(h.Volumes) != 0 {
 		volumeIDs := []string{}
 		for _, attachment := range h.Volumes {
 			volumeIDs = append(volumeIDs, attachment.VolumeID)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -825,7 +825,7 @@ func (s *EC2Suite) TestOnUp() {
 	s.NotNil(foundHost)
 	s.Require().Len(foundHost.Volumes, 1)
 	s.Equal("volume_id", foundHost.Volumes[0].VolumeID)
-	s.Equal("volume_id", foundHost.Volumes[0].DeviceName)
+	s.Equal("device_name", foundHost.Volumes[0].DeviceName)
 }
 
 func (s *EC2Suite) TestGetDNSName() {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1314,11 +1314,11 @@ func (s *EC2Suite) TestAttachVolume() {
 	defer cancel()
 
 	s.Require().NoError(s.h.Insert())
-	newAttachment := &host.VolumeAttachment{
+	newAttachment := host.VolumeAttachment{
 		VolumeID:   "test-volume",
 		DeviceName: "test-device-name",
 	}
-	s.NoError(s.onDemandManager.AttachVolume(ctx, s.h, newAttachment))
+	s.NoError(s.onDemandManager.AttachVolume(ctx, s.h, &newAttachment))
 
 	manager, ok := s.onDemandManager.(*ec2Manager)
 	s.True(ok)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -814,7 +814,7 @@ func (s *EC2Suite) TestOnUp() {
 	s.True(ok)
 	mock, ok := manager.client.(*awsClientMock)
 	s.True(ok)
-	s.Nil(mock.DescribeVolumesInput)
+	s.NotNil(mock.DescribeVolumesInput)
 
 	s.Len(mock.CreateTagsInput.Resources, 2)
 	s.Equal(s.h.Id, *mock.CreateTagsInput.Resources[0])
@@ -826,6 +826,7 @@ func (s *EC2Suite) TestOnUp() {
 	s.Require().Len(foundHost.Volumes, 1)
 	s.Equal("volume_id", foundHost.Volumes[0].VolumeID)
 	s.Equal("device_name", foundHost.Volumes[0].DeviceName)
+	s.NotZero(foundHost.VolumeTotalSize)
 }
 
 func (s *EC2Suite) TestGetDNSName() {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -814,7 +814,7 @@ func (s *EC2Suite) TestOnUp() {
 	s.True(ok)
 	mock, ok := manager.client.(*awsClientMock)
 	s.True(ok)
-	s.NotNil(mock.DescribeVolumesInput)
+	s.Nil(mock.DescribeVolumesInput)
 
 	s.Len(mock.CreateTagsInput.Resources, 2)
 	s.Equal(s.h.Id, *mock.CreateTagsInput.Resources[0])
@@ -826,7 +826,6 @@ func (s *EC2Suite) TestOnUp() {
 	s.Require().Len(foundHost.Volumes, 1)
 	s.Equal("volume_id", foundHost.Volumes[0].VolumeID)
 	s.Equal("device_name", foundHost.Volumes[0].DeviceName)
-	s.NotZero(foundHost.VolumeTotalSize)
 }
 
 func (s *EC2Suite) TestGetDNSName() {

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -380,10 +380,12 @@ func makeBlockDeviceMappingsTemplate(mounts []MountPoint) ([]*ec2aws.LaunchTempl
 func makeVolumeAttachments(devices []*ec2.InstanceBlockDeviceMapping) []host.VolumeAttachment {
 	attachments := []host.VolumeAttachment{}
 	for _, device := range devices {
-		attachments = append(attachments, host.VolumeAttachment{
-			VolumeID:   *device.Ebs.VolumeId,
-			DeviceName: *device.DeviceName,
-		})
+		if device.Ebs != nil && device.Ebs.VolumeId != nil && device.DeviceName != nil {
+			attachments = append(attachments, host.VolumeAttachment{
+				VolumeID:   *device.Ebs.VolumeId,
+				DeviceName: *device.DeviceName,
+			})
+		}
 	}
 	return attachments
 }

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -996,6 +996,23 @@ func AggregateLastContainerFinishTimes() ([]FinishTime, error) {
 
 }
 
+func (h *Host) SetVolumes(volumes []VolumeAttachment) error {
+	_, err := UpsertOne(
+		bson.M{
+			IdKey: h.Id,
+		},
+		bson.M{
+			"$set": bson.M{
+				VolumesKey: volumes,
+			},
+		})
+	if err != nil {
+		return errors.Wrapf(err, "error updating host volumes")
+	}
+	h.Volumes = volumes
+	return nil
+}
+
 func (h *Host) AddVolumeToHost(newVolume *VolumeAttachment) error {
 	_, err := db.FindAndModify(Collection,
 		bson.M{

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -996,22 +996,20 @@ func AggregateLastContainerFinishTimes() ([]FinishTime, error) {
 
 }
 
-func (h *Host) SetVolumes(volumes []VolumeAttachment, size int64) error {
+func (h *Host) SetVolumes(volumes []VolumeAttachment) error {
 	_, err := UpsertOne(
 		bson.M{
 			IdKey: h.Id,
 		},
 		bson.M{
 			"$set": bson.M{
-				VolumesKey:         volumes,
-				VolumeTotalSizeKey: size,
+				VolumesKey: volumes,
 			},
 		})
 	if err != nil {
 		return errors.Wrapf(err, "error updating host volumes")
 	}
 	h.Volumes = volumes
-	h.VolumeTotalSize = size
 	return nil
 }
 

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -997,7 +997,7 @@ func AggregateLastContainerFinishTimes() ([]FinishTime, error) {
 }
 
 func (h *Host) SetVolumes(volumes []VolumeAttachment) error {
-	_, err := UpsertOne(
+	_, err := UpdateOne(
 		bson.M{
 			IdKey: h.Id,
 		},

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -996,20 +996,22 @@ func AggregateLastContainerFinishTimes() ([]FinishTime, error) {
 
 }
 
-func (h *Host) SetVolumes(volumes []VolumeAttachment) error {
+func (h *Host) SetVolumes(volumes []VolumeAttachment, size int64) error {
 	_, err := UpsertOne(
 		bson.M{
 			IdKey: h.Id,
 		},
 		bson.M{
 			"$set": bson.M{
-				VolumesKey: volumes,
+				VolumesKey:         volumes,
+				VolumeTotalSizeKey: size,
 			},
 		})
 	if err != nil {
 		return errors.Wrapf(err, "error updating host volumes")
 	}
 	h.Volumes = volumes
+	h.VolumeTotalSize = size
 	return nil
 }
 

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -997,7 +997,7 @@ func AggregateLastContainerFinishTimes() ([]FinishTime, error) {
 }
 
 func (h *Host) SetVolumes(volumes []VolumeAttachment) error {
-	_, err := UpdateOne(
+	err := UpdateOne(
 		bson.M{
 			IdKey: h.Id,
 		},


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6912

* Several cloud tests were expecting fields when caching host data that were not set in the mock AWS client.
* Also fix some `TestAttachVolumes` types.
* Fix `TestOnUp` due to bug where host volumes would be set on in-memory host but would not be persisted to the database the first time the host's volumes are retrieved. (Can someone verify that this is actually what we want to do?)