### PR TITLE
GQL http handler

### DIFF
--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -1,0 +1,14 @@
+package graphql
+
+import (
+	"net/http"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+)
+
+// Handler returns a gimlet http handler func used as the gql route handler
+func Handler() func(w http.ResponseWriter, r *http.Request) {
+	srv := handler.NewDefaultServer(NewExecutableSchema(New()))
+
+	return srv.ServeHTTP
+}

--- a/service/ui.go
+++ b/service/ui.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/auth"
@@ -280,7 +279,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 
 	// GraphQL
 	app.AddRoute("/graphql").Wrap(allowsCORS, needsLogin).Handler(playground.Handler("GraphQL playground", "/graphql/query")).Get()
-	app.AddRoute("/graphql/query").Wrap(allowsCORS, needsLogin).Handler(handler.NewDefaultServer(graphql.NewExecutableSchema(graphql.New())).ServeHTTP).Post().Get()
+	app.AddRoute("/graphql/query").Wrap(allowsCORS, needsLogin).Handler(graphql.Handler()).Post().Get()
 	// this route is used solely to introspect the schema of the GQL server. OPTIONS request by design do not include auth headers; therefore must not require login.
 	app.AddRoute("/graphql/query").Wrap(allowsCORS).Handler(func(_ http.ResponseWriter, _ *http.Request) {}).Options()
 


### PR DESCRIPTION
Refactor the gql http handler func to be in the graphql package. This format will allow for more easily adding middleware later on. 