### PR TITLE
EVG-7797 cleanup StopInstance

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -967,7 +967,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 	}
 
 	prevStatus := h.Status
-	if err := h.SetStopping(user); err != nil {
+	if err = h.SetStopping(user); err != nil {
 		return errors.Wrap(err, "failed to mark instance as stopping in db")
 	}
 


### PR DESCRIPTION
I'm not sure if this is the extent to what you wanted.

We could alternatively have two jobs: a job that requests Stop and sets to stopping, and then a cron job that checks hosts in the Stopping status to see if they've stopped. Depends on how much trouble this is actually causing.