### PR TITLE
EVG-6630 give metric data to admins

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -246,6 +246,16 @@ type HostModifyOptions struct {
 	DetachVolume       string
 }
 
+type SpawnHostUsage struct {
+	TotalHosts            int `bson:"total_hosts"`
+	TotalUnexpirableHosts int `bson:"total_unexpirable_hosts"`
+	NumUsersWithHosts     int `bson:"num_users_with_hosts"`
+
+	TotalVolumes        int `bson:"total_volumes"`
+	TotalVolumeSize     int `bson:"total_volume_size"`
+	NumUsersWithVolumes int `bson:"num_users_with_volumes"`
+}
+
 const (
 	MaxLCTInterval = 5 * time.Minute
 
@@ -1776,6 +1786,57 @@ func (h *Host) SetInstanceType(instanceType string) error {
 	}
 	h.InstanceType = instanceType
 	return nil
+}
+
+func AggregateSpawnhostData() (*SpawnHostUsage, error) {
+	res := []SpawnHostUsage{}
+	pipeline := []bson.M{
+		{"$match": bson.M{
+			StartedByKey: bson.M{"$exists": true, "$ne": ""},
+			StatusKey:    bson.M{"$in": evergreen.UpHostStatus},
+		}},
+		{"$group": bson.M{
+			"_id":         nil,
+			"hosts":       bson.M{"$sum": 1},
+			"unexpirable": bson.M{"$sum": bson.M{"$cond": []interface{}{"$" + NoExpirationKey, 1, 0}}},
+			"users":       bson.M{"$addToSet": "$" + StartedByKey},
+		}},
+		{"$project": bson.M{
+			"_id":                     "0",
+			"total_hosts":             "$hosts",
+			"total_unexpirable_hosts": "$unexpirable",
+			"num_users_with_hosts":    bson.M{"$size": "$users"},
+		}},
+	}
+
+	if err := db.Aggregate(Collection, pipeline, &res); err != nil {
+		return nil, errors.Wrap(err, "error aggregating hosts")
+	}
+	if len(res) == 0 {
+		return nil, errors.New("no host results found")
+	}
+
+	pipeline = []bson.M{
+		{"$group": bson.M{
+			"_id":     nil,
+			"volumes": bson.M{"$sum": 1},
+			"size":    bson.M{"$sum": "$" + VolumeSizeKey},
+			"users":   bson.M{"$addToSet": "$" + VolumeCreatedByKey},
+		}},
+		{"$project": bson.M{
+			"_id":                    "0",
+			"total_volumes":          "$volumes",
+			"total_volume_size":      "$size",
+			"num_users_with_volumes": bson.M{"$size": "$users"},
+		}},
+	}
+	if err := db.Aggregate(VolumesCollection, pipeline, &res); err != nil {
+		return nil, errors.Wrap(err, "error aggregating volumes")
+	}
+	if len(res) == 0 {
+		return nil, errors.New("no volume results found")
+	}
+	return &res[0], nil
 }
 
 // CountSpawnhostsWithNoExpirationByUser returns a count of all hosts associated

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3709,38 +3709,52 @@ func TestAggregateSpawnhostData(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection, VolumesCollection))
 	hosts := []Host{
 		{
-			Id:           "host-1",
-			Status:       evergreen.HostRunning,
-			StartedBy:    "me",
-			NoExpiration: true,
+			Id:                 "host-1",
+			Status:             evergreen.HostRunning,
+			InstanceType:       "small",
+			ComputeCostPerHour: 20,
+			StartedBy:          "me",
+			UserHost:           true,
+			NoExpiration:       true,
 		},
 		{
-			Id:           "host-2",
-			Status:       evergreen.HostRunning,
-			StartedBy:    "me",
-			NoExpiration: false,
+			Id:                 "host-2",
+			Status:             evergreen.HostRunning,
+			InstanceType:       "small",
+			ComputeCostPerHour: 30,
+			StartedBy:          "me",
+			UserHost:           true,
+			NoExpiration:       false,
 		},
 		{
-			Id:           "host-3",
-			Status:       evergreen.HostStopped,
-			StartedBy:    "you",
-			NoExpiration: false,
+			Id:                 "host-3",
+			Status:             evergreen.HostStopped,
+			InstanceType:       "large",
+			ComputeCostPerHour: 60,
+			StartedBy:          "you",
+			UserHost:           true,
+			NoExpiration:       false,
 		},
 		{
-			Id:           "host-4",
-			Status:       evergreen.HostRunning,
-			StartedBy:    "her",
-			NoExpiration: true,
+			Id:                 "host-4",
+			Status:             evergreen.HostRunning,
+			InstanceType:       "medium",
+			ComputeCostPerHour: 10,
+			StartedBy:          "her",
+			UserHost:           true,
+			NoExpiration:       true,
 		},
 		{
 			Id:        "host-5",
 			Status:    evergreen.HostStarting,
-			StartedBy: "",
+			StartedBy: "no-one",
 		},
 		{
-			Id:        "host-6",
-			Status:    evergreen.HostTerminated,
-			StartedBy: "no-one",
+			Id:           "host-6",
+			Status:       evergreen.HostTerminated,
+			InstanceType: "tiny",
+			StartedBy:    "doesnt-matter",
+			UserHost:     true,
 		},
 	}
 	for _, h := range hosts {
@@ -3773,7 +3787,10 @@ func TestAggregateSpawnhostData(t *testing.T) {
 	require.NotNil(t, res)
 	assert.Equal(t, 3, res.NumUsersWithHosts)
 	assert.Equal(t, 4, res.TotalHosts)
+	assert.Equal(t, 1, res.TotalStoppedHosts)
 	assert.EqualValues(t, 2, res.TotalUnexpirableHosts)
+	assert.Equal(t, 30.0, res.AverageComputeCostPerHour)
+	assert.Len(t, res.InstanceTypes, 3)
 	assert.Equal(t, 2, res.NumUsersWithVolumes)
 	assert.Equal(t, 412, res.TotalVolumeSize)
 	assert.Equal(t, 3, res.TotalVolumes)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3790,10 +3790,15 @@ func TestAggregateSpawnhostData(t *testing.T) {
 	assert.Equal(t, 1, res.TotalStoppedHosts)
 	assert.EqualValues(t, 2, res.TotalUnexpirableHosts)
 	assert.Equal(t, 30.0, res.AverageComputeCostPerHour)
-	assert.Len(t, res.InstanceTypes, 3)
 	assert.Equal(t, 2, res.NumUsersWithVolumes)
 	assert.Equal(t, 412, res.TotalVolumeSize)
 	assert.Equal(t, 3, res.TotalVolumes)
+	assert.NotNil(t, res.InstanceTypes)
+	assert.Len(t, res.InstanceTypes, 3)
+	assert.Equal(t, res.InstanceTypes["small"], 2)
+	assert.Equal(t, res.InstanceTypes["medium"], 1)
+	assert.Equal(t, res.InstanceTypes["large"], 1)
+	assert.Equal(t, res.InstanceTypes["tiny"], 0)
 }
 
 func TestCountSpawnhostsWithNoExpirationByUser(t *testing.T) {

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -131,10 +131,19 @@ func (hc *DBHostConnector) CheckHostSecret(r *http.Request) (int, error) {
 	return code, errors.WithStack(err)
 }
 
+func (hc *DBHostConnector) AggregateSpawnHostData() (*host.SpawnHostUsage, error) {
+	data, err := host.AggregateSpawnhostData()
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting spawn host data")
+	}
+	return data, nil
+}
+
 // MockHostConnector is a struct that implements the Host related methods
 // from the Connector through interactions with the backing database.
 type MockHostConnector struct {
-	CachedHosts []host.Host
+	CachedHosts   []host.Host
+	CachedVolumes []host.Volume
 }
 
 // FindHostsById searches the mock hosts slice for hosts and returns them
@@ -283,6 +292,42 @@ func (hc *MockHostConnector) CheckHostSecret(r *http.Request) (int, error) {
 
 func (dbc *MockConnector) FindHostByIdWithOwner(hostID string, user gimlet.User) (*host.Host, error) {
 	return findHostByIdWithOwner(dbc, hostID, user)
+}
+
+func (hc *MockConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error) {
+	data := host.SpawnHostUsage{}
+	usersWithHosts := map[string]bool{} // set for existing users
+	data.InstanceTypes = map[string]int{}
+	totalComputeCost := 0.0
+	for _, h := range hc.CachedHosts {
+		if !h.UserHost {
+			continue
+		}
+		data.TotalHosts += 1
+		if h.Status == evergreen.HostStopped {
+			data.TotalStoppedHosts += 1
+		}
+		if h.NoExpiration {
+			data.TotalUnexpirableHosts += 1
+		}
+		data.InstanceTypes[h.InstanceType] += 1
+		usersWithHosts[h.StartedBy] = true
+		totalComputeCost += h.ComputeCostPerHour
+	}
+	data.AverageComputeCostPerHour = totalComputeCost / float64(data.TotalHosts)
+	data.NumUsersWithHosts = len(usersWithHosts)
+
+	usersWithVolumes := map[string]bool{}
+	for _, v := range hc.CachedVolumes {
+		data.TotalVolumes += 1
+		data.TotalVolumeSize += v.Size
+		usersWithVolumes[v.CreatedBy] = true
+	}
+	data.NumUsersWithVolumes = len(usersWithVolumes)
+	if data.TotalVolumes == 0 && data.TotalHosts == 0 {
+		return nil, errors.New("no host/volume results found")
+	}
+	return &data, nil
 }
 
 func findHostByIdWithOwner(c Connector, hostID string, user gimlet.User) (*host.Host, error) {

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -131,7 +131,7 @@ func (hc *DBHostConnector) CheckHostSecret(r *http.Request) (int, error) {
 	return code, errors.WithStack(err)
 }
 
-func (hc *DBHostConnector) AggregateSpawnHostData() (*host.SpawnHostUsage, error) {
+func (hc *DBHostConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error) {
 	data, err := host.AggregateSpawnhostData()
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting spawn host data")

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -140,6 +140,8 @@ type Connector interface {
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
 	NewIntentHost(*restModel.HostRequestOptions, *user.DBUser) (*host.Host, error)
 
+	// AggregateSpawnhostData returns basic metrics on spawn host/volume usage.
+	AggregateSpawnhostData() (*host.SpawnHostUsage, error)
 	// FetchContext is a method to fetch a context given a series of identifiers.
 	FetchContext(string, string, string, string, string) (model.Context, error)
 

--- a/rest/route/admin_spawn_hosts.go
+++ b/rest/route/admin_spawn_hosts.go
@@ -1,0 +1,54 @@
+package route
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/evergreen-ci/gimlet"
+)
+
+/*
+type SpawnHostUsageByUser struct {
+	User            string
+	SpawnHosts      HostData
+	NumEBSVolumes   int
+	TotalVolumeSize int
+}
+
+type HostData struct {
+	Uptime     time.Duration
+	Expiration time.Time
+	Type       string
+}
+*/
+
+func makeFetchSpawnHostUsage(sc data.Connector) gimlet.RouteHandler {
+	return &adminSpawnHostHandler{sc: sc}
+}
+
+type adminSpawnHostHandler struct {
+	//userID string
+
+	sc data.Connector
+}
+
+func (h *adminSpawnHostHandler) Factory() gimlet.RouteHandler {
+	return &adminSpawnHostHandler{
+		sc: h.sc,
+	}
+}
+
+func (h *adminSpawnHostHandler) Parse(ctx context.Context, r *http.Request) error {
+	//h.userID = gimlet.GetVars(r)["user_id"]
+	return nil
+}
+
+func (h *adminSpawnHostHandler) Run(ctx context.Context) gimlet.Responder {
+	res, err := host.AggregateSpawnhostData()
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(err)
+	}
+	return gimlet.NewJSONResponse(res)
+}

--- a/rest/route/admin_spawn_hosts.go
+++ b/rest/route/admin_spawn_hosts.go
@@ -9,28 +9,11 @@ import (
 	"github.com/evergreen-ci/gimlet"
 )
 
-/*
-type SpawnHostUsageByUser struct {
-	User            string
-	SpawnHosts      HostData
-	NumEBSVolumes   int
-	TotalVolumeSize int
-}
-
-type HostData struct {
-	Uptime     time.Duration
-	Expiration time.Time
-	Type       string
-}
-*/
-
 func makeFetchSpawnHostUsage(sc data.Connector) gimlet.RouteHandler {
 	return &adminSpawnHostHandler{sc: sc}
 }
 
 type adminSpawnHostHandler struct {
-	//userID string
-
 	sc data.Connector
 }
 
@@ -41,7 +24,6 @@ func (h *adminSpawnHostHandler) Factory() gimlet.RouteHandler {
 }
 
 func (h *adminSpawnHostHandler) Parse(ctx context.Context, r *http.Request) error {
-	//h.userID = gimlet.GetVars(r)["user_id"]
 	return nil
 }
 

--- a/rest/route/admin_spawn_hosts.go
+++ b/rest/route/admin_spawn_hosts.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
 )
@@ -28,7 +27,7 @@ func (h *adminSpawnHostHandler) Parse(ctx context.Context, r *http.Request) erro
 }
 
 func (h *adminSpawnHostHandler) Run(ctx context.Context) gimlet.Responder {
-	res, err := host.AggregateSpawnhostData()
+	res, err := h.sc.AggregateSpawnhostData()
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -50,7 +50,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/admin/banner").Version(2).Post().Wrap(superUser).RouteHandler(makeSetAdminBanner(sc))
 	app.AddRoute("/admin/bugsnag").Version(2).Get().RouteHandler(makeFetchBugsnag(sc))
 	app.AddRoute("/admin/events").Version(2).Get().Wrap(superUser).RouteHandler(makeFetchAdminEvents(sc))
-	app.AddRoute("/admin/spawn_hosts").Version(2).Get().Wrap(superUser).RouteHandler(makeFetchSpawnHostUsage())
+	app.AddRoute("/admin/spawn_hosts").Version(2).Get().Wrap(superUser).RouteHandler(makeFetchSpawnHostUsage(sc))
 	app.AddRoute("/admin/restart/versions").Version(2).Post().Wrap(superUser).RouteHandler(makeRestartRoute(sc, evergreen.RestartVersions, nil))
 	app.AddRoute("/admin/restart/tasks").Version(2).Post().Wrap(superUser).RouteHandler(makeRestartRoute(sc, evergreen.RestartTasks, opts.APIQueue))
 	app.AddRoute("/admin/revert").Version(2).Post().Wrap(superUser).RouteHandler(makeRevertRouteManager(sc))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -50,6 +50,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/admin/banner").Version(2).Post().Wrap(superUser).RouteHandler(makeSetAdminBanner(sc))
 	app.AddRoute("/admin/bugsnag").Version(2).Get().RouteHandler(makeFetchBugsnag(sc))
 	app.AddRoute("/admin/events").Version(2).Get().Wrap(superUser).RouteHandler(makeFetchAdminEvents(sc))
+	app.AddRoute("/admin/spawn_hosts").Version(2).Get().Wrap(superUser).RouteHandler(makeFetchSpawnHostUsage())
 	app.AddRoute("/admin/restart/versions").Version(2).Post().Wrap(superUser).RouteHandler(makeRestartRoute(sc, evergreen.RestartVersions, nil))
 	app.AddRoute("/admin/restart/tasks").Version(2).Post().Wrap(superUser).RouteHandler(makeRestartRoute(sc, evergreen.RestartTasks, opts.APIQueue))
 	app.AddRoute("/admin/revert").Version(2).Post().Wrap(superUser).RouteHandler(makeRevertRouteManager(sc))


### PR DESCRIPTION
The commented code isn't meant to be committed--I started adding something for admins to filter data by user and then couldn't think of a use case so I stopped, but if someone has an argument for why it's valuable I'll implement it.

This returns some basic metrics on overall spawn host and volume usage.