### PR TITLE
EVG-8206 manifest retries

### DIFF
--- a/thirdparty/api_models.go
+++ b/thirdparty/api_models.go
@@ -67,6 +67,7 @@ func (y YAMLFormatError) Error() string {
 // For example, see https://developer.github.com/v3/#authentication.
 // This struct should be used for errors in fetching a requested remote config.
 type APIRequestError struct {
+	StatusCode       int
 	Message          string `json:"message"`
 	DocumentationUrl string `json:"documentation_url"`
 }


### PR DESCRIPTION
When the app server returns a 500 error for the `load.manifest` command the command will retry ten times. When the error is caused by a misconfigured module we should recognize it and return an error to the agent that will tell it not to retry. This will 1) give faster feedback on the error and 2) avoid consuming our allotment of GitHub API calls.