### PR TITLE
EVG-13097 extra sanity check in task status displays

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1213,6 +1213,9 @@ func (t *Task) GetDisplayStatus() string {
 	if t.DisplayStatus != "" {
 		return t.DisplayStatus
 	}
+	if !t.IsFinished() {
+		return t.Status
+	}
 	if t.Status == evergreen.TaskSucceeded {
 		return evergreen.TaskSucceeded
 	}

--- a/public/static/js/filters/filters.common.js
+++ b/public/static/js/filters/filters.common.js
@@ -391,7 +391,9 @@ filters.common.filter('conditional', function () {
         if (!task.dispatch_time || task.dispatch_time == 0 || (typeof task.dispatch_time === "string" && +new Date(task.dispatch_time) <= 0)) {
           return "not scheduled"
         }
-        return 'aborted';
+        if (task.abort) {
+          return 'aborted';
+        }
       } else if (task.status == 'success') {
         return 'success';
       } else if (task.status == 'failed') {

--- a/trigger/task_jira_test.go
+++ b/trigger/task_jira_test.go
@@ -57,6 +57,7 @@ func TestJIRASummary(t *testing.T) {
 				},
 				Task: &task.Task{
 					DisplayName: taskName,
+					Status:      evergreen.TaskFailed,
 					Details:     apimodels.TaskEndDetail{},
 				},
 				Build:   &build.Build{DisplayName: buildName},
@@ -439,6 +440,7 @@ func TestCustomFields(t *testing.T) {
 				Id:           taskId,
 				BuildVariant: "build12",
 				DisplayName:  taskName,
+				Status:       evergreen.TaskFailed,
 				Details: apimodels.TaskEndDetail{
 					Type: evergreen.CommandTypeSystem,
 				},


### PR DESCRIPTION
The task in the ticket is in a really weird state where it has everything that a finished task would, except that it's in a non-finished status. I couldn't figure out how it got like that but also think it's not that important to do so given that this is the only case we know of so far. This pr just adds a sanity check to both UIs that shouldn't be hit ever, but if they do then it'll hopefully display something more accurate than before