### PR TITLE
EVG-7593: allow distro aliases in host.create

### DIFF
--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -166,7 +166,8 @@ func makeDockerIntentHost(taskID, userID string, createHost apimodels.CreateHost
 	var err error
 
 	if distroID := createHost.Distro; distroID != "" {
-		dat, err := distro.NewDistroAliasesLookupTable()
+		var dat distro.AliasLookupTable
+		dat, err = distro.NewDistroAliasesLookupTable()
 		if err != nil {
 			return nil, errors.Wrap(err, "problem creating distro alias lookup table")
 		}
@@ -249,7 +250,8 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	ec2Settings := cloud.EC2ProviderSettings{}
 	var err error
 	if distroID := createHost.Distro; distroID != "" {
-		dat, err := distro.NewDistroAliasesLookupTable()
+		var dat distro.AliasLookupTable
+		dat, err = distro.NewDistroAliasesLookupTable()
 		if err != nil {
 			return nil, errors.Wrap(err, "problem creating distro alias lookup table")
 		}

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -626,7 +626,6 @@ func (h *distroIDExecuteHandler) Parse(ctx context.Context, r *http.Request) err
 // Run enqueues a job to run a script on all hosts (excluding spawn hosts) that
 // are not down for the given given distro ID.
 func (h *distroIDExecuteHandler) Run(ctx context.Context) gimlet.Responder {
-	// enqueue job - per host, per distro?
 	hosts, err := h.sc.FindHostsByDistroID(h.distroID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "could not find hosts for the distro %s", h.distroID))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7593

I just used the first distro ID that the alias can resolve into.