### PR TITLE
EVG-7895: error if S3 task sync contents are empty when pulling

### DIFF
--- a/command/s3_pull_test.go
+++ b/command/s3_pull_test.go
@@ -98,9 +98,9 @@ func TestS3PullExecute(t *testing.T) {
 		},
 		"ExpandsParameters": func(ctx context.Context, t *testing.T, c *s3Pull, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig, bucketDir string) {
 			taskDir := filepath.Join(bucketDir, conf.Task.S3Path(c.FromBuildVariant, c.Task))
-			require.NoError(t, os.MkdirAll(taskDir, os.ModePerm))
+			require.NoError(t, os.MkdirAll(taskDir, 0777))
 
-			require.NoError(t, ioutil.WriteFile(filepath.Join(taskDir, "foo-12345"), []byte("bar"), os.ModePerm))
+			require.NoError(t, ioutil.WriteFile(filepath.Join(taskDir, "foo"), []byte("bar"), 0777))
 
 			wd, err := ioutil.TempDir("", "s3-pull-output")
 			require.NoError(t, err)
@@ -133,15 +133,6 @@ func TestS3PullExecute(t *testing.T) {
 			assert.Error(t, c.Execute(ctx, comm, logger, conf))
 		},
 		"FailsWithNoContentsToPull": func(ctx context.Context, t *testing.T, c *s3Pull, comm *client.Mock, logger client.LoggerProducer, conf *model.TaskConfig, bucketDir string) {
-			emptyDir, err := ioutil.TempDir("", "s3-pull-bucket")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(emptyDir))
-			}()
-			c.bucket, err = pail.NewLocalBucket(pail.LocalOptions{
-				Path: emptyDir,
-			})
-			require.NoError(t, err)
 			assert.Error(t, c.Execute(ctx, comm, logger, conf))
 		},
 	} {

--- a/operations/pull.go
+++ b/operations/pull.go
@@ -56,7 +56,7 @@ func Pull() cli.Command {
 				return errors.Wrap(err, "could not fetch credentials")
 			}
 
-			path, err := client.GetTaskSyncPath(ctx, taskID)
+			remotePath, err := client.GetTaskSyncPath(ctx, taskID)
 			if err != nil {
 				return errors.Wrap(err, "could not get location of task directory in S3")
 			}
@@ -77,7 +77,17 @@ func Pull() cli.Command {
 				Workers: runtime.NumCPU(),
 			}, bucket)
 
-			if err := os.MkdirAll(workingDir, 0755); err != nil {
+			// Verify that the contents exist before pulling, otherwise pull may
+			// no-op.
+			iter, err := bucket.List(ctx, remotePath)
+			if err != nil {
+				return errors.Wrap(err, "error checking for existence of remote task directory contents")
+			}
+			if !iter.Next(ctx) {
+				return errors.Errorf("remote task directory contents could not be found")
+			}
+
+			if err = os.MkdirAll(workingDir, 0755); err != nil {
 				return errors.Wrap(err, "could not make working directory")
 			}
 
@@ -87,7 +97,7 @@ func Pull() cli.Command {
 
 			if err := bucket.Pull(ctx, pail.SyncOptions{
 				Local:  workingDir,
-				Remote: path,
+				Remote: remotePath,
 			}); err != nil {
 				return errors.Wrap(err, "error while pulling task directory")
 			}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7895

If a pail bucket uses `Pull()`, it no-ops if there is no matching content. This validates that there's at least one item in the bucket before pulling.