### PR TITLE
EVG-12476 add --reuse option for patch definitions

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2021-02-01"
+	ClientVersion = "2021-02-12"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2021-02-10"

--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -78,6 +78,8 @@ type cliIntent struct {
 
 	// BackportOf specifies what to backport
 	BackportOf BackportInfo `bson:"backport_of,omitempty"`
+
+	ReuseDefinition bool `bson:"reuse_definition"`
 }
 
 // BSON fields for the patches
@@ -149,6 +151,10 @@ func (c *cliIntent) ShouldFinalizePatch() bool {
 	return c.Finalize
 }
 
+func (c *cliIntent) ReusePreviousPatchDefinition() bool {
+	return c.ReuseDefinition
+}
+
 func (g *cliIntent) RequesterIdentity() string {
 	return evergreen.PatchVersionRequester
 }
@@ -184,20 +190,21 @@ func (c *cliIntent) NewPatch() *Patch {
 }
 
 type CLIIntentParams struct {
-	User           string
-	Project        string
-	BaseGitHash    string
-	Module         string
-	PatchContent   string
-	Description    string
-	Finalize       bool
-	BackportOf     BackportInfo
-	Parameters     []Parameter
-	Variants       []string
-	Tasks          []string
-	Alias          string
-	TriggerAliases []string
-	SyncParams     SyncAtEndOptions
+	User            string
+	Project         string
+	BaseGitHash     string
+	Module          string
+	PatchContent    string
+	Description     string
+	Finalize        bool
+	BackportOf      BackportInfo
+	Parameters      []Parameter
+	Variants        []string
+	Tasks           []string
+	Alias           string
+	TriggerAliases  []string
+	ReuseDefinition bool
+	SyncParams      SyncAtEndOptions
 }
 
 func NewCliIntent(params CLIIntentParams) (Intent, error) {
@@ -237,22 +244,23 @@ func NewCliIntent(params CLIIntentParams) (Intent, error) {
 	}
 
 	return &cliIntent{
-		DocumentID:     mgobson.NewObjectId().Hex(),
-		IntentType:     CliIntentType,
-		PatchContent:   params.PatchContent,
-		Description:    params.Description,
-		BuildVariants:  params.Variants,
-		Tasks:          params.Tasks,
-		Parameters:     params.Parameters,
-		SyncAtEndOpts:  params.SyncParams,
-		User:           params.User,
-		ProjectID:      params.Project,
-		BaseHash:       params.BaseGitHash,
-		Finalize:       params.Finalize,
-		Module:         params.Module,
-		Alias:          params.Alias,
-		TriggerAliases: params.TriggerAliases,
-		BackportOf:     params.BackportOf,
+		DocumentID:      mgobson.NewObjectId().Hex(),
+		IntentType:      CliIntentType,
+		PatchContent:    params.PatchContent,
+		Description:     params.Description,
+		BuildVariants:   params.Variants,
+		Tasks:           params.Tasks,
+		Parameters:      params.Parameters,
+		SyncAtEndOpts:   params.SyncParams,
+		User:            params.User,
+		ProjectID:       params.Project,
+		BaseHash:        params.BaseGitHash,
+		Finalize:        params.Finalize,
+		Module:          params.Module,
+		Alias:           params.Alias,
+		TriggerAliases:  params.TriggerAliases,
+		BackportOf:      params.BackportOf,
+		ReuseDefinition: params.ReuseDefinition,
 	}, nil
 }
 

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -151,14 +151,14 @@ func ByUserPaginated(user string, ts time.Time, limit int) db.Q {
 	}).Sort([]string{"-" + CreateTimeKey}).Limit(limit)
 }
 
