### PR TITLE
EVG-7062 add restricted projects

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -122,7 +122,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: e5548953650b5d4cc7b6d7aba4cb1b2771e35342
   - name: github.com/evergreen-ci/gimlet
-    version: f29b6c78d420998c0d30f5477c0ddbf93bead2a3
+    version: 4f547e94d38b4aa93fb9505eed83b1e4f50a585d
   - name: github.com/evergreen-ci/shrub
     version: 32e668cd99410328bf6659e55671c11a6c727d9a
   - name: github.com/evergreen-ci/pail

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -430,8 +430,7 @@ func TestAddPermissions(t *testing.T) {
 }
 
 func TestUpdateAdminRoles(t *testing.T) {
-	expect := assert.New(t)
-	expect.NoError(db.ClearCollections(ProjectRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection, user.Collection))
+	require.NoError(t, db.ClearCollections(ProjectRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection, user.Collection))
 	env := evergreen.GetEnvironment()
 	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 	rm := env.RoleManager()
@@ -440,32 +439,32 @@ func TestUpdateAdminRoles(t *testing.T) {
 		Type:      evergreen.ProjectResourceType,
 		Resources: []string{"proj"},
 	}
-	expect.NoError(rm.AddScope(adminScope))
+	require.NoError(t, rm.AddScope(adminScope))
 	adminRole := gimlet.Role{
 		ID:          "admin",
 		Scope:       evergreen.AllProjectsScope,
 		Permissions: adminPermissions,
 	}
-	expect.NoError(rm.UpdateRole(adminRole))
+	require.NoError(t, rm.UpdateRole(adminRole))
 	oldAdmin := user.DBUser{
 		Id:          "oldAdmin",
 		SystemRoles: []string{"admin"},
 	}
-	expect.NoError(oldAdmin.Insert())
+	require.NoError(t, oldAdmin.Insert())
 	newAdmin := user.DBUser{
 		Id: "newAdmin",
 	}
-	expect.NoError(newAdmin.Insert())
+	require.NoError(t, newAdmin.Insert())
 	p := ProjectRef{
 		Identifier: "proj",
 	}
-	expect.NoError(p.Insert())
+	require.NoError(t, p.Insert())
 
-	expect.NoError(p.UpdateAdminRoles([]string{newAdmin.Id}, []string{oldAdmin.Id}))
+	assert.NoError(t, p.UpdateAdminRoles([]string{newAdmin.Id}, []string{oldAdmin.Id}))
 	oldAdminFromDB, err := user.FindOneById(oldAdmin.Id)
-	expect.NoError(err)
-	expect.Len(oldAdminFromDB.Roles(), 0)
+	assert.NoError(t, err)
+	assert.Len(t, oldAdminFromDB.Roles(), 0)
 	newAdminFromDB, err := user.FindOneById(newAdmin.Id)
-	expect.NoError(err)
-	expect.Len(newAdminFromDB.Roles(), 1)
+	assert.NoError(t, err)
+	assert.Len(t, newAdminFromDB.Roles(), 1)
 }

--- a/service/project.go
+++ b/service/project.go
@@ -225,6 +225,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		PrivateVars         map[string]bool                `json:"private_vars"`
 		Enabled             bool                           `json:"enabled"`
 		Private             bool                           `json:"private"`
+		Restricted          bool                           `json:"restricted"`
 		Owner               string                         `json:"owner_name"`
 		Repo                string                         `json:"repo_name"`
 		Admins              []string                       `json:"admins"` //TODO: update roles for this project if admins change
@@ -436,6 +437,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectRef.Branch = responseRef.Branch
 	projectRef.Enabled = responseRef.Enabled
 	projectRef.Private = responseRef.Private
+	projectRef.Restricted = responseRef.Restricted
 	projectRef.Owner = responseRef.Owner
 	projectRef.DeactivatePrevious = responseRef.DeactivatePrevious
 	projectRef.Repo = responseRef.Repo
