### PR TITLE
EVG-7737: add filtered task count field to patch tasks query

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -185,6 +185,11 @@ type ComplexityRoot struct {
 		Variants func(childComplexity int) int
 	}
 
+	PatchTasks struct {
+		Count func(childComplexity int) int
+		Tasks func(childComplexity int) int
+	}
+
 	PatchTime struct {
 		Finished    func(childComplexity int) int
 		Started     func(childComplexity int) int
@@ -376,7 +381,7 @@ type QueryResolver interface {
 	Patch(ctx context.Context, id string) (*model.APIPatch, error)
 	Task(ctx context.Context, taskID string) (*model.APITask, error)
 	Projects(ctx context.Context) (*Projects, error)
-	PatchTasks(ctx context.Context, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) ([]*TaskResult, error)
+	PatchTasks(ctx context.Context, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) (*PatchTasks, error)
 	TaskTests(ctx context.Context, taskID string, sortCategory *TestSortCategory, sortDirection *SortDirection, page *int, limit *int, testName *string, statuses []string) (*TaskTestResult, error)
 	TaskFiles(ctx context.Context, taskID string) (*TaskFiles, error)
 	User(ctx context.Context) (*model.APIUser, error)
@@ -1021,6 +1026,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PatchProject.Variants(childComplexity), true
+
+	case "PatchTasks.count":
+		if e.complexity.PatchTasks.Count == nil {
+			break
+		}
+
+		return e.complexity.PatchTasks.Count(childComplexity), true
+
+	case "PatchTasks.tasks":
+		if e.complexity.PatchTasks.Tasks == nil {
+			break
+		}
+
+		return e.complexity.PatchTasks.Tasks(childComplexity), true
 
 	case "PatchTime.finished":
 		if e.complexity.PatchTime.Finished == nil {
@@ -1930,7 +1949,7 @@ var sources = []*ast.Source{
     baseStatuses: [String!] = []
     variant: String
     taskName: String
-  ): [TaskResult!]!
+  ): PatchTasks!
   taskTests(
     taskId: String!
     sortCategory: TestSortCategory = TEST_NAME
@@ -2022,6 +2041,11 @@ input SelectorInput {
 input SubscriberInput {
   type: String!
   target: String!
+}
+
+type PatchTasks {
+  tasks: [TaskResult!]!
+  count: Int!
 }
 
 type PatchBuildVariant {
@@ -5518,6 +5542,74 @@ func (ec *executionContext) _PatchProject_tasks(ctx context.Context, field graph
 	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _PatchTasks_tasks(ctx context.Context, field graphql.CollectedField, obj *PatchTasks) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchTasks",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Tasks, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*TaskResult)
+	fc.Result = res
+	return ec.marshalNTaskResult2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskResultᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PatchTasks_count(ctx context.Context, field graphql.CollectedField, obj *PatchTasks) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchTasks",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Count, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _PatchTime_started(ctx context.Context, field graphql.CollectedField, obj *PatchTime) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -6110,9 +6202,9 @@ func (ec *executionContext) _Query_patchTasks(ctx context.Context, field graphql
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*TaskResult)
+	res := resTmp.(*PatchTasks)
 	fc.Result = res
-	return ec.marshalNTaskResult2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskResultᚄ(ctx, field.Selections, res)
+	return ec.marshalNPatchTasks2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchTasks(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_taskTests(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -11320,6 +11412,38 @@ func (ec *executionContext) _PatchProject(ctx context.Context, sel ast.Selection
 	return out
 }
 
+var patchTasksImplementors = []string{"PatchTasks"}
+
+func (ec *executionContext) _PatchTasks(ctx context.Context, sel ast.SelectionSet, obj *PatchTasks) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, patchTasksImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PatchTasks")
+		case "tasks":
+			out.Values[i] = ec._PatchTasks_tasks(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "count":
+			out.Values[i] = ec._PatchTasks_count(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var patchTimeImplementors = []string{"PatchTime"}
 
 func (ec *executionContext) _PatchTime(ctx context.Context, sel ast.SelectionSet, obj *PatchTime) graphql.Marshaler {
@@ -13141,6 +13265,20 @@ func (ec *executionContext) marshalNPatchMetadata2ᚖgithubᚗcomᚋevergreenᚑ
 
 func (ec *executionContext) unmarshalNPatchReconfigure2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchReconfigure(ctx context.Context, v interface{}) (PatchReconfigure, error) {
 	return ec.unmarshalInputPatchReconfigure(ctx, v)
+}
+
+func (ec *executionContext) marshalNPatchTasks2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchTasks(ctx context.Context, sel ast.SelectionSet, v PatchTasks) graphql.Marshaler {
+	return ec._PatchTasks(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPatchTasks2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchTasks(ctx context.Context, sel ast.SelectionSet, v *PatchTasks) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._PatchTasks(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNProject2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFields(ctx context.Context, sel ast.SelectionSet, v model.UIProjectFields) graphql.Marshaler {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -70,6 +70,11 @@ type PatchReconfigure struct {
 	VariantsTasks []*VariantTasks `json:"variantsTasks"`
 }
 
+type PatchTasks struct {
+	Tasks []*TaskResult `json:"tasks"`
+	Count int           `json:"count"`
+}
+
 type PatchTime struct {
 	Started     *string `json:"started"`
 	Finished    *string `json:"finished"`

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -20,7 +20,7 @@ type Query {
     baseStatuses: [String!] = []
     variant: String
     taskName: String
-  ): [TaskResult!]!
+  ): PatchTasks!
   taskTests(
     taskId: String!
     sortCategory: TestSortCategory = TEST_NAME
@@ -112,6 +112,11 @@ input SelectorInput {
 input SubscriberInput {
   type: String!
   target: String!
+}
+
+type PatchTasks {
+  tasks: [TaskResult!]!
+  count: Int!
 }
 
 type PatchBuildVariant {

--- a/graphql/tests/patchTasks/queries/all-params.graphql
+++ b/graphql/tests/patchTasks/queries/all-params.graphql
@@ -8,10 +8,13 @@
     variant: "ubuntu1604"
     taskName: "party"
   ) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/count.graphql
+++ b/graphql/tests/patchTasks/queries/count.graphql
@@ -1,0 +1,5 @@
+{
+  patchTasks(patchId: "5e4ff3abe3c3317e352062e4") {
+    count
+  }
+}

--- a/graphql/tests/patchTasks/queries/filter-by-bad-task-name.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-bad-task-name.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", taskName: "asdfd") {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/filter-by-bad-variant.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-bad-variant.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", variant: "asdfd") {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/filter-by-base-status.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-base-status.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", baseStatuses: ["failed"]) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/filter-by-multiple-statuses.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-multiple-statuses.graphql
@@ -3,10 +3,13 @@
     patchId: "5e4ff3abe3c3317e352062e4"
     statuses: ["failed", "success"]
   ) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/filter-by-status.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-status.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", statuses: ["failed"]) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/filter-by-task-name.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-task-name.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", taskName: "test") {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/filter-by-variant-partial-search-term.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-variant-partial-search-term.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", variant: "win") {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/filter-by-variant.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-variant.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", variant: "windows") {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/limit-and-pagination-1.graphql
+++ b/graphql/tests/patchTasks/queries/limit-and-pagination-1.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", limit: 2, page: 0) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/limit-and-pagination-2.graphql
+++ b/graphql/tests/patchTasks/queries/limit-and-pagination-2.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", limit: 2, page: 1) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/no-params.graphql
+++ b/graphql/tests/patchTasks/queries/no-params.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4") {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/sort-base-status-descending.graphql
+++ b/graphql/tests/patchTasks/queries/sort-base-status-descending.graphql
@@ -4,10 +4,13 @@
     sortBy: BASE_STATUS
     sortDir: DESC
   ) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/sort-by-base-status.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-base-status.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: BASE_STATUS) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/sort-by-name.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-name.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: NAME) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/sort-by-status.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-status.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: STATUS) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/sort-by-variant.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-variant.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: VARIANT) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/queries/sort-descending.graphql
+++ b/graphql/tests/patchTasks/queries/sort-descending.graphql
@@ -1,9 +1,12 @@
 {
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortDir: DESC) {
-    id
-    status
-    baseStatus
-    displayName
-    buildVariant
+    tasks {
+      id
+      status
+      baseStatus
+      displayName
+      buildVariant
+    }
+    count
   }
 }

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -5,7 +5,8 @@
       "result": {
         "data": {
           "patchTasks": {
-            "tasks": []
+            "tasks": [],
+            "count": 0
           }
         }
       }
@@ -30,7 +31,8 @@
                 "displayName": "test-thirdparty-docker",
                 "buildVariant": "ubuntu1604"
               }
-            ]
+            ],
+            "count": 2
           }
         }
       }
@@ -55,7 +57,8 @@
                 "displayName": "lint",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 2
           }
         }
       }
