### PR TITLE
EVG-12693 schedule generators earlier

### DIFF
--- a/config_scheduler.go
+++ b/config_scheduler.go
@@ -23,6 +23,7 @@ type SchedulerConfig struct {
 	CommitQueueFactor             int64   `bson:"commit_queue_factor" json:"commit_queue_factor" mapstructure:"commit_queue_factor"`
 	MainlineTimeInQueueFactor     int64   `bson:"mainline_time_in_queue_factor" json:"mainline_time_in_queue_factor" mapstructure:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor         int64   `bson:"expected_runtime_factor" json:"expected_runtime_factor" mapstructure:"expected_runtime_factor"`
+	GenerateTaskFactor            int64   `bson:"generate_task_factor" json:"generate_task_factor" mapstructure:"generate_task_factor"`
 }
 
 func (c *SchedulerConfig) SectionId() string { return "scheduler" }
@@ -68,6 +69,7 @@ func (c *SchedulerConfig) Set() error {
 			"commit_queue_factor":               c.CommitQueueFactor,
 			"mainline_time_in_queue_factor":     c.MainlineTimeInQueueFactor,
 			"expected_runtime_factor":           c.ExpectedRuntimeFactor,
+			"generate_task_factor":              c.GenerateTaskFactor,
 		},
 	}, options.Update().SetUpsert(true))
 
@@ -143,6 +145,9 @@ func (c *SchedulerConfig) ValidateAndDefault() error {
 
 	if c.ExpectedRuntimeFactor < 0 || c.ExpectedRuntimeFactor > 100 {
 		return errors.New("expected runtime factor must be between 0 and 100")
+	}
+	if c.GenerateTaskFactor < 0 || c.GenerateTaskFactor > 100 {
+		return errors.New("generate task factor must be between 0 and 100")
 	}
 
 	return nil

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -222,6 +222,7 @@ type PlannerSettings struct {
 	CommitQueueFactor         int64         `bson:"commit_queue_factor" json:"commit_queue_factor" mapstructure:"commit_queue_factor"`
 	MainlineTimeInQueueFactor int64         `bson:"mainline_time_in_queue_factor" json:"mainline_time_in_queue_factor" mapstructure:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor     int64         `bson:"expected_runtime_factor" json:"expected_runtime_factor" mapstructure:"expected_runtime_factor"`
+	GenerateTaskFactor        int64         `bson:"generate_task_factor" json:"generate_task_factor" mapstructure:"generate_task_factor"`
 
 	maxDurationPerHost time.Duration
 }
@@ -354,6 +355,13 @@ func (d *Distro) GetCommitQueueFactor() int64 {
 		return 1
 	}
 	return d.PlannerSettings.CommitQueueFactor
+}
+
+func (d *Distro) GetGenerateTaskFactor() int64 {
+	if d.PlannerSettings.GenerateTaskFactor <= 0 {
+		return 1
+	}
+	return d.PlannerSettings.GenerateTaskFactor
 }
 
 func (d *Distro) GetMainlineTimeInQueueFactor() int64 {
@@ -690,6 +698,7 @@ func (d *Distro) GetResolvedPlannerSettings(s *evergreen.Settings) (PlannerSetti
 		CommitQueueFactor:         ps.CommitQueueFactor,
 		MainlineTimeInQueueFactor: ps.MainlineTimeInQueueFactor,
 		ExpectedRuntimeFactor:     ps.ExpectedRuntimeFactor,
+		GenerateTaskFactor:        ps.GenerateTaskFactor,
 		maxDurationPerHost:        evergreen.MaxDurationPerDistroHost,
 	}
 
@@ -729,6 +738,9 @@ func (d *Distro) GetResolvedPlannerSettings(s *evergreen.Settings) (PlannerSetti
 	}
 	if resolved.ExpectedRuntimeFactor == 0 {
 		resolved.ExpectedRuntimeFactor = config.ExpectedRuntimeFactor
+	}
+	if resolved.GenerateTaskFactor == 0 {
+		resolved.GenerateTaskFactor = config.GenerateTaskFactor
 	}
 	if catcher.HasErrors() {
 		return PlannerSettings{}, errors.Wrapf(catcher.Resolve(), "cannot resolve PlannerSettings for distro '%s'", d.Id)

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -336,6 +336,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 			CommitQueueFactor:         0,
 			MainlineTimeInQueueFactor: 0,
 			ExpectedRuntimeFactor:     0,
+			GenerateTaskFactor:        0,
 		},
 	}
 	config0 := evergreen.SchedulerConfig{
@@ -352,6 +353,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 		CommitQueueFactor:             50,
 		MainlineTimeInQueueFactor:     10,
 		ExpectedRuntimeFactor:         7,
+		GenerateTaskFactor:            20,
 	}
 
 	settings0 := &evergreen.Settings{Scheduler: config0}
