### PR TITLE
EVG-7595: decommission hosts running agents on distros that are deleted

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -510,19 +510,14 @@ var IsTerminated = db.Query(
 		StatusKey:      evergreen.HostTerminated},
 )
 
-func ByDistroIdDoc(distroId string) bson.M {
-	dId := fmt.Sprintf("%v.%v", DistroKey, distro.IdKey)
+// ByDistroIDs produces a query that returns all up hosts of the given distros.
+func ByDistroIDs(distroIDs ...string) bson.M {
+	distroIDKey := bsonutil.GetDottedKeyName(DistroKey, distro.IdKey)
 	return bson.M{
-		dId:          distroId,
+		distroIDKey:  bson.M{"$in": distroIDs},
 		StartedByKey: evergreen.User,
 		StatusKey:    bson.M{"$in": evergreen.UpHostStatus},
 	}
-}
-
-// ByDistroId produces a query that returns all working hosts (not terminated and
-// not quarantined) of the given distro.
-func ByDistroId(distroId string) db.Q {
-	return db.Query(ByDistroIdDoc(distroId))
 }
 
 // ById produces a query that returns a host with the given id.

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1317,6 +1317,8 @@ func (h *Host) GetElapsedCommunicationTime() time.Duration {
 	return time.Since(h.CreationTime)
 }
 
+// DecommissionHostsWithDistroId marks all up hosts intended for running tasks
+// that have a matching distro ID as decommissioned.
 func DecommissionHostsWithDistroId(distroId string) error {
 	err := UpdateAll(
 		ByDistroIdDoc(distroId),

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1321,7 +1321,7 @@ func (h *Host) GetElapsedCommunicationTime() time.Duration {
 // that have a matching distro ID as decommissioned.
 func DecommissionHostsWithDistroId(distroId string) error {
 	err := UpdateAll(
-		ByDistroIdDoc(distroId),
+		ByDistroIDs(distroId),
 		bson.M{
 			"$set": bson.M{
 				StatusKey: evergreen.HostDecommissioned,

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -888,10 +888,10 @@ func TestDecommissionHostsWithDistroId(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			Convey("Distro should be marked as decommissioned accordingly", func() {
-				hostsTypeA, err := Find(ByDistroId(distroA))
+				hostsTypeA, err := Find(db.Query(ByDistroIDs(distroA)))
 				So(err, ShouldBeNil)
 
-				hostsTypeB, err := Find(ByDistroId(distroB))
+				hostsTypeB, err := Find(db.Query(ByDistroIDs(distroB)))
 				So(err, ShouldBeNil)
 				for _, host := range hostsTypeA {
 

--- a/model/task_start_estimation.go
+++ b/model/task_start_estimation.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
@@ -113,7 +114,7 @@ func GetEstimatedStartTime(t task.Task) (time.Duration, error) {
 	if queuePos == -1 {
 		return -1, nil
 	}
-	hosts, err := host.Find(host.ByDistroId(t.DistroId))
+	hosts, err := host.Find(db.Query(host.ByDistroIDs(t.DistroId)))
 	if err != nil {
 		return -1, errors.Wrap(err, "error retrieving hosts")
 	}

--- a/service/distros.go
+++ b/service/distros.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -177,7 +178,7 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if shouldDeco {
-		hosts, err := host.Find(host.ByDistroId(newDistro.Id))
+		hosts, err := host.Find(db.Query(host.ByDistroIDs(newDistro.Id)))
 		if err != nil {
 			message := fmt.Sprintf("error finding hosts: %s", err.Error())
 			PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))

--- a/units/host_monitoring_idle_termination_test.go
+++ b/units/host_monitoring_idle_termination_test.go
@@ -416,8 +416,8 @@ func TestFlaggingIdleHostsWithMissingDistroIDs(t *testing.T) {
 		require.NoError(t, host4.Insert(), "error inserting host '%s'", host4.Id)
 		require.NoError(t, host5.Insert(), "error inserting host '%s'", host5.Id)
 
-		// If we encounter missing distros, we decommission hosts that do not
-		// exist
+		// If we encounter missing distros, we decommission hosts from those
+		// distros.
 		idle, err := flagIdleHosts(ctx, env)
 		require.NoError(t, err)
 		require.Len(t, idle, 3)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7595

The job that populates the idle host termination job now decommissions hosts in missing (i.e. deleted) distros rather than erroring when it finds a missing distro.