### PR TITLE
EVG-12943 suppress dequeue error for BlockTaskGroupTasks

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -396,7 +396,8 @@ func (t *Task) AddDependency(d Dependency) error {
 			if existingDependency.Unattainable == d.Unattainable {
 				return nil // nothing to be done
 			}
-			return UpdateAllMatchingDependenciesForTask(t.Id, existingDependency.TaskId, d.Unattainable)
+			return errors.Wrapf(UpdateAllMatchingDependenciesForTask(t.Id, existingDependency.TaskId, d.Unattainable),
+				"error updating matching dependency '%s' for task '%s'", existingDependency.TaskId, t.Id)
 		}
 	}
 	t.DependsOn = append(t.DependsOn, d)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -557,7 +557,7 @@ func UpdateBlockedDependencies(t *task.Task) error {
 			return errors.Wrap(err, "error marking dependency unattainable")
 		}
 		if err = UpdateBlockedDependencies(&dependentTask); err != nil {
-			return errors.WithStack(err)
+			return errors.Wrapf(err, "error updating blocked dependencies for '%s'", t.Id)
 		}
 
 		if !dependentTask.IsPartOfDisplay() { // execution tasks not cached in build so we should skip

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -285,7 +285,7 @@ func BlockTaskGroupTasks(taskID string) error {
 	if err != nil {
 		return errors.Wrapf(err, "problem finding tasks %s", strings.Join(taskNamesToBlock, ", "))
 	}
-	if err := ValidateNewGraph(t, tasksToBlock); err != nil {
+	if err = ValidateNewGraph(t, tasksToBlock); err != nil {
 		return errors.Wrap(err, "problem validating proposed dependencies")
 	}
 


### PR DESCRIPTION
There was a commit queue patch that got blocked because something broke when trying to clear/reset a stranded task. From splunk, a DocumentNotFound was caught in BlockTaskGroupTasks. I'm assuming this issue came from `dequeue`, because A) the others are more verifiable and B) in the other place we use `dequeue` we do filter out NotFound errors.

I'm also wondering if ClearAndResetStrandedTask should remove commit queue  patches in case of error, to prevent a commit queue patch from getting stuck if it failed to restart, but that might suppress important errors  / be unnecessary since this doesn't happen often so I left it out for now.