### PR TITLE
EVG-7921 add timestamp

### DIFF
--- a/service/ui_plugin_build_baron.go
+++ b/service/ui_plugin_build_baron.go
@@ -336,7 +336,8 @@ func (uis *UIServer) bbFileTicket(w http.ResponseWriter, r *http.Request) {
 		gimlet.WriteJSONInternalError(w, err.Error())
 		return
 	}
-	err = uis.queue.Put(r.Context(), units.NewEventNotificationJob(n.ID))
+	ts := utility.RoundPartOfMinute(1).Format(units.TSFormat)
+	err = uis.queue.Put(r.Context(), units.NewEventNotificationJob(n.ID, ts))
 	if err != nil {
 		gimlet.WriteJSONInternalError(w, fmt.Sprintf("error inserting notification job: %s", err.Error()))
 		return

--- a/units/event_metajob.go
+++ b/units/event_metajob.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/evergreen/trigger"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
@@ -238,7 +239,8 @@ func (j *eventMetaJob) dispatch(ctx context.Context, notifications []notificatio
 	catcher := grip.NewBasicCatcher()
 	for i := range notifications {
 		if notificationIsEnabled(j.flags, &notifications[i]) {
-			if err := j.q.Put(ctx, NewEventNotificationJob(notifications[i].ID)); !amboy.IsDuplicateJobError(err) {
+			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
+			if err := j.q.Put(ctx, NewEventNotificationJob(notifications[i].ID, ts)); !amboy.IsDuplicateJobError(err) {
 				catcher.Add(err)
 			}
 		} else {

--- a/units/event_send.go
+++ b/units/event_send.go
@@ -49,11 +49,11 @@ func makeEventNotificationJob() *eventNotificationJob {
 	return j
 }
 
-func NewEventNotificationJob(id string) amboy.Job {
+func NewEventNotificationJob(id, ts string) amboy.Job {
 	j := makeEventNotificationJob()
 	j.NotificationID = id
 
-	j.SetID(fmt.Sprintf("%s:%s", eventNotificationJobName, id))
+	j.SetID(fmt.Sprintf("%s:%s:%s", eventNotificationJobName, id, ts))
 	return j
 }
 

--- a/units/event_send_test.go
+++ b/units/event_send_test.go
@@ -187,7 +187,7 @@ func (s *eventNotificationSuite) TestDegradedMode() {
 	s.NoError(flags.Set())
 
 	for i := range s.notifications {
-		job := NewEventNotificationJob(s.notifications[i].ID).(*eventNotificationJob)
+		job := NewEventNotificationJob(s.notifications[i].ID, "").(*eventNotificationJob)
 		job.env = evergreen.GetEnvironment()
 
 		job.Run(s.ctx)
@@ -198,7 +198,7 @@ func (s *eventNotificationSuite) TestDegradedMode() {
 }
 
 func (s *eventNotificationSuite) TestEvergreenWebhook() {
-	job := NewEventNotificationJob(s.webhook.ID).(*eventNotificationJob)
+	job := NewEventNotificationJob(s.webhook.ID, "").(*eventNotificationJob)
 	job.env = s.env
 
 	job.Run(s.ctx)
@@ -215,7 +215,7 @@ func (s *eventNotificationSuite) TestEvergreenWebhook() {
 }
 
 func (s *eventNotificationSuite) TestSlack() {
-	job := NewEventNotificationJob(s.slack.ID).(*eventNotificationJob)
+	job := NewEventNotificationJob(s.slack.ID, "").(*eventNotificationJob)
 	job.env = s.env
 	job.Run(s.ctx)
 
@@ -233,7 +233,7 @@ func (s *eventNotificationSuite) TestSlack() {
 }
 
 func (s *eventNotificationSuite) TestJIRAComment() {
-	job := NewEventNotificationJob(s.jiraComment.ID).(*eventNotificationJob)
+	job := NewEventNotificationJob(s.jiraComment.ID, "").(*eventNotificationJob)
 	job.env = s.env
 	job.Run(s.ctx)
 
@@ -250,7 +250,7 @@ func (s *eventNotificationSuite) TestJIRAComment() {
 }
 
 func (s *eventNotificationSuite) TestJIRAIssue() {
-	job := NewEventNotificationJob(s.jiraIssue.ID).(*eventNotificationJob)
+	job := NewEventNotificationJob(s.jiraIssue.ID, "").(*eventNotificationJob)
 	job.env = s.env
 	job.Run(s.ctx)
 
@@ -276,7 +276,7 @@ func (s *eventNotificationSuite) TestSendFailureResultsInNoMessages() {
 		n[i].Payload = nil
 		s.NoError(notification.InsertMany(n[i]))
 
-		job := NewEventNotificationJob(n[i].ID).(*eventNotificationJob)
+		job := NewEventNotificationJob(n[i].ID, "").(*eventNotificationJob)
 		job.env = s.env
 		job.Run(s.ctx)
 		s.Error(job.Error())


### PR DESCRIPTION
#2774 added a step to the event-metajob to catch unprocessed notifications and enqueue a new job for them, but the id of the new job collides with the original so it's not inserted. 

Add a timestamp to the job ID.