### PR TITLE
EVG-8028 remove non-home volumes from volume list

### DIFF
--- a/model/host/volume.go
+++ b/model/host/volume.go
@@ -19,6 +19,7 @@ type Volume struct {
 	NoExpiration     bool      `bson:"no_expiration" json:"no_expiration"`
 	CreationDate     time.Time `bson:"created_at" json:"created_at"`
 	Host             string    `bson:"host,omitempty" json:"host"`
+	HomeVolume       bool      `bson:"home_volume" json:"home_volume"`
 }
 
 // Insert a volume into the volumes collection.

--- a/public/static/partials/user_host_options.html
+++ b/public/static/partials/user_host_options.html
@@ -104,7 +104,7 @@
                 New Volume
               </a>
             </li>
-            <li role="presentation" ng-repeat="volume in $parent.volumes | filter:{status:'free'}">
+            <li role="presentation" ng-repeat="volume in $parent.volumes | filter:{status:'free', home_volume: true}">
               <a role="menuitem" ng-click="setHomeVolume(volume)">
                 [[ concatName(volume.volume_id, volume.display_name) ]]
               </a>

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -154,6 +154,7 @@ type APIVolume struct {
 	DeviceName       *string    `json:"device_name"`
 	HostID           *string    `json:"host_id"`
 	NoExpiration     bool       `json:"no_expiration"`
+	HomeVolume       bool       `json:"home_volume"`
 }
 
 type VolumePostRequest struct {
@@ -199,6 +200,7 @@ func (apiVolume *APIVolume) buildFromVolumeStruct(volume interface{}) error {
 	apiVolume.HostID = ToStringPtr(v.Host)
 	apiVolume.Expiration = ToTimePtr(v.Expiration)
 	apiVolume.NoExpiration = v.NoExpiration
+	apiVolume.HomeVolume = v.HomeVolume
 	return nil
 }
 
@@ -217,6 +219,7 @@ func (apiVolume *APIVolume) ToService() (interface{}, error) {
 		Expiration:       expiration,
 		Size:             apiVolume.Size,
 		NoExpiration:     apiVolume.NoExpiration,
+		HomeVolume:       apiVolume.HomeVolume,
 	}, nil
 }
 

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -759,6 +759,7 @@ func attachVolume(ctx context.Context, env evergreen.Environment, h *host.Host) 
 				AvailabilityZone: h.Zone,
 				CreatedBy:        h.StartedBy,
 				Type:             evergreen.DefaultEBSType,
+				HomeVolume:       true,
 			})
 			if err != nil {
 				return errors.Wrapf(err, "can't create a new volume for host '%s'", h.Id)


### PR DESCRIPTION
https://github.com/evergreen-ci/evergreen/commit/0da1ec1e1367fc65810c69edab58f6ae3198d961 mounts a volume on ~. If the volume has a filesystem we don't copy anything onto them on the assumption the home contents of the previous instance will work on the next. We need to prevent users from mounting other volumes they've created (and potentially created a filesystem on) that have never been a workstation's home directory.

Admittedly this is not a common case going forward, but if users migrate from existing workstations which didn't mount on ~ to new ones which do they will have problems...