### PR TITLE
EVG-13680: check for special host key verification message in Docker git test

### DIFF
--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -331,7 +331,7 @@ func (s *GitGetProjectSuite) TestStdErrLogged() {
 			if strings.Contains(msg.Message, "ERROR: Repository not found.") {
 				foundCloneErr = true
 			}
-			if strings.Contains(msg.Message, "Permission denied (publickey)") {
+			if strings.Contains(msg.Message, "Permission denied (publickey)") || strings.Contains(msg.Message, "Host key verification failed.") {
 				foundSSHErr = true
 			}
 		}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13680

For some reason, the error message from git changed when running on the Docker image (maybe due to some image change). I just updated the error string.