### PR TITLE
EVG-7741 allow creating new users for onboarding

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -183,7 +183,7 @@ func SetLoginToken(token, domain string, w http.ResponseWriter) {
 }
 
 func getOrCreateUser(u gimlet.User) (gimlet.User, error) {
-	return model.GetOrCreateUser(u.Username(), u.DisplayName(), u.Email(), u.GetAccessToken(), u.GetRefreshToken())
+	return model.GetOrCreateUser(u.Username(), u.DisplayName(), u.Email(), u.GetAccessToken(), u.GetRefreshToken(), u.Roles())
 }
 
 func getUserByID(id string) (gimlet.User, error) { return model.FindUserByID(id) }

--- a/model/user_lifecycle.go
+++ b/model/user_lifecycle.go
@@ -35,7 +35,7 @@ func FindUserByID(id string) (*user.DBUser, error) {
 
 // GetOrCreateUser fetches a user with the given userId and returns it. If no document exists for
 // that userId, inserts it along with the provided display name and email.
-func GetOrCreateUser(userId, displayName, email, accessToken, refreshToken string) (*user.DBUser, error) {
+func GetOrCreateUser(userId, displayName, email, accessToken, refreshToken string, roles []string) (*user.DBUser, error) {
 	u := &user.DBUser{}
 	env := evergreen.GetEnvironment()
 	ctx, cancel := env.Context()
@@ -49,6 +49,9 @@ func GetOrCreateUser(userId, displayName, email, accessToken, refreshToken strin
 	}
 	if refreshToken != "" {
 		setFields[bsonutil.GetDottedKeyName(user.LoginCacheKey, user.LoginCacheRefreshTokenKey)] = refreshToken
+	}
+	if roles != nil {
+		setFields[user.RolesKey] = roles
 	}
 	res := env.DB().Collection(user.Collection).FindOneAndUpdate(ctx,
 		bson.M{user.IdKey: userId},

--- a/model/user_lifecycle_test.go
+++ b/model/user_lifecycle_test.go
@@ -90,6 +90,7 @@ func TestGetOrCreateUser(t *testing.T) {
 			assert.Equal(t, roles, user.Roles())
 
 			user, err = GetOrCreateUser(id, name, email, accessToken, refreshToken, nil)
+			assert.NoError(t, err)
 			checkUser(t, user, id, name, email, accessToken, refreshToken)
 			assert.Equal(t, roles, user.Roles())
 		},

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/auth"
 	serviceModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -22,6 +23,7 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/grip"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	mgobson "gopkg.in/mgo.v2/bson"
@@ -29,6 +31,10 @@ import (
 
 func init() {
 	testutil.Setup()
+	config := evergreen.NaiveAuthConfig{}
+	um, err := auth.NewNaiveUserManager(&config)
+	grip.Error(err)
+	evergreen.GetEnvironment().SetUserManager(um)
 }
 
 func TestHostParseAndValidate(t *testing.T) {

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -365,13 +365,17 @@ func (h *userPermissionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewJSONResponse(permissions)
 }
 
-type userRolesPostHandler struct {
+type rolesPostRequest struct {
 	Roles      []string `json:"roles"`
 	CreateUser bool     `json:"create_user"`
+}
 
-	sc     data.Connector
-	rm     gimlet.RoleManager
-	userID string
+type userRolesPostHandler struct {
+	sc         data.Connector
+	rm         gimlet.RoleManager
+	userID     string
+	roles      []string
+	createUser bool
 }
 
 func makeModifyUserRoles(sc data.Connector, rm gimlet.RoleManager) gimlet.RouteHandler {
@@ -389,12 +393,15 @@ func (h *userRolesPostHandler) Factory() gimlet.RouteHandler {
 }
 
 func (h *userRolesPostHandler) Parse(ctx context.Context, r *http.Request) error {
-	if err := utility.ReadJSON(r.Body, h); err != nil {
+	var request rolesPostRequest
+	if err := utility.ReadJSON(r.Body, &request); err != nil {
 		return errors.Wrap(err, "request body is malformed")
 	}
-	if len(h.Roles) == 0 {
+	if len(request.Roles) == 0 {
 		return errors.New("must specify at least 1 role to add")
 	}
+	h.roles = request.Roles
+	h.createUser = request.CreateUser
 	vars := gimlet.GetVars(r)
 	h.userID = vars["user_id"]
 
@@ -407,16 +414,22 @@ func (h *userRolesPostHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{StatusCode: http.StatusInternalServerError, Message: fmt.Sprintf("can't get user for id '%s'", h.userID)})
 	}
 	dbUser, valid := u.(*user.DBUser)
+	if !valid {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			Message:    "unexpected structure for user",
+			StatusCode: http.StatusInternalServerError,
+		})
+	}
 	if dbUser == nil {
-		if h.CreateUser {
+		if h.createUser {
 			um := evergreen.GetEnvironment().UserManager()
 			newUser := user.DBUser{
 				Id:          h.userID,
-				SystemRoles: h.Roles,
+				SystemRoles: h.roles,
 			}
-			u, err = um.GetOrCreateUser(&newUser)
+			_, err = um.GetOrCreateUser(&newUser)
 			if err != nil {
-				return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{StatusCode: http.StatusInternalServerError, Message: fmt.Sprintf("unable to create new user: %s'", err.Error())})
+				return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "unable to create user"))
 			}
 			return gimlet.NewJSONResponse(struct{}{})
 		} else {
@@ -426,13 +439,7 @@ func (h *userRolesPostHandler) Run(ctx context.Context) gimlet.Responder {
 			})
 		}
 	}
-	if !valid {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			Message:    "unexpected structure for user",
-			StatusCode: http.StatusInternalServerError,
-		})
-	}
-	dbRoles, err := h.rm.GetRoles(h.Roles)
+	dbRoles, err := h.rm.GetRoles(h.roles)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error finding roles",
@@ -446,17 +453,18 @@ func (h *userRolesPostHandler) Run(ctx context.Context) gimlet.Responder {
 	for _, found := range dbRoles {
 		foundRoles = append(foundRoles, found.ID)
 	}
-	nonexistent, _ := utility.StringSliceSymmetricDifference(h.Roles, foundRoles)
+	nonexistent, _ := utility.StringSliceSymmetricDifference(h.roles, foundRoles)
 	if len(nonexistent) > 0 {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			Message:    fmt.Sprintf("roles not found: %v", nonexistent),
 			StatusCode: http.StatusNotFound,
 		})
 	}
-	for _, toAdd := range h.Roles {
+	for _, toAdd := range h.roles {
 		if err = dbUser.AddRole(toAdd); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "unable to add role",
+				"role":    toAdd,
 			}))
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 				Message:    "error adding role",


### PR DESCRIPTION
I think this will still work correctly in the case where the user document is created before the user actually logs in, but I'm not 100% confident
- Allow setting a user's roles when we first create the user
- Change the role adding route to create a shell user if the user doesn't exist, so that they will have the given roles when they first log in