### PR TITLE
EVG-12825 remove diffToMbox

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-08-19"
+	ClientVersion = "2020-08-20"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-08-17"

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -120,12 +120,6 @@ func Patch() cli.Command {
 			if err != nil {
 				return err
 			}
-			if !params.PreserveCommits {
-				diffData.fullPatch, err = diffToMbox(diffData, params.Description)
-				if err != nil {
-					return err
-				}
-			}
 
 			if err = params.validateSubmission(diffData); err != nil {
 				return err

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -91,16 +90,6 @@ func PatchSetModule() cli.Command {
 			diffData, err := loadGitData(moduleBranch, ref, "", preserveCommits, args...)
 			if err != nil {
 				return err
-			}
-			if !preserveCommits {
-				var existingPatch *patch.Patch
-				if existingPatch, err = ac.GetPatch(patchID); err != nil {
-					return errors.Wrapf(err, "can't get existing patch '%s'", patchID)
-				}
-				diffData.fullPatch, err = diffToMbox(diffData, existingPatch.Description)
-				if err != nil {
-					return err
-				}
 			}
 
 			if err = validatePatchSize(diffData, large); err != nil {

--- a/operations/patch_util_test.go
+++ b/operations/patch_util_test.go
@@ -147,51 +147,6 @@ func (s *PatchUtilTestSuite) TestVariantsTasksFromCLI() {
 	s.Contains(pp.Tasks, "mytask2")
 }
 
-func (s *PatchUtilTestSuite) TestAddMetadataToDiff() {
-	metadata := GitMetadata{
-		Username:    "octocat",
-		Email:       "octocat@github.com",
-		CurrentTime: "Tue, 7 Jul 2020 16:50:42 -0400",
-		GitVersion:  "2.19.1",
-		Subject:     "EVG-12345 diff to mbox",
-	}
-
-	diffData := &localDiff{
-		fullPatch: "+ func diffToMbox(diffData *localDiff, subject string) (string, error) {",
-		log:       "operations/patch_util.go           |  17 ---",
-	}
-
-	mboxDiff, err := addMetadataToDiff(diffData, metadata)
-	s.NoError(err)
-	s.Equal(`From 72899681697bc4c45b1dae2c97c62e2e7e5d597b Mon Sep 17 00:00:00 2001
-From: octocat <octocat@github.com>
-Date: Tue, 7 Jul 2020 16:50:42 -0400
-Subject: EVG-12345 diff to mbox
-
----
-operations/patch_util.go           |  17 ---
-
-+ func diffToMbox(diffData *localDiff, subject string) (string, error) {
---
-2.19.1
-`, mboxDiff)
-}
-
-func (s *PatchUtilTestSuite) TestParseGitVersionString() {
-	versionStrings := map[string]string{
-		"git version 2.19.1":                   "2.19.1",
-		"git version 2.24.3 (Apple Git-128)":   "2.24.3",
-		"git version 2.21.1 (Apple Git-122.3)": "2.21.1",
-		"git version 2.16.2.windows.1":         "2.16.2.windows.1",
-	}
-
-	for versionString, version := range versionStrings {
-		parsedVersion, err := parseGitVersion(versionString)
-		s.NoError(err)
-		s.Equal(version, parsedVersion)
-	}
-}
-
 func (s *PatchUtilTestSuite) TearDownSuite() {
 	s.Require().NoError(os.RemoveAll(s.tempDir))
 }


### PR DESCRIPTION
Having every patch in patch format needs to be temporarily reverted. Users can still make their patches enqueuable by passing the `--preserve-commits` flag.