### PR TITLE
EVG-8094 set default docker distro from admin settings

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -170,7 +170,7 @@ func (ch *CreateHost) ValidateDocker() error {
 	if ch.Distro == "" {
 		settings, err := evergreen.GetConfig()
 		if err != nil {
-			catcher.New("error getting docker config to get default distro")
+			catcher.New("error getting config to set default distro")
 		} else {
 			ch.Distro = settings.Providers.Docker.DefaultDistro
 		}

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -164,13 +164,18 @@ func (ch *CreateHost) ValidateDocker() error {
 	catcher.Add(ch.setNumHosts())
 	catcher.Add(ch.validateAgentOptions())
 
-	if ch.Distro == "" {
-		catcher.New("distro must be set")
-	}
 	if ch.Image == "" {
 		catcher.New("docker image must be set")
 	}
+	if ch.Distro == "" {
+		settings, err := evergreen.GetConfig()
+		if err != nil {
+			catcher.New("error getting docker config to get default distro")
+		} else {
+			ch.Distro = settings.Providers.Docker.DefaultDistro
+		}
 
+	}
 	if ch.ContainerWaitTimeoutSecs <= 0 {
 		ch.ContainerWaitTimeoutSecs = DefaultContainerWaitTimeoutSecs
 	} else if ch.ContainerWaitTimeoutSecs >= 3600 || ch.ContainerWaitTimeoutSecs <= 10 {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -161,7 +161,7 @@ func SetLoginToken(token, domain string, w http.ResponseWriter) {
 	if err != nil {
 		grip.Error(err)
 	}
-	if settings.Ui.ExpireLoginCookieDomain != "" {
+	if settings != nil && settings.Ui.ExpireLoginCookieDomain != "" {
 		http.SetCookie(w, &http.Cookie{
 			Name:     evergreen.AuthTokenCookie,
 			Value:    "",

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -108,7 +108,8 @@ func (c *S3Credentials) Validate() error {
 
 // DockerConfig stores auth info for Docker.
 type DockerConfig struct {
-	APIVersion string `bson:"api_version" json:"api_version" yaml:"api_version"`
+	APIVersion    string `bson:"api_version" json:"api_version" yaml:"api_version"`
+	DefaultDistro string `bson:"default_distro" json:"default_distro" yaml:"default_distro"`
 }
 
 // OpenStackConfig stores auth info for Linaro using Identity V3. All fields required.

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1526,13 +1526,15 @@ func (a *APIAWSConfig) ToService() (interface{}, error) {
 }
 
 type APIDockerConfig struct {
-	APIVersion *string `json:"api_version"`
+	APIVersion    *string `json:"api_version"`
+	DefaultDistro *string `json:"default_distro"`
 }
 
 func (a *APIDockerConfig) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case evergreen.DockerConfig:
 		a.APIVersion = ToStringPtr(v.APIVersion)
+		a.DefaultDistro = ToStringPtr(v.DefaultDistro)
 	default:
 		return errors.Errorf("%T is not a supported type", h)
 	}
@@ -1541,7 +1543,8 @@ func (a *APIDockerConfig) BuildFromService(h interface{}) error {
 
 func (a *APIDockerConfig) ToService() (interface{}, error) {
 	return evergreen.DockerConfig{
-		APIVersion: FromStringPtr(a.APIVersion),
+		APIVersion:    FromStringPtr(a.APIVersion),
+		DefaultDistro: FromStringPtr(a.DefaultDistro),
 	}, nil
 }
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1529,6 +1529,10 @@ Admin Settings
 										<label>API version</label>
 										<input type="text" ng-model="Settings.providers.docker.api_version">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Distro for Default Container Pool</label>
+										<input type="text" ng-model="Settings.providers.docker.default_distro">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 


### PR DESCRIPTION
The problem is that for docker host.create, we require a distro to be given so that we know container pool information, but this is clunky for the user as they don't necessarily care about this.

Theoretically we don't need a distro at all because I think we  just need the container pool; however a lot of places in the code rely on hosts having a distro document correctly configured, so we'd have to build a partial distro with the passed in container pool and other configuration options. The other issue with this is that currently container pools are defined in admin settings, which users can't see, so having them specify this is just as clunky.

A default distro seems the best, since if users don't specify a distro for host.create they'll be none the wiser (I'll set Distro in Admin Settings to be ubuntu1604-container and update the documentation).