### PR TITLE
EVG-7423: create s3 command to download task directory

### DIFF
--- a/command/s3_pull.go
+++ b/command/s3_pull.go
@@ -1,0 +1,156 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/pail"
+	"github.com/mitchellh/mapstructure"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+type s3Base struct {
+	// BuildVariants contains all build variants this command should be run on.
+	BuildVariants []string `mapstructure:"build_variants"`
+	// ExcludeFilter contains a regexp describing files that should be
+	// excluded from the operation.
+	ExcludeFilter string `mapstructure:"exclude" plugin:"expand"`
+	MaxRetries    uint   `mapstructure:"max_retries"`
+
+	bucket pail.Bucket
+}
+
+func (c *s3Base) ParseParams(params map[string]interface{}) error {
+	if err := mapstructure.Decode(params, c); err != nil {
+		return errors.Wrapf(err, "error decoding S3 parameters")
+	}
+	return nil
+}
+
+func (c *s3Base) shouldRunOnBuildVariant(bv string) bool {
+	if len(c.BuildVariants) == 0 {
+		return true
+	}
+
+	return util.StringSliceContains(c.BuildVariants, bv)
+}
+
+func (c *s3Base) expandParams(conf *model.TaskConfig) error {
+	if err := util.ExpandValues(c, conf.Expansions); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (c *s3Base) createBucket(client *http.Client, conf *model.TaskConfig, parallelOpts pail.ParallelBucketOptions) error {
+	if c.bucket != nil {
+		return nil
+	}
+	if err := conf.S3Data.Validate(); err != nil {
+		return errors.Wrap(err, "invalid S3 task credentials")
+	}
+
+	opts := pail.S3Options{
+		Credentials: pail.CreateAWSCredentials(conf.S3Data.Key, conf.S3Data.Secret, ""),
+		Region:      endpoints.UsEast1RegionID,
+		Name:        conf.S3Data.Bucket,
+		MaxRetries:  int(c.MaxRetries),
+		Permissions: pail.S3PermissionsPrivate,
+	}
+	bucket, err := pail.NewS3MultiPartBucketWithHTTPClient(client, opts)
+	if err != nil {
+		return errors.Wrap(err, "could not create bucket")
+	}
+	bucket = pail.NewParallelSyncBucket(parallelOpts, bucket)
+	c.bucket = bucket
+
+	return nil
+}
+
+// s3Pull is a command to download the task directory from S3.
+type s3Pull struct {
+	s3Base
+	WorkingDir   string `mapstructure:"working_directory" plugin:"expand"`
+	DeleteOnSync bool   `mapstructure:"delete_on_sync"`
+
+	bucket pail.Bucket
+	base
+}
+
+func s3PullFactory() Command { return &s3Pull{} }
+
+func (*s3Pull) Name() string {
+	return "s3.pull"
+}
+
+func (c *s3Pull) ParseParams(params map[string]interface{}) error {
+	if err := c.s3Base.ParseParams(params); err != nil {
+		return errors.Wrapf(err, "error decoding %s params", c.Name())
+	}
+	if err := mapstructure.Decode(params, c); err != nil {
+		return errors.Wrapf(err, "error decoding %s params", c.Name())
+	}
+	if c.WorkingDir == "" {
+		return errors.New("working directory cannot be empty")
+	}
+	return nil
+}
+
+func (c *s3Pull) expandParams(conf *model.TaskConfig) error {
+	catcher := grip.NewBasicCatcher()
+	catcher.Add(c.s3Base.expandParams(conf))
+	catcher.Add(util.ExpandValues(c, conf.Expansions))
+	return catcher.Resolve()
+}
+
+func (c *s3Pull) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *model.TaskConfig) error {
+	if err := c.expandParams(conf); err != nil {
+		return errors.Wrap(err, "error applying expansions to parameters")
+	}
+
+	if !c.shouldRunOnBuildVariant(conf.BuildVariant.Name) {
+		logger.Task().Infof("Skipping s3.pull for build variant '%s'", conf.BuildVariant.Name)
+		return nil
+	}
+
+	httpClient := util.GetHTTPClient()
+	defer util.PutHTTPClient(httpClient)
+
+	if err := c.createBucket(httpClient, conf, pail.ParallelBucketOptions{
+		Workers:      runtime.NumCPU(),
+		DeleteOnSync: c.DeleteOnSync,
+	}); err != nil {
+		return errors.Wrap(err, "could not set up S3 task bucket")
+	}
+	if err := c.bucket.Check(ctx); err != nil {
+		return errors.Wrap(err, "could not find S3 task bucket")
+	}
+
+	logger.Execution().WarningWhen(filepath.IsAbs(c.WorkingDir) && !strings.HasPrefix(c.WorkingDir, conf.WorkDir),
+		fmt.Sprintf("the working directory ('%s') is an absolute path, which isn't supported except when prefixed by '%s'",
+			c.WorkingDir, conf.WorkDir))
+
+	pullMsg := "Pulling task directory files from S3"
+	if c.ExcludeFilter != "" {
+		pullMsg += ", excluding files matching filter " + c.ExcludeFilter
+	}
+	logger.Task().Infof(pullMsg)
+	if err := c.bucket.Pull(ctx, pail.SyncOptions{
+		Local:   c.WorkingDir,
+		Remote:  conf.S3Path(),
+		Exclude: c.ExcludeFilter,
+	}); err != nil {
+		return errors.Wrap(err, "error pulling task data from S3")
+	}
+
+	return nil
+}

