### PR TITLE
EVG-8203 remove support for legacy repotracker

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -43,8 +43,7 @@ type ProjectRef struct {
 	DeactivatePrevious bool     `bson:"deactivate_previous" json:"deactivate_previous" yaml:"deactivate_previous"`
 	Tags               []string `bson:"tags" json:"tags" yaml:"tags"`
 
-	// TracksPushEvents, if true indicates that Repotracker is triggered by
-	// Github PushEvents for this project, instead of the Repotracker runner
+	// TracksPushEvents, if true indicates that Repotracker is triggered by Github PushEvents for this project.
 	TracksPushEvents bool `bson:"tracks_push_events" json:"tracks_push_events" yaml:"tracks_push_events"`
 
 	DefaultLogger string `bson:"default_logger" json:"default_logger" yaml:"default_logger"`

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -78,6 +78,7 @@ func (pc *DBProjectConnector) EnableWebhooks(ctx context.Context, projectRef *mo
 		return false, errors.Wrapf(err, "Database error finding github hook for project '%s'", projectRef.Identifier)
 	}
 	if hook != nil {
+		projectRef.TracksPushEvents = true
 		return true, nil
 	}
 
@@ -105,6 +106,7 @@ func (pc *DBProjectConnector) EnableWebhooks(ctx context.Context, projectRef *mo
 	if err = hook.Insert(); err != nil {
 		return false, errors.Wrapf(err, "error inserting new webhook for project '%s'", projectRef.Identifier)
 	}
+	projectRef.TracksPushEvents = true
 	return true, nil
 }
 

--- a/service/project.go
+++ b/service/project.go
@@ -315,6 +315,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				uis.LoggedError(w, r, http.StatusInternalServerError, err)
 				return
 			}
