### PR TITLE
EVG-7751: add warnings for tasks and buildvariants with special keywords

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -555,6 +555,30 @@ func validateTaskNames(project *model.Project) ValidationErrors {
 						task.Name, unauthorizedTaskCharacters),
 				})
 		}
+		// Warn against commas because the CLI allows users to specify
+		// tasks separated by commas in their patches.
+		if strings.Contains(task.Name, ",") {
+			errs = append(errs, ValidationError{
+				Level:   Warning,
+				Message: fmt.Sprintf("task name %s should not contains commas", task.Name),
+			})
+		}
+		// Warn against using "*" since it is ambiguous with the
+		// all-dependencies specification (also "*").
+		if task.Name == model.AllDependencies {
+			errs = append(errs, ValidationError{
+				Level:   Warning,
+				Message: "task should not be named '*' because it is ambiguous with the all-dependencies '*' specification",
+			})
+		}
+		// Warn against using "all" since it is ambiguous with the special "all"
+		// task specifier when creating patches.
+		if task.Name == "all" {
+			errs = append(errs, ValidationError{
+				Level:   Warning,
+				Message: "task should not be named 'all' because it is ambiguous in task specifications for patches",
+			})
+		}
 	}
 	return errs
 }
@@ -593,6 +617,31 @@ func validateBVNames(project *model.Project) ValidationErrors {
 					Message: fmt.Sprintf("buildvariant name %s contains unauthorized characters (%s)",
 						buildVariant.Name, unauthorizedCharacters),
 				})
+		}
+
+		// Warn against commas because the CLI allows users to specify
+		// variants separated by commas in their patches.
+		if strings.Contains(buildVariant.Name, ",") {
+			errs = append(errs, ValidationError{
+				Level:   Warning,
+				Message: fmt.Sprintf("buildvariant name %s should not contains commas", buildVariant.Name),
+			})
+		}
+		// Warn against using "*" since it is ambiguous with the
+		// all-dependencies specification (also "*").
+		if buildVariant.Name == model.AllVariants {
+			errs = append(errs, ValidationError{
+				Level:   Warning,
+				Message: "buildvariant should not be named '*' because it is ambiguous with the all-variants '*' specification",
+			})
+		}
+		// Warn against using "all" since it is ambiguous with the special "all"
+		// task specifier when creating patches.
+		if buildVariant.Name == "all" {
+			errs = append(errs, ValidationError{
+				Level:   Warning,
+				Message: "buildvariant should not be named 'all' because it is ambiguous in buildvariant specifications for patches",
+			})
 		}
 	}
 	// don't bother checking for the warnings if we already found errors

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -551,7 +551,7 @@ func validateTaskNames(project *model.Project) ValidationErrors {
 		if strings.ContainsAny(strings.TrimSpace(task.Name), unauthorizedTaskCharacters) {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("task name %s contains unauthorized characters ('%s')",
+					Message: fmt.Sprintf("task name '%s' contains unauthorized characters ('%s')",
 						task.Name, unauthorizedTaskCharacters),
 				})
 		}
@@ -560,7 +560,7 @@ func validateTaskNames(project *model.Project) ValidationErrors {
 		if strings.Contains(task.Name, ",") {
 			errs = append(errs, ValidationError{
 				Level:   Warning,
-				Message: fmt.Sprintf("task name %s should not contains commas", task.Name),
+				Message: fmt.Sprintf("task name '%s' should not contains commas", task.Name),
 			})
 		}
 		// Warn against using "*" since it is ambiguous with the
@@ -614,7 +614,7 @@ func validateBVNames(project *model.Project) ValidationErrors {
 		if strings.ContainsAny(buildVariant.Name, unauthorizedCharacters) {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("buildvariant name %s contains unauthorized characters (%s)",
+					Message: fmt.Sprintf("buildvariant name '%s' contains unauthorized characters (%s)",
 						buildVariant.Name, unauthorizedCharacters),
 				})
 		}
@@ -624,7 +624,7 @@ func validateBVNames(project *model.Project) ValidationErrors {
 		if strings.Contains(buildVariant.Name, ",") {
 			errs = append(errs, ValidationError{
 				Level:   Warning,
-				Message: fmt.Sprintf("buildvariant name %s should not contains commas", buildVariant.Name),
+				Message: fmt.Sprintf("buildvariant name '%s' should not contains commas", buildVariant.Name),
 			})
 		}
 		// Warn against using "*" since it is ambiguous with the

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -13,7 +13,6 @@ import (
 	tu "github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
-	"github.com/k0kubun/pp"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -793,7 +792,6 @@ func TestValidateBVNames(t *testing.T) {
 				project := &model.Project{
 					BuildVariants: []model.BuildVariant{{Name: "all", DisplayName: "display_name"}},
 				}
-				pp.Println(validateBVNames(project))
 				So(len(validateBVNames(project)), ShouldEqual, 1)
 			})
 		})

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -13,6 +13,7 @@ import (
 	tu "github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
+	"github.com/k0kubun/pp"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -680,6 +681,26 @@ func TestValidateTaskNames(t *testing.T) {
 		validationResults := validateTaskNames(project)
 		So(len(validationResults), ShouldEqual, 4)
 	})
+	Convey("An error should be returned when a task name", t, func() {
+		Convey("Contains commas", func() {
+			project := &model.Project{
+				Tasks: []model.ProjectTask{{Name: "task,"}},
+			}
+			So(len(validateTaskNames(project)), ShouldEqual, 1)
+		})
+		Convey("Is the same as the all-dependencies syntax", func() {
+			project := &model.Project{
+				Tasks: []model.ProjectTask{{Name: model.AllDependencies}},
+			}
+			So(len(validateTaskNames(project)), ShouldEqual, 1)
+		})
+		Convey("Is 'all'", func() {
+			project := &model.Project{
+				Tasks: []model.ProjectTask{{Name: "all"}},
+			}
+			So(len(validateTaskNames(project)), ShouldEqual, 1)
+		})
+	})
 }
 
 func TestValidateBVNames(t *testing.T) {
@@ -750,6 +771,31 @@ func TestValidateBVNames(t *testing.T) {
 			}
 			So(validateBVNames(project), ShouldNotResemble, ValidationErrors{})
 			So(len(validateBVNames(project)), ShouldEqual, 3)
+		})
+		Convey("An error should be returned when a buildvariant name", func() {
+			Convey("Contains commas", func() {
+				project := &model.Project{
+					BuildVariants: []model.BuildVariant{
+						{Name: "variant,", DisplayName: "display_name"},
+					},
+				}
+				So(len(validateBVNames(project)), ShouldEqual, 1)
+			})
+			Convey("Is the same as the all-dependencies syntax", func() {
+				project := &model.Project{
+					BuildVariants: []model.BuildVariant{
+						{Name: model.AllVariants, DisplayName: "display_name"},
+					},
+				}
+				So(len(validateBVNames(project)), ShouldEqual, 1)
+			})
+			Convey("Is 'all'", func() {
+				project := &model.Project{
+					BuildVariants: []model.BuildVariant{{Name: "all", DisplayName: "display_name"}},
+				}
+				pp.Println(validateBVNames(project))
+				So(len(validateBVNames(project)), ShouldEqual, 1)
+			})
 		})
 	})
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7751

Give validation warnings if tasks/build variants have names with special meaning.