### PR TITLE
EVG-7685 generate device name without host query

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1140,15 +1140,17 @@ func (m *ec2Manager) AttachVolume(ctx context.Context, h *host.Host, attachment 
 	}
 	defer m.client.Close()
 
-	opts := generateDeviceNameOptions{isWindows: h.Distro.IsWindows()}
+	opts := generateDeviceNameOptions{
+		isWindows:           h.Distro.IsWindows(),
+		existingDeviceNames: h.HostVolumeDeviceNames(),
+	}
 	// if no device name is provided, generate a unique device name
 	if attachment.DeviceName == "" {
-		deviceName, err := getGeneratedDeviceNameForVolume(ctx, h.Distro.IsWindows())
+		deviceName, err := generateDeviceNameForVolume(opts)
 		if err != nil {
 			return errors.Wrap(err, "error generating initial device name")
 		}
 		attachment.DeviceName = deviceName
-		opts.shouldGenerate = true
 	}
 
 	volume, err := m.client.AttachVolume(ctx, &ec2.AttachVolumeInput{

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -326,10 +326,6 @@ type Terms struct {
 // formats /dev/sd[f-p]and xvd[f-p] taken from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
 func generateDeviceNameForVolume(opts generateDeviceNameOptions) (string, error) {
 	letters := "fghijklmnop"
-	if len(opts.existingDeviceNames) >= len(letters) {
-		return "", errors.Errorf("host cannot have more than '%d' volumes", len(letters))
-	}
-
 	pattern := "/dev/sd%c"
 	if opts.isWindows {
 		pattern = "xvd%c"

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -363,20 +363,6 @@ func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, erro
 	return len(hosts), nil
 }
 
-func HostExistsWithVolumeWithDeviceName(deviceName string) (bool, error) {
-	q := db.Query(
-		bson.M{bsonutil.GetDottedKeyName(VolumesKey, VolumeDeviceNameKey): deviceName},
-	)
-
-	hosts, err := Find(q)
-	if err != nil {
-		return false, errors.Wrapf(err, "error querying database for host volumes")
-	}
-	hostExists := len(hosts) > 0
-	return hostExists, nil
-
-}
-
 // IsUninitialized is a query that returns all unstarted + uninitialized Evergreen hosts.
 var IsUninitialized = db.Query(
 	bson.M{StatusKey: evergreen.HostUninitialized},

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2289,6 +2289,14 @@ func (h *Host) HomeVolume() *VolumeAttachment {
 	return nil
 }
 
+func (h *Host) HostVolumeDeviceNames() []string {
+	res := []string{}
+	for _, vol := range h.Volumes {
+		res = append(res, vol.DeviceName)
+	}
+	return res
+}
+
 // FindHostWithVolume finds the host associated with the
 // specified volume ID.
 func FindHostWithVolume(volumeID string) (*Host, error) {

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -446,6 +446,14 @@ func (h *attachVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 			Message:    errors.Errorf("host '%s' status is %s", targetHost.Id, targetHost.Status).Error(),
 		})
 	}
+	if h.attachment.DeviceName != "" {
+		if util.StringSliceContains(targetHost.HostVolumeDeviceNames(), h.attachment.DeviceName) {
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusBadRequest,
+				Message:    errors.Errorf("host '%s' already has a volume with device name '%s'", h.hostID, h.attachment.DeviceName).Error(),
+			})
+		}
+	}
 
 	// Check whether attachment already attached to a host
 	attachedHost, err := h.sc.FindHostWithVolume(h.attachment.VolumeID)


### PR DESCRIPTION
For whatever reason when I did this query originally I made it so device name had to be unique across all hosts--it just needs to be unique for the given host, so no DB query is necessary.

Additionally, we know that the 10 names we generate are valid so we shouldn't need to retry device names for that.

Having an issue though where errors aren't being returned correctly to the CLI? Seems to be hanging instead, even if the errors are inside of Run() for the route (`error sending request to attach volume: Post https://evergreen-staging.corp.mongodb.com/api/rest/v2/hosts/i-06c3e1da518f1f056/attach: net/http: request canceled (Client.Timeout exceeded while awaiting headers)`)

Also made a fix to DeleteVolume: saw an issue with a volume in my list not existing in AWS. Does AWS terminate volumes that aren't in use? Are we okay with this? 