### PR TITLE
EVG-7865 parserDependency only unmarshals taskSelector on error

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -188,7 +188,7 @@ func (pd *parserDependency) UnmarshalYAML(unmarshal func(interface{}) error) err
 			PatchOptional bool   `yaml:"patch_optional"`
 		}{}
 		// ignore error here: expected to fail considering the single-string selector
-		grip.Debug(unmarshal(&otherFields))
+		unmarshal(&otherFields)
 		pd.Status = otherFields.Status
 		pd.PatchOptional = otherFields.PatchOptional
 		return nil
@@ -224,7 +224,7 @@ func (vs *variantSelector) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	// first, attempt to unmarshal just a selector string
 	// ignore errors here, because there may be other fields that are valid with single-string selectors
 	var onlySelector string
-	grip.Debug(unmarshal(&onlySelector))
+	unmarshal(&onlySelector)
 	if onlySelector != "" {
 		vs.StringSelector = onlySelector
 		return nil

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -188,7 +188,7 @@ func (pd *parserDependency) UnmarshalYAML(unmarshal func(interface{}) error) err
 			PatchOptional bool   `yaml:"patch_optional"`
 		}{}
 		// ignore error here: expected to fail considering the single-string selector
-		_ := unmarshal(&otherFields)
+		_ = unmarshal(&otherFields)
 		pd.Status = otherFields.Status
 		pd.PatchOptional = otherFields.PatchOptional
 		return nil
@@ -224,7 +224,7 @@ func (vs *variantSelector) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	// first, attempt to unmarshal just a selector string
 	// ignore errors here, because there may be other fields that are valid with single-string selectors
 	var onlySelector string
-	_ := unmarshal(&onlySelector)
+	_ = unmarshal(&onlySelector)
 	if onlySelector != "" {
 		vs.StringSelector = onlySelector
 		return nil
@@ -273,11 +273,9 @@ func (tss *taskSelectors) UnmarshalYAML(unmarshal func(interface{}) error) error
 func (ts *taskSelector) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// first, attempt to unmarshal just a selector string
 	var onlySelector string
-	if err := unmarshal(&onlySelector); err == nil {
-		if onlySelector != "" {
-			ts.Name = onlySelector
-			return nil
-		}
+	if _ = unmarshal(&onlySelector); onlySelector != "" {
+		ts.Name = onlySelector
+		return nil
 	}
 	// we define a new type so that we can grab the yaml struct tags without the struct methods,
 	// preventing infinite recursion on the UnmarshalYAML() method.

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -180,7 +180,7 @@ func (pd *parserDependency) UnmarshalYAML(unmarshal func(interface{}) error) err
 	var copy copyType
 	if err := unmarshal(&copy); err != nil {
 		// try unmarshalling for a single-string selector instead
-		if err := unmarshal(&copy.TaskSelector); err != nil {
+		if err := unmarshal(&pd.TaskSelector); err != nil {
 			return err
 		}
 		otherFields := struct {
@@ -191,8 +191,12 @@ func (pd *parserDependency) UnmarshalYAML(unmarshal func(interface{}) error) err
 		grip.Debug(unmarshal(&otherFields))
 		pd.Status = otherFields.Status
 		pd.PatchOptional = otherFields.PatchOptional
+		return nil
 	}
 	*pd = parserDependency(copy)
+	if pd.TaskSelector.Name == "" {
+		return errors.WithStack(errors.New("task selector must have a name"))
+	}
 	return nil
 }
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -188,7 +188,7 @@ func (pd *parserDependency) UnmarshalYAML(unmarshal func(interface{}) error) err
 			PatchOptional bool   `yaml:"patch_optional"`
 		}{}
 		// ignore error here: expected to fail considering the single-string selector
-		unmarshal(&otherFields)
+		_ := unmarshal(&otherFields)
 		pd.Status = otherFields.Status
 		pd.PatchOptional = otherFields.PatchOptional
 		return nil
@@ -224,7 +224,7 @@ func (vs *variantSelector) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	// first, attempt to unmarshal just a selector string
 	// ignore errors here, because there may be other fields that are valid with single-string selectors
 	var onlySelector string
-	unmarshal(&onlySelector)
+	_ := unmarshal(&onlySelector)
 	if onlySelector != "" {
 		vs.StringSelector = onlySelector
 		return nil

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -99,7 +99,6 @@ tasks:
 				p, err := createIntermediateProject([]byte(nameless))
 				So(p, ShouldBeNil)
 				So(err, ShouldNotBeNil)
-				fmt.Println(err.Error())
 			})
 			Convey("but an unused depends_on field should not error", func() {
 				nameless := `

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -99,6 +99,7 @@ tasks:
 				p, err := createIntermediateProject([]byte(nameless))
 				So(p, ShouldBeNil)
 				So(err, ShouldNotBeNil)
+				fmt.Println(err.Error())
 			})
 			Convey("but an unused depends_on field should not error", func() {
 				nameless := `


### PR DESCRIPTION
This is a nuanced change so let me know if you don't follow:
We were getting warnings from YamlStrict about tasks having Status dependencies. This came from the TaskSelector unmarshaller, because Status is a field of ParserDependency, not TaskSelector. 

The reason ParserDependency even calls a TaskSelector is for single-string dependencies (for which we would unmarshal into a string). If ParserDependency only tries to do this if a normal unmarshal errors (i.e. we probably have a single string selector) then this should unmarshal correctly (and if it can't for good reason, it should still error in the second phase of the TaskSelector unmarshaller).