### PR TITLE
EVG-7078 allow selecting metrics in perf discovery

### DIFF
--- a/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
+++ b/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
@@ -154,7 +154,7 @@ mciModule.factory('PerfDiscoveryDataService', function (
   //   },
   //   {...}
   // ]
-  function onProcessData(metricName, data) {
+  function onProcessDataFn(metricName) {
     return function (data) {
       var now = {},
         baseline = {},
@@ -451,7 +451,7 @@ mciModule.factory('PerfDiscoveryDataService', function (
   // Populates dicts of current (now, baseline) and history result items
   // returns dict of {now, baseline, history} test result items
   function processData(promise, metricName) {
-    return promise.then(onProcessData(metricName))
+    return promise.then(onProcessDataFn(metricName))
   }
 
   // Returns data for the (ui) grid
@@ -535,7 +535,7 @@ mciModule.factory('PerfDiscoveryDataService', function (
     // For teting
     _extractTasks: extractTasks,
     _processItem: processItem,
-    _onProcessData: onProcessData,
+    _onProcessData: onProcessDataFn(),
     _onGetRows: onGetRows,
     _versionSelectAdaptor: versionSelectAdaptor,
     _tagSelectAdaptor: tagSelectAdaptor,

--- a/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
+++ b/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
@@ -98,7 +98,10 @@ mciModule.factory('PerfDiscoveryDataService', function (
   // :param receiver: dict which will receive processed results
   // :param ctx: dict of {build, task, storageEngine} see `extractTasks`
   // returns: could be ignored
-  function processItem(item, receiver, ctx) {
+  function processItem(item, receiver, ctx, metricName) {
+    if (!metricName) {
+      metricName = "ops_per_sec";
+    }
     var parts = item.name.split('-')
     // At some point we renamed the tests to remove -wiredTiger and -MMAPv1 suffixs.
     // Normalize old names to match the new ones
@@ -110,6 +113,7 @@ mciModule.factory('PerfDiscoveryDataService', function (
       .omit(_.isString)
       .each(function (speed, threads) {
         var data = {
+          all_metrics: getAllMetrics(speed),
           build: ctx.buildName,
           buildId: ctx.buildId,
           buildVariant: ctx.buildVariant,
@@ -123,11 +127,22 @@ mciModule.factory('PerfDiscoveryDataService', function (
           taskId: ctx.taskId,
           test: item.name,
           threads: +threads,
-          speed: speed.ops_per_sec,
+          speed: speed[metricName],
           storageEngine: ctx.storageEngine,
         }
         receiver[slug(data)] = data
       })
+  }
+
+  // getAllMetrics returns all properties that have scalar numeric values in a single test result
+  function getAllMetrics(result) {
+    let metrics = [];
+    for (const name in result) {
+      if (Number.isFinite(result[name])) {
+        metrics.push(name);
+      }
+    }
+    return metrics;
   }
 
   // data is [
@@ -139,56 +154,58 @@ mciModule.factory('PerfDiscoveryDataService', function (
   //   },
   //   {...}
   // ]
-  function onProcessData(data) {
-    var now = {},
-      baseline = {},
-      history = {}
+  function onProcessData(metricName, data) {
+    return function (data) {
+      var now = {},
+        baseline = {},
+        history = {}
 
-    _.each(data, function (d) {
-      // Skip empty items
-      if (d == null) return
+      _.each(data, function (d) {
+        // Skip empty items
+        if (d == null) return
 
-      // TODO add group validation instead of individual
-      // Process current (revision) data
-      if (d.current && d.current.data) {
-        // Copy storageEngine to the context
-        d.ctx.storageEngine = d.current.data.storageEngine || '(none)'
+        // TODO add group validation instead of individual
+        // Process current (revision) data
+        if (d.current && d.current.data) {
+          // Copy storageEngine to the context
+          d.ctx.storageEngine = d.current.data.storageEngine || '(none)'
 
-        _.each(d.current.data.results, function (result) {
-          processItem(result, now, d.ctx)
-        })
-      }
-
-      // Process baseline data
-      if (d.baseline && d.baseline.data) {
-        _.each(d.baseline.data.results, function (result) {
-          processItem(result, baseline, d.ctx)
-        })
-      }
-
-      // Process history data
-      _.each(d.history, function (histItems) {
-        // Create an empty 'bucket' for history items if not exists
-        var order = histItems.order
-        if (history[order] == undefined) {
-          history[order] = {}
+          _.each(d.current.data.results, function (result) {
+            processItem(result, now, d.ctx, metricName);
+          })
         }
-        _.each(histItems.data.results, function (result) {
-          processItem(result, history[order], d.ctx)
+
+        // Process baseline data
+        if (d.baseline && d.baseline.data) {
+          _.each(d.baseline.data.results, function (result) {
+            processItem(result, baseline, d.ctx, metricName);
+          })
+        }
+
+        // Process history data
+        _.each(d.history, function (histItems) {
+          // Create an empty 'bucket' for history items if not exists
+          var order = histItems.order
+          if (history[order] == undefined) {
+            history[order] = {}
+          }
+          _.each(histItems.data.results, function (result) {
+            processItem(result, history[order], d.ctx, metricName);
+          })
         })
       })
-    })
 
-    return {
-      now: now,
-      baseline: baseline,
-      // Sorts history items by `order` and returns the list
-      history: _.map(
-        _.sortBy(_.keys(history)),
-        function (key) {
-          return history[key]
-        }
-      ),
+      return {
+        now: now,
+        baseline: baseline,
+        // Sorts history items by `order` and returns the list
+        history: _.map(
+          _.sortBy(_.keys(history)),
+          function (key) {
+            return history[key]
+          }
+        ),
+      }
     }
   }
 
@@ -433,8 +450,8 @@ mciModule.factory('PerfDiscoveryDataService', function (
   // Processes `queryData` return value
   // Populates dicts of current (now, baseline) and history result items
   // returns dict of {now, baseline, history} test result items
-  function processData(promise) {
-    return promise.then(onProcessData)
+  function processData(promise, metricName) {
+    return promise.then(onProcessData(metricName))
   }
 
   // Returns data for the (ui) grid
@@ -495,12 +512,12 @@ mciModule.factory('PerfDiscoveryDataService', function (
       })
   }
 
-  function getData(version, baselineTag, expandedCurrent, expandedBaseline, expandedTrend) {
+  function getData(version, baselineTag, expandedCurrent, expandedBaseline, expandedTrend, metricName) {
     return getRows(
       processData(
         queryData(
           tasksOfBuilds(queryBuildData(version)), tasksOfBuilds(queryBuildData(baselineTag)), expandedCurrent, expandedBaseline, expandedTrend
-        )
+        ), metricName
       )
     )
   }
@@ -522,5 +539,6 @@ mciModule.factory('PerfDiscoveryDataService', function (
     _onGetRows: onGetRows,
     _versionSelectAdaptor: versionSelectAdaptor,
     _tagSelectAdaptor: tagSelectAdaptor,
+    _getAllMetrics: getAllMetrics,
   }
 })

--- a/public/static/app/perfdiscovery/PerfDiscoveryDataService.test.js
+++ b/public/static/app/perfdiscovery/PerfDiscoveryDataService.test.js
@@ -191,7 +191,7 @@ describe('PerfDiscoveryDataServiceTest', function () {
       }
     }];
 
-    const processed = service._onProcessData()(data);
+    const processed = service._onProcessData(data);
 
     expect(
       _.keys(processed.now).length
@@ -222,7 +222,7 @@ describe('PerfDiscoveryDataServiceTest', function () {
     }];
 
     expect(
-      service._onProcessData()(data)
+      service._onProcessData(data)
     ).toEqual({
       now: {},
       baseline: {},
@@ -234,7 +234,7 @@ describe('PerfDiscoveryDataServiceTest', function () {
     const data = [null];
 
     expect(
-      service._onProcessData()(data)
+      service._onProcessData(data)
     ).toEqual({
       now: {},
       baseline: {},

--- a/public/static/app/perfdiscovery/PerfDiscoveryDataService.test.js
+++ b/public/static/app/perfdiscovery/PerfDiscoveryDataService.test.js
@@ -115,6 +115,7 @@ describe('PerfDiscoveryDataServiceTest', function () {
       receiver
     ).toEqual({
       'b-wt-t-name-8': {
+        all_metrics: ['ops_per_sec'],
         build: 'b',
         buildId: 'bid',
         buildVariant: 'bv',
@@ -128,6 +129,7 @@ describe('PerfDiscoveryDataServiceTest', function () {
         speed: 100,
       },
       'b-wt-t-name-16': {
+        all_metrics: ['ops_per_sec'],
         build: 'b',
         buildId: 'bid',
         buildVariant: 'bv',
@@ -189,7 +191,7 @@ describe('PerfDiscoveryDataServiceTest', function () {
       }
     }];
 
-    const processed = service._onProcessData(data);
+    const processed = service._onProcessData()(data);
 
     expect(
       _.keys(processed.now).length
@@ -220,7 +222,7 @@ describe('PerfDiscoveryDataServiceTest', function () {
     }];
 
     expect(
-      service._onProcessData(data)
+      service._onProcessData()(data)
     ).toEqual({
       now: {},
       baseline: {},
@@ -232,7 +234,7 @@ describe('PerfDiscoveryDataServiceTest', function () {
     const data = [null];
 
     expect(
-      service._onProcessData(data)
+      service._onProcessData()(data)
     ).toEqual({
       now: {},
       baseline: {},
@@ -466,5 +468,17 @@ describe('PerfDiscoveryDataServiceTest', function () {
       id: sysPerfIdLong,
       name: sysPerfIdLong
     });
+  })
+
+  it("extracts metric names correctly", () => {
+    const testData = {
+      "95th_read_latency_us": 8410,
+      "95th_read_latency_us_values": [8410],
+      "average_read_latency_us": 100232.63822741479,
+      "average_read_latency_us_values": [100232.63822741479],
+      "ops_per_sec": 549.8739561462517,
+      "ops_per_sec_values": [549.8739561462517]
+    }
+    expect(service._getAllMetrics(testData)).toEqual(["95th_read_latency_us", "average_read_latency_us", "ops_per_sec"]);
   })
 });

--- a/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
+++ b/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
@@ -142,11 +142,7 @@ mciModule.controller('PerformanceDiscoveryCtrl', function (
       // Apply perf data
       .then(function (res) {
         vm.gridOptions.data = res
-        let metrics = [];
-        _.each(res, (test) => {
-          metrics = metrics.concat(test.all_metrics)
-        });
-        vm.all_metrics = _.uniq(metrics).sort();
+        vm.all_metrics = _.chain(res).map(test => test.all_metrics).flatten().uniq().sort().value();
         // Apply options data to filter drop downs
         gridUtil.applyMultiselectOptions(
           res,

--- a/service/templates/perfdiscovery.html
+++ b/service/templates/perfdiscovery.html
@@ -45,11 +45,18 @@ Performance Discovery
     </label>
 
     <md-input-container style="width: 200px;">
-      <label>Use Expanded Data For:</label>
+      <label>Use Expanded Data For</label>
       <md-select ng-model="$ctrl.expandedOptions" ng-change="reload()" multiple>
         <md-option value="current">Current Results</md-option>
         <md-option value="baseline">Baseline Results</md-option>
         <md-option value="history">History</md-option>
+      </md-select>
+    </md-input-container>
+
+    <md-input-container style="width: 180px;">
+      <label>Metric</label>
+      <md-select ng-model="$ctrl.metric_name" ng-change="reload()">
+        <md-option ng-value="metric" ng-repeat="metric in $ctrl.all_metrics">[[ metric ]]</md-option>
       </md-select>
     </md-input-container>
   </div>


### PR DESCRIPTION
- Add a dropdown to perf discovery that allow selection of metrics other than ops/sec
- Populate this dropdown from the loaded data. Any metrics that either the baseline or comparison has data for will be added to the list. The default is still ops/sec
- When the dropdown is changed, reload the data, filtering for just that metric. Also change the header of the column for this value to the appropriate label