### PR TITLE
EVG-6186 sort by patch create_time

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1187,12 +1187,7 @@ func (m *ec2Manager) CostForDuration(ctx context.Context, h *host.Host, start, e
 	if end.Before(start) || util.IsZeroTime(start) || util.IsZeroTime(end) {
 		return 0, errors.New("task timing data is malformed")
 	}
-	ec2Settings := &EC2ProviderSettings{}
-	err := ec2Settings.fromDistroSettings(h.Distro)
-	if err != nil {
-		return 0, errors.Wrap(err, "problem getting region from host")
-	}
-	if err = m.client.Create(m.credentials, m.region); err != nil {
+	if err := m.client.Create(m.credentials, m.region); err != nil {
 		return 0, errors.Wrap(err, "error creating client")
 	}
 	defer m.client.Close()

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -327,6 +327,34 @@ func (m *ec2FleetManager) TimeTilNextPayment(h *host.Host) time.Duration {
 	return timeTilNextEC2Payment(h)
 }
 
+func (m *ec2FleetManager) CostForDuration(ctx context.Context, h *host.Host, start, end time.Time) (float64, error) {
+	if end.Before(start) || util.IsZeroTime(start) || util.IsZeroTime(end) {
+		return 0, errors.New("task timing data is malformed")
+	}
+
+	if err := m.client.Create(m.credentials, m.region); err != nil {
+		return 0, errors.Wrap(err, "error creating client")
+	}
+	defer m.client.Close()
+
+	t := timeRange{start: start, end: end}
+	ec2Cost, err := pkgCachingPriceFetcher.getEC2Cost(ctx, m.client, h, t)
+	if err != nil {
+		return 0, errors.Wrap(err, "error fetching ec2 cost")
+	}
+	ebsCost, err := pkgCachingPriceFetcher.getEBSCost(ctx, m.client, h, t)
+	if err != nil {
+		return 0, errors.Wrap(err, "error fetching ebs cost")
+	}
+	total := ec2Cost + ebsCost
+
+	if total < 0 {
+		return 0, errors.Errorf("cost appears to be less than 0 (%g) which is impossible", total)
+	}
+
+	return total, nil
+}
+
 func (m *ec2FleetManager) spawnFleetSpotHost(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings, blockDevices []*ec2.LaunchTemplateBlockDeviceMappingRequest) error {
 	// Cleanup
 	var templateID *string

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -148,6 +149,21 @@ func TestFleet(t *testing.T) {
 				AvailabilityZone: aws.String("us-east-1a"),
 			}
 			assert.True(t, subnetMatchesAz(subnet))
+		},
+		"CostForDuration": func(*testing.T) {
+			start := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+			end := start.Add(time.Duration(time.Hour * 24))
+			h := &host.Host{
+				ComputeCostPerHour: float64(1),
+				VolumeTotalSize:    int64(30),
+				Zone:               "us-east-1a",
+			}
+			pkgCachingPriceFetcher.ebsPrices = make(map[string]float64)
+			pkgCachingPriceFetcher.ebsPrices["us-east-1"] = float64(1)
+
+			cost, err := m.CostForDuration(context.Background(), h, start, end)
+			assert.NoError(t, err)
+			assert.EqualValues(t, 25, cost)
 		},
 	} {
 		h = &host.Host{

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -410,3 +410,17 @@ func MakeMergePatch(pr *github.PullRequest, projectID, alias string) (*Patch, er
 
 	return patchDoc, nil
 }
+
+type PatchesByCreateTime []Patch
+
+func (p PatchesByCreateTime) Len() int {
+	return len(p)
+}
+
+func (p PatchesByCreateTime) Less(i, j int) bool {
+	return p[i].CreateTime.Before(p[j].CreateTime)
+}
+
+func (p PatchesByCreateTime) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -1,6 +1,7 @@
 package patch
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -202,4 +203,21 @@ func (s *patchSuite) TestUpdateGithashProjectAndTasks() {
 
 	s.Require().NotEmpty(patch.VariantsTasks)
 	s.Equal("variant1", dbPatch.VariantsTasks[0].Variant)
+}
+
+func TestPatchSortByCreateTime(t *testing.T) {
+	assert := assert.New(t)
+	patches := PatchesByCreateTime{
+		{PatchNumber: 5, CreateTime: time.Now().Add(time.Hour * 3)},
+		{PatchNumber: 3, CreateTime: time.Now().Add(time.Hour)},
+		{PatchNumber: 1, CreateTime: time.Now()},
+		{PatchNumber: 4, CreateTime: time.Now().Add(time.Hour * 2)},
+		{PatchNumber: 100, CreateTime: time.Now().Add(time.Hour * 4)},
+	}
+	sort.Sort(patches)
+	assert.Equal(1, patches[0].PatchNumber)
+	assert.Equal(3, patches[1].PatchNumber)
+	assert.Equal(4, patches[2].PatchNumber)
+	assert.Equal(5, patches[3].PatchNumber)
+	assert.Equal(100, patches[4].PatchNumber)
 }

--- a/model/version.go
+++ b/model/version.go
@@ -241,3 +241,17 @@ func (v *Version) UpdateMergeTaskDependencies(p *Project, mergeTask *task.Task) 
 
 	return mergeTask.UpdateDependencies(mergeTaskDependencies)
 }
+
+type VersionsByCreateTime []Version
+
+func (v VersionsByCreateTime) Len() int {
+	return len(v)
+}
+
+func (v VersionsByCreateTime) Less(i, j int) bool {
+	return v[i].CreateTime.Before(v[j].CreateTime)
+}
+
+func (v VersionsByCreateTime) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -64,6 +65,23 @@ func TestLastKnownGoodConfig(t *testing.T) {
 			So(db.Clear(VersionCollection), ShouldBeNil)
 		})
 	})
