### PR TITLE
EVG-13764: add logging and improve comments on set-cloud-hosts-ready

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1288,14 +1288,6 @@ func (m *ec2Manager) IsUp(ctx context.Context, h *host.Host) (bool, error) {
 
 // OnUp is called when the host is up.
 func (m *ec2Manager) OnUp(ctx context.Context, h *host.Host) error {
-	grip.Debug(message.Fields{
-		"message":       "host is up",
-		"host_id":       h.Id,
-		"host_provider": h.Distro.Provider,
-		"distro":        h.Distro.Id,
-		"is_spot":       isHostSpot(h),
-	})
-
 	if isHostOnDemand(h) {
 		// On-demand hosts and its volumes are already tagged in the request for
 		// the instance.

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -32,8 +32,11 @@ type cloudHostReadyJob struct {
 	env      evergreen.Environment
 }
 
-// NewCloudHostReadyJob gets statuses for all jobs created by Cloud providers which the Cloud providers'
-// APIs have not yet returned all running. It marks the hosts running in the database.
+// NewCloudHostReadyJob checks the cloud instance status for all hosts created
+// by cloud providers when the instance is not yet ready to be used (e.g. the
+// instance is still booting up). Once the cloud instance status is resolved,
+// the job can either transition the host into the next step in the host
+// lifecycle or be appropriately handled if it is in an unrecoverable state.
 func NewCloudHostReadyJob(env evergreen.Environment, id string) amboy.Job {
 	j := makeCloudHostReadyJob()
 	j.SetID(fmt.Sprintf("%s.%s", cloudHostReadyJobName, id))
@@ -60,9 +63,6 @@ func makeCloudHostReadyJob() *cloudHostReadyJob {
 }
 
 func (j *cloudHostReadyJob) Run(ctx context.Context) {
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithCancel(ctx)
-	defer cancel()
 	defer j.MarkComplete()
 	if j.env == nil {
 		j.env = evergreen.GetEnvironment()
@@ -100,7 +100,14 @@ clientsLoop:
 			return
 		}
 		if batch, ok := m.(cloud.BatchManager); ok {
+			startAt := time.Now()
 			statuses, err := batch.GetInstanceStatuses(ctx, hosts)
+			grip.Debug(message.Fields{
+				"message":       "finished getting instance statuses",
+				"num_hosts":     len(hosts),
+				"provider":      clientOpts.Provider,
+				"duration_secs": time.Since(startAt).Seconds(),
+			})
 			if err != nil {
 				if strings.Contains(err.Error(), "InvalidInstanceID.NotFound") {
 					j.AddError(j.terminateUnknownHosts(ctx, err.Error()))
@@ -119,12 +126,19 @@ clientsLoop:
 			continue clientsLoop
 		}
 		for _, h := range hosts {
-			hostStatus, err := m.GetInstanceStatus(ctx, &h)
+			startAt := time.Now()
+			cloudStatus, err := m.GetInstanceStatus(ctx, &h)
+			grip.Debug(message.Fields{
+				"message":       "finished getting instance status",
+				"host_id":       h.Id,
+				"provider":      clientOpts.Provider,
+				"duration_secs": time.Since(startAt).Seconds(),
+			})
 			if err != nil {
 				j.AddError(errors.Wrapf(err, "error checking instance status of host %s", h.Id))
 				continue clientsLoop
 			}
-			j.AddError(errors.Wrap(j.setCloudHostStatus(ctx, m, h, hostStatus), "error setting instance status"))
+			j.AddError(errors.Wrap(j.setCloudHostStatus(ctx, m, h, cloudStatus), "error setting instance status"))
 		}
 	}
 }
@@ -154,16 +168,14 @@ func (j *cloudHostReadyJob) terminateUnknownHosts(ctx context.Context, awsErr st
 	return catcher.Resolve()
 }
 
-// setCloudHostStatus sets the host's status to HostProvisioning if host is running.
-func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Manager, h host.Host, hostStatus cloud.CloudStatus) error {
-	switch hostStatus {
+// setCloudHostStatus checks the status of the host's cloud instance to
+// determine the next step in the host lifecycle. Hosts that are running
+// in the cloud can successfully transition to the next step in the lifecycle.
+// Hosts found in an unrecoverable state are terminated.
+func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Manager, h host.Host, cloudStatus cloud.CloudStatus) error {
+	switch cloudStatus {
 	case cloud.StatusFailed, cloud.StatusTerminated, cloud.StatusStopped:
-		grip.WarningWhen(hostStatus == cloud.StatusStopped, message.Fields{
-			"message":      "host was found in stopped state, which should not occur",
-			"hypothesis":   "stopped by the AWS reaper",
-			"host_id":      h.Id,
-			"cloud_status": hostStatus.String(),
-		})
+		j.logHostStatusMessage(&h, cloudStatus)
 
 		event.LogHostTerminatedExternally(h.Id, h.Status)
 
@@ -176,16 +188,18 @@ func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Mana
 		if err := j.initialSetup(ctx, m, &h); err != nil {
 			return errors.Wrap(err, "problem doing initial setup")
 		}
-		return j.setNextState(h)
+		err := j.setNextState(h)
+		j.logHostStatusMessage(&h, cloudStatus)
+		return err
 	}
 
 	grip.Info(message.Fields{
 		"message":      "host not ready for setup",
 		"host_id":      h.Id,
-		"DNS":          h.Host,
 		"distro":       h.Distro.Id,
 		"runner":       "hostinit",
-		"cloud_status": hostStatus,
+		"cloud_status": cloudStatus.String(),
+		"job":          j.ID(),
 	})
 	return nil
 }
@@ -193,10 +207,13 @@ func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Mana
 func (j *cloudHostReadyJob) setNextState(h host.Host) error {
 	switch h.Distro.BootstrapSettings.Method {
 	case distro.BootstrapMethodUserData:
-		// We're done provisioning user data hosts. The user data script will do the rest.
+		// From the app server's perspective, it is done provisioning a user
+		// data host once the instance is running. The user data script will
+		// handle the rest of host provisioning.
 		return errors.Wrapf(h.SetProvisionedNotRunning(), "error marking host %s as provisioned not running", h.Id)
 	case distro.BootstrapMethodNone:
-		// hosts created by tasks are not provisioned so we can skip the provisioning state.
+		// A host created by a task goes through no further provisioning, so we
+		// can just set it as running.
 		return errors.Wrapf(h.MarkAsProvisioned(), "error marking host %s as running", h.Id)
 	default:
 		return errors.Wrap(h.SetProvisioning(), "error setting host to provisioning")
@@ -215,7 +232,6 @@ func (j *cloudHostReadyJob) setDNSName(ctx context.Context, cloudMgr cloud.Manag
 		return nil
 	}
 
-	// get the DNS name for the host
 	hostDNS, err := cloudMgr.GetDNSName(ctx, h)
 	if err != nil {
 		return errors.Wrapf(err, "error checking DNS name for host %s", h.Id)
@@ -236,4 +252,53 @@ func (j *cloudHostReadyJob) setDNSName(ctx context.Context, cloudMgr cloud.Manag
 	}
 
 	return nil
+}
+
+// logHostStatusMessage logs the appropriate message once the status of a host's
+// cloud instance is known and the host can transition to the next step in
+// provisioning.
+func (j *cloudHostReadyJob) logHostStatusMessage(h *host.Host, cloudStatus cloud.CloudStatus) {
+	switch cloudStatus {
+	case cloud.StatusStopped:
+		grip.Warning(message.Fields{
+			"message":      "host was found in stopped state before it could transition to ready, which should not occur",
+			"hypothesis":   "stopped by the AWS reaper",
+			"host_id":      h.Id,
+			"distro":       h.Distro.Id,
+			"cloud_status": cloudStatus.String(),
+			"job":          j.ID(),
+		})
+	case cloud.StatusTerminated:
+		grip.Warning(message.Fields{
+			"message":      "host's instance was terminated before it could transition to ready",
+			"host_id":      h.Id,
+			"distro":       h.Distro.Id,
+			"cloud_status": cloudStatus.String(),
+			"job":          j.ID(),
+		})
+	case cloud.StatusFailed:
+		grip.Warning(message.Fields{
+			"message":      "host's instance failed to start",
+			"host_id":      h.Id,
+			"distro":       h.Distro.Id,
+			"cloud_status": cloudStatus.String(),
+			"job":          j.ID(),
+		})
+	case cloud.StatusRunning:
+		grip.Info(message.Fields{
+			"message":      "host's instance was successfully found up and running",
+			"host_id":      h.Id,
+			"distro":       h.Distro.Id,
+			"cloud_status": cloudStatus.String(),
+			"job":          j.ID(),
+		})
+	default:
+		grip.Error(message.Fields{
+			"message":      "host's instance is in a state that the system does not know how to handle",
+			"host_id":      h.Id,
+			"distro":       h.Distro.Id,
+			"cloud_status": cloudStatus.String(),
+			"job":          j.ID(),
+		})
+	}
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13764

* Add logging (including timing info) for potentially long cloud provider requests so we can diagnose if the job is taking a long time to finish its requests.
* Update the comments in set-cloud-hosts-ready to be more precise about what it's doing.