### PR TITLE
EVG-8028 reintroduce home mount

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -157,7 +157,6 @@ const (
 	PowerShellSetupScriptName     = "setup.ps1"
 	PowerShellTempSetupScriptName = "setup-temp.ps1"
 	TeardownScriptName            = "teardown.sh"
-	HomeVolumeDir                 = "user_home"
 
 	RoutePaginatorNextPageHeaderKey = "Link"
 

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -316,7 +316,7 @@ func hostConfigure() cli.Command {
 						return errors.Wrap(err, "problem finding home directory")
 					}
 
-					directory = filepath.Join(userHome, evergreen.HomeVolumeDir, directory)
+					directory = filepath.Join(userHome, directory)
 				}
 			}
 

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -906,10 +906,11 @@ func findMnt(ctx context.Context, client remote.Manager, h *host.Host) (bool, er
 }
 
 type blockDevice struct {
-	Name       string `json:"name"`
-	FSType     string `json:"fstype"`
-	UUID       string `json:"uuid"`
-	MountPoint string `json:"mountpoint"`
+	Name       string        `json:"name"`
+	FSType     string        `json:"fstype"`
+	UUID       string        `json:"uuid"`
+	MountPoint string        `json:"mountpoint"`
+	Children   []blockDevice `json:"children"`
 }
 
 func getMostRecentlyAddedDevice(ctx context.Context, env evergreen.Environment, h *host.Host) (blockDevice, error) {
@@ -928,11 +929,12 @@ func getMostRecentlyAddedDevice(ctx context.Context, env evergreen.Environment, 
 		return blockDevice{}, errors.New("output contained no devices")
 	}
 
-	if !utility.StringSliceContains([]string{"", h.Distro.HomeDir()}, devices[len(devices)-1].MountPoint) {
+	lastDevice := devices[len(devices)-1]
+	if len(lastDevice.Children) != 0 || !utility.StringSliceContains([]string{"", h.Distro.HomeDir()}, lastDevice.MountPoint) {
 		return blockDevice{}, errors.New("device hasn't been attached yet")
 	}
 
-	return devices[len(devices)-1], nil
+	return lastDevice, nil
 }
 
 func parseLsblkOutput(lsblkOutput string) ([]blockDevice, error) {

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -17,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
@@ -782,15 +783,8 @@ func attachVolume(ctx context.Context, env evergreen.Environment, h *host.Host) 
 		}
 	}
 
-	// run the distro's mount script
-	var err error
-	for i := 0; i < mountRetryLimit; i++ {
-		if err = errors.Wrap(mountLinuxVolume(ctx, env, h), "can't mount volume"); err == nil {
-			return nil
-		}
-		time.Sleep(mountSleepDuration)
-	}
-	return err
+	// run the appropriate mount script
+	return errors.Wrap(mountLinuxVolume(ctx, env, h), "can't mount volume")
 }
 
 func mountLinuxVolume(ctx context.Context, env evergreen.Environment, h *host.Host) error {
@@ -806,64 +800,77 @@ func mountLinuxVolume(ctx context.Context, env evergreen.Environment, h *host.Ho
 		}))
 	}()
 
-	device, err := getMostRecentlyAddedDevice(ctx, env, h)
+	// wait for the volume to come up on the instance
+	device, err := waitForDevice(ctx, env, h)
 	if err != nil {
-		return errors.Wrap(err, "can't get device info")
+		return errors.Wrap(err, "can't get device")
 	}
 
-	cmd := client.CreateCommand(ctx).Sudo(true)
-	// umount if it's already mounted
+	// the device is aleady mounted on ~
+	// nothing left to do
 	if device.MountPoint != "" {
-		cmd.Append(fmt.Sprintf("umount -f /dev/%s", device.Name))
-	}
-	// format if the volume doesn't have a filesystem
-	if device.FSType == "" {
-		cmd.Append(fmt.Sprintf("%s /dev/%s", h.Distro.HomeVolumeSettings.FormatCommand, device.Name))
-	}
-	cmd.Append(fmt.Sprintf("mkdir -p /%s", evergreen.HomeVolumeDir))
-	cmd.Append(fmt.Sprintf("mount /dev/%s /%s", device.Name, evergreen.HomeVolumeDir))
-	cmd.Append(fmt.Sprintf("chown -R %s:%s /%s", h.User, h.User, evergreen.HomeVolumeDir))
-	// add symlink if it wasn't created yet
-	symlinkExists, err := symlinkExists(ctx, client, h)
-	if err != nil {
-		return errors.Wrapf(err, "can't verify if symlink exists for host '%s'", h.Id)
-	}
-	if !symlinkExists {
-		cmd.Append(fmt.Sprintf("ln -s /%s %s", evergreen.HomeVolumeDir, h.Distro.HomeDir()))
+		return nil
 	}
 
