### PR TITLE
EVG-12554 handle aliases before creating tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -597,6 +597,10 @@ type BuildCreateArgs struct {
 // from the corresponding version and project and a list of tasks. Note that the caller
 // is responsible for inserting the created build and task documents
 func CreateBuildFromVersionNoInsert(args BuildCreateArgs) (*build.Build, task.Tasks, error) {
+	// avoid adding all tasks in the case of no tasks matching aliases
+	if len(args.Aliases) > 0 && len(args.TaskNames) == 0 {
+		return nil, nil, nil
+	}
 	// find the build variant for this project/build
 	buildVariant := args.Project.FindBuildVariant(args.BuildName)
 	if buildVariant == nil {
@@ -653,10 +657,6 @@ func CreateBuildFromVersionNoInsert(args BuildCreateArgs) (*build.Build, task.Ta
 	}
 	b.BuildNumber = strconv.FormatUint(buildNumber, 10)
 
-	// no tasks available for build
-	if len(args.Aliases) > 0 && len(args.TaskNames) == 0 {
-		return b, nil, nil
-	}
 	// create all of the necessary tasks for the build
 	tasksForBuild, err := createTasksForBuild(&args.Project, buildVariant, b, &args.Version, args.TaskIDs, args.TaskNames,
 		args.DisplayNames, args.GeneratedBy, nil, args.SyncAtEndOpts, args.DistroAliases, args.TaskCreateTime)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -311,6 +311,9 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if projectRef == nil {
+		return nil, errors.Errorf("project '%s' doesn't exist", p.Project)
+	}
 
 	githubCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1065,7 +1065,7 @@ func TestBlocked(t *testing.T) {
 					{TaskId: "t2", Status: evergreen.TaskSucceeded, Unattainable: true},
 				},
 			}
-			state, err := t1.BlockedState()
+			state, err := t1.BlockedState(map[string]*Task{})
 			assert.NoError(t, err)
 			assert.Equal(t, evergreen.TaskStatusBlocked, state)
 		},
@@ -1081,8 +1081,8 @@ func TestBlocked(t *testing.T) {
 				Status: evergreen.TaskDispatched,
 			}
 			require.NoError(t, t2.Insert())
-
-			state, err := t1.BlockedState()
+			dependencies := map[string]*Task{t2.Id: &t2}
+			state, err := t1.BlockedState(dependencies)
 			assert.NoError(t, err)
 			assert.Equal(t, evergreen.TaskStatusPending, state)
 		},
@@ -1101,8 +1101,8 @@ func TestBlocked(t *testing.T) {
 				},
 			}
 			require.NoError(t, t2.Insert())
-
-			state, err := t1.BlockedState()
+			dependencies := map[string]*Task{t2.Id: &t2}
+			state, err := t1.BlockedState(dependencies)
 			assert.NoError(t, err)
 			assert.Equal(t, "", state)
 		},
@@ -1182,7 +1182,12 @@ func TestSiblingDependency(t *testing.T) {
 		Status:      evergreen.TaskSucceeded,
 	}
 	assert.NoError(t4.Insert())
-	state, err := t1.BlockedState()
+	dependencies := map[string]*Task{
+		"t2": &t2,
+		"t3": &t3,
+		"t4": &t4,
+	}
+	state, err := t1.BlockedState(dependencies)
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskStatusPending, state)
 }

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -768,6 +768,8 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 	// create all builds for the version
 	buildsToCreate := []interface{}{}
 	tasksToCreate := task.Tasks{}
+	pairsToCreate := model.TVPairSet{}
+	// build all pairsToCreate before creating builds, to handle dependencies (if applicaable)
 	for _, buildvariant := range projectInfo.Project.BuildVariants {
 		if ctx.Err() != nil {
 			return errors.Wrapf(err, "aborting version creation for version %s", v.Id)
@@ -788,11 +790,36 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			if !match {
 				continue
 			}
+			for _, t := range buildvariant.Tasks {
+				match, err := aliases.HasMatchingTask(buildvariant.Name, buildvariant.Tags, projectInfo.Project.FindProjectTask(t.Name))
+				if err != nil {
+					grip.Error(message.WrapError(err, message.Fields{
+						"message": "error creating tasks with alias filter",
+						"task":    t.Name,
+						"project": projectInfo.Project.Identifier,
+						"alias":   aliases,
+					}))
+					continue
+				}
+				if match {
+					pairsToCreate = append(pairsToCreate, model.TVPair{Variant: buildvariant.Name, TaskName: t.Name})
+				}
+			}
+			pairsToCreate = model.IncludePatchDependencies(projectInfo.Project, pairsToCreate)
+		}
+	}
+
+	for _, buildvariant := range projectInfo.Project.BuildVariants {
+		taskNames := pairsToCreate.TaskNames(buildvariant.Name)
+		if len(aliases) > 0 && len(taskNames) == 0 {
+			// avoid adding all tasks in the case of no tasks matching aliases
+			continue
 		}
 		args := model.BuildCreateArgs{
 			Project:        *projectInfo.Project,
 			Version:        *v,
 			TaskIDs:        taskIds,
+			TaskNames:      taskNames,
 			BuildName:      buildvariant.Name,
 			Activated:      false,
 			SourceRev:      sourceRev,

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -794,7 +794,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 				match, err := aliases.HasMatchingTask(buildvariant.Name, buildvariant.Tags, projectInfo.Project.FindProjectTask(t.Name))
 				if err != nil {
 					grip.Error(message.WrapError(err, message.Fields{
-						"message": "error creating tasks with alias filter",
+						"message": "error finding tasks with alias filter",
 						"task":    t.Name,
 						"project": projectInfo.Project.Identifier,
 						"alias":   aliases,
@@ -811,10 +811,6 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 
 	for _, buildvariant := range projectInfo.Project.BuildVariants {
 		taskNames := pairsToCreate.TaskNames(buildvariant.Name)
-		if len(aliases) > 0 && len(taskNames) == 0 {
-			// avoid adding all tasks in the case of no tasks matching aliases
-			continue
-		}
 		args := model.BuildCreateArgs{
 			Project:        *projectInfo.Project,
 			Version:        *v,

--- a/service/task.go
+++ b/service/task.go
@@ -528,7 +528,7 @@ func getTaskDependencies(t *task.Task) ([]uiDep, string, error) {
 	if err = t.CircularDependencies(); err != nil {
 		return nil, "", err
 	}
-	state, err := t.BlockedState()
+	state, err := t.BlockedState(taskMap)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "can't get blocked state")
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -213,6 +213,9 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	if err != nil {
 		return errors.Wrap(err, "can't find patch project")
 	}
+	if pref == nil {
+		return errors.Errorf("patch project '%s' doesn't exist", patchDoc.Project)
+	}
 
 	if !pref.Enabled {
 		j.gitHubError = ProjectDisabled


### PR DESCRIPTION
Because in `createTasksForBuild` we strictly match on alias, we filter out any dependencies that don't match the alias. Some functions that call this already add dependencies to the list of taskNames, but some don't seem to so I added `IncludePatchDependencies`. 

I also snuck in a performance fix for BlockedState, because this individually finds each of the tasks dependencies, but getTaskDependencies already gets all of these in one statement so we can just use that.