### PR TITLE
EVG-6439 use correct thread level for perf comparisons

### DIFF
--- a/public/static/app/perf/TestSample.js
+++ b/public/static/app/perf/TestSample.js
@@ -36,6 +36,7 @@ mciModule.factory('TestSample', function () {
     // Returns only the keys that have results stored in them
     this.resultKeys = function (testName) {
       var testInfo = this.resultForTest(testName);
+      // FIXME: questionable null handling. see https://github.com/evergreen-ci/evergreen/pull/3103/files#r375279754
       return _.pluck(_(testInfo.results).pairs().filter(function (x) {
         return typeof (x[1]) == "object"
       }), 0)

--- a/public/static/app/perf/TestSample.js
+++ b/public/static/app/perf/TestSample.js
@@ -73,7 +73,7 @@ mciModule.factory('TestSample', function () {
     this.maxThroughputForTest = function (testName, metric, threadLevel) {
       const d = this.resultForTest(testName);
       if (!d) {
-        return 0;
+        return null;
       }
       if (threadLevel) {
         return d.results[threadLevel][metric];

--- a/public/static/app/perf/TestSample.js
+++ b/public/static/app/perf/TestSample.js
@@ -1,15 +1,14 @@
-mciModule.factory('TestSample', function() {
-  return function(sample){
+mciModule.factory('TestSample', function () {
+  return function (sample) {
     this.sample = sample;
     this._threads = null;
-    this._maxes = {};
 
-    this.threads = function(){
-      if(this._threads == null){
+    this.threads = function () {
+      if (this._threads == null) {
         this._threads = _.uniq(
           _.filter(
             _.flatten(
-              _.map(this.sample.data.results, function(x){
+              _.map(this.sample.data.results, function (x) {
                 return _.keys(x.results)
               }), true
             ), numericFilter
@@ -19,7 +18,7 @@ mciModule.factory('TestSample', function() {
       return this._threads;
     }
 
-    this.testNames = function(){
+    this.testNames = function () {
       var tests = _.pluck(this.sample.data.results, "name");
       if (tests.length === 0) {
         tests = _.pluck(_.pluck(this.sample, "info"), "test_name");
@@ -27,20 +26,22 @@ mciModule.factory('TestSample', function() {
       return tests
     }
 
-    this.getLegendName = function(){
-      if(!!this.sample.tag){
+    this.getLegendName = function () {
+      if (!!this.sample.tag) {
         return this.sample.tag
       }
-      return this.sample.revision.substring(0,7)
+      return this.sample.revision.substring(0, 7)
     }
 
     // Returns only the keys that have results stored in them
-    this.resultKeys = function(testName){
+    this.resultKeys = function (testName) {
       var testInfo = this.resultForTest(testName);
-      return _.pluck(_(testInfo.results).pairs().filter(function(x){return typeof(x[1]) == "object"}), 0)
+      return _.pluck(_(testInfo.results).pairs().filter(function (x) {
+        return typeof (x[1]) == "object"
+      }), 0)
     }
 
-    this.threadsVsOps = function(testName) {
+    this.threadsVsOps = function (testName) {
       var testInfo = this.resultForTest(testName);
       var result = [];
       if (!testInfo)
@@ -49,7 +50,9 @@ mciModule.factory('TestSample', function() {
 
       var keys = this.resultKeys(testName)
       for (var j = 0; j < keys.length; j++) {
-        let value = {threads: parseInt(keys[j])};
+        let value = {
+          threads: parseInt(keys[j])
+        };
         for (key in series[keys[j]]) {
           value[key] = series[keys[j]][key];
         }
@@ -59,19 +62,23 @@ mciModule.factory('TestSample', function() {
       return result;
     }
 
-    this.resultForTest = function(testName){
+    this.resultForTest = function (testName) {
       return _.findWhere(
-        this.sample.data.results, {name: testName}
+        this.sample.data.results, {
+          name: testName
+        }
       );
     }
 
-    this.maxThroughputForTest = function(testName, metric){
-      if(!_.has(this._maxes, testName)){
-        var d = this.resultForTest(testName);
-        if(!d){
-          return;
-        }
-        this._maxes[testName] = _.max(
+    this.maxThroughputForTest = function (testName, metric, threadLevel) {
+      const d = this.resultForTest(testName);
+      if (!d) {
+        return 0;
+      }
+      if (threadLevel) {
+        return d.results[threadLevel][metric];
+      } else {
+        return _.max(
           _.filter(
             _.pluck(
               _.values(d.results), metric
@@ -79,7 +86,6 @@ mciModule.factory('TestSample', function() {
           )
         );
       }
-      return this._maxes[testName];
     }
   }
 })

--- a/public/static/app/perf/TrendSamples.js
+++ b/public/static/app/perf/TrendSamples.js
@@ -1,6 +1,6 @@
-mciModule.factory('TrendSamples', function() {
+mciModule.factory('TrendSamples', function () {
   // Class to contain a collection of samples in a series.
-  return function(samples){
+  return function (samples) {
     this.samples = samples;
     var NON_THREAD_LEVELS = ['start', 'end']
 
@@ -39,7 +39,7 @@ mciModule.factory('TrendSamples', function() {
             this.seriesByName[rec.name] = [];
           }
 
-          var maxValues = _.max(rec.results, function(d) {
+          var maxValues = _.max(rec.results, function (d) {
             return null;
           })
 
@@ -47,7 +47,7 @@ mciModule.factory('TrendSamples', function() {
           // Change dict to array
           var threadResults = _.chain(rec.results)
             .omit(NON_THREAD_LEVELS)
-            .map(function(v, k) {
+            .map(function (v, k) {
               _.each(_.keys(v), (d) => metricsSet.add(d))
               v.threadLevel = k
               return v
@@ -83,15 +83,14 @@ mciModule.factory('TrendSamples', function() {
     for (let i = 0; i < this.testNames.length; i++) {
       //make an index for commit hash -> sample for each test series
       var k = this.testNames[i];
-      // FIXME Unknown behavior (coma operator after _groupBy stmt)
-      this._sampleByCommitIndexes[k] = _.groupBy(this.seriesByName[k], "revision"), function(x){return x[0]};
-      for(let t in this._sampleByCommitIndexes[k]){
+      this._sampleByCommitIndexes[k] = _.groupBy(this.seriesByName[k], "revision");
+      for (let t in this._sampleByCommitIndexes[k]) {
         this._sampleByCommitIndexes[k][t] = this._sampleByCommitIndexes[k][t][0];
       }
     }
 
     // Returns a list of samples for a given test, sorted in the order that they were committed.
-    this.tasksByCommitOrder = function(){
+    this.tasksByCommitOrder = function () {
       if (!this._tasks) {
         this._tasks = _.chain(this.seriesByName)
           .values()
@@ -103,14 +102,16 @@ mciModule.factory('TrendSamples', function() {
       return this._tasks;
     }
 
-    this.tasksByCommitOrderByTestName = function(testName){
-       if(!(testName in this._tasksByName)){
-          this._tasksByName[testName] = _.sortBy(_.uniq(this.seriesByName[testName], function(x){return x.task_id}), "order")
-       }
-       return this._tasksByName[testName]
+    this.tasksByCommitOrderByTestName = function (testName) {
+      if (!(testName in this._tasksByName)) {
+        this._tasksByName[testName] = _.sortBy(_.uniq(this.seriesByName[testName], function (x) {
+          return x.task_id
+        }), "order")
+      }
+      return this._tasksByName[testName]
     }
 
-    this.sampleInSeriesAtCommit = function(testName, revision){
+    this.sampleInSeriesAtCommit = function (testName, revision) {
       let sample = this._sampleByCommitIndexes[testName];
       if (sample) {
         return this._sampleByCommitIndexes[testName][revision];
@@ -118,14 +119,16 @@ mciModule.factory('TrendSamples', function() {
       return null;
     }
 
-    this.indexOfCommitInSeries = function(testName, revision){
+    this.indexOfCommitInSeries = function (testName, revision) {
       var t = this.tasksByCommitOrderByTestName(testName)
-      return findIndex(t, function(x) { return x.revision==revision })
+      return findIndex(t, function (x) {
+        return x.revision == revision
+      })
     }
 
-    this.noiseAtCommit = function(testName, revision){
+    this.noiseAtCommit = function (testName, revision) {
       var sample = this._sampleByCommitIndexes[testName][revision];
-      if(sample && sample.ops_per_sec_values && sample.ops_per_sec_values.length > 1){
+      if (sample && sample.ops_per_sec_values && sample.ops_per_sec_values.length > 1) {
         var r = (_.max(sample.ops_per_sec_values) - _.min(sample.ops_per_sec_values)) / d3.mean(sample.ops_per_sec_values);
         return r;
       }

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -276,6 +276,9 @@ $http.get(templateUrl).success(function(template) {
 
   // converts a percentage to a color. Higher -> greener, Lower -> redder.
   $scope.percentToColor = function (percent) {
+    if (percent === null) {
+      return "";
+    }
     var percentColorRanges = [{
         min: -Infinity,
         max: -15,
@@ -333,7 +336,12 @@ $http.get(templateUrl).success(function(template) {
     if (!hoverResults) {
       hoverResults = $scope.hoverSamples[testName];
     }
-    const diff = 100 * $scope.percentDiff(hoverResults[$scope.metricSelect.value.key], compareSample.maxThroughputForTest(testName, $scope.metricSelect.value.key, threadLevel));
+    const currentResults = hoverResults[$scope.metricSelect.value.key];
+    const compareResults = compareSample.maxThroughputForTest(testName, $scope.metricSelect.value.key, threadLevel);
+    if (currentResults === null || compareResults === null) {
+      return "no comparison data";
+    }
+    const diff = 100 * $scope.percentDiff(currentResults, compareResults);
     return diff;
   }
 

--- a/public/static/app/perf/trend_chart.js
+++ b/public/static/app/perf/trend_chart.js
@@ -109,9 +109,13 @@ mciModule.factory('DrawPerfTrendChart', function (
 
     maxIdx = _.max(allLevels);
 
-    const levelsMeta = threadMode === MAXONLY
-      ? [{ name: 'MAX', idx: maxIdx, color: '#484848', isActive: true }]
-      : _.map(allLevels, function (d, i) {
+    const levelsMeta = threadMode === MAXONLY ? [{
+        name: 'MAX',
+        idx: maxIdx,
+        color: '#484848',
+        isActive: true
+      }] :
+      _.map(allLevels, function (d, i) {
         const data = {
           name: d,
           idx: i,
@@ -130,6 +134,9 @@ mciModule.factory('DrawPerfTrendChart', function (
     function updateActiveLevels() {
       activeLevels = levelsMeta.filter(meta => meta.isActive);
       activeLevelNames = activeLevels.map(level => level.name)
+      if (params.updateThreadLevels) {
+        params.updateThreadLevels(_.pluck(activeLevels, "name"));
+      }
     }
 
     updateActiveLevels();
@@ -200,7 +207,9 @@ mciModule.factory('DrawPerfTrendChart', function (
       changePointForLevel = [];
       _.each(visibleChangePoints, function (point) {
         point.bfs = _.chain(buildFailures).filter((bf) => bf.revisions.includes(point.suspect_revision)).value() || [];
-        const level = _.findWhere(levelsMeta, { name: point.thread_level });
+        const level = _.findWhere(levelsMeta, {
+          name: point.thread_level
+        });
         const levels = level ? [level] : levelsMeta;
 
         _.each(levels, function (level) {
@@ -235,9 +244,9 @@ mciModule.factory('DrawPerfTrendChart', function (
 
     // Obtains value extractor fn for given `level` and series `item`
     // The obtained function is curried, so you should call it as fn(level)(item)
-    const getValueFor = threadMode === MAXONLY
-      ? PerfChartService.getValueForMaxOnly
-      : PerfChartService.getValueForAllLevels;
+    const getValueFor = threadMode === MAXONLY ?
+      PerfChartService.getValueForMaxOnly :
+      PerfChartService.getValueForAllLevels;
 
     // When there are more than one value in opsValues item
     const hasValues = _.all(opsValues, function (d) {
@@ -260,7 +269,9 @@ mciModule.factory('DrawPerfTrendChart', function (
       // For each active thread level extract values
       // including undefined values for missing data
       return _.map(activeLevelNames, function (d) {
-        const result = _.findWhere(sample.threadResults, { threadLevel: d });
+        const result = _.findWhere(sample.threadResults, {
+          threadLevel: d
+        });
         return result && (result[cfg.valueAttr]);
       })
     }
@@ -484,7 +495,9 @@ mciModule.factory('DrawPerfTrendChart', function (
     const chartG = svg.append('svg:g')
       .attr('transform', d3Translate(cfg.margin.left, cfg.margin.top));
 
-    const linesG = chartG.append('g').attr({ class: 'lines-g' });
+    const linesG = chartG.append('g').attr({
+      class: 'lines-g'
+    });
 
     function redrawLines() {
       const lines = linesG.selectAll('path')
@@ -525,9 +538,9 @@ mciModule.factory('DrawPerfTrendChart', function (
         const commitCircle = chartG
           .selectAll('circle.current')
           .data(
-            threadMode === MAXONLY
-              ? activeLevels
-              : threadLevelsForSample(series[currentItemIdx], activeLevels)
+            threadMode === MAXONLY ?
+            activeLevels :
+            threadLevelsForSample(series[currentItemIdx], activeLevels)
           );
 
         commitCircle
@@ -624,7 +637,9 @@ mciModule.factory('DrawPerfTrendChart', function (
 
       // Create new elements (ref. line groups)
       refLinesG
-        .attr({ class: (_, idx) => 'cmp-' + idx })
+        .attr({
+          class: (_, idx) => 'cmp-' + idx
+        })
         .each(drawRefLines);
 
       // Remove unused elements (ref. line groups)
@@ -713,11 +728,8 @@ mciModule.factory('DrawPerfTrendChart', function (
         })
         .style({
           stroke: (d) =>
-            d.changePoint.processed_type === PROCESSED_TYPE.NONE ? 'red' :
-              d.changePoint.processed_type === PROCESSED_TYPE.ACKNOWLEDGED ? 'green' :
-                d.changePoint.processed_type === PROCESSED_TYPE.HIDDEN ? 'darkblue' :
-                  'cyan' // cyan for invalid processed_type
-          ,
+            d.changePoint.processed_type === PROCESSED_TYPE.NONE ? 'red' : d.changePoint.processed_type === PROCESSED_TYPE.ACKNOWLEDGED ? 'green' : d.changePoint.processed_type === PROCESSED_TYPE.HIDDEN ? 'darkblue' : 'cyan' // cyan for invalid processed_type
+            ,
         });
 
       changePointSegments.exit().remove();
@@ -740,7 +752,7 @@ mciModule.factory('DrawPerfTrendChart', function (
           fill: function (d) {
             return d.count === 1 ? 'yellow' :
               d.count === 2 ? 'orange' :
-                'red'
+              'red'
           },
         });
 
@@ -772,7 +784,9 @@ mciModule.factory('DrawPerfTrendChart', function (
     redrawChangePoints();
 
     chartG.append('g')
-      .attr({ class: 'change-point-info' });
+      .attr({
+        class: 'change-point-info'
+      });
 
     // -- REGULAR POINT HOVER --
     // Contains elements for hover behavior
@@ -905,8 +919,7 @@ mciModule.factory('DrawPerfTrendChart', function (
       .data(
         _.filter(cfg.toolTip.labels, function (d) {
           return d.nonStat !== true
-        }
-        )
+        })
       )
       .enter()
       .append('g')
@@ -917,7 +930,9 @@ mciModule.factory('DrawPerfTrendChart', function (
 
     const nonStatToolTipItem = toolTipContentG
       .selectAll('g.non-stat')
-      .data(_.where(cfg.toolTip.labels, { nonStat: true }))
+      .data(_.where(cfg.toolTip.labels, {
+        nonStat: true
+      }))
       .enter()
       .append('g')
       .attr({
@@ -1032,7 +1047,10 @@ mciModule.factory('DrawPerfTrendChart', function (
             return d3Translate.apply(
               null,
               fit(
-                [[0, cfg.effectiveWidth], [0, cfg.effectiveHeight]],
+                [
+                  [0, cfg.effectiveWidth],
+                  [0, cfg.effectiveHeight]
+                ],
                 [mousePos[0] + 10, mousePos[1]], // 10 for extra offset
                 [
                   cfg.toolTip.width + cfg.toolTip.margin * 2 + 20, // 20 for extra offset
@@ -1047,9 +1065,9 @@ mciModule.factory('DrawPerfTrendChart', function (
     function changePointMouseOver(point) {
       function extractToolTipValue(item, obj) {
         // Get raw value of the stat item
-        const rawValue = _.isFunction(item.key)
-          ? item.key(obj)
-          : obj[item.key];
+        const rawValue = _.isFunction(item.key) ?
+          item.key(obj) :
+          obj[item.key];
         // Apply formatting if defined
         return item.formatter ? item.formatter(rawValue) : rawValue
       }
@@ -1156,9 +1174,8 @@ mciModule.factory('DrawPerfTrendChart', function (
 
       // List of per thread level values for selected item
       let values = _.filter(
-        threadMode === MAXONLY
-          ? [item.threadResults[maxLevelIdx(idx)][cfg.valueAttr]]
-          : _.filter(getOpsValues(item))
+        threadMode === MAXONLY ? [item.threadResults[maxLevelIdx(idx)][cfg.valueAttr]] :
+        _.filter(getOpsValues(item))
       );
 
       // If there are no values for current metric, skip
@@ -1173,9 +1190,9 @@ mciModule.factory('DrawPerfTrendChart', function (
       focusG.attr('transform', d3Translate(x, 0));
 
       // Add/Remove tooltip items (some data samples may not contain all thread levels)
-      updateTooltip(threadMode === MAXONLY
-        ? activeLevels
-        : threadLevelsForSample(item, activeLevels)
+      updateTooltip(threadMode === MAXONLY ?
+        activeLevels :
+        threadLevelsForSample(item, activeLevels)
       );
 
       focusedPointsRef.attr({

--- a/public/static/app/perf/trend_chart.test.js
+++ b/public/static/app/perf/trend_chart.test.js
@@ -8,18 +8,24 @@ describe('DrawPerfTrendChartTest', function () {
     rootScope = $rootScope
   }));
 
-  it('should not generate error when given non-constant max indices', function () {
+  it('should create a trend graph without errors', function () {
     let scope = {
-      task:{
+      task: {
         id: "sys_perf_linux_standalone_big_update_bb9114dc71bfcf42422471f7789eca00881b8864_19_01_03_20_13_57",
       },
       $parent: rootScope,
-      $on: function(){}
+      $on: function () {}
     }
 
+    let spy = {
+      checkThreadLevels: (threads) => {
+        expect(threads).toEqual(["1", "100"]);
+      }
+    }
+    let checkThreadLevels = spyOn(spy, "checkThreadLevels").and.callThrough();
+
     let params = {
-      series: [
-        {
+      series: [{
           "revision": "bb9114dc71bfcf42422471f7789eca00881b8864",
           "task_id": "sys_perf_linux_standalone_big_update_bb9114dc71bfcf42422471f7789eca00881b8864_19_01_03_20_13_57",
           "order": 14925,
@@ -54,14 +60,16 @@ describe('DrawPerfTrendChartTest', function () {
       scope: scope,
       containerId: 'containerId',
       compareSamples: [],
-      threadMode: 'maxonly',
+      threadMode: 'all',
       linearMode: true,
-      originMode: true
+      originMode: true,
+      updateThreadLevels: checkThreadLevels
     };
 
-    document.getElementById = function (){
+    document.getElementById = function () {
       return {}
     };
     svcFactory(params)
+    expect(checkThreadLevels).toHaveBeenCalled();
   });
 });

--- a/service/templates/task_perf_data.html
+++ b/service/templates/task_perf_data.html
@@ -409,9 +409,9 @@
                     metric has no data
                   </span>
                   <span ng-if="hoverSamples[k][metricSelect.value.key] != undefined"
-                        ng-style="{backgroundColor: percentToColor(100 * percentDiff(hoverSamples[k][metricSelect.value.key], compareSamp.maxThroughputForTest(k, metricSelect.value.key)))}"
+                        ng-style="{backgroundColor: percentToColor(comparisonPct(compareSamp, k))}"
                   >
-                    [[100*percentDiff(hoverSamples[k][metricSelect.value.key], compareSamp.maxThroughputForTest(k, metricSelect.value.key)) | number:1]]%
+                    [[ comparisonPct(compareSamp, k) | number:1]]%
                     vs [[compareSamp.getLegendName()]]
                   <span>
                 </b>


### PR DESCRIPTION
- Expose the selected threads data (currently scoped to only the trend chart) by passing a closure which returns the data to the parent scope
- Use the selected threads data to filter both the baseline and hover sample data
- Refactor the HTML template a bit to have less inline computation