### PR TITLE
EVG-13270 get merged project when repo settings are used

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -966,7 +966,7 @@ func (r *queryResolver) TaskAllExecutions(ctx context.Context, taskID string) ([
 }
 
 func (r *queryResolver) Projects(ctx context.Context) (*Projects, error) {
-	allProjs, err := model.FindAllTrackedProjectRefs()
+	allProjs, err := model.FindAllMergedTrackedProjectRefs()
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, err.Error())
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -486,7 +486,7 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 				}
 				proj = projRef
 			}
-			_, err := commitqueue.RemoveCommitQueueItemForVersion(proj.Identifier,
+			_, err := commitqueue.RemoveCommitQueueItemForVersion(proj.Id,
 				proj.CommitQueue.PatchType, version.Id, user.DisplayName())
 			if err != nil {
 				return http.StatusInternalServerError, errors.Errorf("error removing patch from commit queue: %s", err)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -111,12 +111,9 @@ func GetPatchedProject(ctx context.Context, p *patch.Patch, githubOauthToken str
 		return nil, "", errors.Errorf("Patch %v already finalized", p.Version)
 	}
 
-	projectRef, err := FindOneProjectRef(p.Project)
+	projectRef, err := FindMergedProjectRef(p.Project)
 	if err != nil {
 		return nil, "", errors.WithStack(err)
-	}
-	if projectRef == nil {
-		return nil, "", errors.Errorf("no project exists with identifier '%s", p.Project)
 	}
 
 	project := &Project{}
@@ -563,12 +560,9 @@ func MakeMergePatchFromExisting(existingPatch *patch.Patch) (*patch.Patch, error
 	}
 
 	// verify the commit queue is on
-	projectRef, err := FindOneProjectRef(existingPatch.Project)
+	projectRef, err := FindMergedProjectRef(existingPatch.Project)
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't get project ref '%s'", existingPatch.Project)
-	}
-	if projectRef == nil {
-		return nil, errors.Errorf("no project '%s' exists", existingPatch.Project)
 	}
 	if err = projectRef.CommitQueueIsOn(); err != nil {
 		return nil, errors.WithStack(err)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -111,7 +111,7 @@ func (pc *DBProjectConnector) EnableWebhooks(ctx context.Context, projectRef *mo
 }
 
 func (pc *DBProjectConnector) EnablePRTesting(projectRef *model.ProjectRef) error {
-	conflictingRefs, err := model.FindProjectRefsByRepoAndBranch(projectRef.Owner, projectRef.Repo, projectRef.Branch)
+	conflictingRefs, err := model.FindMergedProjectRefsByRepoAndBranch(projectRef.Owner, projectRef.Repo, projectRef.Branch)
 	if err != nil {
 		return errors.Wrap(err, "error finding project refs")
 	}
@@ -263,7 +263,7 @@ func (ac *DBProjectConnector) GetProjectWithCommitQueueByOwnerRepoAndBranch(owne
 }
 
 func (ac *DBProjectConnector) FindEnabledProjectRefsByOwnerAndRepo(owner, repo string) ([]model.ProjectRef, error) {
-	return model.FindEnabledProjectRefsByOwnerAndRepo(owner, repo)
+	return model.FindMergedEnabledProjectRefsByOwnerAndRepo(owner, repo)
 }
 
 func (ac *DBProjectConnector) GetVersionsInProject(identifier, requester string, limit, startOrder int) ([]restModel.APIVersion, error) {

--- a/rest/data/repotracker.go
+++ b/rest/data/repotracker.go
@@ -66,7 +66,7 @@ func (c *RepoTrackerConnector) TriggerRepotracker(q amboy.Queue, msgID string, e
 		return errors.New("owner from push event is invalid")
 	}
 
-	refs, err := model.FindProjectRefsByRepoAndBranch(*event.Repo.Owner.Name, *event.Repo.Name, branch)
+	refs, err := model.FindMergedProjectRefsByRepoAndBranch(*event.Repo.Owner.Name, *event.Repo.Name, branch)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"source":  "github hook",
@@ -167,7 +167,7 @@ func (c *MockRepoTrackerConnector) TriggerRepotracker(_ amboy.Queue, _ string, e
 		return nil
 	}
 
-	_, err = model.FindProjectRefsByRepoAndBranch(*event.Repo.Owner.Name, *event.Repo.Name, branch)
+	_, err = model.FindMergedProjectRefsByRepoAndBranch(*event.Repo.Owner.Name, *event.Repo.Name, branch)
 	return err
 }
 

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -596,9 +596,6 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 	// check to see if this is an anonymous user requesting a private project
 	user := gimlet.GetUser(r.Context())
 	if user == nil {
-		if err != nil || projectRef == nil {
-			return nil, http.StatusNotFound, errors.New("no project found")
-		}
 		if projectRef.Private {
 			projectID = ""
 		}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -167,7 +167,7 @@ func (h *versionsGetHandler) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (h *versionsGetHandler) Run(ctx context.Context) gimlet.Responder {
-	projRef, err := dbModel.FindOneProjectRef(h.project)
+	projRefId, err := dbModel.FindIdForProject(h.project)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -175,7 +175,7 @@ func (h *versionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	proj, err := dbModel.FindLastKnownGoodProject(projRef.Id)
+	proj, err := dbModel.FindLastKnownGoodProject(projRefId)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -434,7 +434,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	if oldProject.UseRepoSettings != newProjectRef.UseRepoSettings {
 		if newProjectRef.UseRepoSettings {
-			err = newProjectRef.AddToRepoScope(ctx, h.user)
+			err = newProjectRef.AddToRepoScope(h.user)
 		} else {
 			err = newProjectRef.RemoveFromRepoScope()
 		}

--- a/scheduler/task_finder.go
+++ b/scheduler/task_finder.go
@@ -364,7 +364,7 @@ func ParallelTaskFinder(d distro.Distro) ([]task.Task, error) {
 
 func getProjectRefCache() (map[string]model.ProjectRef, error) {
 	out := map[string]model.ProjectRef{}
-	refs, err := model.FindAllProjectRefs()
+	refs, err := model.FindAllMergedProjectRefs()
 	if err != nil {
 		return out, err
 	}

--- a/service/api.go
+++ b/service/api.go
@@ -223,7 +223,6 @@ func (as *APIServer) GetProjectRef(w http.ResponseWriter, r *http.Request) {
 	t := MustHaveTask(r)
 
 	p, err := model.FindOneProjectRef(t.Project)
-
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
@@ -432,8 +431,9 @@ func (as *APIServer) fetchProjectRef(w http.ResponseWriter, r *http.Request) {
 	gimlet.WriteJSON(w, projectRef)
 }
 
+// listProjects returns the projects merged with the repo settings
 func (as *APIServer) listProjects(w http.ResponseWriter, r *http.Request) {
-	allProjs, err := model.FindAllTrackedProjectRefs()
+	allProjs, err := model.FindAllMergedTrackedProjectRefs()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -61,7 +61,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		as.LoggedError(w, r, http.StatusBadRequest, err)
 		return
 	}
-	pref, err := model.FindOneProjectRef(data.Project)
+	pref, err := model.FindMergedProjectRef(data.Project)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrapf(err, "project '%s' is not specified", data.Project))
 		return

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -486,8 +486,8 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			continue
 		}
 
-		projectRef, err := model.FindOneProjectRef(nextTask.Project)
-		if err != nil || projectRef == nil {
+		projectRef, err := model.FindMergedProjectRef(nextTask.Project)
+		if err != nil {
 			grip.Alert(message.Fields{
 				"task_id":            nextTask.Id,
 				"message":            "could not find project ref for next task, skipping",

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -275,7 +275,7 @@ func (uis *UIServer) loadCtx(next http.HandlerFunc) http.HandlerFunc {
 // all available projects will be included, otherwise only public projects will be loaded.
 // Sets IsAdmin to true if the user id is located in a project's admin list.
 func (pc *projectContext) populateProjectRefs(includePrivate bool, user gimlet.User) error {
-	allProjs, err := model.FindAllTrackedProjectRefs()
+	allProjs, err := model.FindAllMergedTrackedProjectRefs()
 	if err != nil {
 		return err
 	}

--- a/service/project.go
+++ b/service/project.go
@@ -27,7 +27,7 @@ import (
 // filterViewableProjects iterates through a list of projects and returns a list of all the projects that a user
 // is authorized to view
 func (uis *UIServer) filterViewableProjects(u gimlet.User) ([]model.ProjectRef, error) {
-	allProjects, err := model.FindAllProjectRefs()
+	allProjects, err := model.FindAllMergedProjectRefs()
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	matchingRefs, err := model.FindProjectRefsByRepoAndBranch(projRef.Owner, projRef.Repo, projRef.Branch)
+	matchingRefs, err := model.FindMergedProjectRefsByRepoAndBranch(projRef.Owner, projRef.Repo, projRef.Branch)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
@@ -341,7 +341,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		var conflictingRefs []model.ProjectRef
-		conflictingRefs, err = model.FindProjectRefsByRepoAndBranch(responseRef.Owner, responseRef.Repo, responseRef.Branch)
+		conflictingRefs, err = model.FindMergedProjectRefsByRepoAndBranch(responseRef.Owner, responseRef.Repo, responseRef.Branch)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
@@ -664,7 +664,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if origProjectRef.UseRepoSettings != projectRef.UseRepoSettings {
 		if projectRef.UseRepoSettings {
-			err = projectRef.AddToRepoScope(ctx, dbUser)
+			err = projectRef.AddToRepoScope(dbUser)
 		} else {
 			err = projectRef.RemoveFromRepoScope()
 		}

--- a/service/rest_project.go
+++ b/service/rest_project.go
@@ -22,7 +22,7 @@ func (restapi restAPI) getProjectRef(w http.ResponseWriter, r *http.Request) {
 // getProjectsIds returns a JSON response of an array of active project Ids.
 // Users must use credentials to see private projects.
 func (restapi restAPI) getProjectIds(w http.ResponseWriter, r *http.Request) {
-	refs, err := model.FindAllProjectRefs()
+	refs, err := model.FindAllMergedProjectRefs()
 	if err != nil {
 		gimlet.WriteJSONResponse(w, http.StatusNotFound, responseError{
 			Message: fmt.Sprintf("error finding projects: %v", err),

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -86,12 +86,6 @@ func (uis *UIServer) spawnPage(w http.ResponseWriter, r *http.Request) {
 				"project_id": spawnTask.Project,
 				"task_id":    spawnTask.Id,
 			}))
-		} else if pRef == nil {
-			grip.Error(message.Fields{
-				"message":    "project is nil",
-				"project_id": spawnTask.Project,
-				"task_id":    spawnTask.Id,
-			})
 		} else {
 			setupScriptPath = pRef.SpawnHostScriptPath
 		}

--- a/units/crons.go
+++ b/units/crons.go
@@ -43,7 +43,7 @@ func PopulateCatchupJobs() amboy.QueueOperation {
 			return nil
 		}
 
-		projects, err := model.FindAllTrackedProjectRefsWithRepoInfo()
+		projects, err := model.FindAllMergedTrackedProjectRefsWithRepoInfo()
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -1092,7 +1092,7 @@ func PopulateCacheHistoricalTestDataJob(part int) amboy.QueueOperation {
 			return nil
 		}
 
-		projects, err := model.FindAllTrackedProjectRefs()
+		projects, err := model.FindAllMergedTrackedProjectRefs()
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -206,12 +206,9 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		patchDoc.DisplayNewUI = true
 	}
 
-	pref, err := model.FindOneProjectRef(patchDoc.Project)
+	pref, err := model.FindMergedProjectRef(patchDoc.Project)
 	if err != nil {
 		return errors.Wrap(err, "can't find patch project")
-	}
-	if pref == nil {
-		return errors.Errorf("patch project '%s' doesn't exist", patchDoc.Project)
 	}
 
 	if !pref.Enabled {

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -66,15 +66,12 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 	var err error
-	j.project, err = model.FindOneProjectRef(j.ProjectID)
+	j.project, err = model.FindMergedProjectRef(j.ProjectID)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "error finding project"))
 		return
 	}
-	if j.project == nil {
-		j.AddError(errors.New("project not found"))
-		return
-	}
+
 	var definition *model.PeriodicBuildDefinition
 	for _, d := range j.project.PeriodicBuilds {
 		if d.ID == j.DefinitionID {

--- a/units/repotracker.go
+++ b/units/repotracker.go
@@ -90,13 +90,9 @@ func (j *repotrackerJob) Run(ctx context.Context) {
 		return
 	}
 
-	ref, err := model.FindOneProjectRef(j.ProjectID)
+	ref, err := model.FindMergedProjectRef(j.ProjectID)
 	if err != nil {
 		j.AddError(err)
-		return
-	}
-	if ref == nil {
-		j.AddError(errors.New("can't find project ref for project"))
 		return
 	}
 

--- a/units/repotracker_test.go
+++ b/units/repotracker_test.go
@@ -32,7 +32,7 @@ func (s *repotrackerJobSuite) TestJob() {
 	s.Equal("repotracker:1:mci", j.ID())
 	j.Run(context.Background())
 	s.Error(j.Error())
-	s.Contains(j.Error().Error(), "can't find project ref for project")
+	s.Contains(j.Error().Error(), "project ref 'mci' does not exist")
 	s.True(j.Status().Completed)
 }
 

--- a/units/version_activation_catchup.go
+++ b/units/version_activation_catchup.go
@@ -70,7 +70,7 @@ func (j *versionActivationCatchup) Run(ctx context.Context) {
 		return
 	}
 
-	projects, err := model.FindAllTrackedProjectRefs()
+	projects, err := model.FindAllMergedTrackedProjectRefs()
 	if err != nil {
 		j.AddError(err)
 		return


### PR DESCRIPTION
There are a few settings with project (detailed in the [design](https://docs.google.com/document/d/1Nrlg_2vZ6Ejr2egQYl4amie_gjv4OcyjHKKjP0Q2mOI/edit#heading=h.2s9zdv6a57gn)) that should be considered at the repo-level, if we're using repo settings. I believe the way to modify the least code is to get the project ref merged with the repo ref, in the instances that we need it.