### PR TITLE
EVG-13690: add environment variables to shell.exec

### DIFF
--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -292,11 +292,15 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 		logger.Execution().Notice(err.Error())
 	}
 
+	var exp util.Expansions
+	if err != nil {
+		exp = *conf.Expansions
+	}
 	c.Env = defaultAndApplyExpansionsToEnv(c.Env, modifyEnvOptions{
 		taskID:                 conf.Task.Id,
 		workingDir:             c.WorkingDir,
 		tmpDir:                 taskTmpDir,
-		expansions:             *conf.Expansions,
+		expansions:             exp,
 		includeExpansionsInEnv: c.IncludeExpansionsInEnv,
 		addExpansionsToEnv:     c.AddExpansionsToEnv,
 	})

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -198,17 +198,6 @@ func defaultAndApplyExpansionsToEnv(env map[string]string, opts modifyEnvOptions
 }
 
 func (c *subprocessExec) getProc(ctx context.Context, taskID string, logger client.LoggerProducer) *jasper.Command {
-	// c.Env[agentutil.MarkerTaskID] = taskID
-	// c.Env[agentutil.MarkerAgentPID] = strconv.Itoa(os.Getpid())
-	//
-	// if _, alreadyDefined := c.Env["GOCACHE"]; !alreadyDefined {
-	//     c.Env["GOCACHE"] = filepath.Join(c.WorkingDir, ".gocache")
-	// }
-	//
-	// if _, alreadyDefined := c.Env["CI"]; !alreadyDefined {
-	//     c.Env["CI"] = "true"
-	// }
-
 	cmd := c.JasperManager().CreateCommand(ctx).Add(append([]string{c.Binary}, c.Args...)).
 		Background(c.Background).Environment(c.Env).Directory(c.WorkingDir).
 		SuppressStandardError(c.IgnoreStandardError).SuppressStandardOutput(c.IgnoreStandardOutput).RedirectErrorToOutput(c.RedirectStandardErrorToOutput).

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -152,21 +152,6 @@ func (c *subprocessExec) doExpansions(exp *util.Expansions) error {
 		c.Env["PATH"] = strings.Join(path, string(filepath.ListSeparator))
 	}
 
-	// kim: TODO: remove
-	// expansions := exp.Map()
-	// if c.AddExpansionsToEnv {
-	//     for k, v := range expansions {
-	//         c.Env[k] = v
-	//     }
-	// }
-
-	// kim: TODO: remove
-	// for _, ei := range c.IncludeExpansionsInEnv {
-	//     if val, ok := expansions[ei]; ok {
-	//         c.Env[ei] = val
-	//     }
-	// }
-
 	return errors.Wrap(catcher.Resolve(), "problem expanding strings")
 }
 
@@ -184,8 +169,6 @@ func defaultAndApplyExpansionsToEnv(env map[string]string, opts modifyEnvOptions
 		env = map[string]string{}
 	}
 
