### PR TITLE
EVG-13702 use timestamp instead of definition next runtime

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -1211,21 +1211,9 @@ func PopulatePeriodicBuilds(part int) amboy.QueueOperation {
 		catcher := grip.NewBasicCatcher()
 		for _, project := range projects {
 			for _, definition := range project.PeriodicBuilds {
-				grip.Debug(message.Fields{
-					"job":        periodicBuildJobName,
-					"message":    "evaluating project definitions",
-					"project":    project.Identifier,
-					"definition": definition.ID,
-				})
 				// schedule the job if we want it to start before the next time this cron runs
 				if time.Now().Add(15 * time.Minute).After(definition.NextRunTime) {
-					grip.Debug(message.Fields{
-						"job":        periodicBuildJobName,
-						"message":    "adding job for definition",
-						"project":    project.Identifier,
-						"definition": definition.ID,
-					})
-					catcher.Add(queue.Put(ctx, NewPeriodicBuildJob(project.Id, definition.ID, definition.NextRunTime)))
+					catcher.Add(queue.Put(ctx, NewPeriodicBuildJob(project.Id, definition.ID)))
 				}
 			}
 		}

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -55,7 +55,8 @@ func NewPeriodicBuildJob(projectID, definitionID string) amboy.Job {
 	j := makePeriodicBuildsJob()
 	j.ProjectID = projectID
 	j.DefinitionID = definitionID
-	j.SetID(fmt.Sprintf("%s-%s-%s-%s", periodicBuildJobName, projectID, definitionID, utility.RoundPartOfHour(15)))
+	ts := utility.RoundPartOfHour(15)
+	j.SetID(fmt.Sprintf("%s-%s-%s-%s", periodicBuildJobName, projectID, definitionID, ts))
 	j.UpdateTimeInfo(amboy.JobTimeInfo{WaitUntil: ts})
 
 	return j

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -51,11 +51,11 @@ func makePeriodicBuildsJob() *periodicBuildJob {
 	return j
 }
 
-func NewPeriodicBuildJob(projectID, definitionID string, ts time.Time) amboy.Job {
+func NewPeriodicBuildJob(projectID, definitionID string) amboy.Job {
 	j := makePeriodicBuildsJob()
 	j.ProjectID = projectID
 	j.DefinitionID = definitionID
-	j.SetID(fmt.Sprintf("%s-%s-%s-%s", periodicBuildJobName, projectID, definitionID, ts.Format(TSFormat)))
+	j.SetID(fmt.Sprintf("%s-%s-%s-%s", periodicBuildJobName, projectID, definitionID, utility.RoundPartOfHour(15)))
 	j.UpdateTimeInfo(amboy.JobTimeInfo{WaitUntil: ts})
 
 	return j


### PR DESCRIPTION
I'm using "RoundPartOfHour" because I like that it lines up with when periodic build jobs would be called. This will prevent deploys from creating periodic build madness.