### PR TITLE
EVG-7003: fix go environment in evergreen config

### DIFF
--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -160,7 +160,7 @@ func generateTasks() (*shrub.Configuration, error) {
 
 	group := conf.TaskGroup(lintGroup).SetMaxHosts(maxHosts)
 	group.SetupGroup.Command().Type("system").Command("git.get_project").Param("directory", "gopath/src/github.com/evergreen-ci/evergreen")
-	group.SetupGroup.Command().Function("set-up-credentials")
+	group.SetupGroup.Command().Function("setup-credentials")
 	group.TeardownTask.Command().Function("attach-test-results")
 	group.TeardownTask.Command().Function("remove-test-results")
 	group.Task(lintTargets...)

--- a/cmd/go-test-config/make-config.go
+++ b/cmd/go-test-config/make-config.go
@@ -30,8 +30,8 @@ func makeTasks() *shrub.Configuration {
 	config.CommandType = "test"
 	for _, target := range targets {
 		config.Task(target).Function("get-project").
-			Function("set-up-credentials").
-			Function("set-up-mongodb").
+			Function("setup-credentials").
+			Function("setup-mongodb").
 			FunctionWithVars("run-make", map[string]string{"target": "revendor"}).
 			FunctionWithVars("run-make", map[string]string{"target": target}).
 			Function("attach-test-results")
@@ -55,7 +55,7 @@ func makeTasks() *shrub.Configuration {
 			"token":     "${github_token}",
 		},
 	})
-	config.Function("set-up-credentials").Append(&shrub.CommandDefinition{
+	config.Function("setup-credentials").Append(&shrub.CommandDefinition{
 		CommandName:   "subprocess.exec",
 		ExecutionType: "setup",
 		Params: map[string]interface{}{
@@ -73,7 +73,7 @@ func makeTasks() *shrub.Configuration {
 			},
 		},
 	})
-	config.Function("set-up-mongodb").Append(&shrub.CommandDefinition{
+	config.Function("setup-mongodb").Append(&shrub.CommandDefinition{
 		CommandName:   "subprocess.exec",
 		ExecutionType: "setup",
 		Params: map[string]interface{}{

--- a/makefile
+++ b/makefile
@@ -168,7 +168,7 @@ lintDeps := $(addprefix $(gopath)/src/,$(lintDeps))
 $(buildDir)/.lintSetup:$(lintDeps)
 	$(gobin) get github.com/evergreen-ci/evg-lint/...
 	@mkdir -p $(buildDir)
-	$(gopath)/bin/gometalinter --force --install >/dev/null && touch $@
+	$(if $(GO_BIN_PATH),export PATH=$(shell dirname $(GO_BIN_PATH)):${PATH} && ,)$(gopath)/bin/gometalinter --force --install >/dev/null && touch $@
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
 	@mkdir -p $(buildDir)
 	$(gobin) build -o $@ $<

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ projectPath := $(orgPath)/$(name)
 ifneq (,$(GO_BIN_PATH))
 gobin := $(GO_BIN_PATH)
 else
-gobin := $(shell if [ -x /opt/golang/go1.9/bin/go ]; then /opt/golang/go1.9/bin/go; fi)
+gobin := $(shell if [ -x /opt/golang/go1.9/bin/go ]; then echo /opt/golang/go1.9/bin/go; fi)
 ifeq (,$(gobin))
 gobin := go
 endif

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -676,6 +676,8 @@ func TestJasperProcess(t *testing.T) {
 			require.NoError(t, env.Configure(tctx, "", nil))
 			env.Settings().HostJasper.BinaryName = "binary"
 
+			require.NoError(t, setupCredentialsCollection(ctx, env))
+
 			manager := &jmock.Manager{}
 			env.JasperProcessManager = manager
 

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -548,6 +548,8 @@ buildvariants:
       - archlinux-test
       - archlinux-build
     expansions:
+      gobin: /opt/golang/go1.9/bin/go
+      goroot: /opt/golang/go1.9
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
       race_detector: true
       test_timeout: 15m
@@ -560,6 +562,9 @@ buildvariants:
     run_on:
       - archlinux-test
       - archlinux-build
+    expansions:
+      gobin: /opt/golang/go1.9/bin/go
+      goroot: /opt/golang/go1.9
     tasks:
       - name: generate-lint
 
@@ -569,6 +574,8 @@ buildvariants:
       - archlinux-test
       - archlinux-build
     expansions:
+      gobin: /opt/golang/go1.9/bin/go
+      goroot: /opt/golang/go1.9
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
       test_timeout: 15m
     tasks:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -250,6 +250,7 @@ functions:
       type: setup
       params:
         env:
+          gobin: /opt/golang/go1.9/bin/go
           MONGODB_URL: ${mongodb_url}
           DECOMPRESS: ${decompress}
         working_dir: gopath/src/github.com/evergreen-ci/evergreen/

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -23,12 +23,12 @@ functions:
        shell: bash
        script: |
          echo "get-project function"
-  set-up-credentials:
+  setup-credentials:
     command: shell.exec
     params:
        shell: bash
        script: |
-         echo "set-up-credentials function"
+         echo "setup-credentials function"
   run-make:
     command: shell.exec
     params:
@@ -98,7 +98,7 @@ var sampleGeneratedProject = []json.RawMessage{json.RawMessage(`
           "func": "get-project"
         },
         {
-          "func": "set-up-credentials"
+          "func": "setup-credentials"
         },
         {
           "func": "run-make",
@@ -115,7 +115,7 @@ var sampleGeneratedProject = []json.RawMessage{json.RawMessage(`
           "func": "get-project"
         },
         {
-          "func": "set-up-credentials"
+          "func": "setup-credentials"
         },
         {
           "func": "run-make",


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7003

From the email yesterday, GOROOT is no longer explicitly set _and_ the default go version in the PATH variable is go1.13. It seems like we were implicitly using go1.7 on race detector and lint for a while. Furthermore, gometalinter relies on invoking the go binary in PATH, so we need to set that. I also fixed a misnamed function "set-up-credentials" (should be setup-credentials) and fixed an annoying log message due to a makefile error when setting gobin.