### PR TITLE
EVG-7616: add environment variable to skip integration tests

### DIFF
--- a/testutil/testing.go
+++ b/testutil/testing.go
@@ -30,6 +30,9 @@ func GetDirectoryOfFile() string {
 
 func ConfigureIntegrationTest(t *testing.T, testSettings *evergreen.Settings, testName string) {
 	// make sure an override file is provided
+	if skip := os.Getenv("SKIP_INTEGRATION_TESTS"); skip != "" {
+		t.Skip("SKIP_INTEGRATION_TESTS is set, skipping integration test")
+	}
 	if (*settingsOverride) == "" {
 		require.NotZero(t, os.Getenv(EnvOverride), "Integration tests need a settings override file to be provided")
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7616

I never run integration tests on my computer anyways, so it would be easier to just ignore them locally rather than check every time I run `make test-` if it failed because of an integration test.