### PR TITLE
EVG-8200: Increase performance of UserPatches query

### DIFF
--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -129,7 +129,7 @@ func ByUserPatchNameStatusesCommitQueuePaginated(user, patchName string, statuse
 	if includeCommitQueue == false {
 		queryInterface[AliasKey] = commitQueueFilter
 	}
-	q := db.Query(queryInterface).Sort([]string{"-" + CreateTimeKey, "-" + IdKey})
+	q := db.Query(queryInterface).Sort([]string{"-" + CreateTimeKey})
 	if page > 0 {
 		q = q.Skip(page * limit)
 	}


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-8200
This change will allow users to fetch large amount of patches without running out of memory