### PR TITLE
EVG-12961: handle restarting Jasper service even if credentials expiration is unknown

### DIFF
--- a/units/provisioning_jasper_restart.go
+++ b/units/provisioning_jasper_restart.go
@@ -418,7 +418,7 @@ func (j *jasperRestartJob) populateIfUnset(ctx context.Context) error {
 			grip.Error(errors.Wrapf(err, "could not get credentials expiration time for host %s in job %s", j.HostID, j.ID()))
 			// If we cannot get the credentials for some reason (e.g. the host's
 			// credentials were deleted), assume the credentials have expired.
-			expiration = time.Now()
+			j.CredentialsExpiration = time.Now()
 		} else {
 			j.CredentialsExpiration = expiration
 		}

--- a/units/provisioning_jasper_restart.go
+++ b/units/provisioning_jasper_restart.go
@@ -415,9 +415,13 @@ func (j *jasperRestartJob) populateIfUnset(ctx context.Context) error {
 	if j.CredentialsExpiration.IsZero() {
 		expiration, err := j.host.JasperCredentialsExpiration(ctx, j.env)
 		if err != nil {
-			return errors.Wrapf(err, "could not get credentials expiration time for host %s in job %s", j.HostID, j.ID())
+			grip.Error(errors.Wrapf(err, "could not get credentials expiration time for host %s in job %s", j.HostID, j.ID()))
+			// If we cannot get the credentials for some reason (e.g. the host's
+			// credentials were deleted), assume the credentials have expired.
+			expiration = time.Now()
+		} else {
+			j.CredentialsExpiration = expiration
 		}
-		j.CredentialsExpiration = expiration
 	}
 
 	return nil


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12961

Currently, the job to restart Jasper on a host won't be enqueued if it can't get the host's credentials from the database (e.g. the credentials may have been deleted when the Jasper restart job used up all of its retries without successfully restarting Jasper). This makes it so that if the credentials can't be found, it'll assume the host isn't running Jasper right now and will restart Jasper using just SSH.