-	// kim: NOTE: this is different from the original behavior because the agent
-	// env vars will always overwrite even if conflicting expansions exist.
 	expansions := opts.expansions.Map()
 	if opts.addExpansionsToEnv {
 		for k, v := range expansions {
@@ -320,8 +303,6 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 		logger.Execution().Notice(err.Error())
 	}
 
-	// kim: TODO: remove
-	// addTempDirs(c.Env, taskTmpDir)
 	c.Env = defaultAndApplyExpansionsToEnv(c.Env, modifyEnvOptions{
 		taskID:                 conf.Task.Id,
 		workingDir:             c.WorkingDir,

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -164,19 +167,6 @@ func (s *execCmdSuite) TestInvalidToSpecifyCommandInMultipleWays() {
 		},
 	}
 	s.Error(cmd.ParseParams(map[string]interface{}{}))
-}
-
-func (s *execCmdSuite) TestGetProcEnvSetting() {
-	cmd := &subprocessExec{
-		Binary:    "bash",
-		SystemLog: true,
-	}
-	cmd.SetJasperManager(s.jasper)
-
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
-	exec := cmd.getProc(s.ctx, "foo", s.logger)
-	s.Len(cmd.Env, 4)
-	s.NotNil(exec)
 }
 
 func (s *execCmdSuite) TestRunCommand() {
@@ -357,36 +347,6 @@ func (s *execCmdSuite) TestExpansionsEnvOptionDisabled() {
 	s.Equal("one", cmd.Env["one"])
 }
 
-func (s *execCmdSuite) TestExpansionsEnvOptionEnabled() {
-	cmd := &subprocessExec{
-		Env:                map[string]string{},
-		WorkingDir:         testutil.GetDirectoryOfFile(),
-		AddExpansionsToEnv: true,
-	}
-
-	s.NoError(cmd.doExpansions(util.NewExpansions(map[string]string{})))
-	s.Len(cmd.Env, 0)
-	cmd.Env["one"] = "one"
-	s.Equal("one", cmd.Env["one"])
-	s.NoError(cmd.doExpansions(util.NewExpansions(map[string]string{"two": "two", "one": "1"})))
-	s.Len(cmd.Env, 2)
-	s.Equal("two", cmd.Env["two"])
-	s.Equal("1", cmd.Env["one"])
-}
-
-func (s *execCmdSuite) TestIncludeExpansionsInEnv() {
-	cmd := &subprocessExec{
-		Env:                    map[string]string{},
-		WorkingDir:             testutil.GetDirectoryOfFile(),
-		IncludeExpansionsInEnv: []string{"foo", "bar"},
-	}
-
-	s.NoError(cmd.doExpansions(util.NewExpansions(map[string]string{})))
-	s.Len(cmd.Env, 0)
-	s.NoError(cmd.doExpansions(util.NewExpansions(map[string]string{"foo": "one", "bar": "two", "baz": "three"})))
-	s.Len(cmd.Env, 2)
-}
-
 func TestAddTemp(t *testing.T) {
 	for name, test := range map[string]func(*testing.T, map[string]string){
 		"Empty": func(t *testing.T, env map[string]string) {
@@ -408,8 +368,8 @@ func TestAddTemp(t *testing.T) {
 		"CorrectKeys": func(t *testing.T, env map[string]string) {
 			addTempDirs(env, "bar")
 			assert.Len(t, env, 3)
-			assert.Equal(t, "bar", env["TMP"])
 			assert.Equal(t, "bar", env["TEMP"])
+			assert.Equal(t, "bar", env["TMP"])
 			assert.Equal(t, "bar", env["TMPDIR"])
 		},
 	} {
@@ -417,6 +377,182 @@ func TestAddTemp(t *testing.T) {
 			env := make(map[string]string)
 			require.Len(t, env, 0)
 			test(t, env)
+		})
+	}
+}
+
+func TestDefaultAndApplyExpansionsToEnv(t *testing.T) {
+	for testName, testCase := range map[string]func(t *testing.T, exp util.Expansions){
+		"SetsDefaultAndRequiredEnvWhenStandardValuesAreGiven": func(t *testing.T, exp util.Expansions) {
+			opts := modifyEnvOptions{
+				taskID:     "task_id",
+				workingDir: "working_dir",
+				tmpDir:     "tmp_dir",
+			}
+			env := defaultAndApplyExpansionsToEnv(map[string]string{}, opts)
+			assert.Len(t, env, 7)
+			assert.Equal(t, opts.taskID, env[agentutil.MarkerTaskID])
+			assert.Contains(t, strconv.Itoa(os.Getpid()), env[agentutil.MarkerAgentPID])
+			assert.Contains(t, opts.tmpDir, env["TEMP"])
+			assert.Contains(t, opts.tmpDir, env["TMP"])
+			assert.Contains(t, opts.tmpDir, env["TMPDIR"])
+			assert.Equal(t, filepath.Join(opts.workingDir, ".gocache"), env["GOCACHE"])
+			assert.Equal(t, "true", env["CI"])
+		},
+		"SetsDefaultAndRequiredEnvEvenWhenStandardValuesAreZero": func(t *testing.T, exp util.Expansions) {
+			env := defaultAndApplyExpansionsToEnv(map[string]string{}, modifyEnvOptions{})
+			assert.Len(t, env, 7)
+			assert.Contains(t, env, agentutil.MarkerTaskID)
+			assert.Contains(t, env, agentutil.MarkerAgentPID)
+			assert.Contains(t, env, "TEMP")
+			assert.Contains(t, env, "TMP")
+			assert.Contains(t, env, "TMPDIR")
+			assert.Equal(t, ".gocache", env["GOCACHE"])
+			assert.Equal(t, "true", env["CI"])
+		},
+		"AgentEnvVarsOverridesExplicitlySetEnvVars": func(t *testing.T, exp util.Expansions) {
+			opts := modifyEnvOptions{
+				taskID: "real_task_id",
+			}
+			env := defaultAndApplyExpansionsToEnv(map[string]string{
+				agentutil.MarkerAgentPID: "12345",
+				agentutil.MarkerTaskID:   "fake_task_id",
+			}, opts)
+			assert.Equal(t, strconv.Itoa(os.Getpid()), env[agentutil.MarkerAgentPID])
+			assert.Equal(t, opts.taskID, env[agentutil.MarkerTaskID])
+		},
+		"ExplicitlySetEnVVarsOverrideDefaultEnvVars": func(t *testing.T, exp util.Expansions) {
+			gocache := "/path/to/gocache"
+			ci := "definitely not Jenkins"
+			tmpDir := "/some/tmpdir"
+			env := defaultAndApplyExpansionsToEnv(map[string]string{
+				"GOCACHE": gocache,
+				"CI":      ci,
+				"TEMP":    tmpDir,
+				"TMP":     "/some/tmpdir",
+				"TMPDIR":  tmpDir,
+			}, modifyEnvOptions{tmpDir: "/tmp"})
+			assert.Equal(t, gocache, env["GOCACHE"])
+			assert.Equal(t, ci, env["CI"])
+		},
+		"AddExpansionsToEnvAddsAllExpansions": func(t *testing.T, exp util.Expansions) {
+			env := defaultAndApplyExpansionsToEnv(map[string]string{
+				"key1": "val1",
+				"key2": "val2",
+			}, modifyEnvOptions{
+				expansions:         exp,
+				addExpansionsToEnv: true,
+			})
+			assert.Equal(t, "val1", env["key1"])
+			assert.Equal(t, "val2", env["key2"])
+			for k, v := range exp.Map() {
+				assert.Equal(t, v, env[k])
+			}
+		},
+		"AddExpansionsToEnvOverridesDefaultEnvVars": func(t *testing.T, exp util.Expansions) {
+			exp.Put("CI", "actually it's Jenkins")
+			exp.Put("GOCACHE", "/path/to/gocache")
+			env := defaultAndApplyExpansionsToEnv(map[string]string{}, modifyEnvOptions{
+				expansions:         exp,
+				addExpansionsToEnv: true,
+			})
+			for k, v := range exp.Map() {
+				assert.Equal(t, v, env[k])
+			}
+		},
+		"AgentEnvVarsOverrideExpansionsAddedToEnv": func(t *testing.T, exp util.Expansions) {
+			agentEnvVars := map[string]string{
+				agentutil.MarkerAgentPID: "12345",
+				agentutil.MarkerTaskID:   "fake_task_id",
+			}
+			exp.Update(agentEnvVars)
+			opts := modifyEnvOptions{
+				taskID:             "task_id",
+				expansions:         exp,
+				addExpansionsToEnv: true,
+			}
+			env := defaultAndApplyExpansionsToEnv(map[string]string{}, opts)
+			for k, v := range exp.Map() {
+				if _, ok := agentEnvVars[k]; ok {
+					continue
+				}
+				assert.Equal(t, v, env[k])
+			}
+			assert.Equal(t, opts.taskID, env[agentutil.MarkerTaskID])
+			assert.Equal(t, strconv.Itoa(os.Getpid()), env[agentutil.MarkerAgentPID])
+		},
+		"IncludeExpansionsToEnvSelectivelyIncludesExpansions": func(t *testing.T, exp util.Expansions) {
+			var include []string
+			for k := range exp.Map() {
+				include = append(include, k)
+				break
+			}
+			opts := modifyEnvOptions{
+				taskID:                 "task_id",
+				expansions:             exp,
+				includeExpansionsInEnv: include,
+			}
+			env := defaultAndApplyExpansionsToEnv(map[string]string{}, opts)
+			for k, v := range exp.Map() {
+				if utility.StringSliceContains(include, k) {
+					assert.Equal(t, v, env[k])
+				} else {
+					_, ok := env[k]
+					assert.False(t, ok)
+				}
+			}
+		},
+		"IncludeExpansionsInEnvOverridesDefaultEnvVars": func(t *testing.T, exp util.Expansions) {
+			exp.Put("CI", "Travis")
+			exp.Put("GOCACHE", "/path/to/gocache")
+			include := []string{"GOCACHE", "CI"}
+			opts := modifyEnvOptions{
+				expansions:             exp,
+				includeExpansionsInEnv: include,
+			}
+			env := defaultAndApplyExpansionsToEnv(map[string]string{}, opts)
+			for k, v := range exp.Map() {
+				if utility.StringSliceContains(include, k) {
+					assert.Equal(t, v, env[k])
+				} else {
+					_, ok := env[k]
+					assert.False(t, ok)
+				}
+			}
+		},
+		"AgentEnvVarsOverrideExpansionsIncludedInEnv": func(t *testing.T, exp util.Expansions) {
+			agentEnvVars := map[string]string{
+				agentutil.MarkerAgentPID: "12345",
+				agentutil.MarkerTaskID:   "fake_task_id",
+			}
+			exp.Update(agentEnvVars)
+			opts := modifyEnvOptions{
+				taskID:                 "task_id",
+				expansions:             exp,
+				includeExpansionsInEnv: []string{agentutil.MarkerAgentPID, agentutil.MarkerTaskID},
+			}
+			env := defaultAndApplyExpansionsToEnv(map[string]string{}, opts)
+			assert.Equal(t, opts.taskID, env[agentutil.MarkerTaskID])
+			assert.Equal(t, strconv.Itoa(os.Getpid()), env[agentutil.MarkerAgentPID])
+		},
+		"IncludeExpansionsToEnvIgnoresNonexistentExpansions": func(t *testing.T, exp util.Expansions) {
+			include := []string{"nonexistent1", "nonexistent2"}
+			opts := modifyEnvOptions{
+				expansions:             exp,
+				includeExpansionsInEnv: include,
+			}
+			env := defaultAndApplyExpansionsToEnv(map[string]string{}, opts)
+			for _, expName := range include {
+				assert.NotContains(t, env, expName)
+			}
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			exp := util.NewExpansions(map[string]string{
+				"expansion1": "foo",
+				"expansion2": "bar",
+			})
+			testCase(t, *exp)
 		})
 	}
 }

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -32,6 +32,9 @@ type execCmdSuite struct {
 	suite.Suite
 }
 
+// kim: TODO: add integration test to ensure subprocess.exec sets environment
+// properly for the command.
+
 func TestExecCmdSuite(t *testing.T) {
 	suite.Run(t, new(execCmdSuite))
 }

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -3,9 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
@@ -35,6 +33,11 @@ type shellExec struct {
 	// with. Defaults to "sh", but users can customize to
 	// explicitly specify another shell.
 	Shell string `mapstructure:"shell"`
+
+	// kim: TODO: document
+	Env                    map[string]string `mapstructure:"env"`
+	AddExpansionsToEnv     bool              `mapstructure:"add_expansions_to_env"`
+	IncludeExpansionsInEnv []string          `mapstructure:"include_expansions_in_env"`
 
 	// Background, if set to true, prevents shell code/output from
 	// waiting for the script to complete and immediately returns
@@ -89,6 +92,10 @@ func (c *shellExec) ParseParams(params map[string]interface{}) error {
 		return errors.New("cannot ignore standard out, and redirect standard error to it")
 	}
 
+	if c.Env == nil {
+		c.Env = map[string]string{}
+	}
+
 	return nil
 }
 
@@ -117,13 +124,23 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 		logger.Execution().Notice(err.Error())
 	}
 
-	env := map[string]string{
-		agentutil.MarkerTaskID:   conf.Task.Id,
-		agentutil.MarkerAgentPID: strconv.Itoa(os.Getpid()),
-		"GOCACHE":                filepath.Join(c.WorkingDir, ".gocache"),
-		"CI":                     "true",
-	}
-	addTempDirs(env, taskTmpDir)
+	c.Env = defaultAndApplyExpansionsToEnv(c.Env, modifyEnvOptions{
+		taskID:                 conf.Task.Id,
+		workingDir:             c.WorkingDir,
+		tmpDir:                 taskTmpDir,
+		expansions:             *conf.Expansions,
+		includeExpansionsInEnv: c.IncludeExpansionsInEnv,
+		addExpansionsToEnv:     c.AddExpansionsToEnv,
+	})
+
+	// kim: TODO: remove
+	// env := map[string]string{
+	//     agentutil.MarkerTaskID:   conf.Task.Id,
+	//     agentutil.MarkerAgentPID: strconv.Itoa(os.Getpid()),
+	//     "GOCACHE":                filepath.Join(c.WorkingDir, ".gocache"),
+	//     "CI":                     "true",
+	// }
+	// addTempDirs(env, taskTmpDir)
 
 	logger.Execution().Debug(message.Fields{
 		"working_directory": c.WorkingDir,
@@ -131,7 +148,7 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 	})
 
 	cmd := c.JasperManager().CreateCommand(ctx).
-		Background(c.Background).Directory(c.WorkingDir).Environment(env).Append(c.Shell).
+		Background(c.Background).Directory(c.WorkingDir).Environment(c.Env).Append(c.Shell).
 		SuppressStandardError(c.IgnoreStandardError).SuppressStandardOutput(c.IgnoreStandardOutput).RedirectErrorToOutput(c.RedirectStandardErrorToOutput).
 		ProcConstructor(func(lctx context.Context, opts *options.Create) (jasper.Process, error) {
 			opts.StandardInput = strings.NewReader(c.Script)
@@ -224,6 +241,11 @@ func (c *shellExec) doExpansions(exp *util.Expansions) error {
 
 	c.Script, err = exp.ExpandString(c.Script)
 	catcher.Add(err)
+
+	for k, v := range c.Env {
+		c.Env[k], err = exp.ExpandString(v)
+		catcher.Add(err)
+	}
 
 	return catcher.Resolve()
 }

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -34,10 +34,13 @@ type shellExec struct {
 	// explicitly specify another shell.
 	Shell string `mapstructure:"shell"`
 
-	// kim: TODO: document
-	Env                    map[string]string `mapstructure:"env"`
-	AddExpansionsToEnv     bool              `mapstructure:"add_expansions_to_env"`
-	IncludeExpansionsInEnv []string          `mapstructure:"include_expansions_in_env"`
+	Env map[string]string `mapstructure:"env"`
+	// AddExpansionsToEnv adds all defined expansions to the shell environment.
+	AddExpansionsToEnv bool `mapstructure:"add_expansions_to_env"`
+	// IncludeExpansionsInEnv allows users to specify which expansions should be
+	// included in the environment, if they are defined. It is not an error to
+	// specify expansions that are not defined in include_expansions_in_env.
+	IncludeExpansionsInEnv []string `mapstructure:"include_expansions_in_env"`
 
 	// Background, if set to true, prevents shell code/output from
 	// waiting for the script to complete and immediately returns
@@ -132,15 +135,6 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 		includeExpansionsInEnv: c.IncludeExpansionsInEnv,
 		addExpansionsToEnv:     c.AddExpansionsToEnv,
 	})
-
-	// kim: TODO: remove
-	// env := map[string]string{
-	//     agentutil.MarkerTaskID:   conf.Task.Id,
-	//     agentutil.MarkerAgentPID: strconv.Itoa(os.Getpid()),
-	//     "GOCACHE":                filepath.Join(c.WorkingDir, ".gocache"),
-	//     "CI":                     "true",
-	// }
-	// addTempDirs(env, taskTmpDir)
 
 	logger.Execution().Debug(message.Fields{
 		"working_directory": c.WorkingDir,

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -127,11 +127,15 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 		logger.Execution().Notice(err.Error())
 	}
 
+	var exp util.Expansions
+	if conf.Expansions != nil {
+		exp = *conf.Expansions
+	}
 	c.Env = defaultAndApplyExpansionsToEnv(c.Env, modifyEnvOptions{
 		taskID:                 conf.Task.Id,
 		workingDir:             c.WorkingDir,
 		tmpDir:                 taskTmpDir,
-		expansions:             *conf.Expansions,
+		expansions:             exp,
 		includeExpansionsInEnv: c.IncludeExpansionsInEnv,
 		addExpansionsToEnv:     c.AddExpansionsToEnv,
 	})

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -17,9 +18,6 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/stretchr/testify/suite"
 )
-
-// kim: TODO: add integration test to ensure shell.exec sets environment
-// properly for the command.
 
 type shellExecuteCommandSuite struct {
 	ctx    context.Context
@@ -49,7 +47,14 @@ func (s *shellExecuteCommandSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
 	s.comm = client.NewMock("http://localhost.com")
-	s.conf = &internal.TaskConfig{Expansions: &util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
+	s.conf = &internal.TaskConfig{
+		Expansions: &util.Expansions{},
+		Task: &task.Task{
+			Id:     "task_id",
+			Secret: "task_secret",
+		},
+		Project: &model.Project{},
+	}
 	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
 	s.NoError(err)
 
@@ -173,4 +178,54 @@ func (s *shellExecuteCommandSuite) TestCancellingContextShouldCancelCommand() {
 	s.Require().NotNil(err)
 	s.Contains(err.Error(), "shell command interrupted")
 	s.NotContains(err.Error(), "error while stopping process")
+}
+
+func (s *shellExecuteCommandSuite) TestEnvIsSetAndDefaulted() {
+	cmd := &shellExec{
+		Script:     "echo hello world",
+		Shell:      "bash",
+		Env:        map[string]string{"foo": "bar"},
+		WorkingDir: testutil.GetDirectoryOfFile(),
+	}
+	cmd.SetJasperManager(s.jasper)
+	ctx, cancel := context.WithTimeout(s.ctx, time.Second)
+	defer cancel()
+	s.Require().NoError(cmd.Execute(ctx, s.comm, s.logger, s.conf))
+	s.Len(cmd.Env, 8)
+	s.Contains(cmd.Env, agentutil.MarkerTaskID)
+	s.Contains(cmd.Env, agentutil.MarkerAgentPID)
+	s.Contains(cmd.Env, "TEMP")
+	s.Contains(cmd.Env, "TMP")
+	s.Contains(cmd.Env, "TMPDIR")
+	s.Contains(cmd.Env, "GOCACHE")
+	s.Contains(cmd.Env, "CI")
+	s.Contains(cmd.Env, "foo")
+}
+
+func (s *shellExecuteCommandSuite) TestEnvAddsExpansionsAndDefaults() {
+	cmd := &shellExec{
+		Script:             "echo hello world",
+		Shell:              "bash",
+		AddExpansionsToEnv: true,
+		WorkingDir:         testutil.GetDirectoryOfFile(),
+	}
+	s.conf.Expansions = util.NewExpansions(map[string]string{
+		"expansion1": "foo",
+		"expansion2": "bar",
+	})
+	cmd.SetJasperManager(s.jasper)
+	ctx, cancel := context.WithTimeout(s.ctx, time.Second)
+	defer cancel()
+	s.Require().NoError(cmd.Execute(ctx, s.comm, s.logger, s.conf))
+	s.Len(cmd.Env, 9)
+	s.Contains(cmd.Env, agentutil.MarkerTaskID)
+	s.Contains(cmd.Env, agentutil.MarkerAgentPID)
+	s.Contains(cmd.Env, "TEMP")
+	s.Contains(cmd.Env, "TMP")
+	s.Contains(cmd.Env, "TMPDIR")
+	s.Contains(cmd.Env, "GOCACHE")
+	s.Contains(cmd.Env, "CI")
+	for k, v := range s.conf.Expansions.Map() {
+		s.Equal(v, cmd.Env[k])
+	}
 }

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// kim: TODO: add integration test to ensure shell.exec sets environment
+// properly for the command.
+
 type shellExecuteCommandSuite struct {
 	ctx    context.Context
 	cancel context.CancelFunc

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2021-02-01"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-02-03"
+	AgentVersion = "2021-02-04"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13690

I mirrored the behavior of environment variables for `subprocess.exec` in `shell.exec` so they should behave identically with regards to `env`, `add_expansions_to_env` and `include_expansions_in_env`. Both of them set the same default variables (e.g. agent variables, temp dirs, gocache).

One minor change that I did make was I made the agent environment variables override any custom ones set by expansions or an explicit setting in `env`, but I don't think it matters since no project is using these variables for anything. Before, it was possible for expansion variables to override the agent variables.