### PR TITLE
EVG-13725 track cq source in individual items

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -126,6 +126,7 @@ type ComplexityRoot struct {
 		Issue       func(childComplexity int) int
 		Modules     func(childComplexity int) int
 		Patch       func(childComplexity int) int
+		Source      func(childComplexity int) int
 		Version     func(childComplexity int) int
 	}
 
@@ -1185,6 +1186,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CommitQueueItem.Patch(childComplexity), true
+
+	case "CommitQueueItem.source":
+		if e.complexity.CommitQueueItem.Source == nil {
+			break
+		}
+
+		return e.complexity.CommitQueueItem.Source(childComplexity), true
 
 	case "CommitQueueItem.version":
 		if e.complexity.CommitQueueItem.Version == nil {
@@ -5218,6 +5226,7 @@ type CommitQueueItem {
   version: String
   enqueueTime: Time
   patch: Patch
+  source: String
   modules: [Module!]
 }
 
@@ -7936,6 +7945,37 @@ func (ec *executionContext) _CommitQueueItem_patch(ctx context.Context, field gr
 	res := resTmp.(*model.APIPatch)
 	fc.Result = res
 	return ec.marshalOPatch2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIPatch(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CommitQueueItem_source(ctx context.Context, field graphql.CollectedField, obj *model.APICommitQueueItem) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "CommitQueueItem",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Source, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CommitQueueItem_modules(ctx context.Context, field graphql.CollectedField, obj *model.APICommitQueueItem) (ret graphql.Marshaler) {
@@ -24411,6 +24451,8 @@ func (ec *executionContext) _CommitQueueItem(ctx context.Context, sel ast.Select
 			out.Values[i] = ec._CommitQueueItem_enqueueTime(ctx, field, obj)
 		case "patch":
 			out.Values[i] = ec._CommitQueueItem_patch(ctx, field, obj)
+		case "source":
+			out.Values[i] = ec._CommitQueueItem_source(ctx, field, obj)
 		case "modules":
 			out.Values[i] = ec._CommitQueueItem_modules(ctx, field, obj)
 		default:

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1488,7 +1488,7 @@ func (r *queryResolver) CommitQueue(ctx context.Context, id string) (*restModel.
 		commitQueue.Message = &project.CommitQueue.Message
 	}
 
-	if project.CommitQueue.PatchType == commitqueue.PRPatchType {
+	if project.CommitQueue.PatchType == commitqueue.SourcePullRequest {
 		if len(commitQueue.Queue) > 0 {
 			versionId := restModel.FromStringPtr(commitQueue.Queue[0].Version)
 			if versionId != "" {
@@ -1806,7 +1806,7 @@ func (r *mutationResolver) EnqueuePatch(ctx context.Context, patchID string) (*r
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error creating new patch: %s", err.Error()))
 	}
 
-	_, err = r.sc.EnqueueItem(restModel.FromStringPtr(newPatch.Project), restModel.APICommitQueueItem{Issue: newPatch.Id}, false)
+	_, err = r.sc.EnqueueItem(restModel.FromStringPtr(newPatch.Project), restModel.APICommitQueueItem{Issue: newPatch.Id, Source: restModel.ToStringPtr(commitqueue.SourceCommandLine)}, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error enqueuing new patch: %s", err.Error()))
 	}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1806,7 +1806,7 @@ func (r *mutationResolver) EnqueuePatch(ctx context.Context, patchID string) (*r
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error creating new patch: %s", err.Error()))
 	}
 
-	_, err = r.sc.EnqueueItem(restModel.FromStringPtr(newPatch.Project), restModel.APICommitQueueItem{Issue: newPatch.Id, Source: restModel.ToStringPtr(commitqueue.SourceCommandLine)}, false)
+	_, err = r.sc.EnqueueItem(restModel.FromStringPtr(newPatch.Project), restModel.APICommitQueueItem{Issue: newPatch.Id, Source: restModel.ToStringPtr(commitqueue.SourceDiff)}, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error enqueuing new patch: %s", err.Error()))
 	}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -744,6 +744,7 @@ type CommitQueueItem {
   version: String
   enqueueTime: Time
   patch: Patch
+  source: String
   modules: [Module!]
 }
 

--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -17,6 +17,7 @@ const (
 	triggerComment    = "evergreen merge"
 	SourcePullRequest = "PR"
 	SourceCommandLine = "CLI"
+	SourceDiff        = "diff"
 )
 
 type Module struct {

--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	triggerComment = "evergreen merge"
-	PRPatchType    = "PR"
-	CLIPatchType   = "CLI"
+	triggerComment    = "evergreen merge"
+	SourcePullRequest = "PR"
+	SourceCommandLine = "CLI"
 )
 
 type Module struct {
@@ -33,6 +33,7 @@ type CommitQueueItem struct {
 	EnqueueTime     time.Time `bson:"enqueue_time"`
 	Modules         []Module  `bson:"modules"`
 	MessageOverride string    `bson:"message_override"`
+	Source          string    `bson:"source"`
 }
 
 func (i *CommitQueueItem) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(i) }
@@ -178,7 +179,7 @@ func RemoveCommitQueueItemForVersion(projectId, patchType, version string, user 
 	}
 
 	issue := version
-	if patchType == PRPatchType {
+	if patchType == SourcePullRequest {
 		head, valid := cq.Next()
 		// version is populated for PR items at the top of the queue only,
 		// so if the version for the item at the top of the queue doesn't match
@@ -212,13 +213,13 @@ func (cq *CommitQueue) RemoveItemAndPreventMerge(issue, patchType string, versio
 }
 
 func preventMergeForItem(patchType string, versionExists bool, item CommitQueueItem, user string) error {
-	if patchType == PRPatchType && item.Version != "" {
+	if patchType == SourcePullRequest && item.Version != "" {
 		if err := clearVersionPatchSubscriber(item.Version, event.GithubMergeSubscriberType); err != nil {
 			return errors.Wrap(err, "can't clear subscriptions")
 		}
 	}
 
-	if patchType == CLIPatchType && versionExists {
+	if patchType == SourceCommandLine && versionExists {
 		if err := clearVersionPatchSubscriber(item.Issue, event.CommitQueueDequeueSubscriberType); err != nil {
 			return errors.Wrap(err, "can't clear subscriptions")
 		}

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -269,7 +269,7 @@ func TestPreventMergeForItemPR(t *testing.T) {
 		Version: patchID,
 	}
 
-	assert.NoError(t, preventMergeForItem(PRPatchType, false, item, "user"))
+	assert.NoError(t, preventMergeForItem(SourcePullRequest, false, item, "user"))
 	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: item.Version}})
 	assert.NoError(t, err)
 	assert.Empty(t, subscriptions)
@@ -292,7 +292,7 @@ func TestPreventMergeForItemCLI(t *testing.T) {
 	require.NoError(t, mergeTask.Insert())
 
 	// Without a corresponding version
-	assert.NoError(t, preventMergeForItem(CLIPatchType, false, item, "user"))
+	assert.NoError(t, preventMergeForItem(SourceCommandLine, false, item, "user"))
 	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, subscriptions)
@@ -302,7 +302,7 @@ func TestPreventMergeForItemCLI(t *testing.T) {
 	assert.Equal(t, int64(0), mergeTask.Priority)
 
 	// With a corresponding version
-	assert.NoError(t, preventMergeForItem(CLIPatchType, true, item, "user"))
+	assert.NoError(t, preventMergeForItem(SourceCommandLine, true, item, "user"))
 	subscriptions, err = event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
 	assert.NoError(t, err)
 	assert.Empty(t, subscriptions)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -562,7 +562,7 @@ func (e *EnqueuePatch) Send() error {
 		return errors.Wrap(err, "problem making merge patch")
 	}
 
-	_, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: mergePatch.Id.Hex(), Source: commitqueue.SourceCommandLine})
+	_, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: mergePatch.Id.Hex(), Source: commitqueue.SourceDiff})
 
 	return errors.Wrap(err, "can't enqueue item")
 }
@@ -777,7 +777,7 @@ func restartCLIItems(patches []patch.Patch, cq *commitqueue.CommitQueue) ([]stri
 			patchesWithErrors = append(patchesWithErrors, p.Id.Hex())
 			continue
 		}
-		if _, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: newPatch.Id.Hex(), Source: commitqueue.SourceCommandLine}); err != nil {
+		if _, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: newPatch.Id.Hex(), Source: commitqueue.SourceDiff}); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"patch":             p.Id,
 				"commit_queue":      cq.ProjectID,

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -562,7 +562,7 @@ func (e *EnqueuePatch) Send() error {
 		return errors.Wrap(err, "problem making merge patch")
 	}
 
-	_, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: mergePatch.Id.Hex()})
+	_, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: mergePatch.Id.Hex(), Source: commitqueue.SourceCommandLine})
 
 	return errors.Wrap(err, "can't enqueue item")
 }
