### PR TITLE
EVG-6945 generate device name better

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1084,6 +1084,7 @@ func (m *ec2Manager) AttachVolume(ctx context.Context, h *host.Host, attachment 
 		return errors.Wrap(err, "error creating client")
 	}
 
+	opts := generateDeviceNameOptions{isWindows: h.Distro.IsWindows()}
 	// if no device name is provided, generate a unique device name
 	if attachment.DeviceName == "" {
 		deviceName, err := getGeneratedDeviceNameForVolume(ctx, h.Distro.IsWindows())
@@ -1091,13 +1092,14 @@ func (m *ec2Manager) AttachVolume(ctx context.Context, h *host.Host, attachment 
 			return errors.Wrap(err, "error generating initial device name")
 		}
 		attachment.DeviceName = deviceName
+		opts.shouldGenerate = true
 	}
 
 	_, err := m.client.AttachVolume(ctx, &ec2.AttachVolumeInput{
 		InstanceId: aws.String(h.Id),
 		Device:     aws.String(attachment.DeviceName),
 		VolumeId:   aws.String(attachment.VolumeID),
-	}, h.Distro.IsWindows())
+	}, opts)
 	if err != nil {
 		return errors.Wrapf(err, "error attaching volume '%s' to host '%s'", attachment.VolumeID, h.Id)
 	}

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1341,7 +1341,6 @@ func (s *EC2Suite) TestAttachVolume() {
 func (s *EC2Suite) TestAttachVolumeGenerateDeviceName() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
 	s.Require().NoError(s.h.Insert())
 	newAttachment := &host.VolumeAttachment{
 		VolumeID: "test-volume",
@@ -1351,7 +1350,7 @@ func (s *EC2Suite) TestAttachVolumeGenerateDeviceName() {
 
 	s.Equal("test-volume", newAttachment.VolumeID)
 	s.NotEqual("", newAttachment.DeviceName)
-	s.Len(newAttachment.DeviceName, len("/dev/sdf1"))
+	s.Len(newAttachment.DeviceName, len("/dev/sdf"))
 }
 
 func (s *EC2Suite) TestDetachVolume() {

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -313,7 +313,7 @@ func getGeneratedDeviceNameForVolume(ctx context.Context, isWindowsHost bool) (s
 				return false, nil
 			}
 			return true, errors.New("generated device name already exists")
-		}, 500, 0, 0)
+		}, 500, 1, 10)
 
 	return deviceName, err
 }

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -322,7 +322,7 @@ func getGeneratedDeviceNameForVolume(ctx context.Context, isWindowsHost bool) (s
 func generateDeviceNameForVolume(isWindowsHost bool) string {
 	letters := "fghijklmnop"
 	rand.Seed(time.Now().Unix())
-	pattern := "/dev/sd%c%d"
+	pattern := "/dev/sd%c"
 	if isWindowsHost {
 		pattern = "xvd%c"
 	}

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -299,12 +299,35 @@ type Terms struct {
 	}
 }
 
-// format /dev/sd[f-p][1-6] taken from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
-func generateDeviceNameForVolume() string {
+func getGeneratedDeviceNameForVolume(ctx context.Context, isWindowsHost bool) (string, error) {
+	deviceName := ""
+	err := util.Retry(
+		ctx,
+		func() (bool, error) {
+			deviceName = generateDeviceNameForVolume(isWindowsHost)
+			exists, err := host.HostExistsWithVolumeWithDeviceName(deviceName)
+			if err != nil {
+				return true, errors.Wrapf(err, "error checking if device name already exists")
+			}
+			if !exists {
+				return false, nil
+			}
+			return true, errors.New("generated device name already exists")
+		}, 500, 0, 0)
+
+	return deviceName, err
+}
+
+// formats /dev/sd[f-p]and xvd[f-p] taken from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
+func generateDeviceNameForVolume(isWindowsHost bool) string {
 	letters := "fghijklmnop"
 	rand.Seed(time.Now().Unix())
+	pattern := "/dev/sd%c%d"
+	if isWindowsHost {
+		pattern = "xvd%c"
+	}
 
-	return fmt.Sprintf("/dev/sd%c%d", letters[rand.Intn(len(letters))], rand.Intn(5)+1)
+	return fmt.Sprintf(pattern, letters[rand.Intn(len(letters))])
 }
 
 func makeBlockDeviceMappings(mounts []MountPoint) ([]*ec2aws.BlockDeviceMapping, error) {

--- a/model/host/volume.go
+++ b/model/host/volume.go
@@ -40,7 +40,6 @@ type volumeSize struct {
 }
 
 func FindTotalVolumeSizeByUser(user string) (int, error) {
-
 	pipeline := []bson.M{
 		{"$match": bson.M{
 			VolumeCreatedByKey: user,
@@ -53,5 +52,9 @@ func FindTotalVolumeSizeByUser(user string) (int, error) {
 
 	out := []volumeSize{}
 	err := db.Aggregate(VolumesCollection, pipeline, &out)
-	return out[0].TotalVolumeSize, err
+	if err != nil || len(out) == 0 {
+		return 0, err
+	}
+
+	return out[0].TotalVolumeSize, nil
 }

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -131,6 +131,18 @@ func (hc *DBHostConnector) CheckHostSecret(r *http.Request) (int, error) {
 	return code, errors.WithStack(err)
 }
 
+func (hc *DBHostConnector) FindVolumeById(volumeID string) (*host.Volume, error) {
+	return host.FindVolumeByID(volumeID)
+}
+
+func (hc *DBHostConnector) FindVolumesByUser(user string) ([]host.Volume, error) {
+	return host.FindVolumesByUser(user)
+}
+
+func (hc *DBHostConnector) FindHostWithVolume(volumeID string) (*host.Host, error) {
+	return host.FindHostWithVolume(volumeID)
+}
+
 func (hc *DBHostConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error) {
 	data, err := host.AggregateSpawnhostData()
 	if err != nil {
@@ -292,6 +304,36 @@ func (hc *MockHostConnector) CheckHostSecret(r *http.Request) (int, error) {
 
 func (dbc *MockConnector) FindHostByIdWithOwner(hostID string, user gimlet.User) (*host.Host, error) {
 	return findHostByIdWithOwner(dbc, hostID, user)
+}
+
+func (hc *MockConnector) FindVolumeById(volumeID string) (*host.Volume, error) {
+	for _, v := range hc.CachedVolumes {
+		if v.ID == volumeID {
+			return &v, nil
+		}
+	}
+	return nil, nil
+}
+
+func (hc *MockConnector) FindVolumesByUser(user string) ([]host.Volume, error) {
+	vols := []host.Volume{}
+	for _, v := range hc.CachedVolumes {
+		if v.CreatedBy == user {
+			vols = append(vols, v)
+		}
+	}
+	return vols, nil
+}
+
+func (hc *MockConnector) FindHostWithVolume(volumeID string) (*host.Host, error) {
+	for _, h := range hc.CachedHosts {
+		for _, v := range h.Volumes {
+			if v.VolumeID == volumeID {
+				return &h, nil
+			}
+		}
+	}
+	return nil, nil
 }
 
 func (hc *MockConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error) {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -137,8 +137,14 @@ type Connector interface {
 
 	FindHostsByDistroID(string) ([]host.Host, error)
 
+	// FindHostWithVolume returns the host that has the given volume attached
+	FindHostWithVolume(string) (*host.Host, error)
+
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
 	NewIntentHost(*restModel.HostRequestOptions, *user.DBUser) (*host.Host, error)
+
+	FindVolumeById(string) (*host.Volume, error)
+	FindVolumesByUser(string) ([]host.Volume, error)
 
 	// AggregateSpawnhostData returns basic metrics on spawn host/volume usage.
 	AggregateSpawnhostData() (*host.SpawnHostUsage, error)

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -477,7 +477,7 @@ func (h *attachVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	v, err := host.FindVolumeByID(h.attachment.VolumeID)
+	v, err := h.sc.FindVolumeById(h.attachment.VolumeID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
@@ -499,20 +499,26 @@ func (h *attachVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	mgrOpts := cloud.ManagerOpts{
-		Provider: attachedHost.Provider,
+		Provider: targetHost.Provider,
 		Region:   cloud.GetRegion(targetHost.Distro),
 	}
 	mgr, err := cloud.GetManager(ctx, h.env, mgrOpts)
 	if err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "error getting cloud manager for spawnhost attach volume job"))
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "error getting cloud manager for spawnhost attach volume job").Error(),
+		})
 	}
 	grip.Info(message.Fields{
 		"message": "attaching volume to spawnhost",
 		"host_id": h.hostID,
 		"volume":  h.attachment,
 	})
-	if err = mgr.AttachVolume(ctx, attachedHost, h.attachment); err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error attaching volume %s for spawnhost %s", h.attachment.VolumeID, h.hostID))
+	if err = mgr.AttachVolume(ctx, targetHost, h.attachment); err != nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrapf(err, "error attaching volume %s for spawnhost %s", h.attachment.VolumeID, h.hostID).Error(),
+		})
 	}
 
 	return gimlet.NewJSONResponse(struct{}{})
@@ -595,11 +601,17 @@ func (h *detachVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	mgr, err := cloud.GetManager(ctx, h.env, mgrOpts)
 	if err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "error getting cloud manager for spawnhost detach volume job"))
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "error getting cloud manager for spawnhost detach volume job").Error(),
+		})
 	}
 
 	if err = mgr.DetachVolume(ctx, targetHost, h.attachment.VolumeID); err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error detaching volume %s from spawnhost %s", h.attachment.VolumeID, h.hostID))
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrapf(err, "error detaching volume %s from spawnhost %s", h.attachment.VolumeID, h.hostID).Error(),
+		})
 	}
 
 	return gimlet.NewJSONResponse(struct{}{})