--- a/command/s3_pull_test.go
+++ b/command/s3_pull_test.go
@@ -1,0 +1,202 @@
+package command
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/apimodels"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/pail"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestS3PullParseParams(t *testing.T) {
+	for testName, testCase := range map[string]func(*testing.T, *s3Pull){
+		"SetsValues": func(t *testing.T, c *s3Pull) {
+			params := map[string]interface{}{
+				"exclude":           "exclude_pattern",
+				"build_variants":    []string{"some_build_variant"},
+				"max_retries":       uint(5),
+				"working_directory": "working_dir",
+			}
+			require.NoError(t, c.ParseParams(params))
+			assert.Equal(t, params["exclude"], c.ExcludeFilter)
+			assert.Equal(t, params["build_variants"], c.BuildVariants)
+			assert.Equal(t, params["max_retries"], c.MaxRetries)
+			assert.Equal(t, params["working_directory"], c.WorkingDir)
+		},
+		"RequiresWorkingDirectory": func(t *testing.T, c *s3Pull) {
+			assert.Error(t, c.ParseParams(map[string]interface{}{}))
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			c := &s3Pull{}
+			testCase(t, c)
+		})
+	}
+}
+
+func TestS3PullExecute(t *testing.T) {
+	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, c *s3Pull, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig, bucketDir string){
+		"PullsTaskDirectoryFromS3": func(ctx context.Context, t *testing.T, c *s3Pull, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig, bucketDir string) {
+			taskDir := filepath.Join(bucketDir, conf.S3Path())
+			require.NoError(t, os.MkdirAll(taskDir, 0777))
+			tmpFile, err := ioutil.TempFile(taskDir, "s3-pull-file")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpFile.Name()))
+			}()
+			fileContent := []byte("foobar")
+			_, err = tmpFile.Write(fileContent)
+			assert.NoError(t, tmpFile.Close())
+			require.NoError(t, err)
+
+			c.WorkingDir, err = ioutil.TempDir("", "s3-pull-output")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(c.WorkingDir))
+			}()
+
+			require.NoError(t, c.Execute(ctx, comm, logger, conf))
+			pulledContent, err := ioutil.ReadFile(filepath.Join(c.WorkingDir, filepath.Base(tmpFile.Name())))
+			require.NoError(t, err)
+			assert.Equal(t, pulledContent, fileContent)
+		},
+		"IgnoresFilesExcludedByFilter": func(ctx context.Context, t *testing.T, c *s3Pull, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig, bucketDir string) {
+			taskDir := filepath.Join(bucketDir, conf.S3Path())
+			require.NoError(t, os.MkdirAll(taskDir, 0777))
+			tmpFile, err := ioutil.TempFile(taskDir, "s3-pull-file")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpFile.Name()))
+			}()
+			_, err = tmpFile.Write([]byte("foobar"))
+			assert.NoError(t, tmpFile.Close())
+			require.NoError(t, err)
+
+			c.WorkingDir, err = ioutil.TempDir("", "s3-pull-output")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(c.WorkingDir))
+			}()
+
+			c.ExcludeFilter = ".*"
+			require.NoError(t, c.Execute(ctx, comm, logger, conf))
+
+			files, err := ioutil.ReadDir(c.WorkingDir)
+			require.NoError(t, err)
+			assert.Empty(t, files)
+		},
+		"NoopsIfIgnoringBuildVariant": func(ctx context.Context, t *testing.T, c *s3Pull, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig, bucketDir string) {
+			taskDir := filepath.Join(bucketDir, conf.S3Path())
+			require.NoError(t, os.MkdirAll(taskDir, 0777))
+			tmpFile, err := ioutil.TempFile(taskDir, "s3-pull-file")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpFile.Name()))
+			}()
+			fileContent := []byte("foobar")
+			_, err = tmpFile.Write(fileContent)
+			assert.NoError(t, tmpFile.Close())
+			require.NoError(t, err)
+
+			c.WorkingDir, err = ioutil.TempDir("", "s3-pull-output")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(c.WorkingDir))
+			}()
+
+			c.BuildVariants = []string{"other_build_variant"}
+			require.NoError(t, c.Execute(ctx, comm, logger, conf))
+
+			files, err := ioutil.ReadDir(c.WorkingDir)
+			require.NoError(t, err)
+			assert.Empty(t, files)
+		},
+		"ExpandsParameters": func(ctx context.Context, t *testing.T, c *s3Pull, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig, bucketDir string) {
+			tmpDir, err := ioutil.TempDir("", "s3-pull")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpDir))
+			}()
+
+			c.WorkingDir, err = ioutil.TempDir("", "s3-pull-output")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(c.WorkingDir))
+			}()
+
+			c.ExcludeFilter = "${exclude_filter}"
+			excludeFilterExpansion := "expanded_exclude_filter"
+			conf.Expansions = util.NewExpansions(map[string]string{
+				"exclude_filter": excludeFilterExpansion,
+			})
+			assert.NoError(t, c.Execute(ctx, comm, logger, conf))
+			assert.Equal(t, excludeFilterExpansion, c.ExcludeFilter)
+		},
+		"FailsWithoutS3Key": func(ctx context.Context, t *testing.T, c *s3Pull, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig, bucketDir string) {
+			c.bucket = nil
+			conf.S3Data.Key = ""
+			assert.Error(t, c.Execute(ctx, comm, logger, conf))
+		},
+		"FailsWithoutS3Secret": func(ctx context.Context, t *testing.T, c *s3Pull, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig, bucketDir string) {
+			c.bucket = nil
+			conf.S3Data.Secret = ""
+			assert.Error(t, c.Execute(ctx, comm, logger, conf))
+		},
+		"FailsWithoutS3BucketName": func(ctx context.Context, t *testing.T, c *s3Pull, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig, bucketDir string) {
+			c.bucket = nil
+			conf.S3Data.Bucket = ""
+			assert.Error(t, c.Execute(ctx, comm, logger, conf))
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			conf := &model.TaskConfig{
+				Task: &task.Task{
+					Id:           "id",
+					Secret:       "secret",
+					Version:      "version",
+					BuildVariant: "build_variant",
+					DisplayName:  "display_name",
+				},
+				BuildVariant: &model.BuildVariant{
+					Name: "build_variant",
+				},
+				ProjectRef: &model.ProjectRef{
+					Identifier: "project_identifier",
+				},
+				S3Data: apimodels.S3TaskSetupData{
+					Key:    "s3_key",
+					Secret: "s3_secret",
+					Bucket: "s3_bucket",
+				},
+			}
+			comm := client.NewMock("localhost")
+			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{
+				ID:     conf.Task.Id,
+				Secret: conf.Task.Secret,
+			}, nil)
+			require.NoError(t, err)
+			tmpDir, err := ioutil.TempDir("", "s3-pull-bucket")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tmpDir))
+			}()
+			c := &s3Pull{}
+			c.bucket, err = pail.NewLocalBucket(pail.LocalOptions{
+				Path: tmpDir,
+			})
+			require.NoError(t, err)
+			testCase(ctx, t, c, comm, logger, conf, tmpDir)
+		})
+	}
+}

