### PR TITLE
EVG-13304: allow ModifyVolume to set volume display name

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1511,6 +1511,12 @@ func (m *ec2Manager) ModifyVolume(ctx context.Context, volume *host.Volume, opts
 			return errors.Wrapf(err, "error modifying volume '%s' size in db", volume.ID)
 		}
 	}
+
+	if opts.NewName != "" {
+		if err := volume.SetDisplayName(opts.NewName); err != nil {
+			return errors.Wrapf(err, "error modifying volume '%s' name in db", volume.ID)
+		}
+	}
 	return nil
 }
 

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1564,3 +1564,12 @@ func (s *EC2Suite) TestModifyVolumeSize() {
 	input := *mock.ModifyVolumeInput
 	s.Equal(int(*input.Size), 100)
 }
+
+func (s *EC2Suite) TestModifyVolumeName() {
+	s.NoError(s.volume.Insert())
+	s.NoError(s.onDemandManager.ModifyVolume(context.Background(), s.volume, &restmodel.VolumeModifyOptions{NewName: "Some new thang"}))
+
+	vol, err := host.FindVolumeByID(s.volume.ID)
+	s.NoError(err)
+	s.Equal(vol.DisplayName, "Some new thang")
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-13304
the updateVolume mutations calls into this function to update the display name of a volume