### PR TITLE
EVG-6890 only create version if patch has versions/tasks

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -349,6 +349,10 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		}).TVPairsToVariantTasks()
 	}
 
+	// if variant tasks is still empty, then the patch is empty and we shouldn't add to commit queue
+	if p.Alias == evergreen.CommitQueueAlias && len(p.VariantsTasks) == 0 {
+		return nil, errors.Errorf("No builds or tasks for commit queue version in projects '%s', githash '%s'", p.Project, p.Githash)
+	}
 	taskIds := NewPatchTaskIdTable(project, patchVersion, tasks)
 	variantsProcessed := map[string]bool{}
 

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -399,7 +399,7 @@ func (pc *MockProjectConnector) GetProjectWithCommitQueueByOwnerRepoAndBranch(ow
 	return nil, nil
 }
 func (pc *MockProjectConnector) EnableWebhooks(ctx context.Context, projectRef *model.ProjectRef) (bool, error) {
-	return false, nil
+	return true, nil
 }
 
 func (pc *MockProjectConnector) EnableCommitQueue(projectRef *model.ProjectRef, commitQueueParams model.CommitQueueParams) error {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -418,7 +418,7 @@ func (h *projectIDPatchHandler) hasCommitQueuePatchDefinition(pRef *model.APIPro
 	aliasesToDelete := map[string]bool{}
 	for _, alias := range pRef.Aliases {
 		// return immediately if new commit queue alias has been added
-		if model.FromAPIString(alias.Alias) == evergreen.CommitQueueAlias {
+		if model.FromAPIString(alias.Alias) == evergreen.CommitQueueAlias && !alias.Delete {
 			return true, nil
 		}
 		aliasesToDelete[model.FromAPIString(alias.ID)] = alias.Delete

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -421,7 +421,7 @@ func (h *projectIDPatchHandler) hasCommitQueuePatchDefinition(pRef *model.APIPro
 		if model.FromAPIString(alias.Alias) == evergreen.CommitQueueAlias {
 			return true, nil
 		}
-		aliasesToDelete[model.FromAPIString(alias.Alias)] = alias.Delete
+		aliasesToDelete[model.FromAPIString(alias.ID)] = alias.Delete
 	}
 
 	aliases, err := h.sc.FindProjectAliases(model.FromAPIString(pRef.Identifier))
@@ -431,7 +431,7 @@ func (h *projectIDPatchHandler) hasCommitQueuePatchDefinition(pRef *model.APIPro
 	for _, alias := range aliases {
 		if model.FromAPIString(alias.Alias) == evergreen.CommitQueueAlias {
 			// assert this alias wasn't meant to be deleted
-			if !aliasesToDelete[model.FromAPIString(alias.Alias)] {
+			if !aliasesToDelete[model.FromAPIString(alias.ID)] {
 				return true, nil
 			}
 		}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -413,9 +413,11 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	return responder
 }
 
+// verify that either the user has added a new commit queue alias, or there is a pre-existing commit queue alias
 func (h *projectIDPatchHandler) hasCommitQueuePatchDefinition(pRef *model.APIProjectRef) (bool, error) {
 	aliasesToDelete := map[string]bool{}
 	for _, alias := range pRef.Aliases {
+		// return immediately if new commit queue alias has been added
 		if model.FromAPIString(alias.Alias) == evergreen.CommitQueueAlias {
 			return true, nil
 		}

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -98,6 +98,20 @@ func (s *ProjectPatchByIDSuite) TestRunValid() {
 	s.True(ok)
 }
 
+func (s *ProjectPatchByIDSuite) TestRunWithCommitQueueEnabled() {
+	ctx := context.Background()
+	jsonBody := []byte(`{"enabled": true, "revision": "my_revision", "commit_queue": {"enabled": true}}`)
+	h := s.rm.(*projectIDPatchHandler)
+	h.projectID = "dimoxinil"
+	h.body = jsonBody
+	resp := s.rm.Run(ctx)
+	s.NotNil(resp)
+	s.NotNil(resp.Data())
+	s.Equal(resp.Status(), http.StatusBadRequest)
+	errResp := (resp.Data()).(gimlet.ErrorResponse)
+	s.Equal(errResp.Message, "Cannot enable commit queue without a __commit_queue patch definition")
+}
+
 ////////////////////////////////////////////////////////////////////////
 //
 // Tests for PUT /rest/v2/projects/{project_id}

--- a/service/project.go
+++ b/service/project.go
@@ -366,6 +366,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			uis.LoggedError(w, r, http.StatusBadRequest, errors.Errorf("Cannot enable Commit Queue without github webhooks enabled for the project"))
 			return
 		}
+		// if no new commit queue aliases, verify there are pre-existing commit queue aliases
 		if len(responseRef.CommitQueueAliases) == 0 {
 			aliases, err := model.FindAliasInProject(responseRef.Identifier, evergreen.CommitQueueAlias)
 			if err != nil {

--- a/service/project.go
+++ b/service/project.go
@@ -377,7 +377,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			remainingAliases := 0
 			for _, a := range aliases {
 				// only consider aliases that won't be deleted
-				if !util.StringSliceContains(responseRef.DeleteAliases, a.Alias) {
+				if !util.StringSliceContains(responseRef.DeleteAliases, a.ID.String()) {
 					remainingAliases++
 				}
 			}

--- a/service/project.go
+++ b/service/project.go
@@ -377,7 +377,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			remainingAliases := 0
 			for _, a := range aliases {
 				// only consider aliases that won't be deleted
-				if !util.StringSliceContains(responseRef.DeleteAliases, a.ID.String()) {
+				if !util.StringSliceContains(responseRef.DeleteAliases, a.ID.Hex()) {
 					remainingAliases++
 				}
 			}

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -399,7 +399,7 @@ Evergreen Projects
           <div class="form-group">
             <div class="col-header col-lg-6 form-control-static"> 
               <h3>Commit Queue</h3> 
-              <div class="muted small">The commit queue merges changes onto the project's branch after they've passed a set of tests.</div>
+              <div class="muted small">The commit queue merges changes onto the project's branch after they've passed a set of tests. Can only be enabled if patch definitions are set.</div>
             </div>
            
           </div>

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -95,6 +95,7 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 	if j.intent == nil {
 		j.intent, err = patch.FindIntent(j.IntentID, j.IntentType)
 		j.AddError(err)
+		j.IntentType = j.intent.GetType()
 	}
 
 	if j.HasErrors() {
@@ -260,8 +261,8 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 
 	project.BuildProjectTVPairs(patchDoc, j.intent.GetAlias())
 
-	if j.intent.ShouldFinalizePatch() && len(patchDoc.Tasks) == 0 &&
-		len(patchDoc.BuildVariants) == 0 {
+	if (j.intent.ShouldFinalizePatch() || patchDoc.Alias == evergreen.CommitQueueAlias) &&
+		len(patchDoc.Tasks) == 0 && len(patchDoc.BuildVariants) == 0 {
 		j.gitHubError = NoTasksOrVariants
 		return errors.New("patch has no build variants or tasks")
 	}


### PR DESCRIPTION
FinalizePatch is called by both CLI and PR patches, to create a version when the item is removed from the queue. I think adding validation at the end of the queue is consistent for the different types of queues, and allows for the changing of task/variant aliases before the item reaches the head of the queue.