### PR TITLE
MAKE-1152: Use MaxInt32 instead of MaxInt64

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -864,10 +864,10 @@ func (h *Host) GetJasperProcess(ctx context.Context, env evergreen.Environment, 
 		return false, "", nil
 	}
 
-	// using MaxInt64 because we can assume the in-mem buffer size is small
+	// using MaxInt32 because we can assume the in-mem buffer size is small
 	// enough and want to get ALL logs in the buffer with one call to
 	// GetLogsStream.
-	logStream, err := client.GetLogStream(ctx, processID, math.MaxInt64)
+	logStream, err := client.GetLogStream(ctx, processID, math.MaxInt32)
 	if err != nil {
 		return true, "", errors.Wrap(err, "can't get output of process")
 	}


### PR DESCRIPTION
[patch build](https://evergreen.mongodb.com/version/5eceaf3832f41719ac97a74f) to make sure dist works