### PR TITLE
EVG-7236 add region support to hosts

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -220,7 +220,7 @@ func GetManagerOptions(d distro.Distro) (ManagerOpts, error) {
 			return ManagerOpts{}, errors.Wrapf(err, "error getting EC2 provider settings from distro")
 		}
 
-		return GetEC2ManagerOptionsFromSettings(d.Provider, s), nil
+		return getEC2ManagerOptionsFromSettings(d.Provider, s), nil
 	}
 	if d.Provider == evergreen.ProviderNameMock {
 		return getMockManagerOptions(d.Provider, d.ProviderSettings)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -509,7 +509,7 @@ func IsEc2Provider(provider string) bool {
 		provider == evergreen.ProviderNameEc2Fleet
 }
 
-func GetEC2ManagerOptionsFromSettings(provider string, settings *EC2ProviderSettings) ManagerOpts {
+func getEC2ManagerOptionsFromSettings(provider string, settings *EC2ProviderSettings) ManagerOpts {
 	region := settings.Region
 	if region == "" {
 		region = evergreen.DefaultEC2Region

--- a/globals.go
+++ b/globals.go
@@ -198,6 +198,8 @@ const (
 
 	// TODO: remove this when degrading YAML
 	UseParserProject = false
+	// can flip this when regions are configured
+	UseSpawnHostRegions = false
 )
 
 func IsFinishedTaskStatus(status string) bool {

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -565,8 +565,7 @@ func (d *Distro) SetUserdata(userdata, region string) error {
 		return errors.Wrap(err, "error getting provider setting from list")
 	}
 
-	e := birch.EC.String("user_data", userdata)
-	d.ProviderSettingsList = []*birch.Document{doc.Set(e)}
+	d.ProviderSettingsList = []*birch.Document{doc.Set(birch.EC.String("user_data", userdata))}
 	return nil
 }
 

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -440,7 +440,10 @@ func (d *Distro) GetImageID() (string, error) {
 	}
 
 	if len(d.ProviderSettingsList) == 1 {
-		res, _ := d.ProviderSettingsList[0].Lookup(key).StringValueOK()
+		res, ok := d.ProviderSettingsList[0].Lookup(key).StringValueOK()
+		if !ok {
+			return "", errors.Errorf("provider setting key '%s' is empty", key)
+		}
 		return res, nil
 	}
 	return "", errors.New("provider settings not configured correctly")

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/user"
@@ -160,10 +161,11 @@ func TestGetImageID(t *testing.T) {
 		name           string
 		provider       string
 		key            string
-		value          interface{}
+		value          string
 		expectedOutput string
 		err            bool
 		noKey          bool
+		legacyOnly     bool
 	}{
 		{
 			name:           "Ec2Auto",
@@ -190,8 +192,8 @@ func TestGetImageID(t *testing.T) {
 			name:           "Ec2Fleet",
 			provider:       evergreen.ProviderNameEc2Fleet,
 			key:            "ami",
-			value:          "imageID",
-			expectedOutput: "imageID",
+			value:          "",
+			expectedOutput: "",
 		},
 		{
 			name:           "Docker",
@@ -237,24 +239,19 @@ func TestGetImageID(t *testing.T) {
 			noKey:    true,
 		},
 		{
-			name:     "UnknownProvider",
-			provider: "unknown",
-			noKey:    true,
-			err:      true,
+			name:       "UnknownProvider",
+			provider:   "unknown",
+			noKey:      true,
+			err:        true,
+			legacyOnly: true,
 		},
 		{
-			name:     "InvalidType",
-			provider: evergreen.ProviderNameEc2Auto,
-			key:      "ami",
-			value:    5,
-			err:      true,
-		},
-		{
-			name:     "InvalidKey",
-			provider: evergreen.ProviderNameEc2Auto,
-			key:      "abi",
-			value:    "imageID",
-			err:      true,
+			name:       "InvalidKey",
+			provider:   evergreen.ProviderNameEc2Auto,
+			key:        "abi",
+			value:      "imageID",
+			err:        true,
+			legacyOnly: true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -262,13 +259,22 @@ func TestGetImageID(t *testing.T) {
 			if !test.noKey {
 				providerSettings[test.key] = test.value
 			}
-			distro := Distro{Provider: test.provider, ProviderSettings: &providerSettings}
-			output, err := distro.GetImageID()
-			assert.Equal(t, output, test.expectedOutput)
+			d := Distro{Provider: test.provider, ProviderSettings: &providerSettings}
+			output1, err1 := d.GetImageID()
+
+			doc := birch.NewDocument(birch.EC.String(test.key, test.value))
+			d = Distro{Provider: test.provider, ProviderSettingsList: []*birch.Document{doc}}
+			output2, err2 := d.GetImageID()
+			assert.Equal(t, output1, test.expectedOutput)
+			assert.Equal(t, output2, test.expectedOutput)
 			if test.err {
-				assert.Error(t, err)
+				assert.Error(t, err1)
+				if !test.legacyOnly {
+					assert.Error(t, err2)
+				}
 			} else {
-				assert.NoError(t, err)
+				assert.NoError(t, err1)
+				assert.NoError(t, err2)
 			}
 		})
 	}

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -196,6 +196,12 @@ func TestGetImageID(t *testing.T) {
 			expectedOutput: "",
 		},
 		{
+			name:     "Ec2NoKey",
+			provider: evergreen.ProviderNameEc2Fleet,
+			noKey:    true,
+			err:      true,
+		},
+		{
 			name:           "Docker",
 			provider:       evergreen.ProviderNameDocker,
 			key:            "image_url",
@@ -239,11 +245,10 @@ func TestGetImageID(t *testing.T) {
 			noKey:    true,
 		},
 		{
-			name:       "UnknownProvider",
-			provider:   "unknown",
-			noKey:      true,
-			err:        true,
-			legacyOnly: true,
+			name:     "UnknownProvider",
+			provider: "unknown",
+			noKey:    true,
+			err:      true,
 		},
 		{
 			name:       "InvalidKey",

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -30,6 +30,7 @@ func hostCreate() cli.Command {
 		tagFlagName          = "tag"
 		instanceTypeFlagName = "type"
 		noExpireFlagName     = "no-expire"
+		regionFlagName       = "region"
 	)
 
 	return cli.Command{
@@ -52,6 +53,10 @@ func hostCreate() cli.Command {
 				Name:  joinFlagNames(instanceTypeFlagName, "i"),
 				Usage: "name of an instance type",
 			},
+			cli.StringFlag{
+				Name:  joinFlagNames(regionFlagName, "r"),
+				Usage: "AWS region to spawn host in",
+			},
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(tagFlagName, "t"),
 				Usage: "key=value pair representing an instance tag, with one pair per flag",
@@ -68,6 +73,7 @@ func hostCreate() cli.Command {
 			fn := c.String(scriptFlagName)
 			tagSlice := c.StringSlice(tagFlagName)
 			instanceType := c.String(instanceTypeFlagName)
+			region := c.String(regionFlagName)
 			noExpire := c.Bool(noExpireFlagName)
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -101,6 +107,7 @@ func hostCreate() cli.Command {
 				UserData:     script,
 				InstanceTags: tags,
 				InstanceType: instanceType,
+				Region:       region,
 				NoExpiration: noExpire,
 			}
 

--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -136,7 +136,10 @@ func (tc *DBDistroConnector) FindCostByDistroId(distroId string,
 	// DistroCost model.
 	dc := res[0]
 	dc.Provider = d.Provider
-	dc.ProviderSettings = *(d.ProviderSettings)
+	if d.ProviderSettings != nil {
+		dc.ProviderSettings = *(d.ProviderSettings)
+	}
+	// TODO: handle multiple regions in ProviderSettingsList
 
 	return &dc, nil
 }

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -291,6 +291,7 @@ func (hc *MockHostConnector) NewIntentHost(options *restmodel.HostRequestOptions
 
 	spawnOptions := cloud.SpawnOptions{
 		DistroId:     options.DistroID,
+		Userdata:     options.UserData,
 		UserName:     user.Username(),
 		PublicKey:    keyVal,
 		TaskId:       options.TaskID,

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -29,6 +29,7 @@ type APIHost struct {
 type HostRequestOptions struct {
 	DistroID       string     `json:"distro"`
 	TaskID         string     `json:"task"`
+	Region         string     `json:"region"`
 	KeyName        string     `json:"keyname"`
 	UserData       string     `json:"userdata"`
 	InstanceTags   []host.Tag `json:"instance_tags"`

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -8,10 +8,8 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/birch"
-
-	"github.com/evergreen-ci/evergreen/cloud"
-
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"


### PR DESCRIPTION
Originally I was planning to add Region to the host document, but since we decided to limit ProviderSettingsList to 1 item (to keep the host document tidy) we don't need that anymore.

1. Sets user_data for the list as well as legacy
2. Gets ImageID from the list if legacy isn't provided
3. Pass region up through the create route

