### PR TITLE
EVG-7969: duplicate scripting test options struct

### DIFF
--- a/command/attach_artifacts_test.go
+++ b/command/attach_artifacts_test.go
@@ -70,7 +70,7 @@ func (s *ArtifactsSuite) TearDownTest() {
 	s.cancel()
 }
 
-func (s *ArtifactsSuite) TestParseErrorWOrks() {
+func (s *ArtifactsSuite) TestParseErrorWorks() {
 	s.cmd.Files = []string{"foo"}
 
 	s.NoError(s.cmd.ParseParams(map[string]interface{}{}))


### PR DESCRIPTION
This is primarily to avoid having the user specify duration in nanoseconds.