### PR TITLE
EVG-13834 add scope to generate.tasks

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -646,7 +646,7 @@ func PopulateGenerateTasksJobs(env evergreen.Environment) amboy.QueueOperation {
 			return errors.Wrap(err, "problem getting tasks that need generators run")
 		}
 		for _, t := range tasks {
-			catcher.Add(env.RemoteQueue().Put(ctx, NewGenerateTasksJob(t)))
+			catcher.Add(env.RemoteQueue().Put(ctx, NewGenerateTasksJob(t, 0)))
 		}
 		return catcher.Resolve()
 	}

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -271,15 +271,16 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 			return
 		}
 		msg := message.Fields{
-			"message":   "generate.tasks error, may retry",
-			"operation": generateTasksJobName,
-			"task":      j.TaskID,
-			"execution": j.Execution,
-			"attempt":   j.Attempt,
-			"job":       j.ID(),
-			"version":   t.Version,
-			"error":     err,
-			"panic":     pErr,
+			"message":       "generate.tasks error, may retry",
+			"operation":     generateTasksJobName,
+			"task":          j.TaskID,
+			"execution":     j.Execution,
+			"attempt":       j.Attempt,
+			"attempts_left": generateTasksJobMaxAttempts - 1 - j.Attempt,
+			"job":           j.ID(),
+			"version":       t.Version,
+			"error":         err,
+			"panic":         pErr,
 		}
 		if pErr != nil {
 			grip.Alert(msg)

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -18,12 +18,14 @@ import (
 	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 const (
-	generateTasksJobName = "generate-tasks"
+	generateTasksJobName        = "generate-tasks"
+	generateTasksJobMaxAttempts = 5
 )
 
 func init() {
@@ -31,8 +33,10 @@ func init() {
 }
 
 type generateTasksJob struct {
-	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
-	TaskID   string `bson:"task_id" json:"task_id" yaml:"task_id"`
+	job.Base  `bson:"job_base" json:"job_base" yaml:"job_base"`
+	TaskID    string `bson:"task_id" json:"task_id" yaml:"task_id"`
+	Execution int    `bson:"execution" json:"execution" yaml:"execution"`
+	Attempt   int    `bson:"attempt" json:"attempt" yaml:"attempt"`
 }
 
 func makeGenerateTaskJob() *generateTasksJob {
@@ -49,12 +53,12 @@ func makeGenerateTaskJob() *generateTasksJob {
 	return j
 }
 
-func NewGenerateTasksJob(t task.Task) amboy.Job {
+func NewGenerateTasksJob(t task.Task, attempt int) amboy.Job {
 	j := makeGenerateTaskJob()
 	j.TaskID = t.Id
 	j.SetScopes([]string{fmt.Sprintf("%s-%s", generateTasksJobName, t.Version)})
 
-	j.SetID(fmt.Sprintf("%s-%s", generateTasksJobName, t.Id))
+	j.SetID(fmt.Sprintf("%s-%s-execution%d-attempt%d", generateTasksJobName, t.Id, t.Execution, attempt))
 	return j
 }
 
@@ -247,9 +251,11 @@ func (j *generateTasksJob) handleError(pp *model.ParserProject, v *model.Version
 
 func (j *generateTasksJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
+	var err error
+	var t *task.Task
 	start := time.Now()
 
-	t, err := task.FindOneId(j.TaskID)
+	t, err = task.FindOneId(j.TaskID)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "problem finding task %s", j.TaskID))
 		return
@@ -258,6 +264,27 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 		j.AddError(errors.Errorf("task %s does not exist", j.TaskID))
 		return
 	}
+
+	defer func() {
+		pErr := recovery.HandlePanicWithError(recover(), nil, fmt.Sprintf("panic in %s job", generateTasksJobName))
+		if err == nil && pErr == nil {
+			return
+		}
+		grip.Error(message.Fields{
+			"message":   "generate.tasks error, may retry",
+			"operation": generateTasksJobName,
+			"task":      j.TaskID,
+			"execution": j.Execution,
+			"attempt":   j.Attempt,
+			"job":       j.ID(),
+			"version":   t.Version,
+			"error":     err,
+			"panic":     pErr,
+		})
+		if j.Attempt < generateTasksJobMaxAttempts-1 {
+			j.AddError(evergreen.GetEnvironment().RemoteQueue().Put(ctx, NewGenerateTasksJob(*t, j.Attempt+1)))
+		}
+	}()
 
 	err = j.generate(ctx, t)
 	shouldNoop := adb.ResultsNotFound(err) || db.IsDuplicateKey(err)

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -49,11 +49,12 @@ func makeGenerateTaskJob() *generateTasksJob {
 	return j
 }
 
-func NewGenerateTasksJob(id string, ts string) amboy.Job {
+func NewGenerateTasksJob(t task.Task) amboy.Job {
 	j := makeGenerateTaskJob()
-	j.TaskID = id
+	j.TaskID = t.Id
+	j.SetScopes([]string{fmt.Sprintf("%s-%s", generateTasksJobName, t.Version)})
 
-	j.SetID(fmt.Sprintf("%s-%s-%s", generateTasksJobName, id, ts))
+	j.SetID(fmt.Sprintf("%s-%s", generateTasksJobName, t.Id))
 	return j
 }
 

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -200,7 +200,7 @@ func TestGenerateTasks(t *testing.T) {
 	projectRef := model.ProjectRef{Id: "mci"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob("sample_task", "1")
+	j := NewGenerateTasksJob(sampleTask)
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 	tasks := []task.Task{}
@@ -356,7 +356,7 @@ buildvariants:
 	projectRef := model.ProjectRef{Id: "mci"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob("generator", "1")
+	j := NewGenerateTasksJob(sampleTask)
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -200,7 +200,7 @@ func TestGenerateTasks(t *testing.T) {
 	projectRef := model.ProjectRef{Id: "mci"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob(sampleTask)
+	j := NewGenerateTasksJob(sampleTask, 0)
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 	tasks := []task.Task{}
@@ -356,7 +356,7 @@ buildvariants:
 	projectRef := model.ProjectRef{Id: "mci"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob(sampleTask)
+	j := NewGenerateTasksJob(sampleTask, 0)
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 


### PR DESCRIPTION
- add a scope to generate.tasks with the version ID so that all jobs within that version are serial
- make the job IDs only have the task ID in them (no timestamp), so that we don't enqueue more than 1 job for the same generator
- move the jobs from the group queue to the regular remote queue since there is no need to have them in a group anymore