### PR TITLE
EVG-13455: do not use verbose output when provisioning WIndows hosts

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -451,9 +451,8 @@ func (h *Host) ProvisioningUserData(settings *evergreen.Settings, creds *certdep
 	if h.Distro.IsWindows() {
 		var setupScriptCmds []string
 		if h.Distro.BootstrapSettings.FetchProvisioningScript {
-			// If we're fetching the provisioning script, we can just execute
-			// the setup script commands directly rather than write it to an
-			// intermediate file.
+			// If we're fetching the provisioning script, we do not need to
+			// write the setup script to its own intermediate file.
 			var setupScript string
 			setupScript, err = h.setupScriptCommands(settings)
 			if err != nil {

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen/rest/client"
 	"github.com/evergreen-ci/evergreen/util"
-	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/jasper"
 	"github.com/pkg/errors"
@@ -61,7 +60,7 @@ func hostProvision() cli.Command {
 			comm := client.NewCommunicator(c.String(apiServerURLFlagName))
 			defer comm.Close()
 
-			opts, err := comm.GetHostProvisioningScript(ctx, c.String(hostIDFlagName), c.String(hostSecretFlagName))
+			opts, err := comm.GetHostProvisioningOptions(ctx, c.String(hostIDFlagName), c.String(hostSecretFlagName))
 			if err != nil {
 				return errors.Wrap(err, "failed to get host provisioning script")
 			}
@@ -69,14 +68,13 @@ func hostProvision() cli.Command {
 			workingDir := c.String(workingDirFlagName)
 			scriptPath, err := makeHostProvisioningScriptFile(workingDir, opts.Content)
 			if err != nil {
-				return errors.Wrap(err, "write host provisioning script to file")
+				return errors.Wrap(err, "writing host provisioning script file")
 			}
 			defer func() {
 				grip.Error(errors.Wrap(os.RemoveAll(scriptPath), "removing host provisioning file"))
 			}()
 
-			cmd := hostProvisioningCommand(c.String(shellPathFlagName), scriptPath)
-			if err := runHostProvisioningCommand(ctx, cmd.Directory(workingDir)); err != nil {
+			if err := runHostProvisioningScript(ctx, c.String(shellPathFlagName), scriptPath, workingDir); err != nil {
 				return errors.Wrap(err, "running host provisioning script")
 			}
 
@@ -85,6 +83,11 @@ func hostProvision() cli.Command {
 	}
 }
 
+// makeHostProvisioningScriptFile creates the working directory with the host
+// provisioning script in it. Returns the
+// Note: we have to write the host provisioning script to a file instead of
+// running it directly like with 'sh -c "<script>"' because the script will exit
+// before it finishes executing on Windows.
 func makeHostProvisioningScriptFile(workingDir string, content string) (string, error) {
 	if err := os.MkdirAll(workingDir, 0755); err != nil {
 		return "", errors.Wrap(err, "creating working directory")
@@ -98,17 +101,13 @@ func makeHostProvisioningScriptFile(workingDir string, content string) (string, 
 	// slashes ('/') instead as the path separator.
 	scriptPath = util.ConsistentFilepath(scriptPath)
 	if err = ioutil.WriteFile(scriptPath, []byte(content), 0700); err != nil {
-		return "", errors.Wrapf(err, "writing script to file '%s'", scriptPath)
+		return "", errors.Wrapf(err, "writing script file '%s'", scriptPath)
 	}
 	return scriptPath, nil
 }
 
-func hostProvisioningCommand(shellPath, scriptPath string) *jasper.Command {
-	return jasper.NewCommand().AppendArgs(shellPath, "-l", scriptPath)
-}
-
-func runHostProvisioningCommand(ctx context.Context, cmd *jasper.Command) error {
-	cmd.SetOutputWriter(utility.NopWriteCloser(os.Stdout)).SetErrorWriter(utility.NopWriteCloser(os.Stderr))
+func runHostProvisioningScript(ctx context.Context, shellPath, scriptPath, workingDir string) error {
+	cmd := jasper.NewCommand().AppendArgs(shellPath, "-l", scriptPath).Directory(workingDir)
 	if err := cmd.Run(ctx); err != nil {
 		return errors.WithStack(err)
 	}

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -86,7 +86,7 @@ func hostProvision() cli.Command {
 }
 
 // makeHostProvisioningScriptFile creates the working directory with the host
-// provisioning script in it. Returns the
+// provisioning script in it. Returns the absolute path to the script.
 // Note: we have to write the host provisioning script to a file instead of
 // running it directly like with 'sh -c "<script>"' because the script will exit
 // before it finishes executing on Windows.

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -122,6 +122,6 @@ type Communicator interface {
 	// Evergreen binary for a given distro.
 	GetClientURLs(ctx context.Context, distroID string) ([]string, error)
 
-	// GetHostProvisioningScript gets the script options to provision a host.
-	GetHostProvisioningScript(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningScriptOptions, error)
+	// GetHostProvisioningOptions gets the options to provision a host.
+	GetHostProvisioningOptions(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningOptions, error)
 }

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1537,10 +1537,10 @@ func (c *communicatorImpl) GetClientURLs(ctx context.Context, distroID string) (
 	return urls, nil
 }
 
-func (c *communicatorImpl) GetHostProvisioningScript(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningScriptOptions, error) {
+func (c *communicatorImpl) GetHostProvisioningOptions(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningOptions, error) {
 	info := requestInfo{
 		method: http.MethodGet,
-		path:   fmt.Sprintf("/hosts/%s/provisioning_script", hostID),
+		path:   fmt.Sprintf("/hosts/%s/provisioning_options", hostID),
 	}
 	r, err := c.createRequest(info, nil)
 	if err != nil {
@@ -1556,7 +1556,7 @@ func (c *communicatorImpl) GetHostProvisioningScript(ctx context.Context, hostID
 	if resp.StatusCode != http.StatusOK {
 		return nil, respErrorf(resp, "received error response")
 	}
-	var opts restmodel.APIHostProvisioningScriptOptions
+	var opts restmodel.APIHostProvisioningOptions
 	if err = utility.ReadJSON(resp.Body, &opts); err != nil {
 		return nil, errors.Wrap(err, "reading response")
 	}

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -337,8 +337,8 @@ func (c *Mock) GetClientURLs(context.Context, string) ([]string, error) {
 	return []string{"https://example.com"}, nil
 }
 
-func (c *Mock) GetHostProvisioningScript(context.Context, string, string) (*restmodel.APIHostProvisioningScriptOptions, error) {
-	return &restmodel.APIHostProvisioningScriptOptions{
+func (c *Mock) GetHostProvisioningOptions(context.Context, string, string) (*restmodel.APIHostProvisioningOptions, error) {
+	return &restmodel.APIHostProvisioningOptions{
 		Directive: string(userdata.ShellScript) + "/bin/bash",
 		Content:   "echo hello world",
 	}, nil

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -189,7 +189,7 @@ func (hc *DBHostConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error
 	return data, nil
 }
 
-func (hc *DBHostConnector) GenerateHostProvisioningScript(ctx context.Context, hostID string) (*userdata.Options, error) {
+func (hc *DBHostConnector) GenerateHostProvisioningOptions(ctx context.Context, hostID string) (*userdata.Options, error) {
 	if hostID == "" {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -558,7 +558,7 @@ func findHostByIdWithOwner(c Connector, hostID string, user gimlet.User) (*host.
 	return host, nil
 }
 
-func (hc *MockHostConnector) GenerateHostProvisioningScript(ctx context.Context, hostID string) (*userdata.Options, error) {
+func (hc *MockHostConnector) GenerateHostProvisioningOptions(ctx context.Context, hostID string) (*userdata.Options, error) {
 	h, err := hc.FindHostById(hostID)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding host by ID")

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -403,11 +403,11 @@ func (s *HostConnectorSuite) TestCheckHostSecret() {
 	s.Equal(http.StatusOK, code)
 }
 
-func (s *HostConnectorSuite) TestGenerateHostProvisioningScriptSucceeds() {
+func (s *HostConnectorSuite) TestGenerateHostProvisioningOptionsSucceeds() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s.withNewEnvironment(ctx, func() {
-		opts, err := s.conn.GenerateHostProvisioningScript(ctx, "host1")
+		opts, err := s.conn.GenerateHostProvisioningOptions(ctx, "host1")
 		s.Require().NoError(err)
 		s.NotZero(opts.Content)
 		s.NotZero(opts.Directive)
@@ -415,11 +415,11 @@ func (s *HostConnectorSuite) TestGenerateHostProvisioningScriptSucceeds() {
 
 }
 
-func (s *HostConnectorSuite) TestGenerateHostProvisioningScriptFailsWithInvalidHostID() {
+func (s *HostConnectorSuite) TestGenerateHostProvisioningOptionsFailsWithInvalidHostID() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s.withNewEnvironment(ctx, func() {
-		opts, err := s.conn.GenerateHostProvisioningScript(ctx, "foo")
+		opts, err := s.conn.GenerateHostProvisioningOptions(ctx, "foo")
 		s.Error(err)
 		s.Zero(opts)
 	})

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -165,9 +165,9 @@ type Connector interface {
 	// Find a host by ID and queries for full running task
 	GetHostByIdWithTask(hostID string) (*host.Host, error)
 
-	// GenerateHostProvisioningScript generates and returns the script to
+	// GenerateHostProvisioningOptions generates and returns the options to
 	// provision the host given by host ID.
-	GenerateHostProvisioningScript(ctx context.Context, hostID string) (*userdata.Options, error)
+	GenerateHostProvisioningOptions(ctx context.Context, hostID string) (*userdata.Options, error)
 
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
 	NewIntentHost(context.Context, *restModel.HostRequestOptions, *user.DBUser, *evergreen.Settings) (*host.Host, error)

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -311,9 +311,9 @@ type APIOffboardUserResults struct {
 	TerminatedVolumes []string `json:"terminated_volumes"`
 }
 
-// APIHostProvisioningScriptOptions represents script to provision a host that
+// APIHostProvisioningOptions represents script to provision a host that
 // is meant to be executed in a particular environment type.
-type APIHostProvisioningScriptOptions struct {
+type APIHostProvisioningOptions struct {
 	Directive string `json:"directive"`
 	Content   string `json:"content"`
 }
@@ -321,7 +321,7 @@ type APIHostProvisioningScriptOptions struct {
 // BuildFromService converts from service level structs to an APIHost. It can
 // be called multiple times with different data types, a service layer host and
 // a service layer task, which are each loaded into the data structure.
-func (a *APIHostProvisioningScriptOptions) BuildFromService(i interface{}) error {
+func (a *APIHostProvisioningOptions) BuildFromService(i interface{}) error {
 	switch opts := i.(type) {
 	case *userdata.Options:
 		a.Directive = string(opts.Directive)

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -548,26 +548,26 @@ func (h *hostFilterGetHandler) Run(ctx context.Context) gimlet.Responder {
 	return resp
 }
 
-// GET /hosts/{host_id}/provisioning_script
+// GET /hosts/{host_id}/provisioning_options
 
-type hostProvisioningScriptGetHandler struct {
+type hostProvisioningOptionsGetHandler struct {
 	sc     data.Connector
 	hostID string
 }
 
-func makeHostProvisioningScriptGetHandler(sc data.Connector) gimlet.RouteHandler {
-	return &hostProvisioningScriptGetHandler{
+func makeHostProvisioningOptionsGetHandler(sc data.Connector) gimlet.RouteHandler {
+	return &hostProvisioningOptionsGetHandler{
 		sc: sc,
 	}
 }
 
-func (rh *hostProvisioningScriptGetHandler) Factory() gimlet.RouteHandler {
-	return &hostProvisioningScriptGetHandler{
+func (rh *hostProvisioningOptionsGetHandler) Factory() gimlet.RouteHandler {
+	return &hostProvisioningOptionsGetHandler{
 		sc: rh.sc,
 	}
 }
 
-func (rh *hostProvisioningScriptGetHandler) Parse(ctx context.Context, r *http.Request) error {
+func (rh *hostProvisioningOptionsGetHandler) Parse(ctx context.Context, r *http.Request) error {
 	hostID := gimlet.GetVars(r)["host_id"]
 	if hostID == "" {
 		return errors.New("missing host ID")
@@ -576,12 +576,12 @@ func (rh *hostProvisioningScriptGetHandler) Parse(ctx context.Context, r *http.R
 	return nil
 }
 
-func (rh *hostProvisioningScriptGetHandler) Run(ctx context.Context) gimlet.Responder {
-	opts, err := rh.sc.GenerateHostProvisioningScript(ctx, rh.hostID)
+func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Responder {
+	opts, err := rh.sc.GenerateHostProvisioningOptions(ctx, rh.hostID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
-	apiOpts := model.APIHostProvisioningScriptOptions{}
+	apiOpts := model.APIHostProvisioningOptions{}
 	if err := apiOpts.BuildFromService(opts); err != nil {
 		gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -979,7 +979,7 @@ func TestHostFilterGetHandler(t *testing.T) {
 	assert.Equal(t, "h2", model.FromStringPtr(hosts[0].(*model.APIHost).Id))
 }
 
-func TestHostProvisioningScriptGetHandler(t *testing.T) {
+func TestHostProvisioningOptionsGetHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	require.NoError(t, db.Clear(host.Collection))
@@ -996,26 +996,26 @@ func TestHostProvisioningScriptGetHandler(t *testing.T) {
 	require.NoError(t, h.Insert())
 
 	t.Run("SucceedsWithValidHostID", func(t *testing.T) {
-		rh := hostProvisioningScriptGetHandler{
+		rh := hostProvisioningOptionsGetHandler{
 			sc:     &data.DBConnector{},
 			hostID: h.Id,
 		}
 		resp := rh.Run(ctx)
 		require.Equal(t, http.StatusOK, resp.Status())
-		opts, ok := resp.Data().(model.APIHostProvisioningScriptOptions)
+		opts, ok := resp.Data().(model.APIHostProvisioningOptions)
 		require.True(t, ok)
 		assert.NotEmpty(t, opts.Directive)
 		assert.NotEmpty(t, opts.Content)
 	})
 	t.Run("FailsWithoutHostID", func(t *testing.T) {
-		rh := hostProvisioningScriptGetHandler{
+		rh := hostProvisioningOptionsGetHandler{
 			sc: &data.DBConnector{},
 		}
 		resp := rh.Run(ctx)
 		assert.NotEqual(t, http.StatusOK, resp.Status())
 	})
 	t.Run("FailsWithInvalidHostID", func(t *testing.T) {
-		rh := hostProvisioningScriptGetHandler{
+		rh := hostProvisioningOptionsGetHandler{
 			sc:     &data.DBConnector{},
 			hostID: "foo",
 		}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -119,7 +119,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/hosts/{task_id}/list").Version(2).Get().Wrap(checkTask).RouteHandler(makeHostListRouteManager(sc))
 	app.AddRoute("/hosts/{host_id}/attach").Version(2).Post().Wrap(checkUser).RouteHandler(makeAttachVolume(sc, env))
 	app.AddRoute("/hosts/{host_id}/detach").Version(2).Post().Wrap(checkUser).RouteHandler(makeDetachVolume(sc, env))
-	app.AddRoute("/hosts/{host_id}/provisioning_script").Version(2).Get().Wrap(checkHost).RouteHandler(makeHostProvisioningScriptGetHandler(sc))
+	app.AddRoute("/hosts/{host_id}/provisioning_options").Version(2).Get().Wrap(checkHost).RouteHandler(makeHostProvisioningOptionsGetHandler(sc))
 	app.AddRoute("/volumes").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetVolumes(sc))
 	app.AddRoute("/volumes").Version(2).Post().Wrap(checkUser).RouteHandler(makeCreateVolume(sc, env))
 	app.AddRoute("/volumes/{volume_id}").Version(2).Wrap(checkUser).Delete().RouteHandler(makeDeleteVolume(sc, env))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13455

It appears that when user data runs a PowerShell script on Windows, it hangs after a partial execution of the host provisioning script if it receives too much output from Cygwin's shell. This may or may not be due to Unix line endings not flushing the buffered output on Windows, but I can't find any docs proving that this is the case.

Instead of writing the Jasper credentials to a file (a symptom of the problem), instead, I removed `set -o verbose` from the Windows distro setup script and from the remainder of the host provisioning script.

# Changes
* Remove verbose output from Windows user data.
* Rename a few things in the host provisioning REST route.