### PR TITLE
EVG-12629: log out user if refresh token is expired

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -127,7 +127,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: 07fdffff5b8c8491ee70e9e25b1f89fe29c168de
   - name: github.com/evergreen-ci/gimlet
-    version: a2019f5a79f3361accef8315a991dd28467e3a08
+    version: d28831ee71d1d02871f7e6a1c94ec5387430218d
   - name: github.com/evergreen-ci/shrub
     version: c335f3500b4c16d51a43c21533d18fb9059af8c5
   - name: github.com/evergreen-ci/pail

--- a/units/reauthorization_job.go
+++ b/units/reauthorization_job.go
@@ -126,7 +126,7 @@ func (j *reauthorizationJob) Run(ctx context.Context) {
 	// This handles a special Okta case in which the user's refresh token from
 	// Okta has expired, in which case they should be logged out, so that they
 	// are forced to log in to get a new refresh token.
-	if err != nil && strings.Contains(err.Error(), "invalid_grant") {
+	if err != nil && strings.Contains(err.Error(), "invalid_grant") && strings.Contains(err.Error(), "The refresh token is invalid or expired.") {
 		grip.Debug(message.WrapError(err, message.Fields{
 			"message": "user's refresh token is invalid, logging them out",
 			"user":    j.UserID,

--- a/vendor/github.com/evergreen-ci/gimlet/CODEOWNERS
+++ b/vendor/github.com/evergreen-ci/gimlet/CODEOWNERS
@@ -1,1 +1,0 @@
-* @evergreen-ci/app-devs

--- a/vendor/github.com/evergreen-ci/gimlet/makefile
+++ b/vendor/github.com/evergreen-ci/gimlet/makefile
@@ -25,12 +25,10 @@ goEnv := GOPATH=$(gopath) $(if $(GO_BIN_PATH),PATH="$(shell dirname $(GO_BIN_PAT
 
 
 # start lint setup targets
-lintDeps := $(buildDir)/.lintSetup $(buildDir)/run-linter $(buildDir)/golangci-lint
-$(buildDir)/.lintSetup:$(buildDir)/golangci-lint
-	@touch $@
+lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:$(buildDir)
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.23.8 >/dev/null 2>&1
-$(buildDir)/run-linter:buildscripts/run-linter.go $(buildDir)/.lintSetup $(buildDir)
+	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.23.8 >/dev/null 2>&1
+$(buildDir)/run-linter:buildscripts/run-linter.go $(buildDir)/golangci-lint
 	@$(goEnv) $(gobin) build -o $@ $<
 # end lint setup targets
 
@@ -140,9 +138,9 @@ $(buildDir)/output.$(name).test: $(buildDir) .FORCE
 $(buildDir)/output.$(name).race: $(buildDir) .FORCE
 	$(goEnv) $(gobin) test $(testArgs) -race ./ | tee $@
 #  targets to generate gotest output from the linter.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter $(buildDir)/.lintSetup .FORCE
+$(buildDir)/output.%.lint:$(buildDir)/run-linter .FORCE
 	@$(goEnv) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
-$(buildDir)/output.lint:$(buildDir)/run-linter $(buildDir)/.lintSetup .FORCE
+$(buildDir)/output.lint:$(buildDir)/run-linter .FORCE
 	@$(goEnv) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$(packages)'
 # end test and coverage artifacts
 

--- a/vendor/github.com/evergreen-ci/gimlet/okta/okta_test.go
+++ b/vendor/github.com/evergreen-ci/gimlet/okta/okta_test.go
@@ -232,12 +232,12 @@ func (s *mockAuthorizationServer) root(rw http.ResponseWriter, r *http.Request) 
 func (s *mockAuthorizationServer) authorize(rw http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		gimlet.WriteJSONError(rw, &tokenResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &tokenResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.AuthorizeParameters, err = url.ParseQuery(string(body))
 	if err != nil {
-		gimlet.WriteJSONError(rw, &tokenResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &tokenResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.AuthorizeHeaders = r.Header
@@ -250,12 +250,12 @@ func (s *mockAuthorizationServer) authorize(rw http.ResponseWriter, r *http.Requ
 func (s *mockAuthorizationServer) token(rw http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		gimlet.WriteJSONError(rw, &tokenResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &tokenResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.TokenParameters, err = url.ParseQuery(string(body))
 	if err != nil {
-		gimlet.WriteJSONError(rw, &tokenResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &tokenResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.TokenHeaders = r.Header
@@ -278,12 +278,12 @@ func (s *mockAuthorizationServer) userinfo(rw http.ResponseWriter, r *http.Reque
 func (s *mockAuthorizationServer) introspect(rw http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		gimlet.WriteJSONError(rw, &introspectResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &introspectResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.IntrospectParameters, err = url.ParseQuery(string(body))
 	if err != nil {
-		gimlet.WriteJSONError(rw, &introspectResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &introspectResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.IntrospectHeaders = r.Header
@@ -321,25 +321,27 @@ func TestRequestHelpers(t *testing.T) {
 			userInfo, err := um.getUserInfo(ctx, "access_token")
 			require.NoError(t, err)
 			mapContains(t, s.UserInfoHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Authorization": []string{"Bearer access_token"},
+				"Accept":        {"application/json"},
+				"Authorization": {"Bearer access_token"},
 			})
 			require.NotNil(t, userInfo)
 			assert.Equal(t, *s.UserInfoResponse, *userInfo)
 		},
 		"GetUserInfoError": func(ctx context.Context, t *testing.T, um *userManager, s *mockAuthorizationServer) {
 			s.UserInfoResponse = &userInfoResponse{
-				Name:             "name",
-				Email:            "email",
-				Groups:           []string{"group"},
-				ErrorCode:        "error_code",
-				ErrorDescription: "error_description",
+				Name:   "name",
+				Email:  "email",
+				Groups: []string{"group"},
+				responseError: responseError{
+					ErrorCode:        "error_code",
+					ErrorDescription: "error_description",
+				},
 			}
 			userInfo, err := um.getUserInfo(ctx, "access_token")
 			assert.Error(t, err)
 			mapContains(t, s.UserInfoHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Authorization": []string{"Bearer access_token"},
+				"Accept":        {"application/json"},
+				"Authorization": {"Bearer access_token"},
 			})
 			require.NotNil(t, userInfo)
 			assert.Equal(t, *s.UserInfoResponse, *userInfo)
@@ -357,41 +359,43 @@ func TestRequestHelpers(t *testing.T) {
 			tokens, err := um.exchangeCodeForTokens(ctx, code)
 			require.NoError(t, err)
 			mapContains(t, s.TokenHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Content-Type":  []string{"application/x-www-form-urlencoded"},
-				"Authorization": []string{"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", um.clientID, um.clientSecret)))},
+				"Accept":        {"application/json"},
+				"Content-Type":  {"application/x-www-form-urlencoded"},
+				"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", um.clientID, um.clientSecret)))},
 			})
 			mapContains(t, s.TokenParameters, map[string][]string{
-				"grant_type":   []string{"authorization_code"},
-				"code":         []string{code},
-				"redirect_uri": []string{um.redirectURI},
+				"grant_type":   {"authorization_code"},
+				"code":         {code},
+				"redirect_uri": {um.redirectURI},
 			})
 			require.NotNil(t, tokens)
 			assert.Equal(t, *s.TokenResponse, *tokens)
 		},
 		"ExchangeCodeForTokensError": func(ctx context.Context, t *testing.T, um *userManager, s *mockAuthorizationServer) {
 			s.TokenResponse = &tokenResponse{
-				AccessToken:      "access_token",
-				IDToken:          "id_token",
-				RefreshToken:     "refresh_token",
-				TokenType:        "token_type",
-				ExpiresIn:        3600,
-				Scope:            "scope",
-				ErrorCode:        "error_code",
-				ErrorDescription: "error_description",
+				AccessToken:  "access_token",
+				IDToken:      "id_token",
+				RefreshToken: "refresh_token",
+				TokenType:    "token_type",
+				ExpiresIn:    3600,
+				Scope:        "scope",
+				responseError: responseError{
+					ErrorCode:        "error_code",
+					ErrorDescription: "error_description",
+				},
 			}
 			code := "some_code"
 			tokens, err := um.exchangeCodeForTokens(ctx, code)
 			assert.Error(t, err)
 			mapContains(t, s.TokenHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Content-Type":  []string{"application/x-www-form-urlencoded"},
-				"Authorization": []string{"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", um.clientID, um.clientSecret)))},
+				"Accept":        {"application/json"},
+				"Content-Type":  {"application/x-www-form-urlencoded"},
+				"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", um.clientID, um.clientSecret)))},
 			})
 			mapContains(t, s.TokenParameters, map[string][]string{
-				"grant_type":   []string{"authorization_code"},
-				"code":         []string{code},
-				"redirect_uri": []string{um.redirectURI},
+				"grant_type":   {"authorization_code"},
+				"code":         {code},
+				"redirect_uri": {um.redirectURI},
 			})
 			require.NotNil(t, tokens)
 			assert.Equal(t, *s.TokenResponse, *tokens)
@@ -744,12 +748,6 @@ func TestClearUser(t *testing.T) {
 				assert.Error(t, err)
 			}
 		})
-	}
-}
-
-func mapContainsKeys(t *testing.T, set map[string]string, subset []string) {
-	for _, name := range subset {
-		assert.Contains(t, set, name)
 	}
 }
 
@@ -1122,22 +1120,25 @@ func TestReauthorization(t *testing.T) {
 			_, err = um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 
-			s.IntrospectResponse = &introspectResponse{Active: true}
+			s.IntrospectResponse = &introspectResponse{
+				Active:      true,
+				ExpiresUnix: int(time.Now().Add(time.Hour).Unix()),
+			}
 			s.UserInfoResponse = &userInfoResponse{Name: "foo", Email: "foo@bar.com", Groups: []string{um.userGroup}}
 
 			require.NoError(t, um.ReauthorizeUser(user))
 
 			mapContains(t, s.IntrospectParameters, map[string][]string{
-				"token":           []string{accessToken},
-				"token_type_hint": []string{"access_token"},
+				"token":           {accessToken},
+				"token_type_hint": {"access_token"},
 			})
 			mapContains(t, s.IntrospectHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
 			})
 			mapContains(t, s.UserInfoHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Authorization": []string{"Bearer " + accessToken},
+				"Accept":        {"application/json"},
+				"Authorization": {"Bearer " + accessToken},
 			})
 			assert.Empty(t, s.TokenParameters, "reauthorization should succeed without requesting new tokens")
 			assert.Empty(t, s.TokenHeaders, "reauthorization should succeed without requesting new tokens")
