### PR TITLE
EVG-12400 No error is displayed when modifying a host that is terminated

### DIFF
--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -127,6 +127,13 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for find() by distro id '%s'", h.hostID))
 	}
 
+	if foundHost.Status == evergreen.HostTerminated {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    "cannot modify a terminated host",
+		})
+	}
+
 	// Validate host modify request
 	catcher := grip.NewBasicCatcher()
 	if len(h.options.AddInstanceTags) > 0 || len(h.options.DeleteInstanceTags) > 0 {


### PR DESCRIPTION
[EVG-12400](https://jira.mongodb.org/browse/EVG-12400)