### PR TITLE
EVG-8021: fields on Patch gql type for all task statuses

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -160,6 +160,7 @@ type ComplexityRoot struct {
 		Activated           func(childComplexity int) int
 		Alias               func(childComplexity int) int
 		Author              func(childComplexity int) int
+		BaseTaskStatuses    func(childComplexity int) int
 		BaseVersionID       func(childComplexity int) int
 		Builds              func(childComplexity int) int
 		CommitQueuePosition func(childComplexity int) int
@@ -174,6 +175,7 @@ type ComplexityRoot struct {
 		ProjectId           func(childComplexity int) int
 		Status              func(childComplexity int) int
 		TaskCount           func(childComplexity int) int
+		TaskStatuses        func(childComplexity int) int
 		Tasks               func(childComplexity int) int
 		Time                func(childComplexity int) int
 		Variants            func(childComplexity int) int
@@ -422,6 +424,8 @@ type PatchResolver interface {
 	Project(ctx context.Context, obj *model.APIPatch) (*PatchProject, error)
 	Builds(ctx context.Context, obj *model.APIPatch) ([]*model.APIBuild, error)
 	CommitQueuePosition(ctx context.Context, obj *model.APIPatch) (*int, error)
+	TaskStatuses(ctx context.Context, obj *model.APIPatch) ([]string, error)
+	BaseTaskStatuses(ctx context.Context, obj *model.APIPatch) ([]string, error)
 }
 type QueryResolver interface {
 	UserPatches(ctx context.Context, limit *int, page *int, patchName *string, statuses []string, userID *string, includeCommitQueue *bool) (*UserPatches, error)
@@ -1013,6 +1017,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Patch.Author(childComplexity), true
 
+	case "Patch.baseTaskStatuses":
+		if e.complexity.Patch.BaseTaskStatuses == nil {
+			break
+		}
+
+		return e.complexity.Patch.BaseTaskStatuses(childComplexity), true
+
 	case "Patch.baseVersionID":
 		if e.complexity.Patch.BaseVersionID == nil {
 			break
@@ -1110,6 +1121,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Patch.TaskCount(childComplexity), true
+
+	case "Patch.taskStatuses":
+		if e.complexity.Patch.TaskStatuses == nil {
+			break
+		}
+
+		return e.complexity.Patch.TaskStatuses(childComplexity), true
 
 	case "Patch.tasks":
 		if e.complexity.Patch.Tasks == nil {
@@ -2404,6 +2422,8 @@ type Patch {
   project: PatchProject
   builds: [Build!]!
   commitQueuePosition: Int
+  taskStatuses: [String!]!
+  baseTaskStatuses: [String!]!
 }
 
 type Build {
@@ -6180,6 +6200,74 @@ func (ec *executionContext) _Patch_commitQueuePosition(ctx context.Context, fiel
 	res := resTmp.(*int)
 	fc.Result = res
 	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Patch_taskStatuses(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Patch",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Patch().TaskStatuses(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Patch_baseTaskStatuses(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Patch",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Patch().BaseTaskStatuses(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _PatchBuildVariant_variant(ctx context.Context, field graphql.CollectedField, obj *PatchBuildVariant) (ret graphql.Marshaler) {
@@ -12837,6 +12925,34 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 					}
 				}()
 				res = ec._Patch_commitQueuePosition(ctx, field, obj)
+				return res
+			})
+		case "taskStatuses":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Patch_taskStatuses(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "baseTaskStatuses":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Patch_baseTaskStatuses(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			})
 		default:

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -190,7 +190,7 @@ func (r *patchResolver) CommitQueuePosition(ctx context.Context, apiPatch *restM
 func (r *patchResolver) TaskStatuses(ctx context.Context, obj *restModel.APIPatch) ([]string, error) {
 	tasks, _, err := r.sc.FindTasksByVersion(*obj.Id, task.DisplayNameKey, []string{}, "", "", 1, 0, 0)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting version task: %s", err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting version tasks: %s", err.Error()))
 	}
 	return getAllTaskStatuses(tasks), nil
 }
@@ -198,7 +198,7 @@ func (r *patchResolver) TaskStatuses(ctx context.Context, obj *restModel.APIPatc
 func (r *patchResolver) BaseTaskStatuses(ctx context.Context, obj *restModel.APIPatch) ([]string, error) {
 	baseTasks, err := getVersionBaseTasks(r.sc, *obj.Id)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting version base task statuses: %s", err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting version base tasks: %s", err.Error()))
 	}
 	return getAllTaskStatuses(baseTasks), nil
 }

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -188,7 +188,7 @@ func (r *patchResolver) CommitQueuePosition(ctx context.Context, apiPatch *restM
 }
 
 func (r *patchResolver) TaskStatuses(ctx context.Context, obj *restModel.APIPatch) ([]string, error) {
-	tasks, _, err := r.sc.FindTasksByVersion(*obj.Id, task.DisplayNameKey, []string{}, "", "", 1, 0, 0)
+	tasks, _, err := r.sc.FindTasksByVersion(*obj.Id, task.DisplayNameKey, []string{}, "", "", 1, 0, 0, []string{task.StatusKey})
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting version tasks: %s", err.Error()))
 	}
@@ -453,7 +453,7 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sortBy *
 	if taskName != nil {
 		taskNameParam = *taskName
 	}
-	tasks, count, err := r.sc.FindTasksByVersion(patchID, sorter, statusesParam, variantParam, taskNameParam, sortDirParam, pageParam, limitParam)
+	tasks, count, err := r.sc.FindTasksByVersion(patchID, sorter, statusesParam, variantParam, taskNameParam, sortDirParam, pageParam, limitParam, []string{})
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting patch tasks for %s: %s", patchID, err.Error()))
 	}
@@ -766,7 +766,7 @@ func (r *queryResolver) PatchBuildVariants(ctx context.Context, patchID string) 
 	for _, variant := range patch.Variants {
 		tasksByVariant[*variant] = []*PatchBuildVariantTask{}
 	}
-	tasks, _, err := r.sc.FindTasksByVersion(patchID, task.DisplayNameKey, []string{}, "", "", 1, 0, 0)
+	tasks, _, err := r.sc.FindTasksByVersion(patchID, task.DisplayNameKey, []string{}, "", "", 1, 0, 0, []string{})
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting tasks for patch `%s`: %s", patchID, err))
 	}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -195,6 +195,8 @@ type Patch {
   project: PatchProject
   builds: [Build!]!
   commitQueuePosition: Int
+  taskStatuses: [String!]!
+  baseTaskStatuses: [String!]!
 }
 
 type Build {

--- a/graphql/tests/patch-taskStatuses/data.json
+++ b/graphql/tests/patch-taskStatuses/data.json
@@ -269,5 +269,98 @@
       "r": "github_pull_request",
       "status": "success"
     }
