### PR TITLE
EVG-9080: handle path-style and virtual hosted-style S3 URLs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -37,13 +37,11 @@ type Agent struct {
 
 // Options contains startup options for the Agent.
 type Options struct {
-	HostID       string
-	HostSecret   string
-	StatusPort   int
-	LogPrefix    string
-	LogkeeperURL string
-	// kim: TODO: remove
-	// S3BaseURL             string
+	HostID                string
+	HostSecret            string
+	StatusPort            int
+	LogPrefix             string
+	LogkeeperURL          string
 	WorkingDirectory      string
 	HeartbeatInterval     time.Duration
 	AgentSleepInterval    time.Duration
@@ -101,8 +99,6 @@ func New(ctx context.Context, opts Options, comm client.Communicator) (*Agent, e
 	if setupData, err := comm.GetAgentSetupData(ctx); err == nil {
 		opts.SetupData = *setupData
 		opts.LogkeeperURL = setupData.LogkeeperURL
-		// kim: TODO: remove
-		// opts.S3BaseURL = setupData.S3Base
 		opts.S3Opts = pail.S3Options{
 			Credentials: pail.CreateAWSCredentials(setupData.S3Key, setupData.S3Secret, ""),
 			Region:      endpoints.UsEast1RegionID,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -37,12 +37,13 @@ type Agent struct {
 
 // Options contains startup options for the Agent.
 type Options struct {
-	HostID                string
-	HostSecret            string
-	StatusPort            int
-	LogPrefix             string
-	LogkeeperURL          string
-	S3BaseURL             string
+	HostID       string
+	HostSecret   string
+	StatusPort   int
+	LogPrefix    string
+	LogkeeperURL string
+	// kim: TODO: remove
+	// S3BaseURL             string
 	WorkingDirectory      string
 	HeartbeatInterval     time.Duration
 	AgentSleepInterval    time.Duration
@@ -100,7 +101,8 @@ func New(ctx context.Context, opts Options, comm client.Communicator) (*Agent, e
 	if setupData, err := comm.GetAgentSetupData(ctx); err == nil {
 		opts.SetupData = *setupData
 		opts.LogkeeperURL = setupData.LogkeeperURL
-		opts.S3BaseURL = setupData.S3Base
+		// kim: TODO: remove
+		// opts.S3BaseURL = setupData.S3Base
 		opts.S3Opts = pail.S3Options{
 			Credentials: pail.CreateAWSCredentials(setupData.S3Key, setupData.S3Secret, ""),
 			Region:      endpoints.UsEast1RegionID,

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -253,7 +254,9 @@ func (a *Agent) uploadSingleFile(ctx context.Context, tc *taskContext, bucket pa
 	if err != nil {
 		return errors.Wrapf(err, "error uploading %s to S3", localPath)
 	}
-	remoteURL := fmt.Sprintf("%s/%s/%s/%s", a.opts.S3BaseURL, a.opts.S3Opts.Name, remotePath, file)
+	remoteURL := util.S3DefaultURL(a.opts.S3Opts.Name, strings.Join([]string{remotePath, file}, "/"))
+	// kim: TODO: remove
+	// remoteURL := fmt.Sprintf("%s/%s/%s/%s", a.opts.S3BaseURL, a.opts.S3Opts.Name, remotePath, file)
 	tc.logger.Execution().Infof("uploaded file %s from %s to %s", file, localPath, remoteURL)
 	switch file {
 	case agentLogFileName:

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -255,8 +255,6 @@ func (a *Agent) uploadSingleFile(ctx context.Context, tc *taskContext, bucket pa
 		return errors.Wrapf(err, "error uploading %s to S3", localPath)
 	}
 	remoteURL := util.S3DefaultURL(a.opts.S3Opts.Name, strings.Join([]string{remotePath, file}, "/"))
-	// kim: TODO: remove
-	// remoteURL := fmt.Sprintf("%s/%s/%s/%s", a.opts.S3BaseURL, a.opts.S3Opts.Name, remotePath, file)
 	tc.logger.Execution().Infof("uploaded file %s from %s to %s", file, localPath, remoteURL)
 	switch file {
 	case agentLogFileName:

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -79,17 +79,15 @@ type ExpansionVars struct {
 }
 
 type AgentSetupData struct {
-	SumoLogicEndpoint string `json:"sumo_logic_endpoint"`
-	SplunkServerURL   string `json:"splunk_server_url"`
-	SplunkClientToken string `json:"splunk_client_token"`
-	SplunkChannel     string `json:"splunk_channel"`
-	// kim: TODO: remove
-	// S3Base            string                  `json:"s3_base"`
-	S3Key        string                  `json:"s3_key"`
-	S3Secret     string                  `json:"s3_secret"`
-	S3Bucket     string                  `json:"s3_bucket"`
-	TaskSync     evergreen.S3Credentials `json:"task_sync"`
-	LogkeeperURL string                  `json:"logkeeper_url"`
+	SumoLogicEndpoint string                  `json:"sumo_logic_endpoint"`
+	SplunkServerURL   string                  `json:"splunk_server_url"`
+	SplunkClientToken string                  `json:"splunk_client_token"`
+	SplunkChannel     string                  `json:"splunk_channel"`
+	S3Key             string                  `json:"s3_key"`
+	S3Secret          string                  `json:"s3_secret"`
+	S3Bucket          string                  `json:"s3_bucket"`
+	TaskSync          evergreen.S3Credentials `json:"task_sync"`
+	LogkeeperURL      string                  `json:"logkeeper_url"`
 }
 
 // NextTaskResponse represents the response sent back when an agent asks for a next task

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -79,16 +79,17 @@ type ExpansionVars struct {
 }
 
 type AgentSetupData struct {
-	SumoLogicEndpoint string                  `json:"sumo_logic_endpoint"`
-	SplunkServerURL   string                  `json:"splunk_server_url"`
-	SplunkClientToken string                  `json:"splunk_client_token"`
-	SplunkChannel     string                  `json:"splunk_channel"`
-	S3Base            string                  `json:"s3_base"`
-	S3Key             string                  `json:"s3_key"`
-	S3Secret          string                  `json:"s3_secret"`
-	S3Bucket          string                  `json:"s3_bucket"`
-	TaskSync          evergreen.S3Credentials `json:"task_sync"`
-	LogkeeperURL      string                  `json:"logkeeper_url"`
+	SumoLogicEndpoint string `json:"sumo_logic_endpoint"`
+	SplunkServerURL   string `json:"splunk_server_url"`
+	SplunkClientToken string `json:"splunk_client_token"`
+	SplunkChannel     string `json:"splunk_channel"`
+	// kim: TODO: remove
+	// S3Base            string                  `json:"s3_base"`
+	S3Key        string                  `json:"s3_key"`
+	S3Secret     string                  `json:"s3_secret"`
+	S3Bucket     string                  `json:"s3_bucket"`
+	TaskSync     evergreen.S3Credentials `json:"task_sync"`
+	LogkeeperURL string                  `json:"logkeeper_url"`
 }
 
 // NextTaskResponse represents the response sent back when an agent asks for a next task

--- a/command/s3_copy.go
+++ b/command/s3_copy.go
@@ -232,7 +232,9 @@ func (c *s3copy) attachFiles(ctx context.Context, comm client.Communicator,
 	logger client.LoggerProducer, td client.TaskData, request apimodels.S3CopyRequest) error {
 
 	remotePath := filepath.ToSlash(request.S3DestinationPath)
-	fileLink := s3baseURL + request.S3DestinationBucket + "/" + remotePath
+	fileLink := util.S3DefaultURL(request.S3DestinationBucket, remotePath)
+	// kim: TODO: handle different S3 URL styles
+	// fileLink := s3baseURL + request.S3DestinationBucket + "/" + remotePath
 
 	displayName := request.S3DisplayName
 

--- a/command/s3_put.go
+++ b/command/s3_put.go
@@ -253,8 +253,7 @@ func (s3pc *s3put) Execute(ctx context.Context,
 			logger.Task().Infof("Putting files matching filter %v into path %v in s3 bucket %v",
 				s3pc.LocalFilesIncludeFilter, s3pc.RemoteFile, s3pc.Bucket)
 		} else {
-			logger.Task().Infof("Putting %s into %s/%s/%s",
-				s3pc.LocalFile, s3baseURL, s3pc.Bucket, s3pc.RemoteFile)
+			logger.Task().Infof("Putting %s into %s", util.S3DefaultURL(s3pc.Bucket, s3pc.RemoteFile))
 		}
 	}
 
@@ -401,7 +400,9 @@ func (s3pc *s3put) attachFiles(ctx context.Context, comm client.Communicator, lo
 			remoteFileName = fmt.Sprintf("%s%s", remoteFile, filepath.Base(fn))
 		}
 
-		fileLink := s3baseURL + s3pc.Bucket + "/" + remoteFileName
+		fileLink := util.S3DefaultURL(s3pc.Bucket, remoteFileName)
+		// kim: TODO: handle different S3 URL styles
+		// fileLink := s3baseURL + s3pc.Bucket + "/" + remoteFileName
 
 		displayName := s3pc.ResourceDisplayName
 		if s3pc.isMulti() || displayName == "" {

--- a/command/s3_put.go
+++ b/command/s3_put.go
@@ -381,6 +381,8 @@ retryLoop:
 		return err
 	}
 
+	logger.Task().WarningWhen(strings.Contains(s3pc.Bucket, "."), "bucket names containing dots that are created after Sept. 30, 2020 are not guaranteed to have valid attached URLs")
+
 	if len(uploadedFiles) != len(filesList) && !s3pc.skipMissing {
 		logger.Task().Infof("%d requested, %d uploaded", len(filesList), len(uploadedFiles))
 		return errors.Errorf("uploaded %d files of %d requested", len(uploadedFiles), len(filesList))
@@ -401,8 +403,6 @@ func (s3pc *s3put) attachFiles(ctx context.Context, comm client.Communicator, lo
 		}
 
 		fileLink := util.S3DefaultURL(s3pc.Bucket, remoteFileName)
-		// kim: TODO: handle different S3 URL styles
-		// fileLink := s3baseURL + s3pc.Bucket + "/" + remoteFileName
 
 		displayName := s3pc.ResourceDisplayName
 		if s3pc.isMulti() || displayName == "" {

--- a/command/s3_util.go
+++ b/command/s3_util.go
@@ -17,8 +17,6 @@ const (
 	s3HTTPClientTimeout = 60 * time.Minute
 	s3OpSleep           = 2 * time.Second
 	s3OpRetryMaxSleep   = 20 * time.Second
-	// kim: TODO: remove
-	// s3baseURL           = "https://s3.amazonaws.com/"
 )
 
 var (

--- a/command/s3_util.go
+++ b/command/s3_util.go
@@ -17,7 +17,8 @@ const (
 	s3HTTPClientTimeout = 60 * time.Minute
 	s3OpSleep           = 2 * time.Second
 	s3OpRetryMaxSleep   = 20 * time.Second
-	s3baseURL           = "https://s3.amazonaws.com/"
+	// kim: TODO: remove
+	// s3baseURL           = "https://s3.amazonaws.com/"
 )
 
 var (

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2020-09-17"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-09-16"
+	AgentVersion = "2020-09-21"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -84,9 +84,6 @@ type AWSConfig struct {
 	TaskSync S3Credentials `bson:"task_sync" json:"task_sync" yaml:"task_sync"`
 	// TaskSyncRead stores credentials for reading task data in S3.
 	TaskSyncRead S3Credentials `bson:"task_sync_read" json:"task_sync_read" yaml:"task_sync_read"`
-	// kim: TODO: remove S3BaseURL from everywhere, since it's not compatible
-	// with both URLs styles.
-	// S3BaseURL string `bson:"s3_base_url" json:"s3_base_url" yaml:"s3_base_url"`
 
 	DefaultSecurityGroup string `bson:"default_security_group" json:"default_security_group" yaml:"default_security_group"`
 

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -84,7 +84,9 @@ type AWSConfig struct {
 	TaskSync S3Credentials `bson:"task_sync" json:"task_sync" yaml:"task_sync"`
 	// TaskSyncRead stores credentials for reading task data in S3.
 	TaskSyncRead S3Credentials `bson:"task_sync_read" json:"task_sync_read" yaml:"task_sync_read"`
-	S3BaseURL    string        `bson:"s3_base_url" json:"s3_base_url" yaml:"s3_base_url"`
+	// kim: TODO: remove S3BaseURL from everywhere, since it's not compatible
+	// with both URLs styles.
+	// S3BaseURL string `bson:"s3_base_url" json:"s3_base_url" yaml:"s3_base_url"`
 
 	DefaultSecurityGroup string `bson:"default_security_group" json:"default_security_group" yaml:"default_security_group"`
 

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1374,7 +1374,7 @@ functions:
       working_dir: gopath/src/github.com/evergreen-ci/evergreen
       binary: make
       env:
-        CLIENT_URL: https://s3.amazonaws.com/mciuploads/evergreen/${task_id}/evergreen-ci/evergreen/clients/${goos}_${goarch}/evergreen
+        CLIENT_URL: https://mciuploads.s3.amazonaws.com/evergreen/${task_id}/evergreen-ci/evergreen/clients/${goos}_${goarch}/evergreen
 buildvariants:
 - matrix_name: "my-matrix"
   matrix_spec: { version: ["4.0", "4.2"], os: "linux" }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1285,16 +1285,17 @@ func (a *APISubnet) ToService() (interface{}, error) {
 }
 
 type APIAWSConfig struct {
-	EC2Keys              []APIEC2Key       `json:"ec2_keys"`
-	Subnets              []APISubnet       `json:"subnets"`
-	S3                   *APIS3Credentials `json:"s3_credentials"`
-	TaskSync             *APIS3Credentials `json:"task_sync"`
-	TaskSyncRead         *APIS3Credentials `json:"task_sync_read"`
-	S3BaseURL            *string           `json:"s3_base_url"`
-	DefaultSecurityGroup *string           `json:"default_security_group"`
-	AllowedInstanceTypes []*string         `json:"allowed_instance_types"`
-	AllowedRegions       []*string         `json:"allowed_regions"`
-	MaxVolumeSizePerUser *int              `json:"max_volume_size"`
+	EC2Keys      []APIEC2Key       `json:"ec2_keys"`
+	Subnets      []APISubnet       `json:"subnets"`
+	S3           *APIS3Credentials `json:"s3_credentials"`
+	TaskSync     *APIS3Credentials `json:"task_sync"`
+	TaskSyncRead *APIS3Credentials `json:"task_sync_read"`
+	// kim: TODO: remove
+	// S3BaseURL            *string           `json:"s3_base_url"`
+	DefaultSecurityGroup *string   `json:"default_security_group"`
+	AllowedInstanceTypes []*string `json:"allowed_instance_types"`
+	AllowedRegions       []*string `json:"allowed_regions"`
+	MaxVolumeSizePerUser *int      `json:"max_volume_size"`
 }
 
 type APIS3Credentials struct {
@@ -1363,7 +1364,8 @@ func (a *APIAWSConfig) BuildFromService(h interface{}) error {
 		}
 		a.TaskSyncRead = taskSyncRead
 
-		a.S3BaseURL = ToStringPtr(v.S3BaseURL)
+		// kim: TODO: remove
+		// a.S3BaseURL = ToStringPtr(v.S3BaseURL)
 		a.DefaultSecurityGroup = ToStringPtr(v.DefaultSecurityGroup)
 		a.MaxVolumeSizePerUser = &v.MaxVolumeSizePerUser
 		a.AllowedInstanceTypes = ToStringPtrSlice(v.AllowedInstanceTypes)
@@ -1380,7 +1382,8 @@ func (a *APIAWSConfig) ToService() (interface{}, error) {
 		return nil, nil
 	}
 	config := evergreen.AWSConfig{
-		S3BaseURL:            FromStringPtr(a.S3BaseURL),
+		// kim: TODO: remove
+		// S3BaseURL:            FromStringPtr(a.S3BaseURL),
 		DefaultSecurityGroup: FromStringPtr(a.DefaultSecurityGroup),
 		MaxVolumeSizePerUser: evergreen.DefaultMaxVolumeSizePerUser,
 	}

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1285,17 +1285,15 @@ func (a *APISubnet) ToService() (interface{}, error) {
 }
 
 type APIAWSConfig struct {
-	EC2Keys      []APIEC2Key       `json:"ec2_keys"`
-	Subnets      []APISubnet       `json:"subnets"`
-	S3           *APIS3Credentials `json:"s3_credentials"`
-	TaskSync     *APIS3Credentials `json:"task_sync"`
-	TaskSyncRead *APIS3Credentials `json:"task_sync_read"`
-	// kim: TODO: remove
-	// S3BaseURL            *string           `json:"s3_base_url"`
-	DefaultSecurityGroup *string   `json:"default_security_group"`
-	AllowedInstanceTypes []*string `json:"allowed_instance_types"`
-	AllowedRegions       []*string `json:"allowed_regions"`
-	MaxVolumeSizePerUser *int      `json:"max_volume_size"`
+	EC2Keys              []APIEC2Key       `json:"ec2_keys"`
+	Subnets              []APISubnet       `json:"subnets"`
+	S3                   *APIS3Credentials `json:"s3_credentials"`
+	TaskSync             *APIS3Credentials `json:"task_sync"`
+	TaskSyncRead         *APIS3Credentials `json:"task_sync_read"`
+	DefaultSecurityGroup *string           `json:"default_security_group"`
+	AllowedInstanceTypes []*string         `json:"allowed_instance_types"`
+	AllowedRegions       []*string         `json:"allowed_regions"`
+	MaxVolumeSizePerUser *int              `json:"max_volume_size"`
 }
 
 type APIS3Credentials struct {
@@ -1364,8 +1362,6 @@ func (a *APIAWSConfig) BuildFromService(h interface{}) error {
 		}
 		a.TaskSyncRead = taskSyncRead
 
-		// kim: TODO: remove
-		// a.S3BaseURL = ToStringPtr(v.S3BaseURL)
 		a.DefaultSecurityGroup = ToStringPtr(v.DefaultSecurityGroup)
 		a.MaxVolumeSizePerUser = &v.MaxVolumeSizePerUser
 		a.AllowedInstanceTypes = ToStringPtrSlice(v.AllowedInstanceTypes)
@@ -1382,8 +1378,6 @@ func (a *APIAWSConfig) ToService() (interface{}, error) {
 		return nil, nil
 	}
 	config := evergreen.AWSConfig{
-		// kim: TODO: remove
-		// S3BaseURL:            FromStringPtr(a.S3BaseURL),
 		DefaultSecurityGroup: FromStringPtr(a.DefaultSecurityGroup),
 		MaxVolumeSizePerUser: evergreen.DefaultMaxVolumeSizePerUser,
 	}

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -141,7 +141,8 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Key, FromStringPtr(apiSettings.Providers.AWS.TaskSyncRead.Key))
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Secret, FromStringPtr(apiSettings.Providers.AWS.TaskSyncRead.Secret))
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Bucket, FromStringPtr(apiSettings.Providers.AWS.TaskSync.Bucket))
-	assert.EqualValues(testSettings.Providers.AWS.S3BaseURL, FromStringPtr(apiSettings.Providers.AWS.S3BaseURL))
+	// kim: TODO: remove
+	// assert.EqualValues(testSettings.Providers.AWS.S3BaseURL, FromStringPtr(apiSettings.Providers.AWS.S3BaseURL))
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, FromStringPtr(apiSettings.Providers.Docker.APIVersion))
 	assert.EqualValues(testSettings.Providers.GCE.ClientEmail, FromStringPtr(apiSettings.Providers.GCE.ClientEmail))
 	assert.EqualValues(testSettings.Providers.OpenStack.IdentityEndpoint, FromStringPtr(apiSettings.Providers.OpenStack.IdentityEndpoint))
@@ -207,7 +208,8 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Key, dbSettings.Providers.AWS.TaskSyncRead.Key)
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Secret, dbSettings.Providers.AWS.TaskSyncRead.Secret)
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Bucket, dbSettings.Providers.AWS.TaskSyncRead.Bucket)
-	assert.EqualValues(testSettings.Providers.AWS.S3BaseURL, dbSettings.Providers.AWS.S3BaseURL)
+	// kim: TODO: remove
+	// assert.EqualValues(testSettings.Providers.AWS.S3BaseURL, dbSettings.Providers.AWS.S3BaseURL)
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, dbSettings.Providers.Docker.APIVersion)
 	assert.EqualValues(testSettings.Providers.GCE.ClientEmail, dbSettings.Providers.GCE.ClientEmail)
 	assert.EqualValues(testSettings.Providers.OpenStack.IdentityEndpoint, dbSettings.Providers.OpenStack.IdentityEndpoint)

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -141,8 +141,6 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Key, FromStringPtr(apiSettings.Providers.AWS.TaskSyncRead.Key))
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Secret, FromStringPtr(apiSettings.Providers.AWS.TaskSyncRead.Secret))
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Bucket, FromStringPtr(apiSettings.Providers.AWS.TaskSync.Bucket))
-	// kim: TODO: remove
-	// assert.EqualValues(testSettings.Providers.AWS.S3BaseURL, FromStringPtr(apiSettings.Providers.AWS.S3BaseURL))
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, FromStringPtr(apiSettings.Providers.Docker.APIVersion))
 	assert.EqualValues(testSettings.Providers.GCE.ClientEmail, FromStringPtr(apiSettings.Providers.GCE.ClientEmail))
 	assert.EqualValues(testSettings.Providers.OpenStack.IdentityEndpoint, FromStringPtr(apiSettings.Providers.OpenStack.IdentityEndpoint))
@@ -208,8 +206,6 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Key, dbSettings.Providers.AWS.TaskSyncRead.Key)
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Secret, dbSettings.Providers.AWS.TaskSyncRead.Secret)
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Bucket, dbSettings.Providers.AWS.TaskSyncRead.Bucket)
-	// kim: TODO: remove
-	// assert.EqualValues(testSettings.Providers.AWS.S3BaseURL, dbSettings.Providers.AWS.S3BaseURL)
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, dbSettings.Providers.Docker.APIVersion)
 	assert.EqualValues(testSettings.Providers.GCE.ClientEmail, dbSettings.Providers.GCE.ClientEmail)
 	assert.EqualValues(testSettings.Providers.OpenStack.IdentityEndpoint, dbSettings.Providers.OpenStack.IdentityEndpoint)

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -242,7 +242,7 @@ functions:
       env:
         AWS_KEY: ${aws_key}
         AWS_SECRET: ${aws_secret}
-        CLIENT_URL: https://s3.amazonaws.com/mciuploads/evergreen/${task_id}/evergreen-ci/evergreen/clients/${goos}_${goarch}/evergreen
+        CLIENT_URL: https://mciuploads.s3.amazonaws.com/evergreen/${task_id}/evergreen-ci/evergreen/clients/${goos}_${goarch}/evergreen
         DEBUG_ENABLED: ${debug}
         DISABLE_COVERAGE: ${disable_coverage}
         DOCKER_HOST: ${docker_host}

--- a/service/api_status.go
+++ b/service/api_status.go
@@ -192,9 +192,7 @@ func (as *APIServer) agentSetup(w http.ResponseWriter, r *http.Request) {
 		S3Secret:          as.Settings.Providers.AWS.S3.Secret,
 		S3Bucket:          as.Settings.Providers.AWS.S3.Bucket,
 		TaskSync:          as.Settings.Providers.AWS.TaskSync,
-		// kim: TODO: remove
-		// S3Base:            as.Settings.Providers.AWS.S3BaseURL,
-		LogkeeperURL: as.Settings.LoggerConfig.LogkeeperURL,
+		LogkeeperURL:      as.Settings.LoggerConfig.LogkeeperURL,
 	}
 	gimlet.WriteJSON(w, out)
 }

--- a/service/api_status.go
+++ b/service/api_status.go
@@ -192,8 +192,9 @@ func (as *APIServer) agentSetup(w http.ResponseWriter, r *http.Request) {
 		S3Secret:          as.Settings.Providers.AWS.S3.Secret,
 		S3Bucket:          as.Settings.Providers.AWS.S3.Bucket,
 		TaskSync:          as.Settings.Providers.AWS.TaskSync,
-		S3Base:            as.Settings.Providers.AWS.S3BaseURL,
-		LogkeeperURL:      as.Settings.LoggerConfig.LogkeeperURL,
+		// kim: TODO: remove
+		// S3Base:            as.Settings.Providers.AWS.S3BaseURL,
+		LogkeeperURL: as.Settings.LoggerConfig.LogkeeperURL,
 	}
 	gimlet.WriteJSON(w, out)
 }

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1530,10 +1530,6 @@ Admin Settings
 										<label>Task Read-Only S3 Bucket</label>
 										<input type="text" ng-model="Settings.providers.aws.task_sync_read.bucket">
 									</md-input-container>
-									<!-- <md-input-container class="control" style="width:45%; margin-left:50px;"> -->
-									<!--   <label>S3 Base URL</label> -->
-									<!--   <input type="text" ng-model="Settings.providers.aws.s3_base_url"> -->
-									<!-- </md-input-container> -->
 									<md-input-container class="control" style="width:45%">
 										<label>Default Security Group</label>
 										<input type="text" ng-model="Settings.providers.aws.default_security_group">

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1530,10 +1530,10 @@ Admin Settings
 										<label>Task Read-Only S3 Bucket</label>
 										<input type="text" ng-model="Settings.providers.aws.task_sync_read.bucket">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
-										<label>S3 Base URL</label>
-										<input type="text" ng-model="Settings.providers.aws.s3_base_url">
-									</md-input-container>
+									<!-- <md-input-container class="control" style="width:45%; margin-left:50px;"> -->
+									<!--   <label>S3 Base URL</label> -->
+									<!--   <input type="text" ng-model="Settings.providers.aws.s3_base_url"> -->
+									<!-- </md-input-container> -->
 									<md-input-container class="control" style="width:45%">
 										<label>Default Security Group</label>
 										<input type="text" ng-model="Settings.providers.aws.default_security_group">

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -232,8 +232,6 @@ func MockConfig() *evergreen.Settings {
 					Secret: "task_sync_read_secret",
 					Bucket: "task_sync_bucket",
 				},
-				// kim: TODO: remove
-				// S3BaseURL: "s3_base_url",
 			},
 			Docker: evergreen.DockerConfig{
 				APIVersion: "docker_version",

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -232,7 +232,8 @@ func MockConfig() *evergreen.Settings {
 					Secret: "task_sync_read_secret",
 					Bucket: "task_sync_bucket",
 				},
-				S3BaseURL: "s3_base_url",
+				// kim: TODO: remove
+				// S3BaseURL: "s3_base_url",
 			},
 			Docker: evergreen.DockerConfig{
 				APIVersion: "docker_version",

--- a/util/s3.go
+++ b/util/s3.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// S3PathURL returns the path-style S3 URL for the given bucket containing the
+// object key.
+func S3PathURL(bucket, key string) string {
+	return strings.Join([]string{"https://s3.amazonaws.com", bucket, key}, "/")
+}
+
+// S3VirtualHostedURL returns the virtual hosted-style S3 URL for the given
+// bucket containing the object key.
+func S3VirtualHostedURL(bucket, key string) string {
+	return strings.Join([]string{fmt.Sprintf("https://%s.s3.amazonaws.com", bucket), key}, "/")
+}
+
+// SS3DefaultURL returns the S3 URL for the given bucket containing the object
+// key. The style of the S3 URL is determined based on the bucket name.
+func S3DefaultURL(bucket, key string) string {
+	if strings.Contains(bucket, ".") {
+		return S3PathURL(bucket, key)
+	}
+	return S3VirtualHostedURL(bucket, key)
+}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-9080

* The agent will use path-style URLs if the bucket has a dot; otherwise, it'll default to virtual hosted-style URLs.
* Warn for dotted buckets because dotted buckets created after Sept. 30 will not have valid URL attachments for `s3.put` and `s3.copy`. Dotted buckets are still okay if the bucket is created before Sept. 30, but since we don't know when a bucket was created, we have to warn even if the dotted bucket was created before Sept 30.
* Remove S3BaseURL from admin settings.