### PR TITLE
EVG-12767: close temp evergreen file before using it

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-08-12"
+	ClientVersion = "2020-08-13"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-07-31"

--- a/operations/update.go
+++ b/operations/update.go
@@ -151,22 +151,26 @@ func prepareUpdate(url, newVersion string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		grip.Error(tempFile.Close())
-	}()
 
 	response, err := http.Get(url)
 	if err != nil {
+		grip.Error(tempFile.Close())
 		return "", err
 	}
 
 	if response == nil {
+		grip.Error(tempFile.Close())
 		return "", errors.Errorf("empty response from URL: %s", url)
 	}
 
 	defer response.Body.Close()
 	_, err = io.Copy(tempFile, response.Body)
 	if err != nil {
+		grip.Error(tempFile.Close())
+		return "", err
+	}
+
+	if err = tempFile.Close(); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12767

Close the temp file before we exec it, otherwise it returns "text file busy". This problem seems to be specific to Linux.