### PR TITLE
EVG-7563 temporary shim for gqlgen

### DIFF
--- a/makefile
+++ b/makefile
@@ -450,6 +450,9 @@ clean:
 	rm -rf $(lintDeps) $(buildDir)/test.* $(buildDir)/output.* $(clientBuildDir) $(tmpDir)
 	rm -rf $(gopath)/pkg/
 phony += clean
+
+gqlgen:
+	go run vendor/github.com/99designs/gqlgen/main.go
 # end dependency targets
 
 

--- a/vendor/github.com/99designs/gqlgen/codegen/generated!.gotpl
+++ b/vendor/github.com/99designs/gqlgen/codegen/generated!.gotpl
@@ -8,7 +8,7 @@
 {{ reserveImport "errors"  }}
 {{ reserveImport "bytes"  }}
 
-{{ reserveImport "github.com/vektah/gqlparser/v2" }}
+{{ reserveImport "github.com/vektah/gqlparser/v2" "gqlparser" }}
 {{ reserveImport "github.com/vektah/gqlparser/v2/ast" }}
 {{ reserveImport "github.com/99designs/gqlgen/graphql" }}
 {{ reserveImport "github.com/99designs/gqlgen/graphql/introspection" }}


### PR DESCRIPTION
I believe the gqlgen library introduced a bug for repos that don't use gomod, so I'll submit an issue to them once I get a minimal repro. In the meantime this should work around the problem, you'll need to run it by typing "make gqlgen"