### PR TITLE
EVG-8133: make baseTaskMetadata nullable

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -2723,7 +2723,7 @@ type Task {
   generateTask: Boolean
   generatedBy: String
   aborted: Boolean
-  baseTaskMetadata: BaseTaskMetadata!
+  baseTaskMetadata: BaseTaskMetadata
   canRestart: Boolean!
   canAbort: Boolean!
   canSchedule: Boolean!
@@ -9510,14 +9510,11 @@ func (ec *executionContext) _Task_baseTaskMetadata(ctx context.Context, field gr
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*BaseTaskMetadata)
 	fc.Result = res
-	return ec.marshalNBaseTaskMetadata2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBaseTaskMetadata(ctx, field.Selections, res)
+	return ec.marshalOBaseTaskMetadata2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBaseTaskMetadata(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Task_canRestart(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
@@ -14548,9 +14545,6 @@ func (ec *executionContext) _Task(ctx context.Context, sel ast.SelectionSet, obj
 					}
 				}()
 				res = ec._Task_baseTaskMetadata(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
 				return res
 			})
 		case "canRestart":
@@ -15405,20 +15399,6 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 // endregion **************************** object.gotpl ****************************
 
 // region    ***************************** type.gotpl *****************************
-
-func (ec *executionContext) marshalNBaseTaskMetadata2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBaseTaskMetadata(ctx context.Context, sel ast.SelectionSet, v BaseTaskMetadata) graphql.Marshaler {
-	return ec._BaseTaskMetadata(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNBaseTaskMetadata2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBaseTaskMetadata(ctx context.Context, sel ast.SelectionSet, v *BaseTaskMetadata) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	return ec._BaseTaskMetadata(ctx, sel, v)
-}
 
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	return graphql.UnmarshalBoolean(v)
@@ -16854,6 +16834,17 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalOBaseTaskMetadata2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBaseTaskMetadata(ctx context.Context, sel ast.SelectionSet, v BaseTaskMetadata) graphql.Marshaler {
+	return ec._BaseTaskMetadata(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOBaseTaskMetadata2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBaseTaskMetadata(ctx context.Context, sel ast.SelectionSet, v *BaseTaskMetadata) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._BaseTaskMetadata(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1164,7 +1164,7 @@ func (r *taskResolver) BaseTaskMetadata(ctx context.Context, at *restModel.APITa
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding task %s on base commit", *at.Id))
 	}
 	if baseTask == nil {
-		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Unable to find task %s on base commit", *at.Id))
+		return nil, nil
 	}
 
 	dur := restModel.NewAPIDuration(baseTask.TimeTaken)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -346,7 +346,7 @@ type Task {
   generateTask: Boolean
   generatedBy: String
   aborted: Boolean
-  baseTaskMetadata: BaseTaskMetadata!
+  baseTaskMetadata: BaseTaskMetadata
   canRestart: Boolean!
   canAbort: Boolean!
   canSchedule: Boolean!

--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -28,16 +28,7 @@
     },
     {
       "query_file": "baseTaskMetadata-no-base-task.graphql",
-      "result": {
-        "errors": [
-          {
-            "message": "Unable to find task taskity_task on base commit",
-            "path": ["task", "baseTaskMetadata"],
-            "extensions": { "code": "RESOURCE_NOT_FOUND" }
-          }
-        ],
-        "data": { "task": null }
-      }
+      "result": { "data": { "task": { "baseTaskMetadata": null } } }
     },
     {
       "query_file": "reliesOn-task-status-not-success-nor-fail.graphql",


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-8133
originally we were throwing an error when a baseTask did not exist. this prevented the user from viewing a task without a base task in spruce. 