### PR TITLE
EVG-7613 handle backend-not-reachable errors

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -127,7 +127,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: 8f70457166d7c55c692421650fc3dbd3a8ef7ba4
   - name: github.com/evergreen-ci/gimlet
-    version: 62e03be7c89a3c538aa8b10e99faee3a34399852
+    version: 370160a3e2c0fd6c95eabf0997f81f707552cb24
   - name: github.com/evergreen-ci/shrub
     version: 32e668cd99410328bf6659e55671c11a6c727d9a
   - name: github.com/evergreen-ci/pail

--- a/service/host.go
+++ b/service/host.go
@@ -323,3 +323,9 @@ func (uis *UIServer) getHostFromCache(hostID string) (*hostCacheItem, error) {
 
 	return &h, nil
 }
+
+func (uis *UIServer) handleBackendError(message string, statusCode int) func(http.ResponseWriter, *http.Request, error) {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		gimlet.WriteTextResponse(w, statusCode, message)
+	}
+}

--- a/service/ui.go
+++ b/service/ui.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/99designs/gqlgen/graphql/playground"
+	"github.com/PuerkitoBio/rehttp"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/graphql"
 	"github.com/evergreen-ci/evergreen/model"
@@ -358,7 +359,8 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 		FindTarget:        uis.getHostDNS,
 		StripSourcePrefix: true,
 		RemoteScheme:      "http",
-		ErrorHandler:      uis.handleBackendError("IDE service is not available", http.StatusInternalServerError),
+		Transport:         rehttp.NewTransport(nil, rehttp.RetryAll(rehttp.RetryMaxRetries(5), rehttp.RetryTemporaryErr()), rehttp.ConstDelay(2*time.Second)),
+		ErrorHandler:      uis.handleBackendError("IDE service is not available.\nEnsure the code-server service is running", http.StatusInternalServerError),
 	}).AllMethods()
 	// Prefix routes not ending in a '/' are not automatically redirected by gimlet's underlying library.
 	// Add another route to match when there's no trailing slash and redirect

--- a/service/ui.go
+++ b/service/ui.go
@@ -358,6 +358,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 		FindTarget:        uis.getHostDNS,
 		StripSourcePrefix: true,
 		RemoteScheme:      "http",
+		ErrorHandler:      uis.handleBackendError("IDE service is not available", http.StatusInternalServerError),
 	}).AllMethods()
 	// Prefix routes not ending in a '/' are not automatically redirected by gimlet's underlying library.
 	// Add another route to match when there's no trailing slash and redirect

--- a/vendor/github.com/evergreen-ci/gimlet/.golangci.yml
+++ b/vendor/github.com/evergreen-ci/gimlet/.golangci.yml
@@ -1,0 +1,15 @@
+---
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - goimports
+    - govet
+    - ineffassign
+    - interfacer
+    - misspell
+    - unconvert
+
+linters-settings:
+  govet:
+    check-shadowing: true

--- a/vendor/github.com/evergreen-ci/gimlet/app.go
+++ b/vendor/github.com/evergreen-ci/gimlet/app.go
@@ -193,7 +193,7 @@ func (a *APIApp) SetHost(name string) error {
 }
 
 // SetPrefix sets the route prefix, adding a leading slash, "/", if
