### PR TITLE
EVG-6847: remove old buildvariants specification

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-11-12"
+	ClientVersion = "2019-12-03"
 )
 
 // ConfigSection defines a sub-document in the evegreen config

--- a/operations/http.go
+++ b/operations/http.go
@@ -391,13 +391,11 @@ func (ac *legacyClient) ListDistros() ([]distro.Distro, error) {
 // the patch object itself.
 func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, error) {
 	data := struct {
-		Description string `json:"desc"`
-		Project     string `json:"project"`
-		Patch       string `json:"patch"`
-		Githash     string `json:"githash"`
-		// TODO: remove this once users have been given enough time to update their binary versions.
-		Variants    string   `json:"buildvariants"`
-		VariantsNew []string `json:"buildvariants_new"`
+		Description string   `json:"desc"`
+		Project     string   `json:"project"`
+		Patch       string   `json:"patch"`
+		Githash     string   `json:"githash"`
+		Variants    []string `json:"buildvariants_new"`
 		Tasks       []string `json:"tasks"`
 		Finalize    bool     `json:"finalize"`
 		Alias       string   `json:"alias"`
@@ -406,7 +404,6 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		incomingPatch.projectId,
 		incomingPatch.patchData,
 		incomingPatch.base,
-		strings.Join(incomingPatch.variants, ","),
 		incomingPatch.variants,
 		incomingPatch.tasks,
 		incomingPatch.finalize,

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -35,14 +35,11 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	dbUser := MustHaveUser(r)
 
 	data := struct {
-		Description string `json:"desc"`
-		Project     string `json:"project"`
-		Patch       string `json:"patch"`
-		Githash     string `json:"githash"`
-		// TODO: remove this once users have been given enough time to update
-		// their binary versions.
-		Variants    string   `json:"buildvariants"`
-		VariantsNew []string `json:"buildvariants_new"`
+		Description string   `json:"desc"`
+		Project     string   `json:"project"`
+		Patch       string   `json:"patch"`
+		Githash     string   `json:"githash"`
+		Variants    []string `json:"buildvariants_new"`
 		Tasks       []string `json:"tasks"`
 		Finalize    bool     `json:"finalize"`
 		Alias       string   `json:"alias"`
@@ -55,10 +52,6 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	if len(data.Patch) > patch.SizeLimit {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.New("Patch is too large"))
 		return
-	}
-	variants := strings.Split(data.Variants, ",")
-	if len(data.VariantsNew) != 0 {
-		variants = data.VariantsNew
 	}
 
 	pref, err := model.FindOneProjectRef(data.Project)
@@ -80,7 +73,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	intent, err := patch.NewCliIntent(dbUser.Id, data.Project, data.Githash, r.FormValue("module"), data.Patch, data.Description, data.Finalize, variants, data.Tasks, data.Alias)
+	intent, err := patch.NewCliIntent(dbUser.Id, data.Project, data.Githash, r.FormValue("module"), data.Patch, data.Description, data.Finalize, data.Variants, data.Tasks, data.Alias)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, err)
 		return


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6847

This is a follow-on for [EVG-6823](https://jira.mongodb.org/browse/EVG-6823) that essentially removes the duplicate buildvariants field after people have had time to update their evergreen binaries.