### PR TITLE
EVG-7329 remove ProviderSettingsList for distro updates 

### DIFF
--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -63,7 +63,7 @@ func (dc *DBDistroConnector) UpdateDistro(old, new *distro.Distro) error {
 			}
 		}
 	}
-
+	new.ProviderSettingsList = nil
 	err := new.Update()
 	if err != nil {
 		return gimlet.ErrorResponse{


### PR DESCRIPTION
I started writing something more complicated but I think the methods involved might impact other things so I want to think about it without a time pressure--regardless, settings this list to be nil in the case of an overall update should make EVG-7232 safe because `FromDistroSettings()` will set it correctly again.