### PR TITLE
EVG-6764 simplify updating cache in generate.tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -480,6 +480,15 @@ func RefreshTasksCache(buildId string) error {
 	return errors.WithStack(build.SetTasksCache(buildId, cache))
 }
 
+func mergeTasksCache(buildID string, oldTasks []task.Task, newTasks task.Tasks) error {
+	allTasks := oldTasks
+	for _, newTask := range newTasks {
+		allTasks = append(allTasks, *newTask)
+	}
+	cache := CreateTasksCache(allTasks)
+	return errors.WithStack(build.SetTasksCache(buildID, cache))
+}
+
 // AddTasksToBuild creates the tasks for the given build of a project
 func AddTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *Version, taskNames []string,
 	displayNames []string, generatedBy string, tasksInBuild []task.Task, distroAliases map[string][]string) (*build.Build, error) {
@@ -502,7 +511,7 @@ func AddTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 	}
 
 	// update the build to hold the new tasks
-	if err := RefreshTasksCache(b.Id); err != nil {
+	if err := mergeTasksCache(b.Id, tasksInBuild, tasks); err != nil {
 		return nil, errors.Wrapf(err, "error updating task cache for '%s'", b.Id)
 	}
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -447,7 +447,7 @@ func CreateTasksCache(tasks []task.Task) []build.TaskCache {
 	tasks = sortTasks(tasks)
 	cache := make([]build.TaskCache, 0, len(tasks))
 	for _, task := range tasks {
-		if task.DisplayTask == nil {
+		if !task.IsPartOfDisplay() {
 			cache = append(cache, cacheFromTask(task))
 		}
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -445,13 +445,18 @@ func RestartBuildTasks(buildId string, caller string) error {
 
 func CreateTasksCache(tasks []task.Task) []build.TaskCache {
 	tasks = sortTasks(tasks)
-	cache := make([]build.TaskCache, 0, len(tasks))
+	buildCache := make([]build.TaskCache, 0, len(tasks))
+	tempCache := task.NewDisplayTaskCache()
 	for _, task := range tasks {
-		if !task.IsPartOfDisplay() {
-			cache = append(cache, cacheFromTask(task))
+		displayTask, err := tempCache.Get(&task)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "unable to get display task",
+		}))
+		if displayTask == nil {
+			buildCache = append(buildCache, cacheFromTask(task))
 		}
 	}
-	return cache
+	return buildCache
 }
 
 // RefreshTasksCache updates a build document so that the tasks cache reflects the correct current

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1842,3 +1842,39 @@ func TestMarkAsDispatched(t *testing.T) {
 	})
 
 }
+
+func TestCreateTasksCache(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(task.Collection))
+	// execution tasks should be removed
+	tasks := []task.Task{
+		{
+			Id:          "execTask1",
+			DisplayName: "execTask1",
+		},
+		{
+			Id:          "execTask2",
+			DisplayName: "execTask2",
+		},
+		{
+			Id:          "displayTask",
+			DisplayName: "displayTask",
+			DisplayOnly: true,
+			ExecutionTasks: []string{
+				"execTask1",
+				"execTask2",
+			},
+		},
+		{
+			Id:          "regularTask",
+			DisplayName: "regularTask",
+		},
+	}
+	for _, t := range tasks {
+		assert.NoError(t.Insert())
+	}
+	cache := CreateTasksCache(tasks)
+	assert.Equal("displayTask", cache[0].Id)
+	assert.Equal("regularTask", cache[1].Id)
+	assert.Len(cache, 2)
+}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -449,16 +449,13 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 			return err
 		}
 		if err = build.UpdateCachedTask(t.DisplayTask, t.TimeTaken); err != nil {
-			b, findErr := build.FindOneId(t.BuildId)
 			grip.Error(message.WrapError(err, message.Fields{
-				"message":     "failed to update cached display task",
-				"function":    "MarkEnd",
-				"build_id":    t.DisplayTask.BuildId,
-				"task_id":     t.DisplayTask.Id,
-				"status":      t.DisplayTask.Status,
-				"time_taken":  t.TimeTaken,
-				"build_cache": b.Tasks,
-				"find_err":    findErr,
+				"message":    "failed to update cached display task",
+				"function":   "MarkEnd",
+				"build_id":   t.DisplayTask.BuildId,
+				"task_id":    t.DisplayTask.Id,
+				"status":     t.DisplayTask.Status,
+				"time_taken": t.TimeTaken,
 			}))
 		}
 		if err = checkResetDisplayTask(t.DisplayTask); err != nil {
@@ -860,19 +857,14 @@ func updateDisplayTaskAndCache(t *task.Task) error {
 		return errors.Wrap(err, "error updating display task")
 	}
 	err = build.UpdateCachedTask(t.DisplayTask, 0)
-	if err != nil {
-		b, findErr := build.FindOneId(t.BuildId)
-		grip.Error(message.WrapError(err, message.Fields{
-			"message":      "failed to update cached display task",
-			"function":     "updateDisplayTaskAndCache",
-			"build_id":     t.BuildId,
-			"task_id":      t.Id,
-			"display_task": t.DisplayTask.Id,
-			"status":       t.Status,
-			"build_cache":  b.Tasks,
-			"find_err":     findErr,
-		}))
-	}
+	grip.Error(message.WrapError(err, message.Fields{
+		"message":      "failed to update cached display task",
+		"function":     "updateDisplayTaskAndCache",
+		"build_id":     t.BuildId,
+		"task_id":      t.Id,
+		"display_task": t.DisplayTask.Id,
+		"status":       t.Status,
+	}))
 	return nil
 }
 


### PR DESCRIPTION
The check to see if a task is an execution task was not always right, which might have led to the weirdness today