### PR TITLE
EVG-12537 disable oom tracker for containers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -432,16 +432,16 @@ func (a *Agent) wait(ctx, taskCtx context.Context, tc *taskContext, heartbeat ch
 		a.runTaskTimeoutCommands(ctx, tc)
 	}
 
-	if tc.project.OomTracker && status == evergreen.TaskFailed {
+	if tc.oomTrackerEnabled() && status == evergreen.TaskFailed {
 		startTime := time.Now()
 		oomCtx, oomCancel := context.WithTimeout(ctx, time.Second*10)
 		defer oomCancel()
 		if err := tc.oomTracker.Check(oomCtx); err != nil {
 			tc.logger.Execution().Errorf("error checking for OOM killed processes: %s", err)
 		}
-		durationString := fmt.Sprintf("found no OOM kill in %.2f seconds", time.Now().Sub(startTime).Seconds())
+		durationString := fmt.Sprintf("found no OOM kill in %.3f seconds", time.Now().Sub(startTime).Seconds())
 		if found, _ := tc.oomTracker.Report(); found {
-			durationString = fmt.Sprintf("found an OOM kill in %.2f seconds", time.Now().Sub(startTime).Seconds())
+			durationString = fmt.Sprintf("found an OOM kill in %.3f seconds", time.Now().Sub(startTime).Seconds())
 		}
 		tc.logger.Execution().Debug(durationString)
 	}

--- a/agent/task.go
+++ b/agent/task.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/command"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -123,7 +124,7 @@ func (a *Agent) startTask(ctx context.Context, tc *taskContext, complete chan<- 
 		return
 	}
 
-	if tc.project.OomTracker {
+	if tc.oomTrackerEnabled() {
 		tc.logger.Execution().Info("OOM tracker clearing system messages")
 		if err = tc.oomTracker.Clear(innerCtx); err != nil {
 			tc.logger.Execution().Errorf("error clearing system messages: %s", err)
@@ -258,6 +259,10 @@ func (tc *taskContext) getOomTrackerInfo() apimodels.OOMTrackerInfo {
 		Detected: detected,
 		Pids:     pids,
 	}
+}
+
+func (tc *taskContext) oomTrackerEnabled() bool {
+	return tc.project.OomTracker && !utility.StringSliceContains(evergreen.ProviderContainer, tc.taskConfig.Distro.Provider)
 }
 
 func (tc *taskContext) setIdleTimeout(dur time.Duration) {

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2020-08-26"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-08-27"
+	AgentVersion = "2020-08-31"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Containers don't have write access to dmesg (needed to clear the log before we start running the task).
Detecting an OOM kill is also not meaningful in the context of containers since it could have been the result of another task.