### PR TITLE
EVG-8310 makespan for first execution only

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -520,7 +520,7 @@ func (r *patchResolver) Builds(ctx context.Context, obj *restModel.APIPatch) ([]
 }
 
 func (r *patchResolver) Duration(ctx context.Context, obj *restModel.APIPatch) (*PatchDuration, error) {
-	tasks, err := task.FindAllNewOrOld(task.ByVersion(*obj.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey), 0)
+	tasks, err := task.FindAllFirstExecution(task.ByVersion(*obj.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -520,8 +520,7 @@ func (r *patchResolver) Builds(ctx context.Context, obj *restModel.APIPatch) ([]
 }
 
 func (r *patchResolver) Duration(ctx context.Context, obj *restModel.APIPatch) (*PatchDuration, error) {
-	// excludes display tasks
-	tasks, err := task.Find(task.ByVersion(*obj.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey))
+	tasks, err := task.FindAllNewOrOld(task.ByVersion(*obj.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey), 0)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}

--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -79,19 +80,12 @@ func BbGetConfig(settings *evergreen.Settings) map[string]evergreen.BuildBaronPr
 	return projects
 }
 
-func BbGetTask(taskId string, execution string) (*task.Task, error) {
-	oldId := fmt.Sprintf("%v_%v", taskId, execution)
-	t, err := task.FindOneOld(task.ById(oldId))
+func BbGetTask(taskId string, executionString string) (*task.Task, error) {
+	execution, err := strconv.Atoi(executionString)
 	if err != nil {
-		return t, errors.Wrap(err, "Failed to find task with old Id")
+		return nil, errors.Wrap(err, "Invalid execution number")
 	}
-	// if the archived task was not found, we must be looking for the most recent exec
-	if t == nil {
-		t, err = task.FindOne(task.ById(taskId))
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to find task")
-		}
-	}
+	t, err := task.FindOneIdOldOrNew(taskId, execution)
 	if t == nil {
 		return nil, errors.Errorf("No task found for taskId: %s and execution: %s", taskId, execution)
 	}

--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -86,8 +86,11 @@ func BbGetTask(taskId string, executionString string) (*task.Task, error) {
 		return nil, errors.Wrap(err, "Invalid execution number")
 	}
 	t, err := task.FindOneIdOldOrNew(taskId, execution)
+	if err != nil {
+		return nil, errors.Wrap(err, "problem finding task")
+	}
 	if t == nil {
-		return nil, errors.Errorf("No task found for taskId: %s and execution: %s", taskId, execution)
+		return nil, errors.Errorf("No task found for taskId: %s and execution: %d", taskId, execution)
 	}
 	if t.DisplayOnly {
 		t.LocalTestResults, err = t.GetTestResultsForDisplayTask()

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1038,7 +1038,7 @@ func MakeOldID(taskID string, execution int) string {
 	return fmt.Sprintf("%s_%d", taskID, execution)
 }
 
-func FindAllNewOrOld(q db.Q, execution int) ([]Task, error) {
+func FindAllFirstExecution(q db.Q) ([]Task, error) {
 	existingTasks, err := FindAll(q)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't get current tasks")
@@ -1046,10 +1046,10 @@ func FindAllNewOrOld(q db.Q, execution int) ([]Task, error) {
 	tasks := []Task{}
 	oldIDs := []string{}
 	for _, t := range existingTasks {
-		if t.Execution == execution {
+		if t.Execution == 0 {
 			tasks = append(tasks, t)
 		} else {
-			oldIDs = append(oldIDs, MakeOldID(t.Id, execution))
+			oldIDs = append(oldIDs, MakeOldID(t.Id, 0))
 		}
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1684,7 +1684,7 @@ func (t *Task) Archive() error {
 	}
 
 	archiveTask := *t
-	archiveTask.Id = fmt.Sprintf("%v_%v", t.Id, t.Execution)
+	archiveTask.Id = MakeOldID(t.Id, t.Execution)
 	archiveTask.OldTaskId = t.Id
 	archiveTask.Archived = true
 	err := db.Insert(OldCollection, &archiveTask)
@@ -2391,12 +2391,14 @@ func GetLatestExecution(taskId string) (int, error) {
 }
 
 // GetTimeSpent returns the total time_taken and makespan of tasks
-// tasks should not include display tasks so they aren't double counted
 func GetTimeSpent(tasks []Task) (time.Duration, time.Duration) {
 	var timeTaken time.Duration
 	earliestStartTime := utility.MaxTime
 	latestFinishTime := utility.ZeroTime
 	for _, t := range tasks {
+		if t.DisplayOnly {
+			continue
+		}
 		timeTaken += t.TimeTaken
 		if !utility.IsZeroTime(t.StartTime) && t.StartTime.Before(earliestStartTime) {
 			earliestStartTime = t.StartTime

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -870,6 +870,35 @@ func TestFindOldTasksByID(t *testing.T) {
 	assert.Equal("task", tasks[1].OldTaskId)
 }
 
+func TestFindAllNewOrOld(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection, OldCollection))
+	tasks := []Task{
+		{Id: "t0"},
+		{Id: "t1", Execution: 1},
+		{Id: "t2", DisplayOnly: true},
+	}
+	for _, task := range tasks {
+		require.NoError(t, task.Insert())
+	}
+	oldTask := Task{Id: MakeOldID("t1", 0)}
+	require.NoError(t, db.Insert(OldCollection, &oldTask))
+
+	foundTasks, err := FindAllNewOrOld(db.Query(nil), 0)
+	assert.NoError(t, err)
+	assert.Len(t, foundTasks, 3)
+	expectedIDs := []string{"t0", MakeOldID("t1", 0), "t2"}
+	for _, task := range foundTasks {
+		assert.Contains(t, expectedIDs, task.Id)
+		assert.Equal(t, 0, task.Execution)
+	}
+
+	foundTasks, err = FindAllNewOrOld(db.Query(nil), 1)
+	assert.NoError(t, err)
+	assert.Len(t, foundTasks, 1)
+	assert.Equal(t, "t1", foundTasks[0].Id)
+	assert.Equal(t, 1, foundTasks[0].Execution)
+}
+
 func TestWithinTimePeriodProjectFilter(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection, OldCollection))
@@ -1570,6 +1599,11 @@ func TestGetTimeSpent(t *testing.T) {
 			StartTime:  referenceTime,
 			FinishTime: referenceTime.Add(2 * time.Hour),
 			TimeTaken:  2 * time.Hour,
+		},
+		{
+			DisplayOnly: true,
+			FinishTime:  referenceTime.Add(3 * time.Hour),
+			TimeTaken:   2 * time.Hour,
 		},
 		{
 			StartTime:  referenceTime,

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -870,7 +870,7 @@ func TestFindOldTasksByID(t *testing.T) {
 	assert.Equal("task", tasks[1].OldTaskId)
 }
 
-func TestFindAllNewOrOld(t *testing.T) {
+func TestFindAllFirstExecution(t *testing.T) {
 	require.NoError(t, db.ClearCollections(Collection, OldCollection))
 	tasks := []Task{
 		{Id: "t0"},
@@ -883,7 +883,7 @@ func TestFindAllNewOrOld(t *testing.T) {
 	oldTask := Task{Id: MakeOldID("t1", 0)}
 	require.NoError(t, db.Insert(OldCollection, &oldTask))
 
-	foundTasks, err := FindAllNewOrOld(db.Query(nil), 0)
+	foundTasks, err := FindAllFirstExecution(db.Query(nil))
 	assert.NoError(t, err)
 	assert.Len(t, foundTasks, 3)
 	expectedIDs := []string{"t0", MakeOldID("t1", 0), "t2"}
@@ -891,12 +891,6 @@ func TestFindAllNewOrOld(t *testing.T) {
 		assert.Contains(t, expectedIDs, task.Id)
 		assert.Equal(t, 0, task.Execution)
 	}
-
-	foundTasks, err = FindAllNewOrOld(db.Query(nil), 1)
-	assert.NoError(t, err)
-	assert.Len(t, foundTasks, 1)
-	assert.Equal(t, "t1", foundTasks[0].Id)
-	assert.Equal(t, 1, foundTasks[0].Execution)
 }
 
 func TestWithinTimePeriodProjectFilter(t *testing.T) {

--- a/model/version.go
+++ b/model/version.go
@@ -107,7 +107,7 @@ func (v *Version) AddSatisfiedTrigger(definitionID string) error {
 // GetTimeSpent returns the total time_taken and makespan of a version for
 // each task that has finished running
 func (v *Version) GetTimeSpent() (time.Duration, time.Duration, error) {
-	tasks, err := task.FindAllNewOrOld(task.ByVersion(v.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey), 0)
+	tasks, err := task.FindAllFirstExecution(task.ByVersion(v.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey))
 	if err != nil {
 		return 0, 0, errors.Wrapf(err, "can't get tasks for version '%s'", v.Id)
 	}

--- a/model/version.go
+++ b/model/version.go
@@ -107,8 +107,7 @@ func (v *Version) AddSatisfiedTrigger(definitionID string) error {
 // GetTimeSpent returns the total time_taken and makespan of a version for
 // each task that has finished running
 func (v *Version) GetTimeSpent() (time.Duration, time.Duration, error) {
-	// Find excludes display tasks from consideration
-	tasks, err := task.Find(task.ByVersion(v.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey))
+	tasks, err := task.FindAllNewOrOld(task.ByVersion(v.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey), 0)
 	if err != nil {
 		return 0, 0, errors.Wrapf(err, "can't get tasks for version '%s'", v.Id)
 	}

--- a/service/build.go
+++ b/service/build.go
@@ -65,7 +65,7 @@ func (uis *UIServer) buildPage(w http.ResponseWriter, r *http.Request) {
 		buildAsUI.Repo = projCtx.ProjectRef.Repo
 	}
 
-	tasks, err := task.FindAllNewOrOld(task.ByBuildId(projCtx.Build.Id), 0)
+	tasks, err := task.FindAllFirstExecution(task.ByBuildId(projCtx.Build.Id))
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't get tasks for build"))
 		return
@@ -245,7 +245,7 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 		Version:     *projCtx.Version,
 	}
 
-	tasks, err := task.FindAllNewOrOld(task.ByBuildId(projCtx.Build.Id), 0)
+	tasks, err := task.FindAllFirstExecution(task.ByBuildId(projCtx.Build.Id))
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't get tasks for build"))
 		return

--- a/service/task.go
+++ b/service/task.go
@@ -185,7 +185,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// Construct the old task id.
-		oldTaskId := fmt.Sprintf("%v_%v", projCtx.Task.Id, executionStr)
+		oldTaskId := task.MakeOldID(projCtx.Task.Id, execution)
 
 		// Try to find the task in the old_tasks collection.
 		var taskFromDb *task.Task


### PR DESCRIPTION
Version/build makespans are the time from the beginning of the first task execution to the end of the last. If a task is restarted long after the version has finished running the makespan is an inordinately long time. Since what users really want to know from the makespan is how long the version took to run, this is not helpful.

This PR uses tasks' first execution to determine the makespan.