### PR TITLE
EVG-13750 don't check for existing item in commit queue middleware

### DIFF
--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
-	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -23,6 +22,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type (
@@ -414,25 +414,7 @@ func (m *CommitQueueItemOwnerMiddleware) ServeHTTP(rw http.ResponseWriter, r *ht
 		return
 	}
 
-	cq, err := commitqueue.FindOneId(projRef.Id)
-	if err != nil || cq == nil {
-		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    "No commit queue for project found",
-		}))
-		return
-	}
-	spot := cq.FindItem(itemId)
-	if spot == -1 {
-		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    "Item not found in queue",
-		}))
-		return
-	}
-	entry := cq.Queue[spot]
-
-	if entry.Source == commitqueue.SourceDiff {
+	if bson.IsObjectIdHex(itemId) {
 		patch, err := m.sc.FindPatchById(itemId)
 		if err != nil {
 			gimlet.WriteResponse(rw, gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't find item")))
@@ -445,8 +427,7 @@ func (m *CommitQueueItemOwnerMiddleware) ServeHTTP(rw http.ResponseWriter, r *ht
 			}))
 			return
 		}
-	} else if entry.Source == commitqueue.SourcePullRequest {
-		itemInt, err := strconv.Atoi(itemId)
+	} else if itemInt, err := strconv.Atoi(itemId); err == nil {
 		if err != nil {
 			gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 				StatusCode: http.StatusBadRequest,
@@ -478,7 +459,7 @@ func (m *CommitQueueItemOwnerMiddleware) ServeHTTP(rw http.ResponseWriter, r *ht
 	} else {
 		grip.Error(message.Fields{
 			"message": "commit queue entry has unknown source",
-			"entry":   entry,
+			"entry":   itemId,
 			"project": projRef.Identifier,
 		})
 	}

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -428,14 +428,6 @@ func (m *CommitQueueItemOwnerMiddleware) ServeHTTP(rw http.ResponseWriter, r *ht
 			return
 		}
 	} else if itemInt, err := strconv.Atoi(itemId); err == nil {
-		if err != nil {
-			gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-				StatusCode: http.StatusBadRequest,
-				Message:    "item is not an integer",
-			}))
-			return
-		}
-
 		pr, err := m.sc.GetGitHubPR(ctx, projRef.Owner, projRef.Repo, itemInt)
 		if err != nil {
 			gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{


### PR DESCRIPTION
There was a chicken/egg problem. The changed code checks to see if you're the owner of the commit queue item you're trying to change, and looks for the entry on the commit queue to see if it needs to check the patch author or PR owner. However this also runs before the route that actually puts something on the queue so there's nothing to check. Also I tested this twice in staging and have no idea how that passed, but that's a problem for later