### PR TITLE
EVG-6743 refresh commit-queue patch tasks when creating version

### DIFF
--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -291,7 +291,6 @@ func (j *commitQueueJob) processCLIPatchItem(ctx context.Context, cq *commitqueu
 	}
 
 	project.BuildProjectTVPairs(patchDoc, patchDoc.Alias)
-
 	if err = patchDoc.UpdateGithashProjectAndTasks(); err != nil {
 		j.logError(err, "can't update patch in db", nextItem)
 		j.dequeue(cq, nextItem)
@@ -681,6 +680,11 @@ func updatePatch(ctx context.Context, githubToken string, projectRef *model.Proj
 
 		patchDoc.Patches[i].Githash = *branch.Commit.SHA
 	}
+
+	// reset patch build variants and tasks
+	patchDoc.BuildVariants = []string{}
+	patchDoc.VariantsTasks = []patch.VariantTasks{}
+	patchDoc.Tasks = []string{}
 
 	return project, nil
 }

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -262,6 +262,11 @@ func (s *commitQueueSuite) TestUpdatePatch() {
 		},
 		PatchedConfig: "asdf",
 		Project:       "evergreen",
+		BuildVariants: []string{"my-variant"},
+		Tasks:         []string{"my-task"},
+		VariantsTasks: []patch.VariantTasks{
+			{Variant: "my-variant", Tasks: []string{"my-task"}},
+		},
 	}
 
 	projectConfig, err := updatePatch(context.Background(), githubToken, projectRef, patchDoc)
@@ -269,4 +274,8 @@ func (s *commitQueueSuite) TestUpdatePatch() {
 	s.NotEqual("abcdef", patchDoc.Patches[0].Githash)
 	s.NotEqual(model.Project{}, projectConfig)
 	s.NotEqual("asdf", patchDoc.PatchedConfig)
+
+	s.Empty(patchDoc.Tasks)
+	s.Empty(patchDoc.VariantsTasks)
+	s.Empty(patchDoc.BuildVariants)
 }


### PR DESCRIPTION
TL;DR Tiny change == big impact

CLI commit queue items define build variants/tasks at the time of insertion into the queue, rather than at the HEAD of the queue, so if the commit queue alias is changed we don't just run those tasks.

Turns out we do already re-generate tasks at the time of creating the version (to add the merge task correctly), but we append to the existing ones. So we just need to null out tasks/build variants before creating the merge task.