### PR TITLE
EVG-7603 parse device name from lsblk

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1151,13 +1151,16 @@ func (m *ec2Manager) AttachVolume(ctx context.Context, h *host.Host, attachment 
 		opts.shouldGenerate = true
 	}
 
-	_, err := m.client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+	volume, err := m.client.AttachVolume(ctx, &ec2.AttachVolumeInput{
 		InstanceId: aws.String(h.Id),
 		Device:     aws.String(attachment.DeviceName),
 		VolumeId:   aws.String(attachment.VolumeID),
 	}, opts)
 	if err != nil {
 		return errors.Wrapf(err, "error attaching volume '%s' to host '%s'", attachment.VolumeID, h.Id)
+	}
+	if volume.Device != nil {
+		attachment.DeviceName = *volume.Device
 	}
 	return errors.Wrapf(h.AddVolumeToHost(attachment), "error attaching volume '%s' to host '%s' in db", attachment.VolumeID, h.Id)
 }

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1159,7 +1159,7 @@ func (m *ec2Manager) AttachVolume(ctx context.Context, h *host.Host, attachment 
 	if err != nil {
 		return errors.Wrapf(err, "error attaching volume '%s' to host '%s'", attachment.VolumeID, h.Id)
 	}
-	if volume.Device != nil {
+	if volume != nil && volume.Device != nil {
 		attachment.DeviceName = *volume.Device
 	}
 	return errors.Wrapf(h.AddVolumeToHost(attachment), "error attaching volume '%s' to host '%s' in db", attachment.VolumeID, h.Id)

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -90,7 +90,6 @@ type ResourceLimits struct {
 }
 
 type HomeVolumeSettings struct {
-	DeviceName    string `bson:"device_name" json:"device_name" mapstructure:"device_name"`
 	FormatCommand string `bson:"format_command" json:"format_command" mapstructure:"format_command"`
 }
 

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -327,7 +327,6 @@ func (s *APIBootstrapSettings) ToService() (interface{}, error) {
 }
 
 type APIHomeVolumeSettings struct {
-	DeviceName    *string `json:"device_name"`
 	FormatCommand *string `json:"format_command"`
 }
 
@@ -337,7 +336,6 @@ func (s *APIHomeVolumeSettings) BuildFromService(h interface{}) error {
 		return errors.Errorf("Unexpected type '%T' for HomeVolumeSettings", h)
 	}
 
-	s.DeviceName = ToStringPtr(settings.DeviceName)
 	s.FormatCommand = ToStringPtr(settings.FormatCommand)
 
 	return nil
@@ -345,7 +343,6 @@ func (s *APIHomeVolumeSettings) BuildFromService(h interface{}) error {
 
 func (s *APIHomeVolumeSettings) ToService() (interface{}, error) {
 	return distro.HomeVolumeSettings{
-		DeviceName:    FromStringPtr(s.DeviceName),
 		FormatCommand: FromStringPtr(s.FormatCommand),
 	}, nil
 }

--- a/rest/model/distro_test.go
+++ b/rest/model/distro_test.go
@@ -24,7 +24,6 @@ func TestDistroBuildFromService(t *testing.T) {
 		},
 		Note: "note1",
 		HomeVolumeSettings: distro.HomeVolumeSettings{
-			DeviceName:    "nvme1n1",
 			FormatCommand: "format_command",
 		},
 		IcecreamSettings: distro.IcecreamSettings{
@@ -44,7 +43,6 @@ func TestDistroBuildFromService(t *testing.T) {
 	assert.Equal(t, d.BootstrapSettings.ServiceUser, FromStringPtr(apiDistro.BootstrapSettings.ServiceUser))
 	assert.Equal(t, d.BootstrapSettings.ShellPath, FromStringPtr(apiDistro.BootstrapSettings.ShellPath))
 	assert.Equal(t, d.Note, FromStringPtr(apiDistro.Note))
-	assert.Equal(t, d.HomeVolumeSettings.DeviceName, FromStringPtr(apiDistro.HomeVolumeSettings.DeviceName))
 	assert.Equal(t, d.HomeVolumeSettings.FormatCommand, FromStringPtr(apiDistro.HomeVolumeSettings.FormatCommand))
 	assert.Equal(t, d.IcecreamSettings.SchedulerHost, FromStringPtr(apiDistro.IcecreamSettings.SchedulerHost))
 	assert.Equal(t, d.IcecreamSettings.ConfigPath, FromStringPtr(apiDistro.IcecreamSettings.ConfigPath))
@@ -84,6 +82,7 @@ func TestDistroToService(t *testing.T) {
 			},
 		},
 		Note: ToStringPtr("note1"),
+<<<<<<< HEAD
 		HomeVolumeSettings: APIHomeVolumeSettings{
 			DeviceName:    ToStringPtr("nvme1n1"),
 			FormatCommand: ToStringPtr("format_command"),
@@ -92,6 +91,8 @@ func TestDistroToService(t *testing.T) {
 			SchedulerHost: ToStringPtr("host"),
 			ConfigPath:    ToStringPtr("config_path"),
 		},
+=======
+>>>>>>> parse device name from lsblk
 	}
 
 	res, err := apiDistro.ToService()
@@ -114,10 +115,13 @@ func TestDistroToService(t *testing.T) {
 	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.LockedMemoryKB, d.BootstrapSettings.ResourceLimits.LockedMemoryKB)
 	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.VirtualMemoryKB, d.BootstrapSettings.ResourceLimits.VirtualMemoryKB)
 	assert.Equal(t, apiDistro.Note, ToStringPtr(d.Note))
+<<<<<<< HEAD
 	assert.Equal(t, apiDistro.HomeVolumeSettings.DeviceName, ToStringPtr(d.HomeVolumeSettings.DeviceName))
 	assert.Equal(t, apiDistro.HomeVolumeSettings.FormatCommand, ToStringPtr(d.HomeVolumeSettings.FormatCommand))
 	assert.Equal(t, apiDistro.IcecreamSettings.SchedulerHost, ToStringPtr(d.IcecreamSettings.SchedulerHost))
 	assert.Equal(t, apiDistro.IcecreamSettings.ConfigPath, ToStringPtr(d.IcecreamSettings.ConfigPath))
+=======
+>>>>>>> parse device name from lsblk
 }
 
 func TestDistroToServiceDefaults(t *testing.T) {

--- a/rest/model/distro_test.go
+++ b/rest/model/distro_test.go
@@ -82,17 +82,13 @@ func TestDistroToService(t *testing.T) {
 			},
 		},
 		Note: ToStringPtr("note1"),
-<<<<<<< HEAD
 		HomeVolumeSettings: APIHomeVolumeSettings{
-			DeviceName:    ToStringPtr("nvme1n1"),
 			FormatCommand: ToStringPtr("format_command"),
 		},
 		IcecreamSettings: APIIcecreamSettings{
 			SchedulerHost: ToStringPtr("host"),
 			ConfigPath:    ToStringPtr("config_path"),
 		},
-=======
->>>>>>> parse device name from lsblk
 	}
 
 	res, err := apiDistro.ToService()
@@ -115,13 +111,9 @@ func TestDistroToService(t *testing.T) {
 	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.LockedMemoryKB, d.BootstrapSettings.ResourceLimits.LockedMemoryKB)
 	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.VirtualMemoryKB, d.BootstrapSettings.ResourceLimits.VirtualMemoryKB)
 	assert.Equal(t, apiDistro.Note, ToStringPtr(d.Note))
