### PR TITLE
EVG-13780 fix restart single-host task group

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -330,7 +330,7 @@ func (as *APIServer) FetchExpansionsForTask(w http.ResponseWriter, r *http.Reque
 	res.RestrictedVars = projectVars.GetRestrictedVars()
 	res.PrivateVars = projectVars.PrivateVars
 
-	v, err := model.VersionFindOne(model.VersionById(t.Version).WithFields(model.VersionParametersKey))
+	v, err := model.VersionFindOne(model.VersionById(t.Version))
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -210,12 +210,8 @@ func cleanUpTimedOutTask(ctx context.Context, env evergreen.Environment, id stri
 			return errors.Wrap(err, "can't mark display task for reset")
 		}
 		return errors.Wrap(model.MarkEnd(t, "monitor", time.Now(), detail, false, &model.StatusChanges{}), "error marking execution task ended")
-	} else if t.IsPartOfSingleHostTaskGroup() {
-		if err = t.SetResetWhenFinished(); err != nil {
-			return errors.Wrap(err, "can't mark display task for reset")
-		}
-		return errors.Wrap(model.MarkEnd(t, "monitor", time.Now(), detail, false, &model.StatusChanges{}), "error marking task in task group ended")
 	}
+
 	return errors.Wrapf(model.TryResetTask(t.Id, "", "monitor", detail), "error trying to reset task %s", t.Id)
 }
 


### PR DESCRIPTION
I'm actually seeing two issues with the task in this ticket:
1) The version is from Dec 2019, i.e. it has no parser project, but we don't get the version fields necessary for the legacy case of `LoadProjectForVersion`.
2) We mistakenly use the same logic for task groups / display tasks in `cleanUpTimedOutTask`, however they do have different paths. TryResetTask handles the task group case already, we don't need to special case it in `cleanUpTimedOutTask`. This is now consistent with ClearAndResetStrandedTask.


