### PR TITLE
EVG-7741 don't update roles after initial insert

### DIFF
--- a/model/user_lifecycle.go
+++ b/model/user_lifecycle.go
@@ -50,16 +50,17 @@ func GetOrCreateUser(userId, displayName, email, accessToken, refreshToken strin
 	if refreshToken != "" {
 		setFields[bsonutil.GetDottedKeyName(user.LoginCacheKey, user.LoginCacheRefreshTokenKey)] = refreshToken
 	}
+	setOnInsertFields := bson.M{
+		user.APIKeyKey: utility.RandomString(),
+	}
 	if roles != nil && len(roles) > 0 {
-		setFields[user.RolesKey] = roles
+		setOnInsertFields[user.RolesKey] = roles
 	}
 	res := env.DB().Collection(user.Collection).FindOneAndUpdate(ctx,
 		bson.M{user.IdKey: userId},
 		bson.M{
-			"$set": setFields,
-			"$setOnInsert": bson.M{
-				user.APIKeyKey: utility.RandomString(),
-			},
+			"$set":         setFields,
+			"$setOnInsert": setOnInsertFields,
 		},
 		options.FindOneAndUpdate().SetUpsert(true).SetReturnDocument(options.After),
 	)


### PR DESCRIPTION
Not urgent, but cleans this up a bit. This function is called every time we re-authenticate a user. Only when the user is first created by the roles route should we be updating roles