### PR TITLE
EVG-12966 redo group setup if switching to a different tg in same build

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -294,7 +294,7 @@ func (a *Agent) prepareNextTask(ctx context.Context, nextTask *apimodels.NextTas
 
 func nextTaskHasDifferentTaskGroupOrBuild(nextTask *apimodels.NextTaskResponse, tc *taskContext) bool {
 	if tc.taskConfig == nil ||
-		nextTask.TaskGroup == "" ||
+		nextTask.TaskGroup != tc.taskGroup ||
 		nextTask.Build != tc.taskConfig.Task.BuildId {
 		return true
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -294,6 +294,7 @@ func (a *Agent) prepareNextTask(ctx context.Context, nextTask *apimodels.NextTas
 
 func nextTaskHasDifferentTaskGroupOrBuild(nextTask *apimodels.NextTaskResponse, tc *taskContext) bool {
 	if tc.taskConfig == nil ||
+		nextTask.TaskGroup == "" ||
 		nextTask.TaskGroup != tc.taskGroup ||
 		nextTask.Build != tc.taskConfig.Task.BuildId {
 		return true

--- a/agent/task.go
+++ b/agent/task.go
@@ -195,6 +195,7 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 					return err
 				}
 			}
+			tc.logger.Task().Infof("Finished running setup_group for '%s'.", taskGroup.Name)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2020-11-11"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-11-13"
+	AgentVersion = "2020-11-13b"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Not changed in this pr: if a task restarts and runs immediately on the same host, we don't consider that a new task group. That's probably the right behavior, but it may be unintuitive