### PR TITLE
EVG-7864 more robust handling in set-cloud-hosts-ready

### DIFF
--- a/config_hostinit.go
+++ b/config_hostinit.go
@@ -11,8 +11,9 @@ const defaultHostThrottle = 32
 
 // HostInitConfig holds logging settings for the hostinit process.
 type HostInitConfig struct {
-	SSHTimeoutSeconds int64 `bson:"ssh_timeout_secs" json:"ssh_timeout_secs" yaml:"sshtimeoutseconds"`
-	HostThrottle      int   `bson:"host_throttle" json:"host_throttle" yaml:"host_throttle"`
+	SSHTimeoutSeconds    int64 `bson:"ssh_timeout_secs" json:"ssh_timeout_secs" yaml:"sshtimeoutseconds"`
+	HostThrottle         int   `bson:"host_throttle" json:"host_throttle" yaml:"host_throttle"`
+	CloudStatusBatchSize int   `bson:"cloud_batch_size" json:"cloud_batch_size" yaml:"cloud_batch_size"`
 }
 
 func (c *HostInitConfig) SectionId() string { return "hostinit" }
@@ -47,6 +48,7 @@ func (c *HostInitConfig) Set() error {
 		"$set": bson.M{
 			"ssh_timeout_secs": c.SSHTimeoutSeconds,
 			"host_throttle":    c.HostThrottle,
+			"cloud_batch_size": c.CloudStatusBatchSize,
 		},
 	}, options.Update().SetUpsert(true))
 
