### PR TITLE
EVG-7037 add restricted project vars for safe commands

### DIFF
--- a/command/s3_get.go
+++ b/command/s3_get.go
@@ -113,10 +113,10 @@ func (c *s3get) shouldRunForVariant(buildVariantName string) bool {
 	return utility.StringSliceContains(c.BuildVariants, buildVariantName)
 }
 
-// Apply the expansions from the relevant task config to all appropriate
-// fields of the s3get.
+// Apply the expansions from the relevant task config (including restricted expansions)
+// to all appropriate fields of the s3get.
 func (c *s3get) expandParams(conf *model.TaskConfig) error {
-	return util.ExpandValues(c, conf.Expansions)
+	return util.ExpandValues(c, conf.GetAllExpansions())
 }
 
 // Implementation of Execute.  Expands the parameters, and then fetches the

--- a/command/s3_get.go
+++ b/command/s3_get.go
@@ -116,7 +116,7 @@ func (c *s3get) shouldRunForVariant(buildVariantName string) bool {
 // Apply the expansions from the relevant task config (including restricted expansions)
 // to all appropriate fields of the s3get.
 func (c *s3get) expandParams(conf *model.TaskConfig) error {
-	return util.ExpandValues(c, conf.GetAllExpansions())
+	return util.ExpandValues(c, conf.GetExpansionsWithRestricted())
 }
 
 // Implementation of Execute.  Expands the parameters, and then fetches the

--- a/command/s3_get_test.go
+++ b/command/s3_get_test.go
@@ -129,7 +129,8 @@ func TestExpandS3GetParams(t *testing.T) {
 
 			cmd = &s3get{}
 			conf = &model.TaskConfig{
-				Expansions: util.NewExpansions(map[string]string{}),
+				Expansions:           util.NewExpansions(map[string]string{}),
+				RestrictedExpansions: util.NewExpansions(map[string]string{}),
 			}
 
 			Convey("all appropriate values should be expanded, if they"+
@@ -142,12 +143,15 @@ func TestExpandS3GetParams(t *testing.T) {
 
 				conf.Expansions.Update(
 					map[string]string{
-						"aws_key":     "key",
-						"aws_secret":  "secret",
-						"remote_file": "remote",
-						"bucket":      "bck",
+						"aws_key":    "key",
+						"aws_secret": "secret",
 					},
 				)
+				conf.RestrictedExpansions.Update(
+					map[string]string{
+						"remote_file": "remote",
+						"bucket":      "bck",
+					})
 
 				So(cmd.expandParams(conf), ShouldBeNil)
 				So(cmd.AwsKey, ShouldEqual, "key")

--- a/command/s3_put.go
+++ b/command/s3_put.go
@@ -168,11 +168,11 @@ func (s3pc *s3put) validate() error {
 	return catcher.Resolve()
 }
 
-// Apply the expansions from the relevant task config to all appropriate
-// fields of the s3put.
+// Apply the expansions from the relevant task config (including restricted expansion)
+// to all appropriate fields of the s3put.
 func (s3pc *s3put) expandParams(conf *model.TaskConfig) error {
 	var err error
-	if err = util.ExpandValues(s3pc, conf.Expansions); err != nil {
+	if err = util.ExpandValues(s3pc, conf.GetAllExpansions()); err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/command/s3_put.go
+++ b/command/s3_put.go
@@ -172,7 +172,7 @@ func (s3pc *s3put) validate() error {
 // to all appropriate fields of the s3put.
 func (s3pc *s3put) expandParams(conf *model.TaskConfig) error {
 	var err error
-	if err = util.ExpandValues(s3pc, conf.GetAllExpansions()); err != nil {
+	if err = util.ExpandValues(s3pc, conf.GetExpansionsWithRestricted()); err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -39,9 +39,10 @@ func getMockProjectSettings() ProjectSettingsEvent {
 		},
 		GitHubHooksEnabled: true,
 		Vars: ProjectVars{
-			Id:          projectId,
-			Vars:        map[string]string{},
-			PrivateVars: map[string]bool{},
+			Id:             projectId,
+			Vars:           map[string]string{},
+			PrivateVars:    map[string]bool{},
+			RestrictedVars: map[string]bool{},
 		},
 		Aliases: []ProjectAlias{ProjectAlias{
 			ID:        mgobson.ObjectIdHex("5bedc72ee4055d31f0340b1d"),

--- a/model/task_config.go
+++ b/model/task_config.go
@@ -16,17 +16,18 @@ import (
 )
 
 type TaskConfig struct {
-	Distro          *distro.Distro
-	ProjectRef      *ProjectRef
-	Project         *Project
-	Task            *task.Task
-	BuildVariant    *BuildVariant
-	Expansions      *util.Expansions
-	Redacted        map[string]bool
-	WorkDir         string
-	GithubPatchData patch.GithubPatch
-	Timeout         *Timeout
-	TaskSync        evergreen.S3Credentials
+	Distro               *distro.Distro
+	ProjectRef           *ProjectRef
+	Project              *Project
+	Task                 *task.Task
+	BuildVariant         *BuildVariant
+	Expansions           *util.Expansions
+	RestrictedExpansions *util.Expansions
+	Redacted             map[string]bool
+	WorkDir              string
+	GithubPatchData      patch.GithubPatch
+	Timeout              *Timeout
+	TaskSync             evergreen.S3Credentials
 
 	mu sync.RWMutex
 }
@@ -114,6 +115,15 @@ func (c *TaskConfig) GetWorkingDirectory(dir string) (string, error) {
 	return dir, nil
 }
 
+// GetAllExpansions should ONLY be used for operations that won't leak restricted expansions.
+// Otherwise, use taskConfig.Expansions directly.
+func (c *TaskConfig) GetAllExpansions() *util.Expansions {
+	allExpansions := util.Expansions{}
+	allExpansions.Update(c.Expansions.Map())
+	allExpansions.Update(c.RestrictedExpansions.Map())
+	return &allExpansions
+}
+
 func MakeConfigFromTask(t *task.Task) (*TaskConfig, error) {
 	if t == nil {
 		return nil, errors.New("no task to make a TaskConfig from")
@@ -177,7 +187,9 @@ func MakeConfigFromTask(t *task.Task) (*TaskConfig, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding project vars")
 	}
-	tc.Expansions.Update(projVars.Vars)
+
+	tc.Expansions.Update(projVars.GetUnrestrictedVars())
+	tc.RestrictedExpansions.Update(projVars.GetRestrictedVars())
 	tc.Redacted = projVars.PrivateVars
 	return tc, nil
 }

--- a/model/task_config.go
+++ b/model/task_config.go
@@ -115,9 +115,9 @@ func (c *TaskConfig) GetWorkingDirectory(dir string) (string, error) {
 	return dir, nil
 }
 
-// GetAllExpansions should ONLY be used for operations that won't leak restricted expansions.
+// GetExpansionsWithRestricted should ONLY be used for operations that won't leak restricted expansions.
 // Otherwise, use taskConfig.Expansions directly.
-func (c *TaskConfig) GetAllExpansions() *util.Expansions {
+func (c *TaskConfig) GetExpansionsWithRestricted() *util.Expansions {
 	allExpansions := *c.Expansions
 	if c.RestrictedExpansions != nil {
 		allExpansions.Update(c.RestrictedExpansions.Map())

--- a/model/task_config.go
+++ b/model/task_config.go
@@ -118,9 +118,10 @@ func (c *TaskConfig) GetWorkingDirectory(dir string) (string, error) {
 // GetAllExpansions should ONLY be used for operations that won't leak restricted expansions.
 // Otherwise, use taskConfig.Expansions directly.
 func (c *TaskConfig) GetAllExpansions() *util.Expansions {
-	allExpansions := util.Expansions{}
-	allExpansions.Update(c.Expansions.Map())
-	allExpansions.Update(c.RestrictedExpansions.Map())
+	allExpansions := *c.Expansions
+	if c.RestrictedExpansions != nil {
+		allExpansions.Update(c.RestrictedExpansions.Map())
+	}
 	return &allExpansions
 }
 

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -275,6 +275,7 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
               if (v) {
                   delete item.project_vars[k];
                   delete item.private_vars[k];
+                  delete item.restricted_vars[k];
               }
           }
           $http.post('/project/' + $scope.newProject.identifier, item).then(
@@ -321,6 +322,7 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
         }
         $scope.projectVars = data.ProjectVars.vars || {};
         $scope.privateVars = data.ProjectVars.private_vars || {};
+        $scope.restrictedVars = data.ProjectVars.restricted_vars || {};
         $scope.github_webhooks_enabled = data.github_webhooks_enabled;
         $scope.prTestingConflicts = data.pr_testing_conflicting_refs || [];
         $scope.prTestingEnabled = data.ProjectRef.pr_testing_enabled || false;
@@ -346,6 +348,7 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
           identifier: $scope.projectRef.identifier,
           project_vars: $scope.projectVars,
           private_vars: $scope.privateVars,
+          restricted_vars: $scope.restrictedVars,
           display_name: $scope.projectRef.display_name,
           default_logger: $scope.projectRef.default_logger,
           remote_path: $scope.projectRef.remote_path,
@@ -510,10 +513,14 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
       if ($scope.proj_var.is_private) {
         $scope.settingsFormData.private_vars[$scope.proj_var.name] = true;
       }
+      if ($scope.proj_var.is_restricted) {
+        $scope.settingsFormData.restricted_vars[$scope.proj_var.name] = true;
+      }
 
       $scope.proj_var.name = "";
       $scope.proj_var.value = "";
       $scope.proj_var.is_private = false;
+      $scope.proj_var.is_restricted = false;
     }
   };
 
@@ -567,6 +574,7 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
   $scope.removeProjectVar = function (name) {
     delete $scope.settingsFormData.project_vars[name];
     delete $scope.settingsFormData.private_vars[name];
+    delete $scope.settingsFormData.restricted_vars[name];
     $scope.isDirty = true;
   };
 

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -205,6 +205,7 @@ func (pc *DBProjectConnector) UpdateProjectVars(projectId string, varsModel *res
 	vars = vars.RedactPrivateVars()
 	varsModel.Vars = vars.Vars
 	varsModel.PrivateVars = vars.PrivateVars
+	varsModel.RestrictedVars = vars.RestrictedVars
 	varsModel.VarsToDelete = []string{}
 	return nil
 }
@@ -453,6 +454,7 @@ func (pc *MockProjectConnector) CopyProjectVars(oldProjectId, newProjectId strin
 		if v.Id == oldProjectId {
 			newVars.Vars = v.Vars
 			newVars.PrivateVars = v.PrivateVars
+			newVars.RestrictedVars = v.RestrictedVars
 			pc.CachedVars = append(pc.CachedVars, &newVars)
 			return nil
 		}

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -26,9 +26,10 @@ type APIProjectSettings struct {
 }
 
 type APIProjectVars struct {
-	Vars         map[string]string `json:"vars"`
-	PrivateVars  map[string]bool   `json:"private_vars"`
-	VarsToDelete []string          `json:"vars_to_delete,omitempty"`
+	Vars           map[string]string `json:"vars"`
+	PrivateVars    map[string]bool   `json:"private_vars"`
+	RestrictedVars map[string]bool   `json:"restricted_vars"`
+	VarsToDelete   []string          `json:"vars_to_delete,omitempty"`
 }
 
 type APIProjectAlias struct {
@@ -108,8 +109,9 @@ func (p *APIProjectVars) ToService() (interface{}, error) {
 		}
 	}
 	return &model.ProjectVars{
-		Vars:        p.Vars,
-		PrivateVars: privateVars,
+		Vars:           p.Vars,
+		RestrictedVars: p.RestrictedVars,
+		PrivateVars:    privateVars,
 	}, nil
 }
 
@@ -118,6 +120,7 @@ func (p *APIProjectVars) BuildFromService(h interface{}) error {
 	case *model.ProjectVars:
 		p.PrivateVars = v.PrivateVars
 		p.Vars = v.Vars
+		p.RestrictedVars = v.RestrictedVars
 	default:
 		return errors.New("Invalid type of the argument")
 	}

--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -155,6 +155,7 @@ func (p *copyVariablesHandler) Run(ctx context.Context) gimlet.Responder {
 		for key, isPrivate := range varsToCopy.PrivateVars {
 			if isPrivate {
 				delete(varsToCopy.Vars, key)
+				delete(varsToCopy.RestrictedVars, key)
 			}
 		}
 		varsToCopy.PrivateVars = map[string]bool{}

--- a/service/api.go
+++ b/service/api.go
@@ -301,7 +301,7 @@ func (as *APIServer) AttachResults(w http.ResponseWriter, r *http.Request) {
 	gimlet.WriteJSON(w, "test results successfully attached")
 }
 
-// FetchProjectVars is an API hook for returning the project variables
+// FetchProjectVars is an API hook for returning the unrestricted project variables
 // associated with a task's project.
 func (as *APIServer) FetchProjectVars(w http.ResponseWriter, r *http.Request) {
 	t := MustHaveTask(r)
@@ -315,7 +315,10 @@ func (as *APIServer) FetchProjectVars(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gimlet.WriteJSON(w, projectVars)
+	res := apimodels.ExpansionVars{}
+	res.Vars = projectVars.GetUnrestrictedVars()
+	res.PrivateVars = projectVars.PrivateVars
+	gimlet.WriteJSON(w, res)
 }
 
 // AttachFiles updates file mappings for a task or build

--- a/service/project.go
+++ b/service/project.go
@@ -211,6 +211,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		DeleteAliases       []string                       `json:"delete_aliases"`
 		DefaultLogger       string                         `json:"default_logger"`
 		PrivateVars         map[string]bool                `json:"private_vars"`
+		RestrictedVars      map[string]bool                `json:"restricted_vars"`
 		Enabled             bool                           `json:"enabled"`
 		Private             bool                           `json:"private"`
 		Restricted          bool                           `json:"restricted"`
@@ -555,7 +556,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	}
 	projectVars.Vars = responseRef.ProjVarsMap
 	projectVars.PrivateVars = responseRef.PrivateVars
-
+	projectVars.RestrictedVars = responseRef.RestrictedVars
 	_, err = projectVars.Upsert()
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -340,6 +340,14 @@ Evergreen Projects
                <input type="checkbox" name="set_private" ng-model="proj_var.is_private" ng-disabled="!validKeyValue(proj_var.name, proj_var.value)" /> <strong>Private Variable</strong>
              </label>
             </div>
+            <div>
+              <label class="control-label">
+                <input type="checkbox" name="set_restricted" ng-model="proj_var.is_restricted" ng-disabled="!validKeyValue(proj_var.name, proj_var.value)" /> <strong>Restricted Variable</strong>
+              </label>
+            </div>
+            <span class="warning-text" ng-show="proj_var.is_restricted"><i class="fa fa-warning"></i>
+              Restricted variables are only used with commands that won't leak the variables. Should also be set to private.
+            </span>
             <div class="col-lg-6">
               <button class="plus-button btn btn-primary " ng-disabled="!validKeyValue(proj_var.name, proj_var.value)" type="button" ng-click="addProjectVar()">
                 <i class="fa fa-plus"></i>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -346,7 +346,7 @@ Evergreen Projects
               </label>
             </div>
             <span class="warning-text" ng-show="proj_var.is_restricted"><i class="fa fa-warning"></i>
-              Restricted variables are only used with commands that won't leak the variables. Should also be set to private.
+              Restricted variables are only used with commands that won't leak the variables.
             </span>
             <div class="col-lg-6">
               <button class="plus-button btn btn-primary " ng-disabled="!validKeyValue(proj_var.name, proj_var.value)" type="button" ng-click="addProjectVar()">


### PR DESCRIPTION
For restricted variables, I don't want to duplicate the logic of private variables as well/allow for programmer error with ensuring restricted variables are also private variables -- I think it's okay to trust the user to make restricted variables private.