### PR TITLE
EVG-6916 add build variant display names to mapping

### DIFF
--- a/service/waterfall.go
+++ b/service/waterfall.go
@@ -258,17 +258,17 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 			for _, b := range buildsInVersion {
 				bvSet[b.BuildVariant] = true
 
+				// variant may not be defined in project, in which case add display name to mapping
+				if buildVariantMappings[b.BuildVariant] == "" {
+					buildVariantMappings[b.BuildVariant] = b.DisplayName
+				}
 				buildVariant := waterfallBuildVariant{
 					Id:          b.BuildVariant,
 					DisplayName: buildVariantMappings[b.BuildVariant],
 				}
 
-				if buildVariant.DisplayName == "" {
-					buildVariant.DisplayName = b.DisplayName
-				}
-
 				// The version is marked active if there are any
-				// activated tasks for the varant
+				// activated tasks for the variant
 				if variantQuery != "" {
 					if versionActive && !variantMatched {
 						variantMatched = variantHasActiveTasks(


### PR DESCRIPTION
To explain what's going on:
When going through the versions, if we find a build with no display name in the buildVariantMappings, we set the build variant display name to be the build's display name (this is why display names still show up correctly in the waterfall).

_However,_ we sort by iterating through bvSet, and if there is no display name in the buildVariantMappings we use the ID instead (this is the structure we use for sorting, which is why we sometimes sort by ID).