### PR TITLE
EVG-7903 fix task group race

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -391,41 +391,12 @@ func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, erro
 			},
 		},
 	)
-	hosts, err := Find(q)
+	numHosts, err := Count(q)
 	if err != nil {
 		return 0, errors.Wrap(err, "error querying database for hosts")
 	}
-	// TODO: when we remove this debugging logic, Find can be changed to Count
-	if len(hosts) > 1 { // for single host task groups, this would indicate a race
-		type hostInfo struct {
-			Id               string
-			Status           string
-			RunningTaskGroup string
-			RunningBV        string
-			LastBV           string
-			LastGroup        string
-		}
-		info := []hostInfo{}
-		for _, h := range hosts {
-			cur := hostInfo{
-				Id:               h.Id,
-				Status:           h.Status,
-				RunningTaskGroup: h.RunningTaskGroup,
-				RunningBV:        h.RunningTaskBuildVariant,
-				LastBV:           h.LastBuildVariant,
-				LastGroup:        h.LastGroup,
-			}
-			info = append(info, cur)
-		}
-		grip.Debug(message.Fields{
-			"message":            "num hosts by task spec",
-			"task_version":       version,
-			"task_group":         group,
-			"task_build_variant": buildVariant,
-			"hosts":              info,
-		})
-	}
-	return len(hosts), nil
+
+	return numHosts, nil
 }
 
 // IsUninitialized is a query that returns all unstarted + uninitialized Evergreen hosts.

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -448,13 +448,6 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 
 		nextTask, err := task.FindOneNoMerge(task.ById(queueItem.Id))
 		if err != nil {
-			grip.DebugWhen(queueItem.Group != "", message.Fields{
-				"message":            "error retrieving next task",
-				"task_id":            queueItem.Id,
-				"task_group":         queueItem.Group,
-				"task_build_variant": queueItem.BuildVariant,
-				"task_version":       queueItem.Version,
-			})
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":      "database error while retrieving the db.tasks document for the next task to be assigned to this host",
 				"distro_id":    d.Id,
@@ -466,13 +459,6 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 		}
 
 		if nextTask == nil {
-			grip.DebugWhen(queueItem.Group != "", message.Fields{
-				"message":            "next task is nil",
-				"task_id":            queueItem.Id,
-				"task_group":         queueItem.Group,
-				"task_build_variant": queueItem.BuildVariant,
-				"task_version":       queueItem.Version,
-			})
 			// An error is not returned in this situation due to https://jira.mongodb.org/browse/EVG-6214
 			return nil, false, nil
 		}
@@ -517,27 +503,12 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 
 		// If the current task group is finished we leave the task on the queue, and indicate the current group needs to be torn down.
 		if details.TaskGroup != "" && details.TaskGroup != nextTask.TaskGroup {
-			grip.DebugWhen(nextTask.TaskGroup != "", message.Fields{
-				"message":            "exiting early to tear down current group",
-				"details_task_group": details.TaskGroup,
-				"task_id":            nextTask.Id,
-				"task_group":         nextTask.TaskGroup,
-				"task_build_variant": nextTask.BuildVariant,
-				"task_version":       nextTask.Version,
-			})
 			return nil, true, nil
 		}
 
 		// UpdateRunningTask updates the running task in the host document
 		ok, err := currentHost.UpdateRunningTask(nextTask)
 		if err != nil {
-			grip.DebugWhen(nextTask.TaskGroup != "", message.Fields{
-				"message":            "failed to update running task for task group",
-				"task_id":            nextTask.Id,
-				"task_group":         nextTask.TaskGroup,
-				"task_build_variant": nextTask.BuildVariant,
-				"task_version":       nextTask.Version,
-			})
 			return nil, false, errors.WithStack(err)
 		}
 
@@ -566,15 +537,28 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			"task_project":            nextTask.Project,
 			"task_group_max_hosts":    nextTask.TaskGroupMaxHosts,
 		})
