### PR TITLE
EVG-7765: do not allow both a command and function to be specified

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -765,6 +765,11 @@ func validateCommands(section string, project *model.Project,
 				errs = append(errs, ValidationError{Message: msg})
 			}
 		}
+		if cmd.Function != "" && cmd.Command != "" {
+			errs = append(errs, ValidationError{
+				Message: fmt.Sprintf("cannot specify both command '%s' and function '%s'", cmd.Command, cmd.Function),
+			})
+		}
 	}
 	return errs
 }

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -767,6 +767,7 @@ func validateCommands(section string, project *model.Project,
 		}
 		if cmd.Function != "" && cmd.Command != "" {
 			errs = append(errs, ValidationError{
+				Level:   Warning,
 				Message: fmt.Sprintf("cannot specify both command '%s' and function '%s'", cmd.Command, cmd.Function),
 			})
 		}

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1170,6 +1170,37 @@ func TestValidatePluginCommands(t *testing.T) {
 			So(validatePluginCommands(project), ShouldNotResemble, ValidationErrors{})
 			So(len(validatePluginCommands(project)), ShouldEqual, 1)
 		})
+		Convey("an error should be thrown if both a function and a plugin command are referenced", func() {
+			project := &model.Project{
+				Functions: map[string]*model.YAMLCommandSet{
+					"funcOne": {
+						SingleCommand: &model.PluginCommandConf{
+							Command: "gotest.parse_files",
+							Params: map[string]interface{}{
+								"files": []interface{}{"test"},
+							},
+						},
+					},
+				},
+				Tasks: []model.ProjectTask{
+					{
+						Name: "compile",
+						Commands: []model.PluginCommandConf{
+							{
+								Function: "funcOne",
+								Command:  "gotest.parse_files",
+								Params: map[string]interface{}{
+									"files": []interface{}{"test"},
+								},
+							},
+						},
+					},
+				},
+			}
+			errs := validatePluginCommands(project)
+			So(errs, ShouldNotResemble, ValidationErrors{})
+			So(len(errs), ShouldEqual, 1)
+		})
 		Convey("an error should be thrown if a function plugin command doesn't have commands", func() {
 			project := &model.Project{
 				Functions: map[string]*model.YAMLCommandSet{
@@ -1224,7 +1255,7 @@ func TestValidatePluginCommands(t *testing.T) {
 				},
 			}
 			So(validatePluginCommands(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validatePluginCommands(project)), ShouldEqual, 1)
+			So(len(validatePluginCommands(project)), ShouldEqual, 2)
 		})
 		Convey("errors should be thrown if a function 'a' references "+
 			"another function, 'b', which that does not exist", func() {
@@ -1242,7 +1273,7 @@ func TestValidatePluginCommands(t *testing.T) {
 				},
 			}
 			So(validatePluginCommands(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validatePluginCommands(project)), ShouldEqual, 2)
+			So(len(validatePluginCommands(project)), ShouldEqual, 3)
 		})
 
 		Convey("an error should be thrown if a referenced pre plugin command is invalid", func() {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7765

For example, this shouldn't be allowed since it should use either a command or a func:
```
task: foo
    commands:
        - func: bar
          command: bat
```