### PR TITLE
EVG-12676 add missing service user pieces

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -115,6 +115,14 @@ func makeMultiManager(settings *evergreen.Settings, config evergreen.AuthConfig)
 		}
 	}
 	var ro []gimlet.UserManager
+	if config.AllowServiceUsers {
+		manager, _, err := makeOnlyAPIManager()
+		if err == nil {
+			ro = append(ro, manager)
+		} else {
+			grip.Critical(errors.Wrap(err, "could not create only-api manager"))
+		}
+	}
 	for _, kind := range config.Multi.ReadOnly {
 		// Ignore info because these managers are read-only and info currently
 		// only contains write operation capabilities.

--- a/config_auth.go
+++ b/config_auth.go
@@ -129,6 +129,7 @@ func (c *AuthConfig) Set() error {
 			AuthMultiKey:                   c.Multi,
 			authPreferredTypeKey:           c.PreferredType,
 			authBackgroundReauthMinutesKey: c.BackgroundReauthMinutes,
+			AllowServiceUsersKey:           c.AllowServiceUsers,
 		}}, options.Update().SetUpsert(true))
 
 	return errors.Wrapf(err, "error updating section %s", c.SectionId())
@@ -202,7 +203,7 @@ func (c *AuthConfig) ValidateAndDefault() error {
 			case AuthNaiveKey:
 				catcher.NewWhen(c.Naive == nil, "Naive settings cannot be empty if using in multi auth")
 			case AuthOnlyAPIKey:
-				catcher.NewWhen(c.OnlyAPI == nil, "OnlyAPI settings cannot be empty if using in multi auth")
+				continue
 			default:
 				catcher.Errorf("unrecognized auth mechanism '%s'", kind)
 			}

--- a/config_db.go
+++ b/config_db.go
@@ -100,6 +100,7 @@ var (
 	AuthMultiKey                   = bsonutil.MustHaveTag(AuthConfig{}, "Multi")
 	authPreferredTypeKey           = bsonutil.MustHaveTag(AuthConfig{}, "PreferredType")
 	authBackgroundReauthMinutesKey = bsonutil.MustHaveTag(AuthConfig{}, "BackgroundReauthMinutes")
+	AllowServiceUsersKey           = bsonutil.MustHaveTag(AuthConfig{}, "AllowServiceUsers")
 
 	// ContainerPoolsConfig keys
 	poolsKey = bsonutil.MustHaveTag(ContainerPoolsConfig{}, "Pools")

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -386,6 +386,7 @@ type APIAuthConfig struct {
 	Multi                   *APIMultiAuthConfig  `json:"multi"`
 	PreferredType           *string              `json:"preferred_type"`
 	BackgroundReauthMinutes int                  `json:"background_reauth_minutes"`
+	AllowServiceUsers       bool                 `json:"allow_service_users"`
 }
 
 func (a *APIAuthConfig) BuildFromService(h interface{}) error {
@@ -423,6 +424,7 @@ func (a *APIAuthConfig) BuildFromService(h interface{}) error {
 		}
 		a.PreferredType = ToStringPtr(v.PreferredType)
 		a.BackgroundReauthMinutes = v.BackgroundReauthMinutes
+		a.AllowServiceUsers = v.AllowServiceUsers
 	default:
 		return errors.Errorf("%T is not a supported type", h)
 	}
@@ -499,6 +501,7 @@ func (a *APIAuthConfig) ToService() (interface{}, error) {
 		Multi:                   multi,
 		PreferredType:           FromStringPtr(a.PreferredType),
 		BackgroundReauthMinutes: a.BackgroundReauthMinutes,
+		AllowServiceUsers:       a.AllowServiceUsers,
 	}, nil
 }
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -750,6 +750,11 @@ Admin Settings
 										<label>Background Reauth (Minutes)</label>
 										<input type="number" ng-model="Settings.auth.background_reauth_minutes">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
+										<md-checkbox ng-model="Settings.auth.allow_service_users">
+											Allow Service Users
+										</md-checkbox>
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 


### PR DESCRIPTION
Missed a couple things in the last pr
- add a read-only only-api auth manager if allowing service users
- add a checkbox to admin settings to toggle this