### PR TITLE
EVG-13404: remove preconfigured image provisioning option and clean up provisioning method queries

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -251,11 +251,10 @@ const (
 
 	// Bootstrapping mechanisms
 	// BootstrapMethodNone is for internal use only.
-	BootstrapMethodNone               = "none"
-	BootstrapMethodLegacySSH          = "legacy-ssh"
-	BootstrapMethodSSH                = "ssh"
-	BootstrapMethodPreconfiguredImage = "preconfigured-image"
-	BootstrapMethodUserData           = "user-data"
+	BootstrapMethodNone      = "none"
+	BootstrapMethodLegacySSH = "legacy-ssh"
+	BootstrapMethodSSH       = "ssh"
+	BootstrapMethodUserData  = "user-data"
 
 	// Means of communicating with hosts
 	CommunicationMethodLegacySSH = "legacy-ssh"
@@ -273,7 +272,6 @@ var validBootstrapMethods = []string{
 	BootstrapMethodNone,
 	BootstrapMethodLegacySSH,
 	BootstrapMethodSSH,
-	BootstrapMethodPreconfiguredImage,
 	BootstrapMethodUserData,
 }
 
@@ -293,18 +291,6 @@ var validCloneMethods = []string{
 // Seed the random number generator for creating distro names
 func init() {
 	rand.Seed(time.Now().UnixNano())
-}
-
-func (d *Distro) ManagementMethodsUseSSH() bool {
-	if utility.StringSliceContains([]string{BootstrapMethodLegacySSH, BootstrapMethodSSH}, d.BootstrapSettings.Method) {
-		return true
-	}
-
-	if utility.StringSliceContains([]string{CommunicationMethodLegacySSH, CommunicationMethodSSH}, d.BootstrapSettings.Communication) {
-		return true
-	}
-
-	return false
 }
 
 // GenerateName generates a unique instance name for a distro.

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -932,12 +932,9 @@ func (h *Host) setAwaitingJasperRestart(user string) error {
 	}
 	bootstrapKey := bsonutil.GetDottedKeyName(DistroKey, distro.BootstrapSettingsKey, distro.BootstrapSettingsMethodKey)
 	if err := UpdateOne(bson.M{
-		IdKey:     h.Id,
-		StatusKey: bson.M{"$in": []string{evergreen.HostProvisioning, evergreen.HostRunning}},
-		bootstrapKey: bson.M{
-			"$exists": true,
-			"$ne":     distro.BootstrapMethodLegacySSH,
-		},
+		IdKey:        h.Id,
+		StatusKey:    bson.M{"$in": []string{evergreen.HostProvisioning, evergreen.HostRunning}},
+		bootstrapKey: bson.M{"$in": []string{distro.BootstrapMethodSSH, distro.BootstrapMethodUserData}},
 		"$or": []bson.M{
 			{NeedsReprovisionKey: bson.M{"$exists": false}},
 			{NeedsReprovisionKey: ReprovisionJasperRestart},

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -77,9 +77,6 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
     'id': 'ssh',
     'display': 'SSH'
   }, {
-    'id': 'preconfigured-image',
-    'display': 'Preconfigured Image'
-  }, {
     'id': 'user-data',
     'display': 'User Data'
   }, {}];

--- a/validator/distro_validator_test.go
+++ b/validator/distro_validator_test.go
@@ -514,7 +514,6 @@ func TestEnsureValidBootstrapSettings(t *testing.T) {
 		distro.BootstrapMethodLegacySSH,
 		distro.BootstrapMethodSSH,
 		distro.BootstrapMethodUserData,
-		distro.BootstrapMethodPreconfiguredImage,
 	} {
 		for _, communication := range []string{
 			distro.CommunicationMethodLegacySSH,
@@ -658,7 +657,6 @@ func TestEnsureValidStaticBootstrapSettings(t *testing.T) {
 	for _, method := range []string{
 		distro.BootstrapMethodLegacySSH,
 		distro.BootstrapMethodSSH,
-		distro.BootstrapMethodPreconfiguredImage,
 	} {
 		d.BootstrapSettings.Method = method
 		assert.Nil(t, ensureValidStaticBootstrapSettings(ctx, &d, &evergreen.Settings{}))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13404

* Remove preconfigured images as a distro provisioning method since we never implemented this.
* All distros/hosts at this point have set their provisioning method to a real value, so it's no longer necessary to count the empty string or a nonexistent provisioning method key as legacy SSH. This means we can simplify the host queries filtering by provisioning method.