### PR TITLE
EVG-7585: allow distro aliases in project config

### DIFF
--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -48,7 +48,7 @@ func CheckDistro(ctx context.Context, d *distro.Distro, s *evergreen.Settings, n
 	distroIds := []string{}
 	var err error
 	if newDistro || len(d.Aliases) > 0 {
-		distroIds, err = getDistroIds()
+		distroIds, _, err = getDistroIds()
 		if err != nil {
 			return nil, err
 		}
@@ -57,7 +57,7 @@ func CheckDistro(ctx context.Context, d *distro.Distro, s *evergreen.Settings, n
 		validationErrs = append(validationErrs, ensureUniqueId(d, distroIds)...)
 	}
 	if len(d.Aliases) > 0 {
-		validationErrs = append(validationErrs, ensureValidAliases(d, distroIds)...)
+		validationErrs = append(validationErrs, ensureValidAliases(d)...)
 	}
 
 	for _, v := range distroSyntaxValidators {
@@ -207,7 +207,7 @@ func ensureUniqueId(d *distro.Distro, distroIds []string) ValidationErrors {
 	return nil
 }
 
-func ensureValidAliases(d *distro.Distro, distroIDs []string) ValidationErrors {
+func ensureValidAliases(d *distro.Distro) ValidationErrors {
 	errs := ValidationErrors{}
 
 	for _, a := range d.Aliases {

--- a/validator/distro_validator_test.go
+++ b/validator/distro_validator_test.go
@@ -148,7 +148,6 @@ func TestCheckDistro(t *testing.T) {
 }
 
 func TestEnsureUniqueId(t *testing.T) {
-
 	Convey("When validating a distros' ids...", t, func() {
 		distroIds := []string{"a", "b", "c"}
 		Convey("if a distro has a duplicate id, an error should be returned", func() {
@@ -164,12 +163,10 @@ func TestEnsureUniqueId(t *testing.T) {
 }
 
 func TestEnsureValidAliases(t *testing.T) {
-
 	Convey("When validating a distros' aliases...", t, func() {
 		d := distro.Distro{Id: "c", Aliases: []string{"c"}}
-		distroIds := []string{"a", "b", "c"}
 		Convey("if a distro is declared as an alias of itself, an error should be returned", func() {
-			vErrors := ensureValidAliases(&d, distroIds)
+			vErrors := ensureValidAliases(&d)
 			So(vErrors, ShouldNotResemble, ValidationErrors{})
 			So(len(vErrors), ShouldEqual, 1)
 			So(vErrors[0].Message, ShouldEqual, "'c' cannot be an distro alias of itself")


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7585

This prevents errors about nonexistent distros when doing `evergreen validate` on a config which uses a distro alias (which is important since I'm in the process of deleting distros and aliasing them).