### PR TITLE
EVG-13115: load S3 binary download feature flag from the DB

### DIFF
--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -890,9 +890,14 @@ func (rh *distroClientURLsGetHandler) Run(ctx context.Context) gimlet.Responder 
 		return gimlet.NewJSONErrorResponse(errors.Wrapf(err, "finding distro '%s'", rh.distroID))
 	}
 
+	flags, err := evergreen.GetServiceFlags()
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "could not fetch service flags"))
+	}
+
 	var urls []string
 	settings := rh.env.Settings()
-	if !settings.ServiceFlags.S3BinaryDownloadsDisabled && settings.HostInit.S3BaseURL != "" {
+	if !flags.S3BinaryDownloadsDisabled && settings.HostInit.S3BaseURL != "" {
 		urls = append(urls, d.S3ClientURL(settings))
 	}
 	urls = append(urls, d.ClientURL(settings))

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -243,7 +243,11 @@ func (j *agentDeployJob) prepRemoteHost(ctx context.Context, settings *evergreen
 	// copy over the correct agent binary to the remote host
 	curlCtx, cancel := context.WithTimeout(ctx, evergreenCurlTimeout)
 	defer cancel()
-	output, err := j.host.RunSSHCommand(curlCtx, j.host.CurlCommand(settings))
+	curlCmd, err := j.host.CurlCommand(settings)
+	if err != nil {
+		return errors.Wrap(err, "could not create command to curl evergreen client")
+	}
+	output, err := j.host.RunSSHCommand(curlCtx, curlCmd)
 	if err != nil {
 		event.LogHostAgentDeployFailed(j.host.Id, err)
 		return errors.Wrapf(err, "error downloading agent binary on remote host: %s", output)

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -236,8 +236,12 @@ func (j *agentMonitorDeployJob) fetchClient(ctx context.Context, settings *everg
 		"job":           j.ID(),
 	})
 
+	cmd, err := j.host.CurlCommand(settings)
+	if err != nil {
+		return errors.Wrap(err, "could not create command to curl evergreen client")
+	}
 	opts := &options.Create{
-		Args: []string{j.host.Distro.ShellBinary(), "-l", "-c", j.host.CurlCommand(settings)},
+		Args: []string{j.host.Distro.ShellBinary(), "-l", "-c", cmd},
 	}
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, evergreenCurlTimeout)

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -573,7 +573,11 @@ func (j *setupHostJob) setupSpawnHost(ctx context.Context, settings *evergreen.S
 
 	curlCtx, cancel := context.WithTimeout(ctx, evergreenCurlTimeout)
 	defer cancel()
-	output, err := j.host.RunSSHCommand(curlCtx, j.host.CurlCommand(settings))
+	curlCmd, err := j.host.CurlCommand(settings)
+	if err != nil {
+		return errors.Wrap(err, "could not create command to curl evergreen client")
+	}
+	output, err := j.host.RunSSHCommand(curlCtx, curlCmd)
 	if err != nil {
 		return errors.Wrapf(err, "error running command to get evergreen binary on spawn host: %s", output)
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13315

Check the feature flag set in the DB rather than the cached value in the global environment struct (so that we can dynamically enable/disable this without requiring an app server restart).