### PR TITLE
EVG-6014 streamline patch finalization

### DIFF
--- a/model/build/build_test.go
+++ b/model/build/build_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -769,4 +770,25 @@ func TestBuildSetCachedTaskFinished(t *testing.T) {
 		b.Tasks[idx].StartTime = b2.Tasks[idx].StartTime
 	}
 	assert.EqualValues(b2, b)
+}
+
+func TestBulkInsert(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
+	builds := Builds{
+		&Build{Id: "b1"},
+		&Build{Id: "b1"},
+		&Build{Id: "b2"},
+		&Build{Id: "b3"},
+	}
+
+	assert.Error(t, builds.InsertMany(context.Background(), true))
+	dbBuilds, err := Find(db.Q{})
+	assert.NoError(t, err)
+	assert.Len(t, dbBuilds, 1)
+
+	assert.NoError(t, db.ClearCollections(Collection))
+	assert.Error(t, builds.InsertMany(context.Background(), false))
+	dbBuilds, err = Find(db.Q{})
+	assert.NoError(t, err)
+	assert.Len(t, dbBuilds, 3)
 }

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -20,7 +20,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"gopkg.in/mgo.v2"
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -492,7 +492,13 @@ func AddTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 
 	// create the new tasks for the build
 	taskIds := NewTaskIdTable(project, v, "", "")
-	tasks, err := createTasksForBuild(project, buildVariant, b, v, taskIds, taskNames, displayNames, generatedBy, nil, tasksInBuild, distroAliases)
+
+	createTime, err := getTaskCreateTime(project.Identifier, v)
+	if err != nil {
+		return nil, errors.Wrapf(err, "can't get create time for tasks in version '%s'", v.Id)
+	}
+
+	tasks, err := createTasksForBuild(project, buildVariant, b, v, taskIds, taskNames, displayNames, generatedBy, nil, tasksInBuild, distroAliases, createTime)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating tasks for build '%s'", b.Id)
 	}
@@ -511,18 +517,19 @@ func AddTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 
 // BuildCreateArgs is the set of parameters used in CreateBuildFromVersionNoInsert
 type BuildCreateArgs struct {
-	Project       Project                 // project to create the build for
-	Version       Version                 // the version the build belong to
-	TaskIDs       TaskIdConfig            // pre-generated IDs for the tasks to be created
-	BuildName     string                  // name of the buildvariant
-	Activated     bool                    // true if the build should be scheduled
-	TaskNames     []string                // names of tasks to create (used in patches). Will create all if nil
-	DisplayNames  []string                // names of display tasks to create (used in patches). Will create all if nil
-	GeneratedBy   string                  // ID of the task that generated this build
-	SourceRev     string                  // githash of the revision that triggered this build
-	DefinitionID  string                  // definition ID of the trigger used to create this build
-	Aliases       ProjectAliases          // project aliases to use to filter tasks created
-	DistroAliases distro.AliasLookupTable // map of distro aliases to names of distros
+	Project        Project                 // project to create the build for
+	Version        Version                 // the version the build belong to
+	TaskIDs        TaskIdConfig            // pre-generated IDs for the tasks to be created
+	BuildName      string                  // name of the buildvariant
+	Activated      bool                    // true if the build should be scheduled
+	TaskNames      []string                // names of tasks to create (used in patches). Will create all if nil
+	DisplayNames   []string                // names of display tasks to create (used in patches). Will create all if nil
+	GeneratedBy    string                  // ID of the task that generated this build
+	SourceRev      string                  // githash of the revision that triggered this build
+	DefinitionID   string                  // definition ID of the trigger used to create this build
+	Aliases        ProjectAliases          // project aliases to use to filter tasks created
+	DistroAliases  distro.AliasLookupTable // map of distro aliases to names of distros
+	TaskCreateTime time.Time               // create time of tasks in the build
 }
 
 // CreateBuildFromVersionNoInsert creates a build given all of the necessary information
