### PR TITLE
EVG-12609 add logging for archive.targz_pack

### DIFF
--- a/command/archive_tarball_create.go
+++ b/command/archive_tarball_create.go
@@ -5,14 +5,13 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/mongodb/grip/recovery"
-
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/rest/client"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
 )
 

--- a/command/archive_tarball_create.go
+++ b/command/archive_tarball_create.go
@@ -80,6 +80,8 @@ func (c *tarballCreate) Execute(ctx context.Context,
 	go func() {
 		var err error
 		filesArchived, err = c.makeArchive(ctx, logger.Execution())
+		logger.Execution().Debugln("Finished making archive")
+
 		errChan <- errors.WithStack(err)
 	}()
 

--- a/util/artifacts_tar.go
+++ b/util/artifacts_tar.go
@@ -108,7 +108,7 @@ func BuildArchive(ctx context.Context, tarWriter *tar.Writer, rootPath string, i
 				return
 			}
 			if hdr.Size >= largeHeaderSize {
-				logger.Debugf("beginning copy for large file (header size %v)\n", hdr.Size)
+				logger.Debugf("beginning copy for large file '%s' (header size %v)\n", file.Path, hdr.Size)
 			}
 			amountWrote, err := io.Copy(tarWriter, in)
 			if err != nil {

--- a/util/artifacts_tar.go
+++ b/util/artifacts_tar.go
@@ -106,7 +106,7 @@ func BuildArchive(ctx context.Context, tarWriter *tar.Writer, rootPath string, i
 				errChan <- errors.Wrapf(err, "Error opening %v", file.Path)
 				return
 			}
-
+			logger.Debugf("Beginning copy (header size %v)\n", hdr.Size)
 			amountWrote, err := io.Copy(tarWriter, in)
 			if err != nil {
 				logger.Debug(in.Close())
@@ -121,6 +121,7 @@ func BuildArchive(ctx context.Context, tarWriter *tar.Writer, rootPath string, i
 					intarball, hdr.Size, amountWrote)
 				return
 			}
+			logger.Debugln("Finished adding to tarball")
 			logger.Debug(in.Close())
 			logger.Warning(tarWriter.Flush())
 		}

--- a/util/artifacts_tar.go
+++ b/util/artifacts_tar.go
@@ -20,7 +20,7 @@ import (
 // Returns the number of files that were added to the archive
 func BuildArchive(ctx context.Context, tarWriter *tar.Writer, rootPath string, includes []string,
 	excludes []string, logger grip.Journaler) (int, error) {
-
+	const largeHeaderSize = 1000000000.0 // for logging
 	pathsToAdd := streamArchiveContents(ctx, rootPath, includes, []string{})
 
 	numFilesArchived := 0
@@ -32,6 +32,7 @@ func BuildArchive(ctx context.Context, tarWriter *tar.Writer, rootPath string, i
 				"building archive")
 		}()
 		processed := map[string]bool{}
+		logger.Infof("beginning to build archive")
 	FileChanLoop:
 		for file := range inputChan {
 			if ctx.Err() != nil {
@@ -106,14 +107,18 @@ func BuildArchive(ctx context.Context, tarWriter *tar.Writer, rootPath string, i
 				errChan <- errors.Wrapf(err, "Error opening %v", file.Path)
 				return
 			}
-			logger.Debugf("Beginning copy (header size %v)\n", hdr.Size)
+			if hdr.Size >= largeHeaderSize {
+				logger.Debugf("beginning copy for large file (header size %v)\n", hdr.Size)
+			}
 			amountWrote, err := io.Copy(tarWriter, in)
 			if err != nil {
 				logger.Debug(in.Close())
 				errChan <- errors.Wrapf(err, "Error writing into tar for %v", file.Path)
 				return
 			}
-
+			if hdr.Size >= largeHeaderSize {
+				logger.Debugln("finished copy for large file")
+			}
 			if amountWrote != hdr.Size {
 				logger.Debug(in.Close())
 				errChan <- errors.Errorf(`Error writing to archive for %v:
@@ -121,7 +126,6 @@ func BuildArchive(ctx context.Context, tarWriter *tar.Writer, rootPath string, i
 					intarball, hdr.Size, amountWrote)
 				return
 			}
-			logger.Debugln("Finished adding to tarball")
 			logger.Debug(in.Close())
 			logger.Warning(tarWriter.Flush())
 		}


### PR DESCRIPTION
Hoping this logging will be enough to help us understand why tasks sometimes restart during this command.