### PR TITLE
EVG-7232 only update distro settings in logged places

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -247,7 +247,6 @@ func ConvertContainerManager(m Manager) (ContainerManager, error) {
 // this updates the local provider settings list
 func UpdateProviderSettings(d *distro.Distro) error {
 	if d.ProviderSettings != nil {
-
 		bytes, err := bson.Marshal(d.ProviderSettings)
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"time"
 
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // ProviderSettings exposes provider-specific configuration settings for a Manager.
@@ -238,4 +242,31 @@ func ConvertContainerManager(m Manager) (ContainerManager, error) {
 		return cm, nil
 	}
 	return nil, errors.New("Error converting manager to container manager")
+}
+
+// this updates the local provider settings list
+func UpdateProviderSettings(d *distro.Distro) error {
+	if d.ProviderSettings != nil {
+
+		bytes, err := bson.Marshal(d.ProviderSettings)
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		doc := &birch.Document{}
+		if err := doc.UnmarshalBSON(bytes); err != nil {
+			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
+		}
+		if IsEc2Provider(d.Provider) {
+			doc = doc.Set(birch.EC.String("region", evergreen.DefaultEC2Region))
+		}
+		d.ProviderSettingsList = []*birch.Document{doc}
+	}
+	grip.Debug(message.Fields{
+		"message":                "updating provider settings list",
+		"distro_id":              d.Id,
+		"provider_settings_list": d.ProviderSettingsList,
+		"provider_settings":      d.ProviderSettings,
+		"provider":               d.Provider,
+	})
+	return nil
 }

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -49,24 +48,6 @@ func (s *dockerSettings) FromDistroSettings(d distro.Distro, _ string) error {
 	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
-		}
-		bytes, err := bson.Marshal(s)
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		doc := &birch.Document{}
-		if err := doc.UnmarshalBSON(bytes); err != nil {
-			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
-		}
-		if len(d.ProviderSettingsList) == 0 {
-			if err := d.UpdateProviderSettings(doc); err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"distro":   d.Id,
-					"provider": d.Provider,
-					"settings": d.ProviderSettings,
-				}))
-				return errors.Wrapf(err, "error updating provider settings")
-			}
 		}
 	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -101,6 +101,11 @@ func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string)
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}
+		grip.Debug(message.Fields{
+			"message": "mapstructure comparison",
+			"input":   *d.ProviderSettings,
+			"output":  *s,
+		})
 		s.Region = s.getRegion()
 		if s.Region != evergreen.DefaultEC2Region {
 			return errors.Errorf("only default region should be saved in provider settings")

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -101,7 +101,8 @@ func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string)
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}
-		if s.getRegion() != evergreen.DefaultEC2Region {
+		s.Region = s.getRegion()
+		if s.Region != evergreen.DefaultEC2Region {
 			return errors.Errorf("only default region should be saved in provider settings")
 		}
 	} else if len(d.ProviderSettingsList) != 0 {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -7,11 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/birch"
-	"go.mongodb.org/mongo-driver/bson"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
@@ -21,6 +19,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 var (

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/birch"
+	"go.mongodb.org/mongo-driver/bson"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/evergreen-ci/evergreen"
@@ -1265,31 +1268,31 @@ func (s *EC2Suite) TestFromDistroSettings() {
 	s.Equal(float64(0.001), ec2Settings.BidPrice)
 	s.Equal(evergreen.DefaultEC2Region, ec2Settings.Region)
 
-	// TODO: include this after EVG-7329
 	// create provider list, choose by region
-	//settings2 := EC2ProviderSettings{
-	//	Region:           "us-east-2",
-	//	AMI:              "other_ami",
-	//	InstanceType:     "other_instance",
-	//	SecurityGroupIDs: []string{"ghijkl"},
-	//	BidPrice:         float64(0.002),
-	//	AWSKeyID:         "other_key_id",
-	//	KeyName:          "other_key",
-	//}
-	//bytes, err := bson.Marshal(ec2Settings)
-	//s.NoError(err)
-	//doc1 := &birch.Document{}
-	//s.NoError(doc1.UnmarshalBSON(bytes))
-	//
-	//bytes, err = bson.Marshal(settings2)
-	//s.NoError(err)
-	//doc2 := &birch.Document{}
-	//s.NoError(doc2.UnmarshalBSON(bytes))
-	//d.ProviderSettingsList = []*birch.Document{doc1, doc2}
-	//
-	//s.NoError(ec2Settings.FromDistroSettings(d, "us-east-2"))
-	//s.Equal(ec2Settings.Region, "us-east-2")
-	//s.Equal(ec2Settings.InstanceType, "other_instance")
+	settings2 := EC2ProviderSettings{
+		Region:           "us-east-2",
+		AMI:              "other_ami",
+		InstanceType:     "other_instance",
+		SecurityGroupIDs: []string{"ghijkl"},
+		BidPrice:         float64(0.002),
+		AWSKeyID:         "other_key_id",
+		KeyName:          "other_key",
+	}
+	bytes, err := bson.Marshal(ec2Settings)
+	s.NoError(err)
+	doc1 := &birch.Document{}
+	s.NoError(doc1.UnmarshalBSON(bytes))
+
+	bytes, err = bson.Marshal(settings2)
+	s.NoError(err)
+	doc2 := &birch.Document{}
+	s.NoError(doc2.UnmarshalBSON(bytes))
+	d.ProviderSettingsList = []*birch.Document{doc1, doc2}
+	d.ProviderSettings = nil
+
+	s.NoError(ec2Settings.FromDistroSettings(d, "us-east-2"))
+	s.Equal(ec2Settings.Region, "us-east-2")
+	s.Equal(ec2Settings.InstanceType, "other_instance")
 }
 
 func (s *EC2Suite) TestGetEC2ManagerOptions() {

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -5,7 +5,6 @@ package cloud
 import (
 	"context"
 
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -74,24 +73,6 @@ func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
 	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
-		}
-		bytes, err := bson.Marshal(opts)
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		doc := &birch.Document{}
-		if err := doc.UnmarshalBSON(bytes); err != nil {
-			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
-		}
-		if len(d.ProviderSettingsList) == 0 {
-			if err := d.UpdateProviderSettings(doc); err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"distro":   d.Id,
-					"provider": d.Provider,
-					"settings": d.ProviderSettings,
-				}))
-				return errors.Wrapf(err, "error updating provider settings")
-			}
 		}
 	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -56,24 +55,6 @@ func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) err
 	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
