### PR TITLE
EVG-7255 add first failing task in version trigger

### DIFF
--- a/model/alertrecord/alert_bookkeeping.go
+++ b/model/alertrecord/alert_bookkeeping.go
@@ -118,7 +118,7 @@ func ByLastFailureTransition(subscriptionID, taskName, variant, projectId string
 	return db.Query(q).Sort([]string{"-" + AlertTimeKey, "-" + RevisionOrderNumberKey}).Limit(1)
 }
 
-func ByFirstFailureInVersion(subscriptionID, projectId, versionId string) db.Q {
+func ByFirstFailureInVersion(subscriptionID, versionId string) db.Q {
 	q := subscriptionIDQuery(subscriptionID)
 	q[TypeKey] = FirstVersionFailureId
 	q[VersionIdKey] = versionId

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -47,6 +47,7 @@ const (
 	TestRegexKey                                      = "test-regex"
 	RenotifyIntervalKey                               = "renotify-interval"
 	ImplicitSubscriptionPatchOutcome                  = "patch-outcome"
+	ImplicitSubscriptionPatchFirstFailure             = "patch-first-failure"
 	ImplicitSubscriptionBuildBreak                    = "build-break"
 	ImplicitSubscriptionSpawnhostExpiration           = "spawnhost-expiration"
 	ImplicitSubscriptionSpawnHostOutcome              = "spawnhost-outcome"
@@ -58,14 +59,15 @@ const (
 	ObjectHost                      = "host"
 	ObjectPatch                     = "patch"
 
-	TriggerOutcome                = "outcome"
-	TriggerFailure                = "failure"
-	TriggerSuccess                = "success"
-	TriggerRegression             = "regression"
-	TriggerExceedsDuration        = "exceeds-duration"
-	TriggerRuntimeChangeByPercent = "runtime-change"
-	TriggerExpiration             = "expiration"
-	TriggerPatchStarted           = "started"
+	TriggerOutcome                   = "outcome"
+	TriggerFailure                   = "failure"
+	TriggerSuccess                   = "success"
+	TriggerRegression                = "regression"
+	TriggerExceedsDuration           = "exceeds-duration"
+	TriggerRuntimeChangeByPercent    = "runtime-change"
+	TriggerExpiration                = "expiration"
+	TriggerPatchStarted              = "started"
+	TriggerTaskFirstFailureInVersion = "first-failure-in-version"
 )
 
 type Subscription struct {
@@ -451,6 +453,8 @@ func CreateOrUpdateImplicitSubscription(resourceType string, id string,
 			switch resourceType {
 			case ImplicitSubscriptionPatchOutcome:
 				temp = NewPatchOutcomeSubscriptionByOwner(user, subscriber)
+			case ImplicitSubscriptionPatchFirstFailure:
+				temp = NewFirstTaskFailureInVersionSubscriptionByOwner(user, subscriber)
 			case ImplicitSubscriptionBuildBreak:
 				temp = NewBuildBreakSubscriptionByOwner(user, subscriber)
 			case ImplicitSubscriptionSpawnhostExpiration:
@@ -504,6 +508,11 @@ func NewPatchOutcomeSubscription(id string, sub Subscriber) Subscription {
 
 func NewPatchOutcomeSubscriptionByOwner(owner string, sub Subscriber) Subscription {
 	return NewSubscriptionByOwner(owner, sub, ResourceTypePatch, TriggerOutcome)
+}
+
+func NewFirstTaskFailureInVersionSubscriptionByOwner(owner string, sub Subscriber) Subscription {
+	return NewSubscriptionByOwner(owner, sub, ResourceTypeTask, TriggerTaskFirstFailureInVersion)
+
 }
 
 func NewBuildBreakSubscriptionByOwner(owner string, sub Subscriber) Subscription {

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -511,8 +511,22 @@ func NewPatchOutcomeSubscriptionByOwner(owner string, sub Subscriber) Subscripti
 }
 
 func NewFirstTaskFailureInVersionSubscriptionByOwner(owner string, sub Subscriber) Subscription {
-	return NewSubscriptionByOwner(owner, sub, ResourceTypeTask, TriggerTaskFirstFailureInVersion)
-
+	return Subscription{
+		ID:           mgobson.NewObjectId().Hex(),
+		ResourceType: ResourceTypeTask,
+		Trigger:      TriggerTaskFirstFailureInVersion,
+		Selectors: []Selector{
+			{
+				Type: SelectorOwner,
+				Data: owner,
+			},
+			{
+				Type: SelectorRequester,
+				Data: evergreen.PatchVersionRequester,
+			},
+		},
+		Subscriber: sub,
+	}
 }
 
 func NewBuildBreakSubscriptionByOwner(owner string, sub Subscriber) Subscription {

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -74,6 +74,8 @@ type NotificationPreferences struct {
 	BuildBreakID          string                     `bson:"build_break_id,omitempty" json:"-"`
 	PatchFinish           UserSubscriptionPreference `bson:"patch_finish" json:"patch_finish"`
 	PatchFinishID         string                     `bson:"patch_finish_id,omitempty" json:"-"`
+	PatchFirstFailure     UserSubscriptionPreference `bson:"patch_first_failure,omitempty" json:"patch_first_failure"`
+	PatchFirstFailureID   string                     `bson:"patch_first_failure_id,omitempty" json:"-"`
 	SpawnHostExpiration   UserSubscriptionPreference `bson:"spawn_host_expiration" json:"spawn_host_expiration"`
 	SpawnHostExpirationID string                     `bson:"spawn_host_expiration_id,omitempty" json:"-"`
 	SpawnHostOutcome      UserSubscriptionPreference `bson:"spawn_host_outcome" json:"spawn_host_outcome"`

--- a/public/static/js/notifications.js
+++ b/public/static/js/notifications.js
@@ -17,17 +17,21 @@ mciModule.controller('NotificationsController', function($scope, $window, mciUse
   $scope.getSubscriptions = function() {
     var success = function(resp) {
       var patchFinishId = $scope.settings.notifications.patch_finish_id;
+      var patchFirstFailureId = $scope.settings.notifications.patch_first_failure_id;
       var buildBreakId = $scope.settings.notifications.build_break_id;
       var spawnhostExpirationId = $scope.settings.notifications.spawn_host_expiration_id;
+      var spawnhostOutcomeId = $scope.settings.notifications.spawn_host_outcome_id;
       var commitQueueId = $scope.settings.notifications.commit_queue_id;
       if (!Array.isArray(resp.data)) {
         resp.data = [resp.data];
       }
       $scope.subscriptions = _.filter(resp.data, function(subscription){
         if (
-          subscription.id === patchFinishId || 
+          subscription.id === patchFinishId ||
+          subscription.id === patchFirstFailureId ||
           subscription.id === buildBreakId || 
-          subscription.id === spawnhostExpirationId || 
+          subscription.id === spawnhostExpirationId ||
+          subscription.id === spawnhostOutcomeId ||
           subscription.id === commitQueueId) {
           return false;
         }

--- a/rest/model/user.go
+++ b/rest/model/user.go
@@ -132,6 +132,8 @@ type APINotificationPreferences struct {
 	BuildBreakID          *string `json:"build_break_id,omitempty"`
 	PatchFinish           *string `json:"patch_finish"`
 	PatchFinishID         *string `json:"patch_finish_id,omitempty"`
+	PatchFirstFailure     *string `json:"patch_first_failure"`
+	PatchFirstFailureID   *string `json:"patch_first_failure_id,omitempty"`
 	SpawnHostExpiration   *string `json:"spawn_host_expiration"`
 	SpawnHostExpirationID *string `json:"spawn_host_expiration_id,omitempty"`
 	SpawnHostOutcome      *string `json:"spawn_host_outcome"`
@@ -148,6 +150,7 @@ func (n *APINotificationPreferences) BuildFromService(h interface{}) error {
 	case user.NotificationPreferences:
 		n.BuildBreak = ToStringPtr(string(v.BuildBreak))
 		n.PatchFinish = ToStringPtr(string(v.PatchFinish))
+		n.PatchFirstFailure = ToStringPtr(string(v.PatchFirstFailure))
 		n.SpawnHostOutcome = ToStringPtr(string(v.SpawnHostOutcome))
 		n.SpawnHostExpiration = ToStringPtr(string(v.SpawnHostExpiration))
 		n.CommitQueue = ToStringPtr(string(v.CommitQueue))
@@ -156,6 +159,9 @@ func (n *APINotificationPreferences) BuildFromService(h interface{}) error {
 		}
 		if v.PatchFinishID != "" {
 			n.PatchFinishID = ToStringPtr(v.PatchFinishID)
+		}
+		if v.PatchFirstFailureID != "" {
+			n.PatchFirstFailureID = ToStringPtr(v.PatchFirstFailureID)
 		}
 		if v.SpawnHostOutcomeID != "" {
 			n.SpawnHostOutcomeID = ToStringPtr(v.SpawnHostOutcomeID)
@@ -178,6 +184,7 @@ func (n *APINotificationPreferences) ToService() (interface{}, error) {
 	}
 	buildbreak := FromStringPtr(n.BuildBreak)
 	patchFinish := FromStringPtr(n.PatchFinish)
+	patchFirstFailure := FromStringPtr(n.PatchFirstFailure)
 	spawnHostExpiration := FromStringPtr(n.SpawnHostExpiration)
 	spawnHostOutcome := FromStringPtr(n.SpawnHostOutcome)
 	commitQueue := FromStringPtr(n.CommitQueue)
@@ -186,6 +193,9 @@ func (n *APINotificationPreferences) ToService() (interface{}, error) {
 	}
 	if !user.IsValidSubscriptionPreference(patchFinish) {
 		return nil, errors.New("Patch finish preference is not a valid type")
+	}
+	if !user.IsValidSubscriptionPreference(patchFirstFailure) {
+		return nil, errors.New("Patch first task failure preference is not a valid type")
 	}
 	if !user.IsValidSubscriptionPreference(spawnHostExpiration) {
 		return nil, errors.New("Spawn Host Expiration preference is not a valid type")
@@ -199,13 +209,15 @@ func (n *APINotificationPreferences) ToService() (interface{}, error) {
 	preferences := user.NotificationPreferences{
 		BuildBreak:          user.UserSubscriptionPreference(buildbreak),
 		PatchFinish:         user.UserSubscriptionPreference(patchFinish),
+		PatchFirstFailure:   user.UserSubscriptionPreference(patchFirstFailure),
 		SpawnHostOutcome:    user.UserSubscriptionPreference(spawnHostOutcome),
 		SpawnHostExpiration: user.UserSubscriptionPreference(spawnHostExpiration),
 		CommitQueue:         user.UserSubscriptionPreference(commitQueue),
 	}
 	preferences.BuildBreakID = FromStringPtr(n.BuildBreakID)
 	preferences.PatchFinishID = FromStringPtr(n.PatchFinishID)
-	preferences.SpawnHostOutcomeID = FromStringPtr(n.PatchFinishID)
+	preferences.PatchFirstFailureID = FromStringPtr(n.PatchFirstFailureID)
+	preferences.SpawnHostOutcomeID = FromStringPtr(n.SpawnHostOutcomeID)
 	preferences.SpawnHostExpirationID = FromStringPtr(n.SpawnHostExpirationID)
 	preferences.CommitQueueID = FromStringPtr(n.CommitQueueID)
 	return preferences, nil

--- a/service/templates/notifications.html
+++ b/service/templates/notifications.html
@@ -49,6 +49,16 @@ Notifications Preferences
                 </td>
               </tr>
               <tr>
+                <td>Patch First Task Failure</td>
+                <td colspan="3">
+                  <md-radio-group layout="row" style="width:100%" ng-model="settings.notifications.patch_first_failure" md-no-ink="true">
+                    <md-radio-button value="email"></md-radio-button>
+                    <md-radio-button value="slack" ng-disabled='!settings.slack_username || settings.slack_username == ""'></md-radio-button>
+                    <md-radio-button value="none"></md-radio-button>
+                  </md-radio-group>
+                </td>
+              </tr>
+              <tr>
                 <td>Spawn Host Outcome</td>
                 <td colspan="3">
                   <md-radio-group layout="row" style="width:100%" ng-model="settings.notifications.spawn_host_outcome" md-no-ink="true">

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -30,7 +30,6 @@ func init() {
 
 const (
 	triggerTaskFirstFailureInBuild           = "first-failure-in-build"
-	triggerTaskFirstFailureInVersion         = "first-failure-in-version"
 	triggerTaskFirstFailureInVersionWithName = "first-failure-in-version-with-name"
 	triggerTaskRegressionByTest              = "regression-by-test"
 	triggerBuildBreak                        = "build-break"
@@ -48,8 +47,8 @@ func makeTaskTriggers() eventHandler {
 		event.TriggerExceedsDuration:             t.taskExceedsDuration,
 		event.TriggerRuntimeChangeByPercent:      t.taskRuntimeChange,
 		event.TriggerRegression:                  t.taskRegression,
+		event.TriggerTaskFirstFailureInVersion:   t.taskFirstFailureInVersion,
 		triggerTaskFirstFailureInBuild:           t.taskFirstFailureInBuild,
-		triggerTaskFirstFailureInVersion:         t.taskFirstFailureInVersion,
 		triggerTaskFirstFailureInVersionWithName: t.taskFirstFailureInVersionWithName,
 		triggerTaskRegressionByTest:              t.taskRegressionByTest,
 		triggerBuildBreak:                        t.buildBreak,
@@ -425,9 +424,9 @@ func (t *taskTriggers) taskFirstFailureInVersion(sub *event.Subscription) (*noti
 	if t.data.Status != evergreen.TaskFailed {
 		return nil, nil
 	}
-	rec, err := alertrecord.FindOne(alertrecord.ByFirstFailureInVersion(sub.ID, t.task.Project, t.task.Version))
+	rec, err := alertrecord.FindOne(alertrecord.ByFirstFailureInVersion(sub.ID, t.task.Version))
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch alertrecord (%s)", triggerTaskFirstFailureInVersion))
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch alertrecord (%s)", event.TriggerTaskFirstFailureInVersion))
 	}
 	if rec != nil {
 		return nil, nil


### PR DESCRIPTION
The Goal: Some users want a notification when the first task fails, not when the whole patch has finished. 

There does seem to be a race condition where tasks that fail around the same time all send the notification (which I think is why I thought this was broken). I'm thinking `generateWithAlertRecord` should do it before actually inserting the alert record because potentially generating takes some time.