@@ -659,11 +659,11 @@ func RetryCommitQueueItems(projectID string, patchType string, opts RestartOptio
 		}
 		return toBeRequeued, nil, nil
 	}
-	if patchType == commitqueue.PRPatchType {
+	if patchType == commitqueue.SourcePullRequest {
 		restarted, notRestarted := restartPRItems(patches, cq)
 		return restarted, notRestarted, nil
 	}
-	if patchType == commitqueue.CLIPatchType {
+	if patchType == commitqueue.SourceCommandLine {
 		restarted, notRestarted := restartCLIItems(patches, cq)
 		return restarted, notRestarted, nil
 	}
@@ -688,12 +688,13 @@ func restartPRItems(patches []patch.Patch, cq *commitqueue.CommitQueue) ([]strin
 		item := commitqueue.CommitQueueItem{
 			Issue:   strconv.Itoa(p.GithubPatchData.PRNumber),
 			Modules: modules,
+			Source:  commitqueue.SourcePullRequest,
 		}
 		if _, err := cq.Enqueue(item); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"patch":             p.Id,
 				"commit_queue":      cq.ProjectID,
-				"commit_queue_type": commitqueue.PRPatchType,
+				"commit_queue_type": commitqueue.SourcePullRequest,
 				"item":              item.Issue,
 				"message":           "error enqueuing item",
 				"operation":         "restart failed commit queue versions",
@@ -715,7 +716,7 @@ func restartCLIItems(patches []patch.Patch, cq *commitqueue.CommitQueue) ([]stri
 			grip.Error(message.WrapError(err, message.Fields{
 				"patch":             p.Id,
 				"commit_queue":      cq.ProjectID,
-				"commit_queue_type": commitqueue.CLIPatchType,
+				"commit_queue_type": commitqueue.SourceCommandLine,
 				"user":              p.Author,
 				"message":           "error finding user patch",
 				"operation":         "restart failed commit queue versions",
@@ -727,7 +728,7 @@ func restartCLIItems(patches []patch.Patch, cq *commitqueue.CommitQueue) ([]stri
 			grip.Error(message.WrapError(err, message.Fields{
 				"patch":             p.Id,
 				"commit_queue":      cq.ProjectID,
-				"commit_queue_type": commitqueue.CLIPatchType,
+				"commit_queue_type": commitqueue.SourceCommandLine,
 				"user":              p.Author,
 				"message":           "user for patch not found",
 				"operation":         "restart failed commit queue versions",
@@ -740,7 +741,7 @@ func restartCLIItems(patches []patch.Patch, cq *commitqueue.CommitQueue) ([]stri
 			grip.Error(message.WrapError(err, message.Fields{
 				"patch":             p.Id,
 				"commit_queue":      cq.ProjectID,
-				"commit_queue_type": commitqueue.CLIPatchType,
+				"commit_queue_type": commitqueue.SourceCommandLine,
 				"user":              p.Author,
 				"message":           "error computing patch number",
 				"operation":         "restart failed commit queue versions",
@@ -769,18 +770,18 @@ func restartCLIItems(patches []patch.Patch, cq *commitqueue.CommitQueue) ([]stri
 			grip.Error(message.WrapError(err, message.Fields{
 				"patch":             p.Id,
 				"commit_queue":      cq.ProjectID,
-				"commit_queue_type": commitqueue.CLIPatchType,
+				"commit_queue_type": commitqueue.SourceCommandLine,
 				"message":           "error inserting new patch",
 				"operation":         "restart failed commit queue versions",
 			}))
 			patchesWithErrors = append(patchesWithErrors, p.Id.Hex())
 			continue
 		}
-		if _, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: newPatch.Id.Hex()}); err != nil {
+		if _, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: newPatch.Id.Hex(), Source: commitqueue.SourceCommandLine}); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"patch":             p.Id,
 				"commit_queue":      cq.ProjectID,
-				"commit_queue_type": commitqueue.CLIPatchType,
+				"commit_queue_type": commitqueue.SourceCommandLine,
 				"message":           "error enqueueing item",
 				"operation":         "restart failed commit queue versions",
 			}))

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -810,7 +810,7 @@ func TestRetryCommitQueueItems(t *testing.T) {
 
 	for name, test := range map[string]func(*testing.T){
 		"PRCommitQueueItems": func(*testing.T) {
-			projectRef.CommitQueue.PatchType = commitqueue.PRPatchType
+			projectRef.CommitQueue.PatchType = commitqueue.SourcePullRequest
 			assert.NoError(t, projectRef.Insert())
 
 			restarted, notRestarted, err := RetryCommitQueueItems(projectRef.Id, projectRef.CommitQueue.PatchType, opts)
@@ -829,7 +829,7 @@ func TestRetryCommitQueueItems(t *testing.T) {
 
 		},
 		"CLICommitQueueItems": func(*testing.T) {
-			projectRef.CommitQueue.PatchType = commitqueue.CLIPatchType
+			projectRef.CommitQueue.PatchType = commitqueue.SourceCommandLine
 			assert.NoError(t, projectRef.Insert())
 
 			u := user.DBUser{Id: "me", PatchNumber: 12}
@@ -855,7 +855,7 @@ func TestRetryCommitQueueItems(t *testing.T) {
 			assert.Equal(t, 0, cq.FindItem(newPatch.Id.Hex()))
 		},
 		"UnstartedPatch": func(*testing.T) {
-			projectRef.CommitQueue.PatchType = commitqueue.PRPatchType
+			projectRef.CommitQueue.PatchType = commitqueue.SourcePullRequest
 			assert.NoError(t, projectRef.Insert())
 
 			// not started but terminated within time range

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1470,7 +1470,7 @@ func TestTryDequeueAndAbortBlockedCommitQueueVersion(t *testing.T) {
 	assert.NoError(t, commitqueue.InsertQueue(cq))
 
 	pRef := &ProjectRef{Id: cq.ProjectID}
-	pRef.CommitQueue.PatchType = commitqueue.CLIPatchType
+	pRef.CommitQueue.PatchType = commitqueue.SourceCommandLine
 
 	assert.NoError(t, TryDequeueAndAbortCommitQueueVersion(pRef, &task.Task{Id: "t1", Version: v.Id}, evergreen.User))
 	cq, err := commitqueue.FindOneId("my-project")

--- a/model/version.go
+++ b/model/version.go
@@ -123,7 +123,7 @@ func (v *Version) GetTimeSpent() (time.Duration, time.Duration, error) {
 
 func VersionExistsForCommitQueueItem(cq *commitqueue.CommitQueue, issue, patchType string) (bool, error) {
 	versionID := issue
-	if patchType == commitqueue.PRPatchType {
+	if patchType == commitqueue.SourcePullRequest {
 		head, valid := cq.Next()
 		// versions are created for PR items at the top of the queue only
 		if !valid || head.Issue != issue {

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -139,7 +139,7 @@ func TestVersionExistsForCommitQueueIssue(t *testing.T) {
 					{Issue: "patch-2345"},
 				},
 			},
-			patchType: commitqueue.CLIPatchType,
+			patchType: commitqueue.SourceCommandLine,
 		},
 		"PRQueue": {
 			cq: &commitqueue.CommitQueue{
@@ -148,7 +148,7 @@ func TestVersionExistsForCommitQueueIssue(t *testing.T) {
 					{Issue: "2345"},
 				},
 			},
-			patchType: commitqueue.PRPatchType,
+			patchType: commitqueue.SourcePullRequest,
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -411,7 +411,7 @@ func listCommitQueue(ctx context.Context, client client.Communicator, ac *legacy
 		grip.Infof("Message: %s\n", projectRef.CommitQueue.Message)
 	}
 
-	if projectRef.CommitQueue.PatchType == commitqueue.PRPatchType {
+	if projectRef.CommitQueue.PatchType == commitqueue.SourcePullRequest {
 		grip.Infof("Owner: %s\n", projectRef.Owner)
 		grip.Infof("Repo: %s\n", projectRef.Repo)
 	}
@@ -419,10 +419,10 @@ func listCommitQueue(ctx context.Context, client client.Communicator, ac *legacy
 	grip.Infof("Queue Length: %d\n", len(cq.Queue))
 	for i, item := range cq.Queue {
 		grip.Infof("%d:", i)
-		if projectRef.CommitQueue.PatchType == commitqueue.PRPatchType {
+		if projectRef.CommitQueue.PatchType == commitqueue.SourcePullRequest {
 			listPRCommitQueueItem(item, projectRef, uiServerHost)
 		}
-		if projectRef.CommitQueue.PatchType == commitqueue.CLIPatchType {
+		if projectRef.CommitQueue.PatchType == commitqueue.SourceCommandLine {
 			listCLICommitQueueItem(item, ac, uiServerHost)
 		}
 		listModules(item)
@@ -540,7 +540,7 @@ func (p *mergeParams) uploadMergePatch(conf *ClientSettings, ac *legacyClient) e
 		}
 		return errors.Wrap(err, "can't get project ref")
 	}
-	if !ref.CommitQueue.Enabled || ref.CommitQueue.PatchType != commitqueue.CLIPatchType {
+	if !ref.CommitQueue.Enabled || ref.CommitQueue.PatchType != commitqueue.SourceCommandLine {
 		return errors.New("CLI commit queue not enabled for project")
 	}
 

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -97,7 +97,7 @@ func (s *CommitQueueSuite) TestListContentsForCLI() {
 
 	pRef := &model.ProjectRef{
 		Id:          "mci",
-		CommitQueue: model.CommitQueueParams{PatchType: commitqueue.CLIPatchType},
+		CommitQueue: model.CommitQueueParams{PatchType: commitqueue.SourceCommandLine},
 	}
 	s.Require().NoError(pRef.Insert())
 
@@ -128,7 +128,7 @@ func (s *CommitQueueSuite) TestListContentsForCLI() {
 	stringOut := string(out[:])
 
 	s.Contains(stringOut, "Project: mci")
-	s.Contains(stringOut, fmt.Sprintf("Type of queue: %s", commitqueue.CLIPatchType))
+	s.Contains(stringOut, fmt.Sprintf("Type of queue: %s", commitqueue.SourceCommandLine))
 	s.Contains(stringOut, "Description : do things")
 	s.Contains(stringOut, "0:")
 	s.Contains(stringOut, fmt.Sprintf("ID : %s", p1.Id.Hex()))
@@ -156,7 +156,7 @@ func (s *CommitQueueSuite) TestListContentsMissingPatch() {
 	s.NoError(p1.Insert())
 	pRef := &model.ProjectRef{
 		Id:          "mci",
-		CommitQueue: model.CommitQueueParams{PatchType: commitqueue.CLIPatchType},
+		CommitQueue: model.CommitQueueParams{PatchType: commitqueue.SourceCommandLine},
 	}
 	s.Require().NoError(pRef.Insert())
 
@@ -183,7 +183,7 @@ func (s *CommitQueueSuite) TestListContentsMissingPatch() {
 	stringOut := string(out[:])
 
 	s.Contains(stringOut, "Project: mci")
-	s.Contains(stringOut, fmt.Sprintf("Type of queue: %s", commitqueue.CLIPatchType))
+	s.Contains(stringOut, fmt.Sprintf("Type of queue: %s", commitqueue.SourceCommandLine))
 	s.Contains(stringOut, "0:")
 	s.Contains(stringOut, fmt.Sprintf("Error getting patch for issue '%s'", fakeIssue))
 	s.Contains(stringOut, fmt.Sprintf("ID : %s", p1.Id.Hex()))
@@ -212,7 +212,7 @@ func (s *CommitQueueSuite) TestListContentsForPRs() {
 		Id:          "mci",
 		Owner:       "evergreen-ci",
 		Repo:        "evergreen",
-		CommitQueue: model.CommitQueueParams{PatchType: commitqueue.PRPatchType},
+		CommitQueue: model.CommitQueueParams{PatchType: commitqueue.SourcePullRequest},
 	}
 	s.Require().NoError(pRef.Insert())
 
@@ -231,7 +231,7 @@ func (s *CommitQueueSuite) TestListContentsForPRs() {
 
 	s.Contains(stringOut, "Project: mci")
 	s.Contains(stringOut, "Repo: evergreen")
-	s.Contains(stringOut, fmt.Sprintf("Type of queue: %s", commitqueue.PRPatchType))
+	s.Contains(stringOut, fmt.Sprintf("Type of queue: %s", commitqueue.SourcePullRequest))
 	s.Contains(stringOut, "Owner: evergreen-ci")
 	s.Contains(stringOut, "0:")
 	s.Contains(stringOut, "PR # : 123")
@@ -271,7 +271,7 @@ func (s *CommitQueueSuite) TestListContentsWithModule() {
 		Id:          "mci",
 		Owner:       "me",
 		Repo:        "evergreen",
-		CommitQueue: model.CommitQueueParams{PatchType: commitqueue.PRPatchType},
+		CommitQueue: model.CommitQueueParams{PatchType: commitqueue.SourcePullRequest},
 	}
 	s.Require().NoError(pRef.Insert())
 

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -42,7 +42,7 @@ func (s *CommitQueueSuite) SetupTest() {
 		PatchingDisabled: false,
 		CommitQueue: model.CommitQueueParams{
 			Enabled:   true,
-			PatchType: commitqueue.CLIPatchType,
+			PatchType: commitqueue.SourceCommandLine,
 		},
 	}
 	s.Require().NoError(s.projectRef.Insert())
@@ -52,10 +52,10 @@ func (s *CommitQueueSuite) SetupTest() {
 
 func (s *CommitQueueSuite) TestEnqueue() {
 	s.ctx = &DBConnector{}
-	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("1234")}, false)
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("1234")}, false)
 	s.NoError(err)
 	s.Equal(0, pos)
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("5678")}, false)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("5678")}, false)
 	s.NoError(err)
 	s.Equal(1, pos)
 
@@ -66,7 +66,7 @@ func (s *CommitQueueSuite) TestEnqueue() {
 	s.Equal("5678", q.Queue[1].Issue)
 
 	// move to front
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("important")}, true)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("important")}, true)
 	s.NoError(err)
 	s.Equal(1, pos)
 	q, err = commitqueue.FindOneId("mci")
@@ -87,13 +87,13 @@ func (s *CommitQueueSuite) TestFindCommitQueueByID() {
 
 func (s *CommitQueueSuite) TestCommitQueueRemoveItem() {
 	s.ctx = &DBConnector{}
-	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("1")}, false)
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("1")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("2")}, false)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("2")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(1, pos)
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("3")}, false)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("3")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(2, pos)
 
@@ -114,7 +114,7 @@ func (s *CommitQueueSuite) TestCommitQueueRemoveItem() {
 
 func (s *CommitQueueSuite) TestIsItemOnCommitQueue() {
 	s.ctx = &DBConnector{}
-	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("1")}, false)
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("1")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
 
@@ -133,13 +133,13 @@ func (s *CommitQueueSuite) TestIsItemOnCommitQueue() {
 
 func (s *CommitQueueSuite) TestCommitQueueClearAll() {
 	s.ctx = &DBConnector{}
-	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("12")}, false)
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("12")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("34")}, false)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("34")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(1, pos)
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("56")}, false)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("56")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(2, pos)
 
@@ -152,7 +152,7 @@ func (s *CommitQueueSuite) TestCommitQueueClearAll() {
 	s.Equal(1, clearedCount)
 
 	// both queues have items
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("12")}, false)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("12")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
 	pos, err = q.Enqueue(commitqueue.CommitQueueItem{Issue: "78"})
@@ -241,10 +241,10 @@ func (s *CommitQueueSuite) TestMockGetGitHubPR() {
 
 func (s *CommitQueueSuite) TestMockEnqueue() {
 	s.ctx = &MockConnector{}
-	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("1234")}, false)
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("1234")}, false)
 	s.NoError(err)
 	s.Equal(0, pos)
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("5678")}, false)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("5678")}, false)
 	s.NoError(err)
 	s.Equal(1, pos)
 
@@ -257,7 +257,7 @@ func (s *CommitQueueSuite) TestMockEnqueue() {
 	s.Equal("5678", restModel.FromStringPtr(q[1].Issue))
 
 	// move to front
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("important")}, true)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("important")}, true)
 	s.NoError(err)
 	s.Equal(1, pos)
 	q, ok = conn.MockCommitQueueConnector.Queue["mci"]
@@ -272,7 +272,7 @@ func (s *CommitQueueSuite) TestMockEnqueue() {
 
 func (s *CommitQueueSuite) TestMockFindCommitQueueForProject() {
 	s.ctx = &MockConnector{}
-	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("1234")}, false)
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("1234")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
 
@@ -284,13 +284,13 @@ func (s *CommitQueueSuite) TestMockFindCommitQueueForProject() {
 
 func (s *CommitQueueSuite) TestMockCommitQueueRemoveItem() {
 	s.ctx = &MockConnector{}
-	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("1")}, false)
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("1")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("2")}, false)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("2")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(1, pos)
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("3")}, false)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("3")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(2, pos)
 
