### PR TITLE
EVG-13268 add repo ref collection

### DIFF
--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -30,14 +30,12 @@ const (
 func getMockProjectSettings() ProjectSettingsEvent {
 	return ProjectSettingsEvent{
 		ProjectRef: ProjectRef{
-			Owner:                 "admin",
-			Enabled:               true,
-			Private:               true,
-			Identifier:            projectId,
-			Admins:                []string{},
-			GitTagAuthorizedUsers: []string{},
-			GitTagAuthorizedTeams: []string{},
-			Tags:                  []string{},
+			Owner:      "admin",
+			Enabled:    true,
+			Private:    true,
+			Identifier: projectId,
+			Admins:     []string{},
+			Tags:       []string{},
 		},
 		GitHubHooksEnabled: true,
 		Vars: ProjectVars{

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -32,51 +32,50 @@ import (
 // The ProjectRef struct contains general information, independent of any
 // revision control system, needed to track a given project
 type ProjectRef struct {
-	Owner              string   `bson:"owner_name" json:"owner_name" yaml:"owner"`
-	Repo               string   `bson:"repo_name" json:"repo_name" yaml:"repo"`
-	Branch             string   `bson:"branch_name" json:"branch_name" yaml:"branch"`
-	RepoKind           string   `bson:"repo_kind" json:"repo_kind" yaml:"repokind"`
-	Enabled            bool     `bson:"enabled" json:"enabled" yaml:"enabled"`
-	Private            bool     `bson:"private" json:"private" yaml:"private"`
-	Restricted         bool     `bson:"restricted" json:"restricted" yaml:"restricted"`
-	BatchTime          int      `bson:"batch_time" json:"batch_time" yaml:"batchtime"`
-	RemotePath         string   `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
-	Identifier         string   `bson:"identifier" json:"identifier" yaml:"identifier"`
-	DisplayName        string   `bson:"display_name" json:"display_name" yaml:"display_name"`
-	DeactivatePrevious bool     `bson:"deactivate_previous" json:"deactivate_previous" yaml:"deactivate_previous"`
-	Tags               []string `bson:"tags" json:"tags" yaml:"tags"`
-
-	// TracksPushEvents, if true indicates that Repotracker is triggered by Github PushEvents for this project.
-	TracksPushEvents bool `bson:"tracks_push_events" json:"tracks_push_events" yaml:"tracks_push_events"`
-
-	DefaultLogger string `bson:"default_logger" json:"default_logger" yaml:"default_logger"`
-
-	CedarTestResultsEnabled bool `bson:"cedar_test_results_enabled" json:"cedar_test_results_enabled" yaml:"cedar_test_results_enabled"`
-
-	PRTestingEnabled bool              `bson:"pr_testing_enabled" json:"pr_testing_enabled" yaml:"pr_testing_enabled"`
-	CommitQueue      CommitQueueParams `bson:"commit_queue" json:"commit_queue" yaml:"commit_queue"`
-
-	// TaskSync holds settings for synchronizing task directories to S3.
-	TaskSync TaskSyncOptions `bson:"task_sync" json:"task_sync" yaml:"task_sync"`
-
-	//Tracked determines whether or not the project is discoverable in the UI
-	Tracked             bool `bson:"tracked" json:"tracked"`
-	PatchingDisabled    bool `bson:"patching_disabled" json:"patching_disabled"`
-	RepotrackerDisabled bool `bson:"repotracker_disabled" json:"repotracker_disabled" yaml:"repotracker_disabled"`
-	DispatchingDisabled bool `bson:"dispatching_disabled" json:"dispatching_disabled" yaml:"dispatching_disabled"`
+	// The following fields can be defined from both the branch and repo level.
+	Identifier          string `bson:"identifier" json:"identifier" yaml:"identifier"`
+	DisplayName         string `bson:"display_name" json:"display_name" yaml:"display_name"`
+	Enabled             bool   `bson:"enabled" json:"enabled" yaml:"enabled"`
+	Private             bool   `bson:"private" json:"private" yaml:"private"`
+	Restricted          bool   `bson:"restricted" json:"restricted" yaml:"restricted"`
+	Owner               string `bson:"owner_name" json:"owner_name" yaml:"owner"`
+	Repo                string `bson:"repo_name" json:"repo_name" yaml:"repo"`
+	RemotePath          string `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
+	PatchingDisabled    bool   `bson:"patching_disabled" json:"patching_disabled"`
+	RepotrackerDisabled bool   `bson:"repotracker_disabled" json:"repotracker_disabled" yaml:"repotracker_disabled"`
+	DispatchingDisabled bool   `bson:"dispatching_disabled" json:"dispatching_disabled" yaml:"dispatching_disabled"`
+	PRTestingEnabled    bool   `bson:"pr_testing_enabled" json:"pr_testing_enabled" yaml:"pr_testing_enabled"`
 
 	// Admins contain a list of users who are able to access the projects page.
 	Admins []string `bson:"admins" json:"admins"`
 
-	// GitTagAuthorizedUsers contains a list of users who are able to create versions from git tags.
-	GitTagAuthorizedUsers []string `bson:"git_tag_authorized_users" json:"git_tag_authorized_users"`
-	GitTagAuthorizedTeams []string `bson:"git_tag_authorized_teams" json:"git_tag_authorized_teams"`
-	GitTagVersionsEnabled bool     `bson:"git_tag_versions_enabled" json:"git_tag_versions_enabled"`
-
-	NotifyOnBuildFailure bool `bson:"notify_on_failure" json:"notify_on_failure"`
-
 	// SpawnHostScriptPath is a path to a script to optionally be run by users on hosts triggered from tasks.
 	SpawnHostScriptPath string `bson:"spawn_host_script_path" json:"spawn_host_script_path" yaml:"spawn_host_script_path"`
+
+	// The following fields can be defined only at the branch level.
+	Branch                  string                    `bson:"branch_name" json:"branch_name" yaml:"branch"`
+	BatchTime               int                       `bson:"batch_time" json:"batch_time" yaml:"batchtime"`
+	DeactivatePrevious      bool                      `bson:"deactivate_previous" json:"deactivate_previous" yaml:"deactivate_previous"`
+	DefaultLogger           string                    `bson:"default_logger" json:"default_logger" yaml:"default_logger"`
+	CommitQueue             CommitQueueParams         `bson:"commit_queue" json:"commit_queue" yaml:"commit_queue"`
+	NotifyOnBuildFailure    bool                      `bson:"notify_on_failure" json:"notify_on_failure"`
+	Triggers                []TriggerDefinition       `bson:"triggers,omitempty" json:"triggers,omitempty"`
+	PeriodicBuilds          []PeriodicBuildDefinition `bson:"periodic_builds,omitempty" json:"periodic_builds,omitempty"`
+	Tags                    []string                  `bson:"tags" json:"tags,omitempty" yaml:"tags,omitempty"`
+	CedarTestResultsEnabled bool                      `bson:"cedar_test_results_enabled" json:"cedar_test_results_enabled" yaml:"cedar_test_results_enabled"`
+	PRTestingEnabled        bool                      `bson:"pr_testing_enabled" json:"pr_testing_enabled" yaml:"pr_testing_enabled"`
+	CommitQueue             CommitQueueParams         `bson:"commit_queue" json:"commit_queue" yaml:"commit_queue"`
+
+	// TracksPushEvents, if true indicates that Repotracker is triggered by Github PushEvents for this project.
+	TracksPushEvents bool `bson:"tracks_push_events" json:"tracks_push_events" yaml:"tracks_push_events"`
+
+	// TaskSync holds settings for synchronizing task directories to S3.
+	TaskSync TaskSyncOptions `bson:"task_sync" json:"task_sync" yaml:"task_sync"`
+
+	// GitTagAuthorizedUsers contains a list of users who are able to create versions from git tags.
+	GitTagAuthorizedUsers []string `bson:"git_tag_authorized_users,omitempty" json:"git_tag_authorized_users,omitempty"`
+	GitTagAuthorizedTeams []string `bson:"git_tag_authorized_teams,omitempty" json:"git_tag_authorized_teams,omitempty"`
+	GitTagVersionsEnabled bool     `bson:"git_tag_versions_enabled" json:"git_tag_versions_enabled"`
 
 	// RepoDetails contain the details of the status of the consistency
 	// between what is in GitHub and what is in Evergreen
@@ -84,12 +83,15 @@ type ProjectRef struct {
 
 	// List of regular expressions describing files to ignore when caching historical test results
 	FilesIgnoredFromCache []string `bson:"files_ignored_from_cache,omitempty" json:"files_ignored_from_cache,omitempty"`
-	DisabledStatsCache    bool     `bson:"disabled_stats_cache,omitempty" json:"disabled_stats_cache,omitempty"`
+	DisabledStatsCache    bool     `bson:"disabled_stats_cache" json:"disabled_stats_cache"`
 
-	Triggers       []TriggerDefinition       `bson:"triggers,omitempty" json:"triggers,omitempty"`
-	PeriodicBuilds []PeriodicBuildDefinition `bson:"periodic_builds,omitempty" json:"periodic_builds,omitempty"`
 	// List of commands
 	WorkstationConfig WorkstationConfig `bson:"workstation_config,omitempty" json:"workstation_config,omitempty"`
+
+	// The following fields are used by Evergreen and are not discoverable.
+	RepoKind string `bson:"repo_kind" json:"repo_kind" yaml:"repokind"`
+	//Tracked determines whether or not the project is discoverable in the UI
+	Tracked bool `bson:"tracked" json:"tracked"`
 }
 
 type CommitQueueParams struct {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -57,13 +57,11 @@ type ProjectRef struct {
 	BatchTime               int                       `bson:"batch_time" json:"batch_time" yaml:"batchtime"`
 	DeactivatePrevious      bool                      `bson:"deactivate_previous" json:"deactivate_previous" yaml:"deactivate_previous"`
 	DefaultLogger           string                    `bson:"default_logger" json:"default_logger" yaml:"default_logger"`
-	CommitQueue             CommitQueueParams         `bson:"commit_queue" json:"commit_queue" yaml:"commit_queue"`
 	NotifyOnBuildFailure    bool                      `bson:"notify_on_failure" json:"notify_on_failure"`
 	Triggers                []TriggerDefinition       `bson:"triggers,omitempty" json:"triggers,omitempty"`
 	PeriodicBuilds          []PeriodicBuildDefinition `bson:"periodic_builds,omitempty" json:"periodic_builds,omitempty"`
 	Tags                    []string                  `bson:"tags" json:"tags,omitempty" yaml:"tags,omitempty"`
 	CedarTestResultsEnabled bool                      `bson:"cedar_test_results_enabled" json:"cedar_test_results_enabled" yaml:"cedar_test_results_enabled"`
-	PRTestingEnabled        bool                      `bson:"pr_testing_enabled" json:"pr_testing_enabled" yaml:"pr_testing_enabled"`
 	CommitQueue             CommitQueueParams         `bson:"commit_queue" json:"commit_queue" yaml:"commit_queue"`
 
 	// TracksPushEvents, if true indicates that Repotracker is triggered by Github PushEvents for this project.

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/mongodb/anser/bsonutil"
+	adb "github.com/mongodb/anser/db"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+const RepoRefCollection = "repo_ref"
+
+// RepoRef is a wrapper for ProjectRef, as many settings in the project ref
+// can be defined at both the branch and repo level.
+type RepoRef struct {
+	ProjectRef `yaml:",inline" bson:",inline"`
+}
+
+var (
+	// bson fields for the RepoRef struct
+	RepoRefIdentifierKey          = bsonutil.MustHaveTag(RepoRef{}, "Identifier")
+	RepoRefOwnerKey               = bsonutil.MustHaveTag(RepoRef{}, "Owner")
+	RepoRefRepoKey                = bsonutil.MustHaveTag(RepoRef{}, "Repo")
+	RepoRefEnabledKey             = bsonutil.MustHaveTag(RepoRef{}, "Enabled")
+	RepoRefPrivateKey             = bsonutil.MustHaveTag(RepoRef{}, "Private")
+	RepoRefRestrictedKey          = bsonutil.MustHaveTag(RepoRef{}, "Restricted")
+	RepoRefDisplayNameKey         = bsonutil.MustHaveTag(RepoRef{}, "DisplayName")
+	RepoRefRemotePathKey          = bsonutil.MustHaveTag(RepoRef{}, "RemotePath")
+	RepoRefAdminsKey              = bsonutil.MustHaveTag(RepoRef{}, "Admins")
+	RepoRefPRTestingEnabledKey    = bsonutil.MustHaveTag(RepoRef{}, "PRTestingEnabled")
+	RepoRefRepotrackerDisabledKey = bsonutil.MustHaveTag(RepoRef{}, "RepotrackerDisabled")
+	RepoRefDispatchingDisabledKey = bsonutil.MustHaveTag(RepoRef{}, "DispatchingDisabled")
+	RepoRefPatchingDisabledKey    = bsonutil.MustHaveTag(RepoRef{}, "PatchingDisabled")
+	RepoRefSpawnHostScriptPathKey = bsonutil.MustHaveTag(RepoRef{}, "SpawnHostScriptPath")
+)
+
+func (RepoRef *RepoRef) Insert() error {
+	return db.Insert(RepoRefCollection, RepoRef)
+}
+
+func (RepoRef *RepoRef) Update() error {
+	return db.Update(
+		RepoRefCollection,
+		bson.M{
+			RepoRefIdentifierKey: RepoRef.Identifier,
+		},
+		RepoRef,
+	)
+}
+
+// Upsert updates the project ref in the db if an entry already exists,
+// overwriting the existing ref. If no project ref exists, one is created
+func (RepoRef *RepoRef) Upsert() error {
+	_, err := db.Upsert(
+		RepoRefCollection,
+		bson.M{
+			RepoRefIdentifierKey: RepoRef.Identifier,
+		},
+		bson.M{
+			"$set": bson.M{
+				RepoRefEnabledKey:             RepoRef.Enabled,
+				RepoRefPrivateKey:             RepoRef.Private,
+				RepoRefRestrictedKey:          RepoRef.Restricted,
+				RepoRefOwnerKey:               RepoRef.Owner,
+				RepoRefRepoKey:                RepoRef.Repo,
+				RepoRefDisplayNameKey:         RepoRef.DisplayName,
+				RepoRefRemotePathKey:          RepoRef.RemotePath,
+				RepoRefAdminsKey:              RepoRef.Admins,
+				RepoRefPRTestingEnabledKey:    RepoRef.PRTestingEnabled,
+				RepoRefPatchingDisabledKey:    RepoRef.PatchingDisabled,
+				RepoRefRepotrackerDisabledKey: RepoRef.RepotrackerDisabled,
+				RepoRefDispatchingDisabledKey: RepoRef.DispatchingDisabled,
+				RepoRefSpawnHostScriptPathKey: RepoRef.SpawnHostScriptPath,
+			},
+		},
+	)
+	return err
+}
+
+// FindOne returns one RepoRef that satisfies the query.
+func FindOne(query db.Q) (*RepoRef, error) {
+	repoRef := &RepoRef{}
+	err := db.FindOneQ(RepoRefCollection, query, repoRef)
+	if adb.ResultsNotFound(err) {
+		return nil, nil
+	}
+	return repoRef, err
+}
+
+// FindOneRepoRef gets a project ref given the owner name, the repo
+// name and the project name
+func FindOneRepoRef(identifier string) (*RepoRef, error) {
+	return FindOne(db.Query(bson.M{
+		RepoRefIdentifierKey: identifier,
+	}))
+}
+
+// FindRepoRefsByRepoAndBranch finds RepoRefs with matching repo/branch
+// that are enabled and setup for PR testing
+func FindRepoRefByOwnerAndRepo(owner, repoName string) (*RepoRef, error) {
+	return FindOne(db.Query(bson.M{
+		RepoRefOwnerKey: owner,
+		RepoRefRepoKey:  repoName,
+	}))
+}


### PR DESCRIPTION
This is to kick off Projects Track Multiple Branches. Because project ref is used in so many places with so many assumptions, in the design we chose to go forward with a different collection for repo configuration documents to avoid introducing bugs / major refactors. I re-arranged the project ref document to be clearer.