### PR TITLE
EVG-7248 patch string cleanup

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-05-04"
+	ClientVersion = "2020-05-12"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-04-27"

--- a/operations/http.go
+++ b/operations/http.go
@@ -336,12 +336,11 @@ func (ac *legacyClient) UpdatePatchModule(params UpdatePatchModuleParams) error 
 	// Because marshalling a byte slice to JSON will base64 encode it, the patch will be sent over the wire in base64
 	// and non utf-8 characters will be preserved.
 	data := struct {
-		Module      string `json:"module"`
-		PatchBytes  []byte `json:"patch_bytes"`
-		PatchString string `json:"patch"`
-		Githash     string `json:"githash"`
-		Message     string `json:"message"`
-	}{params.module, []byte(params.patch), params.patch, params.base, params.message}
+		Module     string `json:"module"`
+		PatchBytes []byte `json:"patch_bytes"`
+		Githash    string `json:"githash"`
+		Message    string `json:"message"`
+	}{params.module, []byte(params.patch), params.base, params.message}
 
 	rPipe, wPipe := io.Pipe()
 	encoder := json.NewEncoder(wPipe)
@@ -432,7 +431,6 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		Description       string        `json:"desc"`
 		Project           string        `json:"project"`
 		PatchBytes        []byte        `json:"patch_bytes"`
-		PatchString       string        `json:"patch"`
 		Githash           string        `json:"githash"`
 		Alias             string        `json:"alias"`
 		Variants          []string      `json:"buildvariants_new"`
@@ -446,7 +444,6 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		Description:       incomingPatch.description,
 		Project:           incomingPatch.projectId,
 		PatchBytes:        []byte(incomingPatch.patchData),
-		PatchString:       incomingPatch.patchData,
 		Githash:           incomingPatch.base,
 		Alias:             incomingPatch.alias,
 		Variants:          incomingPatch.variants,


### PR DESCRIPTION
https://github.com/evergreen-ci/evergreen/commit/f036124c01bd7de98e2b03e660636d08634a6fe9 added a copy of patches that gets base64 encoded over the wire.
The string version is no longer necessary and now that enough users have updated their CLI it should be okay to remove.