### PR TITLE
EVG-6408 fix CostCalculator not implemented errors

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1187,12 +1187,7 @@ func (m *ec2Manager) CostForDuration(ctx context.Context, h *host.Host, start, e
 	if end.Before(start) || util.IsZeroTime(start) || util.IsZeroTime(end) {
 		return 0, errors.New("task timing data is malformed")
 	}
-	ec2Settings := &EC2ProviderSettings{}
-	err := ec2Settings.fromDistroSettings(h.Distro)
-	if err != nil {
-		return 0, errors.Wrap(err, "problem getting region from host")
-	}
-	if err = m.client.Create(m.credentials, m.region); err != nil {
+	if err := m.client.Create(m.credentials, m.region); err != nil {
 		return 0, errors.Wrap(err, "error creating client")
 	}
 	defer m.client.Close()

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -327,6 +327,34 @@ func (m *ec2FleetManager) TimeTilNextPayment(h *host.Host) time.Duration {
 	return timeTilNextEC2Payment(h)
 }
 
+func (m *ec2FleetManager) CostForDuration(ctx context.Context, h *host.Host, start, end time.Time) (float64, error) {
+	if end.Before(start) || util.IsZeroTime(start) || util.IsZeroTime(end) {
+		return 0, errors.New("task timing data is malformed")
+	}
+
+	if err := m.client.Create(m.credentials, m.region); err != nil {
+		return 0, errors.Wrap(err, "error creating client")
+	}
+	defer m.client.Close()
+
+	t := timeRange{start: start, end: end}
+	ec2Cost, err := pkgCachingPriceFetcher.getEC2Cost(ctx, m.client, h, t)
+	if err != nil {
+		return 0, errors.Wrap(err, "error fetching ec2 cost")
+	}
+	ebsCost, err := pkgCachingPriceFetcher.getEBSCost(ctx, m.client, h, t)
+	if err != nil {
+		return 0, errors.Wrap(err, "error fetching ebs cost")
+	}
+	total := ec2Cost + ebsCost
+
+	if total < 0 {
+		return 0, errors.Errorf("cost appears to be less than 0 (%g) which is impossible", total)
+	}
+
+	return total, nil
+}
+
 func (m *ec2FleetManager) spawnFleetSpotHost(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings, blockDevices []*ec2.LaunchTemplateBlockDeviceMappingRequest) error {
 	// Cleanup
 	var templateID *string

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -148,6 +149,21 @@ func TestFleet(t *testing.T) {
 				AvailabilityZone: aws.String("us-east-1a"),
 			}
 			assert.True(t, subnetMatchesAz(subnet))
+		},
+		"CostForDuration": func(*testing.T) {
+			start := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+			end := start.Add(time.Duration(time.Hour * 24))
+			h := &host.Host{
+				ComputeCostPerHour: float64(1),
+				VolumeTotalSize:    int64(30),
+				Zone:               "us-east-1a",
+			}
+			pkgCachingPriceFetcher.ebsPrices = make(map[string]float64)
+			pkgCachingPriceFetcher.ebsPrices["us-east-1"] = float64(1)
+
+			cost, err := m.CostForDuration(context.Background(), h, start, end)
+			assert.NoError(t, err)
+			assert.EqualValues(t, 25, cost)
 		},
 	} {
 		h = &host.Host{

--- a/units/stats_host_idle.go
+++ b/units/stats_host_idle.go
@@ -163,7 +163,8 @@ func (j *collectHostIdleDataJob) incrementCostForDuration(ctx context.Context) (
 
 	calc, ok := j.manager.(cloud.CostCalculator)
 	if !ok {
-		return 0, errors.Errorf("manager of type '%T' isn't a cost calculator", j.manager)
+		// return early if we can't get the cost
+		return 0, nil
 	}
 
 	cost, err := calc.CostForDuration(ctx, j.host, j.StartTime, j.FinishTime)

--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -168,7 +168,8 @@ func (j *collectTaskEndDataJob) recordTaskCost(ctx context.Context) error {
 
 	calc, ok := manager.(cloud.CostCalculator)
 	if !ok {
-		return errors.Errorf("manager of type '%T' is not a cost calculator", manager)
+		// return early if we can't get the cost
+		return nil
 	}
 	cost, err := calc.CostForDuration(ctx, j.host, j.task.StartTime, j.task.FinishTime)
 	if err != nil {


### PR DESCRIPTION
#2898 caused the case where CostCalculator wasn't implemented to error, and we want to ignore the error. 
Logging the error brought to light that Fleet doesn't implement the interface, so this fixes that too.