### PR TITLE
EVG-6934 compare url config

### DIFF
--- a/model/github_hook.go
+++ b/model/github_hook.go
@@ -144,17 +144,17 @@ func GetExistingGithubHook(ctx context.Context, settings evergreen.Settings, own
 	}
 	defer util.PutHTTPClient(httpClient)
 	client := github.NewClient(httpClient)
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	newCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	respHooks, _, err := client.Repositories.ListHooks(ctx, owner, repo, nil)
+	respHooks, _, err := client.Repositories.ListHooks(newCtx, owner, repo, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't get hooks for owner '%s', repo '%s'", owner, repo)
 	}
 
 	url := fmt.Sprintf(githubHookURLString, settings.ApiUrl)
 	for _, hook := range respHooks {
-		if hook.GetURL() == url {
+		if hook.Config["url"] == url {
 			return &GithubHook{
 				HookID: int(hook.GetID()),
 				Owner:  owner,


### PR DESCRIPTION
This ticket is to fix EVG-6540, i.e. use an existing webhook if applicable.

The main thing I see is that we expect `hook.GetURL()` to equal the `config.url` that we set in CreateHooks, but the github [documentation](https://developer.github.com/v3/repos/hooks/#create-a-hook) implies that the hook URL isn't made from the config.url.