@@ -80,7 +83,8 @@
                 "displayName": "lint",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 2
           }
         }
       }
@@ -90,7 +94,8 @@
       "result": {
         "data": {
           "patchTasks": {
-            "tasks": []
+            "tasks": [],
+            "count": 0
           }
         }
       }
@@ -129,7 +134,8 @@
                 "displayName": "lint",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 4
           }
         }
       }
@@ -168,7 +174,8 @@
                 "displayName": "test-thirdparty-docker",
                 "buildVariant": "ubuntu1604"
               }
-            ]
+            ],
+            "count": 4
           }
         }
       }
@@ -207,7 +214,8 @@
                 "displayName": "compile",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 4
           }
         }
       }
@@ -246,7 +254,8 @@
                 "displayName": "lint",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 4
           }
         }
       }
@@ -285,7 +294,8 @@
                 "displayName": "compile",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 4
           }
         }
       }
@@ -324,7 +334,8 @@
                 "displayName": "test-cloud",
                 "buildVariant": "ubuntu1604"
               }
-            ]
+            ],
+            "count": 4
           }
         }
       }
@@ -363,7 +374,8 @@
                 "displayName": "compile",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 4
           }
         }
       }
@@ -388,7 +400,8 @@
                 "displayName": "compile",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 2
           }
         }
       }
