### PR TITLE
EVG-13428: prefer updating CLIs from S3 URL

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-11-23"
+	ClientVersion = "2020-12-01"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-11-30-b"

--- a/config_api.go
+++ b/config_api.go
@@ -15,8 +15,9 @@ type ClientBinary struct {
 }
 
 type ClientConfig struct {
-	ClientBinaries []ClientBinary `yaml:"client_binaries" json:"ClientBinaries"`
-	LatestRevision string         `yaml:"latest_revision" json:"LatestRevision"`
+	ClientBinaries   []ClientBinary `yaml:"client_binaries" json:"client_binaries"`
+	S3ClientBinaries []ClientBinary `yaml:"s3_client_binaries" json:"s3_client_binaries"`
+	LatestRevision   string         `yaml:"latest_revision" json:"latest_revision"`
 }
 
 // APIConfig holds relevant log and listener settings for the API server.

--- a/operations/update.go
+++ b/operations/update.go
@@ -282,6 +282,9 @@ func checkUpdate(client client.Communicator, silent bool, force bool) (updateSta
 
 // Searches a ClientConfig for a ClientBinary with a non-empty URL, whose architecture and OS
 // match that of the current system.
+// kim: TODO: we're going to return multiple ClientBinary objects which map to
+// the same GOOS/GOARCH (one for S3, one for Evergreen app server). The user
+// should attempt to download from both of them.
 func findClientUpdate(clients evergreen.ClientConfig) *evergreen.ClientBinary {
 	for _, c := range clients.ClientBinaries {
 		if c.Arch == runtime.GOARCH && c.OS == runtime.GOOS && len(c.URL) > 0 {

--- a/operations/update.go
+++ b/operations/update.go
@@ -61,12 +61,11 @@ func Update() cli.Command {
 			if err != nil {
 				return err
 			}
-			if !update.needsUpdate || update.binary == nil {
+			if !update.needsUpdate || len(update.binaries) == 0 {
 				return nil
 			}
 
-			grip.Infoln("Fetching update from", update.binary.URL)
-			updatedBin, err := prepareUpdate(update.binary.URL, update.newVersion)
+			updatedBin, err := tryAllPrepareUpdate(update)
 			if err != nil {
 				return err
 			}
@@ -145,6 +144,7 @@ func Update() cli.Command {
 		},
 	}
 }
+
 func copyFile(dst, src string) error {
 	s, err := os.Open(src)
 	if err != nil {
@@ -166,6 +166,24 @@ func copyFile(dst, src string) error {
 	return d.Close()
 }
 
+// tryAllPrepareUpdate tries to prepare the binary update with any of the
+// possible client downloads. It returns the first one that succeeds, or an
+// error if none succeed.
+func tryAllPrepareUpdate(update updateStatus) (string, error) {
+	var err error
+	for _, binary := range update.binaries {
+		grip.Infoln("Fetching update from", binary.URL)
+		var updatedBin string
+		updatedBin, err = prepareUpdate(binary.URL, update.newVersion)
+		if err != nil {
+			grip.Error(err)
+			continue
+		}
+		return updatedBin, nil
+	}
+	return "", err
+}
+
 // prepareUpdate fetches the update at the given URL, writes it to a temporary file, and returns
 // the path to the temporary file.
 func prepareUpdate(url, newVersion string) (string, error) {
@@ -178,6 +196,10 @@ func prepareUpdate(url, newVersion string) (string, error) {
 	if err != nil {
 		grip.Error(tempFile.Close())
 		return "", err
+	}
+	if response.StatusCode != http.StatusOK {
+		grip.Error(tempFile.Close())
+		return "", errors.Errorf("received status code %s", response.Status)
 	}
 
 	if response == nil {
@@ -237,7 +259,7 @@ func prepareUpdate(url, newVersion string) (string, error) {
 }
 
 type updateStatus struct {
-	binary      *evergreen.ClientBinary
+	binaries    []evergreen.ClientBinary
 	needsUpdate bool
 	newVersion  string
 }
@@ -250,7 +272,11 @@ func checkUpdate(client client.Communicator, silent bool, force bool) (updateSta
 		"message": "Failed checking for updates",
 	}))
 	if err != nil {
-		return updateStatus{nil, false, ""}, err
+		return updateStatus{
+			binaries:    nil,
+			needsUpdate: false,
+			newVersion:  "",
+		}, err
 	}
 
 	// No update needed
@@ -259,17 +285,25 @@ func checkUpdate(client client.Communicator, silent bool, force bool) (updateSta
 			"message":  "Binary is already up to date - not updating.",
 			"revision": evergreen.ClientVersion,
 		})
-		return updateStatus{nil, false, clients.LatestRevision}, nil
+		return updateStatus{
+			binaries:    nil,
+			needsUpdate: false,
+			newVersion:  clients.LatestRevision,
+		}, nil
 	}
 
-	binarySource := findClientUpdate(*clients)
-	if binarySource == nil {
+	binarySources := findClientUpdates(*clients)
+	if len(binarySources) == 0 {
 		// Client is out of date but no update available
 		grip.NoticeWhen(!silent, message.WrapError(err, message.Fields{
 			"message":  "Client is out of date but update is unavailable.",
 			"revision": evergreen.ClientVersion,
 		}))
-		return updateStatus{nil, true, clients.LatestRevision}, nil
+		return updateStatus{
+			binaries:    nil,
+			needsUpdate: true,
+			newVersion:  clients.LatestRevision,
+		}, nil
 	}
 
 	grip.NoticeWhen(!silent, message.WrapError(err, message.Fields{
@@ -277,19 +311,21 @@ func checkUpdate(client client.Communicator, silent bool, force bool) (updateSta
 		"revision":     evergreen.ClientVersion,
 		"new_revision": clients.LatestRevision,
 	}))
-	return updateStatus{binarySource, true, clients.LatestRevision}, nil
+	return updateStatus{
+		binaries:    binarySources,
+		needsUpdate: true,
+		newVersion:  clients.LatestRevision,
+	}, nil
 }
 
-// Searches a ClientConfig for a ClientBinary with a non-empty URL, whose architecture and OS
-// match that of the current system.
-// kim: TODO: we're going to return multiple ClientBinary objects which map to
-// the same GOOS/GOARCH (one for S3, one for Evergreen app server). The user
-// should attempt to download from both of them.
-func findClientUpdate(clients evergreen.ClientConfig) *evergreen.ClientBinary {
-	for _, c := range clients.ClientBinaries {
+// findClientUpdates searches a ClientConfig for all ClientBinaries with
+// non-empty URLs, whose architecture and OS match that of the current system.
+func findClientUpdates(clients evergreen.ClientConfig) []evergreen.ClientBinary {
+	var binaries []evergreen.ClientBinary
+	for _, c := range append(clients.S3ClientBinaries, clients.ClientBinaries...) {
 		if c.Arch == runtime.GOARCH && c.OS == runtime.GOOS && len(c.URL) > 0 {
-			return &c
+			binaries = append(binaries, c)
 		}
 	}
-	return nil
+	return binaries
 }

--- a/rest/data/cli_update.go
+++ b/rest/data/cli_update.go
@@ -49,7 +49,7 @@ func (c *MockCLIUpdateConnector) GetCLIUpdate() (*model.APICLIUpdate, error) {
 	update := &model.APICLIUpdate{
 		ClientConfig: model.APIClientConfig{
 			ClientBinaries: []model.APIClientBinary{
-				model.APIClientBinary{
+				{
 					Arch: model.ToStringPtr("amd64"),
 					OS:   model.ToStringPtr("darwin"),
 					URL:  model.ToStringPtr("localhost/clients/darwin_amd64/evergreen"),

--- a/rest/route/cli_version.go
+++ b/rest/route/cli_version.go
@@ -28,9 +28,6 @@ func (gh *cliVersion) Parse(ctx context.Context, r *http.Request) error {
 	return nil
 }
 
-// kim: TODO: have to update this to handle multiple URLs (first the S3 URL,
-// which could fail if we deploy a custom build and the deployer fails to turn
-// off S3 binary downloads) instead of just one.
 func (gh *cliVersion) Run(ctx context.Context) gimlet.Responder {
 	version, err := gh.sc.GetCLIUpdate()
 	if err != nil || version == nil {

--- a/rest/route/cli_version.go
+++ b/rest/route/cli_version.go
@@ -28,6 +28,9 @@ func (gh *cliVersion) Parse(ctx context.Context, r *http.Request) error {
 	return nil
 }
 
+// kim: TODO: have to update this to handle multiple URLs (first the S3 URL,
+// which could fail if we deploy a custom build and the deployer fails to turn
+// off S3 binary downloads) instead of just one.
 func (gh *cliVersion) Run(ctx context.Context) gimlet.Responder {
 	version, err := gh.sc.GetCLIUpdate()
 	if err != nil || version == nil {

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -152,7 +152,7 @@ Admin Settings
 												</td>
 											</tr>
 											<tr>
-												<td>Download host binaries from S3</td>
+												<td>Download Evergreen clients from S3</td>
 												<td colspan="2">
 													<md-radio-group
 														data-ng-model="Settings.service_flags.s3_binary_downloads_disabled"


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13428

Try downloading the binary from S3 and fall back to downloading from the app server if it fails. The self-updater logic won't take effect until people update their binaries after this commit, so this CLI update will still be downloaded from the app server.