### PR TITLE
EVG-8028 mount on ~

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -157,7 +157,6 @@ const (
 	PowerShellSetupScriptName     = "setup.ps1"
 	PowerShellTempSetupScriptName = "setup-temp.ps1"
 	TeardownScriptName            = "teardown.sh"
-	HomeVolumeDir                 = "user_home"
 
 	RoutePaginatorNextPageHeaderKey = "Link"
 

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -316,7 +316,7 @@ func hostConfigure() cli.Command {
 						return errors.Wrap(err, "problem finding home directory")
 					}
 
-					directory = filepath.Join(userHome, evergreen.HomeVolumeDir, directory)
+					directory = filepath.Join(userHome, directory)
 				}
 			}
 

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -822,8 +822,6 @@ func mountLinuxVolume(ctx context.Context, env evergreen.Environment, h *host.Ho
 		return errors.Wrap(err, "problem running mount commands")
 	}
 
-	// write to /etc/fstab so the volume is mounted on restart
-	// use the UUID which is constant over the life of the filesystem
 	entryInFstab, err := findMnt(ctx, client, h)
 	if err != nil {
 		return errors.Wrap(err, "problem verifying mount")
@@ -833,6 +831,8 @@ func mountLinuxVolume(ctx context.Context, env evergreen.Environment, h *host.Ho
 		if err != nil {
 			return errors.Wrap(err, "can't refresh device info")
 		}
+		// write to /etc/fstab so the volume is mounted on restart
+		// use the UUID which is constant over the life of the filesystem
 		cmd := client.CreateCommand(ctx).Sudo(true).Append("tee --append /etc/fstab")
 		cmd.SetInputBytes([]byte(fmt.Sprintf("UUID=%s %s auto noatime 0 0\n", device.UUID, h.Distro.HomeDir())))
 		err = cmd.Run(ctx)

--- a/units/provisioning_setup_host_test.go
+++ b/units/provisioning_setup_host_test.go
@@ -21,10 +21,11 @@ func TestGetMostRecentlyAddedDevice(t *testing.T) {
 	]
 }`
 
-	device, err := parseLsblkOutput(lsblkOutput)
+	devices, err := parseLsblkOutput(lsblkOutput)
 	assert.NoError(t, err)
-	assert.Equal(t, "nvme1n1", device.Name)
-	assert.Equal(t, "fee4e1cc-1b86-4cee-8dd3-96f52f5b3ecb", device.UUID)
-	assert.Equal(t, "xfs", device.FSType)
-	assert.Equal(t, "/user_home", device.MountPoint)
+	assert.Len(t, devices, 5)
+	assert.Equal(t, "nvme1n1", devices[len(devices)-1].Name)
+	assert.Equal(t, "fee4e1cc-1b86-4cee-8dd3-96f52f5b3ecb", devices[len(devices)-1].UUID)
+	assert.Equal(t, "xfs", devices[len(devices)-1].FSType)
+	assert.Equal(t, "/user_home", devices[len(devices)-1].MountPoint)
 }


### PR DESCRIPTION
The strategy is:
```
If (the volume is fresh) {
    mount the volume on the instance (somewhere that's not ~)
    copy the contents of the home directory into the volume
    umount 
}
mount on ~
```

If it's being migrated from another instance (I've used whether it has a filesystem as a proxy for this) just mount on ~. I considered moving the preexisting contents into a `old_home` directory and copying the new instance's home like we do for fresh volumes, but it was decided leaving the user's configuration in place would be less confusing for users and that the image's ~ would be relatively static between workstation distros.

I considered cp'ing the contents of ~ to another place on the root partition, mounting, and mv'ing the contents into the volume. I worried this approach wouldn't work if the root partition is too small  to fit another copy of the home directory (though admittedly this is unlikely in our current configuration).