### PR TITLE
EVG-7233 display multiple regions on distro page

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -265,14 +265,17 @@ func UpdateProviderSettings(d *distro.Distro) error {
 }
 
 func CreateSettingsListFromLegacy(d *distro.Distro) error {
-	bytes, err := bson.Marshal(d.ProviderSettings)
-	if err != nil {
-		return errors.Wrap(err, "error marshalling provider setting into bson")
-	}
 	doc := &birch.Document{}
-	if err := doc.UnmarshalBSON(bytes); err != nil {
-		return errors.Wrapf(err, "error unmarshalling settings bytes into document")
+	if d.ProviderSettings != nil {
+		bytes, err := bson.Marshal(d.ProviderSettings)
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		if err := doc.UnmarshalBSON(bytes); err != nil {
+			return errors.Wrapf(err, "error unmarshalling settings bytes into document")
+		}
 	}
+
 	if IsEc2Provider(d.Provider) {
 		doc = doc.Set(birch.EC.String("region", evergreen.DefaultEC2Region))
 	}

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/testutil"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -82,6 +80,4 @@ func TestConvertContainerManager(t *testing.T) {
 	cm2, err := ConvertContainerManager(m2)
 	assert.EqualError(err, "Error converting manager to container manager")
 	assert.Nil(cm2)
-}
-
 }

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/testutil"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -80,5 +82,6 @@ func TestConvertContainerManager(t *testing.T) {
 	cm2, err := ConvertContainerManager(m2)
 	assert.EqualError(err, "Error converting manager to container manager")
 	assert.Nil(cm2)
+}
 
 }

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -98,7 +98,19 @@ func (s *EC2ProviderSettings) Validate() error {
 
 // region is only provided if we want to filter by region
 func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string) error {
-	if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 { // legacy case, to be removed
+	if len(d.ProviderSettingsList) != 0 {
+		settingsDoc, err := d.GetProviderSettingByRegion(region)
+		if err != nil {
+			return errors.Wrapf(err, "providers list doesn't contain region '%s'", region)
+		}
+		bytes, err := settingsDoc.MarshalBSON()
+		if err != nil {
+			return errors.Wrap(err, "error marshalling provider setting into bson")
+		}
+		if err := bson.Unmarshal(bytes, s); err != nil {
+			return errors.Wrap(err, "error unmarshalling bson into provider settings")
+		}
+	} else if d.ProviderSettings != nil && len(*d.ProviderSettings) > 0 { // legacy case, to be removed
 		if err := mapstructure.Decode(d.ProviderSettings, s); err != nil {
 			return errors.Wrapf(err, "Error decoding params for distro %s: %+v", d.Id, s)
 		}
@@ -112,18 +124,6 @@ func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string)
 			return errors.Errorf("only default region should be saved in provider settings")
 		}
 		s.Region = s.getRegion()
-	} else if len(d.ProviderSettingsList) != 0 {
-		settingsDoc, err := d.GetProviderSettingByRegion(region)
-		if err != nil {
-			return errors.Wrapf(err, "providers list doesn't contain region '%s'", region)
-		}
-		bytes, err := settingsDoc.MarshalBSON()
-		if err != nil {
-			return errors.Wrap(err, "error marshalling provider setting into bson")
-		}
-		if err := bson.Unmarshal(bytes, s); err != nil {
-			return errors.Wrap(err, "error unmarshalling bson into provider settings")
-		}
 	}
 	return nil
 }

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -231,9 +231,8 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
           return;
         }
     }
-    // if we haven't updated it, then we should remove from the list for now
+    // if the settings object is cleared, then we should remove from the list for now
     $scope.activeDistro.provider_settings.splice($scope.currentIdx);
-
   };
 
   $scope.switchRegion = function(region) {
@@ -262,6 +261,11 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
         return {"region": "us-east-1"};
       }
       return {};
+  };
+
+  // clear every field but region for the current settings object
+  $scope.clearSettings = function() {
+    $scope.activeDistro.settings = $scope.getNewProviderSettings($scope.activeDistro.provider, $scope.activeDistro.settings.region)
   };
 
   $scope.initOptions = function () {
@@ -612,6 +616,14 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
       return $scope.validSecurityGroup() && $scope.validSubnetId();
     }
     return true;
