### PR TITLE
EVG-13874: tag on demand hosts in initial request

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -401,10 +401,6 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 	})
 	h.Id = *instance.InstanceId
 
-	// kim: NOTE: the fact that we can get the instance ID immediately means
-	// only spot hosts need to deal with the unknown instance ID and wait until
-	// later to create the tags.
-
 	return nil
 }
 
@@ -629,10 +625,6 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 }
 
 // getResources returns a slice of the AWS resources for the given host
-// kim: NOTE: this gets the IDs for resources that need tagging for the reaper:
-// - Instance ID (the host ID for on-demand, gets the instance ID
-//   Host.ExternalIdentifier once if it's a spot host and isn't yet loaded)
-// - Volume IDs attached to the instance
 func (m *ec2Manager) getResources(ctx context.Context, h *host.Host) ([]string, error) {
 	instanceID := h.Id
 	if isHostSpot(h) {
@@ -663,8 +655,6 @@ func (m *ec2Manager) getResources(ctx context.Context, h *host.Host) ([]string, 
 }
 
 // addTags adds or updates the specified tags in the client and db
-// kim: TODO: figure out what exactly this is doing, which is only called by
-// ModifyHost
 func (m *ec2Manager) addTags(ctx context.Context, h *host.Host, tags []host.Tag) error {
 	resources, err := m.getResources(ctx, h)
 	if err != nil {

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1044,16 +1044,10 @@ func (c *awsClientImpl) makeNewKey(ctx context.Context, project string, h *host.
 // SetTags creates the initial tags for an EC2 host and updates the database with the
 // host's Evergreen-generated tags.
 func (c *awsClientImpl) SetTags(ctx context.Context, resources []string, h *host.Host) error {
-	tags := makeTags(h)
-	tagSlice := []*ec2.Tag{}
-	for _, tag := range tags {
-		key := tag.Key
-		val := tag.Value
-		tagSlice = append(tagSlice, &ec2.Tag{Key: &key, Value: &val})
-	}
+	tags := hostToEC2Tags(makeTags(h))
 	if _, err := c.CreateTags(ctx, &ec2.CreateTagsInput{
 		Resources: aws.StringSlice(resources),
-		Tags:      tagSlice,
+		Tags:      tags,
 	}); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":       "error attaching tags",

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -28,12 +28,6 @@ var (
 	base64OfSomeUserData = base64.StdEncoding.EncodeToString([]byte(someUserData))
 )
 
-/*
-kim: TODO: test
-- Tags set for on-demand instances
-- OnUp is a no-op for on demand hosts.
-*/
-
 type EC2Suite struct {
 	suite.Suite
 	onDemandOpts              *EC2ManagerOptions
@@ -870,7 +864,7 @@ func (s *EC2Suite) TestOnUpTagsForSpotInstance() {
 
 func (s *EC2Suite) TestGetDNSName() {
 	s.h.Host = "public_dns_name"
-	dns, err := s.spotManager.GetDNSName(s.ctx, s.h)
+	dns, err := s.onDemandManager.GetDNSName(s.ctx, s.h)
 	s.Equal("public_dns_name", dns)
 	s.NoError(err)
 

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -191,8 +191,8 @@ func hostToEC2Tags(hostTags []host.Tag) []*ec2.Tag {
 	var tags []*ec2.Tag
 	for _, tag := range hostTags {
 		key := tag.Key
-		value := tag.Value
-		tags = append(tags, &ec2.Tag{Key: &key, Value: &value})
+		val := tag.Value
+		tags = append(tags, &ec2.Tag{Key: &key, Value: &val})
 	}
 	return tags
 }

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -187,26 +187,45 @@ func makeTags(intentHost *host.Host) []host.Tag {
 	return intentHost.InstanceTags
 }
 
-func makeTagTemplate(hostTags []host.Tag) []*ec2.LaunchTemplateTagSpecificationRequest {
-	awsTags := []*ec2.Tag{}
+func hostToEC2Tags(hostTags []host.Tag) []*ec2.Tag {
+	var tags []*ec2.Tag
 	for _, tag := range hostTags {
 		key := tag.Key
-		val := tag.Value
-		awsTags = append(awsTags, &ec2.Tag{Key: &key, Value: &val})
+		value := tag.Value
+		tags = append(tags, &ec2.Tag{Key: &key, Value: &value})
 	}
+	return tags
+}
+
+func makeTagTemplate(hostTags []host.Tag) []*ec2.LaunchTemplateTagSpecificationRequest {
+	tags := hostToEC2Tags(hostTags)
 	tagTemplates := []*ec2.LaunchTemplateTagSpecificationRequest{
 		{
 			ResourceType: aws.String(ec2.ResourceTypeInstance),
-			Tags:         awsTags,
+			Tags:         tags,
 		},
 		// every host has at least a root volume that needs to be tagged
 		{
 			ResourceType: aws.String(ec2.ResourceTypeVolume),
-			Tags:         awsTags,
+			Tags:         tags,
 		},
 	}
 
 	return tagTemplates
+}
+
+func makeTagSpecifications(hostTags []host.Tag) []*ec2.TagSpecification {
+	tags := hostToEC2Tags(hostTags)
+	return []*ec2.TagSpecification{
+		{
+			ResourceType: aws.String(ec2.ResourceTypeInstance),
+			Tags:         tags,
+		},
+		{
+			ResourceType: aws.String(ec2.ResourceTypeVolume),
+			Tags:         tags,
+		},
+	}
 }
 
 func timeTilNextEC2Payment(h *host.Host) time.Duration {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13874

Include instance and volume tags with the `RunInstances` request for the on-demand provider and no-op the tagging in `OnUp()`, since the resources are already tagged.

For spot instances, we have to keep the existing behavior because the instances can't be tagged in the spot instance request, so we have to wait until the instance ID is available from `GetInstanceStatuses()`. It shouldn't be a problem since we've replace regular spot requests with spot fleet.