### PR TITLE
EVG-7226 Check if LocalFile is absolute after expanding values

### DIFF
--- a/command/s3_put.go
+++ b/command/s3_put.go
@@ -157,15 +157,15 @@ func (s3pc *s3put) validate() error {
 // Apply the expansions from the relevant task config to all appropriate
 // fields of the s3put.
 func (s3pc *s3put) expandParams(conf *model.TaskConfig) error {
+	var err error
+	if err = util.ExpandValues(s3pc, conf.Expansions); err != nil {
+		return errors.WithStack(err)
+	}
+
 	if filepath.IsAbs(s3pc.LocalFile) {
 		s3pc.workDir = ""
 	} else {
 		s3pc.workDir = conf.WorkDir
-	}
-
-	var err error
-	if err = util.ExpandValues(s3pc, conf.Expansions); err != nil {
-		return errors.WithStack(err)
 	}
 
 	if s3pc.Optional != "" {

--- a/command/s3_put_test.go
+++ b/command/s3_put_test.go
@@ -230,10 +230,13 @@ func TestS3PutValidateParams(t *testing.T) {
 func TestExpandS3PutParams(t *testing.T) {
 
 	Convey("With an s3 put command and a task config", t, func() {
+		abs, err := filepath.Abs("working_directory")
+		So(err, ShouldBeNil)
+
 		cmd := &s3put{}
 		conf := &model.TaskConfig{
 			Expansions: util.NewExpansions(map[string]string{}),
-			WorkDir:    "/working_directory",
+			WorkDir:    abs,
 		}
 
 		Convey("when expanding the command's params all appropriate values should be expanded, if they"+
@@ -247,7 +250,7 @@ func TestExpandS3PutParams(t *testing.T) {
 			cmd.ResourceDisplayName = "${display_name}"
 			cmd.Visibility = "${visibility}"
 			cmd.Optional = "${optional}"
-			cmd.LocalFile = "${workdir}/foo"
+			cmd.LocalFile = abs
 
 			conf.Expansions.Update(
 				map[string]string{

--- a/command/s3_put_test.go
+++ b/command/s3_put_test.go
@@ -233,7 +233,7 @@ func TestExpandS3PutParams(t *testing.T) {
 		cmd := &s3put{}
 		conf := &model.TaskConfig{
 			Expansions: util.NewExpansions(map[string]string{}),
-			WorkDir:    "working_directory",
+			WorkDir:    "/working_directory",
 		}
 
 		Convey("when expanding the command's params all appropriate values should be expanded, if they"+

--- a/command/s3_put_test.go
+++ b/command/s3_put_test.go
@@ -247,6 +247,7 @@ func TestExpandS3PutParams(t *testing.T) {
 			cmd.ResourceDisplayName = "${display_name}"
 			cmd.Visibility = "${visibility}"
 			cmd.Optional = "${optional}"
+			cmd.LocalFile = "${workdir}/foo"
 
 			conf.Expansions.Update(
 				map[string]string{
@@ -269,9 +270,10 @@ func TestExpandS3PutParams(t *testing.T) {
 			So(cmd.ContentType, ShouldEqual, "ct")
 			So(cmd.ResourceDisplayName, ShouldEqual, "file")
 			So(cmd.Visibility, ShouldEqual, "private")
-			So(cmd.workDir, ShouldEqual, "working_directory")
 			So(cmd.Optional, ShouldEqual, "true")
 
+			// EVG-7226 Since LocalFile is an absolute path, workDir should be empty
+			So(cmd.workDir, ShouldEqual, "")
 		})
 
 		Convey("the expandParams function should error for invalid optional values", func() {

--- a/command/s3_put_test.go
+++ b/command/s3_put_test.go
@@ -259,6 +259,7 @@ func TestExpandS3PutParams(t *testing.T) {
 					"display_name": "file",
 					"optional":     "true",
 					"visibility":   artifact.Private,
+					"workdir":      "/working_directory",
 				},
 			)
 


### PR DESCRIPTION
Prior to this commit s3.put checked if LocalFile was an absolute path before 
expanding values. This means that if a user provided an expansion in LocalPath
which made it absolute, s3.put would behave as if it were local. This commit
inverts the order, expanding values before checking if the path is absolute.