### PR TITLE
EVG-13311: do not populate commit queue jobs in two different Amboy queues

### DIFF
--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -49,7 +49,6 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 
 	ops := []amboy.QueueOperation{
 		PopulateBackgroundStatsJobs(j.env, 0),
-		PopulateCommitQueueJobs(j.env),
 		PopulateContainerStateJobs(j.env),
 		PopulateDataCleanupJobs(j.env),
 		PopulateEventAlertProcessing(j.env),


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13311

The double commit queue job running bug seems to be happening because each per-minute commit queue job is enqueued in two logically separate queues. They get populated once in the regular remote queue (in the "evg.service.jobs" collection) and then again in the dedicated "service.commitqueue" queue group (which is stored in a separate collection "evg.service.group"). The reason the commit queue job ran twice in the logs is because they apparently _always_ run twice, but I guess usually we're lucky and one finishes fast enough that the duplicate one doesn't interfere.

Evidence: If you look for the job in "evg.service.jobs" (`{"_id": "commit-queue:mongot-master_2020-10-21.15-42-00"}`) and "evg.service.group" (`{"_id": "service.commitqueue.commit-queue:mongot-master_2020-10-21.15-42-00"}`), you'll see that both of them were, in fact, dispatched to two different app servers with two different results because they're in separate collections. The double enqueueing problem should be fixed by just not populating the regular remote queue.