-		}
-		bytes, err := bson.Marshal(opts)
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		doc := &birch.Document{}
-		if err := doc.UnmarshalBSON(bytes); err != nil {
-			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
-		}
-		if len(d.ProviderSettingsList) == 0 {
-			if err := d.UpdateProviderSettings(doc); err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"distro":   d.Id,
-					"provider": d.Provider,
-					"settings": d.ProviderSettings,
-				}))
-				return errors.Wrapf(err, "error updating provider settings")
-			}
 		}
 	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -12,7 +11,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -49,24 +47,6 @@ func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
 	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
-		}
-		bytes, err := bson.Marshal(s)
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		doc := &birch.Document{}
-		if err := doc.UnmarshalBSON(bytes); err != nil {
-			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
-		}
-		if len(d.ProviderSettingsList) == 0 {
-			if err := d.UpdateProviderSettings(doc); err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"distro":   d.Id,
-					"provider": d.Provider,
-					"settings": d.ProviderSettings,
-				}))
-				return errors.Wrapf(err, "error updating provider settings")
-			}
 		}
 	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -58,24 +57,6 @@ func (opts *vsphereSettings) FromDistroSettings(d distro.Distro, _ string) error
 	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
-		}
-		bytes, err := bson.Marshal(opts)
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		doc := &birch.Document{}
-		if err := doc.UnmarshalBSON(bytes); err != nil {
-			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
-		}
-		if len(d.ProviderSettingsList) == 0 {
-			if err := d.UpdateProviderSettings(doc); err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"distro":   d.Id,
-					"provider": d.Provider,
-					"settings": d.ProviderSettings,
-				}))
-				return errors.Wrapf(err, "error updating provider settings")
-			}
 		}
 	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -1,7 +1,6 @@
 package distro
 
 import (
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
@@ -107,17 +106,6 @@ func (d *Distro) Insert() error {
 // Update updates one distro.
 func (d *Distro) Update() error {
 	return db.UpdateId(Collection, d.Id, d)
-}
-
-func (d *Distro) UpdateProviderSettings(doc *birch.Document) error {
-	if d.ProviderSettingsList == nil {
-		d.ProviderSettingsList = []*birch.Document{}
-	}
-	d.ProviderSettingsList = append(d.ProviderSettingsList, doc)
-	if err := d.Update(); err != nil && !adb.ResultsNotFound(err) {
-		return errors.Wrapf(err, "error updating distro")
-	}
-	return nil
 }
 
 // Remove removes one distro.

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/certdepot"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -221,24 +220,6 @@ func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
 	if d.ProviderSettings != nil {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
-		}
-		bytes, err := bson.Marshal(opts)
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		doc := &birch.Document{}
-		if err := doc.UnmarshalBSON(bytes); err != nil {
-			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
-		}
-		if len(d.ProviderSettingsList) == 0 {
-			if err := d.UpdateProviderSettings(doc); err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"distro":   d.Id,
-					"provider": d.Provider,
-					"settings": d.ProviderSettings,
-				}))
-				return errors.Wrapf(err, "error updating provider settings")
-			}
 		}
 	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()

