### PR TITLE
EVG-9694: auth into buildlogger with API key instead of LDAP password

### DIFF
--- a/apimodels/buildlogger_models.go
+++ b/apimodels/buildlogger_models.go
@@ -4,5 +4,6 @@ type BuildloggerInfo struct {
 	BaseURL  string `json:"base_url"`
 	RPCPort  string `json:"rpc_port"`
 	Username string `json:"username"`
-	Password string `json:"password"`
+	Password string `json:"password,omitempty"`
+	APIKey   string `json:"api_key,omitempty"`
 }

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	ClientVersion = "2020-06-23"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-06-05"
+	AgentVersion = "2020-07-07"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config_logger.go
+++ b/config_logger.go
@@ -18,6 +18,7 @@ type LoggerConfig struct {
 	BuildloggerRPCPort  string       `bson:"buildlogger_rpc_port" json:"buildlogger_rpc_port" yaml:"buildlogger_rpc_port"`
 	BuildloggerUser     string       `bson:"buildlogger_user" json:"buildlogger_user" yaml:"buildlogger_user"`
 	BuildloggerPassword string       `bson:"buildlogger_password" json:"buildlogger_password" yaml:"buildlogger_password"`
+	BuildloggerAPIKey   string       `bson:"buildlogger_api_key" json:"buildlogger_api_key" yaml:"buildlogger_api_key"`
 	DefaultLogger       string       `bson:"default_logger" json:"default_logger" yaml:"default_logger"`
 }
 
@@ -66,6 +67,7 @@ func (c *LoggerConfig) Set() error {
 			"buildlogger_rpc_port": c.BuildloggerRPCPort,
 			"buildlogger_user":     c.BuildloggerUser,
 			"buildlogger_password": c.BuildloggerPassword,
+			"buildlogger_api_key":  c.BuildloggerAPIKey,
 			"default_logger":       c.DefaultLogger,
 		},
 	}, options.Update().SetUpsert(true))

--- a/glide.lock
+++ b/glide.lock
@@ -137,7 +137,7 @@ imports:
   - name: go.mongodb.org/mongo-driver
     version: 90164f879ba927bc0fa38682215b7a71d4ff8a92
   - name: github.com/evergreen-ci/timber
-    version: 2866ce5b9aa79dd434ddfb7ee5fff159cf197a9b
+    version: f241d47dc48b4f45a4cca54c3d72b357ac7fc6ef
 
   - name: github.com/evergreen-ci/certdepot
     version: 270990334f8f50e41a803e88f169d2f467e376c5

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -287,6 +287,7 @@ func (c *communicatorImpl) makeSender(ctx context.Context, td TaskData, opts []L
 					RPCPort:     bi.RPCPort,
 					Username:    bi.Username,
 					Password:    bi.Password,
+					APIKey:      bi.APIKey,
 					Retries:     10,
 				}
 				c.cedarGRPCClient, err = timber.DialCedar(ctx, c.httpClient, dialOpts)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1030,6 +1030,7 @@ type APILoggerConfig struct {
 	BuildloggerRPCPort  *string          `json:"buildlogger_rpc_port"`
 	BuildloggerUser     *string          `json:"buildlogger_user"`
 	BuildloggerPassword *string          `json:"buildlogger_password"`
+	BuildloggerAPIKey   *string          `json:"buildlogger_api_key"`
 	DefaultLogger       *string          `json:"default_logger"`
 }
 
@@ -1043,6 +1044,7 @@ func (a *APILoggerConfig) BuildFromService(h interface{}) error {
 		a.BuildloggerRPCPort = ToStringPtr(v.BuildloggerRPCPort)
 		a.BuildloggerUser = ToStringPtr(v.BuildloggerUser)
 		a.BuildloggerPassword = ToStringPtr(v.BuildloggerPassword)
+		a.BuildloggerAPIKey = ToStringPtr(v.BuildloggerAPIKey)
 		a.DefaultLogger = ToStringPtr(v.DefaultLogger)
 		a.Buffer = &APILogBuffering{}
 		if err := a.Buffer.BuildFromService(v.Buffer); err != nil {
@@ -1063,6 +1065,7 @@ func (a *APILoggerConfig) ToService() (interface{}, error) {
 		BuildloggerRPCPort:  FromStringPtr(a.BuildloggerRPCPort),
 		BuildloggerUser:     FromStringPtr(a.BuildloggerUser),
 		BuildloggerPassword: FromStringPtr(a.BuildloggerPassword),
+		BuildloggerAPIKey:   FromStringPtr(a.BuildloggerAPIKey),
 		DefaultLogger:       FromStringPtr(a.DefaultLogger),
 	}
 	i, err := a.Buffer.ToService()

--- a/service/api_buildlogger.go
+++ b/service/api_buildlogger.go
@@ -13,5 +13,6 @@ func (as *APIServer) Buildlogger(w http.ResponseWriter, r *http.Request) {
 		RPCPort:  as.Settings.LoggerConfig.BuildloggerRPCPort,
 		Username: as.Settings.LoggerConfig.BuildloggerUser,
 		Password: as.Settings.LoggerConfig.BuildloggerPassword,
+		APIKey:   as.Settings.LoggerConfig.BuildloggerAPIKey,
 	})
 }

