### PR TITLE
EVG-7013 Extra notifications

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -74,6 +74,8 @@ func SetVersionActivation(versionId string, active bool, caller string) error {
 		buildIDs = append(buildIDs, build.Id)
 	}
 
+	// Update activation for all builds before updating their tasks so the version won't spend
+	// time in an intermediate state where only some builds are updated
 	if err = build.UpdateActivation(buildIDs, active, caller); err != nil {
 		return errors.Wrapf(err, "can't set activation for builds in '%s'", versionId)
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -90,7 +90,7 @@ func SetVersionActivation(versionId string, active bool, caller string) error {
 // It also updates the task cache for the build document.
 func SetBuildActivation(buildId string, active bool, caller string, skipDependencies bool) error {
 	if err := build.UpdateActivation([]string{buildId}, active, caller); err != nil {
-		return errors.WithStack(err)
+		return errors.Wrapf(err, "can't set build activation to %t for build '%s'", active, buildId)
 	}
 
 	return errors.Wrapf(SetTaskActivationForBuild(buildId, active, caller, skipDependencies), "can't set task activation for build '%s'", buildId)

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -860,9 +860,9 @@ func FindAllTaskIDsFromBuild(buildId string) ([]string, error) {
 }
 
 // FindTasksFromBuildWithDependencies finds tasks from a build that have dependencies.
-func FindTasksFromBuildWithDependencies(buildId string) ([]Task, error) {
+func FindTasksFromBuildWithDependencies(buildIds []string) ([]Task, error) {
 	q := db.Query(bson.M{
-		BuildIdKey:   buildId,
+		BuildIdKey:   bson.M{"$in": buildIds},
 		DependsOnKey: bson.M{"$not": bson.M{"$size": 0}},
 	}).WithFields(IdKey, DependsOnKey)
 	tasks := []Task{}

--- a/service/version.go
+++ b/service/version.go
@@ -253,6 +253,8 @@ func (uis *UIServer) modifyVersion(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// abort after deactivating the version so we aren't bombarded with failing tasks while
+		// the deactivation is in progress
 		if jsonMap.Abort {
 			if err = model.AbortVersion(projCtx.Version.Id, authName); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/service/version.go
+++ b/service/version.go
@@ -248,16 +248,18 @@ func (uis *UIServer) modifyVersion(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case "set_active":
+		if err = model.SetVersionActivation(projCtx.Version.Id, jsonMap.Active, user.Id); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
 		if jsonMap.Abort {
 			if err = model.AbortVersion(projCtx.Version.Id, authName); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 		}
-		if err = model.SetVersionActivation(projCtx.Version.Id, jsonMap.Active, user.Id); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+
 		if !jsonMap.Active && projCtx.Version.Requester == evergreen.MergeTestRequester {
 			_, err := commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
 				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Version.Id, true)


### PR DESCRIPTION
Deactivating a version takes a long time when there are many tasks. While the version is in an intermediate state where some builds are deactivated and some are active, there's an execution path where every task to finish will be considered to be the last task in the version to finish*. If in-flight tasks are also aborted this exacerbates the problem since many tasks will be finishing while the version is in the intermediate state.

The fixes here are to:
- Abort tasks **after** we've deactivated builds and tasks
- Deactivate all the builds and then all the tasks (as opposed to interleaving them). This minimizes the time the version is in the intermediate state where some builds are still activated.

\* For the record, what happened was: the version was unscheduled with the option to abort in-flight tasks. However, some builds had completed with a successful status. The API call took about 20 seconds. While the only build left to deactivate was a successful build it was the only build considered and for every task that finished and called MarkEnd we decided the version was complete. In this execution path, the version logging considers the failed tasks but not the patch logging, so the version events say the version has failed while the patch events say the patch has succeeded.