### PR TITLE
EVG-12404: set host to running if reprovision is aborted

### DIFF
--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -180,6 +180,8 @@ func doStaticHostUpdate(d distro.Distro) ([]string, error) {
 			if dbHost != nil {
 				event.LogHostStatusChanged(dbHost.Id, dbHost.Status, staticHost.Status, evergreen.User, "host status changed by host allocator")
 			}
+		} else if provisioned && dbHost.Status == evergreen.HostProvisioning {
+			staticHost.Status = evergreen.HostRunning
 		} else {
 			staticHost.Status = dbHost.Status
 		}

--- a/scheduler/wrapper_test.go
+++ b/scheduler/wrapper_test.go
@@ -582,6 +582,54 @@ func TestDoStaticHostUpdate(t *testing.T) {
 			assert.Equal(t, host.ReprovisionToLegacy, dbHost.NeedsReprovision)
 			assert.True(t, dbHost.Provisioned)
 		},
+		"ProvisioningLegacyHostOnLegacyDistro": func(t *testing.T) {
+			h := legacyHost()
+			h.Status = evergreen.HostProvisioning
+			require.NoError(t, h.Insert())
+			d := distro.Distro{
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodLegacySSH,
+					Communication: distro.BootstrapMethodLegacySSH,
+				},
+			}
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0])
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.HostRunning, dbHost.Status)
+			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"ProvisioningNonLegacyHostOnNonLegacyDistro": func(t *testing.T) {
+			h := nonLegacyHost()
+			h.Status = evergreen.HostProvisioning
+			require.NoError(t, h.Insert())
+			d := distro.Distro{
+				Id:                   "distro",
+				ProviderSettingsList: []*birch.Document{makeStaticHostProviderSettings(t, h.Id)},
+				Provider:             evergreen.ProviderNameStatic,
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodSSH,
+					Communication: distro.BootstrapMethodSSH,
+				},
+			}
+			hosts, err := doStaticHostUpdate(d)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0])
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.HostRunning, dbHost.Status)
+			assert.Equal(t, host.ReprovisionNone, dbHost.NeedsReprovision)
+			assert.True(t, dbHost.Provisioned)
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			require.NoError(t, db.Clear(host.Collection))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12404

Currently, if a host is converted from legacy to non-legacy provisioning (or vice versa) but it fails and we want to back out of the conversion by reverting the distro settings, the host status will not change from provisioning back to running. This aims to fix that.