### PR TITLE
MAKE-1169: store API-only users in the DB

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -4,10 +4,22 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	testutil.Setup()
+}
+
 func TestLoadUserManager(t *testing.T) {
+	require.NoError(t, db.Clear(user.Collection))
+	defer func() {
+		assert.NoError(t, db.Clear(user.Collection))
+	}()
 	ldap := evergreen.LDAPConfig{
 		URL:                "url",
 		Port:               "port",

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -4,22 +4,11 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/evergreen-ci/evergreen/testutil"
+	_ "github.com/evergreen-ci/evergreen/testutil" // Import testutil to force init to run
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func init() {
-	testutil.Setup()
-}
-
 func TestLoadUserManager(t *testing.T) {
-	require.NoError(t, db.Clear(user.Collection))
-	defer func() {
-		assert.NoError(t, db.Clear(user.Collection))
-	}()
 	ldap := evergreen.LDAPConfig{
 		URL:                "url",
 		Port:               "port",

--- a/auth/only_api.go
+++ b/auth/only_api.go
@@ -93,14 +93,14 @@ func NewOnlyAPIUserManager(config *evergreen.OnlyAPIAuthConfig) (gimlet.UserMana
 			return errors.New("cannot clear user token")
 		},
 		GetUserByID: func(id string) (gimlet.User, bool, error) {
-			user, err := findAPIOnlyUser(id, validIDs, validUsers)
+			user, err := findOnlyAPIUser(id, validIDs, validUsers)
 			if err != nil {
 				return nil, false, errors.Errorf("failed to get API-only user")
 			}
 			return user, true, nil
 		},
 		GetOrCreateUser: func(u gimlet.User) (gimlet.User, error) {
-			user, err := findAPIOnlyUser(u.Username(), validIDs, validUsers)
+			user, err := findOnlyAPIUser(u.Username(), validIDs, validUsers)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get API-only user and cannot create new one")
 			}
@@ -114,9 +114,9 @@ func NewOnlyAPIUserManager(config *evergreen.OnlyAPIAuthConfig) (gimlet.UserMana
 	return cached.NewUserManager(cache)
 }
 
-// findAPIOnlyUser finds an API-only user by ID and verifies that it is a valid
+// findOnlyAPIUser finds an API-only user by ID and verifies that it is a valid
 // user against the list of authoritative valid users.
-func findAPIOnlyUser(id string, validIDs []string, validUsers []gimlet.User) (*user.DBUser, error) {
+func findOnlyAPIUser(id string, validIDs []string, validUsers []gimlet.User) (*user.DBUser, error) {
 	if !util.StringSliceContains(validIDs, id) {
 		return nil, errors.Errorf("user '%s' does not match a valid API-only user", validIDs)
 	}

--- a/auth/only_api.go
+++ b/auth/only_api.go
@@ -2,29 +2,119 @@ package auth
 
 import (
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/gimlet/cached"
+	"github.com/evergreen-ci/gimlet/usercache"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/pkg/errors"
 )
 
 // NewOnlyAPIUserManager creates a user manager for special users that can only
-// make API requests. Users are pre-populated from the given config.
+// make API requests. Users cannot be created and must come from the database.
 func NewOnlyAPIUserManager(config *evergreen.OnlyAPIAuthConfig) (gimlet.UserManager, error) {
-	env := evergreen.GetEnvironment()
-	var rm gimlet.RoleManager
-	if env != nil {
-		rm = env.RoleManager()
-	}
+	users := make([]gimlet.User, 0, len(config.Users))
+	ids := make([]string, 0, len(config.Users))
 
-	users := make([]gimlet.BasicUser, 0, len(config.Users))
 	catcher := grip.NewBasicCatcher()
 	for _, u := range config.Users {
-		opts, err := gimlet.NewBasicUserOptions(u.Username)
+		// Synchronize API-only users with those in the database.
+		checkUser, err := user.FindOneById(u.Username)
 		if err != nil {
-			catcher.Wrap(err, "invalid API-only user in config")
+			catcher.Wrapf(err, "could not check whether user '%s' exists in the DB already", u.Username)
 			continue
 		}
-		users = append(users, *gimlet.NewBasicUser(opts.Key(u.Key).RoleManager(rm)))
+		if checkUser != nil && !checkUser.OnlyAPI {
+			catcher.Errorf("cannot use API-only user '%s' who is not marked as API-only", u.Username)
+			continue
+		}
+		_, err = db.Upsert(user.Collection,
+			bson.M{user.IdKey: u.Username, user.OnlyAPIKey: true},
+			bson.M{
+				"$set": bson.M{
+					user.APIKeyKey: u.Key,
+					user.RolesKey:  u.Roles,
+				},
+				"$setOnInsert": bson.M{
+					user.IdKey:      u.Username,
+					user.OnlyAPIKey: true,
+				},
+			},
+		)
+		if err != nil {
+			catcher.Wrapf(err, "could not upsert API-only user '%s'", u.Username)
+			continue
+		}
+
+		dbUser := &user.DBUser{
+			Id:          u.Username,
+			APIKey:      u.Key,
+			SystemRoles: u.Roles,
+			OnlyAPI:     true,
+		}
+
+		users = append(users, dbUser)
+		ids = append(ids, u.Username)
 	}
 
-	return gimlet.NewBasicUserManager(users, rm)
+	// Remove API-only users that are no longer in the API-only config.
+	if err := db.RemoveAll(user.Collection, bson.M{user.IdKey: bson.M{"$nin": ids}, user.OnlyAPIKey: true}); err != nil {
+		catcher.Wrap(err, "failed to remove nonexistent API-only users from database")
+	}
+
+	if catcher.HasErrors() {
+		grip.Critical(message.WrapError(catcher.Resolve(), message.Fields{
+			"message": "failed to create API-only manager",
+			"reason":  "problems updating API-only users in database",
+		}))
+		return nil, errors.Wrap(catcher.Resolve(), "could not initialize API-only user manager")
+	}
+
+	opts := usercache.ExternalOptions{
+		PutUserGetToken: func(gimlet.User) (string, error) {
+			return "", errors.New("cannot put new users in DB")
+		},
+		GetUserByToken: func(string) (gimlet.User, bool, error) {
+			return nil, false, errors.New("cannot get user by login token")
+		},
+		ClearUserToken: func(gimlet.User, bool) error {
+			return errors.New("cannot clear user token")
+		},
+		GetUserByID: func(id string) (gimlet.User, bool, error) {
+			dbUser, err := user.FindOneById(id)
+			if err != nil {
+				return nil, false, errors.Wrapf(err, "could not find user '%s' in DB", id)
+			}
+			for _, user := range users {
+				if user.Username() == dbUser.Username() && user.GetAPIKey() == dbUser.GetAPIKey() {
+					return dbUser, true, nil
+				}
+			}
+			return nil, false, errors.Errorf("user '%s' found in DB but does not match a pre-populated API-only user", id)
+		},
+		GetOrCreateUser: func(u gimlet.User) (gimlet.User, error) {
+			dbUser, err := user.FindOneById(u.Username())
+			if err != nil {
+				return nil, errors.Wrapf(err, "could not find user '%s' in DB", u.Username())
+			}
+			if dbUser == nil {
+				return nil, errors.Errorf("no such user '%s' in db", u.Username())
+			}
+			for _, user := range users {
+				if user.Username() == dbUser.Username() && user.GetAPIKey() == dbUser.GetAPIKey() {
+					return dbUser, nil
+				}
+			}
+			return nil, errors.New("cannot create user that does not already exist")
+		},
+	}
+	cache, err := usercache.NewExternal(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create DB cache")
+	}
+	return cached.NewUserManager(cache)
 }

--- a/auth/only_api_test.go
+++ b/auth/only_api_test.go
@@ -1,14 +1,17 @@
 package auth
 
 import (
+	"context"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestOnlyAPIAuthManager(t *testing.T) {
+func TestOnlyAPIUserManager(t *testing.T) {
 	config := evergreen.AuthConfig{
 		OnlyAPI: &evergreen.OnlyAPIAuthConfig{},
 	}
@@ -18,4 +21,383 @@ func TestOnlyAPIAuthManager(t *testing.T) {
 	assert.False(t, info.CanReauthorize)
 	assert.Nil(t, manager.GetLoginHandler(""))
 	assert.Nil(t, manager.GetLoginCallbackHandler())
+	assert.False(t, manager.IsRedirect())
+
+	checkUser := func(t *testing.T, u evergreen.OnlyAPIUser) {
+		dbUser, err := user.FindOneById(u.Username)
+		require.NoError(t, err)
+		require.NotNil(t, dbUser)
+		assert.Equal(t, u.Key, dbUser.GetAPIKey())
+		assert.Equal(t, u.Key, dbUser.GetAPIKey())
+		assert.True(t, dbUser.OnlyAPI)
+		assert.Subset(t, u.Roles, dbUser.Roles())
+		assert.Subset(t, dbUser.Roles(), u.Roles)
+	}
+
+	for testName, testCase := range map[string]func(t *testing.T){
+		"InsertsNewUsers": func(t *testing.T) {
+			u1 := evergreen.OnlyAPIUser{
+				Username: "api_user1",
+				Key:      "api_key1",
+				Roles:    []string{"role1"},
+			}
+			u2 := evergreen.OnlyAPIUser{
+				Username: "api_user2",
+				Key:      "api_key2",
+				Roles:    []string{"role2"},
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u1, u2},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			assert.NotNil(t, um)
+
+			checkUser(t, u1)
+			checkUser(t, u2)
+		},
+		"UpdatesExistingUsers": func(t *testing.T) {
+			apiUser := &user.DBUser{
+				Id:      "api_user",
+				APIKey:  "api_key",
+				OnlyAPI: true,
+			}
+			require.NoError(t, apiUser.Insert())
+			u := evergreen.OnlyAPIUser{
+				Username: apiUser.Id,
+				Key:      "new_" + apiUser.APIKey,
+				Roles:    []string{"role"},
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			assert.NotNil(t, um)
+
+			checkUser(t, u)
+		},
+		"UpdateExistingNotOnlyAPIUserFails": func(t *testing.T) {
+			regUser := &user.DBUser{
+				Id:     "reg_user",
+				APIKey: "key",
+			}
+			require.NoError(t, regUser.Insert())
+			u1 := evergreen.OnlyAPIUser{
+				Username: "reg_user",
+				Key:      "new_key",
+				Roles:    []string{"role"},
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u1},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			assert.Error(t, err)
+			assert.Nil(t, um)
+		},
+		"DeletesOldOnlyAPIUsers": func(t *testing.T) {
+			regUser := &user.DBUser{
+				Id:     "reg_user",
+				APIKey: "reg_key",
+			}
+			require.NoError(t, regUser.Insert())
+			apiUser := &user.DBUser{
+				Id:      "api_user",
+				APIKey:  "api_key",
+				OnlyAPI: true,
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			assert.NotNil(t, um)
+
+			checkRegUser, err := user.FindOneById(regUser.Id)
+			require.NoError(t, err)
+			require.NotNil(t, checkRegUser)
+			assert.Equal(t, regUser.APIKey, checkRegUser.APIKey)
+
+			checkAPIUser, err := user.FindOneById(apiUser.Id)
+			assert.NoError(t, err)
+			assert.Nil(t, checkAPIUser)
+		},
+		"SynchronizesListOfChangedUsers": func(t *testing.T) {
+			apiUser1 := &user.DBUser{
+				Id:      "api_user1",
+				APIKey:  "api_key1",
+				OnlyAPI: true,
+			}
+			require.NoError(t, apiUser1.Insert())
+			apiUser2 := &user.DBUser{
+				Id:      "api_user2",
+				APIKey:  "api_key2",
+				OnlyAPI: true,
+			}
+			require.NoError(t, apiUser2.Insert())
+			apiUser3 := &user.DBUser{
+				Id:      "api_user3",
+				APIKey:  "api_key3",
+				OnlyAPI: true,
+			}
+			require.NoError(t, apiUser3.Insert())
+			regUser1 := &user.DBUser{
+				Id:     "reg_user1",
+				APIKey: "reg_key1",
+			}
+			require.NoError(t, regUser1.Insert())
+			u1 := evergreen.OnlyAPIUser{
+				Username: apiUser1.Id,
+				Key:      apiUser1.APIKey,
+			}
+			u2 := evergreen.OnlyAPIUser{
+				Username: apiUser2.Id,
+				Key:      "new_" + apiUser2.APIKey,
+			}
+			u4 := evergreen.OnlyAPIUser{
+				Username: "api_user4",
+				Key:      "api_key4",
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u1, u2, u4},
+			}
+
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			assert.NotNil(t, um)
+
+			checkAPIUser1, err := user.FindOneById(u1.Username)
+			require.NoError(t, err)
+			assert.Equal(t, apiUser1.APIKey, checkAPIUser1.APIKey, "API-only user should be unchanged")
+
+			checkAPIUser2, err := user.FindOneById(u2.Username)
+			require.NoError(t, err)
+			assert.Equal(t, u2.Key, checkAPIUser2.APIKey, "API-only user should be updated")
+
+			checkAPIUser3, err := user.FindOneById(apiUser3.Id)
+			assert.NoError(t, err)
+			assert.Nil(t, checkAPIUser3, "old API-only user should be deleted from the DB")
+
+			checkRegUser1, err := user.FindOneById(regUser1.Id)
+			require.NoError(t, err)
+			assert.Equal(t, regUser1.APIKey, checkRegUser1.APIKey, "regular user should not be changed")
+
+			checkAPIUser5, err := user.FindOneById(u4.Username)
+			require.NoError(t, err)
+			assert.Equal(t, u4.Key, checkAPIUser5.APIKey, "new API-only user should be inserted")
+		},
+		"GetUserByIDSucceeds": func(t *testing.T) {
+			u1 := evergreen.OnlyAPIUser{
+				Username: "user1",
+				Key:      "key1",
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u1},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			require.NotNil(t, um)
+
+			checkUser, err := um.GetUserByID(u1.Username)
+			require.NoError(t, err)
+			checkDBUser, ok := checkUser.(*user.DBUser)
+			require.True(t, ok, "user manager in evergreen must return DBUser")
+			assert.Equal(t, u1.Key, checkDBUser.APIKey)
+			assert.True(t, checkDBUser.OnlyAPI)
+		},
+		"GetUserByIDFailsIfNonexistent": func(t *testing.T) {
+			u := evergreen.OnlyAPIUser{
+				Username: "user1",
+				Key:      "key1",
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			require.NotNil(t, um)
+
+			checkUser, err := um.GetUserByID("nonexistent")
+			assert.Error(t, err)
+			assert.Nil(t, checkUser)
+		},
+		"GetUserByIDFailsIfNotOnlyAPIUser": func(t *testing.T) {
+			regUser := &user.DBUser{
+				Id:     "reg_user",
+				APIKey: "reg_key",
+			}
+			require.NoError(t, regUser.Insert())
+			apiUser := &user.DBUser{
+				Id:      "api_user",
+				APIKey:  "api_key",
+				OnlyAPI: true,
+			}
+			require.NoError(t, apiUser.Insert())
+			u := evergreen.OnlyAPIUser{
+				Username: apiUser.Id,
+				Key:      apiUser.APIKey,
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			require.NotNil(t, um)
+
+			checkUser, err := um.GetUserByID(regUser.Id)
+			assert.Error(t, err)
+			assert.Nil(t, checkUser)
+		},
+		"GetUserByTokenFails": func(t *testing.T) {
+			apiUser := &user.DBUser{
+				Id: "api_user",
+				LoginCache: user.LoginCache{
+					Token: "token",
+				},
+				APIKey:  "api_key",
+				OnlyAPI: true,
+			}
+			require.NoError(t, apiUser.Insert())
+			u := evergreen.OnlyAPIUser{
+				Username: apiUser.Id,
+				Key:      apiUser.APIKey,
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			require.NotNil(t, um)
+
+			checkUser, err := um.GetUserByToken(context.Background(), apiUser.LoginCache.Token)
+			assert.Error(t, err)
+			assert.Nil(t, checkUser)
+		},
+		"CreateUserTokenFails": func(t *testing.T) {
+			apiUser := &user.DBUser{
+				Id:      "api_user",
+				APIKey:  "api_key",
+				OnlyAPI: true,
+			}
+			require.NoError(t, apiUser.Insert())
+			u := evergreen.OnlyAPIUser{
+				Username: apiUser.Id,
+				Key:      apiUser.APIKey,
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			require.NotNil(t, um)
+
+			token, err := um.CreateUserToken(apiUser.Id, "")
+			assert.Error(t, err)
+			assert.Empty(t, token)
+
+			token, err = um.CreateUserToken("new_api_user", "")
+			assert.Error(t, err)
+			assert.Empty(t, token)
+		},
+		"ClearUserFails": func(t *testing.T) {
+			apiUser := &user.DBUser{
+				Id:      "api_user",
+				APIKey:  "api_key",
+				OnlyAPI: true,
+			}
+			require.NoError(t, apiUser.Insert())
+			u := evergreen.OnlyAPIUser{
+				Username: apiUser.Id,
+				Key:      apiUser.APIKey,
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			require.NotNil(t, um)
+
+			assert.Error(t, um.ClearUser(apiUser, false))
+			checkUser, err := user.FindOneById(apiUser.Id)
+			require.NoError(t, err)
+			require.NotNil(t, checkUser)
+			assert.Equal(t, checkUser.APIKey, apiUser.APIKey)
+
+			assert.Error(t, um.ClearUser(apiUser, true))
+			checkUser, err = user.FindOneById(apiUser.Id)
+			require.NoError(t, err)
+			require.NotNil(t, checkUser)
+			assert.Equal(t, checkUser.APIKey, apiUser.APIKey)
+
+			assert.Error(t, um.ClearUser(&user.DBUser{}, true))
+			checkUser, err = user.FindOneById(apiUser.Id)
+			require.NoError(t, err)
+			require.NotNil(t, checkUser)
+			assert.Equal(t, checkUser.APIKey, apiUser.APIKey)
+		},
+		"ReauthorizeUserFails": func(t *testing.T) {
+			apiUser := &user.DBUser{
+				Id:      "api_user",
+				APIKey:  "api_key",
+				OnlyAPI: true,
+			}
+			require.NoError(t, apiUser.Insert())
+			regUser := &user.DBUser{
+				Id:     "reg_user",
+				APIKey: "reg_key",
+			}
+			require.NoError(t, regUser.Insert())
+			u := evergreen.OnlyAPIUser{
+				Username: apiUser.Id,
+				Key:      apiUser.APIKey,
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			require.NotNil(t, um)
+
+			assert.Error(t, um.ReauthorizeUser(apiUser))
+			assert.Error(t, um.ReauthorizeUser(regUser))
+		},
+		"GetGroupsForUserFails": func(t *testing.T) {
+			apiUser := &user.DBUser{
+				Id:      "api_user",
+				APIKey:  "api_key",
+				OnlyAPI: true,
+			}
+			require.NoError(t, apiUser.Insert())
+			regUser := &user.DBUser{
+				Id:     "reg_user",
+				APIKey: "reg_key",
+			}
+			require.NoError(t, regUser.Insert())
+			u := evergreen.OnlyAPIUser{
+				Username: apiUser.Id,
+				Key:      apiUser.APIKey,
+			}
+			conf := &evergreen.OnlyAPIAuthConfig{
+				Users: []evergreen.OnlyAPIUser{u},
+			}
+			um, err := NewOnlyAPIUserManager(conf)
+			require.NoError(t, err)
+			require.NotNil(t, um)
+
+			groups, err := um.GetGroupsForUser(apiUser.Id)
+			assert.Error(t, err)
+			assert.Empty(t, groups)
+			groups, err = um.GetGroupsForUser(regUser.Id)
+			assert.Error(t, err)
+			assert.Empty(t, groups)
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			require.NoError(t, db.Clear(user.Collection))
+			defer func() {
+				assert.NoError(t, db.Clear(user.Collection))
+			}()
+			testCase(t)
+		})
+	}
 }

--- a/auth/only_api_test.go
+++ b/auth/only_api_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/user"
+	_ "github.com/evergreen-ci/evergreen/testutil" // Import testutil to force init to run
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/glide.lock
+++ b/glide.lock
@@ -126,6 +126,7 @@ imports:
     version: 505d1051058d81836ddb3cb839ba06009588a14e
   - name: github.com/mongodb/amboy
     version: df24672ec6aa73d93b329b156128e645fb34ee79
+    # kim: TODO: update when MAKE-1178 is merged
   - name: github.com/evergreen-ci/gimlet
     version: f4dd85baa80ace3799e1e9d8eb3cec6ca7182f91
   - name: github.com/evergreen-ci/shrub

--- a/glide.lock
+++ b/glide.lock
@@ -126,9 +126,8 @@ imports:
     version: 505d1051058d81836ddb3cb839ba06009588a14e
   - name: github.com/mongodb/amboy
     version: df24672ec6aa73d93b329b156128e645fb34ee79
-    # kim: TODO: update when MAKE-1178 is merged
   - name: github.com/evergreen-ci/gimlet
-    version: f4dd85baa80ace3799e1e9d8eb3cec6ca7182f91
+    version: 8d7559cbe3a465d8fcc0539cedee6e2c7e3e8c5e
   - name: github.com/evergreen-ci/shrub
     version: 32e668cd99410328bf6659e55671c11a6c727d9a
   - name: github.com/evergreen-ci/pail

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -22,6 +22,7 @@ var (
 	CreatedAtKey                = bsonutil.MustHaveTag(DBUser{}, "CreatedAt")
 	SettingsKey                 = bsonutil.MustHaveTag(DBUser{}, "Settings")
 	APIKeyKey                   = bsonutil.MustHaveTag(DBUser{}, "APIKey")
+	OnlyAPIKey                  = bsonutil.MustHaveTag(DBUser{}, "OnlyAPI")
 	PubKeysKey                  = bsonutil.MustHaveTag(DBUser{}, "PubKeys")
 	LoginCacheKey               = bsonutil.MustHaveTag(DBUser{}, "LoginCache")
 	RolesKey                    = bsonutil.MustHaveTag(DBUser{}, "SystemRoles")

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -32,6 +32,7 @@ type DBUser struct {
 	SystemRoles      []string     `bson:"roles"`
 	LoginCache       LoginCache   `bson:"login_cache,omitempty"`
 	FavoriteProjects []string     `bson:"favorite_projects"`
+	OnlyAPI          bool         `bson:"only_api,omitempty"`
 }
 
 func (u *DBUser) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(u) }

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -370,11 +370,11 @@ tasks:
   - <<: *run-build
     name: dist
   - <<: *run-go-test-suite
-    tags: ["db", "test"]
-    name: test-auth
-  - <<: *run-go-test-suite
     tags: ["nodb", "test", "agent"]
     name: test-thirdparty-docker
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
+    name: test-auth
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
     name: test-rest-route

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -370,7 +370,7 @@ tasks:
   - <<: *run-build
     name: dist
   - <<: *run-go-test-suite
-    tags: ["nodb", "test"]
+    tags: ["db", "test"]
     name: test-auth
   - <<: *run-go-test-suite
     tags: ["nodb", "test", "agent"]

--- a/vendor/github.com/evergreen-ci/gimlet/cached/user_service_cached.go
+++ b/vendor/github.com/evergreen-ci/gimlet/cached/user_service_cached.go
@@ -1,0 +1,72 @@
+package cached
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/gimlet/usercache"
+	"github.com/pkg/errors"
+)
+
+// cacheUserManager creates a thin wrapper around a user cache.
+type cachedUserManager struct {
+	cache usercache.Cache
+}
+
+// NewUserManager returns a user manager backed by a cache that manages users.
+func NewUserManager(cache usercache.Cache) (gimlet.UserManager, error) {
+	if cache == nil {
+		return nil, errors.New("cache cannot be nil")
+	}
+	return &cachedUserManager{cache: cache}, nil
+}
+
+func (um *cachedUserManager) GetUserByToken(_ context.Context, token string) (gimlet.User, error) {
+	user, _, err := um.cache.Get(token)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get cached user with token")
+	}
+	if user == nil {
+		return nil, errors.New("user not found in cache with token")
+	}
+	return user, nil
+}
+
+func (um *cachedUserManager) ReauthorizeUser(user gimlet.User) error {
+	return errors.New("cannot reauthorize users for cached user manager")
+}
+
+func (um *cachedUserManager) CreateUserToken(username, password string) (string, error) {
+	return "", errors.New("cannot create user tokens for cached user manager")
+}
+
+func (um *cachedUserManager) GetOrCreateUser(user gimlet.User) (gimlet.User, error) {
+	return um.cache.GetOrCreate(user)
+}
+
+func (*cachedUserManager) GetLoginHandler(string) http.HandlerFunc   { return nil }
+func (*cachedUserManager) GetLoginCallbackHandler() http.HandlerFunc { return nil }
+func (*cachedUserManager) IsRedirect() bool                          { return false }
+
+func (um *cachedUserManager) GetUserByID(id string) (gimlet.User, error) {
+	user, valid, err := um.cache.Find(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get cached user with ID")
+	}
+	if user == nil {
+		return nil, errors.New("user not found in cache with ID")
+	}
+	if !valid {
+		return nil, errors.New("user is invalid")
+	}
+	return user, nil
+}
+
+func (um *cachedUserManager) ClearUser(user gimlet.User, all bool) error {
+	return um.cache.Clear(user, all)
+}
+
+func (um *cachedUserManager) GetGroupsForUser(id string) ([]string, error) {
+	return nil, errors.New("cannot get groups for cached user manager")
+}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1178

* Store API-only users in the users collection because `MustHaveUser` requires that it receive a DBUser from the gimlet middleware. No regular user can be authed in by the API-only user manager.
* Add a special OnlyAPI flag to DBUsers so that we can distinguish regular users from API-only users. This is also used to ensure that the set of API-only users in the users collection exactly matches the ones populated in the admin config.
* The only downside I can see to this is that before we make the user manager, we have to sync the API-only users in the DB before we set up the user manager. We also can't know if a regular user with the same ID is already in the collection when we save the admin settings (because it would cause a dependency on the DBUsers model, which would cause a nasty cyclical dependency). I don't think this is a big deal, so I'm leaving it as is.

I'm going to make an index on the DBUser's only_api field before this gets deployed.