### PR TITLE
EVG-7711 stop trying to attach volume for invalid params

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -606,7 +606,7 @@ func (c *awsClientImpl) AttachVolume(ctx context.Context, input *ec2.AttachVolum
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
 					grip.Error(message.WrapError(ec2err, msg))
-					if strings.Contains(ec2err.Message(), "not a valid EBS device name") {
+					if strings.Contains(ec2err.Message(), "InvalidParameterValue") {
 						return false, err
 					}
 				}


### PR DESCRIPTION
My only theory for how we got this far with an device name already in use is that we were using a stale host document.

This doesn't happen often though so probably just catching this error in AttachVolume is enough. InvalidParameterValue will cover anything that would error repeatedly and so shouldn't be repeated ("not a valid EBS device name" and also "already in use" are included).