### PR TITLE
Evg 7915: Allow passing a file to host.create

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -102,6 +102,9 @@ type EndTaskResponse struct {
 }
 
 type CreateHost struct {
+	//option to parse params from a file
+	File string `yaml:"file"`
+	
 	// agent-controlled settings
 	CloudProvider       string `mapstructure:"provider" json:"provider" yaml:"provider" plugin:"expand"`
 	NumHosts            string `mapstructure:"num_hosts" json:"num_hosts" yaml:"num_hosts" plugin:"expand"`

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -102,9 +102,6 @@ type EndTaskResponse struct {
 }
 
 type CreateHost struct {
-	//option to parse params from a file
-	File string `yaml:"file"`
-	
 	// agent-controlled settings
 	CloudProvider       string `mapstructure:"provider" json:"provider" yaml:"provider" plugin:"expand"`
 	NumHosts            string `mapstructure:"num_hosts" json:"num_hosts" yaml:"num_hosts" plugin:"expand"`

--- a/command/host_create.go
+++ b/command/host_create.go
@@ -37,9 +37,8 @@ func (c *createHost) ParseParams(params map[string]interface{}) error {
 	if _, ok := params["file"]; ok {
 		fileName := fmt.Sprintf("%v", params["file"])
 		c.File = fileName
-		fmt.Println(len(params))
 		if len(params) > 1 {
-			return errors.New("Programmer error: no params should be defined when using a file to parse params")
+			return errors.New("no params should be defined when using a file to parse params")
 		}
 		return nil
 	}

--- a/command/host_create.go
+++ b/command/host_create.go
@@ -18,6 +18,7 @@ import (
 
 type createHost struct {
 	CreateHost *apimodels.CreateHost
+	File       string
 	base
 }
 
@@ -31,6 +32,11 @@ func (c *createHost) ParseParams(params map[string]interface{}) error {
 	// background default is true
 	if _, ok := params["background"]; !ok {
 		c.CreateHost.Background = true
+	}
+
+	if _, ok := params["file"]; ok {
+		fileName := fmt.Sprintf("%v", params["file"])
+		c.File = fileName
 	}
 
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
@@ -54,8 +60,10 @@ func (c *createHost) parseParamsFromFile(fn string, conf *model.TaskConfig) erro
 func (c *createHost) expandAndValidate(conf *model.TaskConfig) error {
 	// if a filename is defined, then parseParams has not parsed the parameters yet,
 	// since the file was not yet available. it therefore needs to be parsed now.
-	if c.CreateHost.File != "" {
-		c.parseParamsFromFile(c.CreateHost.File, conf)
+	if c.File != "" {
+		if err := c.parseParamsFromFile(c.File, conf); err != nil {
+			return err
+		}
 	}
 
 	if err := c.CreateHost.Expand(conf.Expansions); err != nil {

--- a/command/host_create.go
+++ b/command/host_create.go
@@ -37,6 +37,11 @@ func (c *createHost) ParseParams(params map[string]interface{}) error {
 	if _, ok := params["file"]; ok {
 		fileName := fmt.Sprintf("%v", params["file"])
 		c.File = fileName
+		fmt.Println(len(params))
+		if len(params) > 1 {
+			return errors.New("Programmer error: no params should be defined when using a file to parse params")
+		}
+		return nil
 	}
 
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{

--- a/command/host_create.go
+++ b/command/host_create.go
@@ -33,13 +33,6 @@ func (c *createHost) ParseParams(params map[string]interface{}) error {
 		c.CreateHost.Background = true
 	}
 
-	// if a filename is defined, get the params from the file
-	if _, ok := params["file"]; ok {
-		fileName := fmt.Sprintf("%v", params["file"])
-		return errors.Wrapf(utility.ReadYAMLFile(fileName, &c.CreateHost),
-			"error reading from file '%s'", fileName)
-	}
-
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		WeaklyTypedInput: true,
 		Result:           c.CreateHost,
@@ -50,7 +43,21 @@ func (c *createHost) ParseParams(params map[string]interface{}) error {
 	return errors.Wrapf(decoder.Decode(params), "error parsing '%s' params", c.Name())
 }
 
+func (c *createHost) parseParamsFromFile(fn string, conf *model.TaskConfig) error {
+	if !filepath.IsAbs(fn) {
+		fn = filepath.Join(conf.WorkDir, fn)
+	}
+	return errors.Wrapf(utility.ReadYAMLFile(fn, &c.CreateHost),
+		"error reading from file '%s'", fn)
+}
+
 func (c *createHost) expandAndValidate(conf *model.TaskConfig) error {
+	// if a filename is defined, then parseParams has not parsed the parameters yet,
+	// since the file was not yet available. it therefore needs to be parsed now.
+	if c.CreateHost.File != "" {
+		c.parseParamsFromFile(c.CreateHost.File, conf)
+	}
+
 	if err := c.CreateHost.Expand(conf.Expansions); err != nil {
 		return err
 	}

--- a/command/host_create_test.go
+++ b/command/host_create_test.go
@@ -122,14 +122,14 @@ func (s *createHostSuite) TestParseFromFile() {
 
 	s.Require().NoError(os.RemoveAll(tmpdir))
 
-	//test with both file and other params 
+	//test with both file and other params
 	s.params = map[string]interface{}{
-		"file": path,
-		"distro":    "myDistro",
+		"file":   path,
+		"distro": "myDistro",
 	}
-	
+
 	err = s.cmd.ParseParams(s.params)
-	s.Contains(err.Error(), "Programmer error: no params should be defined when using a file to parse params")
+	s.Contains(err.Error(), "no params should be defined when using a file to parse params")
 
 }
 

--- a/command/host_create_test.go
+++ b/command/host_create_test.go
@@ -121,6 +121,16 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.Equal("myDevice", s.cmd.CreateHost.EBSDevices[0].DeviceName)
 
 	s.Require().NoError(os.RemoveAll(tmpdir))
+
+	//test with both file and other params 
+	s.params = map[string]interface{}{
+		"file": path,
+		"distro":    "myDistro",
+	}
+	
+	err = s.cmd.ParseParams(s.params)
+	s.Contains(err.Error(), "Programmer error: no params should be defined when using a file to parse params")
+
 }
 
 func (s *createHostSuite) TestParamValidation() {


### PR DESCRIPTION
Move parsing from a file out of ParseParams, to its own method called in expandAndValidate. Parsing from a file in ParseParams doesn't work since the file is not yet available at that point.