### PR TITLE
EVG-13428: do not return S3 URLs if S3 binary downloads are disabled

### DIFF
--- a/rest/data/cli_update.go
+++ b/rest/data/cli_update.go
@@ -21,13 +21,6 @@ func (c *CLIUpdateConnector) GetCLIUpdate() (*model.APICLIUpdate, error) {
 		}
 	}
 
-	if err := update.BuildFromService(*config); err != nil {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    err.Error(),
-		}
-	}
-
 	flags, err := evergreen.GetServiceFlags()
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
@@ -35,9 +28,19 @@ func (c *CLIUpdateConnector) GetCLIUpdate() (*model.APICLIUpdate, error) {
 			Message:    err.Error(),
 		}
 	}
-	if flags != nil {
-		update.IgnoreUpdate = flags.CLIUpdatesDisabled
+	if flags.S3BinaryDownloadsDisabled {
+		config.S3ClientBinaries = nil
 	}
+
+	if err := update.BuildFromService(*config); err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    err.Error(),
+		}
+	}
+
+	update.IgnoreUpdate = flags.CLIUpdatesDisabled
+
 	return update, nil
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13428

Small optimization to ensure that if the feature flag is disabled, it won't return the S3 URLs to the client.