### PR TITLE
EVG-7467 generalize copy project vars route

### DIFF
--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -154,16 +154,15 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 	)
 }
 
-func (projectVars *ProjectVars) RedactedOnly() *ProjectVars {
+func (projectVars *ProjectVars) PublicVarsOnly() *ProjectVars {
 	res := ProjectVars{
 		Id:          projectVars.Id,
 		Vars:        map[string]string{},
 		PrivateVars: map[string]bool{},
 	}
 	for name, isPrivate := range projectVars.PrivateVars {
-		if val, ok := projectVars.Vars[name]; ok && isPrivate {
+		if val, ok := projectVars.Vars[name]; ok && !isPrivate {
 			res.Vars[name] = val
-			res.PrivateVars[name] = true
 		}
 	}
 	return &res

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -115,27 +115,6 @@ func TestRedactPrivateVars(t *testing.T) {
 	assert.NotEqual("", projectVars.Vars["a"], "original vars should not be modified")
 }
 
-func TestRedactedOnly(t *testing.T) {
-	assert := assert.New(t)
-
-	vars := map[string]string{
-		"a": "a",
-		"b": "b",
-	}
-	privateVars := map[string]bool{
-		"a": true,
-	}
-	projectVars := &ProjectVars{
-		Id:          "mongodb",
-		Vars:        vars,
-		PrivateVars: privateVars,
-	}
-	newVars := projectVars.RedactedOnly()
-	assert.Equal("a", newVars.Vars["a"])
-	assert.Equal("", newVars.Vars["b"], "shouldn't return un-redacted variables")
-	assert.NotEqual("", projectVars.Vars["b"], "original vars should not be modified")
-}
-
 func TestAWSVars(t *testing.T) {
 	require := require.New(t)
 	require.NoError(db.ClearCollections(ProjectVarsCollection))

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -73,11 +73,12 @@ type Connector interface {
 	// RestartBuild is a method to restart the build matching the same BuildId.
 	RestartBuild(string, string) error
 
-	// Find project variables matching given projectId. If bool is set, returns only redacted values.
+	// Find project variables matching given projectId. If bool is set, also return private variables.
 	FindProjectVarsById(string, bool) (*restModel.APIProjectVars, error)
-	// UpdateProjectVars updates the project using the variables given in the model.ggg
+	// UpdateProjectVars updates the project using the variables given
+	// in the model (removing old variables if overwrite is set).
 	// If successful, updates the given projectVars with the updated projectVars.
-	UpdateProjectVars(string, *restModel.APIProjectVars) error
+	UpdateProjectVars(string, *restModel.APIProjectVars, bool) error
 	// CopyProjectVars copies the variables for the first project to the second
 	CopyProjectVars(string, string) error
 

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -357,18 +357,20 @@ func (s *ProjectConnectorGetSuite) TestGetProjectSettingsEventNoRepo() {
 }
 
 func (s *ProjectConnectorGetSuite) TestFindProjectVarsById() {
-	res, err := s.ctx.FindProjectVarsById(projectId, false)
+	// redact private variables
+	res, err := s.ctx.FindProjectVarsById(projectId, true)
 	s.NoError(err)
 	s.Require().NotNil(res)
 	s.Equal("1", res.Vars["a"])
 	s.Equal("", res.Vars["b"])
 	s.True(res.PrivateVars["b"])
 
-	res, err = s.ctx.FindProjectVarsById(projectId, true)
+	// not redacted
+	res, err = s.ctx.FindProjectVarsById(projectId, false)
 	s.NoError(err)
 	s.Require().NotNil(res)
+	s.Equal("1", res.Vars["a"])
 	s.Equal("3", res.Vars["b"])
-	s.Equal("", res.Vars["a"]) // not returned bc not private
 }
 
 func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
@@ -379,7 +381,7 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 		PrivateVars:  map[string]bool{"b": false, "c": true},
 		VarsToDelete: varsToDelete,
 	}
-	s.NoError(s.ctx.UpdateProjectVars(projectId, &newVars))
+	s.NoError(s.ctx.UpdateProjectVars(projectId, &newVars, false))
 	s.Equal(newVars.Vars["b"], "") // can't unredact previously redacted  variables
 	s.Equal(newVars.Vars["c"], "")
 	_, ok := newVars.Vars["a"]
@@ -391,7 +393,7 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 	s.False(ok)
 
 	// successful upsert
-	s.NoError(s.ctx.UpdateProjectVars("not-an-id", &newVars))
+	s.NoError(s.ctx.UpdateProjectVars("not-an-id", &newVars, false))
 }
 
 func (s *ProjectConnectorGetSuite) TestCopyProjectVars() {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -393,7 +393,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	if err = h.sc.UpdateProject(dbProjectRef); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for update() by project id '%s'", h.projectID))
 	}
-	if err = h.sc.UpdateProjectVars(h.projectID, &apiProjectRef.Variables); err != nil { // destructively modifies apiProjectRef.Variables
+	if err = h.sc.UpdateProjectVars(h.projectID, &apiProjectRef.Variables, false); err != nil { // destructively modifies apiProjectRef.Variables
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error updating variables for project '%s'", h.projectID))
 	}
 	if err = h.sc.UpdateProjectAliases(h.projectID, apiProjectRef.Aliases); err != nil {
@@ -585,7 +585,7 @@ func (h *projectIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	variables, err := h.sc.FindProjectVarsById(h.projectID, false)
+	variables, err := h.sc.FindProjectVarsById(h.projectID, true)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -123,7 +123,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}").Version(2).Patch().Wrap(checkUser, addProject, checkProjectAdmin, editProjectSettings).RouteHandler(makePatchProjectByID(sc, env.Settings()))
 	app.AddRoute("/projects/{project_id}").Version(2).Put().Wrap(createProject).RouteHandler(makePutProjectByID(sc))
 	app.AddRoute("/projects/{project_id}/copy").Version(2).Post().Wrap(checkUser, addProject, createProject, checkProjectAdmin, editProjectSettings).RouteHandler(makeCopyProject(sc))
-	app.AddRoute("/projects/{project_id}/copy_redacted_variables").Version(2).Post().Wrap(checkUser, addProject, checkProjectAdmin, editProjectSettings).RouteHandler(makeCopyRedactedVars(sc))
+	app.AddRoute("/projects/{project_id}/copy/variables").Version(2).Post().Wrap(checkUser, addProject, checkProjectAdmin, editProjectSettings).RouteHandler(makeCopyVariables(sc))
 	app.AddRoute("/projects/{project_id}/events").Version(2).Get().Wrap(checkUser, addProject, checkProjectAdmin, viewProjectSettings).RouteHandler(makeFetchProjectEvents(sc))
 	app.AddRoute("/projects/{project_id}/patches").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makePatchesByProjectRoute(sc))
 	app.AddRoute("/projects/{project_id}/recent_versions").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchProjectVersions(sc))


### PR DESCRIPTION
Originally when I made this route, cloud had very specific requests. Now doing what I should have done, which was make a more generalized/customizable route. Changes include:
1) Copy public variables (only copy private if indicated)
2) Allow users to fully overwrite the source project variables (i.e. delete variables projectB has that projectA did not)
3) Dry run returns what would be copied as is more conventional, not what will be overwritten (if users want that level of information they can use more API calls). This still redacts private variables.