### PR TITLE
EVG-12453 add API to test a project alias

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1260,14 +1260,14 @@ func (p *Project) IgnoresAllFiles(files []string) bool {
 // BuildProjectTVPairs resolves the build variants and tasks into which build
 // variants will run and which tasks will run on each build variant.
 func (p *Project) BuildProjectTVPairs(patchDoc *patch.Patch, alias string) {
-	patchDoc.BuildVariants, patchDoc.Tasks, patchDoc.VariantsTasks = p.resolvePatchVTs(patchDoc.BuildVariants, patchDoc.Tasks, alias, true)
+	patchDoc.BuildVariants, patchDoc.Tasks, patchDoc.VariantsTasks = p.ResolvePatchVTs(patchDoc.BuildVariants, patchDoc.Tasks, alias, true)
 }
 
-// resolvePatchVTs resolves a list of build variants and tasks into a list of
+// ResolvePatchVTs resolves a list of build variants and tasks into a list of
 // all build variants that will run, a list of all tasks that will run, and a
 // mapping of the build variant to the tasks that will run on that build
 // variant. If includeDeps is set, it will also resolve task dependencies.
-func (p *Project) resolvePatchVTs(bvs, tasks []string, alias string, includeDeps bool) (resolvedBVs []string, resolvedTasks []string, vts []patch.VariantTasks) {
+func (p *Project) ResolvePatchVTs(bvs, tasks []string, alias string, includeDeps bool) (resolvedBVs []string, resolvedTasks []string, vts []patch.VariantTasks) {
 	if len(bvs) == 1 && bvs[0] == "all" {
 		bvs = []string{}
 		for _, bv := range p.BuildVariants {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -87,6 +87,7 @@ type Connector interface {
 	// Create/Update a project the given projectRef
 	CreateProject(*model.ProjectRef, *user.DBUser) error
 	UpdateProject(*model.ProjectRef) error
+	TestProjectAlias(*model.Project, string, bool) ([]restModel.APIVariantTasks, error)
 
 	// GetProjectFromFile finds the file for the projectRef and returns the translated project, using the given token
 	GetProjectFromFile(context.Context, model.ProjectRef, string, string) (*model.Project, *model.ParserProject, error)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -87,7 +87,7 @@ type Connector interface {
 	// Create/Update a project the given projectRef
 	CreateProject(*model.ProjectRef, *user.DBUser) error
 	UpdateProject(*model.ProjectRef) error
-	TestProjectAlias(*model.Project, string, bool) ([]restModel.APIVariantTasks, error)
+	GetProjectAliasResults(*model.Project, string, bool) ([]restModel.APIVariantTasks, error)
 
 	// GetProjectFromFile finds the file for the projectRef and returns the translated project, using the given token
 	GetProjectFromFile(context.Context, model.ProjectRef, string, string) (*model.Project, *model.ParserProject, error)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -312,7 +312,7 @@ func (pc *DBProjectConnector) GetProjectSettingsEvent(p *model.ProjectRef) (*mod
 	return &projectSettingsEvent, nil
 }
 
-func (pc *DBProjectConnector) TestProjectAlias(p *model.Project, alias string, includeDeps bool) ([]restModel.APIVariantTasks, error) {
+func (pc *DBProjectConnector) GetProjectAliasResults(p *model.Project, alias string, includeDeps bool) ([]restModel.APIVariantTasks, error) {
 	projectAliases, err := model.FindAliasInProject(p.Identifier, alias)
 	if err != nil {
 		return nil, err
@@ -559,6 +559,6 @@ func (pc *MockProjectConnector) GetProjectSettingsEvent(p *model.ProjectRef) (*m
 	return &model.ProjectSettingsEvent{}, nil
 }
 
-func (pc *MockProjectConnector) TestProjectAlias(*model.Project, string, bool) ([]restModel.APIVariantTasks, error) {
+func (pc *MockProjectConnector) GetProjectAliasResults(*model.Project, string, bool) ([]restModel.APIVariantTasks, error) {
 	return nil, nil
 }

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -315,7 +315,10 @@ func (pc *DBProjectConnector) GetProjectSettingsEvent(p *model.ProjectRef) (*mod
 func (pc *DBProjectConnector) GetProjectAliasResults(p *model.Project, alias string, includeDeps bool) ([]restModel.APIVariantTasks, error) {
 	projectAliases, err := model.FindAliasInProject(p.Identifier, alias)
 	if err != nil {
-		return nil, err
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("no alias named '%s' for project '%s'", alias, p.Identifier),
+		}
 	}
 	matches := []restModel.APIVariantTasks{}
 	for _, projectAlias := range projectAliases {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -312,6 +312,22 @@ func (pc *DBProjectConnector) GetProjectSettingsEvent(p *model.ProjectRef) (*mod
 	return &projectSettingsEvent, nil
 }
 
+func (pc *DBProjectConnector) TestProjectAlias(p *model.Project, alias string, includeDeps bool) ([]restModel.APIVariantTasks, error) {
+	projectAliases, err := model.FindAliasInProject(p.Identifier, alias)
+	if err != nil {
+		return nil, err
+	}
+	matches := []restModel.APIVariantTasks{}
+	for _, projectAlias := range projectAliases {
+		_, _, variantTasks := p.ResolvePatchVTs(nil, nil, projectAlias.Alias, includeDeps)
+		for _, variantTask := range variantTasks {
+			matches = append(matches, restModel.APIVariantTasksBuildFromService(variantTask))
+		}
+	}
+
+	return matches, nil
+}
+
 // MockPatchConnector is a struct that implements the Patch related methods
 // from the Connector through interactions with he backing database.
 type MockProjectConnector struct {
@@ -541,4 +557,8 @@ func (pc *MockProjectConnector) GetProjectSettingsEvent(p *model.ProjectRef) (*m
 		return nil, errors.New("Owner and repository must not be empty strings")
 	}
 	return &model.ProjectSettingsEvent{}, nil
+}
+
+func (pc *MockProjectConnector) TestProjectAlias(*model.Project, string, bool) ([]restModel.APIVariantTasks, error) {
+	return nil, nil
 }

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	mgobson "gopkg.in/mgo.v2/bson"
 )
@@ -406,4 +408,45 @@ func (s *ProjectConnectorGetSuite) TestCopyProjectVars() {
 
 	s.Equal(origProj.PrivateVars, newProj.PrivateVars)
 	s.Equal(origProj.Vars, newProj.Vars)
+}
+
+func TestProjectAlias(t *testing.T) {
+	require.NoError(t, db.ClearCollections(model.ProjectAliasCollection))
+	p := model.Project{
+		Identifier: "helloworld",
+		BuildVariants: model.BuildVariants{
+			{Name: "bv1", Tasks: []model.BuildVariantTaskUnit{{Name: "task1"}}},
+			{Name: "bv2", Tasks: []model.BuildVariantTaskUnit{{Name: "task2"}, {Name: "task3"}}},
+		},
+		Tasks: []model.ProjectTask{
+			{Name: "task1"},
+			{Name: "task2"},
+			{Name: "task3"},
+		},
+	}
+	alias1 := model.ProjectAlias{
+		Alias:     "select_bv1",
+		ProjectID: p.Identifier,
+		Variant:   "^bv1$",
+		Task:      ".*",
+	}
+	require.NoError(t, alias1.Upsert())
+	alias2 := model.ProjectAlias{
+		Alias:     "select_bv2",
+		ProjectID: p.Identifier,
+		Variant:   "^bv2$",
+		Task:      ".*",
+	}
+	require.NoError(t, alias2.Upsert())
+
+	dc := &DBProjectConnector{}
+	variantTasks, err := dc.TestProjectAlias(&p, alias1.Alias, false)
+	assert.NoError(t, err)
+	assert.Len(t, variantTasks, 1)
+	assert.Len(t, variantTasks[0].Tasks, 1)
+	assert.Equal(t, "task1", variantTasks[0].Tasks[0])
+	variantTasks, err = dc.TestProjectAlias(&p, alias2.Alias, false)
+	assert.NoError(t, err)
+	assert.Len(t, variantTasks, 1)
+	assert.Len(t, variantTasks[0].Tasks, 2)
 }

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -410,7 +410,7 @@ func (s *ProjectConnectorGetSuite) TestCopyProjectVars() {
 	s.Equal(origProj.Vars, newProj.Vars)
 }
 
-func TestProjectAlias(t *testing.T) {
+func TestGetProjectAliasResults(t *testing.T) {
 	require.NoError(t, db.ClearCollections(model.ProjectAliasCollection))
 	p := model.Project{
 		Identifier: "helloworld",
@@ -440,12 +440,12 @@ func TestProjectAlias(t *testing.T) {
 	require.NoError(t, alias2.Upsert())
 
 	dc := &DBProjectConnector{}
-	variantTasks, err := dc.TestProjectAlias(&p, alias1.Alias, false)
+	variantTasks, err := dc.GetProjectAliasResults(&p, alias1.Alias, false)
 	assert.NoError(t, err)
 	assert.Len(t, variantTasks, 1)
 	assert.Len(t, variantTasks[0].Tasks, 1)
 	assert.Equal(t, "task1", variantTasks[0].Tasks[0])
-	variantTasks, err = dc.TestProjectAlias(&p, alias2.Alias, false)
+	variantTasks, err = dc.GetProjectAliasResults(&p, alias2.Alias, false)
 	assert.NoError(t, err)
 	assert.Len(t, variantTasks, 1)
 	assert.Len(t, variantTasks[0].Tasks, 2)

--- a/rest/model/build.go
+++ b/rest/model/build.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/pkg/errors"
 )
@@ -120,4 +121,34 @@ type APITaskCache struct {
 	TimeTaken       time.Duration           `json:"time_taken"`
 	Activated       bool                    `json:"activated"`
 	FailedTestNames []string                `json:"failed_test_names,omitempty"`
+}
+
+type APIVariantTasks struct {
+	Variant      *string
+	Tasks        []string
+	DisplayTasks []APIDisplayTask
+}
+
+func APIVariantTasksBuildFromService(v patch.VariantTasks) APIVariantTasks {
+	out := APIVariantTasks{}
+	out.Variant = &v.Variant
+	out.Tasks = v.Tasks
+	for _, e := range v.DisplayTasks {
+		n := APIDisplayTaskBuildFromService(e)
+		out.DisplayTasks = append(out.DisplayTasks, n)
+	}
+	return out
+}
+
+func APIVariantTasksToService(v APIVariantTasks) patch.VariantTasks {
+	out := patch.VariantTasks{}
+	if v.Variant != nil {
+		out.Variant = *v.Variant
+	}
+	out.Tasks = v.Tasks
+	for _, e := range v.DisplayTasks {
+		n := APIDisplayTaskToService(e)
+		out.DisplayTasks = append(out.DisplayTasks, n)
+	}
+	return out
 }

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/artifact"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/pkg/errors"
 )
@@ -416,4 +417,25 @@ func (ad *APIDependency) BuildFromService(dep task.Dependency) {
 }
 func (ad *APIDependency) ToService() (interface{}, error) {
 	return nil, errors.Errorf("ToService() is not implemented for APIDependency")
+}
+
+type APIDisplayTask struct {
+	Name           *string
+	ExecutionTasks []string
+}
+
+func APIDisplayTaskBuildFromService(v patch.DisplayTask) APIDisplayTask {
+	out := APIDisplayTask{}
+	out.Name = &v.Name
+	out.ExecutionTasks = v.ExecTasks
+	return out
+}
+
+func APIDisplayTaskToService(v APIDisplayTask) patch.DisplayTask {
+	out := patch.DisplayTask{}
+	if v.Name != nil {
+		out.Name = *v.Name
+	}
+	out.ExecTasks = v.ExecutionTasks
+	return out
 }

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -122,7 +122,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/patches/{patch_id}/abort").Version(2).Post().Wrap(checkUser, submitPatches).RouteHandler(makeAbortPatch(sc))
 	app.AddRoute("/patches/{patch_id}/restart").Version(2).Post().Wrap(checkUser, submitPatches).RouteHandler(makeRestartPatch(sc))
 	app.AddRoute("/projects").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchProjectsRoute(sc))
-	app.AddRoute("/projects/test_alias").Version(2).Get().Wrap(checkUser).RouteHandler(makeTestProjectAliasHandler(sc))
+	app.AddRoute("/projects/test_alias").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetProjectAliasResultsHandler(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Get().Wrap(checkUser, addProject, viewProjectSettings).RouteHandler(makeGetProjectByID(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Patch().Wrap(checkUser, addProject, checkProjectAdmin, editProjectSettings).RouteHandler(makePatchProjectByID(sc, env.Settings()))
 	app.AddRoute("/projects/{project_id}/repotracker").Version(2).Post().Wrap(checkUser, addProject).RouteHandler(makeRunRepotrackerForProject(sc))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -122,6 +122,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/patches/{patch_id}/abort").Version(2).Post().Wrap(checkUser, submitPatches).RouteHandler(makeAbortPatch(sc))
 	app.AddRoute("/patches/{patch_id}/restart").Version(2).Post().Wrap(checkUser, submitPatches).RouteHandler(makeRestartPatch(sc))
 	app.AddRoute("/projects").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchProjectsRoute(sc))
+	app.AddRoute("/projects/test_alias").Version(2).Get().Wrap(checkUser).RouteHandler(makeTestProjectAliasHandler(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Get().Wrap(checkUser, addProject, viewProjectSettings).RouteHandler(makeGetProjectByID(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Patch().Wrap(checkUser, addProject, checkProjectAdmin, editProjectSettings).RouteHandler(makePatchProjectByID(sc, env.Settings()))
 	app.AddRoute("/projects/{project_id}/repotracker").Version(2).Post().Wrap(checkUser, addProject).RouteHandler(makeRunRepotrackerForProject(sc))


### PR DESCRIPTION
Timelines didn't line up to be able to generate this, but I wrote it in a way that generating it will probably create the same-ish code, and will try to do it again once array handling is done. This route takes a version, retrieves its config, and returns the variants and tasks that a given alias would select for it