### PR TITLE
EVG-13573 filter tasks/variants for waterfall checks

### DIFF
--- a/model/build/build.go
+++ b/model/build/build.go
@@ -55,6 +55,9 @@ type Build struct {
 	PredictedMakespan   time.Duration `bson:"predicted_makespan" json:"predicted_makespan,omitempty"`
 	ActualMakespan      time.Duration `bson:"actual_makespan" json:"actual_makespan,omitempty"`
 
+	// The status of the subset of the build that's used for github checks
+	GithubCheckStatus string `bson:"github_check_status,omitempty" json:"github_check_status,omitempty"`
+
 	// build requester - this is used to help tell the
 	// reason this build was created. e.g. it could be
 	// because the repotracker requested it (via tracking the
@@ -83,7 +86,7 @@ func (b *Build) IsFinished() bool {
 // one of the statuses in IsFinishedTaskStatus or the task is considered blocked
 //
 // returns boolean to indicate if tasks are complete, string with either BuildFailed or
-// BuildSucceded. The string is only valid when the boolean is true
+// BuildSucceeded. The string is only valid when the boolean is true
 func (b *Build) AllUnblockedTasksFinished(tasks []task.Task) (bool, string, error) {
 	if !b.Activated {
 		return false, b.Status, nil
@@ -167,6 +170,17 @@ func (b *Build) UpdateStatus(status string) error {
 	return UpdateOne(
 		bson.M{IdKey: b.Id},
 		bson.M{"$set": bson.M{StatusKey: status}},
+	)
+}
+
+func (b *Build) UpdateGithubCheckStatus(status string) error {
+	if b.GithubCheckStatus == status {
+		return nil
+	}
+	b.GithubCheckStatus = status
+	return UpdateOne(
+		bson.M{IdKey: b.Id},
+		bson.M{"$set": bson.M{GithubCheckStatusKey: status}},
 	)
 }
 

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -27,6 +27,7 @@ var (
 	BuildVariantKey        = bsonutil.MustHaveTag(Build{}, "BuildVariant")
 	BuildNumberKey         = bsonutil.MustHaveTag(Build{}, "BuildNumber")
 	StatusKey              = bsonutil.MustHaveTag(Build{}, "Status")
+	GithubCheckStatusKey   = bsonutil.MustHaveTag(Build{}, "GithubCheckStatus")
 	ActivatedKey           = bsonutil.MustHaveTag(Build{}, "Activated")
 	ActivatedByKey         = bsonutil.MustHaveTag(Build{}, "ActivatedBy")
 	ActivatedTimeKey       = bsonutil.MustHaveTag(Build{}, "ActivatedTime")

--- a/model/event/event_registry.go
+++ b/model/event/event_registry.go
@@ -27,6 +27,7 @@ func init() {
 	registry.AddType(ResourceTypeDistro, distroEventDataFactory)
 	registry.AddType(ResourceTypeUser, userEventDataFactory)
 	registry.AllowSubscription(ResourceTypeBuild, BuildStateChange)
+	registry.AllowSubscription(ResourceTypeBuild, BuildGithubCheckFinished)
 
 	registry.AddType(ResourceTypeCommitQueue, commitQueueEventDataFactory)
 	registry.AllowSubscription(ResourceTypeCommitQueue, CommitQueueStartTest)

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -63,6 +63,7 @@ const (
 	ObjectPatch                     = "patch"
 
 	TriggerOutcome                   = "outcome"
+	TriggerGithubCheckOutcome        = "github-check-outcome"
 	TriggerFailure                   = "failure"
 	TriggerSuccess                   = "success"
 	TriggerRegression                = "regression"
@@ -509,8 +510,8 @@ func NewSubscriptionByID(resourceType, trigger, id string, sub Subscriber) Subsc
 	}
 }
 
-func NewVersionOutcomeSubscription(id string, sub Subscriber) Subscription {
-	subscription := NewSubscriptionByID(ResourceTypeVersion, TriggerOutcome, id, sub)
+func NewVersionGithubCheckOutcomeSubscription(id string, sub Subscriber) Subscription {
+	subscription := NewSubscriptionByID(ResourceTypeVersion, TriggerGithubCheckOutcome, id, sub)
 	subscription.LastUpdated = time.Now()
 	return subscription
 }
@@ -596,6 +597,21 @@ func NewExpiringBuildOutcomeSubscriptionByVersion(versionID string, sub Subscrib
 	return Subscription{
 		ResourceType: ResourceTypeBuild,
 		Trigger:      TriggerOutcome,
+		Selectors: []Selector{
+			{
+				Type: SelectorInVersion,
+				Data: versionID,
+			},
+		},
+		Subscriber:  sub,
+		LastUpdated: time.Now(),
+	}
+}
+
+func NewGithubCheckBuildOutcomeSubscriptionByVersion(versionID string, sub Subscriber) Subscription {
+	return Subscription{
+		ResourceType: ResourceTypeBuild,
+		Trigger:      TriggerGithubCheckOutcome,
 		Selectors: []Selector{
 			{
 				Type: SelectorInVersion,

--- a/model/event/version_event.go
+++ b/model/event/version_event.go
@@ -10,6 +10,7 @@ import (
 func init() {
 	registry.AddType(ResourceTypeVersion, versionEventDataFactory)
 	registry.AllowSubscription(ResourceTypeVersion, VersionStateChange)
+	registry.AllowSubscription(ResourceTypeVersion, VersionGithubCheckFinished)
 }
 
 func versionEventDataFactory() interface{} {
@@ -17,12 +18,14 @@ func versionEventDataFactory() interface{} {
 }
 
 const (
-	ResourceTypeVersion = "VERSION"
-	VersionStateChange  = "STATE_CHANGE"
+	ResourceTypeVersion        = "VERSION"
+	VersionStateChange         = "STATE_CHANGE"
+	VersionGithubCheckFinished = "GITHUB_CHECK_FINISHED"
 )
 
 type VersionEventData struct {
-	Status string `bson:"status,omitempty" json:"status,omitempty"`
+	Status            string `bson:"status,omitempty" json:"status,omitempty"`
+	GithubCheckStatus string `bson:"github_check_status,omitempty" json:"github_check_status,omitempty"`
 }
 
 func LogVersionStateChangeEvent(id, newStatus string) {
@@ -33,6 +36,27 @@ func LogVersionStateChangeEvent(id, newStatus string) {
 		EventType:    VersionStateChange,
 		Data: &VersionEventData{
 			Status: newStatus,
+		},
+	}
+
+	logger := NewDBEventLogger(AllLogCollection)
+	if err := logger.LogEvent(&event); err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"resource_type": ResourceTypeVersion,
+			"message":       "error logging event",
+			"source":        "event-log-fail",
+		}))
+	}
+}
+
+func LogVersionGithubCheckFinishedEvent(id, newStatus string) {
+	event := EventLogEntry{
+		Timestamp:    time.Now().Truncate(0).Round(time.Millisecond),
+		ResourceId:   id,
+		ResourceType: ResourceTypeVersion,
+		EventType:    VersionGithubCheckFinished,
+		Data: &VersionEventData{
+			GithubCheckStatus: newStatus,
 		},
 	}
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -263,7 +263,7 @@ func markVersionCompleted(versionId string, finishTime time.Time, updates *Statu
 		updates.VersionNewStatus = versionStatusFromTasks
 		event.LogVersionStateChangeEvent(versionId, status)
 	}
-	if checkGithubStatus && activeBuilds > 0 && buildsWithGithubCheckTasksComplete == len(builds) {
+	if checkGithubStatus && activeBuilds > 0 && buildsWithGithubCheckTasksComplete >= activeBuilds {
 		event.LogVersionGithubCheckFinishedEvent(versionId, githubCheckStatusFromTasks)
 	}
 	if !finished {

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -226,36 +226,32 @@ func aliasesMatchingGitTag(a ProjectAliases, tag string) (ProjectAliases, error)
 	return res, nil
 }
 
-func (a ProjectAliases) HasMatchingVariant(variant string, variantTags []string) (bool, error) {
+func (a ProjectAliases) AliasesMatchingVariant(variant string, variantTags []string) (ProjectAliases, error) {
+	res := []ProjectAlias{}
 	for _, alias := range a {
 		variantRegex, err := regexp.Compile(alias.Variant)
 		if err != nil {
-			return false, errors.Wrapf(err, "unable to compile regex %s", variantRegex)
+			return nil, errors.Wrapf(err, "unable to compile regex %s", variantRegex)
 		}
 		if isValidRegexOrTag(variant, alias.Variant, variantTags, alias.VariantTags, variantRegex) {
-			return true, nil
+			res = append(res, alias)
 		}
 	}
-	return false, nil
+	return res, nil
 }
 
-func (a ProjectAliases) HasMatchingTask(variant string, variantTags []string, t *ProjectTask) (bool, error) {
+// HasMatchingTask assumes that the aliases given already match the preferred variant.
+func (a ProjectAliases) HasMatchingTask(t *ProjectTask) (bool, error) {
 	if t == nil {
 		return false, errors.New("no task found")
 	}
 	for _, alias := range a {
-		variantRegex, err := regexp.Compile(alias.Variant)
+		taskRegex, err := regexp.Compile(alias.Task)
 		if err != nil {
-			return false, errors.Wrapf(err, "unable to compile regex %s", variantRegex)
+			return false, errors.Wrapf(err, "unable to compile regex %s", taskRegex)
 		}
-		if isValidRegexOrTag(variant, alias.Variant, variantTags, alias.VariantTags, variantRegex) {
-			taskRegex, err := regexp.Compile(alias.Task)
-			if err != nil {
-				return false, errors.Wrapf(err, "unable to compile regex %s", taskRegex)
-			}
-			if isValidRegexOrTag(t.Name, alias.Task, t.Tags, alias.TaskTags, taskRegex) {
-				return true, nil
-			}
+		if isValidRegexOrTag(t.Name, alias.Task, t.Tags, alias.TaskTags, taskRegex) {
+			return true, nil
 		}
 	}
 	return false, nil

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -253,65 +253,74 @@ func TestMatching(t *testing.T) {
 		{Alias: "four", VariantTags: []string{"variantTag"}, TaskTags: []string{"tag4"}},
 		{Alias: "five", Variant: "bv4", TaskTags: []string{"!tag3", "tag5"}},
 	}
-	match, err := aliases.HasMatchingVariant("bv1", nil)
+	bv1Matches, err := aliases.AliasesMatchingVariant("bv1", nil)
 	assert.NoError(err)
-	assert.True(match)
-	match, err = aliases.HasMatchingVariant("bv5", nil)
+	assert.NotEmpty(bv1Matches)
+	bv2Matches, err := aliases.AliasesMatchingVariant("bv2", nil)
 	assert.NoError(err)
-	assert.False(match)
-	match, err = aliases.HasMatchingVariant("", []string{"variantTag"})
+	assert.NotEmpty(bv2Matches)
+	bv3Matches, err := aliases.AliasesMatchingVariant("bv3", nil)
 	assert.NoError(err)
-	assert.True(match)
+	assert.NotEmpty(bv3Matches)
+	bv4Matches, err := aliases.AliasesMatchingVariant("bv4", nil)
+	assert.NoError(err)
+	assert.NotEmpty(bv4Matches)
+	bv5Matches, err := aliases.AliasesMatchingVariant("bv5", nil)
+	assert.NoError(err)
+	assert.Empty(bv5Matches)
+	tagsMatches, err := aliases.AliasesMatchingVariant("", []string{"variantTag", "notATag"})
+	assert.NoError(err)
+	assert.NotEmpty(tagsMatches)
+	matches, err := aliases.AliasesMatchingVariant("", []string{"notATag"})
+	assert.NoError(err)
+	assert.Empty(matches)
 
-	match, err = aliases.HasMatchingVariant("variantTag", nil)
+	matches, err = aliases.AliasesMatchingVariant("variantTag", nil)
 	assert.NoError(err)
-	assert.False(match)
-	match, err = aliases.HasMatchingVariant("", []string{"notATag"})
-	assert.NoError(err)
-	assert.False(match)
+	assert.Empty(matches)
 
 	task := &ProjectTask{
 		Name: "t1",
 	}
-	match, err = aliases.HasMatchingTask("bv1", nil, task)
+	match, err := bv1Matches.HasMatchingTask(task)
 	assert.NoError(err)
 	assert.True(match)
 	task = &ProjectTask{
 		Name: "t2",
 	}
-	match, err = aliases.HasMatchingTask("bv1", nil, task)
+	match, err = bv1Matches.HasMatchingTask(task)
 	assert.NoError(err)
 	assert.False(match)
 	task = &ProjectTask{
 		Name: "t2",
 	}
-	match, err = aliases.HasMatchingTask("bv2", nil, task)
+	match, err = bv2Matches.HasMatchingTask(task)
 	assert.NoError(err)
 	assert.True(match)
 	task = &ProjectTask{
 		Tags: []string{"tag3"},
 		Name: "t3",
 	}
-	match, err = aliases.HasMatchingTask("bv3", nil, task)
+	match, err = bv3Matches.HasMatchingTask(task)
 	assert.NoError(err)
 	assert.True(match)
 	task = &ProjectTask{}
-	match, err = aliases.HasMatchingTask("bv3", nil, task)
+	match, err = bv3Matches.HasMatchingTask(task)
 	assert.NoError(err)
 	assert.False(match)
 
 	task = &ProjectTask{
 		Tags: []string{"tag4"},
 	}
-	match, err = aliases.HasMatchingTask("bv5", nil, task)
+	match, err = bv5Matches.HasMatchingTask(task)
 	assert.NoError(err)
 	assert.False(match)
 
-	match, err = aliases.HasMatchingTask("", []string{"variantTag", "notATag"}, task)
+	match, err = tagsMatches.HasMatchingTask(task)
 	assert.NoError(err)
 	assert.True(match)
 
-	match, err = aliases.HasMatchingTask("bv4", nil, task)
+	match, err = bv4Matches.HasMatchingTask(task)
 	assert.NoError(err)
 	assert.True(match)
 

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -73,6 +73,7 @@ var (
 	GeneratedTasksKey           = bsonutil.MustHaveTag(Task{}, "GeneratedTasks")
 	GeneratedByKey              = bsonutil.MustHaveTag(Task{}, "GeneratedBy")
 	HasCedarResultsKey          = bsonutil.MustHaveTag(Task{}, "HasCedarResults")
+	IsGithubCheckKey            = bsonutil.MustHaveTag(Task{}, "IsGithubCheck")
 
 	// GeneratedJSONKey is no longer used but must be kept for old tasks.
 	GeneratedJSONKey         = bsonutil.MustHaveTag(Task{}, "GeneratedJSON")
@@ -222,6 +223,13 @@ func ByIds(ids []string) db.Q {
 func ByBuildId(buildId string) db.Q {
 	return db.Query(bson.M{
 		BuildIdKey: buildId,
+	})
+}
+
+func ByBuildIdAndGithubChecks(buildId string) db.Q {
+	return db.Query(bson.M{
+		BuildIdKey:       buildId,
+		IsGithubCheckKey: true,
 	})
 }
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -112,7 +112,7 @@ type Task struct {
 	// The version of the agent this task was run on.
 	AgentVersion string `bson:"agent_version,omitempty" json:"agent_version,omitempty"`
 
-	// Set to true if the task should be concerned for mainline github checks
+	// Set to true if the task should be considered for mainline github checks
 	IsGithubCheck bool `bson:"is_github_check,omitempty" json:"is_github_check,omitempty"`
 
 	// the number of times this task has been restarted

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -106,12 +106,14 @@ type Task struct {
 	// Tags that describe the task
 	Tags []string `bson:"tags,omitempty" json:"tags,omitempty"`
 
-	// The host the task was run on. This value is empty for display
-	// tasks
+	// The host the task was run on. This value is empty for display tasks
 	HostId string `bson:"host_id" json:"host_id"`
 
 	// The version of the agent this task was run on.
 	AgentVersion string `bson:"agent_version,omitempty" json:"agent_version,omitempty"`
+
+	// Set to true if the task should be concerned for mainline github checks
+	IsGithubCheck bool `bson:"is_github_check,omitempty" json:"is_github_check,omitempty"`
 
 	// the number of times this task has been restarted
 	Restarts            int    `bson:"restarts" json:"restarts,omitempty"`

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -445,6 +445,43 @@ func TestFindTasksByIds(t *testing.T) {
 	})
 }
 
+func TestFindTasksByBuildIdAndGithubChecks(t *testing.T) {
+	tasks := []Task{
+		{
+			Id:            "t1",
+			BuildId:       "b1",
+			IsGithubCheck: true,
+		},
+		{
+			Id:      "t2",
+			BuildId: "b1",
+		},
+		{
+			Id:            "t3",
+			BuildId:       "b2",
+			IsGithubCheck: true,
+		},
+		{
+			Id:            "t4",
+			BuildId:       "b2",
+			IsGithubCheck: true,
+		},
+	}
+
+	for _, task := range tasks {
+		assert.NoError(t, task.Insert())
+	}
+	dbTasks, err := FindAll(ByBuildIdAndGithubChecks("b1"))
+	assert.NoError(t, err)
+	assert.Len(t, dbTasks, 1)
+	dbTasks, err = FindAll(ByBuildIdAndGithubChecks("b2"))
+	assert.NoError(t, err)
+	assert.Len(t, dbTasks, 2)
+	dbTasks, err = FindAll(ByBuildIdAndGithubChecks("b3"))
+	assert.NoError(t, err)
+	assert.Len(t, dbTasks, 0)
+}
+
 func TestCountSimilarFailingTasks(t *testing.T) {
 	Convey("When calling CountSimilarFailingTasks...", t, func() {
 		So(db.Clear(Collection), ShouldBeNil)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -805,7 +805,7 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 			}
 			failedTask = true
 		} else if githubCheckTasks[t.Id] {
-			successfulGithubCheckTasks += 1
+			successfulGithubCheckTasks++
 		}
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -761,6 +761,16 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 		return errors.WithStack(err)
 	}
 
+	githubCheckTasks := map[string]bool{}
+	githubCheckStatus := ""
+	successfulGithubCheckTasks := 0
+	// also check the current status of github checks
+	for _, bt := range buildTasks {
+		if bt.IsGithubCheck {
+			githubCheckTasks[bt.Id] = bt.IsGithubCheck
+		}
+	}
+
 	failedTask := false
 	finishedTasks := 0
 	blockedTasks := 0
@@ -787,15 +797,28 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 
 		// update the build's status when a test task isn't successful
 		if evergreen.IsFailedTaskStatus(t.Status) {
-			err = b.UpdateStatus(evergreen.BuildFailed)
-			if err != nil {
-				err = errors.Wrap(err, "Error updating build status")
-				grip.Error(err)
-				return err
+			if err = b.UpdateStatus(evergreen.BuildFailed); err != nil {
+				return errors.Wrap(err, "Error updating build status")
 			}
-
+			if githubCheckTasks[t.Id] {
+				githubCheckStatus = evergreen.BuildFailed
+			}
 			failedTask = true
+		} else if githubCheckTasks[t.Id] {
+			successfulGithubCheckTasks += 1
 		}
+	}
+
+	// we only calculate github check status if the task that finished is a github check task
+	if successfulGithubCheckTasks > 0 && successfulGithubCheckTasks == len(githubCheckTasks) {
+		githubCheckStatus = evergreen.BuildSucceeded
+	}
+
+	if githubCheckStatus != "" && b.GithubCheckStatus == "" {
+		if err = b.UpdateGithubCheckStatus(githubCheckStatus); err != nil {
+			return errors.Wrap(err, "error updating github check status")
+		}
+		event.LogBuildGithubCheckFinishedEvent(t.BuildId, githubCheckStatus)
 	}
 
 	cachedTasks := buildTasks
@@ -846,7 +869,7 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 
 	// These are deliberately out of the buildComplete block to ensure versions
 	// are iterated so version and patch notifications can be sent out
-	if err = MarkVersionCompleted(b.Version, finishTime, updates); err != nil {
+	if err = markVersionCompleted(b.Version, finishTime, updates, t.IsGithubCheck); err != nil {
 		err = errors.Wrap(err, "Error marking version as finished")
 		grip.Error(err)
 		return err
@@ -854,7 +877,7 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 	if time.Since(startPhaseAt) > slowMS {
 		grip.Debug(message.Fields{
 			"function":      "UpdateBuildAndVersionStatusForTask",
-			"operation":     "b.MarkVersionCompleted()",
+			"operation":     "b.markVersionCompleted()",
 			"message":       "slow operation",
 			"duration_secs": time.Since(startPhaseAt).Seconds(),
 			"task":          t.Id,

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -930,7 +930,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}))
 	}
 	for _, buildvariant := range projectInfo.Project.BuildVariants {
-		taskNames := pairsToCreate.TaskNames(buildvariant.Name) // if no aliases provided then this is empty
+		taskNames := pairsToCreate.TaskNames(buildvariant.Name)
 		var aliasesMatchingVariant model.ProjectAliases
 		aliasesMatchingVariant, err = githubCheckAliases.AliasesMatchingVariant(buildvariant.Name, buildvariant.Tags)
 		grip.Error(message.WrapError(err, message.Fields{

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -429,13 +429,13 @@ func addGithubCheckSubscriptions(v *model.Version) error {
 		Ref:   v.Revision,
 	})
 
-	versionSub := event.NewVersionOutcomeSubscription(v.Id, ghSub)
+	versionSub := event.NewVersionGithubCheckOutcomeSubscription(v.Id, ghSub)
 	if err := versionSub.Upsert(); err != nil {
-		catcher.Wrap(err, "failed to insert version subscription for Github check")
+		catcher.Wrap(err, "failed to insert version github check subscription")
 	}
-	buildSub := event.NewExpiringBuildOutcomeSubscriptionByVersion(v.Id, ghSub)
+	buildSub := event.NewGithubCheckBuildOutcomeSubscriptionByVersion(v.Id, ghSub)
 	if err := buildSub.Upsert(); err != nil {
-		catcher.Wrap(err, "failed to insert build subscription for Github check")
+		catcher.Wrap(err, "failed to insert build github check subscription")
 	}
 	flags, err := evergreen.GetServiceFlags()
 	if err != nil {
@@ -879,9 +879,9 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		if buildvariant.Disabled {
 			continue
 		}
-		var match bool
 		if len(aliases) > 0 {
-			match, err = aliases.HasMatchingVariant(buildvariant.Name, buildvariant.Tags)
+			var aliasesMatchingVariant model.ProjectAliases
+			aliasesMatchingVariant, err = aliases.AliasesMatchingVariant(buildvariant.Name, buildvariant.Tags)
 			if err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"message": "error checking project aliases",
@@ -890,12 +890,12 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 				}))
 				continue
 			}
-			if !match {
+			if len(aliasesMatchingVariant) == 0 {
 				continue
 			}
 			for _, t := range buildvariant.Tasks {
 				var match bool
-				match, err = aliases.HasMatchingTask(buildvariant.Name, buildvariant.Tags, projectInfo.Project.FindProjectTask(t.Name))
+				match, err = aliasesMatchingVariant.HasMatchingTask(projectInfo.Project.FindProjectTask(t.Name))
 				if err != nil {
 					grip.Error(message.WrapError(err, message.Fields{
 						"message": "error finding tasks with alias filter",
@@ -920,20 +920,38 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 	}))
 	batchTimeCatcher := grip.NewBasicCatcher()
 	debuggingData := map[string]string{}
+	var githubCheckAliases model.ProjectAliases
+	if v.Requester == evergreen.RepotrackerVersionRequester && projectInfo.Ref.GithubChecksEnabled {
+		githubCheckAliases, err = model.FindAliasInProject(v.Identifier, evergreen.GithubChecksAlias)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "error getting github check aliases",
+			"project": projectInfo.Project.Identifier,
+			"version": v.Id,
+		}))
+	}
 	for _, buildvariant := range projectInfo.Project.BuildVariants {
-		taskNames := pairsToCreate.TaskNames(buildvariant.Name)
+		taskNames := pairsToCreate.TaskNames(buildvariant.Name) // if no aliases provided then this is empty
+		var aliasesMatchingVariant model.ProjectAliases
+		aliasesMatchingVariant, err = githubCheckAliases.AliasesMatchingVariant(buildvariant.Name, buildvariant.Tags)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "error getting aliases matching variant",
+			"project": projectInfo.Ref.Id,
+			"version": v.Id,
+			"variant": buildvariant.Name,
+		}))
 		args := model.BuildCreateArgs{
-			Project:        *projectInfo.Project,
-			Version:        *v,
-			TaskIDs:        taskIds,
-			TaskNames:      taskNames,
-			BuildName:      buildvariant.Name,
-			ActivateBuild:  false,
-			SourceRev:      sourceRev,
-			DefinitionID:   metadata.TriggerDefinitionID,
-			Aliases:        aliases,
-			DistroAliases:  distroAliases,
-			TaskCreateTime: v.CreateTime,
+			Project:             *projectInfo.Project,
+			Version:             *v,
+			TaskIDs:             taskIds,
+			TaskNames:           taskNames,
+			BuildName:           buildvariant.Name,
+			ActivateBuild:       false,
+			SourceRev:           sourceRev,
+			DefinitionID:        metadata.TriggerDefinitionID,
+			Aliases:             aliases,
+			DistroAliases:       distroAliases,
+			TaskCreateTime:      v.CreateTime,
+			GithubChecksAliases: aliasesMatchingVariant,
 		}
 		b, tasks, err := model.CreateBuildFromVersionNoInsert(args)
 		if err != nil {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -345,6 +345,21 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 			}
 		}
 
+		// verify enabling github checks is valid
+		if newProjectRef.GithubChecksEnabled {
+			var githubChecksAliasesDefined bool
+			githubChecksAliasesDefined, err = h.hasAliasDefined(requestProjectRef, evergreen.GithubChecksAlias)
+			if err != nil {
+				return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't check for alias definitions"))
+			}
+			if !githubChecksAliasesDefined {
+				return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+					StatusCode: http.StatusBadRequest,
+					Message:    "cannot enable github checks without a version definition",
+				})
+			}
+		}
+
 		// verify enabling git tag versions is valid
 		if newProjectRef.GitTagVersionsEnabled {
 			var gitTagAliasesDefined bool

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -479,7 +479,7 @@ Evergreen Projects
             <div class="col-lg-6">
               <input type="checkbox" id="github-checks-checkbox" ng-model="settingsFormData.github_checks_enabled" />
               <label for="github-checks-checkbox">Enable Github Commit Checks</label>
-              <div class="muted small">When checked, the waterfall build will be added as a Github check for a commit (the check will pass/fail on only the tasks matching the tags/regexes definitions).</div>
+              <div class="muted small">Commits will send their status as a Github Check (the check will pass/fail based only on the tasks matching the tags/regexes definitions).</div>
             </div>
           </div>
           <div ng-show="settingsFormData.github_checks_enabled === true && githubChecksConflicts.length === 0">

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -470,15 +470,58 @@ Evergreen Projects
           </div>
 
           <!--Github Commit Checks-->
-          <div class="form-group" ng-hide="true">
+          <div class="form-group">
             <div class="col-header col-lg-6 form-control-static">
               <h3>Github Commit Checks</h3>
             </div>
           </div>
-          <div id="github_checks" class="form-group" ng-hide="true">
+          <div id="github_checks" class="form-group">
             <div class="col-lg-6">
               <input type="checkbox" id="github-checks-checkbox" ng-model="settingsFormData.github_checks_enabled" />
               <label for="github-checks-checkbox">Enable Github Commit Checks</label>
+            </div>
+          </div>
+          <div ng-show="settingsFormData.github_checks_enabled === true && githubChecksConflicts.length === 0">
+            <div id="patch-variants-list-header" class="form-group">
+              <div class="col-lg-3"> <label class="control-label"> Variant Regex </label> </div>
+              <div class="col-lg-3"> <label class="control-label"> Task Regex </label> </div>
+              <div class="col-lg-2"> <label class="control-label"> Task Tags </label> </div>
+              <div class="col-lg-2"></div>
+            </div>
+
+            <div id="patch-variants-list" class="form-group" ng-repeat="obj in settingsFormData.github_checks_aliases track by $index">
+              <div class="col-lg-3">
+                <input class="form-control" ng-model="obj.variant" type="text" placeholder="variant regex">
+              </div>
+              <div class="col-lg-3">
+                <input class="form-control" ng-model="obj.task" type="text" placeholder="task regex">
+              </div>
+              <div class="col-lg-2">
+                <tag-input klass="form-control" items="obj.tags" placeholder="tags (comma-delimited)" />
+              </div>
+              <div class="col-lg-4">
+                <button class="btn btn-default btn-danger" type="button" ng-click="removeGithubChecksAlias($index)">
+                  <i class="fa fa-trash"></i>
+                </button>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <div class="col-lg-3">
+                <input ng-model="github_checks_alias.variant" class="form-control" type="text" placeholder="variant regex">
+              </div>
+              <div class="col-lg-3">
+                <input ng-model="github_checks_alias.task" class="form-control" type="text" placeholder="task regex">
+              </div>
+              <div class="col-lg-2">
+                <tag-input klass="form-control" items="github_checks_alias.tags" placeholder="tags (comma-delimited)" />
+              </div>
+              <div class="col-lg-4">
+                <button class="plus-button btn btn-primary" ng-disabled="!validPatchDefinition(github_checks_alias)" type="button" ng-click="addGithubChecksAlias()">
+                  <i class="fa fa-plus"></i>
+                </button>
+                <label class="distro-error">[[invalidGitHubPatchDefinitionMessage]]</label>
+              </div>
             </div>
           </div>
           <!-- GIT TAGS -->

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -479,6 +479,7 @@ Evergreen Projects
             <div class="col-lg-6">
               <input type="checkbox" id="github-checks-checkbox" ng-model="settingsFormData.github_checks_enabled" />
               <label for="github-checks-checkbox">Enable Github Commit Checks</label>
+              <div class="muted small">When checked, the waterfall build will be added as a Github check for a commit (the check will pass/fail on only the tasks matching the tags/regexes definitions).</div>
             </div>
           </div>
           <div ng-show="settingsFormData.github_checks_enabled === true && githubChecksConflicts.length === 0">

--- a/trigger/build_test.go
+++ b/trigger/build_test.go
@@ -105,6 +105,7 @@ func (s *buildSuite) SetupTest() {
 				event.BuildPercentChangeKey: "50",
 			},
 		},
+		event.NewSubscriptionByID(event.ResourceTypeBuild, event.TriggerGithubCheckOutcome, s.event.ResourceId, apiSub),
 	}
 
 	for i := range s.subs {
@@ -134,7 +135,7 @@ func (s *buildSuite) TestAllTriggers() {
 
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)
-	s.Len(n, 2)
+	s.Len(n, 3)
 
 	s.build.Status = evergreen.BuildFailed
 	s.data.Status = evergreen.BuildFailed
@@ -142,7 +143,7 @@ func (s *buildSuite) TestAllTriggers() {
 
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)
-	s.Len(n, 2)
+	s.Len(n, 3)
 
 	s.build.Status = evergreen.BuildFailed
 	s.data.Status = evergreen.BuildCreated
@@ -186,6 +187,26 @@ func (s *buildSuite) TestFailure() {
 }
 
 func (s *buildSuite) TestOutcome() {
+	n, err := s.t.buildOutcome(&s.subs[1])
+	s.NoError(err)
+	s.Nil(n)
+
+	n, err = s.t.buildOutcome(&s.subs[0])
+	s.NoError(err)
+	s.Nil(n)
+
+	s.data.Status = evergreen.BuildSucceeded
+	n, err = s.t.buildOutcome(&s.subs[0])
+	s.NoError(err)
+	s.NotNil(n)
+
+	s.data.Status = evergreen.BuildFailed
+	n, err = s.t.buildOutcome(&s.subs[0])
+	s.NoError(err)
+	s.NotNil(n)
+}
+
+func (s *buildSuite) TestGithubCheckOutcome() {
 	n, err := s.t.buildOutcome(&s.subs[1])
 	s.NoError(err)
 	s.Nil(n)

--- a/trigger/build_test.go
+++ b/trigger/build_test.go
@@ -135,7 +135,7 @@ func (s *buildSuite) TestAllTriggers() {
 
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)
-	s.Len(n, 3)
+	s.Len(n, 2)
 
 	s.build.Status = evergreen.BuildFailed
 	s.data.Status = evergreen.BuildFailed
@@ -143,7 +143,7 @@ func (s *buildSuite) TestAllTriggers() {
 
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)
-	s.Len(n, 3)
+	s.Len(n, 2)
 
 	s.build.Status = evergreen.BuildFailed
 	s.data.Status = evergreen.BuildCreated
@@ -152,6 +152,15 @@ func (s *buildSuite) TestAllTriggers() {
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)
 	s.Len(n, 0)
+
+	s.build.GithubCheckStatus = evergreen.BuildFailed
+	s.data.GithubCheckStatus = evergreen.BuildFailed
+	s.NoError(db.Update(build.Collection, bson.M{"_id": s.build.Id}, &s.build))
+
+	n, err = NotificationsFromEvent(&s.event)
+	s.NoError(err)
+	s.Len(n, 1)
+
 }
 
 func (s *buildSuite) TestSuccess() {
@@ -207,21 +216,21 @@ func (s *buildSuite) TestOutcome() {
 }
 
 func (s *buildSuite) TestGithubCheckOutcome() {
-	n, err := s.t.buildOutcome(&s.subs[1])
+	n, err := s.t.buildGithubCheckOutcome(&s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
-	n, err = s.t.buildOutcome(&s.subs[0])
+	n, err = s.t.buildGithubCheckOutcome(&s.subs[0])
 	s.NoError(err)
 	s.Nil(n)
 
-	s.data.Status = evergreen.BuildSucceeded
-	n, err = s.t.buildOutcome(&s.subs[0])
+	s.data.GithubCheckStatus = evergreen.BuildSucceeded
+	n, err = s.t.buildGithubCheckOutcome(&s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 
-	s.data.Status = evergreen.BuildFailed
-	n, err = s.t.buildOutcome(&s.subs[0])
+	s.data.GithubCheckStatus = evergreen.BuildFailed
+	n, err = s.t.buildGithubCheckOutcome(&s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 }


### PR DESCRIPTION
I switched this over to a new trigger type, so that we wouldn't have to wait for the build/version to finish if the tasks/variants requested in the alias have been completed. (This could result in the github status being sent early, if generated tasks should be part of the alias, but the generator itself isn't part of the alias, but I argue this is unlikely.)

Example of failed:
![image](https://user-images.githubusercontent.com/26798134/103427057-0c066500-4b73-11eb-8f7e-ab14f5d420e5.png)

Example from project page:
![image](https://user-images.githubusercontent.com/26798134/103427070-1a548100-4b73-11eb-8bdc-ce5bb8ab06f7.png)
