### PR TITLE
EVG-7387: use correct home directory for legacy SSH

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -388,8 +388,12 @@ func (d *Distro) ExecutableSubPath() string {
 	return filepath.Join(arch, d.BinaryName())
 }
 
-// HomeDir gets the absolute path to the home directory for this distro's user.
+// HomeDir gets the absolute path to the home directory for this distro's user
+// for non-legacy provisioned hosts.
 func (d *Distro) HomeDir() string {
+	if d.LegacyBootstrap() {
+		return "~"
+	}
 	if d.User == "root" {
 		return filepath.Join("/", d.User)
 	}

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1047,7 +1047,7 @@ func (h *Host) spawnHostConfigJSON(settings *evergreen.Settings) ([]byte, error)
 // SpawnHostGetTaskDataCommand returns the command that fetches the task data
 // for a spawn host.
 func (h *Host) SpawnHostGetTaskDataCommand() []string {
-	return []string{h.AgentBinary(),
+	return []string{h.PathToFile(h.AgentBinary()),
 		"-c", h.PathToFile(h.spawnHostConfigFile()),
 		"fetch",
 		"-t", h.ProvisionOptions.TaskId,

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -362,7 +362,7 @@ func (h *Host) jasperBinaryFileName(config evergreen.HostJasperConfig) string {
 
 // JasperBinaryFilePath returns the full path to the Jasper binary.
 func (h *Host) JasperBinaryFilePath(config evergreen.HostJasperConfig) string {
-	return h.PathByProvisioning(filepath.Join(h.Distro.BootstrapSettings.JasperBinaryDir, h.jasperBinaryFileName(config)))
+	return filepath.Join(h.Distro.BootstrapSettings.JasperBinaryDir, h.jasperBinaryFileName(config))
 }
 
 // BootstrapScript creates the user data script to bootstrap the host.
@@ -383,7 +383,7 @@ func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Cr
 			return "", errors.Wrap(err, "error creating commands to load task data")
 		}
 		if h.ProvisionOptions.TaskId != "" {
-			fetchCmd := h.SpawnHostGetTaskDataCommand()
+			fetchCmd := append([]string{h.PathByProvisioning(h.Distro.BootstrapSettings.ShellPath), "-l", "-c"}, h.SpawnHostGetTaskDataCommand()...)
 			var getTaskDataCmd string
 			getTaskDataCmd, err = h.buildLocalJasperClientRequest(settings.HostJasper, strings.Join([]string{jcli.ManagerCommand, jcli.CreateCommand}, " "), &options.Command{Commands: [][]string{fetchCmd}})
 			if err != nil {

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -362,7 +362,7 @@ func (h *Host) jasperBinaryFileName(config evergreen.HostJasperConfig) string {
 
 // JasperBinaryFilePath returns the full path to the Jasper binary.
 func (h *Host) JasperBinaryFilePath(config evergreen.HostJasperConfig) string {
-	return filepath.Join(h.Distro.BootstrapSettings.JasperBinaryDir, h.jasperBinaryFileName(config))
+	return h.PathToFile(filepath.Join(h.Distro.BootstrapSettings.JasperBinaryDir, h.jasperBinaryFileName(config)))
 }
 
 // BootstrapScript creates the user data script to bootstrap the host.

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1047,12 +1047,6 @@ func (h *Host) spawnHostConfigJSON(settings *evergreen.Settings) ([]byte, error)
 // SpawnHostGetTaskDataCommand returns the command that fetches the task data
 // for a spawn host.
 func (h *Host) SpawnHostGetTaskDataCommand() []string {
-	// TODO (EVG-7387): this should be fixed to work with legacy SSH on Windows.
-	// The config file path has to be a native Windows path in order to properly
-	// read the config file, but currently the working directory is specified as
-	// a Cygwin-style directory (i.e. /home/Administrator should actually be
-	// C:/cygwin/home/Administrator).
-	// kim: TODO: use Jasper in setupHostJob instead of regular SSH.
 	return []string{h.AgentBinary(),
 		"-c", h.PathToFile(h.spawnHostConfigFile()),
 		"fetch",

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -383,7 +383,7 @@ func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Cr
 			return "", errors.Wrap(err, "error creating commands to load task data")
 		}
 		if h.ProvisionOptions.TaskId != "" {
-			fetchCmd := append([]string{h.PathByProvisioning(h.Distro.BootstrapSettings.ShellPath), "-l", "-c"}, h.SpawnHostGetTaskDataCommand()...)
+			fetchCmd := []string{h.PathByProvisioning(h.Distro.BootstrapSettings.ShellPath), "-l", "-c", strings.Join(h.SpawnHostGetTaskDataCommand(), " ")}
 			var getTaskDataCmd string
 			getTaskDataCmd, err = h.buildLocalJasperClientRequest(settings.HostJasper, strings.Join([]string{jcli.ManagerCommand, jcli.CreateCommand}, " "), &options.Command{Commands: [][]string{fetchCmd}})
 			if err != nil {
@@ -1013,6 +1013,9 @@ func (h *Host) AgentBinary() string {
 // spawnHostConfigDir returns the directory containing the CLI and evergreen
 // yaml for a spawn host.
 func (h *Host) spawnHostConfigDir() string {
+	if h.Distro.LegacyBootstrap() {
+		return "cli_bin"
+	}
 	return filepath.Join(h.Distro.HomeDir(), "cli_bin")
 }
 

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -243,9 +243,10 @@ func TestJasperCommands(t *testing.T) {
 			setupSpawnHost, err := h.SpawnHostSetupCommands(settings)
 			require.NoError(t, err)
 
+			bashSetupSpawnHost := []string{h.PathByProvisioning(h.Distro.BootstrapSettings.ShellPath), "-l", "-c", strings.Join(h.SpawnHostGetTaskDataCommand(), " ")}
 			getTaskData, err := h.buildLocalJasperClientRequest(settings.HostJasper,
 				strings.Join([]string{jcli.ManagerCommand, jcli.CreateCommand}, " "),
-				&options.Command{Commands: [][]string{h.SpawnHostGetTaskDataCommand()}})
+				&options.Command{Commands: [][]string{bashSetupSpawnHost}})
 			require.NoError(t, err)
 
 			markDone, err := h.MarkUserDataDoneCommands()
@@ -279,7 +280,6 @@ func TestJasperCommands(t *testing.T) {
 				require.NotEqual(t, -1, offset, fmt.Sprintf("missing %s", expectedCmd))
 				currPos += offset + len(expectedCmd)
 			}
-
 		},
 		"ForceReinstallJasperCommand": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			cmd := h.ForceReinstallJasperCommand(settings)
@@ -321,6 +321,9 @@ func TestJasperCommands(t *testing.T) {
 				Distro: distro.Distro{
 					Arch: distro.ArchLinuxAmd64,
 					BootstrapSettings: distro.BootstrapSettings{
+						Method:                distro.BootstrapMethodUserData,
+						Communication:         distro.CommunicationMethodRPC,
+						ShellPath:             "/bin/bash",
 						JasperBinaryDir:       "/foo",
 						JasperCredentialsPath: "/bar/bat.txt",
 						Env: []distro.EnvVar{

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -41,11 +41,11 @@ func TestCurlCommand(t *testing.T) {
 		Ui:                evergreen.UIConfig{Url: "www.example.com"},
 		ClientBinariesDir: "clients",
 	}
-	expected := "cd /home/user && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' && chmod +x evergreen.exe"
+	expected := "cd ~ && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' && chmod +x evergreen.exe"
 	assert.Equal(expected, h.CurlCommand(settings))
 
 	h = &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64, User: "user"}}
-	expected = "cd /home/user && curl -LO 'www.example.com/clients/linux_amd64/evergreen' && chmod +x evergreen"
+	expected = "cd ~ && curl -LO 'www.example.com/clients/linux_amd64/evergreen' && chmod +x evergreen"
 	assert.Equal(expected, h.CurlCommand(settings))
 }
 
@@ -55,11 +55,11 @@ func TestCurlCommandWithRetry(t *testing.T) {
 		Ui:                evergreen.UIConfig{Url: "www.example.com"},
 		ClientBinariesDir: "clients",
 	}
-	expected := "cd /home/user && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10 && chmod +x evergreen.exe"
+	expected := "cd ~ && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10 && chmod +x evergreen.exe"
 	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, 5, 10))
 
 	h = &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64, User: "user"}}
-	expected = "cd /home/user && curl -LO 'www.example.com/clients/linux_amd64/evergreen' --retry 5 --retry-max-time 10 && chmod +x evergreen"
+	expected = "cd ~ && curl -LO 'www.example.com/clients/linux_amd64/evergreen' --retry 5 --retry-max-time 10 && chmod +x evergreen"
 	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, 5, 10))
 }
 
@@ -1036,6 +1036,8 @@ func TestSpawnHostSetupCommands(t *testing.T) {
 			WorkDir: "/dir",
 			User:    "user",
 			BootstrapSettings: distro.BootstrapSettings{
+				Method:                distro.BootstrapMethodUserData,
+				Communication:         distro.CommunicationMethodRPC,
 				JasperCredentialsPath: "/jasper_credentials_path",
 			},
 		},

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -1147,7 +1147,7 @@ func (hs *hostStartProcesses) Run(ctx context.Context) gimlet.Responder {
 			continue
 		}
 
-		bashPath := h.PathToFile(h.Distro.BootstrapSettings.ShellPath)
+		bashPath := h.PathByProvisioning(h.Distro.BootstrapSettings.ShellPath)
 		opts := &options.Create{
 			Args:   []string{bashPath, "-l", "-c", hs.script},
 			Output: options.Output{Loggers: []options.Logger{jasper.NewInMemoryLogger(host.OutputBufferSize)}},

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -1148,7 +1147,7 @@ func (hs *hostStartProcesses) Run(ctx context.Context) gimlet.Responder {
 			continue
 		}
 
-		bashPath := filepath.Join(h.Distro.BootstrapSettings.RootDir, h.Distro.BootstrapSettings.ShellPath)
+		bashPath := h.PathToFile(h.Distro.BootstrapSettings.ShellPath)
 		opts := &options.Create{
 			Args:   []string{bashPath, "-l", "-c", hs.script},
 			Output: options.Output{Loggers: []options.Logger{jasper.NewInMemoryLogger(host.OutputBufferSize)}},

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -769,7 +769,7 @@ func (j *setupHostJob) fetchRemoteTaskData(ctx context.Context, settings *evergr
 	} else {
 		var logs []string
 		logs, err = j.host.RunJasperProcess(ctx, j.env, &options.Create{
-			Args: cmd,
+			Args: append([]string{j.host.PathByProvisioning(j.host.Distro.BootstrapSettings.ShellPath), "-l", "-c"}, cmd...),
 		})
 		output = strings.Join(logs, " ")
 	}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -762,14 +762,14 @@ func (j *setupHostJob) fetchRemoteTaskData(ctx context.Context, settings *evergr
 		return errors.Wrapf(err, "error parsing ssh info %s", j.host.Host)
 	}
 
-	cmd := j.host.SpawnHostGetTaskDataCommand()
+	cmd := strings.Join(j.host.SpawnHostGetTaskDataCommand(), " ")
 	var output string
 	if j.host.Distro.LegacyBootstrap() {
-		output, err = j.host.RunSSHCommandWithTimeout(ctx, strings.Join(cmd, " "), sshOpts, 15*time.Minute)
+		output, err = j.host.RunSSHCommandWithTimeout(ctx, cmd, sshOpts, 15*time.Minute)
 	} else {
 		var logs []string
 		logs, err = j.host.RunJasperProcess(ctx, j.env, &options.Create{
-			Args: append([]string{j.host.PathByProvisioning(j.host.Distro.BootstrapSettings.ShellPath), "-l", "-c"}, cmd...),
+			Args: []string{j.host.PathByProvisioning(j.host.Distro.BootstrapSettings.ShellPath), "-l", "-c", cmd},
 		})
 		output = strings.Join(logs, " ")
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7387

This is a compatibility fix for Windows legacy and non-legacy provisioning.

For almost all cases, paths to Windows files and directories have to be specified as native file paths when passing them as command line arguments (i.e. if you use `/`, it refers to `C:/` not `C:/cygwin`). Jasper processes (which run via exec), are consistent with this behavior because all file paths have to be in native Windows style (e.g. `C:/cygwin/home/Administrator/evergreen.exe fetch --dir C:/cygwin/data`). However, when invoking executables directly through legacy SSH, we have to use Unix-style paths (e.g. `/home/Administrator/evergreen.exe`) since their paths are evaluated directly in Cygwin bash. The Unix-style path rule doesn't apply for CLI flags on the evergreen binary, which are native Windows-style paths.

We have some dependency in legacy provisioning on the fact that `/data` is symlinked at the root of the C drive in order to do `evergreen fetch`.

The best solution is probably to require `RootDir` be specified for both legacy and non-legacy hosts on Windows so that we can use native Windows paths correctly. There's a ticket for follow-on work to do this: https://jira.mongodb.org/browse/EVG-7439

tl;dr - Jasper is consistent and will always require native WIndows paths for everything (binaries, files, directories). Cygwin is painfully inconsistent since depends on the context in which the filepath is being used.
