### PR TITLE
EVG-7200: Filter favorites out of all projects

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -80,8 +80,8 @@ type ComplexityRoot struct {
 	}
 
 	Projects struct {
-		All       func(childComplexity int) int
-		Favorites func(childComplexity int) int
+		Favorites     func(childComplexity int) int
+		OtherProjects func(childComplexity int) int
 	}
 
 	Query struct {
@@ -358,19 +358,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Project.Repo(childComplexity), true
 
-	case "Projects.all":
-		if e.complexity.Projects.All == nil {
-			break
-		}
-
-		return e.complexity.Projects.All(childComplexity), true
-
 	case "Projects.favorites":
 		if e.complexity.Projects.Favorites == nil {
 			break
 		}
 
 		return e.complexity.Projects.Favorites(childComplexity), true
+
+	case "Projects.other_projects":
+		if e.complexity.Projects.OtherProjects == nil {
+			break
+		}
+
+		return e.complexity.Projects.OtherProjects(childComplexity), true
 
 	case "Query.projects":
 		if e.complexity.Query.Projects == nil {
@@ -1004,7 +1004,7 @@ type Task {
 
 type Projects {
   favorites: [Project!]!
-  all: [GroupedProjects!]!
+  other_projects: [GroupedProjects!]!
 }
 
 type GroupedProjects {
@@ -1999,7 +1999,7 @@ func (ec *executionContext) _Projects_favorites(ctx context.Context, field graph
 	return ec.marshalNProject2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFieldsᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Projects_all(ctx context.Context, field graphql.CollectedField, obj *Projects) (ret graphql.Marshaler) {
+func (ec *executionContext) _Projects_other_projects(ctx context.Context, field graphql.CollectedField, obj *Projects) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -2016,7 +2016,7 @@ func (ec *executionContext) _Projects_all(ctx context.Context, field graphql.Col
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.All, nil
+		return obj.OtherProjects, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5357,8 +5357,8 @@ func (ec *executionContext) _Projects(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "all":
-			out.Values[i] = ec._Projects_all(ctx, field, obj)
+		case "other_projects":
+			out.Values[i] = ec._Projects_other_projects(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -365,7 +365,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Projects.Favorites(childComplexity), true
 
-	case "Projects.other_projects":
+	case "Projects.otherProjects":
 		if e.complexity.Projects.OtherProjects == nil {
 			break
 		}
@@ -1004,7 +1004,7 @@ type Task {
 
 type Projects {
   favorites: [Project!]!
-  other_projects: [GroupedProjects!]!
+  otherProjects: [GroupedProjects!]!
 }
 
 type GroupedProjects {
@@ -1999,7 +1999,7 @@ func (ec *executionContext) _Projects_favorites(ctx context.Context, field graph
 	return ec.marshalNProject2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFieldsᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Projects_other_projects(ctx context.Context, field graphql.CollectedField, obj *Projects) (ret graphql.Marshaler) {
+func (ec *executionContext) _Projects_otherProjects(ctx context.Context, field graphql.CollectedField, obj *Projects) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -5357,8 +5357,8 @@ func (ec *executionContext) _Projects(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "other_projects":
-			out.Values[i] = ec._Projects_other_projects(ctx, field, obj)
+		case "otherProjects":
+			out.Values[i] = ec._Projects_otherProjects(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -1244,15 +1244,6 @@
         "periodic_builds": [],
         "triggers": []
       }
-    ],
-    "users": [
-      {
-        "_id": "admin",
-        "apikey": "480550ebb70b5604c2abd26185d8a680",
-        "display_name": "Evergreen Admin",
-        "email": "",
-        "favorite_projects": []
-      }
     ]
   },
   "tests": [
@@ -1520,21 +1511,44 @@
           "projects": {
             "favorites": [
               {
+                "identifier": "mci",
+                "displayName": "Evergreen Self-Tests",
+                "repo": "evergreen",
+                "owner": "evergreen-ci"
+              },
+              {
+                "identifier": "lobster",
+                "displayName": "Lobster",
+                "repo": "lobster",
+                "owner": "evergreen-ci"
+              },
+              {
                 "identifier": "buildhost-test",
+                "displayName": "buildhost-test",
                 "repo": "buildhost-configuration",
-                "owner": "annie.black",
-                "displayName": "buildhost-test"
+                "owner": "annie.black"
               }
             ],
             "all": [
+              {
+                "name": "annie.black/buildhost-configuration",
+                "projects": [
+                  {
+                    "identifier": "buildhost-test",
+                    "displayName": "buildhost-test",
+                    "repo": "buildhost-configuration",
+                    "owner": "annie.black"
+                  }
+                ]
+              },
               {
                 "name": "bsamek/mongo",
                 "projects": [
                   {
                     "identifier": "sys-perf",
+                    "displayName": "System Performance (master)",
                     "repo": "mongo",
-                    "owner": "bsamek",
-                    "displayName": "System Performance (master)"
+                    "owner": "bsamek"
                   }
                 ]
               },
@@ -1542,16 +1556,10 @@
                 "name": "evergreen-ci/evergreen",
                 "projects": [
                   {
-                    "identifier": "mci",
-                    "repo": "evergreen",
-                    "owner": "evergreen-ci",
-                    "displayName": "Evergreen Self-Tests"
-                  },
-                  {
                     "identifier": "clone-of-mci-to-test-a-thing",
+                    "displayName": "Evergreen Self-Tests",
                     "repo": "evergreen",
-                    "owner": "evergreen-ci",
-                    "displayName": "Evergreen Self-Tests"
+                    "owner": "evergreen-ci"
                   }
                 ]
               },
@@ -1560,20 +1568,9 @@
                 "projects": [
                   {
                     "identifier": "annie-copy2",
+                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "evergreen-ci",
-                    "displayName": "something temporary"
-                  }
-                ]
-              },
-              {
-                "name": "evergreen-ci/lobster",
-                "projects": [
-                  {
-                    "identifier": "lobster",
-                    "repo": "lobster",
-                    "owner": "evergreen-ci",
-                    "displayName": "Lobster"
+                    "owner": "evergreen-ci"
                   }
                 ]
               },
@@ -1582,9 +1579,9 @@
                 "projects": [
                   {
                     "identifier": "logkeeper",
+                    "displayName": "Logkeeper",
                     "repo": "logkeeper",
-                    "owner": "evergreen-ci",
-                    "displayName": "Logkeeper"
+                    "owner": "evergreen-ci"
                   }
                 ]
               },
@@ -1593,9 +1590,9 @@
                 "projects": [
                   {
                     "identifier": "amboy",
+                    "displayName": "Not Amboy",
                     "repo": "amboy",
-                    "owner": "hello it's me",
-                    "displayName": "Not Amboy"
+                    "owner": "hello it's me"
                   }
                 ]
               },
@@ -1604,9 +1601,9 @@
                 "projects": [
                   {
                     "identifier": "john_test",
+                    "displayName": "john test",
                     "repo": "evergreen",
-                    "owner": "john-m-liu",
-                    "displayName": "john test"
+                    "owner": "john-m-liu"
                   }
                 ]
               },
@@ -1615,9 +1612,9 @@
                 "projects": [
                   {
                     "identifier": "curator",
+                    "displayName": "Curator",
                     "repo": "curator",
-                    "owner": "mongodb",
-                    "displayName": "Curator"
+                    "owner": "mongodb"
                   }
                 ]
               },
@@ -1626,9 +1623,9 @@
                 "projects": [
                   {
                     "identifier": "Greenbay",
+                    "displayName": "Greenbay",
                     "repo": "greenbay",
-                    "owner": "mongodb",
-                    "displayName": "Greenbay"
+                    "owner": "mongodb"
                   }
                 ]
               },
@@ -1637,87 +1634,87 @@
                 "projects": [
                   {
                     "identifier": "grip",
+                    "displayName": "Grip (Logging)",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "Grip (Logging)"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "ernietest20171110",
+                    "displayName": "test display name update",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "test display name update"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "ernietest2017111002",
+                    "displayName": "Grip (Logging)",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "Grip (Logging)"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "ernie-copy",
+                    "displayName": "test display name update",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "test display name update"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "ernie-copy2",
+                    "displayName": "test display name update",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "test display name update"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "ernie-copy3",
+                    "displayName": "test display name update",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "test display name update"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "ernie-copy4",
+                    "displayName": "test display name update",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "test display name update"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "annie-test",
+                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "annie-test-copy",
+                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "annie-copy3",
+                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "annie-copy4",
+                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "annie-copy-vars",
+                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "annie_api_copy",
+                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
+                    "owner": "mongodb"
                   },
                   {
                     "identifier": "annie_api_copy2",
+                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
+                    "owner": "mongodb"
                   }
                 ]
               },
@@ -1726,39 +1723,39 @@
                 "projects": [
                   {
                     "identifier": "ron_test_copy_1",
+                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
+                    "owner": "rongodb"
                   },
                   {
                     "identifier": "qa-template",
+                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
+                    "owner": "rongodb"
                   },
                   {
                     "identifier": "qa-template-copy-for-testing",
+                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
+                    "owner": "rongodb"
                   },
                   {
                     "identifier": "ron_test_output",
+                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
+                    "owner": "rongodb"
                   },
                   {
                     "identifier": "ron_three",
+                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
+                    "owner": "rongodb"
                   },
                   {
                     "identifier": "qa-template-for-testing",
+                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
+                    "owner": "rongodb"
                   }
                 ]
               },
@@ -1767,9 +1764,9 @@
                 "projects": [
                   {
                     "identifier": "ron_two_via_postman",
+                    "displayName": "1st project to be moved around",
                     "repo": "v20380713",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
+                    "owner": "rongodb"
                   }
                 ]
               },
@@ -1778,9 +1775,9 @@
                 "projects": [
                   {
                     "identifier": "annie-copy5",
+                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "something crazy",
-                    "displayName": "something temporary"
+                    "owner": "something crazy"
                   }
                 ]
               },
@@ -1789,9 +1786,9 @@
                 "projects": [
                   {
                     "identifier": "thomas-test",
+                    "displayName": "thomas test",
                     "repo": "evergreen",
-                    "owner": "tzembo",
-                    "displayName": "thomas test"
+                    "owner": "tzembo"
                   }
                 ]
               }

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -1251,7 +1251,7 @@
         "apikey": "480550ebb70b5604c2abd26185d8a680",
         "display_name": "Evergreen Admin",
         "email": "",
-        "favorite_projects": []
+        "favorite_projects": ["mci", "lobster"]
       }
     ]
   },
