### PR TITLE
EVG-7674 multiple commits

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-08-11"
+	ClientVersion = "2020-08-12"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-07-31"

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -98,7 +98,7 @@ func Patch() cli.Command {
 				return errors.Wrap(err, "can't test for uncommitted changes")
 			}
 			if !keepGoing {
-				return nil
+				return errors.New("patch aborted")
 			}
 
 			comm := conf.setupRestCommunicator(ctx)

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -60,7 +60,7 @@ func PatchSetModule() cli.Command {
 				return errors.Wrap(err, "can't test for uncommitted changes")
 			}
 			if !keepGoing {
-				return nil
+				return errors.New("patch aborted")
 			}
 
 			proj, err := rc.GetPatchedConfig(patchID)


### PR DESCRIPTION
Add checks for skipConfirm to more prompts.
I'm open to discussion about individual cases where we haven't been checking it, but I think in general we should honor the user's choice to skip confirmations. I could hear an argument for confirm at least logging the message when we skip confirmation, but I've left it alone for now.

A separate issue I included in this PR was to return an error when the user aborts a patch for uncommitted changes.