### PR TITLE
EVG-13093 split commands after expansions in subprocess.exec

### DIFF
--- a/command/exec.go
+++ b/command/exec.go
@@ -85,23 +85,8 @@ func (c *subprocessExec) ParseParams(params map[string]interface{}) error {
 		return errors.Wrapf(err, "error decoding %s params", c.Name())
 	}
 
-	if c.Command != "" {
-		if c.Binary != "" || len(c.Args) > 0 {
-			return errors.New("must specify command as either arguments or a command string but not both")
-		}
-
-		args, err := shlex.Split(c.Command)
-		if err != nil {
-			return errors.Wrapf(err, "problem parsing %s command", c.Name())
-		}
-		if len(args) == 0 {
-			return errors.Errorf("no arguments for command %s", c.Name())
-		}
-
-		c.Binary = args[0]
-		if len(args) > 1 {
-			c.Args = args[1:]
-		}
+	if c.Command != "" && (c.Binary != "" || len(c.Args) > 0) {
+		return errors.New("must specify command as either arguments or a command string but not both")
 	}
 
 	if c.Silent {
@@ -117,6 +102,24 @@ func (c *subprocessExec) ParseParams(params map[string]interface{}) error {
 		c.Env = make(map[string]string)
 	}
 
+	return nil
+}
+
+func (c *subprocessExec) splitCommands() error {
+	if c.Command != "" {
+		args, err := shlex.Split(c.Command)
+		if err != nil {
+			return errors.Wrapf(err, "problem parsing %s command", c.Name())
+		}
+		if len(args) == 0 {
+			return errors.Errorf("no arguments for command %s", c.Name())
+		}
+
+		c.Binary = args[0]
+		if len(args) > 1 {
+			c.Args = args[1:]
+		}
+	}
 	return nil
 }
 
@@ -252,6 +255,11 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 
 	if err = c.doExpansions(conf.Expansions); err != nil {
 		logger.Execution().Error("problem expanding command values")
+		return errors.WithStack(err)
+	}
+
+	if err = c.splitCommands(); err != nil {
+		logger.Execution().Error(err.Error())
 		return errors.WithStack(err)
 	}
 

--- a/command/exec.go
+++ b/command/exec.go
@@ -140,7 +140,8 @@ func (c *subprocessExec) doExpansions(exp *util.Expansions) error {
 
 	newArgs := []string{}
 	for idx := range c.Args {
-		arg, err := exp.ExpandString(c.Args[idx])
+		var arg string
+		arg, err = exp.ExpandString(c.Args[idx])
 		catcher.Add(err)
 		if arg == "" {
 			newArgs = append(newArgs, arg)

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -109,7 +109,20 @@ func (s *execCmdSuite) TestWeirdAndBadExpansions() {
 	s.Equal("baf}}r", cmd.Binary)
 	s.Equal("a", cmd.Args[0])
 	s.Equal("b", cmd.Args[1])
+}
 
+func (s execCmdSuite) TestMultiwordCommandExpansion() {
+	cmd := &subprocessExec{
+		Command: "binary something ${long}",
+	}
+	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	expansions := &util.Expansions{"long": "multiword expansion"}
+	s.NoError(cmd.doExpansions(expansions))
+	s.Equal("binary", cmd.Binary)
+	s.Require().Len(cmd.Args, 3)
+	s.Equal(cmd.Args[0], "something")
+	s.Equal(cmd.Args[1], "multiword")
+	s.Equal(cmd.Args[2], "expansion")
 }
 
 func (s *execCmdSuite) TestParseParamsInitializesEnvMap() {


### PR DESCRIPTION
Otherwise there's unexpected behavior when the expansion value has spaces and should also be split.