### PR TITLE
EVG-7577: log when static host status is changed by the system

### DIFF
--- a/model/host/static_hosts.go
+++ b/model/host/static_hosts.go
@@ -2,18 +2,19 @@ package host
 
 import (
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// DecommissionInactiveStaticHosts marks static hosts
-// in the database as terminated provided their ids aren't contained in the
-// passed in activeStaticHosts slice. This is called in the scheduler,
-// and marks any static host in the system that was removed from the
-// distro as "terminated".
+// MarkInactiveStaticHosts marks static hosts in the database as terminated
+// provided their ids aren't contained in the passed in activeStaticHosts slice.
+// This is called in the scheduler, and marks any static host in the system that
+// was removed from the distro as "terminated".
 //
 // Previously this oepration marked these hosts as "decommissioned,"
 // which is not a state that makes sense for static hosts.
@@ -30,16 +31,17 @@ func MarkInactiveStaticHosts(activeStaticHosts []string, distroID string) error 
 		query[bsonutil.GetDottedKeyName(DistroKey, distro.IdKey)] = distroID
 	}
 
-	err := UpdateAll(
-		query,
-		bson.M{
-			"$set": bson.M{
-				StatusKey: evergreen.HostTerminated,
-			},
-		},
-	)
+	toTerminate, err := Find(db.Query(query))
 	if adb.ResultsNotFound(err) {
 		return nil
 	}
-	return errors.Wrap(err, "could not terminate static hosts")
+	if err != nil {
+		return errors.Wrap(err, "could not get hosts to be terminated")
+	}
+	catcher := grip.NewBasicCatcher()
+	for _, h := range toTerminate {
+		catcher.Wrapf(h.SetStatus(evergreen.HostTerminated, evergreen.User, "static host removed from distro"), "could not terminate host '%s'", h.Id)
+	}
+
+	return errors.Wrap(catcher.Resolve(), "could not terminate static hosts")
 }

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
@@ -155,6 +156,9 @@ func doStaticHostUpdate(d distro.Distro) ([]string, error) {
 				staticHost.Status = evergreen.HostRunning
 			} else {
 				staticHost.Status = evergreen.HostProvisioning
+			}
+			if dbHost != nil {
+				event.LogHostStatusChanged(dbHost.Id, dbHost.Status, staticHost.Status, evergreen.User, "host status changed by host allocator")
 			}
 		} else {
 			staticHost.Status = dbHost.Status


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7577

The host allocator updates the static host status every 15 seconds, which can be confusing if you manually update the status in the UI but then its status changes invisibly after the host allocator runs. This change is mostly to track when the host allocator does such a change.