### PR TITLE
EVG-6579 Store strings instead of bytes for generate.tasks

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -97,9 +97,10 @@ func MergeGeneratedProjects(projects []GeneratedProject) *GeneratedProject {
 // ParseProjectFromJSON returns a GeneratedTasks type from JSON. We use the
 // YAML parser instead of the JSON parser because the JSON parser will not
 // properly unmarshal into a struct with multiple fields as options, like the YAMLCommandSet.
-func ParseProjectFromJSON(data []byte) (GeneratedProject, error) {
+func ParseProjectFromJSON(data string) (GeneratedProject, error) {
 	g := GeneratedProject{}
-	if err := yaml.Unmarshal(data, &g); err != nil {
+	dataAsJSON := []byte(data)
+	if err := yaml.Unmarshal(dataAsJSON, &g); err != nil {
 		return g, errors.Wrap(err, "error unmarshaling into GeneratedTasks")
 	}
 	return g, nil

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -306,7 +306,7 @@ func (s *GenerateSuite) SetupTest() {
 }
 
 func (s *GenerateSuite) TestParseProjectFromJSON() {
-	g, err := ParseProjectFromJSON([]byte(sampleGenerateTasksYml))
+	g, err := ParseProjectFromJSON(sampleGenerateTasksYml)
 	s.NotNil(g)
 	s.Nil(err)
 

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -69,11 +69,13 @@ var (
 	GenerateTaskKey           = bsonutil.MustHaveTag(Task{}, "GenerateTask")
 	GeneratedTasksKey         = bsonutil.MustHaveTag(Task{}, "GeneratedTasks")
 	GeneratedByKey            = bsonutil.MustHaveTag(Task{}, "GeneratedBy")
-	GeneratedJSONKey          = bsonutil.MustHaveTag(Task{}, "GeneratedJSON")
-	GenerateTasksErrorKey     = bsonutil.MustHaveTag(Task{}, "GenerateTasksError")
-	ResetWhenFinishedKey      = bsonutil.MustHaveTag(Task{}, "ResetWhenFinished")
-	LogsKey                   = bsonutil.MustHaveTag(Task{}, "Logs")
-	CommitQueueMergeKey       = bsonutil.MustHaveTag(Task{}, "CommitQueueMerge")
+	// TODO Remove GeneratedJSONKey after EVG-6759 is deployed
+	GeneratedJSONKey         = bsonutil.MustHaveTag(Task{}, "GeneratedJSON")
+	GeneratedJSONAsStringKey = bsonutil.MustHaveTag(Task{}, "GeneratedJSONAsString")
+	GenerateTasksErrorKey    = bsonutil.MustHaveTag(Task{}, "GenerateTasksError")
+	ResetWhenFinishedKey     = bsonutil.MustHaveTag(Task{}, "ResetWhenFinished")
+	LogsKey                  = bsonutil.MustHaveTag(Task{}, "Logs")
+	CommitQueueMergeKey      = bsonutil.MustHaveTag(Task{}, "CommitQueueMerge")
 
 	// BSON fields for the test result struct
 	TestResultStatusKey    = bsonutil.MustHaveTag(TestResult{}, "Status")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -683,7 +683,7 @@ func (t *Task) SetGeneratedJSON(json []json.RawMessage) error {
 		},
 		bson.M{
 			"$set": bson.M{
-				GeneratedJSONAsStringKey: json,
+				GeneratedJSONAsStringKey: s,
 			},
 		},
 	)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -152,8 +152,11 @@ type Task struct {
 	GeneratedTasks bool `bson:"generated_tasks,omitempty" json:"generated_tasks,omitempty"`
 	// GeneratedBy, if present, is the ID of the task that generated this task.
 	GeneratedBy string `bson:"generated_by,omitempty" json:"generated_by,omitempty"`
-	// GeneratedJSON is the the configuration information to create new tasks from.
+	// TODO Remove GeneratedJSON after EVG-6759 is deployed
+	// GeneratedJSON is the configuration information to create new tasks from.
 	GeneratedJSON []json.RawMessage `bson:"generate_json,omitempty" json:"generate_json,omitempty"`
+	// GeneratedJSONAsString is the configuration information to create new tasks from.
+	GeneratedJSONAsString []string `bson:"generated_json,omitempty" json:"generated_json,omitempty"`
 	// GenerateTasksError any encountered while generating tasks.
 	GenerateTasksError string `bson:"generate_error,omitempty" json:"generate_error,omitempty"`
 
@@ -657,25 +660,30 @@ func GenerateNotRun() ([]Task, error) {
 		StartTimeKey:      bson.M{"$gt": time.Now().Add(-maxGenerateTimeAgo)}, // ignore older tasks, just in case
 		GenerateTaskKey:   true,                                               // task contains generate.tasks command
 		GeneratedTasksKey: bson.M{"$exists": false},                           // generate.tasks has not yet run
-		GeneratedJSONKey:  bson.M{"$exists": true},                            // config has been posted by generate.tasks command
+		"$or": []bson.M{
+			bson.M{GeneratedJSONAsStringKey: bson.M{"$exists": true}}, // config has been posted by generate.tasks command
+			bson.M{GeneratedJSONKey: bson.M{"$exists": true}},         // TODO Remove after EVG-6759 is deployed
+		},
 	}))
 }
 
 // SetGeneratedJSON sets JSON data to generate tasks from.
 func (t *Task) SetGeneratedJSON(json []json.RawMessage) error {
-	if len(t.GeneratedJSON) > 0 {
+	if len(t.GeneratedJSONAsString) > 0 {
 		return nil
 	}
-	t.GeneratedJSON = json
+	s := []string{}
+	for _, j := range json {
+		s = append(s, string(j))
+	}
+	t.GeneratedJSONAsString = s
 	return UpdateOne(
 		bson.M{
 			IdKey: t.Id,
-			// If this field already is set, something has gone wrong.
-			GeneratedJSONKey: bson.M{"$exists": false},
 		},
 		bson.M{
 			"$set": bson.M{
-				GeneratedJSONKey: json,
+				GeneratedJSONAsStringKey: json,
 			},
 		},
 	)

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -2,7 +2,6 @@ package units
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -74,7 +73,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		return nil
 	}
 
-	projects, err := parseProjects(t.GeneratedJSON)
+	projects, err := parseProjects(t.GeneratedJSONAsString)
 	if err != nil {
 		return errors.Wrap(err, "error parsing JSON from `generate.tasks`")
 	}
@@ -167,10 +166,10 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 	}))
 }
 
