### PR TITLE
EVG-8057: add userId to user query

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -378,6 +378,7 @@ type ComplexityRoot struct {
 
 	User struct {
 		DisplayName func(childComplexity int) int
+		UserID      func(childComplexity int) int
 	}
 
 	UserConfig struct {
@@ -2114,6 +2115,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.DisplayName(childComplexity), true
 
+	case "User.userId":
+		if e.complexity.User.UserID == nil {
+			break
+		}
+
+		return e.complexity.User.UserID(childComplexity), true
+
 	case "UserConfig.api_key":
 		if e.complexity.UserConfig.APIKey == nil {
 			break
@@ -2642,6 +2650,7 @@ type File {
 
 type User {
   displayName: String!
+  userId: String!
 }
 
 type RecentTaskLogs {
@@ -10634,6 +10643,40 @@ func (ec *executionContext) _User_displayName(ctx context.Context, field graphql
 	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _User_userId(ctx context.Context, field graphql.CollectedField, obj *model.APIUser) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "User",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _UserConfig_user(ctx context.Context, field graphql.CollectedField, obj *UserConfig) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -14369,6 +14412,11 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			out.Values[i] = graphql.MarshalString("User")
 		case "displayName":
 			out.Values[i] = ec._User_displayName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "userId":
+			out.Values[i] = ec._User_userId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1108,8 +1108,10 @@ func (r *mutationResolver) UpdateUserSettings(ctx context.Context, userSettings 
 func (r *queryResolver) User(ctx context.Context) (*restModel.APIUser, error) {
 	usr := route.MustHaveUser(ctx)
 	displayName := usr.DisplayName()
+	userID := usr.Username()
 	user := restModel.APIUser{
 		DisplayName: &displayName,
+		UserID:      &userID,
 	}
 	return &user, nil
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -371,6 +371,7 @@ type File {
 
 type User {
   displayName: String!
+  userId: String!
 }
 
 type RecentTaskLogs {

--- a/graphql/tests/user/data.json
+++ b/graphql/tests/user/data.json
@@ -1,0 +1,15 @@
+{
+  "users": [
+    {
+      "first_name": "Mohamed",
+      "last_name": "Khelif",
+      "settings": {
+        "timezone": "America/New_York",
+        "region": "us-east-1",
+        "github_user": {
+          "last_known_as": "khelif96"
+        }
+      }
+    }
+  ]
+}

--- a/graphql/tests/user/queries/user.graphql
+++ b/graphql/tests/user/queries/user.graphql
@@ -1,0 +1,6 @@
+{
+  user {
+    displayName
+    userId
+  }
+}

--- a/graphql/tests/user/results.json
+++ b/graphql/tests/user/results.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "query_file": "user.graphql",
+      "result": {
+        "data": {
+          "user": {
+            "displayName": "testuser",
+            "userId": "testuser"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/rest/model/user.go
+++ b/rest/model/user.go
@@ -299,6 +299,7 @@ func (a *APIQuestionAnswer) ToService() (interface{}, error) {
 
 type APIUser struct {
 	DisplayName *string `json:"display_name"`
+	UserID      *string `json:"user_id"`
 }
 
 func (a *APIUser) BuildFromService(h interface{}) error {


### PR DESCRIPTION
User ID is needed in parts of the UI, such as for generating the href for the 'user patches' link, which will be `/user/:userId/patches` (the new 'my patches' url)