### PR TITLE
EVG-12791 don't mark tasks generated if errors

### DIFF
--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -60,20 +60,10 @@ func NewGenerateTasksJob(id string, ts string) amboy.Job {
 func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	start := time.Now()
 	if t.GeneratedTasks {
-		grip.Debug(message.Fields{
-			"message": "attempted to generate tasks, but generator already ran for this task",
-			"task":    t.Id,
-			"version": t.Version,
-		})
 		return mongo.ErrNoDocuments
 	}
 	if t.Status != evergreen.TaskStarted {
-		grip.Debug(message.Fields{
-			"message": "task is not running, not generating tasks",
-			"task":    t.Id,
-			"version": t.Version,
-		})
-		return nil
+		return errors.New("task is not running, not generating tasks")
 	}
 
 	v, err := model.VersionFindOneId(t.Version)
@@ -265,10 +255,6 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 
 	err = j.generate(ctx, t)
 	shouldNoop := adb.ResultsNotFound(err) || db.IsDuplicateKey(err)
-	if err != nil && !shouldNoop {
-		j.AddError(err)
-	}
-	j.AddError(task.MarkGeneratedTasks(j.TaskID, err))
 
 	grip.InfoWhen(err == nil, message.Fields{
 		"message":       "generate.tasks finished",
@@ -294,6 +280,12 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 		"job":           j.ID(),
 		"version":       t.Version,
 	}))
+
+	if err != nil && !shouldNoop {
+		j.AddError(err)
+		return
+	}
+	j.AddError(task.MarkGeneratedTasks(j.TaskID, err))
 }
 
 func parseProjectsAsString(jsonStrings []string) ([]model.GeneratedProject, error) {


### PR DESCRIPTION
What happened is that the first execution got terminated externally after the generate.tasks command ran. The timing was just right so that the generate job on the server hit the "task is not running, not generating tasks." However this still marks the task as having run its generators, so on the second execution we noop.

This pr changes this scenario to be an error (I believe this is ok to error, a bit of context on what was here previously in https://github.com/evergreen-ci/evergreen/pull/2684). Also don't mark the generators as having run if there are errors