### PR TITLE
EVG-12664 set default project per directory

### DIFF
--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -583,6 +583,7 @@ func (p *mergeParams) uploadMergePatch(conf *ClientSettings, ac *legacyClient) e
 	}
 
 	p.id = patch.Id.Hex()
+	patchParams.setDefaultProject(conf)
 
 	return nil
 }

--- a/operations/model.go
+++ b/operations/model.go
@@ -76,15 +76,17 @@ func isValidPath(path string) bool {
 // located at ~/.evergreen.yml
 // If you change the JSON tags, you must also change an anonymous struct in hostinit/setup.go
 type ClientSettings struct {
-	APIServerHost      string              `json:"api_server_host" yaml:"api_server_host,omitempty"`
-	UIServerHost       string              `json:"ui_server_host" yaml:"ui_server_host,omitempty"`
-	APIKey             string              `json:"api_key" yaml:"api_key,omitempty"`
-	User               string              `json:"user" yaml:"user,omitempty"`
-	UncommittedChanges bool                `json:"patch_uncommitted_changes" yaml:"patch_uncommitted_changes,omitempty"`
-	PreserveCommits    bool                `json:"preserve_commits" yaml:"preserve_commits,omitempty"`
-	Projects           []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
-	Admin              ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`
-	LoadedFrom         string              `json:"-" yaml:"-"`
+	APIServerHost         string              `json:"api_server_host" yaml:"api_server_host,omitempty"`
+	UIServerHost          string              `json:"ui_server_host" yaml:"ui_server_host,omitempty"`
+	APIKey                string              `json:"api_key" yaml:"api_key,omitempty"`
+	User                  string              `json:"user" yaml:"user,omitempty"`
+	UncommittedChanges    bool                `json:"patch_uncommitted_changes" yaml:"patch_uncommitted_changes,omitempty"`
+	PreserveCommits       bool                `json:"preserve_commits" yaml:"preserve_commits,omitempty"`
+	Projects              []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
+	Admin                 ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`
+	LoadedFrom            string              `json:"-" yaml:"-"`
+	DontSetDefaultProject bool                `json:"dont_set_default_project" yaml:"dont_set_default_project"`
+	ProjectsForDirectory  map[string]string   `json:"projects_for_directory,omitempty" yaml:"projects_for_directory,omitempty"`
 }
 
 func NewClientSettings(fn string) (*ClientSettings, error) {
@@ -210,10 +212,20 @@ func (s *ClientSettings) getLegacyClients() (*legacyClient, *legacyClient, error
 	return ac, rc, nil
 }
 
-func (s *ClientSettings) FindDefaultProject() string {
-	for _, p := range s.Projects {
-		if p.Default {
-			return p.Name
+func (s *ClientSettings) FindDefaultProject(useRoot bool) string {
+	cwd, err := os.Getwd()
+	grip.Error(errors.Wrap(err, "unable to get current working directory"))
+	cwd, err = filepath.EvalSymlinks(cwd)
+	grip.Error(errors.Wrap(err, "unable to resolve symlinks"))
+	if project, exists := s.ProjectsForDirectory[cwd]; exists {
+		return project
+	}
+
+	if useRoot {
+		for _, p := range s.Projects {
+			if p.Default {
+				return p.Name
+			}
 		}
 	}
 	return ""
@@ -235,7 +247,6 @@ func (s *ClientSettings) SetDefaultVariants(project string, variants ...string) 
 			return
 		}
 	}
-
 	s.Projects = append(s.Projects, ClientProjectConf{
 		Name:     project,
 		Default:  true,
@@ -302,7 +313,6 @@ func (s *ClientSettings) SetDefaultTasks(project string, tasks ...string) {
 			return
 		}
 	}
-
 	s.Projects = append(s.Projects, ClientProjectConf{
 		Name:     project,
 		Default:  true,
@@ -328,7 +338,6 @@ func (s *ClientSettings) SetDefaultAlias(project string, alias string) {
 			return
 		}
 	}
-
 	s.Projects = append(s.Projects, ClientProjectConf{
 		Name:     project,
 		Default:  true,
@@ -338,24 +347,28 @@ func (s *ClientSettings) SetDefaultAlias(project string, alias string) {
 	})
 }
 
-func (s *ClientSettings) SetDefaultProject(name string) {
-	var foundDefault bool
-	for i, p := range s.Projects {
-		if p.Name == name {
-			s.Projects[i].Default = true
-			foundDefault = true
-		} else {
-			s.Projects[i].Default = false
-		}
+func (s *ClientSettings) SetDefaultProject(project string) {
+	if s.DontSetDefaultProject {
+		return
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		grip.Error(errors.Wrap(err, "unable to get current working directory"))
+		return
+	}
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		grip.Error(errors.Wrap(err, "unable to evaluate symlinks"))
+		return
 	}
 
-	if !foundDefault {
-		s.Projects = append(s.Projects, ClientProjectConf{
-			Name:     name,
-			Default:  true,
-			Alias:    "",
-			Variants: []string{},
-			Tasks:    []string{},
-		})
+	_, found := s.ProjectsForDirectory[cwd]
+	if found {
+		return
 	}
+	if s.ProjectsForDirectory == nil {
+		s.ProjectsForDirectory = map[string]string{}
+	}
+	s.ProjectsForDirectory[cwd] = project
+	grip.Infof("Project '%s' will be set as the one to use for directory '%s'. To disable automatic defaulting, set 'dont_set_default_project' to true.", project, cwd)
 }

--- a/operations/model_test.go
+++ b/operations/model_test.go
@@ -163,7 +163,10 @@ projects:
   tasks: 
     - all
   variants: 
-    - all`), 0600)
+    - all
+projects_for_directory:
+  some/directory: myProj
+`), 0600)
 	assert.NoError(t, err)
 	defer os.Remove(localConfigPath)
 
@@ -188,6 +191,9 @@ projects:
 				Tasks:    []string{"all"},
 				Variants: []string{"all"},
 			},
+		},
+		ProjectsForDirectory: map[string]string{
+			"some/directory": "myProj",
 		},
 	}, *localClientSettings)
 }

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -154,7 +154,11 @@ func Patch() cli.Command {
 			if err != nil {
 				return err
 			}
-			return params.displayPatch(conf, newPatch)
+			if err = params.displayPatch(conf, newPatch); err != nil {
+				grip.Error(err)
+			}
+			params.setDefaultProject(conf)
+			return nil
 		},
 	}
 }

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -250,12 +250,11 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 }
 
 func (p *patchParams) loadProject(conf *ClientSettings) error {
-	cwd, err := os.Getwd()
-	grip.Error(errors.Wrap(err, "unable to get current working directory"))
-	cwd, err = filepath.EvalSymlinks(cwd)
-	grip.Error(errors.Wrap(err, "unable to resolve symlinks"))
-
 	if p.Project == "" {
+		cwd, err := os.Getwd()
+		grip.Error(errors.Wrap(err, "unable to get current working directory"))
+		cwd, err = filepath.EvalSymlinks(cwd)
+		grip.Error(errors.Wrap(err, "unable to resolve symlinks"))
 		p.Project = conf.FindDefaultProject(cwd, true)
 	}
 	if p.Project == "" {

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -250,25 +250,25 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 
 func (p *patchParams) loadProject(conf *ClientSettings) error {
 	if p.Project == "" {
-		p.Project = conf.FindDefaultProject()
-	} else {
-		if conf.FindDefaultProject() == "" &&
-			!p.SkipConfirm && confirm(fmt.Sprintf("Make %s your default project?", p.Project), true) {
-			conf.SetDefaultProject(p.Project)
-			if err := conf.Write(""); err != nil {
-				grip.Warning(message.WrapError(err, message.Fields{
-					"message": "failed to set default project",
-					"project": p.Project,
-				}))
-			}
-		}
+		p.Project = conf.FindDefaultProject(true)
 	}
-
 	if p.Project == "" {
 		return errors.New("Need to specify a project")
 	}
 
 	return nil
+}
+
+func (p *patchParams) setDefaultProject(conf *ClientSettings) {
+	if conf.FindDefaultProject(false) == "" {
+		conf.SetDefaultProject(p.Project)
+		if err := conf.Write(""); err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"message": "failed to set default project",
+				"project": p.Project,
+			}))
+		}
+	}
 }
 
 // Sets the patch's alias to either the passed in option or the default


### PR DESCRIPTION
- instead of prompting for a default project do it automatically
- add a new structure to store default projects per directory, as well as a flag to stop the automatic defaulting
I'll add documentation on this before merging

Output looks something like

john@johns-MacBook-Pro foo % clients/darwin_amd64/evergreen -c ~/.evergreenstaging.yml patch -p mci -y
Patch successfully created.

	     ID : 5fb43a689dbe32678001c3a0
	Created : 2020-11-17 21:02:33.035 +0000 UTC
    Description : EVG-12664: wip
	  Build : https://evergreen-staging.corp.mongodb.com//patch/5fb43a689dbe32678001c3a0
	 Status : created


Project 'mci' will be set as the one to use for directory '/Users/john/go/src/github.com/evergreen-ci/evergreen'. To disable automatic defaulting, set 'dont_set_default_project' to true.
