### PR TITLE
EVG-7460 add some logging for github errors

### DIFF
--- a/rest/data/patch_intent.go
+++ b/rest/data/patch_intent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/units"
@@ -35,6 +36,9 @@ func (p *DBPatchIntentConnector) AddPatchIntent(intent patch.Intent, queue amboy
 	}
 
 	if err := intent.Insert(); err != nil {
+		if db.IsDuplicateKey(err) {
+			return nil
+		}
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    "couldn't insert patch intent",


### PR DESCRIPTION
splunk logs for the date no longer exist so part of this is speculation

we can't be hitting a duplicate key for the _id because that's an object ID, so that leaves the only possible culprit being the github message ID. Github is probably not sending the same message ID twice, but we shouldn't necessarily rely on that. So my approach is to make the inserting a github intent part idempotent, which should get around a potential race in our code