### PR TITLE
EVG-7990 add git tag requester

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -325,12 +325,6 @@ var (
 	SystemVersionRequesterTypes = []string{
 		RepotrackerVersionRequester,
 		TriggerRequester,
-	}
-
-	// all types that can request versions to be on the waterfall
-	VersionRequesterTypes = []string{
-		RepotrackerVersionRequester,
-		TriggerRequester,
 		GitTagRequester,
 	}
 

--- a/globals.go
+++ b/globals.go
@@ -327,6 +327,13 @@ var (
 		TriggerRequester,
 	}
 
+	// all types that can request versions to be on the waterfall
+	VersionRequesterTypes = []string{
+		RepotrackerVersionRequester,
+		TriggerRequester,
+		GitTagRequester,
+	}
+
 	ProviderEc2Type = []string{
 		ProviderNameEc2Auto,
 		ProviderNameEc2Spot,
@@ -347,6 +354,7 @@ const (
 	// version requester types
 	PatchVersionRequester       = "patch_request"
 	GithubPRRequester           = "github_pull_request"
+	GitTagRequester             = "git_tag_request"
 	RepotrackerVersionRequester = "gitter_request"
 	TriggerRequester            = "trigger_request"
 	MergeTestRequester          = "merge_test"

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -265,7 +265,7 @@ func (r *patchResolver) TaskCount(ctx context.Context, obj *restModel.APIPatch) 
 }
 
 func (r *patchResolver) BaseVersionID(ctx context.Context, obj *restModel.APIPatch) (*string, error) {
-	baseVersion, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(*obj.ProjectId, *obj.Githash).Project(bson.M{model.VersionIdentifierKey: 1}))
+	baseVersion, err := model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(*obj.ProjectId, *obj.Githash).Project(bson.M{model.VersionIdentifierKey: 1}))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting base version ID for patch %s: %s", *obj.Id, err.Error()))
 	}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -265,7 +265,7 @@ func (r *patchResolver) TaskCount(ctx context.Context, obj *restModel.APIPatch) 
 }
 
 func (r *patchResolver) BaseVersionID(ctx context.Context, obj *restModel.APIPatch) (*string, error) {
-	baseVersion, err := model.VersionFindOne(model.VersionBaseVersionFromPatch(*obj.ProjectId, *obj.Githash).Project(bson.M{model.VersionIdentifierKey: 1}))
+	baseVersion, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(*obj.ProjectId, *obj.Githash).Project(bson.M{model.VersionIdentifierKey: 1}))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting base version ID for patch %s: %s", *obj.Id, err.Error()))
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -110,7 +110,7 @@ func GetBaseTaskStatusesFromPatchID(r *queryResolver, patchID string) (BaseTaskS
 	if version == nil {
 		return nil, fmt.Errorf("No version found for ID %s", patchID)
 	}
-	baseVersion, err := model.VersionFindOne(model.VersionBaseVersionFromPatch(version.Identifier, version.Revision))
+	baseVersion, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(version.Identifier, version.Revision))
 	if err != nil {
 		return nil, fmt.Errorf("Error getting base version from version %s: %s", version.Id, err.Error())
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -110,7 +110,7 @@ func GetBaseTaskStatusesFromPatchID(r *queryResolver, patchID string) (BaseTaskS
 	if version == nil {
 		return nil, fmt.Errorf("No version found for ID %s", patchID)
 	}
-	baseVersion, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(version.Identifier, version.Revision))
+	baseVersion, err := model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(version.Identifier, version.Revision))
 	if err != nil {
 		return nil, fmt.Errorf("Error getting base version from version %s: %s", version.Id, err.Error())
 	}

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -97,7 +97,7 @@ func ByProjectAndVariant(project, variant, requester string, statuses []string) 
 }
 
 // ByRevisionAndVariant creates a query that returns the non-patch build for
