### PR TITLE
EVG-12779 set local git config

### DIFF
--- a/command/git.go
+++ b/command/git.go
@@ -286,8 +286,8 @@ func (c *gitFetchProject) getConfigCommands() []string {
 	}
 
 	return []string{
-		fmt.Sprintf("git config --local user.name %s", userName),
-		fmt.Sprintf("git config --local user.email %s", userEmail),
+		fmt.Sprintf(`git config --local user.name "%s"`, userName),
+		fmt.Sprintf(`git config --local user.email "%s"`, userEmail),
 	}
 }
 

--- a/command/git_push.go
+++ b/command/git_push.go
@@ -20,11 +20,9 @@ import (
 type gitPush struct {
 	// The root directory (locally) that the code is checked out into.
 	// Must be a valid non-blank directory name.
-	Directory      string `yaml:"directory" plugin:"expand"`
-	DryRun         bool   `yaml:"dry_run" mapstructure:"dry_run"`
-	CommitterName  string `yaml:"committer_name" mapstructure:"committer_name"`
-	CommitterEmail string `yaml:"committer_email" mapstructure:"committer_email"`
-	Token          string `yaml:"token" plugin:"expand" mapstructure:"token"`
+	Directory string `yaml:"directory" plugin:"expand"`
+	DryRun    bool   `yaml:"dry_run" mapstructure:"dry_run"`
+	Token     string `yaml:"token" plugin:"expand" mapstructure:"token"`
 
 	base
 }

--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -27,10 +27,8 @@ import (
 func TestGitPush(t *testing.T) {
 	token := "0123456789"
 	c := gitPush{
-		Directory:      "src",
-		CommitterName:  "octocat",
-		CommitterEmail: "octocat@github.com",
-		Token:          token,
+		Directory: "src",
+		Token:     token,
 	}
 	comm := client.NewMock("http://localhost.com")
 	conf := &model.TaskConfig{

--- a/command/git_test.go
+++ b/command/git_test.go
@@ -476,7 +476,7 @@ func (s *GitGetProjectSuite) TestBuildCommand() {
 	s.Require().NoError(err)
 	cmds, err = c.buildCloneCommand(conf, opts)
 	s.NoError(err)
-	s.Require().Len(cmds, 9)
+	s.Require().Len(cmds, 11)
 	s.Equal("set -o xtrace", cmds[0])
 	s.Equal("set -o errexit", cmds[1])
 	s.Equal("rm -rf dir", cmds[2])
@@ -486,6 +486,8 @@ func (s *GitGetProjectSuite) TestBuildCommand() {
 	s.Equal("set -o xtrace", cmds[6])
 	s.Equal("cd dir", cmds[7])
 	s.Equal("git reset --hard ", cmds[8])
+	s.Equal(`git config --local user.name "Evergreen Agent"`, cmds[9])
+	s.Equal(`git config --local user.email "no-reply@evergreen.mongodb.com"`, cmds[10])
 }
 
 func (s *GitGetProjectSuite) TestBuildCommandForPullRequests() {

--- a/command/git_test.go
+++ b/command/git_test.go
@@ -458,13 +458,15 @@ func (s *GitGetProjectSuite) TestBuildCommand() {
 	s.Require().NoError(opts.setLocation())
 	cmds, err := c.buildCloneCommand(conf, opts)
 	s.NoError(err)
-	s.Require().Len(cmds, 6)
+	s.Require().Len(cmds, 8)
 	s.Equal("set -o xtrace", cmds[0])
 	s.Equal("set -o errexit", cmds[1])
 	s.Equal("rm -rf dir", cmds[2])
 	s.Equal("git clone 'git@github.com:deafgoat/mci_test.git' 'dir' --branch 'master'", cmds[3])
 	s.Equal("cd dir", cmds[4])
 	s.Equal("git reset --hard ", cmds[5])
+	s.Equal(`git config --local user.name "Evergreen Agent"`, cmds[6])
+	s.Equal(`git config --local user.email "no-reply@evergreen.mongodb.com"`, cmds[7])
 
 	// ensure clone command with location containing "https://github.com" uses
 	// HTTPS.
@@ -503,10 +505,12 @@ func (s *GitGetProjectSuite) TestBuildCommandForPullRequests() {
 
 	cmds, err := c.buildCloneCommand(conf, opts)
 	s.NoError(err)
-	s.Require().Len(cmds, 8)
+	s.Require().Len(cmds, 10)
 	s.True(strings.HasPrefix(cmds[5], "git fetch origin \"pull/9001/head:evg-pr-test-"))
 	s.True(strings.HasPrefix(cmds[6], "git checkout \"evg-pr-test-"))
 	s.Equal("git reset --hard 55ca6286e3e4f4fba5d0448333fa99fc5a404a73", cmds[7])
+	s.Equal(`git config --local user.name "Evergreen Agent"`, cmds[8])
+	s.Equal(`git config --local user.email "no-reply@evergreen.mongodb.com"`, cmds[9])
 }
 
 func (s *GitGetProjectSuite) TestBuildCommandForPRMergeTests() {
@@ -525,10 +529,12 @@ func (s *GitGetProjectSuite) TestBuildCommandForPRMergeTests() {
 	s.Require().NoError(opts.setLocation())
 	cmds, err := c.buildCloneCommand(conf, opts)
 	s.NoError(err)
-	s.Require().Len(cmds, 8)
+	s.Require().Len(cmds, 10)
 	s.True(strings.HasPrefix(cmds[5], "git fetch origin \"pull/9001/merge:evg-merge-test-"))
 	s.True(strings.HasPrefix(cmds[6], "git checkout \"evg-merge-test-"))
 	s.Equal("git reset --hard abcdef", cmds[7])
+	s.Equal(`git config --local user.name "Evergreen Agent"`, cmds[8])
+	s.Equal(`git config --local user.email "no-reply@evergreen.mongodb.com"`, cmds[9])
 }
 
 func (s *GitGetProjectSuite) TestBuildCommandForCLIMergeTests() {
@@ -552,7 +558,7 @@ func (s *GitGetProjectSuite) TestBuildCommandForCLIMergeTests() {
 	s.modelData2.TaskConfig.Task.Requester = evergreen.MergeTestRequester
 	cmds, err := c.buildCloneCommand(conf, opts)
 	s.NoError(err)
-	s.Len(cmds, 8)
+	s.Len(cmds, 10)
 	s.True(strings.HasSuffix(cmds[5], fmt.Sprintf("--branch '%s'", s.modelData2.TaskConfig.ProjectRef.Branch)))
 }
 

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -624,15 +624,15 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 				Command: "git.get_project",
 				Type:    evergreen.CommandTypeSetup,
 				Params: map[string]interface{}{
-					"directory": "src",
+					"directory":  "src",
+					"user_name":  settings.CommitQueue.CommitterName,
+					"user_email": settings.CommitQueue.CommitterEmail,
 				},
 			},
 			{
 				Command: "git.push",
 				Params: map[string]interface{}{
-					"directory":       "src",
-					"committer_name":  settings.CommitQueue.CommitterName,
-					"committer_email": settings.CommitQueue.CommitterEmail,
+					"directory": "src",
 				},
 			},
 		},


### PR DESCRIPTION
Old versions of git (<2.1.2) don't support the -c option. Instead, set the config on the repo (--local) level when we clone the repo.
I considered just setting it in the case where we need it (when we run `git am`) but it seems like a good idea to set it in every case since git sometimes refuses to do random things when it's not set.

Also removed the committer_name and committer_email parameters from the git.push command where they are no longer used (post the transition to mbox).