### PR TITLE
EVG-7008 retry with new client if transaction won't abort

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -825,12 +825,11 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 		}
 		_, err = evergreen.GetEnvironment().DB().Collection(model.VersionCollection).InsertOne(sessCtx, v)
 		if err != nil {
-			grip.Notice(message.Fields{
-				"message":    "aborting transaction",
-				"cause":      "can't insert version",
-				"version":    v.Id,
-				"insert_err": err.Error(),
-			})
+			grip.Notice(message.WrapError(err, message.Fields{
+				"message": "aborting transaction",
+				"cause":   "can't insert version",
+				"version": v.Id,
+			}))
 			if err = sessCtx.AbortTransaction(sessCtx); err != nil {
 				return errors.Wrap(err, "error aborting transaction")
 			}
@@ -838,12 +837,11 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 		}
 		_, err = evergreen.GetEnvironment().DB().Collection(build.Collection).InsertMany(sessCtx, buildsToCreate)
 		if err != nil {
-			grip.Error(message.Fields{
-				"message":    "aborting transaction",
-				"cause":      "can't insert builds",
-				"version":    v.Id,
-				"insert_err": err.Error(),
-			})
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "aborting transaction",
+				"cause":   "can't insert builds",
+				"version": v.Id,
+			}))
 			if err = sessCtx.AbortTransaction(sessCtx); err != nil {
 				return errors.Wrap(err, "error aborting transaction")
 			}
@@ -852,12 +850,11 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 		}
 		err = tasksToCreate.InsertUnordered(sessCtx)
 		if err != nil {
-			grip.Error(message.Fields{
-				"message":    "aborting transaction",
-				"cause":      "can't insert tasks",
-				"version":    v.Id,
-				"insert_err": err.Error(),
-			})
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "aborting transaction",
+				"cause":   "can't insert tasks",
+				"version": v.Id,
+			}))
 			if err = sessCtx.AbortTransaction(sessCtx); err != nil {
 				return errors.Wrap(err, "error aborting transaction")
 			}
@@ -865,12 +862,11 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 		}
 		err = sessCtx.CommitTransaction(sessCtx)
 		if err != nil {
-			grip.Error(message.Fields{
-				"message":    "aborting transaction",
-				"cause":      "unable to commit transaction",
-				"version":    v.Id,
-				"insert_err": err.Error(),
-			})
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "aborting transaction",
+				"cause":   "unable to commit transaction",
+				"version": v.Id,
+			}))
 			if err = sessCtx.AbortTransaction(sessCtx); err != nil {
 				return errors.Wrap(err, "error aborting transaction")
 			}


### PR DESCRIPTION
We saw a case of a version not being created for server commit 88956acd276472b1b4c0192f73b07d67c4cae29c-- there was a transaction error and this failed to start the transaction again on retry. Likely what happened is in the first attempt we errored at aborting the transaction, so we couldn't start the transaction again and we don't retry again.

Instead, we should create a new client if an abort attempt fails. 
(Alternatively we could try to abort the transaction in a retry loop, but it's possible there's some reason it can't be aborted and this won't help us move on.)