### PR TITLE
EVG-13049 allow ec2-spot/fleet to fallback to on-demand

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -391,7 +391,7 @@ func (a *Agent) runTask(ctx context.Context, tc *taskContext) (bool, error) {
 	innerCtx, innerCancel := context.WithCancel(tskCtx)
 
 	go a.startIdleTimeoutWatch(tskCtx, tc, innerCancel)
-	if utility.StringSliceContains(evergreen.ProviderEc2Type, tc.taskConfig.Distro.Provider) {
+	if utility.StringSliceContains(evergreen.ProviderSpotEc2Type, tc.taskConfig.Distro.Provider) {
 		go a.startSpotTerminationWatcher(tskCtx)
 	}
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -70,6 +70,10 @@ type EC2ProviderSettings struct {
 	// IsVpc is set to true if the security group is part of a VPC.
 	IsVpc bool `mapstructure:"is_vpc" json:"is_vpc,omitempty" bson:"is_vpc,omitempty"`
 
+	// FallbackToOnDemand is set to true if on-demand should be tried in the case of capacity errors
+	// from spot/fleet instance creation.
+	FallbackToOnDemand bool `mapstructure:"fallback" json:"fallback" bson:"fallback"`
+
 	// BidPrice is the price we are willing to pay for a spot instance.
 	BidPrice float64 `mapstructure:"bid_price" json:"bid_price,omitempty" bson:"bid_price,omitempty"`
 

--- a/globals.go
+++ b/globals.go
@@ -329,7 +329,7 @@ var (
 		GitTagRequester,
 	}
 
-	ProviderEc2Type = []string{
+	ProviderSpotEc2Type = []string{
 		ProviderNameEc2Auto,
 		ProviderNameEc2Spot,
 		ProviderNameEc2Fleet,

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -32,6 +32,7 @@ const (
 	EventHostStarted                     = "HOST_STARTED"
 	EventHostStopped                     = "HOST_STOPPED"
 	EventHostModified                    = "HOST_MODIFIED"
+	EventHostFallback                    = "HOST_FALLBACK"
 	EventHostAgentDeployed               = "HOST_AGENT_DEPLOYED"
 	EventHostAgentDeployFailed           = "HOST_AGENT_DEPLOY_FAILED"
 	EventHostAgentMonitorDeployed        = "HOST_AGENT_MONITOR_DEPLOYED"
@@ -109,6 +110,10 @@ func LogHostCreated(hostId string) {
 
 func LogHostStartFinished(hostId string, successful bool) {
 	LogHostEvent(hostId, EventHostStarted, HostEventData{Successful: successful})
+}
+
+func LogHostFallback(hostId string) {
+	LogHostEvent(hostId, EventHostFallback, HostEventData{})
 }
 
 func LogHostStopFinished(hostId string, successful bool) {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -413,6 +413,15 @@ func (h *Host) IsEphemeral() bool {
 	return utility.StringSliceContains(evergreen.ProviderSpawnable, h.Provider)
 }
 
+func (h *Host) ShouldFallbackToOnDemand() bool {
+	// this case shouldn't happen unless the host is somehow misconfigured
+	if len(h.Distro.ProviderSettingsList) != 1 {
+		return false
+	}
+	fallback, _ := h.Distro.ProviderSettingsList[0].Lookup("fallback").BooleanOK()
+	return fallback
+}
+
 func (h *Host) IsContainer() bool {
 	return utility.StringSliceContains(evergreen.ProviderContainer, h.Provider)
 }

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -408,7 +408,7 @@ func (m *monitor) runAgent(ctx context.Context, retry util.RetryArgs) error {
 func (m *monitor) run(ctx context.Context) {
 	for {
 		if err := util.RetryWithArgs(ctx, func() (bool, error) {
-			if utility.StringSliceContains(evergreen.ProviderEc2Type, m.provider) {
+			if utility.StringSliceContains(evergreen.ProviderSpotEc2Type, m.provider) {
 				if util.SpotHostWillTerminateSoon() {
 					return true, errors.New("spot host terminating soon, not starting a new agent")
 				}

--- a/public/static/partials/hostevent.html
+++ b/public/static/partials/hostevent.html
@@ -5,6 +5,7 @@
     <span ng-switch-when="HOST_STARTED">Host start attempt[[eventLogObj.data.successful | conditional:' succeeded':'']]</span>
     <span ng-switch-when="HOST_STOPPED">Host stop attempt[[eventLogObj.data.successful | conditional:' succeeded':'']]</span>
     <span ng-switch-when="HOST_MODIFIED">Host modify attempt[[eventLogObj.data.successful | conditional:' succeeded':'']]</span>
+    <span ng-switch-when="HOST_FALLBACK">Host start attempt failed, attempting to fallback to EC2 On-Demand</span>
     <span ng-switch-when="HOST_PROVISION_ERROR">Host encountered error during provisioning</span>
     <span ng-switch-when="HOST_AGENT_DEPLOY_FAILED">New agent deploy failed</span>
     <span ng-switch-when="HOST_AGENT_DEPLOYED">Agent deployed with revision <b>[[eventLogObj.data.agent_revision]]</b> from <b>[[eventLogObj.data.agent_build]]</b></span>

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -360,9 +360,15 @@ Evergreen - Distros
                 <div class="icon fa fa-warning distro-error" ng-show="form.keyName.$dirty && form.keyName.$error.required || form.keyName.$invalid">EC2
                   key name is required</div>
               </div>
+              <div class="distro-label">
+                <div ng-show="activeDistro.provider == 'ec2-spot' || activeDistro.provider == 'ec2-fleet'">
+                  <label><input style="margin-right:10px;" ng-disabled="readOnly" type="checkbox"
+                    name="fallback" ng-model="activeDistro.settings.fallback">Fallback to EC2 On-Demand in the case of insufficient capacity </label> <br>
+                </div>
+                <label><input style="margin-right:10px;" ng-disabled="readOnly" type="checkbox"
+                  name="is_vpc" ng-model="activeDistro.settings.is_vpc">Use security group in an EC2 VPC </label> <br>
+              </div>
               <div>
-                <label class="distro-label"><input style="margin-right:10px;" ng-disabled="readOnly" type="checkbox"
-                    name="is_vpc" ng-model="activeDistro.settings.is_vpc">Use security group in an EC2 VPC </label> <br>
                 <label class="distro-label">Security Groups:</label>
                 <textarea ng-readonly="readOnly" placeholder="List 1 security group per line" ng-required="isDefaultRegion() && activeDistro.provider.startsWith('ec2')"
                   type="text" wrap="off" class="form-control" rows="3" name="securityGroups" ng-model="activeDistro.settings.security_group_ids"

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -313,7 +314,28 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	}
 
 	if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {
-		return errors.Wrapf(err, "error spawning host %s", j.host.Id)
+		if strings.Contains(err.Error(), cloud.EC2InsufficientCapacity) && j.host.ShouldFallbackToOnDemand() {
+			event.LogHostFallback(j.host.Id)
+			// create a new cloud manager for on demand, and re-attempt to spawn
+			j.host.Provider = evergreen.ProviderNameEc2OnDemand
+			j.host.Distro.Provider = evergreen.ProviderNameEc2OnDemand
+			mgrOpts.Provider = j.host.Provider
+			cloudManager, err = cloud.GetManager(ctx, j.env, mgrOpts)
+			if err != nil {
+				grip.Warning(message.WrapError(err, message.Fields{
+					"message":   "problem getting cloud provider for host",
+					"operation": "fallback to EC2 on-demand",
+					"host_id":   j.host.Id,
+					"job":       j.ID(),
+				}))
+				return errors.Wrapf(errIgnorableCreateHost, "problem getting cloud provider for host '%s' [%s]", j.host.Id, err.Error())
+			}
+			if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {
+				return errors.Wrapf(err, "error falling back to on-demand for host '%s'", j.host.Id)
+			}
+		} else {
+			return errors.Wrapf(err, "error spawning host '%s'", j.host.Id)
+		}
 	}
 	// Don't mark containers as starting. SpawnHost already marks containers as
 	// running.
@@ -340,6 +362,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 				"host_id":     j.host.Id,
 				"intent_host": j.HostID,
 				"distro":      j.host.Distro.Id,
+				"provider":    j.host.Provider,
 				"job":         j.ID(),
 			}))
 			grip.Warning(message.WrapError(err, message.Fields{
@@ -355,10 +378,11 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 			terminateCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			grip.Error(message.WrapError(cloudManager.TerminateInstance(terminateCtx, j.host, evergreen.User, "hit database error trying to update host"), message.Fields{
-				"message": "problem terminating instance after cloud host was spawned",
-				"host_id": j.host.Id,
-				"distro":  j.host.Distro.Id,
-				"job":     j.ID(),
+				"message":  "problem terminating instance after cloud host was spawned",
+				"host_id":  j.host.Id,
+				"distro":   j.host.Distro.Id,
+				"provider": j.host.Provider,
+				"job":      j.ID(),
 			}))
 			return errors.Wrapf(err, "error inserting host %s", j.host.Id)
 		}
@@ -374,11 +398,13 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 
 	event.LogHostStartFinished(j.host.Id, true)
 	grip.Info(message.Fields{
-		"message": "successfully started host",
-		"host_id": j.host.Id,
-		"distro":  j.host.Distro.Id,
-		"job":     j.ID(),
-		"runtime": time.Since(hostStartTime),
+		"message":   "successfully started host",
+		"operation": "fallback to EC2 on-demand",
+		"host_id":   j.host.Id,
+		"distro":    j.host.Distro.Id,
+		"provider":  j.host.Provider,
+		"job":       j.ID(),
+		"runtime":   time.Since(hostStartTime),
 	})
 
 	return nil


### PR DESCRIPTION
Example of a host that was configured to fallback: https://evergreen-staging.corp.mongodb.com/host/i-0cd48c0a2350cc643 (verified in AWS that the lifecycle was normal and not spot).
The event log can be modified if that wording is clunky, but I think it'll be nice to have something.

Distro page change:
![image](https://user-images.githubusercontent.com/26798134/93806581-32c11100-fbfe-11ea-821f-d40c0e83320f.png)
