### PR TITLE
EVG-7194 don't reload data when changing metric

### DIFF
--- a/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
+++ b/public/static/app/perfdiscovery/PerfDiscoveryDataService.js
@@ -12,6 +12,8 @@ mciModule.factory('PerfDiscoveryDataService', function (
     return resp.data;
   }
 
+  var cachedData = {};
+
   function slug(data) {
     return [
       data.build,
@@ -155,6 +157,7 @@ mciModule.factory('PerfDiscoveryDataService', function (
   //   {...}
   // ]
   function onProcessData(data, metricName) {
+    cachedData = data;
     var now = {},
       baseline = {},
       history = {}
@@ -520,6 +523,13 @@ mciModule.factory('PerfDiscoveryDataService', function (
     )
   }
 
+  function changeMetric(metricName) {
+    let p = new Promise((resolve) => {
+      resolve(cachedData);
+    })
+    return getRows(processData(p, metricName));
+  }
+
   return {
     // public api
     getData: getData,
@@ -529,6 +539,7 @@ mciModule.factory('PerfDiscoveryDataService', function (
     getCompItemVersion: getCompItemVersion,
     getQueryBasedItem: getQueryBasedItem,
     getBFTicketsForRows: getBFTicketsForRows,
+    changeMetric: changeMetric,
 
     // For teting
     _extractTasks: extractTasks,

--- a/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
+++ b/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
@@ -93,8 +93,6 @@ mciModule.controller('PerformanceDiscoveryCtrl', function (
   }
 
   $scope.changeMetric = function () {
-    const fromVersion = vm.fromSelect.selected
-    const toVersion = vm.toSelect.selected
     updateColumnDefs(vm.gridApi.grid);
 
     vm.isLoading = true;

--- a/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
+++ b/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
@@ -92,6 +92,39 @@ mciModule.controller('PerformanceDiscoveryCtrl', function (
     vm.updateData(true);
   }
 
+  $scope.changeMetric = function () {
+    const fromVersion = vm.fromSelect.selected
+    const toVersion = vm.toSelect.selected
+    const expandedCurrent = vm.expandedOptions && vm.expandedOptions.includes("current");
+    const expandedBaseline = vm.expandedOptions && vm.expandedOptions.includes("baseline");
+    const expandedHistory = vm.expandedOptions && vm.expandedOptions.includes("history");
+    updateColumnDefs(vm.gridApi.grid);
+
+    vm.isLoading = true;
+    $q.all({
+        fromVersionObj: dataUtil.getCompItemVersion(fromVersion),
+        toVersionObj: dataUtil.getCompItemVersion(toVersion),
+      })
+      .then(function (promise) {
+        return dataUtil.changeMetric(vm.metric_name);
+      })
+      .then(function (res) {
+        vm.gridOptions.data = res
+        vm.all_metrics = _.chain(res).map(test => test.all_metrics).flatten().uniq().sort().value();
+        // Apply options data to filter drop downs
+        gridUtil.applyMultiselectOptions(
+          res,
+          ['build', 'storageEngine', 'task', 'threads'],
+          vm.gridApi,
+          true
+        );
+        return res
+      })
+      .finally(function () {
+        vm.isLoading = false
+      })
+  }
+
   let oldFromVersion, oldToVersion;
 
   // Convert the name to a revision that can be used to query atlas.

--- a/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
+++ b/public/static/app/perfdiscovery/PerformanceDiscoveryCtrl.js
@@ -95,19 +95,10 @@ mciModule.controller('PerformanceDiscoveryCtrl', function (
   $scope.changeMetric = function () {
     const fromVersion = vm.fromSelect.selected
     const toVersion = vm.toSelect.selected
-    const expandedCurrent = vm.expandedOptions && vm.expandedOptions.includes("current");
-    const expandedBaseline = vm.expandedOptions && vm.expandedOptions.includes("baseline");
-    const expandedHistory = vm.expandedOptions && vm.expandedOptions.includes("history");
     updateColumnDefs(vm.gridApi.grid);
 
     vm.isLoading = true;
-    $q.all({
-        fromVersionObj: dataUtil.getCompItemVersion(fromVersion),
-        toVersionObj: dataUtil.getCompItemVersion(toVersion),
-      })
-      .then(function (promise) {
-        return dataUtil.changeMetric(vm.metric_name);
-      })
+    dataUtil.changeMetric(vm.metric_name)
       .then(function (res) {
         vm.gridOptions.data = res
         vm.all_metrics = _.chain(res).map(test => test.all_metrics).flatten().uniq().sort().value();

--- a/service/templates/perfdiscovery.html
+++ b/service/templates/perfdiscovery.html
@@ -55,7 +55,7 @@ Performance Discovery
 
     <md-input-container style="width: 180px;">
       <label>Metric</label>
-      <md-select ng-model="$ctrl.metric_name" ng-change="reload()">
+      <md-select ng-model="$ctrl.metric_name" ng-change="changeMetric()">
         <md-option ng-value="metric" ng-repeat="metric in $ctrl.all_metrics">[[ metric ]]</md-option>
       </md-select>
     </md-input-container>


### PR DESCRIPTION
Previously we were doing a full load of data from evergreen/cedar when the metric changed. Now we're caching any loads of the data and just filtering the bound data when it changes