### PR TITLE
EVG-6918 Handle additional error case in CreateFleet

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -869,9 +869,7 @@ func (c *awsClientImpl) CreateFleet(ctx context.Context, input *ec2.CreateFleetI
 			// implement awserr.Error. We therefore have to check this case in addition
 			// to the standard `err != nil` case above.
 			if len(output.Errors) > 0 {
-				if fleetErr, ok := output.Errors[0].(ec2.CreateFleetError); ok {
-					grip.Error(message.WrapError(fleetErr, msg))
-				}
+				grip.Error(message.WrapError(errors.New(output.Errors[0].String()), msg))
 				return true, err
 			}
 			grip.Info(msg)


### PR DESCRIPTION
In instant mode CreateFleet can error without returning an error. This means we
have to add an additional check for that case so that we do the right thing in
the RequestLimitExceeded case. Currently we are not doing exponential back off
for CreateFleet the way we do for every other API all.