### PR TITLE
EVG-7232 add provider settings list

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -3,6 +3,8 @@ package apimodels
 import (
 	"strconv"
 
+	"github.com/evergreen-ci/evergreen"
+
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -174,6 +176,9 @@ func (ch *CreateHost) ValidateEC2() error {
 
 	catcher.Add(ch.setNumHosts())
 	catcher.Add(ch.validateAgentOptions())
+	if ch.Region == "" {
+		ch.Region = evergreen.DefaultEC2Region
+	}
 
 	if (ch.AMI != "" && ch.Distro != "") || (ch.AMI == "" && ch.Distro == "") {
 		catcher.New("must set exactly one of ami or distro")

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 
 	"github.com/evergreen-ci/evergreen"
-
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -188,7 +188,7 @@ func GetManager(ctx context.Context, env evergreen.Environment, mgrOpts ManagerO
 // provider name.
 func GetManagerOptions(d distro.Distro) (ManagerOpts, error) {
 	if IsEc2Provider(d.Provider) {
-		return getEC2ManagerOptions(d.Provider, d.ProviderSettings)
+		return getEC2ManagerOptions(d)
 	}
 	if d.Provider == evergreen.ProviderNameMock {
 		return getMockManagerOptions(d.Provider, d.ProviderSettings)

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -13,6 +13,10 @@ import (
 // ProviderSettings exposes provider-specific configuration settings for a Manager.
 type ProviderSettings interface {
 	Validate() error
+
+	// If zone is specified, returns the provider settings for that region.
+	// This is currently only being implemented for EC2 hosts.
+	FromDistroSettings(distro.Distro, string) error
 }
 
 //Manager is an interface which handles creating new hosts or modifying

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -61,7 +62,11 @@ func (s *dockerSettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
-		if err := d.UpdateProviderSettings(bytes); err != nil {
+		doc := &birch.Document{}
+		if err := doc.UnmarshalBSON(bytes); err != nil {
+			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
+		}
+		if err := d.UpdateProviderSettings(doc); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
 				"provider": d.Provider,

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -67,6 +67,7 @@ func (s *dockerSettings) FromDistroSettings(d distro.Distro, _ string) error {
 				"provider": d.Provider,
 				"settings": d.ProviderSettings,
 			}))
+			return errors.Wrapf(err, "error updating provider settings")
 		}
 	}
 	return nil

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -46,15 +46,7 @@ func (settings *dockerSettings) Validate() error {
 }
 
 func (s *dockerSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
-		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		if err := bson.Unmarshal(bytes, s); err != nil {
-			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if d.ProviderSettings != nil {
+	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}
@@ -66,13 +58,23 @@ func (s *dockerSettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := doc.UnmarshalBSON(bytes); err != nil {
 			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
 		}
-		if err := d.UpdateProviderSettings(doc); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"distro":   d.Id,
-				"provider": d.Provider,
-				"settings": d.ProviderSettings,
-			}))
-			return errors.Wrapf(err, "error updating provider settings")
+		if len(d.ProviderSettingsList) == 0 {
+			if err := d.UpdateProviderSettings(doc); err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"distro":   d.Id,
+					"provider": d.Provider,
+					"settings": d.ProviderSettings,
+				}))
+				return errors.Wrapf(err, "error updating provider settings")
+			}
+		}
+	} else if len(d.ProviderSettingsList) != 0 {
+		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		if err := bson.Unmarshal(bytes, s); err != nil {
+			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
 	}
 	return nil

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -95,10 +95,8 @@ func (s *EC2ProviderSettings) Validate() error {
 	return nil
 }
 
+// region is only provided if we want to filter by region
 func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string) error {
-	if region == "" {
-		region = evergreen.DefaultEC2Region
-	}
 	if len(d.ProviderSettingsList) != 0 {
 		settingsDoc, err := d.GetProviderSettingByRegion(region)
 		if err != nil {
@@ -121,7 +119,7 @@ func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string)
 			"output":  *s,
 		})
 		// error if region doesn't match (unless region is default)
-		if s.Region != region {
+		if region != "" && s.Region != region {
 			if region == evergreen.DefaultEC2Region && s.Region == "" {
 				s.Region = region
 			} else {
@@ -444,7 +442,6 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 			h.Distro.Id, h.Distro.Provider)
 	}
 
-	// TODO: either add h.Zone to this, or make m.region already know about h.Zone
 	if err := m.client.Create(m.credentials, m.region); err != nil {
 		return nil, errors.Wrap(err, "error creating client")
 	}

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -136,6 +136,7 @@ func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string)
 				"provider": d.Provider,
 				"settings": d.ProviderSettings,
 			}))
+			return errors.Wrapf(err, "error updating provider settings")
 		}
 	}
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -133,7 +133,8 @@ func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string)
 		if err := d.UpdateProviderSettings(bytes); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