-<<<<<<< HEAD
-	assert.Equal(t, apiDistro.HomeVolumeSettings.DeviceName, ToStringPtr(d.HomeVolumeSettings.DeviceName))
 	assert.Equal(t, apiDistro.HomeVolumeSettings.FormatCommand, ToStringPtr(d.HomeVolumeSettings.FormatCommand))
 	assert.Equal(t, apiDistro.IcecreamSettings.SchedulerHost, ToStringPtr(d.IcecreamSettings.SchedulerHost))
 	assert.Equal(t, apiDistro.IcecreamSettings.ConfigPath, ToStringPtr(d.IcecreamSettings.ConfigPath))
-=======
->>>>>>> parse device name from lsblk
 }
 
 func TestDistroToServiceDefaults(t *testing.T) {

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -865,10 +865,6 @@ Evergreen - Distros
             </div>
           </div>
           <div>
-            <label class="distro-label">Home Volume Device Name:</label>
-            <input ng-readonly="readOnly" type="text" class="form-control" ng-model="activeDistro.home_volume_settings.device_name">
-          </div>
-          <div>
             <label class="distro-label">Home Volume Format Command:</label>
             <input ng-readonly="readOnly" name="formatCommand" ng-required="activeDistro.is_virtual_workstation" type="text" class="form-control" ng-model="activeDistro.home_volume_settings.format_command">
             <div class="icon fa fa-warning distro-error"

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -802,6 +802,9 @@ func mountLinuxVolume(ctx context.Context, env evergreen.Environment, h *host.Ho
 	output, err := h.RunJasperProcess(ctx, env, &options.Create{
 		Args: []string{"lsblk"},
 	})
+	if err != nil {
+		return errors.Wrap(err, "can't run lsblk")
+	}
 	deviceName, err := getMostRecentlyAddedDevice(output)
 	if err != nil {
 		return errors.Wrapf(err, "can't get device name from '%s'", output)

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -872,7 +872,10 @@ func getMostRecentlyAddedDevice(lsblkOutput []string) (string, error) {
 	}
 
 	device := lsblkOutput[len(lsblkOutput)-1]
-	deviceNameRegexp := regexp.MustCompile(`^(?P<deviceName>sd[a-z]\d{0,2}|xvd[a-z]|hd[a-z]\d{0,2}|nvme\d{1,2}n1)`)
+	deviceNameRegexp, err := regexp.Compile(`^(?P<deviceName>sd[a-z]\d{0,2}|xvd[a-z]|hd[a-z]\d{0,2}|nvme\d{1,2}n1)`)
+	if err != nil {
+		return "", errors.Wrap(err, "can't compile device name regexp")
+	}
 	deviceNameMatch := deviceNameRegexp.FindStringSubmatch(device)
 	if len(deviceNameMatch) < 2 {
 		return "", errors.Errorf("can't get device name from device: '%s'", device)

--- a/units/provisioning_setup_host_test.go
+++ b/units/provisioning_setup_host_test.go
@@ -1,0 +1,33 @@
+package units
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMostRecentlyAddedDevice(t *testing.T) {
+	lsblkOutput := []string{
+		"NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT",
+		"loop0     7:0    0 88.5M  1 loop ...",
+		"xvda    202:0    0   64G  0 disk",
+		"`-xvda1 202:1    0   64G  0 part /",
+		"xvdc    202:160  0   10G  0 disk",
+	}
+
+	output, err := getMostRecentlyAddedDevice(lsblkOutput)
+	assert.NoError(t, err)
+	assert.Equal(t, "/dev/xvdc", output)
+
+	lsblkOutput = []string{
+		"NAME        MAJ:MIN RM SIZE RO TYPE MOUNTPOINT",
+		"nvme0n1     259:1    0  40G  0 disk",
+		"`-nvme0n1p1 259:2    0  40G  0 part /",
+		"nvme1n1     259:0    0  40G  0 disk /data",
+		"nvme2n1     259:3    0  10G  0 disk",
+	}
+
+	output, err = getMostRecentlyAddedDevice(lsblkOutput)
+	assert.NoError(t, err)
+	assert.Equal(t, "/dev/nvme2n1", output)
+}

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -102,17 +102,6 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 		return
 	}
 
-	if err := j.host.SetUserDataHostProvisioned(); err != nil {
-		grip.Error(message.WrapError(err, message.Fields{
-			"message": "could not mark host that has finished running user data as done provisioning",
-			"host_id": j.host.Id,
-			"distro":  j.host.Distro.Id,
-			"job":     j.ID(),
-		}))
-		j.AddError(err)
-		return
-	}
-
 	if j.host.IsVirtualWorkstation {
 		if err := attachVolume(ctx, j.env, j.host); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
@@ -132,6 +121,17 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 				"job":     j.ID(),
 			}))
 		}
+	}
+
+	if err := j.host.SetUserDataHostProvisioned(); err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "could not mark host that has finished running user data as done provisioning",
+			"host_id": j.host.Id,
+			"distro":  j.host.Distro.Id,
+			"job":     j.ID(),
+		}))
+		j.AddError(err)
+		return
 	}
 }
 


### PR DESCRIPTION
- A mounted volume's device name isn't necessarily the same as the device name specified in the AWS AttachVolume request, and isn't necessarily the same every time. The docs suggest pulling the device name from the output of the `lsblk` command, so this PR parses the device name from the output of that command. The parsing relies on the assumption that the most recently added device will be listed last in `lsblk`'s output. It's no longer necessary to keep a device name field in the distro, so it's been removed.

AWS docs:  1) [device names](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html), 2) [identifying the device](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#identify-nvme-ebs-device)

- The ec2Client may generate a different device name than the one passed in to the `client.AttachVolume` call. The new device name is what should be saved in the db.

- For userdata hosts is to only transition a host from provisioning to running once the volume has been mounted.