@@ -584,7 +591,7 @@ func CreateBuildFromVersionNoInsert(args BuildCreateArgs) (*build.Build, task.Ta
 	b.BuildNumber = strconv.FormatUint(buildNumber, 10)
 
 	// create all of the necessary tasks for the build
-	tasksForBuild, err := createTasksForBuild(&args.Project, buildVariant, b, &args.Version, args.TaskIDs, args.TaskNames, args.DisplayNames, args.GeneratedBy, args.Aliases, nil, args.DistroAliases)
+	tasksForBuild, err := createTasksForBuild(&args.Project, buildVariant, b, &args.Version, args.TaskIDs, args.TaskNames, args.DisplayNames, args.GeneratedBy, args.Aliases, nil, args.DistroAliases, args.TaskCreateTime)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "error creating tasks for build %s", b.Id)
 	}
@@ -642,7 +649,7 @@ func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project) []BuildVariant
 // appear in the specified build variant.
 func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.Build, v *Version,
 	taskIds TaskIdConfig, taskNames []string, displayNames []string, generatedBy string,
-	aliases ProjectAliases, tasksInBuild []task.Task, distroAliases map[string][]string) (task.Tasks, error) {
+	aliases ProjectAliases, tasksInBuild []task.Task, distroAliases map[string][]string, createTime time.Time) (task.Tasks, error) {
 
 	// the list of tasks we should create.  if tasks are passed in, then
 	// use those, else use the default set
@@ -740,7 +747,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 			}
 			execTaskIds = append(execTaskIds, execTaskId)
 		}
-		t, err := createDisplayTask(id, dt.Name, execTaskIds, buildVariant, b, v, project)
+		t, err := createDisplayTask(id, dt.Name, execTaskIds, buildVariant, b, v, project, createTime)
 		if err != nil {
 			return tasks, errors.Wrapf(err, "Failed to create display task %s", id)
 		}
@@ -753,7 +760,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 
 	for _, t := range tasksToCreate {
 		id := execTable.GetId(b.BuildVariant, t.Name)
-		newTask, err := createOneTask(id, t, project, buildVariant, b, v, distroAliases)
+		newTask, err := createOneTask(id, t, project, buildVariant, b, v, distroAliases, createTime)
 		if err != nil {
 			return tasks, errors.Wrapf(err, "Failed to create task %s", id)
 		}
@@ -940,7 +947,7 @@ func getTaskCreateTime(projectId string, v *Version) (time.Time, error) {
 
 // createOneTask is a helper to create a single task.
 func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Project,
-	buildVariant *BuildVariant, b *build.Build, v *Version, dat distro.AliasLookupTable) (*task.Task, error) {
+	buildVariant *BuildVariant, b *build.Build, v *Version, dat distro.AliasLookupTable, createTime time.Time) (*task.Task, error) {
 
 	buildVarTask.Distros = dat.Expand(buildVarTask.Distros)
 	buildVariant.RunOn = dat.Expand(buildVariant.RunOn)
@@ -972,11 +979,6 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 			"version":   v.Revision,
 			"requester": v.Requester,
 		})
-	}
-
-	createTime, err := getTaskCreateTime(project.Identifier, v)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to get create time for task %s", id)
 	}
 
 	activatedTime := util.ZeroTime
