### PR TITLE
EVG-12519: GetPaginatedRunningHosts DB query

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2461,3 +2461,122 @@ func (h *Host) IsSubjectToHostCreationThrottle() bool {
 
 	return true
 }
+
+func GetRunningHosts(sortBy string, statuses []string, sortDir, page, limit int) ([]Host, *int, int, error) {
+	// PIPELINE FOR ALL RUNNING HOSTS
+	runningHostsPipeline := []bson.M{
+		{
+			"$match": bson.M{StatusKey: bson.M{"$ne": evergreen.HostTerminated}},
+		},
+		{
+			"$lookup": bson.M{
+				"from":         task.Collection,
+				"localField":   RunningTaskKey,
+				"foreignField": task.IdKey,
+				"as":           "task_full",
+			},
+		},
+		{
+			"$unwind": bson.M{
+				"path":                       "$task_full",
+				"preserveNullAndEmptyArrays": true,
+			},
+		},
+	}
+
+	// CONTEXT
+	env := evergreen.GetEnvironment()
+	ctx, cancel := env.Context()
+	defer cancel()
+
+	// TOTAL RUNNING HOSTS COUNT
+	countPipeline := []bson.M{}
+	for _, stage := range runningHostsPipeline {
+		countPipeline = append(countPipeline, stage)
+	}
+	countPipeline = append(countPipeline, bson.M{"$count": "count"})
+
+	tmp := []counter{}
+	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, countPipeline)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	err = cursor.All(ctx, &tmp)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	totalRunningHostsCount := 0
+	if len(tmp) > 0 {
+		totalRunningHostsCount = tmp[0].Count
+	}
+
+	// APPLY FILTERS AND SORTERS TO PIPELINE
+	if len(statuses) > 0 {
+		runningHostsPipeline = append(runningHostsPipeline, bson.M{
+			"$match": bson.M{
+				StatusKey: bson.M{"$in": statuses},
+			},
+		})
+	}
+
+	sorters := bson.D{}
+	if len(sortBy) > 0 {
+		sorters = append(sorters, bson.E{Key: sortBy, Value: sortDir})
+	}
+	// _id must be the LAST item in sort array to ensure a consistent sort order when previous sort keys result in a tie
+	sorters = append(sorters, bson.E{Key: IdKey, Value: 1})
+	runningHostsPipeline = append(runningHostsPipeline, bson.M{
+		"$sort": sorters,
+	})
+
+	if limit > 0 {
+		runningHostsPipeline = append(runningHostsPipeline, bson.M{
+			"$skip": page * limit,
+		})
+		runningHostsPipeline = append(runningHostsPipeline, bson.M{
+			"$limit": limit,
+		})
+	}
+
+	hosts := []Host{}
+
+	cursor, err = env.DB().Collection(Collection).Aggregate(ctx, runningHostsPipeline)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	err = cursor.All(ctx, &hosts)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	// FILTERED HOSTS COUNT
+	var filteredHostsCount *int
+	hasFilters := len(statuses) > 0
+
+	if hasFilters == true {
+		countPipeline = []bson.M{}
+		for _, stage := range runningHostsPipeline {
+			countPipeline = append(countPipeline, stage)
+		}
+		countPipeline = append(countPipeline, bson.M{"$count": "count"})
+
+		tmp = []counter{}
+		cursor, err = env.DB().Collection(Collection).Aggregate(ctx, countPipeline)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		err = cursor.All(ctx, &tmp)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		if len(tmp) > 0 {
+			filteredHostsCount = &tmp[0].Count
+		}
+	}
+
+	return hosts, filteredHostsCount, totalRunningHostsCount, err
+}
+
+type counter struct {
+	Count int `bson:"count"`
+}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2462,7 +2462,7 @@ func (h *Host) IsSubjectToHostCreationThrottle() bool {
 	return true
 }
 
