### PR TITLE
EVG-7948 fix volume expiration query

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1255,14 +1255,16 @@ func FindDistroForHost(hostID string) (string, error) {
 	return h.Distro.Id, nil
 }
 
-func FindVolumesByUser(userID string) ([]Volume, error) {
+func FindVolumes(query bson.M) ([]Volume, error) {
 	volumes := []Volume{}
-	query := bson.M{
-		VolumeCreatedByKey: userID,
-	}
 	err := db.FindAll(VolumesCollection, query, db.NoProjection, db.NoSort, db.NoSkip, db.NoLimit, &volumes)
 
 	return volumes, err
+}
+
+func FindVolumesByUser(userID string) ([]Volume, error) {
+	query := bson.M{VolumeCreatedByKey: userID}
+	return FindVolumes(query)
 }
 
 type ClientOptions struct {

--- a/model/host/volume.go
+++ b/model/host/volume.go
@@ -3,7 +3,6 @@ package host
 import (
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
@@ -18,7 +17,7 @@ type Volume struct {
 	AvailabilityZone string    `bson:"availability_zone" json:"availability_zone"`
 	Expiration       time.Time `bson:"expiration" json:"expiration"`
 	CreationDate     time.Time `bson:"created_at" json:"created_at"`
-	Host             string    `bson:"host" json:"host"`
+	Host             string    `bson:"host,omitempty" json:"host"`
 }
 
 // Insert a volume into the volumes collection.
@@ -90,42 +89,12 @@ func (v *Volume) SetExpiration(expiration time.Time) error {
 }
 
 func FindVolumesToDelete(expirationTime time.Time) ([]Volume, error) {
-	pipeline := []bson.M{
-		{
-			"$match": bson.M{VolumeExpirationKey: bson.M{"$lte": expirationTime}},
-		},
-		{
-			"$lookup": bson.M{
-				"from":         Collection,
-				"localField":   "_id",
-				"foreignField": "volumes.volume_id",
-				"as":           "hosts",
-			},
-		},
-		{
-			"$project": bson.M{
-				"hosts": bson.M{
-					"$filter": bson.M{
-						"input": "$hosts",
-						"as":    "host",
-						"cond":  bson.M{"$ne": []string{"$$host.status", evergreen.HostTerminated}},
-					},
-				},
-				VolumeExpirationKey: 1,
-			},
-		},
-		{
-			"$match": bson.M{"$expr": bson.M{"$eq": bson.A{bson.M{"$size": "$hosts"}, 0}}},
-		},
+	q := bson.M{
+		VolumeExpirationKey: bson.M{"$lte": expirationTime},
+		VolumeHostKey:       bson.M{"$exists": false},
 	}
 
-	volumes := []Volume{}
-	err := db.Aggregate(VolumesCollection, pipeline, &volumes)
-	if err != nil {
-		return nil, errors.Wrap(err, "can't find volumes to delete")
-	}
-
-	return volumes, nil
+	return FindVolumes(q)
 }
 
 // FindVolumeByID finds a volume by its ID field.

--- a/model/host/volume.go
+++ b/model/host/volume.go
@@ -96,17 +96,22 @@ func FindVolumesToDelete(expirationTime time.Time) ([]Volume, error) {
 		},
 		{
 			"$lookup": bson.M{
-				"from": Collection,
-				"let":  bson.M{"host_id": "$host"},
-				"pipeline": bson.A{
-					bson.M{
-						"$match": bson.M{"$expr": bson.M{"$and": bson.A{
-							bson.M{"$eq": bson.A{"$_id", "$$host_id"}},
-							bson.M{"$ne": bson.A{"$status", evergreen.HostTerminated}},
-						}}},
+				"from":         Collection,
+				"localField":   "_id",
+				"foreignField": "volumes.volume_id",
+				"as":           "hosts",
+			},
+		},
+		{
+			"$project": bson.M{
+				"hosts": bson.M{
+					"$filter": bson.M{
+						"input": "$hosts",
+						"as":    "host",
+						"cond":  bson.M{"$ne": []string{"$$host.status", evergreen.HostTerminated}},
 					},
 				},
-				"as": "hosts",
+				VolumeExpirationKey: 1,
 			},
 		},
 		{

--- a/model/host/volume_test.go
+++ b/model/host/volume_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,35 +14,15 @@ func TestFindVolumesToDelete(t *testing.T) {
 
 	volumes := []Volume{
 		{ID: "v0", Expiration: time.Date(2010, time.December, 10, 23, 0, 0, 0, time.UTC)},
-		{ID: "v1", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
+		{ID: "v1", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), Host: "h0"},
 		{ID: "v2", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
-		{ID: "v3", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
 	}
 	for _, vol := range volumes {
 		require.NoError(t, vol.Insert())
 	}
 
-	hosts := []Host{
-		{
-			Id:      "h0",
-			Status:  evergreen.HostRunning,
-			Volumes: []VolumeAttachment{{VolumeID: "v1"}, {VolumeID: "other"}},
-		},
-		{
-			Id:      "h1",
-			Status:  evergreen.HostTerminated,
-			Volumes: []VolumeAttachment{{VolumeID: "v2"}, {VolumeID: "other"}},
-		},
-	}
-	for _, h := range hosts {
-		require.NoError(t, h.Insert())
-	}
-
 	toDelete, err := FindVolumesToDelete(time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC))
 	assert.NoError(t, err)
-	assert.Len(t, toDelete, 2)
-	expectedVolumeIDs := []string{"v2", "v3"}
-	for _, vol := range toDelete {
-		assert.Contains(t, expectedVolumeIDs, vol.ID)
-	}
+	assert.Len(t, toDelete, 1)
+	assert.Equal(t, "v2", toDelete[0].ID)
 }

--- a/model/host/volume_test.go
+++ b/model/host/volume_test.go
@@ -15,8 +15,8 @@ func TestFindVolumesToDelete(t *testing.T) {
 
 	volumes := []Volume{
 		{ID: "v0", Expiration: time.Date(2010, time.December, 10, 23, 0, 0, 0, time.UTC)},
-		{ID: "v1", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
-		{ID: "v2", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
+		{ID: "v1", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), Host: "h0"},
+		{ID: "v2", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), Host: "h1"},
 		{ID: "v3", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
 	}
 	for _, vol := range volumes {

--- a/model/host/volume_test.go
+++ b/model/host/volume_test.go
@@ -15,8 +15,8 @@ func TestFindVolumesToDelete(t *testing.T) {
 
 	volumes := []Volume{
 		{ID: "v0", Expiration: time.Date(2010, time.December, 10, 23, 0, 0, 0, time.UTC)},
-		{ID: "v1", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), Host: "h0"},
-		{ID: "v2", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), Host: "h1"},
+		{ID: "v1", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
+		{ID: "v2", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
 		{ID: "v3", Expiration: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
 	}
 	for _, vol := range volumes {


### PR DESCRIPTION
The way the query had been written was querying the host collection with an unindexed field (`volumes.volume_id`).
Use the host id in the volume document instead.