### PR TITLE
EVG-7545 put config file in home dir

### DIFF
--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -79,7 +79,7 @@ func buildApp() *cli.App {
 			userHome = os.Getenv("HOME")
 		}
 	}
-	confPath := filepath.Join(userHome, ".evergreen.yml")
+	confPath := filepath.Join(userHome, evergreen.DefaultEvergreenConfig)
 
 	// These are global options. Use this to configure logging or
 	// other options independent from specific sub commands.

--- a/globals.go
+++ b/globals.go
@@ -125,6 +125,8 @@ const (
 	LogmessageFormatTimestamp = 1
 	LogmessageCurrentVersion  = LogmessageFormatTimestamp
 
+	DefaultEvergreenConfig = ".evergreen.yml"
+
 	EvergreenHome = "EVGHOME"
 	MongodbUrl    = "MONGO_URL"
 

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1027,7 +1027,7 @@ func (h *Host) spawnHostConfigDir() string {
 
 // spawnHostConfigFile returns the path to the evergreen yaml for a spawn host.
 func (h *Host) spawnHostConfigFile() string {
-	return filepath.Join(h.spawnHostConfigDir(), ".evergreen.yml")
+	return filepath.Join(h.Distro.HomeDir(), evergreen.DefaultEvergreenConfig)
 }
 
 // spawnHostConfigJSON returns evergreen yaml configuration for a spawn host in

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1066,7 +1066,7 @@ func TestSpawnHostSetupCommands(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := "mkdir -m 777 -p /home/user/cli_bin" +
-		" && echo '{\"api_key\":\"key\",\"api_server_host\":\"www.example0.com/api\",\"ui_server_host\":\"www.example1.com\",\"user\":\"user\"}' > /home/user/cli_bin/.evergreen.yml" +
+		" && echo '{\"api_key\":\"key\",\"api_server_host\":\"www.example0.com/api\",\"ui_server_host\":\"www.example1.com\",\"user\":\"user\"}' > /home/user/.evergreen.yml" +
 		" && cp /home/user/evergreen /home/user/cli_bin" +
 		" && (echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.profile || true; echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.bash_profile || true)" +
 		" && chown -R user /home/user/cli_bin" +

--- a/operations/model.go
+++ b/operations/model.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/rest/client"
 	"github.com/kardianos/osext"
 	homedir "github.com/mitchellh/go-homedir"
@@ -43,8 +44,8 @@ func findConfigFilePath(fn string) (string, error) {
 	files := []string{
 		fn,
 		absfn,
-		filepath.Join(userHome, ".evergreen.yml"),
-		filepath.Join(filepath.Dir(currentBinPath), ".evergreen.yml"),
+		filepath.Join(userHome, evergreen.DefaultEvergreenConfig),
+		filepath.Join(filepath.Dir(currentBinPath), evergreen.DefaultEvergreenConfig),
 	}
 
 	for _, path := range files {


### PR DESCRIPTION
The config file that's placed on spawnhosts is overshadowed by the config placed in the home directory in the build image (which is missing a user's credentials) because we look for the config file in the home directory before the executable directory. 
This PR will overwrite the build image's config with a user specific one.