### PR TITLE
EVG-7426: make icecream settings optional and fix json tag

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -51,7 +51,7 @@ type Distro struct {
 	ValidProjects         []string                `bson:"valid_projects,omitempty" json:"valid_projects,omitempty" mapstructure:"valid_projects,omitempty"`
 	IsVirtualWorkstation  bool                    `bson:"is_virtual_workstation" json:"is_virtual_workstation" mapstructure:"is_virtual_workstation"`
 	HomeVolumeSettings    HomeVolumeSettings      `bson:"home_volume_settings" json:"home_volume_settings" mapstructure:"home_volume_settings"`
-	IcecreamSettings      IcecreamSettings        `bson:"icecream_settings" josn:"icecream_settings" yaml:"icecream_settings"`
+	IcecreamSettings      IcecreamSettings        `bson:"icecream_settings" json:"icecream_settings" yaml:"icecream_settings"`
 }
 
 // BootstrapSettings encapsulates all settings related to bootstrapping hosts.

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -5,7 +5,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/distro"
-	"github.com/k0kubun/pp"
 	"github.com/pkg/errors"
 )
 
@@ -412,7 +411,6 @@ type APIDistro struct {
 
 // BuildFromService converts from service level distro.Distro to an APIDistro
 func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
-	pp.Println("kim: BuildFromService()")
 	var d distro.Distro
 	switch v := h.(type) {
 	case distro.Distro:
@@ -508,7 +506,6 @@ func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
 
 // ToService returns a service layer distro using the data from APIDistro
 func (apiDistro *APIDistro) ToService() (interface{}, error) {
-	pp.Println("kim: ToService()")
 	d := distro.Distro{}
 	d.Id = FromStringPtr(apiDistro.Name)
 	d.Aliases = apiDistro.Aliases
@@ -614,7 +611,6 @@ func (apiDistro *APIDistro) ToService() (interface{}, error) {
 	if !ok {
 		return nil, errors.Errorf("Unexpected type %T for distro.IcecreamSettings", i)
 	}
-	pp.Println("icecream settings:", icecreamSettings)
 	d.IcecreamSettings = icecreamSettings
 	d.IsVirtualWorkstation = apiDistro.IsVirtualWorkstation
 

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -5,6 +5,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/k0kubun/pp"
 	"github.com/pkg/errors"
 )
 
@@ -411,6 +412,7 @@ type APIDistro struct {
 
 // BuildFromService converts from service level distro.Distro to an APIDistro
 func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
+	pp.Println("kim: BuildFromService()")
 	var d distro.Distro
 	switch v := h.(type) {
 	case distro.Distro:
@@ -506,6 +508,7 @@ func (apiDistro *APIDistro) BuildFromService(h interface{}) error {
 
 // ToService returns a service layer distro using the data from APIDistro
 func (apiDistro *APIDistro) ToService() (interface{}, error) {
+	pp.Println("kim: ToService()")
 	d := distro.Distro{}
 	d.Id = FromStringPtr(apiDistro.Name)
 	d.Aliases = apiDistro.Aliases
@@ -602,6 +605,7 @@ func (apiDistro *APIDistro) ToService() (interface{}, error) {
 		return nil, errors.Errorf("Unexpected type %T for distro.HomeVolumeSettings", i)
 	}
 	d.HomeVolumeSettings = homeVolumeSettings
+
 	i, err = apiDistro.IcecreamSettings.ToService()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error converting from model.APIIcecreamSettings to distro.IcecreamSettings")
@@ -610,6 +614,7 @@ func (apiDistro *APIDistro) ToService() (interface{}, error) {
 	if !ok {
 		return nil, errors.Errorf("Unexpected type %T for distro.IcecreamSettings", i)
 	}
+	pp.Println("icecream settings:", icecreamSettings)
 	d.IcecreamSettings = icecreamSettings
 	d.IsVirtualWorkstation = apiDistro.IsVirtualWorkstation
 

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -873,19 +873,13 @@ Evergreen - Distros
           </div>
           <div ng-show="activeDistro.is_virtual_workstation">
             <label class="distro-label">Icecream Scheduler Host:</label>
-            <input ng-required="activeDistro.is_virtual_workstation" ng-readonly="readOnly" name="icecreamSchedulerHost" type="text"
+            <input ng-readonly="readOnly" name="icecreamSchedulerHost" type="text"
               class="form-control" ng-model="activeDistro.icecream_settings.scheduler_host"
               placeholder="Host name to connect to the icecream scheduler">
-            <div class="icon fa fa-warning distro-error"
-              ng-show="form.icecreamSchedulerHost.$dirty && form.icecreamSchedulerHost.$error.required || form.icecreamSchedulerHost.$invalid"> Icecream scheduler host is required
-            </div><br>
             <label class="distro-label">Icecream Config File Path:</label>
-            <input ng-required="activeDistro.is_virtual_workstation" ng-readonly="readOnly" name="icecreamConfigPath" type="text"
+            <input ng-readonly="readOnly" name="icecreamConfigPath" type="text"
               class="form-control" ng-model="activeDistro.icecream_settings.config_path"
               placeholder="Path to the icecream config file">
-            <div class="icon fa fa-warning distro-error"
-              ng-show="form.icecreamConfigPath.$dirty && form.icecreamConfigPath.$error.required || form.icecreamConfigPath.$invalid"> Icecream config path is required
-            </div><br>
           </div>
           <p class="distro-checkbox checkbox">
             <input ng-disabled="readOnly" type="checkbox" ng-model="activeDistro.use_legacy_agent">


### PR DESCRIPTION
The icecream settings aren't required since the host already has the icecream config built into the AMI.