### PR TITLE
EVG-13418 keep display task in sync when updating blocked dependencies

### DIFF
--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -511,5 +511,14 @@ func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.T
 		}
 	}
 
+	// also update the display task status in case it is out of date
+	if t.IsPartOfDisplay() {
+		parent, err := t.GetDisplayTask()
+		catcher.Add(err)
+		if parent != nil {
+			catcher.Add(UpdateDisplayTask(parent))
+		}
+	}
+
 	return catcher.Resolve()
 }


### PR DESCRIPTION
The general problem was already fixed by https://github.com/evergreen-ci/evergreen/commit/f30bef32b4c99a24b4cd9441e7b256237f764c84 but this is an edge case that was not handled. If you have a generator create only execution tasks that would be blocked eventually without anything else in the display task running, we won't run the logic added in that commit. In this case the generator adds tasks that would be blocked due to a failure from outside the display task. This adds an extra check in a logical spot (where we check dependencies in the task queue).

I kind of hate this approach though. It also adds a small amount of work in a code path that's called a lot. Probably won't noticeably degrade performance at all, but it can add up. Suggestions of alternate approaches are welcome and I'll continue thinking on this