### PR TITLE
EVG-13593: reprovision unquarantined hosts

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/units"
@@ -60,7 +61,7 @@ func GetHostsAndUserPermissions(user *user.DBUser, hostIds []string) ([]host.Hos
 		return nil, nil, http.StatusInternalServerError, errors.New("unable to get user permissions")
 	}
 
-	return hosts, permissions, 0, nil
+	return hosts, permissions, http.StatusOK, nil
 }
 
 // ModifyHostsWithPermissions performs an update on each of the given hosts
@@ -68,7 +69,7 @@ func GetHostsAndUserPermissions(user *user.DBUser, hostIds []string) ([]host.Hos
 func ModifyHostsWithPermissions(hosts []host.Host, perm map[string]gimlet.Permissions, modifyHost func(h *host.Host) (int, error)) (updated int, httpStatus int, err error) {
 	catcher := grip.NewBasicCatcher()
 
-	httpStatus = 0
+	httpStatus = http.StatusOK
 
 	for _, h := range hosts {
 		if perm[h.Distro.Id][evergreen.PermissionHosts] < evergreen.HostsEdit.Value {
@@ -100,6 +101,16 @@ func ModifyHostStatus(queue amboy.Queue, h *host.Host, newStatus string, notes s
 		return "", http.StatusBadRequest, errors.New(DecommissionStaticHostError)
 	}
 
+	unquarantinedAndNeedsReprovision := utility.StringSliceContains([]string{distro.BootstrapMethodSSH, distro.BootstrapMethodUserData}, h.Distro.BootstrapSettings.Method) &&
+		h.Status == evergreen.HostQuarantined &&
+		utility.StringSliceContains([]string{evergreen.HostRunning, evergreen.HostProvisioning}, newStatus)
+	if unquarantinedAndNeedsReprovision {
+		if err := h.SetNeedsReprovisionToNew(u.Username()); err != nil {
+			return "", http.StatusInternalServerError, errors.Wrap(err, HostUpdateError)
+		}
+		return HostReprovisionConfirm, http.StatusOK, nil
+	}
+
 	if newStatus == evergreen.HostTerminated {
 		if !queue.Info().Started {
 			return "", http.StatusInternalServerError, errors.New(HostTerminationQueueingError)
@@ -108,7 +119,7 @@ func ModifyHostStatus(queue amboy.Queue, h *host.Host, newStatus string, notes s
 		if err := queue.Put(ctx, units.NewHostTerminationJob(env, h, true, fmt.Sprintf("terminated by %s", u.Username()))); err != nil {
 			return "", http.StatusInternalServerError, errors.New(HostTerminationQueueingError)
 		}
-		return fmt.Sprintf(HostTerminationQueueingSuccess, h.Id), 0, nil
+		return fmt.Sprintf(HostTerminationQueueingSuccess, h.Id), http.StatusOK, nil
 	}
 
 	err := h.SetStatus(newStatus, u.Id, notes)
@@ -116,7 +127,7 @@ func ModifyHostStatus(queue amboy.Queue, h *host.Host, newStatus string, notes s
 		return "", http.StatusInternalServerError, errors.Wrap(err, HostUpdateError)
 	}
 
-	return fmt.Sprintf(HostStatusUpdateSuccess, currentStatus, h.Status), 0, nil
+	return fmt.Sprintf(HostStatusUpdateSuccess, currentStatus, h.Status), http.StatusOK, nil
 }
 
 func GetRestartJasperCallback(username string) func(h *host.Host) (int, error) {
@@ -125,7 +136,7 @@ func GetRestartJasperCallback(username string) func(h *host.Host) (int, error) {
 		if modifyErr != nil {
 			return http.StatusInternalServerError, modifyErr
 		}
-		return 0, nil
+		return http.StatusOK, nil
 	}
 }
 
@@ -135,7 +146,7 @@ func GetReprovisionToNewCallback(username string) func(h *host.Host) (int, error
 		if modifyErr != nil {
 			return http.StatusInternalServerError, modifyErr
 		}
-		return 0, nil
+		return http.StatusOK, nil
 	}
 }
 

--- a/api/host.go
+++ b/api/host.go
@@ -118,7 +118,7 @@ func ModifyHostStatus(queue amboy.Queue, h *host.Host, newStatus string, notes s
 	}
 
 	unquarantinedAndNeedsReprovision := utility.StringSliceContains([]string{distro.BootstrapMethodSSH, distro.BootstrapMethodUserData}, h.Distro.BootstrapSettings.Method) &&
-		h.Status == evergreen.HostQuarantined &&
+		currentStatus == evergreen.HostQuarantined &&
 		utility.StringSliceContains([]string{evergreen.HostRunning, evergreen.HostProvisioning}, newStatus)
 	if unquarantinedAndNeedsReprovision {
 		if err := h.SetNeedsReprovisionToNew(u.Username()); err != nil {

--- a/service/host.go
+++ b/service/host.go
@@ -166,7 +166,11 @@ func (uis *UIServer) modifyHost(w http.ResponseWriter, r *http.Request) {
 
 	switch opts.Action {
 	case "updateStatus":
-		msg, statusCode, err := api.ModifyHostStatus(queue, h, opts.Status, opts.Notes, u)
+		var (
+			msg        string
+			statusCode int
+		)
+		msg, statusCode, err = api.ModifyHostStatus(queue, h, opts.Status, opts.Notes, u)
 		if err != nil {
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(gimlet.ErrorResponse{
 				StatusCode: statusCode,

--- a/service/host.go
+++ b/service/host.go
@@ -166,23 +166,15 @@ func (uis *UIServer) modifyHost(w http.ResponseWriter, r *http.Request) {
 
 	switch opts.Action {
 	case "updateStatus":
-		currentStatus := h.Status
-		var modifyResult string
-		modifyResult, _, err = api.ModifyHostStatus(queue, h, opts.Status, opts.Notes, u)
-
+		msg, statusCode, err := api.ModifyHostStatus(queue, h, opts.Status, opts.Notes, u)
 		if err != nil {
-			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(err))
+			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(gimlet.ErrorResponse{
+				StatusCode: statusCode,
+				Message:    msg,
+			}))
 			return
 		}
-
-		var msg flashMessage
-		switch modifyResult {
-		case fmt.Sprintf(api.HostTerminationQueueingSuccess, h.Id):
-			msg = NewSuccessFlash(fmt.Sprintf(api.HostTerminationQueueingSuccess, h.Id))
-		case fmt.Sprintf(api.HostStatusUpdateSuccess, currentStatus, h.Status):
-			msg = NewSuccessFlash(fmt.Sprintf(api.HostStatusUpdateSuccess, currentStatus, h.Status))
-		}
-		PushFlash(uis.CookieStore, r, w, msg)
+		PushFlash(uis.CookieStore, r, w, NewSuccessFlash(msg))
 		gimlet.WriteJSON(w, api.HostStatusWriteConfirm)
 	case "restartJasper":
 		if err = h.SetNeedsJasperRestart(u.Username()); err != nil {

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -27,7 +27,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 
 	env := mock.Environment{}
 	assert.NoError(env.Configure(ctx))
-	require.NoError(db.ClearCollections(event.AllLogCollection), "error clearing collections")
+	require.NoError(db.ClearCollections(host.Collection, event.AllLogCollection), "error clearing collections")
 
 	// Normal test, changing a host from running to quarantined
 	user1 := user.DBUser{Id: "user1"}

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/api"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
@@ -30,38 +31,62 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 	require.NoError(db.ClearCollections(host.Collection, event.AllLogCollection), "error clearing collections")
 
 	// Normal test, changing a host from running to quarantined
-	user1 := user.DBUser{Id: "user1"}
-	h1 := host.Host{Id: "h1", Status: evergreen.HostRunning}
-	require.NoError(h1.Insert())
-	opts1 := uiParams{Action: "updateStatus", Status: evergreen.HostQuarantined, Notes: "because I can"}
+	t.Run("SuccessfullyModifiesHostStatusWithNote", func(t *testing.T) {
+		user := user.DBUser{Id: "user"}
+		h := host.Host{Id: "h1", Status: evergreen.HostRunning}
+		require.NoError(h.Insert())
+		opts := uiParams{Action: "updateStatus", Status: evergreen.HostQuarantined, Notes: "because I can"}
 
-	result, httpStatus, err := api.ModifyHostStatus(env.LocalQueue(), &h1, opts1.Status, opts1.Notes, &user1)
-	require.NoError(err)
-	assert.Equal(http.StatusOK, httpStatus)
-	assert.Equal(result, fmt.Sprintf(api.HostStatusUpdateSuccess, evergreen.HostRunning, evergreen.HostQuarantined))
-	assert.Equal(h1.Status, evergreen.HostQuarantined)
-	events, err2 := event.Find(event.AllLogCollection, event.MostRecentHostEvents("h1", "", 1))
-	assert.NoError(err2)
-	assert.Len(events, 1)
-	hostevent, ok := events[0].Data.(*event.HostEventData)
-	require.True(ok, "%T", events[0].Data)
-	assert.Equal("because I can", hostevent.Logs)
+		result, httpStatus, err := api.ModifyHostStatus(env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
+		require.NoError(err)
+		assert.Equal(http.StatusOK, httpStatus)
+		assert.Equal(result, fmt.Sprintf(api.HostStatusUpdateSuccess, evergreen.HostRunning, evergreen.HostQuarantined))
+		assert.Equal(h.Status, evergreen.HostQuarantined)
+		events, err := event.Find(event.AllLogCollection, event.MostRecentHostEvents("h1", "", 1))
+		assert.NoError(err)
+		assert.Len(events, 1)
+		hostevent, ok := events[0].Data.(*event.HostEventData)
+		require.True(ok, "%T", events[0].Data)
+		assert.Equal("because I can", hostevent.Logs)
+	})
+	t.Run("SuccessfullyUnquarantinesHostAndMarksAsReprovisioning", func(t *testing.T) {
+		user := user.DBUser{Id: "user"}
+		h := host.Host{
+			Id:     "h2",
+			Status: evergreen.HostQuarantined,
+			Distro: distro.Distro{
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodSSH,
+					Communication: distro.BootstrapMethodSSH,
+				},
+			},
+		}
+		require.NoError(h.Insert())
 
-	user2 := user.DBUser{Id: "user2"}
-	h2 := host.Host{Id: "h2", Status: evergreen.HostRunning, Provider: evergreen.ProviderNameStatic}
-	opts2 := uiParams{Action: "updateStatus", Status: evergreen.HostDecommissioned}
+		_, httpStatus, err := api.ModifyHostStatus(env.LocalQueue(), &h, evergreen.HostRunning, "", &user)
+		require.NoError(err)
+		assert.Equal(http.StatusOK, httpStatus)
+		assert.Equal(h.Status, evergreen.HostProvisioning)
+		assert.Equal(host.ReprovisionToNew, h.NeedsReprovision)
+	})
+	t.Run("FailsToDecommissionStaticHosts", func(t *testing.T) {
+		user := user.DBUser{Id: "user"}
+		h := host.Host{Id: "h3", Status: evergreen.HostRunning, Provider: evergreen.ProviderNameStatic}
+		opts := uiParams{Action: "updateStatus", Status: evergreen.HostDecommissioned}
 
-	_, _, err = api.ModifyHostStatus(env.LocalQueue(), &h2, opts2.Status, opts2.Notes, &user2)
-	assert.Error(err)
-	assert.Contains(err.Error(), api.DecommissionStaticHostError)
+		_, _, err := api.ModifyHostStatus(env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
+		assert.Error(err)
+		assert.Contains(err.Error(), api.DecommissionStaticHostError)
+	})
+	t.Run("FailsWithInvalidHostStatus", func(t *testing.T) {
+		user := user.DBUser{Id: "user"}
+		h := host.Host{Id: "h4", Status: evergreen.HostRunning, Provider: evergreen.ProviderNameStatic}
+		opts := uiParams{Action: "updateStatus", Status: "undefined"}
 
-	user3 := user.DBUser{Id: "user3"}
-	h3 := host.Host{Id: "h3", Status: evergreen.HostRunning, Provider: evergreen.ProviderNameStatic}
-	opts3 := uiParams{Action: "updateStatus", Status: "undefined"}
-
-	_, _, err = api.ModifyHostStatus(env.LocalQueue(), &h3, opts3.Status, opts3.Notes, &user3)
-	assert.Error(err)
-	assert.Contains(err.Error(), fmt.Sprintf(api.InvalidStatusError, "undefined"))
+		_, _, err := api.ModifyHostStatus(env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
+		assert.Error(err)
+		assert.Contains(err.Error(), fmt.Sprintf(api.InvalidStatusError, "undefined"))
+	})
 }
 
 func TestGetHostFromCache(t *testing.T) {

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -32,11 +32,12 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 	// Normal test, changing a host from running to quarantined
 	user1 := user.DBUser{Id: "user1"}
 	h1 := host.Host{Id: "h1", Status: evergreen.HostRunning}
+	require.NoError(h1.Insert())
 	opts1 := uiParams{Action: "updateStatus", Status: evergreen.HostQuarantined, Notes: "because I can"}
 
 	result, httpStatus, err := api.ModifyHostStatus(env.LocalQueue(), &h1, opts1.Status, opts1.Notes, &user1)
-	assert.NoError(err)
-	assert.Equal(httpStatus, 0)
+	require.NoError(err)
+	assert.Equal(http.StatusOK, httpStatus)
 	assert.Equal(result, fmt.Sprintf(api.HostStatusUpdateSuccess, evergreen.HostRunning, evergreen.HostQuarantined))
 	assert.Equal(h1.Status, evergreen.HostQuarantined)
 	events, err2 := event.Find(event.AllLogCollection, event.MostRecentHostEvents("h1", "", 1))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13593

When a host (usually a static host but sometimes an EC2 instance) is unquarantined, it might be in a state where it can't run the agent. For example, if the host is quarantined and the underlying host is replaced with a brand new host, it won't have the filesystem state necessary to run the agent monitor. This adds a special case where unquarantining a host and setting it to run again forces it to reprovision to ensure it's in the correct state.

* Reprovision hosts that transition from quarantined to running.
* Fix some weirdness in how the host status update route deals with HTTP status codes and success/error flash messages.