### PR TITLE
EVG-7441: Use NaiveManager instead of MockUserManager for GQL tests

### DIFF
--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2286,11 +2286,13 @@
       "query_file": "patch-time-2.graphql",
       "result": {
         "data": {
-          "patch": {
-            "time": {
-              "started": "February 13, 2020, 5:42PM",
-              "finished": "February 14, 2020, 6:03PM",
-              "submittedAt": "February 12, 2020, 4:58PM"
+          "data": {
+            "patch": {
+              "time": {
+                "started": "February 13, 2020, 12:42PM",
+                "finished": "February 14, 2020, 1:03PM",
+                "submittedAt": "February 12, 2020, 11:58AM"
+              }
             }
           }
         }

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2268,7 +2268,6 @@
         }
       }
     },
-
     {
       "query_file": "patch-time-1.graphql",
       "result": {

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2268,6 +2268,7 @@
         }
       }
     },
+
     {
       "query_file": "patch-time-1.graphql",
       "result": {
@@ -2276,7 +2277,7 @@
             "time": {
               "started": null,
               "finished": null,
-              "submittedAt": "January 11, 2018, 12:01AM"
+              "submittedAt": "January 10, 2018, 7:01PM"
             }
           }
         }

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2287,13 +2287,11 @@
       "query_file": "patch-time-2.graphql",
       "result": {
         "data": {
-          "data": {
-            "patch": {
-              "time": {
-                "started": "February 13, 2020, 12:42PM",
-                "finished": "February 14, 2020, 1:03PM",
-                "submittedAt": "February 12, 2020, 11:58AM"
-              }
+          "patch": {
+            "time": {
+              "started": "February 13, 2020, 12:42PM",
+              "finished": "February 14, 2020, 1:03PM",
+              "submittedAt": "February 12, 2020, 11:58AM"
             }
           }
         }

--- a/graphql/integration_test.go
+++ b/graphql/integration_test.go
@@ -56,6 +56,7 @@ func (s *graphQLSuite) SetupSuite() {
 	s.Require().NoError(testUser.Insert())
 	s.url = server.URL
 	s.apiKey = apiKey
+	s.apiUser = apiUser
 }
 
 func (s *graphQLSuite) TestQueries() {

--- a/graphql/integration_test.go
+++ b/graphql/integration_test.go
@@ -47,7 +47,7 @@ func (s *graphQLSuite) SetupSuite() {
 	const apiKey = "testapikey"
 	const apiUser = "testuser"
 
-	server, err := service.CreateTestServer(testutil.TestConfig(), nil)
+	server, err := service.CreateTestServer(testutil.TestConfig(), nil, true)
 	s.Require().NoError(err)
 	env := evergreen.GetEnvironment()
 	ctx := context.Background()

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -56,7 +56,7 @@ type cliTestHarness struct {
 
 func setupCLITestHarness() cliTestHarness {
 	// create a test API server
-	testServer, err := service.CreateTestServer(testConfig, nil)
+	testServer, err := service.CreateTestServer(testConfig, nil, false)
 	So(err, ShouldBeNil)
 	So(
 		db.ClearCollections(

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -40,7 +40,7 @@ func (s *CommitQueueSuite) SetupSuite() {
 	testutil.DisablePermissionsForTests()
 
 	var err error
-	s.server, err = service.CreateTestServer(testConfig, nil)
+	s.server, err = service.CreateTestServer(testConfig, nil, false)
 	s.Require().NoError(err)
 
 	settings := ClientSettings{

--- a/service/api_patch_test.go
+++ b/service/api_patch_test.go
@@ -20,7 +20,7 @@ func TestPatchListModulesEndPoints(t *testing.T) {
 	defer testutil.EnablePermissionsForTests()
 	testDirectory := testutil.GetDirectoryOfFile()
 	testConfig := testutil.TestConfig()
-	testApiServer, err := CreateTestServer(testConfig, nil)
+	testApiServer, err := CreateTestServer(testConfig, nil, false)
 	require.NoError(t, err, "failed to create new API server")
 	defer testApiServer.Close()
 

--- a/service/api_status_test.go
+++ b/service/api_status_test.go
@@ -150,7 +150,7 @@ func TestConsistentTaskAssignment(t *testing.T) {
 
 func TestServiceStatusEndPoints(t *testing.T) {
 	testConfig := testutil.TestConfig()
-	testServer, err := CreateTestServer(testConfig, nil)
+	testServer, err := CreateTestServer(testConfig, nil, false)
 	require.NoError(t, err, "Couldn't create apiserver: %v", err)
 	defer testServer.Close()
 
@@ -177,7 +177,7 @@ func TestServiceStatusEndPoints(t *testing.T) {
 func TestStuckHostEndpoints(t *testing.T) {
 	Convey("With a test server and test config", t, func() {
 		testConfig := testutil.TestConfig()
-		testServer, err := CreateTestServer(testConfig, nil)
+		testServer, err := CreateTestServer(testConfig, nil, false)
 		require.NoError(t, err, "Couldn't create apiserver: %v", err)
 		defer testServer.Close()
 

--- a/service/api_test_utils.go
+++ b/service/api_test_utils.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/auth"
 	"github.com/evergreen-ci/evergreen/service/testutil"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -51,8 +52,12 @@ func CreateTestServer(settings *evergreen.Settings, tlsConfig *tls.Config) (*Tes
 	}
 
 	env := evergreen.GetEnvironment()
-	env.SetUserManager(testutil.MockUserManager{})
-
+	um, info, err := auth.LoadUserManager(settings)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load user manager")
+	}
+	env.SetUserManager(um)
+	env.SetUserManagerInfo(info)
 	as, err := NewAPIServer(env, env.LocalQueue())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change allows us to access user permissions set in the gql integration test setup data during gql tests so we can properly test queries that require specific permissions. 
I added a third parameter to `CreateTestsServer` to enable this setting and had to change some test results since the time zone was adjusted after enabling NaiveManager for GQL tests. 