### PR TITLE
EVG-7603: remove scopes from host provisioning jobs

### DIFF
--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -72,7 +72,6 @@ func NewHostSetupJob(env evergreen.Environment, h host.Host, id string) amboy.Jo
 	j.HostID = h.Id
 	j.env = env
 	j.SetPriority(1)
-	j.SetScopes([]string{fmt.Sprintf("%s.%s", setupHostJobName, j.HostID)})
 	j.SetID(fmt.Sprintf("%s.%s.%s", setupHostJobName, j.HostID, id))
 	return j
 }

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -57,7 +57,6 @@ func NewUserDataDoneJob(env evergreen.Environment, h host.Host, id string) amboy
 	j.HostID = h.Id
 	j.env = env
 	j.SetPriority(1)
-	j.SetScopes([]string{fmt.Sprintf("%s.%s", userDataDoneJobName, j.HostID)})
 	j.SetID(fmt.Sprintf("%s.%s.%s", userDataDoneJobName, j.HostID, id))
 
 	return j


### PR DESCRIPTION
The original purpose of the scopes was to prevent multiple home volumes from being created. They were causing a job backup and some app servers weren't running jobs due to provisioning jobs having a higher priority than other jobs like the stats jobs.

We'll probably have to rethink how home volumes are created/attached during provisioning to make sure they don't make duplicates.