### PR TITLE
EVG-7601 cache instance types by supported by AZs

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1145,6 +1145,7 @@ type awsClientMock struct { //nolint
 	*ec2.DescribeSpotInstanceRequestsOutput
 	*ec2.DescribeInstancesOutput
 	*ec2.CreateLaunchTemplateOutput
+	*ec2.DescribeInstanceTypeOfferingsOutput
 }
 
 // Create a new mock client.
@@ -1231,7 +1232,7 @@ func (c *awsClientMock) ModifyInstanceAttribute(ctx context.Context, input *ec2.
 
 func (c *awsClientMock) DescribeInstanceTypeOfferings(ctx context.Context, input *ec2.DescribeInstanceTypeOfferingsInput) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
 	c.DescribeInstanceTypeOfferingsInput = input
-	return nil, nil
+	return c.DescribeInstanceTypeOfferingsOutput, nil
 }
 
 // TerminateInstances is a mock for ec2.TerminateInstances.

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -41,6 +41,9 @@ func (c *azInstanceTypeCache) azSupportsInstanceType(ctx context.Context, client
 		if err != nil {
 			return false, errors.Wrapf(err, "can't get instance types for '%s'", az)
 		}
+		if output == nil {
+			return false, errors.Wrap(err, "DescribeInstanceTypeOfferings returned nil output")
+		}
 
 		instanceTypes := make([]string, 0, len(output.InstanceTypeOfferings))
 		for _, offering := range output.InstanceTypeOfferings {

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -97,7 +97,10 @@ func TestFleet(t *testing.T) {
 			assert.Equal(t, "templateID", *mockClient.CreateFleetInput.LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateId)
 		},
 		"MakeOverrides": func(*testing.T) {
-			ec2Settings := &EC2ProviderSettings{VpcName: "vpc-123456"}
+			ec2Settings := &EC2ProviderSettings{
+				VpcName:      "vpc-123456",
+				InstanceType: "instanceType0",
+			}
 
 			overrides, err := m.makeOverrides(context.Background(), ec2Settings)
 			assert.NoError(t, err)
@@ -172,7 +175,13 @@ func TestFleet(t *testing.T) {
 
 		m = &ec2FleetManager{
 			EC2FleetManagerOptions: &EC2FleetManagerOptions{
-				client: &awsClientMock{},
+				client: &awsClientMock{
+					DescribeInstanceTypeOfferingsOutput: &ec2.DescribeInstanceTypeOfferingsOutput{
+						InstanceTypeOfferings: []*ec2.InstanceTypeOffering{
+							{InstanceType: aws.String("instanceType0")},
+						},
+					},
+				},
 				region: "test-region",
 			},
 			credentials: credentials.NewStaticCredentialsFromCreds(credentials.Value{


### PR DESCRIPTION
Query the AWS API for which instance types are supported by an AZ and only ask for one of the AZs that support the distro's instance type.
Keep an in-memory cache so we don't need to make these calls every time we start an instance. 

I'm open to creating a new collection as an alternative to the in-memory cache.