--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -63,7 +63,6 @@ func (dc *DBDistroConnector) UpdateDistro(old, new *distro.Distro) error {
 			}
 		}
 	}
-	new.ProviderSettingsList = nil
 	err := new.Update()
 	if err != nil {
 		return gimlet.ErrorResponse{

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -729,6 +729,17 @@ func (s *DistroPatchByIDSuite) TestRunValidProviderSettings() {
 	s.Equal(apiDistro.ProviderSettings["key_name"], "mci")
 	s.Equal(apiDistro.ProviderSettings["security_group"], "password123")
 	s.Equal(apiDistro.ProviderSettings["ami"], "ami-2814683f")
+
+	s.Require().Len(apiDistro.ProviderSettingsList, 1)
+	doc := apiDistro.ProviderSettingsList[0]
+	mappedDoc := doc.Lookup("mount_points").MutableDocument()
+	s.Equal(mappedDoc.Lookup("device_name").StringValue(), "/dev/xvdb")
+	s.Equal(mappedDoc.Lookup("virtual_name").StringValue(), "ephemeral0")
+	s.Equal(doc.Lookup("bid_price").Double(), .15)
+	s.Equal(doc.Lookup("instance_type").StringValue(), "m3.large")
+	s.Equal(doc.Lookup("key_name").StringValue(), "mci")
+	s.Equal(doc.Lookup("security_group").StringValue(), "password123")
+	s.Equal(doc.Lookup("ami").StringValue(), "ami-2814683f")
 }
 
 func (s *DistroPatchByIDSuite) TestRunValidArch() {
@@ -927,7 +938,7 @@ func (s *DistroPatchByIDSuite) TestRunValidContainer() {
 
 func (s *DistroPatchByIDSuite) TestRunInvalidEmptyStringValues() {
 	ctx := context.Background()
-	json := []byte(`{"arch": "","user": "","work_dir": "","ssh_key": "","provider": ""}`)
+	json := []byte(`{"arch": "","user": "","work_dir": "","ssh_key": "","provider": "mock"}`)
 	h := s.rm.(*distroIDPatchHandler)
 	h.distroID = "fedora8"
 	h.body = json
@@ -942,7 +953,6 @@ func (s *DistroPatchByIDSuite) TestRunInvalidEmptyStringValues() {
 		"ERROR: distro 'user' cannot be blank",
 		"ERROR: distro 'work_dir' cannot be blank",
 		"ERROR: distro 'ssh_key' cannot be blank",
-		"ERROR: distro 'provider' cannot be blank",
 	}
 
 	error := (resp.Data()).(gimlet.ErrorResponse)

--- a/service/distros.go
+++ b/service/distros.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -121,6 +122,13 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// for now, assume we only handle one region, so return a new document
+	if err = cloud.UpdateProviderSettings(&newDistro); err != nil {
+		message := fmt.Sprintf("error updating provider settings: %v", err)
+		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
+		http.Error(w, message, http.StatusInternalServerError)
+		return
+	}
 	if newDistro.PlannerSettings.Version == "" {
 		newDistro.PlannerSettings.Version = evergreen.PlannerVersionLegacy
 	}
@@ -285,7 +293,12 @@ func (uis *UIServer) addDistro(w http.ResponseWriter, r *http.Request) {
 	if hasId {
 		d.Id = id
 	}
-
+	if err := cloud.UpdateProviderSettings(&d); err != nil {
+		message := fmt.Sprintf("error creating provider settings: %v", err)
+		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
+		http.Error(w, message, http.StatusInternalServerError)
+		return
+	}
 	vErrs, err := validator.CheckDistro(r.Context(), &d, &uis.Settings, true)
 	if err != nil {
 		message := fmt.Sprintf("error retrieving distroIds: %v", err)

--- a/service/distros.go
+++ b/service/distros.go
@@ -293,7 +293,7 @@ func (uis *UIServer) addDistro(w http.ResponseWriter, r *http.Request) {
 	if hasId {
 		d.Id = id
 	}
-	if err := cloud.UpdateProviderSettings(&d); err != nil {
+	if err = cloud.UpdateProviderSettings(&d); err != nil {
 		message := fmt.Sprintf("error creating provider settings: %v", err)
 		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
 		http.Error(w, message, http.StatusInternalServerError)


### PR DESCRIPTION
This to maybe fix the weird "overwriting AMIs and distro provider" thing by not calling a different Update for provider settings list.