### PR TITLE
EVG-7813: add persist tags for Windows user data shell scripts

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -510,7 +510,11 @@ func (h *Host) CheckUserDataStartedCommand() (string, error) {
 		return "", errors.Wrap(err, "could not get path to user data done file")
 	}
 	if h.Distro.IsWindows() {
-		return fmt.Sprintf(" if (Test-Path -Path %s) { exit }\r\nNew-Item -Force -Path '%s' -ItemType File", h.Distro.AbsPathNotCygwinCompatible(path), h.Distro.AbsPathCygwinCompatible(path)), nil
+		return fmt.Sprintf(strings.Join([]string{
+			fmt.Sprintf("if (Test-Path -Path %s) { exit }", h.Distro.AbsPathNotCygwinCompatible(path)),
+			fmt.Sprintf("New-Item -Force -ItemType Directory -Path %s", filepath.Dir(h.Distro.AbsPathNotCygwinCompatible(path))),
+			fmt.Sprintf("New-Item -ItemType File -Path %s", h.Distro.AbsPathNotCygwinCompatible(path)),
+		}, "\r\n")), nil
 	}
 
 	return fmt.Sprintf("[ -a %s ] && exit || touch %s", path, path), nil

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -380,6 +380,9 @@ func (h *Host) JasperBinaryFilePath(config evergreen.HostJasperConfig) string {
 }
 
 // BootstrapScript creates the user data script to bootstrap the host.
+// If, for some reason, this script gets interrupted, there's no guarantee that
+// it will succeed if run again, since we cannot enforce idempotency on the
+// setup script.
 func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Credentials) (string, error) {
 	bashPrefix := []string{"set -o errexit", "set -o verbose"}
 
@@ -389,8 +392,13 @@ func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Cr
 	// permissions that allow it to be modified after user data is finished.
 	fixClientOwner := h.changeOwnerCommand(filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()))
 
-	var postFetchClient string
 	var err error
+	checkUserDataRan, err := h.CheckUserDataStartedCommand()
+	if err != nil {
+		return "", errors.Wrap(err, "error creating command to check if user data is already done")
+	}
+
+	var postFetchClient string
 	if h.StartedBy == evergreen.User {
 		// Start the host with an agent monitor to run tasks.
 		if postFetchClient, err = h.StartAgentMonitorRequest(settings); err != nil {
@@ -446,7 +454,9 @@ func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Cr
 			h.ForceReinstallJasperCommand(settings),
 		)
 
-		bashCmds := append(writeSetupScriptCmds, setupJasperCmds...)
+		var bashCmds []string
+		bashCmds = append(bashCmds, writeSetupScriptCmds...)
+		bashCmds = append(bashCmds, setupJasperCmds...)
 		bashCmds = append(bashCmds, fetchClient, fixClientOwner, h.SetupCommand(), postFetchClient, markDone)
 
 		for i := range bashCmds {
@@ -455,6 +465,7 @@ func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Cr
 
 		powershellCmds := append(append([]string{
 			"<powershell>",
+			checkUserDataRan,
 			setupUserCmds},
 			bashCmds...),
 			"</powershell>",
@@ -473,7 +484,7 @@ func (h *Host) BootstrapScript(settings *evergreen.Settings, creds *certdepot.Cr
 		return "", errors.Wrap(err, "could not get commands to write Jasper credentials file")
 	}
 
-	bashCmds := append(bashPrefix, setupScriptCmds)
+	bashCmds := append(bashPrefix, checkUserDataRan, setupScriptCmds)
 	bashCmds = append(bashCmds, writeCredentialsCmds, h.FetchJasperCommand(settings.HostJasper), h.ForceReinstallJasperCommand(settings))
 	bashCmds = append(bashCmds, fetchClient, fixClientOwner, postFetchClient, markDone)
 
@@ -488,6 +499,21 @@ func (h *Host) changeOwnerCommand(path string) string {
 		return cmd
 	}
 	return "sudo " + cmd
+}
+
+// CheckUserDataStartedCommand checks whether user data has already run on this
+// host. If it has, it exits. Otherwise, it creates the file marking it as
+// started.
+func (h *Host) CheckUserDataStartedCommand() (string, error) {
+	path, err := h.UserDataStartedFile()
+	if err != nil {
+		return "", errors.Wrap(err, "could not get path to user data done file")
+	}
+	if h.Distro.IsWindows() {
+		return fmt.Sprintf(" if (Test-Path -Path %s) { exit }\r\nNew-Item -Force -Path '%s' -ItemType File", h.Distro.AbsPathNotCygwinCompatible(path), h.Distro.AbsPathCygwinCompatible(path)), nil
+	}
+
+	return fmt.Sprintf("[ -a %s ] && exit || touch %s", path, path), nil
 }
 
 // SetupServiceUserCommands returns the commands to create a passwordless
@@ -1107,7 +1133,18 @@ func (h *Host) SpawnHostGetTaskDataCommand() []string {
 	}
 }
 
-const userDataDoneFileName = "user_data_done"
+const (
+	userDataStarteFileName = "user_data_started"
+	userDataDoneFileName   = "user_data_done"
+)
+
+func (h *Host) UserDataStartedFile() (string, error) {
+	if h.Distro.BootstrapSettings.JasperBinaryDir == "" {
+		return "", errors.New("distro jasper binary directory must be specified")
+	}
+
+	return filepath.Join(h.Distro.BootstrapSettings.JasperBinaryDir, userDataStarteFileName), nil
+}
 
 // UserDataDoneFile returns the path to the user data done marker file.
 func (h *Host) UserDataDoneFile() (string, error) {

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -509,15 +509,15 @@ func (h *Host) CheckUserDataStartedCommand() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "could not get path to user data done file")
 	}