+			projectRef.TracksPushEvents = true
 		} else {
 			grip.Error(message.WrapError(err, message.Fields{
 				"source":  "project edit",

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -235,7 +235,7 @@ Evergreen Projects
           </div>
           <div class="h3">Repotracker Settings</div>
           <div class="project-error" ng-hide="github_webhooks_enabled">
-             Webhooks must be enabled to run the repotracker.
+             Webhooks must be enabled to run the repotracker. Webhooks are enabled after saving with a valid repository and branch.
           </div>
           <div class="form-group" ng-show="github_webhooks_enabled">
               <div class="col-lg-5 col-header">

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -234,7 +234,10 @@ Evergreen Projects
             </div>
           </div>
           <div class="h3">Repotracker Settings</div>
-          <div class="form-group">
+          <div class="project-error" ng-hide="github_webhooks_enabled">
+             Webhooks must be enabled to run the repotracker.
+          </div>
+          <div class="form-group" ng-show="github_webhooks_enabled">
               <div class="col-lg-5 col-header">
                   <div>
                       <label class="control-label">Disable Repotracker&nbsp;&nbsp;
@@ -242,17 +245,18 @@ Evergreen Projects
                       </label>
                       <div class="muted small">Ignore commits pushed to the repo</div>
                   </div>
-                  <div ng-hide="settingsFormData.repotracker_disabled || !github_webhooks_enabled">
-                    <label class="muted col-lg-offset-1">Repotracker will be triggered from Github PushEvents sent via webhooks</label>
+                  <div ng-hide="settingsFormData.repotracker_disabled">
+                    <label class="muted col-lg-offset-1">Repotracker will be triggered from Github PushEvents sent via webhooks.</label>
+                    <div class="col-lg-8 col-header">
+                      <label class="control-label">Force run Repotracker on Save&nbsp;&nbsp;
+                        <input type="checkbox" name="force_repotracker_run" ng-model="settingsFormData.force_repotracker_run" ng-checked="repoChanged" />
+                      </label>
+                    </div>
                   </div>
               </div>
               <br />
-              <div class="col-lg-8 col-header">
-                <label class="control-label">Force run Repotracker on Save&nbsp;&nbsp;
-                  <input type="checkbox" name="force_repotracker_run" ng-model="settingsFormData.force_repotracker_run" ng-checked="repoChanged" />
-                </label>
-              </div>
           </div>
+
         </div>
 
         <div id="logging-info">

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -243,18 +243,7 @@ Evergreen Projects
                       <div class="muted small">Ignore commits pushed to the repo</div>
                   </div>
                   <div ng-hide="settingsFormData.repotracker_disabled || !github_webhooks_enabled">
-                    <div class="radio">
-                        <label class="control-label">
-                            <input type="radio" ng-model="settingsFormData.tracks_push_events" ng-value="false"> <strong> Trigger Repotracker via Runner</strong>
-                        </label> <br>
-                        <label class="muted col-lg-offset-1">Repotracker will be automatically run every few minutes</label>
-                    </div>
-                    <div class="radio">
-                        <label class="control-label">
-                            <input type="radio" ng-model="settingsFormData.tracks_push_events" ng-value="true"> <strong> Trigger Repotracker via PushEvents</strong>
-                        </label> <br>
-                        <label class="muted col-lg-offset-1">Repotracker will be triggered from Github PushEvents sent via webhooks</label>
-                    </div>
+                    <label class="muted col-lg-offset-1">Repotracker will be triggered from Github PushEvents sent via webhooks</label>
                   </div>
               </div>
               <br />

--- a/units/crons.go
+++ b/units/crons.go
@@ -53,8 +53,7 @@ func PopulateCatchupJobs() amboy.QueueOperation {
 
 		catcher := grip.NewBasicCatcher()
 		for _, proj := range projects {
-			// only do catchup jobs for enabled projects
-			// that track push events.
+			// only do catchup jobs for enabled projects that track push events.
 			if !proj.Enabled || proj.RepotrackerDisabled || !proj.TracksPushEvents {
 				continue
 			}
@@ -76,44 +75,6 @@ func PopulateCatchupJobs() amboy.QueueOperation {
 				j.SetPriority(-1)
 				catcher.Add(queue.Put(ctx, j))
 			}
-		}
-
-		return catcher.Resolve()
-	}
-}
-
-func PopulateRepotrackerPollingJobs() amboy.QueueOperation {
-	return func(ctx context.Context, queue amboy.Queue) error {
-		flags, err := evergreen.GetServiceFlags()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		if flags.RepotrackerDisabled {
-			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
-				"message": "repotracker is disabled",
-				"impact":  "polling repos disabled",
-				"mode":    "degraded",
-			})
-			return nil
-		}
-
-		projects, err := model.FindAllTrackedProjectRefsWithRepoInfo()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		ts := utility.RoundPartOfHour(15).Format(TSFormat)
-
-		catcher := grip.NewBasicCatcher()
-		for _, proj := range projects {
-			if !proj.Enabled || proj.RepotrackerDisabled || proj.TracksPushEvents {
-				continue
-			}
-
-			j := NewRepotrackerJob(fmt.Sprintf("polling-%s", ts), proj.Identifier)
-			j.SetPriority(-1)
-			catcher.Add(queue.Put(ctx, j))
 		}
 
 		return catcher.Resolve()

--- a/units/crons_remote_five_minute.go
+++ b/units/crons_remote_five_minute.go
@@ -50,7 +50,6 @@ func (j *cronsRemoteFiveMinuteJob) Run(ctx context.Context) {
 	ops := []amboy.QueueOperation{
 		PopulateTaskMonitoring(5),
 		PopulateActivationJobs(10),
-		PopulateRepotrackerPollingJobs(),
 		PopulateHostJasperRestartJobs(j.env),
 	}
 

--- a/units/repotracker.go
+++ b/units/repotracker.go
@@ -106,9 +106,7 @@ func (j *repotrackerJob) Run(ctx context.Context) {
 		return
 	}
 
-	err = repotracker.CollectRevisionsForProject(ctx, settings, *ref)
-
-	if err != nil {
+	if err = repotracker.CollectRevisionsForProject(ctx, settings, *ref); err != nil {
 		grip.Info(message.WrapError(err, message.Fields{
 			"job":     repotrackerJobName,
 			"job_id":  j.ID(),


### PR DESCRIPTION
This change can't be committed until we've modified the projects that are currently using the legacy repotracker to stop using it. Because we still use the repotracker for catchup jobs and github webhooks, the repotracker itself doesn't seem to need edits.

![image](https://user-images.githubusercontent.com/26798134/84066377-a9514000-a97a-11ea-9af2-11b6584eb33c.png)


Note: I don't want to hide repotracker settings if webhooks aren't enabled since people might not expect that / understand why those are related, which is why I'm keeping the section but adding a new warning.