### PR TITLE
EVG-8311: add sanity debug log to check Slack notifications

### DIFF
--- a/operations/service_web.go
+++ b/operations/service_web.go
@@ -45,6 +45,10 @@ func startWebService() cli.Command {
 			grip.EmergencyFatal(errors.Wrap(env.RemoteQueue().Start(ctx), "problem starting remote queue"))
 			grip.EmergencyFatal(errors.Wrap(commitqueue.SetupEnv(env), "problem adding commit queue sender"))
 
+			grip.Critical(message.Fields{
+				"message": "test log for Slack, please ignore",
+			})
+
 			settings := env.Settings()
 			sender, err := settings.GetSender(ctx, env)
 			grip.EmergencyFatal(err)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-8311

I have no clue what's wrong with the production Slack logger since it looks the same as staging, so I'm adding this one-time sanity log in tomorrow's deploy to see if it will actually just work.