### PR TITLE
EVG-7809: evaluate idle termination if provisioning cutoff is passed

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -173,10 +173,10 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 					{
 						StatusKey:    bson.M{"$in": []string{evergreen.HostStarting, evergreen.HostProvisioning}},
 						bootstrapKey: distro.BootstrapMethodUserData,
-						// User data hosts have a grace period during which
-						// they are not considered idle to give agents time to
-						// start.
-						LastCommunicationTimeKey: bson.M{"$lte": time.Now().Add(-MaxUncommunicativeInterval)},
+						// User data hosts have a grace period between creation
+						// and provisioning during which they are not considered
+						// for idle termination to give agents time to start.
+						CreateTimeKey: bson.M{"$lte": time.Now().Add(-provisioningCutoff)},
 					},
 				},
 			},

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -242,7 +242,7 @@ func TestGenerateTasks(t *testing.T) {
 	require.Len(p.BuildVariants, 2)
 	assert.Len(p.BuildVariants[0].Tasks, 1)
 	assert.Len(p.BuildVariants[1].Tasks, 4)
-	assert.Len(p.TaskGroups, 1)
+	require.Len(p.TaskGroups, 1)
 	assert.Len(p.TaskGroups[0].Tasks, 2)
 
 	b, err := build.FindOneId("sample_build_id")

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -173,7 +173,7 @@ func (j *idleHostJob) checkAndTerminateHost(ctx context.Context, h *host.Host) e
 			"job_type": j.Type().Name,
 			"status":   h.Status,
 			"provider": h.Distro.Provider,
-			"message":  "host termination for a non-spawnable distro",
+			"message":  "host termination for a non-ephemeral distro",
 			"cause":    "programmer error",
 		})
 		return errors.New("attempted to terminate non-ephemeral host")


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7809

This evaluates a user data host for idle termination if it's stuck in the provisioning state but has an agent that has run tasks. Before, it if managed to run tasks before the cutoff and was stuck in the provisioning state forever, it would never be terminated. This only occurs if the setup host job was unable to retry (most likely because the app server was restarted). However, with the recent changes to the setup host job so that it can retry without relying on the job to re-enqueue itself and this change, it should no longer be an issue.