### PR TITLE
EVG-11615 include original instance type in allowed list

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -203,7 +203,11 @@ func CreateVolume(ctx context.Context, env evergreen.Environment, volume *host.V
 // assumes distro already modified to have one region
 func CheckInstanceTypeValid(ctx context.Context, d distro.Distro, requestedType string, allowedTypes []string) error {
 	if !utility.StringSliceContains(allowedTypes, requestedType) {
-		return errors.New("This instance type has not been allowed by admins")
+		// if it's not in the settings list, check the distro
+		originalInstanceType, ok := d.ProviderSettingsList[0].Lookup("instance_type").StringValueOK()
+		if !ok || originalInstanceType != requestedType {
+			return errors.New("This instance type has not been allowed by admins")
+		}
 	}
 	env := evergreen.GetEnvironment()
 	opts, err := GetManagerOptions(d)

--- a/public/static/js/services/rest.js
+++ b/public/static/js/services/rest.js
@@ -266,11 +266,12 @@ mciServices.rest.factory('mciSpawnRestService', ['mciBaseRestService', function 
         baseSvc.getResource(resource, action, config, callbacks);
     };
 
-    service.getAllowedInstanceTypes = function (action, provider, params, callbacks) {
+    service.getAllowedInstanceTypes = function (action, provider, originalType, params, callbacks) {
         var config = {
             params: params
         }
         config.params['provider'] = provider
+        config.params['original_type'] = originalType,
         baseSvc.getResource(resource, action, config, callbacks);
     }
 

--- a/public/static/js/spawned_hosts.js
+++ b/public/static/js/spawned_hosts.js
@@ -145,7 +145,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
           error: function (resp) {
             // Avoid errors when leaving the page because of a background refresh
             if ($scope.hosts == null && !$scope.errorFetchingHosts) {
-              notificationService.pushNotification('Error fetching spawned hosts: ' + resp.data.error, 'errorHeader');
+              notificationService.pushNotification('Error fetching spawned hosts: ' + resp.data, 'errorHeader');
               $scope.errorFetchingHosts = true;
             }
           }
@@ -206,7 +206,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
           error: function (resp) {
             // Avoid errors when leaving the page because of a background refresh
             if ($scope.volumes == null && !$scope.errorFetchingVolumes) {
-              notificationService.pushNotification('Error fetching volumes: ' + resp.data.error, 'errorHeader');
+              notificationService.pushNotification('Error fetching volumes: ' + resp.data, 'errorHeader');
               $scope.errorFetchingVolumes = true;
             }
           }
@@ -387,7 +387,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
             }
           },
           error: function (resp) {
-            notificationService.pushNotification('Error fetching spawnable distros: ' + resp.data.error, 'errorHeader');
+            notificationService.pushNotification('Error fetching spawnable distros: ' + resp.data, 'errorHeader');
           }
         }
       );
@@ -395,12 +395,12 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
 
     $scope.fetchAllowedInstanceTypes = function () {
       mciSpawnRestService.getAllowedInstanceTypes(
-        'types', $scope.curHostData.host_type, {}, {
+        'types', $scope.curHostData.host_type, $scope.curHostData.distro.provider_settings[0].instance_type,{}, {
           success: function (resp) {
             $scope.allowedInstanceTypes = resp.data;
           },
           error: function (resp) {
-            notificationService.pushNotification('Error fetching allowed instance types: ' + resp.data.error, 'errorHeader')
+            notificationService.pushNotification('Error fetching allowed instance types: ' + resp.data, 'errorHeader')
           }
         }
       )
@@ -413,7 +413,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
             $scope.setUserKeys(resp.data);
           },
           error: function (resp) {
-            notificationService.pushNotification('Error fetching user keys: ' + resp.data.error, 'errorHeader');
+            notificationService.pushNotification('Error fetching user keys: ' + resp.data, 'errorHeader');
           }
         }
       );
@@ -426,7 +426,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
             host.originalDisplayName = host.display_name;
           },
           error: function (resp) {
-            notificationService.pushNotification('Error setting host display name: ' + resp.data.error, 'errorHeader');
+            notificationService.pushNotification('Error setting host display name: ' + resp.data, 'errorHeader');
           }
         }
       );
@@ -443,7 +443,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
             volume.originalDisplayName = volume.display_name;
           },
           error: function (resp) {
-            notificationService.pushNotification('Error setting volume display name: ' + resp.data.error, 'errorHeader');
+            notificationService.pushNotification('Error setting volume display name: ' + resp.data, 'errorHeader');
           }
         }
       );
@@ -529,7 +529,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
           },
           error: function (resp) {
             $scope.spawnReqSent = false;
-            notificationService.pushNotification('Error spawning host: ' + resp.data.error, 'errorHeader');
+            notificationService.pushNotification('Error spawning host: ' + resp.data, 'errorHeader');
           }
         }
       );
@@ -657,7 +657,7 @@ mciModule.controller('SpawnedHostsCtrl', ['$scope', '$window', '$timeout', '$q',
             $window.location.reload();
           },
           error: function (resp) {
-            notificationService.pushNotification('Error editing volume: ' + resp.data.error, 'errorHeader');
+            notificationService.pushNotification('Error editing volume: ' + resp.data, 'errorHeader');
           }
         }
       );

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -113,9 +113,14 @@ func (uis *UIServer) getUserPublicKeys(w http.ResponseWriter, r *http.Request) {
 
 func (uis *UIServer) getAllowedInstanceTypes(w http.ResponseWriter, r *http.Request) {
 	provider := r.FormValue("provider")
+	originalInstanceType := r.FormValue("original_type")
 	if len(provider) > 0 {
 		if cloud.IsEc2Provider(provider) {
-			gimlet.WriteJSON(w, uis.Settings.Providers.AWS.AllowedInstanceTypes)
+			allowedTypes := uis.Settings.Providers.AWS.AllowedInstanceTypes
+			if originalInstanceType != "" && !utility.StringSliceContains(allowedTypes, originalInstanceType) {
+				allowedTypes = append(allowedTypes, originalInstanceType)
+			}
+			gimlet.WriteJSON(w, allowedTypes)
 			return
 		}
 	}


### PR DESCRIPTION
If you look up the ticket, I was unable to replicate my issue, but I did use this as an opportunity to fix the "you can't change your instance type back to what it was" problem, as well as errors not displaying correctly because it always bothers me.

I chose to pass the instance type in from the UI since that's what we do with provider; if that seems messy I can just send hostID and get it from the other side instead, but I'd like to avoid processing the list in the javascript (especially since this will soon be legacy code anyway).