### PR TITLE
EVG-13406 check for Not Found in manifest error message

### DIFF
--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -196,7 +196,7 @@ func GetGithubFile(ctx context.Context, oauthToken, owner, repo, path, hash stri
 			return nil, parseGithubErrorResponse(resp)
 		}
 	} else {
-		errMsg := fmt.Sprintf("nil response from github for '%s/%s' for '%s'", owner, repo, path)
+		errMsg := fmt.Sprintf("nil response from github for '%s/%s' for '%s': %v", owner, repo, path, err)
 		grip.Error(errMsg)
 		return nil, APIResponseError{errMsg}
 	}
@@ -323,7 +323,7 @@ func GetBranchEvent(ctx context.Context, oauthToken, repoOwner, repo, branch str
 			return nil, parseGithubErrorResponse(resp)
 		}
 	} else {
-		errMsg := fmt.Sprintf("error querying  '%s/%s': branch: '%s': %v", repoOwner, repo, branch, err)
+		errMsg := fmt.Sprintf("nil response from github for '%s/%s': branch: '%s': %v", repoOwner, repo, branch, err)
 		grip.Error(errMsg)
 		return nil, APIResponseError{errMsg}
 	}


### PR DESCRIPTION
In the previous fix for this, we assume that an APIRequestError has been returned.
https://github.com/evergreen-ci/evergreen/blob/7f3ad0d051fdb88d1b414d9c033c7866a5afcc31/service/api_plugin_manifest.go#L59
However, in the code itself, we hit this error, which is of the form APIResponseError, which has only a message.
https://github.com/evergreen-ci/evergreen/blob/7f3ad0d051fdb88d1b414d9c033c7866a5afcc31/thirdparty/github.go#L155
Really, the response is likely not nil, and if we correctly ran parseGithubErrorResponse(resp) then we would get a format that's more readable, and that the existing error check could understand. For simplicity, I moved this check into the existing initial `resp != nil` check for github functions.