### PR TITLE
EVG-14048: change owner of shell profile files to distro user

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1047,7 +1047,7 @@ func (h *Host) SpawnHostSetupCommands(settings *evergreen.Settings) (string, err
 // spawnHostSetupConfigDirCommands the shell script that sets up the
 // config directory on a spawn host. In particular, it makes the client binary
 // directory, puts both the evergreen yaml and the client into it, and attempts
-// to add the directory to the path.,
+// to add the directory to the path.
 func (h *Host) spawnHostSetupConfigDirCommands(conf []byte) string {
 	return strings.Join([]string{
 		fmt.Sprintf("mkdir -m 777 -p %s", h.spawnHostConfigDir()),

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1147,7 +1147,8 @@ func TestSpawnHostSetupCommands(t *testing.T) {
 		" && echo \"user: user\napi_key: key\napi_server_host: www.example0.com/api\nui_server_host: www.example1.com\n\" > /home/user/.evergreen.yml" +
 		" && chmod +x /home/user/evergreen" +
 		" && cp /home/user/evergreen /home/user/cli_bin" +
-		" && (echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.profile || true; echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.bash_profile || true)"
+		" && (echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.profile || true; echo '\nexport PATH=\"${PATH}:/home/user/cli_bin\"\n' >> /home/user/.bash_profile || true)" +
+		" && (sudo chown -R user /home/user/.profile /home/user/.bash_profile || true)"
 	assert.Equal(t, expected, cmd)
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14048

`~/.profile` and `~/.bash_profile` might be owned by root since the user data script runs as root, so change it back to the regular distro  user.