@@ -1520,6 +1520,18 @@
           "projects": {
             "favorites": [
               {
+                "identifier": "mci",
+                "displayName": "Evergreen Self-Tests",
+                "repo": "evergreen",
+                "owner": "evergreen-ci"
+              },
+              {
+                "identifier": "lobster",
+                "displayName": "Lobster",
+                "repo": "lobster",
+                "owner": "evergreen-ci"
+              },
+              {
                 "identifier": "buildhost-test",
                 "displayName": "buildhost-test",
                 "repo": "buildhost-configuration",
@@ -1553,12 +1565,6 @@
                 "name": "evergreen-ci/evergreen",
                 "projects": [
                   {
-                    "identifier": "mci",
-                    "displayName": "Evergreen Self-Tests",
-                    "repo": "evergreen",
-                    "owner": "evergreen-ci"
-                  },
-                  {
                     "identifier": "clone-of-mci-to-test-a-thing",
                     "displayName": "Evergreen Self-Tests",
                     "repo": "evergreen",
@@ -1573,17 +1579,6 @@
                     "identifier": "annie-copy2",
                     "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "evergreen-ci"
-                  }
-                ]
-              },
-              {
-                "name": "evergreen-ci/lobster",
-                "projects": [
-                  {
-                    "identifier": "lobster",
-                    "displayName": "Lobster",
-                    "repo": "lobster",
                     "owner": "evergreen-ci"
                   }
                 ]

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -1251,7 +1251,7 @@
         "apikey": "480550ebb70b5604c2abd26185d8a680",
         "display_name": "Evergreen Admin",
         "email": "",
-        "favorite_projects": ["mci", "lobster"]
+        "favorite_projects": []
       }
     ]
   },
