### PR TITLE
EVG-13077 specify patch trigger aliases from the CLI

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-11-11"
+	ClientVersion = "2020-11-18"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-11-10"

--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -73,6 +73,9 @@ type cliIntent struct {
 	// alias defines the variants and tasks to run this patch on.
 	Alias string `bson:"alias"`
 
+	// TriggerAliases alias sets of tasks to include in child patches
+	TriggerAliases []string `bson:"trigger_aliases"`
+
 	// BackportOf specifies what to backport
 	BackportOf BackportInfo `bson:"backport_of,omitempty"`
 }
@@ -150,18 +153,19 @@ func (g *cliIntent) RequesterIdentity() string {
 // NewPatch creates a patch from the intent
 func (c *cliIntent) NewPatch() *Patch {
 	p := Patch{
-		Description:   c.Description,
-		Author:        c.User,
-		Project:       c.ProjectID,
-		Githash:       c.BaseHash,
-		Status:        evergreen.PatchCreated,
-		BuildVariants: c.BuildVariants,
-		Parameters:    c.Parameters,
-		Alias:         c.Alias,
-		Tasks:         c.Tasks,
-		SyncAtEndOpts: c.SyncAtEndOpts,
-		BackportOf:    c.BackportOf,
-		Patches:       []ModulePatch{},
+		Description:    c.Description,
+		Author:         c.User,
+		Project:        c.ProjectID,
+		Githash:        c.BaseHash,
+		Status:         evergreen.PatchCreated,
+		BuildVariants:  c.BuildVariants,
+		Parameters:     c.Parameters,
+		Alias:          c.Alias,
+		TriggerAliases: c.TriggerAliases,
+		Tasks:          c.Tasks,
+		SyncAtEndOpts:  c.SyncAtEndOpts,
+		BackportOf:     c.BackportOf,
+		Patches:        []ModulePatch{},
 	}
 	if p.BackportOf.PatchID == "" { // the intent processor adds the patches if backporting by patch ID
 		p.Patches = append(p.Patches,
@@ -177,19 +181,20 @@ func (c *cliIntent) NewPatch() *Patch {
 }
 
 type CLIIntentParams struct {
-	User         string
-	Project      string
-	BaseGitHash  string
-	Module       string
-	PatchContent string
-	Description  string
-	Finalize     bool
-	BackportOf   BackportInfo
-	Parameters   []Parameter
-	Variants     []string
-	Tasks        []string
-	Alias        string
-	SyncParams   SyncAtEndOptions
+	User           string
+	Project        string
+	BaseGitHash    string
+	Module         string
+	PatchContent   string
+	Description    string
+	Finalize       bool
+	BackportOf     BackportInfo
+	Parameters     []Parameter
+	Variants       []string
+	Tasks          []string
+	Alias          string
+	TriggerAliases []string
+	SyncParams     SyncAtEndOptions
 }
 
 func NewCliIntent(params CLIIntentParams) (Intent, error) {
@@ -229,21 +234,22 @@ func NewCliIntent(params CLIIntentParams) (Intent, error) {
 	}
 
 	return &cliIntent{
-		DocumentID:    mgobson.NewObjectId().Hex(),
-		IntentType:    CliIntentType,
-		PatchContent:  params.PatchContent,
-		Description:   params.Description,
-		BuildVariants: params.Variants,
-		Tasks:         params.Tasks,
-		Parameters:    params.Parameters,
-		SyncAtEndOpts: params.SyncParams,
-		User:          params.User,
-		ProjectID:     params.Project,
-		BaseHash:      params.BaseGitHash,
-		Finalize:      params.Finalize,
-		Module:        params.Module,
-		Alias:         params.Alias,
-		BackportOf:    params.BackportOf,
+		DocumentID:     mgobson.NewObjectId().Hex(),
+		IntentType:     CliIntentType,
+		PatchContent:   params.PatchContent,
+		Description:    params.Description,
+		BuildVariants:  params.Variants,
+		Tasks:          params.Tasks,
+		Parameters:     params.Parameters,
+		SyncAtEndOpts:  params.SyncParams,
+		User:           params.User,
+		ProjectID:      params.Project,
+		BaseHash:       params.BaseGitHash,
+		Finalize:       params.Finalize,
+		Module:         params.Module,
+		Alias:          params.Alias,
+		TriggerAliases: params.TriggerAliases,
+		BackportOf:     params.BackportOf,
 	}, nil
 }
 

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -148,6 +148,7 @@ type Patch struct {
 	Activated       bool                   `bson:"activated"`
 	PatchedConfig   string                 `bson:"patched_config"`
 	Alias           string                 `bson:"alias"`
+	TriggerAliases  []string               `bson:"trigger_aliases"`
 	BackportOf      BackportInfo           `bson:"backport_of,omitempty"`
 	MergePatch      string                 `bson:"merge_patch"`
 	GithubPatchData thirdparty.GithubPatch `bson:"github_patch_data,omitempty"`

--- a/operations/http.go
+++ b/operations/http.go
@@ -523,6 +523,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		SyncTimeout       time.Duration      `json:"sync_timeout"`
 		Finalize          bool               `json:"finalize"`
 		BackportInfo      patch.BackportInfo `json:"backport_info"`
+		TriggerAliases    []string           `json:"trigger_aliases"`
 		Parameters        []patch.Parameter  `json:"parameters"`
 	}{
 		Description:       incomingPatch.description,
@@ -538,6 +539,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		SyncTimeout:       incomingPatch.syncTimeout,
 		Finalize:          incomingPatch.finalize,
 		BackportInfo:      incomingPatch.backportOf,
+		TriggerAliases:    incomingPatch.triggerAliases,
 		Parameters:        incomingPatch.parameters,
 	}
 

--- a/operations/model.go
+++ b/operations/model.go
@@ -22,12 +22,13 @@ import (
 const localConfigPath = ".evergreen.local.yml"
 
 type ClientProjectConf struct {
-	Name       string            `json:"name" yaml:"name,omitempty"`
-	Default    bool              `json:"default" yaml:"default,omitempty"`
-	Alias      string            `json:"alias" yaml:"alias,omitempty"`
-	Variants   []string          `json:"variants" yaml:"variants,omitempty"`
-	Tasks      []string          `json:"tasks" yaml:"tasks,omitempty"`
-	Parameters map[string]string `json:"parameters" yaml:"parameters,omitempty"`
+	Name           string            `json:"name" yaml:"name,omitempty"`
+	Default        bool              `json:"default" yaml:"default,omitempty"`
+	Alias          string            `json:"alias" yaml:"alias,omitempty"`
+	Variants       []string          `json:"variants" yaml:"variants,omitempty"`
+	Tasks          []string          `json:"tasks" yaml:"tasks,omitempty"`
+	Parameters     map[string]string `json:"parameters" yaml:"parameters,omitempty"`
+	TriggerAliases []string          `json:"trigger_aliases" yaml:"trigger_aliases"`
 }
 
 func findConfigFilePath(fn string) (string, error) {
@@ -242,6 +243,30 @@ func (s *ClientSettings) SetDefaultVariants(project string, variants ...string) 
 		Alias:    "",
 		Variants: variants,
 		Tasks:    nil,
+	})
+}
+
+func (s *ClientSettings) FindDefaultTriggerAliases(project string) []string {
+	for _, p := range s.Projects {
+		if p.Name == project {
+			return p.TriggerAliases
+		}
+	}
+	return nil
+}
+
+func (s *ClientSettings) SetDefaultTriggerAliases(project string, triggerAliases []string) {
+	for i, p := range s.Projects {
+		if p.Name == project {
+			s.Projects[i].TriggerAliases = triggerAliases
+			return
+		}
+	}
+
+	s.Projects = append(s.Projects, ClientProjectConf{
+		Name:           project,
+		Default:        true,
+		TriggerAliases: triggerAliases,
 	})
 }
 

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -16,6 +16,7 @@ import (
 const (
 	patchDescriptionFlagName = "description"
 	patchVerboseFlagName     = "verbose"
+	patchTriggerAliasFlag    = "trigger-alias"
 )
 
 func getPatchFlags(flags ...cli.Flag) []cli.Flag {
@@ -49,6 +50,10 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 			cli.BoolFlag{
 				Name:  patchVerboseFlagName,
 				Usage: "show patch summary",
+			},
+			cli.StringSliceFlag{
+				Name:  patchTriggerAliasFlag,
+				Usage: "patch trigger alias (set by project admin) specifying tasks from other projects",
 			},
 		))
 }
@@ -93,6 +98,7 @@ func Patch() cli.Command {
 				Ref:               c.String(refFlagName),
 				Uncommitted:       c.Bool(uncommittedChangesFlag),
 				PreserveCommits:   c.Bool(preserveCommitsFlag),
+				TriggerAliases:    utility.SplitCommas(c.StringSlice(patchTriggerAliasFlag)),
 			}
 
 			var err error

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -254,14 +254,10 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 		if err != nil {
 			return nil, errors.Wrap(err, "error fetching trigger aliases")
 		}
-		invalidAliases := []string{}
 		for _, alias := range p.TriggerAliases {
 			if !utility.StringSliceContains(validTriggerAliases, alias) {
-				invalidAliases = append(invalidAliases, alias)
+				return nil, errors.Errorf("Trigger alias '%s' is not defined for project '%s'. Valid aliases are %v", alias, p.Project, validTriggerAliases)
 			}
-		}
-		if len(invalidAliases) > 0 {
-			return nil, errors.Errorf("trigger aliases %v are not defined for project '%s'", invalidAliases, p.Project)
 		}
 	}
 

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -71,6 +71,7 @@ type patchParams struct {
 	PreserveCommits   bool
 	Ref               string
 	BackportOf        patch.BackportInfo
+	TriggerAliases    []string
 	Parameters        []patch.Parameter
 }
 
@@ -88,6 +89,7 @@ type patchSubmission struct {
 	syncTimeout       time.Duration
 	finalize          bool
 	parameters        []patch.Parameter
+	triggerAliases    []string
 	backportOf        patch.BackportInfo
 }
 
@@ -107,6 +109,7 @@ func (p *patchParams) createPatch(ac *legacyClient, diffData *localDiff) (*patch
 		finalize:          p.Finalize,
 		backportOf:        p.BackportOf,
 		parameters:        p.Parameters,
+		triggerAliases:    p.TriggerAliases,
 	}
 
 	newPatch, err := ac.PutPatch(patchSub)
@@ -210,6 +213,10 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 		grip.Warningf("warning - failed to set default parameters: %v\n", err)
 	}
 
