### PR TITLE
EVG-6976, EVG-6977: fetch task data as unprivileged user and continue on error

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -949,8 +949,20 @@ func (h *Host) SetupSpawnHostCommands(settings *evergreen.Settings) (string, err
 
 	script := setupBinDirCmds
 	if h.ProvisionOptions.TaskId != "" {
-		fetchCmd := fmt.Sprintf("%s -c %s fetch -t %s --source --artifacts --dir='%s' || true", binaryPath, confPath, h.ProvisionOptions.TaskId, h.Distro.WorkDir)
-		script += " && " + fetchCmd
+		fetchCmd := []string{
+			binaryPath,
+			"-c", confPath,
+			"fetch",
+			"-t", h.ProvisionOptions.TaskId,
+			"--source",
+			"--artifacts",
+			"--dir", h.Distro.WorkDir,
+		}
+		jasperFetchCmd, err := h.buildLocalJasperClientRequest(settings.HostJasper, strings.Join([]string{jcli.ManagerCommand, jcli.CreateCommand}, " "), &options.Command{Commands: [][]string{fetchCmd}})
+		if err != nil {
+			return "", errors.Wrap(err, "could not construct Jasper command to fetch task data")
+		}
+		script += " && " + jasperFetchCmd
 	}
 
 	return script, nil

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -949,7 +949,7 @@ func (h *Host) SetupSpawnHostCommands(settings *evergreen.Settings) (string, err
 
 	script := setupBinDirCmds
 	if h.ProvisionOptions.TaskId != "" {
-		fetchCmd := fmt.Sprintf("%s -c %s fetch -t %s --source --artifacts --dir='%s'", binaryPath, confPath, h.ProvisionOptions.TaskId, h.Distro.WorkDir)
+		fetchCmd := fmt.Sprintf("%s -c %s fetch -t %s --source --artifacts --dir='%s' || true", binaryPath, confPath, h.ProvisionOptions.TaskId, h.Distro.WorkDir)
 		script += " && " + fetchCmd
 	}
 

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -924,6 +924,9 @@ func TestSetupSpawnHostCommands(t *testing.T) {
 			Arch:    distro.ArchLinuxAmd64,
 			WorkDir: "/dir",
 			User:    "user",
+			BootstrapSettings: distro.BootstrapSettings{
+				JasperCredentialsPath: "/jasper_credentials_path",
+			},
 		},
 		ProvisionOptions: &ProvisionOptions{
 			OwnerId: user.Id,
@@ -936,6 +939,10 @@ func TestSetupSpawnHostCommands(t *testing.T) {
 		Ui: evergreen.UIConfig{
 			Url: "www.example1.com",
 		},
+		HostJasper: evergreen.HostJasperConfig{
+			BinaryName: "jasper_cli",
+			Port:       12345,
+		},
 	}
 
 	cmd, err := h.SetupSpawnHostCommands(settings)
@@ -946,9 +953,15 @@ func TestSetupSpawnHostCommands(t *testing.T) {
 
 	h.ProvisionOptions.TaskId = "task_id"
 	cmd, err = h.SetupSpawnHostCommands(settings)
+	assert.Contains(t, cmd, expected)
 	require.NoError(t, err)
-	expected += " && /home/user/evergreen -c /home/user/cli_bin/.evergreen.yml fetch -t task_id --source --artifacts --dir='/dir'"
-	assert.Equal(t, expected, cmd)
+	fetchCmd := []string{"/home/user/evergreen", "-c", "/home/user/cli_bin/.evergreen.yml", "fetch", "-t", "task_id", "--source", "--artifacts", "--dir", "/dir"}
+	currIndex := 0
+	for _, arg := range fetchCmd {
+		foundIndex := strings.Index(cmd[currIndex:], arg)
+		require.NotEqual(t, foundIndex, -1)
+		currIndex += foundIndex
+	}
 }
 
 func TestMarkUserDataDoneCommands(t *testing.T) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6976, https://jira.mongodb.org/browse/EVG-6977

`evergreen fetch` failed on an ubuntu1804-test spawn host because the user data script ran evergreen as root instead of the distro user (ubuntu). This prevented the host from transitioning from provisioning to running. Fetching task data is a nice to have but not required for the spawn host to be considered running.

* Run `evergreen fetch` as Jasper command.
* Even if `evergreen fetch` fails, the CLI will return exit code 0 (because the request was made successfully, even if the command did not), so it will not trigger errexit on the user data script (unless Jasper could not be contacted).