### PR TITLE
EVG-7324 respect min hosts for parents

### DIFF
--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -140,12 +140,20 @@ func BySpawnAllowed() db.Q {
 	return db.Query(bson.M{SpawnAllowedKey: true})
 }
 
-// ByActiveOrStatic returns a query that selects only active or static distros
-func ByActiveOrStatic() db.Q {
-	return db.Query(bson.M{"$or": []bson.M{
-		bson.M{DisabledKey: bson.M{"$exists": false}},
-		bson.M{ProviderKey: evergreen.HostTypeStatic},
-	}})
+// ByNeedsPlanning returns a query that selects only active or static distros that don't run containers
+func ByNeedsPlanning(containerPools []evergreen.ContainerPool) db.Q {
+	poolDistros := []string{}
+	for _, pool := range containerPools {
+		poolDistros = append(poolDistros, pool.Distro)
+	}
+	return db.Query(bson.M{
+		"_id": bson.M{
+			"$nin": poolDistros,
+		},
+		"$or": []bson.M{
+			bson.M{DisabledKey: bson.M{"$exists": false}},
+			bson.M{ProviderKey: evergreen.HostTypeStatic},
+		}})
 }
 
 // ByIds creates a query that finds all distros for the given ids and implicitly

--- a/units/crons.go
+++ b/units/crons.go
@@ -482,7 +482,7 @@ func PopulateHostAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 		}
 
 		// find all active distros
-		distros, err := distro.Find(distro.ByActiveOrStatic())
+		distros, err := distro.Find(distro.ByNeedsPlanning(env.Settings().ContainerPools.Pools))
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -523,7 +523,7 @@ func PopulateSchedulerJobs(env evergreen.Environment) amboy.QueueOperation {
 		catcher.Add(err)
 
 		// find all active distros
-		distros, err := distro.Find(distro.ByActiveOrStatic())
+		distros, err := distro.Find(distro.ByNeedsPlanning(env.Settings().ContainerPools.Pools))
 		catcher.Add(err)
 
 		grip.InfoWhen(sometimes.Percent(10), message.Fields{
@@ -586,7 +586,7 @@ func PopulateAliasSchedulerJobs(env evergreen.Environment) amboy.QueueOperation 
 		catcher.Add(err)
 
 		// find all active distros
-		distros, err := distro.Find(distro.ByActiveOrStatic())
+		distros, err := distro.Find(distro.ByNeedsPlanning(env.Settings().ContainerPools.Pools))
 		catcher.Add(err)
 
 		lastRuntime, err := model.FindTaskQueueGenerationRuntime()


### PR DESCRIPTION
Previously the scheduler was creating host intents for parent distros in the same way that it creates other hosts, so that it didn't get marked as running containers. This now makes the scheduler skip planning parent distros, and also makes the job that deco's parents handle min hosts