### PR TITLE
EVG-7376 remove check for legacy manifest

### DIFF
--- a/model/manifest/db.go
+++ b/model/manifest/db.go
@@ -58,13 +58,6 @@ func ByBaseProjectAndRevision(project, revision string) db.Q {
 	})
 }
 
-func ByProjectAndRevision(project, revision string) db.Q {
-	return db.Query(bson.M{
-		ProjectNameKey:      project,
-		ManifestRevisionKey: revision,
-	})
-}
-
 func FindFromVersion(versionID, project, revision, requester string) (*Manifest, error) {
 	manifest, err := FindOne(ById(versionID))
 	if err != nil {
@@ -81,14 +74,7 @@ func FindFromVersion(versionID, project, revision, requester string) (*Manifest,
 		return nil, errors.Wrap(err, "error finding manifest")
 	}
 	if manifest == nil {
-		// check for a legacy manifest
-		manifest, err = FindOne(ByProjectAndRevision(project, revision))
-		if err != nil {
-			return nil, errors.Wrap(err, "error finding manifest")
-		}
-		if manifest == nil {
-			return nil, nil
-		}
+		return nil, nil
 	}
 
 	if evergreen.IsPatchRequester(requester) {

--- a/model/manifest/manifest_test.go
+++ b/model/manifest/manifest_test.go
@@ -60,21 +60,6 @@ func TestFindFromVersion(t *testing.T) {
 	assert.Equal(t, "m1", mfest.Id)
 }
 
-func TestByProjectAndRevision(t *testing.T) {
-	require.NoError(t, db.Clear(Collection))
-	mfest := &Manifest{
-		Id:          "m1",
-		ProjectName: "evergreen",
-		Revision:    "abcdef",
-	}
-	_, err := mfest.TryInsert()
-	require.NoError(t, err)
-
-	mfest, err = FindOne(ByProjectAndRevision("evergreen", "abcdef"))
-	assert.NoError(t, err)
-	assert.Equal(t, "m1", mfest.Id)
-}
-
 func TestByBaseProjectAndRevision(t *testing.T) {
 	require.NoError(t, db.Clear(Collection))
 	mfests := []Manifest{


### PR DESCRIPTION
With the migration complete, the check for legacy manifests (without the `is_base` field) is no longer necessary.