### PR TITLE
EVG-7804: return errors from MergeGeneratedProjects

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -33,8 +33,6 @@ type GeneratedProject struct {
 
 // MergeGeneratedProjects takes a slice of generated projects and returns a single, deduplicated project.
 func MergeGeneratedProjects(projects []GeneratedProject) *GeneratedProject {
-	catcher := grip.NewBasicCatcher()
-
 	bvs := map[string]*parserBV{}
 	tasks := map[string]*parserTask{}
 	functions := map[string]*YAMLCommandSet{}
@@ -44,9 +42,7 @@ func MergeGeneratedProjects(projects []GeneratedProject) *GeneratedProject {
 	mergeBuildVariants:
 		for i, bv := range p.BuildVariants {
 			if len(bv.Tasks) == 0 {
-				if _, ok := bvs[bv.Name]; ok {
-					catcher.Add(errors.Errorf("found duplicate buildvariant (%s)", bv.Name))
-				} else {
+				if _, ok := bvs[bv.Name]; !ok {
 					bvs[bv.Name] = &p.BuildVariants[i]
 					continue mergeBuildVariants
 				}
@@ -58,22 +54,15 @@ func MergeGeneratedProjects(projects []GeneratedProject) *GeneratedProject {
 			bvs[bv.Name] = &p.BuildVariants[i]
 		}
 		for i, t := range p.Tasks {
-			if _, ok := tasks[t.Name]; ok {
-				catcher.Add(errors.Errorf("found duplicate task (%s)", t.Name))
-			} else {
+			if _, ok := tasks[t.Name]; !ok {
 				tasks[t.Name] = &p.Tasks[i]
 			}
 		}
 		for f, val := range p.Functions {
-			if _, ok := functions[f]; ok {
-				catcher.Add(errors.Errorf("found duplicate function (%s)", f))
-			}
 			functions[f] = val
 		}
 		for i, tg := range p.TaskGroups {
-			if _, ok := taskGroups[tg.Name]; ok {
-				catcher.Add(errors.Errorf("found duplicate task group (%s)", tg.Name))
-			} else {
+			if _, ok := taskGroups[tg.Name]; !ok {
 				taskGroups[tg.Name] = &p.TaskGroups[i]
 			}
 		}

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -826,7 +826,8 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 
 func (s *GenerateSuite) TestMergeGeneratedProjectsWithNoTasks() {
 	projects := []GeneratedProject{smallGeneratedProject}
-	merged := MergeGeneratedProjects(projects)
+	merged, err := MergeGeneratedProjects(projects)
+	s.Require().NoError(err)
 	s.Require().NotNil(merged)
 	s.Require().Len(merged.BuildVariants, 1)
 	s.Len(merged.BuildVariants[0].DisplayTasks, 1)

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -97,7 +97,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	})
 	start = time.Now()
 
-	g := model.MergeGeneratedProjects(projects)
+	g, err := model.MergeGeneratedProjects(projects)
 	grip.Debug(message.Fields{
 		"message":       "generate.tasks timing",
 		"function":      "generate",
@@ -107,6 +107,9 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		"job":           j.ID(),
 		"version":       t.Version,
 	})
+	if err != nil {
+		return errors.Wrap(err, "error merging generated projects")
+	}
 	start = time.Now()
 	g.TaskID = j.TaskID
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7804

The errors are accumulated but never used. Alternatively, if we think this actually requires error handling, we could just return/log the error.