### PR TITLE
EVG-6895 evergreen host modify should update expiration on UI

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2353,8 +2353,8 @@ func (h *Host) MarkShouldNotExpire(expireOnValue string) error {
 // MarkShouldExpire resets a host's expiration to expire like
 // a normal spawn host, after 24 hours.
 func (h *Host) MarkShouldExpire(expireOnValue string) error {
-	//if it's already set to expire, do nothing.
-	if h.NoExpiration == false {
+	// If it's already set to expire, do nothing.
+	if !h.NoExpiration {
 		return nil
 	}
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2353,6 +2353,11 @@ func (h *Host) MarkShouldNotExpire(expireOnValue string) error {
 // MarkShouldExpire resets a host's expiration to expire like
 // a normal spawn host, after 24 hours.
 func (h *Host) MarkShouldExpire(expireOnValue string) error {
+	//if it's already set to expire, do nothing.
+	if h.NoExpiration == false {
+		return nil
+	}
+
 	h.NoExpiration = false
 	h.ExpirationTime = time.Now().Add(evergreen.DefaultSpawnHostExpiration)
 	h.addTag(makeExpireOnTag(expireOnValue), true)


### PR DESCRIPTION
[EVG-6895](https://jira.mongodb.org/browse/EVG-6895)

`modify --host <hostID> --expire  --extend 5  ` didn't work properly, because even if it was already set to expire, --expire would set  `h.ExpirationTime = time.Now().Add(evergreen.DefaultSpawnHostExpiration)`. The time was reset before adding on the desired extension time, causing it to update to the wrong time. 

