### PR TITLE
EVG-6549 allow toggling expanded metrics in perf discovery

### DIFF
--- a/public/static/app/common/ApiTaskdata.js
+++ b/public/static/app/common/ApiTaskdata.js
@@ -1,18 +1,24 @@
-mciModule.factory('ApiTaskdata', function($http, $filter, ApiUtil, API_TASKDATA, CEDAR_APP_URL) {
-  const  get = ApiUtil.httpGetter(API_TASKDATA.BASE);
+mciModule.factory('ApiTaskdata', function ($http, $filter, ApiUtil, API_TASKDATA, CEDAR_APP_URL) {
+  const get = ApiUtil.httpGetter(API_TASKDATA.BASE);
   const cedarAPI = ApiUtil.httpGetter(CEDAR_APP_URL);
 
   return {
     cedarAPI: cedarAPI,
-    getTaskById: function(taskId, name) {
-      return get(API_TASKDATA.TASK_BY_ID, {task_id: taskId, name: name})
+    getTaskById: function (taskId, name) {
+      return get(API_TASKDATA.TASK_BY_ID, {
+        task_id: taskId,
+        name: name
+      })
     },
 
-    getTaskHistory: function(taskId, name) {
-      return get(API_TASKDATA.TASK_HISTORY, {task_id: taskId, name: name})
+    getTaskHistory: function (taskId, name) {
+      return get(API_TASKDATA.TASK_HISTORY, {
+        task_id: taskId,
+        name: name
+      })
     },
 
-    getTaskByCommit: function(param) {
+    getTaskByCommit: function (param) {
       // Optional TODO Assert params
       return get(API_TASKDATA.TASK_BY_COMMIT, {
         project_id: param.projectId,
@@ -23,7 +29,7 @@ mciModule.factory('ApiTaskdata', function($http, $filter, ApiUtil, API_TASKDATA,
       })
     },
 
-    getTaskByTag: function(param) {
+    getTaskByTag: function (param) {
       // Optional TODO Assert params
       return get(API_TASKDATA.TASK_BY_TAG, {
         project_id: param.projectId,
@@ -34,11 +40,13 @@ mciModule.factory('ApiTaskdata', function($http, $filter, ApiUtil, API_TASKDATA,
       })
     },
 
-    getProjectTags: function(projectId) {
-      return get(API_TASKDATA.PROJECT_TAGS, {}, {project_id: projectId})
+    getProjectTags: function (projectId) {
+      return get(API_TASKDATA.PROJECT_TAGS, {}, {
+        project_id: projectId
+      })
     },
 
-    getExpandedTaskById: function(taskId) {
+    getExpandedTaskById: function (taskId) {
       return cedarAPI("rest/v1/perf/task_id/" + taskId);
     },
   }

--- a/public/static/app/common/ApiTaskdata.js
+++ b/public/static/app/common/ApiTaskdata.js
@@ -46,8 +46,16 @@ mciModule.factory('ApiTaskdata', function ($http, $filter, ApiUtil, API_TASKDATA
       })
     },
 
-    getExpandedTaskById: function (taskId) {
-      return cedarAPI("rest/v1/perf/task_id/" + taskId);
+    getExpandedTaskById: function (taskId, name) {
+      return cedarAPI("rest/v1/perf/task_id/" + taskId).then(resp => {
+        return $filter("expandedMetricConverter")(resp.data); // note: this will filter data to just the latest execution
+      });
+    },
+
+    getExpandedHistory: function (taskName, variant, project) {
+      return cedarAPI("rest/v1/perf/task_name/" + taskName + "?variant=" + variant + "&project=" + project).then(resp => {
+        return $filter("expandedHistoryConverter")(resp.data); // note: this will filter data to just the latest execution
+      });
     },
   }
 })

--- a/public/static/app/common/ApiTaskdata.js
+++ b/public/static/app/common/ApiTaskdata.js
@@ -47,15 +47,13 @@ mciModule.factory('ApiTaskdata', function ($http, $filter, ApiUtil, API_TASKDATA
     },
 
     getExpandedTaskById: function (taskId, name) {
-      return cedarAPI("rest/v1/perf/task_id/" + taskId).then(resp => {
-        return $filter("expandedMetricConverter")(resp.data); // note: this will filter data to just the latest execution
-      });
+      // note: this will filter data to just the latest execution
+      return cedarAPI("rest/v1/perf/task_id/" + taskId).then(resp => $filter("expandedMetricConverter")(resp.data));
     },
 
     getExpandedHistory: function (taskName, variant, project) {
-      return cedarAPI("rest/v1/perf/task_name/" + taskName + "?variant=" + variant + "&project=" + project).then(resp => {
-        return $filter("expandedHistoryConverter")(resp.data); // note: this will filter data to just the latest execution
-      });
+      // note: this will filter data to just the latest execution
+      return cedarAPI("rest/v1/perf/task_name/" + taskName + "?variant=" + variant + "&project=" + project).then(resp => $filter("expandedHistoryConverter")(resp.data));
     },
   }
 })

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -98,8 +98,12 @@ $http.get(templateUrl).success(function(template) {
 
   $scope.deleteTag = function () {
     $http.delete("/plugin/json/task/" + $scope.task.id + "/perf/tag").then(
-      function (resp) { delete $scope.perfTagData.tag; },
-      function () { console.log("error") }
+      function (resp) {
+        delete $scope.perfTagData.tag;
+      },
+      function () {
+        console.log("error")
+      }
     );
   }
 
@@ -110,16 +114,24 @@ $http.get(templateUrl).success(function(template) {
   $scope.task = $window.task_data;
   $scope.tablemode = 'maxthroughput';
   $scope.threadLevelsRadio = {
-    options: [
-      { key: 'maxonly', val: 'Max Only' },
-      { key: 'all', val: 'All' }
+    options: [{
+        key: 'maxonly',
+        val: 'Max Only'
+      },
+      {
+        key: 'all',
+        val: 'All'
+      }
     ],
     value: Settings.perf.trendchart.threadLevelMode,
   }
 
   $scope.metricSelect = {
     options: [],
-    default: { key: 'ops_per_sec', name: 'ops/sec (Default)' },
+    default: {
+      key: 'ops_per_sec',
+      name: 'ops/sec (Default)'
+    },
     value: undefined,
   }
   $scope.metricSelect.options.push($scope.metricSelect.default)
@@ -258,14 +270,41 @@ $http.get(templateUrl).success(function(template) {
 
   // converts a percentage to a color. Higher -> greener, Lower -> redder.
   $scope.percentToColor = function (percent) {
-    var percentColorRanges = [
-      { min: -Infinity, max: -15, color: "#FF0000" },
-      { min: -15, max: -10, color: "#FF5500" },
-      { min: -10, max: -5, color: "#FFAA00" },
-      { min: -5, max: -2.5, color: "#FEFF00" },
-      { min: -2.5, max: 5, color: "#A9FF00" },
-      { min: 5, max: 10, color: "#54FF00" },
-      { min: 10, max: +Infinity, color: "#00FF00" }
+    var percentColorRanges = [{
+        min: -Infinity,
+        max: -15,
+        color: "#FF0000"
+      },
+      {
+        min: -15,
+        max: -10,
+        color: "#FF5500"
+      },
+      {
+        min: -10,
+        max: -5,
+        color: "#FFAA00"
+      },
+      {
+        min: -5,
+        max: -2.5,
+        color: "#FEFF00"
+      },
+      {
+        min: -2.5,
+        max: 5,
+        color: "#A9FF00"
+      },
+      {
+        min: 5,
+        max: 10,
+        color: "#54FF00"
+      },
+      {
+        min: 10,
+        max: +Infinity,
+        color: "#00FF00"
+      }
     ];
 
     for (var i = 0; i < percentColorRanges.length; i++) {
@@ -294,7 +333,12 @@ $http.get(templateUrl).success(function(template) {
       var testName = testNames[i];
       $("#chart-" + cleanId(taskId) + "-" + i).empty();
       var series1 = sample.threadsVsOps(testName);
-      var margin = { top: 20, right: 50, bottom: 30, left: 80 };
+      var margin = {
+        top: 20,
+        right: 50,
+        bottom: 30,
+        left: 80
+      };
       var width = 450 - margin.left - margin.right;
       var height = 200 - margin.top - margin.bottom;
       var id = "chart-" + cleanId(taskId) + "-" + i;
@@ -338,7 +382,9 @@ $http.get(templateUrl).success(function(template) {
       var bar = svg.selectAll("g")
         .data(series)
         .enter().append("g")
-        .style("fill", function (d, i) { return z(i); })
+        .style("fill", function (d, i) {
+          return z(i);
+        })
         .attr("transform", function (d, i) {
           let x = x1(i);
           if (Number.isNaN(x)) {
@@ -348,7 +394,9 @@ $http.get(templateUrl).success(function(template) {
         });
 
       bar.selectAll("rect")
-        .data(function (d) { return d })
+        .data(function (d) {
+          return d
+        })
         .enter().append("rect")
         .attr('stroke', 'black')
         .attr('x', function (d, i) {
@@ -419,24 +467,34 @@ $http.get(templateUrl).success(function(template) {
           .data(series)
           .enter()
           .append("rect")
-          .attr("fill", function (d, i) { return z(i) })
-          .attr("x", function (d, i) { return 0 })
-          .attr("y", function (d, i) { return 5 + legend_y(i) })
+          .attr("fill", function (d, i) {
+            return z(i)
+          })
+          .attr("x", function (d, i) {
+            return 0
+          })
+          .attr("y", function (d, i) {
+            return 5 + legend_y(i)
+          })
           .attr("width", legendWidth / 3)
           .attr("height", legend_y.rangeBand());
         svg.selectAll("text")
           .data(series)
           .enter()
           .append("text")
-          .attr("x", function (d, i) { return (legendWidth / 3) + 10 })
-          .attr("y", function (d, i) { return legend_y(i) })
+          .attr("x", function (d, i) {
+            return (legendWidth / 3) + 10
+          })
+          .attr("y", function (d, i) {
+            return legend_y(i)
+          })
           .attr("dy", legend_y.rangeBand())
           .attr("class", "mono")
           .text(function (d, i) {
             if (i == 0) {
               return "this task";
             } else {
-              return compareSamples[i - 1].getLegendName()//series.legendName
+              return compareSamples[i - 1].getLegendName() //series.legendName
             }
           });
       }
@@ -474,7 +532,9 @@ $http.get(templateUrl).success(function(template) {
   }
 
   $scope.getSampleAtCommit = function (series, commit) {
-    return _.find(series, function (x) { return x.revision == commit });
+    return _.find(series, function (x) {
+      return x.revision == commit
+    });
   }
 
   $scope.getCommits = function (seriesByName) {
@@ -485,9 +545,15 @@ $http.get(templateUrl).success(function(template) {
 
   $scope.setTaskTag = function (keyEvent) {
     if (keyEvent.which === 13) {
-      $http.post("/plugin/json/task/" + $scope.task.id + "/perf/tag", { tag: $scope.perfTagData.input }).then(
-        function (resp) { $scope.perfTagData.tag = $scope.perfTagData.input },
-        function () { console.log("error") }
+      $http.post("/plugin/json/task/" + $scope.task.id + "/perf/tag", {
+        tag: $scope.perfTagData.input
+      }).then(
+        function (resp) {
+          $scope.perfTagData.tag = $scope.perfTagData.input
+        },
+        function () {
+          console.log("error")
+        }
       );
     }
     return true
@@ -520,7 +586,9 @@ $http.get(templateUrl).success(function(template) {
           $scope.comparePerfSamples.push(compareSample)
           if (draw) $scope.redrawGraphs()
         },
-        function (resp) { console.log(resp.data) });
+        function (resp) {
+          console.log(resp.data)
+        });
     } else if (Boolean(formData.tag) && formData.tag.length > 0) {
       $http.get("/plugin/json/tag/" + $scope.project + "/" + formData.tag + "/" + $scope.task.build_variant + "/" + $scope.task.display_name + "/perf").then(
         function (resp) {
@@ -529,7 +597,9 @@ $http.get(templateUrl).success(function(template) {
           $scope.comparePerfSamples.push(compareSample)
           if (draw) $scope.redrawGraphs()
         },
-        function (resp) { console.log(resp.data) });
+        function (resp) {
+          console.log(resp.data)
+        });
     }
 
     $scope.compareForm = {}
@@ -546,7 +616,9 @@ $http.get(templateUrl).success(function(template) {
   }
 
   $scope.addComparisonHash = function (hash) {
-    $scope.addComparisonForm({ hash: hash }, true)
+    $scope.addComparisonForm({
+      hash: hash
+    }, true)
   }
 
   $scope.redrawGraphs = function () {
@@ -565,8 +637,10 @@ $http.get(templateUrl).success(function(template) {
       let series = samples.seriesByName;
       $scope.hiddenGraphs = {};
       _.each(series, function (testResults, testName) {
-        if (_.some(testResults, (singleResult) => { return singleResult[metric] })) {
-          delete ($scope.hiddenGraphs[testName]);
+        if (_.some(testResults, (singleResult) => {
+            return singleResult[metric]
+          })) {
+          delete($scope.hiddenGraphs[testName]);
         } else {
           $scope.hiddenGraphs[testName] = true;
         }
@@ -590,7 +664,9 @@ $http.get(templateUrl).success(function(template) {
 
   // Once the task data has been loaded
   $scope.processAndDrawGraphs = function () {
-    setTimeout(function () { drawDetailGraph($scope.perfSample, $scope.comparePerfSamples, $scope.task.id, $scope.metricSelect.value.key) }, 0);
+    setTimeout(function () {
+      drawDetailGraph($scope.perfSample, $scope.comparePerfSamples, $scope.task.id, $scope.metricSelect.value.key)
+    }, 0);
 
     const project = $scope.task.branch;
     const task_name = $scope.task.display_name;
@@ -636,7 +712,7 @@ $http.get(templateUrl).success(function(template) {
             $scope.addComparisonForm(hashparsed.compare[i], false)
           }
         }
-      } catch (e) { }
+      } catch (e) {}
     }
     // Populate the graph and table for this task
     var legacySuccess = function (toMerge, resp) {
@@ -663,7 +739,9 @@ $http.get(templateUrl).success(function(template) {
     $http.get("/plugin/json/task/" + $scope.task.id + "/perf/tags").then(
       function (resp) {
         const d = resp.data;
-        $scope.tags = d.sort(function (a, b) { return a.tag.localeCompare(b.tag) })
+        $scope.tags = d.sort(function (a, b) {
+          return a.tag.localeCompare(b.tag)
+        })
       });
 
     if ($scope.task.patch_info && $scope.task.patch_info.Patch.Githash) {
@@ -674,7 +752,9 @@ $http.get(templateUrl).success(function(template) {
 }).factory('trendDataComplete', function ($location, TrendSamples) {
   // Create a callback function to handle
   return function (scope, data) {
-    const {legacy = [], cedar = []} = data;
+    const {
+      legacy = [], cedar = []
+    } = data;
 
     if (!scope.trendResults.length && scope.perfSample && scope.perfSample.sample) {
       scope.trendResults = scope.trendResults.concat(scope.perfSample.sample);
@@ -702,7 +782,10 @@ $http.get(templateUrl).success(function(template) {
     }
     scope.metricSelect.options = scope.metricSelect.options.concat(
       _.map(
-        _.without(scope.allTrendSamples.metrics, scope.metricSelect.default.key), d => ({ key: d, name: d }))
+        _.without(scope.allTrendSamples.metrics, scope.metricSelect.default.key), d => ({
+          key: d,
+          name: d
+        }))
     );
     scope.metricSelect.options = _.uniq(scope.metricSelect.options, false, function (option) {
       return option.key;
@@ -713,9 +796,11 @@ $http.get(templateUrl).success(function(template) {
       if ($location.hash().length > 0) {
         try {
           if ('metric' in hashparsed) {
-            scope.metricSelect.value = _.findWhere(scope.metricSelect.options, { key: hashparsed.metric }) || scope.metricSelect.default
+            scope.metricSelect.value = _.findWhere(scope.metricSelect.options, {
+              key: hashparsed.metric
+            }) || scope.metricSelect.default
           }
-        } catch (e) { }
+        } catch (e) {}
       }
     }
     return data;
@@ -727,8 +812,15 @@ $http.get(templateUrl).success(function(template) {
   return function (project, variant, task) {
     // Get a list of rejected points.
     const points = PointsDataService.getOutlierPointsQ(project, variant, task);
-    const whitelist= WhitelistDataService.getWhitelistQ({ project, variant, task });
-    return $q.all({ points, whitelist });
+    const whitelist = WhitelistDataService.getWhitelistQ({
+      project,
+      variant,
+      task
+    });
+    return $q.all({
+      points,
+      whitelist
+    });
   }
 }).factory('loadTrendData', function ($http, $filter, $q, $log, ApiTaskdata) {
   // Attempt to load historical performance data from both the following sources:
@@ -742,11 +834,14 @@ $http.get(templateUrl).success(function(template) {
       .catch(err => $log.warn('error loading legacy data', err));
 
     const cedar = ApiTaskdata.cedarAPI("/rest/v1/perf/task_name/" + task +
-      "?variant=" + variant + "&project=" + project)
+        "?variant=" + variant + "&project=" + project)
       .then(resp => $filter("expandedHistoryConverter")(resp.data, scope.task.execution))
       .catch(err => $log.warn('error loading cedar data', err));
 
-    return $q.all({legacy, cedar});
+    return $q.all({
+      legacy,
+      cedar
+    });
   }
 }).factory('loadChangePoints', function ($q, loadUnprocessed, loadProcessed) {
   return function (scope, project, variant, task) {
@@ -758,11 +853,20 @@ $http.get(templateUrl).success(function(template) {
     // Wait for processed / unprocessed and then merge processed and unprocessed change points.
     // Processed ones always have a priority (in situations, when the revision has one processed
     // and one unprocessed point).
-    return $q.all({ processed, unprocessed }).then(function (points) {
-      const { processed, unprocessed } = points;
+    return $q.all({
+      processed,
+      unprocessed
+    }).then(function (points) {
+      const {
+        processed,
+        unprocessed
+      } = points;
       const docs = _.reduce(unprocessed, function (m, d) {
         // If there are no processed change point with same revision and test
-        if (!_.findWhere(m, { suspect_revision: d.suspect_revision , test: d.test })) {
+        if (!_.findWhere(m, {
+            suspect_revision: d.suspect_revision,
+            test: d.test
+          })) {
           return m.concat(d);
         }
         return m;
@@ -778,7 +882,11 @@ $http.get(templateUrl).success(function(template) {
       return db
         .db(STITCH_CONFIG.PERF.DB_PERF)
         .collection(STITCH_CONFIG.PERF.COLL_PROCESSED_POINTS)
-        .find({ project, variant, task})
+        .find({
+          project,
+          variant,
+          task
+        })
         .execute();
     }).then(
       docs => docs,
@@ -890,25 +998,52 @@ $http.get(templateUrl).success(function(template) {
   return function (project, variant, task) {
     // Load revisions to orders from the points collection.
     // const task_identifier = { project: $scope.task.branch, task: $scope.task.display_name, variant: $scope.task.build_variant };
-    const task_identifier = { project: project, variant: variant, task: task };
-    const pipeline = [
-      { $match: { project: project } },
-      {
-        "$group": {
-          "_id": { revision: "$revision", order: '$order' },
-          "tasks": { $addToSet: { project: '$project', variant: '$variant', task: '$task' } }
+    const task_identifier = {
+      project: project,
+      variant: variant,
+      task: task
+    };
+    const pipeline = [{
+        $match: {
+          project: project
         }
       },
-      { $project: { revision: '$_id.revision', order: '$_id.order', tasks: 1, _id: 0 } },
-      { $sort: { order: 1 } }
+      {
+        "$group": {
+          "_id": {
+            revision: "$revision",
+            order: '$order'
+          },
+          "tasks": {
+            $addToSet: {
+              project: '$project',
+              variant: '$variant',
+              task: '$task'
+            }
+          }
+        }
+      },
+      {
+        $project: {
+          revision: '$_id.revision',
+          order: '$_id.order',
+          tasks: 1,
+          _id: 0
+        }
+      },
+      {
+        $sort: {
+          order: 1
+        }
+      }
     ];
 
     return Stitch.use(STITCH_CONFIG.PERF).query(function (db) {
-      return db
-        .db(STITCH_CONFIG.PERF.DB_PERF)
-        .collection(STITCH_CONFIG.PERF.COLL_POINTS)
-        .aggregate(pipeline);
-    }).catch(err => null)
+        return db
+          .db(STITCH_CONFIG.PERF.DB_PERF)
+          .collection(STITCH_CONFIG.PERF.COLL_POINTS)
+          .aggregate(pipeline);
+      }).catch(err => null)
       .then((points) => new RevisionsMapper(points, task_identifier))
   }
 }).factory('loadBuildFailures', function ($log, Stitch, STITCH_CONFIG, loadRevisions) {
@@ -919,8 +1054,7 @@ $http.get(templateUrl).success(function(template) {
       return db
         .db(STITCH_CONFIG.PERF.DB_PERF)
         .collection(STITCH_CONFIG.PERF.COLL_BUILD_FAILURES)
-        .aggregate([
-          {
+        .aggregate([{
             $match: {
               project: project,
               buildvariants: variant,
@@ -928,8 +1062,18 @@ $http.get(templateUrl).success(function(template) {
             }
           },
           // Denormalization
-          { $unwind: { path: '$tests', preserveNullAndEmptyArrays: true } },
-          { $unwind: { path: '$first_failing_revision', preserveNullAndEmptyArrays: true } },
+          {
+            $unwind: {
+              path: '$tests',
+              preserveNullAndEmptyArrays: true
+            }
+          },
+          {
+            $unwind: {
+              path: '$first_failing_revision',
+              preserveNullAndEmptyArrays: true
+            }
+          },
         ]);
     }).then(
       docs => {
@@ -949,7 +1093,7 @@ $http.get(templateUrl).success(function(template) {
                 doc.order = order;
               }
             }
-            doc.revisions = doc.orders.map(order => (scope.lookups.allOrdersMap[order]  || null))
+            doc.revisions = doc.orders.map(order => (scope.lookups.allOrdersMap[order] || null))
           });
           scope.buildFailures = _.groupBy(docs, 'tests');
           return scope.buildFailures;

--- a/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
+++ b/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
@@ -1,4 +1,4 @@
-mciModule.factory('PerfDiscoveryDataService', function(
+mciModule.factory('PerfDiscoveryDataService', function (
   $q, $window, ApiV1, ApiV2, ApiTaskdata, BF, EVG, MPA_UI,
   PERF_DISCOVERY, Stitch, STITCH_CONFIG
 ) {
@@ -8,7 +8,7 @@ mciModule.factory('PerfDiscoveryDataService', function(
    * UTILITY FUNCTIONS *
    *********************/
 
-  var respData = function(resp) {
+  var respData = function (resp) {
     return resp.data
   }
 
@@ -33,7 +33,7 @@ mciModule.factory('PerfDiscoveryDataService', function(
   }
 
   function noBaselineFilter(results) {
-    return function(item, id) {
+    return function (item, id) {
       return results.baseline[id] == undefined
     }
   }
@@ -51,7 +51,7 @@ mciModule.factory('PerfDiscoveryDataService', function(
   }
 
   function githashToVersionId(githash) {
-    return $window.project.replace('sys-perf','sys_perf') + '_' + githash
+    return $window.project.replace('sys-perf', 'sys_perf') + '_' + githash
   }
 
   // For given `query` attempts to construct valid selctable
@@ -108,21 +108,25 @@ mciModule.factory('PerfDiscoveryDataService', function(
 
     return _.chain(item.results)
       .omit(_.isString)
-      .each(function(speed, threads) {
+      .each(function (speed, threads) {
         var data = {
           build: ctx.buildName,
           buildId: ctx.buildId,
           buildVariant: ctx.buildVariant,
           task: ctx.taskName,
-          taskURL: MPA_UI.TASK_BY_ID({task_id: ctx.taskId}),
-          buildURL: MPA_UI.BUILD_BY_ID({build_id: ctx.buildId}),
+          taskURL: MPA_UI.TASK_BY_ID({
+            task_id: ctx.taskId
+          }),
+          buildURL: MPA_UI.BUILD_BY_ID({
+            build_id: ctx.buildId
+          }),
           taskId: ctx.taskId,
           test: item.name,
           threads: +threads,
           speed: speed.ops_per_sec,
           storageEngine: ctx.storageEngine,
         }
-        receiver[slug(data)] =  data
+        receiver[slug(data)] = data
       })
   }
 
@@ -136,9 +140,11 @@ mciModule.factory('PerfDiscoveryDataService', function(
   //   {...}
   // ]
   function onProcessData(data) {
-    var now = {}, baseline = {}, history = {}
+    var now = {},
+      baseline = {},
+      history = {}
 
-    _.each(data, function(d) {
+    _.each(data, function (d) {
       // Skip empty items
       if (d == null) return
 
@@ -148,26 +154,26 @@ mciModule.factory('PerfDiscoveryDataService', function(
         // Copy storageEngine to the context
         d.ctx.storageEngine = d.current.data.storageEngine || '(none)'
 
-        _.each(d.current.data.results, function(result) {
+        _.each(d.current.data.results, function (result) {
           processItem(result, now, d.ctx)
         })
       }
 
       // Process baseline data
       if (d.baseline) {
-        _.each(d.baseline.data.results, function(result) {
+        _.each(d.baseline.data.results, function (result) {
           processItem(result, baseline, d.ctx)
         })
       }
 
       // Process history data
-      _.each(d.history, function(histItems) {
+      _.each(d.history, function (histItems) {
         // Create an empty 'bucket' for history items if not exists
         var order = histItems.order
         if (history[order] == undefined) {
           history[order] = {}
         }
-        _.each(histItems.data.results, function(result) {
+        _.each(histItems.data.results, function (result) {
           processItem(result, history[order], d.ctx)
         })
       })
@@ -179,7 +185,9 @@ mciModule.factory('PerfDiscoveryDataService', function(
       // Sorts history items by `order` and returns the list
       history: _.map(
         _.sortBy(_.keys(history)),
-        function(key) { return history[key] }
+        function (key) {
+          return history[key]
+        }
       ),
     }
   }
@@ -187,7 +195,7 @@ mciModule.factory('PerfDiscoveryDataService', function(
   function onGetRows(results) {
     return _.chain(results.now)
       .omit(noBaselineFilter(results))
-      .map(function(item, id) {
+      .map(function (item, id) {
         var baseline = results.baseline[id]
         var appendix = {
           ratio: ratio(item.speed, baseline.speed),
@@ -196,7 +204,7 @@ mciModule.factory('PerfDiscoveryDataService', function(
 
         var trendData = _.chain(results.history)
           .take(100)
-          .map(function(run) {
+          .map(function (run) {
             var base = run[id]
             if (base == undefined || !base.speed) {
               return 1
@@ -220,9 +228,9 @@ mciModule.factory('PerfDiscoveryDataService', function(
   // :parm version: version object
   // :returns: Array of {taskId, taskName, buildName}
   function extractTasks(version) {
-    return _.reduce(version.builds, function(items, build) {
+    return _.reduce(version.builds, function (items, build) {
       // Going over dict of tasks ({taskName: data})
-      return items.concat(_.map(build.tasks, function(taskData, taskName) {
+      return items.concat(_.map(build.tasks, function (taskData, taskName) {
         return {
           taskId: taskData.task_id,
           buildId: build.id,
@@ -236,24 +244,31 @@ mciModule.factory('PerfDiscoveryDataService', function(
 
   function queryBuildData(version) {
     return $q.all(
-      _.map(version.build_variants_status, function(d) {
+      _.map(version.build_variants_status, function (d) {
         return ApiV1.getBuildDetail(d.build_id).then(
-          respData, function(e) { return {} }
+          respData,
+          function (e) {
+            return {}
+          }
         )
       })
     )
   }
 
   function tasksOfBuilds(promise) {
-    return promise.then(function(builds) {
-      return extractTasks({builds: builds})
+    return promise.then(function (builds) {
+      return extractTasks({
+        builds: builds
+      })
     })
   }
 
   function versionSelectAdaptor(versionsRes) {
     return _.chain(versionsRes.data.versions)
-      .where({rolled_up: false})
-      .map(function(d) {
+      .where({
+        rolled_up: false
+      })
+      .map(function (d) {
         return {
           kind: PD.KIND_VERSION,
           id: d.versions[0].version_id,
@@ -264,8 +279,12 @@ mciModule.factory('PerfDiscoveryDataService', function(
   }
 
   function tagSelectAdaptor(tagsRes) {
-    return _.map(tagsRes.data, function(d) {
-      return {kind: PD.KIND_TAG, id: d.obj.version_id, name: d.name}
+    return _.map(tagsRes.data, function (d) {
+      return {
+        kind: PD.KIND_TAG,
+        id: d.obj.version_id,
+        name: d.name
+      }
     })
   }
 
@@ -278,24 +297,26 @@ mciModule.factory('PerfDiscoveryDataService', function(
   function postprocessBFs(bfs) {
     return _.chain(bfs)
       // Group all BFs by task, bv and test
-      .groupBy(function(bf) {
+      .groupBy(function (bf) {
         return [bf.tasks, bf.buildvariants, bf.tests && ''].join('|')
       })
       // In each group, sort by status/date and mark 'open' items
-      .map(function(bfsGroup) {
+      .map(function (bfsGroup) {
         return _.chain(bfsGroup)
           // Split Bfs into two category 'Open' and 'not open'
-          .partition(function(bf) {
+          .partition(function (bf) {
             return _.contains(BF.OPEN_STATUSES, bf.status)
           })
           // Sort BFs in each split by date created
-          .map(function(bfs) {
+          .map(function (bfs) {
             return _.sortBy(bfs, '-created')
           })
           // Kind of minor optimisation - sets _isOpen to true for
           // each BF which was considered to be open on the first stage
-          .each(function(bfs, idx) {
-            idx == 0 && _.each(bfs, function(bf) { bf._isOpen = true })
+          .each(function (bfs, idx) {
+            idx == 0 && _.each(bfs, function (bf) {
+              bf._isOpen = true
+            })
           })
           // Merging two splits into single array of BFs
           .flatten(true)
@@ -312,24 +333,54 @@ mciModule.factory('PerfDiscoveryDataService', function(
   // :rtype: $q.promise({taskId: {key, link}, ...})
   function getBFTicketsForRows(rows) {
     var uniqueTasks = _.chain(rows)
-      .uniq(false, function(d) {
+      .uniq(false, function (d) {
         return d.task
       })
       .pluck('task')
       .value()
 
-    return Stitch.use(STITCH_CONFIG.PERF).query(function(client) {
+    return Stitch.use(STITCH_CONFIG.PERF).query(function (client) {
       return client
         .db(STITCH_CONFIG.PERF.DB_PERF)
         .collection(STITCH_CONFIG.PERF.COLL_BUILD_FAILURES)
-        .aggregate([
-          {$match: {tasks: {$in: uniqueTasks}}},
+        .aggregate([{
+            $match: {
+              tasks: {
+                $in: uniqueTasks
+              }
+            }
+          },
           // Denormalization
-          {$unwind: {path: '$tasks', preserveNullAndEmptyArrays: true}},
-          {$unwind: {path: '$buildvariants', preserveNullAndEmptyArrays: true}},
-          {$unwind: {path: '$project', preserveNullAndEmptyArrays: true}},
-          {$unwind: {path: '$tests', preserveNullAndEmptyArrays: true}},
-          {$unwind: {path: '$first_failing_revision', preserveNullAndEmptyArrays: true}},
+          {
+            $unwind: {
+              path: '$tasks',
+              preserveNullAndEmptyArrays: true
+            }
+          },
+          {
+            $unwind: {
+              path: '$buildvariants',
+              preserveNullAndEmptyArrays: true
+            }
+          },
+          {
+            $unwind: {
+              path: '$project',
+              preserveNullAndEmptyArrays: true
+            }
+          },
+          {
+            $unwind: {
+              path: '$tests',
+              preserveNullAndEmptyArrays: true
+            }
+          },
+          {
+            $unwind: {
+              path: '$first_failing_revision',
+              preserveNullAndEmptyArrays: true
+            }
+          },
         ])
     }).then(postprocessBFs)
   }
@@ -340,11 +391,13 @@ mciModule.factory('PerfDiscoveryDataService', function(
     return $q.all({
       tasks: tasksPromise,
       baselineTasks: baselineTasks
-    }).then(function(promise) {
-      return $q.all(_.map(promise.tasks, function(task) {
+    }).then(function (promise) {
+      return $q.all(_.map(promise.tasks, function (task) {
         return ApiTaskdata.getTaskById(task.taskId, 'perf')
-          .then(respData, function() { return null })
-          .then(function(data) {
+          .then(respData, function () {
+            return null
+          })
+          .then(function (data) {
             if (data) {
               var baseline = _.findWhere(promise.baselineTasks, {
                 buildName: task.buildName,
@@ -357,9 +410,13 @@ mciModule.factory('PerfDiscoveryDataService', function(
                 ctx: $q.resolve(task),
                 current: data,
                 history: ApiTaskdata.getTaskHistory(task.taskId, 'perf')
-                  .then(respData, function(e) { return [] }),
+                  .then(respData, function (e) {
+                    return []
+                  }),
                 baseline: ApiTaskdata.getTaskById(baseline.taskId, 'perf')
-                  .then(respData, function(e) { return null }),
+                  .then(respData, function (e) {
+                    return null
+                  }),
               })
             } else {
               return null
@@ -397,7 +454,7 @@ mciModule.factory('PerfDiscoveryDataService', function(
     return $q.all([
       ApiV2.getRecentVersions(projectId).then(versionSelectAdaptor),
       ApiTaskdata.getProjectTags(projectId).then(tagSelectAdaptor)
-    ]).then(function(data) {
+    ]).then(function (data) {
       return Array.prototype.concat.apply([], data)
     })
   }
@@ -405,7 +462,7 @@ mciModule.factory('PerfDiscoveryDataService', function(
   function findVersionItem(items, query) {
     if (query == undefined) return
 
-    return _.find(items, function(d) {
+    return _.find(items, function (d) {
       // Checks if query is inside or equal an id
       // Useful for long verion ids and revisions
       // e.g. $GITHASH will match sys-perf_$GITHASH
@@ -429,7 +486,7 @@ mciModule.factory('PerfDiscoveryDataService', function(
   function getCompItemVersion(compItem) {
     return ApiV2.getVersionById(compItem.id)
       // Extract version object
-      .then(function(res) {
+      .then(function (res) {
         return res.data
       })
   }

--- a/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
+++ b/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
@@ -226,7 +226,7 @@ mciModule.factory('PerfDiscoveryDataService', function (
 
   // TODO Should be part of `VersionResource`
   // :parm version: version object
-  // :returns: Array of {taskId, taskName, buildName}
+  // :returns: Array of objects representing tasks within a version
   function extractTasks(version) {
     return _.reduce(version.builds, function (items, build) {
       // Going over dict of tasks ({taskName: data})
@@ -394,8 +394,8 @@ mciModule.factory('PerfDiscoveryDataService', function (
       baselineTasks: baselineTasks
     }).then(function (promise) {
       return $q.all(_.map(promise.tasks, function (task) {
-        let currentTaskPromise = expandedCurrent ? ApiTaskdata.getExpandedTaskById(task.taskId, 'perf') : ApiTaskdata.getTaskById(task.taskId, 'perf');
-        let taskHistory = expandedTrend ? ApiTaskdata.getExpandedHistory(task.taskName, task.buildVariant, task.project) : ApiTaskdata.getTaskHistory(task.taskId, 'perf');
+        const currentTaskPromise = expandedCurrent ? ApiTaskdata.getExpandedTaskById(task.taskId, 'perf') : ApiTaskdata.getTaskById(task.taskId, 'perf');
+        const taskHistory = expandedTrend ? ApiTaskdata.getExpandedHistory(task.taskName, task.buildVariant, task.project) : ApiTaskdata.getTaskHistory(task.taskId, 'perf');
         return currentTaskPromise
           .then(respData, function () {
             return null

--- a/public/static/app/perfdiscovery/PerfDiscoveryDataService.test.js
+++ b/public/static/app/perfdiscovery/PerfDiscoveryDataService.test.js
@@ -28,6 +28,7 @@ describe('PerfDiscoveryDataServiceTest', function () {
           id: 'baid',
           name: 'buildAName',
           variant: 'bvA',
+          project: "foo",
           tasks: {
             taskA: {
               task_id: 'idA'
@@ -41,6 +42,7 @@ describe('PerfDiscoveryDataServiceTest', function () {
           id: 'bbid',
           name: 'buildBName',
           variant: 'bvB',
+          project: "foo",
           tasks: {
             taskC: {
               task_id: 'idC'
@@ -61,24 +63,28 @@ describe('PerfDiscoveryDataServiceTest', function () {
       taskId: 'idA',
       taskName: 'taskA',
       buildName: 'buildAName',
+      project: "foo",
     }, {
       buildId: 'baid',
       buildVariant: 'bvA',
       taskId: 'idB',
       taskName: 'taskB',
       buildName: 'buildAName',
+      project: "foo",
     }, {
       buildId: 'bbid',
       buildVariant: 'bvB',
       taskId: 'idC',
       taskName: 'taskC',
       buildName: 'buildBName',
+      project: "foo",
     }, {
       buildId: 'bbid',
       buildVariant: 'bvB',
       taskId: 'idD',
       taskName: 'taskD',
       buildName: 'buildBName',
+      project: "foo",
     }]);
   });
 

--- a/public/static/app/perfdiscovery/PerfDiscoveryDataService.test.js
+++ b/public/static/app/perfdiscovery/PerfDiscoveryDataService.test.js
@@ -1,4 +1,4 @@
-describe('PerfDiscoveryDataServiceTest', function() {
+describe('PerfDiscoveryDataServiceTest', function () {
   beforeEach(module('MCI'));
 
   var githash = '1234567890123456789012345678901234567890';
@@ -6,32 +6,52 @@ describe('PerfDiscoveryDataServiceTest', function() {
 
   var service, $httpBackend, $window, PD;
 
-  beforeEach(function() {
-    module(function($provide) {
-      $window = {project: project}
+  beforeEach(function () {
+    module(function ($provide) {
+      $window = {
+        project: project
+      }
       $provide.value('$window', $window)
     });
 
-    inject(function($injector) {
+    inject(function ($injector) {
       service = $injector.get('PerfDiscoveryDataService');
       $httpBackend = $injector.get('$httpBackend');
       PD = $injector.get('PERF_DISCOVERY');
     })
   });
 
-  it('should extract tasks from version', function() {
+  it('should extract tasks from version', function () {
     const version = {
       builds: {
         buildA: {
           id: 'baid',
           name: 'buildAName',
           variant: 'bvA',
-          tasks: { taskA: {task_id: 'idA'}, taskB: {task_id: 'idB'}, } },
+          tasks: {
+            taskA: {
+              task_id: 'idA'
+            },
+            taskB: {
+              task_id: 'idB'
+            },
+          }
+        },
         buildB: {
           id: 'bbid',
           name: 'buildBName',
           variant: 'bvB',
-          tasks: { taskC: {task_id: 'idC'}, taskD: {task_id: 'idD'}, } } } };
+          tasks: {
+            taskC: {
+              task_id: 'idC'
+            },
+            taskD: {
+              task_id: 'idD'
+            },
+          }
+        }
+      }
+    };
 
     expect(
       service._extractTasks(version)
@@ -60,14 +80,18 @@ describe('PerfDiscoveryDataServiceTest', function() {
       taskName: 'taskD',
       buildName: 'buildBName',
     }]);
-});
+  });
 
-  it('processes single data item', function() {
+  it('processes single data item', function () {
     const item = {
       name: 'name',
       results: {
-        8: {ops_per_sec: 100},
-        16: {ops_per_sec: 200},
+        8: {
+          ops_per_sec: 100
+        },
+        16: {
+          ops_per_sec: 200
+        },
       }
     };
     const ctx = {
@@ -113,30 +137,45 @@ describe('PerfDiscoveryDataServiceTest', function() {
     });
   });
 
-  it('processes the data', function() {
+  it('processes the data', function () {
     const data = [{
       current: {
         data: {
           results: [{
             name: 'test',
             results: {
-              8: {ops_per_sec: 100}}}
-          ]}},
+              8: {
+                ops_per_sec: 100
+              }
+            }
+          }]
+        }
+      },
       baseline: {
         data: {
           results: [{
             name: 'test',
             results: {
-              8: {ops_per_sec: 100}}}
-          ]}},
+              8: {
+                ops_per_sec: 100
+              }
+            }
+          }]
+        }
+      },
       history: [{
         order: 1,
         data: {
           results: [{
             name: 'test',
-            results: {8: {ops_per_sec: 100}}}
-          ]}}
-      ],
+            results: {
+              8: {
+                ops_per_sec: 100
+              }
+            }
+          }]
+        }
+      }],
       ctx: {
         buildName: 'b',
         taskName: 't',
@@ -163,12 +202,15 @@ describe('PerfDiscoveryDataServiceTest', function() {
     ).toBe(1);
   });
 
-  it('prcocesses the empty data', function() {
+  it('prcocesses the empty data', function () {
     const data = [{
       current: null,
       baseline: null,
       history: [],
-      ctx: {buildName: 'b', taskName: 't'}
+      ctx: {
+        buildName: 'b',
+        taskName: 't'
+      }
     }];
 
     expect(
@@ -180,7 +222,7 @@ describe('PerfDiscoveryDataServiceTest', function() {
     });
   });
 
-  it('processes null items', function() {
+  it('processes null items', function () {
     const data = [null];
 
     expect(
@@ -192,7 +234,7 @@ describe('PerfDiscoveryDataServiceTest', function() {
     })
   });
 
-  it('convert test data to row items', function() {
+  it('convert test data to row items', function () {
     var results = {
       now: {
         'b-wt-t-name-8': {
@@ -201,7 +243,9 @@ describe('PerfDiscoveryDataServiceTest', function() {
           storageEngine: 'wt',
           test: 'name',
           threads: 8,
-          speed: 100 } },
+          speed: 100
+        }
+      },
       baseline: {
         'b-wt-t-name-8': {
           build: 'b',
@@ -209,24 +253,28 @@ describe('PerfDiscoveryDataServiceTest', function() {
           storageEngine: 'wt',
           test: 'name',
           threads: 8,
-          speed: 200 } },
+          speed: 200
+        }
+      },
       history: [{
-          'b-wt-t-name-8': {
-            build: 'b',
-            task: 't',
-            storageEngine: 'wt',
-            test: 'name',
-            threads: 8,
-            speed: 400 }
-        }, {
-          'b-wt-t-name-8': {
-            build: 'b',
-            task: 't',
-            storageEngine: 'wt',
-            test: 'name',
-            threads: 8,
-            speed: 50 } },
-      ]
+        'b-wt-t-name-8': {
+          build: 'b',
+          task: 't',
+          storageEngine: 'wt',
+          test: 'name',
+          threads: 8,
+          speed: 400
+        }
+      }, {
+        'b-wt-t-name-8': {
+          build: 'b',
+          task: 't',
+          storageEngine: 'wt',
+          test: 'name',
+          threads: 8,
+          speed: 50
+        }
+      }, ]
     };
 
     expect(
@@ -247,7 +295,7 @@ describe('PerfDiscoveryDataServiceTest', function() {
 
   });
 
-  it('Extracts versions from the response', function() {
+  it('Extracts versions from the response', function () {
     const resp = {
       data: {
         versions: [{
@@ -271,11 +319,13 @@ describe('PerfDiscoveryDataServiceTest', function() {
     }]);
   });
 
-  it('Extracts versions from the response', function() {
+  it('Extracts versions from the response', function () {
     var resp = {
       data: [{
         name: 't_name',
-        obj: { version_id: 'v_id' },
+        obj: {
+          version_id: 'v_id'
+        },
       }]
     };
 
@@ -288,10 +338,19 @@ describe('PerfDiscoveryDataServiceTest', function() {
     }]);
   });
 
-  it('Finds tag/version in items', function() {
-    const item1 = {id: 'id1', name: 'name1'};
-    const item2 = {id: 'id2', name: 'name2'};
-    const item3 = {id: 'sys-perf_githash', name: 'name2'};
+  it('Finds tag/version in items', function () {
+    const item1 = {
+      id: 'id1',
+      name: 'name1'
+    };
+    const item2 = {
+      id: 'id2',
+      name: 'name2'
+    };
+    const item3 = {
+      id: 'sys-perf_githash',
+      name: 'name2'
+    };
     const items = [item1, item2, item3];
 
     expect(
@@ -315,12 +374,21 @@ describe('PerfDiscoveryDataServiceTest', function() {
     ).toBe(item3);
   });
 
-  it('Adds query based item to comp items', function() {
+  it('Adds query based item to comp items', function () {
     const LEN24_A = '1234567890123456789012_A';
     const LEN24_B = '1234567890123456789012_B';
-    const item1 = {id: LEN24_A, name: 'name1'};
-    const item2 = {id: 'id2', name: 'name2'};
-    const item3 = {id: 'sys_perf_0fe17ec2e1aed45ca280afb8da06cb178219d261', name: 'name2'};
+    const item1 = {
+      id: LEN24_A,
+      name: 'name1'
+    };
+    const item2 = {
+      id: 'id2',
+      name: 'name2'
+    };
+    const item3 = {
+      id: 'sys_perf_0fe17ec2e1aed45ca280afb8da06cb178219d261',
+      name: 'name2'
+    };
     const items = [item1, item2, item3];
 
     expect(
@@ -352,7 +420,7 @@ describe('PerfDiscoveryDataServiceTest', function() {
     }))
   });
 
-  it('attempts to build a comp item from query string', function() {
+  it('attempts to build a comp item from query string', function () {
     const LEN24 = '123456789012345678901234';
     const versionIdLong = project + '_' + githash;
     const sysPerfIdLong = 'sys_perf_' + githash;
@@ -363,24 +431,34 @@ describe('PerfDiscoveryDataServiceTest', function() {
 
     expect(
       service.getQueryBasedItem(LEN24)
-    ).toEqual({kind: PD.KIND_VERSION, id: LEN24, name: LEN24});
+    ).toEqual({
+      kind: PD.KIND_VERSION,
+      id: LEN24,
+      name: LEN24
+    });
 
     expect(
       service.getQueryBasedItem(versionIdLong)
     ).toEqual({
-      kind: PD.KIND_VERSION, id: versionIdLong, name: versionIdLong
+      kind: PD.KIND_VERSION,
+      id: versionIdLong,
+      name: versionIdLong
     });
 
     expect(
       service.getQueryBasedItem(githash)
     ).toEqual({
-      kind: PD.KIND_VERSION, id: versionIdLong, name: githash
+      kind: PD.KIND_VERSION,
+      id: versionIdLong,
+      name: githash
     });
 
     expect(
       service.getQueryBasedItem(sysPerfIdLong)
     ).toEqual({
-      kind: PD.KIND_VERSION, id: sysPerfIdLong, name: sysPerfIdLong
+      kind: PD.KIND_VERSION,
+      id: sysPerfIdLong,
+      name: sysPerfIdLong
     });
   })
 });

--- a/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
+++ b/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
@@ -1,4 +1,4 @@
-mciModule.controller('PerformanceDiscoveryCtrl', function(
+mciModule.controller('PerformanceDiscoveryCtrl', function (
   $q, $scope, $timeout, $window, ApiTaskdata, ApiV1, ApiV2,
   EVG, EvgUiGridUtil, PERF_DISCOVERY, PerfDiscoveryDataService,
   PerfDiscoveryStateService, uiGridConstants, OutliersDataService,
@@ -51,7 +51,7 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
   }
 
   dataUtil.getComparisionOptions(projectId)
-    .then(function(items) {
+    .then(function (items) {
       vm.fromSelect.options = items
 
       // Sets 'compare from' version from the state if available
@@ -59,7 +59,9 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
       vm.fromSelect.selected = cascade(
         _.bind(dataUtil.findVersionItem, null, items),
         _.bind(dataUtil.getQueryBasedItem, null, state.from),
-        _.bind(_.findWhere, null, items, {kind: PD.KIND_VERSION}),
+        _.bind(_.findWhere, null, items, {
+          kind: PD.KIND_VERSION
+        }),
         _.bind(_.first, null, items)
       )
 
@@ -69,18 +71,20 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
       vm.toSelect.selected = cascade(
         _.bind(dataUtil.findVersionItem, null, items, state.to),
         _.bind(dataUtil.getQueryBasedItem, null, state.to),
-        _.bind(_.findWhere, null, items, {kind: PD.KIND_TAG}),
+        _.bind(_.findWhere, null, items, {
+          kind: PD.KIND_TAG
+        }),
         _.bind(_.first, null, items)
       )
     })
 
   // Handles changes in selectFrom/To drop downs
   // Ignores `null` on start up
-  $scope.$watch('$ctrl.fromSelect.selected', function(item) {
+  $scope.$watch('$ctrl.fromSelect.selected', function (item) {
     item && vm.updateData()
   })
 
-  $scope.$watch('$ctrl.toSelect.selected', function(item) {
+  $scope.$watch('$ctrl.toSelect.selected', function (item) {
     item && vm.updateData()
   })
 
@@ -88,7 +92,7 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
 
   // Convert the name to a revision that can be used to query atlas.
   const nameToRevision = (name) => {
-    if(name) {
+    if (name) {
       const parts = name.split(/[-_]/);
       name = parts[parts.length - 1];
     }
@@ -112,22 +116,27 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
     // Load the marked and detected outliers for this revision. If no revision, don't load anything.
     const revision = nameToRevision(fromVersion.name);
     const outliersPromise = $q.all({
-      detected:revision ? OutliersDataService.getOutliersQ(projectId, {revision:revision})  : [],
-      marked:revision ? OutliersDataService.getMarkedOutliersQ({project: projectId, revision:revision})  : [],
+      detected: revision ? OutliersDataService.getOutliersQ(projectId, {
+        revision: revision
+      }) : [],
+      marked: revision ? OutliersDataService.getMarkedOutliersQ({
+        project: projectId,
+        revision: revision
+      }) : [],
     });
 
     $q.all({
-      fromVersionObj: dataUtil.getCompItemVersion(fromVersion),
-      toVersionObj: dataUtil.getCompItemVersion(toVersion),
-    })
-    // Load perf data
-      .then(function(promise) {
+        fromVersionObj: dataUtil.getCompItemVersion(fromVersion),
+        toVersionObj: dataUtil.getCompItemVersion(toVersion),
+      })
+      // Load perf data
+      .then(function (promise) {
         return dataUtil.getData(
           promise.fromVersionObj, promise.toVersionObj
         );
       })
       // Apply perf data
-      .then(function(res) {
+      .then(function (res) {
         vm.gridOptions.data = res
         // Apply options data to filter drop downs
         gridUtil.applyMultiselectOptions(
@@ -139,30 +148,32 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
         return res
       })
       // Stop spinner
-      .finally(function() { vm.isLoading = false })
+      .finally(function () {
+        vm.isLoading = false
+      })
       // Fetch BF tickets and outliers.
-      .then(function() {
+      .then(function () {
 
         const projectRevisionMatcher = {
           project: projectId,
-          revision:  revision
+          revision: revision
         };
 
-        outliersPromise.then(function(outliers) {
+        outliersPromise.then(function (outliers) {
           // add 'm' for marked.
-          _.chain(outliers.marked).where(projectRevisionMatcher).each(function(outlier) {
+          _.chain(outliers.marked).where(projectRevisionMatcher).each(function (outlier) {
             _.chain(vm.gridOptions.data)
               .where(createMatcher(outlier))
-              .each(task =>  task.outlier = 'm');
+              .each(task => task.outlier = 'm');
           });
 
-          _.chain(outliers.detected).where(projectRevisionMatcher).each(function(outlier) {
+          _.chain(outliers.detected).where(projectRevisionMatcher).each(function (outlier) {
             // add '✓' for marked.
             _.chain(vm.gridOptions.data)
               .where(createMatcher(outlier))
               .each(task => {
-                if(task.outlier) {
-                  if(task.outlier.indexOf('✓') == -1 ) {
+                if (task.outlier) {
+                  if (task.outlier.indexOf('✓') == -1) {
                     task.outlier += '✓';
                   }
                 } else {
@@ -172,12 +183,14 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
           })
         });
 
-        dataUtil.getBFTicketsForRows(vm.gridOptions.data).then(function(bfGroups) {
+        dataUtil.getBFTicketsForRows(vm.gridOptions.data).then(function (bfGroups) {
 
           // Match grouped points (by task, bv, test) w/ rows
-          _.each(bfGroups, function(bfGroup) {
+          _.each(bfGroups, function (bfGroup) {
             // Dedupe by 'key' (BFs might have different revisions or other fields)
-            var bfs = _.uniq(bfGroup, function(d) { return d.key })
+            var bfs = _.uniq(bfGroup, function (d) {
+              return d.key
+            })
 
             var bf = bfs[0] // using the first element as characteristic
 
@@ -189,7 +202,7 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
             // If BF has associated test
             bf.tests && (matcher['test'] = bf.tests)
 
-            _.each(_.where(vm.gridOptions.data, matcher), function(task) {
+            _.each(_.where(vm.gridOptions.data, matcher), function (task) {
               task.buildFailures = bfs
             })
           })
@@ -197,7 +210,7 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
       })
   }
 
-  vm.updateData = function() {
+  vm.updateData = function () {
     var fromVersion = vm.fromSelect.selected
     var toVersion = vm.toSelect.selected
 
@@ -225,7 +238,7 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
     // Update context chart data for given rendered rows
     // sets [min, max] list to the scope for visible rows
     vm.refCtx = d3.extent(
-      _.reduce(grid.renderContainers.body.renderedRows, function(m, d) {
+      _.reduce(grid.renderContainers.body.renderedRows, function (m, d) {
         return m.concat([
           Math.log(d.entity.avgVsSelf[0]),
           Math.log(d.entity.avgVsSelf[1])
@@ -236,22 +249,22 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
 
   // Returns a predefined URL for given `row` and `col`
   // Works with build abd task columns only
-  vm.getCellUrl = function(row, col) {
+  vm.getCellUrl = function (row, col) {
     return row.entity[{
       build: 'buildURL',
       task: 'taskURL',
-    }[col.field]]
+    } [col.field]]
   }
 
   vm.gridOptions = {
     enableFiltering: true,
     enableGridMenu: true,
-    onRegisterApi: function(gridApi) {
+    onRegisterApi: function (gridApi) {
       vm.gridApi = gridApi
       grid = gridApi.grid;
 
       // Using _.once, because this behavior is required on init only
-      gridApi.core.on.rowsRendered($scope, function() {
+      gridApi.core.on.rowsRendered($scope, function () {
         // For some reason, calback being called before
         // the changes were applied to grid
         // Timeout forces underlying code to be executed at the end
@@ -260,7 +273,7 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
         )
       })
 
-      gridApi.core.on.rowsRendered($scope, _.once(function() { // Do once
+      gridApi.core.on.rowsRendered($scope, _.once(function () { // Do once
         stateUtil.applyStateToGrid(state, grid)
         // Set handlers after grid initialized
         gridApi.core.on.sortChanged(
@@ -275,13 +288,13 @@ mciModule.controller('PerformanceDiscoveryCtrl', function(
       $scope.grid = grid
       // This triggers on vertical scroll
       $scope.$watch(
-        'grid.renderContainers.body.currentTopRow', function() {
+        'grid.renderContainers.body.currentTopRow',
+        function () {
           updateChartContext(grid)
         }
       )
     },
-    columnDefs: [
-      {
+    columnDefs: [{
         name: 'Tickets',
         field: 'buildFailures',
         cellTemplate: 'perf-discovery-bfs',

--- a/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
+++ b/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
@@ -88,6 +88,10 @@ mciModule.controller('PerformanceDiscoveryCtrl', function (
     item && vm.updateData()
   })
 
+  $scope.reload = function () {
+    vm.updateData(true);
+  }
+
   let oldFromVersion, oldToVersion;
 
   // Convert the name to a revision that can be used to query atlas.
@@ -109,7 +113,7 @@ mciModule.controller('PerformanceDiscoveryCtrl', function (
     };
   };
 
-  function loadCompOptions(fromVersion, toVersion) {
+  function loadCompOptions(fromVersion, toVersion, expandedCurrent, expandedBaseline, expandedTrend) {
     // Set loading flag to display spinner
     vm.isLoading = true;
 
@@ -132,7 +136,7 @@ mciModule.controller('PerformanceDiscoveryCtrl', function (
       // Load perf data
       .then(function (promise) {
         return dataUtil.getData(
-          promise.fromVersionObj, promise.toVersionObj
+          promise.fromVersionObj, promise.toVersionObj, expandedCurrent, expandedBaseline, expandedTrend
         );
       })
       // Apply perf data
@@ -210,12 +214,12 @@ mciModule.controller('PerformanceDiscoveryCtrl', function (
       })
   }
 
-  vm.updateData = function () {
+  vm.updateData = function (force) {
     var fromVersion = vm.fromSelect.selected
     var toVersion = vm.toSelect.selected
 
     // If nothing has changed, exit the function
-    if (fromVersion == oldFromVersion && toVersion == oldToVersion) {
+    if (!force && (fromVersion == oldFromVersion && toVersion == oldToVersion)) {
       return
     }
 
@@ -230,8 +234,11 @@ mciModule.controller('PerformanceDiscoveryCtrl', function (
 
     // Display no data while loading is in progress
     vm.gridOptions.data = []
+    expandedCurrent = vm.expandedOptions && vm.expandedOptions.includes("current");
+    expandedBaseline = vm.expandedOptions && vm.expandedOptions.includes("baseline");
+    expandedHistory = vm.expandedOptions && vm.expandedOptions.includes("history");
 
-    loadCompOptions(fromVersion, toVersion)
+    loadCompOptions(fromVersion, toVersion, expandedCurrent, expandedBaseline, expandedHistory);
   }
 
   function updateChartContext(grid) {

--- a/public/static/js/filters/filters.common.js
+++ b/public/static/js/filters/filters.common.js
@@ -85,10 +85,13 @@ var convertSingleTest = function (test, execution) {
   return output;
 }
 
-let latestExecution = function (perfData) {
+const latestExecution = function (perfData) {
+  if (perfData.length === 0) {
+    return 0;
+  }
   return _.max(perfData, (singleTest) => {
     return singleTest.info && singleTest.info.execution || 0;
-  }).execution;
+  }).info.execution;
 }
 
 filters.common.filter('conditional', function () {

--- a/public/static/js/filters/filters.common.js
+++ b/public/static/js/filters/filters.common.js
@@ -85,6 +85,12 @@ var convertSingleTest = function (test, execution) {
   return output;
 }
 
+let latestExecution = function (perfData) {
+  return _.max(perfData, (singleTest) => {
+    return singleTest.info && singleTest.info.execution || 0;
+  }).execution;
+}
+
 filters.common.filter('conditional', function () {
     return function (b, t, f) {
       return b ? t : f;
@@ -471,6 +477,9 @@ filters.common.filter('conditional', function () {
       if (!data) {
         return null;
       }
+      if (!execution) {
+        execution = latestExecution(data);
+      }
       var output = {
         data: {
           "results": []
@@ -491,6 +500,9 @@ filters.common.filter('conditional', function () {
     return function (data, execution) {
       if (!data) {
         return null;
+      }
+      if (!execution) {
+        execution = latestExecution(data);
       }
       let output = [];
 

--- a/public/static/js/filters/filters.common.js
+++ b/public/static/js/filters/filters.common.js
@@ -17,22 +17,22 @@ var LINK_REGEXP =
 
 var JIRA_REGEXP = /[A-Z]{1,10}-\d{1,6}/ig;
 
-var escapeHtml = function(str) {
+var escapeHtml = function (str) {
   var div = document.createElement('div');
   div.appendChild(document.createTextNode(str));
   return div.innerHTML;
 };
 
 
-var isDismissed = function(bannerText) {
+var isDismissed = function (bannerText) {
   return md5(bannerText) === localStorage.getItem("dismissed");
 }
 
-var bannerText = function() {
+var bannerText = function () {
   return escapeHtml(window.BannerText);
 }
 
-var convertSingleTest = function(test, execution) {
+var convertSingleTest = function (test, execution) {
   if (execution && test.info.execution !== execution) {
     return null;
   }
@@ -73,456 +73,457 @@ var convertSingleTest = function(test, execution) {
   result[threads] = {};
 
   _.each(test.rollups.stats, function (stat) {
-      result[threads][stat.name] = Array.isArray(stat.val) ? stat.val[0].Value : stat.val;
-      result[threads][stat.name + "_values"] = Array.isArray(stat.val) ? [stat.val[0].Value] : [stat.val];
+    result[threads][stat.name] = Array.isArray(stat.val) ? stat.val[0].Value : stat.val;
+    result[threads][stat.name + "_values"] = Array.isArray(stat.val) ? [stat.val[0].Value] : [stat.val];
   });
   output.data.results.push({
-      "name": test.info.test_name,
-      "isExpandedMetric": true,
-      "results": result
+    "name": test.info.test_name,
+    "isExpandedMetric": true,
+    "results": result
   });
-  
+
   return output;
 }
 
-filters.common.filter('conditional', function() {
-  return function(b, t, f) {
-    return b ? t : f;
-  }
-}).filter('min', function() {
-  return function(v, m) {
-    return Math.min(v, m);
-  };
-}).filter('default', function() {
-  return function(input, def) {
-    return input ? input : def;
-  };
-}).filter('undef', function() {
-  return function(v) {
-    return v == null || v == undefined;
-  };
-}).filter('shortenString', function() {
-  // shortenString shortens a long string with the following options.
-  // wordwise (boolean) - if true, cut only by words bounds
-  // max (integer) - max length of the text, cut to this number of chars
-  // tail (string, default: ' …') - add this string to the input string if the string was cut
-  return function(value, wordwise, max, tail) {
-    if (!value) {
+filters.common.filter('conditional', function () {
+    return function (b, t, f) {
+      return b ? t : f;
+    }
+  }).filter('min', function () {
+    return function (v, m) {
+      return Math.min(v, m);
+    };
+  }).filter('default', function () {
+    return function (input, def) {
+      return input ? input : def;
+    };
+  }).filter('undef', function () {
+    return function (v) {
+      return v == null || v == undefined;
+    };
+  }).filter('shortenString', function () {
+    // shortenString shortens a long string with the following options.
+    // wordwise (boolean) - if true, cut only by words bounds
+    // max (integer) - max length of the text, cut to this number of chars
+    // tail (string, default: ' …') - add this string to the input string if the string was cut
+    return function (value, wordwise, max, tail) {
+      if (!value) {
         return '';
-    }
+      }
 
-    max = parseInt(max, 10);
-    if (!max) {
+      max = parseInt(max, 10);
+      if (!max) {
         return value;
-    }
-    if (value.length <= max) {
+      }
+      if (value.length <= max) {
         return value;
-    }
+      }
 
-    value = value.substr(0, max);
-    if (wordwise) {
+      value = value.substr(0, max);
+      if (wordwise) {
         var lastspace = value.lastIndexOf(' ');
         if (lastspace !== -1) {
-            value = value.substr(0, lastspace);
+          value = value.substr(0, lastspace);
         }
-    }
-
-    return value + (tail || ' …');
-  };
-}).filter('pluralize', function() {
-  return function(v, noun) {
-    if (isNaN(v)) {
-      return noun + 's';
-    } else if (v == 1) {
-      return noun;
-    } else {
-      return noun + 's';
-    }
-  };
-}).filter('capitalize', function() {
-  return function(input) {
-    if (!input) {
-      return input;
-    }
-
-    var ret = "";
-    var sp = input.split(' ');
-
-    for (var i = 0; i < sp.length; ++i) {
-      if (sp[i].charAt(0).toUpperCase() >= 'A' && sp[i].charAt(0).toUpperCase() <= 'Z') {
-        sp[i] = sp[i].substr(0, 1).toUpperCase() + sp[i].substr(1);
       }
-      ret += (i == 0 ? '' : ' ') + sp[i];
-    }
 
-    return ret;
-  }
-}).filter('dateFromNanoseconds', function() {
-  return function(v) {
-    return new Date(v / (1000 * 1000));
-  }
-}).filter('nanoToSeconds', function() {
-  return function(nanoseconds) {
-    return nanoseconds * 1000 * 1000 * 1000;
-  }
-}).filter('stringifyNanoseconds', function() {
-  var NS_PER_MS = 1000 * 1000; // 10^6
-  var NS_PER_SEC = NS_PER_MS * 1000
-  var NS_PER_MINUTE = NS_PER_SEC * 60;
-  var NS_PER_HOUR = NS_PER_MINUTE * 60;
-
-  // stringifyNanoseconds takes an integer count of nanoseconds and
-  // returns it formatted as a human readable string, like "1h32m40s"
-  // If skipDayMax is true, then durations longer than 1 day will be represented
-  // in hours. Otherwise, they will be displayed as '>=1 day'
-  return function(input, skipDayMax, skipSecMax) {
-    if (input === 0) {
-      return "0 seconds";
-    } else if (input == "unknown" || input < 0) {
-      return "unknown";
-    } else if (input < NS_PER_MS) {
-      return "< 1 ms";
-    } else if (input < NS_PER_SEC) {
-      if (skipSecMax){
-        return Math.floor(input / NS_PER_MS) + " ms";
+      return value + (tail || ' …');
+    };
+  }).filter('pluralize', function () {
+    return function (v, noun) {
+      if (isNaN(v)) {
+        return noun + 's';
+      } else if (v == 1) {
+        return noun;
       } else {
-        return "< 1 second"
-      }
-    } else if (input < NS_PER_MINUTE) {
-      return Math.floor(input / NS_PER_SEC) + " seconds";
-    } else if (input < NS_PER_HOUR) {
-      return Math.floor(input / NS_PER_MINUTE) + "m " + Math.floor((input % NS_PER_MINUTE) / NS_PER_SEC) + "s";
-    } else if (input < NS_PER_HOUR * 24 || skipDayMax) {
-      return Math.floor(input / NS_PER_HOUR) + "h " +
-          Math.floor((input % NS_PER_HOUR) / NS_PER_MINUTE) + "m " +
-          Math.floor((input % NS_PER_MINUTE) / NS_PER_SEC) + "s";
-    } else {
-      return ">= 1 day";
-    }
-  };
-}).filter('linkify', function() {
-  return function(input) {
-    var ret = "";
-    var index = 0;
-
-    if (!input) {
-      return input;
-    }
-
-    return input.replace(LINK_REGEXP, function(match) {
-      return '<a href="' + match + '">' + match + '</a>';
-    });
-  };
-}).filter('jiraLinkify', function($sce) {
-  return function(input, jiraHost) {
-    if (!input) {
-      return input
-    }
-    return input.replace(JIRA_REGEXP, function(match) {
-      return $sce.trustAsHtml(
-        '<a href="https://'+jiraHost +'/browse/' + match + '">' + match + '</a>'
-      )
-    })
-  }
-}).filter('convertDateToUserTimezone', function() {
-  return function(input, timezone, format) {
-    return moment(input).tz(timezone).format(format);
-  }
-}).filter('encodeUri', function() {
-  return function(url) {
-    return encodeURIComponent(url);
-  }
-}).filter('ansi', function($window) {
-  return function(input) {
-    /* AnsiUp does some unexpected things in a pre tag, so run AnsiUp on a
-     * line-by-line basis */
-    return _.map(input.split('\n'), $window.ansi_up.ansi_to_html).join('\n');
-  };
-}).filter('trustAsHtml', function($sce) {
-  return function(input) {
-    return $sce.trustAsHtml(input);
-  };
-}).filter('escapeHtml', function() {
-  return escapeHtml;
-}).filter('pretty', function() {
-  return function(obj) {
-    return JSON.stringify(obj, null, 2);
-  };
-}).filter('ordinalNum', function() {
-  // converts 1, 2, 3, etc. to 1st, 2nd, 3rd, etc.
-  return function(n) {
-    var s = ["th","st","nd","rd"], v = n % 100;
-    // Past the first twenty, the first four of every ten have the special endings
-    // Within in the first twenty, the first four have special endings
-    // All of the others have the default ending
-    return n + ( s[(v-20)%10] || s[v] || s[0] );
-  }
-}).filter('range', function() {
-  // Returns an array of numbers which are >= low and < high. Useful for when
-  // your use case doesn't quite fit into an `in` loop for ng-repeat
-  return function(low, high) {
-    var ret = [];
-    for (var i = low; i < high; ++i) {
-      ret.push(i);
-    }
-    return ret;
-  };
-}).filter('sample', function() {
-  // Given a potentially long array, returns an array which contains equally
-  // spaced elements from the original array such that there are no more than
-  // `maxNum` elements. Effectively, gives you `maxNum` samples from the source
-  // array.
-  return function(arr, maxNum) {
-    if (arr.length === 0) {
-      return [];
-    }
-    if (arr.length < maxNum) {
-      return arr;
-    }
-
-    var ret = [];
-    var every = Math.floor(arr.length / maxNum);
-    for (var i = 0; i < maxNum; ++i) {
-      ret.push(arr[i * every]);
-    }
-    return ret;
-  };
-}).filter('fixedPrecisionTimeDiff', function() {
-  var SECOND = 1000;
-  var MINUTE = 60 * SECOND;
-  var HOUR = 60 * MINUTE;
-  var DAY = 24 * HOUR;
-
-  return function(diff) {
-    if (diff < SECOND) {
-      // ex: 433ms
-      return diff + 'ms';
-    } else if (diff < MINUTE) {
-      // ex: 17.2s
-      return Math.floor(diff / SECOND) + '.' +
-        Math.floor((diff % SECOND ) / 100) + 's'
-    } else if (diff < HOUR) {
-      // ex: 12m48s
-      return Math.floor(diff / MINUTE) + 'm' +
-        Math.floor((diff % MINUTE) / SECOND) + 's';
-    } else if (diff < DAY) {
-      // ex: 13h27m
-      return Math.floor(diff / HOUR) + 'h' +
-        Math.floor((diff % HOUR) / MINUTE) + 'm';
-    } else {
-      return '>=1d';
-    }
-  };
-})
-// Displays input value as percentage
-// "0.85 | percentage" => "85"
-.filter('percentage', function() {
-  return function(input) {
-    return input * 100
-  }
-})
-
-.filter('statusFilter', function() {
-  return function(task) {
-    // for task test results, return the status passed in
-    if (task !== Object(task)) {
-      return task;
-    }
-    var cls = task.status;
-    if (task.status == 'started') {
-      cls = 'started';
-    } else if (task.status == 'success') {
-      cls = 'success';
-    } else if (task.status == 'failed') {
-      cls = 'failed';
-      // Get a property name where task details are stored
-      // Name may differe from API to API
-      let detailsProp = _.find(['task_end_details', 'status_details'],  d => d in task)
-      if (detailsProp) {
-        let details = task[detailsProp]
-        if ('type' in details) {
-          if (details.type == 'system' && details.status != 'success') {
-            cls = 'system-failed';
-          }
-          if (details.type == 'setup' && details.status != 'success') {
-            cls = 'setup-failed';
-          }
-        }
-        if ('timed_out' in details) {
-          if (details.timed_out && 'desc' in details && details.desc == 'heartbeat') {
-            cls = 'system-failed';
-          }
-        }
-      }
-    } else if (task.status == 'undispatched' || task.status == 'inactive' || task.status == 'unstarted' || (task.display_only && task.task_waiting)) {
-        if (!task.activated) {
-            cls = 'inactive';
-        } else {
-            cls = 'unstarted';
-        }
-    }
-    return cls;
-  }
-})
-
-.filter('statusLabel', function() {
-  return function(task) {
-    if (task.status == 'started') {
-      return 'started';
-    } else if (task.status == 'undispatched' && task.activated) {
-      if (task.task_waiting) {
-        return task.task_waiting;
-      }
-      return 'scheduled';
-    } else if (task.status == 'undispatched' && !task.activated){
-      // dispatch_time could be a string or a number. to check when the dispatch_time
-      // is a real value, this if-statement accounts for cases where
-      // dispatch_time is 0, "0" or even new Date(0) or older.
-      if (!task.dispatch_time || task.dispatch_time == 0 || (typeof task.dispatch_time === "string" && +new Date(task.dispatch_time) <= 0)) {
-        return "not scheduled"
-      }
-      return 'aborted';
-    } else if (task.status == 'success') {
-      return 'success';
-    } else if (task.status == 'failed') {
-      // Get a property name where task details are stored
-      // Name may differe from API to API
-      let detailsProp = _.find(['task_end_details', 'status_details'],  d => d in task)
-      if (detailsProp) {
-        let details = task[detailsProp]
-        if ('timed_out' in details) {
-          if (details.timed_out && 'desc' in details && details.desc == 'heartbeat') {
-            return 'system unresponsive';
-          }
-          if (details.type == 'setup') {
-            return 'setup timed out';
-          }
-          if (details.type == 'system') {
-            return 'system timed out';
-          }
-          return 'test timed out';
-        }
-        if (details.type == 'system' && details.status != 'success') {
-          return 'system failure';
-        }
-        if (details.type == 'setup' && details.status != 'success') {
-          return 'setup failure';
-        }
-        return 'failed';
-      }
-    }
-    if (task.task_waiting && !task.override_dependencies) {
-        return task.task_waiting;
-    }
-    return task.status;
-  }
-})
-
-.filter('endOfPath', function() {
-  return function(input) {
-    var lastSlash = input.lastIndexOf('/');
-    if (lastSlash === -1 || lastSlash === input.length - 1) {
-      // try to find the index using windows-style filesystem separators
-      lastSlash = input.lastIndexOf('\\');
-      if (lastSlash === -1 || lastSlash === input.length - 1) {
-        return input;
-      }
-    }
-    return input.substring(lastSlash + 1);
-  }
-})
-
-.filter('buildStatus', function() {
-  // given a list of tasks, returns the status of the overall build.
-  return function(tasks) {
-    var countSuccess = 0;
-    var countInProgress = 0;
-    var countActive = 0;
-    for(i=0;i<tasks.length;i++){
-      // if any task is failed, the build status is "failed"
-      if(tasks[i].status == "failed"){
-        return "block-status-failed";
-      }
-      if(tasks[i].status == "success"){
-        countSuccess++;
-      } else if(tasks[i].status == "dispatched" || tasks[i].status=="started"){
-        countInProgress++;
-      } else if(tasks[i].status == "undispatched") {
-        countActive += tasks[i].activated ? 1 : 0;
-      }
-    }
-    if(countSuccess == tasks.length){
-      // all tasks are passing
-      return "block-status-success";
-    }else if(countInProgress>0){
-      // no failures yet, but at least 1 task in still progress
-      return "block-status-started";
-    }else if(countActive>0){
-      // no failures yet, but at least 1 task still active
-      return "block-status-created";
-    }
-    // no active tasks pending
-    return "block-status-inactive";
-  }
-})
-.filter('expandedMetricConverter', function() {
-  return function(data, execution) {
-    if (!data) {
-      return null;
-    }
-    var output = {
-      data: {
-          "results": []
+        return noun + 's';
       }
     };
-
-    _.each(data, function(test) {
-      let singleTest = convertSingleTest(test, execution);
-      if (singleTest) {
-        output.data.results = output.data.results.concat(singleTest.data.results);
+  }).filter('capitalize', function () {
+    return function (input) {
+      if (!input) {
+        return input;
       }
-    })
 
-    return output;
-  }
-})
-.filter('expandedHistoryConverter', function() {
-  return function(data, execution) {
-    if (!data) {
-      return null;
-    }
-    let output = [];
+      var ret = "";
+      var sp = input.split(' ');
 
-    _.each(data, function(test) {
-      const converted = convertSingleTest(test, execution);
-      if (converted) {
-        output.push(converted);
+      for (var i = 0; i < sp.length; ++i) {
+        if (sp[i].charAt(0).toUpperCase() >= 'A' && sp[i].charAt(0).toUpperCase() <= 'Z') {
+          sp[i] = sp[i].substr(0, 1).toUpperCase() + sp[i].substr(1);
+        }
+        ret += (i == 0 ? '' : ' ') + sp[i];
       }
-    })
 
-    return output;
-  }
-})
-// merges two sets of perf results, taking metadata from the second sample but giving test result preference to the first one
-.filter('mergePerfResults', function() {
-  return function(firstSample, secondSample) {
-    if (!firstSample) {
-      return secondSample;
+      return ret;
     }
-    if (!secondSample) {
-      return firstSample;
+  }).filter('dateFromNanoseconds', function () {
+    return function (v) {
+      return new Date(v / (1000 * 1000));
     }
-    var toReturn = Object.assign({}, secondSample);
-    tempResults = {};
+  }).filter('nanoToSeconds', function () {
+    return function (nanoseconds) {
+      return nanoseconds * 1000 * 1000 * 1000;
+    }
+  }).filter('stringifyNanoseconds', function () {
+    var NS_PER_MS = 1000 * 1000; // 10^6
+    var NS_PER_SEC = NS_PER_MS * 1000
+    var NS_PER_MINUTE = NS_PER_SEC * 60;
+    var NS_PER_HOUR = NS_PER_MINUTE * 60;
 
-    _.each(secondSample.data.results, function(result) {
-      tempResults[result.name] = result;
-    })
-    _.each(firstSample.data.results, function(result) {
-      tempResults[result.name] = result;
-    })
-    toReturn.data.results = _.toArray(tempResults);
+    // stringifyNanoseconds takes an integer count of nanoseconds and
+    // returns it formatted as a human readable string, like "1h32m40s"
+    // If skipDayMax is true, then durations longer than 1 day will be represented
+    // in hours. Otherwise, they will be displayed as '>=1 day'
+    return function (input, skipDayMax, skipSecMax) {
+      if (input === 0) {
+        return "0 seconds";
+      } else if (input == "unknown" || input < 0) {
+        return "unknown";
+      } else if (input < NS_PER_MS) {
+        return "< 1 ms";
+      } else if (input < NS_PER_SEC) {
+        if (skipSecMax) {
+          return Math.floor(input / NS_PER_MS) + " ms";
+        } else {
+          return "< 1 second"
+        }
+      } else if (input < NS_PER_MINUTE) {
+        return Math.floor(input / NS_PER_SEC) + " seconds";
+      } else if (input < NS_PER_HOUR) {
+        return Math.floor(input / NS_PER_MINUTE) + "m " + Math.floor((input % NS_PER_MINUTE) / NS_PER_SEC) + "s";
+      } else if (input < NS_PER_HOUR * 24 || skipDayMax) {
+        return Math.floor(input / NS_PER_HOUR) + "h " +
+          Math.floor((input % NS_PER_HOUR) / NS_PER_MINUTE) + "m " +
+          Math.floor((input % NS_PER_MINUTE) / NS_PER_SEC) + "s";
+      } else {
+        return ">= 1 day";
+      }
+    };
+  }).filter('linkify', function () {
+    return function (input) {
+      var ret = "";
+      var index = 0;
 
-    return toReturn;
-  }
-})
+      if (!input) {
+        return input;
+      }
+
+      return input.replace(LINK_REGEXP, function (match) {
+        return '<a href="' + match + '">' + match + '</a>';
+      });
+    };
+  }).filter('jiraLinkify', function ($sce) {
+    return function (input, jiraHost) {
+      if (!input) {
+        return input
+      }
+      return input.replace(JIRA_REGEXP, function (match) {
+        return $sce.trustAsHtml(
+          '<a href="https://' + jiraHost + '/browse/' + match + '">' + match + '</a>'
+        )
+      })
+    }
+  }).filter('convertDateToUserTimezone', function () {
+    return function (input, timezone, format) {
+      return moment(input).tz(timezone).format(format);
+    }
+  }).filter('encodeUri', function () {
+    return function (url) {
+      return encodeURIComponent(url);
+    }
+  }).filter('ansi', function ($window) {
+    return function (input) {
+      /* AnsiUp does some unexpected things in a pre tag, so run AnsiUp on a
+       * line-by-line basis */
+      return _.map(input.split('\n'), $window.ansi_up.ansi_to_html).join('\n');
+    };
+  }).filter('trustAsHtml', function ($sce) {
+    return function (input) {
+      return $sce.trustAsHtml(input);
+    };
+  }).filter('escapeHtml', function () {
+    return escapeHtml;
+  }).filter('pretty', function () {
+    return function (obj) {
+      return JSON.stringify(obj, null, 2);
+    };
+  }).filter('ordinalNum', function () {
+    // converts 1, 2, 3, etc. to 1st, 2nd, 3rd, etc.
+    return function (n) {
+      var s = ["th", "st", "nd", "rd"],
+        v = n % 100;
+      // Past the first twenty, the first four of every ten have the special endings
+      // Within in the first twenty, the first four have special endings
+      // All of the others have the default ending
+      return n + (s[(v - 20) % 10] || s[v] || s[0]);
+    }
+  }).filter('range', function () {
+    // Returns an array of numbers which are >= low and < high. Useful for when
+    // your use case doesn't quite fit into an `in` loop for ng-repeat
+    return function (low, high) {
+      var ret = [];
+      for (var i = low; i < high; ++i) {
+        ret.push(i);
+      }
+      return ret;
+    };
+  }).filter('sample', function () {
+    // Given a potentially long array, returns an array which contains equally
+    // spaced elements from the original array such that there are no more than
+    // `maxNum` elements. Effectively, gives you `maxNum` samples from the source
+    // array.
+    return function (arr, maxNum) {
+      if (arr.length === 0) {
+        return [];
+      }
+      if (arr.length < maxNum) {
+        return arr;
+      }
+
+      var ret = [];
+      var every = Math.floor(arr.length / maxNum);
+      for (var i = 0; i < maxNum; ++i) {
+        ret.push(arr[i * every]);
+      }
+      return ret;
+    };
+  }).filter('fixedPrecisionTimeDiff', function () {
+    var SECOND = 1000;
+    var MINUTE = 60 * SECOND;
+    var HOUR = 60 * MINUTE;
+    var DAY = 24 * HOUR;
+
+    return function (diff) {
+      if (diff < SECOND) {
+        // ex: 433ms
+        return diff + 'ms';
+      } else if (diff < MINUTE) {
+        // ex: 17.2s
+        return Math.floor(diff / SECOND) + '.' +
+          Math.floor((diff % SECOND) / 100) + 's'
+      } else if (diff < HOUR) {
+        // ex: 12m48s
+        return Math.floor(diff / MINUTE) + 'm' +
+          Math.floor((diff % MINUTE) / SECOND) + 's';
+      } else if (diff < DAY) {
+        // ex: 13h27m
+        return Math.floor(diff / HOUR) + 'h' +
+          Math.floor((diff % HOUR) / MINUTE) + 'm';
+      } else {
+        return '>=1d';
+      }
+    };
+  })
+  // Displays input value as percentage
+  // "0.85 | percentage" => "85"
+  .filter('percentage', function () {
+    return function (input) {
+      return input * 100
+    }
+  })
+
+  .filter('statusFilter', function () {
+    return function (task) {
+      // for task test results, return the status passed in
+      if (task !== Object(task)) {
+        return task;
+      }
+      var cls = task.status;
+      if (task.status == 'started') {
+        cls = 'started';
+      } else if (task.status == 'success') {
+        cls = 'success';
+      } else if (task.status == 'failed') {
+        cls = 'failed';
+        // Get a property name where task details are stored
+        // Name may differe from API to API
+        let detailsProp = _.find(['task_end_details', 'status_details'], d => d in task)
+        if (detailsProp) {
+          let details = task[detailsProp]
+          if ('type' in details) {
+            if (details.type == 'system' && details.status != 'success') {
+              cls = 'system-failed';
+            }
+            if (details.type == 'setup' && details.status != 'success') {
+              cls = 'setup-failed';
+            }
+          }
+          if ('timed_out' in details) {
+            if (details.timed_out && 'desc' in details && details.desc == 'heartbeat') {
+              cls = 'system-failed';
+            }
+          }
+        }
+      } else if (task.status == 'undispatched' || task.status == 'inactive' || task.status == 'unstarted' || (task.display_only && task.task_waiting)) {
+        if (!task.activated) {
+          cls = 'inactive';
+        } else {
+          cls = 'unstarted';
+        }
+      }
+      return cls;
+    }
+  })
+
+  .filter('statusLabel', function () {
+    return function (task) {
+      if (task.status == 'started') {
+        return 'started';
+      } else if (task.status == 'undispatched' && task.activated) {
+        if (task.task_waiting) {
+          return task.task_waiting;
+        }
+        return 'scheduled';
+      } else if (task.status == 'undispatched' && !task.activated) {
+        // dispatch_time could be a string or a number. to check when the dispatch_time
+        // is a real value, this if-statement accounts for cases where
+        // dispatch_time is 0, "0" or even new Date(0) or older.
+        if (!task.dispatch_time || task.dispatch_time == 0 || (typeof task.dispatch_time === "string" && +new Date(task.dispatch_time) <= 0)) {
+          return "not scheduled"
+        }
+        return 'aborted';
+      } else if (task.status == 'success') {
+        return 'success';
+      } else if (task.status == 'failed') {
+        // Get a property name where task details are stored
+        // Name may differe from API to API
+        let detailsProp = _.find(['task_end_details', 'status_details'], d => d in task)
+        if (detailsProp) {
+          let details = task[detailsProp]
+          if ('timed_out' in details) {
+            if (details.timed_out && 'desc' in details && details.desc == 'heartbeat') {
+              return 'system unresponsive';
+            }
+            if (details.type == 'setup') {
+              return 'setup timed out';
+            }
+            if (details.type == 'system') {
+              return 'system timed out';
+            }
+            return 'test timed out';
+          }
+          if (details.type == 'system' && details.status != 'success') {
+            return 'system failure';
+          }
+          if (details.type == 'setup' && details.status != 'success') {
+            return 'setup failure';
+          }
+          return 'failed';
+        }
+      }
+      if (task.task_waiting && !task.override_dependencies) {
+        return task.task_waiting;
+      }
+      return task.status;
+    }
+  })
+
+  .filter('endOfPath', function () {
+    return function (input) {
+      var lastSlash = input.lastIndexOf('/');
+      if (lastSlash === -1 || lastSlash === input.length - 1) {
+        // try to find the index using windows-style filesystem separators
+        lastSlash = input.lastIndexOf('\\');
+        if (lastSlash === -1 || lastSlash === input.length - 1) {
+          return input;
+        }
+      }
+      return input.substring(lastSlash + 1);
+    }
+  })
+
+  .filter('buildStatus', function () {
+    // given a list of tasks, returns the status of the overall build.
+    return function (tasks) {
+      var countSuccess = 0;
+      var countInProgress = 0;
+      var countActive = 0;
+      for (i = 0; i < tasks.length; i++) {
+        // if any task is failed, the build status is "failed"
+        if (tasks[i].status == "failed") {
+          return "block-status-failed";
+        }
+        if (tasks[i].status == "success") {
+          countSuccess++;
+        } else if (tasks[i].status == "dispatched" || tasks[i].status == "started") {
+          countInProgress++;
+        } else if (tasks[i].status == "undispatched") {
+          countActive += tasks[i].activated ? 1 : 0;
+        }
+      }
+      if (countSuccess == tasks.length) {
+        // all tasks are passing
+        return "block-status-success";
+      } else if (countInProgress > 0) {
+        // no failures yet, but at least 1 task in still progress
+        return "block-status-started";
+      } else if (countActive > 0) {
+        // no failures yet, but at least 1 task still active
+        return "block-status-created";
+      }
+      // no active tasks pending
+      return "block-status-inactive";
+    }
+  })
+  .filter('expandedMetricConverter', function () {
+    return function (data, execution) {
+      if (!data) {
+        return null;
+      }
+      var output = {
+        data: {
+          "results": []
+        }
+      };
+
+      _.each(data, function (test) {
+        let singleTest = convertSingleTest(test, execution);
+        if (singleTest) {
+          output.data.results = output.data.results.concat(singleTest.data.results);
+        }
+      })
+
+      return output;
+    }
+  })
+  .filter('expandedHistoryConverter', function () {
+    return function (data, execution) {
+      if (!data) {
+        return null;
+      }
+      let output = [];
+
+      _.each(data, function (test) {
+        const converted = convertSingleTest(test, execution);
+        if (converted) {
+          output.push(converted);
+        }
+      })
+
+      return output;
+    }
+  })
+  // merges two sets of perf results, taking metadata from the second sample but giving test result preference to the first one
+  .filter('mergePerfResults', function () {
+    return function (firstSample, secondSample) {
+      if (!firstSample) {
+        return secondSample;
+      }
+      if (!secondSample) {
+        return firstSample;
+      }
+      var toReturn = Object.assign({}, secondSample);
+      tempResults = {};
+
+      _.each(secondSample.data.results, function (result) {
+        tempResults[result.name] = result;
+      })
+      _.each(firstSample.data.results, function (result) {
+        tempResults[result.name] = result;
+      })
+      toReturn.data.results = _.toArray(tempResults);
+
+      return toReturn;
+    }
+  })

--- a/public/static/js/filters/filters.test.js
+++ b/public/static/js/filters/filters.test.js
@@ -1,16 +1,16 @@
-describe('FiltersTest', function() {
+describe('FiltersTest', function () {
   beforeEach(module('MCI'));
 
   let statusLabel
 
-  beforeEach(inject(function($injector) {
+  beforeEach(inject(function ($injector) {
     let $filter = $injector.get('$filter')
     statusLabel = $filter('statusLabel')
   }))
 
 
-  describe('statusLabel filter test', function() {
-    it('Tasks with overriden dependencies are not blocked', function() {
+  describe('statusLabel filter test', function () {
+    it('Tasks with overriden dependencies are not blocked', function () {
       expect(
         statusLabel({
           task_waiting: 'blocked',
@@ -20,219 +20,218 @@ describe('FiltersTest', function() {
       ).toBe('success')
     })
 
-    it('Successfull tasks displayed as successfull', function() {
+    it('Successfull tasks displayed as successfull', function () {
       expect(
-        statusLabel({status: 'success'})
+        statusLabel({
+          status: 'success'
+        })
       ).toBe('success')
     })
 
-    it('Waiting tasks displayed as blocked', function() {
+    it('Waiting tasks displayed as blocked', function () {
       expect(
-        statusLabel({task_waiting: 'blocked'})
+        statusLabel({
+          task_waiting: 'blocked'
+        })
       ).toBe('blocked')
     })
   })
 });
 
-describe('expandedHistoryConverter', function() {
+describe('expandedHistoryConverter', function () {
   beforeEach(module('MCI'));
 
   let expandedHistoryConverter;
-  let rawData = [
-    {
-      "name" : "8ff0d32307c7d1bc7afa4b30ce4366d5f9f22850",
-      "info" : {
-        "project" : "sys-perf",
-        "version" : "sys_perf_4807c2165b552670c9fe66c79c6d5be34e845023",
-        "order" : 18362,
-        "variant" : "linux-1-node-15gbwtcache",
-        "task_name" : "out_of_cache_scanner",
-        "task_id" : "sys_perf_linux_1_node_15gbwtcache_out_of_cache_scanner_4807c2165b552670c9fe66c79c6d5be34e845023_19_09_04_18_45_37",
-        "execution" : 0,
-        "test_name" : "out_of_cache_scanner",
-        "trial" : 0,
-        "parent" : "",
-        "tags" : null,
-        "args" : null
+  let rawData = [{
+      "name": "8ff0d32307c7d1bc7afa4b30ce4366d5f9f22850",
+      "info": {
+        "project": "sys-perf",
+        "version": "sys_perf_4807c2165b552670c9fe66c79c6d5be34e845023",
+        "order": 18362,
+        "variant": "linux-1-node-15gbwtcache",
+        "task_name": "out_of_cache_scanner",
+        "task_id": "sys_perf_linux_1_node_15gbwtcache_out_of_cache_scanner_4807c2165b552670c9fe66c79c6d5be34e845023_19_09_04_18_45_37",
+        "execution": 0,
+        "test_name": "out_of_cache_scanner",
+        "trial": 0,
+        "parent": "",
+        "tags": null,
+        "args": null
       },
-      "created_at" : "2019-09-06T01:14:10.000Z",
-      "completed_at" : "2019-09-06T02:03:19.000Z",
-      "artifacts" : null,
-      "rollups" : {
-        "stats" : null,
-        "processed_at" : null,
-        "valid" : false
+      "created_at": "2019-09-06T01:14:10.000Z",
+      "completed_at": "2019-09-06T02:03:19.000Z",
+      "artifacts": null,
+      "rollups": {
+        "stats": null,
+        "processed_at": null,
+        "valid": false
       }
     },
     {
-      "name" : "4bc9e4beb31e36d3cd83adbd75f5f8eb63c5a09c",
-      "info" : {
-        "project" : "sys-perf",
-        "version" : "sys_perf_4807c2165b552670c9fe66c79c6d5be34e845023",
-        "order" : 18362,
-        "variant" : "linux-1-node-15gbwtcache",
-        "task_name" : "out_of_cache_scanner",
-        "task_id" : "sys_perf_linux_1_node_15gbwtcache_out_of_cache_scanner_4807c2165b552670c9fe66c79c6d5be34e845023_19_09_04_18_45_37",
-        "execution" : 0,
-        "test_name" : "ColdScanner-Scan.2",
-        "trial" : 0,
-        "parent" : "8ff0d32307c7d1bc7afa4b30ce4366d5f9f22850",
-        "tags" : null,
-        "args" : null
+      "name": "4bc9e4beb31e36d3cd83adbd75f5f8eb63c5a09c",
+      "info": {
+        "project": "sys-perf",
+        "version": "sys_perf_4807c2165b552670c9fe66c79c6d5be34e845023",
+        "order": 18362,
+        "variant": "linux-1-node-15gbwtcache",
+        "task_name": "out_of_cache_scanner",
+        "task_id": "sys_perf_linux_1_node_15gbwtcache_out_of_cache_scanner_4807c2165b552670c9fe66c79c6d5be34e845023_19_09_04_18_45_37",
+        "execution": 0,
+        "test_name": "ColdScanner-Scan.2",
+        "trial": 0,
+        "parent": "8ff0d32307c7d1bc7afa4b30ce4366d5f9f22850",
+        "tags": null,
+        "args": null
       },
-      "created_at" : "2019-09-06T01:14:10.000Z",
-      "completed_at" : "2019-09-06T02:03:19.000Z",
-      "artifacts" : [
-        {
-          "type" : "s3",
-          "bucket" : "genny-metrics",
-          "prefix" : "sys_perf_linux_1_node_15gbwtcache_out_of_cache_scanner_4807c2165b552670c9fe66c79c6d5be34e845023_19_09_04_18_45_37_0",
-          "path" : "ColdScanner-Scan.2",
-          "format" : "ftdc",
-          "compression" : "none",
-          "schema" : "raw-events",
-          "tags" : null,
-          "created_at" : "2019-09-06T02:03:23.790Z",
-          "download_url" : "https://genny-metrics.s3.amazonaws.com/sys_perf_linux_1_node_15gbwtcache_out_of_cache_scanner_4807c2165b552670c9fe66c79c6d5be34e845023_19_09_04_18_45_37_0/ColdScanner-Scan.2"
-        }
-      ],
-      "rollups" : {
-        "stats" : [
-          {
-            "name" : "AverageLatency",
-            "val" : 7010.185110530556,
-            "version" : 3,
-            "user" : false
+      "created_at": "2019-09-06T01:14:10.000Z",
+      "completed_at": "2019-09-06T02:03:19.000Z",
+      "artifacts": [{
+        "type": "s3",
+        "bucket": "genny-metrics",
+        "prefix": "sys_perf_linux_1_node_15gbwtcache_out_of_cache_scanner_4807c2165b552670c9fe66c79c6d5be34e845023_19_09_04_18_45_37_0",
+        "path": "ColdScanner-Scan.2",
+        "format": "ftdc",
+        "compression": "none",
+        "schema": "raw-events",
+        "tags": null,
+        "created_at": "2019-09-06T02:03:23.790Z",
+        "download_url": "https://genny-metrics.s3.amazonaws.com/sys_perf_linux_1_node_15gbwtcache_out_of_cache_scanner_4807c2165b552670c9fe66c79c6d5be34e845023_19_09_04_18_45_37_0/ColdScanner-Scan.2"
+      }],
+      "rollups": {
+        "stats": [{
+            "name": "AverageLatency",
+            "val": 7010.185110530556,
+            "version": 3,
+            "user": false
           },
           {
-            "name" : "AverageSize",
-            "val" : 130,
-            "version" : 3,
-            "user" : false
+            "name": "AverageSize",
+            "val": 130,
+            "version": 3,
+            "user": false
           },
           {
-            "name" : "OperationThroughput",
-            "val" : 2059576.0991914733,
-            "version" : 4,
-            "user" : false
+            "name": "OperationThroughput",
+            "val": 2059576.0991914733,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "SizeThroughput",
-            "val" : 267744892.89489153,
-            "version" : 4,
-            "user" : false
+            "name": "SizeThroughput",
+            "val": 267744892.89489153,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "ErrorRate",
-            "val" : 0,
-            "version" : 4,
-            "user" : false
+            "name": "ErrorRate",
+            "val": 0,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "Latency50thPercentile",
-            "val" : 780947002426.5,
-            "version" : 4,
-            "user" : false
+            "name": "Latency50thPercentile",
+            "val": 780947002426.5,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "Latency80thPercentile",
-            "val" : 1104667169411,
-            "version" : 4,
-            "user" : false
+            "name": "Latency80thPercentile",
+            "val": 1104667169411,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "Latency90thPercentile",
-            "val" : 1104678496947.6333,
-            "version" : 4,
-            "user" : false
+            "name": "Latency90thPercentile",
+            "val": 1104678496947.6333,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "Latency95thPercentile",
-            "val" : 1104684900770,
-            "version" : 4,
-            "user" : false
+            "name": "Latency95thPercentile",
+            "val": 1104684900770,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "Latency99thPercentile",
-            "val" : 1104684900770,
-            "version" : 4,
-            "user" : false
+            "name": "Latency99thPercentile",
+            "val": 1104684900770,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "WorkersMin",
-            "val" : 6,
-            "version" : 3,
-            "user" : false
+            "name": "WorkersMin",
+            "val": 6,
+            "version": 3,
+            "user": false
           },
           {
-            "name" : "WorkersMax",
-            "val" : 6,
-            "version" : 3,
-            "user" : false
+            "name": "WorkersMax",
+            "val": 6,
+            "version": 3,
+            "user": false
           },
           {
-            "name" : "LatencyMin",
-            "val" : 697970870799,
-            "version" : 4,
-            "user" : false
+            "name": "LatencyMin",
+            "val": 697970870799,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "LatencyMax",
-            "val" : 1104684900770,
-            "version" : 4,
-            "user" : false
+            "name": "LatencyMax",
+            "val": 1104684900770,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "DurationTotal",
-            "val" : 699173000000,
-            "version" : 4,
-            "user" : false
+            "name": "DurationTotal",
+            "val": 699173000000,
+            "version": 4,
+            "user": false
           },
           {
-            "name" : "ErrorsTotal",
-            "val" : 0,
-            "version" : 3,
-            "user" : false
+            "name": "ErrorsTotal",
+            "val": 0,
+            "version": 3,
+            "user": false
           },
           {
-            "name" : "OperationsTotal",
-            "val" : 1440000000,
-            "version" : 3,
-            "user" : false
+            "name": "OperationsTotal",
+            "val": 1440000000,
+            "version": 3,
+            "user": false
           },
           {
-            "name" : "SizeTotal",
-            "val" : 187200000000,
-            "version" : 3,
-            "user" : false
+            "name": "SizeTotal",
+            "val": 187200000000,
+            "version": 3,
+            "user": false
           },
           {
-            "name" : "OverheadTotal",
-            "val" : 6057087203,
-            "version" : 1,
-            "user" : false
+            "name": "OverheadTotal",
+            "val": 6057087203,
+            "version": 1,
+            "user": false
           }
         ],
-        "processed_at" : null,
-        "valid" : false
+        "processed_at": null,
+        "valid": false
       }
     }
   ];
 
-  beforeEach(inject(function($injector) {
+  beforeEach(inject(function ($injector) {
     const $filter = $injector.get('$filter');
     expandedHistoryConverter = $filter('expandedHistoryConverter');
   }));
 
-  it('should handle empty', function() {
+  it('should handle empty', function () {
     expect(expandedHistoryConverter(undefined)).toBe(null);
     expect(expandedHistoryConverter(null)).toBe(null);
     expect(expandedHistoryConverter([])).toEqual([]);
   });
 
-  it('should convert data', function() {
-    expect(expandedHistoryConverter(rawData)).toEqual([
-      {
+  it('should convert data', function () {
+    expect(expandedHistoryConverter(rawData)).toEqual([{
         "data": {
           "results": []
         },
@@ -247,92 +246,90 @@ describe('expandedHistoryConverter', function() {
       },
       {
         "data": {
-          "results": [
-            {
-              "name": "ColdScanner-Scan.2",
-              "isExpandedMetric": true,
-              "results": {
-                "6": {
-                  "AverageLatency": 7010.185110530556,
-                  "AverageLatency_values": [
-                    7010.185110530556
-                  ],
-                  "AverageSize": 130,
-                  "AverageSize_values": [
-                    130
-                  ],
-                  "OperationThroughput": 2059576.0991914733,
-                  "OperationThroughput_values": [
-                    2059576.0991914733
-                  ],
-                  "SizeThroughput": 267744892.89489153,
-                  "SizeThroughput_values": [
-                    267744892.89489153
-                  ],
-                  "ErrorRate": 0,
-                  "ErrorRate_values": [
-                    0
-                  ],
-                  "Latency50thPercentile": 780947002426.5,
-                  "Latency50thPercentile_values": [
-                    780947002426.5
-                  ],
-                  "Latency80thPercentile": 1104667169411,
-                  "Latency80thPercentile_values": [
-                    1104667169411
-                  ],
-                  "Latency90thPercentile": 1104678496947.6333,
-                  "Latency90thPercentile_values": [
-                    1104678496947.6333
-                  ],
-                  "Latency95thPercentile": 1104684900770,
-                  "Latency95thPercentile_values": [
-                    1104684900770
-                  ],
-                  "Latency99thPercentile": 1104684900770,
-                  "Latency99thPercentile_values": [
-                    1104684900770
-                  ],
-                  "WorkersMin": 6,
-                  "WorkersMin_values": [
-                    6
-                  ],
-                  "WorkersMax": 6,
-                  "WorkersMax_values": [
-                    6
-                  ],
-                  "LatencyMin": 697970870799,
-                  "LatencyMin_values": [
-                    697970870799
-                  ],
-                  "LatencyMax": 1104684900770,
-                  "LatencyMax_values": [
-                    1104684900770
-                  ],
-                  "DurationTotal": 699173000000,
-                  "DurationTotal_values": [
-                    699173000000
-                  ],
-                  "ErrorsTotal": 0,
-                  "ErrorsTotal_values": [
-                    0
-                  ],
-                  "OperationsTotal": 1440000000,
-                  "OperationsTotal_values": [
-                    1440000000
-                  ],
-                  "SizeTotal": 187200000000,
-                  "SizeTotal_values": [
-                    187200000000
-                  ],
-                  "OverheadTotal": 6057087203,
-                  "OverheadTotal_values": [
-                    6057087203
-                  ]
-                }
+          "results": [{
+            "name": "ColdScanner-Scan.2",
+            "isExpandedMetric": true,
+            "results": {
+              "6": {
+                "AverageLatency": 7010.185110530556,
+                "AverageLatency_values": [
+                  7010.185110530556
+                ],
+                "AverageSize": 130,
+                "AverageSize_values": [
+                  130
+                ],
+                "OperationThroughput": 2059576.0991914733,
+                "OperationThroughput_values": [
+                  2059576.0991914733
+                ],
+                "SizeThroughput": 267744892.89489153,
+                "SizeThroughput_values": [
+                  267744892.89489153
+                ],
+                "ErrorRate": 0,
+                "ErrorRate_values": [
+                  0
+                ],
+                "Latency50thPercentile": 780947002426.5,
+                "Latency50thPercentile_values": [
+                  780947002426.5
+                ],
+                "Latency80thPercentile": 1104667169411,
+                "Latency80thPercentile_values": [
+                  1104667169411
+                ],
+                "Latency90thPercentile": 1104678496947.6333,
+                "Latency90thPercentile_values": [
+                  1104678496947.6333
+                ],
+                "Latency95thPercentile": 1104684900770,
+                "Latency95thPercentile_values": [
+                  1104684900770
+                ],
+                "Latency99thPercentile": 1104684900770,
+                "Latency99thPercentile_values": [
+                  1104684900770
+                ],
+                "WorkersMin": 6,
+                "WorkersMin_values": [
+                  6
+                ],
+                "WorkersMax": 6,
+                "WorkersMax_values": [
+                  6
+                ],
+                "LatencyMin": 697970870799,
+                "LatencyMin_values": [
+                  697970870799
+                ],
+                "LatencyMax": 1104684900770,
+                "LatencyMax_values": [
+                  1104684900770
+                ],
+                "DurationTotal": 699173000000,
+                "DurationTotal_values": [
+                  699173000000
+                ],
+                "ErrorsTotal": 0,
+                "ErrorsTotal_values": [
+                  0
+                ],
+                "OperationsTotal": 1440000000,
+                "OperationsTotal_values": [
+                  1440000000
+                ],
+                "SizeTotal": 187200000000,
+                "SizeTotal_values": [
+                  187200000000
+                ],
+                "OverheadTotal": 6057087203,
+                "OverheadTotal_values": [
+                  6057087203
+                ]
               }
             }
-          ]
+          }]
         },
         "create_time": "2019-09-06T01:14:10.000Z",
         "order": 18362,
@@ -346,3 +343,352 @@ describe('expandedHistoryConverter', function() {
     ])
   })
 });
+
+describe('expandedMetricConverter', function () {
+  beforeEach(module('MCI'));
+
+  beforeEach(inject(function ($injector) {
+    const $filter = $injector.get('$filter');
+    expandedMetricConverter = $filter('expandedMetricConverter');
+  }));
+
+  it('Correctly formatted data should be converted correctly', function () {
+    const dataSample = [{
+        "name": "87a18ca40e878b535409db66a071bb92a0bee20b",
+        "info": {
+          "project": "sys-perf",
+          "version": "sys_perf_95eedd93ea7a5b8b35b9bb042d5ca165736c17c2",
+          "order": 19613,
+          "variant": "wtdevelop-1-node-replSet",
+          "task_name": "insert_remove",
+          "task_id": "sys_perf_wtdevelop_1_node_replSet_insert_remove_95eedd93ea7a5b8b35b9bb042d5ca165736c17c2_19_12_05_04_28_59",
+          "execution": 0,
+          "test_name": "insert_remove",
+          "trial": 0,
+          "parent": "",
+          "tags": null,
+          "args": null
+        },
+        "created_at": "2019-12-05T07:19:22.000Z",
+        "completed_at": "2019-12-05T07:31:57.000Z",
+        "artifacts": null,
+        "rollups": {
+          "stats": null,
+          "processed_at": null,
+          "valid": false
+        }
+      },
+      {
+        "name": "2668d260c2a7925689b21524d4c7b943fe91c3fa",
+        "info": {
+          "project": "sys-perf",
+          "version": "sys_perf_95eedd93ea7a5b8b35b9bb042d5ca165736c17c2",
+          "order": 19613,
+          "variant": "wtdevelop-1-node-replSet",
+          "task_name": "insert_remove",
+          "task_id": "sys_perf_wtdevelop_1_node_replSet_insert_remove_95eedd93ea7a5b8b35b9bb042d5ca165736c17c2_19_12_05_04_28_59",
+          "execution": 0,
+          "test_name": "InsertRemoveTest-Insert",
+          "trial": 0,
+          "parent": "87a18ca40e878b535409db66a071bb92a0bee20b",
+          "tags": null,
+          "args": null
+        },
+        "created_at": "2019-12-05T07:19:22.000Z",
+        "completed_at": "2019-12-05T07:31:57.000Z",
+        "artifacts": [{
+          "type": "s3",
+          "bucket": "genny-metrics",
+          "prefix": "sys_perf_wtdevelop_1_node_replSet_insert_remove_95eedd93ea7a5b8b35b9bb042d5ca165736c17c2_19_12_05_04_28_59_0",
+          "path": "InsertRemoveTest-Insert",
+          "format": "ftdc",
+          "compression": "none",
+          "schema": "raw-events",
+          "tags": null,
+          "created_at": "2019-12-05T07:34:02.875Z",
+          "download_url": "www.example.com"
+        }],
+        "rollups": {
+          "stats": [{
+              "name": "AverageLatency",
+              "val": 3116886.561614268,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "AverageSize",
+              "val": 14,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "OperationThroughput",
+              "val": 15876.74890823621,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "SizeThroughput",
+              "val": 222274.48471530696,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "ErrorRate",
+              "val": 0,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "Latency50thPercentile",
+              "val": 2775838,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "Latency80thPercentile",
+              "val": 4533626.800000002,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "Latency90thPercentile",
+              "val": 5624434.400000001,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "Latency95thPercentile",
+              "val": 6629202.40000001,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "Latency99thPercentile",
+              "val": 8782489.040000014,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "WorkersMin",
+              "val": 100,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "WorkersMax",
+              "val": 100,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "LatencyMin",
+              "val": 262779,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "LatencyMax",
+              "val": 572543762,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "DurationTotal",
+              "val": 179755000000,
+              "version": 4,
+              "user": false
+            },
+            {
+              "name": "ErrorsTotal",
+              "val": 0,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "OperationsTotal",
+              "val": 2853925,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "SizeTotal",
+              "val": 39954950,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "OverheadTotal",
+              "val": 9097063636926,
+              "version": 1,
+              "user": false
+            }
+          ],
+          "processed_at": null,
+          "valid": false
+        }
+      }
+    ]
+
+    const expected = {
+      "data": {
+        "results": [{
+          "name": "InsertRemoveTest-Insert",
+          "isExpandedMetric": true,
+          "results": {
+            "100": {
+              "AverageLatency": 3116886.561614268,
+              "AverageLatency_values": [3116886.561614268],
+              "AverageSize": 14,
+              "AverageSize_values": [14],
+              "OperationThroughput": 15876.74890823621,
+              "OperationThroughput_values": [15876.74890823621],
+              "SizeThroughput": 222274.48471530696,
+              "SizeThroughput_values": [222274.48471530696],
+              "ErrorRate": 0,
+              "ErrorRate_values": [0],
+              "Latency50thPercentile": 2775838,
+              "Latency50thPercentile_values": [2775838],
+              "Latency80thPercentile": 4533626.800000002,
+              "Latency80thPercentile_values": [4533626.800000002],
+              "Latency90thPercentile": 5624434.400000001,
+              "Latency90thPercentile_values": [5624434.400000001],
+              "Latency95thPercentile": 6629202.40000001,
+              "Latency95thPercentile_values": [6629202.40000001],
+              "Latency99thPercentile": 8782489.040000014,
+              "Latency99thPercentile_values": [8782489.040000014],
+              "WorkersMin": 100,
+              "WorkersMin_values": [100],
+              "WorkersMax": 100,
+              "WorkersMax_values": [100],
+              "LatencyMin": 262779,
+              "LatencyMin_values": [262779],
+              "LatencyMax": 572543762,
+              "LatencyMax_values": [572543762],
+              "DurationTotal": 179755000000,
+              "DurationTotal_values": [179755000000],
+              "ErrorsTotal": 0,
+              "ErrorsTotal_values": [0],
+              "OperationsTotal": 2853925,
+              "OperationsTotal_values": [2853925],
+              "SizeTotal": 39954950,
+              "SizeTotal_values": [39954950],
+              "OverheadTotal": 9097063636926,
+              "OverheadTotal_values": [9097063636926]
+            }
+          }
+        }]
+      }
+    }
+
+    expect(expandedMetricConverter(dataSample, 0)).toEqual(expected);
+  })
+
+  it('Not passing an execution should use the latest one', function () {
+    const dataSample = [{
+        "name": "2668d260c2a7925689b21524d4c7b943fe91c3fa",
+        "info": {
+          "project": "sys-perf",
+          "version": "sys_perf_95eedd93ea7a5b8b35b9bb042d5ca165736c17c2",
+          "order": 19613,
+          "variant": "wtdevelop-1-node-replSet",
+          "task_name": "insert_remove",
+          "task_id": "sys_perf_wtdevelop_1_node_replSet_insert_remove_95eedd93ea7a5b8b35b9bb042d5ca165736c17c2_19_12_05_04_28_59",
+          "execution": 0,
+          "test_name": "InsertRemoveTest-Insert",
+          "trial": 0,
+          "parent": "87a18ca40e878b535409db66a071bb92a0bee20b",
+          "tags": null,
+          "args": null
+        },
+        "created_at": "2019-12-05T07:19:22.000Z",
+        "completed_at": "2019-12-05T07:31:57.000Z",
+        "rollups": {
+          "stats": [{
+              "name": "AverageLatency",
+              "val": 3116886.561614268,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "WorkersMin",
+              "val": 100,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "WorkersMax",
+              "val": 100,
+              "version": 3,
+              "user": false
+            },
+          ],
+          "processed_at": null,
+          "valid": false
+        }
+      },
+      {
+        "name": "2668d260c2a7925689b21524d4c7b943fe91c3fb",
+        "info": {
+          "project": "sys-perf",
+          "version": "sys_perf_95eedd93ea7a5b8b35b9bb042d5ca165736c17c2",
+          "order": 19613,
+          "variant": "wtdevelop-1-node-replSet",
+          "task_name": "insert_remove",
+          "task_id": "sys_perf_wtdevelop_1_node_replSet_insert_remove_95eedd93ea7a5b8b35b9bb042d5ca165736c17c2_19_12_05_04_28_59",
+          "execution": 1,
+          "test_name": "InsertRemoveTest-Insert",
+          "trial": 0,
+          "parent": "87a18ca40e878b535409db66a071bb92a0bee20b",
+          "tags": null,
+          "args": null
+        },
+        "created_at": "2019-12-05T07:19:22.000Z",
+        "completed_at": "2019-12-05T07:31:57.000Z",
+        "rollups": {
+          "stats": [{
+              "name": "AverageLatency",
+              "val": 12345,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "WorkersMin",
+              "val": 100,
+              "version": 3,
+              "user": false
+            },
+            {
+              "name": "WorkersMax",
+              "val": 100,
+              "version": 3,
+              "user": false
+            },
+          ],
+          "processed_at": null,
+          "valid": false
+        }
+      }
+    ]
+
+    const expected = {
+      "data": {
+        "results": [{
+          "name": "InsertRemoveTest-Insert",
+          "isExpandedMetric": true,
+          "results": {
+            "100": {
+              "AverageLatency": 12345,
+              "AverageLatency_values": [12345],
+              "WorkersMin": 100,
+              "WorkersMin_values": [100],
+              "WorkersMax": 100,
+              "WorkersMax_values": [100]
+            }
+          }
+        }]
+      }
+    };
+    expect(expandedMetricConverter(dataSample)).toEqual(expected);
+  })
+})

--- a/service/templates/perfdiscovery.html
+++ b/service/templates/perfdiscovery.html
@@ -43,6 +43,15 @@ Performance Discovery
       Baseline Results
       <version-dropdown model="$ctrl.toSelect" />
     </label>
+
+    <md-input-container style="width: 200px;">
+      <label>Use Expanded Data For:</label>
+      <md-select ng-model="$ctrl.expandedOptions" ng-change="reload()" multiple>
+        <md-option value="current">Current Results</md-option>
+        <md-option value="baseline">Baseline Results</md-option>
+        <md-option value="history">History</md-option>
+      </md-select>
+    </md-input-container>
   </div>
 
   <div


### PR DESCRIPTION
- Run a formatter on the files I touched (don't review the first commit)
- Add wrapper methods to retrieve task and trend data from cedar and convert afterwards (same as those used in trend charts)
- Conditionally use those to retrieve data, based on user selecting what they want to be the data source for the current/baseline/trend data
<img width="1668" alt="Screen Shot 2019-12-04 at 11 41 23 AM" src="https://user-images.githubusercontent.com/29384396/70162038-0b0eb580-168b-11ea-81f1-2edd37946f92.png">
