### PR TITLE
EVG-13724 log host.create errors in host.list

### DIFF
--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -110,7 +110,7 @@ type Communicator interface {
 
 	// Spawn-hosts for tasks methods
 	CreateHost(context.Context, TaskData, apimodels.CreateHost) ([]string, error)
-	ListHosts(context.Context, TaskData) ([]restmodel.CreateHost, error)
+	ListHosts(context.Context, TaskData) (restmodel.HostListResults, error)
 
 	// GetDockerLogs returns logs for the given docker container
 	GetDockerLogs(ctx context.Context, hostID string, startTime time.Time, endTime time.Time, isError bool) ([]byte, error)

--- a/agent/internal/client/methods.go
+++ b/agent/internal/client/methods.go
@@ -761,7 +761,7 @@ func (c *communicatorImpl) CreateHost(ctx context.Context, td TaskData, options 
 	return ids, nil
 }
 
-func (c *communicatorImpl) ListHosts(ctx context.Context, td TaskData) ([]restmodel.CreateHost, error) {
+func (c *communicatorImpl) ListHosts(ctx context.Context, td TaskData) (restmodel.HostListResults, error) {
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &td,
@@ -769,17 +769,17 @@ func (c *communicatorImpl) ListHosts(ctx context.Context, td TaskData) ([]restmo
 		path:     fmt.Sprintf("hosts/%s/list", td.ID),
 	}
 
+	result := restmodel.HostListResults{}
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {
-		return nil, utility.RespErrorf(resp, "failed to list hosts for task %s: %s", td.ID, err.Error())
+		return result, utility.RespErrorf(resp, "failed to list hosts for task %s: %s", td.ID, err.Error())
 	}
 	defer resp.Body.Close()
 
-	hosts := []restmodel.CreateHost{}
-	if err := utility.ReadJSON(resp.Body, &hosts); err != nil {
-		return nil, errors.Wrapf(err, "problem reading hosts from response body for '%s'", td.ID)
+	if err := utility.ReadJSON(resp.Body, &result); err != nil {
+		return result, errors.Wrapf(err, "problem reading hosts from response body for '%s'", td.ID)
 	}
-	return hosts, nil
+	return result, nil
 }
 
 func (c *communicatorImpl) GetDistroByName(ctx context.Context, id string) (*restmodel.APIDistro, error) {

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -467,7 +467,9 @@ func (c *Mock) CreateHost(ctx context.Context, td TaskData, options apimodels.Cr
 	return []string{"id"}, options.Validate()
 }
 
-func (c *Mock) ListHosts(_ context.Context, _ TaskData) ([]model.CreateHost, error) { return nil, nil }
+func (c *Mock) ListHosts(_ context.Context, _ TaskData) (model.HostListResults, error) {
+	return model.HostListResults{}, nil
+}
 
 func (c *Mock) GetDockerLogs(context.Context, string, time.Time, time.Time, bool) ([]byte, error) {
 	return []byte("this is a log"), nil

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2021-02-01"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2020-12-18"
+	AgentVersion = "2021-02-03"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -10,8 +10,6 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -1288,11 +1286,6 @@ func AbortTasksForVersion(versionId string, taskIds []string, caller string) err
 
 func AddHostCreateDetails(taskId, hostId string, hostCreateError error) error {
 	if hostCreateError == nil {
-		grip.Warning(message.Fields{
-			"message": "no error to logs",
-			"task_id": taskId,
-			"host_id": hostId,
-		})
 		return nil
 	}
 	err := UpdateOne(

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -137,6 +137,9 @@ type Task struct {
 	Details   apimodels.TaskEndDetail `bson:"details" json:"task_end_details"`
 	Aborted   bool                    `bson:"abort,omitempty" json:"abort"`
 	AbortInfo AbortInfo               `bson:"abort_info,omitempty" json:"abort_info,omitempty"`
+
+	// HostCreateDetails stores information about why host.create failed for this task
+	HostCreateDetails []HostCreateDetail `bson:"host_create_details,omitempty" json:"host_create_details,omitempty"`
 	// DisplayStatus is not persisted to the db. It is the status to display in the UI.
 	// It may be added via aggregation
 	DisplayStatus string `bson:"display_status,omitempty" json:"display_status,omitempty"`
@@ -247,6 +250,11 @@ type DistroCost struct {
 type BaseTaskInfo struct {
 	Id     string `bson:"_id" json:"id"`
 	Status string `bson:"status" json:"status"`
+}
+
+type HostCreateDetail struct {
+	HostId string `bson:"host_id" json:"host_id"`
+	Error  string `bson:"error" json:"error"`
 }
 
 func (d *Dependency) UnmarshalBSON(in []byte) error {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1669,6 +1669,25 @@ func TestGetTimeSpent(t *testing.T) {
 	assert.EqualValues(0, makespan)
 }
 
+func TestAddHostCreateDetails(t *testing.T) {
+	task := Task{Id: "t1"}
+	assert.NoError(t, task.Insert())
+	errToSave := errors.Wrapf(errors.New("InsufficientCapacityError"), "error trying to start host")
+	assert.NoError(t, AddHostCreateDetails(task.Id, "h1", errToSave))
+	dbTask, err := FindOneId(task.Id)
+	assert.NoError(t, err)
+	assert.NotNil(t, dbTask)
+	require.Len(t, dbTask.HostCreateDetails, 1)
+	assert.Equal(t, dbTask.HostCreateDetails[0].HostId, "h1")
+	assert.Contains(t, dbTask.HostCreateDetails[0].Error, "InsufficientCapacityError")
+
+	assert.NoError(t, AddHostCreateDetails(task.Id, "h2", errToSave))
+	dbTask, err = FindOneId(task.Id)
+	assert.NoError(t, err)
+	assert.NotNil(t, dbTask)
+	assert.Len(t, dbTask.HostCreateDetails, 2)
+}
+
 func TestUpdateDependsOn(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	t1 := &Task{Id: "t1"}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1670,6 +1670,7 @@ func TestGetTimeSpent(t *testing.T) {
 }
 
 func TestAddHostCreateDetails(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
 	task := Task{Id: "t1"}
 	assert.NoError(t, task.Insert())
 	errToSave := errors.Wrapf(errors.New("InsufficientCapacityError"), "error trying to start host")

--- a/rest/model/listhost.go
+++ b/rest/model/listhost.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/pkg/errors"
+)
+
+type HostListResults struct {
+	Hosts   []CreateHost
+	Details []APIHostCreateDetail
+}
+
+type APIHostCreateDetail struct {
+	HostId *string `bson:"host_id" json:"host_id"`
+	Error  *string `bson:"error" json:"error"`
+}
+
+func (a *APIHostCreateDetail) BuildFromService(t interface{}) error {
+	switch v := t.(type) {
+	case task.HostCreateDetail:
+		a.HostId = ToStringPtr(v.HostId)
+		a.Error = ToStringPtr(v.Error)
+	default:
+		return errors.New("Incorrect type when unmarshalling HostCreateDetail")
+	}
+	return nil
+}
+
+func (a *APIHostCreateDetail) ToService() (interface{}, error) {
+	return nil, errors.New("ToService() is not implemented for APIHostCreateDetail")
+}

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
@@ -434,6 +435,12 @@ func (j *createHostJob) tryRequeue(ctx context.Context) {
 		j.AddError(err)
 	} else if j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding {
 		event.LogHostStartFinished(j.host.Id, false)
+		if j.host.SpawnOptions.SpawnedByTask {
+			if err := task.AddHostCreateDetails(j.host.StartedBy, j.host.Id, j.Error()); err != nil {
+				j.AddError(errors.Wrapf(err, "error adding host create error details"))
+			}
+		}
+
 	}
 }
 


### PR DESCRIPTION
I decided to store "host_id" with the error, since that might help us investigate issues that aren't AWS capacity, and also because there might be multiple hosts. 
https://evergreen-staging.corp.mongodb.com/task_log_raw/mci_ubuntu1604_test_cloud_patch_d04dfaa265a05c6e26d704930ca54b63e2f15c36_6019b0cf97b1d3353309a45b_21_02_02_20_06_49/2?type=T#L257