### PR TITLE
EVG-12873: fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ linters:
     - goimports
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - unconvert
 

--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -161,6 +161,8 @@ func generateTasks() (*shrub.Configuration, error) {
 	group := conf.TaskGroup(lintGroup).SetMaxHosts(maxHosts)
 	group.SetupGroup.Command().Type("system").Command("git.get_project").Param("directory", "gopath/src/github.com/evergreen-ci/evergreen")
 	group.SetupGroup.Command().Function("setup-credentials")
+	cmd := group.SetupGroup.Command().Function("run-make")
+	cmd.Vars = map[string]string{"target": "get-go-imports"}
 	group.TeardownTask.Command().Function("attach-test-results")
 	group.TeardownTask.Command().Function("remove-test-results")
 	group.Task(lintTargets...)

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -235,7 +235,7 @@ func (r *mutationResolver) SpawnHost(ctx context.Context, spawnHostInput *SpawnH
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error spawning host: %s", err))
 	}
 	if spawnHost == nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("An error occured Spawn host is nil"))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("An error occurred Spawn host is nil"))
 	}
 	apiHost := restModel.APIHost{}
 	err = apiHost.BuildFromService(spawnHost)
@@ -1318,7 +1318,7 @@ func (r *mutationResolver) SchedulePatch(ctx context.Context, patchID string, re
 		// FindVersionById does not distinguish between nil version err and db err; therefore must check that err
 		// does not contain nil version err values before sending InternalServerError
 		if !strings.Contains(err.Error(), strconv.Itoa(http.StatusNotFound)) {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error occured fetching patch `%s`: %s", patchID, err.Error()))
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error occurred fetching patch `%s`: %s", patchID, err.Error()))
 		}
 	}
 	err, _, _, versionID := SchedulePatch(ctx, patchID, version, patchUpdateReq)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -31,7 +31,7 @@ type StatusChanges struct {
 }
 
 func SetActiveState(t *task.Task, caller string, active bool) error {
-	modifiedTasks := []task.Task{}
+	var modifiedTasks []task.Task
 	if active {
 		// if the task is being activated and it doesn't override its dependencies
 		// activate the task's dependencies as well

--- a/rest/model/codegen.go
+++ b/rest/model/codegen.go
@@ -129,7 +129,9 @@ func Codegen(schema string, config ModelMapping) ([]byte, []byte, error) {
 			continue
 		}
 
-		structData, code, err := generateForStruct(fieldTemplate, structTemplate, typeName, dbModel, *gqlType, generatedConversions)
+		var structData string
+		var code string
+		structData, code, err = generateForStruct(fieldTemplate, structTemplate, typeName, dbModel, *gqlType, generatedConversions)
 		if err != nil {
 			catcher.Add(err)
 			continue
@@ -163,10 +165,10 @@ func Codegen(schema string, config ModelMapping) ([]byte, []byte, error) {
 // as well as BuildFromService/ToService conversion methods
 func generateForStruct(fieldTemplate, structTemplate *template.Template, typeName, dbModel string, gqlType ast.Definition, generatedConversions map[typeInfo]string) (string, string, error) {
 	fields := ""
-	extractedFields := extractedFields{}
+	extracted := extractedFields{}
 	for _, field := range gqlType.Fields {
 		fieldInfo := getFieldInfo(field)
-		extractedFields[dbField(*field)] = fieldInfo
+		extracted[dbField(*field)] = fieldInfo
 		fieldData, err := output(fieldTemplate, fieldInfo)
 		if err != nil {
 			return "", "", err
@@ -184,7 +186,7 @@ func generateForStruct(fieldTemplate, structTemplate *template.Template, typeNam
 		return "", "", err
 	}
 
-	code, err := createConversionMethods(dbPkg, dbStructName, extractedFields, generatedConversions)
+	code, err := createConversionMethods(dbPkg, dbStructName, extracted, generatedConversions)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "error generating conversion methods for type '%s'", typeName)
 	}

--- a/rest/model/conversions.go
+++ b/rest/model/conversions.go
@@ -131,12 +131,12 @@ func generateArrayConversions(modelName string, modelType types.Type, restName, 
 		outIsPtr: outIsPtr,
 		outType:  restType,
 	}
-	convertFuncs, err := arrayConversionFn(opts, generatedConversions)
+	funcs, err := arrayConversionFn(opts, generatedConversions)
 	if err != nil {
 		return "", err
 	}
 	bfsData := conversionLine{
-		TypeConversionFunc: convertFuncs.converter,
+		TypeConversionFunc: funcs.converter,
 	}
 	bfsCode, err := output(lineTemplate, bfsData)
 	if err != nil {
@@ -156,7 +156,7 @@ func generateArrayConversions(modelName string, modelType types.Type, restName, 
 	}
 	if modelTypeStr != restType {
 		tsData := conversionLine{
-			TypeConversionFunc: convertFuncs.inverter,
+			TypeConversionFunc: funcs.inverter,
 		}
 		tsCode, err := output(lineTemplate, tsData)
 		if err != nil {

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -58,9 +60,9 @@ type DistroInfo struct {
 	Id                   *string `json:"distro_id"`
 	Provider             *string `json:"provider"`
 	ImageId              *string `json:"image_id"`
-	WorkDir              *string `json:"work_dir`
-	IsVirtualWorkstation bool    `json:"is_virtual_workstation`
-	User                 *string `json:user"`
+	WorkDir              *string `json:"work_dir"`
+	IsVirtualWorkstation bool    `json:"is_virtual_workstation"`
+	User                 *string `json:"user"`
 }
 
 type TaskInfo struct {
@@ -133,7 +135,11 @@ func (apiHost *APIHost) buildFromHostStruct(h interface{}) error {
 	imageId, err := v.Distro.GetImageID()
 	if err != nil {
 		// report error but do not fail function because of a bad imageId
-		errors.Wrap(err, "problem getting image ID")
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "could not get image ID",
+			"host":    v.Id,
+			"distro":  v.Distro.Id,
+		}))
 	}
 	di := DistroInfo{
 		Id:                   ToStringPtr(v.Distro.Id),

--- a/util/expand_params.go
+++ b/util/expand_params.go
@@ -60,7 +60,7 @@ func expandMap(inputMap reflect.Value, expansions *Expansions) error {
 
 		// expand and set new value
 		val := inputMap.MapIndex(key)
-		expandedVal := reflect.Value{}
+		var expandedVal reflect.Value
 		switch val.Type().Kind() {
 		case reflect.String:
 			expandedValString, err := expansions.ExpandString(val.String())


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12873

* Fix generate-lint, which did not run `make get-go-imports`, which is required for Evergreen to compile.
* Fix all package linting issues.