@@ -634,11 +646,9 @@ func (h *createVolumeHandler) Factory() gimlet.RouteHandler {
 func (h *createVolumeHandler) Parse(ctx context.Context, r *http.Request) error {
 	h.volume = &host.Volume{}
 	if err := util.ReadJSONInto(r.Body, h.volume); err != nil {
-		grip.Debug(message.WrapError(err, "problem reading JSON into"))
 		return err
 	}
 	if h.volume.Size == 0 {
-		grip.Debug("Size is required")
 		return errors.New("Size is required")
 	}
 	h.provider = evergreen.ProviderNameEc2OnDemand
@@ -671,7 +681,6 @@ func (h *createVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	mgr, err := cloud.GetManager(ctx, h.env, mgrOpts)
 	if err != nil {
-		grip.Debug(message.WrapError(err, "manager error"))
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    err.Error(),
@@ -679,7 +688,6 @@ func (h *createVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	if h.volume, err = mgr.CreateVolume(ctx, h.volume); err != nil {
-		grip.Debug(message.WrapError(err, "create volume error"))
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    err.Error(),
@@ -689,7 +697,6 @@ func (h *createVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 	volumeModel := &model.APIVolume{}
 	err = volumeModel.BuildFromService(h.volume)
 	if err != nil {
-		message.WrapError(err, "build from service")
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "API model error"))
 	}
 
@@ -732,7 +739,7 @@ func (h *deleteVolumeHandler) Parse(ctx context.Context, r *http.Request) error 
 func (h *deleteVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 	u := MustHaveUser(ctx)
 
-	volume, err := host.FindVolumeByID(h.VolumeID)
+	volume, err := h.sc.FindVolumeById(h.VolumeID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
@@ -752,6 +759,21 @@ func (h *deleteVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("not authorized to delete attachment '%s'", volume.ID),
 		})
 	}
+
+	attachedHost, err := h.sc.FindHostWithVolume(h.VolumeID)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    fmt.Sprintf("problem finding host with volume"),
+		})
+	}
+	if attachedHost != nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintf("Must detach from host '%s'", attachedHost.Id),
+		})
+	}
+
 	// TODO: Allow different providers/regions
 	mgrOpts := cloud.ManagerOpts{
 		Provider: h.provider,
@@ -801,8 +823,9 @@ func (h *getVolumesHandler) Parse(ctx context.Context, r *http.Request) error {
 func (h *getVolumesHandler) Run(ctx context.Context) gimlet.Responder {
 	u := MustHaveUser(ctx)
 
-	volumes, err := host.FindVolumesByUser(u.Username())
+	volumes, err := h.sc.FindVolumesByUser(u.Username())
 	if err != nil {
+		fmt.Println("grr")
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 
@@ -810,11 +833,12 @@ func (h *getVolumesHandler) Run(ctx context.Context) gimlet.Responder {
 	for _, v := range volumes {
 		volumeDoc := model.APIVolume{}
 		if err = volumeDoc.BuildFromService(v); err != nil {
+			fmt.Println("ahhh")
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "err converting volume '%s' to API model", v.ID))
 		}
 
 		// if the volume is attached to a host, also return the host ID and volume device name
-		h, err := host.FindHostWithVolume(v.ID)
+		h, err := h.sc.FindHostWithVolume(v.ID)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "error querying for host"))
 		}


### PR DESCRIPTION
Generates device name differently because the AWS docs seem inconsistent, and we should regenerate device name on failure so we don't retry repeatedly with a bad device name. Also some code cleanup (using the connector for volume things, remove old debugging, etc.)