### PR TITLE
EVG-12923 add logging

### DIFF
--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1725,7 +1725,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 
 	// test that restarting a task correctly resets the task and archives it
 	assert.NoError(resetTaskData())
-	assert.NoError(resetTask("displayTask", "caller"))
+	assert.NoError(resetTask("displayTask", "caller", false))
 	archivedTasks, err := task.FindOldWithDisplayTasks(task.All)
 	assert.NoError(err)
 	assert.Len(archivedTasks, 3)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"fmt"
-	"runtime/debug"
 	"sort"
 	"strconv"
 	"time"
@@ -529,7 +528,7 @@ func UpdateBlockedDependencies(t *task.Task) error {
 			"message": "blocked task group dependent tasks",
 			"ticket":  "EVG-12923",
 			"task":    t.Id,
-			"stack":   debug.Stack(),
+			"stack":   message.NewStack(2, ""),
 		})
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -561,7 +561,6 @@ func UpdateUnblockedDependencies(t *task.Task, logIDs bool) error {
 			"message": "unblocked task group dependent tasks",
 			"ticket":  "EVG-12923",
 			"task":    t.Id,
-			"stack":   debug.Stack(),
 		})
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"time"
@@ -45,7 +46,7 @@ func SetActiveState(t *task.Task, caller string, active bool) error {
 		}
 
 		if t.DispatchTime != utility.ZeroTime && t.Status == evergreen.TaskUndispatched {
-			if err := resetTask(t.Id, caller); err != nil {
+			if err := resetTask(t.Id, caller, false); err != nil {
 				return errors.Wrap(err, "error resetting task")
 			}
 		} else {
@@ -114,16 +115,16 @@ func ActivatePreviousTask(taskId, caller string) error {
 	return errors.WithStack(SetActiveState(prevTask, caller, true))
 }
 
-func resetManyTasks(tasks []task.Task, caller string) error {
+func resetManyTasks(tasks []task.Task, caller string, logIDs bool) error {
 	catcher := grip.NewBasicCatcher()
 	for _, t := range tasks {
-		catcher.Add(resetTask(t.Id, caller))
+		catcher.Add(resetTask(t.Id, caller, logIDs))
 	}
 	return catcher.Resolve()
 }
 
 // reset task finds a task, attempts to archive it, and resets the task and resets the TaskCache in the build as well.
-func resetTask(taskId, caller string) error {
+func resetTask(taskId, caller string, logIDs bool) error {
 	t, err := task.FindOneNoMerge(task.ById(taskId))
 	if err != nil {
 		return errors.WithStack(err)
@@ -135,7 +136,7 @@ func resetTask(taskId, caller string) error {
 		return errors.Wrap(err, "can't restart task because it can't be archived")
 	}
 
-	if err = MarkOneTaskReset(t); err != nil {
+	if err = MarkOneTaskReset(t, logIDs); err != nil {
 		return errors.WithStack(err)
 	}
 	event.LogTaskRestarted(t.Id, t.Execution, caller)
@@ -245,7 +246,7 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 		return errors.Wrap(checkResetSingleHostTaskGroup(t, caller), "can't reset single host task group")
 	}
 
-	return errors.WithStack(resetTask(t.Id, caller))
+	return errors.WithStack(resetTask(t.Id, caller, false))
 }
 
 func AbortTask(taskId, caller string) error {
@@ -437,7 +438,7 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 		return errors.Wrap(err, "could not mark task finished")
 	}
 
-	if err = UpdateUnblockedDependencies(t); err != nil {
+	if err = UpdateUnblockedDependencies(t, true); err != nil {
 		return errors.Wrap(err, "could not update unblocked dependencies")
 	}
 
@@ -523,6 +524,15 @@ func UpdateBlockedDependencies(t *task.Task) error {
 		return errors.Wrapf(err, "can't get tasks depending on task '%s'", t.Id)
 	}
 
+	if t.IsPartOfSingleHostTaskGroup() && len(dependentTasks) > 0 {
+		grip.Info(message.Fields{
+			"message": "blocked task group dependent tasks",
+			"ticket":  "EVG-12923",
+			"task":    t.Id,
+			"stack":   debug.Stack(),
+		})
+	}
+
 	for _, dependentTask := range dependentTasks {
 		if err = dependentTask.MarkUnattainableDependency(t, true); err != nil {
 			return errors.Wrap(err, "error marking dependency unattainable")
@@ -540,17 +550,26 @@ func UpdateBlockedDependencies(t *task.Task) error {
 	return nil
 }
 
-func UpdateUnblockedDependencies(t *task.Task) error {
+func UpdateUnblockedDependencies(t *task.Task, logIDs bool) error {
 	blockedTasks, err := t.FindAllMarkedUnattainableDependencies()
 	if err != nil {
 		return errors.Wrap(err, "can't get dependencies marked unattainable")
+	}
+
+	if logIDs && t.IsPartOfSingleHostTaskGroup() && len(blockedTasks) > 0 {
+		grip.Info(message.Fields{
+			"message": "unblocked task group dependent tasks",
+			"ticket":  "EVG-12923",
+			"task":    t.Id,
+			"stack":   debug.Stack(),
+		})
 	}
 
 	for _, blockedTask := range blockedTasks {
 		if err = blockedTask.MarkUnattainableDependency(t, false); err != nil {
 			return errors.Wrap(err, "error marking dependency attainable")
 		}
-		if err = UpdateUnblockedDependencies(&blockedTask); err != nil {
+		if err = UpdateUnblockedDependencies(&blockedTask, logIDs); err != nil {
 			return errors.WithStack(err)
 		}
 
@@ -905,20 +924,20 @@ func MarkTaskDispatched(t *task.Task, h *host.Host) error {
 	return nil
 }
 
-func MarkOneTaskReset(t *task.Task) error {
+func MarkOneTaskReset(t *task.Task, logIDs bool) error {
 	if t.DisplayOnly {
 		for _, et := range t.ExecutionTasks {
 			execTask, err := task.FindOneId(et)
 			if err != nil {
 				return errors.Wrap(err, "error retrieving execution task")
 			}
-			if err = MarkOneTaskReset(execTask); err != nil {
+			if err = MarkOneTaskReset(execTask, logIDs); err != nil {
 				return errors.Wrap(err, "error resetting execution task")
 			}
 		}
 	}
 
-	if err := UpdateUnblockedDependencies(t); err != nil {
+	if err := UpdateUnblockedDependencies(t, logIDs); err != nil {
 		return errors.Wrap(err, "can't clear cached unattainable dependencies")
 	}
 	return errors.Wrap(t.Reset(), "error resetting task in database")
@@ -933,7 +952,7 @@ func MarkTasksReset(taskIds []string) error {
 		if t.DisplayOnly {
 			taskIds = append(taskIds, t.Id)
 		}
-		if err = UpdateUnblockedDependencies(&t); err != nil {
+		if err = UpdateUnblockedDependencies(&t, false); err != nil {
 			return errors.Wrap(err, "can't clear cached unattainable dependencies")
 		}
 	}
@@ -1246,7 +1265,29 @@ func checkResetSingleHostTaskGroup(t *task.Task, caller string) error {
 		return nil
 	}
 
-	return resetManyTasks(tasks, caller)
+	if err = resetManyTasks(tasks, caller, true); err != nil {
+		return errors.Wrap(err, "can't reset task group tasks")
+	}
+
+	tasks, err = task.FindTaskGroupFromBuild(t.BuildId, t.TaskGroup)
+	if err != nil {
+		return errors.Wrapf(err, "can't get task group for task '%s'", t.Id)
+	}
+	taskSet := map[string]bool{}
+	for _, t := range tasks {
+		taskSet[t.Id] = true
+		for _, dep := range t.DependsOn {
+			if taskSet[dep.TaskId] && dep.Unattainable {
+				grip.Info(message.Fields{
+					"message": "task group task was blocked on an earlier task group task after reset",
+					"task":    t.Id,
+					"ticket":  "EVG-12923",
+				})
+			}
+		}
+	}
+
+	return nil
 }
 
 func checkResetDisplayTask(t *task.Task) error {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3436,7 +3436,7 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 	}
 	assert.NoError(b.Insert())
 
-	assert.NoError(UpdateUnblockedDependencies(&tasks[0]))
+	assert.NoError(UpdateUnblockedDependencies(&tasks[0], false))
 	dbBuild, err := build.FindOneId(b.Id)
 	assert.NoError(err)
 	require.Len(t, dbBuild.Tasks, 6)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3436,7 +3436,7 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 	}
 	assert.NoError(b.Insert())
 
-	assert.NoError(UpdateUnblockedDependencies(&tasks[0], false))
+	assert.NoError(UpdateUnblockedDependencies(&tasks[0], false, ""))
 	dbBuild, err := build.FindOneId(b.Id)
 	assert.NoError(err)
 	require.Len(t, dbBuild.Tasks, 6)


### PR DESCRIPTION
Add logging to help trace down the cause of (errantly) blocked task group tasks.

In defence of logging the stack trace: it's not really that big. We [log it](https://github.com/evergreen-ci/evergreen/blob/e1a1a040cb99960a0422e85928d280f08e8cb897/service/ui.go#L149) with many UI errors and with panics. It will get logged once for each task group task that gets blocked and has unblocked dependencies.
(The issue we had previously was with logging the display task cache which was huge).