### PR TITLE
EVG-7334: move user-data-specific spawn host fetch

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -382,6 +382,14 @@ func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Cr
 		if postFetchClient, err = h.SpawnHostSetupCommands(settings); err != nil {
 			return "", errors.Wrap(err, "error creating commands to load task data")
 		}
+		if h.ProvisionOptions.TaskId != "" {
+			fetchCmd := h.SpawnHostGetTaskDataCommand()
+			getTaskDataCmd, err := h.buildLocalJasperClientRequest(settings.HostJasper, strings.Join([]string{jcli.ManagerCommand, jcli.CreateCommand}, " "), &options.Command{Commands: [][]string{fetchCmd}})
+			if err != nil {
+				return "", errors.Wrap(err, "could not construct Jasper command to fetch task data")
+			}
+			postFetchClient += " && " + getTaskDataCmd
+		}
 	}
 
 	markDone, err := h.MarkUserDataDoneCommands()
@@ -948,7 +956,7 @@ func (h *Host) AgentMonitorOptions(settings *evergreen.Settings) *options.Create
 }
 
 // SpawnHostSetupCommands returns the commands to handle setting up a spawn
-// host.
+// host with the evergreen binary and config file for the owner.
 func (h *Host) SpawnHostSetupCommands(settings *evergreen.Settings) (string, error) {
 	if h.ProvisionOptions == nil {
 		return "", errors.New("missing spawn host provisioning options")
@@ -962,17 +970,7 @@ func (h *Host) SpawnHostSetupCommands(settings *evergreen.Settings) (string, err
 		return "", errors.Wrap(err, "could not create JSON configuration settings")
 	}
 
-	script := h.spawnHostSetupConfigDirCommands(confJSON)
-	if h.ProvisionOptions.TaskId != "" {
-		fetchCmd := h.SpawnHostGetTaskDataCommand()
-		jasperFetchCmd, err := h.buildLocalJasperClientRequest(settings.HostJasper, strings.Join([]string{jcli.ManagerCommand, jcli.CreateCommand}, " "), &options.Command{Commands: [][]string{fetchCmd}})
-		if err != nil {
-			return "", errors.Wrap(err, "could not construct Jasper command to fetch task data")
-		}
-		script += " && " + jasperFetchCmd
-	}
-
-	return script, nil
+	return h.spawnHostSetupConfigDirCommands(confJSON), nil
 }
 
 // spawnHostSetupConfigDirCommands the shell script that sets up the

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -384,7 +384,8 @@ func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Cr
 		}
 		if h.ProvisionOptions.TaskId != "" {
 			fetchCmd := h.SpawnHostGetTaskDataCommand()
-			getTaskDataCmd, err := h.buildLocalJasperClientRequest(settings.HostJasper, strings.Join([]string{jcli.ManagerCommand, jcli.CreateCommand}, " "), &options.Command{Commands: [][]string{fetchCmd}})
+			var getTaskDataCmd string
+			getTaskDataCmd, err = h.buildLocalJasperClientRequest(settings.HostJasper, strings.Join([]string{jcli.ManagerCommand, jcli.CreateCommand}, " "), &options.Command{Commands: [][]string{fetchCmd}})
 			if err != nil {
 				return "", errors.Wrap(err, "could not construct Jasper command to fetch task data")
 			}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7334

* Move user data specific command to user data script.
* Only apply curl timeout to curl command.