### PR TITLE
EVG-6929 stop writing config string to versions

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -87,7 +87,6 @@ var (
 	commitQueueDisabledKey          = bsonutil.MustHaveTag(ServiceFlags{}, "CommitQueueDisabled")
 	plannerDisabledKey              = bsonutil.MustHaveTag(ServiceFlags{}, "PlannerDisabled")
 	hostAllocatorDisabledKey        = bsonutil.MustHaveTag(ServiceFlags{}, "HostAllocatorDisabled")
-	parserProjectDisabledKey        = bsonutil.MustHaveTag(ServiceFlags{}, "ParserProjectDisabled")
 	drBackupDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "DRBackupDisabled")
 	backgroundReauthDisabledKey     = bsonutil.MustHaveTag(ServiceFlags{}, "BackgroundReauthDisabled")
 

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -27,7 +27,6 @@ type ServiceFlags struct {
 	CommitQueueDisabled        bool `bson:"commit_queue_disabled" json:"commit_queue_disabled"`
 	PlannerDisabled            bool `bson:"planner_disabled" json:"planner_disabled"`
 	HostAllocatorDisabled      bool `bson:"host_allocator_disabled" json:"host_allocator_disabled"`
-	ParserProjectDisabled      bool `bson:"parser_project_disabled" json:"parser_project_disabled"`
 	DRBackupDisabled           bool `bson:"dr_backup_disabled" json:"dr_backup_disabled"`
 	BackgroundReauthDisabled   bool `bson:"background_reauth_disabled" json:"background_reauth_disabled"`
 
@@ -93,7 +92,6 @@ func (c *ServiceFlags) Set() error {
 			commitQueueDisabledKey:          c.CommitQueueDisabled,
 			plannerDisabledKey:              c.PlannerDisabled,
 			hostAllocatorDisabledKey:        c.HostAllocatorDisabled,
-			parserProjectDisabledKey:        c.ParserProjectDisabled,
 			drBackupDisabledKey:             c.DRBackupDisabled,
 			backgroundReauthDisabledKey:     c.BackgroundReauthDisabled,
 		},

--- a/model/generate.go
+++ b/model/generate.go
@@ -178,7 +178,7 @@ func updateParserProject(v *Version, pp *ParserProject) error {
 	}
 
 	// legacy
-	if err := VersionUpdateConfig(v.Id, v.Config, v.ConfigUpdateNumber, true); err != nil {
+	if err := VersionUpdateConfig(v.Id, v.Config, v.ConfigUpdateNumber); err != nil {
 		return errors.Wrapf(err, "error updating version '%s'", v.Id)
 	}
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -473,7 +473,6 @@ func CreateTasksCache(tasks []task.Task) []build.TaskCache {
 // RefreshTasksCache updates a build document so that the tasks cache reflects the correct current
 // state of the tasks it represents.
 func RefreshTasksCache(buildId string) error {
-
 	tasks, err := task.FindWithDisplayTasks(task.ByBuildId(buildId))
 	if err != nil {
 		return errors.WithStack(err)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -325,7 +325,6 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		Message:             p.Description,
 		BuildIds:            []string{},
 		BuildVariants:       []VersionBuildStatus{},
-		Config:              p.PatchedConfig,
 		Status:              evergreen.PatchCreated,
 		Requester:           requester,
 		Branch:              projectRef.Branch,

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -444,18 +444,14 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 		return nil, nil, errors.Wrap(err, "error finding parser project")
 	}
 
-	if pp != nil {
-		// if parser project config number is old then there was a race,
-		// and we should default to the version config
-		if pp.ConfigUpdateNumber >= v.ConfigUpdateNumber {
-			pp.Identifier = identifier
-			var p *Project
-			p, err = TranslateProject(pp)
-			return p, pp, err
-		}
+	// if parser project config number is old then we should default to legacy
+	if pp != nil && pp.ConfigUpdateNumber >= v.ConfigUpdateNumber {
+		pp.Identifier = identifier
+		var p *Project
+		p, err = TranslateProject(pp)
+		return p, pp, err
 	}
 
-	// else, use legacy
 	if v.Config == "" {
 		return nil, nil, errors.New("version has no config")
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -9,7 +9,6 @@ import (
 	mgobson "gopkg.in/mgo.v2/bson"
 	"gopkg.in/yaml.v2"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
@@ -437,36 +436,31 @@ func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(interface{}) error) e
 // LoadProjectForVersion returns the project for a version, either from the parser project or the config string.
 // If read from the config string and shouldSave is set, the resulting parser project will be saved.
 func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Project, *ParserProject, error) {
-	var ppFromDB *ParserProject
+	var pp *ParserProject
 	var err error
-	flags, err := evergreen.GetServiceFlags()
+
+	pp, err = ParserProjectFindOneById(v.Id)
 	if err != nil {
-		return nil, nil, errors.WithStack(err)
-	}
-	// if not using parser project anyway, only lookup if saving
-	if !flags.ParserProjectDisabled || shouldSave {
-		ppFromDB, err = ParserProjectFindOneById(v.Id)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "error finding parser project")
-		}
+		return nil, nil, errors.Wrap(err, "error finding parser project")
 	}
 
-	if !flags.ParserProjectDisabled && ppFromDB != nil {
+	if pp != nil {
 		// if parser project config number is old then there was a race,
 		// and we should default to the version config
-		if ppFromDB.ConfigUpdateNumber >= v.ConfigUpdateNumber {
-			ppFromDB.Identifier = identifier
+		if pp.ConfigUpdateNumber >= v.ConfigUpdateNumber {
+			pp.Identifier = identifier
 			var p *Project
-			p, err = TranslateProject(ppFromDB)
-			return p, ppFromDB, err
+			p, err = TranslateProject(pp)
+			return p, pp, err
 		}
 	}
 
+	// else, use legacy
 	if v.Config == "" {
 		return nil, nil, errors.New("version has no config")
 	}
 	p := &Project{}
-	pp, err := LoadProjectInto([]byte(v.Config), identifier, p)
+	pp, err = LoadProjectInto([]byte(v.Config), identifier, p)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error loading project")
 	}
@@ -475,8 +469,7 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 	pp.ConfigUpdateNumber = v.ConfigUpdateNumber
 	pp.CreateTime = v.CreateTime
 
-	// TODO: don't need separate ppFromDB variable once using parser project
-	if shouldSave && ppFromDB == nil {
+	if shouldSave {
 		if err = pp.TryUpsert(); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"project": identifier,

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
-	"gopkg.in/yaml.v2"
 )
 
 type TestModelData struct {
@@ -70,10 +69,6 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 
 	// Marshal the parser project YAML for storage
 	pp.AddBuildVariant(variant, "", "", nil, []string{taskDisplayName})
-	projectYamlBytes, err := yaml.Marshal(pp)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal project config")
-	}
 
 	// Create the ref for the project
 	projectRef := &model.ProjectRef{
@@ -176,7 +171,6 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 	v := &model.Version{
 		Id:       taskOne.Version,
 		BuildIds: []string{taskOne.BuildId},
-		Config:   string(projectYamlBytes),
 	}
 	pp.Id = taskOne.Version
 	if err = v.Insert(); err != nil {

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -295,11 +295,12 @@ func VersionUpdateOne(query interface{}, update interface{}) error {
 	)
 }
 
-func VersionUpdateConfig(id, config string, configUpdateNumber int, shouldEqual bool) error {
-	query := bson.M{VersionIdKey: id}
-	if shouldEqual {
-		query[VersionConfigNumberKey] = configUpdateNumber
+func VersionUpdateConfig(id, config string, configUpdateNumber int) error {
+	query := bson.M{
+		VersionIdKey:           id,
+		VersionConfigNumberKey: configUpdateNumber,
 	}
+
 	update := bson.M{
 		"$set": bson.M{
 			VersionConfigKey:       config,

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -73,11 +73,6 @@ func (p *ProjectInfo) notPopulated() bool {
 	return p.Ref == nil || p.IntermediateProject == nil
 }
 
-// PopulateVersion updates the version's ParserProject if we have or can create it
-func (p *ProjectInfo) populateVersion(v *model.Version) error {
-
-}
-
 // The RepoPoller interface specifies behavior required of all repository poller
 // implementations
 type RepoPoller interface {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -832,7 +832,8 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata VersionM
 		if err != nil {
 			return errors.Wrap(err, "error starting transaction")
 		}
-		_, err = evergreen.GetEnvironment().DB().Collection(model.VersionCollection).InsertOne(sessCtx, v)
+		db := evergreen.GetEnvironment().DB()
+		_, err = db.Collection(model.VersionCollection).InsertOne(sessCtx, v)
 		if err != nil {
 			grip.Notice(message.WrapError(err, message.Fields{
 				"message": "aborting transaction",
@@ -844,7 +845,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata VersionM
 			}
 			return errors.Wrapf(err, "error inserting version '%s'", v.Id)
 		}
-		_, err = evergreen.GetEnvironment().DB().Collection(model.ParserProjectCollection).InsertOne(sessCtx, projectInfo.IntermediateProject)
+		_, err = db.Collection(model.ParserProjectCollection).InsertOne(sessCtx, projectInfo.IntermediateProject)
 		if err != nil {
 			grip.Notice(message.WrapError(err, message.Fields{
 				"message": "aborting transaction",
@@ -856,7 +857,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata VersionM
 			}
 			return errors.Wrapf(err, "error inserting parser project '%s'", v.Id)
 		}
-		_, err = evergreen.GetEnvironment().DB().Collection(build.Collection).InsertMany(sessCtx, buildsToCreate)
+		_, err = db.Collection(build.Collection).InsertMany(sessCtx, buildsToCreate)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "aborting transaction",

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -327,8 +327,6 @@ func TestCreateContainerFromTask(t *testing.T) {
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, host.Collection))
 
-	flags := evergreen.ServiceFlags{ParserProjectDisabled: true}
-	assert.NoError(evergreen.SetServiceFlags(flags))
 	t1 := task.Task{
 		Id:           "t1",
 		DisplayName:  "t1",

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -91,7 +91,7 @@ func TestListHostsForTask(t *testing.T) {
 
 func TestCreateHostsFromTask(t *testing.T) {
 	// Setup tests
-	assert.NoError(t, db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, host.Collection))
+	assert.NoError(t, db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection))
 	providerSettings := map[string]interface{}{
 		"ami":                "ami-1234",
 		"vpc_name":           "my_vpc",
@@ -325,7 +325,7 @@ buildvariants:
 func TestCreateContainerFromTask(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	assert.NoError(db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, host.Collection))
+	assert.NoError(db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection))
 
 	t1 := task.Task{
 		Id:           "t1",

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -440,7 +440,12 @@ func TestCreateVersionFromConfig(t *testing.T) {
 	assert.Equal(ref.Identifier, newVersion.Identifier)
 	assert.Equal(6, newVersion.RevisionOrderNumber)
 	assert.Equal(evergreen.AdHocRequester, newVersion.Requester)
-	assert.NotEmpty(newVersion.Config)
+	assert.Empty(newVersion.Config)
+
+	pp, err := model.ParserProjectFindOneById(newVersion.Id)
+	assert.NoError(err)
+	assert.NotNil(pp)
+	assert.True(pp.Stepback)
 
 	b, err := build.FindOneId(newVersion.BuildIds[0])
 	assert.NoError(err)
@@ -471,7 +476,12 @@ tasks:
 	assert.Equal(ref.Identifier, newVersion.Identifier)
 	assert.Equal(7, newVersion.RevisionOrderNumber)
 	assert.Equal(evergreen.AdHocRequester, newVersion.Requester)
-	assert.NotEmpty(newVersion.Config)
+	assert.Empty(newVersion.Config)
+
+	pp, err = model.ParserProjectFindOneById(newVersion.Id)
+	assert.NoError(err)
+	assert.NotNil(pp)
+	assert.True(pp.Stepback)
 
 	b, err = build.FindOneId(newVersion.BuildIds[0])
 	assert.NoError(err)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1429,7 +1429,6 @@ type APIServiceFlags struct {
 	CommitQueueDisabled        bool `json:"commit_queue_disabled"`
 	PlannerDisabled            bool `json:"planner_disabled"`
 	HostAllocatorDisabled      bool `json:"host_allocator_disabled"`
-	ParserProjectDisabled      bool `json:"parser_project_disabled"`
 	DRBackupDisabled           bool `json:"dr_backup_disabled"`
 	BackgroundReauthDisabled   bool `json:"background_reauth_disabled"`
 
@@ -1692,7 +1691,6 @@ func (as *APIServiceFlags) BuildFromService(h interface{}) error {
 		as.CommitQueueDisabled = v.CommitQueueDisabled
 		as.PlannerDisabled = v.PlannerDisabled
 		as.HostAllocatorDisabled = v.HostAllocatorDisabled
-		as.ParserProjectDisabled = v.ParserProjectDisabled
 		as.DRBackupDisabled = v.DRBackupDisabled
 		as.BackgroundReauthDisabled = v.BackgroundReauthDisabled
 	default:
@@ -1728,7 +1726,6 @@ func (as *APIServiceFlags) ToService() (interface{}, error) {
 		CommitQueueDisabled:          as.CommitQueueDisabled,
 		PlannerDisabled:              as.PlannerDisabled,
 		HostAllocatorDisabled:        as.HostAllocatorDisabled,
-		ParserProjectDisabled:        as.ParserProjectDisabled,
 		DRBackupDisabled:             as.DRBackupDisabled,
 		BackgroundReauthDisabled:     as.BackgroundReauthDisabled,
 	}, nil

--- a/service/rest_version_test.go
+++ b/service/rest_version_test.go
@@ -20,7 +20,6 @@ import (
 	modelutil "github.com/evergreen-ci/evergreen/model/testutil"
 	serviceutil "github.com/evergreen-ci/evergreen/service/testutil"
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -235,9 +234,6 @@ func TestGetVersionInfo(t *testing.T) {
 	router, err := newTestUIRouter(ctx, env)
 	require.NoError(t, err, "error setting up router")
 
-	flags := evergreen.ServiceFlags{ParserProjectDisabled: true}
-	assert.NoError(t, evergreen.SetServiceFlags(flags))
-
 	err = modelutil.CreateTestLocalConfig(buildTestConfig, "mci-test", "")
 	require.NoError(t, err, "Error loading local config mci-test")
 
@@ -410,9 +406,6 @@ func TestActivateVersion(t *testing.T) {
 	env.SetUserManager(serviceutil.MockUserManager{})
 	router, err := newAuthTestUIRouter(ctx, env)
 	require.NoError(t, err, "error setting up router")
-
-	flags := evergreen.ServiceFlags{ParserProjectDisabled: true}
-	assert.NoError(t, evergreen.SetServiceFlags(flags))
 
 	Convey("When marking a particular version as active", t, func() {
 		require.NoError(t, db.ClearCollections(model.VersionCollection, build.Collection),


### PR DESCRIPTION
Stop writing to version config if we don't have to! 

(Surprised this wasn't already in the transaction, I definitely remember writing that at some point. Wonder if it got included in a revert at some point and accidentally got left out. If anyone can think of a reason it shouldn't be in the transaction let me know).