### PR TITLE
EVG-7725: fix span closing tag in volume dropdown

### DIFF
--- a/public/static/partials/user_host_options.html
+++ b/public/static/partials/user_host_options.html
@@ -90,7 +90,7 @@
           <button class="btn btn-link btn-dropdown" data-toggle="dropdown">
             <span class="semi-muted">
              Volume:
-            < /span>
+            </span>
             <strong>
               [[getHomeVolumeDisplayName()]]
               <span class="fa fa-caret-down"></span>


### PR DESCRIPTION
The UI seems broken due to this tag so you can't actually select the desired volume.