### PR TITLE
EVG-13932 merge prs in a task

### DIFF
--- a/agent/command/git_merge_pr.go
+++ b/agent/command/git_merge_pr.go
@@ -60,7 +60,7 @@ func (c *gitMergePr) Execute(ctx context.Context, comm client.Communicator, logg
 		logger.Task().Error(err)
 		logger.Task().Critical(pErr)
 		td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
-		logger.Task().Error(comm.ConcludeMerge(ctx, conf.Task.Version, conf.ProjectRef.Identifier, status, td))
+		logger.Task().Error(comm.ConcludeMerge(ctx, conf.Task.Version, status, td))
 	}()
 	if err = util.ExpandValues(c, conf.Expansions); err != nil {
 		return errors.Wrap(err, "can't apply expansions")
@@ -71,24 +71,23 @@ func (c *gitMergePr) Execute(ctx context.Context, comm client.Communicator, logg
 		return errors.Wrap(err, "unable to get patch")
 	}
 
-	_, projectToken, err := getProjectMethodAndToken(c.Token, conf.Expansions.Get(evergreen.GlobalGitHubTokenExpansion), conf.Distro.CloneMethod)
-	if err != nil {
-		return errors.Wrap(err, "failed to get token")
+	token := c.Token
+	if token == "" {
+		token = conf.Expansions.Get(evergreen.GlobalGitHubTokenExpansion)
 	}
-	httpClient := utility.GetOAuth2HTTPClient(projectToken)
+	httpClient := utility.GetOAuth2HTTPClient(token)
 	defer utility.PutHTTPClient(httpClient)
 	githubClient := github.NewClient(httpClient)
 
 	c.statusSender, err = send.NewGithubStatusLogger("evergreen", &send.GithubOptions{
-		Token: projectToken,
+		Token: token,
 	}, "")
 	if err != nil {
 		return errors.Wrap(err, "failed to setup github status logger")
 	}
 
 	status := evergreen.PatchFailed
-	// TODO: have this instead look at a new field for "rest of the patch succeeded"
-	if patchDoc.Status == evergreen.PatchSucceeded {
+	if patchDoc.MergeStatus == evergreen.PatchSucceeded {
 		status = evergreen.PatchSucceeded
 	}
 	c.sendPatchResult(patchDoc.GithubPatchData, conf, status)
@@ -97,7 +96,7 @@ func (c *gitMergePr) Execute(ctx context.Context, comm client.Communicator, logg
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	githubCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	mergeMethod := conf.ProjectRef.CommitQueue.MergeMethod
 	title := patchDoc.GithubPatchData.CommitTitle
@@ -113,7 +112,7 @@ func (c *gitMergePr) Execute(ctx context.Context, comm client.Communicator, logg
 	}
 
 	// do the merge
-	res, _, err := githubClient.PullRequests.Merge(ctx, conf.ProjectRef.Owner, conf.ProjectRef.Repo,
+	res, _, err := githubClient.PullRequests.Merge(githubCtx, conf.ProjectRef.Owner, conf.ProjectRef.Repo,
 		patchDoc.GithubPatchData.PRNumber, patchDoc.GithubPatchData.CommitTitle, mergeOpts)
 	if err != nil {
 		c.sendMergeFailedStatus(fmt.Sprintf("Github Error: %s", err.Error()), patchDoc.GithubPatchData, conf)

--- a/agent/command/git_merge_pr.go
+++ b/agent/command/git_merge_pr.go
@@ -95,6 +95,8 @@ func (c *gitMergePr) Execute(ctx context.Context, comm client.Communicator, logg
 		logger.Task().Warning("at least 1 task failed, will not merge pull request")
 		return nil
 	}
+	// only successful patches should get past here. Failed patches will just send the failed
+	// status to github
 
 	githubCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -117,7 +117,7 @@ type Communicator interface {
 	GetDockerStatus(ctx context.Context, hostID string) (*cloud.ContainerStatus, error)
 
 	// ConcludeMerge reports the status of a commit queue merge back to the server
-	ConcludeMerge(ctx context.Context, patchId, project, status string, td TaskData) error
+	ConcludeMerge(ctx context.Context, patchId, status string, td TaskData) error
 }
 
 type LoggerMetadata struct {

--- a/agent/internal/client/methods.go
+++ b/agent/internal/client/methods.go
@@ -866,7 +866,7 @@ func (c *communicatorImpl) GetDockerLogs(ctx context.Context, hostID string, sta
 	return body, nil
 }
 
-func (c *communicatorImpl) ConcludeMerge(ctx context.Context, patchId, project, status string, td TaskData) error {
+func (c *communicatorImpl) ConcludeMerge(ctx context.Context, patchId, status string, td TaskData) error {
 	info := requestInfo{
 		method:   http.MethodGet,
 		path:     fmt.Sprintf("commit_queue/%s/conclude_merge", patchId),
@@ -874,11 +874,9 @@ func (c *communicatorImpl) ConcludeMerge(ctx context.Context, patchId, project, 
 		taskData: &td,
 	}
 	body := struct {
-		Project string `json:"project"`
-		Status  string `json:"status"`
+		Status string `json:"status"`
 	}{
-		Project: project,
-		Status:  status,
+		Status: status,
 	}
 	resp, err := c.request(ctx, info, body)
 	if err != nil {

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -480,6 +480,6 @@ func (c *Mock) GetDockerStatus(context.Context, string) (*cloud.ContainerStatus,
 	return &cloud.ContainerStatus{HasStarted: true}, nil
 }
 
-func (c *Mock) ConcludeMerge(ctx context.Context, patchId, project, status string, td TaskData) error {
+func (c *Mock) ConcludeMerge(ctx context.Context, patchId, status string, td TaskData) error {
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2021-02-01"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-02-08"
+	AgentVersion = "2021-02-09"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 	ClientVersion = "2021-02-01"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-02-04"
+	AgentVersion = "2021-02-05"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -231,7 +231,7 @@ func preventMergeForItem(item CommitQueueItem, user string) error {
 		return errors.Wrap(err, "can't disable merge task")
 	}
 	if err = build.SetCachedTaskActivated(mergeTask.BuildId, mergeTask.Id, false); err != nil {
-		return errors.Wrap(err, "can't update build cache for deactivated ")
+		return errors.Wrapf(err, "error updating task cache for build %s", mergeTask.BuildId)
 	}
 
 	return nil

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -256,7 +256,7 @@ func (s *CommitQueueSuite) TestFindOneId() {
 	s.Nil(cq)
 }
 
-func TestPreventMergeForItemCLI(t *testing.T) {
+func TestPreventMergeForItem(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(event.SubscriptionsCollection, task.Collection, build.Collection))
 
 	patchID := "abcdef012345"

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -264,8 +264,9 @@ func TestPreventMergeForItemCLI(t *testing.T) {
 	require.NoError(t, patchSub.Upsert())
 
 	item := CommitQueueItem{
-		Issue:  patchID,
-		Source: SourceDiff,
+		Issue:   patchID,
+		Source:  SourceDiff,
+		Version: patchID,
 	}
 
 	mergeBuild := &build.Build{Id: "b1", Tasks: []build.TaskCache{{Id: "t1", Activated: true}}}
@@ -273,19 +274,9 @@ func TestPreventMergeForItemCLI(t *testing.T) {
 	mergeTask := &task.Task{Id: "t1", CommitQueueMerge: true, Version: patchID, BuildId: "b1"}
 	require.NoError(t, mergeTask.Insert())
 
-	// Without a corresponding version
-	assert.NoError(t, preventMergeForItem(false, item, "user"))
-	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
-	assert.NoError(t, err)
-	assert.NotEmpty(t, subscriptions)
-
-	mergeTask, err = task.FindOneId("t1")
-	assert.NoError(t, err)
-	assert.Equal(t, int64(0), mergeTask.Priority)
-
 	// With a corresponding version
-	assert.NoError(t, preventMergeForItem(true, item, "user"))
-	subscriptions, err = event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
+	assert.NoError(t, preventMergeForItem(item, "user"))
+	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: patchID}})
 	assert.NoError(t, err)
 	assert.Empty(t, subscriptions)
 

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -256,25 +256,6 @@ func (s *CommitQueueSuite) TestFindOneId() {
 	s.Nil(cq)
 }
 
-func TestPreventMergeForItemPR(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(event.SubscriptionsCollection))
-
-	patchID := "abcdef012345"
-	patchSub := event.NewExpiringPatchOutcomeSubscription(patchID, event.NewGithubMergeSubscriber(event.GithubMergeSubscriber{}))
-	require.NoError(t, patchSub.Upsert())
-
-	item := CommitQueueItem{
-		Issue:   "1234",
-		Version: patchID,
-		Source:  SourcePullRequest,
-	}
-
-	assert.NoError(t, preventMergeForItem(false, item, "user"))
-	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, []event.Selector{{Type: event.SelectorID, Data: item.Version}})
-	assert.NoError(t, err)
-	assert.Empty(t, subscriptions)
-}
-
 func TestPreventMergeForItemCLI(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(event.SubscriptionsCollection, task.Collection, build.Collection))
 

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -18,7 +18,7 @@ const (
 	EvergreenWebhookSubscriberType   = "evergreen-webhook"
 	EmailSubscriberType              = "email"
 	SlackSubscriberType              = "slack"
-	GithubMergeSubscriberType        = "github-merge"
+	GithubMergeSubscriberType        = "github-merge" //TODO: remove this once deployed
 	CommitQueueDequeueSubscriberType = "commit-queue-dequeue"
 	EnqueuePatchSubscriberType       = "enqueue-patch"
 	SubscriberTypeNone               = "none"
@@ -190,13 +190,6 @@ func (s *GithubMergeSubscriber) String() string {
 		s.MergeMethod,
 		s.Item,
 	)
-}
-
-func NewGithubMergeSubscriber(s GithubMergeSubscriber) Subscriber {
-	return Subscriber{
-		Type:   GithubMergeSubscriberType,
-		Target: s,
-	}
 }
 
 func NewCommitQueueDequeueSubscriber() Subscriber {

--- a/model/event/subscribers_test.go
+++ b/model/event/subscribers_test.go
@@ -27,22 +27,6 @@ func TestSubscribers(t *testing.T) {
 			},
 		},
 		{
-			Type: GithubMergeSubscriberType,
-			Target: &GithubMergeSubscriber{
-				PRs: []PRInfo{
-					{
-						Owner:       "evergreen-ci",
-						Repo:        "evergreen",
-						PRNum:       9001,
-						Ref:         "deadbeef",
-						CommitTitle: "abcd",
-					},
-				},
-				MergeMethod: "squash",
-				Item:        "9001",
-			},
-		},
-		{
 			Type: EvergreenWebhookSubscriberType,
 			Target: &WebhookSubscriber{
 				URL:    "https://example.com",
@@ -66,7 +50,6 @@ func TestSubscribers(t *testing.T) {
 		},
 	}
 	expected := []string{"github_pull_request-evergreen-ci-evergreen-9001-sadasdkjsad",
-		"github-merge-evergreen-ci-evergreen-9001-deadbeef-abcd-squash-9001",
 		"evergreen-webhook-https://example.com", "email-hi@example.com",
 		"jira-issue-BF-Fail", "jira-comment-BF-1234"}
 	for i := range subs {
@@ -77,7 +60,7 @@ func TestSubscribers(t *testing.T) {
 	fetchedSubs := []Subscriber{}
 	assert.NoError(db.FindAllQ(SubscriptionsCollection, db.Q{}, &fetchedSubs))
 
-	assert.Len(fetchedSubs, 6)
+	assert.Len(fetchedSubs, 5)
 
 	for i := range subs {
 		assert.Contains(fetchedSubs, subs[i])
@@ -108,9 +91,6 @@ func TestSubscribersStringerWithMissingAttributes(t *testing.T) {
 	subs := []Subscriber{
 		{
 			Type: GithubPullRequestSubscriberType,
-		},
-		{
-			Type: GithubMergeSubscriberType,
 		},
 		{
 			Type: EvergreenWebhookSubscriberType,

--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -356,9 +356,6 @@ func CollectUnsentNotificationStats() (*NotificationStats, error) {
 		case event.SlackSubscriberType:
 			nStats.Slack = data.Count
 
-		case event.GithubMergeSubscriberType:
-			nStats.GithubMerge = data.Count
-
 		case event.CommitQueueDequeueSubscriberType:
 			nStats.CommitQueueDequeue = data.Count
 

--- a/model/notification/notification_test.go
+++ b/model/notification/notification_test.go
@@ -420,6 +420,9 @@ func (s *notificationSuite) TestCollectUnsentNotificationStats() {
 	// we should count 1 of each type
 	v := reflect.ValueOf(stats).Elem()
 	for i := 0; i < v.NumField(); i++ {
+		if i == 6 {
+			continue // TODO: temporary until GithubMerge is removed as a notification type
+		}
 		f := v.Field(i)
 		s.Equal(1, int(f.Int()))
 	}

--- a/model/notification/notification_test.go
+++ b/model/notification/notification_test.go
@@ -396,7 +396,7 @@ func (s *notificationSuite) TestCollectUnsentNotificationStats() {
 	types := []string{event.GithubPullRequestSubscriberType, event.EmailSubscriberType,
 		event.SlackSubscriberType, event.EvergreenWebhookSubscriberType,
 		event.JIRACommentSubscriberType, event.JIRAIssueSubscriberType,
-		event.GithubMergeSubscriberType, event.CommitQueueDequeueSubscriberType, event.EnqueuePatchSubscriberType,
+		event.CommitQueueDequeueSubscriberType, event.EnqueuePatchSubscriberType,
 		event.GithubCheckSubscriberType}
 
 	n := []Notification{}

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -154,6 +154,9 @@ type Patch struct {
 	GithubPatchData thirdparty.GithubPatch `bson:"github_patch_data,omitempty"`
 	// DisplayNewUI is only used when roundtripping the patch via the CLI
 	DisplayNewUI bool `bson:"display_new_ui,omitempty"`
+	// MergeStatus is only used in gitServePatch to send the status of this
+	// patch on the commit queue to the agent
+	MergeStatus string `json:"merge_status"`
 }
 
 func (p *Patch) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(p) }

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1506,6 +1506,9 @@ func TestTryDequeueAndAbortCommitQueueVersion(t *testing.T) {
 	b := build.Build{
 		Id:      "my-build",
 		Version: v.Id,
+		Tasks: []build.TaskCache{
+			{Id: "merge"},
+		},
 	}
 	t1 := &task.Task{
 		Id:        "t1",
@@ -1535,9 +1538,17 @@ func TestTryDequeueAndAbortCommitQueueVersion(t *testing.T) {
 		Version:   v.Id,
 		BuildId:   b.Id,
 	}
+	m := task.Task{
+		Id:               "merge",
+		Status:           evergreen.TaskUndispatched,
+		Activated:        true,
+		CommitQueueMerge: true,
+		Version:          v.Id,
+		BuildId:          b.Id,
+	}
 	q := []commitqueue.CommitQueueItem{
-		{Issue: "12"},
-		{Issue: "42"},
+		{Issue: "12", Source: commitqueue.SourcePullRequest, Version: v.Id},
+		{Issue: "42", Source: commitqueue.SourcePullRequest},
 	}
 	cq := &commitqueue.CommitQueue{ProjectID: "my-project", Processing: true, Queue: q}
 	assert.NoError(t, v.Insert())
@@ -1547,6 +1558,7 @@ func TestTryDequeueAndAbortCommitQueueVersion(t *testing.T) {
 	assert.NoError(t, t2.Insert())
 	assert.NoError(t, t3.Insert())
 	assert.NoError(t, t4.Insert())
+	assert.NoError(t, m.Insert())
 	assert.NoError(t, commitqueue.InsertQueue(cq))
 
 	pRef := &ProjectRef{Id: cq.ProjectID}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1455,7 +1455,7 @@ func TestTryDequeueAndAbortBlockedCommitQueueVersion(t *testing.T) {
 	}
 
 	q := []commitqueue.CommitQueueItem{
-		{Issue: patchID, Source: commitqueue.SourceDiff},
+		{Issue: patchID, Source: commitqueue.SourceDiff, Version: patchID},
 		{Issue: "42"},
 	}
 	cq := &commitqueue.CommitQueue{

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -304,8 +304,9 @@ func (s *CommitQueueSuite) TestDeleteCommitQueueItem() {
 		ProjectID: "mci",
 		Queue: []commitqueue.CommitQueueItem{
 			{
-				Issue:  validId,
-				Source: commitqueue.SourceDiff,
+				Issue:   validId,
+				Source:  commitqueue.SourceDiff,
+				Version: validId,
 			},
 			{
 				Issue:  bson.NewObjectId().Hex(),

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -223,14 +223,18 @@ func (pc *DBCommitQueueConnector) GetMessageForPatch(patchID string) (string, er
 	return project.CommitQueue.Message, nil
 }
 
-func (pc *DBCommitQueueConnector) ConcludeMerge(patchID, project, status string) error {
+func (pc *DBCommitQueueConnector) ConcludeMerge(patchID, status string) error {
 	event.LogCommitQueueConcludeTest(patchID, status)
-	cq, err := commitqueue.FindOneId(project)
+	p, err := patch.FindOneId(patchID)
 	if err != nil {
-		return errors.Wrapf(err, "can't find commit queue for '%s'", project)
+		return errors.Wrap(err, "error finding patch")
+	}
+	cq, err := commitqueue.FindOneId(p.Project)
+	if err != nil {
+		return errors.Wrapf(err, "can't find commit queue for '%s'", p.Project)
 	}
 	if cq == nil {
-		return errors.Errorf("no commit queue found for '%s'", project)
+		return errors.Errorf("no commit queue found for '%s'", p.Project)
 	}
 	item := ""
 	for _, entry := range cq.Queue {
@@ -344,6 +348,6 @@ func (pc *MockCommitQueueConnector) GetMessageForPatch(patchID string) (string, 
 	return "", nil
 }
 
-func (pc *MockCommitQueueConnector) ConcludeMerge(patchID, project, status string) error {
+func (pc *MockCommitQueueConnector) ConcludeMerge(patchID, status string) error {
 	return nil
 }

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -229,6 +229,9 @@ func (pc *DBCommitQueueConnector) ConcludeMerge(patchID, status string) error {
 	if err != nil {
 		return errors.Wrap(err, "error finding patch")
 	}
+	if p == nil {
+		return errors.Errorf("patch %s not found", patchID)
+	}
 	cq, err := commitqueue.FindOneId(p.Project)
 	if err != nil {
 		return errors.Wrapf(err, "can't find commit queue for '%s'", p.Project)

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -361,7 +361,7 @@ func TestConcludeMerge(t *testing.T) {
 	require.NoError(t, commitqueue.InsertQueue(queue))
 	dc := &DBCommitQueueConnector{}
 
-	assert.NoError(t, dc.ConcludeMerge(itemID, projectID, "foo"))
+	assert.NoError(t, dc.ConcludeMerge(itemID, "foo"))
 
 	queue, err := commitqueue.FindOneId(projectID)
 	require.NoError(t, err)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -342,7 +342,7 @@ type Connector interface {
 	IsPatchEmpty(string) (bool, error)
 	IsAuthorizedToPatchAndMerge(context.Context, *evergreen.Settings, UserRepoInfo) (bool, error)
 	GetMessageForPatch(string) (string, error)
-	ConcludeMerge(string, string, string) error
+	ConcludeMerge(string, string) error
 
 	// GetDockerLogs returns logs for the given docker container
 	GetDockerLogs(context.Context, string, *host.Host, *evergreen.Settings, types.ContainerLogsOptions) (io.Reader, error)

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -76,13 +76,6 @@ func (s *APISubscriber) BuildFromService(h interface{}) error {
 				return err
 			}
 			target = sub
-		case event.GithubMergeSubscriberType:
-			sub := APIGithubMergeSubscriber{}
-			err := sub.BuildFromService(v.Target)
-			if err != nil {
-				return err
-			}
-			target = sub
 
 		case event.EvergreenWebhookSubscriberType:
 			sub := APIWebhookSubscriber{}
@@ -146,21 +139,6 @@ func (s *APISubscriber) ToService() (interface{}, error) {
 			return nil, gimlet.ErrorResponse{
 				StatusCode: http.StatusBadRequest,
 				Message:    errors.Wrap(err, "Github check subscriber target is malformed").Error(),
-			}
-		}
-		target, err = apiModel.ToService()
-		if err != nil {
-			return nil, gimlet.ErrorResponse{
-				StatusCode: http.StatusBadRequest,
-				Message:    errors.Wrap(err, "can't read subscriber target from API model").Error(),
-			}
-		}
-	case event.GithubMergeSubscriberType:
-		apiModel := APIGithubMergeSubscriber{}
-		if err = mapstructure.Decode(s.Target, &apiModel); err != nil {
-			return nil, gimlet.ErrorResponse{
-				StatusCode: http.StatusBadRequest,
-				Message:    errors.Wrap(err, "GitHub merge subscriber target is malformed").Error(),
 			}
 		}
 		target, err = apiModel.ToService()

--- a/rest/model/subscriber_test.go
+++ b/rest/model/subscriber_test.go
@@ -49,60 +49,6 @@ func TestSubscriberModelsGithubStatusAPI(t *testing.T) {
 	assert.EqualValues(origPrSubscriber, serviceModel)
 }
 
-func TestSubscriberModelsGithubMerge(t *testing.T) {
-	assert := assert.New(t)
-	target := event.GithubMergeSubscriber{
-		PRs: []event.PRInfo{
-			{
-				Owner:       "me",
-				Repo:        "mine",
-				PRNum:       5,
-				Ref:         "deadbeef",
-				CommitTitle: "PR (#5)",
-			},
-		},
-		MergeMethod: "squash",
-		Item:        "5",
-	}
-	subscriber := event.Subscriber{
-		Type:   event.GithubMergeSubscriberType,
-		Target: &target,
-	}
-	apiSubscriber := APISubscriber{}
-	err := apiSubscriber.BuildFromService(subscriber)
-	assert.NoError(err)
-
-	origSubscriberInterface, err := apiSubscriber.ToService()
-	assert.NoError(err)
-
-	origSubscriber, ok := origSubscriberInterface.(event.Subscriber)
-	assert.True(ok)
-	assert.EqualValues(subscriber.Type, origSubscriber.Type)
-	assert.EqualValues(target, origSubscriber.Target)
-
-	// incoming subscribers have target serialized as a map
-	incoming := APISubscriber{
-		Type: utility.ToStringPtr(event.GithubMergeSubscriberType),
-		Target: map[string]interface{}{
-			"prs": []map[string]interface{}{
-				{
-					"owner":        "me",
-					"repo":         "mine",
-					"pr_number":    5,
-					"ref":          "deadbeef",
-					"commit_title": "PR (#5)",
-				},
-			},
-			"merge_method": "squash",
-			"item":         "5",
-		},
-	}
-
-	serviceModel, err := incoming.ToService()
-	assert.NoError(err)
-	assert.EqualValues(origSubscriber, serviceModel)
-}
-
 func TestSubscriberModelsWebhook(t *testing.T) {
 	assert := assert.New(t)
 

--- a/rest/route/commit_queue.go
+++ b/rest/route/commit_queue.go
@@ -253,8 +253,7 @@ func (p *cqMessageForPatch) Run(ctx context.Context) gimlet.Responder {
 }
 
 type commitQueueConcludeMerge struct {
-	Project string `json:"project"`
-	Status  string `json:"status"`
+	Status string `json:"status"`
 
 	patchId string
 	sc      data.Connector
@@ -283,9 +282,6 @@ func (p *commitQueueConcludeMerge) Parse(ctx context.Context, r *http.Request) e
 	if err := utility.ReadJSON(body, p); err != nil {
 		return errors.Wrap(err, "unable to parse request body")
 	}
-	if p.Project == "" {
-		return errors.New("project must be specified")
-	}
 	if p.Status == "" {
 		return errors.New("status must be specified")
 	}
@@ -294,7 +290,7 @@ func (p *commitQueueConcludeMerge) Parse(ctx context.Context, r *http.Request) e
 }
 
 func (p *commitQueueConcludeMerge) Run(ctx context.Context) gimlet.Responder {
-	err := p.sc.ConcludeMerge(p.patchId, p.Project, p.Status)
+	err := p.sc.ConcludeMerge(p.patchId, p.Status)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}

--- a/service/api_plugin_git.go
+++ b/service/api_plugin_git.go
@@ -4,27 +4,67 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
 )
 
 func (as *APIServer) gitServePatch(w http.ResponseWriter, r *http.Request) {
-	task := MustHaveTask(r)
+	t := MustHaveTask(r)
 
-	patch, err := patch.FindOne(patch.ByVersion(task.Version))
+	p, err := patch.FindOne(patch.ByVersion(t.Version))
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError,
-			errors.Wrapf(err, "problem fetching patch for task '%s' from db", task.Id))
+			errors.Wrapf(err, "problem fetching patch for task '%s' from db", t.Id))
 		return
 	}
-	if patch == nil {
+	if p == nil {
 		as.LoggedError(w, r, http.StatusNotFound,
-			errors.Errorf("no patch found for task %s", task.Id))
+			errors.Errorf("no patch found for task %s", t.Id))
 		return
 	}
-	gimlet.WriteJSON(w, patch)
+
+	// add on the merge status for the patch, if applicable
+	if p.GetRequester() == evergreen.MergeTestRequester {
+		builds, err := build.Find(build.ByVersion(p.Version))
+		if err != nil {
+			as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error retrieving builds for task"))
+			return
+		}
+		tasks, err := task.Find(task.ByVersion(p.Version).WithFields(task.BuildIdKey, task.StatusKey, task.ActivatedKey, task.DependsOnKey, task.IsGithubCheckKey))
+		if err != nil {
+			as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "problem finding tasks for version"))
+			return
+		}
+
+		status := evergreen.PatchSucceeded
+		for _, b := range builds {
+			if b.BuildVariant == evergreen.MergeTaskVariant {
+				continue
+			}
+			complete, buildStatus, err := b.AllUnblockedTasksFinished(tasks)
+			if err != nil {
+				as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "problem checking build tasks"))
+				return
+			}
+			if !complete {
+				status = evergreen.PatchStarted
+				break
+			}
+			if buildStatus == evergreen.BuildFailed {
+				status = evergreen.PatchFailed
+				break
+			}
+		}
+		p.MergeStatus = status
+	}
+	p.MergeStatus = evergreen.PatchSucceeded
+
+	gimlet.WriteJSON(w, p)
 }
 
 func (as *APIServer) gitServePatchFile(w http.ResponseWriter, r *http.Request) {

--- a/service/api_plugin_git.go
+++ b/service/api_plugin_git.go
@@ -35,7 +35,7 @@ func (as *APIServer) gitServePatch(w http.ResponseWriter, r *http.Request) {
 			as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error retrieving builds for task"))
 			return
 		}
-		tasks, err := task.Find(task.ByVersion(p.Version).WithFields(task.BuildIdKey, task.StatusKey, task.ActivatedKey, task.DependsOnKey, task.IsGithubCheckKey))
+		tasks, err := task.Find(task.ByVersion(p.Version).WithFields(task.BuildIdKey, task.StatusKey, task.ActivatedKey, task.DependsOnKey))
 		if err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "problem finding tasks for version"))
 			return

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -401,15 +401,6 @@ func makeCommonPayload(sub *event.Subscription, selectors []event.Selector,
 		}
 		return msg, nil
 
-	case event.GithubMergeSubscriberType:
-		msg := &commitqueue.GithubMergePR{
-			Status:    data.PastTenseStatus,
-			PatchID:   data.ID,
-			URL:       data.URL,
-			ProjectID: data.Project,
-		}
-		return msg, nil
-
 	case event.CommitQueueDequeueSubscriberType:
 		return &commitqueue.DequeueItem{
 			Status:    data.PastTenseStatus,

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -617,6 +617,8 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 	// Merge task depends on all the tasks already in the patch
 	status := ""
 	if source == commitqueue.SourcePullRequest {
+		// for pull requests we need to run the merge task at the end even if something
+		// fails, so that it can tell github something failed
 		status = model.AllStatuses
 	}
 	dependencies := []model.TaskUnitDependency{}

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -2,7 +2,6 @@ package units
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/distro"
-	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -129,32 +127,6 @@ func (s *commitQueueSuite) TestNewCommitQueueJob() {
 	s.Equal("commit-queue:mci_job-1", job.ID())
 }
 
-func (s *commitQueueSuite) TestSubscribeMerge() {
-	s.NoError(db.ClearCollections(event.SubscriptionsCollection))
-	s.NoError(subscribeGitHubPRs(s.pr, nil, s.projectRef, "abcdef", ""))
-
-	selectors := []event.Selector{
-		event.Selector{
-			Type: "id",
-			Data: "abcdef",
-		},
-	}
-	subscriptions, err := event.FindSubscriptions(event.ResourceTypePatch, selectors)
-	s.NoError(err)
-	s.Require().Len(subscriptions, 1)
-
-	subscription := subscriptions[0]
-
-	s.Equal(event.GithubMergeSubscriberType, subscription.Subscriber.Type)
-	s.Equal(event.ResourceTypePatch, subscription.ResourceType)
-	target, ok := subscription.Subscriber.Target.(*event.GithubMergeSubscriber)
-	s.True(ok)
-	s.Require().Len(target.PRs, 1)
-	s.Equal(s.projectRef.Owner, target.PRs[0].Owner)
-	s.Equal(s.projectRef.Repo, target.PRs[0].Repo)
-	s.Equal(fmt.Sprintf("%s (#%d)", s.pr.GetTitle(), *s.pr.Number), target.PRs[0].CommitTitle)
-}
-
 func (s *commitQueueSuite) TestWritePatchInfo() {
 	s.NoError(db.ClearGridCollections(patch.GridFSPrefix))
 
@@ -219,7 +191,7 @@ func (s *commitQueueSuite) TestAddMergeTaskAndVariant() {
 	patchDoc := &patch.Patch{}
 	ref := &model.ProjectRef{}
 
-	s.NoError(addMergeTaskAndVariant(patchDoc, project, ref))
+	s.NoError(addMergeTaskAndVariant(patchDoc, project, ref, commitqueue.SourceDiff))
 
 	s.Require().Len(patchDoc.BuildVariants, 1)
 	s.Equal(evergreen.MergeTaskVariant, patchDoc.BuildVariants[0])

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -275,7 +275,7 @@ func notificationIsEnabled(flags *evergreen.ServiceFlags, n *notification.Notifi
 	case event.SlackSubscriberType:
 		return !flags.SlackNotificationsDisabled
 
-	case event.GithubMergeSubscriberType, event.CommitQueueDequeueSubscriberType, event.EnqueuePatchSubscriberType:
+	case event.CommitQueueDequeueSubscriberType, event.EnqueuePatchSubscriberType:
 		return !flags.CommitQueueDisabled
 
 	default:

--- a/units/event_send.go
+++ b/units/event_send.go
@@ -163,7 +163,7 @@ func (j *eventSendJob) checkDegradedMode(n *notification.Notification) error {
 	case event.EmailSubscriberType:
 		return checkFlag(j.flags.EmailNotificationsDisabled)
 
-	case event.GithubMergeSubscriberType, event.CommitQueueDequeueSubscriberType, event.EnqueuePatchSubscriberType:
+	case event.CommitQueueDequeueSubscriberType, event.EnqueuePatchSubscriberType:
 		return checkFlag(j.flags.CommitQueueDisabled)
 
 	default:

--- a/units/event_send_test.go
+++ b/units/event_send_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/mock"
-	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/evergreen/util"
@@ -127,25 +126,6 @@ func (s *eventNotificationSuite) SetupTest() {
 				URL:     "https://example.com",
 				State:   message.GithubStateFailure,
 			},
-		},
-		{
-			ID: "github-pr-merge",
-			Subscriber: event.Subscriber{
-				Type: event.GithubMergeSubscriberType,
-				Target: event.GithubMergeSubscriber{
-					PRs: []event.PRInfo{
-						{
-							Owner:       "evergreen-ci",
-							Repo:        "evergreen",
-							PRNum:       1234,
-							CommitTitle: "PR (#1234)",
-						},
-					},
-					Item:        "1234",
-					MergeMethod: "squash",
-				},
-			},
-			Payload: commitqueue.GithubMergePR{},
 		},
 	}
 	s.webhook = &s.notifications[0]

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -658,6 +658,10 @@ func validateBVNames(project *model.Project) ValidationErrors {
 						project.Identifier, buildVariant.Name),
 				},
 			)
+		} else if dispName == evergreen.MergeTaskVariant {
+			errs = append(errs, ValidationError{
+				Message: fmt.Sprintf("the variant name '%s' is reserved for the commit queue", evergreen.MergeTaskVariant),
+			})
 		}
 		displayNames[dispName] = displayNames[dispName] + 1
 


### PR DESCRIPTION
Really the only new thing here is that commit queue entries from prs will now be merged in a task rather than through the notification system. I removed about half of the old code using the notification system, specifically the parts that were adding subscriptions. I left in the parts that process notifications so that unfinished pr merges from when this is deployed will still work