### PR TITLE
EVG-7683: Add createTime field to Patch gql type

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -133,6 +133,7 @@ type ComplexityRoot struct {
 		Alias             func(childComplexity int) int
 		Author            func(childComplexity int) int
 		BaseVersionID     func(childComplexity int) int
+		CreateTime        func(childComplexity int) int
 		Description       func(childComplexity int) int
 		Duration          func(childComplexity int) int
 		Githash           func(childComplexity int) int
@@ -787,6 +788,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Patch.BaseVersionID(childComplexity), true
+
+	case "Patch.createTime":
+		if e.complexity.Patch.CreateTime == nil {
+			break
+		}
+
+		return e.complexity.Patch.CreateTime(childComplexity), true
 
 	case "Patch.description":
 		if e.complexity.Patch.Description == nil {
@@ -2007,6 +2015,7 @@ type FileDiff {
 }
 
 type Patch {
+  createTime: Time
   id: ID!
   description: String!
   projectID: String!
@@ -4258,6 +4267,37 @@ func (ec *executionContext) _Mutation_saveSubscription(ctx context.Context, fiel
 	res := resTmp.(bool)
 	fc.Result = res
 	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Patch_createTime(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Patch",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreateTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Patch_id(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
@@ -10705,6 +10745,8 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Patch")
+		case "createTime":
+			out.Values[i] = ec._Patch_createTime(ctx, field, obj)
 		case "id":
 			out.Values[i] = ec._Patch_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -149,6 +149,7 @@ type FileDiff {
 }
 
 type Patch {
+  createTime: Time
   id: ID!
   description: String!
   projectID: String!

--- a/graphql/tests/patch/queries/createTime-does-not-exist.graphql
+++ b/graphql/tests/patch/queries/createTime-does-not-exist.graphql
@@ -1,0 +1,5 @@
+{
+  patch(id: "5e4ff3abe3c3317e352062e4") {
+    createTime
+  }
+}

--- a/graphql/tests/patch/queries/createTime-exists.graphql
+++ b/graphql/tests/patch/queries/createTime-exists.graphql
@@ -1,0 +1,5 @@
+{
+  patch(id: "5e94c8213e8e8651bee37561") {
+    createTime
+  }
+}

--- a/graphql/tests/patch/results.json
+++ b/graphql/tests/patch/results.json
@@ -89,6 +89,18 @@
           }
         }
       }
+    },
+    {
+      "query_file": "createTime-exists.graphql",
+      "result": {
+        "data": { "patch": { "createTime": "2020-04-13T16:12:39-04:00" } }
+      }
+    },
+    {
+      "query_file": "createTime-does-not-exist.graphql",
+      "result": {
+        "data": { "patch": { "createTime": null } }
+      }
     }
   ]
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7863
This field is meant to be displayed in the My Patches underneath the patch description
![Screen Shot 2020-04-21 at 2 36 22 PM](https://user-images.githubusercontent.com/10734386/79903243-b91fbf80-83e0-11ea-80bb-f8f127ec3a8b.png)
