### PR TITLE
EVG-7746 use created volume in retry attempts

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -87,6 +87,7 @@ var (
 	ContainerPoolSettingsKey     = bsonutil.MustHaveTag(Host{}, "ContainerPoolSettings")
 	InstanceTagsKey              = bsonutil.MustHaveTag(Host{}, "InstanceTags")
 	SSHKeyNamesKey               = bsonutil.MustHaveTag(Host{}, "SSHKeyNames")
+	HomeVolumeIDKey              = bsonutil.MustHaveTag(Host{}, "HomeVolumeID")
 	SpawnOptionsTaskIDKey        = bsonutil.MustHaveTag(SpawnOptions{}, "TaskID")
 	SpawnOptionsBuildIDKey       = bsonutil.MustHaveTag(SpawnOptions{}, "BuildID")
 	SpawnOptionsTimeoutKey       = bsonutil.MustHaveTag(SpawnOptions{}, "TimeoutTeardown")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2293,6 +2293,17 @@ func (h *Host) MarkShouldExpire(expireOnValue string) error {
 	)
 }
 
+func (h *Host) SetHomeVolumeID(volumeID string) error {
+	h.HomeVolumeID = volumeID
+	return UpdateOne(bson.M{
+		IdKey:           h.Id,
+		HomeVolumeIDKey: "",
+	},
+		bson.M{
+			"$set": bson.M{HomeVolumeIDKey: volumeID},
+		})
+}
+
 func (h *Host) HomeVolume() *VolumeAttachment {
 	for _, vol := range h.Volumes {
 		if vol.IsHome {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2301,7 +2301,8 @@ func (h *Host) SetHomeVolumeID(volumeID string) error {
 	},
 		bson.M{
 			"$set": bson.M{HomeVolumeIDKey: volumeID},
-		})
+		},
+	)
 }
 
 func (h *Host) HomeVolume() *VolumeAttachment {

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -767,6 +767,9 @@ func attachVolume(ctx context.Context, env evergreen.Environment, h *host.Host) 
 			if err != nil {
 				return errors.Wrapf(err, "can't create a new volume for host '%s'", h.Id)
 			}
+			if err = h.SetHomeVolumeID(volume.ID); err != nil {
+				return errors.Wrapf(err, "can't set home volume ID in host")
+			}
 		}
 
 		// attach to the host


### PR DESCRIPTION
Set HomeVolumeID so in future retries we continue to attach using the already created volume.