--- a/service/api_buildlogger_test.go
+++ b/service/api_buildlogger_test.go
@@ -24,6 +24,7 @@ func TestBuildlogger(t *testing.T) {
 	conf.LoggerConfig.BuildloggerRPCPort = "7070"
 	conf.LoggerConfig.BuildloggerUser = "user"
 	conf.LoggerConfig.BuildloggerPassword = "pass"
+	conf.LoggerConfig.BuildloggerAPIKey = "api_key"
 	queue := evergreen.GetEnvironment().LocalQueue()
 	as, err := NewAPIServer(evergreen.GetEnvironment(), queue)
 	require.NoError(t, err)
@@ -59,4 +60,5 @@ func TestBuildlogger(t *testing.T) {
 	assert.Equal(t, "7070", bi.RPCPort)
 	assert.Equal(t, "user", bi.Username)
 	assert.Equal(t, "pass", bi.Password)
+	assert.Equal(t, "api_key", bi.APIKey)
 }

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1293,6 +1293,10 @@ Admin Settings
 										<label>Buildlogger Password</label>
 										<input type="text" ng-model="Settings.logger_config.buildlogger_password">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Buildlogger API Key</label>
+										<input type="text" ng-model="Settings.logger_config.buildlogger_api_key">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>

--- a/vendor/github.com/evergreen-ci/timber/basic_sender.go
+++ b/vendor/github.com/evergreen-ci/timber/basic_sender.go
@@ -115,7 +115,7 @@ type LoggerOptions struct {
 	// Disable checking for new lines in messages. If this is set to true,
 	// make sure log messages do not contain new lines, otherwise the logs
 	// will be stored incorrectly.
-	DisableNewLineCheck bool `bson:"new_line_check_off" json:"new_line_check_off" yaml:"new_line_check_off"`
+	DisableNewLineCheck bool `bson:"disable_new_line_check" json:"disable_new_line_check" yaml:"disable_new_line_check"`
 
 	// The gRPC client connection. If nil, a new connection will be
 	// established with the gRPC connection configuration.

--- a/vendor/github.com/evergreen-ci/timber/glide.lock
+++ b/vendor/github.com/evergreen-ci/timber/glide.lock
@@ -4,7 +4,7 @@ imports:
 - name: github.com/mongodb/grip
   version: 7b77abce30e2f707b37c8321f192e5a83c597e7f
 - name: github.com/evergreen-ci/aviation
-  version: 0d9addebe820f37b79433a37d0d53f06bfbb7f01
+  version: e576e1538fbf9207f2abb3ded217d5b633f5e379
 - name: go.mongodb.org/mongo-driver
   version: 305bc4a5e4131420fe8ba5628e6faa9e6ade4e86
 - name: github.com/evergreen-ci/utility

--- a/vendor/github.com/evergreen-ci/timber/logger_producer.go
+++ b/vendor/github.com/evergreen-ci/timber/logger_producer.go
@@ -1,0 +1,40 @@
+package timber
+
+import (
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/send"
+	"github.com/pkg/errors"
+)
+
+// JasperLoggerOptions wraps LoggerOptions and implements a jasper
+// options.LoggerProducer for BuildloggerV3.
+type JasperLoggerOptions struct {
+	Name          string         `json:"name" bson:"name"`
+	Level         send.LevelInfo `json:"level" bson:"level"`
+	BuildloggerV3 LoggerOptions  `json:"buildloggerv3" bson:"buildloggerv3"`
+}
+
+// NewBuildloggerV3LoggerProducer returns a jasper options.LoggerProducer
+// backed by JasperLoggerOptions.
+func NewBuildloggerV3LoggerProducer() *JasperLoggerOptions { return &JasperLoggerOptions{} }
+
+func (opts *JasperLoggerOptions) validate() error {
+	if opts.Name == "" {
+		opts.Name = "jasper"
+	}
+	if opts.Level.Threshold == 0 && opts.Level.Default == 0 {
+		opts.Level = send.LevelInfo{Default: level.Trace, Threshold: level.Trace}
+	}
+
+	return opts.BuildloggerV3.validate()
+}
+
+func (opts *JasperLoggerOptions) Type() string { return "BuildloggerV3" }
+
+func (opts *JasperLoggerOptions) Configure() (send.Sender, error) {
+	if err := opts.validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid config")
+	}
+
+	return NewLogger(opts.Name, opts.Level, &opts.BuildloggerV3)
+}

--- a/vendor/github.com/evergreen-ci/timber/makefile
+++ b/vendor/github.com/evergreen-ci/timber/makefile
@@ -19,12 +19,10 @@ goEnv := GOPATH=$(gopath)$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PAT
 
 
 # start lint setup targets
-lintDeps := $(buildDir)/.lintSetup $(buildDir)/run-linter $(buildDir)/golangci-lint
-$(buildDir)/.lintSetup:$(buildDir)/golangci-lint
-	@touch $@
+lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:$(buildDir)
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.23.8 >/dev/null 2>&1
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup $(buildDir)
+	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.23.8 >/dev/null 2>&1
+$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint $(buildDir)
 	@$(goEnv) $(gobin) build -o $@ $<
 # end lint setup targets
 

--- a/vendor/github.com/evergreen-ci/timber/setup.go
+++ b/vendor/github.com/evergreen-ci/timber/setup.go
@@ -11,8 +11,8 @@ import (
 // DialCedarOptions describes the options for the DialCedar function. The base
 // address defaults to `cedar.mongodb.com` and the RPC port to 7070. If a base
 // address is provided the RPC port must also be provided. Username and
-// password must always be provided. This aliases the same type in aviation in
-// order to avoid users having to vendor aviation.
+// either password or API key must always be provided. This aliases the same
+// type in aviation in order to avoid users having to vendor aviation.
 type DialCedarOptions services.DialCedarOptions
 
 // DialCedar is a convenience function for creating a RPC client connection

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/makefile
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/makefile
@@ -19,7 +19,7 @@ $(buildDir)/.lintSetup:$(buildDir)/golangci-lint
 	@mkdir -p $(buildDir)
 	@touch $@
 $(buildDir)/golangci-lint:
-	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.10.2 >/dev/null 2>&1 && touch $@
+	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.10.2 >/dev/null 2>&1 && touch $@
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
 	@mkdir -p $(buildDir)
 	$(gobin) build -o $@ $<

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/services/cedar_test.go
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/services/cedar_test.go
@@ -20,7 +20,7 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		}
 		assert.Error(t, opts.validate())
 	})
