### PR TITLE
EVG-13808 make task status check a warning again

### DIFF
--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -63,7 +63,12 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		return mongo.ErrNoDocuments
 	}
 	if t.Status != evergreen.TaskStarted {
-		return errors.New("task is not running, not generating tasks")
+		grip.Debug(message.Fields{
+			"message": "task is not running, not generating tasks",
+			"task":    t.Id,
+			"version": t.Version,
+		})
+		return nil
 	}
 
 	v, err := model.VersionFindOneId(t.Version)


### PR DESCRIPTION
This reverts the specific change to make this check an error. While I don't understand why it failed here while the task was running, in the past this has allowed scenarios where a task was stranded to continue generating tasks, so I believe it's appropriate to revert