### PR TITLE
EVG-13269 hide use repo settings

### DIFF
--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -122,7 +122,7 @@ Evergreen Projects
         </div>
       </div>
       <div id="use_repo_settings" class="form-group">
-        <div class="col-lg-6">
+        <div class="col-lg-6" ng-hide="true">
           <input type="checkbox" id="use-repo-settings-checkbox" ng-model="settingsFormData.use_repo_settings" />
           <label for="use-repo-settings-checkbox">Use Repo Settings</label>
         </div>


### PR DESCRIPTION
This is actually just for our own development; I don't want to confuse users into thinking this does something. (I'm just going to hide it entirely, because we can use the PATCH api route with {"use_repo_settings":<boolean>} to turn it on/off in most cases, and deploy without it hidden to staging/local if we need to test the UI)