### PR TITLE
Evg-7474 Generate self-signed s3 URLs on build page load

### DIFF
--- a/command/s3_put.go
+++ b/command/s3_put.go
@@ -236,12 +236,17 @@ func (s3pc *s3put) Execute(ctx context.Context,
 		return nil
 	}
 
-	if s3pc.isMulti() {
-		logger.Task().Infof("Putting files matching filter %v into path %v in s3 bucket %v",
-			s3pc.LocalFilesIncludeFilter, s3pc.RemoteFile, s3pc.Bucket)
+	if s3pc.isPrivate(s3pc.Visibility) {
+		logger.Task().Infof("Putting files in s3")
+
 	} else {
-		logger.Task().Infof("Putting %s into %s/%s/%s",
-			s3pc.LocalFile, s3baseURL, s3pc.Bucket, s3pc.RemoteFile)
+		if s3pc.isMulti() {
+			logger.Task().Infof("Putting files matching filter %v into path %v in s3 bucket %v",
+				s3pc.LocalFilesIncludeFilter, s3pc.RemoteFile, s3pc.Bucket)
+		} else {
+			logger.Task().Infof("Putting %s into %s/%s/%s",
+				s3pc.LocalFile, s3baseURL, s3pc.Bucket, s3pc.RemoteFile)
+		}
 	}
 
 	errChan := make(chan error)
@@ -421,4 +426,13 @@ func (s3pc *s3put) createPailBucket(httpClient *http.Client) error {
 	bucket, err := pail.NewS3MultiPartBucketWithHTTPClient(httpClient, opts)
 	s3pc.bucket = bucket
 	return err
+}
+
+func (s3pc *s3put) isPrivate(visibility string) bool {
+
+	if visibility == artifact.Signed || visibility == artifact.Private || visibility == artifact.None {
+		return true
+	}
+
+	return false
 }

--- a/command/s3_put.go
+++ b/command/s3_put.go
@@ -237,7 +237,7 @@ func (s3pc *s3put) Execute(ctx context.Context,
 	}
 
 	if s3pc.isPrivate(s3pc.Visibility) {
-		logger.Task().Infof("Putting files in s3")
+		logger.Task().Infof("Putting private file(s) into s3")
 
 	} else {
 		if s3pc.isMulti() {
@@ -279,9 +279,13 @@ func (s3pc *s3put) putWithRetry(ctx context.Context, comm client.Communicator, l
 
 retryLoop:
 	for i := 1; i <= maxS3OpAttempts; i++ {
-		logger.Task().Infof("performing s3 put to %s of %s [%d of %d]",
-			s3pc.Bucket, s3pc.RemoteFile,
-			i, maxS3OpAttempts)
+		if s3pc.isPrivate(s3pc.Visibility) {
+			logger.Task().Infof("performing s3 put of a hidden file")
+		} else {
+			logger.Task().Infof("performing s3 put to %s of %s [%d of %d]",
+				s3pc.Bucket, s3pc.RemoteFile,
+				i, maxS3OpAttempts)
+		}
 
 		select {
 		case <-ctx.Done():
@@ -429,10 +433,8 @@ func (s3pc *s3put) createPailBucket(httpClient *http.Client) error {
 }
 
 func (s3pc *s3put) isPrivate(visibility string) bool {
-
 	if visibility == artifact.Signed || visibility == artifact.Private || visibility == artifact.None {
 		return true
 	}
-
 	return false
 }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -24,7 +24,7 @@ func GetGroupedFiles(ctx context.Context, name string, taskID string, execution 
 	hasUser := gimlet.GetUser(ctx) != nil
 	strippedFiles, err := artifact.StripHiddenFiles(taskFiles, hasUser)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, err.Error())
+		return nil, err
 	}
 
 	apiFileList := []*restModel.APIFile{}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -32,7 +32,7 @@ func GetGroupedFiles(ctx context.Context, name string, taskID string, execution 
 		apiFile := restModel.APIFile{}
 		err := apiFile.BuildFromService(file)
 		if err != nil {
-			return nil, InternalServerError.Send(ctx, err.Error())
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("error stripping hidden files"))
 		}
 		apiFileList = append(apiFileList, &apiFile)
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -13,8 +13,6 @@ import (
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/rest/route"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 )
 
 // GetGroupedFiles returns the files of a Task inside a GroupedFile struct
@@ -23,12 +21,6 @@ func GetGroupedFiles(ctx context.Context, name string, taskID string, execution 
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, err.Error())
 	}
-	grip.Debug(message.Fields{
-		"message":   "Chaya. util.go 27. ",
-		"taskFiles": taskFiles,
-		"user":      gimlet.GetUser(ctx),
-		"stack":     message.NewStack(1, "").Raw(),
-	})
 	hasUser := gimlet.GetUser(ctx) != nil
 	strippedFiles, err := artifact.StripHiddenFiles(taskFiles, hasUser)
 	if err != nil {

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -68,7 +68,7 @@ func StripHiddenFiles(files []File, hasUser bool) ([]File, error) {
 			continue
 		case (file.Visibility == Private || file.Visibility == Signed) && hasUser == false:
 			continue
-		case file.Visibility == Signed && hasUser == true:
+		case file.Visibility == Signed && hasUser:
 			if !file.ContainsSigningParams() {
 				return nil, errors.Errorf("error presigning the url for %s, awsSecret, awsKey, bucket, or filekey missing", file.Name)
 			}

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen/thirdparty"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -62,55 +60,13 @@ type File struct {
 
 // StripHiddenFiles is a helper for only showing users the files they are allowed to see.
 func StripHiddenFiles(files []File, hasUser bool) ([]File, error) {
+	//todo: are private files getting signed?
 	publicFiles := []File{}
-	grip.Debug(message.Fields{
-		"message": "Chaya. artifact_file 67. File: ",
-		"files":   files,
-		"stack":   message.NewStack(1, "").Raw(),
-		"hasuser": hasUser,
-	})
 	for _, file := range files {
-		//check if any files need to be signed.
-		// if file.Visibility == Signed {
-		// 	if !file.ContainsSigningParams() {
-		// 		return nil, errors.Errorf("error presigning the url for %s, awsSecret, awsKey, bucket, or filekey missing", file.Name)
-		// 	}
-		// 	requestParams := thirdparty.RequestParams{
-		// 		Bucket:    file.Bucket,
-		// 		FileKey:   file.FileKey,
-		// 		AwsKey:    file.AwsKey,
-		// 		AwsSecret: file.AwsSecret,
-		// 	}
-		// 	urlStr, err := thirdparty.PreSign(requestParams)
-		// 	if err != nil {
-		// 		return nil, errors.Wrap(err, "problem presigning url")
-		// 	}
-		// 	file.Link = urlStr
-		// }
-
-		grip.Debug(message.Fields{
-			"message": "Chaya. artifact_file 92. File: ",
-			"File":    file,
-			"stack":   message.NewStack(1, "").Raw(),
-			"hasuser": hasUser,
-		})
-
 		switch {
 		case file.Visibility == None:
-			grip.Debug(message.Fields{
-				"message": "Chaya. artifact_file 101. File: case file.Visibility == None",
-				"File":    file,
-				"stack":   message.NewStack(1, "").Raw(),
-				"hasuser": hasUser,
-			})
 			continue
 		case (file.Visibility == Private || file.Visibility == Signed) && hasUser == false:
-			grip.Debug(message.Fields{
-				"message": "Chaya. artifact_file 109. File: case file.Visibility == case (file.Visibility == Private || file.Visibility == Signed) && hasUser == false:",
-				"File":    file,
-				"stack":   message.NewStack(1, "").Raw(),
-				"hasuser": hasUser,
-			})
 			continue
 		case file.Visibility == Signed && hasUser == true:
 			if !file.ContainsSigningParams() {
@@ -127,24 +83,11 @@ func StripHiddenFiles(files []File, hasUser bool) ([]File, error) {
 				return nil, errors.Wrap(err, "problem presigning url")
 			}
 			file.Link = urlStr
+			publicFiles = append(publicFiles, file)
 		default:
 			publicFiles = append(publicFiles, file)
-			grip.Debug(message.Fields{
-				"message":     "default",
-				"File":        file,
-				"stack":       message.NewStack(1, "").Raw(),
-				"hasuser":     hasUser,
-				"publicFiles": publicFiles,
-			})
-
 		}
 	}
-	// grip.Debug(message.Fields{
-	// 	"message":     "Chaya. artifact_file 128. Returning public files",
-	// 	"stack":       message.NewStack(1, "").Raw(),
-	// 	"hasuser":     hasUser,
-	// 	"publicFiles": publicFiles,
-	// })
 	return publicFiles, nil
 }
 

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -203,16 +203,3 @@ func (s *TestArtifactFileSuite) TestFindByIds() {
 	s.NoError(err)
 	s.Len(entries, 3)
 }
-
-func (s *TestArtifactFileSuite) TestGetAllArtifacts() {
-	tasks := []TaskIDAndExecution{
-		{TaskID: "task1", Execution: 1},
-		{TaskID: "task2", Execution: 5},
-	}
-	files, _ := GetAllArtifacts(tasks)
-	for i := range files {
-		if files[i].Visibility == "signed" {
-			s.Contains(files[i].Link, "Signature")
-		}
-	}
-}

--- a/plugin/attach_plugin.go
+++ b/plugin/attach_plugin.go
@@ -73,7 +73,8 @@ func (self *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 								return nil, err
 							}
 							hasUser := context.User.(*user.DBUser) != nil
-							strippedFiles, err := artifact.StripHiddenFiles(execTaskFiles, hasUser)
+							var strippedFiles []artifact.File
+							strippedFiles, err = artifact.StripHiddenFiles(execTaskFiles, hasUser)
 							if err != nil {
 								return nil, errors.Wrap(err, "error signing urls")
 							}

--- a/plugin/attach_plugin.go
+++ b/plugin/attach_plugin.go
@@ -75,7 +75,7 @@ func (self *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 							hasUser := context.User.(*user.DBUser) != nil
 							strippedFiles, err := artifact.StripHiddenFiles(execTaskFiles, hasUser)
 							if err != nil {
-								return nil, errors.Wrap(err, "error signign urls")
+								return nil, errors.Wrap(err, "error signing urls")
 							}
 							var execTask *task.Task
 							execTask, err = task.FindOne(task.ById(execTaskID))

--- a/plugin/attach_plugin.go
+++ b/plugin/attach_plugin.go
@@ -6,8 +6,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -75,24 +73,7 @@ func (self *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 								return nil, err
 							}
 							hasUser := context.User.(*user.DBUser) != nil
-
-							grip.Debug(message.Fields{
-								"message":       "Chaya. attache_plugin  77",
-								"execTaskFiles": execTaskFiles,
-								"stack":         message.NewStack(1, "").Raw(),
-								"hasuser":       hasUser,
-								"user":          context.User,
-								"user == nil":   context.User == nil,
-							})
 							strippedFiles, err := artifact.StripHiddenFiles(execTaskFiles, hasUser)
-							grip.Debug(message.Fields{
-								"message":       "Chaya. attach_plugin 87 after calling stripHidden",
-								"execTaskFiles": execTaskFiles,
-								"stack":         message.NewStack(1, "").Raw(),
-								"hasUser":       hasUser,
-								"user":          context.User,
-								"user == nil":   context.User == nil,
-							})
 							if err != nil {
 								return nil, errors.Wrap(err, "error signign urls")
 							}
@@ -121,40 +102,7 @@ func (self *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 					}
 					hasUser := context.User.(*user.DBUser) != nil
 
-					// var currentUser gimlet.User = context.User
-					if context.User.DisplayName != nil {
-						grip.Debug(message.Fields{
-							"err":     err,
-							"message": "Chaya. attach_plugin  123",
-							"files":   files,
-							"stack":   message.NewStack(1, "").Raw(),
-							"hasUser": hasUser,
-							"user":    context.User,
-						})
-					} else {
-
-						grip.Debug(message.Fields{
-							"err":         err,
-							"message":     "Chaya. attach_plugin  139. username is nil",
-							"files":       files,
-							"stack":       message.NewStack(1, "").Raw(),
-							"hasUser":     hasUser,
-							"user":        context.User,
-							"user == nil": context.User == nil,
-						})
-					}
-
 					strippedFiles, err := artifact.StripHiddenFiles(files, hasUser)
-
-					grip.Debug(message.Fields{
-						"err":         err,
-						"message":     "Chaya. attach_plugin  145, after Striphiddenfiles",
-						"files":       files,
-						"stack":       message.NewStack(1, "").Raw(),
-						"hasUser":     hasUser,
-						"user":        context.User,
-						"user == nil": context.User.(*user.DBUser) == nil,
-					})
 					if err != nil {
 						return nil, errors.Wrap(err, "error signing urls")
 					}
@@ -177,25 +125,7 @@ func (self *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 					for i := range taskArtifactFiles {
 						// remove hidden files if the user isn't logged in
 						hasUser := context.User.(*user.DBUser) != nil
-						grip.Debug(message.Fields{
-							"err":         err,
-							"message":     "Chaya. attach_plugin  158, before  Striphiddenfiles",
-							"files":       taskArtifactFiles,
-							"stack":       message.NewStack(1, "").Raw(),
-							"hasUser":     hasUser,
-							"user":        context.User,
-							"user == nil": context.User == nil,
-						})
 						taskArtifactFiles[i].Files, err = artifact.StripHiddenFiles(taskArtifactFiles[i].Files, hasUser)
-						grip.Debug(message.Fields{
-							"err":         err,
-							"message":     "Chaya. attach_plugin  167, after Striphiddenfiles",
-							"files":       taskArtifactFiles,
-							"stack":       message.NewStack(1, "").Raw(),
-							"hasUser":     hasUser,
-							"user":        context.User,
-							"user == nil": context.User == nil,
-						})
 						if err != nil {
 							return nil, errors.Wrap(err, "error singing urls")
 						}

--- a/plugin/attach_plugin_test.go
+++ b/plugin/attach_plugin_test.go
@@ -24,7 +24,7 @@ func (s *TestFileVisibilitySuite) SetupTest() {
 		{Name: "Public", Visibility: artifact.Public},
 		{Name: "Hidden", Visibility: artifact.None},
 		{Name: "Unset", Visibility: ""},
-		{Name: "Signed", Visibility: artifact.Signed},
+		{Name: "Signed", Visibility: artifact.Signed, AwsKey: "key", AwsSecret: "secret", Bucket: "bucket", FileKey: "filekey"},
 	}
 }
 

--- a/plugin/attach_plugin_test.go
+++ b/plugin/attach_plugin_test.go
@@ -29,7 +29,8 @@ func (s *TestFileVisibilitySuite) SetupTest() {
 }
 
 func (s *TestFileVisibilitySuite) TestFileVisibilityWithoutUser() {
-	stripped := artifact.StripHiddenFiles(s.files, false)
+	stripped, err := artifact.StripHiddenFiles(s.files, false)
+	s.Require().NoError(err)
 	s.Len(s.files, 5)
 
 	s.Equal("Public", stripped[0].Name)
@@ -39,7 +40,8 @@ func (s *TestFileVisibilitySuite) TestFileVisibilityWithoutUser() {
 
 func (s *TestFileVisibilitySuite) TestFileVisibilityWithUser() {
 	hasUser := &user.DBUser{} != nil
-	stripped := artifact.StripHiddenFiles(s.files, hasUser)
+	stripped, err := artifact.StripHiddenFiles(s.files, hasUser)
+	s.Require().NoError(err)
 	s.Len(s.files, 5)
 
 	s.Equal("Private", stripped[0].Name)


### PR DESCRIPTION
This PR mainly takes care of moving the url signing code so that it loads n the build page as well, and not only on the task page. [EVG-7474](https://jira.mongodb.org/browse/EVG-7474)
It also fixes the visibility (for signed and private)[EVG-7136](https://jira.mongodb.org/browse/EVG-7136) and suppresses some logging for private files. 