### PR TITLE
EVG-7993 distinguish between issue and version when removing from cq

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -946,7 +946,7 @@ func (r *mutationResolver) AbortTask(ctx context.Context, taskID string) (*restM
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error aborting task %s: %s", taskID, err.Error()))
 	}
 	if t.Requester == evergreen.MergeTestRequester {
-		_, err = commitqueue.RemoveCommitQueueItem(t.Project, p.CommitQueue.PatchType, t.Version, true)
+		_, err = commitqueue.RemoveCommitQueueItemForVersion(t.Project, p.CommitQueue.PatchType, t.Version)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Unable to remove commit queue item for project %s, version %s: %s", taskID, t.Version, err.Error()))
 		}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -431,8 +431,8 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 				}
 				proj = projRef
 			}
-			_, err := commitqueue.RemoveCommitQueueItem(proj.Identifier,
-				proj.CommitQueue.PatchType, version.Id, true)
+			_, err := commitqueue.RemoveCommitQueueItemForVersion(proj.Identifier,
+				proj.CommitQueue.PatchType, version.Id)
 			if err != nil {
 				return http.StatusInternalServerError, errors.Errorf("error removing patch from commit queue: %s", err)
 			}

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -37,7 +37,8 @@ func (s *CommitQueueSuite) SetupTest() {
 		Repo:       "evergreen",
 		Branch:     "master",
 		CommitQueue: model.CommitQueueParams{
-			Enabled: true,
+			Enabled:   true,
+			PatchType: commitqueue.CLIPatchType,
 		},
 	}
 	s.Require().NoError(s.projectRef.Insert())

--- a/service/build.go
+++ b/service/build.go
@@ -172,8 +172,8 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if projCtx.Build.Requester == evergreen.MergeTestRequester {
-			_, err = commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
-				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Build.Version, true)
+			_, err = commitqueue.RemoveCommitQueueItemForVersion(projCtx.ProjectRef.Identifier,
+				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Build.Version)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
@@ -218,8 +218,8 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if !putParams.Active && projCtx.Build.Requester == evergreen.MergeTestRequester {
-			_, err = commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
-				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Build.Version, true)
+			_, err = commitqueue.RemoveCommitQueueItemForVersion(projCtx.ProjectRef.Identifier,
+				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Build.Version)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}

--- a/service/task.go
+++ b/service/task.go
@@ -711,8 +711,8 @@ func (uis *UIServer) taskModify(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if projCtx.Task.Requester == evergreen.MergeTestRequester {
-			_, err = commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
-				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Task.Version, true)
+			_, err = commitqueue.RemoveCommitQueueItemForVersion(projCtx.ProjectRef.Identifier,
+				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Task.Version)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
@@ -735,8 +735,8 @@ func (uis *UIServer) taskModify(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if !active && projCtx.Task.Requester == evergreen.MergeTestRequester {
-			_, err = commitqueue.RemoveCommitQueueItem(projCtx.ProjectRef.Identifier,
-				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Task.Version, true)
+			_, err = commitqueue.RemoveCommitQueueItemForVersion(projCtx.ProjectRef.Identifier,
+				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Task.Version)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}


### PR DESCRIPTION
We were calling RemoveCommitQueueItem using a versionID, but this only worked for CLI queues because the item issue would equal the versionID. Instead we should have different deletions for issue or for version.