-// ByUserProjectAndGitspec produces a query that returns patches by the given
-// patch author, project, and gitspec.
-func ByUserProjectAndGitspec(user string, project string, gitspec string) db.Q {
+// MostRecentPatchByUserAndProject returns the latest patch made by the user for the project.
+func MostRecentPatchByUserAndProject(user, project string) db.Q {
 	return db.Query(bson.M{
-		AuthorKey:  user,
-		ProjectKey: project,
-		GithashKey: gitspec,
-	})
+		AuthorKey:    user,
+		ProjectKey:   project,
+		ActivatedKey: true,
+		AliasKey:     bson.M{"$nin": []string{evergreen.GithubPRAlias, evergreen.CommitQueueAlias}},
+	}).Sort([]string{"-" + CreateTimeKey}).Limit(1)
 }
 
 // ByVersion produces a query that returns the patch for a given version.

--- a/model/patch/db_test.go
+++ b/model/patch/db_test.go
@@ -1,0 +1,71 @@
+package patch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/mgo.v2/bson"
+)
+
+func TestMostRecentByUserAndProject(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
+
+	now := time.Now()
+	previousPatch := Patch{
+		Id:         bson.NewObjectId(),
+		Project:    "correct",
+		Author:     "me",
+		CreateTime: now,
+		Activated:  true,
+	}
+	assert.NoError(t, previousPatch.Insert())
+	yourPatch := Patch{
+		Id:         bson.NewObjectId(),
+		Project:    "correct",
+		Author:     "you",
+		CreateTime: now,
+		Activated:  true,
+	}
+	assert.NoError(t, yourPatch.Insert())
+	notActivatedPatch := Patch{
+		Id:         bson.NewObjectId(),
+		Project:    "correct",
+		Author:     "you",
+		CreateTime: now,
+		Activated:  false,
+	}
+	assert.NoError(t, notActivatedPatch.Insert())
+	wrongPatch := Patch{
+		Id:         bson.NewObjectId(),
+		Project:    "wrong",
+		Author:     "me",
+		CreateTime: now,
+		Activated:  true,
+	}
+	assert.NoError(t, wrongPatch.Insert())
+	prPatch := Patch{
+		Id:         bson.NewObjectId(),
+		Project:    "correct",
+		Author:     "me",
+		CreateTime: now,
+		Alias:      evergreen.GithubPRAlias,
+		Activated:  true,
+	}
+	assert.NoError(t, prPatch.Insert())
+	oldPatch := Patch{
+		Id:         bson.NewObjectId(),
+		Project:    "correct",
+		Author:     "me",
+		CreateTime: now.Add(-time.Minute),
+		Activated:  true,
+	}
+	assert.NoError(t, oldPatch.Insert())
+
+	p, err := FindOne(MostRecentPatchByUserAndProject("me", "correct"))
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+	assert.Equal(t, p.Id, previousPatch.Id)
+}

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -205,6 +205,10 @@ func (g *githubIntent) ShouldFinalizePatch() bool {
 	return true
 }
 
+func (g *githubIntent) ReusePreviousPatchDefinition() bool {
+	return false
+}
+
 func (g *githubIntent) RequesterIdentity() string {
 	return evergreen.GithubPRRequester
 }

