### PR TITLE
EVG-13349 fix backporting of patches by patch ID

### DIFF
--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -149,7 +149,7 @@ func (g *cliIntent) RequesterIdentity() string {
 
 // NewPatch creates a patch from the intent
 func (c *cliIntent) NewPatch() *Patch {
-	return &Patch{
+	p := Patch{
 		Description:   c.Description,
 		Author:        c.User,
 		Project:       c.ProjectID,
@@ -161,16 +161,19 @@ func (c *cliIntent) NewPatch() *Patch {
 		Tasks:         c.Tasks,
 		SyncAtEndOpts: c.SyncAtEndOpts,
 		BackportOf:    c.BackportOf,
-		Patches: []ModulePatch{
-			{
+		Patches:       []ModulePatch{},
+	}
+	if p.BackportOf.PatchID == "" { // the intent processor adds the patches if backporting by patch ID
+		p.Patches = append(p.Patches,
+			ModulePatch{
 				ModuleName: c.Module,
 				Githash:    c.BaseHash,
 				PatchSet: PatchSet{
 					PatchFileId: c.PatchFileID.Hex(),
 				},
-			},
-		},
+			})
 	}
+	return &p
 }
 
 type CLIIntentParams struct {

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -74,6 +74,9 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 		RemotePath:       "self-tests.yml",
 		RepoKind:         "github",
 		PRTestingEnabled: true,
+		CommitQueue: model.CommitQueueParams{
+			Enabled: true,
+		},
 	}).Insert())
 
 	s.NoError((&user.DBUser{
@@ -552,4 +555,53 @@ func (s *PatchIntentUnitsSuite) verifyGithubSubscriptions(patchDoc *patch.Patch)
 
 	s.True(foundPatch)
 	s.True(foundBuild)
+}
+
+func (s *PatchIntentUnitsSuite) TestCliBackport() {
+	sourcePatch := &patch.Patch{
+		Id:      mgobson.NewObjectId(),
+		Project: s.project,
+		Githash: s.hash,
+		Alias:   evergreen.CommitQueueAlias,
+		Patches: []patch.ModulePatch{
+			{
+				Githash: "revision",
+				PatchSet: patch.PatchSet{
+					Patch: "something",
+					Summary: []thirdparty.Summary{
+						{Name: "asdf", Additions: 4, Deletions: 80},
+						{Name: "random.txt", Additions: 6, Deletions: 0},
+					},
+				},
+			},
+		},
+	}
+	s.NoError(sourcePatch.Insert())
+	params := patch.CLIIntentParams{
+		User:        s.user,
+		Project:     s.project,
+		BaseGitHash: s.hash,
+		BackportOf: patch.BackportInfo{
+			PatchID: sourcePatch.Id.Hex(),
+		},
+	}
+
+	intent, err := patch.NewCliIntent(params)
+	s.NoError(err)
+	s.NotNil(intent)
+	s.NoError(intent.Insert())
+
+	id := mgobson.NewObjectId()
+	j, ok := NewPatchIntentProcessor(id, intent).(*patchIntentProcessor)
+	j.env = s.env
+	s.True(ok)
+	s.NotNil(j)
+	j.Run(context.Background())
+	s.NoError(j.Error())
+
+	backportPatch, err := patch.FindOneId(id.Hex())
+	s.NoError(err)
+	s.Equal(sourcePatch.Id.Hex(), backportPatch.BackportOf.PatchID)
+	s.Len(backportPatch.Patches, 1)
+	s.Equal(sourcePatch.Patches[0].PatchSet.Patch, backportPatch.Patches[0].PatchSet.Patch)
 }


### PR DESCRIPTION
I think this never worked, but hopefully should now
`mci:SECONDARY> db.patches.findOne({"backport_of.patch_id": {$exists: true}})
null`