### PR TITLE
EVG-7776: use FindVersionById to get patch metadata

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1097,12 +1097,12 @@ func (r *taskResolver) FailedTestCount(ctx context.Context, obj *restModel.APITa
 }
 
 func (r *taskResolver) PatchMetadata(ctx context.Context, obj *restModel.APITask) (*PatchMetadata, error) {
-	patch, err := r.sc.FindPatchById(*obj.Version)
+	version, err := r.sc.FindVersionById(*obj.Version)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error retrieving patch %s: %s", *obj.Version, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error retrieving version %s: %s", *obj.Version, err.Error()))
 	}
 	patchMetadata := PatchMetadata{
-		Author: *patch.Author,
+		Author: version.Author,
 	}
 	return &patchMetadata, nil
 }

--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -136,7 +136,7 @@
           "task": {
             "id": "taskity_task",
             "patchMetadata": {
-              "author": "arjun"
+              "author": "brian.samek"
             }
           }
         }


### PR DESCRIPTION
This is a fix for the task patch metadata resolver. All base commits have version IDs, therefore `FindPatchById` was throwing an error because ID is not a Mongo `ObjectId`. The fix is to use `FindVersionById` which will work for both Patch and Version IDs.