### PR TITLE
EVG-12964 remove support for unconfigured distro regions

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -265,8 +265,6 @@ const (
 
 	CloneMethodLegacySSH = "legacy-ssh"
 	CloneMethodOAuth     = "oauth"
-
-	unconfiguredAmi = "ami-1234"
 )
 
 // validBootstrapMethods includes all recognized bootstrap methods.
@@ -571,11 +569,6 @@ func (d *Distro) GetProviderSettingByRegion(region string) (*birch.Document, err
 	for _, s := range d.ProviderSettingsList {
 		if val, ok := s.Lookup("region").StringValueOK(); ok {
 			if val == region {
-				// TODO: remove once the build script has configured all AMIs.
-				ami, _ := s.Lookup("ami").StringValueOK()
-				if ami == unconfiguredAmi {
-					return nil, errors.Errorf("distro '%s' has unfinished settings for region '%s'", d.Id, region)
-				}
 				return s, nil
 			}
 		}
@@ -597,11 +590,6 @@ func (d *Distro) GetRegionsList(allowedRegions []string) []string {
 		}
 		// admins don't allow this region
 		if !utility.StringSliceContains(allowedRegions, region) {
-			continue
-		}
-		// TODO: remove once the build script has configured all AMIs.
-		ami, _ := doc.Lookup("ami").StringValueOK()
-		if ami == unconfiguredAmi {
 			continue
 		}
 		regions = append(regions, region)


### PR DESCRIPTION
To begin with, regions were added to all distros with a dummy "ami-1234" AMI. Now that build's scripts are working again, all distros that can support multiple regions have been updated with real AMIs, and all dummy AMIs have been removed, so this is dead code.