### PR TITLE
EVG-6848 refresh cached host values on start

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1174,6 +1174,11 @@ func (c *awsClientMock) StartInstances(ctx context.Context, input *ec2.StartInst
 		State: &ec2.InstanceState{
 			Name: aws.String(ec2.InstanceStateNameRunning),
 		},
+		Placement: &ec2.Placement{
+			AvailabilityZone: aws.String("us-east-1a"),
+		},
+		PublicDnsName: aws.String("public_dns_name"),
+		LaunchTime:    aws.Time(time.Now()),
 	}
 	return &ec2.StartInstancesOutput{}, nil
 }

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -777,6 +777,7 @@ func (s *EC2Suite) TestStartInstance() {
 		&host.Host{
 			Id:     "host-stopped",
 			Status: evergreen.HostStopped,
+			Host:   "old_dns_name",
 		},
 	}
 	for _, h := range hosts {
@@ -789,6 +790,7 @@ func (s *EC2Suite) TestStartInstance() {
 	found, err := host.FindOne(host.ById("host-stopped"))
 	s.NoError(err)
 	s.Equal(evergreen.HostRunning, found.Status)
+	s.Equal("public_dns_name", found.Host)
 }
 
 func (s *EC2Suite) TestIsUp() {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -375,7 +375,28 @@ func (h *Host) SetStopping(user string) error {
 }
 
 func (h *Host) SetStopped(user string) error {
-	return h.SetStatus(evergreen.HostStopped, user, "")
+	err := UpdateOne(
+		bson.M{
+			IdKey:     h.Id,
+			StatusKey: h.Status,
+		},
+		bson.M{"$set": bson.M{
+			StatusKey:    evergreen.HostStopped,
+			DNSKey:       "",
+			StartTimeKey: util.ZeroTime,
+		}},
+	)
+	if err != nil {
+		return errors.Wrap(err, "can't set host stopped in db")
+	}
+
+	event.LogHostStatusChanged(h.Id, h.Status, evergreen.HostStopped, user, "")
+
+	h.Status = evergreen.HostStopped
+	h.Host = ""
+	h.StartTime = util.ZeroTime
+
+	return nil
 }
 
 func (h *Host) SetUnprovisioned() error {

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -267,7 +267,7 @@ func TestSetStopped(t *testing.T) {
 
 	require.NoError(t, h.Insert())
 
-	h.SetStopped("")
+	assert.NoError(t, h.SetStopped(""))
 	assert.Equal(t, evergreen.HostStopped, h.Status)
 	assert.Empty(t, h.Host)
 	assert.True(t, util.IsZeroTime(h.StartTime))

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -256,6 +256,29 @@ func TestUpdatingHostStatus(t *testing.T) {
 
 }
 
+func TestSetStopped(t *testing.T) {
+	require.NoError(t, db.Clear(Collection))
+	h := &Host{
+		Id:        "h1",
+		Status:    evergreen.HostRunning,
+		StartTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Host:      "host.mongodb.com",
+	}
+
+	require.NoError(t, h.Insert())
+
+	h.SetStopped("")
+	assert.Equal(t, evergreen.HostStopped, h.Status)
+	assert.Empty(t, h.Host)
+	assert.True(t, util.IsZeroTime(h.StartTime))
+
+	h, err := FindOneId("h1")
+	require.NoError(t, err)
+	assert.Equal(t, evergreen.HostStopped, h.Status)
+	assert.Empty(t, h.Host)
+	assert.True(t, util.IsZeroTime(h.StartTime))
+}
+
 func TestSetHostTerminated(t *testing.T) {
 
 	Convey("With a host", t, func() {

--- a/public/static/js/spawned_hosts.js
+++ b/public/static/js/spawned_hosts.js
@@ -87,6 +87,8 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope','$window', '$timeout', 'mciSp
                             $scope.hosts[i].expires_in = host.expires_in;
                             $scope.hosts[i].status = host.status;
                             $scope.hosts[i].id = host.id;
+                            $scope.hosts[i].host = host.host;
+                            $scope.hosts[i].start_time = host.start_time;
                             if ($scope.hosts[i].instance_type === undefined || $scope.hosts[i].instance_type === "") {
                                 $scope.hosts[i].instance_type = host.instance_type;
                             }
@@ -121,15 +123,18 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope','$window', '$timeout', 'mciSp
 
     $scope.computeUptime = function(host) {
         host.isTerminated = host.status == 'terminated';
-        var terminateTime = moment(host.termination_time);
+        const terminateTime = moment(host.termination_time);
+        const startTime = moment(host.start_time);
         // check if the host is terminated to determine uptime
         if (host.isTerminated && terminateTime > epochTime) {
-            var uptime = terminateTime.diff(host.creation_time, 'seconds');
-            host.uptime = moment.duration(uptime, 'seconds').humanize();
+          const uptime = terminateTime.diff(startTime, 'seconds');
+          host.uptime = moment.duration(uptime, 'seconds').humanize();
+        } else if (host.status == 'stopped') {
+          host.uptime = "";
         } else {
-            var uptime = moment().diff(host.creation_time, 'seconds');
-            host.uptime = moment.duration(uptime, 'seconds').humanize();
-        }
+          const uptime = moment().diff(startTime, 'seconds');
+          host.uptime = moment.duration(uptime, 'seconds').humanize();
+        }        
     }
 
     $scope.setCurrentExpirationOnClick = function() {

--- a/public/static/partials/user_host_details.html
+++ b/public/static/partials/user_host_details.html
@@ -13,7 +13,10 @@
           <span>[[curHostData.id]] </span>
         </div>
         <div class="entry">
-          <strong>Started at</strong> <span>[[curHostData.creation_time | convertDateToUserTimezone:userTz:"MMM D, YYYY h:mm:ss a"]]</span>
+          <strong>Created at</strong> <span>[[curHostData.creation_time | convertDateToUserTimezone:userTz:"MMM D, YYYY h:mm:ss a"]]</span>
+        </div>
+        <div class="entry" ng-hide="curHostData.status=='stopped'">
+          <strong>Started at</strong> <span>[[curHostData.start_time | convertDateToUserTimezone:userTz:"MMM D, YYYY h:mm:ss a"]]</span>
         </div>
         <div class="entry" ng-hide="curHostData.no_expiration">
           <strong>Expires at</strong> <span>[[curHostData.original_expiration | convertDateToUserTimezone:userTz:"MMM D, YYYY h:mm:ss a"]]</span>

--- a/service/templates/spawned_hosts.html
+++ b/service/templates/spawned_hosts.html
@@ -92,8 +92,8 @@ Evergreen - My Hosts
               </td>
               <td class="col-sm-2 no-word-wrap">
                 <i class="fa fa-trash pointer" ng-show="host.status!='terminated'" style="float: right" ng-click="openSpawnModal('terminateHost')"></i>
-                <i class="fa fa-play pointer" ng-show="false" style="float: right" ng-click="openSpawnModal('startHost')" ></i>
-                <i class="fa fa-pause pointer" ng-show="false" style="float: right" ng-click="openSpawnModal('stopHost')" ></i>
+                <i class="fa fa-play pointer" ng-show="host.status=='stopped'" style="float: right" ng-click="openSpawnModal('startHost')"></i>
+                <i class="fa fa-pause pointer" ng-show="host.status=='running'" style="float: right" ng-click="openSpawnModal('stopHost')"></i>
               </td>
             </tr>
           </tbody>

--- a/service/templates/spawned_hosts.html
+++ b/service/templates/spawned_hosts.html
@@ -59,6 +59,9 @@ Evergreen - My Hosts
             <span class="label success" style="margin-right: 5px">
               [[(hosts | filter:{'status' : 'running'}).length]] Running
             </span>
+            <span class="label block-status-started" style="margin-right: 5px">
+              [[(hosts | filter:{'status' : 'stopped'}).length]] Stopped
+            </span>
             <span class="label failed">
               [[(hosts | filter:{'status' : 'terminated'}).length]] Terminated
             </span>


### PR DESCRIPTION
If a host is stopped and then started:
1. AWS will give the instance a new public IP and DNS name
2. the launch time is reset
3. instance stores go away

When we start the instance we should cache the new values for DNS name, launch time, volumes, and volume sizes.