### PR TITLE
EVG-7184 generator deps

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -272,7 +272,7 @@ func addDependencies(t *task.Task, p *Project, v *Version, newTasks TVPairSet) e
 		newDependencyIDs = append(newDependencyIDs, taskIDTable.ExecutionTasks.GetId(newTask.Variant, newTask.TaskName))
 	}
 
-	statuses := []string{evergreen.TaskSucceeded, evergreen.TaskFailed, task.AllStatuses}
+	statuses := []string{evergreen.TaskSucceeded, task.AllStatuses}
 	for _, status := range statuses {
 		if err := t.UpdateDependsOn(status, newDependencyIDs); err != nil {
 			return errors.Wrapf(err, "can't update tasks depending on '%s'", t.Id)

--- a/model/generate.go
+++ b/model/generate.go
@@ -257,10 +257,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, cachedProj
 		return errors.Wrap(err, "errors adding new builds")
 	}
 
-	newTasks := TaskVariantPairs{
-		DisplayTasks: append(newTVPairsForExistingVariants.DisplayTasks, newTVPairsForNewVariants.DisplayTasks...),
-		ExecTasks:    append(newTVPairsForExistingVariants.ExecTasks, newTVPairsForNewVariants.ExecTasks...),
-	}
+	newTasks := append(newTVPairsForExistingVariants.ExecTasks, newTVPairsForNewVariants.ExecTasks...)
 	if err = addDependencies(t, p, v, newTasks); err != nil {
 		return errors.Wrap(err, "error adding dependencies")
 	}
@@ -268,14 +265,11 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, cachedProj
 	return nil
 }
 
