### PR TITLE
EVG-13249 speed up finding parent display tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -381,16 +381,20 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 		})
 	}
 	startPhaseAt := time.Now()
-	finishedTasks, err := task.FindWithDisplayTasks(task.ByIdsAndStatus(taskIds, evergreen.CompletedStatuses))
+	finishedTasks, err := task.FindAll(task.ByIdsAndStatus(taskIds, evergreen.CompletedStatuses))
+	if err != nil && !adb.ResultsNotFound(err) {
+		return errors.WithStack(err)
+	}
+	finishedTasks, err = task.AddParentDisplayTasks(finishedTasks)
+	if err != nil && !adb.ResultsNotFound(err) {
+		return errors.WithStack(err)
+	}
 	grip.Info(message.Fields{
 		"message":       "Find completed tasks",
 		"version":       versionId,
 		"ticket":        "EVG-12549",
 		"duration_secs": time.Since(startPhaseAt).Seconds(),
 	})
-	if err != nil && !adb.ResultsNotFound(err) {
-		return errors.WithStack(err)
-	}
 	// remove execution tasks in case the caller passed both display and execution tasks
 	// the functions below are expected to work if just the display task is passed
 	for i := len(finishedTasks) - 1; i >= 0; i-- {
@@ -516,7 +520,7 @@ func RestartBuild(buildId string, taskIds []string, abortInProgress bool, caller
 	}
 
 	// restart all the 'not in-progress' tasks for the build
-	tasks, err := task.FindWithDisplayTasks(task.ByIdsAndStatus(taskIds, evergreen.CompletedStatuses))
+	tasks, err := task.FindAll(task.ByIdsAndStatus(taskIds, evergreen.CompletedStatuses))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -532,7 +536,7 @@ func RestartAllBuildTasks(buildId string, caller string) error {
 		return errors.WithStack(err)
 	}
 
-	allTasks, err := task.FindWithDisplayTasks(task.ByBuildId(buildId))
+	allTasks, err := task.FindAll(task.ByBuildId(buildId))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -597,7 +601,11 @@ func CreateTasksCache(tasks []task.Task) []build.TaskCache {
 // RefreshTasksCache updates a build document so that the tasks cache reflects the correct current
 // state of the tasks it represents.
 func RefreshTasksCache(buildId string) error {
-	tasks, err := task.FindWithDisplayTasks(task.ByBuildId(buildId))
+	tasks, err := task.FindAll(task.ByBuildId(buildId))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	tasks, err = task.AddParentDisplayTasks(tasks)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -382,12 +382,15 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 	}
 	startPhaseAt := time.Now()
 	finishedTasks, err := task.FindAll(task.ByIdsAndStatus(taskIds, evergreen.CompletedStatuses))
-	if err != nil && !adb.ResultsNotFound(err) {
+	if err != nil {
 		return errors.WithStack(err)
 	}
 	finishedTasks, err = task.AddParentDisplayTasks(finishedTasks)
-	if err != nil && !adb.ResultsNotFound(err) {
+	if err != nil {
 		return errors.WithStack(err)
+	}
+	if len(finishedTasks) == 0 {
+		return nil
 	}
 	grip.Info(message.Fields{
 		"message":       "Find completed tasks",

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1731,7 +1731,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 	// test restarting a version
 	assert.NoError(resetTaskData())
 	assert.NoError(RestartVersion("version", displayTasks, false, "test"))
-	tasks, err := task.FindWithDisplayTasks(task.ByIds(allTasks))
+	tasks, err := task.FindAll(task.ByIds(allTasks))
 	assert.NoError(err)
 	assert.Len(tasks, 3)
 	for _, dbTask := range tasks {
@@ -1742,7 +1742,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 	// test restarting a build
 	assert.NoError(resetTaskData())
 	assert.NoError(RestartBuild("build3", displayTasks, false, "test"))
-	tasks, err = task.FindWithDisplayTasks(task.ByIds(allTasks))
+	tasks, err = task.FindAll(task.ByIds(allTasks))
 	assert.NoError(err)
 	assert.Len(tasks, 3)
 	for _, dbTask := range tasks {
@@ -1763,7 +1763,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 		}
 	}
 	assert.True(foundDisplayTask)
-	tasks, err = task.FindWithDisplayTasks(task.ByIds(allTasks))
+	tasks, err = task.FindAll(task.ByIds(allTasks))
 	assert.NoError(err)
 	assert.Len(tasks, 3)
 	for _, dbTask := range tasks {
@@ -1784,7 +1784,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 	// trying to restart execution tasks should restart the entire display task, if it's done
 	assert.NoError(resetTaskData())
 	assert.NoError(RestartVersion("version", allTasks, false, "test"))
-	tasks, err = task.FindWithDisplayTasks(task.ByIds(allTasks))
+	tasks, err = task.FindAll(task.ByIds(allTasks))
 	assert.NoError(err)
 	assert.Len(tasks, 3)
 	for _, dbTask := range tasks {

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -650,7 +650,7 @@ func TestAddNewPatch(t *testing.T) {
 	assert.Equal(dbBuild.Tasks[1].DisplayName, "task3")
 
 	assert.NoError(AddNewTasksForPatch(context.Background(), p, v, proj, tasks))
-	dbTasks, err := task.FindWithDisplayTasks(task.ByBuildId(dbBuild.Id))
+	dbTasks, err := task.FindAll(task.ByBuildId(dbBuild.Id))
 	assert.NoError(err)
 	assert.NotNil(dbBuild)
 	assert.Len(dbTasks, 4)
@@ -720,7 +720,7 @@ func TestAddNewPatchWithMissingBaseVersion(t *testing.T) {
 	assert.Equal(dbBuild.Tasks[1].DisplayName, "task3")
 
 	assert.NoError(AddNewTasksForPatch(context.Background(), p, v, proj, tasks))
-	dbTasks, err := task.FindWithDisplayTasks(task.ByBuildId(dbBuild.Id))
+	dbTasks, err := task.FindAll(task.ByBuildId(dbBuild.Id))
 	assert.NoError(err)
 	assert.NotNil(dbBuild)
 	assert.Len(dbTasks, 4)

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -543,6 +543,14 @@ func ByExecutionTask(taskId string) db.Q {
 	})
 }
 
+func ByExecutionTasks(ids []string) db.Q {
+	return db.Query(bson.M{
+		ExecutionTasksKey: bson.M{
+			"$in": ids,
+		},
+	})
+}
+
 var (
 	IsDispatchedOrStarted = db.Query(bson.M{
 		StatusKey: bson.M{"$in": []string{evergreen.TaskStarted, evergreen.TaskDispatched}},

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2586,6 +2586,9 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 }
 
 func AddParentDisplayTasks(tasks []Task) ([]Task, error) {
+	if len(tasks) == 0 {
+		return tasks, nil
+	}
 	taskIDs := []string{}
 	tasksCopy := tasks
 	for _, t := range tasks {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2142,3 +2142,38 @@ func TestGetLatestExecution(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, sample.Execution, execution)
 }
+
+func TestAddParentDisplayTasks(t *testing.T) {
+	assert.NoError(t, db.Clear(Collection))
+	dt1 := Task{
+		Id:             "dt1",
+		DisplayOnly:    true,
+		ExecutionTasks: []string{"et1", "et2"},
+	}
+	assert.NoError(t, dt1.Insert())
+	dt2 := Task{
+		Id:             "dt2",
+		DisplayOnly:    true,
+		ExecutionTasks: []string{"et3", "et4"},
+	}
+	assert.NoError(t, dt2.Insert())
+	execTasks := []Task{
+		{Id: "et1"},
+		{Id: "et2"},
+		{Id: "et3"},
+		{Id: "et4"},
+	}
+	for _, et := range execTasks {
+		assert.NoError(t, et.Insert())
+	}
+	tasks, err := AddParentDisplayTasks(execTasks)
+	assert.NoError(t, err)
+	assert.Equal(t, "et1", tasks[0].Id)
+	assert.Equal(t, dt1.Id, tasks[0].DisplayTask.Id)
+	assert.Equal(t, "et2", tasks[1].Id)
+	assert.Equal(t, dt1.Id, tasks[1].DisplayTask.Id)
+	assert.Equal(t, "et3", tasks[2].Id)
+	assert.Equal(t, dt2.Id, tasks[2].DisplayTask.Id)
+	assert.Equal(t, "et4", tasks[3].Id)
+	assert.Equal(t, dt2.Id, tasks[3].DisplayTask.Id)
+}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -297,7 +297,7 @@ func AbortTask(taskId, caller string) error {
 // as the task.
 func DeactivatePreviousTasks(t *task.Task, caller string) error {
 	statuses := []string{evergreen.TaskUndispatched}
-	allTasks, err := task.FindWithDisplayTasks(task.ByActivatedBeforeRevisionWithStatuses(
+	allTasks, err := task.FindAll(task.ByActivatedBeforeRevisionWithStatuses(
 		t.RevisionOrderNumber,
 		statuses,
 		t.BuildVariant,
@@ -958,7 +958,11 @@ func MarkOneTaskReset(t *task.Task, logIDs bool) error {
 }
 
 func MarkTasksReset(taskIds []string) error {
-	tasks, err := task.FindWithDisplayTasks(task.ByIds(taskIds))
+	tasks, err := task.FindAll(task.ByIds(taskIds))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	tasks, err = task.AddParentDisplayTasks(tasks)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -1025,9 +1029,13 @@ func RestartFailedTasks(opts RestartOptions) (RestartResults, error) {
 	if opts.IncludeSetupFailed {
 		failureTypes = append(failureTypes, evergreen.CommandTypeSetup)
 	}
-	tasksToRestart, err := task.FindWithDisplayTasks(task.ByTimeStartedAndFailed(opts.StartTime, opts.EndTime, failureTypes))
+	tasksToRestart, err := task.FindAll(task.ByTimeStartedAndFailed(opts.StartTime, opts.EndTime, failureTypes))
 	if err != nil {
-		return results, err
+		return results, errors.WithStack(err)
+	}
+	tasksToRestart, err = task.AddParentDisplayTasks(tasksToRestart)
+	if err != nil {
+		return results, errors.WithStack(err)
 	}
 
 	type taskGroupAndBuild struct {

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -519,7 +519,7 @@ func getTaskDrawerItems(displayName string, variant string, reverseOrder bool, v
 		revisionSort = "-" + revisionSort
 	}
 
-	tasks, err := task.FindWithDisplayTasks(task.ByVersionsForNameAndVariant(versionIds, []string{displayName}, variant).Sort([]string{revisionSort}))
+	tasks, err := task.FindAll(task.ByVersionsForNameAndVariant(versionIds, []string{displayName}, variant).Sort([]string{revisionSort}))
 
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting sibling tasks")

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -226,7 +226,7 @@ func (t *versionTriggers) versionRegression(sub *event.Subscription) (*notificat
 		return nil, nil
 	}
 
-	versionTasks, err := task.FindWithDisplayTasks(task.ByVersion(t.version.Id))
+	versionTasks, err := task.FindAll(task.ByVersion(t.version.Id))
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving tasks for version")
 	}


### PR DESCRIPTION
This is only half of the ticket, the second half is a logically different change so it'll be a separate pr
- Remove the FindWithDisplayTasks function. It was problematic for two reasons - it was named in a way that said "task.Find but also includes display tasks in the results" (the regular task.Find does not), and also that the way it added display tasks to its results was inefficient
- For any callers using it as a task.FindAll, switch them to using FindAll. The fact that the function didn't actually link display tasks for a long time suggests that most callers are in this bucket. This part is probably the most bug-prone if I misread what the caller was doing
- For any callers actually using it for its intended purpose, split them into 2 calls - 1 to find tasks, and 1 to link up parent tasks. The linking part is doing a single query that has a dedicated index