### PR TITLE
EVG-13160 add mutation to edit annotation note

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -281,6 +281,7 @@ type ComplexityRoot struct {
 		ClearMySubscriptions      func(childComplexity int) int
 		CreatePublicKey           func(childComplexity int, publicKeyInput PublicKeyInput) int
 		DetachVolumeFromHost      func(childComplexity int, volumeID string) int
+		EditAnnotationNote        func(childComplexity int, taskID string, execution int, originalMessage string, newMessage string) int
 		EditSpawnHost             func(childComplexity int, spawnHost *EditSpawnHostInput) int
 		EnqueuePatch              func(childComplexity int, patchID string) int
 		MoveAnnotationIssue       func(childComplexity int, annotationID string, apiIssue model.APIIssueLink, isIssue bool) int
@@ -725,6 +726,7 @@ type MutationResolver interface {
 	SetTaskPriority(ctx context.Context, taskID string, priority int) (*model.APITask, error)
 	RestartTask(ctx context.Context, taskID string) (*model.APITask, error)
 	SaveSubscription(ctx context.Context, subscription model.APISubscription) (bool, error)
+	EditAnnotationNote(ctx context.Context, taskID string, execution int, originalMessage string, newMessage string) (bool, error)
 	MoveAnnotationIssue(ctx context.Context, annotationID string, apiIssue model.APIIssueLink, isIssue bool) (bool, error)
 	AddAnnotationIssue(ctx context.Context, taskID string, execution int, apiIssue model.APIIssueLink, isIssue bool) (bool, error)
 	RemoveItemFromCommitQueue(ctx context.Context, commitQueueID string, issue string) (*string, error)
@@ -1838,6 +1840,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DetachVolumeFromHost(childComplexity, args["volumeId"].(string)), true
+
+	case "Mutation.editAnnotationNote":
+		if e.complexity.Mutation.EditAnnotationNote == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_editAnnotationNote_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.EditAnnotationNote(childComplexity, args["taskId"].(string), args["execution"].(int), args["originalMessage"].(string), args["newMessage"].(string)), true
 
 	case "Mutation.editSpawnHost":
 		if e.complexity.Mutation.EditSpawnHost == nil {
@@ -4250,6 +4264,12 @@ type Mutation {
   setTaskPriority(taskId: String!, priority: Int!): Task!
   restartTask(taskId: String!): Task!
   saveSubscription(subscription: SubscriptionInput!): Boolean!
+  editAnnotationNote(
+    taskId: String!
+    execution: Int!
+    originalMessage: String!
+    newMessage: String!
+  ): Boolean!
   moveAnnotationIssue(
     annotationId: String!
     apiIssue: AnnotationIssue!
@@ -5172,6 +5192,44 @@ func (ec *executionContext) field_Mutation_detachVolumeFromHost_args(ctx context
 		}
 	}
 	args["volumeId"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_editAnnotationNote_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["taskId"]; ok {
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["taskId"] = arg0
+	var arg1 int
+	if tmp, ok := rawArgs["execution"]; ok {
+		arg1, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["execution"] = arg1
+	var arg2 string
+	if tmp, ok := rawArgs["originalMessage"]; ok {
+		arg2, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["originalMessage"] = arg2
+	var arg3 string
+	if tmp, ok := rawArgs["newMessage"]; ok {
+		arg3, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["newMessage"] = arg3
 	return args, nil
 }
 
@@ -10940,6 +10998,47 @@ func (ec *executionContext) _Mutation_saveSubscription(ctx context.Context, fiel
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return ec.resolvers.Mutation().SaveSubscription(rctx, args["subscription"].(model.APISubscription))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_editAnnotationNote(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_editAnnotationNote_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().EditAnnotationNote(rctx, args["taskId"].(string), args["execution"].(int), args["originalMessage"].(string), args["newMessage"].(string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -23655,6 +23754,11 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			}
 		case "saveSubscription":
 			out.Values[i] = ec._Mutation_saveSubscription(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "editAnnotationNote":
+			out.Values[i] = ec._Mutation_editAnnotationNote(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1872,6 +1872,15 @@ func (r *mutationResolver) RestartTask(ctx context.Context, taskID string) (*res
 	return apiTask, err
 }
 
+// EditAnnotationNote updates the note for the annotation, assuming it hasn't been updated in the meantime.
+func (r *mutationResolver) EditAnnotationNote(ctx context.Context, taskID string, execution int, originalMessage, newMessage string) (bool, error) {
+	usr := MustHaveUser(ctx)
+	if err := annotations.UpdateAnnotationNote(taskID, execution, originalMessage, newMessage, usr.Username()); err != nil {
+		return false, InternalServerError.Send(ctx, fmt.Sprintf("couldn't update note: %s", err.Error()))
+	}
+	return true, nil
+}
+
 // MoveAnnotationIssue moves an issue for the annotation. If isIssue is set, it removes the issue from Issues and adds it
 // to Suspected Issues, otherwise vice versa.
 func (r *mutationResolver) MoveAnnotationIssue(ctx context.Context, annotationID string, apiIssue restModel.APIIssueLink, isIssue bool) (bool, error) {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -86,6 +86,12 @@ type Mutation {
   setTaskPriority(taskId: String!, priority: Int!): Task!
   restartTask(taskId: String!): Task!
   saveSubscription(subscription: SubscriptionInput!): Boolean!
+  editAnnotationNote(
+    taskId: String!
+    execution: Int!
+    originalMessage: String!
+    newMessage: String!
+  ): Boolean!
   moveAnnotationIssue(
     annotationId: String!
     apiIssue: AnnotationIssue!

--- a/graphql/tests/annotationIssue/data.json
+++ b/graphql/tests/annotationIssue/data.json
@@ -3,7 +3,7 @@
     {
       "_id": "my-annotation",
       "task_id": "task-1234",
-      "execution": 0,
+      "task_execution": 0,
       "issues": [
         {
           "url": "https://link.com",
@@ -21,7 +21,24 @@
             "author": "annie.black"
           }
         }
-      ]
+      ],
+      "note": {
+        "message": "my message",
+        "source": {
+          "author": "annie.black"
+        }
+      }
+    },
+    {
+      "_id":  "my-other-annotation",
+      "task_id": "task-5678",
+      "task_execution": 0,
+      "note": {
+        "message": "my other message",
+        "source": {
+          "author": "annie.black"
+        }
+      }
     }
   ]
 }

--- a/graphql/tests/annotationIssue/queries/editNote.graphql
+++ b/graphql/tests/annotationIssue/queries/editNote.graphql
@@ -1,0 +1,8 @@
+mutation {
+    editAnnotationNote(
+        taskId: "task-1234"
+        execution: 0
+        originalMessage: "my message"
+        newMessage: "my new message"
+    )
+}

--- a/graphql/tests/annotationIssue/queries/editNoteInvalid.graphql
+++ b/graphql/tests/annotationIssue/queries/editNoteInvalid.graphql
@@ -1,0 +1,8 @@
+mutation {
+    editAnnotationNote(
+        taskId: "task-5678"
+        execution: 0
+        originalMessage: "something outdated"
+        newMessage: "something new"
+    )
+}

--- a/graphql/tests/annotationIssue/results.json
+++ b/graphql/tests/annotationIssue/results.json
@@ -25,7 +25,7 @@
       "result": {
         "errors": [
           {
-            "message": "couldn't update note: note has already been updated",
+            "message": "couldn't update note: note is out of sync, please try again",
             "path": [
               "editAnnotationNote"
             ],

--- a/graphql/tests/annotationIssue/results.json
+++ b/graphql/tests/annotationIssue/results.json
@@ -15,6 +15,27 @@
     {
       "query_file": "addSuspectedIssue.graphql",
       "result": { "data": { "addAnnotationIssue": true } }
+    },
+    {
+      "query_file": "editNote.graphql",
+      "result": { "data": { "editAnnotationNote":  true } }
+    },
+    {
+      "query_file": "editNoteInvalid.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "couldn't update note: note has already been updated",
+            "path": [
+              "editAnnotationNote"
+            ],
+            "extensions": {
+              "code": "INTERNAL_SERVER_ERROR"
+            }
+          }
+        ],
+        "data": null
+      }
     }
   ]
 }

--- a/model/annotations/db.go
+++ b/model/annotations/db.go
@@ -18,7 +18,6 @@ var (
 	IssuesKey          = bsonutil.MustHaveTag(TaskAnnotation{}, "Issues")
 	SuspectedIssuesKey = bsonutil.MustHaveTag(TaskAnnotation{}, "SuspectedIssues")
 
-	NoteMessageKey    = bsonutil.MustHaveTag(Note{}, "Message")
 	IssueLinkIssueKey = bsonutil.MustHaveTag(IssueLink{}, "IssueKey")
 )
 

--- a/model/annotations/db.go
+++ b/model/annotations/db.go
@@ -18,6 +18,7 @@ var (
 	IssuesKey          = bsonutil.MustHaveTag(TaskAnnotation{}, "Issues")
 	SuspectedIssuesKey = bsonutil.MustHaveTag(TaskAnnotation{}, "SuspectedIssues")
 
+	NoteMessageKey    = bsonutil.MustHaveTag(Note{}, "Message")
 	IssueLinkIssueKey = bsonutil.MustHaveTag(IssueLink{}, "IssueKey")
 )
 

--- a/model/annotations/task_annotations.go
+++ b/model/annotations/task_annotations.go
@@ -109,7 +109,7 @@ func UpdateAnnotationNote(taskId string, execution int, originalMessage, newMess
 	}
 
 	if annotation != nil && annotation.Note != nil && annotation.Note.Message != originalMessage {
-		return errors.New("note has already been updated")
+		return errors.New("note is out of sync, please try again")
 	}
 	_, err = db.Upsert(
 		Collection,

--- a/model/annotations/task_annotations.go
+++ b/model/annotations/task_annotations.go
@@ -97,6 +97,30 @@ func MoveSuspectedIssueToIssue(annotationId string, issue IssueLink, username st
 	)
 }
 
+func UpdateAnnotationNote(taskId string, execution int, originalMessage, newMessage, username string) error {
+	note := Note{
+		Message: newMessage,
+		Source:  &Source{Requester: UIRequester, Author: username, Time: time.Now()},
+	}
+
+	annotation, err := FindOneByTaskIdAndExecution(taskId, execution)
+	if err != nil {
+		return errors.Wrapf(err, "error finding task annotation")
+	}
+
+	if annotation != nil && annotation.Note != nil && annotation.Note.Message != originalMessage {
+		return errors.New("note has already been updated")
+	}
+	_, err = db.Upsert(
+		Collection,
+		ByTaskIdAndExecution(taskId, execution),
+		bson.M{
+			"$set": bson.M{NoteKey: note},
+		},
+	)
+	return errors.Wrapf(err, "problem updating note for task '%s'", taskId)
+}
+
 func AddIssueToAnnotation(taskId string, execution int, issue IssueLink, username string) error {
 	issue.Source = &Source{
 		Author:    username,


### PR DESCRIPTION
I forgot that we'd be using Upsert for the annotation update, since we wouldn't know yet if the annotation existed, so to verify that the note hasn't been updated already we have to do a find query first. If we aren't concerned about users looking at very inconsistent data, then we can probably drop this extra query, but since this resolver doesn't do much it's not a performance issue or anything.