### PR TITLE
EVG-9701 give user friendly error for bad config file

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-07-29"
+	ClientVersion = "2020-07-30"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-07-29"


### PR DESCRIPTION
This now returns "configuration file \`<bad_file>\` does not exist", instead of continuing on to unhelpful errors.