### PR TITLE
EVG-7682: Remove patchNumber field from Task gql type

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -265,6 +265,7 @@ type ComplexityRoot struct {
 		Logs              func(childComplexity int) int
 		Order             func(childComplexity int) int
 		PatchMetadata     func(childComplexity int) int
+		PatchNumber       func(childComplexity int) int
 		Priority          func(childComplexity int) int
 		ProjectId         func(childComplexity int) int
 		ReliesOn          func(childComplexity int) int
@@ -402,6 +403,8 @@ type TaskResolver interface {
 	PatchMetadata(ctx context.Context, obj *model.APITask) (*PatchMetadata, error)
 
 	ReliesOn(ctx context.Context, obj *model.APITask) ([]*Dependency, error)
+
+	PatchNumber(ctx context.Context, obj *model.APITask) (*int, error)
 
 	BaseTaskMetadata(ctx context.Context, obj *model.APITask) (*BaseTaskMetadata, error)
 }
@@ -1489,6 +1492,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Task.PatchMetadata(childComplexity), true
 
+	case "Task.patchNumber":
+		if e.complexity.Task.PatchNumber == nil {
+			break
+		}
+
+		return e.complexity.Task.PatchNumber(childComplexity), true
+
 	case "Task.priority":
 		if e.complexity.Task.Priority == nil {
 			break
@@ -2272,6 +2282,7 @@ type Task {
   restarts: Int
   execution: Int
   order: Int
+  patchNumber: Int
   requester: String!
   status: String!
   details: TaskEndDetail
@@ -7746,6 +7757,37 @@ func (ec *executionContext) _Task_order(ctx context.Context, field graphql.Colle
 	return ec.marshalOInt2int(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Task_patchNumber(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Task",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Task().PatchNumber(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Task_requester(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -12122,6 +12164,17 @@ func (ec *executionContext) _Task(ctx context.Context, sel ast.SelectionSet, obj
 			out.Values[i] = ec._Task_execution(ctx, field, obj)
 		case "order":
 			out.Values[i] = ec._Task_order(ctx, field, obj)
+		case "patchNumber":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Task_patchNumber(ctx, field, obj)
+				return res
+			})
 		case "requester":
 			out.Values[i] = ec._Task_requester(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -265,7 +265,6 @@ type ComplexityRoot struct {
 		Logs              func(childComplexity int) int
 		Order             func(childComplexity int) int
 		PatchMetadata     func(childComplexity int) int
-		PatchNumber       func(childComplexity int) int
 		Priority          func(childComplexity int) int
 		ProjectId         func(childComplexity int) int
 		ReliesOn          func(childComplexity int) int
@@ -404,7 +403,6 @@ type TaskResolver interface {
 
 	ReliesOn(ctx context.Context, obj *model.APITask) ([]*Dependency, error)
 
-	PatchNumber(ctx context.Context, obj *model.APITask) (*int, error)
 	BaseTaskMetadata(ctx context.Context, obj *model.APITask) (*BaseTaskMetadata, error)
 }
 
@@ -1491,13 +1489,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Task.PatchMetadata(childComplexity), true
 
-	case "Task.patchNumber":
-		if e.complexity.Task.PatchNumber == nil {
-			break
-		}
-
-		return e.complexity.Task.PatchNumber(childComplexity), true
-
 	case "Task.priority":
 		if e.complexity.Task.Priority == nil {
 			break
@@ -2291,7 +2282,6 @@ type Task {
   generateTask: Boolean
   generatedBy: String
   aborted: Boolean
-  patchNumber: Int
   baseTaskMetadata: BaseTaskMetadata!
 }
 
@@ -8072,37 +8062,6 @@ func (ec *executionContext) _Task_aborted(ctx context.Context, field graphql.Col
 	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Task_patchNumber(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:   "Task",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Task().PatchNumber(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*int)
-	fc.Result = res
-	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _Task_baseTaskMetadata(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -12189,17 +12148,6 @@ func (ec *executionContext) _Task(ctx context.Context, sel ast.SelectionSet, obj
 			out.Values[i] = ec._Task_generatedBy(ctx, field, obj)
 		case "aborted":
 			out.Values[i] = ec._Task_aborted(ctx, field, obj)
-		case "patchNumber":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Task_patchNumber(ctx, field, obj)
-				return res
-			})
 		case "baseTaskMetadata":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -1749,7 +1749,7 @@
             "hostId": "host",
             "restarts": 5,
             "execution": 5,
-            "order": 5,
+            "patchNumber": 5,
             "requester": "merge_test",
             "status": "started",
             "details": {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -996,14 +996,6 @@ func (r *queryResolver) User(ctx context.Context) (*restModel.APIUser, error) {
 
 type taskResolver struct{ *Resolver }
 
-func (r *taskResolver) PatchNumber(ctx context.Context, obj *restModel.APITask) (*int, error) {
-	patch, err := r.sc.FindPatchById(*obj.Version)
-	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error retrieving patch %s: %s", *obj.Version, err.Error()))
-	}
-	return &patch.PatchNumber, nil
-}
-
 func (r *taskResolver) FailedTestCount(ctx context.Context, obj *restModel.APITask) (int, error) {
 	failedTestCount, err := r.sc.GetTestCountByTaskIdAndFilters(*obj.Id, "", []string{evergreen.TestFailedStatus}, obj.Execution)
 	if err != nil {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1058,6 +1058,11 @@ func (r *taskResolver) SpawnHostLink(ctx context.Context, at *restModel.APITask)
 	return nil, nil
 }
 
+func (r *taskResolver) PatchNumber(ctx context.Context, obj *restModel.APITask) (*int, error) {
+	order := obj.Order
+	return &order, nil
+}
+
 // New injects resources into the resolvers, such as the data connector
 func New(apiURL string) Config {
 	return Config{

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -321,7 +321,6 @@ type Task {
   generateTask: Boolean
   generatedBy: String
   aborted: Boolean
-  patchNumber: Int
   baseTaskMetadata: BaseTaskMetadata!
 }
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -310,7 +310,6 @@ type Task {
   hostLink: String
   restarts: Int
   execution: Int
-  order: Int
   patchNumber: Int
   requester: String!
   status: String!

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -311,6 +311,7 @@ type Task {
   restarts: Int
   execution: Int
   order: Int
+  patchNumber: Int
   requester: String!
   status: String!
   details: TaskEndDetail

--- a/graphql/testdata/task1.graphql
+++ b/graphql/testdata/task1.graphql
@@ -29,7 +29,6 @@
     hostId
     restarts
     execution
-    order
     requester
     status
     details {

--- a/graphql/testdata/task1.graphql
+++ b/graphql/testdata/task1.graphql
@@ -10,6 +10,7 @@
     createTime
     ingestTime
     dispatchTime
+    patchNumber
     scheduledTime
     startTime
     finishTime

--- a/graphql/tests/task/data.json
+++ b/graphql/tests/task/data.json
@@ -192,6 +192,7 @@
   "tasks": [
     {
       "_id": "taskity_task",
+      "order": 2567,
       "version": "5e4ff3abe3c3317e352062e4",
       "host_id": "i-0bb70e2ac4c1a9ac8",
       "depends_on": [

--- a/graphql/tests/task/queries/patchNumber.graphql
+++ b/graphql/tests/task/queries/patchNumber.graphql
@@ -1,6 +1,0 @@
-{
-  task(taskId: "taskity_task") {
-    id
-    patchNumber
-  }
-}

--- a/graphql/tests/task/queries/patchNumber.graphql
+++ b/graphql/tests/task/queries/patchNumber.graphql
@@ -1,0 +1,5 @@
+{
+  task(taskId: "taskity_task") {
+    patchNumber
+  }
+}

--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -1,17 +1,6 @@
 {
   "tests": [
     {
-      "query_file": "patchNumber.graphql",
-      "result": {
-        "data": {
-          "task": {
-            "id": "taskity_task",
-            "patchNumber": 1234
-          }
-        }
-      }
-    },
-    {
       "query_file": "baseTaskMetadata.graphql",
       "result": {
         "data": {

--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -193,6 +193,10 @@
     {
       "query_file": "failedTestCount-no-tests.graphql",
       "result": { "data": { "task": { "failedTestCount": 0 } } }
+    },
+    {
+      "query_file": "patchNumber.graphql",
+      "result": { "data": { "task": { "patchNumber": 2567 } } }
     }
   ]
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7682
Remove the patchNumber field because it represents the same thing as the order field on the Task gql type. https://github.com/evergreen-ci/spruce/pull/155 should be merged before this PR to avoid gql errors in Spruce. 