### PR TITLE
EVG-7514: query for patch build variants

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -99,6 +99,17 @@ type ComplexityRoot struct {
 		Version       func(childComplexity int) int
 	}
 
+	PatchBuildVariant struct {
+		Tasks   func(childComplexity int) int
+		Variant func(childComplexity int) int
+	}
+
+	PatchBuildVariantTask struct {
+		ID     func(childComplexity int) int
+		Name   func(childComplexity int) int
+		Status func(childComplexity int) int
+	}
+
 	PatchDuration struct {
 		Makespan  func(childComplexity int) int
 		Time      func(childComplexity int) int
@@ -124,15 +135,16 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Patch       func(childComplexity int, id string) int
-		PatchTasks  func(childComplexity int, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, page *int, limit *int, statuses []string) int
-		Projects    func(childComplexity int) int
-		Task        func(childComplexity int, taskID string) int
-		TaskFiles   func(childComplexity int, taskID string) int
-		TaskLogs    func(childComplexity int, taskID string) int
-		TaskTests   func(childComplexity int, taskID string, sortCategory *TestSortCategory, sortDirection *SortDirection, page *int, limit *int, testName *string, statuses []string) int
-		User        func(childComplexity int) int
-		UserPatches func(childComplexity int, userID string) int
+		Patch              func(childComplexity int, id string) int
+		PatchBuildVariants func(childComplexity int, patchID string) int
+		PatchTasks         func(childComplexity int, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, page *int, limit *int, statuses []string) int
+		Projects           func(childComplexity int) int
+		Task               func(childComplexity int, taskID string) int
+		TaskFiles          func(childComplexity int, taskID string) int
+		TaskLogs           func(childComplexity int, taskID string) int
+		TaskTests          func(childComplexity int, taskID string, sortCategory *TestSortCategory, sortDirection *SortDirection, page *int, limit *int, testName *string, statuses []string) int
+		User               func(childComplexity int) int
+		UserPatches        func(childComplexity int, userID string) int
 	}
 
 	RecentTaskLogs struct {
@@ -270,6 +282,7 @@ type QueryResolver interface {
 	TaskFiles(ctx context.Context, taskID string) ([]*GroupedFiles, error)
 	User(ctx context.Context) (*model.APIUser, error)
 	TaskLogs(ctx context.Context, taskID string) (*RecentTaskLogs, error)
+	PatchBuildVariants(ctx context.Context, patchID string) ([]*PatchBuildVariant, error)
 }
 type TaskResolver interface {
 	PatchNumber(ctx context.Context, obj *model.APITask) (*int, error)
@@ -558,6 +571,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Patch.Version(childComplexity), true
 
+	case "PatchBuildVariant.tasks":
+		if e.complexity.PatchBuildVariant.Tasks == nil {
+			break
+		}
+
+		return e.complexity.PatchBuildVariant.Tasks(childComplexity), true
+
+	case "PatchBuildVariant.variant":
+		if e.complexity.PatchBuildVariant.Variant == nil {
+			break
+		}
+
+		return e.complexity.PatchBuildVariant.Variant(childComplexity), true
+
+	case "PatchBuildVariantTask.id":
+		if e.complexity.PatchBuildVariantTask.ID == nil {
+			break
+		}
+
+		return e.complexity.PatchBuildVariantTask.ID(childComplexity), true
+
+	case "PatchBuildVariantTask.name":
+		if e.complexity.PatchBuildVariantTask.Name == nil {
+			break
+		}
+
+		return e.complexity.PatchBuildVariantTask.Name(childComplexity), true
+
+	case "PatchBuildVariantTask.status":
+		if e.complexity.PatchBuildVariantTask.Status == nil {
+			break
+		}
+
+		return e.complexity.PatchBuildVariantTask.Status(childComplexity), true
+
 	case "PatchDuration.makespan":
 		if e.complexity.PatchDuration.Makespan == nil {
 			break
@@ -653,6 +701,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Patch(childComplexity, args["id"].(string)), true
+
+	case "Query.patchBuildVariants":
+		if e.complexity.Query.PatchBuildVariants == nil {
+			break
+		}
+
+		args, err := ec.field_Query_patchBuildVariants_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.PatchBuildVariants(childComplexity, args["patchId"].(string)), true
 
 	case "Query.patchTasks":
 		if e.complexity.Query.PatchTasks == nil {
@@ -1375,6 +1435,7 @@ var sources = []*ast.Source{
   taskFiles(taskId: String!): [GroupedFiles!]!
   user: User!
   taskLogs(taskId: String!): RecentTaskLogs!
+  patchBuildVariants(patchId: String!): [PatchBuildVariant!]!
 }
 
 type Mutation {
@@ -1402,6 +1463,16 @@ enum TestSortCategory {
 enum SortDirection {
   ASC
   DESC
+}
+
+type PatchBuildVariant {
+  variant: String!
+  tasks: [PatchBuildVariantTask]
+}
+type PatchBuildVariantTask {
+  id: ID!
+  name: String!
+  status: String!
 }
 
 type GroupedFiles {
@@ -1695,6 +1766,20 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 		}
 	}
 	args["name"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_patchBuildVariants_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["patchId"]; ok {
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["patchId"] = arg0
 	return args, nil
 }
 
@@ -3088,6 +3173,173 @@ func (ec *executionContext) _Patch_taskCount(ctx context.Context, field graphql.
 	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _PatchBuildVariant_variant(ctx context.Context, field graphql.CollectedField, obj *PatchBuildVariant) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchBuildVariant",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Variant, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PatchBuildVariant_tasks(ctx context.Context, field graphql.CollectedField, obj *PatchBuildVariant) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchBuildVariant",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Tasks, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*PatchBuildVariantTask)
+	fc.Result = res
+	return ec.marshalOPatchBuildVariantTask2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchBuildVariantTask(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PatchBuildVariantTask_id(ctx context.Context, field graphql.CollectedField, obj *PatchBuildVariantTask) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchBuildVariantTask",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PatchBuildVariantTask_name(ctx context.Context, field graphql.CollectedField, obj *PatchBuildVariantTask) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchBuildVariantTask",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PatchBuildVariantTask_status(ctx context.Context, field graphql.CollectedField, obj *PatchBuildVariantTask) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchBuildVariantTask",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _PatchDuration_makespan(ctx context.Context, field graphql.CollectedField, obj *PatchDuration) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -3828,6 +4080,47 @@ func (ec *executionContext) _Query_taskLogs(ctx context.Context, field graphql.C
 	res := resTmp.(*RecentTaskLogs)
 	fc.Result = res
 	return ec.marshalNRecentTaskLogs2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐRecentTaskLogs(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_patchBuildVariants(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_patchBuildVariants_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().PatchBuildVariants(rctx, args["patchId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*PatchBuildVariant)
+	fc.Result = res
+	return ec.marshalNPatchBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchBuildVariantᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -7773,6 +8066,72 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 	return out
 }
 
+var patchBuildVariantImplementors = []string{"PatchBuildVariant"}
+
+func (ec *executionContext) _PatchBuildVariant(ctx context.Context, sel ast.SelectionSet, obj *PatchBuildVariant) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, patchBuildVariantImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PatchBuildVariant")
+		case "variant":
+			out.Values[i] = ec._PatchBuildVariant_variant(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "tasks":
+			out.Values[i] = ec._PatchBuildVariant_tasks(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var patchBuildVariantTaskImplementors = []string{"PatchBuildVariantTask"}
+
+func (ec *executionContext) _PatchBuildVariantTask(ctx context.Context, sel ast.SelectionSet, obj *PatchBuildVariantTask) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, patchBuildVariantTaskImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PatchBuildVariantTask")
+		case "id":
+			out.Values[i] = ec._PatchBuildVariantTask_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "name":
+			out.Values[i] = ec._PatchBuildVariantTask_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "status":
+			out.Values[i] = ec._PatchBuildVariantTask_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var patchDurationImplementors = []string{"PatchDuration"}
 
 func (ec *executionContext) _PatchDuration(ctx context.Context, sel ast.SelectionSet, obj *PatchDuration) graphql.Marshaler {
@@ -8036,6 +8395,20 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_taskLogs(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "patchBuildVariants":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_patchBuildVariants(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
@@ -9076,6 +9449,57 @@ func (ec *executionContext) marshalNPatch2ᚖgithubᚗcomᚋevergreenᚑciᚋeve
 	return ec._Patch(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNPatchBuildVariant2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchBuildVariant(ctx context.Context, sel ast.SelectionSet, v PatchBuildVariant) graphql.Marshaler {
+	return ec._PatchBuildVariant(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPatchBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchBuildVariantᚄ(ctx context.Context, sel ast.SelectionSet, v []*PatchBuildVariant) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNPatchBuildVariant2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchBuildVariant(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
+func (ec *executionContext) marshalNPatchBuildVariant2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchBuildVariant(ctx context.Context, sel ast.SelectionSet, v *PatchBuildVariant) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._PatchBuildVariant(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNProject2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFields(ctx context.Context, sel ast.SelectionSet, v model.UIProjectFields) graphql.Marshaler {
 	return ec._Project(ctx, sel, &v)
 }
@@ -9768,6 +10192,57 @@ func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.Sele
 		return graphql.Null
 	}
 	return ec.marshalOInt2int(ctx, sel, *v)
+}
+
+func (ec *executionContext) marshalOPatchBuildVariantTask2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchBuildVariantTask(ctx context.Context, sel ast.SelectionSet, v PatchBuildVariantTask) graphql.Marshaler {
+	return ec._PatchBuildVariantTask(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOPatchBuildVariantTask2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchBuildVariantTask(ctx context.Context, sel ast.SelectionSet, v []*PatchBuildVariantTask) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOPatchBuildVariantTask2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchBuildVariantTask(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
+func (ec *executionContext) marshalOPatchBuildVariantTask2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchBuildVariantTask(ctx context.Context, sel ast.SelectionSet, v *PatchBuildVariantTask) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._PatchBuildVariantTask(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOPatchDuration2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchDuration(ctx context.Context, sel ast.SelectionSet, v PatchDuration) graphql.Marshaler {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -21,6 +21,17 @@ type GroupedProjects struct {
 	Projects []*model.UIProjectFields `json:"projects"`
 }
 
+type PatchBuildVariant struct {
+	Variant string                   `json:"variant"`
+	Tasks   []*PatchBuildVariantTask `json:"tasks"`
+}
+
+type PatchBuildVariantTask struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
 type PatchDuration struct {
 	Makespan  *string    `json:"makespan"`
 	TimeTaken *string    `json:"timeTaken"`

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -589,6 +589,7 @@ func (r *queryResolver) PatchBuildVariants(ctx context.Context, patchID string) 
 		}
 		result = append(result, &pbv)
 	}
+	// sort variants by name
 	sort.SliceStable(result, func(i, j int) bool {
 		return result[i].Variant < result[j].Variant
 	})

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -568,7 +568,7 @@ func (r *queryResolver) PatchBuildVariants(ctx context.Context, patchID string) 
 	for _, variant := range patch.Variants {
 		tasksByVariant[*variant] = []*PatchBuildVariantTask{}
 	}
-	tasks, err := r.sc.FindTasksByVersion(patchID, task.DisplayNameKey, []string{}, 1, 0, 1000)
+	tasks, err := r.sc.FindTasksByVersion(patchID, task.DisplayNameKey, []string{}, 1, 0, 0)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting tasks for patch `%s`: %s", patchID, err))
 	}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -23,6 +23,7 @@ type Query {
   taskFiles(taskId: String!): [GroupedFiles!]!
   user: User!
   taskLogs(taskId: String!): RecentTaskLogs!
+  patchBuildVariants(patchId: String!): [PatchBuildVariant!]!
 }
 
 type Mutation {
@@ -50,6 +51,16 @@ enum TestSortCategory {
 enum SortDirection {
   ASC
   DESC
+}
+
+type PatchBuildVariant {
+  variant: String!
+  tasks: [PatchBuildVariantTask]
+}
+type PatchBuildVariantTask {
+  id: ID!
+  name: String!
+  status: String!
 }
 
 type GroupedFiles {

--- a/graphql/tests/patchBuildVariants/data.json
+++ b/graphql/tests/patchBuildVariants/data.json
@@ -1,0 +1,91 @@
+{
+  "patches": [
+    {
+      "_id": {
+        "$oid": "5e4ff3abe3c3317e352062e4"
+      },
+      "desc": "do things",
+      "branch": "evergreen",
+      "githash": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "patch_number": 2567,
+      "author": "brian.samek",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "status": "started",
+      "create_time": {
+        "$date": "2020-02-21T15:13:28Z"
+      },
+      "start_time": {
+        "$date": "2020-02-21T15:14:26.122Z"
+      },
+      "finish_time": {
+        "$date": "2020-02-21T15:29:54.869Z"
+      },
+      "build_variants": ["ubuntu1604", "osx", "windows"],
+      "tasks": [
+        "test-thirdparty-docker",
+        "test-cloud",
+        "lint",
+        "compile",
+        "test-thirdparty-docker",
+        "test-cloud",
+        "lint-graphql"
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "_id": "1",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "display_name": "test-thirdparty-docker",
+      "r": "github_pull_request",
+      "status": "success"
+    },
+    {
+      "_id": "2",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "display_name": "test-cloud",
+      "r": "github_pull_request",
+      "status": "failed"
+    },
+    {
+      "_id": "4",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "windows",
+      "display_name": "compile",
+      "r": "github_pull_request",
+      "status": "failed"
+    },
+    {
+      "_id": "5",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "display_name": "test-docker",
+      "r": "github_pull_request",
+      "status": "success"
+    },
+    {
+      "_id": "7",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "windows",
+      "display_name": "lint",
+      "r": "github_pull_request",
+      "status": "success"
+    },
+    {
+      "_id": "9",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "osx",
+      "display_name": "lint-graphql",
+      "r": "github_pull_request",
+      "status": "started"
+    }
+  ]
+}

--- a/graphql/tests/patchBuildVariants/queries/invalid-id.graphql
+++ b/graphql/tests/patchBuildVariants/queries/invalid-id.graphql
@@ -1,0 +1,10 @@
+{
+  patchBuildVariants(patchId: "5e4ff3abe3c3317e352962e4") {
+    variant
+    tasks {
+      id
+      name
+      status
+    }
+  }
+}

--- a/graphql/tests/patchBuildVariants/queries/patch-build-variants.graphql
+++ b/graphql/tests/patchBuildVariants/queries/patch-build-variants.graphql
@@ -1,0 +1,10 @@
+{
+  patchBuildVariants(patchId: "5e4ff3abe3c3317e352062e4") {
+    variant
+    tasks {
+      id
+      name
+      status
+    }
+  }
+}

--- a/graphql/tests/patchBuildVariants/results.json
+++ b/graphql/tests/patchBuildVariants/results.json
@@ -1,0 +1,73 @@
+{
+  "tests": [
+    {
+      "query_file": "patch-build-variants.graphql",
+      "result": {
+        "data": {
+          "patchBuildVariants": [
+            {
+              "variant": "osx",
+              "tasks": [
+                {
+                  "id": "9",
+                  "name": "lint-graphql",
+                  "status": "started"
+                }
+              ]
+            },
+            {
+              "variant": "ubuntu1604",
+              "tasks": [
+                {
+                  "id": "2",
+                  "name": "test-cloud",
+                  "status": "failed"
+                },
+                {
+                  "id": "5",
+                  "name": "test-docker",
+                  "status": "success"
+                },
+                {
+                  "id": "1",
+                  "name": "test-thirdparty-docker",
+                  "status": "success"
+                }
+              ]
+            },
+            {
+              "variant": "windows",
+              "tasks": [
+                {
+                  "id": "4",
+                  "name": "compile",
+                  "status": "failed"
+                },
+                {
+                  "id": "7",
+                  "name": "lint",
+                  "status": "success"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "query_file": "invalid-id.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "Error finding patch `5e4ff3abe3c3317e352962e4`: 404 (Not Found): patch with id 5e4ff3abe3c3317e352962e4 not found",
+            "path": ["patchBuildVariants"],
+            "extensions": {
+              "code": "INTERNAL_SERVER_ERROR"
+            }
+          }
+        ],
+        "data": null
+      }
+    }
+  ]
+}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1956,8 +1956,13 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, sortDir, pag
 	// _id must be the LAST item in sort array to ensure a consistent sort order when previous sort keys result in a tie
 	sorters = append(sorters, "_id")
 
+	query := db.Query(match).Sort(sorters)
+	if limit > 0 {
+		query = query.Limit(limit).Skip(page * limit)
+	}
+
 	tasks := []Task{}
-	err := db.FindAllQ(Collection, db.Query(match).Sort(sorters).Limit(limit).Skip(page*limit), &tasks)
+	err := db.FindAllQ(Collection, query, &tasks)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7514

### Related UI
<img width="276" alt="Screen Shot 2020-03-16 at 6 06 00 PM" src="https://user-images.githubusercontent.com/15262143/76803701-d1cd0200-67b0-11ea-8e35-c2e657b53616.png">

### Summary
Use patch ID to query for build variants

- Get all tasks for patch using `FindTasksByVersion`
- Map tasks to their respective variant