@@ -406,7 +419,8 @@
                 "displayName": "test-cloud",
                 "buildVariant": "ubuntu1604"
               }
-            ]
+            ],
+            "count": 1
           }
         }
       }
@@ -445,7 +459,8 @@
                 "displayName": "lint",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 4
           }
         }
       }
@@ -470,7 +485,8 @@
                 "displayName": "compile",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 4
           }
         }
       }
@@ -495,7 +511,8 @@
                 "displayName": "lint",
                 "buildVariant": "windows"
               }
-            ]
+            ],
+            "count": 4
           }
         }
       }
@@ -513,7 +530,8 @@
                 "id": "1",
                 "status": "success"
               }
-            ]
+            ],
+            "count": 1
           }
         }
       }
@@ -523,7 +541,7 @@
       "result": {
         "data": {
           "patchTasks": {
-            "count": 44
+            "count": 4
           }
         }
       }

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -4,7 +4,9 @@
       "query_file": "filter-by-bad-task-name.graphql",
       "result": {
         "data": {
-          "patchTasks": []
+          "patchTasks": {
+            "tasks": []
+          }
         }
       }
     },
@@ -12,22 +14,24 @@
       "query_file": "filter-by-task-name.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "1",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "test-thirdparty-docker",
-              "buildVariant": "ubuntu1604"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
+              }
+            ]
+          }
         }
       }
     },
@@ -35,22 +39,24 @@
       "query_file": "filter-by-variant.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -58,22 +64,24 @@
       "query_file": "filter-by-variant-partial-search-term.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -81,7 +89,9 @@
       "query_file": "filter-by-bad-variant.graphql",
       "result": {
         "data": {
-          "patchTasks": []
+          "patchTasks": {
+            "tasks": []
+          }
         }
       }
     },
@@ -89,36 +99,38 @@
       "query_file": "no-params.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "1",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "test-thirdparty-docker",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -126,36 +138,38 @@
       "query_file": "sort-by-name.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "1",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "test-thirdparty-docker",
-              "buildVariant": "ubuntu1604"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
+              }
+            ]
+          }
         }
       }
     },
