### PR TITLE
EVG-5883 check for enabling PR testing without patch definitions

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -188,6 +188,7 @@ const (
 	TaskOrderingPatchFirst    = "patchfirst"
 
 	CommitQueueAlias = "__commit_queue"
+	GithubAlias      = "__github"
 	MergeTaskVariant = "commit-queue-merge"
 	MergeTaskName    = "merge-patch"
 	MergeTaskGroup   = "merge-task-group"

--- a/globals.go
+++ b/globals.go
@@ -187,8 +187,10 @@ const (
 	TaskOrderingMainlineFirst = "mainlinefirst"
 	TaskOrderingPatchFirst    = "patchfirst"
 
+	// CommitQueueAlias and GithubAlias are special aliases to specify variants and tasks for commit queue and GitHub PR patches
 	CommitQueueAlias = "__commit_queue"
 	GithubAlias      = "__github"
+
 	MergeTaskVariant = "commit-queue-merge"
 	MergeTaskName    = "merge-patch"
 	MergeTaskGroup   = "merge-task-group"

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -21,9 +21,6 @@ const (
 
 	// GithubIntentType represents patch intents created for GitHub.
 	GithubIntentType = "github"
-
-	// GithubAlias is a special alias to specify default variants and tasks for GitHub pull requests.
-	GithubAlias = "__github"
 )
 
 // githubIntent represents an intent to create a patch build as a result of a
@@ -224,7 +221,7 @@ func (g *githubIntent) NewPatch() *Patch {
 	pullURL := fmt.Sprintf("https://github.com/%s/pull/%d", g.BaseRepoName, g.PRNumber)
 	patchDoc := &Patch{
 		Id:          mgobson.NewObjectId(),
-		Alias:       GithubAlias,
+		Alias:       evergreen.GithubAlias,
 		Description: fmt.Sprintf("'%s' pull request #%d by %s: %s (%s)", g.BaseRepoName, g.PRNumber, g.User, g.Title, pullURL),
 		Author:      evergreen.GithubPatchUser,
 		Status:      evergreen.PatchCreated,
@@ -245,5 +242,5 @@ func (g *githubIntent) NewPatch() *Patch {
 }
 
 func (g *githubIntent) GetAlias() string {
-	return GithubAlias
+	return evergreen.GithubAlias
 }

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -235,7 +235,7 @@ func (s *GithubSuite) TestNewPatch() {
 	s.Empty(patchDoc.Patches)
 	s.False(patchDoc.Activated)
 	s.Empty(patchDoc.PatchedConfig)
-	s.Equal(GithubAlias, patchDoc.Alias)
+	s.Equal(evergreen.GithubAlias, patchDoc.Alias)
 	s.Equal(5, patchDoc.GithubPatchData.PRNumber)
 	s.Equal("evergreen-ci", patchDoc.GithubPatchData.BaseOwner)
 	s.Equal("evergreen", patchDoc.GithubPatchData.BaseRepo)

--- a/operations/list.go
+++ b/operations/list.go
@@ -282,7 +282,7 @@ func listAliases(ctx context.Context, confPath, project, filename string) error 
 	}
 
 	for _, alias := range aliases {
-		if alias.Alias != patch.GithubAlias {
+		if alias.Alias != evergreen.GithubAlias {
 			fmt.Printf("%s\t%s\t%s\t%s\t%s\n", alias.Alias, alias.Variant, strings.Join(alias.VariantTags, ","),
 				alias.Task, strings.Join(alias.TaskTags, ", "))
 		}

--- a/operations/list.go
+++ b/operations/list.go
@@ -10,8 +10,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/cheynewallace/tabby"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/patch"
 	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/pkg/errors"

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -83,11 +83,13 @@ func (d *DBAliasConnector) UpdateProjectAliases(projectId string, aliases []rest
 
 // MockAliasConnector is a struct that implements mock versions of
 // Alias-related methods for testing.
-type MockAliasConnector struct{}
+type MockAliasConnector struct {
+	Aliases []restModel.APIProjectAlias
+}
 
 // FindAllAliases is a mock implementation for testing.
 func (d *MockAliasConnector) FindProjectAliases(projectId string) ([]restModel.APIProjectAlias, error) {
-	return nil, nil
+	return d.Aliases, nil
 }
 
 func (d *MockAliasConnector) CopyProjectAliases(oldProjectId, newProjectId string) error {

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -107,9 +107,9 @@ func (s *ProjectPatchByIDSuite) TestRunWithCommitQueueEnabled() {
 	resp := s.rm.Run(ctx)
 	s.NotNil(resp)
 	s.NotNil(resp.Data())
-	s.Equal(resp.Status(), http.StatusBadRequest)
+	s.Equal(http.StatusBadRequest, resp.Status())
 	errResp := (resp.Data()).(gimlet.ErrorResponse)
-	s.Equal(errResp.Message, "Cannot enable commit queue without a __commit_queue patch definition")
+	s.Equal("cannot enable commit queue without a commit queue patch definition", errResp.Message)
 }
 
 func (s *ProjectPatchByIDSuite) TestHasAliasDefined() {

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -112,6 +112,48 @@ func (s *ProjectPatchByIDSuite) TestRunWithCommitQueueEnabled() {
 	s.Equal(errResp.Message, "Cannot enable commit queue without a __commit_queue patch definition")
 }
 
+func (s *ProjectPatchByIDSuite) TestHasAliasDefined() {
+	h := s.rm.(*projectIDPatchHandler)
+
+	projectID := "evergreen"
+	// a new definition for the github alias is added
+	pref := &model.APIProjectRef{
+		Identifier: model.ToAPIString(projectID),
+		Aliases: []model.APIProjectAlias{
+			{
+				Alias: model.ToAPIString(evergreen.GithubAlias),
+			},
+		},
+	}
+
+	exists, err := h.hasAliasDefined(pref, evergreen.GithubAlias)
+	s.NoError(err)
+	s.True(exists)
+
+	// a definition already exists
+	s.sc.MockAliasConnector.Aliases = []model.APIProjectAlias{
+		{
+			ID:    model.ToAPIString("abcdef"),
+			Alias: model.ToAPIString(evergreen.GithubAlias),
+		},
+	}
+	pref.Aliases = nil
+	exists, err = h.hasAliasDefined(pref, evergreen.GithubAlias)
+	s.NoError(err)
+	s.True(exists)
+
+	// the only existing github alias is being deleted
+	pref.Aliases = []model.APIProjectAlias{
+		{
+			ID:     model.ToAPIString("abcdef"),
+			Delete: true,
+		},
+	}
+	exists, err = h.hasAliasDefined(pref, evergreen.GithubAlias)
+	s.NoError(err)
+	s.False(exists)
+}
+
 ////////////////////////////////////////////////////////////////////////
 //
 // Tests for PUT /rest/v2/projects/{project_id}

--- a/service/project.go
+++ b/service/project.go
@@ -746,14 +746,11 @@ func verifyAliasExists(alias, projectIdentifier string, newAliasDefinitions []mo
 		return false, errors.Wrap(err, "error checking for existing aliases")
 	}
 
-	remainingAliases := false
 	for _, a := range existingAliasDefinitions {
 		// only consider aliases that won't be deleted
 		if !util.StringSliceContains(deletedAliasDefinitionIDs, a.ID.Hex()) {
-			remainingAliases = true
-			break
+			return true, nil
 		}
 	}
-
-	return remainingAliases, nil
+	return false, nil
 }

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyAliasExists(t *testing.T) {
+	assert.NoError(t, db.Clear(model.ProjectAliasCollection))
+
+	// a new definition for the github alias is added
+	newDefinitions := []model.ProjectAlias{{Alias: evergreen.GithubAlias}}
+	exists, err := verifyAliasExists(evergreen.GithubAlias, "evergreen", newDefinitions, []string{})
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	// a definition already exists
+	alias := &model.ProjectAlias{
+		Alias:     evergreen.GithubAlias,
+		ProjectID: "evergreen",
+	}
+	require.NoError(t, alias.Upsert())
+	aliases, err := model.FindAliasInProject("evergreen", evergreen.GithubAlias)
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	exists, err = verifyAliasExists(evergreen.GithubAlias, "evergreen", []model.ProjectAlias{}, []string{})
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	// the only existing definition is being deleted
+	exists, err = verifyAliasExists(evergreen.GithubAlias, "evergreen", []model.ProjectAlias{}, []string{aliases[0].ID.Hex()})
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
-
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/stretchr/testify/assert"

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -86,13 +86,13 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 
 	s.NoError((&model.ProjectAlias{
 		ProjectID: "mci",
-		Alias:     patch.GithubAlias,
+		Alias:     evergreen.GithubAlias,
 		Variant:   "ubuntu.*",
 		Task:      "dist.*",
 	}).Upsert())
 	s.NoError((&model.ProjectAlias{
 		ProjectID: "mci",
-		Alias:     patch.GithubAlias,
+		Alias:     evergreen.GithubAlias,
 		Variant:   "race.*",
 		Task:      "dist.*",
 	}).Upsert())


### PR DESCRIPTION
Check for GitHub alias definitions when enabling PR testing by generalizing changes made in #2896 that check for commit queue alias definitions when enabling the commit queue.