### PR TITLE
EVG-7613 handle backend error

### DIFF
--- a/service/host.go
+++ b/service/host.go
@@ -323,3 +323,9 @@ func (uis *UIServer) getHostFromCache(hostID string) (*hostCacheItem, error) {
 
 	return &h, nil
 }
+
+func (uis *UIServer) handleBackendError(message string, statusCode int) func(http.ResponseWriter, *http.Request, error) {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		gimlet.WriteTextResponse(w, statusCode, message)
+	}
+}

--- a/service/ui.go
+++ b/service/ui.go
@@ -358,6 +358,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 		FindTarget:        uis.getHostDNS,
 		StripSourcePrefix: true,
 		RemoteScheme:      "http",
+		ErrorHandler:      uis.handleBackendError("IDE service is not available", http.StatusInternalServerError),
 	}).AllMethods()
 	// Prefix routes not ending in a '/' are not automatically redirected by gimlet's underlying library.
 	// Add another route to match when there's no trailing slash and redirect

--- a/vendor/github.com/evergreen-ci/gimlet/proxy.go
+++ b/vendor/github.com/evergreen-ci/gimlet/proxy.go
@@ -25,6 +25,7 @@ type ProxyOptions struct {
 	TargetPool        []string
 	FindTarget        func(*http.Request) ([]string, error)
 	RemoteScheme      string
+	ErrorHandler      func(http.ResponseWriter, *http.Request, error)
 }
 
 // Validate checks the default configuration of a proxy configuration.
@@ -137,8 +138,9 @@ func (r *APIRoute) Proxy(opts ProxyOptions) *APIRoute {
 	}
 
 	r.handler = (&httputil.ReverseProxy{
-		ErrorLog: grip.MakeStandardLogger(level.Warning),
-		Director: opts.director,
+		ErrorLog:     grip.MakeStandardLogger(level.Warning),
+		Director:     opts.director,
+		ErrorHandler: opts.ErrorHandler,
 	}).ServeHTTP
 
 	return r


### PR DESCRIPTION
If an error occurs reaching the backend (e.g.code-server isn't running) the default behavior is to return a 502 status code and an empty response. This will catch that error and pass a message and 500 status code.

Goes together with https://github.com/evergreen-ci/gimlet/pull/76. Once that PR is approved it will be revendored and included here. 