### PR TITLE
EVG-13236: fix shell quotes and check error from http.NewRequest()

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1067,11 +1067,11 @@ func (h *Host) AgentCommand(settings *evergreen.Settings) []string {
 	return []string{
 		h.Distro.AbsPathCygwinCompatible(h.Distro.HomeDir(), h.Distro.BinaryName()),
 		"agent",
-		fmt.Sprintf("--api_server='%s'", settings.ApiUrl),
-		fmt.Sprintf("--host_id='%s'", h.Id),
-		fmt.Sprintf("--host_secret='%s'", h.Secret),
-		fmt.Sprintf("--log_prefix='%s'", filepath.Join(h.Distro.WorkDir, "agent")),
-		fmt.Sprintf("--working_directory='%s'", h.Distro.WorkDir),
+		fmt.Sprintf("--api_server=%s", settings.ApiUrl),
+		fmt.Sprintf("--host_id=%s", h.Id),
+		fmt.Sprintf("--host_secret=%s", h.Secret),
+		fmt.Sprintf("--log_prefix=%s", filepath.Join(h.Distro.WorkDir, "agent")),
+		fmt.Sprintf("--working_directory=%s", h.Distro.WorkDir),
 		"--cleanup",
 	}
 }

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -56,6 +56,9 @@ var AuthError = errors.New("401 Unauthorized: User credentials are likely expire
 func (c *communicatorImpl) newRequest(method, path, taskID, taskSecret, version string, data interface{}) (*http.Request, error) {
 	url := c.getPath(path, version)
 	r, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, errors.New("Error building request")
+	}
 	if data != nil {
 		if rc, ok := data.(io.ReadCloser); ok {
 			r.Body = rc
@@ -70,9 +73,6 @@ func (c *communicatorImpl) newRequest(method, path, taskID, taskSecret, version 
 		}
 	}
 
-	if err != nil {
-		return nil, errors.New("Error building request")
-	}
 	if taskID != "" {
 		r.Header.Add(evergreen.TaskHeader, taskID)
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13238

Two changes to fix a panic in the agent monitor, which was relying on the agent's API server URL.
1. Remove shell quotes from the command to invoke the agent. There's some possibility that this will be wrong if we ever have paths with spaces in them, but I'm just gonna assume it won't happen.
2. Check the error from `http.NewRequest()` immediately because if `http.NewRequest()` errors and you try to set a field on it, it'll panic the REST communicator.

This didn't arise in the smoke test because it doesn't use shell quotes when it's invoking the agent monitor.