### PR TITLE
EVG-7724: fix permissions on evergreen yaml for spawn host

### DIFF
--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1080,10 +1080,11 @@ func TestSpawnHostSetupCommands(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := "mkdir -m 777 -p /home/user/cli_bin" +
+		" && sudo chown -R user /home/user/.evergreen.yml" +
 		" && echo '{\"api_key\":\"key\",\"api_server_host\":\"www.example0.com/api\",\"ui_server_host\":\"www.example1.com\",\"user\":\"user\"}' > /home/user/.evergreen.yml" +
+		" && chmod +x /home/user/evergreen" +
 		" && cp /home/user/evergreen /home/user/cli_bin" +
-		" && (echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.profile || true; echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.bash_profile || true)" +
-		" && chmod +x /home/user/cli_bin/evergreen"
+		" && (echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.profile || true; echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.bash_profile || true)"
 	assert.Equal(t, expected, cmd)
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7724

Make the change to the .evergreen.yml location (#3316) compatible with non-userdata spawn hosts.