### PR TITLE
EVG-7627 trigger version from git tag (using yaml)

### DIFF
--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -103,7 +103,16 @@ func FindMatchingGitTagAliasesInProject(projectID, tag string) ([]ProjectAlias, 
 	if err != nil {
 		return nil, err
 	}
-	return aliasesMatchingGitTag(aliases, tag)
+	matchingAliases, err := aliasesMatchingGitTag(aliases, tag)
+	if err != nil {
+		return nil, err
+	}
+	for _, alias := range matchingAliases {
+		if alias.RemotePath != "" && len(matchingAliases) > 1 {
+			return matchingAliases, errors.Errorf("git tag '%s' matches multiple aliases but a remote path is defined", tag)
+		}
+	}
+	return matchingAliases, nil
 }
 
 // IsValidId returns whether the supplied Id is a valid patch doc id (BSON ObjectId).

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -520,20 +520,27 @@ func LoadProjectInto(data []byte, identifier string, project *Project) (*ParserP
 	return intermediateProject, errors.Wrap(err, LoadProjectError)
 }
 
-func GetProjectFromFile(ctx context.Context, ref ProjectRef, file, token string) (*Project, *ParserProject, error) {
-	configFile, err := thirdparty.GetGithubFile(ctx, token, ref.Owner, ref.Repo, file, ref.Branch)
+type GetProjectOpts struct {
+	Ref        *ProjectRef
+	RemotePath string
+	Revision   string
+	Token      string
+}
+
+func GetProjectFromFile(ctx context.Context, opts GetProjectOpts) (*Project, *ParserProject, error) {
+	configFile, err := thirdparty.GetGithubFile(ctx, opts.Token, opts.Ref.Owner, opts.Ref.Repo, opts.RemotePath, opts.Revision)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error fetching project file for '%s'", ref.Identifier)
+		return nil, nil, errors.Wrapf(err, "error fetching project file for '%s'", opts.Ref.Identifier)
 	}
 	fileContents, err := base64.StdEncoding.DecodeString(*configFile.Content)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "unable to decode config file for '%s'", ref.Identifier)
+		return nil, nil, errors.Wrapf(err, "unable to decode config file for '%s'", opts.Ref.Identifier)
 	}
 
 	config := Project{}
-	pp, err := LoadProjectInto(fileContents, ref.Identifier, &config)
+	pp, err := LoadProjectInto(fileContents, opts.Ref.Identifier, &config)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error parsing config file for '%s'", ref.Identifier)
+		return nil, nil, errors.Wrapf(err, "error parsing config file for '%s'", opts.Ref.Identifier)
 	}
 	return &config, pp, nil
 }