+  }
+
+  $scope.isDefaultRegion = function() {
+    // default region cannot be empty
+    if ($scope.activeDistro === undefined || $scope.activeDistro.settings === undefined || $scope.activeDistro.settings.region === "us-east-1") {
+      return true;
+    }
+    return false;
   }
 
   $scope.isWindows = function () {

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -488,13 +488,13 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
       var defaultOptions = {
         '_id': newId,
         'arch': 'linux_amd64',
-        'provider': 'ec2',
+        'provider': 'ec2-auto',
         'bootstrap_settings': {
           'method': 'legacy-ssh',
           'communication': 'legacy-ssh'
         },
         'clone_method': 'legacy-ssh',
-        'provider_settings': [{}], // empty list with one empty object
+        'provider_settings': [$scope.getNewProviderSettings('ec2-auto', "")], // empty list with one new object
         'finder_settings': {
           'version': 'legacy'
         },

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -148,6 +148,7 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
       } else if (distroHash != newId) {
         $scope.getDistroById(distroHash).then(function (distro) {
           if (distro) {
+            $scope.regions = distro.regions;
             $scope.readOnly = distro.permissions.distro_settings < 20
             $scope.remove = distro.permissions.distro_settings >= 30
             $scope.activeDistro = distro.distro;
@@ -206,12 +207,61 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
           distro.distro.bootstrap_settings.method = distro.distro.bootstrap_settings.method || 'legacy-ssh';
           distro.distro.bootstrap_settings.communication = distro.distro.bootstrap_settings.communication || 'legacy-ssh';
           distro.distro.clone_method = distro.distro.clone_method || 'legacy-ssh';
+
+          // current settings from provider settings
+          if (distro.distro.provider_settings === undefined || distro.distro.provider_settings.length === 0) {
+            distro.distro.provider_settings = [$scope.getNewProviderSettings(distro.distro.provider)];
+
+          }
+          distro.distro.settings = distro.distro.provider_settings[0];
+          $scope.currentIdx = 0;
         }
         return distro
       },
       function (resp) {
         console.log(resp.status)
       });
+  };
+
+  $scope.updateSettingsList = function() {
+    // don't save if there aren't any populated fields
+    for (let [key, val] of Object.entries($scope.activeDistro.settings)) {
+        if (key !== "region" && val !== "" && val !== undefined) {
+          $scope.activeDistro.provider_settings[$scope.currentIdx] = $scope.activeDistro.settings;
+          return;
+        }
+    }
+    // if we haven't updated it, then we should remove from the list for now
+    $scope.activeDistro.provider_settings.splice($scope.currentIdx);
+
+  };
+
+  $scope.switchRegion = function(region) {
+    // save current settings to the overall provider settings list
+    $scope.updateSettingsList();
+
+    for (var i = 0; i < $scope.activeDistro.provider_settings.length; i++) {
+      if ($scope.activeDistro.provider_settings[i].region === region) {
+        $scope.activeDistro.settings = $scope.activeDistro.provider_settings[i];
+        $scope.currentIdx = i;
+        return;
+      }
+    }
+
+    // if we didn't find the region in the provider settings list, then we must be adding a new one
+    $scope.activeDistro.settings = $scope.getNewProviderSettings($scope.activeDistro.provider, region);
+    $scope.activeDistro.provider_settings.push($scope.activeDistro.settings);
+    $scope.currentIdx = $scope.activeDistro.provider_settings.length - 1;
+  };
+
+  $scope.getNewProviderSettings = function(provider, region) {
+      if (provider.startsWith('ec2')) {
+        if (region !== "") {
+          return {"region": region};
+        }
+        return {"region": "us-east-1"};
+      }
+      return {};
   };
 
   $scope.initOptions = function () {
@@ -385,6 +435,8 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
     if ($scope.activeDistro.host_allocator_settings.acceptable_host_idle_time > 0) {
       $scope.activeDistro.host_allocator_settings.acceptable_host_idle_time *= 1e9
     }
+    $scope.updateSettingsList();
+    $scope.activeDistro.settings = null;
     if ($scope.activeDistro.new) {
       mciDistroRestService.addDistro(
         $scope.activeDistro, {
@@ -442,7 +494,7 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
           'communication': 'legacy-ssh'
         },
         'clone_method': 'legacy-ssh',
-        'settings': {},
+        'provider_settings': [{}], // empty list with one empty object
         'finder_settings': {
           'version': 'legacy'
         },
@@ -602,10 +654,13 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
   // if a security group is in a vpc it needs to be the id which starts with 'sg-'
   $scope.validSecurityGroup = function () {
     if ($scope.activeDistro) {
-      if ($scope.activeDistro.settings.is_vpc && $scope.activeDistro.settings.security_group_ids) {
-        for (var i = 0; i < $scope.activeDistro.settings.security_group_ids.length; i++) {
-          if ($scope.activeDistro.settings.security_group_ids[i].substring(0, 3) !== "sg-") {
-            return false
+      $scope.updateSettingsList(); // to validate list
+      for (var i = 0; i < $scope.activeDistro.provider_settings; i++) {
+        if ($scope.activeDistro.provider_settings[i].is_vpc && $scope.activeDistro.provider_settings[i].security_group_ids) {
+          for (var i = 0; i < $scope.activeDistro.provider_settings[i].security_group_ids.length; i++) {
+            if ($scope.activeDistro.provider_settings[i].security_group_ids[i].substring(0, 3) !== "sg-") {
+                return false;
+            }
           }
         }
       }
@@ -616,8 +671,11 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
   // if a security group is in a vpc it needs to be the id which starts with 'subnet-'
   $scope.validSubnetId = function () {
     if ($scope.activeDistro) {
-      if ($scope.activeDistro.settings.is_vpc) {
-        return $scope.activeDistro.settings.subnet_id.substring(0, 7) == 'subnet-';
+      $scope.updateSettingsList(); // to validate list
+      for (var i = 0; i < $scope.activeDistro.provider_settings; i++) {
+        if ($scope.activeDistro.provider_settings[i].is_vpc) {
+            return $scope.activeDistro.provider_settings[i].subnet_id.substring(0, 7) == 'subnet-';
+        }
       }
     }
     return true

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -613,6 +613,9 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
       return false;
     }
     if ($scope.activeDistro.provider.startsWith('ec2')) {
+      if ($scope.activeDistro) {
+          $scope.updateSettingsList(); // remove any empty settings before validating
+      }
       return $scope.validSecurityGroup() && $scope.validSubnetId();
     }
     return true;
@@ -666,7 +669,6 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
   // if a security group is in a vpc it needs to be the id which starts with 'sg-'
   $scope.validSecurityGroup = function () {
     if ($scope.activeDistro) {
-      $scope.updateSettingsList(); // to validate list
       for (var i = 0; i < $scope.activeDistro.provider_settings; i++) {
         if ($scope.activeDistro.provider_settings[i].is_vpc && $scope.activeDistro.provider_settings[i].security_group_ids) {
           for (var i = 0; i < $scope.activeDistro.provider_settings[i].security_group_ids.length; i++) {
@@ -683,7 +685,6 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
   // if a security group is in a vpc it needs to be the id which starts with 'subnet-'
   $scope.validSubnetId = function () {
     if ($scope.activeDistro) {
-      $scope.updateSettingsList(); // to validate list
       for (var i = 0; i < $scope.activeDistro.provider_settings; i++) {
         if ($scope.activeDistro.provider_settings[i].is_vpc) {
             return $scope.activeDistro.provider_settings[i].subnet_id.substring(0, 7) == 'subnet-';

--- a/service/distros.go
+++ b/service/distros.go
@@ -276,6 +276,14 @@ func (uis *UIServer) getDistro(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusInternalServerError)
 		return
 	}
+	if len(d.ProviderSettingsList) == 0 {
+		if err := cloud.CreateSettingsListFromLegacy(&d); err != nil {
+			message := fmt.Sprintf("error converting from legacy settings for distro '%v'", id)
+			PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
+			http.Error(w, message, http.StatusInternalServerError)
+			return
+		}
+	}
 
 	opts := gimlet.PermissionOpts{Resource: id, ResourceType: evergreen.DistroResourceType}
 	permissions, err := rolemanager.HighestPermissionsForRoles(u.Roles(), evergreen.GetEnvironment().RoleManager(), opts)

--- a/service/distros.go
+++ b/service/distros.go
@@ -277,7 +277,7 @@ func (uis *UIServer) getDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(d.ProviderSettingsList) == 0 {
-		if err := cloud.CreateSettingsListFromLegacy(&d); err != nil {
+		if err = cloud.CreateSettingsListFromLegacy(&d); err != nil {
 			message := fmt.Sprintf("error converting from legacy settings for distro '%v'", id)
 			PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
 			http.Error(w, message, http.StatusInternalServerError)

--- a/service/distros.go
+++ b/service/distros.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
@@ -116,7 +117,8 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 	}
 
 	newDistro := oldDistro
-	newDistro.ProviderSettings = nil // new distro only handle ProviderSettingsList
+	newDistro.ProviderSettings = nil                     // new distro only handles ProviderSettingsList
+	newDistro.ProviderSettingsList = []*birch.Document{} // remove old list to prevent collisions within birch documents
 	// attempt to unmarshal data into distros field for type validation
 	if err = json.Unmarshal(b, &newDistro); err != nil {
 		message := fmt.Sprintf("error unmarshaling request: %v", err)

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -377,7 +377,7 @@ Evergreen - Distros
               </div>
               <div ng-show="activeDistro.provider.startsWith('ec2-spot')">
                 <label class="distro-label">Bid Price:</label>
-                <input ng-readonly="readOnly" name="bidPrice"
+                <input ng-readonly="readOnly" ng-required="activeDistro.provider.startsWith('ec2-spot')" name="bidPrice"
                   type="number" class="form-control" ng-model="activeDistro.settings.bid_price" placeholder="Maximum amount you're willing to pay per hour (dollars)">
                 <div class="icon fa fa-warning distro-error" ng-show="form.bidPrice.$dirty && form.bidPrice.$error.required || form.bidPrice.$invalid">Numeric
                   bid price is required</div>

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -361,7 +361,7 @@ Evergreen - Distros
               </div>
               <div>
                 <label class="distro-label">AMI ID:</label>
-                <input ng-readonly="readOnly" type="text" name="ami"
+                <input ng-readonly="readOnly" type="text" name="ami" ng-required="isDefaultRegion() && activeDistro.provider.startsWith('ec2')"
                   class="form-control" ng-model="activeDistro.settings.ami" placeholder="EC2 image identifier e.g. ami-1ecae776"
                   ng-readonly="readOnly">
                 <div class="icon fa fa-warning distro-error" ng-show="form.ami.$dirty && form.ami.$error.required || form.ami.$invalid">AMI

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -347,9 +347,21 @@ Evergreen - Distros
               </div>
             </div>
             <div ng-show="activeDistro.provider.startsWith('ec2')">
+              <div class="dropdown" ng-show="regions.length > 1" style="top:10px;">
+                <span class="distro-menu-title">Current Region:</span>
+                <button class="btn btn-default dropdown-toggle" ng-disabled="readOnly" type="button" data-toggle="dropdown">
+                  <strong class="distro-menu-item">[[activeDistro.settings.region]]<span class="fa fa-caret-down"></span></strong>
+                </button>
+                <ul class="dropdown-menu" role="menu" style="margin-left: 60px">
+                  <li ng-click="switchRegion(region)" required name="regionForm"
+                      ng-repeat="region in regions" role="presentation"><a role="menuitem" tabindex="-1">[[region]]</a></li>
+                </ul>
+                <div class="icon fa fa-warning distro-error" ng-show="form.regionForm.$dirty && form.regionForm.$error.required">Distro
+                  Region is required</div>
+              </div>
               <div>
                 <label class="distro-label">AMI ID:</label>
-                <input ng-readonly="readOnly" type="text" ng-required="activeDistro.provider.startsWith('ec2')" name="ami"
+                <input ng-readonly="readOnly" type="text" name="ami"
                   class="form-control" ng-model="activeDistro.settings.ami" placeholder="EC2 image identifier e.g. ami-1ecae776"
                   ng-readonly="readOnly">
                 <div class="icon fa fa-warning distro-error" ng-show="form.ami.$dirty && form.ami.$error.required || form.ami.$invalid">AMI
@@ -365,14 +377,14 @@ Evergreen - Distros
               </div>
               <div ng-show="activeDistro.provider.startsWith('ec2-spot')">
                 <label class="distro-label">Bid Price:</label>
-                <input ng-readonly="readOnly" ng-required="activeDistro.provider.startsWith('ec2-spot')" name="bidPrice"
+                <input ng-readonly="readOnly" name="bidPrice"
                   type="number" class="form-control" ng-model="activeDistro.settings.bid_price" placeholder="Maximum amount you're willing to pay per hour (dollars)">
                 <div class="icon fa fa-warning distro-error" ng-show="form.bidPrice.$dirty && form.bidPrice.$error.required || form.bidPrice.$invalid">Numeric
                   bid price is required</div>
               </div>
               <div>
                 <label class="distro-label">Key Name:</label>
-                <input type="text" ng-readonly="readOnly" ng-required="activeDistro.provider.startsWith('ec2')" name="keyName"
+                <input type="text" ng-readonly="readOnly" name="keyName"
                   class="form-control" ng-model="activeDistro.settings.key_name" placeholder="SSH Key (public part in EC2) to add on host machine"
                   ng-readonly="readOnly">
                 <div class="icon fa fa-warning distro-error" ng-show="form.keyName.$dirty && form.keyName.$error.required || form.keyName.$invalid">EC2

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -369,7 +369,7 @@ Evergreen - Distros
               </div>
               <div>
                 <label class="distro-label">Instance Type:</label>
-                <input ng-readonly="readOnly" type="text" ng-required="activeDistro.provider.startsWith('ec2')" name="instanceType"
+                <input ng-readonly="readOnly" type="text" ng-required="isDefaultRegion() && activeDistro.provider.startsWith('ec2')" name="instanceType"
                   class="form-control" ng-model="activeDistro.settings.instance_type" placeholder="EC2 instance type for the AMI e.g t1.micro (must be available)"
                   ng-readonly="readOnly">
                 <div class="icon fa fa-warning distro-error" ng-show="form.instanceType.$dirty && form.instanceType.$error.required || form.instanceType.$invalid">Instance
@@ -377,7 +377,7 @@ Evergreen - Distros
               </div>
               <div ng-show="activeDistro.provider.startsWith('ec2-spot')">
                 <label class="distro-label">Bid Price:</label>
-                <input ng-readonly="readOnly" ng-required="activeDistro.provider.startsWith('ec2-spot')" name="bidPrice"
+                <input ng-readonly="readOnly" ng-required="isDefaultRegion() && activeDistro.provider.startsWith('ec2-spot')" name="bidPrice"
                   type="number" class="form-control" ng-model="activeDistro.settings.bid_price" placeholder="Maximum amount you're willing to pay per hour (dollars)">
                 <div class="icon fa fa-warning distro-error" ng-show="form.bidPrice.$dirty && form.bidPrice.$error.required || form.bidPrice.$invalid">Numeric
                   bid price is required</div>
@@ -394,7 +394,7 @@ Evergreen - Distros
                 <label class="distro-label"><input style="margin-right:10px;" ng-disabled="readOnly" type="checkbox"
                     name="is_vpc" ng-model="activeDistro.settings.is_vpc">Use security group in an EC2 VPC </label> <br>
                 <label class="distro-label">Security Groups:</label>
-                <textarea ng-readonly="readOnly" placeholder="List 1 security group per line" ng-required="activeDistro.provider.startsWith('ec2')"
+                <textarea ng-readonly="readOnly" placeholder="List 1 security group per line" ng-required="isDefaultRegion() && activeDistro.provider.startsWith('ec2')"
                   type="text" wrap="off" class="form-control" rows="3" name="securityGroups" ng-model="activeDistro.settings.security_group_ids"
                   ng-list="/\n/" style="margin-left: 0px; font-family: monospace"></textarea>
                 <div class="icon fa fa-warning distro-error" ng-show="form.securityGroups.$dirty && form.securityGroups.$error.required || form.securityGroups.$invalid">Security
@@ -455,12 +455,15 @@ Evergreen - Distros
                   class="btn btn-primary" ng-click="form.$setDirty();addMount()"><i class="fa fa-plus"></i>Add Mount
                   Point</button>
               </div>
-              <div ng-show="activeDistro.provider.startsWith('ec2')">
+              <div>
                 <div>
                   <label class="distro-label">User Data:</label>
                 </div>
                 <textarea ng-readonly="readOnly" name="script" type="text" wrap="off" class="form-control" rows="7"
                   ng-model="activeDistro.settings.user_data" style="margin-left: 0px; font-family: monospace"></textarea>
+              </div>
+              <div ng-show="regions.length > 1" style="margin-top:10px;">
+                <button ng-hide="readOnly" type="button" class="btn btn-danger" ng-click="form.$setDirty();clearSettings()">Clear Region's Settings</button>
               </div>
             </div>
             <div ng-show="activeDistro.provider == 'openstack'">

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -127,8 +127,7 @@ func ensureHasRequiredFields(ctx context.Context, d *distro.Distro, _ *evergreen
 	}
 	if cloud.IsEc2Provider(d.Provider) && len(d.ProviderSettingsList) > 1 {
 		return append(errs, validateMultipleProviderSettings(d)...)
-	}
-	if err := validateSingleProviderSettings(d); err != nil {
+	} else if err := validateSingleProviderSettings(d); err != nil {
 		errs = append(errs, ValidationError{
 			Message: err.Error(),
 			Level:   Error,
@@ -140,6 +139,7 @@ func ensureHasRequiredFields(ctx context.Context, d *distro.Distro, _ *evergreen
 func validateMultipleProviderSettings(d *distro.Distro) ValidationErrors {
 	errs := ValidationErrors{}
 	definedRegions := map[string]bool{}
+	d.ProviderSettings = nil
 	for _, doc := range d.ProviderSettingsList {
 		region, ok := doc.Lookup("region").StringValueOK()
 		if !ok {
@@ -170,15 +170,11 @@ func validateMultipleProviderSettings(d *distro.Distro) ValidationErrors {
 			})
 			continue
 		}
-		if err := settings.FromDistroSettings(*d, region); err != nil {
+		if err := settings.Validate(); err != nil {
 			errs = append(errs, ValidationError{
-				Message: fmt.Sprintf("distro '%v' decode error: %v", distro.ProviderSettingsListKey, err),
+				Message: errors.Wrapf(err, "error validating settings for region '%s'", region).Error(),
 				Level:   Error,
 			})
-			continue
-		}
-		if err := settings.Validate(); err != nil {
-			errs = append(errs, ValidationError{Error, err.Error()})
 		}
 	}
 	return errs


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26798134/77360013-d2fab380-6d09-11ea-90df-bcfb9694bf35.png)

This is my start! Feel free to play around. The thing I'm having the most trouble with is:
Right now (for example), australia-1 isn't configured. If I go in and type some stuff and then remove it all, I don't want australia-1 to be saved. (I wrote this into UpdateProviderSettingsList).

I was thinking though, if australia-1 was already configured and I want to remove all the settings (i.e. delete it as an existing option), I'm not sure the best way to do that. 
1) Should all of this validation go in the go file instead? 
2) Should I be using form better? I'm not sure I can use $dirty because that also takes into consideration non provider settings fields. Can I define form.settings somehow and then call form.settings.$dirty? Will this still allow me to define settings.region from the javascript setup?