### PR TITLE
EVG-7640 fix trend data from cedar getting incorrectly filtered

### DIFF
--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -866,7 +866,7 @@ $http.get(templateUrl).success(function(template) {
 
     const cedar = ApiTaskdata.cedarAPI("/rest/v1/perf/task_name/" + task +
         "?variant=" + variant + "&project=" + project)
-      .then(resp => $filter("expandedHistoryConverter")(resp.data, scope.task.execution))
+      .then(resp => $filter("expandedHistoryConverter")(resp.data))
       .catch(err => $log.warn('error loading cedar data', err));
 
     return $q.all({

--- a/public/static/js/filters/filters.common.js
+++ b/public/static/js/filters/filters.common.js
@@ -499,17 +499,14 @@ filters.common.filter('conditional', function () {
     }
   })
   .filter('expandedHistoryConverter', function () {
-    return function (data, execution) {
+    return function (data) {
       if (!data) {
         return null;
-      }
-      if (!execution) {
-        execution = latestExecution(data);
       }
       let output = [];
 
       _.each(data, function (test) {
-        const converted = convertSingleTest(test, execution);
+        const converted = convertSingleTest(test);
         if (converted) {
           output.push(converted);
         }


### PR DESCRIPTION
Previously, we were attempting to match the execution number on previous iterations for a task when converting trend data, but that should not be done at all