### PR TITLE
EVG-13394 skip adding an edge to a non-existent node

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -706,6 +706,10 @@ func NewTaskIdTable(p *Project, v *Version, sourceRev, defID string) TaskIdConfi
 			rev = fmt.Sprintf("%s_%s", sourceRev, v.TriggeredByGitTag.Tag)
 		}
 		for _, t := range bv.Tasks {
+			// omit tasks excluded from the version
+			if t.SkipOnRequester(v.Requester) {
+				continue
+			}
 			if tg := p.FindTaskGroup(t.Name); tg != nil {
 				for _, groupTask := range tg.Tasks {
 					taskId := generateId(groupTask, p, &bv, rev, v)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -424,12 +424,17 @@ func (t *Task) DependenciesMet(depCaches map[string]Task) (bool, error) {
 		return true, nil
 	}
 
-	deps, err := t.populateDependencyTaskCache(depCaches)
+	_, err := t.populateDependencyTaskCache(depCaches)
 	if err != nil {
 		return false, errors.WithStack(err)
 	}
 
-	for _, depTask := range deps {
+	for _, dependency := range t.DependsOn {
+		depTask, ok := depCaches[dependency.TaskId]
+		// ignore non-existent dependencies
+		if !ok {
+			continue
+		}
 		if !t.SatisfiesDependency(&depTask) {
 			return false, nil
 		}
@@ -453,12 +458,6 @@ func (t *Task) populateDependencyTaskCache(depCache map[string]Task) ([]Task, er
 		newDeps, err := Find(ByIds(depIdsToQueryFor).WithFields(StatusKey, DependsOnKey, ActivatedKey))
 		if err != nil {
 			return nil, errors.WithStack(err)
-		}
-		if len(newDeps) != len(depIdsToQueryFor) {
-			grip.Warning(message.Fields{
-				"message": "task depends on non-existent tasks",
-				"task_id": t.Id,
-			})
 		}
 
 		// add queried dependencies to the cache

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -455,7 +455,10 @@ func (t *Task) populateDependencyTaskCache(depCache map[string]Task) ([]Task, er
 			return nil, errors.WithStack(err)
 		}
 		if len(newDeps) != len(depIdsToQueryFor) {
-			return nil, errors.Errorf("task '%s' depends on non-existent tasks", t.Id)
+			grip.Warning(message.Fields{
+				"message": "task depends on non-existent tasks",
+				"task_id": t.Id,
+			})
 		}
 
 		// add queried dependencies to the cache

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -433,6 +433,11 @@ func (t *Task) DependenciesMet(depCaches map[string]Task) (bool, error) {
 		depTask, ok := depCaches[dependency.TaskId]
 		// ignore non-existent dependencies
 		if !ok {
+			grip.Warning(message.Fields{
+				"message":       "task has non-existent dependencies",
+				"task_id":       t.Id,
+				"dependency_id": dependency.TaskId,
+			})
 			continue
 		}
 		if !t.SatisfiesDependency(&depTask) {

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -133,57 +133,8 @@ func (d *basicCachedDAGDispatcherImpl) addEdge(fromID string, toID string) error
 	fromNode := d.getNodeByItemID(fromID)
 	toNode := d.getNodeByItemID(toID)
 
+	// The "depend_on" <from> task is not in the DAG so we don't need an edge.
 	if fromNode == nil {
-		// Get the "dependent" <to> task from the database.
-		toTask, err := task.FindOneId(toID)
-		if err != nil {
-			grip.Warning(message.WrapError(err, message.Fields{
-				"dispatcher": DAGDispatcher,
-				"function":   "addEdge",
-				"message":    "problem finding task in db",
-				"task_id":    toID,
-				"distro_id":  d.distroID,
-			}))
-
-			return errors.Wrapf(err, "error adding edge from '%s' to '%s' - database problem while finding task '%s'", fromID, toID, toID)
-		}
-		if toTask == nil {
-			grip.Warning(message.Fields{
-				"dispatcher": DAGDispatcher,
-				"function":   "addEdge",
-				"message":    "task from db not found",
-				"task_id":    toID,
-				"distro_id":  d.distroID,
-			})
-
-			return errors.Errorf("error adding edge from '%s' to '%s' - task '%s' does not exist in the database", fromID, toID, toID)
-		}
-
-		// Get the "depends_on" <from> task to be satisfied from the database.
-		fromTask, err := task.FindOneId(fromID)
-		if err != nil {
-			grip.Warning(message.WrapError(err, message.Fields{
-				"dispatcher": DAGDispatcher,
-				"function":   "addEdge",
-				"message":    "problem finding task in db",
-				"task_id":    fromID,
-				"distro_id":  d.distroID,
-			}))
-
-			return errors.Wrapf(err, "error adding edge from '%s' to '%s' - database problem while finding task '%s'", fromID, toID, fromID)
-		}
-		if fromTask == nil {
-			grip.Warning(message.Fields{
-				"dispatcher": DAGDispatcher,
-				"function":   "addEdge",
-				"message":    "task from db not found",
-				"task_id":    fromID,
-				"distro_id":  d.distroID,
-			})
-
-			return errors.Errorf("error adding edge from '%s' to '%s' - task '%s' does not exist in the database", fromID, toID, fromID)
-		}
-
 		return nil
 	}
 

--- a/model/task_queue_service_test.go
+++ b/model/task_queue_service_test.go
@@ -960,11 +960,6 @@ func (s *taskDAGDispatchServiceSuite) TestAddingEdgeWithMissingNodes() {
 	next := service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("1", next.Id)
-
-	next = service.FindNextTask(spec)
-	s.Require().Nil(next)
-	next = service.FindNextTask(spec)
-	s.Require().Nil(next)
 	next = service.FindNextTask(spec)
 	s.Require().Nil(next)
 
@@ -1001,10 +996,8 @@ func (s *taskDAGDispatchServiceSuite) TestAddingEdgeWithMissingNodes() {
 	next = service.FindNextTask(spec)
 	s.Require().Nil(next)
 
-	//
-
 	t2.DependsOn = []task.Dependency{
-		task.Dependency{
+		{
 			TaskId:       "1", // A Task.Id that will not be in the task_queue.
 			Status:       evergreen.TaskSucceeded,
 			Unattainable: false,
@@ -1017,7 +1010,6 @@ func (s *taskDAGDispatchServiceSuite) TestAddingEdgeWithMissingNodes() {
 	s.Require().NoError(t3.Insert())
 
 	items = []TaskQueueItem{}
-	// items = append(items, item1)
 	items = append(items, item2)
 	items = append(items, item3)
 
@@ -1028,11 +1020,15 @@ func (s *taskDAGDispatchServiceSuite) TestAddingEdgeWithMissingNodes() {
 
 	service, err = newDistroTaskDAGDispatchService(s.taskQueue, time.Minute)
 	s.NoError(err)
-	err = service.addEdge("2", "5") // There is no Node for the <to> task.Id: "5" in the task_queue.
+
+	// There is no Node for the <to> task.Id: "5" in the task_queue.
+	err = service.addEdge("2", "5")
 	s.Error(err)
 	s.Contains(err.Error(), "is not present in the DAG", nil)
 
-	//
+	// There is no Node for the <from> task.Id: "5" in the task_queue.
+	err = service.addEdge("5", "2")
+	s.NoError(err)
 
 	t1.Status = evergreen.TaskFailed
 	t3.DependsOn = []task.Dependency{{


### PR DESCRIPTION
It's valid for the task queue to not contain tasks that are depended on:
- if the depended on task doesn't exist.
- if the depended on task has already run.

We don't need to validate the existence of the tasks when the depended_on task because it's not an error condition from the perspective of the dispatcher. Skipping the edge is the right thing to do: we don't need to be ordered after a task if the task isn't in the queue. Granted, we shouldn't have dependencies that don't exist, but this shouldn't be the dispatcher's concern.

Also, ignore dependencies that don't exist. We should separately handle why dependencies on tasks that don't exist get created, but they shouldn't cause the task to hang out in the task queue forever. Either we automatically deactivate such a task or allow it to run. I opted to allow it to run.