### PR TITLE
EVG-7167 add routes to get project with bson

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-03-31"
+	ClientVersion = "2020-04-02"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 	"time"
 
-	mgobson "gopkg.in/mgo.v2/bson"
-	"gopkg.in/yaml.v2"
-
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	mgobson "gopkg.in/mgo.v2/bson"
+	"gopkg.in/yaml.v2"
 )
 
 const LoadProjectError = "load project error(s)"
@@ -479,6 +479,14 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 		}
 	}
 	return p, pp, nil
+}
+
+func GetProjectFromBSON(data []byte) (*Project, error) {
+	pp := &ParserProject{}
+	if err := bson.Unmarshal(data, pp); err != nil {
+		return nil, errors.Wrap(err, "error unmarshalling bson into parser project")
+	}
+	return TranslateProject(pp)
 }
 
 // LoadProjectInto loads the raw data from the config file into project

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 	"gopkg.in/yaml.v2"
 )
 
@@ -1364,6 +1365,32 @@ func TestTryUpsert(t *testing.T) {
 			testCase(t)
 		})
 	}
+}
+
+func TestParserProjectRoundtrip(t *testing.T) {
+	filepath := filepath.Join(testutil.GetDirectoryOfFile(), "..", "self-tests.yml")
+	yml, err := ioutil.ReadFile(filepath)
+	assert.NoError(t, err)
+
+	original, err := createIntermediateProject(yml)
+	assert.NoError(t, err)
+
+	// to and from yaml
+	yamlBytes, err := yaml.Marshal(original)
+	assert.NoError(t, err)
+	pp := &ParserProject{}
+	assert.NoError(t, yaml.Unmarshal(yamlBytes, pp))
+
+	// to and from BSON
+	bsonBytes, err := bson.Marshal(original)
+	assert.NoError(t, err)
+	bsonPP := &ParserProject{}
+	assert.NoError(t, bson.Unmarshal(bsonBytes, bsonPP))
+
+	// ensure bson actually worked
+	newBytes, err := yaml.Marshal(bsonPP)
+	assert.NoError(t, err)
+	assert.True(t, bytes.Equal(yamlBytes, newBytes))
 }
 
 func TestParserProjectPersists(t *testing.T) {

--- a/operations/admin_all_configs.go
+++ b/operations/admin_all_configs.go
@@ -7,7 +7,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	yaml "gopkg.in/yaml.v2"
 )
 
 func fetchAllProjectConfigs() cli.Command {
@@ -79,12 +78,7 @@ func fetchAndWriteConfig(c *legacyClient, project string) error {
 		return errors.Wrapf(err, "failed to fetch config for project %s, version %s", project, versions[0])
 	}
 
-	data, err := yaml.Marshal(config)
-	if err != nil {
-		return errors.Wrapf(err, "failed to marshal configuration for project %s", project)
-	}
-
-	err = ioutil.WriteFile(project+".yml", data, 0666)
+	err = ioutil.WriteFile(project+".yml", config, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to write configuration for project %s", project)
 	}

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -153,12 +153,12 @@ func fetchSource(ctx context.Context, ac, rc *legacyClient, comm client.Communic
 	if task == nil {
 		return errors.New("task not found.")
 	}
-	config, err := rc.GetConfig(task.Version)
+	project, err := rc.GetProject(task.Version)
 	if err != nil {
 		return err
 	}
 
-	project, err := ac.GetProjectRef(task.Project)
+	pRef, err := ac.GetProjectRef(task.Project)
 	if err != nil {
 		return err
 	}
@@ -187,12 +187,12 @@ func fetchSource(ctx context.Context, ac, rc *legacyClient, comm client.Communic
 		}
 	}
 	cloneDir = filepath.Join(rootPath, cloneDir)
-	err = cloneSource(task, project, config, cloneDir, token, mfest)
+	err = cloneSource(task, pRef, project, cloneDir, token, mfest)
 	if err != nil {
 		return err
 	}
 	if patch != nil && !noPatch {
-		err = applyPatch(patch, cloneDir, config, config.FindBuildVariant(task.BuildVariant))
+		err = applyPatch(patch, cloneDir, project, project.FindBuildVariant(task.BuildVariant))
 		if err != nil {
 			return err
 		}

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -58,10 +58,12 @@ type Communicator interface {
 	EndTask(context.Context, *apimodels.TaskEndDetail, TaskData) (*apimodels.EndTaskResponse, error)
 	// GetTask returns the active task.
 	GetTask(context.Context, TaskData) (*task.Task, error)
-	// GetProjectRef loads the task's project.
+	// GetProjectRef loads the task's project ref.
 	GetProjectRef(context.Context, TaskData) (*model.ProjectRef, error)
 	// GetDistro returns the distro for the task.
 	GetDistro(context.Context, TaskData) (*distro.Distro, error)
+	// GetProject loads the project using the task's version ID
+	GetProject(context.Context, TaskData) (*model.Project, error)
 	// GetVersion loads the task's Version
 	GetVersion(context.Context, TaskData) (*model.Version, error)
 	// GetExpansions returns all expansions for the task known by the app server

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -195,6 +195,20 @@ func (c *Mock) GetVersion(ctx context.Context, td TaskData) (*serviceModel.Versi
 	}, nil
 }
 
+func (c *Mock) GetProject(ctx context.Context, td TaskData) (*serviceModel.Project, error) {
+	var err error
+	var data []byte
+	_, file, _, _ := runtime.Caller(0)
+
+	data, err = ioutil.ReadFile(filepath.Join(filepath.Dir(file), "testdata", fmt.Sprintf("%s.yaml", td.ID)))
+	if err != nil {
+		grip.Error(err)
+	}
+	proj := &serviceModel.Project{}
+	_, err = serviceModel.LoadProjectInto(data, "", proj)
+	return proj, err
+}
+
 func (c *Mock) GetExpansions(ctx context.Context, taskData TaskData) (util.Expansions, error) {
 	e := util.Expansions{
 		"foo": "bar",

--- a/service/api.go
+++ b/service/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
 	"gopkg.in/yaml.v2"
 )
 
@@ -209,6 +210,43 @@ func (as *APIServer) GetVersion(w http.ResponseWriter, r *http.Request) {
 		v.Config = string(config)
 	}
 	gimlet.WriteJSON(w, v)
+}
+
+func (as *APIServer) GetParserProject(w http.ResponseWriter, r *http.Request) {
+	t := MustHaveTask(r)
+	v, err := model.VersionFindOne(model.VersionById(t.Version))
+	if err != nil {
+		as.LoggedError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	if v == nil {
+		http.Error(w, "version not found", http.StatusNotFound)
+		return
+	}
+	pp, err := model.ParserProjectFindOneById(t.Version)
+	if err != nil {
+		as.LoggedError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	// handle legacy
+	if pp == nil || pp.ConfigUpdateNumber < v.ConfigUpdateNumber {
+		pp = &model.ParserProject{}
+		if err = yaml.Unmarshal([]byte(v.Config), pp); err != nil {
+			http.Error(w, "invalid version config", http.StatusNotFound)
+			return
+		}
+	}
+	if pp.Functions == nil {
+		pp.Functions = map[string]*model.YAMLCommandSet{}
+	}
+	projBytes, err := bson.Marshal(pp)
+	if err != nil {
+		as.LoggedError(w, r, http.StatusInternalServerError, err)
+		gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "problem marshalling to bson"})
+		return
+	}
+	gimlet.WriteBinary(w, projBytes)
 }
 
 func (as *APIServer) GetProjectRef(w http.ResponseWriter, r *http.Request) {
@@ -558,6 +596,7 @@ func (as *APIServer) GetServiceApp() *gimlet.APIApp {
 	app.Route().Version(2).Route("/task/{taskId}/files").Wrap(checkTask, checkHost).Handler(as.AttachFiles).Post()
 	app.Route().Version(2).Route("/task/{taskId}/distro").Wrap(checkTask).Handler(as.GetDistro).Get()
 	app.Route().Version(2).Route("/task/{taskId}/version").Wrap(checkTask).Handler(as.GetVersion).Get()
+	app.Route().Version(2).Route("/task/{taskId}/parser_project").Wrap(checkTask).Handler(as.GetParserProject).Get()
 	app.Route().Version(2).Route("/task/{taskId}/project_ref").Wrap(checkTask).Handler(as.GetProjectRef).Get()
 	app.Route().Version(2).Route("/task/{taskId}/expansions").Wrap(checkTask, checkHost).Handler(as.GetExpansions).Get()
 

--- a/service/rest.go
+++ b/service/rest.go
@@ -77,7 +77,7 @@ func GetRESTv1App(evgService restAPIService) *gimlet.APIApp {
 	app.AddRoute("/patches/{patch_id}").Version(1).Get().Handler(rest.getPatch).Wrap(middleware)
 	app.AddRoute("/patches/{patch_id}/config").Version(1).Get().Handler(rest.getPatchConfig).Wrap(middleware)
 	app.AddRoute("/projects").Version(1).Get().Handler(rest.getProjectIds).Wrap(middleware)
-	app.AddRoute("/projects/{project_id}").Version(1).Get().Handler(rest.getProject).Wrap(middleware)
+	app.AddRoute("/projects/{project_id}").Version(1).Get().Handler(rest.getProjectRef).Wrap(middleware)
 	app.AddRoute("/projects/{project_id}/last_green").Version(1).Get().Handler(rest.lastGreen).Wrap(middleware)
 	app.AddRoute("/projects/{project_id}/revisions/{revision}").Version(1).Get().Handler(rest.getVersionInfoViaRevision).Wrap(middleware)
 	app.AddRoute("/projects/{project_id}/versions").Version(1).Get().Handler(rest.getRecentVersions).Wrap(middleware)
@@ -89,6 +89,7 @@ func GetRESTv1App(evgService restAPIService) *gimlet.APIApp {
 	app.AddRoute("/versions/{version_id}").Version(1).Get().Handler(rest.getVersionInfo).Wrap(middleware)
 	app.AddRoute("/versions/{version_id}").Version(1).Patch().Handler(requireUser(rest.modifyVersionInfo, nil)).Wrap(middleware)
 	app.AddRoute("/versions/{version_id}/config").Version(1).Get().Handler(rest.getVersionConfig).Wrap(middleware)
+	app.AddRoute("/versions/{version_id}/parser_project").Version(1).Get().Handler(rest.getVersionProject).Wrap(middleware)
 	app.AddRoute("/versions/{version_id}/status").Version(1).Get().Handler(rest.getVersionStatus).Wrap(middleware)
 	app.AddRoute("/waterfall/{project_id}").Version(1).Get().Handler(rest.getWaterfallData).Wrap(middleware)
 

--- a/service/rest_project.go
+++ b/service/rest_project.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Returns a JSON response of an array with the ref information for the requested project_id.
-func (restapi restAPI) getProject(w http.ResponseWriter, r *http.Request) {
+func (restapi restAPI) getProjectRef(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveRESTContext(r)
 	ref := projCtx.ProjectRef
 	if ref == nil {


### PR DESCRIPTION
As elaborated in [EVG-7167](https://github.com/evergreen-ci/evergreen/pull/3383), this adds new functions and modifies the operations package but the agent still uses the legacy functions.