### PR TITLE
EVG-7342: gql error handling

### DIFF
--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -1,0 +1,41 @@
+package graphql
+
+import (
+	"context"
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/vektah/gqlparser/gqlerror"
+)
+
+type GqlError string
+
+const (
+	// InternalServerError conveys that the server errored out when trying to perform an action
+	InternalServerError GqlError = "INTERNAL_SERVER_ERROR"
+	// Forbidden conveys that user does not required permissions to access resource
+	Forbidden GqlError = "FORBIDDEN"
+	// ResourceNotFound conveys the requested resource does not exist
+	ResourceNotFound GqlError = "RESOURCE_NOT_FOUND"
+)
+
+// Send sends a gql error to the client formatted with
+func (err GqlError) Send(ctx context.Context, message string) *gqlerror.Error {
+	switch err {
+	case InternalServerError:
+		return formError(ctx, message, InternalServerError)
+	case Forbidden:
+		return formError(ctx, message, Forbidden)
+	case ResourceNotFound:
+		return formError(ctx, message, ResourceNotFound)
+	default:
+		return gqlerror.ErrorPathf(graphql.GetResolverContext(ctx).Path(), message)
+	}
+}
+
+func formError(ctx context.Context, message string, code GqlError) *gqlerror.Error {
+	return &gqlerror.Error{
+		Message: message,
+		Extensions: map[string]interface{}{
+			"code": code,
+		},
+	}
+}


### PR DESCRIPTION
Create a better system for sending errors in GQL resolvers. Now all errors in resolvers will be associated with an error code. 