### PR TITLE
EVG-8010 terminated workstations

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -75,6 +75,9 @@ type Manager interface {
 	// ModifyVolume modifies an existing volume.
 	ModifyVolume(context.Context, *host.Volume, *model.VolumeModifyOptions) error
 
+	// GetVolumeAttachment gets a volume's attachement
+	GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error)
+
 	// CheckInstanceType determines if the given instance type is available in the current region.
 	CheckInstanceType(context.Context, string) error
 

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -242,6 +242,10 @@ func (m *dockerManager) ModifyVolume(context.Context, *host.Volume, *model.Volum
 	return errors.New("can't modify volume with docker provider")
 }
 
+func (m *dockerManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+	return nil, errors.New("can't get volume attachment with docker provider")
+}
+
 func (m *dockerManager) CheckInstanceType(context.Context, string) error {
 	return errors.New("can't specify instance type with docker provider")
 }

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -346,6 +346,10 @@ func (m *ec2FleetManager) ModifyVolume(context.Context, *host.Volume, *model.Vol
 	return errors.New("can't modify volume with ec2 fleet provider")
 }
 
+func (m *ec2FleetManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+	return nil, errors.New("can't get volume attachment with ec2 fleet provider")
+}
+
 func (m *ec2FleetManager) GetDNSName(ctx context.Context, h *host.Host) (string, error) {
 	if err := m.client.Create(m.credentials, m.region); err != nil {
 		return "", errors.Wrap(err, "error creating client")

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -240,6 +240,10 @@ func (m *gceManager) ModifyVolume(context.Context, *host.Volume, *model.VolumeMo
 	return errors.New("can't modify volume with gce provider")
 }
 
+func (m *gceManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+	return nil, errors.New("can't get volume attachment with gce provider")
+}
+
 func (m *gceManager) CheckInstanceType(context.Context, string) error {
 	return errors.New("can't specify instance type with gce provider")
 }

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -431,6 +431,21 @@ func (mockMgr *mockManager) ModifyVolume(ctx context.Context, volume *host.Volum
 	return nil
 }
 
+func (mockMgr *mockManager) GetVolumeAttachment(ctx context.Context, volumeID string) (*host.VolumeAttachment, error) {
+	l := mockMgr.mutex
+	l.Lock()
+	defer l.Unlock()
+
+	for id, instance := range mockMgr.Instances {
+		for _, device := range instance.BlockDevices {
+			if device == volumeID {
+				return &host.VolumeAttachment{HostID: id, VolumeID: volumeID}, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
 func (mockMgr *mockManager) GetInstanceStatuses(ctx context.Context, hosts []host.Host) ([]CloudStatus, error) {
 	if len(hosts) != 1 {
 		return nil, errors.New("expecting 1 hosts")

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -251,6 +251,10 @@ func (m *openStackManager) ModifyVolume(context.Context, *host.Volume, *model.Vo
 	return errors.New("can't modify volume with openstack provider")
 }
 
+func (m *openStackManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+	return nil, errors.New("can't get volume attachment with openstack provider")
+}
+
 func (m *openStackManager) CheckInstanceType(context.Context, string) error {
 	return errors.New("can't specify instance type with openstack provider")
 }

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -135,6 +135,10 @@ func (m *staticManager) ModifyVolume(context.Context, *host.Volume, *model.Volum
 	return errors.New("can't modify volume with static provider")
 }
 
+func (m *staticManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+	return nil, errors.New("can't get volume attachment with static provider")
+}
+
 func (staticMgr *staticManager) CheckInstanceType(context.Context, string) error {
 	return errors.New("can't specify instance type with static provider")
 }

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -212,6 +212,10 @@ func (m *vsphereManager) ModifyVolume(context.Context, *host.Volume, *model.Volu
 	return errors.New("can't modify volume with vsphere provider")
 }
 
+func (m *vsphereManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+	return nil, errors.New("can't get volume attachment with vsphere provider")
+}
+
 func (m *vsphereManager) CheckInstanceType(context.Context, string) error {
 	return errors.New("can't specify instance type with vsphere provider")
 }

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -195,6 +195,7 @@ type VolumeAttachment struct {
 	VolumeID   string `bson:"volume_id" json:"volume_id"`
 	DeviceName string `bson:"device_name" json:"device_name"`
 	IsHome     bool   `bson:"is_home" json:"is_home"`
+	HostID     string `bson:"host_id" json:"host_id"`
 }
 
 // DockerOptions contains options for starting a container

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -770,8 +770,12 @@ func attachVolume(ctx context.Context, env evergreen.Environment, h *host.Host) 
 		// attach to the host
 		attachment := host.VolumeAttachment{VolumeID: volume.ID, IsHome: true}
 		if err = cloudMgr.AttachVolume(ctx, h, &attachment); err != nil {
-			// another job has already attached the volume
-			if !strings.Contains(err.Error(), "IncorrectState") {
+			attachment, attachmentInfoErr := cloudMgr.GetVolumeAttachment(ctx, volume.ID)
+			if attachmentInfoErr != nil {
+				return errors.Wrapf(attachmentInfoErr, "can't query cloud provider for volume attachments for '%s'", volume.ID)
+			}
+			// if the volume isn't attached to this host then we have a problem
+			if !(attachment != nil && attachment.HostID == h.Id) {
 				return errors.Wrapf(err, "can't attach volume '%s' to host '%s'", volume.ID, h.Id)
 			}
 		}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -775,7 +775,7 @@ func attachVolume(ctx context.Context, env evergreen.Environment, h *host.Host) 
 				return errors.Wrapf(attachmentInfoErr, "can't query cloud provider for volume attachments for '%s'", volume.ID)
 			}
 			// if the volume isn't attached to this host then we have a problem
-			if !(attachment != nil && attachment.HostID == h.Id) {
+			if attachment == nil || attachment.HostID != h.Id {
 				return errors.Wrapf(err, "can't attach volume '%s' to host '%s'", volume.ID, h.Id)
 			}
 		}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -74,7 +74,6 @@ func NewHostSetupJob(env evergreen.Environment, h *host.Host) amboy.Job {
 	j.SetPriority(1)
 
 	j.SetID(fmt.Sprintf("%s.%s.attempt-%d", setupHostJobName, j.HostID, h.ProvisionAttempts))
-	j.SetScopes([]string{fmt.Sprintf("%s.%s", setupHostJobName, j.HostID)})
 	return j
 }
 

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -74,6 +74,7 @@ func NewHostSetupJob(env evergreen.Environment, h *host.Host) amboy.Job {
 	j.SetPriority(1)
 
 	j.SetID(fmt.Sprintf("%s.%s.attempt-%d", setupHostJobName, j.HostID, h.ProvisionAttempts))
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", setupHostJobName, j.HostID)})
 	return j
 }
 

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -58,6 +58,7 @@ func NewUserDataDoneJob(env evergreen.Environment, hostID string, ts time.Time) 
 	j.env = env
 	j.SetPriority(1)
 	j.SetID(fmt.Sprintf("%s.%s.%s", userDataDoneJobName, j.HostID, ts.Format(TSFormat)))
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", userDataDoneJobName, j.HostID)})
 
 	return j
 }

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -58,7 +58,6 @@ func NewUserDataDoneJob(env evergreen.Environment, hostID string, ts time.Time) 
 	j.env = env
 	j.SetPriority(1)
 	j.SetID(fmt.Sprintf("%s.%s.%s", userDataDoneJobName, j.HostID, ts.Format(TSFormat)))
-	j.SetScopes([]string{fmt.Sprintf("%s.%s", userDataDoneJobName, j.HostID)})
 
 	return j
 }


### PR DESCRIPTION
Reinstating scopes on `provisioning-setup-host` and `user-data-done` jobs now that they won't break amboy (hopefully). Will need to monitor the amboy dashboard after it's deployed.

Also, string matching on the AWS error was sketchy. If trying to attach the volume returns an error ask AWS if the volume is attached to **this** instance and continue on error if it is.