### PR TITLE
EVG-6901 Fix task group order regression

### DIFF
--- a/scheduler/task_priority_cmp_test.go
+++ b/scheduler/task_priority_cmp_test.go
@@ -205,7 +205,7 @@ func TestByTaskGroupOrder(t *testing.T) {
 	tasks[0].TaskGroup = "example_task_group"
 	result, err = byTaskGroupOrder(tasks[0], tasks[1], taskComparator)
 	assert.NoError(err)
-	assert.Equal(0, result)
+	assert.Equal(1, result)
 	tasks[0].TaskGroup = ""
 	tasks[1].TaskGroup = "example_task_group"
 	result, err = byTaskGroupOrder(tasks[0], tasks[1], taskComparator)
@@ -217,7 +217,7 @@ func TestByTaskGroupOrder(t *testing.T) {
 	tasks[1].TaskGroup = "another_task_group"
 	result, err = byTaskGroupOrder(tasks[0], tasks[1], taskComparator)
 	assert.NoError(err)
-	assert.Equal(1, result)
+	assert.Equal(-1, result)
 
 	// mismatched builds
 	tasks[0].TaskGroup = "example_task_group"
@@ -226,7 +226,7 @@ func TestByTaskGroupOrder(t *testing.T) {
 	tasks[1].BuildId = "another_build_id"
 	result, err = byTaskGroupOrder(tasks[0], tasks[1], taskComparator)
 	assert.NoError(err)
-	assert.Equal(1, result)
+	assert.Equal(-1, result)
 
 	// t1 is earlier
 	tasks[0].TaskGroup = "example_task_group"


### PR DESCRIPTION
In https://github.com/evergreen-ci/evergreen/commit/60788eca2454682f882ae00e4e9b4659d651e119, we started using the cached task group order instead of parsing the yaml in order to determine the order of task groups. This introduced a regression. In the case where two task groups have different build IDs, they should be sorted according to how they were originally sorted, i.e., in groupTaskGroups.