### PR TITLE
EVG-7298: fix spawn host binary permissions

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -997,6 +997,7 @@ func (h *Host) SetupSpawnHostCommands(settings *evergreen.Settings) (string, err
 		fmt.Sprintf("echo '%s' > %s", confJSON, confPath),
 		fmt.Sprintf("cp %s %s", binaryPath, binDir),
 		fmt.Sprintf("(echo '\nexport PATH=\"${PATH}:%s\"\n' >> %s/.profile || true; echo '\nexport PATH=\"${PATH}:%s\"\n' >> %s/.bash_profile || true)", binDir, h.Distro.HomeDir(), binDir, h.Distro.HomeDir()),
+		fmt.Sprintf("chown -R %s %s", h.Distro.User, binDir),
 	}, " && ")
 
 	script := setupBinDirCmds

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -985,7 +985,11 @@ func TestSetupSpawnHostCommands(t *testing.T) {
 	cmd, err := h.SetupSpawnHostCommands(settings)
 	require.NoError(t, err)
 
-	expected := "mkdir -m 777 -p /home/user/cli_bin && echo '{\"api_key\":\"key\",\"api_server_host\":\"www.example0.com/api\",\"ui_server_host\":\"www.example1.com\",\"user\":\"user\"}' > /home/user/cli_bin/.evergreen.yml && cp /home/user/evergreen /home/user/cli_bin && (echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.profile || true; echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.bash_profile || true)"
+	expected := "mkdir -m 777 -p /home/user/cli_bin" +
+		" && echo '{\"api_key\":\"key\",\"api_server_host\":\"www.example0.com/api\",\"ui_server_host\":\"www.example1.com\",\"user\":\"user\"}' > /home/user/cli_bin/.evergreen.yml" +
+		" && cp /home/user/evergreen /home/user/cli_bin" +
+		" && (echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.profile || true; echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.bash_profile || true)" +
+		" && chown -R user /home/user/cli_bin"
 	assert.Equal(t, expected, cmd)
 
 	h.ProvisionOptions.TaskId = "task_id"


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7298

Ensure that the owner is the distro owner so when users SSH into their spawn host, the evergreen binary is executable.