### PR TITLE
EVG-13312 use transaction in finalizePatch

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -490,10 +490,10 @@ func (p *Patch) ConfigChanged(remotePath string) bool {
 }
 
 // SetActivated sets the patch to activated in the db, in a way that's safe for transactions.
-func (p *Patch) SetActivated(ctx context.Context, versionId string) error {
+func (p *Patch) SetActivated(versionId string) error {
 	p.Version = versionId
 	p.Activated = true
-	_, err := evergreen.GetEnvironment().DB().Collection(Collection).UpdateOne(ctx,
+	return UpdateOne(
 		bson.M{IdKey: p.Id},
 		bson.M{
 			"$set": bson.M{
@@ -502,7 +502,6 @@ func (p *Patch) SetActivated(ctx context.Context, versionId string) error {
 			},
 		},
 	)
-	return err
 }
 
 // SetActivation sets the patch to the desired activation state without

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -489,7 +489,7 @@ func (p *Patch) ConfigChanged(remotePath string) bool {
 	return false
 }
 
-// SetActivated sets the patch to activated in the db, in a way that's safe for transactions.
+// SetActivated sets the patch to activated in the db
 func (p *Patch) SetActivated(versionId string) error {
 	p.Version = versionId
 	p.Activated = true

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -489,11 +489,11 @@ func (p *Patch) ConfigChanged(remotePath string) bool {
 	return false
 }
 
-// SetActivated sets the patch to activated in the db
-func (p *Patch) SetActivated(versionId string) error {
+// SetActivated sets the patch to activated in the db, in a way that's safe for transactions.
+func (p *Patch) SetActivated(ctx context.Context, versionId string) error {
 	p.Version = versionId
 	p.Activated = true
-	return UpdateOne(
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).UpdateOne(ctx,
 		bson.M{IdKey: p.Id},
 		bson.M{
 			"$set": bson.M{
@@ -502,6 +502,7 @@ func (p *Patch) SetActivated(versionId string) error {
 			},
 		},
 	)
+	return err
 }
 
 // SetActivation sets the patch to the desired activation state without

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/mongo"
 	mgobson "gopkg.in/mgo.v2/bson"
 )
 
@@ -408,23 +409,42 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 			},
 		)
 	}
+	mongoClient := evergreen.GetEnvironment().Client()
+	session, err := mongoClient.StartSession()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to start session")
+	}
+	defer session.EndSession(ctx)
 
-	if err = patchVersion.Insert(); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if err = intermediateProject.Insert(); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if err = buildsToInsert.InsertMany(ctx, false); err != nil {
-		return nil, errors.Wrapf(err, "error inserting builds for version '%s'", patchVersion.Id)
-	}
-	if err = tasksToInsert.InsertUnordered(ctx); err != nil {
-		return nil, errors.Wrapf(err, "error inserting tasks for version '%s'", patchVersion.Id)
+	txFunc := func(sessCtx mongo.SessionContext) (interface{}, error) {
+		db := evergreen.GetEnvironment().DB()
+		_, err = db.Collection(VersionCollection).InsertOne(ctx, patchVersion)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error inserting version '%s'", patchVersion.Id)
+		}
+		_, err = db.Collection(ParserProjectCollection).InsertOne(ctx, intermediateProject)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error inserting parser project for version '%s'", patchVersion.Id)
+		}
+		if err = buildsToInsert.InsertMany(ctx, false); err != nil {
+			return nil, errors.Wrapf(err, "error inserting builds for version '%s'", patchVersion.Id)
+		}
+		if err = tasksToInsert.InsertUnordered(ctx); err != nil {
+			return nil, errors.Wrapf(err, "error inserting tasks for version '%s'", patchVersion.Id)
+		}
+		if err = p.SetActivated(ctx, patchVersion.Id); err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return nil, err
 	}
 
-	if err = p.SetActivated(patchVersion.Id); err != nil {
-		return nil, errors.WithStack(err)
+	_, err = session.WithTransaction(ctx, txFunc)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to archive tasks")
 	}
+	p.Activated = true
+	p.Version = patchVersion.Id
+
 	return patchVersion, nil
 }
 

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -437,7 +437,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 
 	_, err = session.WithTransaction(ctx, txFunc)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to archive tasks")
+		return nil, errors.Wrap(err, "unable to finalize patch")
 	}
 	if err = p.SetActivated(patchVersion.Id); err != nil {
 		return nil, errors.WithStack(err)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -432,9 +432,6 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		if err = tasksToInsert.InsertUnordered(ctx); err != nil {
 			return nil, errors.Wrapf(err, "error inserting tasks for version '%s'", patchVersion.Id)
 		}
-		if err = p.SetActivated(ctx, patchVersion.Id); err != nil {
-			return nil, errors.WithStack(err)
-		}
 		return nil, err
 	}
 
@@ -442,8 +439,9 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to archive tasks")
 	}
-	p.Activated = true
-	p.Version = patchVersion.Id
+	if err = p.SetActivated(patchVersion.Id); err != nil {
+		return nil, errors.WithStack(err)
+	}
 
 	return patchVersion, nil
 }


### PR DESCRIPTION
A commit queue version was created, but no builds/tasks were created with it, the patch was never marked as Activated, etc. This was a pretty frustrating bug, because this commit blocked the queue for a quite a while, and would be a hard state for us to write an unstick function for, since it's not a consistent state. From the splunk logs, it looks like we deployed or bounced, and this hit in between creating the parser project and creating the builds. A transaction would prevent this inconsistent state from occurring.