### PR TITLE
EVG-14022 record generate.tasks errors

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -756,7 +756,7 @@ func MarkGeneratedTasks(taskID string) error {
 	return errors.Wrap(err, "problem marking generate.tasks complete")
 }
 
-// MarkGeneratedTasksErr marks that the taask hit errors generating tasks.
+// MarkGeneratedTasksErr marks that the task hit errors generating tasks.
 func MarkGeneratedTasksErr(taskID string, errorToSet error) error {
 	if errorToSet == nil || adb.ResultsNotFound(errorToSet) || db.IsDuplicateKey(errorToSet) {
 		return nil

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -762,7 +762,8 @@ func MarkGeneratedTasksErr(taskID string, errorToSet error) error {
 		return nil
 	}
 	query := bson.M{
-		IdKey: taskID,
+		IdKey:             taskID,
+		GeneratedTasksKey: bson.M{"$exists": false},
 	}
 	update := bson.M{
 		"$set": bson.M{

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1786,33 +1786,24 @@ func TestMarkGeneratedTasks(t *testing.T) {
 
 	mockError := errors.New("mock error")
 
-	require.NoError(t, MarkGeneratedTasks(t1.Id, nil))
+	require.NoError(t, MarkGeneratedTasks(t1.Id))
 	found, err := FindOneId(t1.Id)
 	require.NoError(t, err)
 	require.Equal(t, true, found.GeneratedTasks)
 	require.Equal(t, "", found.GenerateTasksError)
 
-	require.NoError(t, MarkGeneratedTasks(t1.Id, mockError))
+	require.NoError(t, MarkGeneratedTasks(t1.Id))
+	require.NoError(t, MarkGeneratedTasksErr(t1.Id, mockError))
 	found, err = FindOneId(t1.Id)
 	require.NoError(t, err)
 	require.Equal(t, true, found.GeneratedTasks)
 	require.Equal(t, "", found.GenerateTasksError, "calling after GeneratedTasks is set should not set an error")
 
-	t2 := &Task{
-		Id: "t2",
-	}
-	require.NoError(t, t2.Insert())
-	require.NoError(t, MarkGeneratedTasks(t2.Id, mockError))
-	found, err = FindOneId(t2.Id)
-	require.NoError(t, err)
-	require.Equal(t, true, found.GeneratedTasks)
-	require.Equal(t, mockError.Error(), found.GenerateTasksError)
-
 	t3 := &Task{
 		Id: "t3",
 	}
 	require.NoError(t, t3.Insert())
-	require.NoError(t, MarkGeneratedTasks(t3.Id, mongo.ErrNoDocuments))
+	require.NoError(t, MarkGeneratedTasksErr(t3.Id, mongo.ErrNoDocuments))
 	found, err = FindOneId(t3.Id)
 	require.NoError(t, err)
 	require.Equal(t, false, found.GeneratedTasks, "document not found should not set generated tasks, since this was a race and did not generate.tasks")
@@ -1823,7 +1814,7 @@ func TestMarkGeneratedTasks(t *testing.T) {
 	}
 	dupError := errors.New("duplicate key error")
 	require.NoError(t, t4.Insert())
-	require.NoError(t, MarkGeneratedTasks(t4.Id, dupError))
+	require.NoError(t, MarkGeneratedTasksErr(t4.Id, dupError))
 	found, err = FindOneId(t4.Id)
 	require.NoError(t, err)
 	require.Equal(t, false, found.GeneratedTasks, "duplicate key error should not set generated tasks, since this was a race and did not generate.tasks")

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -76,7 +76,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		return errors.Wrapf(err, "error finding version %s", t.Version)
 	}
 	if v == nil {
-		return errors.Wrapf(err, "unable to find version %s", t.Version)
+		return errors.Errorf("unable to find version %s", t.Version)
 	}
 	p, pp, err := model.LoadProjectForVersion(v, t.Project, false)
 	if err != nil {
@@ -288,9 +288,10 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 
 	if err != nil && !shouldNoop {
 		j.AddError(err)
+		j.AddError(task.MarkGeneratedTasksErr(j.TaskID, err))
 		return
 	}
-	j.AddError(task.MarkGeneratedTasks(j.TaskID, err))
+	j.AddError(task.MarkGeneratedTasks(j.TaskID))
 }
 
 func parseProjectsAsString(jsonStrings []string) ([]model.GeneratedProject, error) {

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -392,4 +392,5 @@ func TestMarkGeneratedTasksError(t *testing.T) {
 	dbTask, err := task.FindOneId(sampleTask.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, "unable to find version sample_version", dbTask.GenerateTasksError)
+	assert.False(t, dbTask.GeneratedTasks)
 }

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -372,3 +372,24 @@ buildvariants:
 	}
 	assert.True(foundGeneratedtask)
 }
+
+func TestMarkGeneratedTasksError(t *testing.T) {
+	require.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.VersionCollection, build.Collection, task.Collection, distro.Collection, patch.Collection, model.ParserProjectCollection))
+	sampleTask := task.Task{
+		Id:                    "sample_task",
+		Version:               "sample_version",
+		BuildId:               "sample_build_id",
+		Project:               "mci",
+		DisplayName:           "sample_task",
+		GeneratedJSONAsString: sampleGeneratedProject,
+		Status:                evergreen.TaskStarted,
+	}
+	require.NoError(t, sampleTask.Insert())
+
+	j := NewGenerateTasksJob(sampleTask.Id, "1")
+	j.Run(context.Background())
+	assert.Error(t, j.Error())
+	dbTask, err := task.FindOneId(sampleTask.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, "unable to find version sample_version", dbTask.GenerateTasksError)
+}


### PR DESCRIPTION
my approach was to split the steps to mark that a task has generated tasks with errors from it, so that we can record errors without having to mark generation complete