### PR TITLE
EVG-8311: add logging for slack logger setup

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/send"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
@@ -503,6 +504,10 @@ func (s *Settings) GetSender(ctx context.Context, env Environment) (send.Sender,
 	}
 
 	if s.Splunk.Populated() {
+		grip.Info(message.Fields{
+			"message": "setting up splunk logger",
+			"context": "logging setup",
+		})
 		retryConf := utility.NewDefaultHTTPRetryConf()
 		retryConf.MaxDelay = time.Second
 		retryConf.BaseDelay = 10 * time.Millisecond
@@ -519,6 +524,10 @@ func (s *Settings) GetSender(ctx context.Context, env Environment) (send.Sender,
 				utility.PutHTTPClient(client)
 				return nil, errors.Wrap(err, "problem setting error handler")
 			}
+			grip.Info(message.Fields{
+				"message": "successfully configured splunk logger",
+				"context": "logging setup",
+			})
 			senders = append(senders,
 				send.NewBufferedSender(sender,
 					time.Duration(s.LoggerConfig.Buffer.DurationSeconds)*time.Second,
@@ -535,6 +544,11 @@ func (s *Settings) GetSender(ctx context.Context, env Environment) (send.Sender,
 
 	// the slack logging service is only for logging very high level alerts.
 	if s.Slack.Token != "" {
+		grip.Info(message.Fields{
+			"message": "setting up slack logger",
+			"level":   fmt.Sprintf("%#v", level.FromString(s.Slack.Level)),
+			"context": "logging setup",
+		})
 		sender, err = send.NewSlackLogger(s.Slack.Options, s.Slack.Token,
 			send.LevelInfo{Default: level.Critical, Threshold: level.FromString(s.Slack.Level)})
 		if err == nil {
@@ -554,6 +568,11 @@ func (s *Settings) GetSender(ctx context.Context, env Environment) (send.Sender,
 			}
 
 			senders = append(senders, logger.MakeQueueSender(ctx, env.LocalQueue(), sender))
+			grip.Info(message.Fields{
+				"message": "successfully configured slack logger",
+				"level":   fmt.Sprintf("%#v", level.FromString(s.Slack.Level)),
+				"context": "logging setup",
+			})
 		}
 		grip.Warning(errors.Wrap(err, "problem setting up slack alert logger"))
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-8311

This will log to `journalctl` since it logs before logging is initialized, but I'm going to check the app server logs once this is deployed. I suspect this isn't actually the problem, but it can't hurt to double check.