@@ -1026,12 +1028,7 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 }
 
 func createDisplayTask(id string, displayName string, execTasks []string,
-	bv *BuildVariant, b *build.Build, v *Version, p *Project) (*task.Task, error) {
-
-	createTime, err := getTaskCreateTime(p.Identifier, v)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to get create time for task %s", id)
-	}
+	bv *BuildVariant, b *build.Build, v *Version, p *Project, createTime time.Time) (*task.Task, error) {
 
 	activatedTime := util.ZeroTime
 	if b.Activated {
@@ -1217,6 +1214,11 @@ func AddNewBuilds(ctx context.Context, activated bool, v *Version, p *Project, t
 		variantsProcessed[b.BuildVariant] = true
 	}
 
+	createTime, err := getTaskCreateTime(p.Identifier, v)
+	if err != nil {
+		return errors.Wrap(err, "can't get create time for tasks")
+	}
+
 	for _, pair := range tasks.ExecTasks {
 		if _, ok := variantsProcessed[pair.Variant]; ok { // skip variant that was already processed
 			continue
@@ -1226,14 +1228,15 @@ func AddNewBuilds(ctx context.Context, activated bool, v *Version, p *Project, t
 		taskNames := tasks.ExecTasks.TaskNames(pair.Variant)
 		displayNames := tasks.DisplayTasks.TaskNames(pair.Variant)
 		buildArgs := BuildCreateArgs{
-			Project:      *p,
-			Version:      *v,
-			TaskIDs:      taskIds,
-			BuildName:    pair.Variant,
-			Activated:    activated,
-			TaskNames:    taskNames,
-			DisplayNames: displayNames,
-			GeneratedBy:  generatedBy,
+			Project:        *p,
+			Version:        *v,
+			TaskIDs:        taskIds,
+			BuildName:      pair.Variant,
+			Activated:      activated,
+			TaskNames:      taskNames,
+			DisplayNames:   displayNames,
+			GeneratedBy:    generatedBy,
+			TaskCreateTime: createTime,
 		}
 
 		grip.Info(message.Fields{

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -980,12 +980,13 @@ buildvariants:
 		Convey("all of the tasks' essential fields should be set correctly", func() {
 
 			args := BuildCreateArgs{
-				Project:   *project,
-				Version:   *v,
-				TaskIDs:   table,
-				BuildName: buildVar1.Name,
-				Activated: false,
-				TaskNames: []string{},
+				Project:        *project,
+				Version:        *v,
+				TaskIDs:        table,
+				BuildName:      buildVar1.Name,
+				Activated:      false,
+				TaskNames:      []string{},
+				TaskCreateTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 			}
 			build, tasks, err := CreateBuildFromVersionNoInsert(args)
 			So(err, ShouldBeNil)
@@ -998,8 +999,7 @@ buildvariants:
 			So(tasks[2].BuildId, ShouldEqual, build.Id)
 			So(tasks[2].DistroId, ShouldEqual, "arch")
 			So(tasks[2].BuildVariant, ShouldEqual, buildVar1.Name)
-			So(tasks[2].CreateTime.Truncate(time.Second), ShouldResemble,
-				build.CreateTime.Truncate(time.Second))
+			So(tasks[2].CreateTime.Equal(args.TaskCreateTime), ShouldBeTrue)
 			So(tasks[2].Status, ShouldEqual, evergreen.TaskUndispatched)
 			So(tasks[2].Activated, ShouldBeFalse)
 			So(tasks[2].ActivatedTime.Equal(util.ZeroTime), ShouldBeTrue)
@@ -1015,8 +1015,7 @@ buildvariants:
 			So(tasks[3].BuildId, ShouldEqual, build.Id)
 			So(tasks[3].DistroId, ShouldEqual, "arch")
 			So(tasks[3].BuildVariant, ShouldEqual, buildVar1.Name)
-			So(tasks[3].CreateTime.Truncate(time.Second), ShouldResemble,
-				build.CreateTime.Truncate(time.Second))
+			So(tasks[3].CreateTime.Equal(args.TaskCreateTime), ShouldBeTrue)
 			So(tasks[3].Status, ShouldEqual, evergreen.TaskUndispatched)
 			So(tasks[3].Activated, ShouldBeFalse)
 			So(tasks[3].ActivatedTime.Equal(util.ZeroTime), ShouldBeTrue)
@@ -1032,8 +1031,7 @@ buildvariants:
 			So(tasks[4].BuildId, ShouldEqual, build.Id)
 			So(tasks[4].DistroId, ShouldEqual, "arch")
 			So(tasks[4].BuildVariant, ShouldEqual, buildVar1.Name)
-			So(tasks[4].CreateTime.Truncate(time.Second), ShouldResemble,
-				build.CreateTime.Truncate(time.Second))
+			So(tasks[4].CreateTime.Equal(args.TaskCreateTime), ShouldBeTrue)
 			So(tasks[4].Status, ShouldEqual, evergreen.TaskUndispatched)
 			So(tasks[4].Activated, ShouldBeFalse)
 			So(tasks[4].ActivatedTime.Equal(util.ZeroTime), ShouldBeTrue)
@@ -1049,8 +1047,7 @@ buildvariants:
 			So(tasks[5].BuildId, ShouldEqual, build.Id)
 			So(tasks[5].DistroId, ShouldEqual, "arch")
 			So(tasks[5].BuildVariant, ShouldEqual, buildVar1.Name)
-			So(tasks[5].CreateTime.Truncate(time.Second), ShouldResemble,
-				build.CreateTime.Truncate(time.Second))
+			So(tasks[5].CreateTime.Equal(args.TaskCreateTime), ShouldBeTrue)
 			So(tasks[5].Status, ShouldEqual, evergreen.TaskUndispatched)
 			So(tasks[5].Activated, ShouldBeFalse)
 			So(tasks[5].ActivatedTime.Equal(util.ZeroTime), ShouldBeTrue)
@@ -1065,12 +1062,13 @@ buildvariants:
 			func() {
 
 				args := BuildCreateArgs{
-					Project:   *project,
-					Version:   *v,
-					TaskIDs:   table,
-					BuildName: buildVar1.Name,
-					Activated: true,
-					TaskNames: []string{},
+					Project:        *project,
+					Version:        *v,
+					TaskIDs:        table,
+					BuildName:      buildVar1.Name,
+					Activated:      true,
+					TaskNames:      []string{},
+					TaskCreateTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 				}
 				build, tasks, err := CreateBuildFromVersionNoInsert(args)
 				So(err, ShouldBeNil)
@@ -1085,8 +1083,7 @@ buildvariants:
 				So(tasks[2].BuildId, ShouldEqual, build.Id)
 				So(tasks[2].DistroId, ShouldEqual, "arch")
 				So(tasks[2].BuildVariant, ShouldEqual, buildVar1.Name)
-				So(tasks[2].CreateTime.Truncate(time.Second), ShouldResemble,
-					build.CreateTime.Truncate(time.Second))
+				So(tasks[2].CreateTime.Equal(args.TaskCreateTime), ShouldBeTrue)
 				So(tasks[2].Status, ShouldEqual, evergreen.TaskUndispatched)
 				So(tasks[2].Activated, ShouldBeTrue)
 				So(tasks[2].ActivatedTime.Equal(util.ZeroTime), ShouldBeFalse)
@@ -1102,8 +1099,7 @@ buildvariants:
 				So(tasks[3].BuildId, ShouldEqual, build.Id)
 				So(tasks[3].DistroId, ShouldEqual, "arch")
 				So(tasks[3].BuildVariant, ShouldEqual, buildVar1.Name)
-				So(tasks[3].CreateTime.Truncate(time.Second), ShouldResemble,
-					build.CreateTime.Truncate(time.Second))
+				So(tasks[3].CreateTime.Equal(args.TaskCreateTime), ShouldBeTrue)
 				So(tasks[3].Status, ShouldEqual, evergreen.TaskUndispatched)
 				So(tasks[3].Activated, ShouldBeTrue)
 				So(tasks[3].ActivatedTime.Equal(util.ZeroTime), ShouldBeFalse)
@@ -1119,8 +1115,7 @@ buildvariants:
 				So(tasks[4].BuildId, ShouldEqual, build.Id)
 				So(tasks[4].DistroId, ShouldEqual, "arch")
 				So(tasks[4].BuildVariant, ShouldEqual, buildVar1.Name)
-				So(tasks[4].CreateTime.Truncate(time.Second), ShouldResemble,
-					build.CreateTime.Truncate(time.Second))
+				So(tasks[4].CreateTime.Equal(args.TaskCreateTime), ShouldBeTrue)
 				So(tasks[4].Status, ShouldEqual, evergreen.TaskUndispatched)
 				So(tasks[4].Activated, ShouldBeTrue)
 				So(tasks[4].ActivatedTime.Equal(util.ZeroTime), ShouldBeFalse)
@@ -1136,8 +1131,7 @@ buildvariants:
 				So(tasks[5].BuildId, ShouldEqual, build.Id)
 				So(tasks[5].DistroId, ShouldEqual, "arch")
 				So(tasks[5].BuildVariant, ShouldEqual, buildVar1.Name)
-				So(tasks[5].CreateTime.Truncate(time.Second), ShouldResemble,
-					build.CreateTime.Truncate(time.Second))
+				So(tasks[5].CreateTime.Equal(args.TaskCreateTime), ShouldBeTrue)
 				So(tasks[5].Status, ShouldEqual, evergreen.TaskUndispatched)
 				So(tasks[5].Activated, ShouldBeTrue)
 				So(tasks[5].ActivatedTime.Equal(util.ZeroTime), ShouldBeFalse)

--- a/model/task/sorter.go
+++ b/model/task/sorter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type Tasks []*Task
@@ -38,7 +39,8 @@ func (t Tasks) InsertUnordered(ctx context.Context) error {
 	if t.Len() == 0 {
 		return nil
 	}
-	_, err := evergreen.GetEnvironment().DB().Collection(Collection).InsertMany(ctx, t.getPayload())
+	ordered := false
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).InsertMany(ctx, t.getPayload(), &options.InsertManyOptions{Ordered: &ordered})
 	return err
 }
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -738,101 +738,101 @@ func TestMergeTestResultsBulk(t *testing.T) {
 }
 
 func TestTaskSetResultsFields(t *testing.T) {
-        taskID := "jstestfuzz_self_tests_replication_fuzzers_master_initial_sync_fuzzer_69e2630b3272211f46bf85dd2577cd9a34c7c2cc_19_09_25_17_40_35"
-        project := "jstestfuzz-self-tests"
-        distroID := "amazon2-test"
-        buildVariant := "replication_fuzzers"
-        displayName := "fuzzer"
-        requester := "gitter_request"
+	taskID := "jstestfuzz_self_tests_replication_fuzzers_master_initial_sync_fuzzer_69e2630b3272211f46bf85dd2577cd9a34c7c2cc_19_09_25_17_40_35"
+	project := "jstestfuzz-self-tests"
+	distroID := "amazon2-test"
+	buildVariant := "replication_fuzzers"
+	displayName := "fuzzer"
+	requester := "gitter_request"
 
-        displayTaskID := "jstestfuzz_self_tests_replication_fuzzers_display_master_69e2630b3272211f46bf85dd2577cd9a34c7c2cc_19_09_25_17_40_35"
-        executionDisplayName := "master"
-        StartTime := 1569431862.508
-        EndTime := 1569431887.2
+	displayTaskID := "jstestfuzz_self_tests_replication_fuzzers_display_master_69e2630b3272211f46bf85dd2577cd9a34c7c2cc_19_09_25_17_40_35"
+	executionDisplayName := "master"
+	StartTime := 1569431862.508
+	EndTime := 1569431887.2
 
-        TestStartTime := util.FromPythonTime(StartTime).In(time.UTC)
-        TestEndTime := util.FromPythonTime(EndTime).In(time.UTC)
+	TestStartTime := util.FromPythonTime(StartTime).In(time.UTC)
+	TestEndTime := util.FromPythonTime(EndTime).In(time.UTC)
 
-        testresults := []TestResult{
-                {
-                        Status:    "pass",
-                        TestFile:  "job0_fixture_setup",
-                        URL:       "https://logkeeper.mongodb.org/build/dd239a5697eedef049a753c6a40a3e7e/test/5d8ba136c2ab68304e1d741c",
-                        URLRaw:    "https://logkeeper.mongodb.org/build/dd239a5697eedef049a753c6a40a3e7e/test/5d8ba136c2ab68304e1d741c?raw=1",
-                        ExitCode:  0,
-                        StartTime: StartTime,
-                        EndTime:   EndTime,
-                },
-        }
+	testresults := []TestResult{
+		{
+			Status:    "pass",
+			TestFile:  "job0_fixture_setup",
+			URL:       "https://logkeeper.mongodb.org/build/dd239a5697eedef049a753c6a40a3e7e/test/5d8ba136c2ab68304e1d741c",
+			URLRaw:    "https://logkeeper.mongodb.org/build/dd239a5697eedef049a753c6a40a3e7e/test/5d8ba136c2ab68304e1d741c?raw=1",
+			ExitCode:  0,
+			StartTime: StartTime,
+			EndTime:   EndTime,
+		},
+	}
 
-        Convey("SetResults", t, func() {
-                So(db.Clear(Collection), ShouldBeNil)
-                So(db.Clear(testresult.Collection), ShouldBeNil)
+	Convey("SetResults", t, func() {
+		So(db.Clear(Collection), ShouldBeNil)
+		So(db.Clear(testresult.Collection), ShouldBeNil)
 
-                taskCreateTime, err := time.Parse(time.RFC3339, "2019-09-25T17:40:35Z")
-                So(err, ShouldBeNil)
+		taskCreateTime, err := time.Parse(time.RFC3339, "2019-09-25T17:40:35Z")
+		So(err, ShouldBeNil)
 
-                task := Task{
-                        Id:           taskID,
-                        CreateTime:   taskCreateTime,
-                        Project:      project,
-                        DistroId:     distroID,
-                        BuildVariant: buildVariant,
-                        DisplayName:  displayName,
-                        Execution:    0,
-                        Requester:    requester,
-                }
+		task := Task{
+			Id:           taskID,
+			CreateTime:   taskCreateTime,
+			Project:      project,
+			DistroId:     distroID,
+			BuildVariant: buildVariant,
+			DisplayName:  displayName,
+			Execution:    0,
+			Requester:    requester,
+		}
 
-                executionDisplayTask := Task{
-                        Id:             displayTaskID,
-                        CreateTime:     taskCreateTime,
-                        Project:        project,
-                        DistroId:       distroID,
-                        BuildVariant:   buildVariant,
-                        DisplayName:    executionDisplayName,
-                        Execution:      0,
-                        Requester:      requester,
-                        ExecutionTasks: []string{taskID},
-                }
+		executionDisplayTask := Task{
+			Id:             displayTaskID,
+			CreateTime:     taskCreateTime,
+			Project:        project,
+			DistroId:       distroID,
+			BuildVariant:   buildVariant,
+			DisplayName:    executionDisplayName,
+			Execution:      0,
+			Requester:      requester,
+			ExecutionTasks: []string{taskID},
+		}
 
-                So(task.Insert(), ShouldBeNil)
-                Convey("Without a display task", func() {
+		So(task.Insert(), ShouldBeNil)
+		Convey("Without a display task", func() {
 
-                        So(task.SetResults(testresults), ShouldBeNil)
+			So(task.SetResults(testresults), ShouldBeNil)
 
-                        written, err := testresult.Find(testresult.ByTaskIDs([]string{taskID}))
-                        So(err, ShouldBeNil)
-                        So(1, ShouldEqual, len(written))
-                        So(written[0].Project, ShouldEqual, project)
-                        So(written[0].BuildVariant, ShouldEqual, buildVariant)
-                        So(written[0].DistroId, ShouldEqual, distroID)
-                        So(written[0].Requester, ShouldEqual, requester)
-                        So(written[0].DisplayName, ShouldEqual, displayName)
-                        So(written[0].ExecutionDisplayName, ShouldBeBlank)
-                        So(written[0].TaskCreateTime.UTC(), ShouldResemble, taskCreateTime.UTC())
-                        So(written[0].TestStartTime.UTC(), ShouldResemble, TestStartTime.UTC())
-                        So(written[0].TestEndTime.UTC(), ShouldResemble, TestEndTime.UTC())
-                })
+			written, err := testresult.Find(testresult.ByTaskIDs([]string{taskID}))
+			So(err, ShouldBeNil)
+			So(1, ShouldEqual, len(written))
+			So(written[0].Project, ShouldEqual, project)
+			So(written[0].BuildVariant, ShouldEqual, buildVariant)
+			So(written[0].DistroId, ShouldEqual, distroID)
+			So(written[0].Requester, ShouldEqual, requester)
+			So(written[0].DisplayName, ShouldEqual, displayName)
+			So(written[0].ExecutionDisplayName, ShouldBeBlank)
+			So(written[0].TaskCreateTime.UTC(), ShouldResemble, taskCreateTime.UTC())
+			So(written[0].TestStartTime.UTC(), ShouldResemble, TestStartTime.UTC())
+			So(written[0].TestEndTime.UTC(), ShouldResemble, TestEndTime.UTC())
+		})
 
-                Convey("With a display task", func() {
-                        So(executionDisplayTask.Insert(), ShouldBeNil)
+		Convey("With a display task", func() {
+			So(executionDisplayTask.Insert(), ShouldBeNil)
 
-                        So(task.SetResults(testresults), ShouldBeNil)
+			So(task.SetResults(testresults), ShouldBeNil)
 
-                        written, err := testresult.Find(testresult.ByTaskIDs([]string{taskID}))
-                        So(err, ShouldBeNil)
-                        So(1, ShouldEqual, len(written))
-                        So(written[0].Project, ShouldEqual, project)
-                        So(written[0].BuildVariant, ShouldEqual, buildVariant)
-                        So(written[0].DistroId, ShouldEqual, distroID)
-                        So(written[0].Requester, ShouldEqual, requester)
-                        So(written[0].DisplayName, ShouldEqual, displayName)
-                        So(written[0].ExecutionDisplayName, ShouldEqual, executionDisplayName)
-                        So(written[0].TaskCreateTime.UTC(), ShouldResemble, taskCreateTime.UTC())
-                        So(written[0].TestStartTime.UTC(), ShouldResemble, TestStartTime.UTC())
-                        So(written[0].TestEndTime.UTC(), ShouldResemble, TestEndTime.UTC())
-                })
-        })
+			written, err := testresult.Find(testresult.ByTaskIDs([]string{taskID}))
+			So(err, ShouldBeNil)
+			So(1, ShouldEqual, len(written))
+			So(written[0].Project, ShouldEqual, project)
+			So(written[0].BuildVariant, ShouldEqual, buildVariant)
+			So(written[0].DistroId, ShouldEqual, distroID)
+			So(written[0].Requester, ShouldEqual, requester)
+			So(written[0].DisplayName, ShouldEqual, displayName)
+			So(written[0].ExecutionDisplayName, ShouldEqual, executionDisplayName)
+			So(written[0].TaskCreateTime.UTC(), ShouldResemble, taskCreateTime.UTC())
+			So(written[0].TestStartTime.UTC(), ShouldResemble, TestStartTime.UTC())
+			So(written[0].TestEndTime.UTC(), ShouldResemble, TestEndTime.UTC())
+		})
+	})
 }
 
 func TestFindOldTasksByID(t *testing.T) {
@@ -1180,7 +1180,11 @@ func TestSiblingDependency(t *testing.T) {
 func TestBulkInsert(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
-	t1 := Task{
+	t1_a := Task{
+		Id:      "t1",
+		Version: "version",
+	}
+	t1_b := Task{
 		Id:      "t1",
 		Version: "version",
 	}
@@ -1192,8 +1196,8 @@ func TestBulkInsert(t *testing.T) {
 		Id:      "t3",
 		Version: "version",
 	}
-	tasks := Tasks{&t1, &t2, &t3}
-	assert.NoError(tasks.InsertUnordered(context.Background()))
+	tasks := Tasks{&t1_a, &t1_b, &t2, &t3}
+	assert.Error(tasks.InsertUnordered(context.Background()))
 	dbTasks, err := Find(ByVersion("version"))
 	assert.NoError(err)
 	assert.Len(dbTasks, 3)

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -790,15 +790,16 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata VersionM
 			}
 		}
 		args := model.BuildCreateArgs{
-			Project:       *projectInfo.Project,
-			Version:       *v,
-			TaskIDs:       taskIds,
-			BuildName:     buildvariant.Name,
-			Activated:     false,
-			SourceRev:     sourceRev,
-			DefinitionID:  metadata.TriggerDefinitionID,
-			Aliases:       aliases,
-			DistroAliases: distroAliases,
+			Project:        *projectInfo.Project,
+			Version:        *v,
+			TaskIDs:        taskIds,
+			BuildName:      buildvariant.Name,
+			Activated:      false,
+			SourceRev:      sourceRev,
+			DefinitionID:   metadata.TriggerDefinitionID,
+			Aliases:        aliases,
+			DistroAliases:  distroAliases,
+			TaskCreateTime: v.CreateTime,
 		}
 		b, tasks, err := model.CreateBuildFromVersionNoInsert(args)
 		if err != nil {


### PR DESCRIPTION
Scheduling a large patch was taking a long time. Tracked down the two biggest culprits to
1. For each task in each build we were making a query to get the `create_time`
2. We were inserting builds and tasks once for each build.

As an aside, tasks' bulk inserter wasn't doing unordered inserts.