### PR TITLE
EVG-13080 extend default volume expiration from terminated hosts

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1049,8 +1049,8 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 			continue
 		}
 
-		if volDB.Expiration.Before(time.Now().Add(evergreen.DefaultSpawnHostExpiration)) {
-			if err = m.modifyVolumeExpiration(ctx, volDB, time.Now().Add(evergreen.DefaultSpawnHostExpiration)); err != nil {
+		if volDB.Expiration.Before(time.Now().Add(evergreen.UnattachedVolumeExpiration)) {
+			if err = m.modifyVolumeExpiration(ctx, volDB, time.Now().Add(evergreen.UnattachedVolumeExpiration)); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"message": "error updating volume expiration",
 					"user":    user,

--- a/globals.go
+++ b/globals.go
@@ -181,6 +181,7 @@ const (
 	DefaultSpawnHostExpiration          = 24 * time.Hour
 	SpawnHostNoExpirationDuration       = 7 * 24 * time.Hour
 	MaxSpawnHostExpirationDurationHours = 24 * time.Hour * 14
+	UnattachedVolumeExpiration          = 24 * time.Hour * 30
 	DefaultMaxVolumeSizePerUser         = 500
 	DefaultUnexpirableHostsPerUser      = 1
 	DefaultUnexpirableVolumesPerUser    = 1

--- a/model/alertrecord/alert_bookkeeping.go
+++ b/model/alertrecord/alert_bookkeeping.go
@@ -23,20 +23,14 @@ const (
 	FirstTaskTypeFailureId   = "first_tasktype_failure"
 	TaskFailTransitionId     = "task_transition_failure"
 	FirstRegressionInVersion = "first_regression_in_version"
-	TaskFailedId             = "task_failed"
 	LastRevisionNotFound     = "last_revision_not_found"
 	taskRegressionByTest     = "task-regression-by-test"
 )
 
 // Host triggers
 const (
-	SpawnFailed                = "spawn_failed"
-	SpawnHostTwoHourWarning    = "spawn_twohour"
-	SpawnHostTwelveHourWarning = "spawn_twelvehour"
-	SlowProvisionWarning       = "slow_provision"
-	ProvisionFailed            = "provision_failed"
-	spawnHostWarningTemplate   = "spawn_%dhour"
-	volumeWarningTemplate      = "volume_%dhour"
+	spawnHostWarningTemplate = "spawn_%dhour"
+	volumeWarningTemplate    = "volume_%dhour"
 )
 
 const legacyAlertsSubscription = "legacy-alerts"

--- a/model/host/volume.go
+++ b/model/host/volume.go
@@ -108,6 +108,15 @@ func FindVolumesToDelete(expirationTime time.Time) ([]Volume, error) {
 	return findVolumes(q)
 }
 
+func FindUnattachedExpirableVolumes() ([]Volume, error) {
+	q := bson.M{
+		NoExpirationKey: bson.M{"$ne": true},
+		VolumeHostKey:   bson.M{"$exists": false},
+	}
+
+	return findVolumes(q)
+}
+
 // FindVolumeByID finds a volume by its ID field.
 func FindVolumeByID(id string) (*Volume, error) {
 	return FindOneVolume(bson.M{VolumeIDKey: id})

--- a/trigger/volume.go
+++ b/trigger/volume.go
@@ -21,8 +21,8 @@ func init() {
 const (
 	// notification templates
 	expiringVolumeEmailSubject         = `Volume termination reminder`
-	expiringVolumeEmailBody            = `Your volume with id {{.ID}} will be terminated at {{.ExpirationTime}}. Visit the <a href={{.URL}}>volume page</a> to extend its lifetime.`
-	expiringVolumeSlackBody            = `Your volume with id {{.ID}} will be terminated at {{.ExpirationTime}}. Visit the <{{.URL}}|volume page> to extend its lifetime.`
+	expiringVolumeEmailBody            = `Your volume with id {{.ID}} is unattached and will be terminated at {{.ExpirationTime}}. Visit the <a href={{.URL}}>volume page</a> to extend its lifetime.`
+	expiringVolumeSlackBody            = `Your volume with id {{.ID}} is unattached and will be terminated at {{.ExpirationTime}}. Visit the <{{.URL}}|volume page> to extend its lifetime.`
 	expiringVolumeSlackAttachmentTitle = "Volume Page"
 )
 

--- a/trigger/volume_test.go
+++ b/trigger/volume_test.go
@@ -46,12 +46,12 @@ func TestVolumeExpiration(t *testing.T) {
 		"Email": func(*testing.T) {
 			email, err := hostExpirationEmailPayload(testData, expiringVolumeEmailSubject, expiringVolumeEmailBody, triggers.Selectors())
 			assert.NoError(t, err)
-			assert.Contains(t, email.Body, "Your volume with id v0 will be terminated at")
+			assert.Contains(t, email.Body, "Your volume with id v0 is unattached and will be terminated at")
 		},
 		"Slack": func(*testing.T) {
 			slack, err := hostExpirationSlackPayload(testData, expiringVolumeSlackBody, "linkTitle", triggers.Selectors())
 			assert.NoError(t, err)
-			assert.Contains(t, slack.Body, "Your volume with id v0 will be terminated at")
+			assert.Contains(t, slack.Body, "Your volume with id v0 is unattached and will be terminated at")
 		},
 		"Fetch": func(*testing.T) {
 			triggers := volumeTriggers{}

--- a/units/volume_expiration_warning_test.go
+++ b/units/volume_expiration_warning_test.go
@@ -20,6 +20,7 @@ func TestVolumeExpiration(t *testing.T) {
 		{ID: "v0", Expiration: time.Now().Add(2 * time.Hour)},
 		{ID: "v1", Expiration: time.Now().Add(10 * time.Hour)},
 		{ID: "v2", Expiration: time.Now().Add(15 * time.Hour)},
+		{ID: "v3", Expiration: time.Now().Add(30 * 24 * time.Hour)},
 	}
 	for _, v := range volumes {
 		require.NoError(t, v.Insert())
@@ -30,10 +31,10 @@ func TestVolumeExpiration(t *testing.T) {
 
 	events, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
 	assert.NoError(t, err)
-	// two events for v0 and one for v1
+	// one event each for v0, v1, v2
 	assert.Len(t, events, 3)
 
-	expiringSoonVolumes := []string{"v0", "v1"}
+	expiringSoonVolumes := []string{"v0", "v1", "v2"}
 	for _, e := range events {
 		assert.Contains(t, expiringSoonVolumes, e.ResourceId)
 	}


### PR DESCRIPTION
Changed the default in this case to be 30 days, with a notification at 3 weeks, 2 weeks, and 1 week.
I _think_ that the existing notification code inserted all notifications regardless of whether or not they failed because we currently only created 2 notifications, but I figure now that there are so many (and because we don't want to accidentally spam people with 3 notifications who currently have unattached volumes expiring in less than a week) we may as well short-circuit when we make a notification.