### PR TITLE
EVG-6629 run command on host

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -687,12 +687,20 @@ func (h *Host) RunJasperProcess(ctx context.Context, env evergreen.Environment, 
 		return nil, errors.Errorf("process returned exit code %d", exitCode)
 	}
 
-	logStream, err := client.GetLogStream(ctx, proc.ID(), 1000)
-	if err != nil {
-		return nil, errors.Wrap(err, "can't get output of process")
+	logs := []string{}
+	for {
+		logStream, err := client.GetLogStream(ctx, proc.ID(), 1000)
+		if err != nil {
+			return nil, errors.Wrap(err, "can't get output of process")
+		}
+
+		logs = append(logs, logStream.Logs...)
+		if logStream.Done {
+			break
+		}
 	}
 
-	return logStream.Logs, nil
+	return logs, nil
 }
 
 // StartJasperProcess makes a request to the host's Jasper service to start a

--- a/operations/before.go
+++ b/operations/before.go
@@ -218,3 +218,26 @@ func mergeBeforeFuncs(ops ...func(c *cli.Context) error) cli.BeforeFunc {
 		return catcher.Resolve()
 	}
 }
+
+// mutuallyExclusiveArgs allows only one of the flags to be set
+// if required is true, one of the flags must be set
+func mutuallyExclusiveArgs(required bool, flags ...string) cli.BeforeFunc {
+	return func(c *cli.Context) error {
+		providedCount := 0
+		for _, flag := range flags {
+			if c.IsSet(flag) {
+				providedCount++
+			}
+		}
+
+		if providedCount > 1 {
+			return errors.Errorf("only one of (%s) can be set", strings.Join(flags, " | "))
+		}
+
+		if required && providedCount == 0 {
+			return errors.Errorf("one of (%s) must be set", strings.Join(flags, " | "))
+		}
+
+		return nil
+	}
+}

--- a/operations/host.go
+++ b/operations/host.go
@@ -17,6 +17,7 @@ func Host() cli.Command {
 			hostTerminate(),
 			hostSetup(),
 			hostTeardown(),
+			hostRunCommand(),
 		},
 	}
 }

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -674,7 +674,10 @@ func hostRunCommand() cli.Command {
 				return errors.Wrap(err, "problem running command")
 			}
 
