### PR TITLE
EVG-7077 include parser project in generate tasks (w/comments)

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -202,6 +202,7 @@ func updateVersionAndParserProject(v *Version, pp *ParserProject) error {
 	if err := pp.UpsertWithConfigNumber(v.ConfigUpdateNumber, false); err != nil {
 		return errors.Wrapf(err, "database error upserting parser project '%s'", pp.Id)
 	}
+	v.ConfigUpdateNumber += 1
 	return nil
 }
 

--- a/model/generate.go
+++ b/model/generate.go
@@ -202,7 +202,6 @@ func updateVersionAndParserProject(v *Version, pp *ParserProject) error {
 	if err := pp.UpsertWithConfigNumber(v.ConfigUpdateNumber, false); err != nil {
 		return errors.Wrapf(err, "database error upserting parser project '%s'", pp.Id)
 	}
-	v.ConfigUpdateNumber += 1
 	return nil
 }
 

--- a/model/generate.go
+++ b/model/generate.go
@@ -184,15 +184,14 @@ func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProje
 // if the parser project is more recent, update contingent on that and force update the version (and vice versa)
 func updateVersionAndParserProject(v *Version, pp *ParserProject) error {
 	if pp.ConfigUpdateNumber > v.ConfigUpdateNumber {
-		//	update parser project contingent on equal config numbers
-		if err := pp.UpsertWithConfigNumber(pp.ConfigUpdateNumber, true); err != nil {
+		curNumber := pp.ConfigUpdateNumber
+		if err := pp.UpsertWithConfigNumber(curNumber, true); err != nil {
 			return errors.Wrapf(err, "error upserting parser project '%s'", pp.Id)
 		}
 
-		if err := VersionUpdateConfig(v.Id, v.Config, pp.ConfigUpdateNumber, false); err != nil {
+		if err := VersionUpdateConfig(v.Id, v.Config, curNumber, false); err != nil {
 			return errors.Wrapf(err, "database error updating version '%s'", v.Id)
 		}
-
 		return nil
 	}
 

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -833,6 +833,11 @@ func TestUpdateVersionAndParserProject(t *testing.T) {
 			assert.NoError(t, v.Insert())
 			assert.NoError(t, pp.Insert())
 		},
+		"WithZero": func(t *testing.T, v *Version, pp *ParserProject) {
+			v.ConfigUpdateNumber = 0
+			assert.NoError(t, v.Insert())
+			assert.NoError(t, pp.Insert())
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(VersionCollection, ParserProjectCollection))
@@ -846,6 +851,11 @@ func TestUpdateVersionAndParserProject(t *testing.T) {
 			pp, err = ParserProjectFindOneById(v.Id)
 			assert.NoError(t, err)
 			require.NotNil(t, pp)
+			if testName == "WithZero" {
+				assert.Equal(t, 1, v.ConfigUpdateNumber)
+				assert.Equal(t, 1, pp.ConfigUpdateNumber)
+				return
+			}
 			assert.Equal(t, 6, v.ConfigUpdateNumber)
 			assert.Equal(t, 6, pp.ConfigUpdateNumber)
 		})

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -5,14 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 	"gopkg.in/yaml.v2"
@@ -607,6 +605,10 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	p, pp, v, t, pm, err := g.NewVersion()
 	s.Require().NoError(err)
 	s.NoError(g.Save(context.Background(), p, pp, v, t, pm))
+
+	v, err = VersionFindOneId(v.Id)
+	s.NoError(err)
+	s.Require().NotNil(v)
 	s.Equal(5, v.ConfigUpdateNumber)
 	builds, err := build.Find(db.Query(bson.M{}))
 	s.NoError(err)
@@ -673,6 +675,10 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 	p, pp, v, t, pm, err := g.NewVersion()
 	s.NoError(err)
 	s.NoError(g.Save(context.Background(), p, pp, v, t, pm))
+
+	v, err = VersionFindOneId(v.Id)
+	s.NoError(err)
+	s.Require().NotNil(v)
 	s.Equal(1, v.ConfigUpdateNumber)
 	tasks := []task.Task{}
 	err = db.FindAllQ(task.Collection, db.Query(bson.M{}), &tasks)
@@ -795,6 +801,10 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 	p, pp, v, t, pm, err := g.NewVersion()
 	s.Require().NoError(err)
 	s.NoError(g.Save(context.Background(), p, pp, v, t, pm))
+
+	v, err = VersionFindOneId(v.Id)
+	s.NoError(err)
+	s.Require().NotNil(v)
 	s.Equal(1, v.ConfigUpdateNumber)
 
 	tasks := []task.Task{}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -468,14 +468,11 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 
 	// TODO: don't need separate ppFromDB variable once UseParserProject = true
 	if shouldSave && ppFromDB == nil {
-		// we upsert here instead of insert bc it is possible that since this function started a project has been inserted, and we don't want to error in that case
-		if err = pp.UpsertWithConfigNumber(pp.ConfigUpdateNumber); err != nil {
+		if err = pp.TryUpsert(); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
-				"project":                 identifier,
-				"version":                 v.Id,
-				"attempted_update_number": pp.ConfigUpdateNumber,
-				"current_update_num":      v.ConfigUpdateNumber,
-				"message":                 "error upserting parser project for version",
+				"project": identifier,
+				"version": v.Id,
+				"message": "error inserting parser project for version",
 			}))
 			return nil, nil, errors.Wrap(err, "error updating version with project")
 		}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -445,10 +445,13 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 	}
 
 	if evergreen.UseParserProject && ppFromDB != nil {
-		// TODO: check here for ppFromDB.ConfigUpdateNumber >= v.ConfigUpdateNumber
-		ppFromDB.Identifier = identifier
-		p, err := TranslateProject(ppFromDB)
-		return p, ppFromDB, err
+		// if parser project config number is old then there was a race,
+		// and we should default to the version config
+		if ppFromDB.ConfigUpdateNumber >= v.ConfigUpdateNumber {
+			ppFromDB.Identifier = identifier
+			p, err := TranslateProject(ppFromDB)
+			return p, ppFromDB, err
+		}
 	}
 
 	if v.Config == "" {
@@ -465,12 +468,15 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 
 	// TODO: don't need separate ppFromDB variable once UseParserProject = true
 	if shouldSave && ppFromDB == nil {
-		if err = pp.Insert(); err != nil {
+		// we upsert here instead of insert bc it is possible that since this function started a project has been inserted, and we don't want to error in that case
+		// https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20%22error%20inserting%20parser%20project%22&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=1575954000&latest=1576645200&sid=1576609915.8744045
+		if err = pp.UpsertWithConfigNumber(pp.ConfigUpdateNumber); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
-				"project":       identifier,
-				"version":       v.Id,
-				"config_number": v.ConfigUpdateNumber,
-				"message":       "error inserting parser project for version",
+				"project":                 identifier,
+				"version":                 v.Id,
+				"attempted_update_number": pp.ConfigUpdateNumber,
+				"current_update_num":      v.ConfigUpdateNumber,
+				"message":                 "error upserting parser project for version",
 			}))
 			return nil, nil, errors.Wrap(err, "error updating version with project")
 		}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -469,7 +469,6 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 	// TODO: don't need separate ppFromDB variable once UseParserProject = true
 	if shouldSave && ppFromDB == nil {
 		// we upsert here instead of insert bc it is possible that since this function started a project has been inserted, and we don't want to error in that case
-		// https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20%22error%20inserting%20parser%20project%22&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=1575954000&latest=1576645200&sid=1576609915.8744045
 		if err = pp.UpsertWithConfigNumber(pp.ConfigUpdateNumber); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"project":                 identifier,

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -63,8 +63,8 @@ func ParserProjectUpdateOne(query interface{}, update interface{}) error {
 	)
 }
 