-				"settings": d.Provider,
+				"provider": d.Provider,
+				"settings": d.ProviderSettings,
 			}))
 		}
 	}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -71,7 +71,7 @@ func (m *ec2FleetManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Ho
 	defer m.client.Close()
 
 	ec2Settings := &EC2ProviderSettings{}
-	if err := ec2Settings.FromDistroSettings(h.Distro, h.Region); err != nil {
+	if err := ec2Settings.FromDistroSettings(h.Distro, ""); err != nil {
 		return nil, errors.Wrap(err, "error getting EC2 settings")
 	}
 	if err := ec2Settings.Validate(); err != nil {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -71,9 +71,11 @@ func (m *ec2FleetManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Ho
 	defer m.client.Close()
 
 	ec2Settings := &EC2ProviderSettings{}
-	err := ec2Settings.FromDistroSettings(h.Distro, h.Zone)
-	if err != nil {
+	if err := ec2Settings.FromDistroSettings(h.Distro, h.Region); err != nil {
 		return nil, errors.Wrap(err, "error getting EC2 settings")
+	}
+	if err := ec2Settings.Validate(); err != nil {
+		return nil, errors.Wrapf(err, "Invalid EC2 settings in distro %s: %+v", h.Distro.Id, ec2Settings)
 	}
 
 	if ec2Settings.KeyName == "" && !h.UserHost {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -71,7 +71,7 @@ func (m *ec2FleetManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Ho
 	defer m.client.Close()
 
 	ec2Settings := &EC2ProviderSettings{}
-	err := ec2Settings.fromDistroSettings(h.Distro)
+	err := ec2Settings.FromDistroSettings(h.Distro, h.Zone)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting EC2 settings")
 	}

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1167,7 +1167,7 @@ func (s *EC2Suite) TestGetRegion() {
 	s.Equal(evergreen.DefaultEC2Region, r)
 
 	(*s.h.Distro.ProviderSettings)["region"] = "us-west-2"
-	s.NoError(ec2Settings.FromDistroSettings(s.h.Distro, "us-west-2a"))
+	s.NoError(ec2Settings.FromDistroSettings(s.h.Distro, "us-west-2"))
 	r = ec2Settings.getRegion()
 	s.Equal("us-west-2", r)
 }
@@ -1284,16 +1284,16 @@ func (s *EC2Suite) TestFromDistroSettings() {
 	}
 	bytes, err := bson.Marshal(ec2Settings)
 	s.NoError(err)
-	doc1 := birch.Document{}
+	doc1 := &birch.Document{}
 	s.NoError(doc1.UnmarshalBSON(bytes))
 
 	bytes, err = bson.Marshal(settings2)
 	s.NoError(err)
-	doc2 := birch.Document{}
+	doc2 := &birch.Document{}
 	s.NoError(doc2.UnmarshalBSON(bytes))
-	d.ProviderSettingsList = []birch.Document{doc1, doc2}
+	d.ProviderSettingsList = []*birch.Document{doc1, doc2}
 
-	s.NoError(ec2Settings.FromDistroSettings(d, "us-east-2a"))
+	s.NoError(ec2Settings.FromDistroSettings(d, "us-east-2"))
 	s.Equal(ec2Settings.Region, "us-east-2")
 	s.Equal(ec2Settings.InstanceType, "other_instance")
 }

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1165,11 +1165,6 @@ func (s *EC2Suite) TestGetRegion() {
 	s.NoError(ec2Settings.FromDistroSettings(s.h.Distro, evergreen.DefaultEC2Region))
 	r = ec2Settings.getRegion()
 	s.Equal(evergreen.DefaultEC2Region, r)
-
-	(*s.h.Distro.ProviderSettings)["region"] = "us-west-2"
-	s.NoError(ec2Settings.FromDistroSettings(s.h.Distro, "us-west-2"))
-	r = ec2Settings.getRegion()
-	s.Equal("us-west-2", r)
 }
 
 func (s *EC2Suite) TestUserDataExpand() {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -7,11 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/birch"
-	"go.mongodb.org/mongo-driver/bson"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
@@ -21,6 +19,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 var (

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
@@ -19,7 +18,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/suite"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 var (
@@ -1267,30 +1265,31 @@ func (s *EC2Suite) TestFromDistroSettings() {
 	s.Equal(float64(0.001), ec2Settings.BidPrice)
 	s.Equal(evergreen.DefaultEC2Region, ec2Settings.Region)
 
+	// TODO: include this after EVG-7329
 	// create provider list, choose by region
-	settings2 := EC2ProviderSettings{
-		Region:           "us-east-2",
-		AMI:              "other_ami",
-		InstanceType:     "other_instance",
-		SecurityGroupIDs: []string{"ghijkl"},
-		BidPrice:         float64(0.002),
-		AWSKeyID:         "other_key_id",
-		KeyName:          "other_key",
-	}
-	bytes, err := bson.Marshal(ec2Settings)
-	s.NoError(err)
-	doc1 := &birch.Document{}
-	s.NoError(doc1.UnmarshalBSON(bytes))
-
-	bytes, err = bson.Marshal(settings2)
-	s.NoError(err)
-	doc2 := &birch.Document{}
-	s.NoError(doc2.UnmarshalBSON(bytes))
-	d.ProviderSettingsList = []*birch.Document{doc1, doc2}
-
-	s.NoError(ec2Settings.FromDistroSettings(d, "us-east-2"))
-	s.Equal(ec2Settings.Region, "us-east-2")
-	s.Equal(ec2Settings.InstanceType, "other_instance")
+	//settings2 := EC2ProviderSettings{
+	//	Region:           "us-east-2",
+	//	AMI:              "other_ami",
+	//	InstanceType:     "other_instance",
+	//	SecurityGroupIDs: []string{"ghijkl"},
+	//	BidPrice:         float64(0.002),
+	//	AWSKeyID:         "other_key_id",
+	//	KeyName:          "other_key",
+	//}
+	//bytes, err := bson.Marshal(ec2Settings)
+	//s.NoError(err)
+	//doc1 := &birch.Document{}
+	//s.NoError(doc1.UnmarshalBSON(bytes))
+	//
+	//bytes, err = bson.Marshal(settings2)
+	//s.NoError(err)
+	//doc2 := &birch.Document{}
+	//s.NoError(doc2.UnmarshalBSON(bytes))
+	//d.ProviderSettingsList = []*birch.Document{doc1, doc2}
+	//
+	//s.NoError(ec2Settings.FromDistroSettings(d, "us-east-2"))
+	//s.Equal(ec2Settings.Region, "us-east-2")
+	//s.Equal(ec2Settings.InstanceType, "other_instance")
 }
 
 func (s *EC2Suite) TestGetEC2ManagerOptions() {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/birch"
+	"go.mongodb.org/mongo-driver/bson"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/evergreen-ci/evergreen"
@@ -1160,12 +1163,12 @@ func (s *EC2Suite) TestGetRegion() {
 	s.Equal(evergreen.DefaultEC2Region, r)
 
 	(*s.h.Distro.ProviderSettings)["region"] = evergreen.DefaultEC2Region
-	s.NoError(ec2Settings.fromDistroSettings(s.h.Distro))
+	s.NoError(ec2Settings.FromDistroSettings(s.h.Distro, evergreen.DefaultEC2Region))
 	r = ec2Settings.getRegion()
 	s.Equal(evergreen.DefaultEC2Region, r)
 
 	(*s.h.Distro.ProviderSettings)["region"] = "us-west-2"
-	s.NoError(ec2Settings.fromDistroSettings(s.h.Distro))
+	s.NoError(ec2Settings.FromDistroSettings(s.h.Distro, "us-west-2a"))
 	r = ec2Settings.getRegion()
 	s.Equal("us-west-2", r)
 }
@@ -1261,13 +1264,39 @@ func (s *EC2Suite) TestFromDistroSettings() {
 	}
 
 	ec2Settings := &EC2ProviderSettings{}
-	s.NoError(ec2Settings.fromDistroSettings(d))
+	s.NoError(ec2Settings.FromDistroSettings(d, evergreen.DefaultEC2Region))
 	s.Equal("key", ec2Settings.KeyName)
 	s.Equal("ami", ec2Settings.AMI)
 	s.Equal("instance", ec2Settings.InstanceType)
 	s.Len(ec2Settings.SecurityGroupIDs, 1)
 	s.Equal("abcdef", ec2Settings.SecurityGroupIDs[0])
 	s.Equal(float64(0.001), ec2Settings.BidPrice)
+	s.Equal(evergreen.DefaultEC2Region, ec2Settings.Region)
+
+	// create provider list, choose by region
+	settings2 := EC2ProviderSettings{
+		Region:           "us-east-2",
+		AMI:              "other_ami",
+		InstanceType:     "other_instance",
+		SecurityGroupIDs: []string{"ghijkl"},
+		BidPrice:         float64(0.002),
+		AWSKeyID:         "other_key_id",
+		KeyName:          "other_key",
+	}
+	bytes, err := bson.Marshal(ec2Settings)
+	s.NoError(err)
+	doc1 := birch.Document{}
+	s.NoError(doc1.UnmarshalBSON(bytes))
+
+	bytes, err = bson.Marshal(settings2)
+	s.NoError(err)
+	doc2 := birch.Document{}
+	s.NoError(doc2.UnmarshalBSON(bytes))
+	d.ProviderSettingsList = []birch.Document{doc1, doc2}
+
+	s.NoError(ec2Settings.FromDistroSettings(d, "us-east-2a"))
+	s.Equal(ec2Settings.Region, "us-east-2")
+	s.Equal(ec2Settings.InstanceType, "other_instance")
 }
 
 func (s *EC2Suite) TestGetEC2ManagerOptions() {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1302,15 +1302,15 @@ func (s *EC2Suite) TestGetEC2ManagerOptions() {
 	d1 := distro.Distro{
 		Provider: evergreen.ProviderNameEc2OnDemand,
 		ProviderSettings: &map[string]interface{}{
-			"region":                "test-region",
+			"region":                evergreen.DefaultEC2Region,
 			"aws_access_key_id":     "key",
 			"aws_secret_access_key": "secret",
 		},
 	}
 
-	managerOpts, err := getEC2ManagerOptions(d1.Provider, d1.ProviderSettings)
+	managerOpts, err := getEC2ManagerOptions(d1)
 	s.NoError(err)
-	s.Equal("test-region", managerOpts.Region)
+	s.Equal(evergreen.DefaultEC2Region, managerOpts.Region)
 	s.Equal("key", managerOpts.ProviderKey)
 	s.Equal("secret", managerOpts.ProviderSecret)
 }

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -247,7 +247,7 @@ func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, cl
 	var err error
 	if h.ComputeCostPerHour == 0 {
 		ec2Settings := &EC2ProviderSettings{}
-		err := ec2Settings.FromDistroSettings(h.Distro, h.Zone)
+		err := ec2Settings.FromDistroSettings(h.Distro, h.Region)
 		if err != nil {
 			return errors.Wrapf(err, "error getting EC2 settings for host '%s'", h.Id)
 		}

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -11,12 +11,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/model/distro"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	ec2aws "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/anser/bsonutil"

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -11,13 +11,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/model/distro"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	ec2aws "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
-	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -247,7 +248,7 @@ func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, cl
 	var err error
 	if h.ComputeCostPerHour == 0 {
 		ec2Settings := &EC2ProviderSettings{}
-		err := ec2Settings.FromDistroSettings(h.Distro, h.Region)
+		err := ec2Settings.FromDistroSettings(h.Distro, "")
 		if err != nil {
 			return errors.Wrapf(err, "error getting EC2 settings for host '%s'", h.Id)
 		}
@@ -508,19 +509,16 @@ func IsEc2Provider(provider string) bool {
 		provider == evergreen.ProviderNameEc2Fleet
 }
 
-// Get EC2 region from an EC2 ProviderSettings object
-func getEC2ManagerOptions(provider string, providerSettings *map[string]interface{}) (ManagerOpts, error) {
+// Get EC2 region from a distro
+func getEC2ManagerOptions(d distro.Distro) (ManagerOpts, error) {
 	opts := ManagerOpts{}
-	if providerSettings == nil {
-		return opts, errors.New("nil ProviderSettings map")
-	}
 
 	s := &EC2ProviderSettings{}
-	if err := mapstructure.Decode(providerSettings, s); err != nil {
-		return opts, errors.Wrap(err, "can't decode into EC2ProviderSettings")
+	if err := s.FromDistroSettings(d, ""); err != nil {
+		return ManagerOpts{}, errors.Wrapf(err, "error getting EC2 provider settings from distro")
 	}
 
-	opts.Provider = provider
+	opts.Provider = d.Provider
 	opts.Region = s.Region
 	opts.ProviderKey = s.AWSKeyID
 	opts.ProviderSecret = s.AWSSecret

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -247,7 +247,7 @@ func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, cl
 	var err error
 	if h.ComputeCostPerHour == 0 {
 		ec2Settings := &EC2ProviderSettings{}
-		err := ec2Settings.fromDistroSettings(h.Distro)
+		err := ec2Settings.FromDistroSettings(h.Distro, h.Zone)
 		if err != nil {
 			return errors.Wrapf(err, "error getting EC2 settings for host '%s'", h.Id)
 		}

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -92,6 +92,7 @@ func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
 				"provider": d.Provider,
 				"settings": d.ProviderSettings,
 			}))
+			return errors.Wrapf(err, "error updating provider settings")
 		}
 	}
 	return nil

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -5,6 +5,7 @@ package cloud
 import (
 	"context"
 
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -86,7 +87,11 @@ func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
-		if err := d.UpdateProviderSettings(bytes); err != nil {
+		doc := &birch.Document{}
+		if err := doc.UnmarshalBSON(bytes); err != nil {
+			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
+		}
+		if err := d.UpdateProviderSettings(doc); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
 				"provider": d.Provider,

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -71,15 +71,7 @@ func (opts *GCESettings) Validate() error {
 }
 
 func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
-		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		if err := bson.Unmarshal(bytes, opts); err != nil {
-			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if d.ProviderSettings != nil {
+	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
@@ -91,13 +83,23 @@ func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := doc.UnmarshalBSON(bytes); err != nil {
 			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
 		}
-		if err := d.UpdateProviderSettings(doc); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"distro":   d.Id,
-				"provider": d.Provider,
-				"settings": d.ProviderSettings,
-			}))
-			return errors.Wrapf(err, "error updating provider settings")
+		if len(d.ProviderSettingsList) == 0 {
+			if err := d.UpdateProviderSettings(doc); err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"distro":   d.Id,
+					"provider": d.Provider,
+					"settings": d.ProviderSettings,
+				}))
+				return errors.Wrapf(err, "error updating provider settings")
+			}
+		}
+	} else if len(d.ProviderSettingsList) != 0 {
+		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		if err := bson.Unmarshal(bytes, opts); err != nil {
+			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
 	}
 	return nil

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -158,6 +158,9 @@ func (m *gceManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 			return nil, errors.Wrapf(err, "Error decoding params for distro %s", h.Distro.Id)
 		}
 	}
+	if err := s.Validate(); err != nil {
+		return nil, errors.Wrapf(err, "Invalid settings in distro %s", h.Distro.Id)
+	}
 
 	grip.Debugf("Settings validated for distro %s", h.Distro.Id)
 

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -89,7 +89,8 @@ func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := d.UpdateProviderSettings(bytes); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
-				"settings": d.Provider,
+				"provider": d.Provider,
+				"settings": d.ProviderSettings,
 			}))
 		}
 	}

