### PR TITLE
EVG-7076 terminate hosts AWS forgot about

### DIFF
--- a/cloud/cloud_status.go
+++ b/cloud/cloud_status.go
@@ -21,7 +21,9 @@ const (
 	//StatusRunning means the machine is done booting, and active
 	StatusRunning
 
+	StatusStopping
 	StatusStopped
+
 	StatusTerminated
 )
 
@@ -35,6 +37,8 @@ func (stat CloudStatus) String() string {
 		return "initializing"
 	case StatusRunning:
 		return "running"
+	case StatusStopping:
+		return "stopping"
 	case StatusStopped:
 		return "stopped"
 	case StatusTerminated:

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -724,7 +724,7 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 				// Terminate an unknown host in the db
 				for _, h := range hosts {
 					if h.Id == *hostsToCheck[i] {
-						grip.Error(message.WrapError(h.Terminate(evergreen.User, "host is unknown to AWS"), message.Fields{
+						grip.Error(message.WrapError(h.Terminate(evergreen.User, "host is missing from DescribeInstances response"), message.Fields{
 							"message":       "can't mark instance as terminated",
 							"host":          h.Id,
 							"host_provider": h.Distro.Provider,

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -721,6 +721,19 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 		for i := range hostsToCheck {
 			instance, ok := reservationsMap[*hostsToCheck[i]]
 			if !ok {
+				// Terminate an unknown host in the db
+				for _, h := range hosts {
+					if h.Id == *hostsToCheck[i] {
+						if err = h.Terminate(evergreen.User, "host is unknown to AWS"); err != nil {
+							grip.Error(message.WrapError(err, message.Fields{
+								"message":       "can't mark instance as terminated",
+								"host":          h.Id,
+								"host_provider": h.Distro.Provider,
+								"distro":        h.Distro.Id,
+							}))
+						}
+					}
+				}
 				return nil, errors.Errorf("host '%s' not included in DescribeInstances response", *hostsToCheck[i])
 			}
 			status := ec2StatusToEvergreenStatus(*instance.State.Name)
@@ -775,6 +788,17 @@ func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cloud
 
 	instance, err := m.client.GetInstanceInfo(ctx, id)
 	if err != nil {
+		// terminate an unknown host in the db
+		if err == noReservationError {
+			if terminateErr := h.Terminate(evergreen.User, "host is unknown to AWS"); terminateErr != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"message":       "can't mark instance as terminated",
+					"host":          h.Id,
+					"host_provider": h.Distro.Provider,
+					"distro":        h.Distro.Id,
+				}))
+			}
+		}
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":       "error getting instance info",
 			"host":          h.Id,

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -724,14 +724,12 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 				// Terminate an unknown host in the db
 				for _, h := range hosts {
 					if h.Id == *hostsToCheck[i] {
-						if err = h.Terminate(evergreen.User, "host is unknown to AWS"); err != nil {
-							grip.Error(message.WrapError(err, message.Fields{
-								"message":       "can't mark instance as terminated",
-								"host":          h.Id,
-								"host_provider": h.Distro.Provider,
-								"distro":        h.Distro.Id,
-							}))
-						}
+						grip.Error(message.WrapError(h.Terminate(evergreen.User, "host is unknown to AWS"), message.Fields{
+							"message":       "can't mark instance as terminated",
+							"host":          h.Id,
+							"host_provider": h.Distro.Provider,
+							"distro":        h.Distro.Id,
+						}))
 					}
 				}
 				return nil, errors.Errorf("host '%s' not included in DescribeInstances response", *hostsToCheck[i])
@@ -790,14 +788,12 @@ func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cloud
 	if err != nil {
 		// terminate an unknown host in the db
 		if err == noReservationError {
-			if terminateErr := h.Terminate(evergreen.User, "host is unknown to AWS"); terminateErr != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"message":       "can't mark instance as terminated",
-					"host":          h.Id,
-					"host_provider": h.Distro.Provider,
-					"distro":        h.Distro.Id,
-				}))
-			}
+			grip.Error(message.WrapError(h.Terminate(evergreen.User, "host is unknown to AWS"), message.Fields{
+				"message":       "can't mark instance as terminated",
+				"host":          h.Id,
+				"host_provider": h.Distro.Provider,
+				"distro":        h.Distro.Id,
+			}))
 		}
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":       "error getting instance info",

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -730,7 +730,6 @@ func (c *awsClientImpl) GetInstanceInfo(ctx context.Context, id string) (*ec2.In
 	}
 	reservation := resp.Reservations
 	if len(reservation) == 0 {
-		err = errors.Errorf("No reservation found for instance id: %s", id)
 		return nil, noReservationError
 	}
 

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -24,6 +24,8 @@ import (
 
 const MockIPV6 = "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47"
 
+var noReservationError = errors.New("no reservation returned for instance")
+
 // AWSClient is a wrapper for aws-sdk-go so we can use a mock in testing.
 type AWSClient interface {
 	// Create a new aws-sdk-client or mock if one does not exist, otherwise no-op.
@@ -729,7 +731,7 @@ func (c *awsClientImpl) GetInstanceInfo(ctx context.Context, id string) (*ec2.In
 	reservation := resp.Reservations
 	if len(reservation) == 0 {
 		err = errors.Errorf("No reservation found for instance id: %s", id)
-		return nil, err
+		return nil, noReservationError
 	}
 
 	instances := reservation[0].Instances

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -111,6 +112,10 @@ func ec2StatusToEvergreenStatus(ec2Status string) CloudStatus {
 	case ec2.InstanceStateNameTerminated, ec2.InstanceStateNameShuttingDown:
 		return StatusTerminated
 	default:
+		grip.Error(message.Fields{
+			"message": "got an unknown ec2 state name",
+			"status":  ec2Status,
+		})
 		return StatusUnknown
 	}
 }

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -23,16 +23,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-//Valid values for EC2 instance states:
-//pending | running | shutting-down | terminated | stopping | stopped
-//see http://goo.gl/3OrCGn
 const (
-	EC2StatusPending      = "pending"
-	EC2StatusRunning      = "running"
-	EC2StatusShuttingdown = "shutting-down"
-	EC2StatusTerminated   = "terminated"
-	EC2StatusStopped      = "stopped"
-	EC2ErrorNotFound      = "InvalidInstanceID.NotFound"
+	EC2ErrorNotFound = "InvalidInstanceID.NotFound"
 )
 
 type MountPoint struct {
@@ -110,16 +102,14 @@ func osBillingName(os osType) string {
 //provider-specific status codes.
 func ec2StatusToEvergreenStatus(ec2Status string) CloudStatus {
 	switch ec2Status {
-	case EC2StatusPending:
+	case ec2.InstanceStateNamePending:
 		return StatusInitializing
-	case EC2StatusRunning:
+	case ec2.InstanceStateNameRunning:
 		return StatusRunning
-	case EC2StatusShuttingdown:
-		return StatusTerminated
-	case EC2StatusTerminated:
-		return StatusTerminated
-	case EC2StatusStopped:
+	case ec2.InstanceStateNameStopped:
 		return StatusStopped
+	case ec2.InstanceStateNameTerminated, ec2.InstanceStateNameShuttingDown:
+		return StatusTerminated
 	default:
 		return StatusUnknown
 	}

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -115,7 +115,7 @@ func (j *cloudHostReadyJob) Run(ctx context.Context) {
 // setCloudHostStatus sets the host's status to HostProvisioning if host is running.
 func setCloudHostStatus(ctx context.Context, m cloud.Manager, h host.Host, hostStatus cloud.CloudStatus) error {
 	switch hostStatus {
-	case cloud.StatusFailed:
+	case cloud.StatusFailed, cloud.StatusTerminated:
 		grip.Debug(message.Fields{
 			"ticket":     "EVG-6100",
 			"message":    "host status",

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -132,6 +132,7 @@ func setCloudHostStatus(ctx context.Context, m cloud.Manager, h host.Host, hostS
 		"DNS":     h.Host,
 		"distro":  h.Distro.Id,
 		"runner":  "hostinit",
+		"status":  hostStatus,
 	})
 	return nil
 }


### PR DESCRIPTION
- Address a possible cause: if the instance is terminated by AWS before it gets to running we should terminate it in the db.
- If AWS forgets about a host we should do the same and terminate it in the db.
- Log the status of a host that's not ready yet and unknown AWS statuses so if this happens again we'll know which status we're not handling
- Use the AWS SDK's constants for instance status