### PR TITLE
EVG-6981 persist parser project (write not read, w/out generate.tasks)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -280,10 +280,12 @@ func (a *Agent) fetchProjectConfig(ctx context.Context, tc *taskContext) error {
 		return errors.Wrap(err, "error getting version")
 	}
 	project := &model.Project{}
-	err = model.LoadProjectInto([]byte(v.Config), v.Identifier, project)
-	if err != nil {
+	// TODO: populated config from parser project
+	// later will want a separate communicator route
+	if _, err = model.LoadProjectInto([]byte(v.Config), v.Identifier, project); err != nil {
 		return errors.Wrapf(err, "error reading project config")
 	}
+
 	taskModel, err := a.comm.GetTask(ctx, tc.task)
 	if err != nil {
 		return errors.Wrap(err, "error getting task")

--- a/agent/command.go
+++ b/agent/command.go
@@ -29,7 +29,6 @@ func (a *Agent) runCommands(ctx context.Context, tc *taskContext, commands []mod
 			grip.Error("runCommands canceled")
 			return errors.New("runCommands canceled")
 		}
-
 		cmds, err = command.Render(commandInfo, tc.taskConfig.Project.Functions)
 		if err != nil {
 			tc.logger.Task().Errorf("Couldn't parse plugin command '%v': %v", commandInfo.Command, err)

--- a/agent/task.go
+++ b/agent/task.go
@@ -249,12 +249,12 @@ func (tc *taskContext) hadTimedOut() bool {
 // makeTaskConfig fetches task configuration data required to run the task from the API server.
 func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*model.TaskConfig, error) {
 	if tc.project == nil && tc.version == nil {
+		tc.logger.Execution().Info("Fetching project config.")
 		err := a.fetchProjectConfig(ctx, tc)
 		if err != nil {
 			return nil, err
 		}
 	}
-
 	tc.logger.Execution().Info("Fetching distro configuration.")
 	confDistro, err := a.comm.GetDistro(ctx, tc.task)
 	if err != nil {

--- a/globals.go
+++ b/globals.go
@@ -196,6 +196,9 @@ const (
 
 	DefaultJasperPort          = 2385
 	GlobalGitHubTokenExpansion = "global_github_oauth_token"
+
+	// TODO: remove this when degrading YAML
+	UseParserProject = false
 )
 
 func IsFinishedTaskStatus(status string) bool {

--- a/model/generate.go
+++ b/model/generate.go
@@ -12,8 +12,7 @@ import (
 	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	"go.mongodb.org/mongo-driver/bson"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -107,34 +106,30 @@ func ParseProjectFromJSON(data []byte) (GeneratedProject, error) {
 
 // NewVersion adds the buildvariants, tasks, and functions
 // from a generated project config to a project, and returns the previous config number.
-func (g *GeneratedProject) NewVersion() (*Project, *Version, *task.Task, *projectMaps, error) {
+func (g *GeneratedProject) NewVersion() (*Project, *ParserProject, *Version, *task.Task, *projectMaps, error) {
 	// Get task, version, and project.
 	t, err := task.FindOneId(g.TaskID)
 	if err != nil {
-		return nil, nil, nil, nil,
+		return nil, nil, nil, nil, nil,
 			gimlet.ErrorResponse{StatusCode: http.StatusInternalServerError, Message: errors.Wrapf(err, "error finding task %s", g.TaskID).Error()}
 	}
 	if t == nil {
-		return nil, nil, nil, nil,
+		return nil, nil, nil, nil, nil,
 			gimlet.ErrorResponse{StatusCode: http.StatusBadRequest, Message: fmt.Sprintf("unable to find task %s", g.TaskID)}
 	}
 	v, err := VersionFindOneId(t.Version)
 	if err != nil {
-		return nil, nil, nil, nil,
+		return nil, nil, nil, nil, nil,
 			gimlet.ErrorResponse{StatusCode: http.StatusInternalServerError, Message: errors.Wrapf(err, "error finding version %s", t.Version).Error()}
 	}
 	if v == nil {
-		return nil, nil, nil, nil,
+		return nil, nil, nil, nil, nil,
 			gimlet.ErrorResponse{StatusCode: http.StatusBadRequest, Message: fmt.Sprintf("unable to find version %s", t.Version)}
 	}
-	if v.Config == "" {
-		return nil, nil, nil, nil,
-			gimlet.ErrorResponse{StatusCode: http.StatusBadRequest, Message: fmt.Sprintf("unable to find config string for version %s", t.Version)}
-	}
-	p := &Project{}
-	if err = LoadProjectInto([]byte(v.Config), t.Project, p); err != nil {
-		return nil, nil, nil, nil,
-			gimlet.ErrorResponse{StatusCode: http.StatusBadRequest, Message: errors.Wrapf(err, "error reading project yaml for version %s", t.Version).Error()}
+	p, pp, err := LoadProjectForVersion(v, t.Project, false)
+	if err != nil {
+		return nil, nil, nil, nil, nil,
+			gimlet.ErrorResponse{StatusCode: http.StatusBadRequest, Message: errors.Wrapf(err, "error getting project for version %s", t.Version).Error()}
 	}
 
 	// Cache project data in maps for quick lookup
@@ -143,36 +138,34 @@ func (g *GeneratedProject) NewVersion() (*Project, *Version, *task.Task, *projec
 	// Validate generated project against original project.
 	if err = g.validateGeneratedProject(p, cachedProject); err != nil {
 		// Return version in this error case for handleError, which checks for a race. We only need to do this in cases where there is a validation check.
-		return nil, v, nil, nil,
+		return nil, nil, v, nil, nil,
 			gimlet.ErrorResponse{StatusCode: http.StatusBadRequest, Message: errors.Wrap(err, "generated project is invalid").Error()}
 	}
 
-	newConfig, err := g.addGeneratedProjectToConfig(v.Config, cachedProject)
+	newPP, newConfig, err := g.addGeneratedProjectToConfig(pp, v.Config, cachedProject)
 	if err != nil {
-		return nil, nil, nil, nil,
+		return nil, nil, nil, nil, nil,
 			gimlet.ErrorResponse{StatusCode: http.StatusBadRequest, Message: errors.Wrap(err, "error creating config from generated config").Error()}
 	}
+	newPP.Id = v.Id
 	v.Config = newConfig
-	if err := LoadProjectInto([]byte(v.Config), t.Project, p); err != nil {
-		return nil, nil, nil, nil,
-			gimlet.ErrorResponse{StatusCode: http.StatusBadRequest, Message: errors.Wrap(err, "error reading project yaml").Error()}
+	p, err = TranslateProject(newPP)
+	if err != nil {
+		return nil, nil, nil, nil, nil,
+			gimlet.ErrorResponse{StatusCode: http.StatusBadRequest, Message: errors.Wrap(err, "error translating project").Error()}
 	}
-	return p, v, t, &cachedProject, nil
+	return p, newPP, v, t, &cachedProject, nil
 }
 
-func (g *GeneratedProject) Save(ctx context.Context, p *Project, v *Version, t *task.Task, pm *projectMaps) error {
-	query := bson.M{
-		VersionIdKey:           v.Id,
-		VersionConfigNumberKey: v.ConfigUpdateNumber,
-	}
-	update := bson.M{
-		"$set": bson.M{VersionConfigKey: v.Config},
-		"$inc": bson.M{VersionConfigNumberKey: 1},
-	}
-
-	err := VersionUpdateOne(query, update)
+func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProject, v *Version, t *task.Task, pm *projectMaps) error {
+	err := VersionUpdateConfig(v.Id, v.Config, v.ConfigUpdateNumber)
 	if err != nil {
 		return errors.Wrapf(err, "error updating version %s", v.Id)
+	}
+	v.ConfigUpdateNumber += 1
+
+	if err := pp.UpsertWithConfigNumber(v.ConfigUpdateNumber); err != nil {
+		return errors.Wrapf(err, "error updating parser project %s", pp.Id)
 	}
 
 	if v.Requester == evergreen.MergeTestRequester {
@@ -188,7 +181,6 @@ func (g *GeneratedProject) Save(ctx context.Context, p *Project, v *Version, t *
 		}
 	}
 
-	v.ConfigUpdateNumber += 1
 	if err := g.saveNewBuildsAndTasks(ctx, pm, v, p, t.Priority); err != nil {
 		return errors.Wrap(err, "error savings new builds and tasks")
 	}
@@ -283,13 +275,18 @@ func appendTasks(pairs TaskVariantPairs, bv parserBV, p *Project) TaskVariantPai
 	return pairs
 }
 
-// addGeneratedProjectToConfig takes a YML config and returns a new one with the GeneratedProject included.
-func (g *GeneratedProject) addGeneratedProjectToConfig(config string, cachedProject projectMaps) (string, error) {
-	// Append buildvariants, tasks, and functions to the config.
-	intermediateProject, err := createIntermediateProject([]byte(config))
-	if err != nil {
-		return "", errors.Wrap(err, "error creating intermediate project")
+// addGeneratedProjectToConfig takes a ParserProject and a YML config and returns a new one with the GeneratedProject included.
+// support for YML config will be degraded.
+func (g *GeneratedProject) addGeneratedProjectToConfig(intermediateProject *ParserProject, config string, cachedProject projectMaps) (*ParserProject, string, error) {
+	var err error
+	if intermediateProject == nil {
+		intermediateProject, err = createIntermediateProject([]byte(config))
+		if err != nil {
+			return nil, "", errors.Wrapf(err, "error creating intermediate project")
+		}
 	}
+
+	// Append buildvariants, tasks, and functions to the config.
 	intermediateProject.TaskGroups = append(intermediateProject.TaskGroups, g.TaskGroups...)
 	intermediateProject.Tasks = append(intermediateProject.Tasks, g.Tasks...)
 	for key, val := range g.Functions {
@@ -309,11 +306,12 @@ func (g *GeneratedProject) addGeneratedProjectToConfig(config string, cachedProj
 			intermediateProject.BuildVariants = append(intermediateProject.BuildVariants, bv)
 		}
 	}
+	// prepare new config file
 	byteConfig, err := yaml.Marshal(intermediateProject)
 	if err != nil {
-		return "", errors.Wrap(err, "error marshalling new project config")
+		return nil, "", errors.Wrap(err, "error marshalling new project config")
 	}
-	return string(byteConfig), nil
+	return intermediateProject, string(byteConfig), nil
 }
 
 // projectMaps is a struct of maps of project fields, which allows efficient comparisons of generated projects to projects.

--- a/model/generate.go
+++ b/model/generate.go
@@ -164,9 +164,7 @@ func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProje
 	}
 	v.ConfigUpdateNumber += 1
 
-	if err := pp.UpsertWithConfigNumber(v.ConfigUpdateNumber); err != nil {
-		return errors.Wrapf(err, "error updating parser project %s", pp.Id)
-	}
+	// TODO: Include parser project in generated tasks
 
 	if v.Requester == evergreen.MergeTestRequester {
 		mergeTask, err := task.FindMergeTaskForVersion(v.Id)

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -744,9 +744,9 @@ buildvariants:
 		},
 	}
 
-	p, v, t, pm, err := g.NewVersion()
+	p, pp, v, t, pm, err := g.NewVersion()
 	s.NoError(err)
-	s.NoError(g.Save(context.Background(), p, v, t, pm))
+	s.NoError(g.Save(context.Background(), p, pp, v, t, pm))
 
 	// the depended-on task is created in the existing variant
 	saySomething := task.Task{}

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -302,7 +303,7 @@ func TestGenerateSuite(t *testing.T) {
 }
 
 func (s *GenerateSuite) SetupTest() {
-	s.Require().NoError(db.ClearCollections(task.Collection, build.Collection, VersionCollection))
+	s.Require().NoError(db.ClearCollections(task.Collection, build.Collection, VersionCollection, ParserProjectCollection))
 }
 
 func (s *GenerateSuite) TestParseProjectFromJSON() {
@@ -313,20 +314,13 @@ func (s *GenerateSuite) TestParseProjectFromJSON() {
 	s.Len(g.Functions, 2)
 	s.Contains(g.Functions, "echo-hi")
 	s.Equal("shell.exec", g.Functions["echo-hi"].List()[0].Command)
-
-	s.Require().NoError(g.Functions["echo-hi"].List()[0].resolveParams())
 	s.Equal("echo hi", g.Functions["echo-hi"].List()[0].Params["script"])
-
-	s.Require().NoError(g.Functions["echo-bye"].List()[0].resolveParams())
 	s.Equal("echo bye", g.Functions["echo-bye"].List()[0].Params["script"])
-
-	s.Require().NoError(g.Functions["echo-bye"].List()[1].resolveParams())
 	s.Equal("echo bye again", g.Functions["echo-bye"].List()[1].Params["script"])
 
 	s.Len(g.Tasks, 1)
 	s.Equal("git.get_project", g.Tasks[0].Commands[0].Command)
 
-	s.Require().NoError(g.Tasks[0].Commands[0].resolveParams())
 	s.Equal("src", g.Tasks[0].Commands[0].Params["directory"])
 	s.Equal("echo-hi", g.Tasks[0].Commands[1].Function)
 	s.Equal("test", g.Tasks[0].Name)
@@ -519,31 +513,67 @@ func (s *GenerateSuite) TestValidateNoRecursiveGenerateTasks() {
 
 func (s *GenerateSuite) TestAddGeneratedProjectToConfig() {
 	p := &Project{}
-	err := LoadProjectInto([]byte(sampleProjYml), "", p)
+	pp, err := LoadProjectInto([]byte(sampleProjYml), "", p)
 	s.NoError(err)
 	cachedProject := cacheProjectData(p)
 	g := sampleGeneratedProject
-	config, err := g.addGeneratedProjectToConfig(sampleProjYml, cachedProject)
+	newPP, newConfig, err := g.addGeneratedProjectToConfig(pp, "", cachedProject)
 	s.NoError(err)
-	s.Contains(config, "say-hi")
-	s.Contains(config, "new_task")
-	s.Contains(config, "a_variant")
-	s.Contains(config, "new_buildvariant")
-	s.Contains(config, "a_function")
-	s.Contains(config, "new_function")
-	s.Contains(config, "say-bye")
-	s.Contains(config, "my_display_task_new_variant")
-	s.Contains(config, "my_display_task_old_variant")
+	s.NotEmpty(newPP)
+	s.NotNil(newConfig)
+	s.Require().Len(newPP.Tasks, 6)
+	s.Require().Len(newPP.BuildVariants, 3)
+	s.Require().Len(newPP.Functions, 2)
+	s.Equal(newPP.Tasks[0].Name, "say-hi")
+	s.Equal(newPP.Tasks[1].Name, "say-bye")
+	s.Equal(newPP.Tasks[2].Name, "a-depended-on-task")
+	s.Equal(newPP.Tasks[3].Name, "task_that_has_dependencies")
+	s.Equal(newPP.Tasks[4].Name, "new_task")
+	s.Equal(newPP.Tasks[5].Name, "another_task")
 
-	config, err = g.addGeneratedProjectToConfig(sampleProjYmlNoFunctions, cachedProject)
+	newPP2, newConfig2, err := g.addGeneratedProjectToConfig(nil, sampleProjYml, cachedProject)
 	s.NoError(err)
-	s.Contains(config, "say-hi")
-	s.Contains(config, "new_task")
-	s.Contains(config, "a_variant")
-	s.Contains(config, "new_buildvariant")
-	s.Contains(config, "say-bye")
-	s.Contains(config, "my_display_task_new_variant")
-	s.Contains(config, "my_display_task_old_variant")
+	s.NotEmpty(newPP2)
+	s.Equal(newConfig, newConfig2)
+
+	s.Equal(newPP.BuildVariants[0].Name, "a_variant")
+	s.Require().Len(newPP.BuildVariants[0].DisplayTasks, 1)
+	s.Equal(newPP.BuildVariants[0].DisplayTasks[0].Name, "my_display_task_old_variant")
+
+	s.Equal(newPP.BuildVariants[1].Name, "new_buildvariant")
+	s.Len(newPP.BuildVariants[1].DisplayTasks, 0)
+
+	s.Equal(newPP.BuildVariants[2].Name, "another_variant")
+	s.Require().Len(newPP.BuildVariants[2].DisplayTasks, 1)
+	s.Equal(newPP.BuildVariants[2].DisplayTasks[0].Name, "my_display_task_new_variant")
+
+	_, ok := newPP.Functions["a_function"]
+	s.True(ok)
+	_, ok = newPP.Functions["new_function"]
+	s.True(ok)
+
+	// verify addGeneratedProjectToConfig returned the updated config
+	ppConfig, err := yaml.Marshal(newPP)
+	s.NoError(err)
+	s.Equal(newConfig, string(ppConfig))
+
+	pp, err = LoadProjectInto([]byte(sampleProjYmlNoFunctions), "", p)
+	s.NoError(err)
+	newPP, newConfig, err = g.addGeneratedProjectToConfig(pp, "", cachedProject)
+	s.NoError(err)
+	s.NotEmpty(newConfig)
+	s.NotNil(newPP)
+	s.Require().Len(newPP.Tasks, 5)
+	s.Require().Len(newPP.BuildVariants, 3)
+	s.Len(newPP.Functions, 1)
+	s.Equal(newPP.Tasks[0].Name, "say-hi")
+	s.Equal(newPP.Tasks[1].Name, "say-bye")
+	s.Equal(newPP.Tasks[3].Name, "new_task")
+
+	newPP2, newConfig2, err = g.addGeneratedProjectToConfig(nil, sampleProjYmlNoFunctions, cachedProject)
+	s.NoError(err)
+	s.NotEmpty(newPP2)
+	s.Equal(newConfig, newConfig2)
 }
 
 func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
@@ -570,9 +600,9 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 
 	g := sampleGeneratedProject
 	g.TaskID = "task_that_called_generate_task"
-	p, v, t, pm, err := g.NewVersion()
-	s.NoError(err)
-	s.NoError(g.Save(context.Background(), p, v, t, pm))
+	p, pp, v, t, pm, err := g.NewVersion()
+	s.Require().NoError(err)
+	s.NoError(g.Save(context.Background(), p, pp, v, t, pm))
 	s.Equal(5, v.ConfigUpdateNumber)
 	builds, err := build.Find(db.Query(bson.M{}))
 	s.NoError(err)
@@ -636,9 +666,9 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 
 	g := sampleGeneratedProjectAddToBVOnly
 	g.TaskID = "task_that_called_generate_task"
-	p, v, t, pm, err := g.NewVersion()
+	p, pp, v, t, pm, err := g.NewVersion()
 	s.NoError(err)
-	s.NoError(g.Save(context.Background(), p, v, t, pm))
+	s.NoError(g.Save(context.Background(), p, pp, v, t, pm))
 	s.Equal(1, v.ConfigUpdateNumber)
 	tasks := []task.Task{}
 	err = db.FindAllQ(task.Collection, db.Query(bson.M{}), &tasks)
@@ -758,9 +788,9 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 
 	g := smallGeneratedProject
 	g.TaskID = "task_that_called_generate_task"
-	p, v, t, pm, err := g.NewVersion()
+	p, pp, v, t, pm, err := g.NewVersion()
 	s.Require().NoError(err)
-	s.NoError(g.Save(context.Background(), p, v, t, pm))
+	s.NoError(g.Save(context.Background(), p, pp, v, t, pm))
 	s.Equal(1, v.ConfigUpdateNumber)
 
 	tasks := []task.Task{}

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1186,10 +1186,10 @@ func TestCreateTaskGroup(t *testing.T) {
     - name: example_task_group
     - name: example_task_3
   `
-	proj, errs := projectFromYAML([]byte(projYml))
-	proj.Identifier = "test"
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(projYml), "test", proj)
 	assert.NotNil(proj)
-	assert.Empty(errs)
+	assert.NoError(err)
 	v := &Version{
 		Id:                  "versionId",
 		CreateTime:          time.Now(),

--- a/model/matrix_smoke_test.go
+++ b/model/matrix_smoke_test.go
@@ -51,7 +51,7 @@ func TestPythonMatrixIntegration(t *testing.T) {
 			"testdata", "matrix_python.yml"))
 		So(err, ShouldBeNil)
 		Convey("the project should parse properly", func() {
-			err := LoadProjectInto(bytes, "python", &p)
+			_, err := LoadProjectInto(bytes, "python", &p)
 			So(err, ShouldBeNil)
 			Convey("and contain the correct variants", func() {
 				So(len(p.BuildVariants), ShouldEqual, (2*2*4 - 4))
@@ -108,7 +108,7 @@ func TestDepsMatrixIntegration(t *testing.T) {
 			"testdata", "matrix_deps.yml"))
 		So(err, ShouldBeNil)
 		Convey("the project should parse properly", func() {
-			err := LoadProjectInto(bytes, "deps", &p)
+			_, err := LoadProjectInto(bytes, "deps", &p)
 			So(err, ShouldBeNil)
 			Convey("and contain the correct variants", func() {
 				So(len(p.BuildVariants), ShouldEqual, (1 + 3*3))

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -326,7 +326,8 @@ func TestMakePatchedConfig(t *testing.T) {
 			So(projectData, ShouldNotBeNil)
 
 			project := &Project{}
-			So(LoadProjectInto(projectData, "", project), ShouldBeNil)
+			_, err = LoadProjectInto(projectData, "", project)
+			So(err, ShouldBeNil)
 			So(len(project.Tasks), ShouldEqual, 2)
 		})
 		Convey("an empty base config should be patched correctly", func() {
@@ -347,7 +348,8 @@ func TestMakePatchedConfig(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			project := &Project{}
-			So(LoadProjectInto(projectData, "", project), ShouldBeNil)
+			_, err = LoadProjectInto(projectData, "", project)
+			So(err, ShouldBeNil)
 			So(project, ShouldNotBeNil)
 
 			So(len(project.Tasks), ShouldEqual, 1)

--- a/model/project.go
+++ b/model/project.go
@@ -19,8 +19,8 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	ignore "github.com/sabhiram/go-git-ignore"
-	yaml "gopkg.in/yaml.v2"
+	"github.com/sabhiram/go-git-ignore"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -242,36 +242,35 @@ type TestSuite struct {
 }
 
 type PluginCommandConf struct {
-	Function string `yaml:"func,omitempty" bson:"func"`
+	Function string `yaml:"func,omitempty" bson:"func,omitempty"`
 	// Type is used to differentiate between setup related commands and actual
 	// testing commands.
-	Type string `yaml:"type,omitempty" bson:"type"`
+	Type string `yaml:"type,omitempty" bson:"type,omitempty"`
 
 	// DisplayName is a human readable description of the function of a given
 	// command.
-	DisplayName string `yaml:"display_name,omitempty" bson:"display_name"`
+	DisplayName string `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
 
 	// Command is a unique identifier for the command configuration. It consists of a
 	// plugin name and a command name.
-	Command string `yaml:"command,omitempty" bson:"command"`
+	Command string `yaml:"command,omitempty" bson:"command,omitempty"`
 
 	// Variants is used to enumerate the particular sets of buildvariants to run
 	// this command configuration on. If it is empty, it is run on all defined
 	// variants.
-	Variants []string `yaml:"variants,omitempty" bson:"variants"`
+	Variants []string `yaml:"variants,omitempty" bson:"variants,omitempty"`
 
 	// TimeoutSecs indicates the maximum duration the command is allowed to run for.
-	TimeoutSecs int `yaml:"timeout_secs,omitempty" bson:"timeout_secs"`
+	TimeoutSecs int `yaml:"timeout_secs,omitempty" bson:"timeout_secs,omitempty"`
 
 	// Params are used to supply configuration specific information.
-	// map[string]interface{} is stored as a JSON string.
-	Params map[string]interface{} `yaml:"params,omitempty" bson:"params"`
+	Params map[string]interface{} `yaml:"params,omitempty" bson:"params,omitempty"`
 
 	// YAML string of Params to store in database
-	ParamsYAML string `yaml:"params_yaml,omitempty" bson:"params_yaml"`
+	ParamsYAML string `yaml:"params_yaml,omitempty" bson:"params_yaml,omitempty"`
 
 	// Vars defines variables that can be used within commands.
-	Vars map[string]string `yaml:"vars,omitempty" bson:"vars"`
+	Vars map[string]string `yaml:"vars,omitempty" bson:"vars,omitempty"`
 
 	Loggers *LoggerConfig `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
 }
@@ -292,15 +291,15 @@ func (c *PluginCommandConf) resolveParams() error {
 
 func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	temp := struct {
-		Function    string                 `yaml:"func,omitempty" bson:"func"`
-		Type        string                 `yaml:"type,omitempty" bson:"type"`
-		DisplayName string                 `yaml:"display_name,omitempty" bson:"display_name"`
-		Command     string                 `yaml:"command,omitempty" bson:"command"`
-		Variants    []string               `yaml:"variants,omitempty" bson:"variants"`
-		TimeoutSecs int                    `yaml:"timeout_secs,omitempty" bson:"timeout_secs"`
-		Params      map[string]interface{} `yaml:"params,omitempty" bson:"params"`
-		ParamsYAML  string                 `yaml:"params_yaml,omitempty" bson:"params_yaml"`
-		Vars        map[string]string      `yaml:"vars,omitempty" bson:"vars"`
+		Function    string                 `yaml:"func,omitempty" bson:"func,omitempty"`
+		Type        string                 `yaml:"type,omitempty" bson:"type,omitempty"`
+		DisplayName string                 `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
+		Command     string                 `yaml:"command,omitempty" bson:"command,omitempty"`
+		Variants    []string               `yaml:"variants,omitempty" bson:"variants,omitempty"`
+		TimeoutSecs int                    `yaml:"timeout_secs,omitempty" bson:"timeout_secs,omitempty"`
+		Params      map[string]interface{} `yaml:"params,omitempty" bson:"params,omitempty"`
+		ParamsYAML  string                 `yaml:"params_yaml,omitempty" bson:"params_yaml,omitempty"`
+		Vars        map[string]string      `yaml:"vars,omitempty" bson:"vars,omitempty"`
 		Loggers     *LoggerConfig          `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
 	}{}
 
@@ -347,8 +346,8 @@ type ArtifactInstructions struct {
 }
 
 type YAMLCommandSet struct {
-	SingleCommand *PluginCommandConf  `bson:"single_command"`
-	MultiCommand  []PluginCommandConf `bson:"multi_command"`
+	SingleCommand *PluginCommandConf  `bson:"single_command,omitempty"`
+	MultiCommand  []PluginCommandConf `bson:"multi_command,omitempty"`
 }
 
 func (c *YAMLCommandSet) List() []PluginCommandConf {
@@ -458,16 +457,16 @@ type ProjectTask struct {
 }
 
 type LoggerConfig struct {
-	Agent  []LogOpts `yaml:"agent" bson:"agent"`
-	System []LogOpts `yaml:"system" bson:"system"`
-	Task   []LogOpts `yaml:"task" bson:"task"`
+	Agent  []LogOpts `yaml:"agent,omitempty" bson:"agent,omitempty"`
+	System []LogOpts `yaml:"system,omitempty" bson:"system,omitempty"`
+	Task   []LogOpts `yaml:"task,omitempty" bson:"task,omitempty"`
 }
 
 type LogOpts struct {
-	Type         string `yaml:"type" bson:"type"`
+	Type         string `yaml:"type,omitempty" bson:"type,omitempty"`
 	SplunkServer string `yaml:"splunk_server,omitempty" bson:"splunk_server,omitempty"`
 	SplunkToken  string `yaml:"splunk_token,omitempty" bson:"splunk_token,omitempty"`
-	LogDirectory string `yaml:"log_directory" bson:"log_directory"`
+	LogDirectory string `yaml:"log_directory,omitempty" bson:"log_directory,omitempty"`
 }
 
 func (c *LoggerConfig) IsValid() error {
@@ -865,14 +864,12 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 	for _, e := range h.Distro.Expansions {
 		expansions.Put(e.Key, e.Value)
 	}
-	proj := &Project{}
-	err = LoadProjectInto([]byte(v.Config), t.Project, proj)
+	proj, _, err := LoadProjectForVersion(v, t.Project, false)
 	if err != nil {
-		return nil, errors.Wrap(err, "error unmarshaling project")
+		return nil, errors.Wrap(err, "error unmarshalling project")
 	}
 	bv := proj.FindBuildVariant(t.BuildVariant)
 	expansions.Update(bv.Expansions)
-
 	return expansions, nil
 }
 
@@ -945,6 +942,7 @@ func (p *Project) FindTaskGroup(name string) *TaskGroup {
 }
 
 // GetTaskGroup returns the task group for a given task from its project
+// Only called by agent so we don't retrieve project from database
 func GetTaskGroup(taskGroup string, tc *TaskConfig) (*TaskGroup, error) {
 	if tc == nil {
 		return nil, errors.New("unable to get task group: TaskConfig is nil")
@@ -958,10 +956,12 @@ func GetTaskGroup(taskGroup string, tc *TaskConfig) (*TaskGroup, error) {
 	if tc.Version == nil {
 		return nil, errors.New("version is nil")
 	}
+
 	var p Project
-	if err := LoadProjectInto([]byte(tc.Version.Config), tc.Task.Project, &p); err != nil {
+	if _, err := LoadProjectInto([]byte(tc.Version.Config), tc.Task.Project, &p); err != nil {
 		return nil, errors.Wrap(err, "error retrieving project for task group")
 	}
+
 	if taskGroup == "" {
 		// if there is no named task group, fall back to project definitions
 		return &TaskGroup{
@@ -987,8 +987,7 @@ func FindProjectFromVersionID(versionStr string) (*Project, error) {
 		return nil, errors.Errorf("nil version returned for version '%s'", versionStr)
 	}
 
-	project := &Project{}
-	err = LoadProjectInto([]byte(ver.Config), ver.Identifier, project)
+	project, _, err := LoadProjectForVersion(ver, ver.Identifier, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to load project config for version %s", versionStr)
 	}
@@ -1033,8 +1032,12 @@ func FindLastKnownGoodProject(identifier string) (*Project, error) {
 	var lastGoodVersion *Version
 	for i := 0; i < retryCount; i++ {
 		lastGoodVersion, err = FindVersionByLastKnownGoodConfig(identifier, revisionOrderNum)
+		if err != nil {
+			// database error, don't log critical
+			continue
+		}
 		if lastGoodVersion != nil {
-			err = LoadProjectInto([]byte(lastGoodVersion.Config), identifier, project)
+			project, _, err = LoadProjectForVersion(lastGoodVersion, identifier, true)
 			revisionOrderNum = lastGoodVersion.RevisionOrderNumber // look for an older version if the returned version is malformed
 		}
 		if err == nil {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -5,10 +5,15 @@ import (
 	"reflect"
 	"strings"
 
+	mgobson "gopkg.in/mgo.v2/bson"
+	"gopkg.in/yaml.v2"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 )
 
 const LoadProjectError = "load project error(s)"
@@ -16,8 +21,8 @@ const LoadProjectError = "load project error(s)"
 // This file contains the infrastructure for turning a YAML project configuration
 // into a usable Project struct. A basic overview of the project parsing process is:
 //
-// First, the YAML bytes are unmarshalled into an intermediary parserProject.
-// The parserProject's internal types define custom YAML unmarshal hooks, allowing
+// First, the YAML bytes are unmarshalled into an intermediary ParserProject.
+// The ParserProject's internal types define custom YAML unmarshal hooks, allowing
 // users to do things like offer a single definition where we expect a list, e.g.
 //   `tags: "single_tag"` instead of the more verbose `tags: ["single_tag"]`
 // or refer to task by a single selector. Custom YAML handling allows us to
@@ -35,59 +40,61 @@ const LoadProjectError = "load project error(s)"
 // Code outside of this file should never have to consider selectors or parser* types
 // when handling project code.
 
-// parserProject serves as an intermediary struct for parsing project
+// ParserProject serves as an intermediary struct for parsing project
 // configuration YAML. It implements the Unmarshaler interface
 // to allow for flexible handling.
-type parserProject struct {
-	Enabled           bool                       `yaml:"enabled,omitempty" bson:"enabled,omitempty"`
-	Stepback          bool                       `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
-	PreErrorFailsTask bool                       `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
-	BatchTime         int                        `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
-	Owner             string                     `yaml:"owner,omitempty" bson:"owner,omitempty"`
-	Repo              string                     `yaml:"repo,omitempty" bson:"repo,omitempty"`
-	RemotePath        string                     `yaml:"remote_path,omitempty" bson:"remote_path,omitempty"`
-	RepoKind          string                     `yaml:"repokind,omitempty" bson:"repokind,omitempty"`
-	Branch            string                     `yaml:"branch,omitempty" bson:"branch,omitempty"`
-	Identifier        string                     `yaml:"identifier,omitempty" bson:"identifier,omitempty"`
-	DisplayName       string                     `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
-	CommandType       string                     `yaml:"command_type,omitempty" bson:"command_type,omitempty"`
-	Ignore            parserStringSlice          `yaml:"ignore,omitempty" bson:"ignore,omitempty"`
-	Pre               *YAMLCommandSet            `yaml:"pre,omitempty" bson:"pre,omitempty"`
-	Post              *YAMLCommandSet            `yaml:"post,omitempty" bson:"post,omitempty"`
-	Timeout           *YAMLCommandSet            `yaml:"timeout,omitempty" bson:"timeout,omitempty"`
-	CallbackTimeout   int                        `yaml:"callback_timeout_secs,omitempty" bson:"callback_timeout_secs,omitempty"`
-	Modules           []Module                   `yaml:"modules,omitempty" bson:"modules,omitempty"`
-	BuildVariants     []parserBV                 `yaml:"buildvariants,omitempty" bson:"buildvariants,omitempty"`
-	Functions         map[string]*YAMLCommandSet `yaml:"functions,omitempty" bson:"functions,omitempty"`
-	TaskGroups        []parserTaskGroup          `yaml:"task_groups,omitempty" bson:"task_groups,omitempty"`
-	Tasks             []parserTask               `yaml:"tasks,omitempty" bson:"tasks,omitempty"`
-	ExecTimeoutSecs   int                        `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
-	Loggers           *LoggerConfig              `yaml:"loggers,omitempty" bson:"loggers:omitempty"`
+type ParserProject struct {
+	Id                 string                     `yaml:"_id" bson:"_id"` // should be the same as the version's ID
+	ConfigUpdateNumber int                        `yaml:"config_number,omitempty" bson:"config_number,omitempty"`
+	Enabled            bool                       `yaml:"enabled,omitempty" bson:"enabled,omitempty"`
+	Stepback           bool                       `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	PreErrorFailsTask  bool                       `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
+	BatchTime          int                        `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
+	Owner              string                     `yaml:"owner,omitempty" bson:"owner,omitempty"`
+	Repo               string                     `yaml:"repo,omitempty" bson:"repo,omitempty"`
+	RemotePath         string                     `yaml:"remote_path,omitempty" bson:"remote_path,omitempty"`
+	RepoKind           string                     `yaml:"repokind,omitempty" bson:"repokind,omitempty"`
+	Branch             string                     `yaml:"branch,omitempty" bson:"branch,omitempty"`
+	Identifier         string                     `yaml:"identifier,omitempty" bson:"identifier,omitempty"`
+	DisplayName        string                     `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
+	CommandType        string                     `yaml:"command_type,omitempty" bson:"command_type,omitempty"`
+	Ignore             parserStringSlice          `yaml:"ignore,omitempty" bson:"ignore,omitempty"`
+	Pre                *YAMLCommandSet            `yaml:"pre,omitempty" bson:"pre,omitempty"`
+	Post               *YAMLCommandSet            `yaml:"post,omitempty" bson:"post,omitempty"`
+	Timeout            *YAMLCommandSet            `yaml:"timeout,omitempty" bson:"timeout,omitempty"`
+	CallbackTimeout    int                        `yaml:"callback_timeout_secs,omitempty" bson:"callback_timeout_secs,omitempty"`
+	Modules            []Module                   `yaml:"modules,omitempty" bson:"modules,omitempty"`
+	BuildVariants      []parserBV                 `yaml:"buildvariants,omitempty" bson:"buildvariants,omitempty"`
+	Functions          map[string]*YAMLCommandSet `yaml:"functions,omitempty" bson:"functions,omitempty"`
+	TaskGroups         []parserTaskGroup          `yaml:"task_groups,omitempty" bson:"task_groups,omitempty"`
+	Tasks              []parserTask               `yaml:"tasks,omitempty" bson:"tasks,omitempty"`
+	ExecTimeoutSecs    int                        `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
+	Loggers            *LoggerConfig              `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
 
 	// Matrix code
 	Axes []matrixAxis `yaml:"axes,omitempty" bson:"axes,omitempty"`
 }
 
 type parserTaskGroup struct {
-	Name                  string             `yaml:"name,omitempty"`
-	Priority              int64              `yaml:"priority,omitempty"`
-	Patchable             *bool              `yaml:"patchable,omitempty"`
-	PatchOnly             *bool              `yaml:"patch_only,omitempty"`
-	ExecTimeoutSecs       int                `yaml:"exec_timeout_secs,omitempty"`
-	Stepback              *bool              `yaml:"stepback,omitempty"`
-	MaxHosts              int                `yaml:"max_hosts,omitempty"`
-	SetupGroupFailTask    bool               `yaml:"setup_group_can_fail_task,omitempty"`
-	SetupGroupTimeoutSecs int                `yaml:"setup_group_timeout_secs,omitempty"`
-	SetupGroup            *YAMLCommandSet    `yaml:"setup_group,omitempty"`
-	TeardownGroup         *YAMLCommandSet    `yaml:"teardown_group,omitempty"`
-	SetupTask             *YAMLCommandSet    `yaml:"setup_task,omitempty"`
-	TeardownTask          *YAMLCommandSet    `yaml:"teardown_task,omitempty"`
-	Timeout               *YAMLCommandSet    `yaml:"timeout,omitempty"`
-	Tasks                 []string           `yaml:"tasks,omitempty"`
-	DependsOn             parserDependencies `yaml:"depends_on,omitempty"`
-	Requires              taskSelectors      `yaml:"requires,omitempty"`
-	Tags                  parserStringSlice  `yaml:"tags,omitempty"`
-	ShareProcs            bool               `yaml:"share_processes,omitempty"`
+	Name                  string             `yaml:"name,omitempty" bson:"name,omitempty"`
+	Priority              int64              `yaml:"priority,omitempty" bson:"priority,omitempty"`
+	Patchable             *bool              `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
+	PatchOnly             *bool              `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	ExecTimeoutSecs       int                `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
+	Stepback              *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	MaxHosts              int                `yaml:"max_hosts,omitempty" bson:"max_hosts,omitempty"`
+	SetupGroupFailTask    bool               `yaml:"setup_group_can_fail_task,omitempty" bson:"setup_group_can_fail_task,omitempty"`
+	SetupGroupTimeoutSecs int                `yaml:"setup_group_timeout_secs,omitempty" bson:"setup_group_timeout_secs,omitempty"`
+	SetupGroup            *YAMLCommandSet    `yaml:"setup_group,omitempty" bson:"setup_group,omitempty"`
+	TeardownGroup         *YAMLCommandSet    `yaml:"teardown_group,omitempty" bson:"teardown_group,omitempty"`
+	SetupTask             *YAMLCommandSet    `yaml:"setup_task,omitempty" bson:"setup_task,omitempty"`
+	TeardownTask          *YAMLCommandSet    `yaml:"teardown_task,omitempty" bson:"teardown_task,omitempty"`
+	Timeout               *YAMLCommandSet    `yaml:"timeout,omitempty" bson:"timeout,omitempty"`
+	Tasks                 []string           `yaml:"tasks,omitempty" bson:"tasks,omitempty"`
+	DependsOn             parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
+	Requires              taskSelectors      `yaml:"requires,omitempty" bson:"requires,omitempty"`
+	Tags                  parserStringSlice  `yaml:"tags,omitempty" bson:"tags,omitempty"`
+	ShareProcs            bool               `yaml:"share_processes,omitempty" bson:"share_processes,omitempty"`
 }
 
 func (ptg *parserTaskGroup) name() string   { return ptg.Name }
@@ -95,19 +102,27 @@ func (ptg *parserTaskGroup) tags() []string { return ptg.Tags }
 
 // parserTask represents an intermediary state of task definitions.
 type parserTask struct {
-	Name            string              `yaml:"name,omitempty"`
-	Priority        int64               `yaml:"priority,omitempty"`
-	ExecTimeoutSecs int                 `yaml:"exec_timeout_secs,omitempty"`
-	DependsOn       parserDependencies  `yaml:"depends_on,omitempty"`
-	Requires        taskSelectors       `yaml:"requires,omitempty"`
-	Commands        []PluginCommandConf `yaml:"commands,omitempty"`
-	Tags            parserStringSlice   `yaml:"tags,omitempty"`
-	Patchable       *bool               `yaml:"patchable,omitempty"`
-	PatchOnly       *bool               `yaml:"patch_only,omitempty"`
-	Stepback        *bool               `yaml:"stepback,omitempty"`
+	Name            string              `yaml:"name,omitempty" bson:"name,omitempty"`
+	Priority        int64               `yaml:"priority,omitempty" bson:"priority,omitempty"`
+	ExecTimeoutSecs int                 `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
+	DependsOn       parserDependencies  `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
+	Requires        taskSelectors       `yaml:"requires,omitempty" bson:"requires,omitempty"`
+	Commands        []PluginCommandConf `yaml:"commands,omitempty" bson:"commands,omitempty"`
+	Tags            parserStringSlice   `yaml:"tags,omitempty" bson:"tags,omitempty"`
+	Patchable       *bool               `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
+	PatchOnly       *bool               `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	Stepback        *bool               `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
 }
 
-func (pp *parserProject) MarshalYAML() (interface{}, error) {
+func (pp *ParserProject) Insert() error {
+	return db.Insert(ParserProjectCollection, pp)
+}
+
+func (pp *ParserProject) MarshalBSON() ([]byte, error) {
+	return mgobson.Marshal(pp)
+}
+
+func (pp *ParserProject) MarshalYAML() (interface{}, error) {
 	for i, pt := range pp.Tasks {
 		for j := range pt.Commands {
 			if err := pp.Tasks[i].Commands[j].resolveParams(); err != nil {
@@ -120,8 +135,8 @@ func (pp *parserProject) MarshalYAML() (interface{}, error) {
 }
 
 type displayTask struct {
-	Name           string   `yaml:"name,omitempty"`
-	ExecutionTasks []string `yaml:"execution_tasks,omitempty"`
+	Name           string   `yaml:"name,omitempty" bson:"name,omitempty"`
+	ExecutionTasks []string `yaml:"execution_tasks,omitempty" bson:"execution_tasks,omitempty"`
 }
 
 // helper methods for task tag evaluations
@@ -131,8 +146,8 @@ func (pt *parserTask) tags() []string { return pt.Tags }
 // parserDependency represents the intermediary state for referencing dependencies.
 type parserDependency struct {
 	TaskSelector  taskSelector `yaml:",inline"`
-	Status        string       `yaml:"status,omitempty"`
-	PatchOptional bool         `yaml:"patch_optional,omitempty"`
+	Status        string       `yaml:"status,omitempty" bson:"status,omitempty"`
+	PatchOptional bool         `yaml:"patch_optional,omitempty" bson:"patch_optional,omitempty"`
 }
 
 // parserDependencies is a type defined for unmarshalling both a single
@@ -268,20 +283,20 @@ func (ts *taskSelector) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // parserBV is a helper type storing intermediary variant definitions.
 type parserBV struct {
-	Name         string             `yaml:"name,omitempty"`
-	DisplayName  string             `yaml:"display_name,omitempty"`
-	Expansions   util.Expansions    `yaml:"expansions,omitempty"`
-	Tags         parserStringSlice  `yaml:"tags,omitempty,omitempty"`
-	Modules      parserStringSlice  `yaml:"modules,omitempty"`
-	Disabled     bool               `yaml:"disabled,omitempty"`
-	Push         bool               `yaml:"push,omitempty"`
-	BatchTime    *int               `yaml:"batchtime,omitempty"`
-	Stepback     *bool              `yaml:"stepback,omitempty"`
-	RunOn        parserStringSlice  `yaml:"run_on,omitempty"`
-	Tasks        parserBVTaskUnits  `yaml:"tasks,omitempty"`
-	DisplayTasks []displayTask      `yaml:"display_tasks,omitempty"`
-	DependsOn    parserDependencies `yaml:"depends_on,omitempty"`
-	Requires     taskSelectors      `yaml:"requires,omitempty"`
+	Name         string             `yaml:"name,omitempty" bson:"name,omitempty"`
+	DisplayName  string             `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
+	Expansions   util.Expansions    `yaml:"expansions,omitempty" bson:"expansions,omitempty"`
+	Tags         parserStringSlice  `yaml:"tags,omitempty,omitempty" bson:"tags,omitempty"`
+	Modules      parserStringSlice  `yaml:"modules,omitempty" bson:"modules,omitempty"`
+	Disabled     bool               `yaml:"disabled,omitempty" bson:"disabled,omitempty"`
+	Push         bool               `yaml:"push,omitempty" bson:"push,omitempty"`
+	BatchTime    *int               `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
+	Stepback     *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	RunOn        parserStringSlice  `yaml:"run_on,omitempty" bson:"run_on,omitempty"`
+	Tasks        parserBVTaskUnits  `yaml:"tasks,omitempty" bson:"tasks,omitempty"`
+	DisplayTasks []displayTask      `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
+	DependsOn    parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
+	Requires     taskSelectors      `yaml:"requires,omitempty" bson:"requires,omitempty"`
 
 	// internal matrix stuff
 	MatrixId  string      `yaml:"matrix_id,omitempty" bson:"matrix_id,omitempty"`
@@ -331,17 +346,17 @@ func (pbv *parserBV) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // parserBVTaskUnit is a helper type storing intermediary variant task configurations.
 type parserBVTaskUnit struct {
-	Name             string             `yaml:"name,omitempty"`
-	Patchable        *bool              `yaml:"patchable,omitempty"`
-	PatchOnly        *bool              `yaml:"patch_only,omitempty"`
-	Priority         int64              `yaml:"priority,omitempty"`
-	DependsOn        parserDependencies `yaml:"depends_on,omitempty"`
-	Requires         taskSelectors      `yaml:"requires,omitempty"`
-	ExecTimeoutSecs  int                `yaml:"exec_timeout_secs,omitempty"`
-	Stepback         *bool              `yaml:"stepback,omitempty"`
-	Distros          parserStringSlice  `yaml:"distros,omitempty"`
-	RunOn            parserStringSlice  `yaml:"run_on,omitempty"` // Alias for "Distros" TODO: deprecate Distros
-	CommitQueueMerge bool               `yaml:"commit_queue_merge,omitempty"`
+	Name             string             `yaml:"name,omitempty" bson:"name,omitempty"`
+	Patchable        *bool              `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
+	PatchOnly        *bool              `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	Priority         int64              `yaml:"priority,omitempty" bson:"priority,omitempty"`
+	DependsOn        parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
+	Requires         taskSelectors      `yaml:"requires,omitempty" bson:"requires,omitempty"`
+	ExecTimeoutSecs  int                `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
+	Stepback         *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	Distros          parserStringSlice  `yaml:"distros,omitempty" bson:"distros,omitempty"`
+	RunOn            parserStringSlice  `yaml:"run_on,omitempty" bson:"run_on,omitempty"` // Alias for "Distros" TODO: deprecate Distros
+	CommitQueueMerge bool               `yaml:"commit_queue_merge,omitempty" bson:"commit_queue_merge,omitempty"`
 }
 
 // UnmarshalYAML allows the YAML parser to read both a single selector string or
@@ -416,37 +431,76 @@ func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(interface{}) error) e
 	return nil
 }
 
-// LoadProjectInto loads the raw data from the config file into project
-// and sets the project's identifier field to identifier. Tags are evaluated.
-func LoadProjectInto(data []byte, identifier string, project *Project) error {
-	p, err := projectFromYAML(data)
-	if err != nil {
-		return errors.Wrap(err, LoadProjectError)
+// LoadProjectForVersion returns the project for a version, either from the parser project or the config string.
+// If read from the config string and shouldSave is set, the resulting parser project will be saved.
+func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Project, *ParserProject, error) {
+	var ppFromDB *ParserProject
+	var err error
+	// if not using parser project anyway, only lookup if saving
+	if evergreen.UseParserProject || shouldSave {
+		ppFromDB, err = ParserProjectFindOneById(v.Id)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "error finding parser project")
+		}
 	}
-	*project = *p
-	project.Identifier = identifier
-	return nil
+
+	if evergreen.UseParserProject && ppFromDB != nil {
+		ppFromDB.Identifier = identifier
+		p, err := TranslateProject(ppFromDB)
+		return p, ppFromDB, err
+	}
+
+	if v.Config == "" {
+		return nil, nil, errors.New("version has no config")
+	}
+	p := &Project{}
+	pp, err := LoadProjectInto([]byte(v.Config), identifier, p)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error loading project")
+	}
+	pp.Id = v.Id
+	pp.Identifier = identifier
+	pp.ConfigUpdateNumber = v.ConfigUpdateNumber
+
+	// TODO: don't need separate ppFromDB variable once UseParserProject = true
+	if shouldSave && ppFromDB == nil {
+		if err = pp.Insert(); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"project":       identifier,
+				"version":       v.Id,
+				"config_number": v.ConfigUpdateNumber,
+				"message":       "error inserting parser project for version",
+			}))
+			return nil, nil, errors.Wrap(err, "error updating version with project")
+		}
+	}
+	return p, pp, nil
 }
 
-// projectFromYAML reads and evaluates project YAML, returning a project and warnings and
-// errors encountered during parsing or evaluation.
-func projectFromYAML(yml []byte) (*Project, error) {
-	intermediateProject, err := createIntermediateProject(yml)
+// LoadProjectInto loads the raw data from the config file into project
+// and sets the project's identifier field to identifier. Tags are evaluated. Returns the intermediate step.
+// If reading from a version config, LoadProjectForVersion should be used to persist the resulting parser project.
+func LoadProjectInto(data []byte, identifier string, project *Project) (*ParserProject, error) {
+	intermediateProject, err := createIntermediateProject(data)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, LoadProjectError)
 	}
-	p, err := translateProject(intermediateProject)
-	return p, err
+
+	// return project even with errors
+	p, err := TranslateProject(intermediateProject)
+	*project = *p
+	project.Identifier = identifier
+	return intermediateProject, errors.Wrap(err, LoadProjectError)
 }
 
 // createIntermediateProject marshals the supplied YAML into our
 // intermediate project representation (i.e. before selectors or
 // matrix logic has been evaluated).
-func createIntermediateProject(yml []byte) (*parserProject, error) {
-	p := &parserProject{}
+func createIntermediateProject(yml []byte) (*ParserProject, error) {
+	p := &ParserProject{}
 	err := yaml.Unmarshal(yml, p)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error unmarshalling into parser project")
 	}
 	if p.Functions == nil {
 		p.Functions = map[string]*YAMLCommandSet{}
@@ -455,10 +509,10 @@ func createIntermediateProject(yml []byte) (*parserProject, error) {
 	return p, nil
 }
 
-// translateProject converts our intermediate project representation into
+// TranslateProject converts our intermediate project representation into
 // the Project type that Evergreen actually uses. Errors are added to
 // pp.errors and pp.warnings and must be checked separately.
-func translateProject(pp *parserProject) (*Project, error) {
+func TranslateProject(pp *ParserProject) (*Project, error) {
 	// Transfer top level fields
 	proj := &Project{
 		Enabled:           pp.Enabled,
@@ -489,18 +543,43 @@ func translateProject(pp *parserProject) (*Project, error) {
 	ase := NewAxisSelectorEvaluator(pp.Axes)
 	regularBVs, matrices := sieveMatrixVariants(pp.BuildVariants)
 
+	var errs []error
 	matrixVariants, errs := buildMatrixVariants(pp.Axes, ase, matrices)
 	catcher.Extend(errs)
 	buildVariants := append(regularBVs, matrixVariants...)
 	vse := NewVariantSelectorEvaluator(buildVariants, ase)
-
 	proj.Tasks, proj.TaskGroups, errs = evaluateTaskUnits(tse, tgse, vse, pp.Tasks, pp.TaskGroups)
 	catcher.Extend(errs)
 
 	proj.BuildVariants, errs = evaluateBuildVariants(tse, tgse, vse, buildVariants, pp.Tasks, proj.TaskGroups)
 	catcher.Extend(errs)
 
-	return proj, catcher.Resolve()
+	proj.BuildVariants, errs = evaluateBuildVariants(tse, tgse, vse, buildVariants, pp.Tasks, proj.TaskGroups)
+	catcher.Extend(errs)
+	return proj, errors.Wrap(catcher.Resolve(), "error translating project")
+}
+
+func (pp *ParserProject) AddTask(name string, commands []PluginCommandConf) {
+	t := parserTask{
+		Name:     name,
+		Commands: commands,
+	}
+	pp.Tasks = append(pp.Tasks, t)
+}
+func (pp *ParserProject) AddBuildVariant(name, displayName, runOn string, batchTime *int, tasks []string) {
+	bv := parserBV{
+		Name:        name,
+		DisplayName: displayName,
+		BatchTime:   batchTime,
+		Tasks:       []parserBVTaskUnit{},
+	}
+	for _, taskName := range tasks {
+		bv.Tasks = append(bv.Tasks, parserBVTaskUnit{Name: taskName})
+	}
+	if runOn != "" {
+		bv.RunOn = []string{runOn}
+	}
+	pp.BuildVariants = append(pp.BuildVariants, bv)
 }
 
 // sieveMatrixVariants takes a set of parserBVs and groups them into regular

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -445,6 +445,7 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 	}
 
 	if evergreen.UseParserProject && ppFromDB != nil {
+		// TODO: check here for ppFromDB.ConfigUpdateNumber >= v.ConfigUpdateNumber
 		ppFromDB.Identifier = identifier
 		p, err := TranslateProject(ppFromDB)
 		return p, ppFromDB, err

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -544,15 +544,11 @@ func TranslateProject(pp *ParserProject) (*Project, error) {
 	ase := NewAxisSelectorEvaluator(pp.Axes)
 	regularBVs, matrices := sieveMatrixVariants(pp.BuildVariants)
 
-	var errs []error
 	matrixVariants, errs := buildMatrixVariants(pp.Axes, ase, matrices)
 	catcher.Extend(errs)
 	buildVariants := append(regularBVs, matrixVariants...)
 	vse := NewVariantSelectorEvaluator(buildVariants, ase)
 	proj.Tasks, proj.TaskGroups, errs = evaluateTaskUnits(tse, tgse, vse, pp.Tasks, pp.TaskGroups)
-	catcher.Extend(errs)
-
-	proj.BuildVariants, errs = evaluateBuildVariants(tse, tgse, vse, buildVariants, pp.Tasks, proj.TaskGroups)
 	catcher.Extend(errs)
 
 	proj.BuildVariants, errs = evaluateBuildVariants(tse, tgse, vse, buildVariants, pp.Tasks, proj.TaskGroups)

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -1,0 +1,116 @@
+package model
+
+import (
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/mongodb/anser/bsonutil"
+	adb "github.com/mongodb/anser/db"
+	"github.com/pkg/errors"
+	"gopkg.in/mgo.v2/bson"
+)
+
+const (
+	ParserProjectCollection = "parser_projects"
+)
+
+var (
+	ParserProjectIdKey                = bsonutil.MustHaveTag(ParserProject{}, "Id")
+	ParserProjectConfigNumberKey      = bsonutil.MustHaveTag(ParserProject{}, "ConfigUpdateNumber")
+	ParserProjectEnabledKey           = bsonutil.MustHaveTag(ParserProject{}, "Enabled")
+	ParserProjectStepbackKey          = bsonutil.MustHaveTag(ParserProject{}, "Stepback")
+	ParserProjectPreErrorFailsTaskKey = bsonutil.MustHaveTag(ParserProject{}, "PreErrorFailsTask")
+	ParserProjectBatchTimeKey         = bsonutil.MustHaveTag(ParserProject{}, "BatchTime")
+	ParserProjectOwnerKey             = bsonutil.MustHaveTag(ParserProject{}, "Owner")
+	ParserProjectRepoKey              = bsonutil.MustHaveTag(ParserProject{}, "Repo")
+	ParserProjectRepoKindKey          = bsonutil.MustHaveTag(ParserProject{}, "RepoKind")
+	ParserProjectRemotePathKey        = bsonutil.MustHaveTag(ParserProject{}, "RemotePath")
+	ParserProjectBranchKey            = bsonutil.MustHaveTag(ParserProject{}, "Branch")
+	ParserProjectIdentifierKey        = bsonutil.MustHaveTag(ParserProject{}, "Identifier")
+	ParserProjectDisplayNameKey       = bsonutil.MustHaveTag(ParserProject{}, "DisplayName")
+	ParserProjectCommandTypeKey       = bsonutil.MustHaveTag(ParserProject{}, "CommandType")
+	ParserProjectIgnoreKey            = bsonutil.MustHaveTag(ParserProject{}, "Ignore")
+	ParserProjectPreKey               = bsonutil.MustHaveTag(ParserProject{}, "Pre")
+	ParserProjectPostKey              = bsonutil.MustHaveTag(ParserProject{}, "Post")
+	ParserProjectTimeoutKey           = bsonutil.MustHaveTag(ParserProject{}, "Timeout")
+	ParserProjectCallbackTimeoutKey   = bsonutil.MustHaveTag(ParserProject{}, "CallbackTimeout")
+	ParserProjectModulesKey           = bsonutil.MustHaveTag(ParserProject{}, "Modules")
+	ParserProjectBuildVariantsKey     = bsonutil.MustHaveTag(ParserProject{}, "BuildVariants")
+	ParserProjectFunctionsKey         = bsonutil.MustHaveTag(ParserProject{}, "Functions")
+	ParserProjectTaskGroupsKey        = bsonutil.MustHaveTag(ParserProject{}, "TaskGroups")
+	ParserProjectTasksKey             = bsonutil.MustHaveTag(ParserProject{}, "Tasks")
+	ParserProjectExecTimeoutSecsKey   = bsonutil.MustHaveTag(ParserProject{}, "ExecTimeoutSecs")
+	ParserProjectLoggersKey           = bsonutil.MustHaveTag(ParserProject{}, "Loggers")
+	ParserProjectAxesKey              = bsonutil.MustHaveTag(ParserProject{}, "Axes")
+)
+
+// ProjectById returns the parser project for the version
+func ParserProjectFindOneById(id string) (*ParserProject, error) {
+	project := &ParserProject{}
+	err := db.FindOneQ(ParserProjectCollection, db.Query(bson.M{ParserProjectIdKey: id}), project)
+	if adb.ResultsNotFound(err) {
+		return nil, nil
+	}
+	return project, err
+}
+
+// UpdateOne updates one project
+func ParserProjectUpdateOne(query interface{}, update interface{}) error {
+	return db.Update(
+		ParserProjectCollection,
+		query,
+		update,
+	)
+}
+
+// UpsertWithConfigNumber inserts project if it DNE, otherwise updates if the config number is correct
+func (pp *ParserProject) UpsertWithConfigNumber(num int) error {
+	if pp.Id == "" {
+		return errors.New("no version ID given")
+	}
+
+	found, err := ParserProjectFindOneById(pp.Id)
+	if err != nil {
+		return errors.Wrapf(err, "error finding parser project '%s'", pp.Id)
+	}
+	if found == nil {
+		pp.ConfigUpdateNumber = num
+		return errors.Wrap(pp.Insert(), "error inserting parser project")
+	}
+
+	return errors.Wrapf(ParserProjectUpdateOne(
+		bson.M{
+			ParserProjectIdKey: pp.Id,
+			"$or": []bson.M{
+				bson.M{ParserProjectConfigNumberKey: bson.M{"$exists": false}},
+				bson.M{ParserProjectConfigNumberKey: pp.ConfigUpdateNumber},
+			},
+		},
+		bson.M{
+			"$set": bson.M{
+				ParserProjectEnabledKey:           pp.Enabled,
+				ParserProjectStepbackKey:          pp.Stepback,
+				ParserProjectPreErrorFailsTaskKey: pp.PreErrorFailsTask,
+				ParserProjectBatchTimeKey:         pp.BatchTime,
+				ParserProjectOwnerKey:             pp.Owner,
+				ParserProjectRepoKey:              pp.Repo,
+				ParserProjectRepoKindKey:          pp.RepoKind,
+				ParserProjectRemotePathKey:        pp.RemotePath,
+				ParserProjectBranchKey:            pp.Branch,
+				ParserProjectIdentifierKey:        pp.Identifier,
+				ParserProjectDisplayNameKey:       pp.DisplayName,
+				ParserProjectCommandTypeKey:       pp.CommandType,
+				ParserProjectIgnoreKey:            pp.Ignore,
+				ParserProjectPreKey:               pp.Pre,
+				ParserProjectPostKey:              pp.Post,
+				ParserProjectTimeoutKey:           pp.Timeout,
+				ParserProjectCallbackTimeoutKey:   pp.CallbackTimeout,
+				ParserProjectModulesKey:           pp.Modules,
+				ParserProjectBuildVariantsKey:     pp.BuildVariants,
+				ParserProjectFunctionsKey:         pp.Functions,
+				ParserProjectTaskGroupsKey:        pp.TaskGroups,
+				ParserProjectTasksKey:             pp.Tasks,
+				ParserProjectExecTimeoutSecsKey:   pp.ExecTimeoutSecs,
+				ParserProjectLoggersKey:           pp.Loggers,
+				ParserProjectConfigNumberKey:      num,
+			},
+		}), "error updating parser project '%s'", pp.Id)
+}

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/testutil"
-
+	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 // ShouldContainResembling tests whether a slice contains an element that DeepEquals
@@ -330,7 +330,7 @@ buildvariants:
 
 func TestTranslateDependsOn(t *testing.T) {
 	Convey("With an intermediate parseProject", t, func() {
-		pp := &parserProject{}
+		pp := &ParserProject{}
 		Convey("a tag-free dependency config should be unchanged", func() {
 			pp.BuildVariants = []parserBV{
 				{Name: "v1"},
@@ -344,7 +344,7 @@ func TestTranslateDependsOn(t *testing.T) {
 						Name: "t2", Variant: &variantSelector{StringSelector: "v1"}}}},
 				},
 			}
-			out, err := translateProject(pp)
+			out, err := TranslateProject(pp)
 			So(out, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			deps := out.Tasks[2].DependsOn
@@ -368,7 +368,7 @@ func TestTranslateDependsOn(t *testing.T) {
 						Name: ".a !.b", Variant: &variantSelector{StringSelector: ".cool"}}}},
 				},
 			}
-			out, err := translateProject(pp)
+			out, err := TranslateProject(pp)
 			So(out, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(out.Tasks[1].DependsOn[0].Name, ShouldEqual, "*")
@@ -396,16 +396,18 @@ func TestTranslateDependsOn(t *testing.T) {
 					{TaskSelector: taskSelector{Name: ".b"}},                                                       //[4] conflicts with above
 				}},
 			}
-			out, err := translateProject(pp)
+
+			out, err := TranslateProject(pp)
 			So(out, ShouldNotBeNil)
 			So(err, ShouldNotBeNil)
+			So(len(strings.Split(err.Error(), "\n")), ShouldEqual, 6)
 		})
 	})
 }
 
 func TestTranslateRequires(t *testing.T) {
 	Convey("With an intermediate parseProject", t, func() {
-		pp := &parserProject{}
+		pp := &ParserProject{}
 		Convey("a task with valid requirements should succeed", func() {
 			pp.BuildVariants = []parserBV{
 				{Name: "v1"},
@@ -418,7 +420,7 @@ func TestTranslateRequires(t *testing.T) {
 					{Name: "t2", Variant: &variantSelector{StringSelector: "v1"}},
 				}},
 			}
-			out, err := translateProject(pp)
+			out, err := TranslateProject(pp)
 			So(out, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			reqs := out.Tasks[2].Requires
@@ -440,16 +442,17 @@ func TestTranslateRequires(t *testing.T) {
 					{Name: "t1 t2"}, //nothing returned
 				}},
 			}
-			out, err := translateProject(pp)
+			out, err := TranslateProject(pp)
 			So(out, ShouldNotBeNil)
 			So(err, ShouldNotBeNil)
+			So(len(strings.Split(err.Error(), "\n")), ShouldEqual, 7)
 		})
 	})
 }
 
 func TestTranslateBuildVariants(t *testing.T) {
 	Convey("With an intermediate parseProject", t, func() {
-		pp := &parserProject{}
+		pp := &ParserProject{}
 		Convey("a project with valid variant tasks should succeed", func() {
 			pp.Tasks = []parserTask{
 				{Name: "t1"},
@@ -466,7 +469,7 @@ func TestTranslateBuildVariants(t *testing.T) {
 				},
 			}}
 
-			out, err := translateProject(pp)
+			out, err := TranslateProject(pp)
 			So(out, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bvts := out.BuildVariants[0].Tasks
@@ -487,9 +490,10 @@ func TestTranslateBuildVariants(t *testing.T) {
 					{Name: "t1", Requires: taskSelectors{{Name: ".b"}}},
 				},
 			}}
-			out, err := translateProject(pp)
+			out, err := TranslateProject(pp)
 			So(out, ShouldNotBeNil)
 			So(err, ShouldNotBeNil)
+			So(len(strings.Split(err.Error(), "\n")), ShouldEqual, 2)
 		})
 	})
 }
@@ -653,9 +657,10 @@ tasks:
 - name: execTask4
 `
 
-	proj, err := projectFromYAML([]byte(validYml))
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(validYml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 1)
 	assert.Len(proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks, 2)
 	assert.Len(proj.BuildVariants[1].DisplayTasks, 0)
@@ -685,9 +690,9 @@ tasks:
 - name: execTask4
 `
 
-	proj, err = projectFromYAML([]byte(nonexistentTaskYml))
+	proj = &Project{}
+	_, err = LoadProjectInto([]byte(nonexistentTaskYml), "id", proj)
 	assert.NotNil(proj)
-	assert.Error(err)
 	assert.Contains(err.Error(), "notHere: nothing named 'notHere'")
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 1)
 	assert.Len(proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks, 2)
@@ -717,9 +722,10 @@ tasks:
 - name: execTask4
 `
 
-	proj, err = projectFromYAML([]byte(duplicateTaskYml))
+	proj = &Project{}
+	_, err = LoadProjectInto([]byte(duplicateTaskYml), "id", proj)
 	assert.NotNil(proj)
-	assert.Error(err)
+	assert.NotNil(err)
 	assert.Contains(err.Error(), "execution task execTask3 is listed in more than 1 display task")
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 0)
 
@@ -742,9 +748,10 @@ tasks:
 - name: execTask4
 `
 
-	proj, err = projectFromYAML([]byte(conflictYml))
+	proj = &Project{}
+	_, err = LoadProjectInto([]byte(conflictYml), "id", proj)
 	assert.NotNil(proj)
-	assert.Error(err)
+	assert.NotNil(err)
 	assert.Contains(err.Error(), "display task execTask1 cannot have the same name as an execution task")
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 0)
 
@@ -771,9 +778,10 @@ tasks:
 - name: execTask4
 `
 
-	proj, err = projectFromYAML([]byte(wildcardYml))
+	proj = &Project{}
+	_, err = LoadProjectInto([]byte(wildcardYml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 1)
 	assert.Len(proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks, 3)
 
@@ -804,9 +812,10 @@ tasks:
   tags: [ "even" ]
 `
 
-	proj, err = projectFromYAML([]byte(tagYml))
+	proj = &Project{}
+	_, err = LoadProjectInto([]byte(tagYml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 2)
 	assert.Len(proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks, 2)
 	assert.Len(proj.BuildVariants[0].DisplayTasks[1].ExecutionTasks, 2)
@@ -854,7 +863,7 @@ tasks:
 	assert.Len(pp.BuildVariants[0].DisplayTasks[1].ExecutionTasks, 1)
 	assert.Equal(".even", pp.BuildVariants[0].DisplayTasks[1].ExecutionTasks[0])
 
-	proj, err := translateProject(pp)
+	proj, err := TranslateProject(pp)
 	assert.NotNil(proj)
 	assert.NoError(err)
 	// assert parser project hasn't changed
@@ -912,9 +921,11 @@ buildvariants:
   tasks:
   - name: example_task_group
 `
-	proj, err := projectFromYAML([]byte(validYml))
+
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(validYml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.TaskGroups, 1)
 	tg := proj.TaskGroups[0]
 	assert.Equal("example_task_group", tg.Name)
@@ -943,9 +954,11 @@ buildvariants:
   tasks:
   - name: example_task_group
 `
-	proj, err = projectFromYAML([]byte(wrongTaskYml))
+
+	proj = &Project{}
+	_, err = LoadProjectInto([]byte(wrongTaskYml), "id", proj)
 	assert.NotNil(proj)
-	assert.Error(err)
+	assert.NotNil(err)
 	assert.Contains(err.Error(), `nothing named 'example_task_3'`)
 
 	// check that tasks listed in the task group yml maintain their order
@@ -977,9 +990,11 @@ buildvariants:
   tasks:
   - name: example_task_group
 `
-	proj, err = projectFromYAML([]byte(orderedYml))
+
+	proj = &Project{}
+	_, err = LoadProjectInto([]byte(orderedYml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	for i, t := range proj.TaskGroups[0].Tasks {
 		assert.Equal(strconv.Itoa(i+1), t)
 	}
@@ -1008,9 +1023,11 @@ buildvariants:
   - name: even_task_group
   - name: odd_task_group
 `
-	proj, err = projectFromYAML([]byte(tagYml))
+
+	proj = &Project{}
+	_, err = LoadProjectInto([]byte(tagYml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.TaskGroups, 2)
 	assert.Equal("even_task_group", proj.TaskGroups[0].Name)
 	assert.Len(proj.TaskGroups[0].Tasks, 2)
@@ -1043,9 +1060,11 @@ buildvariants:
       - task_1
       - task_2
 `
-	proj, err := projectFromYAML([]byte(validYml))
+
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(validYml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.TaskGroups, 1)
 	tg := proj.TaskGroups[0]
 	assert.Equal("task_group_1", tg.Name)
@@ -1077,9 +1096,11 @@ buildvariants:
       execution_tasks:
       - ".tag_1"
 `
-	proj, err := projectFromYAML([]byte(validYml))
+
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(validYml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.TaskGroups, 1)
 	tg := proj.TaskGroups[0]
 	assert.Equal("task_group_1", tg.Name)
@@ -1111,9 +1132,11 @@ buildvariants:
       - task_1
       - task_2
 `
-	proj, err := projectFromYAML([]byte(validYml))
+
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(validYml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.TaskGroups, 1)
 	tg := proj.TaskGroups[0]
 	assert.Equal("task_group_1", tg.Name)
@@ -1144,9 +1167,11 @@ buildvariants:
       execution_tasks:
       - ".tag_1"
 `
-	proj, err := projectFromYAML([]byte(validYml))
+
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(validYml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.TaskGroups, 1)
 	tg := proj.TaskGroups[0]
 	assert.Equal("task_group_1", tg.Name)
@@ -1184,9 +1209,11 @@ buildvariants:
     - name: task_4
     - name: task_5
 `
-	proj, err := projectFromYAML([]byte(yml))
+
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(yml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.BuildVariants, 3)
 
 	assert.Equal("bv_1", proj.BuildVariants[0].Name)
@@ -1233,9 +1260,10 @@ buildvariants:
   - name: task_2
 `
 
-	proj, err := projectFromYAML([]byte(yml))
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(yml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Len(proj.BuildVariants, 3)
 
 	assert.Len(proj.BuildVariants[0].Tasks, 2)
@@ -1267,17 +1295,31 @@ tasks:
         - type: commandLogger
 `
 
-	proj, err := projectFromYAML([]byte(yml))
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(yml), "id", proj)
 	assert.NotNil(proj)
-	assert.NoError(err)
+	assert.Nil(err)
 	assert.Equal("something", proj.Loggers.Agent[0].Type)
 	assert.Equal("idk", proj.Loggers.Agent[0].SplunkToken)
 	assert.Equal("somethingElse", proj.Loggers.Agent[1].Type)
 	assert.Equal("commandLogger", proj.Tasks[0].Commands[0].Loggers.System[0].Type)
 }
 
+func TestAddBuildVariant(t *testing.T) {
+	pp := ParserProject{
+		Identifier: "small",
+	}
+
+	pp.AddBuildVariant("name", "my-name", "", nil, []string{"task"})
+	require.Len(t, pp.BuildVariants, 1)
+	assert.Equal(t, pp.BuildVariants[0].Name, "name")
+	assert.Equal(t, pp.BuildVariants[0].DisplayName, "my-name")
+	assert.Nil(t, pp.BuildVariants[0].RunOn)
+	assert.Len(t, pp.BuildVariants[0].Tasks, 1)
+}
+
 func TestParserProjectPersists(t *testing.T) {
-	simpleYml := `
+	simpleYaml := `
 loggers:
   agent:
     - type: something
@@ -1315,7 +1357,7 @@ buildvariants:
 
 	for name, test := range map[string]func(t *testing.T){
 		"simpleYaml": func(t *testing.T) {
-			assert.NoError(t, checkProjectPersists([]byte(simpleYml)))
+			assert.NoError(t, checkProjectPersists([]byte(simpleYaml)))
 		},
 		"self-tests.yml": func(t *testing.T) {
 			filepath := filepath.Join(testutil.GetDirectoryOfFile(), "..", "self-tests.yml")
@@ -1325,7 +1367,7 @@ buildvariants:
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			assert.NoError(t, db.ClearCollections(VersionCollection))
+			assert.NoError(t, db.ClearCollections(ParserProjectCollection))
 			test(t)
 		})
 	}
@@ -1334,34 +1376,53 @@ buildvariants:
 func checkProjectPersists(yml []byte) error {
 	pp, err := createIntermediateProject(yml)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error creating project")
 	}
+	pp.Id = "my-project"
+	pp.Identifier = "old-project-identifier"
+	pp.ConfigUpdateNumber = 1
+
 	yamlToCompare, err := yaml.Marshal(pp)
 	if err != nil {
 		return errors.Wrapf(err, "error marshalling original project")
 	}
 
-	_, err = createIntermediateProject([]byte(yamlToCompare))
-	if err != nil {
-		return errors.Wrap(err, "marshalled project cannot be parsed")
+	if err = pp.UpsertWithConfigNumber(1); err != nil {
+		return errors.Wrapf(err, "error inserting parser project")
 	}
-	v := Version{
-		Id:            "my-version",
-		ParserProject: pp,
-	}
-	if err = v.Insert(); err != nil {
-		return errors.Wrapf(err, "error inserting version")
-	}
-	newV, err := VersionFindOneId(v.Id)
+	newPP, err := ParserProjectFindOneById(pp.Id)
 	if err != nil {
 		return errors.Wrapf(err, "error finding version")
 	}
-	newYaml, err := yaml.Marshal(newV.ParserProject)
+	newYaml, err := yaml.Marshal(newPP)
 	if err != nil {
 		return errors.Wrapf(err, "error marshalling database project")
 	}
 	if !bytes.Equal(newYaml, yamlToCompare) {
 		return errors.New("yamls not equal")
 	}
+
+	// ensure that updating with the re-parsed project doesn't error
+	pp, err = createIntermediateProject([]byte(newYaml))
+	pp.Id = "my-project"
+	pp.Identifier = "new-project-identifier"
+	if err != nil {
+		return errors.Wrap(err, "error creating intermediate project from stored config")
+	}
+	if err = pp.UpsertWithConfigNumber(2); err != nil {
+		return errors.Wrap(err, "error updating version's project")
+	}
+
+	newPP, err = ParserProjectFindOneById(pp.Id)
+	if err != nil {
+		return errors.Wrapf(err, "error finding updated project")
+	}
+	if newPP.Identifier != pp.Identifier {
+		return errors.New("version project not updated")
+	}
+	if newPP.ConfigUpdateNumber != 2 {
+		return errors.New("Config update number wrong")
+	}
+
 	return nil
 }

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -10,9 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
-
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/pkg/errors"

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -41,6 +41,7 @@ func TestFindProject(t *testing.T) {
 			"should be unmarshalled and returned", func() {
 			So(db.ClearCollections(VersionCollection), ShouldBeNil)
 			v := &Version{
+				Id:         "my_version",
 				Owner:      "fakeowner",
 				Repo:       "fakerepo",
 				Branch:     "fakebranch",
@@ -295,9 +296,6 @@ task_groups:
   - example_task_1
   - example_task_2
 `
-	proj, errs := projectFromYAML([]byte(projYml))
-	assert.NotNil(proj)
-	assert.Empty(errs)
 	v := Version{
 		Id:     "v1",
 		Config: projYml,
@@ -1131,7 +1129,7 @@ tasks:
 	s.NoError(err)
 	marshaled, err := yaml.Marshal(intermediate)
 	s.NoError(err)
-	unmarshaled := parserProject{}
+	unmarshaled := ParserProject{}
 	s.NoError(yaml.Unmarshal(marshaled, &unmarshaled))
 }
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1264,7 +1264,7 @@ func (t *Task) String() (taskStruct string) {
 	return
 }
 
-// Insert writes the b to the db.
+// Insert writes the task to the db.
 func (t *Task) Insert() error {
 	return db.Insert(Collection, t)
 }

--- a/model/task_config.go
+++ b/model/task_config.go
@@ -127,8 +127,7 @@ func MakeConfigFromTask(t *task.Task) (*TaskConfig, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding distro")
 	}
-	proj := &Project{}
-	err = LoadProjectInto([]byte(v.Config), v.Identifier, proj)
+	proj, _, err := LoadProjectForVersion(v, v.Identifier, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "error loading project")
 	}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -622,6 +622,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 			v = &Version{
 				Id:     b.Version,
 				Status: evergreen.VersionStarted,
+				Config: "identifier: sample",
 			}
 			testTask = &task.Task{
 				Id:          "testone",
@@ -630,9 +631,6 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 				BuildId:     b.Id,
 				Project:     "sample",
 				Version:     b.Version,
-			}
-			ref := &ProjectRef{
-				Identifier: "sample",
 			}
 			detail = &apimodels.TaskEndDetail{
 				Status: evergreen.TaskSucceeded,
@@ -643,12 +641,11 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 				},
 			}
 
-			require.NoError(t, db.ClearCollections(ProjectRefCollection, task.Collection, build.Collection, VersionCollection),
-				"Error clearing task and build collections")
+			require.NoError(t, db.ClearCollections(task.Collection, build.Collection, VersionCollection),
+				"Error clearing collections")
 			So(b.Insert(), ShouldBeNil)
 			So(testTask.Insert(), ShouldBeNil)
 			So(v.Insert(), ShouldBeNil)
-			So(ref.Insert(), ShouldBeNil)
 		}
 
 		Convey("task should not fail if there are no failed test, also logs should be updated", func() {
@@ -805,12 +802,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 func TestMarkEnd(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, build.Collection, VersionCollection),
-		"Error clearing task and build collections")
-
-	ref := &ProjectRef{
-		Identifier: "sample",
-	}
-	assert.NoError(ref.Insert())
+		"Error clearing collections")
 
 	displayName := "testName"
 	userName := "testUser"
@@ -822,6 +814,7 @@ func TestMarkEnd(t *testing.T) {
 	v := &Version{
 		Id:     b.Version,
 		Status: evergreen.VersionStarted,
+		Config: "identifier: sample",
 	}
 	testTask := task.Task{
 		Id:          "testone",
@@ -904,10 +897,8 @@ func TestMarkEnd(t *testing.T) {
 func TestTryResetTask(t *testing.T) {
 	Convey("With a task, a build, version and a project", t, func() {
 		Convey("resetting a task without a max number of executions", func() {
-			require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, VersionCollection, ProjectRefCollection),
+			require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, VersionCollection),
 				"Error clearing task and build collections")
-			p := &ProjectRef{Identifier: "sample"}
-			So(p.Insert(), ShouldBeNil)
 
 			displayName := "testName"
 			userName := "testUser"
@@ -919,6 +910,7 @@ func TestTryResetTask(t *testing.T) {
 			v := &Version{
 				Id:     b.Version,
 				Status: evergreen.VersionStarted,
+				Config: "identifier: sample",
 			}
 			testTask := &task.Task{
 				Id:          "testone",
@@ -998,6 +990,7 @@ func TestTryResetTask(t *testing.T) {
 			v := &Version{
 				Id:     b.Version,
 				Status: evergreen.VersionStarted,
+				Config: "identifier: sample",
 			}
 			testTask := &task.Task{
 				Id:          "testone",
@@ -1057,12 +1050,9 @@ func TestTryResetTask(t *testing.T) {
 	})
 
 	Convey("with a display task", t, func() {
-		p := &Project{
-			Identifier: "sample",
-		}
 		b := &build.Build{
 			Id:      "displayBuild",
-			Project: p.Identifier,
+			Project: "sample",
 			Version: "version1",
 			Tasks: []build.TaskCache{
 				{Id: "displayTask", Activated: false, Status: evergreen.TaskSucceeded},
@@ -1072,6 +1062,7 @@ func TestTryResetTask(t *testing.T) {
 		v := &Version{
 			Id:     b.Version,
 			Status: evergreen.VersionStarted,
+			Config: "identifier: sample",
 		}
 		So(v.Insert(), ShouldBeNil)
 		dt := &task.Task{
@@ -1298,6 +1289,7 @@ func TestMarkStart(t *testing.T) {
 		v := &Version{
 			Id:     b.Version,
 			Status: evergreen.VersionCreated,
+			Config: "identifier: sample",
 		}
 		testTask := &task.Task{
 			Id:          "testTask",
@@ -1341,12 +1333,9 @@ func TestMarkStart(t *testing.T) {
 	})
 
 	Convey("with a task that is part of a display task", t, func() {
-		p := &Project{
-			Identifier: "sample",
-		}
 		b := &build.Build{
 			Id:      "displayBuild",
-			Project: p.Identifier,
+			Project: "sample",
 			Version: "version1",
 			Tasks: []build.TaskCache{
 				{Id: "displayTask", Activated: false, Status: evergreen.TaskUndispatched},
@@ -1356,6 +1345,7 @@ func TestMarkStart(t *testing.T) {
 		v := &Version{
 			Id:     b.Version,
 			Status: evergreen.VersionStarted,
+			Config: "identifier: sample",
 		}
 		So(v.Insert(), ShouldBeNil)
 		dt := &task.Task{
@@ -1403,6 +1393,7 @@ func TestMarkUndispatched(t *testing.T) {
 		v := &Version{
 			Id:     b.Version,
 			Status: evergreen.VersionStarted,
+			Config: "identifier: sample",
 		}
 		testTask := &task.Task{
 			Id:          "testTask",
@@ -1584,6 +1575,7 @@ func TestFailedTaskRestart(t *testing.T) {
 	v := &Version{
 		Id:     b.Version,
 		Status: evergreen.VersionStarted,
+		Config: "identifier: sample",
 	}
 	testTask1 := &task.Task{
 		Id:        "taskToRestart",
@@ -1628,9 +1620,6 @@ func TestFailedTaskRestart(t *testing.T) {
 		Details:   apimodels.TaskEndDetail{Type: "setup"},
 		Version:   b.Version,
 	}
-	p := &ProjectRef{
-		Identifier: "sample",
-	}
 
 	b.Tasks = []build.TaskCache{
 		{
@@ -1652,7 +1641,6 @@ func TestFailedTaskRestart(t *testing.T) {
 	assert.NoError(testTask2.Insert())
 	assert.NoError(testTask3.Insert())
 	assert.NoError(testTask4.Insert())
-	assert.NoError(p.Insert())
 
 	// test a dry run
 	opts := RestartOptions{
@@ -1862,9 +1850,6 @@ func TestStepback(t *testing.T) {
 		RevisionOrderNumber: 1,
 		Requester:           evergreen.RepotrackerVersionRequester,
 	}
-	p := &ProjectRef{
-		Identifier: "sample",
-	}
 
 	b1.Tasks = []build.TaskCache{
 		{
@@ -1902,7 +1887,6 @@ func TestStepback(t *testing.T) {
 	assert.NoError(dt1.Insert())
 	assert.NoError(dt2.Insert())
 	assert.NoError(dt3.Insert())
-	assert.NoError(p.Insert())
 
 	// test stepping back a regular task
 	assert.NoError(doStepback(t3))
@@ -1924,15 +1908,13 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	require.NoError(db.ClearCollections(task.Collection, build.Collection, VersionCollection, ProjectRefCollection, event.AllLogCollection))
-	ref := ProjectRef{
-		Identifier: "sample",
-	}
-	require.NoError(ref.Insert())
+	require.NoError(db.ClearCollections(task.Collection, build.Collection, VersionCollection, event.AllLogCollection))
+
 	v := &Version{
 		Id:         "sample_version",
 		Identifier: "sample",
 		Requester:  evergreen.RepotrackerVersionRequester,
+		Config:     "identifier: sample",
 		Status:     evergreen.VersionStarted,
 	}
 	require.NoError(v.Insert())
@@ -2100,6 +2082,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	v := &Version{
 		Id:        "sample_version",
 		Requester: evergreen.RepotrackerVersionRequester,
+		Config:    "identifier: sample",
 		Status:    evergreen.VersionStarted,
 	}
 	require.NoError(v.Insert())
@@ -2188,6 +2171,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 	v := &Version{
 		Id:        "sample_version",
 		Requester: evergreen.RepotrackerVersionRequester,
+		Config:    "identifier: sample",
 		Status:    evergreen.VersionStarted,
 	}
 	require.NoError(v.Insert())

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -260,7 +260,6 @@ func BlockTaskGroupTasks(taskID string) error {
 	if tg == nil {
 		return errors.Errorf("unable to find task group '%s' for task '%s'", t.TaskGroup, taskID)
 	}
-
 	indexOfTask := -1
 	for i, tgTask := range tg.Tasks {
 		if t.DisplayName == tgTask {
@@ -279,7 +278,6 @@ func BlockTaskGroupTasks(taskID string) error {
 	if err != nil {
 		catcher.Add(errors.Wrapf(err, "problem finding tasks %s", strings.Join(taskNamesToBlock, ", ")))
 	}
-
 	if err := ValidateNewGraph(t, tasksToBlock); err != nil {
 		return errors.Wrap(err, "problem validating proposed dependencies")
 	}

--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -205,6 +205,8 @@ tasks:
 	assert.NoError(BlockTaskGroupTasks("task_id_1"))
 	found, err := task.FindOneId("one_1")
 	assert.NoError(err)
+	require.NotNil(found)
+	require.NotEmpty(found.DependsOn)
 	assert.Equal("task_id_1", found.DependsOn[0].TaskId)
 
 	queue, err = LoadTaskQueue("distro_1")

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -14,7 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type TestModelData struct {
@@ -30,7 +30,7 @@ func CleanupAPITestData() error {
 		task.Collection, build.Collection, host.Collection,
 		distro.Collection, model.VersionCollection, patch.Collection,
 		model.PushlogCollection, model.ProjectVarsCollection, model.TaskQueuesCollection,
-		manifest.Collection, model.ProjectRefCollection}
+		manifest.Collection, model.ProjectRefCollection, model.ParserProjectCollection}
 
 	if err := db.ClearCollections(testCollections...); err != nil {
 		return errors.Wrap(err, "Failed to clear test data collection")
@@ -54,7 +54,8 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 
 	// Unmarshal the project configuration into a struct
 	project := &model.Project{}
-	if err = model.LoadProjectInto(projectConfig, "test", project); err != nil {
+	pp, err := model.LoadProjectInto(projectConfig, "test", project)
+	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal project config")
 	}
 
@@ -65,10 +66,11 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 			Name: taskDisplayName,
 		}},
 	}
-
 	project.BuildVariants = append(project.BuildVariants, bv)
-	// Marshall the project YAML for storage
-	projectYamlBytes, err := yaml.Marshal(project)
+
+	// Marshal the parser project YAML for storage
+	pp.AddBuildVariant(variant, "", "", nil, []string{taskDisplayName})
+	projectYamlBytes, err := yaml.Marshal(pp)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal project config")
 	}
@@ -176,8 +178,12 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 		BuildIds: []string{taskOne.BuildId},
 		Config:   string(projectYamlBytes),
 	}
+	pp.Id = taskOne.Version
 	if err = v.Insert(); err != nil {
-		return nil, errors.Wrap(err, "failed to insert version: ")
+		return nil, errors.Wrap(err, "failed to insert version")
+	}
+	if err = pp.Insert(); err != nil {
+		return nil, errors.Wrap(err, "failed to insert parser project")
 	}
 
 	// Insert the build that contains the tasks

--- a/model/version.go
+++ b/model/version.go
@@ -24,7 +24,6 @@ type Version struct {
 	Message             string               `bson:"message" json:"message,omitempty"`
 	Status              string               `bson:"status" json:"status,omitempty"`
 	RevisionOrderNumber int                  `bson:"order,omitempty" json:"order,omitempty"`
-	ParserProject       *parserProject       `bson:"project" json:"project,omitempty"`
 	Config              string               `bson:"config" json:"config,omitempty"`
 	ConfigUpdateNumber  int                  `bson:"config_number" json:"config_number,omitempty"`
 	Ignored             bool                 `bson:"ignored" json:"ignored"`

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -30,7 +30,6 @@ var (
 	VersionBuildVariantsKey       = bsonutil.MustHaveTag(Version{}, "BuildVariants")
 	VersionRevisionOrderNumberKey = bsonutil.MustHaveTag(Version{}, "RevisionOrderNumber")
 	VersionRequesterKey           = bsonutil.MustHaveTag(Version{}, "Requester")
-	VersionProjectKey             = bsonutil.MustHaveTag(Version{}, "ParserProject")
 	VersionConfigKey              = bsonutil.MustHaveTag(Version{}, "Config")
 	VersionConfigNumberKey        = bsonutil.MustHaveTag(Version{}, "ConfigUpdateNumber")
 	VersionIgnoredKey             = bsonutil.MustHaveTag(Version{}, "Ignored")
@@ -294,6 +293,18 @@ func VersionUpdateOne(query interface{}, update interface{}) error {
 		query,
 		update,
 	)
+}
+
+func VersionUpdateConfig(id, config string, configUpdateNumber int) error {
+	query := bson.M{
+		VersionIdKey:           id,
+		VersionConfigNumberKey: configUpdateNumber,
+	}
+	update := bson.M{
+		"$set": bson.M{VersionConfigKey: config},
+		"$inc": bson.M{VersionConfigNumberKey: 1},
+	}
+	return VersionUpdateOne(query, update)
 }
 
 func AddSatisfiedTrigger(versionID, definitionID string) error {

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -65,6 +65,7 @@ func setupCLITestHarness() cliTestHarness {
 			user.Collection,
 			patch.Collection,
 			model.ProjectRefCollection,
+			model.ParserProjectCollection,
 			artifact.Collection,
 			model.VersionCollection,
 			distro.Collection,

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -40,7 +40,7 @@ func Evaluate() cli.Command {
 			}
 
 			p := &model.Project{}
-			err = model.LoadProjectInto(configBytes, "", p)
+			_, err = model.LoadProjectInto(configBytes, "", p)
 			if err != nil {
 				return errors.Wrap(err, "error loading project")
 			}

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -153,7 +153,6 @@ func fetchSource(ctx context.Context, ac, rc *legacyClient, comm client.Communic
 	if task == nil {
 		return errors.New("task not found.")
 	}
-
 	config, err := rc.GetConfig(task.Version)
 	if err != nil {
 		return err

--- a/operations/list.go
+++ b/operations/list.go
@@ -349,8 +349,7 @@ func loadLocalConfig(filepath string) (*model.Project, error) {
 	}
 
 	project := &model.Project{}
-	err = model.LoadProjectInto(configBytes, "", project)
-	if err != nil {
+	if _, err = model.LoadProjectInto(configBytes, "", project); err != nil {
 		return nil, errors.Wrap(err, "error loading project")
 	}
 

--- a/public/static/js/task_admin.js
+++ b/public/static/js/task_admin.js
@@ -169,6 +169,7 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
 mciModule.directive('adminAbortTask', function() {
     let merge_test = "merge_test"
     return {
+
         restrict: 'E',
         template:
     '<div class="row">' +

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -58,7 +58,7 @@ func githubCommitToRevision(repoCommit *github.RepositoryCommit) model.Revision 
 
 // GetRemoteConfig fetches the contents of a remote github repository's
 // configuration data as at a given revision
-func (gRepoPoller *GithubRepositoryPoller) GetRemoteConfig(ctx context.Context, projectFileRevision string) (projectConfig *model.Project, err error) {
+func (gRepoPoller *GithubRepositoryPoller) GetRemoteConfig(ctx context.Context, projectFileRevision string) (*model.Project, *model.ParserProject, error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -70,21 +70,22 @@ func (gRepoPoller *GithubRepositoryPoller) GetRemoteConfig(ctx context.Context, 
 		projectRef.Owner, projectRef.Repo, projectRef.RemotePath,
 		projectFileRevision)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	projectFileBytes, err := base64.StdEncoding.DecodeString(*githubFile.Content)
 	if err != nil {
-		return nil, thirdparty.FileDecodeError{Message: err.Error()}
+		return nil, nil, thirdparty.FileDecodeError{Message: err.Error()}
 	}
 
-	projectConfig = &model.Project{}
-	err = model.LoadProjectInto(projectFileBytes, projectRef.Identifier, projectConfig)
+	projectConfig := &model.Project{}
+	pp, err := model.LoadProjectInto(projectFileBytes, projectRef.Identifier, projectConfig)
+
 	if err != nil {
-		return nil, thirdparty.YAMLFormatError{Message: err.Error()}
+		return nil, nil, thirdparty.YAMLFormatError{Message: err.Error()}
 	}
 
-	return projectConfig, nil
+	return projectConfig, pp, nil
 }
 
 // GetRemoteConfig fetches the contents of a remote github repository's

--- a/repotracker/github_poller_test.go
+++ b/repotracker/github_poller_test.go
@@ -109,6 +109,8 @@ func createTaskCollections() {
 	_ = evergreen.GetEnvironment().DB().RunCommand(nil, cmd)
 	cmd["create"] = model.VersionCollection
 	_ = evergreen.GetEnvironment().DB().RunCommand(nil, cmd)
+	cmd["create"] = model.ParserProjectCollection
+	_ = evergreen.GetEnvironment().DB().RunCommand(nil, cmd)
 }
 
 func TestGetRevisionsSinceWithPaging(t *testing.T) {
@@ -220,23 +222,23 @@ func TestGetRemoteConfig(t *testing.T) {
 
 			Convey("The config file at the requested revision should be "+
 				"exactly what is returned", func() {
-				projectConfig, err := self.GetRemoteConfig(ctx, firstRemoteConfigRef)
+				projectConfig, _, err := self.GetRemoteConfig(ctx, firstRemoteConfigRef)
 				require.NoError(t, err, "Error fetching github "+
 					"configuration file")
 				So(projectConfig, ShouldNotBeNil)
 				So(len(projectConfig.Tasks), ShouldEqual, 0)
-				projectConfig, err = self.GetRemoteConfig(ctx, secondRemoteConfigRef)
+				projectConfig, _, err = self.GetRemoteConfig(ctx, secondRemoteConfigRef)
 				require.NoError(t, err, "Error fetching github "+
 					"configuration file")
 				So(projectConfig, ShouldNotBeNil)
 				So(len(projectConfig.Tasks), ShouldEqual, 1)
 			})
 			Convey("an invalid revision should return an error", func() {
-				_, err := self.GetRemoteConfig(ctx, "firstRemoteConfRef")
+				_, _, err := self.GetRemoteConfig(ctx, "firstRemoteConfRef")
 				So(err, ShouldNotBeNil)
 			})
 			Convey("an invalid project configuration should error out", func() {
-				_, err := self.GetRemoteConfig(ctx, badRemoteConfigRef)
+				_, _, err := self.GetRemoteConfig(ctx, badRemoteConfigRef)
 				So(err, ShouldNotBeNil)
 			})
 		})

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -64,12 +64,39 @@ type VersionMetadata struct {
 	PeriodicBuildID     string
 }
 
+type ProjectInfo struct {
+	Ref                 *model.ProjectRef
+	Project             *model.Project
+	IntermediateProject *model.ParserProject
+}
+
+func (p *ProjectInfo) notPopulated() bool {
+	return p.Ref == nil || p.IntermediateProject == nil
+}
+
+// PopulateVersion updates the version's ParserProject if we have or can create it
+func (p *ProjectInfo) populateVersion(v *model.Version) error {
+	config, err := yaml.Marshal(p.IntermediateProject)
+	if err != nil {
+		return errors.Wrap(err, "error marshalling intermediate project")
+	}
+	v.Config = string(config)
+
+	if p.Project == nil {
+		p.Project, err = model.TranslateProject(p.IntermediateProject)
+		if err != nil {
+			return errors.Wrap(err, "error translating intermediate project")
+		}
+	}
+	return nil
+}
+
 // The RepoPoller interface specifies behavior required of all repository poller
 // implementations
 type RepoPoller interface {
 	// Fetches the contents of a remote repository's configuration data as at
 	// the given revision.
-	GetRemoteConfig(ctx context.Context, revision string) (*model.Project, error)
+	GetRemoteConfig(ctx context.Context, revision string) (*model.Project, *model.ParserProject, error)
 
 	// Fetches a list of all filepaths modified by a given revision.
 	GetChangedFiles(ctx context.Context, revision string) ([]string, error)
@@ -245,7 +272,7 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 		}
 
 		var versionErrs *VersionErrors
-		project, err := repoTracker.GetProjectConfig(ctx, revision)
+		project, intermediateProject, err := repoTracker.GetProjectConfig(ctx, revision)
 		if err != nil {
 			// this is an error that implies the file is invalid - create a version and store the error
 			projErr, isProjErr := err.(projectConfigError)
@@ -309,7 +336,12 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 		metadata := VersionMetadata{
 			Revision: revisions[i],
 		}
-		v, err := CreateVersionFromConfig(ctx, ref, project, metadata, ignore, versionErrs)
+		projectInfo := &ProjectInfo{
+			Ref:                 ref,
+			Project:             project,
+			IntermediateProject: intermediateProject,
+		}
+		v, err := CreateVersionFromConfig(ctx, projectInfo, metadata, ignore, versionErrs)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error creating version",
@@ -359,9 +391,9 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 // returning a remote config if the project references a remote repository
 // configuration file - via the Identifier. Otherwise it defaults to the local
 // project file. An erroneous project file may be returned along with an error.
-func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision string) (*model.Project, error) {
+func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision string) (*model.Project, *model.ParserProject, error) {
 	projectRef := repoTracker.ProjectRef
-	project, err := repoTracker.GetRemoteConfig(ctx, revision)
+	project, intermediateProj, err := repoTracker.GetRemoteConfig(ctx, revision)
 	if err != nil {
 		// Only create a stub version on API request errors that pertain
 		// to actually fetching a config. Those errors currently include:
@@ -383,7 +415,7 @@ func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision s
 			})
 
 			grip.Error(message.WrapError(err, msg))
-			return nil, projectConfigError{Errors: []string{msg.String()}, Warnings: nil}
+			return nil, nil, projectConfigError{Errors: []string{msg.String()}, Warnings: nil}
 		}
 		// If we get here then we have an infrastructural error - e.g.
 		// a thirdparty.APIUnmarshalError (indicating perhaps an API has
@@ -414,9 +446,9 @@ func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision s
 			"lastRevision": lastRevision,
 		}))
 
-		return nil, err
+		return nil, nil, err
 	}
-	return project, nil
+	return project, intermediateProj, nil
 }
 
 // AddBuildBreakSubscriptions will subscribe admins of a project to a version if no one
@@ -574,29 +606,29 @@ func CreateManifest(v model.Version, proj *model.Project, branch string, setting
 	return newManifest, errors.Wrap(err, "error inserting manifest")
 }
 
-func CreateVersionFromConfig(ctx context.Context, ref *model.ProjectRef, config *model.Project,
+func CreateVersionFromConfig(ctx context.Context, projectInfo *ProjectInfo,
 	metadata VersionMetadata, ignore bool, versionErrs *VersionErrors) (*model.Version, error) {
-	if ref == nil || config == nil {
-		return nil, errors.New("project ref and project cannot be nil")
+	if projectInfo.notPopulated() {
+		return nil, errors.New("project ref and parser project cannot be nil")
 	}
 
 	// create a version document
-	v, err := shellVersionFromRevision(ref, metadata)
+	v, err := shellVersionFromRevision(projectInfo.Ref, metadata)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shell version")
 	}
-	if err = sanityCheckOrderNum(v.RevisionOrderNumber, ref.Identifier, metadata.Revision.Revision); err != nil {
+	if err = sanityCheckOrderNum(v.RevisionOrderNumber, projectInfo.Ref.Identifier, metadata.Revision.Revision); err != nil {
 		return nil, errors.Wrap(err, "inconsistent version order")
 	}
-	configYaml, err := yaml.Marshal(config)
-	if err != nil {
-		return nil, errors.Wrap(err, "error marshaling config")
+
+	if err = projectInfo.populateVersion(v); err != nil {
+		return nil, errors.Wrap(err, "problem updating version project")
 	}
-	v.Config = string(configYaml)
+	projectInfo.IntermediateProject.Id = v.Id
 	v.Ignored = ignore
 
 	// validate the project
-	verrs := validator.CheckProjectSyntax(config)
+	verrs := validator.CheckProjectSyntax(projectInfo.Project)
 	if len(verrs) > 0 || versionErrs != nil {
 		// We have syntax errors in the project.
 		// Format them, as we need to store + display them to the user
@@ -617,18 +649,25 @@ func CreateVersionFromConfig(ctx context.Context, ref *model.ProjectRef, config 
 			v.Errors = append(v.Errors, versionErrs.Errors...)
 		}
 		if len(v.Errors) > 0 {
-			return v, errors.Wrap(v.Insert(), "error inserting version")
+			if err = v.Insert(); err != nil {
+				return nil, errors.Wrap(err, "error inserting version")
+			}
+			if err = projectInfo.IntermediateProject.Insert(); err != nil {
+				return v, errors.Wrap(err, "error inserting project")
+			}
+			return v, nil
+
 		}
 	}
 	var aliases model.ProjectAliases
 	if metadata.Alias != "" {
-		aliases, err = model.FindAliasInProject(ref.Identifier, metadata.Alias)
+		aliases, err = model.FindAliasInProject(projectInfo.Ref.Identifier, metadata.Alias)
 		if err != nil {
 			return v, errors.Wrap(err, "error finding project alias")
 		}
 	}
 
-	return v, errors.Wrap(createVersionItems(ctx, v, ref, metadata, config, aliases), "error creating version items")
+	return v, errors.Wrap(createVersionItems(ctx, v, metadata, projectInfo, aliases), "error creating version items")
 }
 
 // shellVersionFromRevision populates a new Version with metadata from a model.Revision.
@@ -711,7 +750,7 @@ func sanityCheckOrderNum(revOrderNum int, projectId, revision string) error {
 
 // createVersionItems populates and stores all the tasks and builds for a version according to
 // the given project config.
-func createVersionItems(ctx context.Context, v *model.Version, ref *model.ProjectRef, metadata VersionMetadata, project *model.Project, aliases model.ProjectAliases) error {
+func createVersionItems(ctx context.Context, v *model.Version, metadata VersionMetadata, projectInfo *ProjectInfo, aliases model.ProjectAliases) error {
 	distroAliases, err := distro.NewDistroAliasesLookupTable()
 	if err != nil {
 		return errors.WithStack(err)
@@ -721,12 +760,12 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 	if metadata.SourceVersion != nil {
 		sourceRev = metadata.SourceVersion.Revision
 	}
-	taskIds := model.NewTaskIdTable(project, v, sourceRev, metadata.TriggerDefinitionID)
+	taskIds := model.NewTaskIdTable(projectInfo.Project, v, sourceRev, metadata.TriggerDefinitionID)
 
 	// create all builds for the version
 	buildsToCreate := []interface{}{}
 	tasksToCreate := task.Tasks{}
-	for _, buildvariant := range project.BuildVariants {
+	for _, buildvariant := range projectInfo.Project.BuildVariants {
 		if ctx.Err() != nil {
 			return errors.Wrapf(err, "aborting version creation for version %s", v.Id)
 		}
@@ -748,7 +787,7 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 			}
 		}
 		args := model.BuildCreateArgs{
-			Project:        *project,
+			Project:        *projectInfo.Project,
 			Version:        *v,
 			TaskIDs:        taskIds,
 			BuildName:      buildvariant.Name,
@@ -778,7 +817,7 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 		var lastActivated *model.Version
 		activateAt := time.Now()
 		if metadata.TriggerID == "" && v.Requester != evergreen.AdHocRequester {
-			lastActivated, err = model.VersionFindOne(model.VersionByLastVariantActivation(ref.Identifier, buildvariant.Name))
+			lastActivated, err = model.VersionFindOne(model.VersionByLastVariantActivation(projectInfo.Ref.Identifier, buildvariant.Name))
 			if err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"message": "error finding last activated",
@@ -797,14 +836,14 @@ func createVersionItems(ctx context.Context, v *model.Version, ref *model.Projec
 			}
 
 			if lastActivation != nil {
-				activateAt = lastActivation.Add(time.Minute * time.Duration(ref.GetBatchTime(&buildvariant)))
+				activateAt = lastActivation.Add(time.Minute * time.Duration(projectInfo.Ref.GetBatchTime(&buildvariant)))
 			}
 		}
 
 		grip.Debug(message.Fields{
 			"message": "activating build",
 			"name":    buildvariant.Name,
-			"project": ref.Identifier,
+			"project": projectInfo.Ref.Identifier,
 			"version": v.Id,
 			"time":    activateAt,
 			"runner":  RunnerName,

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -322,7 +322,7 @@ func (vc *DBVersionConnector) CreateVersionFromConfig(ctx context.Context, proje
 		}
 	}
 	project := &model.Project{}
-	err = model.LoadProjectInto(config, projectID, project)
+	intermediateProject, err := model.LoadProjectInto(config, projectID, project)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -334,7 +334,12 @@ func (vc *DBVersionConnector) CreateVersionFromConfig(ctx context.Context, proje
 		User:    user,
 		Message: message,
 	}
-	newVersion, err := repotracker.CreateVersionFromConfig(ctx, ref, project, metadata, false, nil)
+	projectInfo := &repotracker.ProjectInfo{
+		Ref:                 ref,
+		Project:             project,
+		IntermediateProject: intermediateProject,
+	}
+	newVersion, err := repotracker.CreateVersionFromConfig(ctx, projectInfo, metadata, false, nil)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -109,6 +109,7 @@ func (s *VersionConnectorSuite) SetupTest() {
 	s.Require().NoError(db.Clear(task.OldCollection))
 	s.Require().NoError(db.Clear(model.VersionCollection))
 	s.Require().NoError(db.Clear(build.Collection))
+	s.Require().NoError(db.Clear(model.ParserProjectCollection))
 
 	// Insert data for the test paths
 	versions := []*model.Version{
@@ -401,7 +402,9 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 
 func TestCreateVersionFromConfig(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.ClearCollections(model.ProjectRefCollection, model.VersionCollection, distro.Collection, task.Collection, build.Collection, user.Collection))
+	assert.NoError(db.ClearCollections(model.ProjectRefCollection, model.ParserProjectCollection, model.VersionCollection, distro.Collection, task.Collection, build.Collection, user.Collection))
+	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": model.ParserProjectCollection})
+
 	ref := model.ProjectRef{
 		Identifier: "mci",
 	}

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -370,7 +370,6 @@ func (as *APIServer) listPatchModules(w http.ResponseWriter, r *http.Request) {
 	for m := range mods {
 		data.Modules = append(data.Modules, m)
 	}
-
 	gimlet.WriteJSON(w, &data)
 }
 

--- a/service/api_patch_test.go
+++ b/service/api_patch_test.go
@@ -89,7 +89,6 @@ func TestPatchListModulesEndPoints(t *testing.T) {
 				Project string   `json:"project"`
 				Modules []string `json:"modules"`
 			}{}
-
 			err = util.ReadJSONInto(resp.Body, &data)
 			So(err, ShouldBeNil)
 			So(len(data.Modules), ShouldEqual, 2)

--- a/service/api_plugin_manifest.go
+++ b/service/api_plugin_manifest.go
@@ -40,8 +40,8 @@ func (as *APIServer) manifestLoadHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	project := &model.Project{}
-	err = model.LoadProjectInto([]byte(v.Config), v.Identifier, project)
+	var project *model.Project
+	project, _, err = model.LoadProjectForVersion(v, v.Identifier, false)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrap(err, "error loading project from version"))
 		return

--- a/service/api_task_test.go
+++ b/service/api_task_test.go
@@ -952,8 +952,8 @@ func TestTaskLifecycleEndpoints(t *testing.T) {
 	defer cancel()
 
 	Convey("with tasks, a host, a build, and a task queue", t, func() {
-		if err := db.ClearCollections(host.Collection, task.Collection, model.TaskQueuesCollection,
-			build.Collection, model.ProjectRefCollection, model.VersionCollection, alertrecord.Collection, event.AllLogCollection); err != nil {
+		if err := db.ClearCollections(host.Collection, task.Collection, model.TaskQueuesCollection, build.Collection,
+			model.ParserProjectCollection, model.ProjectRefCollection, model.VersionCollection, alertrecord.Collection, event.AllLogCollection); err != nil {
 			t.Fatalf("clearing db: %v", err)
 		}
 
@@ -1023,6 +1023,7 @@ func TestTaskLifecycleEndpoints(t *testing.T) {
 		testVersion := model.Version{
 			Id:     versionId,
 			Branch: projectId,
+			Config: "identifier: " + projectId,
 		}
 		So(testVersion.Insert(), ShouldBeNil)
 

--- a/service/middleware_helpers_current.go
+++ b/service/middleware_helpers_current.go
@@ -16,7 +16,7 @@ func setAPIHostContext(r *http.Request, h *host.Host) *http.Request {
 func setAPITaskContext(r *http.Request, t *task.Task) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), model.ApiTaskKey, t))
 }
-func setProjectReftContext(r *http.Request, p *model.ProjectRef) *http.Request {
+func setProjectRefContext(r *http.Request, p *model.ProjectRef) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), model.ApiProjectRefKey, p))
 }
 func setProjectContext(r *http.Request, p *model.Project) *http.Request {

--- a/service/patch.go
+++ b/service/patch.go
@@ -53,7 +53,7 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 
 	// Unmarshal the patch's project config so that it is always up to date with the configuration file in the project
 	project := &model.Project{}
-	if err := model.LoadProjectInto([]byte(projCtx.Patch.PatchedConfig), projCtx.Patch.Project, project); err != nil {
+	if _, err := model.LoadProjectInto([]byte(projCtx.Patch.PatchedConfig), projCtx.Patch.Project, project); err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Error unmarshaling project config"))
 	}
 
@@ -125,7 +125,7 @@ func (uis *UIServer) schedulePatch(w http.ResponseWriter, r *http.Request) {
 
 	// Unmarshal the project config and set it in the project context
 	project := &model.Project{}
-	if err = model.LoadProjectInto([]byte(projCtx.Patch.PatchedConfig), projCtx.Patch.Project, project); err != nil {
+	if _, err = model.LoadProjectInto([]byte(projCtx.Patch.PatchedConfig), projCtx.Patch.Project, project); err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Errorf("Error unmarshaling project config: %v", err))
 	}
 

--- a/testdata/smoke/parser_projects.json
+++ b/testdata/smoke/parser_projects.json
@@ -1,0 +1,1 @@
+{"_id": "not_a_real_version"}

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -257,7 +257,9 @@ func TestProjectTriggerIntegration(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, build.Collection, model.VersionCollection, evergreen.ConfigCollection,
-		model.ProjectRefCollection, model.RepositoriesCollection, model.ProjectAliasCollection))
+		model.ProjectRefCollection, model.RepositoriesCollection, model.ProjectAliasCollection, model.ParserProjectCollection))
+	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": model.ParserProjectCollection})
+
 	config := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, config, "TestProjectTriggerIntegration")
 	assert.NoError(config.Set())
@@ -324,7 +326,6 @@ func TestProjectTriggerIntegration(t *testing.T) {
 		assert.Equal(upstreamTask.Id, v.TriggerID)
 		assert.Equal("task", v.TriggerType)
 		assert.Equal(e.ID, v.TriggerEvent)
-		assert.NotEmpty(v.Config)
 	}
 	builds, err := build.Find(build.ByVersion(downstreamVersions[0].Id))
 	assert.NoError(err)

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -35,14 +35,15 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 	metadata.Alias = args.Alias
 
 	// get the downstream config
-	var config *model.Project
+	var proj *model.Project
+	var pp *model.ParserProject
 	if args.ConfigFile != "" {
-		config, err = makeDownstreamConfigFromFile(args.DownstreamProject, args.ConfigFile)
+		proj, pp, err = makeDownstreamProjectFromFile(args.DownstreamProject, args.ConfigFile)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 	} else if args.Command != "" {
-		config, err = makeDownstreamConfigFromCommand(args.DownstreamProject, args.Command, args.GenerateFile)
+		proj, pp, err = makeDownstreamProjectFromCommand(args.DownstreamProject.Identifier, args.Command, args.GenerateFile)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -51,7 +52,12 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 	}
 
 	// create version
-	v, err := repotracker.CreateVersionFromConfig(context.Background(), &args.DownstreamProject, config, metadata, false, nil)
+	projectInfo := &repotracker.ProjectInfo{
+		Ref:                 &args.DownstreamProject,
+		Project:             proj,
+		IntermediateProject: pp,
+	}
+	v, err := repotracker.CreateVersionFromConfig(context.Background(), projectInfo, metadata, false, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating version")
 	}
@@ -101,42 +107,43 @@ func metadataFromVersion(source model.Version, ref model.ProjectRef) (repotracke
 	return metadata, nil
 }
 
-func makeDownstreamConfigFromFile(ref model.ProjectRef, file string) (*model.Project, error) {
+func makeDownstreamProjectFromFile(ref model.ProjectRef, file string) (*model.Project, *model.ParserProject, error) {
 	settings, err := evergreen.GetConfig()
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting evergreen settings")
+		return nil, nil, errors.Wrap(err, "error getting evergreen settings")
 	}
 	token, err := settings.GetGithubOauthToken()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 	configFile, err := thirdparty.GetGithubFile(ctx, token, ref.Owner, ref.Repo, file, ref.Branch)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error fetching project file for '%s'", ref.Identifier)
+		return nil, nil, errors.Wrapf(err, "error fetching project file for '%s'", ref.Identifier)
 	}
 	fileContents, err := base64.StdEncoding.DecodeString(*configFile.Content)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to decode config file for '%s'", ref.Identifier)
+		return nil, nil, errors.Wrapf(err, "unable to decode config file for '%s'", ref.Identifier)
 	}
 
 	config := model.Project{}
-	err = model.LoadProjectInto(fileContents, ref.Identifier, &config)
+	pp, err := model.LoadProjectInto(fileContents, ref.Identifier, &config)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing config file for '%s'", ref.Identifier)
+		return nil, nil, errors.Wrapf(err, "error parsing config file for '%s'", ref.Identifier)
 	}
-	return &config, nil
+	return &config, pp, nil
 }
 
-func makeDownstreamConfigFromCommand(ref model.ProjectRef, command, generateFile string) (*model.Project, error) {
+func makeDownstreamProjectFromCommand(identifier, command, generateFile string) (*model.Project, *model.ParserProject, error) {
 	settings, err := evergreen.GetConfig()
 	if err != nil {
-		return nil, errors.Wrap(err, "error retrieving config")
+		return nil, nil, errors.Wrap(err, "error retrieving config")
 	}
-	baseConfig := model.Project{
-		Identifier: ref.Identifier,
+	bvtName := "generate-config"
+	fullProject := &model.Project{
+		Identifier: identifier,
 		Tasks: []model.ProjectTask{
 			{
 				Name: "generate-config",
@@ -170,10 +177,16 @@ func makeDownstreamConfigFromCommand(ref model.ProjectRef, command, generateFile
 				DisplayName: "generate",
 				RunOn:       []string{settings.Triggers.GenerateTaskDistro},
 				Tasks: []model.BuildVariantTaskUnit{
-					{Name: "generate-config"},
+					{Name: bvtName},
 				},
 			},
 		},
 	}
-	return &baseConfig, nil
+	pp := &model.ParserProject{
+		Identifier: identifier,
+	}
+
+	pp.AddTask(fullProject.Tasks[0].Name, fullProject.Tasks[0].Commands)
+	pp.AddBuildVariant(fullProject.BuildVariants[0].Name, fullProject.BuildVariants[0].DisplayName, settings.Triggers.GenerateTaskDistro, nil, []string{bvtName})
+	return fullProject, pp, nil
 }

--- a/trigger/project_triggers_test.go
+++ b/trigger/project_triggers_test.go
@@ -57,8 +57,10 @@ func TestMakeDownstreamConfigFromFile(t *testing.T) {
 		Owner:      "evergreen-ci",
 		Repo:       "evergreen",
 	}
-	proj, err := makeDownstreamConfigFromFile(ref, "trigger/testdata/downstream_config.yml")
+	proj, pp, err := makeDownstreamProjectFromFile(ref, "trigger/testdata/downstream_config.yml")
 	assert.NoError(err)
+	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.Equal(ref.Identifier, proj.Identifier)
 	assert.Len(proj.Tasks, 2)
 	assert.Equal("task1", proj.Tasks[0].Name)
@@ -71,17 +73,34 @@ func TestMakeDownstreamConfigFromCommand(t *testing.T) {
 	assert.NoError(db.ClearCollections(evergreen.ConfigCollection))
 	config := testutil.MockConfig()
 	assert.NoError(evergreen.UpdateConfig(config))
-	ref := model.ProjectRef{
-		Identifier: "project",
-	}
+	identifier := "project"
 	cmd := "echo hi"
 
-	project, err := makeDownstreamConfigFromCommand(ref, cmd, "generate.json")
+	proj, pp, err := makeDownstreamProjectFromCommand(identifier, cmd, "generate.json")
 	assert.NoError(err)
-	assert.Equal(ref.Identifier, project.Identifier)
+	assert.NotNil(proj)
+	assert.NotNil(pp)
+	assert.Equal(identifier, proj.Identifier)
 	foundCommand := false
 	foundFile := false
-	for _, t := range project.Tasks {
+	for _, t := range proj.Tasks {
+		for _, c := range t.Commands {
+			if c.Command == "subprocess.exec" {
+				foundCommand = true
+			} else if c.Command == "generate.tasks" {
+				for _, value := range c.Params {
+					assert.Contains(value, "generate.json")
+					foundFile = true
+				}
+			}
+		}
+	}
+	assert.True(foundCommand)
+	assert.True(foundFile)
+
+	foundCommand = false
+	foundFile = false
+	for _, t := range pp.Tasks {
 		for _, c := range t.Commands {
 			if c.Command == "subprocess.exec" {
 				foundCommand = true

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -94,7 +94,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	err = g.Save(context.Background(), p, pp, v, t, pm)
 
 	// If the version has changed there was a race. Another generator will try again.
-	if err != nil && adb.ResultsNotFound(err) {
+	if adb.ResultsNotFound(err) {
 		return err
 	}
 	if err != nil {
@@ -151,13 +151,13 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 		"task":          t.Id,
 		"version":       t.Version,
 	})
-	grip.DebugWhen(adb.ResultsNotFound(err), message.Fields{
+	grip.DebugWhen(adb.ResultsNotFound(err), message.WrapError(err, message.Fields{
 		"message":       "generate.tasks noop",
 		"operation":     "generate.tasks",
 		"duration_secs": time.Since(start).Seconds(),
 		"task":          t.Id,
 		"version":       t.Version,
-	})
+	}))
 	grip.ErrorWhen(!adb.ResultsNotFound(err), message.WrapError(err, message.Fields{
 		"message":       "generate.tasks finished with errors",
 		"operation":     "generate.tasks",

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -81,7 +81,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	g := model.MergeGeneratedProjects(projects)
 	g.TaskID = j.TaskID
 
-	p, v, t, pm, err := g.NewVersion()
+	p, pp, v, t, pm, err := g.NewVersion()
 	if err != nil {
 		return j.handleError(v, errors.WithStack(err))
 	}
@@ -91,7 +91,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 
 	// Don't use the job's context, because it's better to finish than to exit early after a
 	// SIGTERM from a deploy. This should maybe be a context with timeout.
-	err = g.Save(context.Background(), p, v, t, pm)
+	err = g.Save(context.Background(), p, pp, v, t, pm)
 
 	// If the version has changed there was a race. Another generator will try again.
 	if err != nil && adb.ResultsNotFound(err) {

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -213,20 +213,22 @@ func TestGenerateTasks(t *testing.T) {
 	// Make sure first project was not changed
 	v, err := model.VersionFindOneId("random_version")
 	assert.NoError(err)
-	p := model.Project{}
-	err = model.LoadProjectInto([]byte(v.Config), "mci", &p)
+	p, _, err := model.LoadProjectForVersion(v, "mci", true)
 	assert.NoError(err)
+	require.NotNil(p)
 	assert.Len(p.Tasks, 2)
+	require.Len(p.BuildVariants, 2)
 	assert.Len(p.BuildVariants[0].Tasks, 1)
 	assert.Len(p.BuildVariants[1].Tasks, 2)
 
 	// Verify second project was changed
 	v, err = model.VersionFindOneId("sample_version")
 	assert.NoError(err)
-	p = model.Project{}
-	err = model.LoadProjectInto([]byte(v.Config), "mci", &p)
+	p, _, err = model.LoadProjectForVersion(v, "mci", true)
 	assert.NoError(err)
+	require.NotNil(p)
 	assert.Len(p.Tasks, 4)
+	require.Len(p.BuildVariants, 2)
 	assert.Len(p.BuildVariants[0].Tasks, 1)
 	assert.Len(p.BuildVariants[1].Tasks, 4)
 	assert.Len(p.TaskGroups, 1)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -387,7 +387,6 @@ func (s *PatchIntentUnitsSuite) verifyVersionDoc(patchDoc *patch.Patch, expected
 	s.Zero(versionDoc.FinishTime)
 	s.Equal(s.hash, versionDoc.Revision)
 	s.Equal(patchDoc.Description, versionDoc.Message)
-	s.NotZero(versionDoc.Config)
 	s.Equal(s.user, versionDoc.Author)
 	s.Len(versionDoc.BuildIds, 4)
 

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1684,8 +1684,9 @@ func TestTaskGroupValidation(t *testing.T) {
     - name: example_task_group
   `
 	var proj model.Project
-	err := model.LoadProjectInto([]byte(duplicateYml), "", &proj)
+	pp, err := model.LoadProjectInto([]byte(duplicateYml), "", &proj)
 	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.NoError(err)
 	validationErrs := validateTaskGroups(&proj)
 	assert.Len(validationErrs, 1)
@@ -1705,8 +1706,9 @@ func TestTaskGroupValidation(t *testing.T) {
     tasks:
     - name: foo
   `
-	err = model.LoadProjectInto([]byte(duplicateTaskYml), "", &proj)
+	pp, err = model.LoadProjectInto([]byte(duplicateTaskYml), "", &proj)
 	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.NoError(err)
 	validationErrs = validateTaskGroups(&proj)
 	assert.Len(validationErrs, 1)
@@ -1733,8 +1735,9 @@ buildvariants:
   tasks:
   - name: example_task_group
 `
-	err = model.LoadProjectInto([]byte(attachInGroupTeardownYml), "", &proj)
+	pp, err = model.LoadProjectInto([]byte(attachInGroupTeardownYml), "", &proj)
 	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.NoError(err)
 	validationErrs = validateTaskGroups(&proj)
 	assert.Len(validationErrs, 1)
@@ -1758,8 +1761,9 @@ buildvariants:
   tasks:
   - name: example_task_group
 `
-	err = model.LoadProjectInto([]byte(largeMaxHostYml), "", &proj)
+	pp, err = model.LoadProjectInto([]byte(largeMaxHostYml), "", &proj)
 	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.NoError(err)
 	validationErrs = checkTaskGroups(&proj)
 	assert.Len(validationErrs, 1)
@@ -1801,9 +1805,10 @@ buildvariants:
   - name: example_task_group
 `
 	proj := model.Project{}
-	err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
+	pp, err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
 	assert.NotNil(proj)
-	assert.Empty(err)
+	assert.NotNil(pp)
+	assert.NoError(err)
 	assert.Len(proj.TaskGroups, 1)
 	tg := proj.TaskGroups[0]
 	assert.Equal("example_task_group", tg.Name)
@@ -1843,9 +1848,10 @@ buildvariants:
   - name: example_task_group
 `
 	proj := model.Project{}
-	err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
+	pp, err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
 	assert.NotNil(proj)
-	assert.Empty(err)
+	assert.NotNil(pp)
+	assert.NoError(err)
 	assert.Len(proj.TaskGroups, 1)
 	tg := proj.TaskGroups[0]
 	assert.Equal("example_task_group", tg.Name)
@@ -1889,8 +1895,9 @@ buildvariants:
     - two
 `
 	proj := model.Project{}
-	err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
+	pp, err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
 	assert.NotNil(proj)
+	assert.NotNil(pp)
 	assert.NoError(err)
 
 	proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks = append(proj.BuildVariants[0].DisplayTasks[0].ExecutionTasks,
@@ -1921,8 +1928,9 @@ func TestValidateCreateHosts(t *testing.T) {
     - name: t_1
   `
 	var p model.Project
-	err := model.LoadProjectInto([]byte(yml), "id", &p)
+	pp, err := model.LoadProjectInto([]byte(yml), "id", &p)
 	require.NoError(err)
+	require.NotNil(pp)
 	errs := validateCreateHosts(&p)
 	assert.Len(errs, 0)
 
@@ -1942,6 +1950,7 @@ func TestValidateCreateHosts(t *testing.T) {
   `
 	err = model.LoadProjectInto([]byte(yml), "id", &p)
 	require.NoError(err)
+	require.NotNil(pp)
 	errs = validateCreateHosts(&p)
 	assert.Len(errs, 1)
 }
@@ -1964,8 +1973,9 @@ func TestDuplicateTaskInBV(t *testing.T) {
     - t1
   `
 	var p model.Project
-	err := model.LoadProjectInto([]byte(yml), "", &p)
+	pp, err := model.LoadProjectInto([]byte(yml), "", &p)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs := validateDuplicateTaskDefinition(&p)
 	assert.Len(errs, 1)
 	assert.Contains(errs[0].Message, "task 't1' in 'bv' is listed more than once")
@@ -1984,8 +1994,9 @@ func TestDuplicateTaskInBV(t *testing.T) {
     - t1
     - tg1
   `
-	err = model.LoadProjectInto([]byte(yml), "", &p)
+	pp, err = model.LoadProjectInto([]byte(yml), "", &p)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs = validateDuplicateTaskDefinition(&p)
 	assert.Len(errs, 1)
 	assert.Contains(errs[0].Message, "task 't1' in 'bv' is listed more than once")
@@ -2007,8 +2018,9 @@ func TestDuplicateTaskInBV(t *testing.T) {
     - tg1
     - tg2
   `
-	err = model.LoadProjectInto([]byte(yml), "", &p)
+	pp, err = model.LoadProjectInto([]byte(yml), "", &p)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs = validateDuplicateTaskDefinition(&p)
 	assert.Len(errs, 1)
 	assert.Contains(errs[0].Message, "task 't1' in 'bv' is listed more than once")
@@ -2033,8 +2045,9 @@ tasks:
       - type: commandLogger
 `
 	project := &model.Project{}
-	err := model.LoadProjectInto([]byte(yml), "", project)
+	pp, err := model.LoadProjectInto([]byte(yml), "", project)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs := checkLoggerConfig(project)
 	assert.Contains(errs.String(), "error in project-level logger config: invalid agent logger config: Splunk logger requires a server URL")
 	assert.Contains(errs.String(), "invalid task logger config: somethingElse is not a valid log sender")
@@ -2051,8 +2064,9 @@ tasks:
     `
 
 	project = &model.Project{}
-	err = model.LoadProjectInto([]byte(yml), "", project)
+	pp, err = model.LoadProjectInto([]byte(yml), "", project)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs = checkLoggerConfig(project)
 	assert.Len(errs, 0)
 }
@@ -2086,9 +2100,10 @@ buildvariants:
   - name: two
 `
 	proj := model.Project{}
-	err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
+	pp, err := model.LoadProjectInto([]byte(exampleYml), "example_project", &proj)
 	assert.NotNil(proj)
 	assert.NoError(err)
+	assert.NotNil(pp)
 	errs := CheckProjectSyntax(&proj)
 	assert.Len(errs, 1, "one warning was found")
 	assert.NoError(CheckProjectConfigurationIsValid(&proj), "no errors are reported because they are warnings")

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1659,7 +1659,7 @@ func TestTaskValidation(t *testing.T) {
     - name: "this task is too long"
 `
 	var proj model.Project
-	err := model.LoadProjectInto([]byte(simpleYml), "", &proj)
+	_, err := model.LoadProjectInto([]byte(simpleYml), "", &proj)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "spaces are unauthorized")
 }
@@ -1948,7 +1948,7 @@ func TestValidateCreateHosts(t *testing.T) {
     tasks:
     - name: t_1
   `
-	err = model.LoadProjectInto([]byte(yml), "id", &p)
+	pp, err = model.LoadProjectInto([]byte(yml), "id", &p)
 	require.NoError(err)
 	require.NotNil(pp)
 	errs = validateCreateHosts(&p)


### PR DESCRIPTION
This is the same as EVG-6270, except removing the variable of the generated tasks bug (which is almost certainly related to the interaction between saving Versions and Parser Projects with the same config number). I think that should be addressed in a separate ticket so we can finally split this problem up a bit.