### PR TITLE
EVG-12642 suppress non-crucial price fetcher errors

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1531,6 +1531,9 @@ func (m *ec2Manager) CostForDuration(ctx context.Context, h *host.Host, start, e
 	if end.Before(start) || utility.IsZeroTime(start) || utility.IsZeroTime(end) {
 		return 0, errors.New("task timing data is malformed")
 	}
+	if m.region != evergreen.DefaultEC2Region { // price fetcher not implemented for other regions
+		return 0, nil
+	}
 	if err := m.client.Create(m.credentials, m.region); err != nil {
 		return 0, errors.Wrap(err, "error creating client")
 	}

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -280,10 +280,12 @@ func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, cl
 		if err != nil {
 			return errors.Wrapf(err, "error getting EC2 settings for host '%s'", h.Id)
 		}
+		// suppress error, as this information isn't crucial.
 		h.ComputeCostPerHour, _, err = pkgCachingPriceFetcher.getLatestSpotCostForInstance(ctx, client, ec2Settings, getOsName(h), h.Zone)
-		if err != nil {
-			return errors.Wrapf(err, "can't get pricing for host '%s'", h.Id)
-		}
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "problem getting latest ec2 spot price",
+			"host":    h.Id,
+		}))
 	}
 
 	h.VolumeTotalSize, err = getVolumeSize(ctx, client, h)

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -371,11 +371,10 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			}
 			if calc, ok := manager.(cloud.CostCalculator); ok {
 				cost, err := calc.CostForDuration(ctx, j.host, j.host.StartTime, hostBillingEnds)
-				if err != nil {
-					j.AddError(err)
-					return
+				j.AddError(err) // don't return as this isn't crucial
+				if err == nil {
+					j.AddError(task.IncSpawnedHostCost(j.host.StartedBy, cost))
 				}
-				j.AddError(task.IncSpawnedHostCost(j.host.StartedBy, cost))
 			}
 		}
 	}


### PR DESCRIPTION
It's probably personal preference where/when to suppress these errors. I've suppressed the functions that are used in places that aren't strictly related to cost (the most important of which is `getProvider`, which is used to spawn hosts). I've also added another region check for the ec2Manager, but I didn't with ec2Fleet since these won't be in other regions.