### PR TITLE
EVG-7681 Count provisioning host status task group task count

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -413,6 +413,12 @@ var (
 		HostStopped,
 	}
 
+	// CanRunTaskStatus is a list of all host statuses in which a host could be running a task.
+	CanRunTaskStatus = []string{
+		HostRunning,
+		HostProvisioning,
+	}
+
 	// DownHostStatus is a list of all host statuses that are considered down.
 	DownHostStatus = []string{
 		HostTerminated,

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -332,7 +332,7 @@ func ByUnprovisionedSince(threshold time.Time) db.Q {
 	})
 }
 
-// ByTaskSpec returns a query that finds all running hosts that are running a
+// NumHostsByTaskSpec returns a query that finds all running hosts that are running a
 // task with the given group, buildvariant, project, and version.
 func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, error) {
 	if group == "" || buildVariant == "" || project == "" || version == "" {

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -342,7 +342,7 @@ func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, erro
 	}
 	q := db.Query(
 		bson.M{
-			StatusKey: evergreen.HostRunning,
+			StatusKey: bson.M{"$in": evergreen.CanRunTaskStatus},
 			"$or": []bson.M{
 				{
 					RunningTaskKey:             bson.M{"$exists": "true"},


### PR DESCRIPTION
New host provisioning allows hosts to begin to run tasks before they are in the
running status. This means that new hosts might not be counted by the
NumHostsByTaskSpec query, which causes a race in task group task dispatching in
which multiple tasks in a single-host task group can run concurrently on several hosts.