### PR TITLE
EVG-7610: Make statuses param in patchTasks resolver optional

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1435,7 +1435,7 @@ var sources = []*ast.Source{
     sortDir: SortDirection = ASC
     page: Int = 0
     limit: Int = 0
-    statuses: [String!]! = []
+    statuses: [String!] = []
   ): [TaskResult!]!
   taskTests(
     taskId: String!
@@ -1879,7 +1879,7 @@ func (ec *executionContext) field_Query_patchTasks_args(ctx context.Context, raw
 	args["limit"] = arg4
 	var arg5 []string
 	if tmp, ok := rawArgs["statuses"]; ok {
-		arg5, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		arg5, err = ec.unmarshalOString2ᚕstringᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -9,7 +9,7 @@ type Query {
     sortDir: SortDirection = ASC
     page: Int = 0
     limit: Int = 0
-    statuses: [String!]! = []
+    statuses: [String!] = []
   ): [TaskResult!]!
   taskTests(
     taskId: String!


### PR DESCRIPTION
there is a default value provided for `statuses` param; therefore this param can be undefined