### PR TITLE
EVG-7769 fix multiple TASK_FINISHED events for display tasks

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -442,21 +442,9 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 	}
 
 	status := t.ResultStatus()
-	if t.DisplayOnly {
-		grip.Debug(message.Fields{
-			"task_id":  t.Id,
-			"status":   t.Status,
-			"EVG-7769": "marking display task as finished in MarkEnd",
-		})
-	}
 	event.LogTaskFinished(t.Id, t.Execution, t.HostId, status)
 
 	if t.IsPartOfDisplay() {
-		grip.Debug(message.Fields{
-			"exec_task": t.Id,
-			"task_id":   t.DisplayTask.Id,
-			"EVG-7769":  "updating display task",
-		})
 		if err = UpdateDisplayTask(t.DisplayTask); err != nil {
 			return err
 		}
@@ -1249,14 +1237,6 @@ func UpdateDisplayTask(t *task.Task) error {
 	t.Details = statusTask.Details
 	t.TimeTaken = timeTaken
 	if !wasFinished && t.IsFinished() {
-		grip.Debug(message.Fields{
-			"task_id":               t.Id,
-			"original_status":       originalStatus,
-			"was_finished":          wasFinished,
-			"status_from_exec_task": t.Status,
-			"exec_task_id":          execTasks[0].Id,
-			"EVG-7769":              "marking display task as finished in MarkEnd",
-		})
 		event.LogTaskFinished(t.Id, t.Execution, "", t.ResultStatus())
 	}
 	return nil

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1158,7 +1158,6 @@ func UpdateDisplayTask(t *task.Task) error {
 
 	var timeTaken time.Duration
 	var statusTask task.Task
-	originalStatus := t.Status
 	execTasks, err := task.Find(task.ByIds(t.ExecutionTasks))
 	if err != nil {
 		return errors.Wrap(err, "error retrieving execution tasks")

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1220,7 +1220,7 @@ func UpdateDisplayTask(t *task.Task) error {
 		return errors.Wrap(err, "error refreshing task status from db")
 	}
 	if taskWithStatus == nil {
-		return errors.Wrap(err, "task not found")
+		return errors.New("task not found")
 	}
 	wasFinished := taskWithStatus.IsFinished()
 	err = task.UpdateOne(

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -746,12 +746,14 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 	}
 
 	cachedTasks := buildTasks
-	for _, displayTask := range cache.List() {
-		grip.Debug(message.Fields{
-			"display_task":          displayTask.Id,
-			"status_from_exec_task": t.Status,
-			"EVG-7769":              "updating display task from UpdateBuildAndVersionStatusForTask",
-		})
+
+	// update the display task for the given task
+	var displayTask *task.Task
+	displayTask, err = cache.Get(t)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if displayTask != nil {
 		if err = UpdateDisplayTask(displayTask); err != nil {
 			return errors.Wrap(errors.WithStack(err), "error updating display task")
 		}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1214,7 +1214,7 @@ func UpdateDisplayTask(t *task.Task) error {
 	}
 
 	// refresh task status from db in case of race
-	taskWithStatus, err := task.FindOneNoMerge(task.ById(t.Id).WithFields(t.Status))
+	taskWithStatus, err := task.FindOneNoMerge(task.ById(t.Id).WithFields(task.StatusKey))
 	if err != nil {
 		return errors.Wrap(err, "error refreshing task status from db")
 	}


### PR DESCRIPTION
Considering UpdateBuildAndVersionStatusForTask is called from MarkEnd whenever a task ends, it shouldn't be necessary to update the status of _every_ display task for the build (doing so caused UpdateDisplayTask to race really frequently with the update).

Also added an additional check to UpdateDisplayTask to verify that the task status hasn't been changed since the display task was cached.