### PR TITLE
EVG-7676 start min hosts for disabled distros

### DIFF
--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -150,6 +150,18 @@ func ByNeedsPlanning(containerPools []evergreen.ContainerPool) db.Q {
 		}})
 }
 
+// ByNeedsPlanning returns a query that selects distros that don't run containers
+func ByNeedsHostsPlanning(containerPools []evergreen.ContainerPool) db.Q {
+	poolDistros := []string{}
+	for _, pool := range containerPools {
+		poolDistros = append(poolDistros, pool.Distro)
+	}
+	return db.Query(bson.M{
+		"_id": bson.M{
+			"$nin": poolDistros,
+		}})
+}
+
 // ByIds creates a query that finds all distros for the given ids and implicitly
 // returns them ordered by {"_id": 1}
 func ByIds(ids []string) db.Q {

--- a/scheduler/utilization_based_host_allocator.go
+++ b/scheduler/utilization_based_host_allocator.go
@@ -44,15 +44,19 @@ func UtilizationBasedHostAllocator(ctx context.Context, hostAllocatorData HostAl
 	// only want to meet minimum hosts
 	if distro.Disabled {
 		numNewHostsToRequest := minimumHostsThreshold - numExistingHosts
-		grip.InfoWhen(numNewHostsToRequest > 0, message.Fields{
-			"runner":                     RunnerName,
-			"message":                    "requesting new hosts for disabled distro",
-			"distro":                     distro.Id,
-			"minimum_hosts_for_distro":   minimumHostsThreshold,
-			"num_existing_hosts":         numExistingHosts,
-			"total_new_hosts_to_request": numNewHostsToRequest,
-		})
-		return numNewHostsToRequest, nil
+
+		if numNewHostsToRequest > 0 {
+			grip.Info(message.Fields{
+				"runner":                     RunnerName,
+				"message":                    "requesting new hosts for disabled distro",
+				"distro":                     distro.Id,
+				"minimum_hosts_for_distro":   minimumHostsThreshold,
+				"num_existing_hosts":         numExistingHosts,
+				"total_new_hosts_to_request": numNewHostsToRequest,
+			})
+			return numNewHostsToRequest, nil
+		}
+		return 0, nil
 	}
 
 	// split tasks/hosts by task group (including those with no group) and find # of hosts needed for each

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -958,6 +958,9 @@ Evergreen - Distros
               <input type="checkbox" ng-model="activeDistro.disabled">
               Disable scheduling this distro. Tasks already in the schedule will be dispatched.
             </p>
+            <span class="warning-text" ng-show="activeDistro.disabled && activeDistro.host_allocator_settings.minimum_hosts > 0"><i class="fa fa-warning"></i>
+This will still allow the minimum number of hosts to start.
+            </span>
           </div>
         </div>
       </div>

--- a/units/crons.go
+++ b/units/crons.go
@@ -493,7 +493,7 @@ func PopulateHostAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 		}
 
 		// find all active distros
-		distros, err := distro.Find(distro.ByNeedsPlanning(env.Settings().ContainerPools.Pools))
+		distros, err := distro.Find(distro.ByNeedsHostsPlanning(env.Settings().ContainerPools.Pools))
 		if err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
I very rarely touch the scheduler (yay for new things!) so let me know if I've gone about this all wrong.

I also considered an additional distro field so we would only do this for distros that are workstation clusters; however, in the DB it looks like we only even have one disabled distro so I'm not convinced it's necessary.