@@ -309,7 +309,7 @@ func (s *CommitQueueSuite) TestMockCommitQueueRemoveItem() {
 
 func (s *CommitQueueSuite) TestMockIsItemOnCommitQueue() {
 	s.ctx = &MockConnector{}
-	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("1")}, false)
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("1")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
 
@@ -328,17 +328,17 @@ func (s *CommitQueueSuite) TestMockIsItemOnCommitQueue() {
 
 func (s *CommitQueueSuite) TestMockCommitQueueClearAll() {
 	s.ctx = &MockConnector{}
-	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("12")}, false)
+	pos, err := s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("12")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
-	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("34")}, false)
+	pos, err = s.ctx.EnqueueItem("mci", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("34")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(1, pos)
 
-	pos, err = s.ctx.EnqueueItem("logkeeper", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("12")}, false)
+	pos, err = s.ctx.EnqueueItem("logkeeper", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("12")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
-	pos, err = s.ctx.EnqueueItem("logkeeper", restModel.APICommitQueueItem{Issue: restModel.ToStringPtr("34")}, false)
+	pos, err = s.ctx.EnqueueItem("logkeeper", restModel.APICommitQueueItem{Source: restModel.ToStringPtr(commitqueue.SourceCommandLine), Issue: restModel.ToStringPtr("34")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(1, pos)
 

--- a/rest/model/commit_queue.go
+++ b/rest/model/commit_queue.go
@@ -23,6 +23,7 @@ type APICommitQueueItem struct {
 	Modules         []APIModule `json:"modules"`
 	Patch           *APIPatch   `json:"patch"`
 	MessageOverride *string     `json:"message_override"`
+	Source          *string     `json:"source"`
 }
 
 type APIModule struct {
@@ -69,6 +70,7 @@ func (item *APICommitQueueItem) BuildFromService(h interface{}) error {
 	item.Version = ToStringPtr(cqItemService.Version)
 	item.EnqueueTime = ToTimePtr(cqItemService.EnqueueTime)
 	item.MessageOverride = ToStringPtr(cqItemService.MessageOverride)
+	item.Source = ToStringPtr(cqItemService.Source)
 
 	for _, module := range cqItemService.Modules {
 		item.Modules = append(item.Modules, APIModule{
@@ -85,6 +87,7 @@ func (item *APICommitQueueItem) ToService() (interface{}, error) {
 		Issue:           FromStringPtr(item.Issue),
 		Version:         FromStringPtr(item.Version),
 		MessageOverride: FromStringPtr(item.MessageOverride),
+		Source:          FromStringPtr(item.Source),
 	}
 	for _, module := range item.Modules {
 		serviceModule := commitqueue.Module{

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -307,7 +307,7 @@ func TestRestartVersionsRoute(t *testing.T) {
 	projectRef := &model.ProjectRef{
 		Id: "my-project",
 		CommitQueue: model.CommitQueueParams{
-			PatchType: commitqueue.PRPatchType,
+			PatchType: commitqueue.SourcePullRequest,
 			Enabled:   true,
 		},
 		Enabled: true,

--- a/rest/route/commit_queue.go
+++ b/rest/route/commit_queue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
+	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
@@ -105,7 +106,7 @@ func (cq *commitQueueDeleteItemHandler) Run(ctx context.Context) gimlet.Responde
 	}
 
 	// Send GitHub status
-	if projectRef.CommitQueue.PatchType == commitqueue.PRPatchType {
+	if projectRef.CommitQueue.PatchType == commitqueue.SourcePullRequest {
 		itemInt, err := strconv.Atoi(cq.item)
 		if err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "item '%s' is not an int", cq.item))
@@ -207,7 +208,7 @@ func (cq *commitQueueEnqueueItemHandler) Run(ctx context.Context) gimlet.Respond
 	if patchEmpty {
 		return gimlet.MakeJSONErrorResponder(errors.New("can't enqueue item, patch is empty"))
 	}
-	position, err := cq.sc.EnqueueItem(cq.project, model.APICommitQueueItem{Issue: model.ToStringPtr(cq.item)}, cq.force)
+	position, err := cq.sc.EnqueueItem(cq.project, model.APICommitQueueItem{Issue: model.ToStringPtr(cq.item), Source: restModel.ToStringPtr(commitqueue.SourceCommandLine)}, cq.force)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't enqueue item"))
 	}

--- a/rest/route/commit_queue.go
+++ b/rest/route/commit_queue.go
@@ -208,7 +208,7 @@ func (cq *commitQueueEnqueueItemHandler) Run(ctx context.Context) gimlet.Respond
 	if patchEmpty {
 		return gimlet.MakeJSONErrorResponder(errors.New("can't enqueue item, patch is empty"))
 	}
-	position, err := cq.sc.EnqueueItem(cq.project, model.APICommitQueueItem{Issue: model.ToStringPtr(cq.item), Source: restModel.ToStringPtr(commitqueue.SourceCommandLine)}, cq.force)
+	position, err := cq.sc.EnqueueItem(cq.project, model.APICommitQueueItem{Issue: model.ToStringPtr(cq.item), Source: restModel.ToStringPtr(commitqueue.SourceDiff)}, cq.force)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't enqueue item"))
 	}

--- a/rest/route/commit_queue_test.go
+++ b/rest/route/commit_queue_test.go
@@ -54,7 +54,8 @@ func (s *CommitQueueSuite) TestGetCommitQueue() {
 	pos, err := s.sc.EnqueueItem(
 		"mci",
 		model.APICommitQueueItem{
-			Issue: model.ToStringPtr("1"),
+			Issue:  model.ToStringPtr("1"),
+			Source: model.ToStringPtr(commitqueue.SourceCommandLine),
 			Modules: []model.APIModule{
 				model.APIModule{
 					Module: model.ToStringPtr("test_module"),
@@ -65,7 +66,7 @@ func (s *CommitQueueSuite) TestGetCommitQueue() {
 	s.NoError(err)
 	s.Equal(0, pos)
 
-	pos, err = s.sc.EnqueueItem("mci", model.APICommitQueueItem{Issue: model.ToStringPtr("2")}, false)
+	pos, err = s.sc.EnqueueItem("mci", model.APICommitQueueItem{Source: model.ToStringPtr(commitqueue.SourceCommandLine), Issue: model.ToStringPtr("2")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(1, pos)
 
@@ -75,7 +76,8 @@ func (s *CommitQueueSuite) TestGetCommitQueue() {
 		ProjectID: model.ToStringPtr("mci"),
 		Queue: []model.APICommitQueueItem{
 			model.APICommitQueueItem{
-				Issue: model.ToStringPtr("1"),
+				Source: model.ToStringPtr(commitqueue.SourceCommandLine),
+				Issue:  model.ToStringPtr("1"),
 				Modules: []model.APIModule{
 					model.APIModule{
 						Module: model.ToStringPtr("test_module"),
@@ -83,7 +85,7 @@ func (s *CommitQueueSuite) TestGetCommitQueue() {
 					},
 				},
 			},
-			model.APICommitQueueItem{
+			model.APICommitQueueItem{Source: model.ToStringPtr(commitqueue.SourceCommandLine),
 				Issue: model.ToStringPtr("2"),
 			},
 		},
@@ -94,7 +96,7 @@ func (s *CommitQueueSuite) TestDeleteItem() {
 	s.sc.MockProjectConnector.CachedProjects = []dbModel.ProjectRef{
 		{
 			Id:          "mci",
-			CommitQueue: dbModel.CommitQueueParams{PatchType: commitqueue.PRPatchType},
+			CommitQueue: dbModel.CommitQueueParams{PatchType: commitqueue.SourcePullRequest},
 		},
 	}
 
@@ -104,10 +106,10 @@ func (s *CommitQueueSuite) TestDeleteItem() {
 	s.Require().NoError(env.Configure(ctx))
 
 	route := makeDeleteCommitQueueItems(s.sc, env).(*commitQueueDeleteItemHandler)
-	pos, err := s.sc.EnqueueItem("mci", model.APICommitQueueItem{Issue: model.ToStringPtr("1")}, false)
+	pos, err := s.sc.EnqueueItem("mci", model.APICommitQueueItem{Source: model.ToStringPtr(commitqueue.SourceCommandLine), Issue: model.ToStringPtr("1")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
-	pos, err = s.sc.EnqueueItem("mci", model.APICommitQueueItem{Issue: model.ToStringPtr("2")}, false)
+	pos, err = s.sc.EnqueueItem("mci", model.APICommitQueueItem{Source: model.ToStringPtr(commitqueue.SourceCommandLine), Issue: model.ToStringPtr("2")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(1, pos)
 
@@ -132,16 +134,16 @@ func (s *CommitQueueSuite) TestDeleteItem() {
 
 func (s *CommitQueueSuite) TestClearAll() {
 	route := makeClearCommitQueuesHandler(s.sc).(*commitQueueClearAllHandler)
-	pos, err := s.sc.EnqueueItem("mci", model.APICommitQueueItem{Issue: model.ToStringPtr("12")}, false)
+	pos, err := s.sc.EnqueueItem("mci", model.APICommitQueueItem{Source: model.ToStringPtr(commitqueue.SourceCommandLine), Issue: model.ToStringPtr("12")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
-	pos, err = s.sc.EnqueueItem("mci", model.APICommitQueueItem{Issue: model.ToStringPtr("23")}, false)
+	pos, err = s.sc.EnqueueItem("mci", model.APICommitQueueItem{Source: model.ToStringPtr(commitqueue.SourceCommandLine), Issue: model.ToStringPtr("23")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(1, pos)
-	pos, err = s.sc.EnqueueItem("logkeeper", model.APICommitQueueItem{Issue: model.ToStringPtr("34")}, false)
+	pos, err = s.sc.EnqueueItem("logkeeper", model.APICommitQueueItem{Source: model.ToStringPtr(commitqueue.SourceCommandLine), Issue: model.ToStringPtr("34")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(0, pos)
-	pos, err = s.sc.EnqueueItem("logkeeper", model.APICommitQueueItem{Issue: model.ToStringPtr("45")}, false)
+	pos, err = s.sc.EnqueueItem("logkeeper", model.APICommitQueueItem{Source: model.ToStringPtr(commitqueue.SourceCommandLine), Issue: model.ToStringPtr("45")}, false)
 	s.Require().NoError(err)
 	s.Require().Equal(1, pos)
 

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -568,6 +568,7 @@ func (gh *githubHookApi) commitQueueEnqueue(ctx context.Context, event *github.I
 		Issue:           restModel.ToStringPtr(strconv.Itoa(PRNum)),
 		MessageOverride: &cqInfo.MessageOverride,
 		Modules:         cqInfo.Modules,
+		Source:          restModel.ToStringPtr(commitqueue.SourcePullRequest),
 	}
 	_, err = gh.sc.EnqueueItem(projectRef.Id, item, false)
 	if err != nil {

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -414,7 +414,7 @@ func (m *CommitQueueItemOwnerMiddleware) ServeHTTP(rw http.ResponseWriter, r *ht
 		return
 	}
 
-	if projRef.CommitQueue.PatchType == commitqueue.CLIPatchType {
+	if projRef.CommitQueue.PatchType == commitqueue.SourceCommandLine {
 		patch, err := m.sc.FindPatchById(item)
 		if err != nil {
 			gimlet.WriteResponse(rw, gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't find item")))
@@ -429,7 +429,7 @@ func (m *CommitQueueItemOwnerMiddleware) ServeHTTP(rw http.ResponseWriter, r *ht
 		}
 	}
 
-	if projRef.CommitQueue.PatchType == commitqueue.PRPatchType {
+	if projRef.CommitQueue.PatchType == commitqueue.SourcePullRequest {
 		itemInt, err := strconv.Atoi(item)
 		if err != nil {
 			gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -239,7 +239,7 @@ func TestCommitQueueItemOwnerMiddlewareUnauthorizedUserGitHub(t *testing.T) {
 		Repo:    "evergreen",
 		Branch:  "master",
 		CommitQueue: model.CommitQueueParams{
-			PatchType: commitqueue.PRPatchType,
+			PatchType: commitqueue.SourcePullRequest,
 			Enabled:   true,
 		},
 	}
@@ -283,7 +283,7 @@ func TestCommitQueueItemOwnerMiddlewareUserPatch(t *testing.T) {
 		Repo:    "evergreen",
 		Branch:  "master",
 		CommitQueue: model.CommitQueueParams{
-			PatchType: commitqueue.CLIPatchType,
+			PatchType: commitqueue.SourceCommandLine,
 			Enabled:   true,
 		},
 	}

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -177,10 +177,10 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 			"project_id":         cq.ProjectID,
 			"processing_seconds": time.Since(cq.ProcessingUpdatedTime).Seconds(),
 		})
-		// if it's a CLIPatchType, check if the patch is done, and if it is, dequeue.
+		// if it's a SourceCommandLine, check if the patch is done, and if it is, dequeue.
 		// It's okay if this gets to it before the notification does, since that will
 		// check if the item is still on the queue before removing it.
-		if projectRef.CommitQueue.PatchType == commitqueue.CLIPatchType {
+		if projectRef.CommitQueue.PatchType == commitqueue.SourceCommandLine {
 			j.TryUnstick(cq)
 		}
 		return
@@ -211,10 +211,9 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 	}
 
 	// create a version with the item and subscribe to its completion
-	if projectRef.CommitQueue.PatchType == commitqueue.PRPatchType {
+	if nextItem.Source == commitqueue.SourcePullRequest {
 		j.processGitHubPRItem(ctx, cq, nextItem, projectRef, githubToken)
-	}
-	if projectRef.CommitQueue.PatchType == commitqueue.CLIPatchType {
+	} else if nextItem.Source == commitqueue.SourceCommandLine {
 		j.processCLIPatchItem(ctx, cq, nextItem, projectRef, githubToken)
 	}
 


### PR DESCRIPTION
This adds a new source field to commit queue entries and populates it from every entry point that can add to the cq (I think)

The general idea is that we'll use this field instead of the project ref setting to determine how to handle it. No migration is needed because the queue should be empty by the time I switch the logic to look at the field