### PR TITLE
EVG-7571 preference legacy for distro settings

### DIFF
--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -45,7 +45,7 @@ func (settings *dockerSettings) Validate() error {
 }
 
 func (s *dockerSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
+	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
@@ -53,7 +53,7 @@ func (s *dockerSettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := bson.Unmarshal(bytes, s); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
-	} else if d.ProviderSettings != nil {
+	} else if len(d.ProviderSettingsList) != 0 {
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -46,16 +46,16 @@ func (settings *dockerSettings) Validate() error {
 
 func (s *dockerSettings) FromDistroSettings(d distro.Distro, _ string) error {
 	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
+		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
+		}
+	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, s); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
-		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}
 	}
 	return nil

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -99,18 +99,6 @@ func (s *EC2ProviderSettings) Validate() error {
 // region is only provided if we want to filter by region
 func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string) error {
 	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 { // legacy case, to be removed
-		settingsDoc, err := d.GetProviderSettingByRegion(region)
-		if err != nil {
-			return errors.Wrapf(err, "providers list doesn't contain region '%s'", region)
-		}
-		bytes, err := settingsDoc.MarshalBSON()
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		if err := bson.Unmarshal(bytes, s); err != nil {
-			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}
@@ -124,6 +112,18 @@ func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string)
 			return errors.Errorf("only default region should be saved in provider settings")
 		}
 		s.Region = s.getRegion()
+	} else if len(d.ProviderSettingsList) != 0 {
+		settingsDoc, err := d.GetProviderSettingByRegion(region)
+		if err != nil {
+			return errors.Wrapf(err, "providers list doesn't contain region '%s'", region)
+		}
+		bytes, err := settingsDoc.MarshalBSON()
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		if err := bson.Unmarshal(bytes, s); err != nil {
+			return errors.Wrap(err, "error unmarshalling bson into provider settings")
+		}
 	}
 	return nil
 }

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -98,7 +98,7 @@ func (s *EC2ProviderSettings) Validate() error {
 
 // region is only provided if we want to filter by region
 func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string) error {
-	if len(d.ProviderSettingsList) != 0 {
+	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 { // legacy case, to be removed
 		settingsDoc, err := d.GetProviderSettingByRegion(region)
 		if err != nil {
 			return errors.Wrapf(err, "providers list doesn't contain region '%s'", region)
@@ -110,7 +110,7 @@ func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string)
 		if err := bson.Unmarshal(bytes, s); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
-	} else if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 { // legacy case, to be removed
+	} else if len(d.ProviderSettingsList) != 0 {
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -70,7 +70,7 @@ func (opts *GCESettings) Validate() error {
 }
 
 func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
+	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
@@ -78,7 +78,7 @@ func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
-	} else if d.ProviderSettings != nil {
+	} else if len(d.ProviderSettingsList) != 0 {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -71,16 +71,17 @@ func (opts *GCESettings) Validate() error {
 
 func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
 	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
+		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
+		}
+
+	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
-		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
 	}
 	return nil

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -52,7 +52,7 @@ func (opts *openStackSettings) Validate() error {
 }
 
 func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
+	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
@@ -60,7 +60,7 @@ func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) err
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
-	} else if d.ProviderSettings != nil {
+	} else if len(d.ProviderSettingsList) != 0 {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -53,16 +53,16 @@ func (opts *openStackSettings) Validate() error {
 
 func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) error {
 	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
+		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
+		}
+	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
-		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
 	}
 	return nil

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -44,7 +44,7 @@ func (s *StaticSettings) Validate() error {
 }
 
 func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
+	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
@@ -52,7 +52,7 @@ func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := bson.Unmarshal(bytes, s); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
-	} else if d.ProviderSettings != nil {
+	} else if len(d.ProviderSettingsList) != 0 {
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -45,16 +45,16 @@ func (s *StaticSettings) Validate() error {
 
 func (s *StaticSettings) FromDistroSettings(d distro.Distro, _ string) error {
 	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
+		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
+		}
+	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, s); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
-		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}
 	}
 	return nil

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -53,7 +53,7 @@ func (opts *vsphereSettings) Validate() error {
 }
 
 func (opts *vsphereSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
+	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
@@ -61,7 +61,7 @@ func (opts *vsphereSettings) FromDistroSettings(d distro.Distro, _ string) error
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
-	} else if d.ProviderSettings != nil {
+	} else if len(d.ProviderSettingsList) != 0 {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -54,16 +54,16 @@ func (opts *vsphereSettings) Validate() error {
 
 func (opts *vsphereSettings) FromDistroSettings(d distro.Distro, _ string) error {
 	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
+		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
+		}
+	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
-		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
 	}
 	return nil

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -217,7 +217,7 @@ type DockerOptions struct {
 }
 
 func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
+	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
@@ -225,7 +225,7 @@ func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
 		}
-	} else if d.ProviderSettings != nil {
+	} else if len(d.ProviderSettingsList) != 0 {
 		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -218,16 +218,16 @@ type DockerOptions struct {
 
 func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
 	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 {
+		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
+			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
+		}
+	} else if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
 		if err != nil {
 			return errors.Wrap(err, "error marshalling provider setting into bson")
 		}
 		if err := bson.Unmarshal(bytes, opts); err != nil {
 			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
-	} else if len(d.ProviderSettingsList) != 0 {
-		if err := mapstructure.Decode(d.ProviderSettings, opts); err != nil {
-			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, opts)
 		}
 	}
 	return nil

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -243,16 +243,17 @@ func TestMakeIntentHost(t *testing.T) {
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, "us-east-1"))
 	assert.Equal(ec2Settings2.AMI, "ami-123456")
 
-	handler.createHost.Region = "us-west-1"
-	h, err = handler.sc.MakeIntentHost(handler.taskID, "", "", handler.createHost)
-	assert.NoError(err)
-	assert.NotNil(h)
-	assert.Equal("archlinux-test", h.Distro.Id)
-	assert.Nil(h.Distro.ProviderSettings)
-	require.Len(h.Distro.ProviderSettingsList, 1)
-	ec2Settings2 = &cloud.EC2ProviderSettings{}
-	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, "us-west-1"))
-	assert.Equal(ec2Settings2.AMI, "ami-987654")
+	// TODO: uncomment this test when off of legacy
+	//handler.createHost.Region = "us-west-1"
+	//h, err = handler.sc.MakeIntentHost(handler.taskID, "", "", handler.createHost)
+	//assert.NoError(err)
+	//assert.NotNil(h)
+	//assert.Equal("archlinux-test", h.Distro.Id)
+	//assert.Nil(h.Distro.ProviderSettings)
+	//require.Len(h.Distro.ProviderSettingsList, 1)
+	//ec2Settings2 = &cloud.EC2ProviderSettings{}
+	//assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, "us-west-1"))
+	//assert.Equal(ec2Settings2.AMI, "ami-987654")
 }
 
 func TestHostCreateDocker(t *testing.T) {


### PR DESCRIPTION
I'd like to revert this within the next week, but need to migrate all of the distros from using settings to using provider_settings (as some unmigrated distros still do have provider_settings with bad data, or with empty items, so there's no way to determine if it's accurate).