### PR TITLE
EVG-12603: suggest re-logging into the UI if the CLI returns 401 Unauthorized

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-07-21"
+	ClientVersion = "2020-07-22"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-07-18"

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -151,6 +151,9 @@ func adminServiceChange(disable bool) cli.ActionFunc {
 		client := conf.setupRestCommunicator(ctx)
 		defer client.Close()
 
+		// TODO: fix this so that there's a route that actually returns the
+		// current service flags correctly (the legacy admin config route
+		// returns empty).
 		flags := &model.APIServiceFlags{}
 		if err := setServiceFlagValues(flagsToSet, disable, flags); err != nil {
 			return errors.Wrap(err, "invalid service flags")

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -151,6 +151,9 @@ func adminServiceChange(disable bool) cli.ActionFunc {
 		client := conf.setupRestCommunicator(ctx)
 		defer client.Close()
 
+		// kim: TODO: remove flags because they don't even get populated by the
+		// route.
+		// flags := &model.APIServiceFlags{}
 		flags, err := client.GetServiceFlags(ctx)
 		if err != nil {
 			return errors.Wrap(err, "problem getting current service flag state")
@@ -194,6 +197,7 @@ func setServiceFlagValues(args []string, target bool, flags *model.APIServiceFla
 	return catcher.Resolve()
 }
 
+// kim: TODO: remove because it doesn't even work.
 func viewSettings() cli.Command {
 	return cli.Command{
 		Name:   "get-settings",

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -151,14 +151,7 @@ func adminServiceChange(disable bool) cli.ActionFunc {
 		client := conf.setupRestCommunicator(ctx)
 		defer client.Close()
 
-		// kim: TODO: remove flags because they don't even get populated by the
-		// route.
-		// flags := &model.APIServiceFlags{}
-		flags, err := client.GetServiceFlags(ctx)
-		if err != nil {
-			return errors.Wrap(err, "problem getting current service flag state")
-		}
-
+		flags := &model.APIServiceFlags{}
 		if err := setServiceFlagValues(flagsToSet, disable, flags); err != nil {
 			return errors.Wrap(err, "invalid service flags")
 		}
@@ -197,7 +190,6 @@ func setServiceFlagValues(args []string, target bool, flags *model.APIServiceFla
 	return catcher.Resolve()
 }
 
-// kim: TODO: remove because it doesn't even work.
 func viewSettings() cli.Command {
 	return cli.Command{
 		Name:   "get-settings",

--- a/operations/http.go
+++ b/operations/http.go
@@ -271,7 +271,7 @@ func (ac *legacyClient) GetConfig(versionId string) ([]byte, error) {
 
 }
 
-// GetProjct fetches the project details from the API server for a given project ID.
+// GetProject fetches the project details from the API server for a given project ID.
 func (ac *legacyClient) GetProject(versionId string) (*model.Project, error) {
 	resp, err := ac.get(fmt.Sprintf("versions/%v/parser_project", versionId), nil)
 	if err != nil {

--- a/operations/http.go
+++ b/operations/http.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/rest/client"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/service"
 	"github.com/evergreen-ci/evergreen/validator"
@@ -129,6 +130,11 @@ func (ac *legacyClient) modifyExisting(patchId, action string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return NewAPIError(resp)
 	}
@@ -141,6 +147,8 @@ func (ac *legacyClient) ValidateLocalConfig(data []byte) (validator.ValidationEr
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == http.StatusBadRequest {
 		errors := validator.ValidationErrors{}
 		err = utility.ReadJSON(resp.Body, &errors)
@@ -148,7 +156,11 @@ func (ac *legacyClient) ValidateLocalConfig(data []byte) (validator.ValidationEr
 			return nil, NewAPIError(resp)
 		}
 		return errors, nil
-	} else if resp.StatusCode != http.StatusOK {
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
+	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
 	return nil, nil
@@ -168,6 +180,11 @@ func (ac *legacyClient) GetPatches(n int) ([]patch.Patch, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -184,6 +201,11 @@ func (ac *legacyClient) GetRestPatch(patchId string) (*service.RestPatch, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -199,6 +221,11 @@ func (ac *legacyClient) GetPatch(patchId string) (*patch.Patch, error) {
 	resp, err := ac.get2(fmt.Sprintf("patches/%v", patchId), nil)
 	if err != nil {
 		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
@@ -224,6 +251,11 @@ func (ac *legacyClient) GetProjectRef(projectId string) (*model.ProjectRef, erro
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -239,6 +271,11 @@ func (ac *legacyClient) GetPatchedConfig(patchId string) (*model.Project, error)
 	resp, err := ac.get(fmt.Sprintf("patches/%v/config", patchId), nil)
 	if err != nil {
 		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
@@ -260,6 +297,11 @@ func (ac *legacyClient) GetConfig(versionId string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -276,6 +318,11 @@ func (ac *legacyClient) GetProject(versionId string) (*model.Project, error) {
 	resp, err := ac.get(fmt.Sprintf("versions/%v/parser_project", versionId), nil)
 	if err != nil {
 		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
@@ -299,6 +346,11 @@ func (ac *legacyClient) GetLastGreen(project string, variants []string) (*model.
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -314,6 +366,11 @@ func (ac *legacyClient) DeletePatchModule(patchId, module string) error {
 	resp, err := ac.delete(fmt.Sprintf("patches/%s/modules?module=%v", patchId, url.QueryEscape(module)), nil)
 	if err != nil {
 		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return client.AuthError
 	}
 	if resp.StatusCode != http.StatusOK {
 		return NewAPIError(resp)
@@ -354,6 +411,11 @@ func (ac *legacyClient) UpdatePatchModule(params UpdatePatchModuleParams) error 
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return NewAPIError(resp)
 	}
@@ -364,6 +426,11 @@ func (ac *legacyClient) ListProjects() ([]model.ProjectRef, error) {
 	resp, err := ac.get("projects", nil)
 	if err != nil {
 		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
@@ -380,6 +447,11 @@ func (ac *legacyClient) ListTasks(project string) ([]model.ProjectTask, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -395,6 +467,11 @@ func (ac *legacyClient) ListVariants(project string) ([]model.BuildVariant, erro
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -409,6 +486,11 @@ func (ac *legacyClient) ListDistros() ([]distro.Distro, error) {
 	resp, err := ac.get2("distros", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "problem querying api server")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Wrap(NewAPIError(resp), "bad status from api server")
@@ -488,10 +570,14 @@ func (ac *legacyClient) GetTask(taskId string) (*service.RestTask, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, nil
 	}
-
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -511,10 +597,14 @@ func (ac *legacyClient) GetHostUtilizationStats(granularity, daysBack int, csv b
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, errors.New("not found")
 	}
-
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -530,10 +620,14 @@ func (ac *legacyClient) GetAverageSchedulerStats(granularity, daysBack int, dist
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, errors.New("not found")
 	}
-
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -548,10 +642,14 @@ func (ac *legacyClient) GetOptimalMakespans(numberBuilds int, csv bool) (io.Read
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, errors.New("not found")
 	}
-
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -567,7 +665,11 @@ func (ac *legacyClient) GetPatchModules(patchId, projectId string) ([]string, er
 	if err != nil {
 		return out, err
 	}
+	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return out, NewAPIError(resp)
 	}
@@ -595,6 +697,9 @@ func (ac *legacyClient) GetRecentVersions(projectID string) ([]string, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -630,7 +735,11 @@ func (ac *legacyClient) UpdateRole(role *gimlet.Role) error {
 	if err != nil {
 		return errors.Wrap(err, "error making request to update role")
 	}
+	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return client.AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return NewAPIError(resp)
 	}

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -49,6 +49,10 @@ const (
 
 var HTTPConflictError = errors.New(evergreen.TaskConflict)
 
+// AuthError is a special error when the CLI receives 401 Unauthorized to
+// suggest logging in again as a possible solution to the error.
+var AuthError = errors.New("401 Unauthorized: try logging into the website again")
+
 func (c *communicatorImpl) newRequest(method, path, taskID, taskSecret, version string, data interface{}) (*http.Request, error) {
 	url := c.getPath(path, version)
 	r, err := http.NewRequest(method, url, nil)
@@ -205,6 +209,9 @@ func (c *communicatorImpl) retryRequest(ctx context.Context, info requestInfo, d
 			} else if resp.StatusCode == http.StatusConflict {
 				defer resp.Body.Close()
 				return nil, HTTPConflictError
+			} else if resp.StatusCode == http.StatusUnauthorized {
+				defer resp.Body.Close()
+				return nil, AuthError
 			} else if resp.StatusCode >= 400 && resp.StatusCode < 500 {
 				defer resp.Body.Close()
 				reader := util.NewResponseReader(resp)

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -51,7 +51,7 @@ var HTTPConflictError = errors.New(evergreen.TaskConflict)
 
 // AuthError is a special error when the CLI receives 401 Unauthorized to
 // suggest logging in again as a possible solution to the error.
-var AuthError = errors.New("401 Unauthorized: try logging into the website again")
+var AuthError = errors.New("401 Unauthorized: User credentials are likely expired, try logging into the website again.")
 
 func (c *communicatorImpl) newRequest(method, path, taskID, taskSecret, version string, data interface{}) (*http.Request, error) {
 	url := c.getPath(path, version)

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -51,7 +51,7 @@ var HTTPConflictError = errors.New(evergreen.TaskConflict)
 
 // AuthError is a special error when the CLI receives 401 Unauthorized to
 // suggest logging in again as a possible solution to the error.
-var AuthError = errors.New("401 Unauthorized: User credentials are likely expired, try logging into the website again.")
+var AuthError = errors.New("401 Unauthorized: User credentials are likely expired, try logging in again via the Evergreen web UI.")
 
 func (c *communicatorImpl) newRequest(method, path, taskID, taskSecret, version string, data interface{}) (*http.Request, error) {
 	url := c.getPath(path, version)

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -59,6 +59,9 @@ func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, spawnRequest *mo
 
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "spawning host")
 	}
@@ -86,6 +89,9 @@ func (c *communicatorImpl) GetSpawnHost(ctx context.Context, hostId string) (*mo
 
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "getting host '%s'", hostId)
 	}
@@ -112,6 +118,9 @@ func (c *communicatorImpl) ModifySpawnHost(ctx context.Context, hostID string, c
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "modifying host '%s'", hostID)
 	}
@@ -136,6 +145,9 @@ func (c *communicatorImpl) StopSpawnHost(ctx context.Context, hostID string, sub
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "stopping host '%s'", hostID)
 	}
@@ -160,6 +172,9 @@ func (c *communicatorImpl) AttachVolume(ctx context.Context, hostID string, opts
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "attaching volume to host '%s'", hostID)
 	}
@@ -183,6 +198,9 @@ func (c *communicatorImpl) DetachVolume(ctx context.Context, hostID, volumeID st
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "detaching volume '%s' from host '%s'", volumeID, hostID)
 	}
@@ -203,6 +221,9 @@ func (c *communicatorImpl) CreateVolume(ctx context.Context, volume *host.Volume
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "creating volume")
 	}
@@ -227,6 +248,9 @@ func (c *communicatorImpl) DeleteVolume(ctx context.Context, volumeID string) er
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "deleting volume '%s'", volumeID)
 	}
@@ -246,6 +270,9 @@ func (c *communicatorImpl) ModifyVolume(ctx context.Context, volumeID string, op
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "modifying volume '%s'", volumeID)
 	}
@@ -266,6 +293,9 @@ func (c *communicatorImpl) GetVolume(ctx context.Context, volumeID string) (*mod
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "getting volume '%s'", volumeID)
 	}
@@ -291,6 +321,9 @@ func (c *communicatorImpl) GetVolumesByUser(ctx context.Context) ([]model.APIVol
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "getting volumes for user '%s'", c.apiUser)
 	}
@@ -320,6 +353,9 @@ func (c *communicatorImpl) StartSpawnHost(ctx context.Context, hostID string, su
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "starting host '%s'", hostID)
 	}
@@ -356,6 +392,9 @@ func (c *communicatorImpl) waitForStatus(ctx context.Context, hostID, status str
 				return errors.Wrap(err, "error sending request to get host info")
 			}
 			defer resp.Body.Close()
+			if resp.StatusCode == http.StatusUnauthorized {
+				return AuthError
+			}
 			if resp.StatusCode != http.StatusOK {
 				return respErrorf(resp, "getting host status")
 			}
@@ -383,6 +422,9 @@ func (c *communicatorImpl) TerminateSpawnHost(ctx context.Context, hostID string
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "terminating host '%s'", hostID)
 	}
@@ -405,6 +447,9 @@ func (c *communicatorImpl) ChangeSpawnHostPassword(ctx context.Context, hostID, 
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "changing RDP password on host '%s'", hostID)
 	}
@@ -427,6 +472,9 @@ func (c *communicatorImpl) ExtendSpawnHostExpiration(ctx context.Context, hostID
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "changing expiration of host '%s'", hostID)
 	}
@@ -447,6 +495,9 @@ func (c *communicatorImpl) GetHosts(ctx context.Context, data model.APIHostParam
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "getting hosts")
 	}
@@ -646,6 +697,9 @@ func (c *communicatorImpl) RevertSettings(ctx context.Context, guid string) erro
 		return errors.Wrap(err, "error reverting settings")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("error reverting %s", guid)
 	}
@@ -668,6 +722,9 @@ func (c *communicatorImpl) ExecuteOnDistro(ctx context.Context, distro string, o
 		return nil, errors.Wrap(err, "problem during request")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "running script on distro '%s'", distro)
 	}
@@ -712,6 +769,9 @@ func (c *communicatorImpl) GetCurrentUsersKeys(ctx context.Context) ([]model.API
 		return nil, errors.Wrap(err, "problem fetching keys list")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "getting key list")
 	}
@@ -742,6 +802,9 @@ func (c *communicatorImpl) AddPublicKey(ctx context.Context, keyName, keyValue s
 		return errors.Wrap(err, "problem reaching evergreen API server")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "adding key")
 	}
@@ -761,6 +824,9 @@ func (c *communicatorImpl) DeletePublicKey(ctx context.Context, keyName string) 
 		return errors.Wrap(err, "problem reaching evergreen API server")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "deleting key")
 	}
@@ -780,6 +846,9 @@ func (c *communicatorImpl) ListAliases(ctx context.Context, project string) ([]s
 		return nil, errors.Wrap(err, "problem querying api server")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Errorf("bad status from api server: %v", resp.StatusCode)
 	}
@@ -812,6 +881,9 @@ func (c *communicatorImpl) GetClientConfig(ctx context.Context) (*evergreen.Clie
 		return nil, errors.Wrap(err, "failed to fetch update manifest from server")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Errorf("expected 200 OK from server, got %s", http.StatusText(resp.StatusCode))
 	}
@@ -847,6 +919,9 @@ func (c *communicatorImpl) GetSubscriptions(ctx context.Context) ([]event.Subscr
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "getting subscriptions")
 	}
@@ -908,6 +983,9 @@ func (c *communicatorImpl) CreateVersionFromConfig(ctx context.Context, project,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "creating version from config")
 	}
@@ -932,6 +1010,9 @@ func (c *communicatorImpl) GetCommitQueue(ctx context.Context, projectID string)
 		return nil, errors.Wrap(err, "problem fetching commit queue list")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "fetching commit queue list")
 	}
@@ -978,6 +1059,9 @@ func (c *communicatorImpl) EnqueueItem(ctx context.Context, patchID string, enqu
 		return 0, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return 0, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return 0, respErrorf(resp, "enqueueing commit queue item")
 	}
@@ -1002,6 +1086,9 @@ func (c *communicatorImpl) SendNotification(ctx context.Context, notificationTyp
 		return errors.Wrapf(err, "problem sending slack notification")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return respErrorf(resp, "sending '%s' notification", notificationType)
 	}
@@ -1083,6 +1170,9 @@ func (c *communicatorImpl) GetManifestByTask(ctx context.Context, taskId string)
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "getting manifest for task '%s'", taskId)
 	}
@@ -1115,6 +1205,9 @@ func (c *communicatorImpl) StartHostProcesses(ctx context.Context, hostIDs []str
 			}
 			defer resp.Body.Close()
 
+			if resp.StatusCode == http.StatusUnauthorized {
+				return nil, AuthError
+			}
 			if resp.StatusCode != http.StatusOK {
 				return nil, respErrorf(resp, "running script on host")
 			}
@@ -1157,6 +1250,9 @@ func (c *communicatorImpl) GetHostProcessOutput(ctx context.Context, hostProcess
 			}
 			defer resp.Body.Close()
 
+			if resp.StatusCode == http.StatusUnauthorized {
+				return nil, AuthError
+			}
 			if resp.StatusCode != http.StatusOK {
 				return nil, respErrorf(resp, "running script on host")
 			}
@@ -1190,6 +1286,9 @@ func (c *communicatorImpl) GetTaskSyncReadCredentials(ctx context.Context) (*eve
 		return nil, errors.Wrap(err, "couldn't make request to get task read-only credentials")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "getting task read-only credentials")
 	}
@@ -1213,6 +1312,9 @@ func (c *communicatorImpl) GetTaskSyncPath(ctx context.Context, taskID string) (
 		return "", errors.Wrap(err, "couldn't make request to get task read-only credentials")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", AuthError
+	}
 	if resp.StatusCode != http.StatusOK {
 		return "", respErrorf(resp, "getting task sync path")
 	}

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -620,11 +620,10 @@ func (c *communicatorImpl) RestartRecentTasks(ctx context.Context, startAt, endA
 }
 
 func (c *communicatorImpl) GetSettings(ctx context.Context) (*evergreen.Settings, error) {
-	// kim: TODO: replace with GET admin/settings since that's the new route
 	info := requestInfo{
 		method:  get,
 		version: apiVersion2,
-		path:    "admin",
+		path:    "admin/settings",
 	}
 
 	resp, err := c.request(ctx, info, "")

--- a/rest/client/rest.go
+++ b/rest/client/rest.go
@@ -569,6 +569,7 @@ func (c *communicatorImpl) RestartRecentTasks(ctx context.Context, startAt, endA
 }
 
 func (c *communicatorImpl) GetSettings(ctx context.Context) (*evergreen.Settings, error) {
+	// kim: TODO: replace with GET admin/settings since that's the new route
 	info := requestInfo{
 		method:  get,
 		version: apiVersion2,

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -170,7 +170,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/users/{user_id}/permissions").Version(2).Post().Wrap(checkUser, editRoles).RouteHandler(makeModifyUserPermissions(sc, evergreen.GetEnvironment().RoleManager()))
 	app.AddRoute("/users/{user_id}/permissions").Version(2).Delete().Wrap(checkUser, editRoles).RouteHandler(makeDeleteUserPermissions(sc, evergreen.GetEnvironment().RoleManager()))
 	app.AddRoute("/users/{user_id}/roles").Version(2).Post().Wrap(checkUser, editRoles).RouteHandler(makeModifyUserRoles(sc, evergreen.GetEnvironment().RoleManager()))
-	app.AddRoute("/versions").Version(2).Put().RouteHandler(makeVersionCreateHandler(sc))
+	app.AddRoute("/versions").Version(2).Put().Wrap(checkUser).RouteHandler(makeVersionCreateHandler(sc))
 	app.AddRoute("/versions/{version_id}").Version(2).Get().Wrap(viewTasks).RouteHandler(makeGetVersionByID(sc))
 	app.AddRoute("/versions/{version_id}/abort").Version(2).Post().Wrap(checkUser, editTasks).RouteHandler(makeAbortVersion(sc))
 	app.AddRoute("/versions/{version_id}/builds").Version(2).Get().Wrap(viewTasks).RouteHandler(makeGetVersionBuilds(sc))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12603

The CLI authentication relies on the user having a valid refresh token from Okta to auth in with their API key. However, this token expires after 100 days, after which the CLI can return 401 Unauthorized without any additional context. The user can fix this by logging in again, which gets them a new Okta refresh token, so any REST requests made through the CLI suggest the re-login solution.

* Add login suggestion if a CLI request gets 401 Unauthorized.
* Drive-by fix `evergreen admin get-settings` because the request goes to the legacy settings and wouldn't actually give you the real settings.
* I opened [a ticket](https://jira.mongodb.org/browse/EVG-12632) for a problem in which `evergreen admin enable-service`/`disable-service` fetch empty service flags from the legacy admin settings route, which, if they were used, would unset all the service flags when the REST request is made to update the service flags.