### PR TITLE
EVG-7865 add status to taskSelector

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -194,6 +194,7 @@ func (pd *parserDependency) UnmarshalYAML(unmarshal func(interface{}) error) err
 // in the context of dependencies and requirements fields. //TODO no export?
 type taskSelector struct {
 	Name    string           `yaml:"name,omitempty"`
+	Status  string           `yaml:"status,omitempty"`
 	Variant *variantSelector `yaml:"variant,omitempty" bson:"variant,omitempty"`
 }
 


### PR DESCRIPTION
The only thing to consider is that this may actually impact what tasks are selected, but since this is what it should've been doing this whole time it's probably fine.