### PR TITLE
EVG-13446 only run test-cloud on ubuntu

### DIFF
--- a/cloud/docker_integration_test.go
+++ b/cloud/docker_integration_test.go
@@ -25,8 +25,7 @@ type DockerIntegrationSuite struct {
 
 func TestDockerIntegrationSuite(t *testing.T) {
 	dns := os.Getenv("DOCKER_HOST")
-	isRunningOnDocker := os.Getenv("IS_DOCKER")
-	if dns == "" || isRunningOnDocker == "true" {
+	if dns == "" {
 		t.Skip()
 	}
 	settings := testutil.TestConfig()

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -214,7 +214,6 @@ functions:
         GOOS: ${goos}
         GOPATH: ${workdir}/gopath
         GOROOT: ${goroot}
-        IS_DOCKER: ${is_docker}
         KARMA_REPORTER: junit
         NODE_BIN_PATH: ${nodebin}
         RACE_DETECTOR: ${race_detector}
@@ -416,7 +415,7 @@ tasks:
     tags: ["db", "test"]
     name: test-db
   - <<: *run-go-test-suite-with-docker
-    tags: ["db", "test"]
+    tags: ["db"]
     name: test-cloud
   - <<: *run-go-test-suite
     tags: ["nodb", "test"]
@@ -606,6 +605,7 @@ buildvariants:
       - name: "js-test"
       - name: "verify-agent-version-update"
       - name: "docker-cleanup"
+      - name: test-cloud
 
   - name: ubuntu1604-docker
     display_name: Ubuntu 16.04 (Docker)
@@ -620,7 +620,6 @@ buildvariants:
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
       test_timeout: 15m
       nodebin: /opt/node/bin
-      is_docker: "true"
     tasks:
       - name: "dist"
       - name: ".smoke"


### PR DESCRIPTION
The problem in the ticket is that the security group for the host running docker does not allow communication from static hosts and probably shouldn't. I decided to only run test-cloud on ubuntu since we don't need to test our cloud provider code on anything other than the architecture the servers are running on. I could have split off the docker integration test into a separate package but that would have required making a bunch of random things public