### PR TITLE
EVG-8026 connect struct and conversion code generation

### DIFF
--- a/rest/model/codegen_test.go
+++ b/rest/model/codegen_test.go
@@ -6,19 +6,34 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func TestCodegen(t *testing.T) {
-	files, err := ioutil.ReadDir(filepath.Join("testdata", "schema"))
+	configFile, err := ioutil.ReadFile("testdata/schema/config.yml")
 	require.NoError(t, err)
-	for _, info := range files {
+	var gqlConfig config.Config
+	err = yaml.Unmarshal(configFile, &gqlConfig)
+	require.NoError(t, err)
+	mapping := ModelMapping{}
+	for dbModel, info := range gqlConfig.Models {
+		mapping[dbModel] = info.Model[0]
+	}
+
+	schemaFiles, err := ioutil.ReadDir(filepath.Join("testdata", "schema"))
+	require.NoError(t, err)
+	for _, info := range schemaFiles {
+		if !strings.HasSuffix(info.Name(), ".graphql") {
+			continue
+		}
 		name := strings.Replace(info.Name(), ".graphql", "", -1)
 		t.Run(name, func(t *testing.T) {
 			f, err := ioutil.ReadFile(filepath.Join("testdata", "schema", name+".graphql"))
 			require.NoError(t, err)
-			generated, err := SchemaToGo(string(f))
+			generated, err := Codegen(string(f), mapping)
 			require.NoError(t, err)
 
 			expected, err := ioutil.ReadFile(filepath.Join("testdata", "expected", name+".go"))
@@ -33,13 +48,13 @@ func TestWords(t *testing.T) {
 	assert.Equal(t, words(s), []string{"this", "is", "a", "field", "name"})
 }
 
-func TestCreateConversionMethods(t *testing.T) {
-	fields := ExtractedFields{
-		"Author":          ExtractedField{OutputFieldName: "One", Nullable: true},
-		"AuthorEmail":     ExtractedField{OutputFieldName: "Two", Nullable: false},
-		"AuthorGithubUID": ExtractedField{OutputFieldName: "Three", Nullable: false},
+func TestcreateConversionMethods(t *testing.T) {
+	fields := extractedFields{
+		"Author":          extractedField{OutputFieldName: "One", OutputFieldType: "*string", Nullable: true},
+		"AuthorEmail":     extractedField{OutputFieldName: "Two", OutputFieldType: "string", Nullable: false},
+		"AuthorGithubUID": extractedField{OutputFieldName: "Three", OutputFieldType: "int", Nullable: false},
 	}
-	generated, err := CreateConversionMethods("github.com/evergreen-ci/evergreen/model", "Revision", fields)
+	generated, err := createConversionMethods("github.com/evergreen-ci/evergreen/model", "Revision", fields)
 	assert.NoError(t, err)
 	expected := `package model
 
@@ -61,4 +76,12 @@ func (m *APIRevision) ToService() (model.Revision, error) {
 }
 `
 	assert.Equal(t, expected, string(generated))
+}
+
+func TestcreateConversionMethodsError(t *testing.T) {
+	fields := extractedFields{
+		"Author": extractedField{OutputFieldName: "One", OutputFieldType: "int", Nullable: true},
+	}
+	_, err := createConversionMethods("github.com/evergreen-ci/evergreen/model", "Revision", fields)
+	assert.EqualError(t, err, `DB model field 'Author' has type string which is incompatible with REST model type int`)
 }

--- a/rest/model/templates/field.gotmpl
+++ b/rest/model/templates/field.gotmpl
@@ -1,1 +1,1 @@
-{{.Name}} {{.Type}} `json:"{{.JsonTag}}"`
+{{.OutputFieldName}} {{.OutputFieldType}} `json:"{{.JsonTag}}"`

--- a/rest/model/templates/service_methods.gotmpl
+++ b/rest/model/templates/service_methods.gotmpl
@@ -1,4 +1,3 @@
-package model
 
 func (m *{{.RestType}}) BuildFromService(t {{shortenpackage .ModelType }}) error {
     {{.BfsConversions}}

--- a/rest/model/testdata/expected/basic.go
+++ b/rest/model/testdata/expected/basic.go
@@ -2,15 +2,22 @@
 
 package model
 
-import "time"
+import "github.com/evergreen-ci/evergreen/model"
 
-type MyType struct {
-	StringField        string    `json:"string_field"`
-	AnotherStringField string    `json:"another_string_field"`
-	ATime              time.Time `json:"a_time"`
-	Number             int       `json:"number"`
-	Complex            What      `json:"complex"`
+type Revision struct {
+	Author          string `json:"author"`
+	AuthorGithubUID int    `json:"author_github_u_i_d"`
 }
-type What struct {
-	Yes string `json:"yes"`
+
+func (m *APIRevision) BuildFromService(t model.Revision) error {
+	m.Author = stringToString(t.Author)
+	m.AuthorGithubUID = intToInt(t.AuthorGithubUID)
+	return nil
+}
+
+func (m *APIRevision) ToService() (model.Revision, error) {
+	out := model.Revision{}
+	out.Author = stringToString(m.Author)
+	out.AuthorGithubUID = intToInt(m.AuthorGithubUID)
+	return out, nil
 }

--- a/rest/model/testdata/schema/basic.graphql
+++ b/rest/model/testdata/schema/basic.graphql
@@ -1,13 +1,4 @@
-type MyType {
-  stringField: String
-  AnotherStringField: String
-  aTime: Time
-  number: Int
-  complex: [What!]
+type Revision {
+  Author: String
+  AuthorGithubUID: Int
 }
-
-type What {
-  yes: String
-}
-
-scalar Time

--- a/rest/model/testdata/schema/config.yml
+++ b/rest/model/testdata/schema/config.yml
@@ -1,0 +1,3 @@
+models:
+  Revision:
+    model: github.com/evergreen-ci/evergreen/model.Revision


### PR DESCRIPTION
This connects the 2 previous parts. Given a schema for what you want the REST model to look like as well as the db model it's connected to, we will generate the struct and conversion code. Still needs work on handling complex types and validation (coming soon)