### PR TITLE
EVG-7420: create s3 command to upload task directory

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -84,10 +84,17 @@ type AgentSetupData struct {
 
 // S3TaskSetupData contains information for tasks running S3 commands.
 type S3TaskSetupData struct {
-	Key     string `json:"key"`
-	Secret  string `json:"secret"`
-	Bucket  string `json:"bucket"`
-	BaseURL string `json:"base_url"`
+	Key    string `json:"key"`
+	Secret string `json:"secret"`
+	Bucket string `json:"bucket"`
+}
+
+func (d *S3TaskSetupData) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(d.Key == "", "S3 key is missing")
+	catcher.NewWhen(d.Secret == "", "S3 secret is missing")
+	catcher.NewWhen(d.Bucket == "", "S3 bucket name is missing")
+	return catcher.Resolve()
 }
 
 // NextTaskResponse represents the response sent back when an agent asks for a next task

--- a/command/registry.go
+++ b/command/registry.go
@@ -45,6 +45,7 @@ func init() {
 		"s3.get":                        s3GetFactory,
 		"s3.put":                        s3PutFactory,
 		"s3Copy.copy":                   s3CopyFactory,
+		"s3.push":                       s3PushFactory,
 		"shell.cleanup":                 shellCleanupFactory,
 		"shell.exec":                    shellExecFactory,
 		"shell.track":                   shellTrackFactory,

--- a/command/s3_push.go
+++ b/command/s3_push.go
@@ -1,0 +1,168 @@
+package command
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path"
+	"runtime"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/pail"
+	"github.com/mitchellh/mapstructure"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+// kim: TODO: figure out how to get a global evergreen S3 key/secret to this
+// command (environment?)
+// kim: TODO: figure out how to set up global private S3 bucket
+// kim: TODO: figure out unique naming scheme for a given task/execution in S3.
+// s3Push is a command to upload the task directory to s3.
+type s3Push struct {
+	// kim: TODO: how to set default values for these? These shouldn't be
+	// configurable fields
+
+	// ExcludeFilter contains a regexp describing files that should be
+	// excluded from the operation.
+	ExcludeFilter string `mapstructure:"exclude_filter" plugin:"expand"`
+	// BuildVariants contains all build variants this command should be run on.
+	BuildVariants []string `mapstructure:"build_variants"`
+
+	bucket pail.Bucket
+	base
+}
+
+func s3PushFactory() Command { return &s3Push{} }
+
+func (*s3Push) Name() string {
+	return "s3.push"
+}
+
+func (c *s3Push) ParseParams(params map[string]interface{}) error {
+	if err := mapstructure.Decode(params, c); err != nil {
+		return errors.Wrapf(err, "error decoding %s params", c.Name())
+	}
+	if err := c.validateParams(); err != nil {
+		return errors.Wrapf(err, "error validating %s params", c.Name())
+	}
+	return nil
+}
+
+func (c *s3Push) validateParams() error {
+	catcher := grip.NewBasicCatcher()
+	// catcher.NewWhen(c.DirPath == "", "directory path must be set")
+	// catcher.NewWhen(c.AWSKey == "", "AWS key must be set")
+	// catcher.NewWhen(c.AWSSecret == "", "AWS secret must be set")
+	return catcher.Resolve()
+}
+
+func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *model.TaskConfig) error {
+	httpClient := util.GetHTTPClient()
+	defer util.PutHTTPClient(httpClient)
+	if err := c.createBucket(httpClient); err != nil {
+		return errors.Wrap(err, "could not create S3 bucket")
+	}
+
+	if err := c.bucket.Check(ctx); err != nil {
+		return errors.Wrap(err, "could not check S3 bucket")
+	}
+
+	if err := c.bucket.Push(ctx, pail.SyncOptions{
+		Local: conf.WorkDir,
+		// kim: TODO: figure out remote once we have a bucket in S3.
+		Remote:  "kim: TODO: remote_goes_here",
+		Exclude: c.ExcludeFilter,
+	}); err != nil {
+		return errors.Wrap(err, "error pushing files to S3")
+	}
+
+	// TODO: project validation to ensure s3 push is not called multiple times.
+	// logs, err := comm.S3Copy(ctx, client.TaskData{
+	//     ID:     conf.Task.Id,
+	//     Secret: conf.Task.Secret,
+	// }, &apimodels.S3CopyRequest{
+	//     AwsKey:              os.Getenv("S3_KEY"),
+	//     AwsSecret:           os.Getenv("S3_SECRET"),
+	//     S3SourceBucket:      "kim: TODO: remote_goes_here",
+	//     S3SourcePath:        s3PushPrefixExecution(conf),
+	//     S3DestinationBucket: "kim: TODO: remote_goes_here",
+	//     S3DestinationPath:   s3PushPrefixLatest(conf),
+	//     S3Permissions:       string(pail.S3PermissionsPrivate),
+	// })
+	// if logs != "" {
+	//     logger.Task.Infof("s3 copy response: %s", logs)
+	// }
+	// if err != nil {
+	//     return errors.Wrap(err, "failed to S3 copy pushed files to latest")
+	// }
+
+	return nil
+}
+
+func (c *s3Push) expandParams(conf *model.TaskConfig) error {
+	if err := util.ExpandValues(c, conf.Expansions); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (c *s3Push) shouldRunOnBuildVariant(bv string) bool {
+	return util.StringSliceContains(c.BuildVariants, bv)
+}
+
+func (c *s3Push) createBucket(client *http.Client, conf *model.TaskConfig) error {
+	if c.bucket != nil {
+		return nil
+	}
+	// kim: TODO: get these into the agent environment
+	s3Key := os.Getenv("S3_KEY")
+	s3Secret := os.Getenv("S3_SECRET")
+	// kim: TODO: use different bucket from this one
+	s3Bucket := os.Getenv("S3_BUCKET")
+	if s3Key == "" || s3Secret == "" || s3Bucket == "" {
+		return errors.New("S3 credentials are missing")
+	}
+	opts := pail.S3Options{
+		Credentials: pail.CreateAWSCredentials(s3Key, s3Secret, ""),
+		Region:      endpoints.UsEast1RegionID,
+		Name:        s3Bucket,
+		// kim: TODO: check permissions
+		Permissions: pail.S3PermissionsPrivate,
+		// kim: TODO: figure out unique prefix using expansion values, which
+		// will be taken from taskconfig
+		// Default expansions: https://github.com/evergreen-ci/evergreen/wiki/Project-Files#default-expansions
+		// Example output: https://evergreen.mongodb.com/task/jasper_ubuntu1604_test_cli_patch_7578fac81116661dc7005038fe0706aad28c9309_5e6b8b3a1e2d1717ba216501_20_03_13_13_31_39
+		// Prefix: "${project_id}/${version_id}/${build_variant}/${task_name}/${execution}",
+		Prefix: s3PushPrefixLatest(conf),
+	}
+	bucket, err := pail.NewS3MultiPartBucketWithHTTPClient(client, opts)
+	if err != nil {
+		return errors.Wrap(err, "could not create bucket")
+	}
+	bucket = pail.NewParallelSyncBucket(pail.ParallelBucketOptions{
+		Workers:      runtime.NumCPU(),
+		DeleteOnSync: true,
+	}, bucket)
+	c.bucket = bucket
+	return nil
+}
+
+// s3PushPrefixLatest returns the path for the latest s3 push for this task.
+func s3PushPrefixLatest(conf *model.TaskConfig) string {
+	return path.Join(s3PushPrefixBase(conf), "latest")
+}
+
+// s3PushPrefixLatest returns the path for the s3 push for this task execution.
+func s3PushPrefixExecution(conf *model.TaskConfig) string {
+	return path.Join(s3PushPrefixBase(conf), strconv.Itoa(conf.Task.Execution))
+}
+
+// s3PushPrefixBase is a helper that returns the common s3 push path for a task.
+func s3PushPrefixBase(conf *model.TaskConfig) string {
+	return path.Join(conf.ProjectRef.Identifier, conf.Task.Version, conf.Task.BuildVariant, conf.Task.DisplayName)
+}

--- a/command/s3_push.go
+++ b/command/s3_push.go
@@ -34,7 +34,7 @@ func (*s3Push) Name() string {
 }
 
 const (
-	defaultS3MaxRetries = 10
+	defaultS3MaxRetries uint = 10
 )
 
 func (c *s3Push) ParseParams(params map[string]interface{}) error {
@@ -48,6 +48,10 @@ func (c *s3Push) ParseParams(params map[string]interface{}) error {
 }
 
 func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *model.TaskConfig) error {
+	if err := c.expandParams(conf); err != nil {
+		return errors.Wrap(err, "error applying expansions to parameters")
+	}
+
 	httpClient := util.GetHTTPClient()
 	defer util.PutHTTPClient(httpClient)
 
@@ -102,6 +106,7 @@ func (c *s3Push) createBucket(client *http.Client, conf *model.TaskConfig) error
 	if c.bucket != nil {
 		return nil
 	}
+
 	if err := conf.S3Data.Validate(); err != nil {
 		return errors.Wrap(err, "invalid S3 task credentials")
 	}
@@ -122,5 +127,6 @@ func (c *s3Push) createBucket(client *http.Client, conf *model.TaskConfig) error
 		DeleteOnSync: true,
 	}, bucket)
 	c.bucket = bucket
