### PR TITLE
EVG-13122: Ignore nonexistent volume Ids when building the volumes field in the Host GQL type

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -86,7 +86,7 @@ func (r *hostResolver) Volumes(ctx context.Context, obj *restModel.APIHost) ([]*
 			return volumes, InternalServerError.Send(ctx, fmt.Sprintf("Error getting volume %s", volId))
 		}
 		if volume == nil {
-			return volumes, ResourceNotFound.Send(ctx, fmt.Sprintf("Unable to find volume %s", volId))
+			continue
 		}
 		apiVolume := &restModel.APIVolume{}
 		err = apiVolume.BuildFromService(volume)

--- a/graphql/tests/myHosts/data.json
+++ b/graphql/tests/myHosts/data.json
@@ -309,6 +309,239 @@
       "running_task_group_order": 0,
       "running_task_project": "mongodb-mongo-v3.6",
       "running_task_version": "mongodb_mongo_v3.6_bc405c72dce4714da604810cdc90c132bd5fbaa1"
+    },
+    {
+      "_id": "i-host-thing",
+      "host_id": "ec2-54-161-252-150.compute-1.amazonaws.com",
+      "user": "ubuntu",
+      "tag": "evg-ubuntu1604-large-20200720180108-7236635000257959768",
+      "distro": {
+        "_id": "ubuntu1604-large",
+        "aliases": ["ubuntu1604", "ubuntu1604-build"],
+        "arch": "linux_amd64",
+        "work_dir": "/data/mci",
+        "provider": "ec2-fleet",
+        "provider_settings": [
+          {
+            "region": "us-east-1",
+            "security_group_ids": ["sg-1a636869"],
+            "key_name": "mci",
+            "bid_price": 0.84,
+            "instance_type": "c4.4xlarge",
+            "is_vpc": true,
+            "subnet_id": "subnet-6dd81326",
+            "mount_points": [
+              {
+                "device_name": "/dev/xvdd",
+                "size": 330
+              }
+            ],
+            "vpc_name": "production_dynamic_vpc",
+            "ami": "ami-08db4ac6ea508c686"
+          }
+        ],
+        "setup_as_sudo": true,
+        "setup": "#!/bin/bash\nset -o errexit\nset -o verbose\n\numount /mnt || true\numount /dev/xvdd || true\n/sbin/mkfs.xfs -f /dev/xvdd\nmkdir -p /data\necho \"/dev/xvdd /data auto noatime 0 0\" | tee -a /etc/fstab\nmount /data\n\n\nchown -R ubuntu:ubuntu /data\n\necho \"github.com,207.97.227.239 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==\" | tee -a /home/ubuntu/.ssh/known_hosts\necho \"${github_private_key}\" | tee /home/ubuntu/.ssh/id_rsa\necho \"${github_public_key}\" | tee /home/ubuntu/.ssh/id_rsa.pub\nchmod 600 /home/ubuntu/.ssh/*\nchown -R ubuntu:ubuntu /data\nchown -R ubuntu:ubuntu /home/ubuntu/.ssh\n\n# /tmp will be a symlink to this\n#\nmkdir /data/tmp\nchmod 1777 /data/tmp\nmkdir -p /data/var/lib/docker\nsystemctl restart docker",
+        "user": "ubuntu",
+        "bootstrap_settings": {
+          "method": "user-data",
+          "communication": "rpc",
+          "client_dir": "/opt/evergreen",
+          "jasper_binary_dir": "/opt/evergreen",
+          "jasper_credentials_path": "/opt/evergreen/jasper_credentials.json",
+          "shell_path": "/bin/bash",
+          "resource_limits": {
+            "num_files": 64000,
+            "num_processes": -1,
+            "locked_memory": -1,
+            "virtual_memory": -1
+          }
+        },
+        "clone_method": "legacy-ssh",
+        "ssh_key": "mci",
+        "ssh_options": [
+          "StrictHostKeyChecking=no",
+          "BatchMode=yes",
+          "ConnectTimeout=10"
+        ],
+        "spawn_allowed": true,
+        "expansions": [
+          {
+            "key": "decompress",
+            "value": "tar zxvf"
+          },
+          {
+            "key": "ps",
+            "value": "ps aux"
+          },
+          {
+            "key": "kill_pid",
+            "value": "kill -- -$(ps opgid= %v)"
+          },
+          {
+            "key": "scons_prune_ratio",
+            "value": "0.8"
+          }
+        ],
+        "finder_settings": {
+          "version": "legacy"
+        },
+        "planner_settings": {
+          "version": "tunable",
+          "target_time": {
+            "$numberLong": "0"
+          },
+          "group_versions": false,
+          "patch_zipper_factor": {
+            "$numberLong": "0"
+          },
+          "patch_time_in_queue_factor": {
+            "$numberLong": "0"
+          },
+          "commit_queue_factor": {
+            "$numberLong": "0"
+          },
+          "mainline_time_in_queue_factor": {
+            "$numberLong": "0"
+          },
+          "expected_runtime_factor": {
+            "$numberLong": "0"
+          }
+        },
+        "dispatcher_settings": {
+          "version": "revised-with-dependencies"
+        },
+        "host_allocator_settings": {
+          "version": "utilization",
+          "minimum_hosts": 0,
+          "maximum_hosts": 120,
+          "acceptable_host_idle_time": {
+            "$numberLong": "0"
+          }
+        },
+        "disable_shallow_clone": false,
+        "use_legacy_agent": false,
+        "note": "",
+        "is_virtual_workstation": false,
+        "is_cluster": false,
+        "home_volume_settings": {
+          "format_command": ""
+        },
+        "icecream_settings": {}
+      },
+      "host_type": "ec2-fleet",
+      "ext_identifier": "",
+      "display_name": "",
+      "project": "",
+      "zone": "us-east-1e",
+      "provisioned": true,
+      "priv_attempts": 1,
+      "last_task": "mongodb_mongo_v3.6_ubuntu1604_debug_ubsan_rollback_fuzzer_WT_bc405c72dce4714da604810cdc90c132bd5fbaa1_20_07_20_17_39_20",
+      "no_expiration": true,
+      "creation_time": {
+        "$date": "2020-07-20T18:01:08.213Z"
+      },
+      "start_time": {
+        "$date": "2020-07-20T18:02:02Z"
+      },
+      "agent_start_time": {
+        "$date": "2020-07-20T18:02:50.406Z"
+      },
+      "termination_time": {
+        "$date": "1970-01-01T00:00:00Z"
+      },
+      "task_count": 2,
+      "last_task_completed_time": {
+        "$date": "2020-07-20T19:00:10.630Z"
+      },
+      "last_communication": {
+        "$date": "2020-07-20T19:08:41.928Z"
+      },
+      "status": "running",
+      "started_by": "testuser",
+      "user_host": false,
+      "agent_revision": "2020-07-18",
+      "needs_agent": false,
+      "needs_agent_monitor": false,
+      "jasper_credentials_id": "evg-ubuntu1604-large-20200720180108-7236635000257959768",
+      "instance_type": "",
+      "volume_total_size": {
+        "$numberLong": "370"
+      },
+      "container_build_attempt": 0,
+      "spawn_options": {},
+      "docker_options": {},
+      "instance_tags": [
+        {
+          "key": "name",
+          "value": "evg-ubuntu1604-large-20200720180108-7236635000257959768",
+          "can_be_modified": false
+        },
+        {
+          "key": "distro",
+          "value": "ubuntu1604-large",
+          "can_be_modified": false
+        },
+        {
+          "key": "evergreen-service",
+          "value": "evergreenapp-4.build.10gen.cc",
+          "can_be_modified": false
+        },
+        {
+          "key": "username",
+          "value": "evergreen application server user",
+          "can_be_modified": false
+        },
+        {
+          "key": "owner",
+          "value": "mci",
+          "can_be_modified": false
+        },
+        {
+          "key": "mode",
+          "value": "production",
+          "can_be_modified": false
+        },
+        {
+          "key": "start-time",
+          "value": "20200720180108",
+          "can_be_modified": false
+        },
+        {
+          "key": "expire-on",
+          "value": "2020-07-30",
+          "can_be_modified": false
+        }
+      ],
+      "is_virtual_workstation": false,
+      "home_volume_size": 0,
+      "home_volume_id": "vol-2-id",
+      "compute_cost_per_hour": 0.261,
+      "volumes": [
+        {
+          "volume_id": "not-real-a-real-volume-id",
+          "device_name": "/dev/sda1",
+          "is_home": false,
+          "host_id": ""
+        }
+      ],
+      "total_cost": 0.3028389870061729,
+      "total_idle_time": {
+        "$numberLong": "50424000000"
+      },
+      "prov_time": {
+        "$date": "2020-07-20T18:03:00.758Z"
+      },
+      "last_bv": "ubuntu1604-debug-ubsan",
+      "last_group": "",
+      "last_project": "mongodb-mongo-v3.6",
+      "last_version": "mongodb_mongo_v3.6_bc405c72dce4714da604810cdc90c132bd5fbaa1",
+      "running_task": "mongodb_mongo_v3.6_enterprise_ubuntu1604_64_jepsen_set_linearizableRead_WT_bc405c72dce4714da604810cdc90c132bd5fbaa1_20_07_20_17_39_20",
+      "running_task_bv": "enterprise-ubuntu1604-64",
+      "running_task_group": "",
+      "running_task_group_order": 0,
+      "running_task_project": "mongodb-mongo-v3.6",
+      "running_task_version": "mongodb_mongo_v3.6_bc405c72dce4714da604810cdc90c132bd5fbaa1"
     }
   ],
   "distro": [

--- a/graphql/tests/myHosts/results.json
+++ b/graphql/tests/myHosts/results.json
@@ -19,6 +19,15 @@
                 { "id": "vol-0b5ec54a106c6e976" },
                 { "id": "vol-015b745bb69a2a16b" }
               ]
+            },
+            {
+              "id": "i-host-thing",
+              "distroId": "ubuntu1604-large",
+              "distro": {
+                "workDir": "/data/mci",
+                "id": "ubuntu1604-large"
+              },
+              "volumes": []
             }
           ]
         }
@@ -36,6 +45,11 @@
             },
             {
               "id": "i-0f81a2d39744003dd",
+              "expiration": null,
+              "noExpiration": true
+            },
+            {
+              "id": "i-host-thing",
               "expiration": null,
               "noExpiration": true
             }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-13122
Originally, the host resolver returned an error when a nonexistent volume id is encountered in the Host.Volumes field. [Recently we discovered that mounting a volume to a host may push volume ids to Host.Volumes that don't exist in the Volumes collection](https://jira.mongodb.org/browse/EVG-13119). This PR allows us to continue using this query by ignoring nonexistent volumes by not returning an error upon discovery. 