### PR TITLE
EVG-14047 remove obsolete sort param

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -481,7 +481,7 @@ type ComplexityRoot struct {
 		MyVolumes               func(childComplexity int) int
 		Patch                   func(childComplexity int, id string) int
 		PatchBuildVariants      func(childComplexity int, patchID string) int
-		PatchTasks              func(childComplexity int, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, sorts []*SortOrder, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) int
+		PatchTasks              func(childComplexity int, patchID string, sorts []*SortOrder, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) int
 		Project                 func(childComplexity int, projectID string) int
 		Projects                func(childComplexity int) int
 		SpruceConfig            func(childComplexity int) int
@@ -838,7 +838,7 @@ type QueryResolver interface {
 	Patch(ctx context.Context, id string) (*model.APIPatch, error)
 	Projects(ctx context.Context) (*Projects, error)
 	Project(ctx context.Context, projectID string) (*model.APIProjectRef, error)
-	PatchTasks(ctx context.Context, patchID string, sortBy *TaskSortCategory, sortDir *SortDirection, sorts []*SortOrder, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) (*PatchTasks, error)
+	PatchTasks(ctx context.Context, patchID string, sorts []*SortOrder, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string) (*PatchTasks, error)
 	TaskTests(ctx context.Context, taskID string, execution *int, sortCategory *TestSortCategory, sortDirection *SortDirection, page *int, limit *int, testName *string, statuses []string) (*TaskTestResult, error)
 	TaskFiles(ctx context.Context, taskID string, execution *int) (*TaskFiles, error)
 	User(ctx context.Context, userID *string) (*model.APIDBUser, error)
@@ -3065,7 +3065,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.PatchTasks(childComplexity, args["patchId"].(string), args["sortBy"].(*TaskSortCategory), args["sortDir"].(*SortDirection), args["sorts"].([]*SortOrder), args["page"].(*int), args["limit"].(*int), args["statuses"].([]string), args["baseStatuses"].([]string), args["variant"].(*string), args["taskName"].(*string)), true
+		return e.complexity.Query.PatchTasks(childComplexity, args["patchId"].(string), args["sorts"].([]*SortOrder), args["page"].(*int), args["limit"].(*int), args["statuses"].([]string), args["baseStatuses"].([]string), args["variant"].(*string), args["taskName"].(*string)), true
 
 	case "Query.project":
 		if e.complexity.Query.Project == nil {
@@ -4578,8 +4578,6 @@ var sources = []*ast.Source{
   project(projectId: String!): Project!
   patchTasks(
     patchId: String!
-    sortBy: TaskSortCategory = STATUS
-    sortDir: SortDirection = ASC
     sorts: [SortOrder!]
     page: Int = 0
     limit: Int = 0
@@ -6460,78 +6458,62 @@ func (ec *executionContext) field_Query_patchTasks_args(ctx context.Context, raw
 		}
 	}
 	args["patchId"] = arg0
-	var arg1 *TaskSortCategory
-	if tmp, ok := rawArgs["sortBy"]; ok {
-		arg1, err = ec.unmarshalOTaskSortCategory2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskSortCategory(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["sortBy"] = arg1
-	var arg2 *SortDirection
-	if tmp, ok := rawArgs["sortDir"]; ok {
-		arg2, err = ec.unmarshalOSortDirection2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortDirection(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["sortDir"] = arg2
-	var arg3 []*SortOrder
+	var arg1 []*SortOrder
 	if tmp, ok := rawArgs["sorts"]; ok {
-		arg3, err = ec.unmarshalOSortOrder2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortOrderᚄ(ctx, tmp)
+		arg1, err = ec.unmarshalOSortOrder2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSortOrderᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["sorts"] = arg3
-	var arg4 *int
+	args["sorts"] = arg1
+	var arg2 *int
 	if tmp, ok := rawArgs["page"]; ok {
-		arg4, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		arg2, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["page"] = arg4
-	var arg5 *int
+	args["page"] = arg2
+	var arg3 *int
 	if tmp, ok := rawArgs["limit"]; ok {
-		arg5, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		arg3, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["limit"] = arg5
-	var arg6 []string
+	args["limit"] = arg3
+	var arg4 []string
 	if tmp, ok := rawArgs["statuses"]; ok {
-		arg6, err = ec.unmarshalOString2ᚕstringᚄ(ctx, tmp)
+		arg4, err = ec.unmarshalOString2ᚕstringᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["statuses"] = arg6
-	var arg7 []string
+	args["statuses"] = arg4
+	var arg5 []string
 	if tmp, ok := rawArgs["baseStatuses"]; ok {
-		arg7, err = ec.unmarshalOString2ᚕstringᚄ(ctx, tmp)
+		arg5, err = ec.unmarshalOString2ᚕstringᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["baseStatuses"] = arg7
-	var arg8 *string
+	args["baseStatuses"] = arg5
+	var arg6 *string
 	if tmp, ok := rawArgs["variant"]; ok {
-		arg8, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		arg6, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["variant"] = arg8
-	var arg9 *string
+	args["variant"] = arg6
+	var arg7 *string
 	if tmp, ok := rawArgs["taskName"]; ok {
-		arg9, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		arg7, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["taskName"] = arg9
+	args["taskName"] = arg7
 	return args, nil
 }
 
@@ -15724,7 +15706,7 @@ func (ec *executionContext) _Query_patchTasks(ctx context.Context, field graphql
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().PatchTasks(rctx, args["patchId"].(string), args["sortBy"].(*TaskSortCategory), args["sortDir"].(*SortDirection), args["sorts"].([]*SortOrder), args["page"].(*int), args["limit"].(*int), args["statuses"].([]string), args["baseStatuses"].([]string), args["variant"].(*string), args["taskName"].(*string))
+		return ec.resolvers.Query().PatchTasks(rctx, args["patchId"].(string), args["sorts"].([]*SortOrder), args["page"].(*int), args["limit"].(*int), args["statuses"].([]string), args["baseStatuses"].([]string), args["variant"].(*string), args["taskName"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -32292,30 +32274,6 @@ func (ec *executionContext) marshalOTaskEndDetail2githubᚗcomᚋevergreenᚑci�
 
 func (ec *executionContext) marshalOTaskInfo2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐTaskInfo(ctx context.Context, sel ast.SelectionSet, v model.TaskInfo) graphql.Marshaler {
 	return ec._TaskInfo(ctx, sel, &v)
-}
-
-func (ec *executionContext) unmarshalOTaskSortCategory2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskSortCategory(ctx context.Context, v interface{}) (TaskSortCategory, error) {
-	var res TaskSortCategory
-	return res, res.UnmarshalGQL(v)
-}
-
-func (ec *executionContext) marshalOTaskSortCategory2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskSortCategory(ctx context.Context, sel ast.SelectionSet, v TaskSortCategory) graphql.Marshaler {
-	return v
-}
-
-func (ec *executionContext) unmarshalOTaskSortCategory2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskSortCategory(ctx context.Context, v interface{}) (*TaskSortCategory, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalOTaskSortCategory2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskSortCategory(ctx, v)
-	return &res, err
-}
-
-func (ec *executionContext) marshalOTaskSortCategory2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskSortCategory(ctx context.Context, sel ast.SelectionSet, v *TaskSortCategory) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return v
 }
 
 func (ec *executionContext) unmarshalOTestSortCategory2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTestSortCategory(ctx context.Context, v interface{}) (TestSortCategory, error) {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -14,8 +14,6 @@ type Query {
   project(projectId: String!): Project!
   patchTasks(
     patchId: String!
-    sortBy: TaskSortCategory = STATUS
-    sortDir: SortDirection = ASC
     sorts: [SortOrder!]
     page: Int = 0
     limit: Int = 0

--- a/graphql/tests/patchTasks-aborted/results.json
+++ b/graphql/tests/patchTasks-aborted/results.json
@@ -1,101 +1,100 @@
 {
-    "tests": [
-      {
-        "query_file": "filter-by-failed.graphql",
-        "result": {
-          "data": {
-            "patchTasks": {
-              "tasks": [
-                {
-                    "id": "1.5"
-                },
-                {
-                    "id": "4.5"
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "query_file": "filter-by-aborted.graphql",
-        "result": {
-          "data": {
-            "patchTasks": {
-              "tasks": [
-                {
-                    "id": "2"
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "query_file": "filter-by-multiple-statuses.graphql",
-        "result": {
-          "data": {
-            "patchTasks": {
-              "tasks": [
-                {
-                    "id": "1.5"
-                },
-                {
-                    "id": "4.5"
-                },
-                {
-                    "id": "2"
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "query_file": "filter-by-aborted-base-status.graphql",
-        "result": {
-          "data": {
-            "patchTasks": {
-              "tasks": [
-                {
-                    "id": "2"
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "query_file": "filter-by-failed-base-status.graphql",
-        "result": {
-          "data": {
-            "patchTasks": {
-              "tasks": [
-                {
-                    "id": "1"
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "query_file": "filter-by-multiple-base-statuses.graphql",
-        "result": {
-          "data": {
-            "patchTasks": {
-              "tasks": [
-                {
-                  "id": "2"
-                },
-                {
-                  "id": "1"
-                }
-              ]
-            }
+  "tests": [
+    {
+      "query_file": "filter-by-failed.graphql",
+      "result": {
+        "data": {
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "1.5"
+              },
+              {
+                "id": "4.5"
+              }
+            ]
           }
         }
       }
-    ]
-  }
-  
+    },
+    {
+      "query_file": "filter-by-aborted.graphql",
+      "result": {
+        "data": {
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "filter-by-multiple-statuses.graphql",
+      "result": {
+        "data": {
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "1.5"
+              },
+              {
+                "id": "2"
+              },
+              {
+                "id": "4.5"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "filter-by-aborted-base-status.graphql",
+      "result": {
+        "data": {
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "2"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "filter-by-failed-base-status.graphql",
+      "result": {
+        "data": {
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "1"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "filter-by-multiple-base-statuses.graphql",
+      "result": {
+        "data": {
+          "patchTasks": {
+            "tasks": [
+              {
+                "id": "1"
+              },
+              {
+                "id": "2"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/graphql/tests/patchTasks/queries/all-params.graphql
+++ b/graphql/tests/patchTasks/queries/all-params.graphql
@@ -3,8 +3,7 @@
     patchId: "5e4ff3abe3c3317e352062e4"
     limit: 2
     page: 0
-    sortDir: DESC
-    sortBy: VARIANT
+    sorts: [{ Key: VARIANT, Direction: DESC }]
     variant: "ubuntu1604"
     taskName: "party"
   ) {

--- a/graphql/tests/patchTasks/queries/sort-base-status-descending.graphql
+++ b/graphql/tests/patchTasks/queries/sort-base-status-descending.graphql
@@ -1,8 +1,7 @@
 {
   patchTasks(
     patchId: "5e4ff3abe3c3317e352062e4"
-    sortBy: BASE_STATUS
-    sortDir: DESC
+    sorts: [{ Key: BASE_STATUS, Direction: DESC }]
   ) {
     tasks {
       id

--- a/graphql/tests/patchTasks/queries/sort-by-base-status.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-base-status.graphql
@@ -1,5 +1,8 @@
 {
-  patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: BASE_STATUS) {
+  patchTasks(
+    patchId: "5e4ff3abe3c3317e352062e4"
+    sorts: [{ Key: BASE_STATUS, Direction: ASC }]
+  ) {
     tasks {
       id
       baseStatus

--- a/graphql/tests/patchTasks/queries/sort-by-name.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-name.graphql
@@ -1,5 +1,8 @@
 {
-  patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: NAME) {
+  patchTasks(
+    patchId: "5e4ff3abe3c3317e352062e4"
+    sorts: [{ Key: NAME, Direction: ASC }]
+  ) {
     tasks {
       id
       displayName

--- a/graphql/tests/patchTasks/queries/sort-by-status.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-status.graphql
@@ -1,5 +1,8 @@
 {
-  patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: STATUS) {
+  patchTasks(
+    patchId: "5e4ff3abe3c3317e352062e4"
+    sorts: [{ Key: STATUS, Direction: ASC }]
+  ) {
     tasks {
       id
       status

--- a/graphql/tests/patchTasks/queries/sort-by-variant.graphql
+++ b/graphql/tests/patchTasks/queries/sort-by-variant.graphql
@@ -1,5 +1,8 @@
 {
-  patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortBy: VARIANT) {
+  patchTasks(
+    patchId: "5e4ff3abe3c3317e352062e4"
+    sorts: [{ Key: VARIANT, Direction: ASC }]
+  ) {
     tasks {
       id
       buildVariant

--- a/graphql/tests/patchTasks/queries/sort-descending.graphql
+++ b/graphql/tests/patchTasks/queries/sort-descending.graphql
@@ -1,5 +1,8 @@
 {
-  patchTasks(patchId: "5e4ff3abe3c3317e352062e4", sortDir: DESC) {
+  patchTasks(
+    patchId: "5e4ff3abe3c3317e352062e4"
+    sorts: [{ Key: STATUS, Direction: DESC }]
+  ) {
     tasks {
       id
       status

--- a/graphql/tests/patchTasks/results.json
+++ b/graphql/tests/patchTasks/results.json
@@ -18,12 +18,12 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "2",
-                "displayName": "test-cloud"
-              },
-              {
                 "id": "1",
                 "displayName": "test-thirdparty-docker"
+              },
+              {
+                "id": "2",
+                "displayName": "test-cloud"
               }
             ],
             "count": 2
@@ -110,16 +110,16 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "4"
-              },
-              {
                 "id": "1.5"
               },
               {
-                "id": "4.5"
+                "id": "3"
               },
               {
-                "id": "3"
+                "id": "4"
+              },
+              {
+                "id": "4.5"
               }
             ],
             "count": 4
@@ -134,16 +134,16 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "4"
-              },
-              {
                 "id": "1.5"
               },
               {
-                "id": "4.5"
+                "id": "3"
               },
               {
-                "id": "3"
+                "id": "4"
+              },
+              {
+                "id": "4.5"
               }
             ],
             "count": 4
@@ -169,18 +169,11 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "2",
-                "status": "failed",
-                "baseStatus": "failed",
-                "displayName": "test-cloud",
-                "buildVariant": "ubuntu1604"
-              },
-              {
-                "id": "4",
-                "status": "task-timed-out",
+                "id": "1",
+                "status": "success",
                 "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "displayName": "test-thirdparty-docker",
+                "buildVariant": "ubuntu1604"
               },
               {
                 "id": "1.5",
@@ -190,17 +183,10 @@
                 "buildVariant": "windows"
               },
               {
-                "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
-              },
-              {
-                "id": "1",
-                "status": "success",
-                "baseStatus": "success",
-                "displayName": "test-thirdparty-docker",
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
                 "buildVariant": "ubuntu1604"
               },
               {
@@ -208,6 +194,20 @@
                 "status": "success",
                 "baseStatus": "failed",
                 "displayName": "lint",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "4",
+                "status": "task-timed-out",
+                "baseStatus": "success",
+                "displayName": "compile",
+                "buildVariant": "windows"
+              },
+              {
+                "id": "4.5",
+                "status": "system-failed",
+                "baseStatus": "success",
+                "displayName": "compile",
                 "buildVariant": "windows"
               }
             ],
@@ -588,12 +588,12 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "2",
-                "status": "failed"
-              },
-              {
                 "id": "1",
                 "status": "success"
+              },
+              {
+                "id": "2",
+                "status": "failed"
               },
               {
                 "id": "3",
@@ -612,15 +612,15 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "2",
-                "status": "failed",
-                "baseStatus": "failed",
-                "displayName": "test-cloud",
+                "id": "1",
+                "status": "success",
+                "baseStatus": "success",
+                "displayName": "test-thirdparty-docker",
                 "buildVariant": "ubuntu1604"
               },
               {
-                "id": "4",
-                "status": "task-timed-out",
+                "id": "1.5",
+                "status": "system-failed",
                 "baseStatus": "success",
                 "displayName": "compile",
                 "buildVariant": "windows"
@@ -638,17 +638,17 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "1.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
-                "buildVariant": "windows"
+                "id": "2",
+                "status": "failed",
+                "baseStatus": "failed",
+                "displayName": "test-cloud",
+                "buildVariant": "ubuntu1604"
               },
               {
-                "id": "4.5",
-                "status": "system-failed",
-                "baseStatus": "success",
-                "displayName": "compile",
+                "id": "3",
+                "status": "success",
+                "baseStatus": "failed",
+                "displayName": "lint",
                 "buildVariant": "windows"
               }
             ],
@@ -694,11 +694,7 @@
           "patchTasks": {
             "tasks": [
               {
-                "id": "2",
-                "executionTasksFull": null
-              },
-              {
-                "id": "4",
+                "id": "1",
                 "executionTasksFull": null
               },
               {
@@ -711,15 +707,19 @@
                 ]
               },
               {
-                "id": "4.5",
-                "executionTasksFull": null
-              },
-              {
-                "id": "1",
+                "id": "2",
                 "executionTasksFull": null
               },
               {
                 "id": "3",
+                "executionTasksFull": null
+              },
+              {
+                "id": "4",
+                "executionTasksFull": null
+              },
+              {
+                "id": "4.5",
                 "executionTasksFull": null
               }
             ]

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -126,7 +126,7 @@ type Connector interface {
 	FindTestsByTaskId(string, string, string, string, int, int) ([]testresult.TestResult, error)
 	FindTestsByTaskIdFilterSortPaginate(string, string, []string, string, int, int, int, int) ([]testresult.TestResult, error)
 	GetTestCountByTaskIdAndFilters(string, string, []string, int) (int, error)
-	FindTasksByVersion(string, string, []string, []string, string, string, int, int, int, []string, []task.TasksSortOrder) ([]task.Task, int, error)
+	FindTasksByVersion(string, []string, []string, string, string, int, int, []string, []task.TasksSortOrder) ([]task.Task, int, error)
 	// FindUserById is a method to find a specific user given its ID.
 	FindUserById(string) (gimlet.User, error)
 	//FindUserByGithubName is a method to find a user given their Github name, if configured.

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -221,11 +221,7 @@ func (tc *DBTaskConnector) GetManifestByTask(taskId string) (*manifest.Manifest,
 
 // FindTasksByVersion gets all tasks for a specific version
 // Results can be filtered by task name, variant name and status in addition to being paginated and limited
-func (tc *DBTaskConnector) FindTasksByVersion(versionID, sortBy string, statuses []string, baseStatuses []string, variant string, taskName string, sortDir, page, limit int, fieldsToProject []string, sorts []task.TasksSortOrder) ([]task.Task, int, error) {
-	if sortBy != "" && sorts == nil {
-		sorts = []task.TasksSortOrder{}
-		sorts = append(sorts, task.TasksSortOrder{Key: sortBy, Order: sortDir})
-	}
+func (tc *DBTaskConnector) FindTasksByVersion(versionID string, statuses []string, baseStatuses []string, variant string, taskName string, page, limit int, fieldsToProject []string, sorts []task.TasksSortOrder) ([]task.Task, int, error) {
 	tasks, total, err := task.GetTasksByVersion(versionID, sorts, statuses, baseStatuses, variant, taskName, page, limit, fieldsToProject)
 	if err != nil {
 		return nil, 0, err
@@ -437,6 +433,6 @@ func (tc *MockTaskConnector) GetManifestByTask(taskId string) (*manifest.Manifes
 	return nil, errors.Errorf("task '%s' not found", taskId)
 }
 
-func (tc *MockTaskConnector) FindTasksByVersion(string, string, []string, []string, string, string, int, int, int, []string, []task.TasksSortOrder) ([]task.Task, int, error) {
+func (tc *MockTaskConnector) FindTasksByVersion(string, []string, []string, string, string, int, int, []string, []task.TasksSortOrder) ([]task.Task, int, error) {
 	return nil, 0, nil
 }


### PR DESCRIPTION
This removes the scalar sortBy and sortDir parameters in favor of the array one. Most of the random test ordering changes were due to the sorting respecting the default sort by ID if nothing else was specified