### PR TITLE
EVG-12872 really remove old backport specification

### DIFF
--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -43,7 +43,6 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		Description       string             `json:"desc"`
 		Project           string             `json:"project"`
 		BackportInfo      patch.BackportInfo `json:"backport_info"`
-		BackportOf        string             `json:"backport_of"`
 		PatchBytes        []byte             `json:"patch_bytes"`
 		Githash           string             `json:"githash"`
 		Parameters        []patch.Parameter  `json:"parameters"`
@@ -93,11 +92,6 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if data.Alias == evergreen.CommitQueueAlias && len(patchString) != 0 && !patch.IsMailboxDiff(patchString) {
-		as.LoggedError(w, r, http.StatusBadRequest, cliOutOfDateError)
-		return
-	}
-
-	if len(data.BackportOf) > 0 && len(data.BackportInfo.PatchID) == 0 {
 		as.LoggedError(w, r, http.StatusBadRequest, cliOutOfDateError)
 		return
 	}


### PR DESCRIPTION
It's been a while that users submitting backports with an old CLI get an error. It _should_ be safe to silently ignore the backport request now, though we'll never know... 
At this point the alternative is to leave it in forever. I think if it's not removed it will become read-only code: we won't remember what the `data.BackportOf` field meant.