### PR TITLE
EVG-8062: github version links redirect opted-in users from legacy to spruce

### DIFF
--- a/service/version.go
+++ b/service/version.go
@@ -29,8 +29,8 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 
 	if r.FormValue("redirect_spruce_users") == "true" {
 		user := MustHaveUser(r)
-		if user.Settings.UseSpruceOptions.PatchPage {
-
+		if user.Settings.UseSpruceOptions.SpruceV1 {
+			http.Redirect(w, r, fmt.Sprintf("%s/patch/%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id), http.StatusTemporaryRedirect)
 			return
 		}
 	}

--- a/service/version.go
+++ b/service/version.go
@@ -27,6 +27,14 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.FormValue("redirect_spruce_users") == "true" {
+		user := MustHaveUser(r)
+		if user.Settings.UseSpruceOptions.PatchPage {
+
+			return
+		}
+	}
+
 	// Set the config to blank to avoid writing it to the UI unnecessarily.
 	projCtx.Version.Config = ""
 

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -288,7 +288,7 @@ func (t *buildTriggers) buildAttachments(data *commonTemplateData) []message.Sla
 		Fields: []*message.SlackAttachmentField{
 			{
 				Title: "Version",
-				Value: fmt.Sprintf("<%s|%s>", versionLink(t.uiConfig.Url, t.build.Version), t.build.Version),
+				Value: fmt.Sprintf("<%s|%s>", versionLink(t.uiConfig.Url, t.build.Version, false), t.build.Version),
 			},
 			{
 				Title: "Makespan",

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -465,8 +465,12 @@ func buildLink(uiBase string, buildID string) string {
 	return fmt.Sprintf("%s/build/%s/", uiBase, url.PathEscape(buildID))
 }
 
-func versionLink(uiBase string, versionID string) string {
-	return fmt.Sprintf("%s/version/%s/", uiBase, url.PathEscape(versionID))
+func versionLink(uiBase string, versionID string, redirectSpruceUsers bool) string {
+	url := fmt.Sprintf("%s/version/%s", uiBase, url.PathEscape(versionID))
+	if redirectSpruceUsers {
+		url = fmt.Sprintf("%s?redirect_spruce_users=true", url)
+	}
+	return url
 }
 
 func hostLink(uiBase string, hostID string) string {

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -311,7 +311,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 				},
 				{
 					Title: "Version",
-					Value: fmt.Sprintf("<%s|%s>", versionLink(t.uiConfig.Url, t.task.Version), t.task.Version),
+					Value: fmt.Sprintf("<%s|%s>", versionLink(t.uiConfig.Url, t.task.Version, false), t.task.Version),
 				},
 				{
 					Title: "Duration",

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -110,7 +110,7 @@ func (t *versionTriggers) makeData(sub *event.Subscription, pastTenseOverride st
 		DisplayName:     t.version.Id,
 		Object:          event.ObjectVersion,
 		Project:         t.version.Identifier,
-		URL:             versionLink(t.uiConfig.Url, t.version.Id),
+		URL:             versionLink(t.uiConfig.Url, t.version.Id, true),
 		PastTenseStatus: t.data.Status,
 		apiModel:        &api,
 	}


### PR DESCRIPTION
⚠️ **POC PR** ⚠️
Is this the recommended way to achieve the following?

The github links in a PR that go to the passing or failing or in progress version in Evergreen need to redirect to Spruce for opted in users. 