### PR TITLE
EVG-7859 trigger patch notifications with PR patches

### DIFF
--- a/trigger/task.go
+++ b/trigger/task.go
@@ -220,6 +220,12 @@ func (t *taskTriggers) Selectors() []event.Selector {
 			Data: evergreen.RepotrackerVersionRequester,
 		})
 	}
+	if t.task.Requester == evergreen.GithubPRRequester {
+		selectors = append(selectors, event.Selector{
+			Type: event.SelectorRequester,
+			Data: evergreen.PatchVersionRequester,
+		})
+	}
 	if t.version != nil && t.version.AuthorID != "" {
 		selectors = append(selectors, event.Selector{
 			Type: event.SelectorOwner,


### PR DESCRIPTION
Sorry about all our previous other conversations; this change should allow us to make no database changes (yay!).

The change to task's selectors makes it so GithubPR tasks will also match for Subscriptions made for patches. This may extend to other subscriptions as well, but if as you say users see PR patches and regular patches to be in the same category, then I think this change is logical.