### PR TITLE
EVG-8067 add logging around patch creation

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -245,6 +245,17 @@ func SchedulePatch(ctx context.Context, patchId string, version *model.Version, 
 		if err != nil {
 			return errors.Wrap(err, "Error finalizing patch"), http.StatusInternalServerError, "", ""
 		}
+		if requester == evergreen.PatchVersionRequester {
+			grip.Info(message.Fields{
+				"operation":     "patch creation",
+				"message":       "finalized patch from the UI",
+				"patch_id":      p.Id,
+				"variants":      p.BuildVariants,
+				"tasks":         p.Tasks,
+				"variant_tasks": p.VariantsTasks,
+				"alias":         p.Alias,
+			})
+		}
 
 		if p.IsGithubPRPatch() {
 			job := units.NewGithubStatusUpdateJobForNewPatch(p.Id.Hex())

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -248,7 +248,8 @@ func SchedulePatch(ctx context.Context, patchId string, version *model.Version, 
 		if requester == evergreen.PatchVersionRequester {
 			grip.Info(message.Fields{
 				"operation":     "patch creation",
-				"message":       "finalized patch from the UI",
+				"message":       "finalized patch",
+				"from":          "UI",
 				"patch_id":      p.Id,
 				"variants":      p.BuildVariants,
 				"tasks":         p.Tasks,

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -161,7 +161,8 @@ func (pc *DBPatchConnector) SetPatchActivated(ctx context.Context, patchId strin
 		if requester == evergreen.PatchVersionRequester {
 			grip.Info(message.Fields{
 				"operation":     "patch creation",
-				"message":       "finalized patch with status rest route",
+				"message":       "finalized patch",
+				"from":          "rest route",
 				"patch_id":      p.Id,
 				"variants":      p.BuildVariants,
 				"tasks":         p.Tasks,

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -109,7 +109,8 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	patchID := mgobson.NewObjectId()
 	grip.Info(message.Fields{
 		"operation":  "patch creation",
-		"message":    "creating patch from CLI",
+		"message":    "creating patch",
+		"from":       "CLI",
 		"patch_id":   patchID,
 		"finalizing": data.Finalize,
 		"variants":   data.Variants,
@@ -357,7 +358,8 @@ func (as *APIServer) existingPatchRequest(w http.ResponseWriter, r *http.Request
 		}
 		grip.Info(message.Fields{
 			"operation":     "patch creation",
-			"message":       "finalized patch with finalize-patch",
+			"message":       "finalized patch",
+			"from":          "CLI",
 			"patch_id":      p.Id,
 			"variants":      p.BuildVariants,
 			"tasks":         p.Tasks,

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -17,6 +17,8 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	mgobson "gopkg.in/mgo.v2/bson"
 )
@@ -105,6 +107,15 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	patchID := mgobson.NewObjectId()
+	grip.Info(message.Fields{
+		"operation":  "patch creation",
+		"message":    "creating patch from CLI",
+		"patch_id":   patchID,
+		"finalizing": data.Finalize,
+		"variants":   data.Variants,
+		"tasks":      data.Tasks,
+		"alias":      data.Alias,
+	})
 	job := units.NewPatchIntentProcessor(patchID, intent)
 	job.Run(r.Context())
 
@@ -344,6 +355,15 @@ func (as *APIServer) existingPatchRequest(w http.ResponseWriter, r *http.Request
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}
+		grip.Info(message.Fields{
+			"operation":     "patch creation",
+			"message":       "finalized patch with finalize-patch",
+			"patch_id":      p.Id,
+			"variants":      p.BuildVariants,
+			"tasks":         p.Tasks,
+			"variant_tasks": p.VariantsTasks,
+			"alias":         p.Alias,
+		})
 
 		gimlet.WriteJSON(w, "patch finalized")
 	case "cancel":

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -354,6 +354,18 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 			}))
 			return err
 		}
+		if j.IntentType == patch.CliIntentType {
+			grip.Info(message.Fields{
+				"operation":     "patch creation",
+				"message":       "finalized patch from CLI",
+				"job":           j.ID(),
+				"patch_id":      patchDoc.Id,
+				"variants":      patchDoc.BuildVariants,
+				"tasks":         patchDoc.Tasks,
+				"variant_tasks": patchDoc.VariantsTasks,
+				"alias":         patchDoc.Alias,
+			})
+		}
 	}
 
 	return catcher.Resolve()

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -357,7 +357,8 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		if j.IntentType == patch.CliIntentType {
 			grip.Info(message.Fields{
 				"operation":     "patch creation",
-				"message":       "finalized patch from CLI",
+				"message":       "finalized patch at time of patch creation",
+				"from":          "CLI",
 				"job":           j.ID(),
 				"patch_id":      patchDoc.Id,
 				"variants":      patchDoc.BuildVariants,


### PR DESCRIPTION
This is to show when patches are created and finalized (and from where), as well as what tasks/variants were scheduled (and at what point).

I used "operation"="patch creation" instead of "source"="patch intent" since the latter also includes logs for github PR patches and etc, but I'm open to changes around the log naming.