### PR TITLE
EVG-7376 disambiguate modules

### DIFF
--- a/model/manifest/db.go
+++ b/model/manifest/db.go
@@ -17,7 +17,7 @@ var (
 	ProjectNameKey      = bsonutil.MustHaveTag(Manifest{}, "ProjectName")
 	ModulesKey          = bsonutil.MustHaveTag(Manifest{}, "Modules")
 	ManifestBranchKey   = bsonutil.MustHaveTag(Manifest{}, "Branch")
-	IsBaseKey           = bsonutil.MustHaveTag(Manifest{}, "IsBase")
+	NotBaseKey          = bsonutil.MustHaveTag(Manifest{}, "NotBase")
 	ModuleBranchKey     = bsonutil.MustHaveTag(Module{}, "Branch")
 	ModuleRevisionKey   = bsonutil.MustHaveTag(Module{}, "Revision")
 	OwnerKey            = bsonutil.MustHaveTag(Module{}, "Owner")
@@ -54,14 +54,7 @@ func ByBaseProjectAndRevision(project, revision string) db.Q {
 	return db.Query(bson.M{
 		ProjectNameKey:      project,
 		ManifestRevisionKey: revision,
-		IsBaseKey:           true,
-	})
-}
-
-func ByProjectAndRevision(project, revision string) db.Q {
-	return db.Query(bson.M{
-		ProjectNameKey:      project,
-		ManifestRevisionKey: revision,
+		NotBaseKey:          bson.M{"$ne": true},
 	})
 }
 
@@ -81,14 +74,7 @@ func FindFromVersion(versionID, project, revision, requester string) (*Manifest,
 		return nil, errors.Wrap(err, "error finding manifest")
 	}
 	if manifest == nil {
-		// check for a legacy manifest
-		manifest, err = FindOne(ByProjectAndRevision(project, revision))
-		if err != nil {
-			return nil, errors.Wrap(err, "error finding manifest")
-		}
-		if manifest == nil {
-			return nil, nil
-		}
+		return nil, nil
 	}
 
 	if evergreen.IsPatchRequester(requester) {

--- a/model/manifest/manifest.go
+++ b/model/manifest/manifest.go
@@ -14,6 +14,7 @@ type Manifest struct {
 	ProjectName     string             `json:"project" bson:"project"`
 	Branch          string             `json:"branch" bson:"branch"`
 	Modules         map[string]*Module `json:"modules" bson:"modules"`
+	IsBase          bool               `json:"is_base" bson:"is_base"`
 	ModuleOverrides map[string]string  `json:"module_overrides,omitempty" bson:"-"`
 }
 

--- a/model/manifest/manifest.go
+++ b/model/manifest/manifest.go
@@ -14,7 +14,7 @@ type Manifest struct {
 	ProjectName     string             `json:"project" bson:"project"`
 	Branch          string             `json:"branch" bson:"branch"`
 	Modules         map[string]*Module `json:"modules" bson:"modules"`
-	NotBase         bool               `json:"not_base" bson:"not_base"`
+	IsBase          bool               `json:"is_base" bson:"is_base"`
 	ModuleOverrides map[string]string  `json:"module_overrides,omitempty" bson:"-"`
 }
 

--- a/model/manifest/manifest.go
+++ b/model/manifest/manifest.go
@@ -14,7 +14,7 @@ type Manifest struct {
 	ProjectName     string             `json:"project" bson:"project"`
 	Branch          string             `json:"branch" bson:"branch"`
 	Modules         map[string]*Module `json:"modules" bson:"modules"`
-	IsBase          bool               `json:"is_base" bson:"is_base"`
+	NotBase         bool               `json:"not_base" bson:"not_base"`
 	ModuleOverrides map[string]string  `json:"module_overrides,omitempty" bson:"-"`
 }
 

--- a/model/manifest/manifest_test.go
+++ b/model/manifest/manifest_test.go
@@ -23,13 +23,13 @@ func TestFindFromVersion(t *testing.T) {
 			ProjectName: projectName,
 			Revision:    revision,
 			Modules:     map[string]*Module{moduleName: &Module{}},
+			IsBase:      true,
 		},
 		{
 			Id:          "m2",
 			ProjectName: projectName,
 			Revision:    revision,
 			Modules:     map[string]*Module{moduleName: &Module{}},
-			NotBase:     true,
 		},
 	}
 	for _, mfest := range mfests {
@@ -60,6 +60,21 @@ func TestFindFromVersion(t *testing.T) {
 	assert.Equal(t, "m1", mfest.Id)
 }
 
+func TestByProjectAndRevision(t *testing.T) {
+	require.NoError(t, db.Clear(Collection))
+	mfest := &Manifest{
+		Id:          "m1",
+		ProjectName: "evergreen",
+		Revision:    "abcdef",
+	}
+	_, err := mfest.TryInsert()
+	require.NoError(t, err)
+
+	mfest, err = FindOne(ByProjectAndRevision("evergreen", "abcdef"))
+	assert.NoError(t, err)
+	assert.Equal(t, "m1", mfest.Id)
+}
+
 func TestByBaseProjectAndRevision(t *testing.T) {
 	require.NoError(t, db.Clear(Collection))
 	mfests := []Manifest{
@@ -67,12 +82,12 @@ func TestByBaseProjectAndRevision(t *testing.T) {
 			Id:          "m1",
 			ProjectName: "evergreen",
 			Revision:    "abcdef",
+			IsBase:      true,
 		},
 		{
 			Id:          "m2",
 			ProjectName: "evergreen",
 			Revision:    "abcdef",
-			NotBase:     true,
 		},
 	}
 	for _, mfest := range mfests {

--- a/model/manifest/manifest_test.go
+++ b/model/manifest/manifest_test.go
@@ -23,13 +23,13 @@ func TestFindFromVersion(t *testing.T) {
 			ProjectName: projectName,
 			Revision:    revision,
 			Modules:     map[string]*Module{moduleName: &Module{}},
-			IsBase:      true,
 		},
 		{
 			Id:          "m2",
 			ProjectName: projectName,
 			Revision:    revision,
 			Modules:     map[string]*Module{moduleName: &Module{}},
+			NotBase:     true,
 		},
 	}
 	for _, mfest := range mfests {
@@ -60,21 +60,6 @@ func TestFindFromVersion(t *testing.T) {
 	assert.Equal(t, "m1", mfest.Id)
 }
 
-func TestByProjectAndRevision(t *testing.T) {
-	require.NoError(t, db.Clear(Collection))
-	mfest := &Manifest{
-		Id:          "m1",
-		ProjectName: "evergreen",
-		Revision:    "abcdef",
-	}
-	_, err := mfest.TryInsert()
-	require.NoError(t, err)
-
-	mfest, err = FindOne(ByProjectAndRevision("evergreen", "abcdef"))
-	assert.NoError(t, err)
-	assert.Equal(t, "m1", mfest.Id)
-}
-
 func TestByBaseProjectAndRevision(t *testing.T) {
 	require.NoError(t, db.Clear(Collection))
 	mfests := []Manifest{
@@ -82,12 +67,12 @@ func TestByBaseProjectAndRevision(t *testing.T) {
 			Id:          "m1",
 			ProjectName: "evergreen",
 			Revision:    "abcdef",
-			IsBase:      true,
 		},
 		{
 			Id:          "m2",
 			ProjectName: "evergreen",
 			Revision:    "abcdef",
+			NotBase:     true,
 		},
 	}
 	for _, mfest := range mfests {

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -132,7 +132,7 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 		var err error
 		commits, commitPage, err = thirdparty.GetGithubCommits(ctx,
 			gRepoPoller.OauthToken, gRepoPoller.ProjectRef.Owner,
-			gRepoPoller.ProjectRef.Repo, gRepoPoller.ProjectRef.Branch, commitPage)
+			gRepoPoller.ProjectRef.Repo, gRepoPoller.ProjectRef.Branch, time.Time{}, commitPage)
 		if err != nil {
 			return nil, err
 		}
@@ -252,7 +252,7 @@ func (gRepoPoller *GithubRepositoryPoller) GetRecentRevisions(maxRevisions int) 
 		repoCommits, commitPage, err = thirdparty.GetGithubCommits(ctx,
 			gRepoPoller.OauthToken, gRepoPoller.ProjectRef.Owner,
 			gRepoPoller.ProjectRef.Repo, gRepoPoller.ProjectRef.Branch,
-			commitPage)
+			time.Time{}, commitPage)
 		if err != nil {
 			return nil, err
 		}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -529,7 +529,7 @@ func CreateManifest(v model.Version, proj *model.Project, projectRef *model.Proj
 		Revision:    v.Revision,
 		ProjectName: v.Identifier,
 		Branch:      projectRef.Branch,
-		IsBase:      v.Requester == evergreen.RepotrackerVersionRequester,
+		NotBase:     v.Requester != evergreen.RepotrackerVersionRequester,
 	}
 	token, err := settings.GetGithubOauthToken()
 	if err != nil {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -545,7 +545,8 @@ func CreateManifest(v model.Version, proj *model.Project, projectRef *model.Proj
 		var sha, url string
 		owner, repo := module.GetRepoOwnerAndName()
 		if module.Ref == "" {
-			commit, err := thirdparty.GetCommitEvent(ctx, token, projectRef.Owner, projectRef.Repo, v.Revision)
+			var commit *github.RepositoryCommit
+			commit, err = thirdparty.GetCommitEvent(ctx, token, projectRef.Owner, projectRef.Repo, v.Revision)
 			if err != nil {
 				return nil, errors.Wrapf(err, "can't get commit '%s' on '%s/%s'", v.Revision, projectRef.Owner, projectRef.Repo)
 			}
@@ -553,7 +554,8 @@ func CreateManifest(v model.Version, proj *model.Project, projectRef *model.Proj
 				return nil, errors.New("malformed GitHub commit response")
 			}
 			revisionTime := commit.Commit.Committer.GetDate()
-			branchCommits, _, err := thirdparty.GetGithubCommits(ctx, token, owner, repo, module.Branch, revisionTime, 0)
+			var branchCommits []*github.RepositoryCommit
+			branchCommits, _, err = thirdparty.GetGithubCommits(ctx, token, owner, repo, module.Branch, revisionTime, 0)
 			if err != nil {
 				return nil, errors.Wrapf(err, "problem retrieving getting git branch for module %s", module.Name)
 			}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -342,7 +342,7 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 			}))
 			continue
 		}
-		_, err = CreateManifest(*v, project, ref.Branch, repoTracker.Settings)
+		_, err = CreateManifest(*v, project, ref, repoTracker.Settings)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error creating manifest",
@@ -520,7 +520,7 @@ func makeBuildBreakSubscriber(userID string) (*event.Subscriber, error) {
 	return subscriber, nil
 }
 
-func CreateManifest(v model.Version, proj *model.Project, branch string, settings *evergreen.Settings) (*manifest.Manifest, error) {
+func CreateManifest(v model.Version, proj *model.Project, projectRef *model.ProjectRef, settings *evergreen.Settings) (*manifest.Manifest, error) {
 	if len(proj.Modules) == 0 {
 		return nil, nil
 	}
@@ -528,7 +528,8 @@ func CreateManifest(v model.Version, proj *model.Project, branch string, setting
 		Id:          v.Id,
 		Revision:    v.Revision,
 		ProjectName: v.Identifier,
-		Branch:      branch,
+		Branch:      projectRef.Branch,
+		IsBase:      v.Requester == evergreen.RepotrackerVersionRequester,
 	}
 	token, err := settings.GetGithubOauthToken()
 	if err != nil {
@@ -544,13 +545,21 @@ func CreateManifest(v model.Version, proj *model.Project, branch string, setting
 		var sha, url string
 		owner, repo := module.GetRepoOwnerAndName()
 		if module.Ref == "" {
-			gitBranch, err = thirdparty.GetBranchEvent(ctx, token, owner, repo, module.Branch)
+			commit, err := thirdparty.GetCommitEvent(ctx, token, projectRef.Owner, projectRef.Repo, v.Revision)
+			if err != nil {
+				return nil, errors.Wrapf(err, "can't get commit '%s' on '%s/%s'", v.Revision, projectRef.Owner, projectRef.Repo)
+			}
+			if commit == nil || commit.Commit == nil || commit.Commit.Committer == nil {
+				return nil, errors.New("malformed GitHub commit response")
+			}
+			revisionTime := commit.Commit.Committer.GetDate()
+			branchCommits, _, err := thirdparty.GetGithubCommits(ctx, token, owner, repo, module.Branch, revisionTime, 0)
 			if err != nil {
 				return nil, errors.Wrapf(err, "problem retrieving getting git branch for module %s", module.Name)
 			}
-			if gitBranch != nil && gitBranch.Commit != nil {
-				sha = *gitBranch.Commit.SHA
-				url = *gitBranch.Commit.URL
+			if len(branchCommits) > 0 {
+				sha = branchCommits[0].GetSHA()
+				url = branchCommits[0].GetURL()
 			}
 		} else {
 			sha = module.Ref

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -529,7 +529,7 @@ func CreateManifest(v model.Version, proj *model.Project, projectRef *model.Proj
 		Revision:    v.Revision,
 		ProjectName: v.Identifier,
 		Branch:      projectRef.Branch,
-		NotBase:     v.Requester != evergreen.RepotrackerVersionRequester,
+		IsBase:      v.Requester == evergreen.RepotrackerVersionRequester,
 	}
 	token, err := settings.GetGithubOauthToken()
 	if err != nil {

--- a/service/api_plugin_manifest.go
+++ b/service/api_plugin_manifest.go
@@ -53,7 +53,7 @@ func (as *APIServer) manifestLoadHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	// attempt to insert a manifest after making GitHub API calls
-	manifest, err := repotracker.CreateManifest(*v, project, projectRef.Branch, &as.Settings)
+	manifest, err := repotracker.CreateManifest(*v, project, projectRef, &as.Settings)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error storing new manifest"))
 		return

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -103,7 +103,7 @@ func (s *githubSuite) TestGetGithubCommitsUntil() {
 	until := time.Date(2013, time.May, 17, 15, 40, 0, 0, time.UTC)
 	githubCommits, _, err := GetGithubCommits(s.ctx, s.token, "deafgoat", "mci-test", "", until, 0)
 	s.NoError(err)
-	s.Len(githubCommits, 3)
+	s.Len(githubCommits, 2)
 }
 
 func (s *githubSuite) TestGetBranchEvent() {

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -94,7 +94,14 @@ func (s *githubSuite) TestCheckGithubAPILimit() {
 }
 
 func (s *githubSuite) TestGetGithubCommits() {
-	githubCommits, _, err := GetGithubCommits(s.ctx, s.token, "deafgoat", "mci-test", "", 0)
+	githubCommits, _, err := GetGithubCommits(s.ctx, s.token, "deafgoat", "mci-test", "", time.Time{}, 0)
+	s.NoError(err)
+	s.Len(githubCommits, 3)
+}
+
+func (s *githubSuite) TestGetGithubCommitsUntil() {
+	until := time.Date(2013, time.May, 17, 15, 40, 0, 0, time.UTC)
+	githubCommits, _, err := GetGithubCommits(s.ctx, s.token, "deafgoat", "mci-test", "", until, 0)
 	s.NoError(err)
 	s.Len(githubCommits, 3)
 }

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -329,7 +329,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 	assert.NoError(alias.Upsert())
 	_, err := model.GetNewRevisionOrderNumber(downstreamProjectRef.Identifier)
 	assert.NoError(err)
-	downstreamRevision := "abc123"
+	downstreamRevision := "cf46076567e4949f9fc68e0634139d4ac495c89b"
 	assert.NoError(model.UpdateLastRevision(downstreamProjectRef.Identifier, downstreamRevision))
 
 	downstreamVersions, err := EvalProjectTriggers(&e, TriggerDownstreamVersion)

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -79,7 +79,7 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 	for _, module := range proj.Modules {
 		owner, repo := module.GetRepoOwnerAndName()
 		if owner == upstreamProject.Owner && repo == upstreamProject.Repo && module.Branch == upstreamProject.Branch {
-			_, err = repotracker.CreateManifest(*v, proj, upstreamProject.Branch, settings)
+			_, err = repotracker.CreateManifest(*v, proj, upstreamProject, settings)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}


### PR DESCRIPTION
If a patch changes a module's definition in the project's evergreen.yml we create a new manifest for the patch and save it in the db so we don't need to make GitHub API calls for each task. However, when subsequent patches are created on the same base commit it's not clear which manifest they should get and we end up creating a new manifest for every subsequent patch that includes a manifest defined differently from the manifest the db returns.
This PR marks the base commit's manifest so patches can get specifically the manifest of the base commit.

Additionally, when a patch warrants creating a new manifest we shouldn't get the most recent module commit as of the time of the _patch_, but rather as of the time of the base commit. This PR gets the base commit's time from GitHub and gets the module commit most current as of that time. This change is something I've been thinking of for a while, since it will also help in case the repotracker falls behind and something is committed to a module in the meantime.