### PR TITLE
EVG-8113 fix project setup commands

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-06-02"
+	ClientVersion = "2020-06-03"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-05-14"

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -964,7 +964,12 @@ func (p *ProjectRef) GetProjectSetupCommands(opts apimodels.WorkstationSetupComm
 			return !os.IsNotExist(err)
 		}
 
-		commandNumber := idx + 1 // to avoid logging a stale number
+		// avoid logging the final value of obj
+		commandNumber := idx + 1
+		cmdString := obj.Command
+
+		// if the directory doesn't currently exist we need to create it
+		// PreHook sets the working directory for the subsequent command
 		cmd := jasper.NewCommand().SetErrorSender(level.Error, opts.Output).
 			PreHook(func(cmd *options.Command, opts *options.Create) {
 				if dirExists() {
@@ -976,7 +981,7 @@ func (p *ProjectRef) GetProjectSetupCommands(opts apimodels.WorkstationSetupComm
 			Prerequisite(func() bool {
 				grip.Info(message.Fields{
 					"directory":      dir,
-					"command":        obj.Command,
+					"command":        cmdString,
 					"command_number": commandNumber,
 					"op":             "setup command",
 					"project":        p.Identifier,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -958,15 +957,12 @@ func (p *ProjectRef) GetProjectSetupCommands(opts apimodels.WorkstationSetupComm
 		if obj.Directory != "" {
 			dir = filepath.Join(dir, obj.Directory)
 		}
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return nil, errors.Wrapf(err, "can't make directory '%s'", dir)
-		}
 
 		// avoid logging the final value of obj
 		commandNumber := idx + 1
 		cmdString := obj.Command
 
-		cmd := jasper.NewCommand().SetErrorSender(level.Error, opts.Output).
+		cmd := jasper.NewCommand().Directory(dir).SetErrorSender(level.Error, opts.Output).
 			Append(obj.Command).
 			Prerequisite(func() bool {
 				grip.Info(message.Fields{

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -966,8 +966,6 @@ func (p *ProjectRef) GetProjectSetupCommands(opts apimodels.WorkstationSetupComm
 		commandNumber := idx + 1
 		cmdString := obj.Command
 
-		// if the directory doesn't currently exist we need to create it
-		// PreHook sets the working directory for the subsequent command
 		cmd := jasper.NewCommand().SetErrorSender(level.Error, opts.Output).
 			Append(obj.Command).
 			Prerequisite(func() bool {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
@@ -560,4 +561,18 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 	assert.True(now.Equal(p.PeriodicBuilds[0].NextRunTime))
 	assert.True(now.Add(10 * time.Hour).Equal(dbProject.PeriodicBuilds[1].NextRunTime))
 	assert.True(now.Add(10 * time.Hour).Equal(p.PeriodicBuilds[1].NextRunTime))
+}
+
+func TestGetProjectSetupCommands(t *testing.T) {
+	p := ProjectRef{}
+	p.WorkstationConfig.SetupCommands = []WorkstationSetupCommand{
+		{Command: "c0"},
+		{Command: "c1"},
+	}
+
+	cmds, err := p.GetProjectSetupCommands(apimodels.WorkstationSetupCommandOptions{})
+	assert.NoError(t, err)
+	assert.Len(t, cmds, 2)
+	assert.Contains(t, cmds[0].String(), "c0")
+	assert.Contains(t, cmds[1].String(), "c1")
 }

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -339,6 +339,10 @@ func hostConfigure() cli.Command {
 			})
 
 			for idx, cmd := range cmds {
+				if err := makeWorkingDir(cmd); err != nil {
+					return errors.Wrap(err, "problem making working directory")
+				}
+
 				if err := cmd.Run(ctx); err != nil {
 					return errors.Wrapf(err, "problem running cmd %d of %d to provision %s", idx+1, len(cmds), projectRef.Identifier)
 				}
@@ -346,6 +350,19 @@ func hostConfigure() cli.Command {
 			return nil
 		},
 	}
+}
+
+func makeWorkingDir(cmd *jasper.Command) error {
+	opts, err := cmd.Export()
+	if err != nil {
+		return errors.Wrap(err, "can't export command options")
+	}
+	if len(opts) == 0 {
+		return errors.New("export returned empty options")
+	}
+
+	workingDir := opts[0].WorkingDirectory
+	return errors.Wrapf(os.MkdirAll(workingDir, 0755), "can't make directory '%s'", workingDir)
 }
 
 func hostStop() cli.Command {


### PR DESCRIPTION
The working directory for commands is validated before we actually run the command so we need to mkdir first.
When the directory doesn't exist we prepend a mkdir command. Subsequent commands will have their working directory set by the PreHook.

A separate bug was the command logging. When we log the command being executed we were logging the last project command for every command. The reason appears to be that when the Prerequisite function executes it captures the current value of the obj variable (which changes as we iterate over the slice). Storing in a separate variable fixes the issue.