### PR TITLE
EVG-12681 really fix Apple git regexp

### DIFF
--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -687,7 +687,7 @@ func parseGitVersion(version string) (string, error) {
 		// capture the version major.minor(.patch(.build(.etc...)))
 		`(\d+(?:\.\d+)+)` +
 		// match and discard Apple git's addition to the version string
-		`(?: \(Apple Git-\d+\))?$`,
+		`(?: \(Apple Git-[\d\.]+\))?$`,
 	).FindStringSubmatch(version)
 	if len(matches) != 2 {
 		return "", errors.Errorf("can't parse git version number from version string '%s'", version)

--- a/operations/patch_util_test.go
+++ b/operations/patch_util_test.go
@@ -179,8 +179,9 @@ operations/patch_util.go           |  17 ---
 
 func (s *PatchUtilTestSuite) TestParseGitVersionString() {
 	versionStrings := map[string]string{
-		"git version 2.19.1":                 "2.19.1",
-		"git version 2.24.3 (Apple Git-128)": "2.24.3",
+		"git version 2.19.1":                   "2.19.1",
+		"git version 2.24.3 (Apple Git-128)":   "2.24.3",
+		"git version 2.21.1 (Apple Git-122.3)": "2.21.1",
 	}
 
 	for versionString, version := range versionStrings {


### PR DESCRIPTION
Fix for dots in Apple's version