@@ -163,36 +177,38 @@
       "query_file": "sort-by-variant.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "1",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "test-thirdparty-docker",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -200,36 +216,38 @@
       "query_file": "sort-by-status.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "1",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "test-thirdparty-docker",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -237,36 +255,38 @@
       "query_file": "sort-by-base-status.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "1",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "test-thirdparty-docker",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -274,36 +294,38 @@
       "query_file": "sort-base-status-descending.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "1",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "test-thirdparty-docker",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              }
+            ]
+          }
         }
       }
     },
@@ -311,36 +333,38 @@
       "query_file": "sort-descending.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "1",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "test-thirdparty-docker",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -348,22 +372,24 @@
       "query_file": "filter-by-status.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -371,15 +397,17 @@
       "query_file": "filter-by-base-status.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              }
+            ]
+          }
         }
       }
     },
@@ -387,36 +415,38 @@
       "query_file": "filter-by-multiple-statuses.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            },
-            {
-              "id": "1",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "test-thirdparty-docker",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -424,22 +454,24 @@
       "query_file": "limit-and-pagination-1.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "2",
-              "status": "failed",
-              "baseStatus": "failed",
-              "displayName": "test-cloud",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "4",
-              "status": "failed",
-              "baseStatus": "success",
-              "displayName": "compile",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "4",
+                "status": "failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -447,22 +479,24 @@
       "query_file": "limit-and-pagination-2.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "id": "1",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "test-thirdparty-docker",
-              "buildVariant": "ubuntu1604"
-            },
-            {
-              "id": "3",
-              "status": "success",
-              "baseStatus": "success",
-              "displayName": "lint",
-              "buildVariant": "windows"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "lint",
+                "buildVariant": "windows"
+              }
+            ]
+          }
         }
       }
     },
