### PR TITLE
EVG-13904 temporary logging for next_task

### DIFF
--- a/service/api_task.go
+++ b/service/api_task.go
@@ -762,7 +762,6 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 			"duration_ms": time.Now().Sub(stepStart).Milliseconds(),
 			"run_id":      runId,
 		})
-		stepStart = time.Now()
 		gimlet.WriteJSON(w, response)
 		return
 	}


### PR DESCRIPTION
while looking at thresholds for a response time alert, I'm seeing unusually long response times in next_task for specific distros again so I added logging for a specific distro that seems problematic