### PR TITLE
EVG-7603 volume fixes

### DIFF
--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -57,6 +57,7 @@ func NewUserDataDoneJob(env evergreen.Environment, h host.Host, id string) amboy
 	j.HostID = h.Id
 	j.env = env
 	j.SetPriority(1)
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", userDataDoneJobName, j.HostID)})
 	j.SetID(fmt.Sprintf("%s.%s.%s", userDataDoneJobName, j.HostID, id))
 
 	return j


### PR DESCRIPTION
- Use the `ln source_file ... destination_dir` form (if for some reason it runs twice it shouldn't make an infinity mirror of soft links)
- Append a newline to the end of `/etc/fstab`
- Scope `provisioning_user_data_done` and `provisioning_setup_host` jobs per host. Each host will only have one job at a time so they don't each add their own home volume to the host.