### PR TITLE
EVG-6747: set status on static hosts depending on provisioning

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -182,7 +182,7 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 		},
 		{
 			"$group": mgobson.M{
-				"_id": "$" + bsonutil.GetDottedKeyName(DistroKey, distro.IdKey),
+				"_id":                             "$" + bsonutil.GetDottedKeyName(DistroKey, distro.IdKey),
 				HostsByDistroRunningHostsCountKey: mgobson.M{"$sum": 1},
 				HostsByDistroIdleHostsKey:         mgobson.M{"$push": bson.M{"$cond": []interface{}{mgobson.M{"$eq": []interface{}{"$running_task", mgobson.Undefined}}, "$$ROOT", mgobson.Undefined}}},
 			},

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1189,13 +1189,13 @@ func (h *Host) Upsert() (*adb.ChangeInfo, error) {
 		ProvisionedKey:       h.Provisioned,
 		ProvisionAttemptsKey: h.ProvisionAttempts,
 		ProvisionOptionsKey:  h.ProvisionOptions,
+		StatusKey:            h.Status,
 		StartTimeKey:         h.StartTime,
 		HasContainersKey:     h.HasContainers,
 		ContainerImagesKey:   h.ContainerImages,
 	}
 	update := bson.M{
 		"$setOnInsert": bson.M{
-			StatusKey:     h.Status,
 			CreateTimeKey: h.CreationTime,
 		},
 	}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -766,7 +766,7 @@ func TestUpsert(t *testing.T) {
 		})
 
 		Convey("Updating some fields of an already inserted host should cause "+
-			"those fields to be updated but should leave status unchanged",
+			"those fields to be updated ",
 			func() {
 				_, err := host.Upsert()
 				So(err, ShouldBeNil)
@@ -795,10 +795,10 @@ func TestUpsert(t *testing.T) {
 				_, err = host.Upsert()
 				So(err, ShouldBeNil)
 
-				// host db status should remain unchanged
+				// host db status should be modified
 				host, err = FindOne(ById(host.Id))
 				So(err, ShouldBeNil)
-				So(host.Status, ShouldEqual, evergreen.HostDecommissioned)
+				So(host.Status, ShouldEqual, evergreen.HostRunning)
 				So(host.Host, ShouldEqual, "host2")
 
 			})

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -155,6 +155,11 @@ func doStaticHostUpdate(d distro.Distro) ([]string, error) {
 			NeedsReprovision: provisionChange,
 			Provisioned:      provisioned,
 		}
+		if provisioned {
+			staticHost.Status = evergreen.HostRunning
+		} else {
+			staticHost.Status = evergreen.HostProvisioning
+		}
 
 		if d.Provider == evergreen.ProviderNameStatic {
 			staticHost.Provider = evergreen.HostTypeStatic

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -50,6 +50,7 @@ func (j *cronsRemoteHourJob) Run(ctx context.Context) {
 	ops := []amboy.QueueOperation{
 		PopulateCacheHistoricalTestDataJob(2),
 		PopulateHostJasperRestartJobs(j.env),
+		PopulateHostProvisioningConversionJobs(j.env),
 		PopulateSpawnhostExpirationCheckJob(),
 	}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6747

Changes the distro page behavior so that adding static hosts (new or existing) to distros automatically starts the agent/agent monitor (after some period of time). If it needs to convert provisioning, this also occurs. I only set the conversion jobs to populate once an hour but I can move it to a more frequent interval (e.g. every 15 mins) if we want a speedier time from static host addition to actually running tasks.