### PR TITLE
EVG-13194: sort all patch failures to top when sorting by status 

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
@@ -251,12 +252,7 @@ func IsFinishedTaskStatus(status string) bool {
 }
 
 func IsFailedTaskStatus(status string) bool {
-	return status == TaskFailed ||
-		status == TaskSystemFailed ||
-		status == TaskSystemTimedOut ||
-		status == TaskSystemUnresponse ||
-		status == TaskTestTimedOut ||
-		status == TaskSetupFailed
+	return utility.StringSliceContains(TaskFailureStatuses, status)
 }
 
 // evergreen package names

--- a/globals.go
+++ b/globals.go
@@ -231,6 +231,16 @@ const (
 	DefaultShutdownWaitSeconds = 10
 )
 
+var TaskFailureStatuses []string = []string{
+	TaskTimedOut,
+	TaskFailed,
+	TaskSystemFailed,
+	TaskTestTimedOut,
+	TaskSetupFailed,
+	TaskSystemUnresponse,
+	TaskSystemTimedOut,
+}
+
 func IsFinishedTaskStatus(status string) bool {
 	if status == TaskSucceeded ||
 		IsFailedTaskStatus(status) {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -998,10 +998,6 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sortBy *
 	baseTaskStatuses, _ := GetBaseTaskStatusesFromPatchID(r.sc, patchID)
 	taskResults := ConvertDBTasksToGqlTasks(tasks, baseTaskStatuses)
 
-	// SORT BY STATUS
-	if sorter == "" || *sortBy == TaskSortCategoryStatus {
-		taskResults = GroupFailuresAndSortTasks(taskResults, sortDirParam, TaskStatus)
-	}
 	// SORT BY BASE STATUS
 	if *sortBy == TaskSortCategoryBaseStatus {
 		taskResults = GroupFailuresAndSortTasks(taskResults, sortDirParam, TaskBaseStatus)

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -998,7 +998,6 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sortBy *
 	baseTaskStatuses, _ := GetBaseTaskStatusesFromPatchID(r.sc, patchID)
 	taskResults := ConvertDBTasksToGqlTasks(tasks, baseTaskStatuses)
 
-	// SORT BY BASE STATUS
 	if *sortBy == TaskSortCategoryBaseStatus {
 		sort.SliceStable(taskResults, func(i, j int) bool {
 			if sortDirParam == 1 {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1000,7 +1000,12 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sortBy *
 
 	// SORT BY BASE STATUS
 	if *sortBy == TaskSortCategoryBaseStatus {
-		taskResults = GroupFailuresAndSortTasks(taskResults, sortDirParam, TaskBaseStatus)
+		sort.SliceStable(taskResults, func(i, j int) bool {
+			if sortDirParam == 1 {
+				return taskResults[i].BaseStatus < taskResults[j].BaseStatus
+			}
+			return taskResults[i].BaseStatus > taskResults[j].BaseStatus
+		})
 	}
 
 	if len(baseStatuses) > 0 {

--- a/graphql/tests/patchTasks/data.json
+++ b/graphql/tests/patchTasks/data.json
@@ -216,7 +216,7 @@
       "build_variant": "windows",
       "display_name": "compile",
       "r": "github_pull_request",
-      "status": "failed"
+      "status": "task-timed-out"
     },
     {
       "_id": "4.5",
@@ -269,7 +269,11 @@
       "build_variant": "windows",
       "display_name": "lint",
       "r": "github_pull_request",
-      "status": "success"
+      "status": "test-timed-out",
+      "details": {
+        "status": "failed",
+        "type": "system"
+      }
     },
     {
       "_id": "base-task-4",

--- a/graphql/tests/patchTasks/queries/filter-by-multiple-statuses.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-multiple-statuses.graphql
@@ -6,9 +6,6 @@
     tasks {
       id
       status
-      baseStatus
-      displayName
-      buildVariant
     }
     count
   }

--- a/graphql/tests/patchTasks/queries/filter-by-task-name.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-task-name.graphql
@@ -2,6 +2,7 @@
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", taskName: "test") {
     tasks {
       id
+      displayName
     }
     count
   }

--- a/graphql/tests/patchTasks/queries/filter-by-task-name.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-task-name.graphql
@@ -2,10 +2,6 @@
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", taskName: "test") {
     tasks {
       id
-      status
-      baseStatus
-      displayName
-      buildVariant
     }
     count
   }

--- a/graphql/tests/patchTasks/queries/filter-by-variant-partial-search-term.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-variant-partial-search-term.graphql
@@ -2,10 +2,6 @@
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", variant: "win") {
     tasks {
       id
-      status
-      baseStatus
-      displayName
-      buildVariant
     }
     count
   }

--- a/graphql/tests/patchTasks/queries/filter-by-variant.graphql
+++ b/graphql/tests/patchTasks/queries/filter-by-variant.graphql
@@ -2,10 +2,6 @@
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", variant: "windows") {
     tasks {
       id
-      status
-      baseStatus
-      displayName
-      buildVariant
     }
     count
   }

--- a/graphql/tests/patchTasks/queries/sort-base-status-descending.graphql
+++ b/graphql/tests/patchTasks/queries/sort-base-status-descending.graphql
@@ -6,10 +6,7 @@
   ) {
     tasks {
       id
-      status
       baseStatus
-      displayName
-      buildVariant
     }
     count
   }

--- a/graphql/tests/patchTasks/queries/sort-by-base-status.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-base-status.graphql
@@ -2,10 +2,7 @@
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: BASE_STATUS) {
     tasks {
       id
-      status
       baseStatus
-      displayName
-      buildVariant
     }
     count
   }

--- a/graphql/tests/patchTasks/queries/sort-by-name.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-name.graphql
@@ -2,10 +2,7 @@
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: NAME) {
     tasks {
       id
-      status
-      baseStatus
       displayName
-      buildVariant
     }
     count
   }