--- a/command/s3_push.go
+++ b/command/s3_push.go
@@ -2,28 +2,18 @@ package command
 
 import (
 	"context"
-	"net/http"
 	"runtime"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/rest/client"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/pail"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
 // s3Push is a command to upload the task directory to s3.
 type s3Push struct {
-	// ExcludeFilter contains a regexp describing files that should be
-	// excluded from the operation.
-	ExcludeFilter string `mapstructure:"exclude_filter" plugin:"expand"`
-	// BuildVariants contains all build variants this command should be run on.
-	BuildVariants []string `mapstructure:"build_variants"`
-	MaxRetries    uint     `mapstructure:"max_retries"`
-
-	bucket pail.Bucket
+	s3Base
 	base
 }
 
@@ -33,16 +23,9 @@ func (*s3Push) Name() string {
 	return "s3.push"
 }
 
-const (
-	defaultS3MaxRetries uint = 10
-)
-
 func (c *s3Push) ParseParams(params map[string]interface{}) error {
-	if err := mapstructure.Decode(params, c); err != nil {
+	if err := c.s3Base.ParseParams(params); err != nil {
 		return errors.Wrapf(err, "error decoding %s params", c.Name())
-	}
-	if c.MaxRetries == 0 {
-		c.MaxRetries = defaultS3MaxRetries
 	}
 	return nil
 }
@@ -52,18 +35,20 @@ func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger c
 		return errors.Wrap(err, "error applying expansions to parameters")
 	}
 
-	httpClient := util.GetHTTPClient()
-	defer util.PutHTTPClient(httpClient)
-
 	if !c.shouldRunOnBuildVariant(conf.BuildVariant.Name) {
-		logger.Task().Infof("Skipping s3.push for task directory for build variant '%s'", conf.BuildVariant.Name)
+		logger.Task().Infof("Skipping s3.push for build variant '%s'", conf.BuildVariant.Name)
 		return nil
 	}
 
-	if err := c.createBucket(httpClient, conf); err != nil {
+	httpClient := util.GetHTTPClient()
+	defer util.PutHTTPClient(httpClient)
+
+	if err := c.createBucket(httpClient, conf, pail.ParallelBucketOptions{
+		Workers:      runtime.NumCPU(),
+		DeleteOnSync: true,
+	}); err != nil {
 		return errors.Wrap(err, "could not set up S3 task bucket")
 	}
-
 	if err := c.bucket.Check(ctx); err != nil {
 		return errors.Wrap(err, "could not find S3 task bucket")
 	}
@@ -72,11 +57,11 @@ func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger c
 	if err != nil {
 		return errors.Wrap(err, "could not get task working directory")
 	}
-	putMsg := "Pushing task directory files into S3"
+	pushMsg := "Pushing task directory files into S3"
 	if c.ExcludeFilter != "" {
-		putMsg += ", excluding files matching filter " + c.ExcludeFilter
+		pushMsg += ", excluding files matching filter " + c.ExcludeFilter
 	}
-	logger.Task().Infof(putMsg)
+	logger.Task().Infof(pushMsg)
 	if err := c.bucket.Push(ctx, pail.SyncOptions{
 		Local:   wd,
 		Remote:  conf.S3Path(),
@@ -84,49 +69,6 @@ func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger c
 	}); err != nil {
 		return errors.Wrap(err, "error pushing task data to S3")
 	}
-
-	return nil
-}
-
-func (c *s3Push) expandParams(conf *model.TaskConfig) error {
-	if err := util.ExpandValues(c, conf.Expansions); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-
-func (c *s3Push) shouldRunOnBuildVariant(bv string) bool {
-	if len(c.BuildVariants) == 0 {
-		return true
-	}
-	return util.StringSliceContains(c.BuildVariants, bv)
-}
-
-func (c *s3Push) createBucket(client *http.Client, conf *model.TaskConfig) error {
-	if c.bucket != nil {
-		return nil
-	}
-
-	if err := conf.S3Data.Validate(); err != nil {
-		return errors.Wrap(err, "invalid S3 task credentials")
-	}
-
-	opts := pail.S3Options{
-		Credentials: pail.CreateAWSCredentials(conf.S3Data.Key, conf.S3Data.Secret, ""),
-		Region:      endpoints.UsEast1RegionID,
-		Name:        conf.S3Data.Bucket,
-		MaxRetries:  int(c.MaxRetries),
-		Permissions: pail.S3PermissionsPrivate,
-	}
-	bucket, err := pail.NewS3MultiPartBucketWithHTTPClient(client, opts)
-	if err != nil {
-		return errors.Wrap(err, "could not create bucket")
-	}
-	bucket = pail.NewParallelSyncBucket(pail.ParallelBucketOptions{
-		Workers:      runtime.NumCPU(),
-		DeleteOnSync: true,
-	}, bucket)
-	c.bucket = bucket
 
 	return nil
 }

--- a/command/s3_push.go
+++ b/command/s3_push.go
@@ -64,7 +64,7 @@ func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger c
 	logger.Task().Infof(pushMsg)
 	if err := c.bucket.Push(ctx, pail.SyncOptions{
 		Local:   wd,
-		Remote:  conf.S3Path(),
+		Remote:  conf.S3Path(conf.Task.DisplayName),
 		Exclude: c.ExcludeFilter,
 	}); err != nil {
 		return errors.Wrap(err, "error pushing task data to S3")

--- a/command/s3_push_test.go
+++ b/command/s3_push_test.go
@@ -19,20 +19,19 @@ import (
 
 func TestS3PushParseParams(t *testing.T) {
 	for testName, testCase := range map[string]func(*testing.T, *s3Push){
-		"SetsDefaults": func(t *testing.T, c *s3Push) {
-			require.NoError(t, c.ParseParams(map[string]interface{}{}))
-			assert.Equal(t, (defaultS3MaxRetries), c.MaxRetries)
-		},
 		"SetsValues": func(t *testing.T, c *s3Push) {
 			params := map[string]interface{}{
-				"exclude_filter": "exclude_pattern",
+				"exclude":        "exclude_pattern",
 				"build_variants": []string{"some_build_variant"},
 				"max_retries":    uint(5),
 			}
 			require.NoError(t, c.ParseParams(params))
-			assert.Equal(t, params["exclude_filter"], c.ExcludeFilter)
+			assert.Equal(t, params["exclude"], c.ExcludeFilter)
 			assert.Equal(t, params["build_variants"], c.BuildVariants)
 			assert.Equal(t, params["max_retries"], c.MaxRetries)
+		},
+		"SucceedsWithNoParameters": func(t *testing.T, c *s3Push) {
+			assert.NoError(t, c.ParseParams(map[string]interface{}{}))
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {

--- a/command/s3_push_test.go
+++ b/command/s3_push_test.go
@@ -61,13 +61,13 @@ func TestS3PushExecute(t *testing.T) {
 			conf.WorkDir = tmpDir
 
 			require.NoError(t, c.Execute(ctx, comm, logger, conf))
-			iter, err := c.bucket.List(ctx, conf.S3Path())
+			iter, err := c.bucket.List(ctx, conf.S3Path(conf.Task.DisplayName))
 			require.NoError(t, err)
 			require.True(t, iter.Next(ctx))
 			item := iter.Item()
 			require.NotNil(t, item)
 			assert.Equal(t, filepath.Base(tmpFile.Name()), filepath.Base(item.Name()))
-			assert.Equal(t, conf.S3Path(), filepath.Dir(item.Name()))
+			assert.Equal(t, conf.S3Path(conf.Task.DisplayName), filepath.Dir(item.Name()))
 			r, err := item.Get(ctx)
 			require.NoError(t, err)
 			defer func() {
@@ -97,7 +97,7 @@ func TestS3PushExecute(t *testing.T) {
 
 			c.ExcludeFilter = ".*"
 			require.NoError(t, c.Execute(ctx, comm, logger, conf))
-			iter, err := c.bucket.List(ctx, conf.S3Path())
+			iter, err := c.bucket.List(ctx, conf.S3Path(conf.Task.DisplayName))
 			require.NoError(t, err)
 			assert.False(t, iter.Next(ctx))
 		},
@@ -119,7 +119,7 @@ func TestS3PushExecute(t *testing.T) {
 
 			c.BuildVariants = []string{"other_build_variant"}
 			require.NoError(t, c.Execute(ctx, comm, logger, conf))
-			iter, err := c.bucket.List(ctx, conf.S3Path())
+			iter, err := c.bucket.List(ctx, conf.S3Path(conf.Task.DisplayName))
 			require.NoError(t, err)
 			assert.False(t, iter.Next(ctx))
 		},

--- a/model/task_config.go
+++ b/model/task_config.go
@@ -118,8 +118,8 @@ func (c *TaskConfig) GetWorkingDirectory(dir string) (string, error) {
 }
 
 // S3Path returns the path to the working directory dump in S3 for a task.
-func (c *TaskConfig) S3Path() string {
-	return filepath.Join(c.ProjectRef.Identifier, c.Task.Version, c.Task.BuildVariant, c.Task.DisplayName, "latest")
+func (c *TaskConfig) S3Path(task string) string {
+	return filepath.Join(c.ProjectRef.Identifier, c.Task.Version, c.Task.BuildVariant, task, "latest")
 }
 
 func MakeConfigFromTask(t *task.Task) (*TaskConfig, error) {

--- a/model/task_config.go
+++ b/model/task_config.go
@@ -119,7 +119,7 @@ func (c *TaskConfig) GetWorkingDirectory(dir string) (string, error) {
 
 // S3Path returns the path to the working directory dump in S3 for a task.
 func (c *TaskConfig) S3Path(task string) string {
-	return filepath.Join(c.ProjectRef.Identifier, c.Task.Version, c.Task.BuildVariant, task, "latest")
+	return strings.Join([]string{c.ProjectRef.Identifier, c.Task.Version, c.Task.BuildVariant, task, "latest"}, "/")
 }
 
 func MakeConfigFromTask(t *task.Task) (*TaskConfig, error) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7423

This is the inverse operation of s3.push. Most of the changes are refactoring since the commands are nearly identical.