### PR TITLE
EVG-12391 terminate spot instances

### DIFF
--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -458,17 +458,16 @@ func (hc *MockConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error) 
 
 func findHostByIdWithOwner(c Connector, hostID string, user gimlet.User) (*host.Host, error) {
 	host, err := c.FindHostById(hostID)
-	if host == nil {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("host with id '%s' not found", hostID),
-		}
-	}
-
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    "error fetching host information",
+		}
+	}
+	if host == nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("host with id '%s' not found", hostID),
 		}
 	}
 

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -65,12 +65,7 @@ func (hc *DBHostConnector) FindHostById(id string) (*host.Host, error) {
 	if err != nil {
 		return nil, err
 	}
-	if h == nil {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("host with id %s not found", id),
-		}
-	}
+
 	return h, nil
 }
 
@@ -295,10 +290,7 @@ func (hc *MockHostConnector) FindHostById(id string) (*host.Host, error) {
 			return &h, nil
 		}
 	}
-	return nil, gimlet.ErrorResponse{
-		StatusCode: http.StatusNotFound,
-		Message:    fmt.Sprintf("host with id %s not found", id),
-	}
+	return nil, nil
 }
 
 func (hc *MockHostConnector) FindHostsByDistro(distro string) ([]host.Host, error) {
@@ -467,7 +459,10 @@ func (hc *MockConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error) 
 func findHostByIdWithOwner(c Connector, hostID string, user gimlet.User) (*host.Host, error) {
 	host, err := c.FindHostById(hostID)
 	if host == nil {
-		return nil, err
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("host with id '%s' not found", hostID),
+		}
 	}
 
 	if err != nil {

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -199,7 +199,7 @@ func (s *HostConnectorSuite) TestFindByIdLast() {
 
 func (s *HostConnectorSuite) TestFindByIdFail() {
 	h, ok := s.ctx.FindHostById("nonexistent")
-	s.Error(ok)
+	s.NoError(ok)
 	s.Nil(h)
 }
 

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -153,7 +153,7 @@ func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instan
 		return nil
 	}
 
-	if h.Status != evergreen.HostRunning {
+	if h.Status == evergreen.HostTerminated {
 		return nil
 	}
 

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -171,7 +172,7 @@ func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instan
 // See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#billing-for-interrupted-spot-instances
 func skipEarlyTermination(h *host.Host) bool {
 	// Let AWS terminate if we're within the first hour
-	if time.Now().Sub(h.StartTime) < time.Hour {
+	if utility.IsZeroTime(h.StartTime) || time.Now().Sub(h.StartTime) < time.Hour {
 		return true
 	}
 

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -6,9 +6,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -19,23 +25,32 @@ const (
 	messageTypeSubscriptionConfirmation = "SubscriptionConfirmation"
 	messageTypeNotification             = "Notification"
 	messageTypeUnsubscribeConfirmation  = "UnsubscribeConfirmation"
+	interruptionWarningType             = "EC2 Spot Instance Interruption Warning"
+	instanceStateChangeType             = "EC2 Instance State-change Notification"
 )
 
 type awsSns struct {
-	sc          data.Connector
+	sc    data.Connector
+	queue amboy.Queue
+	env   evergreen.Environment
+
 	messageType string
 	payload     sns.Payload
 }
 
-func makeAwsSnsRoute(sc data.Connector) gimlet.RouteHandler {
+func makeAwsSnsRoute(sc data.Connector, env evergreen.Environment, queue amboy.Queue) gimlet.RouteHandler {
 	return &awsSns{
-		sc: sc,
+		sc:    sc,
+		env:   env,
+		queue: queue,
 	}
 }
 
 func (aws *awsSns) Factory() gimlet.RouteHandler {
 	return &awsSns{
-		sc: aws.sc,
+		sc:    aws.sc,
+		env:   aws.env,
+		queue: aws.queue,
 	}
 }
 
@@ -78,13 +93,7 @@ func (aws *awsSns) Run(ctx context.Context) gimlet.Responder {
 			"topic_arn":       aws.payload.TopicArn,
 		})
 	case messageTypeNotification:
-		// TODO: handle the message
-		grip.Info(message.Fields{
-			"message":         "got an AWS SNS notification",
-			"payload_subject": aws.payload.Subject,
-			"payload_message": aws.payload.Message,
-			"payload_topic":   aws.payload.TopicArn,
-		})
+		return aws.handleNotification(ctx)
 	default:
 		grip.Error(message.Fields{
 			"message":         "got an unknown message type",
@@ -97,4 +106,91 @@ func (aws *awsSns) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	return gimlet.NewJSONResponse(struct{}{})
+}
+
+type eventBridgeNotification struct {
+	DetailType string      `json:"detail-type"`
+	Detail     eventDetail `json:"detail"`
+}
+type eventDetail struct {
+	InstanceID string `json:"instance-id"`
+	State      string `json:"state"`
+}
+
+func (aws *awsSns) handleNotification(ctx context.Context) gimlet.Responder {
+	notification := &eventBridgeNotification{}
+	if err := json.Unmarshal([]byte(aws.payload.Message), notification); err != nil {
+		return gimlet.NewJSONErrorResponse(errors.Wrap(err, "problem unmarshalling notification"))
+	}
+
+	switch notification.DetailType {
+	case interruptionWarningType:
+		if err := aws.handleInstanceInterruptionWarning(ctx, notification.Detail.InstanceID); err != nil {
+			return gimlet.NewJSONErrorResponse(errors.Wrap(err, "problem processing interruption warning"))
+		}
+
+	case instanceStateChangeType:
+		if notification.Detail.State == ec2.InstanceStateNameTerminated {
+			if err := aws.handleInstanceTerminated(ctx, notification.Detail.InstanceID); err != nil {
+				return gimlet.NewJSONErrorResponse(errors.Wrap(err, "problem processing instance termination"))
+			}
+		}
+
+	default:
+		return gimlet.NewJSONErrorResponse(errors.Errorf("unknown detail type '%s'", notification.DetailType))
+	}
+
+	return gimlet.NewJSONResponse(struct{}{})
+}
+
+func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instanceID string) error {
+	h, err := aws.sc.FindHostById(instanceID)
+	if err != nil {
+		return err
+	}
+
+	if h.Status != evergreen.HostRunning {
+		return nil
+	}
+
+	if skipEarlyTermination(h) {
+		return nil
+	}
+
+	// return success on duplicate job errors so AWS won't keep retrying
+	_ = aws.queue.Put(ctx, units.NewHostTerminationJob(aws.env, h, true, "got interruption warning"))
+
+	return nil
+}
+
+// skipEarlyTermination decides if we should terminate the instance now or wait for AWS to do it.
+// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#billing-for-interrupted-spot-instances
+func skipEarlyTermination(h *host.Host) bool {
+	// Let AWS terminate if we're within the first hour
+	if time.Now().Sub(h.StartTime) < time.Hour {
+		return true
+	}
+
+	// Let AWS terminate Windows hosts themselves.
+	if h.Distro.IsWindows() {
+		return true
+	}
+
+	return false
+}
+
+func (aws *awsSns) handleInstanceTerminated(ctx context.Context, instanceID string) error {
+	h, err := aws.sc.FindHostById(instanceID)
+	if err != nil {
+		return err
+	}
+
+	if h.Status == evergreen.HostTerminated {
+		return nil
+	}
+
+	// return success on duplicate job errors so AWS won't keep retrying
+	_ = aws.queue.Put(ctx, units.NewHostMonitorExternalStateJob(aws.env, h, aws.payload.MessageId))
+
+	return nil
 }

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -23,11 +23,14 @@ import (
 )
 
 const (
+	// SNS message types
+	// See https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html#http-header
 	messageTypeSubscriptionConfirmation = "SubscriptionConfirmation"
 	messageTypeNotification             = "Notification"
 	messageTypeUnsubscribeConfirmation  = "UnsubscribeConfirmation"
-	interruptionWarningType             = "EC2 Spot Instance Interruption Warning"
-	instanceStateChangeType             = "EC2 Instance State-change Notification"
+
+	interruptionWarningType = "EC2 Spot Instance Interruption Warning"
+	instanceStateChangeType = "EC2 Instance State-change Notification"
 )
 
 type awsSns struct {

--- a/rest/route/aws_test.go
+++ b/rest/route/aws_test.go
@@ -2,14 +2,88 @@ package route
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/mongodb/amboy/queue"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
+	sns "github.com/robbiet480/go.sns"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAwsSnsRun(t *testing.T) {
 	aws := awsSns{messageType: "unknown"}
 	responder := aws.Run(context.Background())
 	assert.Equal(t, http.StatusBadRequest, responder.Status())
+
+	defer func(s send.Sender) {
+		assert.NoError(t, grip.SetSender(s))
+	}(grip.GetSender())
+
+	sender := send.MakeInternalLogger()
+	assert.NoError(t, grip.SetSender(sender))
+	aws.messageType = messageTypeSubscriptionConfirmation
+	responder = aws.Run(context.Background())
+	assert.Equal(t, http.StatusOK, responder.Status())
+	assert.True(t, sender.HasMessage())
+	m := sender.GetMessage()
+	assert.Equal(t, level.Alert, m.Priority)
+	assert.Equal(t, "got AWS SNS subscription confirmation. Visit subscribe_url to confirm", m.Message.Raw().(message.Fields)["message"])
+}
+
+func TestHandleNotification(t *testing.T) {
+	ctx := context.Background()
+
+	aws := awsSns{}
+	aws.queue = queue.NewLocalLimitedSize(1, 1)
+	require.NoError(t, aws.queue.Start(ctx))
+	aws.payload = sns.Payload{Message: `{"version":"0","id":"qwertyuiop","detail-type":"EC2 Instance State-change Notification","source":"aws.ec2","time":"2020-07-23T14:48:37Z","region":"us-east-1","resources":["arn:aws:ec2:us-east-1:1234567890:instance/i-0123456789"],"detail":{"instance-id":"i-0123456789","state":"terminated"}}`}
+
+	// unknown host
+	aws.sc = &data.MockConnector{}
+	response := aws.handleNotification(ctx)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, aws.queue.Stats(ctx).Total, 0)
+
+	// known host
+	aws.sc = &data.MockConnector{MockHostConnector: data.MockHostConnector{CachedHosts: []host.Host{{Id: "i-0123456789"}}}}
+	response = aws.handleNotification(ctx)
+	assert.Equal(t, http.StatusOK, response.Status())
+	require.Equal(t, 1, aws.queue.Stats(ctx).Total)
+	assert.True(t, strings.HasPrefix(aws.queue.Next(ctx).ID(), "host-monitoring-external-state-check"))
+}
+
+func TestHandlers(t *testing.T) {
+	ctx := context.Background()
+	hostID := "h0"
+	messageID := "m0"
+	aws := awsSns{}
+	aws.sc = &data.MockConnector{MockHostConnector: data.MockHostConnector{CachedHosts: []host.Host{{Id: hostID}}}}
+
+	for name, test := range map[string]func(*testing.T){
+		"InstanceInterruptionWarning": func(t *testing.T) {
+			aws.payload = sns.Payload{MessageId: messageID}
+			assert.NoError(t, aws.handleInstanceInterruptionWarning(ctx, hostID))
+			require.Equal(t, 1, aws.queue.Stats(ctx).Total)
+			assert.True(t, strings.HasPrefix(aws.queue.Next(ctx).ID(), fmt.Sprintf("host-termination-job.%s", hostID)))
+		},
+		"InstanceTerminated": func(t *testing.T) {
+			assert.NoError(t, aws.handleInstanceTerminated(ctx, hostID))
+			require.Equal(t, 1, aws.queue.Stats(ctx).Total)
+			assert.Equal(t, fmt.Sprintf("host-monitoring-external-state-check.%s.%s", hostID, messageID), aws.queue.Next(ctx).ID())
+		},
+	} {
+		aws.queue = queue.NewLocalLimitedSize(1, 1)
+		require.NoError(t, aws.queue.Start(ctx))
+
+		t.Run(name, test)
+	}
 }

--- a/rest/route/aws_test.go
+++ b/rest/route/aws_test.go
@@ -50,14 +50,12 @@ func TestHandleNotification(t *testing.T) {
 
 	// unknown host
 	aws.sc = &data.MockConnector{}
-	response := aws.handleNotification(ctx)
-	assert.Equal(t, http.StatusOK, response.Status())
+	assert.NoError(t, aws.handleNotification(ctx))
 	assert.Equal(t, aws.queue.Stats(ctx).Total, 0)
 
 	// known host
 	aws.sc = &data.MockConnector{MockHostConnector: data.MockHostConnector{CachedHosts: []host.Host{{Id: "i-0123456789"}}}}
-	response = aws.handleNotification(ctx)
-	assert.Equal(t, http.StatusOK, response.Status())
+	assert.NoError(t, aws.handleNotification(ctx))
 	require.Equal(t, 1, aws.queue.Stats(ctx).Total)
 	assert.True(t, strings.HasPrefix(aws.queue.Next(ctx).ID(), "host-monitoring-external-state-check"))
 }

--- a/rest/route/aws_test.go
+++ b/rest/route/aws_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/data"
@@ -66,7 +67,10 @@ func TestHandlers(t *testing.T) {
 	hostID := "h0"
 	messageID := "m0"
 	aws := awsSns{}
-	aws.sc = &data.MockConnector{MockHostConnector: data.MockHostConnector{CachedHosts: []host.Host{{Id: hostID}}}}
+	aws.payload.MessageId = messageID
+	aws.sc = &data.MockConnector{MockHostConnector: data.MockHostConnector{
+		CachedHosts: []host.Host{{Id: hostID, StartTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)}}},
+	}
 
 	for name, test := range map[string]func(*testing.T){
 		"InstanceInterruptionWarning": func(t *testing.T) {

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -152,6 +152,12 @@ func (high *hostIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for find() by distro id '%s'", high.hostID))
 	}
+	if foundHost == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("host with id '%s' not found", high.hostID),
+		})
+	}
 
 	hostModel := &model.APIHost{}
 	if err = hostModel.BuildFromService(*foundHost); err != nil {

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -197,6 +197,12 @@ func (m *TaskHostAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 	if err != nil {
 		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(err))
 	}
+	if h == nil {
+		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("host with id '%s' not found", hostID),
+		}))
+	}
 
 	if h.StartedBy == "" {
 		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -88,7 +88,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/distros/{distro_id}/icecream_config").Version(2).Patch().Wrap(editHosts).RouteHandler(makeDistroIcecreamConfig(sc, env))
 
 	app.AddRoute("/hooks/github").Version(2).Post().RouteHandler(makeGithubHooksRoute(sc, opts.APIQueue, opts.GithubSecret, settings))
-	app.AddRoute("/hooks/aws").Version(2).Post().RouteHandler(makeAwsSnsRoute(sc))
+	app.AddRoute("/hooks/aws").Version(2).Post().RouteHandler(makeAwsSnsRoute(sc, env, opts.APIQueue))
 	app.AddRoute("/host/filter").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchHostFilter(sc))
 	app.AddRoute("/host/start_processes").Version(2).Post().Wrap(checkUser).RouteHandler(makeHostStartProcesses(sc, env))
 	app.AddRoute("/host/get_processes").Version(2).Get().Wrap(checkUser).RouteHandler(makeHostGetProcesses(sc, env))


### PR DESCRIPTION
When we get a notification for a spot host about to be terminated enqueue a job to terminate it.
If we get a notification that a host that was already terminated and we didn't know about it enqueue a job to clean up the host.