### PR TITLE
EVG-7024 deco parent if container is poisoned

### DIFF
--- a/service/api_task.go
+++ b/service/api_task.go
@@ -285,14 +285,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	if event.AllRecentHostEventsMatchStatus(currentHost.Id, consecutiveSystemFailureThreshold, evergreen.TaskSystemFailed) {
 		msg := "host encountered consecutive system failures"
 		if currentHost.Provider != evergreen.ProviderNameStatic {
-			err = currentHost.DisablePoisonedHost(msg)
-
-			job := units.NewDecoHostNotifyJob(as.env, currentHost, err, msg)
-			grip.Critical(message.WrapError(as.queue.Put(r.Context(), job),
-				message.Fields{
-					"host_id": currentHost.Id,
-					"task_id": t.Id,
-				}))
+			err = units.HandlePoisonedHost(r.Context(), as.env, currentHost, msg)
 
 			if err != nil {
 				gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -286,11 +286,9 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		msg := "host encountered consecutive system failures"
 		if currentHost.Provider != evergreen.ProviderNameStatic {
 			err = units.HandlePoisonedHost(r.Context(), as.env, currentHost, msg)
-
-			if err != nil {
-				gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
-				return
-			}
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "unable to disable poisoned host",
+			}))
 		}
 
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -285,9 +285,9 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	if event.AllRecentHostEventsMatchStatus(currentHost.Id, consecutiveSystemFailureThreshold, evergreen.TaskSystemFailed) {
 		msg := "host encountered consecutive system failures"
 		if currentHost.Provider != evergreen.ProviderNameStatic {
-			err = units.HandlePoisonedHost(r.Context(), as.env, currentHost, msg)
-			grip.Error(message.WrapError(err, message.Fields{
+			grip.Error(message.WrapError(units.HandlePoisonedHost(r.Context(), as.env, currentHost, msg), message.Fields{
 				"message": "unable to disable poisoned host",
+				"host":    currentHost.Id,
 			}))
 		}
 

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -104,7 +104,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		return
 	}
 
-	if j.host.HasContainers {
+	if j.host.HasContainers && !j.TerminateIfBusy {
 		var idle bool
 		idle, err = j.host.IsIdleParent()
 		if err != nil {
@@ -115,6 +115,15 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			}))
 		}
 		if !idle {
+			grip.Info(message.Fields{
+				"job":      j.ID(),
+				"host_id":  j.HostID,
+				"job_type": j.Type().Name,
+				"status":   j.host.Status,
+				"provider": j.host.Distro.Provider,
+				"reason":   j.Reason,
+				"message":  "attempted to terminate a non-idle parent",
+			})
 			return
 		}
 	}

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -195,18 +195,7 @@ func (j *agentMonitorDeployJob) hostDown() bool {
 // disableHost changes the host so that it is down and enqueues a job to
 // terminate it.
 func (j *agentMonitorDeployJob) disableHost(ctx context.Context, reason string) error {
-	if err := j.host.DisablePoisonedHost(reason); err != nil {
-		return errors.Wrapf(err, "error terminating host %s", j.host.Id)
-	}
-
-	job := NewDecoHostNotifyJob(j.env, j.host, nil, reason)
-	grip.Error(message.WrapError(j.env.RemoteQueue().Put(ctx, job), message.Fields{
-		"message": fmt.Sprintf("tried %d times to start agent monitor on host", agentMonitorPutRetries),
-		"host_id": j.host.Id,
-		"distro":  j.host.Distro.Id,
-	}))
-
-	return nil
+	return errors.Wrapf(HandlePoisonedHost(ctx, j.env, j.host, reason), "error terminating host %s", j.host.Id)
 }
 
 // checkNoRetries checks if the job has exhausted the maximum allowed attempts

--- a/units/util.go
+++ b/units/util.go
@@ -1,0 +1,45 @@
+package units
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+func HandlePoisonedHost(ctx context.Context, env evergreen.Environment, h *host.Host, reason string) error {
+	if h == nil {
+		return errors.New("no host found")
+	}
+	if h.ParentID != "" {
+		parent, err := host.FindOneId(h.ParentID)
+		if err != nil {
+			return errors.Wrap(err, "error finding parent host")
+		}
+		if parent != nil {
+			containers, err := parent.GetActiveContainers()
+			if err != nil {
+				return errors.Wrap(err, "error getting containers")
+			}
+			catcher := grip.NewBasicCatcher()
+			for _, container := range containers {
+				err = DisableAndNotifyPoisonedHost(ctx, env, container, reason)
+			}
+			catcher.Add(DisableAndNotifyPoisonedHost(ctx, env, *parent, reason))
+			if catcher.HasErrors() {
+				return catcher.Resolve()
+			}
+		}
+	}
+	return DisableAndNotifyPoisonedHost(ctx, env, *h, reason)
+}
+
+func DisableAndNotifyPoisonedHost(ctx context.Context, env evergreen.Environment, h host.Host, reason string) error {
+	err := h.DisablePoisonedHost(reason)
+	if err != nil {
+		return errors.Wrap(err, "error disabling poisoned host")
+	}
+	return env.RemoteQueue().Put(ctx, NewDecoHostNotifyJob(env, &h, nil, reason))
+}

--- a/units/util.go
+++ b/units/util.go
@@ -25,7 +25,7 @@ func HandlePoisonedHost(ctx context.Context, env evergreen.Environment, h *host.
 			}
 			catcher := grip.NewBasicCatcher()
 			for _, container := range containers {
-				err = DisableAndNotifyPoisonedHost(ctx, env, container, reason)
+				catcher.Add(DisableAndNotifyPoisonedHost(ctx, env, container, reason))
 			}
 			catcher.Add(DisableAndNotifyPoisonedHost(ctx, env, *parent, reason))
 			if catcher.HasErrors() {

--- a/units/util.go
+++ b/units/util.go
@@ -36,6 +36,9 @@ func HandlePoisonedHost(ctx context.Context, env evergreen.Environment, h *host.
 }
 
 func DisableAndNotifyPoisonedHost(ctx context.Context, env evergreen.Environment, h host.Host, reason string) error {
+	if h.Status == evergreen.HostDecommissioned || h.Status == evergreen.HostTerminated {
+		return nil
+	}
 	err := h.DisablePoisonedHost(reason)
 	if err != nil {
 		return errors.Wrap(err, "error disabling poisoned host")

--- a/units/util_test.go
+++ b/units/util_test.go
@@ -1,0 +1,52 @@
+package units
+
+import (
+	"context"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandlePoisonedHost(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(host.Collection))
+	parent := host.Host{
+		Id:            "parent",
+		HasContainers: true,
+		Status:        evergreen.HostRunning,
+	}
+	container1 := host.Host{
+		Id:       "container1",
+		Status:   evergreen.HostRunning,
+		ParentID: parent.Id,
+	}
+	container2 := host.Host{
+		Id:       "container2",
+		Status:   evergreen.HostRunning,
+		ParentID: parent.Id,
+	}
+	assert.NoError(parent.Insert())
+	assert.NoError(container1.Insert())
+	assert.NoError(container2.Insert())
+	env := evergreen.GetEnvironment()
+	ctx := context.Background()
+	if !env.RemoteQueue().Started() {
+		_ = env.RemoteQueue().Start(ctx)
+	}
+
+	_ = HandlePoisonedHost(ctx, env, &container1, "")
+	dbParent, err := host.FindOneId(parent.Id)
+	assert.NoError(err)
+	assert.Equal(evergreen.HostDecommissioned, dbParent.Status)
+	dbContainer1, err := host.FindOneId(container1.Id)
+	assert.NoError(err)
+	assert.Equal(evergreen.HostDecommissioned, dbContainer1.Status)
+	dbContainer2, err := host.FindOneId(container2.Id)
+	assert.NoError(err)
+	assert.Equal(evergreen.HostDecommissioned, dbContainer2.Status)
+	nextJob := env.RemoteQueue().Next(ctx)
+	assert.Contains(nextJob.ID(), "deco-host-notify")
+}


### PR DESCRIPTION
- Refactor the places that were decoing a poisoned host and adding a job into a single function
- Call this function for parent + other containers if we try to disable a container