@@ -1520,44 +1520,21 @@
           "projects": {
             "favorites": [
               {
-                "identifier": "mci",
-                "displayName": "Evergreen Self-Tests",
-                "repo": "evergreen",
-                "owner": "evergreen-ci"
-              },
-              {
-                "identifier": "lobster",
-                "displayName": "Lobster",
-                "repo": "lobster",
-                "owner": "evergreen-ci"
-              },
-              {
                 "identifier": "buildhost-test",
-                "displayName": "buildhost-test",
                 "repo": "buildhost-configuration",
-                "owner": "annie.black"
+                "owner": "annie.black",
+                "displayName": "buildhost-test"
               }
             ],
             "all": [
-              {
-                "name": "annie.black/buildhost-configuration",
-                "projects": [
-                  {
-                    "identifier": "buildhost-test",
-                    "displayName": "buildhost-test",
-                    "repo": "buildhost-configuration",
-                    "owner": "annie.black"
-                  }
-                ]
-              },
               {
                 "name": "bsamek/mongo",
                 "projects": [
                   {
                     "identifier": "sys-perf",
-                    "displayName": "System Performance (master)",
                     "repo": "mongo",
-                    "owner": "bsamek"
+                    "owner": "bsamek",
+                    "displayName": "System Performance (master)"
                   }
                 ]
               },
@@ -1565,10 +1542,16 @@
                 "name": "evergreen-ci/evergreen",
                 "projects": [
                   {
-                    "identifier": "clone-of-mci-to-test-a-thing",
-                    "displayName": "Evergreen Self-Tests",
+                    "identifier": "mci",
                     "repo": "evergreen",
-                    "owner": "evergreen-ci"
+                    "owner": "evergreen-ci",
+                    "displayName": "Evergreen Self-Tests"
+                  },
+                  {
+                    "identifier": "clone-of-mci-to-test-a-thing",
+                    "repo": "evergreen",
+                    "owner": "evergreen-ci",
+                    "displayName": "Evergreen Self-Tests"
                   }
                 ]
               },
@@ -1577,9 +1560,20 @@
                 "projects": [
                   {
                     "identifier": "annie-copy2",
-                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "evergreen-ci"
+                    "owner": "evergreen-ci",
+                    "displayName": "something temporary"
+                  }
+                ]
+              },
+              {
+                "name": "evergreen-ci/lobster",
+                "projects": [
+                  {
+                    "identifier": "lobster",
+                    "repo": "lobster",
+                    "owner": "evergreen-ci",
+                    "displayName": "Lobster"
                   }
                 ]
               },
@@ -1588,9 +1582,9 @@
                 "projects": [
                   {
                     "identifier": "logkeeper",
-                    "displayName": "Logkeeper",
                     "repo": "logkeeper",
-                    "owner": "evergreen-ci"
+                    "owner": "evergreen-ci",
+                    "displayName": "Logkeeper"
                   }
                 ]
               },
@@ -1599,9 +1593,9 @@
                 "projects": [
                   {
                     "identifier": "amboy",
-                    "displayName": "Not Amboy",
                     "repo": "amboy",
-                    "owner": "hello it's me"
+                    "owner": "hello it's me",
+                    "displayName": "Not Amboy"
                   }
                 ]
               },
@@ -1610,9 +1604,9 @@
                 "projects": [
                   {
                     "identifier": "john_test",
-                    "displayName": "john test",
                     "repo": "evergreen",
-                    "owner": "john-m-liu"
+                    "owner": "john-m-liu",
+                    "displayName": "john test"
                   }
                 ]
               },
@@ -1621,9 +1615,9 @@
                 "projects": [
                   {
                     "identifier": "curator",
-                    "displayName": "Curator",
                     "repo": "curator",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "Curator"
                   }
                 ]
               },
@@ -1632,9 +1626,9 @@
                 "projects": [
                   {
                     "identifier": "Greenbay",
-                    "displayName": "Greenbay",
                     "repo": "greenbay",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "Greenbay"
                   }
                 ]
               },
@@ -1643,87 +1637,87 @@
                 "projects": [
                   {
                     "identifier": "grip",
-                    "displayName": "Grip (Logging)",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "Grip (Logging)"
                   },
                   {
                     "identifier": "ernietest20171110",
-                    "displayName": "test display name update",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
                   },
                   {
                     "identifier": "ernietest2017111002",
-                    "displayName": "Grip (Logging)",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "Grip (Logging)"
                   },
                   {
                     "identifier": "ernie-copy",
-                    "displayName": "test display name update",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
                   },
                   {
                     "identifier": "ernie-copy2",
-                    "displayName": "test display name update",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
                   },
                   {
                     "identifier": "ernie-copy3",
-                    "displayName": "test display name update",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
                   },
                   {
                     "identifier": "ernie-copy4",
-                    "displayName": "test display name update",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
                   },
                   {
                     "identifier": "annie-test",
-                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
                   },
                   {
                     "identifier": "annie-test-copy",
-                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
                   },
                   {
                     "identifier": "annie-copy3",
-                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
                   },
                   {
                     "identifier": "annie-copy4",
-                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
                   },
                   {
                     "identifier": "annie-copy-vars",
-                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
                   },
                   {
                     "identifier": "annie_api_copy",
-                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
                   },
                   {
                     "identifier": "annie_api_copy2",
-                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "mongodb"
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
                   }
                 ]
               },
@@ -1732,39 +1726,39 @@
                 "projects": [
                   {
                     "identifier": "ron_test_copy_1",
-                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb"
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
                   },
                   {
                     "identifier": "qa-template",
-                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb"
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
                   },
                   {
                     "identifier": "qa-template-copy-for-testing",
-                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb"
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
                   },
                   {
                     "identifier": "ron_test_output",
-                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb"
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
                   },
                   {
                     "identifier": "ron_three",
-                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb"
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
                   },
                   {
                     "identifier": "qa-template-for-testing",
-                    "displayName": "1st project to be moved around",
                     "repo": "ron_repo_1",
-                    "owner": "rongodb"
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
                   }
                 ]
               },
@@ -1773,9 +1767,9 @@
                 "projects": [
                   {
                     "identifier": "ron_two_via_postman",
-                    "displayName": "1st project to be moved around",
                     "repo": "v20380713",
-                    "owner": "rongodb"
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
                   }
                 ]
               },
