### PR TITLE
EVG-7089: run teardown script on new provisioned hosts

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -704,7 +704,7 @@ func (h *Host) RunJasperProcess(ctx context.Context, env evergreen.Environment, 
 		catcher.Wrap(err, "problem waiting for process completion")
 	}
 
-	logs := []string{}
+	var logs []string
 	for {
 		logStream, err := client.GetLogStream(ctx, proc.ID(), 1000)
 		if err != nil {

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -48,12 +48,12 @@ func (h *Host) TearDownCommand() string {
 	return fmt.Sprintf("cd %s && ./%s host teardown", h.Distro.HomeDir(), h.Distro.BinaryName())
 }
 
-// TearDownCommandOverSSH returns a command for running a teardown script on a host. This command
+// TearDownDirectlyCommand returns a command for running a teardown script on a host. This command
 // runs if there is a problem running host teardown with the agent and is intended only as a
 // backstop if multiple agent deploys interfere with one another
 // (https://jira.mongodb.org/browse/EVG-5972). It likely can be removed after work to improve amboy
 // job locking or the SSH dependency.
-func TearDownCommandOverSSH() string {
+func TearDownDirectlyCommand() string {
 	chmod := ChmodCommandWithSudo(context.Background(), evergreen.TeardownScriptName, false).Args
 	chmodString := strings.Join(chmod, " ")
 	sh := ShCommandWithSudo(context.Background(), evergreen.TeardownScriptName, false).Args

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -745,8 +745,8 @@ func TestBufferedWriteFileCommands(t *testing.T) {
 	}
 }
 
-func TestTeardownCommandOverSSH(t *testing.T) {
-	cmd := TearDownCommandOverSSH()
+func TestTearDownDirectlyCommand(t *testing.T) {
+	cmd := TearDownDirectlyCommand()
 	assert.Equal(t, "chmod +x teardown.sh && sh teardown.sh", cmd)
 }
 

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -3,11 +3,14 @@ package units
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -19,6 +22,7 @@ import (
 	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
+	"github.com/mongodb/jasper/options"
 	"github.com/pkg/errors"
 )
 
@@ -368,22 +372,54 @@ func (j *hostTerminationJob) runHostTeardown(ctx context.Context, settings *ever
 		return nil
 	}
 
-	sshOptions, err := j.host.GetSSHOptions(settings)
-	if err != nil {
-		return errors.Wrapf(err, "error getting ssh options for host %s", j.host.Id)
-	}
-	startTime := time.Now()
-	// run the teardown script with the agent
-	logs, err := j.host.RunSSHCommand(ctx, j.host.TearDownCommand(), sshOptions)
-	if err != nil {
-		event.LogHostTeardown(j.host.Id, logs, false, time.Since(startTime))
-		// Try again, this time without the agent, just in case.
-		logs, err = j.host.RunSSHCommand(ctx, host.TearDownCommandOverSSH(), sshOptions)
-		if err != nil {
-			event.LogHostTeardown(j.host.Id, logs, false, time.Since(startTime))
-			return errors.Wrapf(err, "error running teardown script on remote host: %s", logs)
+	var startTime time.Time
+	if j.host.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData {
+		startTime = time.Now()
+		args := []string{filepath.Join(j.host.Distro.BootstrapSettings.RootDir, j.host.Distro.BootstrapSettings.ShellPath), "-c", fmt.Sprintf("set -o verbose && cat > %s <<'EOF'\n%s\nEOF", filepath.Join(j.host.Distro.HomeDir(), evergreen.TeardownScriptName), j.host.Distro.Teardown)}
+		if output, err := j.host.RunJasperProcess(ctx, j.env, &options.Create{
+			Args: args,
+		}); err != nil {
+			event.LogHostTeardown(j.host.Id, strings.Join(output, "\n"), false, time.Since(startTime))
+			return errors.Wrapf(err, "could not write teardown file to host: %s", strings.Join(output, "\n"))
 		}
 	}
+
+	var logs string
+	if j.host.LegacyBootstrap() {
+		sshOptions, err := j.host.GetSSHOptions(settings)
+		if err != nil {
+			return errors.Wrapf(err, "error getting ssh options for host %s", j.host.Id)
+		}
+		startTime = time.Now()
+		// run the teardown script with the agent
+		logs, err = j.host.RunSSHCommand(ctx, j.host.TearDownCommand(), sshOptions)
+		if err != nil {
+			event.LogHostTeardown(j.host.Id, logs, false, time.Since(startTime))
+			// Try again, this time without the agent, just in case.
+			logs, err = j.host.RunSSHCommand(ctx, host.TearDownDirectlyCommand(), sshOptions)
+			if err != nil {
+				event.LogHostTeardown(j.host.Id, logs, false, time.Since(startTime))
+				return errors.Wrapf(err, "error running teardown script on remote host: %s", logs)
+			}
+		}
+	} else {
+		startTime = time.Now()
+		output, err := j.host.RunJasperProcess(ctx, j.env, &options.Create{
+			Args: []string{filepath.Join(j.host.Distro.BootstrapSettings.RootDir, j.host.Distro.BootstrapSettings.ShellPath), "-l", "-c", j.host.TearDownCommand()},
+		})
+		if err != nil {
+			event.LogHostTeardown(j.host.Id, strings.Join(output, "\n"), false, time.Since(startTime))
+			startTime = time.Now()
+			output, err = j.host.RunJasperProcess(ctx, j.env, &options.Create{
+				Args: []string{filepath.Join(j.host.Distro.BootstrapSettings.RootDir, j.host.Distro.BootstrapSettings.ShellPath), "-l", "-c", host.TearDownDirectlyCommand()},
+			})
+			if err != nil {
+				return errors.Wrapf(err, "error running teardown script on remote host")
+			}
+		}
+		logs = strings.Join(output, "\n")
+	}
+
 	event.LogHostTeardown(j.host.Id, logs, true, time.Since(startTime))
 	return nil
 }

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -398,7 +398,6 @@ func (j *hostTerminationJob) runHostTeardown(ctx context.Context, settings *ever
 	// We do not write the teardown script in user data because the user
 	// data script is subject to a 16kB text limit, which is easy to exceed.
 	if j.host.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData {
-		startTime = time.Now()
 		args := []string{filepath.Join(j.host.Distro.BootstrapSettings.RootDir, j.host.Distro.BootstrapSettings.ShellPath), "-c", fmt.Sprintf("cat > %s <<'EOF'\n%s\nEOF", filepath.Join(j.host.Distro.HomeDir(), evergreen.TeardownScriptName), j.host.Distro.Teardown)}
 		if output, err := j.host.RunJasperProcess(ctx, j.env, &options.Create{
 			Args: args,

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -392,13 +392,14 @@ func (j *hostTerminationJob) runHostTeardown(ctx context.Context, settings *ever
 			}
 		}
 	} else {
+		// We do not write the teardown script in user data because the user
+		// data script is subject to a 16kB text limit, which is easy to exceed.
 		if j.host.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData {
 			startTime = time.Now()
 			args := []string{filepath.Join(j.host.Distro.BootstrapSettings.RootDir, j.host.Distro.BootstrapSettings.ShellPath), "-c", fmt.Sprintf("cat > %s <<'EOF'\n%s\nEOF", filepath.Join(j.host.Distro.HomeDir(), evergreen.TeardownScriptName), j.host.Distro.Teardown)}
 			if output, err := j.host.RunJasperProcess(ctx, j.env, &options.Create{
 				Args: args,
 			}); err != nil {
-				event.LogHostTeardown(j.host.Id, strings.Join(output, "\n"), false, time.Since(startTime))
 				return errors.Wrapf(err, "could not write teardown file to host: %s", strings.Join(output, "\n"))
 			}
 		}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7089

* User data provisioning does not write the script to a file, so do it before running it during termination. I don't want to do this in the user data script since I want to keep the user data script as small as possible and writing a shell script within a shell script is likely to cause shell quoting madness.
    * I'm pretty sure this doesn't work on Windows, but I'm also pretty sure the legacy method also doesn't work with teardown scripts on Windows.
* Run the teardown script with Jasper if using new provisioning.