### PR TITLE
EVG-12681 fix for Apple's git

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,10 +29,10 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-07-24"
+	ClientVersion = "2020-07-28"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-07-23"
+	AgentVersion = "2020-07-28"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -679,7 +679,12 @@ func getGitConfigMetadata() (GitMetadata, error) {
 }
 
 func parseGitVersion(version string) (string, error) {
-	matches := regexp.MustCompile(`^git version (\d+(?:\.\d+)+)(?: \(Apple Git-\d+\))?$`).FindStringSubmatch(version)
+	matches := regexp.MustCompile(`^git version ` +
+		// capture the version major.minor(.patch(.build(.etc...)))
+		`(\d+(?:\.\d+)+)` +
+		// match and discard Apple git's addition to the version string
+		`(?: \(Apple Git-\d+\))?$`,
+	).FindStringSubmatch(version)
 	if len(matches) != 2 {
 		return "", errors.Errorf("can't parse git version number from version string '%s'", version)
 	}

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -670,13 +670,21 @@ func getGitConfigMetadata() (GitMetadata, error) {
 		return metadata, errors.Wrap(err, "can't get git version")
 	}
 	versionString = strings.TrimSpace(versionString)
-	matches := regexp.MustCompile(`^git version (\d+(\.\d+)+)$`).FindStringSubmatch(versionString)
-	if len(matches) < 2 {
-		return metadata, errors.Errorf("can't get git version number from version string '%s'", versionString)
+	metadata.GitVersion, err = parseGitVersion(versionString)
+	if err != nil {
+		return metadata, errors.Wrap(err, "can't get git version")
 	}
-	metadata.GitVersion = matches[1]
 
 	return metadata, nil
+}
+
+func parseGitVersion(version string) (string, error) {
+	matches := regexp.MustCompile(`^git version (\d+(?:\.\d+)+)(?: \(Apple Git-\d+\))?$`).FindStringSubmatch(version)
+	if len(matches) != 2 {
+		return "", errors.Errorf("can't parse git version number from version string '%s'", version)
+	}
+
+	return matches[1], nil
 }
 
 func gitCmd(cmdName string, gitArgs ...string) (string, error) {

--- a/operations/patch_util_test.go
+++ b/operations/patch_util_test.go
@@ -147,7 +147,7 @@ func (s *PatchUtilTestSuite) TestVariantsTasksFromCLI() {
 	s.Contains(pp.Tasks, "mytask2")
 }
 
-func (s *PatchUtilTestSuite) TestaddMetadataToDiff() {
+func (s *PatchUtilTestSuite) TestAddMetadataToDiff() {
 	metadata := GitMetadata{
 		Username:    "octocat",
 		Email:       "octocat@github.com",
@@ -175,6 +175,19 @@ operations/patch_util.go           |  17 ---
 --
 2.19.1
 `, mboxDiff)
+}
+
+func (s *PatchUtilTestSuite) TestParseGitVersionString() {
+	versionStrings := map[string]string{
+		"git version 2.19.1":                 "2.19.1",
+		"git version 2.24.3 (Apple Git-128)": "2.24.3",
+	}
+
+	for versionString, version := range versionStrings {
+		parsedVersion, err := parseGitVersion(versionString)
+		s.NoError(err)
+		s.Equal(version, parsedVersion)
+	}
 }
 
 func (s *PatchUtilTestSuite) TearDownSuite() {


### PR DESCRIPTION
The Apple version of git adds a string to the end of git's version string. 
1. Match the addition to the version string (`(Apple Git-128)`) in a non-capture group.
2. Use a non-capture group for the rest of the version number, so there's only one captured group.

At least we're [not alone](https://github.com/chef/chef/issues/6350)