### PR TITLE
EVG-7190 standardize commit queue patch descriptions

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-05-01"
+	ClientVersion = "2020-05-04"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-04-27"

--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-04-27"
+	ClientVersion = "2020-05-01"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-04-27"

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -427,6 +427,7 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 	}
 	commits := fmt.Sprintf(commitFmtString, commitMessages, owner, repo, module.Branch)
 	message := fmt.Sprintf("%s || %s", patch.Description, commits)
+	// replace the description if the original patch was empty
 	if strings.HasSuffix(patch.Description, noCommits) {
 		message = fmt.Sprintf("%s %s", commitQueuePatchLabel, commits)
 	}

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/rest/client"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -17,10 +19,13 @@ import (
 )
 
 const (
-	itemFlagName    = "item"
-	pauseFlagName   = "pause"
-	resumeFlagName  = "resume"
-	commitsFlagName = "commits"
+	itemFlagName          = "item"
+	pauseFlagName         = "pause"
+	resumeFlagName        = "resume"
+	commitsFlagName       = "commits"
+	noCommits             = "No Commits Added"
+	commitQueuePatchLabel = "Commit Queue Merge:"
+	commitFmtString       = "'%s' into '%s/%s:%s'"
 )
 
 func CommitQueue() cli.Command {
@@ -351,12 +356,16 @@ func (p *mergeParams) uploadMergePatch(conf *ClientSettings, ac *legacyClient) e
 		return errors.Wrap(err, "can't generate patches")
 	}
 
+	commits := noCommits
 	if commitCount > 0 {
-		patchParams.Description, err = gitCommitMessages(ref.Branch, p.ref, p.commits)
+		var commitMessages string
+		commitMessages, err = gitCommitMessages(ref.Branch, p.ref, p.commits)
 		if err != nil {
 			return errors.Wrap(err, "can't get commit messages")
 		}
+		commits = fmt.Sprintf(commitFmtString, commitMessages, ref.Owner, ref.Repo, ref.Branch)
 	}
+	patchParams.Description = fmt.Sprintf("%s %s", commitQueuePatchLabel, commits)
 
 	patch, err := patchParams.createPatch(ac, conf, diffData)
 	if err != nil {
@@ -378,6 +387,10 @@ type moduleParams struct {
 }
 
 func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
+	if err := isValidCommitsFormat(p.commits); err != nil {
+		return err
+	}
+
 	proj, err := rc.GetPatchedConfig(p.patchID)
 	if err != nil {
 		return err
@@ -398,21 +411,24 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 		return errors.New("module patch aborted")
 	}
 
+	owner, repo, err := thirdparty.ParseGitUrl(module.Repo)
+	if err != nil {
+		return errors.Wrapf(err, "can't get owner/repo from '%s'", module.Repo)
+	}
+
 	patch, err := rc.GetPatch(p.patchID)
 	if err != nil {
 		return errors.Wrapf(err, "can't get patch '%s'", p.patchID)
 	}
 
-	if err = isValidCommitsFormat(p.commits); err != nil {
-		return err
+	commitMessages, err := gitCommitMessages(module.Branch, p.ref, p.commits)
+	if err != nil {
+		return errors.Wrap(err, "can't get module commit messages")
 	}
-
-	message := ""
-	if patch.Description == "" {
-		message, err = gitCommitMessages(module.Branch, p.ref, p.commits)
-		if err != nil {
-			return errors.Wrap(err, "can't get module commit messages")
-		}
+	commits := fmt.Sprintf(commitFmtString, commitMessages, owner, repo, module.Branch)
+	message := fmt.Sprintf("%s || %s", patch.Description, commits)
+	if strings.HasSuffix(patch.Description, noCommits) {
+		message = fmt.Sprintf("%s %s", commitQueuePatchLabel, commits)
 	}
 
 	diffData, err := loadGitData(module.Branch, p.ref, p.commits, true)

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -441,6 +441,7 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 
 	if !p.skipConfirm {
 		grip.InfoWhen(diffData.patchSummary != "", diffData.patchSummary)
+		grip.InfoWhen(diffData.log != "", diffData.log)
 		if !confirm("This is a summary of the patch to be submitted. Continue? (y/n):", true) {
 			return nil
 		}


### PR DESCRIPTION
Give every commit queue patch a label to make it clear which patches are for the commit queue.

For example:
```
Commit Queue Merge: 'SERVER-12345 message' into 'mongodb/mongo:master'
```
This was originally the intention of #3047 but needed to wait for the changes to pass commit queue validation. https://github.com/mongodb/mongo/commit/09b9e9316877084501db453d08510345465a6770 added this format so both the new and old formats pass validation.