### PR TITLE
EVG-13555 check if previous task in task group is dispatchable

### DIFF
--- a/service/api_task.go
+++ b/service/api_task.go
@@ -568,7 +568,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 				}
 				if numHosts > nextTask.TaskGroupMaxHosts {
 					dispatchRace = fmt.Sprintf("tasks found on %d hosts", numHosts)
-				} else if nextTask.TaskGroupOrder != 0 && nextTask.TaskGroupMaxHosts == 1 {
+				} else if nextTask.TaskGroupOrder > 1 && nextTask.TaskGroupMaxHosts == 1 {
 					// if the previous task in the group has yet to run and should run, then wait for it
 					tgTasks, err := task.FindTaskGroupFromBuild(nextTask.BuildId, nextTask.TaskGroup)
 					if err != nil {

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -568,10 +568,8 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 				}
 				if numHosts > nextTask.TaskGroupMaxHosts {
 					dispatchRace = fmt.Sprintf("tasks found on %d hosts", numHosts)
-				}
-
-				// if the previous task in the group has yet to run and should run, then wait for it
-				if nextTask.TaskGroupOrder != 0 && nextTask.TaskGroupMaxHosts == 1 {
+				} else if nextTask.TaskGroupOrder != 0 && nextTask.TaskGroupMaxHosts == 1 {
+					// if the previous task in the group has yet to run and should run, then wait for it
 					tgTasks, err := task.FindTaskGroupFromBuild(nextTask.BuildId, nextTask.TaskGroup)
 					if err != nil {
 						return nil, false, errors.WithStack(err)


### PR DESCRIPTION
This task group race occurs when the first task in the group comes after another task group, because then we do this [teardown step.](https://github.com/evergreen-ci/evergreen/blob/b58685992234364395c9a882e55da1a05e4222c1/service/api_task.go#L503) And then the next task doesn't hit any of the dispatch error catches. In my original work for EVG-7903, I tried a strict catch: `if nextTask.TaskGroupMaxHosts == 1 && nextTask.TaskGroupOrder > 1 then it's a race`. This ended up being too strict (if there's any bug with task group restarting, then a task can get stuck on the queue forever), so even though this version requires a DB lookup, it should be a rare enough case, and I believe if a previous task is technically dispatchable, it makes sense for later tasks to wait.