@@ -372,6 +374,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 	assert.EqualValues(t, 10, resolved0.MainlineTimeInQueueFactor)
 	// Fallback to the SchedulerConfig.ExpectedRuntimeFactor as PlannerSettings.ExpectedRunTimeFactor is equal to 0.
 	assert.EqualValues(t, 7, resolved0.ExpectedRuntimeFactor)
+	assert.EqualValues(t, 20, resolved0.GenerateTaskFactor)
 
 	d1 := Distro{
 		Id: "distro1",
@@ -384,6 +387,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 			CommitQueueFactor:         0,
 			MainlineTimeInQueueFactor: 0,
 			ExpectedRuntimeFactor:     0,
+			GenerateTaskFactor:        0,
 		},
 	}
 	config1 := evergreen.SchedulerConfig{
@@ -400,6 +404,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 		CommitQueueFactor:             0,
 		MainlineTimeInQueueFactor:     0,
 		ExpectedRuntimeFactor:         0,
+		GenerateTaskFactor:            0,
 	}
 
 	settings1 := &evergreen.Settings{Scheduler: config1}
@@ -415,6 +420,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 	assert.EqualValues(t, 0, resolved1.CommitQueueFactor)
 	assert.EqualValues(t, 0, resolved1.MainlineTimeInQueueFactor)
 	assert.EqualValues(t, 0, resolved1.ExpectedRuntimeFactor)
+	assert.EqualValues(t, 0, resolved1.GenerateTaskFactor)
 
 	ps := &PlannerSettings{
 		Version:                   "",
@@ -425,6 +431,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 		CommitQueueFactor:         0,
 		MainlineTimeInQueueFactor: 0,
 		ExpectedRuntimeFactor:     0,
+		GenerateTaskFactor:        0,
 	}
 	d2 := Distro{
 		Id:              "distro2",
@@ -444,6 +451,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 		CommitQueueFactor:             0,
 		MainlineTimeInQueueFactor:     0,
 		ExpectedRuntimeFactor:         0,
+		GenerateTaskFactor:            0,
 	}
 	settings2 := &evergreen.Settings{Scheduler: config2}
 
@@ -461,6 +469,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 	assert.EqualValues(t, 0, resolved2.CommitQueueFactor)
 	assert.EqualValues(t, 0, resolved2.MainlineTimeInQueueFactor)
 	assert.EqualValues(t, 0, resolved2.ExpectedRuntimeFactor)
