### PR TITLE
EVG-8324: Add baseStatus field to PatchBuildVariantTask gql type

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -359,9 +359,10 @@ type ComplexityRoot struct {
 	}
 
 	PatchBuildVariantTask struct {
-		ID     func(childComplexity int) int
-		Name   func(childComplexity int) int
-		Status func(childComplexity int) int
+		BaseStatus func(childComplexity int) int
+		ID         func(childComplexity int) int
+		Name       func(childComplexity int) int
+		Status     func(childComplexity int) int
 	}
 
 	PatchDuration struct {
@@ -2365,6 +2366,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PatchBuildVariant.Variant(childComplexity), true
+
+	case "PatchBuildVariantTask.baseStatus":
+		if e.complexity.PatchBuildVariantTask.BaseStatus == nil {
+			break
+		}
+
+		return e.complexity.PatchBuildVariantTask.BaseStatus(childComplexity), true
 
 	case "PatchBuildVariantTask.id":
 		if e.complexity.PatchBuildVariantTask.ID == nil {
@@ -4457,6 +4465,7 @@ type PatchBuildVariantTask {
   id: ID!
   name: String!
   status: String!
+  baseStatus: String
 }
 
 type TaskFiles {
@@ -12808,6 +12817,37 @@ func (ec *executionContext) _PatchBuildVariantTask_status(ctx context.Context, f
 	res := resTmp.(string)
 	fc.Result = res
 	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PatchBuildVariantTask_baseStatus(ctx context.Context, field graphql.CollectedField, obj *PatchBuildVariantTask) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchBuildVariantTask",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BaseStatus, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _PatchDuration_makespan(ctx context.Context, field graphql.CollectedField, obj *PatchDuration) (ret graphql.Marshaler) {
@@ -23700,6 +23740,8 @@ func (ec *executionContext) _PatchBuildVariantTask(ctx context.Context, sel ast.
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "baseStatus":
+			out.Values[i] = ec._PatchBuildVariantTask_baseStatus(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -83,9 +83,10 @@ type PatchBuildVariant struct {
 }
 
 type PatchBuildVariantTask struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	Status string `json:"status"`
+	ID         string  `json:"id"`
+	Name       string  `json:"name"`
+	Status     string  `json:"status"`
+	BaseStatus *string `json:"baseStatus"`
 }
 
 type PatchDuration struct {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1383,12 +1383,17 @@ func (r *queryResolver) PatchBuildVariants(ctx context.Context, patchID string) 
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting tasks for patch `%s`: %s", patchID, err))
 	}
+	baseTaskStatuses, _ := GetBaseTaskStatusesFromPatchID(r.sc, patchID)
 	variantDisplayName := make(map[string]string)
 	for _, task := range tasks {
 		t := PatchBuildVariantTask{
 			ID:     task.Id,
 			Name:   task.DisplayName,
 			Status: task.GetDisplayStatus(),
+		}
+		if baseTaskStatuses != nil && baseTaskStatuses[task.BuildVariant] != nil {
+			s := baseTaskStatuses[task.BuildVariant][task.DisplayName]
+			t.BaseStatus = &s
 		}
 		tasksByVariant[task.BuildVariant] = append(tasksByVariant[task.BuildVariant], &t)
 		if _, ok := variantDisplayName[task.BuildVariant]; !ok {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -353,6 +353,7 @@ type PatchBuildVariantTask {
   id: ID!
   name: String!
   status: String!
+  baseStatus: String
 }
 
 type TaskFiles {
@@ -458,7 +459,7 @@ type TaskResult {
   displayName: String!
   version: String!
   status: String!
-  baseStatus: String!
+  baseStatus: String
   buildVariant: String!
   blocked: Boolean!
 }

--- a/graphql/tests/patchBuildVariants/queries/patch-build-variants.graphql
+++ b/graphql/tests/patchBuildVariants/queries/patch-build-variants.graphql
@@ -6,6 +6,7 @@
       id
       name
       status
+      baseStatus
     }
   }
 }

--- a/graphql/tests/patchBuildVariants/results.json
+++ b/graphql/tests/patchBuildVariants/results.json
@@ -12,17 +12,20 @@
                 {
                   "id": "2",
                   "name": "test-cloud",
-                  "status": "failed"
+                  "status": "failed",
+                  "baseStatus": null
                 },
                 {
                   "id": "5",
                   "name": "test-docker",
-                  "status": "success"
+                  "status": "success",
+                  "baseStatus": null
                 },
                 {
                   "id": "1",
                   "name": "test-thirdparty-docker",
-                  "status": "success"
+                  "status": "success",
+                  "baseStatus": null
                 }
               ]
             },
@@ -33,12 +36,14 @@
                 {
                   "id": "4",
                   "name": "compile",
-                  "status": "failed"
+                  "status": "failed",
+                  "baseStatus": null
                 },
                 {
                   "id": "7",
                   "name": "lint",
-                  "status": "success"
+                  "status": "success",
+                  "baseStatus": null
                 }
               ]
             },
@@ -49,7 +54,8 @@
                 {
                   "id": "9",
                   "name": "lint-graphql",
-                  "status": "started"
+                  "status": "started",
+                  "baseStatus": null
                 }
               ]
             }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-8324
These code changes will help enable the patch restart modal to filter by tasks' base status.
`PatchBuildVariantTask` is returned from the `patchBuildVariants` query is currently utilized to render the "Build Variants" card and Restart Patch modal checkboxes. 
A difference between the two use cases is that the "Build Variants" card doesn't need base task statuses. It would have been nice to conditionally resolve the baseStatus field so querying `patchBuildVariants` doesn't make superfluous mongodb queries.     
There are 3 other ways we could have done this but they all turned out to be insufficient solutions:
Option 1) `patchBuildVariants` returns the gql type below and conditionally resolves the base field.
```
type PatchBuildVariantsResult {
  patch: [PatchBuildVariant!]!
  base: [PatchBuildVariant!]
}
```
The issue with this is that the resolver for base doesn't have access to the query variables which prevent it from finding the base patch. 

Option 2)  add a conditionally resolved baseTasks field to `PatchBuildVariant` so it looks like this:
```
type PatchBuildVariant {
  variant: String!
  displayName: String!
  tasks: [PatchBuildVariantTask]
  baseTasks: [PatchBuildVariantTask!]
}
```
as a conditionally resolved field, baseTasks will not have access to the query variables but it will have access to the `tasks` field which can be used to find baseTasks. This seems like a reasonable solution but the downside is that we are blocked from making `tasks` conditionally resolved bc as soon as we do that, baseTasks will no longer have access to `tasks`.

Option 3) add a conditionally resolved baseStatus field to `PatchBuildVariantTask` so it looks like this:
```
type PatchBuildVariantTask {
  id: ID!
  name: String!
  status: String!
  baseStatus: String
}
```
The PatchBuildVariantTask baseStatus resolver will have to make a query per patch task. This seems unreasonable because there could be 1000+ task statuses we would need query to display one patch restart modal. 

I think the best solution could have been Option 1 if we had access to query variables for conditionally resolved fields. This PR follows Option 3 without conditionally resolving any fields because it provides an optimal data shape for our UI components at the cost of an additional mongodb query for the "Build Variant" component on the Patch page. 