### PR TITLE
EVG-13365 support multiple sorts for patch tasks

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -4802,8 +4802,8 @@ input IssueLinkInput {
 }
 
 input SortOrder {
-  Key: String!
-  Direction: Int!
+  Key: TaskSortCategory!
+  Direction: SortDirection!
 }
 
 type TaskQueueItem {
@@ -23798,13 +23798,13 @@ func (ec *executionContext) unmarshalInputSortOrder(ctx context.Context, obj int
 		switch k {
 		case "Key":
 			var err error
-			it.Key, err = ec.unmarshalNString2string(ctx, v)
+			it.Key, err = ec.unmarshalNTaskSortCategory2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskSortCategory(ctx, v)
 			if err != nil {
 				return it, err
 			}
 		case "Direction":
 			var err error
-			it.Direction, err = ec.unmarshalNInt2int(ctx, v)
+			it.Direction, err = ec.unmarshalNSortDirection2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortDirection(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -29937,6 +29937,15 @@ func (ec *executionContext) unmarshalNSelectorInput2ᚕgithubᚗcomᚋevergreen�
 	return res, nil
 }
 
+func (ec *executionContext) unmarshalNSortDirection2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortDirection(ctx context.Context, v interface{}) (SortDirection, error) {
+	var res SortDirection
+	return res, res.UnmarshalGQL(v)
+}
+
+func (ec *executionContext) marshalNSortDirection2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortDirection(ctx context.Context, sel ast.SelectionSet, v SortDirection) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) unmarshalNSortOrder2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortOrder(ctx context.Context, v interface{}) (SortOrder, error) {
 	return ec.unmarshalInputSortOrder(ctx, v)
 }
@@ -30405,6 +30414,15 @@ func (ec *executionContext) marshalNTaskResult2ᚖgithubᚗcomᚋevergreenᚑci�
 		return graphql.Null
 	}
 	return ec._TaskResult(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNTaskSortCategory2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskSortCategory(ctx context.Context, v interface{}) (TaskSortCategory, error) {
+	var res TaskSortCategory
+	return res, res.UnmarshalGQL(v)
+}
+
+func (ec *executionContext) marshalNTaskSortCategory2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskSortCategory(ctx context.Context, sel ast.SelectionSet, v TaskSortCategory) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) marshalNTaskTestResult2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskTestResult(ctx context.Context, sel ast.SelectionSet, v TaskTestResult) graphql.Marshaler {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -84,6 +84,11 @@ type ComplexityRoot struct {
 		BaseTaskLink     func(childComplexity int) int
 	}
 
+	BaseTaskResult struct {
+		ID     func(childComplexity int) int
+		Status func(childComplexity int) int
+	}
+
 	Build struct {
 		ActualMakespan    func(childComplexity int) int
 		BuildVariant      func(childComplexity int) int
@@ -472,7 +477,7 @@ type ComplexityRoot struct {
 		MyVolumes               func(childComplexity int) int
 		Patch                   func(childComplexity int, id string) int
 		PatchBuildVariants      func(childComplexity int, patchID string) int
-		PatchTasks              func(childComplexity int, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) int
+		PatchTasks              func(childComplexity int, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, sorts []*SortOrder, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) int
 		Project                 func(childComplexity int, projectID string) int
 		Projects                func(childComplexity int) int
 		SpruceConfig            func(childComplexity int) int
@@ -650,6 +655,7 @@ type ComplexityRoot struct {
 	TaskResult struct {
 		Aborted            func(childComplexity int) int
 		BaseStatus         func(childComplexity int) int
+		BaseTask           func(childComplexity int) int
 		Blocked            func(childComplexity int) int
 		BuildVariant       func(childComplexity int) int
 		DisplayName        func(childComplexity int) int
@@ -823,7 +829,7 @@ type QueryResolver interface {
 	Patch(ctx context.Context, id string) (*model.APIPatch, error)
 	Projects(ctx context.Context) (*Projects, error)
 	Project(ctx context.Context, projectID string) (*model.APIProjectRef, error)
-	PatchTasks(ctx context.Context, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) (*PatchTasks, error)
+	PatchTasks(ctx context.Context, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, sorts []*SortOrder, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) (*PatchTasks, error)
 	TaskTests(ctx context.Context, taskID string, execution *int, sortCategory *TestSortCategory, sortDirection *SortDirection, page *int, limit *int, testName *string, statuses []string) (*TaskTestResult, error)
 	TaskFiles(ctx context.Context, taskID string, execution *int) (*TaskFiles, error)
 	User(ctx context.Context, userID *string) (*model.APIDBUser, error)
@@ -1024,6 +1030,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.BaseTaskMetadata.BaseTaskLink(childComplexity), true
+
+	case "BaseTaskResult.id":
+		if e.complexity.BaseTaskResult.ID == nil {
+			break
+		}
+
+		return e.complexity.BaseTaskResult.ID(childComplexity), true
+
+	case "BaseTaskResult.status":
+		if e.complexity.BaseTaskResult.Status == nil {
+			break
+		}
+
+		return e.complexity.BaseTaskResult.Status(childComplexity), true
 
 	case "Build.actualMakespan":
 		if e.complexity.Build.ActualMakespan == nil {
@@ -3003,7 +3023,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.PatchTasks(childComplexity, args["patchId"].(string), args["sortBy"].(*TaskSortCategory), args["sortDir"].(*SortDirection), args["page"].(*int), args["limit"].(*int), args["statuses"].([]string), args["baseStatuses"].([]string), args["variant"].(*string), args["taskName"].(*string)), true
+		return e.complexity.Query.PatchTasks(childComplexity, args["patchId"].(string), args["sortBy"].(*TaskSortCategory), args["sortDir"].(*SortDirection), args["sorts"].([]*SortOrder), args["page"].(*int), args["limit"].(*int), args["statuses"].([]string), args["baseStatuses"].([]string), args["variant"].(*string), args["taskName"].(*string)), true
 
 	case "Query.project":
 		if e.complexity.Query.Project == nil {
@@ -3969,6 +3989,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TaskResult.BaseStatus(childComplexity), true
 
+	case "TaskResult.baseTask":
+		if e.complexity.TaskResult.BaseTask == nil {
+			break
+		}
+
+		return e.complexity.TaskResult.BaseTask(childComplexity), true
+
 	case "TaskResult.blocked":
 		if e.complexity.TaskResult.Blocked == nil {
 			break
@@ -4490,6 +4517,7 @@ var sources = []*ast.Source{
     patchId: String!
     sortBy: TaskSortCategory = STATUS
     sortDir: SortDirection = ASC
+    sorts: [SortOrder!]
     page: Int = 0
     limit: Int = 0
     statuses: [String!] = []
@@ -4773,6 +4801,11 @@ input IssueLinkInput {
   issueKey: String!
 }
 
+input SortOrder {
+  Key: String!
+  Direction: Int!
+}
+
 type TaskQueueItem {
   id: ID!
   displayName: String!
@@ -4985,9 +5018,15 @@ type TaskResult {
   version: String!
   status: String!
   baseStatus: String
+  baseTask: BaseTaskResult
   buildVariant: String!
   blocked: Boolean!
   executionTasksFull: [Task!]
+}
+
+type BaseTaskResult {
+  id: ID!
+  status: String!
 }
 
 type PatchDuration {
@@ -6357,54 +6396,62 @@ func (ec *executionContext) field_Query_patchTasks_args(ctx context.Context, raw
 		}
 	}
 	args["sortDir"] = arg2
-	var arg3 *int
-	if tmp, ok := rawArgs["page"]; ok {
-		arg3, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+	var arg3 []*SortOrder
+	if tmp, ok := rawArgs["sorts"]; ok {
+		arg3, err = ec.unmarshalOSortOrder2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortOrderᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["page"] = arg3
+	args["sorts"] = arg3
 	var arg4 *int
-	if tmp, ok := rawArgs["limit"]; ok {
+	if tmp, ok := rawArgs["page"]; ok {
 		arg4, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["limit"] = arg4
-	var arg5 []string
-	if tmp, ok := rawArgs["statuses"]; ok {
-		arg5, err = ec.unmarshalOString2ᚕstringᚄ(ctx, tmp)
+	args["page"] = arg4
+	var arg5 *int
+	if tmp, ok := rawArgs["limit"]; ok {
+		arg5, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["statuses"] = arg5
+	args["limit"] = arg5
 	var arg6 []string
-	if tmp, ok := rawArgs["baseStatuses"]; ok {
+	if tmp, ok := rawArgs["statuses"]; ok {
 		arg6, err = ec.unmarshalOString2ᚕstringᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["baseStatuses"] = arg6
-	var arg7 *string
-	if tmp, ok := rawArgs["variant"]; ok {
-		arg7, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+	args["statuses"] = arg6
+	var arg7 []string
+	if tmp, ok := rawArgs["baseStatuses"]; ok {
+		arg7, err = ec.unmarshalOString2ᚕstringᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["variant"] = arg7
+	args["baseStatuses"] = arg7
 	var arg8 *string
-	if tmp, ok := rawArgs["taskName"]; ok {
+	if tmp, ok := rawArgs["variant"]; ok {
 		arg8, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["taskName"] = arg8
+	args["variant"] = arg8
+	var arg9 *string
+	if tmp, ok := rawArgs["taskName"]; ok {
+		arg9, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["taskName"] = arg9
 	return args, nil
 }
 
@@ -7191,6 +7238,74 @@ func (ec *executionContext) _BaseTaskMetadata_baseTaskLink(ctx context.Context, 
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.BaseTaskLink, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _BaseTaskResult_id(ctx context.Context, field graphql.CollectedField, obj *BaseTaskResult) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "BaseTaskResult",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _BaseTaskResult_status(ctx context.Context, field graphql.CollectedField, obj *BaseTaskResult) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "BaseTaskResult",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -15382,7 +15497,7 @@ func (ec *executionContext) _Query_patchTasks(ctx context.Context, field graphql
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().PatchTasks(rctx, args["patchId"].(string), args["sortBy"].(*TaskSortCategory), args["sortDir"].(*SortDirection), args["page"].(*int), args["limit"].(*int), args["statuses"].([]string), args["baseStatuses"].([]string), args["variant"].(*string), args["taskName"].(*string))
+		return ec.resolvers.Query().PatchTasks(rctx, args["patchId"].(string), args["sortBy"].(*TaskSortCategory), args["sortDir"].(*SortDirection), args["sorts"].([]*SortOrder), args["page"].(*int), args["limit"].(*int), args["statuses"].([]string), args["baseStatuses"].([]string), args["variant"].(*string), args["taskName"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -20334,6 +20449,37 @@ func (ec *executionContext) _TaskResult_baseStatus(ctx context.Context, field gr
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _TaskResult_baseTask(ctx context.Context, field graphql.CollectedField, obj *TaskResult) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "TaskResult",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BaseTask, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*BaseTaskResult)
+	fc.Result = res
+	return ec.marshalOBaseTaskResult2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBaseTaskResult(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _TaskResult_buildVariant(ctx context.Context, field graphql.CollectedField, obj *TaskResult) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -23644,6 +23790,30 @@ func (ec *executionContext) unmarshalInputSelectorInput(ctx context.Context, obj
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputSortOrder(ctx context.Context, obj interface{}) (SortOrder, error) {
+	var it SortOrder
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "Key":
+			var err error
+			it.Key, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "Direction":
+			var err error
+			it.Direction, err = ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputSpawnHostInput(ctx context.Context, obj interface{}) (SpawnHostInput, error) {
 	var it SpawnHostInput
 	var asMap = obj.(map[string]interface{})
@@ -24190,6 +24360,38 @@ func (ec *executionContext) _BaseTaskMetadata(ctx context.Context, sel ast.Selec
 			out.Values[i] = ec._BaseTaskMetadata_baseTaskDuration(ctx, field, obj)
 		case "baseTaskLink":
 			out.Values[i] = ec._BaseTaskMetadata_baseTaskLink(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var baseTaskResultImplementors = []string{"BaseTaskResult"}
+
+func (ec *executionContext) _BaseTaskResult(ctx context.Context, sel ast.SelectionSet, obj *BaseTaskResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, baseTaskResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("BaseTaskResult")
+		case "id":
+			out.Values[i] = ec._BaseTaskResult_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "status":
+			out.Values[i] = ec._BaseTaskResult_status(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -27649,6 +27851,8 @@ func (ec *executionContext) _TaskResult(ctx context.Context, sel ast.SelectionSe
 			}
 		case "baseStatus":
 			out.Values[i] = ec._TaskResult_baseStatus(ctx, field, obj)
+		case "baseTask":
+			out.Values[i] = ec._TaskResult_baseTask(ctx, field, obj)
 		case "buildVariant":
 			out.Values[i] = ec._TaskResult_buildVariant(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -29733,6 +29937,18 @@ func (ec *executionContext) unmarshalNSelectorInput2ᚕgithubᚗcomᚋevergreen�
 	return res, nil
 }
 
+func (ec *executionContext) unmarshalNSortOrder2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortOrder(ctx context.Context, v interface{}) (SortOrder, error) {
+	return ec.unmarshalInputSortOrder(ctx, v)
+}
+
+func (ec *executionContext) unmarshalNSortOrder2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortOrder(ctx context.Context, v interface{}) (*SortOrder, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalNSortOrder2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortOrder(ctx, v)
+	return &res, err
+}
+
 func (ec *executionContext) marshalNSource2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPISource(ctx context.Context, sel ast.SelectionSet, v model.APISource) graphql.Marshaler {
 	return ec._Source(ctx, sel, &v)
 }
@@ -30732,6 +30948,17 @@ func (ec *executionContext) marshalOBaseTaskMetadata2ᚖgithubᚗcomᚋevergreen
 	return ec._BaseTaskMetadata(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOBaseTaskResult2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBaseTaskResult(ctx context.Context, sel ast.SelectionSet, v BaseTaskResult) graphql.Marshaler {
+	return ec._BaseTaskResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOBaseTaskResult2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBaseTaskResult(ctx context.Context, sel ast.SelectionSet, v *BaseTaskResult) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._BaseTaskResult(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	return graphql.UnmarshalBoolean(v)
 }
@@ -31426,6 +31653,26 @@ func (ec *executionContext) marshalOSortDirection2ᚖgithubᚗcomᚋevergreenᚑ
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) unmarshalOSortOrder2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortOrderᚄ(ctx context.Context, v interface{}) ([]*SortOrder, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]*SortOrder, len(vSlice))
+	for i := range vSlice {
+		res[i], err = ec.unmarshalNSortOrder2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortOrder(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) unmarshalOSpawnHostInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSpawnHostInput(ctx context.Context, v interface{}) (SpawnHostInput, error) {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -28,6 +28,11 @@ type BaseTaskMetadata struct {
 	BaseTaskLink     string             `json:"baseTaskLink"`
 }
 
+type BaseTaskResult struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
 type BuildBaron struct {
 	SearchReturnInfo     *thirdparty.SearchReturnInfo `json:"searchReturnInfo"`
 	BuildBaronConfigured bool                         `json:"buildBaronConfigured"`
@@ -161,6 +166,11 @@ type RecentTaskLogs struct {
 	AgentLogs  []*apimodels.LogMessage       `json:"agentLogs"`
 }
 
+type SortOrder struct {
+	Key       string `json:"Key"`
+	Direction int    `json:"Direction"`
+}
+
 type SpawnHostInput struct {
 	DistroID                string          `json:"distroId"`
 	Region                  string          `json:"region"`
@@ -204,6 +214,7 @@ type TaskResult struct {
 	Version            string           `json:"version"`
 	Status             string           `json:"status"`
 	BaseStatus         *string          `json:"baseStatus"`
+	BaseTask           *BaseTaskResult  `json:"baseTask"`
 	BuildVariant       string           `json:"buildVariant"`
 	Blocked            bool             `json:"blocked"`
 	ExecutionTasksFull []*model.APITask `json:"executionTasksFull"`

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -167,8 +167,8 @@ type RecentTaskLogs struct {
 }
 
 type SortOrder struct {
-	Key       string `json:"Key"`
-	Direction int    `json:"Direction"`
+	Key       TaskSortCategory `json:"Key"`
+	Direction SortDirection    `json:"Direction"`
 }
 
 type SpawnHostInput struct {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -777,7 +777,7 @@ func (r *patchResolver) CommitQueuePosition(ctx context.Context, apiPatch *restM
 }
 
 func (r *patchResolver) TaskStatuses(ctx context.Context, obj *restModel.APIPatch) ([]string, error) {
-	tasks, _, err := r.sc.FindTasksByVersion(*obj.Id, task.DisplayNameKey, []string{}, "", "", 1, 0, 0, []string{task.DisplayStatusKey})
+	tasks, _, err := r.sc.FindTasksByVersion(*obj.Id, task.DisplayNameKey, []string{}, []string{}, "", "", 1, 0, 0, []string{task.DisplayStatusKey}, nil)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting version tasks: %s", err.Error()))
 	}
@@ -1058,7 +1058,7 @@ func (r *queryResolver) Projects(ctx context.Context) (*Projects, error) {
 	return &pjs, nil
 }
 
-func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) (*PatchTasks, error) {
+func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, sorts []*SortOrder, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) (*PatchTasks, error) {
 	sorter := ""
 	if sortBy != nil {
 		switch *sortBy {
@@ -1091,10 +1091,6 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sortBy *
 	if limit != nil {
 		limitParam = *limit
 	}
-	statusesParam := []string{}
-	if statuses != nil {
-		statusesParam = statuses
-	}
 	variantParam := ""
 	if variant != nil {
 		variantParam = *variant
@@ -1103,12 +1099,35 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sortBy *
 	if taskName != nil {
 		taskNameParam = *taskName
 	}
-	tasks, count, err := r.sc.FindTasksByVersion(patchID, sorter, statusesParam, variantParam, taskNameParam, sortDirParam, pageParam, limitParam, []string{})
+	var taskSorts []task.TasksSortOrder
+	if len(sorts) > 0 {
+		taskSorts = []task.TasksSortOrder{}
+		for _, singleSort := range sorts {
+			key := ""
+			switch singleSort.Key {
+			// the keys here should be the keys for the column headers of the tasks table
+			case "NAME":
+				key = task.DisplayNameKey
+			case "STATUS":
+				key = task.DisplayStatusKey
+			case "BASE_STATUS":
+				key = task.BaseTaskStatusKey
+			case "VARIANT":
+				key = task.BuildVariantKey
+			default:
+				return nil, InputValidationError.Send(ctx, fmt.Sprintf("invalid sort key: %s", singleSort.Key))
+			}
+			if singleSort.Direction == 0 {
+				return nil, InputValidationError.Send(ctx, "0 is not a valid sort direction")
+			}
+			taskSorts = append(taskSorts, task.TasksSortOrder{Key: key, Order: singleSort.Direction})
+		}
+	}
+	tasks, count, err := r.sc.FindTasksByVersion(patchID, sorter, statuses, baseStatuses, variantParam, taskNameParam, sortDirParam, pageParam, limitParam, []string{}, taskSorts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting patch tasks for %s: %s", patchID, err.Error()))
 	}
-	baseTaskStatuses, _ := GetBaseTaskStatusesFromPatchID(r.sc, patchID)
-	taskResults := ConvertDBTasksToGqlTasks(tasks, baseTaskStatuses)
+	taskResults := ConvertDBTasksToGqlTasks(tasks)
 
 	if *sortBy == TaskSortCategoryBaseStatus {
 		sort.SliceStable(taskResults, func(i, j int) bool {
@@ -1125,20 +1144,6 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sortBy *
 			}
 			return iBaseStatus > jBaseStatus
 		})
-	}
-
-	if len(baseStatuses) > 0 {
-		// tasks cannot be filtered by base status through a DB query. tasks are filtered by base status here.
-		allTasks, err := task.Find(task.ByVersion(patchID))
-		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting tasks for patch %s: %s", patchID, err.Error()))
-		}
-		taskResults = FilterTasksByBaseStatuses(taskResults, baseStatuses, baseTaskStatuses)
-		if count > 0 {
-			// calculate filtered task count by base status
-			allTasksGql := ConvertDBTasksToGqlTasks(allTasks, baseTaskStatuses)
-			count = len(FilterTasksByBaseStatuses(allTasksGql, baseStatuses, baseTaskStatuses))
-		}
 	}
 
 	patchTasks := PatchTasks{
@@ -1429,7 +1434,7 @@ func (r *queryResolver) PatchBuildVariants(ctx context.Context, patchID string) 
 	for _, variant := range patch.Variants {
 		tasksByVariant[*variant] = []*PatchBuildVariantTask{}
 	}
-	tasks, _, err := r.sc.FindTasksByVersion(patchID, task.DisplayNameKey, []string{}, "", "", 1, 0, 0, []string{})
+	tasks, _, err := r.sc.FindTasksByVersion(patchID, task.DisplayNameKey, []string{}, []string{}, "", "", 1, 0, 0, []string{}, nil)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting tasks for patch `%s`: %s", patchID, err))
 	}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1106,21 +1106,22 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sortBy *
 			key := ""
 			switch singleSort.Key {
 			// the keys here should be the keys for the column headers of the tasks table
-			case "NAME":
+			case TaskSortCategoryName:
 				key = task.DisplayNameKey
-			case "STATUS":
+			case TaskSortCategoryStatus:
 				key = task.DisplayStatusKey
-			case "BASE_STATUS":
+			case TaskSortCategoryBaseStatus:
 				key = task.BaseTaskStatusKey
-			case "VARIANT":
+			case TaskSortCategoryVariant:
 				key = task.BuildVariantKey
 			default:
 				return nil, InputValidationError.Send(ctx, fmt.Sprintf("invalid sort key: %s", singleSort.Key))
 			}
-			if singleSort.Direction == 0 {
-				return nil, InputValidationError.Send(ctx, "0 is not a valid sort direction")
+			order := 1
+			if singleSort.Direction == SortDirectionDesc {
+				order = -1
 			}
-			taskSorts = append(taskSorts, task.TasksSortOrder{Key: key, Order: singleSort.Direction})
+			taskSorts = append(taskSorts, task.TasksSortOrder{Key: key, Order: order})
 		}
 	}
 	tasks, count, err := r.sc.FindTasksByVersion(patchID, sorter, statuses, baseStatuses, variantParam, taskNameParam, sortDirParam, pageParam, limitParam, []string{}, taskSorts)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -16,6 +16,7 @@ type Query {
     patchId: String!
     sortBy: TaskSortCategory = STATUS
     sortDir: SortDirection = ASC
+    sorts: [SortOrder!]
     page: Int = 0
     limit: Int = 0
     statuses: [String!] = []
@@ -299,6 +300,11 @@ input IssueLinkInput {
   issueKey: String!
 }
 
+input SortOrder {
+  Key: String!
+  Direction: Int!
+}
+
 type TaskQueueItem {
   id: ID!
   displayName: String!
@@ -511,9 +517,15 @@ type TaskResult {
   version: String!
   status: String!
   baseStatus: String
+  baseTask: BaseTaskResult
   buildVariant: String!
   blocked: Boolean!
   executionTasksFull: [Task!]
+}
+
+type BaseTaskResult {
+  id: ID!
+  status: String!
 }
 
 type PatchDuration {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -301,8 +301,8 @@ input IssueLinkInput {
 }
 
 input SortOrder {
-  Key: String!
-  Direction: Int!
+  Key: TaskSortCategory!
+  Direction: SortDirection!
 }
 
 type TaskQueueItem {

--- a/graphql/tests/patchTasks-aborted/data.json
+++ b/graphql/tests/patchTasks-aborted/data.json
@@ -10,7 +10,8 @@
       ],
       "r": "github_pull_request",
       "_id": "1",
-      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab"
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab"
     },
     {
       "status": "failed",
@@ -20,7 +21,8 @@
       "abort": true,
       "r": "github_pull_request",
       "_id": "2",
-      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab"
+      "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab"
     },
     {
       "status": "success",
@@ -63,8 +65,9 @@
       "display_name": "test-thirdparty-docker",
       "version": "evergreen_5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "ubuntu1604",
-      "r": "github_pull_request",
+      "r": "gitter_request",
       "_id": "base-task-1",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab"
     },
     {
@@ -73,8 +76,9 @@
       "version": "evergreen_5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "ubuntu1604",
       "abort": true,
-      "r": "github_pull_request",
+      "r": "gitter_request",
       "_id": "base-task-2",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab"
     },
     {

--- a/graphql/tests/patchTasks/data.json
+++ b/graphql/tests/patchTasks/data.json
@@ -183,6 +183,7 @@
       "_id": "1",
       "version": "5e4ff3abe3c3317e352062e4",
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "ubuntu1604",
       "display_name": "test-thirdparty-docker",
       "r": "github_pull_request",
@@ -195,15 +196,18 @@
       "_id": "2",
       "version": "5e4ff3abe3c3317e352062e4",
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "ubuntu1604",
       "display_name": "test-cloud",
       "r": "github_pull_request",
+      "branch": "myProject",
       "status": "failed"
     },
     {
       "_id": "3",
       "version": "5e4ff3abe3c3317e352062e4",
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "windows",
       "display_name": "lint",
       "r": "github_pull_request",
@@ -213,15 +217,22 @@
       "_id": "4",
       "version": "5e4ff3abe3c3317e352062e4",
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "windows",
       "display_name": "compile",
       "r": "github_pull_request",
-      "status": "task-timed-out"
+      "status": "failed",
+      "details": {
+        "status": "failed",
+        "timed_out": true,
+        "type": "test"
+      }
     },
     {
       "_id": "4.5",
       "version": "5e4ff3abe3c3317e352062e4",
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "windows",
       "display_name": "compile",
       "r": "github_pull_request",
@@ -235,6 +246,7 @@
       "_id": "1.5",
       "version": "5e4ff3abe3c3317e352062e4",
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "windows",
       "display_name": "compile",
       "r": "github_pull_request",
@@ -261,16 +273,20 @@
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "ubuntu1604",
       "display_name": "test-thirdparty-docker",
-      "r": "github_pull_request",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "branch": "myProject",
+      "r": "gitter_request",
       "status": "success"
     },
     {
       "_id": "base-task-2",
       "version": "evergreen_5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "ubuntu1604",
       "display_name": "test-cloud",
-      "r": "github_pull_request",
+      "branch": "myProject",
+      "r": "gitter_request",
       "status": "failed"
     },
     {
@@ -279,11 +295,13 @@
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "windows",
       "display_name": "lint",
-      "r": "github_pull_request",
-      "status": "test-timed-out",
+      "status": "failed",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "branch": "myProject",
+      "r": "gitter_request",
       "details": {
         "status": "failed",
-        "type": "system"
+        "type": "test"
       }
     },
     {
@@ -292,7 +310,9 @@
       "revision": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "build_variant": "windows",
       "display_name": "compile",
-      "r": "github_pull_request",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "branch": "myProject",
+      "r": "gitter_request",
       "status": "success"
     }
   ]

--- a/graphql/tests/patchTasks/queries/sort-by-base.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-base.graphql
@@ -1,5 +1,8 @@
 {
-  patchTasks(patchId: "5e4ff3abe3c3317e352062e4", baseStatuses: ["failed"]) {
+  patchTasks(
+    patchId: "5e4ff3abe3c3317e352062e4"
+    sorts: [{ Key: "BASE_STATUS", Direction: 1 }]
+  ) {
     tasks {
       id
       status

--- a/graphql/tests/patchTasks/queries/sort-by-base.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-base.graphql
@@ -1,7 +1,7 @@
 {
   patchTasks(
     patchId: "5e4ff3abe3c3317e352062e4"
-    sorts: [{ Key: "BASE_STATUS", Direction: 1 }]
+    sorts: [{ Key: BASE_STATUS, Direction: ASC }]
   ) {
     tasks {
       id

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -134,7 +134,7 @@
               {
                 "id": "3",
                 "status": "success",
-                "baseStatus": "test-timed-out",
+                "baseStatus": "failed",
                 "displayName": "lint",
                 "buildVariant": "windows"
               }
@@ -253,6 +253,84 @@
       }
     },
     {
+      "query_file": "sort-by-base.graphql",
+      "result": {
+        "data": {
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604",
+                "baseTask": {
+                  "id": "base-task-2",
+                  "status": "failed"
+                }
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "failed",
+                "displayName": "lint",
+                "buildVariant": "windows",
+                "baseTask": {
+                  "id": "base-task-3",
+                  "status": "failed"
+                }
+              },
+              {
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604",
+                "baseTask": {
+                  "id": "base-task-1",
+                  "status": "success"
+                }
+              },
+              {
+                "id": "1.5",
+                "status": "system-failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows",
+                "baseTask": {
+                  "id": "base-task-4",
+                  "status": "success"
+                }
+              },
+              {
+                "id": "4",
+                "status": "task-timed-out",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows",
+                "baseTask": {
+                  "id": "base-task-4",
+                  "status": "success"
+                }
+              },
+              {
+                "id": "4.5",
+                "status": "system-failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows",
+                "baseTask": {
+                  "id": "base-task-4",
+                  "status": "success"
+                }
+              }
+            ],
+            "count": 6
+          }
+        }
+      }
+    },
+    {
       "query_file": "sort-by-base-status.graphql",
       "result": {
         "data": {
@@ -260,6 +338,10 @@
             "tasks": [
               {
                 "id": "2",
+                "baseStatus": "failed"
+              },
+              {
+                "id": "3",
                 "baseStatus": "failed"
               },
               {
@@ -277,10 +359,6 @@
               {
                 "id": "4.5",
                 "baseStatus": "success"
-              },
-              {
-                "id": "3",
-                "baseStatus": "test-timed-out"
               }
             ],
             "count": 6
@@ -294,10 +372,6 @@
         "data": {
           "patchTasks": {
             "tasks": [
-              {
-                "id": "3",
-                "baseStatus": "test-timed-out"
-              },
               {
                 "id": "1",
                 "baseStatus": "success"
@@ -316,6 +390,10 @@
               },
               {
                 "id": "2",
+                "baseStatus": "failed"
+              },
+              {
+                "id": "3",
                 "baseStatus": "failed"
               }
             ],
@@ -340,7 +418,7 @@
               {
                 "id": "3",
                 "status": "success",
-                "baseStatus": "test-timed-out",
+                "baseStatus": "failed",
                 "displayName": "lint",
                 "buildVariant": "windows"
               },
@@ -408,10 +486,25 @@
                 "status": "failed",
                 "baseStatus": "failed",
                 "displayName": "test-cloud",
-                "buildVariant": "ubuntu1604"
+                "buildVariant": "ubuntu1604",
+                "baseTask": {
+                  "id": "base-task-2",
+                  "status": "failed"
+                }
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseStatus": "failed",
+                "displayName": "lint",
+                "buildVariant": "windows",
+                "baseTask": {
+                  "id": "base-task-3",
+                  "status": "failed"
+                }
               }
             ],
-            "count": 1
+            "count": 2
           }
         }
       }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -137,8 +137,12 @@ type Task struct {
 	Details   apimodels.TaskEndDetail `bson:"details" json:"task_end_details"`
 	Aborted   bool                    `bson:"abort,omitempty" json:"abort"`
 	AbortInfo AbortInfo               `bson:"abort_info,omitempty" json:"abort_info,omitempty"`
-	// DisplayStatus is not persisted to the db, but may be added via aggregation
+	// DisplayStatus is not persisted to the db. It is the status to display in the UI.
+	// It may be added via aggregation
 	DisplayStatus string `bson:"display_status,omitempty" json:"display_status,omitempty"`
+	// BaseTask is not persisted to the db. It is the data of the task on the base commit
+	// It may be added via aggregation
+	BaseTask BaseTaskInfo `bson:"base_task" json:"base_task"`
 
 	// TimeTaken is how long the task took to execute.  meaningless if the task is not finished
 	TimeTaken time.Duration `bson:"time_taken" json:"time_taken"`
@@ -236,6 +240,13 @@ type DistroCost struct {
 	Provider         string                 `json:"provider"`
 	ProviderSettings map[string]interface{} `json:"provider_settings"`
 	NumTasks         int                    `bson:"num_tasks"`
+}
+
+// BaseTaskInfo is a subset of task fields that should be returned for patch tasks.
+// The bson keys must match those of the actual task document
+type BaseTaskInfo struct {
+	Id     string `bson:"_id" json:"id"`
+	Status string `bson:"status" json:"status"`
 }
 
 func (d *Dependency) UnmarshalBSON(in []byte) error {
@@ -2598,19 +2609,14 @@ func GetTimeSpent(tasks []Task) (time.Duration, time.Duration) {
 	return timeTaken, latestFinishTime.Sub(earliestStartTime)
 }
 
-func getBsonFailureStatuses() bson.A {
-	failureStatusDocs := bson.A{}
-
-	for _, status := range evergreen.TaskFailureStatuses {
-		failureStatusDocs = append(failureStatusDocs, bson.M{"$eq": bson.A{"$" + DisplayStatusKey, status}})
-	}
-
-	return failureStatusDocs
+type TasksSortOrder struct {
+	Key   string
+	Order int
 }
 
 // GetTasksByVersion gets all tasks for a specific version
 // Query results can be filtered by task name, variant name and status in addition to being paginated and limited
-func GetTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int, fieldsToProject []string) ([]Task, int, error) {
+func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []string, baseStatuses []string, variant string, taskName string, page, limit int, fieldsToProject []string) ([]Task, int, error) {
 	match := bson.M{
 		VersionKey: versionID,
 	}
@@ -2645,11 +2651,51 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 		}},
 		// add a field for the display status of each task
 		addDisplayStatus,
+		// add data about the base task
+		{"$lookup": bson.M{
+			"from": Collection,
+			"let": bson.M{
+				RevisionKey:     "$" + RevisionKey,
+				BuildVariantKey: "$" + BuildVariantKey,
+				DisplayNameKey:  "$" + DisplayNameKey,
+			},
+			"as": BaseTaskKey,
+			"pipeline": []bson.M{
+				{"$match": bson.M{
+					RequesterKey: evergreen.RepotrackerVersionRequester,
+					"$expr": bson.M{
+						"$and": []bson.M{
+							{"$eq": []string{"$" + RevisionKey, "$$" + RevisionKey}},
+							{"$eq": []string{"$" + BuildVariantKey, "$$" + BuildVariantKey}},
+							{"$eq": []string{"$" + DisplayNameKey, "$$" + DisplayNameKey}},
+						},
+					},
+				}},
+				{"$project": bson.M{
+					IdKey:     1,
+					StatusKey: displayStatusExpression,
+				}},
+				{"$limit": 1},
+			},
+		}},
+		{
+			"$unwind": bson.M{
+				"path":                       "$" + BaseTaskKey,
+				"preserveNullAndEmptyArrays": true,
+			},
+		},
 	}
 	if len(statuses) > 0 {
 		pipeline = append(pipeline, bson.M{
 			"$match": bson.M{
 				DisplayStatusKey: bson.M{"$in": statuses},
+			},
+		})
+	}
+	if len(baseStatuses) > 0 {
+		pipeline = append(pipeline, bson.M{
+			"$match": bson.M{
+				BaseTaskStatusKey: bson.M{"$in": baseStatuses},
 			},
 		})
 	}
@@ -2659,46 +2705,22 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 	}
 	countPipeline = append(countPipeline, bson.M{"$count": "count"})
 
+	sortFields := bson.D{}
 	if len(sortBy) > 0 {
-		if sortBy == DisplayStatusKey {
-			// setting field `first` onto tasks with a failed status allows us to sort all failed statuses to top of query and then sort alphabetically
-			pipeline = append(pipeline, bson.M{
-				"$addFields": bson.M{
-					"first": bson.M{
-						"$cond": bson.M{
-							"if": bson.M{
-								"$or": getBsonFailureStatuses(),
-							},
-							"then": "a",
-							"else": "b",
-						},
-					},
-				},
-			})
-			// ordered sort with `first` at beginning of sort to sort all failure statuses to the top
-			pipeline = append(pipeline, bson.M{
-				"$sort": bson.D{
-					bson.E{Key: "first", Value: sortDir},
-					bson.E{Key: DisplayStatusKey, Value: sortDir},
-					bson.E{Key: IdKey, Value: 1},
-				},
-			})
-		} else {
-			pipeline = append(pipeline, bson.M{
-				"$sort": bson.D{
-					bson.E{Key: sortBy, Value: sortDir},
-					bson.E{Key: IdKey, Value: 1},
-				},
-			})
+		for _, singleSort := range sortBy {
+			if singleSort.Key == DisplayStatusKey || singleSort.Key == BaseTaskStatusKey {
+				pipeline = append(pipeline, addCustomStatusSortField((singleSort.Key)))
+				sortFields = append(sortFields, bson.E{Key: "__" + singleSort.Key, Value: singleSort.Order})
+				sortFields = append(sortFields, bson.E{Key: singleSort.Key, Value: singleSort.Order})
+			} else {
+				sortFields = append(sortFields, bson.E{Key: singleSort.Key, Value: singleSort.Order})
+			}
 		}
-	} else {
-		pipeline = append(pipeline, bson.M{
-			"$sort": bson.D{
-				// sort by _id to ensure a consistent sort order
-				bson.E{Key: IdKey, Value: 1},
-			},
-		})
 	}
+	sortFields = append(sortFields, bson.E{Key: IdKey, Value: 1})
+	pipeline = append(pipeline, bson.M{
+		"$sort": sortFields,
+	})
 
 	if limit > 0 {
 		pipeline = append(pipeline, bson.M{
@@ -2747,6 +2769,22 @@ func GetTasksByVersion(versionID, sortBy string, statuses []string, variant stri
 		count = tmp[0].Count
 	}
 	return tasks, count, nil
+}
+
+func addCustomStatusSortField(key string) bson.M {
+	return bson.M{
+		"$addFields": bson.M{
+			"__" + key: bson.M{
+				"$cond": bson.M{
+					"if": bson.M{
+						"$in": []interface{}{"$" + key, evergreen.TaskFailureStatuses},
+					},
+					"then": "a",
+					"else": "b",
+				},
+			},
+		},
+	}
 }
 
 func AddParentDisplayTasks(tasks []Task) ([]Task, error) {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -125,7 +125,7 @@ type Connector interface {
 	FindTestsByTaskId(string, string, string, string, int, int) ([]testresult.TestResult, error)
 	FindTestsByTaskIdFilterSortPaginate(string, string, []string, string, int, int, int, int) ([]testresult.TestResult, error)
 	GetTestCountByTaskIdAndFilters(string, string, []string, int) (int, error)
-	FindTasksByVersion(string, string, []string, string, string, int, int, int, []string) ([]task.Task, int, error)
+	FindTasksByVersion(string, string, []string, []string, string, string, int, int, int, []string, []task.TasksSortOrder) ([]task.Task, int, error)
 	// FindUserById is a method to find a specific user given its ID.
 	FindUserById(string) (gimlet.User, error)
 	//FindUserByGithubName is a method to find a user given their Github name, if configured.

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -221,8 +221,12 @@ func (tc *DBTaskConnector) GetManifestByTask(taskId string) (*manifest.Manifest,
 
 // FindTasksByVersion gets all tasks for a specific version
 // Results can be filtered by task name, variant name and status in addition to being paginated and limited
-func (tc *DBTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int, fieldsToProject []string) ([]task.Task, int, error) {
-	tasks, total, err := task.GetTasksByVersion(versionID, sortBy, statuses, variant, taskName, sortDir, page, limit, fieldsToProject)
+func (tc *DBTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, baseStatuses []string, variant string, taskName string, sortDir, page, limit int, fieldsToProject []string, sorts []task.TasksSortOrder) ([]task.Task, int, error) {
+	if sortBy != "" && sorts == nil {
+		sorts = []task.TasksSortOrder{}
+		sorts = append(sorts, task.TasksSortOrder{Key: sortBy, Order: sortDir})
+	}
+	tasks, total, err := task.GetTasksByVersion(versionID, sorts, statuses, baseStatuses, variant, taskName, page, limit, fieldsToProject)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -433,7 +437,6 @@ func (tc *MockTaskConnector) GetManifestByTask(taskId string) (*manifest.Manifes
 	return nil, errors.Errorf("task '%s' not found", taskId)
 }
 
-func (tc *MockTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, variant string, taskName string, sortDir, page, limit int, fieldsToProject []string) ([]task.Task, int, error) {
-	// FindTasksByVersion is extensively tested byt he gql test suite for the patchTasks query
+func (tc *MockTaskConnector) FindTasksByVersion(string, string, []string, []string, string, string, int, int, int, []string, []task.TasksSortOrder) ([]task.Task, int, error) {
 	return nil, 0, nil
 }

--- a/rest/model/generated.go
+++ b/rest/model/generated.go
@@ -4,9 +4,14 @@ package model
 
 import (
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 )
 
+type APIBaseTaskInfo struct {
+	Id     *string `json:"id"`
+	Status *string `json:"status"`
+}
 type APIDisplayTask struct {
 	Name           *string  `json:"name"`
 	ExecutionTasks []string `json:"execution_tasks"`
@@ -17,6 +22,24 @@ type APIDBUser struct {
 	OnlyApi      bool     `json:"only_api"`
 	Roles        []string `json:"roles"`
 	EmailAddress *string  `json:"email_address"`
+}
+
+// APIBaseTaskInfoBuildFromService takes the task.BaseTaskInfo DB struct and
+// returns the REST struct *APIBaseTaskInfo with the corresponding fields populated
+func APIBaseTaskInfoBuildFromService(t task.BaseTaskInfo) *APIBaseTaskInfo {
+	m := APIBaseTaskInfo{}
+	m.Id = StringStringPtr(t.Id)
+	m.Status = StringStringPtr(t.Status)
+	return &m
+}
+
+// APIBaseTaskInfoToService takes the APIBaseTaskInfo REST struct and returns the DB struct
+// *task.BaseTaskInfo with the corresponding fields populated
+func APIBaseTaskInfoToService(m APIBaseTaskInfo) *task.BaseTaskInfo {
+	out := &task.BaseTaskInfo{}
+	out.Id = StringPtrString(m.Id)
+	out.Status = StringPtrString(m.Status)
+	return out
 }
 
 // APIDisplayTaskBuildFromService takes the patch.DisplayTask DB struct and

--- a/rest/model/schema/rest_model.graphql
+++ b/rest/model/schema/rest_model.graphql
@@ -12,3 +12,8 @@ type DisplayTask {
   Name: String
   ExecutionTasks: [String!]! @aliases(db: ExecTasks)
 }
+
+type BaseTaskInfo {
+  Id: String
+  Status: String
+}

--- a/rest/model/schema/type_mapping.yml
+++ b/rest/model/schema/type_mapping.yml
@@ -3,3 +3,5 @@ models:
     model: github.com/evergreen-ci/evergreen/model/user.DBUser
   DisplayTask:
     model: github.com/evergreen-ci/evergreen/model/patch.DisplayTask
+  BaseTaskInfo:
+    model: github.com/evergreen-ci/evergreen/model/task.BaseTaskInfo

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -71,6 +71,7 @@ type APITask struct {
 	SyncAtEndOpts      APISyncAtEndOptions `json:"sync_at_end_opts"`
 	Ami                *string             `json:"ami"`
 	MustHaveResults    bool                `json:"must_have_test_results"`
+	BaseTask           APIBaseTaskInfo     `json:"base_task"`
 }
 
 type APIAbortInfo struct {
@@ -239,6 +240,12 @@ func (at *APITask) BuildFromService(t interface{}) error {
 				PRClosed:   v.AbortInfo.PRClosed,
 			},
 		}
+		if v.BaseTask.Id != "" {
+			at.BaseTask = APIBaseTaskInfo{
+				Id:     ToStringPtr(v.BaseTask.Id),
+				Status: ToStringPtr(v.BaseTask.Status),
+			}
+		}
 
 		if err := at.Details.BuildFromService(v.Details); err != nil {
 			return errors.Wrap(err, "can't build TaskEndDetail from service")
@@ -334,6 +341,10 @@ func (ad *APITask) ToService() (interface{}, error) {
 			Enabled:  ad.SyncAtEndOpts.Enabled,
 			Statuses: ad.SyncAtEndOpts.Statuses,
 			Timeout:  ad.SyncAtEndOpts.Timeout,
+		},
+		BaseTask: task.BaseTaskInfo{
+			Id:     FromStringPtr(ad.BaseTask.Id),
+			Status: FromStringPtr(ad.BaseTask.Status),
 		},
 	}
 	catcher := grip.NewBasicCatcher()


### PR DESCRIPTION
- Add a new computed field in the task data structure that contains info about its base task. Right now it just includes ID and status but it's easy to add to
- Use this new field in the patchTasks query instead of the old method of adding the base status afterwards. This allows us to be able to filter and sort by base task data.
- Add a new sort parameter to the patchTask query that supports sorting by any of the columns. The old sorting params are kept for 1 deploy to maintain backwards compatibility, but will be removed ASAP (along with supporting code/tests)