### PR TITLE
EVG-12779 remove git -c option

### DIFF
--- a/command/git_push.go
+++ b/command/git_push.go
@@ -20,11 +20,9 @@ import (
 type gitPush struct {
 	// The root directory (locally) that the code is checked out into.
 	// Must be a valid non-blank directory name.
-	Directory      string `yaml:"directory" plugin:"expand"`
-	DryRun         bool   `yaml:"dry_run" mapstructure:"dry_run"`
-	CommitterName  string `yaml:"committer_name" mapstructure:"committer_name"`
-	CommitterEmail string `yaml:"committer_email" mapstructure:"committer_email"`
-	Token          string `yaml:"token" plugin:"expand" mapstructure:"token"`
+	Directory string `yaml:"directory" plugin:"expand"`
+	DryRun    bool   `yaml:"dry_run" mapstructure:"dry_run"`
+	Token     string `yaml:"token" plugin:"expand" mapstructure:"token"`
 
 	base
 }

--- a/command/git_push_test.go
+++ b/command/git_push_test.go
@@ -27,10 +27,8 @@ import (
 func TestGitPush(t *testing.T) {
 	token := "0123456789"
 	c := gitPush{
-		Directory:      "src",
-		CommitterName:  "octocat",
-		CommitterEmail: "octocat@github.com",
-		Token:          token,
+		Directory: "src",
+		Token:     token,
 	}
 	comm := client.NewMock("http://localhost.com")
 	conf := &model.TaskConfig{

--- a/command/git_test.go
+++ b/command/git_test.go
@@ -628,6 +628,27 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 	s.Equal("git reset --hard 1234abcd", cmds[6])
 }
 
+func (s *GitGetProjectSuite) TestGetApplyCommand() {
+	c := &gitFetchProject{
+		Directory:      "dir",
+		Token:          projectGitHubToken,
+		CommitterName:  "octocat",
+		CommitterEmail: "octocat@github.com",
+	}
+
+	// regular patch
+	patchPath := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test.patch")
+	applyCommand, err := c.getApplyCommand(patchPath)
+	s.NoError(err)
+	s.Equal(fmt.Sprintf("git apply --binary --index < '%s'", patchPath), applyCommand)
+
+	// mbox patch
+	patchPath = filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test_mbox.patch")
+	applyCommand, err = c.getApplyCommand(patchPath)
+	s.NoError(err)
+	s.Equal(fmt.Sprintf(`GIT_COMMITTER_NAME="%s" GIT_COMMITTER_EMAIL="%s" git am --keep-cr < '%s'`, c.CommitterName, c.CommitterEmail, patchPath), applyCommand)
+}
+
 func (s *GitGetProjectSuite) TestCorrectModuleRevisionSetModule() {
 	const correctHash = "b27779f856b211ffaf97cbc124b7082a20ea8bc0"
 	conf := s.modelData2.TaskConfig

--- a/command/git_test.go
+++ b/command/git_test.go
@@ -646,7 +646,7 @@ func (s *GitGetProjectSuite) TestGetApplyCommand() {
 	patchPath = filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test_mbox.patch")
 	applyCommand, err = c.getApplyCommand(patchPath)
 	s.NoError(err)
-	s.Equal(fmt.Sprintf(`GIT_COMMITTER_NAME="%s" GIT_COMMITTER_EMAIL="%s" git am --keep-cr < '%s'`, c.CommitterName, c.CommitterEmail, patchPath), applyCommand)
+	s.Equal(fmt.Sprintf(`GIT_COMMITTER_NAME="%s" GIT_COMMITTER_EMAIL="%s" git am --keep-cr < "%s"`, c.CommitterName, c.CommitterEmail, patchPath), applyCommand)
 }
 
 func (s *GitGetProjectSuite) TestCorrectModuleRevisionSetModule() {

--- a/command/testdata/git/test_mbox.patch
+++ b/command/testdata/git/test_mbox.patch
@@ -1,0 +1,25 @@
+From bd195cb35107cd558965b8433b32fa090f97ae9b Mon Sep 17 00:00:00 2001
+From: Jonathan Brill <jonathan.brill@10gen.com>
+Date: Fri, 14 Aug 2020 09:39:26 -0400
+Subject: [PATCH] EVG-12779 increment agent version
+
+---
+ config.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config.go b/config.go
+index afe7908dd..714e415a3 100644
+--- a/config.go
++++ b/config.go
+@@ -32,7 +32,7 @@ var (
+ 	ClientVersion = "2020-08-13"
+ 
+ 	// Agent version to control agent rollover.
+-	AgentVersion = "2020-07-31"
++	AgentVersion = "2020-08-14"
+ )
+ 
+ // ConfigSection defines a sub-document in the evergreen config
+-- 
+2.19.1
+

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	ClientVersion = "2020-08-13"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-08-14.a"
+	AgentVersion = "2020-08-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -624,15 +624,15 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 				Command: "git.get_project",
 				Type:    evergreen.CommandTypeSetup,
 				Params: map[string]interface{}{
-					"directory": "src",
+					"directory":       "src",
+					"committer_name":  settings.CommitQueue.CommitterName,
+					"committer_email": settings.CommitQueue.CommitterEmail,
 				},
 			},
 			{
 				Command: "git.push",
 				Params: map[string]interface{}{
-					"directory":       "src",
-					"committer_name":  settings.CommitQueue.CommitterName,
-					"committer_email": settings.CommitQueue.CommitterEmail,
+					"directory": "src",
 				},
 			},
 		},


### PR DESCRIPTION
The changes in #3887 were reverted because the --local option also isn't supported on old versions of git.
Instead, pass the committer information as [environment variables](https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing). I _tested_ that this method is supported.