### PR TITLE
EVG-8145 Format duration strings on backend

### DIFF
--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2519,7 +2519,7 @@
         "data": {
           "patch": {
             "duration": {
-              "makespan": "3m39s",
+              "makespan": "3m 39s",
               "timeTaken": null
             }
           }

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -230,16 +230,19 @@ func (r *patchResolver) Duration(ctx context.Context, obj *restModel.APIPatch) (
 		return nil, ResourceNotFound.Send(ctx, err.Error())
 	}
 	timeTaken, makespan := task.GetTimeSpent(tasks)
+
 	// return nil if rounded timeTaken/makespan == 0s
 	t := timeTaken.Round(time.Second).String()
 	var tPointer *string
 	if t != "0s" {
-		tPointer = &t
+		tFormated := formatDuration(t)
+		tPointer = &tFormated
 	}
 	m := makespan.Round(time.Second).String()
 	var mPointer *string
 	if m != "0s" {
-		mPointer = &m
+		mFormated := formatDuration(m)
+		mPointer = &mFormated
 	}
 
 	return &PatchDuration{

--- a/graphql/tests/patch/results.json
+++ b/graphql/tests/patch/results.json
@@ -119,24 +119,12 @@
         "data": {
           "patch": {
             "project": {
-              "tasks": [
-                "compile",
-                "test",
-                "lint",
-                "coverage",
-                "e2e_test"
-              ],
+              "tasks": ["compile", "test", "lint", "coverage", "e2e_test"],
               "variants": [
                 {
                   "name": "ubuntu1604",
                   "displayName": "Ubuntu 16.04",
-                  "tasks": [
-                    "compile",
-                    "coverage",
-                    "e2e_test",
-                    "lint",
-                    "test"
-                  ]
+                  "tasks": ["compile", "coverage", "e2e_test", "lint", "test"]
                 }
               ]
             }
@@ -190,8 +178,8 @@
         "data": {
           "patch": {
             "duration": {
-              "timeTaken": "1m37s",
-              "makespan": "1m37s"
+              "timeTaken": "1m 37s",
+              "makespan": "1m 37s"
             }
           }
         }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -561,4 +563,11 @@ func getAllTaskStatuses(tasks []task.Task) []string {
 		return statusesArr[i] < statusesArr[j]
 	})
 	return statusesArr
+}
+
+func formatDuration(duration string) string {
+	regex := regexp.MustCompile(`\d*[dhms]`)
+	return strings.TrimSpace(regex.ReplaceAllStringFunc(duration, func(m string) string {
+		return m + " "
+	}))
 }


### PR DESCRIPTION
In response to https://github.com/evergreen-ci/spruce/pull/279#discussion_r451265753

This pr formats the duration strings on the backend.