### PR TITLE
EVG-7085 turn on parser project

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -196,7 +196,7 @@ const (
 	GlobalGitHubTokenExpansion = "global_github_oauth_token"
 
 	// TODO: remove this when degrading YAML
-	UseParserProject = false
+	UseParserProject = true
 )
 
 func IsFinishedTaskStatus(status string) bool {

--- a/model/generate.go
+++ b/model/generate.go
@@ -183,7 +183,7 @@ func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProje
 
 // if the parser project is more recent, update contingent on that and force update the version (and vice versa)
 func updateVersionAndParserProject(v *Version, pp *ParserProject) error {
-	if pp.ConfigUpdateNumber > v.ConfigUpdateNumber {
+	if pp.ConfigUpdateNumber >= v.ConfigUpdateNumber {
 		curNumber := pp.ConfigUpdateNumber
 		if err := pp.UpsertWithConfigNumber(curNumber, true); err != nil {
 			return errors.Wrapf(err, "error upserting parser project '%s'", pp.Id)

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -233,7 +233,6 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		if err != nil {
 			return nil, errors.Wrap(err, "problem finding distro")
 		}
-		grip.Info(d)
 		if err = mapstructure.Decode(d.ProviderSettings, &ec2Settings); err != nil {
 			return nil, errors.Wrap(err, "problem unmarshaling provider settings")
 		}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -233,6 +233,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		if err != nil {
 			return nil, errors.Wrap(err, "problem finding distro")
 		}
+		grip.Info(d)
 		if err = mapstructure.Decode(d.ProviderSettings, &ec2Settings); err != nil {
 			return nil, errors.Wrap(err, "problem unmarshaling provider settings")
 		}

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -325,7 +325,7 @@ buildvariants:
 func TestCreateContainerFromTask(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	assert.NoError(db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, host.Collection))
+	assert.NoError(db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ParserProjectCollection, model.ProjectVarsCollection, host.Collection))
 	t1 := task.Task{
 		Id:           "t1",
 		DisplayName:  "t1",

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -274,14 +274,20 @@ func (restapi restAPI) getVersionInfo(w http.ResponseWriter, r *http.Request) {
 
 	if evergreen.UseParserProject && destVersion.Config == "" {
 		var err error
+		var config []byte
 		pp, err := model.ParserProjectFindOneById(projCtx.Version.Id)
 		if err != nil {
 			gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "problem finding parser project"})
+			return
 		}
-		config, err := yaml.Marshal(pp)
-		if err != nil {
-			gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "problem marshalling project"})
+		if pp != nil {
+			config, err = yaml.Marshal(pp)
+			if err != nil {
+				gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "problem marshalling project"})
+				return
+			}
 		}
+
 		destVersion.Config = string(config)
 	}
 

--- a/service/rest_version_test.go
+++ b/service/rest_version_test.go
@@ -304,6 +304,7 @@ func TestGetVersionInfo(t *testing.T) {
 			Remote:              false,
 			RemotePath:          "",
 			Requester:           evergreen.RepotrackerVersionRequester,
+			Config:              "this is my config",
 		}
 		So(v.Insert(), ShouldBeNil)
 
@@ -500,6 +501,7 @@ func TestActivateVersion(t *testing.T) {
 			Remote:              false,
 			RemotePath:          "",
 			Requester:           evergreen.RepotrackerVersionRequester,
+			Config:              "this is my config",
 		}
 		So(v.Insert(), ShouldBeNil)
 


### PR DESCRIPTION
I'd like to deploy this next week. Before that I'll do a re-read of what UseParserProject touches (reference https://github.com/evergreen-ci/evergreen/commit/37638678d41c27d3ffe7702ffc9c34fd6fe5dbdb and https://github.com/evergreen-ci/evergreen/commit/3c877e5ac0e81aca1627ff1cbb8caeb0667cf8b5). 

generate-lint and the smoke tasks work in staging, and I'd like to let it bake over the weekend.