### PR TITLE
EVG-13555 task group debugging

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2020-12-03"
+	ClientVersion = "2021-01-20"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2020-12-18"

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -434,14 +434,14 @@ func MinTaskGroupOrderRunningByTaskSpec(group, buildVariant, project, version st
 			"project is '%s' and version is '%s')", group, buildVariant, project, version)
 	}
 
-	numHosts, err := Find(ByTaskSpec(group, buildVariant, project, version).WithFields(RunningTaskGroupOrderKey).Sort([]string{RunningTaskGroupOrderKey}))
+	hosts, err := Find(ByTaskSpec(group, buildVariant, project, version).WithFields(RunningTaskGroupOrderKey).Sort([]string{RunningTaskGroupOrderKey}))
 	if err != nil {
 		return 0, errors.Wrap(err, "error querying database for hosts")
 	}
 	minTaskGroupOrder := 0
 	//  can look at only one host because we sorted
-	if len(numHosts) > 0 {
-		minTaskGroupOrder = numHosts[0].RunningTaskGroupOrder
+	if len(hosts) > 0 {
+		minTaskGroupOrder = hosts[0].RunningTaskGroupOrder
 	}
 	return minTaskGroupOrder, nil
 }

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -125,5 +125,6 @@ type Communicator interface {
 	// GetHostProvisioningOptions gets the options to provision a host.
 	GetHostProvisioningOptions(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningOptions, error)
 
-	CompareTasks(context.Context, []string) ([]string, map[string]map[string]string, error)
+	// CompareTasks returns the order that the given tasks would be scheduled, along with the scheduling logic.
+	CompareTasks(context.Context, []string, bool) ([]string, map[string]map[string]string, error)
 }

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1540,13 +1540,14 @@ func (c *communicatorImpl) GetHostProvisioningOptions(ctx context.Context, hostI
 	return &opts, nil
 }
 
