### PR TITLE
EVG-7111 enable CORS for gql requests

### DIFF
--- a/service/middleware.go
+++ b/service/middleware.go
@@ -174,12 +174,19 @@ func (uis *UIServer) isSuperUser(u gimlet.User) bool {
 
 func (uis *UIServer) setCORSHeaders(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && len(uis.Settings.Ui.CORSOrigins) > 0 {
+		if len(uis.Settings.Ui.CORSOrigins) > 0 {
 			requester := r.Header.Get("Origin")
+
+			// Requests from a GQL client include this header, which must be added to the response to enable CORS
+			gqlHeader := r.Header.Get("Access-Control-Request-Headers")
+
 			if util.StringSliceContains(uis.Settings.Ui.CORSOrigins, requester) {
 				w.Header().Add("Access-Control-Allow-Origin", requester)
 				w.Header().Add("Access-Control-Allow-Credentials", "true")
 				w.Header().Add("Access-Control-Allow-Headers", fmt.Sprintf("%s, %s", evergreen.APIKeyHeader, evergreen.APIUserHeader))
+				if gqlHeader != "" {
+					w.Header().Add("Access-Control-Allow-Headers", gqlHeader)
+				}
 			}
 		}
 		grip.ErrorWhen(r.Method != http.MethodGet, message.Fields{

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -183,16 +183,9 @@ func (uis *UIServer) setCORSHeaders(next http.HandlerFunc) http.HandlerFunc {
 			if util.StringSliceContains(uis.Settings.Ui.CORSOrigins, requester) {
 				w.Header().Add("Access-Control-Allow-Origin", requester)
 				w.Header().Add("Access-Control-Allow-Credentials", "true")
-				w.Header().Add("Access-Control-Allow-Headers", fmt.Sprintf("%s, %s", evergreen.APIKeyHeader, evergreen.APIUserHeader))
-				if gqlHeader != "" {
-					w.Header().Add("Access-Control-Allow-Headers", gqlHeader)
-				}
+				w.Header().Add("Access-Control-Allow-Headers", fmt.Sprintf("%s, %s, %s", evergreen.APIKeyHeader, evergreen.APIUserHeader, gqlHeader))
 			}
 		}
-		grip.ErrorWhen(r.Method != http.MethodGet, message.Fields{
-			"cause":   "programmer error",
-			"message": "CORS headers should only be sent on requests that are idempotent and safe",
-		})
 		next(w, r)
 	}
 }

--- a/service/ui.go
+++ b/service/ui.go
@@ -279,8 +279,8 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	}
 
 	// GraphQL
-	app.AddRoute("/graphql").Handler(playground.Handler("GraphQL playground", "/graphql/query")).Get().Wrap(needsLogin)
-	app.AddRoute("/graphql/query").Handler(handler.NewDefaultServer(graphql.NewExecutableSchema(graphql.New())).ServeHTTP).Options().Post().Get().Wrap(needsLogin)
+	app.AddRoute("/graphql").Wrap(needsLogin, allowsCORS).Handler(playground.Handler("GraphQL playground", "/graphql/query")).Get()
+	app.AddRoute("/graphql/query").Wrap(needsLogin, allowsCORS).Handler(handler.NewDefaultServer(graphql.NewExecutableSchema(graphql.New())).ServeHTTP).Options().Post().Get()
 
 	// Waterfall pages
 	app.AddRoute("/").Wrap(needsContext).Handler(uis.waterfallPage).Get()


### PR DESCRIPTION
Enabling CORS for GQL requests requires setting the header from the GQL request in the response headers.