### PR TITLE
MCI-3056: do not create indexes on nonexistent data.r_id field in event_log

### DIFF
--- a/scripts/indexes.js
+++ b/scripts/indexes.js
@@ -21,7 +21,6 @@ db.builds.ensureIndex({ "branch" : 1, "r" : 1, "order" : 1 })
 db.patchfiles.files.ensureIndex({"filename":1})
 
 //======event_log======//
-db.event_log.ensureIndex({ "r_id" : 1, "data.r_type" : 1, "ts" : 1 })
 db.event_log.ensureIndex({ "r_id" : 1, "r_type" : 1, "ts" : 1 })
 db.event_log.ensureIndex({ "processed_at" : 1 })
 db.event_log.ensureIndex({ "data.guid" : 1}, { sparse: true })
@@ -61,7 +60,6 @@ db.spawn_requests.ensureIndex({ "user" : 1, "status" : 1 })
 db.task_bk.ensureIndex({ "branch" : 1, "build_variant" : 1, "name" : 1 })
 
 //======task_event_log======//
-db.task_event_log.ensureIndex({ "r_id" : 1, "data.r_type" : 1, "ts" : 1 })
 db.task_event_log.ensureIndex({ "r_id" : 1, "r_type" : 1, "ts" : 1 })
 db.task_event_log.ensureIndex({ "processed_at" : 1 })
 db.task_event_log.createIndexes({"ts": 1}, {background: true, expireAfterSeconds: 60*60*24*30*6}) // (6 months)

--- a/scripts/indexes.js
+++ b/scripts/indexes.js
@@ -21,6 +21,7 @@ db.builds.ensureIndex({ "branch" : 1, "r" : 1, "order" : 1 })
 db.patchfiles.files.ensureIndex({"filename":1})
 
 //======event_log======//
+db.event_log.ensureIndex({ "r_id" : 1, "r_type" : 1, "ts" : -1 })
 db.event_log.ensureIndex({ "r_id" : 1, "r_type" : 1, "ts" : 1 })
 db.event_log.ensureIndex({ "processed_at" : 1 })
 db.event_log.ensureIndex({ "data.guid" : 1}, { sparse: true })
@@ -60,6 +61,7 @@ db.spawn_requests.ensureIndex({ "user" : 1, "status" : 1 })
 db.task_bk.ensureIndex({ "branch" : 1, "build_variant" : 1, "name" : 1 })
 
 //======task_event_log======//
+db.task_event_log.ensureIndex({ "r_id" : 1, "r_type" : 1, "ts" : -1 })
 db.task_event_log.ensureIndex({ "r_id" : 1, "r_type" : 1, "ts" : 1 })
 db.task_event_log.ensureIndex({ "processed_at" : 1 })
 db.task_event_log.createIndexes({"ts": 1}, {background: true, expireAfterSeconds: 60*60*24*30*6}) // (6 months)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MCI-3056

`data.r_type` does not exist in the event_log collections. The `EventLogEntry` struct type has an `EventLogEntry.ResourceType` (`r_type`) field but the event types in `EventLogEntry.Data` (`data`) (e.g. `HostEventData`, `DistroEventData`) do not have any field with a bson struct tag `r_type`.