### PR TITLE
EVG-13229: Query Project Patches 

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -74,6 +74,9 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.UIProjectFields
   User:
     model: github.com/evergreen-ci/evergreen/rest/model.APIDBUser
+    fields:
+      patches:
+        resolver: true
   TaskEventLogEntry:
     model: github.com/evergreen-ci/evergreen/rest/model.TaskAPIEventLogEntry
   TaskEventLogData:

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -71,7 +71,7 @@ models:
   Duration:
     model: github.com/evergreen-ci/evergreen/rest/model.APIDuration
   Project:
-    model: github.com/evergreen-ci/evergreen/rest/model.UIProjectFields
+    model: github.com/evergreen-ci/evergreen/rest/model.APIProjectRef
   User:
     model: github.com/evergreen-ci/evergreen/rest/model.APIDBUser
     fields:

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -72,6 +72,9 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.APIDuration
   Project:
     model: github.com/evergreen-ci/evergreen/rest/model.APIProjectRef
+    fields:
+      patches:
+        resolver: true
   User:
     model: github.com/evergreen-ci/evergreen/rest/model.APIDBUser
     fields:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -4469,11 +4469,11 @@ input UseSpruceOptionsInput {
 }
 
 input PatchesInput {
-  limit: Int = 0
-  page: Int = 0
-  patchName: String = ""
-  statuses: [String!] = []
-  includeCommitQueue: Boolean = false
+  limit: Int! = 0
+  page: Int! = 0
+  patchName: String! = ""
+  statuses: [String!]! = []
+  includeCommitQueue: Boolean! = false
 }
 
 input SpawnHostInput {
@@ -22360,31 +22360,31 @@ func (ec *executionContext) unmarshalInputPatchesInput(ctx context.Context, obj 
 		switch k {
 		case "limit":
 			var err error
-			it.Limit, err = ec.unmarshalOInt2ᚖint(ctx, v)
+			it.Limit, err = ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
 		case "page":
 			var err error
-			it.Page, err = ec.unmarshalOInt2ᚖint(ctx, v)
+			it.Page, err = ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
 		case "patchName":
 			var err error
-			it.PatchName, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.PatchName, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
 		case "statuses":
 			var err error
-			it.Statuses, err = ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			it.Statuses, err = ec.unmarshalNString2ᚕstringᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
 		case "includeCommitQueue":
 			var err error
-			it.IncludeCommitQueue, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			it.IncludeCommitQueue, err = ec.unmarshalNBoolean2bool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -446,7 +446,7 @@ type ComplexityRoot struct {
 		Patch                   func(childComplexity int, id string) int
 		PatchBuildVariants      func(childComplexity int, patchID string) int
 		PatchTasks              func(childComplexity int, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) int
-		Project                 func(childComplexity int, id string) int
+		Project                 func(childComplexity int, projectID string) int
 		Projects                func(childComplexity int) int
 		SpruceConfig            func(childComplexity int) int
 		SubnetAvailabilityZones func(childComplexity int) int
@@ -777,7 +777,7 @@ type QueryResolver interface {
 	TaskAllExecutions(ctx context.Context, taskID string) ([]*model.APITask, error)
 	Patch(ctx context.Context, id string) (*model.APIPatch, error)
 	Projects(ctx context.Context) (*Projects, error)
-	Project(ctx context.Context, id string) (*model.APIProjectRef, error)
+	Project(ctx context.Context, projectID string) (*model.APIProjectRef, error)
 	PatchTasks(ctx context.Context, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) (*PatchTasks, error)
 	TaskTests(ctx context.Context, taskID string, execution *int, sortCategory *TestSortCategory, sortDirection *SortDirection, page *int, limit *int, testName *string, statuses []string) (*TaskTestResult, error)
 	TaskFiles(ctx context.Context, taskID string, execution *int) (*TaskFiles, error)
@@ -2836,7 +2836,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Project(childComplexity, args["id"].(string)), true
+		return e.complexity.Query.Project(childComplexity, args["projectId"].(string)), true
 
 	case "Query.projects":
 		if e.complexity.Query.Projects == nil {
@@ -4250,7 +4250,7 @@ var sources = []*ast.Source{
   taskAllExecutions(taskId: String!): [Task!]!
   patch(id: String!): Patch!
   projects: Projects!
-  project(id: String!): Project!
+  project(projectId: String!): Project!
   patchTasks(
     patchId: String!
     sortBy: TaskSortCategory = STATUS
@@ -6067,13 +6067,13 @@ func (ec *executionContext) field_Query_project_args(ctx context.Context, rawArg
 	var err error
 	args := map[string]interface{}{}
 	var arg0 string
-	if tmp, ok := rawArgs["id"]; ok {
+	if tmp, ok := rawArgs["projectId"]; ok {
 		arg0, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["id"] = arg0
+	args["projectId"] = arg0
 	return args, nil
 }
 
@@ -14402,7 +14402,7 @@ func (ec *executionContext) _Query_project(ctx context.Context, field graphql.Co
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Project(rctx, args["id"].(string))
+		return ec.resolvers.Query().Project(rctx, args["projectId"].(string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -718,8 +718,8 @@ type HostResolver interface {
 	Volumes(ctx context.Context, obj *model.APIHost) ([]*model.APIVolume, error)
 }
 type MutationResolver interface {
-	AddFavoriteProject(ctx context.Context, identifier string) (*model.UIProjectFields, error)
-	RemoveFavoriteProject(ctx context.Context, identifier string) (*model.UIProjectFields, error)
+	AddFavoriteProject(ctx context.Context, identifier string) (*model.APIProjectRef, error)
+	RemoveFavoriteProject(ctx context.Context, identifier string) (*model.APIProjectRef, error)
 	SchedulePatch(ctx context.Context, patchID string, configure PatchConfigure) (*model.APIPatch, error)
 	SchedulePatchTasks(ctx context.Context, patchID string) (*string, error)
 	UnschedulePatchTasks(ctx context.Context, patchID string, abort bool) (*string, error)
@@ -8188,9 +8188,9 @@ func (ec *executionContext) _GroupedProjects_projects(ctx context.Context, field
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.UIProjectFields)
+	res := resTmp.([]*model.APIProjectRef)
 	fc.Result = res
-	return ec.marshalNProject2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFieldsᚄ(ctx, field.Selections, res)
+	return ec.marshalNProject2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRefᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Host_id(ctx context.Context, field graphql.CollectedField, obj *model.APIHost) (ret graphql.Marshaler) {
@@ -10494,9 +10494,9 @@ func (ec *executionContext) _Mutation_addFavoriteProject(ctx context.Context, fi
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.UIProjectFields)
+	res := resTmp.(*model.APIProjectRef)
 	fc.Result = res
-	return ec.marshalNProject2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFields(ctx, field.Selections, res)
+	return ec.marshalNProject2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRef(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_removeFavoriteProject(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -10535,9 +10535,9 @@ func (ec *executionContext) _Mutation_removeFavoriteProject(ctx context.Context,
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.UIProjectFields)
+	res := resTmp.(*model.APIProjectRef)
 	fc.Result = res
-	return ec.marshalNProject2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFields(ctx, field.Selections, res)
+	return ec.marshalNProject2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRef(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_schedulePatch(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -13664,7 +13664,7 @@ func (ec *executionContext) _Patches_filteredPatchCount(ctx context.Context, fie
 	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Project_identifier(ctx context.Context, field graphql.CollectedField, obj *model.UIProjectFields) (ret graphql.Marshaler) {
+func (ec *executionContext) _Project_identifier(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -13693,12 +13693,12 @@ func (ec *executionContext) _Project_identifier(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Project_displayName(ctx context.Context, field graphql.CollectedField, obj *model.UIProjectFields) (ret graphql.Marshaler) {
+func (ec *executionContext) _Project_displayName(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -13727,12 +13727,12 @@ func (ec *executionContext) _Project_displayName(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Project_repo(ctx context.Context, field graphql.CollectedField, obj *model.UIProjectFields) (ret graphql.Marshaler) {
+func (ec *executionContext) _Project_repo(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -13761,12 +13761,12 @@ func (ec *executionContext) _Project_repo(ctx context.Context, field graphql.Col
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Project_owner(ctx context.Context, field graphql.CollectedField, obj *model.UIProjectFields) (ret graphql.Marshaler) {
+func (ec *executionContext) _Project_owner(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -13795,9 +13795,9 @@ func (ec *executionContext) _Project_owner(ctx context.Context, field graphql.Co
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ProjectBuildVariant_name(ctx context.Context, field graphql.CollectedField, obj *ProjectBuildVariant) (ret graphql.Marshaler) {
@@ -13931,9 +13931,9 @@ func (ec *executionContext) _Projects_favorites(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.UIProjectFields)
+	res := resTmp.([]*model.APIProjectRef)
 	fc.Result = res
-	return ec.marshalNProject2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFieldsᚄ(ctx, field.Selections, res)
+	return ec.marshalNProject2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRefᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Projects_otherProjects(ctx context.Context, field graphql.CollectedField, obj *Projects) (ret graphql.Marshaler) {
@@ -24545,7 +24545,7 @@ func (ec *executionContext) _Patches(ctx context.Context, sel ast.SelectionSet, 
 
 var projectImplementors = []string{"Project"}
 
-func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, obj *model.UIProjectFields) graphql.Marshaler {
+func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, obj *model.APIProjectRef) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, projectImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -27846,11 +27846,11 @@ func (ec *executionContext) unmarshalNPatchesInput2githubᚗcomᚋevergreenᚑci
 	return ec.unmarshalInputPatchesInput(ctx, v)
 }
 
-func (ec *executionContext) marshalNProject2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFields(ctx context.Context, sel ast.SelectionSet, v model.UIProjectFields) graphql.Marshaler {
+func (ec *executionContext) marshalNProject2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRef(ctx context.Context, sel ast.SelectionSet, v model.APIProjectRef) graphql.Marshaler {
 	return ec._Project(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNProject2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFieldsᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.UIProjectFields) graphql.Marshaler {
+func (ec *executionContext) marshalNProject2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRefᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.APIProjectRef) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -27874,7 +27874,7 @@ func (ec *executionContext) marshalNProject2ᚕᚖgithubᚗcomᚋevergreenᚑci�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNProject2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFields(ctx, sel, v[i])
+			ret[i] = ec.marshalNProject2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRef(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -27887,7 +27887,7 @@ func (ec *executionContext) marshalNProject2ᚕᚖgithubᚗcomᚋevergreenᚑci�
 	return ret
 }
 
-func (ec *executionContext) marshalNProject2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐUIProjectFields(ctx context.Context, sel ast.SelectionSet, v *model.UIProjectFields) graphql.Marshaler {
+func (ec *executionContext) marshalNProject2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRef(ctx context.Context, sel ast.SelectionSet, v *model.APIProjectRef) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "must not be null")

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -124,6 +124,19 @@ type PatchTime struct {
 	SubmittedAt string  `json:"submittedAt"`
 }
 
+type Patches struct {
+	Patches            []*model.APIPatch `json:"patches"`
+	FilteredPatchCount int               `json:"filteredPatchCount"`
+}
+
+type PatchesInput struct {
+	Limit              *int     `json:"limit"`
+	Page               *int     `json:"page"`
+	PatchName          *string  `json:"patchName"`
+	Statuses           []string `json:"statuses"`
+	IncludeCommitQueue *bool    `json:"includeCommitQueue"`
+}
+
 type ProjectBuildVariant struct {
 	Name        string   `json:"name"`
 	DisplayName string   `json:"displayName"`

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -130,11 +130,11 @@ type Patches struct {
 }
 
 type PatchesInput struct {
-	Limit              *int     `json:"limit"`
-	Page               *int     `json:"page"`
-	PatchName          *string  `json:"patchName"`
+	Limit              int      `json:"limit"`
+	Page               int      `json:"page"`
+	PatchName          string   `json:"patchName"`
 	Statuses           []string `json:"statuses"`
-	IncludeCommitQueue *bool    `json:"includeCommitQueue"`
+	IncludeCommitQueue bool     `json:"includeCommitQueue"`
 }
 
 type ProjectBuildVariant struct {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -63,8 +63,8 @@ type GroupedFiles struct {
 }
 
 type GroupedProjects struct {
-	Name     string                   `json:"name"`
-	Projects []*model.UIProjectFields `json:"projects"`
+	Name     string                 `json:"name"`
+	Projects []*model.APIProjectRef `json:"projects"`
 }
 
 type HostEvents struct {
@@ -144,8 +144,8 @@ type ProjectBuildVariant struct {
 }
 
 type Projects struct {
-	Favorites     []*model.UIProjectFields `json:"favorites"`
-	OtherProjects []*GroupedProjects       `json:"otherProjects"`
+	Favorites     []*model.APIProjectRef `json:"favorites"`
+	OtherProjects []*GroupedProjects     `json:"otherProjects"`
 }
 
 type PublicKeyInput struct {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -902,11 +902,11 @@ func (r *queryResolver) Project(ctx context.Context, id string) (*restModel.APIP
 }
 
 func (r *projectResolver) Patches(ctx context.Context, obj *restModel.APIProjectRef, patchesInput PatchesInput) (*Patches, error) {
-	patches, count, err := r.sc.FindPatchesByProjectPatchNameStatusesCommitQueue(*obj.Identifier, patchesInput.PatchName, patchesInput.Statuses, patchesInput.IncludeCommitQueue, patchesInput.Page, patchesInput.Limit)
-	patchPointers := []*restModel.APIPatch{}
+	patches, count, err := r.sc.FindPatchesByProjectPatchNameStatusesCommitQueue(*obj.Id, patchesInput.PatchName, patchesInput.Statuses, patchesInput.IncludeCommitQueue, patchesInput.Page, patchesInput.Limit)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}
+	patchPointers := []*restModel.APIPatch{}
 	for i := range patches {
 		patchPointers = append(patchPointers, &patches[i])
 	}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1011,9 +1011,8 @@ func (r *queryResolver) Projects(ctx context.Context) (*Projects, error) {
 	for _, p := range allProjs {
 		groupName := strings.Join([]string{p.Owner, p.Repo}, "/")
 		apiProjectRef := restModel.APIProjectRef{}
-		pErr := apiProjectRef.BuildFromService(p)
-		if pErr != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("error building APIProjectRef from service: %s", err.Error()))
+		if pErr := apiProjectRef.BuildFromService(p); pErr != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("error building APIProjectRef from service: %s", pErr.Error()))
 		}
 		// favorite projects are filtered out and appended to their own array
 		if utility.StringSliceContains(usr.FavoriteProjects, p.Identifier) {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -902,7 +902,7 @@ func (r *queryResolver) Project(ctx context.Context, id string) (*restModel.APIP
 }
 
 func (r *projectResolver) Patches(ctx context.Context, obj *restModel.APIProjectRef, patchesInput PatchesInput) (*Patches, error) {
-	patches, count, err := r.sc.FindPatchesByUserPatchNameStatusesCommitQueue(*obj.Identifier, patchesInput.PatchName, patchesInput.Statuses, patchesInput.IncludeCommitQueue, patchesInput.Page, patchesInput.Limit)
+	patches, count, err := r.sc.FindPatchesByProjectPatchNameStatusesCommitQueue(*obj.Identifier, patchesInput.PatchName, patchesInput.Statuses, patchesInput.IncludeCommitQueue, patchesInput.Page, patchesInput.Limit)
 	patchPointers := []*restModel.APIPatch{}
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1011,8 +1011,8 @@ func (r *queryResolver) Projects(ctx context.Context) (*Projects, error) {
 	for _, p := range allProjs {
 		groupName := strings.Join([]string{p.Owner, p.Repo}, "/")
 		apiProjectRef := restModel.APIProjectRef{}
-		if pErr := apiProjectRef.BuildFromService(p); pErr != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("error building APIProjectRef from service: %s", pErr.Error()))
+		if err = apiProjectRef.BuildFromService(p); err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("error building APIProjectRef from service: %s", err.Error()))
 		}
 		// favorite projects are filtered out and appended to their own array
 		if utility.StringSliceContains(usr.FavoriteProjects, p.Identifier) {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -902,7 +902,7 @@ func (r *queryResolver) Project(ctx context.Context, id string) (*restModel.APIP
 }
 
 func (r *projectResolver) Patches(ctx context.Context, obj *restModel.APIProjectRef, patchesInput PatchesInput) (*Patches, error) {
-	patches, count, err := r.sc.FindPatchesByUserPatchNameStatusesCommitQueue(*obj.Identifier, *patchesInput.PatchName, patchesInput.Statuses, *patchesInput.IncludeCommitQueue, *patchesInput.Page, *patchesInput.Limit)
+	patches, count, err := r.sc.FindPatchesByUserPatchNameStatusesCommitQueue(*obj.Identifier, patchesInput.PatchName, patchesInput.Statuses, patchesInput.IncludeCommitQueue, patchesInput.Page, patchesInput.Limit)
 	patchPointers := []*restModel.APIPatch{}
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
@@ -2147,7 +2147,7 @@ func (r *queryResolver) User(ctx context.Context, userIdParam *string) (*restMod
 }
 
 func (r *userResolver) Patches(ctx context.Context, obj *restModel.APIDBUser, patchesInput PatchesInput) (*Patches, error) {
-	patches, count, err := r.sc.FindPatchesByUserPatchNameStatusesCommitQueue(*obj.UserID, *patchesInput.PatchName, patchesInput.Statuses, *patchesInput.IncludeCommitQueue, *patchesInput.Page, *patchesInput.Limit)
+	patches, count, err := r.sc.FindPatchesByUserPatchNameStatusesCommitQueue(*obj.UserID, patchesInput.PatchName, patchesInput.Statuses, patchesInput.IncludeCommitQueue, patchesInput.Page, patchesInput.Limit)
 	patchPointers := []*restModel.APIPatch{}
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2147,10 +2147,10 @@ func (r *queryResolver) User(ctx context.Context, userIdParam *string) (*restMod
 
 func (r *userResolver) Patches(ctx context.Context, obj *restModel.APIDBUser, patchesInput PatchesInput) (*Patches, error) {
 	patches, count, err := r.sc.FindPatchesByUserPatchNameStatusesCommitQueue(*obj.UserID, patchesInput.PatchName, patchesInput.Statuses, patchesInput.IncludeCommitQueue, patchesInput.Page, patchesInput.Limit)
-	patchPointers := []*restModel.APIPatch{}
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}
+	patchPointers := []*restModel.APIPatch{}
 	for i := range patches {
 		patchPointers = append(patchPointers, &patches[i])
 	}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -230,11 +230,11 @@ input UseSpruceOptionsInput {
 }
 
 input PatchesInput {
-  limit: Int = 0
-  page: Int = 0
-  patchName: String = ""
-  statuses: [String!] = []
-  includeCommitQueue: Boolean = false
+  limit: Int! = 0
+  page: Int! = 0
+  patchName: String! = ""
+  statuses: [String!]! = []
+  includeCommitQueue: Boolean! = false
 }
 
 input SpawnHostInput {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -228,6 +228,14 @@ input UseSpruceOptionsInput {
   spruceV1: Boolean
 }
 
+input PatchesInput {
+  limit: Int = 0
+  page: Int = 0
+  patchName: String = ""
+  statuses: [String!] = []
+  includeCommitQueue: Boolean = false
+}
+
 input SpawnHostInput {
   distroId: String!
   region: String!
@@ -398,6 +406,11 @@ type FileDiff {
 }
 
 type UserPatches {
+  patches: [Patch!]!
+  filteredPatchCount: Int!
+}
+
+type Patches {
   patches: [Patch!]!
   filteredPatchCount: Int!
 }
@@ -658,6 +671,7 @@ type User {
   displayName: String!
   userId: String!
   emailAddress: String!
+  patches(patchesInput: PatchesInput!): Patches!
 }
 
 type RecentTaskLogs {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -11,6 +11,7 @@ type Query {
   taskAllExecutions(taskId: String!): [Task!]!
   patch(id: String!): Patch!
   projects: Projects!
+  project(id: String!): Project!
   patchTasks(
     patchId: String!
     sortBy: TaskSortCategory = STATUS
@@ -656,9 +657,11 @@ type GroupedProjects {
 
 type Project {
   identifier: String!
+  id: String!
   displayName: String!
   repo: String!
   owner: String!
+  patches(patchesInput: PatchesInput!): Patches!
 }
 
 type File {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -11,7 +11,7 @@ type Query {
   taskAllExecutions(taskId: String!): [Task!]!
   patch(id: String!): Patch!
   projects: Projects!
-  project(id: String!): Project!
+  project(projectId: String!): Project!
   patchTasks(
     patchId: String!
     sortBy: TaskSortCategory = STATUS

--- a/graphql/tests/project/data.json
+++ b/graphql/tests/project/data.json
@@ -1,0 +1,75 @@
+{
+  "project_ref": [
+    {
+      "_id": "evergreen",
+      "identifier": "evergreen",
+      "commit_queue": {
+        "patch_type": "PR"
+      }
+    }
+  ],
+  "patches": [
+    {
+      "branch": "evergreen",
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e4" },
+      "author": "testuser",
+      "create_time": { "$date": "2020-01-01T00:00:01Z" },
+      "desc": "1",
+      "status": "created",
+      "alias": "__commit_queue"
+    },
+    {
+      "branch": "evergreen",
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e5" },
+      "author": "testuser",
+      "create_time": { "$date": "2020-01-01T00:00:02Z" },
+      "desc": "222",
+      "status": "created",
+      "alias": "__commit_queue"
+    },
+    {
+      "branch": "evergreen",
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e6" },
+      "author": "testuser",
+      "create_time": { "$date": "2020-01-01T00:00:03Z" },
+      "desc": "1",
+      "status": "created",
+      "alias": "__commit_queue"
+    },
+    {
+      "branch": "evergreen",
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e7" },
+      "author": "testuser",
+      "create_time": { "$date": "2020-01-01T00:00:04Z" },
+      "desc": "222",
+      "status": "failed",
+      "alias": "__github"
+    },
+    {
+      "branch": "evergreen",
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e8" },
+      "author": "testuser",
+      "create_time": { "$date": "2020-01-01T00:00:05Z" },
+      "desc": "1",
+      "status": "created",
+      "alias": "__github"
+    },
+    {
+      "branch": "evergreen",
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e9" },
+      "author": "testuser",
+      "create_time": { "$date": "2019-01-01T00:00:06Z" },
+      "desc": "222",
+      "status": "failed",
+      "alias": "__github"
+    },
+    {
+      "_id": { "$oid": "6e4ff3abe3c3317e352062e9" },
+      "author": "user1",
+      "create_time": { "$date": "2019-01-01T00:00:06Z" },
+      "desc": "222",
+      "status": "failed",
+      "alias": "__github"
+    }
+  ]
+}

--- a/graphql/tests/project/queries/patches-all-params.graphql
+++ b/graphql/tests/project/queries/patches-all-params.graphql
@@ -1,0 +1,21 @@
+{
+  project(projectId: "evergreen") {
+    patches(
+      patchesInput: {
+        includeCommitQueue: true
+        statuses: ["failed", "succeeded"]
+        patchName: "2"
+        page: 0
+        limit: 2
+      }
+    ) {
+      patches {
+        status
+        id
+        description
+        alias
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/project/queries/patches-default-params.graphql
+++ b/graphql/tests/project/queries/patches-default-params.graphql
@@ -1,0 +1,10 @@
+{
+  project(projectId: "evergreen") {
+    patches(patchesInput: {}) {
+      patches {
+        id
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/project/queries/patches-include-commit-queue.graphql
+++ b/graphql/tests/project/queries/patches-include-commit-queue.graphql
@@ -1,0 +1,10 @@
+{
+  project(projectId: "evergreen") {
+    patches(patchesInput: { includeCommitQueue: true }) {
+      patches {
+        id
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/project/queries/patches-nonexisting-user.graphql
+++ b/graphql/tests/project/queries/patches-nonexisting-user.graphql
@@ -1,0 +1,10 @@
+{
+  project(projectId: "not a real project") {
+    patches(patchesInput: {}) {
+      patches {
+        id
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/project/queries/patches-page-0-limit-3.graphql
+++ b/graphql/tests/project/queries/patches-page-0-limit-3.graphql
@@ -1,0 +1,10 @@
+{
+  project(projectId: "evergreen") {
+    patches(patchesInput: { includeCommitQueue: true, page: 0, limit: 3 }) {
+      patches {
+        id
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/project/queries/patches-page-1-limit-3.graphql
+++ b/graphql/tests/project/queries/patches-page-1-limit-3.graphql
@@ -1,0 +1,10 @@
+{
+  project(projectId: "evergreen") {
+    patches(patchesInput: { includeCommitQueue: true, page: 1, limit: 3 }) {
+      patches {
+        id
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/project/queries/patches-patchName.graphql
+++ b/graphql/tests/project/queries/patches-patchName.graphql
@@ -1,0 +1,11 @@
+{
+  project(projectId: "evergreen") {
+    patches(patchesInput: { patchName: "22", includeCommitQueue: true }) {
+      patches {
+        id
+        description
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/project/queries/patches-statuses.graphql
+++ b/graphql/tests/project/queries/patches-statuses.graphql
@@ -1,0 +1,11 @@
+{
+  project(projectId: "evergreen") {
+    patches(patchesInput: { includeCommitQueue: true, statuses: ["failed"] }) {
+      patches {
+        id
+        status
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/project/results.json
+++ b/graphql/tests/project/results.json
@@ -1,0 +1,149 @@
+{
+  "tests": [
+    {
+      "query_file": "patches-all-params.graphql",
+      "result": {
+        "data": {
+          "project": {
+            "patches": {
+              "patches": [
+                {
+                  "status": "failed",
+                  "id": "5e4ff3abe3c3317e352062e7",
+                  "description": "222",
+                  "alias": "__github"
+                },
+                {
+                  "status": "failed",
+                  "id": "5e4ff3abe3c3317e352062e9",
+                  "description": "222",
+                  "alias": "__github"
+                }
+              ],
+              "filteredPatchCount": 2
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-default-params.graphql",
+      "result": {
+        "data": {
+          "project": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e8" },
+                { "id": "5e4ff3abe3c3317e352062e7" },
+                { "id": "5e4ff3abe3c3317e352062e9" }
+              ],
+              "filteredPatchCount": 3
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-include-commit-queue.graphql",
+      "result": {
+        "data": {
+          "project": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e8" },
+                { "id": "5e4ff3abe3c3317e352062e7" },
+                { "id": "5e4ff3abe3c3317e352062e6" },
+                { "id": "5e4ff3abe3c3317e352062e5" },
+                { "id": "5e4ff3abe3c3317e352062e4" },
+                { "id": "5e4ff3abe3c3317e352062e9" }
+              ],
+              "filteredPatchCount": 6
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-nonexisting-user.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "Error finding project by id not a real project: 404 (Not Found): project with id 'not a real project' not found",
+            "path": ["project"],
+            "extensions": {
+              "code": "INTERNAL_SERVER_ERROR"
+            }
+          }
+        ],
+        "data": null
+      }
+    },
+    {
+      "query_file": "patches-page-0-limit-3.graphql",
+      "result": {
+        "data": {
+          "project": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e8" },
+                { "id": "5e4ff3abe3c3317e352062e7" },
+                { "id": "5e4ff3abe3c3317e352062e6" }
+              ],
+              "filteredPatchCount": 6
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-page-1-limit-3.graphql",
+      "result": {
+        "data": {
+          "project": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e5" },
+                { "id": "5e4ff3abe3c3317e352062e4" },
+                { "id": "5e4ff3abe3c3317e352062e9" }
+              ],
+              "filteredPatchCount": 6
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-patchName.graphql",
+      "result": {
+        "data": {
+          "project": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e7", "description": "222" },
+                { "id": "5e4ff3abe3c3317e352062e5", "description": "222" },
+                { "id": "5e4ff3abe3c3317e352062e9", "description": "222" }
+              ],
+              "filteredPatchCount": 3
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-statuses.graphql",
+      "result": {
+        "data": {
+          "project": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e7", "status": "failed" },
+                { "id": "5e4ff3abe3c3317e352062e9", "status": "failed" }
+              ],
+              "filteredPatchCount": 2
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/graphql/tests/user/data.json
+++ b/graphql/tests/user/data.json
@@ -24,5 +24,63 @@
         }
       }
     }
+  ],
+  "patches": [
+    {
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e4" },
+      "author": "testuser",
+      "create_time": { "$date": "2020-01-01T00:00:01Z" },
+      "desc": "1",
+      "status": "created",
+      "alias": "__commit_queue"
+    },
+    {
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e5" },
+      "author": "testuser",
+      "create_time": { "$date": "2020-01-01T00:00:02Z" },
+      "desc": "222",
+      "status": "created",
+      "alias": "__commit_queue"
+    },
+    {
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e6" },
+      "author": "testuser",
+      "create_time": { "$date": "2020-01-01T00:00:03Z" },
+      "desc": "1",
+      "status": "created",
+      "alias": "__commit_queue"
+    },
+    {
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e7" },
+      "author": "testuser",
+      "create_time": { "$date": "2020-01-01T00:00:04Z" },
+      "desc": "222",
+      "status": "failed",
+      "alias": "__github"
+    },
+    {
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e8" },
+      "author": "testuser",
+      "create_time": { "$date": "2020-01-01T00:00:05Z" },
+      "desc": "1",
+      "status": "created",
+      "alias": "__github"
+    },
+    {
+      "_id": { "$oid": "5e4ff3abe3c3317e352062e9" },
+      "author": "testuser",
+      "create_time": { "$date": "2019-01-01T00:00:06Z" },
+      "desc": "222",
+      "status": "failed",
+      "alias": "__github"
+    },
+    {
+      "_id": { "$oid": "6e4ff3abe3c3317e352062e9" },
+      "author": "user1",
+      "create_time": { "$date": "2019-01-01T00:00:06Z" },
+      "desc": "222",
+      "status": "failed",
+      "alias": "__github"
+    }
   ]
 }

--- a/graphql/tests/user/queries/patches-all-params.graphql
+++ b/graphql/tests/user/queries/patches-all-params.graphql
@@ -1,0 +1,21 @@
+{
+  user(userId: "testuser") {
+    patches(
+      patchesInput: {
+        includeCommitQueue: true
+        statuses: ["failed", "succeeded"]
+        patchName: "2"
+        page: 0
+        limit: 2
+      }
+    ) {
+      patches {
+        status
+        id
+        description
+        alias
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/user/queries/patches-default-params.graphql
+++ b/graphql/tests/user/queries/patches-default-params.graphql
@@ -1,0 +1,10 @@
+{
+  user(userId: "testuser") {
+    patches(patchesInput: {}) {
+      patches {
+        id
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/user/queries/patches-include-commit-queue.graphql
+++ b/graphql/tests/user/queries/patches-include-commit-queue.graphql
@@ -1,0 +1,10 @@
+{
+  user {
+    patches(patchesInput: { includeCommitQueue: true }) {
+      patches {
+        id
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/user/queries/patches-nonexisting-user.graphql
+++ b/graphql/tests/user/queries/patches-nonexisting-user.graphql
@@ -1,0 +1,10 @@
+{
+  user(userId: "nonexistent user") {
+    patches(patchesInput: {}) {
+      patches {
+        id
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/user/queries/patches-page-0-limit-3.graphql
+++ b/graphql/tests/user/queries/patches-page-0-limit-3.graphql
@@ -1,0 +1,10 @@
+{
+  user {
+    patches(patchesInput: { includeCommitQueue: true, page: 0, limit: 3 }) {
+      patches {
+        id
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/user/queries/patches-page-1-limit-3.graphql
+++ b/graphql/tests/user/queries/patches-page-1-limit-3.graphql
@@ -1,0 +1,10 @@
+{
+  user {
+    patches(patchesInput: { includeCommitQueue: true, page: 1, limit: 3 }) {
+      patches {
+        id
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/user/queries/patches-patchName.graphql
+++ b/graphql/tests/user/queries/patches-patchName.graphql
@@ -1,0 +1,11 @@
+{
+  user {
+    patches(patchesInput: { patchName: "22", includeCommitQueue: true }) {
+      patches {
+        id
+        description
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/user/queries/patches-statuses.graphql
+++ b/graphql/tests/user/queries/patches-statuses.graphql
@@ -1,0 +1,11 @@
+{
+  user {
+    patches(patchesInput: { includeCommitQueue: true, statuses: ["failed"] }) {
+      patches {
+        id
+        status
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/user/queries/patches-userId.graphql
+++ b/graphql/tests/user/queries/patches-userId.graphql
@@ -1,0 +1,8 @@
+{
+  userPatches(userId: "user1") {
+    patches {
+      id
+    }
+    filteredPatchCount
+  }
+}

--- a/graphql/tests/user/results.json
+++ b/graphql/tests/user/results.json
@@ -29,15 +29,158 @@
         "errors": [
           {
             "message": "Could not find user from user ID",
-            "path": [
-              "user"
-            ],
+            "path": ["user"],
             "extensions": {
               "code": "RESOURCE_NOT_FOUND"
             }
           }
         ],
         "data": null
+      }
+    },
+    {
+      "query_file": "patches-all-params.graphql",
+      "result": {
+        "data": {
+          "user": {
+            "patches": {
+              "patches": [
+                {
+                  "status": "failed",
+                  "id": "5e4ff3abe3c3317e352062e7",
+                  "description": "222",
+                  "alias": "__github"
+                },
+                {
+                  "status": "failed",
+                  "id": "5e4ff3abe3c3317e352062e9",
+                  "description": "222",
+                  "alias": "__github"
+                }
+              ],
+              "filteredPatchCount": 2
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-default-params.graphql",
+      "result": {
+        "data": {
+          "user": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e8" },
+                { "id": "5e4ff3abe3c3317e352062e7" },
+                { "id": "5e4ff3abe3c3317e352062e9" }
+              ],
+              "filteredPatchCount": 3
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-include-commit-queue.graphql",
+      "result": {
+        "data": {
+          "user": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e8" },
+                { "id": "5e4ff3abe3c3317e352062e7" },
+                { "id": "5e4ff3abe3c3317e352062e6" },
+                { "id": "5e4ff3abe3c3317e352062e5" },
+                { "id": "5e4ff3abe3c3317e352062e4" },
+                { "id": "5e4ff3abe3c3317e352062e9" }
+              ],
+              "filteredPatchCount": 6
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-nonexisting-user.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "Could not find user from user ID",
+            "path": ["user"],
+            "extensions": {
+              "code": "RESOURCE_NOT_FOUND"
+            }
+          }
+        ],
+        "data": null
+      }
+    },
+    {
+      "query_file": "patches-page-0-limit-3.graphql",
+      "result": {
+        "data": {
+          "user": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e8" },
+                { "id": "5e4ff3abe3c3317e352062e7" },
+                { "id": "5e4ff3abe3c3317e352062e6" }
+              ],
+              "filteredPatchCount": 6
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-page-1-limit-3.graphql",
+      "result": {
+        "data": {
+          "user": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e5" },
+                { "id": "5e4ff3abe3c3317e352062e4" },
+                { "id": "5e4ff3abe3c3317e352062e9" }
+              ],
+              "filteredPatchCount": 6
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-patchName.graphql",
+      "result": {
+        "data": {
+          "user": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e7", "description": "222" },
+                { "id": "5e4ff3abe3c3317e352062e5", "description": "222" },
+                { "id": "5e4ff3abe3c3317e352062e9", "description": "222" }
+              ],
+              "filteredPatchCount": 3
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patches-statuses.graphql",
+      "result": {
+        "data": {
+          "user": {
+            "patches": {
+              "patches": [
+                { "id": "5e4ff3abe3c3317e352062e7", "status": "failed" },
+                { "id": "5e4ff3abe3c3317e352062e9", "status": "failed" }
+              ],
+              "filteredPatchCount": 2
+            }
+          }
+        }
       }
     }
   ]

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -108,9 +108,14 @@ func ByUserAndCommitQueue(user string, filterCommitQueue bool) db.Q {
 }
 
 func ByUserPatchNameStatusesCommitQueuePaginated(user, patchName string, statuses []string, includeCommitQueue bool, page int, limit int) db.Q {
-	queryInterface := bson.M{
-		AuthorKey: user,
-	}
+	return byPatchNameStatusesCommitQueuePaginated(bson.M{AuthorKey: user}, patchName, statuses, includeCommitQueue, page, limit)
+}
+
+func ByProjectPatchNameStatusesCommitQueuePaginated(projectId, patchName string, statuses []string, includeCommitQueue bool, page int, limit int) db.Q {
+	return byPatchNameStatusesCommitQueuePaginated(bson.M{ProjectKey: projectId}, patchName, statuses, includeCommitQueue, page, limit)
+}
+
+func byPatchNameStatusesCommitQueuePaginated(queryInterface map[string]interface{}, patchName string, statuses []string, includeCommitQueue bool, page int, limit int) db.Q {
 	if patchName != "" {
 		queryInterface[DescriptionKey] = bson.M{"$regex": patchName, "$options": "i"}
 	}

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -215,7 +215,7 @@ type Connector interface {
 	FindPatchesByProject(string, time.Time, int) ([]restModel.APIPatch, error)
 	// FindPatchByUser finds patches for the input user as ordered by creation time
 	FindPatchesByUser(string, time.Time, int) ([]restModel.APIPatch, error)
-	// FindPatchesByProjectPatchNameStatusesCommitQueue fetches a page of patches corresponding to the input user ID
+	// FindPatchesByUserPatchNameStatusesCommitQueue fetches a page of patches corresponding to the input user ID
 	// as ordered by creation time and filtered by given statuses, patch name commit queue parameter
 	FindPatchesByUserPatchNameStatusesCommitQueue(string, string, []string, bool, int, int) ([]restModel.APIPatch, *int, error)
 	// FindPatchesByProjectPatchNameStatusesCommitQueue fetches a page of patches corresponding to the input project ID

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -215,9 +215,12 @@ type Connector interface {
 	FindPatchesByProject(string, time.Time, int) ([]restModel.APIPatch, error)
 	// FindPatchByUser finds patches for the input user as ordered by creation time
 	FindPatchesByUser(string, time.Time, int) ([]restModel.APIPatch, error)
-	// FindPatchesByUser fetches a page of patches for the input user ordered by creation
-	// time and filters when given statuses, patch name, and commit queue parameters
+	// FindPatchesByProjectPatchNameStatusesCommitQueue fetches a page of patches corresponding to the input user ID
+	// as ordered by creation time and filtered by given statuses, patch name commit queue parameter
 	FindPatchesByUserPatchNameStatusesCommitQueue(string, string, []string, bool, int, int) ([]restModel.APIPatch, *int, error)
+	// FindPatchesByProjectPatchNameStatusesCommitQueue fetches a page of patches corresponding to the input project ID
+	// as ordered by creation time and filtered by given statuses, patch name commit queue parameter
+	FindPatchesByProjectPatchNameStatusesCommitQueue(string, string, []string, bool, int, int) ([]restModel.APIPatch, *int, error)
 	// FindPatchById fetches the patch corresponding to the input patch ID.
 	FindPatchById(string) (*restModel.APIPatch, error)
 	//FindPatchesByIds fetches an array of patches that corresponding to the input patch IDs

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -196,7 +196,7 @@ func (pc *DBPatchConnector) FindPatchesByProjectPatchNameStatusesCommitQueue(pro
 		apiPatch := restModel.APIPatch{}
 		err = apiPatch.BuildFromService(p)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, fmt.Sprintf("problem building APIPatch from service for patch: %s", p.Id.Hex()))
+			return nil, nil, errors.Wrapf(err, "problem building APIPatch from service for patch: %s", p.Id.Hex())
 		}
 		apiPatches = append(apiPatches, apiPatch)
 	}
@@ -217,7 +217,7 @@ func (pc *DBPatchConnector) FindPatchesByUserPatchNameStatusesCommitQueue(user s
 		apiPatch := restModel.APIPatch{}
 		err = apiPatch.BuildFromService(p)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, fmt.Sprintf("problem building APIPatch from service for patch: %s", p.Id.Hex()))
+			return nil, nil, errors.Wrapf(err, "problem building APIPatch from service for patch: %s", p.Id.Hex())
 		}
 		apiPatches = append(apiPatches, apiPatch)
 	}

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -182,6 +182,27 @@ func (pc *DBPatchConnector) SetPatchActivated(ctx context.Context, patchId strin
 	return model.SetVersionActivation(patchId, activated, user)
 }
 
+func (pc *DBPatchConnector) FindPatchesByProjectPatchNameStatusesCommitQueue(projectId string, patchName string, statuses []string, includeCommitQueue bool, page int, limit int) ([]restModel.APIPatch, *int, error) {
+	patches, err := patch.Find(patch.ByProjectPatchNameStatusesCommitQueuePaginated(projectId, patchName, statuses, includeCommitQueue, page, limit))
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "problem fetching patches for project %s", projectId)
+	}
+	count, err := patch.Count(patch.ByProjectPatchNameStatusesCommitQueuePaginated(projectId, patchName, statuses, includeCommitQueue, 0, 0))
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "problem counting patches for project %s", projectId)
+	}
+	apiPatches := []restModel.APIPatch{}
+	for _, p := range patches {
+		apiPatch := restModel.APIPatch{}
+		err = apiPatch.BuildFromService(p)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, fmt.Sprintf("problem building APIPatch from service for patch: %s", p.Id.Hex()))
+		}
+		apiPatches = append(apiPatches, apiPatch)
+	}
+	return apiPatches, &count, nil
+}
+
 func (pc *DBPatchConnector) FindPatchesByUserPatchNameStatusesCommitQueue(user string, patchName string, statuses []string, includeCommitQueue bool, page int, limit int) ([]restModel.APIPatch, *int, error) {
 	patches, err := patch.Find(patch.ByUserPatchNameStatusesCommitQueuePaginated(user, patchName, statuses, includeCommitQueue, page, limit))
 	if err != nil {
@@ -366,6 +387,10 @@ func (pc *MockPatchConnector) SetPatchActivated(ctx context.Context, patchId str
 }
 
 func (hp *MockPatchConnector) FindPatchesByUserPatchNameStatusesCommitQueue(user string, patchName string, statuses []string, includeCommitQueue bool, page int, limit int) ([]restModel.APIPatch, *int, error) {
+	return nil, nil, nil
+}
+
+func (hp *MockPatchConnector) FindPatchesByProjectPatchNameStatusesCommitQueue(projectId string, patchName string, statuses []string, includeCommitQueue bool, page int, limit int) ([]restModel.APIPatch, *int, error) {
 	return nil, nil, nil
 }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-13229
These code changes utilize the existing Project gql type by adding a patches field to it and setting the base model to the ProjectRef struct instead of UIProjectFields (a pared down version of ProjectRef).
These code changes also add a patches field to the User gql type that is modeled after the UserPatches query so the UserPatches query can be removed ([EVG-13508](https://jira.mongodb.org/browse/EVG-13508)). The benefit of replacing gql query definitions with gql types is so developers can understand the type of data that can be queried by examining gql type fields instead of perusing our growing list of query definitions. It also prevents us from overloading queries to handle different resource types or adding additional queries that correlate with existing gql types in order to keep our schema simple to understand. 