### PR TITLE
EVG-7135 Expand AttachFiles to persist expansion key with artifact

### DIFF
--- a/command/s3_put.go
+++ b/command/s3_put.go
@@ -69,6 +69,7 @@ type s3put struct {
 	//  "private", which allows logged-in users to see the file;
 	//  "public", which allows anyone to see the file; or
 	//  "none", which hides the file from the UI for everybody.
+	//  "signed" which grants access to private S3 objects to logged-in users
 	// If unset, the file will be public.
 	Visibility string `mapstructure:"visibility" plugin:"expand"`
 
@@ -374,11 +375,18 @@ func (s3pc *s3put) attachFiles(ctx context.Context, comm client.Communicator, lo
 		if s3pc.isMulti() || displayName == "" {
 			displayName = fmt.Sprintf("%s %s", s3pc.ResourceDisplayName, filepath.Base(fn))
 		}
+		var key, secret string
+		if s3pc.Visibility == "signed" {
+			key = s3pc.AwsKey
+			secret = s3pc.AwsSecret
+		}
 
 		files = append(files, &artifact.File{
 			Name:       displayName,
 			Link:       fileLink,
 			Visibility: s3pc.Visibility,
+			AwsKey:     key,
+			AwsSecret:  secret,
 		})
 	}
 

--- a/command/s3_put_test.go
+++ b/command/s3_put_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -308,7 +307,6 @@ func TestSignedUrlVisibility(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	for _, vis := range []string{"signed", "private"} {
-		var err error
 		s := s3put{
 			AwsKey:        "key",
 			AwsSecret:     "secret",
@@ -336,17 +334,15 @@ func TestSignedUrlVisibility(t *testing.T) {
 		require.NoError(t, s.attachFiles(ctx, comm, logger, localFiles, remoteFile))
 
 		attachedFiles := comm.AttachedFiles
-		assert := assert.New(t)
 		if v, found := attachedFiles[""]; found {
-			fmt.Println(v)
 			for _, file := range v {
 				if file.Visibility == artifact.Signed {
-					assert.Equal(file.AwsKey, s.AwsKey)
-					assert.Equal(file.AwsSecret, s.AwsSecret)
+					assert.Equal(t, file.AwsKey, s.AwsKey)
+					assert.Equal(t, file.AwsSecret, s.AwsSecret)
 
 				} else {
-					assert.Equal(file.AwsKey, "")
-					assert.Equal(file.AwsSecret, "")
+					assert.Equal(t, file.AwsKey, "")
+					assert.Equal(t, file.AwsSecret, "")
 				}
 			}
 		}

--- a/command/s3_put_test.go
+++ b/command/s3_put_test.go
@@ -309,9 +309,9 @@ func TestExpandS3PutParams(t *testing.T) {
 }
 
 func TestSignedUrlVisibility(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	for _, vis := range []string{"signed", "private"} {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 		var err error
 		s := s3put{
 			AwsKey:        "key",

--- a/command/s3_put_test.go
+++ b/command/s3_put_test.go
@@ -20,10 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	signedConst = "signed"
-)
-
 func TestS3PutValidateParams(t *testing.T) {
 
 	Convey("With an s3 put command", t, func() {

--- a/command/s3_put_test.go
+++ b/command/s3_put_test.go
@@ -374,7 +374,6 @@ func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
 			} else {
 				localFilesIncludeFilterPrefix = prefix
 			}
-			//set visibility based on the prefix
 			s := s3put{
 				AwsKey:                        "key",
 				AwsSecret:                     "secret",

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -7,9 +7,10 @@ const (
 	Public  = "public"
 	Private = "private"
 	None    = "none"
+	Signed  = "signed"
 )
 
-var ValidVisibilities = []string{Public, Private, None, ""}
+var ValidVisibilities = []string{Public, Private, None, Signed, ""}
 
 // Entry stores groups of names and links (not content!) for
 // files uploaded to the api server by a running agent. These links could
@@ -38,6 +39,9 @@ type File struct {
 	Visibility string `json:"visibility" bson:"visibility"`
 	// When true, these artifacts are excluded from reproduction
 	IgnoreForFetch bool `bson:"fetch_ignore,omitempty" json:"ignore_for_fetch"`
+	//AwsKey and AwsSercret are the key and secret with which the file was uploaded to s3
+	AwsKey    string `json:"aws_key" bson:"aws_key"`
+	AwsSecret string `json:"aws_secret" bson:"aws_secret"`
 }
 
 // Array turns the parameter map into an array of File structs.

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -40,9 +40,9 @@ type File struct {
 	// When true, these artifacts are excluded from reproduction
 	IgnoreForFetch bool `bson:"fetch_ignore,omitempty" json:"ignore_for_fetch"`
 	//AwsKey is the key with which the file was uploaded to s3
-	AwsKey string `json:"aws_key,omitempty" bson:"aws_key"`
+	AwsKey string `json:"aws_key,omitempty" bson:"aws_key,omitempty"`
 	//AwsSercret is the secret with which the file was uploaded to s3
-	AwsSecret string `json:"aws_secret,omitempty" bson:"aws_secret"`
+	AwsSecret string `json:"aws_secret,omitempty" bson:"aws_secret,omitempty"`
 }
 
 // Array turns the parameter map into an array of File structs.

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -39,9 +39,10 @@ type File struct {
 	Visibility string `json:"visibility" bson:"visibility"`
 	// When true, these artifacts are excluded from reproduction
 	IgnoreForFetch bool `bson:"fetch_ignore,omitempty" json:"ignore_for_fetch"`
-	//AwsKey and AwsSercret are the key and secret with which the file was uploaded to s3
-	AwsKey    string `json:"aws_key" bson:"aws_key"`
-	AwsSecret string `json:"aws_secret" bson:"aws_secret"`
+	//AwsKey is the key with which the file was uploaded to s3
+	AwsKey string `json:"aws_key,omitempty" bson:"aws_key"`
+	//AwsSercret is the secret with which the file was uploaded to s3
+	AwsSecret string `json:"aws_secret,omitempty" bson:"aws_secret"`
 }
 
 // Array turns the parameter map into an array of File structs.

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -27,8 +27,22 @@ func (s *TestArtifactFileSuite) SetupTest() {
 			TaskDisplayName: "Task One",
 			BuildId:         "build1",
 			Files: []File{
-				{"cat_pix", "http://placekitten.com/800/600", "", false},
-				{"fast_download", "https://fastdl.mongodb.org", "", false},
+				{
+					Name:           "cat_pix",
+					Link:           "http://placekitten.com/800/600",
+					Visibility:     "",
+					IgnoreForFetch: false,
+					AwsKey:         "key",
+					AwsSecret:      "secret",
+				},
+				{
+					Name:           "fast_download",
+					Link:           "https://fastdl.mongodb.org",
+					Visibility:     "",
+					IgnoreForFetch: false,
+					AwsKey:         "key",
+					AwsSecret:      "secret",
+				},
 			},
 			Execution: 1,
 		},
@@ -37,7 +51,14 @@ func (s *TestArtifactFileSuite) SetupTest() {
 			TaskDisplayName: "Task Two",
 			BuildId:         "build2",
 			Files: []File{
-				{"other", "http://example.com/other", "", false},
+				{
+					Name:           "other",
+					Link:           "http://example.com/other",
+					Visibility:     "",
+					IgnoreForFetch: false,
+					AwsKey:         "key",
+					AwsSecret:      "secret",
+				},
 			},
 			Execution: 5,
 		},
@@ -55,7 +76,14 @@ func (s *TestArtifactFileSuite) SetupTest() {
 		TaskDisplayName: "Task Two",
 		BuildId:         "build2",
 		Files: []File{
-			{"other", "http://example.com/other", "", false},
+			{
+				Name:           "other",
+				Link:           "http://example.com/other",
+				Visibility:     "",
+				IgnoreForFetch: false,
+				AwsKey:         "key",
+				AwsSecret:      "secret",
+			},
 		},
 	}))
 
@@ -85,8 +113,22 @@ func (s *TestArtifactFileSuite) TestArtifactFieldsArePresent() {
 
 func (s *TestArtifactFileSuite) TestArtifactFieldsAfterUpdate() {
 	s.testEntries[0].Files = []File{
-		{"cat_pix", "http://placekitten.com/300/400", "", false},
-		{"the_value_of_four", "4", "", false},
+		{
+			Name:           "cat_pix",
+			Link:           "http://placekitten.com/300/400",
+			Visibility:     "",
+			IgnoreForFetch: false,
+			AwsKey:         "key",
+			AwsSecret:      "secret",
+		},
+		{
+			Name:           "the_value_of_four",
+			Link:           "4",
+			Visibility:     "",
+			IgnoreForFetch: false,
+			AwsKey:         "key",
+			AwsSecret:      "secret",
+		},
 	}
 	s.NoError(s.testEntries[0].Upsert())
 

--- a/service/task.go
+++ b/service/task.go
@@ -398,8 +398,6 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	}{uiTask, taskHost, pluginContent, uis.Settings.Jira.Host, isAdmin, permissions, uis.GetCommonViewData(w, r, false, true)}, "base", "task.html", "base_angular.html", "menu.html")
 }
 
- //find where the url is created. update to a signedUrl. 
-
 type taskHistoryPageData struct {
 	TaskName    string
 	Tasks       []bson.M

--- a/service/task.go
+++ b/service/task.go
@@ -398,6 +398,8 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	}{uiTask, taskHost, pluginContent, uis.Settings.Jira.Host, isAdmin, permissions, uis.GetCommonViewData(w, r, false, true)}, "base", "task.html", "base_angular.html", "menu.html")
 }
 
+ //find where the url is created. update to a signedUrl. 
+
 type taskHistoryPageData struct {
 	TaskName    string
 	Tasks       []bson.M


### PR DESCRIPTION
Note: I know that the testing is probably a bit overkill, but it helped me verify that it is working as expected. Should I leave it in there, or remove it? 