### PR TITLE
EVG-7597 BFG display task logs

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -267,6 +267,8 @@ type TestResult struct {
 	ExitCode  int     `json:"exit_code" bson:"exit_code"`
 	StartTime float64 `json:"start" bson:"start"`
 	EndTime   float64 `json:"end" bson:"end"`
+	TaskID    string  `json:"task_id" bson:"task_id"`
+	Execution int     `json:"execution" bson:"execution"`
 
 	// LogRaw is not saved in the task
 	LogRaw string `json:"log_raw" bson:"log_raw,omitempty"`
@@ -1180,6 +1182,8 @@ func ConvertToOld(in *testresult.TestResult) TestResult {
 		StartTime: in.StartTime,
 		EndTime:   in.EndTime,
 		LogRaw:    in.LogRaw,
+		TaskID:    in.TaskID,
+		Execution: in.Execution,
 	}
 }
 

--- a/trigger/task_jira.go
+++ b/trigger/task_jira.go
@@ -86,6 +86,8 @@ type jiraTestFailure struct {
 	Name       string
 	URL        string
 	HistoryURL string
+	TaskID     string
+	Execution  int
 }
 
 type jiraBuilder struct {
@@ -331,6 +333,8 @@ func (j *jiraBuilder) getDescription() (string, error) {
 				Name:       cleanTestName(test.TestFile),
 				URL:        logURL(test, j.data.UIRoot),
 				HistoryURL: historyURL(j.data.Task, cleanTestName(test.TestFile), j.data.UIRoot),
+				TaskID:     test.TaskID,
+				Execution:  test.Execution,
 			})
 		}
 	}

--- a/trigger/task_jira_test.go
+++ b/trigger/task_jira_test.go
@@ -381,6 +381,19 @@ func TestJIRADescription(t *testing.T) {
 			So(strings.Contains(desc, "http://evergreen.ui/task/t1%21/0"), ShouldBeTrue)
 			So(strings.Contains(desc, "shouldn't be here"), ShouldBeFalse)
 		})
+		Convey("display tasks have links to execution task logs", func() {
+			j.data.Task.DisplayOnly = true
+			j.data.Task.LocalTestResults = []task.TestResult{
+				{TestFile: "test0", Status: evergreen.TestFailedStatus, TaskID: "et0", Execution: 0},
+				{TestFile: "test1", Status: evergreen.TestFailedStatus, TaskID: "et1", Execution: 1},
+				{TestFile: "test2", Status: evergreen.TestFailedStatus, TaskID: "et1", Execution: 1},
+			}
+
+			desc, err := j.getDescription()
+			So(err, ShouldBeNil)
+			So(strings.Contains(desc, "[Task Logs (test0) | http://evergreen.ui/task_log_raw/et0/0?type=T]"), ShouldBeTrue)
+			So(strings.Contains(desc, "[Task Logs (test1 test2) | http://evergreen.ui/task_log_raw/et1/1?type=T]"), ShouldBeTrue)
+		})
 	})
 }
 


### PR DESCRIPTION
The link to task logs stopped working when failing execution tasks were grouped together in one BFG (#3281) since the link points to the display task's (inexistent) logs.

This PR will change the links for display task BFGs to look like this:
```
Task Logs (test1 test2)
Task Logs (test3 test4)
```
Grouping tests by execution task will also make it easier to identify when a task went off the rails and caused its tests to fail.