### PR TITLE
EVG-8259: allow running hosts to restart jasper service

### DIFF
--- a/units/provisioning_jasper_restart.go
+++ b/units/provisioning_jasper_restart.go
@@ -96,7 +96,7 @@ func (j *jasperRestartJob) Run(ctx context.Context) {
 		return
 	}
 
-	if j.host.NeedsReprovision != host.ReprovisionJasperRestart || j.host.Status != evergreen.HostProvisioning || j.host.RunningTask != "" {
+	if j.host.NeedsReprovision != host.ReprovisionJasperRestart || (j.host.Status != evergreen.HostProvisioning && j.host.Status != evergreen.HostRunning) {
 		return
 	}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-8259

Allow hosts that are provisioning/running to restart jasper, which is only safe to do if the host is not running a task (since restarting jasper will shut down the agent and agent monitor and we wouldn't want this to abruptly system fail a task).

This change should be safe because there's a check [here](https://github.com/evergreen-ci/evergreen/blob/bd4afd4af6d8ea1e5b3bf7abfc8955170969db1d/units/provisioning_jasper_restart.go#L139-L149) to verify that 1. the host is not running a task and 2. the host is not running an agent monitor (which fulfills the conditions to restart jasper).