### PR TITLE
EVG-6139 unshallow clone for a test using old commits

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -398,9 +398,6 @@ tasks:
     name: test-cloud
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
-    name: test-repotracker
-  - <<: *run-go-test-suite-with-mongodb
-    tags: ["db", "test"]
     name: test-scheduler
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
@@ -487,6 +484,22 @@ tasks:
           target: revendor
       - func: run-make
         vars: { target: "test-thirdparty-docker" }
+  - name: test-repotracker
+    tags: ["db", "test"]
+    commands:
+      - command: git.get_project
+        type: setup
+        params:
+          directory: gopath/src/github.com/evergreen-ci/evergreen
+          token: ${github_token}
+          shallow_clone: false
+      - func: setup-credentials
+      - func: setup-mongodb
+      - func: run-make
+        vars:
+          target: revendor
+      - func: run-make
+        vars: { target: "test-repotracker" }
 
 
 buildvariants:


### PR DESCRIPTION
Getting a commit 100 commits prior to HEAD 
https://github.com/evergreen-ci/evergreen/blob/6e1246f06a283334bdbee1ddbfb4168cdebaf4ea/repotracker/github_poller_test.go#L51
 failed because shallow clone specifies a depth of 100 (so we're off by one).
I considered getting the SHA of 99 commits ago, but this seemed cleanest to me since we won't have a dependency on the depth remaining the same.