### PR TITLE
EVG-7085 generate tasks should noop with duplicate key errors

### DIFF
--- a/db/errors.go
+++ b/db/errors.go
@@ -12,12 +12,11 @@ func IsDuplicateKey(err error) bool {
 		return false
 	}
 
-	err = errors.Cause(err)
-	if mgo.IsDup(err) {
+	if mgo.IsDup(errors.Cause(err)) {
 		return true
 	}
 
-	if strings.Contains(err.Error(), "duplicate key") {
+	if strings.Contains(errors.Cause(err).Error(), "duplicate key") {
 		return true
 	}
 

--- a/db/errors.go
+++ b/db/errors.go
@@ -3,7 +3,7 @@ package db
 import (
 	"strings"
 
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2"
 )
 
 func IsDuplicateKey(err error) bool {

--- a/db/errors.go
+++ b/db/errors.go
@@ -3,7 +3,8 @@ package db
 import (
 	"strings"
 
-	"gopkg.in/mgo.v2"
+	"github.com/pkg/errors"
+	mgo "gopkg.in/mgo.v2"
 )
 
 func IsDuplicateKey(err error) bool {
@@ -11,6 +12,7 @@ func IsDuplicateKey(err error) bool {
 		return false
 	}
 
+	err = errors.Cause(err)
 	if mgo.IsDup(err) {
 		return true
 	}

--- a/model/generate.go
+++ b/model/generate.go
@@ -159,7 +159,7 @@ func (g *GeneratedProject) NewVersion() (*Project, *ParserProject, *Version, *ta
 
 func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProject, v *Version, t *task.Task, pm *projectMaps) error {
 	if err := updateVersionAndParserProject(v, pp); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	if v.Requester == evergreen.MergeTestRequester {

--- a/model/generate.go
+++ b/model/generate.go
@@ -159,7 +159,7 @@ func (g *GeneratedProject) NewVersion() (*Project, *ParserProject, *Version, *ta
 
 func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProject, v *Version, t *task.Task, pm *projectMaps) error {
 	if err := updateVersionAndParserProject(v, pp); err != nil {
-		return errors.Wrapf(err, "error saving version/parser project")
+		return err
 	}
 
 	if v.Requester == evergreen.MergeTestRequester {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -630,7 +630,7 @@ func (t *Task) MarkAsUndispatched() error {
 
 // MarkGeneratedTasks marks that the task has generated tasks.
 func MarkGeneratedTasks(taskID string, errorToSet error) error {
-	if adb.ResultsNotFound(errorToSet) {
+	if adb.ResultsNotFound(errorToSet) || db.IsDuplicateKey(errorToSet) {
 		return nil
 	}
 	query := bson.M{

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1775,4 +1775,15 @@ func TestMarkGeneratedTasks(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, false, found.GeneratedTasks, "document not found should not set generated tasks, since this was a race and did not generate.tasks")
 	require.Equal(t, "", found.GenerateTasksError)
+
+	t4 := &Task{
+		Id: "t4",
+	}
+	dupError := errors.New("duplicate key error")
+	require.NoError(t, t4.Insert())
+	require.NoError(t, MarkGeneratedTasks(t4.Id, dupError))
+	found, err = FindOneId(t4.Id)
+	require.NoError(t, err)
+	require.Equal(t, false, found.GeneratedTasks, "duplicate key error should not set generated tasks, since this was a race and did not generate.tasks")
+	require.Equal(t, "", found.GenerateTasksError)
 }


### PR DESCRIPTION
Because parser project race conditions are exposed as duplicate key errors and not results not found, we want to case on this in generate tasks.

(For context, this is because of upsert: when we can't find a parser project with our config number, we attempt to insert a new one, but if a parser project already exists with an updated config number then we receive a duplicate key error for trying to reuse the version ID, so effectively it says the same thing as a ResultsNotFound.)