### PR TITLE
EVG-12712 match underwater query with task finder

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -806,8 +806,8 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 func UnscheduleStaleUnderwaterTasks(distroID string) (int, error) {
 	query := scheduleableTasksQuery()
 
-	if distroID != "" {
-		query[DistroIdKey] = distroID
+	if err := addApplicableDistroFilter(distroID, DistroIdKey, query); err != nil {
+		return 0, errors.WithStack(err)
 	}
 
 	query[ActivatedTimeKey] = bson.M{"$lte": time.Now().Add(-UnschedulableThreshold)}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1255,6 +1255,31 @@ func TestUnscheduleStaleUnderwaterTasksWithDistro(t *testing.T) {
 	require.NoError(t, t1.Insert())
 
 	d := distro.Distro{
+		Id: "d0",
+	}
+	require.NoError(t, d.Insert())
+
+	_, err := UnscheduleStaleUnderwaterTasks("d0")
+	assert.NoError(t, err)
+	dbTask, err := FindOneId("t1")
+	assert.NoError(t, err)
+	assert.False(t, dbTask.Activated)
+	assert.EqualValues(t, -1, dbTask.Priority)
+}
+
+func TestUnscheduleStaleUnderwaterTasksWithDistroAlias(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection, distro.Collection))
+	t1 := Task{
+		Id:            "t1",
+		Status:        evergreen.TaskUndispatched,
+		Activated:     true,
+		Priority:      0,
+		ActivatedTime: time.Time{},
+		DistroId:      "d0.0",
+	}
+	require.NoError(t, t1.Insert())
+
+	d := distro.Distro{
 		Id:      "d0",
 		Aliases: []string{"d0.0", "d0.1"},
 	}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -1221,7 +1222,7 @@ func TestBulkInsert(t *testing.T) {
 	}
 }
 
-func TestUnscheduleStaleUnderwaterTasks(t *testing.T) {
+func TestUnscheduleStaleUnderwaterTasksNoDistro(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 	t1 := Task{
@@ -1239,6 +1240,32 @@ func TestUnscheduleStaleUnderwaterTasks(t *testing.T) {
 	assert.NoError(err)
 	assert.False(dbTask.Activated)
 	assert.EqualValues(-1, dbTask.Priority)
+}
+
+func TestUnscheduleStaleUnderwaterTasksWithDistro(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection, distro.Collection))
+	t1 := Task{
+		Id:            "t1",
+		Status:        evergreen.TaskUndispatched,
+		Activated:     true,
+		Priority:      0,
+		ActivatedTime: time.Time{},
+		DistroId:      "d0",
+	}
+	require.NoError(t, t1.Insert())
+
+	d := distro.Distro{
+		Id:      "d0",
+		Aliases: []string{"d0.0", "d0.1"},
+	}
+	require.NoError(t, d.Insert())
+
+	_, err := UnscheduleStaleUnderwaterTasks("d0")
+	assert.NoError(t, err)
+	dbTask, err := FindOneId("t1")
+	assert.NoError(t, err)
+	assert.False(t, dbTask.Activated)
+	assert.EqualValues(t, -1, dbTask.Priority)
 }
 
 func TestGetRecentTaskStats(t *testing.T) {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -91,10 +91,7 @@ type Scheduler struct {
 	FindRunnableTasks TaskFinder
 }
 
-const (
-	RunnerName               = "scheduler"
-	underwaterPruningEnabled = true
-)
+const RunnerName = "scheduler"
 
 type distroScheduler struct {
 	startedAt time.Time
@@ -304,20 +301,19 @@ func generateIntentHost(d distro.Distro, pool *evergreen.ContainerPool) (*host.H
 	return host.NewIntent(d, d.GenerateName(), d.Provider, hostOptions), nil
 }
 
-// pass 'allDistros' or the empty string to unchedule all distros.
+// pass the empty string to unschedule all distros.
 func underwaterUnschedule(distroID string) error {
-	if underwaterPruningEnabled {
-		num, err := task.UnscheduleStaleUnderwaterTasks(distroID)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		grip.InfoWhen(num > 0, message.Fields{
-			"message": "unscheduled stale tasks",
-			"runner":  RunnerName,
-			"count":   num,
-		})
+	num, err := task.UnscheduleStaleUnderwaterTasks(distroID)
+	if err != nil {
+		return errors.WithStack(err)
 	}
+
+	grip.InfoWhen(num > 0, message.Fields{
+		"message": "unscheduled stale tasks",
+		"distro":  distroID,
+		"runner":  RunnerName,
+		"count":   num,
+	})
 
 	return nil
 }


### PR DESCRIPTION
We're supposed to deactivate and disable underwater tasks (i.e. tasks that have been activated and not run for ~a week). The task finders and [UnscheduleStaleUnderwaterTasks](https://github.com/evergreen-ci/evergreen/blob/582e882a8e2d35e66d7f9ac1bc23c838b9546840/model/task/task.go#L806) both use the [same query](https://github.com/evergreen-ci/evergreen/blob/582e882a8e2d35e66d7f9ac1bc23c838b9546840/model/task/db.go#L523) to find tasks that are ready to run, but the task finders also [include any distro in the set of distro aliases](https://github.com/evergreen-ci/evergreen/blob/582e882a8e2d35e66d7f9ac1bc23c838b9546840/model/task/task.go#L1818), while UnscheduleStaleUnderwaterTasks only looks for the distro itself. This PR makes UnscheduleStaleUnderwaterTasks also look for tasks in any of the distro aliases.

We don't usually hit this (the distro id in the task document is set to the main distro even when the project specifies run_on to a distro alias), but in this case after the task was created and before it ran the distro was 1) deleted and 2) added as an alias to another distro. As a result the tasks kept being found by the task finders but not by UnscheduleStaleUnderwaterTasks. 

I considered instead disabling a distro's tasks when the distro is deleted, but that might not be what we want. For example, in this case we wanted to relocate the distro's tasks to the new distro. Instead, I opted to make the underwater task query consistent with the task finders so anything we could potentially schedule is fair game for getting disabled when it's been sitting too long.