### PR TITLE
EVG-7432: enable CORS for login and logout endpoints

### DIFF
--- a/service/ui.go
+++ b/service/ui.go
@@ -264,7 +264,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.NoVersions = true
 
 	// User login and logout
-	app.AddRoute("/login").Wrap(allowsCORS).Handler(uis.loginPage).Get()
+	app.AddRoute("/login").Handler(uis.loginPage).Get()
 	app.AddRoute("/login").Wrap(allowsCORS).Handler(uis.login).Post()
 	app.AddRoute("/login/key").Handler(uis.userGetKey).Post()
 	app.AddRoute("/logout").Wrap(allowsCORS).Handler(uis.logout).Get()

--- a/service/ui.go
+++ b/service/ui.go
@@ -264,10 +264,10 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.NoVersions = true
 
 	// User login and logout
-	app.AddRoute("/login").Handler(uis.loginPage).Get()
-	app.AddRoute("/login").Handler(uis.login).Post()
+	app.AddRoute("/login").Wrap(allowsCORS).Handler(uis.loginPage).Get()
+	app.AddRoute("/login").Wrap(allowsCORS).Handler(uis.login).Post()
 	app.AddRoute("/login/key").Handler(uis.userGetKey).Post()
-	app.AddRoute("/logout").Handler(uis.logout).Get()
+	app.AddRoute("/logout").Wrap(allowsCORS).Handler(uis.logout).Get()
 
 	app.AddRoute("/robots.txt").Get().Handler(func(rw http.ResponseWriter, r *http.Request) {
 		_, err := rw.Write([]byte(strings.Join([]string{


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7432

Spruce utilizes the login and logout endpoints for authentication. These changes are necessary for spruce to work in staging and prod environments. However these changes will be removed once @john-m-liu configures Spruce to use okta for authentication. 

RELATED TO PR https://github.com/evergreen-ci/spruce/pull/130