-func GetRunningHosts(sortBy, hostId, distro, currentTask, owner string, statuses []string, sortDir, page, limit int) ([]Host, *int, int, error) {
+func GetPaginatedRunningHosts(hostID, distroID, currentTaskID string, statuses []string, startedBy string, sortBy string, sortDir, page, limit int) ([]Host, *int, int, error) {
 	// PIPELINE FOR ALL RUNNING HOSTS
 	runningHostsPipeline := []bson.M{
 		{
@@ -2510,45 +2510,45 @@ func GetRunningHosts(sortBy, hostId, distro, currentTask, owner string, statuses
 		totalRunningHostsCount = tmp[0].Count
 	}
 
-	// APPLY FILTERS AND SORTERS TO PIPELINE
+	// APPLY FILTERS TO PIPELINE
 	hasFilters := false
 
-	if len(hostId) > 0 {
+	if len(hostID) > 0 {
 		hasFilters = true
 
 		runningHostsPipeline = append(runningHostsPipeline, bson.M{
 			"$match": bson.M{
-				IdKey: hostId,
+				IdKey: hostID,
 			},
 		})
 	}
 
-	if len(distro) > 0 {
+	if len(distroID) > 0 {
 		hasFilters = true
 
 		runningHostsPipeline = append(runningHostsPipeline, bson.M{
 			"$match": bson.M{
-				DistroKey: distro,
+				"distro._id": distroID,
 			},
 		})
 	}
 
-	if len(currentTask) > 0 {
+	if len(currentTaskID) > 0 {
 		hasFilters = true
 
 		runningHostsPipeline = append(runningHostsPipeline, bson.M{
 			"$match": bson.M{
-				RunningTaskKey: currentTask,
+				RunningTaskKey: currentTaskID,
 			},
 		})
 	}
 
-	if len(currentTask) > 0 {
+	if len(startedBy) > 0 {
 		hasFilters = true
 
 		runningHostsPipeline = append(runningHostsPipeline, bson.M{
 			"$match": bson.M{
-				ProjectKey: owner,
+				StartedByKey: startedBy,
 			},
 		})
 	}
@@ -2563,7 +2563,7 @@ func GetRunningHosts(sortBy, hostId, distro, currentTask, owner string, statuses
 		})
 	}
 
-	// APPLY SORT
+	// APPLY SORTERS TO PIPELINE
 	sorters := bson.D{}
 	if len(sortBy) > 0 {
 		sorters = append(sorters, bson.E{Key: sortBy, Value: sortDir})

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2598,7 +2598,7 @@ func GetPaginatedRunningHosts(hostID, distroID, currentTaskID string, statuses [
 	// FILTERED HOSTS COUNT
 	var filteredHostsCount *int
 
-	if hasFilters == true {
+	if hasFilters {
 		countPipeline = []bson.M{}
 		for _, stage := range runningHostsPipeline {
 			countPipeline = append(countPipeline, stage)

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -82,6 +82,14 @@ func (hc *DBHostConnector) FindHostsByDistro(distro string) ([]host.Host, error)
 	return host.Find(db.Query(host.ByDistroIDsOrAliasesRunning(distro)))
 }
 
+func (hc *DBConnector) FindRunningHosts(sortBy, hostId, distro, currentTask, owner string, statuses []string, sortDir, page, limit int) ([]host.Host, *int, int, error) {
+	hosts, filterdHostsCount, totalHostsCount, err := host.GetRunningHosts(sortBy, hostId, distro, currentTask, owner, statuses, sortDir, page, limit)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	return hosts, filterdHostsCount, totalHostsCount, nil
+}
+
 // NewIntentHost is a method to insert an intent host given a distro and a public key
 // The public key can be the name of a saved key or the actual key string
 func (hc *DBHostConnector) NewIntentHost(ctx context.Context, options *restmodel.HostRequestOptions, user *user.DBUser,
@@ -414,6 +422,10 @@ func (hc *MockConnector) SetVolumeName(volume *host.Volume, name string) error {
 		}
 	}
 	return nil
+}
+
+func (hc *MockConnector) FindRunningHosts(sortBy, hostId, distro, currentTask, owner string, statuses []string, sortDir, page, limit int) ([]host.Host, *int, int, error) {
+	return nil, nil, 0, nil
 }
 
 func (hc *MockConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error) {

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -82,8 +82,8 @@ func (hc *DBHostConnector) FindHostsByDistro(distro string) ([]host.Host, error)
 	return host.Find(db.Query(host.ByDistroIDsOrAliasesRunning(distro)))
 }
 
-func (hc *DBConnector) FindRunningHosts(sortBy, hostId, distro, currentTask, owner string, statuses []string, sortDir, page, limit int) ([]host.Host, *int, int, error) {
-	hosts, filterdHostsCount, totalHostsCount, err := host.GetRunningHosts(sortBy, hostId, distro, currentTask, owner, statuses, sortDir, page, limit)
+func (hc *DBConnector) GetPaginatedRunningHosts(hostID, distroID, currentTaskID string, statuses []string, startedBy string, sortBy string, sortDir, page, limit int) ([]host.Host, *int, int, error) {
+	hosts, filterdHostsCount, totalHostsCount, err := host.GetPaginatedRunningHosts(hostID, distroID, currentTaskID, statuses, startedBy, sortBy, sortDir, page, limit)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -424,7 +424,7 @@ func (hc *MockConnector) SetVolumeName(volume *host.Volume, name string) error {
 	return nil
 }
 
-func (hc *MockConnector) FindRunningHosts(sortBy, hostId, distro, currentTask, owner string, statuses []string, sortDir, page, limit int) ([]host.Host, *int, int, error) {
+func (hc *MockConnector) GetPaginatedRunningHosts(hostID, distroID, currentTaskID string, statuses []string, startedBy string, sortBy string, sortDir, page, limit int) ([]host.Host, *int, int, error) {
 	return nil, nil, 0, nil
 }
 

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -153,6 +153,9 @@ type Connector interface {
 	// FindHostWithVolume returns the host that has the given volume attached
 	FindHostWithVolume(string) (*host.Host, error)
 
+	// GetRunningHosts gets paginated running hosts and applies any filters
+	FindRunningHosts(sortBy, hostId, distro, currentTask, owner string, statuses []string, sortDir, page, limit int) ([]host.Host, *int, int, error)
+
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
 	NewIntentHost(context.Context, *restModel.HostRequestOptions, *user.DBUser, *evergreen.Settings) (*host.Host, error)
 

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -154,7 +154,7 @@ type Connector interface {
 	FindHostWithVolume(string) (*host.Host, error)
 
 	// GetRunningHosts gets paginated running hosts and applies any filters
-	FindRunningHosts(sortBy, hostId, distro, currentTask, owner string, statuses []string, sortDir, page, limit int) ([]host.Host, *int, int, error)
+	GetPaginatedRunningHosts(hostID, distroID, currentTaskID string, statuses []string, startedBy string, sortBy string, sortDir, page, limit int) ([]host.Host, *int, int, error)
 
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
 	NewIntentHost(context.Context, *restModel.HostRequestOptions, *user.DBUser, *evergreen.Settings) (*host.Host, error)


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-12519

DB query for getting paginated running hosts for the `/hosts` page in the new UI

**Hosts can be filtered by**
- hostID
- distroID
- currentTaskID
- statuses
- startedBy

Hosts can be sorted in ascending and descending order by all column headers (id, distro, status, current task, elapsed, uptime, idle time)

### I did not include tests for this query because it will be tested from every angle through the GQL integration tests, which are coming in a subsequent PR. The mock tests for DB functions do not seem to test the actual DB logic anyways since the logic itself is mocked. 