### PR TITLE
EVG-13878: handle stopped host in external termination check

### DIFF
--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -54,6 +54,8 @@ func NewHostMonitorExternalStateJob(env evergreen.Environment, h *host.Host, id 
 	job.host = h
 	job.HostID = h.Id
 
+	job.env = env
+
 	job.SetID(fmt.Sprintf("%s.%s.%s", hostMonitorExternalStateCheckName, job.HostID, id))
 
 	return job
@@ -129,7 +131,7 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 	case cloud.StatusStopped, cloud.StatusTerminated:
 		event.LogHostTerminatedExternally(h.Id, h.Status)
 
-		err := amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewHostTerminationJob(env, h, true, "host was found in stopped state"))
+		err := amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewHostTerminationJob(env, h, true, fmt.Sprintf("host was found in %s state", cloudStatus.String())))
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":      "could not enqueue job to terminate externally-modified host",
 			"cloud_status": cloudStatus,

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -134,7 +134,7 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 		err := amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewHostTerminationJob(env, h, true, fmt.Sprintf("host was found in %s state", cloudStatus.String())))
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":      "could not enqueue job to terminate externally-modified host",
-			"cloud_status": cloudStatus,
+			"cloud_status": cloudStatus.String(),
 			"host_id":      h.Id,
 			"distro":       h.Distro.Id,
 			"op_id":        id,
@@ -147,7 +147,7 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 			"host_id":      h.Id,
 			"distro":       h.Distro.Id,
 			"host_status":  h.Status,
-			"cloud_status": cloudStatus,
+			"cloud_status": cloudStatus.String(),
 		})
 		return false, errors.Errorf("unexpected host status '%s'", cloudStatus)
 	}

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -159,9 +159,11 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 
 		return true, catcher.Resolve()
 	case cloud.StatusStopped:
