### PR TITLE
EVG-13127: add historical stats settings to REST route for project settings

### DIFF
--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -46,7 +46,7 @@ func getMockProjectSettings() model.ProjectSettingsEvent {
 			Vars:        map[string]string{},
 			PrivateVars: map[string]bool{},
 		},
-		Aliases: []model.ProjectAlias{model.ProjectAlias{
+		Aliases: []model.ProjectAlias{{
 			ID:        mgobson.ObjectIdHex("5bedc72ee4055d31f0340b1d"),
 			ProjectID: projectId,
 			Alias:     "alias1",
@@ -54,7 +54,7 @@ func getMockProjectSettings() model.ProjectSettingsEvent {
 			Task:      "subcommand",
 		},
 		},
-		Subscriptions: []event.Subscription{event.Subscription{
+		Subscriptions: []event.Subscription{{
 			ID:           "subscription1",
 			ResourceType: "project",
 			Owner:        "admin",
@@ -171,13 +171,13 @@ func TestMockProjectConnectorGetSuite(t *testing.T) {
 				Vars:        map[string]string{},
 				PrivateVars: map[string]bool{},
 			},
-			Aliases: []restModel.APIProjectAlias{restModel.APIProjectAlias{
+			Aliases: []restModel.APIProjectAlias{{
 				Alias:   restModel.ToStringPtr("alias1"),
 				Variant: restModel.ToStringPtr("ubuntu"),
 				Task:    restModel.ToStringPtr("subcommand"),
 			},
 			},
-			Subscriptions: []restModel.APISubscription{restModel.APISubscription{
+			Subscriptions: []restModel.APISubscription{{
 				ID:           restModel.ToStringPtr("subscription1"),
 				ResourceType: restModel.ToStringPtr("project"),
 				Owner:        restModel.ToStringPtr("admin"),

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -250,6 +250,8 @@ type APIProjectRef struct {
 	PatchingDisabled            bool                 `json:"patching_disabled"`
 	RepotrackerDisabled         bool                 `json:"repotracker_disabled"`
 	DispatchingDisabled         bool                 `json:"dispatching_disabled"`
+	DisabledStatsCache          bool                 `json:"disabled_stats_cache"`
+	FilesIgnoredFromCache       []*string            `json:"files_ignored_from_cache,omitempty"`
 	Admins                      []*string            `json:"admins"`
 	DeleteAdmins                []*string            `json:"delete_admins,omitempty"`
 	GitTagAuthorizedUsers       []*string            `bson:"git_tag_authorized_users" json:"git_tag_authorized_users"`
@@ -315,6 +317,8 @@ func (p *APIProjectRef) ToService() (interface{}, error) {
 		PatchingDisabled:      p.PatchingDisabled,
 		RepotrackerDisabled:   p.RepotrackerDisabled,
 		DispatchingDisabled:   p.DispatchingDisabled,
+		DisabledStatsCache:    p.DisabledStatsCache,
+		FilesIgnoredFromCache: FromStringPtrSlice(p.FilesIgnoredFromCache),
 		NotifyOnBuildFailure:  p.NotifyOnBuildFailure,
 		SpawnHostScriptPath:   FromStringPtr(p.SpawnHostScriptPath),
 		Admins:                FromStringPtrSlice(p.Admins),
@@ -393,6 +397,8 @@ func (p *APIProjectRef) BuildFromService(v interface{}) error {
 	p.PatchingDisabled = projectRef.PatchingDisabled
 	p.RepotrackerDisabled = projectRef.RepotrackerDisabled
 	p.DispatchingDisabled = projectRef.DispatchingDisabled
+	p.DisabledStatsCache = projectRef.DisabledStatsCache
+	p.FilesIgnoredFromCache = ToStringPtrSlice(projectRef.FilesIgnoredFromCache)
 	p.NotifyOnBuildFailure = projectRef.NotifyOnBuildFailure
 	p.SpawnHostScriptPath = ToStringPtr(projectRef.SpawnHostScriptPath)
 	p.Admins = ToStringPtrSlice(projectRef.Admins)

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -297,10 +297,32 @@ func (s *ProjectGetByIDSuite) TestRunExistingId() {
 	h.projectID = "dimoxinil"
 
 	resp := s.rm.Run(ctx)
-	s.NotNil(resp.Data())
+	s.Require().NotNil(resp.Data())
 	s.Equal(resp.Status(), http.StatusOK)
 
-	s.Equal(model.ToStringPtr("dimoxinil"), resp.Data().(*model.APIProjectRef).Identifier)
+	projectRef, ok := resp.Data().(*model.APIProjectRef)
+	s.Require().True(ok)
+	cachedProject := s.sc.MockProjectConnector.CachedProjects[0]
+	s.Equal(cachedProject.Repo, model.FromStringPtr(projectRef.Repo))
+	s.Equal(cachedProject.Owner, model.FromStringPtr(projectRef.Owner))
+	s.Equal(cachedProject.Branch, model.FromStringPtr(projectRef.Branch))
+	s.Equal(cachedProject.RepoKind, model.FromStringPtr(projectRef.RepoKind))
+	s.Equal(cachedProject.Enabled, projectRef.Enabled)
+	s.Equal(cachedProject.Private, projectRef.Private)
+	s.Equal(cachedProject.BatchTime, projectRef.BatchTime)
+	s.Equal(cachedProject.RemotePath, model.FromStringPtr(projectRef.RemotePath))
+	s.Equal(cachedProject.Identifier, model.FromStringPtr(projectRef.Identifier))
+	s.Equal(cachedProject.DisplayName, model.FromStringPtr(projectRef.DisplayName))
+	s.Equal(cachedProject.DeactivatePrevious, projectRef.DeactivatePrevious)
+	s.Equal(cachedProject.TracksPushEvents, projectRef.TracksPushEvents)
+	s.Equal(cachedProject.PRTestingEnabled, projectRef.PRTestingEnabled)
+	s.Equal(cachedProject.CommitQueue.Enabled, projectRef.CommitQueue.Enabled)
+	s.Equal(cachedProject.Tracked, projectRef.Tracked)
+	s.Equal(cachedProject.PatchingDisabled, projectRef.PatchingDisabled)
+	s.Equal(cachedProject.Admins, model.FromStringPtrSlice(projectRef.Admins))
+	s.Equal(cachedProject.NotifyOnBuildFailure, projectRef.NotifyOnBuildFailure)
+	s.Equal(cachedProject.DisabledStatsCache, projectRef.DisabledStatsCache)
+	s.Equal(cachedProject.FilesIgnoredFromCache, model.FromStringPtrSlice(projectRef.FilesIgnoredFromCache))
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -424,14 +446,16 @@ func getMockProjectsConnector() *data.MockConnector {
 					CommitQueue: serviceModel.CommitQueueParams{
 						Enabled: false,
 					},
-					Tracked:              true,
-					PatchingDisabled:     false,
-					Admins:               []string{"langdon.alger"},
-					NotifyOnBuildFailure: false,
+					Tracked:               true,
+					PatchingDisabled:      false,
+					Admins:                []string{"langdon.alger"},
+					NotifyOnBuildFailure:  false,
+					DisabledStatsCache:    true,
+					FilesIgnoredFromCache: []string{"ignored"},
 				},
 			},
 			CachedVars: []*serviceModel.ProjectVars{
-				&serviceModel.ProjectVars{
+				{
 					Id:   "dimoxinil",
 					Vars: map[string]string{"apple": "green", "banana": "yellow"},
 				},


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13127

The response returned from `/rest/v2/projects/{project_id}` is missing some fields. I added the project ref settings related to historical stats to the response because they're required for Cedar to run the historical stats job.