### PR TITLE
EVG-6935 Fix panic and 401 error when fetching with non-existent project_id or distro_id 

### DIFF
--- a/model/context.go
+++ b/model/context.go
@@ -49,9 +49,6 @@ func LoadContext(taskId, buildId, versionId, patchId, projectId string) (Context
 		// Also lookup the ProjectRef itself and add it to context.
 		ctx.ProjectRef, err = FindOneProjectRef(projectId)
 		if err != nil {
-			// if errors.Cause(err) == ErrProjectNotFound {
-			// 	return ctx, errors.Errorf("error finding the project %s", projectId)
-			// }
 			return ctx, err
 		}
 	}

--- a/model/context.go
+++ b/model/context.go
@@ -49,6 +49,9 @@ func LoadContext(taskId, buildId, versionId, patchId, projectId string) (Context
 		// Also lookup the ProjectRef itself and add it to context.
 		ctx.ProjectRef, err = FindOneProjectRef(projectId)
 		if err != nil {
+			// if errors.Cause(err) == ErrProjectNotFound {
+			// 	return ctx, errors.Errorf("error finding the project %s", projectId)
+			// }
 			return ctx, err
 		}
 	}

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/patch"
@@ -441,10 +442,17 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 		}
 	}
 
+	projectRef, err := model.FindOneProjectRef(projectID)
+	if err != nil {
+		return nil, http.StatusInternalServerError, errors.WithStack(err)
+	}
+	if projectRef == nil {
+		return nil, http.StatusNotFound, errors.Errorf("error finding the project %s", projectID)
+	}
+
 	// check to see if this is an anonymous user requesting a private project
 	user := gimlet.GetUser(r.Context())
 	if user == nil {
-		projectRef, err := model.FindOneProjectRef(projectID)
 		if err != nil || projectRef == nil {
 			return nil, http.StatusNotFound, errors.New("no project found")
 		}
@@ -494,6 +502,14 @@ func urlVarsToDistroScopes(r *http.Request) ([]string, int, error) {
 	// no distro found - return a 404
 	if distroID == "" {
 		return nil, http.StatusNotFound, errors.New("no distro found")
+	}
+
+	distro, err := distro.FindByID(distroID)
+	if err != nil {
+		return nil, http.StatusInternalServerError, errors.WithStack(err)
+	}
+	if distro == nil {
+		return nil, http.StatusNotFound, errors.Errorf("error finding the distro %s", distroID)
 	}
 
 	return []string{distroID}, http.StatusOK, nil


### PR DESCRIPTION
[EVG-6935](https://jira.mongodb.org/browse/EVG-6935)

This bug was reproducible when run locally. However, when run in production or staging, instead of causing a panic, a 401 -Unauthorized- error was returned instead. 

This fixes the cause of the panic, and also returns a 400 error with a message indicating that the project was not found, instead of 401 Unauthorized  