### PR TITLE
EVG-12393 eliminate provisioning state for userdata hosts

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -470,13 +470,6 @@ var (
 		HostBuilding,
 	}
 
-	// CanRunTaskStatus is a list of all host statuses in which a host could be running a task.
-	CanRunTaskStatus = []string{
-		HostStarting,
-		HostProvisioning,
-		HostRunning,
-	}
-
 	// DownHostStatus is a list of all host statuses that are considered down.
 	DownHostStatus = []string{
 		HostTerminated,

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -175,7 +175,7 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 						StatusKey: evergreen.HostRunning,
 					},
 					{
-						StatusKey:    bson.M{"$in": []string{evergreen.HostStarting, evergreen.HostProvisioning}},
+						StatusKey:    evergreen.HostStarting,
 						bootstrapKey: distro.BootstrapMethodUserData,
 						// User data hosts have a grace period between creation
 						// and provisioning during which they are not considered
@@ -909,7 +909,7 @@ func FindUserDataSpawnHostsProvisioning() ([]Host, error) {
 	bootstrapKey := bsonutil.GetDottedKeyName(DistroKey, distro.BootstrapSettingsKey, distro.BootstrapSettingsMethodKey)
 
 	hosts, err := Find(db.Query(bson.M{
-		StatusKey:      evergreen.HostProvisioning,
+		StatusKey:      evergreen.HostStarting,
 		ProvisionedKey: true,
 		StartedByKey:   bson.M{"$ne": evergreen.User},
 		bootstrapKey:   distro.BootstrapMethodUserData,

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -388,7 +388,7 @@ func ByUnprovisionedSince(threshold time.Time) db.Q {
 func ByTaskSpec(group, buildVariant, project, version string) db.Q {
 	return db.Query(
 		bson.M{
-			StatusKey: bson.M{"$in": evergreen.CanRunTaskStatus},
+			StatusKey: bson.M{"$in": []string{evergreen.HostStarting, evergreen.HostRunning}},
 			"$or": []bson.M{
 				{
 					RunningTaskKey:             bson.M{"$exists": "true"},

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -871,22 +871,22 @@ func (h *Host) SetProvisionedNotRunning() error {
 	return nil
 }
 
-// UpdateProvisioningToRunning changes the host status from provisioning to
+// UpdateStartingToRunning changes the host status from provisioning to
 // running, as well as logging that the host has finished provisioning.
-func (h *Host) UpdateProvisioningToRunning() error {
-	if h.Status != evergreen.HostProvisioning {
+func (h *Host) UpdateStartingToRunning() error {
+	if h.Status != evergreen.HostStarting {
 		return nil
 	}
 
 	if err := UpdateOne(
 		bson.M{
 			IdKey:          h.Id,
-			StatusKey:      evergreen.HostProvisioning,
+			StatusKey:      evergreen.HostStarting,
 			ProvisionedKey: true,
 		},
 		bson.M{"$set": bson.M{StatusKey: evergreen.HostRunning}},
 	); err != nil {
-		return errors.Wrap(err, "problem changing host status from provisioning to running")
+		return errors.Wrap(err, "problem changing host status from starting to running")
 	}
 
 	h.Status = evergreen.HostRunning

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1118,7 +1118,7 @@ func (h *Host) UpdateRunningTask(t *task.Task) (bool, error) {
 	// User data can start anytime after the instance is created, so the app
 	// server may not have marked it as running yet.
 	if h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData {
-		statuses = append(statuses, evergreen.HostStarting, evergreen.HostProvisioning)
+		statuses = append(statuses, evergreen.HostStarting)
 	}
 	selector := bson.M{
 		IdKey:          h.Id,
@@ -1549,7 +1549,7 @@ func FindHostsToTerminate() ([]Host, error) {
 					// Host is not yet done provisioning
 					{"$or": []bson.M{
 						{ProvisionedKey: false},
-						{StatusKey: evergreen.HostProvisioning},
+						{StatusKey: bson.M{"$in": []string{evergreen.HostStarting, evergreen.HostProvisioning}}},
 					}},
 					{"$or": []bson.M{
 						{

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -747,7 +747,7 @@ func TestUpdateHostRunningTask(t *testing.T) {
 			_, err = h.UpdateRunningTask(&task.Task{Id: newTaskId})
 			So(err, ShouldNotBeNil)
 		})
-		Convey("updating the running task on a starting userdata host should succeed", func() {
+		Convey("updating the running task on a starting user data host should succeed", func() {
 			_, err := h2.UpdateRunningTask(&task.Task{Id: newTaskId})
 			So(err, ShouldBeNil)
 			found, err := FindOne(ById(h2.Id))

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -718,7 +718,7 @@ func TestUpdateHostRunningTask(t *testing.T) {
 		}
 		h2 := Host{
 			Id:     "test2",
-			Status: evergreen.HostProvisioning,
+			Status: evergreen.HostStarting,
 			Distro: distro.Distro{
 				BootstrapSettings: distro.BootstrapSettings{
 					Method: distro.BootstrapMethodUserData,
@@ -747,7 +747,7 @@ func TestUpdateHostRunningTask(t *testing.T) {
 			_, err = h.UpdateRunningTask(&task.Task{Id: newTaskId})
 			So(err, ShouldNotBeNil)
 		})
-		Convey("updating the running task on a provisioning host should succeed", func() {
+		Convey("updating the running task on a starting userdata host should succeed", func() {
 			_, err := h2.UpdateRunningTask(&task.Task{Id: newTaskId})
 			So(err, ShouldBeNil)
 			found, err := FindOne(ById(h2.Id))
@@ -1342,7 +1342,7 @@ func TestNeedsReprovisioningLocked(t *testing.T) {
 
 func TestFindUserDataSpawnHostsProvisioning(t *testing.T) {
 	for testName, testCase := range map[string]func(t *testing.T, h *Host){
-		"ReturnsHostsProvisionedButNotRunning": func(t *testing.T, h *Host) {
+		"ReturnsHostsStartedButNotRunning": func(t *testing.T, h *Host) {
 			require.NoError(t, h.Insert())
 
 			hosts, err := FindUserDataSpawnHostsProvisioning()
@@ -1390,7 +1390,7 @@ func TestFindUserDataSpawnHostsProvisioning(t *testing.T) {
 			}()
 			h := Host{
 				Id:          "host_id",
-				Status:      evergreen.HostProvisioning,
+				Status:      evergreen.HostStarting,
 				Provisioned: true,
 				StartedBy:   "user",
 				Distro: distro.Distro{
@@ -1994,7 +1994,7 @@ func TestIdleEphemeralGroupedByDistroID(t *testing.T) {
 		RunningTask:           "running_task",
 		StartedBy:             evergreen.User,
 		Provider:              evergreen.ProviderNameMock,
-		Status:                evergreen.HostProvisioning,
+		Status:                evergreen.HostStarting,
 		CreationTime:          time.Now().Add(-60 * time.Minute),
 	}
 	// User data host that is not running task and has passed the grace period
@@ -2010,7 +2010,7 @@ func TestIdleEphemeralGroupedByDistroID(t *testing.T) {
 		LastCommunicationTime: time.Now().Add(-time.Hour),
 		StartedBy:             evergreen.User,
 		Provider:              evergreen.ProviderNameMock,
-		Status:                evergreen.HostProvisioning,
+		Status:                evergreen.HostStarting,
 		CreationTime:          time.Now().Add(-70 * time.Minute),
 	}
 	// User data host that is running task but has not communicated recently is
@@ -2027,7 +2027,7 @@ func TestIdleEphemeralGroupedByDistroID(t *testing.T) {
 		LastCommunicationTime: time.Now().Add(-time.Hour),
 		StartedBy:             evergreen.User,
 		Provider:              evergreen.ProviderNameMock,
-		Status:                evergreen.HostProvisioning,
+		Status:                evergreen.HostStarting,
 		CreationTime:          time.Now().Add(-100 * time.Minute),
 	}
 	// User data host that is not running task but has not passed the grace
@@ -2043,7 +2043,7 @@ func TestIdleEphemeralGroupedByDistroID(t *testing.T) {
 		LastCommunicationTime: time.Now(),
 		StartedBy:             evergreen.User,
 		Provider:              evergreen.ProviderNameMock,
-		Status:                evergreen.HostProvisioning,
+		Status:                evergreen.HostStarting,
 		CreationTime:          time.Now(),
 	}
 

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1246,7 +1246,7 @@ func (h *Host) SetUserDataHostProvisioned() error {
 		return nil
 	}
 
-	if h.Status != evergreen.HostProvisioning {
+	if h.Status != evergreen.HostStarting {
 		return nil
 	}
 

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1254,7 +1254,7 @@ func (h *Host) SetUserDataHostProvisioned() error {
 		return nil
 	}
 
-	if err := h.UpdateProvisioningToRunning(); err != nil {
+	if err := h.UpdateStartingToRunning(); err != nil {
 		return errors.Wrapf(err, "could not mark host %s as done provisioning itself and now running", h.Id)
 	}
 

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1217,23 +1217,23 @@ func TestSetUserDataHostProvisioned(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NoError(t, h.SetUserDataHostProvisioned())
-			assert.Equal(t, evergreen.HostProvisioning, h.Status)
+			assert.Equal(t, evergreen.HostStarting, h.Status)
 
 			dbHost, err := FindOneId(h.Id)
 			require.NoError(t, err)
-			assert.Equal(t, evergreen.HostProvisioning, dbHost.Status)
+			assert.Equal(t, evergreen.HostStarting, dbHost.Status)
 		},
 		"IgnoresHostsNeverProvisioned": func(t *testing.T, h *Host) {
 			h.Provisioned = false
 
 			require.NoError(t, h.SetUserDataHostProvisioned())
-			assert.Equal(t, evergreen.HostProvisioning, h.Status)
+			assert.Equal(t, evergreen.HostStarting, h.Status)
 
 			dbHost, err := FindOneId(h.Id)
 			require.NoError(t, err)
-			assert.Equal(t, evergreen.HostProvisioning, dbHost.Status)
+			assert.Equal(t, evergreen.HostStarting, dbHost.Status)
 		},
-		"IgnoresNonProvisioningHosts": func(t *testing.T, h *Host) {
+		"IgnoresNonStartingHosts": func(t *testing.T, h *Host) {
 			require.NoError(t, h.SetDecommissioned(evergreen.User, ""))
 
 			require.NoError(t, h.SetUserDataHostProvisioned())
@@ -1254,7 +1254,7 @@ func TestSetUserDataHostProvisioned(t *testing.T) {
 				Distro: distro.Distro{BootstrapSettings: distro.BootstrapSettings{
 					Method: distro.BootstrapMethodUserData,
 				}},
-				Status:      evergreen.HostProvisioning,
+				Status:      evergreen.HostStarting,
 				Provisioned: true,
 			}
 			require.NoError(t, h.Insert())

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -113,11 +113,7 @@ func checkHostHealth(h *host.Host) bool {
 
 	// User data can start anytime after the instance is created, so the app
 	// server may not have marked it as running yet.
-	if h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData &&
-		utility.StringSliceContains([]string{
-			evergreen.HostStarting,
-			evergreen.HostProvisioning,
-		}, h.Status) {
+	if h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData && h.Status == evergreen.HostStarting {
 		return false
 	}
 

--- a/service/api_task_test.go
+++ b/service/api_task_test.go
@@ -966,10 +966,9 @@ func TestNextTask(t *testing.T) {
 				Convey("should get next task when provisioning", func() {
 					// setup host
 					So(db.Update(host.Collection, bson.M{host.IdKey: nonLegacyHost.Id}, bson.M{"$set": bson.M{host.StatusKey: evergreen.HostStarting}}), ShouldBeNil)
-					So(nonLegacyHost.SetProvisioning(), ShouldBeNil)
 					dbHost, err := host.FindOneId(nonLegacyHost.Id)
 					So(err, ShouldBeNil)
-					So(dbHost.Status, ShouldEqual, evergreen.HostProvisioning)
+					So(dbHost.Status, ShouldEqual, evergreen.HostStarting)
 
 					// next task action
 					reqDetails := &apimodels.GetNextTaskDetails{AgentRevision: evergreen.AgentVersion}

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -189,10 +189,10 @@ func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Mana
 func (j *cloudHostReadyJob) setNextState(h host.Host) error {
 	switch h.Distro.BootstrapSettings.Method {
 	case distro.BootstrapMethodUserData:
-		// Task hosts are not provisioned so we can skip the provisioning state.
+		// We're done provisioning user data hosts. The user data script will do the rest.
 		return errors.Wrapf(h.SetProvisionedNotRunning(), "error marking host %s as provisioned not running", h.Id)
 	case distro.BootstrapMethodNone:
-		// We're done provisioning user data hosts. The user data script will do the rest.
+		// hosts created by tasks are not provisioned so we can skip the provisioning state.
 		return errors.Wrapf(h.MarkAsProvisioned(), "error marking host %s as running", h.Id)
 	default:
 		return errors.Wrap(h.SetProvisioning(), "error setting host to provisioning")

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -281,10 +281,10 @@ func TestFlaggingUnprovisionedHosts(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(len(hosts), ShouldEqual, 0)
 		})
-		Convey("user data hosts that have run tasks before provisioning should be returned if they have communicated recently", func() {
+		Convey("user data hosts that have run tasks before provisioning should be returned if they haven't communicated recently", func() {
 			h1 := &host.Host{
 				Id:          "h1",
-				Status:      evergreen.HostProvisioning,
+				Status:      evergreen.HostStarting,
 				Provisioned: false,
 				Distro: distro.Distro{
 					BootstrapSettings: distro.BootstrapSettings{

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -204,10 +204,7 @@ func (j *setupHostJob) setupHost(ctx context.Context, settings *evergreen.Settin
 // that occurs. If the script exits with a non-zero exit code, the error will be
 // non-nil.
 func (j *setupHostJob) runHostSetup(ctx context.Context, settings *evergreen.Settings) error {
-	switch j.host.Distro.BootstrapSettings.Method {
-	case distro.BootstrapMethodNone:
-		return nil
-	case distro.BootstrapMethodSSH:
+	if j.host.Distro.BootstrapSettings.Method == distro.BootstrapMethodSSH {
 		if err := setupJasper(ctx, j.env, settings, j.host); err != nil {
 			grip.Warning(message.WrapError(err, message.Fields{
 				"message": "could not set up Jasper",

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -70,7 +70,7 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 		return
 	}
 
-	if j.host.Status != evergreen.HostProvisioning {
+	if j.host.Status != evergreen.HostStarting {
 		return
 	}
 

--- a/units/provisioning_user_data_done_test.go
+++ b/units/provisioning_user_data_done_test.go
@@ -89,7 +89,7 @@ func TestUserDataDoneJob(t *testing.T) {
 						ShellPath:       "/shell_path",
 					},
 				},
-				Status:      evergreen.HostProvisioning,
+				Status:      evergreen.HostStarting,
 				Provisioned: true,
 			}
 			require.NoError(t, withJasperServiceSetupAndTeardown(tctx, env, mngr, h, func(env evergreen.Environment) {


### PR DESCRIPTION
All we were doing for userdata hosts in provisioning-setup-host was to call the host's OnUp function and set the DNS name. Relocating these steps to the cloud-host-ready job allows us to skip the provisioning state for userdata hosts, so:
- there's one less job per host (we don't need to run the provisioning-setup-host job anymore)
- the exceptions for allowing userdata hosts to run tasks are simpler