### PR TITLE
EVG-7054: use golangci-lint instead of gometalinter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+---
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - goimports
+    - govet
+    - ineffassign
+    - interfacer
+    - misspell
+    - unconvert

--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -61,7 +61,9 @@ func targetsFromChangedFiles(files []string) ([]string, error) {
 				continue
 			}
 
-			if strings.HasPrefix(dir, "vendor") {
+			// We can't run make targets on packages in the cmd directory
+			// because the packages contain dashes.
+			if strings.HasPrefix(dir, "vendor") || strings.HasPrefix(dir, "cmd") {
 				continue
 			}
 

--- a/cmd/run-linter/run-linter.go
+++ b/cmd/run-linter/run-linter.go
@@ -28,7 +28,6 @@ func (r *result) String() string {
 	if r.passed {
 		fmt.Fprintf(buf, "--- PASS: %s (%s)", r.name, r.duration)
 	} else {
-		// fmt.Fprintln(buf, "    CMD:", r.cmd)
 		fmt.Fprintf(buf, strings.Join(r.output, "\n"))
 		fmt.Fprintf(buf, "--- FAIL: %s (%s)", r.name, r.duration)
 	}
@@ -50,13 +49,15 @@ func (r *result) fixup(dirname string) {
 // runs the gometalinter on a list of packages; integrating with the "make lint" target.
 func main() {
 	var (
-		lintArgs       string
-		lintBin        string
-		packageList    string
-		output         string
-		packages       []string
-		results        []*result
-		hasFailingTest bool
+		lintArgs          string
+		lintBin           string
+		customLintersFlag string
+		customLinters     []string
+		packageList       string
+		output            string
+		packages          []string
+		results           []*result
+		hasFailingTest    bool
 
 		gopath = os.Getenv("GOPATH")
 	)
@@ -64,23 +65,24 @@ func main() {
 	gopath, _ = filepath.Abs(gopath)
 
 	flag.StringVar(&lintArgs, "lintArgs", "", "args to pass to gometalinter")
-	flag.StringVar(&lintBin, "lintBin", filepath.Join(gopath, "bin", "gometalinter"), "path to go metalinter")
+	flag.StringVar(&lintBin, "lintBin", filepath.Join(gopath, "bin", "golangci-lint"), "path to go metalinter")
 	flag.StringVar(&packageList, "packages", "", "list of space separated packages")
+	flag.StringVar(&customLintersFlag, "customLinters", "", "list of comma-separated custom linter commands")
 	flag.StringVar(&output, "output", "", "output file for to write results.")
 	flag.Parse()
 
+	customLinters = strings.Split(customLintersFlag, ",")
 	packages = strings.Split(strings.Replace(packageList, "-", "/", -1), " ")
 	dirname, _ := os.Getwd()
 	cwd := filepath.Base(dirname)
 	lintArgs += fmt.Sprintf(" --concurrency=%d", runtime.NumCPU()/2)
 
 	for _, pkg := range packages {
-		args := []string{lintBin, lintArgs}
-		if cwd == pkg {
-			args = append(args, ".")
-		} else {
-			args = append(args, "./"+pkg)
+		pkgDir := "./"
+		if cwd != pkg {
+			pkgDir += pkg
 		}
+		args := []string{lintBin, "run", lintArgs, pkgDir}
 
 		startAt := time.Now()
 		cmd := strings.Join(args, " ")
@@ -91,6 +93,13 @@ func main() {
 			passed:   err == nil,
 			duration: time.Since(startAt),
 			output:   strings.Split(string(out), "\n"),
+		}
+		for _, linter := range customLinters {
+			customLinterStart := time.Now()
+			out, err = exec.Command("sh", "-c", fmt.Sprintf("%s %s", linter, pkgDir)).CombinedOutput()
+			r.passed = r.passed && err == nil
+			r.duration += time.Since(customLinterStart)
+			r.output = append(r.output, strings.Split(string(out), "\n")...)
 		}
 		r.fixup(dirname)
 

--- a/command/git.go
+++ b/command/git.go
@@ -681,7 +681,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		defer tempFile.Close() //nolint: evg
+		defer tempFile.Close() //nolint: evg-lint
 		_, err = io.WriteString(tempFile, patchPart.PatchSet.Patch)
 		if err != nil {
 			return errors.WithStack(err)

--- a/command/results_gotest.go
+++ b/command/results_gotest.go
@@ -170,7 +170,7 @@ func parseTestOutputFiles(ctx context.Context, logger client.LoggerProducer,
 				outputFile, err)
 			continue
 		}
-		defer fileReader.Close() //nolint: evg
+		defer fileReader.Close() //nolint: evg-lint
 
 		// parse the output logs
 		parser := &goTestParser{Suite: suiteName}

--- a/config_auth.go
+++ b/config_auth.go
@@ -29,7 +29,7 @@ type LDAPConfig struct {
 	Port                string `bson:"port" json:"port" yaml:"port"`
 	ServiceUserName     string `bson:"service_user_name" json:"service_user_name" yaml:"service_user_name"`
 	ServiceUserPassword string `bson:"service_user_password" json:"service_user_password" yaml:"service_user_password"`
-	ServiceUserPath     string `bson:"service_user_path json:"service_user_path" yaml:"service_user_path"`
+	ServiceUserPath     string `bson:"service_user_path" json:"service_user_path" yaml:"service_user_path"`
 	UserPath            string `bson:"path" json:"path" yaml:"path"`
 	ServicePath         string `bson:"service_path" json:"service_path" yaml:"service_path"`
 	Group               string `bson:"group" json:"group" yaml:"group"`

--- a/config_test.go
+++ b/config_test.go
@@ -150,7 +150,7 @@ func (s *AdminSuite) TestBaseConfig() {
 		GithubOrgs:         []string{"evergreen-ci"},
 		Keys:               map[string]string{"k3": "v3"},
 		LogPath:            "logpath",
-		Plugins:            map[string]map[string]interface{}{"k4": map[string]interface{}{"k5": "v5"}},
+		Plugins:            map[string]map[string]interface{}{"k4": {"k5": "v5"}},
 		PprofPort:          "port",
 		Splunk: send.SplunkConnectionInfo{
 			ServerURL: "server",
@@ -278,7 +278,7 @@ func (s *AdminSuite) TestAuthConfig() {
 			ExpireAfterMinutes: "60",
 		},
 		Naive: &NaiveAuthConfig{
-			Users: []*AuthUser{&AuthUser{Username: "user", Password: "pw"}},
+			Users: []*AuthUser{{Username: "user", Password: "pw"}},
 		},
 		Github: &GithubAuthConfig{
 			ClientId:     "ghclient",
@@ -537,7 +537,7 @@ func (s *AdminSuite) TestContainerPoolsConfig() {
 
 	invalidConfig := ContainerPoolsConfig{
 		Pools: []ContainerPool{
-			ContainerPool{
+			{
 				Distro:        "d1",
 				Id:            "test-pool-1",
 				MaxContainers: -5,
@@ -550,12 +550,12 @@ func (s *AdminSuite) TestContainerPoolsConfig() {
 
 	validConfig := ContainerPoolsConfig{
 		Pools: []ContainerPool{
-			ContainerPool{
+			{
 				Distro:        "d1",
 				Id:            "test-pool-1",
 				MaxContainers: 100,
 			},
-			ContainerPool{
+			{
 				Distro:        "d2",
 				Id:            "test-pool-2",
 				MaxContainers: 1,

--- a/environment_test.go
+++ b/environment_test.go
@@ -95,7 +95,7 @@ func (s *EnvironmentSuite) TestGetClientConfig() {
 		file := path + "/evergreen"
 		_, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 		s.NoError(err)
-		defer func() { //nolint: evg
+		defer func() { //nolint: evg-lint
 			_ = os.Remove(file)
 			_ = os.Remove(path)
 		}()

--- a/makefile
+++ b/makefile
@@ -54,35 +54,6 @@ gopath := $(shell cygpath -m $(gopath))
 endif
 endif
 
-# start linting configuration
-#   package, testing, and linter dependencies specified
-#   separately. This is a temporary solution: eventually we should
-#   vendorize all of these dependencies.
-lintDeps := github.com/alecthomas/gometalinter
-#   include test files and give linters 40s to run to avoid timeouts
-lintArgs := --tests --deadline=10m --vendor --aggregate --sort=line
-lintArgs += --vendored-linters --enable-gc
-#   gotype produces false positives because it reads .a files which
-#   are rarely up to date.
-lintArgs += --disable="gotype" --disable="gosec" --disable="gocyclo" --disable="maligned"
-lintArgs += --disable="golint" --disable="goconst" --disable="dupl"
-lintArgs += --disable="varcheck" --disable="structcheck" --disable="aligncheck"
-lintArgs += --skip="$(buildDir)" --skip="scripts" --skip="$(gopath)"
-#  add and configure additional linters
-lintArgs += --enable="misspell" # --enable="lll" --line-length=100
-lintArgs += --disable="staticcheck" --disable="megacheck"
-#  suppress some lint errors (logging methods could return errors, and error checking in defers.)
-lintArgs += --exclude=".*([mM]ock.*ator|modadvapi32|osSUSE) is unused \((deadcode|unused|megacheck)\)$$"
-lintArgs += --exclude="error return value not checked \((defer .*|fmt.Fprint.*) \(errcheck\)$$"
-lintArgs += --exclude=".* \(SA5001\) \(megacheck\)$$"
-lintArgs += --exclude=".*file is not goimported"
-lintArgs += --exclude="declaration of \"assert\" shadows declaration at .*_test.go:"
-lintArgs += --exclude="declaration of \"require\" shadows declaration at .*_test.go:"
-lintArgs += --linter="evg:$(gopath)/bin/evg-lint:PATH:LINE:COL:MESSAGE" --enable=evg
-lintArgs += --enable=goimports --disable="gotypex"
-# end lint configuration
-
-
 ######################################################################
 ##
 ## Build rules and instructions for building evergreen binaries and targets.
@@ -166,15 +137,16 @@ coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).
 $(gopath)/src/%:
 	@-[ ! -d $(gopath) ] && mkdir -p $(gopath) || true
 	$(gobin) get $(subst $(gopath)/src/,,$@)
+$(gopath)/bin:
+	mkdir -p $@
 # end dependency installation tools
 
 
 # lint setup targets
-lintDeps := $(addprefix $(gopath)/src/,$(lintDeps))
-$(buildDir)/.lintSetup:$(lintDeps)
+$(buildDir)/.lintSetup:
 	$(gobin) get github.com/evergreen-ci/evg-lint/...
 	@mkdir -p $(buildDir)
-	$(if $(GO_BIN_PATH),export PATH=$(shell dirname $(GO_BIN_PATH)):${PATH} && ,)$(gopath)/bin/gometalinter --force --install >/dev/null && touch $@
+	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.10.2 >/dev/null 2>&1 && touch $@
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
 	@mkdir -p $(buildDir)
 	$(gobin) build -o $@ $<
@@ -445,9 +417,9 @@ $(buildDir)/output.%.coverage:$(tmpDir) .FORCE
 	@-[ -f $@ ] && go tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 #  targets to generate gotest output from the linter.
 $(buildDir)/output.%.lint:$(buildDir)/run-linter $(testSrcFiles) .FORCE
-	@./$< --output=$@ --lintArgs='$(lintArgs)' --packages='$*'
+	@./$< --output=$@ --lintBin="$(buildDir)/golangci-lint" --customLinters="$(gopath)/bin/evg-lint -set_exit_status" --packages='$*'
 $(buildDir)/output.lint:$(buildDir)/run-linter .FORCE
-	@./$< --output="$@" --lintArgs='$(lintArgs)' --packages="$(packages)"
+	@./$< --output="$@" --lintBin="$(buildDir)/golangci-lint" --customLinters="$(gopath)/bin/evg-lint -set_exit_status" --packages="$(packages)"
 #  targets to process and generate coverage reports
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -681,7 +681,13 @@ func (h *Host) RunJasperProcess(ctx context.Context, env evergreen.Environment, 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get a Jasper client")
 	}
-	defer client.CloseConnection()
+	defer func() {
+		grip.Warning(message.WrapError(client.CloseConnection(), message.Fields{
+			"message": "could not close connection to Jasper",
+			"host":    h.Id,
+			"distro":  h.Distro.Id,
+		}))
+	}()
 
 	inMemoryLoggerExists := false
 	for _, logger := range opts.Output.Loggers {
@@ -728,7 +734,13 @@ func (h *Host) StartJasperProcess(ctx context.Context, env evergreen.Environment
 	if err != nil {
 		return errors.Wrap(err, "could not get a Jasper client")
 	}
-	defer client.CloseConnection()
+	defer func() {
+		grip.Warning(message.WrapError(client.CloseConnection(), message.Fields{
+			"message": "could not close connection to Jasper",
+			"host":    h.Id,
+			"distro":  h.Distro.Id,
+		}))
+	}()
 
 	if _, err := client.CreateProcess(ctx, opts); err != nil {
 		return errors.Wrap(err, "problem creating Jasper process")
@@ -856,7 +868,13 @@ func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) 
 	if err != nil {
 		return errors.Wrap(err, "could not get a Jasper client")
 	}
-	defer client.CloseConnection()
+	defer func() {
+		grip.Warning(message.WrapError(client.CloseConnection(), message.Fields{
+			"message": "could not close connection to Jasper",
+			"host":    h.Id,
+			"distro":  h.Distro.Id,
+		}))
+	}()
 
 	procs, err := client.Group(ctx, evergreen.AgentMonitorTag)
 	if err != nil {

--- a/model/notify_history.go
+++ b/model/notify_history.go
@@ -16,13 +16,13 @@ const (
 
 type NotificationHistory struct {
 	Id                    mgobson.ObjectId `bson:"_id,omitempty"`
-	PrevNotificationId    string              `bson:"p_nid"`
-	CurrNotificationId    string              `bson:"c_nid"`
-	NotificationName      string              `bson:"n_name"`
-	NotificationType      string              `bson:"n_type"`
-	NotificationTime      time.Time           `bson:"n_time"`
-	NotificationProject   string              `bson:"n_branch"`
-	NotificationRequester string              `bson:"n_requester"`
+	PrevNotificationId    string           `bson:"p_nid"`
+	CurrNotificationId    string           `bson:"c_nid"`
+	NotificationName      string           `bson:"n_name"`
+	NotificationType      string           `bson:"n_type"`
+	NotificationTime      time.Time        `bson:"n_time"`
+	NotificationProject   string           `bson:"n_branch"`
+	NotificationRequester string           `bson:"n_requester"`
 }
 
 var (

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -129,7 +129,7 @@ func (p *Patch) FetchPatchFiles() error {
 		if err != nil {
 			return err
 		}
-		defer file.Close() //nolint: evg
+		defer file.Close() //nolint: evg-lint
 		raw, err := ioutil.ReadAll(file)
 		if err != nil {
 			return err

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -221,13 +221,13 @@ func MakePatchedConfig(ctx context.Context, env evergreen.Environment, p *patch.
 			}
 		}
 
-		defer os.Remove(patchFilePath) //nolint: evg
+		defer os.Remove(patchFilePath) //nolint: evg-lint
 		// write project configuration
 		configFilePath, err := util.WriteToTempFile(projectConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not write config file")
 		}
-		defer os.Remove(configFilePath) //nolint: evg
+		defer os.Remove(configFilePath) //nolint: evg-lint
 
 		// clean the working directory
 		workingDirectory := filepath.Dir(patchFilePath)

--- a/model/project.go
+++ b/model/project.go
@@ -19,7 +19,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"github.com/sabhiram/go-git-ignore"
+	ignore "github.com/sabhiram/go-git-ignore"
 	"gopkg.in/yaml.v2"
 )
 

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1400,7 +1400,7 @@ func checkProjectPersists(yml []byte) error {
 	}
 
 	// ensure that updating with the re-parsed project doesn't error
-	pp, err = createIntermediateProject([]byte(newYaml))
+	pp, err = createIntermediateProject(newYaml)
 	pp.Id = "my-project"
 	pp.Identifier = "new-project-identifier"
 	if err != nil {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -345,7 +345,8 @@ func TestProjectRefTags(t *testing.T) {
 		require.Equal(t, "amboy", prjs[0].Identifier)
 	})
 	t.Run("Add", func(t *testing.T) {
-		mci.AddTags("test", "testing")
+		_, err := mci.AddTags("test", "testing")
+		require.NoError(t, err)
 
 		prjs, err := FindTaggedProjectRefs(false, "testing")
 		require.NoError(t, err)

--- a/model/stats/query.go
+++ b/model/stats/query.go
@@ -89,25 +89,25 @@ func StartAtFromTaskStats(taskStats *TaskStats) StartAt {
 func (s *StartAt) validateCommon(groupBy GroupBy) error {
 	catcher := grip.NewBasicCatcher()
 	if s == nil {
-                catcher.New("StartAt should not be nil")
+		catcher.New("StartAt should not be nil")
 	}
 	if !s.Date.Equal(util.GetUTCDay(s.Date)) {
-                catcher.New("Invalid StartAt Date value")
+		catcher.New("Invalid StartAt Date value")
 	}
 	switch groupBy {
 	case GroupByDistro:
 		if len(s.Distro) == 0 {
-                        catcher.New("Missing StartAt Distro value")
+			catcher.New("Missing StartAt Distro value")
 		}
 		fallthrough
 	case GroupByVariant:
 		if len(s.BuildVariant) == 0 {
-                        catcher.New("Missing StartAt BuildVariant value")
+			catcher.New("Missing StartAt BuildVariant value")
 		}
 		fallthrough
 	case GroupByTask:
 		if len(s.Task) == 0 {
-                        catcher.New("Missing StartAt Task value")
+			catcher.New("Missing StartAt Task value")
 		}
 	}
 	return catcher.Resolve()
@@ -118,7 +118,7 @@ func (s *StartAt) validateForTests(groupBy GroupBy) error {
 	catcher := grip.NewBasicCatcher()
 	catcher.Add(s.validateCommon(groupBy))
 	if len(s.Test) == 0 {
-                catcher.New("Missing Start Test value")
+		catcher.New("Missing Start Test value")
 	}
 	return catcher.Resolve()
 }
@@ -128,7 +128,7 @@ func (s *StartAt) validateForTasks(groupBy GroupBy) error {
 	catcher := grip.NewBasicCatcher()
 	catcher.Add(s.validateCommon(groupBy))
 	if len(s.Test) != 0 {
-                catcher.New("StartAt for task stats should not have a Test value")
+		catcher.New("StartAt for task stats should not have a Test value")
 	}
 	return catcher.Resolve()
 }
@@ -154,80 +154,80 @@ type StatsFilter struct {
 
 // validateCommon performs common validations regardless of the filter's intended use.
 func (f *StatsFilter) ValidateCommon() error {
-        catcher := grip.NewBasicCatcher()
-        if f == nil {
-                catcher.New("StatsFilter should not be nil")
-        }
+	catcher := grip.NewBasicCatcher()
+	if f == nil {
+		catcher.New("StatsFilter should not be nil")
+	}
 
-        if f.GroupNumDays <= 0 {
-                catcher.New("Invalid GroupNumDays value")
-        }
-        if len(f.Requesters) == 0 {
-                catcher.New("Missing Requesters values")
-        }
-        catcher.Add(f.Sort.validate())
-        catcher.Add(f.GroupBy.validate())
+	if f.GroupNumDays <= 0 {
+		catcher.New("Invalid GroupNumDays value")
+	}
+	if len(f.Requesters) == 0 {
+		catcher.New("Missing Requesters values")
+	}
+	catcher.Add(f.Sort.validate())
+	catcher.Add(f.GroupBy.validate())
 
-        return catcher.Resolve()
+	return catcher.Resolve()
 }
 
 // validateDates performs common date validation for test / task stats.
 func (f *StatsFilter) validateDates() error {
-        catcher := grip.NewBasicCatcher()
-        if !f.AfterDate.Equal(util.GetUTCDay(f.AfterDate)) {
-                catcher.New("Invalid AfterDate value")
-        }
-        if !f.BeforeDate.Equal(util.GetUTCDay(f.BeforeDate)) {
-                catcher.New("Invalid BeforeDate value")
-        }
-        if !f.BeforeDate.After(f.AfterDate) {
-                catcher.New("Invalid AfterDate/BeforeDate values")
-        }
+	catcher := grip.NewBasicCatcher()
+	if !f.AfterDate.Equal(util.GetUTCDay(f.AfterDate)) {
+		catcher.New("Invalid AfterDate value")
+	}
+	if !f.BeforeDate.Equal(util.GetUTCDay(f.BeforeDate)) {
+		catcher.New("Invalid BeforeDate value")
+	}
+	if !f.BeforeDate.After(f.AfterDate) {
+		catcher.New("Invalid AfterDate/BeforeDate values")
+	}
 
-        return catcher.Resolve()
+	return catcher.Resolve()
 }
 
 // ValidateForTests validates that the StatsFilter struct is valid for use with test stats.
 func (f *StatsFilter) ValidateForTests() error {
-        catcher := grip.NewBasicCatcher()
+	catcher := grip.NewBasicCatcher()
 
-        catcher.Add(f.ValidateCommon())
-        catcher.Add(f.validateDates())
+	catcher.Add(f.ValidateCommon())
+	catcher.Add(f.validateDates())
 
-        if f.Limit > MaxQueryLimit || f.Limit <= 0 {
-                catcher.New("Invalid Limit value")
-        }
-        if f.StartAt != nil {
-                catcher.Add(f.StartAt.validateForTests(f.GroupBy))
-        }
-        if len(f.Tests) == 0 && len(f.Tasks) == 0 {
-                catcher.New("Missing Tests or Tasks values")
-        }
+	if f.Limit > MaxQueryLimit || f.Limit <= 0 {
+		catcher.New("Invalid Limit value")
+	}
+	if f.StartAt != nil {
+		catcher.Add(f.StartAt.validateForTests(f.GroupBy))
+	}
+	if len(f.Tests) == 0 && len(f.Tasks) == 0 {
+		catcher.New("Missing Tests or Tasks values")
+	}
 
-        return catcher.Resolve()
+	return catcher.Resolve()
 }
 
 // ValidateForTasks use with test stats validates that the StatsFilter struct is valid for use with task stats.
 func (f *StatsFilter) ValidateForTasks() error {
-        catcher := grip.NewBasicCatcher()
+	catcher := grip.NewBasicCatcher()
 
-        catcher.Add(f.ValidateCommon())
-        catcher.Add(f.validateDates())
+	catcher.Add(f.ValidateCommon())
+	catcher.Add(f.validateDates())
 
-        if f.Limit > MaxQueryLimit || f.Limit <= 0 {
-                catcher.New("Invalid Limit value")
-        }
+	if f.Limit > MaxQueryLimit || f.Limit <= 0 {
+		catcher.New("Invalid Limit value")
+	}
 	if f.StartAt != nil {
 		catcher.Add(f.StartAt.validateForTasks(f.GroupBy))
 	}
 	if len(f.Tests) > 0 {
-                catcher.New("Invalid Tests value, should be nil or empty")
+		catcher.New("Invalid Tests value, should be nil or empty")
 	}
 	if len(f.Tasks) == 0 {
-                catcher.New("Missing Tasks values")
+		catcher.New("Missing Tasks values")
 	}
 	if f.GroupBy == GroupByTest {
-                catcher.New("Invalid GroupBy value for a task filter")
+		catcher.New("Invalid GroupBy value for a task filter")
 	}
 
 	return catcher.Resolve()

--- a/model/task_history_test.go
+++ b/model/task_history_test.go
@@ -707,7 +707,7 @@ func TestGetTestHistory(t *testing.T) {
 			DisplayName:         "test",
 			BuildVariant:        "osx",
 			Project:             project,
-			StartTime:           now.Add(time.Duration(30 * time.Minute)),
+			StartTime:           now.Add(30 * time.Minute),
 			RevisionOrderNumber: 2,
 			Status:              evergreen.TaskFailed,
 		}
@@ -849,7 +849,7 @@ func TestGetTestHistory(t *testing.T) {
 		params = TestHistoryParameters{
 			TaskNames:  []string{"test"},
 			Project:    project,
-			BeforeDate: now.Add(time.Duration(15 * time.Minute)),
+			BeforeDate: now.Add(15 * time.Minute),
 			Limit:      20,
 		}
 		assert.NoError(params.SetDefaultsAndValidate())

--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -267,7 +267,9 @@ func TestFindNextTaskEmptySpec(t *testing.T) {
 	require := require.New(t)
 
 	require.NoError(db.ClearCollections(host.Collection, task.Collection))
-	defer db.ClearCollections(host.Collection, task.Collection)
+	defer func() {
+		assert.NoError(db.ClearCollections(host.Collection, task.Collection))
+	}()
 
 	hosts := []host.Host{}
 	for i := 0; i < 10; i++ {
@@ -380,7 +382,9 @@ func TestFindNextTaskWithLastTask(t *testing.T) {
 	require := require.New(t)
 
 	require.NoError(db.ClearCollections(host.Collection, task.Collection))
-	defer db.ClearCollections(host.Collection, task.Collection)
+	defer func() {
+		assert.NoError(db.ClearCollections(host.Collection, task.Collection))
+	}()
 
 	hosts := []host.Host{}
 	for i := 0; i < 10; i++ {
@@ -440,7 +444,9 @@ func TestTaskQueueGenerationTimes(t *testing.T) {
 	require := require.New(t)
 
 	require.NoError(db.ClearCollections(TaskQueuesCollection))
-	defer db.ClearCollections(TaskQueuesCollection)
+	defer func() {
+		assert.NoError(db.ClearCollections(TaskQueuesCollection))
+	}()
 
 	now := time.Now().Round(time.Millisecond).UTC()
 	taskQueue := &TaskQueue{
@@ -495,7 +501,9 @@ func TestFindDistroTaskQueue(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	require.NoError(db.ClearCollections(TaskQueuesCollection))
-	defer db.ClearCollections(TaskQueuesCollection)
+	defer func() {
+		assert.NoError(db.ClearCollections(TaskQueuesCollection))
+	}()
 
 	distroID := "distro1"
 	info := DistroQueueInfo{
@@ -537,7 +545,9 @@ func TestGetDistroQueueInfo(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	require.NoError(db.ClearCollections(TaskQueuesCollection))
-	defer db.ClearCollections(TaskQueuesCollection)
+	defer func() {
+		assert.NoError(db.ClearCollections(TaskQueuesCollection))
+	}()
 
 	distroID := "distro1"
 	info := DistroQueueInfo{

--- a/operations/admin_from_mdb.go
+++ b/operations/admin_from_mdb.go
@@ -109,7 +109,7 @@ func toMdbForLocal() cli.Command {
 					continue
 				case tar.TypeReg:
 					buf = &bytes.Buffer{}
-					io.Copy(buf, tr)
+					_, _ = io.Copy(buf, tr)
 				}
 
 				docs := []interface{}{}
@@ -123,7 +123,7 @@ func toMdbForLocal() cli.Command {
 					}
 					docs = append(docs, doc)
 				}
-				coll.InsertMany(ctx, docs)
+				_, _ = coll.InsertMany(ctx, docs)
 				grip.Infof("inserted %d docs into %s", len(docs), header.Name)
 			}
 

--- a/operations/service_deploy_smoke.go
+++ b/operations/service_deploy_smoke.go
@@ -158,7 +158,9 @@ func smokeStartEvergreen() cli.Command {
 				if err != nil {
 					return errors.Wrap(err, "error setting up Jasper RPC service")
 				}
-				defer closeServer()
+				defer func() {
+					grip.Warning(closeServer())
+				}()
 
 				clientFile, err := ioutil.TempFile("", "evergreen")
 				if err != nil {

--- a/operations/service_web.go
+++ b/operations/service_web.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/service"
-	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/queue"
@@ -60,8 +59,6 @@ func startWebService() cli.Command {
 			grip.Notice(message.Fields{"build": evergreen.BuildRevision, "process": grip.Name()})
 
 			grip.EmergencyFatal(errors.Wrap(startSystemCronJobs(ctx, env), "problem starting background work"))
-
-			_ = units.PopulateHostProvisioningConversionJobs(env)(ctx, queue)
 
 			var (
 				apiServer *http.Server

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -107,7 +107,7 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 		Convey("On storing several repo revisions, we expect a version to be created "+
 			"for each revision", func() {
 			createTime := time.Now()
-			laterCreateTime := createTime.Add(time.Duration(4 * time.Hour))
+			laterCreateTime := createTime.Add(4 * time.Hour)
 
 			revisionOne := *createTestRevision("1d97b5e8127a684f341d9fea5b3a2848f075c3b0", laterCreateTime)
 			revisionTwo := *createTestRevision("d8e95fcffa1055fb9e2793fa47fec39d61dd1500", createTime)
@@ -314,7 +314,7 @@ func TestBatchTimes(t *testing.T) {
 			"have overridden their batch times, all variants should be activated", func() {
 			project := createTestProject(nil, nil)
 			revisions := []model.Revision{
-				*createTestRevision("bar", time.Now().Add(time.Duration(-6*time.Minute))),
+				*createTestRevision("bar", time.Now().Add(-6*time.Minute)),
 			}
 			repoTracker := RepoTracker{
 				testConfig,

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -1118,7 +1118,7 @@ func TestTaskResetExecute(t *testing.T) {
 			So(resTask.DispatchTime, ShouldResemble, model.APIZeroTime)
 			dbTask, err := sc.FindTaskById("testTaskId")
 			So(err, ShouldBeNil)
-			So(string(dbTask.Secret), ShouldNotResemble, "initialSecret")
+			So(dbTask.Secret, ShouldNotResemble, "initialSecret")
 		})
 	})
 

--- a/scheduler/task_priority_cmp_test.go
+++ b/scheduler/task_priority_cmp_test.go
@@ -190,7 +190,9 @@ func TestByTaskGroupOrder(t *testing.T) {
 	require := require.New(t)
 
 	require.NoError(db.ClearCollections(model.VersionCollection))
-	defer db.ClearCollections(model.VersionCollection)
+	defer func() {
+		assert.NoError(db.ClearCollections(model.VersionCollection))
+	}()
 
 	taskComparator := &CmpBasedTaskComparator{}
 	tasks := []task.Task{

--- a/service/api_task_test.go
+++ b/service/api_task_test.go
@@ -674,7 +674,7 @@ func TestNextTask(t *testing.T) {
 					as.env = env
 				}()
 				mockEnv := &mock.Environment{}
-				mockEnv.Configure(ctx)
+				require.NoError(t, mockEnv.Configure(ctx))
 				as.env = mockEnv
 
 				h := host.Host{

--- a/service/rest_build_test.go
+++ b/service/rest_build_test.go
@@ -67,7 +67,7 @@ func TestGetBuildInfo(t *testing.T) {
 			Id:          "some-task-id",
 			DisplayName: "some-task-name",
 			Status:      "success",
-			TimeTaken:   time.Duration(100 * time.Millisecond),
+			TimeTaken:   100 * time.Millisecond,
 		}
 		build := &build.Build{
 			Id:                  buildId,
@@ -84,7 +84,7 @@ func TestGetBuildInfo(t *testing.T) {
 			ActivatedTime:       time.Now().Add(-15 * time.Minute),
 			RevisionOrderNumber: rand.Int(),
 			Tasks:               []build.TaskCache{task},
-			TimeTaken:           time.Duration(10 * time.Minute),
+			TimeTaken:           10 * time.Minute,
 			DisplayName:         "My build",
 			Requester:           evergreen.RepotrackerVersionRequester,
 		}
@@ -220,7 +220,7 @@ func TestGetBuildStatus(t *testing.T) {
 			Id:          "some-task-id",
 			DisplayName: "some-task-name",
 			Status:      "success",
-			TimeTaken:   time.Duration(100 * time.Millisecond),
+			TimeTaken:   100 * time.Millisecond,
 		}
 		build := &build.Build{
 			Id:           buildId,

--- a/service/rest_task_test.go
+++ b/service/rest_task_test.go
@@ -58,8 +58,8 @@ func insertTaskForTesting(taskId, versionId, projectName string, testResults []t
 			Description: "some-stage",
 		},
 		Aborted:          false,
-		TimeTaken:        time.Duration(100 * time.Millisecond),
-		ExpectedDuration: time.Duration(99 * time.Millisecond),
+		TimeTaken:        100 * time.Millisecond,
+		ExpectedDuration: 99 * time.Millisecond,
 	}
 
 	err := task.Insert()

--- a/service/rest_version_test.go
+++ b/service/rest_version_test.go
@@ -132,7 +132,7 @@ func TestGetRecentVersions(t *testing.T) {
 				Version:      versions[i].Id,
 				DisplayName:  "some-task-name",
 				Status:       "success",
-				TimeTaken:    time.Duration(100 * time.Millisecond),
+				TimeTaken:    100 * time.Millisecond,
 				BuildVariant: build.BuildVariant,
 			}
 			So(task.Insert(), ShouldBeNil)
@@ -614,7 +614,7 @@ func TestGetVersionStatus(t *testing.T) {
 			Id:          "some-task-id",
 			DisplayName: "some-task-name",
 			Status:      "success",
-			TimeTaken:   time.Duration(100 * time.Millisecond),
+			TimeTaken:   100 * time.Millisecond,
 		}
 		build := &build.Build{
 			Id:           "some-build-id",

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -330,7 +330,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 }
 
 func (j *patchIntentProcessor) buildCliPatchDoc(ctx context.Context, patchDoc *patch.Patch, githubOauthToken string) error {
-	defer j.intent.SetProcessed()
+	defer j.intent.SetProcessed() //nolint: errcheck
 	projectRef, err := model.FindOneProjectRef(patchDoc.Project)
 	if err != nil {
 		return errors.Wrapf(err, "Could not find project ref '%s'", patchDoc.Project)
@@ -385,7 +385,7 @@ func (j *patchIntentProcessor) buildGithubPatchDoc(ctx context.Context, patchDoc
 		})
 		return false, errors.New("github pr testing is disabled, not processing pull request")
 	}
-	defer j.intent.SetProcessed()
+	defer j.intent.SetProcessed() //nolint: errcheck
 
 	mustBeMemberOfOrg := j.env.Settings().GithubPRCreatorOrg
 	if mustBeMemberOfOrg == "" {

--- a/units/provisioning_jasper_restart.go
+++ b/units/provisioning_jasper_restart.go
@@ -197,8 +197,14 @@ func (j *jasperRestartJob) Run(ctx context.Context) {
 			j.AddError(err)
 			return
 		}
-		defer client.CloseConnection()
-
+		defer func() {
+			grip.Warning(message.WrapError(client.CloseConnection(), message.Fields{
+				"message": "could not close connection to Jasper",
+				"host":    j.host.Id,
+				"distro":  j.host.Distro.Id,
+				"job":     j.ID(),
+			}))
+		}()
 		// We use this ID to later verify the current running Jasper service.
 		// When Jasper is restarted, its ID should be different to indicate it
 		// is a new Jasper service.
@@ -254,7 +260,14 @@ func (j *jasperRestartJob) Run(ctx context.Context) {
 			j.AddError(err)
 			return
 		}
-		defer client.CloseConnection()
+		defer func() {
+			grip.Warning(message.WrapError(client.CloseConnection(), message.Fields{
+				"message": "could not close connection to Jasper",
+				"host":    j.host.Id,
+				"distro":  j.host.Distro.Id,
+				"job":     j.ID(),
+			}))
+		}()
 
 		newServiceID := client.ID()
 		if newServiceID == "" {

--- a/units/stats_host_idle_test.go
+++ b/units/stats_host_idle_test.go
@@ -23,7 +23,7 @@ func TestIncrementCostForDuration(t *testing.T) {
 	assert.NoError(t, h1.Insert())
 
 	startTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	finishTime := startTime.Add(time.Duration(time.Hour))
+	finishTime := startTime.Add(time.Hour)
 
 	j := newHostIdleJob()
 	j.env = evergreen.GetEnvironment()

--- a/units/stats_task_end_test.go
+++ b/units/stats_task_end_test.go
@@ -24,7 +24,7 @@ func TestRecordTaskCost(t *testing.T) {
 	t1 := &task.Task{
 		Id:         "t1",
 		StartTime:  time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
-		FinishTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Add(time.Duration(time.Hour)),
+		FinishTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Add(time.Hour),
 	}
 	assert.NoError(t, t1.Insert())
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7054

Since generate-lint for patches only lints based on diffs, this is a patch that lints all packages: https://evergreen.mongodb.com/version/5df40ddee3c3313103ab3f47
This seems to be slightly faster than gometalinter.

* Use same linters that we currently use on gometalinter. I'm using the version of golangci-lint for go1.9.
* Actually run evg-lint. It seems like it hasn't been producing output for a long while because `evg-lint`'s `set_exit_status` was never set (so it always returned exit code 0).
* Fix legitimate lint issues.