### PR TITLE
EVG-13166 Backend function that files a ticket

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -306,7 +306,7 @@ type ComplexityRoot struct {
 		AddAnnotationIssue        func(childComplexity int, taskID string, execution int, apiIssue model.APIIssueLink, isIssue bool) int
 		AddFavoriteProject        func(childComplexity int, identifier string) int
 		AttachVolumeToHost        func(childComplexity int, volumeAndHost VolumeHost) int
-		BbCreateTicket            func(childComplexity int, taskID string) int
+		BbCreateTicket            func(childComplexity int, taskID string, execution *int) int
 		ClearMySubscriptions      func(childComplexity int) int
 		CreatePublicKey           func(childComplexity int, publicKeyInput PublicKeyInput) int
 		DetachVolumeFromHost      func(childComplexity int, volumeID string) int
@@ -810,7 +810,7 @@ type MutationResolver interface {
 	DetachVolumeFromHost(ctx context.Context, volumeID string) (bool, error)
 	RemoveVolume(ctx context.Context, volumeID string) (bool, error)
 	EditSpawnHost(ctx context.Context, spawnHost *EditSpawnHostInput) (*model.APIHost, error)
-	BbCreateTicket(ctx context.Context, taskID string) (bool, error)
+	BbCreateTicket(ctx context.Context, taskID string, execution *int) (bool, error)
 	ClearMySubscriptions(ctx context.Context) (int, error)
 }
 type PatchResolver interface {
@@ -2010,7 +2010,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.BbCreateTicket(childComplexity, args["taskId"].(string)), true
+		return e.complexity.Mutation.BbCreateTicket(childComplexity, args["taskId"].(string), args["execution"].(*int)), true
 
 	case "Mutation.clearMySubscriptions":
 		if e.complexity.Mutation.ClearMySubscriptions == nil {
@@ -4687,7 +4687,7 @@ type Mutation {
   detachVolumeFromHost(volumeId: String!): Boolean!
   removeVolume(volumeId: String!): Boolean!
   editSpawnHost(spawnHost: EditSpawnHostInput): Host!
-  bbCreateTicket(taskId: String!): Boolean!
+  bbCreateTicket(taskId: String!, execution: Int): Boolean!
   clearMySubscriptions: Int!
 }
 
@@ -5619,6 +5619,14 @@ func (ec *executionContext) field_Mutation_bbCreateTicket_args(ctx context.Conte
 		}
 	}
 	args["taskId"] = arg0
+	var arg1 *int
+	if tmp, ok := rawArgs["execution"]; ok {
+		arg1, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["execution"] = arg1
 	return args, nil
 }
 
@@ -12922,7 +12930,7 @@ func (ec *executionContext) _Mutation_bbCreateTicket(ctx context.Context, field 
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().BbCreateTicket(rctx, args["taskId"].(string))
+		return ec.resolvers.Mutation().BbCreateTicket(rctx, args["taskId"].(string), args["execution"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2446,8 +2446,8 @@ func (r *queryResolver) BuildBaron(ctx context.Context, taskID string, exec int)
 	}, nil
 }
 
-func (r *mutationResolver) BbCreateTicket(ctx context.Context, taskID string) (bool, error) {
-	taskNotFound, err := BbFileTicket(ctx, taskID)
+func (r *mutationResolver) BbCreateTicket(ctx context.Context, taskID string, execution *int) (bool, error) {
+	taskNotFound, err := BbFileTicket(ctx, taskID, *execution)
 	successful := true
 
 	if err != nil {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -133,7 +133,7 @@ type Mutation {
   detachVolumeFromHost(volumeId: String!): Boolean!
   removeVolume(volumeId: String!): Boolean!
   editSpawnHost(spawnHost: EditSpawnHostInput): Host!
-  bbCreateTicket(taskId: String!): Boolean!
+  bbCreateTicket(taskId: String!, execution: Int): Boolean!
   clearMySubscriptions: Int!
 }
 

--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -56,8 +56,8 @@ func BbFileTicket(context context.Context, taskId string, execution int) (bool, 
 	annotationSettings := buildBaronProjects[t.Project].TaskAnnotationSettings
 	webHook := annotationSettings.FileTicketWebHook
 	if webHook.Endpoint != "" {
-		//todo: add execution
-		resp, err := fileTicketCustomHook(context, taskId, execution, webHook)
+		var resp *http.Response
+		resp, err = fileTicketCustomHook(context, taskId, execution, webHook)
 		return resp.StatusCode == http.StatusOK, err
 	}
 

--- a/model/annotations/db.go
+++ b/model/annotations/db.go
@@ -17,8 +17,8 @@ var (
 	NoteKey            = bsonutil.MustHaveTag(TaskAnnotation{}, "Note")
 	IssuesKey          = bsonutil.MustHaveTag(TaskAnnotation{}, "Issues")
 	SuspectedIssuesKey = bsonutil.MustHaveTag(TaskAnnotation{}, "SuspectedIssues")
-
-	IssueLinkIssueKey = bsonutil.MustHaveTag(IssueLink{}, "IssueKey")
+	CreatedIssuesKey   = bsonutil.MustHaveTag(TaskAnnotation{}, "CreatedIssues")
+	IssueLinkIssueKey  = bsonutil.MustHaveTag(IssueLink{}, "IssueKey")
 )
 
 const (

--- a/model/annotations/task_annotations.go
+++ b/model/annotations/task_annotations.go
@@ -22,6 +22,8 @@ type TaskAnnotation struct {
 	Issues []IssueLink `bson:"issues,omitempty" json:"issues,omitempty"`
 	// links to tickets possibly related
 	SuspectedIssues []IssueLink `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
+	// links to tickets created from the task using a custom web hook
+	CreatedIssues []IssueLink `bson:"created_issues,omitempty" json:"created_issues,omitempty"`
 }
 
 type IssueLink struct {

--- a/rest/model/task_annotations.go
+++ b/rest/model/task_annotations.go
@@ -19,6 +19,7 @@ type APITaskAnnotation struct {
 	Note            *APINote        `bson:"note,omitempty" json:"note,omitempty"`
 	Issues          []APIIssueLink  `bson:"issues,omitempty" json:"issues,omitempty"`
 	SuspectedIssues []APIIssueLink  `bson:"suspected_issues,omitempty" json:"suspected_issues,omitempty"`
+	CreatedIssues   []APIIssueLink  `bson:"created_issues,omitempty" json:"created_issues,omitempty"`
 }
 
 type APINote struct {
@@ -121,6 +122,7 @@ func APITaskAnnotationBuildFromService(t annotations.TaskAnnotation) *APITaskAnn
 	m.Metadata = t.Metadata
 	m.Issues = ArrtaskannotationsIssueLinkArrAPIIssueLink(t.Issues)
 	m.SuspectedIssues = ArrtaskannotationsIssueLinkArrAPIIssueLink(t.SuspectedIssues)
+	m.CreatedIssues = ArrtaskannotationsIssueLinkArrAPIIssueLink(t.CreatedIssues)
 	m.Note = APINoteBuildFromService(t.Note)
 	return &m
 }
@@ -135,6 +137,7 @@ func APITaskAnnotationToService(m APITaskAnnotation) *annotations.TaskAnnotation
 	out.Metadata = m.Metadata
 	out.Issues = ArrAPIIssueLinkArrtaskannotationsIssueLink(m.Issues)
 	out.SuspectedIssues = ArrAPIIssueLinkArrtaskannotationsIssueLink(m.SuspectedIssues)
+	out.CreatedIssues = ArrAPIIssueLinkArrtaskannotationsIssueLink(m.CreatedIssues)
 	out.Note = APINoteToService(m.Note)
 	return out
 }

--- a/service/ui_plugin_build_baron.go
+++ b/service/ui_plugin_build_baron.go
@@ -138,10 +138,10 @@ func (uis *UIServer) bbFileTicket(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 		gimlet.WriteJSONInternalError(w, err.Error())
 	}
-	// the execution doesn't matter here. It only matters for webhooks, which will only be used in Spruce
+	// the execution doesn't matter here. It only matters for custom webhooks, which will only be used in Spruce
 	taskNotFound, err := graphql.BbFileTicket(r.Context(), input.TaskId, 0)
 
-	if taskNotFound {
+	if taskNotFound && err != nil {
 		gimlet.WriteJSON(w, err.Error())
 		return
 	}

--- a/service/ui_plugin_build_baron.go
+++ b/service/ui_plugin_build_baron.go
@@ -138,8 +138,8 @@ func (uis *UIServer) bbFileTicket(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 		gimlet.WriteJSONInternalError(w, err.Error())
 	}
-
-	taskNotFound, err := graphql.BbFileTicket(r.Context(), input.TaskId)
+	// the execution doesn't matter here. It only matters for webhooks, which will only be used in Spruce
+	taskNotFound, err := graphql.BbFileTicket(r.Context(), input.TaskId, 0)
 
 	if taskNotFound {
 		gimlet.WriteJSON(w, err.Error())


### PR DESCRIPTION
In a separate ticket, I will create an api endpoint for teams to use to send back the ticket id of the ticket that was created. It will be stored in CreatedIssues. 
@khelif96 and @SupaJoon, I'm adding you because it touches the resolvers and schema but I checked and made sure that it doesn't break Spruce. (I made it nullable, but will probably change it once the Spruce part which I'll do in a separate ticket is deployed). Feel free to skip reviewing this, I just wanted you to be aware of it. 