@@ -470,15 +504,27 @@
       "query_file": "all-params.graphql",
       "result": {
         "data": {
-          "patchTasks": [
-            {
-              "baseStatus": "success",
-              "buildVariant": "ubuntu1604",
-              "displayName": "test-thirdparty-docker",
-              "id": "1",
-              "status": "success"
-            }
-          ]
+          "patchTasks": {
+            "tasks": [
+              {
+                "baseStatus": "success",
+                "buildVariant": "ubuntu1604",
+                "displayName": "test-thirdparty-docker",
+                "id": "1",
+                "status": "success"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "count.graphql",
+      "result": {
+        "data": {
+          "patchTasks": {
+            "count": 44
+          }
         }
       }
     }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/route"
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -356,4 +357,29 @@ func GetAPITaskFromTask(ctx context.Context, sc data.Connector, task task.Task) 
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error setting building task from apiTask %s: %s", task.Id, err.Error()))
 	}
 	return &apiTask, nil
+}
+
+func FilterTasksByBaseStatuses(taskResults []*TaskResult, baseStatuses []string, baseTaskStatuses BaseTaskStatuses) []*TaskResult {
+	tasksFilteredByBaseStatus := []*TaskResult{}
+	for _, taskResult := range taskResults {
+		if utility.StringSliceContains(baseStatuses, baseTaskStatuses[taskResult.BuildVariant][taskResult.DisplayName]) {
+			tasksFilteredByBaseStatus = append(tasksFilteredByBaseStatus, taskResult)
+		}
+	}
+	return tasksFilteredByBaseStatus
+}
+func ConvertDBTasksToGqlTasks(tasks []task.Task, baseTaskStatuses BaseTaskStatuses) []*TaskResult {
+	var taskResults []*TaskResult
+	for _, task := range tasks {
+		t := TaskResult{
+			ID:           task.Id,
+			DisplayName:  task.DisplayName,
+			Version:      task.Version,
+			Status:       task.Status,
+			BuildVariant: task.BuildVariant,
+			BaseStatus:   baseTaskStatuses[task.BuildVariant][task.DisplayName],
+		}
+		taskResults = append(taskResults, &t)
+	}
+	return taskResults
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1952,7 +1952,7 @@ func GetTimeSpent(tasks []Task) (time.Duration, time.Duration) {
 
 // GetTasksByVersion gets all tasks for a specific version
 // Query results can be filtered by task name, variant name and status in addition to being paginated and limited
-func GetTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int) ([]Task, error) {
+func GetTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int) ([]Task, int, error) {
 	match := bson.M{
 		VersionKey: versionID,
 	}
@@ -1984,9 +1984,13 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 	tasks := []Task{}
 	err := db.FindAllQ(Collection, query, &tasks)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return tasks, nil
+	count, err := Count(query)
+	if err != nil {
+		return tasks, 0, err
+	}
+	return tasks, count, nil
 }
 
 // UpdateDependsOn appends new dependencies to tasks that already depend on this task

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1986,11 +1986,11 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 	if err != nil {
 		return nil, 0, err
 	}
-	count, err := Count(query)
+	total, err := Count(query)
 	if err != nil {
 		return tasks, 0, err
 	}
-	return tasks, count, nil
+	return tasks, total, nil
 }
 
 // UpdateDependsOn appends new dependencies to tasks that already depend on this task

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -123,7 +123,7 @@ type Connector interface {
 	FindTestsByTaskId(string, string, string, string, int, int) ([]testresult.TestResult, error)
 	FindTestsByTaskIdFilterSortPaginate(string, string, []string, string, int, int, int, int) ([]testresult.TestResult, error)
 	GetTestCountByTaskIdAndFilters(string, string, []string, int) (int, error)
-	FindTasksByVersion(string, string, []string, string, string, int, int, int) ([]task.Task, error)
+	FindTasksByVersion(string, string, []string, string, string, int, int, int) ([]task.Task, int, error)
 	// FindUserById is a method to find a specific user given its ID.
 	FindUserById(string) (gimlet.User, error)
 

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -211,11 +211,11 @@ func (tc *DBTaskConnector) GetManifestByTask(taskId string) (*manifest.Manifest,
 // FindTasksByVersion gets all tasks for a specific version
 // Results can be filtered by task name, variant name and status in addition to being paginated and limited
 func (tc *DBTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int) ([]task.Task, int, error) {
-	tasks, count, err := task.GetTasksByVersion(versionID, sortBy, statuses, variant, taskName, sortDir, page, limit)
+	tasks, total, err := task.GetTasksByVersion(versionID, sortBy, statuses, variant, taskName, sortDir, page, limit)
 	if err != nil {
 		return nil, 0, err
 	}
-	return tasks, count, nil
+	return tasks, total, nil
 }
 
 // MockTaskConnector stores a cached set of tasks that are queried against by the

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -210,12 +210,12 @@ func (tc *DBTaskConnector) GetManifestByTask(taskId string) (*manifest.Manifest,
 
 // FindTasksByVersion gets all tasks for a specific version
 // Results can be filtered by task name, variant name and status in addition to being paginated and limited
-func (tc *DBTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int) ([]task.Task, error) {
-	tasks, err := task.GetTasksByVersion(versionID, sortBy, statuses, variant, taskName, sortDir, page, limit)
+func (tc *DBTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int) ([]task.Task, int, error) {
+	tasks, count, err := task.GetTasksByVersion(versionID, sortBy, statuses, variant, taskName, sortDir, page, limit)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return tasks, nil
+	return tasks, count, nil
 }
 
 // MockTaskConnector stores a cached set of tasks that are queried against by the
@@ -422,7 +422,7 @@ func (tc *MockTaskConnector) GetManifestByTask(taskId string) (*manifest.Manifes
 	return nil, errors.Errorf("task '%s' not found", taskId)
 }
 
-func (tc *MockTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int) ([]task.Task, error) {
+func (tc *MockTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int) ([]task.Task, int, error) {
 	// FindTasksByVersion is extensively tested byt he gql test suite for the patchTasks query
-	return nil, nil
+	return nil, 0, nil
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7737
<img width="290" alt="Screen Shot 2020-04-22 at 5 17 15 PM" src="https://user-images.githubusercontent.com/15262143/80034909-22750080-84bd-11ea-9168-7fd11b46cc58.png">

The numerator in the task count on the patch page. It currently represents number of paginated tasks fetched; it increases as user scrolls. this fixes it so that denominator = total patch task count. numerator = total # tasks that match filter criteria