### PR TITLE
EVG-7492 disable merge method for CLI commit queues

### DIFF
--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -643,13 +643,13 @@ Evergreen Projects
           <div ng-show="settingsFormData.commit_queue.enabled">
             <div>
               <div>
-                <label for="mergeMethodSelect"> Merge Method: </label>
-                <select id="mergeMethodSelect" ng-model="settingsFormData.commit_queue.merge_method" ng-options="option for option in validMergeMethods"></select>
-              </div>
-              <div>
                 <label for="PatchTypeSelect"> Patch Type: </label>
                 <select id="PatchTypeSelect" ng-model="settingsFormData.commit_queue.patch_type" ng-options="option for option in validPatchTypes"></select>
                 <div class="muted small">Patch Type is PR for merging GitHub PRs or CLI for merging patches submitted through Evergreen's CLI.</div>
+              </div>
+              <div>
+                <label for="mergeMethodSelect"> Merge Method: </label>
+                <select id="mergeMethodSelect" ng-disabled="settingsFormData.commit_queue.patch_type!=='PR'" ng-model="settingsFormData.commit_queue.merge_method" ng-options="option for option in validMergeMethods"></select>
               </div>
             </div>
             <div class="form-group">


### PR DESCRIPTION
Since we create our own commits with the changes in a CLI queue, handling the 3 merge methods would be different than how we handle them for merging PRs so I'm not implementing that. Also swapped the position of the queue type and merge method to better represent how the settings are hierarchically 