### PR TITLE
MAKE-1139: revendor gimlet

### DIFF
--- a/auth/okta.go
+++ b/auth/okta.go
@@ -26,7 +26,7 @@ func NewOktaUserManager(conf *evergreen.OktaConfig, evgURL, loginDomain string) 
 		LoginCookieName:      evergreen.AuthTokenCookie,
 		LoginCookieTTL:       365 * 24 * time.Hour,
 		AllowReauthorization: true,
-		AlwaysRefreshTokens:  true,
+		ValidateGroups:       true,
 		ReconciliateID: func(id string) string {
 			emailDomainStart := strings.LastIndex(id, "@")
 			if emailDomainStart == -1 {

--- a/auth/okta.go
+++ b/auth/okta.go
@@ -26,7 +26,6 @@ func NewOktaUserManager(conf *evergreen.OktaConfig, evgURL, loginDomain string) 
 		LoginCookieName:      evergreen.AuthTokenCookie,
 		LoginCookieTTL:       365 * 24 * time.Hour,
 		AllowReauthorization: true,
-		ValidateGroups:       true,
 		ReconciliateID: func(id string) string {
 			emailDomainStart := strings.LastIndex(id, "@")
 			if emailDomainStart == -1 {

--- a/glide.lock
+++ b/glide.lock
@@ -120,6 +120,7 @@ imports:
   - name: github.com/Masterminds/glide
     version: 23f6a9d8e774f597faabae8b58b8c6020b3f79ef
 
+    # TODO: revendor grip once MAKE-1139 merged
   - name: github.com/mongodb/grip
     version: 584e10f183651989291528fc432824587903b6fd
   - name: github.com/mongodb/amboy

--- a/glide.lock
+++ b/glide.lock
@@ -126,7 +126,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: e5548953650b5d4cc7b6d7aba4cb1b2771e35342
   - name: github.com/evergreen-ci/gimlet
-    version: 5ca77021ff9b964bababef0fd454ccf3dd29e752
+    version: 04e321216cc80f86b238686afdda123dec296b28
   - name: github.com/evergreen-ci/shrub
     version: 32e668cd99410328bf6659e55671c11a6c727d9a
   - name: github.com/evergreen-ci/pail

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1,7 +1,7 @@
 {{define "scripts"}}
 <script>
-        window.validDefaultLoggers = {{.ValidDefaultLoggers}};
-	window.can_logout = {{.CanClearTokens}};
+	window.validDefaultLoggers = {{.ValidDefaultLoggers}};
+	window.can_clear_tokens = {{.CanClearTokens}};
 </script>
 <script src="{{Static "js" "admin.js"}}?hash={{ BuildRevision }}"></script>
 <script type="text/javascript" src="{{Static "thirdparty" "js-yaml.min.js"}}?hash={{ BuildRevision }}"></script>

--- a/service/user.go
+++ b/service/user.go
@@ -19,6 +19,7 @@ import (
 func (uis *UIServer) loginPage(w http.ResponseWriter, r *http.Request) {
 	if uis.UserManager.IsRedirect() {
 		http.Redirect(w, r, "/login/redirect", http.StatusFound)
+		return
 	}
 	uis.render.WriteResponse(w, http.StatusOK, nil, "base", "login.html", "base_angular.html")
 }

--- a/vendor/github.com/evergreen-ci/gimlet/glide.lock
+++ b/vendor/github.com/evergreen-ci/gimlet/glide.lock
@@ -8,7 +8,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 - name: github.com/mongodb/grip
-  version: 83f68c032477a92d44a49baa5c7ef25c4c2f1a04
+  version: 2e402613ba129030dffcf05f53f185ea52d350c2
 - name: github.com/urfave/negroni
   version: 3444e69ea1ef03a77998d11fc56e7f0a34f7213c
 - name: github.com/stretchr/testify

--- a/vendor/github.com/evergreen-ci/gimlet/middleware_auth_user.go
+++ b/vendor/github.com/evergreen-ci/gimlet/middleware_auth_user.go
@@ -23,7 +23,6 @@ type UserMiddlewareConfiguration struct {
 	CookiePath      string
 	CookieTTL       time.Duration
 	CookieDomain    string
-	SetRedirect     func(*http.Request, string)
 }
 
 // Validate ensures that the UserMiddlewareConfiguration is correct

--- a/vendor/github.com/evergreen-ci/gimlet/okta/okta.go
+++ b/vendor/github.com/evergreen-ci/gimlet/okta/okta.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/usercache"
 	"github.com/evergreen-ci/gimlet/util"
+	"github.com/k0kubun/pp"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	jwtverifier "github.com/okta/okta-jwt-verifier-golang"
@@ -27,14 +28,13 @@ type CreationOptions struct {
 	Issuer       string
 
 	UserGroup string
-	// If set, user authentication will not attempt to populate the user's
-	// groups.
-	SkipGroupPopulation bool
-	// If set, user reauthorization will always refresh the access and refresh
-	// tokens without trying to use the existing access token.
-	AlwaysRefreshTokens bool
 	// If set, user can be reauthorized without needing to authenticate.
 	AllowReauthorization bool
+	// If set, authentication and reauthorization will validate the group for
+	// the user matches UserGroup. Otherwise, it simply checks that the user
+	// attempting to reauthorize has the same name as that returned by the ID
+	// token.
+	ValidateGroups bool
 
 	CookiePath   string
 	CookieDomain string
@@ -60,7 +60,9 @@ func (opts *CreationOptions) Validate() error {
 	catcher.NewWhen(opts.ClientSecret == "", "must specify client secret")
 	catcher.NewWhen(opts.RedirectURI == "", "must specify redirect URI")
 	catcher.NewWhen(opts.Issuer == "", "must specify issuer")
-	catcher.NewWhen(opts.UserGroup == "", "must specify user group")
+	if opts.ValidateGroups {
+		catcher.NewWhen(opts.UserGroup == "", "must specify user group")
+	}
 	catcher.NewWhen(opts.CookiePath == "", "must specify cookie path")
 	catcher.NewWhen(opts.LoginCookieName == "", "must specify login cookie name")
 	if opts.LoginCookieTTL == time.Duration(0) {
@@ -87,11 +89,10 @@ type userManager struct {
 
 	userGroup string
 
-	skipGroupPopulation  bool
+	validateGroups       bool
 	allowReauthorization bool
-	alwaysRefreshTokens  bool
 
-	// This is used only for testing purposes.
+	// This is used only for testing purposes. It skips all token validation.
 	insecureSkipTokenValidation bool
 
 	cookiePath   string
@@ -137,9 +138,8 @@ func NewUserManager(opts CreationOptions) (gimlet.UserManager, error) {
 		cookieTTL:            opts.CookieTTL,
 		loginCookieName:      opts.LoginCookieName,
 		loginCookieTTL:       opts.LoginCookieTTL,
-		skipGroupPopulation:  opts.SkipGroupPopulation,
+		validateGroups:       opts.ValidateGroups,
 		allowReauthorization: opts.AllowReauthorization,
-		alwaysRefreshTokens:  opts.AlwaysRefreshTokens,
 		getHTTPClient:        opts.GetHTTPClient,
 		putHTTPClient:        opts.PutHTTPClient,
 		reconciliateID:       opts.ReconciliateID,
@@ -167,8 +167,8 @@ func (m *userManager) GetUserByToken(ctx context.Context, token string) (gimlet.
 	return user, nil
 }
 
-// doReauthorize attempts to authorize the user based on their tokens.
-func (m *userManager) doReauthorize(accessToken, refreshToken string) error {
+// reauthorizeGroup attempts to reauthorize the user based on their groups.
+func (m *userManager) reauthorizeGroup(accessToken, refreshToken string) error {
 	catcher := grip.NewBasicCatcher()
 	var err error
 	if !m.insecureSkipTokenValidation {
@@ -176,11 +176,12 @@ func (m *userManager) doReauthorize(accessToken, refreshToken string) error {
 		catcher.Wrap(err, "invalid access token")
 	}
 	if err == nil {
+		pp.Println("generating user from access token")
 		user, err := m.generateUserFromInfo(accessToken, refreshToken)
 		catcher.Wrap(err, "could not generate user from Okta user info")
 		if err == nil {
 			_, err = m.cache.Put(user)
-			catcher.Wrap(err, "could not update user in cache")
+			catcher.Wrap(err, "could not update reauthorized user in cache")
 			if err == nil {
 				return nil
 			}
@@ -189,18 +190,61 @@ func (m *userManager) doReauthorize(accessToken, refreshToken string) error {
 	return catcher.Resolve()
 }
 
-// reauthorizeUser attempts to reauthorize the user, first with their current
-// access token. If that fails, it refreshes the tokens and attempts to
+// reauthorizeID attempts to reauthorize the user based on their ID token.
+// Reauthorization succeeds if the username derived from their ID token matches
+// the given username.
+func (m *userManager) reauthorizeID(username string, tokens *tokenResponse) error {
+	idToken, err := m.validateIDToken(tokens.IDToken, "")
+	// When we receive an ID token from a refresh grant (i.e. during
+	// reauthorization), the ID token does not contain a nonce. However, the
+	// Okta token verification library requires that a nonce always be specified
+	// for verifying ID tokens.
+	// We ignore this error if it occurs. More info can be found here:
+	// https://bitbucket.org/openid/connect/issues/1025/ambiguity-with-how-nonce-is-handled-on
+	if err != nil && !strings.Contains(strings.ToLower(err.Error()), "nonce") {
+		return errors.Wrap(err, "invalid ID token")
+	}
+	email, ok := idToken.Claims["email"].(string)
+	if ok {
+		checkUsername := m.reconciliateID(email)
+		pp.Println("checking username:", checkUsername, username)
+		if checkUsername != username {
+			return errors.Errorf("user name from ID token '%s' did not match user '%s'", checkUsername, username)
+		}
+	} else {
+		return errors.New("ID token is missing email claim")
+	}
+	catcher := grip.NewBasicCatcher()
+	user, err := makeUserFromIDToken(idToken, tokens.AccessToken, tokens.RefreshToken, m.reconciliateID)
+	catcher.Wrap(err, "could not generate user from Okta ID token")
+	if err == nil {
+		_, err = m.cache.Put(user)
+		catcher.Wrapf(err, "could not update reauthorized user in cache")
+		if err == nil {
+			pp.Println("reauthorize ID passed")
+			return nil
+		}
+	}
+	return catcher.Resolve()
+}
+
+// reauthorizeUser attempts to reauthorize the user.
+// Reauthorization works as follows: if the user manager is configured to
+// validate their groups, it tries checking their user groups using their access
+// token. Otherwise, it just validates that the ID token user matches the
+// current user.
+// If reauthorization fails or the user manager is configured to always refresh
+// the user's tokens that fails, it refreshes the tokens and attempts to
 // reauthorize them again.
 func (m *userManager) reauthorizeUser(ctx context.Context, user gimlet.User) error {
-	accessToken := user.GetAccessToken()
-	if accessToken == "" {
-		return errors.Errorf("user '%s' cannot reauthorize because user is missing access token", user.Username())
-	}
 	refreshToken := user.GetRefreshToken()
 	catcher := grip.NewBasicCatcher()
-	if !m.alwaysRefreshTokens {
-		err := m.doReauthorize(accessToken, refreshToken)
+	if m.validateGroups {
+		accessToken := user.GetAccessToken()
+		if accessToken == "" {
+			return errors.Errorf("user '%s' cannot reauthorize because user is missing access token", user.Username())
+		}
+		err := m.reauthorizeGroup(accessToken, refreshToken)
 		catcher.Wrap(err, "could not reauthorize user with current access token")
 		if err == nil {
 			return nil
@@ -213,10 +257,17 @@ func (m *userManager) reauthorizeUser(ctx context.Context, user gimlet.User) err
 	tokens, err := m.refreshTokens(ctx, refreshToken)
 	catcher.Wrap(err, "could not refresh authorization tokens")
 	if err == nil {
-		err = m.doReauthorize(tokens.AccessToken, tokens.RefreshToken)
-		catcher.Wrap(err, "could  not reauthorize user after refreshing tokens")
-		if err == nil {
-			return nil
+		if m.validateGroups {
+			err = m.reauthorizeGroup(tokens.AccessToken, tokens.RefreshToken)
+			catcher.Wrap(err, "could  not reauthorize user after refreshing tokens")
+			if err == nil {
+				return nil
+			}
+		} else if !m.insecureSkipTokenValidation {
+			err = m.reauthorizeID(user.Username(), tokens)
+		} else {
+			grip.Criticalf("cannot reauthorize user '%s' if we cannot validate the user's groups and we are cannot validate their ID token", user.Username())
+			catcher.New("no valid method of reauthorizing user")
 		}
 	}
 
@@ -296,7 +347,7 @@ func (m *userManager) GetLoginHandler(_ string) http.HandlerFunc {
 		q.Add("client_id", m.clientID)
 		q.Add("response_type", "code")
 		q.Add("response_mode", "query")
-		q.Add("scope", "openid email profile offline_access groups")
+		q.Add("scope", m.scopes())
 		if !canSilentReauth {
 			q.Add("prompt", "login consent")
 		}
@@ -387,20 +438,26 @@ func (m *userManager) GetLoginCallbackHandler() http.HandlerFunc {
 		}
 
 		var user gimlet.User
-		if m.skipGroupPopulation && !m.insecureSkipTokenValidation {
+		if !m.validateGroups && !m.insecureSkipTokenValidation {
+			pp.Println("login user from ID token")
 			user, err = makeUserFromIDToken(idToken, tokens.AccessToken, tokens.RefreshToken, m.reconciliateID)
 			if err != nil {
 				grip.Error(err)
 				writeError(w, err)
 				return
 			}
-		} else {
+		} else if m.validateGroups {
+			pp.Println("login user from access token")
 			user, err = m.generateUserFromInfo(tokens.AccessToken, tokens.RefreshToken)
 			if err != nil {
 				grip.Error(err)
 				writeError(w, err)
 				return
 			}
+		} else {
+			grip.Criticalf("cannot login user if we cannot validate the user's groups and we are validate their ID token")
+			writeError(w, errors.New("programmatic error: invalid state reached"))
+			return
 		}
 
 		user, err = m.GetOrCreateUser(user)
@@ -444,7 +501,7 @@ func (m *userManager) getUserTokens(code, nonce string) (*tokenResponse, *jwtver
 	if err != nil {
 		return tokens, nil, errors.Wrap(err, "invalid ID token from Okta")
 	}
-	if m.insecureSkipTokenValidation {
+	if m.insecureSkipTokenValidation || !m.validateGroups {
 		return tokens, idToken, nil
 	}
 	if err := m.validateAccessToken(tokens.AccessToken); err != nil {
@@ -461,13 +518,16 @@ func (m *userManager) generateUserFromInfo(accessToken, refreshToken string) (gi
 		err = errors.Wrap(err, "could not retrieve user info from Okta")
 		return nil, err
 	}
-	if err := m.validateGroup(userInfo.Groups); err != nil {
-		err = errors.Wrap(err, "could not authorize user")
-		grip.Error(message.WrapError(err, message.Fields{
-			"expected_group": m.userGroup,
-			"actual_groups":  userInfo.Groups,
-		}))
-		return nil, err
+	if m.validateGroups {
+		pp.Println("validating groups")
+		if err := m.validateGroup(userInfo.Groups); err != nil {
+			err = errors.Wrap(err, "could not authorize user")
+			grip.Error(message.WrapError(err, message.Fields{
+				"expected_group": m.userGroup,
+				"actual_groups":  userInfo.Groups,
+			}))
+			return nil, err
+		}
 	}
 	return makeUserFromInfo(userInfo, accessToken, refreshToken, m.reconciliateID)
 }
@@ -597,8 +657,13 @@ func (m *userManager) refreshTokens(ctx context.Context, refreshToken string) (*
 	q := url.Values{}
 	q.Set("grant_type", "refresh_token")
 	q.Set("refresh_token", refreshToken)
-	q.Set("scope", "openid email profile offline_access groups")
+	q.Set("scope", m.scopes())
 	return m.redeemTokens(ctx, q.Encode())
+}
+
+// scopes returns the necessary scopes for Okta to return.
+func (m *userManager) scopes() string {
+	return "openid email profile offline_access groups"
 }
 
 // redeemTokens sends the request to redeem tokens with the required client
@@ -775,8 +840,8 @@ func makeUserFromInfo(info *userInfoResponse, accessToken, refreshToken string, 
 }
 
 // makeUserFromIDToken returns a user based on information from an ID token.
-func makeUserFromIDToken(jwt *jwtverifier.Jwt, accessToken, refreshToken string, reconciliateID func(string) string) (gimlet.User, error) {
-	email, ok := jwt.Claims["email"].(string)
+func makeUserFromIDToken(idToken *jwtverifier.Jwt, accessToken, refreshToken string, reconciliateID func(string) string) (gimlet.User, error) {
+	email, ok := idToken.Claims["email"].(string)
 	if !ok {
 		return nil, errors.New("user is missing email")
 	}
@@ -787,7 +852,7 @@ func makeUserFromIDToken(jwt *jwtverifier.Jwt, accessToken, refreshToken string,
 	if id == "" {
 		return nil, errors.New("could not create user ID from email")
 	}
-	name, ok := jwt.Claims["name"].(string)
+	name, ok := idToken.Claims["name"].(string)
 	if !ok {
 		return nil, errors.New("user is missing name")
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1139

This gimlet version makes fewer Okta calls by making group checking optional to try to speed up logging in and reauthing. I did some random drive-by fixes that I found in the login and admin page.