### PR TITLE
EVG-7256 send users notification for enqueue cq patch failures

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -114,6 +114,7 @@ const (
 	MergeTestStarted   = "started"
 	MergeTestSucceeded = "succeeded"
 	MergeTestFailed    = "failed"
+	EnqueueFailed      = "failed to enqueue"
 
 	// maximum task (zero based) execution number
 	MaxTaskExecution = 9

--- a/model/event/commit_queue_event.go
+++ b/model/event/commit_queue_event.go
@@ -13,9 +13,10 @@ func commitQueueEventDataFactory() interface{} {
 }
 
 const (
-	ResourceTypeCommitQueue = "COMMIT_QUEUE"
-	CommitQueueStartTest    = "START_TEST"
-	CommitQueueConcludeTest = "CONCLUDE_TEST"
+	ResourceTypeCommitQueue  = "COMMIT_QUEUE"
+	CommitQueueEnqueueFailed = "ENQUEUE_FAILED"
+	CommitQueueStartTest     = "START_TEST"
+	CommitQueueConcludeTest  = "CONCLUDE_TEST"
 )
 
 type PRInfo struct {
@@ -47,6 +48,7 @@ func logCommitQueueEvent(patchID, eventType string, data *CommitQueueEventData) 
 
 type CommitQueueEventData struct {
 	Status string `bson:"status,omitempty" json:"status,omitempty"`
+	Error  string `bson:"error,omitempty" json:"error,omitempty"`
 }
 
 func LogCommitQueueStartTestEvent(patchID string) {
@@ -61,4 +63,13 @@ func LogCommitQueueConcludeTest(patchID, status string) {
 		Status: status,
 	}
 	logCommitQueueEvent(patchID, CommitQueueConcludeTest, data)
+}
+
+func LogCommitQueueEnqueueFailed(patchID string, err error) {
+	data := &CommitQueueEventData{
+		Status: evergreen.EnqueueFailed,
+		Error:  err.Error(),
+	}
+	logCommitQueueEvent(patchID, CommitQueueEnqueueFailed, data)
+
 }

--- a/model/event/event_registry.go
+++ b/model/event/event_registry.go
@@ -31,6 +31,7 @@ func init() {
 	registry.AddType(ResourceTypeCommitQueue, commitQueueEventDataFactory)
 	registry.AllowSubscription(ResourceTypeCommitQueue, CommitQueueStartTest)
 	registry.AllowSubscription(ResourceTypeCommitQueue, CommitQueueConcludeTest)
+	registry.AllowSubscription(ResourceTypeCommitQueue, CommitQueueEnqueueFailed)
 }
 
 // AddType adds an event data factory to the registry with the given resource


### PR DESCRIPTION
Users will only get this notification if they're subscribed to commit queue notifications. Examples below (I changed "enqueue-failed" to "failed to enqueue" though)
**Slack:**
![image](https://user-images.githubusercontent.com/26798134/98271861-3eb22980-1f45-11eb-8b3f-02d77256227e.png)

**Email:**
![image](https://user-images.githubusercontent.com/26798134/98271907-496cbe80-1f45-11eb-9df4-392c321107ec.png)
