### PR TITLE
EVG-13058: Logging to understand why EC2 Capacity errors

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -204,6 +204,11 @@ func (c *awsClientImpl) RunInstances(ctx context.Context, input *ec2.RunInstance
 						return false, EC2InsufficientCapacityError
 					}
 					grip.Debug(message.WrapError(ec2err, msg))
+					grip.Debug(message.Fields{
+						"message":    "no match found for EC2 error code",
+						"err_code":   ec2err.Code(),
+						"err_search": EC2InsufficientCapacity,
+					})
 				}
 				return true, err
 			}


### PR DESCRIPTION
 EC2 Capacity errors are not being handled in an expected way. If you can figure out why and we don't need to add this logging, please let me know.