### PR TITLE
EVG-12405: unschedule underwater tasks with non-zero priority

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -802,7 +802,6 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 // operation will select tasks from all distros.
 func UnscheduleStaleUnderwaterTasks(distroID string) (int, error) {
 	query := scheduleableTasksQuery()
-	query[PriorityKey] = 0
 
 	if distroID != "" {
 		query[DistroIdKey] = distroID

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1312,8 +1312,8 @@ func TestFindVariantsWithTask(t *testing.T) {
 	bvs, err := FindVariantsWithTask("match", "p", 10, 20)
 	assert.NoError(err)
 	require.Len(t, bvs, 2)
-	assert.Equal(bvs[0], "bv2")
-	assert.Equal(bvs[1], "bv1")
+	assert.Contains(bvs, "bv1")
+	assert.Contains(bvs, "bv2")
 }
 
 func TestFindAllUnmarkedBlockedDependencies(t *testing.T) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12405

Some projects use priority in their waterfall tasks, which cause them to never be unscheduled after the underwater threshold (2 weeks). This doesn't actually fix the original problem that the task queue never empties out, but it prevents tasks from passing the underwater unscheduling threshold and lingering forever.

* Do not allow tasks with set priority to remain in underwater task queues.
* Minor fix for test that was depending on order of docs returned from a find query.