### PR TITLE
EVG-8053 Aborted by task name is too long

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -437,11 +437,11 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 func getAbortedBy(abortedByTaskId string) (*abortedByDisplay, error) {
 	abortedTask, err := task.FindOne(task.ById(abortedByTaskId))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "problem getting abortedBy task")
 	}
 	buildDisplay, err := build.FindOne(build.ById(abortedTask.BuildId))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "problem getting abortedBy build")
 	}
 	abortedBy := &abortedByDisplay{
 		TaskDisplayName:     abortedTask.DisplayName,

--- a/service/task.go
+++ b/service/task.go
@@ -436,12 +436,15 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 
 func getAbortedBy(abortedByTaskId string) (*abortedByDisplay, error) {
 	abortedTask, err := task.FindOne(task.ById(abortedByTaskId))
-	if err != nil || abortedTask == nil {
+	if err != nil {
 		return nil, errors.Wrap(err, "problem getting abortedBy task")
 	}
 	buildDisplay, err := build.FindOne(build.ById(abortedTask.BuildId))
-	if err != nil || buildDisplay == nil {
+	if err != nil {
 		return nil, errors.Wrap(err, "problem getting abortedBy build")
+	}
+	if buildDisplay == nil || abortedTask == nil {
+		return nil, errors.New("problem getting abortBy display information")
 	}
 	abortedBy := &abortedByDisplay{
 		TaskDisplayName:     abortedTask.DisplayName,

--- a/service/task.go
+++ b/service/task.go
@@ -440,7 +440,7 @@ func getAbortedBy(abortedByTaskId string) (*abortedByDisplay, error) {
 		return nil, errors.Wrap(err, "problem getting abortedBy task")
 	}
 	buildDisplay, err := build.FindOne(build.ById(abortedTask.BuildId))
-	if err != nil {
+	if err != nil || buildDisplay == nil {
 		return nil, errors.Wrap(err, "problem getting abortedBy build")
 	}
 	abortedBy := &abortedByDisplay{

--- a/service/task.go
+++ b/service/task.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -56,6 +57,7 @@ type uiTaskData struct {
 	AbortInfo            task.AbortInfo          `json:"abort_info,omitempty"`
 	MinQueuePos          int                     `json:"min_queue_pos"`
 	DependsOn            []uiDep                 `json:"depends_on"`
+	AbortedByDisplay     *abortedByDisplay       `json:"aborted_by_display,omitempty"`
 	OverrideDependencies bool                    `json:"override_dependencies"`
 	IngestTime           time.Time               `json:"ingest_time"`
 	EstWaitTime          time.Duration           `json:"wait_time"`
@@ -130,6 +132,11 @@ type logData struct {
 	Buildlogger chan apimodels.LogMessage
 	Data        chan apimodels.LogMessage
 	User        gimlet.User
+}
+
+type abortedByDisplay struct {
+	TaskDisplayName     string `json:"task_display_name"`
+	BuildVariantDisplay string `json:"build_variant_display"`
 }
 
 func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
@@ -408,6 +415,15 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if uiTask.AbortInfo.TaskID != "" {
+		abortedBy, err := getAbortedBy(projCtx.Task.AbortInfo.TaskID)
+		if err != nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, err)
+			return
+		}
+		uiTask.AbortedByDisplay = abortedBy
+	}
+
 	uis.render.WriteResponse(w, http.StatusOK, struct {
 		Task          uiTaskData
 		Host          *host.Host
@@ -416,6 +432,23 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		Permissions   gimlet.Permissions
 		ViewData
 	}{uiTask, taskHost, pluginContent, uis.Settings.Jira.Host, permissions, uis.GetCommonViewData(w, r, false, true)}, "base", "task.html", "base_angular.html", "menu.html")
+}
+
+func getAbortedBy(abortedByTaskId string) (*abortedByDisplay, error) {
+	abortedTask, err := task.FindOne(task.ById(abortedByTaskId))
+	if err != nil {
+		return nil, err
+	}
+	buildDisplay, err := build.FindOne(build.ById(abortedTask.BuildId))
+	if err != nil {
+		return nil, err
+	}
+	abortedBy := &abortedByDisplay{
+		TaskDisplayName:     abortedTask.DisplayName,
+		BuildVariantDisplay: buildDisplay.DisplayName,
+	}
+
+	return abortedBy, nil
 }
 
 type taskHistoryPageData struct {

--- a/service/task.go
+++ b/service/task.go
@@ -436,7 +436,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 
 func getAbortedBy(abortedByTaskId string) (*abortedByDisplay, error) {
 	abortedTask, err := task.FindOne(task.ById(abortedByTaskId))
-	if err != nil {
+	if err != nil || abortedTask == nil {
 		return nil, errors.Wrap(err, "problem getting abortedBy task")
 	}
 	buildDisplay, err := build.FindOne(build.ById(abortedTask.BuildId))

--- a/service/templates/task.html
+++ b/service/templates/task.html
@@ -236,7 +236,7 @@ Evergreen - {{Trunc .Task.Revision 10}} / {{.Task.BuildVariantDisplay}} / {{.Tas
                       <td>
                         Aborted
                         <span ng-show="task.abort_info.user">by [[task.abort_info.user]]</span>
-                        <span ng-show="task.abort_info.task_id">because of failing task <a ng-href="[[task.abort_info.task_id]]">[[task.abort_info.task_id]]</a></span>
+                        <span ng-show="task.abort_info.task_id">because of failing task <a ng-href="[[task.abort_info.task_id]]">[[task.aborted_by_display.build_variant_display]]:[[task.aborted_by_display.task_display_name]]</a></span>
                         <span ng-show="task.abort_info.new_version">because of new version <a ng-href="/version/[[task.abort_info.new_version]]">[[task.abort_info.new_version]]</a></span>
                         <span ng-show="task.abort_info.pr_closed">because the GitHub PR was closed</span>
                       </td>


### PR DESCRIPTION
[EVG-8053](https://jira.mongodb.org/browse/EVG-8053)

Shorted aborted by from "taskID" to "build display name:task display name". 
Previous: 
![image](https://user-images.githubusercontent.com/13104717/84069906-44f1a900-a999-11ea-9636-361d6f8ba014.png)
Post change (different task data):
![image](https://user-images.githubusercontent.com/13104717/84069957-5d61c380-a999-11ea-8c14-0ae235c19603.png)
