### PR TITLE
EVG-13693 add logging for test_logs volume

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1526,6 +1526,12 @@ func (t *Task) SetResults(results []TestResult) error {
 		docs[idx] = result.convertToNewStyleTestResult(t)
 	}
 
+	grip.Debug(message.Fields{
+		"message":        "writing test results",
+		"task":           t.Id,
+		"results_length": len(results),
+	})
+
 	return errors.Wrap(testresult.InsertMany(docs), "error inserting into testresults collection")
 }
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1529,6 +1529,10 @@ func (t *Task) SetResults(results []TestResult) error {
 	grip.Debug(message.Fields{
 		"message":        "writing test results",
 		"task":           t.Id,
+		"project":        t.Project,
+		"requester":      t.Requester,
+		"version":        t.Version,
+		"display_name":   t.DisplayName,
 		"results_length": len(results),
 	})
 

--- a/service/api.go
+++ b/service/api.go
@@ -274,10 +274,14 @@ func (as *APIServer) AttachTestLog(w http.ResponseWriter, r *http.Request) {
 	log.TaskExecution = t.Execution
 
 	grip.Debug(message.Fields{
-		"message":    "received test log",
-		"task":       t.Id,
-		"execution":  t.Execution,
-		"log_length": len(log.Lines),
+		"message":      "received test log",
+		"task":         t.Id,
+		"project":      t.Project,
+		"requester":    t.Requester,
+		"version":      t.Version,
+		"display_name": t.DisplayName,
+		"execution":    t.Execution,
+		"log_length":   len(log.Lines),
 	})
 
 	if err := log.Insert(); err != nil {

--- a/service/api.go
+++ b/service/api.go
@@ -273,6 +273,13 @@ func (as *APIServer) AttachTestLog(w http.ResponseWriter, r *http.Request) {
 	log.Task = t.Id
 	log.TaskExecution = t.Execution
 
+	grip.Debug(message.Fields{
+		"message":    "received test log",
+		"task":       t.Id,
+		"execution":  t.Execution,
+		"log_length": len(log.Lines),
+	})
+
 	if err := log.Insert(); err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return


### PR DESCRIPTION
It's really hard to tell what's writing so many logs.
Add (temporary?) logging so we can figure it out and ask the culprit to hold off until we finish[ PM-1607](https://jira.mongodb.org/browse/PM-1607).