### PR TITLE
EVG-13387 use comment body as commit message for pr commit queue

### DIFF
--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -32,7 +32,6 @@ type CommitQueueItem struct {
 	Version         string    `bson:"version,omitempty"`
 	EnqueueTime     time.Time `bson:"enqueue_time"`
 	Modules         []Module  `bson:"modules"`
-	TitleOverride   string    `bson:"title_override"`
 	MessageOverride string    `bson:"message_override"`
 }
 

--- a/model/commitqueue/github_merge_generic.go
+++ b/model/commitqueue/github_merge_generic.go
@@ -91,9 +91,6 @@ func (s *GithubMergePR) Send() (err error) {
 			// if the merge method is to add a merge commit, send no title to the github API so that they use the default merge commit title
 			title = ""
 		}
-		if pr.TitleOverride != "" {
-			title = pr.TitleOverride
-		}
 		mergeOpts := &github.PullRequestOptions{
 			MergeMethod: s.MergeMethod,
 			CommitTitle: title,

--- a/model/event/commit_queue_event.go
+++ b/model/event/commit_queue_event.go
@@ -25,7 +25,6 @@ type PRInfo struct {
 	Ref             string `bson:"ref"`
 	PRNum           int    `bson:"pr_number"`
 	CommitTitle     string `bson:"commit_title"`
-	TitleOverride   string `bson:"title_override"`
 	MessageOverride string `bson:"message_override"`
 }
 

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -697,7 +697,7 @@ func IsMailboxDiff(patchDiff string) bool {
 	return strings.HasPrefix(patchDiff, "From ")
 }
 
-func MakeNewMergePatch(pr *github.PullRequest, projectID, alias, titleOverride string) (*Patch, error) {
+func MakeNewMergePatch(pr *github.PullRequest, projectID, alias string) (*Patch, error) {
 	if pr.User == nil {
 		return nil, errors.New("pr contains no user")
 	}
@@ -716,17 +716,12 @@ func MakeNewMergePatch(pr *github.PullRequest, projectID, alias, titleOverride s
 		return nil, errors.New("pr contains no base branch data")
 	}
 
-	title := pr.GetTitle()
-	if titleOverride != "" {
-		title = titleOverride
-	}
-
 	patchDoc := &Patch{
 		Id:          id,
 		Project:     projectID,
 		Author:      u.Id,
 		Githash:     pr.Base.GetSHA(),
-		Description: fmt.Sprintf("'%s' commit queue merge (PR #%d) by %s: %s (%s)", pr.Base.Repo.GetFullName(), pr.GetNumber(), u.Username(), title, pr.GetHTMLURL()),
+		Description: fmt.Sprintf("'%s' commit queue merge (PR #%d) by %s: %s (%s)", pr.Base.Repo.GetFullName(), pr.GetNumber(), u.Username(), pr.GetTitle(), pr.GetHTMLURL()),
 		CreateTime:  time.Now(),
 		Status:      evergreen.PatchCreated,
 		Alias:       alias,

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -162,7 +162,7 @@ func (s *patchSuite) TestMakeMergePatch() {
 		MergeCommitSHA: github.String("abcdef"),
 	}
 
-	p, err := MakeNewMergePatch(pr, "mci", evergreen.CommitQueueAlias, "")
+	p, err := MakeNewMergePatch(pr, "mci", evergreen.CommitQueueAlias)
 	s.NoError(err)
 	s.Equal("mci", p.Project)
 	s.Equal(evergreen.PatchCreated, p.Status)

--- a/rest/model/commit_queue_test.go
+++ b/rest/model/commit_queue_test.go
@@ -78,16 +78,17 @@ func TestParseGitHubComment(t *testing.T) {
 	data = ParseGitHubComment(comment)
 	assert.Len(data.Modules, 0)
 
-	comment = `evergreen merge --title "!$&*);" -m "a     b"`
-	data = ParseGitHubComment(comment)
-	assert.Equal("!$&*);", data.TitleOverride)
-	assert.Equal("a     b", data.MessageOverride)
+	comment = `evergreen merge --unknown-option blah_blah --module module1:1234
 
-	comment = `evergreen merge --unknown-option blah_blah --module module1:1234 -t "my title here" --message "hello"`
+
+this is my commit message
+some more lines
+    extra whitespace  `
 	data = ParseGitHubComment(comment)
 	assert.Len(data.Modules, 1)
 	assert.Equal(ToStringPtr("module1"), data.Modules[0].Module)
 	assert.Equal(ToStringPtr("1234"), data.Modules[0].Issue)
-	assert.Equal("my title here", data.TitleOverride)
-	assert.Equal("hello", data.MessageOverride)
+	assert.Equal(`this is my commit message
+some more lines
+    extra whitespace  `, data.MessageOverride)
 }

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -565,7 +565,6 @@ func (gh *githubHookApi) commitQueueEnqueue(ctx context.Context, event *github.I
 	}
 	item := restModel.APICommitQueueItem{
 		Issue:           restModel.ToStringPtr(strconv.Itoa(PRNum)),
-		TitleOverride:   &cqInfo.TitleOverride,
 		MessageOverride: &cqInfo.MessageOverride,
 		Modules:         cqInfo.Modules,
 	}

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -241,7 +241,7 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 		return
 	}
 
-	patchDoc, err := patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias, nextItem.TitleOverride)
+	patchDoc, err := patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias)
 	if err != nil {
 		j.logError(err, "can't make patch", nextItem)
 		j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't make patch", ""))
@@ -323,7 +323,7 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 		return
 	}
 
-	err = subscribeGitHubPRs(pr, modulePRs, projectRef, v.Id, nextItem.TitleOverride, nextItem.MessageOverride)
+	err = subscribeGitHubPRs(pr, modulePRs, projectRef, v.Id, nextItem.MessageOverride)
 	if err != nil {
 		j.logError(err, "can't subscribe for PR merge", nextItem)
 		j.dequeue(cq, nextItem)
@@ -546,7 +546,7 @@ func sendCommitQueueGithubStatus(env evergreen.Environment, pr *github.PullReque
 	return nil
 }
 
-func subscribeGitHubPRs(pr *github.PullRequest, modulePRs []*github.PullRequest, projectRef *model.ProjectRef, patchID, titleOverride, messageOverride string) error {
+func subscribeGitHubPRs(pr *github.PullRequest, modulePRs []*github.PullRequest, projectRef *model.ProjectRef, patchID, messageOverride string) error {
 	prs := make([]event.PRInfo, 0, len(modulePRs)+1)
 	for _, modulePR := range modulePRs {
 		prs = append(prs, event.PRInfo{
@@ -564,7 +564,6 @@ func subscribeGitHubPRs(pr *github.PullRequest, modulePRs []*github.PullRequest,
 		PRNum:           *pr.Number,
 		CommitTitle:     fmt.Sprintf("%s (#%d)", *pr.Title, *pr.Number),
 		MessageOverride: messageOverride,
-		TitleOverride:   titleOverride,
 	})
 
 	mergeSubscriber := event.NewGithubMergeSubscriber(event.GithubMergeSubscriber{

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -128,7 +128,7 @@ func (s *commitQueueSuite) TestNewCommitQueueJob() {
 
 func (s *commitQueueSuite) TestSubscribeMerge() {
 	s.NoError(db.ClearCollections(event.SubscriptionsCollection))
-	s.NoError(subscribeGitHubPRs(s.pr, nil, s.projectRef, "abcdef", "", ""))
+	s.NoError(subscribeGitHubPRs(s.pr, nil, s.projectRef, "abcdef", ""))
 
 	selectors := []event.Selector{
 		event.Selector{


### PR DESCRIPTION
I am breaking backwards compatibility by removing a field, but I don't think anyone is using this