### PR TITLE
EVG-12825 put diffToMbox behind a flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-08-19"
+	ClientVersion = "2020-08-20"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-08-17"

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -309,7 +310,7 @@ func addUncommittedChangesFlag(flags ...cli.Flag) []cli.Flag {
 func addPreserveCommitsFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.BoolFlag{
 		Name:  preserveCommitsFlag,
-		Usage: "preserve separate commits when enqueueing to the commit queue",
+		Usage: fmt.Sprintf("preserve separate commits when enqueueing to the commit queue. Implies --%s", enableEnqueueFlag),
 	})
 }
 

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -40,6 +40,7 @@ const (
 	dirFlagName               = "dir"
 	uncommittedChangesFlag    = "uncommitted"
 	preserveCommitsFlag       = "preserve-commits"
+	enableEnqueueFlag         = "enable-enqueue"
 	subscriptionTypeFlag      = "subscription-type"
 
 	anserDryRunFlagName      = "dry-run"
@@ -309,6 +310,13 @@ func addPreserveCommitsFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.BoolFlag{
 		Name:  preserveCommitsFlag,
 		Usage: "preserve separate commits when enqueueing to the commit queue",
+	})
+}
+
+func addEnableEnqueueFlag(flags ...cli.Flag) []cli.Flag {
+	return append(flags, cli.BoolFlag{
+		Name:  enableEnqueueFlag,
+		Usage: "format patch to enable enqueueing to the commit queue",
 	})
 }
 

--- a/operations/model.go
+++ b/operations/model.go
@@ -79,6 +79,8 @@ type ClientSettings struct {
 	APIKey             string              `json:"api_key" yaml:"api_key,omitempty"`
 	User               string              `json:"user" yaml:"user,omitempty"`
 	UncommittedChanges bool                `json:"patch_uncommitted_changes" yaml:"patch_uncommitted_changes,omitempty"`
+	EnableEnqueue      bool                `json:"enable_enqueue" yaml:"enable_enqueue,omitempty"`
+	PreserveCommits    bool                `json:"preserve_commits" yaml:"preserve_commits,omitempty"`
 	Projects           []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
 	Admin              ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`
 	LoadedFrom         string              `json:"-" yaml:"-"`

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -32,7 +32,8 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 		addYesFlag(),
 		addRefFlag(),
 		addUncommittedChangesFlag(),
-		addPreserveCommitsFlag(
+		addPreserveCommitsFlag(),
+		addEnableEnqueueFlag(
 			cli.StringFlag{
 				Name:  joinFlagNames(patchDescriptionFlagName, "d"),
 				Usage: "description for the patch",
@@ -84,6 +85,7 @@ func Patch() cli.Command {
 				Ref:               c.String(refFlagName),
 				Uncommitted:       c.Bool(uncommittedChangesFlag),
 				PreserveCommits:   c.Bool(preserveCommitsFlag),
+				EnableEnqueue:     c.Bool(enableEnqueueFlag),
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -120,7 +122,7 @@ func Patch() cli.Command {
 			if err != nil {
 				return err
 			}
-			if !params.PreserveCommits {
+			if params.EnableEnqueue && !params.PreserveCommits {
 				diffData.fullPatch, err = diffToMbox(diffData, params.Description)
 				if err != nil {
 					return err

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -96,6 +96,7 @@ func Patch() cli.Command {
 				return errors.Wrap(err, "problem loading configuration")
 			}
 
+			params.PreserveCommits = params.PreserveCommits || conf.PreserveCommits
 			keepGoing, err := confirmUncommittedChanges(params.PreserveCommits, params.Uncommitted || conf.UncommittedChanges)
 			if err != nil {
 				return errors.Wrap(err, "can't test for uncommitted changes")
@@ -122,7 +123,7 @@ func Patch() cli.Command {
 			if err != nil {
 				return err
 			}
-			if params.EnableEnqueue && !params.PreserveCommits {
+			if (params.EnableEnqueue || conf.EnableEnqueue) && !params.PreserveCommits {
 				diffData.fullPatch, err = diffToMbox(diffData, params.Description)
 				if err != nil {
 					return err

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -19,7 +19,7 @@ func PatchSetModule() cli.Command {
 		Name:    "patch-set-module",
 		Aliases: []string{"set-module"},
 		Usage:   "update or add module to an existing patch",
-		Flags: mergeFlagSlices(addPatchIDFlag(), addPathFlag(), addModuleFlag(), addYesFlag(), addRefFlag(), addUncommittedChangesFlag(), addPreserveCommitsFlag(
+		Flags: mergeFlagSlices(addPatchIDFlag(), addPathFlag(), addModuleFlag(), addYesFlag(), addRefFlag(), addUncommittedChangesFlag(), addPreserveCommitsFlag(), addEnableEnqueueFlag(
 			cli.BoolFlag{
 				Name:  largeFlagName,
 				Usage: "enable submitting larger patches (>16MB)",
@@ -39,6 +39,7 @@ func PatchSetModule() cli.Command {
 			ref := c.String(refFlagName)
 			uncommittedOk := c.Bool(uncommittedChangesFlag)
 			preserveCommits := c.Bool(preserveCommitsFlag)
+			enableEnqueue := c.Bool(enableEnqueueFlag)
 			args := c.Args()
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -92,7 +93,7 @@ func PatchSetModule() cli.Command {
 			if err != nil {
 				return err
 			}
-			if !preserveCommits {
+			if enableEnqueue && !preserveCommits {
 				var existingPatch *patch.Patch
 				if existingPatch, err = ac.GetPatch(patchID); err != nil {
 					return errors.Wrapf(err, "can't get existing patch '%s'", patchID)

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -56,6 +56,7 @@ func PatchSetModule() cli.Command {
 				return errors.Wrap(err, "problem accessing evergreen service")
 			}
 
+			preserveCommits = preserveCommits || conf.PreserveCommits
 			keepGoing, err := confirmUncommittedChanges(preserveCommits, uncommittedOk || conf.UncommittedChanges)
 			if err != nil {
 				return errors.Wrap(err, "can't test for uncommitted changes")
@@ -93,7 +94,7 @@ func PatchSetModule() cli.Command {
 			if err != nil {
 				return err
 			}
-			if enableEnqueue && !preserveCommits {
+			if (enableEnqueue || conf.EnableEnqueue) && !preserveCommits {
 				var existingPatch *patch.Patch
 				if existingPatch, err = ac.GetPatch(patchID); err != nil {
 					return errors.Wrapf(err, "can't get existing patch '%s'", patchID)

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -69,6 +69,7 @@ type patchParams struct {
 	ShowSummary       bool
 	Uncommitted       bool
 	PreserveCommits   bool
+	EnableEnqueue     bool
 	Ref               string
 	BackportOf        string
 }


### PR DESCRIPTION
An alternative to #3909: Allow users to continue using diffToMbox, but only if they opt-in.
This has an advantage that users will have the option to package multiple commits in one commit when it's enqueued (without squashing themselves).