### PR TITLE
EVG-5284 add continue on error option to task groups

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -475,7 +475,8 @@ type TaskGroup struct {
 	Tasks                 []string        `yaml:"tasks" bson:"tasks"`
 	Tags                  []string        `yaml:"tags,omitempty" bson:"tags"`
 	// ShareProcs causes processes to persist between task group tasks.
-	ShareProcs bool `yaml:"share_processes" bson:"share_processes"`
+	ShareProcs      bool `yaml:"share_processes" bson:"share_processes"`
+	ContinueOnError bool `yaml:"continue_on_error" bson:"continue_on_error"`
 }
 
 // Unmarshalled from the "tasks" list in the project file

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -102,6 +102,7 @@ type parserTaskGroup struct {
 	Requires              taskSelectors      `yaml:"requires,omitempty" bson:"requires,omitempty"`
 	Tags                  parserStringSlice  `yaml:"tags,omitempty" bson:"tags,omitempty"`
 	ShareProcs            bool               `yaml:"share_processes,omitempty" bson:"share_processes,omitempty"`
+	ContinueOnError       bool               `yaml:"continue_on_error,omitempty" bson:"continue_on_error,omitempty"`
 }
 
 func (ptg *parserTaskGroup) name() string   { return ptg.Name }
@@ -686,6 +687,7 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 			MaxHosts:              ptg.MaxHosts,
 			Timeout:               ptg.Timeout,
 			ShareProcs:            ptg.ShareProcs,
+			ContinueOnError:       ptg.ContinueOnError,
 		}
 		if tg.MaxHosts < 1 {
 			tg.MaxHosts = 1

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -268,6 +268,10 @@ func BlockTaskGroupTasks(taskID string) error {
 	if tg == nil {
 		return errors.Errorf("unable to find task group '%s' for task '%s'", t.TaskGroup, taskID)
 	}
+	if tg.ContinueOnError {
+		return nil
+	}
+
 	indexOfTask := -1
 	for i, tgTask := range tg.Tasks {
 		if t.DisplayName == tgTask {


### PR DESCRIPTION
Don't block later tasks in the task group when the task group is configured to continue on error.