### PR TITLE
EVG-6671 add query parameters to limit results

### DIFF
--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -97,7 +97,7 @@ func ByTaskIDs(ids []string) db.Q {
 	})
 }
 
-// find returns all test results that satisfy the query. Returns an empty slice no tasks match.
+// find returns all test results that satisfy the query. Returns an empty slice if no tasks match.
 func Find(query db.Q) ([]TestResult, error) {
 	tests := []TestResult{}
 	err := db.FindAllQ(Collection, query, &tests)
@@ -134,13 +134,16 @@ func Aggregate(pipeline []bson.M, results interface{}) error {
 }
 
 // TestResultsQuery is a query for returning test results to the REST v2 API.
-func TestResultsQuery(taskIds []string, testId, status string, limit, execution int) db.Q {
+func TestResultsQuery(taskIds []string, testId, testName, status string, limit, execution int) db.Q {
 	match := bson.M{
 		TaskIDKey:    bson.M{"$in": taskIds},
 		ExecutionKey: execution,
 	}
 	if status != "" {
 		match[StatusKey] = status
+	}
+	if testName != "" {
+		match[TestFileKey] = testName
 	}
 	if testId != "" {
 		match[IDKey] = bson.M{"$gte": mgobson.ObjectId(testId)}

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -121,9 +121,9 @@ type Connector interface {
 	FindTasksByProjectAndCommit(string, string, string, string, int) ([]task.Task, error)
 
 	// FindTestsByTaskId is a method to find a set of tests that correspond to
-	// a given task. It takes a taskId, testName to start from, test status to filter,
+	// a given task. It takes a taskId, testId to start from, test name and status to filter,
 	// limit, and sort to provide additional control over the results.
-	FindTestsByTaskId(string, string, string, int, int) ([]testresult.TestResult, error)
+	FindTestsByTaskId(string, string, string, string, int, int) ([]testresult.TestResult, error)
 
 	// FindUserById is a method to find a specific user given its ID.
 	FindUserById(string) (gimlet.User, error)

--- a/rest/data/test_test.go
+++ b/rest/data/test_test.go
@@ -11,24 +11,21 @@ import (
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFindTestsByTaskId(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.Clear(task.Collection))
+	assert.NoError(db.ClearCollections(task.Collection, testresult.Collection))
 
 	serviceContext := &DBConnector{}
 	numTests := 10
 	numTasks := 2
 	testObjects := make([]string, numTests)
 	for ix := range testObjects {
-		testObjects[ix] = fmt.Sprintf("object_id_%d_", ix)
+		testObjects[ix] = fmt.Sprintf("TestSuite/TestNum%d", ix)
 	}
 	sort.StringSlice(testObjects).Sort()
 
-	require.NoError(t, db.Clear(task.Collection), "Error clearing '%v' collection", task.Collection)
-	require.NoError(t, db.Clear(testresult.Collection), "Error clearing '%v' collection", testresult.Collection)
 	for i := 0; i < numTasks; i++ {
 		id := fmt.Sprintf("task_%d", i)
 		testTask := &task.Task{
@@ -54,13 +51,23 @@ func TestFindTestsByTaskId(t *testing.T) {
 	}
 
 	for i := 0; i < numTasks; i++ {
-		foundTests, err := serviceContext.FindTestsByTaskId(fmt.Sprintf("task_%d", i), "", "", 0, 0)
+		taskId := fmt.Sprintf("task_%d", i)
+		foundTests, err := serviceContext.FindTestsByTaskId(taskId, "", "", "", 0, 0)
 		assert.NoError(err)
 		assert.Len(foundTests, numTests)
-	}
-	for _, status := range []string{"pass", "fail"} {
-		for i := 0; i < numTasks; i++ {
-			foundTests, err := serviceContext.FindTestsByTaskId(fmt.Sprintf("task_%d", i), "", status, 0, 0)
+
+		foundTests, err = serviceContext.FindTestsByTaskId(taskId, "", "", "", i+1, 0)
+		assert.NoError(err)
+		assert.Len(foundTests, i+1)
+
+		for _, testName := range testObjects {
+			foundTests, err = serviceContext.FindTestsByTaskId(taskId, "", testName, "", 0, 0)
+			assert.NoError(err)
+			assert.Len(foundTests, 1)
+		}
+
+		for _, status := range []string{"pass", "fail"} {
+			foundTests, err := serviceContext.FindTestsByTaskId(fmt.Sprintf("task_%d", i), "", "", status, 0, 0)
 			assert.NoError(err)
 			assert.Equal(numTests/2, len(foundTests))
 			for _, t := range foundTests {
@@ -69,38 +76,17 @@ func TestFindTestsByTaskId(t *testing.T) {
 		}
 	}
 
-	taskId := "task_1"
-	for i := 0; i < numTests; i++ {
-		foundTests, err := serviceContext.FindTestsByTaskId(taskId, "", "", 0, 0)
-		assert.NoError(err)
-		assert.Len(foundTests, numTests)
-	}
-	taskname := "task_0"
-	limit := 2
-	for i := 0; i < numTests/limit; i++ {
-		foundTests, err := serviceContext.FindTestsByTaskId(taskname, "", "", limit, 0)
-		assert.NoError(err)
-		assert.Len(foundTests, limit)
-	}
-
-	foundTests, err := serviceContext.FindTestsByTaskId("fake_task", "", "", 0, 0)
+	foundTests, err := serviceContext.FindTestsByTaskId("fake_task", "", "", "", 0, 0)
 	assert.Error(err)
 	assert.Len(foundTests, 0)
 	apiErr, ok := err.(gimlet.ErrorResponse)
 	assert.True(ok)
 	assert.Equal(http.StatusNotFound, apiErr.StatusCode)
-
-	taskname = "task_0"
-	foundTests, err = serviceContext.FindTestsByTaskId(taskname, "", "", 1, 0)
-	assert.NoError(err)
-	assert.Len(foundTests, 1)
-	test1 := foundTests[0]
-	assert.Equal(testObjects[0], test1.TestFile)
 }
 
 func TestFindTestsByDisplayTaskId(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.Clear(task.Collection))
+	assert.NoError(db.ClearCollections(task.Collection, testresult.Collection))
 
 	serviceContext := &DBConnector{}
 	numTests := 10
@@ -111,8 +97,6 @@ func TestFindTestsByDisplayTaskId(t *testing.T) {
 	}
 	sort.StringSlice(testObjects).Sort()
 
-	require.NoError(t, db.Clear(task.Collection), "Error clearing '%v' collection", task.Collection)
-	require.NoError(t, db.Clear(testresult.Collection), "Error clearing '%v' collection", testresult.Collection)
 	for i := 0; i < numTasks; i++ {
 		id := fmt.Sprintf("task_%d", i)
 		testTask := &task.Task{
@@ -149,10 +133,10 @@ func TestFindTestsByDisplayTaskId(t *testing.T) {
 		ExecutionTasks: []string{},
 	}
 	assert.NoError(displayTaskWithoutTasks.Insert())
-	foundTests, err := serviceContext.FindTestsByTaskId("with_tasks", "", "", 0, 0)
+	foundTests, err := serviceContext.FindTestsByTaskId("with_tasks", "", "", "", 0, 0)
 	assert.NoError(err)
 	assert.Len(foundTests, 20)
-	foundTests, err = serviceContext.FindTestsByTaskId("without_tasks", "", "", 0, 0)
+	foundTests, err = serviceContext.FindTestsByTaskId("without_tasks", "", "", "", 0, 0)
 	assert.Error(err)
 	assert.Len(foundTests, 0)
 }

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -15,6 +15,7 @@ import (
 type testGetHandler struct {
 	taskId        string
 	testStatus    string
+	testName      string
 	testExecution int
 	key           string
 	limit         int
@@ -61,7 +62,7 @@ func (tgh *testGetHandler) Parse(ctx context.Context, r *http.Request) error {
 
 	tgh.testStatus = vals.Get("status")
 	tgh.key = vals.Get("start_at")
-
+	tgh.testName = vals.Get("test_name")
 	tgh.limit, err = getLimit(vals)
 	if err != nil {
 		return errors.WithStack(err)
@@ -71,7 +72,7 @@ func (tgh *testGetHandler) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
-	tests, err := tgh.sc.FindTestsByTaskId(tgh.taskId, tgh.key, tgh.testStatus, tgh.limit+1, tgh.testExecution)
+	tests, err := tgh.sc.FindTestsByTaskId(tgh.taskId, tgh.key, tgh.testName, tgh.testStatus, tgh.limit+1, tgh.testExecution)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Database error"))
 	}

--- a/rest/route/version_test.go
+++ b/rest/route/version_test.go
@@ -147,7 +147,7 @@ func (s *VersionSuite) TestFindAllBuildsForVersion() {
 	builds, ok := res.Data().([]model.Model)
 	s.True(ok)
 
-	s.Equal(2, len(builds))
+	s.Len(builds, 2)
 
 	for idx, build := range builds {
 		b, ok := (build).(*model.APIBuild)
@@ -159,6 +159,28 @@ func (s *VersionSuite) TestFindAllBuildsForVersion() {
 		s.Equal(model.NewTime(timeField), b.FinishTime)
 		s.Equal(model.ToAPIString(versionId), b.Version)
 		s.Equal(model.ToAPIString(s.bv[idx]), b.BuildVariant)
+	}
+}
+
+func (s *VersionSuite) TestFindBuildsForVersionByVariant() {
+	handler := &buildsForVersionHandler{versionId: "versionId", sc: s.sc}
+
+	for i, variant := range s.bv {
+		handler.variant = variant
+		res := handler.Run(context.Background())
+		s.Equal(http.StatusOK, res.Status())
+		s.NotNil(res)
+
+		builds, ok := res.Data().([]model.Model)
+		s.True(ok)
+
+		s.Require().Len(builds, 1)
+		b, ok := (builds[0]).(*model.APIBuild)
+		s.True(ok)
+
+		s.Equal(versionId, model.FromAPIString(b.Version))
+		s.Equal(s.bi[i], model.FromAPIString(b.Id))
+		s.Equal(variant, model.FromAPIString(b.BuildVariant))
 	}
 }
 


### PR DESCRIPTION
** Will update documentation after approval, and attach to the ticket. 
 
I outlined the following workflow for cloud in the ticket, for which we're adding a `variant` parameter to route (3) to filter results by variant, and a `task_name` parameter to route (4) to filter results by test.

(also some of these tests were messy and I couldn't resist a mild refactor)

> (1) /versions/{start_version_id} to get the RevisionOrderNumber.
> (2) /projects/{project_id}/versions — pass in this RevisionOrderNumber as the start, include the limit (would only need the version IDs from this)
> (3) /versions/{version_id}/builds gives Tasks in the TaskCache, can find the ID of the correct task (looking at display name "d", could add a parameter to get a specific build using variant name)
> (4) Can get tasks with /tasks/{task_id} or tests using /tasks/{task_id}/tests (we could add a parameter to get a specific test using "test_file")