### PR TITLE
EVG-13931: include hostname and IP addresses in Jasper certificates

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -140,7 +140,7 @@ imports:
     version: 75f93ec68b7847d65e8c0508a8553608e0e60aff
 
   - name: github.com/evergreen-ci/certdepot
-    version: 270990334f8f50e41a803e88f169d2f467e376c5
+    version: 9456d26c9ecb153ae54a546691e8d9aae859201b
 
   # git library and its dependencies
   - name: gopkg.in/src-d/go-git.v4

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -664,18 +664,27 @@ func (h *Host) GenerateJasperCredentials(ctx context.Context, env evergreen.Envi
 	if err := h.DeleteJasperCredentials(ctx, env); err != nil {
 		return nil, errors.Wrap(err, "problem deleting existing Jasper credentials")
 	}
+	addToSet := func(set []string, val string) []string {
+		if utility.StringSliceContains(set, val) {
+			return set
+		}
+		return append(set, val)
+	}
 
 	domains := []string{h.JasperCredentialsID}
 	var ipAddrs []string
+	if net.ParseIP(h.JasperCredentialsID) != nil {
+		ipAddrs = addToSet(ipAddrs, h.JasperCredentialsID)
+	}
 	if h.Host != "" {
 		if net.ParseIP(h.Host) != nil {
-			ipAddrs = append(ipAddrs, h.Host)
-		} else if !utility.StringSliceContains(domains, h.Host) {
-			domains = append(domains, h.Host)
+			ipAddrs = addToSet(ipAddrs, h.Host)
+		} else {
+			domains = addToSet(domains, h.Host)
 		}
 	}
 	if h.IP != "" && net.ParseIP(h.IP) != nil {
-		ipAddrs = append(ipAddrs, h.IP)
+		ipAddrs = addToSet(ipAddrs, h.IP)
 	}
 	opts := certdepot.CertificateOptions{
 		CommonName: h.JasperCredentialsID,

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -680,33 +680,14 @@ func (h *Host) GenerateJasperCredentials(ctx context.Context, env evergreen.Envi
 	opts := certdepot.CertificateOptions{
 		CommonName: h.JasperCredentialsID,
 		Host:       h.JasperCredentialsID,
-		// kim: TODO: is it valid to add the host ID as part of the IP/domain?
-		// It isn't a real domain, but it seems like it threads the needle with
-		// SANs to allow TLS connections using host IDs as the server name.
-		Domain: domains,
-		IP:     ipAddrs,
-		CA:     evergreen.CAName,
+		Domain:     domains,
+		IP:         ipAddrs,
+		CA:         evergreen.CAName,
 	}
-	grip.Debug(message.Fields{
-		"message": "kim: generating certificate with options",
-		"host_id": h.Id,
-		"distro":  h.Distro.Id,
-		"opts":    opts,
-	})
 	creds, err := env.CertificateDepot().GenerateWithOptions(opts)
 	if err != nil {
-		grip.Debug(message.WrapError(err, message.Fields{
-			"message": "kim: failed to generate certificate with options",
-			"host_id": h.Id,
-			"distro":  h.Distro.Id,
-			"opts":    opts,
-		}))
 		return nil, errors.Wrapf(err, "credential generation issue for host '%s'", h.JasperCredentialsID)
 	}
-	grip.Debug(message.Fields{
-		"message": "kim: successfully generated certificate with options",
-		"opts":    opts,
-	})
 
 	return creds, nil
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1484,6 +1484,104 @@ func TestFindUserDataSpawnHostsProvisioning(t *testing.T) {
 	}
 }
 
+func TestGenerateAndSaveJasperCredentials(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	checkCredentialsAreSet := func(t *testing.T, h *Host, creds *certdepot.Credentials) {
+		assert.NotZero(t, creds.CACert)
+		assert.NotZero(t, creds.Cert)
+		assert.NotZero(t, creds.Key)
+		assert.Equal(t, h.Id, h.JasperCredentialsID)
+		assert.Equal(t, h.JasperCredentialsID, creds.ServerName)
+	}
+	generateAndSaveCreds := func(ctx context.Context, t *testing.T, env *mock.Environment, h *Host) *certdepot.Credentials {
+		require.NoError(t, h.Insert())
+		creds, err := h.GenerateJasperCredentials(ctx, env)
+		require.NoError(t, err)
+		assert.NotZero(t, h.JasperCredentialsID)
+		checkCredentialsAreSet(t, h, creds)
+		require.NoError(t, h.SaveJasperCredentials(ctx, env, creds))
+		return creds
+	}
+	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, h *Host){
+		"FailsWithoutHostInDB": func(ctx context.Context, t *testing.T, env *mock.Environment, h *Host) {
+			creds, err := h.GenerateJasperCredentials(ctx, env)
+			assert.Error(t, err)
+			assert.Zero(t, creds)
+		},
+		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, h *Host) {
+			generateAndSaveCreds(ctx, t, env, h)
+			cert, err := certdepot.GetCertificate(env.CertificateDepot(), h.JasperCredentialsID)
+			require.NoError(t, err)
+			rawCert, err := cert.GetRawCertificate()
+			require.NoError(t, err)
+			assert.Equal(t, h.JasperCredentialsID, rawCert.Subject.CommonName)
+			assert.Equal(t, []string{h.JasperCredentialsID}, rawCert.DNSNames)
+		},
+		"SucceedsWithHostnameDifferentFromID": func(ctx context.Context, t *testing.T, env *mock.Environment, h *Host) {
+			h.Host = "127.0.0.1"
+			generateAndSaveCreds(ctx, t, env, h)
+			cert, err := certdepot.GetCertificate(env.CertificateDepot(), h.JasperCredentialsID)
+			require.NoError(t, err)
+			rawCert, err := cert.GetRawCertificate()
+			require.NoError(t, err)
+			assert.Equal(t, h.JasperCredentialsID, rawCert.Subject.CommonName)
+			assert.Equal(t, []string{h.JasperCredentialsID}, rawCert.DNSNames)
+			require.Len(t, rawCert.IPAddresses, 1)
+			assert.Equal(t, h.Host, rawCert.IPAddresses[0].String())
+		},
+		"SucceedsWithIDAsIPAddress": func(ctx context.Context, t *testing.T, env *mock.Environment, h *Host) {
+			h.Id = "127.0.0.1"
+			generateAndSaveCreds(ctx, t, env, h)
+			cert, err := certdepot.GetCertificate(env.CertificateDepot(), h.JasperCredentialsID)
+			require.NoError(t, err)
+			rawCert, err := cert.GetRawCertificate()
+			require.NoError(t, err)
+			assert.Equal(t, h.JasperCredentialsID, rawCert.Subject.CommonName)
+			assert.Equal(t, []string{h.JasperCredentialsID}, rawCert.DNSNames)
+			require.Len(t, rawCert.IPAddresses, 1)
+			assert.Equal(t, h.JasperCredentialsID, rawCert.IPAddresses[0].String())
+		},
+		"SucceedsWithIPAddress": func(ctx context.Context, t *testing.T, env *mock.Environment, h *Host) {
+			h.IP = "2600:1f18:ae9:dd00:d071:8752:6e2b:fc6a"
+			generateAndSaveCreds(ctx, t, env, h)
+			cert, err := certdepot.GetCertificate(env.CertificateDepot(), h.JasperCredentialsID)
+			require.NoError(t, err)
+			rawCert, err := cert.GetRawCertificate()
+			require.NoError(t, err)
+			assert.Equal(t, h.JasperCredentialsID, rawCert.Subject.CommonName)
+			assert.Equal(t, []string{h.JasperCredentialsID}, rawCert.DNSNames)
+			require.Len(t, rawCert.IPAddresses, 1)
+			assert.Equal(t, h.IP, rawCert.IPAddresses[0].String())
+		},
+		"SucceedsWithDuplicateIDAndHostname": func(ctx context.Context, t *testing.T, env *mock.Environment, h *Host) {
+			h.Id = "127.0.0.1"
+			h.Host = "127.0.0.1"
+			generateAndSaveCreds(ctx, t, env, h)
+			cert, err := certdepot.GetCertificate(env.CertificateDepot(), h.JasperCredentialsID)
+			require.NoError(t, err)
+			rawCert, err := cert.GetRawCertificate()
+			require.NoError(t, err)
+			assert.Equal(t, h.JasperCredentialsID, rawCert.Subject.CommonName)
+			assert.Equal(t, []string{h.JasperCredentialsID}, rawCert.DNSNames)
+			require.Len(t, rawCert.IPAddresses, 1)
+			assert.Equal(t, h.JasperCredentialsID, rawCert.IPAddresses[0].String())
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, 5*time.Second)
+			defer tcancel()
+			require.NoError(t, db.ClearCollections(evergreen.CredentialsCollection, Collection))
+			defer func() {
+				assert.NoError(t, db.ClearCollections(evergreen.CredentialsCollection, Collection))
+			}()
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(tctx))
+			testCase(tctx, t, env, &Host{Id: "id"})
+		})
+	}
+}
+
 func TestFindByExpiringJasperCredentials(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/vendor/github.com/evergreen-ci/certdepot/.golangci.yml
+++ b/vendor/github.com/evergreen-ci/certdepot/.golangci.yml
@@ -1,0 +1,14 @@
+---
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - goimports
+    - govet
+    - ineffassign
+    - misspell
+    - unconvert
+
+linters-settings:
+  govet:
+    check-shadowing: true

--- a/vendor/github.com/evergreen-ci/certdepot/LICENSE
+++ b/vendor/github.com/evergreen-ci/certdepot/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 MongoDB, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/evergreen-ci/certdepot/README.rst
+++ b/vendor/github.com/evergreen-ci/certdepot/README.rst
@@ -21,13 +21,13 @@ Certificate Creation and Signing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 SSL certificates and certificate authorities (CAs) can easily be created and
-signed using Certdepot. 
+signed using Certdepot.
 
 
 MongoDB Backed Depot
 ~~~~~~~~~~~~~~~~~~~~
 
-Certdepot implements a certstrap 
+Certdepot implements a certstrap
 `depot <https://godoc.org/github.com/square/certstrap/depot#Depot>`_ backed by
 MongoDB. This facilitates the storing and fetching of SSL certificates to and
 from a Mongo database. There are various functions for maintaining the depot,
@@ -74,7 +74,7 @@ with that CA in the depot: ::
 	// stores it in the depot
 	certOpts.CreateCertificate(d)
 
-The following does the same as above, but now using the bootstrap 
+The following does the same as above, but now using the bootstrap
 functionality: ::
 	bootstrapConf := certdepot.BootstrapDepotConfig{
                 MongoDepot:  mongoOpts,
@@ -119,7 +119,7 @@ project.
 Documentation
 -------------
 
-See the 
+See the
 `certdepot godoc <https://godoc.org/github.com/evergreen-ci/certdepot>`_ for
 complete documentation of certdepot.
 

--- a/vendor/github.com/evergreen-ci/certdepot/cmd/run-linter/run-linter.go
+++ b/vendor/github.com/evergreen-ci/certdepot/cmd/run-linter/run-linter.go
@@ -7,9 +7,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
+
+	"github.com/mongodb/grip"
 )
 
 type result struct {
@@ -28,7 +29,6 @@ func (r *result) String() string {
 	if r.passed {
 		fmt.Fprintf(buf, "--- PASS: %s (%s)", r.name, r.duration)
 	} else {
-		// fmt.Fprintln(buf, "    CMD:", r.cmd)
 		fmt.Fprintf(buf, strings.Join(r.output, "\n"))
 		fmt.Fprintf(buf, "--- FAIL: %s (%s)", r.name, r.duration)
 	}
@@ -47,50 +47,70 @@ func (r *result) fixup(dirname string) {
 	}
 }
 
-// runs the gometalinter on a list of packages; integrating with the "make lint" target.
+// runs the golangci-lint on a list of packages; integrating with the "make lint" target.
 func main() {
 	var (
-		lintArgs       string
-		lintBin        string
-		packageList    string
-		output         string
-		packages       []string
-		results        []*result
-		hasFailingTest bool
+		lintArgs          string
+		lintBin           string
+		customLintersFlag string
+		customLinters     []string
+		packageList       string
+		output            string
+		packages          []string
+		results           []*result
+		hasFailingTest    bool
 
 		gopath = os.Getenv("GOPATH")
 	)
 
-	flag.StringVar(&lintArgs, "lintArgs", "", "args to pass to gometalinter")
-	flag.StringVar(&lintBin, "lintBin", filepath.Join(gopath, "bin", "gometalinter"), "path to go metalinter")
+	gopath, _ = filepath.Abs(gopath)
+
+	flag.StringVar(&lintArgs, "lintArgs", "", "args to pass to golangci-lint")
+	flag.StringVar(&lintBin, "lintBin", filepath.Join(gopath, "bin", "golangci-lint"), "path to golangci-lint")
 	flag.StringVar(&packageList, "packages", "", "list of space separated packages")
+	flag.StringVar(&customLintersFlag, "customLinters", "", "list of comma-separated custom linter commands")
 	flag.StringVar(&output, "output", "", "output file for to write results.")
 	flag.Parse()
 
+	if len(customLintersFlag) != 0 {
+		customLinters = strings.Split(customLintersFlag, ",")
+	}
 	packages = strings.Split(strings.Replace(packageList, "-", "/", -1), " ")
 	dirname, _ := os.Getwd()
 	cwd := filepath.Base(dirname)
-	gopath, _ = filepath.Abs(gopath)
-	lintArgs += fmt.Sprintf(" --concurrency=%d", runtime.NumCPU()/2)
 
 	for _, pkg := range packages {
-		args := []string{lintBin, lintArgs}
-		if cwd == pkg {
-			args = append(args, ".")
-		} else {
-			args = append(args, "./"+pkg)
+		pkgDir := "./"
+		if cwd != pkg {
+			pkgDir += pkg
 		}
+		splitLintArgs := strings.Split(lintArgs, " ")
+		args := []string{lintBin, "run"}
+		args = append(args, splitLintArgs...)
+		args = append(args, pkgDir)
 
 		startAt := time.Now()
-		cmd := strings.Join(args, " ")
-		out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
-
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dirname
+		out, err := cmd.CombinedOutput()
 		r := &result{
 			cmd:      strings.Join(args, " "),
 			name:     "lint-" + strings.Replace(pkg, "/", "-", -1),
 			passed:   err == nil,
 			duration: time.Since(startAt),
 			output:   strings.Split(string(out), "\n"),
+		}
+
+		for _, linter := range customLinters {
+			customLinterStart := time.Now()
+			linterArgs := (strings.Split(linter, " "))
+			linterArgs = append(linterArgs, pkgDir)
+			cmd := exec.Command(linterArgs[0], linterArgs[1:]...)
+			cmd.Dir = dirname
+			out, err := cmd.CombinedOutput()
+			r.passed = r.passed && err == nil
+			r.duration += time.Since(customLinterStart)
+			r.output = append(r.output, strings.Split(string(out), "\n")...)
 		}
 		r.fixup(dirname)
 
@@ -114,7 +134,10 @@ func main() {
 		}()
 
 		for _, r := range results {
-			f.WriteString(r.String() + "\n")
+			if _, err = f.WriteString(r.String() + "\n"); err != nil {
+				grip.Error(err)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/vendor/github.com/evergreen-ci/certdepot/db_test.go
+++ b/vendor/github.com/evergreen-ci/certdepot/db_test.go
@@ -74,7 +74,9 @@ func TestDB(t *testing.T) {
 
 					d, err := BootstrapDepot(ctx, conf)
 					require.NoError(t, err)
-					defer client.Database(databaseName).Drop(ctx)
+					defer func() {
+						assert.NoError(t, client.Database(databaseName).Drop(ctx))
+					}()
 
 					md, ok := d.(*mongoDepot)
 					require.True(t, ok)

--- a/vendor/github.com/evergreen-ci/certdepot/evergreen.yaml
+++ b/vendor/github.com/evergreen-ci/certdepot/evergreen.yaml
@@ -41,11 +41,9 @@ functions:
     params:
       working_dir: gopath/src/github.com/evergreen-ci/certdepot
       binary: make
-      args: ["${make_args|}", "${target}"]
+      args: ["${target}"]
+      add_expansions_to_env: true
       env:
-        GO_BIN_PATH: ${gobin}
-        DISABLE_COVERAGE: ${disable_coverage}
-        GOROOT: ${goroot}
         GOPATH: ${workdir}/gopath
   set-up-mongodb:
     - command: subprocess.exec
@@ -77,9 +75,6 @@ post:
     params:
       files:
         - "gopath/src/github.com/evergreen-ci/certdepot/build/output.*"
-        - "gopath/src/github.com/evergreen-ci/certdepot/build/test.out"
-        - "gopath/src/github.com/evergreen-ci/certdepot/build/race.out"
-        - "gopath/src/github.com/evergreen-ci/certdepot/build/cover*"
   - command: subprocess.exec
     type: setup
     params:
@@ -89,7 +84,7 @@ post:
     params:
       aws_key: ${aws_key}
       aws_secret: ${aws_secret}
-      local_files_include_filter: ["gopath/src/github.com/evergreen-ci/certdepot/build/cover.html"]
+      local_files_include_filter: ["gopath/src/github.com/evergreen-ci/certdepot/build/output.*.coverage.html"]
       remote_file: certdepot/${task_id}/
       bucket: mciuploads
       content_type: text/html
@@ -100,7 +95,7 @@ post:
     params:
       aws_key: ${aws_key}
       aws_secret: ${aws_secret}
-      local_files_include_filter: ["gopath/src/github.com/evergreen-ci/certdepot/build/cover.out"]
+      local_files_include_filter: ["gopath/src/github.com/evergreen-ci/certdepot/build/output.*.coverage"]
       remote_file: certdepot/${task_id}/
       bucket: mciuploads
       content_type: text/plain
@@ -129,16 +124,11 @@ tasks:
           directory: gopath/src/github.com/evergreen-ci/certdepot
       - func: set-up-mongodb
       - func: run-make
-        vars:
-          target: "coverage-html"
+        vars: { target: "coverage-html" }
 
   - <<: *run-build-with-mongodb
     tags: ["test"]
     name: test
-
-  - <<: *run-build-with-mongodb
-    tags: ["race"]
-    name: race
 
 #######################################
 #           Buildvariants             #
@@ -147,20 +137,36 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector (Arch Linux)
     expansions:
+      DISABLE_COVERAGE: true
+      GO_BIN_PATH: /opt/golang/go1.13/bin/go
+      GOROOT: /opt/golang/go1.13
+      RACE_DETECTOR: true
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
       - archlinux-test
     tasks:
-      - name: ".race"
+      - name: ".test"
+
+  - name: lint
+    display_name: Lint (Arch Linux)
+    expansions:
+      DISABLE_COVERAGE: true
+      GO_BIN_PATH: /opt/golang/go1.13/bin/go
+      GOROOT: /opt/golang/go1.13
+      mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
+    run_on:
+      - archlinux-test
+      - archlinux-build
+    tasks:
       - name: ".report"
 
   - name: ubuntu1604
     display_name: Ubuntu 16.04
     expansions:
+      DISABLE_COVERAGE: true
+      GO_BIN_PATH: /opt/golang/go1.9/bin/go
+      GOROOT: /opt/golang/go1.9
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
-      goroot: /opt/golang/go1.9
-      gobin: /opt/golang/go1.9/bin/go
-      disable_coverage: true
     run_on:
       - ubuntu1604-test
     tasks:
@@ -169,10 +175,10 @@ buildvariants:
   - name: macos
     display_name: macOS 10.14
     expansions:
+      DISABLE_COVERAGE: true
+      GO_BIN_PATH: /opt/golang/go1.13/bin/go
+      GOROOT: /opt/golang/go1.13
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.1.tgz
-      goroot: /opt/golang/go1.9
-      gobin: /opt/golang/go1.9/bin/go
-      disable_coverage: true
     run_on:
       - macos-1014
     tasks:
@@ -183,10 +189,10 @@ buildvariants:
     run_on:
       - windows-64-vs2015-small
     expansions:
+      DISABLE_COVERAGE: true
+      GO_BIN_PATH: /cygdrive/c/golang/go1.13/bin/go
+      GOROOT: c:/golang/go1.13
       mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.1.zip
-      goroot: c:/golang/go1.9
-      gobin: /cygdrive/c/golang/go1.9/bin/go
-      disable_coverage: true
       extension: ".exe"
       archiveExt: ".zip"
     tasks:

--- a/vendor/github.com/evergreen-ci/certdepot/file.go
+++ b/vendor/github.com/evergreen-ci/certdepot/file.go
@@ -40,5 +40,9 @@ func MakeFileDepot(dir string, opts DepotOptions) (Depot, error) {
 func (fd *fileDepot) Save(name string, creds *Credentials) error { return depotSave(fd, name, creds) }
 func (fd *fileDepot) Find(name string) (*Credentials, error)     { return depotFind(fd, name, fd.opts) }
 func (fd *fileDepot) Generate(name string) (*Credentials, error) {
-	return depotGenerate(fd, name, fd.opts)
+	return depotGenerateDefault(fd, name, fd.opts)
+}
+
+func (fd *fileDepot) GenerateWithOptions(opts CertificateOptions) (*Credentials, error) {
+	return depotGenerate(fd, opts.CommonName, fd.opts, opts)
 }

--- a/vendor/github.com/evergreen-ci/certdepot/glide.lock
+++ b/vendor/github.com/evergreen-ci/certdepot/glide.lock
@@ -7,7 +7,7 @@ imports:
 - name: github.com/mongodb/anser
   version: 1fb43a6d9968b19ddfd66e6a77373f9e4c54adeb
 - name: github.com/mongodb/grip
-  version: 8b8accd7a3ec9b31a2d3eea610d5bf906bddfd11
+  version: e78519fadff49ae1fd719a10d124755089615238
 - name: go.mongodb.org/mongo-driver
   version: 305bc4a5e4131420fe8ba5628e6faa9e6ade4e86
 - name: gopkg.in/mgo.v2

--- a/vendor/github.com/evergreen-ci/certdepot/interface.go
+++ b/vendor/github.com/evergreen-ci/certdepot/interface.go
@@ -13,6 +13,7 @@ type Depot interface {
 	Save(string, *Credentials) error
 	Find(string) (*Credentials, error)
 	Generate(string) (*Credentials, error)
+	GenerateWithOptions(CertificateOptions) (*Credentials, error)
 }
 
 // DepotOptions capture default options used during certificate

--- a/vendor/github.com/evergreen-ci/certdepot/makefile
+++ b/vendor/github.com/evergreen-ci/certdepot/makefile
@@ -1,137 +1,109 @@
 buildDir := build
-srcFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "*\#*")
-testFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
+name := certdepot
+packages := $(name)
+projectPath := github.com/evergreen-ci/certdepot
 
-packages := certdepot
-#
-# override the go binary path if set
-ifneq (,$(GO_BIN_PATH))
+# start environment setup
 gobin := $(GO_BIN_PATH)
-else
+ifeq ($(gobin),)
 gobin := go
 endif
-
-
-# start linting configuration
-#   package, testing, and linter dependencies specified
-#   separately. This is a temporary solution: eventually we should
-#   vendorize all of these dependencies.
-lintDeps := github.com/alecthomas/gometalinter
-#   include test files and give linters 40s to run to avoid timeouts
-lintArgs := --tests --deadline=13m --vendor
-#   gotype produces false positives because it reads .a files which
-#   are rarely up to date.
-lintArgs += --disable="gotype" --disable="gosec" --disable="gocyclo" --enable="golint"
-lintArgs += --skip="build"
-#   enable and configure additional linters
-lintArgs += --line-length=100 --dupl-threshold=150
-#   some test cases are structurally similar, and lead to dupl linter
-#   warnings, but are important to maintain separately, and would be
-#   difficult to test without a much more complex reflection/code
-#   generation approach, so we ignore dupl errors in tests.
-lintArgs += --exclude="warning: duplicate of .*_test.go"
-#   go lint warns on an error in docstring format, erroneously because
-#   it doesn't consider the entire package.
-lintArgs += --exclude="warning: package comment should be of the form \"Package .* ...\""
-#   known issues that the linter picks up that are not relevant in our cases
-lintArgs += --exclude="file is not goimported" # top-level mains aren't imported
-lintArgs += --exclude="error return value not checked .defer.*"
-# end linting configuration
-
-
-# start dependency installation tools
-#   implementation details for being able to lazily install dependencies
 gopath := $(GOPATH)
+gocache := $(abspath $(buildDir)/.cache)
+goroot := $(GOROOT)
 ifeq ($(OS),Windows_NT)
+gocache := $(shell cygpath -m $(gocache))
 gopath := $(shell cygpath -m $(gopath))
+goroot := $(shell cygpath -m $(goroot))
 endif
-lintDeps := $(addprefix $(gopath)/src/,$(lintDeps))
-$(gopath)/src/%:
-	@-[ ! -d $(gopath) ] && mkdir -p $(gopath) || true
-	$(gobin) get $(subst $(gopath)/src/,,$@)
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
-	 $(gobin) build -o $@ $<
-$(buildDir)/.lintSetup:$(lintDeps)
-	@-$(gopath)/bin/gometalinter --install >/dev/null && touch $@
-# end dependency installation tools
+
+export GOPATH := $(gopath)
+export GOCACHE := $(gocache)
+export GOROOT := $(goroot)
+# end environment setup
+
+
+# Ensure the build directory exists, since most targets require it.
+$(shell mkdir -p $(buildDir))
+
+
+# start lint setup targets
+lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
+$(buildDir)/golangci-lint:
+	@curl  --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.30.0 >/dev/null 2>&1
+$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
+	@$(gobin) build -o $@ $<
+# end lint setup targets
+
+
+testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
+lintOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
+coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
+coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
 
 
 testArgs := -v
-ifneq (,$(RUN_TEST))
-testArgs += -run='$(RUN_TEST)'
-endif
-ifneq (,$(RUN_COUNT))
-testArgs += -count='$(RUN_COUNT)'
-endif
-ifneq (,$(SKIP_LONG))
-testArgs += -short
-endif
-ifneq (,$(DISABLE_COVERAGE))
+ifeq (,$(DISABLE_COVERAGE))
 testArgs += -cover
 endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif
+ifneq (,$(RUN_COUNT))
+testArgs += -count='$(RUN_COUNT)'
+endif
+ifneq (,$(RUN_TEST))
+testArgs += -run='$(RUN_TEST)'
+endif
+ifneq (,$(SKIP_LONG))
+testArgs += -short
+endif
 # test execution and output handlers
-$(buildDir)/:
-	mkdir -p $@
-$(buildDir)/output.%.test:$(buildDir)/ .FORCE
-	GOPATH=$(gopath) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$*,) | tee $@
+compile $(buildDir):
+	$(gobin) build ./
+$(buildDir)/output.%.test:.FORCE
+	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$*,) | tee $@
 	@! grep -s -q -e "^FAIL" $@ && ! grep -s -q "^WARNING: DATA RACE" $@
-$(buildDir)/output.test:$(buildDir)/ .FORCE
-	GOPATH=$(gopath) $(gobin) test $(testArgs) ./... | tee $@
-	@! grep -s -q -e "^FAIL" $@ && ! grep -s -q "^WARNING: DATA RACE" $@
-$(buildDir)/output.%.coverage:$(buildDir)/ .FORCE
-	GOPATH=$(gopath) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$*,) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
+$(buildDir)/output.%.coverage:.FORCE
+	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$*,) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
-	GOPATH=$(gopath) $(gobin) tool cover -html=$< -o $@
+	$(gobin) tool cover -html=$< -o $@
 #  targets to generate gotest output from the linter.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter $(buildDir)/ .FORCE
-	@./$< --output=$@ --lintArgs='$(lintArgs)' --packages='$*'
-$(buildDir)/output.lint:$(buildDir)/run-linter $(buildDir)/ .FORCE
-	@./$< --output="$@" --lintArgs='$(lintArgs)' --packages="$(packages)"
+# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
+$(buildDir)/output.%.lint:$(buildDir)/run-linter .FORCE
+	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 #  targets to process and generate coverage reports
 # end test and coverage artifacts
 
 
 # userfacing targets for basic build and development operations
-compile:
-	GOPATH=$(gopath) $(gobin) build ./
-test:$(buildDir)/test.out
-$(buildDir)/test.out:.FORCE
-	@mkdir -p $(buildDir)
-	GOPATH=$(gopath) $(gobin) test $(testArgs) ./ | tee $@
-	@grep -s -q -e "^PASS" $@
-coverage:$(buildDir)/cover.out
-	GOPATH=$(gopath) @$(gobin) tool cover -func=$< | sed -E 's%github.com/.*/ftdc/%%' | column -t
-coverage-html:$(buildDir)/cover.html
+test:$(testOutput)
+coverage:$(coverageOutput)
 
+coverage-html:$(coverageHtmlOutput)
 benchmark:
 	$(gobin) test -v -benchmem -bench=. -run="Benchmark.*" -timeout=20m
-lint:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
+lint:$(lintOutput)
 
-phony += lint lint-deps build build-race race test coverage coverage-html
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
-.PRECIOUS:$(buildDir)/output.lint
+phony += lint $(buildDir) test coverage coverage-html
+.PRECIOUS:$(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
 # end front-ends
 
 
-$(buildDir):$(srcFiles) compile
-	@mkdir -p $@
-$(buildDir)/cover.out:$(buildDir) $(testFiles) .FORCE
-	$(gobin) test $(testArgs) -covermode=count -coverprofile $@ -cover ./
-$(buildDir)/cover.html:$(buildDir)/cover.out
-	$(gobin) tool cover -html=$< -o $@
-
-
 vendor-clean:
-	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*testdata*" | xargs rm -rf
 	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/stretchr/testify/
 	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/pkg/errors/
 	rm -rf vendor/go.mongodb.org/mongo-driver/vendor/github.com/stretchr/testify/
 	rm -rf vendor/go.mongodb.org/mongo-driver/vendor/github.com/pkg/errors/
+	find vendor/ -type d -empty | xargs rm -rf
+	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*testdata*" | xargs rm -rf
 phony += vendor-clean
+clean:
+	rm -rf $(lintDeps)
+clean-results:
+	rm -rf $(buildDir)/output.*
+phony += clean
 
 # mongodb utility targets
 mongodb/.get-mongodb:

--- a/vendor/github.com/evergreen-ci/certdepot/mgo_depot.go
+++ b/vendor/github.com/evergreen-ci/certdepot/mgo_depot.go
@@ -165,7 +165,11 @@ func (m *mgoCertDepot) Delete(tag *depot.Tag) error {
 func (m *mgoCertDepot) Save(name string, creds *Credentials) error { return depotSave(m, name, creds) }
 func (m *mgoCertDepot) Find(name string) (*Credentials, error)     { return depotFind(m, name, m.opts) }
 func (m *mgoCertDepot) Generate(name string) (*Credentials, error) {
-	return depotGenerate(m, name, m.opts)
+	return depotGenerateDefault(m, name, m.opts)
+}
+
+func (m *mgoCertDepot) GenerateWithOptions(opts CertificateOptions) (*Credentials, error) {
+	return depotGenerate(m, opts.CommonName, m.opts, opts)
 }
 
 func errNotNotFound(err error) bool {

--- a/vendor/github.com/evergreen-ci/certdepot/mongodb_depot.go
+++ b/vendor/github.com/evergreen-ci/certdepot/mongodb_depot.go
@@ -176,7 +176,11 @@ func (m *mongoDepot) Delete(tag *depot.Tag) error {
 func (m *mongoDepot) Save(name string, creds *Credentials) error { return depotSave(m, name, creds) }
 func (m *mongoDepot) Find(name string) (*Credentials, error)     { return depotFind(m, name, m.opts) }
 func (m *mongoDepot) Generate(name string) (*Credentials, error) {
-	return depotGenerate(m, name, m.opts)
+	return depotGenerateDefault(m, name, m.opts)
+}
+
+func (m *mongoDepot) GenerateWithOptions(opts CertificateOptions) (*Credentials, error) {
+	return depotGenerate(m, opts.CommonName, m.opts, opts)
 }
 
 func errNotNoDocuments(err error) bool {

--- a/vendor/github.com/evergreen-ci/certdepot/mongodb_options.go
+++ b/vendor/github.com/evergreen-ci/certdepot/mongodb_options.go
@@ -25,7 +25,7 @@ var (
 	userTTLKey           = bsonutil.MustHaveTag(User{}, "TTL")
 )
 
-// MongoDBOptions conatins options for NewMongoDBCertDepot,
+// MongoDBOptions contains options for NewMongoDBCertDepot,
 // NewMongoDBCertDepotWithClient, NewMgoCertDepot, and
 // NewMgoCertDepotWithSession.
 type MongoDBOptions struct {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13931

Static hosts typically have a hostname as their host ID. The host ID is used the server name and common name on the Jasper gRPC certificates, which is fine when the host ID is a hostname. However, some static hosts might only have an IP address and not a hostname. The gRPC client doesn't seem to be able to connect when the common name is an IP address. This change adds the IP address and hostnames as subject alternative names (SANs) in Jasper certificates, so those will also be valid server names when connecting to Jasper's gRPC service using TLS credentials. It should be backwards compatible since we're just adding SANs to new host certificates.

* Revendor certdepot.
* Include IP addresses and domains in Jasper certificates.