### PR TITLE
EVG-8310 add execution number to projections

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -561,7 +561,7 @@ func (r *patchResolver) Builds(ctx context.Context, obj *restModel.APIPatch) ([]
 }
 
 func (r *patchResolver) Duration(ctx context.Context, obj *restModel.APIPatch) (*PatchDuration, error) {
-	tasks, err := task.FindAllFirstExecution(task.ByVersion(*obj.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey))
+	tasks, err := task.FindAllFirstExecution(task.ByVersion(*obj.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey, task.ExecutionKey))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}

--- a/model/version.go
+++ b/model/version.go
@@ -107,7 +107,7 @@ func (v *Version) AddSatisfiedTrigger(definitionID string) error {
 // GetTimeSpent returns the total time_taken and makespan of a version for
 // each task that has finished running
 func (v *Version) GetTimeSpent() (time.Duration, time.Duration, error) {
-	tasks, err := task.FindAllFirstExecution(task.ByVersion(v.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey))
+	tasks, err := task.FindAllFirstExecution(task.ByVersion(v.Id).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey, task.ExecutionKey))
 	if err != nil {
 		return 0, 0, errors.Wrapf(err, "can't get tasks for version '%s'", v.Id)
 	}


### PR DESCRIPTION
The changes in #3955 are only evident in builds. Patch/Version makespans are still taking later executions into account.
The issue is the projection which excluded execution numbers...