### PR TITLE
EVG-5545 send patches over the wire base64 encoded

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2019-01-07"
+	ClientVersion = "2019-01-09"
 )
 
 // ConfigSection defines a sub-document in the evegreen config

--- a/operations/http.go
+++ b/operations/http.go
@@ -321,11 +321,12 @@ func (ac *legacyClient) UpdatePatchModule(params UpdatePatchModuleParams) error 
 	// Because marshalling a byte slice to JSON will base64 encode it, the patch will be sent over the wire in base64
 	// and non utf-8 characters will be preserved.
 	data := struct {
-		Module  string `json:"module"`
-		Patch   []byte `json:"patch"`
-		Githash string `json:"githash"`
-		Message string `json:"message"`
-	}{params.module, []byte(params.patch), params.base, params.message}
+		Module      string `json:"module"`
+		PatchBytes  []byte `json:"patch_bytes"`
+		PatchString string `json:"patch"`
+		Githash     string `json:"githash"`
+		Message     string `json:"message"`
+	}{params.module, []byte(params.patch), params.patch, params.base, params.message}
 
 	rPipe, wPipe := io.Pipe()
 	encoder := json.NewEncoder(wPipe)
@@ -415,7 +416,8 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 	data := struct {
 		Description string   `json:"desc"`
 		Project     string   `json:"project"`
-		Patch       []byte   `json:"patch"`
+		PatchBytes  []byte   `json:"patch_bytes"`
+		PatchString string   `json:"patch"`
 		Githash     string   `json:"githash"`
 		Variants    []string `json:"buildvariants_new"`
 		Tasks       []string `json:"tasks"`
@@ -425,6 +427,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		incomingPatch.description,
 		incomingPatch.projectId,
 		[]byte(incomingPatch.patchData),
+		incomingPatch.patchData,
 		incomingPatch.base,
 		incomingPatch.variants,
 		incomingPatch.tasks,

--- a/operations/http.go
+++ b/operations/http.go
@@ -316,12 +316,16 @@ type UpdatePatchModuleParams struct {
 
 // UpdatePatchModule makes a request to the API server to set a module patch on the given patch ID.
 func (ac *legacyClient) UpdatePatchModule(params UpdatePatchModuleParams) error {
+	// Characters in a string without a utf-8 representation are shoehorned into the � replacement character
+	// when marshalled into JSON.
+	// Because marshalling a byte slice to JSON will base64 encode it, the patch will be sent over the wire in base64
+	// and non utf-8 characters will be preserved.
 	data := struct {
 		Module  string `json:"module"`
-		Patch   string `json:"patch"`
+		Patch   []byte `json:"patch"`
 		Githash string `json:"githash"`
 		Message string `json:"message"`
-	}{params.module, params.patch, params.base, params.message}
+	}{params.module, []byte(params.patch), params.base, params.message}
 
 	rPipe, wPipe := io.Pipe()
 	encoder := json.NewEncoder(wPipe)
@@ -404,10 +408,14 @@ func (ac *legacyClient) ListDistros() ([]distro.Distro, error) {
 // PutPatch submits a new patch for the given project to the API server. If successful, returns
 // the patch object itself.
 func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, error) {
+	// Characters in a string without a utf-8 representation are shoehorned into the � replacement character
+	// when marshalled into JSON.
+	// Because marshalling a byte slice to JSON will base64 encode it, the patch will be sent over the wire in base64
+	// and non utf-8 characters will be preserved.
 	data := struct {
 		Description string   `json:"desc"`
 		Project     string   `json:"project"`
-		Patch       string   `json:"patch"`
+		Patch       []byte   `json:"patch"`
 		Githash     string   `json:"githash"`
 		Variants    []string `json:"buildvariants_new"`
 		Tasks       []string `json:"tasks"`
@@ -416,7 +424,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 	}{
 		incomingPatch.description,
 		incomingPatch.projectId,
-		incomingPatch.patchData,
+		[]byte(incomingPatch.patchData),
 		incomingPatch.base,
 		incomingPatch.variants,
 		incomingPatch.tasks,


### PR DESCRIPTION
Characters in a string without a utf-8 representation are shoehorned into the � replacement character when marshalled into JSON. A patch _to_ these characters will not apply since the patch is trying to remove the � character, which isn't there. Additionally, adding these characters will just add �s. Apparently there's a word for this: [mojibake](https://en.wikipedia.org/wiki/Mojibake)

Because marshalling a byte slice to JSON will base64 encode it, the patch will be sent over the wire in base64 and non utf-8 characters will be preserved.