### PR TITLE
EVG-7382 consolidate calls to remove from commit queue

### DIFF
--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2583,7 +2583,7 @@
       "result": {
         "errors": [
           {
-            "message": "Unable to remove commit queue item for project exec2, version version: no commit queue found for 'logkeeper'",
+            "message": "Error aborting task exec2: no commit queue found for 'logkeeper'",
             "path": ["abortTask"],
             "extensions": { "code": "INTERNAL_SERVER_ERROR" }
           }

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1835,12 +1835,6 @@ func (r *mutationResolver) AbortTask(ctx context.Context, taskID string) (*restM
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error aborting task %s: %s", taskID, err.Error()))
 	}
-	if t.Requester == evergreen.MergeTestRequester {
-		_, err = commitqueue.RemoveCommitQueueItemForVersion(t.Project, p.CommitQueue.PatchType, t.Version, user)
-		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Unable to remove commit queue item for project %s, version %s: %s", taskID, t.Version, err.Error()))
-		}
-	}
 	t, err = r.sc.FindTaskById(taskID)
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("error finding task by id %s: %s", taskID, err.Error()))

--- a/graphql/tests/abortTask/data.json
+++ b/graphql/tests/abortTask/data.json
@@ -1,0 +1,45 @@
+{
+  "tasks": [
+    {
+      "_id": "t1",
+      "display_name": "cq merge",
+      "branch": "p1",
+      "status": "started",
+      "build_id": "b1",
+      "r": "merge_test",
+      "commit_queue_merge": true,
+      "version": "v1"
+    }
+  ],
+  "builds": [
+    {
+      "_id": "b1",
+      "status": "started",
+      "build_variant": "commit-queue",
+      "display_name": "~ Commit Queue",
+      "tasks": [{ "id": "t1" }]
+    }
+  ],
+  "versions": [
+    {
+      "_id": "v1"
+    }
+  ],
+  "project_ref": [
+    {
+      "_id": "p1",
+      "identifier": "p1",
+      "commit_queue": {
+        "enabled": true,
+        "patch_type": "CLI"
+      }
+    }
+  ],
+  "commit_queue": [
+    {
+      "_id": "p1",
+      "processing": true,
+      "queue": [{ "version": "v1", "issue": "v1" }]
+    }
+  ]
+}

--- a/graphql/tests/abortTask/queries/commit-queue-dequeue.graphql
+++ b/graphql/tests/abortTask/queries/commit-queue-dequeue.graphql
@@ -1,0 +1,6 @@
+mutation {
+  abortTask(taskId: "t1") {
+    activated
+    aborted
+  }
+}

--- a/graphql/tests/abortTask/results.json
+++ b/graphql/tests/abortTask/results.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "query_file": "commit-queue-dequeue.graphql",
+      "result": {
+        "data": {
+          "abortTask": {
+            "activated": false,
+            "aborted": true
+          }
+        }
+      }
+    }
+  ]
+}

--- a/graphql/tests/unschedulePatchTasks/data.json
+++ b/graphql/tests/unschedulePatchTasks/data.json
@@ -5,6 +5,11 @@
       "branch": "evergreen",
       "identifier": "evergreen",
       "r": "patch_request"
+    },
+    {
+      "_id": "7",
+      "r": "merge_test",
+      "identifier": "p1"
     }
   ],
   "tasks": [
@@ -13,7 +18,17 @@
     { "_id": "3", "version": "5e4ff3abe3c3317e352062e4" },
     { "_id": "4", "version": "5e4ff3abe3c3317e352062e4" },
     { "_id": "5", "version": "5e4ff3abe3c3317e352062e4" },
-    { "_id": "6", "version": "5e4ff3abe3c3317e352062e4" }
+    { "_id": "6", "version": "5e4ff3abe3c3317e352062e4" },
+    {
+      "_id": "7",
+      "display_name": "cq merge",
+      "branch": "p1",
+      "status": "started",
+      "build_id": "7",
+      "r": "merge_test",
+      "commit_queue_merge": true,
+      "version": "7"
+    }
   ],
   "builds": [
     {
@@ -46,6 +61,13 @@
       "r": "gitter_request",
       "time_taken": 30000000000000,
       "predicted_makespan": 70000000000000
+    },
+    {
+      "_id": "7",
+      "status": "started",
+      "build_variant": "commit-queue",
+      "display_name": "~ Commit Queue",
+      "tasks": [{ "id": "7" }]
     }
   ],
   "patches": [
@@ -99,13 +121,21 @@
       ]
     }
   ],
