### PR TITLE
EVG-7190 standardize commit queue patch messages

### DIFF
--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -239,4 +240,40 @@ func TestIsMailbox(t *testing.T) {
 	isMBP, err = IsMailbox(filepath.Join(testutil.GetDirectoryOfFile(), "..", "testdata", "emptyfile.txt"))
 	assert.NoError(t, err)
 	assert.False(t, isMBP)
+}
+
+func TestUpdateModulePatch(t *testing.T) {
+	require.NoError(t, db.Clear(Collection))
+	p := &Patch{Description: "original message"}
+	require.NoError(t, p.Insert())
+	p, err := FindOne(db.Q{})
+	require.NoError(t, err)
+
+	// with a new module patch
+	assert.NoError(t, p.UpdateModulePatch(ModulePatch{
+		ModuleName: "mod1",
+		Message:    "new message",
+	}))
+
+	assert.Len(t, p.Patches, 1)
+	assert.Equal(t, "new message", p.Description)
+
+	pDb, err := FindOne(db.Q{})
+	assert.NoError(t, err)
+	assert.Equal(t, "new message", pDb.Description)
+	assert.Len(t, pDb.Patches, 1)
+
+	// with an existing module patch
+	assert.NoError(t, p.UpdateModulePatch(ModulePatch{
+		ModuleName: "mod1",
+		Message:    "newer message",
+	}))
+
+	assert.Len(t, p.Patches, 1)
+	assert.Equal(t, "newer message", p.Description)
+
+	pDb, err = FindOne(db.Q{})
+	assert.NoError(t, err)
+	assert.Equal(t, "newer message", pDb.Description)
+	assert.Len(t, pDb.Patches, 1)
 }

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -21,8 +21,6 @@ const (
 	pauseFlagName       = "pause"
 	resumeFlagName      = "resume"
 	descriptionFlagName = "description"
-	noCommits           = "No Commits Added"
-	commitFmtString     = "'%s' into '%s/%s:%s'"
 )
 
 func CommitQueue() cli.Command {

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -396,7 +396,7 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 	if patch.Description == "" {
 		message, err = gitCommitMessages(module.Branch, p.ref)
 		if err != nil {
-			errors.Wrap(err, "can't get module commit messages")
+			return errors.Wrap(err, "can't get module commit messages")
 		}
 	}
 

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -345,15 +345,15 @@ func (p *mergeParams) uploadMergePatch(conf *ClientSettings, ac *legacyClient) e
 		return errors.Wrap(err, "can't generate patches")
 	}
 
+	commits := noCommits
 	if commitCount > 0 {
 		commitMessage, err := gitCommitMessages(ref.Branch, p.ref)
 		if err != nil {
-			errors.Wrap(err, "can't get commit messages")
+			return errors.Wrap(err, "can't get commit messages")
 		}
-		patchParams.Description = fmt.Sprintf("Commit Queue Merge: %s", fmt.Sprintf(commitFmtString, commitMessage, ref.Owner, ref.Repo, ref.Branch))
-	} else {
-		patchParams.Description = fmt.Sprintf("Commit Queue Merge: %s", noCommits)
+		commits = fmt.Sprintf(commitFmtString, commitMessage, ref.Owner, ref.Repo, ref.Branch)
 	}
+	patchParams.Description = fmt.Sprintf("Commit Queue Merge: %s", commits)
 
 	patch, err := patchParams.createPatch(ac, conf, diffData)
 	if err != nil {
@@ -408,7 +408,8 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 	if err != nil {
 		errors.Wrap(err, "can't get commit messages")
 	}
-	message := fmt.Sprintf("%s %s", strings.TrimSuffix(patch.Description, noCommits), fmt.Sprintf(commitFmtString, commitMessage, owner, repo, module.Branch))
+	commits := fmt.Sprintf(commitFmtString, commitMessage, owner, repo, module.Branch)
+	message := fmt.Sprintf("%s || %s", strings.TrimSuffix(patch.Description, noCommits), commits)
 
 	diffData, err := loadGitData(module.Branch, p.ref, true)
 	if err != nil {

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -105,7 +105,7 @@ func Patch() cli.Command {
 			if params.Description == "" {
 				params.Description, err = getDefaultDescription()
 				if err != nil {
-					grip.Debug(err)
+					grip.Error(err)
 				}
 			}
 
@@ -181,7 +181,7 @@ func PatchFile() cli.Command {
 			if params.Description == "" {
 				params.Description, err = getDefaultDescription()
 				if err != nil {
-					grip.Debug(err)
+					grip.Error(err)
 				}
 			}
 

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -102,6 +102,13 @@ func Patch() cli.Command {
 				return err
 			}
 
+			if params.Description == "" {
+				params.Description, err = getDefaultDescription()
+				if err != nil {
+					grip.Debug(err)
+				}
+			}
+
 			_, err = params.createPatch(ac, conf, diffData)
 			return err
 		},
@@ -170,6 +177,13 @@ func PatchFile() cli.Command {
 			}
 
 			diffData := &localDiff{string(fullPatch), "", "", base}
+
+			if params.Description == "" {
+				params.Description, err = getDefaultDescription()
+				if err != nil {
+					grip.Debug(err)
+				}
+			}
 
 			_, err = params.createPatch(ac, conf, diffData)
 			return err

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -430,14 +430,14 @@ func gitLog(base, ref string) (string, error) {
 }
 
 func gitCommitMessages(base, ref string) (string, error) {
-	args := []string{"--no-show-signature", "--pretty=format:%B", "--reverse", fmt.Sprintf("%s@{upstream}..%s", base, ref)}
+	args := []string{"--no-show-signature", "--pretty=format:%s", "--reverse", fmt.Sprintf("%s@{upstream}..%s", base, ref)}
 	msg, err := gitCmd("log", args...)
 	if err != nil {
 		return "", errors.Wrap(err, "can't get messages")
 	}
 	// separate multiple commits with <-
-	msg = strings.Replace(msg, "\n\n", " <- ", -1)
 	msg = strings.TrimSpace(msg)
+	msg = strings.Replace(msg, "\n", " <- ", -1)
 
 	return msg, nil
 }


### PR DESCRIPTION
The immediate issue is that since c022192f89f2ac746dbe07d9c5c76752dcabdf3f commit queue patches with no community commits get the default patch description which fails commit message validation. This is addressed by moving the check for an empty patch description to be specific to the patch and patch-file CLI commands.

Since de91beefb4ca4ffced5138447ed94cdba4e55042 commit queue commit messages come from the messages of the commits enqueued and the patch description is no longer doing double-duty as the commit message. Therefore, it seems reasonable to standardize commit queue patch descriptions (especially in light of complaints like [this one](https://jira.mongodb.org/browse/EVG-6600)). The original patch's description will be of the form 
```
Commit Queue Merge: '<commit message>' into '<owner>/<repo>:<branch>'
```
If modules are added `'<commit message>' into '<module_owner>/<module_repo>:<module_branch>'` will be appended to the description. A potential issue with this is if a module is updated, where it will appear twice. I think the gain of solving this problem doesn't warrant additional complexity it will entail, but I could be convinced otherwise.

**Backwards Compatibility**
Users who are still on the old CLI will be _mostly_ unaffected: their commit messages will still be the patch description supplied on the command line. The patch description will be the concatenation of the main patch's commit message and each module's commit message, but the commit messages will still be correct.
In case of rollback to a post de91beefb4ca4ffced5138447ed94cdba4e55042 commit users with the new CLI will still have correct commit messages. The patch description will not be adjusted when modules are added.

**Merging this change will require coordination with DAG to adjust the commit message validation script to parse commit message(s) from the description.**