### PR TITLE
EVG-13106 clarify backport help doc

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-11-10"
+	ClientVersion = "2020-11-11"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-11-10"

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -294,13 +294,22 @@ func enqueuePatch() cli.Command {
 func backport() cli.Command {
 	return cli.Command{
 		Name:  "backport",
-		Usage: "automatically backport low-risk commits",
+		Usage: "Create a backport patch for low-risk commits. Changes are automatically enqueued when the patch succeeds.",
 		Flags: mergeFlagSlices(
 			addPatchFinalizeFlag(),
-			addVariantsFlag(),
-			addTasksFlag(),
-			addPatchAliasFlag(),
 			addPatchBrowseFlag(
+				cli.StringSliceFlag{
+					Name:  joinFlagNames(tasksFlagName, "t"),
+					Usage: "tasks to validate the backport",
+				},
+				cli.StringSliceFlag{
+					Name:  joinFlagNames(variantsFlagName, "v"),
+					Usage: "variants to validate the backport",
+				},
+				cli.StringFlag{
+					Name:  joinFlagNames(patchAliasFlagName, "a"),
+					Usage: "patch alias to select tasks/variants to validate the backport",
+				},
 				cli.StringFlag{
 					Name:  joinFlagNames(existingPatchFlag, "e"),
 					Usage: "existing commit queue patch",

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -99,24 +99,10 @@ func addLargeFlag(flags ...cli.Flag) []cli.Flag {
 
 }
 
-func addTasksFlag(flags ...cli.Flag) []cli.Flag {
-	return append(flags, cli.StringSliceFlag{
-		Name:  joinFlagNames(tasksFlagName, "t"),
-		Usage: "task names",
-	})
-}
-
 func addParameterFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.StringSliceFlag{
 		Name:  parameterFlagName,
 		Usage: "specify a parameter as a KEY=VALUE pair",
-	})
-}
-
-func addPatchAliasFlag(flags ...cli.Flag) []cli.Flag {
-	return append(flags, cli.StringFlag{
-		Name:  joinFlagNames(patchAliasFlagName, "a"),
-		Usage: "patch alias (set by project admin)",
 	})
 }
 

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -23,9 +23,7 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 		addProjectFlag(flags...),
 		addPatchFinalizeFlag(),
 		addVariantsFlag(),
-		addTasksFlag(),
 		addParameterFlag(),
-		addPatchAliasFlag(),
 		addPatchBrowseFlag(),
 		addSyncBuildVariantsFlag(),
 		addSyncTasksFlag(),
@@ -36,6 +34,14 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 		addRefFlag(),
 		addUncommittedChangesFlag(),
 		addPreserveCommitsFlag(
+			cli.StringSliceFlag{
+				Name:  joinFlagNames(tasksFlagName, "t"),
+				Usage: "task names",
+			},
+			cli.StringFlag{
+				Name:  joinFlagNames(patchAliasFlagName, "a"),
+				Usage: "patch alias (set by project admin)",
+			},
 			cli.StringFlag{
 				Name:  joinFlagNames(patchDescriptionFlagName, "d"),
 				Usage: "description for the patch",


### PR DESCRIPTION
Make the help doc for `evergreen commit-queue backport --help` a little more helpful.