### PR TITLE
EVG-13050 patch trigger aliases

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1188,7 +1188,7 @@ func (t *PatchTriggerDefinition) Validate(parentProject string) error {
 	if childProject.Identifier == parentProject {
 		return errors.New("a project cannot trigger itself")
 	}
-	if !utility.StringSliceContains([]string{"", evergreen.PatchSucceeded, evergreen.PatchFailed}, t.Status) {
+	if !utility.StringSliceContains([]string{"", AllStatuses, evergreen.PatchSucceeded, evergreen.PatchFailed}, t.Status) {
 		return errors.Errorf("invalid status: %s", t.Status)
 	}
 	_, regexErr := regexp.Compile(t.BuildVariantRegex)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -144,12 +144,12 @@ type TriggerDefinition struct {
 }
 
 type PatchTriggerDefinition struct {
-	DefinitionAlias   string `bson:"definition_alias" json:"definition_alias"`
-	ChildProject      string `bson:"child_project" json:"child_project"`
-	Status            string `bson:"status,omitempty" json:"status,omitempty"`
-	TaskRegex         string `bson:"task_regex,omitempty" json:"task_regex,omitempty"`
-	BuildVariantRegex string `bson:"buildvariant_regex,omitempty" json:"buildvariant_regex,omitempty"`
-	ParentAsModule    string `bson:"parent_as_module,omitempty" json:"parent_as_module,omitempty"`
+	Alias          string `bson:"alias" json:"alias"`
+	ChildProject   string `bson:"child_project" json:"child_project"`
+	Status         string `bson:"status,omitempty" json:"status,omitempty"`
+	TaskRegex      string `bson:"task_regex,omitempty" json:"task_regex,omitempty"`
+	VariantRegex   string `bson:"variant_regex,omitempty" json:"variant_regex,omitempty"`
+	ParentAsModule string `bson:"parent_as_module,omitempty" json:"parent_as_module,omitempty"`
 }
 
 type PeriodicBuildDefinition struct {
@@ -1191,7 +1191,7 @@ func (t *PatchTriggerDefinition) Validate(parentProject string) error {
 	if !utility.StringSliceContains([]string{"", AllStatuses, evergreen.PatchSucceeded, evergreen.PatchFailed}, t.Status) {
 		return errors.Errorf("invalid status: %s", t.Status)
 	}
-	_, regexErr := regexp.Compile(t.BuildVariantRegex)
+	_, regexErr := regexp.Compile(t.VariantRegex)
 	if regexErr != nil {
 		return errors.Wrap(regexErr, "invalid variant regex")
 	}

--- a/public/static/partials/patch_trigger_alias_modal.html
+++ b/public/static/partials/patch_trigger_alias_modal.html
@@ -33,7 +33,7 @@
                 <section layout="row" flex>
                     <md-input-container flex=50>
                         <label>Variant regex:</label>
-                        <input type="text" ng-model="alias.buildvariant_regex" placeholder="select variants matching regex">
+                        <input type="text" ng-model="alias.variant_regex" placeholder="select variants matching regex">
                     </md-input-container>
                     <md-input-container flex=50>
                         <label>Task regex:</label>

--- a/public/static/partials/patch_trigger_alias_modal.html
+++ b/public/static/partials/patch_trigger_alias_modal.html
@@ -1,0 +1,49 @@
+<md-dialog style="width:650px">
+    <md-dialog-content>
+        <md-card style="width:97.5%">
+            <md-card-title>
+                <div ng-bind="modalTitle()"></div>
+            </md-card-title>
+            <md-card-content>
+                <section layout="row" flex>
+                    <md-input-container flex=50>
+                        <label>Alias:</label>
+                        <input type="text" ng-model="alias.definition_alias" ng-required="true" placeholder="alias name">
+                    </md-input-container>
+                    <md-input-container flex=50>
+                        <label>Project:</label>
+                        <input type="text" ng-model="alias.child_project" ng-required="true" placeholder="project to include tasks from">
+                    </md-input-container>
+                </section>
+                <section layout="row" flex>
+                    <md-input-container flex=50>
+                        <label>Module:</label>
+                        <input type="text" ng-model="alias.parent_as_module" placeholder="apply changes to a module">
+                    </md-input-container>
+                    <md-input-container flex=50>
+                        <label>Wait on:</label>
+                        <md-select ng-model="alias.status">
+                            <md-option value=""></md-option>
+                            <md-option value="*">Any Completed Status</md-option>
+                            <md-option value="succeeded">Success</md-option>
+                            <md-option value="failed">Failed</md-option>
+                        </md-select>
+                    </md-input-container>
+                </section>
+                <section layout="row" flex>
+                    <md-input-container flex=50>
+                        <label>Variant regex:</label>
+                        <input type="text" ng-model="alias.buildvariant_regex" placeholder="select variants matching regex">
+                    </md-input-container>
+                    <md-input-container flex=50>
+                        <label>Task regex:</label>
+                        <input type="text" ng-model="alias.task_regex" placeholder="select tasks matching regex">
+                    </md-input-container>
+                </section>
+            </md-card-content>
+        </md-card>
+        <md-button class="md-raised" ng-click="closeDialog(true)" style="width:20%;float:right">Save Changes</md-button>
+        <md-button class="md-raised" ng-show="aliasIndex!=undefined" ng-click="deleteAlias()" style="width:20%;float:right">Delete Alias</md-button>
+        <md-button class="md-raised" ng-click="closeDialog(false)" style="width:20%;float:right">Cancel</md-button>
+    </md-dialog-content>
+</md-dialog>

--- a/service/project.go
+++ b/service/project.go
@@ -240,6 +240,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		Subscriptions         []restModel.APISubscription      `json:"subscriptions"`
 		DeleteSubscriptions   []string                         `json:"delete_subscriptions"`
 		Triggers              []model.TriggerDefinition        `json:"triggers"`
+		PatchTriggerAliases   []model.PatchTriggerDefinition   `json:"patch_trigger_aliases"`
 		FilesIgnoredFromCache []string                         `json:"files_ignored_from_cache"`
 		DisabledStatsCache    bool                             `json:"disabled_stats_cache"`
 		PeriodicBuilds        []*model.PeriodicBuildDefinition `json:"periodic_builds"`
@@ -448,6 +449,9 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			responseRef.Triggers[i].DefinitionID = utility.RandomString()
 		}
 	}
+	for _, t := range responseRef.PatchTriggerAliases {
+		catcher.Add(t.Validate(id))
+	}
 	for i, buildDef := range responseRef.PeriodicBuilds {
 		catcher.Wrapf(buildDef.Validate(), "invalid periodic build definition on line %d", i+1)
 	}
@@ -482,6 +486,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectRef.RepotrackerDisabled = responseRef.RepotrackerDisabled
 	projectRef.NotifyOnBuildFailure = responseRef.NotifyOnBuildFailure
 	projectRef.Triggers = responseRef.Triggers
+	projectRef.PatchTriggerAliases = responseRef.PatchTriggerAliases
 	projectRef.FilesIgnoredFromCache = responseRef.FilesIgnoredFromCache
 	projectRef.DisabledStatsCache = responseRef.DisabledStatsCache
 	projectRef.PeriodicBuilds = []model.PeriodicBuildDefinition{}

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -766,7 +766,7 @@ Evergreen Projects
         </div>
 
         <!-- Patch Trigger Aliases -->
-        <div class="variables">
+        <div class="variables" style="display: none;">
           <div class="form-group">
             <div class="col-header col-lg-6 form-control-static">
               <h3>Patch Trigger Aliases</h3>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -765,6 +765,28 @@ Evergreen Projects
           </div>
         </div>
 
+        <!-- Patch Trigger Aliases -->
+        <div class="variables">
+          <div class="form-group">
+            <div class="col-header col-lg-6 form-control-static">
+              <h3>Patch Trigger Aliases</h3>
+              <div class="muted small">Define aliases used to add tasks from other projects to patches</div>
+            </div>
+          </div>
+
+          <div class="form-group" ng-repeat="alias in patch_trigger_aliases track by $index">
+              <a class="col-lg-12 link" ng-click="showPatchTriggerAliasModal($index)">[[alias.definition_alias]]</a>
+          </div>
+
+          <div class="form-group">
+            <div class="col-lg-2">
+              <button class="plus-button btn btn-primary" type="button" ng-click="showPatchTriggerAliasModal()">
+                <i class="fa fa-plus"></i> New Alias
+              </button>
+            </div>
+          </div>
+        </div>
+
         <!-- Triggers -->
         <div class="variables">
           <div class="form-group">


### PR DESCRIPTION
Users will eventually specify aliases to include tasks from other projects in their patch. This PR allows project admins to define the aliases that users will specify. It's mostly modeled after trigger definitions.

![Screen Shot 2020-11-13 at 10 55 17 AM](https://user-images.githubusercontent.com/17027265/99092277-ee6b4500-259e-11eb-920b-9b6b8d02cca4.png)
