### PR TITLE
EVG-12720: fix smoke tests

### DIFF
--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -5,14 +5,16 @@ import (
 	"path/filepath"
 	"runtime"
 
+	// this *must* be included in the binary so that the legacy
+	// plugins are built into the binary.
+	_ "github.com/evergreen-ci/evergreen/plugin"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/operations"
-	_ "github.com/evergreen-ci/evergreen/plugin" // included so that the legacy plugins are built into the binary
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/send"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -96,23 +98,10 @@ func buildApp() *cli.App {
 	}
 
 	app.Before = func(c *cli.Context) error {
-		conf := c.String("conf")
-		if conf != "" {
-			if err := checkConfPath(conf); err != nil {
-				return err
-			}
-		}
 		return loggingSetup(app.Name, c.String("level"))
 	}
 
 	return app
-}
-
-func checkConfPath(conf string) error {
-	if _, err := os.Stat(conf); os.IsNotExist(err) {
-		return errors.Errorf("configuration file `%s` does not exist", conf)
-	}
-	return nil
 }
 
 func loggingSetup(name, l string) error {

--- a/command/git.go
+++ b/command/git.go
@@ -688,7 +688,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		defer func() { //nolint: evg-lint
+		defer func() {
 			grip.Error(tempFile.Close())
 			grip.Error(os.Remove(tempFile.Name()))
 		}()

--- a/command/git.go
+++ b/command/git.go
@@ -688,7 +688,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		defer func() {
+		defer func() { //nolint: evg-lint
 			grip.Error(tempFile.Close())
 			grip.Error(os.Remove(tempFile.Name()))
 		}()

--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-07-31"
+	ClientVersion = "2020-08-06"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-07-31"

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -335,8 +335,6 @@ func (m *monitor) createAgentProcess(ctx context.Context, retry util.RetryArgs) 
 	if err = util.RetryWithArgs(ctx, func() (bool, error) {
 		cmd := m.jasperClient.CreateCommand(ctx).
 			Add([]string{m.shellPath, "-l", "-c", strings.Join(agentCmdArgs, " ")}).
-			SetOutputSender(level.Info, grip.GetSender()).
-			SetErrorSender(level.Error, grip.GetSender()).
 			Environment(env).
 			Background(true)
 		if err = cmd.Run(ctx); err != nil {

--- a/operations/service_deploy_smoke.go
+++ b/operations/service_deploy_smoke.go
@@ -166,7 +166,7 @@ func smokeStartEvergreen() cli.Command {
 				if err != nil {
 					return errors.Wrap(err, "error setting up monitor client directory")
 				}
-				if err := clientFile.Close(); err != nil {
+				if err = clientFile.Close(); err != nil {
 					return errors.Wrap(err, "closing evergreen client binary")
 				}
 

--- a/operations/service_deploy_smoke.go
+++ b/operations/service_deploy_smoke.go
@@ -166,10 +166,9 @@ func smokeStartEvergreen() cli.Command {
 				if err != nil {
 					return errors.Wrap(err, "error setting up monitor client directory")
 				}
-				defer func() {
-					grip.Error(clientFile.Close())
-					grip.Error(os.Remove(clientFile.Name()))
-				}()
+				if err := clientFile.Close(); err != nil {
+					return errors.Wrap(err, "closing evergreen client binary")
+				}
 
 				err = smokeRunBinary(
 					exit,


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12720

This fixes two separate problems that broke the smoke tests:
1. Revert e317c728fa2e1ea078368e57bc2c2c5919045e68 (@ablack12) because the CLI requires an evergreen YAML for all commands, which will break commands that don't have an evergreen.yaml (e.g. `evergreen service deploy`).
2. For smoke-test-agent-monitor specifically - do not remove temp file from smoke test command, because the agent monitor needs to be given a path to a file where the agent will be downloaded. If you try removing the file at the same time that the agent monitor is downloading the agent, it'll get "Text file busy" and the agent won't be able to run.