### PR TITLE
EVG-12393 remove provisioned user data hosts from cloud-host-ready job

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1341,7 +1341,10 @@ func StartingHostsByClient(limit int) (map[ClientOptions][]Host, error) {
 
 	pipeline := []bson.M{
 		{
-			"$match": bson.M{StatusKey: evergreen.HostStarting},
+			"$match": bson.M{
+				StatusKey:      evergreen.HostStarting,
+				ProvisionedKey: false,
+			},
 		},
 		{
 			"$sort": bson.M{

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4614,6 +4614,15 @@ func TestStartingHostsByClient(t *testing.T) {
 				ProviderSettingsList: []*birch.Document{doc3},
 			},
 		},
+		{
+			Id:          "h6",
+			Status:      evergreen.HostStarting,
+			Provisioned: true,
+			Distro: distro.Distro{
+				Provider:             evergreen.ProviderNameEc2Spot,
+				ProviderSettingsList: []*birch.Document{doc3},
+			},
+		},
 	}
 	for _, h := range startingHosts {
 		require.NoError(t, h.Insert())


### PR DESCRIPTION
#3970 has the cloud-host-ready job set user data hosts as `provisioned: true` and `status: starting` once we find out the host is running. Hosts in this state need to be excluded from the query the cloud-host-ready job uses to find hosts to check.