### PR TITLE
EVG-7017: remove unused path and db settings from mock environment

### DIFF
--- a/migrations/anser_test.go
+++ b/migrations/anser_test.go
@@ -2,14 +2,11 @@ package migrations
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	evg "github.com/evergreen-ci/evergreen/db"
 	evgmock "github.com/evergreen-ci/evergreen/mock"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/mongodb/anser"
 	"github.com/mongodb/anser/client"
 	"github.com/mongodb/anser/mock"
@@ -29,7 +26,7 @@ func TestAnserBasicPlaceholder(t *testing.T) {
 
 	evgEnv := &evgmock.Environment{}
 
-	assert.NoError(evgEnv.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	assert.NoError(evgEnv.Configure(ctx))
 
 	opts := Options{
 		Database: "mci_test",

--- a/migrations/suite_test.go
+++ b/migrations/suite_test.go
@@ -2,13 +2,10 @@ package migrations
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/mock"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/mongodb/anser"
 	"github.com/mongodb/anser/client"
 	adb "github.com/mongodb/anser/db"
@@ -35,7 +32,7 @@ func (s *migrationSuite) SetupSuite() {
 	ctx, s.cancel = context.WithCancel(context.Background())
 
 	s.env = &mock.Environment{}
-	require.NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	require.NoError(s.env.Configure(ctx))
 
 	var err error
 	session, database, err := db.GetGlobalSessionFactory().GetSession()

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -45,15 +45,12 @@ type Environment struct {
 	roleManager          gimlet.RoleManager
 }
 
-func (e *Environment) Configure(ctx context.Context, path string, db *evergreen.DBSettings) error {
+func (e *Environment) Configure(ctx context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.EnvContext = ctx
 
 	e.EvergreenSettings = testutil.TestConfig()
-	if db != nil {
-		e.EvergreenSettings.Database = *db
-	}
 	e.DBSession = anserMock.NewSession()
 
 	e.Remote = queue.NewLocalLimitedSize(2, 1048)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1558,7 +1558,7 @@ func TestFindByExpiringJasperCredentials(t *testing.T) {
 			defer cancel()
 
 			env := &mock.Environment{}
-			require.NoError(t, env.Configure(tctx, "", nil))
+			require.NoError(t, env.Configure(tctx))
 			env.EnvContext = tctx
 
 			require.NoError(t, setupCredentialsCollection(ctx, env))

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -616,7 +616,7 @@ func TestJasperClient(t *testing.T) {
 			defer cancel()
 
 			env := &mock.Environment{}
-			require.NoError(t, env.Configure(tctx, "", nil))
+			require.NoError(t, env.Configure(tctx))
 			env.Settings().HostJasper.BinaryName = "binary"
 			env.Settings().Keys = map[string]string{sshKeyName: sshKeyValue}
 
@@ -689,7 +689,7 @@ func TestJasperProcess(t *testing.T) {
 			defer cancel()
 
 			env := &mock.Environment{}
-			require.NoError(t, env.Configure(tctx, "", nil))
+			require.NoError(t, env.Configure(tctx))
 			env.Settings().HostJasper.BinaryName = "binary"
 
 			manager := &jmock.Manager{}
@@ -920,7 +920,7 @@ func TestStopAgentMonitor(t *testing.T) {
 			defer tcancel()
 
 			env := &mock.Environment{}
-			require.NoError(t, env.Configure(tctx, "", nil))
+			require.NoError(t, env.Configure(tctx))
 			manager := &jmock.Manager{}
 
 			h := &Host{

--- a/model/reliability/db_test.go
+++ b/model/reliability/db_test.go
@@ -18,7 +18,7 @@ import (
 func setupEnv(ctx context.Context) (*mock.Environment, error) {
 	env := &mock.Environment{}
 
-	if err := env.Configure(ctx, "", nil); err != nil {
+	if err := env.Configure(ctx); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return env, nil

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -102,7 +102,7 @@ func TestMockConnectorSuite(t *testing.T) {
 
 func (s *AdminDataSuite) SetupSuite() {
 	s.env = &mock.Environment{}
-	s.Require().NoError(s.env.Configure(context.Background(), "", nil))
+	s.Require().NoError(s.env.Configure(context.Background()))
 }
 
 func (s *AdminDataSuite) TestSetAndGetSettings() {

--- a/rest/route/commit_queue_test.go
+++ b/rest/route/commit_queue_test.go
@@ -2,17 +2,14 @@ package route
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/mock"
 	dbModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/suite"
 	mgobson "gopkg.in/mgo.v2/bson"
 )
@@ -85,7 +82,7 @@ func (s *CommitQueueSuite) TestDeleteItem() {
 
 	ctx := context.Background()
 	env := &mock.Environment{}
-	s.Require().NoError(env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	s.Require().NoError(env.Configure(ctx))
 
 	route := makeDeleteCommitQueueItems(s.sc, env).(*commitQueueDeleteItemHandler)
 	pos, err := s.sc.EnqueueItem("mci", model.APICommitQueueItem{Issue: model.ToAPIString("1")})

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1385,7 +1385,7 @@ func (s *DistroIDExecuteSuite) SetupTest() {
 	s.cancel = cancel
 	env := &mock.Environment{}
 	s.env = env
-	s.Require().NoError(env.Configure(ctx, "", nil))
+	s.Require().NoError(env.Configure(ctx))
 	h := makeDistroExecute(s.sc, s.env)
 	rh, ok := h.(*distroIDExecuteHandler)
 	s.Require().True(ok)

--- a/rest/route/reliability_test.go
+++ b/rest/route/reliability_test.go
@@ -659,7 +659,7 @@ func TestRun(t *testing.T) {
 func setupEnv(ctx context.Context) (*mock.Environment, error) {
 	env := &mock.Environment{}
 
-	if err := env.Configure(ctx, "", nil); err != nil {
+	if err := env.Configure(ctx); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return env, nil

--- a/service/api_task_test.go
+++ b/service/api_task_test.go
@@ -674,7 +674,7 @@ func TestNextTask(t *testing.T) {
 					as.env = env
 				}()
 				mockEnv := &mock.Environment{}
-				mockEnv.Configure(ctx, "", nil)
+				mockEnv.Configure(ctx)
 				as.env = mockEnv
 
 				h := host.Host{

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -12,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +22,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 	defer cancel()
 
 	env := mock.Environment{}
-	assert.NoError(env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	assert.NoError(env.Configure(ctx))
 	require.NoError(db.ClearCollections(event.AllLogCollection), "error clearing collections")
 
 	// Normal test, changing a host from running to quarantined

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -63,7 +63,7 @@ func (s *commitQueueSuite) SetupSuite() {
 
 	s.env = &mock.Environment{}
 	s.ctx = context.Background()
-	s.NoError(s.env.Configure(s.ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	s.NoError(s.env.Configure(s.ctx))
 }
 
 func (s *commitQueueSuite) SetupTest() {

--- a/units/event_send_test.go
+++ b/units/event_send_test.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"testing"
 	"time"
@@ -14,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/suite"
@@ -46,7 +44,7 @@ func (s *eventNotificationSuite) SetupSuite() {
 
 func (s *eventNotificationSuite) SetupTest() {
 	s.env = &mock.Environment{}
-	s.NoError(s.env.Configure(s.ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	s.NoError(s.env.Configure(s.ctx))
 
 	s.NoError(db.ClearCollections(notification.Collection, evergreen.ConfigCollection))
 

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -48,7 +47,7 @@ func (s *githubStatusUpdateSuite) SetupTest() {
 	s.cancel = cancel
 
 	s.env = &mock.Environment{}
-	s.Require().NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	s.Require().NoError(s.env.Configure(ctx))
 
 	startTime := time.Now().Truncate(time.Millisecond)
 	id := mgobson.NewObjectId()

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -36,7 +36,7 @@ func TestTerminateHosts(t *testing.T) {
 	defer cancel()
 
 	env := &mock.Environment{}
-	assert.NoError(env.Configure(ctx, "", nil))
+	assert.NoError(env.Configure(ctx))
 
 	hostID := "i-12345"
 	mcp := cloud.GetMockProvider()
@@ -102,7 +102,7 @@ func TestHostCosts(t *testing.T) {
 	assert.NoError(t1.Insert())
 
 	env := &mock.Environment{}
-	require.NoError(t, env.Configure(ctx, "", nil))
+	require.NoError(t, env.Configure(ctx))
 	j := NewHostTerminationJob(env, *h, true, "")
 	j.Run(ctx)
 	assert.NoError(j.Error())

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -57,7 +56,7 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
-	s.Require().NoError(s.env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	s.Require().NoError(s.env.Configure(ctx))
 
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), "TestPatchIntentUnitsSuite")
 	s.NotNil(s.env.Settings())

--- a/units/periodic_builds_test.go
+++ b/units/periodic_builds_test.go
@@ -2,7 +2,6 @@ package units
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -22,7 +21,7 @@ func TestPeriodicBuildsJob(t *testing.T) {
 	ctx := context.Background()
 	env := &mock.Environment{}
 	j.env = env
-	assert.NoError(env.Configure(ctx, filepath.Join(evergreen.FindEvergreenHome(), testutil.TestDir, testutil.TestSettings), nil))
+	assert.NoError(env.Configure(ctx))
 	testutil.ConfigureIntegrationTest(t, j.env.Settings(), "TestPeriodicBuildsJob")
 
 	sampleProject := model.ProjectRef{

--- a/units/provisioning_convert_host_to_legacy_test.go
+++ b/units/provisioning_convert_host_to_legacy_test.go
@@ -74,7 +74,7 @@ func TestConvertHostToLegacyProvisioningJob(t *testing.T) {
 			defer cancel()
 
 			env := &mock.Environment{}
-			require.NoError(t, env.Configure(tctx, "", nil))
+			require.NoError(t, env.Configure(tctx))
 			mgr := &jmock.Manager{}
 			env.JasperProcessManager = mgr
 			sshKeyName, sshKeyValue := "foo", "bar"

--- a/units/provisioning_convert_host_to_new_test.go
+++ b/units/provisioning_convert_host_to_new_test.go
@@ -74,7 +74,7 @@ func TestConvertHostToNewProvisioningJob(t *testing.T) {
 			defer cancel()
 
 			env := &mock.Environment{}
-			require.NoError(t, env.Configure(tctx, "", nil))
+			require.NoError(t, env.Configure(tctx))
 			mgr := &jmock.Manager{}
 			env.JasperProcessManager = mgr
 			sshKeyName, sshKeyValue := "foo", "bar"

--- a/units/provisioning_jasper_restart_test.go
+++ b/units/provisioning_jasper_restart_test.go
@@ -304,7 +304,7 @@ func TestJasperRestartJob(t *testing.T) {
 			}
 
 			env := &mock.Environment{}
-			require.NoError(t, env.Configure(tctx, "", nil))
+			require.NoError(t, env.Configure(tctx))
 
 			require.NoError(t, withJasperServiceSetupAndTeardown(tctx, env, mngr, h, func(env evergreen.Environment) {
 				testCase(tctx, t, env, mngr, h)

--- a/units/provisioning_user_data_done_test.go
+++ b/units/provisioning_user_data_done_test.go
@@ -73,7 +73,7 @@ func TestUserDataDoneJob(t *testing.T) {
 			defer cancel()
 
 			env := &mock.Environment{}
-			require.NoError(t, env.Configure(tctx, "", nil))
+			require.NoError(t, env.Configure(tctx))
 			env.Settings().HostJasper = evergreen.HostJasperConfig{}
 
 			mngr := &jmock.Manager{}

--- a/units/stats_test.go
+++ b/units/stats_test.go
@@ -30,7 +30,7 @@ func (s *StatUnitsSuite) SetupTest() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
-	s.Require().NoError(s.env.Configure(ctx, "", nil))
+	s.Require().NoError(s.env.Configure(ctx))
 }
 
 func (s *StatUnitsSuite) TestAmboyStatsCollector() {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7017

`(mock.Environment).Configure()` is primarily used to set sane default values. The db settings field on the mock environment has never been set and the path to the settings has been ignored for a long time so I just removed both.