### PR TITLE
EVG-13629: exception to prevent small distros from being stranded by global MaxTotalDynamicHosts

### DIFF
--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -147,12 +147,12 @@ func (j *createHostJob) Run(ctx context.Context) {
 
 		allRunningDynamicHosts, err := host.CountAllRunningDynamicHosts()
 		j.AddError(err)
-		smallDistroException := false
+		lowHostNumException := false
 		if numHosts < 10 {
-			smallDistroException = true
+			lowHostNumException = true
 		}
 
-		if allRunningDynamicHosts > j.env.Settings().HostInit.MaxTotalDynamicHosts && !smallDistroException {
+		if allRunningDynamicHosts > j.env.Settings().HostInit.MaxTotalDynamicHosts && !lowHostNumException {
 
 			grip.Info(message.Fields{
 				"host_id":                 j.HostID,

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -147,8 +147,13 @@ func (j *createHostJob) Run(ctx context.Context) {
 
 		allRunningDynamicHosts, err := host.CountAllRunningDynamicHosts()
 		j.AddError(err)
+		smallDistroException := false
+		if numHosts < 10 {
+			smallDistroException = true
+		}
 
-		if allRunningDynamicHosts > j.env.Settings().HostInit.MaxTotalDynamicHosts {
+		if allRunningDynamicHosts > j.env.Settings().HostInit.MaxTotalDynamicHosts && !smallDistroException {
+
 			grip.Info(message.Fields{
 				"host_id":                 j.HostID,
 				"attempt":                 j.CurrentAttempt,


### PR DESCRIPTION
prevent small distros from being stranded  when global max hosts is reached