### PR TITLE
EVG-6957: use correct CLI context to get conf path

### DIFF
--- a/operations/admin.go
+++ b/operations/admin.go
@@ -60,16 +60,15 @@ func adminSetBanner() cli.Command {
 			},
 		},
 		Before: mergeBeforeFuncs(
-			requireClientConfig,
 			func(c *cli.Context) error {
 				if c.String(messageFlagName) != "" && c.Bool(clearFlagName) {
-					return errors.New("cannot specify a message and the 'clear' option at the same time")
+					return errors.New("must specify either a message or the  'clear' option, but not both")
 				}
 				return nil
 			},
 			func(c *cli.Context) error {
 				if c.String(messageFlagName) == "" && !c.Bool(clearFlagName) {
-					return errors.New("cannot specify a message and the 'clear' option at the same time")
+					return errors.New("must specify either a message or the 'clear' option, but not both")
 				}
 				return nil
 			},

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -558,7 +558,7 @@ func hostList() cli.Command {
 		},
 		Before: mergeBeforeFuncs(setPlainLogger, requireOnlyOneBool(mineFlagName, allFlagName)),
 		Action: func(c *cli.Context) error {
-			confPath := c.Parent().String(confFlagName)
+			confPath := c.Parent().Parent().String(confFlagName)
 			showMine := c.Bool(mineFlagName)
 			showAll := c.Bool(allFlagName)
 
@@ -617,7 +617,7 @@ func hostTerminate() cli.Command {
 		Flags:  addHostFlag(),
 		Before: mergeBeforeFuncs(setPlainLogger, requireHostFlag),
 		Action: func(c *cli.Context) error {
-			confPath := c.Parent().String(confFlagName)
+			confPath := c.Parent().Parent().String(confFlagName)
 			hostID := c.String(hostFlagName)
 
 			ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6957

Fixes config file flag for `evergreen admin banner`, `evergreen host list`, and `evergreen host terminate`.