### PR TITLE
EVG-12602 isolate schedule patch context

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1688,7 +1688,7 @@ func (r *mutationResolver) SchedulePatch(ctx context.Context, patchID string, co
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error occurred fetching patch `%s`: %s", patchID, err.Error()))
 		}
 	}
-	err, _, _, versionID := SchedulePatch(ctx, patchID, version, patchUpdateReq, configure.Parameters)
+	err, _, _, versionID := SchedulePatch(patchID, version, patchUpdateReq, configure.Parameters)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error scheduling patch `%s`: %s", patchID, err))
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -230,6 +230,8 @@ func SchedulePatch(patchId string, version *model.Version, patchUpdateReq PatchV
 		return errors.Wrap(err, "Error setting description"), http.StatusInternalServerError, "", ""
 	}
 
+	// create a separate context from the one the callar has so that the caller
+	// can't interrupt the db operations here
 	ctx := context.Background()
 	if p.Version != "" {
 		p.Activated = true

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -160,7 +160,7 @@ func GetBaseTaskStatusesFromPatchID(d data.Connector, patchID string) (BaseTaskS
 
 // SchedulePatch schedules a patch. It returns an error and an HTTP status code. In the case of
 // success, it also returns a success message and a version ID.
-func SchedulePatch(ctx context.Context, patchId string, version *model.Version, patchUpdateReq PatchVariantsTasksRequest, parametersModel []*restModel.APIParameter) (error, int, string, string) {
+func SchedulePatch(patchId string, version *model.Version, patchUpdateReq PatchVariantsTasksRequest, parametersModel []*restModel.APIParameter) (error, int, string, string) {
 	var err error
 	p, err := patch.FindOneId(patchId)
 	if err != nil {
@@ -230,6 +230,7 @@ func SchedulePatch(ctx context.Context, patchId string, version *model.Version, 
 		return errors.Wrap(err, "Error setting description"), http.StatusInternalServerError, "", ""
 	}
 
+	ctx := context.Background()
 	if p.Version != "" {
 		p.Activated = true
 		// This patch has already been finalized, just add the new builds and tasks
@@ -264,10 +265,6 @@ func SchedulePatch(ctx context.Context, patchId string, version *model.Version, 
 		if err != nil {
 			return errors.Wrap(err, "Error setting patch variants and tasks"), http.StatusInternalServerError, "", ""
 		}
-
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithCancel(ctx)
-		defer cancel()
 
 		requester := p.GetRequester()
 		ver, err := model.FinalizePatch(ctx, p, requester, githubOauthToken)

--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -591,7 +591,7 @@ func (p *schedulePatchHandler) Run(ctx context.Context) gimlet.Responder {
 		}
 		variantTasks.VariantsTasks = append(variantTasks.VariantsTasks, variantToSchedule)
 	}
-	err, code, msg, versionId := graphql.SchedulePatch(ctx, p.patchId, dbVersion, variantTasks, nil)
+	err, code, msg, versionId := graphql.SchedulePatch(p.patchId, dbVersion, variantTasks, nil)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "unable to schedule patch"))
 	}

--- a/service/patch.go
+++ b/service/patch.go
@@ -98,7 +98,7 @@ func (uis *UIServer) schedulePatchUI(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusBadRequest, err)
 	}
 
-	err, status, successMessage, versionId := graphql.SchedulePatch(r.Context(), projCtx.Patch.Id.Hex(), projCtx.Version, patchUpdateReq, nil)
+	err, status, successMessage, versionId := graphql.SchedulePatch(projCtx.Patch.Id.Hex(), projCtx.Version, patchUpdateReq, nil)
 	if err != nil {
 		uis.LoggedError(w, r, status, err)
 		return


### PR DESCRIPTION
What I think happened is that if you cancel the request to finalize a patch from the web UI (by navigating away or hitting stop), it will propagate to the db operations. If you time it just right, you can get the data in an inconsistent state where the version is inserted but nothing else, so you'll hit this problem.

The actual fix should maybe be to put this in a transaction, but for now I think keeping the context separate is good enough