### PR TITLE
EVG-7022: agent contact should disable agent deploys

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1429,8 +1429,8 @@ func FindAllRunningParentsOrdered() ([]Host, error) {
 // FindAllRunningParentsOnDistro finds all running hosts of a given distro with child containers
 func FindAllRunningParentsByDistro(distroId string) ([]Host, error) {
 	query := db.Query(bson.M{
-		StatusKey:        evergreen.HostRunning,
-		HasContainersKey: true,
+		StatusKey:                                          evergreen.HostRunning,
+		HasContainersKey:                                   true,
 		bsonutil.GetDottedKeyName(DistroKey, distro.IdKey): distroId,
 	}).Sort([]string{LastContainerFinishTimeKey})
 	return Find(query)
@@ -1538,7 +1538,7 @@ func FindRunningHosts(includeSpawnHosts bool) ([]Host, error) {
 		},
 		{
 			"$unwind": bson.M{
-				"path":                       "$task_full",
+				"path": "$task_full",
 				"preserveNullAndEmptyArrays": true,
 			},
 		},

--- a/service/api.go
+++ b/service/api.go
@@ -168,6 +168,16 @@ func (as *APIServer) checkHost(next http.HandlerFunc) http.HandlerFunc {
 		if err := h.UpdateLastCommunicated(); err != nil {
 			grip.Warningf("Could not update host last communication time for %s: %+v", h.Id, err)
 		}
+		// Since the host has contacted the app server, we should prevent the
+		// app server from attempting to deploy agents or agent monitors.
+		// Deciding whether or not we should redeploy agents or agent monitors
+		// is handled within the REST route handler.
+		if h.NeedsNewAgent {
+			grip.Warning(message.WrapError(h.SetNeedsNewAgent(false), "problem clearing host needs new agent"))
+		}
+		if h.NeedsNewAgentMonitor {
+			grip.Warning(message.WrapError(h.SetNeedsNewAgentMonitor(false), "problem clearing host needs new agent monitor"))
+		}
 		r = setAPIHostContext(r, h)
 		next(w, r)
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7022

Some hosts had their "needs new agent monitor" flag set due to max LCT elapsing on a particularly long latency between intent host creation and agent start time. Therefore, it attempted to deploy when an agent monitor was running on the host.

* The max LCT check should only be used to redeploy the agent if the agent is not obviously up and running (in this case, it was definitely running). This change disables the flag that triggers agent/agent monitor deploys if the agent successfully contacts the app server via a REST route.
* I also made the

The flow is slightly confusing but this is because the following events occurred:
1. The intent host was created at 10:34am.
2. The create host job only started at 11:12am, well after max LCT elapsed (5 mins).
3. The host was put in the provisioning state.
4. The populate agent monitor deploy job started and saw the host's status was provisioning but it hadn't contacted the app server yet, so it set the "needs new agent monitor" flag.
5. The agent monitor started up a few second afters the agent monitor deploy jobs were populated and started running tasks, prevent the agent monitor deploy job from running. However, it did not claer the "needs new agent monitor" flag until this PR.