### PR TITLE
EVG-7463 send correct status from agent, add a default logger for errors

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -73,6 +73,9 @@ func (s *AgentSuite) SetupTest() {
 	s.tmpDirName, err = ioutil.TempDir("", "agent-command-suite-")
 	s.Require().NoError(err)
 	s.tc.taskDirectory = s.tmpDirName
+	sender, err := s.a.GetSender(ctx, evergreen.LocalLoggingOverride)
+	s.Require().NoError(err)
+	s.a.SetDefaultLogger(sender)
 }
 
 func (s *AgentSuite) TearDownTest() {

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -46,7 +46,7 @@ func init() {
 func getInc() int { return <-idSource }
 
 // GetSender configures the agent's local logging to a file.
-func (a *Agent) GetSender(ctx context.Context, prefix, taskId string) (send.Sender, error) {
+func (a *Agent) GetSender(ctx context.Context, prefix string) (send.Sender, error) {
 	var (
 		err     error
 		sender  send.Sender
@@ -91,6 +91,10 @@ func (a *Agent) GetSender(ctx context.Context, prefix, taskId string) (send.Send
 	}
 
 	return send.NewConfiguredMultiSender(senders...), nil
+}
+
+func (a *Agent) SetDefaultLogger(sender send.Sender) {
+	a.defaultLogger = sender
 }
 
 func (a *Agent) makeLoggerProducer(ctx context.Context, tc *taskContext, c *model.LoggerConfig, commandName string) (client.LoggerProducer, error) {

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -23,7 +23,7 @@ func TestGetSenderLocal(t *testing.T) {
 	assert := assert.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_, err := (&Agent{}).GetSender(ctx, evergreen.LocalLoggingOverride, "task_id")
+	_, err := (&Agent{}).GetSender(ctx, evergreen.LocalLoggingOverride)
 	assert.NoError(err)
 }
 

--- a/agent/task.go
+++ b/agent/task.go
@@ -185,7 +185,9 @@ func (tc *taskContext) setCurrentCommand(command command.Command) {
 	defer tc.Unlock()
 	tc.currentCommand = command
 
-	tc.logger.Execution().Infof("Current command set to '%s' (%s)", tc.currentCommand.DisplayName(), tc.currentCommand.Type())
+	if tc.logger != nil {
+		tc.logger.Execution().Infof("Current command set to '%s' (%s)", tc.currentCommand.DisplayName(), tc.currentCommand.Type())
+	}
 }
 
 func (tc *taskContext) getCurrentCommand() command.Command {

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -111,7 +111,7 @@ func Agent() cli.Command {
 
 			go hardShutdownForSignals(ctx, cancel)
 
-			sender, err := agt.GetSender(ctx, opts.LogPrefix, "init")
+			sender, err := agt.GetSender(ctx, opts.LogPrefix)
 			if err != nil {
 				return errors.Wrap(err, "problem configuring logger")
 			}
@@ -119,6 +119,7 @@ func Agent() cli.Command {
 			if err = grip.SetSender(sender); err != nil {
 				return errors.Wrap(err, "problem setting up logger")
 			}
+			agt.SetDefaultLogger(sender)
 
 			err = agt.Start(ctx)
 			grip.Emergency(err)


### PR DESCRIPTION
The initial problem was that the agent was sending system-failed in the wrong format. I fixed that, but it surfaced another problem in which some shared functions to end the task will attempt to log to the task, but the scenarios in which we were trying to send system-failed did not have a logger for the task. This now adds a default sender which can be used to log to the agent's file