### PR TITLE
EVG-12545 zero out display task OOM info

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1218,6 +1218,9 @@ func UpdateDisplayTask(t *task.Task) error {
 		statusTask.Details = apimodels.TaskEndDetail{}
 	}
 
+	// zero out OOMTracker info
+	statusTask.Details.OOMTracker = apimodels.OOMTrackerInfo{}
+
 	update := bson.M{
 		task.StatusKey:    statusTask.Status,
 		task.ActivatedKey: t.Activated,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1218,8 +1218,12 @@ func UpdateDisplayTask(t *task.Task) error {
 		statusTask.Details = apimodels.TaskEndDetail{}
 	}
 
-	// zero out OOMTracker info
-	statusTask.Details.OOMTracker = apimodels.OOMTrackerInfo{}
+	// zero out irrelevant info
+	statusTask.Details = apimodels.TaskEndDetail{
+		Status:   statusTask.Details.Status,
+		Type:     statusTask.Details.Type,
+		TimedOut: statusTask.Details.TimedOut,
+	}
 
 	update := bson.M{
 		task.StatusKey:    statusTask.Status,

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3019,8 +3019,9 @@ func TestDisplayTaskFailedExecTasks(t *testing.T) {
 		Activated: true,
 		Status:    evergreen.TaskFailed,
 		Details: apimodels.TaskEndDetail{
-			Status: evergreen.TaskFailed,
-			Type:   evergreen.CommandTypeSystem,
+			Status:     evergreen.TaskFailed,
+			Type:       evergreen.CommandTypeSystem,
+			OOMTracker: apimodels.OOMTrackerInfo{Detected: true},
 		}}
 	assert.NoError(execTask0.Insert())
 
@@ -3032,6 +3033,7 @@ func TestDisplayTaskFailedExecTasks(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskFailed, dbTask.Status)
 	assert.Equal(evergreen.CommandTypeSystem, dbTask.Details.Type)
+	assert.False(dbTask.Details.OOMTracker.Detected)
 	assert.True(dbTask.Activated)
 }
 


### PR DESCRIPTION
It's confusing for a display task to show OOM information.
Other information in the task details also seems extra. I find everything besides the status, type, and timedOut fields (the fields used to determine the displayed status) to be confusing, since it's not clear which execution task they came from. For example, the description 
```
Failing Command: 'shell.exec' in "run generated tests" (#7)
```
is not meaningful in the context of the display task. I'm open to other perspectives.