### PR TITLE
EVG-6973: use existing client credentials in database to connect to Jasper

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -736,7 +736,7 @@ func (h *Host) JasperClient(ctx context.Context, env evergreen.Environment) (jas
 
 			return jcli.NewSSHClient(remoteOpts, clientOpts, true)
 		case distro.CommunicationMethodRPC:
-			creds, err := h.GenerateJasperCredentials(ctx, env)
+			creds, err := h.JasperClientCredentials(ctx, env)
 			if err != nil {
 				return nil, errors.Wrap(err, "could not get client credentials to communicate with the host's Jasper service")
 			}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6973

Using `(*Host).GenerateJasperCredentials()` deletes the existing credentials and does not save the new ones to the database. This was effectively deleting all the credentials stored in the database each time a connection was established to a host Jasper service.