### PR TITLE
EVG-7408 don't add duplicate dependencies

### DIFF
--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -205,6 +205,15 @@ func FindAll(collection string, query interface{},
 	return errors.WithStack(q.Skip(skip).Limit(limit).All(out))
 }
 
+func FindOneAndUpdate(collection string, query interface{}, update interface{}, opts *options.FindOneAndUpdateOptions) error {
+	env := evergreen.GetEnvironment()
+	ctx, cancel := env.Context()
+	defer cancel()
+	coll := env.DB().Collection(collection)
+	res := coll.FindOneAndUpdate(ctx, query, update, opts)
+	return res.Err()
+}
+
 // Update updates one matching document in the collection.
 func Update(collection string, query interface{}, update interface{}) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -205,15 +205,6 @@ func FindAll(collection string, query interface{},
 	return errors.WithStack(q.Skip(skip).Limit(limit).All(out))
 }
 
-func FindOneAndUpdate(collection string, query interface{}, update interface{}, opts *options.FindOneAndUpdateOptions) error {
-	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
-	coll := env.DB().Collection(collection)
-	res := coll.FindOneAndUpdate(ctx, query, update, opts)
-	return res.Err()
-}
-
 // Update updates one matching document in the collection.
 func Update(collection string, query interface{}, update interface{}) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -12,6 +12,7 @@ import (
 	adb "github.com/mongodb/anser/db"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const (
@@ -1038,6 +1039,15 @@ func UpdateAll(query interface{}, update interface{}) (*adb.ChangeInfo, error) {
 		Collection,
 		query,
 		update,
+	)
+}
+
+func FindOneAndUpdate(query interface{}, update interface{}, opts *options.FindOneAndUpdateOptions) error {
+	return db.FindOneAndUpdate(
+		Collection,
+		query,
+		update,
+		opts,
 	)
 }
 

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1084,17 +1084,18 @@ func UpdateAllMatchingDependenciesForTask(taskId, dependencyId string, unattaina
 	env := evergreen.GetEnvironment()
 	ctx, cancel := env.Context()
 	defer cancel()
-	coll := env.DB().Collection(Collection)
-	filter := bson.M{bsonutil.GetDottedKeyName("elem", DependencyTaskIdKey): dependencyId}
-	opts := options.FindOneAndUpdate().SetArrayFilters(options.ArrayFilters{Filters: []interface{}{filter}})
-	res := coll.FindOneAndUpdate(ctx,
+	res := env.DB().Collection(Collection).FindOneAndUpdate(ctx,
 		bson.M{
 			IdKey: taskId,
 		},
 		bson.M{
 			"$set": bson.M{bsonutil.GetDottedKeyName(DependsOnKey, "$[elem]", DependencyUnattainableKey): unattainable},
 		},
-		opts,
+		options.FindOneAndUpdate().SetArrayFilters(options.ArrayFilters{Filters: []interface{}{
+			bson.M{
+				bsonutil.GetDottedKeyName("elem", DependencyTaskIdKey): dependencyId,
+			},
+		}}),
 	)
 	return res.Err()
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1201,14 +1201,13 @@ func (t *Task) MarkUnattainableDependency(dependency *Task, unattainable bool) e
 			t.DependsOn[i].Unattainable = unattainable
 		}
 	}
-
 	return UpdateOne(
 		bson.M{
 			IdKey: t.Id,
 			bsonutil.GetDottedKeyName(DependsOnKey, DependencyTaskIdKey): dependency.Id,
 		},
 		bson.M{
-			"$set": bson.M{bsonutil.GetDottedKeyName(DependsOnKey, "$", DependencyUnattainableKey): unattainable},
+			"$set": bson.M{bsonutil.GetDottedKeyName(DependsOnKey, "$[]", DependencyUnattainableKey): unattainable},
 		},
 	)
 }
@@ -2006,7 +2005,7 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 	return tasks, nil
 }
 