+	makeFileCmd := fmt.Sprintf("mkdir -m 777 -p %s && touch %s", filepath.Dir(path), path)
 	if h.Distro.IsWindows() {
 		return fmt.Sprintf(strings.Join([]string{
 			fmt.Sprintf("if (Test-Path -Path %s) { exit }", h.Distro.AbsPathNotCygwinCompatible(path)),
-			fmt.Sprintf("New-Item -Force -ItemType Directory -Path %s", filepath.Dir(h.Distro.AbsPathNotCygwinCompatible(path))),
-			fmt.Sprintf("New-Item -ItemType File -Path %s", h.Distro.AbsPathNotCygwinCompatible(path)),
+			fmt.Sprintf("%s -l -c %s", h.Distro.ShellBinary(), util.PowerShellQuotedString(makeFileCmd)),
 		}, "\r\n")), nil
 	}
 
-	return fmt.Sprintf("[ -a %s ] && exit || touch %s", path, path), nil
+	return fmt.Sprintf("[ -a %s ] && exit || %s", path, makeFileCmd), nil
 }
 
 // SetupServiceUserCommands returns the commands to create a passwordless

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1098,9 +1098,10 @@ func TestCheckUserDataStartedCommand(t *testing.T) {
 	t.Run("WithWindowsHost", func(t *testing.T) {
 		for testName, testCase := range map[string]func(t *testing.T, h *Host){
 			"CreatesExpectedCommand": func(t *testing.T, h *Host) {
-				expectedCmd := "if (Test-Path -Path /jasper_binary_dir/user_data_started) { exit }" +
-					"\r\nNew-Item -Force -ItemType Directory -Path /jasper_binary_dir" +
-					"\r\nNew-Item -ItemType File -Path /jasper_binary_dir/user_data_started"
+				expectedCmd := "if (Test-Path -Path /root_dir/jasper_binary_dir/user_data_started) { exit }" +
+					"\r\n/root_dir/bin/bash -l -c @'" +
+					"\nmkdir -m 777 -p /jasper_binary_dir && touch /jasper_binary_dir/user_data_started" +
+					"\n'@"
 				cmd, err := h.CheckUserDataStartedCommand()
 				require.NoError(t, err)
 				assert.Equal(t, expectedCmd, cmd)
@@ -1118,6 +1119,8 @@ func TestCheckUserDataStartedCommand(t *testing.T) {
 						Arch: distro.ArchWindowsAmd64,
 						BootstrapSettings: distro.BootstrapSettings{
 							JasperBinaryDir: "/jasper_binary_dir",
+							RootDir:         "/root_dir",
+							ShellPath:       "/bin/bash",
 						},
 					},
 				}
@@ -1128,7 +1131,7 @@ func TestCheckUserDataStartedCommand(t *testing.T) {
 	t.Run("WithNonWindowsHost", func(t *testing.T) {
 		for testName, testCase := range map[string]func(t *testing.T, h *Host){
 			"CreatesExpectedCommand": func(t *testing.T, h *Host) {
-				expectedCmd := "[ -a /jasper_binary_dir/user_data_started ] && exit || touch /jasper_binary_dir/user_data_started"
+				expectedCmd := "[ -a /jasper_binary_dir/user_data_started ] && exit || mkdir -m 777 -p /jasper_binary_dir && touch /jasper_binary_dir/user_data_started"
 				cmd, err := h.CheckUserDataStartedCommand()
 				require.NoError(t, err)
 				assert.Equal(t, expectedCmd, cmd)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7813

This change only matters for Windows.

We've been relying on build to let us run user data after after a Windows host is created (because it restarts several times and runs the image has its own user data that runs before ours does). You can only run user data once on Windows unless you do one of these: 

1. You reset the "user data ran" flag (which has been done in buildhost-configuration up until now). It won't run if you run user data (which is done in the AMI to initialize disks) and upload more user data (which we rely on for host provisioning). As part of incremental builds, they're removing the user data reset.
2. You add the "persist" tag to your script, which means that the script will run every single time the host is restarted.

The implications of using persist is that we can no longer assume user data will run exactly once. Furthermore, if a user stops and starts a Windows spawn host, we have to ensure that it is not allowed to run the user data script again (mostly because the setup script has no guarantee that it's written in an idempotent way). I highly doubt the Windows host will restart after the user data script has run once, but nonetheless we have to handle it. It also means that any user data that is uploaded as part of a spawn host request will run on every single boot. I'm assuming that _nobody uses user data on Windows_.


## Changes
* Add persist tags for Windows hosts to ensure user data runs on each restart. Any user data script will run every single time the host restarts.
* Do not allow reruns of user data by writing a file that indicates user data ran once (i.e. `user_data_started`).
