### PR TITLE
EVG-12491 block dependencies for system-failed tg

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1106,6 +1106,7 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 				"message": "problem blocking task group tasks",
 				"task_id": t.Id,
 			}))
+			return errors.Wrapf(err, "problem blocking task group tasks")
 		}
 		grip.Debug(message.Fields{
 			"message": "blocked task group tasks for task",


### PR DESCRIPTION
The issue that happened on Saturday was with System Failed tasks: it looks like they hit ClearAndResetStrandedTask, which doesn't mark other tasks in the task group as unattainable the way that cleanUpTimedOutTask does, so the task group is unable to restart because the other tasks in the group are still Activated and Unblocked. By marking these dependencies as blocked, we enable restarting the task group.