### PR TITLE
EVG-7304 group all tests in a display task in one BFG

### DIFF
--- a/trigger/task.go
+++ b/trigger/task.go
@@ -751,13 +751,14 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 	}
 	if previousCompleteTask != nil {
 		if previousCompleteTask.DisplayOnly {
-			results, err := previousCompleteTask.GetTestResultsForDisplayTask()
+			var results []task.TestResult
+			results, err = previousCompleteTask.GetTestResultsForDisplayTask()
 			if err != nil {
 				return nil, errors.Wrapf(err, "can't get test results for previous display task '%s'", previousCompleteTask.Id)
 			}
 			t.oldTestResults = mapTestResultsByTestFile(results)
 		} else {
-			if err := previousCompleteTask.MergeNewTestResults(); err != nil {
+			if err = previousCompleteTask.MergeNewTestResults(); err != nil {
 				return nil, errors.Wrapf(err, "can't get test results for previous task '%s'", previousCompleteTask.Id)
 			}
 			t.oldTestResults = mapTestResultsByTestFile(previousCompleteTask.LocalTestResults)
@@ -771,7 +772,8 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 			continue
 		}
 		hasFailingTest = true
-		match, err := testMatchesRegex(test.TestFile, sub)
+		var match bool
+		match, err = testMatchesRegex(test.TestFile, sub)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"source":  "test-trigger",


### PR DESCRIPTION
#3241 grouped test results from a display task together so a test could be compared against its last execution even when the test had moved within execution tasks. Every execution task with a test regression still generated a separate BFG.
This PR groups all test regressions from a single display task into a single BFG reporting all test regressions in the display task.

Because the task triggers were excluding display tasks from notifications and this is no longer true for test regressions the check for display task has been moved into the individual triggers.