### PR TITLE
EVG-13876: terminate stopped hosts in set-cloud-hosts-ready

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -569,7 +569,7 @@ func (h *Host) SetUnprovisioned() error {
 	return UpdateOne(
 		bson.M{
 			IdKey:     h.Id,
-			StatusKey: evergreen.HostProvisioning,
+			StatusKey: h.Status,
 		},
 		bson.M{
 			"$set": bson.M{

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -156,16 +156,8 @@ func (j *cloudHostReadyJob) terminateUnknownHosts(ctx context.Context, awsErr st
 // setCloudHostStatus sets the host's status to HostProvisioning if host is running.
 func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Manager, h host.Host, hostStatus cloud.CloudStatus) error {
 	switch hostStatus {
-	case cloud.StatusFailed, cloud.StatusTerminated:
-		grip.Debug(message.Fields{
-			"ticket":     "EVG-6100",
-			"message":    "host status",
-			"host_id":    h,
-			"hostStatus": hostStatus.String(),
-		})
-		return errors.Wrap(m.TerminateInstance(ctx, &h, evergreen.User, "cloud provider reported host failed to start"), "error terminating instance")
-	case cloud.StatusStopped:
-		grip.Warning(message.Fields{
+	case cloud.StatusFailed, cloud.StatusTerminated, cloud.StatusStopped:
+		grip.WarningWhen(hostStatus == cloud.StatusStopped, message.Fields{
 			"message":    "host was found in stopped state, which should not occur",
 			"hypothesis": "stopped by the AWS reaper",
 			"host_id":    h.Id,

--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -185,11 +185,12 @@ func TestSetCloudHostStatus(t *testing.T) {
 
 			require.True(t, amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond))
 
+			assert.Equal(t, cloud.StatusTerminated, cloud.GetMockProvider().Get(h.Id).Status)
+
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
-			assert.Zero(t, dbHost.RunningTask)
 		},
 		"StoppedStatusInitiatesTermination": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			tsk := task.Task{
@@ -201,6 +202,8 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusStopped))
 
 			require.True(t, amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond))
+
+			assert.Equal(t, cloud.StatusTerminated, cloud.GetMockProvider().Get(h.Id).Status)
 
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)

--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -179,14 +179,17 @@ func TestSetCloudHostStatus(t *testing.T) {
 			assert.Equal(t, evergreen.HostStarting, dbHost.Status)
 			assert.True(t, dbHost.Provisioned)
 		},
-		"FailedStatusTerminatesCloudInstance": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
+		"FailedStatusInitiatesTermination": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			require.NoError(t, h.Insert())
 			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusFailed))
+
+			require.True(t, amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond))
 
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
+			assert.Zero(t, dbHost.RunningTask)
 		},
 		"StoppedStatusInitiatesTermination": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			tsk := task.Task{

--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -135,18 +135,6 @@ func TestSetCloudHostStatus(t *testing.T) {
 	defer cancel()
 
 	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mgr cloud.Manager){
-		"RunningStatusPreparesForNextStepInHostLifecycle": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mgr cloud.Manager) {
-			require.NoError(t, h.Insert())
-			// This errors because we have no way of configuring the mock
-			// instance in the mock cloud manager to set the DNS name.
-			assert.Error(t, j.setCloudHostStatus(ctx, mgr, *h, cloud.StatusRunning))
-			_, err := mgr.GetDNSName(ctx, h)
-			assert.NoError(t, err)
-			// Mock manager:
-			// Calls OnUp
-			// Sets DNS name
-
-		},
 		"FailedStatusTerminatesCloudInstance": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mgr cloud.Manager) {
 			require.NoError(t, h.Insert())
 			require.NoError(t, j.setCloudHostStatus(ctx, mgr, *h, cloud.StatusFailed))
@@ -173,7 +161,6 @@ func TestSetCloudHostStatus(t *testing.T) {
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
 			assert.Zero(t, dbHost.RunningTask)
 		},
-		// "": func(ctx  context.Context, t *testing.T, h *host.Host, j *cloudHostReadyJob, mgr cloud.Manager) {},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 5*time.Second)

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -111,10 +111,10 @@ func TestHostCosts(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(dbHost)
 	assert.Equal(evergreen.HostTerminated, dbHost.Status)
-	assert.InDelta(5, dbHost.TotalCost, 0.002)
+	assert.InDelta(5, dbHost.TotalCost, 0.01)
 	dbTask, err := task.FindOneId(t1.Id)
 	assert.NoError(err)
-	assert.InDelta(5, dbTask.SpawnedHostCost, 0.002)
+	assert.InDelta(5, dbTask.SpawnedHostCost, 0.01)
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13876

If the host is stopped externally (i.e. because of the reaper), terminate it. I didn't try attempting to just set the host to starting because it'll add complexity for a rare case which should not happen (i.e. dealing with agent monitor deploys, resetting any task that it may have picked up before the reaper stopped it, etc). It's simplest to just treat a stopped host like an externally-terminated spot host.