### PR TITLE
EVG-7778: Fix build

### DIFF
--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -509,11 +509,12 @@ func (m *cedarTestStatsMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Req
 		gimlet.GetVars(r)["project_id"],
 		r.URL.RawQuery,
 	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, newURL, nil)
+	req, err := http.NewRequest(http.MethodGet, newURL, nil)
 	if err != nil {
 		gimlet.WriteResponse(rw, gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "problem creating cedar test stats request")))
 		return
 	}
+	req = req.WithContext(ctx)
 
 	c := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(c)


### PR DESCRIPTION
I was using go1.15 locally and forgot that go1.9 does not have `http.RequestWithContext`. 