### PR TITLE
EVG-7085 handle params when unmarshalling bson

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	ignore "github.com/sabhiram/go-git-ignore"
+	mgobson "gopkg.in/mgo.v2/bson"
 	"gopkg.in/yaml.v2"
 )
 
@@ -316,6 +317,13 @@ func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(interface{}) error) err
 	c.Loggers = temp.Loggers
 	c.ParamsYAML = temp.ParamsYAML
 	c.Params = temp.Params
+	return c.unmarshalParams()
+}
+
+func (c *PluginCommandConf) UnmarshalBSON(in []byte) error {
+	if err := mgobson.Unmarshal(in, c); err != nil {
+		return err
+	}
 	return c.unmarshalParams()
 }
 


### PR DESCRIPTION
This can be done independently of the other EVG-7085 revert.

I have no idea how this slipped through during phase 1 of this project, since that was forever ago, but when retrieving a parser project from the database, params weren't being restored before use.

Also improved the parser project test to have caught this, and tested with server and cloud yamls.