### PR TITLE
EVG-12937: increase linter timeout

### DIFF
--- a/makefile
+++ b/makefile
@@ -472,7 +472,7 @@ $(buildDir)/output.%.coverage:$(tmpDir) .FORCE
 #  targets to generate gotest output from the linter.
 # We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
 $(buildDir)/output.%.lint:$(buildDir)/run-linter $(testSrcFiles) .FORCE
-	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin="$(buildDir)/golangci-lint" --customLinters="$(gopath)/bin/evg-lint -set_exit_status" --packages='$*'
+	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin="$(buildDir)/golangci-lint" --lintArgs="--timeout=2m" --customLinters="$(gopath)/bin/evg-lint -set_exit_status" --packages='$*'
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
 # end test and coverage artifacts


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12937

The linter is quite slow on the first task that runs in a task group (usually it's lint-api or lint-agent), likely because golangci-lint hasn't cached anything yet. Passing an increased timeout to handle the first slow task in the task group should fix the intermittent lint failures.