### PR TITLE
EVG-1134 oom killer

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -432,9 +432,10 @@ func (a *Agent) wait(ctx, taskCtx context.Context, tc *taskContext, heartbeat ch
 		a.runTaskTimeoutCommands(ctx, tc)
 	}
 
-	oomCtx, oomCancel := context.WithTimeout(ctx, time.Second*10)
-	defer oomCancel()
-	if status == evergreen.TaskFailed {
+	if tc.project.OomTracker && status == evergreen.TaskFailed {
+		tc.logger.Execution().Info("OOM tracker checking system logs")
+		oomCtx, oomCancel := context.WithTimeout(ctx, time.Second*10)
+		defer oomCancel()
 		if err := tc.oomTracker.Check(oomCtx); err != nil {
 			tc.logger.Execution().Errorf("error checking for OOM killed processes: %s", err)
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -518,7 +518,7 @@ func (a *Agent) endTaskResponse(tc *taskContext, status string) *apimodels.TaskE
 		TimedOut:        tc.hadTimedOut(),
 		TimeoutType:     string(tc.getTimeoutType()),
 		TimeoutDuration: tc.getTimeoutDuration(),
-		OOMKiller:       tc.getOomTrackerInfo(),
+		OOMTracker:      tc.getOomTrackerInfo(),
 		Status:          status,
 		Logs:            tc.logs,
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -439,6 +439,7 @@ func (a *Agent) wait(ctx, taskCtx context.Context, tc *taskContext, heartbeat ch
 		if err := tc.oomTracker.Check(oomCtx); err != nil {
 			tc.logger.Execution().Errorf("error checking for OOM killed processes: %s", err)
 		}
+		tc.logger.Execution().Debug("OOM tracker finished checking system logs")
 	}
 
 	return status

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -433,7 +433,6 @@ func (a *Agent) wait(ctx, taskCtx context.Context, tc *taskContext, heartbeat ch
 	}
 
 	if tc.project.OomTracker && status == evergreen.TaskFailed {
-		tc.logger.Execution().Info("OOM tracker checking system logs")
 		startTime := time.Now()
 		oomCtx, oomCancel := context.WithTimeout(ctx, time.Second*10)
 		defer oomCancel()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -434,12 +434,17 @@ func (a *Agent) wait(ctx, taskCtx context.Context, tc *taskContext, heartbeat ch
 
 	if tc.project.OomTracker && status == evergreen.TaskFailed {
 		tc.logger.Execution().Info("OOM tracker checking system logs")
+		startTime := time.Now()
 		oomCtx, oomCancel := context.WithTimeout(ctx, time.Second*10)
 		defer oomCancel()
 		if err := tc.oomTracker.Check(oomCtx); err != nil {
 			tc.logger.Execution().Errorf("error checking for OOM killed processes: %s", err)
 		}
-		tc.logger.Execution().Debug("OOM tracker finished checking system logs")
+		durationString := fmt.Sprintf("found no OOM kill in %.2f seconds", time.Now().Sub(startTime).Seconds())
+		if found, _ := tc.oomTracker.Report(); found {
+			durationString = fmt.Sprintf("found an OOM kill in %.2f seconds", time.Now().Sub(startTime).Seconds())
+		}
+		tc.logger.Execution().Debug(durationString)
 	}
 
 	return status

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -408,8 +408,8 @@ func (s *AgentSuite) TestOOMTracker() {
 	_, err := s.a.runTask(ctx, s.tc)
 	s.NoError(err)
 	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
-	s.True(s.mockCommunicator.EndTaskResult.Detail.OOMKiller.Detected)
-	s.Equal(pids, s.mockCommunicator.EndTaskResult.Detail.OOMKiller.PIDS)
+	s.True(s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Detected)
+	s.Equal(pids, s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Pids)
 }
 
 func (s *AgentSuite) TestWaitCompleteSuccess() {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -385,7 +385,7 @@ func (s *AgentSuite) TestAbort() {
 	}
 	s.Require().NoError(s.tc.logger.Close())
 	for _, m := range s.mockCommunicator.GetMockMessages()["task_id"] {
-		for toFind, _ := range shouldFind {
+		for toFind := range shouldFind {
 			if strings.Contains(m.Message, toFind) {
 				shouldFind[toFind] = true
 			}
@@ -422,6 +422,7 @@ func (s *AgentSuite) TestWaitCompleteSuccess() {
 	defer cancel()
 	innerCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	s.tc.project = &model.Project{}
 	status := s.a.wait(ctx, innerCtx, s.tc, heartbeat, complete)
 	s.Equal(evergreen.TaskSucceeded, status)
 	s.False(s.tc.hadTimedOut())
@@ -437,6 +438,7 @@ func (s *AgentSuite) TestWaitCompleteFailure() {
 	defer cancel()
 	innerCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	s.tc.project = &model.Project{}
 	status := s.a.wait(ctx, innerCtx, s.tc, heartbeat, complete)
 	s.Equal(evergreen.TaskFailed, status)
 	s.False(s.tc.hadTimedOut())
@@ -449,6 +451,7 @@ func (s *AgentSuite) TestWaitExecTimeout() {
 	cancel()
 	innerCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	s.tc.project = &model.Project{}
 	status := s.a.wait(ctx, innerCtx, s.tc, heartbeat, complete)
 	s.Equal(evergreen.TaskFailed, status)
 	s.False(s.tc.hadTimedOut())
@@ -464,7 +467,7 @@ func (s *AgentSuite) TestWaitHeartbeatTimeout() {
 	defer cancel()
 	innerCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-
+	s.tc.project = &model.Project{}
 	status := s.a.wait(ctx, innerCtx, s.tc, heartbeat, complete)
 	s.Equal(evergreen.TaskUndispatched, status)
 	s.False(s.tc.hadTimedOut())
@@ -496,6 +499,7 @@ func (s *AgentSuite) TestWaitIdleTimeout() {
 			},
 		},
 		oomTracker: jasper.NewMockOOMTracker(),
+		project:    &model.Project{},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/agent/agent_timeout_test.go
+++ b/agent/agent_timeout_test.go
@@ -70,6 +70,7 @@ func (s *TimeoutSuite) TestExecTimeoutProject() {
 		},
 		taskModel:     &task.Task{},
 		runGroupSetup: true,
+		oomTracker:    &jasper.OomTrackerMock{},
 	}
 	// Windows may not have finished deleting task directories when
 	// os.RemoveAll returns. Setting TaskExecution in this suite causes the
@@ -139,6 +140,7 @@ func (s *TimeoutSuite) TestExecTimeoutTask() {
 		},
 		taskModel:     &task.Task{},
 		runGroupSetup: true,
+		oomTracker:    &jasper.OomTrackerMock{},
 	}
 	// Windows may not have finished deleting task directories when
 	// os.RemoveAll returns. Setting TaskExecution in this suite causes the
@@ -205,6 +207,7 @@ func (s *TimeoutSuite) TestIdleTimeoutFunc() {
 		},
 		taskModel:     &task.Task{},
 		runGroupSetup: true,
+		oomTracker:    &jasper.OomTrackerMock{},
 	}
 	// Windows may not have finished deleting task directories when
 	// os.RemoveAll returns. Setting TaskExecution in this suite causes the
@@ -271,6 +274,7 @@ func (s *TimeoutSuite) TestIdleTimeoutCommand() {
 		},
 		taskModel:     &task.Task{},
 		runGroupSetup: true,
+		oomTracker:    &jasper.OomTrackerMock{},
 	}
 	// Windows may not have finished deleting task directories when
 	// os.RemoveAll returns. Setting TaskExecution in this suite causes the
@@ -337,6 +341,7 @@ func (s *TimeoutSuite) TestDynamicIdleTimeout() {
 		},
 		taskModel:     &task.Task{},
 		runGroupSetup: true,
+		oomTracker:    &jasper.OomTrackerMock{},
 	}
 	// Windows may not have finished deleting task directories when
 	// os.RemoveAll returns. Setting TaskExecution in this suite causes the
@@ -403,6 +408,7 @@ func (s *TimeoutSuite) TestDynamicExecTimeoutTask() {
 		},
 		taskModel:     &task.Task{},
 		runGroupSetup: true,
+		oomTracker:    &jasper.OomTrackerMock{},
 	}
 	// Windows may not have finished deleting task directories when
 	// os.RemoveAll returns. Setting TaskExecution in this suite causes the

--- a/agent/task.go
+++ b/agent/task.go
@@ -123,10 +123,13 @@ func (a *Agent) startTask(ctx context.Context, tc *taskContext, complete chan<- 
 		return
 	}
 
-	if err = tc.oomTracker.Clear(innerCtx); err != nil {
-		tc.logger.Execution().Errorf("error clearing system messages: %s", err)
-		complete <- evergreen.TaskFailed
-		return
+	if tc.project.OomTracker {
+		tc.logger.Execution().Info("OOM tracker clearing system messages")
+		if err = tc.oomTracker.Clear(innerCtx); err != nil {
+			tc.logger.Execution().Errorf("error clearing system messages: %s", err)
+			complete <- evergreen.TaskFailed
+			return
+		}
 	}
 
 	if err = a.runTaskCommands(innerCtx, tc); err != nil {

--- a/agent/task.go
+++ b/agent/task.go
@@ -256,7 +256,7 @@ func (tc *taskContext) getOomTrackerInfo() apimodels.OOMTrackerInfo {
 	detected, pids := tc.oomTracker.Report()
 	return apimodels.OOMTrackerInfo{
 		Detected: detected,
-		PIDS:     pids,
+		Pids:     pids,
 	}
 }
 

--- a/agent/task.go
+++ b/agent/task.go
@@ -250,21 +250,11 @@ func (tc *taskContext) hadTimedOut() bool {
 }
 
 func (tc *taskContext) getOomTrackerInfo() apimodels.OOMTrackerInfo {
-	tc.RLock()
-	defer tc.RUnlock()
-
 	detected, pids := tc.oomTracker.Report()
 	return apimodels.OOMTrackerInfo{
 		Detected: detected,
 		Pids:     pids,
 	}
-}
-
-func (tc *taskContext) runOomTrackerCheck(ctx context.Context) error {
-	tc.Lock()
-	defer tc.Unlock()
-
-	return tc.oomTracker.Check(ctx)
 }
 
 func (tc *taskContext) setIdleTimeout(dur time.Duration) {

--- a/agent/testdata/agent-integration.yml
+++ b/agent/testdata/agent-integration.yml
@@ -6,6 +6,7 @@ branch: master
 enabled: true
 batch_time: 180
 stepback: true
+oom_tracker: true
 
 functions:
   "list of commands":

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -42,13 +42,13 @@ type TaskEndDetail struct {
 	TimedOut        bool           `bson:"timed_out,omitempty" json:"timed_out,omitempty"`
 	TimeoutType     string         `bson:"timeout_type,omitempty" json:"timeout_type,omitempty"`
 	TimeoutDuration time.Duration  `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty"`
-	OOMKiller       OOMTrackerInfo `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
+	OOMTracker      OOMTrackerInfo `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
 	Logs            *TaskLogs      `bson:"-" json:"logs,omitempty"`
 }
 
 type OOMTrackerInfo struct {
 	Detected bool  `bson:"detected" json:"detected"`
-	PIDS     []int `bson:"pids" json:"pids"`
+	Pids     []int `bson:"pids" json:"pids"`
 }
 
 type TaskLogs struct {

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -36,13 +36,19 @@ type HeartbeatResponse struct {
 // TaskEndDetail contains data sent from the agent to the
 // API server after each task run.
 type TaskEndDetail struct {
-	Status          string        `bson:"status,omitempty" json:"status,omitempty"`
-	Type            string        `bson:"type,omitempty" json:"type,omitempty"`
-	Description     string        `bson:"desc,omitempty" json:"desc,omitempty"`
-	TimedOut        bool          `bson:"timed_out,omitempty" json:"timed_out,omitempty"`
-	TimeoutType     string        `bson:"timeout_type,omitempty" json:"timeout_type,omitempty"`
-	TimeoutDuration time.Duration `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty"`
-	Logs            *TaskLogs     `bson:"-" json:"logs,omitempty"`
+	Status          string         `bson:"status,omitempty" json:"status,omitempty"`
+	Type            string         `bson:"type,omitempty" json:"type,omitempty"`
+	Description     string         `bson:"desc,omitempty" json:"desc,omitempty"`
+	TimedOut        bool           `bson:"timed_out,omitempty" json:"timed_out,omitempty"`
+	TimeoutType     string         `bson:"timeout_type,omitempty" json:"timeout_type,omitempty"`
+	TimeoutDuration time.Duration  `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty"`
+	OOMKiller       OOMTrackerInfo `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
+	Logs            *TaskLogs      `bson:"-" json:"logs,omitempty"`
+}
+
+type OOMTrackerInfo struct {
+	Detected bool  `bson:"detected" json:"detected"`
+	PIDS     []int `bson:"pids" json:"pids"`
 }
 
 type TaskLogs struct {

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	ClientVersion = "2020-05-14"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-05-14"
+	AgentVersion = "2020-05-27"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/project.go
+++ b/model/project.go
@@ -35,6 +35,7 @@ type Project struct {
 	Enabled           bool                       `yaml:"enabled,omitempty" bson:"enabled"`
 	Stepback          bool                       `yaml:"stepback,omitempty" bson:"stepback"`
 	PreErrorFailsTask bool                       `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
+	OomTracker        bool                       `yaml:"oom_tracker,omitempty" bson:"oom_tracker"`
 	BatchTime         int                        `yaml:"batchtime,omitempty" bson:"batch_time"`
 	Owner             string                     `yaml:"owner,omitempty" bson:"owner_name"`
 	Repo              string                     `yaml:"repo,omitempty" bson:"repo_name"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -50,6 +50,7 @@ type ParserProject struct {
 	Enabled            bool                       `yaml:"enabled,omitempty" bson:"enabled,omitempty"`
 	Stepback           bool                       `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
 	PreErrorFailsTask  bool                       `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
+	OomTracker         bool                       `yaml:"oom_tracker,omitempty" bson:"oom_tracker,omitempty"`
 	BatchTime          int                        `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
 	Owner              string                     `yaml:"owner,omitempty" bson:"owner,omitempty"`
 	Repo               string                     `yaml:"repo,omitempty" bson:"repo,omitempty"`
@@ -542,6 +543,7 @@ func TranslateProject(pp *ParserProject) (*Project, error) {
 		Enabled:           pp.Enabled,
 		Stepback:          pp.Stepback,
 		PreErrorFailsTask: pp.PreErrorFailsTask,
+		OomTracker:        pp.OomTracker,
 		BatchTime:         pp.BatchTime,
 		Owner:             pp.Owner,
 		Repo:              pp.Repo,

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -20,6 +20,7 @@ var (
 	ParserProjectEnabledKey           = bsonutil.MustHaveTag(ParserProject{}, "Enabled")
 	ParserProjectStepbackKey          = bsonutil.MustHaveTag(ParserProject{}, "Stepback")
 	ParserProjectPreErrorFailsTaskKey = bsonutil.MustHaveTag(ParserProject{}, "PreErrorFailsTask")
+	ParserProjectOomTracker           = bsonutil.MustHaveTag(ParserProject{}, "OomTracker")
 	ParserProjectBatchTimeKey         = bsonutil.MustHaveTag(ParserProject{}, "BatchTime")
 	ParserProjectOwnerKey             = bsonutil.MustHaveTag(ParserProject{}, "Owner")
 	ParserProjectRepoKey              = bsonutil.MustHaveTag(ParserProject{}, "Repo")

--- a/rest/model/codegen.go
+++ b/rest/model/codegen.go
@@ -102,14 +102,16 @@ func SchemaToGo(schema string) ([]byte, error) {
 		}
 		fields := ""
 		for _, field := range gqlType.Fields {
-			fieldData, err := output(fieldTemplate, getFieldInfo(field))
+			var fieldData string
+			fieldData, err = output(fieldTemplate, getFieldInfo(field))
 			if err != nil {
 				catcher.Add(err)
 				continue
 			}
 			fields += fieldData
 		}
-		structData, err := output(structTemplate, structInfo{Name: typeName, Fields: fields})
+		var structData string
+		structData, err = output(structTemplate, structInfo{Name: typeName, Fields: fields})
 		if err != nil {
 			catcher.Add(err)
 			continue

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -75,10 +75,69 @@ type LogLinks struct {
 }
 
 type ApiTaskEndDetail struct {
-	Status      *string `json:"status"`
-	Type        *string `json:"type"`
-	Description *string `json:"desc"`
-	TimedOut    bool    `json:"timed_out"`
+	Status      *string           `json:"status"`
+	Type        *string           `json:"type"`
+	Description *string           `json:"desc"`
+	TimedOut    bool              `json:"timed_out"`
+	OOMTracker  APIOomTrackerInfo `json:"oom_tracker_info"`
+}
+
+func (at *ApiTaskEndDetail) BuildFromService(t interface{}) error {
+	v, ok := t.(apimodels.TaskEndDetail)
+	if !ok {
+		return errors.Errorf("Incorrect type %T when unmarshalling TaskEndDetail", t)
+	}
+	at.Status = ToStringPtr(v.Status)
+	at.Type = ToStringPtr(v.Type)
+	at.Description = ToStringPtr(v.Description)
+	at.TimedOut = v.TimedOut
+
+	apiOomTracker := APIOomTrackerInfo{}
+	if err := apiOomTracker.BuildFromService(v.OOMTracker); err != nil {
+		return errors.Wrap(err, "can't build oom tracker from service")
+	}
+	at.OOMTracker = apiOomTracker
+
+	return nil
+}
+
+func (ad *ApiTaskEndDetail) ToService() (interface{}, error) {
+	detail := apimodels.TaskEndDetail{
+		Status:      FromStringPtr(ad.Status),
+		Type:        FromStringPtr(ad.Type),
+		Description: FromStringPtr(ad.Description),
+		TimedOut:    ad.TimedOut,
+	}
+	oomTrackerIface, err := ad.OOMTracker.ToService()
+	if err != nil {
+		return nil, errors.Wrap(err, "can't convert OOMTrackerInfo to service")
+	}
+	detail.OOMTracker = oomTrackerIface.(apimodels.OOMTrackerInfo)
+
+	return detail, nil
+}
+
+type APIOomTrackerInfo struct {
+	Detected bool  `json:"detected"`
+	Pids     []int `json:"pids"`
+}
+
+func (at *APIOomTrackerInfo) BuildFromService(t interface{}) error {
+	v, ok := t.(apimodels.OOMTrackerInfo)
+	if !ok {
+		return errors.Errorf("Incorrect type %T when unmarshalling OOMTrackerInfo", t)
+	}
+	at.Detected = v.Detected
+	at.Pids = v.Pids
+
+	return nil
+}
+
+func (ad *APIOomTrackerInfo) ToService() (interface{}, error) {
+	return apimodels.OOMTrackerInfo{
+		Detected: ad.Detected,
+		Pids:     ad.Pids,
+	}, nil
 }
 
 func (at *APITask) BuildPreviousExecutions(tasks []task.Task, url string) error {
@@ -104,34 +163,28 @@ func (at *APITask) BuildFromService(t interface{}) error {
 	switch v := t.(type) {
 	case *task.Task:
 		(*at) = APITask{
-			Id:            ToStringPtr(v.Id),
-			ProjectId:     ToStringPtr(v.Project),
-			CreateTime:    ToTimePtr(v.CreateTime),
-			DispatchTime:  ToTimePtr(v.DispatchTime),
-			ScheduledTime: ToTimePtr(v.ScheduledTime),
-			StartTime:     ToTimePtr(v.StartTime),
-			FinishTime:    ToTimePtr(v.FinishTime),
-			IngestTime:    ToTimePtr(v.IngestTime),
-			ActivatedTime: ToTimePtr(v.ActivatedTime),
-			Version:       ToStringPtr(v.Version),
-			Revision:      ToStringPtr(v.Revision),
-			Priority:      v.Priority,
-			Activated:     v.Activated,
-			ActivatedBy:   ToStringPtr(v.ActivatedBy),
-			BuildId:       ToStringPtr(v.BuildId),
-			DistroId:      ToStringPtr(v.DistroId),
-			BuildVariant:  ToStringPtr(v.BuildVariant),
-			DisplayName:   ToStringPtr(v.DisplayName),
-			HostId:        ToStringPtr(v.HostId),
-			Restarts:      v.Restarts,
-			Execution:     v.Execution,
-			Order:         v.RevisionOrderNumber,
-			Details: ApiTaskEndDetail{
-				Status:      ToStringPtr(v.Details.Status),
-				Type:        ToStringPtr(v.Details.Type),
-				Description: ToStringPtr(v.Details.Description),
-				TimedOut:    v.Details.TimedOut,
-			},
+			Id:                ToStringPtr(v.Id),
+			ProjectId:         ToStringPtr(v.Project),
+			CreateTime:        ToTimePtr(v.CreateTime),
+			DispatchTime:      ToTimePtr(v.DispatchTime),
+			ScheduledTime:     ToTimePtr(v.ScheduledTime),
+			StartTime:         ToTimePtr(v.StartTime),
+			FinishTime:        ToTimePtr(v.FinishTime),
+			IngestTime:        ToTimePtr(v.IngestTime),
+			ActivatedTime:     ToTimePtr(v.ActivatedTime),
+			Version:           ToStringPtr(v.Version),
+			Revision:          ToStringPtr(v.Revision),
+			Priority:          v.Priority,
+			Activated:         v.Activated,
+			ActivatedBy:       ToStringPtr(v.ActivatedBy),
+			BuildId:           ToStringPtr(v.BuildId),
+			DistroId:          ToStringPtr(v.DistroId),
+			BuildVariant:      ToStringPtr(v.BuildVariant),
+			DisplayName:       ToStringPtr(v.DisplayName),
+			HostId:            ToStringPtr(v.HostId),
+			Restarts:          v.Restarts,
+			Execution:         v.Execution,
+			Order:             v.RevisionOrderNumber,
 			Status:            ToStringPtr(v.Status),
 			TimeTaken:         NewAPIDuration(v.TimeTaken),
 			ExpectedDuration:  NewAPIDuration(v.ExpectedDuration),
@@ -151,6 +204,10 @@ func (at *APITask) BuildFromService(t interface{}) error {
 				Statuses: v.SyncAtEndOpts.Statuses,
 				Timeout:  v.SyncAtEndOpts.Timeout,
 			},
+		}
+
+		if err := at.Details.BuildFromService(v.Details); err != nil {
+			return errors.Wrap(err, "can't build TaskEndDetail from service")
 		}
 
 		if v.HostId != "" {
@@ -208,21 +265,15 @@ func (ad *APITask) ToService() (interface{}, error) {
 		Restarts:            ad.Restarts,
 		Execution:           ad.Execution,
 		RevisionOrderNumber: ad.Order,
-		Details: apimodels.TaskEndDetail{
-			Status:      FromStringPtr(ad.Details.Status),
-			Type:        FromStringPtr(ad.Details.Type),
-			Description: FromStringPtr(ad.Details.Description),
-			TimedOut:    ad.Details.TimedOut,
-		},
-		Status:           FromStringPtr(ad.Status),
-		TimeTaken:        ad.TimeTaken.ToDuration(),
-		ExpectedDuration: ad.ExpectedDuration.ToDuration(),
-		Cost:             ad.EstimatedCost,
-		GenerateTask:     ad.GenerateTask,
-		GeneratedBy:      ad.GeneratedBy,
-		DisplayOnly:      ad.DisplayOnly,
-		Requester:        FromStringPtr(ad.Requester),
-		CanSync:          ad.CanSync,
+		Status:              FromStringPtr(ad.Status),
+		TimeTaken:           ad.TimeTaken.ToDuration(),
+		ExpectedDuration:    ad.ExpectedDuration.ToDuration(),
+		Cost:                ad.EstimatedCost,
+		GenerateTask:        ad.GenerateTask,
+		GeneratedBy:         ad.GeneratedBy,
+		DisplayOnly:         ad.DisplayOnly,
+		Requester:           FromStringPtr(ad.Requester),
+		CanSync:             ad.CanSync,
 		SyncAtEndOpts: task.SyncAtEndOptions{
 			Enabled:  ad.SyncAtEndOpts.Enabled,
 			Statuses: ad.SyncAtEndOpts.Statuses,
@@ -230,6 +281,9 @@ func (ad *APITask) ToService() (interface{}, error) {
 		},
 	}
 	catcher := grip.NewBasicCatcher()
+	serviceDetails, err := ad.Details.ToService()
+	catcher.Add(err)
+	st.Details = serviceDetails.(apimodels.TaskEndDetail)
 	createTime, err := FromTimePtr(ad.CreateTime)
 	catcher.Add(err)
 	dispatchTime, err := FromTimePtr(ad.DispatchTime)

--- a/service/templates/task.html
+++ b/service/templates/task.html
@@ -315,6 +315,10 @@ Evergreen - {{Trunc .Task.Revision 10}} / {{.Task.BuildVariantDisplay}} / {{.Tas
                         </div>
                       </td>
                     </tr>
+                    <tr ng-show="task.task_end_details.oom_killer.detected">
+                      <td class="icon"><i class="fa fa-exclamation"></i></td>
+                      <td>OOM Killer detected (<b>[[ task.task_end_details.oom_killer.pids.join(", ") ]]</b>)</td>
+                    </tr>
                   </table>
                 </div>
               </div>

--- a/service/templates/task.html
+++ b/service/templates/task.html
@@ -317,7 +317,7 @@ Evergreen - {{Trunc .Task.Revision 10}} / {{.Task.BuildVariantDisplay}} / {{.Tas
                     </tr>
                     <tr ng-show="task.task_end_details.oom_killer.detected">
                       <td class="icon"><i class="fa fa-exclamation"></i></td>
-                      <td>OOM Killer detected (<b>[[ task.task_end_details.oom_killer.pids.join(", ") ]]</b>)</td>
+                      <td>Out of Memory Kill detected (PIDs: [[ task.task_end_details.oom_killer.pids.join(", ") ]])</td>
                     </tr>
                   </table>
                 </div>


### PR DESCRIPTION
Run the oom tracker in the agent. The messages are cleared just before the task's commands run and the messages are checked when they complete or time out.
Add the results to the task's status details so it's stored in the db and accessible through the API. Also add to the task card.

<img width="307" alt="Screen Shot 2020-05-19 at 6 23 41 PM" src="https://user-images.githubusercontent.com/17027265/82384594-32212f80-99fe-11ea-9222-62d73b4e2771.png">

