### PR TITLE
EVG-7438 dequeue item if patch is nil

### DIFF
--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2548,7 +2548,7 @@
       "result": {
         "errors": [
           {
-            "message": "Unable to remove commit queue item for project exec2, version version: can't get commit queue for id 'logkeeper': document not found",
+            "message": "Unable to remove commit queue item for project exec2, version version: no commit queue found for 'logkeeper'",
             "path": ["abortTask"],
             "extensions": { "code": "INTERNAL_SERVER_ERROR" }
           }

--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -215,6 +215,9 @@ func RemoveCommitQueueItem(projectId, patchType, item string, versionExists bool
 	if err != nil {
 		return false, errors.Wrapf(err, "can't get commit queue for id '%s'", projectId)
 	}
+	if cq == nil {
+		return false, errors.Errorf("no commit queue found for '%s'", projectId)
+	}
 
 	head, valid := cq.Next()
 	if !valid {

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/testutil"
 	_ "github.com/evergreen-ci/evergreen/testutil"
-	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip/send"
 	"github.com/stretchr/testify/suite"
 )
@@ -252,13 +251,13 @@ func (s *CommitQueueSuite) TestFindOneId() {
 	cq := &CommitQueue{ProjectID: "mci"}
 	s.NoError(InsertQueue(cq))
 
-	_, err := FindOneId("mci")
+	cq, err := FindOneId("mci")
 	s.NoError(err)
 	s.Equal("mci", cq.ProjectID)
 
-	_, err = FindOneId("not_here")
-	s.Error(err)
-	s.True(adb.ResultsNotFound(err))
+	cq, err = FindOneId("not_here")
+	s.NoError(err)
+	s.Nil(cq)
 }
 
 func (s *CommitQueueSuite) TestSetupEnv() {

--- a/model/commitqueue/db.go
+++ b/model/commitqueue/db.go
@@ -47,7 +47,12 @@ func FindOneId(id string) (*CommitQueue, error) {
 func findOne(query db.Q) (*CommitQueue, error) {
 	queue := &CommitQueue{}
 	err := db.FindOneQ(Collection, query, queue)
-
+	if adb.ResultsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "error finding queue by id")
+	}
 	return queue, err
 }
 

--- a/model/commitqueue/github_pr_sender.go
+++ b/model/commitqueue/github_pr_sender.go
@@ -171,6 +171,9 @@ func dequeueFromCommitQueue(projectID string, item string) error {
 	if err != nil {
 		return errors.Wrapf(err, "can't find commit queue for '%s'", projectID)
 	}
+	if cq == nil {
+		return errors.Errorf("no commit queue found for '%s'", projectID)
+	}
 	found, err := cq.Remove(item)
 	if err != nil {
 		return errors.Wrapf(err, "can't dequeue '%s' from commit queue", item)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -496,7 +496,7 @@ func RetryCommitQueueItems(projectID string, patchType string, opts RestartOptio
 		return nil, nil, errors.Wrapf(err, "error finding commit queue '%s'", projectID)
 	}
 	if cq == nil {
-		return nil, nil, errors.New("commit queue '%s' not found")
+		return nil, nil, errors.Errorf("commit queue '%s' not found", projectID)
 	}
 
 	// don't requeue items, just return what would be requeued

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -567,6 +567,9 @@ func TryDequeueAndAbortCommitQueueVersion(projectRef *ProjectRef, versionId, req
 	if err != nil {
 		return errors.Wrapf(err, "can't get commit queue for id '%s'", projectRef.Identifier)
 	}
+	if cq == nil {
+		return errors.Errorf("no commit queue found for '%s'", projectRef.Identifier)
+	}
 	issue := p.Id.Hex()
 	if p.IsPRMergePatch() {
 		issue = strconv.Itoa(p.GithubPatchData.PRNumber)

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -245,7 +245,7 @@ func listCLICommitQueueItem(item restModel.APICommitQueueItem, ac *legacyClient,
 	issue := restModel.FromStringPtr(item.Issue)
 	p, err := ac.GetPatch(issue)
 	if err != nil {
-		grip.Error(message.WrapErrorf(err, "\terror getting patch for issue '%s'", issue))
+		grip.Errorf("Error getting patch for issue '%s': %v", issue, err.Error())
 		return
 	}
 

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -245,7 +245,7 @@ func listCLICommitQueueItem(item restModel.APICommitQueueItem, ac *legacyClient,
 	issue := restModel.FromStringPtr(item.Issue)
 	p, err := ac.GetPatch(issue)
 	if err != nil {
-		grip.Errorf("Error getting patch for issue '%s': %v", issue, err.Error())
+		grip.Errorf("Error getting patch for issue '%s': %s", issue, err.Error())
 		return
 	}
 

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -143,7 +143,7 @@ func (s *CommitQueueSuite) TestListContentsForCLI() {
 }
 
 func (s *CommitQueueSuite) TestListContentsMissingPatch() {
-	s.Require().NoError(db.ClearCollections(commitqueue.Collection, model.ProjectRefCollection))
+	s.Require().NoError(db.ClearCollections(commitqueue.Collection, model.ProjectRefCollection, patch.Collection))
 	p1 := patch.Patch{
 		Id:          bson.NewObjectId(),
 		Project:     "mci",

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -42,6 +42,9 @@ func (pc *DBCommitQueueConnector) EnqueueItem(projectID string, item restModel.A
 	if err != nil {
 		return 0, errors.Wrapf(err, "can't query for queue id '%s'", projectID)
 	}
+	if q == nil {
+		return 0, errors.Errorf("no commit queue found for '%s'", projectID)
+	}
 
 	itemInterface, err := item.ToService()
 	if err != nil {
@@ -70,6 +73,9 @@ func (pc *DBCommitQueueConnector) FindCommitQueueByID(id string) (*restModel.API
 	cqService, err := commitqueue.FindOneId(id)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't get commit queue from database")
+	}
+	if cqService == nil {
+		return nil, errors.Errorf("no commit queue found for '%s'", id)
 	}
 
 	apiCommitQueue := &restModel.APICommitQueue{}
@@ -104,6 +110,9 @@ func (pc *DBCommitQueueConnector) IsItemOnCommitQueue(id, item string) (bool, er
 	cq, err := commitqueue.FindOneId(id)
 	if err != nil {
 		return false, errors.Wrapf(err, "can't get commit queue for id '%s'", id)
+	}
+	if cq == nil {
+		return false, errors.Errorf("no commit queue found for '%s'", id)
 	}
 
 	pos := cq.FindItem(item)

--- a/service/project.go
+++ b/service/project.go
@@ -389,8 +389,8 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			uis.LoggedError(w, r, http.StatusBadRequest, errors.New("cannot enable commit queue without patch definitions"))
 			return
 		}
-
-		cq, err := commitqueue.FindOneId(responseRef.Identifier)
+		var cq *commitqueue.CommitQueue
+		cq, err = commitqueue.FindOneId(responseRef.Identifier)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -240,6 +240,11 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 		j.dequeue(cq, nextItem)
 		return
 	}
+	if patchDoc == nil {
+		j.logError(err, "patch not found", nextItem)
+		j.dequeue(cq, nextItem)
+		return
+	}
 
 	patch, patchSummaries, projectConfig, err := getPatchInfo(ctx, githubToken, patchDoc)
 	if err != nil {
@@ -330,6 +335,11 @@ func (j *commitQueueJob) processCLIPatchItem(ctx context.Context, cq *commitqueu
 	patchDoc, err := patch.FindOne(patch.ById(patch.NewId(nextItem.Issue)))
 	if err != nil {
 		j.logError(err, "can't find patch", nextItem)
+		j.dequeue(cq, nextItem)
+		return
+	}
+	if patchDoc == nil {
+		j.logError(err, "patch not found", nextItem)
 		j.dequeue(cq, nextItem)
 		return
 	}


### PR DESCRIPTION
When processing a commit queue item, we need to check that the patch isn't nil so we don't panic.