### PR TITLE
EVG-7437: do not use clean path

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -339,7 +338,7 @@ func (h *Host) fetchJasperCommands(config evergreen.HostJasperConfig) []string {
 	return []string{
 		fmt.Sprintf("mkdir -m 777 -p %s", h.Distro.BootstrapSettings.JasperBinaryDir),
 		fmt.Sprintf("cd %s", h.Distro.BootstrapSettings.JasperBinaryDir),
-		fmt.Sprintf("curl -LO '%s' %s", path.Join(config.URL, downloadedFile), curlRetryArgs(curlDefaultNumRetries, curlDefaultMaxSecs)),
+		fmt.Sprintf("curl -LO '%s/%s' %s", config.URL, downloadedFile, curlRetryArgs(curlDefaultNumRetries, curlDefaultMaxSecs)),
 		fmt.Sprintf("tar xzf '%s'", downloadedFile),
 		fmt.Sprintf("chmod +x '%s'", extractedFile),
 		fmt.Sprintf("rm -f '%s'", downloadedFile),


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7437

I forgot that `path.Join` cleans the path.