### PR TITLE
EVG-8159: include response body in error message from REST client

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-07-17"
+	ClientVersion = "2020-07-20"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-07-18"

--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-07-15"
+	ClientVersion = "2020-07-17"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-07-18"

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -20,6 +20,27 @@ import (
 	"github.com/pkg/errors"
 )
 
+// respErrorf attempts to read a gimlet.ErrorResponse from the response body
+// JSON. If successful, it returns the gimlet.ErrorResponse wrapped with the
+// HTTP status code and the formatted error message. Otherwise, it returns an
+// error message with the HTTP status and raw response body.
+func respErrorf(resp *http.Response, format string, args ...interface{}) error {
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		err = errors.Wrapf(err, "status code %d", resp.StatusCode)
+		return errors.Wrap(err, "could not read response body")
+	}
+
+	respErr := gimlet.ErrorResponse{}
+	if err = json.Unmarshal(b, &respErr); err != nil {
+		err = errors.Errorf("received HTTP status code %s with response: %s", resp.Status, string(b))
+		return errors.Wrapf(err, format, args...)
+	}
+
+	err = errors.Wrapf(respErr, "status code %d", resp.StatusCode)
+	return errors.Wrapf(err, format, args...)
+}
+
 // CreateSpawnHost will insert an intent host into the DB that will be spawned later by the runner
 func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, spawnRequest *model.HostRequestOptions) (*model.APIHost, error) {
 
@@ -37,11 +58,7 @@ func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, spawnRequest *mo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err = utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return nil, errors.Wrap(err, "problem spawning host and parsing error message")
-		}
-		return nil, errors.Wrap(errMsg, "problem spawning host")
+		return nil, respErrorf(resp, "spawning host")
 	}
 
 	spawnHostResp := model.APIHost{}
@@ -68,11 +85,7 @@ func (c *communicatorImpl) GetSpawnHost(ctx context.Context, hostId string) (*mo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err = utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return nil, errors.Wrap(err, "problem getting host and parsing error message")
-		}
-		return nil, errors.Wrap(errMsg, "problem getting host")
+		return nil, respErrorf(resp, "getting host '%s'", hostId)
 	}
 
 	spawnHostResp := model.APIHost{}
@@ -98,11 +111,7 @@ func (c *communicatorImpl) ModifySpawnHost(ctx context.Context, hostID string, c
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem modifying host and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem modifying host")
+		return respErrorf(resp, "modifying host '%s'", hostID)
 	}
 
 	return nil
@@ -126,11 +135,7 @@ func (c *communicatorImpl) StopSpawnHost(ctx context.Context, hostID string, sub
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem stopping host and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem stopping host")
+		return respErrorf(resp, "stopping host '%s'", hostID)
 	}
 
 	if wait {
@@ -154,11 +159,7 @@ func (c *communicatorImpl) AttachVolume(ctx context.Context, hostID string, opts
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem attaching volume and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem attaching volume")
+		return respErrorf(resp, "attaching volume to host '%s'", hostID)
 	}
 
 	return nil
@@ -181,11 +182,7 @@ func (c *communicatorImpl) DetachVolume(ctx context.Context, hostID, volumeID st
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem detaching volume and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem detaching volume")
+		return respErrorf(resp, "detaching volume '%s' from host '%s'", volumeID, hostID)
 	}
 
 	return nil
@@ -205,11 +202,7 @@ func (c *communicatorImpl) CreateVolume(ctx context.Context, volume *host.Volume
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err = utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return nil, errors.Wrap(err, "problem creating volume and parsing error message")
-		}
-		return nil, errors.Wrap(errMsg, "problem creating volume")
+		return nil, respErrorf(resp, "creating volume")
 	}
 
 	createVolumeResp := model.APIVolume{}
@@ -233,11 +226,7 @@ func (c *communicatorImpl) DeleteVolume(ctx context.Context, volumeID string) er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem deleting volume and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem deleting volume")
+		return respErrorf(resp, "deleting volume '%s'", volumeID)
 	}
 
 	return nil
@@ -256,11 +245,7 @@ func (c *communicatorImpl) ModifyVolume(ctx context.Context, volumeID string, op
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem modifying volume and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem modifying volume")
+		return respErrorf(resp, "modifying volume '%s'", volumeID)
 	}
 
 	return nil
@@ -280,11 +265,7 @@ func (c *communicatorImpl) GetVolume(ctx context.Context, volumeID string) (*mod
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err = utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return nil, errors.Wrap(err, "problem getting volume and parsing error message")
-		}
-		return nil, errors.Wrapf(errMsg, "problem getting volume '%s'", volumeID)
+		return nil, respErrorf(resp, "getting volume '%s'", volumeID)
 	}
 
 	volumeResp := &model.APIVolume{}