+
 	return nil
 }

--- a/command/s3_push.go
+++ b/command/s3_push.go
@@ -102,6 +102,7 @@ func (c *s3Push) createBucket(client *http.Client, conf *model.TaskConfig) error
 		Credentials: pail.CreateAWSCredentials(conf.S3Data.Key, conf.S3Data.Secret, ""),
 		Region:      endpoints.UsEast1RegionID,
 		Name:        conf.S3Data.Bucket,
+		MaxRetries:  10,
 		Permissions: pail.S3PermissionsPrivate,
 	}
 	bucket, err := pail.NewS3MultiPartBucketWithHTTPClient(client, opts)

--- a/command/s3_push.go
+++ b/command/s3_push.go
@@ -3,10 +3,8 @@ package command
 import (
 	"context"
 	"net/http"
-	"os"
 	"path"
 	"runtime"
-	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/evergreen-ci/evergreen/model"
@@ -18,15 +16,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// kim: TODO: figure out how to get a global evergreen S3 key/secret to this
-// command (environment?)
-// kim: TODO: figure out how to set up global private S3 bucket
-// kim: TODO: figure out unique naming scheme for a given task/execution in S3.
 // s3Push is a command to upload the task directory to s3.
 type s3Push struct {
-	// kim: TODO: how to set default values for these? These shouldn't be
-	// configurable fields
-
 	// ExcludeFilter contains a regexp describing files that should be
 	// excluded from the operation.
 	ExcludeFilter string `mapstructure:"exclude_filter" plugin:"expand"`
@@ -55,51 +46,39 @@ func (c *s3Push) ParseParams(params map[string]interface{}) error {
 
 func (c *s3Push) validateParams() error {
 	catcher := grip.NewBasicCatcher()
-	// catcher.NewWhen(c.DirPath == "", "directory path must be set")
-	// catcher.NewWhen(c.AWSKey == "", "AWS key must be set")
-	// catcher.NewWhen(c.AWSSecret == "", "AWS secret must be set")
+	// kim: TODO: validate buildvariants?
 	return catcher.Resolve()
 }
 
 func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *model.TaskConfig) error {
 	httpClient := util.GetHTTPClient()
 	defer util.PutHTTPClient(httpClient)
-	if err := c.createBucket(httpClient); err != nil {
-		return errors.Wrap(err, "could not create S3 bucket")
+
+	if !c.shouldRunOnBuildVariant(conf.BuildVariant.Name) {
+		logger.Task().Infof("Skipping s3.push for task directory for build variant '%s'", conf.BuildVariant.Name)
+		return nil
+	}
+
+	if err := c.createBucket(httpClient, conf); err != nil {
+		return errors.Wrap(err, "could not set up S3 task bucket")
 	}
 
 	if err := c.bucket.Check(ctx); err != nil {
-		return errors.Wrap(err, "could not check S3 bucket")
+		return errors.Wrap(err, "could not find S3 task bucket")
 	}
 
+	putMsg := "Pushing task directory files into S3"
+	if c.ExcludeFilter != "" {
+		putMsg += ", excluding files matching filter " + c.ExcludeFilter
+	}
+	logger.Task().Infof(putMsg)
 	if err := c.bucket.Push(ctx, pail.SyncOptions{
-		Local: conf.WorkDir,
-		// kim: TODO: figure out remote once we have a bucket in S3.
-		Remote:  "kim: TODO: remote_goes_here",
+		Local:   conf.WorkDir,
+		Remote:  s3TaskRemotePath(conf),
 		Exclude: c.ExcludeFilter,
 	}); err != nil {
-		return errors.Wrap(err, "error pushing files to S3")
+		return errors.Wrap(err, "error pushing task data to S3")
 	}
-
-	// TODO: project validation to ensure s3 push is not called multiple times.
-	// logs, err := comm.S3Copy(ctx, client.TaskData{
-	//     ID:     conf.Task.Id,
-	//     Secret: conf.Task.Secret,
-	// }, &apimodels.S3CopyRequest{
-	//     AwsKey:              os.Getenv("S3_KEY"),
-	//     AwsSecret:           os.Getenv("S3_SECRET"),
-	//     S3SourceBucket:      "kim: TODO: remote_goes_here",
-	//     S3SourcePath:        s3PushPrefixExecution(conf),
-	//     S3DestinationBucket: "kim: TODO: remote_goes_here",
-	//     S3DestinationPath:   s3PushPrefixLatest(conf),
-	//     S3Permissions:       string(pail.S3PermissionsPrivate),
-	// })
-	// if logs != "" {
-	//     logger.Task.Infof("s3 copy response: %s", logs)
-	// }
-	// if err != nil {
-	//     return errors.Wrap(err, "failed to S3 copy pushed files to latest")
-	// }
 
 	return nil
 }
@@ -119,26 +98,11 @@ func (c *s3Push) createBucket(client *http.Client, conf *model.TaskConfig) error
 	if c.bucket != nil {
 		return nil
 	}
-	// kim: TODO: get these into the agent environment
-	s3Key := os.Getenv("S3_KEY")
-	s3Secret := os.Getenv("S3_SECRET")
-	// kim: TODO: use different bucket from this one
-	s3Bucket := os.Getenv("S3_BUCKET")
-	if s3Key == "" || s3Secret == "" || s3Bucket == "" {
-		return errors.New("S3 credentials are missing")
-	}
 	opts := pail.S3Options{
-		Credentials: pail.CreateAWSCredentials(s3Key, s3Secret, ""),
+		Credentials: pail.CreateAWSCredentials(conf.S3Data.Key, conf.S3Data.Secret, ""),
 		Region:      endpoints.UsEast1RegionID,
-		Name:        s3Bucket,
-		// kim: TODO: check permissions
+		Name:        conf.S3Data.Bucket,
 		Permissions: pail.S3PermissionsPrivate,
-		// kim: TODO: figure out unique prefix using expansion values, which
-		// will be taken from taskconfig
-		// Default expansions: https://github.com/evergreen-ci/evergreen/wiki/Project-Files#default-expansions
-		// Example output: https://evergreen.mongodb.com/task/jasper_ubuntu1604_test_cli_patch_7578fac81116661dc7005038fe0706aad28c9309_5e6b8b3a1e2d1717ba216501_20_03_13_13_31_39
-		// Prefix: "${project_id}/${version_id}/${build_variant}/${task_name}/${execution}",
-		Prefix: s3PushPrefixLatest(conf),
 	}
 	bucket, err := pail.NewS3MultiPartBucketWithHTTPClient(client, opts)
 	if err != nil {
@@ -152,17 +116,13 @@ func (c *s3Push) createBucket(client *http.Client, conf *model.TaskConfig) error
 	return nil
 }
 
-// s3PushPrefixLatest returns the path for the latest s3 push for this task.
-func s3PushPrefixLatest(conf *model.TaskConfig) string {
-	return path.Join(s3PushPrefixBase(conf), "latest")
+// s3TaskRemotePath returns the path for the latest s3 push for this task.
+func s3TaskRemotePath(conf *model.TaskConfig) string {
+	return path.Join(s3TaskRemotePathBase(conf), "latest")
 }
 
-// s3PushPrefixLatest returns the path for the s3 push for this task execution.
-func s3PushPrefixExecution(conf *model.TaskConfig) string {
-	return path.Join(s3PushPrefixBase(conf), strconv.Itoa(conf.Task.Execution))
-}
-
-// s3PushPrefixBase is a helper that returns the common s3 push path for a task.
-func s3PushPrefixBase(conf *model.TaskConfig) string {
+// s3TaskPrefixBase is a helper that returns the base s3 path in S3, which is a
+// path path unique to a task.
+func s3TaskRemotePathBase(conf *model.TaskConfig) string {
 	return path.Join(conf.ProjectRef.Identifier, conf.Task.Version, conf.Task.BuildVariant, conf.Task.DisplayName)
 }

--- a/command/s3_push_test.go
+++ b/command/s3_push_test.go
@@ -16,9 +16,70 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestS3Push(t *testing.T) {
+func TestS3PushParseParams(t *testing.T) {
+	for testName, testCase := range map[string]func(*testing.T, *s3Push){
+		"SetsDefaults": func(t *testing.T, c *s3Push) {
+			require.NoError(t, c.ParseParams(map[string]interface{}{}))
+			assert.Equal(t, (defaultS3MaxRetries), c.MaxRetries)
+		},
+		"SetsValues": func(t *testing.T, c *s3Push) {
+			params := map[string]interface{}{
+				"exclude_filter": "exclude_pattern",
+				"build_variants": []string{"some_build_variant"},
+				"max_retries":    uint(5),
+			}
+			require.NoError(t, c.ParseParams(params))
+			assert.Equal(t, params["exclude_filter"], c.ExcludeFilter)
+			assert.Equal(t, params["build_variants"], c.BuildVariants)
+			assert.Equal(t, params["max_retries"], c.MaxRetries)
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			c := &s3Push{}
+			testCase(t, c)
+		})
+	}
+}
+
+func TestS3PushExecute(t *testing.T) {
 	for testName, testCase := range map[string]func(context.Context, *testing.T, *s3Push, *client.Mock, client.LoggerProducer, *model.TaskConfig){
 		"PushesTaskDirectoryToS3": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig) {
+			tmpDir, err := ioutil.TempDir("", "s3-push")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpDir))
+			}()
+			tmpFile, err := ioutil.TempFile(tmpDir, "s3-push-file")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpFile.Name()))
+			}()
+			fileContent := []byte("foobar")
+			_, err = tmpFile.Write(fileContent)
+			assert.NoError(t, tmpFile.Close())
+			require.NoError(t, err)
+			conf.WorkDir = tmpDir
+
+			require.NoError(t, c.Execute(ctx, comm, logger, conf))
+			iter, err := c.bucket.List(ctx, conf.S3Path())
+			require.NoError(t, err)
+			require.True(t, iter.Next(ctx))
+			item := iter.Item()
+			require.NotNil(t, item)
+			assert.Equal(t, filepath.Base(tmpFile.Name()), filepath.Base(item.Name()))
+			assert.Equal(t, conf.S3Path(), filepath.Dir(item.Name()))
+			r, err := item.Get(ctx)
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, r.Close())
+			}()
+			pulledContent, err := ioutil.ReadAll(r)
+			require.NoError(t, err)
+			assert.Equal(t, pulledContent, fileContent)
+
+			assert.False(t, iter.Next(ctx))
+		},
+		"IgnoresFilesExcludedByFilter": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig) {
 			tmpDir, err := ioutil.TempDir("", "s3-push")
 			require.NoError(t, err)
 			defer func() {
@@ -34,14 +95,10 @@ func TestS3Push(t *testing.T) {
 			require.NoError(t, err)
 			conf.WorkDir = tmpDir
 
+			c.ExcludeFilter = ".*"
 			require.NoError(t, c.Execute(ctx, comm, logger, conf))
 			iter, err := c.bucket.List(ctx, conf.S3Path())
 			require.NoError(t, err)
-			require.True(t, iter.Next(ctx))
-			item := iter.Item()
-			require.NotNil(t, item)
-			assert.Equal(t, filepath.Base(tmpFile.Name()), filepath.Base(item.Name()))
-			assert.Equal(t, conf.S3Path(), filepath.Dir(item.Name()))
 			assert.False(t, iter.Next(ctx))
 		},
 		"NoopsIfIgnoringBuildVariant": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig) {

--- a/command/s3_push_test.go
+++ b/command/s3_push_test.go
@@ -1,0 +1,127 @@
+package command
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/apimodels"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/pail"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestS3Push(t *testing.T) {
+	for testName, testCase := range map[string]func(context.Context, *testing.T, *s3Push, *client.Mock, client.LoggerProducer, *model.TaskConfig){
+		"PushesTaskDirectoryToS3": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig) {
+			tmpDir, err := ioutil.TempDir("", "s3-push")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpDir))
+			}()
+			tmpFile, err := ioutil.TempFile(tmpDir, "s3-push-file")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpFile.Name()))
+			}()
+			_, err = tmpFile.Write([]byte("foobar"))
+			assert.NoError(t, tmpFile.Close())
+			require.NoError(t, err)
+			conf.WorkDir = tmpDir
+
+			require.NoError(t, c.Execute(ctx, comm, logger, conf))
+			iter, err := c.bucket.List(ctx, conf.S3Path())
+			require.NoError(t, err)
+			require.True(t, iter.Next(ctx))
+			item := iter.Item()
+			require.NotNil(t, item)
+			assert.Equal(t, filepath.Base(tmpFile.Name()), filepath.Base(item.Name()))
+			assert.Equal(t, conf.S3Path(), filepath.Dir(item.Name()))
+			assert.False(t, iter.Next(ctx))
+		},
+		"NoopsIfIgnoringBuildVariant": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig) {
+			tmpDir, err := ioutil.TempDir("", "s3-push")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpDir))
+			}()
+			tmpFile, err := ioutil.TempFile(tmpDir, "s3-push-file")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpFile.Name()))
+			}()
+			_, err = tmpFile.Write([]byte("foobar"))
+			assert.NoError(t, tmpFile.Close())
+			require.NoError(t, err)
+			conf.WorkDir = tmpDir
+
+			c.BuildVariants = []string{"other_build_variant"}
+			require.NoError(t, c.Execute(ctx, comm, logger, conf))
+			iter, err := c.bucket.List(ctx, conf.S3Path())
+			require.NoError(t, err)
+			assert.False(t, iter.Next(ctx))
+		},
+		"FailsWithoutS3Key": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig) {
+			c.bucket = nil
+			conf.S3Data.Key = ""
+			assert.Error(t, c.Execute(ctx, comm, logger, conf))
+		},
+		"FailsWithoutS3Secret": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig) {
+			c.bucket = nil
+			conf.S3Data.Secret = ""
+			assert.Error(t, c.Execute(ctx, comm, logger, conf))
+		},
+		"FailsWithoutS3BucketName": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig) {
+			c.bucket = nil
+			conf.S3Data.Bucket = ""
+			assert.Error(t, c.Execute(ctx, comm, logger, conf))
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			conf := &model.TaskConfig{
+				Task: &task.Task{
+					Id:           "id",
+					Secret:       "secret",
+					Version:      "version",
+					BuildVariant: "build_variant",
+					DisplayName:  "display_name",
+				},
+				BuildVariant: &model.BuildVariant{
+					Name: "build_variant",
+				},
+				ProjectRef: &model.ProjectRef{
+					Identifier: "project_identifier",
+				},
+				S3Data: apimodels.S3TaskSetupData{
+					Key:    "s3_key",
+					Secret: "s3_secret",
+					Bucket: "s3_bucket",
+				},
+			}
+			comm := client.NewMock("localhost")
+			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{
+				ID:     conf.Task.Id,
+				Secret: conf.Task.Secret,
+			}, nil)
+			require.NoError(t, err)
+			tmpDir, err := ioutil.TempDir("", "s3-push-bucket")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpDir))
+			}()
+			c := &s3Push{}
+			c.bucket, err = pail.NewLocalBucket(pail.LocalOptions{
+				Path: tmpDir,
+			})
+			require.NoError(t, err)
+			testCase(ctx, t, c, comm, logger, conf)
+		})
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -131,7 +131,7 @@ imports:
   - name: github.com/evergreen-ci/shrub
     version: 32e668cd99410328bf6659e55671c11a6c727d9a
   - name: github.com/evergreen-ci/pail