--- a/graphql/tests/patchTasks/queries/sort-by-status.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-status.graphql
@@ -3,9 +3,6 @@
     tasks {
       id
       status
-      baseStatus
-      displayName
-      buildVariant
     }
     count
   }

--- a/graphql/tests/patchTasks/queries/sort-by-variant.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-variant.graphql
@@ -2,9 +2,6 @@
   patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: VARIANT) {
     tasks {
       id
-      status
-      baseStatus
-      displayName
       buildVariant
     }
     count

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -38,16 +38,16 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "4"
-              },
-              {
-                "id": "3"
-              },
-              {
                 "id": "1.5"
               },
               {
                 "id": "4.5"
+              },
+              {
+                "id": "4"
+              },
+              {
+                "id": "3"
               }
             ],
             "count": 4
@@ -62,16 +62,16 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "4"
-              },
-              {
-                "id": "3"
-              },
-              {
                 "id": "1.5"
               },
               {
                 "id": "4.5"
+              },
+              {
+                "id": "4"
+              },
+              {
+                "id": "3"
               }
             ],
             "count": 4
@@ -104,6 +104,20 @@
                 "buildVariant": "ubuntu1604"
               },
               {
+                "id": "1.5",
+                "status": "system-failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "4.5",
+                "status": "system-failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
                 "id": "4",
                 "status": "task-timed-out",
                 "baseStatus": "success",
@@ -122,20 +136,6 @@
                 "status": "success",
                 "baseStatus": "test-timed-out",
                 "displayName": "lint",
-                "buildVariant": "windows"
-              },
-              {
-                "id": "1.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
-              },
-              {
-                "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
                 "buildVariant": "windows"
               }
             ],
@@ -227,6 +227,14 @@
                 "status": "failed"
               },
               {
+                "id": "1.5",
+                "status": "system-failed"
+              },
+              {
+                "id": "4.5",
+                "status": "system-failed"
+              },
+              {
                 "id": "4",
                 "status": "task-timed-out"
               },
@@ -237,14 +245,6 @@
               {
                 "id": "3",
                 "status": "success"
-              },
-              {
-                "id": "1.5",
-                "status": "system-failed"
-              },
-              {
-                "id": "4.5",
-                "status": "system-failed"
               }
             ],
             "count": 6
