### PR TITLE
EVG-12614 support list of json

### DIFF
--- a/cmd/scrambled-eggs/scramble.py
+++ b/cmd/scrambled-eggs/scramble.py
@@ -7,20 +7,32 @@ def main():
     '''takes a json file as input and destructively hashes all string values in it'''
     args = argparse.ArgumentParser()
     args.add_argument("file")
+    args.add_argument("--multi", type=bool, nargs="?", const=True, default=False)
     flags = args.parse_args()
 
-    with open(flags.file, "r") as f:
-        data = json.load(f)
-
-    traverse(data)
-    
-    with open(flags.file, "w") as f:
-        json.dump(data, f)
+    if flags.multi:
+        processed = []
+        with open(flags.file, "r") as f:
+            for line in f:
+                line_data = line.strip()
+                data = json.loads(line_data)
+                traverse(data)
+                processed.append(data)
+        with open(flags.file, "w") as f:
+            for line in processed:
+                json.dump(line, f)
+                f.write("\n")
+    else:
+        with open(flags.file, "r") as f:
+            data = json.load(f)
+        traverse(data)
+        with open(flags.file, "w") as f:
+            json.dump(data, f)
 
 def traverse(obj):
     if isinstance(obj, dict):
         for key, value in obj.items():
-            if isExtJson(key):
+            if should_skip_key(key):
                 continue
             if isinstance(value, dict):
                 traverse(value)
@@ -50,8 +62,8 @@ def is_numeric(s):
         pass
     return False
 
-def isExtJson(key):
-    specialKeys = [
+def should_skip_key(key):
+    special_keys = [
         "$binary",
         "$date",
         "$numberDecimal",
@@ -64,7 +76,7 @@ def isExtJson(key):
         "$regularExpression",
         "$timestamp"
     ]
-    return key in specialKeys
+    return key in special_keys
 
 if __name__ == "__main__":
     main()

--- a/makefile
+++ b/makefile
@@ -486,8 +486,11 @@ gqlgen:
 
 # sanitizes a json file by hashing string values. Note that this will not work well with
 # string data that only has a subset of valid values
+ifneq (,$(multi))
+multiarg = --multi
+endif
 scramble:
-	python cmd/scrambled-eggs/scramble.py $(file)
+	python cmd/scrambled-eggs/scramble.py $(file) $(multiarg)
 
 # mongodb utility targets
 mongodb/.get-mongodb:


### PR DESCRIPTION
This adds support for scrambling a newline-delimited list of json, rather than strict json. If the input file is a list, call it like 
`make scramble file=testdata/local/admin.json multi=1`