+  ],
+  "patches": [
+    {
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e4" },
+      "desc": "'evergreen-ci/spruce' pull request #27 by tgrander: Refactor App + Use Context for global state (https://github.com/evergreen-ci/spruce/pull/27)",
+      "branch": "spruce",
+      "githash": "3b53f9b61226491cd31113c773d66e351957ed29",
+      "patch_number": 20,
+      "author": "trey.granderson",
+      "version": "5dd2e89cd1fe07048e43bb9c",
+      "status": "failed",
+      "create_time": { "$date": "2019-11-18T18:53:15Z" },
+      "start_time": { "$date": "2019-11-18T18:54:15.734Z" },
+      "finish_time": { "$date": "2019-11-18T18:57:15.053Z" },
+      "build_variants": ["ubuntu1804"],
+      "tasks": ["compile", "test", "lint", "coverage"],
+      "variants_tasks": [
+        {
+          "variant": "ubuntu1804",
+          "tasks": ["lint", "coverage", "compile", "test"],
+          "displaytasks": []
+        }
+      ],
+      "patches": [
+        {
+          "name": "",
+          "githash": "3b53f9b61226491cd31113c773d66e351957ed29",
+          "patch_set": {
+            "patch_file_id": "5dd2e89cd1fe07048e43bb9e_3b53f9b61226491cd31113c773d66e351957ed29",
+            "summary": [
+              { "filename": "package.json", "additions": 2, "deletions": 0 },
+              {
+                "filename": "src/components/Navbar.tsx",
+                "additions": 70,
+                "deletions": 0
+              },
+              {
+                "filename": "src/components/app/App.tsx",
+                "additions": 78,
+                "deletions": 289
+              },
+              {
+                "filename": "src/components/navbar/DevMenu.tsx",
+                "additions": 62,
+                "deletions": 0
+              },
+              {
+                "filename": "src/components/navbar/PluginsMenu.tsx",
+                "additions": 42,
+                "deletions": 0
+              },
+              {
+                "filename": "src/context/ContextProvider.tsx",
+                "additions": 11,
+                "deletions": 0
+              },
+              {
+                "filename": "src/context/apiClient.tsx",
+                "additions": 70,
+                "deletions": 0
+              },
+              {
+                "filename": "src/context/user.tsx",
+                "additions": 33,
+                "deletions": 0
+              },
+              {
+                "filename": "src/utils/isDevelopment.ts",
+                "additions": 1,
+                "deletions": 0
+              },
+              { "filename": "tslint.json", "additions": 1, "deletions": 0 }
+            ]
+          },
+          "message": ""
+        }
+      ],
+      "activated": true,
+      "patched_config": "stepback: true\ncommand_type: test\nignore:\n - \"*.md\"\n - \".github/*\"\n\nfunctions:\n get-project:\n command: git.get_project\n type: setup\n params:\n directory: spruce\n\n npm-install:\n command: subprocess.exec\n type: setup\n params:\n working_dir: spruce\n binary: npm\n args: [install]\n\n npm-test:\n command: subprocess.exec\n params:\n working_dir: spruce\n binary: npm\n args: [test, --, -u, --reporters=default, --reporters=jest-junit]\n env:\n CI: \"true\"\n\n npm-lint:\n command: subprocess.exec\n params:\n working_dir: spruce\n binary: npm\n args: [run, lint]\n\n npm-build:\n command: subprocess.exec\n params:\n working_dir: spruce\n binary: npm\n args: [run, build]\n\n npm-build:\n command: subprocess.exec\n params:\n working_dir: spruce\n binary: npm\n args: [run, build]\n\n npm-coverage:\n command: subprocess.exec\n params:\n working_dir: spruce\n binary: npm\n args: [run, coverage]\n\n attach-results:\n command: attach.xunit_results\n params:\n files:\n - \"./spruce/junit.xml\"\n\ntasks:\n - name: compile\n commands:\n - func: get-project\n - func: npm-install\n - func: npm-build\n - func: npm-build\n - name: test\n commands:\n - func: get-project\n - func: npm-install\n - func: npm-test\n - func: attach-results\n - name: lint\n commands:\n - func: get-project\n - func: npm-install\n - func: npm-lint\n - name: coverage\n commands:\n - func: get-project\n - func: npm-install\n - func: npm-coverage\n\nbuildvariants:\n - name: ubuntu1804\n display_name: Ubuntu 18.04\n run_on:\n - ubuntu1804-test\n tasks:\n - name: compile\n - name: test\n - name: lint\n - name: coverage\n",
+      "alias": "__github",
+      "github_patch_data": {
+        "pr_number": 27,
+        "base_owner": "evergreen-ci",
+        "base_repo": "spruce",
+        "base_branch": "master",
+        "head_owner": "evergreen-ci",
+        "head_repo": "spruce",
+        "head_hash": "2b37dacf86f9d4d1545faaba37c7c5693202e645",
+        "author": "tgrander",
+        "author_uid": 15262143,
+        "merge_commit_sha": ""
+      }
+    }
   ]
 }

