### PR TITLE
ExecutionTasks -> ExecTasks

### DIFF
--- a/public/static/js/patch_new.js
+++ b/public/static/js/patch_new.js
@@ -160,7 +160,7 @@ mciModule.controller('PatchController', function($scope, $filter, $window, mciCo
       if (v.DisplayTasks && v.DisplayTasks.length > 0) {
         v.DisplayTasks.forEach(function(task) {
           tasks[task.Name] = {checked: false, displayOnly: true, execTasks: []};
-          task.ExecutionTasks.forEach(function(execTask) {
+          task.ExecTasks.forEach(function(execTask) {
             execTasks[execTask] = "";
             tasks[task.Name].execTasks.push(execTask);
           });


### PR DESCRIPTION
BuildVariants were changed to use a different struct for display tasks (#3954) but the old UI is still referencing a field from the old struct.