### PR TITLE
EVG-8082 don't send some notifications for execution tasks

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2067,6 +2067,10 @@ func (t *Task) IsPartOfSingleHostTaskGroup() bool {
 func (t *Task) IsPartOfDisplay() bool {
 	dt, err := t.GetDisplayTask()
 	if err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":        "unable to get display task",
+			"execution_task": t.Id,
+		}))
 		return false
 	}
 	return dt != nil

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -259,14 +259,6 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 
 	displayName := t.task.DisplayName
 	status := t.task.Status
-	parentDisplayTask, err := t.task.GetDisplayTask()
-	if err != nil {
-		return nil, errors.Wrap(err, "error getting display task")
-	}
-	if parentDisplayTask != nil {
-		displayName = t.task.DisplayTask.DisplayName
-		status = t.task.DisplayTask.Status
-	}
 	if testNames != "" {
 		displayName += fmt.Sprintf(" (%s)", testNames)
 	}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -141,7 +141,6 @@ func (t *taskTriggers) Process(sub *event.Subscription) (*notification.Notificat
 	if t.task.Aborted {
 		return nil, nil
 	}
-
 	return t.base.Process(sub)
 }
 
@@ -410,7 +409,7 @@ func GetRecordByTriggerType(subID, triggerType string, t *task.Task) (*alertreco
 }
 
 func (t *taskTriggers) taskOutcome(sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.DisplayOnly {
+	if t.task.IsPartOfDisplay() {
 		return nil, nil
 	}
 
@@ -422,7 +421,7 @@ func (t *taskTriggers) taskOutcome(sub *event.Subscription) (*notification.Notif
 }
 
 func (t *taskTriggers) taskFailure(sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.DisplayOnly {
+	if t.task.IsPartOfDisplay() {
 		return nil, nil
 	}
 
@@ -442,7 +441,7 @@ func (t *taskTriggers) taskFailure(sub *event.Subscription) (*notification.Notif
 }
 
 func (t *taskTriggers) taskSuccess(sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.DisplayOnly {
+	if t.task.IsPartOfDisplay() {
 		return nil, nil
 	}
 
@@ -457,7 +456,6 @@ func (t *taskTriggers) taskFirstFailureInBuild(sub *event.Subscription) (*notifi
 	if t.task.DisplayOnly {
 		return nil, nil
 	}
-
 	if t.data.Status != evergreen.TaskFailed || t.task.IsSystemUnresponsive() {
 		return nil, nil
 	}
@@ -476,7 +474,6 @@ func (t *taskTriggers) taskFirstFailureInVersion(sub *event.Subscription) (*noti
 	if t.task.DisplayOnly {
 		return nil, nil
 	}
-
 	if t.data.Status != evergreen.TaskFailed || t.task.IsSystemUnresponsive() {
 		return nil, nil
 	}
@@ -492,10 +489,6 @@ func (t *taskTriggers) taskFirstFailureInVersion(sub *event.Subscription) (*noti
 }
 
 func (t *taskTriggers) taskFirstFailureInVersionWithName(sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.DisplayOnly {
-		return nil, nil
-	}
-
 	if t.data.Status != evergreen.TaskFailed || t.task.IsSystemUnresponsive() {
 		return nil, nil
 	}
@@ -511,7 +504,7 @@ func (t *taskTriggers) taskFirstFailureInVersionWithName(sub *event.Subscription
 }
 
 func (t *taskTriggers) taskRegression(sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.DisplayOnly {
+	if t.task.IsPartOfDisplay() {
 		return nil, nil
 	}
 
@@ -640,7 +633,7 @@ func shouldSendTaskRegression(sub *event.Subscription, t *task.Task, previousTas
 }
 
 func (t *taskTriggers) taskExceedsDuration(sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.DisplayOnly {
+	if t.task.IsPartOfDisplay() {
 		return nil, nil
 	}
 
@@ -661,7 +654,7 @@ func (t *taskTriggers) taskExceedsDuration(sub *event.Subscription) (*notificati
 }
 
 func (t *taskTriggers) taskRuntimeChange(sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.DisplayOnly {
+	if t.task.IsPartOfDisplay() {
 		return nil, nil
 	}
 
@@ -991,6 +984,10 @@ func detailStatusToHumanSpeak(status string) string {
 
 // this is very similar to taskRegression, but different enough
 func (t *taskTriggers) buildBreak(sub *event.Subscription) (*notification.Notification, error) {
+	if t.task.IsPartOfDisplay() {
+		return nil, nil
+	}
+
 	if t.task.Status != evergreen.TaskFailed || !utility.StringSliceContains(evergreen.SystemVersionRequesterTypes, t.task.Requester) {
 		return nil, nil
 	}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -259,7 +259,11 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 
 	displayName := t.task.DisplayName
 	status := t.task.Status
-	if t.task.DisplayTask != nil {
+	parentDisplayTask, err := t.task.GetDisplayTask()
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting display task")
+	}
+	if parentDisplayTask != nil {
 		displayName = t.task.DisplayTask.DisplayName
 		status = t.task.DisplayTask.Status
 	}

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -389,8 +389,7 @@ func (s *taskSuite) TestAllTriggers() {
 	s.NoError(db.Update(task.Collection, bson.M{"_id": s.task.Id}, &s.task))
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)
-	s.Empty(n)
-
+	s.Len(n, 3)
 }
 
 func (s *taskSuite) TestAbortedTaskDoesNotNotify() {
@@ -417,9 +416,7 @@ func (s *taskSuite) TestExecutionTask() {
 	s.NoError(t.Insert())
 	n, err := NotificationsFromEvent(&s.event)
 	s.NoError(err)
-	s.Require().Len(n, 1)
-	s.Contains(*n[0].Payload.(*string), "displaytask")
-	s.Contains(*n[0].Payload.(*string), "https://evergreen.mongodb.com/task/test/0")
+	s.Len(n, 0)
 }
 
 func (s *taskSuite) TestSuccess() {


### PR DESCRIPTION
This expands on the changes in https://github.com/evergreen-ci/evergreen/commit/23940c688fd955095789ad8b0a7b01ff0dd3d0eb. For the most part it doesn't make sense for tasks to notify for individual execution tasks, except for the "first failure" triggers. For those we alert on execution tasks (as soon as we know we have a failure) but not the display task, with the exception of the "first failure with name" which will run all the checks to see if the name matches