### PR TITLE
EVG-13371  Add source field to notes

### DIFF
--- a/model/task_annotations/db.go
+++ b/model/task_annotations/db.go
@@ -1,8 +1,6 @@
 package task_annotations
 
 import (
-	"time"
-
 	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
@@ -87,10 +85,7 @@ func (annotation *TaskAnnotation) UpdateAPIAnnotation(id string, execution int, 
 }
 
 // Update updates one task_annotation.
-func (annotation *TaskAnnotation) UpdateUserAnnotation(id string, execution int, a Annotation, author string) error {
-	a.Source.Author = author
-	a.Source.Time = time.Now()
-
+func (annotation *TaskAnnotation) UpdateUserAnnotation(id string, execution int, a Annotation) error {
 	return errors.WithStack(db.Update(
 		Collection,
 		bson.M{

--- a/model/task_annotations/task_annotations.go
+++ b/model/task_annotations/task_annotations.go
@@ -21,8 +21,8 @@ type TaskAnnotation struct {
 type IssueLink struct {
 	URL string `bson:"url" json:"url"`
 	// Text to be displayed
-	IssueKey string `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
-	Source   Source `bson:"link_source,omitempty" json:"link_source,omitempty"`
+	IssueKey string  `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
+	Source   *Source `bson:"source,omitempty" json:"source,omitempty"`
 }
 
 type Source struct {
@@ -41,5 +41,5 @@ type Annotation struct {
 
 type Note struct {
 	Message string  `bson:"message,omitempty" json:"message,omitempty"`
-	Source  *Source `bson:"note_source,omitempty" json:"note_source,omitempty"`
+	Source  *Source `bson:"source,omitempty" json:"source,omitempty"`
 }

--- a/model/task_annotations/task_annotations.go
+++ b/model/task_annotations/task_annotations.go
@@ -21,8 +21,8 @@ type TaskAnnotation struct {
 type IssueLink struct {
 	URL string `bson:"url" json:"url"`
 	// Text to be displayed
-	IssueKey   string `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
-	LinkSource Source `bson:"link_source,omitempty" json:"link_source,omitempty"`
+	IssueKey string `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
+	Source   Source `bson:"link_source,omitempty" json:"link_source,omitempty"`
 }
 
 type Source struct {
@@ -32,7 +32,7 @@ type Source struct {
 
 type Annotation struct {
 	// comment about the failure
-	Note Note `bson:"note,omitempty" json:"note,omitempty"`
+	Note *Note `bson:"note,omitempty" json:"note,omitempty"`
 	// links to tickets definitely related.
 	Issues []IssueLink `bson:"issues,omitempty" json:"issues,omitempty"`
 	// links to tickets possibly related
@@ -40,6 +40,6 @@ type Annotation struct {
 }
 
 type Note struct {
-	Message    string `bson:"message,omitempty" json:"message,omitempty"`
-	NoteSource Source `bson:"note_source,omitempty" json:"note_source,omitempty"`
+	Message string  `bson:"message,omitempty" json:"message,omitempty"`
+	Source  *Source `bson:"note_source,omitempty" json:"note_source,omitempty"`
 }

--- a/model/task_annotations/task_annotations.go
+++ b/model/task_annotations/task_annotations.go
@@ -21,21 +21,25 @@ type TaskAnnotation struct {
 type IssueLink struct {
 	URL string `bson:"url" json:"url"`
 	// Text to be displayed
-	IssueKey string `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
+	IssueKey   string `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
+	LinkSource Source `bson:"link_source,omitempty" json:"link_source,omitempty"`
 }
 
-type AnnotationSource struct {
+type Source struct {
 	Author string    `bson:"author,omitempty" json:"author,omitempty"`
 	Time   time.Time `bson:"time,omitempty" json:"time,omitempty"`
 }
 
 type Annotation struct {
 	// comment about the failure
-	Note string `bson:"note,omitempty" json:"note,omitempty"`
+	Note Note `bson:"note,omitempty" json:"note,omitempty"`
 	// links to tickets definitely related.
 	Issues []IssueLink `bson:"issues,omitempty" json:"issues,omitempty"`
 	// links to tickets possibly related
 	SuspectedIssues []IssueLink `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
-	// annotation attribution
-	Source AnnotationSource `bson:"source" json:"source"`
+}
+
+type Note struct {
+	Message    string `bson:"message,omitempty" json:"message,omitempty"`
+	NoteSource Source `bson:"note_source,omitempty" json:"note_source,omitempty"`
 }

--- a/rest/model/task_annotations.go
+++ b/rest/model/task_annotations.go
@@ -16,22 +16,22 @@ type APITaskAnnotation struct {
 	Metadata       *birch.Document `bson:"metadata,omitempty" json:"metadata,omitempty"`
 }
 type APIAnnotation struct {
-	Note          *APINote       `bson:"note,omitempty" json:"note,omitempty"`
-	Issues        []APIIssueLink `bson:"issues,omitempty" json:"issues,omitempty"`
-	SuspectIssues []APIIssueLink `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
+	Note            *APINote       `bson:"note,omitempty" json:"note,omitempty"`
+	Issues          []APIIssueLink `bson:"issues,omitempty" json:"issues,omitempty"`
+	SuspectedIssues []APIIssueLink `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
 }
 type APINote struct {
 	Message *string    `bson:"message,omitempty" json:"message,omitempty"`
-	Source  *APISource `bson:"note_source,omitempty" json:"note_source,omitempty"`
+	Source  *APISource `bson:"source,omitempty" json:"source,omitempty"`
 }
 type APISource struct {
 	Author *string    `bson:"author,omitempty" json:"author,omitempty"`
 	Time   *time.Time `bson:"time,omitempty" json:"time,omitempty"`
 }
 type APIIssueLink struct {
-	URL      *string   `bson:"url" json:"url"`
-	IssueKey *string   `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
-	Source   APISource `bson:"link_source,omitempty" json:"link_source,omitempty"`
+	URL      *string    `bson:"url" json:"url"`
+	IssueKey *string    `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
+	Source   *APISource `bson:"source,omitempty" json:"source,omitempty"`
 }
 
 // APIAnnotationBuildFromService takes the task_annotations.Annotation DB struct and
@@ -80,7 +80,7 @@ func APIIssueLinkBuildFromService(t task_annotations.IssueLink) *APIIssueLink {
 	m := APIIssueLink{}
 	m.URL = StringStringPtr(t.URL)
 	m.IssueKey = StringStringPtr(t.IssueKey)
-	m.Source = *APISourceBuildFromService(t.Source)
+	m.Source = APISourceBuildFromService(*t.Source)
 	return &m
 }
 
@@ -90,7 +90,7 @@ func APIIssueLinkToService(m APIIssueLink) *task_annotations.IssueLink {
 	out := &task_annotations.IssueLink{}
 	out.URL = StringPtrString(m.URL)
 	out.IssueKey = StringPtrString(m.IssueKey)
-	out.Source = *APISourceToService(m.Source)
+	out.Source = APISourceToService(*m.Source)
 	return out
 }
 

--- a/rest/model/task_annotations.go
+++ b/rest/model/task_annotations.go
@@ -16,22 +16,22 @@ type APITaskAnnotation struct {
 	Metadata       *birch.Document `bson:"metadata,omitempty" json:"metadata,omitempty"`
 }
 type APIAnnotation struct {
-	Note          APINote        `bson:"note,omitempty" json:"note,omitempty"`
+	Note          *APINote       `bson:"note,omitempty" json:"note,omitempty"`
 	Issues        []APIIssueLink `bson:"issues,omitempty" json:"issues,omitempty"`
 	SuspectIssues []APIIssueLink `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
 }
 type APINote struct {
-	Message    *string   `bson:"message,omitempty" json:"message,omitempty"`
-	NoteSource APISource `bson:"note_source,omitempty" json:"note_source,omitempty"`
+	Message *string    `bson:"message,omitempty" json:"message,omitempty"`
+	Source  *APISource `bson:"note_source,omitempty" json:"note_source,omitempty"`
 }
 type APISource struct {
 	Author *string    `bson:"author,omitempty" json:"author,omitempty"`
 	Time   *time.Time `bson:"time,omitempty" json:"time,omitempty"`
 }
 type APIIssueLink struct {
-	URL        *string   `bson:"url" json:"url"`
-	IssueKey   *string   `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
-	LinkSource APISource `bson:"link_source,omitempty" json:"link_source,omitempty"`
+	URL      *string   `bson:"url" json:"url"`
+	IssueKey *string   `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
+	Source   APISource `bson:"link_source,omitempty" json:"link_source,omitempty"`
 }
 
 // APIAnnotationBuildFromService takes the task_annotations.Annotation DB struct and
@@ -39,7 +39,7 @@ type APIIssueLink struct {
 func APIAnnotationBuildFromService(t *task_annotations.Annotation) *APIAnnotation {
 	m := APIAnnotation{}
 	m.Issues = ArrtaskannotationsIssueLinkArrAPIIssueLink(t.Issues)
-	m.Note = *APINoteBuildFromService(t.Note)
+	m.Note = APINoteBuildFromService(*t.Note)
 	return &m
 }
 
@@ -48,7 +48,7 @@ func APIAnnotationBuildFromService(t *task_annotations.Annotation) *APIAnnotatio
 func APIAnnotationToService(m APIAnnotation) *task_annotations.Annotation {
 	out := &task_annotations.Annotation{}
 	out.Issues = ArrAPIIssueLinkArrtaskannotationsIssueLink(m.Issues)
-	out.Note = *APINoteToService(m.Note)
+	out.Note = APINoteToService(*m.Note)
 	return out
 }
 
@@ -80,7 +80,7 @@ func APIIssueLinkBuildFromService(t task_annotations.IssueLink) *APIIssueLink {
 	m := APIIssueLink{}
 	m.URL = StringStringPtr(t.URL)
 	m.IssueKey = StringStringPtr(t.IssueKey)
-	m.LinkSource = *APISourceBuildFromService(t.LinkSource)
+	m.Source = *APISourceBuildFromService(t.Source)
 	return &m
 }
 
@@ -90,7 +90,7 @@ func APIIssueLinkToService(m APIIssueLink) *task_annotations.IssueLink {
 	out := &task_annotations.IssueLink{}
 	out.URL = StringPtrString(m.URL)
 	out.IssueKey = StringPtrString(m.IssueKey)
-	out.LinkSource = *APISourceToService(m.LinkSource)
+	out.Source = *APISourceToService(m.Source)
 	return out
 }
 
@@ -99,7 +99,7 @@ func APIIssueLinkToService(m APIIssueLink) *task_annotations.IssueLink {
 func APINoteBuildFromService(t task_annotations.Note) *APINote {
 	m := APINote{}
 	m.Message = StringStringPtr(t.Message)
-	m.NoteSource = *APISourceBuildFromService(t.NoteSource)
+	m.Source = APISourceBuildFromService(*t.Source)
 	return &m
 }
 
@@ -108,7 +108,7 @@ func APINoteBuildFromService(t task_annotations.Note) *APINote {
 func APINoteToService(m APINote) *task_annotations.Note {
 	out := &task_annotations.Note{}
 	out.Message = StringPtrString(m.Message)
-	out.NoteSource = *APISourceToService(m.NoteSource)
+	out.Source = APISourceToService(*m.Source)
 	return out
 }
 

--- a/rest/model/task_annotations.go
+++ b/rest/model/task_annotations.go
@@ -13,23 +13,25 @@ type APITaskAnnotation struct {
 	TaskExecution  int             `bson:"task_execution" json:"task_execution"`
 	APIAnnotation  *APIAnnotation  `bson:"api_annotation,omitempty" json:"api_annotation,omitempty"`
 	UserAnnotation *APIAnnotation  `bson:"user_annotation,omitempty" json:"user_annotation,omitempty"`
-	Metadata       *birch.Document `bson:"metadata" json:"metadata"`
+	Metadata       *birch.Document `bson:"metadata,omitempty" json:"metadata,omitempty"`
 }
-
 type APIAnnotation struct {
-	Note            *string             `bson:"note,omitempty" json:"note,omitempty"`
-	Issues          []APIIssueLink      `bson:"issues,omitempty" json:"issues,omitempty"`
-	SuspectedIssues []APIIssueLink      `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
-	Source          APIAnnotationSource `bson:"source" json:"source"`
+	Note          APINote        `bson:"note,omitempty" json:"note,omitempty"`
+	Issues        []APIIssueLink `bson:"issues,omitempty" json:"issues,omitempty"`
+	SuspectIssues []APIIssueLink `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
 }
-type APIAnnotationSource struct {
+type APINote struct {
+	Message    *string   `bson:"message,omitempty" json:"message,omitempty"`
+	NoteSource APISource `bson:"note_source,omitempty" json:"note_source,omitempty"`
+}
+type APISource struct {
 	Author *string    `bson:"author,omitempty" json:"author,omitempty"`
 	Time   *time.Time `bson:"time,omitempty" json:"time,omitempty"`
 }
-
 type APIIssueLink struct {
-	URL      *string `bson:"url,omitempty" json:"url,omitempty"`
-	IssueKey *string `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
+	URL        *string   `bson:"url" json:"url"`
+	IssueKey   *string   `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
+	LinkSource APISource `bson:"link_source,omitempty" json:"link_source,omitempty"`
 }
 
 // APIAnnotationBuildFromService takes the task_annotations.Annotation DB struct and
@@ -37,34 +39,32 @@ type APIIssueLink struct {
 func APIAnnotationBuildFromService(t *task_annotations.Annotation) *APIAnnotation {
 	m := APIAnnotation{}
 	m.Issues = ArrtaskannotationsIssueLinkArrAPIIssueLink(t.Issues)
-	m.Note = StringStringPtr(t.Note)
-	m.Source = *APIAnnotationSourceBuildFromService(t.Source)
+	m.Note = *APINoteBuildFromService(t.Note)
 	return &m
 }
 
 // APIAnnotationToService takes the APIAnnotation REST struct and returns the DB struct
 // *task_annotations.Annotation with the corresponding fields populated
-func APIAnnotationToService(m *APIAnnotation) *task_annotations.Annotation {
+func APIAnnotationToService(m APIAnnotation) *task_annotations.Annotation {
 	out := &task_annotations.Annotation{}
 	out.Issues = ArrAPIIssueLinkArrtaskannotationsIssueLink(m.Issues)
-	out.Note = StringPtrString(m.Note)
-	out.Source = *APIAnnotationSourceToService(m.Source)
+	out.Note = *APINoteToService(m.Note)
 	return out
 }
 
-// APIAnnotationSourceBuildFromService takes the task_annotations.AnnotationSource DB struct and
-// returns the REST struct *APIAnnotationSource with the corresponding fields populated
-func APIAnnotationSourceBuildFromService(t task_annotations.AnnotationSource) *APIAnnotationSource {
-	m := APIAnnotationSource{}
+// APISourceBuildFromService takes the task_annotations.Source DB struct and
+// returns the REST struct *APISource with the corresponding fields populated
+func APISourceBuildFromService(t task_annotations.Source) *APISource {
+	m := APISource{}
 	m.Author = StringStringPtr(t.Author)
 	m.Time = ToTimePtr(t.Time)
 	return &m
 }
 
-// APIAnnotationSourceToService takes the APIAnnotationSource REST struct and returns the DB struct
-// *task_annotations.AnnotationSource with the corresponding fields populated
-func APIAnnotationSourceToService(m APIAnnotationSource) *task_annotations.AnnotationSource {
-	out := &task_annotations.AnnotationSource{}
+// APISourceToService takes the APISource REST struct and returns the DB struct
+// *task_annotations.Source with the corresponding fields populated
+func APISourceToService(m APISource) *task_annotations.Source {
+	out := &task_annotations.Source{}
 	out.Author = StringPtrString(m.Author)
 	if m.Time != nil {
 		out.Time = *m.Time
@@ -80,6 +80,7 @@ func APIIssueLinkBuildFromService(t task_annotations.IssueLink) *APIIssueLink {
 	m := APIIssueLink{}
 	m.URL = StringStringPtr(t.URL)
 	m.IssueKey = StringStringPtr(t.IssueKey)
+	m.LinkSource = *APISourceBuildFromService(t.LinkSource)
 	return &m
 }
 
@@ -89,6 +90,25 @@ func APIIssueLinkToService(m APIIssueLink) *task_annotations.IssueLink {
 	out := &task_annotations.IssueLink{}
 	out.URL = StringPtrString(m.URL)
 	out.IssueKey = StringPtrString(m.IssueKey)
+	out.LinkSource = *APISourceToService(m.LinkSource)
+	return out
+}
+
+// APINoteBuildFromService takes the task_annotations.Note DB struct and
+// returns the REST struct *APINote with the corresponding fields populated
+func APINoteBuildFromService(t task_annotations.Note) *APINote {
+	m := APINote{}
+	m.Message = StringStringPtr(t.Message)
+	m.NoteSource = *APISourceBuildFromService(t.NoteSource)
+	return &m
+}
+
+// APINoteToService takes the APINote REST struct and returns the DB struct
+// *task_annotations.Note with the corresponding fields populated
+func APINoteToService(m APINote) *task_annotations.Note {
+	out := &task_annotations.Note{}
+	out.Message = StringPtrString(m.Message)
+	out.NoteSource = *APISourceToService(m.NoteSource)
 	return out
 }
 
@@ -109,11 +129,11 @@ func APITaskAnnotationBuildFromService(t task_annotations.TaskAnnotation) *APITa
 // *task_annotations.TaskAnnotation with the corresponding fields populated
 func APITaskAnnotationToService(m APITaskAnnotation) *task_annotations.TaskAnnotation {
 	out := &task_annotations.TaskAnnotation{}
-	out.APIAnnotation = APIAnnotationToService(m.APIAnnotation)
+	out.APIAnnotation = APIAnnotationToService(*m.APIAnnotation)
 	out.Id = StringPtrString(m.Id)
 	out.TaskExecution = m.TaskExecution
 	out.TaskId = StringPtrString(m.TaskId)
-	out.UserAnnotation = APIAnnotationToService(m.UserAnnotation)
+	out.UserAnnotation = APIAnnotationToService(*m.UserAnnotation)
 	out.Metadata = m.Metadata
 	return out
 }


### PR DESCRIPTION
We are waiting on a discussion with users to determine wether or not we will want to display the source of each issue or suspected link. However, I think it makes sense to make this backend change without waiting on that for the following reasons: 

- We have determined that, since users can edit issues, having a global source for the entire task annotation document is not useful. If we were to remove that, I think it's important for us to have access to the source of edits whether we choose to display it or not. 

- If we determine that displaying the source is indeed unnecessary, since this feature is not in use yet, we might find after some time that we do indeed want to display the source. I think it makes sense to start storing that data in case that happens. 

- It probably makes sense to know the shape of the data before we move on to building the rest routes. If we wait until after the meeting to make this change, that work would have to be put on hold.   