### PR TITLE
EVG-12888 log host.create AMI/distro

### DIFF
--- a/command/host_create.go
+++ b/command/host_create.go
@@ -117,7 +117,7 @@ func (c *createHost) logAMI(ctx context.Context, comm client.Communicator, logge
 		return
 	}
 	if c.CreateHost.AMI != "" {
-		logger.Task().Infof("host.create: using given AMI '%s'\n", c.CreateHost.AMI)
+		logger.Task().Infof("host.create: using given AMI '%s'", c.CreateHost.AMI)
 		return
 	}
 
@@ -128,7 +128,7 @@ func (c *createHost) logAMI(ctx context.Context, comm client.Communicator, logge
 		return
 	}
 
-	logger.Task().Infof("host.create: using AMI '%s' (for distro '%s')\n", ami, c.CreateHost.Distro)
+	logger.Task().Infof("host.create: using AMI '%s' (for distro '%s')", ami, c.CreateHost.Distro)
 }
 
 type logBatchInfo struct {

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -63,6 +63,8 @@ type Communicator interface {
 	GetProjectRef(context.Context, TaskData) (*model.ProjectRef, error)
 	// GetDistro returns the distro for the task.
 	GetDistro(context.Context, TaskData) (*distro.Distro, error)
+	// GetDistroAMI gets the AMI for the given distro/region
+	GetDistroAMI(context.Context, string, string, TaskData) (string, error)
 	// GetProject loads the project using the task's version ID
 	GetProject(context.Context, TaskData) (*model.Project, error)
 	// GetExpansions returns all expansions for the task known by the app server

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -181,6 +181,10 @@ func (c *Mock) GetDistro(ctx context.Context, td TaskData) (*distro.Distro, erro
 	}, nil
 }
 
+func (c *Mock) GetDistroAMI(context.Context, string, string, TaskData) (string, error) {
+	return "ami-mock", nil
+}
+
 func (c *Mock) GetProject(ctx context.Context, td TaskData) (*serviceModel.Project, error) {
 	var err error
 	var data []byte

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -387,7 +387,7 @@ func (h *distroIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 //
 // GET /rest/v2/distros/{distro_id}/ami
 
-type DistroAMIHandler struct {
+type distroAMIHandler struct {
 	distroID string
 	region   string
 
@@ -395,18 +395,18 @@ type DistroAMIHandler struct {
 }
 
 func makeGetDistroAMI(sc data.Connector) gimlet.RouteHandler {
-	return &DistroAMIHandler{
+	return &distroAMIHandler{
 		sc: sc,
 	}
 }
 
-func (h *DistroAMIHandler) Factory() gimlet.RouteHandler {
-	return &DistroAMIHandler{
+func (h *distroAMIHandler) Factory() gimlet.RouteHandler {
+	return &distroAMIHandler{
 		sc: h.sc,
 	}
 }
 
-func (h *DistroAMIHandler) Parse(ctx context.Context, r *http.Request) error {
+func (h *distroAMIHandler) Parse(ctx context.Context, r *http.Request) error {
 	h.distroID = gimlet.GetVars(r)["distro_id"]
 	vals := r.URL.Query()
 	h.region = vals.Get("region")
@@ -416,7 +416,7 @@ func (h *DistroAMIHandler) Parse(ctx context.Context, r *http.Request) error {
 	return nil
 }
 
-func (h *DistroAMIHandler) Run(ctx context.Context) gimlet.Responder {
+func (h *distroAMIHandler) Run(ctx context.Context) gimlet.Responder {
 	d, err := h.sc.FindDistroById(h.distroID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for find() by distro id '%s'", h.distroID))

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
@@ -380,6 +381,61 @@ func (h *distroIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	return gimlet.NewJSONResponse(apiDistro)
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+// GET /rest/v2/distros/{distro_id}/ami
+
+type DistroAMIHandler struct {
+	distroID string
+	region   string
+
+	sc data.Connector
+}
+
+func makeGetDistroAMI(sc data.Connector) gimlet.RouteHandler {
+	return &DistroAMIHandler{
+		sc: sc,
+	}
+}
+
+func (h *DistroAMIHandler) Factory() gimlet.RouteHandler {
+	return &DistroAMIHandler{
+		sc: h.sc,
+	}
+}
+
+func (h *DistroAMIHandler) Parse(ctx context.Context, r *http.Request) error {
+	h.distroID = gimlet.GetVars(r)["distro_id"]
+	vals := r.URL.Query()
+	h.region = vals.Get("region")
+	if h.region == "" {
+		h.region = evergreen.DefaultEC2Region
+	}
+	return nil
+}
+
+func (h *DistroAMIHandler) Run(ctx context.Context) gimlet.Responder {
+	d, err := h.sc.FindDistroById(h.distroID)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for find() by distro id '%s'", h.distroID))
+	}
+	if !strings.HasPrefix(d.Provider, "ec2") {
+		return gimlet.NewJSONResponse("")
+	}
+
+	for _, ec2Settings := range d.ProviderSettingsList {
+		curRegion, ok := ec2Settings.Lookup("region").StringValueOK()
+		if !ok || curRegion != h.region {
+			continue
+		}
+
+		ami, _ := ec2Settings.Lookup("ami").StringValueOK()
+		return gimlet.NewTextResponse(ami)
+	}
+	return gimlet.MakeJSONErrorResponder(errors.Errorf(
+		"no settings available for region '%s' for distro '%s'", h.region, h.distroID))
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -8,13 +8,10 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen/db"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -24,6 +21,7 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -253,7 +251,7 @@ func TestDistroAMIHandler(t *testing.T) {
 		},
 	}
 	assert.NoError(t, d.Insert())
-	h := makeGetDistroAMI(&data.DBConnector{}).(*DistroAMIHandler)
+	h := makeGetDistroAMI(&data.DBConnector{}).(*distroAMIHandler)
 
 	// default region
 	r, err := http.NewRequest("GET", "/distros/d1/ami", nil)

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -26,6 +26,11 @@ type hostCreateHandler struct {
 	sc data.Connector
 }
 
+type HostCreateResults struct {
+	hostID string
+	AMI    string
+}
+
 func makeHostCreateRouteManager(sc data.Connector) gimlet.RouteHandler {
 	return &hostCreateHandler{sc: sc}
 }

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -88,6 +88,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/distros/{distro_id}/setup").Version(2).Patch().Wrap(editDistroSettings).RouteHandler(makeChangeDistroSetup(sc))
 	app.AddRoute("/distros/{distro_id}/execute").Version(2).Patch().Wrap(editHosts).RouteHandler(makeDistroExecute(sc, env))
 	app.AddRoute("/distros/{distro_id}/icecream_config").Version(2).Patch().Wrap(editHosts).RouteHandler(makeDistroIcecreamConfig(sc, env))
+	app.AddRoute("/distros/{distro_id}/ami").Version(2).Get().Wrap(checkTask).RouteHandler(makeGetDistroAMI(sc))
 
 	app.AddRoute("/hooks/github").Version(2).Post().RouteHandler(makeGithubHooksRoute(sc, opts.APIQueue, opts.GithubSecret, settings))
 	app.AddRoute("/hooks/aws").Version(2).Post().RouteHandler(makeAwsSnsRoute(sc, env, opts.APIQueue))


### PR DESCRIPTION
https://evergreen-staging.corp.mongodb.com/task_log_raw/mci_ubuntu1604_test_cloud_patch_c2e82da3ba68a0acbe9c8c6cee7fede58bf52314_5f6a552a97b1d3217bdc21c8_20_09_22_19_49_41/3?type=T#L171

Originally I thought about having host.create return AMIs as a result, or adding it to host.list, but it seems we want to know the AMI in the case of error as well (or especially), so that's why I added a separate route.
