### PR TITLE
EVG-13763: Put limits on the max duration for AWS calls

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -153,7 +153,7 @@ type generateDeviceNameOptions struct {
 }
 
 const (
-	awsClientImplRetries     = 5
+	awsClientImplRetries     = 9
 	awsClientImplStartPeriod = time.Second
 )
 

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -153,7 +153,7 @@ type generateDeviceNameOptions struct {
 }
 
 const (
-	awsClientImplRetries     = 10
+	awsClientImplRetries     = 5
 	awsClientImplStartPeriod = time.Second
 )
 

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -184,9 +184,16 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 	}
 	defer m.client.Close()
 
+	startAt := time.Now()
 	describeInstancesOutput, err := m.client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		InstanceIds: instanceIDs,
 	})
+	grip.Debug(message.Fields{
+		"message":       "finished getting describe instances",
+		"num_hosts":     len(hosts),
+		"duration_secs": time.Since(startAt).Seconds(),
+	})
+
 	if err != nil {
 		return nil, errors.Wrap(err, "error describing instances")
 	}
@@ -205,6 +212,7 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 	}
 
 	// Return as an ordered slice of statuses
+	startAt = time.Now()
 	statuses := []CloudStatus{}
 	for _, h := range hosts {
 		status := ec2StatusToEvergreenStatus(*instanceMap[h.Id].State.Name)
@@ -217,6 +225,11 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 		}
 		statuses = append(statuses, status)
 	}
+	grip.Debug(message.Fields{
+		"message":       "finished caching host data",
+		"num_hosts":     len(hosts),
+		"duration_secs": time.Since(startAt).Seconds(),
+	})
 	return statuses, nil
 }
 

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -212,8 +212,9 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 	}
 
 	// Return as an ordered slice of statuses
-	startAt = time.Now()
+	runningHosts := 0
 	statuses := []CloudStatus{}
+	startAt = time.Now()
 	for _, h := range hosts {
 		status := ec2StatusToEvergreenStatus(*instanceMap[h.Id].State.Name)
 		if status == StatusRunning {
@@ -222,13 +223,14 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 				"message": "can't update host cached data",
 				"host_id": h.Id,
 			}))
+			runningHosts += 1
 		}
 		statuses = append(statuses, status)
 	}
 	grip.Debug(message.Fields{
-		"message":       "finished caching host data",
-		"num_hosts":     len(hosts),
-		"duration_secs": time.Since(startAt).Seconds(),
+		"message":           "finished caching host data",
+		"num_hosts_running": runningHosts,
+		"duration_secs":     time.Since(startAt).Seconds(),
 	})
 	return statuses, nil
 }

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -100,8 +100,11 @@ clientsLoop:
 			return
 		}
 		if batch, ok := m.(cloud.BatchManager); ok {
+			statusesCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer cancel()
+
 			startAt := time.Now()
-			statuses, err := batch.GetInstanceStatuses(ctx, hosts)
+			statuses, err := batch.GetInstanceStatuses(statusesCtx, hosts)
 			grip.Debug(message.Fields{
 				"message":       "finished getting instance statuses",
 				"num_hosts":     len(hosts),
@@ -126,8 +129,11 @@ clientsLoop:
 			continue clientsLoop
 		}
 		for _, h := range hosts {
+			statusCtx, cancel := context.WithTimeout(ctx, time.Minute)
+			defer cancel()
+
 			startAt := time.Now()
-			cloudStatus, err := m.GetInstanceStatus(ctx, &h)
+			cloudStatus, err := m.GetInstanceStatus(statusCtx, &h)
 			grip.Debug(message.Fields{
 				"message":       "finished getting instance status",
 				"host_id":       h.Id,

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -130,10 +130,9 @@ clientsLoop:
 		}
 		for _, h := range hosts {
 			statusCtx, cancel := context.WithTimeout(ctx, time.Minute)
-			defer cancel()
-
 			startAt := time.Now()
 			cloudStatus, err := m.GetInstanceStatus(statusCtx, &h)
+			cancel()
 			grip.Debug(message.Fields{
 				"message":       "finished getting instance status",
 				"host_id":       h.Id,


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13763

I set the max backoff to 10 seconds, in `utility.Retry` it defaults to `min * 2^maxAttempts` which in this case would be 1024 secs.