### PR TITLE
EVG-7671 exclude hosts spawned by tasks from stale host intent check

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -854,6 +854,7 @@ func FindUserDataSpawnHostsProvisioning() ([]Host, error) {
 func RemoveStaleInitializing(distroID string) error {
 	query := bson.M{
 		UserHostKey: false,
+		bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsSpawnedByTaskKey): bson.M{"$ne": true},
 		ProviderKey: bson.M{"$in": evergreen.ProviderSpawnable},
 		"$or": []bson.M{
 			{

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3607,6 +3607,15 @@ func TestRemoveStaleInitializing(t *testing.T) {
 			UserHost:     false,
 			Provider:     evergreen.ProviderNameEc2Auto,
 		},
+		{
+			Id:           "host8",
+			Distro:       distro2,
+			Status:       evergreen.HostUninitialized,
+			CreationTime: now.Add(-30 * time.Minute),
+			UserHost:     false,
+			SpawnOptions: SpawnOptions{SpawnedByTask: true},
+			Provider:     evergreen.ProviderNameEc2Auto,
+		},
 	}
 
 	for i, _ := range hosts {
@@ -3621,7 +3630,7 @@ func TestRemoveStaleInitializing(t *testing.T) {
 
 	numHosts, err := Count(All)
 	assert.NoError(err)
-	assert.Equal(5, numHosts)
+	assert.Equal(6, numHosts)
 
 	dbCreds := certdepot.User{}
 	assert.NoError(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host1"}, db.NoProjection, db.NoSort, &dbCreds))
@@ -3629,6 +3638,7 @@ func TestRemoveStaleInitializing(t *testing.T) {
 	assert.NoError(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host4"}, db.NoProjection, db.NoSort, &dbCreds))
 	assert.NoError(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host5"}, db.NoProjection, db.NoSort, &dbCreds))
 	assert.NoError(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host7"}, db.NoProjection, db.NoSort, &dbCreds))
+	assert.NoError(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host8"}, db.NoProjection, db.NoSort, &dbCreds))
 	assert.True(adb.ResultsNotFound(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host2"}, db.NoProjection, db.NoSort, &dbCreds)))
 	assert.True(adb.ResultsNotFound(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host6"}, db.NoProjection, db.NoSort, &dbCreds)))
 
@@ -3638,11 +3648,12 @@ func TestRemoveStaleInitializing(t *testing.T) {
 	assert.NoError(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host3"}, db.NoProjection, db.NoSort, &dbCreds))
 	assert.NoError(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host5"}, db.NoProjection, db.NoSort, &dbCreds))
 	assert.NoError(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host7"}, db.NoProjection, db.NoSort, &dbCreds))
+	assert.NoError(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host8"}, db.NoProjection, db.NoSort, &dbCreds))
 	assert.True(adb.ResultsNotFound(db.FindOne(evergreen.CredentialsCollection, bson.M{CertUserIDKey: "host4"}, db.NoProjection, db.NoSort, &dbCreds)))
 
 	numHosts, err = Count(All)
 	assert.NoError(err)
-	assert.Equal(4, numHosts)
+	assert.Equal(5, numHosts)
 
 }
 


### PR DESCRIPTION
The host allocator should only look at hosts that it starts when finding stale hosts to remove. Exclude hosts spawned by tasks from the query.