### PR TITLE
EVG-7626 add git_tag_only option for tasks/variants

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -578,11 +578,15 @@ func IsSystemActivator(caller string) bool {
 }
 
 func IsPatchRequester(requester string) bool {
-	return requester == PatchVersionRequester || requester == GithubPRRequester || requester == MergeTestRequester
+	return requester == PatchVersionRequester || IsGitHubPatchRequester(requester)
 }
 
 func IsGitHubPatchRequester(requester string) bool {
 	return requester == GithubPRRequester || requester == MergeTestRequester
+}
+
+func IsGitTagRequester(requester string) bool {
+	return requester == GitTagRequester
 }
 
 // Permissions-related constants

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -19,6 +19,7 @@ import (
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/rest/route"
 	"github.com/evergreen-ci/evergreen/units"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
@@ -269,8 +270,8 @@ func GetVariantsAndTasksFromProject(patchedConfig string, patchProject string) (
 
 	tasksList := []struct{ Name string }{}
 	for _, task := range project.Tasks {
-		// add a task name to the list if it's patchable
-		if !(task.Patchable != nil && !*task.Patchable) {
+		// add a task name to the list if it's patchable and not restricted to git tags
+		if !util.IsPtrSetToFalse(task.Patchable) && !util.IsPtrSetToTrue(task.GitTagOnly) {
 			tasksList = append(tasksList, struct{ Name string }{task.Name})
 		}
 	}

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/user"
 	_ "github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -372,13 +373,12 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 	// Fallback to the SchedulerConfig.ExpectedRuntimeFactor as PlannerSettings.ExpectedRunTimeFactor is equal to 0.
 	assert.EqualValues(t, 7, resolved0.ExpectedRuntimeFactor)
 
-	pTrue := true
 	d1 := Distro{
 		Id: "distro1",
 		PlannerSettings: PlannerSettings{
 			Version:                   evergreen.PlannerVersionTunable,
 			TargetTime:                98765000000000,
-			GroupVersions:             &pTrue,
+			GroupVersions:             util.TruePtr(),
 			PatchFactor:               25,
 			PatchTimeInQueueFactor:    0,
 			CommitQueueFactor:         0,

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -632,6 +632,8 @@ func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project) []BuildVariant
 			IsGroup:          true,
 			GroupName:        in.Name,
 			Patchable:        in.Patchable,
+			PatchOnly:        in.PatchOnly,
+			GitTagOnly:       in.GitTagOnly,
 			Priority:         in.Priority,
 			DependsOn:        in.DependsOn,
 			Requires:         in.Requires,
@@ -696,8 +698,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 		// sanity check that the config isn't malformed
 		if taskSpec.Name != "" {
 			task.Populate(taskSpec)
-			if skipTask := b.IsPatchBuild() && task.SkipOnPatchBuild() ||
-				!b.IsPatchBuild() && task.SkipOnNonPatchBuild(); skipTask {
+			if task.SkipOnRequester(b.Requester) {
 				continue
 			}
 			if createAll || utility.StringSliceContains(taskNames, task.Name) {
@@ -706,8 +707,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 		} else if _, ok := tgMap[task.Name]; ok {
 			tasksFromVariant := CreateTasksFromGroup(task, project)
 			for _, taskFromVariant := range tasksFromVariant {
-				if skipTask := b.IsPatchBuild() && taskFromVariant.SkipOnPatchBuild() ||
-					!b.IsPatchBuild() && taskFromVariant.SkipOnNonPatchBuild(); skipTask {
+				if taskFromVariant.SkipOnRequester(b.Requester) {
 					continue
 				}
 				if createAll || utility.StringSliceContains(taskNames, taskFromVariant.Name) {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1755,46 +1755,6 @@ func resetTaskData() error {
 	return nil
 }
 
-func TestSkipOnPatch(t *testing.T) {
-	assert := assert.New(t)
-	falseTmp := false
-	bvt := BuildVariantTaskUnit{Patchable: &falseTmp}
-
-	b := &build.Build{Requester: evergreen.RepotrackerVersionRequester}
-	assert.False(b.IsPatchBuild() && bvt.SkipOnPatchBuild())
-
-	b.Requester = evergreen.PatchVersionRequester
-	assert.True(b.IsPatchBuild() && bvt.SkipOnPatchBuild())
-
-	b.Requester = evergreen.GithubPRRequester
-	assert.True(b.IsPatchBuild() && bvt.SkipOnPatchBuild())
-
-	b.Requester = evergreen.MergeTestRequester
-	assert.True(b.IsPatchBuild() && bvt.SkipOnPatchBuild())
-
-	bvt.Patchable = nil
-	assert.False(b.IsPatchBuild() && bvt.SkipOnPatchBuild())
-}
-
-func TestSkipOnNonPatch(t *testing.T) {
-	assert := assert.New(t)
-	boolTmp := true
-	bvt := BuildVariantTaskUnit{PatchOnly: &boolTmp}
-	b := &build.Build{Requester: evergreen.RepotrackerVersionRequester}
-	assert.True(!b.IsPatchBuild() && bvt.SkipOnNonPatchBuild())
-
-	b.Requester = evergreen.PatchVersionRequester
-	assert.False(!b.IsPatchBuild() && bvt.SkipOnNonPatchBuild())
-
-	b.Requester = evergreen.GithubPRRequester
-	assert.False(!b.IsPatchBuild() && bvt.SkipOnNonPatchBuild())
-	bvt.PatchOnly = nil
-	assert.False(!b.IsPatchBuild() && bvt.SkipOnNonPatchBuild())
-
-	b.Requester = evergreen.GithubPRRequester
-	assert.False(b.IsPatchBuild() && bvt.SkipOnPatchBuild())
-}
-
 func TestCreateTasksFromGroup(t *testing.T) {
 	assert := assert.New(t)
 	in := BuildVariantTaskUnit{

--- a/model/patch_dependencies.go
+++ b/model/patch_dependencies.go
@@ -61,7 +61,7 @@ func (di *dependencyIncluder) handle(pair TVPair) bool {
 		return false // task not found in project--skip it.
 	}
 
-	if patchable := bvt.Patchable; patchable != nil && !*patchable {
+	if bvt.SkipOnPatchBuild() || bvt.SkipOnNonGitTagBuild() {
 		di.included[pair] = false
 		return false // task cannot be patched, so skip it
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -82,6 +82,7 @@ type parserTaskGroup struct {
 	Priority              int64              `yaml:"priority,omitempty" bson:"priority,omitempty"`
 	Patchable             *bool              `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
 	PatchOnly             *bool              `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	GitTagOnly            *bool              `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
 	ExecTimeoutSecs       int                `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
 	Stepback              *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
 	MaxHosts              int                `yaml:"max_hosts,omitempty" bson:"max_hosts,omitempty"`
@@ -113,6 +114,7 @@ type parserTask struct {
 	Tags            parserStringSlice   `yaml:"tags,omitempty" bson:"tags,omitempty"`
 	Patchable       *bool               `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
 	PatchOnly       *bool               `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	GitTagOnly      *bool               `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
 	Stepback        *bool               `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
 }
 
@@ -360,6 +362,7 @@ type parserBVTaskUnit struct {
 	Name             string             `yaml:"name,omitempty" bson:"name,omitempty"`
 	Patchable        *bool              `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
 	PatchOnly        *bool              `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	GitTagOnly       *bool              `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
 	Priority         int64              `yaml:"priority,omitempty" bson:"priority,omitempty"`
 	DependsOn        parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
 	Requires         taskSelectors      `yaml:"requires,omitempty" bson:"requires,omitempty"`
@@ -628,6 +631,7 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 			Tags:            pt.Tags,
 			Patchable:       pt.Patchable,
 			PatchOnly:       pt.PatchOnly,
+			GitTagOnly:      pt.GitTagOnly,
 			Stepback:        pt.Stepback,
 		}
 		if strings.Contains(strings.TrimSpace(pt.Name), " ") {
@@ -842,6 +846,7 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 				Name:             name,
 				Patchable:        pt.Patchable,
 				PatchOnly:        pt.PatchOnly,
+				GitTagOnly:       pt.GitTagOnly,
 				Priority:         pt.Priority,
 				ExecTimeoutSecs:  pt.ExecTimeoutSecs,
 				Stepback:         pt.Stepback,

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1275,6 +1275,47 @@ buildvariants:
 	assert.Nil(proj.BuildVariants[2].Tasks[0].PatchOnly)
 }
 
+func TestGitTagOnlyTasks(t *testing.T) {
+	yml := `
+tasks:
+- name: task_1
+  git_tag_only: true
+- name: task_2
+buildvariants:
+- name: bv_1
+  tasks:
+  - name: task_1
+  - name: task_2
+    git_tag_only: false
+- name: bv_2
+  tasks:
+  - name: task_1
+    git_tag_only: false
+  - name: task_2
+    git_tag_only: true
+- name: bv_3
+  tasks:
+  - name: task_2
+`
+
+	proj := &Project{}
+	_, err := LoadProjectInto([]byte(yml), "id", proj)
+	assert.NotNil(t, proj)
+	assert.Nil(t, err)
+	assert.Len(t, proj.BuildVariants, 3)
+
+	assert.Len(t, proj.BuildVariants[0].Tasks, 2)
+	assert.Nil(t, proj.BuildVariants[0].Tasks[0].GitTagOnly)
+	assert.False(t, *proj.BuildVariants[0].Tasks[1].GitTagOnly)
+
+	assert.Len(t, proj.BuildVariants[1].Tasks, 2)
+	assert.False(t, *proj.BuildVariants[1].Tasks[0].GitTagOnly)
+	assert.True(t, *proj.BuildVariants[1].Tasks[1].GitTagOnly)
+
+	assert.Len(t, proj.BuildVariants[2].Tasks, 1)
+	assert.Nil(t, proj.BuildVariants[2].Tasks[0].GitTagOnly)
+}
+
 func TestLoggerConfig(t *testing.T) {
 	assert := assert.New(t)
 	yml := `

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -157,7 +157,6 @@ func VersionByProjectId(projectId string) db.Q {
 		})
 }
 
-// Use all version requester types
 func VersionByProjectAndTrigger(projectID string, includeTriggered bool) db.Q {
 	q := bson.M{
 		VersionIdentifierKey: projectID,

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -173,7 +173,8 @@ func VersionByProjectAndTrigger(projectID string, includeTriggered bool) db.Q {
 	return db.Query(q)
 }
 
-// ByProjectId finds all mainline versions within a project, ordered by most recently created to oldest.
+// VersionByMostRecentSystemRequester finds all mainline versions within a project,
+// ordered by most recently created to oldest.
 func VersionByMostRecentSystemRequester(projectId string) db.Q {
 	return db.Query(
 		bson.M{

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
@@ -256,7 +257,6 @@ func TestDistroByIDSuite(t *testing.T) {
 }
 
 func (s *DistroByIDSuite) SetupSuite() {
-	pTrue := true
 	s.data = data.MockDistroConnector{
 		CachedDistros: []*distro.Distro{
 			{
@@ -276,7 +276,7 @@ func (s *DistroByIDSuite) SetupSuite() {
 				PlannerSettings: distro.PlannerSettings{
 					Version:       evergreen.PlannerVersionTunable,
 					TargetTime:    80000000000,
-					GroupVersions: &pTrue,
+					GroupVersions: util.TruePtr(),
 					PatchFactor:   7,
 				},
 				BootstrapSettings: distro.BootstrapSettings{

--- a/util/bool.go
+++ b/util/bool.go
@@ -1,0 +1,19 @@
+package util
+
+func IsPtrSetToTrue(ptr *bool) bool {
+	return ptr != nil && *ptr
+}
+
+func IsPtrSetToFalse(ptr *bool) bool {
+	return ptr != nil && !*ptr
+}
+
+func TruePtr() *bool {
+	res := true
+	return &res
+}
+
+func FalsePtr() *bool {
+	res := false
+	return &res
+}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1379,10 +1379,9 @@ func validateTVDependsOnTV(source, target model.TVPair, tvToTaskUnit map[model.T
 }
 
 type dependencyRequirements struct {
-	lastDepNeedsSuccess   bool
-	requireOnPatches      bool
-	requireOnNonPatches   bool
-	requireOnGitTagBuilds bool
+	lastDepNeedsSuccess bool
+	requireOnPatches    bool
+	requireOnNonPatches bool
 }
 
 // dependencyMustRun checks whether or not the current task in a build

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -3179,6 +3179,27 @@ func TestDependencyMustRun(t *testing.T) {
 			},
 			expectDependencyFound: false,
 		},
+		"DependencySkipsPatchIfSourceIncludesGitTags": {
+			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			depReqs: dependencyRequirements{
+				lastDepNeedsSuccess: true,
+				requireOnPatches:    false,
+				requireOnNonPatches: false,
+				requireOnGitTag:     true,
+			},
+			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
+				{TaskName: "A", Variant: "ubuntu"}: {
+					DependsOn: []model.TaskUnitDependency{
+						{Name: "B", Variant: "ubuntu"},
+					},
+				},
+				{TaskName: "B", Variant: "ubuntu"}: {
+					PatchOnly: truePtr,
+				},
+			},
+			expectDependencyFound: false,
+		},
 		"DependencyIncludesGitTags": {
 			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
 			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},


### PR DESCRIPTION
This mildly depends on EVG-7990 but only because of the requester, I think I can re-base this later.

Tasks with `git_tag_only: true` should only be able to run for the GitTagRequester type, so mainline builds and patches should ignore it. This means that `patchable: false` a subset of GitTagOnly since these are already not patchable, and PatchOnly contradictory as they shouldn't be able to be patched.