### PR TITLE
EVG-5313 reset all tasks in single host task groups

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1004,6 +1004,27 @@ func GetTaskGroup(taskGroup string, tc *TaskConfig) (*TaskGroup, error) {
 	return tg, nil
 }
 
+// getTasksInTaskGroup finds the TaskGroup for the given task, and returns all tasks in the group
+func GetTasksInTaskGroup(t *task.Task) ([]task.Task, error) {
+	proj, err := FindProjectFromVersionID(t.Version)
+	if err != nil {
+		return nil, errors.Wrapf(err, "problem finding project for task '%s'", t.Id)
+	}
+	tg := proj.FindTaskGroup(t.TaskGroup)
+	if tg == nil {
+		return nil, errors.Errorf("problem finding task group '%s'", t.TaskGroup)
+	}
+
+	tasks, err := task.Find(task.ByVersionsForNameAndVariant([]string{t.Version}, tg.Tasks, t.BuildVariant))
+	if err != nil {
+		return nil, errors.Wrapf(err, "can't get tasks for task group '%s'", t.TaskGroup)
+	}
+	if len(tasks) == 0 {
+		return nil, errors.New("no tasks in task group")
+	}
+	return tasks, nil
+}
+
 func FindProjectFromVersionID(versionStr string) (*Project, error) {
 	ver, err := VersionFindOne(VersionById(versionStr))
 	if err != nil {

--- a/model/project.go
+++ b/model/project.go
@@ -1004,27 +1004,6 @@ func GetTaskGroup(taskGroup string, tc *TaskConfig) (*TaskGroup, error) {
 	return tg, nil
 }
 
-// getTasksInTaskGroup finds the TaskGroup for the given task, and returns all tasks in the group
-func GetTasksInTaskGroup(t *task.Task) ([]task.Task, error) {
-	proj, err := FindProjectFromVersionID(t.Version)
-	if err != nil {
-		return nil, errors.Wrapf(err, "problem finding project for task '%s'", t.Id)
-	}
-	tg := proj.FindTaskGroup(t.TaskGroup)
-	if tg == nil {
-		return nil, errors.Errorf("problem finding task group '%s'", t.TaskGroup)
-	}
-
-	tasks, err := task.Find(task.ByVersionsForNameAndVariant([]string{t.Version}, tg.Tasks, t.BuildVariant))
-	if err != nil {
-		return nil, errors.Wrapf(err, "can't get tasks for task group '%s'", t.TaskGroup)
-	}
-	if len(tasks) == 0 {
-		return nil, errors.New("no tasks in task group")
-	}
-	return tasks, nil
-}
-
 func FindProjectFromVersionID(versionStr string) (*Project, error) {
 	ver, err := VersionFindOne(VersionById(versionStr))
 	if err != nil {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -222,16 +222,6 @@ func ByCommit(revision, buildVariant, displayName, project, requester string) db
 	})
 }
 
-// ByStatusAndActivation creates a query that returns tasks of a certain status and activation state.
-func ByStatusAndActivation(status string, active bool) db.Q {
-	return db.Query(bson.M{
-		ActivatedKey: active,
-		StatusKey:    status,
-		//Filter out blacklisted tasks
-		PriorityKey: bson.M{"$gte": 0},
-	})
-}
-
 func ByVersionsForNameAndVariant(versions, displayNames []string, buildVariant string) db.Q {
 	return db.Query(bson.M{
 		VersionKey: bson.M{
@@ -873,6 +863,20 @@ func FindAllTasksFromVersionWithDependencies(versionId string) ([]Task, error) {
 func FindTasksFromVersions(versionIds []string) ([]Task, error) {
 	return Find(ByVersions(versionIds).
 		WithFields(IdKey, DisplayNameKey, StatusKey, TimeTakenKey, VersionKey, BuildVariantKey))
+}
+
+func FindTaskGroupFromBuild(buildId, taskGroup string) ([]Task, error) {
+	tasks, err := Find(db.Query(bson.M{
+		BuildIdKey:   buildId,
+		TaskGroupKey: taskGroup,
+	}))
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting tasks in task group")
+	}
+	if len(tasks) == 0 {
+		return nil, errors.New("no tasks in task group")
+	}
+	return tasks, nil
 }
 
 func FindAllTaskIDsFromBuild(buildId string) ([]string, error) {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1365,10 +1365,11 @@ func (t *Task) GetTestResultsForDisplayTask() ([]TestResult, error) {
 	return tasks[0].LocalTestResults, nil
 }
 
-// SetResetWhenFinished requests that a display task reset itself when finished. Will mark itself as system failed
+// SetResetWhenFinished requests that a display task or single-host task group
+// reset itself when finished. Will mark itself as system failed.
 func (t *Task) SetResetWhenFinished() error {
-	if !t.DisplayOnly {
-		return errors.Errorf("%s is not a display task", t.Id)
+	if !t.DisplayOnly && !t.IsPartOfSingleHostTaskGroup() {
+		return errors.Errorf("%s is not a display task or in a task group", t.Id)
 	}
 	t.ResetWhenFinished = true
 	return UpdateOne(
@@ -1665,6 +1666,10 @@ func FindVariantsWithTask(taskName, project string, orderMin, orderMax int) ([]s
 		variants = append(variants, doc["_id"])
 	}
 	return variants, nil
+}
+
+func (t *Task) IsPartOfSingleHostTaskGroup() bool {
+	return t.TaskGroup != "" && t.TaskGroupMaxHosts == 1
 }
 
 func (t *Task) IsPartOfDisplay() bool {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1026,19 +1026,7 @@ func doRestartFailedTasks(tasks []task.Task, user string, results RestartResults
 	var tasksErrored []string
 
 	for _, t := range tasks {
-		p, err := FindProjectFromVersionID(t.Version)
-		if err != nil || p == nil {
-			tasksErrored = append(tasksErrored, t.Id)
-			grip.Error(message.Fields{
-				"task":    t.Id,
-				"status":  "failed",
-				"message": "error retrieving project",
-				"error":   err.Error(),
-			})
-			continue
-		}
-		err = TryResetTask(t.Id, user, evergreen.RESTV2Package, nil)
-		if err != nil {
+		if err := TryResetTask(t.Id, user, evergreen.RESTV2Package, nil); err != nil {
 			tasksErrored = append(tasksErrored, t.Id)
 			grip.Error(message.Fields{
 				"task":    t.Id,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -238,7 +238,7 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 
 	if t.IsPartOfSingleHostTaskGroup() {
 		var tasks []task.Task
-		tasks, err = GetTasksInTaskGroup(t)
+		tasks, err = task.FindTaskGroupFromBuild(t.BuildId, t.TaskGroup)
 		if err != nil {
 			return errors.Wrapf(err, "couldn't get tasks in group '%s'", t.TaskGroup)
 		}
@@ -1199,7 +1199,7 @@ func checkResetSingleHostTaskGroup(t *task.Task) error {
 	if !t.IsPartOfSingleHostTaskGroup() {
 		return nil
 	}
-	tasks, err := GetTasksInTaskGroup(t)
+	tasks, err := task.FindTaskGroupFromBuild(t.BuildId, t.TaskGroup)
 	if err != nil {
 		return errors.Wrapf(err, "can't get task group for task '%s'", t.Id)
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -237,7 +237,8 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 	}
 
 	if t.IsPartOfSingleHostTaskGroup() {
-		tasks, err := GetTasksInTaskGroup(t)
+		var tasks []task.Task
+		tasks, err = GetTasksInTaskGroup(t)
 		if err != nil {
 			return errors.Wrapf(err, "couldn't get tasks in group '%s'", t.TaskGroup)
 		}

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -205,7 +205,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	// For a single-host task group, if a task fails, block and dequeue later tasks in that group.
 	// Call before MarkEnd so the version is marked finished when this is the last task in the version
 	// to finish
-	if t.TaskGroup != "" && t.TaskGroupMaxHosts == 1 && details.Status != evergreen.TaskSucceeded {
+	if t.IsPartOfSingleHostTaskGroup() && details.Status != evergreen.TaskSucceeded {
 		// BlockTaskGroups is a recursive operation, which
 		// includes updating a large number of task
 		// documents.

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -165,7 +165,7 @@ func cleanUpTimedOutTask(ctx context.Context, env evergreen.Environment, id stri
 	}
 
 	// For a single-host task group, if a task fails, block and dequeue later tasks in that group.
-	if t.TaskGroup != "" && t.TaskGroupMaxHosts == 1 && t.Status != evergreen.TaskSucceeded {
+	if t.IsPartOfSingleHostTaskGroup() && t.Status != evergreen.TaskSucceeded {
 		if err = model.BlockTaskGroupTasks(t.Id); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "problem blocking task group tasks",
@@ -209,7 +209,12 @@ func cleanUpTimedOutTask(ctx context.Context, env evergreen.Environment, id stri
 		if err = t.DisplayTask.SetResetWhenFinished(); err != nil {
 			return errors.Wrap(err, "can't mark display task for reset")
 		}
-		return errors.Wrap(model.MarkEnd(t, "monitor", time.Now(), detail, false, &model.StatusChanges{}), "error marking task ended")
+		return errors.Wrap(model.MarkEnd(t, "monitor", time.Now(), detail, false, &model.StatusChanges{}), "error marking execution task ended")
+	} else if t.IsPartOfSingleHostTaskGroup() {
+		if err = t.SetResetWhenFinished(); err != nil {
+			return errors.Wrap(err, "can't mark display task for reset")
+		}
+		return errors.Wrap(model.MarkEnd(t, "monitor", time.Now(), detail, false, &model.StatusChanges{}), "error marking task in task group ended")
 	}
 	return errors.Wrapf(model.TryResetTask(t.Id, "", "monitor", detail), "error trying to reset task %s", t.Id)
 }

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
@@ -16,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
@@ -203,4 +205,93 @@ func TestCleanupTask(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestCleanupTimedOutTaskWithTaskGroup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := testutil.NewEnvironment(ctx, t)
+	require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, host.Collection, model.VersionCollection))
+
+	t1 := &task.Task{
+		Id:                "t1",
+		DisplayName:       "display_t1",
+		Status:            evergreen.TaskStarted,
+		HostId:            "h1",
+		BuildId:           "b1",
+		Version:           "v1",
+		TaskGroup:         "my_task_group",
+		TaskGroupMaxHosts: 1,
+		Project:           "proj",
+		Restarts:          1,
+	}
+	t2 := &task.Task{
+		Id:                "t2",
+		DisplayName:       "display_t2",
+		Status:            evergreen.TaskSucceeded,
+		HostId:            "h2",
+		BuildId:           "b1",
+		Version:           "v1",
+		TaskGroup:         "my_task_group",
+		TaskGroupMaxHosts: 1,
+		Project:           "proj",
+		Restarts:          1,
+	}
+	t3 := &task.Task{
+		Id:                "t3",
+		DisplayName:       "display_t3",
+		Status:            evergreen.TaskUndispatched,
+		BuildId:           "b1",
+		Version:           "v1",
+		TaskGroup:         "my_task_group",
+		TaskGroupMaxHosts: 1,
+		Project:           "proj",
+		Restarts:          1,
+	}
+	b := &build.Build{
+		Id:      "b1",
+		Tasks:   []build.TaskCache{{Id: "t1"}, {Id: "t2"}, {Id: "t3"}},
+		Version: "v1",
+	}
+	h := &host.Host{
+		Id:          "h1",
+		RunningTask: "t1",
+		Distro:      distro.Distro{Provider: evergreen.ProviderNameMock},
+		Status:      evergreen.HostRunning,
+	}
+	yml := `
+task_groups:
+- name: my_task_group
+  tasks: [display_t1, display_t2, display_t3]
+tasks:
+- name: display_t1
+- name: display_t2
+- name: display_t3
+`
+	v := &model.Version{
+		Id:     "v1",
+		Config: yml,
+	}
+	assert.NoError(t, t1.Insert())
+	assert.NoError(t, t2.Insert())
+	assert.NoError(t, t3.Insert())
+	assert.NoError(t, b.Insert())
+	assert.NoError(t, h.Insert())
+	assert.NoError(t, v.Insert())
+	cloud.GetMockProvider().Set(h.Id, cloud.MockInstance{
+		Status: cloud.StatusRunning,
+	})
+
+	assert.NoError(t, cleanUpTimedOutTask(ctx, env, t.Name(), t1))
+
+	// refresh the host, make sure its running task field has been reset
+	var err error
+	h, err = host.FindOneId("h1")
+	assert.NoError(t, err)
+	assert.Empty(t, h.RunningTask)
+
+	t2, err = task.FindOneId(t2.Id)
+	assert.NoError(t, err)
+	assert.NotNil(t, t2)
+	assert.NotEqual(t, evergreen.TaskSucceeded, t2.Status)
 }


### PR DESCRIPTION
As compared to the original iteration of this: https://github.com/evergreen-ci/evergreen/commit/7f1c714ea371d492f9bcd18e7d241b443549070a

Update: this now queries directly from tasks, avoiding the project step altogether. If BuildId is granular enough then we can go forward, otherwise we'll block on https://jira.mongodb.org/browse/MCI-3200.