### PR TITLE
EVG-7212 remove extra calls to CreateTags

### DIFF
--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -87,14 +87,14 @@ func TestFleet(t *testing.T) {
 			assert.Equal(t, "public_dns_name", dnsName)
 		},
 		"SpawnFleetSpotHost": func(*testing.T) {
-			assert.NoError(t, m.spawnFleetSpotHost(context.Background(), &host.Host{}, &EC2ProviderSettings{}, []*ec2.LaunchTemplateBlockDeviceMappingRequest{}))
+			assert.NoError(t, m.spawnFleetSpotHost(context.Background(), &host.Host{}, &EC2ProviderSettings{}))
 
 			mockClient := m.client.(*awsClientMock)
 			assert.Equal(t, "templateID", *mockClient.DeleteLaunchTemplateInput.LaunchTemplateId)
 		},
 		"UploadLaunchTemplate": func(*testing.T) {
 			ec2Settings := &EC2ProviderSettings{AMI: "ami"}
-			templateID, templateVersion, err := m.uploadLaunchTemplate(context.Background(), &host.Host{}, ec2Settings, []*ec2.LaunchTemplateBlockDeviceMappingRequest{})
+			templateID, templateVersion, err := m.uploadLaunchTemplate(context.Background(), &host.Host{}, ec2Settings)
 			assert.NoError(t, err)
 			assert.Equal(t, "templateID", *templateID)
 			assert.Equal(t, int64(1), *templateVersion)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -181,6 +181,28 @@ func makeTags(intentHost *host.Host) []host.Tag {
 	return intentHost.InstanceTags
 }
 
+func makeTagTemplate(hostTags []host.Tag) []*ec2.LaunchTemplateTagSpecificationRequest {
+	awsTags := []*ec2.Tag{}
+	for _, tag := range hostTags {
+		key := tag.Key
+		val := tag.Value
+		awsTags = append(awsTags, &ec2.Tag{Key: &key, Value: &val})
+	}
+	tagTemplates := []*ec2.LaunchTemplateTagSpecificationRequest{
+		{
+			ResourceType: aws.String(ec2.ResourceTypeInstance),
+			Tags:         awsTags,
+		},
+		// every host has at least a root volume that needs to be tagged
+		{
+			ResourceType: aws.String(ec2.ResourceTypeVolume),
+			Tags:         awsTags,
+		},
+	}
+
+	return tagTemplates
+}
+
 func timeTilNextEC2Payment(h *host.Host) time.Duration {
 	if usesHourlyBilling(h) {
 		return timeTilNextHourlyPayment(h)


### PR DESCRIPTION
Because Evergreen's most common call to the AWS API is CreateTags, combining tagging with the CreateFleet request will save many API calls.