### PR TITLE
EVG-6186 order by patch/version create time

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -410,3 +410,17 @@ func MakeMergePatch(pr *github.PullRequest, projectID, alias string) (*Patch, er
 
 	return patchDoc, nil
 }
+
+type PatchesByCreateTime []Patch
+
+func (p PatchesByCreateTime) Len() int {
+	return len(p)
+}
+
+func (p PatchesByCreateTime) Less(i, j int) bool {
+	return p[i].CreateTime.Before(p[j].CreateTime)
+}
+
+func (p PatchesByCreateTime) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -1,6 +1,7 @@
 package patch
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -202,4 +203,21 @@ func (s *patchSuite) TestUpdateGithashProjectAndTasks() {
 
 	s.Require().NotEmpty(patch.VariantsTasks)
 	s.Equal("variant1", dbPatch.VariantsTasks[0].Variant)
+}
+
+func TestPatchSortByCreateTime(t *testing.T) {
+	assert := assert.New(t)
+	patches := PatchesByCreateTime{
+		{PatchNumber: 5, CreateTime: time.Now().Add(time.Hour * 3)},
+		{PatchNumber: 3, CreateTime: time.Now().Add(time.Hour)},
+		{PatchNumber: 1, CreateTime: time.Now()},
+		{PatchNumber: 4, CreateTime: time.Now().Add(time.Hour * 2)},
+		{PatchNumber: 100, CreateTime: time.Now().Add(time.Hour * 4)},
+	}
+	sort.Sort(patches)
+	assert.Equal(1, patches[0].PatchNumber)
+	assert.Equal(3, patches[1].PatchNumber)
+	assert.Equal(4, patches[2].PatchNumber)
+	assert.Equal(5, patches[3].PatchNumber)
+	assert.Equal(100, patches[4].PatchNumber)
 }

--- a/model/version.go
+++ b/model/version.go
@@ -241,3 +241,17 @@ func (v *Version) UpdateMergeTaskDependencies(p *Project, mergeTask *task.Task) 
 
 	return mergeTask.UpdateDependencies(mergeTaskDependencies)
 }
+
+type VersionsByCreateTime []Version
+
+func (v VersionsByCreateTime) Len() int {
+	return len(v)
+}
+
+func (v VersionsByCreateTime) Less(i, j int) bool {
+	return v[i].CreateTime.Before(v[j].CreateTime)
+}
+
+func (v VersionsByCreateTime) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -64,6 +65,23 @@ func TestLastKnownGoodConfig(t *testing.T) {
 			So(db.Clear(VersionCollection), ShouldBeNil)
 		})
 	})
+}
+
+func TestVersionSortByCreateTime(t *testing.T) {
+	assert := assert.New(t)
+	versions := VersionsByCreateTime{
+		{Id: "5", CreateTime: time.Now().Add(time.Hour * 3)},
+		{Id: "3", CreateTime: time.Now().Add(time.Hour)},
+		{Id: "1", CreateTime: time.Now()},
+		{Id: "4", CreateTime: time.Now().Add(time.Hour * 2)},
+		{Id: "100", CreateTime: time.Now().Add(time.Hour * 4)},
+	}
+	sort.Sort(versions)
+	assert.Equal("1", versions[0].Id)
+	assert.Equal("3", versions[1].Id)
+	assert.Equal("4", versions[2].Id)
+	assert.Equal("5", versions[3].Id)
+	assert.Equal("100", versions[4].Id)
 }
 
 func TestUpdateMergeTaskDependencies(t *testing.T) {


### PR DESCRIPTION
#2971 displays task history sorted by create_time of the tasks/builds. Since this is defined differently for tasks/builds and patches/versions and the create_time shown on the page is that of patches/versions, they still appear out of order. Moreover, the definition of create_time for patches/versions is probably what we're after anyway.

This PR aligns builds/tasks with patches/versions sorted on create_time.