### PR TITLE
EVG-6922 don't retry if user-given device name fails

### DIFF
--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -465,7 +465,7 @@ func (h *attachVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 	if util.StringSliceContains(evergreen.DownHostStatus, targetHost.Status) {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
-			Message:    errors.Errorf("host '%s' is not up (status is %s)", targetHost.Id, targetHost.Status).Error(),
+			Message:    errors.Errorf("host '%s' status is %s", targetHost.Id, targetHost.Status).Error(),
 		})
 	}
 

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -831,7 +831,6 @@ func (h *getVolumesHandler) Run(ctx context.Context) gimlet.Responder {
 
 	volumes, err := h.sc.FindVolumesByUser(u.Username())
 	if err != nil {
-		fmt.Println("grr")
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 
@@ -839,7 +838,6 @@ func (h *getVolumesHandler) Run(ctx context.Context) gimlet.Responder {
 	for _, v := range volumes {
 		volumeDoc := model.APIVolume{}
 		if err = volumeDoc.BuildFromService(v); err != nil {
-			fmt.Println("ahhh")
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "err converting volume '%s' to API model", v.ID))
 		}
 

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -462,8 +462,15 @@ func (h *attachVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Error getting host '%s'", h.hostID))
 	}
 
+	if util.StringSliceContains(evergreen.DownHostStatus, targetHost.Status) {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    errors.Errorf("host '%s' is not up (status is %s)", targetHost.Id, targetHost.Status).Error(),
+		})
+	}
+
 	// Check whether attachment already attached to a host
-	attachedHost, err := host.FindHostWithVolume(h.attachment.VolumeID)
+	attachedHost, err := h.sc.FindHostWithVolume(h.attachment.VolumeID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,


### PR DESCRIPTION
If the user gives a bad device name, we should error immediately because it will also not work on retry, and we can't simply regenerate the device name. 

Also noticed that we don't check if the host we've looked up is actually still up--can't attach volumes to terminated instances so.