### PR TITLE
EVG-9767 allow termination of non-ephemeral hosts

### DIFF
--- a/model/host/static_hosts.go
+++ b/model/host/static_hosts.go
@@ -21,18 +21,18 @@ import (
 //
 // If the distro is the empty string ("") then this operation affects all distros.
 // If distro aliases are included, then this operation affects also hosts with the alias.
-func MarkInactiveStaticHosts(activeStaticHosts []string, distroID string, distroAliases []string) error {
+func MarkInactiveStaticHosts(activeStaticHosts []string, d *distro.Distro) error {
 	query := bson.M{
 		IdKey:       bson.M{"$nin": activeStaticHosts},
 		ProviderKey: evergreen.HostTypeStatic,
 	}
-	if len(distroAliases) == 0 {
-		if distroID != "" {
-			query[bsonutil.GetDottedKeyName(DistroKey, distro.IdKey)] = distroID
+	if d != nil {
+		if len(d.Aliases) > 0 {
+			ids := append(d.Aliases, d.Id)
+			query[bsonutil.GetDottedKeyName(DistroKey, distro.IdKey)] = bson.M{"$in": ids}
+		} else {
+			query[bsonutil.GetDottedKeyName(DistroKey, distro.IdKey)] = d.Id
 		}
-	} else {
-		ids := append(distroAliases, distroID)
-		query[bsonutil.GetDottedKeyName(DistroKey, distro.IdKey)] = bson.M{"$in": ids}
 	}
 
 	toTerminate, err := Find(db.Query(query))

--- a/model/host/static_hosts_test.go
+++ b/model/host/static_hosts_test.go
@@ -63,7 +63,7 @@ func TestDecommissionInactiveStaticHosts(t *testing.T) {
 			So(inactiveUnknownTypeOne.Insert(), ShouldBeNil)
 
 			activeStaticHosts := []string{"activeStaticOne", "activeStaticTwo"}
-			So(MarkInactiveStaticHosts(activeStaticHosts, "", nil), ShouldBeNil)
+			So(MarkInactiveStaticHosts(activeStaticHosts, nil), ShouldBeNil)
 
 			found, err := Find(IsTerminated)
 			So(err, ShouldBeNil)
@@ -123,11 +123,13 @@ func TestTerminateStaticHostsForDistro(t *testing.T) {
 	found, err := Find(IsTerminated)
 	assert.NoError(t, err)
 	assert.Len(t, found, 0)
-	assert.NoError(t, MarkInactiveStaticHosts([]string{}, "d1", nil))
+	d := &distro.Distro{Id: "d1"}
+	assert.NoError(t, MarkInactiveStaticHosts([]string{}, d))
 	found, err = Find(IsTerminated)
 	assert.NoError(t, err)
 	assert.Len(t, found, 3)
-	assert.NoError(t, MarkInactiveStaticHosts([]string{}, "d2", nil))
+	d2 := &distro.Distro{Id: "d2"}
+	assert.NoError(t, MarkInactiveStaticHosts([]string{}, d2))
 	found, err = Find(IsTerminated)
 	assert.NoError(t, err)
 	assert.Len(t, found, 4)
@@ -173,7 +175,11 @@ func TestTerminateStaticHostsForDistroAliases(t *testing.T) {
 	for _, h := range hosts {
 		assert.NoError(t, h.Insert())
 	}
-	assert.NoError(t, MarkInactiveStaticHosts([]string{"h1"}, "d1", []string{"dAlias"}))
+	d := &distro.Distro{
+		Id:      "d1",
+		Aliases: []string{"dAlias"},
+	}
+	assert.NoError(t, MarkInactiveStaticHosts([]string{"h1"}, d))
 	found, err := Find(IsTerminated)
 	assert.NoError(t, err)
 	assert.Len(t, found, 3)

--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -89,8 +89,20 @@ func (dc *DBDistroConnector) CreateDistro(distro *distro.Distro) error {
 
 // DeleteDistroById removes a given distro from the database based on its id.
 func (dc *DBDistroConnector) DeleteDistroById(distroId string) error {
-	var err error
-	if err = host.MarkInactiveStaticHosts([]string{}, distroId); err != nil {
+	d, err := distro.FindByID(distroId)
+	if err != nil {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    fmt.Sprintf("problem finding distro '%s'", distroId),
+		}
+	}
+	if d == nil {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintf("distro '%s' doesn't exist", distroId),
+		}
+	}
+	if err = host.MarkInactiveStaticHosts([]string{}, distroId, d.Aliases); err != nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    fmt.Sprintf("hosts for distro with id '%s' were not terminated", distroId),

--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -102,7 +102,7 @@ func (dc *DBDistroConnector) DeleteDistroById(distroId string) error {
 			Message:    fmt.Sprintf("distro '%s' doesn't exist", distroId),
 		}
 	}
-	if err = host.MarkInactiveStaticHosts([]string{}, distroId, d.Aliases); err != nil {
+	if err = host.MarkInactiveStaticHosts([]string{}, d); err != nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    fmt.Sprintf("hosts for distro with id '%s' were not terminated", distroId),

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -139,7 +139,7 @@ func UpdateStaticDistro(d distro.Distro) error {
 	if d.Id == "" && len(d.Aliases) == 0 {
 		return nil
 	}
-	return host.MarkInactiveStaticHosts(hosts, d.Id, d.Aliases)
+	return host.MarkInactiveStaticHosts(hosts, &d)
 }
 
 func doStaticHostUpdate(d distro.Distro) ([]string, error) {

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -136,11 +136,10 @@ func UpdateStaticDistro(d distro.Distro) error {
 		return errors.WithStack(err)
 	}
 
-	if d.Id == "" {
+	if d.Id == "" && len(d.Aliases) == 0 {
 		return nil
 	}
-
-	return host.MarkInactiveStaticHosts(hosts, d.Id)
+	return host.MarkInactiveStaticHosts(hosts, d.Id, d.Aliases)
 }
 
 func doStaticHostUpdate(d distro.Distro) ([]string, error) {

--- a/service/distros.go
+++ b/service/distros.go
@@ -225,15 +225,21 @@ func (uis *UIServer) removeDistro(w http.ResponseWriter, r *http.Request) {
 
 	u := MustHaveUser(r)
 
-	d, err := distro.FindOne(distro.ById(id))
+	d, err := distro.FindByID(id)
 	if err != nil {
 		message := fmt.Sprintf("error finding distro: %v", err)
 		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
 		http.Error(w, message, http.StatusInternalServerError)
 		return
 	}
+	if d == nil {
+		message := fmt.Sprintf("distro '%s' doesn't exist", id)
+		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
+		http.Error(w, message, http.StatusBadRequest)
+		return
+	}
 
-	if err = host.MarkInactiveStaticHosts([]string{}, id, d.Aliases); err != nil {
+	if err = host.MarkInactiveStaticHosts([]string{}, d); err != nil {
 		message := fmt.Sprintf("error removing hosts for distro '%s': %s", id, err)
 		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
 		http.Error(w, message, http.StatusInternalServerError)

--- a/service/distros.go
+++ b/service/distros.go
@@ -233,7 +233,7 @@ func (uis *UIServer) removeDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = host.MarkInactiveStaticHosts([]string{}, id); err != nil {
+	if err = host.MarkInactiveStaticHosts([]string{}, id, d.Aliases); err != nil {
 		message := fmt.Sprintf("error removing hosts for distro '%s': %s", id, err)
 		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
 		http.Error(w, message, http.StatusInternalServerError)


### PR DESCRIPTION
Zakhar thought this host couldn't be terminated due to distro aliases, but really we don't allow termination for non-ephemeral hosts. Distro admins / super users should be able to do this though, given that we need to do this right now.

I originally wrote something to authenticate that the user has distro host edit permissions, but it actually looks like we already do this [here](https://github.com/evergreen-ci/evergreen/blob/05466742638f662831fcf70b959b12dcdd99e3d0/public/static/js/host.js#L7) and [here](https://github.com/evergreen-ci/evergreen/blob/55ea271af62f265d44b624f7204e59438fcef1fe/service/ui.go#L340) so I think this check is overall unnecessary.