### PR TITLE
EVG-7210: Expose URLs for html & raw logs in TestLog GQL type

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -160,10 +160,8 @@ type ComplexityRoot struct {
 	}
 
 	TestLog struct {
-		LineNum func(childComplexity int) int
-		LogId   func(childComplexity int) int
-		URL     func(childComplexity int) int
-		URLRaw  func(childComplexity int) int
+		HTMLDisplayURL func(childComplexity int) int
+		RawDisplayURL  func(childComplexity int) int
 	}
 
 	TestResult struct {
@@ -832,33 +830,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TaskLogs.TaskLogLink(childComplexity), true
 
-	case "TestLog.lineNum":
-		if e.complexity.TestLog.LineNum == nil {
+	case "TestLog.htmlDisplayURL":
+		if e.complexity.TestLog.HTMLDisplayURL == nil {
 			break
 		}
 
-		return e.complexity.TestLog.LineNum(childComplexity), true
+		return e.complexity.TestLog.HTMLDisplayURL(childComplexity), true
 
-	case "TestLog.logId":
-		if e.complexity.TestLog.LogId == nil {
+	case "TestLog.rawDisplayURL":
+		if e.complexity.TestLog.RawDisplayURL == nil {
 			break
 		}
 
-		return e.complexity.TestLog.LogId(childComplexity), true
-
-	case "TestLog.url":
-		if e.complexity.TestLog.URL == nil {
-			break
-		}
-
-		return e.complexity.TestLog.URL(childComplexity), true
-
-	case "TestLog.urlRaw":
-		if e.complexity.TestLog.URLRaw == nil {
-			break
-		}
-
-		return e.complexity.TestLog.URLRaw(childComplexity), true
+		return e.complexity.TestLog.RawDisplayURL(childComplexity), true
 
 	case "TestResult.duration":
 		if e.complexity.TestResult.Duration == nil {
@@ -1109,10 +1093,8 @@ enum TaskSortCategory {
 	TEST_NAME
 }
 type TestLog {
-	url: String
-	urlRaw: String
-	lineNum: Int
-	logId: String
+	htmlDisplayURL: String
+	rawDisplayURL: String
 }
 type TestResult {
 	id: String!
@@ -4172,7 +4154,7 @@ func (ec *executionContext) _TaskLogs_taskLogLink(ctx context.Context, field gra
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _TestLog_url(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
+func (ec *executionContext) _TestLog_htmlDisplayURL(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -4189,7 +4171,7 @@ func (ec *executionContext) _TestLog_url(ctx context.Context, field graphql.Coll
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.URL, nil
+		return obj.HTMLDisplayURL, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4203,7 +4185,7 @@ func (ec *executionContext) _TestLog_url(ctx context.Context, field graphql.Coll
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _TestLog_urlRaw(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
+func (ec *executionContext) _TestLog_rawDisplayURL(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -4220,69 +4202,7 @@ func (ec *executionContext) _TestLog_urlRaw(ctx context.Context, field graphql.C
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.URLRaw, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _TestLog_lineNum(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:   "TestLog",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.LineNum, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalOInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _TestLog_logId(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:   "TestLog",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.LogId, nil
+		return obj.RawDisplayURL, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6308,14 +6228,10 @@ func (ec *executionContext) _TestLog(ctx context.Context, sel ast.SelectionSet, 
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("TestLog")
-		case "url":
-			out.Values[i] = ec._TestLog_url(ctx, field, obj)
-		case "urlRaw":
-			out.Values[i] = ec._TestLog_urlRaw(ctx, field, obj)
-		case "lineNum":
-			out.Values[i] = ec._TestLog_lineNum(ctx, field, obj)
-		case "logId":
-			out.Values[i] = ec._TestLog_logId(ctx, field, obj)
+		case "htmlDisplayURL":
+			out.Values[i] = ec._TestLog_htmlDisplayURL(ctx, field, obj)
+		case "rawDisplayURL":
+			out.Values[i] = ec._TestLog_rawDisplayURL(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -1536,6 +1536,749 @@
   },
   "tests": [
     {
+      "query_file": "user-patches.graphql",
+      "result": {
+        "data": {
+          "userPatches": [
+            {
+              "id": "5e1f8ab8834b87d7b5d251a5",
+              "description": "mydesc",
+              "projectID": "mci",
+              "githash": "7ad0c6bb0d5b8586f3a0442f365e259d40f5a7f1",
+              "patchNumber": 1,
+              "author": "testuser",
+              "version": "",
+              "status": "created",
+              "tasks": ["test-auth"],
+              "activated": false,
+              "alias": "",
+              "variants": ["rhel62"],
+              "variantsTasks": [
+                { "name": "rhel62", "tasks": ["test-model-host"] }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "patch.graphql",
+      "result": {
+        "data": {
+          "patch": {
+            "id": "5e1f8ab8834b87d7b5d251a5",
+            "description": "mydesc",
+            "projectID": "mci",
+            "githash": "7ad0c6bb0d5b8586f3a0442f365e259d40f5a7f1",
+            "patchNumber": 1,
+            "author": "testuser",
+            "version": "",
+            "status": "created",
+            "tasks": ["test-auth"],
+            "activated": false,
+            "alias": "",
+            "variants": ["rhel62"],
+            "variantsTasks": [
+              { "name": "rhel62", "tasks": ["test-model-host"] }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patch-does-not-exist.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "400 (Bad Request): id 'i-dont-exist' is not a valid patch id",
+            "path": ["patch"],
+            "extensions": {
+              "code": "INTERNAL_SERVER_ERROR"
+            }
+          }
+        ],
+        "data": null
+      }
+    },
+    {
+      "query_file": "task1.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "logs": {
+              "allLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=ALL",
+              "taskLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=T",
+              "agentLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=E",
+              "systemLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=S"
+            },
+            "id": "wuzzup",
+            "createTime": "2018-01-10T19:01:36-05:00",
+            "ingestTime": "2018-01-10T19:01:36-05:00",
+            "dispatchTime": "2018-01-10T19:01:36-05:00",
+            "scheduledTime": "2018-01-10T19:01:36-05:00",
+            "startTime": "2018-01-10T19:01:36-05:00",
+            "finishTime": "2018-01-10T19:01:36-05:00",
+            "activatedTime": "2018-01-10T19:01:36-05:00",
+            "version": "version",
+            "projectId": "id",
+            "revision": "revise",
+            "priority": 5,
+            "taskGroup": "grp",
+            "taskGroupMaxHosts": 100,
+            "activated": false,
+            "activatedBy": "someone",
+            "buildId": "some_thang",
+            "distroId": "distro",
+            "buildVariant": "variant",
+            "dependsOn": null,
+            "displayName": "exec1 display name",
+            "hostId": "host",
+            "restarts": 5,
+            "execution": 5,
+            "order": 5,
+            "requester": "something",
+            "status": "pass",
+            "details": {
+              "status": "status",
+              "type": "type",
+              "description": "description",
+              "timedOut": false
+            },
+            "displayOnly": true,
+            "executionTasks": ["exec1"],
+            "generateTask": false,
+            "generatedBy": "something"
+          }
+        }
+      }
+    },
+    {
+      "query_file": "taskTestStatusAsc.graphql",
+      "result": {
+        "data": {
+          "taskTests": [
+            { "status": "a" },
+            { "status": "b" },
+            { "status": "c" },
+            { "status": "dog" }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "taskTestStatusDesc.graphql",
+      "result": {
+        "data": {
+          "taskTests": [
+            { "status": "dog" },
+            { "status": "c" },
+            { "status": "b" },
+            { "status": "a" }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "taskTestNameAsc.graphql",
+      "result": {
+        "data": {
+          "taskTests": [
+            { "testFile": "apple" },
+            { "testFile": "b" },
+            { "testFile": "c" },
+            { "testFile": "d" }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "taskTestNameDesc.graphql",
+      "result": {
+        "data": {
+          "taskTests": [
+            { "testFile": "d" },
+            { "testFile": "c" },
+            { "testFile": "b" },
+            { "testFile": "apple" }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "taskTestDurationDesc.graphql",
+      "result": {
+        "data": {
+          "taskTests": [
+            { "duration": 40 },
+            { "duration": 30 },
+            { "duration": 20 },
+            { "duration": 10 }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "taskTestDurationAsc.graphql",
+      "result": {
+        "data": {
+          "taskTests": [
+            { "duration": 10 },
+            { "duration": 20 },
+            { "duration": 30 },
+            { "duration": 40 }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "taskTestFilterStatus.graphql",
+      "result": {
+        "data": {
+          "taskTests": [{ "status": "dog" }]
+        }
+      }
+    },
+    {
+      "query_file": "taskTestFilterTestFile.graphql",
+      "result": {
+        "data": {
+          "taskTests": [{ "testFile": "apple" }]
+        }
+      }
+    },
+    {
+      "query_file": "taskTestFilterNoResults.graphql",
+      "result": {
+        "data": {
+          "taskTests": []
+        }
+      }
+    },
+    {
+      "query_file": "taskTestFilterStatusSubstr1.graphql",
+      "result": {
+        "data": {
+          "taskTests": []
+        }
+      }
+    },
+    {
+      "query_file": "taskTestFilterStatusSubstr2.graphql",
+      "result": {
+        "data": {
+          "taskTests": []
+        }
+      }
+    },
+    {
+      "query_file": "taskTestPageLimit.graphql",
+      "result": {
+        "data": {
+          "taskTests": [{ "testFile": "c" }, { "testFile": "d" }]
+        }
+      }
+    },
+    {
+      "query_file": "taskTestDefaultParams.graphql",
+      "result": {
+        "data": {
+          "taskTests": [
+            { "testFile": "apple" },
+            { "testFile": "b" },
+            { "testFile": "c" },
+            { "testFile": "d" }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "add-favorite-project-mutation.graphql",
+      "result": {
+        "data": {
+          "addFavoriteProject": {
+            "identifier": "buildhost-test",
+            "displayName": "buildhost-test",
+            "repo": "buildhost-configuration",
+            "owner": "annie.black"
+          }
+        }
+      }
+    },
+    {
+      "query_file": "add-favorite-project-mutation.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "cannot add duplicate project 'buildhost-test'",
+            "path": ["addFavoriteProject"],
+            "extensions": {
+              "code": "INTERNAL_SERVER_ERROR"
+            }
+          }
+        ],
+        "data": null
+      }
+    },
+    {
+      "query_file": "add-favorite-project-that-does-not-exist.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "could not find project 'i-dont-exist'",
+            "path": ["addFavoriteProject"],
+            "extensions": {
+              "code": "RESOURCE_NOT_FOUND"
+            }
+          }
+        ],
+        "data": null
+      }
+    },
+    {
+      "query_file": "projects1.graphql",
+      "result": {
+        "data": {
+          "projects": {
+            "favorites": [
+              {
+                "identifier": "buildhost-test",
+                "repo": "buildhost-configuration",
+                "owner": "annie.black",
+                "displayName": "buildhost-test"
+              }
+            ],
+            "otherProjects": [
+              {
+                "name": "bsamek/mongo",
+                "projects": [
+                  {
+                    "identifier": "sys-perf",
+                    "repo": "mongo",
+                    "owner": "bsamek",
+                    "displayName": "System Performance (master)"
+                  }
+                ]
+              },
+              {
+                "name": "evergreen-ci/evergreen",
+                "projects": [
+                  {
+                    "identifier": "mci",
+                    "repo": "evergreen",
+                    "owner": "evergreen-ci",
+                    "displayName": "Evergreen Self-Tests"
+                  },
+                  {
+                    "identifier": "clone-of-mci-to-test-a-thing",
+                    "repo": "evergreen",
+                    "owner": "evergreen-ci",
+                    "displayName": "Evergreen Self-Tests"
+                  }
+                ]
+              },
+              {
+                "name": "evergreen-ci/grip",
+                "projects": [
+                  {
+                    "identifier": "annie-copy2",
+                    "repo": "grip",
+                    "owner": "evergreen-ci",
+                    "displayName": "something temporary"
+                  }
+                ]
+              },
+              {
+                "name": "evergreen-ci/lobster",
+                "projects": [
+                  {
+                    "identifier": "lobster",
+                    "repo": "lobster",
+                    "owner": "evergreen-ci",
+                    "displayName": "Lobster"
+                  }
+                ]
+              },
+              {
+                "name": "evergreen-ci/logkeeper",
+                "projects": [
+                  {
+                    "identifier": "logkeeper",
+                    "repo": "logkeeper",
+                    "owner": "evergreen-ci",
+                    "displayName": "Logkeeper"
+                  }
+                ]
+              },
+              {
+                "name": "hello it's me/amboy",
+                "projects": [
+                  {
+                    "identifier": "amboy",
+                    "repo": "amboy",
+                    "owner": "hello it's me",
+                    "displayName": "Not Amboy"
+                  }
+                ]
+              },
+              {
+                "name": "john-m-liu/evergreen",
+                "projects": [
+                  {
+                    "identifier": "john_test",
+                    "repo": "evergreen",
+                    "owner": "john-m-liu",
+                    "displayName": "john test"
+                  }
+                ]
+              },
+              {
+                "name": "mongodb/curator",
+                "projects": [
+                  {
+                    "identifier": "curator",
+                    "repo": "curator",
+                    "owner": "mongodb",
+                    "displayName": "Curator"
+                  }
+                ]
+              },
+              {
+                "name": "mongodb/greenbay",
+                "projects": [
+                  {
+                    "identifier": "Greenbay",
+                    "repo": "greenbay",
+                    "owner": "mongodb",
+                    "displayName": "Greenbay"
+                  }
+                ]
+              },
+              {
+                "name": "mongodb/grip",
+                "projects": [
+                  {
+                    "identifier": "grip",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "Grip (Logging)"
+                  },
+                  {
+                    "identifier": "ernietest20171110",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
+                  },
+                  {
+                    "identifier": "ernietest2017111002",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "Grip (Logging)"
+                  },
+                  {
+                    "identifier": "ernie-copy",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
+                  },
+                  {
+                    "identifier": "ernie-copy2",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
+                  },
+                  {
+                    "identifier": "ernie-copy3",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
+                  },
+                  {
+                    "identifier": "ernie-copy4",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "test display name update"
+                  },
+                  {
+                    "identifier": "annie-test",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie-test-copy",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie-copy3",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie-copy4",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie-copy-vars",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie_api_copy",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  },
+                  {
+                    "identifier": "annie_api_copy2",
+                    "repo": "grip",
+                    "owner": "mongodb",
+                    "displayName": "something temporary"
+                  }
+                ]
+              },
+              {
+                "name": "rongodb/ron_repo_1",
+                "projects": [
+                  {
+                    "identifier": "ron_test_copy_1",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  },
+                  {
+                    "identifier": "qa-template",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  },
+                  {
+                    "identifier": "qa-template-copy-for-testing",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  },
+                  {
+                    "identifier": "ron_test_output",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  },
+                  {
+                    "identifier": "ron_three",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  },
+                  {
+                    "identifier": "qa-template-for-testing",
+                    "repo": "ron_repo_1",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  }
+                ]
+              },
+              {
+                "name": "rongodb/v20380713",
+                "projects": [
+                  {
+                    "identifier": "ron_two_via_postman",
+                    "repo": "v20380713",
+                    "owner": "rongodb",
+                    "displayName": "1st project to be moved around"
+                  }
+                ]
+              },
+              {
+                "name": "something crazy/grip",
+                "projects": [
+                  {
+                    "identifier": "annie-copy5",
+                    "repo": "grip",
+                    "owner": "something crazy",
+                    "displayName": "something temporary"
+                  }
+                ]
+              },
+              {
+                "name": "tzembo/evergreen",
+                "projects": [
+                  {
+                    "identifier": "thomas-test",
+                    "repo": "evergreen",
+                    "owner": "tzembo",
+                    "displayName": "thomas test"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "remove-favorite-project-mutation.graphql",
+      "result": {
+        "data": {
+          "removeFavoriteProject": {
+            "identifier": "buildhost-test",
+            "repo": "buildhost-configuration",
+            "owner": "annie.black",
+            "displayName": "buildhost-test"
+          }
+        }
+      }
+    },
+    {
+      "query_file": "schedule-task-mutation.graphql",
+      "result": {
+        "data": {
+          "scheduleTask": {
+            "activated": true,
+            "activatedBy": "testuser"
+          }
+        }
+      }
+    },
+    {
+      "query_file": "unschedule-task-mutation.graphql",
+      "result": {
+        "data": {
+          "unscheduleTask": {
+            "activated": false
+          }
+        }
+      }
+    },
+    {
+      "query_file": "task-files-query-display.graphql",
+      "result": {
+        "data": {
+          "taskFiles": [
+            {
+              "taskName": "exec 1 display!!",
+              "files": [
+                {
+                  "name": "awesome_test!!!",
+                  "link": "www.wikipedia.com",
+                  "visibility": "the whole world"
+                }
+              ]
+            },
+            {
+              "taskName": "exec 2 display!!",
+              "files": [
+                {
+                  "name": "THIS IS REALLY COOL",
+                  "link": "www.wikipedia.com",
+                  "visibility": "the whole world"
+                },
+                {
+                  "name": "really cool test file",
+                  "link": "www.wikipedia.com",
+                  "visibility": "the whole world"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "patch-time-1.graphql",
+      "result": {
+        "data": {
+          "patch": {
+            "time": {
+              "started": null,
+              "finished": null,
+              "submittedAt": "January 11, 2018, 12:01AM"
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patch-time-2.graphql",
+      "result": {
+        "data": {
+          "patch": {
+            "time": {
+              "started": "February 13, 2020, 5:42PM",
+              "finished": "February 14, 2020, 6:03PM",
+              "submittedAt": "February 12, 2020, 4:58PM"
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "task-files-query-exec.graphql",
+      "result": {
+        "data": {
+          "taskFiles": [
+            {
+              "taskName": "exec 1 display!!",
+              "files": [
+                {
+                  "name": "awesome_test!!!",
+                  "link": "www.wikipedia.com",
+                  "visibility": "the whole world"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "task-files-query-err1.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "cannot find task with id NOT-A-REAL-TASKID",
+            "path": ["taskFiles"],
+            "extensions": { "code": "RESOURCE_NOT_FOUND" }
+          }
+        ],
+        "data": null
+      }
+    },
+    {
+      "query_file": "task-files-query-err2.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "cannot find old task with id task-with-fake-old-id",
+            "path": ["taskFiles"],
+            "extensions": { "code": "RESOURCE_NOT_FOUND" }
+          }
+        ],
+        "data": null
+      }
+    },
+    {
+      "query_file": "task-files-query-empty.graphql",
+      "result": {
+        "data": { "taskFiles": [] }
+      }
+    },
+    {
+      "query_file": "user.graphql",
+      "result": {
+        "data": {
+          "user": {
+            "displayName": "testuser"
+          }
+        }
+      }
+    },
+    {
       "query_file": "task_test-logs-empty-str.graphql",
       "result": {
         "data": {

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -406,22 +406,22 @@
         "end": 10,
         "task_id": "exec1",
         "task_execution": 5,
-        "url": "a url",
-        "url_raw": "a raw url"
+        "url": "https://original-url.com",
+        "url_raw": "https://original-raw-url.com"
       },
       {
         "_id": { "$oid": "29ef7a20a7798219e191d00e" },
         "status": "c",
         "test_file": "apple",
-        "log_id": "59ef7a2097b1d3148d0004f1",
+        "log_id": "",
         "line_num": 126,
         "exit_code": 0,
         "start": 0,
         "end": 20,
         "task_id": "exec1",
         "task_execution": 5,
-        "url": "a url",
-        "url_raw": "a raw url"
+        "url": "",
+        "url_raw": ""
       },
       {
         "_id": { "$oid": "39ef7a20a7798219e191d00e" },
@@ -434,8 +434,8 @@
         "end": 40,
         "task_id": "exec1",
         "task_execution": 5,
-        "url": "a url",
-        "url_raw": "a raw url"
+        "url": "",
+        "url_raw": ""
       },
       {
         "_id": { "$oid": "49ef7a20a7798219e191d00e" },
@@ -448,8 +448,8 @@
         "end": 30,
         "task_id": "exec1",
         "task_execution": 5,
-        "url": "a url",
-        "url_raw": "a raw url"
+        "url": "/url/without/scheme/host",
+        "url_raw": "/raw/url/without/scheme/host"
       }
     ],
     "project_ref": [
@@ -1536,745 +1536,77 @@
   },
   "tests": [
     {
-      "query_file": "user-patches.graphql",
+      "query_file": "task_test-logs-empty-str.graphql",
       "result": {
         "data": {
-          "userPatches": [
+          "taskTests": [
             {
-              "id": "5e1f8ab8834b87d7b5d251a5",
-              "description": "mydesc",
-              "projectID": "mci",
-              "githash": "7ad0c6bb0d5b8586f3a0442f365e259d40f5a7f1",
-              "patchNumber": 1,
-              "author": "testuser",
-              "version": "",
-              "status": "created",
-              "tasks": ["test-auth"],
-              "activated": false,
-              "alias": "",
-              "variants": ["rhel62"],
-              "variantsTasks": [
-                { "name": "rhel62", "tasks": ["test-model-host"] }
-              ]
+              "logs": { "htmlDisplayURL": "", "rawDisplayURL": "" },
+              "id": "29ef7a20a7798219e191d00e"
             }
           ]
         }
       }
     },
     {
-      "query_file": "patch.graphql",
-      "result": {
-        "data": {
-          "patch": {
-            "id": "5e1f8ab8834b87d7b5d251a5",
-            "description": "mydesc",
-            "projectID": "mci",
-            "githash": "7ad0c6bb0d5b8586f3a0442f365e259d40f5a7f1",
-            "patchNumber": 1,
-            "author": "testuser",
-            "version": "",
-            "status": "created",
-            "tasks": ["test-auth"],
-            "activated": false,
-            "alias": "",
-            "variants": ["rhel62"],
-            "variantsTasks": [
-              { "name": "rhel62", "tasks": ["test-model-host"] }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "query_file": "patch-does-not-exist.graphql",
-      "result": {
-        "errors": [
-          {
-            "message": "400 (Bad Request): id 'i-dont-exist' is not a valid patch id",
-            "path": ["patch"],
-            "extensions": {
-              "code": "INTERNAL_SERVER_ERROR"
-            }
-          }
-        ],
-        "data": null
-      }
-    },
-    {
-      "query_file": "task1.graphql",
-      "result": {
-        "data": {
-          "task": {
-            "logs": {
-              "allLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=ALL",
-              "taskLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=T",
-              "agentLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=E",
-              "systemLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=S"
-            },
-            "id": "wuzzup",
-            "createTime": "2018-01-10T19:01:36-05:00",
-            "ingestTime": "2018-01-10T19:01:36-05:00",
-            "dispatchTime": "2018-01-10T19:01:36-05:00",
-            "scheduledTime": "2018-01-10T19:01:36-05:00",
-            "startTime": "2018-01-10T19:01:36-05:00",
-            "finishTime": "2018-01-10T19:01:36-05:00",
-            "activatedTime": "2018-01-10T19:01:36-05:00",
-            "version": "version",
-            "projectId": "id",
-            "revision": "revise",
-            "priority": 5,
-            "taskGroup": "grp",
-            "taskGroupMaxHosts": 100,
-            "activated": false,
-            "activatedBy": "someone",
-            "buildId": "some_thang",
-            "distroId": "distro",
-            "buildVariant": "variant",
-            "dependsOn": null,
-            "displayName": "exec1 display name",
-            "hostId": "host",
-            "restarts": 5,
-            "execution": 5,
-            "order": 5,
-            "requester": "something",
-            "status": "pass",
-            "details": {
-              "status": "status",
-              "type": "type",
-              "description": "description",
-              "timedOut": false
-            },
-            "displayOnly": true,
-            "executionTasks": ["exec1"],
-            "generateTask": false,
-            "generatedBy": "something"
-          }
-        }
-      }
-    },
-    {
-      "query_file": "taskTestStatusAsc.graphql",
+      "query_file": "task_test-logs-use-original-url-when-provided.graphql",
       "result": {
         "data": {
           "taskTests": [
-            { "status": "a" },
-            { "status": "b" },
-            { "status": "c" },
-            { "status": "dog" }
-          ]
-        }
-      }
-    },
-    {
-      "query_file": "taskTestStatusDesc.graphql",
-      "result": {
-        "data": {
-          "taskTests": [
-            { "status": "dog" },
-            { "status": "c" },
-            { "status": "b" },
-            { "status": "a" }
-          ]
-        }
-      }
-    },
-    {
-      "query_file": "taskTestNameAsc.graphql",
-      "result": {
-        "data": {
-          "taskTests": [
-            { "testFile": "apple" },
-            { "testFile": "b" },
-            { "testFile": "c" },
-            { "testFile": "d" }
-          ]
-        }
-      }
-    },
-    {
-      "query_file": "taskTestNameDesc.graphql",
-      "result": {
-        "data": {
-          "taskTests": [
-            { "testFile": "d" },
-            { "testFile": "c" },
-            { "testFile": "b" },
-            { "testFile": "apple" }
-          ]
-        }
-      }
-    },
-    {
-      "query_file": "taskTestDurationDesc.graphql",
-      "result": {
-        "data": {
-          "taskTests": [
-            { "duration": 40 },
-            { "duration": 30 },
-            { "duration": 20 },
-            { "duration": 10 }
-          ]
-        }
-      }
-    },
-    {
-      "query_file": "taskTestDurationAsc.graphql",
-      "result": {
-        "data": {
-          "taskTests": [
-            { "duration": 10 },
-            { "duration": 20 },
-            { "duration": 30 },
-            { "duration": 40 }
-          ]
-        }
-      }
-    },
-    {
-      "query_file": "taskTestFilterStatus.graphql",
-      "result": {
-        "data": {
-          "taskTests": [{ "status": "dog" }]
-        }
-      }
-    },
-    {
-      "query_file": "taskTestFilterTestFile.graphql",
-      "result": {
-        "data": {
-          "taskTests": [{ "testFile": "apple" }]
-        }
-      }
-    },
-    {
-      "query_file": "taskTestFilterNoResults.graphql",
-      "result": {
-        "data": {
-          "taskTests": []
-        }
-      }
-    },
-    {
-      "query_file": "taskTestFilterStatusSubstr1.graphql",
-      "result": {
-        "data": {
-          "taskTests": []
-        }
-      }
-    },
-    {
-      "query_file": "taskTestFilterStatusSubstr2.graphql",
-      "result": {
-        "data": {
-          "taskTests": []
-        }
-      }
-    },
-    {
-      "query_file": "taskTestPageLimit.graphql",
-      "result": {
-        "data": {
-          "taskTests": [{ "testFile": "c" }, { "testFile": "d" }]
-        }
-      }
-    },
-    {
-      "query_file": "taskTestDefaultParams.graphql",
-      "result": {
-        "data": {
-          "taskTests": [
-            { "testFile": "apple" },
-            { "testFile": "b" },
-            { "testFile": "c" },
-            { "testFile": "d" }
-          ]
-        }
-      }
-    },
-    {
-      "query_file": "add-favorite-project-mutation.graphql",
-      "result": {
-        "data": {
-          "addFavoriteProject": {
-            "identifier": "buildhost-test",
-            "displayName": "buildhost-test",
-            "repo": "buildhost-configuration",
-            "owner": "annie.black"
-          }
-        }
-      }
-    },
-    {
-      "query_file": "add-favorite-project-mutation.graphql",
-      "result": {
-        "errors": [
-          {
-            "message": "cannot add duplicate project 'buildhost-test'",
-            "path": ["addFavoriteProject"],
-            "extensions": {
-              "code": "INTERNAL_SERVER_ERROR"
-            }
-          }
-        ],
-        "data": null
-      }
-    },
-    {
-      "query_file": "add-favorite-project-that-does-not-exist.graphql",
-      "result": {
-        "errors": [
-          {
-            "message": "could not find project 'i-dont-exist'",
-            "path": ["addFavoriteProject"],
-            "extensions": {
-              "code": "RESOURCE_NOT_FOUND"
-            }
-          }
-        ],
-        "data": null
-      }
-    },
-    {
-      "query_file": "projects1.graphql",
-      "result": {
-        "data": {
-          "projects": {
-            "favorites": [
-              {
-                "identifier": "buildhost-test",
-                "repo": "buildhost-configuration",
-                "owner": "annie.black",
-                "displayName": "buildhost-test"
-              }
-            ],
-            "otherProjects": [
-              {
-                "name": "bsamek/mongo",
-                "projects": [
-                  {
-                    "identifier": "sys-perf",
-                    "repo": "mongo",
-                    "owner": "bsamek",
-                    "displayName": "System Performance (master)"
-                  }
-                ]
-              },
-              {
-                "name": "evergreen-ci/evergreen",
-                "projects": [
-                  {
-                    "identifier": "mci",
-                    "repo": "evergreen",
-                    "owner": "evergreen-ci",
-                    "displayName": "Evergreen Self-Tests"
-                  },
-                  {
-                    "identifier": "clone-of-mci-to-test-a-thing",
-                    "repo": "evergreen",
-                    "owner": "evergreen-ci",
-                    "displayName": "Evergreen Self-Tests"
-                  }
-                ]
-              },
-              {
-                "name": "evergreen-ci/grip",
-                "projects": [
-                  {
-                    "identifier": "annie-copy2",
-                    "repo": "grip",
-                    "owner": "evergreen-ci",
-                    "displayName": "something temporary"
-                  }
-                ]
-              },
-              {
-                "name": "evergreen-ci/lobster",
-                "projects": [
-                  {
-                    "identifier": "lobster",
-                    "repo": "lobster",
-                    "owner": "evergreen-ci",
-                    "displayName": "Lobster"
-                  }
-                ]
-              },
-              {
-                "name": "evergreen-ci/logkeeper",
-                "projects": [
-                  {
-                    "identifier": "logkeeper",
-                    "repo": "logkeeper",
-                    "owner": "evergreen-ci",
-                    "displayName": "Logkeeper"
-                  }
-                ]
-              },
-              {
-                "name": "hello it's me/amboy",
-                "projects": [
-                  {
-                    "identifier": "amboy",
-                    "repo": "amboy",
-                    "owner": "hello it's me",
-                    "displayName": "Not Amboy"
-                  }
-                ]
-              },
-              {
-                "name": "john-m-liu/evergreen",
-                "projects": [
-                  {
-                    "identifier": "john_test",
-                    "repo": "evergreen",
-                    "owner": "john-m-liu",
-                    "displayName": "john test"
-                  }
-                ]
-              },
-              {
-                "name": "mongodb/curator",
-                "projects": [
-                  {
-                    "identifier": "curator",
-                    "repo": "curator",
-                    "owner": "mongodb",
-                    "displayName": "Curator"
-                  }
-                ]
-              },
-              {
-                "name": "mongodb/greenbay",
-                "projects": [
-                  {
-                    "identifier": "Greenbay",
-                    "repo": "greenbay",
-                    "owner": "mongodb",
-                    "displayName": "Greenbay"
-                  }
-                ]
-              },
-              {
-                "name": "mongodb/grip",
-                "projects": [
-                  {
-                    "identifier": "grip",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "Grip (Logging)"
-                  },
-                  {
-                    "identifier": "ernietest20171110",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "test display name update"
-                  },
-                  {
-                    "identifier": "ernietest2017111002",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "Grip (Logging)"
-                  },
-                  {
-                    "identifier": "ernie-copy",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "test display name update"
-                  },
-                  {
-                    "identifier": "ernie-copy2",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "test display name update"
-                  },
-                  {
-                    "identifier": "ernie-copy3",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "test display name update"
-                  },
-                  {
-                    "identifier": "ernie-copy4",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "test display name update"
-                  },
-                  {
-                    "identifier": "annie-test",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
-                  },
-                  {
-                    "identifier": "annie-test-copy",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
-                  },
-                  {
-                    "identifier": "annie-copy3",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
-                  },
-                  {
-                    "identifier": "annie-copy4",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
-                  },
-                  {
-                    "identifier": "annie-copy-vars",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
-                  },
-                  {
-                    "identifier": "annie_api_copy",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
-                  },
-                  {
-                    "identifier": "annie_api_copy2",
-                    "repo": "grip",
-                    "owner": "mongodb",
-                    "displayName": "something temporary"
-                  }
-                ]
-              },
-              {
-                "name": "rongodb/ron_repo_1",
-                "projects": [
-                  {
-                    "identifier": "ron_test_copy_1",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
-                  },
-                  {
-                    "identifier": "qa-template",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
-                  },
-                  {
-                    "identifier": "qa-template-copy-for-testing",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
-                  },
-                  {
-                    "identifier": "ron_test_output",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
-                  },
-                  {
-                    "identifier": "ron_three",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
-                  },
-                  {
-                    "identifier": "qa-template-for-testing",
-                    "repo": "ron_repo_1",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
-                  }
-                ]
-              },
-              {
-                "name": "rongodb/v20380713",
-                "projects": [
-                  {
-                    "identifier": "ron_two_via_postman",
-                    "repo": "v20380713",
-                    "owner": "rongodb",
-                    "displayName": "1st project to be moved around"
-                  }
-                ]
-              },
-              {
-                "name": "something crazy/grip",
-                "projects": [
-                  {
-                    "identifier": "annie-copy5",
-                    "repo": "grip",
-                    "owner": "something crazy",
-                    "displayName": "something temporary"
-                  }
-                ]
-              },
-              {
-                "name": "tzembo/evergreen",
-                "projects": [
-                  {
-                    "identifier": "thomas-test",
-                    "repo": "evergreen",
-                    "owner": "tzembo",
-                    "displayName": "thomas test"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "query_file": "remove-favorite-project-mutation.graphql",
-      "result": {
-        "data": {
-          "removeFavoriteProject": {
-            "identifier": "buildhost-test",
-            "repo": "buildhost-configuration",
-            "owner": "annie.black",
-            "displayName": "buildhost-test"
-          }
-        }
-      }
-    },
-    {
-      "query_file": "schedule-task-mutation.graphql",
-      "result": {
-        "data": {
-          "scheduleTask": {
-            "activated": true,
-            "activatedBy": "testuser"
-          }
-        }
-      }
-    },
-    {
-      "query_file": "unschedule-task-mutation.graphql",
-      "result": {
-        "data": {
-          "unscheduleTask": {
-            "activated": false
-          }
-        }
-      }
-    },
-    {
-      "query_file": "task-files-query-display.graphql",
-      "result": {
-        "data": {
-          "taskFiles": [
             {
-              "taskName": "exec 1 display!!",
-              "files": [
-                {
-                  "name": "awesome_test!!!",
-                  "link": "www.wikipedia.com",
-                  "visibility": "the whole world"
-                }
-              ]
-            },
-            {
-              "taskName": "exec 2 display!!",
-              "files": [
-                {
-                  "name": "THIS IS REALLY COOL",
-                  "link": "www.wikipedia.com",
-                  "visibility": "the whole world"
-                },
-                {
-                  "name": "really cool test file",
-                  "link": "www.wikipedia.com",
-                  "visibility": "the whole world"
-                }
-              ]
+              "logs": {
+                "htmlDisplayURL": "https://original-url.com",
+                "rawDisplayURL": "https://original-raw-url.com"
+              },
+              "id": "19ef7a20a7798219e191d00e"
             }
           ]
         }
       }
     },
     {
-      "query_file": "patch-time-1.graphql",
+      "query_file": "task_test-logs-prepend-api_url-when-scheme-and-host-not-provided.graphql",
       "result": {
         "data": {
-          "patch": {
-            "time": {
-              "started": null,
-              "finished": null,
-              "submittedAt": "January 11, 2018, 12:01AM"
-            }
-          }
-        }
-      }
-    },
-    {
-      "query_file": "patch-time-2.graphql",
-      "result": {
-        "data": {
-          "patch": {
-            "time": {
-              "started": "February 13, 2020, 5:42PM",
-              "finished": "February 14, 2020, 6:03PM",
-              "submittedAt": "February 12, 2020, 4:58PM"
-            }
-          }
-        }
-      }
-    },
-    {
-      "query_file": "task-files-query-exec.graphql",
-      "result": {
-        "data": {
-          "taskFiles": [
+          "taskTests": [
             {
-              "taskName": "exec 1 display!!",
-              "files": [
-                {
-                  "name": "awesome_test!!!",
-                  "link": "www.wikipedia.com",
-                  "visibility": "the whole world"
-                }
-              ]
+              "logs": {
+                "htmlDisplayURL": "https://localhost:8443/url/without/scheme/host",
+                "rawDisplayURL": "https://localhost:8443/raw/url/without/scheme/host"
+              },
+              "id": "49ef7a20a7798219e191d00e"
             }
           ]
         }
       }
     },
     {
-      "query_file": "task-files-query-err1.graphql",
-      "result": {
-        "errors": [
-          {
-            "message": "cannot find task with id NOT-A-REAL-TASKID",
-            "path": ["taskFiles"],
-            "extensions": { "code": "RESOURCE_NOT_FOUND" }
-          }
-        ],
-        "data": null
-      }
-    },
-    {
-      "query_file": "task-files-query-err2.graphql",
-      "result": {
-        "errors": [
-          {
-            "message": "cannot find old task with id task-with-fake-old-id",
-            "path": ["taskFiles"],
-            "extensions": { "code": "RESOURCE_NOT_FOUND" }
-          }
-        ],
-        "data": null
-      }
-    },
-    {
-      "query_file": "task-files-query-empty.graphql",
-      "result": {
-        "data": { "taskFiles": [] }
-      }
-    },
-    {
-      "query_file": "user.graphql",
+      "query_file": "task_test-formats-html-url-with-line-num-and-log-id-when-url-empty.graphql",
       "result": {
         "data": {
-          "user": {
-            "displayName": "testuser"
-          }
+          "taskTests": [
+            {
+              "logs": {
+                "htmlDisplayURL": "https://localhost:8443/test_log/59ef7a2097b1d3148d0004f1#L126"
+              },
+              "id": "39ef7a20a7798219e191d00e"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "task_test-formats-raw-url-with-query-param-and-log-id-when-raw-url-empty.graphql",
+      "result": {
+        "data": {
+          "taskTests": [
+            {
+              "logs": {
+                "rawDisplayURL": "https://localhost:8443/test_log/59ef7a2097b1d3148d0004f1?raw=1"
+              },
+              "id": "39ef7a20a7798219e191d00e"
+            }
+          ]
         }
       }
     }

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2284,7 +2284,7 @@
         "data": {
           "taskTests": [
             {
-              "logs": { "htmlDisplayURL": "", "rawDisplayURL": "" },
+              "logs": { "htmlDisplayURL": null, "rawDisplayURL": null },
               "id": "29ef7a20a7798219e191d00e"
             }
           ]

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2352,6 +2352,19 @@
           ]
         }
       }
+    },
+    {
+      "query_file": "task_test-nonexistent-task_id.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "cannot find task with id THIS-TASK-DOES-NOT-EXIST-!!!!",
+            "path": ["taskTests"],
+            "extensions": { "code": "RESOURCE_NOT_FOUND" }
+          }
+        ],
+        "data": { "taskTests": null }
+      }
     }
   ]
 }

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3,7 +3,6 @@ package graphql
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -273,16 +272,16 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, sortCatego
 	for _, t := range tests {
 		apiTest := restModel.APITest{}
 		err := apiTest.BuildFromService(&t)
-		if _, err := url.ParseRequestURI(*apiTest.Logs.HTMLDisplayURL); len(*apiTest.Logs.HTMLDisplayURL) != 0 && err != nil {
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, err.Error())
+		}
+		if len(*apiTest.Logs.HTMLDisplayURL) != 0 && IsURL(*apiTest.Logs.HTMLDisplayURL) == false {
 			formattedURL := fmt.Sprintf("%s%s", r.sc.GetURL(), *apiTest.Logs.HTMLDisplayURL)
 			apiTest.Logs.HTMLDisplayURL = &formattedURL
 		}
-		if _, err := url.ParseRequestURI(*apiTest.Logs.RawDisplayURL); len(*apiTest.Logs.RawDisplayURL) != 0 && err != nil {
+		if len(*apiTest.Logs.RawDisplayURL) != 0 && IsURL(*apiTest.Logs.RawDisplayURL) == false {
 			formattedURL := fmt.Sprintf("%s%s", r.sc.GetURL(), *apiTest.Logs.RawDisplayURL)
 			apiTest.Logs.RawDisplayURL = &formattedURL
-		}
-		if err != nil {
-			return nil, InternalServerError.Send(ctx, err.Error())
 		}
 		testPointers = append(testPointers, &apiTest)
 	}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -275,11 +275,11 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, sortCatego
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, err.Error())
 		}
-		if len(*apiTest.Logs.HTMLDisplayURL) != 0 && IsURL(*apiTest.Logs.HTMLDisplayURL) == false {
+		if apiTest.Logs.HTMLDisplayURL != nil && IsURL(*apiTest.Logs.HTMLDisplayURL) == false {
 			formattedURL := fmt.Sprintf("%s%s", r.sc.GetURL(), *apiTest.Logs.HTMLDisplayURL)
 			apiTest.Logs.HTMLDisplayURL = &formattedURL
 		}
-		if len(*apiTest.Logs.RawDisplayURL) != 0 && IsURL(*apiTest.Logs.RawDisplayURL) == false {
+		if apiTest.Logs.RawDisplayURL != nil && IsURL(*apiTest.Logs.RawDisplayURL) == false {
 			formattedURL := fmt.Sprintf("%s%s", r.sc.GetURL(), *apiTest.Logs.RawDisplayURL)
 			apiTest.Logs.RawDisplayURL = &formattedURL
 		}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -216,8 +216,8 @@ func (r *queryResolver) Projects(ctx context.Context) (*Projects, error) {
 
 func (r *queryResolver) TaskTests(ctx context.Context, taskID string, sortCategory *TaskSortCategory, sortDirection *SortDirection, page *int, limit *int, testName *string, status *string) ([]*restModel.APITest, error) {
 	task, err := task.FindOneId(taskID)
-	if err != nil {
-		return nil, ResourceNotFound.Send(ctx, err.Error())
+	if task == nil || err != nil {
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find task with id %s", taskID))
 	}
 
 	sortBy := ""

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -272,6 +273,14 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, sortCatego
 	for _, t := range tests {
 		apiTest := restModel.APITest{}
 		err := apiTest.BuildFromService(&t)
+		if _, err := url.ParseRequestURI(*apiTest.Logs.HTMLDisplayURL); len(*apiTest.Logs.HTMLDisplayURL) != 0 && err != nil {
+			formattedURL := fmt.Sprintf("%s%s", r.sc.GetURL(), *apiTest.Logs.HTMLDisplayURL)
+			apiTest.Logs.HTMLDisplayURL = &formattedURL
+		}
+		if _, err := url.ParseRequestURI(*apiTest.Logs.RawDisplayURL); len(*apiTest.Logs.RawDisplayURL) != 0 && err != nil {
+			formattedURL := fmt.Sprintf("%s%s", r.sc.GetURL(), *apiTest.Logs.RawDisplayURL)
+			apiTest.Logs.RawDisplayURL = &formattedURL
+		}
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, err.Error())
 		}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -88,10 +88,8 @@ type TestResult {
 }
 
 type TestLog {
-  url: String
-  urlRaw: String
-  lineNum: Int
-  logId: String
+  htmlDisplayURL: String
+  rawDisplayURL: String
 }
 
 type Task {

--- a/graphql/testdata/task_test-formats-html-url-with-line-num-and-log-id-when-url-empty.graphql
+++ b/graphql/testdata/task_test-formats-html-url-with-line-num-and-log-id-when-url-empty.graphql
@@ -1,0 +1,8 @@
+{
+  taskTests(taskId: "wuzzup", page: 3, limit: 1) {
+    logs {
+      htmlDisplayURL
+    }
+    id
+  }
+}

--- a/graphql/testdata/task_test-formats-raw-url-with-query-param-and-log-id-when-raw-url-empty.graphql
+++ b/graphql/testdata/task_test-formats-raw-url-with-query-param-and-log-id-when-raw-url-empty.graphql
@@ -1,0 +1,8 @@
+{
+  taskTests(taskId: "wuzzup", page: 3, limit: 1) {
+    logs {
+      rawDisplayURL
+    }
+    id
+  }
+}

--- a/graphql/testdata/task_test-logs-empty-str.graphql
+++ b/graphql/testdata/task_test-logs-empty-str.graphql
@@ -1,0 +1,9 @@
+{
+  taskTests(taskId: "wuzzup", page: 0, limit: 1) {
+    logs {
+      htmlDisplayURL
+      rawDisplayURL
+    }
+    id
+  }
+}

--- a/graphql/testdata/task_test-logs-prepend-api_url-when-scheme-and-host-not-provided.graphql
+++ b/graphql/testdata/task_test-logs-prepend-api_url-when-scheme-and-host-not-provided.graphql
@@ -1,0 +1,9 @@
+{
+  taskTests(taskId: "wuzzup", page: 2, limit: 1) {
+    logs {
+      htmlDisplayURL
+      rawDisplayURL
+    }
+    id
+  }
+}

--- a/graphql/testdata/task_test-logs-use-original-url-when-provided.graphql
+++ b/graphql/testdata/task_test-logs-use-original-url-when-provided.graphql
@@ -1,0 +1,9 @@
+{
+  taskTests(taskId: "wuzzup", page: 1, limit: 1) {
+    logs {
+      htmlDisplayURL
+      rawDisplayURL
+    }
+    id
+  }
+}

--- a/graphql/testdata/task_test-nonexistent-task_id.graphql
+++ b/graphql/testdata/task_test-nonexistent-task_id.graphql
@@ -1,0 +1,9 @@
+{
+  taskTests(taskId: "THIS-TASK-DOES-NOT-EXIST-!!!!", page: 1, limit: 1) {
+    logs {
+      htmlDisplayURL
+      rawDisplayURL
+    }
+    id
+  }
+}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/evergreen-ci/evergreen/model"
@@ -73,4 +74,10 @@ func GetFormattedDate(t *time.Time, timezone string) (*string, error) {
 	newTime := fmt.Sprintf("%s %d, %d, %s", timeInUserTimezone.Month(), timeInUserTimezone.Day(), timeInUserTimezone.Year(), timeInUserTimezone.Format(time.Kitchen))
 
 	return &newTime, nil
+}
+
+// IsURL returns true if str is a url with scheme and domain name
+func IsURL(str string) bool {
+	u, err := url.ParseRequestURI(str)
+	return err == nil && u.Scheme != "" && u.Host != ""
 }

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -56,9 +56,9 @@ func (at *APITest) BuildFromService(st interface{}) error {
 			LineNum: v.LineNum,
 		}
 
-		isEmptyLogID := len(v.LogID) == 0
-		isEmptyURL := len(v.URL) == 0
-		isEmptyURLRaw := len(v.URLRaw) == 0
+		isEmptyLogID := v.LogID == ""
+		isEmptyURL := v.URL == ""
+		isEmptyURLRaw := v.URLRaw == ""
 
 		if !isEmptyURL {
 			at.Logs.HTMLDisplayURL = at.Logs.URL

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -66,7 +66,7 @@ func (at *APITest) BuildFromService(st interface{}) error {
 		} else if isEmptyLogID {
 			at.Logs.HTMLDisplayURL = &emptyStr
 		} else {
-			dispString := fmt.Sprintf("/test_log/%s/#L%d", *at.Logs.LogId, at.Logs.LineNum)
+			dispString := fmt.Sprintf("/test_log/%s#L%d", *at.Logs.LogId, at.Logs.LineNum)
 			at.Logs.HTMLDisplayURL = &dispString
 		}
 

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -56,7 +56,6 @@ func (at *APITest) BuildFromService(st interface{}) error {
 			LineNum: v.LineNum,
 		}
 
-		emptyStr := ""
 		isEmptyLogID := len(v.LogID) == 0
 		isEmptyURL := len(v.URL) == 0
 		isEmptyURLRaw := len(v.URLRaw) == 0
@@ -64,7 +63,7 @@ func (at *APITest) BuildFromService(st interface{}) error {
 		if !isEmptyURL {
 			at.Logs.HTMLDisplayURL = at.Logs.URL
 		} else if isEmptyLogID {
-			at.Logs.HTMLDisplayURL = &emptyStr
+			at.Logs.HTMLDisplayURL = nil
 		} else {
 			dispString := fmt.Sprintf("/test_log/%s#L%d", *at.Logs.LogId, at.Logs.LineNum)
 			at.Logs.HTMLDisplayURL = &dispString
@@ -73,7 +72,7 @@ func (at *APITest) BuildFromService(st interface{}) error {
 		if !isEmptyURLRaw {
 			at.Logs.RawDisplayURL = at.Logs.URLRaw
 		} else if isEmptyLogID {
-			at.Logs.RawDisplayURL = &emptyStr
+			at.Logs.RawDisplayURL = nil
 		} else {
 			dispString := fmt.Sprintf("/test_log/%s?raw=1", *at.Logs.LogId)
 			at.Logs.RawDisplayURL = &dispString

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -27,10 +27,12 @@ type APITest struct {
 // TestLogs is a struct for storing the information about logs that will
 // be written out as part of an APITest.
 type TestLogs struct {
-	URL     *string `json:"url"`
-	LineNum int     `json:"line_num"`
-	URLRaw  *string `json:"url_raw"`
-	LogId   *string `json:"log_id"`
+	URL            *string `json:"url"`
+	LineNum        int     `json:"line_num"`
+	URLRaw         *string `json:"url_raw"`
+	LogId          *string `json:"log_id"`
+	RawDisplayURL  *string `json:"url_raw_display"`
+	HTMLDisplayURL *string `json:"url_html_display"`
 }
 
 func (at *APITest) BuildFromService(st interface{}) error {
@@ -52,6 +54,29 @@ func (at *APITest) BuildFromService(st interface{}) error {
 			URLRaw:  ToStringPtr(v.URLRaw),
 			LogId:   ToStringPtr(v.LogID),
 			LineNum: v.LineNum,
+		}
+
+		emptyStr := ""
+		isEmptyLogID := len(v.LogID) == 0
+		isEmptyURL := len(v.URL) == 0
+		isEmptyURLRaw := len(v.URLRaw) == 0
+
+		if !isEmptyURL {
+			at.Logs.HTMLDisplayURL = at.Logs.URL
+		} else if isEmptyLogID {
+			at.Logs.HTMLDisplayURL = &emptyStr
+		} else {
+			dispString := fmt.Sprintf("/test_log/%s/#L%d", *at.Logs.LogId, at.Logs.LineNum)
+			at.Logs.HTMLDisplayURL = &dispString
+		}
+
+		if !isEmptyURLRaw {
+			at.Logs.RawDisplayURL = at.Logs.URLRaw
+		} else if isEmptyLogID {
+			at.Logs.RawDisplayURL = &emptyStr
+		} else {
+			dispString := fmt.Sprintf("/test_log/%s?raw=1", *at.Logs.LogId)
+			at.Logs.RawDisplayURL = &dispString
 		}
 	case string:
 		at.TaskId = ToStringPtr(v)

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -659,11 +659,9 @@ func TestTestPaginator(t *testing.T) {
 						TaskId:    model.ToStringPtr(""),
 						TestFile:  model.ToStringPtr(""),
 						Logs: model.TestLogs{
-							URL:            model.ToStringPtr(""),
-							URLRaw:         model.ToStringPtr(""),
-							LogId:          model.ToStringPtr(""),
-							RawDisplayURL:  model.ToStringPtr(""),
-							HTMLDisplayURL: model.ToStringPtr(""),
+							URL:    model.ToStringPtr(""),
+							URLRaw: model.ToStringPtr(""),
+							LogId:  model.ToStringPtr(""),
 						},
 					}
 					expectedTests = append(expectedTests, nextModelTest)
@@ -705,11 +703,9 @@ func TestTestPaginator(t *testing.T) {
 						TaskId:    model.ToStringPtr(""),
 						TestFile:  model.ToStringPtr(""),
 						Logs: model.TestLogs{
-							URL:            model.ToStringPtr(""),
-							URLRaw:         model.ToStringPtr(""),
-							LogId:          model.ToStringPtr(""),
-							RawDisplayURL:  model.ToStringPtr(""),
-							HTMLDisplayURL: model.ToStringPtr(""),
+							URL:    model.ToStringPtr(""),
+							URLRaw: model.ToStringPtr(""),
+							LogId:  model.ToStringPtr(""),
 						},
 					}
 					expectedTests = append(expectedTests, nextModelTest)
@@ -751,11 +747,9 @@ func TestTestPaginator(t *testing.T) {
 						TaskId:    model.ToStringPtr(""),
 						TestFile:  model.ToStringPtr(""),
 						Logs: model.TestLogs{
-							URL:            model.ToStringPtr(""),
-							URLRaw:         model.ToStringPtr(""),
-							LogId:          model.ToStringPtr(""),
-							RawDisplayURL:  model.ToStringPtr(""),
-							HTMLDisplayURL: model.ToStringPtr(""),
+							URL:    model.ToStringPtr(""),
+							URLRaw: model.ToStringPtr(""),
+							LogId:  model.ToStringPtr(""),
 						},
 					}
 					expectedTests = append(expectedTests, nextModelTest)
@@ -797,11 +791,9 @@ func TestTestPaginator(t *testing.T) {
 						TaskId:    model.ToStringPtr(""),
 						TestFile:  model.ToStringPtr(""),
 						Logs: model.TestLogs{
-							URL:            model.ToStringPtr(""),
-							URLRaw:         model.ToStringPtr(""),
-							LogId:          model.ToStringPtr(""),
-							RawDisplayURL:  model.ToStringPtr(""),
-							HTMLDisplayURL: model.ToStringPtr(""),
+							URL:    model.ToStringPtr(""),
+							URLRaw: model.ToStringPtr(""),
+							LogId:  model.ToStringPtr(""),
 						},
 					}
 					expectedTests = append(expectedTests, nextModelTest)

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -659,9 +659,11 @@ func TestTestPaginator(t *testing.T) {
 						TaskId:    model.ToStringPtr(""),
 						TestFile:  model.ToStringPtr(""),
 						Logs: model.TestLogs{
-							URL:    model.ToStringPtr(""),
-							URLRaw: model.ToStringPtr(""),
-							LogId:  model.ToStringPtr(""),
+							URL:            model.ToStringPtr(""),
+							URLRaw:         model.ToStringPtr(""),
+							LogId:          model.ToStringPtr(""),
+							RawDisplayURL:  model.ToStringPtr(""),
+							HTMLDisplayURL: model.ToStringPtr(""),
 						},
 					}
 					expectedTests = append(expectedTests, nextModelTest)
@@ -703,9 +705,11 @@ func TestTestPaginator(t *testing.T) {
 						TaskId:    model.ToStringPtr(""),
 						TestFile:  model.ToStringPtr(""),
 						Logs: model.TestLogs{
-							URL:    model.ToStringPtr(""),
-							URLRaw: model.ToStringPtr(""),
-							LogId:  model.ToStringPtr(""),
+							URL:            model.ToStringPtr(""),
+							URLRaw:         model.ToStringPtr(""),
+							LogId:          model.ToStringPtr(""),
+							RawDisplayURL:  model.ToStringPtr(""),
+							HTMLDisplayURL: model.ToStringPtr(""),
 						},
 					}
 					expectedTests = append(expectedTests, nextModelTest)
@@ -747,9 +751,11 @@ func TestTestPaginator(t *testing.T) {
 						TaskId:    model.ToStringPtr(""),
 						TestFile:  model.ToStringPtr(""),
 						Logs: model.TestLogs{
-							URL:    model.ToStringPtr(""),
-							URLRaw: model.ToStringPtr(""),
-							LogId:  model.ToStringPtr(""),
+							URL:            model.ToStringPtr(""),
+							URLRaw:         model.ToStringPtr(""),
+							LogId:          model.ToStringPtr(""),
+							RawDisplayURL:  model.ToStringPtr(""),
+							HTMLDisplayURL: model.ToStringPtr(""),
 						},
 					}
 					expectedTests = append(expectedTests, nextModelTest)
@@ -791,9 +797,11 @@ func TestTestPaginator(t *testing.T) {
 						TaskId:    model.ToStringPtr(""),
 						TestFile:  model.ToStringPtr(""),
 						Logs: model.TestLogs{
-							URL:    model.ToStringPtr(""),
-							URLRaw: model.ToStringPtr(""),
-							LogId:  model.ToStringPtr(""),
+							URL:            model.ToStringPtr(""),
+							URLRaw:         model.ToStringPtr(""),
+							LogId:          model.ToStringPtr(""),
+							RawDisplayURL:  model.ToStringPtr(""),
+							HTMLDisplayURL: model.ToStringPtr(""),
 						},
 					}
 					expectedTests = append(expectedTests, nextModelTest)


### PR DESCRIPTION
This PR was made to support the HTML and RAW log links in the Task page test table
![Screen Shot 2020-02-19 at 2 56 17 PM](https://user-images.githubusercontent.com/10734386/74870627-0a033100-5328-11ea-8c10-9419d269de0e.png)

The two new TestLog fields are `htmlDisplayURL` and `rawDisplayURL`. We prepend the API URL to the `rawDisplayURL` and `htmlDisplayURL` inside of the resolver instead of `APITest.BuildFromService` if there is not a scheme and host present in the display URLs from the APITest struct. The code in `BuildFromService` decides if we need to change up the format of the URL using logID and/or lineNum depending on a set of conditions. 
