### PR TITLE
EVG-7464 create manifest for triggered builds if matching module

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -944,6 +944,7 @@ func (p PluginCommandConf) GetType(prj *Project) string {
 	return DefaultCommandType
 }
 
+// GetRepoOwnerAndName returns the owner and repo name (in that order) of a module
 func (m *Module) GetRepoOwnerAndName() (string, string) {
 	parts := strings.Split(m.Repo, ":")
 	basename := parts[len(parts)-1]

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -81,7 +81,7 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 		if owner == upstreamProject.Owner && repo == upstreamProject.Repo && module.Branch == upstreamProject.Branch {
 			_, err = repotracker.CreateManifest(*v, proj, upstreamProject.Branch, settings)
 			if err != nil {
-				return nil, err
+				return nil, errors.WithStack(err)
 			}
 			break
 		}

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -73,6 +73,9 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding project ref")
 	}
+	if upstreamProject == nil {
+		return nil, errors.Errorf("project %s not found", args.SourceVersion.Identifier)
+	}
 	for _, module := range proj.Modules {
 		owner, repo := module.GetRepoOwnerAndName()
 		if owner == upstreamProject.Owner && repo == upstreamProject.Repo && module.Branch == upstreamProject.Branch {


### PR DESCRIPTION
A common workflow is probably to set a trigger on a project that is also one of your modules. In that scenario, we will now create a manifest with the triggered version so that test setup should for the most part just work without you having to add configuration to check out the upstream revision 