+		event.LogHostTerminatedExternally(h.Id, h.Status)
+
 		err := amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewHostTerminationJob(env, h, true, "host was found in stopped state"))
 		grip.Error(message.WrapError(err, message.Fields{
-			"message": "could not enqueue job to terminate host that was found in stopped state",
+			"message": "could not enqueue job to terminate externally-stopped host",
 			"host_id": h.Id,
 			"distro":  h.Distro.Id,
 			"op_id":   id,

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -131,10 +131,11 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 
 		err := amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewHostTerminationJob(env, h, true, "host was found in stopped state"))
 		grip.Error(message.WrapError(err, message.Fields{
-			"message": "could not enqueue job to terminate externally-stopped host",
-			"host_id": h.Id,
-			"distro":  h.Distro.Id,
-			"op_id":   id,
+			"message":      "could not enqueue job to terminate externally-modified host",
+			"cloud_status": cloudStatus,
+			"host_id":      h.Id,
+			"distro":       h.Distro.Id,
+			"op_id":        id,
 		}))
 		return true, err
 	default:

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -129,8 +129,8 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 		}
 		return false, nil
 	case cloud.StatusStopped, cloud.StatusTerminated:
-		// Non-agent hosts that are stopped (e.g. spawn hosts) should not be
-		// treated as externally terminated.
+		// Avoid accidentally terminating non-agent hosts that are stopped (e.g.
+		// spawn hosts).
 		if cloudStatus == cloud.StatusStopped && (h.UserHost || h.StartedBy != evergreen.User) {
 			return false, errors.New("non-agent host is stopped and should not be terminated")
 		}

--- a/units/host_monitoring_external_termination_test.go
+++ b/units/host_monitoring_external_termination_test.go
@@ -12,62 +12,67 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/mongodb/amboy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHostMonitoringCheckJob(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	assert := assert.New(t)
 	require := require.New(t)
-	testConfig := testutil.TestConfig()
 
-	env := &mock.Environment{
-		EvergreenSettings: testConfig,
-	}
+	env := &mock.Environment{}
+	require.NoError(env.Configure(ctx))
 
-	mockCloud := cloud.GetMockProvider()
-	mockCloud.Reset()
-
-	// reset the db
 	require.NoError(db.ClearCollections(host.Collection))
-
-	m1 := cloud.MockInstance{
-		IsUp:           true,
-		IsSSHReachable: true,
-		Status:         cloud.StatusTerminated,
-	}
-	mockCloud.Set("h1", m1)
-
-	// this host should be picked up and updated to running
+	defer func() {
+		assert.NoError(db.ClearCollections(host.Collection))
+	}()
 	h := &host.Host{
 		Id:                    "h1",
 		LastCommunicationTime: time.Now().Add(-15 * time.Minute),
 		Status:                evergreen.HostRunning,
 		Distro:                distro.Distro{Provider: evergreen.ProviderNameMock},
+		Provider:              evergreen.ProviderNameMock,
 		StartedBy:             evergreen.User,
 	}
 	require.NoError(h.Insert())
 
-	j := NewHostMonitorExternalStateJob(env, h, "one")
-	assert.False(j.Status().Completed)
+	mockInstance := cloud.MockInstance{
+		IsUp:           true,
+		IsSSHReachable: true,
+		Status:         cloud.StatusTerminated,
+	}
+	mockCloud := cloud.GetMockProvider()
+	mockCloud.Reset()
+	mockCloud.Set(h.Id, mockInstance)
 
-	j.Run(context.Background())
+	j := NewHostMonitorExternalStateJob(env, h, "one")
+
+	j.Run(ctx)
 
 	assert.NoError(j.Error())
 	assert.True(j.Status().Completed)
 
-	host1, err := host.FindOne(host.ById("h1"))
-	assert.NoError(err)
-	assert.Equal(host1.Status, evergreen.HostTerminated)
+	require.True(amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond))
+
+	dbHost, err := host.FindOneId(h.Id)
+	require.NoError(err)
+	require.NotZero(t, dbHost)
+	assert.Equal(evergreen.HostTerminated, dbHost.Status)
 }
 
 func TestHandleExternallyTerminatedHost(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	for _, terminatedStatus := range []cloud.CloudStatus{cloud.StatusTerminated, cloud.StatusStopped} {
-		t.Run("InstanceStatus"+terminatedStatus.String(), func(t *testing.T) {
+	for statusName, status := range map[string]cloud.CloudStatus{
+		"Terminated": cloud.StatusTerminated,
+		"Stopped":    cloud.StatusStopped,
+	} {
+		t.Run("InstanceStatus"+statusName, func(t *testing.T) {
 			t.Run("TerminatesHostAndClearsTask", func(t *testing.T) {
 				tctx, tcancel := context.WithTimeout(ctx, 5*time.Second)
 				defer tcancel()
@@ -100,7 +105,7 @@ func TestHandleExternallyTerminatedHost(t *testing.T) {
 					RunningTask: tsk.Id,
 				}
 				mockInstance := cloud.MockInstance{
-					Status: terminatedStatus,
+					Status: status,
 				}
 				cloud.GetMockProvider().Set(h.Id, mockInstance)
 

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -159,9 +159,10 @@ func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Mana
 	switch hostStatus {
 	case cloud.StatusFailed, cloud.StatusTerminated, cloud.StatusStopped:
 		grip.WarningWhen(hostStatus == cloud.StatusStopped, message.Fields{
-			"message":    "host was found in stopped state, which should not occur",
-			"hypothesis": "stopped by the AWS reaper",
-			"host_id":    h.Id,
+			"message":      "host was found in stopped state, which should not occur",
+			"hypothesis":   "stopped by the AWS reaper",
+			"host_id":      h.Id,
+			"cloud_status": hostStatus.String(),
 		})
 
 		event.LogHostTerminatedExternally(h.Id, h.Status)
@@ -179,12 +180,12 @@ func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Mana
 	}
 
 	grip.Info(message.Fields{
-		"message": "host not ready for setup",
-		"host_id": h.Id,
-		"DNS":     h.Host,
-		"distro":  h.Distro.Id,
-		"runner":  "hostinit",
-		"status":  hostStatus,
+		"message":      "host not ready for setup",
+		"host_id":      h.Id,
+		"DNS":          h.Host,
+		"distro":       h.Distro.Id,
+		"runner":       "hostinit",
+		"cloud_status": hostStatus,
 	})
 	return nil
 }

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -181,7 +181,7 @@ func cleanUpTimedOutTask(ctx context.Context, env evergreen.Environment, id stri
 	// if the host still has the task as its running task, clear it.
 	if host.RunningTask == t.Id {
 		// Check if the host was externally terminated. When the running task is
-		// cleared on the host, an agent or agent moniitor deploy might run,
+		// cleared on the host, an agent or agent monitor deploy might run,
 		// which updates the LCT and prevents detection of external termination
 		// until the deploy job runs out of retries.
 		var terminated bool

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -165,6 +165,7 @@ func TestCleanupTask(t *testing.T) {
 					RunningTask: "t1",
 					Distro:      distro.Distro{Provider: evergreen.ProviderNameMock},
 					Provider:    evergreen.ProviderNameMock,
+					StartedBy:   evergreen.User,
 					Status:      evergreen.HostRunning,
 				}
 				So(h.Insert(), ShouldBeNil)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13878

* Treat a stopped host as externally terminated and merge the cases (the host termination job will operate the same on a stopped/terminated instance except it'll also terminate a stopped cloud instance).
* Include an event log for external termination if it's caught by set-cloud-hosts-ready.