### PR TITLE
EVG-8327 activate tasks that already exist in generate.tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1451,7 +1451,7 @@ func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pa
 					var fullTask *task.Task
 					fullTask, err = task.FindOneId(info.id)
 					if err != nil {
-						return nil, err
+						return nil, errors.Wrapf(err, "problem finding task '%s'", info.id)
 					}
 					if fullTask == nil {
 						return nil, errors.Errorf("task '%s' not found", info.id)

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1426,7 +1426,7 @@ func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pa
 	taskIds := []string{}
 	for _, b := range builds {
 		// Find the set of tasks that already exist for the set we want to add
-		taskNames := append(pairs.ExecTasks.TaskNames(b.BuildVariant), pairs.DisplayTasks.TaskNames(b.BuildVariant)...)
+		taskNames := append(pairs.ExecTasks.TaskNames(b.Id), pairs.DisplayTasks.TaskNames(b.Id)...)
 		tasksInBuild, err := task.Find(task.ByBuildIdAndTaskNames(b.Id, taskNames))
 		if err != nil {
 			return nil, err

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1430,7 +1430,7 @@ func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pa
 		if err != nil {
 			return nil, err
 		}
-		// build an index to keep track of which tasks already exist, using display name
+		// build an index to keep track of which tasks already exist, and their activation
 		type taskInfo struct {
 			id        string
 			activated bool
@@ -1448,7 +1448,8 @@ func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pa
 		for _, taskname := range pairs.ExecTasks.TaskNames(b.BuildVariant) {
 			if info, ok := existingTasksIndex[taskname]; ok {
 				if !info.activated && activated { // update task activation for dependencies that already exist
-					fullTask, err := task.FindOneNoMerge(task.ById(info.id))
+					var fullTask *task.Task
+					fullTask, err = task.FindOneId(info.id)
 					if err != nil {
 						return nil, err
 					}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1448,7 +1448,6 @@ func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pa
 					if _, err = t.ActivateTask(evergreen.User); err != nil {
 						return nil, errors.Wrapf(err, "problem updating active state for existing task '%s'", taskname)
 					}
-					existingTasksIndex[taskname] = t
 				}
 				continue
 			}
@@ -1462,7 +1461,6 @@ func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pa
 					if _, err = t.ActivateTask(evergreen.User); err != nil {
 						return nil, errors.Wrapf(err, "problem updating active state for existing display task '%s'", taskname)
 					}
-					existingTasksIndex[taskname] = t
 				}
 				continue
 			}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1426,7 +1426,7 @@ func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pa
 	taskIds := []string{}
 	for _, b := range builds {
 		// Find the set of tasks that already exist for the set we want to add
-		taskNames := append(pairs.ExecTasks.TaskNames(b.Id), pairs.DisplayTasks.TaskNames(b.Id)...)
+		taskNames := append(pairs.ExecTasks.TaskNames(b.BuildVariant), pairs.DisplayTasks.TaskNames(b.BuildVariant)...)
 		tasksInBuild, err := task.Find(task.ByBuildIdAndTaskNames(b.Id, taskNames))
 		if err != nil {
 			return nil, err

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1425,17 +1425,19 @@ func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pa
 
 	taskIds := []string{}
 	for _, b := range builds {
-		// Find the set of tasks that already exist for the set we want to add
-		taskNames := append(pairs.ExecTasks.TaskNames(b.Id), pairs.DisplayTasks.TaskNames(b.Id)...)
-		tasksInBuild, err := task.Find(task.ByBuildIdAndTaskNames(b.Id, taskNames))
+		// Find the set of task names that already exist for the given build
+		tasksInBuild, err := task.Find(task.ByBuildId(b.Id).WithFields(task.DisplayNameKey, task.ActivatedKey))
 		if err != nil {
 			return nil, err
 		}
-
-		// build an index to keep track of tasks that already exist
-		existingTasksIndex := map[string]task.Task{}
+		// build an index to keep track of which tasks already exist, and their activation
+		type taskInfo struct {
+			id        string
+			activated bool
+		}
+		existingTasksIndex := map[string]taskInfo{}
 		for _, t := range tasksInBuild {
-			existingTasksIndex[t.DisplayName] = t
+			existingTasksIndex[t.DisplayName] = taskInfo{id: t.Id, activated: t.Activated}
 		}
 		// if the patch is activated, treat the build as activated
 		b.Activated = activated
@@ -1444,10 +1446,18 @@ func AddNewTasks(ctx context.Context, activated bool, v *Version, p *Project, pa
 		// a record in the TVPairSet indicating that it should exist
 		tasksToAdd := []string{}
 		for _, taskname := range pairs.ExecTasks.TaskNames(b.BuildVariant) {
-			if t, ok := existingTasksIndex[taskname]; ok {
-				if !t.Activated && activated { // update task activation for tasks that already exist
-					if err = SetActiveState(&t, evergreen.User, true); err != nil {
-						return nil, errors.Wrapf(err, "problem updating active state for existing task '%s'", t.Id)
+			if info, ok := existingTasksIndex[taskname]; ok {
+				if !info.activated && activated { // update task activation for dependencies that already exist
+					var fullTask *task.Task
+					fullTask, err = task.FindOneId(info.id)
+					if err != nil {
+						return nil, err
+					}
+					if fullTask == nil {
+						return nil, errors.Errorf("task '%s' not found", info.id)
+					}
+					if err = SetActiveState(fullTask, evergreen.User, true); err != nil {
+						return nil, errors.Wrapf(err, "problem updating active state for existing task '%s'", info.id)
 					}
 				}
 				continue

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -208,21 +208,30 @@ func ByBuildId(buildId string) db.Q {
 	})
 }
 
-// ByAborted creates a query to return tasks with an aborted state
+// ByBuildIdAndTasksNames creates a query to return tasks for the build
+// with the given task display names.
+func ByBuildIdAndTaskNames(buildId string, taskNames []string) db.Q {
+	return db.Query(bson.M{
+		BuildIdKey:     buildId,
+		DisplayNameKey: bson.M{"$in": taskNames},
+	})
+}
+
+// ByAborted creates a query to return tasks with an aborted state.
 func ByAborted(aborted bool) db.Q {
 	return db.Query(bson.M{
 		AbortedKey: aborted,
 	})
 }
 
-// ByAborted creates a query to return tasks with an aborted state
+// ByAborted creates a query to return activated tasks.
 func ByActivation(active bool) db.Q {
 	return db.Query(bson.M{
 		ActivatedKey: active,
 	})
 }
 
-// ByVersion creates a query to return tasks with a certain build id
+// ByVersion creates a query to return tasks with a certain version id.
 func ByVersion(version string) db.Q {
 	return db.Query(bson.M{
 		VersionKey: version,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -208,30 +208,21 @@ func ByBuildId(buildId string) db.Q {
 	})
 }
 
-// ByBuildIdAndTasksNames creates a query to return tasks for the build
-// with the given task display names.
-func ByBuildIdAndTaskNames(buildId string, taskNames []string) db.Q {
-	return db.Query(bson.M{
-		BuildIdKey:     buildId,
-		DisplayNameKey: bson.M{"$in": taskNames},
-	})
-}
-
-// ByAborted creates a query to return tasks with an aborted state.
+// ByAborted creates a query to return tasks with an aborted state
 func ByAborted(aborted bool) db.Q {
 	return db.Query(bson.M{
 		AbortedKey: aborted,
 	})
 }
 
-// ByAborted creates a query to return activated tasks.
+// ByAborted creates a query to return tasks with an aborted state
 func ByActivation(active bool) db.Q {
 	return db.Query(bson.M{
 		ActivatedKey: active,
 	})
 }
 
-// ByVersion creates a query to return tasks with a certain version id.
+// ByVersion creates a query to return tasks with a certain build id
 func ByVersion(version string) db.Q {
 	return db.Query(bson.M{
 		VersionKey: version,


### PR DESCRIPTION
While generate.tasks does activate tasks that it creates, it seems that when a task already exists it skips it. My theory is that this doesn't normally cause a problem since most of the version will be activated already, but in the case that existing dependencies _haven't_ been activated, this doesn't activate them. (This is assuming that dependencies have been added by IncludeDependencies and not somewhere later.)