@@ -309,11 +290,7 @@ func (c *communicatorImpl) GetVolumesByUser(ctx context.Context) ([]model.APIVol
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err = utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return nil, errors.Wrap(err, "problem getting volumes and parsing error message")
-		}
-		return nil, errors.Wrapf(errMsg, "problem getting volumes for user '%s'", c.apiUser)
+		return nil, respErrorf(resp, "getting volumes for user '%s'", c.apiUser)
 	}
 
 	getVolumesResp := []model.APIVolume{}
@@ -342,11 +319,7 @@ func (c *communicatorImpl) StartSpawnHost(ctx context.Context, hostID string, su
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem starting host and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem starting host")
+		return respErrorf(resp, "starting host '%s'", hostID)
 	}
 
 	if wait {
@@ -380,12 +353,9 @@ func (c *communicatorImpl) waitForStatus(ctx context.Context, hostID, status str
 			if err != nil {
 				return errors.Wrap(err, "error sending request to get host info")
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
-				errMsg := gimlet.ErrorResponse{}
-				if err = utility.ReadJSON(resp.Body, &errMsg); err != nil {
-					return errors.Wrap(err, "problem getting host and parsing error message")
-				}
-				return errors.Wrap(errMsg, "problem getting host")
+				return respErrorf(resp, "getting host status")
 			}
 			hostResp := model.APIHost{}
 			if err = utility.ReadJSON(resp.Body, &hostResp); err != nil {
@@ -412,11 +382,7 @@ func (c *communicatorImpl) TerminateSpawnHost(ctx context.Context, hostID string
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem terminating host and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem terminating host")
+		return respErrorf(resp, "terminating host '%s'", hostID)
 	}
 
 	return nil
@@ -438,12 +404,9 @@ func (c *communicatorImpl) ChangeSpawnHostPassword(ctx context.Context, hostID, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem changing host RDP password and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem changing host RDP password")
+		return respErrorf(resp, "changing RDP password on host '%s'", hostID)
 	}
+
 	return nil
 }
 
@@ -463,11 +426,7 @@ func (c *communicatorImpl) ExtendSpawnHostExpiration(ctx context.Context, hostID
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem changing host expiration and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem changing host expiration")
+		return respErrorf(resp, "changing expiration of host '%s'", hostID)
 	}
 	return nil
 }
@@ -487,11 +446,7 @@ func (c *communicatorImpl) GetHosts(ctx context.Context, data model.APIHostParam
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err = utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return nil, errors.Wrapf(err, "Got %d code. Problem reading hosts error", resp.StatusCode)
-		}
-		return nil, errors.Wrap(errMsg, "problem getting hosts")
+		return nil, respErrorf(resp, "getting hosts")
 	}
 
 	hosts := []*model.APIHost{}
@@ -508,15 +463,19 @@ func (c *communicatorImpl) SetBannerMessage(ctx context.Context, message string,
 		path:    "admin/banner",
 	}
 
