### PR TITLE
EVG-7229 BFGs on stepback

### DIFF
--- a/model/alertrecord/alert_bookkeeping.go
+++ b/model/alertrecord/alert_bookkeeping.go
@@ -165,6 +165,28 @@ func FindByLastTaskRegressionByTest(subscriptionID, testName, taskDisplayName, v
 	return FindOne(db.Query(q).Sort([]string{"-" + AlertTimeKey, "-" + RevisionOrderNumberKey}))
 }
 
+func FindByTaskRegressionByTaskTest(subscriptionID, testName, taskDisplayName, variant, projectID, taskID string) (*AlertRecord, error) {
+	q := subscriptionIDQuery(subscriptionID)
+	q[TypeKey] = taskRegressionByTest
+	q[testNameKey] = testName
+	q[TaskNameKey] = taskDisplayName
+	q[VariantKey] = variant
+	q[ProjectIdKey] = projectID
+	q[TaskIdKey] = taskID
+	return FindOne(db.Query(q).Sort([]string{"-" + AlertTimeKey}))
+}
+
+func FindByTaskRegressionTestAndOrderNumber(subscriptionID, testName, taskDisplayName, variant, projectID string, revisionOrderNumber int) (*AlertRecord, error) {
+	q := subscriptionIDQuery(subscriptionID)
+	q[TypeKey] = taskRegressionByTest
+	q[testNameKey] = testName
+	q[TaskNameKey] = taskDisplayName
+	q[VariantKey] = variant
+	q[ProjectIdKey] = projectID
+	q[RevisionOrderNumberKey] = revisionOrderNumber
+	return FindOne(db.Query(q))
+}
+
 func FindBySpawnHostExpirationWithHours(hostID string, hours int) (*AlertRecord, error) {
 	alerttype := fmt.Sprintf(spawnHostWarningTemplate, hours)
 	q := subscriptionIDQuery(legacyAlertsSubscription)

--- a/model/alertrecord/alert_bookkeeping_test.go
+++ b/model/alertrecord/alert_bookkeeping_test.go
@@ -243,3 +243,61 @@ func (s *alertRecordSuite) TestFindByLastTaskRegressionByTest() {
 	s.NoError(err)
 	s.Equal("t3", alert.TaskId)
 }
+
+func (s *alertRecordSuite) TestFindByTaskRegressionByTaskTest() {
+	alert1 := AlertRecord{
+		Id:        mgobson.NewObjectId(),
+		Type:      taskRegressionByTest,
+		TaskName:  "t",
+		Variant:   "v",
+		ProjectId: "p",
+		TaskId:    "t1",
+		TestName:  "test",
+		AlertTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+	}
+	s.NoError(alert1.Insert())
+	alert2 := AlertRecord{
+		Id:        mgobson.NewObjectId(),
+		Type:      taskRegressionByTest,
+		TaskName:  "t",
+		Variant:   "v",
+		ProjectId: "p",
+		TaskId:    "t2",
+		TestName:  "test",
+		AlertTime: time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	}
+	s.NoError(alert2.Insert())
+
+	alert, err := FindByTaskRegressionByTaskTest("", "test", "t", "v", "p", "t2")
+	s.NoError(err)
+	s.True(time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC).Equal(alert.AlertTime))
+}
+
+func (s *alertRecordSuite) TestFindByTaskRegressionTestAndOrderNumber() {
+	alert1 := AlertRecord{
+		Id:                  mgobson.NewObjectId(),
+		Type:                taskRegressionByTest,
+		TaskName:            "t",
+		Variant:             "v",
+		ProjectId:           "p",
+		TaskId:              "t1",
+		TestName:            "test",
+		RevisionOrderNumber: 1,
+	}
+	s.NoError(alert1.Insert())
+	alert2 := AlertRecord{
+		Id:                  mgobson.NewObjectId(),
+		Type:                taskRegressionByTest,
+		TaskName:            "t",
+		Variant:             "v",
+		ProjectId:           "p",
+		TaskId:              "t2",
+		TestName:            "test",
+		RevisionOrderNumber: 2,
+	}
+	s.NoError(alert2.Insert())
+
+	alert, err := FindByTaskRegressionTestAndOrderNumber("", "test", "t", "v", "p", 1)
+	s.NoError(err)
+	s.Equal("t1", alert.TaskId)
+}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -660,7 +660,7 @@ func (t *taskTriggers) shouldIncludeTest(sub *event.Subscription, previousTask *
 		// try to find a stepback alert
 		alertForStepback, err := alertrecord.FindByTaskRegressionTestAndOrderNumber(sub.ID, test.TestFile, t.task.DisplayName, t.task.BuildVariant, t.task.Project, previousTask.RevisionOrderNumber)
 		if err != nil {
-			return false, errors.Wrap(err, "can't get alert record")
+			return false, errors.Wrap(err, "can't get alert for stepback")
 		}
 		// never alerted for this regression before
 		if alertForStepback == nil {
@@ -668,6 +668,9 @@ func (t *taskTriggers) shouldIncludeTest(sub *event.Subscription, previousTask *
 		}
 	} else {
 		mostRecentAlert, err := alertrecord.FindByLastTaskRegressionByTest(sub.ID, test.TestFile, t.task.DisplayName, t.task.BuildVariant, t.task.Project)
+		if err != nil {
+			return false, errors.Wrap(err, "can't get most recent alert")
+		}
 		if mostRecentAlert == nil {
 			return true, nil
 		}

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -875,6 +875,22 @@ func (s *taskSuite) TestRegressionByTestWithDuplicateTestNames() {
 	s.tryDoubleTrigger(true)
 }
 
+func (s *taskSuite) TestRegressionByTestWithTestsWithStepback() {
+	s.NoError(db.ClearCollections(task.Collection, testresult.Collection))
+
+	// TestFailed should generate
+	s.makeTask(22, evergreen.TaskSucceeded)
+	s.makeTest(22, 0, "", evergreen.TestSucceededStatus)
+	s.makeTask(24, evergreen.TaskFailed)
+	s.makeTest(24, 0, "", evergreen.TestFailedStatus)
+	s.tryDoubleTrigger(true)
+
+	// but not when we run the earlier task
+	s.makeTask(23, evergreen.TaskFailed)
+	s.makeTest(23, 0, "", evergreen.TestFailedStatus)
+	s.tryDoubleTrigger(false)
+}
+
 func (s *taskSuite) TestRegressionByTestWithRegex() {
 	sub := event.Subscription{
 		ID:           mgobson.NewObjectId().Hex(),


### PR DESCRIPTION
The task trigger checks if a BFG has already been created for an earlier revision, but in the case of stepback the existing alert is for a later revision.

This PR records the revision order number of the _previous_ task in the alert (similar to how it's done for TaskRegression) so we can check if **this transition** from passing to failing already has an alert. Also reorganized `shouldIncludeTest` to be more understandable/maintainable.