### PR TITLE
EVG-8031 reword evergreen validate error

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -336,7 +336,7 @@ func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(interface{}) error) err
 	}{}
 
 	if err := unmarshal(&temp); err != nil {
-		return errors.Wrap(err, "error unmarshalling into temp structure")
+		return errors.Wrap(err, "input fields may not match the command fields")
 	}
 	c.Function = temp.Function
 	c.Type = temp.Type


### PR DESCRIPTION
This change isn't much but maybe it'll help users more clearly understand that the warning is their fault (a misnamed field for commands would now give this warning:
```
WARNING: input fields may not match the command fields: yaml: unmarshal errors:
  line 832: cannot unmarshal !!seq into struct { Function string "yaml:\"func,omitempty\" bson:\"func,omitempty\""; Type string "yaml:\"type,omitempty\" bson:\"type,omitempty\""; DisplayName string "yaml:\"display_name,omitempty\" bson:\"display_name,omitempty\""; Command string "yaml:\"command,omitempty\" bson:\"command,omitempty\""; Variants []string "yaml:\"variants,omitempty\" bson:\"variants,omitempty\""; TimeoutSecs int "yaml:\"timeout_secs,omitempty\" bson:\"timeout_secs,omitempty\""; Params map[string]interface {} "yaml:\"params,omitempty\" bson:\"params,omitempty\""; ParamsYAML string "yaml:\"params_yaml,omitempty\" bson:\"params_yaml,omitempty\""; Vars map[string]string "yaml:\"vars,omitempty\" bson:\"vars,omitempty\""; Loggers *model.LoggerConfig "yaml:\"loggers,omitempty\" bson:\"loggers,omitempty\"" }
./evergreen.yml is an invalid configuration
```

We could also not wrap the error for readability but I worry then we may suppress other errors that are important.