### PR TITLE
EVG-13286: fix small bugs from test fetching host provisioning script

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -988,8 +988,8 @@ func FindOneId(id string) (*Host, error) {
 func FindOneByIdOrTag(id string) (*Host, error) {
 	query := db.Query(bson.M{
 		"$or": []bson.M{
-			bson.M{TagKey: id},
-			bson.M{IdKey: id},
+			{TagKey: id},
+			{IdKey: id},
 		},
 	})
 	host, err := FindOne(query) // try to find by tag

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -554,6 +554,8 @@ func (h *Host) ChangeJasperDirsOwnerCommand() string {
 	}, " && ")
 }
 
+// MakeJasperDirsCommand creates the directories with the correct permissions to
+// provision the host with Jasper.
 func (h *Host) MakeJasperDirsCommand() string {
 	return fmt.Sprintf("mkdir -m 777 -p %s %s %s",
 		h.Distro.BootstrapSettings.JasperBinaryDir,
@@ -1334,7 +1336,10 @@ func (h *Host) FetchProvisioningScriptUserData(settings *evergreen.Settings) (*u
 		fmt.Sprintf("--shell_path=%s", h.Distro.ShellBinary()),
 	}, " ")
 
+	makeJasperDirs := h.MakeJasperDirsCommand()
+
 	cmds := []string{
+		makeJasperDirs,
 		fetchClient,
 		fixClientOwner,
 		fetchScriptCmd,

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -419,20 +419,13 @@ func (h *Host) ProvisioningUserData(settings *evergreen.Settings, creds *certdep
 			// use the correct SSH key. Additionally, since this can take a long
 			// time to download all the task data, user data may time out this
 			// operation, which would prevent user data from completing and the
-			// host would be stuck in provisioning.
+			// host would be stuck in provisioning. To alleviate this, we
+			// download the task data using Jasper.
 			var fetchCmd []string
 			if h.ProvisionOptions.TaskSync {
-				if h.Distro.BootstrapSettings.FetchProvisioningScript {
-					fetchCmd = h.SpawnHostPullTaskSyncCommand()
-				} else {
-					fetchCmd = []string{h.Distro.ShellBinary(), "-l", "-c", strings.Join(h.SpawnHostPullTaskSyncCommand(), " ")}
-				}
+				fetchCmd = []string{h.Distro.ShellBinary(), "-l", "-c", strings.Join(h.SpawnHostPullTaskSyncCommand(), " ")}
 			} else {
-				if h.Distro.BootstrapSettings.FetchProvisioningScript {
-					fetchCmd = h.SpawnHostGetTaskDataCommand()
-				} else {
-					fetchCmd = []string{h.Distro.ShellBinary(), "-l", "-c", strings.Join(h.SpawnHostGetTaskDataCommand(), " ")}
-				}
+				fetchCmd = []string{h.Distro.ShellBinary(), "-l", "-c", strings.Join(h.SpawnHostGetTaskDataCommand(), " ")}
 			}
 			var getTaskDataCmd string
 			getTaskDataCmd, err = h.buildLocalJasperClientRequest(

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -524,13 +524,13 @@ func (h *Host) ProvisioningUserData(settings *evergreen.Settings, creds *certdep
 
 	shellPrefix := []string{"set -o errexit", "set -o verbose"}
 
-	bashCmds := append(shellPrefix, checkUserDataRan, setupScriptCmds)
-	bashCmds = append(bashCmds, setupJasperCmds...)
-	bashCmds = append(bashCmds, fetchClient, fixClientOwner, postFetchClient, markDone)
+	shellCmds := append(shellPrefix, checkUserDataRan, setupScriptCmds)
+	shellCmds = append(shellCmds, setupJasperCmds...)
+	shellCmds = append(shellCmds, fetchClient, fixClientOwner, postFetchClient, markDone)
 
 	return &userdata.Options{
 		Directive: userdata.ShellScript + userdata.Directive(h.Distro.BootstrapSettings.ShellPath),
-		Content:   strings.Join(bashCmds, "\n"),
+		Content:   strings.Join(shellCmds, "\n"),
 	}, nil
 }
 
@@ -1321,19 +1321,15 @@ func (h *Host) FetchProvisioningScriptUserData(settings *evergreen.Settings) (*u
 		fetchScriptCmd,
 	}
 
+	var directive userdata.Directive
 	if h.Distro.IsWindows() {
 		for i := range cmds {
 			cmds[i] = fmt.Sprintf("%s -l -c %s", h.Distro.ShellBinary(), util.PowerShellQuotedString(cmds[i]))
 		}
+		directive = userdata.PowerShellScript
 	} else {
 		shellPrefix := []string{"set -o errexit", "set -o verbose"}
 		cmds = append(shellPrefix, cmds...)
-	}
-
-	var directive userdata.Directive
-	if h.Distro.IsWindows() {
-		directive = userdata.PowerShellScript
-	} else {
 		directive = userdata.ShellScript + userdata.Directive(h.Distro.BootstrapSettings.ShellPath)
 	}
 

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -383,6 +383,8 @@ func (h *Host) JasperBinaryFilePath(config evergreen.HostJasperConfig) string {
 // it will succeed if run again, since we cannot enforce idempotency on the
 // setup script.
 func (h *Host) ProvisioningUserData(settings *evergreen.Settings, creds *certdepot.Credentials) (*userdata.Options, error) {
+	shellPrefix := []string{"set -o errexit", "set -o verbose"}
+
 	var fetchClient, fixClientOwner string
 	var err error
 	// If we're fetching the provisioning script from the app server, the
@@ -487,6 +489,9 @@ func (h *Host) ProvisioningUserData(settings *evergreen.Settings, creds *certdep
 		)
 
 		var shellCmds []string
+		if h.Distro.BootstrapSettings.FetchProvisioningScript {
+			shellCmds = append(shellCmds, shellPrefix...)
+		}
 		shellCmds = append(shellCmds, writeSetupScriptCmds...)
 		shellCmds = append(shellCmds, setupJasperCmds...)
 		shellCmds = append(shellCmds, fetchClient, fixClientOwner, h.SetupCommand(), postFetchClient, markDone)
@@ -531,8 +536,6 @@ func (h *Host) ProvisioningUserData(settings *evergreen.Settings, creds *certdep
 		h.ForceReinstallJasperCommand(settings),
 		fixJasperDirsOwner,
 	)
-
-	shellPrefix := []string{"set -o errexit", "set -o verbose"}
 
 	shellCmds := append(shellPrefix, checkUserDataRan, setupScriptCmds)
 	shellCmds = append(shellCmds, setupJasperCmds...)

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1312,7 +1312,7 @@ func (h *Host) FetchProvisioningScriptUserData(settings *evergreen.Settings) (*u
 		fmt.Sprintf("--api_server=%s", settings.ApiUrl),
 		fmt.Sprintf("--host_id=%s", h.Id),
 		fmt.Sprintf("--host_secret=%s", h.Secret),
-		fmt.Sprintf("--working_dir=%s", h.Distro.BootstrapSettings.JasperBinaryDir),
+		fmt.Sprintf("--working_dir=%s", h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.JasperBinaryDir)),
 	}, " ")
 
 	cmds := []string{

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1181,7 +1181,7 @@ func TestCheckUserDataStartedCommand(t *testing.T) {
 		for testName, testCase := range map[string]func(t *testing.T, h *Host){
 			"CreatesExpectedCommand": func(t *testing.T, h *Host) {
 				expectedCmd := "if (Test-Path -Path /root_dir/jasper_binary_dir/user_data_started) { exit }" +
-					"\r\n/root_dir/bin/bash -l -c @'" +
+					"\n/root_dir/bin/bash -l -c @'" +
 					"\nmkdir -m 777 -p /jasper_binary_dir && touch /jasper_binary_dir/user_data_started" +
 					"\n'@"
 				cmd := h.CheckUserDataStartedCommand()

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1420,10 +1420,13 @@ func TestFetchProvisioningScriptUserData(t *testing.T) {
 			opts, err := h.FetchProvisioningScriptUserData(settings)
 			require.NoError(t, err)
 
+			makeJasperDirs := h.MakeJasperDirsCommand()
 			fetchClient, err := h.CurlCommandWithRetry(settings, curlDefaultNumRetries, curlDefaultMaxSecs)
 			fixClientOwner := h.changeOwnerCommand(filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()))
 			require.NoError(t, err)
+
 			expectedParts := []string{
+				makeJasperDirs,
 				fetchClient,
 				fixClientOwner,
 				"/home/user/evergreen host provision",
@@ -1431,6 +1434,7 @@ func TestFetchProvisioningScriptUserData(t *testing.T) {
 				"--host_id=host_id",
 				"--host_secret=host_secret",
 				"--working_dir=/jasper_binary_dir",
+				"--shell_path=/bin/bash",
 			}
 
 			assertStringContainsOrderedSubstrings(t, opts.Content, expectedParts)
@@ -1442,19 +1446,21 @@ func TestFetchProvisioningScriptUserData(t *testing.T) {
 			opts, err := h.FetchProvisioningScriptUserData(settings)
 			require.NoError(t, err)
 
+			makeJasperDirs := h.MakeJasperDirsCommand()
 			fetchClient, err := h.CurlCommandWithRetry(settings, curlDefaultNumRetries, curlDefaultMaxSecs)
 			require.NoError(t, err)
-
 			fixClientOwner := h.changeOwnerCommand(filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()))
 
 			expectedParts := []string{
-				util.PowerShellQuotedString(fetchClient),
-				util.PowerShellQuotedString(fixClientOwner),
+				makeJasperDirs,
+				fetchClient,
+				fixClientOwner,
 				"/home/user/evergreen.exe host provision",
 				"--api_server=https://example.com",
 				"--host_id=host_id",
 				"--host_secret=host_secret",
 				"--working_dir=/jasper_binary_dir",
+				"--shell_path=/bin/bash",
 			}
 			for _, part := range expectedParts {
 				assert.Contains(t, opts.Content, part)

--- a/model/validate.go
+++ b/model/validate.go
@@ -62,26 +62,21 @@ func ValidateHost(hostId string, r *http.Request) (*host.Host, int, error) {
 		}
 	}
 	secret := r.Header.Get(evergreen.HostSecretHeader)
-
-	h, err := host.FindOne(host.ById(hostId))
-	if h == nil || err != nil {
-		// If the host was provisioned through user data, the host's agent will
-		// be started with the intent host ID intead of the _id. In this case,
-		// the intent host ID should equal the Jasper credentials ID.
-		altHost, altErr := host.FindOneByJasperCredentialsID(hostId)
-		if altHost == nil {
-			return nil, http.StatusBadRequest, errors.Errorf("host %s not found", hostId)
-		}
-		if altErr != nil {
-			return nil, http.StatusInternalServerError, errors.Wrapf(err, "error loading context for host %s", hostId)
-		}
-		h = altHost
-	}
 	if secret == "" {
-		return nil, http.StatusBadRequest, errors.Errorf("Missing host secret for host %s", h.Id)
+		return nil, http.StatusBadRequest, errors.Errorf("Missing host secret for host '%s'", hostId)
+	}
+
+	// If the host was provisioned through user data, the host be started with
+	// the intent host ID instead of the _id.
+	h, err := host.FindOneByIdOrTag(hostId)
+	if err != nil {
+		return nil, http.StatusInternalServerError, errors.Wrapf(err, "finding host '%s'", hostId)
+	}
+	if h == nil {
+		return nil, http.StatusNotFound, errors.Errorf("host '%s' not found", hostId)
 	}
 	if secret != h.Secret {
-		return nil, http.StatusUnauthorized, errors.Errorf("Invalid host secret for host %s", h.Id)
+		return nil, http.StatusUnauthorized, errors.Errorf("Invalid host secret for host '%s'", hostId)
 	}
 
 	// if the task is attached to the context, check host-task relationship
@@ -92,7 +87,7 @@ func ValidateHost(hostId string, r *http.Request) (*host.Host, int, error) {
 		}
 	}
 	if badHostTaskRelationship(h, t) {
-		return nil, http.StatusConflict, errors.Errorf("Host %s should be running %s, not %s", h.Id, h.RunningTask, t.Id)
+		return nil, http.StatusConflict, errors.Errorf("Host '%s' should be running '%s', not '%s'", hostId, h.RunningTask, t.Id)
 	}
 	return h, http.StatusOK, nil
 }

--- a/model/validate.go
+++ b/model/validate.go
@@ -66,8 +66,8 @@ func ValidateHost(hostId string, r *http.Request) (*host.Host, int, error) {
 		return nil, http.StatusBadRequest, errors.Errorf("Missing host secret for host '%s'", hostId)
 	}
 
-	// If the host was provisioned through user data, the host be started with
-	// the intent host ID instead of the _id.
+	// If the host was provisioned through user data, the host will be started
+	// with the intent host ID instead of the _id.
 	h, err := host.FindOneByIdOrTag(hostId)
 	if err != nil {
 		return nil, http.StatusInternalServerError, errors.Wrapf(err, "finding host '%s'", hostId)

--- a/model/validate_test.go
+++ b/model/validate_test.go
@@ -58,7 +58,7 @@ func TestValidateHost(t *testing.T) {
 			assert.Equal(t, http.StatusOK, status)
 			assert.Equal(t, h, validatedHost)
 		},
-		"PassesIfHostHasValidJasperCredentialsID": func(t *testing.T, h *host.Host, tsk *task.Task, header http.Header) {
+		"PassesIfHostHasValidTag": func(t *testing.T, h *host.Host, tsk *task.Task, header http.Header) {
 			h.Id = ""
 			require.NoError(t, h.Insert())
 
@@ -126,10 +126,10 @@ func TestValidateHost(t *testing.T) {
 			}()
 
 			h := &host.Host{
-				Id:                  hostID,
-				RunningTask:         taskID,
-				Secret:              secret,
-				JasperCredentialsID: hostID,
+				Id:          hostID,
+				Tag:         hostID,
+				RunningTask: taskID,
+				Secret:      secret,
 			}
 
 			tsk := &task.Task{Id: taskID}

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -61,13 +61,13 @@ func hostProvision() cli.Command {
 			comm := client.NewCommunicator(c.String(apiServerURLFlagName))
 			defer comm.Close()
 
-			script, err := comm.GetHostProvisioningScript(ctx, c.String(hostIDFlagName), c.String(hostSecretFlagName))
+			opts, err := comm.GetHostProvisioningScript(ctx, c.String(hostIDFlagName), c.String(hostSecretFlagName))
 			if err != nil {
 				return errors.Wrap(err, "failed to get host provisioning script")
 			}
 
 			workingDir := c.String(workingDirFlagName)
-			scriptPath, err := makeHostProvisioningScriptFile(workingDir, script.Content)
+			scriptPath, err := makeHostProvisioningScriptFile(workingDir, opts.Content)
 			if err != nil {
 				return errors.Wrap(err, "write host provisioning script to file")
 			}
@@ -94,8 +94,8 @@ func makeHostProvisioningScriptFile(workingDir string, content string) (string, 
 	if err != nil {
 		return "", errors.Wrap(err, "making absolute path to the host provisioning script")
 	}
-	// Cygwin bash is unhappy if you use back slashes ('\') without escaping
-	// them, so use forward slashes ('/') instead as the path separator.
+	// Cygwin shell requires back slashes ('\') to be escaped, so use forward
+	// slashes ('/') instead as the path separator.
 	scriptPath = util.ConsistentFilepath(scriptPath)
 	if err = ioutil.WriteFile(scriptPath, []byte(content), 0700); err != nil {
 		return "", errors.Wrapf(err, "writing script to file '%s'", scriptPath)

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -104,7 +104,7 @@ func makeHostProvisioningScriptFile(workingDir string, content string) (string, 
 }
 
 func hostProvisioningCommand(shellPath, scriptPath string) *jasper.Command {
-	return jasper.NewCommand().AppendArgs(shellPath, "-l", "-c", scriptPath)
+	return jasper.NewCommand().AppendArgs(shellPath, "-l", scriptPath)
 }
 
 func runHostProvisioningCommand(ctx context.Context, cmd *jasper.Command) error {

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -190,7 +190,7 @@ func (hc *DBHostConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error
 }
 
 func (hc *DBHostConnector) GenerateHostProvisioningScript(ctx context.Context, hostID string) (*userdata.Options, error) {
-	h, err := host.FindOneId(hostID)
+	h, err := host.FindOneByIdOrTag(hostID)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -190,6 +190,12 @@ func (hc *DBHostConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error
 }
 
 func (hc *DBHostConnector) GenerateHostProvisioningScript(ctx context.Context, hostID string) (*userdata.Options, error) {
+	if hostID == "" {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    "cannot generate host provisioning script without a host ID",
+		}
+	}
 	h, err := host.FindOneByIdOrTag(hostID)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13286

* Use intent host ID (i.e. the host tag) when checking host ID/secret instead of host ID/Jasper credentials ID (which isn't set yet).
* Put Evergreen client on the host before invoking Evergreen CLI command to provision the host.
* Write the shebang line to host provisioning script.
* Connect stdout/stderr directly to output of host provisioning script rather than storing it in memory and then logging it.