### PR TITLE
EVG-8088 only allow distros with container pools for docker hosts

### DIFF
--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -64,7 +64,7 @@ func (*dockerManager) GetSettings() ProviderSettings {
 
 // SpawnHost creates and starts a new Docker container
 func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, error) {
-	if h.Distro.Provider != evergreen.ProviderNameDocker {
+	if !IsDockerProvider(h.Distro.Provider) {
 		return nil, errors.Errorf("Can't spawn instance of %s for distro %s: provider is %s",
 			evergreen.ProviderNameDocker, h.Distro.Id, h.Distro.Provider)
 	}

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -520,6 +520,11 @@ func IsEc2Provider(provider string) bool {
 		provider == evergreen.ProviderNameEc2Fleet
 }
 
+func IsDockerProvider(provider string) bool {
+	return provider == evergreen.ProviderNameDocker ||
+		provider == evergreen.ProviderNameDockerMock
+}
+
 func getEC2ManagerOptionsFromSettings(provider string, settings *EC2ProviderSettings) ManagerOpts {
 	region := settings.Region
 	if region == "" {

--- a/model/host/host_intent.go
+++ b/model/host/host_intent.go
@@ -113,13 +113,13 @@ func generateParentCreateOptions(pool *evergreen.ContainerPool) CreateOptions {
 }
 
 func MakeContainersAndParents(d distro.Distro, pool *evergreen.ContainerPool, newContainersNeeded int, hostOptions CreateOptions) ([]Host, []Host, error) {
-	// get the parents that are up and split into ones that already have a contaienr from this distro
+	// get the parents that are up and split into ones that already have a container from this distro
 	currentHosts, err := GetContainersOnParents(d)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Could not find number of containers on parents")
 	}
 	maxImages := defaultMaxImagesPerParent
-	if pool != nil && pool.MaxImages > 0 {
+	if pool.MaxImages > 0 {
 		maxImages = pool.MaxImages
 	}
 	matched, notMatched := partitionParents(currentHosts, d.Id, maxImages)

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -182,7 +182,7 @@ func createHostFromCommand(cmd model.PluginCommandConf) (*apimodels.CreateHost, 
 }
 
 func (dc *DBCreateHostConnector) MakeIntentHost(taskID, userID, publicKey string, createHost apimodels.CreateHost) (*host.Host, error) {
-	if createHost.CloudProvider == evergreen.ProviderNameDocker {
+	if cloud.IsDockerProvider(createHost.CloudProvider) {
 		return makeDockerIntentHost(taskID, userID, createHost)
 	}
 	return makeEC2IntentHost(taskID, userID, publicKey, createHost)
@@ -199,7 +199,7 @@ func makeDockerIntentHost(taskID, userID string, createHost apimodels.CreateHost
 	if d == nil {
 		return nil, errors.Errorf("distro '%s' not found", createHost.Distro)
 	}
-	if d.Provider != evergreen.ProviderNameDocker {
+	if !cloud.IsDockerProvider(d.Provider) {
 		return nil, errors.Errorf("distro '%s' provider must be docker (provider is '%s')", d.Id, d.Provider)
 	}
 

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -334,7 +334,7 @@ func TestCreateContainerFromTask(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection,
-		model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection, evergreen.ConfigCollection))
+		model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection))
 
 	t1 := task.Task{
 		Id:           "t1",
@@ -391,8 +391,10 @@ buildvariants:
 
 	pool := evergreen.ContainerPool{Distro: "parent-distro", Id: "test-pool", MaxContainers: 2}
 	poolConfig := evergreen.ContainerPoolsConfig{Pools: []evergreen.ContainerPool{pool}}
-	settings := evergreen.Settings{ContainerPools: poolConfig}
-	assert.NoError(evergreen.UpdateConfig(&settings))
+	settings, err := evergreen.GetConfig()
+	assert.NoError(err)
+	settings.ContainerPools = poolConfig
+	assert.NoError(evergreen.UpdateConfig(settings))
 	parentHost := &host.Host{
 		Id:                    "host1",
 		Host:                  "host",
@@ -421,8 +423,7 @@ buildvariants:
 	assert.NoError(pvars.Insert())
 
 	dc := DBCreateHostConnector{}
-	err := dc.CreateHostsFromTask(&t1, user.DBUser{Id: "me"}, "")
-	assert.NoError(err)
+	assert.NoError(dc.CreateHostsFromTask(&t1, user.DBUser{Id: "me"}, ""))
 
 	createdHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -388,8 +388,9 @@ func TestGetDockerLogs(t *testing.T) {
 		Command:       "echo hello",
 	}
 	h, err := handler.sc.MakeIntentHost("task-id", "", "", c)
-	assert.NotEmpty(h.ParentID)
 	require.NoError(err)
+	require.NotNil(h)
+	assert.NotEmpty(h.ParentID)
 
 	poolConfig := evergreen.ContainerPoolsConfig{Pools: []evergreen.ContainerPool{*pool}}
 	settings := evergreen.Settings{ContainerPools: poolConfig}


### PR DESCRIPTION
Cloud used "archlinux-parent" as the docker distro instead of a docker distro, so pool was nil.