### PR TITLE
EVG-13238: upload agent binaries to S3

### DIFF
--- a/cmd/upload-binaries/upload-binaries.go
+++ b/cmd/upload-binaries/upload-binaries.go
@@ -1,8 +1,0 @@
-package main
-
-import "os"
-
-// Upload all of the per-platform evergreen binaries to S3.
-func main() {
-	awsKey := os.Getenv("AWS_KEY")
-}

--- a/cmd/upload-binaries/upload-binaries.go
+++ b/cmd/upload-binaries/upload-binaries.go
@@ -1,0 +1,8 @@
+package main
+
+import "os"
+
+// Upload all of the per-platform evergreen binaries to S3.
+func main() {
+	awsKey := os.Getenv("AWS_KEY")
+}

--- a/cmd/upload-s3/upload-s3.go
+++ b/cmd/upload-s3/upload-s3.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/evergreen-ci/pail"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/send"
+	"github.com/pkg/errors"
+)
+
+// Upload a directory/file to S3.
+func main() {
+	var bucketName, local, remote, exclude string
+	flag.StringVar(&bucketName, "bucket", "", "the S3 bucket name")
+	flag.StringVar(&local, "local", "", "the local path")
+	flag.StringVar(&remote, "remote", "", "the remote path")
+	flag.StringVar(&exclude, "exclude", "", "file pattern to exclude from  upload")
+	flag.Parse()
+	if bucketName == "" {
+		grip.EmergencyFatal("bucket name is missing")
+	}
+	if local == "" {
+		grip.EmergencyFatal("local path is missing")
+	}
+	if remote == "" {
+		grip.EmergencyFatal("remote path is missing")
+	}
+
+	awsKey := os.Getenv("AWS_KEY")
+	if awsKey == "" {
+		grip.EmergencyFatal("AWS key is missing (env var: AWS_KEY)")
+	}
+	awsSecret := os.Getenv("AWS_SECRET")
+	if awsSecret == "" {
+		grip.EmergencyFatal("AWS secret is missing (env var: AWS_SECRET)")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := utility.GetDefaultHTTPRetryableClient()
+	defer utility.PutHTTPClient(client)
+
+	opts := pail.S3Options{
+		Credentials: pail.CreateAWSCredentials(awsKey, awsSecret, ""),
+		Region:      endpoints.UsEast1RegionID,
+		Name:        bucketName,
+		MaxRetries:  10,
+		Permissions: pail.S3PermissionsPublicRead,
+		Verbose:     true,
+	}
+	bucket, err := pail.NewS3Bucket(opts)
+	if err != nil {
+		grip.EmergencyFatal("could not initialize bucket")
+	}
+
+	if err := grip.SetLevel(send.LevelInfo{Threshold: level.Debug, Default: level.Debug}); err != nil {
+		grip.EmergencyFatal(errors.Wrap(err, "setting grip logging level"))
+	}
+
+	if err := bucket.Push(ctx, pail.SyncOptions{
+		Local:   local,
+		Remote:  remote,
+		Exclude: exclude,
+	}); err != nil {
+		grip.EmergencyFatal(errors.Wrapf(err, "pushing contents from local path %s to remote path %s in bucket %s", local, remote, bucketName))
+	}
+}

--- a/makefile
+++ b/makefile
@@ -88,7 +88,12 @@ cli:$(localClientBinary)
 clis:$(clientBinaries)
 $(clientBuildDir)/%/evergreen $(clientBuildDir)/%/evergreen.exe:$(buildDir)/build-cross-compile $(srcFiles)
 	@./$(buildDir)/build-cross-compile -buildName=$* -ldflags="$(ldFlags)" -legacyGoBinary="$(legacyGobin)" -goBinary="$(gobin)" $(if $(RACE_DETECTOR),-race ,)-directory=$(clientBuildDir) -source=$(clientSource) -output=$@
-phony += cli clis
+# Targets to upload the CLI binaries to S3.
+$(buildDir)/upload-s3:cmd/upload-s3/upload-s3.go
+	$(gobin) build -o $@ $<
+upload-clis:$(buildDir)/upload-s3 clis
+	$(buildDir)/upload-s3 -bucket="${BUCKET_NAME}" -local="${LOCAL_PATH}" -remote="${REMOTE_PATH}" -exclude="${EXCLUDE_PATTERN}"
+phony += cli clis upload-clis
 # end client build directives
 
 

--- a/makefile
+++ b/makefile
@@ -90,7 +90,7 @@ $(clientBuildDir)/%/evergreen $(clientBuildDir)/%/evergreen.exe:$(buildDir)/buil
 	@./$(buildDir)/build-cross-compile -buildName=$* -ldflags="$(ldFlags)" -legacyGoBinary="$(legacyGobin)" -goBinary="$(gobin)" $(if $(RACE_DETECTOR),-race ,)-directory=$(clientBuildDir) -source=$(clientSource) -output=$@
 # Targets to upload the CLI binaries to S3.
 $(buildDir)/upload-s3:cmd/upload-s3/upload-s3.go
-	$(gobin) build -o $@ $<
+	@$(gobin) build -o $@ $<
 upload-clis:$(buildDir)/upload-s3 clis
 	$(buildDir)/upload-s3 -bucket="${BUCKET_NAME}" -local="${LOCAL_PATH}" -remote="${REMOTE_PATH}" -exclude="${EXCLUDE_PATTERN}"
 phony += cli clis upload-clis

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -61,6 +61,18 @@ variables:
           content_type: application/x-gzip
           permissions: public-read
           display_name: dist.tar.gz
+      # kim: TODO: might have to modify clients directory structure to include goos+goarch in file name, or just write a
+      # script to do it
+      - command: s3.put
+        type: system
+        params:
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          local_files_include_filter: gopath/src/github.com/evergreen-ci/evergreen/clients/*/evergreen
+          remote_file: evergreen/binaries/${revision}
+          bucket: mciuploads
+          content_type: application/octet-stream
+          permissions: public-read
   - &run-go-test-suite
     # runs a make target and then uploads gotest output to
     # evergreen. The test name should correspond to a make target for

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -576,6 +576,7 @@ tasks:
       - func: run-make
         vars: { target: "test-repotracker" }
   - name: upload-clis
+    patchable: false
     commands:
       - func: get-project
       - func: run-make
@@ -592,7 +593,7 @@ tasks:
             BUCKET_NAME: mciuploads
             LOCAL_PATH: clients
             EXCLUDE_PATTERN: .cache
-            REMOTE_PATH: evergreen/clients/${revision}/${project}
+            REMOTE_PATH: evergreen/clients/${project}/${revision}
             GO_BIN_PATH: ${gobin}
             LEGACY_GO_BIN_PATH: ${legacyGobin}
             GOPATH: ${workdir}/gopath

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -593,6 +593,11 @@ tasks:
             LOCAL_PATH: clients
             EXCLUDE_PATTERN: .cache
             REMOTE_PATH: evergreen/clients/${revision}/${project}
+            GO_BIN_PATH: ${gobin}
+            LEGACY_GO_BIN_PATH: ${legacyGobin}
+            GOPATH: ${workdir}/gopath
+            GOROOT: ${goroot}
+
 
 buildvariants:
   - name: ubuntu1604

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -61,18 +61,6 @@ variables:
           content_type: application/x-gzip
           permissions: public-read
           display_name: dist.tar.gz
-      # kim: TODO: might have to modify clients directory structure to include goos+goarch in file name, or just write a
-      # script to do it
-      - command: s3.put
-        type: system
-        params:
-          aws_key: ${aws_key}
-          aws_secret: ${aws_secret}
-          local_files_include_filter: gopath/src/github.com/evergreen-ci/evergreen/clients/*/evergreen
-          remote_file: evergreen/binaries/${revision}
-          bucket: mciuploads
-          content_type: application/octet-stream
-          permissions: public-read
   - &run-go-test-suite
     # runs a make target and then uploads gotest output to
     # evergreen. The test name should correspond to a make target for
@@ -587,6 +575,24 @@ tasks:
           target: revendor
       - func: run-make
         vars: { target: "test-repotracker" }
+  - name: upload-clis
+    commands:
+      - func: get-project
+      - func: run-make
+        vars:
+          target: get-go-imports
+      - command: subprocess.exec
+        params:
+          binary: make
+          args: ["upload-clis"]
+          working_dir: gopath/src/github.com/evergreen-ci/evergreen
+          env:
+            AWS_KEY: ${aws_key}
+            AWS_SECRET: ${aws_secret}
+            BUCKET_NAME: mciuploads
+            LOCAL_PATH: clients
+            EXCLUDE_PATTERN: .cache
+            REMOTE_PATH: evergreen/clients/${revision}/${project}
 
 buildvariants:
   - name: ubuntu1604
@@ -606,6 +612,7 @@ buildvariants:
     tasks:
       - name: "dist"
       - name: "dist-staging"
+      - name: "upload-clis"
       - name: ".smoke"
       - name: ".test"
       - name: "js-test"


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13238

* Add script to use pail to push `clients` directory to S3 bucket.
* Add task that only runs on the waterfall to push binaries to S3 so they can be used for the deploy.
    * When we deploy with commit `abc123`, the agents should also be downloadable from the prefix with `abc123` in S3.
    * To avoid pushing the same binaries to the same S3 location (due to the task running in both staging and production), include the project name in the S3 prefix (which is different in each environment).