### PR TITLE
EVG-7439: use absolute paths where possible

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -391,7 +391,7 @@ func (d *Distro) ExecutableSubPath() string {
 }
 
 // HomeDir gets the absolute path to the home directory for this distro's user.
-// This is compatible with Cygwin (see (*host.Host).AbsPathCygwinCompatible for
+// This is compatible with Cygwin (see (*Distro).AbsPathCygwinCompatible for
 // details).
 func (d *Distro) HomeDir() string {
 	if d.User == "root" {
@@ -751,24 +751,23 @@ func (d *Distro) JasperCommunication() bool {
 	return d.BootstrapSettings.Communication == CommunicationMethodSSH || d.BootstrapSettings.Communication == CommunicationMethodRPC
 }
 
-// AbsPathCygwinCompatible creates an absolute path from the given path. It is a
-// hack to create a filepath that is compatible with the host's provisioning
-// settings.
+// AbsPathCygwinCompatible creates an absolute path from the given path that is
+// compatible with the host's provisioning settings.
 //
 // For example, in the context of an SSH session with Cygwin, if you invoke the
-// "/usr/bin/echo" binary, Cygwin finds the binary in "$ROOT_DIR/usr/bin/echo".
-// Similarly, Cygwin binaries like "ls" will resolve filepaths as paths relative
-// to the Cygwin root directory, so "ls /usr/bin", will correctly list the
-// directory contents of "$ROOT_DIR/usr/bin".
+// "/usr/bin/echo" binary, Cygwin uses the binary located relative to Cygwin's
+// filesystem root directory, so it will use the binary at
+// "$ROOT_DIR/usr/bin/echo". Similarly, Cygwin binaries like "ls" will resolve
+// filepaths as paths relative to the Cygwin root directory, so "ls /usr/bin",
+// will correctly list the directory contents of "$ROOT_DIR/usr/bin".
 //
-// However, in almost all other cases, we must use native Windows paths for
-// everything. For example, if the evergreen binary tries to open a file given
-// in the command line flags, the Golang standard library uses native paths, so
-// giving a path like "/home/Administrator/my_file" will fail because the
-// library has no awareness of the Cygwin filesystem context. The correct
-// specification of the path would be to give an absolute native path,
-// "$ROOT_DIR/home/Administrator/evergreen". In these cases, use
-// (*Distro).AbsPathNotCygwinCompatible.
+// However, in almost all other cases, Windows binaries expect native Windows
+// paths for everything. For example, if the evergreen binary accepts a filepath
+// given in the command line flags, the Golang standard library uses native
+// paths. Therefore, giving a path like "/home/Administrator/my_file" will fail,
+// because the library has no awareness of the Cygwin filesystem context. The
+// correct path would be to give an absolute native path,
+// "$ROOT_DIR/home/Administrator/evergreen".
 //
 // Documentation for Cygwin paths:
 // https://www.cygwin.com/cygwin-ug-net/using-effectively.html
@@ -779,10 +778,10 @@ func (d *Distro) AbsPathCygwinCompatible(path ...string) string {
 	return d.AbsPathNotCygwinCompatible(path...)
 }
 
-// AbsPathNotCygwinCompatible is a hack that requires RootDir (the path to the
-// Cygwin root directory) to get around the fact that Cygwin binaries use Unix
-// paths relative to the Cygwin filesystem root directory, but most other paths
-// require absolute filepaths using native Windows absolute paths. See
+// AbsPathNotCygwinCompatible creates a Cygwin-incompatible absolute path using
+// RootDir to get around the fact that Cygwin binaries use POSIX paths relative
+// to the Cygwin filesystem root directory, but most other paths require
+// absolute filepaths using native Windows absolute paths. See
 // (*Distro).AbsPathCygwinCompatible for more details.
 func (d *Distro) AbsPathNotCygwinCompatible(path ...string) string {
 	return filepath.Join(append([]string{d.BootstrapSettings.RootDir}, path...)...)

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -243,7 +243,7 @@ func TestJasperCommands(t *testing.T) {
 			setupSpawnHost, err := h.SpawnHostSetupCommands(settings)
 			require.NoError(t, err)
 
-			bashSetupSpawnHost := []string{h.PathByProvisioning(h.Distro.BootstrapSettings.ShellPath), "-l", "-c", strings.Join(h.SpawnHostGetTaskDataCommand(), " ")}
+			bashSetupSpawnHost := []string{h.Distro.ShellBinary(), "-l", "-c", strings.Join(h.SpawnHostGetTaskDataCommand(), " ")}
 			getTaskData, err := h.buildLocalJasperClientRequest(settings.HostJasper,
 				strings.Join([]string{jcli.ManagerCommand, jcli.CreateCommand}, " "),
 				&options.Command{Commands: [][]string{bashSetupSpawnHost}})

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -41,11 +41,11 @@ func TestCurlCommand(t *testing.T) {
 		Ui:                evergreen.UIConfig{Url: "www.example.com"},
 		ClientBinariesDir: "clients",
 	}
-	expected := "cd ~ && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' && chmod +x evergreen.exe"
+	expected := "cd /home/user && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' && chmod +x evergreen.exe"
 	assert.Equal(expected, h.CurlCommand(settings))
 
 	h = &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64, User: "user"}}
-	expected = "cd ~ && curl -LO 'www.example.com/clients/linux_amd64/evergreen' && chmod +x evergreen"
+	expected = "cd /home/user && curl -LO 'www.example.com/clients/linux_amd64/evergreen' && chmod +x evergreen"
 	assert.Equal(expected, h.CurlCommand(settings))
 }
 
@@ -55,11 +55,11 @@ func TestCurlCommandWithRetry(t *testing.T) {
 		Ui:                evergreen.UIConfig{Url: "www.example.com"},
 		ClientBinariesDir: "clients",
 	}
-	expected := "cd ~ && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10 && chmod +x evergreen.exe"
+	expected := "cd /home/user && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10 && chmod +x evergreen.exe"
 	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, 5, 10))
 
 	h = &Host{Distro: distro.Distro{Arch: distro.ArchLinuxAmd64, User: "user"}}
