### PR TITLE
EVG-7531: spawnHostLink field in Task GQL type

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -273,7 +273,6 @@ const (
 var (
 	// Providers where hosts can be created and terminated automatically.
 	ProviderSpawnable = []string{
-		ProviderNameDocker,
 		ProviderNameEc2OnDemand,
 		ProviderNameEc2Spot,
 		ProviderNameEc2Auto,

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -32,6 +32,8 @@ models:
         resolver: true
       baseTaskMetadata:
         resolver: true
+      spawnHostLink:
+        resolver: true
   TaskLogLinks:
     model: github.com/evergreen-ci/evergreen/rest/model.LogLinks
   TaskEndDetail:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -223,6 +223,7 @@ type ComplexityRoot struct {
 		Restarts          func(childComplexity int) int
 		Revision          func(childComplexity int) int
 		ScheduledTime     func(childComplexity int) int
+		SpawnHostLink     func(childComplexity int) int
 		StartTime         func(childComplexity int) int
 		Status            func(childComplexity int) int
 		TaskGroup         func(childComplexity int) int
@@ -329,6 +330,7 @@ type QueryResolver interface {
 	PatchBuildVariants(ctx context.Context, patchID string) ([]*PatchBuildVariant, error)
 }
 type TaskResolver interface {
+	SpawnHostLink(ctx context.Context, obj *model.APITask) (*string, error)
 	PatchMetadata(ctx context.Context, obj *model.APITask) (*PatchMetadata, error)
 
 	ReliesOn(ctx context.Context, obj *model.APITask) ([]*Dependency, error)
@@ -1253,6 +1255,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Task.ScheduledTime(childComplexity), true
 
+	case "Task.spawnHostLink":
+		if e.complexity.Task.SpawnHostLink == nil {
+			break
+		}
+
+		return e.complexity.Task.SpawnHostLink(childComplexity), true
+
 	case "Task.startTime":
 		if e.complexity.Task.StartTime == nil {
 			break
@@ -1846,6 +1855,7 @@ type BaseTaskMetadata {
 }
 
 type Task {
+  spawnHostLink: String
   patchMetadata: PatchMetadata!
   id: String!
   createTime: Time
@@ -5312,6 +5322,37 @@ func (ec *executionContext) _RecentTaskLogs_agentLogs(ctx context.Context, field
 	res := resTmp.([]*apimodels.LogMessage)
 	fc.Result = res
 	return ec.marshalNLogMessage2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋapimodelsᚐLogMessageᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Task_spawnHostLink(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Task",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Task().SpawnHostLink(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Task_patchMetadata(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
@@ -9924,6 +9965,17 @@ func (ec *executionContext) _Task(ctx context.Context, sel ast.SelectionSet, obj
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Task")
+		case "spawnHostLink":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Task_spawnHostLink(ctx, field, obj)
+				return res
+			})
 		case "patchMetadata":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -212,6 +212,7 @@ type BaseTaskMetadata {
 }
 
 type Task {
+  spawnHostLink: String
   patchMetadata: PatchMetadata!
   id: String!
   createTime: Time

--- a/graphql/tests/task/data.json
+++ b/graphql/tests/task/data.json
@@ -329,7 +329,7 @@
       "_id": "host1",
       "distro": {
         "_id": "localhost1",
-        "provider": "not static and not docker",
+        "provider": "gce",
         "spawn_allowed": true
       }
     },
@@ -353,7 +353,7 @@
       "_id": "host4",
       "distro": {
         "_id": "localhost3",
-        "provider": "not static and not docker",
+        "provider": "gce",
         "spawn_allowed": false
       }
     }

--- a/graphql/tests/task/data.json
+++ b/graphql/tests/task/data.json
@@ -250,7 +250,8 @@
       "_id": "dep1",
       "version": "5e4ff3abe3c3317e352062e4",
       "display_name": "dep1",
-      "build_variant": "ubuntu"
+      "build_variant": "ubuntu",
+      "host_id": "host1"
     },
     {
       "_id": "dep2",
@@ -285,7 +286,8 @@
     {
       "_id": "task2",
       "version": "5e4ff3abe3c3317e352062e4",
-      "depends_on": [{ "_id": "dep1", "status": "*", "unattainable": false }]
+      "depends_on": [{ "_id": "dep1", "status": "*", "unattainable": false }],
+      "host_id": "host2"
     },
     {
       "_id": "task3",
@@ -293,12 +295,14 @@
       "depends_on": [
         { "_id": "dep1", "status": "started", "unattainable": false }
       ],
-      "status": "failed"
+      "status": "failed",
+      "host_id": "host3"
     },
     {
       "_id": "task4",
       "version": "5e4ff3abe3c3317e352062e4",
-      "depends_on": [{ "_id": "dep2", "status": "*", "unattainable": false }]
+      "depends_on": [{ "_id": "dep2", "status": "*", "unattainable": false }],
+      "host_id": "host4"
     },
     {
       "_id": "task5",
@@ -318,6 +322,40 @@
       "_id": "task7",
       "version": "5e4ff3abe3c3317e352062e4",
       "depends_on": [{ "_id": "dep5", "status": "", "unattainable": false }]
+    }
+  ],
+  "hosts": [
+    {
+      "_id": "host1",
+      "distro": {
+        "_id": "localhost1",
+        "provider": "not static and not docker",
+        "spawn_allowed": true
+      }
+    },
+    {
+      "_id": "host2",
+      "distro": {
+        "_id": "localhost2",
+        "provider": "static",
+        "spawn_allowed": true
+      }
+    },
+    {
+      "_id": "host3",
+      "distro": {
+        "_id": "localhost3",
+        "provider": "docker",
+        "spawn_allowed": true
+      }
+    },
+    {
+      "_id": "host4",
+      "distro": {
+        "_id": "localhost3",
+        "provider": "not static and not docker",
+        "spawn_allowed": false
+      }
     }
   ]
 }

--- a/graphql/tests/task/queries/spawnHostLink-distro-provider-docker.graphql
+++ b/graphql/tests/task/queries/spawnHostLink-distro-provider-docker.graphql
@@ -1,0 +1,5 @@
+{
+  task(taskId: "task3") {
+    spawnHostLink
+  }
+}

--- a/graphql/tests/task/queries/spawnHostLink-distro-provider-static.graphql
+++ b/graphql/tests/task/queries/spawnHostLink-distro-provider-static.graphql
@@ -1,0 +1,5 @@
+{
+  task(taskId: "task2") {
+    spawnHostLink
+  }
+}

--- a/graphql/tests/task/queries/spawnHostLink-no-host.graphql
+++ b/graphql/tests/task/queries/spawnHostLink-no-host.graphql
@@ -1,0 +1,5 @@
+{
+  task(taskId: "task6") {
+    spawnHostLink
+  }
+}

--- a/graphql/tests/task/queries/spawnHostLink-spawn-not-allowed.graphql
+++ b/graphql/tests/task/queries/spawnHostLink-spawn-not-allowed.graphql
@@ -1,0 +1,5 @@
+{
+  task(taskId: "task4") {
+    spawnHostLink
+  }
+}

--- a/graphql/tests/task/queries/spawnHostLink.graphql
+++ b/graphql/tests/task/queries/spawnHostLink.graphql
@@ -1,0 +1,5 @@
+{
+  task(taskId: "dep1") {
+    spawnHostLink
+  }
+}

--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -174,6 +174,32 @@
           }
         }
       }
+    },
+    {
+      "query_file": "spawnHostLink.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "spawnHostLink": "http://localhost/spawn?distro_id=localhost1&task_id=dep1"
+          }
+        }
+      }
+    },
+    {
+      "query_file": "spawnHostLink-no-host.graphql",
+      "result": { "data": { "task": { "spawnHostLink": null } } }
+    },
+    {
+      "query_file": "spawnHostLink-distro-provider-docker.graphql",
+      "result": { "data": { "task": { "spawnHostLink": null } } }
+    },
+    {
+      "query_file": "spawnHostLink-distro-provider-static.graphql",
+      "result": { "data": { "task": { "spawnHostLink": null } } }
+    },
+    {
+      "query_file": "spawnHostLink-spawn-not-allowed.graphql",
+      "result": { "data": { "task": { "spawnHostLink": null } } }
     }
   ]
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7531
This field will be used to link to the Spawn host page from the task metadata panel in Spruce.