-func (c *communicatorImpl) CompareTasks(ctx context.Context, tasks []string) ([]string, map[string]map[string]string, error) {
+func (c *communicatorImpl) CompareTasks(ctx context.Context, tasks []string, useLegacy bool) ([]string, map[string]map[string]string, error) {
 	info := requestInfo{
 		method: http.MethodPost,
 		path:   "/scheduler/compare_tasks",
 	}
 	body := restmodel.CompareTasksRequest{
-		Tasks: tasks,
+		Tasks:     tasks,
+		UseLegacy: useLegacy,
 	}
 	r, err := c.createRequest(info, body)
 	if err != nil {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -350,5 +350,6 @@ type Connector interface {
 	//GetProjectSettingsEvent returns the ProjectSettingsEvents of the given identifier and ProjectRef
 	GetProjectSettingsEvent(p *model.ProjectRef) (*model.ProjectSettingsEvent, error)
 
-	CompareTasks([]string) ([]string, map[string]map[string]string, error)
+	// CompareTasks returns the order that the given tasks would be scheduled, along with the scheduling logic.
+	CompareTasks([]string, bool) ([]string, map[string]map[string]string, error)
 }

--- a/rest/data/scheduler.go
+++ b/rest/data/scheduler.go
@@ -45,10 +45,10 @@ func (s *SchedulerConnector) CompareTasks(taskIds []string, useLegacy bool) ([]s
 	} else { // this is temporary: logic should be added in EVG-13795
 		d, err := distro.FindByID(distroId)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "unable to find d")
+			return nil, nil, errors.Wrap(err, "unable to find distro")
 		}
 		if d == nil {
-			return nil, nil, errors.Errorf("distro doesn't exist")
+			return nil, nil, errors.New("distro doesn't exist")
 		}
 		taskPlan := scheduler.PrepareTasksForPlanning(d, tasks)
 		tasks = taskPlan.Export()

--- a/rest/data/scheduler.go
+++ b/rest/data/scheduler.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/scheduler"
 	"github.com/pkg/errors"
@@ -8,7 +9,7 @@ import (
 
 type SchedulerConnector struct{}
 
-func (s *SchedulerConnector) CompareTasks(taskIds []string) ([]string, map[string]map[string]string, error) {
+func (s *SchedulerConnector) CompareTasks(taskIds []string, useLegacy bool) ([]string, map[string]map[string]string, error) {
 	if len(taskIds) == 0 {
 		return nil, nil, nil
 	}
@@ -19,10 +20,10 @@ func (s *SchedulerConnector) CompareTasks(taskIds []string) ([]string, map[strin
 	if len(tasks) != len(taskIds) {
 		return nil, nil, errors.Errorf("%d tasks do not exist", len(taskIds)-len(tasks))
 	}
-	distro := tasks[0].DistroId
+	distroId := tasks[0].DistroId
 	for _, t := range tasks {
-		if t.DistroId != distro {
-			return nil, nil, errors.New("all tasks must have the same distro")
+		if t.DistroId != distroId {
+			return nil, nil, errors.New("all tasks must have the same distroId")
 		}
 	}
 	tasks, versions, err := scheduler.FilterTasksWithVersionCache(tasks)
@@ -31,9 +32,26 @@ func (s *SchedulerConnector) CompareTasks(taskIds []string) ([]string, map[strin
 	}
 
 	cmp := scheduler.CmpBasedTaskPrioritizer{}
-	tasks, logic, err := cmp.PrioritizeTasks(distro, tasks, versions)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "unable to prioritize tasks")
+	logic := map[string]map[string]string{}
+	if useLegacy {
+		tasks, logic, err = cmp.PrioritizeTasks(distroId, tasks, versions)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unable to prioritize tasks")
+		}
+		prioritizedIds := []string{}
+		for _, t := range tasks {
+			prioritizedIds = append(prioritizedIds, t.Id)
+		}
+	} else { // this is temporary: logic should be added in EVG-13795
+		d, err := distro.FindByID(distroId)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unable to find d")
+		}
+		if d == nil {
+			return nil, nil, errors.Errorf("distro doesn't exist")
+		}
+		taskPlan := scheduler.PrepareTasksForPlanning(d, tasks)
+		tasks = taskPlan.Export()
 	}
 	prioritizedIds := []string{}
 	for _, t := range tasks {
@@ -44,6 +62,6 @@ func (s *SchedulerConnector) CompareTasks(taskIds []string) ([]string, map[strin
 
 type MockSchedulerConnector struct{}
 
-func (s *MockSchedulerConnector) CompareTasks(taskIds []string) ([]string, map[string]map[string]string, error) {
+func (s *MockSchedulerConnector) CompareTasks(taskIds []string, useLegacy bool) ([]string, map[string]map[string]string, error) {
 	return nil, nil, nil
 }

--- a/rest/data/scheduler_test.go
+++ b/rest/data/scheduler_test.go
@@ -64,18 +64,18 @@ func TestCompareTasks(t *testing.T) {
 	assert.NoError(t, cqVersion.Insert())
 
 	s := &SchedulerConnector{}
-	order, logic, err := s.CompareTasks([]string{"t1", "t2"})
+	order, logic, err := s.CompareTasks([]string{"t1", "t2"}, true)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"t2", "t1"}, order)
 	assert.Equal(t, "task priority: higher is first", logic[t1.Id][t2.Id])
 
-	order, logic, err = s.CompareTasks([]string{"t1", "t2", "t3"})
+	order, logic, err = s.CompareTasks([]string{"t1", "t2", "t3"}, true)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"t3", "t2", "t1"}, order)
 	assert.Equal(t, "task generator: higher task is a generator", logic[t2.Id][t3.Id])
 	assert.Equal(t, "task priority: higher is first", logic[t1.Id][t2.Id])
 
-	order, logic, err = s.CompareTasks([]string{"t1", "t2", "t3", "cqt1"})
+	order, logic, err = s.CompareTasks([]string{"t1", "t2", "t3", "cqt1"}, true)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"cqt1", "t3", "t2", "t1"}, order)
 	//TODO: change the assertion below once tracing for the zippering logic is implemented

--- a/rest/model/scheduler.go
+++ b/rest/model/scheduler.go
@@ -1,7 +1,8 @@
 package model
 
 type CompareTasksRequest struct {
-	Tasks []string `json:"tasks"`
+	Tasks     []string `json:"tasks"`
+	UseLegacy bool     `json:"use_legacy"`
 }
 
 type CompareTasksResponse struct {

--- a/rest/route/scheduler.go
+++ b/rest/route/scheduler.go
@@ -11,7 +11,7 @@ import (
 )
 
 type compareTasksRoute struct {
-	taskIds []string
+	request model.CompareTasksRequest
 	sc      data.Connector
 }
 
@@ -36,12 +36,12 @@ func (p *compareTasksRoute) Parse(ctx context.Context, r *http.Request) error {
 			Message:    err.Error(),
 		}
 	}
-	p.taskIds = request.Tasks
+	p.request = request
 	return nil
 }
 
 func (p *compareTasksRoute) Run(ctx context.Context) gimlet.Responder {
-	order, logic, err := p.sc.CompareTasks(p.taskIds)
+	order, logic, err := p.sc.CompareTasks(p.request.Tasks, p.request.UseLegacy)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}

--- a/scheduler/distro_alias_test.go
+++ b/scheduler/distro_alias_test.go
@@ -59,7 +59,7 @@ func TestDistroAliases(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 		})
-		t.Run("Legacy", func(t *testing.T) {
+		t.Run("UseLegacy", func(t *testing.T) {
 			require.NoError(t, db.Clear(model.TaskQueuesCollection))
 
 			distroOne.PlannerSettings.Version = evergreen.PlannerVersionLegacy
@@ -106,7 +106,7 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, 0, ct)
 
 		})
-		t.Run("Legacy", func(t *testing.T) {
+		t.Run("UseLegacy", func(t *testing.T) {
 			require.NoError(t, db.Clear(model.TaskAliasQueuesCollection))
 
 			distroTwo.PlannerSettings.Version = evergreen.PlannerVersionLegacy

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -56,7 +56,7 @@ func runTunablePlanner(d *distro.Distro, tasks []task.Task, opts TaskPlannerOpti
 
 ////////////////////////////////////////////////////////////////////////
 //
-// Legacy Scheduler Implementation
+// UseLegacy Scheduler Implementation
 
 func runLegacyPlanner(d *distro.Distro, tasks []task.Task, opts TaskPlannerOptions) ([]task.Task, error) {
 	runnableTasks, versions, err := FilterTasksWithVersionCache(tasks)

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -177,6 +177,7 @@ func validateMultipleProviderSettings(d *distro.Distro) ValidationErrors {
 			continue
 		}
 		if err := settings.Validate(); err != nil {
+
 			errs = append(errs, ValidationError{
 				Message: errors.Wrapf(err, "error validating settings for region '%s'", region).Error(),
 				Level:   Error,


### PR DESCRIPTION
It's most likely that task group tasks are racing when the hosts pick them up (again), but the existing logging doesn't actually imply that, so I added a little bit more logging, and modified the scheduler command to use the tunable logic (I didn't go super deep into that though; fleshing out the reasoning can be done in EVG-13795).