-// neccessary.
+// necessary.
 func (a *APIApp) SetPrefix(p string) {
 	if !strings.HasPrefix(p, "/") {
 		p = "/" + p

--- a/vendor/github.com/evergreen-ci/gimlet/app_routing.go
+++ b/vendor/github.com/evergreen-ci/gimlet/app_routing.go
@@ -155,7 +155,7 @@ func (r *APIRoute) Version(version int) *APIRoute {
 // Handler makes it possible to register an http.HandlerFunc with a
 // route. Chainable. The common pattern for implementing these
 // functions is to write functions and methods in your application
-// that *return* handler fucntions, so you can pass application state
+// that *return* handler functions, so you can pass application state
 // or other data into to the handlers when the applications start,
 // without relying on either global state *or* running into complex
 // typing issues.

--- a/vendor/github.com/evergreen-ci/gimlet/buildscripts/run-linter.go
+++ b/vendor/github.com/evergreen-ci/gimlet/buildscripts/run-linter.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/mongodb/grip"
 )
 
 type result struct {
@@ -28,7 +30,6 @@ func (r *result) String() string {
 	if r.passed {
 		fmt.Fprintf(buf, "--- PASS: %s (%s)", r.name, r.duration)
 	} else {
-		// fmt.Fprintln(buf, "    CMD:", r.cmd)
 		fmt.Fprintf(buf, strings.Join(r.output, "\n"))
 		fmt.Fprintf(buf, "--- FAIL: %s (%s)", r.name, r.duration)
 	}
@@ -47,40 +48,45 @@ func (r *result) fixup(dirname string) {
 	}
 }
 
-// runs the gometalinter on a list of packages; integrating with the "make lint" target.
+// runs the golangci-lint on a list of packages; integrating with the "make lint" target.
 func main() {
 	var (
-		lintArgs       string
-		lintBin        string
-		packageList    string
-		output         string
-		packages       []string
-		results        []*result
-		hasFailingTest bool
+		lintArgs          string
+		lintBin           string
+		customLintersFlag string
+		customLinters     []string
+		packageList       string
+		output            string
+		packages          []string
+		results           []*result
+		hasFailingTest    bool
 
 		gopath = os.Getenv("GOPATH")
 	)
 
 	gopath, _ = filepath.Abs(gopath)
 
-	flag.StringVar(&lintArgs, "lintArgs", "", "args to pass to gometalinter")
-	flag.StringVar(&lintBin, "lintBin", filepath.Join(gopath, "bin", "gometalinter"), "path to go metalinter")
+	flag.StringVar(&lintArgs, "lintArgs", "", "args to pass to golangci-lint")
+	flag.StringVar(&lintBin, "lintBin", filepath.Join(gopath, "bin", "golangci-lint"), "path to golangci-lint")
 	flag.StringVar(&packageList, "packages", "", "list of space separated packages")
+	flag.StringVar(&customLintersFlag, "customLinters", "", "list of comma-separated custom linter commands")
 	flag.StringVar(&output, "output", "", "output file for to write results.")
 	flag.Parse()
 
+	if len(customLintersFlag) != 0 {
+		customLinters = strings.Split(customLintersFlag, ",")
+	}
 	packages = strings.Split(strings.Replace(packageList, "-", "/", -1), " ")
 	dirname, _ := os.Getwd()
 	cwd := filepath.Base(dirname)
 	lintArgs += fmt.Sprintf(" --concurrency=%d", runtime.NumCPU()/2)
 
 	for _, pkg := range packages {
-		args := []string{lintBin, lintArgs}
-		if cwd == pkg {
-			args = append(args, ".")
-		} else {
-			args = append(args, "./"+pkg)
+		pkgDir := "./"
+		if cwd != pkg {
+			pkgDir += pkg
 		}
+		args := []string{lintBin, "run", lintArgs, pkgDir}
 
 		startAt := time.Now()
 		cmd := strings.Join(args, " ")
@@ -91,6 +97,13 @@ func main() {
 			passed:   err == nil,
 			duration: time.Since(startAt),
 			output:   strings.Split(string(out), "\n"),
+		}
+		for _, linter := range customLinters {
+			customLinterStart := time.Now()
+			out, err = exec.Command("sh", "-c", fmt.Sprintf("%s %s", linter, pkgDir)).CombinedOutput()
+			r.passed = r.passed && err == nil
+			r.duration += time.Since(customLinterStart)
+			r.output = append(r.output, strings.Split(string(out), "\n")...)
 		}
 		r.fixup(dirname)
 
@@ -114,7 +127,10 @@ func main() {
 		}()
 
 		for _, r := range results {
-			f.WriteString(r.String() + "\n")
+			if _, err = f.WriteString(r.String() + "\n"); err != nil {
+				grip.Error(err)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/vendor/github.com/evergreen-ci/gimlet/evergreen.yaml
+++ b/vendor/github.com/evergreen-ci/gimlet/evergreen.yaml
@@ -139,14 +139,14 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector (Arch Linux)
     expansions:
-      goroot: /opt/golang/go1.9
-      go_bin_path: /opt/golang/go1.9/bin/go
+      goroot: /opt/golang/go1.13
+      go_bin_path: /opt/golang/go1.13/bin/go
       race_enabed: true
       test_timeout: 15m
       disable_coverage: yes
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
     run_on:
-      - archlinux-test
+      - ubuntu1604-test
     tasks:
       - name: ".race"
 
@@ -156,8 +156,8 @@ buildvariants:
       - ubuntu1604-test
     expansions:
       test_timeout: 15m
-      goroot: /opt/golang/go1.9
-      go_bin_path: /opt/golang/go1.9/bin/go
+      goroot: /opt/golang/go1.13
+      go_bin_path: /opt/golang/go1.13/bin/go
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
     tasks:
       - name: ".report"
@@ -176,13 +176,13 @@ buildvariants:
       - ".test"
 
   - name: macos
-    display_name: macOS 10.12
+    display_name: macOS
     expansions:
       disable_coverage: yes
       go_bin_path: /opt/golang/go1.9/bin/go
       goroot: /opt/golang/go1.9
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     run_on:
-      - macos-1012
+      - macos-1014
     tasks:
       - name: ".test"

--- a/vendor/github.com/evergreen-ci/gimlet/framework_response_error.go
+++ b/vendor/github.com/evergreen-ci/gimlet/framework_response_error.go
@@ -7,7 +7,7 @@ import (
 // MakeTextErrorResponder takes an error object and converts
 // it into a responder object that wrap's gimlet's ErrorResponse
 // type. Since ErrorResponse implements the error interface, if you
-// pass an ErrorResposne object, this function will propogate the
+// pass an ErrorResposne object, this function will propagate the
 // status code specified in the ErrorResponse if that code is valid,
 // otherwise the status code of the request and the response object
 // will be 400.
@@ -18,7 +18,7 @@ func MakeTextErrorResponder(err error) Responder {
 // MakeJSONErrorResponder takes an error object and converts
 // it into a responder object that wrap's gimlet's ErrorResponse
 // type. Since ErrorResponse implements the error interface, if you
-// pass an ErrorResposne object, this function will propogate the
+// pass an ErrorResposne object, this function will propagate the
 // status code specified in the ErrorResponse if that code is valid,
 // otherwise the status code of the request and the response object
 // will be 400.
@@ -29,7 +29,7 @@ func MakeJSONErrorResponder(err error) Responder {
 // MakeYAMLErrorResponder takes an error object and converts
 // it into a responder object that wrap's gimlet's ErrorResponse
 // type. Since ErrorResponse implements the error interface, if you
-// pass an ErrorResposne object, this function will propogate the
+// pass an ErrorResposne object, this function will propagate the
 // status code specified in the ErrorResponse if that code is valid,
 // otherwise the status code of the request and the response object
 // will be 400.
@@ -40,7 +40,7 @@ func MakeYAMLErrorResponder(err error) Responder {
 // MakeTextInternalErrorResponder takes an error object and converts
 // it into a responder object that wrap's gimlet's ErrorResponse
 // type. Since ErrorResponse implements the error interface, if you
-// pass an ErrorResposne object, this function will propogate the
+// pass an ErrorResposne object, this function will propagate the
 // status code specified in the ErrorResponse if that code is valid,
 // otherwise the status code of the request and the response object
 // will be 500.
@@ -51,7 +51,7 @@ func MakeTextInternalErrorResponder(err error) Responder {
 // MakeJSONInternalErrorResponder takes an error object and converts
 // it into a responder object that wrap's gimlet's ErrorResponse
 // type. Since ErrorResponse implements the error interface, if you
-// pass an ErrorResposne object, this function will propogate the
+// pass an ErrorResposne object, this function will propagate the
 // status code specified in the ErrorResponse if that code is valid,
 // otherwise the status code of the request and the response object
 // will be 500.
@@ -62,7 +62,7 @@ func MakeJSONInternalErrorResponder(err error) Responder {
 // MakeYAMLInternalErrorResponder takes an error object and converts
 // it into a responder object that wrap's gimlet's ErrorResponse
 // type. Since ErrorResponse implements the error interface, if you
-// pass an ErrorResposne object, this function will propogate the
+// pass an ErrorResposne object, this function will propagate the
 // status code specified in the ErrorResponse if that code is valid,
 // otherwise the status code of the request and the response object
 // will be 500.

--- a/vendor/github.com/evergreen-ci/gimlet/handling_test.go
+++ b/vendor/github.com/evergreen-ci/gimlet/handling_test.go
@@ -141,7 +141,9 @@ type mangledResponseWriter struct{ *httptest.ResponseRecorder }
 func (r mangledResponseWriter) Write(b []byte) (int, error) { return 0, errors.New("always errors") }
 
 func TestWriteResponseErrorLogs(t *testing.T) {
-	defer grip.SetSender(grip.GetSender())
+	defer func(s send.Sender) {
+		assert.NoError(t, grip.SetSender(s))
+	}(grip.GetSender())
 	assert := assert.New(t)
 	sender := send.MakeInternalLogger()
 	rw := mangledResponseWriter{httptest.NewRecorder()}

--- a/vendor/github.com/evergreen-ci/gimlet/makefile
+++ b/vendor/github.com/evergreen-ci/gimlet/makefile
@@ -24,31 +24,16 @@ goEnv := GOPATH=$(gopath) $(if $(GO_BIN_PATH),PATH="$(shell dirname $(GO_BIN_PAT
 # end go environment configuration
 
 
-# start linting configuration
-#   package, testing, and linter dependencies specified
-#   separately. This is a temporary solution: eventually we should
-#   vendorize all of these dependencies.
-lintDeps := github.com/alecthomas/gometalinter
-lintDeps += github.com/richardsamuels/evg-lint/...
-#   include test files and give linters 40s to run to avoid timeouts
-lintArgs := --tests --deadline=1m --vendor --aggregate --sort=line
-#   gotype produces false positives because it reads .a files which
-#   are rarely up to date.
-lintArgs += --disable="gotype" --disable="golint" --disable="gosec" --disable="staticcheck"
-lintArgs += --enable="goimports"
-lintArgs += --vendored-linters --enable-gc
-#  add and configure additional linters
-lintArgs += --line-length=100 --dupl-threshold=175 --cyclo-over=17
-#  two similar functions triggered the duplicate warning, but they're not.
-lintArgs += --exclude="duplicate of registry.go"
-lintArgs += --exclude="don.t use underscores.*_DependencyState.*"
-#  golint doesn't handle splitting package comments between multiple files.
-lintArgs += --exclude="package comment should be of the form \"Package .* \(golint\)"
-lintArgs += --exclude="error return value not checked \(defer .* \(errcheck\)$$"
-lintArgs += --exclude="declaration of \"assert\" shadows declaration at .*_test.go:"
-lintArgs += --exclude="declaration of \"require\" shadows declaration at .*_test.go:"
-lintArgs += --linter="evg:$(gopath)/bin/evg-lint:PATH:LINE:COL:MESSAGE" --enable=evg
-# end lint suppressions
+# start lint setup targets
+lintDeps := $(buildDir)/.lintSetup $(buildDir)/run-linter $(buildDir)/golangci-lint
+$(buildDir)/.lintSetup:$(buildDir)/golangci-lint
+	@touch $@
+$(buildDir)/golangci-lint:$(buildDir)
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.23.8 >/dev/null 2>&1
+$(buildDir)/run-linter:buildscripts/run-linter.go $(buildDir)/.lintSetup $(buildDir)
+	@$(goEnv) $(gobin) build -o $@ $<
+# end lint setup targets
+
 
 ######################################################################
 ##
@@ -61,46 +46,30 @@ lintArgs += --linter="evg:$(gopath)/bin/evg-lint:PATH:LINE:COL:MESSAGE" --enable
 
 # start dependency installation tools
 #   implementation details for being able to lazily install dependencies
-lintDeps := $(addprefix $(gopath)/src/,$(lintDeps))
-srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go")
-testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*")
 testOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).test))
 raceOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).race))
 coverageOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).coverage))
 coverageHtmlOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html))
-$(gopath)/src/%:
-	@-[ ! -d $(gopath) ] && mkdir -p $(gopath) || true
-	$(goEnv) $(gobin) get $(subst $(gopath)/src/,,$@)
 # end dependency installation tools
 
 
 # lint setup targets
-lintDeps := $(addprefix $(gopath)/src/,$(lintDeps))
-lintTargets := $(foreach target,$(packages),lint-$(target))
-$(buildDir)/.lintSetup:$(lintDeps)
-	@mkdir -p $(buildDir)
-	@-$(goEnv) $(gopath)/bin/gometalinter --force --install >/dev/null && touch $@
-	@touch $@
-$(buildDir)/run-linter:buildscripts/run-linter.go
-	$(goEnv) $(gobin) build -o $@ $<
-.PRECIOUS:$(buildDir)/output.lint
 # end lint setup targets
 
 # userfacing targets for basic build and development operations
 lint:$(buildDir)/output.lint
-lint-deps:$(lintDeps)
-build:$(deps) $(srcFiles) $(gopath)/src/$(projectPath)
+$(buildDir): $(gopath)/src/$(projectPath)
 	@mkdir -p $(buildDir)
 	$(goEnv) $(gobin) build ./.
-build-race:$(deps) $(srcFiles) $(gopath)/src/$(projectPath)
+build-race: $(gopath)/src/$(projectPath)
 	$(goEnv) $(gobin) build -race $(subst -,/,$(foreach pkg,$(packages),./$(pkg)))
 test:$(testOutput)
 race:$(raceOutput)
 coverage:$(coverageOutput)
 coverage-html:$(coverageHtmlOutput)
 phony := build build-race race test coverage coverage-html
-phony += deps test-deps lint-deps
 .PRECIOUS: $(testOutput) $(raceOutput) $(coverageOutput) $(coverageHtmlOutput)
+.PRECIOUS: $(buildDir)/output.lint
 # end front-ends
 
 
@@ -110,9 +79,9 @@ $(gopath)/src/$(orgPath):
 	@mkdir -p $@
 $(gopath)/src/$(projectPath):$(gopath)/src/$(orgPath)
 	@[ -L $@ ] || ln -s $(shell pwd) $@
-$(buildDir)/$(name):$(gopath)/src/$(projectPath) $(srcFiles) $(deps)
+$(buildDir)/$(name):$(gopath)/src/$(projectPath)
 	$(goEnv) $(gobin) build -o $@ main/$(name).go
-$(buildDir)/$(name).race:$(gopath)/src/$(projectPath) $(srcFiles) $(deps)
+$(buildDir)/$(name).race:
 	$(goEnv) $(gobin) build -race -o $@ main/$(name).go
 # end main build
 
@@ -137,7 +106,6 @@ lint-%:$(buildDir)/output.%.lint
 #    tests have compile and runtime deps. This varable has everything
 #    that the tests actually need to run. (The "build" target is
 #    intentional and makes these targets rerun as expected.)
-testRunDeps := $(testSrcFiles) build
 testArgs := -test.v
 ifneq (,$(RUN_TEST))
 testArgs += -test.run='$(RUN_TEST)'
@@ -157,25 +125,25 @@ endif
 #    and save test output.
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	$(goEnv) $(gobin) tool cover -html=$(buildDir)/output.$(subst /,-,$*).coverage -o $(buildDir)/output.$(subst /,-,$*).coverage.html
-$(buildDir)/output.%.coverage:$(testRunDeps)
+$(buildDir)/output.%.coverage: $(buildDir)
 	$(goEnv) $(gobin) test $(testArgs) -covermode=count -coverprofile=$(buildDir)/output.$(subst /,-,$*).coverage $(projectPath)/$(subst -,/,$*)
 	@-[ -f $(buildDir)/output.$(subst /,-,$*).coverage ] && $(goEnv) $(gobin) tool cover -func=$(buildDir)/output.$(subst /,-,$*).coverage | sed 's%$(projectPath)/%%' | column -t
-$(buildDir)/output.$(name).coverage:$(testRunDeps)
+$(buildDir)/output.$(name).coverage: $(buildDir)
 	$(goEnv) $(gobin) test -covermode=count -coverprofile=$@ $(projectPath)
 	@-[ -f $@ ] && $(goEnv) $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
-$(buildDir)/output.%.test:$(testRunDeps) .FORCE
+$(buildDir)/output.%.test: $(buildDir) .FORCE
 	$(goEnv) $(gobin) test $(testArgs) ./$(subst -,/,$*) | tee $(buildDir)/output.$(subst /,-,$*).test
-$(buildDir)/output.%.race:$(testRunDeps) .FORCE
+$(buildDir)/output.%.race: .FORCE
 	$(goEnv) $(gobin) test $(testArgs) -race ./$(subst -,/,$*) | tee $(buildDir)/output.$(subst /,-,$*).race
-$(buildDir)/output.$(name).test:$(testRunDeps) .FORCE
+$(buildDir)/output.$(name).test: $(buildDir) .FORCE
 	$(goEnv) $(gobin) test $(testArgs) ./ | tee $@
-$(buildDir)/output.$(name).race:$(testRunDeps) .FORCE
+$(buildDir)/output.$(name).race: $(buildDir) .FORCE
 	$(goEnv) $(gobin) test $(testArgs) -race ./ | tee $@
 #  targets to generate gotest output from the linter.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter $(testSrcFiles)  $(buildDir)/.lintSetup .FORCE
-	@./$< --output=$@ --lintArgs='$(lintArgs)' --packages='$*'
+$(buildDir)/output.%.lint:$(buildDir)/run-linter $(buildDir)/.lintSetup .FORCE
+	@$(goEnv) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 $(buildDir)/output.lint:$(buildDir)/run-linter $(buildDir)/.lintSetup .FORCE
-	@./$< --output="$@" --lintArgs='$(lintArgs)' --packages="$(packages)"
+	@$(goEnv) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$(packages)'
 # end test and coverage artifacts
 
 

--- a/vendor/github.com/evergreen-ci/gimlet/middleware_auth_user_test.go
+++ b/vendor/github.com/evergreen-ci/gimlet/middleware_auth_user_test.go
@@ -181,18 +181,18 @@ func TestUserMiddlewareConfiguration(t *testing.T) {
 	require.NoError(t, conf.Validate())
 
 	t.Run("DiabledChecksAreValid", func(t *testing.T) {
-		conf := UserMiddlewareConfiguration{
+		emptyConf := UserMiddlewareConfiguration{
 			SkipCookie:      true,
 			SkipHeaderCheck: true,
 		}
-		assert.NoError(t, conf.Validate())
+		assert.NoError(t, emptyConf.Validate())
 	})
 	t.Run("ZeroValueIsNotValid", func(t *testing.T) {
-		conf := UserMiddlewareConfiguration{}
-		assert.Zero(t, conf.CookiePath)
-		assert.Error(t, conf.Validate())
+		emptyConf := UserMiddlewareConfiguration{}
+		assert.Zero(t, emptyConf.CookiePath)
+		assert.Error(t, emptyConf.Validate())
 		// also we expect that the validate will populate the Tl
-		assert.NotZero(t, conf.CookiePath)
+		assert.NotZero(t, emptyConf.CookiePath)
 	})
 
 	t.Run("Cookie", func(t *testing.T) {

--- a/vendor/github.com/evergreen-ci/gimlet/proxy_no_error.go
+++ b/vendor/github.com/evergreen-ci/gimlet/proxy_no_error.go
@@ -1,0 +1,44 @@
+// +build !go1.11
+
+package gimlet
+
+import (
+	"net/http/httputil"
+
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
+)
+
+// Proxy adds a simple reverse proxy handler to the specified route,
+// based on the options described in the ProxyOption structure.
+// In most cases you'll want to specify a route matching pattern
+// that captures all routes that begin with a specific prefix.
+func (r *APIRoute) Proxy(opts ProxyOptions) *APIRoute {
+	if err := opts.Validate(); err != nil {
+		grip.Alert(message.WrapError(err, message.Fields{
+			"message":          "invalid proxy options",
+			"route":            r.route,
+			"version":          r.version,
+			"existing_handler": r.handler != nil,
+		}))
+		return r
+	}
+
+	if opts.ErrorHandler != nil {
+		grip.Alert(message.Fields{
+			"message":          "custom error handler ignored in < go1.11",
+			"route":            r.route,
+			"version":          r.version,
+			"existing_handler": r.handler != nil,
+		})
+	}
+
+	r.handler = (&httputil.ReverseProxy{
+		Transport: opts.Transport,
+		ErrorLog:  grip.MakeStandardLogger(level.Warning),
+		Director:  opts.director,
+	}).ServeHTTP
+
+	return r
+}

--- a/vendor/github.com/evergreen-ci/gimlet/proxy_with_error.go
+++ b/vendor/github.com/evergreen-ci/gimlet/proxy_with_error.go
@@ -1,0 +1,36 @@
+// +build go1.11
+
+package gimlet
+
+import (
+	"net/http/httputil"
+
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
+)
+
+// Proxy adds a simple reverse proxy handler to the specified route,
+// based on the options described in the ProxyOption structure.
+// In most cases you'll want to specify a route matching pattern
+// that captures all routes that begin with a specific prefix.
+func (r *APIRoute) Proxy(opts ProxyOptions) *APIRoute {
+	if err := opts.Validate(); err != nil {
+		grip.Alert(message.WrapError(err, message.Fields{
+			"message":          "invalid proxy options",
+			"route":            r.route,
+			"version":          r.version,
+			"existing_handler": r.handler != nil,
+		}))
+		return r
+	}
+
+	r.handler = (&httputil.ReverseProxy{
+		Transport:    opts.Transport,
+		ErrorLog:     grip.MakeStandardLogger(level.Warning),
+		Director:     opts.director,
+		ErrorHandler: opts.ErrorHandler,
+	}).ServeHTTP
+
+	return r
+}

--- a/vendor/github.com/evergreen-ci/gimlet/rolemanager/role_manager_test.go
+++ b/vendor/github.com/evergreen-ci/gimlet/rolemanager/role_manager_test.go
@@ -579,3 +579,30 @@ func (s *RoleManagerSuite) TestPermissionSummaryForRoles() {
 	s.Equal(40, summary[0].Permissions["resource3"]["edit"])
 	s.Equal(50, summary[0].Permissions["resource3"]["read"])
 }
+
+func (s *RoleManagerSuite) TestHasPermission() {
+	opts := gimlet.PermissionOpts{
+		Resource:      "resource1",
+		ResourceType:  "project",
+		Permission:    "edit",
+		RequiredLevel: 10,
+	}
+	hasPermission := gimlet.Role{
+		ID:    "1",
+		Scope: "1",
+		Permissions: map[string]int{
+			"edit": 10,
+		},
+	}
+	s.NoError(s.m.UpdateRole(hasPermission))
+	noPermission := gimlet.Role{
+		ID:    "1",
+		Scope: "1",
+		Permissions: map[string]int{
+			"edit": 0,
+		},
+	}
+	s.NoError(s.m.UpdateRole(noPermission))
+	s.False(gimlet.HasPermission(s.m, opts, []gimlet.Role{noPermission}))
+	s.True(gimlet.HasPermission(s.m, opts, []gimlet.Role{hasPermission}))
+}

--- a/vendor/github.com/evergreen-ci/gimlet/server.go
+++ b/vendor/github.com/evergreen-ci/gimlet/server.go
@@ -79,7 +79,7 @@ func (c *ServerConfig) build() Server {
 	}}
 }
 
-// Resovle validates a config and constructs a server from the
+// Resolve validates a config and constructs a server from the
 // configuration if possible.
 func (c *ServerConfig) Resolve() (Server, error) {
 	if err := c.Validate(); err != nil {


### PR DESCRIPTION
If an error occurs reaching the backend (e.g.code-server isn't running) the default behavior is to return a 502 status code and an empty response. This will catch that error and pass a message and 500 status code.

Goes together with evergreen-ci/gimlet#77. Once that PR is approved it will be revendored and included here.