--- a/cloud/gce_costs_test.go
+++ b/cloud/gce_costs_test.go
@@ -43,6 +43,10 @@ func (s *GCESuite) TestZoneToRegion() {
 	s.NoError(err)
 	s.Equal("us-west1", reg)
 
+	reg, err := zoneToRegion("us-west1")
+	s.NoError(err)
+	s.Equal("us-west1", reg)
+
 	reg, err = zoneToRegion("europe-west2-a")
 	s.NoError(err)
 	s.Equal("europe-west2", reg)

--- a/cloud/gce_costs_test.go
+++ b/cloud/gce_costs_test.go
@@ -43,10 +43,6 @@ func (s *GCESuite) TestZoneToRegion() {
 	s.NoError(err)
 	s.Equal("us-west1", reg)
 
-	reg, err := zoneToRegion("us-west1")
-	s.NoError(err)
-	s.Equal("us-west1", reg)
-
 	reg, err = zoneToRegion("europe-west2-a")
 	s.NoError(err)
 	s.Equal("europe-west2", reg)

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -5,9 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/model/distro"
-
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/model/distro"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mitchellh/mapstructure"
@@ -232,6 +234,10 @@ func (_ *mockManager) GetSettings() ProviderSettings {
 }
 
 func (_ *mockManager) Validate() error {
+	return nil
+}
+
+func (_ *mockManager) FromDistroSettings(_ distro.Distro, _ string) error {
 	return nil
 }
 

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -59,6 +59,14 @@ func GetMockProvider() MockProvider {
 	return globalMockState
 }
 
+func (_ *MockProviderSettings) Validate() error {
+	return nil
+}
+
+func (_ *MockProviderSettings) FromDistroSettings(_ distro.Distro, _ string) error {
+	return nil
+}
+
 type mockState struct {
 	instances map[string]MockInstance
 	volumes   map[string]MockVolume
@@ -229,15 +237,7 @@ func (mockMgr *mockManager) GetDNSName(ctx context.Context, host *host.Host) (st
 }
 
 func (_ *mockManager) GetSettings() ProviderSettings {
-	return &mockManager{}
-}
-
-func (_ *mockManager) Validate() error {
-	return nil
-}
-
-func (_ *mockManager) FromDistroSettings(_ distro.Distro, _ string) error {
-	return nil
+	return &MockProviderSettings{}
 }
 
 // terminate an instance

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -71,7 +71,8 @@ func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) err
 		if err := d.UpdateProviderSettings(bytes); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
-				"settings": d.Provider,
+				"provider": d.Provider,
+				"settings": d.ProviderSettings,
 			}))
 		}
 	}

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -68,7 +69,11 @@ func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) err
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
-		if err := d.UpdateProviderSettings(bytes); err != nil {
+		doc := &birch.Document{}
+		if err := doc.UnmarshalBSON(bytes); err != nil {
+			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
+		}
+		if err := d.UpdateProviderSettings(doc); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
 				"provider": d.Provider,

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -74,6 +74,7 @@ func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) err
 				"provider": d.Provider,
 				"settings": d.ProviderSettings,
 			}))
