### PR TITLE
EVG-13154 add route to get task annotations by build

### DIFF
--- a/model/annotations/task_annotations.go
+++ b/model/annotations/task_annotations.go
@@ -44,7 +44,7 @@ type Note struct {
 	Source  *Source `bson:"source,omitempty" json:"source,omitempty"`
 }
 
-// GetLatestExecutions filters by latest execution only
+// GetLatestExecutions returns only the latest execution for each task, and filters out earlier executions
 func GetLatestExecutions(annotations []TaskAnnotation) []TaskAnnotation {
 	highestExecutionAnnotations := map[string]TaskAnnotation{}
 	for idx, a := range annotations {

--- a/model/annotations/task_annotations.go
+++ b/model/annotations/task_annotations.go
@@ -1,4 +1,4 @@
-package task_annotations
+package annotations
 
 import (
 	"time"
@@ -42,4 +42,20 @@ type Annotation struct {
 type Note struct {
 	Message string  `bson:"message,omitempty" json:"message,omitempty"`
 	Source  *Source `bson:"source,omitempty" json:"source,omitempty"`
+}
+
+// GetLatestExecutions filters by latest execution only
+func GetLatestExecutions(annotations []TaskAnnotation) []TaskAnnotation {
+	highestExecutionAnnotations := map[string]TaskAnnotation{}
+	for idx, a := range annotations {
+		storedAnnotation, ok := highestExecutionAnnotations[a.TaskId]
+		if !ok || storedAnnotation.TaskExecution < a.TaskExecution {
+			highestExecutionAnnotations[a.TaskId] = annotations[idx]
+		}
+	}
+	res := []TaskAnnotation{}
+	for _, a := range highestExecutionAnnotations {
+		res = append(res, a)
+	}
+	return res
 }

--- a/model/annotations/task_annotations_test.go
+++ b/model/annotations/task_annotations_test.go
@@ -1,0 +1,55 @@
+package annotations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLatestExecutions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testutil.NewEnvironment(ctx, t)
+	assert.NoError(t, db.Clear(Collection))
+	annotations := []TaskAnnotation{
+		{
+			Id:             "1",
+			TaskId:         "t1",
+			TaskExecution:  2,
+			APIAnnotation:  &Annotation{Note: &Note{Message: "this is a note"}},
+			UserAnnotation: &Annotation{Note: &Note{Message: "this will not be returned"}},
+		},
+		{
+			Id:            "2",
+			TaskId:        "t1",
+			TaskExecution: 1,
+			APIAnnotation: &Annotation{Note: &Note{Message: "another note"}},
+		},
+		{
+			Id:             "3",
+			TaskId:         "t1",
+			TaskExecution:  0,
+			UserAnnotation: &Annotation{Note: &Note{Message: "only a user annotation"}},
+		},
+		{
+			Id:            "4",
+			TaskId:        "t2",
+			TaskExecution: 0,
+			APIAnnotation: &Annotation{Note: &Note{Message: "this is the wrong task"}},
+		},
+	}
+	for _, a := range annotations {
+		assert.NoError(t, a.Insert())
+	}
+
+	annotations, err := FindAPIAnnotationsByTaskIds([]string{"t1", "t2"})
+	assert.NoError(t, err)
+	assert.Len(t, annotations, 3)
+	for _, a := range annotations {
+		assert.Nil(t, a.UserAnnotation)
+	}
+	assert.Len(t, GetLatestExecutions(annotations), 2)
+}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -928,6 +928,11 @@ func FindAllTaskIDsFromVersion(versionId string) ([]string, error) {
 	return findAllTaskIDs(q)
 }
 
+func FindAllTaskIDsFromBuild(buildId string) ([]string, error) {
+	q := db.Query(bson.M{BuildIdKey: buildId}).WithFields(IdKey)
+	return findAllTaskIDs(q)
+}
+
 // FindAllTasksFromVersionWithDependencies finds all tasks in a version and includes only their dependencies.
 func FindAllTasksFromVersionWithDependencies(versionId string) ([]Task, error) {
 	q := db.Query(bson.M{

--- a/rest/model/task_annotations.go
+++ b/rest/model/task_annotations.go
@@ -42,22 +42,28 @@ func APIAnnotationBuildFromService(t *annotations.Annotation) *APIAnnotation {
 	}
 	m := APIAnnotation{}
 	m.Issues = ArrtaskannotationsIssueLinkArrAPIIssueLink(t.Issues)
-	m.Note = APINoteBuildFromService(*t.Note)
+	m.Note = APINoteBuildFromService(t.Note)
 	return &m
 }
 
 // APIAnnotationToService takes the APIAnnotation REST struct and returns the DB struct
 // *annotations.Annotation with the corresponding fields populated
-func APIAnnotationToService(m APIAnnotation) *annotations.Annotation {
+func APIAnnotationToService(m *APIAnnotation) *annotations.Annotation {
+	if m == nil {
+		return nil
+	}
 	out := &annotations.Annotation{}
 	out.Issues = ArrAPIIssueLinkArrtaskannotationsIssueLink(m.Issues)
-	out.Note = APINoteToService(*m.Note)
+	out.Note = APINoteToService(m.Note)
 	return out
 }
 
 // APISourceBuildFromService takes the annotations.Source DB struct and
 // returns the REST struct *APISource with the corresponding fields populated
-func APISourceBuildFromService(t annotations.Source) *APISource {
+func APISourceBuildFromService(t *annotations.Source) *APISource {
+	if t == nil {
+		return nil
+	}
 	m := APISource{}
 	m.Author = StringStringPtr(t.Author)
 	m.Time = ToTimePtr(t.Time)
@@ -66,7 +72,10 @@ func APISourceBuildFromService(t annotations.Source) *APISource {
 
 // APISourceToService takes the APISource REST struct and returns the DB struct
 // *annotations.Source with the corresponding fields populated
-func APISourceToService(m APISource) *annotations.Source {
+func APISourceToService(m *APISource) *annotations.Source {
+	if m == nil {
+		return nil
+	}
 	out := &annotations.Source{}
 	out.Author = StringPtrString(m.Author)
 	if m.Time != nil {
@@ -83,7 +92,7 @@ func APIIssueLinkBuildFromService(t annotations.IssueLink) *APIIssueLink {
 	m := APIIssueLink{}
 	m.URL = StringStringPtr(t.URL)
 	m.IssueKey = StringStringPtr(t.IssueKey)
-	m.Source = APISourceBuildFromService(*t.Source)
+	m.Source = APISourceBuildFromService(t.Source)
 	return &m
 }
 
@@ -93,25 +102,31 @@ func APIIssueLinkToService(m APIIssueLink) *annotations.IssueLink {
 	out := &annotations.IssueLink{}
 	out.URL = StringPtrString(m.URL)
 	out.IssueKey = StringPtrString(m.IssueKey)
-	out.Source = APISourceToService(*m.Source)
+	out.Source = APISourceToService(m.Source)
 	return out
 }
 
 // APINoteBuildFromService takes the annotations.Note DB struct and
 // returns the REST struct *APINote with the corresponding fields populated
-func APINoteBuildFromService(t annotations.Note) *APINote {
+func APINoteBuildFromService(t *annotations.Note) *APINote {
+	if t == nil {
+		return nil
+	}
 	m := APINote{}
 	m.Message = StringStringPtr(t.Message)
-	m.Source = APISourceBuildFromService(*t.Source)
+	m.Source = APISourceBuildFromService(t.Source)
 	return &m
 }
 
 // APINoteToService takes the APINote REST struct and returns the DB struct
 // *annotations.Note with the corresponding fields populated
-func APINoteToService(m APINote) *annotations.Note {
+func APINoteToService(m *APINote) *annotations.Note {
+	if m == nil {
+		return nil
+	}
 	out := &annotations.Note{}
 	out.Message = StringPtrString(m.Message)
-	out.Source = APISourceToService(*m.Source)
+	out.Source = APISourceToService(m.Source)
 	return out
 }
 
@@ -132,11 +147,11 @@ func APITaskAnnotationBuildFromService(t annotations.TaskAnnotation) *APITaskAnn
 // *annotations.TaskAnnotation with the corresponding fields populated
 func APITaskAnnotationToService(m APITaskAnnotation) *annotations.TaskAnnotation {
 	out := &annotations.TaskAnnotation{}
-	out.APIAnnotation = APIAnnotationToService(*m.APIAnnotation)
+	out.APIAnnotation = APIAnnotationToService(m.APIAnnotation)
 	out.Id = StringPtrString(m.Id)
 	out.TaskExecution = m.TaskExecution
 	out.TaskId = StringPtrString(m.TaskId)
-	out.UserAnnotation = APIAnnotationToService(*m.UserAnnotation)
+	out.UserAnnotation = APIAnnotationToService(m.UserAnnotation)
 	out.Metadata = m.Metadata
 	return out
 }

--- a/rest/model/task_annotations.go
+++ b/rest/model/task_annotations.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/birch"
-	"github.com/evergreen-ci/evergreen/model/task_annotations"
+	"github.com/evergreen-ci/evergreen/model/annotations"
 )
 
 type APITaskAnnotation struct {
@@ -34,9 +34,12 @@ type APIIssueLink struct {
 	Source   *APISource `bson:"source,omitempty" json:"source,omitempty"`
 }
 
-// APIAnnotationBuildFromService takes the task_annotations.Annotation DB struct and
+// APIAnnotationBuildFromService takes the annotations.Annotation DB struct and
 // returns the REST struct *APIAnnotation with the corresponding fields populated
-func APIAnnotationBuildFromService(t *task_annotations.Annotation) *APIAnnotation {
+func APIAnnotationBuildFromService(t *annotations.Annotation) *APIAnnotation {
+	if t == nil {
+		return nil
+	}
 	m := APIAnnotation{}
 	m.Issues = ArrtaskannotationsIssueLinkArrAPIIssueLink(t.Issues)
 	m.Note = APINoteBuildFromService(*t.Note)
@@ -44,17 +47,17 @@ func APIAnnotationBuildFromService(t *task_annotations.Annotation) *APIAnnotatio
 }
 
 // APIAnnotationToService takes the APIAnnotation REST struct and returns the DB struct
-// *task_annotations.Annotation with the corresponding fields populated
-func APIAnnotationToService(m APIAnnotation) *task_annotations.Annotation {
-	out := &task_annotations.Annotation{}
+// *annotations.Annotation with the corresponding fields populated
+func APIAnnotationToService(m APIAnnotation) *annotations.Annotation {
+	out := &annotations.Annotation{}
 	out.Issues = ArrAPIIssueLinkArrtaskannotationsIssueLink(m.Issues)
 	out.Note = APINoteToService(*m.Note)
 	return out
 }
 
-// APISourceBuildFromService takes the task_annotations.Source DB struct and
+// APISourceBuildFromService takes the annotations.Source DB struct and
 // returns the REST struct *APISource with the corresponding fields populated
-func APISourceBuildFromService(t task_annotations.Source) *APISource {
+func APISourceBuildFromService(t annotations.Source) *APISource {
 	m := APISource{}
 	m.Author = StringStringPtr(t.Author)
 	m.Time = ToTimePtr(t.Time)
@@ -62,9 +65,9 @@ func APISourceBuildFromService(t task_annotations.Source) *APISource {
 }
 
 // APISourceToService takes the APISource REST struct and returns the DB struct
-// *task_annotations.Source with the corresponding fields populated
-func APISourceToService(m APISource) *task_annotations.Source {
-	out := &task_annotations.Source{}
+// *annotations.Source with the corresponding fields populated
+func APISourceToService(m APISource) *annotations.Source {
+	out := &annotations.Source{}
 	out.Author = StringPtrString(m.Author)
 	if m.Time != nil {
 		out.Time = *m.Time
@@ -74,9 +77,9 @@ func APISourceToService(m APISource) *task_annotations.Source {
 	return out
 }
 
-// APIIssueLinkBuildFromService takes the task_annotations.IssueLink DB struct and
+// APIIssueLinkBuildFromService takes the annotations.IssueLink DB struct and
 // returns the REST struct *APIIssueLink with the corresponding fields populated
-func APIIssueLinkBuildFromService(t task_annotations.IssueLink) *APIIssueLink {
+func APIIssueLinkBuildFromService(t annotations.IssueLink) *APIIssueLink {
 	m := APIIssueLink{}
 	m.URL = StringStringPtr(t.URL)
 	m.IssueKey = StringStringPtr(t.IssueKey)
@@ -85,18 +88,18 @@ func APIIssueLinkBuildFromService(t task_annotations.IssueLink) *APIIssueLink {
 }
 
 // APIIssueLinkToService takes the APIIssueLink REST struct and returns the DB struct
-// *task_annotations.IssueLink with the corresponding fields populated
-func APIIssueLinkToService(m APIIssueLink) *task_annotations.IssueLink {
-	out := &task_annotations.IssueLink{}
+// *annotations.IssueLink with the corresponding fields populated
+func APIIssueLinkToService(m APIIssueLink) *annotations.IssueLink {
+	out := &annotations.IssueLink{}
 	out.URL = StringPtrString(m.URL)
 	out.IssueKey = StringPtrString(m.IssueKey)
 	out.Source = APISourceToService(*m.Source)
 	return out
 }
 
-// APINoteBuildFromService takes the task_annotations.Note DB struct and
+// APINoteBuildFromService takes the annotations.Note DB struct and
 // returns the REST struct *APINote with the corresponding fields populated
-func APINoteBuildFromService(t task_annotations.Note) *APINote {
+func APINoteBuildFromService(t annotations.Note) *APINote {
 	m := APINote{}
 	m.Message = StringStringPtr(t.Message)
 	m.Source = APISourceBuildFromService(*t.Source)
@@ -104,17 +107,17 @@ func APINoteBuildFromService(t task_annotations.Note) *APINote {
 }
 
 // APINoteToService takes the APINote REST struct and returns the DB struct
-// *task_annotations.Note with the corresponding fields populated
-func APINoteToService(m APINote) *task_annotations.Note {
-	out := &task_annotations.Note{}
+// *annotations.Note with the corresponding fields populated
+func APINoteToService(m APINote) *annotations.Note {
+	out := &annotations.Note{}
 	out.Message = StringPtrString(m.Message)
 	out.Source = APISourceToService(*m.Source)
 	return out
 }
 
-// APITaskAnnotationBuildFromService takes the task_annotations.TaskAnnotation DB struct and
+// APITaskAnnotationBuildFromService takes the annotations.TaskAnnotation DB struct and
 // returns the REST struct *APITaskAnnotation with the corresponding fields populated
-func APITaskAnnotationBuildFromService(t task_annotations.TaskAnnotation) *APITaskAnnotation {
+func APITaskAnnotationBuildFromService(t annotations.TaskAnnotation) *APITaskAnnotation {
 	m := APITaskAnnotation{}
 	m.APIAnnotation = APIAnnotationBuildFromService(t.APIAnnotation)
 	m.Id = StringStringPtr(t.Id)
@@ -126,9 +129,9 @@ func APITaskAnnotationBuildFromService(t task_annotations.TaskAnnotation) *APITa
 }
 
 // APITaskAnnotationToService takes the APITaskAnnotation REST struct and returns the DB struct
-// *task_annotations.TaskAnnotation with the corresponding fields populated
-func APITaskAnnotationToService(m APITaskAnnotation) *task_annotations.TaskAnnotation {
-	out := &task_annotations.TaskAnnotation{}
+// *annotations.TaskAnnotation with the corresponding fields populated
+func APITaskAnnotationToService(m APITaskAnnotation) *annotations.TaskAnnotation {
+	out := &annotations.TaskAnnotation{}
 	out.APIAnnotation = APIAnnotationToService(*m.APIAnnotation)
 	out.Id = StringPtrString(m.Id)
 	out.TaskExecution = m.TaskExecution
@@ -138,7 +141,7 @@ func APITaskAnnotationToService(m APITaskAnnotation) *task_annotations.TaskAnnot
 	return out
 }
 
-func ArrtaskannotationsIssueLinkArrAPIIssueLink(t []task_annotations.IssueLink) []APIIssueLink {
+func ArrtaskannotationsIssueLinkArrAPIIssueLink(t []annotations.IssueLink) []APIIssueLink {
 	m := []APIIssueLink{}
 	for _, e := range t {
 		m = append(m, *APIIssueLinkBuildFromService(e))
@@ -146,8 +149,8 @@ func ArrtaskannotationsIssueLinkArrAPIIssueLink(t []task_annotations.IssueLink) 
 	return m
 }
 
-func ArrAPIIssueLinkArrtaskannotationsIssueLink(t []APIIssueLink) []task_annotations.IssueLink {
-	m := []task_annotations.IssueLink{}
+func ArrAPIIssueLinkArrtaskannotationsIssueLink(t []APIIssueLink) []annotations.IssueLink {
+	m := []annotations.IssueLink{}
 	for _, e := range t {
 		m = append(m, *APIIssueLinkToService(e))
 	}

--- a/rest/route/annotations.go
+++ b/rest/route/annotations.go
@@ -1,0 +1,70 @@
+package route
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/evergreen-ci/evergreen/model/annotations"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/pkg/errors"
+)
+
+type annotationsByBuildHandler struct {
+	buildId            string
+	fetchAllExecutions bool
+	sc                 data.Connector
+}
+
+func makeFetchAnnotationsByBuild(sc data.Connector) gimlet.RouteHandler {
+	return &annotationsByBuildHandler{
+		sc: sc,
+	}
+}
+
+func (h *annotationsByBuildHandler) Factory() gimlet.RouteHandler {
+	return &annotationsByBuildHandler{
+		sc: h.sc,
+	}
+}
+
+func (h *annotationsByBuildHandler) Parse(ctx context.Context, r *http.Request) error {
+	h.buildId = gimlet.GetVars(r)["build_id"]
+	if h.buildId == "" {
+		return gimlet.ErrorResponse{
+			Message:    "build ID cannot be empty",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	h.fetchAllExecutions = r.URL.Query().Get("fetch_all_executions") == "true"
+	return nil
+}
+
+func (h *annotationsByBuildHandler) Run(ctx context.Context) gimlet.Responder {
+	// Fetch all of the tasks to be returned in this page plus the tasks used for
+	// calculating information about the next page. Here the limit is multiplied
+	// by two to fetch the next page.
+
+	taskIds, err := task.FindAllTaskIDsFromBuild(h.buildId)
+	if err != nil {
+		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "error finding task IDs for build '%s'", h.buildId))
+	}
+	allAnnotations, err := annotations.FindAPIAnnotationsByTaskIds(taskIds)
+	if err != nil {
+		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "error finding task annotations"))
+	}
+	annotationsToReturn := allAnnotations
+	if !h.fetchAllExecutions {
+		annotationsToReturn = annotations.GetLatestExecutions(allAnnotations)
+	}
+	var res []model.APITaskAnnotation
+	for _, a := range annotationsToReturn {
+		apiAnnotation := model.APITaskAnnotationBuildFromService(a)
+		res = append(res, *apiAnnotation)
+	}
+
+	return gimlet.NewJSONResponse(res)
+}

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -1,0 +1,110 @@
+package route
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/annotations"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnotationsByBuildHandlerParse(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(annotations.Collection))
+	h := &annotationsByBuildHandler{}
+	r, err := http.NewRequest("GET", "/builds/b1/annotations", nil)
+	assert.NoError(t, err)
+	r = gimlet.SetURLVars(r, map[string]string{"build_id": "b1"})
+
+	ctx := context.TODO()
+	assert.NoError(t, h.Parse(ctx, r))
+	assert.Equal(t, "b1", h.buildId)
+	assert.False(t, h.fetchAllExecutions)
+
+	r, err = http.NewRequest("GET", "/builds/b2/annotations?fetch_all_executions=true", nil)
+	assert.NoError(t, err)
+	r = gimlet.SetURLVars(r, map[string]string{"build_id": "b2"})
+	assert.NoError(t, h.Parse(ctx, r))
+	assert.Equal(t, "b2", h.buildId)
+	assert.True(t, h.fetchAllExecutions)
+}
+
+func TestAnnotationsByBuildHandlerRun(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(annotations.Collection, task.Collection))
+	tasks := []task.Task{
+		{Id: "task-with-many-executions", BuildId: "b1"},
+		{Id: "task-without-api-annotation", BuildId: "b1"},
+		{Id: "wrong-build", BuildId: "b2"},
+	}
+	for _, each := range tasks {
+		assert.NoError(t, each.Insert())
+	}
+	h := &annotationsByBuildHandler{
+		sc:      &data.DBConnector{},
+		buildId: "b1",
+	}
+	ctx := context.TODO()
+	// no annotations doesn't error
+	resp := h.Run(ctx)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Status())
+	apiAnnotations := resp.Data().([]model.APITaskAnnotation)
+	assert.Len(t, apiAnnotations, 0)
+
+	annotations := []annotations.TaskAnnotation{
+		{
+			Id:             "1",
+			TaskId:         "task-with-many-executions",
+			TaskExecution:  0,
+			APIAnnotation:  &annotations.Annotation{Note: &annotations.Note{Message: "note"}},
+			UserAnnotation: &annotations.Annotation{Note: &annotations.Note{Message: "this note won't come up"}},
+		},
+		{
+			Id:             "2",
+			TaskId:         "task-with-many-executions",
+			TaskExecution:  1,
+			UserAnnotation: &annotations.Annotation{Note: &annotations.Note{Message: "this note won't come up"}}},
+		{
+			Id:            "3",
+			TaskId:        "task-with-many-executions",
+			TaskExecution: 2,
+			APIAnnotation: &annotations.Annotation{Note: &annotations.Note{Message: "note"}}},
+		{
+			Id:             "4",
+			TaskId:         "task-without-api-annotations",
+			UserAnnotation: &annotations.Annotation{Note: &annotations.Note{Message: "this note won't come up"}}},
+		{
+			Id:            "5",
+			TaskId:        "wrong-build",
+			APIAnnotation: &annotations.Annotation{Note: &annotations.Note{Message: "this note won't come up"}}},
+	}
+	for _, a := range annotations {
+		assert.NoError(t, a.Insert())
+	}
+
+	resp = h.Run(ctx)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Status())
+	apiAnnotations = resp.Data().([]model.APITaskAnnotation)
+	require.Len(t, apiAnnotations, 1) // only most recent execution
+	assert.Equal(t, 2, apiAnnotations[0].TaskExecution)
+
+	h.fetchAllExecutions = true
+	resp = h.Run(ctx)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Status())
+	apiAnnotations = resp.Data().([]model.APITaskAnnotation)
+	assert.Len(t, apiAnnotations, 2) // all executions for which APIAnnotation is populated
+	for _, a := range apiAnnotations {
+		assert.Equal(t, "task-with-many-executions", model.FromStringPtr(a.TaskId))
+		assert.Equal(t, "note", model.FromStringPtr(a.APIAnnotation.Note.Message))
+		assert.NotEqual(t, 1, a.TaskExecution)
+		assert.Nil(t, a.UserAnnotation)
+	}
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -72,6 +72,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/builds/{build_id}/abort").Version(2).Post().Wrap(checkUser, editTasks).RouteHandler(makeAbortBuild(sc))
 	app.AddRoute("/builds/{build_id}/restart").Version(2).Post().Wrap(checkUser, editTasks).RouteHandler(makeRestartBuild(sc))
 	app.AddRoute("/builds/{build_id}/tasks").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchTasksByBuild(sc))
+	app.AddRoute("/builds/{build_id}/annotations").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchAnnotationsByBuild(sc))
 	app.AddRoute("/commit_queue/{project_id}").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeGetCommitQueueItems(sc))
 	app.AddRoute("/commit_queue/{project_id}/{item}").Version(2).Delete().Wrap(checkUser, addProject, checkCommitQueueItemOwner, editTasks).RouteHandler(makeDeleteCommitQueueItems(sc, env))
 	app.AddRoute("/commit_queue/{patch_id}").Version(2).Put().Wrap(checkUser, addProject, checkCommitQueueItemOwner, editTasks).RouteHandler(makeCommitQueueEnqueueItem(sc))


### PR DESCRIPTION
This ticket does a couple of other things to improve organization, once I started writing the route and realized some things:
* Changed task_annotations to annotations because a) that's descriptive enough, b) underscores in package names are weird for the make target and also just embedded in the code, and c) task_annotations.TaskAnnotations is soo long 
* Added an enum to distinguish the types of annotations for easier querying (could use constants instead of an enum if preferred, given there are only like three possible states)
* Strayed from the design of returning one document, in lieu of returning a list, which also makes it easier to return multiple executions (rather than a map of taskID to a list of annotation docs)