### PR TITLE
EVG-12967 move setup code within graphql subtests

### DIFF
--- a/graphql/tests/userSettings/data.json
+++ b/graphql/tests/userSettings/data.json
@@ -1,15 +1,1 @@
-{
-  "users": [
-    {
-      "first_name": "Mohamed",
-      "last_name": "Khelif",
-      "settings": {
-        "timezone": "America/New_York",
-        "region": "us-east-1",
-        "github_user": {
-          "last_known_as": "khelif96"
-        }
-      }
-    }
-  ]
-}
+{}


### PR DESCRIPTION
- more cleanly split up the tests into suite/directory/test. Full test names have not changed
- scope setup code to the appropriate one of the 3 levels. No more starting up a ton of http servers if you want to run 1 test so things should be a lot faster
- clean up the http server, which should prevent too many open file errors
- pretty print the actual query response so you don't need to copy it to another editor to look at