### PR TITLE
EVG-13534 make project ref id separate from identifier

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1069,26 +1069,26 @@ func (p *Project) FindDistroNameForTask(t *task.Task) (string, error) {
 	return distro, nil
 }
 
-func FindLatestVersionWithValidProject(identifier string) (*Version, *Project, error) {
+func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, error) {
 	const retryCount = 5
-	if identifier == "" {
-		return nil, nil, errors.WithStack(errors.New("cannot pass empty identifier to FindLatestVersionWithValidProject"))
+	if projectId == "" {
+		return nil, nil, errors.WithStack(errors.New("cannot pass empty projectId to FindLatestVersionWithValidProject"))
 	}
 	project := &Project{
-		Identifier: identifier,
+		Identifier: projectId,
 	}
 
 	revisionOrderNum := -1 // only specify in the event of failure
 	var err error
 	var lastGoodVersion *Version
 	for i := 0; i < retryCount; i++ {
-		lastGoodVersion, err = FindVersionByLastKnownGoodConfig(identifier, revisionOrderNum)
+		lastGoodVersion, err = FindVersionByLastKnownGoodConfig(projectId, revisionOrderNum)
 		if err != nil {
 			// database error, don't log critical
 			continue
 		}
 		if lastGoodVersion != nil {
-			project, _, err = LoadProjectForVersion(lastGoodVersion, identifier, true)
+			project, _, err = LoadProjectForVersion(lastGoodVersion, projectId, true)
 			revisionOrderNum = lastGoodVersion.RevisionOrderNumber // look for an older version if the returned version is malformed
 		}
 		if err == nil {
@@ -1097,7 +1097,7 @@ func FindLatestVersionWithValidProject(identifier string) (*Version, *Project, e
 		grip.Critical(message.WrapError(err, message.Fields{
 			"message": "last known good version has malformed config",
 			"version": lastGoodVersion.Id,
-			"project": identifier,
+			"project": projectId,
 		}))
 	}
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -459,7 +459,7 @@ func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(interface{}) error) e
 
 // LoadProjectForVersion returns the project for a version, either from the parser project or the config string.
 // If read from the config string and shouldSave is set, the resulting parser project will be saved.
-func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Project, *ParserProject, error) {
+func LoadProjectForVersion(v *Version, id string, shouldSave bool) (*Project, *ParserProject, error) {
 	var pp *ParserProject
 	var err error
 
@@ -473,7 +473,7 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 		if pp.Functions == nil {
 			pp.Functions = map[string]*YAMLCommandSet{}
 		}
-		pp.Identifier = identifier
+		pp.Identifier = id
 		var p *Project
 		p, err = TranslateProject(pp)
 		return p, pp, err
@@ -483,19 +483,19 @@ func LoadProjectForVersion(v *Version, identifier string, shouldSave bool) (*Pro
 		return nil, nil, errors.New("version has no config")
 	}
 	p := &Project{}
-	pp, err = LoadProjectInto([]byte(v.Config), identifier, p)
+	pp, err = LoadProjectInto([]byte(v.Config), id, p)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error loading project")
 	}
 	pp.Id = v.Id
-	pp.Identifier = identifier
+	pp.Identifier = id
 	pp.ConfigUpdateNumber = v.ConfigUpdateNumber
 	pp.CreateTime = v.CreateTime
 
 	if shouldSave {
 		if err = pp.TryUpsert(); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
-				"project": identifier,
+				"project": id,
 				"version": v.Id,
 				"message": "error inserting parser project for version",
 			}))

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -247,6 +247,7 @@ func (projectRef *ProjectRef) Insert() error {
 }
 
 func (p *ProjectRef) Add(creator *user.DBUser) error {
+	p.Id = mgobson.NewObjectId().Hex()
 	err := db.Insert(ProjectRefCollection, p)
 	if err != nil {
 		return errors.Wrap(err, "Error inserting distro")
@@ -1203,12 +1204,12 @@ func GetSetupScriptForTask(ctx context.Context, taskId string) (string, error) {
 	configFile, err := thirdparty.GetGithubFile(ctx, token, pRef.Owner, pRef.Repo, pRef.SpawnHostScriptPath, "")
 	if err != nil {
 		return "", errors.Wrapf(err,
-			"error fetching spawn host script for '%s' at path '%s'", pRef.Id, pRef.SpawnHostScriptPath)
+			"error fetching spawn host script for '%s' at path '%s'", pRef.Identifier, pRef.SpawnHostScriptPath)
 	}
 	fileContents, err := base64.StdEncoding.DecodeString(*configFile.Content)
 	if err != nil {
 		return "", errors.Wrapf(err,
-			"unable to spawn host script for '%s' at path '%s'", pRef.Id, pRef.SpawnHostScriptPath)
+			"unable to spawn host script for '%s' at path '%s'", pRef.Identifier, pRef.SpawnHostScriptPath)
 	}
 
 	return string(fileContents), nil

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
+	mgobson "gopkg.in/mgo.v2/bson"
 )
 
 func TestFindOneProjectRef(t *testing.T) {
@@ -514,9 +516,11 @@ func TestAddPermissions(t *testing.T) {
 	}
 	assert.NoError(u.Insert())
 	p := ProjectRef{
-		Id: "myProject",
+		Identifier: "myProject",
 	}
 	assert.NoError(p.Add(&u))
+	assert.NotEmpty(p.Id)
+	assert.True(mgobson.IsObjectIdHex(p.Id))
 
 	rm := evergreen.GetEnvironment().RoleManager()
 	scope, err := rm.FindScopeForResources(evergreen.ProjectResourceType, p.Id)
@@ -532,7 +536,7 @@ func TestAddPermissions(t *testing.T) {
 	assert.NotNil(role)
 	dbUser, err := user.FindOneById(u.Id)
 	assert.NoError(err)
-	assert.Contains(dbUser.Roles(), "admin_project_myProject")
+	assert.Contains(dbUser.Roles(), fmt.Sprintf("admin_project_%s", p.Id))
 }
 
 func TestUpdateAdminRoles(t *testing.T) {

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -286,8 +286,11 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
         function (resp) {
           var data_put = resp.data;
           item = Object.assign({}, $scope.settingsFormData);
+          item.identifier = $scope.newProject.identifier;
           item.pr_testing_enabled = false;
           item.commit_queue.enabled = false;
+          item.git_tag_versions_enabled = false;
+          item.github_checks_enabled = false;
           item.enabled = false;
           item.subscriptions = _.filter($scope.subscriptions, function (d) {
             return !d.changed;
@@ -365,6 +368,7 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
         });
 
         $scope.settingsFormData = {
+          id: $scope.projectRef.id,
           identifier: $scope.projectRef.identifier,
           project_vars: $scope.projectVars,
           private_vars: $scope.privateVars,
@@ -542,19 +546,18 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
       $scope.addGitTagTeam();
     }
 
-    $http.post('/project/' + $scope.settingsFormData.identifier, $scope.settingsFormData).then(
+    $http.post('/project/' + $scope.settingsFormData.id, $scope.settingsFormData).then(
       function (resp) {
         var data = resp.data;
         $scope.saveMessage = "Settings Saved.";
         $scope.refreshTrackedProjects(data.AllProjects);
         $scope.settingsForm.$setPristine();
         $scope.settingsFormData.force_repotracker_run = false;
-        $scope.loadProject($scope.settingsFormData.identifier)
+        $scope.loadProject($scope.settingsFormData.id)
         $scope.isDirty = false;
       },
       function (resp) {
-        $scope.saveMessage = "Couldn't save project: " + resp.data.error;
-        console.log(resp.status);
+        $scope.saveMessage = "Couldn't save project: " + resp.data;
       });
   };
 

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"time"
 
+	mgobson "gopkg.in/mgo.v2/bson"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
@@ -392,7 +394,7 @@ func (pc *MockProjectConnector) FindProjects(key string, limit int, sortDir int)
 
 func (pc *MockProjectConnector) FindProjectById(projectId string) (*model.ProjectRef, error) {
 	for _, p := range pc.CachedProjects {
-		if p.Id == projectId {
+		if p.Id == projectId || p.Identifier == projectId {
 			return &p, nil
 		}
 	}
@@ -403,6 +405,7 @@ func (pc *MockProjectConnector) FindProjectById(projectId string) (*model.Projec
 }
 
 func (pc *MockProjectConnector) CreateProject(projectRef *model.ProjectRef, u *user.DBUser) error {
+	projectRef.Id = mgobson.NewObjectId().Hex()
 	for _, p := range pc.CachedProjects {
 		if p.Id == projectRef.Id {
 			return gimlet.ErrorResponse{

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -8,6 +8,7 @@ import (
 // publicProjectFields are the fields needed by the UI
 // on base_angular and the menu
 type UIProjectFields struct {
+	Id          string `json:"id"`
 	Identifier  string `json:"identifier"`
 	DisplayName string `json:"display_name"`
 	Repo        string `json:"repo_name"`

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -503,7 +503,7 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 		// use the standard project config with the git tag alias
 		info.Project, info.IntermediateProject, err = gh.sc.LoadProjectForVersion(existingVersion, pRef.Id)
 		if err != nil {
-			return nil, errors.Wrapf(err, "problem getting project for  '%s'", pRef.Id)
+			return nil, errors.Wrapf(err, "problem getting project for  '%s'", pRef.Identifier)
 		}
 		metadata.Alias = evergreen.GitTagAlias
 	}

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -592,6 +592,7 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 	if projectRef == nil {
 		return nil, http.StatusNotFound, errors.Errorf("error finding the project '%s'", projectID)
 	}
+	projectID = projectRef.Id
 
 	// check to see if this is an anonymous user requesting a private project
 	user := gimlet.GetUser(r.Context())

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -614,7 +614,6 @@ func (h *projectIDPutHandler) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("Unexpected type %T for model.ProjectRef", i),
 		})
 	}
-	dbProjectRef.Id = h.projectName
 	dbProjectRef.Identifier = h.projectName
 
 	responder := gimlet.NewJSONResponse(struct{}{})

--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -70,7 +70,6 @@ func (p *projectCopyHandler) Run(ctx context.Context) gimlet.Responder {
 
 	// copy project, disable necessary settings
 	oldId := projectToCopy.Id
-	projectToCopy.Id = p.newProject // TODO: this will be internally generated in future work
 	projectToCopy.Identifier = p.newProject
 	projectToCopy.Enabled = false
 	projectToCopy.PRTestingEnabled = false

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -31,14 +31,14 @@ func (s *ProjectCopySuite) SetupSuite() {
 	s.data = data.MockProjectConnector{
 		CachedProjects: []model.ProjectRef{
 			{
-				Id:         "projectA",
+				Id:         "12345",
 				Identifier: "projectA",
 				Branch:     "abcd",
 				Enabled:    true,
 				Admins:     []string{"my-user"},
 			},
 			{
-				Id:         "projectB",
+				Id:         "23456",
 				Identifier: "projectB",
 				Branch:     "bcde",
 				Enabled:    true,
@@ -47,7 +47,7 @@ func (s *ProjectCopySuite) SetupSuite() {
 		},
 		CachedVars: []*model.ProjectVars{
 			{
-				Id:          "projectA",
+				Id:          "12345",
 				Vars:        map[string]string{"a": "1", "b": "2"},
 				PrivateVars: map[string]bool{"b": true},
 			},
@@ -94,7 +94,7 @@ func (s *ProjectCopySuite) TestCopyToNewProject() {
 	s.Require().Equal(http.StatusOK, resp.Status())
 
 	newProject := resp.Data().(*restmodel.APIProjectRef)
-	s.Equal("projectC", restmodel.FromStringPtr(newProject.Id))
+	s.NotEqual("projectC", restmodel.FromStringPtr(newProject.Id))
 	s.Equal("projectC", restmodel.FromStringPtr(newProject.Identifier))
 	s.Equal("abcd", restmodel.FromStringPtr(newProject.Branch))
 	s.False(newProject.Enabled)
@@ -107,6 +107,10 @@ func (s *ProjectCopySuite) TestCopyToNewProject() {
 	res, err = s.route.sc.FindProjectById("projectA")
 	s.NoError(err)
 	s.NotNil(res)
+	vars, err := s.route.sc.FindProjectVarsById(restmodel.FromStringPtr(newProject.Id), false)
+	s.NoError(err)
+	s.Require().NotNil(vars)
+	s.Len(vars.Vars, 2)
 }
 
 type copyVariablesSuite struct {

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -263,7 +263,7 @@ func (s *ProjectPutSuite) TestRunNewWithValidEntity() {
 	p, err := h.sc.FindProjectById("nutsandgum")
 	s.NoError(err)
 	s.Require().NotNil(p)
-	s.Equal("nutsandgum", p.Id)
+	s.NotEqual("nutsandgum", p.Id)
 	s.Equal("nutsandgum", p.Identifier)
 }
 

--- a/service/project.go
+++ b/service/project.go
@@ -668,7 +668,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		}
 		if projectVars == nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError,
-				errors.Errorf("no project variables for project '%s'"))
+				errors.Errorf("no project variables for project '%s'", responseRef.Identifier))
 			return
 		}
 		projectVars.Id = id

--- a/service/project.go
+++ b/service/project.go
@@ -776,7 +776,6 @@ func (uis *UIServer) addProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	newProject := model.ProjectRef{
-		Id:         id,
 		Identifier: id,
 		Hidden:     false,
 	}

--- a/service/project.go
+++ b/service/project.go
@@ -7,9 +7,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/evergreen-ci/gimlet/rolemanager"
-	"github.com/evergreen-ci/utility"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
@@ -20,6 +17,8 @@ import (
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/gimlet/rolemanager"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -109,14 +108,18 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 		projRef.PatchTriggerAliases[i].ChildProject = childProject.Identifier
 	}
 
-	projVars, err := model.FindOneProjectVars(id)
+	projVars, err := model.FindOneProjectVars(projRef.Id)
 	if err != nil {
+		uis.LoggedError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	if projVars == nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 	projVars = projVars.RedactPrivateVars()
 
-	projectAliases, err := model.FindAliasesForProject(id)
+	projectAliases, err := model.FindAliasesForProject(projRef.Id)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
@@ -211,20 +214,19 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	projectRef, err := model.FindOneProjectRef(id)
-
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-
 	if projectRef == nil {
 		http.Error(w, "Project not found", http.StatusNotFound)
 		return
 	}
-
+	id = projectRef.Id
 	origProjectRef := *projectRef
 
 	responseRef := struct {
+		Id                      string                         `json:"id"`
 		Identifier              string                         `json:"identifier"`
 		DisplayName             string                         `json:"display_name"`
 		RemotePath              string                         `json:"remote_path"`
@@ -519,6 +521,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	projectRef.Id = id
 	projectRef.DisplayName = responseRef.DisplayName
 	projectRef.RemotePath = responseRef.RemotePath
 	projectRef.SpawnHostScriptPath = responseRef.SpawnHostScriptPath
@@ -538,7 +541,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectRef.GitTagVersionsEnabled = responseRef.GitTagVersionsEnabled
 	projectRef.UseRepoSettings = responseRef.UseRepoSettings
 	projectRef.Hidden = responseRef.Hidden
-	projectRef.Id = id
+	projectRef.Identifier = responseRef.Identifier
 	projectRef.PRTestingEnabled = responseRef.PRTestingEnabled
 	projectRef.GithubChecksEnabled = responseRef.GithubChecksEnabled
 	projectRef.CommitQueue = commitQueueParams
@@ -656,11 +659,16 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 
 	// if we're copying a project we should use the variables from the DB for that project,
 	// in order to get/store the correct values for private variables.
-	if responseRef.Identifier != id && responseRef.Identifier != "" {
-		projectVars, err = model.FindOneProjectVars(responseRef.Identifier)
+	if responseRef.Id != id && responseRef.Id != "" {
+		projectVars, err = model.FindOneProjectVars(responseRef.Id)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError,
 				errors.Wrapf(err, "problem getting variables for project '%s'", responseRef.Identifier))
+			return
+		}
+		if projectVars == nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError,
+				errors.Errorf("no project variables for project '%s'"))
 			return
 		}
 		projectVars.Id = id
@@ -901,12 +909,12 @@ func (uis *UIServer) projectEvents(w http.ResponseWriter, r *http.Request) {
 	uis.render.WriteResponse(w, http.StatusOK, data, "base", template, "base_angular.html", "menu.html")
 }
 
-func verifyAliasExists(alias, projectIdentifier string, newAliasDefinitions []model.ProjectAlias, deletedAliasDefinitionIDs []string) (bool, error) {
+func verifyAliasExists(alias, projectId string, newAliasDefinitions []model.ProjectAlias, deletedAliasDefinitionIDs []string) (bool, error) {
 	if len(newAliasDefinitions) > 0 {
 		return true, nil
 	}
 
-	existingAliasDefinitions, err := model.FindAliasInProjectOrRepo(projectIdentifier, alias)
+	existingAliasDefinitions, err := model.FindAliasInProjectOrRepo(projectId, alias)
 	if err != nil {
 		return false, errors.Wrap(err, "error checking for existing aliases")
 	}

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -40,7 +40,7 @@ Evergreen Projects
     <div class="row">
       <ul class="list-unstyled col-lg-offset-1" id="projects-table">
         <li ng-repeat="project in enabledProjects | orderBy:'identifier'" style="padding:3px">
-          <a ng-click="loadProject(project.identifier)"  ng-class="{true:'current-project', false:''}[shouldHighlight(project)]" style="cursor:pointer;padding:5px;">
+          <a ng-click="loadProject(project.id)"  ng-class="{true:'current-project', false:''}[shouldHighlight(project)]" style="cursor:pointer;padding:5px;">
             [[project.identifier]]
           </a>
         </li>
@@ -52,7 +52,7 @@ Evergreen Projects
     <div class="row">
       <ul class="list-unstyled col-lg-offset-1">
         <li ng-repeat="project in disabledProjects | orderBy : 'identifier'" style="padding:3px">
-          <a ng-click="loadProject(project.identifier)" ng-class="{true:'current-project', false:''}[shouldHighlight(project)]" style="cursor:pointer;padding:5px">
+          <a ng-click="loadProject(project.id)" ng-class="{true:'current-project', false:''}[shouldHighlight(project)]" style="cursor:pointer;padding:5px">
             [[project.identifier]]
           </a>
         </li>


### PR DESCRIPTION
Because ID is our internal immutable representation, it doesn't really make sense to have it be user-defined, since the identifier could be changed to something completely different and the ID could become misleading (and it could never be used as an identifier name for a future project). If I missed a spot where we use Identifier when we should use ID, then any new projects (that have different IDs / identifiers) may encounter a bug, and probably the only way to fix would be a hot fix (although it would be a relatively simple fix).

In staging I'd like to switch the mci and yb_mci projects to new projects, so they have different ID / Identifier (I tested some things already with a new yb_mci). Potentially in prod too, although this would switch over our waterfall and etc so maybe not worth it.