### PR TITLE
EVG-7056 cache spot instance pricing

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1187,12 +1187,7 @@ func (m *ec2Manager) CostForDuration(ctx context.Context, h *host.Host, start, e
 	if end.Before(start) || util.IsZeroTime(start) || util.IsZeroTime(end) {
 		return 0, errors.New("task timing data is malformed")
 	}
-	ec2Settings := &EC2ProviderSettings{}
-	err := ec2Settings.fromDistroSettings(h.Distro)
-	if err != nil {
-		return 0, errors.Wrap(err, "problem getting region from host")
-	}
-	if err = m.client.Create(m.credentials, m.region); err != nil {
+	if err := m.client.Create(m.credentials, m.region); err != nil {
 		return 0, errors.Wrap(err, "error creating client")
 	}
 	defer m.client.Close()

--- a/cloud/ec2_cost_test.go
+++ b/cloud/ec2_cost_test.go
@@ -404,14 +404,14 @@ func (s *CostIntegrationSuite) TestGetProviderAuto() {
 
 	settings.InstanceType = "m4.large"
 	settings.IsVpc = true
-	m4LargeSpot, az, err := pkgCachingPriceFetcher.getLatestLowestSpotCostForInstance(ctx, s.m.client, settings, getOsName(s.h))
+	m4LargeSpot, az, err := pkgCachingPriceFetcher.getLatestSpotCostForInstance(ctx, s.m.client, settings, getOsName(s.h), "")
 	s.Contains(az, "us-east")
 	s.True(m4LargeSpot > 0)
 	s.NoError(err)
 
 	settings.InstanceType = "t2.micro"
 	settings.IsVpc = true
-	t2MicroSpot, az, err := pkgCachingPriceFetcher.getLatestLowestSpotCostForInstance(ctx, s.m.client, settings, getOsName(s.h))
+	t2MicroSpot, az, err := pkgCachingPriceFetcher.getLatestSpotCostForInstance(ctx, s.m.client, settings, getOsName(s.h), "")
 	s.Contains(az, "us-east")
 	s.True(t2MicroSpot > 0)
 	s.NoError(err)

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -327,6 +327,34 @@ func (m *ec2FleetManager) TimeTilNextPayment(h *host.Host) time.Duration {
 	return timeTilNextEC2Payment(h)
 }
 
+func (m *ec2FleetManager) CostForDuration(ctx context.Context, h *host.Host, start, end time.Time) (float64, error) {
+	if end.Before(start) || util.IsZeroTime(start) || util.IsZeroTime(end) {
+		return 0, errors.New("task timing data is malformed")
+	}
+
+	if err := m.client.Create(m.credentials, m.region); err != nil {
+		return 0, errors.Wrap(err, "error creating client")
+	}
+	defer m.client.Close()
+
+	t := timeRange{start: start, end: end}
+	ec2Cost, err := pkgCachingPriceFetcher.getEC2Cost(ctx, m.client, h, t)
+	if err != nil {
+		return 0, errors.Wrap(err, "error fetching ec2 cost")
+	}
+	ebsCost, err := pkgCachingPriceFetcher.getEBSCost(ctx, m.client, h, t)
+	if err != nil {
+		return 0, errors.Wrap(err, "error fetching ebs cost")
+	}
+	total := ec2Cost + ebsCost
+
+	if total < 0 {
+		return 0, errors.Errorf("cost appears to be less than 0 (%g) which is impossible", total)
+	}
+
+	return total, nil
+}
+
 func (m *ec2FleetManager) spawnFleetSpotHost(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings, blockDevices []*ec2.LaunchTemplateBlockDeviceMappingRequest) error {
 	// Cleanup
 	var templateID *string

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -152,7 +152,7 @@ func TestFleet(t *testing.T) {
 		},
 		"CostForDuration": func(*testing.T) {
 			start := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-			end := start.Add(time.Duration(time.Hour * 24))
+			end := start.Add(time.Hour * 24)
 			h := &host.Host{
 				ComputeCostPerHour: float64(1),
 				VolumeTotalSize:    int64(30),

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -148,6 +149,21 @@ func TestFleet(t *testing.T) {
 				AvailabilityZone: aws.String("us-east-1a"),
 			}
 			assert.True(t, subnetMatchesAz(subnet))
+		},
+		"CostForDuration": func(*testing.T) {
+			start := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+			end := start.Add(time.Duration(time.Hour * 24))
+			h := &host.Host{
+				ComputeCostPerHour: float64(1),
+				VolumeTotalSize:    int64(30),
+				Zone:               "us-east-1a",
+			}
+			pkgCachingPriceFetcher.ebsPrices = make(map[string]float64)
+			pkgCachingPriceFetcher.ebsPrices["us-east-1"] = float64(1)
+
+			cost, err := m.CostForDuration(context.Background(), h, start, end)
+			assert.NoError(t, err)
+			assert.EqualValues(t, 25, cost)
 		},
 	} {
 		h = &host.Host{

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1126,10 +1126,7 @@ func (s *EC2Suite) TestGetSecurityGroups() {
 func (s *EC2Suite) TestCacheHostData() {
 	ec2m := s.onDemandManager.(*ec2Manager)
 
-	h := &host.Host{
-		Id: "h1",
-	}
-	s.Require().NoError(h.Insert())
+	s.Require().NoError(s.h.Insert())
 
 	instance := &ec2.Instance{Placement: &ec2.Placement{}}
 	instance.Placement.AvailabilityZone = aws.String("us-east-1a")
@@ -1153,18 +1150,19 @@ func (s *EC2Suite) TestCacheHostData() {
 	}
 	instance.PublicDnsName = aws.String("public_dns_name")
 
-	s.NoError(cacheHostData(s.ctx, h, instance, ec2m.client))
+	s.NoError(cacheHostData(s.ctx, s.h, instance, ec2m.client))
 
-	s.Equal(*instance.Placement.AvailabilityZone, h.Zone)
-	s.True(instance.LaunchTime.Equal(h.StartTime))
-	s.Equal("2001:0db8:85a3:0000:0000:8a2e:0370:7334", h.IP)
+	s.Equal(*instance.Placement.AvailabilityZone, s.h.Zone)
+	s.True(instance.LaunchTime.Equal(s.h.StartTime))
+	s.Equal("2001:0db8:85a3:0000:0000:8a2e:0370:7334", s.h.IP)
 	s.Equal([]host.VolumeAttachment{
 		{
 			VolumeID:   "volume_id",
 			DeviceName: "device_name",
 		},
-	}, h.Volumes)
-	s.Equal(int64(10), h.VolumeTotalSize)
+	}, s.h.Volumes)
+	s.Equal(int64(10), s.h.VolumeTotalSize)
+	s.Equal(float64(1), s.h.ComputeCostPerHour)
 
 	h, err := host.FindOneId("h1")
 	s.Require().NoError(err)
@@ -1179,6 +1177,7 @@ func (s *EC2Suite) TestCacheHostData() {
 		},
 	}, h.Volumes)
 	s.Equal(int64(10), h.VolumeTotalSize)
+	s.Equal(float64(1), h.ComputeCostPerHour)
 }
 
 func (s *EC2Suite) TestFromDistroSettings() {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -899,37 +899,43 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 		{
 			Id: "sir-1",
 			Distro: distro.Distro{
-				Provider: evergreen.ProviderNameEc2Spot,
+				Provider:         evergreen.ProviderNameEc2Spot,
+				ProviderSettings: s.distro.ProviderSettings,
 			},
 		},
 		{
 			Id: "i-2",
 			Distro: distro.Distro{
-				Provider: evergreen.ProviderNameEc2OnDemand,
+				Provider:         evergreen.ProviderNameEc2OnDemand,
+				ProviderSettings: s.distro.ProviderSettings,
 			},
 		},
 		{
 			Id: "sir-3",
 			Distro: distro.Distro{
-				Provider: evergreen.ProviderNameEc2Spot,
+				Provider:         evergreen.ProviderNameEc2Spot,
+				ProviderSettings: s.distro.ProviderSettings,
 			},
 		},
 		{
 			Id: "i-4",
 			Distro: distro.Distro{
-				Provider: evergreen.ProviderNameEc2OnDemand,
+				Provider:         evergreen.ProviderNameEc2OnDemand,
+				ProviderSettings: s.distro.ProviderSettings,
 			},
 		},
 		{
 			Id: "i-5",
 			Distro: distro.Distro{
-				Provider: evergreen.ProviderNameEc2OnDemand,
+				Provider:         evergreen.ProviderNameEc2OnDemand,
+				ProviderSettings: s.distro.ProviderSettings,
 			},
 		},
 		{
 			Id: "i-6",
 			Distro: distro.Distro{
-				Provider: evergreen.ProviderNameEc2OnDemand,
+				Provider:         evergreen.ProviderNameEc2OnDemand,
+				ProviderSettings: s.distro.ProviderSettings,
 			},
 		},
 	}

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -250,6 +250,15 @@ func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, cl
 	h.Volumes = makeVolumeAttachments(instance.BlockDeviceMappings)
 
 	var err error
+	if h.ComputeCostPerHour == 0 {
+		ec2Settings := &EC2ProviderSettings{}
+		err := ec2Settings.fromDistroSettings(h.Distro)
+		if err != nil {
+			return errors.Wrapf(err, "error getting EC2 settings for host '%s'", h.Id)
+		}
+		h.ComputeCostPerHour, _, err = pkgCachingPriceFetcher.getLatestSpotCostForInstance(ctx, client, ec2Settings, getOsName(h), h.Zone)
+	}
+
 	h.VolumeTotalSize, err = getVolumeSize(ctx, client, h)
 	if err != nil {
 		return errors.Wrapf(err, "error getting volume size for host %s", h.Id)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -257,6 +257,9 @@ func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, cl
 			return errors.Wrapf(err, "error getting EC2 settings for host '%s'", h.Id)
 		}
 		h.ComputeCostPerHour, _, err = pkgCachingPriceFetcher.getLatestSpotCostForInstance(ctx, client, ec2Settings, getOsName(h), h.Zone)
+		if err != nil {
+			return errors.Wrapf(err, "can't get pricing for host '%s'", h.Id)
+		}
 	}
 
 	h.VolumeTotalSize, err = getVolumeSize(ctx, client, h)

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1216,11 +1216,12 @@ func (h *Host) CacheHostData() error {
 		},
 		bson.M{
 			"$set": bson.M{
-				ZoneKey:            h.Zone,
-				StartTimeKey:       h.StartTime,
-				VolumeTotalSizeKey: h.VolumeTotalSize,
-				VolumesKey:         h.Volumes,
-				DNSKey:             h.Host,
+				ZoneKey:               h.Zone,
+				StartTimeKey:          h.StartTime,
+				VolumeTotalSizeKey:    h.VolumeTotalSize,
+				VolumesKey:            h.Volumes,
+				DNSKey:                h.Host,
+				ComputeCostPerHourKey: h.ComputeCostPerHour,
 			},
 		},
 	)

--- a/units/stats_host_idle.go
+++ b/units/stats_host_idle.go
@@ -163,7 +163,8 @@ func (j *collectHostIdleDataJob) incrementCostForDuration(ctx context.Context) (
 
 	calc, ok := j.manager.(cloud.CostCalculator)
 	if !ok {
-		return 0, errors.Errorf("manager of type '%T' isn't a cost calculator", j.manager)
+		// return early if we can't get the cost
+		return 0, nil
 	}
 
 	cost, err := calc.CostForDuration(ctx, j.host, j.StartTime, j.FinishTime)

--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -168,7 +168,8 @@ func (j *collectTaskEndDataJob) recordTaskCost(ctx context.Context) error {
 
 	calc, ok := manager.(cloud.CostCalculator)
 	if !ok {
-		return errors.Errorf("manager of type '%T' is not a cost calculator", manager)
+		// return early if we can't get the cost
+		return nil
 	}
 	cost, err := calc.CostForDuration(ctx, j.host, j.task.StartTime, j.task.FinishTime)
 	if err != nil {


### PR DESCRIPTION
#2933 was reverted because we were making too many AWS API calls to get spot instance pricing. Because Fleet wasn't caching pricing, every task that completed caused us to make an API call.

This PR reintroduces the changes from #2933 and caches cost in the host document when the host is marked as running. This is similar to the existing strategy for hosts requested through the ec2Manager. Although the pricing will not be accurate since AWS charges the _current_ rate and the rate may change over the lifetime of the host, it is sufficiently accurate for calculating the cost of a task.