### PR TITLE
EVG-12788 re-evaluate dependencies on end task

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -437,6 +437,10 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 		return errors.Wrap(err, "could not mark task finished")
 	}
 
+	if err = UpdateUnblockedDependencies(t); err != nil {
+		return errors.Wrap(err, "could not update unblocked dependencies")
+	}
+
 	if err = UpdateBlockedDependencies(t); err != nil {
 		return errors.Wrap(err, "could not update blocked dependencies")
 	}


### PR DESCRIPTION
I wasn't able to figure out the cause, so the approach here is to add more redundancy when computing dependencies. Now in end task, we will reset the unattainable state of dependent tasks to what they should be. In the scenarios that I'm aware of, the line I added should not actually do anything, but the hope is that whatever scenario is causing this ticket will be fixed by this.

Note that not all code paths to put a task in a finalized status goes through here - notably our stranded task jobs. For those, they should already be resetting the dependencies as well as the task, so it presumably will run again to completion and hit this path