### PR TITLE
Evg 7130 - Adding a tag fails before AWS gives us an instance

### DIFF
--- a/public/static/partials/user_host_details.html
+++ b/public/static/partials/user_host_details.html
@@ -54,8 +54,7 @@
             <div class="entry">
               <strong>User Tags</strong>
             </div>
-            <div>
-              <div class="variables" style="display: grid;"></div>
+            <div class="variables" style="display: grid;">
               <div id="userTagsList" class="form-group" ng-repeat="(key, value) in curHostData.userTags">
                 <div class="col-lg-2"> <label class="control-label">[[key]]</label></div>
                 <div class="col-lg-2"> <label class="control-label">[[value]]</label></div>
@@ -78,7 +77,6 @@
                   </button>
                 </div>
               </div>
-            </div>
             </div>
           </md-card-content>
         </md-card>

--- a/public/static/partials/user_host_details.html
+++ b/public/static/partials/user_host_details.html
@@ -50,17 +50,11 @@
         </md-card>
 
         <md-card style="width:99%">
-          <md-card-content>
+          <md-card-content ng-show="curHostData.status!='initializing' && curHostData.status!='building'">
             <div class="entry">
               <strong>User Tags</strong>
             </div>
-            <div >
-              <em class="text-error" style="margin-left: 5px;" ng-show="curHostData.status=='initializing' || curHostData.status=='building'"  ng-cloak>
-                <!-- building -->
-                Cannot set tags while host is initializing or building.  
-              </em>
-            </div>
-            <div ng-show="curHostData.status!='initializing' && curHostData.status!='building'">
+            <div>
               <div class="variables" style="display: grid;"></div>
               <div id="userTagsList" class="form-group" ng-repeat="(key, value) in curHostData.userTags">
                 <div class="col-lg-2"> <label class="control-label">[[key]]</label></div>

--- a/public/static/partials/user_host_details.html
+++ b/public/static/partials/user_host_details.html
@@ -55,11 +55,12 @@
               <strong>User Tags</strong>
             </div>
             <div >
-              <em class="text-error" style="margin-left: 5px;" ng-show="curHostData.status=='initializing'"  ng-cloak>
-                Please wait until the host is done initializing. 
+              <em class="text-error" style="margin-left: 5px;" ng-show="curHostData.status=='initializing' || curHostData.status=='building'"  ng-cloak>
+                <!-- building -->
+                Cannot set tags while host is initializing or building.  
               </em>
             </div>
-            <div ng-show="curHostData.status!='initializing'">
+            <div ng-show="curHostData.status!='initializing' && curHostData.status!='building'">
               <div class="variables" style="display: grid;"></div>
               <div id="userTagsList" class="form-group" ng-repeat="(key, value) in curHostData.userTags">
                 <div class="col-lg-2"> <label class="control-label">[[key]]</label></div>

--- a/public/static/partials/user_host_details.html
+++ b/public/static/partials/user_host_details.html
@@ -54,7 +54,13 @@
             <div class="entry">
               <strong>User Tags</strong>
             </div>
-            <div class="variables" ng-show="curHostData.status!='initializing'" style="display: grid;"></div>
+            <div >
+              <em class="text-error" style="margin-left: 5px;" ng-show="curHostData.status=='initializing'"  ng-cloak>
+                Please wait until the host is done initializing. 
+              </em>
+            </div>
+            <div ng-show="curHostData.status!='initializing'">
+              <div class="variables" style="display: grid;"></div>
               <div id="userTagsList" class="form-group" ng-repeat="(key, value) in curHostData.userTags">
                 <div class="col-lg-2"> <label class="control-label">[[key]]</label></div>
                 <div class="col-lg-2"> <label class="control-label">[[value]]</label></div>
@@ -78,11 +84,9 @@
                 </div>
               </div>
             </div>
-            <div >
-              <em ng-class="{'text-muted': unexpirableEnabled(), 'text-error': !unexpirableEnabled()}" style="margin-left: 5px;" ng-show="curHostData.status=='initializing'"  ng-cloak>
-                Please wait until the host is done initializing. 
-              </em>
             </div>
+       
+           
           </md-card-content>
         </md-card>
 

--- a/public/static/partials/user_host_details.html
+++ b/public/static/partials/user_host_details.html
@@ -54,7 +54,7 @@
             <div class="entry">
               <strong>User Tags</strong>
             </div>
-            <div class="variables" style="display: grid;">
+            <div class="variables" ng-show="curHostData.status!='initializing'" style="display: grid;"></div>
               <div id="userTagsList" class="form-group" ng-repeat="(key, value) in curHostData.userTags">
                 <div class="col-lg-2"> <label class="control-label">[[key]]</label></div>
                 <div class="col-lg-2"> <label class="control-label">[[value]]</label></div>
@@ -77,6 +77,11 @@
                   </button>
                 </div>
               </div>
+            </div>
+            <div >
+              <em ng-class="{'text-muted': unexpirableEnabled(), 'text-error': !unexpirableEnabled()}" style="margin-left: 5px;" ng-show="curHostData.status=='initializing'"  ng-cloak>
+                Please wait until the host is done initializing. 
+              </em>
             </div>
           </md-card-content>
         </md-card>

--- a/public/static/partials/user_host_details.html
+++ b/public/static/partials/user_host_details.html
@@ -85,8 +85,6 @@
               </div>
             </div>
             </div>
-       
-           
           </md-card-content>
         </md-card>
 


### PR DESCRIPTION
[EVG-7130](https://jira.mongodb.org/browse/EVG-7130)

While tags can be added to a host that is starting, provisioning, stopping, or stopped, it cannot be added to a host that is still initializing. Attempting to do so causes 500 errors that are confusing to the user. 

I added error prevention, by removing the the option to add a tag while the host is initializing, instead asking the user to wait until it's done. 

Attached are screenshots that show the adding tags card in different host states. 

![evg-7130B](https://user-images.githubusercontent.com/13104717/73856612-b65ef680-4803-11ea-859d-163a14ae99b0.png)
![evg-7130A](https://user-images.githubusercontent.com/13104717/73856617-b8c15080-4803-11ea-9913-d1bc130b7f6e.png)
