### PR TITLE
EVG-12687 handle empty patches

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-07-28"
+	ClientVersion = "2020-07-29"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-07-28"

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -598,6 +598,10 @@ func gitUncommittedChanges() (bool, error) {
 }
 
 func diffToMbox(diffData *localDiff, subject string) (string, error) {
+	if len(diffData.fullPatch) == 0 {
+		return "", nil
+	}
+
 	metadata, err := getGitConfigMetadata()
 	if err != nil {
 		return "", errors.Wrap(err, "problem getting git metadata")


### PR DESCRIPTION
Another bug deriving from #3762: the app server expects empty patches to be the empty string, but we put mbox headers on every patch.
Catch the case of empty patches.