### PR TITLE
EVG-7176 migrate volumes

### DIFF
--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -471,7 +471,7 @@ func (m *ec2FleetManager) requestFleet(ctx context.Context, ec2Settings *EC2Prov
 }
 
 func (m *ec2FleetManager) makeOverrides(ctx context.Context, ec2Settings *EC2ProviderSettings) ([]*ec2.FleetLaunchTemplateOverridesRequest, error) {
-	subnets := m.env.Settings().Providers.AWS.Subnets
+	subnets := m.settings.Providers.AWS.Subnets
 	if len(subnets) > 0 {
 		overrides := make([]*ec2.FleetLaunchTemplateOverridesRequest, 0, len(subnets))
 		for _, subnet := range subnets {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -471,6 +471,16 @@ func (m *ec2FleetManager) requestFleet(ctx context.Context, ec2Settings *EC2Prov
 }
 
 func (m *ec2FleetManager) makeOverrides(ctx context.Context, ec2Settings *EC2ProviderSettings) ([]*ec2.FleetLaunchTemplateOverridesRequest, error) {
+	subnets := m.env.Settings().Providers.AWS.Subnets
+	if len(subnets) > 0 {
+		overrides := make([]*ec2.FleetLaunchTemplateOverridesRequest, 0, len(subnets))
+		for _, subnet := range subnets {
+			overrides = append(overrides, &ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String(subnet.SubnetID)})
+		}
+
+		return overrides, nil
+	}
+
 	describeVpcsOutput, err := m.client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
 		Filters: []*ec2.Filter{
 			{

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -40,6 +40,7 @@ type SpawnOptions struct {
 	NoExpiration         bool
 	IsVirtualWorkstation bool
 	HomeVolumeSize       int
+	HomeVolumeID         string
 }
 
 // Validate returns an instance of BadOptionsErr if the SpawnOptions object contains invalid
@@ -173,6 +174,7 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 		NoExpiration:         so.NoExpiration,
 		IsVirtualWorkstation: so.IsVirtualWorkstation,
 		HomeVolumeSize:       so.HomeVolumeSize,
+		HomeVolumeID:         so.HomeVolumeID,
 		Region:               so.Region,
 	}
 

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -67,9 +67,15 @@ type EC2Key struct {
 	Secret string `bson:"secret" json:"secret" yaml:"secret"`
 }
 
+type Subnet struct {
+	AZ       string `bson:"az" json:"az" yaml:"az"`
+	SubnetID string `bson:"subnet_id" json:"subnet_id" yaml:"subnet_id"`
+}
+
 // AWSConfig stores auth info for Amazon Web Services.
 type AWSConfig struct {
 	EC2Keys []EC2Key `bson:"ec2_keys" json:"ec2_keys" yaml:"ec2_keys"`
+	Subnets []Subnet `bson:"subnets" json:"subnets" yaml:"subnets"`
 
 	S3Key                string `bson:"s3_key" json:"s3_key" yaml:"s3_key"`
 	S3Secret             string `bson:"s3_secret" json:"s3_secret" yaml:"s3_secret"`

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -531,22 +531,6 @@ func (distros DistroGroup) GetDistroIds() []string {
 	return ids
 }
 
-func (d *Distro) RemoveExtraneousProviderSettings(region string) error {
-	doc, err := d.GetProviderSettingByRegion(region)
-	if err != nil {
-		grip.Warning(message.WrapError(err, message.Fields{
-			"message":       "provider list missing region",
-			"distro":        d.Id,
-			"region":        region,
-			"settings_list": d.ProviderSettingsList,
-		}))
-		return errors.Wrapf(err, "error getting provider settings by region")
-	}
-	d.ProviderSettingsList = []*birch.Document{doc}
-	d.ProviderSettings = nil
-	return nil
-}
-
 func (d *Distro) GetProviderSettingByRegion(region string) (*birch.Document, error) {
 	// check legacy case
 	if (region == "" || region == evergreen.DefaultEC2Region) && len(d.ProviderSettingsList) == 0 {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -151,7 +151,8 @@ type Host struct {
 
 	IsVirtualWorkstation bool `bson:"is_virtual_workstation" json:"is_virtual_workstation"`
 	// HomeVolumeSize is the size of the home volume in GB
-	HomeVolumeSize int `bson:"home_volume_size" json:"home_volume_size"`
+	HomeVolumeSize int    `bson:"home_volume_size" json:"home_volume_size"`
+	HomeVolumeID   string `bson:"home_volume_id" json:"home_volume_id"`
 }
 
 type Tag struct {

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -30,6 +30,7 @@ type CreateOptions struct {
 	NoExpiration          bool
 	IsVirtualWorkstation  bool
 	HomeVolumeSize        int
+	HomeVolumeID          string
 }
 
 // NewIntent creates an IntentHost using the given host settings. An IntentHost is a host that
@@ -63,6 +64,7 @@ func NewIntent(d distro.Distro, instanceName, provider string, options CreateOpt
 		InstanceType:          options.InstanceType,
 		IsVirtualWorkstation:  options.IsVirtualWorkstation,
 		HomeVolumeSize:        options.HomeVolumeSize,
+		HomeVolumeID:          options.HomeVolumeID,
 	}
 
 	if options.ExpirationDuration != nil {

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -200,7 +200,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
       };
     }
     if ($scope.Settings.providers.aws.ec2_keys === undefined || $scope.Settings.providers.aws.ec2_keys === null) {
-        $scope.Settings.providers.aws = {"ec2_keys": []}
+        $scope.Settings.providers.aws.ec2_keys = []
     }
     if (!$scope.validEC2Credentials($scope.new_item)){
         $scope.invalidCredential = "EC2 Region, Key, and Secret required.";
@@ -222,7 +222,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
       };
     }
     if ($scope.Settings.providers.aws.subnets == null) {
-        $scope.Settings.providers.aws = {"subnets": []}
+        $scope.Settings.providers.aws.subnets = []
     }
 
     if (!$scope.validSubnet($scope.new_subnet)){
@@ -240,7 +240,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
   }
 
   $scope.validSubnet = function(subnet){
-    return subnet && subnet.az && subnet.subnetID;
+    return subnet && subnet.az && subnet.subnet_id;
   }
 
   $scope.clearAllUserTokens = function(){

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -215,6 +215,34 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     $scope.Settings.providers.aws.ec2_keys.splice(index, 1);
   }
 
+  $scope.addSubnet = function(){
+    if ($scope.Settings.providers == null) {
+      $scope.Settings.providers = {
+        "aws": {"subnets": []}
+      };
+    }
+    if ($scope.Settings.providers.aws.subnets == null) {
+        $scope.Settings.providers.aws = {"subnets": []}
+    }
+
+    if (!$scope.validSubnet($scope.new_subnet)){
+        $scope.invalidSubnet = "Availability zone and subnet ID are required.";
+        return
+    }
+
+    $scope.Settings.providers.aws.subnets.push($scope.new_subnet);
+    $scope.new_subnet = {};
+    $scope.invalidSubnet = "";
+  }
+
+  $scope.deleteSubnet = function(index){
+    $scope.Settings.providers.aws.subnets.splice(index, 1);
+  }
+
+  $scope.validSubnet = function(subnet){
+    return subnet && subnet.az && subnet.subnetID;
+  }
+
   $scope.clearAllUserTokens = function(){
     if(!confirm("This will log out all users from all existing sessions. Continue?"))
       return

--- a/public/static/js/services/rest.js
+++ b/public/static/js/services/rest.js
@@ -270,6 +270,7 @@ mciServices.rest.factory('mciSpawnRestService', ['mciBaseRestService', function 
         config.data['userdata'] = spawnInfo.userData;
         config.data['is_virtual_workstation'] = spawnInfo.is_virtual_workstation;
         config.data['home_volume_size'] = spawnInfo.home_volume_size;
+        config.data['home_volume_id'] = spawnInfo.home_volume_id;
         config.data['use_task_config'] = spawnInfo.useTaskConfig;
         baseSvc.putResource(resource, [], config, callbacks);
     };
@@ -322,6 +323,10 @@ mciServices.rest.factory('mciSpawnRestService', ['mciBaseRestService', function 
         config.data['host_id'] = hostId;
         config.data['instance_type'] = newInstanceType;
         return baseSvc.postResource(resource, [], config, callbacks);
+    }
+
+    service.getAvailableVolumes = function (callbacks) {
+        baseSvc.getResource(resource, "available_volumes", {}, callbacks);
     }
 
     return service;

--- a/public/static/partials/user_host_details.html
+++ b/public/static/partials/user_host_details.html
@@ -41,7 +41,7 @@
             <div class="entry"ng-show="curHostData.zone">
               <strong>Availability Zone</strong> <span>[[curHostData.zone]]</span>
             </div>
-            <div class="entry" ng-show="curHostData.is_virtual_workstation">
+            <div class="entry" ng-show="curHostData.is_virtual_workstation && curHostData.status == 'running'">
               <strong>IDE</strong> <span> <a href="/host/[[curHostData.id]]/ide/" target="_blank">Open IDE</a> </span>
             </div>
             <div class ="entry" ng-show="curHostData.userdata">

--- a/public/static/partials/user_host_options.html
+++ b/public/static/partials/user_host_options.html
@@ -84,10 +84,36 @@
       </p>
     </div>
     <div style="padding-bottom:5px;" ng-show="selectedDistro.virtual_workstation_allowed">
-      <input type="checkbox" ng-model="$parent.is_virtual_workstation"> Virtual Workstation </input>
-      <div ng-show="$parent.is_virtual_workstation">
-        <label> Volume size (GB) </label>
-        <input type="number" ng-model="$parent.home_volume_size" min="1" max="10000"></input>
+      <input type="checkbox" ng-model="$parent.isVirtualWorkstation"> Virtual Workstation </input>
+      <div ng-show="$parent.isVirtualWorkstation">
+        <div class="dropdown">
+          <button class="btn btn-link btn-dropdown" data-toggle="dropdown">
+            <span class="semi-muted">
+             Volume:
+            </span>
+            <strong>
+              [[ homeVolumeID ? homeVolumeID : "New Volume" ]]
+              <span class="fa fa-caret-down"></span>
+            </strong>
+          </button>
+          <ul class="dropdown-menu" role="menu" aria-labelledby="volumes">
+            <li role="presentation" class="dropdown-header">Home Volume</li>
+            <li role="presentation">
+              <a role="menuitem" ng-click="setVolume()">
+                New Volume
+              </a>
+            </li>
+            <li role="presentation" ng-repeat="volume in $parent.availableVolumes">
+              <a role="menuitem" ng-click="setVolume(volume)">
+                [[ volume.volume_id ]]
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div ng-show="!$parent.homeVolumeID">
+          <label> Volume size (GB) </label>
+          <input type="number" ng-model="$parent.homeVolumeSize" min="1" max="10000"></input>
+        </div>
       </div>
     </div>
     <div id="userData" style="padding-bottom:5px;">

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -109,6 +109,7 @@ func (hc *DBHostConnector) NewIntentHost(ctx context.Context, options *restmodel
 		NoExpiration:         options.NoExpiration,
 		IsVirtualWorkstation: options.IsVirtualWorkstation,
 		HomeVolumeSize:       options.HomeVolumeSize,
+		HomeVolumeID:         options.HomeVolumeID,
 		Region:               options.Region,
 	}
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1378,7 +1378,7 @@ func (a *APIAWSConfig) ToService() (interface{}, error) {
 		}
 		subnet, ok := i.(evergreen.Subnet)
 		if !ok {
-			return nil, errors.New("Unable to convert key to EC2Key")
+			return nil, errors.New("Unable to convert APISubnet to Subnet")
 		}
 		config.Subnets = append(config.Subnets, subnet)
 	}

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -37,6 +37,7 @@ type HostRequestOptions struct {
 	NoExpiration         bool       `json:"no_expiration"`
 	IsVirtualWorkstation bool       `json:"is_virtual_workstation"`
 	HomeVolumeSize       int        `json:"home_volume_size"`
+	HomeVolumeID         string     `json:"home_volume_id"`
 }
 
 type DistroInfo struct {

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1355,7 +1355,7 @@ Admin Settings
 														<input class="control" type="text" ng-model="subnet.az" placeholder="Availability Zone">
 													</md-input-container>
 													<md-input-container class="control" flex=50>
-														<input class="control" type="text" ng-model="subnet.subnetID" placeholder="Subnet ID">
+														<input class="control" type="text" ng-model="subnet.subnet_id" placeholder="Subnet ID">
 													</md-input-container>
 													<div style="margin-top: 1%;">
 														<button class="btn btn-default btn-danger" type="button" style="float: left" ng-click="deleteSubnet(index)">
@@ -1370,7 +1370,7 @@ Admin Settings
 												</md-input-container>
 
 												<md-input-container class="control" flex=50>
-													<input class="control" type="text" ng-model="new_subnet.subnetID" placeholder="Subnet ID">
+													<input class="control" type="text" ng-model="new_subnet.subnet_id" placeholder="Subnet ID">
 												</md-input-container>
 												<div style="margin-top: 1%;">
 													<button class="plus-button btn btn-primary" ng-disabled="!validSubnet(new_subnet)" type="button" style="float: left" ng-click="addSubnet()">

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1296,7 +1296,12 @@ Admin Settings
 									</md-button>
 								</md-card-title>
 								<md-card-content>
-									<md-card style="margin-bottom:20px;">
+									<md-card>
+										<md-card-title>
+											<md-card-title-text>
+												<span>Regions</span>
+											</md-card-title-text>
+										</md-card-title>
 										<md-card-content>
 											<div id="ec2-list" class="form-group" ng-repeat="(index, item) in Settings.providers.aws.ec2_keys">
 												<section layout="row" flex>
@@ -1333,6 +1338,45 @@ Admin Settings
 														<i class="fa fa-plus"></i>
 													</button>
 													<label class="control">[[invalidCredential]]</label>
+												</div>
+											</section>
+										</md-card-content>
+									</md-card>
+									<md-card style="margin-bottom:20px;">
+										<md-card-title>
+											<md-card-title-text>
+												<span>Subnets</span>
+											</md-card-title-text>
+										</md-card-title>
+										<md-card-content>
+											<div id="ec2-list" class="form-group" ng-repeat="(index, subnet) in Settings.providers.aws.subnets">
+												<section layout="row" flex>
+													<md-input-container class="control" flex=25>
+														<input class="control" type="text" ng-model="subnet.az" placeholder="Availability Zone">
+													</md-input-container>
+													<md-input-container class="control" flex=50>
+														<input class="control" type="text" ng-model="subnet.subnetID" placeholder="Subnet ID">
+													</md-input-container>
+													<div style="margin-top: 1%;">
+														<button class="btn btn-default btn-danger" type="button" style="float: left" ng-click="deleteSubnet(index)">
+															<i class="fa fa-trash"></i>
+														</button>
+													</div>
+												</section>
+											</div>
+											<section layout="row" flex>
+												<md-input-container class="control" flex=25>
+													<input class="control" type="text" ng-model="new_subnet.az" placeholder="Availability Zone">
+												</md-input-container>
+
+												<md-input-container class="control" flex=50>
+													<input class="control" type="text" ng-model="new_subnet.subnetID" placeholder="Subnet ID">
+												</md-input-container>
+												<div style="margin-top: 1%;">
+													<button class="plus-button btn btn-primary" ng-disabled="!validSubnet(new_subnet)" type="button" style="float: left" ng-click="addSubnet()">
+														<i class="fa fa-plus"></i>
+													</button>
+													<label class="control">[[ invalidSubnet ]]</label>
 												</div>
 											</section>
 										</md-card-content>

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -916,7 +916,7 @@ Evergreen - Distros
               <input ng-disabled="readOnly" type="checkbox" ng-model="activeDistro.spawn_allowed">
               Allow users to spawn these hosts for personal use.
             </p>
-            <p class="distro-checkbox checkbox" ng-show="activeDistro.spawn_allowed && isLinux() && home_volume_settings.format_command">
+            <p class="distro-checkbox checkbox" ng-show="activeDistro.spawn_allowed && isLinux() && activeDistro.home_volume_settings.format_command">
               <input ng-disabled="readOnly" type="checkbox" ng-model="activeDistro.is_virtual_workstation">
               Allow users to use spawnhosts of this distro as virtual workstations.
             </p>

--- a/service/ui.go
+++ b/service/ui.go
@@ -398,6 +398,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/spawn/distros").Wrap(needsLogin, needsContext).Handler(uis.listSpawnableDistros).Get()
 	app.AddRoute("/spawn/keys").Wrap(needsLogin, needsContext).Handler(uis.getUserPublicKeys).Get()
 	app.AddRoute("/spawn/types").Wrap(needsLogin, needsContext).Handler(uis.getAllowedInstanceTypes).Get()
+	app.AddRoute("/spawn/available_volumes").Wrap(needsLogin).Handler(uis.availableVolumes).Get()
 
 	// User settings
 	app.AddRoute("/settings").Wrap(needsLogin, needsContext).Handler(uis.userSettingsPage).Get()

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -922,8 +922,8 @@ func mountLinuxVolume(ctx context.Context, env evergreen.Environment, h *host.Ho
 
 	cmd.Append(fmt.Sprintf("mkdir -p /%s", evergreen.HomeVolumeDir))
 	cmd.Append(fmt.Sprintf("mount /dev/%s /%s", deviceName, evergreen.HomeVolumeDir))
+	cmd.Append(fmt.Sprintf("chown -R %s:%s /%s", h.User, h.User, evergreen.HomeVolumeDir))
 	cmd.Append(fmt.Sprintf("ln -s /%s %s/%s", evergreen.HomeVolumeDir, h.Distro.HomeDir(), evergreen.HomeVolumeDir))
-	cmd.Append(fmt.Sprintf("chown -R %s:%s %s/%s", h.User, h.User, h.Distro.HomeDir(), evergreen.HomeVolumeDir))
 	if err = cmd.Run(ctx); err != nil {
 		return errors.Wrap(err, "problem running mount commands")
 	}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -840,12 +840,7 @@ func attachVolume(ctx context.Context, env evergreen.Environment, h *host.Host) 
 				return errors.Wrapf(err, "can't get source host for volume '%s'", h.HomeVolumeID)
 			}
 			if sourceHost != nil {
-				if sourceHost.Status != evergreen.HostTerminated {
-					return errors.Errorf("source host '%s' is not terminated", sourceHost.Id)
-				}
-				if err = sourceHost.RemoveVolumeFromHost(h.HomeVolumeID); err != nil {
-					return errors.Wrapf(err, "can't remove volume '%s' from source host '%s'", h.HomeVolumeID)
-				}
+				return errors.Errorf("volume '%s' is already attached to host '%s'", h.HomeVolumeID, sourceHost.Id)
 			}
 		} else {
 			// create the volume

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -835,7 +835,8 @@ func attachVolume(ctx context.Context, env evergreen.Environment, h *host.Host) 
 			if volume == nil {
 				return errors.Errorf("volume '%s' does not exist", h.HomeVolumeID)
 			}
-			sourceHost, err := host.FindHostWithVolume(h.HomeVolumeID)
+			var sourceHost *host.Host
+			sourceHost, err = host.FindHostWithVolume(h.HomeVolumeID)
 			if err != nil {
 				return errors.Wrapf(err, "can't get source host for volume '%s'", h.HomeVolumeID)
 			}


### PR DESCRIPTION
<img width="641" alt="Screen Shot 2020-03-12 at 3 59 41 PM" src="https://user-images.githubusercontent.com/17027265/76562006-d7f27400-647a-11ea-9e30-4edba5eba0ee.png">

Automate migrating volumes between spawnhosts. Allow a user to select a volume to mount on the new spawnhost from a list of volumes that they've created and that aren't currently mounted on an instance.

- Set the AZ (by way of its subnet id) of a new spawn host to match the AZ of the volume we want to mount on it (because volumes need to be in the same AZ as the instance you want to mount it to)
- Add a map of `AZ -> subnet id` to the admin page so we don't need to keep asking AWS for the subnet ids in Fleet and when mounting an instance. This will save many API calls.
- Don't run the format command if the volume has already been formatted