### PR TITLE
EVG-13239: remove old route to get agent's distro

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -586,8 +586,6 @@ func (as *APIServer) GetServiceApp() *gimlet.APIApp {
 	app.Route().Version(2).Route("/task/{taskId}/results").Wrap(checkTaskSecret, checkHost).Handler(as.AttachResults).Post()
 	app.Route().Version(2).Route("/task/{taskId}/test_logs").Wrap(checkTaskSecret, checkHost).Handler(as.AttachTestLog).Post()
 	app.Route().Version(2).Route("/task/{taskId}/files").Wrap(checkTask, checkHost).Handler(as.AttachFiles).Post()
-	// TODO (EVG-13239): remove this route once agents have updated.
-	app.Route().Version(2).Route("/task/{taskId}/distro").Wrap(checkTask).Handler(as.GetDistro).Get()
 	app.Route().Version(2).Route("/task/{taskId}/distro_view").Wrap(checkTask, checkHost).Handler(as.GetDistroView).Get()
 	app.Route().Version(2).Route("/task/{taskId}/parser_project").Wrap(checkTask).Handler(as.GetParserProject).Get()
 	app.Route().Version(2).Route("/task/{taskId}/project_ref").Wrap(checkTask).Handler(as.GetProjectRef).Get()

--- a/service/api_distro.go
+++ b/service/api_distro.go
@@ -1,36 +1,11 @@
 package service
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/evergreen-ci/evergreen/apimodels"
-	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/gimlet"
 )
-
-// TODO (EVG-13239): remove once agents have updated.
-// GetDistro loads the task's distro and sends it to the requester.
-func (as *APIServer) GetDistro(w http.ResponseWriter, r *http.Request) {
-	t := MustHaveTask(r)
-
-	// Get the distro for this task
-	h, err := host.FindOne(host.ByRunningTaskId(t.Id))
-	if err != nil {
-		as.LoggedError(w, r, http.StatusInternalServerError, err)
-		return
-	}
-
-	if h == nil {
-		message := fmt.Errorf("No host found running task %v", t.Id)
-		as.LoggedError(w, r, http.StatusInternalServerError, message)
-		return
-	}
-
-	// agent can't properly unmarshal provider settings
-	h.Distro.ProviderSettingsList = nil
-	gimlet.WriteJSON(w, h.Distro)
-}
 
 func (as *APIServer) GetDistroView(w http.ResponseWriter, r *http.Request) {
 	h := MustHaveHost(r)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13239

Since the agents have rolled over to use the new distro route, this route can be removed.