### PR TITLE
EVG-7085 check length and add omitempty

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -346,8 +346,8 @@ type ArtifactInstructions struct {
 }
 
 type YAMLCommandSet struct {
-	SingleCommand *PluginCommandConf  `bson:"single_command,omitempty"`
-	MultiCommand  []PluginCommandConf `bson:"multi_command,omitempty"`
+	SingleCommand *PluginCommandConf  `yaml:"single_command,omitempty" bson:"single_command,omitempty"`
+	MultiCommand  []PluginCommandConf `yaml:"multi_command,omitempty" bson:"multi_command,omitempty"`
 }
 
 func (c *YAMLCommandSet) List() []PluginCommandConf {
@@ -1045,7 +1045,7 @@ func FindLastKnownGoodProject(identifier string) (*Project, error) {
 		}
 		grip.Critical(message.WrapError(err, message.Fields{
 			"message": "last known good version has malformed config",
-			"version": lastGoodVersion.Identifier,
+			"version": lastGoodVersion.Id,
 			"project": identifier,
 		}))
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -192,7 +192,7 @@ func (pd *parserDependency) UnmarshalYAML(unmarshal func(interface{}) error) err
 // in the context of dependencies and requirements fields. //TODO no export?
 type taskSelector struct {
 	Name    string           `yaml:"name,omitempty"`
-	Variant *variantSelector `yaml:"variant,omitempty" bson:"variant"`
+	Variant *variantSelector `yaml:"variant,omitempty" bson:"variant,omitempty"`
 }
 
 // TaskSelectors is a helper type for parsing arrays of TaskSelector.
@@ -201,8 +201,8 @@ type taskSelectors []taskSelector
 // VariantSelector handles the selection of a variant, either by a id/tag selector
 // or by matching against matrix axis values.
 type variantSelector struct {
-	StringSelector string           `yaml:"string_selector" bson:"string_selector"`
-	MatrixSelector matrixDefinition `yaml:"matrix_selector" bson:"matrix_selector"`
+	StringSelector string           `yaml:"string_selector,omitempty" bson:"string_selector,omitempty"`
+	MatrixSelector matrixDefinition `yaml:"matrix_selector,omitempty" bson:"matrix_selector,omitempty"`
 }
 
 // UnmarshalYAML allows variants to be referenced as single selector strings or

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -372,7 +372,7 @@ func (v *variantSelectorEvaluator) evalSelector(vs *variantSelector) ([]string, 
 	if vs == nil {
 		return nil, errors.New("empty selector")
 	}
-	if vs.MatrixSelector != nil {
+	if len(vs.MatrixSelector) > 0 {
 		evaluatedSelector, errs := vs.MatrixSelector.evaluatedCopy(v.axisEval)
 		if len(errs) > 0 {
 			return nil, errors.Errorf(
@@ -381,7 +381,7 @@ func (v *variantSelectorEvaluator) evalSelector(vs *variantSelector) ([]string, 
 		results := []string{}
 		// this could be sped up considerably with caching, but I doubt we'll need to
 		for _, v := range v.variants {
-			if v.MatrixVal != nil && evaluatedSelector.contains(v.MatrixVal) {
+			if len(v.MatrixVal) > 0 && evaluatedSelector.contains(v.MatrixVal) {
 				results = append(results, v.Name)
 			}
 		}


### PR DESCRIPTION
Potentially some omitempties missing (I actually don't know if it matters but just in case), but we should check length of empty maps rather than nil since it might exist bc of database things but still just be empty.

I looked in project_matrix.go, project_parser.go, project.go, and project_selector.go for other instances of this problem and this is what I came up with.