### PR TITLE
EVG-7314: fix docker tests

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -549,8 +549,8 @@ buildvariants:
     expansions:
       goos: linux
       goarch: amd64
-      gobin: /opt/golang/go1.10/bin/go
-      goroot: /opt/golang/go1.10
+      gobin: /opt/golang/go1.13/bin/go
+      goroot: /opt/golang/go1.13
       legacyGobin: /opt/golang/go1.9/bin/go
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
       test_timeout: 15m


### PR DESCRIPTION
https://evergreen.mongodb.com/build/evergreen_ubuntu1604_docker_patch_1bc18e2b55c47b8e3bcac136c539e42edef45b9b_5e402c1f2a60ed2a3ac25db0_20_02_09_15_58_24