### PR TITLE
EVG-7304 group display task BFGs together

### DIFF
--- a/trigger/task.go
+++ b/trigger/task.go
@@ -737,13 +737,12 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 
 	testsToAlert := []task.TestResult{}
 	hasFailingTest := false
-	var match bool
 	for _, test := range testResults {
 		if test.Status != evergreen.TestFailedStatus {
 			continue
 		}
 		hasFailingTest = true
-		match, err = testMatchesRegex(test.TestFile, sub)
+		match, err := testMatchesRegex(test.TestFile, sub)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"source":  "test-trigger",

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -702,8 +702,8 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 	catcher := grip.NewBasicCatcher()
 	currentTask := t.task
 	var previousCompleteTask *task.Task
-	var err error
 	if t.task.IsPartOfDisplay() {
+		var err error
 		currentTask, err = t.task.GetDisplayTask()
 		if err != nil {
 			return nil, errors.Wrapf(err, "can't get display task for '%s'", t.task)
@@ -872,13 +872,13 @@ func JIRATaskPayload(subID, project, uiUrl, eventID, testNames string, t *task.T
 func mapTestResultsByTestFile(results []task.TestResult) map[string]*task.TestResult {
 	m := map[string]*task.TestResult{}
 
-	for _, result := range results {
+	for i, result := range results {
 		if testResult, ok := m[result.TestFile]; ok {
 			if !isTestStatusRegression(testResult.Status, result.Status) {
 				continue
 			}
 		}
-		m[result.TestFile] = &result
+		m[result.TestFile] = &results[i]
 	}
 
 	return m

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -1204,9 +1204,8 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 			ExecutionTasks:      []string{"et0_0", "et1_0"},
 			RevisionOrderNumber: 1,
 			BuildVariant:        "bv0",
-			Status:              evergreen.TaskFailed,
-			BuildId:             "b0",
 			Project:             "p0",
+			Status:              evergreen.TaskFailed,
 			Requester:           evergreen.RepotrackerVersionRequester,
 			FinishTime:          time.Now(),
 		},
@@ -1214,6 +1213,8 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 			Id:                  "et0_0",
 			DisplayName:         "et0",
 			RevisionOrderNumber: 1,
+			BuildId:             "b0",
+			Project:             "p0",
 			Status:              evergreen.TaskFailed,
 			Requester:           evergreen.RepotrackerVersionRequester,
 			LocalTestResults:    []task.TestResult{{TestFile: "f0", Status: evergreen.TestFailedStatus}},
@@ -1222,6 +1223,8 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 			Id:                  "et1_0",
 			DisplayName:         "et1",
 			RevisionOrderNumber: 1,
+			BuildId:             "b0",
+			Project:             "p0",
 			Status:              evergreen.TaskSucceeded,
 			Requester:           evergreen.RepotrackerVersionRequester,
 		},
@@ -1231,15 +1234,16 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 			ExecutionTasks:      []string{"et0_1", "et1_1"},
 			RevisionOrderNumber: 2,
 			BuildVariant:        "bv0",
-			Status:              evergreen.TaskFailed,
-			BuildId:             "b0",
 			Project:             "p0",
+			Status:              evergreen.TaskFailed,
 			Requester:           evergreen.RepotrackerVersionRequester,
 		},
 		{
 			Id:                  "et0_1",
 			DisplayName:         "et0",
 			RevisionOrderNumber: 2,
+			BuildId:             "b0",
+			Project:             "p0",
 			Status:              evergreen.TaskFailed,
 			Requester:           evergreen.RepotrackerVersionRequester,
 			LocalTestResults:    []task.TestResult{{TestFile: "f1", Status: evergreen.TestFailedStatus}},
@@ -1248,6 +1252,8 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 			Id:                  "et1_1",
 			DisplayName:         "et1",
 			RevisionOrderNumber: 2,
+			BuildId:             "b0",
+			Project:             "p0",
 			Status:              evergreen.TaskFailed,
 			Requester:           evergreen.RepotrackerVersionRequester,
 			LocalTestResults:    []task.TestResult{{TestFile: "f0", Status: evergreen.TestFailedStatus}},
@@ -1274,6 +1280,7 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 	notification, err := tr.taskRegressionByTest(&event.Subscription{ID: "s1", Subscriber: event.Subscriber{Type: event.JIRACommentSubscriberType}, Trigger: "t1"})
 	assert.NoError(t, err)
 	assert.NotNil(t, notification)
+	assert.Equal(t, "et0_0", notification.Metadata.TaskID)
 
 	// trigger for the second run of the display task for a different execution task that contains the same test
 	tr.task = &tasks[5]
@@ -1286,4 +1293,5 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 	notification, err = tr.taskRegressionByTest(&event.Subscription{ID: "s1", Subscriber: event.Subscriber{Type: event.JIRACommentSubscriberType}, Trigger: "t1"})
 	assert.NoError(t, err)
 	assert.NotNil(t, notification)
+	assert.Equal(t, "et0_1", notification.Metadata.TaskID)
 }

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -1053,7 +1053,7 @@ func TestMergeTestResultsByTestFile(t *testing.T) {
 		)
 	}
 
-	m := mergeTestResultsByTestFile(nil, taskDoc.LocalTestResults)
+	m := mapTestResultsByTestFile(taskDoc.LocalTestResults)
 	assert.Len(m, 4)
 
 	for _, v := range m {

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -1026,10 +1026,10 @@ func TestIsTestRegression(t *testing.T) {
 	assert.False(isTestStatusRegression(evergreen.TestSilentlyFailedStatus, evergreen.TestSucceededStatus))
 }
 
-func TestMergeTestResultsByTestFile(t *testing.T) {
+func TestMapTestResultsByTestFile(t *testing.T) {
 	assert := assert.New(t)
 
-	taskDoc := task.Task{}
+	results := []task.TestResult{}
 
 	statuses := []string{evergreen.TestSucceededStatus, evergreen.TestFailedStatus,
 		evergreen.TestSilentlyFailedStatus, evergreen.TestSkippedStatus}
@@ -1041,7 +1041,7 @@ func TestMergeTestResultsByTestFile(t *testing.T) {
 			first = statuses[i]
 			second = evergreen.TestFailedStatus
 		}
-		taskDoc.LocalTestResults = append(taskDoc.LocalTestResults,
+		results = append(results,
 			task.TestResult{
 				TestFile: fmt.Sprintf("file%d", i),
 				Status:   first,
@@ -1053,7 +1053,7 @@ func TestMergeTestResultsByTestFile(t *testing.T) {
 		)
 	}
 
-	m := mapTestResultsByTestFile(taskDoc.LocalTestResults)
+	m := mapTestResultsByTestFile(results)
 	assert.Len(m, 4)
 
 	for _, v := range m {
@@ -1208,6 +1208,7 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 			Status:              evergreen.TaskFailed,
 			Requester:           evergreen.RepotrackerVersionRequester,
 			FinishTime:          time.Now(),
+			DisplayOnly:         true,
 		},
 		{
 			Id:                  "et0_0",
@@ -1237,6 +1238,7 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 			Project:             "p0",
 			Status:              evergreen.TaskFailed,
 			Requester:           evergreen.RepotrackerVersionRequester,
+			DisplayOnly:         true,
 		},
 		{
 			Id:                  "et0_1",

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 	mgobson "gopkg.in/mgo.v2/bson"
@@ -1025,7 +1026,7 @@ func TestIsTestRegression(t *testing.T) {
 	assert.False(isTestStatusRegression(evergreen.TestSilentlyFailedStatus, evergreen.TestSucceededStatus))
 }
 
-func TestMapTestResultsByTestFile(t *testing.T) {
+func TestMergeTestResultsByTestFile(t *testing.T) {
 	assert := assert.New(t)
 
 	taskDoc := task.Task{}
@@ -1052,7 +1053,7 @@ func TestMapTestResultsByTestFile(t *testing.T) {
 		)
 	}
 
-	m := mapTestResultsByTestFile(&taskDoc)
+	m := mergeTestResultsByTestFile(nil, taskDoc.LocalTestResults)
 	assert.Len(m, 4)
 
 	for _, v := range m {
@@ -1186,4 +1187,103 @@ func (s *taskSuite) TestBuildBreak() {
 	n, err = s.t.buildBreak(&s.subs[6])
 	s.NoError(err)
 	s.Nil(n)
+}
+
+func TestTaskRegressionByTestDisplayTask(t *testing.T) {
+	require.NoError(t, db.ClearCollections(task.Collection, testresult.Collection, alertrecord.Collection, build.Collection, model.ProjectRefCollection))
+
+	b := build.Build{Id: "b0"}
+	require.NoError(t, b.Insert())
+	projectRef := model.ProjectRef{Identifier: "p0"}
+	require.NoError(t, projectRef.Insert())
+
+	tasks := []task.Task{
+		{
+			Id:                  "dt0_0",
+			DisplayName:         "dt0",
+			ExecutionTasks:      []string{"et0_0", "et1_0"},
+			RevisionOrderNumber: 1,
+			BuildVariant:        "bv0",
+			Status:              evergreen.TaskFailed,
+			BuildId:             "b0",
+			Project:             "p0",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			FinishTime:          time.Now(),
+		},
+		{
+			Id:                  "et0_0",
+			DisplayName:         "et0",
+			RevisionOrderNumber: 1,
+			Status:              evergreen.TaskFailed,
+			Requester:           evergreen.RepotrackerVersionRequester,
+			LocalTestResults:    []task.TestResult{{TestFile: "f0", Status: evergreen.TestFailedStatus}},
+		},
+		{
+			Id:                  "et1_0",
+			DisplayName:         "et1",
+			RevisionOrderNumber: 1,
+			Status:              evergreen.TaskSucceeded,
+			Requester:           evergreen.RepotrackerVersionRequester,
+		},
+		{
+			Id:                  "dt0_1",
+			DisplayName:         "dt0",
+			ExecutionTasks:      []string{"et0_1", "et1_1"},
+			RevisionOrderNumber: 2,
+			BuildVariant:        "bv0",
+			Status:              evergreen.TaskFailed,
+			BuildId:             "b0",
+			Project:             "p0",
+			Requester:           evergreen.RepotrackerVersionRequester,
+		},
+		{
+			Id:                  "et0_1",
+			DisplayName:         "et0",
+			RevisionOrderNumber: 2,
+			Status:              evergreen.TaskFailed,
+			Requester:           evergreen.RepotrackerVersionRequester,
+			LocalTestResults:    []task.TestResult{{TestFile: "f1", Status: evergreen.TestFailedStatus}},
+		},
+		{
+			Id:                  "et1_1",
+			DisplayName:         "et1",
+			RevisionOrderNumber: 2,
+			Status:              evergreen.TaskFailed,
+			Requester:           evergreen.RepotrackerVersionRequester,
+			LocalTestResults:    []task.TestResult{{TestFile: "f0", Status: evergreen.TestFailedStatus}},
+		},
+	}
+	for _, task := range tasks {
+		require.NoError(t, task.Insert())
+	}
+
+	testResults := []testresult.TestResult{
+		{TaskID: "et0_0", TestFile: "f0", Status: evergreen.TestFailedStatus},
+		{TaskID: "et1_0", TestFile: "f1", Status: evergreen.TestSucceededStatus},
+	}
+
+	for _, result := range testResults {
+		require.NoError(t, result.Insert())
+	}
+
+	// trigger for the first run of this display task
+	tr := taskTriggers{
+		task:  &tasks[1],
+		event: &event.EventLogEntry{ID: "e0"},
+	}
+	notification, err := tr.taskRegressionByTest(&event.Subscription{ID: "s1", Subscriber: event.Subscriber{Type: event.JIRACommentSubscriberType}, Trigger: "t1"})
+	assert.NoError(t, err)
+	assert.NotNil(t, notification)
+
+	// trigger for the second run of the display task for a different execution task that contains the same test
+	tr.task = &tasks[5]
+	notification, err = tr.taskRegressionByTest(&event.Subscription{ID: "s1", Subscriber: event.Subscriber{Type: event.JIRACommentSubscriberType}, Trigger: "t1"})
+	assert.NoError(t, err)
+	assert.Nil(t, notification)
+
+	// trigger for the second run of the display task for the same execution task that triggered before, for a different test
+	tr.task = &tasks[4]
+	notification, err = tr.taskRegressionByTest(&event.Subscription{ID: "s1", Subscriber: event.Subscriber{Type: event.JIRACommentSubscriberType}, Trigger: "t1"})
+	assert.NoError(t, err)
+	assert.NotNil(t, notification)
 }


### PR DESCRIPTION
When a server test moves between execution tasks the test failure trigger thinks the test is new and alert for every failure. By grouping all tests in a display task together we look for this test in the entire display task and recognize the test has run before.