### PR TITLE
EVG-7101 correctly order trend graphs for patches

### DIFF
--- a/public/static/app/perf/TrendSamples.js
+++ b/public/static/app/perf/TrendSamples.js
@@ -76,7 +76,6 @@ mciModule.factory('TrendSamples', function () {
     metricsSet.clear()
 
     for (let key in this.seriesByName) {
-      this.seriesByName[key] = _.sortBy(this.seriesByName[key], 'order');
       this.testNames.unshift(key);
     }
 

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -795,6 +795,7 @@ $http.get(templateUrl).success(function(template) {
     if (cedar && cedar.length) {
       scope.trendResults = scope.trendResults.concat(cedar);
     }
+    scope.trendResults = _.sortBy(scope.trendResults, (result) => Date.parse(result.create_time));
     let rejects = scope.outliers ? scope.outliers.rejects : [];
 
     scope.allTrendSamples = new TrendSamples(scope.trendResults);

--- a/public/static/app/perf/perf.test.js
+++ b/public/static/app/perf/perf.test.js
@@ -1630,8 +1630,8 @@ describe('trendDataComplete', () => {
       expect(scope.filteredTrendSamples).toEqual(jasmine.anything(TrendSamples));
       expect(scope.allTrendSamples).not.toBe(scope.filteredTrendSamples);
       expect(scope.filteredTrendSamples.samples.length).toBe(2);
-      expect(scope.filteredTrendSamples.samples[0].task_id).toBe('mongohouse_archlinux_latency_benchmark_patch_63a5a59830a1e0a8614b12cbff62cca065bfcad5_5d6ff50257e85a69060aa156_19_09_04_17_31_51');
-      expect(scope.filteredTrendSamples.samples[1].task_id).toBe('sys_perf_linux_1_node_15gbwtcache_out_of_cache_scanner_20ba91db04c0b7b3d10fe2527b6938b1a14fcaa6_19_08_12_20_24_04');
+      expect(scope.filteredTrendSamples.samples[0].task_id).toBe('sys_perf_linux_1_node_15gbwtcache_out_of_cache_scanner_20ba91db04c0b7b3d10fe2527b6938b1a14fcaa6_19_08_12_20_24_04');
+      expect(scope.filteredTrendSamples.samples[1].task_id).toBe('mongohouse_archlinux_latency_benchmark_patch_63a5a59830a1e0a8614b12cbff62cca065bfcad5_5d6ff50257e85a69060aa156_19_09_04_17_31_51');
       expect(scope.metricSelect.options).toEqual([{
         "key": "threadLevel",
         "name": "threadLevel"


### PR DESCRIPTION
Previously we were sorting by commit order in the structure that stores trend data. For patches, commit order is a number that is the patch # for the user (we use the same field as commits) so it sorts nonsensically. This fixes the sorting.

There is still the lingering issue of patches being mislabeled (for example https://evergreen.mongodb.com/task/sys_perf_linux_standalone_audit_industry_benchmarks_patch_58abcf6577982367232a6c76d1ee277a4031ed3c_5dead5740ae6060c325daab9_19_12_06_22_26_35##%257B%2522compare%2522%253A%255B%257B%2522hash%2522%253A%252258abcf6577982367232a6c76d1ee277a4031ed3c%2522%257D%255D%257D shows on the trend graph with the metadata from its base commit) but that is due to the data being stored ambiguously