### PR TITLE
EVG-8285 don't redirect by default in configure page

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-06-15"
+	ClientVersion = "2020-06-16"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-06-05"

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -137,6 +137,8 @@ type Patch struct {
 	PatchedConfig   string           `bson:"patched_config"`
 	Alias           string           `bson:"alias"`
 	GithubPatchData GithubPatch      `bson:"github_patch_data,omitempty"`
+	// DisplayNewUI is only used when roundtripping the patch via the CLI
+	DisplayNewUI bool `bson:"display_new_ui,omitempty"`
 }
 
 func (p *Patch) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(p) }
@@ -190,6 +192,20 @@ func (p *Patch) SetDescription(desc string) error {
 			},
 		},
 	)
+}
+
+func (p *Patch) GetURL(uiHost string) string {
+	var url string
+	if p.Activated {
+		url = uiHost + "/version/" + p.Id.Hex()
+	} else {
+		url = uiHost + "/patch/" + p.Id.Hex()
+	}
+	if p.DisplayNewUI {
+		url = url + "?redirect_spruce_users=true"
+	}
+
+	return url
 }
 
 // ClearPatchData removes any inline patch data stored in this patch object for patches that have

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -138,14 +138,7 @@ func (p *patchParams) createPatch(ac *legacyClient, conf *ClientSettings, diffDa
 			return newPatch, nil
 		}
 
-		var url string
-		if newPatch.Activated {
-			url = conf.UIServerHost + "/version/" + newPatch.Id.Hex()
-		} else {
-			url = conf.UIServerHost + "/patch/" + newPatch.Id.Hex()
-		}
-
-		browserCmd = append(browserCmd, url)
+		browserCmd = append(browserCmd, newPatch.GetURL(conf.UIServerHost))
 		cmd := exec.Command(browserCmd[0], browserCmd[1:]...)
 		return newPatch, cmd.Run()
 	}
@@ -338,12 +331,6 @@ func validatePatchSize(diff *localDiff, allowLarge bool) error {
 // which can be written to the terminal.
 func getPatchDisplay(p *patch.Patch, summarize bool, uiHost string) (string, error) {
 	var out bytes.Buffer
-	var url string
-	if p.Activated {
-		url = uiHost + "/version/" + p.Id.Hex()
-	} else {
-		url = uiHost + "/patch/" + p.Id.Hex()
-	}
 
 	err := patchDisplayTemplate.Execute(&out, struct {
 		Patch         *patch.Patch
@@ -354,7 +341,7 @@ func getPatchDisplay(p *patch.Patch, summarize bool, uiHost string) (string, err
 		Patch:         p,
 		ShowSummary:   summarize,
 		ShowFinalized: p.Alias != evergreen.CommitQueueAlias,
-		Link:          url,
+		Link:          p.GetURL(uiHost),
 	})
 	if err != nil {
 		return "", err

--- a/service/patch.go
+++ b/service/patch.go
@@ -26,9 +26,11 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 
 	currentUser := MustHaveUser(r)
 	spruceLink := fmt.Sprintf("%s/patch/%s/configure", uis.Settings.Ui.UIv2Url, projCtx.Patch.Id.Hex())
-	if currentUser.Settings.UseSpruceOptions.SpruceV1 {
-		http.Redirect(w, r, spruceLink, http.StatusTemporaryRedirect)
-		return
+	if r.FormValue("redirect_spruce_users") == "true" {
+		if currentUser.Settings.UseSpruceOptions.SpruceV1 {
+			http.Redirect(w, r, spruceLink, http.StatusTemporaryRedirect)
+			return
+		}
 	}
 
 	var versionAsUI *uiVersion

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -203,6 +203,10 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		}
 	}
 
+	if j.user.Settings.UseSpruceOptions.SpruceV1 {
+		patchDoc.DisplayNewUI = true
+	}
+
 	pref, err := model.FindOneProjectRef(patchDoc.Project)
 	if err != nil {
 		return errors.Wrap(err, "can't find patch project")


### PR DESCRIPTION
The patch configure page now uses the same pattern as the other ones, meaning you have to add something extra in the URL to go to spruce