+	if err := p.loadTriggerAliases(conf); err != nil {
+		grip.Warningf("warning - failed to set default trigger aliases: %v\n", err)
+	}
+
 	if p.Uncommitted || conf.UncommittedChanges {
 		p.Ref = ""
 	}
@@ -238,6 +245,23 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 		}
 		if !validAlias {
 			return nil, errors.Errorf("%s is not a valid alias", p.Alias)
+		}
+	}
+
+	// Validate trigger aliases exist
+	if len(p.TriggerAliases) > 0 {
+		validTriggerAliases, err := comm.ListPatchTriggerAliases(ctx, p.Project)
+		if err != nil {
+			return nil, errors.Wrap(err, "error fetching trigger aliases")
+		}
+		invalidAliases := []string{}
+		for _, alias := range p.TriggerAliases {
+			if !utility.StringSliceContains(validTriggerAliases, alias) {
+				invalidAliases = append(invalidAliases, alias)
+			}
+		}
+		if len(invalidAliases) > 0 {
+			return nil, errors.Errorf("trigger aliases %v are not defined for project '%s'", invalidAliases, p.Project)
 		}
 	}
 
@@ -324,6 +348,23 @@ func (p *patchParams) loadParameters(conf *ClientSettings) error {
 		}
 	} else {
 		p.Parameters = defaultParameters
+	}
+	return nil
+}
+
+func (p *patchParams) loadTriggerAliases(conf *ClientSettings) error {
+	defaultAliases := conf.FindDefaultTriggerAliases(p.Project)
+	if len(p.TriggerAliases) != 0 {
+		if len(defaultAliases) == 0 && !p.SkipConfirm &&
+			confirm(fmt.Sprintf("Set %v as the default trigger aliases for project '%v'?",
+				p.TriggerAliases, p.Project), false) {
+			conf.SetDefaultTriggerAliases(p.Project, p.TriggerAliases)
+			if err := conf.Write(""); err != nil {
+				return err
+			}
+		}
+	} else {
+		p.TriggerAliases = defaultAliases
 	}
 	return nil
 }

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -80,6 +80,7 @@ type Communicator interface {
 
 	// List variant/task aliases
 	ListAliases(context.Context, string) ([]model.ProjectAlias, error)
+	ListPatchTriggerAliases(context.Context, string) ([]string, error)
 	GetDistroByName(context.Context, string) (*restmodel.APIDistro, error)
 
 	// Get parameters for project

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -910,6 +910,32 @@ func (c *communicatorImpl) ListAliases(ctx context.Context, project string) ([]s
 	return patchAliases, nil
 }
 
+func (c *communicatorImpl) ListPatchTriggerAliases(ctx context.Context, project string) ([]string, error) {
+	path := fmt.Sprintf("projects/%s/patch_trigger_aliases", project)
+	info := requestInfo{
+		method: http.MethodGet,
+		path:   path,
+	}
+	resp, err := c.request(ctx, info, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "problem querying api server")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, AuthError
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("bad status from api server: %v", resp.StatusCode)
+	}
+
+	triggerAliases := []string{}
+	if err = utility.ReadJSON(resp.Body, &triggerAliases); err != nil {
+		return nil, errors.Wrap(err, "failed to parse update manifest from server")
+	}
+
+	return triggerAliases, nil
+}
+
 func (c *communicatorImpl) GetClientConfig(ctx context.Context) (*evergreen.ClientConfig, error) {
 	info := requestInfo{
 		path:   "/status/cli_version",

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -200,6 +200,10 @@ func (c *Mock) ListAliases(ctx context.Context, keyName string) ([]serviceModel.
 	return nil, errors.New("(c *Mock) ListAliases not implemented")
 }
 
+func (c *Mock) ListPatchTriggerAliases(ctx context.Context, project string) ([]string, error) {
+	return nil, errors.New("(c *Mock) ListPatchTriggerAliases not implemented")
+}
+
 func (c *Mock) GetParameters(context.Context, string) ([]serviceModel.ParameterInfo, error) {
 	return nil, errors.New("(c *Mock) GetParameters not implemented")
 }

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -148,6 +148,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}/test_stats").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeGetProjectTestStats(sc))
 	app.AddRoute("/projects/{project_id}/versions").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeGetProjectVersionsHandler(sc))
 	app.AddRoute("/projects/{project_id}/versions/tasks").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchProjectTasks(sc))
