### PR TITLE
EVG-12962 give loop more time to exit

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -188,19 +188,18 @@ func (s *AgentSuite) TestAgentEndTaskShouldExit() {
 
 func (s *AgentSuite) TestNextTaskConflict() {
 	s.mockCommunicator.NextTaskShouldConflict = true
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	errs := make(chan error, 1)
 	go func() {
 		errs <- s.a.loop(ctx)
 	}()
-	time.Sleep(time.Millisecond)
 	select {
 	case err := <-errs:
 		s.NoError(err)
-	default:
-		// pass
+	case <-ctx.Done():
+		s.FailNow(ctx.Err().Error())
 	}
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -191,10 +191,16 @@ func (s *AgentSuite) TestNextTaskConflict() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	agentCtx, agentCancel := context.WithCancel(ctx)
+	defer agentCancel()
+
 	errs := make(chan error, 1)
 	go func() {
-		errs <- s.a.loop(ctx)
+		errs <- s.a.loop(agentCtx)
 	}()
+	time.Sleep(1 * time.Second)
+	agentCancel()
+
 	select {
 	case err := <-errs:
 		s.NoError(err)


### PR DESCRIPTION
[Jira ticket](https://jira.mongodb.org/browse/EVG-12962)

The test currently gives the agent loop a millisecond to exit. Even if the loop goroutine has not yet run we will go on with the next test which races on the agent struct we're using in the loop goroutine this test created.
The best thing to do would be to wait indefinitely for an (hopefully nil) error back from loop, but that could block. Instead, settle for giving it up to 5 seconds to return, returning earlier if loop returns before the deadline.