### PR TITLE
EVG-6454 use githashes from patch modules

### DIFF
--- a/model/manifest/db.go
+++ b/model/manifest/db.go
@@ -1,7 +1,9 @@
 package manifest
 
 import (
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
 	"github.com/pkg/errors"
@@ -54,24 +56,35 @@ func ByProjectAndRevision(project, revision string) db.Q {
 	})
 }
 
-func FindFromVersion(versionID, project, revision string) (*Manifest, error) {
+func FindFromVersion(versionID, project, revision, requester string) (*Manifest, error) {
 	manifest, err := FindOne(ById(versionID))
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding manifest")
 	}
+
+	// the version wasn't from the repotracker
 	if manifest == nil {
 		manifest, err = FindOne(ByProjectAndRevision(project, revision))
 		if err != nil {
 			return nil, errors.Wrap(err, "error finding manifest")
 		}
+		if manifest != nil {
+			if evergreen.IsPatchRequester(requester) {
+				p, err := patch.FindOne(patch.ById(patch.NewId(versionID)))
+				if err != nil {
+					return nil, errors.Wrapf(err, "can't get patch for '%s'", versionID)
+				}
+				if p == nil {
+					return nil, errors.Errorf("no corresponding patch with id '%s'", versionID)
+				}
+				manifest.ModuleOverrides = make(map[string]string)
+				for _, patchModule := range p.Patches {
+					if patchModule.ModuleName != "" && patchModule.Githash != "" {
+						manifest.ModuleOverrides[patchModule.ModuleName] = patchModule.Githash
+					}
+				}
+			}
+		}
 	}
 	return manifest, err
-}
-
-func updateRevision(manifestId, moduleName, newRevision string) error {
-	return db.UpdateId(Collection, manifestId, bson.M{
-		"$set": bson.M{
-			bsonutil.GetDottedKeyName(ModulesKey, moduleName, ModuleRevisionKey): newRevision,
-		},
-	})
 }

--- a/model/manifest/manifest.go
+++ b/model/manifest/manifest.go
@@ -14,7 +14,7 @@ type Manifest struct {
 	ProjectName     string             `json:"project" bson:"project"`
 	Branch          string             `json:"branch" bson:"branch"`
 	Modules         map[string]*Module `json:"modules" bson:"modules"`
-	ModuleOverrides map[string]string  `json:"module_overrides,omitempty" bson:"module_overrides,omitempty"`
+	ModuleOverrides map[string]string  `json:"module_overrides,omitempty" bson:"omitempty"`
 }
 
 // A Module is a snapshot of the module associated with a version.

--- a/model/manifest/manifest.go
+++ b/model/manifest/manifest.go
@@ -1,9 +1,5 @@
 package manifest
 
-import (
-	"github.com/pkg/errors"
-)
-
 const Collection = "manifest"
 
 // Manifest is a representation of the modules associated with the a version.
@@ -13,11 +9,12 @@ const Collection = "manifest"
 // Branch is the branch of the repository. Modules is a map of the GitHub repository name to the
 // Module's information associated with the specific version.
 type Manifest struct {
-	Id          string             `json:"id" bson:"_id"`
-	Revision    string             `json:"revision" bson:"revision"`
-	ProjectName string             `json:"project" bson:"project"`
-	Branch      string             `json:"branch" bson:"branch"`
-	Modules     map[string]*Module `json:"modules" bson:"modules"`
+	Id              string             `json:"id" bson:"_id"`
+	Revision        string             `json:"revision" bson:"revision"`
+	ProjectName     string             `json:"project" bson:"project"`
+	Branch          string             `json:"branch" bson:"branch"`
+	Modules         map[string]*Module `json:"modules" bson:"modules"`
+	ModuleOverrides map[string]string  `json:"module_overrides,omitempty" bson:"module_overrides,omitempty"`
 }
 
 // A Module is a snapshot of the module associated with a version.
@@ -32,19 +29,4 @@ type Module struct {
 	Revision string `json:"revision" bson:"revision"`
 	Owner    string `json:"owner" bson:"owner"`
 	URL      string `json:"url" bson:"url"`
-}
-
-func (m *Manifest) UpdateModuleRevision(moduleName, newRevision string) error {
-	wasUpdated := false
-	for name, module := range m.Modules {
-		if name == moduleName {
-			module.Revision = newRevision
-			wasUpdated = true
-		}
-	}
-	if !wasUpdated {
-		return errors.Errorf("no module named %s found", moduleName)
-	}
-
-	return updateRevision(m.Id, moduleName, newRevision)
 }

