### PR TITLE
EVG-6022 add secondary sort on order number

### DIFF
--- a/service/task_history.go
+++ b/service/task_history.go
@@ -427,23 +427,29 @@ func getVersionsInWindow(wt, projectID string, radius int, center *model.Version
 
 // Helper to query the versions collection for versions created before
 // or after the center, indicated by "before", and sorted backwards in time
+// Results are sorted on create_time and revision order number, similar to the waterfall
 func surroundingVersions(center *model.Version, projectId string, versionsToFetch int, before bool) ([]model.Version, error) {
 	direction := "$gt"
-	sortOn := []string{model.VersionCreateTimeKey}
+	sortOnConsecutive := []string{model.VersionCreateTimeKey, model.VersionRevisionOrderNumberKey}
+	sortOnConcurrent := []string{model.VersionRevisionOrderNumberKey}
 	if before {
 		direction = "$lt"
-		sortOn = []string{"-" + model.VersionCreateTimeKey}
+		sortOnConsecutive = []string{"-" + model.VersionCreateTimeKey, "-" + model.VersionRevisionOrderNumberKey}
+		sortOnConcurrent = []string{"-" + model.VersionRevisionOrderNumberKey}
 	}
 
-	// fetch other concurrent versions
-	concurrentVersions, err := model.VersionFind(
+	// Break the query in two: concurrent and consecutive versions.
+	// Since we know they can just be concatenated this allows us to use the index efficiently
+
+	// fetch concurrent versions
+	versions, err := model.VersionFind(
 		db.Query(bson.M{
 			model.VersionIdentifierKey: projectId,
 			model.VersionCreateTimeKey: center.CreateTime,
 			model.VersionRequesterKey: bson.M{
 				"$in": evergreen.SystemVersionRequesterTypes,
 			},
-			model.VersionRevisionKey: bson.M{direction: center.Revision},
+			model.VersionRevisionOrderNumberKey: bson.M{direction: center.RevisionOrderNumber},
 		}).WithFields(
 			model.VersionRevisionOrderNumberKey,
 			model.VersionRevisionKey,
@@ -452,40 +458,45 @@ func surroundingVersions(center *model.Version, projectId string, versionsToFetc
 			model.VersionErrorsKey,
 			model.VersionWarningsKey,
 			model.VersionIgnoredKey,
-		).Limit(versionsToFetch))
+		).Sort(sortOnConcurrent).Limit(versionsToFetch))
 	if err != nil {
 		return nil, errors.Wrap(err, "can't get concurrent versions")
 	}
 
-	// fetch consecutive versions
-	versions, err := model.VersionFind(
-		db.Query(bson.M{
-			model.VersionIdentifierKey: projectId,
-			model.VersionCreateTimeKey: bson.M{direction: center.CreateTime},
-			model.VersionRequesterKey: bson.M{
-				"$in": evergreen.SystemVersionRequesterTypes,
-			},
-		}).WithFields(
-			model.VersionRevisionOrderNumberKey,
-			model.VersionRevisionKey,
-			model.VersionMessageKey,
-			model.VersionCreateTimeKey,
-			model.VersionErrorsKey,
-			model.VersionWarningsKey,
-			model.VersionIgnoredKey,
-		).Sort(sortOn).Limit(versionsToFetch - len(concurrentVersions)))
-	if err != nil {
-		return nil, errors.Wrap(err, "can't get consecutive versions")
+	if len(versions) < versionsToFetch {
+		// fetch consecutive versions
+		consecutiveVersions, err := model.VersionFind(
+			db.Query(bson.M{
+				model.VersionIdentifierKey: projectId,
+				model.VersionCreateTimeKey: bson.M{direction: center.CreateTime},
+				model.VersionRequesterKey: bson.M{
+					"$in": evergreen.SystemVersionRequesterTypes,
+				},
+			}).WithFields(
+				model.VersionRevisionOrderNumberKey,
+				model.VersionRevisionKey,
+				model.VersionMessageKey,
+				model.VersionCreateTimeKey,
+				model.VersionErrorsKey,
+				model.VersionWarningsKey,
+				model.VersionIgnoredKey,
+			).Sort(sortOnConsecutive).Limit(versionsToFetch - len(versions)))
+		if err != nil {
+			return nil, errors.Wrap(err, "can't get consecutive versions")
+		}
+
+		versions = append(versions, consecutiveVersions...)
 	}
 
 	if before {
-		return append(concurrentVersions, versions...), nil
+		return versions, nil
 	}
+
 	// reverse versions
 	for begin, end := 0, len(versions)-1; begin < end; begin, end = begin+1, end-1 {
 		versions[begin], versions[end] = versions[end], versions[begin]
 	}
-	return append(versions, concurrentVersions...), nil
+	return versions, nil
 }
 
 // Given a task name and a slice of versions, return the appropriate sibling

--- a/service/task_history_test.go
+++ b/service/task_history_test.go
@@ -34,11 +34,11 @@ func (s *TaskHistorySuite) SetupTest() {
 		// backwards in time, in descending order
 		now = now.Add(-time.Minute)
 		version := model.Version{
-			Id:         util.RandomString(),
-			Revision:   "cccc",
-			CreateTime: now,
-			Identifier: s.projectID,
-			Requester:  evergreen.RepotrackerVersionRequester,
+			Id:                  util.RandomString(),
+			RevisionOrderNumber: 101 - i,
+			CreateTime:          now,
+			Identifier:          s.projectID,
+			Requester:           evergreen.RepotrackerVersionRequester,
 		}
 		s.versionsAfter = append(s.versionsAfter, version)
 		s.NoError(version.Insert())
@@ -47,21 +47,21 @@ func (s *TaskHistorySuite) SetupTest() {
 	// Middle version with the same createTime as the last version in versionsBefore
 	// and the first version in versionsAfter
 	s.middleVersion = model.Version{
-		Id:         util.RandomString(),
-		Revision:   "bbbb",
-		CreateTime: now,
-		Identifier: s.projectID,
-		Requester:  evergreen.RepotrackerVersionRequester,
+		Id:                  util.RandomString(),
+		RevisionOrderNumber: 51,
+		CreateTime:          now,
+		Identifier:          s.projectID,
+		Requester:           evergreen.RepotrackerVersionRequester,
 	}
 	s.NoError(s.middleVersion.Insert())
 
 	for i := 0; i < 50; i++ {
 		version := model.Version{
-			Id:         util.RandomString(),
-			Revision:   "aaaa",
-			CreateTime: now,
-			Identifier: s.projectID,
-			Requester:  evergreen.RepotrackerVersionRequester,
+			Id:                  util.RandomString(),
+			RevisionOrderNumber: 50 - i,
+			CreateTime:          now,
+			Identifier:          s.projectID,
+			Requester:           evergreen.RepotrackerVersionRequester,
 		}
 		s.versionsBefore = append(s.versionsBefore, version)
 		s.NoError(version.Insert())
@@ -93,7 +93,6 @@ func (s *TaskHistorySuite) TestSurroundingVersions() {
 	s.NoError(err)
 	s.Require().Len(versionsAfter, radius)
 	for i, version := range versionsAfter {
-		s.Equal("cccc", version.Revision)
 		// compare to the last _radius_ elements in s.versionsAfter
 		s.True(version.CreateTime.Equal(s.versionsAfter[(len(s.versionsAfter)-radius)+i].CreateTime))
 	}
@@ -102,7 +101,22 @@ func (s *TaskHistorySuite) TestSurroundingVersions() {
 	s.NoError(err)
 	s.Len(versionsBefore, radius)
 	for i, version := range versionsBefore {
-		s.Equal("aaaa", version.Revision)
 		s.True(version.CreateTime.Equal(s.versionsBefore[i].CreateTime))
 	}
+}
+
+func (s *TaskHistorySuite) TestSurroundingVersionsSort() {
+	versionsAfter, err := surroundingVersions(&s.versionsBefore[0], s.projectID, 2, false)
+	s.NoError(err)
+	s.Require().Len(versionsAfter, 2)
+	// sorted ascending, then reversed
+	s.Equal(52, versionsAfter[0].RevisionOrderNumber)
+	s.Equal(51, versionsAfter[1].RevisionOrderNumber)
+
+	versionsBefore, err := surroundingVersions(&s.versionsAfter[49], s.projectID, 2, true)
+	s.NoError(err)
+	s.Require().Len(versionsBefore, 2)
+	// sorted descending
+	s.Equal(51, versionsBefore[0].RevisionOrderNumber)
+	s.Equal(50, versionsBefore[1].RevisionOrderNumber)
 }


### PR DESCRIPTION
#2812 added a secondary sort on revision order number. However, because the query was no longer able to use the index for sort the query failed (the in-memory sort exceeded memory limits) and the commit was reverted. 

In the interim, an index was added to the database, `identifier_1_r_1_create_time_1_order_1` which supported the query.

Looking over the explain plan with Stu, though, we decided that breaking the query in two and concatenating the results, as it originally was, makes for a more efficient query.