### PR TITLE
EVG-7135	Expand AttachFiles to persist expansion key with artifact

### DIFF
--- a/command/s3_put.go
+++ b/command/s3_put.go
@@ -69,6 +69,7 @@ type s3put struct {
 	//  "private", which allows logged-in users to see the file;
 	//  "public", which allows anyone to see the file; or
 	//  "none", which hides the file from the UI for everybody.
+	//  "signed" which grants access to private S3 objects to logged-in users
 	// If unset, the file will be public.
 	Visibility string `mapstructure:"visibility" plugin:"expand"`
 
@@ -379,6 +380,8 @@ func (s3pc *s3put) attachFiles(ctx context.Context, comm client.Communicator, lo
 			Name:       displayName,
 			Link:       fileLink,
 			Visibility: s3pc.Visibility,
+			AwsKey:     s3pc.AwsKey,
+			AwsSecret:  s3pc.AwsSecret,
 		})
 	}
 

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -38,7 +38,7 @@ type File struct {
 	Visibility string `json:"visibility" bson:"visibility"`
 	// When true, these artifacts are excluded from reproduction
 	IgnoreForFetch bool `bson:"fetch_ignore,omitempty" json:"ignore_for_fetch"`
-	//AwsKey and AwsSercret and the key and secret with which the file was uploaded to s3
+	//AwsKey and AwsSercret are the key and secret with which the file was uploaded to s3
 	AwsKey    string `json:"aws_key" bson:"aws_key"`
 	AwsSecret string `json:"aws_secret" bson:"aws_secret"`
 }

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -38,6 +38,9 @@ type File struct {
 	Visibility string `json:"visibility" bson:"visibility"`
 	// When true, these artifacts are excluded from reproduction
 	IgnoreForFetch bool `bson:"fetch_ignore,omitempty" json:"ignore_for_fetch"`
+	//AwsKey and AwsSercret and the key and secret with which the file was uploaded to s3
+	AwsKey    string `json:"aws_key" bson:"aws_key"`
+	AwsSecret string `json:"aws_secret" bson:"aws_secret"`
 }
 
 // Array turns the parameter map into an array of File structs.

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -27,8 +27,22 @@ func (s *TestArtifactFileSuite) SetupTest() {
 			TaskDisplayName: "Task One",
 			BuildId:         "build1",
 			Files: []File{
-				{"cat_pix", "http://placekitten.com/800/600", "", false},
-				{"fast_download", "https://fastdl.mongodb.org", "", false},
+				{
+					Name:           "cat_pix",
+					Link:           "http://placekitten.com/800/600",
+					Visibility:     "",
+					IgnoreForFetch: false,
+					AwsKey:         "key",
+					AwsSecret:      "secret",
+				},
+				{
+					Name:           "fast_download",
+					Link:           "https://fastdl.mongodb.org",
+					Visibility:     "",
+					IgnoreForFetch: false,
+					AwsKey:         "key",
+					AwsSecret:      "secret",
+				},
 			},
 			Execution: 1,
 		},
@@ -37,7 +51,14 @@ func (s *TestArtifactFileSuite) SetupTest() {
 			TaskDisplayName: "Task Two",
 			BuildId:         "build2",
 			Files: []File{
-				{"other", "http://example.com/other", "", false},
+				{
+					Name:           "other",
+					Link:           "http://example.com/other",
+					Visibility:     "",
+					IgnoreForFetch: false,
+					AwsKey:         "key",
+					AwsSecret:      "secret",
+				},
 			},
 			Execution: 5,
 		},
@@ -55,7 +76,14 @@ func (s *TestArtifactFileSuite) SetupTest() {
 		TaskDisplayName: "Task Two",
 		BuildId:         "build2",
 		Files: []File{
-			{"other", "http://example.com/other", "", false},
+			{
+				Name:           "other",
+				Link:           "http://example.com/other",
+				Visibility:     "",
+				IgnoreForFetch: false,
+				AwsKey:         "key",
+				AwsSecret:      "secret",
+			},
 		},
 	}))
 
@@ -85,8 +113,22 @@ func (s *TestArtifactFileSuite) TestArtifactFieldsArePresent() {
 
 func (s *TestArtifactFileSuite) TestArtifactFieldsAfterUpdate() {
 	s.testEntries[0].Files = []File{
-		{"cat_pix", "http://placekitten.com/300/400", "", false},
-		{"the_value_of_four", "4", "", false},
+		{
+			Name:           "cat_pix",
+			Link:           "http://placekitten.com/300/400",
+			Visibility:     "",
+			IgnoreForFetch: false,
+			AwsKey:         "key",
+			AwsSecret:      "secret",
+		},
+		{
+			Name:           "the_value_of_four",
+			Link:           "4",
+			Visibility:     "",
+			IgnoreForFetch: false,
+			AwsKey:         "key",
+			AwsSecret:      "secret",
+		},
 	}
 	s.NoError(s.testEntries[0].Upsert())
 


### PR DESCRIPTION
[EVG-7135](https://jira.mongodb.org/browse/EVG-7135)

Note: I realized that I shouldn't always save the key and secret, but instead ONLY save it when the user want's a presigned url. I'm working on that change now. 