### PR TITLE
EVG-13116 add logging, fix stale task query

### DIFF
--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3745,9 +3745,13 @@ func TestStaleRunningTasks(t *testing.T) {
 	}
 	assert.NoError(t3.Insert())
 
-	tasks, err := FindStaleRunningTasks(10 * time.Minute)
+	tasks, err := FindStaleRunningTasks(10*time.Minute, TaskHeartbeatPastCutoff)
 	assert.NoError(err)
-	assert.Len(tasks, 2)
+	assert.Len(tasks, 1)
+
+	tasks, err = FindStaleRunningTasks(10*time.Minute, TaskNoHeartbeatSinceDispatch)
+	assert.NoError(err)
+	assert.Len(tasks, 1)
 }
 
 func TestNumNewParentsNeeded(t *testing.T) {


### PR DESCRIPTION
- separate the interesting part of the stale task queries. This does mean we do multiple queries but they should be pretty fast
- log the reason for staleness
- fix a bug in the undispatched tag case where we were not respecting the cutoff check. If something races such that the heartbeat reaches the server before we mark the task as started, this could cause the problem we saw
- add a sanity check to the running task case that we don't have a heartbeat time of 0