### PR TITLE
EVG-7165 simplify how we allocate containers

### DIFF
--- a/config_containerpools.go
+++ b/config_containerpools.go
@@ -17,6 +17,8 @@ type ContainerPool struct {
 	MaxContainers int `bson:"max_containers" json:"max_containers" yaml:"max_containers"`
 	// Port number to start at for SSH connections
 	Port uint16 `bson:"port" json:"port" yaml:"port"`
+	// # of images that can be on a single host, defaults to 3 if not set
+	MaxImages int
 }
 
 type ContainerPoolsConfig struct {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -348,6 +348,8 @@ const (
 
 	MaxTagKeyLength   = 128
 	MaxTagValueLength = 256
+
+	ErrorParentNotFound = "Parent not found"
 )
 
 func (h *Host) GetTaskGroupString() string {
@@ -1560,7 +1562,7 @@ func (h *Host) GetParent() (*Host, error) {
 		return nil, errors.Wrap(err, "Error finding parent")
 	}
 	if host == nil {
-		return nil, errors.New("Parent not found")
+		return nil, errors.New(ErrorParentNotFound)
 	}
 	if !host.HasContainers {
 		return nil, errors.New("Host found is not a parent")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1533,13 +1533,14 @@ func (h *Host) GetActiveContainers() ([]Host, error) {
 	if !h.HasContainers {
 		return nil, errors.New("Host does not host containers")
 	}
-	query := db.Query(bson.M{"$or": []bson.M{
-		{ParentIDKey: h.Id},
-		{ParentIDKey: h.Tag},
-		{StatusKey: bson.M{
+	query := db.Query(bson.M{
+		StatusKey: bson.M{
 			"$in": evergreen.UpHostStatus,
-		}},
-	}})
+		},
+		"$or": []bson.M{
+			{ParentIDKey: h.Id},
+			{ParentIDKey: h.Tag},
+		}})
 	hosts, err := Find(query)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error finding containers")

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const maxImagesPerParent = 3
+
 // CreateOptions is a struct of options that are commonly passed around when creating a
 // new cloud host.
 type CreateOptions struct {
@@ -76,61 +78,28 @@ func NewIntent(d distro.Distro, instanceName, provider string, options CreateOpt
 	return intentHost
 }
 
-// GenerateContainerHostIntents generates container intent documents by going
-// through available parents and packing on the parents with longest expected
-// finish time
-func GenerateContainerHostIntents(d distro.Distro, newContainersNeeded int, hostOptions CreateOptions) ([]Host, error) {
-	parents, err := GetNumContainersOnParents(d)
-	if err != nil {
-		return nil, errors.Wrap(err, "Could not find number of containers on each parent")
-	}
-	image, err := d.GetImageID()
-	if err != nil {
-		return nil, errors.Wrapf(err, "error getting image for distro %s", d.Id)
-	}
-	parents = partitionParents(parents, image)
-	containerHostIntents := make([]Host, 0)
-	for _, parent := range parents {
-		// find out how many more containers this parent can fit
-		containerSpace := parent.ParentHost.ContainerPoolSettings.MaxContainers - parent.NumContainers
-		containersToCreate := containerSpace
-		// only create containers as many as we need
-		if newContainersNeeded < containerSpace {
-			containersToCreate = newContainersNeeded
-		}
-		for i := 0; i < containersToCreate; i++ {
-			hostOptions.ParentID = parent.ParentHost.Id
-			containerHostIntents = append(containerHostIntents, *NewIntent(d, d.GenerateName(), d.Provider, hostOptions))
-		}
-		newContainersNeeded -= containersToCreate
-		if newContainersNeeded == 0 {
-			return containerHostIntents, nil
-		}
-	}
-	return containerHostIntents, nil
-}
-
-func partitionParents(parents []ContainersOnParents, image string) []ContainersOnParents {
+// partitionParents will split parent hosts based on those that already have/will have the image for this distro
+// it does not handle scenarios where the image for a distro has changed recently or multiple app servers calling this
+// and racing each other, on the assumption that having to download a small number of extra images is not a big deal
+func partitionParents(parents []ContainersOnParents, distro string) ([]ContainersOnParents, []ContainersOnParents) {
 	matched := []ContainersOnParents{}
 	notMatched := []ContainersOnParents{}
-	for _, h := range parents {
-		if h.ParentHost.ContainerImages[image] {
-			matched = append(matched, h)
-		} else {
-			notMatched = append(notMatched, h)
+parentLoop:
+	for _, parent := range parents {
+		currentImages := map[string]bool{}
+		for _, c := range parent.Containers {
+			currentImages[c.Distro.Id] = true
+			if c.Distro.Id == distro {
+				matched = append(matched, parent)
+				continue parentLoop
+			}
+		}
+		// only return parent hosts that would be below the max if they downloaded another image
+		if len(currentImages) < maxImagesPerParent {
+			notMatched = append(notMatched, parent)
 		}
 	}
-	return append(matched, notMatched...)
-}
-
-// createParents creates host intent documents for each parent
-func createParents(parent distro.Distro, numNewParents int, pool *evergreen.ContainerPool) []Host {
-	hostsSpawned := make([]Host, numNewParents)
-
-	for idx := range hostsSpawned {
-		hostsSpawned[idx] = *NewIntent(parent, parent.GenerateName(), parent.Provider, generateParentCreateOptions(pool))
-	}
-	return hostsSpawned
+	return matched, notMatched
 }
 
 // generateParentCreateOptions generates host options for a parent host
@@ -143,24 +112,61 @@ func generateParentCreateOptions(pool *evergreen.ContainerPool) CreateOptions {
 	return options
 }
 
-func InsertParentIntentsAndGetNumHostsToSpawn(pool *evergreen.ContainerPool, newHostsNeeded int, ignoreMaxHosts bool) ([]Host, int, error) {
-	// find all running parents with the specified container pool
-	numNewParentsToSpawn, newHostsNeeded, err := getNumNewParentsAndHostsToSpawn(pool, newHostsNeeded, ignoreMaxHosts)
+func MakeContainersAndParents(d distro.Distro, pool *evergreen.ContainerPool, newContainersNeeded int, hostOptions CreateOptions) ([]Host, []Host, error) {
+	// get the parents that are up and split into ones that already have a contaienr from this distro
+	currentHosts, err := GetContainersOnParents(d)
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "error getting number of parents to spawn")
+		return nil, nil, errors.Wrap(err, "Could not find number of containers on parents")
 	}
-	if numNewParentsToSpawn <= 0 {
-		return nil, newHostsNeeded, nil
+	matched, notMatched := partitionParents(currentHosts, d.Id)
+	existingHosts := append(matched, notMatched...)
+
+	// add containers to existing parents
+	containersToInsert := []Host{}
+	parentsToInsert := []Host{}
+	containersLeftToCreate := newContainersNeeded
+	for _, parent := range existingHosts {
+		intents := makeContainerIntentsForParent(parent, containersLeftToCreate, d, hostOptions)
+		containersToInsert = append(containersToInsert, intents...)
+		containersLeftToCreate -= len(intents)
+		if containersLeftToCreate <= 0 {
+			return containersToInsert, parentsToInsert, nil
+		}
 	}
 
-	// get parent distro from pool
-	parentDistro, err := distro.FindOne(distro.ById(pool.Distro))
+	// create new parents and add containers to them
+	numNewParents, _, err := getNumNewParentsAndHostsToSpawn(pool, containersLeftToCreate, false)
+	parentDistro, err := distro.FindByID(pool.Distro)
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "error find parent distro")
+		return nil, nil, errors.Wrap(err, "error finding distro")
 	}
-	newParentHosts := createParents(parentDistro, numNewParentsToSpawn, pool)
-	if err = InsertMany(newParentHosts); err != nil {
-		return nil, 0, errors.Wrap(err, "error inserting new parent hosts")
+	if parentDistro == nil {
+		return nil, nil, errors.Errorf("distro %s not found", pool.Distro)
 	}
-	return newParentHosts, newHostsNeeded, nil
+	for i := 0; i < numNewParents; i++ {
+		newParent := NewIntent(*parentDistro, parentDistro.GenerateName(), parentDistro.Provider, generateParentCreateOptions(pool))
+		parentsToInsert = append(parentsToInsert, *newParent)
+		parentInfo := ContainersOnParents{ParentHost: *newParent}
+		intents := makeContainerIntentsForParent(parentInfo, containersLeftToCreate, d, hostOptions)
+		containersToInsert = append(containersToInsert, intents...)
+		containersLeftToCreate -= len(intents)
+	}
+
+	return containersToInsert, parentsToInsert, nil
+}
+
+func makeContainerIntentsForParent(parent ContainersOnParents, newContainersNeeded int, d distro.Distro, hostOptions CreateOptions) []Host {
+	// find out how many more containers this parent can fit
+	containerSpace := parent.ParentHost.ContainerPoolSettings.MaxContainers - len(parent.Containers)
+	containersToCreate := containerSpace
+	// only create containers as many as we need
+	if newContainersNeeded < containerSpace {
+		containersToCreate = newContainersNeeded
+	}
+	containerHostIntents := []Host{}
+	for i := 0; i < containersToCreate; i++ {
+		hostOptions.ParentID = parent.ParentHost.Id
+		containerHostIntents = append(containerHostIntents, *NewIntent(d, d.GenerateName(), d.Provider, hostOptions))
+	}
+	return containerHostIntents
 }

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -136,6 +136,9 @@ func MakeContainersAndParents(d distro.Distro, pool *evergreen.ContainerPool, ne
 
 	// create new parents and add containers to them
 	numNewParents, _, err := getNumNewParentsAndHostsToSpawn(pool, containersLeftToCreate, false)
+	if err != nil {
+		return nil, nil, err
+	}
 	parentDistro, err := distro.FindByID(pool.Distro)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error finding distro")

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4675,7 +4675,7 @@ func TestPartitionParents(t *testing.T) {
 		{ParentHost: Host{Id: "3"}, Containers: []Host{{Distro: distro.Distro{Id: distroId}}, {Distro: distro.Distro{Id: "foo"}}}},
 		{ParentHost: Host{Id: "4"}, Containers: []Host{{Distro: distro.Distro{Id: "foo"}}}},
 	}
-	matched, notMatched := partitionParents(parents, distroId)
+	matched, notMatched := partitionParents(parents, distroId, evergreen.ContainerPool{})
 	assert.Len(matched, 2)
 	assert.Len(notMatched, 2)
 	assert.Equal("1", matched[0].ParentHost.Id)
@@ -4686,7 +4686,7 @@ func TestPartitionParents(t *testing.T) {
 	parents = []ContainersOnParents{
 		{ParentHost: Host{Id: "1"}, Containers: []Host{{Distro: distro.Distro{Id: "1"}}, {Distro: distro.Distro{Id: "2"}}, {Distro: distro.Distro{Id: "3"}}}},
 	}
-	matched, notMatched = partitionParents(parents, distroId)
+	matched, notMatched = partitionParents(parents, distroId, evergreen.ContainerPool{})
 	assert.Len(matched, 0)
 	assert.Len(notMatched, 0)
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4675,7 +4675,7 @@ func TestPartitionParents(t *testing.T) {
 		{ParentHost: Host{Id: "3"}, Containers: []Host{{Distro: distro.Distro{Id: distroId}}, {Distro: distro.Distro{Id: "foo"}}}},
 		{ParentHost: Host{Id: "4"}, Containers: []Host{{Distro: distro.Distro{Id: "foo"}}}},
 	}
-	matched, notMatched := partitionParents(parents, distroId, evergreen.ContainerPool{})
+	matched, notMatched := partitionParents(parents, distroId, defaultMaxImagesPerParent)
 	assert.Len(matched, 2)
 	assert.Len(notMatched, 2)
 	assert.Equal("1", matched[0].ParentHost.Id)
@@ -4686,7 +4686,7 @@ func TestPartitionParents(t *testing.T) {
 	parents = []ContainersOnParents{
 		{ParentHost: Host{Id: "1"}, Containers: []Host{{Distro: distro.Distro{Id: "1"}}, {Distro: distro.Distro{Id: "2"}}, {Distro: distro.Distro{Id: "3"}}}},
 	}
-	matched, notMatched = partitionParents(parents, distroId, evergreen.ContainerPool{})
+	matched, notMatched = partitionParents(parents, distroId, defaultMaxImagesPerParent)
 	assert.Len(matched, 0)
 	assert.Len(notMatched, 0)
 }

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -71,7 +71,6 @@ func TestMakeIntentHost(t *testing.T) {
 	assert.Equal(true, ec2Settings.IsVpc)
 
 	// test roundtripping
-	assert.NoError(h.Insert())
 	h, err = host.FindOneByIdOrTag(h.Id)
 	assert.NoError(err)
 	require.NotNil(h)
@@ -139,7 +138,6 @@ func TestMakeIntentHost(t *testing.T) {
 	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
 
-	assert.NoError(h.Insert())
 	h, err = host.FindOneByIdOrTag(h.Id)
 	assert.NoError(err)
 	require.NotNil(h)
@@ -284,18 +282,15 @@ func TestHostCreateDocker(t *testing.T) {
 	assert.Equal("my-image", h.DockerOptions.Image)
 	assert.Equal("echo hello", h.DockerOptions.Command)
 	assert.Equal("myregistry", h.DockerOptions.RegistryName)
-	hosts, err := host.Find(db.Q{})
-	assert.NoError(err)
-	require.Len(hosts, 1)
 
 	poolConfig := evergreen.ContainerPoolsConfig{Pools: []evergreen.ContainerPool{*pool}}
 	settings := evergreen.Settings{ContainerPools: poolConfig}
 	assert.NoError(evergreen.UpdateConfig(&settings))
 	assert.Equal(200, handler.Run(context.Background()).Status())
 
-	hosts, err = host.Find(db.Q{})
+	hosts, err := host.Find(db.Q{})
 	assert.NoError(err)
-	require.Len(hosts, 2)
+	require.Len(hosts, 3)
 	assert.Equal(h.DockerOptions.Command, hosts[1].DockerOptions.Command)
 }
 
@@ -346,7 +341,6 @@ func TestGetDockerLogs(t *testing.T) {
 	h, err := handler.sc.MakeIntentHost("task-id", "", "", c)
 	assert.NotEmpty(h.ParentID)
 	require.NoError(err)
-	require.NoError(h.Insert())
 
 	poolConfig := evergreen.ContainerPoolsConfig{Pools: []evergreen.ContainerPool{*pool}}
 	settings := evergreen.Settings{ContainerPools: poolConfig}
@@ -451,7 +445,6 @@ func TestGetDockerStatus(t *testing.T) {
 	h, err := handler.sc.MakeIntentHost("task-id", "", "", c)
 	assert.NotEmpty(h.ParentID)
 	require.NoError(err)
-	require.NoError(h.Insert())
 
 	url := fmt.Sprintf("/hosts/%s/logs/status", h.Id)
 	options := map[string]string{"host_id": h.Id}

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -219,11 +219,11 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	if j.host.ParentID != "" {
 		var parent *host.Host
 		parent, err = j.host.GetParent()
-		if err != nil {
+		if err != nil && err.Error() != host.ErrorParentNotFound {
 			j.AddError(errors.Wrapf(err, "problem finding parent of '%s'", j.host.Id))
 			return
 		}
-		if parent.Status == evergreen.HostTerminated {
+		if parent.Status == evergreen.HostTerminated || err.Error() == host.ErrorParentNotFound {
 			if err = j.host.Terminate(evergreen.User, "parent was already terminated"); err != nil {
 				j.AddError(errors.Wrap(err, "problem terminating container in db"))
 				grip.Error(message.WrapError(err, message.Fields{


### PR DESCRIPTION
Previously, the approach was to pack containers on as few parent hosts as possible, because that would minimize cost. This changes that behavior to pack containers from the same distro (and thus image, usually) onto the same host, because that will minimize latency. It also sets a cap of 3 distros on the same host to make it unlikely that downloading many different images will fill up the disk