### PR TITLE
EVG-6844 rename misleading query

### DIFF
--- a/model/build/db.go
+++ b/model/build/db.go
@@ -107,8 +107,8 @@ func ByRevisionAndVariant(revision, variant string) db.Q {
 	})
 }
 
-// ByRevision creates a query that returns all builds for a revision.
-func ByRevision(revision string) db.Q {
+// ByRevisionWithSystemVersionRequester creates a query that returns all builds for a revision.
+func ByRevisionWithSystemVersionRequester(revision string) db.Q {
 	return db.Query(bson.M{
 		RevisionKey: revision,
 		RequesterKey: bson.M{

--- a/service/version.go
+++ b/service/version.go
@@ -96,7 +96,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 		versionAsUI.PatchInfo = &uiPatch{Patch: *projCtx.Patch}
 		// diff builds for each build in the version
 		var baseBuilds []build.Build
-		baseBuilds, err = build.Find(build.ByRevision(projCtx.Version.Revision))
+		baseBuilds, err = build.Find(build.ByRevisionWithSystemVersionRequester(projCtx.Version.Revision))
 		if err != nil {
 			http.Error(w,
 				fmt.Sprintf("error loading base builds for patch: %v", err),


### PR DESCRIPTION
This ticket was made because looking up base builds just by revision would be incorrect (as other patches would also have this revision), but actually the query is correct since it checks Requester, it's just misleadingly named.