-// a revision + buildvariant combionation.
+// a revision + buildvariant combination.
 func ByRevisionAndVariant(revision, variant string) db.Q {
 	return db.Query(bson.M{
 		RevisionKey: revision,

--- a/model/generate.go
+++ b/model/generate.go
@@ -207,9 +207,9 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, cachedProj
 			p.BuildVariants[i].Tasks[j].Priority = t.Priority
 		}
 	}
-	// for patches activate all builds, otherwise activate ones that are not setting batchtime
+	// for patches and versions triggered by users, activate all builds. Otherwise activate ones that are not setting batchtime
 	var variantsToActivate []string
-	if !evergreen.IsPatchRequester(v.Requester) && v.Requester != evergreen.AdHocRequester {
+	if !evergreen.IsPatchRequester(v.Requester) && v.Requester != evergreen.AdHocRequester && v.Requester != evergreen.GitTagRequester {
 		variantsToActivate = g.findVariantsToActivate()
 	}
 	newTVPairs := TaskVariantPairs{}

--- a/model/grid/grid.go
+++ b/model/grid/grid.go
@@ -89,7 +89,7 @@ func FetchCells(current model.Version, depth int) (Grid, error) {
 		// as far as depth versions.
 		{"$match": bson.M{
 			build.RequesterKey: bson.M{
-				"$in": evergreen.SystemVersionRequesterTypes,
+				"$in": evergreen.VersionRequesterTypes,
 			},
 			build.RevisionOrderNumberKey: bson.M{
 				"$lte": current.RevisionOrderNumber,

--- a/model/grid/grid.go
+++ b/model/grid/grid.go
@@ -89,7 +89,7 @@ func FetchCells(current model.Version, depth int) (Grid, error) {
 		// as far as depth versions.
 		{"$match": bson.M{
 			build.RequesterKey: bson.M{
-				"$in": evergreen.VersionRequesterTypes,
+				"$in": evergreen.SystemVersionRequesterTypes,
 			},
 			build.RevisionOrderNumberKey: bson.M{
 				"$lte": current.RevisionOrderNumber,

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -550,6 +550,8 @@ func CreateBuildFromVersionNoInsert(args BuildCreateArgs) (*build.Build, task.Ta
 		rev = fmt.Sprintf("%s_%s", args.SourceRev, args.DefinitionID)
 	} else if args.Version.Requester == evergreen.AdHocRequester {
 		rev = args.Version.Id
+	} else if args.Version.Requester == evergreen.GitTagRequester {
+		rev = fmt.Sprintf("%s_%s", args.SourceRev, args.Version.TriggeredByGitTag.Tag)
 	}
 
 	// create a new build id
@@ -977,7 +979,7 @@ func TryMarkPatchBuildFinished(b *build.Build, finishTime time.Time, updates *St
 func getTaskCreateTime(projectId string, v *Version) (time.Time, error) {
 	createTime := time.Time{}
 	if evergreen.IsPatchRequester(v.Requester) {
-		baseVersion, err := VersionFindOne(VersionBaseVersionFromPatch(projectId, v.Revision))
+		baseVersion, err := VersionFindOne(VersionByProjectIdAndRevision(projectId, v.Revision))
 		if err != nil {
 			return createTime, errors.Wrap(err, "Error finding base version for patch version")
 		}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -979,7 +979,7 @@ func TryMarkPatchBuildFinished(b *build.Build, finishTime time.Time, updates *St
 func getTaskCreateTime(projectId string, v *Version) (time.Time, error) {
 	createTime := time.Time{}
 	if evergreen.IsPatchRequester(v.Requester) {
-		baseVersion, err := VersionFindOne(VersionByProjectIdAndRevision(projectId, v.Revision))
+		baseVersion, err := VersionFindOne(BaseVersionByProjectIdAndRevision(projectId, v.Revision))
 		if err != nil {
 			return createTime, errors.Wrap(err, "Error finding base version for patch version")
 		}

--- a/model/project.go
+++ b/model/project.go
@@ -1490,7 +1490,6 @@ func (p *Project) CommandsRunOnBV(cmds []PluginCommandConf, cmd, bv string) []Pl
 // Returns the versions themselves, as well as a map of version id -> the
 // builds that are a part of the version (unsorted).
 func FetchVersionsAndAssociatedBuilds(project *Project, skip int, numVersions int, showTriggered bool) ([]Version, map[string][]build.Build, error) {
-
 	// fetch the versions from the db
 	versionsFromDB, err := VersionFind(VersionByProjectAndTrigger(project.Identifier, showTriggered).
 		WithFields(

--- a/model/project.go
+++ b/model/project.go
@@ -675,6 +675,8 @@ func NewTaskIdTable(p *Project, v *Version, sourceRev, defID string) TaskIdConfi
 			rev = fmt.Sprintf("%s_%s", sourceRev, defID)
 		} else if v.Requester == evergreen.AdHocRequester {
 			rev = v.Id
+		} else if v.Requester == evergreen.GitTagRequester {
+			rev = fmt.Sprintf("%s_%s", sourceRev, v.TriggeredByGitTag.Tag)
 		}
 		for _, t := range bv.Tasks {
 			if tg := p.FindTaskGroup(t.Name); tg != nil {

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -670,7 +670,7 @@ func buildTestHistoryQuery(testHistoryParameters *TestHistoryParameters) ([]bson
 
 		revisionOrderNumberClause := bson.M{}
 		if testHistoryParameters.BeforeRevision != "" {
-			v, err := VersionFindOne(VersionByProjectIdAndRevision(testHistoryParameters.Project,
+			v, err := VersionFindOne(BaseVersionByProjectIdAndRevision(testHistoryParameters.Project,
 				testHistoryParameters.BeforeRevision).WithFields(VersionRevisionOrderNumberKey))
 			if err != nil {
 				return nil, err
@@ -682,7 +682,7 @@ func buildTestHistoryQuery(testHistoryParameters *TestHistoryParameters) ([]bson
 		}
 
 		if testHistoryParameters.AfterRevision != "" {
-			v, err := VersionFindOne(VersionByProjectIdAndRevision(testHistoryParameters.Project,
+			v, err := VersionFindOne(BaseVersionByProjectIdAndRevision(testHistoryParameters.Project,
 				testHistoryParameters.AfterRevision).WithFields(VersionRevisionOrderNumberKey))
 			if err != nil {
 				return nil, err
@@ -931,7 +931,7 @@ func formRevisionQuery(params *TestHistoryParameters) (*bson.M, error) {
 	}
 	revisionOrderNumberClause := bson.M{}
 	if params.BeforeRevision != "" {
-		v, err := VersionFindOne(VersionByProjectIdAndRevision(params.Project,
+		v, err := VersionFindOne(BaseVersionByProjectIdAndRevision(params.Project,
 			params.BeforeRevision).WithFields(VersionRevisionOrderNumberKey))
 		if err != nil {
 			return nil, errors.WithStack(err)
@@ -943,7 +943,7 @@ func formRevisionQuery(params *TestHistoryParameters) (*bson.M, error) {
 	}
 
 	if params.AfterRevision != "" {
-		v, err := VersionFindOne(VersionByProjectIdAndRevision(params.Project,
+		v, err := VersionFindOne(BaseVersionByProjectIdAndRevision(params.Project,
 			params.AfterRevision).WithFields(VersionRevisionOrderNumberKey))
 		if err != nil {
 			return nil, errors.WithStack(err)

--- a/model/version.go
+++ b/model/version.go
@@ -35,7 +35,10 @@ type Version struct {
 	RepoKind            string               `bson:"repo_kind" json:"repo_kind,omitempty"`
 	BuildVariants       []VersionBuildStatus `bson:"build_variants_status,omitempty" json:"build_variants_status,omitempty"`
 	PeriodicBuildID     string               `bson:"periodic_build_id,omitempty" json:"periodic_build_id,omitempty"`
-	GitTags             []GitTag             `bson:"git_tags,omitempty" json:"git_tags,omitempty"`
+
+	// GitTags stores tags that were pushed to this version, while TriggeredByGitTag is for versions created by tags
+	GitTags           []GitTag `bson:"git_tags,omitempty" json:"git_tags,omitempty"`
+	TriggeredByGitTag GitTag   `bson:"triggered_by_git_tag,omitempty" json:"triggered_by_git_tag,omitempty"`
 
 	// This is technically redundant, but a lot of code relies on it, so I'm going to leave it
 	BuildIds []string `bson:"builds" json:"builds,omitempty"`

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -154,11 +154,12 @@ func VersionByProjectId(projectId string) db.Q {
 		})
 }
 
+// Use all version requester types
 func VersionByProjectAndTrigger(projectID string, includeTriggered bool) db.Q {
 	q := bson.M{
 		VersionIdentifierKey: projectID,
 		VersionRequesterKey: bson.M{
-			"$in": evergreen.SystemVersionRequesterTypes,
+			"$in": evergreen.VersionRequesterTypes,
 		},
 	}
 	if !includeTriggered {
@@ -169,8 +170,7 @@ func VersionByProjectAndTrigger(projectID string, includeTriggered bool) db.Q {
 	return db.Query(q)
 }
 
-// ByProjectId finds all versions within a project, ordered by most recently created to oldest.
-// The requester controls if it should search patch or non-patch versions.
+// ByProjectId finds all mainline versions within a project, ordered by most recently created to oldest.
 func VersionByMostRecentSystemRequester(projectId string) db.Q {
 	return db.Query(
 		bson.M{
@@ -225,18 +225,6 @@ func VersionBySuccessfulBeforeRevision(project string, beforeRevision int) db.Q 
 			},
 		},
 	)
-}
-
-// BaseVersionFromPatch finds the base version for a patch version.
-func VersionBaseVersionFromPatch(projectId, revision string) db.Q {
-	return db.Query(
-		bson.M{
-			VersionIdentifierKey: projectId,
-			VersionRevisionKey:   revision,
-			VersionRequesterKey: bson.M{
-				"$in": evergreen.SystemVersionRequesterTypes,
-			},
-		})
 }
 
 func VersionsByRequesterOrdered(project, requester string, limit, startOrder int) db.Q {

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -85,14 +85,17 @@ func FindVersionByLastKnownGoodConfig(projectId string, revisionOrderNumber int)
 	return v, nil
 }
 
-// ByProjectIdAndRevision finds non-patch versions for the given project and revision.
-func VersionByProjectIdAndRevision(projectId, revision string) db.Q {
+// BaseVersionByProjectIdAndRevision finds a base version for the given project and revision.
+func BaseVersionByProjectIdAndRevision(projectId, revision string) db.Q {
 	return db.Query(
 		bson.M{
 			VersionIdentifierKey: projectId,
 			VersionRevisionKey:   revision,
 			VersionRequesterKey: bson.M{
-				"$in": evergreen.SystemVersionRequesterTypes,
+				"$in": []string{
+					evergreen.RepotrackerVersionRequester,
+					evergreen.TriggerRequester,
+				},
 			},
 		})
 }
@@ -159,7 +162,7 @@ func VersionByProjectAndTrigger(projectID string, includeTriggered bool) db.Q {
 	q := bson.M{
 		VersionIdentifierKey: projectID,
 		VersionRequesterKey: bson.M{
-			"$in": evergreen.VersionRequesterTypes,
+			"$in": evergreen.SystemVersionRequesterTypes,
 		},
 	}
 	if !includeTriggered {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -208,7 +208,7 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 		grip.Infof("Processing revision %s in project %s", revision, ref.Identifier)
 
 		// We check if the version exists here so we can avoid fetching the github config unnecessarily
-		existingVersion, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(ref.Identifier, revisions[i].Revision))
+		existingVersion, err := model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(ref.Identifier, revisions[i].Revision))
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":  "problem looking up version for project",
 			"runner":   RunnerName,

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -117,9 +117,9 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 			err := repoTracker.StoreRevisions(ctx, revisions)
 			require.NoError(t, err, "Error storing repository revisions %s, %s", revisionOne.Revision, revisionTwo.Revision)
 
-			versionOne, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(evgProjectRef.Identifier, revisionOne.Revision))
+			versionOne, err := model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(evgProjectRef.Identifier, revisionOne.Revision))
 			require.NoError(t, err, "Error retrieving first stored version %s", versionOne.Id)
-			versionTwo, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(evgProjectRef.Identifier, revisionTwo.Revision))
+			versionTwo, err := model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(evgProjectRef.Identifier, revisionTwo.Revision))
 			require.NoError(t, err, "Error retreiving second stored version %s", versionTwo.Revision)
 
 			So(versionOne.Revision, ShouldEqual, revisionOne.Revision)
@@ -145,7 +145,7 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 
 			err := repoTracker.StoreRevisions(ctx, revisions)
 			So(err, ShouldBeNil)
-			versionOne, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(evgProjectRef.Identifier, revisionOne.Revision))
+			versionOne, err := model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(evgProjectRef.Identifier, revisionOne.Revision))
 			So(err, ShouldBeNil)
 			So(versionOne.AuthorID, ShouldEqual, "testUser")
 

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -962,11 +962,13 @@ func (c *communicatorImpl) CreateVersionFromConfig(ctx context.Context, project,
 		ProjectID string          `json:"project_id"`
 		Message   string          `json:"message"`
 		Active    bool            `json:"activate"`
+		IsAdHoc   bool            `json:"is_adhoc"`
 		Config    json.RawMessage `json:"config"`
 	}{
 		ProjectID: project,
 		Message:   message,
 		Active:    active,
+		IsAdHoc:   true,
 		Config:    config,
 	}
 	resp, err := c.request(ctx, info, body)

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -61,7 +61,7 @@ func (vc *DBVersionConnector) FindVersionById(versionId string) (*model.Version,
 }
 
 func (vc *DBVersionConnector) FindVersionByProjectAndRevision(projectId, revision string) (*model.Version, error) {
-	return model.VersionFindOne(model.VersionByProjectIdAndRevision(projectId, revision))
+	return model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(projectId, revision))
 }
 
 func (vc *DBVersionConnector) AddGitTagToVersion(versionId string, gitTag model.GitTag) error {

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -319,23 +319,6 @@ func addFailedAndStartedTests(rows map[string]restModel.BuildList, failedAndStar
 
 func (vc *DBVersionConnector) CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo,
 	metadata model.VersionMetadata, active bool) (*model.Version, error) {
-	if projectInfo.Ref == nil {
-		ref, err := model.FindOneProjectRef(projectInfo.Ref.Identifier)
-		if err != nil {
-			return nil, gimlet.ErrorResponse{
-				StatusCode: http.StatusInternalServerError,
-				Message:    "error finding project",
-			}
-		}
-		if ref == nil {
-			return nil, gimlet.ErrorResponse{
-				StatusCode: http.StatusNotFound,
-				Message:    fmt.Sprintf("project %s does not exist", projectInfo.Ref.Identifier),
-			}
-		}
-		projectInfo.Ref = ref
-	}
-
 	newVersion, err := repotracker.CreateVersionFromConfig(ctx, projectInfo, metadata, false, nil)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{

--- a/rest/model/build.go
+++ b/rest/model/build.go
@@ -16,6 +16,7 @@ var (
 	patchOrigin   = "patch"
 	triggerOrigin = "trigger"
 	triggerAdHoc  = "ad_hoc"
+	gitTagOrigin  = "git_tag"
 )
 
 // APIBuild is the model to be returned by the API whenever builds are fetched.
@@ -85,6 +86,8 @@ func (apiBuild *APIBuild) BuildFromService(h interface{}) error {
 		origin = triggerOrigin
 	case evergreen.AdHocRequester:
 		origin = triggerAdHoc
+	case evergreen.GitTagRequester:
+		origin = gitTagOrigin
 	}
 	apiBuild.Origin = ToStringPtr(origin)
 	apiBuild.TaskCache = []APITaskCache{}

--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -23,6 +23,7 @@ const (
 	statsAPIRequesterMainline = "mainline"
 	statsAPIRequesterPatch    = "patch"
 	statsAPIRequesterTrigger  = "trigger"
+	statsAPIRequesterGitTag   = "git_tag"
 	statsAPIRequesterAdhoc    = "adhoc"
 
 	// Sort API values
@@ -190,6 +191,8 @@ func (sh *StatsHandler) readRequesters(requesters []string) ([]string, error) {
 			requesterValues = append(requesterValues, evergreen.PatchRequesters...)
 		case statsAPIRequesterTrigger:
 			requesterValues = append(requesterValues, evergreen.TriggerRequester)
+		case statsAPIRequesterGitTag:
+			requesterValues = append(requesterValues, evergreen.GitTagRequester)
 		case statsAPIRequesterAdhoc:
 			requesterValues = append(requesterValues, evergreen.AdHocRequester)
 		default:

--- a/scheduler/task_prioritizer.go
+++ b/scheduler/task_prioritizer.go
@@ -246,7 +246,7 @@ func (self *CmpBasedTaskComparator) splitTasksByRequester(
 		switch {
 		case task.Priority > evergreen.MaxTaskPriority:
 			priorityTasks = append(priorityTasks, task)
-		case utility.StringSliceContains(evergreen.SystemVersionRequesterTypes, task.Requester):
+		case utility.StringSliceContains(evergreen.VersionRequesterTypes, task.Requester):
 			repoTrackerTasks = append(repoTrackerTasks, task)
 		case evergreen.IsPatchRequester(task.Requester):
 			patchTasks = append(patchTasks, task)

--- a/scheduler/task_prioritizer.go
+++ b/scheduler/task_prioritizer.go
@@ -246,7 +246,7 @@ func (self *CmpBasedTaskComparator) splitTasksByRequester(
 		switch {
 		case task.Priority > evergreen.MaxTaskPriority:
 			priorityTasks = append(priorityTasks, task)
-		case utility.StringSliceContains(evergreen.VersionRequesterTypes, task.Requester):
+		case utility.StringSliceContains(evergreen.SystemVersionRequesterTypes, task.Requester):
 			repoTrackerTasks = append(repoTrackerTasks, task)
 		case evergreen.IsPatchRequester(task.Requester):
 			patchTasks = append(patchTasks, task)

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -346,7 +346,7 @@ func (restapi restAPI) getVersionInfoViaRevision(w http.ResponseWriter, r *http.
 	projectId := vars["project_id"]
 	revision := vars["revision"]
 
-	srcVersion, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(projectId, revision))
+	srcVersion, err := model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(projectId, revision))
 	if err != nil || srcVersion == nil {
 		msg := fmt.Sprintf("Error finding revision '%v' for project '%v'", revision, projectId)
 		statusCode := http.StatusNotFound

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -100,7 +100,7 @@ func (uis *UIServer) taskHistoryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if revision := r.FormValue("revision"); revision != "" {
-		v, err = model.VersionFindOne(model.VersionByProjectIdAndRevision(project.Identifier, revision))
+		v, err = model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(project.Identifier, revision))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -151,7 +151,7 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 			versionIds = append(versionIds, patch.Version)
 		}
 		var baseVersion *model.Version
-		baseVersion, err = model.VersionFindOne(model.VersionByProjectIdAndRevision(patch.Project, patch.Githash))
+		baseVersion, err = model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(patch.Project, patch.Githash))
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return

--- a/service/ui_plugin_manifest.go
+++ b/service/ui_plugin_manifest.go
@@ -14,7 +14,7 @@ func (uis *UIServer) GetManifest(w http.ResponseWriter, r *http.Request) {
 	project := vars["project_id"]
 	revision := vars["revision"]
 
-	version, err := model.VersionFindOne(model.VersionByProjectIdAndRevision(project, revision))
+	version, err := model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(project, revision))
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error getting version for project %v with revision %v: %v",
 			project, revision, err), http.StatusInternalServerError)

--- a/service/version.go
+++ b/service/version.go
@@ -121,7 +121,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		var baseVersion *model.Version
-		baseVersion, err = model.VersionFindOne(model.VersionBaseVersionFromPatch(projCtx.Version.Identifier, projCtx.Version.Revision))
+		baseVersion, err = model.VersionFindOne(model.VersionByProjectIdAndRevision(projCtx.Version.Identifier, projCtx.Version.Revision))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/service/version.go
+++ b/service/version.go
@@ -121,7 +121,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		var baseVersion *model.Version
-		baseVersion, err = model.VersionFindOne(model.VersionByProjectIdAndRevision(projCtx.Version.Identifier, projCtx.Version.Revision))
+		baseVersion, err = model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(projCtx.Version.Identifier, projCtx.Version.Revision))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -334,7 +334,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 
 	downstreamVersions, err := EvalProjectTriggers(&e, TriggerDownstreamVersion)
 	assert.NoError(err)
-	dbVersions, err := model.VersionFind(model.VersionByProjectIdAndRevision(downstreamProjectRef.Identifier, downstreamRevision))
+	dbVersions, err := model.VersionFind(model.BaseVersionByProjectIdAndRevision(downstreamProjectRef.Identifier, downstreamRevision))
 	assert.NoError(err)
 	require.Len(downstreamVersions, 1)
 	require.Len(dbVersions, 1)


### PR DESCRIPTION
I could use some thoughts on this ticket: 
I want to create a new requester GitTagRequester that is also used for displaying the waterfall. But it looks like we use SystemVersionRequesterTypes for the waterfall and also a lot of logical things.

I've only modified the query used for displaying versions on the waterfall to include GitTagRequester, but is there somewhere else I should be considering?