### PR TITLE
EVG-12407 Dont return patchable:false tasks

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -299,10 +299,12 @@ func GetVariantsAndTasksFromProject(patchedConfig string, patchProject string) (
 	for _, variant := range project.BuildVariants {
 		tasksForVariant := []model.BuildVariantTaskUnit{}
 		for _, TaskFromVariant := range variant.Tasks {
-			if TaskFromVariant.IsGroup {
-				tasksForVariant = append(tasksForVariant, model.CreateTasksFromGroup(TaskFromVariant, project)...)
-			} else {
-				tasksForVariant = append(tasksForVariant, TaskFromVariant)
+			if *TaskFromVariant.Patchable {
+				if TaskFromVariant.IsGroup {
+					tasksForVariant = append(tasksForVariant, model.CreateTasksFromGroup(TaskFromVariant, project)...)
+				} else {
+					tasksForVariant = append(tasksForVariant, TaskFromVariant)
+				}
 			}
 		}
 		variant.Tasks = tasksForVariant

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -299,7 +299,7 @@ func GetVariantsAndTasksFromProject(patchedConfig string, patchProject string) (
 	for _, variant := range project.BuildVariants {
 		tasksForVariant := []model.BuildVariantTaskUnit{}
 		for _, TaskFromVariant := range variant.Tasks {
-			if *TaskFromVariant.Patchable {
+			if !util.IsPtrSetToFalse(TaskFromVariant.Patchable) {
 				if TaskFromVariant.IsGroup {
 					tasksForVariant = append(tasksForVariant, model.CreateTasksFromGroup(TaskFromVariant, project)...)
 				} else {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -299,7 +299,7 @@ func GetVariantsAndTasksFromProject(patchedConfig string, patchProject string) (
 	for _, variant := range project.BuildVariants {
 		tasksForVariant := []model.BuildVariantTaskUnit{}
 		for _, TaskFromVariant := range variant.Tasks {
-			if !util.IsPtrSetToFalse(TaskFromVariant.Patchable) {
+			if !util.IsPtrSetToFalse(TaskFromVariant.Patchable) && !util.IsPtrSetToTrue(TaskFromVariant.GitTagOnly) {
 				if TaskFromVariant.IsGroup {
 					tasksForVariant = append(tasksForVariant, model.CreateTasksFromGroup(TaskFromVariant, project)...)
 				} else {


### PR DESCRIPTION
This function is only used in the projects resolver of the patch resolver. The projects field is used to to render the configure patch view on the ui. So by preventing non patchable tasks from being returned here it should not show up in the UI