### PR TITLE
EVG-6600 option to filter commit queue patches

### DIFF
--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -86,7 +86,7 @@ func ById(id mgobson.ObjectId) db.Q {
 var commitQueueFilter = bson.M{"$ne": evergreen.CommitQueueAlias}
 
 // ByProject produces a query that returns projects with the given identifier.
-func ByProject(project string, filterCommitQueue bool) db.Q {
+func ByProjectAndCommitQueue(project string, filterCommitQueue bool) db.Q {
 	q := bson.M{ProjectKey: project}
 	if filterCommitQueue {
 		q[AliasKey] = commitQueueFilter
@@ -95,7 +95,7 @@ func ByProject(project string, filterCommitQueue bool) db.Q {
 }
 
 // ByUser produces a query that returns patches by the given user.
-func ByUser(user string, filterCommitQueue bool) db.Q {
+func ByUserAndCommitQueue(user string, filterCommitQueue bool) db.Q {
 	q := bson.M{AuthorKey: user}
 	if filterCommitQueue {
 		q[AliasKey] = commitQueueFilter

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -83,14 +83,25 @@ func ById(id mgobson.ObjectId) db.Q {
 	return db.Query(bson.M{IdKey: id})
 }
 
+var commitQueueFilter = bson.M{"$ne": evergreen.CommitQueueAlias}
+
 // ByProject produces a query that returns projects with the given identifier.
-func ByProject(project string) db.Q {
-	return db.Query(bson.M{ProjectKey: project})
+func ByProject(project string, filterCommitQueue bool) db.Q {
+	q := bson.M{ProjectKey: project}
+	if filterCommitQueue {
+		q[AliasKey] = commitQueueFilter
+	}
+	return db.Query(q)
 }
 
 // ByUser produces a query that returns patches by the given user.
-func ByUser(user string) db.Q {
-	return db.Query(bson.M{AuthorKey: user})
+func ByUser(user string, filterCommitQueue bool) db.Q {
+	q := bson.M{AuthorKey: user}
+	if filterCommitQueue {
+		q[AliasKey] = commitQueueFilter
+	}
+
+	return db.Query(q)
 }
 
 // ByUserPaginated produces a query that returns patches by the given user

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -166,7 +166,7 @@ func (s *patchSuite) TestMakeMergePatch() {
 }
 
 func (s *patchSuite) TestUpdateGithashProjectAndTasks() {
-	patch, err := FindOne(ByUser("octocat", false))
+	patch, err := FindOne(ByUserAndCommitQueue("octocat", false))
 	s.NoError(err)
 	s.Empty(patch.Githash)
 	s.Empty(patch.VariantsTasks)

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -166,7 +166,7 @@ func (s *patchSuite) TestMakeMergePatch() {
 }
 
 func (s *patchSuite) TestUpdateGithashProjectAndTasks() {
-	patch, err := FindOne(ByUser("octocat"))
+	patch, err := FindOne(ByUser("octocat", false))
 	s.NoError(err)
 	s.Empty(patch.Githash)
 	s.Empty(patch.VariantsTasks)

--- a/public/static/js/patches.js
+++ b/public/static/js/patches.js
@@ -3,7 +3,6 @@ mciModule.controller('PatchesController', function($scope, $filter, $http, $wind
   $scope.userTz = $window.userTz;
 
   $scope.loading = true;
-  $scope.filterCommitQueue = false;
   $scope.patchesForUsername = $window.patchesForUsername;
   var endpoint = $scope.patchesForUsername ?
     '/json/patches/user/' + encodeURIComponent($window.patchesForUsername) :
@@ -18,6 +17,7 @@ mciModule.controller('PatchesController', function($scope, $filter, $http, $wind
   };
 
   $scope.loadCurrentPage = function() {
+    $scope.filterCommitQueue = localStorage.getItem("filterCommitQueue") === "true";
     $scope.loading = true;
     $scope.patches = [];
     $scope.patchesError = null;
@@ -57,11 +57,10 @@ mciModule.controller('PatchesController', function($scope, $filter, $http, $wind
     });
   };
 
-  $scope.toggleFilter = function() {
-    $scope.filterCommitQueue = !$scope.filterCommitQueue;
-    $scope.loadCurrentPage();
-  }
-
+  $scope.$watch("filterCommitQueue", function() {
+      localStorage.setItem("filterCommitQueue", $scope.filterCommitQueue);
+      $scope.loadCurrentPage();
+  });
 
   $rootScope.$on('$locationChangeStart', function() {
     var page = $location.search()['page'];

--- a/public/static/js/patches.js
+++ b/public/static/js/patches.js
@@ -3,7 +3,7 @@ mciModule.controller('PatchesController', function($scope, $filter, $http, $wind
   $scope.userTz = $window.userTz;
 
   $scope.loading = true;
-
+  $scope.filterCommitQueue = false;
   $scope.patchesForUsername = $window.patchesForUsername;
   var endpoint = $scope.patchesForUsername ?
     '/json/patches/user/' + encodeURIComponent($window.patchesForUsername) :
@@ -21,10 +21,10 @@ mciModule.controller('PatchesController', function($scope, $filter, $http, $wind
     $scope.loading = true;
     $scope.patches = [];
     $scope.patchesError = null;
-
     var params = {
       params: {
-        page: $scope.currentPage
+        page: $scope.currentPage,
+        filter_commit_queue: $scope.filterCommitQueue,
       }
     };
     $http.get(endpoint, params).then(
@@ -56,6 +56,12 @@ mciModule.controller('PatchesController', function($scope, $filter, $http, $wind
       $scope.patchesError = resp.err;
     });
   };
+
+  $scope.toggleFilter = function() {
+    $scope.filterCommitQueue = !$scope.filterCommitQueue;
+    $scope.loadCurrentPage();
+  }
+
 
   $rootScope.$on('$locationChangeStart', function() {
     var page = $location.search()['page'];

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -281,7 +281,7 @@ func TestCommitQueueItemOwnerMiddlewareUserPatch(t *testing.T) {
 		Author: "octocat",
 	}
 	assert.NoError(p.Insert())
-	p, err = patch.FindOne(patch.ByUser("octocat", false))
+	p, err = patch.FindOne(patch.ByUserAndCommitQueue("octocat", false))
 	assert.NoError(err)
 	assert.NotNil(p)
 

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -281,7 +281,7 @@ func TestCommitQueueItemOwnerMiddlewareUserPatch(t *testing.T) {
 		Author: "octocat",
 	}
 	assert.NoError(p.Insert())
-	p, err = patch.FindOne(patch.ByUser("octocat"))
+	p, err = patch.FindOne(patch.ByUser("octocat", false))
 	assert.NoError(err)
 	assert.NotNil(p)
 

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -247,7 +247,8 @@ func (as *APIServer) listPatches(w http.ResponseWriter, r *http.Request) {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrap(err, "cannot read value n"))
 		return
 	}
-	query := patch.ByUser(dbUser.Id).Sort([]string{"-" + patch.CreateTimeKey})
+	filterCommitQueue := r.FormValue("filter_commit_queue") == "true"
+	query := patch.ByUser(dbUser.Id, filterCommitQueue).Sort([]string{"-" + patch.CreateTimeKey})
 	if n > 0 {
 		query = query.Limit(n)
 	}

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -248,7 +248,7 @@ func (as *APIServer) listPatches(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	filterCommitQueue := r.FormValue("filter_commit_queue") == "true"
-	query := patch.ByUser(dbUser.Id, filterCommitQueue).Sort([]string{"-" + patch.CreateTimeKey})
+	query := patch.ByUserAndCommitQueue(dbUser.Id, filterCommitQueue).Sort([]string{"-" + patch.CreateTimeKey})
 	if n > 0 {
 		query = query.Limit(n)
 	}

--- a/service/templates/patches.html
+++ b/service/templates/patches.html
@@ -39,7 +39,7 @@ Evergreen - Patches
             Newer
           </a>
         </span>
-        <span>
+        <span ng-if="patches.length > 0">
           <a  class="btn btn-default"
               style="cursor: pointer"
               ng-click="nextPage()">

--- a/service/templates/patches.html
+++ b/service/templates/patches.html
@@ -28,9 +28,9 @@ Evergreen - Patches
       Error loading data from server: [[patchesError]]
     </div>
 
-    <div class="form-inline" ng-if="patches.length > 0">
+    <div class="form-inline">
       <div class="btn-group btn-group-sm header-pagination">
-        <input type="checkbox" id="queue" ng-model="filterCommitQueue" ng-change="toggleFilter()">
+        <input type="checkbox" id="queue" ng-model="filterCommitQueue">
         <label for="queue" style="font-weight:normal;margin-right: 10px;">Filter Commit Queue</label>
         <span ng-if="currentPage > 0">
           <a  class="btn btn-default"

--- a/service/templates/patches.html
+++ b/service/templates/patches.html
@@ -28,22 +28,25 @@ Evergreen - Patches
       Error loading data from server: [[patchesError]]
     </div>
 
-    <div  ng-if="patches.length > 0"
-          class="btn-group btn-group-sm pagination-fixed">
-      <span ng-if="currentPage > 0">
-        <a  class="btn btn-default"
-            style="cursor: pointer"
-            ng-click="previousPage()">
-          Newer
-        </a>
-      </span>
-      <span>
-        <a  class="btn btn-default"
-            style="cursor: pointer"
-            ng-click="nextPage()">
-          Older
-        </a>
-      </span>
+    <div class="form-inline" ng-if="patches.length > 0">
+      <div class="btn-group btn-group-sm header-pagination">
+        <input type="checkbox" id="queue" ng-model="filterCommitQueue" ng-change="toggleFilter()">
+        <label for="queue" style="font-weight:normal;margin-right: 10px;">Filter Commit Queue</label>
+        <span ng-if="currentPage > 0">
+          <a  class="btn btn-default"
+              style="cursor: pointer"
+              ng-click="previousPage()">
+            Newer
+          </a>
+        </span>
+        <span>
+          <a  class="btn btn-default"
+              style="cursor: pointer"
+              ng-click="nextPage()">
+            Older
+          </a>
+        </span>
+      </div>
     </div>
   </header>
 

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -115,7 +115,7 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 	user := gimlet.GetVars(r)["user_id"]
 	var patches []patch.Patch
 	if len(user) > 0 {
-		patches, err = patch.Find(patch.ByUser(user, filterCommitQueue).
+		patches, err = patch.Find(patch.ByUserAndCommitQueue(user, filterCommitQueue).
 			Project(patch.ExcludePatchDiff).
 			Sort([]string{"-" + patch.CreateTimeKey}).
 			Skip(skip).Limit(DefaultLimit))

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -132,7 +132,7 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 				"Error fetching project %v", projectID))
 			return
 		}
-		patches, err = patch.Find(patch.ByProject(project.Identifier, filterCommitQueue).
+		patches, err = patch.Find(patch.ByProjectAndCommitQueue(project.Identifier, filterCommitQueue).
 			Sort([]string{"-" + patch.CreateTimeKey}).
 			Project(patch.ExcludePatchDiff).
 			Skip(skip).Limit(DefaultLimit))

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -111,11 +111,11 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 		pageNum = 0
 	}
 	skip := pageNum * DefaultLimit
-
+	filterCommitQueue := r.FormValue("filter_commit_queue") == "true"
 	user := gimlet.GetVars(r)["user_id"]
 	var patches []patch.Patch
 	if len(user) > 0 {
-		patches, err = patch.Find(patch.ByUser(user).
+		patches, err = patch.Find(patch.ByUser(user, filterCommitQueue).
 			Project(patch.ExcludePatchDiff).
 			Sort([]string{"-" + patch.CreateTimeKey}).
 			Skip(skip).Limit(DefaultLimit))
@@ -132,7 +132,7 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 				"Error fetching project %v", projectID))
 			return
 		}
-		patches, err = patch.Find(patch.ByProject(project.Identifier).
+		patches, err = patch.Find(patch.ByProject(project.Identifier, filterCommitQueue).
 			Sort([]string{"-" + patch.CreateTimeKey}).
 			Project(patch.ExcludePatchDiff).
 			Skip(skip).Limit(DefaultLimit))


### PR DESCRIPTION
This is in-line with the Newer/Older buttons, and modifies the query rather than the current patch results (John has verified that this is the least awkward approach).

![image](https://user-images.githubusercontent.com/26798134/72467437-e4bf5800-37a8-11ea-8d95-272b256dafee.png)
