### PR TITLE
EVG-6833 use event initiator as patch author

### DIFF
--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -99,7 +99,7 @@ var (
 
 // NewGithubIntent creates an Intent from a google/go-github PullRequestEvent,
 // or returns an error if the some part of the struct is invalid
-func NewGithubIntent(msgDeliveryID string, pr *github.PullRequest) (Intent, error) {
+func NewGithubIntent(msgDeliveryID, patchOwner string, pr *github.PullRequest) (Intent, error) {
 	if pr == nil ||
 		pr.Base == nil || pr.Base.Repo == nil ||
 		pr.Head == nil || pr.Head.Repo == nil || pr.Head.Repo.PushedAt == nil ||
@@ -133,6 +133,9 @@ func NewGithubIntent(msgDeliveryID string, pr *github.PullRequest) (Intent, erro
 	if utility.IsZeroTime(pr.Head.Repo.PushedAt.Time) {
 		return nil, errors.New("pushed at time not set")
 	}
+	if patchOwner == "" {
+		patchOwner = pr.User.GetLogin()
+	}
 
 	return &githubIntent{
 		DocumentID:   msgDeliveryID,
@@ -141,7 +144,7 @@ func NewGithubIntent(msgDeliveryID string, pr *github.PullRequest) (Intent, erro
 		BaseBranch:   pr.Base.GetRef(),
 		HeadRepoName: pr.Head.Repo.GetFullName(),
 		PRNumber:     pr.GetNumber(),
-		User:         pr.User.GetLogin(),
+		User:         patchOwner,
 		UID:          int(pr.User.GetID()),
 		HeadHash:     pr.Head.GetSHA(),
 		Title:        pr.GetTitle(),

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -44,32 +44,32 @@ func (s *GithubSuite) SetupTest() {
 }
 
 func (s *GithubSuite) TestNewGithubIntent() {
-	intent, err := NewGithubIntent("1", testutil.NewGithubPR(0, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent("1", "", testutil.NewGithubPR(0, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", testutil.NewGithubPR(s.pr, "", s.headRepo, s.hash, s.user, s.title))
+	intent, err = NewGithubIntent("2", "", testutil.NewGithubPR(s.pr, "", s.headRepo, s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", testutil.NewGithubPR(s.pr, s.baseRepo, "", s.hash, s.user, s.title))
+	intent, err = NewGithubIntent("2", "", testutil.NewGithubPR(s.pr, s.baseRepo, "", s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, "", s.user, s.title))
+	intent, err = NewGithubIntent("2", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, "", s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, "", s.title))
+	intent, err = NewGithubIntent("2", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, "", s.title))
 	s.Nil(intent)
 	s.Error(err)
 
 	// PRs can't have an empty title
-	intent, err = NewGithubIntent("2", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, ""))
+	intent, err = NewGithubIntent("2", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, ""))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("4", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
+	intent, err = NewGithubIntent("4", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.Implements((*Intent)(nil), intent)
@@ -105,7 +105,7 @@ func (s *GithubSuite) TestNewGithubIntent() {
 }
 
 func (s *GithubSuite) TestInsert() {
-	intent, err := NewGithubIntent("1", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent("1", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())
@@ -125,7 +125,7 @@ func (s *GithubSuite) TestInsert() {
 }
 
 func (s *GithubSuite) TestFindIntentSpecifically() {
-	intent, err := NewGithubIntent("300", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent("300", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())
@@ -144,7 +144,7 @@ func (s *GithubSuite) TestFindIntentSpecifically() {
 }
 
 func (s *GithubSuite) TestSetProcessed() {
-	intent, err := NewGithubIntent("1", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent("1", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())
@@ -214,7 +214,7 @@ func (s *GithubSuite) TestFindUnprocessedGithubIntents() {
 }
 
 func (s *GithubSuite) TestNewPatch() {
-	intent, err := NewGithubIntent("4", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent("4", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -252,7 +252,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 					"user":      *event.Sender.Login,
 					"message":   "retry triggered",
 				})
-				if err := gh.retryPRPatch(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), event.Sender.GetLogin(), event.Issue.GetNumber()); err != nil {
+				if err := gh.retryPRPatch(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), event.Issue.GetNumber()); err != nil {
 					grip.Error(message.WrapError(err, message.Fields{
 						"source":    "github hook",
 						"msg_id":    gh.msgID,
@@ -292,7 +292,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewJSONResponse(struct{}{})
 }
 
-func (gh *githubHookApi) retryPRPatch(ctx context.Context, owner, repo, initiator string, prNumber int) error {
+func (gh *githubHookApi) retryPRPatch(ctx context.Context, owner, repo string, prNumber int) error {
 	settings, err := gh.sc.GetEvergreenSettings()
 	if err != nil {
 		return errors.Wrap(err, "can't get Evergreen settings")
@@ -307,7 +307,7 @@ func (gh *githubHookApi) retryPRPatch(ctx context.Context, owner, repo, initiato
 		return errors.Wrapf(err, "can't get PR for repo %s:%s, PR #%d", owner, repo, prNumber)
 	}
 
-	return gh.AddIntentForPR(pr, initiator)
+	return gh.AddIntentForPR(pr, pr.User.GetLogin())
 }
 
 func (gh *githubHookApi) AddIntentForPR(pr *github.PullRequest, owner string) error {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -144,6 +144,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 				"ref":       *event.PullRequest.Base.Ref,
 				"pr_number": *event.PullRequest.Number,
 				"hash":      *event.PullRequest.Head.SHA,
+				"user":      *event.Sender.Login,
 				"message":   "pr accepted, attempting to queue",
 			})
 			if err := gh.AddIntentForPR(event.PullRequest, event.Sender.GetLogin()); err != nil {
@@ -155,6 +156,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 					"repo":      *event.PullRequest.Base.Repo.FullName,
 					"ref":       *event.PullRequest.Base.Ref,
 					"pr_number": *event.PullRequest.Number,
+					"user":      *event.Sender.Login,
 					"message":   "can't add intent",
 				}))
 				return gimlet.NewJSONErrorResponse(err)

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -165,7 +165,7 @@ func (s *githubStatusUpdateSuite) TestForDeleteFromCommitQueue() {
 }
 
 func (s *githubStatusUpdateSuite) TestForProcessingError() {
-	intent, err := patch.NewGithubIntent("1", testutil.NewGithubPR(448,
+	intent, err := patch.NewGithubIntent("1", "", testutil.NewGithubPR(448,
 		"evergreen-ci/evergreen", "tychoish/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", "tychoish", "Title"))
 	s.NoError(err)
 	s.NotNil(intent)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -319,7 +319,7 @@ func (s *PatchIntentUnitsSuite) TestProcessGithubPatchIntent() {
 	s.NoError(dbUser.Insert())
 	s.user = dbUser.Id
 	patchEvent := testutil.NewGithubPR(s.prNumber, s.repo, s.headRepo, s.hash, "evrg-bot-webhook", "title1")
-	intent, err := patch.NewGithubIntent("1", patchEvent)
+	intent, err := patch.NewGithubIntent("1", "", patchEvent)
 	tempPatch := intent.NewPatch()
 	s.NoError(err)
 	s.NotNil(intent)
@@ -461,7 +461,7 @@ func (s *PatchIntentUnitsSuite) TestRunInDegradedModeWithGithubIntent() {
 	}
 	s.NoError(evergreen.SetServiceFlags(flags))
 
-	intent, err := patch.NewGithubIntent("1", testutil.NewGithubPR(s.prNumber, s.repo, s.headRepo, s.hash, "tychoish", "title1"))
+	intent, err := patch.NewGithubIntent("1", "", testutil.NewGithubPR(s.prNumber, s.repo, s.headRepo, s.hash, "tychoish", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())
@@ -492,7 +492,7 @@ func (s *PatchIntentUnitsSuite) TestGithubPRTestFromUnknownUserDoesntCreateVersi
 	}
 	s.Require().NoError(evergreen.SetServiceFlags(flags))
 
-	intent, err := patch.NewGithubIntent("1", testutil.NewGithubPR(s.prNumber, s.repo, s.headRepo, s.hash, "octocat", "title1"))
+	intent, err := patch.NewGithubIntent("1", "", testutil.NewGithubPR(s.prNumber, s.repo, s.headRepo, s.hash, "octocat", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())


### PR DESCRIPTION
not only does this allow someone internal pushing to a pr to automatically trigger pr checks, but also person A typing a retry comment on person B's pr will make person A own the patch, so person A gets the notifications