### PR TITLE
EVG-8016: add eventLogLink to Task type log field

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -354,6 +354,7 @@ type ComplexityRoot struct {
 	TaskLogLinks struct {
 		AgentLogLink  func(childComplexity int) int
 		AllLogLink    func(childComplexity int) int
+		EventLogLink  func(childComplexity int) int
 		SystemLogLink func(childComplexity int) int
 		TaskLogLink   func(childComplexity int) int
 	}
@@ -2024,6 +2025,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TaskLogLinks.AllLogLink(childComplexity), true
 
+	case "TaskLogLinks.eventLogLink":
+		if e.complexity.TaskLogLinks.EventLogLink == nil {
+			break
+		}
+
+		return e.complexity.TaskLogLinks.EventLogLink(childComplexity), true
+
 	case "TaskLogLinks.systemLogLink":
 		if e.complexity.TaskLogLinks.SystemLogLink == nil {
 			break
@@ -2592,6 +2600,7 @@ type TaskLogLinks {
   agentLogLink: String
   systemLogLink: String
   taskLogLink: String
+  eventLogLink: String
 }
 
 type TaskEndDetail {
@@ -10273,6 +10282,37 @@ func (ec *executionContext) _TaskLogLinks_taskLogLink(ctx context.Context, field
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _TaskLogLinks_eventLogLink(ctx context.Context, field graphql.CollectedField, obj *model.LogLinks) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "TaskLogLinks",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EventLogLink, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _TaskResult_id(ctx context.Context, field graphql.CollectedField, obj *TaskResult) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -14582,6 +14622,8 @@ func (ec *executionContext) _TaskLogLinks(ctx context.Context, sel ast.Selection
 			out.Values[i] = ec._TaskLogLinks_systemLogLink(ctx, field, obj)
 		case "taskLogLink":
 			out.Values[i] = ec._TaskLogLinks_taskLogLink(ctx, field, obj)
+		case "eventLogLink":
+			out.Values[i] = ec._TaskLogLinks_eventLogLink(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -1724,7 +1724,8 @@
               "allLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=ALL",
               "taskLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=T",
               "agentLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=E",
-              "systemLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=S"
+              "systemLogLink": "https://localhost:8443/task_log_raw/wuzzup/5?type=S",
+              "eventLogLink": "https://localhost:8443/event_log/task/wuzzup"
             },
             "id": "wuzzup",
             "createTime": "2018-01-10T19:01:36-05:00",

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -250,6 +250,7 @@ type TaskLogLinks {
   agentLogLink: String
   systemLogLink: String
   taskLogLink: String
+  eventLogLink: String
 }
 
 type TaskEndDetail {

--- a/graphql/testdata/task1.graphql
+++ b/graphql/testdata/task1.graphql
@@ -5,6 +5,7 @@
       taskLogLink
       agentLogLink
       systemLogLink
+      eventLogLink
     }
     id
     createTime

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	LogLinkFormat = "%s/task_log_raw/%s/%d?type=%s"
+	TaskLogLinkFormat  = "%s/task_log_raw/%s/%d?type=%s"
+	EventLogLinkFormat = "%s/event_log/task/%s"
 )
 
 // APITask is the model to be returned by the API whenever tasks are fetched.
@@ -72,6 +73,7 @@ type LogLinks struct {
 	TaskLogLink   *string `json:"task_log"`
 	AgentLogLink  *string `json:"agent_log"`
 	SystemLogLink *string `json:"system_log"`
+	EventLogLink  *string `json:"event_log"`
 }
 
 type ApiTaskEndDetail struct {
@@ -177,10 +179,11 @@ func (at *APITask) BuildFromService(t interface{}) error {
 		}
 	case string:
 		ll := LogLinks{
-			AllLogLink:    ToStringPtr(fmt.Sprintf(LogLinkFormat, v, FromStringPtr(at.Id), at.Execution, "ALL")),
-			TaskLogLink:   ToStringPtr(fmt.Sprintf(LogLinkFormat, v, FromStringPtr(at.Id), at.Execution, "T")),
-			AgentLogLink:  ToStringPtr(fmt.Sprintf(LogLinkFormat, v, FromStringPtr(at.Id), at.Execution, "E")),
-			SystemLogLink: ToStringPtr(fmt.Sprintf(LogLinkFormat, v, FromStringPtr(at.Id), at.Execution, "S")),
+			AllLogLink:    ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, v, FromStringPtr(at.Id), at.Execution, "ALL")),
+			TaskLogLink:   ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, v, FromStringPtr(at.Id), at.Execution, "T")),
+			AgentLogLink:  ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, v, FromStringPtr(at.Id), at.Execution, "E")),
+			SystemLogLink: ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, v, FromStringPtr(at.Id), at.Execution, "S")),
+			EventLogLink:  ToStringPtr(fmt.Sprintf(EventLogLinkFormat, v, FromStringPtr(at.Id))),
 		}
 		at.Logs = ll
 	default:

--- a/rest/model/task_test.go
+++ b/rest/model/task_test.go
@@ -91,6 +91,7 @@ func TestTaskBuildFromService(t *testing.T) {
 						TaskLogLink:   ToStringPtr("url/task_log_raw//0?type=T"),
 						SystemLogLink: ToStringPtr("url/task_log_raw//0?type=S"),
 						AgentLogLink:  ToStringPtr("url/task_log_raw//0?type=E"),
+						EventLogLink:  ToStringPtr("url/event_log/task/"),
 					},
 					CreateTime:    &time.Time{},
 					DispatchTime:  &time.Time{},


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-8016
a link to the html event logs for the task log page in Spruce