@@ -331,20 +331,6 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "1.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
-              },
-              {
-                "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
-              },
-              {
                 "id": "1",
                 "status": "success",
                 "baseStatus": "success",
@@ -361,6 +347,20 @@
               {
                 "id": "4",
                 "status": "task-timed-out",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "1.5",
+                "status": "system-failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "4.5",
+                "status": "system-failed",
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
@@ -454,8 +454,8 @@
                 "buildVariant": "ubuntu1604"
               },
               {
-                "id": "4",
-                "status": "task-timed-out",
+                "id": "1.5",
+                "status": "system-failed",
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
@@ -473,17 +473,17 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "1",
-                "status": "success",
+                "id": "4.5",
+                "status": "system-failed",
                 "baseStatus": "success",
-                "displayName": "test-thirdparty-docker",
-                "buildVariant": "ubuntu1604"
+                "displayName": "compile",
+                "buildVariant": "windows"
               },
               {
-                "id": "3",
-                "status": "success",
-                "baseStatus": "test-timed-out",
-                "displayName": "lint",
+                "id": "4",
+                "status": "task-timed-out",
+                "baseStatus": "success",
+                "displayName": "compile",
                 "buildVariant": "windows"
               }
             ],

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -455,7 +455,7 @@
               },
               {
                 "id": "4",
-                "status": "failed",
+                "status": "task-timed-out",
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
@@ -482,7 +482,7 @@
               {
                 "id": "3",
                 "status": "success",
-                "baseStatus": "success",
+                "baseStatus": "test-timed-out",
                 "displayName": "lint",
                 "buildVariant": "windows"
               }

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -18,10 +18,12 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "2"
+                "id": "1",
+                "displayName": "test-thirdparty-docker"
               },
               {
-                "id": "1"
+                "id": "2",
+                "displayName": "test-cloud"
               }
             ],
             "count": 2

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -263,10 +263,6 @@
                 "baseStatus": "failed"
               },
               {
-                "id": "3",
-                "baseStatus": "test-timed-out"
-              },
-              {
                 "id": "1",
                 "baseStatus": "success"
               },
@@ -281,6 +277,10 @@
               {
                 "id": "4.5",
                 "baseStatus": "success"
+              },
+              {
+                "id": "3",
+                "baseStatus": "test-timed-out"
               }
             ],
             "count": 6
@@ -295,6 +295,10 @@
           "patchTasks": {
             "tasks": [
               {
+                "id": "3",
+                "baseStatus": "test-timed-out"
+              },
+              {
                 "id": "1",
                 "baseStatus": "success"
               },
@@ -309,10 +313,6 @@
               {
                 "id": "4.5",
                 "baseStatus": "success"
-              },
-              {
-                "id": "3",
-                "baseStatus": "test-timed-out"
               },
               {
                 "id": "2",

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -18,12 +18,12 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "1",
-                "displayName": "test-thirdparty-docker"
-              },
-              {
                 "id": "2",
                 "displayName": "test-cloud"
+              },
+              {
+                "id": "1",
+                "displayName": "test-thirdparty-docker"
               }
             ],
             "count": 2

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -265,15 +265,15 @@
                 "baseStatus": "test-timed-out"
               },
               {
-                "id": "4",
-                "baseStatus": "success"
-              },
-              {
                 "id": "1",
                 "baseStatus": "success"
               },
               {
                 "id": "1.5",
+                "baseStatus": "success"
+              },
+              {
+                "id": "4",
                 "baseStatus": "success"
               },
               {
@@ -293,19 +293,19 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "1.5",
-                "baseStatus": "success"
-              },
-              {
-                "id": "4.5",
-                "baseStatus": "success"
-              },
-              {
                 "id": "1",
                 "baseStatus": "success"
               },
               {
+                "id": "1.5",
+                "baseStatus": "success"
+              },
+              {
                 "id": "4",
+                "baseStatus": "success"
+              },
+              {
+                "id": "4.5",
                 "baseStatus": "success"
               },
               {
@@ -362,14 +362,14 @@
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
-              }
+              },
               {
                 "id": "2",
                 "status": "failed",
                 "baseStatus": "failed",
                 "displayName": "test-cloud",
                 "buildVariant": "ubuntu1604"
-              },
+              }
             ],
             "count": 6
           }

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -18,18 +18,10 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "2",
-                "status": "failed",
-                "baseStatus": "failed",
-                "displayName": "test-cloud",
-                "buildVariant": "ubuntu1604"
+                "id": "2"
               },
               {
-                "id": "1",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "test-thirdparty-docker",
-                "buildVariant": "ubuntu1604"
+                "id": "1"
               }
             ],
             "count": 2
