### PR TITLE
EVG-6286 use ID and tag for host logging

### DIFF
--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -83,15 +83,11 @@ func CountUnprocessedEvents() (int, error) {
 // === Queries ===
 
 // Host Events
-func HostEventsForId(ids []string) db.Q {
+func MostRecentHostEvents(ids []string, n int) db.Q {
 	filter := ResourceTypeKeyIs(ResourceTypeHost)
 	filter[ResourceIdKey] = bson.M{"$in": ids}
 
-	return db.Query(filter)
-}
-
-func MostRecentHostEvents(ids []string, n int) db.Q {
-	return HostEventsForId(ids).Sort([]string{"-" + TimestampKey}).Limit(n)
+	return db.Query(filter).Sort([]string{"-" + TimestampKey}).Limit(n)
 }
 
 // Task Events

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -83,19 +83,15 @@ func CountUnprocessedEvents() (int, error) {
 // === Queries ===
 
 // Host Events
-func HostEventsForId(id string) db.Q {
+func HostEventsForId(ids []string) db.Q {
 	filter := ResourceTypeKeyIs(ResourceTypeHost)
-	filter[ResourceIdKey] = id
+	filter[ResourceIdKey] = bson.M{"$in": ids}
 
 	return db.Query(filter)
 }
 
-func MostRecentHostEvents(id string, n int) db.Q {
-	return HostEventsForId(id).Sort([]string{"-" + TimestampKey}).Limit(n)
-}
-
-func HostEventsInOrder(id string) db.Q {
-	return HostEventsForId(id).Sort([]string{TimestampKey})
+func MostRecentHostEvents(ids []string, n int) db.Q {
+	return HostEventsForId(ids).Sort([]string{"-" + TimestampKey}).Limit(n)
 }
 
 // Task Events

--- a/service/event_log.go
+++ b/service/event_log.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/evergreen-ci/evergreen/model/host"
+
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/gimlet"
@@ -31,7 +33,14 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 			uis.RedirectToLogin(w, r)
 			return
 		}
-		eventQuery := event.MostRecentHostEvents(resourceID, 5000)
+		ids := []string{}
+		h, err := host.FindOneByIdOrTag(resourceID)
+		if err != nil || h == nil {
+			ids = []string{resourceID}
+		} else {
+			ids = []string{h.Id, h.Tag}
+		}
+		eventQuery := event.MostRecentHostEvents(ids, 5000)
 		loggedEvents, err = event.Find(event.AllLogCollection, eventQuery)
 	case event.ResourceTypeDistro:
 		if u == nil {

--- a/service/event_log.go
+++ b/service/event_log.go
@@ -36,7 +36,8 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		ids := []string{}
-		h, err := host.FindOneByIdOrTag(resourceID)
+		var h *host.Host
+		h, err = host.FindOneByIdOrTag(resourceID)
 		if err != nil {
 			http.Error(w, errors.Wrap(err, "error finding host '%s'").Error(), http.StatusInternalServerError)
 			return

--- a/service/event_log.go
+++ b/service/event_log.go
@@ -34,8 +34,8 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		ids := []string{}
-		h, err := host.FindOneByIdOrTag(resourceID)
-		if err != nil || h == nil {
+		h, _ := host.FindOneByIdOrTag(resourceID)
+		if h == nil {
 			ids = []string{resourceID}
 		} else {
 			ids = []string{h.Id, h.Tag}

--- a/service/host.go
+++ b/service/host.go
@@ -65,7 +65,7 @@ func (uis *UIServer) hostPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	events, err := event.Find(event.AllLogCollection, event.MostRecentHostEvents(id, 50))
+	events, err := event.Find(event.AllLogCollection, event.MostRecentHostEvents([]string{h.Id, h.Tag}, 50))
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -33,10 +33,10 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 	opts1 := uiParams{Action: "updateStatus", Status: evergreen.HostQuarantined, Notes: "because I can"}
 
 	result, err := modifyHostStatus(env.LocalQueue(), &h1, &opts1, &user1)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal(result, fmt.Sprintf(HostStatusUpdateSuccess, evergreen.HostRunning, evergreen.HostQuarantined))
 	assert.Equal(h1.Status, evergreen.HostQuarantined)
-	events, err2 := event.Find(event.AllLogCollection, event.MostRecentHostEvents("h1", 1))
+	events, err2 := event.Find(event.AllLogCollection, event.MostRecentHostEvents([]string{"h1"}, 1))
 	assert.NoError(err2)
 	assert.Len(events, 1)
 	hostevent, ok := events[0].Data.(*event.HostEventData)
@@ -48,7 +48,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 	opts2 := uiParams{Action: "updateStatus", Status: evergreen.HostDecommissioned}
 
 	_, err = modifyHostStatus(env.LocalQueue(), &h2, &opts2, &user2)
-	assert.NotNil(err)
+	assert.Error(err)
 	assert.Contains(err.Error(), DecommissionStaticHostError)
 
 	user3 := user.DBUser{Id: "user3"}
@@ -56,6 +56,6 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 	opts3 := uiParams{Action: "updateStatus", Status: "undefined"}
 
 	_, err = modifyHostStatus(env.LocalQueue(), &h3, &opts3, &user3)
-	assert.NotNil(err)
+	assert.Error(err)
 	assert.Contains(err.Error(), fmt.Sprintf(InvalidStatusError, "undefined"))
 }

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -61,9 +61,9 @@ func TestTerminateHosts(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(dbHost)
 	assert.Equal(evergreen.HostTerminated, dbHost.Status)
-	events, err := event.Find(event.AllLogCollection, event.HostEventsInOrder(hostID))
+	events, err := event.Find(event.AllLogCollection, event.MostRecentHostEvents([]string{hostID}, 50))
 	assert.NoError(err)
-	data, valid := events[len(events)-1].Data.(*event.HostEventData)
+	data, valid := events[0].Data.(*event.HostEventData)
 	assert.True(valid)
 	assert.Equal("foo", data.Logs)
 }


### PR DESCRIPTION
Host event logs are created using both the host ID and the host tag (bringing us back to the FindHostByIdOrTag changes), so we should find event logs using both of these.

Also removed an unused host event.