### PR TITLE
EVG-8325 skip codegen tests on race detector

### DIFF
--- a/rest/model/codegen_test.go
+++ b/rest/model/codegen_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestCodegen(t *testing.T) {
+	if os.Getenv("RACE_DETECTOR") != "" {
+		t.Skip()
+		return
+	}
 	configFile, err := ioutil.ReadFile("testdata/schema/config.yml")
 	require.NoError(t, err)
 	var gqlConfig config.Config


### PR DESCRIPTION
I had investigated this previously and didn't turn up anything, so I'm just adding the skip to this test as well. For whatever reason, having the race detector enabled makes this test unable to resolve packages within our own repo. The code doesn't currently have any concurrency features and I don't plan on using them, so I'm not concerned about skipping the test