-
 		if ok && isTaskGroupNewToHost(currentHost, nextTask) {
-			numHosts, err := host.NumHostsByTaskSpec(nextTask.TaskGroup, nextTask.BuildVariant, nextTask.Project, nextTask.Version)
-			if err != nil {
-				return nil, false, errors.WithStack(err)
+			dispatchRace := ""
+
+			// in this case, the task group is new to the host, but this isn't the first task in the
+			// single host task group, so we have a race.
+			if nextTask.TaskGroupMaxHosts == 1 && nextTask.TaskGroupOrder > 1 {
+				dispatchRace = "didn't get first task in single-host task group"
 			}
-			if numHosts > nextTask.TaskGroupMaxHosts {
+			// we don't compute this for single-host task groups, because the previous case will ensure tasks are started on the right host
+			if nextTask.TaskGroupMaxHosts > 1 {
+				numHosts, err := host.NumHostsByTaskSpec(nextTask.TaskGroup, nextTask.BuildVariant, nextTask.Project, nextTask.Version)
+				if err != nil {
+					return nil, false, errors.WithStack(err)
+				}
+				if numHosts > nextTask.TaskGroupMaxHosts {
+					dispatchRace = fmt.Sprintf("tasks found on %d hosts", numHosts)
+				}
+			}
+			if dispatchRace != "" {
 				grip.Debug(message.Fields{
 					"message":              "task group race, not dispatching",
+					"dispatch_race":        dispatchRace,
 					"task_distro_id":       nextTask.DistroId,
 					"task_id":              nextTask.Id,
 					"host_id":              currentHost.Id,
@@ -583,10 +567,11 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 					"task_version":         nextTask.Version,
 					"task_project":         nextTask.Project,
 					"task_group_max_hosts": nextTask.TaskGroupMaxHosts,
-					"num_hosts_found":      numHosts,
+					"task_group_order":     nextTask.TaskGroupOrder,
 				})
 				grip.Error(message.WrapError(currentHost.ClearRunningTask(), message.Fields{
 					"message":              "problem clearing task group task from host after dispatch race",
+					"dispatch_race":        dispatchRace,
 					"task_distro_id":       nextTask.DistroId,
 					"task_id":              nextTask.Id,
 					"host_id":              currentHost.Id,
@@ -599,7 +584,6 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 				ok = false // continue loop after dequeueing task
 			}
 		}
-
 		// Dequeue the task so we don't get it on another iteration of the loop.
 		grip.Warning(message.WrapError(taskQueue.DequeueTask(nextTask.Id), message.Fields{
 			"message":   "updated the relevant running task fields for the given host, but there was an issue dequeuing the task",

--- a/service/api_task_test.go
+++ b/service/api_task_test.go
@@ -167,10 +167,12 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 		So(theHostWhoCanBoastTheMostRoast.Insert(), ShouldBeNil)
 
 		task1 := task.Task{
-			Id:        "task1",
-			Status:    evergreen.TaskUndispatched,
-			Activated: true,
-			Project:   "exists",
+			Id:             "task1",
+			TaskGroup:      "group1",
+			TaskGroupOrder: 1,
+			Status:         evergreen.TaskUndispatched,
+			Activated:      true,
+			Project:        "exists",
 		}
 		task2 := task.Task{
 			Id:        "task2",
@@ -341,6 +343,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 				Version:           "version1",
 				Project:           "exists",
 				TaskGroupMaxHosts: 1,
+				TaskGroupOrder:    2,
 			}
 			So(task3.Insert(), ShouldBeNil)
 			task4 := task.Task{
@@ -352,6 +355,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 				Version:           "version1",
 				Project:           "exists",
 				TaskGroupMaxHosts: 1,
+				TaskGroupOrder:    1,
 			}
 			So(task4.Insert(), ShouldBeNil)
 			taskQueue.Queue = []model.TaskQueueItem{
@@ -423,11 +427,13 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 		So(theHostWhoCanBoastTheMostRoast.Insert(), ShouldBeNil)
 
 		task1 := task.Task{
-			Id:        "task1",
-			Status:    evergreen.TaskUndispatched,
-			Activated: true,
-			Project:   "exists",
-			StartTime: utility.ZeroTime,
+			Id:             "task1",
+			TaskGroup:      "group1",
+			TaskGroupOrder: 1,
+			Status:         evergreen.TaskUndispatched,
+			Activated:      true,
+			Project:        "exists",
+			StartTime:      utility.ZeroTime,
 		}
 		task2 := task.Task{
 			Id:        "task2",
@@ -607,6 +613,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				Version:           "version1",
 				Project:           "exists",
 				TaskGroupMaxHosts: 1,
+				TaskGroupOrder:    2,
 			}
 			So(task3.Insert(), ShouldBeNil)
 			task4 := task.Task{

--- a/service/ui.go
+++ b/service/ui.go
@@ -65,7 +65,7 @@ type ViewData struct {
 	Bugsnag             string
 	NewRelic            evergreen.NewRelicConfig
 	IsAdmin             bool
-	NewUILink        string
+	NewUILink           string
 	ValidDefaultLoggers []string
 }
 


### PR DESCRIPTION
I believe the race looked like this:
1) host1 gets task1 and sets as running task
2) host2 gets task2 and sets as running task
3) host1 sees that there are 2 hosts running tasks for the task group, and there should only be one, so it unsets task1 as running 
4) host2 sees that there is 1 host running tasks for the task group, which is correct, and attempts to run task2, which fails.

Considering single_host_task_groups can rely on order mattering, I think we can handle this race condition using order instead.