@@ -44,32 +36,16 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "4",
-                "status": "failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "id": "4"
               },
               {
-                "id": "3",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "lint",
-                "buildVariant": "windows"
+                "id": "3"
               },
               {
-                "id": "1.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "id": "1.5"
               },
               {
-                "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "id": "4.5"
               }
             ],
             "count": 4
@@ -84,32 +60,16 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "4",
-                "status": "failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "id": "4"
               },
               {
-                "id": "3",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "lint",
-                "buildVariant": "windows"
+                "id": "3"
               },
               {
-                "id": "1.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "id": "1.5"
               },
               {
-                "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "id": "4.5"
               }
             ],
             "count": 4
@@ -143,7 +103,7 @@
               },
               {
                 "id": "4",
-                "status": "failed",
+                "status": "task-timed-out",
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
@@ -158,7 +118,7 @@
               {
                 "id": "3",
                 "status": "success",
-                "baseStatus": "success",
+                "baseStatus": "test-timed-out",
                 "displayName": "lint",
                 "buildVariant": "windows"
               },
@@ -190,45 +150,27 @@
             "tasks": [
               {
                 "id": "1.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "displayName": "compile"
               },
               {
                 "id": "4",
-                "status": "failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "displayName": "compile"
               },
               {
                 "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "displayName": "compile"
               },
               {
                 "id": "3",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "lint",
-                "buildVariant": "windows"
+                "displayName": "lint"
               },
               {
                 "id": "2",
-                "status": "failed",
-                "baseStatus": "failed",
-                "displayName": "test-cloud",
-                "buildVariant": "ubuntu1604"
+                "displayName": "test-cloud"
               },
               {
                 "id": "1",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "test-thirdparty-docker",
-                "buildVariant": "ubuntu1604"
+                "displayName": "test-thirdparty-docker"
               }
             ],
             "count": 6
@@ -244,44 +186,26 @@
             "tasks": [
               {
                 "id": "1",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "test-thirdparty-docker",
                 "buildVariant": "ubuntu1604"
               },
               {
                 "id": "2",
-                "status": "failed",
-                "baseStatus": "failed",
-                "displayName": "test-cloud",
                 "buildVariant": "ubuntu1604"
               },
               {
                 "id": "1.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
                 "buildVariant": "windows"
               },
               {
                 "id": "3",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "lint",
                 "buildVariant": "windows"
               },
               {
                 "id": "4",
-                "status": "failed",
-                "baseStatus": "success",
-                "displayName": "compile",
                 "buildVariant": "windows"
               },
               {
                 "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
                 "buildVariant": "windows"
               }
             ],
@@ -298,45 +222,27 @@
             "tasks": [
               {
                 "id": "2",
-                "status": "failed",
-                "baseStatus": "failed",
-                "displayName": "test-cloud",
-                "buildVariant": "ubuntu1604"
+                "status": "failed"
               },
               {
                 "id": "4",
-                "status": "failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "status": "task-timed-out"
               },
               {
                 "id": "1",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "test-thirdparty-docker",
-                "buildVariant": "ubuntu1604"
+                "status": "success"
               },
               {
                 "id": "3",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "lint",
-                "buildVariant": "windows"
+                "status": "success"
               },
               {
                 "id": "1.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "status": "system-failed"
               },
               {
                 "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "status": "system-failed"
               }
             ],
             "count": 6
@@ -352,45 +258,27 @@
             "tasks": [
               {
                 "id": "2",
-                "status": "failed",
-                "baseStatus": "failed",
-                "displayName": "test-cloud",
-                "buildVariant": "ubuntu1604"
-              },
-              {
-                "id": "1",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "test-thirdparty-docker",
-                "buildVariant": "ubuntu1604"
-              },
-              {
-                "id": "1.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "baseStatus": "failed"
               },
               {
                 "id": "3",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "lint",
-                "buildVariant": "windows"
+                "baseStatus": "test-timed-out"
               },
               {
                 "id": "4",
-                "status": "failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "baseStatus": "success"
+              },
+              {
+                "id": "1",
+                "baseStatus": "success"
+              },
+              {
+                "id": "1.5",
+                "baseStatus": "success"
               },
               {
                 "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "baseStatus": "success"
               }
             ],
             "count": 6
@@ -405,46 +293,28 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "1",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "test-thirdparty-docker",
-                "buildVariant": "ubuntu1604"
-              },
-              {
                 "id": "1.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
-              },
-              {
-                "id": "3",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "lint",
-                "buildVariant": "windows"
-              },
-              {
-                "id": "4",
-                "status": "failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "baseStatus": "success"
               },
               {
                 "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "baseStatus": "success"
+              },
+              {
+                "id": "1",
+                "baseStatus": "success"
+              },
+              {
+                "id": "4",
+                "baseStatus": "success"
+              },
+              {
+                "id": "3",
+                "baseStatus": "test-timed-out"
               },
               {
                 "id": "2",
-                "status": "failed",
-                "baseStatus": "failed",
-                "displayName": "test-cloud",
-                "buildVariant": "ubuntu1604"
+                "baseStatus": "failed"
               }
             ],
             "count": 6
