### PR TITLE
EVG-12942 fix restarting patches with display tasks from spruce

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -391,28 +391,17 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 	if err != nil && !adb.ResultsNotFound(err) {
 		return errors.WithStack(err)
 	}
+	for i := len(finishedTasks) - 1; i >= 0; i-- {
+		t := finishedTasks[i]
+		if t.DisplayTask != nil {
+			finishedTasks = append(finishedTasks[:i], finishedTasks[i+1:]...)
+		}
+	}
 	// archive all the finished tasks
 	startPhaseAt = time.Now()
 	for _, t := range finishedTasks {
 		if !t.IsPartOfSingleHostTaskGroup() { // for single host task groups we don't archive until fully restarting
 			if err = t.Archive(); err != nil {
-				type idAndExecution struct {
-					Id        string `json:"id"`
-					Execution int    `json:"execution"`
-				}
-				dbTasks := []idAndExecution{}
-				for _, dbTask := range finishedTasks {
-					dbTasks = append(dbTasks, idAndExecution{Id: dbTask.Id, Execution: dbTask.Execution})
-				}
-				grip.Debug(message.WrapError(err, message.Fields{
-					"ticket":          "EVG-12942",
-					"message":         "error archiving task",
-					"task_id":         t.Id,
-					"execution_after": t.Execution,
-					"display_only":    t.DisplayOnly,
-					"query_results":   dbTasks,
-					"requested_tasks": taskIds,
-				}))
 				return errors.Wrap(err, "failed to archive task")
 			}
 		}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -391,6 +391,8 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 	if err != nil && !adb.ResultsNotFound(err) {
 		return errors.WithStack(err)
 	}
+	// remove execution tasks in case the caller passed both display and execution tasks
+	// the functions below are expected to work if just the display task is passed
 	for i := len(finishedTasks) - 1; i >= 0; i-- {
 		t := finishedTasks[i]
 		if t.DisplayTask != nil {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1780,6 +1780,17 @@ func TestDisplayTaskRestart(t *testing.T) {
 	// test that execution tasks cannot be restarted
 	assert.NoError(resetTaskData())
 	assert.Error(TryResetTask("task5", "", "", nil))
+
+	// trying to restart execution tasks should restart the entire display task, if it's done
+	assert.NoError(resetTaskData())
+	assert.NoError(RestartVersion("version", allTasks, false, "test"))
+	tasks, err = task.FindWithDisplayTasks(task.ByIds(allTasks))
+	assert.NoError(err)
+	assert.Len(tasks, 3)
+	for _, dbTask := range tasks {
+		assert.Equal(evergreen.TaskUndispatched, dbTask.Status, dbTask.Id)
+		assert.True(dbTask.Activated, dbTask.Id)
+	}
 }
 
 func resetTaskData() error {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1121,11 +1121,12 @@ func FindWithDisplayTasks(query db.Q) ([]Task, error) {
 		return nil, nil
 	}
 
-	for _, t := range tasks {
+	for i, t := range tasks {
 		_, err = t.GetDisplayTask()
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to retrieve parent display task")
 		}
+		tasks[i] = t
 	}
 
 	return tasks, err

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1710,8 +1710,7 @@ func (t *Task) Archive() error {
 	archiveTask.Archived = true
 	err := db.Insert(OldCollection, &archiveTask)
 	if err != nil {
-		grip.Debug(message.WrapError(err, message.Fields{
-			"ticket":          "EVG-12942",
+		grip.Error(message.WrapError(err, message.Fields{
 			"archive_task_id": archiveTask.Id,
 			"old_task_id":     archiveTask.OldTaskId,
 			"execution":       t.Execution,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -311,7 +311,7 @@ func DeactivatePreviousTasks(t *task.Task, caller string) error {
 	if t.DisplayOnly {
 		for _, dt := range allTasks {
 			var execTasks []task.Task
-			execTasks, err = task.FindWithDisplayTasks(task.ByIds(dt.ExecutionTasks))
+			execTasks, err = task.Find(task.ByIds(dt.ExecutionTasks))
 			if err != nil {
 				return errors.Wrapf(err, "error finding execution tasks to deactivate for task %s", t.Id)
 			}


### PR DESCRIPTION
Sorry there's going to be lots of context for this. The immediate problem is that spruce shows both execution and display tasks, and a user can pass those into the restart code. We have handling for restarting display tasks to also restart/archive their children, but since both will be in the list we will try to archive the same execution of a child twice. This fix is a targeted fix for just that to remove execution tasks, so that this is consistent with the old UI

Ideally this should be addressed with EVG-12549, because Arjun found performance problems with the exact code that this is touching, and whatever fix for that will likely have to redo this. I tried a couple things but none worked, so I'm going with something simple just for this problem because people hit this a couple times a day.

Additionally EVG-12591 also will probably make this change obsolete, but that's going to be much later