### PR TITLE
EVG-8294 look at the cause of repotracker errors

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -356,9 +356,9 @@ func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision s
 		// to actually fetching a config. Those errors currently include:
 		// thirdparty.APIRequestError, thirdparty.FileNotFoundError and
 		// thirdparty.YAMLFormatError
-		_, apiReqErr := err.(thirdparty.APIRequestError)
-		_, ymlFmtErr := err.(thirdparty.YAMLFormatError)
-		_, noFileErr := err.(thirdparty.FileNotFoundError)
+		_, apiReqErr := errors.Cause(err).(thirdparty.APIRequestError)
+		_, ymlFmtErr := errors.Cause(err).(thirdparty.YAMLFormatError)
+		_, noFileErr := errors.Cause(err).(thirdparty.FileNotFoundError)
 		if apiReqErr || noFileErr || ymlFmtErr {
 			// If there's an error getting the remote config, e.g. because it
 			// does not exist, we treat this the same as when the remote config


### PR DESCRIPTION
The issue is definitely similar to what we were referring to earlier this week: the repotracker is trying to catch up on old revisions. We’re supposed to be hitting this thirdparty.FileNotFoundError, and the root error is "Requested file at .evergreen2.yml not found" but it turns  out we're not because I decided to [wrap the error](https://github.com/evergreen-ci/evergreen/pull/3644/files) in a refactor.

I am perplexed about how [the commit it’s failing on](https://github.com/10gen/mms/tree/8ad61471afd1a54c9543acf37b0da3ed95cc8574) doesn't have the requested file considering the commit before does have it, but 🤷 

