### PR TITLE
EVG-7983: allow changing owner of existing evergreen yaml optional on spawn hosts

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1110,9 +1110,11 @@ func (h *Host) SpawnHostSetupCommands(settings *evergreen.Settings) (string, err
 func (h *Host) spawnHostSetupConfigDirCommands(conf []byte) string {
 	return strings.Join([]string{
 		fmt.Sprintf("mkdir -m 777 -p %s", h.spawnHostConfigDir()),
-		// We have to do this because the evergreen config file is already baked
-		// into the AMI and owned by the privileged user.
-		h.changeOwnerCommand(h.spawnHostConfigFile()),
+		// We have to do this because on most of the distro (but not all of
+		// them), the evergreen config file is already baked into the AMI and
+		// owned by the privileged user. This is allowed to fail since some
+		// distros don't have the evergreen config file.
+		fmt.Sprintf("(%s || true)", h.changeOwnerCommand(h.spawnHostConfigFile())),
 		// Note: this will likely fail if the configuration file content
 		// contains quotes.
 		fmt.Sprintf("echo \"%s\" > %s", conf, h.spawnHostConfigFile()),

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1104,7 +1104,7 @@ func TestSpawnHostSetupCommands(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := "mkdir -m 777 -p /home/user/cli_bin" +
-		" && sudo chown -R user /home/user/.evergreen.yml" +
+		" && (sudo chown -R user /home/user/.evergreen.yml || true)" +
 		" && echo \"user: user\napi_key: key\napi_server_host: www.example0.com/api\nui_server_host: www.example1.com\n\" > /home/user/.evergreen.yml" +
 		" && chmod +x /home/user/evergreen" +
 		" && cp /home/user/evergreen /home/user/cli_bin" +


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7983

The `.evergreen.yml` file used to written to `~/cli_bin` but is now written to the home directory. Therefore, we had to change the owner of the file to the distro user because the file already existed as a leftover artifact from AMI creation (which also uses evergreen, so it created a `~/.evergreen.yml` owned by the privileged user and is baked into the AMI). However, some distros (e.g. debian) seem to not have this file, so we have to make this command optional.