### PR TITLE
MCI-3215 check host can spawn from task before loading task page

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -293,7 +293,8 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 			uiTask.HostDNS = taskHost.Host
 			// ensure that the ability to spawn is updated from the existing distro
 			taskHost.Distro.SpawnAllowed = false
-			d, err := distro.FindByID(taskHost.Distro.Id)
+			var d *distro.Distro
+			d, err = distro.FindByID(taskHost.Distro.Id)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return

--- a/service/task.go
+++ b/service/task.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -290,6 +291,16 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		}
 		if taskHost != nil {
 			uiTask.HostDNS = taskHost.Host
+			// ensure that the ability to spawn is updated from the existing distro
+			taskHost.Distro.SpawnAllowed = false
+			d, err := distro.FindByID(taskHost.Distro.Id)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if d != nil {
+				taskHost.Distro.SpawnAllowed = d.SpawnAllowed
+			}
 		}
 	}
 


### PR DESCRIPTION
If the host was created before a distro was updated, some parameters may be out of date that we would want to refresh (i.e. maybe just SpawnAllowed) so we should check the existing distro configuration.

My only question is if a host was created before SpawnAllowed was set to False, should we still allow the task to spawn a host? I assume not.