@@ -1784,9 +1778,9 @@
                 "projects": [
                   {
                     "identifier": "annie-copy5",
-                    "displayName": "something temporary",
                     "repo": "grip",
-                    "owner": "something crazy"
+                    "owner": "something crazy",
+                    "displayName": "something temporary"
                   }
                 ]
               },
@@ -1795,9 +1789,9 @@
                 "projects": [
                   {
                     "identifier": "thomas-test",
-                    "displayName": "thomas test",
                     "repo": "evergreen",
-                    "owner": "tzembo"
+                    "owner": "tzembo",
+                    "displayName": "thomas test"
                   }
                 ]
               }

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -1508,287 +1508,285 @@
       "query_file": "projects1.graphql",
       "result": {
         "data": {
-          "data": {
-            "projects": {
-              "favorites": [
-                {
-                  "identifier": "buildhost-test",
-                  "repo": "buildhost-configuration",
-                  "owner": "annie.black",
-                  "displayName": "buildhost-test"
-                }
-              ],
-              "all": [
-                {
-                  "name": "bsamek/mongo",
-                  "projects": [
-                    {
-                      "identifier": "sys-perf",
-                      "repo": "mongo",
-                      "owner": "bsamek",
-                      "displayName": "System Performance (master)"
-                    }
-                  ]
-                },
-                {
-                  "name": "evergreen-ci/evergreen",
-                  "projects": [
-                    {
-                      "identifier": "mci",
-                      "repo": "evergreen",
-                      "owner": "evergreen-ci",
-                      "displayName": "Evergreen Self-Tests"
-                    },
-                    {
-                      "identifier": "clone-of-mci-to-test-a-thing",
-                      "repo": "evergreen",
-                      "owner": "evergreen-ci",
-                      "displayName": "Evergreen Self-Tests"
-                    }
-                  ]
-                },
-                {
-                  "name": "evergreen-ci/grip",
-                  "projects": [
-                    {
-                      "identifier": "annie-copy2",
-                      "repo": "grip",
-                      "owner": "evergreen-ci",
-                      "displayName": "something temporary"
-                    }
-                  ]
-                },
-                {
-                  "name": "evergreen-ci/lobster",
-                  "projects": [
-                    {
-                      "identifier": "lobster",
-                      "repo": "lobster",
-                      "owner": "evergreen-ci",
-                      "displayName": "Lobster"
-                    }
-                  ]
-                },
-                {
-                  "name": "evergreen-ci/logkeeper",
-                  "projects": [
-                    {
-                      "identifier": "logkeeper",
-                      "repo": "logkeeper",
-                      "owner": "evergreen-ci",
-                      "displayName": "Logkeeper"
-                    }
-                  ]
-                },
-                {
-                  "name": "hello it's me/amboy",
-                  "projects": [
-                    {
-                      "identifier": "amboy",
-                      "repo": "amboy",
-                      "owner": "hello it's me",
-                      "displayName": "Not Amboy"
-                    }
-                  ]
-                },
-                {
-                  "name": "john-m-liu/evergreen",
-                  "projects": [
-                    {
-                      "identifier": "john_test",
-                      "repo": "evergreen",
-                      "owner": "john-m-liu",
-                      "displayName": "john test"
-                    }
-                  ]
-                },
-                {
-                  "name": "mongodb/curator",
-                  "projects": [
-                    {
-                      "identifier": "curator",
-                      "repo": "curator",
-                      "owner": "mongodb",
-                      "displayName": "Curator"
-                    }
-                  ]
-                },
-                {
-                  "name": "mongodb/greenbay",
-                  "projects": [
-                    {
-                      "identifier": "Greenbay",
-                      "repo": "greenbay",
-                      "owner": "mongodb",
-                      "displayName": "Greenbay"
-                    }
-                  ]
-                },
-                {
-                  "name": "mongodb/grip",
-                  "projects": [
-                    {
-                      "identifier": "grip",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "Grip (Logging)"
-                    },
-                    {
-                      "identifier": "ernietest20171110",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "test display name update"
-                    },
-                    {
-                      "identifier": "ernietest2017111002",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "Grip (Logging)"
-                    },
-                    {
-                      "identifier": "ernie-copy",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "test display name update"
-                    },
-                    {
-                      "identifier": "ernie-copy2",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "test display name update"
-                    },
-                    {
-                      "identifier": "ernie-copy3",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "test display name update"
-                    },
-                    {
-                      "identifier": "ernie-copy4",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "test display name update"
-                    },
-                    {
-                      "identifier": "annie-test",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "something temporary"
-                    },
-                    {
-                      "identifier": "annie-test-copy",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "something temporary"
-                    },
-                    {
-                      "identifier": "annie-copy3",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "something temporary"
-                    },
-                    {
-                      "identifier": "annie-copy4",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "something temporary"
-                    },
-                    {
-                      "identifier": "annie-copy-vars",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "something temporary"
-                    },
-                    {
-                      "identifier": "annie_api_copy",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "something temporary"
-                    },
-                    {
-                      "identifier": "annie_api_copy2",
-                      "repo": "grip",
-                      "owner": "mongodb",
-                      "displayName": "something temporary"
-                    }
-                  ]
-                },
-                {
-                  "name": "rongodb/ron_repo_1",
-                  "projects": [
-                    {
-                      "identifier": "ron_test_copy_1",
-                      "repo": "ron_repo_1",
-                      "owner": "rongodb",
-                      "displayName": "1st project to be moved around"
-                    },
-                    {
-                      "identifier": "qa-template",
-                      "repo": "ron_repo_1",
-                      "owner": "rongodb",
-                      "displayName": "1st project to be moved around"
-                    },
-                    {
-                      "identifier": "qa-template-copy-for-testing",
-                      "repo": "ron_repo_1",
-                      "owner": "rongodb",
-                      "displayName": "1st project to be moved around"
-                    },
-                    {
-                      "identifier": "ron_test_output",
-                      "repo": "ron_repo_1",
-                      "owner": "rongodb",
-                      "displayName": "1st project to be moved around"
-                    },
-                    {
-                      "identifier": "ron_three",
-                      "repo": "ron_repo_1",
-                      "owner": "rongodb",
-                      "displayName": "1st project to be moved around"
-                    },
-                    {
-                      "identifier": "qa-template-for-testing",
-                      "repo": "ron_repo_1",
-                      "owner": "rongodb",
-                      "displayName": "1st project to be moved around"
-                    }
-                  ]
-                },
-                {
-                  "name": "rongodb/v20380713",
-                  "projects": [
-                    {
-                      "identifier": "ron_two_via_postman",
-                      "repo": "v20380713",
-                      "owner": "rongodb",
-                      "displayName": "1st project to be moved around"
-                    }
-                  ]
-                },
-                {
-                  "name": "something crazy/grip",
-                  "projects": [
-                    {
-                      "identifier": "annie-copy5",
-                      "repo": "grip",
-                      "owner": "something crazy",
-                      "displayName": "something temporary"
-                    }
-                  ]
-                },
-                {
-                  "name": "tzembo/evergreen",
-                  "projects": [
-                    {
-                      "identifier": "thomas-test",
-                      "repo": "evergreen",
-                      "owner": "tzembo",
-                      "displayName": "thomas test"
-                    }
-                  ]
-                }
-              ]
-            }
+          "projects": {
+            "favorites": [
+              {
+                "identifier": "buildhost-test",
+                "repo": "buildhost-configuration",
+                "owner": "annie.black",
+                "displayName": "buildhost-test"
+              }
+            ],
+            "all": [
+              {
+                "name": "bsamek/mongo",
+                "projects": [
+                  {
+                    "identifier": "sys-perf",
+                    "repo": "mongo",
+                    "owner": "bsamek",
+                    "displayName": "System Performance (master)"
+                  }
+                ]
+              },
+              {
+                "name": "evergreen-ci/evergreen",
+                "projects": [
+                  {
+                    "identifier": "mci",
+                    "repo": "evergreen",
+                    "owner": "evergreen-ci",
+                    "displayName": "Evergreen Self-Tests"
+                  },
+                  {
+                    "identifier": "clone-of-mci-to-test-a-thing",
+                    "repo": "evergreen",
+                    "owner": "evergreen-ci",
+                    "displayName": "Evergreen Self-Tests"
+                  }
+                ]
+              },
+              {
+                "name": "evergreen-ci/grip",
+                "projects": [
+                  {
+                    "identifier": "annie-copy2",
+                    "repo": "grip",
+                    "owner": "evergreen-ci",
+                    "displayName": "something temporary"
+                  }
+                ]
+              },
+              {
+                "name": "evergreen-ci/lobster",
+                "projects": [
+                  {
+                    "identifier": "lobster",
+                    "repo": "lobster",
+                    "owner": "evergreen-ci",
+                    "displayName": "Lobster"
+                  }
+                ]
+              },
+              {
+                "name": "evergreen-ci/logkeeper",
+                "projects": [
+                  {
+                    "identifier": "logkeeper",
+                    "repo": "logkeeper",
+                    "owner": "evergreen-ci",
+                    "displayName": "Logkeeper"
+                  }
+                ]
+              },
+              {
+                "name": "hello it's me/amboy",
+                "projects": [
+                  {
+                    "identifier": "amboy",
+                    "repo": "amboy",
+                    "owner": "hello it's me",
+                    "displayName": "Not Amboy"
+                  }
+                ]
+              },
+              {
+                "name": "john-m-liu/evergreen",
+                "projects": [
+                  {
+                    "identifier": "john_test",
+                    "repo": "evergreen",
+                    "owner": "john-m-liu",
+                    "displayName": "john test"
+                  }
+                ]
+              },
+              {
+                "name": "mongodb/curator",
+                "projects": [
+                  {
+                    "identifier": "curator",
+                    "repo": "curator",
+                    "owner": "mongodb",
+                    "displayName": "Curator"
+                  }
+                ]
+              },
+              {
+                "name": "mongodb/greenbay",
+                "projects": [
+                  {
+                    "identifier": "Greenbay",
+                    "repo": "greenbay",
+                    "owner": "mongodb",
+                    "displayName": "Greenbay"
+                  }
+                ]
+              },
+              {
+                "name": "mongodb/grip",
+                "projects": [
+                  {
+                    "identifier": "grip",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "Grip (Logging)"
+                  },
+                  {
+                    "identifier": "ernietest20171110",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
+                  },
+                  {
+                    "identifier": "ernietest2017111002",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "Grip (Logging)"
+                  },
+                  {
+                    "identifier": "ernie-copy",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
+                  },
+                  {
+                    "identifier": "ernie-copy2",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
+                  },
+                  {
+                    "identifier": "ernie-copy3",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
+                  },
+                  {
+                    "identifier": "ernie-copy4",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
+                  },
+                  {
+                    "identifier": "annie-test",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie-test-copy",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie-copy3",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie-copy4",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie-copy-vars",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie_api_copy",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie_api_copy2",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  }
+                ]
+              },
+              {
+                "name": "rongodb/ron_repo_1",
+                "projects": [
+                  {
+                    "identifier": "ron_test_copy_1",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  },
+                  {
+                    "identifier": "qa-template",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  },
+                  {
+                    "identifier": "qa-template-copy-for-testing",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  },
+                  {
+                    "identifier": "ron_test_output",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  },
+                  {
+                    "identifier": "ron_three",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  },
+                  {
+                    "identifier": "qa-template-for-testing",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  }
+                ]
+              },
+              {
+                "name": "rongodb/v20380713",
+                "projects": [
+                  {
+                    "identifier": "ron_two_via_postman",
+                    "repo": "v20380713",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  }
+                ]
+              },
+              {
+                "name": "something crazy/grip",
+                "projects": [
+                  {
+                    "identifier": "annie-copy5",
+                    "repo": "grip",
+                    "owner": "something crazy",
+                    "displayName": "something temporary"
+                  }
+                ]
+              },
+              {
+                "name": "tzembo/evergreen",
+                "projects": [
+                  {
+                    "identifier": "thomas-test",
+                    "repo": "evergreen",
+                    "owner": "tzembo",
+                    "displayName": "thomas test"
+                  }
+                ]
+              }
+            ]
           }
         }
       }

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -1517,7 +1517,7 @@
                 "displayName": "buildhost-test"
               }
             ],
