### PR TITLE
EVG-6592 (part 1) check is not mailbox diff

### DIFF
--- a/command/git.go
+++ b/command/git.go
@@ -606,7 +606,7 @@ func isMailboxPatch(patchFile string) (bool, error) {
 // patch, it uses git-am (see https://git-scm.com/docs/git-am), otherwise
 // it uses git apply
 func getApplyCommand(patchFile string) (string, error) {
-	isMBP, err := isMailboxPatch(patchFile)
+	isMBP, err := patch.IsMailbox(patchFile)
 	if err != nil {
 		return "", errors.Wrap(err, "can't check patch type")
 	}

--- a/command/git.go
+++ b/command/git.go
@@ -1,14 +1,12 @@
 package command
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -576,30 +574,6 @@ func (c *gitFetchProject) getPatchContents(ctx context.Context, comm client.Comm
 		patch.Patches[i].PatchSet.Patch = result
 	}
 	return nil
-}
-
-// isMailboxPatch checks if the first line of a patch file
-// has "From ". If so, it's assumed to be a mailbox-style patch, otherwise
-// it's a diff
-func isMailboxPatch(patchFile string) (bool, error) {
-	file, err := os.Open(patchFile)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to read patch file")
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	if !scanner.Scan() {
-		if err = scanner.Err(); err != nil {
-			return false, errors.Wrap(err, "failed to read patch file")
-		}
-
-		// otherwise, it's EOF. Empty patches are not errors!
-		return false, nil
-	}
-	line := scanner.Text()
-
-	return strings.HasPrefix(line, "From "), nil
 }
 
 // getApplyCommand determines the patch type. If the patch is a mailbox-style

--- a/command/git_test.go
+++ b/command/git_test.go
@@ -720,24 +720,6 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionManifest() {
 	s.True(foundMsg)
 }
 
-func (s *GitGetProjectSuite) TestIsMailboxPatch() {
-	isMBP, err := isMailboxPatch(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "filethatdoesntexist.txt"))
-	s.Error(err)
-	s.False(isMBP)
-
-	isMBP, err = isMailboxPatch(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "test.patch"))
-	s.NoError(err)
-	s.True(isMBP)
-
-	isMBP, err = isMailboxPatch(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "test.diff"))
-	s.NoError(err)
-	s.False(isMBP)
-
-	isMBP, err = isMailboxPatch(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "emptyfile.txt"))
-	s.NoError(err)
-	s.False(isMBP)
-}
-
 func (s *GitGetProjectSuite) TearDownSuite() {
 	if s.modelData1.TaskConfig != nil {
 		s.NoError(os.RemoveAll(s.modelData1.TaskConfig.WorkDir))

--- a/command/testdata/test.diff
+++ b/command/testdata/test.diff
@@ -1,4 +1,0 @@
-diff --git a/migrations/anser.go b/migrations/anser.go
-index e11ae935..116da030 100644
---- a/migrations/anser.go
-+++ b/migrations/anser.go

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -1,6 +1,7 @@
 package patch
 
 import (
+	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -220,4 +221,22 @@ func TestPatchSortByCreateTime(t *testing.T) {
 	assert.Equal(4, patches[2].PatchNumber)
 	assert.Equal(5, patches[3].PatchNumber)
 	assert.Equal(100, patches[4].PatchNumber)
+}
+
+func TestIsMailboxPatch(t *testing.T) {
+	isMBP, err := IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "filethatdoesntexist.txt"))
+	assert.Error(t, err)
+	assert.False(t, isMBP)
+
+	isMBP, err = IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "test.patch"))
+	assert.NoError(t, err)
+	assert.True(t, isMBP)
+
+	isMBP, err = IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "test.diff"))
+	assert.NoError(t, err)
+	assert.False(t, isMBP)
+
+	isMBP, err = IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "emptyfile.txt"))
+	assert.NoError(t, err)
+	assert.False(t, isMBP)
 }

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -223,20 +223,20 @@ func TestPatchSortByCreateTime(t *testing.T) {
 	assert.Equal(100, patches[4].PatchNumber)
 }
 