-func parseProjects(jsonBytes []json.RawMessage) ([]model.GeneratedProject, error) {
+func parseProjects(jsonStrings []string) ([]model.GeneratedProject, error) {
 	catcher := grip.NewBasicCatcher()
 	var projects []model.GeneratedProject
-	for _, f := range jsonBytes {
+	for _, f := range jsonStrings {
 		p, err := model.ParseProjectFromJSON(f)
 		if err != nil {
 			catcher.Add(err)

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -2,7 +2,6 @@ package units
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -67,7 +66,7 @@ buildvariants:
       - name: generate-lint
 `
 
-var sampleGeneratedProject = []json.RawMessage{json.RawMessage(`
+var sampleGeneratedProject = []string{`
 {
   "buildvariants": [
     {
@@ -138,7 +137,7 @@ var sampleGeneratedProject = []json.RawMessage{json.RawMessage(`
       },
   ]
 }
-`)}
+`}
 
 func TestGenerateTasks(t *testing.T) {
 	assert := assert.New(t)
@@ -166,13 +165,13 @@ func TestGenerateTasks(t *testing.T) {
 	}
 	require.NoError(sampleBuild.Insert())
 	sampleTask := task.Task{
-		Id:            "sample_task",
-		Version:       "sample_version",
-		BuildId:       "sample_build_id",
-		Project:       "mci",
-		DisplayName:   "sample_task",
-		GeneratedJSON: sampleGeneratedProject,
-		Status:        evergreen.TaskStarted,
+		Id:                    "sample_task",
+		Version:               "sample_version",
+		BuildId:               "sample_build_id",
+		Project:               "mci",
+		DisplayName:           "sample_task",
+		GeneratedJSONAsString: sampleGeneratedProject,
+		Status:                evergreen.TaskStarted,
 	}
 	sampleDistros := []distro.Distro{
 		distro.Distro{


### PR DESCRIPTION
Although storing bytes is convenient, since it means that you never have to
convert to and from byte slices, it makes it difficult for a human being to
examine the task document in the database to find out the contents of the
generator.