### PR TITLE
EVG-7778: Recommit test stats passthrough

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -22,6 +22,8 @@ type HandlerOpts struct {
 // the api to the router.
 func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	sc := &data.DBConnector{}
+	env := evergreen.GetEnvironment()
+	settings := env.Settings()
 
 	sc.SetURL(opts.URL)
 
@@ -48,9 +50,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	editDistroSettings := RequiresDistroPermission(evergreen.PermissionDistroSettings, evergreen.DistroSettingsEdit)
 	removeDistroSettings := RequiresDistroPermission(evergreen.PermissionDistroSettings, evergreen.DistroSettingsAdmin)
 	editHosts := RequiresDistroPermission(evergreen.PermissionHosts, evergreen.HostsEdit)
-
-	env := evergreen.GetEnvironment()
-	settings := env.Settings()
+	cedarTestStats := checkCedarTestStats(settings)
 
 	// Routes
 	app.AddRoute("/").Version(2).Get().RouteHandler(makePlaceHolderManger(sc))
@@ -152,7 +152,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}/revisions/{commit_hash}/tasks").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeTasksByProjectAndCommitHandler(sc))
 	app.AddRoute("/projects/{project_id}/task_reliability").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetProjectTaskReliability(sc))
 	app.AddRoute("/projects/{project_id}/task_stats").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeGetProjectTaskStats(sc))
-	app.AddRoute("/projects/{project_id}/test_stats").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeGetProjectTestStats(sc))
+	app.AddRoute("/projects/{project_id}/test_stats").Version(2).Get().Wrap(checkUser, viewTasks, cedarTestStats).RouteHandler(makeGetProjectTestStats(sc))
 	app.AddRoute("/projects/{project_id}/versions").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeGetProjectVersionsHandler(sc))
 	app.AddRoute("/projects/{project_id}/versions/tasks").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchProjectTasks(sc))
 	app.AddRoute("/projects/{project_id}/patch_trigger_aliases").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchPatchTriggerAliases(sc))

--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -4,6 +4,8 @@ package route
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -15,6 +17,9 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -483,4 +488,58 @@ func (tsh *taskStatsHandler) Run(ctx context.Context) gimlet.Responder {
 
 func makeGetProjectTaskStats(sc data.Connector) gimlet.RouteHandler {
 	return &taskStatsHandler{sc: sc}
+}
+
+type cedarTestStatsMiddleware struct {
+	settings *evergreen.Settings
+}
+
+func checkCedarTestStats(settings *evergreen.Settings) gimlet.Middleware {
+	return &cedarTestStatsMiddleware{
+		settings: settings,
+	}
+}
+
+func (m *cedarTestStatsMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	ctx := r.Context()
+
+	newURL := fmt.Sprintf(
+		"https://%s/rest/v1/historical_test_data/%s?%s",
+		m.settings.Cedar.BaseURL,
+		gimlet.GetVars(r)["project_id"],
+		r.URL.RawQuery,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, newURL, nil)
+	if err != nil {
+		gimlet.WriteResponse(rw, gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "problem creating cedar test stats request")))
+		return
+	}
+
+	c := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(c)
+
+	resp, err := c.Do(req)
+	if err != nil {
+		gimlet.WriteResponse(rw, gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "problem sending test stats request to cedar")))
+		return
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode == http.StatusOK {
+		for key, vals := range resp.Header {
+			for _, val := range vals {
+				rw.Header().Add(key, val)
+			}
+		}
+		_, err = io.Copy(rw, resp.Body)
+		grip.Error(message.WrapError(err, message.Fields{
+			"route":      "/projects/{project_id}/test_stats",
+			"message":    "problem copying cedar test stats",
+			"project_id": gimlet.GetVars(r)["project_id"],
+		}))
+		return
+	}
+
+	next(rw, r)
 }

--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -509,11 +509,12 @@ func (m *cedarTestStatsMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Req
 		gimlet.GetVars(r)["project_id"],
 		r.URL.RawQuery,
 	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, newURL, nil)
+	req, err := http.NewRequest(http.MethodGet, newURL, nil)
 	if err != nil {
 		gimlet.WriteResponse(rw, gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "problem creating cedar test stats request")))
 		return
 	}
+	req = req.WithContext(ctx)
 
 	c := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(c)


### PR DESCRIPTION
This has no code changes, just recommits what was reverted. Cedar now returns 404s when it cannot find historical test data, which will then cause this route to fall back to the legacy evg test stats lookup.