### PR TITLE
EVG-7903 improve task group race with cached order numbers

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1,7 +1,6 @@
 package host
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/evergreen-ci/certdepot"
@@ -363,7 +362,7 @@ func ByUnprovisionedSince(threshold time.Time) db.Q {
 	})
 }
 
-// ByTakSpec returns a query that finds all running hosts that are running a
+// ByTaskSpec returns a query that finds all running hosts that are running a
 // task with the given group, buildvariant, project, and version.
 func ByTaskSpec(group, buildVariant, project, version string) db.Q {
 	return db.Query(
@@ -393,9 +392,8 @@ func ByTaskSpec(group, buildVariant, project, version string) db.Q {
 // the given group, buildvariant, project, and version.
 func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, error) {
 	if group == "" || buildVariant == "" || project == "" || version == "" {
-		s := "all arguments passed to host.NumHostsByTaskSpec must be non-empty strings: "
-		s += fmt.Sprintf("group is '%s', buildVariant is '%s', project is '%s' and version is '%s'", group, buildVariant, project, version)
-		return 0, errors.New(s)
+		return 0, errors.Errorf("all arguments must be non-empty strings: (group is '%s', buildVariant is '%s', "+
+			"project is '%s' and version is '%s')", group, buildVariant, project, version)
 	}
 
 	numHosts, err := Count(ByTaskSpec(group, buildVariant, project, version))
@@ -411,9 +409,8 @@ func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, erro
 // Returns 0 in the case of missing task group order numbers or no hosts.
 func MinTaskGroupOrderRunningByTaskSpec(group, buildVariant, project, version string) (int, error) {
 	if group == "" || buildVariant == "" || project == "" || version == "" {
-		s := "all arguments passed to host.NumHostsByTaskSpec must be non-empty strings: "
-		s += fmt.Sprintf("group is '%s', buildVariant is '%s', project is '%s' and version is '%s'", group, buildVariant, project, version)
-		return 0, errors.New(s)
+		return 0, errors.Errorf("all arguments must be non-empty strings: (group is '%s', buildVariant is '%s', "+
+			"project is '%s' and version is '%s')", group, buildVariant, project, version)
 	}
 
 	numHosts, err := Find(ByTaskSpec(group, buildVariant, project, version).WithFields(RunningTaskGroupOrderKey).Sort([]string{RunningTaskGroupOrderKey}))

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -42,6 +42,7 @@ var (
 	DisplayNameKey               = bsonutil.MustHaveTag(Host{}, "DisplayName")
 	RunningTaskKey               = bsonutil.MustHaveTag(Host{}, "RunningTask")
 	RunningTaskGroupKey          = bsonutil.MustHaveTag(Host{}, "RunningTaskGroup")
+	RunningTaskGroupOrderKey     = bsonutil.MustHaveTag(Host{}, "RunningTaskGroupOrder")
 	RunningTaskBuildVariantKey   = bsonutil.MustHaveTag(Host{}, "RunningTaskBuildVariant")
 	RunningTaskVersionKey        = bsonutil.MustHaveTag(Host{}, "RunningTaskVersion")
 	RunningTaskProjectKey        = bsonutil.MustHaveTag(Host{}, "RunningTaskProject")
@@ -362,15 +363,10 @@ func ByUnprovisionedSince(threshold time.Time) db.Q {
 	})
 }
 
-// NumHostsByTaskSpec returns a query that finds all running hosts that are running a
+// ByTakSpec returns a query that finds all running hosts that are running a
 // task with the given group, buildvariant, project, and version.
-func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, error) {
-	if group == "" || buildVariant == "" || project == "" || version == "" {
-		s := "all arguments passed to host.NumHostsByTaskSpec must be non-empty strings: "
-		s += fmt.Sprintf("group is '%s', buildVariant is '%s', project is '%s' and version is '%s'", group, buildVariant, project, version)
-		return 0, errors.New(s)
-	}
-	q := db.Query(
+func ByTaskSpec(group, buildVariant, project, version string) db.Q {
+	return db.Query(
 		bson.M{
 			StatusKey: bson.M{"$in": evergreen.CanRunTaskStatus},
 			"$or": []bson.M{
@@ -391,41 +387,45 @@ func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, erro
 			},
 		},
 	)
-	hosts, err := Find(q)
+}
+
+// NumHostsByTaskSpec returns the number of running hosts that are running a task with
+// the given group, buildvariant, project, and version.
+func NumHostsByTaskSpec(group, buildVariant, project, version string) (int, error) {
+	if group == "" || buildVariant == "" || project == "" || version == "" {
+		s := "all arguments passed to host.NumHostsByTaskSpec must be non-empty strings: "
+		s += fmt.Sprintf("group is '%s', buildVariant is '%s', project is '%s' and version is '%s'", group, buildVariant, project, version)
+		return 0, errors.New(s)
+	}
+
+	numHosts, err := Count(ByTaskSpec(group, buildVariant, project, version))
+	if err != nil {
+		return 0, errors.Wrap(err, "error querying database for host count")
+	}
+
+	return numHosts, nil
+}
+
+//  MinTaskGroupOrderRunningByTaskSpec returns the smallest task group order number for tasks with the
+// given group, buildvariant, project, and version that are running on hosts.
+// Returns 0 in the case of missing task group order numbers or no hosts.
+func MinTaskGroupOrderRunningByTaskSpec(group, buildVariant, project, version string) (int, error) {
+	if group == "" || buildVariant == "" || project == "" || version == "" {
+		s := "all arguments passed to host.NumHostsByTaskSpec must be non-empty strings: "
+		s += fmt.Sprintf("group is '%s', buildVariant is '%s', project is '%s' and version is '%s'", group, buildVariant, project, version)
+		return 0, errors.New(s)
+	}
+
+	numHosts, err := Find(ByTaskSpec(group, buildVariant, project, version).WithFields(RunningTaskGroupOrderKey).Sort([]string{RunningTaskGroupOrderKey}))
 	if err != nil {
 		return 0, errors.Wrap(err, "error querying database for hosts")
 	}
-	// TODO: when we remove this debugging logic, Find can be changed to Count
-	if len(hosts) > 1 { // for single host task groups, this would indicate a race
-		type hostInfo struct {
-			Id               string
-			Status           string
-			RunningTaskGroup string
-			RunningBV        string
-			LastBV           string
-			LastGroup        string
-		}
-		info := []hostInfo{}
-		for _, h := range hosts {
-			cur := hostInfo{
-				Id:               h.Id,
-				Status:           h.Status,
-				RunningTaskGroup: h.RunningTaskGroup,
-				RunningBV:        h.RunningTaskBuildVariant,
-				LastBV:           h.LastBuildVariant,
-				LastGroup:        h.LastGroup,
-			}
-			info = append(info, cur)
-		}
-		grip.Debug(message.Fields{
-			"message":            "num hosts by task spec",
-			"task_version":       version,
-			"task_group":         group,
-			"task_build_variant": buildVariant,
-			"hosts":              info,
-		})
+	minTaskGroupOrder := 0
+	//  can look at only one host because we sorted
+	if len(numHosts) > 0 {
+		minTaskGroupOrder = numHosts[0].RunningTaskGroupOrder
 	}
-	return len(hosts), nil
+	return minTaskGroupOrder, nil
 }
 
 // IsUninitialized is a query that returns all unstarted + uninitialized Evergreen hosts.

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -55,10 +55,11 @@ type Host struct {
 
 	// the task that is currently running on the host
 	RunningTask             string `bson:"running_task,omitempty" json:"running_task,omitempty"`
-	RunningTaskGroup        string `bson:"running_task_group,omitempty" json:"running_task_group,omitempty"`
 	RunningTaskBuildVariant string `bson:"running_task_bv,omitempty" json:"running_task_bv,omitempty"`
 	RunningTaskVersion      string `bson:"running_task_version,omitempty" json:"running_task_version,omitempty"`
 	RunningTaskProject      string `bson:"running_task_project,omitempty" json:"running_task_project,omitempty"`
+	RunningTaskGroup        string `bson:"running_task_group,omitempty" json:"running_task_group,omitempty"`
+	RunningTaskGroupOrder   int    `bson:"running_task_group_order,omitempty" json:"running_task_group_order,omitempty"`
 
 	// the task the most recently finished running on the host
 	LastTask         string `bson:"last_task" json:"last_task"`
@@ -1019,6 +1020,7 @@ func (h *Host) ClearRunningAndSetLastTask(t *task.Task) error {
 			"$unset": bson.M{
 				RunningTaskKey:             1,
 				RunningTaskGroupKey:        1,
+				RunningTaskGroupOrderKey:   1,
 				RunningTaskBuildVariantKey: 1,
 				RunningTaskVersionKey:      1,
 				RunningTaskProjectKey:      1,
@@ -1031,10 +1033,11 @@ func (h *Host) ClearRunningAndSetLastTask(t *task.Task) error {
 
 	event.LogHostRunningTaskCleared(h.Id, h.RunningTask)
 	h.RunningTask = ""
-	h.RunningTaskGroup = ""
 	h.RunningTaskBuildVariant = ""
 	h.RunningTaskVersion = ""
 	h.RunningTaskProject = ""
+	h.RunningTaskGroup = ""
+	h.RunningTaskGroupOrder = 0
 	h.LastTask = t.Id
 	h.LastGroup = t.TaskGroup
 	h.LastBuildVariant = t.BuildVariant
@@ -1055,6 +1058,7 @@ func (h *Host) ClearRunningTask() error {
 			"$unset": bson.M{
 				RunningTaskKey:             1,
 				RunningTaskGroupKey:        1,
+				RunningTaskGroupOrderKey:   1,
 				RunningTaskBuildVariantKey: 1,
 				RunningTaskVersionKey:      1,
 				RunningTaskProjectKey:      1,
@@ -1069,10 +1073,11 @@ func (h *Host) ClearRunningTask() error {
 		event.LogHostRunningTaskCleared(h.Id, h.RunningTask)
 	}
 	h.RunningTask = ""
-	h.RunningTaskGroup = ""
 	h.RunningTaskBuildVariant = ""
 	h.RunningTaskVersion = ""
 	h.RunningTaskProject = ""
+	h.RunningTaskGroup = ""
+	h.RunningTaskGroupOrder = 0
 
 	return nil
 }
@@ -1105,6 +1110,7 @@ func (h *Host) UpdateRunningTask(t *task.Task) (bool, error) {
 		"$set": bson.M{
 			RunningTaskKey:             t.Id,
 			RunningTaskGroupKey:        t.TaskGroup,
+			RunningTaskGroupOrderKey:   t.TaskGroupOrder,
 			RunningTaskBuildVariantKey: t.BuildVariant,
 			RunningTaskVersionKey:      t.Version,
 			RunningTaskProjectKey:      t.Project,


### PR DESCRIPTION
In the previous PR https://github.com/evergreen-ci/evergreen/commit/354f21dd42516d7c884fa371ff439069ea78f556, we exited with a race if the current task was in a single-host task group, was new to the host, and wasn't the first task in the group.

This was evidently too strict and had to be reverted. A less-strict version may be this: store running task order numbers with the host, and exit with a race if the current task is later in the task group than a currently running task. (If the host doesn't have order number cached, we'll revert to the previous format of race detecting).

So in the race condition scenario we currently have: 
Host1 gets/assigns task1
Host2 gets/assigns task2
Host1 checks for race--sees 2 hosts are running tasks but max hosts is 1, so it exits
Host2 checks for race--sees only 1 host (itself) is running task from group, incorrectly runs task out of order

We'll now have:
Host1 gets/assigns task1
Host2 gets/assigns task2
Host1 checks for race--sees the smallest running order number is 1, which is not smaller than its task, so it continues to run the task
Host2 checks for race--sees the smallest running order number is 1, which _is_ smaller than its task, so it logs a race and doesn't run the task