-	expected = "cd ~ && curl -LO 'www.example.com/clients/linux_amd64/evergreen' --retry 5 --retry-max-time 10 && chmod +x evergreen"
+	expected = "cd /home/user && curl -LO 'www.example.com/clients/linux_amd64/evergreen' --retry 5 --retry-max-time 10 && chmod +x evergreen"
 	assert.Equal(t, expected, h.CurlCommandWithRetry(settings, 5, 10))
 }
 

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -1114,8 +1114,8 @@ func buildRsyncCommand(opts rsyncOpts) (*jasper.Command, error) {
 	if opts.makeRemoteParentDirs {
 		var parentDir string
 		if runtime.GOOS == "windows" {
-			// If we're using cygwin rsync, we have to use the Unix path and not
-			// the native one.
+			// If we're using cygwin rsync, we have to use the POSIX path and
+			// not the native one.
 			baseIndex := strings.LastIndex(opts.remote, "/")
 			if baseIndex == -1 {
 				parentDir = opts.remote

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -1147,7 +1147,7 @@ func (hs *hostStartProcesses) Run(ctx context.Context) gimlet.Responder {
 			continue
 		}
 
-		bashPath := h.PathByProvisioning(h.Distro.BootstrapSettings.ShellPath)
+		bashPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.ShellPath)
 		opts := &options.Create{
 			Args:   []string{bashPath, "-l", "-c", hs.script},
 			Output: options.Output{Loggers: []options.Logger{jasper.NewInMemoryLogger(host.OutputBufferSize)}},

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -699,6 +699,11 @@ Evergreen - Distros
           </div>
           <div class="icon fa fa-warning distro-error" ng-show="!validBootstrapAndCommunication()"> Legacy and non-legacy bootstrapping and communication are incompatible</div>
           <br />
+
+          <label class="distro-label">Root Directory:</label>
+          <input type="text" ng-required="isWindows()" name="rootDir" class="form-control" ng-model="activeDistro.bootstrap_settings.root_dir"
+            placeholder="Native path to root directory" ng-readonly="readOnly">
+          <div class="icon fa fa-warning distro-error" ng-show="form.rootDir.$invalid"> Root directory is required</div><br />
           <div ng-show="isNonLegacyProvisioning()">
             <label class="distro-label">Jasper Binary Directory:</label>
             <input type="text" ng-required="isNonLegacyProvisioning()" ng-readonly="readOnly" name="jasperBinaryDir"
@@ -711,7 +716,7 @@ Evergreen - Distros
             <div class="icon fa fa-warning distro-error" ng-show="form.jasperCredentialsPath.$invalid"> Jasper credentials path is required</div><br />
 
             <label class="distro-label">Client Directory:</label>
-            <input type="text" ng-required="isNonLegacyProvisioning(0)" ng-readonly="readOnly" name="clientDir"
+            <input type="text" ng-required="isNonLegacyProvisioning()" ng-readonly="readOnly" name="clientDir"
               class="form-control" ng-model="activeDistro.bootstrap_settings.client_dir" placeholder="Absolute native path to the directory of the evergreen binary">
             <div class="icon fa fa-warning distro-error" ng-show="form.clientDir.$invalid"> Client directory is required</div><br />
 
@@ -727,11 +732,6 @@ Evergreen - Distros
                 ng-readonly="readOnly" name="serviceUser"
                 class="form-control" ng-model="activeDistro.bootstrap_settings.service_user" placeholder="Username for setting up Evergreen services">
               <div class="icon fa fa-warning distro-error" ng-show="form.serviceUser.$invalid"> Service user is required</div><br />
-
-              <label class="distro-label">Root Directory:</label>
-              <input type="text" ng-required="isWindows() && isNonLegacyProvisioning()" name="rootDir" class="form-control" ng-model="activeDistro.bootstrap_settings.root_dir"
-                placeholder="Native path to root directory" ng-readonly="readOnly">
-              <div class="icon fa fa-warning distro-error" ng-show="form.rootDir.$invalid"> Root directory is required</div><br />
             </div>
 			<div ng-form name="env">
 			  <label id="env-table" class="distro-label">Environment Variables:</label>

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -309,11 +308,8 @@ func (j *agentDeployJob) prepRemoteHost(ctx context.Context, sshOptions []string
 
 // Start the agent process on the specified remote host.
 func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *evergreen.Settings, sshOptions []string) error {
-	// the path to the agent binary on the remote machine
-	binary := filepath.Join(j.host.Distro.HomeDir(), j.host.Distro.BinaryName())
-
 	// build the command to run on the remote machine
-	remoteCmd := strings.Join(j.host.AgentCommand(binary, settings), " ")
+	remoteCmd := strings.Join(j.host.AgentCommand(settings), " ")
 	grip.Info(message.Fields{
 		"message": "starting agent on host",
 		"host_id": j.host.Id,

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -768,8 +768,10 @@ func (j *setupHostJob) fetchRemoteTaskData(ctx context.Context, settings *evergr
 		output, err = j.host.RunSSHCommandWithTimeout(ctx, cmd, sshOpts, 15*time.Minute)
 	} else {
 		var logs []string
+		// We have to run this in the Cygwin shell in order for git clone to
+		// use the correct SSH key.
 		logs, err = j.host.RunJasperProcess(ctx, j.env, &options.Create{
-			Args: []string{j.host.PathByProvisioning(j.host.Distro.BootstrapSettings.ShellPath), "-l", "-c", cmd},
+			Args: []string{j.host.Distro.ShellBinary(), "-l", "-c", cmd},
 		})
 		output = strings.Join(logs, " ")
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7439

This changes no functionality, but tries to use native paths instead of Cygwin POSIX paths (which are deceptive and dangerous) wherever possible in host provisioning. There's some cases where this is impossible, for which I wrote comments explaining the reason I hacked around them to make it as obvious as possible why they have to be done that way.