@@ -581,6 +583,25 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if err = model.LogProjectModified(id, username, before, after); err != nil {
 		grip.Infof("Could not log changes to project %s", id)
+	}
+
+	if origProjectRef.Restricted != projectRef.Restricted {
+		var err error
+		if projectRef.Restricted {
+			err = projectRef.MakeRestricted()
+		} else {
+			err = projectRef.MakeUnrestricted()
+		}
+		if err != nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, err)
+			return
+		}
+	}
+
+	toAdd, toRemove := util.StringSliceSymmetricDifference(projectRef.Admins, origProjectRef.Admins)
+	if err = projectRef.UpdateAdminRoles(toAdd, toRemove); err != nil {
+		uis.LoggedError(w, r, http.StatusInternalServerError, err)
+		return
 	}
 
 	allProjects, err := uis.filterAuthorizedProjects(dbUser)

--- a/util/slice.go
+++ b/util/slice.go
@@ -32,6 +32,30 @@ func StringSliceIntersection(a, b []string) []string {
 	return out
 }
 
+// StringSliceSymmetricDifference returns only elements not in common between 2 slices
+// (ie. inverse of the intersection)
+func StringSliceSymmetricDifference(a, b []string) ([]string, []string) {
+	mapA := map[string]bool{}
+	mapAcopy := map[string]bool{}
+	for _, elem := range a {
+		mapA[elem] = true
+		mapAcopy[elem] = true
+	}
+	inB := []string{}
+	for _, elem := range b {
+		if mapAcopy[elem] { // need to delete from the copy in case B has duplicates of the same value in A
+			delete(mapA, elem)
+		} else {
+			inB = append(inB, elem)
+		}
+	}
+	inA := []string{}
+	for elem := range mapA {
+		inA = append(inA, elem)
+	}
+	return inA, inB
+}
+
 // UniqueStrings takes a slice of strings and returns a new slice with duplicates removed.
 // Order is preserved.
 func UniqueStrings(slice []string) []string {

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -54,23 +54,22 @@ func TestSplitCommas(t *testing.T) {
 }
 
 func TestStringSliceSymmetricDifference(t *testing.T) {
-	assert := assert.New(t)
 	a := []string{"a", "c", "f", "n", "q"}
 	b := []string{"q", "q", "g", "y", "a"}
 
 	onlyA, onlyB := StringSliceSymmetricDifference(a, b)
-	assert.EqualValues([]string{"c", "f", "n"}, onlyA)
-	assert.EqualValues([]string{"g", "y"}, onlyB)
+	assert.EqualValues(t, []string{"c", "f", "n"}, onlyA)
+	assert.EqualValues(t, []string{"g", "y"}, onlyB)
 
 	onlyB, onlyA = StringSliceSymmetricDifference(b, a)
-	assert.EqualValues([]string{"c", "f", "n"}, onlyA)
-	assert.EqualValues([]string{"g", "y"}, onlyB)
+	assert.EqualValues(t, []string{"c", "f", "n"}, onlyA)
+	assert.EqualValues(t, []string{"g", "y"}, onlyB)
 
 	onlyA, onlyB = StringSliceSymmetricDifference(a, a)
-	assert.Equal([]string{}, onlyA)
-	assert.Equal([]string{}, onlyB)
+	assert.Equal(t, []string{}, onlyA)
+	assert.Equal(t, []string{}, onlyB)
 
 	empty1, empty2 := StringSliceSymmetricDifference([]string{}, []string{})
-	assert.Equal([]string{}, empty1)
-	assert.Equal([]string{}, empty2)
+	assert.Equal(t, []string{}, empty1)
+	assert.Equal(t, []string{}, empty2)
 }

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -58,12 +58,22 @@ func TestStringSliceSymmetricDifference(t *testing.T) {
 	b := []string{"q", "q", "g", "y", "a"}
 
 	onlyA, onlyB := StringSliceSymmetricDifference(a, b)
-	assert.EqualValues(t, []string{"c", "f", "n"}, onlyA)
-	assert.EqualValues(t, []string{"g", "y"}, onlyB)
+	assert.Contains(t, onlyA, "c")
+	assert.Contains(t, onlyA, "f")
+	assert.Contains(t, onlyA, "n")
+	assert.Len(t, onlyA, 3)
+	assert.Contains(t, onlyB, "g")
+	assert.Contains(t, onlyB, "y")
+	assert.Len(t, onlyB, 2)
 
 	onlyB, onlyA = StringSliceSymmetricDifference(b, a)
-	assert.EqualValues(t, []string{"c", "f", "n"}, onlyA)
-	assert.EqualValues(t, []string{"g", "y"}, onlyB)
+	assert.Contains(t, onlyA, "c")
+	assert.Contains(t, onlyA, "f")
+	assert.Contains(t, onlyA, "n")
+	assert.Len(t, onlyA, 3)
+	assert.Contains(t, onlyB, "g")
+	assert.Contains(t, onlyB, "y")
+	assert.Len(t, onlyB, 2)
 
 	onlyA, onlyB = StringSliceSymmetricDifference(a, a)
 	assert.Equal(t, []string{}, onlyA)

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -52,3 +52,25 @@ func TestSplitCommas(t *testing.T) {
 		})
 	}
 }
