### PR TITLE
EVG-7360: preserve reprovisioning if already set

### DIFF
--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -184,6 +184,20 @@ func needsReprovisioning(d distro.Distro, h *host.Host) host.ReprovisionType {
 		return host.ReprovisionNone
 	}
 
+	// If the host has already been marked as needing reprovisioning before but
+	// has not done the reprovisioned yet, preserve the transition.
+	if h.NeedsReprovision != host.ReprovisionNone {
+		if d.LegacyBootstrap() && h.NeedsReprovision == host.ReprovisionToLegacy {
+			return host.ReprovisionToLegacy
+		}
+		if !d.LegacyBootstrap() && h.NeedsReprovision == host.ReprovisionToNew {
+			return host.ReprovisionToNew
+		}
+		return host.ReprovisionNone
+	}
+
+	// Transition the host to legacy or non-legacy depending on current distro
+	// settings.
 	if h.Distro.LegacyBootstrap() && d.BootstrapSettings.Method != "" && d.BootstrapSettings.Method != distro.BootstrapMethodLegacySSH {
 		return host.ReprovisionToNew
 	}

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -185,7 +185,7 @@ func needsReprovisioning(d distro.Distro, h *host.Host) host.ReprovisionType {
 	}
 
 	// If the host has already been marked as needing reprovisioning before but
-	// has not done the reprovisioned yet, preserve the transition.
+	// has not performed reprovisioning yet, preserve the transition.
 	if h.NeedsReprovision != host.ReprovisionNone {
 		if d.LegacyBootstrap() && h.NeedsReprovision == host.ReprovisionToLegacy {
 			return host.ReprovisionToLegacy

--- a/scheduler/wrapper_test.go
+++ b/scheduler/wrapper_test.go
@@ -76,6 +76,42 @@ func TestNeedsReprovision(t *testing.T) {
 			},
 			expected: host.ReprovisionToLegacy,
 		},
+		"ExistingHostsPreservesExistingReprovisioning": {
+			d: distro.Distro{
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodSSH,
+					Communication: distro.CommunicationMethodSSH,
+				},
+			},
+			h: &host.Host{
+				Distro: distro.Distro{
+					BootstrapSettings: distro.BootstrapSettings{
+						Method:        distro.BootstrapMethodSSH,
+						Communication: distro.CommunicationMethodSSH,
+					},
+				},
+				NeedsReprovision: host.ReprovisionToNew,
+			},
+			expected: host.ReprovisionToNew,
+		},
+		"ExistingLegacyHostsPreservesExistingReprovisioning": {
+			d: distro.Distro{
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodLegacySSH,
+					Communication: distro.CommunicationMethodLegacySSH,
+				},
+			},
+			h: &host.Host{
+				Distro: distro.Distro{
+					BootstrapSettings: distro.BootstrapSettings{
+						Method:        distro.BootstrapMethodLegacySSH,
+						Communication: distro.CommunicationMethodLegacySSH,
+					},
+				},
+				NeedsReprovision: host.ReprovisionToLegacy,
+			},
+			expected: host.ReprovisionToLegacy,
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			assert.Equal(t, testCase.expected, needsReprovisioning(testCase.d, testCase.h))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7360

If we don't do this, the allocator turns off the reprovisioning flag after the first update.