--- a/model/manifest/manifest.go
+++ b/model/manifest/manifest.go
@@ -14,7 +14,7 @@ type Manifest struct {
 	ProjectName     string             `json:"project" bson:"project"`
 	Branch          string             `json:"branch" bson:"branch"`
 	Modules         map[string]*Module `json:"modules" bson:"modules"`
-	ModuleOverrides map[string]string  `json:"module_overrides,omitempty" bson:"omitempty"`
+	ModuleOverrides map[string]string  `json:"module_overrides,omitempty" bson:"-"`
 }
 
 // A Module is a snapshot of the module associated with a version.

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -298,13 +298,12 @@ func cloneSource(task *service.RestTask, project *model.ProjectRef, config *mode
 		}
 		revision := module.Branch
 		if mfest != nil {
+			mfestModule, ok := mfest.Modules[moduleName]
+			if ok && mfestModule.Revision != "" {
+				revision = mfestModule.Revision
+			}
 			if override, ok := mfest.ModuleOverrides[moduleName]; ok {
 				revision = override
-			} else {
-				mfestModule, ok := mfest.Modules[moduleName]
-				if ok && mfestModule.Revision != "" {
-					revision = mfestModule.Revision
-				}
 			}
 		}
 

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/manifest"
@@ -298,9 +298,13 @@ func cloneSource(task *service.RestTask, project *model.ProjectRef, config *mode
 		}
 		revision := module.Branch
 		if mfest != nil {
-			mfestModule, ok := mfest.Modules[moduleName]
-			if ok && mfestModule.Revision != "" {
-				revision = mfestModule.Revision
+			if override, ok := mfest.ModuleOverrides[moduleName]; ok {
+				revision = override
+			} else {
+				mfestModule, ok := mfest.Modules[moduleName]
+				if ok && mfestModule.Revision != "" {
+					revision = mfestModule.Revision
+				}
 			}
 		}
 

--- a/plugin/manifest_plugin.go
+++ b/plugin/manifest_plugin.go
@@ -34,7 +34,7 @@ func (m *ManifestPlugin) GetPanelConfig() (*PanelConfig, error) {
 					if context.Version == nil {
 						return nil, nil
 					}
-					currentManifest, err := manifest.FindFromVersion(context.Version.Id, context.Version.Identifier, context.Version.Revision)
+					currentManifest, err := manifest.FindFromVersion(context.Version.Id, context.Version.Identifier, context.Version.Revision, context.Version.Requester)
 					if err != nil {
 						return nil, err
 					}

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -198,7 +198,7 @@ func (tc *DBTaskConnector) GetManifestByTask(taskId string) (*manifest.Manifest,
 	if t == nil {
 		return nil, errors.Errorf("task '%s' not found", t.Id)
 	}
-	mfest, err := manifest.FindFromVersion(t.Version, t.Project, t.Revision)
+	mfest, err := manifest.FindFromVersion(t.Version, t.Project, t.Revision, t.Requester)
 	if err != nil {
 		return nil, errors.Wrapf(err, "problem finding manifest from version '%s'", t.Version)
 	}

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/manifest"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/units"
@@ -229,24 +228,6 @@ func (as *APIServer) updatePatchModule(w http.ResponseWriter, r *http.Request) {
 	if err = p.UpdateModulePatch(modulePatch); err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
-	}
-
-	if p.Version != "" {
-		patchVersion, err := model.VersionFindOneId(p.Version)
-		if err != nil {
-			as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err, "error finding patch version %s", p.Version))
-			return
-		}
-		m, err := manifest.FindFromVersion(patchVersion.Id, patchVersion.Identifier, patchVersion.Revision)
-		if err != nil {
-			as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error finding patch manifest"))
-			return
-		}
-		err = m.UpdateModuleRevision(moduleName, githash)
-		if err != nil {
-			as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err, "error finding updating revision for module %s", moduleName))
-			return
-		}
 	}
 
 	gimlet.WriteJSON(w, "Patch module updated")

--- a/service/api_plugin_manifest.go
+++ b/service/api_plugin_manifest.go
@@ -33,7 +33,7 @@ func (as *APIServer) manifestLoadHandler(w http.ResponseWriter, r *http.Request)
 		as.LoggedError(w, r, http.StatusNotFound, errors.Errorf("version not found: %s", task.Version))
 		return
 	}
-	currentManifest, err := manifest.FindFromVersion(v.Id, v.Identifier, v.Revision)
+	currentManifest, err := manifest.FindFromVersion(v.Id, v.Identifier, v.Revision, v.Requester)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest,
 			errors.Wrapf(err, "error retrieving manifest with version id %s", task.Version))

--- a/service/ui_plugin_manifest.go
+++ b/service/ui_plugin_manifest.go
@@ -17,7 +17,7 @@ func (uis *UIServer) GetManifest(w http.ResponseWriter, r *http.Request) {
 	version, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(project, revision))
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error getting version for project %v with revision %v: %v",
-			project, revision, err), http.StatusBadRequest)
+			project, revision, err), http.StatusInternalServerError)
 		return
 	}
 	if version == nil {
@@ -26,15 +26,16 @@ func (uis *UIServer) GetManifest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	foundManifest, err := manifest.FindFromVersion(version.Id, version.Identifier, version.Revision)
+	foundManifest, err := manifest.FindFromVersion(version.Id, version.Identifier, version.Revision, version.Requester)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error getting manifest with version id %v: %v",
-			version.Id, err), http.StatusBadRequest)
+			version.Id, err), http.StatusInternalServerError)
 		return
 	}
 	if foundManifest == nil {
 		http.Error(w, fmt.Sprintf("manifest not found for version %v", version.Id), http.StatusNotFound)
 		return
 	}
+
 	gimlet.WriteJSON(w, foundManifest)
 }


### PR DESCRIPTION
Manifests' records of module githashes are updated when a patch is created that includes module patches where the base commit is not the same as the one recorded in the manifest. This causes the manifest to be incorrect for other versions sharing the same manifest (the repotracker version as well as other patches off the same base commit).
This PR removes the manifest update in favor of dynamically adding a `ModuleOverrides` field to the manifest based on the patch requesting the manifest.