@@ -482,10 +352,17 @@
               {
                 "id": "3",
                 "status": "success",
-                "baseStatus": "success",
+                "baseStatus": "test-timed-out",
                 "displayName": "lint",
                 "buildVariant": "windows"
               },
+              {
+                "id": "4",
+                "status": "task-timed-out",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              }
               {
                 "id": "2",
                 "status": "failed",
@@ -493,13 +370,6 @@
                 "displayName": "test-cloud",
                 "buildVariant": "ubuntu1604"
               },
-              {
-                "id": "4",
-                "status": "failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
-              }
             ],
             "count": 6
           }
@@ -518,16 +388,9 @@
                 "baseStatus": "failed",
                 "displayName": "test-cloud",
                 "buildVariant": "ubuntu1604"
-              },
-              {
-                "id": "4",
-                "status": "failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
               }
             ],
-            "count": 2
+            "count": 1
           }
         }
       }
@@ -559,34 +422,18 @@
             "tasks": [
               {
                 "id": "2",
-                "status": "failed",
-                "baseStatus": "failed",
-                "displayName": "test-cloud",
-                "buildVariant": "ubuntu1604"
-              },
-              {
-                "id": "4",
-                "status": "failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "status": "failed"
               },
               {
                 "id": "1",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "test-thirdparty-docker",
-                "buildVariant": "ubuntu1604"
+                "status": "success"
               },
               {
                 "id": "3",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "lint",
-                "buildVariant": "windows"
+                "status": "success"
               }
             ],
-            "count": 4
+            "count": 3
           }
         }
       }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -34,6 +34,68 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+type TaskStatusKey string
