### PR TITLE
EVG-6939: remove empty task_event_log collection

### DIFF
--- a/model/event/event.go
+++ b/model/event/event.go
@@ -9,10 +9,7 @@ import (
 	mgobson "gopkg.in/mgo.v2/bson"
 )
 
-const (
-	AllLogCollection  = "event_log"
-	TaskLogCollection = "task_event_log"
-)
+const AllLogCollection = "event_log"
 
 type EventLogEntry struct {
 	ID           string    `bson:"_id" json:"-"`

--- a/model/event/event_test.go
+++ b/model/event/event_test.go
@@ -24,7 +24,7 @@ func TestEventSuite(t *testing.T) {
 }
 
 func (s *eventSuite) SetupTest() {
-	s.NoError(db.ClearCollections(AllLogCollection, TaskLogCollection))
+	s.NoError(db.ClearCollections(AllLogCollection))
 }
 
 func (s *eventSuite) TestMarshallAndUnarshallingStructsHaveSameTags() {

--- a/scripts/indexes.js
+++ b/scripts/indexes.js
@@ -60,12 +60,6 @@ db.spawn_requests.ensureIndex({ "user" : 1, "status" : 1 })
 //======task_bk======//
 db.task_bk.ensureIndex({ "branch" : 1, "build_variant" : 1, "name" : 1 })
 
-//======task_event_log======//
-db.task_event_log.ensureIndex({ "r_id" : 1, "r_type" : 1, "ts" : -1 })
-db.task_event_log.ensureIndex({ "r_id" : 1, "r_type" : 1, "ts" : 1 })
-db.task_event_log.ensureIndex({ "processed_at" : 1 })
-db.task_event_log.createIndexes({"ts": 1}, {background: true, expireAfterSeconds: 60*60*24*30*6}) // (6 months)
-
 //======tasks======//
 db.tasks.ensureIndex({ "build_variant" : 1, "display_name" : 1, "order" : 1 })
 db.tasks.ensureIndex({ "gitspec" : 1, "build_variant" : 1, "display_name" : 1 })

--- a/units/event_metajob_test.go
+++ b/units/event_metajob_test.go
@@ -49,7 +49,7 @@ func (s *eventMetaJobSuite) TearDownSuite() {
 }
 
 func (s *eventMetaJobSuite) SetupTest() {
-	s.NoError(db.ClearCollections(event.AllLogCollection, event.TaskLogCollection, evergreen.ConfigCollection, notification.Collection, event.SubscriptionsCollection, patch.Collection))
+	s.NoError(db.ClearCollections(event.AllLogCollection, evergreen.ConfigCollection, notification.Collection, event.SubscriptionsCollection, patch.Collection))
 
 	events := []event.EventLogEntry{
 		{


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6939

Remove the unused `task_event_log` collection.