### PR TITLE
EVG-12967 better handle ambiguous dependencies with * selector

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -194,7 +194,11 @@ func SchedulePatch(ctx context.Context, patchId string, version *model.Version, 
 		}
 	}
 
-	tasks.ExecTasks = model.IncludeDependencies(project, tasks.ExecTasks, p.GetRequester())
+	tasks.ExecTasks, err = model.IncludeDependencies(project, tasks.ExecTasks, p.GetRequester())
+	grip.Warning(message.WrapError(err, message.Fields{
+		"message": "error including dependencies for patch",
+		"patch":   patchId,
+	}))
 
 	if err = model.ValidateTVPairs(project, tasks.ExecTasks); err != nil {
 		return err, http.StatusBadRequest, "", ""

--- a/model/dependencies.go
+++ b/model/dependencies.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
 )
 
 type dependencyIncluder struct {
@@ -14,7 +15,8 @@ type dependencyIncluder struct {
 // and returns the expanded set of variant/task pairs to include all the dependencies/requirements
 // for the given set of tasks.
 // If any dependency is cross-variant, it will include the variant and task for that dependency.
-func IncludeDependencies(project *Project, tvpairs []TVPair, requester string) []TVPair {
+// This function can return an error, but it should be treated as an informational warning
+func IncludeDependencies(project *Project, tvpairs []TVPair, requester string) ([]TVPair, error) {
 	di := &dependencyIncluder{Project: project, requester: requester}
 	return di.include(tvpairs)
 }
@@ -23,13 +25,15 @@ func IncludeDependencies(project *Project, tvpairs []TVPair, requester string) [
 // add or removes tasks based on the dependency graph. Dependent tasks
 // are added; tasks that depend on unreachable tasks are pruned. New slices
 // of variants and tasks are returned.
-func (di *dependencyIncluder) include(initialDeps []TVPair) []TVPair {
+func (di *dependencyIncluder) include(initialDeps []TVPair) ([]TVPair, error) {
 	di.included = map[TVPair]bool{}
 
+	warnings := grip.NewBasicCatcher()
 	// handle each pairing, recursively adding and pruning based
 	// on the task's dependencies
 	for _, d := range initialDeps {
-		di.handle(d)
+		_, err := di.handle(d)
+		warnings.Add(err)
 	}
 
 	outPairs := []TVPair{}
@@ -38,56 +42,58 @@ func (di *dependencyIncluder) include(initialDeps []TVPair) []TVPair {
 			outPairs = append(outPairs, pair)
 		}
 	}
-	return outPairs
+	return outPairs, warnings.Resolve()
 }
 
 // handle finds and includes all tasks that the given task/variant pair depends
 // on. Returns true if the task and all of its dependent tasks can be scheduled
-// for the requester.
-func (di *dependencyIncluder) handle(pair TVPair) bool {
+// for the requester. Returns false if it cannot be scheduled, with an error
+// explaining why
+func (di *dependencyIncluder) handle(pair TVPair) (bool, error) {
 	if included, ok := di.included[pair]; ok {
 		// we've been here before, so don't redo work
-		return included
+		return included, nil
 	}
 
 	// if the given task is a task group, recurse on each task
 	if tg := di.Project.FindTaskGroup(pair.TaskName); tg != nil {
 		for _, t := range tg.Tasks {
-			if ok := di.handle(TVPair{TaskName: t, Variant: pair.Variant}); !ok {
+			ok, err := di.handle(TVPair{TaskName: t, Variant: pair.Variant})
+			if !ok {
 				di.included[pair] = false
-				return false // task depends on an unreachable task, so skip it
+				return false, errors.Wrapf(err, "task group '%s' in variant '%s' contains unschedulable task '%s'", pair.TaskName, pair.Variant, t)
 			}
 		}
-		return true
+		return true, nil
 	}
 
 	// we must load the BuildVariantTaskUnit for the task/variant pair,
 	// since it contains the full scope of dependency information
 	bvt := di.Project.FindTaskForVariant(pair.TaskName, pair.Variant)
 	if bvt == nil {
-		grip.Errorf("task %s does not exist in project '%s' for variant '%s'", pair.TaskName,
-			di.Project.Identifier, pair.Variant)
 		di.included[pair] = false
-		return false // task not found in project--skip it.
+		return false, errors.Errorf("task %s does not exist in project '%s' for variant '%s'", pair.TaskName,
+			di.Project.Identifier, pair.Variant)
 	}
 
 	if bvt.SkipOnRequester(di.requester) {
 		di.included[pair] = false
-		return false // task can't be run for this requester, so skip it
+		return false, errors.Errorf("task %s in variant '%s' cannot be run for a '%s'", pair.TaskName, pair.Variant, di.requester)
 	}
 	di.included[pair] = true
 
 	// queue up all dependencies for recursive inclusion
 	deps := di.expandDependencies(pair, bvt.DependsOn)
 	for _, dep := range deps {
-		if ok := di.handle(dep); !ok {
+		ok, err := di.handle(dep)
+		if !ok {
 			di.included[pair] = false
-			return false // task depends on an unreachable or non-existent task, so skip it
+			return false, errors.Wrapf(err, "task '%s' in variant '%s' has an unschedulable dependency", pair.TaskName, pair.Variant)
 		}
 	}
 
 	// we've reached a point where we know it is safe to include the current task
-	return true
+	return true, nil
 }
 
 // expandDependencies finds all tasks depended on by the current task/variant pair.
@@ -102,10 +108,17 @@ func (di *dependencyIncluder) expandDependencies(pair TVPair, depends []TaskUnit
 		case d.Variant == AllVariants && d.Name == AllDependencies: // task = *, variant = *
 			// Here we get all variants and tasks (excluding the current task)
 			// and add them to the list of tasks and variants.
-			for _, v := range di.Project.FindAllVariants() {
-				for _, t := range di.Project.FindTasksForVariant(v) {
-					if !(t == pair.TaskName && v == pair.Variant) {
-						deps = append(deps, TVPair{TaskName: t, Variant: v})
+			for _, v := range di.Project.BuildVariants {
+				for _, t := range v.Tasks {
+					projectTask := di.Project.FindTaskForVariant(t.Name, v.Name)
+					if projectTask != nil {
+						if projectTask.SkipOnRequester(di.requester) {
+							continue
+						}
+						if t.Name == pair.TaskName && v.Name == pair.Variant {
+							continue
+						}
+						deps = append(deps, TVPair{TaskName: t.Name, Variant: v.Name})
 					}
 				}
 			}
@@ -113,9 +126,21 @@ func (di *dependencyIncluder) expandDependencies(pair TVPair, depends []TaskUnit
 		case d.Variant == AllVariants: // specific task, variant = *
 			// In the case where we depend on a task on all variants, we fetch the task's
 			// dependencies, then add that task for all variants that have it.
-			for _, v := range di.Project.FindVariantsWithTask(d.Name) {
-				if !(pair.TaskName == d.Name && pair.Variant == v) {
-					deps = append(deps, TVPair{TaskName: d.Name, Variant: v})
+			for _, v := range di.Project.BuildVariants {
+				for _, t := range v.Tasks {
+					if t.Name != d.Name {
+						continue
+					}
+					projectTask := di.Project.FindTaskForVariant(t.Name, v.Name)
+					if projectTask != nil {
+						if projectTask.SkipOnRequester(di.requester) {
+							continue
+						}
+						if t.Name == pair.TaskName && v.Name == pair.Variant {
+							continue
+						}
+						deps = append(deps, TVPair{TaskName: t.Name, Variant: v.Name})
+					}
 				}
 			}
 
@@ -126,14 +151,26 @@ func (di *dependencyIncluder) expandDependencies(pair TVPair, depends []TaskUnit
 			if v == "" {
 				v = pair.Variant
 			}
-			for _, t := range di.Project.FindTasksForVariant(v) {
-				if !(pair.TaskName == t && pair.Variant == v) {
-					deps = append(deps, TVPair{TaskName: t, Variant: v})
+			variant := di.Project.FindBuildVariant(v)
+			if variant != nil {
+				for _, t := range variant.Tasks {
+					projectTask := di.Project.FindTaskForVariant(t.Name, v)
+					if projectTask != nil {
+						if projectTask.SkipOnRequester(di.requester) {
+							continue
+						}
+						if t.Name == pair.TaskName && variant.Name == pair.Variant {
+							continue
+						}
+						deps = append(deps, TVPair{TaskName: t.Name, Variant: variant.Name})
+					}
 				}
 			}
 
 		default: // specific name, specific variant
-			// We simply add a single task/variant and its dependencies.
+			// We simply add a single task/variant and its dependencies. This does not do
+			// the requester check above because we assume the user has configured this
+			// correctly
 			v := d.Variant
 			if v == "" {
 				v = pair.Variant

--- a/model/dependencies.go
+++ b/model/dependencies.go
@@ -110,12 +110,12 @@ func (di *dependencyIncluder) expandDependencies(pair TVPair, depends []TaskUnit
 			// and add them to the list of tasks and variants.
 			for _, v := range di.Project.BuildVariants {
 				for _, t := range v.Tasks {
+					if t.Name == pair.TaskName && v.Name == pair.Variant {
+						continue
+					}
 					projectTask := di.Project.FindTaskForVariant(t.Name, v.Name)
 					if projectTask != nil {
 						if projectTask.SkipOnRequester(di.requester) {
-							continue
-						}
-						if t.Name == pair.TaskName && v.Name == pair.Variant {
 							continue
 						}
 						deps = append(deps, TVPair{TaskName: t.Name, Variant: v.Name})
@@ -131,12 +131,12 @@ func (di *dependencyIncluder) expandDependencies(pair TVPair, depends []TaskUnit
 					if t.Name != d.Name {
 						continue
 					}
+					if t.Name == pair.TaskName && v.Name == pair.Variant {
+						continue
+					}
 					projectTask := di.Project.FindTaskForVariant(t.Name, v.Name)
 					if projectTask != nil {
 						if projectTask.SkipOnRequester(di.requester) {
-							continue
-						}
-						if t.Name == pair.TaskName && v.Name == pair.Variant {
 							continue
 						}
 						deps = append(deps, TVPair{TaskName: t.Name, Variant: v.Name})
@@ -154,12 +154,12 @@ func (di *dependencyIncluder) expandDependencies(pair TVPair, depends []TaskUnit
 			variant := di.Project.FindBuildVariant(v)
 			if variant != nil {
 				for _, t := range variant.Tasks {
+					if t.Name == pair.TaskName {
+						continue
+					}
 					projectTask := di.Project.FindTaskForVariant(t.Name, v)
 					if projectTask != nil {
 						if projectTask.SkipOnRequester(di.requester) {
-							continue
-						}
-						if t.Name == pair.TaskName && variant.Name == pair.Variant {
 							continue
 						}
 						deps = append(deps, TVPair{TaskName: t.Name, Variant: variant.Name})

--- a/model/dependencies.go
+++ b/model/dependencies.go
@@ -72,13 +72,13 @@ func (di *dependencyIncluder) handle(pair TVPair) (bool, error) {
 	bvt := di.Project.FindTaskForVariant(pair.TaskName, pair.Variant)
 	if bvt == nil {
 		di.included[pair] = false
-		return false, errors.Errorf("task %s does not exist in project '%s' for variant '%s'", pair.TaskName,
+		return false, errors.Errorf("task '%s' does not exist in project '%s' for variant '%s'", pair.TaskName,
 			di.Project.Identifier, pair.Variant)
 	}
 
 	if bvt.SkipOnRequester(di.requester) {
 		di.included[pair] = false
-		return false, errors.Errorf("task %s in variant '%s' cannot be run for a '%s'", pair.TaskName, pair.Variant, di.requester)
+		return false, errors.Errorf("task '%s' in variant '%s' cannot be run for a '%s'", pair.TaskName, pair.Variant, di.requester)
 	}
 	di.included[pair] = true
 

--- a/model/generate.go
+++ b/model/generate.go
@@ -216,7 +216,12 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 	for _, bv := range g.BuildVariants {
 		newTVPairs = appendTasks(newTVPairs, bv, p)
 	}
-	newTVPairs.ExecTasks = IncludeDependencies(p, newTVPairs.ExecTasks, v.Requester)
+	var err error
+	newTVPairs.ExecTasks, err = IncludeDependencies(p, newTVPairs.ExecTasks, v.Requester)
+	grip.Warning(message.WrapError(err, message.Fields{
+		"message": "error including dependencies for generator",
+		"task":    g.TaskID,
+	}))
 
 	// group into new builds and new tasks for existing builds
 	builds, err := build.Find(build.ByVersion(v.Id).WithFields(build.IdKey, build.BuildVariantKey))

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -412,20 +412,20 @@ func TestIncludeDependencies(t *testing.T) {
 		}
 
 		Convey("a patch against v1/t1 should remain unchanged", func() {
-			pairs := IncludeDependencies(p, []TVPair{{"v1", "t1"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t1"}}, evergreen.PatchVersionRequester)
 			So(len(pairs), ShouldEqual, 1)
 			So(pairs[0], ShouldResemble, TVPair{"v1", "t1"})
 		})
 
 		Convey("a patch against v1/t2 should add t1", func() {
-			pairs := IncludeDependencies(p, []TVPair{{"v1", "t2"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t2"}}, evergreen.PatchVersionRequester)
 			So(len(pairs), ShouldEqual, 2)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
 		})
 
 		Convey("a patch against v2/t3 should add t1,t2, and v1", func() {
-			pairs := IncludeDependencies(p, []TVPair{{"v2", "t3"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t3"}}, evergreen.PatchVersionRequester)
 			So(len(pairs), ShouldEqual, 3)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -433,10 +433,10 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v2/t5 should be pruned, since its dependency is not patchable", func() {
-			pairs := IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.PatchVersionRequester)
 			So(len(pairs), ShouldEqual, 0)
 
-			pairs = IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.RepotrackerVersionRequester)
+			pairs, _ = IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.RepotrackerVersionRequester)
 			So(len(pairs), ShouldEqual, 2)
 		})
 	})
@@ -459,7 +459,7 @@ func TestIncludeDependencies(t *testing.T) {
 		}
 
 		Convey("a patch against v1/t3 should include t2 and t1", func() {
-			pairs := IncludeDependencies(p, []TVPair{{"v1", "t3"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t3"}}, evergreen.PatchVersionRequester)
 			So(len(pairs), ShouldEqual, 3)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -467,7 +467,7 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v3/t4 should include v1, v2, t3, t2, and t1", func() {
-			pairs := IncludeDependencies(p, []TVPair{{"v3", "t4"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v3", "t4"}}, evergreen.PatchVersionRequester)
 			So(len(pairs), ShouldEqual, 7)
 
 			So(pairs, shouldContainPair, TVPair{"v3", "t4"})
@@ -483,7 +483,7 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v4/t5 should include v1, v2, v3, t4, t3, t2, and t1", func() {
-			pairs := IncludeDependencies(p, []TVPair{{"v4", "t5"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v4", "t5"}}, evergreen.PatchVersionRequester)
 			So(len(pairs), ShouldEqual, 8)
 			So(pairs, shouldContainPair, TVPair{"v4", "t5"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -511,14 +511,14 @@ func TestIncludeDependencies(t *testing.T) {
 		}
 		Convey("all tasks should be scheduled no matter which is initially added", func() {
 			Convey("for '1'", func() {
-				pairs := IncludeDependencies(p, []TVPair{{"v1", "1"}}, evergreen.PatchVersionRequester)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "1"}}, evergreen.PatchVersionRequester)
 				So(len(pairs), ShouldEqual, 3)
 				So(pairs, shouldContainPair, TVPair{"v1", "1"})
 				So(pairs, shouldContainPair, TVPair{"v1", "2"})
 				So(pairs, shouldContainPair, TVPair{"v1", "3"})
 			})
 			Convey("for '2'", func() {
-				pairs := IncludeDependencies(p, []TVPair{{"v1", "2"}, {"v2", "2"}}, evergreen.PatchVersionRequester)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "2"}, {"v2", "2"}}, evergreen.PatchVersionRequester)
 				So(len(pairs), ShouldEqual, 6)
 				So(pairs, shouldContainPair, TVPair{"v1", "1"})
 				So(pairs, shouldContainPair, TVPair{"v1", "2"})
@@ -528,7 +528,7 @@ func TestIncludeDependencies(t *testing.T) {
 				So(pairs, shouldContainPair, TVPair{"v2", "3"})
 			})
 			Convey("for '3'", func() {
-				pairs := IncludeDependencies(p, []TVPair{{"v2", "3"}}, evergreen.PatchVersionRequester)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "3"}}, evergreen.PatchVersionRequester)
 				So(len(pairs), ShouldEqual, 3)
 				So(pairs, shouldContainPair, TVPair{"v2", "1"})
 				So(pairs, shouldContainPair, TVPair{"v2", "2"})
@@ -552,7 +552,7 @@ func TestIncludeDependencies(t *testing.T) {
 		}
 
 		initDep := TVPair{TaskName: "a", Variant: "initial-variant"}
-		pairs := IncludeDependencies(p, []TVPair{initDep}, evergreen.PatchVersionRequester)
+		pairs, _ := IncludeDependencies(p, []TVPair{initDep}, evergreen.PatchVersionRequester)
 		So(pairs, ShouldHaveLength, 2)
 		So(initDep, ShouldBeIn, pairs)
 	})
@@ -573,16 +573,16 @@ func TestIncludeDependencies(t *testing.T) {
 		So(bvt, ShouldNotBeNil)
 		So(bvt.DependsOn, ShouldHaveLength, 1)
 
-		pairs := IncludeDependencies(project, []TVPair{{"bv1", "t1"}}, evergreen.PatchVersionRequester)
-		So(pairs, ShouldHaveLength, 0)
+		pairs, _ := IncludeDependencies(project, []TVPair{{"bv1", "t1"}}, evergreen.PatchVersionRequester)
+		So(pairs, ShouldHaveLength, 1)
 
-		pairs = IncludeDependencies(project, []TVPair{{"bv1", "t1"}}, evergreen.GithubPRRequester)
-		So(pairs, ShouldHaveLength, 0)
+		pairs, _ = IncludeDependencies(project, []TVPair{{"bv1", "t1"}}, evergreen.GithubPRRequester)
+		So(pairs, ShouldHaveLength, 1)
 
-		pairs = IncludeDependencies(project, []TVPair{{"bv1", "t1"}}, evergreen.RepotrackerVersionRequester)
+		pairs, _ = IncludeDependencies(project, []TVPair{{"bv1", "t1"}}, evergreen.RepotrackerVersionRequester)
 		So(pairs, ShouldHaveLength, 2)
 
-		pairs = IncludeDependencies(project, []TVPair{{"bv1", "t1"}}, evergreen.GitTagRequester)
+		pairs, _ = IncludeDependencies(project, []TVPair{{"bv1", "t1"}}, evergreen.GitTagRequester)
 		So(pairs, ShouldHaveLength, 2)
 	})
 }

--- a/model/project.go
+++ b/model/project.go
@@ -1128,6 +1128,8 @@ func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit
 			if projectTask := p.FindProjectTask(task); projectTask != nil {
 				bvt.Populate(*projectTask)
 				return &bvt
+			} else if _, exists := tgMap[task]; exists {
+				return &bvt
 			}
 		}
 		if tg, ok := tgMap[bvt.Name]; ok {
@@ -1325,7 +1327,12 @@ func (p *Project) ResolvePatchVTs(bvs, tasks []string, requester, alias string, 
 
 	tvPairs := p.extractDisplayTasks(pairs, tasks, bvs)
 	if includeDeps {
-		tvPairs.ExecTasks = IncludeDependencies(p, tvPairs.ExecTasks, requester)
+		var err error
+		tvPairs.ExecTasks, err = IncludeDependencies(p, tvPairs.ExecTasks, requester)
+		grip.Warning(message.WrapError(err, message.Fields{
+			"message": "error including dependencies",
+			"project": p.Identifier,
+		}))
 	}
 
 	vts = tvPairs.TVPairsToVariantTasks()

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -816,7 +816,12 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}
 	}
 
-	pairsToCreate = model.IncludeDependencies(projectInfo.Project, pairsToCreate, v.Requester)
+	pairsToCreate, err = model.IncludeDependencies(projectInfo.Project, pairsToCreate, v.Requester)
+	grip.Warning(message.WrapError(err, message.Fields{
+		"message": "error including dependencies",
+		"project": projectInfo.Project.Identifier,
+		"version": v.Id,
+	}))
 	for _, buildvariant := range projectInfo.Project.BuildVariants {
 		taskNames := pairsToCreate.TaskNames(buildvariant.Name)
 		args := model.BuildCreateArgs{


### PR DESCRIPTION
- have the dependency includer be able to return errors. This ended up being a bit unnecessary since the callers will all just log the error, but oh well
- when expanding a single task's dependencies, have any scenarios where you specify * to mean "all tasks that would be able to run for this version" rather than "all valid tasks for this variant." This is the same check that we would do later for the main task. This allows * to be more intelligent when pulling in dependencies, because it won't pull in ones that wouldn't be able to run anyway