### PR TITLE
EVG-6984 don't log when host create succeeded

### DIFF
--- a/public/static/partials/hostevent.html
+++ b/public/static/partials/hostevent.html
@@ -2,9 +2,9 @@
   <div class="timestamp col-lg-2 col-md-3 col-sm-4" style="min-width: 250px;">[[eventLogObj.timestamp | convertDateToUserTimezone:userTz:'MMM D, YYYY h:mm:ss a']]</div>
   <div class="event_details col-lg-9 col-md-8 col-sm-7" ng-switch="eventLogObj.event_type" ng-init="showlogs = false">
     <span ng-switch-when="HOST_CREATED">Host created</span>
-    <span ng-switch-when="HOST_STARTED">Host started</span>
-    <span ng-switch-when="HOST_STOPPED">Host stopped</span>
-    <span ng-switch-when="HOST_MODIFIED">Host modified</span>
+    <span ng-switch-when="HOST_STARTED">Host start attempt[[eventLogObj.data.successful | conditional:' succeeded':'']]</span>
+    <span ng-switch-when="HOST_STOPPED">Host stop attempt[[eventLogObj.data.successful | conditional:' succeeded':'']]</span>
+    <span ng-switch-when="HOST_MODIFIED">Host modify attempt[[eventLogObj.data.successful | conditional:' succeeded':'']]</span>
     <span ng-switch-when="HOST_PROVISION_ERROR">Host encountered error during provisioning</span>
     <span ng-switch-when="HOST_AGENT_DEPLOY_FAILED">New agent deploy failed</span>
     <span ng-switch-when="HOST_AGENT_DEPLOYED">Agent deployed with revision <b>[[eventLogObj.data.agent_revision]]</b></span>

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -329,7 +329,7 @@ func (j *createHostJob) tryRequeue(ctx context.Context) {
 			"attempts": j.CurrentAttempt,
 		}))
 		j.AddError(err)
-	} else if j.host.Status != evergreen.HostStarting {
+	} else if j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding {
 		event.LogHostStartFinished(j.host.Id, false)
 	}
 }

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -329,7 +329,7 @@ func (j *createHostJob) tryRequeue(ctx context.Context) {
 			"attempts": j.CurrentAttempt,
 		}))
 		j.AddError(err)
-	} else {
+	} else if j.host.Status != evergreen.HostStarting {
 		event.LogHostStartFinished(j.host.Id, false)
 	}
 }


### PR DESCRIPTION
Also disambiguate successful and failed start/stop/modify attempts on the host events page.
Can't print "failed" for failed attempts since the successful field is only present for events that occurred since 50df9cd27639e7e3cd0962ab5c22ef3cf96f9dcf was deployed.