### PR TITLE
EVG-12923 reorder reset

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -950,10 +950,11 @@ func MarkOneTaskReset(t *task.Task, logIDs bool) error {
 		}
 	}
 
-	if err := UpdateUnblockedDependencies(t, logIDs, "MarkOneTaskReset"); err != nil {
-		return errors.Wrap(err, "can't clear cached unattainable dependencies")
+	if err := t.Reset(); err != nil {
+		return errors.Wrap(err, "error resetting task in database")
 	}
-	return errors.Wrap(t.Reset(), "error resetting task in database")
+
+	return errors.Wrap(UpdateUnblockedDependencies(t, logIDs, "MarkOneTaskReset"), "can't clear cached unattainable dependencies")
 }
 
 func MarkTasksReset(taskIds []string) error {
@@ -961,15 +962,22 @@ func MarkTasksReset(taskIds []string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+
 	for _, t := range tasks {
 		if t.DisplayOnly {
 			taskIds = append(taskIds, t.Id)
 		}
-		if err = UpdateUnblockedDependencies(&t, false, ""); err != nil {
-			return errors.Wrap(err, "can't clear cached unattainable dependencies")
-		}
 	}
-	return errors.Wrap(task.ResetTasks(taskIds), "error resetting tasks in database")
+
+	if err = task.ResetTasks(taskIds); err != nil {
+		return errors.Wrap(err, "error resetting tasks in database")
+	}
+
+	catcher := grip.NewBasicCatcher()
+	for _, t := range tasks {
+		catcher.Add(errors.Wrap(UpdateUnblockedDependencies(&t, false, ""), "can't clear cached unattainable dependencies"))
+	}
+	return catcher.Resolve()
 }
 
 func updateDisplayTaskAndCache(t *task.Task) error {


### PR DESCRIPTION
Logging shows a race between resetting a task group and the [scheduler's sanity check](https://github.com/evergreen-ci/evergreen/blob/6d61fdd4be109f73665fa13d1c3fa13d39547193/model/task_queue_service_dependency.go#L544) that blocked tasks are marked blocked. 

My read of the race is that `MarkOneTaskReset` first clears the blocked status from dependencies before it resets the task they depend on. Since clearing the blocked status takes some time (it's recursive and there's a pretty deep call stack for the compile task) there's a significant amount of time where immediate dependencies are marked as not blocked while the task they depend on still has a failed status. This state is what the sanity check is trying to correct, so it calls UpdateBlockedDependencies on the depended-on task.

My solution is to reverse the order we reset in: first reset the depended-on task's status and then clear the blocked status from it's dependencies.

If after this deploys we no longer see this issue (i.e. [this](https://github.com/evergreen-ci/evergreen/blob/6d61fdd4be109f73665fa13d1c3fa13d39547193/model/task_lifecycle.go#L1294) isn't being logged) I'll remove the logging.