### PR TITLE
EVG-8255: clear login cache when offboarding users

### DIFF
--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -446,12 +446,14 @@ func (ch *offboardUserHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(catcher.Resolve(), "not all unexpirable hosts/volumes terminated"))
 	}
 
-	if err := ch.clearLogin(); err != nil {
-		grip.Error(message.WrapError(err, message.Fields{
-			"message": "could not clear user's login cache",
-			"context": "user offboarding",
-			"user":    ch.user,
-		}))
+	if !ch.dryRun {
+		if err := ch.clearLogin(); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "could not clear user's login cache",
+				"context": "user offboarding",
+				"user":    ch.user,
+			}))
+		}
 	}
 
 	return gimlet.NewJSONResponse(toTerminate)

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/util"
@@ -447,7 +446,7 @@ func (ch *offboardUserHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(catcher.Resolve(), "not all unexpirable hosts/volumes terminated"))
 	}
 
-	if err := ch.clearLoginCache(); err != nil {
+	if err := ch.clearLogin(); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "could not clear user's login cache",
 			"context": "user offboarding",
@@ -458,8 +457,8 @@ func (ch *offboardUserHandler) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewJSONResponse(toTerminate)
 }
 
-// clearLoginCache invalidates the user's login session.
-func (ch *offboardUserHandler) clearLoginCache() error {
+// clearLogin invalidates the user's login session.
+func (ch *offboardUserHandler) clearLogin() error {
 	usrMngr := ch.env.UserManager()
 	if usrMngr == nil {
 		return errors.New("no user manager found in environment")
@@ -468,7 +467,7 @@ func (ch *offboardUserHandler) clearLoginCache() error {
 	if err != nil {
 		return errors.Wrap(err, "finding user")
 	}
-	return errors.Wrap(user.ClearLoginCache(usr, false), "clearing login cache")
+	return errors.Wrap(usrMngr.ClearUser(usr, false), "clearing login cache")
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -442,9 +443,11 @@ func (ch *offboardUserHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	if !ch.dryRun {
-		if err := ch.clearLogin(); err != nil {
-			catcher.Wrapf(err, "clearing user login cache")
-		}
+		grip.Error(message.WrapError(ch.clearLogin(), message.Fields{
+			"message": "could not clear login token",
+			"context": "user offboarding",
+			"user":    ch.user,
+		}))
 	}
 
 	if catcher.HasErrors() {

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
@@ -19,11 +18,8 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/evergreen-ci/gimlet/cached"
-	"github.com/evergreen-ci/gimlet/usercache"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/jasper/options"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -818,8 +814,7 @@ func getMockHostsConnector() *data.MockConnector {
 }
 
 func TestClearHostsHandler(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(host.Collection, host.VolumesCollection, user.Collection))
-
+	assert.NoError(t, db.ClearCollections(host.Collection, host.VolumesCollection))
 	h0 := host.Host{
 		Id:           "h0",
 		StartedBy:    "user0",
@@ -853,45 +848,11 @@ func TestClearHostsHandler(t *testing.T) {
 	assert.NoError(t, h1.Insert())
 	assert.NoError(t, h2.Insert())
 	assert.NoError(t, v1.Insert())
-
-	usr := &user.DBUser{
-		Id: "user0",
-		LoginCache: user.LoginCache{
-			Token: "token",
-		},
-	}
-	require.NoError(t, usr.Insert())
-
-	env := &mock.Environment{}
-	require.NoError(t, env.Configure(context.Background()))
-	opts := usercache.ExternalOptions{
-		PutUserGetToken: func(gimlet.User) (string, error) {
-			return "", errors.New("fail")
-		},
-		GetUserByToken: func(string) (gimlet.User, bool, error) {
-			return nil, false, errors.New("fail")
-		},
-		ClearUserToken: user.ClearLoginCache,
-		GetUserByID: func(id string) (gimlet.User, bool, error) {
-			return usr, true, nil
-		},
-		GetOrCreateUser: func(u gimlet.User) (gimlet.User, error) {
-			return nil, errors.New("fail")
-		},
-	}
-	cache, err := usercache.NewExternal(opts)
-	require.NoError(t, err)
-	um, err := cached.NewUserManager(cache)
-	require.NoError(t, err)
-	env.SetUserManager(um)
-
 	handler := offboardUserHandler{
-		env:    env,
 		sc:     &data.DBConnector{},
 		dryRun: true,
-		user:   usr.Id,
+		user:   "user0",
 	}
-
 	resp := handler.Run(gimlet.AttachUser(context.Background(), &user.DBUser{Id: "root"}))
 	require.Equal(t, http.StatusOK, resp.Status())
 	res, ok := resp.Data().(model.APIOffboardUserResults)
@@ -900,10 +861,6 @@ func TestClearHostsHandler(t *testing.T) {
 	assert.Equal(t, res.TerminatedHosts[0], "h1")
 	require.Len(t, res.TerminatedVolumes, 1)
 	assert.Equal(t, res.TerminatedVolumes[0], "v1")
-
-	dbUser, err := user.FindOneById(usr.Id)
-	assert.NoError(t, err)
-	assert.Zero(t, dbUser.LoginCache)
 }
 
 func TestHostFilterGetHandler(t *testing.T) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-8255

* Log out the user so that their login session is invalidated and the background reauth job doesn't attempt to auth the user.