+			return errors.Wrapf(err, "error updating provider settings")
 		}
 	}
 	return nil

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -53,15 +53,7 @@ func (opts *openStackSettings) Validate() error {
 }
 
 func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
-		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		if err := bson.Unmarshal(bytes, opts); err != nil {
-			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if d.ProviderSettings != nil {
+	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
@@ -73,13 +65,23 @@ func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) err
 		if err := doc.UnmarshalBSON(bytes); err != nil {
 			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
 		}
-		if err := d.UpdateProviderSettings(doc); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"distro":   d.Id,
-				"provider": d.Provider,
-				"settings": d.ProviderSettings,
-			}))
-			return errors.Wrapf(err, "error updating provider settings")
+		if len(d.ProviderSettingsList) == 0 {
+			if err := d.UpdateProviderSettings(doc); err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"distro":   d.Id,
+					"provider": d.Provider,
+					"settings": d.ProviderSettings,
+				}))
+				return errors.Wrapf(err, "error updating provider settings")
+			}
+		}
+	} else if len(d.ProviderSettingsList) != 0 {
+		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		if err := bson.Unmarshal(bytes, opts); err != nil {
+			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
 	}
 	return nil

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -67,6 +67,7 @@ func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
 				"provider": d.Provider,
 				"settings": d.ProviderSettings,
 			}))
+			return errors.Wrapf(err, "error updating provider settings")
 		}
 	}
 	return nil

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -61,7 +62,11 @@ func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
-		if err := d.UpdateProviderSettings(bytes); err != nil {
+		doc := &birch.Document{}
+		if err := doc.UnmarshalBSON(bytes); err != nil {
+			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
+		}
+		if err := d.UpdateProviderSettings(doc); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
 				"provider": d.Provider,

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/mongodb/grip/message"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -13,6 +11,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -46,15 +46,7 @@ func (s *StaticSettings) Validate() error {
 }
 
 func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
-		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		if err := bson.Unmarshal(bytes, s); err != nil {
-			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if d.ProviderSettings != nil {
+	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}
@@ -66,13 +58,23 @@ func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := doc.UnmarshalBSON(bytes); err != nil {
 			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
 		}
-		if err := d.UpdateProviderSettings(doc); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"distro":   d.Id,
-				"provider": d.Provider,
-				"settings": d.ProviderSettings,
-			}))
-			return errors.Wrapf(err, "error updating provider settings")
+		if len(d.ProviderSettingsList) == 0 {
+			if err := d.UpdateProviderSettings(doc); err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"distro":   d.Id,
+					"provider": d.Provider,
+					"settings": d.ProviderSettings,
+				}))
+				return errors.Wrapf(err, "error updating provider settings")
+			}
+		}
+	} else if len(d.ProviderSettingsList) != 0 {
+		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		if err := bson.Unmarshal(bytes, s); err != nil {
+			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
 	}
 	return nil

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"time"
 
+	"github.com/mongodb/grip/message"
+
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 type staticManager struct{}
@@ -35,6 +40,33 @@ func (s *StaticSettings) Validate() error {
 	for _, h := range s.Hosts {
 		if h.Name == "" {
 			return errors.New("host 'name' field can not be blank")
+		}
+	}
+	return nil
+}
+
+func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
+	if len(d.ProviderSettingsList) != 0 {
+		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		if err := bson.Unmarshal(bytes, s); err != nil {
+			return errors.Wrap(err, "error unmarshalling bson into provider settings")
+		}
+	} else if d.ProviderSettings != nil {
+		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
+		}
+		bytes, err := bson.Marshal(s)
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		if err := d.UpdateProviderSettings(bytes); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"distro":   d.Id,
+				"settings": d.Provider,
+			}))
 		}
 	}
 	return nil

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -64,7 +64,8 @@ func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := d.UpdateProviderSettings(bytes); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
-				"settings": d.Provider,
+				"provider": d.Provider,
+				"settings": d.ProviderSettings,
 			}))
 		}
 	}

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -70,7 +71,11 @@ func (opts *vsphereSettings) FromDistroSettings(d distro.Distro, _ string) error
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
-		if err := d.UpdateProviderSettings(bytes); err != nil {
+		doc := &birch.Document{}
+		if err := doc.UnmarshalBSON(bytes); err != nil {
+			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
+		}
+		if err := d.UpdateProviderSettings(doc); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
 				"provider": d.Provider,

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -73,7 +73,8 @@ func (opts *vsphereSettings) FromDistroSettings(d distro.Distro, _ string) error
 		if err := d.UpdateProviderSettings(bytes); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
-				"settings": d.Provider,
+				"provider": d.Provider,
+				"settings": d.ProviderSettings,
 			}))
 		}
 	}

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -76,6 +76,7 @@ func (opts *vsphereSettings) FromDistroSettings(d distro.Distro, _ string) error
 				"provider": d.Provider,
 				"settings": d.ProviderSettings,
 			}))
