### PR TITLE
EVG-6367 noop attempts to add duplicate roles

### DIFF
--- a/model/user/user.go
+++ b/model/user/user.go
@@ -251,7 +251,7 @@ func (u *DBUser) RemoveFavoriteProject(identifier string) error {
 
 func (u *DBUser) AddRole(role string) error {
 	if utility.StringSliceContains(u.SystemRoles, role) {
-		return errors.Errorf("cannot add duplicate role '%s'", role)
+		return nil
 	}
 	update := bson.M{
 		"$push": bson.M{RolesKey: role},


### PR DESCRIPTION
this will allow our rest APIs to noop if someone tries to add a duplicate role, which will make handling edge cases in mana easier