### PR TITLE
EVG-8204 pass through standard streams

### DIFF
--- a/apimodels/runtime_models.go
+++ b/apimodels/runtime_models.go
@@ -1,7 +1,5 @@
 package apimodels
 
-import "github.com/mongodb/grip/send"
-
 // Struct for reporting process timeouts
 type ProcessTimeoutResponse struct {
 	Status        string      `json:"status"`
@@ -12,5 +10,4 @@ type WorkstationSetupCommandOptions struct {
 	Directory string
 	Quiet     bool
 	DryRun    bool
-	Output    send.Sender
 }

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -346,7 +346,6 @@ func hostConfigure() cli.Command {
 				Directory: directory,
 				Quiet:     quiet,
 				DryRun:    dryRun,
-				Output:    grip.GetSender(),
 			})
 			if err != nil {
 				return errors.Wrapf(err, "error getting commands")


### PR DESCRIPTION
In order to allow scripts to get input from a user we need to pass stdin through to the jasper command that runs the script. The SenderWriter that was wrapping stdout was causing issues too (because it doesn't flush until it hits a \n), so I replaced it with `os.Stdout`. The script's errors should go to our stderr as well (not stdout), so I replaced that too.