### PR TITLE
EVG-14047 fix wrong sort logic on patch tasks table

### DIFF
--- a/graphql/tests/patchTasks/queries/sorts.graphql
+++ b/graphql/tests/patchTasks/queries/sorts.graphql
@@ -1,0 +1,23 @@
+{
+  patchTasks(
+    patchId: "5e4ff3abe3c3317e352062e4"
+    limit: 50
+    page: 0
+    sorts: [
+      { Key: STATUS, Direction: ASC }
+      { Key: BASE_STATUS, Direction: DESC }
+    ]
+  ) {
+    tasks {
+      id
+      status
+      baseTask {
+        status
+      }
+      displayName
+      buildVariant
+      blocked
+    }
+    count
+  }
+}

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -32,6 +32,78 @@
       }
     },
     {
+      "query_file": "sorts.graphql",
+      "result": {
+        "data": {
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "4",
+                "status": "task-timed-out",
+                "baseTask": {
+                  "status": "success"
+                },
+                "displayName": "compile",
+                "buildVariant": "windows",
+                "blocked": false
+              },
+              {
+                "id": "2",
+                "status": "failed",
+                "baseTask": {
+                  "status": "failed"
+                },
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604",
+                "blocked": false
+              },
+              {
+                "id": "1.5",
+                "status": "system-failed",
+                "baseTask": {
+                  "status": "success"
+                },
+                "displayName": "compile",
+                "buildVariant": "windows",
+                "blocked": false
+              },
+              {
+                "id": "4.5",
+                "status": "system-failed",
+                "baseTask": {
+                  "status": "success"
+                },
+                "displayName": "compile",
+                "buildVariant": "windows",
+                "blocked": false
+              },
+              {
+                "id": "1",
+                "status": "success",
+                "baseTask": {
+                  "status": "success"
+                },
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604",
+                "blocked": true
+              },
+              {
+                "id": "3",
+                "status": "success",
+                "baseTask": {
+                  "status": "failed"
+                },
+                "displayName": "lint",
+                "buildVariant": "windows",
+                "blocked": false
+              }
+            ],
+            "count": 6
+          }
+        }
+      }
+    },
+    {
       "query_file": "filter-by-variant.graphql",
       "result": {
         "data": {
@@ -437,18 +509,18 @@
                 "buildVariant": "windows"
               },
               {
-                "id": "4",
-                "status": "task-timed-out",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
-              },
-              {
                 "id": "2",
                 "status": "failed",
                 "baseStatus": "failed",
                 "displayName": "test-cloud",
                 "buildVariant": "ubuntu1604"
+              },
+              {
+                "id": "4",
+                "status": "task-timed-out",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
               }
             ],
             "count": 6

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2750,7 +2750,6 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 			if singleSort.Key == DisplayStatusKey || singleSort.Key == BaseTaskStatusKey {
 				pipeline = append(pipeline, addStatusColorSort((singleSort.Key)))
 				sortFields = append(sortFields, bson.E{Key: "__" + singleSort.Key, Value: singleSort.Order})
-				sortFields = append(sortFields, bson.E{Key: singleSort.Key, Value: singleSort.Order})
 			} else {
 				sortFields = append(sortFields, bson.E{Key: singleSort.Key, Value: singleSort.Order})
 			}


### PR DESCRIPTION
I had left a line of code in from the old sort logic, so that's gone now. I still need to remove the old sort parameter in the schema, but that needs to happen after spruce switches to the new array sorting param on the patch tasks table