### PR TITLE
EVG-7976 move log message to task logs

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -81,13 +81,6 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			continue
 		}
 
-		if len(cmds) == 1 {
-			tc.logger.Task().Infof("Running command %s (step %d of %d)", fullCommandName, index, total)
-		} else {
-			// for functions with more than one command
-			tc.logger.Task().Infof("Running command %v (step %d.%d of %d)", fullCommandName, index, idx+1, total)
-		}
-
 		for key, val := range commandInfo.Vars {
 			var newVal string
 			newVal, err = tc.taskConfig.Expansions.ExpandString(val)
@@ -103,6 +96,12 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			a.comm.UpdateLastMessageTime()
 		} else {
 			tc.setCurrentIdleTimeout(nil)
+		}
+		if len(cmds) == 1 {
+			tc.logger.Task().Infof("Running command %s (step %d of %d)", fullCommandName, index, total)
+		} else {
+			// for functions with more than one command
+			tc.logger.Task().Infof("Running command %v (step %d.%d of %d)", fullCommandName, index, idx+1, total)
 		}
 
 		start := time.Now()
@@ -131,7 +130,7 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			tc.logger.Task().Errorf("Command stopped early: %s", ctx.Err())
 			return errors.Wrap(ctx.Err(), "Agent stopped early")
 		}
-		tc.logger.Execution().Infof("Finished %s in %s", fullCommandName, time.Since(start).String())
+		tc.logger.Task().Infof("Finished %s in %s", fullCommandName, time.Since(start).String())
 	}
 	return nil
 }

--- a/agent/command.go
+++ b/agent/command.go
@@ -81,6 +81,12 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			continue
 		}
 
+		if len(cmds) == 1 {
+			tc.logger.Task().Infof("Running command %s (step %d of %d)", fullCommandName, index, total)
+		} else {
+			// for functions with more than one command
+			tc.logger.Task().Infof("Running command %v (step %d.%d of %d)", fullCommandName, index, idx+1, total)
+		}
 		for key, val := range commandInfo.Vars {
 			var newVal string
 			newVal, err = tc.taskConfig.Expansions.ExpandString(val)
@@ -96,12 +102,6 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			a.comm.UpdateLastMessageTime()
 		} else {
 			tc.setCurrentIdleTimeout(nil)
-		}
-		if len(cmds) == 1 {
-			tc.logger.Task().Infof("Running command %s (step %d of %d)", fullCommandName, index, total)
-		} else {
-			// for functions with more than one command
-			tc.logger.Task().Infof("Running command %v (step %d.%d of %d)", fullCommandName, index, idx+1, total)
 		}
 
 		start := time.Now()

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2020-08-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-08-17"
+	AgentVersion = "2020-08-21"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
I originally took this ticket with the intent of adding a display name to commands (didn't know that it already exists) and to improve command logging in general. The only change here is to move the end of command log line from the agent to task log