--- a/graphql/tests/patch-taskStatuses/data.json
+++ b/graphql/tests/patch-taskStatuses/data.json
@@ -1,0 +1,273 @@
+{
+  "versions": [
+    {
+      "_id": "5e4ff3abe3c3317e352062e4",
+      "create_time": {
+        "$date": "2020-02-21T15:13:48.801Z"
+      },
+      "start_time": {
+        "$date": "2020-02-21T15:15:38.261Z"
+      },
+      "finish_time": {
+        "$date": "2020-02-21T15:29:54.869Z"
+      },
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "author": "brian.samek",
+      "author_email": "",
+      "message": "'evergreen-ci/evergreen' pull request #3186 by bsamek: EVG-7425 Don't send ShouldExit to unprovisioned hosts (https://github.com/evergreen-ci/evergreen/pull/3186)",
+      "status": "failed",
+      "order": 2567,
+      "config_number": 1,
+      "ignored": false,
+      "owner_name": "",
+      "repo_name": "",
+      "branch_name": "master",
+      "repo_kind": "",
+      "build_variants_status": [
+        {
+          "build_variant": "ubuntu1604",
+          "activated": true,
+          "build_id": "evergreen_ubuntu1604_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48"
+        },
+        {
+          "build_variant": "lint",
+          "activated": true,
+          "build_id": "evergreen_lint_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48"
+        }
+      ],
+      "builds": [
+        "evergreen_ubuntu1604_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+        "evergreen_lint_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48"
+      ],
+      "identifier": "evergreen",
+      "remote": false,
+      "remote_path": "",
+      "r": "github_pull_request",
+      "author_id": "brian.samek"
+    },
+    {
+      "_id": "evergreen_5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "create_time": {
+        "$date": "2020-02-20T20:37:06Z"
+      },
+      "start_time": {
+        "$date": "2020-02-22T01:40:41.991Z"
+      },
+      "finish_time": {
+        "$date": "0001-01-01T00:00:00Z"
+      },
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "author": "Trey Granderson",
+      "author_email": "trey.granderson@mongodb.com",
+      "message": "EVG-7343: timeTaken and makespan fields on Patch type (#3166)\n\n* EVG-7327: query for patch by id\r\n\r\n* EVG-7343: add makespan and timetaken to patch schema type\r\n\r\n* generated\r\n\r\n* remove patch dates type\r\n\r\n* add back time fields\r\n\r\n* change time field to duration\r\n\r\n* update tests\r\n\r\n* put time fields back on Patch type\r\n\r\n* revert time fields\r\n\r\n* update tests\r\n\r\n* import time in util\r\n\r\n* fix util imports\r\n\r\n* change patch id to $oid\r\n\r\n* change $oid field to numbers\r\n\r\n* remove dashes from $oid field\r\n\r\n* more fixes\r\n\r\n* omg\r\n\r\n* use correct patch id in query\r\n\r\n* add create time to test patch\r\n\r\n* add to patch\r\n\r\n* idek at this point\r\n\r\n* fix duration query\r\n\r\n* add right version id to tasks\r\n\r\n* use duration.String()\r\n\r\n* remove unusued imports in util\r\n\r\n* change json keys of tasks\r\n\r\n* use $date in task date fields\r\n\r\n* round by seconds\r\n\r\n* update test results\r\n\r\n* merge merge merge\r\n\r\n* fix leftover conflict\r\n\r\n* duration times of 0 are null\r\n\r\n* convert durations to string before inspecting",
+      "status": "started",
+      "order": 1354,
+      "config_number": 1,
+      "ignored": false,
+      "owner_name": "evergreen-ci",
+      "repo_name": "evergreen",
+      "branch_name": "master",
+      "repo_kind": "github",
+      "build_variants_status": [
+        {
+          "build_variant": "linux-docker",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-20T20:37:12.925Z"
+          },
+          "build_id": "evergreen_linux_docker_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        },
+        {
+          "build_variant": "coverage",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-20T20:37:12.925Z"
+          },
+          "build_id": "evergreen_coverage_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        },
+        {
+          "build_variant": "lint",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-20T20:37:12.925Z"
+          },
+          "build_id": "evergreen_lint_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        },
+        {
+          "build_variant": "osx",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-21T02:50:12.919Z"
+          },
+          "build_id": "evergreen_osx_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        },
+        {
+          "build_variant": "rhel71-power8",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-21T02:50:12.919Z"
+          },
+          "build_id": "evergreen_rhel71_power8_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        },
+        {
+          "build_variant": "rhel72-s390x",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-21T02:50:12.919Z"
+          },
+          "build_id": "evergreen_rhel72_s390x_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        },
+        {
+          "build_variant": "race-detector",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-20T20:37:12.925Z"
+          },
+          "build_id": "evergreen_race_detector_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        },
+        {
+          "build_variant": "ubuntu1604",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-20T20:37:12.925Z"
+          },
+          "build_id": "evergreen_ubuntu1604_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        },
+        {
+          "build_variant": "ubuntu1604-docker",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-20T20:37:12.925Z"
+          },
+          "build_id": "evergreen_ubuntu1604_docker_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        },
+        {
+          "build_variant": "ubuntu1604-arm64",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-21T02:50:12.919Z"
+          },
+          "build_id": "evergreen_ubuntu1604_arm64_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        },
+        {
+          "build_variant": "windows",
+          "activated": true,
+          "activate_at": {
+            "$date": "2020-02-20T20:37:12.925Z"
+          },
+          "build_id": "evergreen_windows_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+        }
+      ],
+      "builds": [
+        "evergreen_linux_docker_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",
+        "evergreen_coverage_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",
+        "evergreen_lint_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",
+        "evergreen_osx_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",
+        "evergreen_rhel71_power8_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",
+        "evergreen_rhel72_s390x_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",
+        "evergreen_race_detector_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",
+        "evergreen_ubuntu1604_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",
+        "evergreen_ubuntu1604_docker_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",
+        "evergreen_ubuntu1604_arm64_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",
+        "evergreen_windows_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06"
+      ],
+      "identifier": "evergreen",
+      "remote": false,
+      "remote_path": "self-tests.yml",
+      "r": "gitter_request",
+      "author_id": "trey.granderson"
+    }
+  ],
+  "tasks": [
+    {
+      "_id": "1",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "display_name": "test-thirdparty-docker",
+      "r": "github_pull_request",
+      "status": "success"
+    },
+    {
+      "_id": "2",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "display_name": "test-cloud",
+      "r": "github_pull_request",
+      "status": "failed"
+    },
+    {
+      "_id": "XYZ",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "display_name": "silver",
+      "r": "github_pull_request",
+      "status": "setup-failed"
+    },
+    {
+      "_id": "X",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "display_name": "gold",
+      "r": "github_pull_request",
+      "status": "undispatched"
+    },
+    {
+      "_id": "3",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "windows",
+      "display_name": "lint",
+      "r": "github_pull_request",
+      "status": "success"
+    },
+    {
+      "_id": "4",
+      "version": "5e4ff3abe3c3317e352062e4",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "windows",
+      "display_name": "compile",
+      "r": "github_pull_request",
+      "status": "failed"
+    },
+    {
+      "_id": "base-task-1",
+      "version": "evergreen_5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "display_name": "test-thirdparty-docker",
+      "r": "github_pull_request",
+      "status": "success"
+    },
+    {
+      "_id": "base-task-2",
+      "version": "evergreen_5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "display_name": "test-cloud",
+      "r": "github_pull_request",
+      "status": "failed"
+    },
+    {
+      "_id": "base-task-3",
+      "version": "evergreen_5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "windows",
+      "display_name": "lint",
+      "r": "github_pull_request",
+      "status": "success"
+    },
+    {
+      "_id": "base-task-4",
+      "version": "evergreen_5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "windows",
+      "display_name": "compile",
+      "r": "github_pull_request",
+      "status": "success"
+    }
+  ]
+}

