### PR TITLE
EVG-7929 Trim whitespace when matching on github comments

### DIFF
--- a/rest/model/commit_queue.go
+++ b/rest/model/commit_queue.go
@@ -2,8 +2,8 @@ package model
 
 import (
 	"regexp"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/pkg/errors"

--- a/rest/model/commit_queue.go
+++ b/rest/model/commit_queue.go
@@ -3,6 +3,7 @@ package model
 import (
 	"regexp"
 	"time"
+	"strings"
 
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/pkg/errors"
@@ -91,6 +92,7 @@ func (item *APICommitQueueItem) ToService() (interface{}, error) {
 }
 
 func ParseGitHubCommentModules(comment string) []APIModule {
+	comment = strings.TrimSpace(comment)
 	modules := []APIModule{}
 
 	r := regexp.MustCompile(`(?:--module|-m)\s+(\w+):(\d+)`)

--- a/rest/model/commit_queue_test.go
+++ b/rest/model/commit_queue_test.go
@@ -44,11 +44,11 @@ func TestCommitQueueBuildFromService(t *testing.T) {
 func TestParseGitHubCommentModules(t *testing.T) {
 	assert := assert.New(t)
 
-	comment := "evergreen merge"
+	comment := " evergreen merge "
 	modules := ParseGitHubCommentModules(comment)
 	assert.Len(modules, 0)
 
-	comment = "evergreen merge --unknown-option blah_blah"
+	comment = " evergreen merge --unknown-option blah_blah "
 	modules = ParseGitHubCommentModules(comment)
 	assert.Len(modules, 0)
 

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -611,7 +611,7 @@ func triggersRetry(action, comment string) bool {
 	if action == "deleted" {
 		return false
 	}
-
+	comment = strings.TrimSpace(comment)
 	return comment == retryComment
 }
 

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -256,6 +256,9 @@ func (s *GithubWebhookRouteSuite) TestRetryCommentTrigger() {
 
 	s.True(triggersRetry("created", commentString))
 	s.False(triggersRetry("deleted", commentString))
+
+	//test whitespace trimming
+	s.True(triggersRetry("created", "  evergreen retry "))
 }
 
 func (s *GithubWebhookRouteSuite) TestTryDequeueCommitQueueItemForPR() {


### PR DESCRIPTION
[EVG-7929](https://jira.mongodb.org/browse/EVG-7929)

Note, this trims leading and trailing whitespace, not duplicate whitespace between words. 