### PR TITLE
EVG-7109 OPTIONS requests do not require login

### DIFF
--- a/service/ui.go
+++ b/service/ui.go
@@ -279,12 +279,10 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	}
 
 	// GraphQL
-	gqlHandler := handler.NewDefaultServer(graphql.NewExecutableSchema(graphql.New())).ServeHTTP
-
 	app.AddRoute("/graphql").Wrap(allowsCORS, needsLogin).Handler(playground.Handler("GraphQL playground", "/graphql/query")).Get()
-	app.AddRoute("/graphql/query").Wrap(allowsCORS, needsLogin).Handler(gqlHandler).Post().Get()
+	app.AddRoute("/graphql/query").Wrap(allowsCORS, needsLogin).Handler(handler.NewDefaultServer(graphql.NewExecutableSchema(graphql.New())).ServeHTTP).Post().Get()
 	// this route is used solely to introspect the schema of the GQL server. OPTIONS request by design do not include auth headers; therefore must not require login.
-	app.AddRoute("/graphql/query").Wrap(allowsCORS).Handler(gqlHandler).Options()
+	app.AddRoute("/graphql/query").Wrap(allowsCORS).Handler(func(_ http.ResponseWriter, _ *http.Request) {}).Options()
 
 	// Waterfall pages
 	app.AddRoute("/").Wrap(needsContext).Handler(uis.waterfallPage).Get()

--- a/service/ui.go
+++ b/service/ui.go
@@ -279,8 +279,12 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	}
 
 	// GraphQL
-	app.AddRoute("/graphql").Wrap(needsLogin, allowsCORS).Handler(playground.Handler("GraphQL playground", "/graphql/query")).Get()
-	app.AddRoute("/graphql/query").Wrap(needsLogin, allowsCORS).Handler(handler.NewDefaultServer(graphql.NewExecutableSchema(graphql.New())).ServeHTTP).Options().Post().Get()
+	gqlHandler := handler.NewDefaultServer(graphql.NewExecutableSchema(graphql.New())).ServeHTTP
+
+	app.AddRoute("/graphql").Wrap(allowsCORS, needsLogin).Handler(playground.Handler("GraphQL playground", "/graphql/query")).Get()
+	app.AddRoute("/graphql/query").Wrap(allowsCORS, needsLogin).Handler(gqlHandler).Post().Get()
+	// this route is used solely to introspect the schema of the GQL server. OPTIONS request by design do not include auth headers; therefore must not require login.
+	app.AddRoute("/graphql/query").Wrap(allowsCORS).Handler(gqlHandler).Options()
 
 	// Waterfall pages
 	app.AddRoute("/").Wrap(needsContext).Handler(uis.waterfallPage).Get()


### PR DESCRIPTION
All GET and POST requests to the GQL server require login. OPTIONS requests do not require login. By design, OPTIONS requests do not include auth headers such as cookie. This is because it's used to describe the communication options for the target resource.

This PR will be followed by a PR to Spruce that allows developer to log in and out while in dev mode. This will set the user's cookie and enable making authenticated queries to gql server. Handling authentication in production in Spruce is a ticket that will be discussed later on in the design doc. Currently Spruce does not handle its own authentication in production--it shares the cookie from Evergreen. 