### PR TITLE
EVG-12937: fix run-linter concurrency

### DIFF
--- a/cmd/run-linter/run-linter.go
+++ b/cmd/run-linter/run-linter.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -79,18 +78,21 @@ func main() {
 	packages = strings.Split(strings.Replace(packageList, "-", "/", -1), " ")
 	dirname, _ := os.Getwd()
 	cwd := filepath.Base(dirname)
-	lintArgs += fmt.Sprintf(" --concurrency=%d", runtime.NumCPU()/2)
 
 	for _, pkg := range packages {
 		pkgDir := "./"
 		if cwd != pkg {
 			pkgDir += pkg
 		}
-		args := []string{lintBin, "run", lintArgs, pkgDir}
+		splitLintArgs := strings.Split(lintArgs, " ")
+		args := []string{lintBin, "run"}
+		args = append(args, splitLintArgs...)
+		args = append(args, pkgDir)
 
 		startAt := time.Now()
-		cmd := strings.Join(args, " ")
-		out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dirname
+		out, err := cmd.CombinedOutput()
 		r := &result{
 			cmd:      strings.Join(args, " "),
 			name:     "lint-" + strings.Replace(pkg, "/", "-", -1),
@@ -98,9 +100,14 @@ func main() {
 			duration: time.Since(startAt),
 			output:   strings.Split(string(out), "\n"),
 		}
+
 		for _, linter := range customLinters {
 			customLinterStart := time.Now()
-			out, err = exec.Command("sh", "-c", fmt.Sprintf("%s %s", linter, pkgDir)).CombinedOutput()
+			linterArgs := strings.Split(linter, " ")
+			linterArgs = append(linterArgs, pkgDir)
+			cmd := exec.Command(linterArgs[0], linterArgs[1:]...)
+			cmd.Dir = dirname
+			out, err := cmd.CombinedOutput()
 			r.passed = r.passed && err == nil
 			r.duration += time.Since(customLinterStart)
 			r.output = append(r.output, strings.Split(string(out), "\n")...)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12937

run-linter has always been set in the evergreen repo only to have half the concurrency that it's supposed to have for no reason. I updated run-linter so it matches the ones in all the PLT repos and uses the default concurrency (i.e. `runtime.NumCPU`).