### PR TITLE
 EVG-13093 split commands after expansions in subprocess.exec

### DIFF
--- a/command/exec.go
+++ b/command/exec.go
@@ -85,25 +85,9 @@ func (c *subprocessExec) ParseParams(params map[string]interface{}) error {
 		return errors.Wrapf(err, "error decoding %s params", c.Name())
 	}
 
-	if c.Command != "" {
-		if c.Binary != "" || len(c.Args) > 0 {
-			return errors.New("must specify command as either arguments or a command string but not both")
-		}
-
-		args, err := shlex.Split(c.Command)
-		if err != nil {
-			return errors.Wrapf(err, "problem parsing %s command", c.Name())
-		}
-		if len(args) == 0 {
-			return errors.Errorf("no arguments for command %s", c.Name())
-		}
-
-		c.Binary = args[0]
-		if len(args) > 1 {
-			c.Args = args[1:]
-		}
+	if err = c.splitCommands(); err != nil {
+		return errors.WithStack(err)
 	}
-
 	if c.Silent {
 		c.IgnoreStandardError = true
 		c.IgnoreStandardOutput = true
@@ -120,6 +104,27 @@ func (c *subprocessExec) ParseParams(params map[string]interface{}) error {
 	return nil
 }
 
+func (c *subprocessExec) splitCommands() error {
+	if c.Command != "" {
+		if c.Binary != "" || len(c.Args) > 0 {
+			return errors.New("must specify command as either arguments or a command string but not both")
+		}
+		args, err := shlex.Split(c.Command)
+		if err != nil {
+			return errors.Wrapf(err, "problem parsing %s command", c.Name())
+		}
+		if len(args) == 0 {
+			return errors.Errorf("no arguments for command %s", c.Name())
+		}
+
+		c.Binary = args[0]
+		if len(args) > 1 {
+			c.Args = args[1:]
+		}
+	}
+	return nil
+}
+
 func (c *subprocessExec) doExpansions(exp *util.Expansions) error {
 	var err error
 	catcher := grip.NewBasicCatcher()
@@ -130,10 +135,25 @@ func (c *subprocessExec) doExpansions(exp *util.Expansions) error {
 	c.Binary, err = exp.ExpandString(c.Binary)
 	catcher.Add(err)
 
+	c.Command, err = exp.ExpandString(c.Command)
+	catcher.Add(err)
+
+	newArgs := []string{}
 	for idx := range c.Args {
-		c.Args[idx], err = exp.ExpandString(c.Args[idx])
+		var arg string
+		arg, err = exp.ExpandString(c.Args[idx])
 		catcher.Add(err)
+		if arg == "" {
+			newArgs = append(newArgs, arg)
+			continue
+		}
+		// in case the expansion has multiple values, split again
+		var splitArgs []string
+		splitArgs, err = shlex.Split(arg)
+		catcher.Add(err)
+		newArgs = append(newArgs, splitArgs...)
 	}
+	c.Args = newArgs
 
 	for k, v := range c.Env {
 		c.Env[k], err = exp.ExpandString(v)

--- a/command/exec.go
+++ b/command/exec.go
@@ -85,9 +85,10 @@ func (c *subprocessExec) ParseParams(params map[string]interface{}) error {
 		return errors.Wrapf(err, "error decoding %s params", c.Name())
 	}
 
-	if err = c.splitCommands(); err != nil {
-		return errors.WithStack(err)
+	if c.Command != "" && (c.Binary != "" || len(c.Args) > 0) {
+		return errors.New("must specify command as either arguments or a command string but not both")
 	}
+
 	if c.Silent {
 		c.IgnoreStandardError = true
 		c.IgnoreStandardOutput = true
@@ -106,9 +107,6 @@ func (c *subprocessExec) ParseParams(params map[string]interface{}) error {
 
 func (c *subprocessExec) splitCommands() error {
 	if c.Command != "" {
-		if c.Binary != "" || len(c.Args) > 0 {
-			return errors.New("must specify command as either arguments or a command string but not both")
-		}
 		args, err := shlex.Split(c.Command)
 		if err != nil {
 			return errors.Wrapf(err, "problem parsing %s command", c.Name())
@@ -138,22 +136,10 @@ func (c *subprocessExec) doExpansions(exp *util.Expansions) error {
 	c.Command, err = exp.ExpandString(c.Command)
 	catcher.Add(err)
 
-	newArgs := []string{}
 	for idx := range c.Args {
-		var arg string
-		arg, err = exp.ExpandString(c.Args[idx])
+		c.Args[idx], err = exp.ExpandString(c.Args[idx])
 		catcher.Add(err)
-		if arg == "" {
-			newArgs = append(newArgs, arg)
-			continue
-		}
-		// in case the expansion has multiple values, split again
-		var splitArgs []string
-		splitArgs, err = shlex.Split(arg)
-		catcher.Add(err)
-		newArgs = append(newArgs, splitArgs...)
 	}
-	c.Args = newArgs
 
 	for k, v := range c.Env {
 		c.Env[k], err = exp.ExpandString(v)
@@ -272,6 +258,10 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 
 	if err = c.doExpansions(conf.Expansions); err != nil {
 		logger.Execution().Error("problem expanding command values")
+		return errors.WithStack(err)
+	}
+
+	if err = c.splitCommands(); err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -109,7 +109,20 @@ func (s *execCmdSuite) TestWeirdAndBadExpansions() {
 	s.Equal("baf}}r", cmd.Binary)
 	s.Equal("a", cmd.Args[0])
 	s.Equal("b", cmd.Args[1])
+}
 
+func (s execCmdSuite) TestMultiwordCommandExpansion() {
+	cmd := &subprocessExec{
+		Command: "binary something ${long}",
+	}
+	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	expansions := &util.Expansions{"long": "multiword expansion"}
+	s.NoError(cmd.doExpansions(expansions))
+	s.Equal("binary", cmd.Binary)
+	s.Require().Len(cmd.Args, 3)
+	s.Equal(cmd.Args[0], "something")
+	s.Equal(cmd.Args[1], "multiword")
+	s.Equal(cmd.Args[2], "expansion")
 }
 
 func (s *execCmdSuite) TestParseParamsInitializesEnvMap() {

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -116,8 +116,8 @@ func (s execCmdSuite) TestMultiwordCommandExpansion() {
 		Command: "binary something ${long}",
 	}
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))
-	expansions := &util.Expansions{"long": "multiword expansion"}
-	s.NoError(cmd.doExpansions(expansions))
+	s.conf.Expansions = &util.Expansions{"long": "multiword expansion"}
+	s.Error(cmd.Execute(s.ctx, s.comm, s.logger, s.conf)) // just want expansions
 	s.Equal("binary", cmd.Binary)
 	s.Require().Len(cmd.Args, 3)
 	s.Equal(cmd.Args[0], "something")
@@ -153,7 +153,8 @@ func (s *execCmdSuite) TestCommandParsing() {
 	s.Zero(cmd.Binary)
 	s.Zero(cmd.Args)
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))
-	s.Len(cmd.Args, 2)
+	s.Error(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
+	s.Require().Len(cmd.Args, 2)
 	s.NotZero(cmd.Binary)
 	s.Equal("/bin/bash", cmd.Binary)
 	s.Equal("-c", cmd.Args[0])
@@ -225,11 +226,14 @@ func (s *execCmdSuite) TestRunCommandContinueOnErrorNoError() {
 func (s *execCmdSuite) TestRunCommandBackgroundAlwaysNil() {
 	cmd := &subprocessExec{
 		Command:    "bash -c 'exit 1'",
+		WorkingDir: testutil.GetDirectoryOfFile(),
 		Background: true,
 		Silent:     true,
 	}
 	cmd.SetJasperManager(s.jasper)
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.conf.Task = &task.Task{Id: "foo"}
+	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 	exec := cmd.getProc(s.ctx, "foo", s.logger)
 	s.NoError(cmd.runCommand(s.ctx, "foo", exec, s.logger))
 }
@@ -301,7 +305,8 @@ func (s *execCmdSuite) TestExecuteErrorsIfCommandAborts() {
 func (s *execCmdSuite) TestKeepEmptyArgs() {
 	// by default empty args should be stripped
 	cmd := &subprocessExec{
-		Command:    "echo ${foo|} bar",
+		Binary:     "echo",
+		Args:       []string{"${foo|}", "bar"},
 		WorkingDir: testutil.GetDirectoryOfFile(),
 	}
 	cmd.SetJasperManager(s.jasper)
@@ -311,7 +316,8 @@ func (s *execCmdSuite) TestKeepEmptyArgs() {
 
 	// empty args should not be stripped if set
 	cmd = &subprocessExec{
-		Command:       "echo ${foo|} bar",
+		Binary:        "echo",
+		Args:          []string{"${foo|}", "bar"},
 		WorkingDir:    testutil.GetDirectoryOfFile(),
 		KeepEmptyArgs: true,
 	}

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2020-10-19"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-10-20"
+	AgentVersion = "2020-10-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Take three:
The expansions fix caused issues with the smoke test because we have an arg with two words--we only say we're going to split commands, not args. However thinking further,  KeepEmptyArgs seems like it should apply to args and NOT commands (it looks like cloud only uses it in this way; I'm not sure anyone else uses it)--it isn't documented but I can add documentation along those lines. In that case the original implementation works for args and commands.