### PR TITLE
EVG-7474 Remove taskName For Empty File Lists

### DIFF
--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -60,7 +60,6 @@ type File struct {
 
 // StripHiddenFiles is a helper for only showing users the files they are allowed to see.
 func StripHiddenFiles(files []File, hasUser bool) ([]File, error) {
-	//todo: are private files getting signed?
 	publicFiles := []File{}
 	for _, file := range files {
 		switch {

--- a/plugin/attach_plugin.go
+++ b/plugin/attach_plugin.go
@@ -6,8 +6,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -122,39 +120,17 @@ func (self *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 						return nil, nil
 					}
 					taskArtifactFiles, err := artifact.FindAll(artifact.ByBuildId(context.Build.Id))
-					grip.Debug(message.Fields{
-						"message":           "Chaya. attach_plugin.go 135. taskArtifactFiles for loop. ",
-						"taskArtifactFiles": taskArtifactFiles,
-						"error":             err,
-						"stack":             message.NewStack(1, "").Raw(),
-					})
 					if err != nil {
 						return nil, errors.Wrap(err, "error finding artifact files for build")
 					}
-
 					for i := range taskArtifactFiles {
 						// remove hidden files if the user isn't logged in
 						hasUser := context.User.(*user.DBUser) != nil
 						taskArtifactFiles[i].Files, err = artifact.StripHiddenFiles(taskArtifactFiles[i].Files, hasUser)
-						grip.Debug(message.Fields{
-							"message":              "Chaya. attach_plugin.go 135. taskArtifactFiles for loop. ",
-							"taskArtifactFiles":    taskArtifactFiles,
-							"current task's files": taskArtifactFiles[i].Files,
-							"error":                err,
-							"hasUser":              hasUser,
-							"stack":                message.NewStack(1, "").Raw(),
-						})
 						if err != nil {
 							return nil, errors.Wrap(err, "error singing urls")
 						}
-
 					}
-					grip.Debug(message.Fields{
-						"message":           "Chaya. attach_plugin.go 135. returning taskArtifactFiles. ",
-						"taskArtifactFiles": taskArtifactFiles,
-						"hasUser":           context.User.(*user.DBUser) != nil,
-						"stack":             message.NewStack(1, "").Raw(),
-					})
 					return taskArtifactFiles, nil
 				},
 			},

--- a/plugin/attach_plugin.go
+++ b/plugin/attach_plugin.go
@@ -6,6 +6,8 @@ import (
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -120,17 +122,39 @@ func (self *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 						return nil, nil
 					}
 					taskArtifactFiles, err := artifact.FindAll(artifact.ByBuildId(context.Build.Id))
+					grip.Debug(message.Fields{
+						"message":           "Chaya. attach_plugin.go 135. taskArtifactFiles for loop. ",
+						"taskArtifactFiles": taskArtifactFiles,
+						"error":             err,
+						"stack":             message.NewStack(1, "").Raw(),
+					})
 					if err != nil {
 						return nil, errors.Wrap(err, "error finding artifact files for build")
 					}
+
 					for i := range taskArtifactFiles {
 						// remove hidden files if the user isn't logged in
 						hasUser := context.User.(*user.DBUser) != nil
 						taskArtifactFiles[i].Files, err = artifact.StripHiddenFiles(taskArtifactFiles[i].Files, hasUser)
+						grip.Debug(message.Fields{
+							"message":              "Chaya. attach_plugin.go 135. taskArtifactFiles for loop. ",
+							"taskArtifactFiles":    taskArtifactFiles,
+							"current task's files": taskArtifactFiles[i].Files,
+							"error":                err,
+							"hasUser":              hasUser,
+							"stack":                message.NewStack(1, "").Raw(),
+						})
 						if err != nil {
 							return nil, errors.Wrap(err, "error singing urls")
 						}
+
 					}
+					grip.Debug(message.Fields{
+						"message":           "Chaya. attach_plugin.go 135. returning taskArtifactFiles. ",
+						"taskArtifactFiles": taskArtifactFiles,
+						"hasUser":           context.User.(*user.DBUser) != nil,
+						"stack":             message.NewStack(1, "").Raw(),
+					})
 					return taskArtifactFiles, nil
 				},
 			},

--- a/public/static/plugins/attach/partials/build_files_panel.html
+++ b/public/static/plugins/attach/partials/build_files_panel.html
@@ -3,10 +3,12 @@
   <div class="row">
     <div class="col-lg-12">
       <div ng-repeat="task in filesByTask | orderBy:'task_name'" class="build-files-list">
-        <h4>[[task.task_name]]</h4>
-        <ul ng-repeat="file in task.files | orderBy:'name'" class="build-files-sublist">
-          <li><a ng-href="[[file.link]]">[[file.name]]</a></li>
-        </ul>
+        <div ng-show="task.task_name && task.files.length > 0">
+          <h4>[[task.task_name]]</h4>
+          <ul ng-repeat="file in task.files | orderBy:'name'" class="build-files-sublist">
+            <li><a ng-href="[[file.link]]">[[file.name]]</a></li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Remove the task name in the Build Page > Files panel for empty file lists. That information shouldn't really be sent to build_files_panel.html in the first place if it has no files, but that's a longer fix. Let me know if you think it's worth pursuing. 