### PR TITLE
EVG-7393: uiLink field for Dependency type

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -52,6 +52,7 @@ type ComplexityRoot struct {
 		MetStatus      func(childComplexity int) int
 		Name           func(childComplexity int) int
 		RequiredStatus func(childComplexity int) int
+		UILink         func(childComplexity int) int
 	}
 
 	File struct {
@@ -358,6 +359,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Dependency.RequiredStatus(childComplexity), true
+
+	case "Dependency.uiLink":
+		if e.complexity.Dependency.UILink == nil {
+			break
+		}
+
+		return e.complexity.Dependency.UILink(childComplexity), true
 
 	case "File.link":
 		if e.complexity.File.Link == nil {
@@ -1743,6 +1751,7 @@ type Dependency {
   metStatus: MetStatus!
   requiredStatus: RequiredStatus!
   buildVariant: String!
+  uiLink: String!
 }
 
 type Task {
@@ -2362,6 +2371,40 @@ func (ec *executionContext) _Dependency_buildVariant(ctx context.Context, field 
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.BuildVariant, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Dependency_uiLink(ctx context.Context, field graphql.CollectedField, obj *Dependency) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Dependency",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UILink, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8623,6 +8666,11 @@ func (ec *executionContext) _Dependency(ctx context.Context, sel ast.SelectionSe
 			}
 		case "buildVariant":
 			out.Values[i] = ec._Dependency_buildVariant(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "uiLink":
+			out.Values[i] = ec._Dependency_uiLink(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -16,6 +16,7 @@ type Dependency struct {
 	MetStatus      MetStatus      `json:"metStatus"`
 	RequiredStatus RequiredStatus `json:"requiredStatus"`
 	BuildVariant   string         `json:"buildVariant"`
+	UILink         string         `json:"uiLink"`
 }
 
 type DisplayTask struct {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -104,6 +104,7 @@ func (r *taskResolver) ReliesOn(ctx context.Context, at *restModel.APITask) ([]*
 			BuildVariant:   depTask.BuildVariant,
 			MetStatus:      metStatus,
 			RequiredStatus: requiredStatus,
+			UILink:         fmt.Sprintf("/task/%s", depTask.Id),
 		}
 
 		dependencies = append(dependencies, &dependency)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -193,6 +193,7 @@ type Dependency {
   metStatus: MetStatus!
   requiredStatus: RequiredStatus!
   buildVariant: String!
+  uiLink: String!
 }
 
 type Task {

--- a/graphql/tests/task/queries/reliesOn-dep-status-equals-all-statuses.graphql
+++ b/graphql/tests/task/queries/reliesOn-dep-status-equals-all-statuses.graphql
@@ -5,6 +5,7 @@
       requiredStatus
       buildVariant
       name
+      uiLink
     }
   }
 }

--- a/graphql/tests/task/queries/reliesOn-dep-status-failed.graphql
+++ b/graphql/tests/task/queries/reliesOn-dep-status-failed.graphql
@@ -5,6 +5,7 @@
       requiredStatus
       buildVariant
       name
+      uiLink
     }
   }
 }

--- a/graphql/tests/task/queries/reliesOn-task-status-equals-dep-status.graphql
+++ b/graphql/tests/task/queries/reliesOn-task-status-equals-dep-status.graphql
@@ -5,6 +5,7 @@
       requiredStatus
       buildVariant
       name
+      uiLink
     }
   }
 }

--- a/graphql/tests/task/queries/reliesOn-task-status-not-success-nor-fail.graphql
+++ b/graphql/tests/task/queries/reliesOn-task-status-not-success-nor-fail.graphql
@@ -5,6 +5,7 @@
       requiredStatus
       buildVariant
       name
+      uiLink
     }
   }
 }

--- a/graphql/tests/task/queries/reliesOn-unmet.graphql
+++ b/graphql/tests/task/queries/reliesOn-unmet.graphql
@@ -5,6 +5,7 @@
       requiredStatus
       buildVariant
       name
+      uiLink
     }
   }
 }

--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -46,7 +46,8 @@
                 "metStatus": "PENDING",
                 "requiredStatus": "MUST_FINISH",
                 "buildVariant": "ubuntu",
-                "name": "dep1"
+                "name": "dep1",
+                "uiLink": "/task/dep1"
               }
             ]
           }
@@ -63,7 +64,8 @@
                 "metStatus": "PENDING",
                 "requiredStatus": "MUST_SUCCEED",
                 "buildVariant": "ubuntu",
-                "name": "dep1"
+                "name": "dep1",
+                "uiLink": "/task/dep1"
               }
             ]
           }
@@ -80,7 +82,8 @@
                 "metStatus": "MET",
                 "requiredStatus": "MUST_FINISH",
                 "buildVariant": "windows",
-                "name": "dep2"
+                "name": "dep2",
+                "uiLink": "/task/dep2"
               }
             ]
           }
@@ -97,7 +100,8 @@
                 "metStatus": "MET",
                 "requiredStatus": "MUST_FAIL",
                 "buildVariant": "windows",
-                "name": "dep2"
+                "name": "dep2",
+                "uiLink": "/task/dep2"
               }
             ]
           }
@@ -114,7 +118,8 @@
                 "metStatus": "UNMET",
                 "requiredStatus": "MUST_SUCCEED",
                 "buildVariant": "windows",
-                "name": "dep5"
+                "name": "dep5",
+                "uiLink": "/task/dep5"
               }
             ]
           }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7393
This PR adds a uiLink for the Dependency type. This is so we can link to the relevant task page from the title of a Depends on entry. 
<img width="278" alt="Screen Shot 2020-03-25 at 2 35 55 PM" src="https://user-images.githubusercontent.com/10734386/78029137-19659900-732e-11ea-8152-3b3971a86484.png">
