### PR TITLE
EVG-7913 error on go test build failures

### DIFF
--- a/command/results_gotest_parser.go
+++ b/command/results_gotest_parser.go
@@ -32,7 +32,7 @@ var (
 	gocheckEndRegex = regexp.MustCompile(`(PASS|SKIP|FAIL): .*.go:[0-9]+: (\S+)\s*([0-9\.m]+[ ]*s)?`)
 
 	// Match the failing status prefix for go build.
-	goTestFailedStatusRegex = regexp.MustCompile(`FAIL[^:]\s+(\S+) .*`)
+	goTestFailedStatusRegex = regexp.MustCompile(`FAIL\s+(\S+)\s+\[build failed\]`)
 )
 
 // This test result implementation maps more idiomatically to Go's test output

--- a/command/results_gotest_parser_test.go
+++ b/command/results_gotest_parser_test.go
@@ -62,6 +62,16 @@ func TestParserRegex(t *testing.T) {
 				So(status, ShouldEqual, PASS)
 				So(dur, ShouldEqual, time.Duration(900)*time.Millisecond)
 			})
+			Convey("go test build lines", func() {
+				path, err := pathNameFromLogLine(
+					"FAIL   github.go/evergreen-ci/evergreen/model/patch.go [build failed]")
+				So(err, ShouldBeNil)
+				So(path, ShouldEqual, "github.go/evergreen-ci/evergreen/model/patch.go")
+
+				_, err = pathNameFromLogLine(
+					"ok     github.go/evergreen-ci/evergreen/model/patch.go 2.47s")
+				So(err, ShouldNotBeNil)
+			})
 		})
 	})
 
@@ -212,5 +222,14 @@ func TestParserFunctionality(t *testing.T) {
 			So(outcome, ShouldBeTrue)
 
 		}
+	})
+
+	Convey("gotest log with failed build", t, func() {
+		logdata, err := ioutil.ReadFile(filepath.Join(cwd, "testdata", "gotest", "8_simple.log"))
+		So(err, ShouldBeNil)
+
+		parser := &goTestParser{}
+		err = parser.Parse(bytes.NewBuffer(logdata))
+		So(err, ShouldNotBeNil)
 	})
 }

--- a/command/results_gotest_parser_test.go
+++ b/command/results_gotest_parser_test.go
@@ -231,5 +231,6 @@ func TestParserFunctionality(t *testing.T) {
 		parser := &goTestParser{}
 		err = parser.Parse(bytes.NewBuffer(logdata))
 		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "github.com/evergreen-ci/evergreen/model/host")
 	})
 }

--- a/command/results_gotest_parser_test.go
+++ b/command/results_gotest_parser_test.go
@@ -64,9 +64,18 @@ func TestParserRegex(t *testing.T) {
 			})
 			Convey("go test build lines", func() {
 				path, err := pathNameFromLogLine(
-					"FAIL   github.go/evergreen-ci/evergreen/model/patch.go [build failed]")
+					"FAIL   github.go/evergreen-ci/evergreen/model/patch.go     [build failed] ")
 				So(err, ShouldBeNil)
 				So(path, ShouldEqual, "github.go/evergreen-ci/evergreen/model/patch.go")
+
+				path, err = pathNameFromLogLine(
+					"FAIL github.go/evergreen-ci/evergreen/model/patch.go [build failed]")
+				So(err, ShouldBeNil)
+				So(path, ShouldEqual, "github.go/evergreen-ci/evergreen/model/patch.go")
+
+				_, err = pathNameFromLogLine(
+					"FAIL   github.go/evergreen-ci/evergreen/model/patch.go 2.47s")
+				So(err, ShouldNotBeNil)
 
 				_, err = pathNameFromLogLine(
 					"ok     github.go/evergreen-ci/evergreen/model/patch.go 2.47s")

--- a/command/testdata/gotest/8_simple.log
+++ b/command/testdata/gotest/8_simple.log
@@ -1,0 +1,10 @@
+=== RUN   TestClientSuite
+=== RUN   TestClientSuite/TestClientGetter
+=== RUN   TestClientSuite/TestCopyeConstructorUsesDifferentHTTPClient
+--- PASS: TestClientSuite (0.01s)
+    --- PASS: TestClientSuite/TestClientGetter (0.00s)
+    --- PASS: TestClientSuite/TestCopyeConstructorUsesDifferentHTTPClient (0.00s)
+ok      github.com/evergreen-ci/evergreen/model/patch	1.785s
+FAIL    github.com/evergreen-ci/evergreen/model/host  [build failed]
+
+PASS


### PR DESCRIPTION
Sometimes the go test build itself can fail and so we don't run tests, and our parser should catch this and fail the task (failing the command will fail the task).