### PR TITLE
EVG-7334: clean up host provisioning

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -1,7 +1,6 @@
 package cloud
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -178,23 +177,16 @@ func SetHostRDPPassword(ctx context.Context, env evergreen.Environment, host *ho
 		return errors.Wrap(err, "Error constructing host RDP password")
 	}
 
-	stdout := &util.CappedWriter{
-		Buffer:   &bytes.Buffer{},
-		MaxBytes: 1024 * 1024,
-	}
-
-	stderr := &util.CappedWriter{
-		Buffer:   &bytes.Buffer{},
-		MaxBytes: 1024 * 1024,
-	}
+	stdout := util.NewMBCappedWriter()
+	stderr := util.NewMBCappedWriter()
 
 	pwdUpdateCmd.SetErrorWriter(stderr).SetOutputWriter(stdout)
 
 	// update RDP and sshd password
 	if err = pwdUpdateCmd.Run(ctx); err != nil {
 		grip.Warning(message.Fields{
-			"stdout":    stdout.Buffer.String(),
-			"stderr":    stderr.Buffer.String(),
+			"stdout":    stdout.String(),
+			"stderr":    stderr.String(),
 			"operation": "set host rdp password",
 			"host_id":   host.Id,
 			"cmd":       pwdUpdateCmd.String(),
@@ -204,8 +196,8 @@ func SetHostRDPPassword(ctx context.Context, env evergreen.Environment, host *ho
 	}
 
 	grip.Debug(message.Fields{
-		"stdout":    stdout.Buffer.String(),
-		"stderr":    stderr.Buffer.String(),
+		"stdout":    stdout.String(),
+		"stderr":    stderr.String(),
 		"operation": "set host rdp password",
 		"host_id":   host.Id,
 		"cmd":       pwdUpdateCmd.String(),

--- a/cloud/user_data.go
+++ b/cloud/user_data.go
@@ -56,7 +56,8 @@ func makeMultipartUserData(files map[string]string) (string, error) {
 	return buf.String(), nil
 }
 
-// writeUserDataHeaders writes the multipart MIME headers for user data.
+// writeUserDataHeaders writes the required multipart MIME headers for user
+// data.
 func writeUserDataHeaders(writer io.Writer, boundary string) error {
 	topLevelHeaders := textproto.MIMEHeader{}
 	topLevelHeaders.Add("MIME-Version", "1.0")
@@ -130,7 +131,9 @@ func parseUserDataContentType(userData string) (string, error) {
 }
 
 // bootstrapUserData returns the multipart user data with logic to bootstrap and
-// set up the host and the custom user data.
+// set up the host and the custom user data. Care should be taken when adding
+// more to this script, since the script length is subject to a 16 kB hard limit
+// (https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#RunInstancesInput).
 func bootstrapUserData(ctx context.Context, env evergreen.Environment, h *host.Host, customScript string) (string, error) {
 	if h.Distro.BootstrapSettings.Method != distro.BootstrapMethodUserData {
 		return customScript, nil

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -74,11 +74,6 @@ type BootstrapSettings struct {
 	ResourceLimits ResourceLimits `bson:"resource_limits,omitempty" json:"resource_limits,omitempty" mapstructure:"resource_limits,omitempty"`
 }
 
-type HomeVolumeSettings struct {
-	DeviceName    string `bson:"device_name" json:"device_name" mapstructure:"device_name"`
-	FormatCommand string `bson:"format_command" json:"format_command" mapstructure:"format_command"`
-}
-
 type EnvVar struct {
 	Key   string `bson:"key" json:"key"`
 	Value string `bson:"value" json:"value"`
@@ -90,6 +85,11 @@ type ResourceLimits struct {
 	NumProcesses    int `bson:"num_processes,omitempty" json:"num_processes,omitempty" mapstructure:"num_processes,omitempty"`
 	LockedMemoryKB  int `bson:"locked_memory,omitempty" json:"locked_memory,omitempty" mapstructure:"locked_memory,omitempty"`
 	VirtualMemoryKB int `bson:"virtual_memory,omitempty" json:"virtual_memory,omitempty" mapstructure:"virtual_memory,omitempty"`
+}
+
+type HomeVolumeSettings struct {
+	DeviceName    string `bson:"device_name" json:"device_name" mapstructure:"device_name"`
+	FormatCommand string `bson:"format_command" json:"format_command" mapstructure:"format_command"`
 }
 
 func (d *Distro) SetBSON(raw mgobson.Raw) error {
@@ -141,6 +141,11 @@ func (d *Distro) ValidateBootstrapSettings() error {
 	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.VirtualMemoryKB < -1, "max virtual memory should be a positive number or -1")
 
 	return catcher.Resolve()
+}
+
+// ShellPath returns the native path to the shell binary.
+func (d *Distro) ShellBinary() string {
+	return filepath.Join(d.BootstrapSettings.RootDir, d.BootstrapSettings.ShellPath)
 }
 
 type HostAllocatorSettings struct {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2251,6 +2251,10 @@ func FindHostWithVolume(volumeID string) (*Host, error) {
 // FindStaticNeedsNewSSHKeys finds all static hosts that do not have the same
 // set of SSH keys as those in the global settings.
 func FindStaticNeedsNewSSHKeys(settings *evergreen.Settings) ([]Host, error) {
+	if len(settings.SSHKeyPairs) == 0 {
+		return nil, nil
+	}
+
 	names := []string{}
 	for _, pair := range settings.SSHKeyPairs {
 		names = append(names, pair.Name)

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -336,11 +336,6 @@ type SpawnHostUsage struct {
 const (
 	MaxLCTInterval = 5 * time.Minute
 
-	// Potential init systems supported by a Linux host.
-	InitSystemSystemd = "systemd"
-	InitSystemSysV    = "sysv"
-	InitSystemUpstart = "upstart"
-
 	// Max number of spawn hosts with no expiration for user
 	DefaultUnexpirableHostsPerUser = 1
 	// Max total EBS volume size for user

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -394,7 +394,7 @@ func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Cr
 		bashCmds = append(bashCmds, fetchClient, h.SetupCommand(), postFetchClient, markDone)
 
 		for i := range bashCmds {
-			bashCmds[i] = fmt.Sprintf("%s -l -c %s", filepath.Join(h.Distro.BootstrapSettings.RootDir, h.Distro.BootstrapSettings.ShellPath), util.PowerShellQuotedString(bashCmds[i]))
+			bashCmds[i] = fmt.Sprintf("%s -l -c %s", h.Distro.ShellBinary(), util.PowerShellQuotedString(bashCmds[i]))
 		}
 
 		powershellCmds := append(append([]string{
@@ -452,7 +452,7 @@ func (h *Host) SetupServiceUserCommands() (string, error) {
 			cmd(fmt.Sprintf(`wmic useraccount where name="%s" set passwordexpires=false`, h.Distro.BootstrapSettings.ServiceUser)),
 			// Allow the user to run the service by granting the "Log on as a
 			// service" right.
-			fmt.Sprintf(`%s -l -c 'editrights -u %s -a SeServiceLogonRight'`, filepath.Join(h.Distro.BootstrapSettings.RootDir, h.Distro.BootstrapSettings.ShellPath), h.Distro.BootstrapSettings.ServiceUser),
+			fmt.Sprintf(`%s -l -c 'editrights -u %s -a SeServiceLogonRight'`, h.Distro.ShellBinary(), h.Distro.BootstrapSettings.ServiceUser),
 		}, "\n"), nil
 }
 

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -216,7 +216,7 @@ func (h *Host) runSSHCommandWithOutput(ctx context.Context, addCommands func(*ja
 	output := util.NewMBCappedWriter()
 
 	var cancel context.CancelFunc
-	if timeout != time.Duration(0) {
+	if timeout != 0 {
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	} else {

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -199,8 +199,10 @@ func (h *Host) RunSSHShellScript(ctx context.Context, script string, sshOpts []s
 // RunSSHShellScript runs a shell script on a remote host over SSH with the
 // given timeout.
 func (h *Host) RunSSHShellScriptWithTimeout(ctx context.Context, script string, sshOpts []string, timeout time.Duration) (string, error) {
+	// We read the shell script verbatim from stdin  (i.e. with "bash -s"
+	// instead of "bash -c") to avoid additional shell processing.
 	return h.runSSHCommandWithOutput(ctx, func(c *jasper.Command) *jasper.Command {
-		return c.ShellScript("bash", script)
+		return c.Bash("-s").SetInputBytes([]byte(script))
 	}, sshOpts, timeout)
 }
 

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1067,7 +1067,7 @@ func TestSetupSpawnHostCommands(t *testing.T) {
 	currIndex := 0
 	for _, arg := range fetchCmd {
 		foundIndex := strings.Index(cmd[currIndex:], arg)
-		require.NotEqual(t, foundIndex, -1)
+		require.NotEqual(t, foundIndex, -1, "missing fetch command arg '%s'", arg)
 		currIndex += foundIndex
 	}
 }

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -239,7 +239,7 @@ func TestJasperCommands(t *testing.T) {
 			setupScript, err := h.setupScriptCommands(settings)
 			require.NoError(t, err)
 
-			setupSpawnHost, err := h.SetupSpawnHostCommands(settings)
+			setupSpawnHost, err := h.SpawnHostSetupCommands(settings)
 			require.NoError(t, err)
 
 			markDone, err := h.MarkUserDataDoneCommands()
@@ -445,7 +445,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 			writeCredentialsCmd, err := h.bufferedWriteJasperCredentialsFilesCommands(settings.Splunk, creds)
 			require.NoError(t, err)
 
-			setupSpawnHost, err := h.SetupSpawnHostCommands(settings)
+			setupSpawnHost, err := h.SpawnHostSetupCommands(settings)
 			require.NoError(t, err)
 
 			markDone, err := h.MarkUserDataDoneCommands()
@@ -1013,7 +1013,7 @@ func TestStopAgentMonitor(t *testing.T) {
 	}
 }
 
-func TestSetupSpawnHostCommands(t *testing.T) {
+func TestSpawnHostSetupCommands(t *testing.T) {
 	require.NoError(t, db.ClearCollections(Collection, user.Collection))
 	defer func() {
 		assert.NoError(t, db.ClearCollections(Collection, user.Collection))
@@ -1048,7 +1048,7 @@ func TestSetupSpawnHostCommands(t *testing.T) {
 		},
 	}
 
-	cmd, err := h.SetupSpawnHostCommands(settings)
+	cmd, err := h.SpawnHostSetupCommands(settings)
 	require.NoError(t, err)
 
 	expected := "mkdir -m 777 -p /home/user/cli_bin" +
@@ -1060,7 +1060,7 @@ func TestSetupSpawnHostCommands(t *testing.T) {
 	assert.Equal(t, expected, cmd)
 
 	h.ProvisionOptions.TaskId = "task_id"
-	cmd, err = h.SetupSpawnHostCommands(settings)
+	cmd, err = h.SpawnHostSetupCommands(settings)
 	assert.Contains(t, cmd, expected)
 	require.NoError(t, err)
 	fetchCmd := []string{"/home/user/evergreen", "-c", "/home/user/cli_bin/.evergreen.yml", "fetch", "-t", "task_id", "--source", "--artifacts", "--dir", "/dir"}

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -8,9 +8,7 @@ import (
 	"math"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -834,21 +832,6 @@ func TestBufferedWriteFileCommands(t *testing.T) {
 func TestTearDownDirectlyCommand(t *testing.T) {
 	cmd := TearDownDirectlyCommand()
 	assert.Equal(t, "chmod +x teardown.sh && sh teardown.sh", cmd)
-}
-
-func TestInitSystemCommand(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("init system test is relevant to Linux only")
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", initSystemCommand())
-	res, err := cmd.Output()
-	require.NoError(t, err)
-	initSystem := strings.TrimSpace(string(res))
-	assert.Contains(t, []string{InitSystemSystemd, InitSystemSysV, InitSystemUpstart}, initSystem)
 }
 
 func TestBuildLocalJasperClientRequest(t *testing.T) {

--- a/operations/host_setup.go
+++ b/operations/host_setup.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"time"
@@ -69,6 +70,9 @@ func runScript(ctx context.Context, wd, scriptFileName, tempFileName string, run
 	catcher := grip.NewSimpleCatcher()
 
 	out, err = runScript.CombinedOutput()
+	if err == nil {
+		fmt.Println(string(out))
+	}
 	catcher.Add(err)
 	catcher.Add(os.Remove(tempFileName))
 
@@ -85,12 +89,12 @@ func hostTeardown() cli.Command {
 			ctx, cancel := context.WithTimeout(context.Background(), setupTimeout)
 			defer cancel()
 
-			return errors.WithStack(runHostTeardownScript(ctx))
+			return errors.WithStack(runTeardownScript(ctx))
 		},
 	}
 }
 
-func runHostTeardownScript(ctx context.Context) error {
+func runTeardownScript(ctx context.Context) error {
 	if _, err := os.Stat(evergreen.TeardownScriptName); os.IsNotExist(err) {
 		return errors.Errorf("no teardown script '%s' found", evergreen.TeardownScriptName)
 	}
@@ -103,6 +107,9 @@ func runHostTeardownScript(ctx context.Context) error {
 
 	cmd := host.ShCommandWithSudo(ctx, evergreen.TeardownScriptName, false)
 	out, err = cmd.CombinedOutput()
+	if err == nil {
+		fmt.Println(string(out))
+	}
 	if err != nil {
 		return errors.Wrap(err, string(out))
 	}

--- a/operations/host_spawn_test.go
+++ b/operations/host_spawn_test.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -35,10 +34,7 @@ func TestHostRsync(t *testing.T) {
 			return "", err
 		}
 
-		output := &util.CappedWriter{
-			Buffer:   &bytes.Buffer{},
-			MaxBytes: 1024 * 1024,
-		}
+		output := util.NewMBCappedWriter()
 
 		err = jasper.NewCommand().Add([]string{cygpath, "-u", path}).SetCombinedWriter(output).Run(ctx)
 		return strings.TrimSpace(output.String()), err

--- a/operations/host_test.go
+++ b/operations/host_test.go
@@ -68,11 +68,11 @@ func TestHostSetupScript(t *testing.T) {
 func TestHostSudoShHelper(t *testing.T) {
 	assert := assert.New(t)
 
-	cmd := host.ShCommandWithSudo(context.Background(), "foo", false)
-	assert.Equal([]string{"sh", "foo"}, cmd.Args)
+	cmd := host.ShCommandWithSudo("foo", false)
+	assert.Equal([]string{"sh", "foo"}, cmd)
 
-	cmd = host.ShCommandWithSudo(context.Background(), "foo", true)
-	assert.Equal([]string{"sudo", "sh", "foo"}, cmd.Args)
+	cmd = host.ShCommandWithSudo("foo", true)
+	assert.Equal([]string{"sudo", "sh", "foo"}, cmd)
 }
 
 func TestHostTeardownScript(t *testing.T) {
@@ -90,7 +90,7 @@ func TestHostTeardownScript(t *testing.T) {
 	defer os.Remove(evergreen.TeardownScriptName)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = runHostTeardownScript(ctx)
+	err = runTeardownScript(ctx)
 	assert.NoError(err)
 
 	// Script should time out with context and return an error
@@ -99,7 +99,7 @@ func TestHostTeardownScript(t *testing.T) {
 	ctx, cancel = context.WithTimeout(context.Background(), time.Nanosecond)
 	defer cancel()
 	time.Sleep(time.Millisecond)
-	err = runHostTeardownScript(ctx)
+	err = runTeardownScript(ctx)
 	assert.Error(err)
 	assert.Contains(err.Error(), "context deadline exceeded")
 
@@ -109,7 +109,7 @@ func TestHostTeardownScript(t *testing.T) {
 	require.NoError(err)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Nanosecond)
 	defer cancel()
-	err = runHostTeardownScript(ctx)
+	err = runTeardownScript(ctx)
 	assert.Error(err)
 
 }

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -128,7 +128,7 @@ func setCloudHostStatus(ctx context.Context, m cloud.Manager, h host.Host, hostS
 	}
 	grip.Info(message.Fields{
 		"message": "host not ready for setup",
-		"hostid":  h.Id,
+		"host_id": h.Id,
 		"DNS":     h.Host,
 		"distro":  h.Distro.Id,
 		"runner":  "hostinit",

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -173,29 +173,29 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 		}
 	}()
 
-	j.AddError(j.startAgentOnHost(ctx, settings, *j.host))
+	j.AddError(j.startAgentOnHost(ctx, settings))
 }
 
 // SSHTimeout defines the timeout for the SSH commands in this package.
 const sshTimeout = 25 * time.Second
 
-func (j *agentDeployJob) getHostMessage(h host.Host) message.Fields {
+func (j *agentDeployJob) getHostMessage() message.Fields {
 	m := message.Fields{
 		"message":  "starting agent on host",
 		"runner":   "taskrunner",
-		"host_id":  h.Host,
-		"distro":   h.Distro.Id,
-		"provider": h.Distro.Provider,
+		"host_id":  j.host.Host,
+		"distro":   j.host.Distro.Id,
+		"provider": j.host.Distro.Provider,
 	}
 
-	if h.InstanceType != "" {
-		m["instance"] = h.InstanceType
+	if j.host.InstanceType != "" {
+		m["instance"] = j.host.InstanceType
 	}
 
-	sinceLCT := time.Since(h.LastCommunicationTime)
-	if h.NeedsNewAgent {
+	sinceLCT := time.Since(j.host.LastCommunicationTime)
+	if j.host.NeedsNewAgent {
 		m["reason"] = "flagged for new agent"
-	} else if h.LastCommunicationTime.IsZero() {
+	} else if j.host.LastCommunicationTime.IsZero() {
 		m["reason"] = "new host"
 	} else if sinceLCT > host.MaxLCTInterval {
 		m["reason"] = "host has exceeded last communication threshold"
@@ -211,36 +211,36 @@ func (j *agentDeployJob) getHostMessage(h host.Host) message.Fields {
 // Start an agent on the host specified.  First runs any necessary
 // preparation on the remote machine, then kicks off the agent process on the
 // machine. Returns an error if any step along the way fails.
-func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergreen.Settings, hostObj host.Host) error {
+func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergreen.Settings) error {
 	// get the host's SSH options
-	sshOptions, err := hostObj.GetSSHOptions(settings)
+	sshOptions, err := j.host.GetSSHOptions(settings)
 	if err != nil {
-		return errors.Wrapf(err, "Error getting ssh options for host %s", hostObj.Id)
+		return errors.Wrapf(err, "Error getting ssh options for host %s", j.host.Id)
 	}
 
-	d, err := distro.FindOne(distro.ById(hostObj.Distro.Id))
+	d, err := distro.FindOne(distro.ById(j.host.Distro.Id))
 	if err != nil {
-		return errors.Wrapf(err, "error finding distro %s", hostObj.Distro.Id)
+		return errors.Wrapf(err, "error finding distro %s", j.host.Distro.Id)
 	}
-	hostObj.Distro = d
+	j.host.Distro = d
 
-	if err = j.prepRemoteHost(ctx, hostObj, sshOptions, settings); err != nil {
+	if err = j.prepRemoteHost(ctx, sshOptions, settings); err != nil {
 		return errors.Wrap(err, "could not prep remote host")
 	}
 
-	grip.Info(message.Fields{"runner": "taskrunner", "message": "prepping host finished successfully", "host_id": hostObj.Id})
+	grip.Info(message.Fields{"runner": "taskrunner", "message": "prepping host finished successfully", "host_id": j.host.Id})
 
 	// generate the host secret if none exists
-	if hostObj.Secret == "" {
-		if err = hostObj.CreateSecret(); err != nil {
-			return errors.Wrapf(err, "creating secret for %s", hostObj.Id)
+	if j.host.Secret == "" {
+		if err = j.host.CreateSecret(); err != nil {
+			return errors.Wrapf(err, "creating secret for %s", j.host.Id)
 		}
 	}
 
 	// Start agent to listen for tasks
-	grip.Info(j.getHostMessage(hostObj))
-	if err = j.startAgentOnRemote(ctx, settings, &hostObj, sshOptions); err != nil {
-		event.LogHostAgentDeployFailed(hostObj.Id, err)
+	grip.Info(j.getHostMessage())
+	if err = j.startAgentOnRemote(ctx, settings, sshOptions); err != nil {
+		event.LogHostAgentDeployFailed(j.host.Id, err)
 		grip.Info(message.WrapError(err, message.Fields{
 			"message": "error starting agent on remote",
 			"host_id": j.HostID,
@@ -248,48 +248,48 @@ func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergre
 		}))
 		return errors.Wrap(err, "could not start agent on remote")
 	}
-	grip.Info(message.Fields{"runner": "taskrunner", "message": "agent successfully started for host", "host_id": hostObj.Id})
+	grip.Info(message.Fields{"runner": "taskrunner", "message": "agent successfully started for host", "host_id": j.host.Id})
 
-	if err = hostObj.SetAgentRevision(evergreen.BuildRevision); err != nil {
-		return errors.Wrapf(err, "error setting agent revision on host %s", hostObj.Id)
+	if err = j.host.SetAgentRevision(evergreen.BuildRevision); err != nil {
+		return errors.Wrapf(err, "error setting agent revision on host %s", j.host.Id)
 	}
 	return nil
 }
 
 // Prepare the remote machine to run a task.
-func (j *agentDeployJob) prepRemoteHost(ctx context.Context, hostObj host.Host, sshOptions []string, settings *evergreen.Settings) error {
+func (j *agentDeployJob) prepRemoteHost(ctx context.Context, sshOptions []string, settings *evergreen.Settings) error {
 	// copy over the correct agent binary to the remote host
-	if logs, err := hostObj.RunSSHCommand(ctx, hostObj.CurlCommand(settings), sshOptions); err != nil {
-		event.LogHostAgentDeployFailed(hostObj.Id, err)
+	if logs, err := j.host.RunSSHCommand(ctx, j.host.CurlCommand(settings), sshOptions); err != nil {
+		event.LogHostAgentDeployFailed(j.host.Id, err)
 		return errors.Wrapf(err, "error downloading agent binary on remote host: %s", logs)
 	}
 
-	if hostObj.Distro.Setup == "" {
+	if j.host.Distro.Setup == "" {
 		return nil
 	}
 
-	if logs, err := hostObj.RunSSHCommand(ctx, hostObj.SetupCommand(), sshOptions); err != nil {
-		event.LogProvisionFailed(hostObj.Id, logs)
+	if logs, err := j.host.RunSSHCommand(ctx, j.host.SetupCommand(), sshOptions); err != nil {
+		event.LogProvisionFailed(j.host.Id, logs)
 
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error running setup script",
 			"runner":  "taskrunner",
-			"host_id": hostObj.Id,
-			"distro":  hostObj.Distro.Id,
+			"host_id": j.host.Id,
+			"distro":  j.host.Distro.Id,
 			"logs":    logs,
 			"job":     j.ID(),
 		}))
 
 		// there is no guarantee setup scripts are idempotent, so we terminate the host if the setup script fails
-		if disableErr := hostObj.DisablePoisonedHost(err.Error()); disableErr != nil {
-			return errors.Wrapf(disableErr, "error terminating host %s", hostObj.Id)
+		if disableErr := j.host.DisablePoisonedHost(err.Error()); disableErr != nil {
+			return errors.Wrapf(disableErr, "error terminating host %s", j.host.Id)
 		}
 
 		grip.Error(message.WrapError(j.env.RemoteQueue().Put(ctx, NewDecoHostNotifyJob(j.env, j.host, nil, "error running setup script on host")),
 			message.Fields{
 				"message": fmt.Sprintf("tried %d times to put agent on host", agentPutRetries),
-				"host_id": hostObj.Id,
-				"distro":  hostObj.Distro,
+				"host_id": j.host.Id,
+				"distro":  j.host.Distro,
 			}))
 
 		return errors.Wrapf(err, "error running setup script on remote host: %s", logs)
@@ -299,37 +299,23 @@ func (j *agentDeployJob) prepRemoteHost(ctx context.Context, hostObj host.Host, 
 }
 
 // Start the agent process on the specified remote host.
-func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *evergreen.Settings, hostObj *host.Host, sshOptions []string) error {
+func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *evergreen.Settings, sshOptions []string) error {
 	// the path to the agent binary on the remote machine
-	pathToExecutable := filepath.Join("~", "evergreen")
-	if hostObj.Distro.IsWindows() {
-		pathToExecutable += ".exe"
-	}
-
-	agentCmdParts := []string{
-		pathToExecutable,
-		"agent",
-		fmt.Sprintf("--api_server='%s'", settings.ApiUrl),
-		fmt.Sprintf("--host_id='%s'", hostObj.Id),
-		fmt.Sprintf("--host_secret='%s'", hostObj.Secret),
-		fmt.Sprintf("--log_prefix='%s'", filepath.Join(hostObj.Distro.WorkDir, "agent")),
-		fmt.Sprintf("--working_directory='%s'", hostObj.Distro.WorkDir),
-		"--cleanup",
-	}
+	binary := filepath.Join(j.host.Distro.HomeDir(), j.host.Distro.BinaryName())
 
 	// build the command to run on the remote machine
-	remoteCmd := strings.Join(agentCmdParts, " ")
+	remoteCmd := strings.Join(j.host.AgentCommand(binary, settings), " ")
 	grip.Info(message.Fields{
 		"message": "starting agent on host",
-		"host_id": hostObj.Id,
+		"host_id": j.host.Id,
 		"command": remoteCmd,
 		"runner":  "taskrunner",
 	})
 
 	// compute any info necessary to ssh into the host
-	hostInfo, err := hostObj.GetSSHInfo()
+	hostInfo, err := j.host.GetSSHInfo()
 	if err != nil {
-		return errors.Wrapf(err, "error parsing ssh info %v", hostObj.Host)
+		return errors.Wrapf(err, "error parsing ssh info %v", j.host.Host)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, sshTimeout)
@@ -338,13 +324,13 @@ func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *everg
 	remoteCmd = fmt.Sprintf("nohup %s > /tmp/start 2>1 &", remoteCmd)
 
 	startAgentCmd := j.env.JasperManager().CreateCommand(ctx).Append(remoteCmd).
-		User(hostObj.User).Host(hostInfo.Hostname).ExtendRemoteArgs("-p", hostInfo.Port).ExtendRemoteArgs(sshOptions...)
+		User(j.host.User).Host(hostInfo.Hostname).ExtendRemoteArgs("-p", hostInfo.Port).ExtendRemoteArgs(sshOptions...)
 
 	if err = startAgentCmd.Run(ctx); err != nil {
-		return errors.Wrapf(err, "error starting agent (%v)", hostObj.Id)
+		return errors.Wrapf(err, "error starting agent (%v)", j.host.Id)
 	}
 
-	event.LogHostAgentDeployed(hostObj.Id)
+	event.LogHostAgentDeployed(j.host.Id)
 
 	return nil
 }

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -228,7 +228,7 @@ func (j *agentMonitorDeployJob) fetchClient(ctx context.Context, settings *everg
 			"message":       "error fetching agent monitor binary on host",
 			"host_id":       j.host.Id,
 			"distro":        j.host.Distro.Id,
-			"output":        output,
+			"logs":          output,
 			"communication": j.host.Distro.BootstrapSettings.Communication,
 			"job":           j.ID(),
 		}))

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -221,7 +220,7 @@ func (j *agentMonitorDeployJob) fetchClient(ctx context.Context, settings *everg
 	})
 
 	opts := &options.Create{
-		Args: []string{filepath.Join(j.host.Distro.BootstrapSettings.RootDir, j.host.Distro.BootstrapSettings.ShellPath), "-l", "-c", j.host.CurlCommand(settings)},
+		Args: []string{j.host.Distro.ShellBinary(), "-l", "-c", j.host.CurlCommand(settings)},
 	}
 	output, err := j.host.RunJasperProcess(ctx, j.env, opts)
 	if err != nil {
@@ -251,7 +250,7 @@ func (j *agentMonitorDeployJob) runSetupScript(ctx context.Context, settings *ev
 	})
 
 	opts := &options.Create{
-		Args: []string{filepath.Join(j.host.Distro.BootstrapSettings.RootDir, j.host.Distro.BootstrapSettings.ShellPath), "-l", "-c", j.host.SetupCommand()},
+		Args: []string{j.host.Distro.ShellBinary(), "-l", "-c", j.host.SetupCommand()},
 	}
 	output, err := j.host.RunJasperProcess(ctx, j.env, opts)
 	if err != nil {

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -239,6 +239,7 @@ func (j *agentMonitorDeployJob) fetchClient(ctx context.Context, settings *everg
 	}
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "timed out curling evergreen binary")
+	}
 
 	return nil
 }

--- a/units/provisioning_convert_host_to_legacy.go
+++ b/units/provisioning_convert_host_to_legacy.go
@@ -146,7 +146,7 @@ func (j *convertHostToLegacyProvisioningJob) Run(ctx context.Context) {
 	// This is a best-effort attempt to uninstall Jasper, but it will silently
 	// fail to uninstall Jasper if the Jasper binary path does not match its
 	// actual path on the remote host.
-	if logs, err := j.host.RunSSHCommandLiterally(ctx, fmt.Sprintf("[ -a \"%s\" ] && %s", j.host.JasperBinaryFilePath(settings.HostJasper), j.host.QuietUninstallJasperCommand(settings.HostJasper)), sshOpts); err != nil {
+	if logs, err := j.host.RunSSHCommand(ctx, fmt.Sprintf("[ -a \"%s\" ] && %s", j.host.JasperBinaryFilePath(settings.HostJasper), j.host.QuietUninstallJasperCommand(settings.HostJasper)), sshOpts); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "could not uninstall Jasper service",
 			"host_id": j.host.Id,

--- a/units/provisioning_convert_host_to_legacy.go
+++ b/units/provisioning_convert_host_to_legacy.go
@@ -72,7 +72,7 @@ func (j *convertHostToLegacyProvisioningJob) Run(ctx context.Context) {
 		return
 	}
 
-	if j.host.NeedsReprovision != host.ReprovisionToLegacy || (j.host.Status != evergreen.HostProvisioning && j.host.Status != evergreen.HostRunning) {
+	if j.host.NeedsReprovision != host.ReprovisionToLegacy || (j.host.Status != evergreen.HostProvisioning && j.host.Status != evergreen.HostRunning) || j.host.RunningTask != "" {
 		return
 	}
 
@@ -112,7 +112,7 @@ func (j *convertHostToLegacyProvisioningJob) Run(ctx context.Context) {
 
 	// The host cannot be reprovisioned until the host's agent has
 	// stopped.
-	if !j.host.NeedsNewAgent {
+	if !j.host.NeedsNewAgent || j.host.RunningTask != "" {
 		grip.Error(message.WrapError(j.tryRequeue(ctx), message.Fields{
 			"message": "could not enqueue job to retry provisioning conversion when host's agent is still running",
 			"host_id": j.host.Id,

--- a/units/provisioning_convert_host_to_new.go
+++ b/units/provisioning_convert_host_to_new.go
@@ -118,7 +118,7 @@ func (j *convertHostToNewProvisioningJob) Run(ctx context.Context) {
 
 	// The host cannot be reprovisioned until the host's agent monitor has
 	// stopped.
-	if !j.host.NeedsNewAgentMonitor {
+	if !j.host.NeedsNewAgentMonitor || j.host.RunningTask != "" {
 		grip.Error(message.WrapError(j.tryRequeue(ctx), message.Fields{
 			"message": "could not enqueue job to retry provisioning conversion when host's agent monitor is still running",
 			"host_id": j.host.Id,

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -172,7 +172,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	hostStartTime := j.start
 	grip.Info(message.Fields{
 		"message":      "attempting to start host",
-		"hostid":       j.host.Id,
+		"host_id":      j.host.Id,
 		"job":          j.ID(),
 		"attempt":      j.CurrentAttempt,
 		"max_attempts": j.MaxAttempts,
@@ -290,7 +290,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	event.LogHostStartFinished(j.host.Id, true)
 	grip.Info(message.Fields{
 		"message": "successfully started host",
-		"hostid":  j.host.Id,
+		"host_id": j.host.Id,
 		"job":     j.ID(),
 		"runtime": time.Since(hostStartTime),
 	})

--- a/units/provisioning_jasper_restart.go
+++ b/units/provisioning_jasper_restart.go
@@ -64,7 +64,7 @@ func makeJasperRestartJob() *jasperRestartJob {
 
 // NewJasperRestartJob creates a job that restarts an existing Jasper service
 // with new credentials.
-// kim: TODO: test this in staging.
+// kim: TODO: test this in staging with the mac host.
 func NewJasperRestartJob(env evergreen.Environment, h host.Host, expiration time.Time, restartThroughJasper bool, ts string, attempt int) amboy.Job {
 	j := makeJasperRestartJob()
 	j.env = env

--- a/units/provisioning_jasper_restart.go
+++ b/units/provisioning_jasper_restart.go
@@ -312,7 +312,7 @@ func (j *jasperRestartJob) Run(ctx context.Context) {
 		if output, err := j.host.RunSSHCommand(ctx, writeCredentialsCmd, sshOpts); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "could not run SSH command to write credentials file",
-				"output":  output,
+				"logs":    output,
 				"host_id": j.host.Id,
 				"distro":  j.host.Distro.Id,
 				"job":     j.ID(),
@@ -324,7 +324,7 @@ func (j *jasperRestartJob) Run(ctx context.Context) {
 		if output, err := j.host.RunSSHCommand(ctx, j.host.RestartJasperCommand(j.settings.HostJasper), sshOpts); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "could not run SSH command to restart Jasper",
-				"output":  output,
+				"logs":    output,
 				"host_id": j.host.Id,
 				"distro":  j.host.Distro.Id,
 				"job":     j.ID(),

--- a/units/provisioning_jasper_restart.go
+++ b/units/provisioning_jasper_restart.go
@@ -64,6 +64,7 @@ func makeJasperRestartJob() *jasperRestartJob {
 
 // NewJasperRestartJob creates a job that restarts an existing Jasper service
 // with new credentials.
+// kim: TODO: test this in staging.
 func NewJasperRestartJob(env evergreen.Environment, h host.Host, expiration time.Time, restartThroughJasper bool, ts string, attempt int) amboy.Job {
 	j := makeJasperRestartJob()
 	j.env = env

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -106,43 +106,43 @@ func (j *setupHostJob) Run(ctx context.Context) {
 
 	settings := j.env.Settings()
 
-	j.AddError(j.setupHost(ctx, j.host, settings))
+	j.AddError(j.setupHost(ctx, settings))
 }
 
 var (
 	errIgnorableCreateHost = errors.New("host.create encountered internal error")
 )
 
-func (j *setupHostJob) setupHost(ctx context.Context, h *host.Host, settings *evergreen.Settings) error {
+func (j *setupHostJob) setupHost(ctx context.Context, settings *evergreen.Settings) error {
 	grip.Info(message.Fields{
 		"message": "attempting to setup host",
-		"distro":  h.Distro.Id,
-		"hostid":  h.Id,
-		"DNS":     h.Host,
+		"distro":  j.host.Distro.Id,
+		"hostid":  j.host.Id,
+		"DNS":     j.host.Host,
 		"job":     j.ID(),
 	})
 
 	if err := ctx.Err(); err != nil {
-		return errors.Wrapf(err, "hostinit canceled during setup for host %s", h.Id)
+		return errors.Wrapf(err, "hostinit canceled during setup for host %s", j.host.Id)
 	}
 
 	setupStartTime := time.Now()
 	grip.Info(message.Fields{
 		"message": "provisioning host",
 		"job":     j.ID(),
-		"distro":  h.Distro.Id,
-		"hostid":  h.Id,
+		"distro":  j.host.Distro.Id,
+		"hostid":  j.host.Id,
 	})
 
-	if err := j.provisionHost(ctx, h, settings); err != nil {
-		event.LogHostProvisionError(h.Id)
+	if err := j.provisionHost(ctx, settings); err != nil {
+		event.LogHostProvisionError(j.host.Id)
 
-		if h.Distro.BootstrapSettings.Method == distro.BootstrapMethodSSH {
+		if j.host.Distro.BootstrapSettings.Method == distro.BootstrapMethodSSH {
 			grip.Error(message.WrapError(j.host.DeleteJasperCredentials(ctx, j.env), message.Fields{
 				"message":  "could not delete Jasper credentials after failed provision attempt",
 				"host_id":  j.host.Id,
 				"distro":   j.host.Distro.Id,
-				"attempts": h.ProvisionAttempts,
+				"attempts": j.host.ProvisionAttempts,
 				"job":      j.ID(),
 			}))
 		}
@@ -150,9 +150,9 @@ func (j *setupHostJob) setupHost(ctx context.Context, h *host.Host, settings *ev
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":  "provisioning host encountered error",
 			"job":      j.ID(),
-			"distro":   h.Distro.Id,
-			"hostid":   h.Id,
-			"attempts": h.ProvisionAttempts,
+			"distro":   j.host.Distro.Id,
+			"hostid":   j.host.Id,
+			"attempts": j.host.ProvisionAttempts,
 		}))
 	}
 
@@ -162,10 +162,10 @@ func (j *setupHostJob) setupHost(ctx context.Context, h *host.Host, settings *ev
 	//
 	// In these cases, ProvisionHost returns a nil error but
 	// does not change the host status.
-	if h.Status == evergreen.HostProvisioning && !h.Provisioned {
+	if j.host.Status == evergreen.HostProvisioning && !j.host.Provisioned {
 		grip.Info(message.Fields{
-			"attempts": h.ProvisionAttempts,
-			"host_id":  h.Id,
+			"attempts": j.host.ProvisionAttempts,
+			"host_id":  j.host.Id,
 			"job":      j.ID(),
 			"message":  "retrying provisioning",
 		})
@@ -174,40 +174,40 @@ func (j *setupHostJob) setupHost(ctx context.Context, h *host.Host, settings *ev
 
 	grip.Info(message.Fields{
 		"message":  "successfully finished provisioning host",
-		"hostid":   h.Id,
-		"DNS":      h.Host,
-		"distro":   h.Distro.Id,
+		"hostid":   j.host.Id,
+		"DNS":      j.host.Host,
+		"distro":   j.host.Distro.Id,
 		"job":      j.ID(),
-		"attempts": h.ProvisionAttempts,
+		"attempts": j.host.ProvisionAttempts,
 		"runtime":  time.Since(setupStartTime),
 	})
 
 	return nil
 }
 
-func (j *setupHostJob) setDNSName(ctx context.Context, host *host.Host, cloudMgr cloud.Manager, settings *evergreen.Settings) error {
-	if host.Host != "" {
+func (j *setupHostJob) setDNSName(ctx context.Context, cloudMgr cloud.Manager, settings *evergreen.Settings) error {
+	if j.host.Host != "" {
 		return nil
 	}
 
 	// get the DNS name for the host
-	hostDNS, err := cloudMgr.GetDNSName(ctx, host)
+	hostDNS, err := cloudMgr.GetDNSName(ctx, j.host)
 	if err != nil {
-		return errors.Wrapf(err, "error checking DNS name for host %s", host.Id)
+		return errors.Wrapf(err, "error checking DNS name for host %s", j.host.Id)
 	}
 
 	// sanity check for the host DNS name
 	if hostDNS == "" {
 		// DNS name not required if IP address set
-		if host.IP != "" {
+		if j.host.IP != "" {
 			return nil
 		}
-		return errors.Errorf("instance %s is running but not returning a DNS name or IP address", host.Id)
+		return errors.Errorf("instance %s is running but not returning a DNS name or IP address", j.host.Id)
 	}
 
 	// update the host's DNS name
-	if err = host.SetDNSName(hostDNS); err != nil {
-		return errors.Wrapf(err, "error setting DNS name for host %s", host.Id)
+	if err = j.host.SetDNSName(hostDNS); err != nil {
+		return errors.Wrapf(err, "error setting DNS name for host %s", j.host.Id)
 	}
 
 	return nil
@@ -217,58 +217,58 @@ func (j *setupHostJob) setDNSName(ctx context.Context, host *host.Host, cloudMgr
 // Returns the output from running the script remotely, as well as any error
 // that occurs. If the script exits with a non-zero exit code, the error will be
 // non-nil.
-func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, settings *evergreen.Settings) error {
+func (j *setupHostJob) runHostSetup(ctx context.Context, settings *evergreen.Settings) error {
 	// fetch the appropriate cloud provider for the host
-	mgrOpts, err := cloud.GetManagerOptions(targetHost.Distro)
+	mgrOpts, err := cloud.GetManagerOptions(j.host.Distro)
 	if err != nil {
-		return errors.Wrapf(err, "can't get ManagerOpts for '%s'", targetHost.Id)
+		return errors.Wrapf(err, "can't get ManagerOpts for '%s'", j.host.Id)
 	}
 	cloudMgr, err := cloud.GetManager(ctx, j.env, mgrOpts)
 	if err != nil {
 		return errors.Wrapf(err,
 			"failed to get cloud manager for host %s with provider %s",
-			targetHost.Id, targetHost.Provider)
+			j.host.Id, j.host.Provider)
 	}
 
-	if err = j.setDNSName(ctx, targetHost, cloudMgr, settings); err != nil {
+	if err = j.setDNSName(ctx, cloudMgr, settings); err != nil {
 		return errors.Wrap(err, "error setting DNS name")
 	}
 
 	// run the function scheduled for when the host is up
-	if err = cloudMgr.OnUp(ctx, targetHost); err != nil {
-		err = errors.Wrapf(err, "OnUp callback failed for host %s", targetHost.Id)
+	if err = cloudMgr.OnUp(ctx, j.host); err != nil {
+		err = errors.Wrapf(err, "OnUp callback failed for host %s", j.host.Id)
 		return err
 	}
 
-	switch targetHost.Distro.BootstrapSettings.Method {
+	switch j.host.Distro.BootstrapSettings.Method {
 	case distro.BootstrapMethodNone:
 		return nil
 	case distro.BootstrapMethodUserData:
 		// Updating the host LCT prevents the agent monitor deploy job from
 		// running. The agent monitor should be started by the user data script.
-		grip.Error(message.WrapError(targetHost.UpdateLastCommunicated(), message.Fields{
+		grip.Error(message.WrapError(j.host.UpdateLastCommunicated(), message.Fields{
 			"message": "failed to update host's last communication time",
-			"host_id": targetHost.Id,
-			"distro":  targetHost.Distro.Id,
+			"host_id": j.host.Id,
+			"distro":  j.host.Distro.Id,
 			"job":     j.ID(),
 		}))
 
 		// Do not set the host to running - hosts bootstrapped with user data
 		// are not considered done provisioning until user data has finished
 		// running.
-		if err = targetHost.SetProvisionedNotRunning(); err != nil {
-			return errors.Wrapf(err, "error marking host %s as provisioned", targetHost.Id)
+		if err = j.host.SetProvisionedNotRunning(); err != nil {
+			return errors.Wrapf(err, "error marking host %s as provisioned", j.host.Id)
 		}
 
 		grip.Info(message.Fields{
 			"message":                 "host successfully provisioned by app server, awaiting host to finish provisioning itself",
-			"host_id":                 targetHost.Id,
-			"distro":                  targetHost.Distro.Id,
-			"provisioning":            targetHost.Distro.BootstrapSettings.Method,
-			"provider":                targetHost.Provider,
-			"attempts":                targetHost.ProvisionAttempts,
+			"host_id":                 j.host.Id,
+			"distro":                  j.host.Distro.Id,
+			"provisioning":            j.host.Distro.BootstrapSettings.Method,
+			"provider":                j.host.Provider,
+			"attempts":                j.host.ProvisionAttempts,
 			"job":                     j.ID(),
-			"provision_duration_secs": time.Since(targetHost.CreationTime).Seconds(),
+			"provision_duration_secs": time.Since(j.host.CreationTime).Seconds(),
 		})
 		return nil
 	case distro.BootstrapMethodSSH:
@@ -279,7 +279,7 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 				"distro":  j.host.Distro.Id,
 				"job":     j.ID(),
 			}))
-			return errors.Wrapf(err, "error putting Jasper on host '%s'", targetHost.Id)
+			return errors.Wrapf(err, "error putting Jasper on host '%s'", j.host.Id)
 		}
 		grip.Info(message.Fields{
 			"message": "successfully fetched Jasper binary and started service",
@@ -290,27 +290,27 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, targetHost *host.Host, 
 	}
 
 	// Do not copy setup scripts to task-spawned hosts
-	if targetHost.SpawnOptions.SpawnedByTask {
+	if j.host.SpawnOptions.SpawnedByTask {
 		return nil
 	}
 
-	if targetHost.Distro.Setup != "" {
+	if j.host.Distro.Setup != "" {
 		scriptName := evergreen.SetupScriptName
-		if targetHost.Distro.IsPowerShellSetup() {
+		if j.host.Distro.IsPowerShellSetup() {
 			scriptName = evergreen.PowerShellSetupScriptName
 		}
-		err = j.copyScript(ctx, settings, targetHost, filepath.Join("~", scriptName), targetHost.Distro.Setup)
+		err = j.copyScript(ctx, settings, filepath.Join("~", scriptName), j.host.Distro.Setup)
 		if err != nil {
 			return errors.Wrapf(err, "error copying setup script %s to host %s",
-				scriptName, targetHost.Id)
+				scriptName, j.host.Id)
 		}
 	}
 
-	if targetHost.Distro.Teardown != "" {
-		err = j.copyScript(ctx, settings, targetHost, filepath.Join("~", evergreen.TeardownScriptName), targetHost.Distro.Teardown)
+	if j.host.Distro.Teardown != "" {
+		err = j.copyScript(ctx, settings, filepath.Join("~", evergreen.TeardownScriptName), j.host.Distro.Teardown)
 		if err != nil {
 			return errors.Wrapf(err, "error copying teardown script %s to host %s",
-				evergreen.TeardownScriptName, targetHost.Id)
+				evergreen.TeardownScriptName, j.host.Id)
 		}
 	}
 
@@ -488,16 +488,16 @@ func copyScript(ctx context.Context, env evergreen.Environment, settings *evergr
 // copyScript writes a given script as file "name" to the target host. This works
 // by creating a local copy of the script on the runner's machine, scping it over
 // then removing the local copy.
-func (j *setupHostJob) copyScript(ctx context.Context, settings *evergreen.Settings, target *host.Host, name, script string) error {
+func (j *setupHostJob) copyScript(ctx context.Context, settings *evergreen.Settings, name, script string) error {
 	// parse the hostname into the user, host and port
 	startAt := time.Now()
 
-	hostInfo, err := target.GetSSHInfo()
+	hostInfo, err := j.host.GetSSHInfo()
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	user := target.Distro.User
+	user := j.host.Distro.User
 	if hostInfo.User != "" {
 		user = hostInfo.User
 	}
@@ -515,8 +515,8 @@ func (j *setupHostJob) copyScript(ctx context.Context, settings *evergreen.Setti
 			"job":       j.ID(),
 			"operation": "cleaning up after script copy",
 			"file":      file.Name(),
-			"distro":    target.Distro.Id,
-			"host_id":   target.Host,
+			"distro":    j.host.Distro.Id,
+			"host_id":   j.host.Host,
 			"name":      name,
 		}
 		grip.Error(message.WrapError(file.Close(), errCtx))
@@ -525,8 +525,8 @@ func (j *setupHostJob) copyScript(ctx context.Context, settings *evergreen.Setti
 			"job":           j.ID(),
 			"operation":     "copy script",
 			"file":          file.Name(),
-			"distro":        target.Distro.Id,
-			"host_id":       target.Host,
+			"distro":        j.host.Distro.Id,
+			"host_id":       j.host.Host,
 			"name":          name,
 			"duration_secs": time.Since(startAt).Seconds(),
 		})
@@ -534,15 +534,15 @@ func (j *setupHostJob) copyScript(ctx context.Context, settings *evergreen.Setti
 
 	expanded, err := expandScript(script, settings)
 	if err != nil {
-		return errors.Wrapf(err, "error expanding script for host %s", target.Id)
+		return errors.Wrapf(err, "error expanding script for host %s", j.host.Id)
 	}
 	if _, err = io.WriteString(file, expanded); err != nil {
 		return errors.Wrap(err, "error writing local script")
 	}
 
-	sshOptions, err := target.GetSSHOptions(settings)
+	sshOptions, err := j.host.GetSSHOptions(settings)
 	if err != nil {
-		return errors.Wrapf(err, "error getting ssh options for host %v", target.Id)
+		return errors.Wrapf(err, "error getting ssh options for host %v", j.host.Id)
 	}
 
 	scpCmdOut := &util.CappedWriter{
@@ -565,8 +565,8 @@ func (j *setupHostJob) copyScript(ctx context.Context, settings *evergreen.Setti
 		"message": "problem copying script to host",
 		"job":     j.ID(),
 		"command": strings.Join(scpArgs, " "),
-		"distro":  target.Distro.Id,
-		"host_id": target.Host,
+		"distro":  j.host.Distro.Id,
+		"host_id": j.host.Host,
 		"output":  scpCmdOut.String(),
 	}))
 
@@ -589,53 +589,53 @@ func expandScript(s string, settings *evergreen.Settings) (string, error) {
 }
 
 // Provision the host, and update the database accordingly.
-func (j *setupHostJob) provisionHost(ctx context.Context, h *host.Host, settings *evergreen.Settings) error {
+func (j *setupHostJob) provisionHost(ctx context.Context, settings *evergreen.Settings) error {
 	grip.Info(message.Fields{
 		"job":     j.ID(),
-		"host_id": h.Id,
-		"distro":  h.Distro.Id,
+		"host_id": j.host.Id,
+		"distro":  j.host.Distro.Id,
 		"message": "setting up host",
 	})
 
-	incErr := h.IncProvisionAttempts()
+	incErr := j.host.IncProvisionAttempts()
 	grip.Critical(message.WrapError(incErr, message.Fields{
 		"job":           j.ID(),
-		"host_id":       h.Id,
-		"attempt_value": h.ProvisionAttempts,
-		"distro":        h.Distro.Id,
+		"host_id":       j.host.Id,
+		"attempt_value": j.host.ProvisionAttempts,
+		"distro":        j.host.Distro.Id,
 		"operation":     "increment provisioning errors failed",
 	}))
 
-	err := j.runHostSetup(ctx, h, settings)
+	err := j.runHostSetup(ctx, settings)
 	if err != nil {
-		if shouldRetryProvisioning(h) {
+		if shouldRetryProvisioning(j.host) {
 			return nil
 		}
 
-		event.LogProvisionFailed(h.Id, "")
+		event.LogProvisionFailed(j.host.Id, "")
 		// mark the host's provisioning as failed
-		grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
+		grip.Error(message.WrapError(j.host.SetUnprovisioned(), message.Fields{
 			"operation": "setting host unprovisioned",
-			"attempts":  h.ProvisionAttempts,
-			"distro":    h.Distro.Id,
+			"attempts":  j.host.ProvisionAttempts,
+			"distro":    j.host.Distro.Id,
 			"job":       j.ID(),
-			"host_id":   h.Id,
+			"host_id":   j.host.Id,
 		}))
 
-		return errors.Wrapf(err, "error initializing host %s", h.Id)
+		return errors.Wrapf(err, "error initializing host %s", j.host.Id)
 	}
 
-	if h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData {
+	if j.host.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData {
 		return nil
 	}
 
-	if h.AttachVolume {
+	if j.host.AttachVolume {
 		if err := attachVolume(ctx, j.env, j.host); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "can't attach volume",
-				"host":     j.host.Id,
+				"host_id":  j.host.Id,
 				"distro":   j.host.Distro.Id,
-				"attempts": h.ProvisionAttempts,
+				"attempts": j.host.ProvisionAttempts,
 				"job":      j.ID(),
 			}))
 			return nil
@@ -643,76 +643,64 @@ func (j *setupHostJob) provisionHost(ctx context.Context, h *host.Host, settings
 	}
 
 	// If this is a spawn host
-	if h.ProvisionOptions != nil && h.ProvisionOptions.LoadCLI {
-		grip.Infof("Uploading client binary to host %s", h.Id)
-		lcr, err := j.loadClient(ctx, h, settings)
+	if j.host.ProvisionOptions != nil && j.host.ProvisionOptions.LoadCLI {
+		grip.Infof("Uploading client binary to host %s", j.host.Id)
+		lcr, err := j.loadClient(ctx, settings)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "failed to load client binary onto host",
 				"job":     j.ID(),
-				"host_id": h.Id,
-				"distro":  h.Distro.Id,
+				"host_id": j.host.Id,
+				"distro":  j.host.Distro.Id,
 			}))
 
-			grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
+			grip.Error(message.WrapError(j.host.SetUnprovisioned(), message.Fields{
 				"operation": "setting host unprovisioned",
 				"job":       j.ID(),
-				"distro":    h.Distro.Id,
-				"host_id":   h.Id,
+				"distro":    j.host.Distro.Id,
+				"host_id":   j.host.Id,
 			}))
-			return errors.Wrapf(err, "Failed to load client binary onto host %s: %+v", h.Id, err)
+			return errors.Wrapf(err, "Failed to load client binary onto host %s: %+v", j.host.Id, err)
 		}
 
-		sshOptions, err := h.GetSSHOptions(settings)
+		sshOptions, err := j.host.GetSSHOptions(settings)
 		if err != nil {
-			grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
+			grip.Error(message.WrapError(j.host.SetUnprovisioned(), message.Fields{
 				"operation": "setting host unprovisioned",
-				"distro":    h.Distro.Id,
+				"distro":    j.host.Distro.Id,
 				"job":       j.ID(),
-				"host_id":   h.Id,
+				"host_id":   j.host.Id,
 			}))
-			return errors.Wrapf(err, "Error getting ssh options for host %s", h.Id)
+			return errors.Wrapf(err, "Error getting ssh options for host %s", j.host.Id)
 		}
 
-		d, err := distro.FindOne(distro.ById(h.Distro.Id))
-		if err != nil {
-			grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
-				"operation": "setting host unprovisioned",
-				"distro":    h.Distro.Id,
-				"job":       j.ID(),
-				"host_id":   h.Id,
-			}))
-			return errors.Wrapf(err, "Error finding distro for host %s", h.Id)
-		}
-		h.Distro = d
-
-		grip.Infof("Running setup script for spawn host %s", h.Id)
+		grip.Infof("Running setup script for spawn host %s", j.host.Id)
 		// run the setup script with the agent
-		if logs, err := h.RunSSHCommand(ctx, h.SetupCommand(), sshOptions); err != nil {
-			grip.Error(message.WrapError(h.SetUnprovisioned(), message.Fields{
+		if logs, err := j.host.RunSSHCommand(ctx, j.host.SetupCommand(), sshOptions); err != nil {
+			grip.Error(message.WrapError(j.host.SetUnprovisioned(), message.Fields{
 				"operation": "setting host unprovisioned",
-				"host_id":   h.Id,
-				"distro":    h.Distro.Id,
+				"host_id":   j.host.Id,
+				"distro":    j.host.Distro.Id,
 				"job":       j.ID(),
 			}))
-			event.LogProvisionFailed(h.Id, logs)
+			event.LogProvisionFailed(j.host.Id, logs)
 			return errors.Wrapf(err, "error running setup script on remote host: %s", logs)
 		}
 
-		if h.ProvisionOptions.OwnerId != "" && len(h.ProvisionOptions.TaskId) > 0 {
+		if j.host.ProvisionOptions.OwnerId != "" && len(j.host.ProvisionOptions.TaskId) > 0 {
 			grip.Info(message.Fields{
 				"message": "fetching data for task on host",
-				"task":    h.ProvisionOptions.TaskId,
-				"distro":  h.Distro.Id,
-				"host_id": h.Id,
+				"task":    j.host.ProvisionOptions.TaskId,
+				"distro":  j.host.Distro.Id,
+				"host_id": j.host.Id,
 				"job":     j.ID(),
 			})
 
-			grip.Error(message.WrapError(j.fetchRemoteTaskData(ctx, h.ProvisionOptions.TaskId, lcr.BinaryPath, lcr.ConfigPath, h, settings),
+			grip.Error(message.WrapError(j.fetchRemoteTaskData(ctx, j.host.ProvisionOptions.TaskId, lcr.BinaryPath, lcr.ConfigPath, settings),
 				message.Fields{
 					"message": "failed to fetch data onto host",
-					"task":    h.ProvisionOptions.TaskId,
-					"host_id": h.Id,
+					"task":    j.host.ProvisionOptions.TaskId,
+					"host_id": j.host.Id,
 					"job":     j.ID(),
 				}))
 		}
@@ -720,31 +708,31 @@ func (j *setupHostJob) provisionHost(ctx context.Context, h *host.Host, settings
 
 	grip.Info(message.Fields{
 		"message": "setup complete for host",
-		"host_id": h.Id,
+		"host_id": j.host.Id,
 		"job":     j.ID(),
-		"distro":  h.Distro.Id,
+		"distro":  j.host.Distro.Id,
 	})
 
 	// the setup was successful. update the host accordingly in the database
-	if err := h.MarkAsProvisioned(); err != nil {
-		return errors.Wrapf(err, "error marking host %s as provisioned", h.Id)
+	if err := j.host.MarkAsProvisioned(); err != nil {
+		return errors.Wrapf(err, "error marking host %s as provisioned", j.host.Id)
 	}
 
 	grip.Info(message.Fields{
-		"host_id":                 h.Id,
-		"distro":                  h.Distro.Id,
-		"provider":                h.Provider,
-		"attempts":                h.ProvisionAttempts,
+		"host_id":                 j.host.Id,
+		"distro":                  j.host.Distro.Id,
+		"provider":                j.host.Provider,
+		"attempts":                j.host.ProvisionAttempts,
 		"job":                     j.ID(),
 		"message":                 "host successfully provisioned",
-		"provision_duration_secs": h.ProvisionTime.Sub(h.CreationTime).Seconds(),
+		"provision_duration_secs": j.host.ProvisionTime.Sub(j.host.CreationTime).Seconds(),
 	})
 
 	return nil
 }
 
-// loadClientResult indicates the locations on a target host where the CLI binary and it's config
-// file have been written to.
+// loadClientResult indicates the locations on a target host where the CLI
+// binary and its config file have been written to.
 type loadClientResult struct {
 	BinaryPath string
 	ConfigPath string
@@ -754,38 +742,38 @@ type loadClientResult struct {
 // settings onto the host, and makes the binary appear in the $PATH when the user logs in.
 // If successful, returns an instance of loadClientResult which contains the paths where the
 // binary and config file were written to.
-func (j *setupHostJob) loadClient(ctx context.Context, target *host.Host, settings *evergreen.Settings) (*loadClientResult, error) {
-	if target.ProvisionOptions == nil {
+func (j *setupHostJob) loadClient(ctx context.Context, settings *evergreen.Settings) (*loadClientResult, error) {
+	if j.host.ProvisionOptions == nil {
 		return nil, errors.New("ProvisionOptions is nil")
 	}
-	if target.ProvisionOptions.OwnerId == "" {
+	if j.host.ProvisionOptions.OwnerId == "" {
 		return nil, errors.New("OwnerId not set")
 	}
 
 	// get the information about the owner of the host
-	owner, err := user.FindOne(user.ById(target.ProvisionOptions.OwnerId))
+	owner, err := user.FindOne(user.ById(j.host.ProvisionOptions.OwnerId))
 	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't fetch owner %v for host", target.ProvisionOptions.OwnerId)
+		return nil, errors.Wrapf(err, "couldn't fetch owner %v for host", j.host.ProvisionOptions.OwnerId)
 	}
 
 	// 1. mkdir the destination directory on the host,
 	//    and modify ~/.profile so the target binary will be on the $PATH
 	targetDir := "cli_bin"
-	hostSSHInfo, err := target.GetSSHInfo()
+	hostSSHInfo, err := j.host.GetSSHInfo()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing ssh info %s", target.Host)
+		return nil, errors.Wrapf(err, "error parsing ssh info %s", j.host.Host)
 	}
 
-	sshOptions, err := target.GetSSHOptions(settings)
+	sshOptions, err := j.host.GetSSHOptions(settings)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error getting ssh options for host %v", target.Id)
+		return nil, errors.Wrapf(err, "Error getting ssh options for host %v", j.host.Id)
 	}
 	sshOptions = append(sshOptions, "-o", "UserKnownHostsFile=/dev/null")
 
 	mkdirctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	output, err := target.RunSSHCommandLiterally(mkdirctx, fmt.Sprintf("mkdir -m 777 -p ~/%s && (echo 'export PATH=\"$PATH:~/%s\"' >> ~/.profile || true; echo 'export PATH=\"$PATH:~/%s\"' >> ~/.bash_profile || true)", targetDir, targetDir, targetDir), sshOptions)
+	output, err := j.host.RunSSHCommandLiterally(mkdirctx, fmt.Sprintf("mkdir -m 777 -p ~/%s && (echo 'export PATH=\"$PATH:~/%s\"' >> ~/.profile || true; echo 'export PATH=\"$PATH:~/%s\"' >> ~/.bash_profile || true)", targetDir, targetDir, targetDir), sshOptions)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error running setup command for cli: %s", output)
 	}
@@ -799,10 +787,10 @@ func (j *setupHostJob) loadClient(ctx context.Context, target *host.Host, settin
 		MaxBytes: 1024 * 1024,
 	}
 
-	curlcmd := j.env.JasperManager().CreateCommand(curlctx).Host(hostSSHInfo.Hostname).User(target.User).
+	curlcmd := j.env.JasperManager().CreateCommand(curlctx).Host(hostSSHInfo.Hostname).User(j.host.User).
 		ExtendRemoteArgs("-p", hostSSHInfo.Port).ExtendRemoteArgs(sshOptions...).
 		RedirectErrorToOutput(true).SetOutputWriter(curlOut).
-		Append(target.CurlCommand(settings))
+		Append(j.host.CurlCommand(settings))
 
 	if err = curlcmd.Run(curlctx); err != nil {
 		return nil, errors.Wrapf(err, "error running curl command for cli, %s", curlOut.Buffer.String())
@@ -836,7 +824,7 @@ func (j *setupHostJob) loadClient(ctx context.Context, target *host.Host, settin
 		MaxBytes: 1024 * 1024,
 	}
 
-	scpArgs := buildScpCommand(tempFileName, filepath.Join("~", targetDir, ".evergreen.yml"), hostSSHInfo, target.User, sshOptions)
+	scpArgs := buildScpCommand(tempFileName, filepath.Join("~", targetDir, ".evergreen.yml"), hostSSHInfo, j.host.User, sshOptions)
 	scpYmlCommand := j.env.JasperManager().CreateCommand(ctx).Add(scpArgs).
 		RedirectErrorToOutput(true).SetOutputWriter(scpOut)
 
@@ -853,15 +841,15 @@ func (j *setupHostJob) loadClient(ctx context.Context, target *host.Host, settin
 	}, nil
 }
 
-func (j *setupHostJob) fetchRemoteTaskData(ctx context.Context, taskId, cliPath, confPath string, target *host.Host, settings *evergreen.Settings) error {
-	hostSSHInfo, err := target.GetSSHInfo()
+func (j *setupHostJob) fetchRemoteTaskData(ctx context.Context, taskId, cliPath, confPath string, settings *evergreen.Settings) error {
+	hostSSHInfo, err := j.host.GetSSHInfo()
 	if err != nil {
-		return errors.Wrapf(err, "error parsing ssh info %s", target.Host)
+		return errors.Wrapf(err, "error parsing ssh info %s", j.host.Host)
 	}
 
-	sshOptions, err := target.GetSSHOptions(settings)
+	sshOptions, err := j.host.GetSSHOptions(settings)
 	if err != nil {
-		return errors.Wrapf(err, "Error getting ssh options for host %v", target.Id)
+		return errors.Wrapf(err, "Error getting ssh options for host %v", j.host.Id)
 	}
 	sshOptions = append(sshOptions, "-o", "UserKnownHostsFile=/dev/null")
 
@@ -869,9 +857,9 @@ func (j *setupHostJob) fetchRemoteTaskData(ctx context.Context, taskId, cliPath,
 		Buffer:   &bytes.Buffer{},
 		MaxBytes: 1024 * 1024,
 	}
-	fetchCmd := fmt.Sprintf("%s -c %s fetch -t %s --source --artifacts --dir='%s'", cliPath, confPath, taskId, target.Distro.WorkDir)
+	fetchCmd := fmt.Sprintf("%s -c %s fetch -t %s --source --artifacts --dir='%s'", cliPath, confPath, taskId, j.host.Distro.WorkDir)
 
-	makeShellCmd := j.env.JasperManager().CreateCommand(ctx).Host(hostSSHInfo.Hostname).User(target.User).
+	makeShellCmd := j.env.JasperManager().CreateCommand(ctx).Host(hostSSHInfo.Hostname).User(j.host.User).
 		ExtendRemoteArgs("-p", hostSSHInfo.Port).ExtendRemoteArgs(sshOptions...).
 		RedirectErrorToOutput(true).SetOutputWriter(cmdOutput).
 		Append(fetchCmd)
@@ -970,7 +958,7 @@ func mountLinuxVolume(ctx context.Context, env evergreen.Environment, h *host.Ho
 	defer func() {
 		grip.Warning(message.WrapError(client.CloseConnection(), message.Fields{
 			"message": "could not close connection to Jasper",
-			"host":    h.Id,
+			"host_id": h.Id,
 			"distro":  h.Distro.Id,
 		}))
 	}()

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -363,7 +363,7 @@ func putJasperCredentials(ctx context.Context, env evergreen.Environment, settin
 	ctx, cancel := context.WithTimeout(ctx, scpTimeout)
 	defer cancel()
 
-	if logs, err := h.RunSSHCommandLiterally(ctx, writeCmds, sshOptions); err != nil {
+	if logs, err := h.RunSSHCommand(ctx, writeCmds, sshOptions); err != nil {
 		return errors.Wrapf(err, "error copying credentials to remote machine: command returned %s", logs)
 	}
 
@@ -402,7 +402,7 @@ func setupServiceUser(ctx context.Context, env evergreen.Environment, settings *
 // Jasper binary and restarts the service.
 func doFetchAndReinstallJasper(ctx context.Context, env evergreen.Environment, h *host.Host, sshOptions []string) error {
 	cmd := h.FetchAndReinstallJasperCommands(env.Settings())
-	if logs, err := h.RunSSHCommandLiterally(ctx, cmd, sshOptions); err != nil {
+	if logs, err := h.RunSSHCommand(ctx, cmd, sshOptions); err != nil {
 		return errors.Wrapf(err, "error while fetching Jasper binary and installing service on remote host: command returned '%s'", logs)
 	}
 	return nil
@@ -773,7 +773,7 @@ func (j *setupHostJob) loadClient(ctx context.Context, settings *evergreen.Setti
 	mkdirctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	output, err := j.host.RunSSHCommandLiterally(mkdirctx, fmt.Sprintf("mkdir -m 777 -p ~/%s && (echo 'export PATH=\"$PATH:~/%s\"' >> ~/.profile || true; echo 'export PATH=\"$PATH:~/%s\"' >> ~/.bash_profile || true)", targetDir, targetDir, targetDir), sshOptions)
+	output, err := j.host.RunSSHCommand(mkdirctx, fmt.Sprintf("mkdir -m 777 -p ~/%s && (echo 'export PATH=\"$PATH:~/%s\"' >> ~/.profile || true; echo 'export PATH=\"$PATH:~/%s\"' >> ~/.bash_profile || true)", targetDir, targetDir, targetDir), sshOptions)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error running setup command for cli: %s", output)
 	}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -116,7 +116,7 @@ func (j *setupHostJob) setupHost(ctx context.Context, settings *evergreen.Settin
 	grip.Info(message.Fields{
 		"message": "attempting to setup host",
 		"distro":  j.host.Distro.Id,
-		"hostid":  j.host.Id,
+		"host_id": j.host.Id,
 		"DNS":     j.host.Host,
 		"job":     j.ID(),
 	})
@@ -130,7 +130,7 @@ func (j *setupHostJob) setupHost(ctx context.Context, settings *evergreen.Settin
 		"message": "provisioning host",
 		"job":     j.ID(),
 		"distro":  j.host.Distro.Id,
-		"hostid":  j.host.Id,
+		"host_id": j.host.Id,
 	})
 
 	if err := j.provisionHost(ctx, settings); err != nil {
@@ -150,7 +150,7 @@ func (j *setupHostJob) setupHost(ctx context.Context, settings *evergreen.Settin
 			"message":  "provisioning host encountered error",
 			"job":      j.ID(),
 			"distro":   j.host.Distro.Id,
-			"hostid":   j.host.Id,
+			"host_id":  j.host.Id,
 			"attempts": j.host.ProvisionAttempts,
 		}))
 	}
@@ -173,7 +173,7 @@ func (j *setupHostJob) setupHost(ctx context.Context, settings *evergreen.Settin
 
 	grip.Info(message.Fields{
 		"message":  "successfully finished provisioning host",
-		"hostid":   j.host.Id,
+		"host_id":  j.host.Id,
 		"DNS":      j.host.Host,
 		"distro":   j.host.Distro.Id,
 		"job":      j.ID(),
@@ -781,7 +781,9 @@ func (j *setupHostJob) setupSpawnHost(ctx context.Context, settings *evergreen.S
 	// defer cancel()
 
 	grip.Info(message.Fields{
-		"message": "running script to setup spawn host",
+		"message": "kim: running script to setup spawn host",
+		"host_id": j.host.Id,
+		"distro":  j.host.Distro.Id,
 		"script":  script,
 	})
 	if output, err := j.host.RunSSHShellScriptWithTimeout(ctx, script, sshOpts, 2*time.Minute); err != nil {

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -723,13 +723,6 @@ func (j *setupHostJob) provisionHost(ctx context.Context, settings *evergreen.Se
 	return nil
 }
 
-// // loadClientResult indicates the locations on a target host where the CLI
-// // binary and its config file have been written to.
-// type loadClientResult struct {
-//     BinaryPath string
-//     ConfigPath string
-// }
-
 // setupSpawnHost places the evergreen command line client on the host, places a
 // copy of the user's settings onto the host, and makes the binary appear in the
 // PATH when the user logs in.

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -1,7 +1,6 @@
 package units
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -466,10 +465,7 @@ func copyScript(ctx context.Context, env evergreen.Environment, settings *evergr
 		return errors.Wrapf(err, "error getting ssh options for host %s", h.Id)
 	}
 
-	scpCmdOut := &util.CappedWriter{
-		Buffer:   &bytes.Buffer{},
-		MaxBytes: 1024 * 1024,
-	}
+	scpCmdOut := util.NewMBCappedWriter()
 	scpArgs := buildScpCommand(file.Name(), name, hostInfo, user, sshOptions)
 
 	scpCmd := env.JasperManager().CreateCommand(ctx).Add(scpArgs).
@@ -545,10 +541,7 @@ func (j *setupHostJob) copyScript(ctx context.Context, settings *evergreen.Setti
 		return errors.Wrapf(err, "error getting ssh options for host %v", j.host.Id)
 	}
 
-	scpCmdOut := &util.CappedWriter{
-		Buffer:   &bytes.Buffer{},
-		MaxBytes: 1024 * 1024,
-	}
+	scpCmdOut := util.NewMBCappedWriter()
 	scpArgs := buildScpCommand(file.Name(), name, hostInfo, user, sshOptions)
 
 	scpCmd := j.env.JasperManager().CreateCommand(ctx).Add(scpArgs).
@@ -782,10 +775,7 @@ func (j *setupHostJob) loadClient(ctx context.Context, settings *evergreen.Setti
 	curlctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	curlOut := &util.CappedWriter{
-		Buffer:   &bytes.Buffer{},
-		MaxBytes: 1024 * 1024,
-	}
+	curlOut := util.NewMBCappedWriter()
 
 	curlcmd := j.env.JasperManager().CreateCommand(curlctx).Host(hostSSHInfo.Hostname).User(j.host.User).
 		ExtendRemoteArgs("-p", hostSSHInfo.Port).ExtendRemoteArgs(sshOptions...).
@@ -819,10 +809,7 @@ func (j *setupHostJob) loadClient(ctx context.Context, settings *evergreen.Setti
 	}
 	defer os.Remove(tempFileName)
 
-	scpOut := &util.CappedWriter{
-		Buffer:   &bytes.Buffer{},
-		MaxBytes: 1024 * 1024,
-	}
+	scpOut := util.NewMBCappedWriter()
 
 	scpArgs := buildScpCommand(tempFileName, filepath.Join("~", targetDir, ".evergreen.yml"), hostSSHInfo, j.host.User, sshOptions)
 	scpYmlCommand := j.env.JasperManager().CreateCommand(ctx).Add(scpArgs).
@@ -853,10 +840,7 @@ func (j *setupHostJob) fetchRemoteTaskData(ctx context.Context, taskId, cliPath,
 	}
 	sshOptions = append(sshOptions, "-o", "UserKnownHostsFile=/dev/null")
 
-	cmdOutput := &util.CappedWriter{
-		Buffer:   &bytes.Buffer{},
-		MaxBytes: 1024 * 1024,
-	}
+	cmdOutput := util.NewMBCappedWriter()
 	fetchCmd := fmt.Sprintf("%s -c %s fetch -t %s --source --artifacts --dir='%s'", cliPath, confPath, taskId, j.host.Distro.WorkDir)
 
 	makeShellCmd := j.env.JasperManager().CreateCommand(ctx).Host(hostSSHInfo.Hostname).User(j.host.User).

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -298,7 +298,7 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, settings *evergreen.Set
 		if j.host.Distro.IsPowerShellSetup() {
 			scriptName = evergreen.PowerShellSetupScriptName
 		}
-		err = j.copyScript(ctx, settings, filepath.Join("~", scriptName), j.host.Distro.Setup)
+		err = j.copyScript(ctx, settings, filepath.Join(j.host.Distro.HomeDir(), scriptName), j.host.Distro.Setup)
 		if err != nil {
 			return errors.Wrapf(err, "error copying setup script %s to host %s",
 				scriptName, j.host.Id)
@@ -306,7 +306,7 @@ func (j *setupHostJob) runHostSetup(ctx context.Context, settings *evergreen.Set
 	}
 
 	if j.host.Distro.Teardown != "" {
-		err = j.copyScript(ctx, settings, filepath.Join("~", evergreen.TeardownScriptName), j.host.Distro.Teardown)
+		err = j.copyScript(ctx, settings, filepath.Join(j.host.Distro.HomeDir(), evergreen.TeardownScriptName), j.host.Distro.Teardown)
 		if err != nil {
 			return errors.Wrapf(err, "error copying teardown script %s to host %s",
 				evergreen.TeardownScriptName, j.host.Id)

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -89,7 +88,7 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 
 	if output, err := j.host.RunJasperProcess(ctx, j.env, &options.Create{
 		Args: []string{
-			filepath.Join(j.host.Distro.BootstrapSettings.RootDir, j.host.Distro.BootstrapSettings.ShellPath),
+			j.host.Distro.ShellBinary(),
 			"-l", "-c",
 			fmt.Sprintf("ls %s", path)}}); err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -74,7 +74,7 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 		return
 	}
 
-	path, err := j.host.UserDataDoneFilePath()
+	path, err := j.host.UserDataDoneFile()
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error getting user data done file path",

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -118,7 +118,7 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 		if err := attachVolume(ctx, j.env, j.host); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "can't attach volume",
-				"host":    j.host.Id,
+				"host_id": j.host.Id,
 				"distro":  j.host.Distro.Id,
 				"job":     j.ID(),
 			}))

--- a/units/provisioning_user_data_done_test.go
+++ b/units/provisioning_user_data_done_test.go
@@ -56,7 +56,7 @@ func TestUserDataDoneJob(t *testing.T) {
 			require.Len(t, mngr.Procs, 1)
 			info := mngr.Procs[0].Info(ctx)
 
-			path, err := h.UserDataDoneFilePath()
+			path, err := h.UserDataDoneFile()
 			require.NoError(t, err)
 
 			expectedCmd := []string{h.Distro.BootstrapSettings.ShellPath, "-l", "-c", fmt.Sprintf("ls %s", path)}

--- a/units/ssh_keys_update_static.go
+++ b/units/ssh_keys_update_static.go
@@ -73,7 +73,7 @@ func (j *staticUpdateSSHKeysJob) Run(ctx context.Context) {
 		err := errors.New("authorized keys file on static hosts must be set")
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message": "cannot deploy SSH keys to static host",
-			"host":    j.host.Id,
+			"host_id": j.host.Id,
 			"job":     j.ID(),
 		}))
 		j.AddError(err)
@@ -84,7 +84,7 @@ func (j *staticUpdateSSHKeysJob) Run(ctx context.Context) {
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "could not get SSH options",
-			"host":    j.host.Id,
+			"host_id": j.host.Id,
 			"job":     j.ID(),
 		}))
 		j.AddError(err)
@@ -102,7 +102,7 @@ func (j *staticUpdateSSHKeysJob) Run(ctx context.Context) {
 		if logs, err := j.host.RunSSHCommand(ctx, addKeyCmd, sshOpts); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "could not run SSH command to add to authorized keys",
-				"host":    j.host.Id,
+				"host_id": j.host.Id,
 				"key":     pair.Name,
 				"logs":    logs,
 			}))
@@ -112,7 +112,7 @@ func (j *staticUpdateSSHKeysJob) Run(ctx context.Context) {
 		if err := j.host.AddSSHKeyName(pair.Name); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "could not add SSH key name to host",
-				"host":    j.host.Id,
+				"host_id": j.host.Id,
 				"name":    pair.Name,
 				"job":     j.ID(),
 			}))

--- a/util/capped_writer.go
+++ b/util/capped_writer.go
@@ -13,6 +13,21 @@ type CappedWriter struct {
 	MaxBytes int
 }
 
+// NewCappedWriter is a convenience constructor to create a CappedWriter with no
+// contents and the given size.
+func NewCappedWriter(size int) *CappedWriter {
+	return &CappedWriter{
+		Buffer:   &bytes.Buffer{},
+		MaxBytes: size,
+	}
+}
+
+// NewMBCappedWriter is the same as NewCappedWriter but sets a default size of
+// 1MB.
+func NewMBCappedWriter() *CappedWriter {
+	return NewCappedWriter(1024 * 1024)
+}
+
 // ErrBufferFull indicates that a CappedWriter's bytes.Buffer has MaxBytes bytes.
 var ErrBufferFull = errors.New("buffer full")
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7334

This is an assortment of random, unrelated improvements and cleanup.

* Make convenience functions for running SSH commands. This includes running arbitrary scripts over SSH so there is no chance of shell quoting problems due to faulty argument interpretation.
* Make teardown more reliable by falling back to SSH in case Jasper fails.
* Print output of teardown script to stdout so it can be captured by host termination job.
* Consolidate common commands between setup host job and user data.
* Replace all usages of `*exec.Cmd` with `*jasper.Command`.
* Remove old init system detection code.
* Add TODO for fixing task fetching on Windows legacy SSH spawn hosts (none at this point, but might as well fix).