### PR TITLE
EVG-13555 include earlier task group tasks as dependencies

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1451,9 +1451,6 @@ func GetRecursiveDependenciesUp(tasks []Task, depCache map[string]Task) ([]Task,
 			if err != nil {
 				return nil, errors.Wrapf(err, "error finding task group '%s'", t.TaskGroup)
 			}
-			if len(tasksInGroup) == 0 {
-				return nil, errors.Errorf("no tasks in task group '%s'", t.TaskGroup)
-			}
 			for _, taskInGroup := range tasksInGroup {
 				if taskInGroup.TaskGroupOrder < t.TaskGroupOrder {
 					if _, ok := depCache[taskInGroup.Id]; !ok {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1853,6 +1853,28 @@ func TestGetRecursiveDependenciesUp(t *testing.T) {
 	}
 }
 
+func TestGetRecursiveDependenciesUpWithTaskGroup(t *testing.T) {
+	require.NoError(t, db.Clear(Collection))
+	tasks := []Task{
+		{Id: "t0", BuildId: "b1", TaskGroup: "tg", TaskGroupMaxHosts: 1, TaskGroupOrder: 0},
+		{Id: "t1", BuildId: "b1", TaskGroup: "tg", TaskGroupMaxHosts: 1, TaskGroupOrder: 1},
+		{Id: "t2", BuildId: "b1", TaskGroup: "tg", TaskGroupMaxHosts: 1, TaskGroupOrder: 2},
+		{Id: "t3", BuildId: "b1", TaskGroup: "tg", TaskGroupMaxHosts: 1, TaskGroupOrder: 3},
+		{Id: "t4", BuildId: "b1", TaskGroup: "tg", TaskGroupMaxHosts: 1, TaskGroupOrder: 4},
+	}
+
+	for _, task := range tasks {
+		require.NoError(t, task.Insert())
+	}
+	taskDependsOn, err := GetRecursiveDependenciesUp([]Task{tasks[2], tasks[3]}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, taskDependsOn, 2)
+	expectedIDs := []string{"t0", "t1"}
+	for _, task := range taskDependsOn {
+		assert.Contains(t, expectedIDs, task.Id)
+	}
+}
+
 func TestGetRecursiveDependenciesDown(t *testing.T) {
 	require.NoError(t, db.Clear(Collection))
 	tasks := []Task{


### PR DESCRIPTION
Really EVG-13555 is open to investigate a race condition, but I realized that some of the linked tasks fail because they've been manually scheduled by a user, and the required earlier tasks in the group aren't also scheduled.