### PR TITLE
EVG-13833: don't specify unset in host upsert if there are no fields to unset

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1479,8 +1479,10 @@ func (h *Host) Upsert() (*adb.ChangeInfo, error) {
 		"$setOnInsert": bson.M{
 			CreateTimeKey: h.CreationTime,
 		},
-		"$set":   setFields,
-		"$unset": unsetFields,
+		"$set": setFields,
+	}
+	if len(unsetFields) != 0 {
+		update["$unset"] = unsetFields
 	}
 
 	return UpsertOne(bson.M{IdKey: h.Id}, update)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13833

The `$unset` portion of the upsert might be empty and MQL doesn't like it when you do `{"$unset": {}}`.