### PR TITLE
EVG-6186 sort patches

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -295,7 +295,7 @@ func ByBeforeRevisionWithStatusesAndRequesters(revisionOrder int, statuses []str
 			"$in": statuses,
 		},
 		ProjectKey: project,
-	}).Sort([]string{"-" + RevisionOrderNumberKey})
+	})
 }
 
 // ByTimeRun returns all tasks that are running in between two given times.

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -542,7 +542,7 @@ func (t *Task) PreviousCompletedTask(project string, statuses []string) (*Task, 
 		statuses = CompletedStatuses
 	}
 	return FindOneNoMerge(ByBeforeRevisionWithStatusesAndRequesters(t.RevisionOrderNumber, statuses, t.BuildVariant,
-		t.DisplayName, project, evergreen.SystemVersionRequesterTypes))
+		t.DisplayName, project, evergreen.SystemVersionRequesterTypes).Sort([]string{"-" + RevisionOrderNumberKey}))
 }
 
 func (t *Task) cacheExpectedDuration() error {

--- a/model/version.go
+++ b/model/version.go
@@ -241,19 +241,3 @@ func (v *Version) UpdateMergeTaskDependencies(p *Project, mergeTask *task.Task) 
 
 	return mergeTask.UpdateDependencies(mergeTaskDependencies)
 }
-
-type VersionsByOrder []Version
-
-func (v VersionsByOrder) Len() int {
-	return len(v)
-}
-
-func (v VersionsByOrder) Less(i, j int) bool {
-	return v[i].RevisionOrderNumber < v[j].RevisionOrderNumber
-}
-
-func (v VersionsByOrder) Swap(i, j int) {
-	temp := v[i]
-	v[i] = v[j]
-	v[j] = temp
-}

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"sort"
 	"testing"
 	"time"
 
@@ -65,23 +64,6 @@ func TestLastKnownGoodConfig(t *testing.T) {
 			So(db.Clear(VersionCollection), ShouldBeNil)
 		})
 	})
-}
-
-func TestVersionSortByOrder(t *testing.T) {
-	assert := assert.New(t)
-	versions := VersionsByOrder{
-		{Id: "5", RevisionOrderNumber: 5},
-		{Id: "3", RevisionOrderNumber: 3},
-		{Id: "1", RevisionOrderNumber: 1},
-		{Id: "4", RevisionOrderNumber: 4},
-		{Id: "100", RevisionOrderNumber: 100},
-	}
-	sort.Sort(versions)
-	assert.Equal("1", versions[0].Id)
-	assert.Equal("3", versions[1].Id)
-	assert.Equal("4", versions[2].Id)
-	assert.Equal("5", versions[3].Id)
-	assert.Equal("100", versions[4].Id)
 }
 
 func TestUpdateMergeTaskDependencies(t *testing.T) {

--- a/public/static/js/task_timing.js
+++ b/public/static/js/task_timing.js
@@ -391,11 +391,6 @@ mciModule.controller('TaskTimingController', function(
         .append("g")
         .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
-        // sort task data by create time
-        $scope.taskData.sort(function(a,b){
-            return moment(a.create_time).diff(moment(b.create_time));
-        })
-
         var maxTime = d3.max($scope.taskData, function(task){return yMap(task);});
         var minTime = d3.min($scope.taskData, function(task){ return yMap(task);});
 

--- a/public/static/js/task_timing.js
+++ b/public/static/js/task_timing.js
@@ -231,7 +231,7 @@ mciModule.controller('TaskTimingController', function(
         var hoverInfo;
         if (isPatch()){
             hoverInfo =  {
-                "revision" : $scope.versions[i].Revision,
+                "revision" : $scope.versions[i].Githash,
                 "duration" : formatDuration(yMap($scope.taskData[i])),
                 "id" : $scope.taskData[i].id,
                 "message" : $scope.versions[i].Description,

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -464,7 +464,7 @@ func isTaskRegression(sub *event.Subscription, t *task.Task) (bool, *alertrecord
 	}
 
 	previousTask, err := task.FindOne(task.ByBeforeRevisionWithStatusesAndRequesters(t.RevisionOrderNumber,
-		task.CompletedStatuses, t.BuildVariant, t.DisplayName, t.Project, evergreen.SystemVersionRequesterTypes))
+		task.CompletedStatuses, t.BuildVariant, t.DisplayName, t.Project, evergreen.SystemVersionRequesterTypes).Sort([]string{"-" + task.RevisionOrderNumberKey}))
 	if err != nil {
 		return false, nil, errors.Wrap(err, "error fetching previous task")
 	}
@@ -682,7 +682,7 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 
 	catcher := grip.NewBasicCatcher()
 	previousCompleteTask, err := task.FindOne(task.ByBeforeRevisionWithStatusesAndRequesters(t.task.RevisionOrderNumber,
-		task.CompletedStatuses, t.task.BuildVariant, t.task.DisplayName, t.task.Project, evergreen.SystemVersionRequesterTypes))
+		task.CompletedStatuses, t.task.BuildVariant, t.task.DisplayName, t.task.Project, evergreen.SystemVersionRequesterTypes).Sort([]string{"-" + task.RevisionOrderNumberKey}))
 	if err != nil {
 		return nil, errors.Wrap(err, "error fetching previous task")
 	}
@@ -867,7 +867,7 @@ func (t *taskTriggers) buildBreak(sub *event.Subscription) (*notification.Notifi
 		return nil, nil
 	}
 	previousTask, err := task.FindOne(task.ByBeforeRevisionWithStatusesAndRequesters(t.task.RevisionOrderNumber,
-		task.CompletedStatuses, t.task.BuildVariant, t.task.DisplayName, t.task.Project, evergreen.SystemVersionRequesterTypes))
+		task.CompletedStatuses, t.task.BuildVariant, t.task.DisplayName, t.task.Project, evergreen.SystemVersionRequesterTypes).Sort([]string{"-" + task.RevisionOrderNumberKey}))
 	if err != nil {
 		return nil, errors.Wrap(err, "error fetching previous task")
 	}


### PR DESCRIPTION
#2963 was reverted so it wouldn't be deployed before an index was built. Now that the index has been built, this PR reintroduces those changes.

There are no new changes in this PR.