### PR TITLE
EVG-12737 add permissions check to submitPatch route

### DIFF
--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -56,6 +56,17 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	opts := gimlet.PermissionOpts{
+		Resource:      data.Project,
+		ResourceType:  evergreen.ProjectResourceType,
+		Permission:    evergreen.PermissionPatches,
+		RequiredLevel: evergreen.PatchSubmit.Value,
+	}
+	if !dbUser.HasPermission(opts) {
+		as.LoggedError(w, r, http.StatusUnauthorized, errors.New("user is not authorized to patch this project"))
+		return
+	}
+
 	patchString := string(data.PatchBytes)
 	if len(patchString) > patch.SizeLimit {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.New("Patch is too large"))


### PR DESCRIPTION
We don't check in middleware because the project ID isn't in the request variables/query parameters and [urlVarsToProjectScopes](https://github.com/evergreen-ci/evergreen/blob/7c56f5ebef25da056b60ed558392d4d6d031d858/rest/route/middleware.go#L503) would return a 404.