### PR TITLE
EVG-7596 consider started tasks when updating display task status

### DIFF
--- a/model/task/results.go
+++ b/model/task/results.go
@@ -21,12 +21,7 @@ func (t *Task) ResultStatus() string {
 		} else {
 			status = evergreen.TaskUnstarted
 		}
-	} else if t.Status == evergreen.TaskStarted {
-		status = evergreen.TaskStarted
-	} else if t.Status == evergreen.TaskSucceeded {
-		status = evergreen.TaskSucceeded
 	} else if t.Status == evergreen.TaskFailed {
-		status = evergreen.TaskFailed
 		if t.Details.Type == evergreen.CommandTypeSystem {
 			status = evergreen.TaskSystemFailed
 			if t.Details.TimedOut {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -951,19 +951,19 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 // for example, if there are both successful and failed tasks, one would expect to see "failed"
 func (t *Task) displayTaskPriority() int {
 	switch t.ResultStatus() {
-	case evergreen.TaskFailed:
-		return 10
-	case evergreen.TaskTestTimedOut:
-		return 20
-	case evergreen.TaskSystemFailed:
-		return 30
-	case evergreen.TaskSystemTimedOut:
-		return 40
-	case evergreen.TaskSystemUnresponse:
-		return 50
-	case evergreen.TaskSetupFailed:
-		return 60
 	case evergreen.TaskStarted:
+		return 10
+	case evergreen.TaskFailed:
+		return 20
+	case evergreen.TaskTestTimedOut:
+		return 30
+	case evergreen.TaskSystemFailed:
+		return 40
+	case evergreen.TaskSystemTimedOut:
+		return 50
+	case evergreen.TaskSystemUnresponse:
+		return 60
+	case evergreen.TaskSetupFailed:
 		return 70
 	case evergreen.TaskUndispatched:
 		return 80

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -313,8 +313,8 @@ var (
 	AllStatuses = "*"
 )
 
-// Abortable returns true if the task can be aborted.
-func IsAbortable(t Task) bool {
+// IsAbortable returns true if the task can be aborted.
+func (t *Task) IsAbortable() bool {
 	return t.Status == evergreen.TaskStarted ||
 		t.Status == evergreen.TaskDispatched
 }

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1115,7 +1115,7 @@ func UpdateDisplayTask(t *task.Task) error {
 		return errors.Wrap(err, "error retrieving execution tasks")
 	}
 	hasFinishedTasks := false
-	hasUnFinishedTasks := false
+	hasUnfinishedTasks := false
 	startTime := time.Unix(1<<62, 0)
 	endTime := utility.ZeroTime
 	for _, execTask := range execTasks {
@@ -1128,7 +1128,7 @@ func UpdateDisplayTask(t *task.Task) error {
 		}
 		// tasks that either are running or should run
 		if execTask.IsDispatchable() || execTask.IsAbortable() {
-			hasUnFinishedTasks = true
+			hasUnfinishedTasks = true
 		}
 
 		// add up the duration of the execution tasks as the cumulative time taken
@@ -1145,7 +1145,7 @@ func UpdateDisplayTask(t *task.Task) error {
 
 	sort.Sort(task.ByPriority(execTasks))
 	statusTask = execTasks[0]
-	if statusTask.Status != evergreen.TaskSystemFailed && (hasFinishedTasks && hasUnFinishedTasks) {
+	if statusTask.Status != evergreen.TaskSystemFailed && (hasFinishedTasks && hasUnfinishedTasks) {
 		// if the display task has a mix of finished and unfinished tasks, the status
 		// will be "started"
 		statusTask.Status = evergreen.TaskStarted
@@ -1162,7 +1162,7 @@ func UpdateDisplayTask(t *task.Task) error {
 	if startTime != time.Unix(1<<62, 0) {
 		update[task.StartTimeKey] = startTime
 	}
-	if endTime != utility.ZeroTime && !hasUnFinishedTasks {
+	if endTime != utility.ZeroTime && !hasUnfinishedTasks {
 		update[task.FinishTimeKey] = endTime
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1109,7 +1109,6 @@ func UpdateDisplayTask(t *task.Task) error {
 	var timeTaken time.Duration
 	var statusTask task.Task
 	wasFinished := t.IsFinished()
-	// display task already has a finished status
 	execTasks, err := task.Find(task.ByIds(t.ExecutionTasks))
 	if err != nil {
 		return errors.Wrap(err, "error retrieving execution tasks")
@@ -1126,7 +1125,6 @@ func UpdateDisplayTask(t *task.Task) error {
 		if execTask.IsFinished() {
 			hasFinishedTasks = true
 		}
-		// tasks that either are running or should run
 		if execTask.IsDispatchable() {
 			hasUnstartedTasks = true
 		}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1108,7 +1108,6 @@ func UpdateDisplayTask(t *task.Task) error {
 
 	var timeTaken time.Duration
 	var statusTask task.Task
-	wasFinished := t.IsFinished()
 	// display task already has a finished status
 	execTasks, err := task.Find(task.ByIds(t.ExecutionTasks))
 	if err != nil {
@@ -1145,7 +1144,7 @@ func UpdateDisplayTask(t *task.Task) error {
 
 	sort.Sort(task.ByPriority(execTasks))
 	statusTask = execTasks[0]
-	if statusTask.Status != evergreen.TaskSystemFailed && (hasFinishedTasks && hasUnfinishedTasks) {
+	if !evergreen.IsFailedTaskStatus(statusTask.Status) && (hasFinishedTasks && hasUnfinishedTasks) {
 		// if the display task has a mix of finished and unfinished tasks, the status
 		// will be "started"
 		statusTask.Status = evergreen.TaskStarted
@@ -1179,7 +1178,7 @@ func UpdateDisplayTask(t *task.Task) error {
 	t.Status = statusTask.Status
 	t.Details = statusTask.Details
 	t.TimeTaken = timeTaken
-	if !wasFinished && t.IsFinished() {
+	if t.IsFinished() && !hasUnfinishedTasks {
 		event.LogTaskFinished(t.Id, t.Execution, "", t.ResultStatus())
 	}
 	return nil

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1108,6 +1108,7 @@ func UpdateDisplayTask(t *task.Task) error {
 
 	var timeTaken time.Duration
 	var statusTask task.Task
+	wasFinished := t.IsFinished()
 	// display task already has a finished status
 	execTasks, err := task.Find(task.ByIds(t.ExecutionTasks))
 	if err != nil {
@@ -1144,7 +1145,7 @@ func UpdateDisplayTask(t *task.Task) error {
 
 	sort.Sort(task.ByPriority(execTasks))
 	statusTask = execTasks[0]
-	if !evergreen.IsFailedTaskStatus(statusTask.Status) && (hasFinishedTasks && hasUnfinishedTasks) {
+	if statusTask.Status != evergreen.TaskSystemFailed && (hasFinishedTasks && hasUnfinishedTasks) {
 		// if the display task has a mix of finished and unfinished tasks, the status
 		// will be "started"
 		statusTask.Status = evergreen.TaskStarted
@@ -1178,7 +1179,7 @@ func UpdateDisplayTask(t *task.Task) error {
 	t.Status = statusTask.Status
 	t.Details = statusTask.Details
 	t.TimeTaken = timeTaken
-	if t.IsFinished() && !hasUnfinishedTasks {
+	if !wasFinished && t.IsFinished() {
 		event.LogTaskFinished(t.Id, t.Execution, "", t.ResultStatus())
 	}
 	return nil

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2532,8 +2532,9 @@ func TestDisplayTaskUpdateNoUndispatched(t *testing.T) {
 	dbTask, err := task.FindOne(task.ById(dt.Id))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
-	assert.Equal(evergreen.TaskStarted, dbTask.Status)
+	assert.Equal(evergreen.TaskFailed, dbTask.Status)
 
+	// didn't log because not all tasks are finished
 	events, err := event.Find(event.AllLogCollection, event.TaskEventsForId(dt.Id))
 	assert.NoError(err)
 	assert.Len(events, 0)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2527,7 +2527,7 @@ func TestDisplayTaskUpdateNoUndispatched(t *testing.T) {
 	}
 	assert.NoError(task2.Insert())
 
-	// test that updating the status + activated from execution tasks works
+	// test that updating the status + activated from execution tasks shows started
 	assert.NoError(UpdateDisplayTask(&dt))
 	dbTask, err := task.FindOne(task.ById(dt.Id))
 	assert.NoError(err)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2532,9 +2532,8 @@ func TestDisplayTaskUpdateNoUndispatched(t *testing.T) {
 	dbTask, err := task.FindOne(task.ById(dt.Id))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
-	assert.Equal(evergreen.TaskFailed, dbTask.Status)
+	assert.Equal(evergreen.TaskStarted, dbTask.Status)
 
-	// didn't log because not all tasks are finished
 	events, err := event.Find(event.AllLogCollection, event.TaskEventsForId(dt.Id))
 	assert.NoError(err)
 	assert.Len(events, 0)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2494,6 +2494,51 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	assert.Len(events, 0)
 }
 
+func TestDisplayTaskUpdateNoUndispatched(t *testing.T) {
+	require.NoError(t, db.ClearCollections(task.Collection, event.AllLogCollection), "error clearing collection")
+	assert := assert.New(t)
+	dt := task.Task{
+		Id:          "dt",
+		DisplayOnly: true,
+		Status:      evergreen.TaskStarted,
+		Activated:   true,
+		ExecutionTasks: []string{
+			"task1",
+			"task2",
+		},
+	}
+	assert.NoError(dt.Insert())
+	task1 := task.Task{
+		Id:     "task1",
+		Status: evergreen.TaskFailed,
+		Details: apimodels.TaskEndDetail{
+			Status:   evergreen.TaskFailed,
+			TimedOut: true,
+		},
+		TimeTaken:  3 * time.Minute,
+		StartTime:  time.Date(2000, 0, 0, 1, 1, 1, 0, time.Local),
+		FinishTime: time.Date(2000, 0, 0, 1, 9, 1, 0, time.Local),
+	}
+	assert.NoError(task1.Insert())
+	task2 := task.Task{
+		Id:        "task2",
+		Status:    evergreen.TaskStarted,
+		StartTime: time.Date(2000, 0, 0, 0, 30, 0, 0, time.Local), // this should end up as the start time for dt1
+	}
+	assert.NoError(task2.Insert())
+
+	// test that updating the status + activated from execution tasks works
+	assert.NoError(UpdateDisplayTask(&dt))
+	dbTask, err := task.FindOne(task.ById(dt.Id))
+	assert.NoError(err)
+	assert.NotNil(dbTask)
+	assert.Equal(evergreen.TaskStarted, dbTask.Status)
+
+	events, err := event.Find(event.AllLogCollection, event.TaskEventsForId(dt.Id))
+	assert.NoError(err)
+	assert.Len(events, 0)
+}
+
 func TestDisplayTaskDelayedRestart(t *testing.T) {
 	require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection), "error clearing collection")
 	assert := assert.New(t)

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -131,7 +131,7 @@ func TestCleanupTask(t *testing.T) {
 					So(et1.Status, ShouldEqual, evergreen.TaskFailed)
 					dt, err = task.FindOneId(dt.Id)
 					So(err, ShouldBeNil)
-					So(dt.Status, ShouldEqual, evergreen.TaskFailed)
+					So(dt.Status, ShouldEqual, evergreen.TaskStarted) // et2 is still running
 					So(dt.ResetWhenFinished, ShouldBeTrue)
 				})
 			})

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -131,7 +131,7 @@ func TestCleanupTask(t *testing.T) {
 					So(et1.Status, ShouldEqual, evergreen.TaskFailed)
 					dt, err = task.FindOneId(dt.Id)
 					So(err, ShouldBeNil)
-					So(dt.Status, ShouldEqual, evergreen.TaskStarted) // et2 is still running
+					So(dt.Status, ShouldEqual, evergreen.TaskFailed)
 					So(dt.ResetWhenFinished, ShouldBeTrue)
 				})
 			})


### PR DESCRIPTION
While I think the logic with unstartedTasks is also wrong, I think the actual case brought up in the ticket comes from the first part of [this line](https://github.com/evergreen-ci/evergreen/blob/master/model/task_lifecycle.go#L1147) `statusTask.Status != evergreen.TaskFailed `.

I'm not 100% sure what you were trying to do in the original ticket @ybrill but given the description about SystemFailed I think we should only set display task as finished early in the system failed case (if at all).