### PR TITLE
EVG-7653 use a secondary sort for perf data with the same create time

### DIFF
--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -795,7 +795,13 @@ $http.get(templateUrl).success(function(template) {
     if (cedar && cedar.length) {
       scope.trendResults = scope.trendResults.concat(cedar);
     }
-    scope.trendResults = _.sortBy(scope.trendResults, (result) => Date.parse(result.create_time));
+    scope.trendResults = scope.trendResults.sort((a, b) => {
+      difference = Date.parse(a.create_time) - Date.parse(b.create_time);
+      if (difference !== 0) {
+        return difference;
+      }
+      return a.order - b.order;
+    })
     let rejects = scope.outliers ? scope.outliers.rejects : [];
 
     scope.allTrendSamples = new TrendSamples(scope.trendResults);


### PR DESCRIPTION
The problem is that for trend data with the same create_time, sorting by just that field can leave it in the wrong order, where "right" is the order in which the commits were pushed. This is really a band-aid to both fix this problem and not re-break sorting for patch builds, since the behavior for patches isn't really defined and the data is not readily available in the trend data.

Opened https://jira.mongodb.org/browse/EVG-7820 for the tech debt part