### PR TITLE
EVG-7249 fix race between provisioning and agent for docker

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"go.mongodb.org/mongo-driver/mongo"
+
 	"github.com/evergreen-ci/certdepot"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -1256,7 +1258,11 @@ func RemoveStrict(id string) error {
 // Replace overwrites an existing host document with a new one. If no existing host is found, the new one will be inserted anyway.
 func (h *Host) Replace() error {
 	result := evergreen.GetEnvironment().DB().Collection(Collection).FindOneAndReplace(context.Background(), bson.M{IdKey: h.Id}, h, options.FindOneAndReplace().SetUpsert(true))
-	return result.Err()
+	err := result.Err()
+	if errors.Cause(err) == mongo.ErrNoDocuments {
+		return nil
+	}
+	return err
 }
 
 // GetElapsedCommunicationTime returns how long since this host has communicated with evergreen or vice versa

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"go.mongodb.org/mongo-driver/mongo"
-
 	"github.com/evergreen-ci/certdepot"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -22,6 +20,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	mgobson "gopkg.in/mgo.v2/bson"
 )

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4487,3 +4487,25 @@ func TestFindHostsInRange(t *testing.T) {
 	assert.Len(t, filteredHosts, 1)
 	assert.Equal(t, "h2", filteredHosts[0].Id)
 }
+
+func TestRemoveAndReplace(t *testing.T) {
+	assert.NoError(t, db.Clear(Collection))
+	// removing a nonexistent host errors
+	assert.Error(t, RemoveStrict("asdf"))
+
+	h := Host{
+		Id:                 "bar",
+		Status:             evergreen.HostUninitialized,
+		ComputeCostPerHour: 50,
+	}
+	assert.NoError(t, h.Insert())
+
+	h.ComputeCostPerHour = 100
+	h.DockerOptions.Command = "hello world"
+	assert.NoError(t, h.Replace())
+	dbHost, err := FindOneId(h.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, evergreen.HostUninitialized, dbHost.Status)
+	assert.EqualValues(t, 100, dbHost.ComputeCostPerHour)
+	assert.Equal(t, "hello world", dbHost.DockerOptions.Command)
+}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4490,9 +4490,11 @@ func TestFindHostsInRange(t *testing.T) {
 
 func TestRemoveAndReplace(t *testing.T) {
 	assert.NoError(t, db.Clear(Collection))
+
 	// removing a nonexistent host errors
 	assert.Error(t, RemoveStrict("asdf"))
 
+	// replacing an existing host works
 	h := Host{
 		Id:                 "bar",
 		Status:             evergreen.HostUninitialized,
@@ -4508,4 +4510,14 @@ func TestRemoveAndReplace(t *testing.T) {
 	assert.Equal(t, evergreen.HostUninitialized, dbHost.Status)
 	assert.EqualValues(t, 100, dbHost.ComputeCostPerHour)
 	assert.Equal(t, "hello world", dbHost.DockerOptions.Command)
+
+	// replacing a nonexisting host will just insert
+	h2 := Host{
+		Id:     "host2",
+		Status: evergreen.HostRunning,
+	}
+	assert.NoError(t, h2.Replace())
+	dbHost, err = FindOneId(h2.Id)
+	assert.NoError(t, err)
+	assert.NotNil(t, dbHost)
 }


### PR DESCRIPTION
This is a small but risky refactor. Previously the behavior of the host create job was:
1. Spawn host with the cloud provider (probably changes ID, except for docker)
2. Remove old host document
3. Mark new host as starting
4. Insert new host document

Now it'll be:
1. Spawn host with the cloud provider (probably changes ID, except for docker)
2. Mark new host as starting
3a. If the ID didn't change, replace the intent host with the new host
3b. If the ID did change, remove the old document then insert the new document