### PR TITLE
EVG-6718 use $merge for hourly and daily test stats.

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -78,6 +78,7 @@ var (
 	cacheStatsJobDisabledKey        = bsonutil.MustHaveTag(ServiceFlags{}, "CacheStatsJobDisabled")
 	cacheStatsEndpointDisabledKey   = bsonutil.MustHaveTag(ServiceFlags{}, "CacheStatsEndpointDisabled")
 	cacheStatsOldTasksDisabledKey   = bsonutil.MustHaveTag(ServiceFlags{}, "CacheStatsOldTasksDisabled")
+        cacheStatsMergeEnabledKey       = bsonutil.MustHaveTag(ServiceFlags{}, "CacheStatsMergeEnabled")
 	taskReliabilityDisabledKey      = bsonutil.MustHaveTag(ServiceFlags{}, "TaskReliabilityDisabled")
 	commitQueueDisabledKey          = bsonutil.MustHaveTag(ServiceFlags{}, "CommitQueueDisabled")
 	plannerDisabledKey              = bsonutil.MustHaveTag(ServiceFlags{}, "PlannerDisabled")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -23,7 +23,8 @@ type ServiceFlags struct {
 	CacheStatsJobDisabled      bool `bson:"cache_stats_job_disabled" json:"cache_stats_job_disabled"`
 	CacheStatsEndpointDisabled bool `bson:"cache_stats_endpoint_disabled" json:"cache_stats_endpoint_disabled"`
 	CacheStatsOldTasksDisabled bool `bson:"cache_stats_old_tasks_disabled" json:"cache_stats_old_tasks_disabled"`
-        CacheStatsMergeEnabled     bool `bson:"cache_stats_merge_enabled" json:"cache_stats_merge_enabled"`
+	CacheStatsMergeEnabled     bool `bson:"cache_stats_merge_enabled" json:"cache_stats_merge_enabled"`
+	CacheStatsMergeBatchLimit  int  `bson:"cache_stats_merge_batch_limit" json:"cache_stats_merge_batch_limit"`
 	TaskReliabilityDisabled    bool `bson:"task_reliability_disabled" json:"task_reliability_disabled"`
 	CommitQueueDisabled        bool `bson:"commit_queue_disabled" json:"commit_queue_disabled"`
 	PlannerDisabled            bool `bson:"planner_disabled" json:"planner_disabled"`
@@ -87,7 +88,7 @@ func (c *ServiceFlags) Set() error {
 			taskLoggingDisabledKey:          c.TaskLoggingDisabled,
 			cacheStatsJobDisabledKey:        c.CacheStatsJobDisabled,
 			cacheStatsEndpointDisabledKey:   c.CacheStatsEndpointDisabled,
-                        cacheStatsMergeEnabledKey:       c.CacheStatsMergeEnabled,
+			cacheStatsMergeEnabledKey:       c.CacheStatsMergeEnabled,
 			taskReliabilityDisabledKey:      c.TaskReliabilityDisabled,
 			commitQueueDisabledKey:          c.CommitQueueDisabled,
 			plannerDisabledKey:              c.PlannerDisabled,

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -23,6 +23,7 @@ type ServiceFlags struct {
 	CacheStatsJobDisabled      bool `bson:"cache_stats_job_disabled" json:"cache_stats_job_disabled"`
 	CacheStatsEndpointDisabled bool `bson:"cache_stats_endpoint_disabled" json:"cache_stats_endpoint_disabled"`
 	CacheStatsOldTasksDisabled bool `bson:"cache_stats_old_tasks_disabled" json:"cache_stats_old_tasks_disabled"`
+        CacheStatsMergeEnabled     bool `bson:"cache_stats_merge_enabled" json:"cache_stats_merge_enabled"`
 	TaskReliabilityDisabled    bool `bson:"task_reliability_disabled" json:"task_reliability_disabled"`
 	CommitQueueDisabled        bool `bson:"commit_queue_disabled" json:"commit_queue_disabled"`
 	PlannerDisabled            bool `bson:"planner_disabled" json:"planner_disabled"`
@@ -86,7 +87,7 @@ func (c *ServiceFlags) Set() error {
 			taskLoggingDisabledKey:          c.TaskLoggingDisabled,
 			cacheStatsJobDisabledKey:        c.CacheStatsJobDisabled,
 			cacheStatsEndpointDisabledKey:   c.CacheStatsEndpointDisabled,
-			cacheStatsOldTasksDisabledKey:   c.CacheStatsOldTasksDisabled,
+                        cacheStatsMergeEnabledKey:       c.CacheStatsMergeEnabled,
 			taskReliabilityDisabledKey:      c.TaskReliabilityDisabled,
 			commitQueueDisabledKey:          c.CommitQueueDisabled,
 			plannerDisabledKey:              c.PlannerDisabled,

--- a/makefile
+++ b/makefile
@@ -459,7 +459,7 @@ mongodb/.get-mongodb:
 get-mongodb:mongodb/.get-mongodb
 	@touch $<
 start-mongod:mongodb/.get-mongodb
-	./mongodb/mongod --dbpath ./mongodb/db_files --port 27017 --replSet evg --smallfiles --oplogSize 10
+        ./mongodb/mongod --dbpath ./mongodb/db_files --port 27017 --replSet evg --oplogSize 10
 	@echo "waiting for mongod to start up"
 init-rs:mongodb/.get-mongodb
 	./mongodb/mongo --eval 'rs.initiate()'

--- a/makefile
+++ b/makefile
@@ -459,7 +459,7 @@ mongodb/.get-mongodb:
 get-mongodb:mongodb/.get-mongodb
 	@touch $<
 start-mongod:mongodb/.get-mongodb
-        ./mongodb/mongod --dbpath ./mongodb/db_files --port 27017 --replSet evg --oplogSize 10
+	./mongodb/mongod --dbpath ./mongodb/db_files --port 27017 --replSet evg --oplogSize 10
 	@echo "waiting for mongod to start up"
 init-rs:mongodb/.get-mongodb
 	./mongodb/mongo --eval 'rs.initiate()'

--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -352,6 +352,9 @@ func testStatsMergePipeline(daily bool, projectIDs []string, requesters []string
         match := bson.M{
                 testresult.IDKey:             bson.M{"$gt": lastID},
                 testresult.TaskCreateTimeKey: bson.M{"$gte": start, "$lt": end},
+                testresult.ProjectKey:        bson.M{"$in": projectIDs},
+                testresult.DisplayNameKey:    bson.M{"$in": tasks},
+                testresult.RequesterKey:      bson.M{"$in": requesters},
                 // For simplicity's sake, (and to shorten any required index) the following line
                 // is removed but could be used to filter further (with a supporting index).
                 // testresult.StatusKey: bson.M{"$in": Array{evergreen.TestSucceededStatus, evergreen.TestFailedStatus, evergreen.TestSilentlyFailedStatus}},
@@ -359,28 +362,14 @@ func testStatsMergePipeline(daily bool, projectIDs []string, requesters []string
 
         if len(projectIDs) == 1 {
                 match[testresult.ProjectKey] = projectIDs[0]
-        } else if len(projectIDs) > 1 {
-                match[testresult.ProjectKey] = bson.M{"$in": projectIDs}
         }
 
-        var or []bson.M
         if len(tasks) == 1 {
-                or = []bson.M{
-                        {testresult.DisplayNameKey: tasks[0]},
-                        {testresult.ExecutionDisplayNameKey: tasks[0]},
-                }
-        } else if len(tasks) > 1 {
-                or = []bson.M{
-                        {testresult.DisplayNameKey: bson.M{"$in": tasks}},
-                        {testresult.ExecutionDisplayNameKey: bson.M{"$in": tasks}},
-                }
+                match[testresult.DisplayNameKey] = tasks[0]
         }
-        match["$or"] = or
 
         if len(requesters) == 1 {
                 match[testresult.RequesterKey] = requesters[0]
-        } else if len(requesters) > 1 {
-                match[testresult.RequesterKey] = bson.M{"$in": requesters}
         }
 
         dateFromParts := bson.M{

--- a/model/stats/stats.go
+++ b/model/stats/stats.go
@@ -87,10 +87,10 @@ type GenerateOptions struct {
 	ProjectID       string
 	Requester       string
 	Tasks           []string
-	Window          time.Time
-	Runtime         time.Time
-	DisableOldTasks bool
-        UseMerge        bool
+        Window          time.Time
+        Runtime         time.Time
+        DisableOldTasks bool
+        EnableMerge     bool
 }
 
 // GenerateHourlyTestStats aggregates task and testresults present in the database and saves the

--- a/model/stats/stats_test.go
+++ b/model/stats/stats_test.go
@@ -585,13 +585,11 @@ func (s *statsSuite) TestGenerateDailyTestStatsMerge() {
 func (s *statsSuite) TestGenerateDailyTaskStats() {
 	require := s.Require()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+        ctx, cancel := context.WithCancel(context.Background())
+        defer cancel()
 
-        // qry := bson.M{}
-
-	// Insert task docs.
-	s.initTasks()
+        // Insert task docs.
+        s.initTasks()
 
 	// Generate task stats for project p1 and an unknown task.
 	err := GenerateDailyTaskStats(ctx, GenerateOptions{
@@ -1081,18 +1079,9 @@ func (s *statsSuite) getLastTestResult(testStatsID DbTestStatsId, hourly bool) (
                 end = start.Add(24 * time.Hour)
         }
 
-        // func (s *statsSuite) getLastTestResult(testStatsID DbTestStatsId) (*testresult.TestResult, error) {
-        // 	var lastTestResult *testresult.TestResult
-        // 	start := util.GetUTCHour(testStatsID.Date)
-        // 	end := start.Add(time.Hour)
-        // 	// if !hourly {
-        // 	// 	start = util.GetUTCDay(testStatsID.Date)
-        // 	// 	end = start.Add(24 * time.Hour)
-        // 	// }
-
-	qry := bson.M{
-		testresult.ProjectKey:   testStatsID.Project,
-		testresult.RequesterKey: testStatsID.Requester,
+        qry := bson.M{
+                testresult.ProjectKey:   testStatsID.Project,
+                testresult.RequesterKey: testStatsID.Requester,
 		testresult.TestFileKey:  testStatsID.TestFile,
 		"$or": []bson.M{
 			{testresult.DisplayNameKey: testStatsID.TaskName},
@@ -1149,27 +1138,6 @@ func (s *statsSuite) getLastHourlyTestStat(testStatsID DbTestStatsId) (*DbTestSt
 
 func (s *statsSuite) validateDbTestStats(testStatsID DbTestStatsId, date time.Time, numPass int, numFail int, avgDurationPass float64, lastUpdate time.Time, hourly bool) {
         require := s.Require()
-        // var doc *DbTestStats
-        // var err error
-
-        // if hourly {
-        // 	doc, err = GetHourlyTestDoc(testStatsID)
-        // } else {
-        // 	doc, err = GetDailyTestDoc(testStatsID)
-        // }
-        // require.Nil(err)
-        // require.NotNil(doc)
-        // require.Equal(testStatsID.Project, doc.Id.Project)
-        // require.Equal(testStatsID.Requester, doc.Id.Requester)
-        // require.Equal(testStatsID.TestFile, doc.Id.TestFile)
-        // require.Equal(testStatsID.TaskName, doc.Id.TaskName)
-        // require.Equal(testStatsID.BuildVariant, doc.Id.BuildVariant)
-        // require.Equal(testStatsID.Distro, doc.Id.Distro)
-        // require.Equal(date, doc.Id.Date.UTC())
-        // require.Equal(numPass, doc.NumPass)
-        // require.Equal(numFail, doc.NumFail)
-        // require.Equal(avgDurationPass, doc.AvgDurationPass)
-        // require.WithinDuration(lastUpdate, doc.LastUpdate, 0)
 
         doc := s.validateDbTestStatsNoLast(testStatsID, date, numPass, numFail, avgDurationPass, lastUpdate, hourly)
         lastTestResult, err := s.getLastTestResult(testStatsID, hourly)

--- a/model/stats/stats_test.go
+++ b/model/stats/stats_test.go
@@ -106,7 +106,7 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 	require.NoError(err)
 	require.Equal(5, s.countHourlyTestDocs())
 
-	testStatsID := DbTestStatsId{
+        s.validateDbTestStats(DbTestStatsId{
 		Project:      "p1",
 		Requester:    "r1",
 		TestFile:     "test1.js",
@@ -114,29 +114,9 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseHour,
-	}
-	doc, err := GetHourlyTestDoc(testStatsID)
+        }, baseHour.UTC(), 0, 2, 0.0, jobTime, true)
 
-	require.NoError(err)
-	require.NotNil(doc)
-	require.Equal("p1", doc.Id.Project)
-	require.Equal("r1", doc.Id.Requester)
-	require.Equal("test1.js", doc.Id.TestFile)
-	require.Equal("task1", doc.Id.TaskName)
-	require.Equal("v1", doc.Id.BuildVariant)
-	require.Equal("d1", doc.Id.Distro)
-	require.Equal(baseHour.UTC(), doc.Id.Date.UTC())
-	require.Equal(0, doc.NumPass)
-	require.Equal(2, doc.NumFail)
-	require.Equal(float64(0), doc.AvgDurationPass)
-	require.WithinDuration(jobTime, doc.LastUpdate, 0)
-
-	var lastTestResult *testresult.TestResult
-	lastTestResult, err = s.getLastTestResult(testStatsID)
-	require.NoError(err)
-	require.Equal(lastTestResult.ID, doc.LastID)
-
-	testStatsID = DbTestStatsId{
+        s.validateDbTestStats(DbTestStatsId{
 		Project:      "p1",
 		Requester:    "r1",
 		TestFile:     "test2.js",
@@ -144,19 +124,9 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseHour,
-	}
-	doc, err = GetHourlyTestDoc(testStatsID)
-	require.NoError(err)
-	require.NotNil(doc)
-	require.Equal(1, doc.NumPass)
-	require.Equal(1, doc.NumFail)
-	require.Equal(float64(120), doc.AvgDurationPass)
+        }, baseHour.UTC(), 1, 1, 120.0, jobTime, true)
 
-	lastTestResult, err = s.getLastTestResult(testStatsID)
-	require.NoError(err)
-	require.Equal(lastTestResult.ID, doc.LastID)
-
-	testStatsID = DbTestStatsId{
+        s.validateDbTestStats(DbTestStatsId{
 		Project:      "p1",
 		Requester:    "r1",
 		TestFile:     "test3.js",
@@ -164,17 +134,7 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseHour,
-	}
-	doc, err = GetHourlyTestDoc(testStatsID)
-	require.NoError(err)
-	require.NotNil(doc)
-	require.Equal(2, doc.NumPass)
-	require.Equal(0, doc.NumFail)
-	require.Equal(float64(12.5), doc.AvgDurationPass)
-
-	lastTestResult, err = s.getLastTestResult(testStatsID)
-	require.NoError(err)
-	require.Equal(lastTestResult.ID, doc.LastID)
+        }, baseHour.UTC(), 2, 0, 12.5, jobTime, true)
 
 	// Generate hourly stats for project p2
 	// Testing old tasks.
@@ -188,7 +148,7 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 	require.NoError(err)
 	require.Equal(8, s.countHourlyTestDocs()) // 3 more tests combination were added to the collection
 
-	testStatsID = DbTestStatsId{
+        s.validateDbTestStats(DbTestStatsId{
 		Project:      "p2",
 		Requester:    "r1",
 		TestFile:     "test1.js",
@@ -196,20 +156,9 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseHour,
-	}
-	doc, err = GetHourlyTestDoc(testStatsID)
-	require.NoError(err)
-	require.NotNil(doc)
-	require.Equal(0, doc.NumPass)
-	require.Equal(3, doc.NumFail)
-	require.Equal(float64(0), doc.AvgDurationPass)
-	require.WithinDuration(jobTime, doc.LastUpdate, 0)
+        }, baseHour.UTC(), 0, 3, 0.0, jobTime, true)
 
-	lastTestResult, err = s.getLastTestResult(testStatsID)
-	require.NoError(err)
-	require.Equal(lastTestResult.ID, doc.LastID)
-
-	testStatsID = DbTestStatsId{
+        s.validateDbTestStats(DbTestStatsId{
 		Project:      "p2",
 		Requester:    "r1",
 		TestFile:     "test2.js",
@@ -217,17 +166,7 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseHour,
-	}
-	doc, err = GetHourlyTestDoc(testStatsID)
-	require.NoError(err)
-	require.Equal(1, doc.NumPass)
-	require.Equal(2, doc.NumFail)
-	require.Equal(float64(120), doc.AvgDurationPass)
-	require.WithinDuration(jobTime, doc.LastUpdate, 0)
-
-	lastTestResult, err = s.getLastTestResult(testStatsID)
-	require.NoError(err)
-	require.Equal(lastTestResult.ID, doc.LastID)
+        }, baseHour.UTC(), 1, 2, 120.0, jobTime, true)
 
 	// Generate hourly stats for project p3.
 	// Testing display task / execution task.
@@ -241,7 +180,7 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 	require.NoError(err)
 	require.Equal(10, s.countHourlyTestDocs()) // 2 more tests combination were added to the collection
 
-	testStatsID = DbTestStatsId{
+        doc, err := GetHourlyTestDoc(DbTestStatsId{
 		Project:      "p3",
 		Requester:    "r1",
 		TestFile:     "test1.js",
@@ -249,12 +188,11 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseHour,
-	}
-	doc, err = GetHourlyTestDoc(testStatsID)
+        })
 	require.NoError(err)
 	require.Nil(doc)
 
-	testStatsID = DbTestStatsId{
+        s.validateDbTestStats(DbTestStatsId{
 		Project:      "p3",
 		Requester:    "r1",
 		TestFile:     "test1.js",
@@ -262,19 +200,9 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseHour,
-	}
-	doc, err = GetHourlyTestDoc(testStatsID)
-	require.NoError(err)
-	require.NotNil(doc)
-	require.Equal(0, doc.NumPass)
-	require.Equal(1, doc.NumFail)
-	require.Equal(float64(0), doc.AvgDurationPass)
+        }, baseHour.UTC(), 0, 1, 0.0, jobTime, true)
 
-	lastTestResult, err = s.getLastTestResult(testStatsID)
-	require.NoError(err)
-	require.Equal(lastTestResult.ID, doc.LastID)
-
-	testStatsID = DbTestStatsId{
+        s.validateDbTestStats(DbTestStatsId{
 		Project:      "p3",
 		Requester:    "r1",
 		TestFile:     "test2.js",
@@ -282,17 +210,7 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseHour,
-	}
-	doc, err = GetHourlyTestDoc(testStatsID)
-	require.NoError(err)
-	require.NotNil(doc)
-	require.Equal(1, doc.NumPass)
-	require.Equal(0, doc.NumFail)
-	require.Equal(float64(120), doc.AvgDurationPass)
-
-	lastTestResult, err = s.getLastTestResult(testStatsID)
-	require.NoError(err)
-	require.Equal(lastTestResult.ID, doc.LastID)
+        }, baseHour.UTC(), 1, 0, 120.0, jobTime, true)
 
 	// Generate hourly stats for project p5.
 	// Testing tests with status 'skip'.
@@ -306,7 +224,7 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 	require.Equal(12, s.countHourlyTestDocs()) // 2 more tests combination were added to the collection.
 
 	// test1.js passed once and was skipped once.
-	testStatsID = DbTestStatsId{
+        s.validateDbTestStats(DbTestStatsId{
 		Project:      "p5",
 		Requester:    "r1",
 		TestFile:     "test1.js",
@@ -314,38 +232,186 @@ func (s *statsSuite) TestGenerateHourlyTestStats() {
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseHour,
-	}
-	doc, err = GetHourlyTestDoc(testStatsID)
-	require.NoError(err)
-	require.NotNil(doc)
-	require.Equal(1, doc.NumPass)
-	require.Equal(0, doc.NumFail)
-	require.Equal(float64(60), doc.AvgDurationPass)
+        }, baseHour.UTC(), 1, 0, 60.0, jobTime, true)
 
-	lastTestResult, err = s.getLastTestResult(testStatsID)
-	require.NoError(err)
-	require.Equal(lastTestResult.ID, doc.LastID)
+        // test2.js failed once and was skipped once.
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p5",
+                Requester:    "r1",
+                TestFile:     "test2.js",
+                TaskName:     "task1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseHour,
+        }, baseHour.UTC(), 0, 1, 0.0, jobTime, true)
+}
 
-	// test2.js failed once and was skipped once.
-	testStatsID = DbTestStatsId{
-		Project:      "p5",
+func (s *statsSuite) TestGenerateHourlyTestStatsMerge() {
+        rand.Seed(314159265)
+        require := s.Require()
+
+        // Insert task docs.
+        s.initTasks()
+
+        ctx, cancel := context.WithCancel(context.Background())
+        defer cancel()
+
+        // Generate hourly stats for project p1 and an unknown task.
+        err := GenerateHourlyTestStatsUsingMerge(ctx, GenerateOptions{
+                ProjectID: "p1",
+                Requester: "r1",
+                Window:    baseHour,
+                Tasks:     []string{"unknown_task"},
+                Runtime:   jobTime})
+	require.NoError(err)
+        require.Equal(0, s.countHourlyTestDocs())
+
+        // Generate hourly stats for project p1.
+        err = GenerateHourlyTestStatsUsingMerge(ctx, GenerateOptions{
+                ProjectID: "p1",
+                Requester: "r1",
+                Window:    baseHour,
+                Tasks:     []string{"task1"},
+                Runtime:   jobTime})
+        require.NoError(err)
+        require.Equal(5, s.countHourlyTestDocs())
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p1",
+                Requester:    "r1",
+                TestFile:     "test1.js",
+                TaskName:     "task1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseHour,
+        }, baseHour.UTC(), 0, 2, 0.0, jobTime, true)
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p1",
+                Requester:    "r1",
+                TestFile:     "test2.js",
+                TaskName:     "task1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseHour,
+        }, baseHour.UTC(), 1, 1, 120.0, jobTime, true)
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p1",
+                Requester:    "r1",
+                TestFile:     "test3.js",
+                TaskName:     "task1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseHour,
+        }, baseHour.UTC(), 2, 0, 12.5, jobTime, true)
+
+        // Generate hourly stats for project p2
+        // Testing old tasks.
+        err = GenerateHourlyTestStatsUsingMerge(ctx, GenerateOptions{
+                ProjectID: "p2",
+                Requester: "r1",
+                Window:    baseHour,
+                Tasks:     []string{"task1"},
+                Runtime:   jobTime})
+	require.NoError(err)
+        require.Equal(8, s.countHourlyTestDocs()) // 3 more tests combination were added to the collection
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p2",
+                Requester:    "r1",
+                TestFile:     "test1.js",
+                TaskName:     "task1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseHour,
+        }, baseHour.UTC(), 0, 3, 0.0, jobTime, true)
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p2",
 		Requester:    "r1",
 		TestFile:     "test2.js",
 		TaskName:     "task1",
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseHour,
-	}
-	doc, err = GetHourlyTestDoc(testStatsID)
-	require.NoError(err)
-	require.NotNil(doc)
-	require.Equal(0, doc.NumPass)
-	require.Equal(1, doc.NumFail)
-	require.Equal(float64(0), doc.AvgDurationPass)
+        }, baseHour.UTC(), 1, 2, 120.0, jobTime, true)
 
-	lastTestResult, err = s.getLastTestResult(testStatsID)
+        // Generate hourly stats for project p3.
+        // Testing display task / execution task.
+        err = GenerateHourlyTestStatsUsingMerge(ctx, GenerateOptions{
+                ProjectID: "p3",
+                Requester: "r1",
+                Window:    baseHour,
+                Tasks:     []string{"task_exec_1"},
+                Runtime:   jobTime})
 	require.NoError(err)
-	require.Equal(lastTestResult.ID, doc.LastID)
+        require.Equal(10, s.countHourlyTestDocs()) // 2 more tests combination were added to the collection
+
+        doc, err := GetHourlyTestDoc(DbTestStatsId{
+                Project:      "p3",
+                Requester:    "r1",
+                TestFile:     "test1.js",
+                TaskName:     "task_exec_1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseHour,
+        })
+	require.NoError(err)
+        require.Nil(doc)
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p3",
+                Requester:    "r1",
+                TestFile:     "test1.js",
+                TaskName:     "task_display_1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseHour,
+        }, baseHour.UTC(), 0, 1, 0.0, jobTime, true)
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p3",
+                Requester:    "r1",
+                TestFile:     "test2.js",
+                TaskName:     "task_display_1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseHour,
+        }, baseHour.UTC(), 1, 0, 120.0, jobTime, true)
+
+        // Generate hourly stats for project p5.
+        // Testing tests with status 'skip'.
+        err = GenerateHourlyTestStatsUsingMerge(ctx, GenerateOptions{
+                ProjectID: "p5",
+                Requester: "r1",
+                Window:    baseHour,
+                Tasks:     []string{"task1", "task2"},
+                Runtime:   jobTime})
+        require.NoError(err)
+        require.Equal(12, s.countHourlyTestDocs()) // 2 more tests combination were added to the collection.
+
+        // test1.js passed once and was skipped once.
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p5",
+                Requester:    "r1",
+                TestFile:     "test1.js",
+                TaskName:     "task1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseHour,
+        }, baseHour.UTC(), 1, 0, 60.0, jobTime, true)
+
+        // test2.js failed once and was skipped once.
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p5",
+                Requester:    "r1",
+                TestFile:     "test2.js",
+                TaskName:     "task1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseHour,
+        }, baseHour.UTC(), 0, 1, 0.0, jobTime, true)
 }
 
 func (s *statsSuite) TestGenerateDailyTestStatsFromHourly() {
@@ -372,7 +438,9 @@ func (s *statsSuite) TestGenerateDailyTestStatsFromHourly() {
 	require.NoError(err)
 	require.Equal(1, s.countDailyTestDocs())
 
-	testStatsID := DbTestStatsId{
+        // This test directly creates hourly test stats without the associated testresults. So
+        // we can't check the value this way.
+        s.validateDbTestStatsNoLast(DbTestStatsId{
 		Project:      "p1",
 		Requester:    "r1",
 		TestFile:     "test1.js",
@@ -380,26 +448,138 @@ func (s *statsSuite) TestGenerateDailyTestStatsFromHourly() {
 		BuildVariant: "v1",
 		Distro:       "d1",
 		Date:         baseDay,
-	}
-	doc, err := GetDailyTestDoc(testStatsID)
-	require.Nil(err)
-	require.NotNil(doc)
-	require.Equal("p1", doc.Id.Project)
-	require.Equal("r1", doc.Id.Requester)
-	require.Equal("test1.js", doc.Id.TestFile)
-	require.Equal("task1", doc.Id.TaskName)
-	require.Equal("v1", doc.Id.BuildVariant)
-	require.Equal("d1", doc.Id.Distro)
-	require.Equal(baseDay.UTC(), doc.Id.Date.UTC())
-	require.Equal(30, doc.NumPass)
-	require.Equal(5, doc.NumFail)
-	require.Equal(float64(4), doc.AvgDurationPass)
-	require.WithinDuration(jobTime, doc.LastUpdate, 0)
+        }, baseDay.UTC(), 30, 5, 4.0, jobTime, false)
+}
 
-	var lastTestResult *dbTestStats
-	lastTestResult, err = s.getLastHourlyTestStat(testStatsID)
+func (s *statsSuite) validateDailyTestResults(ctx context.Context, dailyOptions GenerateOptions) {
+
+        require := s.Require()
+
+        // Generate daily test stats for exiting task
+        require.Equal(5, s.countDailyTestDocs())
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p1",
+                Requester:    "r1",
+                TestFile:     "test1.js",
+                TaskName:     "task1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseDay,
+        }, baseDay.UTC(), 0, 3, 0.0, jobTime, false)
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p1",
+                Requester:    "r1",
+                TestFile:     "test1.js",
+                TaskName:     "task1",
+                BuildVariant: "v2",
+                Distro:       "d1",
+                Date:         baseDay,
+        }, baseDay.UTC(), 0, 1, 0.0, jobTime, false)
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p1",
+                Requester:    "r1",
+                TestFile:     "test2.js",
+                TaskName:     "task1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseDay,
+        }, baseDay.UTC(), 2, 1, 120.0, jobTime, false)
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p1",
+                Requester:    "r1",
+                TestFile:     "test2.js",
+                TaskName:     "task1",
+                BuildVariant: "v2",
+                Distro:       "d1",
+                Date:         baseDay,
+        }, baseDay.UTC(), 0, 1, 0.0, jobTime, false)
+
+        s.validateDbTestStats(DbTestStatsId{
+                Project:      "p1",
+                Requester:    "r1",
+                TestFile:     "test3.js",
+                TaskName:     "task1",
+                BuildVariant: "v1",
+                Distro:       "d1",
+                Date:         baseDay,
+        }, baseDay.UTC(), 2, 0, 12.5, jobTime, false)
+}
+
+func (s *statsSuite) TestGenerateDailyTestStatsChained() {
+        // The merge version does not generate the Daily test stats from the hourly test stats.
+        // This approach is simpler and allows the calculations to be run independently and to
+        // be independently restarted.
+        rand.Seed(314159265)
+        require := s.Require()
+
+        ctx, cancel := context.WithCancel(context.Background())
+        defer cancel()
+
+        // Insert tasks.
+        s.initTasks()
+
+        // Generate daily test stats for unknown task.
+        err := GenerateDailyTestStatsFromHourly(ctx, GenerateOptions{
+                ProjectID: "p1",
+                Requester: "r1",
+                Window:    baseDay,
+                Tasks:     []string{"unknown_task"},
+                Runtime:   jobTime})
+        require.NoError(err)
+        require.Equal(0, s.countDailyTestDocs())
+
+        // Generate daily test stats for exiting task
+        generateOptions := GenerateOptions{ProjectID: "p1", Requester: "r1", Window: baseDay, Tasks: []string{"task1"}, Runtime: jobTime}
+        for hour := 0; hour < 24; hour++ {
+                err = GenerateHourlyTestStats(ctx, GenerateOptions{
+                        ProjectID: generateOptions.ProjectID,
+                        Requester: generateOptions.Requester,
+                        Window:    generateOptions.Window.Add(time.Hour * time.Duration(hour)),
+                        Tasks:     generateOptions.Tasks,
+                        Runtime:   generateOptions.Runtime})
+                require.NoError(err)
+	}
+
+        // Generate daily test stats for exiting task
+        err = GenerateDailyTestStatsFromHourly(ctx, generateOptions)
+        require.NoError(err)
+
+        s.validateDailyTestResults(ctx, generateOptions)
+}
+
+func (s *statsSuite) TestGenerateDailyTestStatsMerge() {
+        // The merge version does not generate the Daily test stats from the hourly test stats.
+        // This approach is simpler and allows the calculations to be run independently and to
+        // be independently restarted.
+        rand.Seed(314159265)
+        require := s.Require()
+
+        ctx, cancel := context.WithCancel(context.Background())
+        defer cancel()
+
+        // Insert hourly test stats docs.
+        s.initTasks()
+
+        // Generate daily test stats for unknown task.
+        err := GenerateDailyTestStatsUsingMerge(ctx, GenerateOptions{
+                ProjectID: "p1",
+                Requester: "r1",
+                Window:    baseDay,
+                Tasks:     []string{"unknown_task"},
+                Runtime:   jobTime})
+        require.NoError(err)
+        require.Equal(0, s.countDailyTestDocs())
+
+        // Generate daily test stats for exiting task
+        generateOptions := GenerateOptions{ProjectID: "p1", Requester: "r1", Window: baseDay, Tasks: []string{"task1"}, Runtime: jobTime}
+        err = GenerateDailyTestStatsUsingMerge(ctx, generateOptions)
 	require.NoError(err)
-	require.Equal(lastTestResult.LastID, doc.LastID)
+
+        s.validateDailyTestResults(ctx, generateOptions)
 }
 
 func (s *statsSuite) TestGenerateDailyTaskStats() {
@@ -407,6 +587,8 @@ func (s *statsSuite) TestGenerateDailyTaskStats() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+        // qry := bson.M{}
 
 	// Insert task docs.
 	s.initTasks()
@@ -654,68 +836,69 @@ func (s *statsSuite) initTasks() {
 	systemFailed := taskStatus{"failed", "system", false, 10}
 
 	// Task
-	task := s.insertTask("p1", "r1", "task_id_1", 0, "task1", "v1", "d1", t0, testFailed)
+        task := s.insertTask("p1", "r1", "task_id_1", 0, "task1", "v1", "d1", t0, t0.Add(3*time.Minute), testFailed)
 	s.insertTestResult("task_id_1", 0, "test1.js", evergreen.TestFailedStatus, 60, &task, nil)
-	s.insertTestResult("task_id_1", 0, "test2.js", evergreen.TestFailedStatus, 120, &task, nil)
+        s.insertTestResult("task_id_1", 0, "test2.js", evergreen.TestSilentlyFailedStatus, 120, &task, nil)
 	s.insertTestResult("task_id_1", 0, "test3.js", evergreen.TestSucceededStatus, 10, &task, nil)
 	// Task on variant v2
-	task = s.insertTask("p1", "r1", "task_id_2", 0, "task1", "v2", "d1", t0, testFailed)
+        task = s.insertTask("p1", "r1", "task_id_2", 0, "task1", "v2", "d1", t0, t0.Add(3*time.Minute), testFailed)
 	s.insertTestResult("task_id_2", 0, "test1.js", evergreen.TestFailedStatus, 60, &task, nil)
 	s.insertTestResult("task_id_2", 0, "test2.js", evergreen.TestFailedStatus, 120, &task, nil)
 	// Task with different task name
-	task = s.insertTask("p1", "r1", "task_id_3", 0, "task2", "v1", "d1", t0, testFailed)
+        task = s.insertTask("p1", "r1", "task_id_3", 0, "task2", "v1", "d1", t0, t0.Add(3*time.Minute), testFailed)
 	s.insertTestResult("task_id_3", 0, "test1.js", evergreen.TestFailedStatus, 60, &task, nil)
 	s.insertTestResult("task_id_3", 0, "test2.js", evergreen.TestFailedStatus, 120, &task, nil)
 	// Task 10 minutes later
-	task = s.insertTask("p1", "r1", "task_id_4", 0, "task1", "v1", "d1", t0plus10m, testFailed)
+        task = s.insertTask("p1", "r1", "task_id_4", 0, "task1", "v1", "d1", t0plus10m, t0plus10m.Add(3*time.Minute), testFailed)
 	s.insertTestResult("task_id_4", 0, "test1.js", evergreen.TestFailedStatus, 60, &task, nil)
 	s.insertTestResult("task_id_4", 0, "test2.js", evergreen.TestSucceededStatus, 120, &task, nil)
 	s.insertTestResult("task_id_4", 0, "test3.js", evergreen.TestSucceededStatus, 15, &task, nil)
 	// Task 1 hour later
-	task = s.insertTask("p1", "r1", "task_id_5", 0, "task1", "v1", "d1", t0plus1h, testFailed)
+        task = s.insertTask("p1", "r1", "task_id_5", 0, "task1", "v1", "d1", t0plus1h, t0plus1h.Add(3*time.Minute), testFailed)
 	s.insertTestResult("task_id_5", 0, "test1.js", evergreen.TestFailedStatus, 60, &task, nil)
-	s.insertTestResult("task_id_5", 0, "test2.js", evergreen.TestFailedStatus, 120, &task, nil)
+        // s.insertTestResult("task_id_5", 0, "test2.js", evergreen.TestFailedStatus, 120, &task, nil)
+        s.insertTestResult("task_id_5", 0, "test2.js", evergreen.TestSucceededStatus, 120, &task, nil)
 	// Task different requester
-	task = s.insertTask("p1", "r2", "task_id_6", 0, "task1", "v1", "d1", t0, testFailed)
+        task = s.insertTask("p1", "r2", "task_id_6", 0, "task1", "v1", "d1", t0, t0.Add(3*time.Second), testFailed)
 	s.insertTestResult("task_id_6", 0, "test1.js", evergreen.TestFailedStatus, 60, &task, nil)
 	s.insertTestResult("task_id_6", 0, "test2.js", evergreen.TestFailedStatus, 120, &task, nil)
 	// Task different project
-	task = s.insertTask("p2", "r1", "task_id_7", 0, "task1", "v1", "d1", t0, testFailed)
+        task = s.insertTask("p2", "r1", "task_id_7", 0, "task1", "v1", "d1", t0, t0.Add(3*time.Second), testFailed)
 	s.insertTestResult("task_id_7", 0, "test1.js", evergreen.TestFailedStatus, 60, &task, nil)
 	s.insertTestResult("task_id_7", 0, "test2.js", evergreen.TestFailedStatus, 120, &task, nil)
 	// Task with old executions.
-	task = s.insertTask("p2", "r1", "task_id_8", 2, "task1", "v1", "d1", t0plus10m, testFailed)
+        task = s.insertTask("p2", "r1", "task_id_8", 2, "task1", "v1", "d1", t0plus10m, t0plus10m.Add(3*time.Minute), testFailed)
 	s.insertTestResult("task_id_8", 2, "test1.js", evergreen.TestFailedStatus, 60, &task, nil)
 	s.insertTestResult("task_id_8", 2, "test2.js", evergreen.TestFailedStatus, 120, &task, nil)
-	task = s.insertOldTask("p2", "r1", "task_id_8", 0, "task1", "v1", "d1", t0min10m, testFailed)
+        task = s.insertOldTask("p2", "r1", "task_id_8", 0, "task1", "v1", "d1", t0min10m, t0min10m.Add(3*time.Minute), testFailed)
 	s.insertTestResult("task_id_8", 0, "test1.js", evergreen.TestFailedStatus, 60, &task, nil)
 	s.insertTestResult("task_id_8", 0, "test2.js", evergreen.TestSucceededStatus, 120, &task, nil)
 	s.insertTestResult("task_id_8", 0, "testOld.js", evergreen.TestFailedStatus, 120, &task, nil)
-	task = s.insertOldTask("p2", "r1", "task_id_8", 1, "task1", "v1", "d1", t0min1h, success100)
+        task = s.insertOldTask("p2", "r1", "task_id_8", 1, "task1", "v1", "d1", t0min1h, t0min10m.Add(3*time.Minute), success100)
 	s.insertTestResult("task_id_8", 1, "test1.js", evergreen.TestSucceededStatus, 60, &task, nil)
 	s.insertTestResult("task_id_8", 1, "test2.js", evergreen.TestSucceededStatus, 120, &task, nil)
 	// Execution task
-	task = s.insertTask("p3", "r1", "task_id_9", 0, "task_exec_1", "v1", "d1", t0, testFailed)
+        task = s.insertTask("p3", "r1", "task_id_9", 0, "task_exec_1", "v1", "d1", t0, t0.Add(3*time.Minute), testFailed)
 	// Display task
 	displayTask := s.insertDisplayTask("p3", "r1", "task_id_10", 0, "task_display_1", "v1", "d1", t0, testFailed, []string{"task_id_9"})
 	s.insertTestResult("task_id_9", 0, "test1.js", evergreen.TestFailedStatus, 60, &task, &displayTask)
 	s.insertTestResult("task_id_9", 0, "test2.js", evergreen.TestSucceededStatus, 120, &task, &displayTask)
 	// Project p4 used to test various task statuses
-	s.insertTask("p4", "r1", "task_id_11", 0, "task1", "v1", "d1", t0, success100)
-	s.insertTask("p4", "r1", "task_id_12", 0, "task1", "v1", "d1", t0, success200)
-	s.insertTask("p4", "r1", "task_id_13", 0, "task1", "v1", "d1", t0, testFailed)
-	s.insertTask("p4", "r1", "task_id_14", 0, "task1", "v1", "d1", t0, systemFailed)
-	s.insertTask("p4", "r1", "task_id_15", 0, "task1", "v1", "d1", t0, systemFailed)
-	s.insertTask("p4", "r1", "task_id_16", 0, "task1", "v1", "d1", t0, setupFailed)
-	s.insertTask("p4", "r1", "task_id_17", 0, "task1", "v1", "d1", t0, setupFailed)
-	s.insertTask("p4", "r1", "task_id_18", 0, "task1", "v1", "d1", t0, setupFailed)
-	s.insertTask("p4", "r1", "task_id_19", 0, "task1", "v1", "d1", t0, timeout)
-	s.insertTask("p4", "r1", "task_id_20", 0, "task1", "v1", "d1", t0, timeout)
+        s.insertTask("p4", "r1", "task_id_11", 0, "task1", "v1", "d1", t0, t0, success100)
+        s.insertTask("p4", "r1", "task_id_12", 0, "task1", "v1", "d1", t0, t0, success200)
+        s.insertTask("p4", "r1", "task_id_13", 0, "task1", "v1", "d1", t0, t0, testFailed)
+        s.insertTask("p4", "r1", "task_id_14", 0, "task1", "v1", "d1", t0, t0, systemFailed)
+        s.insertTask("p4", "r1", "task_id_15", 0, "task1", "v1", "d1", t0, t0, systemFailed)
+        s.insertTask("p4", "r1", "task_id_16", 0, "task1", "v1", "d1", t0, t0, setupFailed)
+        s.insertTask("p4", "r1", "task_id_17", 0, "task1", "v1", "d1", t0, t0, setupFailed)
+        s.insertTask("p4", "r1", "task_id_18", 0, "task1", "v1", "d1", t0, t0, setupFailed)
+        s.insertTask("p4", "r1", "task_id_19", 0, "task1", "v1", "d1", t0, t0, timeout)
+        s.insertTask("p4", "r1", "task_id_20", 0, "task1", "v1", "d1", t0, t0, timeout)
 	// Project p5 used to test handling of skipped tests.
-	task = s.insertTask("p5", "r1", "task_id_5_1", 0, "task1", "v1", "d1", t0, success100)
+        task = s.insertTask("p5", "r1", "task_id_5_1", 0, "task1", "v1", "d1", t0, t0.Add(3*time.Minute), success100)
 	s.insertTestResult("task_id_5_1", 0, "test1.js", evergreen.TestSkippedStatus, 60, &task, nil)
 	s.insertTestResult("task_id_5_1", 0, "test2.js", evergreen.TestSkippedStatus, 60, &task, nil)
-	task = s.insertTask("p5", "r1", "task_id_5_2", 0, "task1", "v1", "d1", t0, testFailed)
+        task = s.insertTask("p5", "r1", "task_id_5_2", 0, "task1", "v1", "d1", t0, t0.Add(3*time.Minute), testFailed)
 	s.insertTestResult("task_id_5_2", 0, "test1.js", evergreen.TestSucceededStatus, 60, &task, nil)
 	s.insertTestResult("task_id_5_2", 0, "test2.js", evergreen.TestFailedStatus, 60, &task, nil)
 }
@@ -729,7 +912,7 @@ func (s *statsSuite) initTasksToUpdate() {
 	s.insertFinishedTask("p5", "r1", "task4", commit2, finish2)
 }
 
-func (s *statsSuite) insertTask(project string, requester string, taskId string, execution int, taskName string, variant string, distro string, createTime time.Time, status taskStatus) task.Task {
+func (s *statsSuite) insertTask(project string, requester string, taskId string, execution int, taskName string, variant string, distro string, createTime time.Time, finishTime time.Time, status taskStatus) task.Task {
 	details := apimodels.TaskEndDetail{
 		Status:   status.Status,
 		Type:     status.DetailsType,
@@ -744,6 +927,7 @@ func (s *statsSuite) insertTask(project string, requester string, taskId string,
 		BuildVariant: variant,
 		DistroId:     distro,
 		CreateTime:   createTime,
+                FinishTime:   finishTime,
 		Status:       status.Status,
 		Details:      details,
 		TimeTaken:    status.TimeTaken,
@@ -753,7 +937,7 @@ func (s *statsSuite) insertTask(project string, requester string, taskId string,
 	return newTask
 }
 
-func (s *statsSuite) insertOldTask(project string, requester string, taskId string, execution int, taskName string, variant string, distro string, createTime time.Time, status taskStatus) task.Task {
+func (s *statsSuite) insertOldTask(project string, requester string, taskId string, execution int, taskName string, variant string, distro string, createTime time.Time, finishTime time.Time, status taskStatus) task.Task {
 	details := apimodels.TaskEndDetail{
 		Status:   status.Status,
 		Type:     status.DetailsType,
@@ -770,6 +954,7 @@ func (s *statsSuite) insertOldTask(project string, requester string, taskId stri
 		BuildVariant: variant,
 		DistroId:     distro,
 		CreateTime:   createTime,
+                FinishTime:   finishTime,
 		Status:       status.Status,
 		Details:      details,
 		TimeTaken:    status.TimeTaken,
@@ -805,7 +990,11 @@ func (s *statsSuite) insertDisplayTask(project string, requester string, taskId 
 
 func (s *statsSuite) insertTestResult(taskId string, execution int, testFile string, status string, durationSeconds int, theExecutionTask *task.Task, theDisplayTask *task.Task) {
 	startTime := time.Now()
+        if theExecutionTask != nil {
+                startTime = theExecutionTask.CreateTime.Add(time.Second)
+        }
 	endTime := startTime.Add(time.Duration(durationSeconds) * time.Second)
+
 	newTestResult := testresult.TestResult{
 		TaskID:    taskId,
 		Execution: execution,
@@ -859,6 +1048,12 @@ func (s *statsSuite) insertFinishedOldTask(project string, requester string, tas
 // Methods to access database data //
 /////////////////////////////////////
 
+func (s *statsSuite) countMatchingDocs(collection string) int {
+        count, err := db.Count(collection, bson.M{})
+        s.Require().NoError(err)
+        return count
+}
+
 func (s *statsSuite) countDocs(collection string) int {
 	count, err := db.Count(collection, bson.M{})
 	s.Require().NoError(err)
@@ -877,10 +1072,23 @@ func (s *statsSuite) countDailyTaskDocs() int {
 	return s.countDocs(DailyTaskStatsCollection)
 }
 
-func (s *statsSuite) getLastTestResult(testStatsID DbTestStatsId) (*testresult.TestResult, error) {
+func (s *statsSuite) getLastTestResult(testStatsID DbTestStatsId, hourly bool) (*testresult.TestResult, error) {
 	var lastTestResult *testresult.TestResult
 	start := util.GetUTCHour(testStatsID.Date)
 	end := start.Add(time.Hour)
+        if !hourly {
+                start = util.GetUTCDay(testStatsID.Date)
+                end = start.Add(24 * time.Hour)
+        }
+
+        // func (s *statsSuite) getLastTestResult(testStatsID DbTestStatsId) (*testresult.TestResult, error) {
+        // 	var lastTestResult *testresult.TestResult
+        // 	start := util.GetUTCHour(testStatsID.Date)
+        // 	end := start.Add(time.Hour)
+        // 	// if !hourly {
+        // 	// 	start = util.GetUTCDay(testStatsID.Date)
+        // 	// 	end = start.Add(24 * time.Hour)
+        // 	// }
 
 	qry := bson.M{
 		testresult.ProjectKey:   testStatsID.Project,
@@ -907,9 +1115,9 @@ func (s *statsSuite) getLastTestResult(testStatsID DbTestStatsId) (*testresult.T
 	return lastTestResult, err
 }
 
-func (s *statsSuite) getLastHourlyTestStat(testStatsID DbTestStatsId) (*dbTestStats, error) {
-	var lastTestStats *dbTestStats
-	testResults := []dbTestStats{}
+func (s *statsSuite) getLastHourlyTestStat(testStatsID DbTestStatsId) (*DbTestStats, error) {
+        var lastTestStats *DbTestStats
+        testResults := []DbTestStats{}
 
 	start := util.GetUTCDay(testStatsID.Date)
 	end := start.Add(24 * time.Hour)
@@ -931,10 +1139,67 @@ func (s *statsSuite) getLastHourlyTestStat(testStatsID DbTestStatsId) (*dbTestSt
 		return nil, nil
 	}
 
-	if err != nil {
+        if err != nil || len(testResults) == 0 {
 		lastTestStats = nil
 	} else {
 		lastTestStats = &testResults[0]
 	}
 	return lastTestStats, err
+}
+
+func (s *statsSuite) validateDbTestStats(testStatsID DbTestStatsId, date time.Time, numPass int, numFail int, avgDurationPass float64, lastUpdate time.Time, hourly bool) {
+        require := s.Require()
+        // var doc *DbTestStats
+        // var err error
+
+        // if hourly {
+        // 	doc, err = GetHourlyTestDoc(testStatsID)
+        // } else {
+        // 	doc, err = GetDailyTestDoc(testStatsID)
+        // }
+        // require.Nil(err)
+        // require.NotNil(doc)
+        // require.Equal(testStatsID.Project, doc.Id.Project)
+        // require.Equal(testStatsID.Requester, doc.Id.Requester)
+        // require.Equal(testStatsID.TestFile, doc.Id.TestFile)
+        // require.Equal(testStatsID.TaskName, doc.Id.TaskName)
+        // require.Equal(testStatsID.BuildVariant, doc.Id.BuildVariant)
+        // require.Equal(testStatsID.Distro, doc.Id.Distro)
+        // require.Equal(date, doc.Id.Date.UTC())
+        // require.Equal(numPass, doc.NumPass)
+        // require.Equal(numFail, doc.NumFail)
+        // require.Equal(avgDurationPass, doc.AvgDurationPass)
+        // require.WithinDuration(lastUpdate, doc.LastUpdate, 0)
+
+        doc := s.validateDbTestStatsNoLast(testStatsID, date, numPass, numFail, avgDurationPass, lastUpdate, hourly)
+        lastTestResult, err := s.getLastTestResult(testStatsID, hourly)
+        require.NoError(err)
+        require.Equal(lastTestResult.ID, doc.LastID)
+}
+
+func (s *statsSuite) validateDbTestStatsNoLast(testStatsID DbTestStatsId, date time.Time, numPass int, numFail int, avgDurationPass float64, lastUpdate time.Time, hourly bool) *DbTestStats {
+        require := s.Require()
+        var doc *DbTestStats
+        var err error
+
+        if hourly {
+                doc, err = GetHourlyTestDoc(testStatsID)
+        } else {
+                doc, err = GetDailyTestDoc(testStatsID)
+        }
+        require.Nil(err)
+        require.NotNil(doc)
+        require.Equal(testStatsID.Project, doc.Id.Project)
+        require.Equal(testStatsID.Requester, doc.Id.Requester)
+        require.Equal(testStatsID.TestFile, doc.Id.TestFile)
+        require.Equal(testStatsID.TaskName, doc.Id.TaskName)
+        require.Equal(testStatsID.BuildVariant, doc.Id.BuildVariant)
+        require.Equal(testStatsID.Distro, doc.Id.Distro)
+        require.Equal(date, doc.Id.Date.UTC())
+        require.Equal(numPass, doc.NumPass)
+        require.Equal(numFail, doc.NumFail)
+        require.Equal(avgDurationPass, doc.AvgDurationPass)
+        require.WithinDuration(lastUpdate, doc.LastUpdate, 0)
+
+        return doc
 }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1288,6 +1288,7 @@ type APIServiceFlags struct {
 	CacheStatsJobDisabled      bool `json:"cache_stats_job_disabled"`
 	CacheStatsEndpointDisabled bool `json:"cache_stats_endpoint_disabled"`
 	CacheStatsOldTasksDisabled bool `json:"cache_stats_old_tasks_disabled"`
+        CacheStatsMergeEnabled     bool `json:"cache_stats_merge_enabled"`
 	TaskReliabilityDisabled    bool `json:"task_reliability_disabled"`
 	CommitQueueDisabled        bool `json:"commit_queue_disabled"`
 	PlannerDisabled            bool `json:"planner_disabled"`
@@ -1508,6 +1509,7 @@ func (as *APIServiceFlags) BuildFromService(h interface{}) error {
 		as.CacheStatsJobDisabled = v.CacheStatsJobDisabled
 		as.CacheStatsEndpointDisabled = v.CacheStatsEndpointDisabled
 		as.CacheStatsOldTasksDisabled = v.CacheStatsOldTasksDisabled
+                as.CacheStatsMergeEnabled = v.CacheStatsMergeEnabled
 		as.TaskReliabilityDisabled = v.TaskReliabilityDisabled
 		as.CommitQueueDisabled = v.CommitQueueDisabled
 		as.PlannerDisabled = v.PlannerDisabled
@@ -1541,6 +1543,7 @@ func (as *APIServiceFlags) ToService() (interface{}, error) {
 		CacheStatsJobDisabled:        as.CacheStatsJobDisabled,
 		CacheStatsEndpointDisabled:   as.CacheStatsEndpointDisabled,
 		CacheStatsOldTasksDisabled:   as.CacheStatsOldTasksDisabled,
+                CacheStatsMergeEnabled:       as.CacheStatsMergeEnabled,
 		TaskReliabilityDisabled:      as.TaskReliabilityDisabled,
 		CommitQueueDisabled:          as.CommitQueueDisabled,
 		PlannerDisabled:              as.PlannerDisabled,

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -500,7 +500,7 @@ buildvariants:
       nodebin: /opt/node/bin
       gobin: /opt/golang/go1.9/bin/go
       goroot: /opt/golang/go1.9
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.1.tgz
     tasks:
       - name: "dist"
       - name: ".smoke"
@@ -516,7 +516,7 @@ buildvariants:
       goarch: amd64
       gobin: /opt/golang/go1.9/bin/go
       goroot: /opt/golang/go1.9
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.2.1.tgz
       test_timeout: 15m
       nodebin: /opt/node/bin
       is_docker: "true"
@@ -537,7 +537,7 @@ buildvariants:
       goarch: amd64
       gobin: /opt/golang/go1.9/bin/go
       goroot: /opt/golang/go1.9
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.1.tgz
       smoke_test_file: scripts/smoke_test_acl.yml
     tasks:
       - name: ".smoke"
@@ -551,7 +551,7 @@ buildvariants:
     expansions:
       gobin: /opt/golang/go1.9/bin/go
       goroot: /opt/golang/go1.9
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.2.1.tgz
       race_detector: true
       test_timeout: 15m
     tasks:
@@ -577,7 +577,7 @@ buildvariants:
     expansions:
       gobin: /opt/golang/go1.9/bin/go
       goroot: /opt/golang/go1.9
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.2.1.tgz
       test_timeout: 15m
     tasks:
       - name: ".report"
@@ -592,7 +592,7 @@ buildvariants:
       disable_coverage: yes
       gobin: /opt/golang/go1.9/bin/go
       goroot: /opt/golang/go1.9
-      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.2.1.tgz
     tasks:
       - name: "dist"
       - name: ".test"
@@ -615,7 +615,7 @@ buildvariants:
       disable_coverage: yes
       gobin: /cygdrive/c/golang/go1.9/bin/go
       goroot: c:/golang/go1.9
-      mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.3.zip
+      mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.2.1.zip
       extension: ".exe"
       archiveExt: ".zip"
     tasks:
@@ -634,7 +634,7 @@ buildvariants:
       gobin: /opt/golang/go1.9/bin/go
       goos: linux
       goroot: /opt/golang/go1.9
-      mongodb_url: https://downloads.mongodb.com/linux/mongodb-linux-ppc64le-enterprise-rhel71-4.0.3.tgz
+      mongodb_url: https://downloads.mongodb.com/linux/mongodb-linux-ppc64le-enterprise-rhel71-4.2.1.tgz
     tasks:
       - name: ".agent .test"
 
@@ -667,7 +667,7 @@ buildvariants:
       goos: linux
       gobin: /opt/golang/go1.9/bin/go
       goroot: /opt/golang/go1.9
-      mongodb_url: https://downloads.mongodb.com/linux/mongodb-linux-arm64-enterprise-ubuntu1604-4.0.3.tgz
+      mongodb_url: https://downloads.mongodb.com/linux/mongodb-linux-arm64-enterprise-ubuntu1604-4.2.1.tgz
     tasks:
       - name: ".agent .test"
   - name: linux-docker

--- a/units/cache_historical_test_data_test.go
+++ b/units/cache_historical_test_data_test.go
@@ -547,7 +547,7 @@ func (s *cacheHistoryTestDataSuite) TestCacheHistoricalTestDataMergeJob() {
 
         job := NewCacheHistoricalTestDataJob(s.projectId, "1")
         job.(*cacheHistoricalTestDataJob).Requesters = []string{s.requester}
-        job.(*cacheHistoricalTestDataJob).UseMerge = true
+        job.(*cacheHistoricalTestDataJob).EnableMerge = true
         job.Run(context.Background())
         s.NoError(job.Error())
 


### PR DESCRIPTION
Some things to note:

1. The new implementation follows the old, this allows them to be somewhat interchangeable and should throttle $merge.
1. It is possible to make the $merge restartable (although a *$sort* and *$limit* stage in the $merge pipelines would be required). The current implementation assumes that the job will run to completion. Both approaches likely require a new index in testresults (I'm pretty sure we can use the same index). 
1. The $merge work flow should now be idempotent. I'm pretty sure the existing one is not.
1. The $merge hourly and daily test stats no longer depend on each other. This is mainly for simplicity, but it also means that they could be run independantly (off cyce with each other). It does mean that we process the same testresults documents twice.
1. The $merge essentially works as if oldTasks is always enabled. It is not possible to disable it currently, fixing this would require another schema change in testresults.

Ultimately, once we know that the new implementation is correct and that it puts less burden on the database, the old hourly and daily test stats code can be removed. The code could be simplified to work directly per project and with the ignore tasks filter (although this may require changing the index at that point). But I suspect that it would also require some kind of throttling mechanism. 

**This code does not change daily task processing as it is not currently as disruptive.**
