### PR TITLE
EVG-6747: change static host status only for new hosts and terminated hosts

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -182,7 +182,7 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 		},
 		{
 			"$group": mgobson.M{
-				"_id": "$" + bsonutil.GetDottedKeyName(DistroKey, distro.IdKey),
+				"_id":                             "$" + bsonutil.GetDottedKeyName(DistroKey, distro.IdKey),
 				HostsByDistroRunningHostsCountKey: mgobson.M{"$sum": 1},
 				HostsByDistroIdleHostsKey:         mgobson.M{"$push": bson.M{"$cond": []interface{}{mgobson.M{"$eq": []interface{}{"$running_task", mgobson.Undefined}}, "$$ROOT", mgobson.Undefined}}},
 			},

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1189,13 +1189,13 @@ func (h *Host) Upsert() (*adb.ChangeInfo, error) {
 		ProvisionedKey:       h.Provisioned,
 		ProvisionAttemptsKey: h.ProvisionAttempts,
 		ProvisionOptionsKey:  h.ProvisionOptions,
+		StatusKey:            h.Status,
 		StartTimeKey:         h.StartTime,
 		HasContainersKey:     h.HasContainers,
 		ContainerImagesKey:   h.ContainerImages,
 	}
 	update := bson.M{
 		"$setOnInsert": bson.M{
-			StatusKey:     h.Status,
 			CreateTimeKey: h.CreationTime,
 		},
 	}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -766,7 +766,7 @@ func TestUpsert(t *testing.T) {
 		})
 
 		Convey("Updating some fields of an already inserted host should cause "+
-			"those fields to be updated but should leave status unchanged",
+			"those fields to be updated ",
 			func() {
 				_, err := host.Upsert()
 				So(err, ShouldBeNil)
@@ -795,10 +795,10 @@ func TestUpsert(t *testing.T) {
 				_, err = host.Upsert()
 				So(err, ShouldBeNil)
 
-				// host db status should remain unchanged
+				// host db status should be modified
 				host, err = FindOne(ById(host.Id))
 				So(err, ShouldBeNil)
-				So(host.Status, ShouldEqual, evergreen.HostDecommissioned)
+				So(host.Status, ShouldEqual, evergreen.HostRunning)
 				So(host.Host, ShouldEqual, "host2")
 
 			})

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -155,6 +155,11 @@ func doStaticHostUpdate(d distro.Distro) ([]string, error) {
 			NeedsReprovision: provisionChange,
 			Provisioned:      provisioned,
 		}
+		if provisioned {
+			staticHost.Status = evergreen.HostRunning
+		} else {
+			staticHost.Status = evergreen.HostProvisioning
+		}
 
 		if d.Provider == evergreen.ProviderNameStatic {
 			staticHost.Provider = evergreen.HostTypeStatic

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -155,10 +155,14 @@ func doStaticHostUpdate(d distro.Distro) ([]string, error) {
 			NeedsReprovision: provisionChange,
 			Provisioned:      provisioned,
 		}
-		if provisioned {
-			staticHost.Status = evergreen.HostRunning
+		if dbHost == nil || dbHost.Status == evergreen.HostTerminated {
+			if provisioned {
+				staticHost.Status = evergreen.HostRunning
+			} else {
+				staticHost.Status = evergreen.HostProvisioning
+			}
 		} else {
-			staticHost.Status = evergreen.HostProvisioning
+			staticHost.Status = dbHost.Status
 		}
 
 		if d.Provider == evergreen.ProviderNameStatic {

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -185,9 +185,6 @@ func needsReprovisioning(d distro.Distro, h *host.Host) host.ReprovisionType {
 		}
 		return host.ReprovisionNone
 	}
-	if h.Status == evergreen.HostQuarantined {
-		return host.ReprovisionNone
-	}
 
 	if h.LegacyBootstrap() && d.BootstrapSettings.Method != "" && d.BootstrapSettings.Method != distro.BootstrapMethodLegacySSH {
 		return host.ReprovisionToNew

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -185,6 +185,9 @@ func needsReprovisioning(d distro.Distro, h *host.Host) host.ReprovisionType {
 		}
 		return host.ReprovisionNone
 	}
+	if h.Status == evergreen.HostQuarantined {
+		return host.ReprovisionNone
+	}
 
 	if h.LegacyBootstrap() && d.BootstrapSettings.Method != "" && d.BootstrapSettings.Method != distro.BootstrapMethodLegacySSH {
 		return host.ReprovisionToNew

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -140,9 +140,6 @@ func doStaticHostUpdate(d distro.Distro) ([]string, error) {
 			return nil, errors.Wrapf(err, "error finding host named %s", h.Name)
 		}
 		provisionChange := needsReprovisioning(d, dbHost)
-		if provisionChange == host.ReprovisionNone && !dbHost.ReprovisioningLocked {
-			provisionChange = dbHost.NeedsReprovision
-		}
 
 		provisioned := provisionChange == host.ReprovisionNone || (dbHost != nil && dbHost.Provisioned)
 		staticHost := host.Host{

--- a/scheduler/wrapper_test.go
+++ b/scheduler/wrapper_test.go
@@ -437,7 +437,7 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
 			assert.Equal(t, evergreen.HostQuarantined, dbHost.Status)
-			assert.Equal(t, host.ReprovisionToNew, dbHost.NeedsReprovision)
+			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
 			assert.True(t, dbHost.Provisioned)
 		},
 		"QuarantinedNonLegacyHostOnNonLegacyDistro": func(t *testing.T) {
@@ -487,7 +487,7 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
 			assert.Equal(t, evergreen.HostQuarantined, dbHost.Status)
-			assert.Equal(t, host.ReprovisionToLegacy, dbHost.NeedsReprovision)
+			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
 			assert.True(t, dbHost.Provisioned)
 		},
 	} {

--- a/scheduler/wrapper_test.go
+++ b/scheduler/wrapper_test.go
@@ -437,7 +437,7 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
 			assert.Equal(t, evergreen.HostQuarantined, dbHost.Status)
-			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
+			assert.Equal(t, host.ReprovisionToNew, dbHost.NeedsReprovision)
 			assert.True(t, dbHost.Provisioned)
 		},
 		"QuarantinedNonLegacyHostOnNonLegacyDistro": func(t *testing.T) {
@@ -487,7 +487,7 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
 			assert.Equal(t, evergreen.HostQuarantined, dbHost.Status)
-			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
+			assert.Equal(t, host.ReprovisionToLegacy, dbHost.NeedsReprovision)
 			assert.True(t, dbHost.Provisioned)
 		},
 	} {

--- a/scheduler/wrapper_test.go
+++ b/scheduler/wrapper_test.go
@@ -1,11 +1,17 @@
 package scheduler
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNeedsReprovision(t *testing.T) {
@@ -71,6 +77,326 @@ func TestNeedsReprovision(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			assert.Equal(t, testCase.expected, needsReprovisioning(testCase.d, testCase.h))
+		})
+	}
+}
+
+func makeStaticHostProviderSettings(t *testing.T, names ...string) *map[string]interface{} {
+	settings := cloud.StaticSettings{
+		Hosts: []cloud.StaticHost{},
+	}
+	for _, name := range names {
+		settings.Hosts = append(settings.Hosts, cloud.StaticHost{Name: name})
+	}
+	b, err := json.Marshal(settings)
+	require.NoError(t, err)
+	m := make(map[string]interface{})
+	require.NoError(t, json.Unmarshal(b, &m))
+	return &m
+}
+
+func TestDoStaticHostUpdate(t *testing.T) {
+	legacyHost := func() *host.Host {
+		return &host.Host{
+			Id:   "host1",
+			User: "user1",
+			Distro: distro.Distro{
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodLegacySSH,
+					Communication: distro.CommunicationMethodLegacySSH,
+				},
+			},
+			Status:      evergreen.HostRunning,
+			Provisioned: true,
+		}
+	}
+	nonLegacyHost := func() *host.Host {
+		return &host.Host{
+			Id:   "host2",
+			User: "user1",
+			Distro: distro.Distro{
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodSSH,
+					Communication: distro.CommunicationMethodSSH,
+				},
+			},
+			Status:      evergreen.HostRunning,
+			Provisioned: true,
+		}
+	}
+
+	for testName, testCase := range map[string]func(t *testing.T){
+		"NewHostWithoutUserUsesDistroUser": func(t *testing.T) {
+			name := "host"
+			user := "user"
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, name),
+				Provider:         evergreen.ProviderNameStatic,
+				User:             user,
+			}
+
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, name, hosts[0])
+
+			dbHost, err := host.FindOneId(name)
+			require.NoError(t, err)
+			assert.Equal(t, user, dbHost.User)
+			assert.Equal(t, evergreen.User, dbHost.StartedBy)
+			assert.Equal(t, name, dbHost.Host)
+			assert.Equal(t, evergreen.HostTypeStatic, dbHost.Provider)
+			assert.WithinDuration(t, time.Now(), dbHost.CreationTime, time.Minute)
+			assert.Equal(t, d.Id, dbHost.Distro.Id)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"NewHostOnLegacyDistro": func(t *testing.T) {
+			name := "user@host"
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, name),
+				Provider:         evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodLegacySSH,
+					Communication: distro.CommunicationMethodLegacySSH,
+				},
+			}
+
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, name, hosts[0])
+
+			dbHost, err := host.FindOneId(name)
+			require.NoError(t, err)
+			assert.Equal(t, dbHost.Status, evergreen.HostRunning)
+			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"NewHostOnNonLegacyDistro": func(t *testing.T) {
+			name := "user@host"
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, name),
+				Provider:         evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodSSH,
+					Communication: distro.BootstrapMethodSSH,
+				},
+			}
+
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, name, hosts[0])
+
+			dbHost, err := host.FindOneId(name)
+			require.NoError(t, err)
+			assert.Equal(t, dbHost.Status, evergreen.HostProvisioning)
+			assert.Equal(t, host.ReprovisionToNew, dbHost.NeedsReprovision)
+			assert.False(t, dbHost.Provisioned)
+		},
+		"LegacyHostOnLegacyDistro": func(t *testing.T) {
+			h := legacyHost()
+			require.NoError(t, h.Insert())
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
+				Provider:         evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodLegacySSH,
+					Communication: distro.BootstrapMethodLegacySSH,
+				},
+			}
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0])
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.HostRunning, dbHost.Status)
+			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"LegacyHostOnNonLegacyDistro": func(t *testing.T) {
+			h := legacyHost()
+			require.NoError(t, h.Insert())
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
+				Provider:         evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodSSH,
+					Communication: distro.BootstrapMethodSSH,
+				},
+			}
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0])
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.HostRunning, dbHost.Status)
+			assert.Equal(t, host.ReprovisionToNew, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"NonLegacyHostOnLegacyDistro": func(t *testing.T) {
+			h := nonLegacyHost()
+			require.NoError(t, h.Insert())
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
+				Provider:         evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodLegacySSH,
+					Communication: distro.BootstrapMethodLegacySSH,
+				},
+			}
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0])
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.HostRunning, dbHost.Status)
+			assert.Equal(t, host.ReprovisionToLegacy, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"NonLegacyHostOnNonLegacyDistro": func(t *testing.T) {
+			h := nonLegacyHost()
+			require.NoError(t, h.Insert())
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
+				Provider:         evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodSSH,
+					Communication: distro.BootstrapMethodSSH,
+				},
+			}
+
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0])
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.HostRunning, dbHost.Status)
+			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"TerminatedLegacyHostOnLegacyDistro": func(t *testing.T) {
+			h := legacyHost()
+			h.Status = evergreen.HostTerminated
+			require.NoError(t, h.Insert())
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
+				Provider:         evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodLegacySSH,
+					Communication: distro.BootstrapMethodLegacySSH,
+				},
+			}
+
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0])
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.HostRunning, dbHost.Status)
+			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"TerminatedLegacyHostOnNonLegacyDistro": func(t *testing.T) {
+			h := legacyHost()
+			h.Status = evergreen.HostTerminated
+			require.NoError(t, h.Insert())
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
+				Provider:         evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodSSH,
+					Communication: distro.BootstrapMethodSSH,
+				},
+			}
+
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0])
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.HostRunning, dbHost.Status)
+			assert.Equal(t, host.ReprovisionToNew, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"TerminatedNonLegacyHostOnNonLegacyDistro": func(t *testing.T) {
+			h := nonLegacyHost()
+			h.Status = evergreen.HostTerminated
+			require.NoError(t, h.Insert())
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
+				Provider:         evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodSSH,
+					Communication: distro.BootstrapMethodSSH,
+				},
+			}
+
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0])
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.HostRunning, dbHost.Status)
+			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"TerminatedNonLegacyHostOnLegacyDistro": func(t *testing.T) {
+			h := nonLegacyHost()
+			h.Status = evergreen.HostTerminated
+			require.NoError(t, h.Insert())
+			d := distro.Distro{
+				Id:               "distro",
+				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
+				Provider:         evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodLegacySSH,
+					Communication: distro.BootstrapMethodLegacySSH,
+				},
+			}
+
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0])
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.HostRunning, dbHost.Status)
+			assert.Equal(t, host.ReprovisionToLegacy, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			require.NoError(t, db.Clear(host.Collection))
+			defer func() {
+				assert.NoError(t, db.Clear(host.Collection))
+			}()
+			testCase(t)
 		})
 	}
 }

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -50,6 +50,7 @@ func (j *cronsRemoteHourJob) Run(ctx context.Context) {
 	ops := []amboy.QueueOperation{
 		PopulateCacheHistoricalTestDataJob(2),
 		PopulateHostJasperRestartJobs(j.env),
+		PopulateHostProvisioningConversionJobs(j.env),
 		PopulateSpawnhostExpirationCheckJob(),
 	}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-6747

Same as previous PR but only sets the static host's status if the host is not in the database or its status was terminated.