### PR TITLE
EVG-12767: fix temp file removal during update

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-08-10"
+	ClientVersion = "2020-08-11"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-07-31"

--- a/operations/update.go
+++ b/operations/update.go
@@ -70,6 +70,11 @@ func Update() cli.Command {
 			if err != nil {
 				return err
 			}
+			defer func() {
+				if doInstall {
+					grip.Error(os.Remove(updatedBin))
+				}
+			}()
 
 			if doInstall {
 				grip.Infoln("Upgraded binary successfully downloaded to temporary file:", updatedBin)
@@ -146,7 +151,6 @@ func prepareUpdate(url, newVersion string) (string, error) {
 	}
 	defer func() {
 		grip.Error(tempFile.Close())
-		grip.Error(os.Remove(tempFile.Name()))
 	}()
 
 	response, err := http.Get(url)
@@ -160,10 +164,6 @@ func prepareUpdate(url, newVersion string) (string, error) {
 
 	defer response.Body.Close()
 	_, err = io.Copy(tempFile, response.Body)
-	if err != nil {
-		return "", err
-	}
-	err = tempFile.Close()
 	if err != nil {
 		return "", err
 	}

--- a/operations/update.go
+++ b/operations/update.go
@@ -130,13 +130,15 @@ func copyFile(dst, src string) error {
 	}
 	// no need to check errors on read only file, we already got everything
 	// we need from the filesystem, so nothing can go wrong now.
-	defer s.Close()
+	defer func() {
+		grip.Error(s.Close())
+	}()
 	d, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
 	if _, err := io.Copy(d, s); err != nil {
-		_ = d.Close()
+		grip.Error(d.Close())
 		return err
 	}
 	return d.Close()


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12767

The update was removing the temp file before it could be installed in the current binary location. It also closed the same file handle multiple times, which was producing errors.