### PR TITLE
EVG-8282 deduplicate display task dependencies

### DIFF
--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -809,7 +809,7 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 		Version: "version_that_called_generate_task",
 	}
 	taskDisplayGen := task.Task{
-		Id:          "my_display_task_gen",
+		Id:          "_my_build_variant_my_display_task_gen__01_01_01_00_00_00",
 		DisplayName: "my_display_task_gen",
 		Version:     "version_that_called_generate_task",
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -913,12 +913,12 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 					}
 				}
 			} else {
-				execTask, err := task.FindOneId(etID)
+				execTask, err := task.FindOneNoMerge(task.ById(etID).WithFields(task.DependsOnKey))
 				if err != nil {
 					return nil, errors.Wrapf(err, "can't get existing execution task for display task '%s'", newDisplayTask.Id)
 				}
 				if execTask == nil {
-					return nil, errors.Wrapf(err, "no existing execution task '%s' found for display task '%s'", etID, newDisplayTask.Id)
+					return nil, errors.Errorf("no existing execution task '%s' found for display task '%s'", etID, newDisplayTask.Id)
 				}
 				for _, dep := range execTask.DependsOn {
 					if !depMap[dep.TaskId] {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -913,7 +913,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 					}
 				}
 			} else {
-				execTask, err := task.FindOneNoMerge(task.ById(etID).WithFields(task.DependsOnKey))
+				execTask, err := task.FindOneId(etID)
 				if err != nil {
 					return nil, errors.Wrapf(err, "can't get existing execution task for display task '%s'", newDisplayTask.Id)
 				}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2098,6 +2098,7 @@ func (t *Task) GetDisplayTask() (*Task, error) {
 	return dt, nil
 }
 
+// GetAllDependencies returns all the dependencies the tasks in taskIDs rely on
 func GetAllDependencies(taskIDs []string, taskMap map[string]*Task) ([]Dependency, error) {
 	// fill in the gaps in taskMap
 	tasksToFetch := []string{}
@@ -2106,6 +2107,7 @@ func GetAllDependencies(taskIDs []string, taskMap map[string]*Task) ([]Dependenc
 			tasksToFetch = append(tasksToFetch, tID)
 		}
 	}
+	missingTaskMap := make(map[string]*Task)
 	if len(tasksToFetch) > 0 {
 		missingTasks, err := FindAll(ByIds(tasksToFetch).WithFields(DependsOnKey))
 		if err != nil {
@@ -2115,7 +2117,7 @@ func GetAllDependencies(taskIDs []string, taskMap map[string]*Task) ([]Dependenc
 			return nil, errors.New("no missing tasks found")
 		}
 		for i, t := range missingTasks {
-			taskMap[t.Id] = &missingTasks[i]
+			missingTaskMap[t.Id] = &missingTasks[i]
 		}
 	}
 
@@ -2123,6 +2125,9 @@ func GetAllDependencies(taskIDs []string, taskMap map[string]*Task) ([]Dependenc
 	depSet := make(map[Dependency]bool)
 	for _, tID := range taskIDs {
 		t, ok := taskMap[tID]
+		if !ok {
+			t, ok = missingTaskMap[tID]
+		}
 		if !ok {
 			return nil, errors.Errorf("task '%s' does not exist", tID)
 		}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1758,10 +1758,11 @@ func TestGetAllDependencies(t *testing.T) {
 
 	// mix of map and db
 	require.NoError(t, tasks[1].Insert())
-	require.NoError(t, tasks[2].Insert())
-	dependencies, err = GetAllDependencies([]string{tasks[0].Id, tasks[1].Id}, map[string]*Task{tasks[0].Id: &tasks[0]})
+	taskMap := map[string]*Task{tasks[0].Id: &tasks[0]}
+	dependencies, err = GetAllDependencies([]string{tasks[0].Id, tasks[1].Id}, taskMap)
 	assert.NoError(t, err)
 	assert.Len(t, dependencies, 2)
+	assert.Len(t, taskMap, 1)
 }
 
 func TestGetRecursiveDependenciesUp(t *testing.T) {


### PR DESCRIPTION
The existing solution wasn't deduplicating the dependencies because as we iterate over the `map[string]displayTaskInfo` we modify a copy of the displayTaskInfo without saving it back into the map. The display task itself has dependencies added because the displayTaskInfo stores a _pointer_ to the task.

I found the pointer logic misleading, so I reordered the function to create execution tasks first. This way we can set the dependencies on the display task without keeping a pointer to it.