### PR TITLE
EVG-7578: prevent autofill passwords for docker in distro settings

### DIFF
--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -23,7 +23,7 @@ Evergreen - Distros
         ng-disabled="activeDistro.new"><i class="fa fa-plus"></i>New Distro</button>
     </div>
   </div>
-  <div ng-form="form" class="row">
+  <div ng-form="form" autocomplete="off" class="row">
     <div id="nav-container" class="col-md-2" ng-show="distroIds.length != 0" style="left:10%; max-width:350px">
       <div>
         <div>

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -332,7 +332,7 @@ Evergreen - Distros
               </div>
               <div>
                 <label class="distro-label">Password for Registries:</label>
-                <input type="password" class="form-control" ng-model="activeDistro.settings.docker_registry_pw" ng-readonly="readOnly">
+                <input type="password" autocomplete="new-password" class="form-control" ng-model="activeDistro.settings.docker_registry_pw" ng-readonly="readOnly">
               </div>
               <div>
                 <label class="distro-label">Pool ID:</label>


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7578

Stop the annoying silent autofilled password causing your evergreen password to be saved in plaintext to the database. It will still give you an autofill dropdown if you use the field since it's a username/password form. I tested only on the latest chrome, firefox, and safari.