### PR TITLE
EVG-12826 store patches in mbox format

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-08-26"
+	ClientVersion = "2020-08-28"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-08-27"

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -41,7 +40,6 @@ const (
 	dirFlagName               = "dir"
 	uncommittedChangesFlag    = "uncommitted"
 	preserveCommitsFlag       = "preserve-commits"
-	enableEnqueueFlag         = "enable-enqueue"
 	subscriptionTypeFlag      = "subscription-type"
 
 	anserDryRunFlagName      = "dry-run"
@@ -310,14 +308,7 @@ func addUncommittedChangesFlag(flags ...cli.Flag) []cli.Flag {
 func addPreserveCommitsFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.BoolFlag{
 		Name:  preserveCommitsFlag,
-		Usage: fmt.Sprintf("preserve separate commits when enqueueing to the commit queue. Implies --%s", enableEnqueueFlag),
-	})
-}
-
-func addEnableEnqueueFlag(flags ...cli.Flag) []cli.Flag {
-	return append(flags, cli.BoolFlag{
-		Name:  enableEnqueueFlag,
-		Usage: "format patch to enable enqueueing to the commit queue",
+		Usage: "preserve separate commits when enqueueing to the commit queue",
 	})
 }
 

--- a/operations/model.go
+++ b/operations/model.go
@@ -79,6 +79,7 @@ type ClientSettings struct {
 	APIKey             string              `json:"api_key" yaml:"api_key,omitempty"`
 	User               string              `json:"user" yaml:"user,omitempty"`
 	UncommittedChanges bool                `json:"patch_uncommitted_changes" yaml:"patch_uncommitted_changes,omitempty"`
+	PreserveCommits    bool                `json:"preserve_commits" yaml:"preserve_commits,omitempty"`
 	Projects           []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
 	Admin              ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`
 	LoadedFrom         string              `json:"-" yaml:"-"`

--- a/operations/model.go
+++ b/operations/model.go
@@ -79,8 +79,6 @@ type ClientSettings struct {
 	APIKey             string              `json:"api_key" yaml:"api_key,omitempty"`
 	User               string              `json:"user" yaml:"user,omitempty"`
 	UncommittedChanges bool                `json:"patch_uncommitted_changes" yaml:"patch_uncommitted_changes,omitempty"`
-	EnableEnqueue      bool                `json:"enable_enqueue" yaml:"enable_enqueue,omitempty"`
-	PreserveCommits    bool                `json:"preserve_commits" yaml:"preserve_commits,omitempty"`
 	Projects           []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
 	Admin              ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`
 	LoadedFrom         string              `json:"-" yaml:"-"`

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -94,6 +94,7 @@ func Patch() cli.Command {
 				return errors.Wrap(err, "problem loading configuration")
 			}
 
+			params.PreserveCommits = params.PreserveCommits || conf.PreserveCommits
 			keepGoing, err := confirmUncommittedChanges(params.PreserveCommits, params.Uncommitted || conf.UncommittedChanges)
 			if err != nil {
 				return errors.Wrap(err, "can't test for uncommitted changes")

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -32,8 +32,7 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 		addYesFlag(),
 		addRefFlag(),
 		addUncommittedChangesFlag(),
-		addPreserveCommitsFlag(),
-		addEnableEnqueueFlag(
+		addPreserveCommitsFlag(
 			cli.StringFlag{
 				Name:  joinFlagNames(patchDescriptionFlagName, "d"),
 				Usage: "description for the patch",
@@ -85,7 +84,6 @@ func Patch() cli.Command {
 				Ref:               c.String(refFlagName),
 				Uncommitted:       c.Bool(uncommittedChangesFlag),
 				PreserveCommits:   c.Bool(preserveCommitsFlag),
-				EnableEnqueue:     c.Bool(enableEnqueueFlag),
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -96,7 +94,6 @@ func Patch() cli.Command {
 				return errors.Wrap(err, "problem loading configuration")
 			}
 
-			params.PreserveCommits = params.PreserveCommits || conf.PreserveCommits
 			keepGoing, err := confirmUncommittedChanges(params.PreserveCommits, params.Uncommitted || conf.UncommittedChanges)
 			if err != nil {
 				return errors.Wrap(err, "can't test for uncommitted changes")
@@ -123,7 +120,7 @@ func Patch() cli.Command {
 			if err != nil {
 				return err
 			}
-			if (params.EnableEnqueue || conf.EnableEnqueue) && !params.PreserveCommits {
+			if !params.PreserveCommits {
 				diffData.fullPatch, err = diffToMbox(diffData, params.Description)
 				if err != nil {
 					return err

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -55,6 +55,7 @@ func PatchSetModule() cli.Command {
 				return errors.Wrap(err, "problem accessing evergreen service")
 			}
 
+			preserveCommits = preserveCommits || conf.PreserveCommits
 			keepGoing, err := confirmUncommittedChanges(preserveCommits, uncommittedOk || conf.UncommittedChanges)
 			if err != nil {
 				return errors.Wrap(err, "can't test for uncommitted changes")

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -19,7 +19,7 @@ func PatchSetModule() cli.Command {
 		Name:    "patch-set-module",
 		Aliases: []string{"set-module"},
 		Usage:   "update or add module to an existing patch",
-		Flags: mergeFlagSlices(addPatchIDFlag(), addPathFlag(), addModuleFlag(), addYesFlag(), addRefFlag(), addUncommittedChangesFlag(), addPreserveCommitsFlag(), addEnableEnqueueFlag(
+		Flags: mergeFlagSlices(addPatchIDFlag(), addPathFlag(), addModuleFlag(), addYesFlag(), addRefFlag(), addUncommittedChangesFlag(), addPreserveCommitsFlag(
 			cli.BoolFlag{
 				Name:  largeFlagName,
 				Usage: "enable submitting larger patches (>16MB)",
@@ -39,7 +39,6 @@ func PatchSetModule() cli.Command {
 			ref := c.String(refFlagName)
 			uncommittedOk := c.Bool(uncommittedChangesFlag)
 			preserveCommits := c.Bool(preserveCommitsFlag)
-			enableEnqueue := c.Bool(enableEnqueueFlag)
 			args := c.Args()
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -56,7 +55,6 @@ func PatchSetModule() cli.Command {
 				return errors.Wrap(err, "problem accessing evergreen service")
 			}
 
-			preserveCommits = preserveCommits || conf.PreserveCommits
 			keepGoing, err := confirmUncommittedChanges(preserveCommits, uncommittedOk || conf.UncommittedChanges)
 			if err != nil {
 				return errors.Wrap(err, "can't test for uncommitted changes")
@@ -94,7 +92,7 @@ func PatchSetModule() cli.Command {
 			if err != nil {
 				return err
 			}
-			if (enableEnqueue || conf.EnableEnqueue) && !preserveCommits {
+			if !preserveCommits {
 				var existingPatch *patch.Patch
 				if existingPatch, err = ac.GetPatch(patchID); err != nil {
 					return errors.Wrapf(err, "can't get existing patch '%s'", patchID)

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -69,7 +69,6 @@ type patchParams struct {
 	ShowSummary       bool
 	Uncommitted       bool
 	PreserveCommits   bool
-	EnableEnqueue     bool
 	Ref               string
 	BackportOf        patch.BackportInfo
 }


### PR DESCRIPTION
#3910 stopped most patches from being wrapped in patch format until [SERVER-50401](https://jira.mongodb.org/browse/SERVER-50401) could be implemented. Now that it has, revert those changes.

Still keep the PreserveCommits configuration option added there, since that still seems useful.