### PR TITLE
EVG-7670: check for spawn hosts where necessary

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -807,8 +807,8 @@ func (d *Distro) AddPermissions(creator *user.DBUser) error {
 	return nil
 }
 
-// LegacyBootstrap returns whether hosts of this distro are bootstrapped using the legacy
-// method.
+// LegacyBootstrap returns whether hosts of this distro are bootstrapped using
+// the legacy method.
 func (d *Distro) LegacyBootstrap() bool {
 	return d.BootstrapSettings.Method == "" || d.BootstrapSettings.Method == BootstrapMethodLegacySSH
 }

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -842,7 +842,6 @@ func FindUserDataSpawnHostsProvisioning() ([]Host, error) {
 		StatusKey:      evergreen.HostProvisioning,
 		ProvisionedKey: true,
 		StartedByKey:   bson.M{"$ne": evergreen.User},
-		UserHostKey:    true,
 		bootstrapKey:   distro.BootstrapMethodUserData,
 	}))
 	if err != nil {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -802,6 +802,10 @@ func (h *Host) UpdateProvisioningToRunning() error {
 // reprovisioning change. If the host is ready to reprovision now (i.e. no agent
 // monitor is running), it is put in the reprovisioning state.
 func (h *Host) SetNeedsJasperRestart(user string) error {
+	// Ignore hosts spawned by tasks.
+	if h.Distro.BootstrapSettings.Method == distro.BootstrapMethodNone {
+		return nil
+	}
 	if err := h.setAwaitingJasperRestart(user); err != nil {
 		return err
 	}

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -801,6 +801,9 @@ func (h *Host) JasperClient(ctx context.Context, env evergreen.Environment) (rem
 	if (h.Distro.LegacyBootstrap() || h.Distro.LegacyCommunication()) && h.NeedsReprovision != ReprovisionToLegacy {
 		return nil, errors.New("legacy host does not support remote Jasper process management")
 	}
+	if h.Distro.BootstrapSettings.Method == distro.BootstrapMethodNone {
+		return nil, errors.New("hosts without any provisioning method cannot use Jasper")
+	}
 
 	settings := env.Settings()
 	if h.Distro.BootstrapSettings.Communication == distro.CommunicationMethodSSH || h.NeedsReprovision == ReprovisionToLegacy {

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -642,7 +642,7 @@ func (h *distroExecuteHandler) Run(ctx context.Context) gimlet.Responder {
 	var hostIDs []string
 	for _, host := range hosts {
 		ts := util.RoundPartOfMinute(0).Format(units.TSFormat)
-		if (host.StartedBy == evergreen.User && h.opts.IncludeTaskHosts) || (host.StartedBy != evergreen.User && h.opts.IncludeSpawnHosts) {
+		if (host.StartedBy == evergreen.User && h.opts.IncludeTaskHosts) || (host.UserHost && h.opts.IncludeSpawnHosts) {
 			if err = h.env.RemoteQueue().Put(ctx, units.NewHostExecuteJob(h.env, host, h.opts.Script, h.opts.Sudo, h.opts.SudoUser, ts)); err != nil {
 				catcher.Wrapf(err, "problem enqueueing job to run script on host '%s'", host.Id)
 				continue

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -32,7 +32,7 @@ func makeSpawnHostProvisioningTriggers() eventHandler {
 }
 
 func (t *spawnHostProvisioningTriggers) hostSpawnProvisionOutcome(sub *event.Subscription) (*notification.Notification, error) {
-	if t.host.StartedBy == evergreen.User {
+	if !t.host.UserHost {
 		return nil, nil
 	}
 
@@ -159,7 +159,7 @@ func makeSpawnHostStateChangeTriggers() eventHandler {
 }
 
 func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(sub *event.Subscription) (*notification.Notification, error) {
-	if t.host.StartedBy == evergreen.User {
+	if !t.host.UserHost {
 		return nil, nil
 	}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7670

This just does a bit stricter checking for hosts created from tasks with host.create. Most of the time, we assume that a host with `StartedBy != evergreen.User` is a spawn host, which is not necessarily the case for hosts started via host.create.