### PR TITLE
EVG-8087 validate host.create counts by provider

### DIFF
--- a/command/registry.go
+++ b/command/registry.go
@@ -26,7 +26,7 @@ func init() {
 		"attach.results":                attachResultsFactory,
 		"attach.xunit_results":          xunitResultsFactory,
 		"attach.artifacts":              attachArtifactsFactory,
-		evergreen.CreateHostCommandName: createHostFactory,
+		evergreen.HostCreateCommandName: createHostFactory,
 		"host.list":                     listHostFactory,
 		"expansions.fetch_vars":         fetchVarsFactory,
 		"expansions.update":             updateExpansionsFactory,

--- a/globals.go
+++ b/globals.go
@@ -356,7 +356,7 @@ const (
 
 const (
 	GenerateTasksCommandName = "generate.tasks"
-	CreateHostCommandName    = "host.create"
+	HostCreateCommandName    = "host.create"
 	S3PushCommandName        = "s3.push"
 	S3PullCommandName        = "s3.pull"
 )

--- a/model/project.go
+++ b/model/project.go
@@ -1356,68 +1356,6 @@ func (p *Project) GetAllVariantTasks() []patch.VariantTasks {
 	return vts
 }
 
-type HostCreateCounts struct {
-	Docker map[string]int
-	EC2    map[string]int
-	All    map[string]int
-}
-
-// TasksThatCallHostCreateByProvider is similar to TasksThatCallCommand, except the output is split into
-// host.create for Docker hosts and host.create for non-docker hosts, so limits can be validated separately.
-func (p *Project) TasksThatCallHostCreateByProvider() HostCreateCounts {
-	// get all functions that call the command.
-	ec2Fs := map[string]int{}
-	dockerFs := map[string]int{}
-	for f, cmds := range p.Functions {
-		if cmds == nil {
-			continue
-		}
-		for _, c := range cmds.List() {
-			if c.Command == evergreen.CreateHostCommandName {
-				provider, ok := c.Params["provider"]
-				if ok && provider.(string) == evergreen.ProviderNameDocker {
-					dockerFs[f] += 1
-				} else {
-					ec2Fs[f] += 1
-				}
-			}
-		}
-	}
-
-	// get all tasks that call the command.
-	counts := HostCreateCounts{
-		Docker: map[string]int{},
-		EC2:    map[string]int{},
-		All:    map[string]int{},
-	}
-	for _, t := range p.Tasks {
-		for _, c := range t.Commands {
-			if c.Function != "" {
-				if times, ok := ec2Fs[c.Function]; ok {
-					counts.EC2[t.Name] += times
-					counts.All[t.Name] += times
-				}
-				if times, ok := dockerFs[c.Function]; ok {
-					counts.Docker[t.Name] += times
-					counts.All[t.Name] += times
-				}
-			}
-			if c.Command == evergreen.CreateHostCommandName {
-				provider, ok := c.Params["provider"]
-				if ok && provider.(string) == evergreen.ProviderNameDocker {
-					counts.Docker[t.Name] += 1
-					counts.All[t.Name] += 1
-				} else {
-					counts.EC2[t.Name] += 1
-					counts.All[t.Name] += 1
-				}
-			}
-		}
-	}
-
-	return counts
-}
-
 // TasksThatCallCommand returns a map of tasks that call a given command to the
 // number of times the command is called in the task.
 func (p *Project) TasksThatCallCommand(find string) map[string]int {

--- a/model/project.go
+++ b/model/project.go
@@ -1357,16 +1357,16 @@ func (p *Project) GetAllVariantTasks() []patch.VariantTasks {
 }
 
 type HostCreateCounts struct {
-	Docker    map[string]int
-	NonDocker map[string]int
-	All       map[string]int
+	Docker map[string]int
+	EC2    map[string]int
+	All    map[string]int
 }
 
 // TasksThatCallHostCreateByProvider is similar to TasksThatCallCommand, except the output is split into
 // host.create for Docker hosts and host.create for non-docker hosts, so limits can be validated separately.
 func (p *Project) TasksThatCallHostCreateByProvider() HostCreateCounts {
 	// get all functions that call the command.
-	nonDockerFs := map[string]int{}
+	ec2Fs := map[string]int{}
 	dockerFs := map[string]int{}
 	for f, cmds := range p.Functions {
 		if cmds == nil {
@@ -1378,7 +1378,7 @@ func (p *Project) TasksThatCallHostCreateByProvider() HostCreateCounts {
 				if ok && provider.(string) == evergreen.ProviderNameDocker {
 					dockerFs[f] += 1
 				} else {
-					nonDockerFs[f] += 1
+					ec2Fs[f] += 1
 				}
 			}
 		}
@@ -1386,15 +1386,15 @@ func (p *Project) TasksThatCallHostCreateByProvider() HostCreateCounts {
 
 	// get all tasks that call the command.
 	counts := HostCreateCounts{
-		Docker:    map[string]int{},
-		NonDocker: map[string]int{},
-		All:       map[string]int{},
+		Docker: map[string]int{},
+		EC2:    map[string]int{},
+		All:    map[string]int{},
 	}
 	for _, t := range p.Tasks {
 		for _, c := range t.Commands {
 			if c.Function != "" {
-				if times, ok := nonDockerFs[c.Function]; ok {
-					counts.NonDocker[t.Name] += times
+				if times, ok := ec2Fs[c.Function]; ok {
+					counts.EC2[t.Name] += times
 					counts.All[t.Name] += times
 				}
 				if times, ok := dockerFs[c.Function]; ok {
@@ -1408,7 +1408,7 @@ func (p *Project) TasksThatCallHostCreateByProvider() HostCreateCounts {
 					counts.Docker[t.Name] += 1
 					counts.All[t.Name] += 1
 				} else {
-					counts.NonDocker[t.Name] += 1
+					counts.EC2[t.Name] += 1
 					counts.All[t.Name] += 1
 				}
 			}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -163,7 +163,7 @@ func (dc *DBCreateHostConnector) CreateHostsFromTask(t *task.Task, user user.DBU
 }
 
 func createHostFromCommand(cmd model.PluginCommandConf) (*apimodels.CreateHost, error) {
-	if cmd.Command != evergreen.CreateHostCommandName {
+	if cmd.Command != evergreen.HostCreateCommandName {
 		return nil, nil
 	}
 	createHost := &apimodels.CreateHost{}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -29,9 +29,9 @@ type ValidationErrorLevel int64
 const (
 	Error ValidationErrorLevel = iota
 	Warning
-	unauthorizedCharacters        = "|"
-	NonDockerHostCreateTotalLimit = 50
-	DockerHostCreateTotalLimit    = 200
+	unauthorizedCharacters     = "|"
+	EC2HostCreateTotalLimit    = 50
+	DockerHostCreateTotalLimit = 200
 )
 
 func (vel ValidationErrorLevel) String() string {
@@ -1139,24 +1139,24 @@ func validateTimesCalledPerTask(p *model.Project, ts map[string]int, commandName
 
 func validateCreateHostTotals(p *model.Project, counts model.HostCreateCounts) ValidationErrors {
 	errs := ValidationErrors{}
-	totalDocker := 0
-	totalNonDocker := 0
+	dockerTotal := 0
+	ec2Total := 0
 	errorFmt := "project config may only call %s %s %d time(s) but it is called %d time(s)"
 	for _, bv := range p.BuildVariants {
 		for _, t := range bv.Tasks {
-			totalDocker += counts.Docker[t.Name]
-			totalNonDocker += counts.NonDocker[t.Name]
+			dockerTotal += counts.Docker[t.Name]
+			ec2Total += counts.EC2[t.Name]
 		}
 	}
-	if totalNonDocker > NonDockerHostCreateTotalLimit {
+	if ec2Total > EC2HostCreateTotalLimit {
 		errs = append(errs, ValidationError{
-			Message: fmt.Sprintf(errorFmt, "non-docker", evergreen.CreateHostCommandName, NonDockerHostCreateTotalLimit, totalNonDocker),
+			Message: fmt.Sprintf(errorFmt, "ec2", evergreen.CreateHostCommandName, EC2HostCreateTotalLimit, ec2Total),
 			Level:   Error,
 		})
 	}
-	if totalDocker > DockerHostCreateTotalLimit {
+	if dockerTotal > DockerHostCreateTotalLimit {
 		errs = append(errs, ValidationError{
-			Message: fmt.Sprintf(errorFmt, "docker", evergreen.CreateHostCommandName, DockerHostCreateTotalLimit, totalDocker),
+			Message: fmt.Sprintf(errorFmt, "docker", evergreen.CreateHostCommandName, DockerHostCreateTotalLimit, dockerTotal),
 			Level:   Error,
 		})
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -108,7 +108,7 @@ var projectSyntaxValidators = []projectValidator{
 	validateProjectTaskNames,
 	validateProjectTaskIdsAndTags,
 	validateTaskGroups,
-	validateCreateHosts,
+	validateHostCreates,
 	validateDuplicateBVTasks,
 	validateGenerateTasks,
 	validateTaskSyncCommands,
@@ -1114,10 +1114,10 @@ func checkOrAddTask(task, variant string, tasksFound map[string]interface{}) *Va
 	return nil
 }
 
-func validateCreateHosts(p *model.Project) ValidationErrors {
+func validateHostCreates(p *model.Project) ValidationErrors {
 	counts := tasksThatCallHostCreateByProvider(p)
-	errs := validateTimesCalledPerTask(p, counts.All, evergreen.CreateHostCommandName, HostCreateLimitPerTask, Error)
-	errs = append(errs, validateCreateHostTotals(p, counts)...)
+	errs := validateTimesCalledPerTask(p, counts.All, evergreen.HostCreateCommandName, HostCreateLimitPerTask, Error)
+	errs = append(errs, validateHostCreateTotals(p, counts)...)
 	return errs
 }
 
@@ -1138,7 +1138,7 @@ func tasksThatCallHostCreateByProvider(p *model.Project) hostCreateCounts {
 			continue
 		}
 		for _, c := range cmds.List() {
-			if c.Command == evergreen.CreateHostCommandName {
+			if c.Command == evergreen.HostCreateCommandName {
 				provider, ok := c.Params["provider"]
 				if ok && provider.(string) == evergreen.ProviderNameDocker {
 					dockerFs[f] += 1
@@ -1167,7 +1167,7 @@ func tasksThatCallHostCreateByProvider(p *model.Project) hostCreateCounts {
 					counts.All[t.Name] += times
 				}
 			}
-			if c.Command == evergreen.CreateHostCommandName {
+			if c.Command == evergreen.HostCreateCommandName {
 				provider, ok := c.Params["provider"]
 				if ok && provider.(string) == evergreen.ProviderNameDocker {
 					counts.Docker[t.Name] += 1
@@ -1200,7 +1200,7 @@ func validateTimesCalledPerTask(p *model.Project, ts map[string]int, commandName
 	return errs
 }
 
-func validateCreateHostTotals(p *model.Project, counts hostCreateCounts) ValidationErrors {
+func validateHostCreateTotals(p *model.Project, counts hostCreateCounts) ValidationErrors {
 	errs := ValidationErrors{}
 	dockerTotal := 0
 	ec2Total := 0
@@ -1213,13 +1213,13 @@ func validateCreateHostTotals(p *model.Project, counts hostCreateCounts) Validat
 	}
 	if ec2Total > EC2HostCreateTotalLimit {
 		errs = append(errs, ValidationError{
-			Message: fmt.Sprintf(errorFmt, "ec2", evergreen.CreateHostCommandName, EC2HostCreateTotalLimit, ec2Total),
+			Message: fmt.Sprintf(errorFmt, "ec2", evergreen.HostCreateCommandName, EC2HostCreateTotalLimit, ec2Total),
 			Level:   Error,
 		})
 	}
 	if dockerTotal > DockerHostCreateTotalLimit {
 		errs = append(errs, ValidationError{
-			Message: fmt.Sprintf(errorFmt, "docker", evergreen.CreateHostCommandName, DockerHostCreateTotalLimit, dockerTotal),
+			Message: fmt.Sprintf(errorFmt, "docker", evergreen.HostCreateCommandName, DockerHostCreateTotalLimit, dockerTotal),
 			Level:   Error,
 		})
 	}

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2038,7 +2038,7 @@ func TestValidateCreateHosts(t *testing.T) {
 	pp, err := model.LoadProjectInto([]byte(yml), "id", &p)
 	require.NoError(err)
 	require.NotNil(pp)
-	errs := validateCreateHosts(&p)
+	errs := validateHostCreates(&p)
 	assert.Len(errs, 0)
 
 	// error: times called per task
@@ -2059,7 +2059,7 @@ func TestValidateCreateHosts(t *testing.T) {
 	pp, err = model.LoadProjectInto([]byte(yml), "id", &p)
 	require.NoError(err)
 	require.NotNil(pp)
-	errs = validateCreateHosts(&p)
+	errs = validateHostCreates(&p)
 	assert.Len(errs, 1)
 }
 


### PR DESCRIPTION
So it could output separate messages now:
```
ERROR: project config may only call ec2 host.create 50 time(s) but it is called 54 time(s)
ERROR: project config may only call docker host.create 200 time(s) but it is called 205 time(s)
```
