### PR TITLE
EVG-13282: create CLI command to fetch and execute host provisioning script

### DIFF
--- a/operations/host.go
+++ b/operations/host.go
@@ -16,6 +16,7 @@ func Host() cli.Command {
 			hostDetach(),
 			hostList(),
 			hostTerminate(),
+			hostProvision(),
 			hostSetup(),
 			hostSSH(),
 			hostRunCommand(),

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -105,10 +105,6 @@ func makeHostProvisioningScriptFile(workingDir, content string) (string, error) 
 }
 
 func hostProvisioningCommand(directive, scriptPath string) (*jasper.Command, error) {
-	// kim: NOTE: I have some doubts about the PowerShell quoted strings in the
-	// script. I wrote the shell quoting and string buffering hacks specifically
-	// for user data, but I'm unsure if it'll behave the exact same way when
-	// invoked with powershell like this.
 	if directive == string(userdata.PowerShellScript) {
 		return jasper.NewCommand().AppendArgs("powershell", scriptPath), nil
 	}

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -1,0 +1,131 @@
+package operations
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/evergreen-ci/evergreen/cloud/userdata"
+	"github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/jasper"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+func hostProvision() cli.Command {
+	const (
+		hostIDFlagName       = "host_id"
+		hostSecretFlagName   = "host_secret"
+		workingDirFlagName   = "working_dir"
+		apiServerURLFlagName = "api_server"
+	)
+	return cli.Command{
+		Name:  "provision",
+		Usage: "fetch and run the host provisioning script",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  hostIDFlagName,
+				Usage: "the host ID",
+			},
+			cli.StringFlag{
+				Name:  hostSecretFlagName,
+				Usage: "the host secret",
+			},
+			cli.StringFlag{
+				Name:  workingDirFlagName,
+				Usage: "the working directory for the script",
+			},
+			cli.StringFlag{
+				Name:  apiServerURLFlagName,
+				Usage: "the base URL for the API server",
+			},
+		},
+		Before: mergeBeforeFuncs(
+			requireStringFlag(hostIDFlagName),
+			requireStringFlag(hostSecretFlagName),
+			requireStringFlag(apiServerURLFlagName),
+		),
+		Action: func(c *cli.Context) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			comm := client.NewCommunicator(c.String(apiServerURLFlagName))
+			defer comm.Close()
+
+			opts, err := comm.GetHostProvisioningScript(ctx, c.String(hostIDFlagName), c.String(hostSecretFlagName))
+			if err != nil {
+				return errors.Wrap(err, "failed to get host provisioning script")
+			}
+
+			workingDir := c.String(workingDirFlagName)
+			scriptPath, err := makeHostProvisioningScriptFile(workingDir, opts.Content)
+			if err != nil {
+				return errors.Wrap(err, "write host provisioning script to file")
+			}
+			defer func() {
+				grip.Error(errors.Wrap(os.RemoveAll(scriptPath), "removing host provisioning file"))
+			}()
+
+			cmd, err := hostProvisioningCommand(opts.Directive, scriptPath)
+			if err != nil {
+				return errors.Wrap(err, "resolving command to execute script")
+			}
+			output, err := runHostProvisioningCommand(ctx, cmd.Directory(workingDir))
+			if err != nil {
+				fmt.Fprintln(os.Stderr, output)
+				return errors.Wrap(err, "running host provisioning script")
+			}
+			if len(output) != 0 {
+				fmt.Println(output)
+			}
+
+			return nil
+		},
+	}
+}
+
+func makeHostProvisioningScriptFile(workingDir, content string) (string, error) {
+	if err := os.MkdirAll(workingDir, 0755); err != nil {
+		return "", errors.Wrap(err, "creating working directory")
+	}
+
+	scriptPath, err := filepath.Abs(filepath.Join(workingDir, "host_provisioning"))
+	if err != nil {
+		return "", errors.Wrap(err, "making absolute path to the host provisioning script")
+	}
+	if err = ioutil.WriteFile(scriptPath, []byte(content), 0700); err != nil {
+		return "", errors.Wrapf(err, "writing script to file '%s'", scriptPath)
+	}
+	return scriptPath, nil
+}
+
+func hostProvisioningCommand(directive, scriptPath string) (*jasper.Command, error) {
+	// kim: NOTE: I have some doubts about the PowerShell quoted strings in the
+	// script. I wrote the shell quoting and string buffering hacks specifically
+	// for user data, but I'm unsure if it'll behave the exact same way when
+	// invoked with powershell like this.
+	if directive == string(userdata.PowerShellScript) {
+		return jasper.NewCommand().AppendArgs("powershell", scriptPath), nil
+	}
+	if directive == string(userdata.BatchScript) {
+		return jasper.NewCommand().AppendArgs("cmd", "/c", scriptPath), nil
+	}
+	if strings.HasPrefix(directive, string(userdata.ShellScript)) {
+		return jasper.NewCommand().AppendArgs(scriptPath), nil
+	}
+
+	return nil, errors.Errorf("unrecognized directive '%s', cannot determine how to execute it", directive)
+}
+
+func runHostProvisioningCommand(ctx context.Context, cmd *jasper.Command) (string, error) {
+	buf := util.NewCappedWriter(1024 * 1024)
+	if err := cmd.SetCombinedWriter(buf).Run(ctx); err != nil {
+		return buf.String(), errors.WithStack(err)
+	}
+	return buf.String(), nil
+}

