### PR TITLE
EVG-7014 fix commit queue dequeue for task groups and PR items

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -525,7 +525,7 @@ func TryDequeueAndAbortCommitQueueVersion(projectRef *ProjectRef, versionId, req
 		return errors.Wrapf(err, "can't get commit queue for id '%s'", projectRef.Identifier)
 	}
 	issue := p.Id.Hex()
-	if p.IsGithubPRPatch() {
+	if p.IsPRMergePatch() {
 		issue = strconv.Itoa(p.GithubPatchData.PRNumber)
 	}
 	removed, err := cq.Remove(issue)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1201,10 +1201,8 @@ func TestTryDequeueAndAbortCommitQueueVersion(t *testing.T) {
 	p := &patch.Patch{
 		Version: v.Id,
 		GithubPatchData: patch.GithubPatch{
-			PRNumber:  12,
-			HeadOwner: "evergreen-ci",
-			BaseRepo:  "evergreen",
-			Author:    "octocat",
+			PRNumber:       12,
+			MergeCommitSHA: "abcdef",
 		},
 		Alias:  evergreen.CommitQueueAlias,
 		Status: evergreen.PatchStarted,
@@ -1257,7 +1255,7 @@ func TestTryDequeueAndAbortCommitQueueVersion(t *testing.T) {
 
 	pRef := &ProjectRef{Identifier: cq.ProjectID}
 
-	assert.NoError(t, TryDequeueAndAbortCommitQueueVersion(pRef, v.Id, t1.Requester))
+	assert.NoError(t, TryDequeueAndAbortCommitQueueVersion(pRef, v.Id, evergreen.User))
 	cq, err := commitqueue.FindOneId("my-project")
 	assert.NoError(t, err)
 	assert.Equal(t, cq.FindItem("12"), -1)

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -187,6 +187,20 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// For a single-host task group, if a task fails, block and dequeue later tasks in that group.
+	if t.TaskGroup != "" && t.TaskGroupMaxHosts == 1 && details.Status != evergreen.TaskSucceeded {
+		if err = model.BlockTaskGroupTasks(t.Id); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "problem blocking task group tasks",
+				"task_id": t.Id,
+			}))
+		}
+		grip.Debug(message.Fields{
+			"message": "blocked task group tasks for task",
+			"task_id": t.Id,
+		})
+	}
+
 	// mark task as finished
 	updates := model.StatusChanges{}
 	err = model.MarkEnd(t, APIServerLockTitle, finishTime, details, projectRef.DeactivatePrevious, &updates)
@@ -196,7 +210,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if projectRef.CommitQueue.Enabled && details.Status != evergreen.TaskSucceeded {
+	if t.Requester == evergreen.MergeTestRequester && details.Status != evergreen.TaskSucceeded {
 		if err = model.TryDequeueAndAbortCommitQueueVersion(projectRef, t.Version, APIServerLockTitle); err != nil {
 			err = errors.Wrapf(err, "Error dequeueing and aborting failed commit queue version")
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
@@ -215,20 +229,6 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		endTaskResp = &apimodels.EndTaskResponse{}
 		gimlet.WriteJSON(w, endTaskResp)
 		return
-	}
-
-	// For a single-host task group, if a task fails, block and dequeue later tasks in that group.
-	if t.TaskGroup != "" && t.TaskGroupMaxHosts == 1 && details.Status != evergreen.TaskSucceeded {
-		if err = model.BlockTaskGroupTasks(t.Id); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"message": "problem blocking task group tasks",
-				"task_id": t.Id,
-			}))
-		}
-		grip.Debug(message.Fields{
-			"message": "blocked task group tasks for task",
-			"task_id": t.Id,
-		})
 	}
 
 	job := units.NewCollectTaskEndDataJob(t, currentHost)

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -188,6 +188,8 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// For a single-host task group, if a task fails, block and dequeue later tasks in that group.
+	// Call before MarkEnd so the version is marked finished when this is the last task in the version
+	// to finish
 	if t.TaskGroup != "" && t.TaskGroupMaxHosts == 1 && details.Status != evergreen.TaskSucceeded {
 		if err = model.BlockTaskGroupTasks(t.Id); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{


### PR DESCRIPTION
This was a fun bug!

Two things went wrong:
1. The attempt to dequeue when the version finished didn't work because the version completion wasn't logged. When a task in a single-host task group fails we add the rest of the tasks in the task group as blocked dependencies of the failed task. Since we do this _after_ the call to `MarkEnd` if there are no more tasks in the version the version will never finish, since when `MarkEnd` ran the tasks were not blocked.
2. The attempt to dequeue when the task failed didn't work since we weren't using the PR number as the issue id.

Along the way it became apparent we were trying to dequeue from the commit queue for failed tasks belonging to versions that had no patch, which returned an error for every failed task for the waterfall, for instance, and the function returned early.