### PR TITLE
EVG-12618 make target for code gen

### DIFF
--- a/cmd/generate-rest-model/generate-rest-model.go
+++ b/cmd/generate-rest-model/generate-rest-model.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+
+	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+func main() {
+	var (
+		configFile string
+		schemaFile string
+		modelFile  string
+		helperFile string
+	)
+	flag.StringVar(&configFile, "config", "", "path to the config yml file with struct mappings")
+	flag.StringVar(&schemaFile, "schema", "", "path to the graphql schema to use for the output")
+	flag.StringVar(&modelFile, "model", "", "file path to write the generated model code <TODO relative>")
+	flag.StringVar(&helperFile, "helper", "", "file path to write the generated helper functions")
+	flag.Parse()
+
+	configData, err := ioutil.ReadFile(configFile)
+	grip.EmergencyFatal(errors.Wrap(err, "unable to read config file"))
+	var gqlConfig config.Config
+	err = yaml.Unmarshal(configData, &gqlConfig)
+	grip.EmergencyFatal(errors.Wrap(err, "unable to parse config file"))
+	schema, err := ioutil.ReadFile(schemaFile)
+	grip.EmergencyFatal(errors.Wrap(err, "unable to read schema file"))
+
+	mapping := model.ModelMapping{}
+	for dbModel, info := range gqlConfig.Models {
+		mapping[dbModel] = info.Model[0]
+	}
+	model.SetGeneratePathPrefix("rest/model")
+	model, helper, err := model.Codegen(string(schema), mapping)
+	grip.EmergencyFatal(errors.Wrap(err, "error generating code"))
+	err = ioutil.WriteFile(modelFile, model, 0644)
+	grip.EmergencyFatal(errors.Wrap(err, "error writing to model file"))
+	err = ioutil.WriteFile(helperFile, helper, 0644)
+	grip.EmergencyFatal(errors.Wrap(err, "error writing to helper file"))
+}

--- a/cmd/generate-rest-model/generate-rest-model.go
+++ b/cmd/generate-rest-model/generate-rest-model.go
@@ -18,10 +18,11 @@ func main() {
 		modelFile  string
 		helperFile string
 	)
-	flag.StringVar(&configFile, "config", "", "path to the config yml file with struct mappings")
-	flag.StringVar(&schemaFile, "schema", "", "path to the graphql schema to use for the output")
-	flag.StringVar(&modelFile, "model", "", "file path to write the generated model code <TODO relative>")
-	flag.StringVar(&helperFile, "helper", "", "file path to write the generated helper functions")
+	const pathToRestModels = "rest/model"
+	flag.StringVar(&configFile, "config", "", "path to the config yml file with struct mappings, either an absolute path or relative to the evergreen folder")
+	flag.StringVar(&schemaFile, "schema", "", "path to the graphql schema to use for the output, either an absolute path or relative to the evergreen folder")
+	flag.StringVar(&modelFile, "model", "", "file path to write the generated model code, either an absolute path or relative to the evergreen folder")
+	flag.StringVar(&helperFile, "helper", "", "file path to write the generated helper functions, either an absolute path or relative to the evergreen folder")
 	flag.Parse()
 
 	configData, err := ioutil.ReadFile(configFile)
@@ -36,7 +37,7 @@ func main() {
 	for dbModel, info := range gqlConfig.Models {
 		mapping[dbModel] = info.Model[0]
 	}
-	model.SetGeneratePathPrefix("rest/model")
+	model.SetGeneratePathPrefix(pathToRestModels)
 	model, helper, err := model.Codegen(string(schema), mapping)
 	grip.EmergencyFatal(errors.Wrap(err, "error generating code"))
 	err = ioutil.WriteFile(modelFile, model, 0644)

--- a/cmd/generate-rest-model/generate-rest-model.go
+++ b/cmd/generate-rest-model/generate-rest-model.go
@@ -43,4 +43,6 @@ func main() {
 	grip.EmergencyFatal(errors.Wrap(err, "error writing to model file"))
 	err = ioutil.WriteFile(helperFile, helper, 0644)
 	grip.EmergencyFatal(errors.Wrap(err, "error writing to helper file"))
+
+	grip.Infof("%s and %s have been updated with the generated code", modelFile, helperFile)
 }

--- a/makefile
+++ b/makefile
@@ -187,6 +187,13 @@ $(buildDir)/go-test-config:cmd/go-test-config/make-config.go
 	GOPATH=$(shell dirname $(shell pwd)) $(gobin) build -o $@ $<
 #end generated config
 
+# generate rest model
+generate-rest-model:$(buildDir)/generate-rest-model
+	./$(buildDir)/generate-rest-model --config "rest/model/schema/type_mapping.yml" --schema "rest/model/schema/rest_model.graphql" --model "rest/model/generated.go" --helper "rest/model/generated_converters.go"
+$(buildDir)/generate-rest-model:cmd/generate-rest-model/generate-rest-model.go
+	$(gobin) build -o $@ $<
+#end generate rest model
+
 # parse a host.create file and set expansions
 parse-host-file:$(buildDir)/parse-host-file
 	./$(buildDir)/parse-host-file --file $(HOST_FILE)


### PR DESCRIPTION
This makes the code generator finally usable! This just adds a simple cli command that calls the code gen code with some hardcoded file paths. I had to add a package-level variable to hold a path prefix, because this command and the tests call it with different working directories