### PR TITLE
EVG-7262 aborted tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -324,8 +324,8 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 				task.StatusKey:  bson.M{"$in": evergreen.AbortableStatuses},
 			},
 			bson.M{"$set": bson.M{
-				task.AbortedKey:     true,
-				task.AbortReasonKey: task.AbortInfo{User: caller},
+				task.AbortedKey:   true,
+				task.AbortInfoKey: task.AbortInfo{User: caller},
 			}},
 		)
 
@@ -401,8 +401,8 @@ func RestartBuild(buildId string, taskIds []string, abortInProgress bool, caller
 			},
 			bson.M{
 				"$set": bson.M{
-					task.AbortedKey:     true,
-					task.AbortReasonKey: task.AbortInfo{User: caller},
+					task.AbortedKey:   true,
+					task.AbortInfoKey: task.AbortInfo{User: caller},
 				},
 			},
 		)

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1534,8 +1534,8 @@ func TestVersionRestart(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.True(dbTask.Aborted)
-	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
-	assert.True(dbTask.Activated)
+	assert.Equal("test", dbTask.AbortReason.User)
+	assert.Equal(evergreen.TaskDispatched, dbTask.Status)
 
 	// test that not aborting in-progress tasks does not reset them
 	assert.NoError(resetTaskData())

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1534,8 +1534,9 @@ func TestVersionRestart(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.True(dbTask.Aborted)
-	assert.Equal("test", dbTask.AbortReason.User)
-	assert.Equal(evergreen.TaskDispatched, dbTask.Status)
+	assert.Equal("test", dbTask.AbortInfo.User)
+	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
+	assert.True(dbTask.Activated)
 
 	// test that not aborting in-progress tasks does not reset them
 	assert.NoError(resetTaskData())

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -436,12 +436,12 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	return patchVersion, nil
 }
 
-func CancelPatch(p *patch.Patch, caller string) error {
+func CancelPatch(p *patch.Patch, reason task.AbortInfo) error {
 	if p.Version != "" {
-		if err := SetVersionActivation(p.Version, false, caller); err != nil {
+		if err := SetVersionActivation(p.Version, false, reason.User); err != nil {
 			return errors.WithStack(err)
 		}
-		return errors.WithStack(AbortVersion(p.Version, caller))
+		return errors.WithStack(task.AbortVersion(p.Version, reason))
 	}
 
 	return errors.WithStack(patch.Remove(patch.ById(p.Id)))
@@ -451,7 +451,7 @@ func CancelPatch(p *patch.Patch, caller string) error {
 // the given time, with the same pr number, and base repository. Tasks which
 // are abortable (see model/task.IsAbortable()) will be aborted, while
 // dispatched/running/completed tasks will not be affected
-func AbortPatchesWithGithubPatchData(createdBefore time.Time, owner, repo string, prNumber int) error {
+func AbortPatchesWithGithubPatchData(createdBefore time.Time, closed bool, newPatch, owner, repo string, prNumber int) error {
 	patches, err := patch.Find(patch.ByGithubPRAndCreatedBefore(createdBefore, owner, repo, prNumber))
 	if err != nil {
 		return errors.Wrap(err, "initial patch fetch failed")
@@ -468,7 +468,7 @@ func AbortPatchesWithGithubPatchData(createdBefore time.Time, owner, repo string
 	catcher := grip.NewSimpleCatcher()
 	for i, _ := range patches {
 		if patches[i].Version != "" {
-			if err = CancelPatch(&patches[i], evergreen.GithubPRRequester); err != nil {
+			if err = CancelPatch(&patches[i], task.AbortInfo{User: evergreen.GithubPatchUser, NewVersion: newPatch, PRClosed: closed}); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"source":         "github hook",
 					"created_before": createdBefore.String(),

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -54,7 +54,7 @@ var (
 	StatusKey                 = bsonutil.MustHaveTag(Task{}, "Status")
 	DetailsKey                = bsonutil.MustHaveTag(Task{}, "Details")
 	AbortedKey                = bsonutil.MustHaveTag(Task{}, "Aborted")
-	AbortReasonKey            = bsonutil.MustHaveTag(Task{}, "AbortReason")
+	AbortInfoKey              = bsonutil.MustHaveTag(Task{}, "AbortInfo")
 	TimeTakenKey              = bsonutil.MustHaveTag(Task{}, "TimeTaken")
 	ExpectedDurationKey       = bsonutil.MustHaveTag(Task{}, "ExpectedDuration")
 	ExpectedDurationStddevKey = bsonutil.MustHaveTag(Task{}, "ExpectedDurationStdDev")

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -54,6 +54,7 @@ var (
 	StatusKey                 = bsonutil.MustHaveTag(Task{}, "Status")
 	DetailsKey                = bsonutil.MustHaveTag(Task{}, "Details")
 	AbortedKey                = bsonutil.MustHaveTag(Task{}, "Aborted")
+	AbortReasonKey            = bsonutil.MustHaveTag(Task{}, "AbortReason")
 	TimeTakenKey              = bsonutil.MustHaveTag(Task{}, "TimeTaken")
 	ExpectedDurationKey       = bsonutil.MustHaveTag(Task{}, "ExpectedDuration")
 	ExpectedDurationStddevKey = bsonutil.MustHaveTag(Task{}, "ExpectedDurationStdDev")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -118,10 +118,10 @@ type Task struct {
 	Requester string `bson:"r" json:"r"`
 
 	// Status represents the various stages the task could be in
-	Status      string                  `bson:"status" json:"status"`
-	Details     apimodels.TaskEndDetail `bson:"details" json:"task_end_details"`
-	Aborted     bool                    `bson:"abort,omitempty" json:"abort"`
-	AbortReason AbortInfo               `bson:"abort_reason,omitempty" json:"abort_reason,omitempty"`
+	Status    string                  `bson:"status" json:"status"`
+	Details   apimodels.TaskEndDetail `bson:"details" json:"task_end_details"`
+	Aborted   bool                    `bson:"abort,omitempty" json:"abort"`
+	AbortInfo AbortInfo               `bson:"abort_info,omitempty" json:"abort_info,omitempty"`
 
 	// TimeTaken is how long the task took to execute.  meaningless if the task is not finished
 	TimeTaken time.Duration `bson:"time_taken" json:"time_taken"`
@@ -299,8 +299,8 @@ func NewDisplayTaskCache() DisplayTaskCache {
 }
 
 type AbortInfo struct {
-	TaskID     string `bson:"task_id,omitempty" json:"task_id,omitempty"`
 	User       string `bson:"user,omitempty" json:"user,omitempty"`
+	TaskID     string `bson:"task_id,omitempty" json:"task_id,omitempty"`
 	NewVersion string `bson:"new_version,omitempty" json:"new_version,omitempty"`
 	PRClosed   bool   `bson:"pr_closed,omitempty" json:"pr_closed,omitempty"`
 }
@@ -621,9 +621,9 @@ func (t *Task) MarkAsDispatched(hostId string, distroId string, dispatchTime tim
 				DistroIdKey:      distroId,
 			},
 			"$unset": bson.M{
-				AbortedKey:     "",
-				AbortReasonKey: "",
-				DetailsKey:     "",
+				AbortedKey:   "",
+				AbortInfoKey: "",
+				DetailsKey:   "",
 			},
 		},
 	)
@@ -661,7 +661,7 @@ func (t *Task) MarkAsUndispatched() error {
 				DistroIdKey:      "",
 				HostIdKey:        "",
 				AbortedKey:       "",
-				AbortReasonKey:   "",
+				AbortInfoKey:     "",
 				DetailsKey:       "",
 			},
 		},
@@ -855,8 +855,8 @@ func (t *Task) SetAborted(reason AbortInfo) error {
 		},
 		bson.M{
 			"$set": bson.M{
-				AbortedKey:     true,
-				AbortReasonKey: reason,
+				AbortedKey:   true,
+				AbortInfoKey: reason,
 			},
 		},
 	)
@@ -1261,8 +1261,8 @@ func AbortBuild(buildId string, reason AbortInfo) error {
 	_, err = UpdateAll(
 		bson.M{IdKey: bson.M{"$in": ids}},
 		bson.M{"$set": bson.M{
-			AbortedKey:     true,
-			AbortReasonKey: reason,
+			AbortedKey:   true,
+			AbortInfoKey: reason,
 		}},
 	)
 	if err != nil {
@@ -1300,8 +1300,8 @@ func AbortVersion(versionId string, reason AbortInfo) error {
 	_, err = UpdateAll(
 		bson.M{IdKey: bson.M{"$in": ids}},
 		bson.M{"$set": bson.M{
-			AbortedKey:     true,
-			AbortReasonKey: reason,
+			AbortedKey:   true,
+			AbortInfoKey: reason,
 		}},
 	)
 	if err != nil {
@@ -1371,7 +1371,7 @@ func (t *Task) Archive() error {
 	err = UpdateOne(
 		bson.M{IdKey: t.Id},
 		bson.M{
-			"$unset": bson.M{AbortedKey: "", AbortReasonKey: ""},
+			"$unset": bson.M{AbortedKey: "", AbortInfoKey: ""},
 			"$inc":   inc,
 		})
 	if err != nil {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -118,9 +118,10 @@ type Task struct {
 	Requester string `bson:"r" json:"r"`
 
 	// Status represents the various stages the task could be in
-	Status  string                  `bson:"status" json:"status"`
-	Details apimodels.TaskEndDetail `bson:"details" json:"task_end_details"`
-	Aborted bool                    `bson:"abort,omitempty" json:"abort"`
+	Status      string                  `bson:"status" json:"status"`
+	Details     apimodels.TaskEndDetail `bson:"details" json:"task_end_details"`
+	Aborted     bool                    `bson:"abort,omitempty" json:"abort"`
+	AbortReason AbortInfo               `bson:"abort_reason,omitempty" json:"abort_reason,omitempty"`
 
 	// TimeTaken is how long the task took to execute.  meaningless if the task is not finished
 	TimeTaken time.Duration `bson:"time_taken" json:"time_taken"`
@@ -295,6 +296,13 @@ func (c *DisplayTaskCache) List() []*Task { return c.displayTasks }
 
 func NewDisplayTaskCache() DisplayTaskCache {
 	return DisplayTaskCache{execToDisplay: map[string]*Task{}, displayTasks: []*Task{}}
+}
+
+type AbortInfo struct {
+	TaskID     string `bson:"task_id,omitempty" json:"task_id,omitempty"`
+	User       string `bson:"user,omitempty" json:"user,omitempty"`
+	NewVersion string `bson:"new_version,omitempty" json:"new_version,omitempty"`
+	PRClosed   bool   `bson:"pr_closed,omitempty" json:"pr_closed,omitempty"`
 }
 
 var (
@@ -613,8 +621,9 @@ func (t *Task) MarkAsDispatched(hostId string, distroId string, dispatchTime tim
 				DistroIdKey:      distroId,
 			},
 			"$unset": bson.M{
-				AbortedKey: "",
-				DetailsKey: "",
+				AbortedKey:     "",
+				AbortReasonKey: "",
+				DetailsKey:     "",
 			},
 		},
 	)
@@ -652,6 +661,7 @@ func (t *Task) MarkAsUndispatched() error {
 				DistroIdKey:      "",
 				HostIdKey:        "",
 				AbortedKey:       "",
+				AbortReasonKey:   "",
 				DetailsKey:       "",
 			},
 		},
@@ -837,7 +847,7 @@ func (t *Task) MarkSystemFailed() error {
 }
 
 // SetAborted sets the abort field of task to aborted
-func (t *Task) SetAborted() error {
+func (t *Task) SetAborted(reason AbortInfo) error {
 	t.Aborted = true
 	return UpdateOne(
 		bson.M{
@@ -845,7 +855,8 @@ func (t *Task) SetAborted() error {
 		},
 		bson.M{
 			"$set": bson.M{
-				AbortedKey: true,
+				AbortedKey:     true,
+				AbortReasonKey: reason,
 			},
 		},
 	)
@@ -1227,24 +1238,78 @@ func IncSpawnedHostCost(taskID string, cost float64) error {
 
 // AbortBuild sets the abort flag on all tasks associated with the build which are in an abortable
 // state
-func AbortBuild(buildId, caller string) error {
-	_, err := UpdateAll(
-		bson.M{
-			BuildIdKey: buildId,
-			StatusKey:  bson.M{"$in": evergreen.AbortableStatuses},
-		},
-		bson.M{"$set": bson.M{AbortedKey: true}},
+func AbortBuild(buildId string, reason AbortInfo) error {
+	q := bson.M{
+		BuildIdKey: buildId,
+		StatusKey:  bson.M{"$in": evergreen.AbortableStatuses},
+	}
+	if reason.TaskID != "" {
+		q[IdKey] = bson.M{"$ne": reason.TaskID}
+	}
+	ids, err := findAllTaskIDs(db.Query(q))
+	if err != nil {
+		return errors.Wrapf(err, "error finding tasks to abort from build '%s'", buildId)
+	}
+	if len(ids) == 0 {
+		grip.Info(message.Fields{
+			"message": "no tasks aborted for build",
+			"buildId": buildId,
+		})
+		return nil
+	}
+
+	_, err = UpdateAll(
+		bson.M{IdKey: bson.M{"$in": ids}},
+		bson.M{"$set": bson.M{
+			AbortedKey:     true,
+			AbortReasonKey: reason,
+		}},
+	)
+	if err != nil {
+		return errors.Wrapf(err, "error setting aborted statuses for tasks in build '%s'", buildId)
+	}
+
+	event.LogManyTaskAbortRequests(ids, reason.User)
+
+	return nil
+}
+
+// AbortVersion sets the abort flag on all tasks associated with the version which are in an
+// abortable state
+func AbortVersion(versionId string, reason AbortInfo) error {
+	q := bson.M{
+		VersionKey: versionId,
+		StatusKey:  bson.M{"$in": evergreen.AbortableStatuses},
+	}
+	if reason.TaskID != "" {
+		q[IdKey] = bson.M{"$ne": reason.TaskID}
+	}
+	ids, err := findAllTaskIDs(db.Query(q))
+	if err != nil {
+		return errors.Wrap(err, "error finding updated tasks")
+	}
+
+	if len(ids) == 0 {
+		grip.Info(message.Fields{
+			"message": "no tasks aborted for version",
+			"buildId": versionId,
+		})
+		return nil
+	}
+
+	_, err = UpdateAll(
+		bson.M{IdKey: bson.M{"$in": ids}},
+		bson.M{"$set": bson.M{
+			AbortedKey:     true,
+			AbortReasonKey: reason,
+		}},
 	)
 	if err != nil {
 		return errors.Wrap(err, "error setting aborted statuses")
 	}
-	ids, err := FindAllTaskIDsFromBuild(buildId)
-	if err != nil {
-		return errors.Wrap(err, "error finding tasks by build id")
-	}
-	if len(ids) > 0 {
-		event.LogManyTaskAbortRequests(ids, caller)
-	}
+
+	event.LogManyTaskAbortRequests(ids, reason.User)
+
 	return nil
 }
 
@@ -1272,7 +1337,6 @@ func (t *Task) Insert() error {
 
 // Inserts the task into the old_tasks collection
 func (t *Task) Archive() error {
-	var update bson.M
 	if t.DisplayOnly {
 		for _, et := range t.ExecutionTasks {
 			execTask, err := FindOne(ById(et))
@@ -1288,39 +1352,31 @@ func (t *Task) Archive() error {
 		}
 	}
 
-	// only increment restarts if have a current restarts
-	// this way restarts will never be set for new tasks but will be
-	// maintained for old ones
-	if t.Restarts > 0 {
-		update = bson.M{
-			"$inc": bson.M{
-				ExecutionKey: 1,
-				RestartsKey:  1,
-			},
-			"$unset": bson.M{AbortedKey: ""},
-		}
-	} else {
-		update = bson.M{
-			"$inc":   bson.M{ExecutionKey: 1},
-			"$unset": bson.M{AbortedKey: ""},
-		}
-	}
-	err := UpdateOne(
-		bson.M{IdKey: t.Id},
-		update)
-	if err != nil {
-		return errors.Wrap(err, "task.Archive() failed")
-	}
-
 	archiveTask := *t
 	archiveTask.Id = fmt.Sprintf("%v_%v", t.Id, t.Execution)
 	archiveTask.OldTaskId = t.Id
 	archiveTask.Archived = true
-	err = db.Insert(OldCollection, &archiveTask)
+	err := db.Insert(OldCollection, &archiveTask)
 	if err != nil {
 		return errors.Wrap(err, "task.Archive() failed")
 	}
 
+	// only increment restarts if have a current restarts
+	// this way restarts will never be set for new tasks but will be
+	// maintained for old ones
+	inc := bson.M{ExecutionKey: 1}
+	if t.Restarts > 0 {
+		inc[RestartsKey] = 1
+	}
+	err = UpdateOne(
+		bson.M{IdKey: t.Id},
+		bson.M{
+			"$unset": bson.M{AbortedKey: "", AbortReasonKey: ""},
+			"$inc":   inc,
+		})
+	if err != nil {
+		return errors.Wrap(err, "task.Archive() failed")
+	}
 	t.Aborted = false
 
 	err = event.UpdateExecutions(t.HostId, t.Id, t.Execution)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1240,8 +1240,8 @@ func TestTryDequeueAndAbortCommitQueueVersion(t *testing.T) {
 		BuildId:   b.Id,
 	}
 	q := []commitqueue.CommitQueueItem{
-		commitqueue.CommitQueueItem{Issue: "12"},
-		commitqueue.CommitQueueItem{Issue: "42"},
+		{Issue: "12"},
+		{Issue: "42"},
 	}
 	cq := &commitqueue.CommitQueue{ProjectID: "my-project", Processing: true, Queue: q}
 	assert.NoError(t, v.Insert())
@@ -1255,7 +1255,7 @@ func TestTryDequeueAndAbortCommitQueueVersion(t *testing.T) {
 
 	pRef := &ProjectRef{Identifier: cq.ProjectID}
 
-	assert.NoError(t, TryDequeueAndAbortCommitQueueVersion(pRef, v.Id, evergreen.User))
+	assert.NoError(t, TryDequeueAndAbortCommitQueueVersion(pRef, &task.Task{Id: "t1", Version: v.Id}, evergreen.User))
 	cq, err := commitqueue.FindOneId("my-project")
 	assert.NoError(t, err)
 	assert.Equal(t, cq.FindItem("12"), -1)

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
@@ -126,7 +127,7 @@ func (pc *DBPatchConnector) AbortPatch(patchId string, user string) error {
 			Message:    fmt.Sprintf("patch with id %s not found", patchId),
 		}
 	}
-	return model.CancelPatch(p, user)
+	return model.CancelPatch(p, task.AbortInfo{User: user})
 }
 
 // SetPatchPriority attempts to set the priority on the corresponding version.
@@ -209,7 +210,7 @@ func (p *DBPatchConnector) AbortPatchesFromPullRequest(event *github.PullRequest
 		return err
 	}
 
-	err = model.AbortPatchesWithGithubPatchData(*event.PullRequest.ClosedAt,
+	err = model.AbortPatchesWithGithubPatchData(*event.PullRequest.ClosedAt, true, "",
 		owner, repo, *event.Number)
 	if err != nil {
 		return gimlet.ErrorResponse{

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -65,7 +65,7 @@ func (vc *DBVersionConnector) FindVersionById(versionId string) (*model.Version,
 // AbortVersion aborts all tasks of a version given its ID.
 // It wraps the service level AbortModel.Version
 func (vc *DBVersionConnector) AbortVersion(versionId, caller string) error {
-	return model.AbortVersion(versionId, caller)
+	return task.AbortVersion(versionId, task.AbortInfo{User: caller})
 }
 
 // RestartVersion wraps the service level RestartVersion, which restarts

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/evergreen/util"
@@ -352,7 +353,7 @@ func (as *APIServer) existingPatchRequest(w http.ResponseWriter, r *http.Request
 
 		gimlet.WriteJSON(w, "patch finalized")
 	case "cancel":
-		err = model.CancelPatch(p, dbUser.Id)
+		err = model.CancelPatch(p, task.AbortInfo{User: dbUser.Id})
 		if err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
 			return

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -236,7 +236,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if t.Requester == evergreen.MergeTestRequester && details.Status != evergreen.TaskSucceeded {
-		if err = model.TryDequeueAndAbortCommitQueueVersion(projectRef, t.Version, APIServerLockTitle); err != nil {
+		if err = model.TryDequeueAndAbortCommitQueueVersion(projectRef, t, APIServerLockTitle); err != nil {
 			err = errors.Wrapf(err, "Error dequeueing and aborting failed commit queue version")
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
 			return

--- a/service/build.go
+++ b/service/build.go
@@ -212,7 +212,7 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !putParams.Active && putParams.Abort {
-			if err = task.AbortBuild(projCtx.Build.Id, user.Id); err != nil {
+			if err = task.AbortBuild(projCtx.Build.Id, task.AbortInfo{User: user.Id}); err != nil {
 				http.Error(w, "Error unscheduling tasks", http.StatusInternalServerError)
 				return
 			}

--- a/service/task.go
+++ b/service/task.go
@@ -52,6 +52,7 @@ type uiTaskData struct {
 	TaskEndDetails       apimodels.TaskEndDetail `json:"task_end_details"`
 	TestResults          []uiTestResult          `json:"test_results"`
 	Aborted              bool                    `json:"abort"`
+	AbortInfo            task.AbortInfo          `json:"abort_info,omitempty"`
 	MinQueuePos          int                     `json:"min_queue_pos"`
 	DependsOn            []uiDep                 `json:"depends_on"`
 	OverrideDependencies bool                    `json:"override_dependencies"`
@@ -235,6 +236,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		TimeTaken:            projCtx.Task.TimeTaken,
 		Priority:             projCtx.Task.Priority,
 		Aborted:              projCtx.Task.Aborted,
+		AbortInfo:            projCtx.Task.AbortInfo,
 		DisplayOnly:          projCtx.Task.DisplayOnly,
 		OverrideDependencies: projCtx.Task.OverrideDependencies,
 		CurrentTime:          time.Now().UnixNano(),

--- a/service/templates/task.html
+++ b/service/templates/task.html
@@ -233,7 +233,13 @@ Evergreen - {{Trunc .Task.Revision 10}} / {{.Task.BuildVariantDisplay}} / {{.Tas
                     </tr>
                     <tr ng-show="task.abort">
                       <td class="icon"><i class="fa fa-level-down"></i></td>
-                      <td>Aborting</td>
+                      <td>
+                        Aborted
+                        <span ng-show="task.abort_info.user">by [[task.abort_info.user]]</span>
+                        <span ng-show="task.abort_info.task_id">because of failing task <a ng-href="[[task.abort_info.task_id]]">[[task.abort_info.task_id]]</a></span>
+                        <span ng-show="task.abort_info.new_version">because the version is replaced by <a ng-href="/version/[[task.abort_info.new_version]]">[[task.abort_info.new_version]]</a></span>
+                        <span ng-show="task.abort_info.pr_closed">because the GitHub PR was closed</span>
+                      </td>
                     </tr>
                     <tr ng-show="task.start_time > 0 && (task.status != 'undispatched' && task.status != 'dispatched') ">
                       <td class="icon"><i class="fa fa-calendar"></i></td>

--- a/service/templates/task.html
+++ b/service/templates/task.html
@@ -237,7 +237,7 @@ Evergreen - {{Trunc .Task.Revision 10}} / {{.Task.BuildVariantDisplay}} / {{.Tas
                         Aborted
                         <span ng-show="task.abort_info.user">by [[task.abort_info.user]]</span>
                         <span ng-show="task.abort_info.task_id">because of failing task <a ng-href="[[task.abort_info.task_id]]">[[task.abort_info.task_id]]</a></span>
-                        <span ng-show="task.abort_info.new_version">because the version is replaced by <a ng-href="/version/[[task.abort_info.new_version]]">[[task.abort_info.new_version]]</a></span>
+                        <span ng-show="task.abort_info.new_version">because of new version <a ng-href="/version/[[task.abort_info.new_version]]">[[task.abort_info.new_version]]</a></span>
                         <span ng-show="task.abort_info.pr_closed">because the GitHub PR was closed</span>
                       </td>
                     </tr>

--- a/service/version.go
+++ b/service/version.go
@@ -258,7 +258,7 @@ func (uis *UIServer) modifyVersion(w http.ResponseWriter, r *http.Request) {
 		// abort after deactivating the version so we aren't bombarded with failing tasks while
 		// the deactivation is in progress
 		if jsonMap.Abort {
-			if err = model.AbortVersion(projCtx.Version.Id, authName); err != nil {
+			if err = task.AbortVersion(projCtx.Version.Id, task.AbortInfo{User: authName}); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -148,8 +148,8 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 		}))
 
 		j.AddError(model.AbortPatchesWithGithubPatchData(patchDoc.CreateTime,
-			patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo,
-			patchDoc.GithubPatchData.PRNumber))
+			false, patchDoc.Id.Hex(), patchDoc.GithubPatchData.BaseOwner,
+			patchDoc.GithubPatchData.BaseRepo, patchDoc.GithubPatchData.PRNumber))
 	}
 }
 


### PR DESCRIPTION
Make it apparent why a task was aborted when:
- the task was cancelled because another task failed (for the commit queue)
- the task was cancelled when another version superseded it (a new commit was pushed to the PR)
- the task was cancelled because the PR was closed
- a user aborted the task

Save the reason in the task document and display it on the task page.