-	t.Run("NoPassword", func(t *testing.T) {
+	t.Run("NoPasswordOrAPIKey", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			BaseAddress: "base",
 			RPCPort:     "9090",
@@ -63,12 +63,27 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		assert.Equal(t, "password", opts.Password)
 		assert.Equal(t, 10, opts.Retries)
 	})
+	t.Run("ConfiguredOptionsWithAPIKey", func(t *testing.T) {
+		opts := &DialCedarOptions{
+			BaseAddress: "base",
+			RPCPort:     "9090",
+			Username:    "username",
+			APIKey:      "apiKey",
+			Retries:     10,
+		}
+		assert.NoError(t, opts.validate())
+		assert.Equal(t, "base", opts.BaseAddress)
+		assert.Equal(t, "9090", opts.RPCPort)
+		assert.Equal(t, "username", opts.Username)
+		assert.Equal(t, "apiKey", opts.APIKey)
+		assert.Equal(t, 10, opts.Retries)
+	})
 }
 
 func TestDialCedar(t *testing.T) {
 	ctx := context.TODO()
-	username := os.Getenv("LDAP_USER")
-	password := os.Getenv("LDAP_PASSWORD")
+	username := os.Getenv("AUTH_USERNAME")
+	password := os.Getenv("AUTH_PASSWORD")
 
 	t.Run("ConnectToCedar", func(t *testing.T) {
 		opts := &DialCedarOptions{


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-9694

* Revendor timber.
* Add API key to admin logger settings.
* Dial into cedar GRPC service using API key if it's set in the admin settings.
* I'm going to migrate the admin settings once this is merged and before the deploy goes out.