+
+const (
+	TaskStatus     TaskStatusKey = "Status"
+	TaskBaseStatus TaskStatusKey = "BaseStatus"
+)
+
+func getTaskStatusAndBaseStatusMap(task *TaskResult) map[TaskStatusKey]string {
+	return map[TaskStatusKey]string{
+		TaskStatus:     task.Status,
+		TaskBaseStatus: task.BaseStatus,
+	}
+}
+
+var taskFailureStatusesToBeGrouped map[string]bool = map[string]bool{
+	evergreen.TaskFailed:       true,
+	evergreen.TaskTestTimedOut: true,
+	evergreen.TaskTimedOut:     true,
+}
+
+func GroupFailuresAndSortTasks(tasks []*TaskResult, sortDirection int, statusKey TaskStatusKey) []*TaskResult {
+	failures := []*TaskResult{}
+	nonFailures := []*TaskResult{}
+
+	for _, task := range tasks {
+		t := getTaskStatusAndBaseStatusMap(task)
+		status := t[statusKey]
+
+		_, ok := taskFailureStatusesToBeGrouped[status]
+
+		if ok {
+			failures = append(failures, task)
+		} else {
+			nonFailures = append(nonFailures, task)
+		}
+	}
+
+	sort.SliceStable(failures, func(i, j int) bool {
+		iStatus := getTaskStatusAndBaseStatusMap(failures[i])[statusKey]
+		jStatus := getTaskStatusAndBaseStatusMap(failures[j])[statusKey]
+
+		if sortDirection == 1 {
+			return iStatus < jStatus
+		}
+		return iStatus > jStatus
+	})
+	sort.SliceStable(nonFailures, func(i, j int) bool {
+		iStatus := getTaskStatusAndBaseStatusMap(nonFailures[i])[statusKey]
+		jStatus := getTaskStatusAndBaseStatusMap(nonFailures[j])[statusKey]
+
+		if sortDirection == 1 {
+			return iStatus < jStatus
+		}
+		return iStatus > jStatus
+	})
+
+	if sortDirection == 1 {
+		return append(failures, nonFailures...)
+	}
+	return append(nonFailures, failures...)
+}
+
 // GetGroupedFiles returns the files of a Task inside a GroupedFile struct
 func GetGroupedFiles(ctx context.Context, name string, taskID string, execution int) (*GroupedFiles, error) {
 	taskFiles, err := artifact.GetAllArtifacts([]artifact.TaskIDAndExecution{{TaskID: taskID, Execution: execution}})

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2509,7 +2509,6 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 							"else": "b",
 						},
 					},
