### PR TITLE
EVG-7962: hide task sync text if disabled

### DIFF
--- a/public/static/partials/user_host_options.html
+++ b/public/static/partials/user_host_options.html
@@ -136,8 +136,10 @@
       <input type="checkbox" ng-disabled="$parent.isVirtualWorkstation" ng-model="$parent.spawnTaskChecked" />
         Load data for <strong>[[spawnTask.display_name]]</strong> on <strong>[[spawnTask.build_variant]]</strong> @ <strong class="mono">[[spawnTask.gitspec | limitTo:5]]</strong> onto host at startup
       <br/>
-      <input type="checkbox" ng-show="spawnTask.can_sync" ng-disabled="$parent.isVirtualWorkstation || !spawnTask.can_sync || !$parent.spawnTaskChecked" ng-model="$parent.spawnTaskSyncChecked" />
+      <div ng-show="spawnTask.can_sync">
+      <input type="checkbox" ng-disabled="$parent.isVirtualWorkstation || !spawnTask.can_sync || !$parent.spawnTaskChecked" ng-model="$parent.spawnTaskSyncChecked" />
         Load from task sync
+      </div>
       <br/>
       <input type="checkbox" ng-disabled="$parent.isVirtualWorkstation" ng-model="$parent.useTaskConfig" />
         Also start any hosts this task started (if applicable)


### PR DESCRIPTION
Basically I just moved the `ng-show` visibility to a div that includes the checkbox and text.