### PR TITLE
EVG-6655 include displayName in WithFields

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1440,7 +1440,7 @@ func FetchVersionsAndAssociatedBuilds(project *Project, skip int, numVersions in
 	// fetch all of the builds (with only relevant fields)
 	buildsFromDb, err := build.Find(
 		build.ByVersions(versionIds).
-			WithFields(build.BuildVariantKey, build.TasksKey, build.VersionKey))
+			WithFields(build.BuildVariantKey, build.TasksKey, build.VersionKey, build.DisplayNameKey))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error fetching builds from database")
 	}

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -445,8 +445,10 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
     _.each($scope.settingsFormData.triggers, function (trigger) {
       if (trigger.command) {
         trigger.generate_file = trigger.file;
+        trigger.config_file = "";
       } else {
         trigger.config_file = trigger.file;
+        trigger.generate_file = "";
       }
       if (trigger.level === "build") {
         delete(trigger.task_regex);


### PR DESCRIPTION
It looks like having empty display names was making the waterfall wonky, and this only happened when the "last good version" had a different config file than the others (in this case, when triggered versions create a "generate" variant; potentially we should _always_ be using build.DisplayName rather than this project mapping but I'm not sure what the argument is either way).

Includes a tiny fix to a triggers bug I hit along the way.