### PR TITLE
EVG-7499 maintain settings for distro UI

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -277,6 +277,5 @@ func CreateSettingsListFromLegacy(d *distro.Distro) error {
 		doc = doc.Set(birch.EC.String("region", evergreen.DefaultEC2Region))
 	}
 	d.ProviderSettingsList = []*birch.Document{doc}
-	d.ProviderSettings = nil
 	return nil
 }

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -45,17 +45,17 @@ func (settings *dockerSettings) Validate() error {
 }
 
 func (s *dockerSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if d.ProviderSettings != nil {
-		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
+	if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, s); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
+		}
+	} else if d.ProviderSettings != nil {
+		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}
 	}
 	return nil

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -16,7 +18,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
-	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -98,20 +99,7 @@ func (s *EC2ProviderSettings) Validate() error {
 
 // region is only provided if we want to filter by region
 func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string) error {
-	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
-		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
-		}
-		grip.Debug(message.Fields{
-			"message": "mapstructure comparison",
-			"input":   *d.ProviderSettings,
-			"output":  *s,
-		})
-		s.Region = s.getRegion()
-		if s.Region != evergreen.DefaultEC2Region {
-			return errors.Errorf("only default region should be saved in provider settings")
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
+	if len(d.ProviderSettingsList) != 0 {
 		settingsDoc, err := d.GetProviderSettingByRegion(region)
 		if err != nil {
 			return errors.Wrapf(err, "providers list doesn't contain region '%s'", region)
@@ -123,6 +111,20 @@ func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string)
 		if err := bson.Unmarshal(bytes, s); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
+	} else if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 { // legacy case, to be removed
+		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
+		}
+		grip.Debug(message.Fields{
+			"message": "mapstructure comparison",
+			"input":   *d.ProviderSettings,
+			"output":  *s,
+		})
+
+		if region != evergreen.DefaultEC2Region && region != "" {
+			return errors.Errorf("only default region should be saved in provider settings")
+		}
+		s.Region = s.getRegion()
 	}
 	return nil
 }

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -18,6 +16,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -5,10 +5,11 @@ package cloud
 import (
 	"context"
 
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
-	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -70,17 +71,17 @@ func (opts *GCESettings) Validate() error {
 }
 
 func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if d.ProviderSettings != nil {
-		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
+	if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
+		}
+	} else if d.ProviderSettings != nil {
+		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
 	}
 	return nil

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -5,11 +5,10 @@ package cloud
 import (
 	"context"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -52,17 +52,17 @@ func (opts *openStackSettings) Validate() error {
 }
 
 func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if d.ProviderSettings != nil {
-		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
+	if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
+		}
+	} else if d.ProviderSettings != nil {
+		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
 	}
 	return nil

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -44,17 +44,17 @@ func (s *StaticSettings) Validate() error {
 }
 
 func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if d.ProviderSettings != nil {
-		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
+	if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, s); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
+		}
+	} else if d.ProviderSettings != nil {
+		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}
 	}
 	return nil

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -6,10 +6,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
-	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -53,17 +54,17 @@ func (opts *vsphereSettings) Validate() error {
 }
 
 func (opts *vsphereSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if d.ProviderSettings != nil {
-		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
+	if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
+		}
+	} else if d.ProviderSettings != nil {
+		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
 	}
 	return nil

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -6,11 +6,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -217,17 +217,17 @@ type DockerOptions struct {
 }
 
 func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
-	if d.ProviderSettings != nil {
-		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
+	if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
+		}
+	} else if d.ProviderSettings != nil {
+		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
 	}
 	return nil

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/mongodb/grip"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -224,7 +223,6 @@ func TestMakeIntentHost(t *testing.T) {
 	doc2 := d.ProviderSettingsList[0].Copy().Set(birch.EC.String("region", "us-west-1")).Set(birch.EC.String("ami", "ami-987654"))
 	d.ProviderSettingsList = append(d.ProviderSettingsList, doc2)
 	require.NoError(d.Update())
-	grip.Debug(d.ProviderSettingsList[1])
 	c = apimodels.CreateHost{
 		Distro:              "archlinux-test",
 		CloudProvider:       "ec2",

--- a/service/distros.go
+++ b/service/distros.go
@@ -122,6 +122,13 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ensure docker password wasn't auto-filled from form
+	if newDistro.Provider != evergreen.ProviderNameDocker && newDistro.Provider != evergreen.ProviderNameDockerMock {
+		if newDistro.ProviderSettings != nil {
+			delete(*newDistro.ProviderSettings, "docker_registry_pw")
+		}
+	}
+
 	// populate settings list with the modified settings (temporary)
 	if err = cloud.UpdateProviderSettings(&newDistro); err != nil {
 		message := fmt.Sprintf("error updating provider settings: %v", err)


### PR DESCRIPTION
Distro UI not loading because updating distro settings in erroneously removing the legacy provider settings structure, which the current distro UI is still using (to be changed in EVG-7233).