-	if err = cmd.Run(ctx); err != nil {
+	// this is a fresh volume
+	if device.FSType == "" {
+		if err = prepareVolume(ctx, client, h, device); err != nil {
+			return errors.Wrap(err, "can't prepare new volume")
+		}
+	}
+
+	if err = client.CreateCommand(ctx).Sudo(true).Append(fmt.Sprintf("mount /dev/%s %s", device.Name, h.Distro.HomeDir())).Run(ctx); err != nil {
 		return errors.Wrap(err, "problem running mount commands")
 	}
 
-	// write to /etc/fstab so the volume is mounted on restart
-	// use the UUID which is constant over the life of the filesystem
-	device, err = getMostRecentlyAddedDevice(ctx, env, h)
+	entryInFstab, err := findMnt(ctx, client, h)
 	if err != nil {
-		return errors.Wrap(err, "can't refresh device info")
+		return errors.Wrap(err, "problem verifying mount")
 	}
-	err = client.CreateCommand(ctx).Sudo(true).SetInputBytes([]byte(fmt.Sprintf("UUID=%s /%s auto noatime 0 0\n", device.UUID, evergreen.HomeVolumeDir))).Append("tee --append /etc/fstab").Run(ctx)
-	if err != nil {
-		return errors.Wrap(err, "problem appending to fstab")
+	if !entryInFstab {
+		device, err = getMostRecentlyAddedDevice(ctx, env, h)
+		if err != nil {
+			return errors.Wrap(err, "can't refresh device info")
+		}
+		// write to /etc/fstab so the volume is mounted on restart
+		// use the UUID which is constant over the life of the filesystem
+		cmd := client.CreateCommand(ctx).Sudo(true).Append("tee --append /etc/fstab")
+		cmd.SetInputBytes([]byte(fmt.Sprintf("UUID=%s %s auto noatime 0 0\n", device.UUID, h.Distro.HomeDir())))
+		err = cmd.Run(ctx)
+		if err != nil {
+			return errors.Wrap(err, "problem appending to fstab")
+		}
 	}
 
 	return nil
 }
 
-func symlinkExists(ctx context.Context, client remote.Manager, h *host.Host) (bool, error) {
-	cmd := client.CreateCommand(ctx).Append(fmt.Sprintf("ls %s/%s", h.Distro.HomeDir(), evergreen.HomeVolumeDir)).Background(true)
-	if err := cmd.Run(ctx); err != nil {
-		return false, errors.Wrap(err, "can't run umount command")
-	}
-	exitCode, err := cmd.Wait(ctx)
-	if err != nil {
-		if exitCode != 0 {
-			return false, nil
+func prepareVolume(ctx context.Context, client remote.Manager, h *host.Host, device blockDevice) error {
+	cmd := client.CreateCommand(ctx).Sudo(true)
+	cmd.Append(fmt.Sprintf("%s /dev/%s", h.Distro.HomeVolumeSettings.FormatCommand, device.Name))
+	cmd.Append("mkdir -p /mnt")
+	cmd.Append(fmt.Sprintf("mount /dev/%s /mnt", device.Name))
+	cmd.Append(fmt.Sprintf("rsync -a %s/ /mnt", h.Distro.HomeDir()))
+	cmd.Append("umount /mnt")
+
+	return errors.Wrap(cmd.Run(ctx), "error with volume initialization")
+}
+
+func waitForDevice(ctx context.Context, env evergreen.Environment, h *host.Host) (blockDevice, error) {
+	var device blockDevice
+	var err error
+	for i := 0; i < mountRetryLimit; i++ {
+		device, err = getMostRecentlyAddedDevice(ctx, env, h)
+		if err == nil {
+			break
 		}
-		return false, errors.Wrap(err, "problem waiting for ls command")
+		time.Sleep(mountSleepDuration)
+	}
+	if err != nil {
+		return device, errors.Wrap(err, "device didn't come up in time")
 	}
 
-	return true, nil
+	return device, nil
 }
 
 func writeIcecreamConfig(ctx context.Context, env evergreen.Environment, h *host.Host) error {
@@ -881,6 +888,23 @@ func writeIcecreamConfig(ctx context.Context, env evergreen.Environment, h *host
 	return nil
 }
 
+func findMnt(ctx context.Context, client remote.Manager, h *host.Host) (bool, error) {
+	cmd := client.CreateCommand(ctx).Background(true)
+	cmd.Append(fmt.Sprintf("findmnt --fstab --target %s", h.Distro.HomeDir()))
+	if err := cmd.Run(ctx); err != nil {
+		return false, errors.Wrap(err, "can't run findmnt command")
+	}
+	exitCode, err := cmd.Wait(ctx)
+	if err != nil {
+		if exitCode != 0 {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "problem waiting for findmnt command")
+	}
+
+	return true, nil
+}
+
 type blockDevice struct {
 	Name       string `json:"name"`
 	FSType     string `json:"fstype"`
@@ -895,20 +919,29 @@ func getMostRecentlyAddedDevice(ctx context.Context, env evergreen.Environment, 
 	if err != nil {
 		return blockDevice{}, errors.Wrap(err, "can't run lsblk")
 	}
-	return parseLsblkOutput(strings.Join(lsblkOutput, "\n"))
+
+	devices, err := parseLsblkOutput(strings.Join(lsblkOutput, "\n"))
+	if err != nil {
+		return blockDevice{}, errors.Wrap(err, "can't parse lsblk output")
+	}
+	if len(devices) == 0 {
+		return blockDevice{}, errors.New("output contained no devices")
+	}
+
+	if !utility.StringSliceContains([]string{"", h.Distro.HomeDir()}, devices[len(devices)-1].MountPoint) {
+		return blockDevice{}, errors.New("device hasn't been attached yet")
+	}
+
+	return devices[len(devices)-1], nil
 }
 
-func parseLsblkOutput(lsblkOutput string) (blockDevice, error) {
+func parseLsblkOutput(lsblkOutput string) ([]blockDevice, error) {
 	devices := struct {
 		BlockDevices []blockDevice `json:"blockdevices"`
 	}{}
 	if err := json.Unmarshal([]byte(lsblkOutput), &devices); err != nil {
-		return blockDevice{}, errors.Wrapf(err, "can't parse lsblk output '%s'", lsblkOutput)
+		return nil, errors.Wrapf(err, "can't parse lsblk output '%s'", lsblkOutput)
 	}
 
-	if len(devices.BlockDevices) == 0 {
-		return blockDevice{}, errors.New("output contained no devices")
-	}
-
-	return devices.BlockDevices[len(devices.BlockDevices)-1], nil
+	return devices.BlockDevices, nil
 }

--- a/units/provisioning_setup_host_test.go
+++ b/units/provisioning_setup_host_test.go
@@ -21,10 +21,11 @@ func TestGetMostRecentlyAddedDevice(t *testing.T) {
 	]
 }`
 
-	device, err := parseLsblkOutput(lsblkOutput)
+	devices, err := parseLsblkOutput(lsblkOutput)
 	assert.NoError(t, err)
-	assert.Equal(t, "nvme1n1", device.Name)
-	assert.Equal(t, "fee4e1cc-1b86-4cee-8dd3-96f52f5b3ecb", device.UUID)
-	assert.Equal(t, "xfs", device.FSType)
-	assert.Equal(t, "/user_home", device.MountPoint)
+	assert.Len(t, devices, 5)
+	assert.Equal(t, "nvme1n1", devices[len(devices)-1].Name)
+	assert.Equal(t, "fee4e1cc-1b86-4cee-8dd3-96f52f5b3ecb", devices[len(devices)-1].UUID)
+	assert.Equal(t, "xfs", devices[len(devices)-1].FSType)
+	assert.Equal(t, "/user_home", devices[len(devices)-1].MountPoint)
 }


### PR DESCRIPTION
Reintroduce the changes from #3610 which were reverted because they broke provisioning for workstations.

The issue was not caught in staging because the distro I was testing on had an additional volume besides the root volume and the home volume. Without the intervening volume we were getting the root volume and thinking it was the home volume, since the volume is partitioned.