### PR TITLE
EVG-13081 report merge errors for PR cq

### DIFF
--- a/model/commitqueue/github_merge_generic.go
+++ b/model/commitqueue/github_merge_generic.go
@@ -99,6 +99,10 @@ func (s *GithubMergePR) Send() (err error) {
 		// do the merge
 		res, _, err := githubClient.PullRequests.Merge(ctx, pr.Owner, pr.Repo, pr.PRNum, pr.MessageOverride, mergeOpts)
 		if err != nil {
+			s.sendMergeFailedStatus(err.Error(), pr)
+			for j := i + 1; j < len(s.PRs); j++ {
+				s.sendMergeFailedStatus("aborted", s.PRs[j])
+			}
 			return errors.Wrap(err, "can't access GitHub merge API")
 		}
 

--- a/model/commitqueue/github_merge_generic.go
+++ b/model/commitqueue/github_merge_generic.go
@@ -99,7 +99,7 @@ func (s *GithubMergePR) Send() (err error) {
 		// do the merge
 		res, _, err := githubClient.PullRequests.Merge(ctx, pr.Owner, pr.Repo, pr.PRNum, pr.MessageOverride, mergeOpts)
 		if err != nil {
-			s.sendMergeFailedStatus(err.Error(), pr)
+			s.sendMergeFailedStatus(fmt.Sprintf("Github Error: %s", err.Error()), pr)
 			for j := i + 1; j < len(s.PRs); j++ {
 				s.sendMergeFailedStatus("aborted", s.PRs[j])
 			}


### PR DESCRIPTION
@ybrill I'm actually a little confused by this structure. Why are there a list of PRInfos--are they unrelated to each other? In which case if one fails I'd think we could send the status and then just continue to try the others, rather than aborting, so I imagine they are related, but I don't understand how.