### PR TITLE
EVG-8057: redirect spruce users from legacy my patches to spruce

### DIFF
--- a/service/timeline.go
+++ b/service/timeline.go
@@ -66,8 +66,8 @@ func (uis *UIServer) patchTimeline(w http.ResponseWriter, r *http.Request) {
 
 func (uis *UIServer) myPatchesTimeline(w http.ResponseWriter, r *http.Request) {
 	user := MustHaveUser(r)
-	if user.Settings.UseSpruceOptions.PatchPage {
-		http.Redirect(w, r, fmt.Sprintf("%s/patches/user/%s", uis.Settings.Ui.UIv2Url, user.Username()), http.StatusTemporaryRedirect)
+	if user.Settings.UseSpruceOptions.SpruceV1 {
+		http.Redirect(w, r, fmt.Sprintf("%s/user/%s/patches", uis.Settings.Ui.UIv2Url, user.Username()), http.StatusTemporaryRedirect)
 		return
 	}
 


### PR DESCRIPTION
'Patches' link in the legacy dropdown will redirect to Spruce user patches page if user is opted into Spruce. 