--- a/graphql/tests/patch-taskStatuses/queries/baseTaskStatuses.graphql
+++ b/graphql/tests/patch-taskStatuses/queries/baseTaskStatuses.graphql
@@ -1,0 +1,5 @@
+{
+  patch(id: "5e4ff3abe3c3317e352062e4") {
+    baseTaskStatuses
+  }
+}

--- a/graphql/tests/patch-taskStatuses/queries/taskStatuses.graphql
+++ b/graphql/tests/patch-taskStatuses/queries/taskStatuses.graphql
@@ -1,0 +1,5 @@
+{
+  patch(id: "5e4ff3abe3c3317e352062e4") {
+    taskStatuses
+  }
+}

--- a/graphql/tests/patch-taskStatuses/results.json
+++ b/graphql/tests/patch-taskStatuses/results.json
@@ -5,12 +5,7 @@
       "result": {
         "data": {
           "patch": {
-            "baseTaskStatuses": [
-              "success",
-              "failed",
-              "setup-failed",
-              "undispatched"
-            ]
+            "baseTaskStatuses": ["success", "failed"]
           }
         }
       }
@@ -20,7 +15,12 @@
       "result": {
         "data": {
           "patch": {
-            "taskStatuses": ["success", "failed"]
+            "taskStatuses": [
+              "success",
+              "setup-failed",
+              "failed",
+              "undispatched"
+            ]
           }
         }
       }

