### PR TITLE
EVG-7835: app shouldn't fail to start if an api_only user is misconfigured	

### DIFF
--- a/auth/only_api.go
+++ b/auth/only_api.go
@@ -74,14 +74,6 @@ func NewOnlyAPIUserManager(config *evergreen.OnlyAPIAuthConfig) (gimlet.UserMana
 		catcher.Wrap(err, "could not delete old API-only users from DB")
 	}
 
-	if catcher.HasErrors() {
-		grip.Critical(message.WrapError(catcher.Resolve(), message.Fields{
-			"message": "failed to create API-only manager",
-			"reason":  "problems updating API-only users in database",
-		}))
-		return nil, errors.Wrap(catcher.Resolve(), "could not initialize API-only user manager")
-	}
-
 	opts := usercache.ExternalOptions{
 		PutUserGetToken: func(gimlet.User) (string, error) {
 			return "", errors.New("cannot put new users in DB")
@@ -109,7 +101,13 @@ func NewOnlyAPIUserManager(config *evergreen.OnlyAPIAuthConfig) (gimlet.UserMana
 	}
 	cache, err := usercache.NewExternal(opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create DB cache")
+		catcher.Wrap(err, "could not create DB cache")
+	}
+	if catcher.HasErrors() {
+		grip.Critical(message.WrapError(catcher.Resolve(), message.Fields{
+			"message": "failed to create API-only manager",
+			"reason":  "problems updating API-only users in database",
+		}))
 	}
 	return cached.NewUserManager(cache)
 }

--- a/auth/only_api.go
+++ b/auth/only_api.go
@@ -100,9 +100,8 @@ func NewOnlyAPIUserManager(config *evergreen.OnlyAPIAuthConfig) (gimlet.UserMana
 		},
 	}
 	cache, err := usercache.NewExternal(opts)
-	if err != nil {
-		catcher.Wrap(err, "could not create DB cache")
-	}
+	catcher.Wrap(err, "could not create DB cache")
+
 	if catcher.HasErrors() {
 		grip.Critical(message.WrapError(catcher.Resolve(), message.Fields{
 			"message": "failed to create API-only manager",

--- a/auth/only_api_test.go
+++ b/auth/only_api_test.go
@@ -93,8 +93,9 @@ func TestOnlyAPIUserManager(t *testing.T) {
 				Users: []evergreen.OnlyAPIUser{u1},
 			}
 			um, err := NewOnlyAPIUserManager(conf)
-			assert.Error(t, err)
-			assert.Nil(t, um)
+			//check that it still returns a user manager and no error
+			assert.NoError(t, err)
+			assert.NotNil(t, um)
 		},
 		"DeletesOldOnlyAPIUsers": func(t *testing.T) {
 			regUser := &user.DBUser{

--- a/auth/only_api_test.go
+++ b/auth/only_api_test.go
@@ -93,7 +93,6 @@ func TestOnlyAPIUserManager(t *testing.T) {
 				Users: []evergreen.OnlyAPIUser{u1},
 			}
 			um, err := NewOnlyAPIUserManager(conf)
-			//check that it still returns a user manager and no error
 			assert.NoError(t, err)
 			assert.NotNil(t, um)
 		},

--- a/operations/service_web.go
+++ b/operations/service_web.go
@@ -55,7 +55,7 @@ func startWebService() cli.Command {
 			// Create the user manager before setting up job queues to allow
 			// background reauthorization jobs to start.
 			if err = setupUserManager(env, settings); err != nil {
-				return errors.Wrap(err, "could not set up user manager")
+				grip.EmergencyFatal(errors.Wrap(err, "could not set up user manager"))
 			}
 
 			defer cancel()

--- a/operations/service_web.go
+++ b/operations/service_web.go
@@ -55,7 +55,7 @@ func startWebService() cli.Command {
 			// Create the user manager before setting up job queues to allow
 			// background reauthorization jobs to start.
 			if err = setupUserManager(env, settings); err != nil {
-				grip.EmergencyFatal(errors.Wrap(err, "could not set up user manager"))
+				return errors.Wrap(err, "could not set up user manager")
 			}
 
 			defer cancel()


### PR DESCRIPTION
[EVG-7835](https://jira.mongodb.org/browse/EVG-7835)

Instead of returning when the setupUserManager fails, log an EmergencyFatal error and continue to start the app. 

Question for reviewers: Does this need to be tested? Any suggestions? 
