### PR TITLE
EVG-8039 use different structure for distro event logs

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -56,7 +56,7 @@ type Distro struct {
 }
 
 type DistroData struct {
-	Distro              Distro                   `bson:",inline"`
+	Distro              `bson:",inline"`
 	ProviderSettingsMap []map[string]interface{} `bson:"provider_settings_list" json:"provider_settings_list"`
 }
 

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -55,6 +55,21 @@ type Distro struct {
 	IcecreamSettings      IcecreamSettings      `bson:"icecream_settings" json:"icecream_settings" yaml:"icecream_settings"`
 }
 
+type DistroData struct {
+	Distro              Distro                   `bson:",inline"`
+	ProviderSettingsMap []map[string]interface{} `bson:"provider_settings_list" json:"provider_settings_list"`
+}
+
+func (d *Distro) NewDistroData() DistroData {
+	res := DistroData{ProviderSettingsMap: []map[string]interface{}{}}
+	res.Distro = *d
+	for _, each := range d.ProviderSettingsList {
+		res.ProviderSettingsMap = append(res.ProviderSettingsMap, each.ExportMap())
+	}
+	res.Distro.ProviderSettingsList = nil
+	return res
+}
+
 // BootstrapSettings encapsulates all settings related to bootstrapping hosts.
 type BootstrapSettings struct {
 	// Required

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -56,7 +56,7 @@ type Distro struct {
 }
 
 type DistroData struct {
-	Distro              `bson:",inline"`
+	Distro              Distro                   `bson:",inline"`
 	ProviderSettingsMap []map[string]interface{} `bson:"provider_settings_list" json:"provider_settings_list"`
 }
 

--- a/model/event/distro_event.go
+++ b/model/event/distro_event.go
@@ -42,14 +42,17 @@ func LogDistroEvent(distroId string, eventType string, eventData DistroEventData
 	}
 }
 
+// LogDistroAdded should take in DistroData in order to preserve the ProviderSettingsList
 func LogDistroAdded(distroId, userId string, data interface{}) {
 	LogDistroEvent(distroId, EventDistroAdded, DistroEventData{UserId: userId, Data: data})
 }
 
+// LogDistroModified should take in DistroData in order to preserve the ProviderSettingsList
 func LogDistroModified(distroId, userId string, data interface{}) {
 	LogDistroEvent(distroId, EventDistroModified, DistroEventData{UserId: userId, Data: data})
 }
 
+// LogDistroRemoved should take in DistroData in order to preserve the ProviderSettingsList
 func LogDistroRemoved(distroId, userId string, data interface{}) {
 	LogDistroEvent(distroId, EventDistroRemoved, DistroEventData{UserId: userId, Data: data})
 }

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -302,7 +302,7 @@ func (h *distroIDPutHandler) Run(ctx context.Context) gimlet.Responder {
 		if err = h.sc.UpdateDistro(original, newDistro); err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for update() distro with distro id '%s'", h.distroID))
 		}
-		event.LogDistroModified(h.distroID, user.Username(), newDistro)
+		event.LogDistroModified(h.distroID, user.Username(), newDistro.NewDistroData())
 		return gimlet.NewJSONResponse(struct{}{})
 	}
 	// New resource

--- a/service/distros.go
+++ b/service/distros.go
@@ -210,7 +210,7 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	event.LogDistroModified(id, u.Username(), newDistro)
+	event.LogDistroModified(id, u.Username(), newDistro.NewDistroData())
 
 	message := fmt.Sprintf("Distro %v successfully updated.", id)
 	if shouldDeco {
@@ -246,7 +246,7 @@ func (uis *UIServer) removeDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	event.LogDistroRemoved(id, u.Username(), d)
+	event.LogDistroRemoved(id, u.Username(), d.NewDistroData())
 
 	PushFlash(uis.CookieStore, r, w, NewSuccessFlash(fmt.Sprintf("Distro %v successfully removed.", id)))
 	gimlet.WriteJSON(w, "distro successfully removed")
@@ -340,7 +340,7 @@ func (uis *UIServer) addDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	event.LogDistroAdded(d.Id, u.Username(), d)
+	event.LogDistroAdded(d.Id, u.Username(), d.NewDistroData())
 
 	PushFlash(uis.CookieStore, r, w, NewSuccessFlash(fmt.Sprintf("Distro %v successfully added.", d.Id)))
 	gimlet.WriteJSON(w, "distro successfully added")


### PR DESCRIPTION
The context for this is that []*birch.Document is showing up as nil for event logs: I believe it has something to do with the way MongoDB inserts interfaces because this isn't something that happens for distros. 

Because the event package has to use interfaces because of import cycle drama, we have to live with the interface nonsense. I propose changing the structure of the event log so that provider setting data can still be seen.

If you have a different idea let me know.