### PR TITLE
EVG-5948 remove references to build's task cache

### DIFF
--- a/model/build/build.go
+++ b/model/build/build.go
@@ -222,16 +222,6 @@ func (b *Build) Insert() error {
 	return db.Insert(Collection, b)
 }
 
-// Checks if the build is active (has any active task)
-func (b *Build) IsActive() bool {
-	for _, task := range b.Tasks {
-		if task.Activated {
-			return true
-		}
-	}
-	return false
-}
-
 func (b *Build) SetCachedTaskFinished(taskID, status string, detail *apimodels.TaskEndDetail, timeTaken time.Duration) error {
 	if err := SetCachedTaskFinished(b.Id, taskID, status, detail, timeTaken); err != nil {
 		return err

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -176,7 +176,7 @@ func MarkVersionCompleted(versionId string, finishTime time.Time, updates *Statu
 
 	// Find the statuses for all builds in the version so we can figure out the version's status
 	builds, err := build.Find(
-		build.ByVersion(versionId).WithFields(build.ActivatedKey, build.StatusKey, build.TasksKey),
+		build.ByVersion(versionId).WithFields(build.ActivatedKey, build.StatusKey),
 	)
 	if err != nil {
 		return err
@@ -996,7 +996,7 @@ func TryMarkPatchBuildFinished(b *build.Build, finishTime time.Time, updates *St
 	}
 
 	// ensure all builds for this patch are finished as well
-	builds, err := build.Find(build.ByIds(v.BuildIds).WithFields(build.StatusKey, build.TasksKey))
+	builds, err := build.Find(build.ByIds(v.BuildIds).WithFields(build.StatusKey))
 	if err != nil {
 		return err
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -1563,9 +1563,7 @@ func FetchVersionsBuildsAndTasks(project *Project, skip int, numVersions int, sh
 		buildsByVersion[build.Version] = append(buildsByVersion[build.Version], build)
 	}
 
-	tasksFromDb, err := task.FindAll(task.ByVersions(versionIds).WithFields(
-		task.BuildIdKey, task.DisplayNameKey, task.StatusKey, task.DetailsKey, task.StartTimeKey, task.TimeTakenKey, task.ActivatedKey, bsonutil.GetDottedKeyName(task.DependsOnKey, task.DependencyUnattainableKey),
-	))
+	tasksFromDb, err := task.FindAll(task.ByVersions(versionIds).WithFields(task.StatusFields...))
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error fetching tasks from database")
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -1567,10 +1567,7 @@ func FetchVersionsBuildsAndTasks(project *Project, skip int, numVersions int, sh
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error fetching tasks from database")
 	}
-	taskMap := make(map[string]task.Task)
-	for _, t := range tasksFromDb {
-		taskMap[t.Id] = t
-	}
+	taskMap := task.TaskSliceToMap(tasksFromDb)
 
 	tasksByBuild := map[string][]task.Task{}
 	for _, b := range buildsFromDb {

--- a/model/project.go
+++ b/model/project.go
@@ -1519,10 +1519,10 @@ func (p *Project) GetDisplayTask(variant, name string) *patch.DisplayTask {
 	return nil
 }
 
-// FetchVersionsAndAssociatedBuilds is a helper function to fetch a group of versions and their associated builds.
+// FetchVersionsBuildsAndTasks is a helper function to fetch a group of versions and their associated builds and tasks.
 // Returns the versions themselves, as well as a map of version id -> the
 // builds that are a part of the version (unsorted).
-func FetchVersionsAndAssociatedBuilds(project *Project, skip int, numVersions int, showTriggered bool) ([]Version, map[string][]build.Build, error) {
+func FetchVersionsBuildsAndTasks(project *Project, skip int, numVersions int, showTriggered bool) ([]Version, map[string][]build.Build, map[string][]task.Task, error) {
 	// fetch the versions from the db
 	versionsFromDB, err := VersionFind(VersionByProjectAndTrigger(project.Identifier, showTriggered).
 		WithFields(
@@ -1540,7 +1540,7 @@ func FetchVersionsAndAssociatedBuilds(project *Project, skip int, numVersions in
 		).Sort([]string{"-" + VersionCreateTimeKey}).Skip(skip).Limit(numVersions))
 
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "error fetching versions from database")
+		return nil, nil, nil, errors.Wrap(err, "error fetching versions from database")
 	}
 
 	// create a slice of the version ids (used to fetch the builds)
@@ -1552,9 +1552,9 @@ func FetchVersionsAndAssociatedBuilds(project *Project, skip int, numVersions in
 	// fetch all of the builds (with only relevant fields)
 	buildsFromDb, err := build.Find(
 		build.ByVersions(versionIds).
-			WithFields(build.BuildVariantKey, build.TasksKey, build.VersionKey, build.DisplayNameKey))
+			WithFields(build.BuildVariantKey, bsonutil.GetDottedKeyName(build.TasksKey, build.TaskCacheIdKey), build.VersionKey, build.DisplayNameKey))
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "error fetching builds from database")
+		return nil, nil, nil, errors.Wrap(err, "error fetching builds from database")
 	}
 
 	// group the builds by version
@@ -1563,7 +1563,25 @@ func FetchVersionsAndAssociatedBuilds(project *Project, skip int, numVersions in
 		buildsByVersion[build.Version] = append(buildsByVersion[build.Version], build)
 	}
 
-	return versionsFromDB, buildsByVersion, nil
+	tasksFromDb, err := task.FindAll(task.ByVersions(versionIds).WithFields(
+		task.BuildIdKey, task.DisplayNameKey, task.StatusKey, task.DetailsKey, task.StartTimeKey, task.TimeTakenKey, task.ActivatedKey, bsonutil.GetDottedKeyName(task.DependsOnKey, task.DependencyUnattainableKey),
+	))
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "error fetching tasks from database")
+	}
+	taskMap := make(map[string]task.Task)
+	for _, t := range tasksFromDb {
+		taskMap[t.Id] = t
+	}
+
+	tasksByBuild := map[string][]task.Task{}
+	for _, b := range buildsFromDb {
+		for _, t := range b.Tasks {
+			tasksByBuild[b.Id] = append(tasksByBuild[b.Id], taskMap[t.Id])
+		}
+	}
+
+	return versionsFromDB, buildsByVersion, tasksByBuild, nil
 }
 
 func (tg *TaskGroup) InjectInfo(t *task.Task) {

--- a/model/project.go
+++ b/model/project.go
@@ -1520,8 +1520,8 @@ func (p *Project) GetDisplayTask(variant, name string) *patch.DisplayTask {
 }
 
 // FetchVersionsBuildsAndTasks is a helper function to fetch a group of versions and their associated builds and tasks.
-// Returns the versions themselves, as well as a map of version id -> the
-// builds that are a part of the version (unsorted).
+// Returns the versions themselves, a map of version id -> the builds that are a part of the version (unsorted)
+// and a map of build ID -> each build's tasks
 func FetchVersionsBuildsAndTasks(project *Project, skip int, numVersions int, showTriggered bool) ([]Version, map[string][]build.Build, map[string][]task.Task, error) {
 	// fetch the versions from the db
 	versionsFromDB, err := VersionFind(VersionByProjectAndTrigger(project.Identifier, showTriggered).
@@ -1552,7 +1552,12 @@ func FetchVersionsBuildsAndTasks(project *Project, skip int, numVersions int, sh
 	// fetch all of the builds (with only relevant fields)
 	buildsFromDb, err := build.Find(
 		build.ByVersions(versionIds).
-			WithFields(build.BuildVariantKey, bsonutil.GetDottedKeyName(build.TasksKey, build.TaskCacheIdKey), build.VersionKey, build.DisplayNameKey))
+			WithFields(
+				build.BuildVariantKey,
+				bsonutil.GetDottedKeyName(build.TasksKey, build.TaskCacheIdKey),
+				build.VersionKey,
+				build.DisplayNameKey,
+			))
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error fetching builds from database")
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -208,6 +208,13 @@ func ByBuildId(buildId string) db.Q {
 	})
 }
 
+// ByBuildIds creates a query to return tasks in buildsIds
+func ByBuildIds(buildIds []string) db.Q {
+	return db.Query(bson.M{
+		BuildIdKey: bson.M{"$in": buildIds},
+	})
+}
+
 // ByAborted creates a query to return tasks with an aborted state
 func ByAborted(aborted bool) db.Q {
 	return db.Query(bson.M{

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -179,6 +179,17 @@ var (
 	}
 )
 
+var StatusFields = []string{
+	BuildIdKey,
+	DisplayNameKey,
+	StatusKey,
+	DetailsKey,
+	StartTimeKey,
+	TimeTakenKey,
+	ActivatedKey,
+	bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey),
+}
+
 // ById creates a query that finds a task by its _id.
 func ById(id string) db.Q {
 	return db.Query(bson.D{{

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -187,7 +187,7 @@ var StatusFields = []string{
 	StartTimeKey,
 	TimeTakenKey,
 	ActivatedKey,
-	bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey),
+	DependsOnKey,
 }
 
 // ById creates a query that finds a task by its _id.

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2368,6 +2368,15 @@ func (t *Task) FindAllMarkedUnattainableDependencies() ([]Task, error) {
 	return FindAll(query)
 }
 
+func AnyActiveTasks(tasks []Task) bool {
+	for _, t := range tasks {
+		if t.Activated {
+			return true
+		}
+	}
+	return false
+}
+
 func GetLatestExecution(taskId string) (int, error) {
 	var t *Task
 	var err error

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2377,6 +2377,15 @@ func AnyActiveTasks(tasks []Task) bool {
 	return false
 }
 
+func TaskSliceToMap(tasks []Task) map[string]Task {
+	taskMap := make(map[string]Task, len(tasks))
+	for _, t := range tasks {
+		taskMap[t.Id] = t
+	}
+
+	return taskMap
+}
+
 func GetLatestExecution(taskId string) (int, error) {
 	var t *Task
 	var err error

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -235,6 +235,7 @@ func (vc *DBVersionConnector) GetVersionsAndVariants(skip, numVersionElements in
 				if err != nil {
 					return nil, errors.Wrapf(err, "error converting build %s from DB model", b.Id)
 				}
+				buildsForRow.SetTaskCache(tasksByBuild[b.Id])
 
 				currentRow.Builds[versionFromDB.Id] = buildsForRow
 				buildList[b.BuildVariant] = currentRow

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -282,26 +282,8 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 		Revision:     v1.Revision,
 		BuildVariant: "bv1",
 		Tasks: []build.TaskCache{
-			{
-				Id:        "t111",
-				Activated: true,
-				Status:    evergreen.TaskFailed,
-				StatusDetails: apimodels.TaskEndDetail{
-					Status:      evergreen.TaskFailed,
-					Type:        evergreen.CommandTypeSystem,
-					TimedOut:    true,
-					Description: evergreen.TaskDescriptionHeartbeat,
-				},
-			},
-			{
-				Id:        "t112",
-				Activated: true,
-				Status:    evergreen.TaskSucceeded,
-				StatusDetails: apimodels.TaskEndDetail{
-					Status: evergreen.TaskSucceeded,
-					Type:   "test",
-				},
-			},
+			{Id: "t111"},
+			{Id: "t112"},
 		},
 	}
 	s.NoError(b11.Insert())
@@ -313,24 +295,8 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 		Revision:     v1.Revision,
 		BuildVariant: "bv2",
 		Tasks: []build.TaskCache{
-			{
-				Id:        "t121",
-				Activated: true,
-				Status:    evergreen.TaskSucceeded,
-				StatusDetails: apimodels.TaskEndDetail{
-					Status: evergreen.TaskSucceeded,
-					Type:   "test",
-				},
-			},
-			{
-				Id:        "t122",
-				Activated: true,
-				Status:    evergreen.TaskSucceeded,
-				StatusDetails: apimodels.TaskEndDetail{
-					Status: evergreen.TaskSucceeded,
-					Type:   "test",
-				},
-			},
+			{Id: "t121"},
+			{Id: "t122"},
 		},
 	}
 	s.NoError(b12.Insert())
@@ -341,14 +307,8 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 		Revision:     v2.Revision,
 		BuildVariant: "bv1",
 		Tasks: []build.TaskCache{
-			{
-				Id:     "t211",
-				Status: evergreen.TaskUnstarted,
-			},
-			{
-				Id:     "t212",
-				Status: evergreen.TaskUnstarted,
-			},
+			{Id: "t211"},
+			{Id: "t212"},
 		},
 	}
 	s.NoError(b21.Insert())
@@ -359,20 +319,15 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 		Revision:     v2.Revision,
 		BuildVariant: "bv2",
 		Tasks: []build.TaskCache{
-			{
-				Id:     "t221",
-				Status: evergreen.TaskUnstarted,
-			},
-			{
-				Id:     "t222",
-				Status: evergreen.TaskUnstarted,
-			},
+			{Id: "t221"},
+			{Id: "t222"},
 		},
 	}
 	s.NoError(b22.Insert())
 	tasks := []task.Task{
 		{
 			Id:        "t111",
+			Version:   v1.Id,
 			Activated: true,
 			Status:    evergreen.TaskFailed,
 			Details: apimodels.TaskEndDetail{
@@ -384,6 +339,7 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 		},
 		{
 			Id:        "t112",
+			Version:   v1.Id,
 			Activated: true,
 			Status:    evergreen.TaskSucceeded,
 			Details: apimodels.TaskEndDetail{
@@ -393,6 +349,7 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 		},
 		{
 			Id:        "t121",
+			Version:   v1.Id,
 			Activated: true,
 			Status:    evergreen.TaskSucceeded,
 			Details: apimodels.TaskEndDetail{
@@ -402,6 +359,7 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 		},
 		{
 			Id:        "t122",
+			Version:   v1.Id,
 			Activated: true,
 			Status:    evergreen.TaskSucceeded,
 			Details: apimodels.TaskEndDetail{
@@ -410,20 +368,24 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 			},
 		},
 		{
-			Id:     "t211",
-			Status: evergreen.TaskUnstarted,
+			Id:      "t211",
+			Version: v2.Id,
+			Status:  evergreen.TaskUnstarted,
 		},
 		{
-			Id:     "t212",
-			Status: evergreen.TaskUnstarted,
+			Id:      "t212",
+			Version: v2.Id,
+			Status:  evergreen.TaskUnstarted,
 		},
 		{
-			Id:     "t221",
-			Status: evergreen.TaskUnstarted,
+			Id:      "t221",
+			Version: v2.Id,
+			Status:  evergreen.TaskUnstarted,
 		},
 		{
-			Id:     "t222",
-			Status: evergreen.TaskUnstarted,
+			Id:      "t222",
+			Version: v2.Id,
+			Status:  evergreen.TaskUnstarted,
 		},
 	}
 	for _, t := range tasks {

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -360,16 +360,75 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 		BuildVariant: "bv2",
 		Tasks: []build.TaskCache{
 			{
-				Id:     "t212",
+				Id:     "t221",
 				Status: evergreen.TaskUnstarted,
 			},
 			{
-				Id:     "t212",
+				Id:     "t222",
 				Status: evergreen.TaskUnstarted,
 			},
 		},
 	}
 	s.NoError(b22.Insert())
+	tasks := []task.Task{
+		{
+			Id:        "t111",
+			Activated: true,
+			Status:    evergreen.TaskFailed,
+			Details: apimodels.TaskEndDetail{
+				Status:      evergreen.TaskFailed,
+				Type:        evergreen.CommandTypeSystem,
+				TimedOut:    true,
+				Description: evergreen.TaskDescriptionHeartbeat,
+			},
+		},
+		{
+			Id:        "t112",
+			Activated: true,
+			Status:    evergreen.TaskSucceeded,
+			Details: apimodels.TaskEndDetail{
+				Status: evergreen.TaskSucceeded,
+				Type:   "test",
+			},
+		},
+		{
+			Id:        "t121",
+			Activated: true,
+			Status:    evergreen.TaskSucceeded,
+			Details: apimodels.TaskEndDetail{
+				Status: evergreen.TaskSucceeded,
+				Type:   "test",
+			},
+		},
+		{
+			Id:        "t122",
+			Activated: true,
+			Status:    evergreen.TaskSucceeded,
+			Details: apimodels.TaskEndDetail{
+				Status: evergreen.TaskSucceeded,
+				Type:   "test",
+			},
+		},
+		{
+			Id:     "t211",
+			Status: evergreen.TaskUnstarted,
+		},
+		{
+			Id:     "t212",
+			Status: evergreen.TaskUnstarted,
+		},
+		{
+			Id:     "t221",
+			Status: evergreen.TaskUnstarted,
+		},
+		{
+			Id:     "t222",
+			Status: evergreen.TaskUnstarted,
+		},
+	}
+	for _, t := range tasks {
+		s.NoError(t.Insert())
+	}
 
 	results, err := s.ctx.GetVersionsAndVariants(0, 10, &proj)
 	s.NoError(err)

--- a/rest/model/build.go
+++ b/rest/model/build.go
@@ -95,10 +95,7 @@ func (apiBuild *APIBuild) BuildFromService(h interface{}) error {
 }
 
 func (apiBuild *APIBuild) SetTaskCache(tasks []task.Task) {
-	taskMap := make(map[string]task.Task)
-	for _, t := range tasks {
-		taskMap[t.Id] = t
-	}
+	taskMap := task.TaskSliceToMap(tasks)
 
 	apiBuild.TaskCache = []APITaskCache{}
 	for _, taskID := range apiBuild.Tasks {

--- a/service/build.go
+++ b/service/build.go
@@ -23,15 +23,17 @@ import (
 // getUiTaskCache takes a build object and returns a slice of
 // uiTask objects suitable for front-end
 func getUiTaskCache(build *build.Build, tasks []task.Task) ([]uiTask, error) {
-	idToTask := make(map[string]task.Task)
-	for _, task := range tasks {
-		idToTask[task.Id] = task
-	}
+	idToTask := task.TaskSliceToMap(tasks)
 
 	// Insert the tasks in the same order as the task cache
 	uiTasks := make([]uiTask, 0, len(build.Tasks))
 	for _, taskCache := range build.Tasks {
-		taskAsUI := uiTask{Task: idToTask[taskCache.Id]}
+		t, ok := idToTask[taskCache.Id]
+		if !ok {
+			continue
+		}
+
+		taskAsUI := uiTask{Task: t}
 		uiTasks = append(uiTasks, taskAsUI)
 	}
 

--- a/service/build.go
+++ b/service/build.go
@@ -102,7 +102,11 @@ func (uis *UIServer) buildPage(w http.ResponseWriter, r *http.Request) {
 			grip.Warningln("Could not find build for base commit of patch build:",
 				projCtx.Build.Id)
 		}
-		diffs := model.StatusDiffBuilds(buildOnBaseCommit, projCtx.Build)
+		diffs, err := model.StatusDiffBuilds(buildOnBaseCommit, projCtx.Build)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 
 		baseId := ""
 		if buildOnBaseCommit != nil {

--- a/service/rest_build.go
+++ b/service/rest_build.go
@@ -57,10 +57,7 @@ func (restapi *restAPI) getBuildInfo(w http.ResponseWriter, r *http.Request) {
 		gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "error finding tasks in build"})
 		return
 	}
-	taskMap := make(map[string]task.Task)
-	for _, t := range tasks {
-		taskMap[t.Id] = t
-	}
+	taskMap := task.TaskSliceToMap(tasks)
 
 	destBuild := &restBuild{}
 	destBuild.Id = b.Id
@@ -112,10 +109,7 @@ func (restapi restAPI) getBuildStatus(w http.ResponseWriter, r *http.Request) {
 		gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "error finding tasks in build"})
 		return
 	}
-	taskMap := make(map[string]task.Task)
-	for _, t := range tasks {
-		taskMap[t.Id] = t
-	}
+	taskMap := task.TaskSliceToMap(tasks)
 
 	result := buildStatusContent{
 		Id:           b.Id,

--- a/service/rest_build_test.go
+++ b/service/rest_build_test.go
@@ -48,12 +48,14 @@ func TestGetBuildInfo(t *testing.T) {
 
 		err = modelutil.CreateTestLocalConfig(buildTestConfig, "project_test", "")
 
-		task := build.TaskCache{
+		task := task.Task{
 			Id:          "some-task-id",
 			DisplayName: "some-task-name",
 			Status:      "success",
 			TimeTaken:   100 * time.Millisecond,
+			BuildId:     buildId,
 		}
+		So(task.Insert(), ShouldBeNil)
 		build := &build.Build{
 			Id:                  buildId,
 			CreateTime:          time.Now().Add(-20 * time.Minute),
@@ -68,7 +70,7 @@ func TestGetBuildInfo(t *testing.T) {
 			Activated:           true,
 			ActivatedTime:       time.Now().Add(-15 * time.Minute),
 			RevisionOrderNumber: rand.Int(),
-			Tasks:               []build.TaskCache{task},
+			Tasks:               []build.TaskCache{{Id: task.Id}},
 			TimeTaken:           10 * time.Minute,
 			DisplayName:         "My build",
 			Requester:           evergreen.RepotrackerVersionRequester,

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
@@ -527,7 +528,7 @@ func (restapi *restAPI) getVersionStatusByTask(versionId string, w http.Response
 func (restapi restAPI) getVersionStatusByBuild(versionId string, w http.ResponseWriter) {
 	// Get all of the builds corresponding to this version
 	builds, err := build.Find(
-		build.ByVersion(versionId).WithFields(build.BuildVariantKey, build.TasksKey),
+		build.ByVersion(versionId).WithFields(build.BuildVariantKey, bsonutil.GetDottedKeyName(build.TasksKey, build.TaskCacheIdKey)),
 	)
 	if err != nil {
 		msg := fmt.Sprintf("Error finding builds for version '%v'", versionId)

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -543,10 +543,7 @@ func (restapi restAPI) getVersionStatusByBuild(versionId string, w http.Response
 		gimlet.WriteJSONInternalError(w, responseError{Message: msg})
 		return
 	}
-	taskMap := make(map[string]task.Task)
-	for _, t := range tasks {
-		taskMap[t.Id] = t
-	}
+	taskMap := task.TaskSliceToMap(tasks)
 
 	result := versionStatusByBuildContent{
 		Id:     versionId,

--- a/service/rest_version_test.go
+++ b/service/rest_version_test.go
@@ -531,23 +531,26 @@ func TestGetVersionStatus(t *testing.T) {
 	require.NoError(t, err, "error setting up router")
 
 	Convey("When finding the status of a particular version", t, func() {
-		require.NoError(t, db.Clear(build.Collection),
+		require.NoError(t, db.ClearCollections(build.Collection, task.Collection),
 			"Error clearing '%v' collection", build.Collection)
 
 		versionId := "my-version"
 
-		task := build.TaskCache{
-			Id:          "some-task-id",
-			DisplayName: "some-task-name",
-			Status:      "success",
-			TimeTaken:   100 * time.Millisecond,
+		task := task.Task{
+			Id:           "some-task-id",
+			DisplayName:  "some-task-name",
+			Status:       "success",
+			TimeTaken:    100 * time.Millisecond,
+			BuildVariant: "some-build-variant",
+			Version:      versionId,
 		}
+		So(task.Insert(), ShouldBeNil)
 		build := &build.Build{
 			Id:           "some-build-id",
 			Version:      versionId,
 			BuildVariant: "some-build-variant",
 			DisplayName:  "Some Build Variant",
-			Tasks:        []build.TaskCache{task},
+			Tasks:        []build.TaskCache{{Id: task.Id}},
 		}
 		So(build.Insert(), ShouldBeNil)
 
@@ -584,7 +587,7 @@ func TestGetVersionStatus(t *testing.T) {
 				jsonTask, ok := _jsonTask.(map[string]interface{})
 				So(ok, ShouldBeTrue)
 
-				_jsonBuild, ok := jsonTask[build.BuildVariant]
+				_jsonBuild, ok := jsonTask[task.BuildVariant]
 				So(ok, ShouldBeTrue)
 				jsonBuild, ok := _jsonBuild.(map[string]interface{})
 				So(ok, ShouldBeTrue)

--- a/service/stats.go
+++ b/service/stats.go
@@ -55,14 +55,13 @@ type UITask struct {
 
 //UIBuild has the fields that are necessary to send over the wire for builds
 type UIBuild struct {
-	Id         string            `json:"id"`
-	CreateTime time.Time         `json:"create_time"`
-	StartTime  time.Time         `json:"start_time"`
-	FinishTime time.Time         `json:"finish_time"`
-	Version    string            `json:"version"`
-	Status     string            `json:"status"`
-	Tasks      []build.TaskCache `json:"tasks"`
-	TimeTaken  int64             `json:"time_taken"`
+	Id         string    `json:"id"`
+	CreateTime time.Time `json:"create_time"`
+	StartTime  time.Time `json:"start_time"`
+	FinishTime time.Time `json:"finish_time"`
+	Version    string    `json:"version"`
+	Status     string    `json:"status"`
+	TimeTaken  int64     `json:"time_taken"`
 }
 
 // UIStats is all of the data that the stats page might need.
@@ -167,7 +166,7 @@ func (uis *UIServer) taskTimingJSON(w http.ResponseWriter, r *http.Request) {
 
 		builds, err = build.Find(build.ByProjectAndVariant(project.Identifier, buildVariant, request, statuses).
 			WithFields(build.IdKey, build.CreateTimeKey, build.VersionKey,
-				build.TimeTakenKey, build.TasksKey, build.FinishTimeKey, build.StartTimeKey, build.StatusKey).
+				build.TimeTakenKey, build.FinishTimeKey, build.StartTimeKey, build.StatusKey).
 			Sort([]string{"-" + build.CreateTimeKey}).
 			Limit(limit))
 		if err != nil {
@@ -178,8 +177,7 @@ func (uis *UIServer) taskTimingJSON(w http.ResponseWriter, r *http.Request) {
 		uiBuilds := []*UIBuild{}
 		// get the versions for every single task that was returned
 		for _, build := range builds {
-
-			// create a UITask
+			// create a UIBuild
 			b := &UIBuild{
 				Id:         build.Id,
 				CreateTime: build.CreateTime,
@@ -188,8 +186,8 @@ func (uis *UIServer) taskTimingJSON(w http.ResponseWriter, r *http.Request) {
 				Version:    build.Version,
 				Status:     build.Status,
 				TimeTaken:  int64(build.TimeTaken),
-				Tasks:      build.Tasks,
 			}
+
 			uiBuilds = append(uiBuilds, b)
 			versionIds = append(versionIds, b.Version)
 		}

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
 )
@@ -187,16 +188,25 @@ func getBuildInfo(buildIds []string) ([]BuildInfo, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "can't get builds")
 	}
+	dbTasks, err := task.FindAll(task.ByBuildIds(buildIds).WithFields(task.DisplayNameKey, task.StatusKey, task.DetailsKey))
+	if err != nil {
+		return nil, errors.Wrap(err, "can't get tasks")
+	}
+	taskMap := task.TaskSliceToMap(dbTasks)
 
 	builds := make([]BuildInfo, 0, len(dbBuilds))
 	for _, dbBuild := range dbBuilds {
 		tasks := make([]TaskInfo, 0, len(dbBuild.Tasks))
 		for _, task := range dbBuild.Tasks {
+			t, ok := taskMap[task.Id]
+			if !ok {
+				continue
+			}
 			tasks = append(tasks, TaskInfo{
-				Id:          task.Id,
-				DisplayName: task.DisplayName,
-				Status:      task.Status,
-				Details:     task.StatusDetails,
+				Id:          t.Id,
+				DisplayName: t.DisplayName,
+				Status:      t.Status,
+				Details:     t.Details,
 			})
 		}
 		builds = append(builds, BuildInfo{

--- a/service/waterfall.go
+++ b/service/waterfall.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
@@ -158,8 +157,8 @@ func (wfv waterfallVersions) Swap(i, j int) {
 	wfv[i], wfv[j] = wfv[j], wfv[i]
 }
 
-// createWaterfallTasks takes ina  build's task cache returns a list of waterfallTasks.
-func createWaterfallTasks(tasks []build.TaskCache) ([]waterfallTask, task.TaskStatusCount) {
+// createWaterfallTasks takes in a list of tasks returns a list of waterfallTasks.
+func createWaterfallTasks(tasks []task.Task) ([]waterfallTask, task.TaskStatusCount) {
 	//initialize and set TaskStatusCount fields to zero
 	statusCount := task.TaskStatusCount{}
 	waterfallTasks := []waterfallTask{}
@@ -169,10 +168,10 @@ func createWaterfallTasks(tasks []build.TaskCache) ([]waterfallTask, task.TaskSt
 		taskForWaterfall := waterfallTask{
 			Id:            t.Id,
 			Status:        t.Status,
-			StatusDetails: t.StatusDetails,
+			StatusDetails: t.Details,
 			DisplayName:   t.DisplayName,
 			Activated:     t.Activated,
-			Blocked:       t.Blocked,
+			Blocked:       t.Blocked(),
 			TimeTaken:     t.TimeTaken,
 			StartTime:     t.StartTime.UnixNano(),
 		}
@@ -187,10 +186,10 @@ func createWaterfallTasks(tasks []build.TaskCache) ([]waterfallTask, task.TaskSt
 
 // For given build variant, variant display name and variant search query
 // checks if matched variant has active tasks
-func variantHasActiveTasks(b build.Build, bvDisplayName string, variantQuery string) bool {
+func variantHasActiveTasks(bvDisplayName, variantQuery string, tasks []task.Task) bool {
 	return strings.Contains(
 		strings.ToUpper(bvDisplayName), strings.ToUpper(variantQuery),
-	) && b.IsActive()
+	) && task.AnyActiveTasks(tasks)
 }
 
 // Fetch versions until 'numVersionElements' elements are created, including
@@ -219,8 +218,8 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 	for len(finalVersions) < numVersionElements {
 
 		// fetch the versions and associated builds
-		versionsFromDB, buildsByVersion, err :=
-			model.FetchVersionsAndAssociatedBuilds(project, skip, numVersionElements, showTriggered)
+		versionsFromDB, buildsByVersion, tasksByBuild, err :=
+			model.FetchVersionsBuildsAndTasks(project, skip, numVersionElements, showTriggered)
 
 		if err != nil {
 			return versionVariantData{}, errors.Wrap(err,
@@ -231,10 +230,6 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 		if len(versionsFromDB) == 0 {
 			break
 		}
-
-		// to fetch started tasks and failed tests for providing additional context
-		// in a tooltip
-		failedAndStartedTaskIds := []string{}
 
 		// update the amount skipped
 		skip += len(versionsFromDB)
@@ -251,7 +246,12 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 			buildsInVersion := buildsByVersion[versionFromDB.Id]
 
 			// see if there are any active tasks in the version
-			versionActive := anyActiveTasks(buildsInVersion)
+			versionActive := false
+			for _, b := range buildsInVersion {
+				if task.AnyActiveTasks(tasksByBuild[b.Id]) {
+					versionActive = true
+				}
+			}
 
 			variantMatched := false
 
@@ -273,7 +273,7 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 				if variantQuery != "" {
 					if versionActive && !variantMatched {
 						variantMatched = variantHasActiveTasks(
-							b, buildVariant.DisplayName, variantQuery,
+							buildVariant.DisplayName, variantQuery, tasksByBuild[b.Id],
 						)
 					}
 				} else {
@@ -361,16 +361,11 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 					Version: versionFromDB.Id,
 				}
 
-				tasks, statusCount := createWaterfallTasks(b.Tasks)
+				tasks, statusCount := createWaterfallTasks(tasksByBuild[b.Id])
 				buildForWaterfall.Tasks = tasks
 				buildForWaterfall.TaskStatusCount = statusCount
 				currentRow.Builds[versionFromDB.Id] = buildForWaterfall
 				waterfallRows[b.BuildVariant] = currentRow
-				for _, task := range buildForWaterfall.Tasks {
-					if task.Status == evergreen.TaskFailed || task.Status == evergreen.TaskStarted {
-						failedAndStartedTaskIds = append(failedAndStartedTaskIds, task.Id)
-					}
-				}
 			}
 
 			// add the version
@@ -378,15 +373,15 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 
 		}
 
-		failedAndStartedTasks, err := task.Find(task.ByIds(failedAndStartedTaskIds))
-		if err != nil {
-			return versionVariantData{}, errors.Wrap(err, "error fetching failed tasks")
-
-		}
-
-		for i := range failedAndStartedTasks {
-			if err := failedAndStartedTasks[i].MergeNewTestResults(); err != nil {
-				return versionVariantData{}, errors.Wrap(err, "error merging test results")
+		failedAndStartedTasks := []task.Task{}
+		for _, tasks := range tasksByBuild {
+			for _, t := range tasks {
+				if t.Status == evergreen.TaskFailed || t.Status == evergreen.TaskStarted {
+					if err = t.MergeNewTestResults(); err != nil {
+						return versionVariantData{}, errors.Wrap(err, "error merging test results")
+					}
+					failedAndStartedTasks = append(failedAndStartedTasks, t)
+				}
 			}
 		}
 
@@ -451,17 +446,6 @@ func addFailedAndStartedTests(waterfallRows map[string]waterfallRow, failedAndSt
 	}
 }
 
-// Takes in a slice of tasks, and determines whether any of the tasks in
-// any of the builds are active.
-func anyActiveTasks(builds []build.Build) bool {
-	for _, build := range builds {
-		if build.IsActive() {
-			return true
-		}
-	}
-	return false
-}
-
 // Calculates how many actual versions would appear on the previous page, given
 // the starting skip for the current page as well as the number of version
 // elements per page (including elements containing rolled-up versions).
@@ -494,8 +478,8 @@ func countOnPreviousPage(skip int, numVersionElements int, project *model.Projec
 	for {
 
 		// fetch the versions and builds
-		versionsFromDB, buildsByVersion, err :=
-			model.FetchVersionsAndAssociatedBuilds(project, stepBack, toFetch, showTriggered)
+		versionsFromDB, buildsByVersion, tasksByBuild, err :=
+			model.FetchVersionsBuildsAndTasks(project, stepBack, toFetch, showTriggered)
 
 		if err != nil {
 			return 0, errors.Wrap(err, "error fetching versions and builds")
@@ -515,7 +499,13 @@ func countOnPreviousPage(skip int, numVersionElements int, project *model.Projec
 
 			variantMatched := false
 
-			if anyActiveTasks(buildsInVersion) {
+			versionActive := false
+			for _, b := range buildsInVersion {
+				if task.AnyActiveTasks(tasksByBuild[b.Id]) {
+					versionActive = true
+				}
+			}
+			if versionActive {
 
 				for _, b := range buildsInVersion {
 					bvDisplayName := buildVariantMappings[b.BuildVariant]
@@ -529,7 +519,7 @@ func countOnPreviousPage(skip int, numVersionElements int, project *model.Projec
 					if variantQuery != "" {
 						if !variantMatched {
 							variantMatched = variantHasActiveTasks(
-								b, bvDisplayName, variantQuery,
+								bvDisplayName, variantQuery, tasksByBuild[b.Id],
 							)
 						}
 					} else {

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -127,10 +127,7 @@ func (t *buildTriggers) Fetch(e *event.EventLogEntry) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch tasks")
 	}
-	taskMap := make(map[string]task.Task)
-	for _, t := range tasks {
-		taskMap[t.Id] = t
-	}
+	taskMap := task.TaskSliceToMap(tasks)
 	for _, taskCache := range t.build.Tasks {
 		t.tasks = append(t.tasks, taskMap[taskCache.Id])
 	}

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -129,7 +129,11 @@ func (t *buildTriggers) Fetch(e *event.EventLogEntry) error {
 	}
 	taskMap := task.TaskSliceToMap(tasks)
 	for _, taskCache := range t.build.Tasks {
-		t.tasks = append(t.tasks, taskMap[taskCache.Id])
+		dbTask, ok := taskMap[taskCache.Id]
+		if !ok {
+			continue
+		}
+		t.tasks = append(t.tasks, dbTask)
 	}
 
 	var ok bool


### PR DESCRIPTION
The final goal is the remove most of the build task cache, leaving over just the task ids. (The list of task ids is still helpful because of the sorting and filtering we do when we create the build).

I intend to divide the work into separate PRs/commits: this one replaces references to the task cache with queries against the task collection. After it's burned-in I'll follow up with a separate PR that will remove most of the build cache and all the logic that keeps it in sync with the tasks collection.