### PR TITLE
EVG-13032 include parser errors in repotracker exceptions

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -3,6 +3,7 @@ package repotracker
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -360,12 +361,13 @@ func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision s
 		_, apiReqErr := errors.Cause(err).(thirdparty.APIRequestError)
 		_, ymlFmtErr := errors.Cause(err).(thirdparty.YAMLFormatError)
 		_, noFileErr := errors.Cause(err).(thirdparty.FileNotFoundError)
-		if apiReqErr || noFileErr || ymlFmtErr {
+		parsingErr := strings.Contains(err.Error(), "translating project")
+		if apiReqErr || noFileErr || ymlFmtErr || parsingErr {
 			// If there's an error getting the remote config, e.g. because it
 			// does not exist, we treat this the same as when the remote config
 			// is invalid - but add a different error message
 			msg := message.ConvertToComposer(level.Error, message.Fields{
-				"message":  "problem finding project configuration",
+				"message":  fmt.Sprintf("problem with project configuration: %s", errors.Cause(err).Error()),
 				"runner":   RunnerName,
 				"project":  projectRef.Identifier,
 				"revision": revision,

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -367,7 +367,7 @@ func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision s
 			// does not exist, we treat this the same as when the remote config
 			// is invalid - but add a different error message
 			msg := message.ConvertToComposer(level.Error, message.Fields{
-				"message":  fmt.Sprintf("problem with project configuration: %s", errors.Cause(err).Error()),
+				"message":  fmt.Sprintf("problem with project configuration: %s", errors.Cause(err)),
 				"runner":   RunnerName,
 				"project":  projectRef.Identifier,
 				"revision": revision,


### PR DESCRIPTION
Considering yaml format errors get a stub version, parser errors should too.

I also think the error should be a little bit more informative, but this _might_ be noisy for parser errors so I can remove that change if preferred.