@@ -1167,7 +1168,10 @@ func TestReauthorization(t *testing.T) {
 				}, nil
 			}
 
-			s.IntrospectResponse = &introspectResponse{Active: true}
+			s.IntrospectResponse = &introspectResponse{
+				Active:      true,
+				ExpiresUnix: int(time.Now().Add(time.Hour).Unix()),
+			}
 			s.UserInfoResponse = &userInfoResponse{Name: "foo", Email: "foo@bar.com", Groups: []string{um.userGroup}}
 			s.TokenResponse = &tokenResponse{
 				AccessToken:  newAccessToken,
@@ -1181,16 +1185,16 @@ func TestReauthorization(t *testing.T) {
 			require.NoError(t, um.ReauthorizeUser(user))
 
 			mapContains(t, s.TokenParameters, map[string][]string{
-				"grant_type":    []string{"refresh_token"},
-				"refresh_token": []string{refreshToken},
-				"scope":         []string{"openid email profile offline_access groups"},
+				"grant_type":    {"refresh_token"},
+				"refresh_token": {refreshToken},
+				"scope":         {"openid email profile offline_access groups"},
 			})
 			mapContains(t, s.TokenHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
 			})
-			assert.Empty(t, s.IntrospectParameters, "should not check access token if not validating groups")
-			assert.Empty(t, s.IntrospectHeaders, "should not check access token if not validating groups")
+			assert.Empty(t, s.IntrospectParameters, "should not introspect access token if not validating groups")
+			assert.Empty(t, s.IntrospectHeaders, "should not introspect access token if not validating groups")
 			assert.Empty(t, s.UserInfoHeaders, "should not get user info if not validating groups")
 
 			cachedUser, _, err := um.cache.Find(user.Username())
@@ -1223,7 +1227,7 @@ func TestReauthorization(t *testing.T) {
 			assert.Empty(t, s.IntrospectParameters, "should not check access token if not validating groups")
 			assert.Empty(t, s.UserInfoHeaders, "should not get user info if not validating groups")
 		},
-		"FailsIfAccessTokenExpiredAndTokensCannotRefresh": func(t *testing.T, um *userManager, s *mockAuthorizationServer) {
+		"FailsIfAccessTokenAndTokensCannotRefresh": func(t *testing.T, um *userManager, s *mockAuthorizationServer) {
 			um.validateGroups = true
 
 			accessToken := "access_token"
@@ -1235,30 +1239,26 @@ func TestReauthorization(t *testing.T) {
 			_, err = um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 
-			s.IntrospectResponse = &introspectResponse{Active: false}
+			s.IntrospectResponse = &introspectResponse{
+				Active:      false,
+				ExpiresUnix: int(time.Now().Add(-time.Hour).Unix()),
+			}
 			s.TokenResponse = &tokenResponse{
-				ErrorCode:        "error",
-				ErrorDescription: "error_description",
+				responseError: responseError{
+					ErrorCode:        "error",
+					ErrorDescription: "error_description",
+				},
 			}
 
 			assert.Error(t, um.ReauthorizeUser(user))
 
 			mapContains(t, s.IntrospectParameters, map[string][]string{
-				"token":           []string{accessToken},
-				"token_type_hint": []string{"access_token"},
+				"token":           {accessToken},
+				"token_type_hint": {"access_token"},
 			})
 			mapContains(t, s.IntrospectHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
-			})
-			mapContains(t, s.TokenParameters, map[string][]string{
-				"grant_type":    []string{"refresh_token"},
-				"refresh_token": []string{refreshToken},
-				"scope":         []string{"openid email profile offline_access groups"},
-			})
-			mapContains(t, s.TokenHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
 			})
 			assert.Empty(t, s.UserInfoHeaders)
 
@@ -1272,7 +1272,10 @@ func TestReauthorization(t *testing.T) {
 			accessToken := "access_token"
 			refreshToken := "refresh_token"
 			newAccessToken := "new_access_token"
-			s.IntrospectResponse = &introspectResponse{Active: true}
+			s.IntrospectResponse = &introspectResponse{
+				Active:      true,
+				ExpiresUnix: int(time.Now().Add(time.Hour).Unix()),
+			}
 			s.TokenResponse = &tokenResponse{
 				AccessToken:  newAccessToken,
 				IDToken:      "new_id_token",
@@ -1291,25 +1294,25 @@ func TestReauthorization(t *testing.T) {
 			assert.Error(t, um.ReauthorizeUser(user))
 
 			mapContains(t, s.IntrospectParameters, map[string][]string{
-				"token":           []string{newAccessToken},
-				"token_type_hint": []string{"access_token"},
+				"token":           {newAccessToken},
+				"token_type_hint": {"access_token"},
 			})
 			mapContains(t, s.IntrospectHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
 			})
 			mapContains(t, s.TokenParameters, map[string][]string{
-				"grant_type":    []string{"refresh_token"},
-				"refresh_token": []string{refreshToken},
-				"scope":         []string{"openid email profile offline_access groups"},
+				"grant_type":    {"refresh_token"},
+				"refresh_token": {refreshToken},
+				"scope":         {"openid email profile offline_access groups"},
 			})
 			mapContains(t, s.TokenHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
 			})
 			mapContains(t, s.UserInfoHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Authorization": []string{"Bearer " + newAccessToken},
+				"Accept":        {"application/json"},
+				"Authorization": {"Bearer " + newAccessToken},
 			})
 
 			cachedUser, _, err := um.cache.Find(user.Username())


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12629

If the background reauth job sees that the refresh token is invalid, log out the user to force them to log back in. This fixes a problem where the user may remain logged into the UI but their CLI will not be able to auth because their refresh token expired. The solution to the expired token is to log in again.

Note that because the tokens we get are only valid for 100 days, it means that people's login sessions are also capped at 100 days before they have to log in again.