+
+func TestStringSliceSymmetricDifference(t *testing.T) {
+	assert := assert.New(t)
+	a := []string{"a", "c", "f", "n", "q"}
+	b := []string{"q", "q", "g", "y", "a"}
+
+	onlyA, onlyB := StringSliceSymmetricDifference(a, b)
+	assert.EqualValues([]string{"c", "f", "n"}, onlyA)
+	assert.EqualValues([]string{"g", "y"}, onlyB)
+
+	onlyB, onlyA = StringSliceSymmetricDifference(b, a)
+	assert.EqualValues([]string{"c", "f", "n"}, onlyA)
+	assert.EqualValues([]string{"g", "y"}, onlyB)
+
+	onlyA, onlyB = StringSliceSymmetricDifference(a, a)
+	assert.Equal([]string{}, onlyA)
+	assert.Equal([]string{}, onlyB)
+
+	empty1, empty2 := StringSliceSymmetricDifference([]string{}, []string{})
+	assert.Equal([]string{}, empty1)
+	assert.Equal([]string{}, empty2)
+}

--- a/vendor/github.com/evergreen-ci/gimlet/auth_interfaces.go
+++ b/vendor/github.com/evergreen-ci/gimlet/auth_interfaces.go
@@ -112,6 +112,9 @@ type RoleManager interface {
 	// error if the same permission is registered more than once
 	RegisterPermissions([]string) error
 
+	// FindRoleWithResources returns all roles that apply to exactly the given resources
+	FindRolesWithResources(string, []string) ([]Role, error)
+
 	// FindRolesWithPermissions returns a role that exactly matches the given resources and permissions
 	FindRoleWithPermissions(string, []string, Permissions) (*Role, error)
 

--- a/vendor/github.com/evergreen-ci/gimlet/rolemanager/role_manager_test.go
+++ b/vendor/github.com/evergreen-ci/gimlet/rolemanager/role_manager_test.go
@@ -493,3 +493,33 @@ func (s *RoleManagerSuite) TestAddAndRemoveResources() {
 	s.NoError(err)
 	s.Equal(foundScope.ID, "root")
 }
+
+func (s *RoleManagerSuite) TestFindRolesWithResources() {
+	r1 := gimlet.Role{
+		ID:    "r1",
+		Scope: "1",
+	}
+	s.NoError(s.m.UpdateRole(r1))
+	r2 := gimlet.Role{
+		ID:    "r2",
+		Scope: "2",
+	}
+	s.NoError(s.m.UpdateRole(r2))
+	r3 := gimlet.Role{
+		ID:    "r3",
+		Scope: "1",
+	}
+	s.NoError(s.m.UpdateRole(r3))
+
+	roles, err := s.m.FindRolesWithResources("project", []string{"resource1", "resource2"})
+	s.NoError(err)
+	s.Len(roles, 2)
+
+	roles, err = s.m.FindRolesWithResources("project", []string{"resource1"})
+	s.NoError(err)
+	s.Len(roles, 0)
+
+	roles, err = s.m.FindRolesWithResources("project", []string{"resource4"})
+	s.NoError(err)
+	s.Len(roles, 0)
+}


### PR DESCRIPTION
- Add a "restricted" field to a project. Selecting this means that logged in users by default do not have any access to it. The admins and superusers will have access to it, and additional access must be granted manually
- This field is intentionally not in the API, let me know if you think it's needed
- When changing this flag in the UI, appropriately adjust access so that logged in users gain/lose access to it
- When updating the list of project admins, give/remove admin access for those users (not related to this flag, should have been in the previous PR)