### PR TITLE
EVG-8203 remove support for legacy repotracker (#3664)

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -43,8 +43,7 @@ type ProjectRef struct {
 	DeactivatePrevious bool     `bson:"deactivate_previous" json:"deactivate_previous" yaml:"deactivate_previous"`
 	Tags               []string `bson:"tags" json:"tags" yaml:"tags"`
 
-	// TracksPushEvents, if true indicates that Repotracker is triggered by
-	// Github PushEvents for this project, instead of the Repotracker runner
+	// TracksPushEvents, if true indicates that Repotracker is triggered by Github PushEvents for this project.
 	TracksPushEvents bool `bson:"tracks_push_events" json:"tracks_push_events" yaml:"tracks_push_events"`
 
 	DefaultLogger string `bson:"default_logger" json:"default_logger" yaml:"default_logger"`

--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -100,12 +100,12 @@ func checkTaskByCommit(username, key string) error {
 	var builds []apimodels.APIBuild
 	var build apimodels.APIBuild
 
-	time.Sleep(10 * time.Second)
 	// trigger repotracker
 	for i := 0; i < 5; i++ {
 		if i == 5 {
 			return errors.Errorf("unable to trigger the repotracker after 5 attempts")
 		}
+		time.Sleep(2 * time.Second)
 		grip.Infof("running repotracker for evergreen project (%d/5)", i)
 		_, err := makeSmokeRequest(username, key, http.MethodPost, client, "/rest/v2/projects/evergreen/repotracker")
 		if err != nil {

--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -114,7 +114,7 @@ func checkTaskByCommit(username, key string) error {
 		grip.Infof("checking for a build of %s (%d/30)", latest, i+1)
 		if i == 0 {
 			grip.Infof("running repotracker for evergreen project")
-			_, err := makeSmokeRequest(username, key, http.MethodPost, client, "/rest/v2/projects/evergreen/repotracker")
+			_, err = makeSmokeRequest(username, key, http.MethodPost, client, "/rest/v2/projects/evergreen/repotracker")
 			if err != nil {
 				grip.Error(err)
 			}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -78,6 +78,7 @@ func (pc *DBProjectConnector) EnableWebhooks(ctx context.Context, projectRef *mo
 		return false, errors.Wrapf(err, "Database error finding github hook for project '%s'", projectRef.Identifier)
 	}
 	if hook != nil {
+		projectRef.TracksPushEvents = true
 		return true, nil
 	}
 
@@ -105,6 +106,7 @@ func (pc *DBProjectConnector) EnableWebhooks(ctx context.Context, projectRef *mo
 	if err = hook.Insert(); err != nil {
 		return false, errors.Wrapf(err, "error inserting new webhook for project '%s'", projectRef.Identifier)
 	}
+	projectRef.TracksPushEvents = true
 	return true, nil
 }
 

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -126,6 +126,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchProjectsRoute(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Get().Wrap(checkUser, addProject, checkProjectAdmin, viewProjectSettings).RouteHandler(makeGetProjectByID(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Patch().Wrap(checkUser, addProject, checkProjectAdmin, editProjectSettings).RouteHandler(makePatchProjectByID(sc, env.Settings()))
+	app.AddRoute("/projects/{project_id}/repotracker").Version(2).Post().Wrap(checkUser, addProject).RouteHandler(makeRunRepotrackerForProject(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Put().Wrap(createProject).RouteHandler(makePutProjectByID(sc))
 	app.AddRoute("/projects/{project_id}/copy").Version(2).Post().Wrap(checkUser, addProject, createProject, checkProjectAdmin, editProjectSettings).RouteHandler(makeCopyProject(sc))
 	app.AddRoute("/projects/{project_id}/copy/variables").Version(2).Post().Wrap(checkUser, addProject, checkProjectAdmin, editProjectSettings).RouteHandler(makeCopyVariables(sc))

--- a/service/project.go
+++ b/service/project.go
@@ -315,6 +315,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				uis.LoggedError(w, r, http.StatusInternalServerError, err)
 				return
 			}
+			projectRef.TracksPushEvents = true
 		} else {
 			grip.Error(message.WrapError(err, message.Fields{
 				"source":  "project edit",

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -234,7 +234,10 @@ Evergreen Projects
             </div>
           </div>
           <div class="h3">Repotracker Settings</div>
-          <div class="form-group">
+          <div class="project-error" ng-hide="github_webhooks_enabled">
+             Webhooks must be enabled to run the repotracker. Webhooks are enabled after saving with a valid repository and branch.
+          </div>
+          <div class="form-group" ng-show="github_webhooks_enabled">
               <div class="col-lg-5 col-header">
                   <div>
                       <label class="control-label">Disable Repotracker&nbsp;&nbsp;
@@ -242,28 +245,18 @@ Evergreen Projects
                       </label>
                       <div class="muted small">Ignore commits pushed to the repo</div>
                   </div>
-                  <div ng-hide="settingsFormData.repotracker_disabled || !github_webhooks_enabled">
-                    <div class="radio">
-                        <label class="control-label">
-                            <input type="radio" ng-model="settingsFormData.tracks_push_events" ng-value="false"> <strong> Trigger Repotracker via Runner</strong>
-                        </label> <br>
-                        <label class="muted col-lg-offset-1">Repotracker will be automatically run every few minutes</label>
-                    </div>
-                    <div class="radio">
-                        <label class="control-label">
-                            <input type="radio" ng-model="settingsFormData.tracks_push_events" ng-value="true"> <strong> Trigger Repotracker via PushEvents</strong>
-                        </label> <br>
-                        <label class="muted col-lg-offset-1">Repotracker will be triggered from Github PushEvents sent via webhooks</label>
+                  <div ng-hide="settingsFormData.repotracker_disabled">
+                    <label class="muted col-lg-offset-1">Repotracker will be triggered from Github PushEvents sent via webhooks.</label>
+                    <div class="col-lg-8 col-header">
+                      <label class="control-label">Force run Repotracker on Save&nbsp;&nbsp;
+                        <input type="checkbox" name="force_repotracker_run" ng-model="settingsFormData.force_repotracker_run" ng-checked="repoChanged" />
+                      </label>
                     </div>
                   </div>
               </div>
               <br />
-              <div class="col-lg-8 col-header">
-                <label class="control-label">Force run Repotracker on Save&nbsp;&nbsp;
-                  <input type="checkbox" name="force_repotracker_run" ng-model="settingsFormData.force_repotracker_run" ng-checked="repoChanged" />
-                </label>
-              </div>
           </div>
+
         </div>
 
         <div id="logging-info">

--- a/units/crons.go
+++ b/units/crons.go
@@ -53,8 +53,7 @@ func PopulateCatchupJobs() amboy.QueueOperation {
 
 		catcher := grip.NewBasicCatcher()
 		for _, proj := range projects {
-			// only do catchup jobs for enabled projects
-			// that track push events.
+			// only do catchup jobs for enabled projects that track push events.
 			if !proj.Enabled || proj.RepotrackerDisabled || !proj.TracksPushEvents {
 				continue
 			}
@@ -76,44 +75,6 @@ func PopulateCatchupJobs() amboy.QueueOperation {
 				j.SetPriority(-1)
 				catcher.Add(queue.Put(ctx, j))
 			}
-		}
-
-		return catcher.Resolve()
-	}
-}
-
-func PopulateRepotrackerPollingJobs() amboy.QueueOperation {
-	return func(ctx context.Context, queue amboy.Queue) error {
-		flags, err := evergreen.GetServiceFlags()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		if flags.RepotrackerDisabled {
-			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
-				"message": "repotracker is disabled",
-				"impact":  "polling repos disabled",
-				"mode":    "degraded",
-			})
-			return nil
-		}
-
-		projects, err := model.FindAllTrackedProjectRefsWithRepoInfo()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		ts := utility.RoundPartOfHour(15).Format(TSFormat)
-
-		catcher := grip.NewBasicCatcher()
-		for _, proj := range projects {
-			if !proj.Enabled || proj.RepotrackerDisabled || proj.TracksPushEvents {
-				continue
-			}
-
-			j := NewRepotrackerJob(fmt.Sprintf("polling-%s", ts), proj.Identifier)
-			j.SetPriority(-1)
-			catcher.Add(queue.Put(ctx, j))
 		}
 
 		return catcher.Resolve()

--- a/units/crons_remote_five_minute.go
+++ b/units/crons_remote_five_minute.go
@@ -50,7 +50,6 @@ func (j *cronsRemoteFiveMinuteJob) Run(ctx context.Context) {
 	ops := []amboy.QueueOperation{
 		PopulateTaskMonitoring(5),
 		PopulateActivationJobs(10),
-		PopulateRepotrackerPollingJobs(),
 		PopulateHostJasperRestartJobs(j.env),
 	}
 

--- a/units/repotracker.go
+++ b/units/repotracker.go
@@ -106,9 +106,7 @@ func (j *repotrackerJob) Run(ctx context.Context) {
 		return
 	}
 
-	err = repotracker.CollectRevisionsForProject(ctx, settings, *ref)
-
-	if err != nil {
+	if err = repotracker.CollectRevisionsForProject(ctx, settings, *ref); err != nil {
 		grip.Info(message.WrapError(err, message.Fields{
 			"job":     repotrackerJobName,
 			"job_id":  j.ID(),


### PR DESCRIPTION
The first commit doesn't need review. My only question is should triggering the repotracker via route be restricted by more than just user (and how that will work with smoke).