### PR TITLE
EVG-12875 add parameters as expansions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -306,7 +306,7 @@ func (a *Agent) fetchProjectConfig(ctx context.Context, tc *taskContext) error {
 	}
 	expVars, err := a.comm.FetchExpansionVars(ctx, tc.task)
 	if err != nil {
-		return errors.Wrap(err, "error getting project vars")
+		return errors.Wrap(err, "error getting task-specific expansions")
 	}
 	exp.Update(expVars.Vars)
 	tc.taskModel = taskModel
@@ -366,7 +366,6 @@ func (a *Agent) runTask(ctx context.Context, tc *taskContext) (bool, error) {
 		tc.logger = client.NewSingleChannelLogHarness("agent.error", a.defaultLogger)
 		return a.handleTaskResponse(tskCtx, tc, evergreen.TaskFailed)
 	}
-	taskConfig.Redacted = tc.expVars.PrivateVars
 	taskConfig.TaskSync = a.opts.SetupData.TaskSync
 	tc.setTaskConfig(taskConfig)
 

--- a/agent/task.go
+++ b/agent/task.go
@@ -357,7 +357,12 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*model.Tas
 	}
 
 	grip.Info("Constructing TaskConfig.")
-	return model.NewTaskConfig(confDistro, tc.project, tc.taskModel, confRef, confPatch, tc.expansions)
+	taskConfig, err := model.NewTaskConfig(confDistro, tc.project, tc.taskModel, confRef, confPatch, tc.expansions)
+	if err != nil {
+		return nil, err
+	}
+	taskConfig.Redacted = tc.expVars.PrivateVars
+	return taskConfig, nil
 }
 
 func (tc *taskContext) getExecTimeout() time.Duration {

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2020-09-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-09-09"
+	AgentVersion = "2020-09-10"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -648,7 +648,7 @@ func TestAddNewPatch(t *testing.T) {
 				},
 				DisplayTasks: []patch.DisplayTask{
 					patch.DisplayTask{
-						Name:           "displaytask1",
+						Name:      "displaytask1",
 						ExecTasks: []string{"task1", "task2"},
 					},
 				},
@@ -718,7 +718,7 @@ func TestAddNewPatchWithMissingBaseVersion(t *testing.T) {
 				},
 				DisplayTasks: []patch.DisplayTask{
 					patch.DisplayTask{
-						Name:           "displaytask1",
+						Name:      "displaytask1",
 						ExecTasks: []string{"task1", "task2"},
 					},
 				},

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -621,7 +621,7 @@ func (s *projectSuite) SetupTest() {
 				},
 				DisplayTasks: []patch.DisplayTask{
 					{
-						Name:           "memes",
+						Name:      "memes",
 						ExecTasks: []string{"9001_task", "very_task", "another_disabled_task"},
 					},
 				},
@@ -1491,7 +1491,7 @@ func TestGetAllVariantTasks(t *testing.T) {
 						Name: "bv1",
 						DisplayTasks: []patch.DisplayTask{
 							{
-								Name:           "dt1",
+								Name:      "dt1",
 								ExecTasks: []string{"et1", "et2"},
 							},
 						},
@@ -1499,7 +1499,7 @@ func TestGetAllVariantTasks(t *testing.T) {
 						Name: "bv2",
 						DisplayTasks: []patch.DisplayTask{
 							{
-								Name:           "dt2",
+								Name:      "dt2",
 								ExecTasks: []string{"et2", "et3"},
 							},
 						},

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -26,6 +26,7 @@ var (
 	VersionAuthorEmailKey         = bsonutil.MustHaveTag(Version{}, "AuthorEmail")
 	VersionMessageKey             = bsonutil.MustHaveTag(Version{}, "Message")
 	VersionStatusKey              = bsonutil.MustHaveTag(Version{}, "Status")
+	VersionParametersKey          = bsonutil.MustHaveTag(Version{}, "Parameters")
 	VersionBuildIdsKey            = bsonutil.MustHaveTag(Version{}, "BuildIds")
 	VersionBuildVariantsKey       = bsonutil.MustHaveTag(Version{}, "BuildVariants")
 	VersionRevisionOrderNumberKey = bsonutil.MustHaveTag(Version{}, "RevisionOrderNumber")

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -259,8 +259,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		return errors.Wrapf(validationCatcher.Resolve(), "patched project config has errors")
 	}
 
-	// TODO: only add if it hasn't already been added from CLI or user-config
-	patchDoc.Parameters = project.GetParameters()
+	// TODO: add only user-defined parameters to patch/version
 	patchDoc.PatchedConfig = projectYaml
 	if patchDoc.Patches[0].ModuleName != "" {
 		// is there a module? validate it.

--- a/util/expansion.go
+++ b/util/expansion.go
@@ -67,6 +67,11 @@ func (self *Expansions) Exists(expansion string) bool {
 	return ok
 }
 
+// Remove deletes a value from the expansions.
+func (self *Expansions) Remove(expansion string) {
+	delete(*self, expansion)
+}
+
 // Apply the expansions to a single string.
 // Return the expanded string, or an error if the input string is malformed.
 func (self *Expansions) ExpandString(toExpand string) (string, error) {


### PR DESCRIPTION
Parameter hierarchy is as follows (lowest to highest priority):
1) Existing expansions
2) Project variables
3) Project parameters
4) Version parameters (in the future, this should include parameters added by UI, CLI, and user project defaults).

Made a change from my last PR to not add project parameters to the version/patch document (if we need to know what the defaults were, we can look up the project used for the version).

This is confirmed to work for project parameters, [here](https://evergreen-staging.corp.mongodb.com/task/yb_mci_ubuntu1604_unit_tests_patch_e04c03bebce04359961eb0074fa46541d8b3c38e_5f5a913ab237364777ce927e_20_09_10_20_50_08) with "hello world!" being the parameter defined in the committed project, and [here](https://evergreen-staging.corp.mongodb.com/task/yb_mci_ubuntu1604_unit_tests_patch_e04c03bebce04359961eb0074fa46541d8b3c38e_5f5a91cd9dbe3250faa4e3bc_20_09_10_20_51_35) with "hello darkness my old friend", with the parameter default having been changed in the patch diff.