### PR TITLE
EVG-12746 catch Windows versioning

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-08-06"
+	ClientVersion = "2020-08-10"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-07-31"

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -604,7 +604,8 @@ func diffToMbox(diffData *localDiff, subject string) (string, error) {
 
 	metadata, err := getGitConfigMetadata()
 	if err != nil {
-		return "", errors.Wrap(err, "problem getting git metadata")
+		grip.Error(errors.Wrap(err, "Problem getting git metadata. Patch will be ineligible to be enqueued on the commit queue."))
+		return diffData.fullPatch, nil
 	}
 	metadata.Subject = subject
 
@@ -685,9 +686,9 @@ func getGitConfigMetadata() (GitMetadata, error) {
 func parseGitVersion(version string) (string, error) {
 	matches := regexp.MustCompile(`^git version ` +
 		// capture the version major.minor(.patch(.build(.etc...)))
-		`(\d+(?:\.\d+)+)` +
+		`(\w+(?:\.\w+)+)` +
 		// match and discard Apple git's addition to the version string
-		`(?: \(Apple Git-[\d\.]+\))?$`,
+		`(?: \(Apple Git-[\w\.]+\))?$`,
 	).FindStringSubmatch(version)
 	if len(matches) != 2 {
 		return "", errors.Errorf("can't parse git version number from version string '%s'", version)

--- a/operations/patch_util_test.go
+++ b/operations/patch_util_test.go
@@ -182,6 +182,7 @@ func (s *PatchUtilTestSuite) TestParseGitVersionString() {
 		"git version 2.19.1":                   "2.19.1",
 		"git version 2.24.3 (Apple Git-128)":   "2.24.3",
 		"git version 2.21.1 (Apple Git-122.3)": "2.21.1",
+		"git version 2.16.2.windows.1":         "2.16.2.windows.1",
 	}
 
 	for versionString, version := range versionStrings {


### PR DESCRIPTION
The git for Windows' version string was being excluded by the regexp because it includes characters that aren't part of the `\d` character class. Loosen the regexp to catch all word characters (`[A-Za-z0-9_]`). You can try it out [here](https://regex101.com/r/Hn4MMA/1).

Additionally, when we hit this error we should print an error and continue with the patch instead of preventing the patch from being uploaded.