### PR TITLE
EVG-13155 add annotation route for version

### DIFF
--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -108,3 +108,97 @@ func TestAnnotationsByBuildHandlerRun(t *testing.T) {
 		assert.Nil(t, a.UserAnnotation)
 	}
 }
+
+func TestAnnotationsByVersionHandlerParse(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(annotations.Collection))
+	h := &annotationsByVersionHandler{}
+	r, err := http.NewRequest("GET", "/versions/v1/annotations", nil)
+	assert.NoError(t, err)
+	r = gimlet.SetURLVars(r, map[string]string{"version_id": "v1"})
+
+	ctx := context.TODO()
+	assert.NoError(t, h.Parse(ctx, r))
+	assert.Equal(t, "v1", h.versionId)
+	assert.False(t, h.fetchAllExecutions)
+
+	r, err = http.NewRequest("GET", "/versions/v2/annotations?fetch_all_executions=true", nil)
+	assert.NoError(t, err)
+	r = gimlet.SetURLVars(r, map[string]string{"version_id": "v2"})
+	assert.NoError(t, h.Parse(ctx, r))
+	assert.Equal(t, "v2", h.versionId)
+	assert.True(t, h.fetchAllExecutions)
+}
+
+func TestAnnotationsByVersionHandlerRun(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(annotations.Collection, task.Collection))
+	tasks := []task.Task{
+		{Id: "task-with-many-executions", Version: "v1"},
+		{Id: "task-without-api-annotation", Version: "v1"},
+		{Id: "wrong-build", Version: "v2"},
+	}
+	for _, each := range tasks {
+		assert.NoError(t, each.Insert())
+	}
+	h := &annotationsByVersionHandler{
+		sc:        &data.DBConnector{},
+		versionId: "v1",
+	}
+	ctx := context.TODO()
+	// no annotations doesn't error
+	resp := h.Run(ctx)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Status())
+	apiAnnotations := resp.Data().([]model.APITaskAnnotation)
+	assert.Len(t, apiAnnotations, 0)
+
+	annotations := []annotations.TaskAnnotation{
+		{
+			Id:             "1",
+			TaskId:         "task-with-many-executions",
+			TaskExecution:  0,
+			APIAnnotation:  &annotations.Annotation{Note: &annotations.Note{Message: "note"}},
+			UserAnnotation: &annotations.Annotation{Note: &annotations.Note{Message: "this note won't come up"}},
+		},
+		{
+			Id:             "2",
+			TaskId:         "task-with-many-executions",
+			TaskExecution:  1,
+			UserAnnotation: &annotations.Annotation{Note: &annotations.Note{Message: "this note won't come up"}}},
+		{
+			Id:            "3",
+			TaskId:        "task-with-many-executions",
+			TaskExecution: 2,
+			APIAnnotation: &annotations.Annotation{Note: &annotations.Note{Message: "note"}}},
+		{
+			Id:             "4",
+			TaskId:         "task-without-api-annotations",
+			UserAnnotation: &annotations.Annotation{Note: &annotations.Note{Message: "this note won't come up"}}},
+		{
+			Id:            "5",
+			TaskId:        "wrong-version",
+			APIAnnotation: &annotations.Annotation{Note: &annotations.Note{Message: "this note won't come up"}}},
+	}
+	for _, a := range annotations {
+		assert.NoError(t, a.Insert())
+	}
+
+	resp = h.Run(ctx)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Status())
+	apiAnnotations = resp.Data().([]model.APITaskAnnotation)
+	require.Len(t, apiAnnotations, 1) // only most recent execution
+	assert.Equal(t, 2, apiAnnotations[0].TaskExecution)
+
+	h.fetchAllExecutions = true
+	resp = h.Run(ctx)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Status())
+	apiAnnotations = resp.Data().([]model.APITaskAnnotation)
+	assert.Len(t, apiAnnotations, 2) // all executions for which APIAnnotation is populated
+	for _, a := range apiAnnotations {
+		assert.Equal(t, "task-with-many-executions", model.FromStringPtr(a.TaskId))
+		assert.Equal(t, "note", model.FromStringPtr(a.APIAnnotation.Note.Message))
+		assert.NotEqual(t, 1, a.TaskExecution)
+		assert.Nil(t, a.UserAnnotation)
+	}
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -188,4 +188,6 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/versions/{version_id}/abort").Version(2).Post().Wrap(checkUser, editTasks).RouteHandler(makeAbortVersion(sc))
 	app.AddRoute("/versions/{version_id}/builds").Version(2).Get().Wrap(viewTasks).RouteHandler(makeGetVersionBuilds(sc))
 	app.AddRoute("/versions/{version_id}/restart").Version(2).Post().Wrap(checkUser, editTasks).RouteHandler(makeRestartVersion(sc))
+	app.AddRoute("/versions/{version_id}/annotations").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchAnnotationsByVersion(sc))
+
 }


### PR DESCRIPTION
This was pretty simple cause it's basically just the build route but again. Also removed some accidental comments. My only concern is if this should use pagination? Idk how many annotations we really expect to have per build/version. I may ask at the design meeting. I mildly hate pagination so I don't want to implement it if they don't want it.