### PR TITLE
EVG-7235 validate multiple provider settings

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -112,7 +112,7 @@ type ManagerOpts struct {
 
 func GetSettings(provider string) (ProviderSettings, error) {
 	switch provider {
-	case evergreen.ProviderNameEc2OnDemand, evergreen.ProviderNameEc2Spot, evergreen.ProviderNameEc2Auto:
+	case evergreen.ProviderNameEc2OnDemand, evergreen.ProviderNameEc2Spot, evergreen.ProviderNameEc2Auto, evergreen.ProviderNameEc2Fleet:
 		return &EC2ProviderSettings{}, nil
 	case evergreen.ProviderNameStatic:
 		return &StaticSettings{}, nil
@@ -121,7 +121,7 @@ func GetSettings(provider string) (ProviderSettings, error) {
 	case evergreen.ProviderNameDocker, evergreen.ProviderNameDockerMock:
 		return &dockerSettings{}, nil
 	case evergreen.ProviderNameOpenstack:
-		return &MockProviderSettings{}, nil
+		return &openStackSettings{}, nil
 	case evergreen.ProviderNameGce:
 		return &GCESettings{}, nil
 	case evergreen.ProviderNameVsphere:

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -110,6 +110,26 @@ type ManagerOpts struct {
 	ProviderSecret string
 }
 
+func GetSettings(provider string) (ProviderSettings, error) {
+	switch provider {
+	case evergreen.ProviderNameEc2OnDemand, evergreen.ProviderNameEc2Spot, evergreen.ProviderNameEc2Auto:
+		return &EC2ProviderSettings{}, nil
+	case evergreen.ProviderNameStatic:
+		return &StaticSettings{}, nil
+	case evergreen.ProviderNameMock:
+		return &MockProviderSettings{}, nil
+	case evergreen.ProviderNameDocker, evergreen.ProviderNameDockerMock:
+		return &dockerSettings{}, nil
+	case evergreen.ProviderNameOpenstack:
+		return &MockProviderSettings{}, nil
+	case evergreen.ProviderNameGce:
+		return &GCESettings{}, nil
+	case evergreen.ProviderNameVsphere:
+		return &vsphereSettings{}, nil
+	}
+	return nil, errors.Errorf("invalid provider name %s", provider)
+}
+
 // GetManager returns an implementation of Manager for the given manager options.
 // It returns an error if the provider name doesn't have a known implementation.
 func GetManager(ctx context.Context, env evergreen.Environment, mgrOpts ManagerOpts) (Manager, error) {
@@ -187,8 +207,16 @@ func GetManager(ctx context.Context, env evergreen.Environment, mgrOpts ManagerO
 // GetManagerOptions gets the manager options from the provider settings object for a given
 // provider name.
 func GetManagerOptions(d distro.Distro) (ManagerOpts, error) {
+	if len(d.ProviderSettingsList) > 1 {
+		return ManagerOpts{}, errors.Errorf("distro should be modified to have only one provider settings")
+	}
 	if IsEc2Provider(d.Provider) {
-		return getEC2ManagerOptions(d)
+		s := &EC2ProviderSettings{}
+		if err := s.FromDistroSettings(d, ""); err != nil {
+			return ManagerOpts{}, errors.Wrapf(err, "error getting EC2 provider settings from distro")
+		}
+
+		return GetEC2ManagerOptionsFromSettings(d.Provider, s), nil
 	}
 	if d.Provider == evergreen.ProviderNameMock {
 		return getMockManagerOptions(d.Provider, d.ProviderSettings)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1302,7 +1302,7 @@ func (s *EC2Suite) TestGetEC2ManagerOptions() {
 		},
 	}
 
-	managerOpts, err := getEC2ManagerOptions(d1)
+	managerOpts, err := GetManagerOptions(d1)
 	s.NoError(err)
 	s.Equal(evergreen.DefaultEC2Region, managerOpts.Region)
 	s.Equal("key", managerOpts.ProviderKey)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	ec2aws "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/anser/bsonutil"
@@ -508,25 +507,17 @@ func IsEc2Provider(provider string) bool {
 		provider == evergreen.ProviderNameEc2Fleet
 }
 
-// Get EC2 region from a distro
-func getEC2ManagerOptions(d distro.Distro) (ManagerOpts, error) {
-	opts := ManagerOpts{}
-
-	s := &EC2ProviderSettings{}
-	if err := s.FromDistroSettings(d, ""); err != nil {
-		return ManagerOpts{}, errors.Wrapf(err, "error getting EC2 provider settings from distro")
+func GetEC2ManagerOptionsFromSettings(provider string, settings *EC2ProviderSettings) ManagerOpts {
+	region := settings.Region
+	if region == "" {
+		region = evergreen.DefaultEC2Region
 	}
-
-	opts.Provider = d.Provider
-	opts.Region = s.Region
-	opts.ProviderKey = s.AWSKeyID
-	opts.ProviderSecret = s.AWSSecret
-
-	if opts.Region == "" {
-		opts.Region = evergreen.DefaultEC2Region
+	return ManagerOpts{
+		Provider:       provider,
+		Region:         region,
+		ProviderKey:    settings.AWSKeyID,
+		ProviderSecret: settings.AWSSecret,
 	}
-
-	return opts, nil
 }
 
 // Get EC2 key and secret from the AWS configuration for the given region

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -170,7 +170,7 @@ func validateMultipleProviderSettings(d *distro.Distro) ValidationErrors {
 		}
 		if err := settings.FromDistroSettings(*d, region); err != nil {
 			errs = append(errs, ValidationError{
-				Message: errors.Wrapf(err, "distro '%v' decode error", distro.ProviderSettingsListKey).Error(),
+				Message: fmt.Sprintf("distro '%v' decode error: %v", distro.ProviderSettingsListKey, err),
 				Level:   Error,
 			})
 			continue

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -148,6 +148,7 @@ func validateMultipleProviderSettings(d *distro.Distro) ValidationErrors {
 				Message: fmt.Sprintf("defined region %s more than once", region),
 				Level:   Error,
 			})
+			continue
 		}
 		definedRegions[region] = true
 		bytes, err := doc.MarshalBSON()
@@ -169,7 +170,7 @@ func validateMultipleProviderSettings(d *distro.Distro) ValidationErrors {
 		}
 		if err := settings.FromDistroSettings(*d, region); err != nil {
 			errs = append(errs, ValidationError{
-				Message: fmt.Sprintf("distro '%v' decode error: %v", distro.ProviderSettingsListKey, err),
+				Message: errors.Wrapf(err, "distro '%v' decode error", distro.ProviderSettingsListKey).Error(),
 				Level:   Error,
 			})
 			continue

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -78,7 +79,7 @@ func ensureStaticHostsAreNotSpawnable(ctx context.Context, d *distro.Distro, s *
 }
 
 // ensureHasRequiredFields check that the distro configuration has all the required fields
-func ensureHasRequiredFields(ctx context.Context, d *distro.Distro, s *evergreen.Settings) ValidationErrors {
+func ensureHasRequiredFields(ctx context.Context, d *distro.Distro, _ *evergreen.Settings) ValidationErrors {
 	errs := ValidationErrors{}
 
 	if d.Id == "" {
@@ -122,36 +123,77 @@ func ensureHasRequiredFields(ctx context.Context, d *distro.Distro, s *evergreen
 			Level:   Error,
 		})
 	}
-
-	// TODO: this later will need to go through every region to check
-	mgrOpts, err := cloud.GetManagerOptions(*d)
-	if err != nil {
-		return append(errs, ValidationError{
+	if cloud.IsEc2Provider(d.Provider) && len(d.ProviderSettingsList) > 1 {
+		return append(errs, validateMultipleProviderSettings(d)...)
+	}
+	if err := validateSingleProviderSettings(d); err != nil {
+		errs = append(errs, ValidationError{
 			Message: err.Error(),
 			Level:   Error,
 		})
 	}
-	mgr, err := cloud.GetManager(ctx, evergreen.GetEnvironment(), mgrOpts)
-	if err != nil {
-		return append(errs, ValidationError{
-			Message: err.Error(),
-			Level:   Error,
-		})
-	}
+	return errs
+}
 
-	settings := mgr.GetSettings()
-	if err = settings.FromDistroSettings(*d, mgrOpts.Region); err != nil {
-		return append(errs, ValidationError{
-			Message: fmt.Sprintf("distro '%v' decode error: %v", distro.ProviderSettingsKey, err),
-			Level:   Error,
-		})
+func validateMultipleProviderSettings(d *distro.Distro) ValidationErrors {
+	errs := ValidationErrors{}
+	definedRegions := map[string]bool{}
+	for _, doc := range d.ProviderSettingsList {
+		region, ok := doc.Lookup("region").StringValueOK()
+		if !ok {
+			region = evergreen.DefaultEC2Region
+		}
+		if definedRegions[region] {
+			errs = append(errs, ValidationError{
+				Message: fmt.Sprintf("defined region %s more than once", region),
+				Level:   Error,
+			})
+		}
+		definedRegions[region] = true
+		bytes, err := doc.MarshalBSON()
+		if err != nil {
+			errs = append(errs, ValidationError{
+				Message: errors.Wrap(err, "error marshalling provider setting into bson").Error(),
+				Level:   Error,
+			})
+			continue
+		}
+
+		settings := &cloud.EC2ProviderSettings{}
+		if err := bson.Unmarshal(bytes, settings); err != nil {
+			errs = append(errs, ValidationError{
+				Message: errors.Wrap(err, "error unmarshalling bson into provider settings").Error(),
+				Level:   Error,
+			})
+			continue
+		}
+		if err := settings.FromDistroSettings(*d, region); err != nil {
+			errs = append(errs, ValidationError{
+				Message: fmt.Sprintf("distro '%v' decode error: %v", distro.ProviderSettingsListKey, err),
+				Level:   Error,
+			})
+			continue
+		}
+		if err := settings.Validate(); err != nil {
+			errs = append(errs, ValidationError{Error, err.Error()})
+		}
+	}
+	return errs
+}
+
+func validateSingleProviderSettings(d *distro.Distro) error {
+	settings, err := cloud.GetSettings(d.Provider)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if err = settings.FromDistroSettings(*d, ""); err != nil {
+		return errors.Wrapf(err, "distro '%v' decode error", distro.ProviderSettingsKey)
 	}
 
 	if err := settings.Validate(); err != nil {
-		errs = append(errs, ValidationError{Error, err.Error()})
+		return errors.Wrap(err, "error validating settings")
 	}
-
-	return errs
+	return nil
 }
 
 // ensureUniqueId checks that the distro's id does not collide with an existing id.


### PR DESCRIPTION
This ticket was originally to change GetManagerOptions to consider multiple regions, but actually it's always called by host distros (which only have one region defined).

This would only be false in the case of validating multiple provider settings, so the big change was that, and to not GetManager just to unmarshal a settings object.