### PR TITLE
EVG-8162 host.create should default to distro security group IDs

### DIFF
--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -391,16 +391,8 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	}
 
 	// Always override distro security group with provided security group.
-	// If empty, retrieve default security group from config.
 	if len(createHost.SecurityGroups) > 0 {
 		ec2Settings.SecurityGroupIDs = createHost.SecurityGroups
-	} else {
-		var settings *evergreen.Settings
-		settings, err = evergreen.GetConfig()
-		if err != nil {
-			return nil, errors.Wrap(err, "error retrieving evergreen settings")
-		}
-		ec2Settings.SecurityGroupIDs = []string{settings.Providers.AWS.DefaultSecurityGroup}
 	}
 
 	ec2Settings.IPv6 = createHost.IPv6

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -157,11 +157,6 @@ buildvariants:
 		assert.NoError(t, h1.Insert())
 
 		settings := &evergreen.Settings{
-			Providers: evergreen.CloudProviders{
-				AWS: evergreen.AWSConfig{
-					DefaultSecurityGroup: "sg-default",
-				},
-			},
 			Credentials: map[string]string{"github": "token globalGitHubOauthToken"},
 		}
 		assert.NoError(t, evergreen.UpdateConfig(settings))
@@ -231,11 +226,6 @@ buildvariants:
 		assert.NoError(t, h2.Insert())
 
 		settings := &evergreen.Settings{
-			Providers: evergreen.CloudProviders{
-				AWS: evergreen.AWSConfig{
-					DefaultSecurityGroup: "sg-default",
-				},
-			},
 			Credentials: map[string]string{"github": "token globalGitHubOauthToken"},
 		}
 		assert.NoError(t, evergreen.UpdateConfig(settings))
@@ -300,11 +290,6 @@ buildvariants:
 		assert.NoError(t, h3.Insert())
 
 		settings := &evergreen.Settings{
-			Providers: evergreen.CloudProviders{
-				AWS: evergreen.AWSConfig{
-					DefaultSecurityGroup: "sg-default",
-				},
-			},
 			Credentials: map[string]string{"github": "token globalGitHubOauthToken"},
 		}
 		assert.NoError(t, evergreen.UpdateConfig(settings))
@@ -324,7 +309,7 @@ buildvariants:
 			assert.NotEmpty(t, ec2Settings.KeyName)
 			assert.InDelta(t, time.Now().Add(evergreen.DefaultSpawnHostExpiration).Unix(), h.ExpirationTime.Unix(), float64(1*time.Millisecond))
 			require.Len(t, ec2Settings.SecurityGroupIDs, 1)
-			assert.Equal(t, "sg-default", ec2Settings.SecurityGroupIDs[0]) // none provided, should get default from config
+			assert.Equal(t, "sg-distro", ec2Settings.SecurityGroupIDs[0]) // if not overridden, stick with ec2 security group
 			assert.Equal(t, distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 		}
 	})

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -39,6 +39,7 @@ func TestMakeIntentHost(t *testing.T) {
 			birch.EC.String("region", "us-east-1"),
 			birch.EC.String("instance_type", "t1.micro"),
 			birch.EC.String("subnet_id", "subnet-12345678"),
+			birch.EC.SliceString("security_group_ids", []string{"abcdef"}),
 		)},
 	}
 	require.NoError(d.Insert())
@@ -236,6 +237,7 @@ func TestMakeIntentHost(t *testing.T) {
 		AWSSecret:           "my_secret_key",
 		InstanceType:        "t1.micro",
 		Subnet:              "subnet-123456",
+		SecurityGroups:      []string{"1234"},
 	}
 	handler.createHost = c
 	h, err = handler.sc.MakeIntentHost(handler.taskID, "", "", handler.createHost)


### PR DESCRIPTION
The [documentation](https://github.com/evergreen-ci/evergreen/wiki/Project-Commands#host-create) says that the default will be the distro security group IDs, but in the code itself we pull from the admin settings default, which isn't even set, so host.create validation doesn't error but the actual host creation doesn't work because no security groups were given to the host.