-	_, err := c.retryRequest(ctx, info, struct {
+	resp, err := c.retryRequest(ctx, info, struct {
 		Banner string `json:"banner"`
 		Theme  string `json:"theme"`
 	}{
 		Banner: message,
 		Theme:  string(theme),
 	})
+	if err != nil {
+		return errors.Wrap(err, "problem setting banner")
+	}
+	defer resp.Body.Close()
 
-	return errors.Wrap(err, "problem setting banner")
+	return nil
 }
 
 func (c *communicatorImpl) GetBannerMessage(ctx context.Context) (string, error) {
@@ -530,6 +489,7 @@ func (c *communicatorImpl) GetBannerMessage(ctx context.Context) (string, error)
 	if err != nil {
 		return "", errors.Wrap(err, "problem getting current banner message")
 	}
+	defer resp.Body.Close()
 
 	banner := model.APIBanner{}
 	if err = utility.ReadJSON(resp.Body, &banner); err != nil {
@@ -546,10 +506,11 @@ func (c *communicatorImpl) SetServiceFlags(ctx context.Context, f *model.APIServ
 		path:    "admin/service_flags",
 	}
 
-	_, err := c.retryRequest(ctx, info, f)
+	resp, err := c.retryRequest(ctx, info, f)
 	if err != nil {
 		return errors.Wrap(err, "problem setting service flags")
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -565,6 +526,7 @@ func (c *communicatorImpl) GetServiceFlags(ctx context.Context) (*model.APIServi
 	if err != nil {
 		return nil, errors.Wrap(err, "problem getting service flags")
 	}
+	defer resp.Body.Close()
 
 	settings := model.APIAdminSettings{}
 	if err = utility.ReadJSON(resp.Body, &settings); err != nil {
@@ -595,10 +557,11 @@ func (c *communicatorImpl) RestartRecentTasks(ctx context.Context, startAt, endA
 		EndTime:   endAt,
 	}
 
-	_, err := c.request(ctx, info, &payload)
+	resp, err := c.request(ctx, info, &payload)
 	if err != nil {
 		return errors.Wrap(err, "problem restarting recent tasks")
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -610,16 +573,15 @@ func (c *communicatorImpl) GetSettings(ctx context.Context) (*evergreen.Settings
 		path:    "admin",
 	}
 
-	resp, client_err := c.request(ctx, info, "")
-	if client_err != nil {
-		return nil, errors.Wrap(client_err, "error retrieving settings")
+	resp, err := c.request(ctx, info, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "error retrieving settings")
 	}
 	defer resp.Body.Close()
 
 	settings := &evergreen.Settings{}
 
-	err := utility.ReadJSON(resp.Body, settings)
-	if err != nil {
+	if err = utility.ReadJSON(resp.Body, settings); err != nil {
 		return nil, errors.Wrap(err, "error parsing evergreen settings")
 	}
 	return settings, nil
@@ -704,11 +666,7 @@ func (c *communicatorImpl) ExecuteOnDistro(ctx context.Context, distro string, o
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err = utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return nil, errors.Errorf("received status %s", resp.Status)
-		}
-		return nil, errors.Wrap(errMsg, "problem running script on hosts")
+		return nil, respErrorf(resp, "running script on distro '%s'", distro)
 	}
 
 	if err = utility.ReadJSON(resp.Body, &result); err != nil {
@@ -724,16 +682,15 @@ func (c *communicatorImpl) GetDistrosList(ctx context.Context) ([]model.APIDistr
 		path:    "distros",
 	}
 
-	resp, client_err := c.request(ctx, info, "")
-	if client_err != nil {
-		return nil, errors.Wrap(client_err, "problem fetching distribution list")
+	resp, err := c.request(ctx, info, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "problem fetching distribution list")
 	}
 	defer resp.Body.Close()
 
 	distros := []model.APIDistro{}
 
-	err := utility.ReadJSON(resp.Body, &distros)
-	if err != nil {
+	if err = utility.ReadJSON(resp.Body, &distros); err != nil {
 		return nil, errors.Wrap(err, "error parsing distribution list")
 	}
 
@@ -747,24 +704,18 @@ func (c *communicatorImpl) GetCurrentUsersKeys(ctx context.Context) ([]model.API
 		path:    "keys",
 	}
 
-	resp, client_err := c.request(ctx, info, "")
-	if client_err != nil {
-		return nil, errors.Wrap(client_err, "problem fetching keys list")
+	resp, err := c.request(ctx, info, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "problem fetching keys list")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return nil, errors.Wrap(err, "problem fetching key list and parsing error message")
-		}
-		return nil, errors.Wrap(errMsg, "problem fetching key list")
+		return nil, respErrorf(resp, "getting key list")
 	}
 
 	keys := []model.APIPubKey{}
 
-	err := utility.ReadJSON(resp.Body, &keys)
-	if err != nil {
+	if err = utility.ReadJSON(resp.Body, &keys); err != nil {
 		return nil, errors.Wrap(err, "error parsing keys list")
 	}
 
@@ -789,12 +740,7 @@ func (c *communicatorImpl) AddPublicKey(ctx context.Context, keyName, keyValue s
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem adding key and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem adding key")
+		return respErrorf(resp, "adding key")
 	}
 
 	return nil
@@ -813,12 +759,7 @@ func (c *communicatorImpl) DeletePublicKey(ctx context.Context, keyName string) 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrap(err, "problem deleting key and parsing error message")
-		}
-		return errors.Wrap(errMsg, "problem deleting key")
+		return respErrorf(resp, "deleting key")
 	}
 
 	return nil
@@ -898,33 +839,21 @@ func (c *communicatorImpl) GetSubscriptions(ctx context.Context) ([]event.Subscr
 		version: apiVersion2,
 	}
 	resp, err := c.request(ctx, info, nil)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch subscriptions")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, respErrorf(resp, "getting subscriptions")
 	}
 
 	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response")
 	}
-	if resp.StatusCode != http.StatusOK {
-		var restErr gimlet.ErrorResponse
-		if err = json.Unmarshal(bytes, &restErr); err != nil {
-			return nil, errors.Errorf("expected 200 OK while fetching subscriptions, got %s. Raw response was: %s", resp.Status, string(bytes))
-		}
-
-		restErr = gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    "Unknown error",
-		}
-
-		return nil, errors.Wrap(restErr, "server returned error while fetching subscriptions")
-	}
 
 	apiSubs := []model.APISubscription{}
-
 	if err = json.Unmarshal(bytes, &apiSubs); err != nil {
 		apiSub := model.APISubscription{}
 		if err = json.Unmarshal(bytes, &apiSub); err != nil {
@@ -976,22 +905,13 @@ func (c *communicatorImpl) CreateVersionFromConfig(ctx context.Context, project,
 		return nil, err
 	}
 	defer resp.Body.Close()
-	bytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read response")
-	}
 	if resp.StatusCode != http.StatusOK {
-		restErr := gimlet.ErrorResponse{}
-		if err = json.Unmarshal(bytes, &restErr); err != nil {
-			return nil, errors.Errorf("received an error but was unable to parse: %s", string(bytes))
-		}
-
-		return nil, errors.Wrap(restErr, "error while creating version from config")
+		return nil, respErrorf(resp, "creating version from config")
 	}
+
 	v := &serviceModel.Version{}
-	err = json.Unmarshal(bytes, v)
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing version data")
+	if err = utility.ReadJSON(resp.Body, v); err != nil {
+		return nil, errors.Wrap(err, "parsing version data")
 	}
 
 	return v, nil
@@ -1010,16 +930,10 @@ func (c *communicatorImpl) GetCommitQueue(ctx context.Context, projectID string)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-
-		if err = utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return nil, errors.Wrap(err, "problem fetching commit queue list and parsing error message")
-		}
-		return nil, errMsg
+		return nil, respErrorf(resp, "fetching commit queue list")
 	}
 
 	cq := model.APICommitQueue{}
-
 	if err = utility.ReadJSON(resp.Body, &cq); err != nil {
 		return nil, errors.Wrap(err, "error parsing commit queue")
 	}
@@ -1040,11 +954,7 @@ func (c *communicatorImpl) DeleteCommitQueueItem(ctx context.Context, projectID,
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrapf(err, "response code %d problem deleting item '%s' from commit queue '%s' and parsing error message", resp.StatusCode, item, projectID)
-		}
-		return errMsg
+		return respErrorf(resp, "problem deleting item '%s' from commit queue '%s'", item, projectID)
 	}
 
 	return nil
@@ -1065,22 +975,13 @@ func (c *communicatorImpl) EnqueueItem(ctx context.Context, patchID string, enqu
 		return 0, err
 	}
 	defer resp.Body.Close()
-	bytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to read response")
-	}
 	if resp.StatusCode != http.StatusOK {
-		restErr := gimlet.ErrorResponse{}
-		if err = json.Unmarshal(bytes, &restErr); err != nil {
-			return 0, errors.Errorf("received an error but was unable to parse: %s", string(bytes))
-		}
-
-		return 0, restErr
+		return 0, respErrorf(resp, "enqueueing commit queue item")
 	}
 
 	positionResp := model.APICommitQueuePosition{}
-	if err = json.Unmarshal(bytes, &positionResp); err != nil {
-		return 0, errors.Wrap(err, "error parsing position response")
+	if err = utility.ReadJSON(resp.Body, positionResp); err != nil {
+		return 0, errors.Wrap(err, "parsing position response")
 	}
 
 	return positionResp.Position, nil
@@ -1099,12 +1000,7 @@ func (c *communicatorImpl) SendNotification(ctx context.Context, notificationTyp
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return errors.Wrapf(err, "response code %d problem sending '%s' notification and parsing errors message",
-				resp.StatusCode, notificationType)
-		}
-		return errMsg
+		return respErrorf(resp, "sending '%s' notification", notificationType)
 	}
 
 	return nil
@@ -1124,11 +1020,7 @@ func (c *communicatorImpl) GetDockerStatus(ctx context.Context, hostID string) (
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errMsg := gimlet.ErrorResponse{}
-		if err := utility.ReadJSON(resp.Body, &errMsg); err != nil {
-			return nil, errors.Wrap(err, "problem getting container status and parsing error message")
-		}
-		return nil, errors.Wrap(errMsg, "problem getting container status")
+		return nil, respErrorf(resp, "getting container status")
 	}
 	status := cloud.ContainerStatus{}
 	if err := utility.ReadJSON(resp.Body, &status); err != nil {
@@ -1164,20 +1056,15 @@ func (c *communicatorImpl) GetDockerLogs(ctx context.Context, hostID string, sta
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, respErrorf(resp, "getting logs for container id '%s'", hostID)
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response")
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		restErr := gimlet.ErrorResponse{}
-		if err = json.Unmarshal(body, &restErr); err != nil {
-			return nil, errors.Errorf("received an error but was unable to parse: %s", string(body))
-		}
-
-		return nil, errors.Wrapf(restErr, "response code %d problem getting logs for container _id %s",
-			resp.StatusCode, hostID)
-	}
 	return body, nil
 }
 
@@ -1194,12 +1081,7 @@ func (c *communicatorImpl) GetManifestByTask(ctx context.Context, taskId string)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		restErr := gimlet.ErrorResponse{}
-		if err = utility.ReadJSON(resp.Body, &restErr); err != nil {
-			return nil, errors.Wrap(err, "received an error but was unable to parse")
-		}
-		return nil, errors.Wrapf(restErr, "response code %d problem getting manifest for task '%s'",
-			resp.StatusCode, taskId)
+		return nil, respErrorf(resp, "getting manifest for task '%s'", taskId)
 	}
 	mfest := manifest.Manifest{}
 	if err := utility.ReadJSON(resp.Body, &mfest); err != nil {
@@ -1231,11 +1113,7 @@ func (c *communicatorImpl) StartHostProcesses(ctx context.Context, hostIDs []str
 			defer resp.Body.Close()
 
 			if resp.StatusCode != http.StatusOK {
-				restErr := gimlet.ErrorResponse{}
-				if err = utility.ReadJSON(resp.Body, &restErr); err != nil {
-					return nil, errors.Wrap(err, "received an error but was unable to parse")
-				}
-				return nil, errors.Wrapf(restErr, "response code %d running script on host", resp.StatusCode)
+				return nil, respErrorf(resp, "running script on host")
 			}
 
 			output := []model.APIHostProcess{}
@@ -1277,11 +1155,7 @@ func (c *communicatorImpl) GetHostProcessOutput(ctx context.Context, hostProcess
 			defer resp.Body.Close()
 
 			if resp.StatusCode != http.StatusOK {
-				restErr := gimlet.ErrorResponse{}
-				if err = utility.ReadJSON(resp.Body, &restErr); err != nil {
-					return nil, errors.Wrap(err, "received an error but was unable to parse")
-				}
-				return nil, errors.Wrapf(restErr, "response code %d running script on host", resp.StatusCode)
+				return nil, respErrorf(resp, "running script on host")
 			}
 
 			output := []model.APIHostProcess{}
@@ -1314,15 +1188,11 @@ func (c *communicatorImpl) GetTaskSyncReadCredentials(ctx context.Context) (*eve
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		respErr := gimlet.ErrorResponse{}
-		if err = utility.ReadJSON(resp.Body, &respErr); err != nil {
-			return nil, errors.Wrapf(err, "received unexpected http status: %s", resp.Status)
-		}
-		return nil, errors.Wrap(respErr, "problem getting task read-only credentials")
+		return nil, respErrorf(resp, "getting task read-only credentials")
 	}
 	creds := &evergreen.S3Credentials{}
 	if err := utility.ReadJSON(resp.Body, creds); err != nil {
-		return nil, errors.Wrap(err, "problem reading credentials from response body")
+		return nil, errors.Wrap(err, "reading credentials from response body")
 	}
 
 	return creds, nil
@@ -1341,15 +1211,11 @@ func (c *communicatorImpl) GetTaskSyncPath(ctx context.Context, taskID string) (
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		respErr := gimlet.ErrorResponse{}
-		if err = utility.ReadJSON(resp.Body, &respErr); err != nil {
-			return "", errors.Wrapf(err, "received unexpected http status: %s", resp.Status)
-		}
-		return "", errors.Wrap(respErr, "problem getting task sync path")
+		return "", respErrorf(resp, "getting task sync path")
 	}
 	var path string
 	if err = utility.ReadJSON(resp.Body, &path); err != nil {
-		return "", errors.Wrap(err, "problem reading task sync path from response body")
+		return "", errors.Wrap(err, "reading task sync path from response body")
 	}
 
 	return path, nil


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7800

A lot of the REST client methods assume that the server will return a `gimlet.ErrorResponse` in the body if it has a non-200 response, but a lot of them don't (e.g. if the user fails auth, it doesn't seem to return a `gimlet.ErrorResponse` as JSON). This is supposed to deal with those two cases better by returning the user a (hopefully) more useful message in either case.

* Return the response body text in the error message if it can't be parsed as a `gimlet.ErrorResponse`. Always return the status code in the error if it's non-200.
* Clean up some of the non-200 logic handling.
* Fix some functions not closing the response body.