### PR TITLE
EVG-7016 stop updating build cache for execution tasks

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -978,8 +978,10 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 	if err = t.MarkSystemFailed(); err != nil {
 		return errors.Wrap(err, "problem marking task failed")
 	}
-	if err := build.UpdateCachedTask(t, 0); err != nil {
-		return errors.Wrap(err, "problem resetting cached task")
+	if !t.IsPartOfDisplay() {
+		if err := build.UpdateCachedTask(t, 0); err != nil {
+			return errors.Wrap(err, "problem resetting cached task")
+		}
 	}
 
 	if time.Since(t.ActivatedTime) > task.UnschedulableThreshold {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2378,7 +2378,6 @@ func TestClearAndResetExecTask(t *testing.T) {
 		Id: "b",
 		Tasks: []build.TaskCache{
 			build.TaskCache{Id: "dt"},
-			build.TaskCache{Id: "et"},
 		},
 	}
 	assert.NoError(t, b.Insert())


### PR DESCRIPTION
Since the task cache doesn't contain execution tasks this update fails for execution tasks, preventing the display task from restarting in the (majority) case where the last task to finish is system failed.