### PR TITLE
EVG-13882 sort patch tasks by color rather than label

### DIFF
--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -38,13 +38,13 @@
           "patchTasks": {
             "tasks": [
               {
+                "id": "4"
+              },
+              {
                 "id": "1.5"
               },
               {
                 "id": "4.5"
-              },
-              {
-                "id": "4"
               },
               {
                 "id": "3"
@@ -62,13 +62,13 @@
           "patchTasks": {
             "tasks": [
               {
+                "id": "4"
+              },
+              {
                 "id": "1.5"
               },
               {
                 "id": "4.5"
-              },
-              {
-                "id": "4"
               },
               {
                 "id": "3"
@@ -104,6 +104,13 @@
                 "buildVariant": "ubuntu1604"
               },
               {
+                "id": "4",
+                "status": "task-timed-out",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
                 "id": "1.5",
                 "status": "system-failed",
                 "baseStatus": "success",
@@ -113,13 +120,6 @@
               {
                 "id": "4.5",
                 "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
-              },
-              {
-                "id": "4",
-                "status": "task-timed-out",
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
@@ -227,16 +227,16 @@
                 "status": "failed"
               },
               {
+                "id": "4",
+                "status": "task-timed-out"
+              },
+              {
                 "id": "1.5",
                 "status": "system-failed"
               },
               {
                 "id": "4.5",
                 "status": "system-failed"
-              },
-              {
-                "id": "4",
-                "status": "task-timed-out"
               },
               {
                 "id": "1",
@@ -423,13 +423,6 @@
                 "buildVariant": "windows"
               },
               {
-                "id": "4",
-                "status": "task-timed-out",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
-              },
-              {
                 "id": "1.5",
                 "status": "system-failed",
                 "baseStatus": "success",
@@ -439,6 +432,13 @@
               {
                 "id": "4.5",
                 "status": "system-failed",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "4",
+                "status": "task-timed-out",
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
@@ -547,8 +547,8 @@
                 "buildVariant": "ubuntu1604"
               },
               {
-                "id": "1.5",
-                "status": "system-failed",
+                "id": "4",
+                "status": "task-timed-out",
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
@@ -566,15 +566,15 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "4.5",
+                "id": "1.5",
                 "status": "system-failed",
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
               },
               {
-                "id": "4",
-                "status": "task-timed-out",
+                "id": "4.5",
+                "status": "system-failed",
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
@@ -626,6 +626,10 @@
                 "executionTasksFull": null
               },
               {
+                "id": "4",
+                "executionTasksFull": null
+              },
+              {
                 "id": "1.5",
                 "executionTasksFull": [
                   {
@@ -636,10 +640,6 @@
               },
               {
                 "id": "4.5",
-                "executionTasksFull": null
-              },
-              {
-                "id": "4",
                 "executionTasksFull": null
               },
               {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -144,46 +144,53 @@ var (
 	displayStatusExpression = bson.M{
 		"$switch": bson.M{
 			"branches": []bson.M{
-				{"case": bson.M{
-					"$eq": []interface{}{"$" + AbortedKey, true},
-				},
+				{
+					"case": bson.M{
+						"$eq": []interface{}{"$" + AbortedKey, true},
+					},
 					"then": evergreen.TaskAborted,
 				},
-				{"case": bson.M{
-					"$eq": []string{"$" + StatusKey, evergreen.TaskSucceeded},
-				},
+				{
+					"case": bson.M{
+						"$eq": []string{"$" + StatusKey, evergreen.TaskSucceeded},
+					},
 					"then": evergreen.TaskSucceeded,
 				},
-				{"case": bson.M{
-					"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailType), evergreen.CommandTypeSetup},
-				},
+				{
+					"case": bson.M{
+						"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailType), evergreen.CommandTypeSetup},
+					},
 					"then": evergreen.TaskSetupFailed,
 				},
-				{"case": bson.M{
-					"$and": []bson.M{
-						{"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailType), evergreen.CommandTypeSystem}},
-						{"$eq": []interface{}{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true}},
-						{"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailDescription), evergreen.TaskDescriptionHeartbeat}},
+				{
+					"case": bson.M{
+						"$and": []bson.M{
+							{"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailType), evergreen.CommandTypeSystem}},
+							{"$eq": []interface{}{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true}},
+							{"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailDescription), evergreen.TaskDescriptionHeartbeat}},
+						},
 					},
-				},
 					"then": evergreen.TaskSystemUnresponse,
 				},
-				{"case": bson.M{
-					"$and": []bson.M{
-						{"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailType), evergreen.CommandTypeSystem}},
-						{"$eq": []interface{}{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true}},
+				{
+					"case": bson.M{
+						"$and": []bson.M{
+							{"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailType), evergreen.CommandTypeSystem}},
+							{"$eq": []interface{}{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true}},
+						},
 					},
-				},
 					"then": evergreen.TaskSystemTimedOut,
 				},
-				{"case": bson.M{
-					"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailType), evergreen.CommandTypeSystem},
-				},
+				{
+					"case": bson.M{
+						"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailType), evergreen.CommandTypeSystem},
+					},
 					"then": evergreen.TaskSystemFailed,
 				},
-				{"case": bson.M{
-					"$eq": []interface{}{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true},
-				},
+				{
+					"case": bson.M{
+						"$eq": []interface{}{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true},
+					},
 					"then": evergreen.TaskTimedOut,
 				},
 			},

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2719,7 +2719,7 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 	if len(sortBy) > 0 {
 		for _, singleSort := range sortBy {
 			if singleSort.Key == DisplayStatusKey || singleSort.Key == BaseTaskStatusKey {
-				pipeline = append(pipeline, addCustomStatusSortField((singleSort.Key)))
+				pipeline = append(pipeline, addStatusColorSort((singleSort.Key)))
 				sortFields = append(sortFields, bson.E{Key: "__" + singleSort.Key, Value: singleSort.Order})
 				sortFields = append(sortFields, bson.E{Key: singleSort.Key, Value: singleSort.Order})
 			} else {
@@ -2781,16 +2781,47 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 	return tasks, count, nil
 }
 
-func addCustomStatusSortField(key string) bson.M {
+// addStatusColorSort adds a stage which takes a task display status and returns an integer
+// for the rank at which it should be sorted. the return value groups all statuses with the
+// same color together. this should be kept consistent with the badge status colors in spruce
+func addStatusColorSort(key string) bson.M {
 	return bson.M{
 		"$addFields": bson.M{
 			"__" + key: bson.M{
-				"$cond": bson.M{
-					"if": bson.M{
-						"$in": []interface{}{"$" + key, evergreen.TaskFailureStatuses},
+				"$switch": bson.M{
+					"branches": []bson.M{
+						{
+							"case": bson.M{
+								"$in": []interface{}{"$" + key, []string{evergreen.TaskFailed, evergreen.TaskTestTimedOut, evergreen.TaskTimedOut}},
+							},
+							"then": 1, // red
+						},
+						{
+							"case": bson.M{
+								"$eq": []string{"$" + key, evergreen.TaskSetupFailed},
+							},
+							"then": 2, // lavender
+						},
+						{
+							"case": bson.M{
+								"$in": []interface{}{"$" + key, []string{evergreen.TaskSystemFailed, evergreen.TaskSystemUnresponse, evergreen.TaskSystemTimedOut}},
+							},
+							"then": 3, // purple
+						},
+						{
+							"case": bson.M{
+								"$in": []interface{}{"$" + key, []string{evergreen.TaskStarted, evergreen.TaskDispatched}},
+							},
+							"then": 4, // yellow
+						},
+						{
+							"case": bson.M{
+								"$eq": []string{"$" + key, evergreen.TaskSucceeded},
+							},
+							"then": 10, // green
+						},
 					},
-					"then": "a",
-					"else": "b",
+					"default": 6, // all shades of grey
 				},
 			},
 		},


### PR DESCRIPTION
The only change here is to the stage we had in the aggregation to get tasks for a patch. Instead of just sorting failed above everything else, we instead assign numbers to statuses corresponding to their color in the UI and sort by that