-func addDependencies(t *task.Task, p *Project, v *Version, newTasks TaskVariantPairs) error {
+func addDependencies(t *task.Task, p *Project, v *Version, newTasks TVPairSet) error {
 	taskIDTable := NewTaskIdTable(p, v, "", "")
 	newDependencyIDs := []string{}
-	for _, newDisplayTask := range newTasks.DisplayTasks {
-		newDependencyIDs = append(newDependencyIDs, taskIDTable.DisplayTasks.GetId(newDisplayTask.Variant, newDisplayTask.TaskName))
-	}
-	for _, newExecTask := range newTasks.ExecTasks {
-		newDependencyIDs = append(newDependencyIDs, taskIDTable.ExecutionTasks.GetId(newExecTask.Variant, newExecTask.TaskName))
+	for _, newTask := range newTasks {
+		newDependencyIDs = append(newDependencyIDs, taskIDTable.ExecutionTasks.GetId(newTask.Variant, newTask.TaskName))
 	}
 
 	statuses := []string{evergreen.TaskSucceeded, evergreen.TaskFailed, task.AllStatuses}

--- a/model/generate.go
+++ b/model/generate.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/gimlet"
-	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
@@ -160,19 +159,6 @@ func (g *GeneratedProject) NewVersion() (*Project, *ParserProject, *Version, *ta
 func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProject, v *Version, t *task.Task, pm *projectMaps) error {
 	if err := updateVersionAndParserProject(v, pp); err != nil {
 		return errors.WithStack(err)
-	}
-
-	if v.Requester == evergreen.MergeTestRequester {
-		mergeTask, err := task.FindMergeTaskForVersion(v.Id)
-		if err != nil && !adb.ResultsNotFound(err) {
-			return errors.Wrap(err, "error finding merge task")
-		}
-		// if a merge task exists then update its dependencies
-		if !adb.ResultsNotFound(err) {
-			if err = v.UpdateMergeTaskDependencies(p, mergeTask); err != nil {
-				return errors.Wrap(err, "error updating merge task")
-			}
-		}
 	}
 
 	if err := g.saveNewBuildsAndTasks(ctx, pm, v, p, t); err != nil {

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -885,9 +885,6 @@ func TestAddDependencies(t *testing.T) {
 				Tasks: []BuildVariantTaskUnit{
 					{Name: "t3"},
 				},
-				DisplayTasks: []DisplayTask{
-					{Name: "dt1"},
-				},
 			},
 		},
 	}
@@ -900,27 +897,19 @@ func TestAddDependencies(t *testing.T) {
 		assert.NoError(t, task.Insert())
 	}
 
-	newTasks := TaskVariantPairs{
-		ExecTasks: TVPairSet{
-			{Variant: "bv1", TaskName: "t3"},
-		},
-		DisplayTasks: TVPairSet{
-			{Variant: "bv1", TaskName: "dt1"},
-		},
-	}
-
+	newTasks := TVPairSet{{Variant: "bv1", TaskName: "t3"}}
 	assert.NoError(t, addDependencies(&task.Task{Id: "generator"}, p, v, newTasks))
 
 	t1, err := task.FindOneId("t1")
 	assert.NoError(t, err)
-	assert.Len(t, t1.DependsOn, 3)
+	assert.Len(t, t1.DependsOn, 2)
 	for _, dep := range t1.DependsOn {
 		assert.Equal(t, evergreen.TaskSucceeded, dep.Status)
 	}
 
 	t2, err := task.FindOneId("t2")
 	assert.NoError(t, err)
-	assert.Len(t, t2.DependsOn, 3)
+	assert.Len(t, t2.DependsOn, 2)
 	for _, dep := range t2.DependsOn {
 		assert.Equal(t, evergreen.TaskFailed, dep.Status)
 	}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -92,13 +92,15 @@ func ValidateTVPairs(p *Project, in []TVPair) error {
 // do not exist yet out of the set of pairs. No tasks are added for builds which already exist
 // (see AddNewTasksForPatch).
 func AddNewBuildsForPatch(ctx context.Context, p *patch.Patch, patchVersion *Version, project *Project, tasks TaskVariantPairs) error {
-	return AddNewBuilds(ctx, p.Activated, patchVersion, project, tasks, "")
+	_, _, err := AddNewBuilds(ctx, p.Activated, patchVersion, project, tasks, "")
+	return errors.Wrap(err, "can't add new builds")
 }
 
 // Given a patch version and set of variant/task pairs, creates any tasks that don't exist yet,
 // within the set of already existing builds.
 func AddNewTasksForPatch(ctx context.Context, p *patch.Patch, patchVersion *Version, project *Project, pairs TaskVariantPairs) error {
-	return AddNewTasks(ctx, p.Activated, patchVersion, project, pairs, "")
+	_, err := AddNewTasks(ctx, p.Activated, patchVersion, project, pairs, "")
+	return errors.Wrap(err, "can't add new tasks")
 }
 
 // IncludePatchDependencies takes a project and a slice of variant/task pairs names

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1960,30 +1960,6 @@ func GetTimeSpent(tasks []Task) (time.Duration, time.Duration) {
 	return timeTaken, latestFinishTime.Sub(earliestStartTime)
 }
 
-// UpdateDependencies replaces the dependencies of a task with
-// the dependencies provided
-func (t *Task) UpdateDependencies(dependsOn []Dependency) error {
-	err := UpdateOne(
-		bson.M{
-			IdKey:        t.Id,
-			DependsOnKey: t.DependsOn,
-		},
-		bson.M{
-			"$push": bson.M{DependsOnKey: bson.M{"$each": dependsOn}},
-		},
-	)
-	if err != nil {
-		if adb.ResultsNotFound(err) {
-			grip.Alert(errors.Wrapf(err, "atomic update failed for %s", t.Id))
-		}
-		return errors.Wrap(err, "can't update dependencies")
-	}
-
-	t.DependsOn = append(t.DependsOn, dependsOn...)
-
-	return nil
-}
-
 // UpdateDependsOn appends new dependnecies to tasks that already depend on this task
 func (t *Task) UpdateDependsOn(status string, newDependencyIDs []string) error {
 	newDependencies := make([]Dependency, 0, len(newDependencyIDs))
@@ -1996,10 +1972,10 @@ func (t *Task) UpdateDependsOn(status string, newDependencyIDs []string) error {
 
 	_, err := UpdateAll(
 		bson.M{
-			"$elemMatch": bson.M{
-				bsonutil.GetDottedKeyName(DependsOnKey, DependencyTaskIdKey): t.Id,
-				bsonutil.GetDottedKeyName(DependsOnKey, DependencyStatusKey): status,
-			},
+			DependsOnKey: bson.M{"$elemMatch": bson.M{
+				DependencyTaskIdKey: t.Id,
+				DependencyStatusKey: status,
+			}},
 		},
 		bson.M{"$push": bson.M{DependsOnKey: bson.M{"$each": newDependencies}}},
 	)

--- a/model/version.go
+++ b/model/version.go
@@ -213,35 +213,6 @@ func VersionGetHistory(versionId string, N int) ([]Version, error) {
 	return versions, nil
 }
 
-func (v *Version) UpdateMergeTaskDependencies(p *Project, mergeTask *task.Task) error {
-	existingDependencies := make(map[string]bool)
-	for _, dep := range mergeTask.DependsOn {
-		existingDependencies[dep.TaskId] = true
-	}
-
-	execPairs, _, err := p.BuildProjectTVPairsWithAlias(evergreen.CommitQueueAlias)
-	if err != nil {
-		return errors.Wrap(err, "can't get alias pairs")
-	}
-
-	mergeTaskDependencies := []task.Dependency{}
-	execTaskIDTable := NewTaskIdTable(p, v, "", "").ExecutionTasks
-	for _, pair := range execPairs {
-		taskID := execTaskIDTable.GetId(pair.Variant, pair.TaskName)
-		if !existingDependencies[taskID] {
-			mergeTaskDependencies = append(
-				mergeTaskDependencies,
-				task.Dependency{
-					TaskId: taskID,
-					Status: evergreen.TaskSucceeded,
-				},
-			)
-		}
-	}
-
-	return mergeTask.UpdateDependencies(mergeTaskDependencies)
-}
-
 type VersionsByCreateTime []Version
 
 func (v VersionsByCreateTime) Len() int {


### PR DESCRIPTION
>Depending on a task generator should also depend on the tasks it generates

It _should_ be okay to do this for all generated tasks, so I opted not to make this a parameter for the generator.

Depend on the generated tasks with the same status as the dependency on the generator. So if you depend on the generator completing (pass, fail, or blocked) you will depend on the generated task completing and if you depend on it succeeding you will depend on the generated task succeeding. Short of adding a parameter on the task I couldn't think of a good way to indicate depending on generated tasks failing, but this seems like it won't be used. 

After looking through some code, I didn't update the dependencies in the project's config string and parser project, though it's hard to be absolutely certain. The dependency includer will not need to include the generated tasks since they're already included.