### PR TITLE
EVG-7903 add task group race debugging logic

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -395,6 +395,36 @@ func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, erro
 	if err != nil {
 		return 0, errors.Wrap(err, "error querying database for hosts")
 	}
+	// TODO: when we remove this debugging logic, Find can be changed to Count
+	if len(hosts) > 1 { // for single host task groups, this would indicate a race
+		type hostInfo struct {
+			Id               string
+			Status           string
+			RunningTaskGroup string
+			RunningBV        string
+			LastBV           string
+			LastGroup        string
+		}
+		info := []hostInfo{}
+		for _, h := range hosts {
+			cur := hostInfo{
+				Id:               h.Id,
+				Status:           h.Status,
+				RunningTaskGroup: h.RunningTaskGroup,
+				RunningBV:        h.RunningTaskBuildVariant,
+				LastBV:           h.LastBuildVariant,
+				LastGroup:        h.LastGroup,
+			}
+			info = append(info, cur)
+		}
+		grip.Debug(message.Fields{
+			"message":            "num hosts by task spec",
+			"task_version":       version,
+			"task_group":         group,
+			"task_build_variant": buildVariant,
+			"hosts":              info,
+		})
+	}
 	return len(hosts), nil
 }
 

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -557,6 +557,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			"host_id":                 currentHost.Id,
 			"host_last_group":         currentHost.LastGroup,
 			"host_last_build_variant": currentHost.LastBuildVariant,
+			"host_last_task":          currentHost.LastTask,
 			"host_last_version":       currentHost.LastVersion,
 			"host_last_project":       currentHost.LastProject,
 			"task_group":              nextTask.TaskGroup,
@@ -565,6 +566,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			"task_project":            nextTask.Project,
 			"task_group_max_hosts":    nextTask.TaskGroupMaxHosts,
 		})
+
 		if ok && isTaskGroupNewToHost(currentHost, nextTask) {
 			numHosts, err := host.NumHostsByTaskSpec(nextTask.TaskGroup, nextTask.BuildVariant, nextTask.Project, nextTask.Version)
 			if err != nil {
@@ -573,7 +575,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			if numHosts > nextTask.TaskGroupMaxHosts {
 				grip.Debug(message.Fields{
 					"message":              "task group race, not dispatching",
-					"distro_id":            nextTask.DistroId,
+					"task_distro_id":       nextTask.DistroId,
 					"task_id":              nextTask.Id,
 					"host_id":              currentHost.Id,
 					"task_group":           nextTask.TaskGroup,
@@ -581,10 +583,11 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 					"task_version":         nextTask.Version,
 					"task_project":         nextTask.Project,
 					"task_group_max_hosts": nextTask.TaskGroupMaxHosts,
+					"num_hosts_found":      numHosts,
 				})
 				grip.Error(message.WrapError(currentHost.ClearRunningTask(), message.Fields{
 					"message":              "problem clearing task group task from host after dispatch race",
-					"distro_id":            nextTask.DistroId,
+					"task_distro_id":       nextTask.DistroId,
 					"task_id":              nextTask.Id,
 					"host_id":              currentHost.Id,
 					"task_group":           nextTask.TaskGroup,


### PR DESCRIPTION
My new theory is that the statuses used in NumHostsByTaskSpec are wrong, because we're hitting[ this race](https://github.com/evergreen-ci/evergreen/blob/5c5e0fa5ce1f1d9a20f8117604350af98440c959/service/api_task.go#L577) in a case where I can't find logged evidence of a race.