### PR TITLE
EVG-7323 remove summary from commit messages

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-01-27"
+	ClientVersion = "2020-02-06"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -475,7 +475,7 @@ func gitFormatPatch(base string, ref, commits string) (string, error) {
 	if commits != "" {
 		revisionRange = formatCommitRange(commits)
 	}
-	return gitCmd("format-patch", "--keep-subject", "--no-signature", "--stdout", "--no-ext-diff", "--summary", "--binary", revisionRange)
+	return gitCmd("format-patch", "--keep-subject", "--no-signature", "--stdout", "--no-ext-diff", "--binary", revisionRange)
 }
 
 // getLog runs "git log <base>...<ref> or uses the commit range given


### PR DESCRIPTION
Remove the `--summary` option to `git format-patch` which causes a summary of file changes to be appended to the commit message.
The fix is on the client side so users will need to update their CLI to get the fix.