+	assert.EqualValues(t, 0, resolved2.GenerateTaskFactor)
 }
 
 func TestAddPermissions(t *testing.T) {

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -167,6 +167,8 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
           distro.distro.planner_settings.patch_factor = distro.distro.planner_settings.patch_factor || 0;
           distro.distro.planner_settings.time_in_queue_factor = distro.distro.planner_settings.time_in_queue_factor || 0;
           distro.distro.planner_settings.expected_runtime_factor = distro.distro.planner_settings.expected_runtime_factor || 0;
+          distro.distro.planner_settings.generate_task_factor = distro.distro.planner_settings.generate_task_factor || 0;
+
           // Convert from nanoseconds (time.Duration) to seconds (UI display units) for the relevant planner_settings' fields.
           if (distro.distro.planner_settings.target_time > 0) {
             distro.distro.planner_settings.target_time /= 1e9;

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1632,6 +1632,7 @@ type APISchedulerConfig struct {
 	CommitQueueFactor             int64   `json:"commit_queue_factor"`
 	MainlineTimeInQueueFactor     int64   `json:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor         int64   `json:"expected_runtime_factor"`
+	GenerateTaskFactor            int64   `json:"generate_task_factor"`
 }
 
 func (a *APISchedulerConfig) BuildFromService(h interface{}) error {
@@ -1650,6 +1651,7 @@ func (a *APISchedulerConfig) BuildFromService(h interface{}) error {
 		a.CommitQueueFactor = v.CommitQueueFactor
 		a.MainlineTimeInQueueFactor = v.MainlineTimeInQueueFactor
 		a.ExpectedRuntimeFactor = v.ExpectedRuntimeFactor
+		a.GenerateTaskFactor = v.GenerateTaskFactor
 	default:
 		return errors.Errorf("%T is not a supported type", h)
 	}
@@ -1671,6 +1673,7 @@ func (a *APISchedulerConfig) ToService() (interface{}, error) {
 		PatchTimeInQueueFactor:        a.PatchTimeInQueueFactor,
 		CommitQueueFactor:             a.CommitQueueFactor,
 		MainlineTimeInQueueFactor:     a.MainlineTimeInQueueFactor,
+		GenerateTaskFactor:            a.GenerateTaskFactor,
 	}, nil
 }
 

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -19,6 +19,7 @@ type APIPlannerSettings struct {
 	PatchTimeInQueueFactor    int64       `json:"patch_time_in_queue_factor"`
 	MainlineTimeInQueueFactor int64       `json:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor     int64       `json:"expected_runtime_factor"`
+	GenerateTaskFactor        int64       `json:"generate_task_factor"`
 }
 
 // BuildFromService converts from service level distro.PlannerSetting to an APIPlannerSettings
@@ -44,7 +45,7 @@ func (s *APIPlannerSettings) BuildFromService(h interface{}) error {
 	s.ExpectedRuntimeFactor = settings.ExpectedRuntimeFactor
 	s.PatchTimeInQueueFactor = settings.PatchTimeInQueueFactor
 	s.MainlineTimeInQueueFactor = settings.MainlineTimeInQueueFactor
-
+	s.GenerateTaskFactor = settings.GenerateTaskFactor
 	return nil
 }
 
@@ -61,6 +62,7 @@ func (s *APIPlannerSettings) ToService() (interface{}, error) {
 	settings.PatchTimeInQueueFactor = s.PatchTimeInQueueFactor
 	settings.MainlineTimeInQueueFactor = s.MainlineTimeInQueueFactor
 	settings.ExpectedRuntimeFactor = s.ExpectedRuntimeFactor
+	settings.GenerateTaskFactor = s.GenerateTaskFactor
 
 	return interface{}(settings), nil
 }

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -229,7 +229,7 @@ func (unit *Unit) RankValue() int64 {
 	}
 	if generateTask {
 		// give generators a boost so people don't have to wait twice.
-		priority += 100
+		priority = priority * unit.distro.GetGenerateTaskFactor()
 	}
 
 	if inPatch {

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -227,6 +227,11 @@ func (unit *Unit) RankValue() int64 {
 		// would also be scheduled in a version.
 		priority += length
 	}
+	if generateTask {
+		// give generators a boost so people don't have to wait twice.
+		priority += 100
+		unit.cachedValue += priority * unit.distro.GetGenerateTaskFactor()
+	}
 
 	if inPatch {
 		// give patches a bump, over non-patches.
@@ -240,9 +245,6 @@ func (unit *Unit) RankValue() int64 {
 		// give commit queue patches a boost over everything else
 		priority += 200
 		unit.cachedValue += priority * unit.distro.GetCommitQueueFactor()
-	} else if generateTask {
-		// give generators a boost so people don't have to wait twice.
-		unit.cachedValue += priority * unit.distro.GetGenerateTaskFactor()
 	} else {
 		// for mainline builds that are more recent, give them a bit
 		// of a bump, to avoid running older builds first.

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -230,7 +230,6 @@ func (unit *Unit) RankValue() int64 {
 	if generateTask {
 		// give generators a boost so people don't have to wait twice.
 		priority += 100
-		unit.cachedValue += priority * unit.distro.GetGenerateTaskFactor()
 	}
 
 	if inPatch {

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -655,6 +655,11 @@ Admin Settings
 										<input type="number" step="1" min="0" max="100"
 											ng-model="Settings.scheduler.expected_runtime_factor">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Generate Task Factor (0 to 100 inclusive)</label>
+										<input type="number" step="1" min="0" max="100"
+											   ng-model="Settings.scheduler.generate_task_factor">
+									</md-input-container>
 									<md-input-container class="control" style="width:170px;">
 										<md-checkbox ng-model="Settings.scheduler.group_versions">
 											Group Versions

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -215,6 +215,17 @@ Evergreen - Distros
                 form.plannerSettingsExpectedRuntimeFactor.$modelValue < 0 ||
                 form.plannerSettingsExpectedRuntimeFactor.$modelValue % 1 != 0"> Time In Queue Factor must be an integer between 0 and 100
               </div>
+              <div>
+                <label class="distro-label">Generate Task Factor (0 to 100 inclusive):</label>
+                <input ng-readonly="readOnly" type="number" ng-required="activeDistro.planner_settings.version == 'tunable'"
+                       name="plannerSettingsGenerateTaskFactor" class="form-control" ng-model="activeDistro.planner_settings.generate_task_factor" placeholder="Set to 0 to use its global default">
+              </div>
+              <div class="icon fa fa-warning distro-error" ng-show="form.plannerSettingsGenerateTaskFactor.$dirty && form.plannerSettingsGenerateTaskFactor.$error.required ||
+                form.plannerSettingsGenerateTaskFactor.$invalid ||
+                form.plannerSettingsGenerateTaskFactor.$modelValue > 100 ||
+                form.plannerSettingsGenerateTaskFactor.$modelValue < 0 ||
+                form.plannerSettingsGenerateTaskFactor.$modelValue % 1 != 0"> Time In Queue Factor must be an integer between 0 and 100
+              </div>
               <br/>
               <div>
                 <span class="distro-menu-title">Group Versions:</span>


### PR DESCRIPTION
When projects use generate tasks, they basically have to wait twice as long for a task, because first they have to wait for the generator to be scheduled, and then for the generated task to be scheduled. The old scheduler [handled this](https://github.com/evergreen-ci/evergreen/blob/28c66fda6b8f4013ed4e0b3548444b5cf0d09245/scheduler/task_priority_cmp.go#L152) by scheduling  generators faster, so that users essentially only had to wait once for generated tasks, but the new scheduler doesn't seem to consider that, so I added a "factor" for it.