### PR TITLE
EVG-13427, EVG-13479: remove fetch host provisioning script distro setting and clean up host provisioning script

### DIFF
--- a/cloud/userdata_test.go
+++ b/cloud/userdata_test.go
@@ -48,7 +48,7 @@ func TestMakeUserData(t *testing.T) {
 			userData, err := makeUserData(ctx, env, h, customUserData, false)
 			require.NoError(t, err)
 
-			cmd, err := h.CurlCommand(env.Settings())
+			cmd, err := h.CurlCommandWithDefaultRetry(env.Settings())
 			require.NoError(t, err)
 			assert.Contains(t, userData, cmd)
 		},

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -76,10 +76,9 @@ type BootstrapSettings struct {
 	Communication string `bson:"communication,omitempty" json:"communication,omitempty" mapstructure:"communication,omitempty"`
 
 	// Optional
-	Env                     []EnvVar             `bson:"env,omitempty" json:"env,omitempty" mapstructure:"env,omitempty"`
-	ResourceLimits          ResourceLimits       `bson:"resource_limits,omitempty" json:"resource_limits,omitempty" mapstructure:"resource_limits,omitempty"`
-	PreconditionScripts     []PreconditionScript `bson:"precondition_scripts,omitempty" json:"precondition_scripts,omitempty" mapstructure:"precondition_scripts,omitempty"`
-	FetchProvisioningScript bool                 `bson:"fetch_provisioning_script,omitempty" json:"fetch_provisioning_script,omitempty" mapstructure:"fetch_provisioning_script,omitempty"`
+	Env                 []EnvVar             `bson:"env,omitempty" json:"env,omitempty" mapstructure:"env,omitempty"`
+	ResourceLimits      ResourceLimits       `bson:"resource_limits,omitempty" json:"resource_limits,omitempty" mapstructure:"resource_limits,omitempty"`
+	PreconditionScripts []PreconditionScript `bson:"precondition_scripts,omitempty" json:"precondition_scripts,omitempty" mapstructure:"precondition_scripts,omitempty"`
 
 	// Required for new provisioning
 	ClientDir             string `bson:"client_dir,omitempty" json:"client_dir,omitempty" mapstructure:"client_dir,omitempty"`

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -378,10 +378,10 @@ func (h *Host) JasperBinaryFilePath(config evergreen.HostJasperConfig) string {
 	return filepath.Join(h.Distro.BootstrapSettings.JasperBinaryDir, h.jasperBinaryFileName(config))
 }
 
-// GenerateUserDataProvisioningScript creates the script to provision the host
-// through user data. If, for some reason, this script gets interrupted, there's
-// no guarantee that it will succeed if run again, since we cannot enforce
-// idempotency on the setup script.
+// GenerateUserDataProvisioningScript creates a script to provision a host that
+// is provisioning in user data. If, for some reason, this script gets
+// interrupted, there's no guarantee that it will succeed if run again, since we
+// cannot enforce idempotency on the setup script.
 func (h *Host) GenerateUserDataProvisioningScript(settings *evergreen.Settings, creds *certdepot.Credentials) (string, error) {
 	var err error
 	checkProvisioningStarted := h.CheckUserDataProvisioningStartedCommand()
@@ -1223,8 +1223,8 @@ func (h *Host) SetUserDataHostProvisioned() error {
 	return nil
 }
 
-// GenerateFetchProvisioningScriptUserData creates the user data to fetch the
-// host provisioning script from the server.
+// GenerateFetchProvisioningScriptUserData creates the user data script to fetch
+// the host provisioning script.
 func (h *Host) GenerateFetchProvisioningScriptUserData(settings *evergreen.Settings) (*userdata.Options, error) {
 	if h.Secret == "" {
 		if err := h.CreateSecret(); err != nil {

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -85,6 +85,12 @@ func (h *Host) CurlCommandWithRetry(settings *evergreen.Settings, numRetries, ma
 	return strings.Join(cmds, " && "), nil
 }
 
+// CurlCommandWithDefaultRetry is the same as CurlCommandWithRetry using the
+// default retry parameters.
+func (h *Host) CurlCommandWithDefaultRetry(settings *evergreen.Settings) (string, error) {
+	return h.CurlCommandWithRetry(settings, curlDefaultNumRetries, curlDefaultMaxSecs)
+}
+
 func (h *Host) curlCommands(settings *evergreen.Settings, curlArgs string) ([]string, error) {
 	flags, err := evergreen.GetServiceFlags()
 	if err != nil {
@@ -1175,7 +1181,7 @@ func (h *Host) GenerateFetchProvisioningScriptUserData(settings *evergreen.Setti
 		}
 	}
 
-	fetchClient, err := h.CurlCommandWithRetry(settings, curlDefaultNumRetries, curlDefaultMaxSecs)
+	fetchClient, err := h.CurlCommandWithDefaultRetry(settings)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating curl command for evergreen client")
 	}

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1086,50 +1086,25 @@ func TestSpawnHostSetupCommands(t *testing.T) {
 }
 
 func TestCheckUserDataProvisioningStartedCommand(t *testing.T) {
-	t.Run("WithWindowsHost", func(t *testing.T) {
-		for testName, testCase := range map[string]func(t *testing.T, h *Host){
-			"CreatesExpectedCommand": func(t *testing.T, h *Host) {
-				expectedCmd := "[ -a /jasper_binary_dir/user_data_started ] && exit || mkdir -m 777 -p /jasper_binary_dir && touch /jasper_binary_dir/user_data_started"
-				cmd := h.CheckUserDataProvisioningStartedCommand()
-				assert.Equal(t, expectedCmd, cmd)
-			},
-		} {
-			t.Run(testName, func(t *testing.T) {
-				h := &Host{
-					Distro: distro.Distro{
-						Arch: evergreen.ArchWindowsAmd64,
-						BootstrapSettings: distro.BootstrapSettings{
-							JasperBinaryDir: "/jasper_binary_dir",
-							ShellPath:       "/bin/bash",
-						},
+	for testName, testCase := range map[string]func(t *testing.T, h *Host){
+		"CreatesExpectedCommand": func(t *testing.T, h *Host) {
+			expectedCmd := "[ -a /jasper_binary_dir/user_data_started ] && exit" +
+				" || mkdir -m 777 -p /jasper_binary_dir && touch /jasper_binary_dir/user_data_started"
+			cmd := h.CheckUserDataProvisioningStartedCommand()
+			assert.Equal(t, expectedCmd, cmd)
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			h := &Host{
+				Distro: distro.Distro{
+					BootstrapSettings: distro.BootstrapSettings{
+						JasperBinaryDir: "/jasper_binary_dir",
 					},
-				}
-				testCase(t, h)
-			})
-		}
-	})
-	t.Run("WithNonWindowsHost", func(t *testing.T) {
-		for testName, testCase := range map[string]func(t *testing.T, h *Host){
-			"CreatesExpectedCommand": func(t *testing.T, h *Host) {
-				expectedCmd := "[ -a /jasper_binary_dir/user_data_started ] && exit" +
-					" || mkdir -m 777 -p /jasper_binary_dir && touch /jasper_binary_dir/user_data_started"
-				cmd := h.CheckUserDataProvisioningStartedCommand()
-				assert.Equal(t, expectedCmd, cmd)
-			},
-		} {
-			t.Run(testName, func(t *testing.T) {
-				h := &Host{
-					Distro: distro.Distro{
-						Arch: evergreen.ArchLinuxAmd64,
-						BootstrapSettings: distro.BootstrapSettings{
-							JasperBinaryDir: "/jasper_binary_dir",
-						},
-					},
-				}
-				testCase(t, h)
-			})
-		}
-	})
+				},
+			}
+			testCase(t, h)
+		})
+	}
 }
 
 func TestMarkUserDataProvisioningDoneCommand(t *testing.T) {

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1326,7 +1326,7 @@ func TestGenerateFetchProvisioningScriptUserData(t *testing.T) {
 			require.NoError(t, err)
 
 			makeJasperDirs := h.MakeJasperDirsCommand()
-			fetchClient, err := h.CurlCommandWithRetry(settings, curlDefaultNumRetries, curlDefaultMaxSecs)
+			fetchClient, err := h.CurlCommandWithDefaultRetry(settings)
 			fixClientOwner := h.changeOwnerCommand(filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()))
 			require.NoError(t, err)
 
@@ -1352,7 +1352,7 @@ func TestGenerateFetchProvisioningScriptUserData(t *testing.T) {
 			require.NoError(t, err)
 
 			makeJasperDirs := h.MakeJasperDirsCommand()
-			fetchClient, err := h.CurlCommandWithRetry(settings, curlDefaultNumRetries, curlDefaultMaxSecs)
+			fetchClient, err := h.CurlCommandWithDefaultRetry(settings)
 			require.NoError(t, err)
 			fixClientOwner := h.changeOwnerCommand(filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()))
 

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -464,7 +464,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 
 			creds, err := newMockCredentials()
 			require.NoError(t, err)
-			writeCredentialsCmd, err := h.bufferedWriteJasperCredentialsFilesCommands(settings.Splunk, creds)
+			writeCredentialsCmd, err := h.WriteJasperCredentialsFilesCommands(settings.Splunk, creds)
 			require.NoError(t, err)
 
 			startAgentMonitor, err := h.StartAgentMonitorRequest(settings)
@@ -473,8 +473,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 			markDone := h.MarkUserDataProvisioningDoneCommand()
 
 			var expectedCmds []string
-			expectedCmds = append(expectedCmds, checkRerun, setupUser, setupScript)
-			expectedCmds = append(expectedCmds, writeCredentialsCmd...)
+			expectedCmds = append(expectedCmds, checkRerun, setupUser, setupScript, writeCredentialsCmd)
 			expectedCmds = append(expectedCmds,
 				h.FetchJasperCommand(settings.HostJasper),
 				h.ForceReinstallJasperCommand(settings),
@@ -513,7 +512,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 
 			creds, err := newMockCredentials()
 			require.NoError(t, err)
-			writeCredentialsCmd, err := h.bufferedWriteJasperCredentialsFilesCommands(settings.Splunk, creds)
+			writeCredentialsCmd, err := h.WriteJasperCredentialsFilesCommands(settings.Splunk, creds)
 			require.NoError(t, err)
 
 			setupSpawnHost, err := h.SpawnHostSetupCommands(settings)
@@ -522,8 +521,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 			markDone := h.MarkUserDataProvisioningDoneCommand()
 
 			var expectedCmds []string
-			expectedCmds = append(expectedCmds, checkRerun, setupUser, setupScript)
-			expectedCmds = append(expectedCmds, writeCredentialsCmd...)
+			expectedCmds = append(expectedCmds, checkRerun, setupUser, setupScript, writeCredentialsCmd)
 			expectedCmds = append(expectedCmds,
 				h.FetchJasperCommand(settings.HostJasper),
 				h.ForceReinstallJasperCommand(settings),
@@ -862,34 +860,6 @@ func TestJasperProcess(t *testing.T) {
 				},
 				Host: "localhost",
 			}, opts)
-		})
-	}
-}
-
-func TestBufferedWriteFileCommands(t *testing.T) {
-	for testName, testCase := range map[string]func(t *testing.T, path, content string){
-		"BufferedWriteFileCommandsUsesSingleCommandForShortFile": func(t *testing.T, path, content string) {
-			cmds := bufferedWriteFileCommands(path, content)
-			require.Len(t, cmds, 2)
-			assert.Equal(t, writeToFileCommand(path, content, true), cmds[0])
-			assert.Equal(t, fmt.Sprintf("chmod 666 %s", path), cmds[1])
-		},
-		"BufferedWriteFileCommandsUsesMultipleCommandsForLongFile": func(t *testing.T, path, content string) {
-			content = strings.Repeat(content, 1000)
-			cmds := bufferedWriteFileCommands(path, content)
-			require.NotZero(t, len(cmds))
-		},
-		"WriteToFileCommandRedirectsOnOverwrite": func(t *testing.T, path, content string) {
-			cmd := writeToFileCommand(path, content, true)
-			assert.Equal(t, fmt.Sprintf("echo -n '%s' > %s", content, path), cmd)
-		},
-		"WriteToFileCommandAppendsOnNoOverwrite": func(t *testing.T, path, content string) {
-			cmd := writeToFileCommand(path, content, false)
-			assert.Equal(t, fmt.Sprintf("echo -n '%s' >> %s", content, path), cmd)
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			testCase(t, "/path/to/file", "foobar")
 		})
 	}
 }

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/cloud/userdata"
 	serviceModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -339,7 +338,6 @@ func (c *Mock) GetClientURLs(context.Context, string) ([]string, error) {
 
 func (c *Mock) GetHostProvisioningOptions(context.Context, string, string) (*restmodel.APIHostProvisioningOptions, error) {
 	return &restmodel.APIHostProvisioningOptions{
-		Directive: string(userdata.ShellScript) + "/bin/bash",
-		Content:   "echo hello world",
+		Content: "echo hello world",
 	}, nil
 }

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -188,7 +188,7 @@ func (hc *DBHostConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error
 	return data, nil
 }
 
-func (hc *DBHostConnector) GenerateHostProvisioningOptions(ctx context.Context, hostID string) (string, error) {
+func (hc *DBHostConnector) GenerateHostProvisioningScript(ctx context.Context, hostID string) (string, error) {
 	if hostID == "" {
 		return "", gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -557,7 +557,7 @@ func findHostByIdWithOwner(c Connector, hostID string, user gimlet.User) (*host.
 	return host, nil
 }
 
-func (hc *MockHostConnector) GenerateHostProvisioningOptions(ctx context.Context, hostID string) (string, error) {
+func (hc *MockHostConnector) GenerateHostProvisioningScript(ctx context.Context, hostID string) (string, error) {
 	h, err := hc.FindHostById(hostID)
 	if err != nil {
 		return "", errors.Wrap(err, "finding host by ID")

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
-	"github.com/evergreen-ci/evergreen/cloud/userdata"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -189,22 +188,22 @@ func (hc *DBHostConnector) AggregateSpawnhostData() (*host.SpawnHostUsage, error
 	return data, nil
 }
 
-func (hc *DBHostConnector) GenerateHostProvisioningOptions(ctx context.Context, hostID string) (*userdata.Options, error) {
+func (hc *DBHostConnector) GenerateHostProvisioningOptions(ctx context.Context, hostID string) (string, error) {
 	if hostID == "" {
-		return nil, gimlet.ErrorResponse{
+		return "", gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    "cannot generate host provisioning script without a host ID",
 		}
 	}
 	h, err := host.FindOneByIdOrTag(hostID)
 	if err != nil {
-		return nil, gimlet.ErrorResponse{
+		return "", gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrapf(err, "finding host with ID '%s'", hostID).Error(),
 		}
 	}
 	if h == nil {
-		return nil, gimlet.ErrorResponse{
+		return "", gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("host with id '%s' not found", hostID),
 		}
@@ -213,25 +212,25 @@ func (hc *DBHostConnector) GenerateHostProvisioningOptions(ctx context.Context, 
 	env := evergreen.GetEnvironment()
 	creds, err := h.GenerateJasperCredentials(ctx, env)
 	if err != nil {
-		return nil, gimlet.ErrorResponse{
+		return "", gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrap(err, "generating Jasper credentials").Error(),
 		}
 	}
-	opts, err := h.ProvisioningUserData(env.Settings(), creds)
+	script, err := h.GenerateUserDataProvisioningScript(env.Settings(), creds)
 	if err != nil {
-		return nil, gimlet.ErrorResponse{
+		return "", gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrap(err, "generating host provisioning script").Error(),
 		}
 	}
 	if err := h.SaveJasperCredentials(ctx, env, creds); err != nil {
-		return nil, gimlet.ErrorResponse{
+		return "", gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrap(err, "saving Jasper credentials").Error(),
 		}
 	}
-	return opts, nil
+	return script, nil
 }
 
 // MockHostConnector is a struct that implements the Host related methods
@@ -558,16 +557,13 @@ func findHostByIdWithOwner(c Connector, hostID string, user gimlet.User) (*host.
 	return host, nil
 }
 
-func (hc *MockHostConnector) GenerateHostProvisioningOptions(ctx context.Context, hostID string) (*userdata.Options, error) {
+func (hc *MockHostConnector) GenerateHostProvisioningOptions(ctx context.Context, hostID string) (string, error) {
 	h, err := hc.FindHostById(hostID)
 	if err != nil {
-		return nil, errors.Wrap(err, "finding host by ID")
+		return "", errors.Wrap(err, "finding host by ID")
 	}
 	if h == nil {
-		return nil, errors.Errorf("host with id '%s' not found", hostID)
+		return "", errors.Errorf("host with id '%s' not found", hostID)
 	}
-	return &userdata.Options{
-		Directive: userdata.ShellScript + "/bin/bash",
-		Content:   fmt.Sprintf("echo hello world %s", hostID),
-	}, nil
+	return "echo hello world", nil
 }

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -403,22 +403,22 @@ func (s *HostConnectorSuite) TestCheckHostSecret() {
 	s.Equal(http.StatusOK, code)
 }
 
-func (s *HostConnectorSuite) TestGenerateHostProvisioningOptionsSucceeds() {
+func (s *HostConnectorSuite) TestGenerateHostProvisioningScriptSucceeds() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s.withNewEnvironment(ctx, func() {
-		script, err := s.conn.GenerateHostProvisioningOptions(ctx, "host1")
+		script, err := s.conn.GenerateHostProvisioningScript(ctx, "host1")
 		s.Require().NoError(err)
 		s.NotZero(script)
 	})
 
 }
 
-func (s *HostConnectorSuite) TestGenerateHostProvisioningOptionsFailsWithInvalidHostID() {
+func (s *HostConnectorSuite) TestGenerateHostProvisioningScriptFailsWithInvalidHostID() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s.withNewEnvironment(ctx, func() {
-		script, err := s.conn.GenerateHostProvisioningOptions(ctx, "foo")
+		script, err := s.conn.GenerateHostProvisioningScript(ctx, "foo")
 		s.Error(err)
 		s.Zero(script)
 	})

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -407,10 +407,9 @@ func (s *HostConnectorSuite) TestGenerateHostProvisioningOptionsSucceeds() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s.withNewEnvironment(ctx, func() {
-		opts, err := s.conn.GenerateHostProvisioningOptions(ctx, "host1")
+		script, err := s.conn.GenerateHostProvisioningOptions(ctx, "host1")
 		s.Require().NoError(err)
-		s.NotZero(opts.Content)
-		s.NotZero(opts.Directive)
+		s.NotZero(script)
 	})
 
 }
@@ -419,9 +418,9 @@ func (s *HostConnectorSuite) TestGenerateHostProvisioningOptionsFailsWithInvalid
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s.withNewEnvironment(ctx, func() {
-		opts, err := s.conn.GenerateHostProvisioningOptions(ctx, "foo")
+		script, err := s.conn.GenerateHostProvisioningOptions(ctx, "foo")
 		s.Error(err)
-		s.Zero(opts)
+		s.Zero(script)
 	})
 }
 

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -164,9 +164,9 @@ type Connector interface {
 	// Find a host by ID and queries for full running task
 	GetHostByIdWithTask(hostID string) (*host.Host, error)
 
-	// GenerateHostProvisioningOptions generates and returns the script to
+	// GenerateHostProvisioningScript generates and returns the script to
 	// provision the host given by host ID.
-	GenerateHostProvisioningOptions(ctx context.Context, hostID string) (string, error)
+	GenerateHostProvisioningScript(ctx context.Context, hostID string) (string, error)
 
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
 	NewIntentHost(context.Context, *restModel.HostRequestOptions, *user.DBUser, *evergreen.Settings) (*host.Host, error)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/cloud"
-	"github.com/evergreen-ci/evergreen/cloud/userdata"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/distro"
@@ -165,9 +164,9 @@ type Connector interface {
 	// Find a host by ID and queries for full running task
 	GetHostByIdWithTask(hostID string) (*host.Host, error)
 
-	// GenerateHostProvisioningOptions generates and returns the options to
+	// GenerateHostProvisioningOptions generates and returns the script to
 	// provision the host given by host ID.
-	GenerateHostProvisioningOptions(ctx context.Context, hostID string) (*userdata.Options, error)
+	GenerateHostProvisioningOptions(ctx context.Context, hostID string) (string, error)
 
 	// NewIntentHost is a method to insert an intent host given a distro and the name of a saved public key
 	NewIntentHost(context.Context, *restModel.HostRequestOptions, *user.DBUser, *evergreen.Settings) (*host.Host, error)

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -201,18 +201,17 @@ func (s *APIDispatcherSettings) ToService() (interface{}, error) {
 // APIBootstrapSettings is the model to be returned by the API whenever distro.BootstrapSettings are fetched
 
 type APIBootstrapSettings struct {
-	Method                  *string                 `json:"method"`
-	Communication           *string                 `json:"communication"`
-	ClientDir               *string                 `json:"client_dir"`
-	JasperBinaryDir         *string                 `json:"jasper_binary_dir"`
-	JasperCredentialsPath   *string                 `json:"jasper_credentials_path"`
-	ServiceUser             *string                 `json:"service_user"`
-	ShellPath               *string                 `json:"shell_path"`
-	RootDir                 *string                 `json:"root_dir"`
-	Env                     []APIEnvVar             `json:"env"`
-	ResourceLimits          APIResourceLimits       `json:"resource_limits"`
-	PreconditionScripts     []APIPreconditionScript `json:"precondition_scripts"`
-	FetchProvisioningScript bool                    `json:"fetch_provisioning_script"`
+	Method                *string                 `json:"method"`
+	Communication         *string                 `json:"communication"`
+	ClientDir             *string                 `json:"client_dir"`
+	JasperBinaryDir       *string                 `json:"jasper_binary_dir"`
+	JasperCredentialsPath *string                 `json:"jasper_credentials_path"`
+	ServiceUser           *string                 `json:"service_user"`
+	ShellPath             *string                 `json:"shell_path"`
+	RootDir               *string                 `json:"root_dir"`
+	Env                   []APIEnvVar             `json:"env"`
+	ResourceLimits        APIResourceLimits       `json:"resource_limits"`
+	PreconditionScripts   []APIPreconditionScript `json:"precondition_scripts"`
 }
 
 type APIEnvVar struct {
@@ -322,7 +321,6 @@ func (s *APIBootstrapSettings) BuildFromService(h interface{}) error {
 	s.ResourceLimits.NumProcesses = settings.ResourceLimits.NumProcesses
 	s.ResourceLimits.LockedMemoryKB = settings.ResourceLimits.LockedMemoryKB
 	s.ResourceLimits.VirtualMemoryKB = settings.ResourceLimits.VirtualMemoryKB
-	s.FetchProvisioningScript = settings.FetchProvisioningScript
 
 	return nil
 }
@@ -371,7 +369,6 @@ func (s *APIBootstrapSettings) ToService() (interface{}, error) {
 	settings.ResourceLimits.NumProcesses = s.ResourceLimits.NumProcesses
 	settings.ResourceLimits.LockedMemoryKB = s.ResourceLimits.LockedMemoryKB
 	settings.ResourceLimits.VirtualMemoryKB = s.ResourceLimits.VirtualMemoryKB
-	settings.FetchProvisioningScript = s.FetchProvisioningScript
 
 	return settings, nil
 }

--- a/rest/model/distro_test.go
+++ b/rest/model/distro_test.go
@@ -87,7 +87,6 @@ func TestDistroToService(t *testing.T) {
 					Script: ToStringPtr("echo foo"),
 				},
 			},
-			FetchProvisioningScript: true,
 		},
 		Note: ToStringPtr("note1"),
 		HomeVolumeSettings: APIHomeVolumeSettings{
@@ -123,7 +122,6 @@ func TestDistroToService(t *testing.T) {
 	require.Len(t, d.BootstrapSettings.PreconditionScripts, 1)
 	assert.Equal(t, FromStringPtr(apiDistro.BootstrapSettings.PreconditionScripts[0].Path), d.BootstrapSettings.PreconditionScripts[0].Path)
 	assert.Equal(t, FromStringPtr(apiDistro.BootstrapSettings.PreconditionScripts[0].Script), d.BootstrapSettings.PreconditionScripts[0].Script)
-	assert.True(t, apiDistro.BootstrapSettings.FetchProvisioningScript)
 	assert.Equal(t, FromStringPtr(apiDistro.Note), (d.Note))
 	assert.Equal(t, FromStringPtr(apiDistro.HomeVolumeSettings.FormatCommand), d.HomeVolumeSettings.FormatCommand)
 	assert.Equal(t, FromStringPtr(apiDistro.IcecreamSettings.SchedulerHost), d.IcecreamSettings.SchedulerHost)

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -3,7 +3,6 @@ package model
 import (
 	"time"
 
-	"github.com/evergreen-ci/evergreen/cloud/userdata"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
@@ -311,23 +310,7 @@ type APIOffboardUserResults struct {
 	TerminatedVolumes []string `json:"terminated_volumes"`
 }
 
-// APIHostProvisioningOptions represents script to provision a host that
-// is meant to be executed in a particular environment type.
+// APIHostProvisioningOptions represents script to provision a host.
 type APIHostProvisioningOptions struct {
-	Directive string `json:"directive"`
-	Content   string `json:"content"`
-}
-
-// BuildFromService converts from service level structs to an APIHost. It can
-// be called multiple times with different data types, a service layer host and
-// a service layer task, which are each loaded into the data structure.
-func (a *APIHostProvisioningOptions) BuildFromService(i interface{}) error {
-	switch opts := i.(type) {
-	case *userdata.Options:
-		a.Directive = string(opts.Directive)
-		a.Content = opts.Content
-		return nil
-	default:
-		return errors.Errorf("invalid type %T, expected user data options", i)
-	}
+	Content string `json:"content"`
 }

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -310,7 +310,7 @@ type APIOffboardUserResults struct {
 	TerminatedVolumes []string `json:"terminated_volumes"`
 }
 
-// APIHostProvisioningOptions represents script to provision a host.
+// APIHostProvisioningOptions represents the script to provision a host.
 type APIHostProvisioningOptions struct {
 	Content string `json:"content"`
 }

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1313,8 +1313,7 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 						"path": "/tmp/foo",
 						"script": "echo foo"
 						}
-					],
-					"fetch_provisioning_script": true
+					]
 				},
 				"clone_method": "legacy-ssh",
 				"ssh_key" : "New SSH Key",
@@ -1389,7 +1388,6 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 	s.Require().Len(apiDistro.BootstrapSettings.PreconditionScripts, 1)
 	s.Equal(model.ToStringPtr("/tmp/foo"), apiDistro.BootstrapSettings.PreconditionScripts[0].Path)
 	s.Equal(model.ToStringPtr("echo foo"), apiDistro.BootstrapSettings.PreconditionScripts[0].Script)
-	s.True(apiDistro.BootstrapSettings.FetchProvisioningScript)
 	s.Equal(model.ToStringPtr("~root"), apiDistro.User)
 	s.Equal(model.ToStringPtr("New SSH Key"), apiDistro.SSHKey)
 	s.Equal([]string{"~StrictHostKeyChecking=no", "~BatchMode=no", "~ConnectTimeout=10"}, apiDistro.SSHOptions)

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -577,16 +577,12 @@ func (rh *hostProvisioningOptionsGetHandler) Parse(ctx context.Context, r *http.
 }
 
 func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Responder {
-	opts, err := rh.sc.GenerateHostProvisioningOptions(ctx, rh.hostID)
+	script, err := rh.sc.GenerateHostProvisioningOptions(ctx, rh.hostID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
-	apiOpts := model.APIHostProvisioningOptions{}
-	if err := apiOpts.BuildFromService(opts); err != nil {
-		gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "failed to build host provisioning script options").Error(),
-		})
+	apiOpts := model.APIHostProvisioningOptions{
+		Content: script,
 	}
 	return gimlet.NewJSONResponse(apiOpts)
 }

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -577,7 +577,7 @@ func (rh *hostProvisioningOptionsGetHandler) Parse(ctx context.Context, r *http.
 }
 
 func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Responder {
-	script, err := rh.sc.GenerateHostProvisioningOptions(ctx, rh.hostID)
+	script, err := rh.sc.GenerateHostProvisioningScript(ctx, rh.hostID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -1004,7 +1004,6 @@ func TestHostProvisioningOptionsGetHandler(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.Status())
 		opts, ok := resp.Data().(model.APIHostProvisioningOptions)
 		require.True(t, ok)
-		assert.NotEmpty(t, opts.Directive)
 		assert.NotEmpty(t, opts.Content)
 	})
 	t.Run("FailsWithoutHostID", func(t *testing.T) {

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -939,12 +939,6 @@ Evergreen - Distros
             <input ng-disabled="readOnly" type="checkbox" ng-model="activeDistro.use_legacy_agent">
             Use legacy version of agent for this distro.
           </p>
-          <div ng-show="activeDistro.bootstrap_settings.method == 'user-data'">
-            <span class="distro-checkbox checkbox">
-              <input ng-disabled="readOnly" type="checkbox" ng-model="activeDistro.bootstrap_settings.fetch_provisioning_script" />
-              Fetch host provisioning script from Evergreen after user data has started
-            </span>
-          </div>
         </div>
         <div class="dropdown">
           <span class="distro-menu-title">Project Cloning Method:</span>

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -74,7 +74,7 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 		return
 	}
 
-	path := j.host.UserDataDoneFile()
+	path := j.host.UserDataProvisioningDoneFile()
 
 	if output, err := j.host.RunJasperProcess(ctx, j.env, &options.Create{
 		Args: []string{
@@ -121,7 +121,8 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 	}
 
 	if j.host.ProvisionOptions != nil && j.host.ProvisionOptions.SetupScript != "" {
-		// Don't wait on setup script to finish, particularly for hosts waiting on task data.
+		// Run the spawn host setup script in a separate job to avoid forcing
+		// this job to wait for task data to be loaded.
 		j.AddError(j.env.RemoteQueue().Put(ctx, NewHostSetupScriptJob(j.env, j.host, 0)))
 	}
 

--- a/units/provisioning_user_data_done_test.go
+++ b/units/provisioning_user_data_done_test.go
@@ -47,7 +47,7 @@ func TestUserDataDoneJob(t *testing.T) {
 			require.Len(t, mngr.Procs, 1)
 			info := mngr.Procs[0].Info(ctx)
 
-			path := h.UserDataDoneFile()
+			path := h.UserDataProvisioningDoneFile()
 
 			expectedCmd := []string{h.Distro.BootstrapSettings.ShellPath, "-l", "-c", fmt.Sprintf("ls %s", path)}
 			require.Equal(t, len(expectedCmd), len(info.Options.Args))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13427
https://jira.mongodb.org/browse/EVG-13479

* Remove the temporary distro setting for fetching the host provisioning script. All distros now fetch the host provisioning script from the app server.
* Rename some host methods for clarity since the provisioning script does not execute directly in user data.
* Clean up some user data provisioning code paths which are no longer needed for tidiness.