### PR TITLE
EVG-13249 be sure to increment executions when restarting

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -405,12 +405,14 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 	}
 	// archive all the finished tasks
 	startPhaseAt = time.Now()
+	toArchive := []task.Task{}
 	for _, t := range finishedTasks {
 		if !t.IsPartOfSingleHostTaskGroup() { // for single host task groups we don't archive until fully restarting
-			if err = t.Archive(); err != nil {
-				return errors.Wrap(err, "failed to archive task")
-			}
+			toArchive = append(toArchive, t)
 		}
+	}
+	if err = task.ArchiveMany(toArchive); err != nil {
+		return errors.Wrap(err, "unable to archive tasks")
 	}
 	grip.Info(message.Fields{
 		"message":       "Archive finished tasks",
@@ -550,6 +552,7 @@ func restartTasksForBuild(buildId string, tasks []task.Task, caller string) erro
 	// maps task group to a single task in the group so we only check once
 	taskGroupsToCheck := map[string]task.Task{}
 	restartIds := []string{}
+	toArchive := []task.Task{}
 	for _, t := range tasks {
 		if t.IsPartOfSingleHostTaskGroup() {
 			if err := t.SetResetWhenFinished(); err != nil {
@@ -562,11 +565,12 @@ func restartTasksForBuild(buildId string, tasks []task.Task, caller string) erro
 				restartIds = append(restartIds, t.ExecutionTasks...)
 			}
 			if t.IsFinished() {
-				if err := t.Archive(); err != nil {
-					return errors.Wrapf(err, "error archiving task '%s'", t.Id)
-				}
+				toArchive = append(toArchive, t)
 			}
 		}
+	}
+	if err := task.ArchiveMany(toArchive); err != nil {
+		return errors.Wrap(err, "unable to archive tasks")
 	}
 	// Set all the task fields to indicate restarted
 	if err := MarkTasksReset(restartIds); err != nil {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tychoish/tarjan"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/simple"
 	"gonum.org/v1/gonum/graph/topo"
@@ -1694,26 +1695,18 @@ func (t *Task) Insert() error {
 
 // Inserts the task into the old_tasks collection
 func (t *Task) Archive() error {
-	if t.DisplayOnly {
-		for _, et := range t.ExecutionTasks {
-			execTask, err := FindOne(ById(et))
-			if err != nil {
-				return errors.Wrap(err, "error retrieving execution task")
-			}
-			if execTask == nil {
-				return errors.Errorf("unable to find execution task '%s' from display task '%s'", et, t.Id)
-			}
-			if err = execTask.Archive(); err != nil {
-				return errors.Wrap(err, "error archiving execution task")
-			}
+	if t.DisplayOnly && len(t.ExecutionTasks) > 0 {
+		execTasks, err := FindAll(ByIds(t.ExecutionTasks))
+		if err != nil {
+			return errors.Wrap(err, "error retrieving execution tasks")
+		}
+		if err = ArchiveMany(execTasks); err != nil {
+			return errors.Wrap(err, "error archiving execution tasks")
 		}
 	}
 
-	archiveTask := *t
-	archiveTask.Id = MakeOldID(t.Id, t.Execution)
-	archiveTask.OldTaskId = t.Id
-	archiveTask.Archived = true
-	err := db.Insert(OldCollection, &archiveTask)
+	archiveTask := t.makeArchivedTask()
+	err := db.Insert(OldCollection, archiveTask)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"archive_task_id": archiveTask.Id,
@@ -1747,6 +1740,109 @@ func (t *Task) Archive() error {
 		return errors.Wrap(err, "unable to update host event logs")
 	}
 	return nil
+}
+
+func ArchiveMany(tasks []Task) error {
+	if len(tasks) == 0 {
+		return nil
+	}
+	// add execution tasks of display tasks passed in, if they are not there
+	execTaskMap := map[string]bool{}
+	for _, t := range tasks {
+		execTaskMap[t.Id] = true
+	}
+	additionalTasks := []string{}
+	for _, t := range tasks {
+		// for any display tasks here, make sure that we archive all their execution tasks
+		for _, et := range t.ExecutionTasks {
+			if !execTaskMap[et] {
+				additionalTasks = append(additionalTasks, t.ExecutionTasks...)
+				continue
+			}
+		}
+	}
+	if len(additionalTasks) > 0 {
+		toAdd, err := FindAll(ByIds((additionalTasks)))
+		if err != nil {
+			return errors.Wrap(err, "unable to find execution tasks")
+		}
+		tasks = append(tasks, toAdd...)
+	}
+
+	archived := []interface{}{}
+	taskIds := []string{}
+	for _, t := range tasks {
+		archived = append(archived, *t.makeArchivedTask())
+		taskIds = append(taskIds, t.Id)
+	}
+
+	mongoClient := evergreen.GetEnvironment().Client()
+	ctx, cancel := evergreen.GetEnvironment().Context()
+	defer cancel()
+	session, err := mongoClient.StartSession()
+	if err != nil {
+		return errors.Wrap(err, "unable to start session")
+	}
+	defer session.EndSession(ctx)
+
+	txFunc := func(sessCtx mongo.SessionContext) (interface{}, error) {
+		oldTaskColl := evergreen.GetEnvironment().DB().Collection(OldCollection)
+		_, err = oldTaskColl.InsertMany(ctx, archived)
+		if err != nil {
+			return nil, err
+		}
+
+		taskColl := evergreen.GetEnvironment().DB().Collection(Collection)
+		_, err = taskColl.UpdateMany(ctx, bson.M{
+			IdKey: bson.M{
+				"$in": taskIds,
+			},
+		},
+			bson.M{
+				"$unset": bson.M{
+					AbortedKey:   "",
+					AbortInfoKey: "",
+				},
+			})
+		if err != nil {
+			return nil, err
+		}
+		_, err = taskColl.UpdateMany(ctx, bson.M{
+			IdKey: bson.M{
+				"$in": taskIds,
+			},
+			RestartsKey: bson.M{
+				"$gt": 0,
+			},
+		},
+			bson.M{
+				"$inc": bson.M{
+					RestartsKey: 1,
+				},
+			})
+		return nil, err
+	}
+
+	_, err = session.WithTransaction(ctx, txFunc)
+	if err != nil {
+		return errors.Wrap(err, "unable to archive tasks")
+	}
+
+	eventLogErrs := grip.NewBasicCatcher()
+	for _, t := range tasks {
+		eventLogErrs.Add(event.UpdateExecutions(t.HostId, t.Id, t.Execution))
+	}
+
+	return eventLogErrs.Resolve()
+}
+
+func (t *Task) makeArchivedTask() *Task {
+	archiveTask := *t
+	archiveTask.Id = MakeOldID(t.Id, t.Execution)
+	archiveTask.OldTaskId = t.Id
+	archiveTask.Archived = true
+
+	return &archiveTask
 }
 
 // Aggregation

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1803,6 +1803,9 @@ func ArchiveMany(tasks []Task) error {
 					AbortedKey:   "",
 					AbortInfoKey: "",
 				},
+				"$inc": bson.M{
+					ExecutionKey: 1,
+				},
 			})
 		if err != nil {
 			return nil, err

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2181,6 +2181,7 @@ func TestArchiveMany(t *testing.T) {
 	assert.Len(t, currentTasks, 4)
 	for _, task := range currentTasks {
 		assert.False(t, task.Aborted)
+		assert.Equal(t, 1, task.Execution)
 		if task.Id == t2.Id {
 			assert.Equal(t, 3, task.Restarts)
 		}
@@ -2190,6 +2191,7 @@ func TestArchiveMany(t *testing.T) {
 	assert.Len(t, oldTasks, 4)
 	for _, task := range oldTasks {
 		assert.True(t, task.Archived)
+		assert.Equal(t, 0, task.Execution)
 	}
 }
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2143,6 +2143,56 @@ func TestGetLatestExecution(t *testing.T) {
 	assert.Equal(t, sample.Execution, execution)
 }
 
+func TestArchiveMany(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection, OldCollection))
+	t1 := Task{
+		Id:      "t1",
+		Status:  evergreen.TaskFailed,
+		Aborted: true,
+		Version: "v",
+	}
+	assert.NoError(t, t1.Insert())
+	t2 := Task{
+		Id:       "t2",
+		Status:   evergreen.TaskFailed,
+		Aborted:  true,
+		Restarts: 2,
+		Version:  "v",
+	}
+	assert.NoError(t, t2.Insert())
+	dt := Task{
+		Id:             "dt",
+		DisplayOnly:    true,
+		ExecutionTasks: []string{"et"},
+		Version:        "v",
+	}
+	assert.NoError(t, dt.Insert())
+	et := Task{
+		Id:      "et",
+		Version: "v",
+	}
+	assert.NoError(t, et.Insert())
+
+	tasks := []Task{t1, t2, dt}
+	err := ArchiveMany(tasks)
+	assert.NoError(t, err)
+	currentTasks, err := FindAll(ByVersion("v"))
+	assert.NoError(t, err)
+	assert.Len(t, currentTasks, 4)
+	for _, task := range currentTasks {
+		assert.False(t, task.Aborted)
+		if task.Id == t2.Id {
+			assert.Equal(t, 3, task.Restarts)
+		}
+	}
+	oldTasks, err := FindAllOld(ByVersion("v"))
+	assert.NoError(t, err)
+	assert.Len(t, oldTasks, 4)
+	for _, task := range oldTasks {
+		assert.True(t, task.Archived)
+	}
+}
+
 func TestAddParentDisplayTasks(t *testing.T) {
 	assert.NoError(t, db.Clear(Collection))
 	dt1 := Task{


### PR DESCRIPTION
The bulk archive function is supposed to mirror the singular one for the most part, but I forgot to [increment the execution](https://github.com/evergreen-ci/evergreen/blob/94a4db5abec79533344b6cf1574d864efce651f3/model/task/task.go#L1730). This means that after the deploy, if you restart a version or build, we actually overwrite the existing execution data when it executions again. We also add a copy to the old collection. If you try and restart a task that was affected by this, you hit the duplicate key error because we already archived this execution