### PR TITLE
EVG-13402 refactor annotations

### DIFF
--- a/model/annotations/db.go
+++ b/model/annotations/db.go
@@ -95,9 +95,8 @@ func ByTaskIds(ids []string) db.Q {
 	return db.Query(q)
 }
 
-// ByIdAndExecutionAndType returns the query for a given Task Id and
-// execution number, populated according to the given type
-func ByIdExecutionAndType(id string, execution int) db.Q {
+// ByIdAndExecution returns the query for a given Task Id and execution number
+func ByIdAndExecution(id string, execution int) db.Q {
 	q := bson.M{
 		TaskIdKey:        id,
 		TaskExecutionKey: execution,

--- a/model/annotations/db.go
+++ b/model/annotations/db.go
@@ -20,9 +20,9 @@ var (
 )
 
 const (
-	Collection = "task_annotation"
-	UISource   = "UI"
-	APISource  = "API"
+	Collection   = "task_annotation"
+	UIRequester  = "ui"
+	APIRequester = "api"
 )
 
 // FindOne gets one TaskAnnotation for the given query.

--- a/model/annotations/db.go
+++ b/model/annotations/db.go
@@ -1,7 +1,6 @@
 package annotations
 
 import (
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
@@ -11,21 +10,19 @@ import (
 
 var (
 	// bson fields for the TaskAnnotation struct
-	IdKey             = bsonutil.MustHaveTag(TaskAnnotation{}, "Id")
-	TaskIdKey         = bsonutil.MustHaveTag(TaskAnnotation{}, "TaskId")
-	TaskExecutionKey  = bsonutil.MustHaveTag(TaskAnnotation{}, "TaskExecution")
-	APIAnnotationKey  = bsonutil.MustHaveTag(TaskAnnotation{}, "APIAnnotation")
-	UserAnnotationKey = bsonutil.MustHaveTag(TaskAnnotation{}, "UserAnnotation")
-	MetadataKey       = bsonutil.MustHaveTag(TaskAnnotation{}, "Metadata")
+	IdKey              = bsonutil.MustHaveTag(TaskAnnotation{}, "Id")
+	TaskIdKey          = bsonutil.MustHaveTag(TaskAnnotation{}, "TaskId")
+	TaskExecutionKey   = bsonutil.MustHaveTag(TaskAnnotation{}, "TaskExecution")
+	MetadataKey        = bsonutil.MustHaveTag(TaskAnnotation{}, "Metadata")
+	NoteKey            = bsonutil.MustHaveTag(TaskAnnotation{}, "Note")
+	IssuesKey          = bsonutil.MustHaveTag(TaskAnnotation{}, "Issues")
+	SuspectedIssuesKey = bsonutil.MustHaveTag(TaskAnnotation{}, "SuspectedIssues")
 )
 
-const Collection = "task_annotation"
-
-type AnnotationType int
-
 const (
-	APIAnnotationType AnnotationType = iota
-	UserAnnotationType
+	Collection = "task_annotation"
+	UISource   = "UI"
+	APISource  = "API"
 )
 
 // FindOne gets one TaskAnnotation for the given query.
@@ -64,51 +61,18 @@ func FindByID(id string) (*TaskAnnotation, error) {
 	return annotation, nil
 }
 
-func FindAPIAnnotationsByTaskIds(ids []string) ([]TaskAnnotation, error) {
-	return Find(ByTaskIdsAndType(ids, APIAnnotationType))
+func FindAnnotationsByTaskIds(ids []string) ([]TaskAnnotation, error) {
+	return Find(ByTaskIds(ids))
 }
 
 // Insert writes the task_annotation to the database.
-func (annotation *TaskAnnotation) Insert() error {
-	return db.Insert(Collection, annotation)
+func (a *TaskAnnotation) Insert() error {
+	return db.Insert(Collection, a)
 }
 
 // Update updates one task_annotation.
-func (annotation *TaskAnnotation) Update() error {
-	return db.UpdateId(Collection, annotation.Id, annotation)
-}
-
-// Update updates one task_annotation.
-func (annotation *TaskAnnotation) UpdateAPIAnnotation(id string, execution int, a Annotation, m *birch.Document) error {
-	return errors.WithStack(db.Update(
-		Collection,
-		bson.M{
-			TaskIdKey:        id,
-			TaskExecutionKey: execution,
-		},
-		bson.M{
-			"$set": bson.M{
-				APIAnnotationKey: a,
-				MetadataKey:      m,
-			},
-		},
-	))
-}
-
-// Update updates one task_annotation.
-func (annotation *TaskAnnotation) UpdateUserAnnotation(id string, execution int, a Annotation) error {
-	return errors.WithStack(db.Update(
-		Collection,
-		bson.M{
-			TaskIdKey:        id,
-			TaskExecutionKey: execution,
-		},
-		bson.M{
-			"$set": bson.M{
-				UserAnnotationKey: a,
-			},
-		},
-	))
+func (a *TaskAnnotation) Update() error {
+	return db.UpdateId(Collection, a.Id, a)
 }
 
 // Remove removes one task_annotation.
@@ -126,29 +90,17 @@ func ByTaskId(taskId string) db.Q {
 	return db.Query(bson.M{TaskIdKey: taskId})
 }
 
-func ByTaskIdsAndType(ids []string, aType AnnotationType) db.Q {
+func ByTaskIds(ids []string) db.Q {
 	q := bson.M{TaskIdKey: bson.M{"$in": ids}}
-	return queryWithType(q, aType)
+	return db.Query(q)
 }
 
 // ByIdAndExecutionAndType returns the query for a given Task Id and
 // execution number, populated according to the given type
-func ByIdExecutionAndType(id string, execution int, aType AnnotationType) db.Q {
+func ByIdExecutionAndType(id string, execution int) db.Q {
 	q := bson.M{
 		TaskIdKey:        id,
 		TaskExecutionKey: execution,
-	}
-	return queryWithType(q, aType)
-}
-
-func queryWithType(q bson.M, aType AnnotationType) db.Q {
-	switch aType {
-	case APIAnnotationType:
-		q[APIAnnotationKey] = bson.M{"$exists": true}
-		return db.Query(q).WithoutFields(UserAnnotationKey)
-	case UserAnnotationType:
-		q[UserAnnotationKey] = bson.M{"$exists": true}
-		return db.Query(q).WithoutFields(MetadataKey, APIAnnotationKey)
 	}
 	return db.Query(q)
 }

--- a/model/annotations/task_annotations.go
+++ b/model/annotations/task_annotations.go
@@ -7,15 +7,16 @@ import (
 )
 
 type TaskAnnotation struct {
-	Id            string `bson:"_id" json:"id"`
-	TaskId        string `bson:"task_id" json:"task_id"`
-	TaskExecution int    `bson:"task_execution" json:"task_execution"`
-	// the task annotation that is api sourced and will be overwritten when updated
-	APIAnnotation *Annotation `bson:"api_annotation,omitempty" json:"api_annotation,omitempty"`
-	// user edits to the annotation that will be preserved
-	UserAnnotation *Annotation `bson:"user_annotation,omitempty" json:"user_annotation,omitempty"`
-	// structured data about the task (not displayed in the UI, but available in the API)
-	Metadata *birch.Document `bson:"metadata,omitempty" json:"metadata,omitempty"`
+	Id            string          `bson:"_id" json:"id"`
+	TaskId        string          `bson:"task_id" json:"task_id"`
+	TaskExecution int             `bson:"task_execution" json:"task_execution"`
+	Metadata      *birch.Document `bson:"metadata,omitempty" json:"metadata,omitempty"`
+	// comment about the failure
+	Note *Note `bson:"note,omitempty" json:"note,omitempty"`
+	// links to tickets definitely related.
+	Issues []IssueLink `bson:"issues,omitempty" json:"issues,omitempty"`
+	// links to tickets possibly related
+	SuspectedIssues []IssueLink `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
 }
 
 type IssueLink struct {
@@ -26,17 +27,9 @@ type IssueLink struct {
 }
 
 type Source struct {
-	Author string    `bson:"author,omitempty" json:"author,omitempty"`
-	Time   time.Time `bson:"time,omitempty" json:"time,omitempty"`
-}
-
-type Annotation struct {
-	// comment about the failure
-	Note *Note `bson:"note,omitempty" json:"note,omitempty"`
-	// links to tickets definitely related.
-	Issues []IssueLink `bson:"issues,omitempty" json:"issues,omitempty"`
-	// links to tickets possibly related
-	SuspectedIssues []IssueLink `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
+	Author    string    `bson:"author,omitempty" json:"author,omitempty"`
+	Time      time.Time `bson:"time,omitempty" json:"time,omitempty"`
+	Requester string    `bson:"requester,omitempty" json:"requester,omitempty"`
 }
 
 type Note struct {

--- a/model/annotations/task_annotations_test.go
+++ b/model/annotations/task_annotations_test.go
@@ -16,40 +16,30 @@ func TestGetLatestExecutions(t *testing.T) {
 	assert.NoError(t, db.Clear(Collection))
 	annotations := []TaskAnnotation{
 		{
-			Id:             "1",
-			TaskId:         "t1",
-			TaskExecution:  2,
-			APIAnnotation:  &Annotation{Note: &Note{Message: "this is a note"}},
-			UserAnnotation: &Annotation{Note: &Note{Message: "this will not be returned"}},
+			Id:            "1",
+			TaskId:        "t1",
+			TaskExecution: 2,
+			Note:          &Note{Message: "this is a note"},
 		},
 		{
 			Id:            "2",
 			TaskId:        "t1",
 			TaskExecution: 1,
-			APIAnnotation: &Annotation{Note: &Note{Message: "another note"}},
+			Note:          &Note{Message: "another note"},
 		},
 		{
-			Id:             "3",
-			TaskId:         "t1",
-			TaskExecution:  0,
-			UserAnnotation: &Annotation{Note: &Note{Message: "only a user annotation"}},
-		},
-		{
-			Id:            "4",
+			Id:            "3",
 			TaskId:        "t2",
 			TaskExecution: 0,
-			APIAnnotation: &Annotation{Note: &Note{Message: "this is the wrong task"}},
+			Note:          &Note{Message: "this is the wrong task"},
 		},
 	}
 	for _, a := range annotations {
 		assert.NoError(t, a.Insert())
 	}
 
-	annotations, err := FindAPIAnnotationsByTaskIds([]string{"t1", "t2"})
+	annotations, err := FindAnnotationsByTaskIds([]string{"t1", "t2"})
 	assert.NoError(t, err)
 	assert.Len(t, annotations, 3)
-	for _, a := range annotations {
-		assert.Nil(t, a.UserAnnotation)
-	}
 	assert.Len(t, GetLatestExecutions(annotations), 2)
 }

--- a/rest/model/task_annotations.go
+++ b/rest/model/task_annotations.go
@@ -8,54 +8,28 @@ import (
 )
 
 type APITaskAnnotation struct {
-	Id             *string         `bson:"_id" json:"id"`
-	TaskId         *string         `bson:"task_id" json:"task_id"`
-	TaskExecution  int             `bson:"task_execution" json:"task_execution"`
-	APIAnnotation  *APIAnnotation  `bson:"api_annotation,omitempty" json:"api_annotation,omitempty"`
-	UserAnnotation *APIAnnotation  `bson:"user_annotation,omitempty" json:"user_annotation,omitempty"`
-	Metadata       *birch.Document `bson:"metadata,omitempty" json:"metadata,omitempty"`
+	Id              *string         `bson:"_id" json:"id"`
+	TaskId          *string         `bson:"task_id" json:"task_id"`
+	TaskExecution   int             `bson:"task_execution" json:"task_execution"`
+	Metadata        *birch.Document `bson:"metadata,omitempty" json:"metadata,omitempty"`
+	Note            *APINote        `bson:"note,omitempty" json:"note,omitempty"`
+	Issues          []APIIssueLink  `bson:"issues,omitempty" json:"issues,omitempty"`
+	SuspectedIssues []APIIssueLink  `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
 }
-type APIAnnotation struct {
-	Note            *APINote       `bson:"note,omitempty" json:"note,omitempty"`
-	Issues          []APIIssueLink `bson:"issues,omitempty" json:"issues,omitempty"`
-	SuspectedIssues []APIIssueLink `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
-}
+
 type APINote struct {
 	Message *string    `bson:"message,omitempty" json:"message,omitempty"`
 	Source  *APISource `bson:"source,omitempty" json:"source,omitempty"`
 }
 type APISource struct {
-	Author *string    `bson:"author,omitempty" json:"author,omitempty"`
-	Time   *time.Time `bson:"time,omitempty" json:"time,omitempty"`
+	Author    *string    `bson:"author,omitempty" json:"author,omitempty"`
+	Time      *time.Time `bson:"time,omitempty" json:"time,omitempty"`
+	Requester *string    `bson:"requester,omitempty" json:"requester,omitempty"`
 }
 type APIIssueLink struct {
 	URL      *string    `bson:"url" json:"url"`
 	IssueKey *string    `bson:"issue_key,omitempty" json:"issue_key,omitempty"`
 	Source   *APISource `bson:"source,omitempty" json:"source,omitempty"`
-}
-
-// APIAnnotationBuildFromService takes the annotations.Annotation DB struct and
-// returns the REST struct *APIAnnotation with the corresponding fields populated
-func APIAnnotationBuildFromService(t *annotations.Annotation) *APIAnnotation {
-	if t == nil {
-		return nil
-	}
-	m := APIAnnotation{}
-	m.Issues = ArrtaskannotationsIssueLinkArrAPIIssueLink(t.Issues)
-	m.Note = APINoteBuildFromService(t.Note)
-	return &m
-}
-
-// APIAnnotationToService takes the APIAnnotation REST struct and returns the DB struct
-// *annotations.Annotation with the corresponding fields populated
-func APIAnnotationToService(m *APIAnnotation) *annotations.Annotation {
-	if m == nil {
-		return nil
-	}
-	out := &annotations.Annotation{}
-	out.Issues = ArrAPIIssueLinkArrtaskannotationsIssueLink(m.Issues)
-	out.Note = APINoteToService(m.Note)
-	return out
 }
 
 // APISourceBuildFromService takes the annotations.Source DB struct and
@@ -67,6 +41,7 @@ func APISourceBuildFromService(t *annotations.Source) *APISource {
 	m := APISource{}
 	m.Author = StringStringPtr(t.Author)
 	m.Time = ToTimePtr(t.Time)
+	m.Requester = StringStringPtr(t.Requester)
 	return &m
 }
 
@@ -78,6 +53,7 @@ func APISourceToService(m *APISource) *annotations.Source {
 	}
 	out := &annotations.Source{}
 	out.Author = StringPtrString(m.Author)
+	out.Requester = StringPtrString(m.Requester)
 	if m.Time != nil {
 		out.Time = *m.Time
 	} else {
@@ -134,12 +110,13 @@ func APINoteToService(m *APINote) *annotations.Note {
 // returns the REST struct *APITaskAnnotation with the corresponding fields populated
 func APITaskAnnotationBuildFromService(t annotations.TaskAnnotation) *APITaskAnnotation {
 	m := APITaskAnnotation{}
-	m.APIAnnotation = APIAnnotationBuildFromService(t.APIAnnotation)
 	m.Id = StringStringPtr(t.Id)
 	m.TaskExecution = t.TaskExecution
 	m.TaskId = StringStringPtr(t.TaskId)
-	m.UserAnnotation = APIAnnotationBuildFromService(t.UserAnnotation)
 	m.Metadata = t.Metadata
+	m.Issues = ArrtaskannotationsIssueLinkArrAPIIssueLink(t.Issues)
+	m.SuspectedIssues = ArrtaskannotationsIssueLinkArrAPIIssueLink(t.SuspectedIssues)
+	m.Note = APINoteBuildFromService(t.Note)
 	return &m
 }
 
@@ -147,12 +124,13 @@ func APITaskAnnotationBuildFromService(t annotations.TaskAnnotation) *APITaskAnn
 // *annotations.TaskAnnotation with the corresponding fields populated
 func APITaskAnnotationToService(m APITaskAnnotation) *annotations.TaskAnnotation {
 	out := &annotations.TaskAnnotation{}
-	out.APIAnnotation = APIAnnotationToService(m.APIAnnotation)
 	out.Id = StringPtrString(m.Id)
 	out.TaskExecution = m.TaskExecution
 	out.TaskId = StringPtrString(m.TaskId)
-	out.UserAnnotation = APIAnnotationToService(m.UserAnnotation)
 	out.Metadata = m.Metadata
+	out.Issues = ArrAPIIssueLinkArrtaskannotationsIssueLink(m.Issues)
+	out.SuspectedIssues = ArrAPIIssueLinkArrtaskannotationsIssueLink(m.SuspectedIssues)
+	out.Note = APINoteToService(m.Note)
 	return out
 }
 

--- a/rest/route/annotations.go
+++ b/rest/route/annotations.go
@@ -100,7 +100,7 @@ func (h *annotationsByVersionHandler) Run(ctx context.Context) gimlet.Responder 
 }
 
 func getAPIAnnotationsForTaskIds(taskIds []string, allExecutions bool) gimlet.Responder {
-	allAnnotations, err := annotations.FindAPIAnnotationsByTaskIds(taskIds)
+	allAnnotations, err := annotations.FindAnnotationsByTaskIds(taskIds)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "error finding task annotations"))
 	}


### PR DESCRIPTION
Choosing to remove a layer of indirection by removing Annotation from being embedded in TaskAnnotation.

Update in the future will need to be modified to update each field of annotation (preferably if that field has been modified) and will also need to populate the source; because no modification routes have been made I think that work will fit better wit those routes, and this refactor unblocks them.