--- a/model/patch/intent.go
+++ b/model/patch/intent.go
@@ -31,6 +31,10 @@ type Intent interface {
 	// intent should be finalized
 	ShouldFinalizePatch() bool
 
+	// ReusePreviousPatchDefinition gives the patch the same tasks/variants
+	// as the previous patch submitted for this project by the user.
+	ReusePreviousPatchDefinition() bool
+
 	// GetAlias defines the variants and tasks this intent should run on.
 	GetAlias() string
 

--- a/model/patch/trigger_intent.go
+++ b/model/patch/trigger_intent.go
@@ -71,6 +71,10 @@ func (t *TriggerIntent) ShouldFinalizePatch() bool {
 	return t.ParentStatus == ""
 }
 
+func (t *TriggerIntent) ReusePreviousPatchDefinition() bool {
+	return false
+}
+
 func (t *TriggerIntent) GetAlias() string {
 	// triggers have no alias
 	return ""

--- a/model/project.go
+++ b/model/project.go
@@ -1223,6 +1223,19 @@ func (p *Project) FindTasksForVariant(build string) []string {
 	return nil
 }
 
+func (p *Project) FindDisplayTasksForVariant(build string) []string {
+	for _, b := range p.BuildVariants {
+		if b.Name == build {
+			displayTasks := make([]string, 0, len(b.DisplayTasks))
+			for _, dt := range b.DisplayTasks {
+				displayTasks = append(displayTasks, dt.Name)
+			}
+			return displayTasks
+		}
+	}
+	return nil
+}
+
 func (p *Project) FindAllVariants() []string {
 	variants := make([]string, 0, len(p.BuildVariants))
 	for _, b := range p.BuildVariants {

--- a/operations/http.go
+++ b/operations/http.go
@@ -524,6 +524,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		BackportInfo      patch.BackportInfo `json:"backport_info"`
 		TriggerAliases    []string           `json:"trigger_aliases"`
 		Parameters        []patch.Parameter  `json:"parameters"`
+		ReuseDefinition   bool               `json:"reuse_definition"`
 	}{
 		Description:       incomingPatch.description,
 		Project:           incomingPatch.projectName,
@@ -540,6 +541,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		BackportInfo:      incomingPatch.backportOf,
 		TriggerAliases:    incomingPatch.triggerAliases,
 		Parameters:        incomingPatch.parameters,
+		ReuseDefinition:   incomingPatch.reuseDefinition,
 	}
 
 	rPipe, wPipe := io.Pipe()

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -58,7 +58,7 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 			},
 			cli.BoolFlag{
 				Name:  reuseDefinitionFlag,
-				Usage: "use the same tasks/variants defined for the last patch scheduled for this project",
+				Usage: "use the same tasks/variants defined for the last patch you scheduled for this project",
 			},
 		))
 }

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -17,6 +17,7 @@ const (
 	patchDescriptionFlagName = "description"
 	patchVerboseFlagName     = "verbose"
 	patchTriggerAliasFlag    = "trigger-alias"
+	reuseDefinitionFlag      = "reuse"
 )
 
 func getPatchFlags(flags ...cli.Flag) []cli.Flag {
@@ -54,6 +55,10 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 			cli.StringSliceFlag{
 				Name:  patchTriggerAliasFlag,
 				Usage: "patch trigger alias (set by project admin) specifying tasks from other projects",
+			},
+			cli.BoolFlag{
+				Name:  reuseDefinitionFlag,
+				Usage: "use the same tasks/variants defined for the last patch scheduled for this project",
 			},
 		))
 }
@@ -99,6 +104,7 @@ func Patch() cli.Command {
 				Uncommitted:       c.Bool(uncommittedChangesFlag),
 				PreserveCommits:   c.Bool(preserveCommitsFlag),
 				TriggerAliases:    utility.SplitCommas(c.StringSlice(patchTriggerAliasFlag)),
+				ReuseDefinition:   c.Bool(reuseDefinitionFlag),
 			}
 
 			var err error
@@ -114,6 +120,9 @@ func Patch() cli.Command {
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
+			}
+			if params.ReuseDefinition && (len(params.Tasks) > 0 || len(params.Variants) > 0) {
+				return errors.Errorf("can't define tasks/variants when reusing previous patch's tasks and variants")
 			}
 
 			params.PreserveCommits = params.PreserveCommits || conf.PreserveCommits

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -74,6 +74,7 @@ type patchParams struct {
 	BackportOf        patch.BackportInfo
 	TriggerAliases    []string
 	Parameters        []patch.Parameter
+	ReuseDefinition   bool
 }
 
 type patchSubmission struct {
@@ -92,6 +93,7 @@ type patchSubmission struct {
 	parameters        []patch.Parameter
 	triggerAliases    []string
 	backportOf        patch.BackportInfo
+	reuseDefinition   bool
 }
 
 func (p *patchParams) createPatch(ac *legacyClient, diffData *localDiff) (*patch.Patch, error) {
@@ -111,6 +113,7 @@ func (p *patchParams) createPatch(ac *legacyClient, diffData *localDiff) (*patch
 		backportOf:        p.BackportOf,
 		parameters:        p.Parameters,
 		triggerAliases:    p.TriggerAliases,
+		reuseDefinition:   p.ReuseDefinition,
 	}
 
 	newPatch, err := ac.PutPatch(patchSub)

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -55,6 +55,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		Finalize          bool               `json:"finalize"`
 		TriggerAliases    []string           `json:"trigger_aliases"`
 		Alias             string             `json:"alias"`
+		ReuseDefinition   bool               `json:"reuse_definition"`
 	}{}
 	if err := utility.ReadJSON(util.NewRequestReaderWithSize(r, patch.SizeLimit), &data); err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, err)
