### PR TITLE
EVG-7160 Use LoadProjectInto instead of ReadYAMLInto in fetch

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-12-18"
+	ClientVersion = "2019-01-07"
 )
 
 // ConfigSection defines a sub-document in the evegreen config

--- a/operations/http.go
+++ b/operations/http.go
@@ -243,7 +243,11 @@ func (ac *legacyClient) GetPatchedConfig(patchId string) (*model.Project, error)
 		return nil, NewAPIError(resp)
 	}
 	ref := &model.Project{}
-	if err := util.ReadYAMLInto(resp.Body, ref); err != nil {
+	yamlBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := model.LoadProjectInto(yamlBytes, "", ref); err != nil {
 		return nil, err
 	}
 	return ref, nil

--- a/operations/http.go
+++ b/operations/http.go
@@ -259,7 +259,11 @@ func (ac *legacyClient) GetConfig(versionId string) (*model.Project, error) {
 		return nil, NewAPIError(resp)
 	}
 	ref := &model.Project{}
-	if err := util.ReadYAMLInto(resp.Body, ref); err != nil {
+	yamlBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := model.LoadProjectInto(yamlBytes, "", ref); err != nil {
 		return nil, err
 	}
 	return ref, nil

--- a/util/yaml.go
+++ b/util/yaml.go
@@ -1,25 +1,12 @@
 package util
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
-
-// ReadYAMLInto reads data for the given io.ReadCloser - until it hits an error
-// or reaches EOF - and attempts to unmarshal the data read into the given
-// interface.
-func ReadYAMLInto(r io.ReadCloser, data interface{}) error {
-	defer r.Close()
-	bytes, err := ioutil.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	return yaml.Unmarshal(bytes, data)
-}
 
 func ReadFromYAMLFile(fn string, data interface{}) error {
 	if _, err := os.Stat(fn); os.IsNotExist(err) {


### PR DESCRIPTION
Reading a project YAML into a model.Project is not always valid. Tags cannot be
parsed correctly. Instead it has to be parsed with LoadProjectInto.