-    version: 4a0b306b2db0e74641aa30b8b9e748054adbee79
+    version: 8e55909532a48733d110b22949dc469e054db8ec
   - name: github.com/mongodb/jasper
     version: 5fb1ab4916bb2cce94a003fc0277d62dccd9cc90
   - name: go.mongodb.org/mongo-driver

--- a/globals.go
+++ b/globals.go
@@ -195,7 +195,8 @@ const (
 
 	MaxTeardownGroupTimeoutSecs = 30 * 60
 
-	DefaultJasperPort          = 2385
+	DefaultJasperPort = 2385
+
 	GlobalGitHubTokenExpansion = "global_github_oauth_token"
 
 	VSCodePort = 2021

--- a/model/task_config.go
+++ b/model/task_config.go
@@ -117,6 +117,11 @@ func (c *TaskConfig) GetWorkingDirectory(dir string) (string, error) {
 	return dir, nil
 }
 
+// S3Path returns the path to the working directory dump in S3 for a task.
+func (c *TaskConfig) S3Path() string {
+	return filepath.Join(c.ProjectRef.Identifier, c.Task.Version, c.Task.BuildVariant, c.Task.DisplayName, "latest")
+}
+
 func MakeConfigFromTask(t *task.Task) (*TaskConfig, error) {
 	if t == nil {
 		return nil, errors.New("no task to make a TaskConfig from")

--- a/service/api_status.go
+++ b/service/api_status.go
@@ -189,10 +189,9 @@ func (as *APIServer) agentSetup(w http.ResponseWriter, r *http.Request) {
 		S3Secret:          as.Settings.Providers.AWS.S3Secret,
 		S3Bucket:          as.Settings.Providers.AWS.Bucket,
 		S3Task: apimodels.S3TaskSetupData{
-			Key:     as.Settings.Providers.AWS.S3TaskKey,
-			Secret:  as.Settings.Providers.AWS.S3TaskSecret,
-			Bucket:  as.Settings.Providers.AWS.S3TaskBucket,
-			BaseURL: as.Settings.Providers.AWS.S3BaseURL,
+			Key:    as.Settings.Providers.AWS.S3TaskKey,
+			Secret: as.Settings.Providers.AWS.S3TaskSecret,
+			Bucket: as.Settings.Providers.AWS.S3TaskBucket,
 		},
 		S3Base:       as.Settings.Providers.AWS.S3BaseURL,
 		LogkeeperURL: as.Settings.LoggerConfig.LogkeeperURL,

--- a/vendor/github.com/evergreen-ci/pail/.golangci.yml
+++ b/vendor/github.com/evergreen-ci/pail/.golangci.yml
@@ -1,0 +1,15 @@
+---
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - goimports
+    - govet
+    - ineffassign
+    - interfacer
+    - misspell
+    - unconvert
+
+linters-settings:
+  govet:
+    check-shadowing: true

--- a/vendor/github.com/evergreen-ci/pail/bucket_test.go
+++ b/vendor/github.com/evergreen-ci/pail/bucket_test.go
@@ -47,7 +47,7 @@ func TestBucket(t *testing.T) {
 	ses, err := mgo.DialWithTimeout(mdburl, time.Second)
 	require.NoError(t, err)
 	defer ses.Close()
-	defer func() { ses.DB(uuid).DropDatabase() }()
+	defer func() { assert.NoError(t, ses.DB(uuid).DropDatabase()) }()
 
 	s3BucketName := "build-test-curator"
 	s3Prefix := newUUID() + "-"
@@ -971,7 +971,8 @@ func TestBucket(t *testing.T) {
 					require.NoError(t, err)
 					counter := 0
 					for iter.Next(ctx) {
-						fn, err := filepath.Rel(remotePrefix, iter.Item().Name())
+						var fn string
+						fn, err = filepath.Rel(remotePrefix, iter.Item().Name())
 						require.NoError(t, err)
 						ok := filenames[fn]
 						if !ok {

--- a/vendor/github.com/evergreen-ci/pail/cmd/run-linter/run-linter.go
+++ b/vendor/github.com/evergreen-ci/pail/cmd/run-linter/run-linter.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/mongodb/grip"
 )
 
 type result struct {
@@ -28,7 +30,6 @@ func (r *result) String() string {
 	if r.passed {
 		fmt.Fprintf(buf, "--- PASS: %s (%s)", r.name, r.duration)
 	} else {
-		// fmt.Fprintln(buf, "    CMD:", r.cmd)
 		fmt.Fprintf(buf, strings.Join(r.output, "\n"))
 		fmt.Fprintf(buf, "--- FAIL: %s (%s)", r.name, r.duration)
 	}
@@ -47,50 +48,62 @@ func (r *result) fixup(dirname string) {
 	}
 }
 
-// runs the gometalinter on a list of packages; integrating with the "make lint" target.
+// runs the golangci-lint on a list of packages; integrating with the "make lint" target.
 func main() {
 	var (
-		lintArgs       string
-		lintBin        string
-		packageList    string
-		output         string
-		packages       []string
-		results        []*result
-		hasFailingTest bool
+		lintArgs          string
+		lintBin           string
+		customLintersFlag string
+		customLinters     []string
+		packageList       string
+		output            string
+		packages          []string
+		results           []*result
+		hasFailingTest    bool
 
 		gopath = os.Getenv("GOPATH")
 	)
 
-	flag.StringVar(&lintArgs, "lintArgs", "", "args to pass to gometalinter")
-	flag.StringVar(&lintBin, "lintBin", filepath.Join(gopath, "bin", "gometalinter"), "path to go metalinter")
+	gopath, _ = filepath.Abs(gopath)
+
+	flag.StringVar(&lintArgs, "lintArgs", "", "args to pass to golangci-lint")
+	flag.StringVar(&lintBin, "lintBin", filepath.Join(gopath, "bin", "golangci-lint"), "path to golangci-lint")
 	flag.StringVar(&packageList, "packages", "", "list of space separated packages")
+	flag.StringVar(&customLintersFlag, "customLinters", "", "list of comma-separated custom linter commands")
 	flag.StringVar(&output, "output", "", "output file for to write results.")
 	flag.Parse()
 
+	if len(customLintersFlag) != 0 {
+		customLinters = strings.Split(customLintersFlag, ",")
+	}
 	packages = strings.Split(strings.Replace(packageList, "-", "/", -1), " ")
 	dirname, _ := os.Getwd()
 	cwd := filepath.Base(dirname)
-	gopath, _ = filepath.Abs(gopath)
 	lintArgs += fmt.Sprintf(" --concurrency=%d", runtime.NumCPU()/2)
 
 	for _, pkg := range packages {
-		args := []string{lintBin, lintArgs}
-		if cwd == pkg {
-			args = append(args, ".")
-		} else {
-			args = append(args, "./"+pkg)
+		pkgDir := "./"
+		if cwd != pkg {
+			pkgDir += pkg
 		}
+		args := []string{lintBin, "run", lintArgs, pkgDir}
 
 		startAt := time.Now()
 		cmd := strings.Join(args, " ")
 		out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
-
 		r := &result{
 			cmd:      strings.Join(args, " "),
 			name:     "lint-" + strings.Replace(pkg, "/", "-", -1),
 			passed:   err == nil,
 			duration: time.Since(startAt),
 			output:   strings.Split(string(out), "\n"),
+		}
+		for _, linter := range customLinters {
+			customLinterStart := time.Now()
+			out, err = exec.Command("sh", "-c", fmt.Sprintf("%s %s", linter, pkgDir)).CombinedOutput()
+			r.passed = r.passed && err == nil
+			r.duration += time.Since(customLinterStart)
+			r.output = append(r.output, strings.Split(string(out), "\n")...)
 		}
 		r.fixup(dirname)
 
@@ -114,7 +127,10 @@ func main() {
 		}()
 
 		for _, r := range results {
-			f.WriteString(r.String() + "\n")
+			if _, err = f.WriteString(r.String() + "\n"); err != nil {
+				grip.Error(err)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/vendor/github.com/evergreen-ci/pail/evergreen.yaml
+++ b/vendor/github.com/evergreen-ci/pail/evergreen.yaml
@@ -189,8 +189,8 @@ buildvariants:
   - name: coverage
     display_name: Coverage (Arch Linux)
     expansions:
-      gobin: /opt/golang/go1.13/bin/go
-      goroot: /opt/golang/go1.13
+      gobin: /opt/golang/go1.9/bin/go
+      goroot: /opt/golang/go1.9
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
       - archlinux-test

--- a/vendor/github.com/evergreen-ci/pail/glide.lock
+++ b/vendor/github.com/evergreen-ci/pail/glide.lock
@@ -4,7 +4,7 @@ imports:
 - name: github.com/pkg/errors
   version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
 - name: github.com/mongodb/grip
-  version: a4288cec9139bc97135a22e795b086baefb167b2
+  version: 2e402613ba129030dffcf05f53f185ea52d350c2
 - name: github.com/aws/aws-sdk-go
   version: cf66c348f82c79de333bd788d4f782c4d623ebad
 - name: gopkg.in/mgo.v2

--- a/vendor/github.com/evergreen-ci/pail/gridfs.go
+++ b/vendor/github.com/evergreen-ci/pail/gridfs.go
@@ -287,7 +287,7 @@ func (b *gridfsBucket) Push(ctx context.Context, opts SyncOptions) error {
 	}
 
 	if b.opts.DeleteOnSync && !b.opts.DryRun {
-		return errors.Wrap(deleteOnPush(ctx, localPaths, opts.Remote, b), "probelm with delete on sync after push")
+		return errors.Wrap(deleteOnPush(ctx, localPaths, opts.Remote, b), "problem with delete on sync after push")
 	}
 
 	return nil

--- a/vendor/github.com/evergreen-ci/pail/gridfs_legacy.go
+++ b/vendor/github.com/evergreen-ci/pail/gridfs_legacy.go
@@ -303,7 +303,7 @@ func (b *gridfsLegacyBucket) Push(ctx context.Context, opts SyncOptions) error {
 	}
 
 	if b.opts.DeleteOnSync && !b.opts.DryRun {
-		return errors.Wrap(deleteOnPush(ctx, localPaths, opts.Remote, b), "probelm with delete on sync after push")
+		return errors.Wrap(deleteOnPush(ctx, localPaths, opts.Remote, b), "problem with delete on sync after push")
 	}
 	return nil
 }

--- a/vendor/github.com/evergreen-ci/pail/interface.go
+++ b/vendor/github.com/evergreen-ci/pail/interface.go
@@ -20,7 +20,7 @@ import (
 //   - https://github.com/evergreen-ci/evergreen/blob/master/thirdparty/s3.go
 //   - https://github.com/mongodb/curator/tree/master/sthree
 //
-// The prefered aws sdk is here: https://docs.aws.amazon.com/sdk-for-go/api/
+// The preferred aws sdk is here: https://docs.aws.amazon.com/sdk-for-go/api/
 //
 // In no particular order:
 //  - implementation constructors should make it possible to use

--- a/vendor/github.com/evergreen-ci/pail/local.go
+++ b/vendor/github.com/evergreen-ci/pail/local.go
@@ -363,7 +363,7 @@ func (b *localFileSystem) Push(ctx context.Context, opts SyncOptions) error {
 	}
 
 	if b.deleteOnSync && !b.dryRun {
-		return errors.Wrap(deleteOnPush(ctx, files, opts.Remote, b), "probelm with delete on sync after push")
+		return errors.Wrap(deleteOnPush(ctx, files, opts.Remote, b), "problem with delete on sync after push")
 	}
 	return nil
 }

--- a/vendor/github.com/evergreen-ci/pail/makefile
+++ b/vendor/github.com/evergreen-ci/pail/makefile
@@ -1,6 +1,4 @@
 buildDir := build
-srcFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "*\#*")
-testFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
 projectPath := github.com/evergreen-ci/pail
 
 packages := pail
@@ -19,44 +17,16 @@ endif
 goEnv := GOPATH=$(gopath) $(if ${GO_BIN_PATH},PATH="$(shell dirname ${GO_BIN_PATH}):${PATH}")
 # end environment setup
 
-# start linting configuration
-#   package, testing, and linter dependencies specified
-#   separately. This is a temporary solution: eventually we should
-#   vendorize all of these dependencies.
-lintDeps := github.com/alecthomas/gometalinter
-#   include test files and give linters 40s to run to avoid timeouts
-lintArgs := --tests --deadline=13m --vendor
-#   gotype produces false positives because it reads .a files which
-#   are rarely up to date.
-lintArgs += --disable="gotype" --disable="gosec" --disable="gocyclo" --enable="golint"
-lintArgs += --skip="build"
-#   enable and configure additional linters
-lintArgs += --line-length=100 --dupl-threshold=150
-#   some test cases are structurally similar, and lead to dupl linter
-#   warnings, but are important to maintain separately, and would be
-#   difficult to test without a much more complex reflection/code
-#   generation approach, so we ignore dupl errors in tests.
-lintArgs += --exclude="warning: duplicate of .*_test.go"
-#   go lint warns on an error in docstring format, erroneously because
-#   it doesn't consider the entire package.
-lintArgs += --exclude="warning: package comment should be of the form \"Package .* ...\""
-#   known issues that the linter picks up that are not relevant in our cases
-lintArgs += --exclude="file is not goimported" # top-level mains aren't imported
-lintArgs += --exclude="error return value not checked .defer.*"
-# end linting configuration
 
-
-# start dependency installation tools
-#   implementation details for being able to lazily install dependencies
-lintDeps := $(addprefix $(gopath)/src/,$(lintDeps))
-$(gopath)/src/%:
-	@-[ ! -d $(gopath) ] && mkdir -p $(gopath) || true
-	$(goEnv) $(gobin) get $(subst $(gopath)/src/,,$@)
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
-	 $(goEnv) $(gobin) build -o $@ $<
-$(buildDir)/.lintSetup:$(lintDeps)
-	@-$(gopath)/bin/gometalinter --install >/dev/null && touch $@
-# end dependency installation tools
+# start lint setup targets
+lintDeps := $(buildDir)/.lintSetup $(buildDir)/run-linter $(buildDir)/golangci-lint
+$(buildDir)/.lintSetup:$(buildDir)/golangci-lint
+	@touch $@
+$(buildDir)/golangci-lint:$(buildDir)
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.10.2 >/dev/null 2>&1
+$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup $(buildDir)
+	@$(goEnv) $(gobin) build -o $@ $<
+# end lint setup targets
 
 
 testArgs := -v
@@ -83,8 +53,6 @@ testArgs += -timeout=30m
 endif
 
 # test execution and output handlers
-$(buildDir)/:
-	mkdir -p $@
 $(buildDir)/output.%.test:$(buildDir)/ .FORCE
 	export USERPROFILE=$(userProfile)
 	$(goEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$*,) | tee $@
@@ -101,9 +69,9 @@ $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	$(goEnv) $(gobin) tool cover -html=$< -o $@
 #  targets to generate gotest output from the linter.
 $(buildDir)/output.%.lint:$(buildDir)/run-linter $(buildDir)/ .FORCE
-	@./$< --output=$@ --lintArgs='$(lintArgs)' --packages='$*'
+	@./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 $(buildDir)/output.lint:$(buildDir)/run-linter $(buildDir)/ .FORCE
-	@./$< --output="$@" --lintArgs='$(lintArgs)' --packages="$(packages)"
+	@./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$(packages)'
 #  targets to process and generate coverage reports
 # end test and coverage artifacts
 
@@ -125,15 +93,15 @@ benchmark:
 	$(goEnv) $(gobin) test -v -benchmem -bench=. -run="Benchmark.*" -timeout=20m
 lint:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 
-phony += lint lint-deps build build-race race test coverage coverage-html
+phony += lint build race test coverage coverage-html
 .PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 .PRECIOUS:$(buildDir)/output.lint
 # end front-ends
 
 
-$(buildDir):$(srcFiles) compile
+$(buildDir): compile
 	@mkdir -p $@
-$(buildDir)/cover.out:$(buildDir) $(testFiles) .FORCE
+$(buildDir)/cover.out:$(buildDir) .FORCE
 	export USERPROFILE=$(userProfile)
 	$(goEnv) $(gobin) test $(testArgs) -covermode=count -coverprofile $@ -cover ./
 $(buildDir)/cover.html:$(buildDir)/cover.out
@@ -147,7 +115,12 @@ vendor-clean:
 	rm -rf vendor/go.mongodb.org/mongo-driver/vendor/github.com/stretchr
 	rm -rf vendor/go.mongodb.org/mongo-driver/vendor/github.com/davecgh
 	rm -rf vendor/go.mongodb.org/mongo-driver/vendor/github.com/montanaflynn
+	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/montanaflynn
+	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/pkg/errors
 phony += vendor-clean
+clean:
+	rm -rf $(lintDeps)
+phony += clean
 
 # mongodb utility targets
 mongodb/.get-mongodb:

--- a/vendor/github.com/evergreen-ci/pail/parallel.go
+++ b/vendor/github.com/evergreen-ci/pail/parallel.go
@@ -97,7 +97,7 @@ func (b *parallelBucketImpl) Push(ctx context.Context, opts SyncOptions) error {
 	wg.Wait()
 
 	if ctx.Err() == nil && b.deleteOnSync && !b.dryRun {
-		catcher.Add(errors.Wrap(deleteOnPush(ctx, files, opts.Remote, b), "probelm with delete on sync after push"))
+		catcher.Add(errors.Wrap(deleteOnPush(ctx, files, opts.Remote, b), "problem with delete on sync after push"))
 	}
 
 	return catcher.Resolve()

--- a/vendor/github.com/evergreen-ci/pail/s3_bucket.go
+++ b/vendor/github.com/evergreen-ci/pail/s3_bucket.go
@@ -92,7 +92,7 @@ type S3Options struct {
 	UseSingleFileChecksums bool
 	// Verbose sets the logging mode to "debug".
 	Verbose bool
-	// MaxRetries sets the number of retry attemps for s3 operations.
+	// MaxRetries sets the number of retry attempts for s3 operations.
 	MaxRetries int
 	// Credentials allows the passing in of explicit AWS credentials. These
 	// will override the default credentials chain. (Optional)
@@ -847,7 +847,7 @@ func (s *s3Bucket) pushHelper(ctx context.Context, b Bucket, opts SyncOptions) e
 	}
 
 	if s.deleteOnSync && !s.dryRun {
-		return errors.Wrap(deleteOnPush(ctx, files, opts.Remote, b), "probelm with delete on sync after push")
+		return errors.Wrap(deleteOnPush(ctx, files, opts.Remote, b), "problem with delete on sync after push")
 	}
 	return nil
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7420

Dump the whole task directory into a private S3 bucket for tasks.
* Allow filtering variants that run s3.push.
* Allow file exclusion.
* Only one copy of s3.push per task. If you run the task again, it overwrites the original s3.push content. It might be possible to make this have unique task dumps for each execution of the task but it would be more complicated.