--- a/operations/host_setup.go
+++ b/operations/host_setup.go
@@ -88,8 +88,6 @@ func runScript(ctx context.Context, wd, scriptFileName, tempFileName string, run
 	}
 	catcher.Add(os.Remove(tempFileName))
 
-	grip.Warning(os.MkdirAll(wd, 0777))
-
 	return errors.Wrap(catcher.Resolve(), output)
 }
 

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -121,5 +121,6 @@ type Communicator interface {
 	// Evergreen binary for a given distro.
 	GetClientURLs(ctx context.Context, distroID string) ([]string, error)
 
+	// GetHostProvisioningScript gets the script options to provision a host.
 	GetHostProvisioningScript(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningScriptOptions, error)
 }

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -120,4 +120,6 @@ type Communicator interface {
 	// GetClientURLs returns the all URLs that can be used to request the
 	// Evergreen binary for a given distro.
 	GetClientURLs(ctx context.Context, distroID string) ([]string, error)
+
+	GetHostProvisioningScript(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningScriptOptions, error)
 }

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/userdata"
 	serviceModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -47,10 +48,6 @@ func (c *Mock) SetMaxAttempts(attempts int)                { c.maxAttempts = att
 
 func (c *Mock) SetAPIUser(apiUser string) { c.apiUser = apiUser }
 func (c *Mock) SetAPIKey(apiKey string)   { c.apiKey = apiKey }
-
-func (c *Mock) GetClientURLs(context.Context, string) ([]string, error) {
-	return []string{"https://example.com"}, nil
-}
 
 // CreateSpawnHost will return a mock host that would have been intended
 func (*Mock) CreateSpawnHost(ctx context.Context, spawnRequest *model.HostRequestOptions) (*model.APIHost, error) {
@@ -330,4 +327,15 @@ func (c *Mock) GetServiceUsers(context.Context) ([]model.APIDBUser, error) {
 }
 func (c *Mock) GetMessageForPatch(context.Context, string) (string, error) {
 	return "", nil
+}
+
+func (c *Mock) GetClientURLs(context.Context, string) ([]string, error) {
+	return []string{"https://example.com"}, nil
+}
+
+func (c *Mock) GetHostProvisioningScript(context.Context, string, string) (*restmodel.APIHostProvisioningScriptOptions, error) {
+	return &restmodel.APIHostProvisioningScriptOptions{
+		Directive: string(userdata.ShellScript) + "/bin/bash",
+		Content:   "echo hello world",
+	}, nil
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13282

* Add REST communicator method to get host provisioning script.
* Write CLI command to execute the host provisioning script.