### PR TITLE
EVG-13239: remove agent's hard dependency on distro document

### DIFF
--- a/agent/command/git_patch_test.go
+++ b/agent/command/git_patch_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	agentutil "github.com/evergreen-ci/evergreen/agent/internal/testutil"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
@@ -47,7 +48,7 @@ func TestPatchPluginAPI(t *testing.T) {
 		taskConfig, err := agentutil.MakeTaskConfigFromModelData(settings, modelData)
 		require.NoError(t, err)
 		taskConfig.Expansions = util.NewExpansions(settings.Credentials)
-		taskConfig.Distro = &distro.Distro{CloneMethod: distro.CloneMethodOAuth}
+		taskConfig.Distro = &apimodels.DistroView{CloneMethod: distro.CloneMethodOAuth}
 
 		err = setupTestPatchData(modelData, patchFile, t)
 		require.NoError(t, err, "Couldn't set up test documents")
@@ -121,7 +122,7 @@ func TestPatchPlugin(t *testing.T) {
 		taskConfig, err := agentutil.MakeTaskConfigFromModelData(settings, modelData)
 		require.NoError(t, err)
 		taskConfig.Expansions = util.NewExpansions(settings.Credentials)
-		taskConfig.Distro = &distro.Distro{CloneMethod: distro.CloneMethodOAuth}
+		taskConfig.Distro = &apimodels.DistroView{CloneMethod: distro.CloneMethodOAuth}
 
 		err = setupTestPatchData(modelData, patchFile, t)
 		require.NoError(t, err, "Couldn't set up patch documents")

--- a/agent/command/git_push_test.go
+++ b/agent/command/git_push_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/patch"
@@ -36,7 +37,7 @@ func TestGitPush(t *testing.T) {
 	conf := &internal.TaskConfig{
 		Task:       &task.Task{},
 		ProjectRef: &model.ProjectRef{Branch: "master"},
-		Distro:     &distro.Distro{CloneMethod: distro.CloneMethodOAuth},
+		Distro:     &apimodels.DistroView{CloneMethod: distro.CloneMethodOAuth},
 		Expansions: &util.Expansions{},
 	}
 	logger, err := comm.GetLoggerProducer(context.Background(), client.TaskData{}, nil)

--- a/agent/command/testdata/attach/plugin_attach_results.yml
+++ b/agent/command/testdata/attach/plugin_attach_results.yml
@@ -3,7 +3,7 @@ tasks:
       commands:
         - command: attach.results
           params:
-              file_location: "command/testdata/attach/plugin_attach_results.json"
+              file_location: "agent/command/testdata/attach/plugin_attach_results.json"
 
 buildvariants:
 - name: linux-64

--- a/agent/command/testdata/attach/plugin_attach_results_raw.yml
+++ b/agent/command/testdata/attach/plugin_attach_results_raw.yml
@@ -3,7 +3,7 @@ tasks:
       commands:
         - command: attach.results
           params:
-              file_location: "command/testdata/attach/plugin_attach_results_raw.json"
+              file_location: "agent/command/testdata/attach/plugin_attach_results_raw.json"
 
 buildvariants:
 - name: linux-64

--- a/agent/command/testdata/attach/plugin_attach_xunit.yml
+++ b/agent/command/testdata/attach/plugin_attach_xunit.yml
@@ -3,14 +3,14 @@ tasks:
   commands:
   - command: attach.xunit_results
     params:
-      file: "command/testdata/xunit/junit_${file_num}.xml" #junit_3.xml
+      file: "agent/command/testdata/xunit/junit_${file_num}.xml" #junit_3.xml
   - command: attach.xunit_results
     params:
       files:
-        - "command/testdata/xunit/junit_1.xml"
-        - "command/testdata/xunit/junit_2.xml"
-        - "command/testdata/xunit/junit_3.xml"
-        - "command/testdata/xunit/junit_4.xml"
+        - "agent/command/testdata/xunit/junit_1.xml"
+        - "agent/command/testdata/xunit/junit_2.xml"
+        - "agent/command/testdata/xunit/junit_3.xml"
+        - "agent/command/testdata/xunit/junit_4.xml"
 
 buildvariants:
 - name: linux-64

--- a/agent/command/testdata/attach/plugin_attach_xunit_wildcard.yml
+++ b/agent/command/testdata/attach/plugin_attach_xunit_wildcard.yml
@@ -3,7 +3,7 @@ tasks:
   commands:
   - command: attach.xunit_results
     params:
-      file: "command/testdata/xunit/junit_*.xml"
+      file: "agent/command/testdata/xunit/junit_*.xml"
 
 buildvariants:
 - name: linux-64

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/thirdparty"
@@ -17,7 +17,7 @@ import (
 )
 
 type TaskConfig struct {
-	Distro               *distro.Distro
+	Distro               *apimodels.DistroView
 	ProjectRef           *model.ProjectRef
 	Project              *model.Project
 	Task                 *task.Task
@@ -62,7 +62,7 @@ func (t *TaskConfig) GetExecTimeout() int {
 	return t.Timeout.ExecTimeoutSecs
 }
 
-func NewTaskConfig(d *distro.Distro, p *model.Project, t *task.Task, r *model.ProjectRef, patchDoc *patch.Patch, e util.Expansions) (*TaskConfig, error) {
+func NewTaskConfig(d *apimodels.DistroView, p *model.Project, t *task.Task, r *model.ProjectRef, patchDoc *patch.Patch, e util.Expansions) (*TaskConfig, error) {
 	// do a check on if the project is empty
 	if p == nil {
 		return nil, errors.Errorf("project for task with project_id %v is empty", t.Project)

--- a/agent/internal/testutil/task_config.go
+++ b/agent/internal/testutil/task_config.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/testutil"
 	"github.com/pkg/errors"
@@ -18,7 +19,14 @@ func MakeTaskConfigFromModelData(settings *evergreen.Settings, data *testutil.Te
 	if err != nil {
 		return nil, errors.Wrap(err, "error populating expansions")
 	}
-	config, err := internal.NewTaskConfig(&data.Host.Distro, data.Project, data.Task, data.ProjectRef, nil, exp)
+	var dv *apimodels.DistroView
+	if data.Host != nil {
+		dv = &apimodels.DistroView{
+			CloneMethod: data.Host.Distro.CloneMethod,
+			WorkDir:     data.Host.Distro.WorkDir,
+		}
+	}
+	config, err := internal.NewTaskConfig(dv, data.Project, data.Task, data.ProjectRef, nil, exp)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not make task config from test model data")
 	}

--- a/agent/task.go
+++ b/agent/task.go
@@ -341,11 +341,6 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	if err != nil {
 		return nil, err
 	}
-	// kim: TODO: remove
-	// confDistro, err := a.comm.GetDistro(ctx, tc.task)
-	// if err != nil {
-	//     return nil, err
-	// }
 
 	grip.Info("Fetching project ref.")
 	confRef, err := a.comm.GetProjectRef(ctx, tc.task)

--- a/agent/task.go
+++ b/agent/task.go
@@ -336,11 +336,16 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 			return nil, err
 		}
 	}
-	grip.Info("Fetching distro configuration.")
-	confDistro, err := a.comm.GetDistro(ctx, tc.task)
+	grip.Info("Fetching distro view configuration.")
+	confDistro, err := a.comm.GetDistroView(ctx, tc.task)
 	if err != nil {
 		return nil, err
 	}
+	// kim: TODO: remove
+	// confDistro, err := a.comm.GetDistro(ctx, tc.task)
+	// if err != nil {
+	//     return nil, err
+	// }
 
 	grip.Info("Fetching project ref.")
 	confRef, err := a.comm.GetProjectRef(ctx, tc.task)

--- a/agent/task.go
+++ b/agent/task.go
@@ -336,7 +336,7 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 			return nil, err
 		}
 	}
-	grip.Info("Fetching distro view configuration.")
+	grip.Info("Fetching distro configuration.")
 	confDistro, err := a.comm.GetDistroView(ctx, tc.task)
 	if err != nil {
 		return nil, err

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -297,3 +297,11 @@ type GeneratePollResponse struct {
 	Finished bool     `json:"finished"`
 	Errors   []string `json:"errors"`
 }
+
+// DistroView represents the view of data that the agent uses from the distro
+// it is running on.
+type DistroView struct {
+	CloneMethod         string `json:"clone_method"`
+	DisableShallowClone bool   `json:"disable_shallow_clone"`
+	WorkDir             string `json:"work_dir"`
+}

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2020-10-19"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-11-06v2"
+	AgentVersion = "2020-11-09"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2020-10-19"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-11-06"
+	AgentVersion = "2020-11-06v2"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -64,10 +64,7 @@ type Communicator interface {
 	GetDisplayTaskNameFromExecution(context.Context, TaskData) (string, error)
 	// GetProjectRef loads the task's project ref.
 	GetProjectRef(context.Context, TaskData) (*model.ProjectRef, error)
-	// kim: TODO: remove
-	// GetDistro returns the distro for the task.
-	// GetDistro(context.Context, TaskData) (*distro.Distro, error)
-	// GetDistroInfo returns the view of the distro information for the task.
+	// GetDistroView returns the view of the distro information for the task.
 	GetDistroView(context.Context, TaskData) (*apimodels.DistroView, error)
 	// GetDistroAMI gets the AMI for the given distro/region
 	GetDistroAMI(context.Context, string, string, TaskData) (string, error)

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/artifact"
-	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/manifest"
@@ -65,8 +64,11 @@ type Communicator interface {
 	GetDisplayTaskNameFromExecution(context.Context, TaskData) (string, error)
 	// GetProjectRef loads the task's project ref.
 	GetProjectRef(context.Context, TaskData) (*model.ProjectRef, error)
+	// kim: TODO: remove
 	// GetDistro returns the distro for the task.
-	GetDistro(context.Context, TaskData) (*distro.Distro, error)
+	// GetDistro(context.Context, TaskData) (*distro.Distro, error)
+	// GetDistroInfo returns the view of the distro information for the task.
+	GetDistroView(context.Context, TaskData) (*apimodels.DistroView, error)
 	// GetDistroAMI gets the AMI for the given distro/region
 	GetDistroAMI(context.Context, string, string, TaskData) (string, error)
 	// GetProject loads the project using the task's version ID

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -204,7 +204,7 @@ func (c *communicatorImpl) GetDistroView(ctx context.Context, taskData TaskData)
 		return nil, errors.New("conflict; wrong secret")
 	}
 	var dv apimodels.DistroView
-	if err = utility.ReadJSON(resp.Body, dv); err != nil {
+	if err = utility.ReadJSON(resp.Body, &dv); err != nil {
 		err = errors.Wrapf(err, "unable to read distro response for task %s", taskData.ID)
 		return nil, err
 	}

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -193,7 +193,7 @@ func (c *communicatorImpl) GetDistroView(ctx context.Context, taskData TaskData)
 		taskData: &taskData,
 		version:  apiVersion1,
 	}
-	info.setTaskPathSuffix("distro")
+	info.setTaskPathSuffix("distro_view")
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to get distro for task %s", taskData.ID)

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -187,32 +187,6 @@ func (c *communicatorImpl) GetProjectRef(ctx context.Context, taskData TaskData)
 	return projectRef, nil
 }
 
-// kim: TODO: remove
-// // GetDistro returns the distro for the task.
-// func (c *communicatorImpl) GetDistro(ctx context.Context, taskData TaskData) (*distro.Distro, error) {
-//     d := &distro.Distro{}
-//     info := requestInfo{
-//         method:   get,
-//         taskData: &taskData,
-//         version:  apiVersion1,
-//     }
-//     info.setTaskPathSuffix("distro")
-//     resp, err := c.retryRequest(ctx, info, nil)
-//     if err != nil {
-//         err = errors.Wrapf(err, "failed to get distro for task %s", taskData.ID)
-//         return nil, err
-//     }
-//     defer resp.Body.Close()
-//     if resp.StatusCode == http.StatusConflict {
-//         return nil, errors.New("conflict; wrong secret")
-//     }
-//     if err = utility.ReadJSON(resp.Body, d); err != nil {
-//         err = errors.Wrapf(err, "unable to read distro response for task %s", taskData.ID)
-//         return nil, err
-//     }
-//     return d, nil
-// }
-
 func (c *communicatorImpl) GetDistroView(ctx context.Context, taskData TaskData) (*apimodels.DistroView, error) {
 	info := requestInfo{
 		method:   get,

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/artifact"
-	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/manifest"
 	patchmodel "github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -188,9 +187,33 @@ func (c *communicatorImpl) GetProjectRef(ctx context.Context, taskData TaskData)
 	return projectRef, nil
 }
 
-// GetDistro returns the distro for the task.
-func (c *communicatorImpl) GetDistro(ctx context.Context, taskData TaskData) (*distro.Distro, error) {
-	d := &distro.Distro{}
+// kim: TODO: remove
+// // GetDistro returns the distro for the task.
+// func (c *communicatorImpl) GetDistro(ctx context.Context, taskData TaskData) (*distro.Distro, error) {
+//     d := &distro.Distro{}
+//     info := requestInfo{
+//         method:   get,
+//         taskData: &taskData,
+//         version:  apiVersion1,
+//     }
+//     info.setTaskPathSuffix("distro")
+//     resp, err := c.retryRequest(ctx, info, nil)
+//     if err != nil {
+//         err = errors.Wrapf(err, "failed to get distro for task %s", taskData.ID)
+//         return nil, err
+//     }
+//     defer resp.Body.Close()
+//     if resp.StatusCode == http.StatusConflict {
+//         return nil, errors.New("conflict; wrong secret")
+//     }
+//     if err = utility.ReadJSON(resp.Body, d); err != nil {
+//         err = errors.Wrapf(err, "unable to read distro response for task %s", taskData.ID)
+//         return nil, err
+//     }
+//     return d, nil
+// }
+
+func (c *communicatorImpl) GetDistroView(ctx context.Context, taskData TaskData) (*apimodels.DistroView, error) {
 	info := requestInfo{
 		method:   get,
 		taskData: &taskData,
@@ -206,11 +229,12 @@ func (c *communicatorImpl) GetDistro(ctx context.Context, taskData TaskData) (*d
 	if resp.StatusCode == http.StatusConflict {
 		return nil, errors.New("conflict; wrong secret")
 	}
-	if err = utility.ReadJSON(resp.Body, d); err != nil {
+	var dv apimodels.DistroView
+	if err = utility.ReadJSON(resp.Body, dv); err != nil {
 		err = errors.Wrapf(err, "unable to read distro response for task %s", taskData.ID)
 		return nil, err
 	}
-	return d, nil
+	return &dv, nil
 }
 
 // GetDistroAMI returns the distro for the task.

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -176,15 +176,6 @@ func (c *Mock) GetProjectRef(ctx context.Context, td TaskData) (*serviceModel.Pr
 	}, nil
 }
 
-// kim: TODO: remove
-// GetDistro returns a mock Distro.
-// func (c *Mock) GetDistro(ctx context.Context, td TaskData) (*distro.Distro, error) {
-//     return &distro.Distro{
-//         Id:      "mock_distro_id",
-//         WorkDir: ".",
-//     }, nil
-// }
-
 func (c *Mock) GetDistroView(context.Context, TaskData) (*apimodels.DistroView, error) {
 	return &apimodels.DistroView{
 		WorkDir: ".",

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -15,7 +15,6 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	serviceModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/artifact"
-	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/manifest"
@@ -177,10 +176,17 @@ func (c *Mock) GetProjectRef(ctx context.Context, td TaskData) (*serviceModel.Pr
 	}, nil
 }
 
+// kim: TODO: remove
 // GetDistro returns a mock Distro.
-func (c *Mock) GetDistro(ctx context.Context, td TaskData) (*distro.Distro, error) {
-	return &distro.Distro{
-		Id:      "mock_distro_id",
+// func (c *Mock) GetDistro(ctx context.Context, td TaskData) (*distro.Distro, error) {
+//     return &distro.Distro{
+//         Id:      "mock_distro_id",
+//         WorkDir: ".",
+//     }, nil
+// }
+
+func (c *Mock) GetDistroView(context.Context, TaskData) (*apimodels.DistroView, error) {
+	return &apimodels.DistroView{
 		WorkDir: ".",
 	}, nil
 }

--- a/service/api.go
+++ b/service/api.go
@@ -588,7 +588,7 @@ func (as *APIServer) GetServiceApp() *gimlet.APIApp {
 	app.Route().Version(2).Route("/task/{taskId}/files").Wrap(checkTask, checkHost).Handler(as.AttachFiles).Post()
 	// TODO (EVG-13239): remove this route once agents have updated.
 	app.Route().Version(2).Route("/task/{taskId}/distro").Wrap(checkTask).Handler(as.GetDistro).Get()
-	app.Route().Version(2).Route("/task/{taskId}/distro_info").Wrap(checkTask).Handler(as.GetDistroView).Get()
+	app.Route().Version(2).Route("/task/{taskId}/distro_view").Wrap(checkTask).Handler(as.GetDistroView).Get()
 	app.Route().Version(2).Route("/task/{taskId}/parser_project").Wrap(checkTask).Handler(as.GetParserProject).Get()
 	app.Route().Version(2).Route("/task/{taskId}/project_ref").Wrap(checkTask).Handler(as.GetProjectRef).Get()
 	app.Route().Version(2).Route("/task/{taskId}/expansions").Wrap(checkTask, checkHost).Handler(as.GetExpansions).Get()

--- a/service/api.go
+++ b/service/api.go
@@ -586,7 +586,9 @@ func (as *APIServer) GetServiceApp() *gimlet.APIApp {
 	app.Route().Version(2).Route("/task/{taskId}/results").Wrap(checkTaskSecret, checkHost).Handler(as.AttachResults).Post()
 	app.Route().Version(2).Route("/task/{taskId}/test_logs").Wrap(checkTaskSecret, checkHost).Handler(as.AttachTestLog).Post()
 	app.Route().Version(2).Route("/task/{taskId}/files").Wrap(checkTask, checkHost).Handler(as.AttachFiles).Post()
+	// TODO (EVG-13239): remove this route once agents have updated.
 	app.Route().Version(2).Route("/task/{taskId}/distro").Wrap(checkTask).Handler(as.GetDistro).Get()
+	app.Route().Version(2).Route("/task/{taskId}/distro_info").Wrap(checkTask).Handler(as.GetDistroView).Get()
 	app.Route().Version(2).Route("/task/{taskId}/parser_project").Wrap(checkTask).Handler(as.GetParserProject).Get()
 	app.Route().Version(2).Route("/task/{taskId}/project_ref").Wrap(checkTask).Handler(as.GetProjectRef).Get()
 	app.Route().Version(2).Route("/task/{taskId}/expansions").Wrap(checkTask, checkHost).Handler(as.GetExpansions).Get()

--- a/service/api.go
+++ b/service/api.go
@@ -588,7 +588,7 @@ func (as *APIServer) GetServiceApp() *gimlet.APIApp {
 	app.Route().Version(2).Route("/task/{taskId}/files").Wrap(checkTask, checkHost).Handler(as.AttachFiles).Post()
 	// TODO (EVG-13239): remove this route once agents have updated.
 	app.Route().Version(2).Route("/task/{taskId}/distro").Wrap(checkTask).Handler(as.GetDistro).Get()
-	app.Route().Version(2).Route("/task/{taskId}/distro_view").Wrap(checkTask).Handler(as.GetDistroView).Get()
+	app.Route().Version(2).Route("/task/{taskId}/distro_view").Wrap(checkTask, checkHost).Handler(as.GetDistroView).Get()
 	app.Route().Version(2).Route("/task/{taskId}/parser_project").Wrap(checkTask).Handler(as.GetParserProject).Get()
 	app.Route().Version(2).Route("/task/{taskId}/project_ref").Wrap(checkTask).Handler(as.GetProjectRef).Get()
 	app.Route().Version(2).Route("/task/{taskId}/expansions").Wrap(checkTask, checkHost).Handler(as.GetExpansions).Get()

--- a/service/api_distro.go
+++ b/service/api_distro.go
@@ -33,18 +33,7 @@ func (as *APIServer) GetDistro(w http.ResponseWriter, r *http.Request) {
 }
 
 func (as *APIServer) GetDistroView(w http.ResponseWriter, r *http.Request) {
-	t := MustHaveTask(r)
-
-	h, err := host.FindOne(host.ByRunningTaskId(t.Id))
-	if err != nil {
-		as.LoggedError(w, r, http.StatusInternalServerError, err)
-		return
-	}
-	if h == nil {
-		message := fmt.Errorf("No host found running task %v", t.Id)
-		as.LoggedError(w, r, http.StatusInternalServerError, message)
-		return
-	}
+	h := MustHaveHost(r)
 
 	dv := apimodels.DistroView{
 		CloneMethod:         h.Distro.CloneMethod,

--- a/service/api_distro.go
+++ b/service/api_distro.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/gimlet"
 )
 
+// TODO (EVG-13239): remove once agents have updated.
 // GetDistro loads the task's distro and sends it to the requester.
 func (as *APIServer) GetDistro(w http.ResponseWriter, r *http.Request) {
 	t := MustHaveTask(r)
@@ -28,4 +30,26 @@ func (as *APIServer) GetDistro(w http.ResponseWriter, r *http.Request) {
 	// agent can't properly unmarshal provider settings
 	h.Distro.ProviderSettingsList = nil
 	gimlet.WriteJSON(w, h.Distro)
+}
+
+func (as *APIServer) GetDistroView(w http.ResponseWriter, r *http.Request) {
+	t := MustHaveTask(r)
+
+	h, err := host.FindOne(host.ByRunningTaskId(t.Id))
+	if err != nil {
+		as.LoggedError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	if h == nil {
+		message := fmt.Errorf("No host found running task %v", t.Id)
+		as.LoggedError(w, r, http.StatusInternalServerError, message)
+		return
+	}
+
+	dv := apimodels.DistroView{
+		CloneMethod:         h.Distro.CloneMethod,
+		DisableShallowClone: h.Distro.DisableShallowClone,
+		WorkDir:             h.Distro.WorkDir,
+	}
+	gimlet.WriteJSON(w, dv)
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13239

The agent and its commands only use a small number of fields from the distro document, so I changed it to pass only the fields it needs rather than the entire distro. I'm purposely not removing the old route yet so that agents have a chance to roll over before removing it.

I also updated the agent version string but because the version has already been updated today, I just tacked a string onto the date.