### PR TITLE
EVG-12433 consider exec tasks when scheduling display task

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -41,7 +41,7 @@ type Version struct {
 	GitTags           []GitTag `bson:"git_tags,omitempty" json:"git_tags,omitempty"`
 	TriggeredByGitTag GitTag   `bson:"triggered_by_git_tag,omitempty" json:"triggered_by_git_tag,omitempty"`
 
-	// Parameters stores both user-defined parameters and default parameters
+	// Parameters stores user-defined parameters
 	Parameters []patch.Parameter `bson:"parameters,omitempty" json:"parameters,omitempty"`
 	// This is technically redundant, but a lot of code relies on it, so I'm going to leave it
 	BuildIds []string `bson:"builds" json:"builds,omitempty"`


### PR DESCRIPTION
We were only scheduling the display task, which means the exec tasks couldn't get scheduled in any way.

Whether or not this fix is temporary depends on what we do with display/execs in the future but 🤷  the fix is done so.