--- a/model/repository.go
+++ b/model/repository.go
@@ -42,6 +42,7 @@ var (
 
 type Revision struct {
 	Author          string
+	AuthorID        string
 	AuthorGithubUID int
 	AuthorEmail     string
 	RevisionMessage string

--- a/model/version.go
+++ b/model/version.go
@@ -159,6 +159,7 @@ type VersionMetadata struct {
 	Message             string
 	Alias               string
 	PeriodicBuildID     string
+	RemotePath          string
 	GitTag              GitTag
 }
 

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -860,13 +860,13 @@ func TestCreateManifest(t *testing.T) {
 }
 
 func TestShellVersionFromRevisionGitTags(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(user.Collection))
 	// triggered from yaml
 	metadata := model.VersionMetadata{
 		RemotePath: "releases.yml",
 		Revision: model.Revision{
-			Author:          "ablack12",
-			AuthorGithubUID: 12,
+			AuthorID:        "regina.phalange",
+			Author:          "Regina Phalange",
+			AuthorEmail:     "not-fake@email.com",
 			RevisionMessage: "EVG-1234 good version",
 			Revision:        "1234",
 		},
@@ -875,16 +875,6 @@ func TestShellVersionFromRevisionGitTags(t *testing.T) {
 			Pusher: "release-bot",
 		},
 	}
-	user := user.DBUser{
-		Id: "annie.black",
-		Settings: user.UserSettings{
-			GithubUser: user.GithubUser{
-				UID:         12,
-				LastKnownAs: "ablack12",
-			},
-		},
-	}
-	assert.NoError(t, user.Insert())
 	pRef := &model.ProjectRef{
 		Identifier:            "my-project",
 		GitTagAuthorizedUsers: []string{"release-bot", "not-release-bot"},
@@ -894,10 +884,12 @@ func TestShellVersionFromRevisionGitTags(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, v)
 	assert.Equal(t, evergreen.GitTagRequester, v.Requester)
-	assert.Equal(t, "annie.black", v.AuthorID)
-	assert.Equal(t, "release", v.TriggeredByGitTag.Tag)
-	assert.Equal(t, "release-bot", v.TriggeredByGitTag.Pusher)
+	assert.Equal(t, metadata.Revision.AuthorID, v.AuthorID)
+	assert.Equal(t, metadata.Revision.Author, v.Author)
+	assert.Equal(t, metadata.Revision.AuthorEmail, v.AuthorEmail)
+	assert.Equal(t, metadata.GitTag.Tag, v.TriggeredByGitTag.Tag)
+	assert.Equal(t, metadata.GitTag.Pusher, v.TriggeredByGitTag.Pusher)
+	assert.Equal(t, metadata.RemotePath, v.RemotePath)
 	assert.Contains(t, v.Id, "my_project_release_")
 	assert.Equal(t, "Triggered From Git Tag 'release': EVG-1234 good version", v.Message)
-	assert.Equal(t, "releases.yml", v.RemotePath)
 }

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -888,6 +888,7 @@ func TestShellVersionFromRevisionGitTags(t *testing.T) {
 	pRef := &model.ProjectRef{
 		Identifier:            "my-project",
 		GitTagAuthorizedUsers: []string{"release-bot", "not-release-bot"},
+		GitTagVersionsEnabled: true,
 	}
 	v, err := shellVersionFromRevision(pRef, metadata)
 	assert.NoError(t, err)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -88,6 +88,9 @@ type Connector interface {
 	CreateProject(*model.ProjectRef, *user.DBUser) error
 	UpdateProject(*model.ProjectRef) error
 
+	// GetProjectFromFile finds the file for the projectRef and returns the translated project, using the given token
+	GetProjectFromFile(context.Context, model.ProjectRef, string, string) (*model.Project, *model.ParserProject, error)
+
 	// EnableWebhooks creates a webhook for the project's owner/repo if one does not exist.
 	// If unable to setup the new webhook, returns false but no error.
 	EnableWebhooks(context.Context, *model.ProjectRef) (bool, error)
@@ -266,8 +269,9 @@ type Connector interface {
 	CopyProjectAliases(string, string) error
 	// UpdateProjectAliases upserts/deletes aliases for the given project
 	UpdateProjectAliases(string, []restModel.APIProjectAlias) error
-	// HasMatchingGitTagAlias returns true if the project has aliases defined that match the given tag
-	HasMatchingGitTagAlias(string, string) (bool, error)
+	// HasMatchingGitTagAliasAndRemotePath returns true if the project has aliases defined that match the given tag, and
+	// returns the remote path if applicable
+	HasMatchingGitTagAliasAndRemotePath(string, string) (bool, string, error)
 	// TriggerRepotracker creates an amboy job to get the commits from a
 	// Github Push Event
 	TriggerRepotracker(amboy.Queue, string, *github.PushEvent) error

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -61,6 +61,10 @@ func (pc *DBProjectConnector) UpdateProject(projectRef *model.ProjectRef) error 
 	return nil
 }
 
+func (pc *DBProjectConnector) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string, token string) (*model.Project, *model.ParserProject, error) {
+	return model.GetProjectFromFile(ctx, pRef, file, token)
+}
+
 // EnableWebhooks returns true if a hook for the given owner/repo exists or was inserted.
 func (pc *DBProjectConnector) EnableWebhooks(ctx context.Context, projectRef *model.ProjectRef) (bool, error) {
 	hook, err := model.FindGithubHook(projectRef.Owner, projectRef.Repo)
@@ -375,6 +379,21 @@ func (pc *MockProjectConnector) UpdateProject(projectRef *model.ProjectRef) erro
 
 func (pc *MockProjectConnector) UpdateAdminRoles(project *model.ProjectRef, toAdd, toDelete []string) error {
 	return nil
+}
+
+func (pc *MockProjectConnector) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string, token string) (*model.Project, *model.ParserProject, error) {
+	config := `
+buildvariants:
+- name: v1
+  run_on: d
+  tasks:
+  - name: t1
+tasks:
+- name: t1
+`
+	p := &model.Project{}
+	pp, err := model.LoadProjectInto([]byte(config), pRef.Identifier, p)
+	return p, pp, err
 }
 
 func (pc *MockProjectConnector) FindProjectVarsById(id string, redact bool) (*restModel.APIProjectVars, error) {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -62,7 +62,13 @@ func (pc *DBProjectConnector) UpdateProject(projectRef *model.ProjectRef) error 
 }
 
 func (pc *DBProjectConnector) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string, token string) (*model.Project, *model.ParserProject, error) {
-	return model.GetProjectFromFile(ctx, pRef, file, token)
+	opts := model.GetProjectOpts{
+		Ref:        &pRef,
+		Revision:   pRef.Branch,
+		RemotePath: file,
+		Token:      token,
+	}
+	return model.GetProjectFromFile(ctx, opts)
 }
 
 // EnableWebhooks returns true if a hook for the given owner/repo exists or was inserted.

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -435,7 +435,10 @@ func (mvc *MockVersionConnector) GetVersionsAndVariants(skip, numVersionElements
 }
 
 func (mvc *MockVersionConnector) CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo, metadata model.VersionMetadata, active bool) (*model.Version, error) {
-	return nil, nil
+	return &model.Version{
+		Requester:         evergreen.GitTagRequester,
+		TriggeredByGitTag: metadata.GitTag,
+	}, nil
 }
 
 func (mvc *MockVersionConnector) LoadProjectForVersion(v *model.Version, projectId string) (*model.Project, *model.ParserProject, error) {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -411,15 +411,16 @@ func (gh *githubHookApi) handleGitTag(ctx context.Context, event *github.PushEve
 		}
 
 		revision := model.Revision{
-			Author:          event.GetSender().GetLogin(),
-			AuthorGithubUID: int(event.GetSender().GetID()),
-			AuthorEmail:     event.GetSender().GetEmail(),
-			Revision:        hash,
+			Author:          existingVersion.Author,
+			AuthorID:        existingVersion.AuthorID,
+			AuthorEmail:     existingVersion.AuthorEmail,
+			Revision:        existingVersion.Revision,
 			RevisionMessage: existingVersion.Message,
 		}
 		v, err := gh.createVersionForTag(ctx, pRef, existingVersion, revision, tag)
 		if err != nil {
 			catcher.Add(errors.Wrapf(err, "error adding new version for tag '%s'", tag.Tag))
+			continue
 		}
 		if v != nil {
 			grip.Info(message.Fields{

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -206,7 +206,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 			"is_tag":     isTag(event.GetRef()),
 		})
 		if isTag(event.GetRef()) {
-			if err := gh.createVersionForTag(ctx, event); err != nil {
+			if err := gh.handleGitTag(ctx, event); err != nil {
 				return gimlet.MakeJSONErrorResponder(err)
 			}
 			return gimlet.NewJSONResponse(struct{}{})
@@ -322,7 +322,7 @@ func (gh *githubHookApi) AddIntentForPR(pr *github.PullRequest) error {
 	return nil
 }
 
-func (gh *githubHookApi) createVersionForTag(ctx context.Context, event *github.PushEvent) error {
+func (gh *githubHookApi) handleGitTag(ctx context.Context, event *github.PushEvent) error {
 	if err := validatePushTagEvent(event); err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{
 			"source":  "github hook",
@@ -408,10 +408,31 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, event *github.
 			catcher.Add(errors.Wrapf(err, "problem adding tag '%s' to version '%s''", tag.Tag, existingVersion.Id))
 			continue
 		}
-		if !utility.StringSliceContains(pRef.GitTagAuthorizedUsers, pusher) {
-			continue
+
+		revision := model.Revision{
+			Author:          event.GetSender().GetLogin(),
+			AuthorGithubUID: int(event.GetSender().GetID()),
+			AuthorEmail:     event.GetSender().GetEmail(),
+			Revision:        hash,
+			RevisionMessage: existingVersion.Message,
 		}
-		// TODO: add ability to create version from config here
+		v, err := gh.createVersionForTag(ctx, pRef, existingVersion, revision, tag)
+		if err != nil {
+			catcher.Add(errors.Wrapf(err, "error adding new version for tag '%s'", tag.Tag))
+		}
+		if v != nil {
+			grip.Info(message.Fields{
+				"source":  "github hook",
+				"msg_id":  gh.msgID,
+				"event":   gh.eventType,
+				"ref":     event.GetRef(),
+				"owner":   ownerAndRepo[0],
+				"repo":    ownerAndRepo[1],
+				"tag":     tag,
+				"version": v.Id,
+				"message": "triggered version from git tag",
+			})
+		}
 	}
 	grip.Error(message.WrapError(catcher.Resolve(), message.Fields{
 		"source":  "github hook",
@@ -424,6 +445,54 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, event *github.
 		"message": "errors updating/creating versions for git tag",
 	}))
 	return nil
+}
+
+func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.ProjectRef, existingVersion *model.Version,
+	revision model.Revision, tag model.GitTag) (*model.Version, error) {
+	if !utility.StringSliceContains(pRef.GitTagAuthorizedUsers, tag.Pusher) {
+		return nil, nil
+	}
+
+	hasAliases, remotePath, err := gh.sc.HasMatchingGitTagAliasAndRemotePath(pRef.String(), tag.Tag)
+	if err != nil {
+		return nil, err
+	}
+	if !hasAliases {
+		return nil, nil
+	}
+	metadata := model.VersionMetadata{
+		Revision:   revision,
+		GitTag:     tag,
+		RemotePath: remotePath,
+	}
+	info := &model.ProjectInfo{Ref: &pRef}
+	if remotePath != "" {
+		// run everything in the yaml that's provided
+		if gh.settings == nil {
+			gh.settings, err = evergreen.GetConfig()
+			if err != nil {
+				return nil, errors.New("error getting settings config")
+			}
+		}
+		var token string
+		token, err = gh.settings.GetGithubOauthToken()
+		if err != nil {
+			return nil, errors.New("error getting github token")
+		}
+		info.Project, info.IntermediateProject, err = gh.sc.GetProjectFromFile(ctx, pRef, remotePath, token)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to unmarshal yaml config")
+		}
+	} else {
+		// use the standard project config with the git tag alias
+		info.Project, info.IntermediateProject, err = gh.sc.LoadProjectForVersion(existingVersion, pRef.Identifier)
+		if err != nil {
+			return nil, errors.Wrapf(err, "problem getting project for  '%s'", pRef.Identifier)
+		}
+		metadata.Alias = evergreen.GitTagAlias
+	}
+
+	return gh.sc.CreateVersionFromConfig(ctx, info, metadata, true)
 }
 
 func validatePushTagEvent(event *github.PushEvent) error {

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -312,3 +312,27 @@ func (s *GithubWebhookRouteSuite) TestTryDequeueCommitQueueItemForPR() {
 	owner = "octocat"
 	s.NoError(s.h.tryDequeueCommitQueueItemForPR(pr))
 }
+
+func (s *GithubWebhookRouteSuite) TestCreateVersionForTag() {
+	s.NoError(db.ClearCollections(model.ProjectRefCollection, model.VersionCollection))
+	//createVersionForTag(ctx context.Context, pRef model.ProjectRef, existingVersion *model.Version,
+	//revision model.Revision, tag model.GitTag)
+	tag := model.GitTag{
+		Tag:    "release",
+		Pusher: "release-bot",
+	}
+	s.sc.Aliases = []restModel.APIProjectAlias{
+		{
+			Alias:      restModel.ToStringPtr(evergreen.GitTagAlias),
+			GitTag:     restModel.ToStringPtr("release"),
+			RemotePath: restModel.ToStringPtr("rest/route/testdata/release.yml"),
+		},
+	}
+	pRef := model.ProjectRef{
+		Identifier:            "my-project",
+		GitTagAuthorizedUsers: []string{"release-bot", "not-release-bot"},
+	}
+	v, err := s.h.createVersionForTag(context.Background(), pRef, nil, model.Revision{}, tag)
+	s.NoError(err)
+	s.NotNil(v)
+}

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -331,6 +331,7 @@ func (s *GithubWebhookRouteSuite) TestCreateVersionForTag() {
 	pRef := model.ProjectRef{
 		Identifier:            "my-project",
 		GitTagAuthorizedUsers: []string{"release-bot", "not-release-bot"},
+		GitTagVersionsEnabled: true,
 	}
 	v, err := s.h.createVersionForTag(context.Background(), pRef, nil, model.Revision{}, tag)
 	s.NoError(err)

--- a/rest/route/testdata/release.yml
+++ b/rest/route/testdata/release.yml
@@ -1,0 +1,15 @@
+command_type: test
+stepback: true
+
+tasks:
+  - name: task1
+  - name: task2
+
+buildvariants:
+  - name: buildvariant
+    display_name: something
+    run_on:
+      - somedistro
+    tasks:
+      - name: task1
+      - name: task2

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -391,7 +391,7 @@ Evergreen Projects
               </div>
           </div>
           <!-- GIT TAGS -->
-          <div id="authorized_for_git_tags" class="form-group" ng-hide="true"> <!-- after functionality is finished, remove hg-hide-->
+          <div id="authorized_for_git_tags" class="form-group"> <!-- after functionality is finished, remove hg-hide-->
             <div class="col-lg-6">
               <input type="checkbox" id="git-tags-checkbox" ng-model="settingsFormData.git_tag_versions_enabled" />
               <label for="git-tags-checkbox">Enable Triggering Versions From Git Tags</label>

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -2,14 +2,12 @@ package trigger
 
 import (
 	"context"
-	"encoding/base64"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/repotracker"
-	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/pkg/errors"
 )
 
@@ -140,21 +138,8 @@ func makeDownstreamProjectFromFile(ref model.ProjectRef, file string) (*model.Pr
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
-	configFile, err := thirdparty.GetGithubFile(ctx, token, ref.Owner, ref.Repo, file, ref.Branch)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error fetching project file for '%s'", ref.Identifier)
-	}
-	fileContents, err := base64.StdEncoding.DecodeString(*configFile.Content)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "unable to decode config file for '%s'", ref.Identifier)
-	}
 
-	config := model.Project{}
-	pp, err := model.LoadProjectInto(fileContents, ref.Identifier, &config)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error parsing config file for '%s'", ref.Identifier)
-	}
-	return &config, pp, nil
+	return model.GetProjectFromFile(ctx, ref, file, token)
 }
 
 func makeDownstreamProjectFromCommand(identifier, command, generateFile string) (*model.Project, *model.ParserProject, error) {

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -127,19 +127,23 @@ func metadataFromVersion(source model.Version, ref model.ProjectRef) (model.Vers
 }
 
 func makeDownstreamProjectFromFile(ref model.ProjectRef, file string) (*model.Project, *model.ParserProject, error) {
+	opts := model.GetProjectOpts{
+		Ref:        &ref,
+		RemotePath: file,
+		Revision:   ref.Branch,
+	}
 	settings, err := evergreen.GetConfig()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error getting evergreen settings")
 	}
-	token, err := settings.GetGithubOauthToken()
+	opts.Token, err = settings.GetGithubOauthToken()
 	if err != nil {
 		return nil, nil, err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
-
-	return model.GetProjectFromFile(ctx, ref, file, token)
+	return model.GetProjectFromFile(ctx, opts)
 }
 
 func makeDownstreamProjectFromCommand(identifier, command, generateFile string) (*model.Project, *model.ParserProject, error) {


### PR DESCRIPTION
Users can either define project aliases the normal way, or using a new yaml file. If multiple git tag aliases match, then it has to be the normal way, since we shouldn't have to do any processing with the new yaml. Defining using aliases will be tested in another ticket. 

From staging test (pre author changes): https://evergreen-staging.corp.mongodb.com/version/yb_mci_testing1_5ed6deb69dbe320829565557