+}
+
+func TestVersionSortByCreateTime(t *testing.T) {
+	assert := assert.New(t)
+	versions := VersionsByCreateTime{
+		{Id: "5", CreateTime: time.Now().Add(time.Hour * 3)},
+		{Id: "3", CreateTime: time.Now().Add(time.Hour)},
+		{Id: "1", CreateTime: time.Now()},
+		{Id: "4", CreateTime: time.Now().Add(time.Hour * 2)},
+		{Id: "100", CreateTime: time.Now().Add(time.Hour * 4)},
+	}
+	sort.Sort(versions)
+	assert.Equal("1", versions[0].Id)
+	assert.Equal("3", versions[1].Id)
+	assert.Equal("4", versions[2].Id)
+	assert.Equal("5", versions[3].Id)
+	assert.Equal("100", versions[4].Id)
 }
 
 func TestUpdateMergeTaskDependencies(t *testing.T) {

--- a/units/stats_host_idle.go
+++ b/units/stats_host_idle.go
@@ -163,7 +163,8 @@ func (j *collectHostIdleDataJob) incrementCostForDuration(ctx context.Context) (
 
 	calc, ok := j.manager.(cloud.CostCalculator)
 	if !ok {
-		return 0, errors.Errorf("manager of type '%T' isn't a cost calculator", j.manager)
+		// return early if we can't get the cost
+		return 0, nil
 	}
 
 	cost, err := calc.CostForDuration(ctx, j.host, j.StartTime, j.FinishTime)

--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -168,7 +168,8 @@ func (j *collectTaskEndDataJob) recordTaskCost(ctx context.Context) error {
 
 	calc, ok := manager.(cloud.CostCalculator)
 	if !ok {
-		return errors.Errorf("manager of type '%T' is not a cost calculator", manager)
+		// return early if we can't get the cost
+		return nil
 	}
 	cost, err := calc.CostForDuration(ctx, j.host, j.task.StartTime, j.task.FinishTime)
 	if err != nil {


### PR DESCRIPTION
#2971 displays task history sorted by create_time of the tasks/builds. Since this is defined differently for tasks/builds and patches/versions and the create_time shown on the page is that of patches/versions, they still appear out of order. Additionally, the definition of create_time for patches/versions is probably what we're after anyway.
This PR aligns builds/tasks with patches/versions sorted on create_time.