+			return errors.Wrapf(err, "error updating provider settings")
 		}
 	}
 	return nil

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -113,7 +113,10 @@ func (d *Distro) UpdateProviderSettings(bytes []byte) error {
 	if err := doc.UnmarshalBSON(bytes); err != nil {
 		return errors.Wrapf(err, "error unmarshalling settings bytes into document")
 	}
-	d.ProviderSettingsList = []birch.Document{doc}
+	if d.ProviderSettingsList == nil {
+		d.ProviderSettingsList = []birch.Document{}
+	}
+	d.ProviderSettingsList = append(d.ProviderSettingsList, doc)
 	if err := d.Update(); err != nil {
 		return errors.Wrapf(err, "error updating distro")
 	}

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -17,6 +17,7 @@ var (
 	ArchKey                  = bsonutil.MustHaveTag(Distro{}, "Arch")
 	ProviderKey              = bsonutil.MustHaveTag(Distro{}, "Provider")
 	ProviderSettingsKey      = bsonutil.MustHaveTag(Distro{}, "ProviderSettings")
+	ProviderSettingsListKey  = bsonutil.MustHaveTag(Distro{}, "ProviderSettingsList")
 	SetupAsSudoKey           = bsonutil.MustHaveTag(Distro{}, "SetupAsSudo")
 	SetupKey                 = bsonutil.MustHaveTag(Distro{}, "Setup")
 	UserKey                  = bsonutil.MustHaveTag(Distro{}, "User")
@@ -109,12 +110,12 @@ func (d *Distro) Update() error {
 }
 
 func (d *Distro) UpdateProviderSettings(bytes []byte) error {
-	doc := birch.Document{}
+	doc := &birch.Document{}
 	if err := doc.UnmarshalBSON(bytes); err != nil {
 		return errors.Wrapf(err, "error unmarshalling settings bytes into document")
 	}
 	if d.ProviderSettingsList == nil {
-		d.ProviderSettingsList = []birch.Document{}
+		d.ProviderSettingsList = []*birch.Document{}
 	}
 	d.ProviderSettingsList = append(d.ProviderSettingsList, doc)
 	if err := d.Update(); err != nil {

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -109,11 +109,7 @@ func (d *Distro) Update() error {
 	return db.UpdateId(Collection, d.Id, d)
 }
 
-func (d *Distro) UpdateProviderSettings(bytes []byte) error {
-	doc := &birch.Document{}
-	if err := doc.UnmarshalBSON(bytes); err != nil {
-		return errors.Wrapf(err, "error unmarshalling settings bytes into document")
-	}
+func (d *Distro) UpdateProviderSettings(doc *birch.Document) error {
 	if d.ProviderSettingsList == nil {
 		d.ProviderSettingsList = []*birch.Document{}
 	}

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -114,7 +114,7 @@ func (d *Distro) UpdateProviderSettings(doc *birch.Document) error {
 		d.ProviderSettingsList = []*birch.Document{}
 	}
 	d.ProviderSettingsList = append(d.ProviderSettingsList, doc)
-	if err := d.Update(); err != nil {
+	if err := d.Update(); err != nil && !adb.ResultsNotFound(err) {
 		return errors.Wrapf(err, "error updating distro")
 	}
 	return nil

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -1,6 +1,7 @@
 package distro
 
 import (
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
@@ -105,6 +106,18 @@ func (d *Distro) Insert() error {
 // Update updates one distro.
 func (d *Distro) Update() error {
 	return db.UpdateId(Collection, d.Id, d)
+}
+
+func (d *Distro) UpdateProviderSettings(bytes []byte) error {
+	doc := birch.Document{}
+	if err := doc.UnmarshalBSON(bytes); err != nil {
+		return errors.Wrapf(err, "error unmarshalling settings bytes into document")
+	}
+	d.ProviderSettingsList = []birch.Document{doc}
+	if err := d.Update(); err != nil {
+		return errors.Wrapf(err, "error updating distro")
+	}
+	return nil
 }
 
 // Remove removes one distro.

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -519,6 +519,13 @@ func (d *Distro) RemoveExtraneousProviderSettings(region string) {
 }
 
 func (d *Distro) GetProviderSettingByRegion(region string) (*birch.Document, error) {
+	// if no region given, we assume the provided settings list is accurate
+	if region == "" {
+		if len(d.ProviderSettingsList) > 1 {
+			return nil, errors.Errorf("multiple provider settings available but no region given")
+		}
+		return d.ProviderSettingsList[0], nil
+	}
 	for _, s := range d.ProviderSettingsList {
 		if val, ok := s.Lookup("region").StringValueOK(); ok {
 			if val == region {

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	mgobson "gopkg.in/mgo.v2/bson"
 )
 
 type Distro struct {
@@ -81,6 +83,10 @@ type ResourceLimits struct {
 	NumProcesses    int `bson:"num_processes,omitempty" json:"num_processes,omitempty" mapstructure:"num_processes,omitempty"`
 	LockedMemoryKB  int `bson:"locked_memory,omitempty" json:"locked_memory,omitempty" mapstructure:"locked_memory,omitempty"`
 	VirtualMemoryKB int `bson:"virtual_memory,omitempty" json:"virtual_memory,omitempty" mapstructure:"virtual_memory,omitempty"`
+}
+
+func (d *Distro) SetBSON(raw mgobson.Raw) error {
+	return bson.Unmarshal(raw.Data, d)
 }
 
 // ValidateBootstrapSettings checks if all of the bootstrap settings are valid

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -25,7 +25,7 @@ type Distro struct {
 	WorkDir               string                  `bson:"work_dir" json:"work_dir,omitempty" mapstructure:"work_dir,omitempty"`
 	Provider              string                  `bson:"provider" json:"provider,omitempty" mapstructure:"provider,omitempty"`
 	ProviderSettings      *map[string]interface{} `bson:"settings" json:"settings,omitempty" mapstructure:"settings,omitempty"`
-	ProviderSettingsList  []birch.Document        `bson:"provider_settings" json:"provider_settings,omitempty" mapstructure:"provider_settings,omitempty"`
+	ProviderSettingsList  []*birch.Document       `bson:"provider_settings,omitempty" json:"provider_settings,omitempty" mapstructure:"provider_settings,omitempty"`
 	SetupAsSudo           bool                    `bson:"setup_as_sudo,omitempty" json:"setup_as_sudo,omitempty" mapstructure:"setup_as_sudo,omitempty"`
 	Setup                 string                  `bson:"setup,omitempty" json:"setup,omitempty" mapstructure:"setup,omitempty"`
 	Teardown              string                  `bson:"teardown,omitempty" json:"teardown,omitempty" mapstructure:"teardown,omitempty"`
@@ -515,10 +515,10 @@ func (d *Distro) RemoveExtraneousProviderSettings(region string) {
 		}))
 		return
 	}
-	d.ProviderSettingsList = []birch.Document{doc}
+	d.ProviderSettingsList = []*birch.Document{doc}
 }
 
-func (d *Distro) GetProviderSettingByRegion(region string) (birch.Document, error) {
+func (d *Distro) GetProviderSettingByRegion(region string) (*birch.Document, error) {
 	for _, s := range d.ProviderSettingsList {
 		if val, ok := s.Lookup("region").StringValueOK(); ok {
 			if val == region {
@@ -526,7 +526,7 @@ func (d *Distro) GetProviderSettingByRegion(region string) (birch.Document, erro
 			}
 		}
 	}
-	return birch.Document{}, errors.Errorf("distro '%s' has no settings for region '%s'", d.Id, region)
+	return nil, errors.Errorf("distro '%s' has no settings for region '%s'", d.Id, region)
 }
 
 // GetResolvedHostAllocatorSettings combines the distro's HostAllocatorSettings fields with the

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -40,7 +40,6 @@ type Host struct {
 
 	// physical location of host
 	Project string `bson:"project" json:"project"`
-	Region  string `bson:"region" json:"region"`
 	Zone    string `bson:"zone" json:"zone"`
 
 	// True if the app server has done all necessary host setup work (although

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -168,7 +168,6 @@ const (
 	ReprovisionJasperRestart ReprovisionType = "jasper-restart"
 )
 
-func (h *Host) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(h) }
 func (h *Host) UnmarshalBSON(in []byte) error { return mgobson.Unmarshal(in, h) }
 
 type IdleHostsByDistroID struct {
@@ -270,10 +269,10 @@ type SpawnOptions struct {
 	// TimeoutTeardown is the time that this host should be torn down. In most cases, a host
 	// should be torn down due to its task or build. TimeoutTeardown is a backstop to ensure that Evergreen
 	// tears down a host if a task hangs or otherwise does not finish within an expected period of time.
-	TimeoutTeardown time.Time `bson:"timeout_teardown" json:"timeout_teardown"`
+	TimeoutTeardown time.Time `bson:"timeout_teardown,omitempty" json:"timeout_teardown,omitempty"`
 
 	// TimeoutTeardown is the time after which Evergreen should give up trying to set up this host.
-	TimeoutSetup time.Time `bson:"timeout_setup" json:"timeout_setup"`
+	TimeoutSetup time.Time `bson:"timeout_setup,omitempty" json:"timeout_setup,omitempty"`
 
 	// TaskID is the task_id of the task to which this host is pinned. When the task finishes,
 	// this host should be torn down. Only one of TaskID or BuildID should be set.
@@ -1597,9 +1596,7 @@ func FindRunningHosts(includeSpawnHosts bool) ([]Host, error) {
 func FindAllHostsSpawnedByTasks() ([]Host, error) {
 	query := db.Query(bson.M{
 		StatusKey: evergreen.HostRunning,
-		SpawnOptionsKey: bson.M{
-			"$exists": true,
-		},
+		bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsSpawnedByTaskKey): true,
 	})
 	hosts, err := Find(query)
 	if err != nil {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -40,6 +40,7 @@ type Host struct {
 
 	// physical location of host
 	Project string `bson:"project" json:"project"`
+	Region  string `bson:"region" json:"region"`
 	Zone    string `bson:"zone" json:"zone"`
 
 	// True if the app server has done all necessary host setup work (although

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -229,6 +229,8 @@ func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
 				"provider": d.Provider,
 				"settings": d.ProviderSettings,
 			}))
+			return errors.Wrapf(err, "error updating provider settings")
+
 		}
 	}
 	return nil

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -226,7 +226,8 @@ func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := d.UpdateProviderSettings(bytes); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
-				"settings": d.Provider,
+				"provider": d.Provider,
+				"settings": d.ProviderSettings,
 			}))
 		}
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -208,15 +208,7 @@ type DockerOptions struct {
 }
 
 func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
-		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		if err := bson.Unmarshal(bytes, opts); err != nil {
-			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if d.ProviderSettings != nil {
+	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
@@ -228,14 +220,23 @@ func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := doc.UnmarshalBSON(bytes); err != nil {
 			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
 		}
-		if err := d.UpdateProviderSettings(doc); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"distro":   d.Id,
-				"provider": d.Provider,
-				"settings": d.ProviderSettings,
-			}))
-			return errors.Wrapf(err, "error updating provider settings")
-
+		if len(d.ProviderSettingsList) == 0 {
+			if err := d.UpdateProviderSettings(doc); err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"distro":   d.Id,
+					"provider": d.Provider,
+					"settings": d.ProviderSettings,
+				}))
+				return errors.Wrapf(err, "error updating provider settings")
+			}
+		}
+	} else if len(d.ProviderSettingsList) != 0 {
+		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		if err := bson.Unmarshal(bytes, opts); err != nil {
+			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
 	}
 	return nil

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/certdepot"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -223,7 +224,11 @@ func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
-		if err := d.UpdateProviderSettings(bytes); err != nil {
+		doc := &birch.Document{}
+		if err := doc.UnmarshalBSON(bytes); err != nil {
+			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
+		}
+		if err := d.UpdateProviderSettings(doc); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"distro":   d.Id,
 				"provider": d.Provider,

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -16,6 +16,7 @@ import (
 type CreateOptions struct {
 	ProvisionOptions   *ProvisionOptions
 	ExpirationDuration *time.Duration
+	Region             string
 	UserName           string
 	UserHost           bool
 
@@ -39,6 +40,11 @@ func NewIntent(d distro.Distro, instanceName, provider string, options CreateOpt
 	// to the host we want to create. this way, if we are unable
 	// to start it or record its instance id, we have a way of knowing
 	// something went wrong - and what
+
+	// remove extraneous provider settings from the host's saved distro document
+	if len(d.ProviderSettingsList) > 1 {
+		d.RemoveExtraneousProviderSettings(options.Region)
+	}
 	intentHost := &Host{
 		Id:                    instanceName,
 		User:                  d.User,

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2701,8 +2701,9 @@ func TestFindHostsSpawnedByTasks(t *testing.T) {
 			Id:     "1",
 			Status: evergreen.HostRunning,
 			SpawnOptions: SpawnOptions{
-				TaskID:  "task_1",
-				BuildID: "build_1",
+				TaskID:        "task_1",
+				BuildID:       "build_1",
+				SpawnedByTask: true,
 			},
 		},
 		{
@@ -2717,24 +2718,27 @@ func TestFindHostsSpawnedByTasks(t *testing.T) {
 			Id:     "4",
 			Status: evergreen.HostRunning,
 			SpawnOptions: SpawnOptions{
-				TaskID:  "task_2",
-				BuildID: "build_1",
+				TaskID:        "task_2",
+				BuildID:       "build_1",
+				SpawnedByTask: true,
 			},
 		},
 		{
 			Id:     "5",
 			Status: evergreen.HostDecommissioned,
 			SpawnOptions: SpawnOptions{
-				TaskID:  "task_1",
-				BuildID: "build_1",
+				TaskID:        "task_1",
+				BuildID:       "build_1",
+				SpawnedByTask: true,
 			},
 		},
 		{
 			Id:     "6",
 			Status: evergreen.HostTerminated,
 			SpawnOptions: SpawnOptions{
-				TaskID:  "task_2",
-				BuildID: "build_1",
+				TaskID:        "task_2",
+				BuildID:       "build_1",
+				SpawnedByTask: true,
 			},
 		},
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -273,9 +273,6 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	if userID == "" {
 		ec2Settings.KeyName = createHost.KeyName // never use the distro's key
 	}
-	if createHost.Region != "" {
-		ec2Settings.Region = createHost.Region
-	}
 	if createHost.Subnet != "" {
 		ec2Settings.SubnetId = createHost.Subnet
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -310,7 +310,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	if err := doc.UnmarshalBSON(bytes); err != nil {
 		return nil, errors.Wrap(err, "error umarshalling settings bytes into document")
 	}
-	d.ProviderSettingsList = []birch.Document{doc}
+	d.ProviderSettingsList = []*birch.Document{&doc}
 
 	options, err := getAgentOptions(taskID, userID, createHost)
 	if err != nil {

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -11,10 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/evergreen-ci/birch"
-	"go.mongodb.org/mongo-driver/bson"
-
 	"github.com/docker/docker/api/types"
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/cloud"
@@ -27,6 +25,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // DBCreateHostConnector supports `host.create` commands from the agent.

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -337,7 +337,7 @@ type APIDistro struct {
 	UserSpawnAllowed      bool                     `json:"user_spawn_allowed"`
 	Provider              *string                  `json:"provider"`
 	ProviderSettings      map[string]interface{}   `json:"settings"`
-	ProviderSettingsList  []birch.Document         `json:"provider_settings"`
+	ProviderSettingsList  []*birch.Document        `json:"provider_settings"`
 	ImageID               *string                  `json:"image_id"`
 	Arch                  *string                  `json:"arch"`
 	WorkDir               *string                  `json:"work_dir"`
@@ -378,8 +378,6 @@ func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
 	apiDistro.Aliases = d.Aliases
 	apiDistro.UserSpawnAllowed = d.SpawnAllowed
 	apiDistro.Provider = ToStringPtr(d.Provider)
-	// TODO: we should get rid of this now that providerSettings is included in APIDistro,
-	//  but I'm not sure if build currently relies on this field.
 	if d.ProviderSettings != nil && cloud.IsEc2Provider(d.Provider) {
 		ec2Settings := &cloud.EC2ProviderSettings{}
 		err := mapstructure.Decode(d.ProviderSettings, ec2Settings)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -300,7 +300,7 @@ func getCreateOptionsFromDistro(d distro.Distro) (*host.CreateOptions, error) {
 		return nil, errors.Wrapf(err, "Error getting docker options from distro %s", d.Id)
 	}
 	if err := dockerOptions.Validate(); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	hostOptions := host.CreateOptions{

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -296,28 +295,19 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 }
 
 func getCreateOptionsFromDistro(d distro.Distro) (*host.CreateOptions, error) {
-	dockerOptions, err := getDockerOptionsFromProviderSettings(*d.ProviderSettings)
-	if err != nil {
+	dockerOptions := &host.DockerOptions{}
+	if err := dockerOptions.FromDistroSettings(d, ""); err != nil {
 		return nil, errors.Wrapf(err, "Error getting docker options from distro %s", d.Id)
 	}
+	if err := dockerOptions.Validate(); err != nil {
+		return nil, err
+	}
+
 	hostOptions := host.CreateOptions{
 		UserName:      evergreen.User,
 		DockerOptions: *dockerOptions,
 	}
 	return &hostOptions, nil
-}
-
-func getDockerOptionsFromProviderSettings(settings map[string]interface{}) (*host.DockerOptions, error) {
-	dockerOptions := &host.DockerOptions{}
-	if settings != nil {
-		if err := mapstructure.Decode(settings, dockerOptions); err != nil {
-			return nil, errors.Wrap(err, "Error decoding params")
-		}
-	}
-	if dockerOptions.Image == "" {
-		return nil, errors.New("docker image cannot be empty")
-	}
-	return dockerOptions, nil
 }
 
 // generateIntentHost creates a host intent document for a regular host

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
-	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/sometimes"
@@ -118,10 +117,10 @@ func UpdateStaticDistro(d distro.Distro) error {
 }
 
 func doStaticHostUpdate(d distro.Distro) ([]string, error) {
+	// TODO: Does a provider label fit this? I think ProviderNameStatic
 	settings := &cloud.StaticSettings{}
-	err := mapstructure.Decode(d.ProviderSettings, settings)
-	if err != nil {
-		return nil, errors.Errorf("invalid static settings for '%v'", d.Id)
+	if err := settings.FromDistroSettings(d, ""); err != nil {
+		return nil, errors.Wrapf(err, "invalid static settings for '%s'", d.Id)
 	}
 
 	staticHosts := []string{}

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -117,7 +117,6 @@ func UpdateStaticDistro(d distro.Distro) error {
 }
 
 func doStaticHostUpdate(d distro.Distro) ([]string, error) {
-	// TODO: Does a provider label fit this? I think ProviderNameStatic
 	settings := &cloud.StaticSettings{}
 	if err := settings.FromDistroSettings(d, ""); err != nil {
 		return nil, errors.Wrapf(err, "invalid static settings for '%s'", d.Id)

--- a/scheduler/wrapper_test.go
+++ b/scheduler/wrapper_test.go
@@ -1,9 +1,11 @@
 package scheduler
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/evergreen-ci/birch"
+	"go.mongodb.org/mongo-driver/bson"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
@@ -81,18 +83,18 @@ func TestNeedsReprovision(t *testing.T) {
 	}
 }
 
-func makeStaticHostProviderSettings(t *testing.T, names ...string) *map[string]interface{} {
+func makeStaticHostProviderSettings(t *testing.T, names ...string) *birch.Document {
 	settings := cloud.StaticSettings{
 		Hosts: []cloud.StaticHost{},
 	}
 	for _, name := range names {
 		settings.Hosts = append(settings.Hosts, cloud.StaticHost{Name: name})
 	}
-	b, err := json.Marshal(settings)
+	b, err := bson.Marshal(settings)
 	require.NoError(t, err)
-	m := make(map[string]interface{})
-	require.NoError(t, json.Unmarshal(b, &m))
-	return &m
+	doc := &birch.Document{}
+	require.NoError(t, doc.UnmarshalBSON(b))
+	return doc
 }
 
 func TestDoStaticHostUpdate(t *testing.T) {
@@ -130,10 +132,10 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			name := "host"
 			user := "user"
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, name),
-				Provider:         evergreen.ProviderNameStatic,
-				User:             user,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, name)},
+				Provider:             evergreen.ProviderNameStatic,
+				User:                 user,
 			}
 
 			hosts, err := doStaticHostUpdate(d)
@@ -154,9 +156,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 		"NewHostOnLegacyDistro": func(t *testing.T) {
 			name := "user@host"
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, name),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, name)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodLegacySSH,
 					Communication: distro.CommunicationMethodLegacySSH,
@@ -177,9 +179,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 		"NewHostOnNonLegacyDistro": func(t *testing.T) {
 			name := "user@host"
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, name),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, name)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodSSH,
 					Communication: distro.BootstrapMethodSSH,
@@ -201,9 +203,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h := legacyHost()
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodLegacySSH,
 					Communication: distro.BootstrapMethodLegacySSH,
@@ -224,9 +226,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h := legacyHost()
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodSSH,
 					Communication: distro.BootstrapMethodSSH,
@@ -247,9 +249,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h := nonLegacyHost()
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodLegacySSH,
 					Communication: distro.BootstrapMethodLegacySSH,
@@ -270,9 +272,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h := nonLegacyHost()
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodSSH,
 					Communication: distro.BootstrapMethodSSH,
@@ -295,9 +297,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h.Status = evergreen.HostTerminated
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodLegacySSH,
 					Communication: distro.BootstrapMethodLegacySSH,
@@ -320,9 +322,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h.Status = evergreen.HostTerminated
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodSSH,
 					Communication: distro.BootstrapMethodSSH,
@@ -345,9 +347,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h.Status = evergreen.HostTerminated
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodSSH,
 					Communication: distro.BootstrapMethodSSH,
@@ -370,9 +372,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h.Status = evergreen.HostTerminated
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodLegacySSH,
 					Communication: distro.BootstrapMethodLegacySSH,
@@ -395,9 +397,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h.Status = evergreen.HostQuarantined
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodLegacySSH,
 					Communication: distro.BootstrapMethodLegacySSH,
@@ -420,9 +422,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h.Status = evergreen.HostQuarantined
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodSSH,
 					Communication: distro.BootstrapMethodSSH,
@@ -445,9 +447,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h.Status = evergreen.HostQuarantined
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodSSH,
 					Communication: distro.BootstrapMethodSSH,
@@ -470,9 +472,9 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			h.Status = evergreen.HostQuarantined
 			require.NoError(t, h.Insert())
 			d := distro.Distro{
-				Id:               "distro",
-				ProviderSettings: makeStaticHostProviderSettings(t, h.Id),
-				Provider:         evergreen.ProviderNameStatic,
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodLegacySSH,
 					Communication: distro.BootstrapMethodLegacySSH,

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/util"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
@@ -142,7 +141,7 @@ func ensureHasRequiredFields(ctx context.Context, d *distro.Distro, s *evergreen
 	settings := mgr.GetSettings()
 
 	if d.ProviderSettings != nil {
-		if err = mapstructure.Decode(d.ProviderSettings, settings); err != nil {
+		if err = settings.FromDistroSettings(*d, mgrOpts.Region); err != nil {
 			return append(errs, ValidationError{
 				Message: fmt.Sprintf("distro '%v' decode error: %v", distro.ProviderSettingsKey, err),
 				Level:   Error,

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -123,6 +123,7 @@ func ensureHasRequiredFields(ctx context.Context, d *distro.Distro, s *evergreen
 		})
 	}
 
+	// TODO: this later need to go through every manager to check
 	mgrOpts, err := cloud.GetManagerOptions(*d)
 	if err != nil {
 		return append(errs, ValidationError{
@@ -139,7 +140,6 @@ func ensureHasRequiredFields(ctx context.Context, d *distro.Distro, s *evergreen
 	}
 
 	settings := mgr.GetSettings()
-
 	if d.ProviderSettings != nil {
 		if err = settings.FromDistroSettings(*d, mgrOpts.Region); err != nil {
 			return append(errs, ValidationError{

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -123,7 +123,7 @@ func ensureHasRequiredFields(ctx context.Context, d *distro.Distro, s *evergreen
 		})
 	}
 
-	// TODO: this later need to go through every manager to check
+	// TODO: this later will need to go through every region to check
 	mgrOpts, err := cloud.GetManagerOptions(*d)
 	if err != nil {
 		return append(errs, ValidationError{
@@ -140,13 +140,11 @@ func ensureHasRequiredFields(ctx context.Context, d *distro.Distro, s *evergreen
 	}
 
 	settings := mgr.GetSettings()
-	if d.ProviderSettings != nil {
-		if err = settings.FromDistroSettings(*d, mgrOpts.Region); err != nil {
-			return append(errs, ValidationError{
-				Message: fmt.Sprintf("distro '%v' decode error: %v", distro.ProviderSettingsKey, err),
-				Level:   Error,
-			})
-		}
+	if err = settings.FromDistroSettings(*d, mgrOpts.Region); err != nil {
+		return append(errs, ValidationError{
+			Message: fmt.Sprintf("distro '%v' decode error: %v", distro.ProviderSettingsKey, err),
+			Level:   Error,
+		})
 	}
 
 	if err := settings.Validate(); err != nil {

--- a/validator/distro_validator_test.go
+++ b/validator/distro_validator_test.go
@@ -180,6 +180,7 @@ func TestEnsureHasRequiredFields(t *testing.T) {
 
 	i := -1
 	Convey("When validating a distro...", t, func() {
+		db.ClearCollections(distro.Collection)
 		d := []distro.Distro{
 			{},
 			{Id: "a"},
@@ -222,6 +223,7 @@ func TestEnsureHasRequiredFields(t *testing.T) {
 			}},
 		}
 		i++
+		So(d[i].Insert(), ShouldBeNil)
 		Convey("an error should be returned if the distro does not contain an id", func() {
 			So(ensureHasRequiredFields(ctx, &d[i], conf), ShouldNotResemble, ValidationErrors{})
 		})

--- a/validator/distro_validator_test.go
+++ b/validator/distro_validator_test.go
@@ -180,7 +180,7 @@ func TestEnsureHasRequiredFields(t *testing.T) {
 
 	i := -1
 	Convey("When validating a distro...", t, func() {
-		db.ClearCollections(distro.Collection)
+		So(db.ClearCollections(distro.Collection), ShouldBeNil)
 		d := []distro.Distro{
 			{},
 			{Id: "a"},


### PR DESCRIPTION
Lots of changed files, basically just to add a ProviderSettingsList to the distro.

**Open Questions:** 
1. Added FromDistroSettings to the ProviderSettings interface, to handle getting from the list or the old data structure. This takes in zone because of ec2 (and potentially for supporting other providers in the future), but is that awkward? Sometimes region (not zone) will be passed in also. Just seems unnecessary to save both region and zone to Host when you can get the region from the zone easily. I almost added this to the Manager, but some places seem to use settings and not a manager.

2. Should we error more visibly if updating Distro with provider list doesn't work?

3. Is `"go.mongodb.org/mongo-driver/bson"` the preferred library? 

4. I wrote this so there might be a reason... but can DockerSettings be turned into DockerOptions at some point? Are these different bc of import cycles? (Really just a reminder for myself to look into it)

5. Does Build need that extra APIDistro field? Mathew Robinson thinks no but isn't sure. (Not a blocker for this ticket, just an eventual thing to get rid of)