-					// DisplayStatusKey: "$" + DisplayStatusKey,
 				},
 			})
 			// ordered sort with `first` at beginning of sort to sort all failure statuses to the top

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2493,7 +2493,7 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 
 	if len(sortBy) > 0 {
 		if sortBy == DisplayStatusKey {
-			// projecting field `first` onto tasks with a failed status allows us to sort all failed statuses to top of query and then sort alphabetically
+			// setting field `first` onto tasks with a failed status allows us to sort all failed statuses to top of query and then sort alphabetically
 			pipeline = append(pipeline, bson.M{
 				"$set": bson.M{
 					"first": bson.M{
@@ -2523,7 +2523,6 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 			pipeline = append(pipeline, bson.M{
 				"$sort": bson.D{
 					bson.E{Key: sortBy, Value: sortDir},
-					// _id must be the LAST item in sort array to ensure a consistent sort order when previous sort keys result in a tie
 					bson.E{Key: IdKey, Value: 1},
 				},
 			})
@@ -2531,7 +2530,7 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 	} else {
 		pipeline = append(pipeline, bson.M{
 			"$sort": bson.D{
-				// _id must be the LAST item in sort array to ensure a consistent sort order when previous sort keys result in a tie
+				// sort by _id to ensure a consistent sort order when previous sort keys result in a tie
 				bson.E{Key: IdKey, Value: 1},
 			},
 		})

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2461,71 +2461,6 @@ var taskFailureStatuses []string = []string{
 	evergreen.TaskTimedOut,
 }
 
-var allTaskFieldKeys = []string{
-	SecretKey,
-	CreateTimeKey,
-	DispatchTimeKey,
-	ScheduledTimeKey,
-	StartTimeKey,
-	FinishTimeKey,
-	ActivatedTimeKey,
-	VersionKey,
-	ProjectKey,
-	RevisionKey,
-	LastHeartbeatKey,
-	ActivatedKey,
-	DeactivatedForDependencyKey,
-	BuildIdKey,
-	DistroIdKey,
-	DistroAliasesKey,
-	BuildVariantKey,
-	DependsOnKey,
-	OverrideDependenciesKey,
-	NumDepsKey,
-	DisplayNameKey,
-	HostIdKey,
-	AgentVersionKey,
-	ExecutionKey,
-	RestartsKey,
-	OldTaskIdKey,
-	ArchivedKey,
-	RevisionOrderNumberKey,
-	RequesterKey,
-	StatusKey,
-	DetailsKey,
-	AbortedKey,
-	AbortInfoKey,
-	TimeTakenKey,
-	ExpectedDurationKey,
-	ExpectedDurationStddevKey,
-	DurationPredictionKey,
-	PriorityKey,
-	ActivatedByKey,
-	CostKey,
-	SpawnedHostCostKey,
-	ExecutionTasksKey,
-	DisplayOnlyKey,
-	TaskGroupKey,
-	TaskGroupMaxHostsKey,
-	TaskGroupOrderKey,
-	GenerateTaskKey,
-	GeneratedTasksKey,
-	GeneratedByKey,
-	GenerateTasksErrorKey,
-	ResetWhenFinishedKey,
-	LogsKey,
-	CommitQueueMergeKey,
-	DisplayStatusKey,
-}
-
-func getFieldsToProject(fieldsToProject []string) bson.M {
-	fieldKeys := bson.M{}
-	for _, field := range fieldsToProject {
-		fieldKeys[field] = "$" + field
-	}
-	return fieldKeys
-}
-
 // GetTasksByVersion gets all tasks for a specific version
 // Query results can be filtered by task name, variant name and status in addition to being paginated and limited
 func GetTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int, fieldsToProject []string) ([]Task, int, error) {
@@ -2612,8 +2547,12 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 		})
 	}
 	if len(fieldsToProject) > 0 {
+		fieldKeys := bson.M{}
+		for _, field := range fieldsToProject {
+			fieldKeys[field] = 1
+		}
 		pipeline = append(pipeline, bson.M{
-			"$project": getFieldsToProject(fieldsToProject),
+			"$project": fieldKeys,
 		})
 	}
 	tasks := []Task{}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2530,7 +2530,7 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 	} else {
 		pipeline = append(pipeline, bson.M{
 			"$sort": bson.D{
-				// sort by _id to ensure a consistent sort order when previous sort keys result in a tie
+				// sort by _id to ensure a consistent sort order
 				bson.E{Key: IdKey, Value: 1},
 			},
 		})

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2462,7 +2462,6 @@ var taskFailureStatuses []string = []string{
 }
 
 var allTaskFieldKeys = []string{
-	IdKey,
 	SecretKey,
 	CreateTimeKey,
 	DispatchTimeKey,
@@ -2522,7 +2521,7 @@ var allTaskFieldKeys = []string{
 func getFieldsToProject(fieldsToProject []string) bson.M {
 	fieldKeys := bson.M{}
 	for _, field := range fieldsToProject {
-		fieldKeys[field] = 1
+		fieldKeys[field] = "$" + field
 	}
 	return fieldKeys
 }
@@ -2561,7 +2560,7 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 		if sortBy == DisplayStatusKey {
 			// projecting field `first` onto tasks with a failed status allows us to sort all failed statuses to top of query and then sort alphabetically
 			pipeline = append(pipeline, bson.M{
-				"$project": bson.M{
+				"$set": bson.M{
 					"first": bson.M{
 						"$cond": bson.M{
 							"if": bson.M{
@@ -2575,7 +2574,7 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 							"else": "b",
 						},
 					},
-					DisplayStatusKey: "$" + DisplayStatusKey,
+					// DisplayStatusKey: "$" + DisplayStatusKey,
 				},
 			})
 			// ordered sort with `first` at beginning of sort to sort all failure statuses to the top
@@ -2585,10 +2584,6 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 					bson.E{Key: DisplayStatusKey, Value: sortDir},
 					bson.E{Key: IdKey, Value: 1},
 				},
-			})
-			// have to project all task fields because the above $project removes all fields except for `first` and DisplayStatusKey
-			pipeline = append(pipeline, bson.M{
-				"$project": getFieldsToProject(allTaskFieldKeys),
 			})
 		} else {
 			pipeline = append(pipeline, bson.M{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2495,7 +2495,7 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 		if sortBy == DisplayStatusKey {
 			// setting field `first` onto tasks with a failed status allows us to sort all failed statuses to top of query and then sort alphabetically
 			pipeline = append(pipeline, bson.M{
-				"$set": bson.M{
+				"$addFields": bson.M{
 					"first": bson.M{
 						"$cond": bson.M{
 							"if": bson.M{


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-13194

When sorted by status, patch tasks were being sorted alphabetically. Therefore all tasks with status `failed` were sorted to the top, but other failed statuses (test-timed-out and task-timed-out) were sorted to the bottom of the list. 

This PR uses an aggregation pipeline in the patch tasks DB query to sort all tasks with a failure status to the top of the list when being sorted by status. 