### PR TITLE
EVG-6409 generated task dependencies

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -226,7 +226,8 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, cachedProj
 	for _, bv := range g.BuildVariants {
 		newTVPairs = appendTasks(newTVPairs, bv, p)
 	}
-	newTVPairs.ExecTasks = append(newTVPairs.ExecTasks, IncludePatchDependencies(p, newTVPairs.ExecTasks)...)
+	newTVPairs.ExecTasks = IncludePatchDependencies(p, newTVPairs.ExecTasks)
+	//newTVPairs.ExecTasks = append(newTVPairs.ExecTasks, IncludePatchDependencies(p, newTVPairs.ExecTasks)...)
 
 	// group into new builds and new tasks for existing builds
 	builds, err := build.Find(build.ByVersion(v.Id).WithFields(build.IdKey, build.BuildVariantKey))

--- a/model/generate.go
+++ b/model/generate.go
@@ -227,7 +227,6 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, cachedProj
 		newTVPairs = appendTasks(newTVPairs, bv, p)
 	}
 	newTVPairs.ExecTasks = IncludePatchDependencies(p, newTVPairs.ExecTasks)
-	//newTVPairs.ExecTasks = append(newTVPairs.ExecTasks, IncludePatchDependencies(p, newTVPairs.ExecTasks)...)
 
 	// group into new builds and new tasks for existing builds
 	builds, err := build.Find(build.ByVersion(v.Id).WithFields(build.IdKey, build.BuildVariantKey))

--- a/model/generate.go
+++ b/model/generate.go
@@ -233,7 +233,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, cachedProj
 	if err != nil {
 		return errors.Wrap(err, "problem finding builds for version")
 	}
-	buildSet := make(map[string]struct{})
+	buildSet := map[string]struct{}{}
 	for _, b := range builds {
 		buildSet[b.BuildVariant] = struct{}{}
 	}

--- a/model/generate.go
+++ b/model/generate.go
@@ -233,14 +233,14 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, cachedProj
 	if err != nil {
 		return errors.Wrap(err, "problem finding builds for version")
 	}
-	buildSet := make(map[string]bool)
+	buildSet := make(map[string]struct{})
 	for _, b := range builds {
-		buildSet[b.BuildVariant] = true
+		buildSet[b.BuildVariant] = struct{}{}
 	}
 	newTVPairsForExistingVariants := TaskVariantPairs{}
 	newTVPairsForNewVariants := TaskVariantPairs{}
 	for _, execTask := range newTVPairs.ExecTasks {
-		if buildSet[execTask.Variant] {
+		if _, ok := buildSet[execTask.Variant]; ok {
 			newTVPairsForExistingVariants.ExecTasks = append(newTVPairsForExistingVariants.ExecTasks, execTask)
 		} else {
 			newTVPairsForNewVariants.ExecTasks = append(newTVPairsForNewVariants.ExecTasks, execTask)

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -557,6 +557,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	sampleBuild := build.Build{
 		Id:           "sample_build",
 		BuildVariant: "a_variant",
+		Version:      "version_that_called_generate_task",
 	}
 	v := &Version{
 		Id:                 "version_that_called_generate_task",
@@ -578,7 +579,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	tasks := []task.Task{}
 	err = db.FindAllQ(task.Collection, db.Q{}, &tasks)
 	s.NoError(err)
-	s.Len(builds, 3)
+	s.Len(builds, 2)
 	s.Len(tasks, 6)
 
 	for _, task := range tasks {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1200,7 +1200,7 @@ func sortLayer(layer []task.Task, idToDisplayName map[string]string) []task.Task
 // do not exist yet out of the set of pairs. No tasks are added for builds which already exist
 // (see AddNewTasksForPatch).
 func AddNewBuilds(ctx context.Context, activated bool, v *Version, p *Project, tasks TaskVariantPairs, generatedBy string) error {
-	taskIds := NewPatchTaskIdTable(p, v, tasks)
+	taskIds := NewTaskIdTable(p, v, "", "")
 
 	newBuildIds := make([]string, 0)
 	newBuildStatuses := make([]VersionBuildStatus, 0)

--- a/model/patch_dependencies.go
+++ b/model/patch_dependencies.go
@@ -55,8 +55,8 @@ func (di *dependencyIncluder) handle(pair TVPair) bool {
 	// since it contains the full scope of dependency information
 	bvt := di.Project.FindTaskForVariant(pair.TaskName, pair.Variant)
 	if bvt == nil {
-		grip.Errorf("task %s does not exist in project %s", pair.TaskName,
-			di.Project.Identifier)
+		grip.Errorf("task %s does not exist in project '%s' for variant '%s'", pair.TaskName,
+			di.Project.Identifier, pair.Variant)
 		di.included[pair] = false
 		return false // task not found in project--skip it.
 	}
@@ -74,7 +74,7 @@ func (di *dependencyIncluder) handle(pair TVPair) bool {
 	for _, dep := range deps {
 		if ok := di.handle(dep); !ok {
 			di.included[pair] = false
-			return false // task depends on an unpatchable task, so skip it
+			return false // task depends on an unpatchable or non-existent task, so skip it
 		}
 	}
 


### PR DESCRIPTION
If a generated task depended on another task being added for another variant that already existed the depended-on task wasn't being pulled in to the patch.
Because dependencies were included for existing and new variants separately, when we called `AddNewBuilds` with tasks for existing builds, they were passed over.
Additionally, the depended-on task wasn't available in `AddNewBuilds`'s TaskIDTable, so it wasn't being added as added as a dependency.