@@ -107,19 +108,20 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	intent, err := patch.NewCliIntent(patch.CLIIntentParams{
-		User:           dbUser.Id,
-		Project:        pref.Id,
-		BaseGitHash:    data.Githash,
-		Module:         r.FormValue("module"),
-		PatchContent:   patchString,
-		Description:    data.Description,
-		Finalize:       data.Finalize,
-		Parameters:     data.Parameters,
-		Variants:       data.Variants,
-		Tasks:          data.Tasks,
-		Alias:          data.Alias,
-		TriggerAliases: data.TriggerAliases,
-		BackportOf:     data.BackportInfo,
+		User:            dbUser.Id,
+		Project:         pref.Id,
+		BaseGitHash:     data.Githash,
+		Module:          r.FormValue("module"),
+		PatchContent:    patchString,
+		Description:     data.Description,
+		Finalize:        data.Finalize,
+		Parameters:      data.Parameters,
+		Variants:        data.Variants,
+		Tasks:           data.Tasks,
+		Alias:           data.Alias,
+		TriggerAliases:  data.TriggerAliases,
+		BackportOf:      data.BackportInfo,
+		ReuseDefinition: data.ReuseDefinition,
 		SyncParams: patch.SyncAtEndOptions{
 			BuildVariants: data.SyncBuildVariants,
 			Tasks:         data.SyncTasks,
@@ -127,6 +129,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 			Timeout:       data.SyncTimeout,
 		},
 	})
+
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, err)
 		return

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/grip/sometimes"
 	"github.com/pkg/errors"
 	mgobson "gopkg.in/mgo.v2/bson"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -276,15 +276,10 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 
 	if j.intent.ReusePreviousPatchDefinition() {
-		var previousPatch *patch.Patch
-		previousPatch, err = patch.FindOne(patch.MostRecentPatchByUserAndProject(j.user.Username(), pref.Id))
+		patchDoc.VariantsTasks, err = j.getPreviousPatchDefinition(project)
 		if err != nil {
-			return errors.Wrap(err, "error querying for most recent patch")
+			return err
 		}
-		if previousPatch == nil {
-			return errors.Errorf("no previous patch available")
-		}
-		patchDoc.VariantsTasks = previousPatch.VariantsTasks
 	}
 
 	// verify that all variants exists
@@ -419,6 +414,40 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 
 	return catcher.Resolve()
