### PR TITLE
EVG-6915: do not contact task-spawned hosts

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -109,9 +109,6 @@ type CreateHost struct {
 	AWSSecret       string      `mapstructure:"aws_secret_access_key" json:"aws_secret_access_key" plugin:"expand"`
 	KeyName         string      `mapstructure:"key_name" json:"key_name" plugin:"expand"`
 
-	// Provisioning-related settings
-	ProvisioningMethod string `mapstructure:"provisioning_method" json:"provisioning_method" plugin:"expand"`
-
 	// docker-related settings
 	Image                    string            `mapstructure:"image" json:"image" plugin:"expand"`
 	Command                  string            `mapstructure:"command" json:"command" plugin:"expand"`

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -3,6 +3,7 @@ package apimodels
 import (
 	"strconv"
 
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -108,6 +109,9 @@ type CreateHost struct {
 	AWSKeyID        string      `mapstructure:"aws_access_key_id" json:"aws_access_key_id" plugin:"expand"`
 	AWSSecret       string      `mapstructure:"aws_secret_access_key" json:"aws_secret_access_key" plugin:"expand"`
 	KeyName         string      `mapstructure:"key_name" json:"key_name" plugin:"expand"`
+
+	// Provisioning-related settings
+	ProvisioningMethod string `mapstructure:"provisioning_method" json:"provisioning_method" plugin:"expand"`
 
 	// docker-related settings
 	Image                    string            `mapstructure:"image" json:"image" plugin:"expand"`
@@ -255,6 +259,10 @@ func (ch *CreateHost) Validate() error {
 
 	if ch.CloudProvider == ProviderDocker {
 		return ch.ValidateDocker()
+	}
+
+	if ch.ProvisioningMethod == "" {
+		ch.ProvisioningMethod = distro.BootstrapMethodNone
 	}
 
 	return errors.Errorf("Cloud provider must be either '%s' or '%s'", ProviderEC2, ProviderDocker)

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -3,7 +3,6 @@ package apimodels
 import (
 	"strconv"
 
-	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -259,10 +258,6 @@ func (ch *CreateHost) Validate() error {
 
 	if ch.CloudProvider == ProviderDocker {
 		return ch.ValidateDocker()
-	}
-
-	if ch.ProvisioningMethod == "" {
-		ch.ProvisioningMethod = distro.BootstrapMethodNone
 	}
 
 	return errors.Errorf("Cloud provider must be either '%s' or '%s'", ProviderEC2, ProviderDocker)

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -152,6 +152,7 @@ const (
 	ArchWindowsAmd64 = "windows_amd64"
 
 	// Bootstrapping mechanisms
+	// BootstrapMethodNone is for internal use only.
 	BootstrapMethodNone               = "none"
 	BootstrapMethodLegacySSH          = "legacy-ssh"
 	BootstrapMethodSSH                = "ssh"

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -76,6 +76,10 @@ func (d *Distro) ValidateBootstrapSettings() error {
 		catcher.Errorf("'%s' is not a valid bootstrap method", d.BootstrapSettings.Method)
 	}
 
+	if d.BootstrapSettings.Method == BootstrapMethodNone {
+		return catcher.Resolve()
+	}
+
 	if !util.StringSliceContains(validCommunicationMethods, d.BootstrapSettings.Communication) {
 		catcher.Errorf("'%s' is not a valid communication method", d.BootstrapSettings.Communication)
 	}
@@ -148,6 +152,7 @@ const (
 	ArchWindowsAmd64 = "windows_amd64"
 
 	// Bootstrapping mechanisms
+	BootstrapMethodNone               = "none"
 	BootstrapMethodLegacySSH          = "legacy-ssh"
 	BootstrapMethodSSH                = "ssh"
 	BootstrapMethodPreconfiguredImage = "preconfigured-image"
@@ -176,6 +181,7 @@ var validArches = []string{
 
 // validBootstrapMethods includes all recognized bootstrap methods.
 var validBootstrapMethods = []string{
+	BootstrapMethodNone,
 	BootstrapMethodLegacySSH,
 	BootstrapMethodSSH,
 	BootstrapMethodPreconfiguredImage,

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -255,11 +255,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	d.Provider = provider
 
 	if publicKey != "" {
-		keyPath := filepath.Join(d.HomeDir(), ".ssh", "authorized_keys")
-		if d.BootstrapSettings.Method != distro.BootstrapMethodLegacySSH {
-			keyPath = d.BootstrapSettings.RootDir + keyPath
-		}
-		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", publicKey, keyPath)
+		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", publicKey, filepath.Join(d.HomeDir(), ".ssh", "authorized_keys"))
 	}
 
 	// set provider settings

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -174,6 +174,14 @@ func makeDockerIntentHost(taskID, userID string, createHost apimodels.CreateHost
 		}
 	}
 
+	if createHost.ProvisioningMethod == "" {
+		createHost.ProvisioningMethod = distro.BootstrapMethodNone
+	}
+	d.BootstrapSettings.Method = createHost.ProvisioningMethod
+	if err := d.ValidateBootstrapSettings(); err != nil {
+		return nil, errors.Wrap(err, "problem validating distro bootstrap settings")
+	}
+
 	options, err := getAgentOptions(taskID, userID, createHost)
 	if err != nil {
 		return nil, errors.Wrap(err, "error making host options for docker")
@@ -233,6 +241,14 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		if err = mapstructure.Decode(d.ProviderSettings, &ec2Settings); err != nil {
 			return nil, errors.Wrap(err, "problem unmarshaling provider settings")
 		}
+	}
+
+	if createHost.ProvisioningMethod == "" {
+		createHost.ProvisioningMethod = distro.BootstrapMethodNone
+	}
+	d.BootstrapSettings.Method = createHost.ProvisioningMethod
+	if err := d.ValidateBootstrapSettings(); err != nil {
+		return nil, errors.Wrap(err, "problem validating distro bootstrap settings")
 	}
 
 	// set provider

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -174,13 +174,8 @@ func makeDockerIntentHost(taskID, userID string, createHost apimodels.CreateHost
 		}
 	}
 
-	if createHost.ProvisioningMethod == "" {
-		createHost.ProvisioningMethod = distro.BootstrapMethodNone
-	}
-	d.BootstrapSettings.Method = createHost.ProvisioningMethod
-	if err := d.ValidateBootstrapSettings(); err != nil {
-		return nil, errors.Wrap(err, "problem validating distro bootstrap settings")
-	}
+	// Do not provision task-spawned hosts.
+	d.BootstrapSettings.Method = distro.BootstrapMethodNone
 
 	options, err := getAgentOptions(taskID, userID, createHost)
 	if err != nil {
@@ -243,13 +238,8 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		}
 	}
 
-	if createHost.ProvisioningMethod == "" {
-		createHost.ProvisioningMethod = distro.BootstrapMethodNone
-	}
-	d.BootstrapSettings.Method = createHost.ProvisioningMethod
-	if err := d.ValidateBootstrapSettings(); err != nil {
-		return nil, errors.Wrap(err, "problem validating distro bootstrap settings")
-	}
+	// Do not provision task-spawned hosts.
+	d.BootstrapSettings.Method = distro.BootstrapMethodNone
 
 	// set provider
 	d.Provider = provider

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -176,6 +176,7 @@ buildvariants:
 			assert.InDelta(t, time.Now().Add(cloud.DefaultSpawnHostExpiration).Unix(), h.ExpirationTime.Unix(), float64(1*time.Millisecond))
 			require.Len(t, ec2Settings.SecurityGroupIDs, 1)
 			assert.Equal(t, "sg-provided", ec2Settings.SecurityGroupIDs[0])
+			assert.Equal(t, distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 		}
 	})
 
@@ -249,6 +250,7 @@ buildvariants:
 			assert.InDelta(t, time.Now().Add(cloud.DefaultSpawnHostExpiration).Unix(), h.ExpirationTime.Unix(), float64(1*time.Millisecond))
 			require.Len(t, ec2Settings.SecurityGroupIDs, 1)
 			assert.Equal(t, "sg-provided", ec2Settings.SecurityGroupIDs[0])
+			assert.Equal(t, distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 		}
 	})
 
@@ -315,6 +317,7 @@ buildvariants:
 			assert.InDelta(t, time.Now().Add(cloud.DefaultSpawnHostExpiration).Unix(), h.ExpirationTime.Unix(), float64(1*time.Millisecond))
 			require.Len(t, ec2Settings.SecurityGroupIDs, 1)
 			assert.Equal(t, "sg-default", ec2Settings.SecurityGroupIDs[0]) // none provided, should get default from config
+			assert.Equal(t, distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 		}
 	})
 }

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -64,6 +64,7 @@ func TestMakeIntentHost(t *testing.T) {
 	assert.Equal("task-id", h.SpawnOptions.TaskID)
 	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
+	assert.Equal(distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 
 	// scope to build
 	myTask := task.Task{
@@ -91,6 +92,7 @@ func TestMakeIntentHost(t *testing.T) {
 	assert.Equal("build-id", h.SpawnOptions.BuildID)
 	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
+	assert.Equal(distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 
 	// spawn a spot evergreen distro
 	c = apimodels.CreateHost{
@@ -116,6 +118,7 @@ func TestMakeIntentHost(t *testing.T) {
 	assert.Equal(evergreen.ProviderNameEc2Spot, h.Distro.Provider)
 	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
+	assert.Equal(distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 
 	// override some evergreen distro settings
 	c = apimodels.CreateHost{
@@ -145,6 +148,7 @@ func TestMakeIntentHost(t *testing.T) {
 	assert.Equal("my_secret_key", ec2Settings.AWSSecret)
 	assert.Equal("subnet-123456", ec2Settings.SubnetId)
 	assert.Equal(true, ec2Settings.IsVpc)
+	assert.Equal(distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 
 	// bring your own ami
 	c = apimodels.CreateHost{
@@ -174,7 +178,7 @@ func TestMakeIntentHost(t *testing.T) {
 	assert.Equal("my_secret_key", ec2Settings.AWSSecret)
 	assert.Equal("subnet-123456", ec2Settings.SubnetId)
 	assert.Equal(true, ec2Settings.IsVpc)
-
+	assert.Equal(distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 }
 
 func TestHostCreateDocker(t *testing.T) {

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -238,6 +238,8 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 	}
 
 	switch targetHost.Distro.BootstrapSettings.Method {
+	case distro.BootstrapMethodNone:
+		return nil
 	case distro.BootstrapMethodUserData:
 		// Updating the host LCT prevents the agent monitor deploy job from
 		// running. The agent monitor should be started by the user data script.

--- a/validator/distro_validator_test.go
+++ b/validator/distro_validator_test.go
@@ -429,6 +429,8 @@ func TestEnsureValidBootstrapSettings(t *testing.T) {
 		}
 	}
 
+	assert.Nil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{BootstrapSettings: distro.BootstrapSettings{Method: distro.BootstrapMethodNone}}, &evergreen.Settings{}))
+
 	for testName, testCase := range map[string]func(t *testing.T, s distro.BootstrapSettings){
 		"InvalidBootstrapMethod": func(t *testing.T, s distro.BootstrapSettings) {
 			s.Method = "foobar"


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6915

The original test failure was due to a security group firewall configuration in host.create that blocked traffic to/from the host's Jasper service To work around this, there's a new provisioning option "none" to effectively do what is currently done for task-spawned hosts (i.e. don't connect to the host at all via SSH or RPC. Just do some cloud host bookkeeping and immediately mark the host as running so that tasks can use it).

## Changes
* Provide user option to override provisioning method in the host.create config. Default is "none".
    * I don't know if we even want users to be able to configure provisioning settings at all given that they've don't do any host SSH provisioning currently anyways. I'm open to just removing this and having "none" be an internal provisioning option used for all hosts created via host.create. *I'm not adding this to the wiki unless we actually want to support this.*
    * This only applies to hosts spawned through tasks. Spawn hosts do not have options to modify provisioning behavior (unless they create hosts from a loaded task config).