### PR TITLE
EVG-7374 handle max only thread level comparisons

### DIFF
--- a/public/static/app/perf/TestSample.js
+++ b/public/static/app/perf/TestSample.js
@@ -76,7 +76,7 @@ mciModule.factory('TestSample', function () {
       if (!d) {
         return null;
       }
-      if (threadLevel) {
+      if (threadLevel > 0) {
         return d.results[threadLevel][metric];
       } else {
         return _.max(

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -330,6 +330,7 @@ $http.get(templateUrl).success(function(template) {
 
   $scope.comparisonPct = function (compareSample, testName) {
     const maxThreadLevel = "MAX";
+    // if only showing max thread level, set it to "MAX", otherwise find the highest value among the thread levels for this test
     let threadLevel = _.contains($scope.selectedThreads[testName], maxThreadLevel) ?
       _.max($scope.hoverSamples[testName].threadResults, (result) => result.threadLevel).threadLevel :
       _.max($scope.selectedThreads[testName]);

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -329,10 +329,10 @@ $http.get(templateUrl).success(function(template) {
   }
 
   $scope.comparisonPct = function (compareSample, testName) {
-    let threadLevel = _.max($scope.selectedThreads[testName]);
-    if (threadLevel < 0) { // if the toggle is set to max only
-      threadLevel = _.max($scope.hoverSamples[testName].threadResults, (result) => result.threadLevel).threadLevel
-    }
+    const maxThreadLevel = "MAX";
+    let threadLevel = _.contains($scope.selectedThreads[testName], maxThreadLevel) ?
+      _.max($scope.hoverSamples[testName].threadResults, (result) => result.threadLevel).threadLevel :
+      _.max($scope.selectedThreads[testName]);
     let hoverResults = _.findWhere($scope.hoverSamples[testName].threadResults, {
       threadLevel: threadLevel
     });

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -329,7 +329,10 @@ $http.get(templateUrl).success(function(template) {
   }
 
   $scope.comparisonPct = function (compareSample, testName) {
-    const threadLevel = _.max($scope.selectedThreads[testName]);
+    let threadLevel = _.max($scope.selectedThreads[testName]);
+    if (threadLevel < 0) { // if the toggle is set to max only
+      threadLevel = _.max($scope.hoverSamples[testName].threadResults, (result) => result.threadLevel).threadLevel
+    }
     let hoverResults = _.findWhere($scope.hoverSamples[testName].threadResults, {
       threadLevel: threadLevel
     });


### PR DESCRIPTION
Previously selecting max only in trend charts would cause a runtime error because we look for thread results with the string "MAX" as the thread level. This handles that by looking up the highest thread count in the results