### PR TITLE
EVG-6940: variant_tasks in patches endpoint contains all tasks

### DIFF
--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -64,7 +64,7 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 	variantTasks := []variantTask{}
 	for _, vt := range v.VariantsTasks {
 		vtasks := make([]APIString, 0)
-		for _, task := range v.Tasks {
+		for _, task := range vt.Tasks {
 			vtasks = append(vtasks, ToAPIString(task))
 		}
 		variantTasks = append(variantTasks, variantTask{

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -78,13 +78,11 @@ func TestAPIPatch(t *testing.T) {
 	}
 	for i, vt := range a.VariantsTasks {
 		assert.Equal(p.VariantsTasks[i].Variant, FromAPIString(vt.Name))
-
-		for i2, task := range vt.Tasks {
-			assert.Equal(a.Tasks[i2], task)
-		}
 	}
 	assert.Equal("__github", FromAPIString(a.Alias))
 	assert.NotZero(a.GithubPatchData)
+	assert.NotEqual(a.VariantsTasks[0].Tasks, a.VariantsTasks[1].Tasks)
+	assert.Len(a.VariantsTasks[0].Tasks, 1)
 }
 
 func TestGithubPatch(t *testing.T) {


### PR DESCRIPTION
Access Tasks from VariantTasks instead of Patch to prevent the variant_tasks in the patches endpoint from containing all tasks