### PR TITLE
EVG-7001: revert LDAP options

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -9,15 +9,12 @@ import (
 
 func TestLoadUserManager(t *testing.T) {
 	l := evergreen.LDAPConfig{
-		URL:                 "url",
-		Port:                "port",
-		UserPath:            "path",
-		ServicePath:         "bot",
-		Group:               "group",
-		ExpireAfterMinutes:  "60",
-		ServiceUserName:     "service",
-		ServiceUserPassword: "password",
-		ServiceUserPath:     "/service",
+		URL:                "url",
+		Port:               "port",
+		UserPath:           "path",
+		ServicePath:        "bot",
+		Group:              "group",
+		ExpireAfterMinutes: "60",
 	}
 	g := evergreen.GithubAuthConfig{
 		ClientId:     "client_id",

--- a/auth/ldap_test.go
+++ b/auth/ldap_test.go
@@ -14,15 +14,12 @@ func TestNewLDAPUserManager(t *testing.T) {
 	assert.Nil(t, u)
 
 	conf = &evergreen.LDAPConfig{
-		URL:                 "url",
-		Port:                "port",
-		UserPath:            "path",
-		ServicePath:         "bot",
-		Group:               "group",
-		ExpireAfterMinutes:  "60",
-		ServiceUserName:     "service",
-		ServiceUserPassword: "password",
-		ServiceUserPath:     "/service",
+		URL:                "url",
+		Port:               "port",
+		UserPath:           "path",
+		ServicePath:        "bot",
+		Group:              "group",
+		ExpireAfterMinutes: "60",
 	}
 	u, err = NewLDAPUserManager(conf)
 	assert.NoError(t, err)

--- a/config_auth.go
+++ b/config_auth.go
@@ -25,17 +25,14 @@ type NaiveAuthConfig struct {
 
 // LDAPConfig contains settings for interacting with an LDAP server.
 type LDAPConfig struct {
-	URL                 string `bson:"url" json:"url" yaml:"url"`
-	Port                string `bson:"port" json:"port" yaml:"port"`
-	ServiceUserName     string `bson:"service_user_name" json:"service_user_name" yaml:"service_user_name"`
-	ServiceUserPassword string `bson:"service_user_password" json:"service_user_password" yaml:"service_user_password"`
-	ServiceUserPath     string `bson:"service_user_path" json:"service_user_path" yaml:"service_user_path"`
-	UserPath            string `bson:"path" json:"path" yaml:"path"`
-	ServicePath         string `bson:"service_path" json:"service_path" yaml:"service_path"`
-	Group               string `bson:"group" json:"group" yaml:"group"`
-	ServiceGroup        string `bson:"service_group" json:"service_group" yaml:"service_group"`
-	ExpireAfterMinutes  string `bson:"expire_after_minutes" json:"expire_after_minutes" yaml:"expire_after_minutes"`
-	GroupOU             string `bson:"group_ou" json:"group_ou" yaml:"group_ou"`
+	URL                string `bson:"url" json:"url" yaml:"url"`
+	Port               string `bson:"port" json:"port" yaml:"port"`
+	UserPath           string `bson:"path" json:"path" yaml:"path"`
+	ServicePath        string `bson:"service_path" json:"service_path" yaml:"service_path"`
+	Group              string `bson:"group" json:"group" yaml:"group"`
+	ServiceGroup       string `bson:"service_group" json:"service_group" yaml:"service_group"`
+	ExpireAfterMinutes string `bson:"expire_after_minutes" json:"expire_after_minutes" yaml:"expire_after_minutes"`
+	GroupOU            string `bson:"group_ou" json:"group_ou" yaml:"group_ou"`
 }
 
 // GithubAuthConfig holds settings for interacting with Github Authentication including the

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -472,17 +472,14 @@ func (a *APIBackupConfig) ToService() (interface{}, error) {
 }
 
 type APILDAPConfig struct {
-	URL                 APIString `json:"url"`
-	Port                APIString `json:"port"`
-	ServiceUserName     APIString `json:"service_user_name"`
-	ServiceUserPassword APIString `json:"service_user_password"`
-	ServiceUserPath     APIString `json:"service_user_path"`
-	UserPath            APIString `json:"path"`
-	ServicePath         APIString `json:"service_path"`
-	Group               APIString `json:"group"`
-	ServiceGroup        APIString `json:"service_group"`
-	ExpireAfterMinutes  APIString `json:"expire_after_minutes"`
-	GroupOU             APIString `json:"group_ou"`
+	URL                APIString `json:"url"`
+	Port               APIString `json:"port"`
+	UserPath           APIString `json:"path"`
+	ServicePath        APIString `json:"service_path"`
+	Group              APIString `json:"group"`
+	ServiceGroup       APIString `json:"service_group"`
+	ExpireAfterMinutes APIString `json:"expire_after_minutes"`
+	GroupOU            APIString `json:"group_ou"`
 }
 
 func (a *APILDAPConfig) BuildFromService(h interface{}) error {
@@ -493,9 +490,6 @@ func (a *APILDAPConfig) BuildFromService(h interface{}) error {
 		}
 		a.URL = ToAPIString(v.URL)
 		a.Port = ToAPIString(v.Port)
-		a.ServiceUserName = ToAPIString(v.ServiceUserName)
-		a.ServiceUserPassword = ToAPIString(v.ServiceUserPassword)
-		a.ServiceUserPath = ToAPIString(v.ServiceUserPath)
 		a.UserPath = ToAPIString(v.UserPath)
 		a.ServicePath = ToAPIString(v.ServicePath)
 		a.Group = ToAPIString(v.Group)
@@ -513,17 +507,14 @@ func (a *APILDAPConfig) ToService() (interface{}, error) {
 		return nil, nil
 	}
 	return &evergreen.LDAPConfig{
-		URL:                 FromAPIString(a.URL),
-		Port:                FromAPIString(a.Port),
-		ServiceUserName:     FromAPIString(a.ServiceUserName),
-		ServiceUserPassword: FromAPIString(a.ServiceUserPassword),
-		ServiceUserPath:     FromAPIString(a.ServiceUserPath),
-		UserPath:            FromAPIString(a.UserPath),
-		ServicePath:         FromAPIString(a.ServicePath),
-		Group:               FromAPIString(a.Group),
-		ServiceGroup:        FromAPIString(a.ServiceGroup),
-		ExpireAfterMinutes:  FromAPIString(a.ExpireAfterMinutes),
-		GroupOU:             FromAPIString(a.Group),
+		URL:                FromAPIString(a.URL),
+		Port:               FromAPIString(a.Port),
+		UserPath:           FromAPIString(a.UserPath),
+		ServicePath:        FromAPIString(a.ServicePath),
+		Group:              FromAPIString(a.Group),
+		ServiceGroup:       FromAPIString(a.ServiceGroup),
+		ExpireAfterMinutes: FromAPIString(a.ExpireAfterMinutes),
+		GroupOU:            FromAPIString(a.Group),
 	}, nil
 }
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -695,18 +695,6 @@ Admin Settings
 										<input type="text" ng-model="Settings.auth.ldap.port">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
-										<label>Service User Name</label>
-										<input type="text" ng-model="Settings.auth.ldap.service_user_name">
-									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
-										<label>Service User Password</label>
-										<input type="text" ng-model="Settings.auth.ldap.service_user_password">
-									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
-										<label>Service User Path</label>
-										<input type="text" ng-model="Settings.auth.ldap.service_user_path">
-									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
 										<label>User Path</label>
 										<input type="text" ng-model="Settings.auth.ldap.path">
 									</md-input-container>


### PR DESCRIPTION
This is to remove the LDAP config that was going to be used for Okta.