-func TestIsMailboxPatch(t *testing.T) {
-	isMBP, err := IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "filethatdoesntexist.txt"))
+func TestIsMailbox(t *testing.T) {
+	isMBP, err := IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "..", "testdata", "filethatdoesntexist.txt"))
 	assert.Error(t, err)
 	assert.False(t, isMBP)
 
-	isMBP, err = IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "test.patch"))
+	isMBP, err = IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "..", "testdata", "test.patch"))
 	assert.NoError(t, err)
 	assert.True(t, isMBP)
 
-	isMBP, err = IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "test.diff"))
+	isMBP, err = IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "..", "testdata", "patch.diff"))
 	assert.NoError(t, err)
 	assert.False(t, isMBP)
 
-	isMBP, err = IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "emptyfile.txt"))
+	isMBP, err = IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "..", "testdata", "emptyfile.txt"))
 	assert.NoError(t, err)
 	assert.False(t, isMBP)
 }

--- a/model/testdata/test.patch
+++ b/model/testdata/test.patch
@@ -1,0 +1,43 @@
+From 8af7f21625315b8c24975016aa2107cf5a8a12b1 Mon Sep 17 00:00:00 2001
+From: ablack12 <annie.black@10gen.com>
+Date: Thu, 2 Jan 2020 10:41:34 -0500
+Subject: EVG-6799 remove one commit validation
+
+---
+operations/commit_queue.go | 16 +++++++++-------
+2 files changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/operations/commit_queue.go b/units/commit_queue.go
+index 3fd24ea7e..800e17d2f 100644
+--- a/operations/commit_queue.go
++++ b/operations/commit_queue.go
+@@ -122,6 +122,7 @@ func mergeCommand() cli.Command {
+                                Usage: "force item to front of queue",
+                        },
+                )),
++               Before: setPlainLogger,
+                Action: func(c *cli.Context) error {
+                        ctx, cancel := context.WithCancel(context.Background())
+                        defer cancel()
+
+From 8c030c565ebca71380f3ca5c88d895fa9f25bebd Mon Sep 17 00:00:00 2001
+From: ablack12 <annie.black@10gen.com>
+Date: Thu, 2 Jan 2020 13:35:10 -0500
+Subject: temp
+
+---
+units/commit_queue.go | 5 +++--
+1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/units/commit_queue.go b/units/commit_queue.go
+index ce0542e91..718dd8099 100644
+--- a/units/commit_queue.go
++++ b/units/commit_queue.go
+@@ -512,6 +512,7 @@ func validateBranch(branch *github.Branch) error {
+ }
+
+ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project) error {
++       grip.Log("From (hoping this doesn't mess anything up)")'"
+        settings, err := evergreen.GetConfig()
+        if err != nil {
+                return errors.Wrap(err, "error retrieving Evergreen config")

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -60,7 +60,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if patch.IsMailboxDiff(patchString) {
-		as.LoggedError(w, r, http.StatusBadRequest, errors.New("CLI is out of date"))
+		as.LoggedError(w, r, http.StatusBadRequest, errors.New("CLI is out of date: use 'evergreen get-update --install'"))
 	}
 	pref, err := model.FindOneProjectRef(data.Project)
 	if err != nil {

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -59,6 +59,9 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if patch.IsMailboxDiff(patchString) {
+		as.LoggedError(w, r, http.StatusBadRequest, errors.New("CLI is out of date"))
+	}
 	pref, err := model.FindOneProjectRef(data.Project)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrapf(err, "project %s is not specified", data.Project))


### PR DESCRIPTION
Merging this ahead of https://github.com/evergreen-ci/evergreen/pull/3006, so if we roll that back we will have a check in place stating that patches cannot be mbox (since apps won't know how to handle this format anymore in `git.push`). 

(refactor of isMailboxPatch was intended for that PR anyway)