-// UpsertWithConfigNumber inserts project if it DNE
-// otherwise, updates if the existing config number is less than or equal to the new config number
+// UpsertWithConfigNumber inserts project if it DNE. Otherwise, updates if the
+// existing config number is less than or equal to the new config number.
 func (pp *ParserProject) UpsertWithConfigNumber(num int) error {
 	if pp.Id == "" {
 		return errors.New("no version ID given")
@@ -85,12 +85,10 @@ func (pp *ParserProject) UpsertWithConfigNumber(num int) error {
 	// or we check before updating if $lte but potentially racey
 	err = ParserProjectUpdateOne(
 		bson.M{
-			"$and": []bson.M{
-				{ParserProjectIdKey: pp.Id},
-				{"$or": []bson.M{
-					bson.M{ParserProjectConfigNumberKey: bson.M{"$exists": false}},
-					bson.M{ParserProjectConfigNumberKey: bson.M{"$lte": num}},
-				}},
+			ParserProjectIdKey: pp.Id,
+			"$or": []bson.M{
+				bson.M{ParserProjectConfigNumberKey: bson.M{"$exists": false}},
+				bson.M{ParserProjectConfigNumberKey: bson.M{"$lte": num}},
 			},
 		},
 		bson.M{
@@ -124,12 +122,12 @@ func (pp *ParserProject) UpsertWithConfigNumber(num int) error {
 			},
 		})
 	if adb.ResultsNotFound(err) {
-		grip.Debug(message.Fields{
+		grip.Debug(message.WrapError(err, message.Fields{
 			"message":                 "parser project not updated",
 			"version":                 pp.Id,
 			"attempted_update_number": pp.ConfigUpdateNumber,
 			"current_update_num":      num,
-		})
+		}))
 		return nil
 	}
 	return errors.Wrapf(err, "error updating parser project '%s'", pp.Id)

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -103,12 +103,10 @@ func setAllFieldsUpdate(pp *ParserProject) interface{} {
 func checkConfigNumberQuery(id string, configNum int) bson.M {
 	q := bson.M{ParserProjectIdKey: id}
 	if configNum == 0 {
-		q["$or"] = []bson.M{
-			bson.M{ParserProjectConfigNumberKey: bson.M{"$exists": false}},
-			bson.M{ParserProjectConfigNumberKey: configNum},
-		}
+		q[ParserProjectConfigNumberKey] = bson.M{"$exists": false}
 		return q
 	}
+
 	q[ParserProjectConfigNumberKey] = configNum
 	return q
 }

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -103,7 +103,10 @@ func setAllFieldsUpdate(pp *ParserProject) interface{} {
 func checkConfigNumberQuery(id string, configNum int) bson.M {
 	q := bson.M{ParserProjectIdKey: id}
 	if configNum == 0 {
-		q[ParserProjectConfigNumberKey] = bson.M{"$exists": false}
+		q["$or"] = []bson.M{
+			bson.M{ParserProjectConfigNumberKey: bson.M{"$exists": false}},
+			bson.M{ParserProjectConfigNumberKey: configNum},
+		}
 		return q
 	}
 
@@ -155,8 +158,8 @@ func (pp *ParserProject) UpsertWithConfigNumber(num int, shouldEqual bool) error
 	return nil
 }
 
+// return true if this is an error we want to expose
 func isValidErr(err error) bool {
-	// suppress results not found errors and dup key errors
 	if err == nil || adb.ResultsNotFound(err) || strings.Contains(err.Error(), "duplicate key error") {
 		return false
 	}

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1384,7 +1384,7 @@ func checkProjectPersists(yml []byte) error {
 		return errors.Wrapf(err, "error marshalling original project")
 	}
 
-	if err = pp.UpsertWithConfigNumber(1); err != nil {
+	if err = pp.TryUpsert(); err != nil {
 		return errors.Wrapf(err, "error inserting parser project")
 	}
 	newPP, err := ParserProjectFindOneById(pp.Id)
@@ -1406,7 +1406,7 @@ func checkProjectPersists(yml []byte) error {
 	if err != nil {
 		return errors.Wrap(err, "error creating intermediate project from stored config")
 	}
-	if err = pp.UpsertWithConfigNumber(2); err != nil {
+	if err = pp.TryUpsert(); err != nil {
 		return errors.Wrap(err, "error updating version's project")
 	}
 
@@ -1416,9 +1416,6 @@ func checkProjectPersists(yml []byte) error {
 	}
 	if newPP.Identifier != pp.Identifier {
 		return errors.New("version project not updated")
-	}
-	if newPP.ConfigUpdateNumber != 2 {
-		return errors.New("Config update number wrong")
 	}
 
 	return nil

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -295,14 +295,16 @@ func VersionUpdateOne(query interface{}, update interface{}) error {
 	)
 }
 
-func VersionUpdateConfig(id, config string, configUpdateNumber int) error {
-	query := bson.M{
-		VersionIdKey:           id,
-		VersionConfigNumberKey: configUpdateNumber,
+func VersionUpdateConfig(id, config string, configUpdateNumber int, shouldEqual bool) error {
+	query := bson.M{VersionIdKey: id}
+	if shouldEqual {
+		query[VersionConfigNumberKey] = configUpdateNumber
 	}
 	update := bson.M{
-		"$set": bson.M{VersionConfigKey: config},
-		"$inc": bson.M{VersionConfigNumberKey: 1},
+		"$set": bson.M{
+			VersionConfigKey:       config,
+			VersionConfigNumberKey: configUpdateNumber + 1,
+		},
 	}
 	return VersionUpdateOne(query, update)
 }


### PR DESCRIPTION
I think implementing that commented code in Save() would be the way to ensure the two stay at the most updated version. I think a next step would be switching `pp.ConfigUpdateNumber > v.ConfigUpdateNumber` to `>=` (potentially at the same time we toggle UseParserProject, or I could just add that as another if statement to avoid the toggle).

If we use the code as it is now (i.e. without implementing the commented code) we could see the following race when UseParserProject is true:

- Version has num 2, Parser Project has num 4, so we generate using the parser project document.
- We store version verifying with the version config number 2, so version is now at 3.
- We don't store parser project because 3 < 4. (unless we don't check `$lte` in which case we just overwrite, possibly the case of parserProject num >= version num shouldn't happen anyway)
- Agent 2 uses parser project to generate next, even though it's outdated, bc the number is higher.

(Another potential way around that is during the "update document contingent on equal config numbers" we pass in the higher number to actually update it to rather than using `$inc`.)

Specifically "update version" and "update parser project" means updating the document even if the config update number isn't entirely accurate, however I can't decide if this should check "$lte" still or just override regardless to ensure they're the same. Could potentially lose data that way. 
 