### PR TITLE
EVG-13050 add more ways to select tasks with trigger aliases

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -148,12 +148,17 @@ type TriggerDefinition struct {
 }
 
 type PatchTriggerDefinition struct {
-	Alias          string `bson:"alias" json:"alias"`
-	ChildProject   string `bson:"child_project" json:"child_project"`
-	Status         string `bson:"status,omitempty" json:"status,omitempty"`
-	TaskRegex      string `bson:"task_regex,omitempty" json:"task_regex,omitempty"`
-	VariantRegex   string `bson:"variant_regex,omitempty" json:"variant_regex,omitempty"`
-	ParentAsModule string `bson:"parent_as_module,omitempty" json:"parent_as_module,omitempty"`
+	Alias          string          `bson:"alias" json:"alias"`
+	ChildProject   string          `bson:"child_project" json:"child_project"`
+	TaskSpecifiers []TaskSpecifier `bson:"task_specifiers" json:"task_specifiers"`
+	Status         string          `bson:"status,omitempty" json:"status,omitempty"`
+	ParentAsModule string          `bson:"parent_as_module,omitempty" json:"parent_as_module,omitempty"`
+}
+
+type TaskSpecifier struct {
+	PatchAlias   string `bson:"patch_alias,omitempty" json:"patch_alias,omitempty"`
+	TaskRegex    string `bson:"task_regex,omitempty" json:"task_regex,omitempty"`
+	VariantRegex string `bson:"variant_regex,omitempty" json:"variant_regex,omitempty"`
 }
 
 type PeriodicBuildDefinition struct {
@@ -1226,13 +1231,39 @@ func (t *PatchTriggerDefinition) Validate(parentProject string) error {
 	if !utility.StringSliceContains([]string{"", AllStatuses, evergreen.PatchSucceeded, evergreen.PatchFailed}, t.Status) {
 		return errors.Errorf("invalid status: %s", t.Status)
 	}
-	_, regexErr := regexp.Compile(t.VariantRegex)
-	if regexErr != nil {
-		return errors.Wrap(regexErr, "invalid variant regex")
-	}
-	_, regexErr = regexp.Compile(t.TaskRegex)
-	if regexErr != nil {
-		return errors.Wrap(regexErr, "invalid task regex")
+
+	for _, specifier := range t.TaskSpecifiers {
+		if (specifier.VariantRegex != "" || specifier.TaskRegex != "") && specifier.PatchAlias != "" {
+			return errors.New("can't specify both a regex set and a patch alias")
+		}
+
+		if specifier.VariantRegex != "" {
+			_, regexErr := regexp.Compile(specifier.VariantRegex)
+			if regexErr != nil {
+				return errors.Wrapf(regexErr, "invalid variant regex '%s'", specifier.VariantRegex)
+			}
+		}
+
+		if specifier.TaskRegex != "" {
+			_, regexErr := regexp.Compile(specifier.TaskRegex)
+			if regexErr != nil {
+				return errors.Wrapf(regexErr, "invalid task regex '%s'", specifier.TaskRegex)
+			}
+		}
+
+		if specifier.PatchAlias != "" {
+			var aliases []ProjectAlias
+			aliases, err = FindAliasesForProject(t.ChildProject)
+			if err != nil {
+				return errors.Wrap(err, "problem fetching aliases for project")
+			}
+			for _, alias := range aliases {
+				if alias.Alias == specifier.PatchAlias {
+					return nil
+				}
+			}
+			return errors.Errorf("patch alias '%s' does not exist for project '%s'", specifier.PatchAlias, t.ChildProject)
+		}
 	}
 
 	return nil

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -943,6 +943,10 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
         return false;
       }
 
+      if (!$scope.alias.task_specifiers.length) {
+        return false;
+      }
+
       return true;
     };
 

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -887,9 +887,34 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
   };
 
   function newPatchTriggerAliasController($scope, $mdDialog) {
+    $scope.new_task_specifier = {};
+    $scope.alias = {task_specifiers: []};
+
     if ($scope.data.aliasToEdit) {
       $scope.alias = $scope.data.aliasToEdit;
+      $scope.alias.task_specifiers = $scope.alias.task_specifiers || [];
       $scope.aliasIndex = $scope.data.index;
+    }
+
+    $scope.removeTaskSpecifier = function(index) {
+      $scope.alias.task_specifiers.splice(index, 1);
+    }
+
+    $scope.addTaskSpecifier = function() {
+      if (!$scope.validTaskSpecifier($scope.new_task_specifier)) {
+        return
+      }
+
+      $scope.alias.task_specifiers.push($scope.new_task_specifier);
+      $scope.new_task_specifier = {};
+    }
+
+    $scope.validTaskSpecifier = function(specifier) {
+      if (!specifier.patch_alias && (!specifier.variant_regex || !specifier.task_regex)) {
+        return false
+      }
+
+      return true;
     }
 
     $scope.closeDialog = function (save) {
@@ -914,7 +939,7 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
     };
 
     $scope.validTriggerAlias = function () {
-      if (!$scope.alias.definition_alias || !$scope.alias.child_project) {
+      if (!$scope.alias.alias || !$scope.alias.child_project) {
         return false;
       }
 

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -910,6 +910,12 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
     }
 
     $scope.validTaskSpecifier = function(specifier) {
+      // can't specify both an alias and a regex set
+      if (specifier.patch_alias && (specifier.variant_regex || specifier.task_regex)) {
+        return false
+      }
+
+      // must specify either an alias or a complete regex set
       if (!specifier.patch_alias && (!specifier.variant_regex || !specifier.task_regex)) {
         return false
       }

--- a/public/static/partials/patch_trigger_alias_modal.html
+++ b/public/static/partials/patch_trigger_alias_modal.html
@@ -31,16 +31,20 @@
                     </md-input-container>
                 </section>
                 <section layout="column" flex>
+                    <label> One of patch alias and variant/task regex set </label>
                     <section layout="row" flex ng-repeat="(index, specifier) in alias.task_specifiers">
-                        <md-input-container flex=33>
-                            <input type="text" ng-model="specifier.variant_regex" placeholder="variant regex">
+                        <md-input-container flex>
+                            <input type="text" ng-disabled="specifier.variant_regex || specifier.task_regex" ng-model="specifier.patch_alias" placeholder="patch alias">
                         </md-input-container>
-                        <md-input-container  flex=33>
-                            <input type="text" ng-model="specifier.task_regex" placeholder="task regex">
-                        </md-input-container>
-                        <md-input-container  flex>
-                            <input type="text" ng-model="specifier.patch_alias" placeholder="patch alias">
-                        </md-input-container>
+                        <md-divider></md-divider>
+                        <div layout="row" flex=55>
+                            <md-input-container flex>
+                                <input type="text" ng-disabled="specifier.patch_alias" ng-model="specifier.variant_regex" placeholder="variant regex">
+                            </md-input-container>
+                            <md-input-container  flex>
+                                <input type="text" ng-disabled="specifier.patch_alias" ng-model="specifier.task_regex" placeholder="task regex">
+                            </md-input-container>
+                        </div>
                         <div>
                             <button class="btn btn-default btn-danger" type="button"
                                 style="float: left" ng-click="removeTaskSpecifier(index)">
@@ -49,15 +53,18 @@
                         </div>
                     </section>
                     <section layout="row" flex>
-                        <md-input-container  flex=33>
-                            <input type="text" ng-model="new_task_specifier.variant_regex" placeholder="variant regex">
-                        </md-input-container>
-                        <md-input-container flex=33>
-                            <input type="text" ng-model="new_task_specifier.task_regex" placeholder="task regex">
-                        </md-input-container>
                         <md-input-container flex>
-                            <input type="text" ng-model="new_task_specifier.patch_alias" placeholder="patch alias">
+                            <input type="text" ng-disabled="new_task_specifier.variant_regex || new_task_specifier.task_regex" ng-model="new_task_specifier.patch_alias" placeholder="patch alias">
                         </md-input-container>
+                        <md-divider></md-divider>
+                        <div layout="row" flex=55>
+                            <md-input-container flex>
+                                <input type="text" ng-disabled="new_task_specifier.patch_alias" ng-model="new_task_specifier.variant_regex" placeholder="variant regex">
+                            </md-input-container>
+                            <md-input-container flex>
+                                <input type="text" ng-disabled="new_task_specifier.patch_alias" ng-model="new_task_specifier.task_regex" placeholder="task regex">
+                            </md-input-container>
+                        </div>
                         <div>
                             <button class="plus-button btn btn-primary"
                                 ng-disabled="!validTaskSpecifier(new_task_specifier)" type="button"

--- a/public/static/partials/patch_trigger_alias_modal.html
+++ b/public/static/partials/patch_trigger_alias_modal.html
@@ -8,7 +8,7 @@
                 <section layout="row" flex>
                     <md-input-container flex=50>
                         <label>Alias:</label>
-                        <input type="text" ng-model="alias.definition_alias" ng-required="true" placeholder="alias name">
+                        <input type="text" ng-model="alias.alias" ng-required="true" placeholder="alias name">
                     </md-input-container>
                     <md-input-container flex=50>
                         <label>Project:</label>
@@ -30,15 +30,42 @@
                         </md-select>
                     </md-input-container>
                 </section>
-                <section layout="row" flex>
-                    <md-input-container flex=50>
-                        <label>Variant regex:</label>
-                        <input type="text" ng-model="alias.variant_regex" placeholder="select variants matching regex">
-                    </md-input-container>
-                    <md-input-container flex=50>
-                        <label>Task regex:</label>
-                        <input type="text" ng-model="alias.task_regex" placeholder="select tasks matching regex">
-                    </md-input-container>
+                <section layout="column" flex>
+                    <section layout="row" flex ng-repeat="(index, specifier) in alias.task_specifiers">
+                        <md-input-container flex=33>
+                            <input type="text" ng-model="specifier.variant_regex" placeholder="variant regex">
+                        </md-input-container>
+                        <md-input-container  flex=33>
+                            <input type="text" ng-model="specifier.task_regex" placeholder="task regex">
+                        </md-input-container>
+                        <md-input-container  flex>
+                            <input type="text" ng-model="specifier.patch_alias" placeholder="patch alias">
+                        </md-input-container>
+                        <div>
+                            <button class="btn btn-default btn-danger" type="button"
+                                style="float: left" ng-click="removeTaskSpecifier(index)">
+                                <i class="fa fa-trash"></i>
+                            </button>
+                        </div>
+                    </section>
+                    <section layout="row" flex>
+                        <md-input-container  flex=33>
+                            <input type="text" ng-model="new_task_specifier.variant_regex" placeholder="variant regex">
+                        </md-input-container>
+                        <md-input-container flex=33>
+                            <input type="text" ng-model="new_task_specifier.task_regex" placeholder="task regex">
+                        </md-input-container>
+                        <md-input-container flex>
+                            <input type="text" ng-model="new_task_specifier.patch_alias" placeholder="patch alias">
+                        </md-input-container>
+                        <div>
+                            <button class="plus-button btn btn-primary"
+                                ng-disabled="!validTaskSpecifier(new_task_specifier)" type="button"
+                                style="float: left" ng-click="addTaskSpecifier()">
+                                <i class="fa fa-plus"></i>
+                            </button>
+                        </div>
+                    </section>
                 </section>
             </md-card-content>
         </md-card>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -775,7 +775,7 @@ Evergreen Projects
           </div>
 
           <div class="form-group" ng-repeat="alias in patch_trigger_aliases track by $index">
-              <a class="col-lg-12 link" ng-click="showPatchTriggerAliasModal($index)">[[alias.definition_alias]]</a>
+              <a class="col-lg-12 link" ng-click="showPatchTriggerAliasModal($index)">[[alias.alias]]</a>
           </div>
 
           <div class="form-group">


### PR DESCRIPTION
Allow users to specify multiple sets of "task specifiers" within a single alias. A "task specifier" now consists of either a set of regexes for task and variant or an existing patch alias.

![Screen Shot 2020-11-18 at 5 31 28 PM](https://user-images.githubusercontent.com/17027265/99597118-81541700-29c5-11eb-9f76-9baf1e7e4492.png)

Also fix some bugs from https://github.com/evergreen-ci/evergreen/pull/4172.