### PR TITLE
EVG-7249 update parent IDs when they're assigned

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1515,6 +1515,18 @@ func (h *Host) IsIdleParent() (bool, error) {
 	return num == 0, nil
 }
 
+func (h *Host) UpdateParentIDs() error {
+	query := bson.M{
+		ParentIDKey: h.Tag,
+	}
+	update := bson.M{
+		"$set": bson.M{
+			ParentIDKey: h.Id,
+		},
+	}
+	return UpdateAll(query, update)
+}
+
 // For spawn hosts that have never been set unexpirable, this will
 // prevent spawn hosts from being set further than 30 days.
 // For unexpirable hosts, this will prevent them from being extended any further

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2477,6 +2477,35 @@ func TestIsIdleParent(t *testing.T) {
 
 }
 
+func TestUpdateParentIDs(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.Clear(Collection))
+	parent := Host{
+		Id:            "parent",
+		Tag:           "foo",
+		HasContainers: true,
+	}
+	assert.NoError(parent.Insert())
+	container1 := Host{
+		Id:       "c1",
+		ParentID: parent.Tag,
+	}
+	assert.NoError(container1.Insert())
+	container2 := Host{
+		Id:       "c2",
+		ParentID: parent.Tag,
+	}
+	assert.NoError(container2.Insert())
+
+	assert.NoError(parent.UpdateParentIDs())
+	dbContainer1, err := FindOneId(container1.Id)
+	assert.NoError(err)
+	assert.Equal(parent.Id, dbContainer1.ParentID)
+	dbContainer2, err := FindOneId(container2.Id)
+	assert.NoError(err)
+	assert.Equal(parent.Id, dbContainer2.ParentID)
+}
+
 func TestFindParentOfContainer(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -277,6 +277,14 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 			}))
 			return errors.Wrapf(err, "error inserting host %s", j.host.Id)
 		}
+		if j.host.HasContainers {
+			grip.Error(message.WrapError(j.host.UpdateParentIDs(), message.Fields{
+				"message": "unable to update parent ID of containers",
+				"host":    j.host.Id,
+				"distro":  j.host.Distro.Id,
+				"job":     j.ID(),
+			}))
+		}
 	}
 
 	event.LogHostStartFinished(j.host.Id, true)


### PR DESCRIPTION
Since the parent ID for containers did not get changed when the actual host's ID changed, [this check](https://github.com/evergreen-ci/evergreen/blob/master/model/host/host.go#L1507) fails, among other places