### PR TITLE
EVG-12872 error on BackportOf

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-09-18"
+	ClientVersion = "2020-09-29"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-09-21"

--- a/operations/http.go
+++ b/operations/http.go
@@ -522,7 +522,6 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		SyncStatuses      []string           `json:"sync_statuses"`
 		SyncTimeout       time.Duration      `json:"sync_timeout"`
 		Finalize          bool               `json:"finalize"`
-		BackportOf        string             `json:"backport_of"`
 		BackportInfo      patch.BackportInfo `json:"backport_info"`
 		Parameters        []patch.Parameter  `json:"parameters"`
 	}{
@@ -538,7 +537,6 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		SyncStatuses:      incomingPatch.syncStatuses,
 		SyncTimeout:       incomingPatch.syncTimeout,
 		Finalize:          incomingPatch.finalize,
-		BackportOf:        incomingPatch.backportOf.PatchID,
 		BackportInfo:      incomingPatch.backportOf,
 		Parameters:        incomingPatch.parameters,
 	}


### PR DESCRIPTION
Add an intermediate step before #4030 to push users to update their CLI.
Also stop sending the BackportOf string given we don't need it anymore.