### PR TITLE
EVG-6931 validate task names don't have spaces

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -286,9 +286,9 @@ func appendTasks(pairs TaskVariantPairs, bv parserBV, p *Project) TaskVariantPai
 // addGeneratedProjectToConfig takes a YML config and returns a new one with the GeneratedProject included.
 func (g *GeneratedProject) addGeneratedProjectToConfig(config string, cachedProject projectMaps) (string, error) {
 	// Append buildvariants, tasks, and functions to the config.
-	intermediateProject, errs := createIntermediateProject([]byte(config))
-	if errs != nil {
-		return "", errors.Wrap(errs[0], "error creating intermediate project")
+	intermediateProject, err := createIntermediateProject([]byte(config))
+	if err != nil {
+		return "", errors.Wrap(err, "error creating intermediate project")
 	}
 	intermediateProject.TaskGroups = append(intermediateProject.TaskGroups, g.TaskGroups...)
 	intermediateProject.Tasks = append(intermediateProject.Tasks, g.Tasks...)

--- a/model/project.go
+++ b/model/project.go
@@ -17,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	ignore "github.com/sabhiram/go-git-ignore"
 	yaml "gopkg.in/yaml.v2"
@@ -1039,6 +1040,11 @@ func FindLastKnownGoodProject(identifier string) (*Project, error) {
 		if err == nil {
 			return project, nil
 		}
+		grip.Critical(message.WrapError(err, message.Fields{
+			"message": "last known good version has malformed config",
+			"version": lastGoodVersion.Identifier,
+			"project": identifier,
+		}))
 	}
 
 	return nil, errors.Wrapf(err, "Error loading project from "+

--- a/model/project.go
+++ b/model/project.go
@@ -1019,6 +1019,7 @@ func (p *Project) FindDistroNameForTask(t *task.Task) (string, error) {
 }
 
 func FindLastKnownGoodProject(identifier string) (*Project, error) {
+	const retryCount = 5
 	if identifier == "" {
 		return nil, errors.WithStack(errors.New("cannot pass empty identifier to FindLastKnownGoodProject"))
 	}
@@ -1026,18 +1027,22 @@ func FindLastKnownGoodProject(identifier string) (*Project, error) {
 		Identifier: identifier,
 	}
 
-	lastGoodVersion, err := VersionFindOne(VersionByLastKnownGoodConfig(identifier))
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error finding recent valid version for '%s'", identifier)
-	}
-	if lastGoodVersion != nil {
-		err = LoadProjectInto([]byte(lastGoodVersion.Config), identifier, project)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Error loading project from "+
-				"last good version for project, %s", lastGoodVersion.Identifier)
+	revisionOrderNum := -1 // only specify in the event of failure
+	var err error
+	var lastGoodVersion *Version
+	for i := 0; i < retryCount; i++ {
+		lastGoodVersion, err = FindVersionByLastKnownGoodConfig(identifier, revisionOrderNum)
+		if lastGoodVersion != nil {
+			err = LoadProjectInto([]byte(lastGoodVersion.Config), identifier, project)
+			revisionOrderNum = lastGoodVersion.RevisionOrderNumber // look for an older version if the returned version is malformed
+		}
+		if err == nil {
+			return project, nil
 		}
 	}
-	return project, nil
+
+	return nil, errors.Wrapf(err, "Error loading project from "+
+		"last good version for project, %s", lastGoodVersion.Identifier)
 }
 
 func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit {

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -41,8 +41,8 @@ buildvariants:
       set:
         tags: "gotcha_boy"
 `
-			p, errs := createIntermediateProject([]byte(axes))
-			So(errs, ShouldBeNil)
+			p, err := createIntermediateProject([]byte(axes))
+			So(err, ShouldBeNil)
 			axis := p.Axes[0]
 			So(axis.Id, ShouldEqual, "os")
 			So(axis.DisplayName, ShouldEqual, "Operating System")
@@ -77,8 +77,8 @@ buildvariants:
     - blue
     - green
 `
-			p, errs := createIntermediateProject([]byte(simple))
-			So(errs, ShouldBeNil)
+			p, err := createIntermediateProject([]byte(simple))
+			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix
 			So(m1, ShouldResemble, matrix{
@@ -108,8 +108,8 @@ buildvariants:
 - name: "single_variant"
   tasks: "*"
 `
-			p, errs := createIntermediateProject([]byte(simple))
-			So(errs, ShouldBeNil)
+			p, err := createIntermediateProject([]byte(simple))
+			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix
 			So(m1.Id, ShouldEqual, "test")

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -433,10 +433,10 @@ func LoadProjectInto(data []byte, identifier string, project *Project) error {
 func projectFromYAML(yml []byte) (*Project, error) {
 	intermediateProject, err := createIntermediateProject(yml)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating intermediate project")
+		return nil, err
 	}
 	p, err := translateProject(intermediateProject)
-	return p, errors.Wrap(err, "error translating project")
+	return p, err
 }
 
 // createIntermediateProject marshals the supplied YAML into our

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -89,7 +89,7 @@ tasks:
 `
 				p, err := createIntermediateProject([]byte(nameless))
 				So(p, ShouldBeNil)
-				So(err, ShouldBeNil)
+				So(err, ShouldNotBeNil)
 			})
 			Convey("or multiple", func() {
 				nameless := `
@@ -398,7 +398,7 @@ func TestTranslateDependsOn(t *testing.T) {
 			}
 			out, err := translateProject(pp)
 			So(out, ShouldNotBeNil)
-			So(err, ShouldBeNil)
+			So(err, ShouldNotBeNil)
 		})
 	})
 }
@@ -688,7 +688,7 @@ tasks:
 	proj, err = projectFromYAML([]byte(nonexistentTaskYml))
 	assert.NotNil(proj)
 	assert.Error(err)
-	assert.Contains(err, "notHere: nothing named 'notHere'")
+	assert.Contains(err.Error(), "notHere: nothing named 'notHere'")
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 1)
 	assert.Len(proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks, 2)
 	assert.Len(proj.BuildVariants[1].DisplayTasks, 0)
@@ -946,7 +946,7 @@ buildvariants:
 	proj, err = projectFromYAML([]byte(wrongTaskYml))
 	assert.NotNil(proj)
 	assert.Error(err)
-	assert.Contains(err, `nothing named 'example_task_3'`)
+	assert.Contains(err.Error(), `nothing named 'example_task_3'`)
 
 	// check that tasks listed in the task group yml maintain their order
 	orderedYml := `

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -101,7 +101,7 @@ tasks:
 `
 				p, err := createIntermediateProject([]byte(nameless))
 				So(p, ShouldBeNil)
-				So(err, ShouldBeNil)
+				So(err, ShouldNotBeNil)
 			})
 			Convey("but an unused depends_on field should not error", func() {
 				nameless := `
@@ -745,7 +745,7 @@ tasks:
 	proj, err = projectFromYAML([]byte(conflictYml))
 	assert.NotNil(proj)
 	assert.Error(err)
-	assert.Contains(err, "display task execTask1 cannot have the same name as an execution task")
+	assert.Contains(err.Error(), "display task execTask1 cannot have the same name as an execution task")
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 0)
 
 	// test that wildcard selectors are resolved correctly

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/stretchr/testify/require"
 
@@ -1333,21 +1332,18 @@ buildvariants:
 }
 
 func checkProjectPersists(yml []byte) error {
-	pp, errs := createIntermediateProject(yml)
-	catcher := grip.NewBasicCatcher()
-	catcher.Extend(errs)
-	if catcher.HasErrors() {
-		return catcher.Resolve()
+	pp, err := createIntermediateProject(yml)
+	if err != nil {
+		return err
 	}
 	yamlToCompare, err := yaml.Marshal(pp)
 	if err != nil {
 		return errors.Wrapf(err, "error marshalling original project")
 	}
 
-	_, errs = createIntermediateProject([]byte(yamlToCompare))
-	catcher.Extend(errs)
-	if catcher.HasErrors() {
-		return errors.Wrap(catcher.Resolve(), "marshalled project cannot be parsed")
+	_, err = createIntermediateProject([]byte(yamlToCompare))
+	if err != nil {
+		return errors.Wrap(err, "marshalled project cannot be parsed")
 	}
 	v := Version{
 		Id:            "my-version",

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -277,7 +277,7 @@ func (t *taskSelectorEvaluator) evalSelector(s Selector) ([]string, error) {
 
 func newTaskGroupSelectorEvaluator(groups []parserTaskGroup) *tagSelectorEvaluator {
 	var selectees []tagged
-	for i, _ := range groups {
+	for i := range groups {
 		selectees = append(selectees, &groups[i])
 	}
 

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1097,8 +1097,8 @@ tasks:
   depends_on:
     - name: dist-test
 `
-	intermediate, errs := createIntermediateProject([]byte(projYml))
-	s.Len(errs, 0)
+	intermediate, err := createIntermediateProject([]byte(projYml))
+	s.NoError(err)
 	marshaled, err := yaml.Marshal(intermediate)
 	s.NoError(err)
 	unmarshaled := parserProject{}

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -25,7 +25,7 @@ func TestLastKnownGoodConfig(t *testing.T) {
 				Errors:     []string{"error 1", "error 2"},
 			}
 			require.NoError(t, v.Insert(), "Error inserting test version: %s", v.Id)
-			lastGood, err := VersionFindOne(VersionByLastKnownGoodConfig(identifier))
+			lastGood, err := FindVersionByLastKnownGoodConfig(identifier, -1)
 			require.NoError(t, err, "error finding last known good")
 			So(lastGood, ShouldBeNil)
 		})
@@ -35,7 +35,7 @@ func TestLastKnownGoodConfig(t *testing.T) {
 				Requester:  evergreen.RepotrackerVersionRequester,
 			}
 			require.NoError(t, v.Insert(), "Error inserting test version: %s", v.Id)
-			lastGood, err := VersionFindOne(VersionByLastKnownGoodConfig(identifier))
+			lastGood, err := FindVersionByLastKnownGoodConfig(identifier, -1)
 			require.NoError(t, err, "error finding last known good: %s", lastGood.Id)
 			So(lastGood, ShouldNotBeNil)
 		})
@@ -56,7 +56,7 @@ func TestLastKnownGoodConfig(t *testing.T) {
 			v.RevisionOrderNumber = 2
 			v.Config = "2"
 			require.NoError(t, v.Insert(), "Error inserting test version: %s", v.Id)
-			lastGood, err := VersionFindOne(VersionByLastKnownGoodConfig(identifier))
+			lastGood, err := FindVersionByLastKnownGoodConfig(identifier, -1)
 			require.NoError(t, err, "error finding last known good: %s", v.Id)
 			So(lastGood, ShouldNotBeNil)
 			So(lastGood.Config, ShouldEqual, "5")

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -518,13 +518,14 @@ func ensureReferentialIntegrity(project *model.Project, distroIds []string) Vali
 
 // validateTaskNames ensures the task names do not contain unauthorized characters.
 func validateTaskNames(project *model.Project) ValidationErrors {
+	unauthorizedTaskCharacters := unauthorizedCharacters + " "
 	errs := ValidationErrors{}
 	for _, task := range project.Tasks {
-		if strings.ContainsAny(task.Name, unauthorizedCharacters) {
+		if strings.ContainsAny(strings.TrimSpace(task.Name), unauthorizedTaskCharacters) {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("task name %v contains unauthorized characters (%v)",
-						task.Name, unauthorizedCharacters),
+					Message: fmt.Sprintf("task name %v contains unauthorized characters ('%v')",
+						task.Name, unauthorizedTaskCharacters),
 				})
 		}
 	}

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1656,7 +1656,7 @@ func TestTaskValidation(t *testing.T) {
   - name: "bv"
     tasks:
     - name: task0
-    -name: "this task is too long"
+    - name: "this task is too long"
 `
 	var proj model.Project
 	err := model.LoadProjectInto([]byte(simpleYml), "", &proj)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -657,11 +657,12 @@ func TestValidateTaskNames(t *testing.T) {
 				{Name: "task|"},
 				{Name: "|task"},
 				{Name: "ta|sk"},
+				{Name: "this is my task"},
 				{Name: "task"},
 			},
 		}
 		validationResults := validateTaskNames(project)
-		So(len(validationResults), ShouldEqual, 3)
+		So(len(validationResults), ShouldEqual, 4)
 	})
 }
 

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1646,6 +1646,23 @@ func TestEnsureHasNecessaryBVFields(t *testing.T) {
 		})
 	})
 }
+func TestTaskValidation(t *testing.T) {
+	assert.New(t)
+	simpleYml := `
+  tasks:
+  - name: task0
+  - name: this task is too long
+  buildvariants:
+  - name: "bv"
+    tasks:
+    - name: task0
+    -name: "this task is too long"
+`
+	var proj model.Project
+	err := model.LoadProjectInto([]byte(simpleYml), "", &proj)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "spaces are unauthorized")
+}
 
 func TestTaskGroupValidation(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
Do this in a validation and in translate project.

This pull request looks longer than it is because I'm mad that createIntermediateProject manually formats []error when modern day evergreen has been blessed with catcher.Resolve(), and I fixed it in parser project but that might never happen so I'm doing it now.