-            "other_projects": [
+            "otherProjects": [
               {
                 "name": "bsamek/mongo",
                 "projects": [

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -1508,291 +1508,287 @@
       "query_file": "projects1.graphql",
       "result": {
         "data": {
-          "projects": {
-            "favorites": [
-              {
-                "identifier": "mci",
-                "displayName": "Evergreen Self-Tests",
-                "repo": "evergreen",
-                "owner": "evergreen-ci"
-              },
-              {
-                "identifier": "lobster",
-                "displayName": "Lobster",
-                "repo": "lobster",
-                "owner": "evergreen-ci"
-              },
-              {
-                "identifier": "buildhost-test",
-                "displayName": "buildhost-test",
-                "repo": "buildhost-configuration",
-                "owner": "annie.black"
-              }
-            ],
-            "all": [
-              {
-                "name": "annie.black/buildhost-configuration",
-                "projects": [
-                  {
-                    "identifier": "buildhost-test",
-                    "displayName": "buildhost-test",
-                    "repo": "buildhost-configuration",
-                    "owner": "annie.black"
-                  }
-                ]
-              },
-              {
-                "name": "bsamek/mongo",
-                "projects": [
-                  {
-                    "identifier": "sys-perf",
-                    "displayName": "System Performance (master)",
-                    "repo": "mongo",
-                    "owner": "bsamek"
-                  }
-                ]
-              },
-              {
-                "name": "evergreen-ci/evergreen",
-                "projects": [
-                  {
-                    "identifier": "clone-of-mci-to-test-a-thing",
-                    "displayName": "Evergreen Self-Tests",
-                    "repo": "evergreen",
-                    "owner": "evergreen-ci"
-                  }
-                ]
-              },
-              {
-                "name": "evergreen-ci/grip",
-                "projects": [
-                  {
-                    "identifier": "annie-copy2",
-                    "displayName": "something temporary",
-                    "repo": "grip",
-                    "owner": "evergreen-ci"
-                  }
-                ]
-              },
-              {
-                "name": "evergreen-ci/logkeeper",
-                "projects": [
-                  {
-                    "identifier": "logkeeper",
-                    "displayName": "Logkeeper",
-                    "repo": "logkeeper",
-                    "owner": "evergreen-ci"
-                  }
-                ]
-              },
-              {
-                "name": "hello it's me/amboy",
-                "projects": [
-                  {
-                    "identifier": "amboy",
-                    "displayName": "Not Amboy",
-                    "repo": "amboy",
-                    "owner": "hello it's me"
-                  }
-                ]
-              },
-              {
-                "name": "john-m-liu/evergreen",
-                "projects": [
-                  {
-                    "identifier": "john_test",
-                    "displayName": "john test",
-                    "repo": "evergreen",
-                    "owner": "john-m-liu"
-                  }
-                ]
-              },
-              {
-                "name": "mongodb/curator",
-                "projects": [
-                  {
-                    "identifier": "curator",
-                    "displayName": "Curator",
-                    "repo": "curator",
-                    "owner": "mongodb"
-                  }
-                ]
-              },
-              {
-                "name": "mongodb/greenbay",
-                "projects": [
-                  {
-                    "identifier": "Greenbay",
-                    "displayName": "Greenbay",
-                    "repo": "greenbay",
-                    "owner": "mongodb"
-                  }
-                ]
-              },
-              {
-                "name": "mongodb/grip",
-                "projects": [
-                  {
-                    "identifier": "grip",
-                    "displayName": "Grip (Logging)",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "ernietest20171110",
-                    "displayName": "test display name update",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "ernietest2017111002",
-                    "displayName": "Grip (Logging)",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "ernie-copy",
-                    "displayName": "test display name update",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "ernie-copy2",
-                    "displayName": "test display name update",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "ernie-copy3",
-                    "displayName": "test display name update",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "ernie-copy4",
-                    "displayName": "test display name update",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "annie-test",
-                    "displayName": "something temporary",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "annie-test-copy",
-                    "displayName": "something temporary",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "annie-copy3",
-                    "displayName": "something temporary",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "annie-copy4",
-                    "displayName": "something temporary",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "annie-copy-vars",
-                    "displayName": "something temporary",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "annie_api_copy",
-                    "displayName": "something temporary",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  },
-                  {
-                    "identifier": "annie_api_copy2",
-                    "displayName": "something temporary",
-                    "repo": "grip",
-                    "owner": "mongodb"
-                  }
-                ]
-              },
-              {
-                "name": "rongodb/ron_repo_1",
-                "projects": [
-                  {
-                    "identifier": "ron_test_copy_1",
-                    "displayName": "1st project to be moved around",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb"
-                  },
-                  {
-                    "identifier": "qa-template",
-                    "displayName": "1st project to be moved around",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb"
-                  },
-                  {
-                    "identifier": "qa-template-copy-for-testing",
-                    "displayName": "1st project to be moved around",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb"
-                  },
-                  {
-                    "identifier": "ron_test_output",
-                    "displayName": "1st project to be moved around",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb"
-                  },
-                  {
-                    "identifier": "ron_three",
-                    "displayName": "1st project to be moved around",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb"
-                  },
-                  {
-                    "identifier": "qa-template-for-testing",
-                    "displayName": "1st project to be moved around",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb"
-                  }
-                ]
-              },
-              {
-                "name": "rongodb/v20380713",
-                "projects": [
-                  {
-                    "identifier": "ron_two_via_postman",
-                    "displayName": "1st project to be moved around",
-                    "repo": "v20380713",
-                    "owner": "rongodb"
-                  }
-                ]
-              },
-              {
-                "name": "something crazy/grip",
-                "projects": [
-                  {
-                    "identifier": "annie-copy5",
-                    "displayName": "something temporary",
-                    "repo": "grip",
-                    "owner": "something crazy"
-                  }
-                ]
-              },
-              {
-                "name": "tzembo/evergreen",
-                "projects": [
-                  {
-                    "identifier": "thomas-test",
-                    "displayName": "thomas test",
-                    "repo": "evergreen",
-                    "owner": "tzembo"
-                  }
-                ]
-              }
-            ]
+          "data": {
+            "projects": {
+              "favorites": [
+                {
+                  "identifier": "buildhost-test",
+                  "repo": "buildhost-configuration",
+                  "owner": "annie.black",
+                  "displayName": "buildhost-test"
+                }
+              ],
+              "all": [
+                {
+                  "name": "bsamek/mongo",
+                  "projects": [
+                    {
+                      "identifier": "sys-perf",
+                      "repo": "mongo",
+                      "owner": "bsamek",
+                      "displayName": "System Performance (master)"
+                    }
+                  ]
+                },
+                {
+                  "name": "evergreen-ci/evergreen",
+                  "projects": [
+                    {
+                      "identifier": "mci",
+                      "repo": "evergreen",
+                      "owner": "evergreen-ci",
+                      "displayName": "Evergreen Self-Tests"
+                    },
+                    {
+                      "identifier": "clone-of-mci-to-test-a-thing",
+                      "repo": "evergreen",
+                      "owner": "evergreen-ci",
+                      "displayName": "Evergreen Self-Tests"
+                    }
+                  ]
+                },
+                {
+                  "name": "evergreen-ci/grip",
+                  "projects": [
+                    {
+                      "identifier": "annie-copy2",
+                      "repo": "grip",
+                      "owner": "evergreen-ci",
+                      "displayName": "something temporary"
+                    }
+                  ]
+                },
+                {
+                  "name": "evergreen-ci/lobster",
+                  "projects": [
+                    {
+                      "identifier": "lobster",
+                      "repo": "lobster",
+                      "owner": "evergreen-ci",
+                      "displayName": "Lobster"
+                    }
+                  ]
+                },
+                {
+                  "name": "evergreen-ci/logkeeper",
+                  "projects": [
+                    {
+                      "identifier": "logkeeper",
+                      "repo": "logkeeper",
+                      "owner": "evergreen-ci",
+                      "displayName": "Logkeeper"
+                    }
+                  ]
+                },
+                {
+                  "name": "hello it's me/amboy",
+                  "projects": [
+                    {
+                      "identifier": "amboy",
+                      "repo": "amboy",
+                      "owner": "hello it's me",
+                      "displayName": "Not Amboy"
+                    }
+                  ]
+                },
+                {
+                  "name": "john-m-liu/evergreen",
+                  "projects": [
+                    {
+                      "identifier": "john_test",
+                      "repo": "evergreen",
+                      "owner": "john-m-liu",
+                      "displayName": "john test"
+                    }
+                  ]
+                },
+                {
+                  "name": "mongodb/curator",
+                  "projects": [
+                    {
+                      "identifier": "curator",
+                      "repo": "curator",
+                      "owner": "mongodb",
+                      "displayName": "Curator"
+                    }
+                  ]
+                },
+                {
+                  "name": "mongodb/greenbay",
+                  "projects": [
+                    {
+                      "identifier": "Greenbay",
+                      "repo": "greenbay",
+                      "owner": "mongodb",
+                      "displayName": "Greenbay"
+                    }
+                  ]
+                },
+                {
+                  "name": "mongodb/grip",
+                  "projects": [
+                    {
+                      "identifier": "grip",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "Grip (Logging)"
+                    },
+                    {
+                      "identifier": "ernietest20171110",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "test display name update"
+                    },
+                    {
+                      "identifier": "ernietest2017111002",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "Grip (Logging)"
+                    },
+                    {
+                      "identifier": "ernie-copy",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "test display name update"
+                    },
+                    {
+                      "identifier": "ernie-copy2",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "test display name update"
+                    },
+                    {
+                      "identifier": "ernie-copy3",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "test display name update"
+                    },
+                    {
+                      "identifier": "ernie-copy4",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "test display name update"
+                    },
+                    {
+                      "identifier": "annie-test",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "something temporary"
+                    },
+                    {
+                      "identifier": "annie-test-copy",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "something temporary"
+                    },
+                    {
+                      "identifier": "annie-copy3",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "something temporary"
+                    },
+                    {
+                      "identifier": "annie-copy4",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "something temporary"
+                    },
+                    {
+                      "identifier": "annie-copy-vars",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "something temporary"
+                    },
+                    {
+                      "identifier": "annie_api_copy",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "something temporary"
+                    },
+                    {
+                      "identifier": "annie_api_copy2",
+                      "repo": "grip",
+                      "owner": "mongodb",
+                      "displayName": "something temporary"
+                    }
+                  ]
+                },
+                {
+                  "name": "rongodb/ron_repo_1",
+                  "projects": [
+                    {
+                      "identifier": "ron_test_copy_1",
+                      "repo": "ron_repo_1",
+                      "owner": "rongodb",
+                      "displayName": "1st project to be moved around"
+                    },
+                    {
+                      "identifier": "qa-template",
+                      "repo": "ron_repo_1",
+                      "owner": "rongodb",
+                      "displayName": "1st project to be moved around"
+                    },
+                    {
+                      "identifier": "qa-template-copy-for-testing",
+                      "repo": "ron_repo_1",
+                      "owner": "rongodb",
+                      "displayName": "1st project to be moved around"
+                    },
+                    {
+                      "identifier": "ron_test_output",
+                      "repo": "ron_repo_1",
+                      "owner": "rongodb",
+                      "displayName": "1st project to be moved around"
+                    },
+                    {
+                      "identifier": "ron_three",
+                      "repo": "ron_repo_1",
+                      "owner": "rongodb",
+                      "displayName": "1st project to be moved around"
+                    },
+                    {
+                      "identifier": "qa-template-for-testing",
+                      "repo": "ron_repo_1",
+                      "owner": "rongodb",
+                      "displayName": "1st project to be moved around"
+                    }
+                  ]
+                },
+                {
+                  "name": "rongodb/v20380713",
+                  "projects": [
+                    {
+                      "identifier": "ron_two_via_postman",
+                      "repo": "v20380713",
+                      "owner": "rongodb",
+                      "displayName": "1st project to be moved around"
+                    }
+                  ]
+                },
+                {
+                  "name": "something crazy/grip",
+                  "projects": [
+                    {
+                      "identifier": "annie-copy5",
+                      "repo": "grip",
+                      "owner": "something crazy",
+                      "displayName": "something temporary"
+                    }
+                  ]
+                },
+                {
+                  "name": "tzembo/evergreen",
+                  "projects": [
+                    {
+                      "identifier": "thomas-test",
+                      "repo": "evergreen",
+                      "owner": "tzembo",
+                      "displayName": "thomas test"
+                    }
+                  ]
+                }
+              ]
+            }
           }
         }
       }

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -1517,7 +1517,7 @@
                 "displayName": "buildhost-test"
               }
             ],
-            "all": [
+            "other_projects": [
               {
                 "name": "bsamek/mongo",
                 "projects": [

--- a/graphql/integration_test.go
+++ b/graphql/integration_test.go
@@ -52,7 +52,7 @@ func (s *graphQLSuite) SetupSuite() {
 	env := evergreen.GetEnvironment()
 	ctx := context.Background()
 	s.Require().NoError(env.DB().Drop(ctx))
-	testUser := user.DBUser{Id: apiUser, APIKey: apiKey, FavoriteProjects: []string{"mci", "lobster"}}
+	testUser := user.DBUser{Id: apiUser, APIKey: apiKey}
 	s.Require().NoError(testUser.Insert())
 	s.url = server.URL
 	s.apiKey = apiKey

--- a/graphql/integration_test.go
+++ b/graphql/integration_test.go
@@ -52,7 +52,7 @@ func (s *graphQLSuite) SetupSuite() {
 	env := evergreen.GetEnvironment()
 	ctx := context.Background()
 	s.Require().NoError(env.DB().Drop(ctx))
-	testUser := user.DBUser{Id: apiUser, APIKey: apiKey}
+	testUser := user.DBUser{Id: apiUser, APIKey: apiKey, FavoriteProjects: []string{"mci", "lobster"}}
 	s.Require().NoError(testUser.Insert())
 	s.url = server.URL
 	s.apiKey = apiKey

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -17,7 +17,7 @@ type GroupedProjects struct {
 
 type Projects struct {
 	Favorites     []*model.UIProjectFields `json:"favorites"`
-	OtherProjects []*GroupedProjects       `json:"other_projects"`
+	OtherProjects []*GroupedProjects       `json:"otherProjects"`
 }
 
 type SortDirection string

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -16,8 +16,8 @@ type GroupedProjects struct {
 }
 
 type Projects struct {
-	Favorites []*model.UIProjectFields `json:"favorites"`
-	All       []*GroupedProjects       `json:"all"`
+	Favorites     []*model.UIProjectFields `json:"favorites"`
+	OtherProjects []*GroupedProjects       `json:"other_projects"`
 }
 
 type SortDirection string

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -112,7 +112,8 @@ func (r *queryResolver) Projects(ctx context.Context) (*Projects, error) {
 			Owner:       p.Owner,
 		}
 
-		if isFavorite := util.StringSliceContains(usr.FavoriteProjects, p.Identifier); isFavorite {
+		// favorite projects are filtered out and appended to their own array
+		if util.StringSliceContains(usr.FavoriteProjects, p.Identifier) {
 			favorites = append(favorites, &uiProj)
 			continue
 		}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -98,11 +98,8 @@ func (r *queryResolver) Projects(ctx context.Context) (*Projects, error) {
 		return nil, errors.Wrap(err, "error retrieving projects")
 	}
 
-	groupsMap := make(map[string][]*restModel.UIProjectFields)
-
 	usr := route.MustHaveUser(ctx)
-
-	favoriteIds := usr.FavoriteProjects
+	groupsMap := make(map[string][]*restModel.UIProjectFields)
 	favorites := []*restModel.UIProjectFields{}
 
 	for _, p := range allProjs {
@@ -115,7 +112,7 @@ func (r *queryResolver) Projects(ctx context.Context) (*Projects, error) {
 			Owner:       p.Owner,
 		}
 
-		if isFavorite := util.StringSliceContains(favoriteIds, p.Identifier); isFavorite {
+		if isFavorite := util.StringSliceContains(usr.FavoriteProjects, p.Identifier); isFavorite {
 			favorites = append(favorites, &uiProj)
 			continue
 		}
@@ -141,8 +138,8 @@ func (r *queryResolver) Projects(ctx context.Context) (*Projects, error) {
 	})
 
 	pjs := Projects{
-		Favorites: favorites,
-		All:       groupsArr,
+		Favorites:     favorites,
+		OtherProjects: groupsArr,
 	}
 
 	return &pjs, nil

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -115,15 +115,14 @@ func (r *queryResolver) Projects(ctx context.Context) (*Projects, error) {
 			Owner:       p.Owner,
 		}
 
+		if isFavorite := util.StringSliceContains(favoriteIds, p.Identifier); isFavorite {
+			favorites = append(favorites, &uiProj)
+			continue
+		}
 		if projs, ok := groupsMap[groupName]; ok {
 			groupsMap[groupName] = append(projs, &uiProj)
 		} else {
 			groupsMap[groupName] = []*restModel.UIProjectFields{&uiProj}
-		}
-
-		// if proj ID is in favoriteIds then add proj to favorites
-		if util.StringSliceContains(favoriteIds, p.Identifier) {
-			favorites = append(favorites, &uiProj)
 		}
 	}
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -124,7 +124,7 @@ type Task {
 
 type Projects {
   favorites: [Project!]!
-  all: [GroupedProjects!]!
+  other_projects: [GroupedProjects!]!
 }
 
 type GroupedProjects {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -124,7 +124,7 @@ type Task {
 
 type Projects {
   favorites: [Project!]!
-  other_projects: [GroupedProjects!]!
+  otherProjects: [GroupedProjects!]!
 }
 
 type GroupedProjects {

--- a/graphql/testdata/projects1.graphql
+++ b/graphql/testdata/projects1.graphql
@@ -6,7 +6,7 @@
       owner
       displayName
     }
-    all {
+    otherProjects {
       name
       projects {
         identifier


### PR DESCRIPTION
Having favorited projects also in all projects caused duplicate key issues when rendering the data in the projects dropdown. This PR filters favorite projects out of all projects.