### PR TITLE
EVG-8151: report go test results from subprocess.scripting

### DIFF
--- a/command/results_gotest.go
+++ b/command/results_gotest.go
@@ -105,7 +105,6 @@ func sendTestLogsAndResults(ctx context.Context, comm client.Communicator, logge
 
 			allResults.Results = append(allResults.Results, result)
 		}
-
 	}
 	logger.Task().Info("Finished posting logs to server")
 
@@ -154,7 +153,7 @@ func (c *goTestResults) allOutputFiles() ([]string, error) {
 // parseTestOutput parses the test results and logs from a single output source.
 func parseTestOutput(ctx context.Context, conf *model.TaskConfig, report io.Reader, suiteName string) (model.TestLog, []task.TestResult, error) {
 	// parse the output logs
-	parser := &goTestParser{ /*kim: TODO: remove Suite: suiteName*/ }
+	parser := &goTestParser{}
 	if err := parser.Parse(report); err != nil {
 		return model.TestLog{}, nil, errors.Wrap(err, "parsing file")
 	}

--- a/command/results_gotest.go
+++ b/command/results_gotest.go
@@ -154,7 +154,7 @@ func (c *goTestResults) allOutputFiles() ([]string, error) {
 // parseTestOutput parses the test results and logs from a single output source.
 func parseTestOutput(ctx context.Context, conf *model.TaskConfig, report io.Reader, suiteName string) (model.TestLog, []task.TestResult, error) {
 	// parse the output logs
-	parser := &goTestParser{Suite: suiteName}
+	parser := &goTestParser{ /*kim: TODO: remove Suite: suiteName*/ }
 	if err := parser.Parse(report); err != nil {
 		return model.TestLog{}, nil, errors.Wrap(err, "parsing file")
 	}
@@ -175,8 +175,8 @@ func parseTestOutput(ctx context.Context, conf *model.TaskConfig, report io.Read
 	return testLog, ToModelTestResults(parser.Results()).Results, nil
 }
 
-// parseTestOutputFiles parses all of the files that are passed in, and returns the
-// test logs and test results found within.
+// parseTestOutputFiles parses all of the files that are passed in, and returns
+// the test logs and test results found within.
 func parseTestOutputFiles(ctx context.Context, logger client.LoggerProducer,
 	conf *model.TaskConfig, outputFiles []string) ([]model.TestLog, [][]task.TestResult, error) {
 
@@ -189,8 +189,6 @@ func parseTestOutputFiles(ctx context.Context, logger client.LoggerProducer,
 			return nil, nil, errors.New("command was stopped")
 		}
 
-		// assume that the name of the file, stripping off the ".suite" extension if present,
-		// is the name of the suite being tested
 		_, suiteName := filepath.Split(outputFile)
 		suiteName = strings.TrimSuffix(suiteName, ".suite")
 

--- a/command/results_gotest_parser.go
+++ b/command/results_gotest_parser.go
@@ -42,7 +42,7 @@ type goTestResult struct {
 	// Currently, for this plugin, this is the name of the package
 	// being tested, prefixed with a unique number to avoid
 	// collisions when packages have the same name
-	SuiteName string
+	// kim:  SuiteName string
 	// The result status of the test
 	Status string
 	// How long the test took to run
@@ -95,8 +95,8 @@ func ToModelTestResults(results []*goTestResult) task.LocalTestResults {
 // This should cover regular go tests as well as those written with the
 // popular testing packages goconvey and gocheck.
 type goTestParser struct {
-	Suite string
-	logs  []string
+	// kim:  Suite string
+	logs []string
 	// map for storing tests during parsing. this is an array to handle multiple
 	// executions of the same test in the same log
 	tests map[string][]*goTestResult
@@ -202,8 +202,8 @@ func (vp *goTestParser) handleStart(line string, rgx *regexp.Regexp, defaultFail
 // test name, current suite, and current line number.
 func (vp *goTestParser) newTestResult(name string) *goTestResult {
 	return &goTestResult{
-		Name:      name,
-		SuiteName: vp.Suite,
+		Name: name,
+		// kim:  SuiteName: vp.Suite,
 		StartLine: len(vp.logs),
 	}
 }

--- a/command/results_gotest_parser.go
+++ b/command/results_gotest_parser.go
@@ -38,11 +38,6 @@ var (
 type goTestResult struct {
 	// The name of the test
 	Name string
-	// The name of the test suite the test is a part of.
-	// Currently, for this plugin, this is the name of the package
-	// being tested, prefixed with a unique number to avoid
-	// collisions when packages have the same name
-	// kim:  SuiteName string
 	// The result status of the test
 	Status string
 	// How long the test took to run
@@ -95,7 +90,6 @@ func ToModelTestResults(results []*goTestResult) task.LocalTestResults {
 // This should cover regular go tests as well as those written with the
 // popular testing packages goconvey and gocheck.
 type goTestParser struct {
-	// kim:  Suite string
 	logs []string
 	// map for storing tests during parsing. this is an array to handle multiple
 	// executions of the same test in the same log
@@ -199,11 +193,10 @@ func (vp *goTestParser) handleStart(line string, rgx *regexp.Regexp, defaultFail
 }
 
 // newTestResult populates a test result type with the given
-// test name, current suite, and current line number.
+// test name and current line number.
 func (vp *goTestParser) newTestResult(name string) *goTestResult {
 	return &goTestResult{
-		Name: name,
-		// kim:  SuiteName: vp.Suite,
+		Name:      name,
 		StartLine: len(vp.logs),
 	}
 }

--- a/command/results_gotest_parser_test.go
+++ b/command/results_gotest_parser_test.go
@@ -73,7 +73,7 @@ func TestParserFunctionality(t *testing.T) {
 	Convey("With a simple log file and parser", t, func() {
 		logdata, err := ioutil.ReadFile(filepath.Join(cwd, "testdata", "gotest", "1_simple.log"))
 		require.NoError(t, err, "couldn't open log file")
-		parser := &goTestParser{Suite: "test"}
+		parser := &goTestParser{}
 
 		Convey("running parse on the given log file should succeed", func() {
 			err = parser.Parse(bytes.NewBuffer(logdata))
@@ -95,14 +95,12 @@ func TestParserFunctionality(t *testing.T) {
 					So(results[0].RunTime, ShouldEqual, rTime)
 					So(results[0].StartLine, ShouldEqual, 1)
 					So(results[0].EndLine, ShouldEqual, 14)
-					So(results[0].SuiteName, ShouldEqual, "test")
 					So(results[1].Name, ShouldEqual, "TestFailures2")
 					So(results[1].Status, ShouldEqual, FAIL)
 					rTime, _ = time.ParseDuration("2.00s")
 					So(results[1].RunTime, ShouldEqual, rTime)
 					So(results[1].StartLine, ShouldEqual, 15)
 					So(results[1].EndLine, ShouldEqual, 15)
-					So(results[1].SuiteName, ShouldEqual, "test")
 				})
 			})
 		})
@@ -110,7 +108,7 @@ func TestParserFunctionality(t *testing.T) {
 	Convey("With a gocheck log file and parser", t, func() {
 		logdata, err := ioutil.ReadFile(filepath.Join(cwd, "testdata", "gotest", "2_simple.log"))
 		require.NoError(t, err, "couldn't open log file")
-		parser := &goTestParser{Suite: "gocheck_test"}
+		parser := &goTestParser{}
 
 		Convey("running parse on the given log file should succeed", func() {
 			err = parser.Parse(bytes.NewBuffer(logdata))
@@ -132,7 +130,6 @@ func TestParserFunctionality(t *testing.T) {
 					So(results[1].RunTime, ShouldEqual, rTime)
 					So(results[1].StartLine, ShouldEqual, 2)
 					So(results[1].EndLine, ShouldEqual, 4)
-					So(results[1].SuiteName, ShouldEqual, "gocheck_test")
 				})
 			})
 		})
@@ -140,7 +137,7 @@ func TestParserFunctionality(t *testing.T) {
 	Convey("un-terminated tests are failures", t, func() {
 		logdata, err := ioutil.ReadFile(filepath.Join(cwd, "testdata", "gotest", "3_simple.log"))
 		require.NoError(t, err, "couldn't open log file")
-		parser := &goTestParser{Suite: "gocheck_test"}
+		parser := &goTestParser{}
 		err = parser.Parse(bytes.NewBuffer(logdata))
 		So(err, ShouldBeNil)
 
@@ -153,7 +150,7 @@ func TestParserFunctionality(t *testing.T) {
 		logdata, err := ioutil.ReadFile(filepath.Join(cwd, "testdata", "gotest", "4_simple.log"))
 		So(err, ShouldBeNil)
 
-		parser := &goTestParser{Suite: "testify test"}
+		parser := &goTestParser{}
 		err = parser.Parse(bytes.NewBuffer(logdata))
 		So(err, ShouldBeNil)
 
@@ -166,7 +163,7 @@ func TestParserFunctionality(t *testing.T) {
 		logdata, err := ioutil.ReadFile(filepath.Join(cwd, "testdata", "gotest", "5_simple.log"))
 		So(err, ShouldBeNil)
 
-		parser := &goTestParser{Suite: "test"}
+		parser := &goTestParser{}
 		err = parser.Parse(bytes.NewBuffer(logdata))
 		So(err, ShouldBeNil)
 
@@ -183,7 +180,7 @@ func TestParserFunctionality(t *testing.T) {
 		logdata, err := ioutil.ReadFile(filepath.Join(cwd, "testdata", "gotest", "6_simple.log"))
 		So(err, ShouldBeNil)
 
-		parser := &goTestParser{Suite: "test"}
+		parser := &goTestParser{}
 		err = parser.Parse(bytes.NewBuffer(logdata))
 		So(err, ShouldBeNil)
 
@@ -196,7 +193,7 @@ func TestParserFunctionality(t *testing.T) {
 		logdata, err := ioutil.ReadFile(filepath.Join(cwd, "testdata", "gotest", "7_simple.log"))
 		So(err, ShouldBeNil)
 
-		parser := &goTestParser{Suite: "test"}
+		parser := &goTestParser{}
 		err = parser.Parse(bytes.NewBuffer(logdata))
 		So(err, ShouldBeNil)
 

--- a/command/scripting.go
+++ b/command/scripting.go
@@ -176,7 +176,7 @@ func (c *scriptingExec) ParseParams(params map[string]interface{}) error {
 	}
 
 	if !utility.StringSliceContains(validTestingHarnesses(), c.Harness) {
-		return errors.Errorf("invalid testing harness '%s': valid options are %s", c.Harness, validTestingHarnesses())
+		return errors.Errorf("invalid testing harness '%s': valid options are %s", c.Harness, strings.Join(validTestingHarnesses(), ", "))
 	}
 
 	if c.Command != "" {

--- a/command/scripting.go
+++ b/command/scripting.go
@@ -418,9 +418,9 @@ func (c *scriptingExec) getHarnessConfig(output options.Output) (options.Scripti
 			Environment:    c.Env,
 			Packages:       c.Packages,
 			CachedDuration: time.Duration(c.CacheDurationSeconds) * time.Second,
-			Gopath:         filepath.Join(c.WorkingDir, c.HarnessPath),
+			Gopath:         gopath,
 			Directory:      c.WorkingDir,
-			Goroot:         c.HostPath,
+			Goroot:         goroot,
 		}, nil
 	default:
 		return nil, errors.Errorf("there is no support for harness: '%s'", c.Harness)

--- a/command/scripting.go
+++ b/command/scripting.go
@@ -527,7 +527,10 @@ func (c *scriptingExec) Execute(ctx context.Context, comm client.Communicator, l
 func (c *scriptingExec) reportTestResults(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *model.TaskConfig, report io.Reader) error {
 	switch c.Harness {
 	case "go", "golang":
-		log, result, err := parseTestOutput(ctx, conf, report, "")
+		// kim: TODO: I don't actually know if the test name is consequential,
+		// but I included it because if  I didn't specify it, the REST request
+		// to post logs hangs and the task times out.
+		log, result, err := parseTestOutput(ctx, conf, report, "output.test")
 		if err != nil {
 			return errors.Wrap(err, "parsing test output")
 		}

--- a/command/scripting_test.go
+++ b/command/scripting_test.go
@@ -14,25 +14,30 @@ func TestScripting(t *testing.T) {
 		assert.Equal(t, "subprocess.scripting", cmd.Name())
 	})
 	t.Run("Parse", func(t *testing.T) {
-		t.Run("ErrorMismatchedTypes", func(t *testing.T) {
+		t.Run("ErrorsWithEmpty", func(t *testing.T) {
 			cmd := &scriptingExec{}
+			err := cmd.ParseParams(map[string]interface{}{})
+			assert.Error(t, err)
+		})
+		t.Run("ErrorMismatchedTypes", func(t *testing.T) {
+			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(map[string]interface{}{"args": true})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "error decoding")
 		})
 		t.Run("NoArgsErrors", func(t *testing.T) {
-			cmd := &scriptingExec{}
+			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(nil)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "must specify")
 		})
 		t.Run("BothArgsAndScript", func(t *testing.T) {
-			cmd := &scriptingExec{}
+			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(map[string]interface{}{"args": []string{"ls"}, "script": "ls"})
 			assert.Error(t, err)
 		})
 		t.Run("ErrorsForArgsAndTestDir", func(t *testing.T) {
-			cmd := &scriptingExec{}
+			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(map[string]interface{}{
 				"args":     []string{"arg"},
 				"test_dir": "dir",
@@ -40,7 +45,7 @@ func TestScripting(t *testing.T) {
 			assert.Error(t, err)
 		})
 		t.Run("ErrorsForCommandAndTestDir", func(t *testing.T) {
-			cmd := &scriptingExec{}
+			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(map[string]interface{}{
 				"command":  "script",
 				"test_dir": "dir",
@@ -49,7 +54,7 @@ func TestScripting(t *testing.T) {
 
 		})
 		t.Run("ErrorsForScriptAndTestDir", func(t *testing.T) {
-			cmd := &scriptingExec{}
+			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(map[string]interface{}{
 				"script":   "script",
 				"test_dir": "dir",
@@ -57,7 +62,7 @@ func TestScripting(t *testing.T) {
 			assert.Error(t, err)
 		})
 		t.Run("ErrorsForTestOptionsWithoutTestDir", func(t *testing.T) {
-			cmd := &scriptingExec{}
+			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(map[string]interface{}{
 				"test_options": map[string]interface{}{
 					"name": "name",
@@ -66,20 +71,20 @@ func TestScripting(t *testing.T) {
 			assert.Error(t, err)
 		})
 		t.Run("SplitCommandWithArgs", func(t *testing.T) {
-			cmd := &scriptingExec{}
+			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(map[string]interface{}{"args": []string{"ls"}, "command": "ls"})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "as either arguments or a command")
 		})
 		t.Run("SplitCommand", func(t *testing.T) {
-			cmd := &scriptingExec{}
+			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(map[string]interface{}{"command": "ls"})
 			require.NoError(t, err)
 			assert.Equal(t, "ls", cmd.Args[0])
 			assert.NotNil(t, cmd.Env)
 		})
 		t.Run("IgnoreAndRedirect", func(t *testing.T) {
-			cmd := &scriptingExec{}
+			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(map[string]interface{}{"command": "ls", "ignore_standard_out": true, "redirect_standard_error_to_output": true})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "cannot ignore standard out, and redirect")

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	ClientVersion = "2020-06-03"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-06-03"
+	AgentVersion = "2020-06-05"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -75,8 +75,22 @@ variables:
       - func: run-make
         vars:
           target: revendor
-      - func: run-make
-        vars: { target: "${task_name}" }
+      # - func: run-make
+      #   vars: { target: "${task_name}" }
+      - command: subprocess.scripting
+        params:
+          harness: "go"
+          working_dir: ${workdir}
+          test_dir: gopath/src/github.com/evergreen-ci/evergreen
+          report: true
+          host_path: /opt/golang/go1.12
+          harness_path: ./gopath
+          test_options:
+            args:
+              - ./util
+          env:
+            GOROOT: /opt/golang/go1.12
+            GOPATH: ${workdir}/gopath
   - &run-go-test-suite-with-docker
     name: test
     commands:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -75,22 +75,8 @@ variables:
       - func: run-make
         vars:
           target: revendor
-      # - func: run-make
-      #   vars: { target: "${task_name}" }
-      - command: subprocess.scripting
-        params:
-          harness: "go"
-          working_dir: ${workdir}
-          test_dir: gopath/src/github.com/evergreen-ci/evergreen
-          report: true
-          host_path: /opt/golang/go1.12
-          harness_path: ./gopath
-          test_options:
-            args:
-              - ./util
-          env:
-            GOROOT: /opt/golang/go1.12
-            GOPATH: ${workdir}/gopath
+      - func: run-make
+        vars: { target: "${task_name}" }
   - &run-go-test-suite-with-docker
     name: test
     commands:


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-8151

This gets around having an extra step where we would have to create a file and call `gotest.parse_files` on the output of `subprocess.scripting`.

* `subprocess.scripting` supports reporting non-JSON go test results.
* Drive-by fix various bugs in `subprocess.scripting`.
* Refactor go test parsing functions so that it can be shared between `gotest.parse_files` and `subprocess.scripting`.