### PR TITLE
EVG-7938 refresh link after creating host

### DIFF
--- a/public/static/js/spawned_hosts.js
+++ b/public/static/js/spawned_hosts.js
@@ -484,7 +484,8 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
       mciSpawnRestService.spawnHost(
         $scope.spawnInfo, {}, {
           success: function (resp) {
-            $window.location.reload();
+            window.location.href = "/spawn";
+            $scope.setResourceType("hosts");
           },
           error: function (resp) {
             $scope.spawnReqSent = false;
@@ -499,7 +500,8 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
       mciSpawnRestService.createVolume(
         $scope.createVolumeInfo, {}, {
           success: function (resp) {
-            $window.location.reload();
+              window.location.href = "/spawn";
+              $scope.setResourceType("volumes");
           },
           error: function (resp) {
               $scope.volumeReqSent = false;

--- a/public/static/js/spawned_hosts.js
+++ b/public/static/js/spawned_hosts.js
@@ -484,7 +484,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
       mciSpawnRestService.spawnHost(
         $scope.spawnInfo, {}, {
           success: function (resp) {
-            window.location.href = "/spawn";
+            $window.location.href = "/spawn";
             $scope.setResourceType("hosts");
           },
           error: function (resp) {
@@ -500,7 +500,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
       mciSpawnRestService.createVolume(
         $scope.createVolumeInfo, {}, {
           success: function (resp) {
-              window.location.href = "/spawn";
+              $window.location.href = "/spawn";
               $scope.setResourceType("volumes");
           },
           error: function (resp) {

--- a/public/static/js/spawned_hosts.js
+++ b/public/static/js/spawned_hosts.js
@@ -484,8 +484,9 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
       mciSpawnRestService.spawnHost(
         $scope.spawnInfo, {}, {
           success: function (resp) {
+            // we don't use reload here because we need to clear query parameters
+            // in the case of spawning a host from a task
             $window.location.href = "/spawn";
-            $scope.setResourceType("hosts");
           },
           error: function (resp) {
             $scope.spawnReqSent = false;
@@ -500,8 +501,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
       mciSpawnRestService.createVolume(
         $scope.createVolumeInfo, {}, {
           success: function (resp) {
-              $window.location.href = "/spawn";
-              $scope.setResourceType("volumes");
+              $window.location.reload();
           },
           error: function (resp) {
               $scope.volumeReqSent = false;

--- a/public/static/js/spawned_hosts.js
+++ b/public/static/js/spawned_hosts.js
@@ -501,7 +501,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
       mciSpawnRestService.createVolume(
         $scope.createVolumeInfo, {}, {
           success: function (resp) {
-              $window.location.reload();
+            $window.location.reload();
           },
           error: function (resp) {
               $scope.volumeReqSent = false;


### PR DESCRIPTION
I'm a little unclear on what all is going on with window.location, but it looks like if we just do "reload" then we don't refresh the stale data when spawning from task.