-// UpdateDependsOn appends new dependnecies to tasks that already depend on this task
+// UpdateDependsOn appends new dependencies to tasks that already depend on this task
 func (t *Task) UpdateDependsOn(status string, newDependencyIDs []string) error {
 	newDependencies := make([]Dependency, 0, len(newDependencyIDs))
 	for _, depID := range newDependencyIDs {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -362,25 +362,9 @@ func (t *Task) AddDependency(d Dependency) error {
 			DependsOnKey: d,
 		},
 	}
+	// ensure the dependency doesn't already exist
 	for _, existingDependency := range t.DependsOn {
 		if existingDependency.TaskId == d.TaskId && existingDependency.Status == d.Status {
-			// If the dependency in the DB is attainable and we want to set it unattainable, update dependency.
-			// Otherwise, no update needed.
-			if !existingDependency.Unattainable && d.Unattainable {
-				query[DependsOnKey] = bson.M{
-					"$elemMatch": bson.M{
-						DependencyTaskIdKey: d.TaskId,
-						DependencyStatusKey: d.Status,
-					},
-				}
-				query[bsonutil.GetDottedKeyName(DependsOnKey, DependencyStatusKey)] = d.Status
-				update = bson.M{
-					"$set": bson.M{
-						bsonutil.GetDottedKeyName(DependsOnKey, "$", DependencyUnattainableKey): d.Unattainable,
-					},
-				}
-				break
-			}
 			return nil
 		}
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tychoish/tarjan"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo/options"
 	mgobson "gopkg.in/mgo.v2/bson"
 )
 
@@ -1202,17 +1201,8 @@ func (t *Task) MarkUnattainableDependency(dependency *Task, unattainable bool) e
 			t.DependsOn[i].Unattainable = unattainable
 		}
 	}
-	filter := bson.M{bsonutil.GetDottedKeyName("elem", DependencyTaskIdKey): dependency.Id}
-	opts := options.FindOneAndUpdate().SetArrayFilters(options.ArrayFilters{Filters: []interface{}{filter}})
-	return FindOneAndUpdate(
-		bson.M{
-			IdKey: t.Id,
-		},
-		bson.M{
-			"$set": bson.M{bsonutil.GetDottedKeyName(DependsOnKey, "$[elem]", DependencyUnattainableKey): unattainable},
-		},
-		opts,
-	)
+
+	return UpdateAllMatchingDependenciesForTask(t.Id, dependency.Id, unattainable)
 }
 
 // SetCost updates the task's Cost field

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1487,7 +1487,7 @@ func TestAddDependency(t *testing.T) {
 	updated, err = FindOneId(t1.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, len(depTaskIds), len(updated.DependsOn))
-	assert.True(t, updated.DependsOn[0].Unattainable)
+	assert.False(t, updated.DependsOn[0].Unattainable) // don't change attainability
 
 	assert.NoError(t, t1.AddDependency(Dependency{TaskId: "td1", Status: evergreen.TaskFailed}))
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1471,6 +1471,31 @@ func TestFindAllUnmarkedBlockedDependencies(t *testing.T) {
 	assert.Len(deps, 1)
 }
 
+func TestAddDependency(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
+	t1 := &Task{Id: "t1", DependsOn: depTaskIds}
+	assert.NoError(t, t1.Insert())
+
+	assert.NoError(t, t1.AddDependency(depTaskIds[0]))
+
+	updated, err := FindOneId(t1.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, t1.DependsOn, updated.DependsOn)
+
+	assert.NoError(t, t1.AddDependency(Dependency{TaskId: "td1", Status: evergreen.TaskSucceeded, Unattainable: true}))
+
+	updated, err = FindOneId(t1.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, len(depTaskIds), len(updated.DependsOn))
+	assert.True(t, updated.DependsOn[0].Unattainable)
+
+	assert.NoError(t, t1.AddDependency(Dependency{TaskId: "td1", Status: evergreen.TaskFailed}))
+
+	updated, err = FindOneId(t1.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, len(depTaskIds)+1, len(updated.DependsOn))
+}
+
 func TestFindAllMarkedUnattainableDependencies(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2798,13 +2798,16 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 					TaskId: "t0",
 					Status: evergreen.TaskSucceeded,
 				},
+				{
+					TaskId: "t0",
+					Status: evergreen.TaskSucceeded,
+				},
 			},
 			Status: evergreen.TaskUndispatched,
 		},
 		{
-			Id:      "t2",
-			BuildId: b.Id,
-
+			Id:          "t2",
+			BuildId:     b.Id,
 			Status:      evergreen.TaskUndispatched,
 			DisplayOnly: true,
 			DependsOn: []task.Dependency{
@@ -2874,7 +2877,9 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 
 	dbTask1, err := task.FindOneId(tasks[1].Id)
 	assert.NoError(err)
+	assert.Len(dbTask1.DependsOn, 2)
 	assert.True(dbTask1.DependsOn[0].Unattainable)
+	assert.True(dbTask1.DependsOn[1].Unattainable) // this task has duplicates which are also marked
 	assert.True(dbBuild.Tasks[1].Blocked)
 
 	dbTask2, err := task.FindOneId(tasks[2].Id)


### PR DESCRIPTION
1) Checks when adding new dependencies if the dependency already exists.
(This also updates unattainable if it should be updated). Do you think it's okay that this would add a new dependency if the taskId matched but the status didn't? I'm not sure when this would happen or if/how we handle that currently.

2) When marking dependencies unattainable/attainable, check all dependencies. (This shouldn't really be too expensive, I don't think a task ever has a _ton_ of dependencies unless there are duplicate bugs.)