### PR TITLE
EVG-7622 invalidate intervals for cron and add quiet flag to validate

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-03-13"
+	ClientVersion = "2020-03-25"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -683,6 +683,9 @@ func (p *ProjectRef) getBatchTime(variant *BuildVariant) int {
 
 // return the next valid batch time
 func GetActivationTimeWithCron(curTime time.Time, cronBatchTime string) (time.Time, error) {
+	if strings.HasPrefix(cronBatchTime, "@every") {
+		return time.Time{}, errors.Errorf("cron batchtime '%s' cannot be an interval", cronBatchTime)
+	}
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.DowOptional | cron.Descriptor)
 	sched, err := parser.Parse(cronBatchTime)
 	if err != nil {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -171,6 +171,7 @@ const (
 	ProjectRefCollection     = "project_ref"
 	ProjectTriggerLevelTask  = "task"
 	ProjectTriggerLevelBuild = "build"
+	intervalPrefix           = "@every"
 )
 
 var adminPermissions = gimlet.Permissions{
@@ -683,8 +684,9 @@ func (p *ProjectRef) getBatchTime(variant *BuildVariant) int {
 
 // return the next valid batch time
 func GetActivationTimeWithCron(curTime time.Time, cronBatchTime string) (time.Time, error) {
-	if strings.HasPrefix(cronBatchTime, "@every") {
-		return time.Time{}, errors.Errorf("cron batchtime '%s' cannot be an interval", cronBatchTime)
+
+	if strings.HasPrefix(cronBatchTime, intervalPrefix) {
+		return time.Time{}, errors.Errorf("cannot use '%s' in cron batchtime '%s'", intervalPrefix, cronBatchTime)
 	}
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.DowOptional | cron.Descriptor)
 	sched, err := parser.Parse(cronBatchTime)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -96,8 +96,8 @@ func TestGetActivationTimeWithCron(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, res.Add(time.Hour*48), newRes)
 		},
-		"15thOfTheMonth": func(t *testing.T) {
-			batchStr := "0 0 15 *"
+		"1and15thOfTheMonth": func(t *testing.T) {
+			batchStr := "0 0 1,15 *"
 			res, err := GetActivationTimeWithCron(prevTime, batchStr)
 			assert.NoError(t, err)
 			assert.Equal(t, prevTime.Add(time.Hour*24*6), res)
@@ -110,9 +110,8 @@ func TestGetActivationTimeWithCron(t *testing.T) {
 		},
 		"Interval": func(t *testing.T) {
 			batchStr := "@every 2h"
-			res, err := GetActivationTimeWithCron(prevTime, batchStr)
-			assert.NoError(t, err)
-			assert.Equal(t, prevTime.Add(time.Hour*2), res)
+			_, err := GetActivationTimeWithCron(prevTime, batchStr)
+			assert.Error(t, err)
 		},
 	} {
 		t.Run(name, test)

--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -43,7 +43,7 @@ func ActivateElapsedBuilds(v *Version) error {
 			grip.Info(message.Fields{
 				"message":   "activating revision",
 				"variant":   status.BuildVariant,
-				"project":   v.Branch,
+				"project":   v.Identifier,
 				"revision":  v.Revision,
 				"operation": "project-activation",
 			})
@@ -59,7 +59,7 @@ func ActivateElapsedBuilds(v *Version) error {
 					"message":   "problem retrieving build",
 					"variant":   status.BuildVariant,
 					"build":     status.BuildId,
-					"project":   v.Branch,
+					"project":   v.Identifier,
 					"operation": "project-activation",
 				}))
 				continue
@@ -70,7 +70,7 @@ func ActivateElapsedBuilds(v *Version) error {
 				"operation": "project-activation",
 				"variant":   status.BuildVariant,
 				"build":     status.BuildId,
-				"project":   v.Branch,
+				"project":   v.Identifier,
 			})
 
 			// Don't need to set the version in here since we do it ourselves in a single update
@@ -80,7 +80,7 @@ func ActivateElapsedBuilds(v *Version) error {
 					"message":   "problem activating build",
 					"variant":   status.BuildVariant,
 					"build":     status.BuildId,
-					"project":   v.Branch,
+					"project":   v.Identifier,
 				}))
 				continue
 			}


### PR DESCRIPTION
I ran evergreen validate over all the configs and removing intervals for cron will only affect the go driver. Also, I added a quiet flag because running evergreen validate on all configs is really annoying.