@@ -56,6 +58,9 @@ func (c *HostInitConfig) Set() error {
 func (c *HostInitConfig) ValidateAndDefault() error {
 	if c.HostThrottle <= 0 {
 		c.HostThrottle = defaultHostThrottle
+	}
+	if c.CloudStatusBatchSize <= 0 {
+		c.CloudStatusBatchSize = 500
 	}
 	return nil
 }

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1255,8 +1255,10 @@ var (
 	awsSecretKey = bsonutil.MustHaveTag(EC2ProviderSettings{}, "Secret")
 )
 
-func StartingHostsByClient() (map[ClientOptions][]Host, error) {
-	const batchSize = 500
+func StartingHostsByClient(limit int) (map[ClientOptions][]Host, error) {
+	if limit <= 0 {
+		limit = 500
+	}
 	results := []struct {
 		Options ClientOptions `bson:"_id"`
 		Hosts   []Host        `bson:"hosts"`
@@ -1267,7 +1269,12 @@ func StartingHostsByClient() (map[ClientOptions][]Host, error) {
 			"$match": bson.M{StatusKey: evergreen.HostStarting},
 		},
 		{
-			"$limit": batchSize,
+			"$sort": bson.M{
+				CreateTimeKey: 1,
+			},
+		},
+		{
+			"$limit": limit,
 		},
 		{
 			"$project": bson.M{

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1256,6 +1256,7 @@ var (
 )
 
 func StartingHostsByClient() (map[ClientOptions][]Host, error) {
+	const batchSize = 500
 	results := []struct {
 		Options ClientOptions `bson:"_id"`
 		Hosts   []Host        `bson:"hosts"`
@@ -1264,6 +1265,9 @@ func StartingHostsByClient() (map[ClientOptions][]Host, error) {
 	pipeline := []bson.M{
 		{
 			"$match": bson.M{StatusKey: evergreen.HostStarting},
+		},
+		{
+			"$limit": batchSize,
 		},
 		{
 			"$project": bson.M{

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4575,7 +4575,7 @@ func TestStartingHostsByClient(t *testing.T) {
 		require.NoError(t, h.Insert())
 	}
 
-	hostsByClient, err := StartingHostsByClient()
+	hostsByClient, err := StartingHostsByClient(0)
 	assert.NoError(t, err)
 	assert.Len(t, hostsByClient, 4)
 	for clientOptions, hosts := range hostsByClient {

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -226,8 +226,9 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	newBanner := "new banner"
 	newExpansions := map[string]string{"newkey": "newval"}
 	newHostinit := restModel.APIHostInitConfig{
-		SSHTimeoutSeconds: 999,
-		HostThrottle:      64,
+		SSHTimeoutSeconds:    999,
+		HostThrottle:         64,
+		CloudStatusBatchSize: 1,
 	}
 	updatedSettings := restModel.APIAdminSettings{
 		Banner:     &newBanner,

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -876,8 +876,9 @@ type APIBanner struct {
 }
 
 type APIHostInitConfig struct {
-	SSHTimeoutSeconds int64 `json:"ssh_timeout_secs"`
-	HostThrottle      int   `json:"host_throttle"`
+	SSHTimeoutSeconds    int64 `json:"ssh_timeout_secs"`
+	HostThrottle         int   `json:"host_throttle"`
+	CloudStatusBatchSize int   `json:"cloud_batch_size"`
 }
 
 func (a *APIHostInitConfig) BuildFromService(h interface{}) error {
@@ -885,6 +886,7 @@ func (a *APIHostInitConfig) BuildFromService(h interface{}) error {
 	case evergreen.HostInitConfig:
 		a.SSHTimeoutSeconds = v.SSHTimeoutSeconds
 		a.HostThrottle = v.HostThrottle
+		a.CloudStatusBatchSize = v.CloudStatusBatchSize
 	default:
 		return errors.Errorf("%T is not a supported type", h)
 	}
@@ -893,8 +895,9 @@ func (a *APIHostInitConfig) BuildFromService(h interface{}) error {
 
 func (a *APIHostInitConfig) ToService() (interface{}, error) {
 	return evergreen.HostInitConfig{
-		SSHTimeoutSeconds: a.SSHTimeoutSeconds,
-		HostThrottle:      a.HostThrottle,
+		SSHTimeoutSeconds:    a.SSHTimeoutSeconds,
+		HostThrottle:         a.HostThrottle,
+		CloudStatusBatchSize: a.CloudStatusBatchSize,
 	}, nil
 }
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -513,6 +513,10 @@ Admin Settings
 										<label>Host throttle (num hosts)</label>
 										<input type="number" ng-model="Settings.hostinit.host_throttle">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Cloud status checking batch size</label>
+										<input type="number" ng-model="Settings.hostinit.cloud_batch_size">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -66,7 +66,12 @@ func (j *cloudHostReadyJob) Run(ctx context.Context) {
 	}
 
 	// Collect hosts by provider and region
-	startingHostsByClient, err := host.StartingHostsByClient()
+	settings, err := evergreen.GetConfig()
+	if err != nil {
+		j.AddError(errors.Wrap(err, "unable to get evergreen settings"))
+		return
+	}
+	startingHostsByClient, err := host.StartingHostsByClient(settings.HostInit.CloudStatusBatchSize)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "can't get starting hosts"))
 		return

--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -77,3 +77,21 @@ func TestCloudStatusJob(t *testing.T) {
 		}
 	}
 }
+
+func TestTerminateUnknownHosts(t *testing.T) {
+	require.NoError(t, db.ClearCollections(host.Collection))
+	h1 := host.Host{
+		Id: "h1",
+	}
+	require.NoError(t, h1.Insert())
+	h2 := host.Host{
+		Id: "h2",
+	}
+	require.NoError(t, h2.Insert())
+	env := &mock.Environment{}
+	ctx := context.Background()
+	require.NoError(t, env.Configure(ctx))
+	j := NewCloudHostReadyJob(env, "id").(*cloudHostReadyJob)
+	awsErr := "error getting host statuses for providers: error describing instances: after 10 retries, operation failed: InvalidInstanceID.NotFound: The instance IDs 'h1, h2' do not exist"
+	assert.NoError(t, j.terminateUnknownHosts(ctx, awsErr))
+}


### PR DESCRIPTION
this is super hacky, but I thought it was less bad than other alternatives
- set an arbitrary limit of 500 for hosts we'll check cloud status for so that the aggregation does not get an intermediate stage that's too big (we hit the problem at ~2000)
- terminate hosts that AWS can't find