### PR TITLE
EVG-13142 ignore blocked execution tasks for status

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -278,11 +278,13 @@ func ByStaleRunningTask(staleness time.Duration, reason StaleReason) db.Q {
 	case HeartbeatPastCutoff:
 		reasonQuery = bson.M{
 			StatusKey:        SelectorTaskInProgress,
+			DisplayOnlyKey:   bson.M{"$ne": true},
 			LastHeartbeatKey: bson.M{"$lte": time.Now().Add(-staleness)},
 		}
 	case NoHeartbeatSinceDispatch:
 		reasonQuery = bson.M{
 			StatusKey:       evergreen.TaskDispatched,
+			DisplayOnlyKey:  bson.M{"$ne": true},
 			DispatchTimeKey: bson.M{"$lte": time.Now().Add(-2 * staleness)},
 		}
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1165,9 +1165,14 @@ func UpdateDisplayTask(t *task.Task) error {
 	}
 	hasFinishedTasks := false
 	hasUnstartedTasks := false
+	hasBlockedtasks := false
 	startTime := time.Unix(1<<62, 0)
 	endTime := utility.ZeroTime
 	for _, execTask := range execTasks {
+		if execTask.Blocked() {
+			hasBlockedtasks = true
+			continue
+		}
 		// if any of the execution tasks are scheduled, the display task is too
 		if execTask.Activated {
 			t.Activated = true
@@ -1193,8 +1198,8 @@ func UpdateDisplayTask(t *task.Task) error {
 
 	sort.Sort(task.ByPriority(execTasks))
 	statusTask = execTasks[0]
-	if hasFinishedTasks && hasUnstartedTasks {
-		// if the display task has a mix of finished and unfinished tasks, the display task is still
+	if !hasBlockedtasks && hasFinishedTasks && hasUnstartedTasks {
+		// if an unblocked display task has a mix of finished and unfinished tasks, the display task is still
 		// "started" even if there aren't currently running tasks
 		statusTask.Status = evergreen.TaskStarted
 		statusTask.Details = apimodels.TaskEndDetail{}


### PR DESCRIPTION
I initially planned to have a display task with only successful + blocked tasks be a failure, but I'm like 51% sure that it's better to leave as successful. Having something in this state is almost certainly bad configuration. And even though it's theoretically correct, showing failed might make someone look for a red execution task and not find one

- Fix a related bug where the stranded task job is trying to clean up display tasks (these have heartbeats set to that of their execution tasks). This was causing blocked display tasks to get "restarted" and end up in a status of undispatched
- Ignore blocked execution tasks when evaluating the overall status of a display task