### PR TITLE
EVG-7688: limit GQL mutations in prod playground to super users

### DIFF
--- a/service/ui.go
+++ b/service/ui.go
@@ -242,6 +242,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	needsLogin := gimlet.WrapperMiddleware(uis.requireLogin)
 	needsLoginNoRedirect := gimlet.WrapperMiddleware(uis.requireLoginStatusUnauthorized)
 	needsContext := gimlet.WrapperMiddleware(uis.loadCtx)
+	noMutationsInProdGQLPlaygroundUnlessSuperUser := gimlet.WrapperMiddleware(uis.noMutationsInProdGQLPlaygroundUnlessSuperUser)
 	allowsCORS := gimlet.WrapperMiddleware(uis.setCORSHeaders)
 	ownsHost := gimlet.WrapperMiddleware(uis.ownsHost)
 	vsCodeRunning := gimlet.WrapperMiddleware(uis.vsCodeRunning)
@@ -293,7 +294,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	}
 
 	// GraphQL
-	app.AddRoute("/graphql").Wrap(allowsCORS, needsLogin).Handler(playground.Handler("GraphQL playground", "/graphql/query")).Get()
+	app.AddRoute("/graphql").Wrap(allowsCORS, needsLogin, noMutationsInProdGQLPlaygroundUnlessSuperUser).Handler(playground.Handler("GraphQL playground", "/graphql/query")).Get()
 	app.AddRoute("/graphql/query").Wrap(allowsCORS, needsLoginNoRedirect).Handler(graphql.Handler(uis.Settings.ApiUrl)).Post().Get()
 	// this route is used solely to introspect the schema of the GQL server. OPTIONS request by design do not include auth headers; therefore must not require login.
 	app.AddRoute("/graphql/query").Wrap(allowsCORS).Handler(func(_ http.ResponseWriter, _ *http.Request) {}).Options()


### PR DESCRIPTION
Proof of concept for limiting GQL mutations in prod playground to super users

**Reason for doing so:** 
Being prudent about the changes to data we allow users to make when those changes are not behind the logic of the UI. 