### PR TITLE
EVG-13340: SpawnHostConfig gql type

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -140,3 +140,5 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.APICloudProviders
   AWSConfig:
     model: github.com/evergreen-ci/evergreen/rest/model.APIAWSConfig
+  SpawnHostConfig:
+    model: github.com/evergreen-ci/evergreen/rest/model.APISpawnHostConfig

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -453,11 +453,18 @@ type ComplexityRoot struct {
 		Source      func(childComplexity int) int
 	}
 
+	SpawnHostConfig struct {
+		SpawnHostsPerUser         func(childComplexity int) int
+		UnexpirableHostsPerUser   func(childComplexity int) int
+		UnexpirableVolumesPerUser func(childComplexity int) int
+	}
+
 	SpruceConfig struct {
 		Banner      func(childComplexity int) int
 		BannerTheme func(childComplexity int) int
 		Jira        func(childComplexity int) int
 		Providers   func(childComplexity int) int
+		Spawnhost   func(childComplexity int) int
 		Ui          func(childComplexity int) int
 	}
 
@@ -2850,6 +2857,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SearchReturnInfo.Source(childComplexity), true
 
+	case "SpawnHostConfig.spawnHostsPerUser":
+		if e.complexity.SpawnHostConfig.SpawnHostsPerUser == nil {
+			break
+		}
+
+		return e.complexity.SpawnHostConfig.SpawnHostsPerUser(childComplexity), true
+
+	case "SpawnHostConfig.unexpirableHostsPerUser":
+		if e.complexity.SpawnHostConfig.UnexpirableHostsPerUser == nil {
+			break
+		}
+
+		return e.complexity.SpawnHostConfig.UnexpirableHostsPerUser(childComplexity), true
+
+	case "SpawnHostConfig.unexpirableVolumesPerUser":
+		if e.complexity.SpawnHostConfig.UnexpirableVolumesPerUser == nil {
+			break
+		}
+
+		return e.complexity.SpawnHostConfig.UnexpirableVolumesPerUser(childComplexity), true
+
 	case "SpruceConfig.banner":
 		if e.complexity.SpruceConfig.Banner == nil {
 			break
@@ -2877,6 +2905,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.SpruceConfig.Providers(childComplexity), true
+
+	case "SpruceConfig.spawnHost":
+		if e.complexity.SpruceConfig.Spawnhost == nil {
+			break
+		}
+
+		return e.complexity.SpruceConfig.Spawnhost(childComplexity), true
 
 	case "SpruceConfig.ui":
 		if e.complexity.SpruceConfig.Ui == nil {
@@ -4760,6 +4795,7 @@ type SpruceConfig {
   banner: String
   bannerTheme: String
   providers: CloudProviderConfig
+  spawnHost: SpawnHostConfig!
 }
 
 type JiraConfig {
@@ -4776,6 +4812,12 @@ type CloudProviderConfig {
 
 type AWSConfig {
   maxVolumeSizePerUser: Int
+}
+
+type SpawnHostConfig {
+  unexpirableHostsPerUser: Int!
+  unexpirableVolumesPerUser: Int!
+  spawnHostsPerUser: Int!
 }
 
 type HostEvents {
@@ -14772,6 +14814,108 @@ func (ec *executionContext) _SearchReturnInfo_featuresURL(ctx context.Context, f
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _SpawnHostConfig_unexpirableHostsPerUser(ctx context.Context, field graphql.CollectedField, obj *model.APISpawnHostConfig) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "SpawnHostConfig",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UnexpirableHostsPerUser, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalNInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _SpawnHostConfig_unexpirableVolumesPerUser(ctx context.Context, field graphql.CollectedField, obj *model.APISpawnHostConfig) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "SpawnHostConfig",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UnexpirableVolumesPerUser, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalNInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _SpawnHostConfig_spawnHostsPerUser(ctx context.Context, field graphql.CollectedField, obj *model.APISpawnHostConfig) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "SpawnHostConfig",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SpawnHostsPerUser, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalNInt2ᚖint(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _SpruceConfig_ui(ctx context.Context, field graphql.CollectedField, obj *model.APIAdminSettings) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -14925,6 +15069,40 @@ func (ec *executionContext) _SpruceConfig_providers(ctx context.Context, field g
 	res := resTmp.(*model.APICloudProviders)
 	fc.Result = res
 	return ec.marshalOCloudProviderConfig2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPICloudProviders(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _SpruceConfig_spawnHost(ctx context.Context, field graphql.CollectedField, obj *model.APIAdminSettings) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "SpruceConfig",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Spawnhost, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.APISpawnHostConfig)
+	fc.Result = res
+	return ec.marshalNSpawnHostConfig2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPISpawnHostConfig(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Task_aborted(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
@@ -24018,6 +24196,43 @@ func (ec *executionContext) _SearchReturnInfo(ctx context.Context, sel ast.Selec
 	return out
 }
 
+var spawnHostConfigImplementors = []string{"SpawnHostConfig"}
+
+func (ec *executionContext) _SpawnHostConfig(ctx context.Context, sel ast.SelectionSet, obj *model.APISpawnHostConfig) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, spawnHostConfigImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SpawnHostConfig")
+		case "unexpirableHostsPerUser":
+			out.Values[i] = ec._SpawnHostConfig_unexpirableHostsPerUser(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "unexpirableVolumesPerUser":
+			out.Values[i] = ec._SpawnHostConfig_unexpirableVolumesPerUser(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "spawnHostsPerUser":
+			out.Values[i] = ec._SpawnHostConfig_spawnHostsPerUser(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var spruceConfigImplementors = []string{"SpruceConfig"}
 
 func (ec *executionContext) _SpruceConfig(ctx context.Context, sel ast.SelectionSet, obj *model.APIAdminSettings) graphql.Marshaler {
@@ -24039,6 +24254,11 @@ func (ec *executionContext) _SpruceConfig(ctx context.Context, sel ast.Selection
 			out.Values[i] = ec._SpruceConfig_bannerTheme(ctx, field, obj)
 		case "providers":
 			out.Values[i] = ec._SpruceConfig_providers(ctx, field, obj)
+		case "spawnHost":
+			out.Values[i] = ec._SpruceConfig_spawnHost(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -26168,6 +26388,24 @@ func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.Selec
 	return res
 }
 
+func (ec *executionContext) unmarshalNInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalNInt2int(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) marshalNInt2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec.marshalNInt2int(ctx, sel, *v)
+}
+
 func (ec *executionContext) marshalNJiraStatus2githubᚗcomᚋevergreenᚑciᚋevergreenᚋthirdpartyᚐJiraStatus(ctx context.Context, sel ast.SelectionSet, v thirdparty.JiraStatus) graphql.Marshaler {
 	return ec._JiraStatus(ctx, sel, &v)
 }
@@ -26778,6 +27016,20 @@ func (ec *executionContext) unmarshalNSelectorInput2ᚕgithubᚗcomᚋevergreen�
 		}
 	}
 	return res, nil
+}
+
+func (ec *executionContext) marshalNSpawnHostConfig2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPISpawnHostConfig(ctx context.Context, sel ast.SelectionSet, v model.APISpawnHostConfig) graphql.Marshaler {
+	return ec._SpawnHostConfig(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNSpawnHostConfig2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPISpawnHostConfig(ctx context.Context, sel ast.SelectionSet, v *model.APISpawnHostConfig) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._SpawnHostConfig(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNSpawnHostStatusActions2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSpawnHostStatusActions(ctx context.Context, v interface{}) (SpawnHostStatusActions, error) {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -752,6 +752,7 @@ type SpruceConfig {
   banner: String
   bannerTheme: String
   providers: CloudProviderConfig
+  spawnHost: SpawnHostConfig!
 }
 
 type JiraConfig {
@@ -768,6 +769,12 @@ type CloudProviderConfig {
 
 type AWSConfig {
   maxVolumeSizePerUser: Int
+}
+
+type SpawnHostConfig {
+  unexpirableHostsPerUser: Int!
+  unexpirableVolumesPerUser: Int!
+  spawnHostsPerUser: Int!
 }
 
 type HostEvents {

--- a/graphql/tests/spruceConfig/queries/spawnHost.graphql
+++ b/graphql/tests/spruceConfig/queries/spawnHost.graphql
@@ -1,0 +1,9 @@
+{
+  spruceConfig {
+    spawnHost {
+      unexpirableHostsPerUser
+      unexpirableVolumesPerUser
+      spawnHostsPerUser
+    }
+  }
+}

--- a/graphql/tests/spruceConfig/results.json
+++ b/graphql/tests/spruceConfig/results.json
@@ -34,6 +34,20 @@
                     }
                 }
             }
+        },
+        {
+            "query_file": "spawnHost.graphql",
+            "result": {
+                "data": {
+                    "spruceConfig": {
+                        "spawnHost": {
+                            "unexpirableHostsPerUser": 0,
+                            "unexpirableVolumesPerUser": 0,
+                            "spawnHostsPerUser": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -160,6 +160,12 @@ func (as *APIAdminSettings) BuildFromService(h interface{}) error {
 		}
 		as.Providers = &cloudProviders
 		as.ShutdownWaitSeconds = &v.ShutdownWaitSeconds
+		spawnHostConfig := APISpawnHostConfig{}
+		err = spawnHostConfig.BuildFromService(v.Spawnhost)
+		if err != nil {
+			return errors.Wrapf(err, "error building apiSpawnHostConfig")
+		}
+		as.Spawnhost = &spawnHostConfig
 	default:
 		return errors.Errorf("%T is not a supported admin settings type", h)
 	}


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-13340
These variables will be used to enforce spawn host/volume limits in Spruce