### PR TITLE
EVG-7904: document host provisioning constants and use them consistently

### DIFF
--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -101,7 +101,7 @@ func (j *agentMonitorDeployJob) Run(ctx context.Context) {
 	// An atomic update on the needs new agent monitor field will cause
 	// concurrent jobs to fail early here. Updating the last communicated time
 	// prevents PopulateAgentMonitorDeployJobs from immediately running unless
-	// MaxLCTInterval passes.
+	// MaxUncommunicativeInterval passes.
 	if err = j.host.SetNeedsNewAgentMonitorAtomically(false); err != nil {
 		grip.Info(message.WrapError(err, message.Fields{
 			"message": "needs new agent monitor flag is already false, not deploying new agent monitor",
@@ -340,10 +340,10 @@ func (j *agentMonitorDeployJob) deployMessage() message.Fields {
 		m["reason"] = "flagged for new agent monitor"
 	} else if j.host.LastCommunicationTime.IsZero() {
 		m["reason"] = "new host"
-	} else if sinceLCT > host.MaxLCTInterval {
+	} else if sinceLCT > host.MaxUncommunicativeInterval {
 		m["reason"] = "host has exceeded last communication threshold"
-		m["threshold"] = host.MaxLCTInterval
-		m["threshold_span"] = host.MaxLCTInterval.String()
+		m["threshold"] = host.MaxUncommunicativeInterval
+		m["threshold_span"] = host.MaxUncommunicativeInterval.String()
 		m["last_communication_at"] = sinceLCT
 		m["last_communication_at_time"] = sinceLCT.String()
 	}

--- a/units/provisioning_convert_host_to_legacy.go
+++ b/units/provisioning_convert_host_to_legacy.go
@@ -45,7 +45,7 @@ func makeConvertHostToLegacyProvisioningJob() *convertHostToLegacyProvisioningJo
 		},
 	}
 	j.UpdateTimeInfo(amboy.JobTimeInfo{
-		MaxTime: host.MaxLCTInterval,
+		MaxTime: maxHostReprovisioningJobTime,
 	})
 	j.SetDependency(dependency.NewAlways())
 	return j

--- a/units/provisioning_convert_host_to_legacy_test.go
+++ b/units/provisioning_convert_host_to_legacy_test.go
@@ -23,7 +23,7 @@ func TestConvertHostToLegacyProvisioningJob(t *testing.T) {
 			j := NewConvertHostToLegacyProvisioningJob(env, *h, "job-id", 0)
 
 			info := j.TimeInfo()
-			assert.Equal(t, host.MaxLCTInterval, info.MaxTime)
+			assert.Equal(t, maxHostReprovisioningJobTime, info.MaxTime)
 
 			convertJob, ok := j.(*convertHostToLegacyProvisioningJob)
 			require.True(t, ok)

--- a/units/provisioning_convert_host_to_new.go
+++ b/units/provisioning_convert_host_to_new.go
@@ -48,7 +48,7 @@ func makeConvertHostToNewProvisioningJob() *convertHostToNewProvisioningJob {
 		},
 	}
 	j.UpdateTimeInfo(amboy.JobTimeInfo{
-		MaxTime: host.MaxLCTInterval,
+		MaxTime: maxHostReprovisioningJobTime,
 	})
 	j.SetDependency(dependency.NewAlways())
 	return j

--- a/units/provisioning_convert_host_to_new_test.go
+++ b/units/provisioning_convert_host_to_new_test.go
@@ -23,7 +23,7 @@ func TestConvertHostToNewProvisioningJob(t *testing.T) {
 			j := NewConvertHostToNewProvisioningJob(env, *h, "job-id", 0)
 
 			info := j.TimeInfo()
-			assert.Equal(t, host.MaxLCTInterval, info.MaxTime)
+			assert.Equal(t, maxHostReprovisioningJobTime, info.MaxTime)
 
 			convertJob, ok := j.(*convertHostToNewProvisioningJob)
 			require.True(t, ok)

--- a/units/provisioning_jasper_restart.go
+++ b/units/provisioning_jasper_restart.go
@@ -25,6 +25,11 @@ const (
 	jasperRestartJobName    = "jasper-restart"
 	expirationCutoff        = 7 * 24 * time.Hour // 1 week
 	jasperRestartRetryLimit = 10
+
+	// maxHostReprovisioningJobTime is the maximum amount of time a
+	// reprovisioning job (i.e. a job that modifies how the host is provisioned
+	// after initial provisioning is complete) can run.
+	maxHostReprovisioningJobTime = 5 * time.Minute
 )
 
 func init() {
@@ -57,7 +62,7 @@ func makeJasperRestartJob() *jasperRestartJob {
 		},
 	}
 	j.UpdateTimeInfo(amboy.JobTimeInfo{
-		MaxTime: host.MaxLCTInterval,
+		MaxTime: maxHostReprovisioningJobTime,
 	})
 	j.SetDependency(dependency.NewAlways())
 	return j


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7904

* Document the meaning of the different host provisioning constants so we don't misuse them or misunderstand them.
* Use the constants consistently according to their semantic meaning.