### PR TITLE
EVG-6595: support new patches page routes

### DIFF
--- a/service/timeline.go
+++ b/service/timeline.go
@@ -67,7 +67,7 @@ func (uis *UIServer) patchTimeline(w http.ResponseWriter, r *http.Request) {
 func (uis *UIServer) myPatchesTimeline(w http.ResponseWriter, r *http.Request) {
 	user := MustHaveUser(r)
 	if user.Settings.UseSpruceOptions.PatchPage {
-		http.Redirect(w, r, fmt.Sprintf("%s/patches?user=%s", uis.Settings.Ui.UIv2Url, user.Username()), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/patches/user/%s", uis.Settings.Ui.UIv2Url, user.Username()), http.StatusTemporaryRedirect)
 		return
 	}
 
@@ -78,11 +78,22 @@ func (uis *UIServer) userPatchesTimeline(w http.ResponseWriter, r *http.Request)
 	user := MustHaveUser(r)
 	author := gimlet.GetVars(r)["user_id"]
 	if user.Settings.UseSpruceOptions.PatchPage {
-		http.Redirect(w, r, fmt.Sprintf("%s/patches?user=%s", uis.Settings.Ui.UIv2Url, author), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/patches/user/%s", uis.Settings.Ui.UIv2Url, author), http.StatusTemporaryRedirect)
 		return
 	}
 
 	uis.patchTimelineWrapper(author, w, r)
+}
+
+func (uis *UIServer) projectPatchesTimeline(w http.ResponseWriter, r *http.Request) {
+	user := MustHaveUser(r)
+	project := gimlet.GetVars(r)["project_id"]
+	if user.Settings.UseSpruceOptions.PatchPage {
+		http.Redirect(w, r, fmt.Sprintf("%s/patches/project/%s", uis.Settings.Ui.UIv2Url, project), http.StatusTemporaryRedirect)
+		return
+	}
+
+	uis.patchTimelineWrapper("", w, r)
 }
 
 func (uis *UIServer) patchTimelineWrapper(author string, w http.ResponseWriter, r *http.Request) {

--- a/service/ui.go
+++ b/service/ui.go
@@ -350,7 +350,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/filediff/{patch_id}/").Wrap(needsLogin, needsContext, viewTasks).Handler(uis.fileDiffPage).Get()
 	app.AddRoute("/rawdiff/{patch_id}/").Wrap(needsLogin, needsContext, viewTasks).Handler(uis.rawDiffPage).Get()
 	app.AddRoute("/patches").Wrap(needsLogin, needsContext).Handler(uis.patchTimeline).Get()
-	app.AddRoute("/patches/project/{project_id}").Wrap(needsLogin, needsContext, viewTasks).Handler(uis.patchTimeline).Get()
+	app.AddRoute("/patches/project/{project_id}").Wrap(needsLogin, needsContext, viewTasks).Handler(uis.projectPatchesTimeline).Get()
 	app.AddRoute("/patches/user/{user_id}").Wrap(needsLogin, needsContext).Handler(uis.userPatchesTimeline).Get()
 	app.AddRoute("/patches/mine").Wrap(needsLogin, needsContext).Handler(uis.myPatchesTimeline).Get()
 


### PR DESCRIPTION
when opted into the new patches page, landing on these routes will redirect from our angular app to our react app patches page:
/patches/user -> /patches/user/{your_username} 
/patches/user/username -> /patches/user/username
/patches/mine -> /patches/user/{your_username}