+}
+
+func (j *patchIntentProcessor) getPreviousPatchDefinition(project *model.Project) ([]patch.VariantTasks, error) {
+	previousPatch, err := patch.FindOne(patch.MostRecentPatchByUserAndProject(j.user.Username(), project.Identifier))
+	if err != nil {
+		return nil, errors.Wrap(err, "error querying for most recent patch")
+	}
+	if previousPatch == nil {
+		return nil, errors.Errorf("no previous patch available")
+	}
+
+	var res []patch.VariantTasks
+	for _, vt := range previousPatch.VariantsTasks {
+		tasksInProjectVariant := project.FindTasksForVariant(vt.Variant)
+		displayTasksInProjectVariant := project.FindDisplayTasksForVariant(vt.Variant)
+
+		// I want the subset of vt.tasks that exists in tasksForVariant
+		tasks := utility.StringSliceIntersection(tasksInProjectVariant, vt.Tasks)
+		var displayTasks []patch.DisplayTask
+		for _, dt := range vt.DisplayTasks {
+			if utility.StringSliceContains(displayTasksInProjectVariant, dt.Name) {
+				displayTasks = append(displayTasks, patch.DisplayTask{Name: dt.Name})
+			}
+		}
+
+		if len(tasks)+len(displayTasks) > 0 {
+			res = append(res, patch.VariantTasks{
+				Variant:      vt.Variant,
+				Tasks:        tasks,
+				DisplayTasks: displayTasks,
+			})
+		}
+	}
+	return res, nil
 }
 
 func (j *patchIntentProcessor) processTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *model.ProjectRef) error {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -276,7 +276,8 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 
 	if j.intent.ReusePreviousPatchDefinition() {
-		previousPatch, err := patch.FindOne(patch.MostRecentPatchByUserAndProject(j.user.Username(), pref.Id))
+		var previousPatch *patch.Patch
+		previousPatch, err = patch.FindOne(patch.MostRecentPatchByUserAndProject(j.user.Username(), pref.Id))
 		if err != nil {
 			return errors.Wrap(err, "error querying for most recent patch")
 		}

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -248,6 +248,63 @@ func (s *PatchIntentUnitsSuite) TestCantFinishCommitQueuePatchWithNoTasksAndVari
 	s.Equal("patch has no build variants or tasks", err.Error())
 }
 
+func (s *PatchIntentUnitsSuite) TestGetPreviousPatchDefinition() {
+	s.NoError((&patch.Patch{
+		Id:         mgobson.NewObjectId(),
+		Activated:  true,
+		Project:    s.project,
+		CreateTime: time.Now(),
+		Author:     "me",
+		VariantsTasks: []patch.VariantTasks{
+			{
+				Variant: "bv1",
+				Tasks:   []string{"t1", "t2"},
+			},
+			{
+				Variant:      "bv_only_dt",
+				DisplayTasks: []patch.DisplayTask{{Name: "dt1"}},
+			},
+			{
+				Variant:      "bv_different_dt",
+				DisplayTasks: []patch.DisplayTask{{Name: "dt2"}},
+			},
+		},
+	}).Insert())
+
+	intent, err := patch.NewCliIntent(patch.CLIIntentParams{
+		User:            "me",
+		Project:         s.project,
+		BaseGitHash:     s.hash,
+		Description:     s.desc,
+		ReuseDefinition: true,
+	})
+	j := NewPatchIntentProcessor(mgobson.NewObjectId(), intent).(*patchIntentProcessor)
+	j.user = &user.DBUser{Id: "me"}
+	project := model.Project{Identifier: s.project, BuildVariants: model.BuildVariants{
+		{
+			Name:  "bv1",
+			Tasks: []model.BuildVariantTaskUnit{{Name: "t1"}},
+		},
+		{
+			Name:         "bv_only_dt",
+			DisplayTasks: []patch.DisplayTask{{Name: "different_dt"}},
+		},
+		{
+			Name:         "bv_different_dt",
+			DisplayTasks: []patch.DisplayTask{{Name: "dt2"}},
+		},
+	}}
+	vt, err := j.getPreviousPatchDefinition(&project)
+	s.NoError(err)
+	s.Require().Len(vt, 2)
+	s.Equal("bv1", vt[0].Variant)
+	s.Require().Len(vt[0].Tasks, 1)
+	s.Equal("t1", vt[0].Tasks[0])
+	s.Equal("bv_different_dt", vt[1].Variant)
+	s.Require().Len(vt[1].DisplayTasks, 1)
+	s.Equal("dt2", vt[1].DisplayTasks[0].Name)
+}
+
 func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntent() {
 	githubOauthToken, err := s.env.Settings().GetGithubOauthToken()
 	s.Require().NoError(err)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -278,6 +278,7 @@ func (s *PatchIntentUnitsSuite) TestGetPreviousPatchDefinition() {
 		Description:     s.desc,
 		ReuseDefinition: true,
 	})
+	s.NoError(err)
 	j := NewPatchIntentProcessor(mgobson.NewObjectId(), intent).(*patchIntentProcessor)
 	j.user = &user.DBUser{Id: "me"}
 	project := model.Project{Identifier: s.project, BuildVariants: model.BuildVariants{


### PR DESCRIPTION
This reuses the task/variant definition for the previous scheduled patch (excludes PR and CLI patches).