-  "projects": [
+  "project_ref": [
     {
-      "_id": "evergreen",
-      "identifier": "evergreen",
+      "_id": "p1",
+      "identifier": "p1",
       "commit_queue": {
-        "patch_type": "PR"
+        "enabled": true,
+        "patch_type": "CLI"
       }
+    }
+  ],
+  "commit_queue": [
+    {
+      "_id": "p1",
+      "processing": true,
+      "queue": [{ "version": "7", "issue": "7" }]
     }
   ]
 }

--- a/graphql/tests/unschedulePatchTasks/queries/commit-queue-dequeue.graphql
+++ b/graphql/tests/unschedulePatchTasks/queries/commit-queue-dequeue.graphql
@@ -1,0 +1,3 @@
+mutation {
+  unschedulePatchTasks(patchId: "7", abort: false)
+}

--- a/graphql/tests/unschedulePatchTasks/results.json
+++ b/graphql/tests/unschedulePatchTasks/results.json
@@ -32,6 +32,14 @@
           "unschedulePatchTasks": "5e4ff3abe3c3317e352062e4"
         }
       }
+    },
+    {
+      "query_file": "commit-queue-dequeue.graphql",
+      "result": {
+        "data": {
+          "unschedulePatchTasks": "7"
+        }
+      }
     }
   ]
 }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -482,7 +482,7 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 					return http.StatusNotFound, errors.Errorf("error getting project ref: %s", err.Error())
 				}
 				if projRef == nil {
-					return http.StatusNotFound, errors.Errorf("project for %s came back nil: %s", version.Branch, err.Error())
+					return http.StatusNotFound, errors.Errorf("project %s does not exist", version.Branch)
 				}
 				proj = projRef
 			}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -479,10 +479,10 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 			if proj == nil {
 				projRef, err := model.FindOneProjectRef(version.Identifier)
 				if err != nil {
-					return http.StatusNotFound, errors.Errorf("error getting project ref: %s", err)
+					return http.StatusNotFound, errors.Errorf("error getting project ref: %s", err.Error())
 				}
 				if projRef == nil {
-					return http.StatusNotFound, errors.Errorf("project for %s came back nil: %s", version.Branch, err)
+					return http.StatusNotFound, errors.Errorf("project for %s came back nil: %s", version.Branch, err.Error())
 				}
 				proj = projRef
 			}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -90,6 +90,17 @@ func SetActiveState(t *task.Task, caller string, active bool) error {
 	} else {
 		return nil
 	}
+	if !active && t.Requester == evergreen.MergeTestRequester {
+		projRef, err := FindOneProjectRef(t.Project)
+		if err != nil {
+			return errors.Wrap(err, "unable to find project ref")
+		}
+		if projRef == nil {
+			return errors.New("no project found")
+		}
+		_, err = commitqueue.RemoveCommitQueueItemForVersion(t.Project,
+			projRef.CommitQueue.PatchType, t.Version, caller)
+	}
 
 	if t.IsPartOfDisplay() {
 		if err := updateDisplayTaskAndCache(t); err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -100,6 +100,9 @@ func SetActiveState(t *task.Task, caller string, active bool) error {
 		}
 		_, err = commitqueue.RemoveCommitQueueItemForVersion(t.Project,
 			projRef.CommitQueue.PatchType, t.Version, caller)
+		if err != nil {
+			return err
+		}
 	}
 
 	if t.IsPartOfDisplay() {

--- a/service/task.go
+++ b/service/task.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
-	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -710,13 +709,6 @@ func (uis *UIServer) taskModify(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("Error aborting task %v: %v", projCtx.Task.Id, err), http.StatusInternalServerError)
 			return
 		}
-		if projCtx.Task.Requester == evergreen.MergeTestRequester {
-			_, err = commitqueue.RemoveCommitQueueItemForVersion(projCtx.ProjectRef.Id,
-				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Task.Version, authName)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-		}
 
 		// Reload the task from db, send it back
 		projCtx.Task, err = task.FindOne(task.ById(projCtx.Task.Id))
@@ -734,13 +726,6 @@ func (uis *UIServer) taskModify(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if !active && projCtx.Task.Requester == evergreen.MergeTestRequester {
-			_, err = commitqueue.RemoveCommitQueueItemForVersion(projCtx.ProjectRef.Id,
-				projCtx.ProjectRef.CommitQueue.PatchType, projCtx.Task.Version, authName)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-		}
 		// Reload the task from db, send it back
 		projCtx.Task, err = task.FindOne(task.ById(projCtx.Task.Id))
 		if err != nil {


### PR DESCRIPTION
This consolidates some things, but the outstanding parts that aren't consolidated would be more messy if they were I think. Also adds a way to run some additional assertions for the graphql tests