### PR TITLE
EVG-7882 set revision in modify project route

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -713,6 +713,17 @@ func (p *ProjectRef) getBatchTime(variant *BuildVariant) int {
 	}
 }
 
+func (p *ProjectRef) UpdateRevisionForProject(revision string) error {
+	// update the latest revision to be the revision id
+	if err := UpdateLastRevision(p.Identifier, revision); err != nil {
+		return errors.Wrapf(err, "error updating last revision to '%s'", revision)
+	}
+	p.RepotrackerError.Exists = false
+	p.RepotrackerError.InvalidRevision = ""
+	p.RepotrackerError.MergeBaseRevision = ""
+	return errors.Wrapf(p.Update(), "error updating project '%s'", p.Identifier)
+}
+
 // return the next valid batch time
 func GetActivationTimeWithCron(curTime time.Time, cronBatchTime string) (time.Time, error) {
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -975,6 +975,10 @@ func (p *ProjectRef) UpdateNextPeriodicBuild(definition string, nextRun time.Tim
 	return db.Update(ProjectRefCollection, filter, update)
 }
 
+func (p *ProjectRef) HasRepotrackerError() bool {
+	return p.RepotrackerError != nil && p.RepotrackerError.Exists
+}
+
 func (t TriggerDefinition) Validate(parentProject string) error {
 	upstreamProject, err := FindOneProjectRef(t.Project)
 	if err != nil {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -975,10 +975,6 @@ func (p *ProjectRef) UpdateNextPeriodicBuild(definition string, nextRun time.Tim
 	return db.Update(ProjectRefCollection, filter, update)
 }
 
-func (p *ProjectRef) HasRepotrackerError() bool {
-	return p.RepotrackerError != nil && p.RepotrackerError.Exists
-}
-
 func (t TriggerDefinition) Validate(parentProject string) error {
 	upstreamProject, err := FindOneProjectRef(t.Project)
 	if err != nil {

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -217,7 +217,6 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 			if err = gRepoPoller.ProjectRef.UpdateRevisionForProject(baseRevision); err != nil {
 				return []model.Revision{}, errors.Wrapf(err, "error updating revision to '%s' for project", baseRevision)
 			}
-			revisionError = nil
 			grip.Info(message.Fields{
 				"source":        "github poller",
 				"message":       "set new revision",

--- a/repotracker/github_poller_test.go
+++ b/repotracker/github_poller_test.go
@@ -128,7 +128,7 @@ func TestGetRevisionsSinceWithPaging(t *testing.T) {
 			distantEvgRevision, err := getDistantEVGRevision()
 			So(err, ShouldBeNil)
 			So(distantEvgRevision, ShouldNotEqual, "")
-			revisions, err := grp.GetRevisionsSince(distantEvgRevision, 5000)
+			revisions, err := grp.GetRevisionsSince(distantEvgRevision, 5000, false)
 			So(err, ShouldBeNil)
 			Convey("and the revision should be found", func() {
 				So(len(revisions), ShouldNotEqual, 0)
@@ -155,7 +155,7 @@ func TestGetRevisionsSince(t *testing.T) {
 				// The test repository contains only 3 revisions with revision
 				// 99162ee5bc41eb314f5bb01bd12f0c43e9cb5f32 being the first
 				// revision
-				revisions, err := self.GetRevisionsSince(firstRevision, 10)
+				revisions, err := self.GetRevisionsSince(firstRevision, 10, false)
 				require.NoError(t, err, "Error fetching github revisions")
 				So(len(revisions), ShouldEqual, 2)
 
@@ -173,7 +173,7 @@ func TestGetRevisionsSince(t *testing.T) {
 		Convey("There should be no revisions since the last revision", func() {
 			// The test repository contains only 3 revisions with revision
 			// d0d878e81b303fd2abbf09331e54af41d6cd0c7d being the last revision
-			revisions, err := self.GetRevisionsSince(lastRevision, 10)
+			revisions, err := self.GetRevisionsSince(lastRevision, 1, false)
 			require.NoError(t, err, "Error fetching github revisions")
 			So(len(revisions), ShouldEqual, 0)
 		})
@@ -182,12 +182,12 @@ func TestGetRevisionsSince(t *testing.T) {
 			"isn't found", func() {
 			// The test repository contains only 3 revisions with revision
 			// d0d878e81b303fd2abbf09331e54af41d6cd0c7d being the last revision
-			revisions, err := self.GetRevisionsSince("lastRevision", 10)
+			revisions, err := self.GetRevisionsSince("lastRevision", 10, false)
 			So(len(revisions), ShouldEqual, 0)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("If the revision is not valid because it has less than 10 characters, should return an error", func() {
-			_, err := self.GetRevisionsSince("master", 10)
+			_, err := self.GetRevisionsSince("master", 10, false)
 			So(err, ShouldNotBeNil)
 		})
 	})

--- a/repotracker/mock_poller.go
+++ b/repotracker/mock_poller.go
@@ -61,8 +61,12 @@ func (d *mockRepoPoller) GetRemoteConfig(_ context.Context, revision string) (*m
 	return p, d.parserProject, nil
 }
 
-func (d *mockRepoPoller) GetRevisionsSince(revision string, maxRevisionsToSearch int) ([]model.Revision, error) {
-	if d.nextError != nil {
+func (d *mockRepoPoller) GetRevisionsSince(revision string, maxRevisionsToSearch int, setRevision bool) ([]model.Revision, error) {
+	if setRevision {
+		if d.nextError != nil {
+			_ = d.clearError()
+		}
+	} else if d.nextError != nil {
 		return nil, d.clearError()
 	}
 	return d.revisions, nil

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -40,6 +40,7 @@ const (
 type RepoTracker struct {
 	*evergreen.Settings
 	*model.ProjectRef
+	SetRevision bool
 	RepoPoller
 }
 
@@ -90,7 +91,7 @@ type RepoPoller interface {
 	// allow to search through - in order to find 'revision' - before we give
 	// up. A value <= 0 implies we allow to search through till we hit the first
 	// revision for the project.
-	GetRevisionsSince(sinceRevision string, maxRevisions int) ([]model.Revision, error)
+	GetRevisionsSince(sinceRevision string, maxRevisions int, setRevision bool) ([]model.Revision, error)
 	// Fetches the most recent 'numNewRepoRevisionsToFetch' revisions for a
 	// project - with the most recent revision appearing as the first element in
 	// the slice.
@@ -175,7 +176,7 @@ func (repoTracker *RepoTracker) FetchRevisions(ctx context.Context) error {
 		if max <= 0 {
 			max = DefaultMaxRepoRevisionsToSearch
 		}
-		revisions, err = repoTracker.GetRevisionsSince(lastRevision, max)
+		revisions, err = repoTracker.GetRevisionsSince(lastRevision, max, repoTracker.SetRevision)
 	}
 
 	if err != nil {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -160,14 +160,16 @@ func (repoTracker *RepoTracker) FetchRevisions(ctx context.Context) error {
 			"revision": lastRevision,
 		})
 		// if the projectRef has a repotracker error then don't get the revisions
-		if projectRef.HasRepotrackerError() {
-			grip.Warning(message.Fields{
-				"runner":  RunnerName,
-				"message": "repotracker error for base revision",
-				"project": projectRef,
-				"path":    fmt.Sprintf("%s/%s:%s", projectRef.Owner, projectRef.Repo, projectRef.Branch),
-			})
-			return nil
+		if projectRef.RepotrackerError != nil {
+			if projectRef.RepotrackerError.Exists {
+				grip.Warning(message.Fields{
+					"runner":  RunnerName,
+					"message": "repotracker error for base revision",
+					"project": projectRef,
+					"path":    fmt.Sprintf("%s/%s:%s", projectRef.Owner, projectRef.Repo, projectRef.Branch),
+				})
+				return nil
+			}
 		}
 		max := settings.RepoTracker.MaxRepoRevisionsToSearch
 		if max <= 0 {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -160,16 +160,14 @@ func (repoTracker *RepoTracker) FetchRevisions(ctx context.Context) error {
 			"revision": lastRevision,
 		})
 		// if the projectRef has a repotracker error then don't get the revisions
-		if projectRef.RepotrackerError != nil {
-			if projectRef.RepotrackerError.Exists {
-				grip.Warning(message.Fields{
-					"runner":  RunnerName,
-					"message": "repotracker error for base revision",
-					"project": projectRef,
-					"path":    fmt.Sprintf("%s/%s:%s", projectRef.Owner, projectRef.Repo, projectRef.Branch),
-				})
-				return nil
-			}
+		if projectRef.HasRepotrackerError() {
+			grip.Warning(message.Fields{
+				"runner":  RunnerName,
+				"message": "repotracker error for base revision",
+				"project": projectRef,
+				"path":    fmt.Sprintf("%s/%s:%s", projectRef.Owner, projectRef.Repo, projectRef.Branch),
+			})
+			return nil
 		}
 		max := settings.RepoTracker.MaxRepoRevisionsToSearch
 		if max <= 0 {

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -36,9 +36,9 @@ func TestFetchRevisions(t *testing.T) {
 		resetProjectRefs()
 
 		repoTracker := RepoTracker{
-			testConfig,
-			evgProjectRef,
-			NewGithubRepositoryPoller(evgProjectRef, token),
+			Settings:   testConfig,
+			ProjectRef: evgProjectRef,
+			RepoPoller: NewGithubRepositoryPoller(evgProjectRef, token),
 		}
 
 		Convey("Fetching commits from the repository should not return any errors", func() {
@@ -80,7 +80,11 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 		So(err, ShouldBeNil)
 		token, err := testConfig.GetGithubOauthToken()
 		So(err, ShouldBeNil)
-		repoTracker := RepoTracker{testConfig, evgProjectRef, NewGithubRepositoryPoller(evgProjectRef, token)}
+		repoTracker := RepoTracker{
+			Settings:   testConfig,
+			ProjectRef: evgProjectRef,
+			RepoPoller: NewGithubRepositoryPoller(evgProjectRef, token),
+		}
 
 		// insert distros used in testing.
 		d := distro.Distro{Id: "test-distro-one"}
@@ -171,12 +175,12 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 		poller := NewMockRepoPoller(project, revisions)
 
 		repoTracker := RepoTracker{
-			testConfig,
-			&model.ProjectRef{
+			Settings: testConfig,
+			ProjectRef: &model.ProjectRef{
 				Identifier: "testproject",
 				BatchTime:  10,
 			},
-			poller,
+			RepoPoller: poller,
 		}
 
 		// insert distros used in testing.
@@ -292,12 +296,12 @@ func TestBatchTimes(t *testing.T) {
 			}
 
 			repoTracker := RepoTracker{
-				testConfig,
-				&model.ProjectRef{
+				Settings: testConfig,
+				ProjectRef: &model.ProjectRef{
 					Identifier: "testproject",
 					BatchTime:  1,
 				},
-				NewMockRepoPoller(project, revisions),
+				RepoPoller: NewMockRepoPoller(project, revisions),
 			}
 			err := repoTracker.StoreRevisions(ctx, revisions)
 			So(err, ShouldBeNil)
@@ -317,12 +321,12 @@ func TestBatchTimes(t *testing.T) {
 				*createTestRevision("bar", time.Now().Add(-6*time.Minute)),
 			}
 			repoTracker := RepoTracker{
-				testConfig,
-				&model.ProjectRef{
+				Settings: testConfig,
+				ProjectRef: &model.ProjectRef{
 					Identifier: "testproject",
 					BatchTime:  0,
 				},
-				NewMockRepoPoller(project, revisions),
+				RepoPoller: NewMockRepoPoller(project, revisions),
 			}
 			err := repoTracker.StoreRevisions(ctx, revisions)
 			So(err, ShouldBeNil)
@@ -352,12 +356,12 @@ func TestBatchTimes(t *testing.T) {
 			}
 
 			repoTracker := RepoTracker{
-				testConfig,
-				&model.ProjectRef{
+				Settings: testConfig,
+				ProjectRef: &model.ProjectRef{
 					Identifier: "testproject",
 					BatchTime:  60,
 				},
-				NewMockRepoPoller(project, revisions),
+				RepoPoller: NewMockRepoPoller(project, revisions),
 			}
 			err := repoTracker.StoreRevisions(ctx, revisions)
 			So(err, ShouldBeNil)
@@ -385,12 +389,12 @@ func TestBatchTimes(t *testing.T) {
 			}
 
 			repoTracker := RepoTracker{
-				testConfig,
-				&model.ProjectRef{
+				Settings: testConfig,
+				ProjectRef: &model.ProjectRef{
 					Identifier: "testproject",
 					BatchTime:  60,
 				},
-				NewMockRepoPoller(project, revisions),
+				RepoPoller: NewMockRepoPoller(project, revisions),
 			}
 			err := repoTracker.StoreRevisions(ctx, revisions)
 			So(err, ShouldBeNil)
@@ -439,12 +443,12 @@ func TestBatchTimes(t *testing.T) {
 			*createTestRevision("garply", time.Now()),
 		}
 		repoTracker := RepoTracker{
-			testConfig,
-			&model.ProjectRef{
+			Settings: testConfig,
+			ProjectRef: &model.ProjectRef{
 				Identifier: "testproject",
 				BatchTime:  60,
 			},
-			NewMockRepoPoller(project, revisions),
+			RepoPoller: NewMockRepoPoller(project, revisions),
 		}
 		err := repoTracker.StoreRevisions(ctx, revisions)
 		So(err, ShouldBeNil)

--- a/repotracker/wrappers.go
+++ b/repotracker/wrappers.go
@@ -20,7 +20,7 @@ const (
 	githubAPILimitCeiling = 20
 )
 
-func getTracker(conf *evergreen.Settings, project model.ProjectRef) (*RepoTracker, error) {
+func getTracker(conf *evergreen.Settings, project model.ProjectRef, setRevision bool) (*RepoTracker, error) {
 	token, err := conf.GetGithubOauthToken()
 	if err != nil {
 		grip.Warning(message.Fields{
@@ -31,20 +31,21 @@ func getTracker(conf *evergreen.Settings, project model.ProjectRef) (*RepoTracke
 	}
 
 	tracker := &RepoTracker{
-		Settings:   conf,
-		ProjectRef: &project,
-		RepoPoller: NewGithubRepositoryPoller(&project, token),
+		Settings:    conf,
+		SetRevision: setRevision,
+		ProjectRef:  &project,
+		RepoPoller:  NewGithubRepositoryPoller(&project, token),
 	}
 
 	return tracker, nil
 }
 
-func CollectRevisionsForProject(ctx context.Context, conf *evergreen.Settings, project model.ProjectRef) error {
+func CollectRevisionsForProject(ctx context.Context, conf *evergreen.Settings, project model.ProjectRef, setRevision bool) error {
 	if !project.Enabled || project.RepotrackerDisabled {
 		return errors.Errorf("project disabled: %s", project.Identifier)
 	}
 
-	tracker, err := getTracker(conf, project)
+	tracker, err := getTracker(conf, project, setRevision)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"project": project.Identifier,

--- a/rest/data/repotracker.go
+++ b/rest/data/repotracker.go
@@ -90,7 +90,7 @@ func (c *RepoTrackerConnector) TriggerRepotracker(q amboy.Queue, msgID string, e
 			continue
 		}
 
-		job := units.NewRepotrackerJob(fmt.Sprintf("github-push-%s", msgID), refs[i].Identifier)
+		job := units.NewRepotrackerJob(fmt.Sprintf("github-push-%s", msgID), refs[i].Identifier, false)
 		job.SetPriority(1)
 
 		if err := q.Put(context.TODO(), job); err != nil {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -379,6 +379,23 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	newRevision := model.FromStringPtr(requestProjectRef.Revision)
+	// user didn't provide updated revision, but we should still update if branch has changed
+	if newRevision == "" && newProjectRef.Branch != oldProject.Branch && !newProjectRef.HasRepotrackerError() {
+		ts := utility.RoundPartOfHour(1).Format(units.TSFormat)
+		units.NewRepotrackerJob(fmt.Sprintf("catchup-%s", ts), h.projectID).Run(ctx)
+		projectWithRevision, err := h.sc.FindProjectById(h.projectID)
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "Database error checking project for new revision"))
+		}
+		if projectWithRevision.HasRepotrackerError() {
+			// if we've found a new merge base revision, set this automatically
+			if projectWithRevision.RepotrackerError.MergeBaseRevision != "" {
+				newRevision = projectWithRevision.RepotrackerError.MergeBaseRevision
+			} else {
+				return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "error checking for new revision, may have to include in request"))
+			}
+		}
+	}
 	if newRevision != "" {
 		if err = h.sc.UpdateProjectRevision(h.projectID, newRevision); err != nil {
 			return gimlet.MakeJSONErrorResponder(err)

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -431,7 +431,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	// run the repotracker for the project
 	if newRevision != "" {
 		ts := utility.RoundPartOfHour(1).Format(units.TSFormat)
-		j := units.NewRepotrackerJob(fmt.Sprintf("catchup-%s", ts), h.projectID)
+		j := units.NewRepotrackerJob(fmt.Sprintf("catchup-%s", ts), h.projectID, true)
 
 		queue := evergreen.GetEnvironment().RemoteQueue()
 		if err = queue.Put(ctx, j); err != nil {

--- a/units/crons.go
+++ b/units/crons.go
@@ -69,7 +69,7 @@ func PopulateCatchupJobs(part int) amboy.QueueOperation {
 			}
 
 			if mostRecentVersion.CreateTime.Before(time.Now().Add(-2 * time.Hour)) {
-				j := NewRepotrackerJob(fmt.Sprintf("catchup-%s", ts), proj.Identifier)
+				j := NewRepotrackerJob(fmt.Sprintf("catchup-%s", ts), proj.Identifier, false)
 				j.SetPriority(-1)
 				catcher.Add(queue.Put(ctx, j))
 			}
@@ -108,7 +108,7 @@ func PopulateRepotrackerPollingJobs(part int) amboy.QueueOperation {
 				continue
 			}
 
-			j := NewRepotrackerJob(fmt.Sprintf("polling-%s", ts), proj.Identifier)
+			j := NewRepotrackerJob(fmt.Sprintf("polling-%s", ts), proj.Identifier, false)
 			j.SetPriority(-1)
 			catcher.Add(queue.Put(ctx, j))
 		}

--- a/units/repotracker_test.go
+++ b/units/repotracker_test.go
@@ -27,7 +27,7 @@ func (s *repotrackerJobSuite) TearDownTest() {
 }
 
 func (s *repotrackerJobSuite) TestJob() {
-	j := NewRepotrackerJob("1", "mci").(*repotrackerJob)
+	j := NewRepotrackerJob("1", "mci", false).(*repotrackerJob)
 	s.Equal("mci", j.ProjectID)
 	s.Equal("repotracker:1:mci", j.ID())
 	j.Run(context.Background())
@@ -42,7 +42,7 @@ func (s *repotrackerJobSuite) TestRunFailsInDegradedMode() {
 	}
 	s.NoError(evergreen.SetServiceFlags(flags))
 
-	job := NewRepotrackerJob("1", "mci")
+	job := NewRepotrackerJob("1", "mci", false)
 	job.Run(context.Background())
 
 	s.Error(job.Error())


### PR DESCRIPTION
My concern with this is that the repotracker job needs to Run in the route, which may be too much to expect?

I think the alternative would be to create a new route, similar to the UI route /repo_revision-- a user who knows they might want to set a new commit would make this API call after they patched the project.

Then again, you couldn't run the update route immediately after the modify project route, because you'd need the repotracker to have run, so this might be hacky too.