### PR TITLE
EVG-7644: allow static host statuses to be changed from terminated

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -364,8 +364,12 @@ func (h *Host) IsEphemeral() bool {
 
 func (h *Host) SetStatus(status, user string, logs string) error {
 	if h.Status == evergreen.HostTerminated && h.Provider != evergreen.ProviderNameStatic {
-		msg := fmt.Sprintf("not changing the status of terminated host %s to %s", h.Id, status)
-		grip.Warning(msg)
+		msg := "not changing status of already terminated host"
+		grip.Warning(message.Fields{
+			"message": msg,
+			"host_id": h.Id,
+			"status":  status,
+		})
 		return errors.New(msg)
 	}
 
@@ -388,8 +392,12 @@ func (h *Host) SetStatus(status, user string, logs string) error {
 // status in the database matches currentStatus.
 func (h *Host) SetStatusAtomically(newStatus, user string, logs string) error {
 	if h.Status == evergreen.HostTerminated && h.Provider != evergreen.ProviderNameStatic {
-		msg := fmt.Sprintf("not changing the status of terminated host %s to %s", h.Id, newStatus)
-		grip.Warning(msg)
+		msg := "not changing status of already terminated host"
+		grip.Warning(message.Fields{
+			"message": msg,
+			"host_id": h.Id,
+			"status":  newStatus,
+		})
 		return errors.New(msg)
 	}
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -363,8 +363,8 @@ func (h *Host) IsEphemeral() bool {
 }
 
 func (h *Host) SetStatus(status, user string, logs string) error {
-	if h.Status == evergreen.HostTerminated {
-		msg := fmt.Sprintf("not changing the status of terminate host %s to %s", h.Id, status)
+	if h.Status == evergreen.HostTerminated && h.Provider != evergreen.ProviderNameStatic {
+		msg := fmt.Sprintf("not changing the status of terminated host %s to %s", h.Id, status)
 		grip.Warning(msg)
 		return errors.New(msg)
 	}
@@ -387,8 +387,8 @@ func (h *Host) SetStatus(status, user string, logs string) error {
 // SetStatusAtomically is the same as SetStatus but only updates the host if its
 // status in the database matches currentStatus.
 func (h *Host) SetStatusAtomically(newStatus, user string, logs string) error {
-	if h.Status == evergreen.HostTerminated {
-		msg := fmt.Sprintf("not changing the status of terminate host %s to %s", h.Id, newStatus)
+	if h.Status == evergreen.HostTerminated && h.Provider != evergreen.ProviderNameStatic {
+		msg := fmt.Sprintf("not changing the status of terminated host %s to %s", h.Id, newStatus)
 		grip.Warning(msg)
 		return errors.New(msg)
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7644

This is only a problem when moving static hosts between distros. I also noticed that static hosts across distros also causes quarantined hosts to be terminated, then set to running, but I don't really think that's super important to fix.