### PR TITLE
EVG-7633: Include fileCount in taskFiles query

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -253,6 +253,11 @@ type ComplexityRoot struct {
 		Timestamp func(childComplexity int) int
 	}
 
+	TaskFiles struct {
+		FileCount    func(childComplexity int) int
+		GroupedFiles func(childComplexity int) int
+	}
+
 	TaskLogLinks struct {
 		AgentLogLink  func(childComplexity int) int
 		AllLogLink    func(childComplexity int) int
@@ -316,7 +321,7 @@ type QueryResolver interface {
 	Projects(ctx context.Context) (*Projects, error)
 	PatchTasks(ctx context.Context, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) ([]*TaskResult, error)
 	TaskTests(ctx context.Context, taskID string, sortCategory *TestSortCategory, sortDirection *SortDirection, page *int, limit *int, testName *string, statuses []string) ([]*model.APITest, error)
-	TaskFiles(ctx context.Context, taskID string) ([]*GroupedFiles, error)
+	TaskFiles(ctx context.Context, taskID string) (*TaskFiles, error)
 	User(ctx context.Context) (*model.APIUser, error)
 	TaskLogs(ctx context.Context, taskID string) (*RecentTaskLogs, error)
 	PatchBuildVariants(ctx context.Context, patchID string) ([]*PatchBuildVariant, error)
@@ -1379,6 +1384,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TaskEventLogEntry.Timestamp(childComplexity), true
 
+	case "TaskFiles.fileCount":
+		if e.complexity.TaskFiles.FileCount == nil {
+			break
+		}
+
+		return e.complexity.TaskFiles.FileCount(childComplexity), true
+
+	case "TaskFiles.groupedFiles":
+		if e.complexity.TaskFiles.GroupedFiles == nil {
+			break
+		}
+
+		return e.complexity.TaskFiles.GroupedFiles(childComplexity), true
+
 	case "TaskLogLinks.agentLogLink":
 		if e.complexity.TaskLogLinks.AgentLogLink == nil {
 			break
@@ -1629,7 +1648,7 @@ var sources = []*ast.Source{
     testName: String = ""
     statuses: [String!]! = []
   ): [TestResult!]
-  taskFiles(taskId: String!): [GroupedFiles!]!
+  taskFiles(taskId: String!): TaskFiles!
   user: User!
   taskLogs(taskId: String!): RecentTaskLogs!
   patchBuildVariants(patchId: String!): [PatchBuildVariant!]!
@@ -1697,6 +1716,11 @@ type PatchBuildVariantTask {
   id: ID!
   name: String!
   status: String!
+}
+
+type TaskFiles {
+  fileCount: Int!
+  groupedFiles: [GroupedFiles!]!
 }
 
 type GroupedFiles {
@@ -4923,9 +4947,9 @@ func (ec *executionContext) _Query_taskFiles(ctx context.Context, field graphql.
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*GroupedFiles)
+	res := resTmp.(*TaskFiles)
 	fc.Result = res
-	return ec.marshalNGroupedFiles2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedFilesᚄ(ctx, field.Selections, res)
+	return ec.marshalNTaskFiles2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskFiles(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_user(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -6969,6 +6993,74 @@ func (ec *executionContext) _TaskEventLogEntry_data(ctx context.Context, field g
 	res := resTmp.(*model.TaskEventData)
 	fc.Result = res
 	return ec.marshalOTaskEventLogData2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐTaskEventData(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _TaskFiles_fileCount(ctx context.Context, field graphql.CollectedField, obj *TaskFiles) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "TaskFiles",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FileCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _TaskFiles_groupedFiles(ctx context.Context, field graphql.CollectedField, obj *TaskFiles) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "TaskFiles",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GroupedFiles, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*GroupedFiles)
+	fc.Result = res
+	return ec.marshalNGroupedFiles2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedFilesᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _TaskLogLinks_allLogLink(ctx context.Context, field graphql.CollectedField, obj *model.LogLinks) (ret graphql.Marshaler) {
@@ -10049,6 +10141,38 @@ func (ec *executionContext) _TaskEventLogEntry(ctx context.Context, sel ast.Sele
 	return out
 }
 
+var taskFilesImplementors = []string{"TaskFiles"}
+
+func (ec *executionContext) _TaskFiles(ctx context.Context, sel ast.SelectionSet, obj *TaskFiles) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, taskFilesImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TaskFiles")
+		case "fileCount":
+			out.Values[i] = ec._TaskFiles_fileCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "groupedFiles":
+			out.Values[i] = ec._TaskFiles_groupedFiles(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var taskLogLinksImplementors = []string{"TaskLogLinks"}
 
 func (ec *executionContext) _TaskLogLinks(ctx context.Context, sel ast.SelectionSet, obj *model.LogLinks) graphql.Marshaler {
@@ -11287,6 +11411,20 @@ func (ec *executionContext) marshalNTaskEventLogEntry2ᚖgithubᚗcomᚋevergree
 		return graphql.Null
 	}
 	return ec._TaskEventLogEntry(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTaskFiles2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskFiles(ctx context.Context, sel ast.SelectionSet, v TaskFiles) graphql.Marshaler {
+	return ec._TaskFiles(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTaskFiles2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskFiles(ctx context.Context, sel ast.SelectionSet, v *TaskFiles) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._TaskFiles(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNTaskLogLinks2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐLogLinks(ctx context.Context, sel ast.SelectionSet, v model.LogLinks) graphql.Marshaler {

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2270,33 +2270,36 @@
       "query_file": "task-files-query-display.graphql",
       "result": {
         "data": {
-          "taskFiles": [
-            {
-              "taskName": "exec 1 display!!",
-              "files": [
-                {
-                  "name": "awesome_test!!!",
-                  "link": "www.wikipedia.com",
-                  "visibility": "the whole world"
-                }
-              ]
-            },
-            {
-              "taskName": "exec 2 display!!",
-              "files": [
-                {
-                  "name": "THIS IS REALLY COOL",
-                  "link": "www.wikipedia.com",
-                  "visibility": "the whole world"
-                },
-                {
-                  "name": "really cool test file",
-                  "link": "www.wikipedia.com",
-                  "visibility": "the whole world"
-                }
-              ]
-            }
-          ]
+          "taskFiles": {
+            "fileCount": 3,
+            "groupedFiles": [
+              {
+                "taskName": "exec 1 display!!",
+                "files": [
+                  {
+                    "name": "awesome_test!!!",
+                    "link": "www.wikipedia.com",
+                    "visibility": "the whole world"
+                  }
+                ]
+              },
+              {
+                "taskName": "exec 2 display!!",
+                "files": [
+                  {
+                    "name": "THIS IS REALLY COOL",
+                    "link": "www.wikipedia.com",
+                    "visibility": "the whole world"
+                  },
+                  {
+                    "name": "really cool test file",
+                    "link": "www.wikipedia.com",
+                    "visibility": "the whole world"
+                  }
+                ]
+              }
+            ]
+          }
         }
       }
     },
@@ -2332,18 +2335,21 @@
       "query_file": "task-files-query-exec.graphql",
       "result": {
         "data": {
-          "taskFiles": [
-            {
-              "taskName": "exec 1 display!!",
-              "files": [
-                {
-                  "name": "awesome_test!!!",
-                  "link": "www.wikipedia.com",
-                  "visibility": "the whole world"
-                }
-              ]
-            }
-          ]
+          "taskFiles": {
+            "fileCount": 1,
+            "groupedFiles": [
+              {
+                "taskName": "exec 1 display!!",
+                "files": [
+                  {
+                    "name": "awesome_test!!!",
+                    "link": "www.wikipedia.com",
+                    "visibility": "the whole world"
+                  }
+                ]
+              }
+            ]
+          }
         }
       }
     },
@@ -2376,7 +2382,7 @@
     {
       "query_file": "task-files-query-empty.graphql",
       "result": {
-        "data": { "taskFiles": [] }
+        "data": { "taskFiles": { "fileCount": 0, "groupedFiles": [] } }
       }
     },
     {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -83,6 +83,11 @@ type RecentTaskLogs struct {
 	AgentLogs  []*apimodels.LogMessage   `json:"agentLogs"`
 }
 
+type TaskFiles struct {
+	FileCount    int             `json:"fileCount"`
+	GroupedFiles []*GroupedFiles `json:"groupedFiles"`
+}
+
 type TaskResult struct {
 	ID           string `json:"id"`
 	DisplayName  string `json:"displayName"`

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -490,44 +490,55 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, sortCatego
 	return testPointers, nil
 }
 
-func (r *queryResolver) TaskFiles(ctx context.Context, taskID string) ([]*GroupedFiles, error) {
-	groupedFilesList := []*GroupedFiles{}
+func (r *queryResolver) TaskFiles(ctx context.Context, taskID string) (*TaskFiles, error) {
+	emptyTaskFiles := TaskFiles{
+		FileCount:    0,
+		GroupedFiles: []*GroupedFiles{},
+	}
 	t, err := task.FindOneId(taskID)
 	if t == nil {
-		return groupedFilesList, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find task with id %s", taskID))
+		return &emptyTaskFiles, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find task with id %s", taskID))
 	}
 	if err != nil {
-		return groupedFilesList, ResourceNotFound.Send(ctx, err.Error())
+		return &emptyTaskFiles, ResourceNotFound.Send(ctx, err.Error())
 	}
 	if t.OldTaskId != "" {
 		t, err = task.FindOneId(t.OldTaskId)
 		if t == nil {
-			return groupedFilesList, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find old task with id %s", taskID))
+			return &emptyTaskFiles, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find old task with id %s", taskID))
 		}
 		if err != nil {
-			return groupedFilesList, ResourceNotFound.Send(ctx, err.Error())
+			return &emptyTaskFiles, ResourceNotFound.Send(ctx, err.Error())
 		}
 	}
+	groupedFilesList := []*GroupedFiles{}
+	fileCount := 0
 	if t.DisplayOnly {
 		execTasks, err := task.Find(task.ByIds(t.ExecutionTasks))
 		if err != nil {
-			return groupedFilesList, ResourceNotFound.Send(ctx, err.Error())
+			return &emptyTaskFiles, ResourceNotFound.Send(ctx, err.Error())
 		}
 		for _, execTask := range execTasks {
 			groupedFiles, err := GetGroupedFiles(ctx, execTask.DisplayName, execTask.Id, t.Execution)
 			if err != nil {
-				return groupedFilesList, err
+				return &emptyTaskFiles, err
 			}
+			fileCount += len(groupedFiles.Files)
 			groupedFilesList = append(groupedFilesList, groupedFiles)
 		}
 	} else {
 		groupedFiles, err := GetGroupedFiles(ctx, t.DisplayName, taskID, t.Execution)
 		if err != nil {
-			return groupedFilesList, err
+			return &emptyTaskFiles, err
 		}
+		fileCount += len(groupedFiles.Files)
 		groupedFilesList = append(groupedFilesList, groupedFiles)
 	}
-	return groupedFilesList, nil
+	taskFiles := TaskFiles{
+		FileCount:    fileCount,
+		GroupedFiles: groupedFilesList,
+	}
+	return &taskFiles, nil
 }
 
 func (r *queryResolver) TaskLogs(ctx context.Context, taskID string) (*RecentTaskLogs, error) {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -23,7 +23,7 @@ type Query {
     testName: String = ""
     statuses: [String!]! = []
   ): [TestResult!]
-  taskFiles(taskId: String!): [GroupedFiles!]!
+  taskFiles(taskId: String!): TaskFiles!
   user: User!
   taskLogs(taskId: String!): RecentTaskLogs!
   patchBuildVariants(patchId: String!): [PatchBuildVariant!]!
@@ -91,6 +91,11 @@ type PatchBuildVariantTask {
   id: ID!
   name: String!
   status: String!
+}
+
+type TaskFiles {
+  fileCount: Int!
+  groupedFiles: [GroupedFiles!]!
 }
 
 type GroupedFiles {

--- a/graphql/testdata/task-files-query-display.graphql
+++ b/graphql/testdata/task-files-query-display.graphql
@@ -1,10 +1,13 @@
 query {
   taskFiles(taskId: "wuzzup-activated") {
-    taskName
-    files {
-      name
-      link
-      visibility
+    fileCount
+    groupedFiles {
+      taskName
+      files {
+        name
+        link
+        visibility
+      }
     }
   }
 }

--- a/graphql/testdata/task-files-query-empty.graphql
+++ b/graphql/testdata/task-files-query-empty.graphql
@@ -1,10 +1,13 @@
 query {
   taskFiles(taskId: "task-without-legit-exec-tasks") {
-    taskName
-    files {
-      name
-      link
-      visibility
+    fileCount
+    groupedFiles {
+      taskName
+      files {
+        name
+        link
+        visibility
+      }
     }
   }
 }

--- a/graphql/testdata/task-files-query-err1.graphql
+++ b/graphql/testdata/task-files-query-err1.graphql
@@ -1,10 +1,13 @@
 query {
   taskFiles(taskId: "NOT-A-REAL-TASKID") {
-    taskName
-    files {
-      name
-      link
-      visibility
+    fileCount
+    groupedFiles {
+      taskName
+      files {
+        name
+        link
+        visibility
+      }
     }
   }
 }

--- a/graphql/testdata/task-files-query-err2.graphql
+++ b/graphql/testdata/task-files-query-err2.graphql
@@ -1,10 +1,13 @@
 query {
   taskFiles(taskId: "task-with-fake-old-id") {
-    taskName
-    files {
-      name
-      link
-      visibility
+    fileCount
+    groupedFiles {
+      taskName
+      files {
+        name
+        link
+        visibility
+      }
     }
   }
 }

--- a/graphql/testdata/task-files-query-exec.graphql
+++ b/graphql/testdata/task-files-query-exec.graphql
@@ -1,10 +1,13 @@
 query {
   taskFiles(taskId: "exec1") {
-    taskName
-    files {
-      name
-      link
-      visibility
+    fileCount
+    groupedFiles {
+      taskName
+      files {
+        name
+        link
+        visibility
+      }
     }
   }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7633
This PR makes some schema changes to include the file count when taskFiles are queried. GroupedFiles are now nested inside the TaskFiles type. 
Frontend changes were made to reflect the schema adjustments: https://github.com/evergreen-ci/spruce/pull/117