-			grip.Info(output)
+			for _, line := range output {
+				grip.Info(line)
+			}
+
 			return nil
 		},
 	}

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -647,7 +647,7 @@ func hostRunCommand() cli.Command {
 	const pathFlagName = "path"
 
 	return cli.Command{
-		Name:  "run-script",
+		Name:  "exec",
 		Usage: "run a bash shell script on a host",
 		Flags: addHostFlag(
 			cli.StringFlag{

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -155,7 +155,7 @@ type Communicator interface {
 	CreateVolume(context.Context, *host.Volume) (*restmodel.APIVolume, error)
 	DeleteVolume(context.Context, string) error
 	GetVolumesByUser(context.Context) ([]restmodel.APIVolume, error)
-	RunHostCommand(context.Context, string, string) (string, error)
+	RunHostCommand(context.Context, string, string) ([]string, error)
 
 	// Fetch list of distributions evergreen can spawn
 	GetDistrosList(context.Context) ([]restmodel.APIDistro, error)

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -155,6 +155,7 @@ type Communicator interface {
 	CreateVolume(context.Context, *host.Volume) (*restmodel.APIVolume, error)
 	DeleteVolume(context.Context, string) error
 	GetVolumesByUser(context.Context) ([]restmodel.APIVolume, error)
+	RunHostCommand(context.Context, string, string) (string, error)
 
 	// Fetch list of distributions evergreen can spawn
 	GetDistrosList(context.Context) ([]restmodel.APIDistro, error)

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -155,7 +155,7 @@ type Communicator interface {
 	CreateVolume(context.Context, *host.Volume) (*restmodel.APIVolume, error)
 	DeleteVolume(context.Context, string) error
 	GetVolumesByUser(context.Context) ([]restmodel.APIVolume, error)
-	RunHostCommand(context.Context, string, string) ([]string, error)
+	RunHostScript(context.Context, string, string) ([]string, error)
 
 	// Fetch list of distributions evergreen can spawn
 	GetDistrosList(context.Context) ([]restmodel.APIDistro, error)

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -684,3 +684,7 @@ func (c *Mock) GetDockerStatus(context.Context, string) (*cloud.ContainerStatus,
 func (c *Mock) GetManifestByTask(context.Context, string) (*manifest.Manifest, error) {
 	return &manifest.Manifest{Id: "manifest0"}, nil
 }
+
+func (c *Mock) RunHostCommand(context.Context, string, string) (string, error) {
+	return "", nil
+}

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -685,6 +685,6 @@ func (c *Mock) GetManifestByTask(context.Context, string) (*manifest.Manifest, e
 	return &manifest.Manifest{Id: "manifest0"}, nil
 }
 
-func (c *Mock) RunHostCommand(context.Context, string, string) ([]string, error) {
+func (c *Mock) RunHostScript(context.Context, string, string) ([]string, error) {
 	return nil, nil
 }

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -685,6 +685,6 @@ func (c *Mock) GetManifestByTask(context.Context, string) (*manifest.Manifest, e
 	return &manifest.Manifest{Id: "manifest0"}, nil
 }
 
-func (c *Mock) RunHostCommand(context.Context, string, string) (string, error) {
-	return "", nil
+func (c *Mock) RunHostCommand(context.Context, string, string) ([]string, error) {
+	return nil, nil
 }

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -1157,17 +1157,17 @@ func (c *communicatorImpl) GetManifestByTask(ctx context.Context, taskId string)
 	return &mfest, nil
 }
 
-func (c *communicatorImpl) RunHostCommand(ctx context.Context, hostID, command string) ([]string, error) {
+func (c *communicatorImpl) RunHostScript(ctx context.Context, hostID, script string) ([]string, error) {
 	info := requestInfo{
 		method:  post,
 		version: apiVersion2,
-		path:    fmt.Sprintf("/hosts/%s/run_command", hostID),
+		path:    fmt.Sprintf("/hosts/%s/run_script", hostID),
 	}
 
-	data := model.APIHostCommand{Command: command}
+	data := model.APIHostScript{Script: script}
 	resp, err := c.request(ctx, info, data)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't make request to run command on host")
+		return nil, errors.Wrap(err, "can't make request to run script on host")
 	}
 	defer resp.Body.Close()
 
@@ -1176,10 +1176,10 @@ func (c *communicatorImpl) RunHostCommand(ctx context.Context, hostID, command s
 		if err = util.ReadJSONInto(resp.Body, &restErr); err != nil {
 			return nil, errors.Wrap(err, "received an error but was unable to parse")
 		}
-		return nil, errors.Wrapf(restErr, "response code %d running command on host", resp.StatusCode)
+		return nil, errors.Wrapf(restErr, "response code %d running script on host", resp.StatusCode)
 	}
 
-	output := model.APIHostCommandResponse{}
+	output := model.APIHostScriptResponse{}
 	if err := util.ReadJSONInto(resp.Body, &output); err != nil {
 		return nil, errors.Wrap(err, "problem reading response")
 	}

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -1157,9 +1157,9 @@ func (c *communicatorImpl) GetManifestByTask(ctx context.Context, taskId string)
 	return &mfest, nil
 }
 
-func (c *communicatorImpl) RunHostCommand(ctx context.Context, hostID, command string) (string, error) {
+func (c *communicatorImpl) RunHostCommand(ctx context.Context, hostID, command string) ([]string, error) {
 	info := requestInfo{
-		method:  get,
+		method:  post,
 		version: apiVersion2,
 		path:    fmt.Sprintf("/hosts/%s/run_command", hostID),
 	}
@@ -1167,21 +1167,21 @@ func (c *communicatorImpl) RunHostCommand(ctx context.Context, hostID, command s
 	data := model.APIHostCommand{Command: command}
 	resp, err := c.request(ctx, info, data)
 	if err != nil {
-		return "", errors.Wrap(err, "can't make request to run command on host")
+		return nil, errors.Wrap(err, "can't make request to run command on host")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		restErr := gimlet.ErrorResponse{}
 		if err = util.ReadJSONInto(resp.Body, &restErr); err != nil {
-			return "", errors.Wrap(err, "received an error but was unable to parse")
+			return nil, errors.Wrap(err, "received an error but was unable to parse")
 		}
-		return "", errors.Wrapf(restErr, "response code %d running command on host", resp.StatusCode)
+		return nil, errors.Wrapf(restErr, "response code %d running command on host", resp.StatusCode)
 	}
 
 	output := model.APIHostCommandResponse{}
 	if err := util.ReadJSONInto(resp.Body, &output); err != nil {
-		return "", errors.Wrap(err, "problem reading response")
+		return nil, errors.Wrap(err, "problem reading response")
 	}
 
 	return output.Output, nil

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -199,5 +199,5 @@ type APIHostCommand struct {
 }
 
 type APIHostCommandResponse struct {
-	Output string `json:"output"`
+	Output []string `json:"output"`
 }

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -197,3 +197,7 @@ type APISpawnHostModify struct {
 type APIHostCommand struct {
 	Command string `json:"command"`
 }
+
+type APIHostCommandResponse struct {
+	Output string `json:"output"`
+}

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -194,10 +194,10 @@ type APISpawnHostModify struct {
 	DeleteTags   []APIString `json:"tags_to_delete"`
 }
 
-type APIHostCommand struct {
-	Command string `json:"command"`
+type APIHostScript struct {
+	Script string `json:"script"`
 }
 
-type APIHostCommandResponse struct {
+type APIHostScriptResponse struct {
 	Output []string `json:"output"`
 }

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -193,3 +193,7 @@ type APISpawnHostModify struct {
 	AddTags      []APIString `json:"tags_to_add"`
 	DeleteTags   []APIString `json:"tags_to_delete"`
 }
+
+type APIHostCommand struct {
+	Command string `json:"command"`
+}

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -1064,6 +1064,10 @@ func (h *hostRunCommand) Run(ctx context.Context) gimlet.Responder {
 		return response
 	}
 
+	if host.Status != evergreen.HostRunning {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Errorf("can't run command on host with status '%s'", host.Status))
+	}
+
 	var output string
 	if host.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData {
 		opts := &options.Create{
@@ -1084,11 +1088,7 @@ func (h *hostRunCommand) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 
-	response := struct {
-		Output string `json:"output"`
-	}{Output: output}
-
-	return gimlet.NewJSONResponse(response)
+	return gimlet.NewJSONResponse(model.APIHostCommandResponse{Output: output})
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -1055,19 +1055,9 @@ func (h *hostRunCommand) Parse(ctx context.Context, r *http.Request) error {
 
 func (h *hostRunCommand) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
-	host, err := host.FindOneId(h.hostID)
+	host, err := h.sc.FindHostByIdWithOwner(h.hostID, user)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't get host"))
-	}
-	if host == nil {
-		response := gimlet.MakeJSONErrorResponder(errors.Errorf("no host found for id '%s'", h.hostID))
-		_ = response.SetStatus(http.StatusNotFound)
-		return response
-	}
-	if host.StartedBy != user.Id {
-		response := gimlet.MakeJSONErrorResponder(errors.New("Unauthorized"))
-		_ = response.SetStatus(http.StatusUnauthorized)
-		return response
 	}
 	if host.Status != evergreen.HostRunning {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Errorf("can't run command on host with status '%s'", host.Status))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -90,7 +90,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/hosts").Version(2).Patch().Wrap(superUser).RouteHandler(makeChangeHostsStatuses(sc))
 	app.AddRoute("/hosts/{host_id}").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetHostByID(sc))
 	app.AddRoute("/hosts/{host_id}").Version(2).Patch().Wrap(checkUser).RouteHandler(makeHostModifyRouteManager(sc, env))
-	app.AddRoute("/hosts/{host_id}/run_command").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostRunCommand(sc, env))
+	app.AddRoute("/hosts/{host_id}/run_script").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostRunScript(sc, env))
 	app.AddRoute("/hosts/{host_id}/stop").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostStopManager(sc, env))
 	app.AddRoute("/hosts/{host_id}/start").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostStartManager(sc, env))
 	app.AddRoute("/hosts/{host_id}/change_password").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostChangePassword(sc, env))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -90,6 +90,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/hosts").Version(2).Patch().Wrap(superUser).RouteHandler(makeChangeHostsStatuses(sc))
 	app.AddRoute("/hosts/{host_id}").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetHostByID(sc))
 	app.AddRoute("/hosts/{host_id}").Version(2).Patch().Wrap(checkUser).RouteHandler(makeHostModifyRouteManager(sc, env))
+	app.AddRoute("/hosts/{host_id}/run_command").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostRunCommand(sc, env))
 	app.AddRoute("/hosts/{host_id}/stop").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostStopManager(sc, env))
 	app.AddRoute("/hosts/{host_id}/start").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostStartManager(sc, env))
 	app.AddRoute("/hosts/{host_id}/change_password").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostChangePassword(sc, env))

--- a/units/jasper_deploy.go
+++ b/units/jasper_deploy.go
@@ -167,8 +167,7 @@ func (j *jasperDeployJob) Run(ctx context.Context) {
 				"bash", "-c", writeCredentialsCmd,
 			},
 		}
-		var output string
-		if output, err = j.host.RunJasperProcess(ctx, j.env, writeCredentialsOpts); err != nil {
+		if output, err := j.host.RunJasperProcess(ctx, j.env, writeCredentialsOpts); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "could not replace existing Jasper credentials on host",
 				"logs":    output,


### PR DESCRIPTION
Add a command to the CLI to run a command on users' spawnhosts.
The command is passed to bash on the spawn host and the CLI prints the command's output.