### PR TITLE
EVG-7600: allow distro aliases where appropriate

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -58,7 +58,7 @@ func (so *SpawnOptions) validate() error {
 	}
 
 	if !d.SpawnAllowed {
-		return errors.Errorf("Invalid spawn options: spawning not allowed for distro  %v", so.DistroId)
+		return errors.Errorf("Invalid spawn options: spawning not allowed for distro %s", so.DistroId)
 	}
 
 	// if the user already has too many active spawned hosts, deny the request

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -490,10 +490,10 @@ func ValidateContainerPoolDistros(s *evergreen.Settings) error {
 	for _, pool := range s.ContainerPools.Pools {
 		d, err := FindOne(ById(pool.Distro))
 		if err != nil {
-			catcher.Add(fmt.Errorf("error finding distro for container pool %s", pool.Id))
+			catcher.Add(fmt.Errorf("error finding distro for container pool '%s'", pool.Id))
 		}
 		if d.ContainerPool != "" {
-			catcher.Add(fmt.Errorf("container pool %s has invalid distro", pool.Id))
+			catcher.Add(fmt.Errorf("container pool '%s' has invalid distro '%s'", pool.Id, d.Id))
 		}
 	}
 	return errors.WithStack(catcher.Resolve())

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -135,8 +135,8 @@ func TestValidateContainerPoolDistros(t *testing.T) {
 	}
 
 	err := ValidateContainerPoolDistros(testSettings)
-	assert.Contains(err.Error(), "container pool test-pool-2 has invalid distro")
-	assert.Contains(err.Error(), "error finding distro for container pool test-pool-3")
+	assert.Contains(err.Error(), "container pool 'test-pool-2' has invalid distro 'invalid-distro'")
+	assert.Contains(err.Error(), "error finding distro for container pool 'test-pool-3'")
 }
 
 func TestGetDistroIds(t *testing.T) {

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -141,7 +141,7 @@ func TestValidateContainerPoolDistros(t *testing.T) {
 
 func TestGetDistroIds(t *testing.T) {
 	assert := assert.New(t)
-	hosts := DistroGroup{
+	distros := DistroGroup{
 		Distro{
 			Id: "d1",
 		},
@@ -152,7 +152,7 @@ func TestGetDistroIds(t *testing.T) {
 			Id: "d3",
 		},
 	}
-	ids := hosts.GetDistroIds()
+	ids := distros.GetDistroIds()
 	assert.Equal([]string{"d1", "d2", "d3"}, ids)
 }
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1498,12 +1498,13 @@ func FindAllRunningParentsOrdered() ([]Host, error) {
 	return hosts, nil
 }
 
-// FindAllRunningParentsOnDistro finds all running hosts of a given distro with child containers
-func FindAllRunningParentsByDistro(distroId string) ([]Host, error) {
+// FindAllRunningParentsByDistroID finds all running hosts of a given distro ID
+// with child containers.
+func FindAllRunningParentsByDistroID(distroID string) ([]Host, error) {
 	query := db.Query(bson.M{
 		StatusKey:        evergreen.HostRunning,
 		HasContainersKey: true,
-		bsonutil.GetDottedKeyName(DistroKey, distro.IdKey): distroId,
+		bsonutil.GetDottedKeyName(DistroKey, distro.IdKey): distroID,
 	}).Sort([]string{LastContainerFinishTimeKey})
 	return Find(query)
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2972,7 +2972,7 @@ func TestGetHostIds(t *testing.T) {
 	assert.Equal([]string{"h1", "h2", "h3"}, ids)
 }
 
-func TestFindAllRunningParentsByDistro(t *testing.T) {
+func TestFindAllRunningParentsByDistroID(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 
@@ -3033,7 +3033,7 @@ func TestFindAllRunningParentsByDistro(t *testing.T) {
 	assert.NoError(host7.Insert())
 	assert.NoError(host8.Insert())
 
-	parents, err := FindAllRunningParentsByDistro(d1)
+	parents, err := FindAllRunningParentsByDistroID(d1)
 	assert.NoError(err)
 	assert.Equal(2, len(parents))
 }

--- a/model/scheduler_stats.go
+++ b/model/scheduler_stats.go
@@ -290,7 +290,6 @@ func CreateAllHostUtilizationBuckets(daysBack, granularity int) ([]HostUtilizati
 // start time for that time frame.
 // One thing to note is that the average time is in milliseconds, not nanoseconds and must be converted.
 func AverageStatistics(distroId string, bounds FrameBounds) (AvgBuckets, error) {
-
 	// error out if the distro does not exist
 	_, err := distro.FindOne(distro.ById(distroId))
 	if err != nil {

--- a/model/task_config.go
+++ b/model/task_config.go
@@ -123,7 +123,17 @@ func MakeConfigFromTask(t *task.Task) (*TaskConfig, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding version")
 	}
-	d, err := distro.FindOne(distro.ById(t.DistroId))
+	dat, err := distro.NewDistroAliasesLookupTable()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get distro lookup table")
+	}
+	distroIDs := dat.Expand([]string{t.DistroId})
+	if len(distroIDs) == 0 {
+		return nil, errors.Errorf("could not resolve distro '%s'", t.DistroId)
+	}
+	// If this distro name is aliased, it could resolve into multiple concrete
+	// distros, so just pick one of them.
+	d, err := distro.FindOne(distro.ById(distroIDs[0]))
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding distro")
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -162,20 +162,11 @@ func (dc *DBCreateHostConnector) MakeIntentHost(taskID, userID, publicKey string
 }
 
 func makeDockerIntentHost(taskID, userID string, createHost apimodels.CreateHost) (*host.Host, error) {
-	d := distro.Distro{}
+	var d distro.Distro
 	var err error
 
 	if distroID := createHost.Distro; distroID != "" {
-		var dat distro.AliasLookupTable
-		dat, err = distro.NewDistroAliasesLookupTable()
-		if err != nil {
-			return nil, errors.Wrap(err, "problem creating distro alias lookup table")
-		}
-		distroIDs := dat.Expand([]string{distroID})
-		if len(distroIDs) == 0 {
-			return nil, errors.Wrap(err, "distro lookup returned no matching distro IDs")
-		}
-		d, err = distro.FindOne(distro.ById(distroIDs[0]))
+		d, err = distro.FindOne(distro.ById(distroID))
 		if err != nil {
 			return nil, errors.Wrapf(err, "problem finding distro '%s'", distroID)
 		}
@@ -253,7 +244,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		var dat distro.AliasLookupTable
 		dat, err = distro.NewDistroAliasesLookupTable()
 		if err != nil {
-			return nil, errors.Wrap(err, "problem creating distro alias lookup table")
+			return nil, errors.Wrap(err, "could not get distro lookup table")
 		}
 		distroIDs := dat.Expand([]string{distroID})
 		if len(distroIDs) == 0 {

--- a/rest/route/admin_clear.go
+++ b/rest/route/admin_clear.go
@@ -2,9 +2,10 @@ package route
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
-	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
 )
@@ -23,12 +24,10 @@ func (h *clearTaskQueueHandler) Factory() gimlet.RouteHandler { return &clearTas
 func (h *clearTaskQueueHandler) Parse(ctx context.Context, r *http.Request) error {
 	h.distro = r.FormValue("distro")
 
-	_, err := distro.FindOne(distro.ById(h.distro))
-
-	if err != nil {
+	if tq, err := model.LoadTaskQueue(h.distro); err != nil || tq == nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
-			Message:    "unable to find distro",
+			Message:    fmt.Sprintf("unable to find task queue for distro '%s'", h.distro),
 		}
 	}
 

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -194,8 +194,8 @@ func (s *AdminRouteSuite) TestAdminRoute() {
 	s.NoError(err)
 	s.NoError(s.postHandler.Parse(ctx, request))
 	resp = s.postHandler.Run(ctx)
-	s.Contains(resp.Data().(gimlet.ErrorResponse).Message, "container pool test-pool-2 has invalid distro")
-	s.Contains(resp.Data().(gimlet.ErrorResponse).Message, "error finding distro for container pool test-pool-3")
+	s.Contains(resp.Data().(gimlet.ErrorResponse).Message, "container pool 'test-pool-2' has invalid distro 'invalid-distro'")
+	s.Contains(resp.Data().(gimlet.ErrorResponse).Message, "error finding distro for container pool 'test-pool-3'")
 	s.NotNil(resp)
 }
 

--- a/scheduler/utilization_based_host_allocator.go
+++ b/scheduler/utilization_based_host_allocator.go
@@ -113,7 +113,7 @@ func evalHostUtilization(ctx context.Context, d distro.Distro, taskGroupData Tas
 	if containerPool != nil {
 		parentDistro, err := distro.FindOne(distro.ById(containerPool.Distro))
 		if err != nil {
-			return 0, errors.Wrap(err, "error finding parent distro")
+			return 0, errors.Wrap(err, "error finding parent distros")
 		}
 		maxHosts = parentDistro.HostAllocatorSettings.MaximumHosts * containerPool.MaxContainers
 	}

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -396,7 +396,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 
 	d, err := distro.FindOne(distro.ById(currentHost.Distro.Id))
 	if err != nil {
-		// Should we bailout if there is a database error leaving us unsure if the distro document actual exists?
+		// Should we bailout if there is a database error leaving us unsure if the distro document actually exists?
 		m := "database error while retrieving distro document;"
 		if adb.ResultsNotFound(err) {
 			m = "cannot find the db.distro document for the given distro;"

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -34,7 +34,6 @@ var (
 )
 
 func (uis *UIServer) spawnPage(w http.ResponseWriter, r *http.Request) {
-
 	var spawnDistro distro.Distro
 	var spawnTask *task.Task
 	var err error

--- a/units/host_monitoring_parent_decommission.go
+++ b/units/host_monitoring_parent_decommission.go
@@ -54,7 +54,7 @@ func NewParentDecommissionJob(id, d string, maxContainers int) amboy.Job {
 
 func (j *parentDecommissionJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
-	parents, err := host.FindAllRunningParentsByDistro(j.DistroId)
+	parents, err := host.FindAllRunningParentsByDistroID(j.DistroId)
 	if err != nil {
 		j.AddError(err)
 		return

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
@@ -216,12 +215,6 @@ func (j *agentDeployJob) startAgentOnHost(ctx context.Context, settings *evergre
 	if err != nil {
 		return errors.Wrapf(err, "Error getting ssh options for host %s", j.host.Id)
 	}
-
-	d, err := distro.FindOne(distro.ById(j.host.Distro.Id))
-	if err != nil {
-		return errors.Wrapf(err, "error finding distro %s", j.host.Distro.Id)
-	}
-	j.host.Distro = d
 
 	if err = j.prepRemoteHost(ctx, sshOptions, settings); err != nil {
 		return errors.Wrap(err, "could not prep remote host")

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2194,7 +2194,7 @@ buildvariants:
 	assert.NoError(CheckProjectConfigurationIsValid(&proj), "no errors are reported because they are warnings")
 }
 
-func TestGetDistroIdsForProject(t *testing.T) {
+func TestGetDistrosForProject(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	require.NoError(db.Clear(distro.Collection))
@@ -2215,20 +2215,20 @@ func TestGetDistroIdsForProject(t *testing.T) {
 	}
 	require.NoError(d.Insert())
 
-	ids, aliases, err := getDistroIds()
+	ids, aliases, err := getDistros()
 	require.NoError(err)
 	require.Len(ids, 3)
 	require.Len(aliases, 3)
 	assert.Contains(aliases, "distro1and2-alias")
 	assert.Contains(aliases, "distro1-alias")
 	assert.Contains(aliases, "distro2-alias")
-	ids, aliases, err = getDistroIdsForProject("project1")
+	ids, aliases, err = getDistrosForProject("project1")
 	require.NoError(err)
 	require.Len(ids, 2)
 	assert.Contains(ids, "distro1")
 	assert.Contains(aliases, "distro1and2-alias")
 	assert.Contains(aliases, "distro1-alias")
-	ids, aliases, err = getDistroIdsForProject("project3")
+	ids, aliases, err = getDistrosForProject("project3")
 	require.NoError(err)
 	require.Len(ids, 1)
 	assert.Contains(ids, "distro2")


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7600

I checked all the places where we rely on distro IDs and added validation to prevent docker parents and containers from using distro aliases.

DIstro aliases are allowed for:
* Tasks
* host.create command
    * Making hosts from this task's host.create when starting a spawn host

Distro aliases are _not_ allowed for:
* Docker container/parent distros
    * This is mostly because container pools have to map 1:1 to an exact distro ID.
    * Also, it would mess with the host allocator if a distro alias mapped to multiple parents or multiple container distros.
* Spawn hosts - typically, someone should know which distro they want to make and what they're going to get.
* Scheduler stats for a distro (i.e. `evergreen export`)