### PR TITLE
EVG-6911 restart stranded display tasks

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -999,7 +999,10 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 	}
 
 	if t.IsPartOfDisplay() {
-		return t.DisplayTask.SetResetWhenFinished()
+		if err = t.DisplayTask.SetResetWhenFinished(); err != nil {
+			return errors.Wrap(err, "can't mark display task for reset")
+		}
+		return errors.Wrap(checkResetDisplayTask(t.DisplayTask), "can't check display task reset")
 	}
 
 	return errors.Wrap(TryResetTask(t.Id, "mci", evergreen.MonitorPackage, &t.Details), "problem resetting task")


### PR DESCRIPTION
If an execution task was running on an externally terminated host but was the last task in the display task to complete we never ended up checking if the display task needed to be reset so it never was.