### PR TITLE
EVG-7519: use regex to match variant name

### DIFF
--- a/graphql/tests/patchTasks/queries/filter-by-variant-partial-search-term.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-variant-partial-search-term.graphql
@@ -1,0 +1,9 @@
+{
+  patchTasks(patchId: "5e4ff3abe3c3317e352062e4", variant: "win") {
+    id
+    status
+    baseStatus
+    displayName
+    buildVariant
+  }
+}

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -55,6 +55,29 @@
       }
     },
     {
+      "query_file": "filter-by-variant-partial-search-term.graphql",
+      "result": {
+        "data": {
+          "patchTasks": [
+            {
+              "id": "4",
+              "status": "failed",
+              "baseStatus": "success",
+              "displayName": "compile",
+              "buildVariant": "windows"
+            },
+            {
+              "id": "3",
+              "status": "success",
+              "baseStatus": "success",
+              "displayName": "lint",
+              "buildVariant": "windows"
+            }
+          ]
+        }
+      }
+    },
+    {
       "query_file": "filter-by-bad-variant.graphql",
       "result": {
         "data": {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1942,7 +1942,7 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 		match[StatusKey] = bson.M{"$in": statuses}
 	}
 	if variant != "" {
-		match[BuildVariantKey] = variant
+		match[BuildVariantKey] = bson.M{"$regex": variant, "$options": "i"}
 	}
 	if len(taskName) > 0 {
 		match[DisplayNameKey] = bson.M{"$regex": taskName, "$options": "i"}


### PR DESCRIPTION
Should have been this all along to return results for partial searches, i.e. `clo` returns true for `cloud`