### PR TITLE
EVG-12936 reset display task if execution tasks are blocked

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1312,7 +1312,7 @@ func checkResetDisplayTask(t *task.Task) error {
 		return errors.Wrapf(err, "can't get exec tasks for '%s'", t.Id)
 	}
 	for _, execTask := range execTasks {
-		if !execTask.IsFinished() && execTask.Activated {
+		if !execTask.IsFinished() && !execTask.Blocked() && execTask.Activated {
 			return nil // all tasks not finished
 		}
 	}


### PR DESCRIPTION
This logic already exists for task groups so I'm not sure why I didn't also add it to display tasks, but this is function is hit for resetting stranded tasks / other kinds of restarts, and I think it makes sense to allow restarting when there are blocked tasks for all of the cases.