### PR TITLE
EVG-7636 handle bookmarks in trend chart URL

### DIFF
--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -58,7 +58,11 @@ $http.get(templateUrl).success(function(template) {
     var hash = {}
     var locationHash = decodeURIComponent($location.hash());
     if (locationHash.length > 0) {
-      hash = JSON.parse(locationHash)
+      try {
+        hash = JSON.parse(locationHash);
+      } catch (e) {
+        return;
+      }
     }
     if (Object.keys($scope.hiddenGraphs).length > 0) {
       hash.hiddenGraphs = Object.keys($scope.hiddenGraphs)


### PR DESCRIPTION
There are links from the perf BB/discovery pages to specific tests on the trend chart which use the location hash like a normal HTML bookmark. The trend charts separately try to encode state as json within the hash (yuck), and don't handle any other formats. This is a band-aid fix to be able to handle both scenarios