### PR TITLE
EVG-12684 catch empty overrides

### DIFF
--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -547,11 +547,14 @@ func (m *ec2FleetManager) makeOverrides(ctx context.Context, ec2Settings *EC2Pro
 		return nil, errors.New("no AWS subnets were configured")
 	}
 
-	overrides := make([]*ec2.FleetLaunchTemplateOverridesRequest, 0, len(subnets))
 	supportingSubnets, err := typeCache.subnetsWithInstanceType(ctx, m.settings, m.client, ec2Settings.InstanceType, ec2Settings.getRegion())
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't get AZs supporting instance type '%s'", ec2Settings.InstanceType)
 	}
+	if len(supportingSubnets) == 0 {
+		return nil, nil
+	}
+	overrides := make([]*ec2.FleetLaunchTemplateOverridesRequest, 0, len(subnets))
 	for _, subnet := range supportingSubnets {
 		overrides = append(overrides, &ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String(subnet.SubnetID)})
 	}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -551,7 +551,7 @@ func (m *ec2FleetManager) makeOverrides(ctx context.Context, ec2Settings *EC2Pro
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't get AZs supporting instance type '%s'", ec2Settings.InstanceType)
 	}
-	if len(supportingSubnets) == 0 {
+	if len(supportingSubnets) == 0 || (len(supportingSubnets) == 1 && supportingSubnets[0].SubnetID == ec2Settings.SubnetId) {
 		return nil, nil
 	}
 	overrides := make([]*ec2.FleetLaunchTemplateOverridesRequest, 0, len(subnets))

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -112,6 +112,14 @@ func TestFleet(t *testing.T) {
 			overrides, err = m.makeOverrides(context.Background(), ec2Settings)
 			assert.NoError(t, err)
 			assert.Nil(t, overrides)
+
+			ec2Settings = &EC2ProviderSettings{
+				InstanceType: "instanceType0",
+				SubnetId:     "subnet-654321",
+			}
+			overrides, err = m.makeOverrides(context.Background(), ec2Settings)
+			assert.NoError(t, err)
+			assert.Nil(t, overrides)
 		},
 		"SubnetMatchesAz": func(*testing.T) {
 			subnet := &ec2.Subnet{

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -105,6 +105,13 @@ func TestFleet(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Len(t, overrides, 1)
 			assert.Equal(t, "subnet-654321", *overrides[0].SubnetId)
+
+			ec2Settings = &EC2ProviderSettings{
+				InstanceType: "not_supported",
+			}
+			overrides, err = m.makeOverrides(context.Background(), ec2Settings)
+			assert.NoError(t, err)
+			assert.Nil(t, overrides)
 		},
 		"SubnetMatchesAz": func(*testing.T) {
 			subnet := &ec2.Subnet{


### PR DESCRIPTION
If we have no overrides to make (i.e. no AZ supports the instance type) we need to pass a nil overrides slice instead of an empty one because AWS considers an empty overrides slice an invalid request.

Also if the only AZ that supports this instance type is already supplied in the launch template (i.e. only one AZ supports the instance type) we should skip making overrides.