### PR TITLE
EVG-7336: fix all vetshadow errors in codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,3 +9,7 @@ linters:
     - interfacer
     - misspell
     - unconvert
+
+linters-settings:
+  govet:
+    check-shadowing: true

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -554,7 +554,8 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 		}
 
 		logger.Info("cleaning up Docker artifacts")
-		ctx, cancel := context.WithTimeout(ctx, dockerTimeout)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, dockerTimeout)
 		defer cancel()
 		if err := docker.Cleanup(ctx, logger); err != nil {
 			msg := fmt.Sprintf("Error cleaning up Docker artifacts (agent-exit): %s", err)

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -458,7 +458,7 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting EC2 settings")
 	}
-	if err := ec2Settings.Validate(); err != nil {
+	if err = ec2Settings.Validate(); err != nil {
 		return nil, errors.Wrapf(err, "Invalid EC2 settings in distro %s: %+v", h.Distro.Id, ec2Settings)
 	}
 	if ec2Settings.KeyName == "" && !h.UserHost {
@@ -538,7 +538,7 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 func (m *ec2Manager) getResources(ctx context.Context, h *host.Host) ([]string, error) {
 	instanceID := h.Id
 	if isHostSpot(h) {
-		var instanceID string
+		var err error
 		instanceID, err = m.client.GetSpotInstanceId(ctx, h)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":       "error getting spot request info",

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -465,7 +465,8 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 		if !h.SpawnOptions.SpawnedByTask {
 			return nil, errors.New("key name must not be empty")
 		}
-		k, err := m.client.GetKey(ctx, h)
+		var k string
+		k, err = m.client.GetKey(ctx, h)
 		if err != nil {
 			return nil, errors.Wrap(err, "not spawning host, problem creating key")
 		}
@@ -494,8 +495,7 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 		return nil, errors.Wrap(err, msg)
 	}
 	if provider == onDemandProvider {
-		err := m.spawnOnDemandHost(ctx, h, ec2Settings, blockDevices)
-		if err != nil {
+		if err = m.spawnOnDemandHost(ctx, h, ec2Settings, blockDevices); err != nil {
 			msg := "error spawning on-demand host"
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":       msg,
@@ -538,7 +538,8 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 func (m *ec2Manager) getResources(ctx context.Context, h *host.Host) ([]string, error) {
 	instanceID := h.Id
 	if isHostSpot(h) {
-		instanceID, err := m.client.GetSpotInstanceId(ctx, h)
+		var instanceID string
+		instanceID, err = m.client.GetSpotInstanceId(ctx, h)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":       "error getting spot request info",
 			"host_id":       h.Id,
@@ -959,7 +960,8 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 	err = util.Retry(
 		ctx,
 		func() (bool, error) {
-			instance, err := m.client.GetInstanceInfo(ctx, h.Id)
+			var instance *ec2.Instance
+			instance, err = m.client.GetInstanceInfo(ctx, h.Id)
 			if err != nil {
 				return false, errors.Wrap(err, "error getting instance info")
 			}

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1041,7 +1041,8 @@ func (c *awsClientImpl) GetPublicDNSName(ctx context.Context, h *host.Host) (str
 func (c *awsClientImpl) getHostInstanceID(ctx context.Context, h *host.Host) (string, error) {
 	id := h.Id
 	if isHostSpot(h) {
-		id, err := c.GetSpotInstanceId(ctx, h)
+		var err error
+		id, err = c.GetSpotInstanceId(ctx, h)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to get spot request info for %s", h.Id)
 		}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -82,8 +82,7 @@ func (m *ec2FleetManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Ho
 		if !h.SpawnOptions.SpawnedByTask {
 			return nil, errors.New("key name must not be empty")
 		}
-		var k string
-		k, err = m.client.GetKey(ctx, h)
+		k, err := m.client.GetKey(ctx, h)
 		if err != nil {
 			return nil, errors.Wrap(err, "not spawning host, problem creating key")
 		}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -82,7 +82,8 @@ func (m *ec2FleetManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Ho
 		if !h.SpawnOptions.SpawnedByTask {
 			return nil, errors.New("key name must not be empty")
 		}
-		k, err := m.client.GetKey(ctx, h)
+		var k string
+		k, err = m.client.GetKey(ctx, h)
 		if err != nil {
 			return nil, errors.Wrap(err, "not spawning host, problem creating key")
 		}

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -38,7 +38,8 @@ func TestFleet(t *testing.T) {
 
 	for name, test := range map[string]func(*testing.T){
 		"SpawnHost": func(*testing.T) {
-			h, err := m.SpawnHost(context.Background(), h)
+			var err error
+			h, err = m.SpawnHost(context.Background(), h)
 			assert.NoError(t, err)
 			assert.Equal(t, "i-12345", h.Id)
 		},
@@ -153,7 +154,7 @@ func TestFleet(t *testing.T) {
 		"CostForDuration": func(*testing.T) {
 			start := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 			end := start.Add(time.Hour * 24)
-			h := &host.Host{
+			h = &host.Host{
 				ComputeCostPerHour: float64(1),
 				VolumeTotalSize:    int64(30),
 				Zone:               "us-east-1a",

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -247,7 +247,7 @@ func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, cl
 	var err error
 	if h.ComputeCostPerHour == 0 {
 		ec2Settings := &EC2ProviderSettings{}
-		err := ec2Settings.FromDistroSettings(h.Distro, "")
+		err = ec2Settings.FromDistroSettings(h.Distro, "")
 		if err != nil {
 			return errors.Wrapf(err, "error getting EC2 settings for host '%s'", h.Id)
 		}

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -174,7 +174,7 @@ func (mockMgr *mockManager) ModifyHost(ctx context.Context, host *host.Host, cha
 		host.AddTags(changes.AddInstanceTags)
 		instance.Tags = host.InstanceTags
 		mockMgr.Instances[host.Id] = instance
-		if err := host.SetTags(); err != nil {
+		if err = host.SetTags(); err != nil {
 			return errors.Errorf("error adding tags in db")
 		}
 	}
@@ -183,7 +183,7 @@ func (mockMgr *mockManager) ModifyHost(ctx context.Context, host *host.Host, cha
 		instance.Tags = host.InstanceTags
 		mockMgr.Instances[host.Id] = instance
 		host.DeleteTags(changes.DeleteInstanceTags)
-		if err := host.SetTags(); err != nil {
+		if err = host.SetTags(); err != nil {
 			return errors.Errorf("error deleting tags in db")
 		}
 	}

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -65,7 +65,7 @@ func (so *SpawnOptions) validate() error {
 		return errors.Wrap(err, "Error occurred finding user's current hosts")
 	}
 
-	if err := checkSpawnHostLimitExceeded(len(activeSpawnedHosts)); err != nil {
+	if err = checkSpawnHostLimitExceeded(len(activeSpawnedHosts)); err != nil {
 		return err
 	}
 

--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -175,5 +175,5 @@ func main() {
 		grip.EmergencyFatal(err)
 	}
 	jsonBytes, _ := json.MarshalIndent(generate, "", "  ")
-	ioutil.WriteFile(jsonFilename, jsonBytes, 0644)
+	grip.Error(ioutil.WriteFile(jsonFilename, jsonBytes, 0644))
 }

--- a/cmd/go-test-config/make-config.go
+++ b/cmd/go-test-config/make-config.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 
 	"github.com/evergreen-ci/shrub"
+	"github.com/mongodb/grip"
 )
 
 var (
@@ -22,7 +23,7 @@ var (
 func main() {
 	config := makeTasks()
 	jsonBytes, _ := json.MarshalIndent(config, "", "  ")
-	ioutil.WriteFile(fileName, jsonBytes, 0644)
+	grip.Error(ioutil.WriteFile(fileName, jsonBytes, 0644))
 }
 
 func makeTasks() *shrub.Configuration {

--- a/cmd/run-linter/run-linter.go
+++ b/cmd/run-linter/run-linter.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/mongodb/grip"
 )
 
 type result struct {
@@ -123,7 +125,10 @@ func main() {
 		}()
 
 		for _, r := range results {
-			f.WriteString(r.String() + "\n")
+			if _, err = f.WriteString(r.String() + "\n"); err != nil {
+				grip.Error(err)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -129,12 +129,14 @@ func TestGitPush(t *testing.T) {
 		},
 		"PushPatch": func(*testing.T) {
 			ctx := context.Background()
-			jpm, err := jasper.NewSynchronizedManager(false)
+			var jpm jasper.Manager
+			jpm, err = jasper.NewSynchronizedManager(false)
 			require.NoError(t, err)
 			c.base.jasper = jpm
 			c.DryRun = true
 
-			repoDir, err := ioutil.TempDir("", "test_repo")
+			var repoDir string
+			repoDir, err = ioutil.TempDir("", "test_repo")
 			require.NoError(t, err)
 			require.NoError(t, ioutil.WriteFile(path.Join(repoDir, "test1.txt"), []byte("test1"), 0644))
 			require.NoError(t, ioutil.WriteFile(path.Join(repoDir, "test2.txt"), []byte("test2"), 0644))

--- a/makefile
+++ b/makefile
@@ -430,9 +430,9 @@ $(buildDir)/output.%.coverage:$(tmpDir) .FORCE
 	$(testRunEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && go tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 #  targets to generate gotest output from the linter.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter $(buildDir)/golangci-lint $(testSrcFiles) .FORCE
+$(buildDir)/output.%.lint:$(buildDir)/run-linter $(testSrcFiles) .FORCE
 	@./$< --output=$@ --lintBin="$(buildDir)/golangci-lint" --customLinters="$(gopath)/bin/evg-lint -set_exit_status" --packages='$*'
-$(buildDir)/output.lint:$(buildDir)/run-linter $(buildDir)/golangci-lint .FORCE
+$(buildDir)/output.lint:$(buildDir)/run-linter .FORCE
 	@./$< --output="$@" --lintBin="$(buildDir)/golangci-lint" --customLinters="$(gopath)/bin/evg-lint -set_exit_status" --packages="$(packages)"
 #  targets to process and generate coverage reports
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -708,7 +708,7 @@ func (h *Host) RunJasperProcess(ctx context.Context, env evergreen.Environment, 
 	}
 
 	catcher := grip.NewBasicCatcher()
-	if _, err := proc.Wait(ctx); err != nil {
+	if _, err = proc.Wait(ctx); err != nil {
 		catcher.Wrap(err, "problem waiting for process completion")
 	}
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -411,7 +411,7 @@ func RestartBuild(buildId string, taskIds []string, abortInProgress bool, caller
 		}
 	}
 
-	if err := build.UpdateActivation([]string{buildId}, true, caller); err != nil {
+	if err = build.UpdateActivation([]string{buildId}, true, caller); err != nil {
 		return errors.Wrapf(err, "can't activate build '%s'", buildId)
 	}
 

--- a/model/manifest/db.go
+++ b/model/manifest/db.go
@@ -70,7 +70,8 @@ func FindFromVersion(versionID, project, revision, requester string) (*Manifest,
 		}
 		if manifest != nil {
 			if evergreen.IsPatchRequester(requester) {
-				p, err := patch.FindOne(patch.ById(patch.NewId(versionID)))
+				var p *patch.Patch
+				p, err = patch.FindOne(patch.ById(patch.NewId(versionID)))
 				if err != nil {
 					return nil, errors.Wrapf(err, "can't get patch for '%s'", versionID)
 				}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -388,7 +388,9 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 			DistroAliases:  distroAliases,
 			TaskCreateTime: createTime,
 		}
-		build, tasks, err := CreateBuildFromVersionNoInsert(buildArgs)
+		var build *build.Build
+		var tasks task.Tasks
+		build, tasks, err = CreateBuildFromVersionNoInsert(buildArgs)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/model/project.go
+++ b/model/project.go
@@ -812,7 +812,8 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 		expansions.Put("trigger_id", t.TriggerEvent)
 		var upstreamProjectID string
 		if t.TriggerType == ProjectTriggerLevelTask {
-			upstreamTask, err := task.FindOneId(t.TriggerID)
+			var upstreamTask *task.Task
+			upstreamTask, err = task.FindOneId(t.TriggerID)
 			if err != nil {
 				return nil, errors.Wrap(err, "error finding task")
 			}
@@ -823,7 +824,8 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 			expansions.Put("trigger_revision", upstreamTask.Revision)
 			upstreamProjectID = upstreamTask.Project
 		} else if t.TriggerType == ProjectTriggerLevelBuild {
-			upstreamBuild, err := build.FindOneId(t.TriggerID)
+			var upstreamBuild *build.Build
+			upstreamBuild, err = build.FindOneId(t.TriggerID)
 			if err != nil {
 				return nil, errors.Wrap(err, "error finding build")
 			}
@@ -834,7 +836,8 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 			expansions.Put("trigger_revision", upstreamBuild.Revision)
 			upstreamProjectID = upstreamBuild.Project
 		}
-		upstreamProject, err := FindOneProjectRef(upstreamProjectID)
+		var upstreamProject *ProjectRef
+		upstreamProject, err = FindOneProjectRef(upstreamProjectID)
 		if err != nil {
 			return nil, errors.Wrap(err, "error finding project")
 		}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -450,7 +450,8 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 		// and we should default to the version config
 		if ppFromDB.ConfigUpdateNumber >= v.ConfigUpdateNumber {
 			ppFromDB.Identifier = identifier
-			p, err := TranslateProject(ppFromDB)
+			var p *Project
+			p, err = TranslateProject(ppFromDB)
 			return p, ppFromDB, err
 		}
 	}

--- a/model/reliability/db_test.go
+++ b/model/reliability/db_test.go
@@ -126,8 +126,8 @@ func TestPipeline(t *testing.T) {
 		},
 		// Test BuildTaskPaginationOrBranches creation for the task reliability pipeline.
 		"BuildTaskPaginationOrBranches": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
-			after := time.Date(2018, 7, 12, 0, 0, 0, 0, time.UTC)
-			before := time.Date(2018, 9, 13, 0, 0, 0, 0, time.UTC)
+			after = time.Date(2018, 7, 12, 0, 0, 0, 0, time.UTC)
+			before = time.Date(2018, 9, 13, 0, 0, 0, 0, time.UTC)
 
 			for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, filter *TaskReliabilityFilter){
 				"Sort Latest, GroupBy task, Num Days 1": func(ctx context.Context, t *testing.T, filter *TaskReliabilityFilter) {

--- a/model/reliability/query.go
+++ b/model/reliability/query.go
@@ -94,7 +94,7 @@ func (s *TaskReliability) calculateSuccessRate() {
 	p := 0.0
 
 	if total != 0 {
-		p := success / total
+		p = success / total
 
 		dist := s.Z * math.Sqrt((p*(1.-p)+s.Z*s.Z/(4.*total))/total)
 		denominator := 1. + s.Z*s.Z/total

--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -1052,7 +1052,8 @@ func aggregateIntoCollection(ctx context.Context, collection string, pipeline []
 
 	buf := make([]mongo.WriteModel, 0, bulkSize)
 	for cursor.Next(ctx) {
-		doc, err := birch.DC.ReaderErr(birch.Reader(cursor.Current))
+		var doc *birch.Document
+		doc, err = birch.DC.ReaderErr(birch.Reader(cursor.Current))
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -979,7 +979,7 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 		return errors.Wrap(err, "problem marking task failed")
 	}
 	if !t.IsPartOfDisplay() {
-		if err := build.UpdateCachedTask(t, 0); err != nil {
+		if err = build.UpdateCachedTask(t, 0); err != nil {
 			return errors.Wrap(err, "problem resetting cached task")
 		}
 	}
@@ -988,7 +988,8 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 		updates := StatusChanges{}
 		if t.DisplayOnly {
 			for _, etID := range t.ExecutionTasks {
-				execTask, err := task.FindOne(task.ById(etID))
+				var execTask *task.Task
+				execTask, err = task.FindOne(task.ById(etID))
 				if err != nil {
 					return errors.Wrap(err, "error finding execution task")
 				}

--- a/model/task_queue_service.go
+++ b/model/task_queue_service.go
@@ -331,7 +331,8 @@ func (d *basicCachedDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueItem {
 
 			// A non-task group schedulableUnit's tasks ([]TaskQueueItem) only contains a single element.
 			item := unit.tasks[0]
-			nextTaskFromDB, err := task.FindOneId(unit.tasks[0].Id)
+			var nextTaskFromDB *task.Task
+			nextTaskFromDB, err = task.FindOneId(unit.tasks[0].Id)
 			if err != nil {
 				grip.Warning(message.WrapError(err, message.Fields{
 					"dispatcher": SchedulableUnitDispatcher,
@@ -353,7 +354,8 @@ func (d *basicCachedDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueItem {
 				return nil
 			}
 
-			dependenciesMet, err := nextTaskFromDB.DependenciesMet(dependencyCaches)
+			var dependenciesMet bool
+			dependenciesMet, err = nextTaskFromDB.DependenciesMet(dependencyCaches)
 			if err != nil {
 				grip.Warning(message.WrapError(err, message.Fields{
 					"dispatcher": SchedulableUnitDispatcher,

--- a/operations/admin_from_mdb.go
+++ b/operations/admin_from_mdb.go
@@ -205,7 +205,8 @@ func fromMdbForLocal() cli.Command {
 
 			for _, collection := range collections {
 				coll := client.Database(dbName).Collection(collection)
-				size, err := coll.CountDocuments(ctx, struct{}{})
+				var size int64
+				size, err = coll.CountDocuments(ctx, struct{}{})
 				if err != nil {
 					return errors.Wrap(err, "problem finding number of source documents")
 				}

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -344,7 +344,7 @@ func (p *mergeParams) uploadMergePatch(conf *ClientSettings, ac *legacyClient) e
 		return errors.New("patch aborted")
 	}
 
-	if err := isValidCommitsFormat(p.commits); err != nil {
+	if err = isValidCommitsFormat(p.commits); err != nil {
 		return err
 	}
 
@@ -405,7 +405,7 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 		return errors.Wrapf(err, "can't get patch '%s'", p.patchID)
 	}
 
-	if err := isValidCommitsFormat(p.commits); err != nil {
+	if err = isValidCommitsFormat(p.commits); err != nil {
 		return err
 	}
 

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/model"
+	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/send"

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -732,7 +732,8 @@ func hostRunCommand() cli.Command {
 					}
 				}
 
-				hosts, err := client.GetHosts(ctx, model.APIHostParams{
+				var hosts []*restmodel.APIHost
+				hosts, err = client.GetHosts(ctx, model.APIHostParams{
 					CreatedBefore: createdBeforeTime,
 					CreatedAfter:  createdAfterTime,
 					Distro:        distro,
@@ -759,7 +760,8 @@ func hostRunCommand() cli.Command {
 			}
 
 			if path != "" {
-				scriptBytes, err := ioutil.ReadFile(path)
+				var scriptBytes []byte
+				scriptBytes, err = ioutil.ReadFile(path)
 				if err != nil {
 					return errors.Wrapf(err, "can't read script from '%s'", path)
 				}

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -987,7 +987,7 @@ Examples:
 				dryRun:               dryRun,
 			}
 			if makeParentDirs && !makeParentDirsOnRemote {
-				if err := makeLocalParentDirs(localPath, remotePath, pull); err != nil {
+				if err = makeLocalParentDirs(localPath, remotePath, pull); err != nil {
 					return errors.Wrap(err, "could not create directory structure")
 				}
 			}

--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -170,7 +170,8 @@ OUTER:
 			// retry for *slightly* delayed logger closing
 			for i := 0; i < 3; i++ {
 				grip.Infof("checking for log %s (%d/3)", task.Logs["task_log"], i+1)
-				body, err := makeSmokeRequest(username, key, client, task.Logs["task_log"]+"&text=true")
+				var body []byte
+				body, err = makeSmokeRequest(username, key, client, task.Logs["task_log"]+"&text=true")
 				if err != nil {
 					err = errors.Wrap(err, "error getting log data")
 					grip.Debug(err)

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -276,7 +276,8 @@ func (c *communicatorImpl) makeSender(ctx context.Context, td TaskData, opts []L
 			}
 
 			if c.cedarGRPCClient == nil {
-				bi, err := c.GetBuildloggerInfo(ctx)
+				var bi *apimodels.BuildloggerInfo
+				bi, err = c.GetBuildloggerInfo(ctx)
 				if err != nil {
 					return nil, errors.Wrap(err, "error setting up buildlogger sender")
 				}

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -38,7 +38,7 @@ func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, spawnRequest *mo
 
 	if resp.StatusCode != http.StatusOK {
 		errMsg := gimlet.ErrorResponse{}
-		if err := util.ReadJSONInto(resp.Body, &errMsg); err != nil {
+		if err = util.ReadJSONInto(resp.Body, &errMsg); err != nil {
 			return nil, errors.Wrap(err, "problem spawning host and parsing error message")
 		}
 		return nil, errors.Wrap(errMsg, "problem spawning host")
@@ -175,7 +175,7 @@ func (c *communicatorImpl) CreateVolume(ctx context.Context, volume *host.Volume
 
 	if resp.StatusCode != http.StatusOK {
 		errMsg := gimlet.ErrorResponse{}
-		if err := util.ReadJSONInto(resp.Body, &errMsg); err != nil {
+		if err = util.ReadJSONInto(resp.Body, &errMsg); err != nil {
 			return nil, errors.Wrap(err, "problem creating volume and parsing error message")
 		}
 		return nil, errors.Wrap(errMsg, "problem creating volume")
@@ -299,7 +299,7 @@ func (c *communicatorImpl) waitForStatus(ctx context.Context, hostID, status str
 			}
 			if resp.StatusCode != http.StatusOK {
 				errMsg := gimlet.ErrorResponse{}
-				if err := util.ReadJSONInto(resp.Body, &errMsg); err != nil {
+				if err = util.ReadJSONInto(resp.Body, &errMsg); err != nil {
 					return errors.Wrap(err, "problem getting host and parsing error message")
 				}
 				return errors.Wrap(errMsg, "problem getting host")
@@ -405,7 +405,7 @@ func (c *communicatorImpl) GetHosts(ctx context.Context, data model.APIHostParam
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		errMsg := gimlet.ErrorResponse{}
-		if err := util.ReadJSONInto(resp.Body, &errMsg); err != nil {
+		if err = util.ReadJSONInto(resp.Body, &errMsg); err != nil {
 			return nil, errors.Wrapf(err, "Got %d code. Problem reading hosts error", resp.StatusCode)
 		}
 		return nil, errors.Wrap(errMsg, "problem getting hosts")

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -50,7 +50,8 @@ func (pc *DBCommitQueueConnector) EnqueueItem(projectID string, item restModel.A
 
 	itemService := itemInterface.(commitqueue.CommitQueueItem)
 	if enqueueNext {
-		position, err := q.EnqueueAtFront(itemService)
+		var position int
+		position, err = q.EnqueueAtFront(itemService)
 		if err != nil {
 			return 0, errors.Wrapf(err, "can't force enqueue item to queue '%s'", projectID)
 		}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -235,7 +235,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		if err != nil {
 			return nil, errors.Wrap(err, "problem finding distro")
 		}
-		if err := ec2Settings.FromDistroSettings(d, createHost.Region); err != nil {
+		if err = ec2Settings.FromDistroSettings(d, createHost.Region); err != nil {
 			return nil, errors.Wrapf(err, "error getting ec2 provider from distro")
 		}
 	}
@@ -305,7 +305,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		return nil, errors.Wrap(err, "error marshalling provider setting into bson")
 	}
 	doc := birch.Document{}
-	if err := doc.UnmarshalBSON(bytes); err != nil {
+	if err = doc.UnmarshalBSON(bytes); err != nil {
 		return nil, errors.Wrap(err, "error umarshalling settings bytes into document")
 	}
 	d.ProviderSettingsList = []*birch.Document{&doc}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -285,7 +285,8 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	if len(createHost.SecurityGroups) > 0 {
 		ec2Settings.SecurityGroupIDs = createHost.SecurityGroups
 	} else {
-		settings, err := evergreen.GetConfig()
+		var settings *evergreen.Settings
+		settings, err = evergreen.GetConfig()
 		if err != nil {
 			return nil, errors.Wrap(err, "error retrieving evergreen settings")
 		}

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1438,7 +1438,7 @@ func (a *APISlackConfig) BuildFromService(h interface{}) error {
 		a.Level = ToStringPtr(v.Level)
 		if v.Options != nil {
 			a.Options = &APISlackOptions{}
-			if err := a.Options.BuildFromService(*v.Options); err != nil { //nolint: vet
+			if err := a.Options.BuildFromService(*v.Options); err != nil { //nolint: govet
 				return err
 			}
 		}
@@ -1453,7 +1453,7 @@ func (a *APISlackConfig) ToService() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	options := i.(send.SlackOptions) //nolint: vet
+	options := i.(send.SlackOptions) //nolint: govet
 	return evergreen.SlackConfig{
 		Token:   FromStringPtr(a.Token),
 		Level:   FromStringPtr(a.Level),

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -422,7 +422,8 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 
 	testLog := util.CoalesceStrings(query["log_id"], vars["log_id"])
 	if projectID == "" && testLog != "" {
-		test, err := model.FindOneTestLogById(testLog)
+		var test *model.TestLog
+		test, err = model.FindOneTestLogById(testLog)
 		if err != nil {
 			return nil, http.StatusNotFound, err
 		}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -270,7 +270,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	if err := dbProjectRef.ValidateOwnerAndRepo(h.settings.GithubOrgs); err != nil {
+	if err = dbProjectRef.ValidateOwnerAndRepo(h.settings.GithubOrgs); err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    err.Error(),
@@ -297,7 +297,8 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 				})
 			}
 
-			ghAliasesDefined, err := h.hasAliasDefined(apiProjectRef, evergreen.GithubAlias)
+			var ghAliasDefined bool
+			ghAliasesDefined, err = h.hasAliasDefined(apiProjectRef, evergreen.GithubAlias)
 			if err != nil {
 				return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't check for alias definitions"))
 			}
@@ -334,7 +335,8 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 				})
 			}
 
-			cqAliasesDefined, err := h.hasAliasDefined(apiProjectRef, evergreen.CommitQueueAlias)
+			var cqAliasDefined bool
+			cqAliasesDefined, err = h.hasAliasDefined(apiProjectRef, evergreen.CommitQueueAlias)
 			if err != nil {
 				return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't check for alias definitions"))
 			}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -297,7 +297,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 				})
 			}
 
-			var ghAliasDefined bool
+			var ghAliasesDefined bool
 			ghAliasesDefined, err = h.hasAliasDefined(apiProjectRef, evergreen.GithubAlias)
 			if err != nil {
 				return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't check for alias definitions"))
@@ -335,7 +335,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 				})
 			}
 
-			var cqAliasDefined bool
+			var cqAliasesDefined bool
 			cqAliasesDefined, err = h.hasAliasDefined(apiProjectRef, evergreen.CommitQueueAlias)
 			if err != nil {
 				return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't check for alias definitions"))

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -316,7 +316,7 @@ func (as *APIServer) existingPatchRequest(w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		var projectYaml *model.Project
+		var projectYaml string
 		_, projectYaml, err = model.GetPatchedProject(ctx, p, githubOauthToken)
 		if err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, err)

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -316,7 +316,8 @@ func (as *APIServer) existingPatchRequest(w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		_, projectYaml, err := model.GetPatchedProject(ctx, p, githubOauthToken)
+		var projectYaml *model.Project
+		_, projectYaml, err = model.GetPatchedProject(ctx, p, githubOauthToken)
 		if err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
 			return

--- a/service/build.go
+++ b/service/build.go
@@ -172,7 +172,7 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if projCtx.Build.Requester == evergreen.MergeTestRequester {
-			_, err := commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
+			_, err = commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
 				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Build.Version, true)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -218,7 +218,7 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if !putParams.Active && projCtx.Build.Requester == evergreen.MergeTestRequester {
-			_, err := commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
+			_, err = commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
 				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Build.Version, true)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/service/project.go
+++ b/service/project.go
@@ -342,7 +342,8 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// verify there are PR aliases defined
-		aliasesDefined, err := verifyAliasExists(evergreen.GithubAlias, projectRef.Identifier, responseRef.GitHubAliases, responseRef.DeleteAliases)
+		var aliasesDefined bool
+		aliasesDefined, err = verifyAliasExists(evergreen.GithubAlias, projectRef.Identifier, responseRef.GitHubAliases, responseRef.DeleteAliases)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't check if GitHub aliases are set"))
 			return
@@ -379,7 +380,8 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// verify there are commit queue aliases defined
-		exists, err := verifyAliasExists(evergreen.CommitQueueAlias, projectRef.Identifier, responseRef.CommitQueueAliases, responseRef.DeleteAliases)
+		var exists bool
+		exists, err = verifyAliasExists(evergreen.CommitQueueAlias, projectRef.Identifier, responseRef.CommitQueueAliases, responseRef.DeleteAliases)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't check if commit queue aliases are set"))
 			return
@@ -578,7 +580,6 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if origProjectRef.Restricted != projectRef.Restricted {
-		var err error
 		if projectRef.Restricted {
 			err = projectRef.MakeRestricted()
 		} else {

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -238,7 +238,7 @@ func (uis *UIServer) modifySpawnHost(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel = context.WithCancel(r.Context())
 		defer cancel()
 
-		if err := cloud.TerminateSpawnHost(ctx, uis.env, h, u.Id, fmt.Sprintf("terminated via UI by %s", u.Username())); err != nil {
+		if err = cloud.TerminateSpawnHost(ctx, uis.env, h, u.Id, fmt.Sprintf("terminated via UI by %s", u.Username())); err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}
@@ -316,13 +316,14 @@ func (uis *UIServer) modifySpawnHost(w http.ResponseWriter, r *http.Request) {
 
 	case HostExpirationExtension:
 		if updateParams.Expiration.IsZero() { // set expiration to never expire
-			settings, err := evergreen.GetConfig()
+			var settings *evergreen.Settings
+			settings, err = evergreen.GetConfig()
 			if err != nil {
 				PushFlash(uis.CookieStore, r, w, NewErrorFlash("Error updating host expiration"))
 				uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Error retrieving settings"))
 				return
 			}
-			if err := route.CheckUnexpirableHostLimitExceeded(u.Id, settings.UnexpirableHostsPerUser); err != nil {
+			if err = route.CheckUnexpirableHostLimitExceeded(u.Id, settings.UnexpirableHostsPerUser); err != nil {
 				PushFlash(uis.CookieStore, r, w, NewErrorFlash(err.Error()))
 				uis.LoggedError(w, r, http.StatusBadRequest, err)
 				return
@@ -361,7 +362,8 @@ func (uis *UIServer) modifySpawnHost(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		loc, err := time.LoadLocation(u.Settings.Timezone)
+		var loc *time.Location
+		loc, err = time.LoadLocation(u.Settings.Timezone)
 		if err != nil || loc == nil {
 			loc = time.UTC
 		}

--- a/service/task.go
+++ b/service/task.go
@@ -524,7 +524,8 @@ func (uis *UIServer) taskLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if defaultLogger == model.BuildloggerLogSender {
-		logReader, err := uis.getBuildloggerLogs(projCtx, r, logType, DefaultLogMessages, execution)
+		var logReader io.ReadCloser
+		logReader, err = uis.getBuildloggerLogs(projCtx, r, logType, DefaultLogMessages, execution)
 		if err == nil {
 			gimlet.WriteText(w, logReader)
 			grip.Warning(logReader.Close())
@@ -758,7 +759,7 @@ func (uis *UIServer) taskModify(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if projCtx.Task.Requester == evergreen.MergeTestRequester {
-			_, err := commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
+			_, err = commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
 				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Task.Version, true)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -782,7 +783,7 @@ func (uis *UIServer) taskModify(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if !active && projCtx.Task.Requester == evergreen.MergeTestRequester {
-			_, err := commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
+			_, err = commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
 				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Task.Version, true)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -126,7 +126,8 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		projectID := gimlet.GetVars(r)["project_id"]
-		project, err := projCtx.GetProject()
+		var project *model.Project
+		project, err = projCtx.GetProject()
 		if err != nil || project == nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err,
 				"Error fetching project %v", projectID))

--- a/service/version.go
+++ b/service/version.go
@@ -264,7 +264,7 @@ func (uis *UIServer) modifyVersion(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if !jsonMap.Active && projCtx.Version.Requester == evergreen.MergeTestRequester {
-			_, err := commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
+			_, err = commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
 				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Version.Id, true)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/thirdparty/docker/docker_cleanup_test.go
+++ b/thirdparty/docker/docker_cleanup_test.go
@@ -31,12 +31,14 @@ func TestCleanup(t *testing.T) {
 
 	for name, test := range map[string]func(*testing.T){
 		"cleanContainers": func(*testing.T) {
-			resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
+			var resp container.ContainerCreateCreatedBody
+			resp, err = dockerClient.ContainerCreate(ctx, &container.Config{
 				Image: "hello-world",
 			}, nil, nil, "")
 			require.NoError(t, err)
 			require.NoError(t, dockerClient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}))
-			info, err := dockerClient.Info(ctx)
+			var info types.Info
+			info, err = dockerClient.Info(ctx)
 			require.NoError(t, err)
 			require.True(t, info.ContainersRunning > 0)
 
@@ -49,7 +51,8 @@ func TestCleanup(t *testing.T) {
 		"cleanImages": func(*testing.T) {
 			assert.NoError(t, cleanImages(context.Background(), dockerClient))
 
-			info, err := dockerClient.Info(ctx)
+			var info types.Info
+			info, err = dockerClient.Info(ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, 0, info.Images)
 		},

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -726,7 +726,8 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 		if !match {
 			continue
 		}
-		shouldInclude, err := t.shouldIncludeTest(sub, previousCompleteTask, &t.task.LocalTestResults[i])
+		var shouldInclude bool
+		shouldInclude, err = t.shouldIncludeTest(sub, previousCompleteTask, &t.task.LocalTestResults[i])
 		if err != nil {
 			catcher.Add(err)
 			continue

--- a/units/cache_historical_test_data.go
+++ b/units/cache_historical_test_data.go
@@ -99,7 +99,6 @@ func (j *cacheHistoricalTestDataJob) Run(ctx context.Context) {
 	var statsStatus stats.StatsStatus
 	timingMsg["status_check"] = reportTiming(func() {
 		// Lookup last sync date for project
-		var err error
 		statsStatus, err = stats.GetStatsStatus(j.ProjectID)
 		j.AddError(errors.Wrap(err, "error retrieving last sync date"))
 	}).Seconds()
@@ -109,7 +108,6 @@ func (j *cacheHistoricalTestDataJob) Run(ctx context.Context) {
 
 	var tasksToIgnore []*regexp.Regexp
 	timingMsg["tasks_to_ignore_lookup"] = reportTiming(func() {
-		var err error
 		tasksToIgnore, err = getTasksToIgnore(j.ProjectID)
 		j.AddError(errors.Wrap(err, "error retrieving project settings"))
 	}).Seconds()
@@ -135,7 +133,6 @@ func (j *cacheHistoricalTestDataJob) Run(ctx context.Context) {
 	timingMsg["sync_to"] = syncToTime
 	var statsToUpdate []stats.StatsToUpdate
 	timingMsg["find_stats_to_update"] = reportTiming(func() {
-		var err error
 		statsToUpdate, err = stats.FindStatsToUpdate(stats.FindStatsOptions{
 			ProjectID:       j.ProjectID,
 			Requesters:      j.Requesters,

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -105,7 +105,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	}
 
 	if j.host.HasContainers {
-		var bool idle
+		var idle bool
 		idle, err = j.host.IsIdleParent()
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -105,7 +105,8 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	}
 
 	if j.host.HasContainers {
-		idle, err := j.host.IsIdleParent()
+		var bool idle
+		idle, err = j.host.IsIdleParent()
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "problem checking if host is an idle parent",

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -423,7 +423,8 @@ func GetPatchSummariesByCommit(reader io.Reader) ([]patch.Summary, error) {
 			n, err := reader.Read(curBytes)
 			if err != nil {
 				if err == io.EOF { // finished reading body of this patch
-					summaries, err := thirdparty.GetPatchSummaries(string(buffer))
+					var summaries []patch.Summary
+					summaries, err = thirdparty.GetPatchSummaries(string(buffer))
 					if err != nil {
 						return nil, errors.Wrapf(err, "error getting patch summaries for commit '%s'", description)
 					}

--- a/units/provisioning_jasper_restart.go
+++ b/units/provisioning_jasper_restart.go
@@ -215,7 +215,7 @@ func (j *jasperRestartJob) Run(ctx context.Context) {
 				"bash", "-c", writeCredentialsCmd,
 			},
 		}
-		var err []string
+		var output []string
 		if output, err = j.host.RunJasperProcess(ctx, j.env, writeCredentialsOpts); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "could not replace existing Jasper credentials on host",

--- a/units/provisioning_jasper_restart.go
+++ b/units/provisioning_jasper_restart.go
@@ -215,7 +215,8 @@ func (j *jasperRestartJob) Run(ctx context.Context) {
 				"bash", "-c", writeCredentialsCmd,
 			},
 		}
-		if output, err := j.host.RunJasperProcess(ctx, j.env, writeCredentialsOpts); err != nil {
+		var err []string
+		if output, err = j.host.RunJasperProcess(ctx, j.env, writeCredentialsOpts); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "could not replace existing Jasper credentials on host",
 				"logs":    output,

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -1000,7 +1000,7 @@ func mountLinuxVolume(ctx context.Context, env evergreen.Environment, h *host.Ho
 	cmd.Append(fmt.Sprintf("mount /dev/%s /%s", deviceName, evergreen.HomeVolumeDir))
 	cmd.Append(fmt.Sprintf("ln -s /%s %s/%s", evergreen.HomeVolumeDir, h.Distro.HomeDir(), evergreen.HomeVolumeDir))
 	cmd.Append(fmt.Sprintf("chown -R %s:%s %s/%s", h.User, h.User, h.Distro.HomeDir(), evergreen.HomeVolumeDir))
-	if err := cmd.Run(ctx); err != nil {
+	if err = cmd.Run(ctx); err != nil {
 		return errors.Wrap(err, "problem running mount commands")
 	}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7336

I liked the linter a lot more when it didn't have vet shadow. It's back I guess, and seemingly more functional than the gometalinter one, which failed to spot so many shadowed `err`s.