--- a/graphql/tests/patch-taskStatuses/results.json
+++ b/graphql/tests/patch-taskStatuses/results.json
@@ -1,0 +1,29 @@
+{
+  "tests": [
+    {
+      "query_file": "baseTaskStatuses.graphql",
+      "result": {
+        "data": {
+          "patch": {
+            "baseTaskStatuses": [
+              "success",
+              "failed",
+              "setup-failed",
+              "undispatched"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "taskStatuses.graphql",
+      "result": {
+        "data": {
+          "patch": {
+            "taskStatuses": ["success", "failed"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/graphql/tests/patch-taskStatuses/results.json
+++ b/graphql/tests/patch-taskStatuses/results.json
@@ -5,7 +5,7 @@
       "result": {
         "data": {
           "patch": {
-            "baseTaskStatuses": ["success", "failed"]
+            "baseTaskStatuses": ["failed", "success"]
           }
         }
       }
@@ -16,9 +16,9 @@
         "data": {
           "patch": {
             "taskStatuses": [
-              "success",
-              "setup-failed",
               "failed",
+              "setup-failed",
+              "success",
               "undispatched"
             ]
           }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -536,5 +536,8 @@ func getAllTaskStatuses(tasks []task.Task) []string {
 	for key := range statusesMap {
 		statusesArr = append(statusesArr, key)
 	}
+	sort.SliceStable(statusesArr, func(i, j int) bool {
+		return statusesArr[i] < statusesArr[j]
+	})
 	return statusesArr
 }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -99,17 +99,13 @@ func IsURL(str string) bool {
 	return err == nil && u.Scheme != "" && u.Host != ""
 }
 
-// BaseTaskStatuses represents the format {buildVariant: {displayName: status}} for base task statuses
-type BaseTaskStatuses map[string]map[string]string
-
-// GetBaseTaskStatusesFromPatchID gets the status of each base build associated with a task
-func GetBaseTaskStatusesFromPatchID(r *queryResolver, patchID string) (BaseTaskStatuses, error) {
-	version, err := r.sc.FindVersionById(patchID)
+func getVersionBaseTasks(d data.Connector, versionID string) ([]task.Task, error) {
+	version, err := d.FindVersionById(versionID)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting version %s: %s", patchID, err.Error())
+		return nil, fmt.Errorf("Error getting version %s: %s", versionID, err.Error())
 	}
 	if version == nil {
-		return nil, fmt.Errorf("No version found for ID %s", patchID)
+		return nil, fmt.Errorf("No version found for ID %s", versionID)
 	}
 	baseVersion, err := model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(version.Identifier, version.Revision))
 	if err != nil {
@@ -125,7 +121,18 @@ func GetBaseTaskStatusesFromPatchID(r *queryResolver, patchID string) (BaseTaskS
 	if baseTasks == nil {
 		return nil, fmt.Errorf("No tasks found for version %s", baseVersion.Id)
 	}
+	return baseTasks, nil
+}
 
+// BaseTaskStatuses represents the format {buildVariant: {displayName: status}} for base task statuses
+type BaseTaskStatuses map[string]map[string]string
+
+// GetBaseTaskStatusesFromPatchID gets the status of each base build associated with a task
+func GetBaseTaskStatusesFromPatchID(d data.Connector, patchID string) (BaseTaskStatuses, error) {
+	baseTasks, err := getVersionBaseTasks(d, patchID)
+	if err != nil {
+		return nil, err
+	}
 	baseTaskStatusesByDisplayNameByVariant := make(map[string]map[string]string)
 	for _, task := range baseTasks {
 		if _, ok := baseTaskStatusesByDisplayNameByVariant[task.BuildVariant]; !ok {
@@ -518,4 +525,16 @@ func canRestartTask(ctx context.Context, at *restModel.APITask) (*bool, error) {
 	nonrestartableStatuses := []string{evergreen.TaskStarted, evergreen.TaskUnstarted, evergreen.TaskUndispatched, evergreen.TaskDispatched, evergreen.TaskInactive}
 	canRestart := !utility.StringSliceContains(nonrestartableStatuses, *at.Status) || at.Aborted || (at.DisplayOnly && *taskBlocked)
 	return &canRestart, nil
+}
+
+func getAllTaskStatuses(tasks []task.Task) []string {
+	statusesMap := map[string]bool{}
+	for _, task := range tasks {
+		statusesMap[task.Status] = true
+	}
+	statusesArr := []string{}
+	for key := range statusesMap {
+		statusesArr = append(statusesArr, key)
+	}
+	return statusesArr
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2014,7 +2014,7 @@ func GetTimeSpent(tasks []Task) (time.Duration, time.Duration) {
 
 // GetTasksByVersion gets all tasks for a specific version
 // Query results can be filtered by task name, variant name and status in addition to being paginated and limited
-func GetTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int) ([]Task, int, error) {
+func GetTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int, fieldsToProject []string) ([]Task, int, error) {
 	match := bson.M{
 		VersionKey: versionID,
 	}
@@ -2041,6 +2041,13 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 	query := db.Query(match).Sort(sorters)
 	if limit > 0 {
 		query = query.Limit(limit).Skip(page * limit)
+	}
+	if len(fieldsToProject) > 0 {
+		fieldKeys := bson.M{}
+		for _, field := range fieldsToProject {
+			fieldKeys[field] = 1
+		}
+		query.Project(fieldKeys)
 	}
 
 	tasks := []Task{}

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -123,7 +123,7 @@ type Connector interface {
 	FindTestsByTaskId(string, string, string, string, int, int) ([]testresult.TestResult, error)
 	FindTestsByTaskIdFilterSortPaginate(string, string, []string, string, int, int, int, int) ([]testresult.TestResult, error)
 	GetTestCountByTaskIdAndFilters(string, string, []string, int) (int, error)
-	FindTasksByVersion(string, string, []string, string, string, int, int, int) ([]task.Task, int, error)
+	FindTasksByVersion(string, string, []string, string, string, int, int, int, []string) ([]task.Task, int, error)
 	// FindUserById is a method to find a specific user given its ID.
 	FindUserById(string) (gimlet.User, error)
 	//FindUserByGithubName is a method to find a user given their Github name, if configured.

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -210,8 +210,8 @@ func (tc *DBTaskConnector) GetManifestByTask(taskId string) (*manifest.Manifest,
 
 // FindTasksByVersion gets all tasks for a specific version
 // Results can be filtered by task name, variant name and status in addition to being paginated and limited
-func (tc *DBTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int) ([]task.Task, int, error) {
-	tasks, total, err := task.GetTasksByVersion(versionID, sortBy, statuses, variant, taskName, sortDir, page, limit)
+func (tc *DBTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int, fieldsToProject []string) ([]task.Task, int, error) {
+	tasks, total, err := task.GetTasksByVersion(versionID, sortBy, statuses, variant, taskName, sortDir, page, limit, fieldsToProject)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -422,7 +422,7 @@ func (tc *MockTaskConnector) GetManifestByTask(taskId string) (*manifest.Manifes
 	return nil, errors.Errorf("task '%s' not found", taskId)
 }
 
-func (tc *MockTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int) ([]task.Task, int, error) {
+func (tc *MockTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int, fieldsToProject []string) ([]task.Task, int, error) {
 	// FindTasksByVersion is extensively tested byt he gql test suite for the patchTasks query
 	return nil, 0, nil
 }


### PR DESCRIPTION
Resolver that gets all tasks for a patch. Will be used to dynamically render the patch task statuses in the dropdown on patch details page. 