### PR TITLE
EVG-7049: fix PATH shell quoting and export

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -986,7 +986,7 @@ func (h *Host) SetupSpawnHostCommands(settings *evergreen.Settings) (string, err
 		fmt.Sprintf("mkdir -m 777 -p %s", binDir),
 		fmt.Sprintf("echo '%s' > %s", confJSON, confPath),
 		fmt.Sprintf("cp %s %s", binaryPath, binDir),
-		fmt.Sprintf("(echo 'PATH=${PATH}:%s' >> %s/.profile || true; echo 'PATH=${PATH}:%s' >> %s/.bash_profile || true)", binDir, h.Distro.HomeDir(), binDir, h.Distro.HomeDir()),
+		fmt.Sprintf("(echo 'export PATH=\"${PATH}:%s\"' >> %s/.profile || true; echo 'export PATH=\"${PATH}:%s\"' >> %s/.bash_profile || true)", binDir, h.Distro.HomeDir(), binDir, h.Distro.HomeDir()),
 	}, " && ")
 
 	script := setupBinDirCmds

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -979,7 +979,7 @@ func TestSetupSpawnHostCommands(t *testing.T) {
 	cmd, err := h.SetupSpawnHostCommands(settings)
 	require.NoError(t, err)
 
-	expected := `mkdir -m 777 -p /home/user/cli_bin && echo '{"api_key":"key","api_server_host":"www.example0.com/api","ui_server_host":"www.example1.com","user":"user"}' > /home/user/cli_bin/.evergreen.yml && cp /home/user/evergreen /home/user/cli_bin && (echo 'PATH=${PATH}:/home/user/cli_bin' >> /home/user/.profile || true; echo 'PATH=${PATH}:/home/user/cli_bin' >> /home/user/.bash_profile || true)`
+	expected := `mkdir -m 777 -p /home/user/cli_bin && echo '{"api_key":"key","api_server_host":"www.example0.com/api","ui_server_host":"www.example1.com","user":"user"}' > /home/user/cli_bin/.evergreen.yml && cp /home/user/evergreen /home/user/cli_bin && (echo 'export PATH="${PATH}:/home/user/cli_bin"' >> /home/user/.profile || true; echo 'export PATH="${PATH}:/home/user/cli_bin"' >> /home/user/.bash_profile || true)`
 	assert.Equal(t, expected, cmd)
 
 	h.ProvisionOptions.TaskId = "task_id"

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -776,7 +776,7 @@ func (j *setupHostJob) loadClient(ctx context.Context, target *host.Host, settin
 	makeShellCmd := j.env.JasperManager().CreateCommand(mkdctx).Host(hostSSHInfo.Hostname).User(target.User).
 		ExtendRemoteArgs("-p", hostSSHInfo.Port).ExtendRemoteArgs(sshOptions...).
 		RedirectErrorToOutput(true).SetOutputWriter(mkdirOutput).
-		Append(fmt.Sprintf("mkdir -m 777 -p ~/%s && (echo 'PATH=$PATH:~/%s' >> ~/.profile || true; echo 'PATH=$PATH:~/%s' >> ~/.bash_profile || true)", targetDir, targetDir, targetDir))
+		Append(fmt.Sprintf("mkdir -m 777 -p ~/%s && (echo 'export PATH=\"$PATH:~/%s\"' >> ~/.profile || true; echo 'export PATH=\"$PATH:~/%s\"' >> ~/.bash_profile || true)", targetDir, targetDir, targetDir))
 
 	// Create the directory for the binary to be uploaded into.
 	// Also, make a best effort to add the binary's location to $PATH upon login. If we can't do


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7049

* Fix an issue on Windows where the existing PATH contains spaces so it needs double quotes to treat it as a string.
* Export the path so that the bash variable is set in the environment.