### PR TITLE
EVG-13003 modify host create job retries

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -19,6 +19,7 @@ const (
 	DefaultTeardownTimeoutSecs      = 21600
 	DefaultContainerWaitTimeoutSecs = 600
 	DefaultPollFrequency            = 30
+	DefaultRetries                  = 2
 )
 
 // TaskStartRequest holds information sent by the agent to the
@@ -231,8 +232,8 @@ func (ch *CreateHost) validateAgentOptions() error {
 	if ch.Retries > 10 {
 		catcher.New("retries must not be greater than 10")
 	}
-	if ch.Retries < 1 {
-		ch.Retries = 1
+	if ch.Retries == 0 {
+		ch.Retries = DefaultRetries
 	}
 	if ch.Scope == "" {
 		ch.Scope = ScopeTask

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -232,7 +232,7 @@ func (ch *CreateHost) validateAgentOptions() error {
 	if ch.Retries > 10 {
 		catcher.New("retries must not be greater than 10")
 	}
-	if ch.Retries == 0 {
+	if ch.Retries <= 0 {
 		ch.Retries = DefaultRetries
 	}
 	if ch.Scope == "" {

--- a/units/crons.go
+++ b/units/crons.go
@@ -798,7 +798,7 @@ func PopulateHostCreationJobs(env evergreen.Environment, part int) amboy.QueueOp
 				submitted++
 			}
 
-			catcher.Add(queue.Put(ctx, NewHostCreateJob(env, h, ts, 1, 0, false)))
+			catcher.Add(queue.Put(ctx, NewHostCreateJob(env, h, ts, 0, 0, false)))
 		}
 
 		if throttleCount > 0 {

--- a/units/crons.go
+++ b/units/crons.go
@@ -798,7 +798,7 @@ func PopulateHostCreationJobs(env evergreen.Environment, part int) amboy.QueueOp
 				submitted++
 			}
 
-			catcher.Add(queue.Put(ctx, NewHostCreateJob(env, h, ts, 0, 0, false)))
+			catcher.Add(queue.Put(ctx, NewHostCreateJob(env, h, ts, 0, false)))
 		}
 
 		if throttleCount > 0 {

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -56,7 +56,7 @@ func makeCreateHostJob() *createHostJob {
 	return j
 }
 
-func NewHostCreateJob(env evergreen.Environment, h host.Host, id string, currentAttempt int, maxAttempts int, buildImageStarted bool) amboy.Job {
+func NewHostCreateJob(env evergreen.Environment, h host.Host, id string, currentAttempt int, buildImageStarted bool) amboy.Job {
 	j := makeCreateHostJob()
 	j.host = &h
 	j.HostID = h.Id
@@ -65,11 +65,7 @@ func NewHostCreateJob(env evergreen.Environment, h host.Host, id string, current
 	j.SetID(fmt.Sprintf("%s.%s.%s", createHostJobName, j.HostID, id))
 	j.BuildImageStarted = buildImageStarted
 	j.CurrentAttempt = currentAttempt
-	if maxAttempts > 0 {
-		j.MaxAttempts = maxAttempts
-	} else if j.host.SpawnOptions.Retries > 0 {
-		j.MaxAttempts = j.host.SpawnOptions.Retries
-	}
+	j.MaxAttempts = j.host.SpawnOptions.Retries
 	return j
 }
 
@@ -409,7 +405,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 
 func (j *createHostJob) tryRequeue(ctx context.Context) {
 	if j.shouldRetryCreateHost(ctx) && j.env.RemoteQueue().Info().Started {
-		job := NewHostCreateJob(j.env, *j.host, fmt.Sprintf("attempt-%d", j.CurrentAttempt+1), j.CurrentAttempt+1, j.MaxAttempts, j.BuildImageStarted)
+		job := NewHostCreateJob(j.env, *j.host, fmt.Sprintf("attempt-%d", j.CurrentAttempt+1), j.CurrentAttempt+1, j.BuildImageStarted)
 		wait := time.Minute
 		if j.host.ParentID != "" {
 			wait = 10 * time.Second

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -70,6 +70,7 @@ func NewHostCreateJob(env evergreen.Environment, h host.Host, id string, current
 	} else if j.host.SpawnOptions.Retries > 0 {
 		j.MaxAttempts = j.host.SpawnOptions.Retries
 	}
+	return j
 }
 
 func (j *createHostJob) Run(ctx context.Context) {

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -69,10 +69,7 @@ func NewHostCreateJob(env evergreen.Environment, h host.Host, id string, current
 		j.MaxAttempts = maxAttempts
 	} else if j.host.SpawnOptions.Retries > 0 {
 		j.MaxAttempts = j.host.SpawnOptions.Retries
-	} else {
-		j.MaxAttempts = 1
 	}
-	return j
 }
 
 func (j *createHostJob) Run(ctx context.Context) {


### PR DESCRIPTION
It looks like tasks that fail on host.list for cloud are hitting EC2 InsufficientCapacity errors for host.create (sigh). By default we should retry once it looks like, but there's an off-by-one bug so we don't actually retry. I'm also going to make the retry limit 2 for now? Although that's an arbitrary decision, we could start by fixing the bug and modify the default later. We also retry with different subnets, so it does seem like there's a benefit to retrying.