### PR TITLE
EVG-8061: redirect opted in users from legacy patch page to Spruce reconfigure page

### DIFF
--- a/model/user/user.go
+++ b/model/user/user.go
@@ -68,6 +68,7 @@ type UserSettings struct {
 
 type UseSpruceOptions struct {
 	PatchPage bool `json:"patch_page" bson:"patch_page"`
+	SpruceV1  bool `json:"spruce_v1" bson:"spruce_v1"`
 }
 
 type NotificationPreferences struct {

--- a/service/patch.go
+++ b/service/patch.go
@@ -26,6 +26,10 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 
 	currentUser := MustHaveUser(r)
 
+	if currentUser.Settings.UseSpruceOptions.SpruceV1 {
+		http.Redirect(w, r, fmt.Sprintf("%s/patch/%s/configure", uis.Settings.Ui.UIv2Url, projCtx.Patch.Id), http.StatusTemporaryRedirect)
+	}
+
 	var versionAsUI *uiVersion
 	if projCtx.Version != nil { // Patch is already finalized
 		versionAsUI = &uiVersion{

--- a/service/patch.go
+++ b/service/patch.go
@@ -28,6 +28,7 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 
 	if currentUser.Settings.UseSpruceOptions.SpruceV1 {
 		http.Redirect(w, r, fmt.Sprintf("%s/patch/%s/configure", uis.Settings.Ui.UIv2Url, projCtx.Patch.Id), http.StatusTemporaryRedirect)
+		return
 	}
 
 	var versionAsUI *uiVersion

--- a/service/patch.go
+++ b/service/patch.go
@@ -27,7 +27,7 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 	currentUser := MustHaveUser(r)
 
 	if currentUser.Settings.UseSpruceOptions.SpruceV1 {
-		http.Redirect(w, r, fmt.Sprintf("%s/patch/%s/configure", uis.Settings.Ui.UIv2Url, projCtx.Patch.Id.Hex(), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/patch/%s/configure", uis.Settings.Ui.UIv2Url, projCtx.Patch.Id.Hex()), http.StatusTemporaryRedirect)
 		return
 	}
 

--- a/service/patch.go
+++ b/service/patch.go
@@ -27,7 +27,7 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 	currentUser := MustHaveUser(r)
 
 	if currentUser.Settings.UseSpruceOptions.SpruceV1 {
-		http.Redirect(w, r, fmt.Sprintf("%s/patch/%s/configure", uis.Settings.Ui.UIv2Url, projCtx.Patch.Id.String()), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/patch/%s/configure", uis.Settings.Ui.UIv2Url, projCtx.Patch.Id.Hex(), http.StatusTemporaryRedirect)
 		return
 	}
 

--- a/service/patch.go
+++ b/service/patch.go
@@ -27,7 +27,7 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 	currentUser := MustHaveUser(r)
 
 	if currentUser.Settings.UseSpruceOptions.SpruceV1 {
-		http.Redirect(w, r, fmt.Sprintf("%s/patch/%s/configure", uis.Settings.Ui.UIv2Url, projCtx.Patch.Id), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/patch/%s/configure", uis.Settings.Ui.UIv2Url, projCtx.Patch.Id.String()), http.StatusTemporaryRedirect)
 		return
 	}
 


### PR DESCRIPTION
If a user is opted into spruce v1, they will be redirected from `evergreen.mongodb.com/patch/:id` to `spruce.mongodb.com/patch/:id/configure`

This allows us to redirect users to Spruce when they click on a patch link from the CLI