### PR TITLE
EVG-9703 fix merge-task dependencies

### DIFF
--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -359,7 +359,6 @@ func (j *commitQueueJob) processCLIPatchItem(ctx context.Context, cq *commitqueu
 		return
 	}
 
-	project.BuildProjectTVPairs(patchDoc, patchDoc.Alias)
 	if err = patchDoc.UpdateGithashProjectAndTasks(); err != nil {
 		j.logError(err, "can't update patch in db", nextItem)
 		j.dequeue(cq, nextItem)
@@ -607,18 +606,15 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 		Modules: modules,
 	}
 
-	// Merge task depends on all commit queue tasks matching the alias
-	// (protect against a user removing tasks from the patch)
-	execPairs, _, err := project.BuildProjectTVPairsWithAlias(evergreen.CommitQueueAlias)
-	if err != nil {
-		return errors.Wrap(err, "can't get alias pairs")
-	}
-	dependencies := make([]model.TaskUnitDependency, 0, len(execPairs))
-	for _, pair := range execPairs {
-		dependencies = append(dependencies, model.TaskUnitDependency{
-			Name:    pair.TaskName,
-			Variant: pair.Variant,
-		})
+	// Merge task depends on all the tasks already in the patch
+	dependencies := []model.TaskUnitDependency{}
+	for _, vt := range patchDoc.VariantsTasks {
+		for _, t := range vt.Tasks {
+			dependencies = append(dependencies, model.TaskUnitDependency{
+				Name:    t,
+				Variant: vt.Variant,
+			})
+		}
 	}
 
 	mergeTask := model.ProjectTask{
@@ -673,6 +669,10 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 	patchDoc.PatchedConfig = string(yamlBytes)
 	patchDoc.BuildVariants = append(patchDoc.BuildVariants, evergreen.MergeTaskVariant)
 	patchDoc.Tasks = append(patchDoc.Tasks, evergreen.MergeTaskName)
+	patchDoc.VariantsTasks = append(patchDoc.VariantsTasks, patch.VariantTasks{
+		Variant: evergreen.MergeTaskVariant,
+		Tasks:   []string{evergreen.MergeTaskName},
+	})
 
 	return nil
 }
@@ -750,10 +750,11 @@ func updatePatch(ctx context.Context, githubToken string, projectRef *model.Proj
 		patchDoc.Patches[i].Githash = *branch.Commit.SHA
 	}
 
-	// reset patch build variants and tasks
+	// rebuild patch build variants and tasks
 	patchDoc.BuildVariants = []string{}
 	patchDoc.VariantsTasks = []patch.VariantTasks{}
 	patchDoc.Tasks = []string{}
+	project.BuildProjectTVPairs(patchDoc, patchDoc.Alias)
 
 	return project, nil
 }


### PR DESCRIPTION
Previously, the commit queue added dependencies for the merge task for every task in the project that matched the commit queue alias. Some time ago a git_tag_only task was defined for the commit queue sandbox. Since it matched the alias, it was added as a dependency for the merge task. Subsequently, the dependency includer would remove the merge task from the patch, since it depended on a task that [wasn't able to be included in the patch](https://github.com/evergreen-ci/evergreen/blob/9fd979e10199588f0fe5109aed9f6419f9ddfb2d/model/patch_dependencies.go#L48).

The solution in this PR is to first figure out which tasks should be in the patch by rebuilding the lists of tasks/variants in `updatePatch`. Then the merge task is made to depend on whatever is actually in the patch.