### PR TITLE
EVG-7623 remove strict user validation in github webhook

### DIFF
--- a/model/repository.go
+++ b/model/repository.go
@@ -49,9 +49,8 @@ type Revision struct {
 }
 
 type GitTag struct {
-	Tag             string
-	Pusher          string
-	PusherGithubUID int
+	Tag    string
+	Pusher string
 }
 
 // FindRepository gets the repository object of a project.


### PR DESCRIPTION
From [this panic](https://mongodb.slack.com/archives/C866SR2LR/p1589469424008500), the nil interface problem has come back to haunt us.

However, from [splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20%22adding%20tag%20to%20version%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=1589428800&latest=1589515200&sid=1589470641.2161980), the pusher of these tags might be legitimate bots (for example, mms-build-account), so I think we want to remove this strict validation so these tags can still show on the waterfall. Potentially we could still make Authorized Users strictly limited to real users and not bots, but I think it's okay to allow that flexibility.