### PR TITLE
EVG-12390 add SNS rest route

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -191,3 +191,6 @@ imports:
     version: 70971dc81bab3671fde85647b0a1367929f92be8
   - name: github.com/evergreen-ci/utility
     version: 8a885e291da3d271f58d396ee2b313ab1aec21a8
+
+  - name: github.com/robbiet480/go.sns
+    version: ca087b49e1da69fa4f163521cc98b1eaf7b66ffd

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -78,7 +78,7 @@ func (aws *awsSns) Run(ctx context.Context) gimlet.Responder {
 		})
 	case messageTypeNotification:
 		// TODO: handle the message
-		grip.Alert(message.Fields{
+		grip.Info(message.Fields{
 			"message":         "got an AWS SNS notification",
 			"payload_subject": aws.payload.Subject,
 			"payload_message": aws.payload.Message,

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -1,0 +1,99 @@
+package route
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+	sns "github.com/robbiet480/go.sns"
+)
+
+const (
+	messageTypeSubscriptionConfirmation = "SubscriptionConfirmation"
+	messageTypeNotification             = "Notification"
+	messageTypeUnsubscribeConfirmation  = "UnsubscribeConfirmation"
+)
+
+type awsSns struct {
+	sc          data.Connector
+	messageType string
+	payload     sns.Payload
+}
+
+func makeAwsSnsRoute(sc data.Connector) gimlet.RouteHandler {
+	return &awsSns{
+		sc: sc,
+	}
+}
+
+func (aws *awsSns) Factory() gimlet.RouteHandler {
+	return &awsSns{
+		sc: aws.sc,
+	}
+}
+
+func (aws *awsSns) Parse(ctx context.Context, r *http.Request) error {
+	aws.messageType = r.Header.Get("x-amz-sns-message-type")
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return errors.Wrap(err, "problem reading body")
+	}
+	if err = json.Unmarshal(body, &aws.payload); err != nil {
+		return errors.Wrap(err, "problem unmarshalling payload")
+	}
+
+	if err = aws.payload.VerifyPayload(); err != nil {
+		msg := "AWS SNS message failed validation"
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": msg,
+			"payload": aws.payload,
+		}))
+		return errors.Wrap(err, msg)
+	}
+
+	return nil
+}
+
+func (aws *awsSns) Run(ctx context.Context) gimlet.Responder {
+	switch aws.messageType {
+	case messageTypeSubscriptionConfirmation:
+		grip.Alert(message.Fields{
+			"message":       "got AWS SNS subscription confirmation. Visit subscribe_url to confirm",
+			"subscribe_url": aws.payload.SubscribeURL,
+			"topic_arn":     aws.payload.TopicArn,
+		})
+	case messageTypeUnsubscribeConfirmation:
+		grip.Alert(message.Fields{
+			"message":         "got AWS SNS unsubscription confirmation. Visit unsubscribe_url to confirm",
+			"unsubscribe_url": aws.payload.SubscribeURL,
+			"topic_arn":       aws.payload.TopicArn,
+		})
+	case messageTypeNotification:
+		// TODO: handle the message
+		grip.Alert(message.Fields{
+			"message":         "got an AWS SNS notification",
+			"payload_subject": aws.payload.Subject,
+			"payload_message": aws.payload.Message,
+			"payload_topic":   aws.payload.TopicArn,
+		})
+	default:
+		grip.Error(message.Fields{
+			"message":         "got an unknown message type",
+			"type":            aws.messageType,
+			"payload_subject": aws.payload.Subject,
+			"payload_message": aws.payload.Message,
+			"payload_topic":   aws.payload.TopicArn,
+		})
+		return gimlet.NewTextErrorResponse(fmt.Sprintf("message type '%s' is not recognized", aws.messageType))
+	}
+
+	return gimlet.NewJSONResponse(struct{}{})
+}

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -63,6 +63,7 @@ func (aws *awsSns) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (aws *awsSns) Run(ctx context.Context) gimlet.Responder {
+	// Subscription/Unsubscription is a rare action that we will handle manually and will be logged to splunk given the logging level.
 	switch aws.messageType {
 	case messageTypeSubscriptionConfirmation:
 		grip.Alert(message.Fields{

--- a/rest/route/aws_test.go
+++ b/rest/route/aws_test.go
@@ -1,0 +1,15 @@
+package route
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAwsSnsRun(t *testing.T) {
+	aws := awsSns{messageType: "unknown"}
+	responder := aws.Run(context.Background())
+	assert.Equal(t, http.StatusBadRequest, responder.Status())
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -88,7 +88,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/distros/{distro_id}/icecream_config").Version(2).Patch().Wrap(editHosts).RouteHandler(makeDistroIcecreamConfig(sc, env))
 
 	app.AddRoute("/hooks/github").Version(2).Post().RouteHandler(makeGithubHooksRoute(sc, opts.APIQueue, opts.GithubSecret, settings))
-	app.AddRoute("/hooks/sns").Version(2).Post().RouteHandler(makeAwsSnsRoute(sc))
+	app.AddRoute("/hooks/aws").Version(2).Post().RouteHandler(makeAwsSnsRoute(sc))
 	app.AddRoute("/host/filter").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchHostFilter(sc))
 	app.AddRoute("/host/start_processes").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostStartProcesses(sc, env))
 	app.AddRoute("/host/get_processes").Version(2).Get().Wrap(checkUser).RouteHandler(makeHostGetProcesses(sc, env))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -88,6 +88,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/distros/{distro_id}/icecream_config").Version(2).Patch().Wrap(editHosts).RouteHandler(makeDistroIcecreamConfig(sc, env))
 
 	app.AddRoute("/hooks/github").Version(2).Post().RouteHandler(makeGithubHooksRoute(sc, opts.APIQueue, opts.GithubSecret, settings))
+	app.AddRoute("/hooks/sns").Version(2).Post().RouteHandler(makeAwsSnsRoute(sc))
 	app.AddRoute("/host/filter").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchHostFilter(sc))
 	app.AddRoute("/host/start_processes").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostStartProcesses(sc, env))
 	app.AddRoute("/host/get_processes").Version(2).Get().Wrap(checkUser).RouteHandler(makeHostGetProcesses(sc, env))

--- a/vendor/github.com/robbiet480/go.sns/.gitignore
+++ b/vendor/github.com/robbiet480/go.sns/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/robbiet480/go.sns/.travis.yml
+++ b/vendor/github.com/robbiet480/go.sns/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+  - tip
+
+install: go get -v
+script: go test -v

--- a/vendor/github.com/robbiet480/go.sns/LICENSE
+++ b/vendor/github.com/robbiet480/go.sns/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Robbie Trencheny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/robbiet480/go.sns/README.md
+++ b/vendor/github.com/robbiet480/go.sns/README.md
@@ -1,0 +1,81 @@
+[![Build Status](https://travis-ci.org/robbiet480/go.sns.svg)](https://travis-ci.org/robbiet480/go.sns)
+[![GoDoc](https://godoc.org/github.com/robbiet480/go.sns?status.svg)](https://godoc.org/github.com/robbiet480/go.sns)
+
+# go.sns
+A helper library for receiving [Amazon AWS SNS](https://aws.amazon.com/sns/) [HTTP(S) notifications](https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html).
+
+It provides [signature validation](https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.verify.signature.html) for payloads and conveinence functions for subscribing and unsubscribing from topics.
+
+## Usage
+
+### Verifying a HTTP POST (a payload)
+
+```go
+import (
+  "encoding/json"
+  "fmt"
+
+  "github.com/robbiet480/go.sns"
+)
+
+var notificationPayload sns.Payload
+err := json.Unmarshal([]byte(notificationJson), &notificationPayload)
+if err != nil {
+  fmt.Print(err)
+}
+verifyErr := notificationPayload.VerifyPayload()
+if verifyErr != nil {
+  fmt.Print(verifyErr)
+}
+fmt.Print("Payload is valid!")
+```
+
+### Subscribing to a topic
+
+```go
+import (
+  "encoding/json"
+  "fmt"
+
+  "github.com/robbiet480/go.sns"
+)
+
+// If it's a SubscriptionConfirmation or UnsubscribeConfirmation
+subscriptionResponse, err := notificationPayload.Subscribe()
+if err != nil {
+  fmt.Println("Error when subscribing!", err)
+}
+fmt.Printf("subscriptionResponse %+v", subscriptionResponse)
+```
+
+### Unsubscribing from a topic
+
+```go
+import (
+  "encoding/json"
+  "fmt"
+
+  "github.com/robbiet480/go.sns"
+)
+
+// If it's a Notification
+unsubscriptionResponse, err := notificationPayload.Unsubscribe()
+if err != nil {
+  fmt.Println("Error when unsubscribing!", err)
+}
+fmt.Printf("unsubscriptionResponse %+v", unsubscriptionResponse)
+```
+
+## Thanks
+This library was based off work by [lazywei](https://github.com/lazywei), found on [this Stack Overflow question](http://stackoverflow.com/q/20014908/486182) and code written by [syama666](https://github.com/syama666).
+
+Thanks also goes to [xibz](https://github.com/xibz) for helping me work out some of the low level certificate/SHA1WithRSA stuff in this [issue on aws-sdk-go](https://github.com/aws/aws-sdk-go/issues/567).
+
+## Contributing
+Fork, edit, write & run tests, submit PR, success!
+
+## Tests
+Tests are written but not passing because the payload string is an example from the documentation.
+
+## License
+MIT

--- a/vendor/github.com/robbiet480/go.sns/example_test.go
+++ b/vendor/github.com/robbiet480/go.sns/example_test.go
@@ -1,0 +1,50 @@
+package sns_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/robbiet480/go.sns"
+)
+
+var notificationJson = ""
+
+func ExamplePayload_VerifyPayload() {
+	var notificationPayload sns.Payload
+	err := json.Unmarshal([]byte(notificationJson), &notificationPayload)
+	if err != nil {
+		fmt.Print(err)
+	}
+	verifyErr := notificationPayload.VerifyPayload()
+	if verifyErr != nil {
+		fmt.Print(verifyErr)
+	} else {
+		fmt.Print("Payload is valid!")
+	}
+}
+
+func ExamplePayload_Subscribe() {
+	var notificationPayload sns.Payload
+	err := json.Unmarshal([]byte(notificationJson), &notificationPayload)
+	if err != nil {
+		fmt.Print(err)
+	}
+	subscriptionResponse, err := notificationPayload.Subscribe()
+	if err != nil {
+		fmt.Println("Error when subscribing!", err)
+	}
+	fmt.Printf("subscriptionResponse %+v", subscriptionResponse)
+}
+
+func ExamplePayload_Unsubscribe() {
+	var notificationPayload sns.Payload
+	err := json.Unmarshal([]byte(notificationJson), &notificationPayload)
+	if err != nil {
+		fmt.Print(err)
+	}
+	unsubscriptionResponse, err := notificationPayload.Unsubscribe()
+	if err != nil {
+		fmt.Println("Error when unsubscribing!", err)
+	}
+	fmt.Printf("unsubscriptionResponse %+v", unsubscriptionResponse)
+}

--- a/vendor/github.com/robbiet480/go.sns/main.go
+++ b/vendor/github.com/robbiet480/go.sns/main.go
@@ -1,0 +1,154 @@
+// Package sns provides helper functions for verifying and processing Amazon AWS SNS HTTP POST payloads.
+package sns
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"regexp"
+)
+
+// https://github.com/robbiet480/go.sns/issues/2
+var hostPattern = regexp.MustCompile(`^sns\.[a-zA-Z0-9\-]{3,}\.amazonaws\.com(\.cn)?$`)
+
+// Payload contains a single POST from SNS
+type Payload struct {
+	Message          string `json:"Message"`
+	MessageId        string `json:"MessageId"`
+	Signature        string `json:"Signature"`
+	SignatureVersion string `json:"SignatureVersion"`
+	SigningCertURL   string `json:"SigningCertURL"`
+	SubscribeURL     string `json:"SubscribeURL"`
+	Subject          string `json:"Subject"`
+	Timestamp        string `json:"Timestamp"`
+	Token            string `json:"Token"`
+	TopicArn         string `json:"TopicArn"`
+	Type             string `json:"Type"`
+	UnsubscribeURL   string `json:"UnsubscribeURL"`
+}
+
+// ConfirmSubscriptionResponse contains the XML response of accessing a SubscribeURL
+type ConfirmSubscriptionResponse struct {
+	XMLName         xml.Name `xml:"ConfirmSubscriptionResponse"`
+	SubscriptionArn string   `xml:"ConfirmSubscriptionResult>SubscriptionArn"`
+	RequestId       string   `xml:"ResponseMetadata>RequestId"`
+}
+
+// UnsubscribeResponse contains the XML response of accessing an UnsubscribeURL
+type UnsubscribeResponse struct {
+	XMLName   xml.Name `xml:"UnsubscribeResponse"`
+	RequestId string   `xml:"ResponseMetadata>RequestId"`
+}
+
+// BuildSignature returns a byte array containing a signature usable for SNS verification
+func (payload *Payload) BuildSignature() []byte {
+	var builtSignature bytes.Buffer
+	signableKeys := []string{"Message", "MessageId", "Subject", "SubscribeURL", "Timestamp", "Token", "TopicArn", "Type"}
+	for _, key := range signableKeys {
+		reflectedStruct := reflect.ValueOf(payload)
+		field := reflect.Indirect(reflectedStruct).FieldByName(key)
+		value := field.String()
+		if field.IsValid() && value != "" {
+			builtSignature.WriteString(key + "\n")
+			builtSignature.WriteString(value + "\n")
+		}
+	}
+	return builtSignature.Bytes()
+}
+
+// VerifyPayload will verify that a payload came from SNS
+func (payload *Payload) VerifyPayload() error {
+	payloadSignature, err := base64.StdEncoding.DecodeString(payload.Signature)
+	if err != nil {
+		return err
+	}
+
+	certURL, err := url.Parse(payload.SigningCertURL)
+	if err != nil {
+		return err
+	}
+
+	if !hostPattern.Match([]byte(certURL.Host)) {
+		return fmt.Errorf("certificate is located on an invalid domain")
+	}
+
+	resp, err := http.Get(payload.SigningCertURL)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	decodedPem, _ := pem.Decode(body)
+	if decodedPem == nil {
+		return errors.New("The decoded PEM file was empty!")
+	}
+
+	parsedCertificate, err := x509.ParseCertificate(decodedPem.Bytes)
+	if err != nil {
+		return err
+	}
+
+	return parsedCertificate.CheckSignature(x509.SHA1WithRSA, payload.BuildSignature(), payloadSignature)
+}
+
+// Subscribe will use the SubscribeURL in a payload to confirm a subscription and return a ConfirmSubscriptionResponse
+func (payload *Payload) Subscribe() (ConfirmSubscriptionResponse, error) {
+	var response ConfirmSubscriptionResponse
+	if payload.SubscribeURL == "" {
+		return response, errors.New("Payload does not have a SubscribeURL!")
+	}
+
+	resp, err := http.Get(payload.SubscribeURL)
+	if err != nil {
+		return response, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return response, err
+	}
+
+	xmlErr := xml.Unmarshal(body, &response)
+	if xmlErr != nil {
+		return response, xmlErr
+	}
+	return response, nil
+}
+
+// Unsubscribe will use the UnsubscribeURL in a payload to confirm a subscription and return a UnsubscribeResponse
+func (payload *Payload) Unsubscribe() (UnsubscribeResponse, error) {
+	var response UnsubscribeResponse
+	resp, err := http.Get(payload.UnsubscribeURL)
+	if err != nil {
+		return response, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return response, err
+	}
+
+	xmlErr := xml.Unmarshal(body, &response)
+	if xmlErr != nil {
+		return response, xmlErr
+	}
+	return response, nil
+}

--- a/vendor/github.com/robbiet480/go.sns/sns_test.go
+++ b/vendor/github.com/robbiet480/go.sns/sns_test.go
@@ -1,0 +1,21 @@
+package sns
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestVerifyPayload(t *testing.T) {
+	notificationJson := `{"Type":"Notification","MessageId":"da41e39f-ea4d-435a-b922-c6aae3915ebe","TopicArn":"arn:aws:sns:us-west-2:123456789012:MyTopic","Subject":"test","Message":"test message","Timestamp":"2012-04-25T21:49:25.719Z","SignatureVersion":"1","Signature":"EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=","SigningCertURL":"https://sns.us-west-2.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem","UnsubscribeURL":"https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:123456789012:MyTopic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"}`
+	var notificationPayload Payload
+	err := json.Unmarshal([]byte(notificationJson), &notificationPayload)
+	if err != nil {
+		t.Error(err)
+	}
+	verifyErr := notificationPayload.VerifyPayload()
+	if verifyErr != nil {
+		t.Error(verifyErr)
+	} else {
+		t.Log("Payload is valid!")
+	}
+}


### PR DESCRIPTION
Add a route to listen for SNS notifications.

The fields of the notification are defined [here](https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html)

The [AWS docs](https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html) suggest verifying the signature included with SNS notifications. I vendored a library to do the heavy lifting.

When you add a subscription to a topic AWS sends an initial subscription confirmation message to the endpoint with a URL to GET to confirm the subscription. No notifications are sent until the subscription is confirmed. (The process of setting up an endpoint to handle HTTP(S) notifications is described [here](https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subscriber.html#SendMessageToHttp.prepare))
I considered two options: 
1) registering the topic beforehand with Evergreen (probably in admin settings) so when Evergreen gets the confirmation message it can check it's been configured and confirm automatically. 
2) sending a Slack alert with the confirmation URL so we can confirm manually. 

I opted for the second option since I didn't see the sense in cluttering admin settings with a setting that's only used once, but I'm open to other options/arguments.

