### PR TITLE
EVG-6436 use requester field

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1294,7 +1294,7 @@ func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pa
 		return nil
 	}
 
-	builds, err := build.Find(build.ByIds(v.BuildIds).WithFields(build.IdKey, build.BuildVariantKey, build.CreateTimeKey))
+	builds, err := build.Find(build.ByIds(v.BuildIds).WithFields(build.IdKey, build.BuildVariantKey, build.CreateTimeKey, build.RequesterKey))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
World's tiniest PR explained:

I don't know how this hasn't been discovered before, but Robert reported an issue where trying to belatedly add a task to a PR patch didn't actually add the task. Apparently, when we get the build we didn't also get the requester field, so `b.IsPatchBuild()` was always returning false since the build requester was empty, and for this task `patch_only` was true, so `task.SkipOnNonPatchBuild()` returned true, so we skipped this task entirely. Correctly interpreting `p.IsPatchBuild()` as true (by including the requester field) fixes this.

https://github.com/evergreen-ci/evergreen/blob/master/model/lifecycle.go#L691