+	app.AddRoute("/projects/{project_id}/patch_trigger_aliases").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchPatchTriggerAliases(sc))
 	app.AddRoute("/projects/{project_id}/parameters").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchParameters(sc))
 	app.AddRoute("/projects/tag/{tag}").Version(2).Get().Wrap(checkUser, checkProjectAdmin).RouteHandler(makeGetProjectsForTag(sc))
 	app.AddRoute("/projects/{project_id}/tag/{tag}").Version(2).Delete().Wrap(checkUser, checkProjectAdmin, editProjectSettings).RouteHandler(makeDeleteProjectTag(sc))

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -54,6 +54,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		SyncStatuses      []string           `json:"sync_statuses"`
 		SyncTimeout       time.Duration      `json:"sync_timeout"`
 		Finalize          bool               `json:"finalize"`
+		TriggerAliases    []string           `json:"trigger_aliases"`
 		Alias             string             `json:"alias"`
 	}{}
 	if err := utility.ReadJSON(util.NewRequestReaderWithSize(r, patch.SizeLimit), &data); err != nil {
@@ -112,18 +113,19 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	intent, err := patch.NewCliIntent(patch.CLIIntentParams{
-		User:         dbUser.Id,
-		Project:      pref.Id,
-		BaseGitHash:  data.Githash,
-		Module:       r.FormValue("module"),
-		PatchContent: patchString,
-		Description:  data.Description,
-		Finalize:     data.Finalize,
-		Parameters:   data.Parameters,
-		Variants:     data.Variants,
-		Tasks:        data.Tasks,
-		Alias:        data.Alias,
-		BackportOf:   data.BackportInfo,
+		User:           dbUser.Id,
+		Project:        pref.Id,
+		BaseGitHash:    data.Githash,
+		Module:         r.FormValue("module"),
+		PatchContent:   patchString,
+		Description:    data.Description,
+		Finalize:       data.Finalize,
+		Parameters:     data.Parameters,
+		Variants:       data.Variants,
+		Tasks:          data.Tasks,
+		Alias:          data.Alias,
+		TriggerAliases: data.TriggerAliases,
+		BackportOf:     data.BackportInfo,
 		SyncParams: patch.SyncAtEndOptions{
 			BuildVariants: data.SyncBuildVariants,
 			Tasks:         data.SyncTasks,


### PR DESCRIPTION
Thread trigger aliases through from the CLI to the patch document.
The actual work of creating the child patches for those aliases will be implemented later.