### PR TITLE
EVG-13279 allow PR testing for untracked branches

### DIFF
--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -423,6 +423,12 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	assert.NoError(repoDoc.Upsert())
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting("mongodb", "mci", "mine")
 	assert.NoError(err)
+	assert.Nil(projectRef)
+
+	repoDoc.RemotePath = "my_path"
+	assert.NoError(repoDoc.Upsert())
+	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting("mongodb", "mci", "mine")
+	assert.NoError(err)
 	require.NotNil(projectRef)
 	assert.Equal("disabled_project", projectRef.Id)
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -338,7 +338,9 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	assert := assert.New(t)   //nolint
 	require := require.New(t) //nolint
 
-	require.NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection))
+	require.NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection))
+	env := evergreen.GetEnvironment()
+	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 
 	projectRef, err := FindOneProjectRefByRepoAndBranchWithPRTesting("mongodb", "mci", "main")
 	assert.NoError(err)

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -127,6 +127,9 @@ func GetAWSKeyForProject(projectId string) (*AWSSSHKey, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "problem getting project vars")
 	}
+	if vars == nil {
+		return nil, errors.New("no variables for project")
+	}
 	return &AWSSSHKey{
 		Name:  vars.Vars[ProjectAWSSSHKeyName],
 		Value: vars.Vars[ProjectAWSSSHKeyValue],

--- a/repotracker/wrappers.go
+++ b/repotracker/wrappers.go
@@ -68,10 +68,6 @@ func CollectRevisionsForProject(ctx context.Context, conf *evergreen.Settings, p
 }
 
 func ActivateBuildsForProject(project model.ProjectRef) error {
-	if !project.IsEnabled() {
-		return errors.Errorf("project disabled: %s", project.Id)
-	}
-
 	if err := model.DoProjectActivation(project.Id); err != nil {
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message": "problem activating recent commit for project",

--- a/repotracker/wrappers.go
+++ b/repotracker/wrappers.go
@@ -68,6 +68,9 @@ func CollectRevisionsForProject(ctx context.Context, conf *evergreen.Settings, p
 }
 
 func ActivateBuildsForProject(project model.ProjectRef) error {
+	if !project.IsEnabled() {
+		return errors.Errorf("project disabled: %s", project.Id)
+	}
 	if err := model.DoProjectActivation(project.Id); err != nil {
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message": "problem activating recent commit for project",

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -131,7 +131,7 @@ func (pc *DBProjectConnector) EnableWebhooks(ctx context.Context, projectRef *mo
 }
 
 func (pc *DBProjectConnector) EnablePRTesting(projectRef *model.ProjectRef) error {
-	conflictingRefs, err := model.FindMergedProjectRefsByRepoAndBranch(projectRef.Owner, projectRef.Repo, projectRef.Branch)
+	conflictingRefs, err := model.FindMergedEnabledProjectRefsByRepoAndBranch(projectRef.Owner, projectRef.Repo, projectRef.Branch)
 	if err != nil {
 		return errors.Wrap(err, "error finding project refs")
 	}

--- a/rest/data/repotracker.go
+++ b/rest/data/repotracker.go
@@ -66,7 +66,7 @@ func (c *RepoTrackerConnector) TriggerRepotracker(q amboy.Queue, msgID string, e
 		return errors.New("owner from push event is invalid")
 	}
 
-	refs, err := model.FindMergedProjectRefsByRepoAndBranch(*event.Repo.Owner.Name, *event.Repo.Name, branch)
+	refs, err := model.FindMergedEnabledProjectRefsByRepoAndBranch(*event.Repo.Owner.Name, *event.Repo.Name, branch)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"source":  "github hook",
@@ -167,7 +167,7 @@ func (c *MockRepoTrackerConnector) TriggerRepotracker(_ amboy.Queue, _ string, e
 		return nil
 	}
 
-	_, err = model.FindMergedProjectRefsByRepoAndBranch(*event.Repo.Owner.Name, *event.Repo.Name, branch)
+	_, err = model.FindMergedEnabledProjectRefsByRepoAndBranch(*event.Repo.Owner.Name, *event.Repo.Name, branch)
 	return err
 }
 

--- a/rest/route/repo_test.go
+++ b/rest/route/repo_test.go
@@ -234,7 +234,7 @@ func TestPatchRepoIDHandler(t *testing.T) {
 	assert.NotNil(t, repoRef)
 	assert.Equal(t, "10gen", repoRef.Owner)
 
-	pRefs, err := dbModel.FindMergedProjectRefsByRepoAndBranch("10gen", "mongo", "main")
+	pRefs, err := dbModel.FindMergedEnabledProjectRefsByRepoAndBranch("10gen", "mongo", "main")
 	assert.NoError(t, err)
 	require.Len(t, pRefs, 1)
 	assert.Equal(t, branchProject.Id, pRefs[0].Id)

--- a/scheduler/task_finder.go
+++ b/scheduler/task_finder.go
@@ -65,16 +65,38 @@ func LegacyFindRunnableTasks(d distro.Distro) ([]task.Task, error) {
 			continue
 		}
 
-		if !ref.IsEnabled() || ref.IsDispatchingDisabled() {
+		if !ref.IsEnabled() {
+			// PR tasks can still run for hidden projects
+			if ref.IsHidden() && t.Requester == evergreen.GithubPRRequester {
+				grip.Debug(message.Fields{
+					"runner":    RunnerName,
+					"message":   "project disabled but hidden",
+					"outcome":   "not skipping",
+					"task":      t.Id,
+					"requester": t.Requester,
+					"planner":   d.PlannerSettings.Version,
+					"project":   t.Project,
+				})
+			} else {
+				grip.Notice(message.Fields{
+					"runner":  RunnerName,
+					"message": "project disabled",
+					"outcome": "skipping",
+					"task":    t.Id,
+					"planner": d.PlannerSettings.Version,
+					"project": t.Project,
+				})
+				continue
+			}
+		}
+		if ref.IsDispatchingDisabled() {
 			grip.Notice(message.Fields{
-				"runner":               RunnerName,
-				"message":              "project disabled",
-				"outcome":              "skipping",
-				"task":                 t.Id,
-				"planner":              d.PlannerSettings.Version,
-				"project":              t.Project,
-				"enabled":              ref.Enabled,
-				"dispatching_disabled": ref.DispatchingDisabled,
+				"runner":  RunnerName,
+				"message": "project dispatching disabled",
+				"outcome": "skipping",
+				"task":    t.Id,
+				"planner": d.PlannerSettings.Version,
+				"project": t.Project,
 			})
 			continue
 		}
@@ -181,16 +203,38 @@ func AlternateTaskFinder(d distro.Distro) ([]task.Task, error) {
 			continue
 		}
 
-		if !ref.IsEnabled() || ref.IsDispatchingDisabled() {
+		if !ref.IsEnabled() {
+			// PR tasks can still run for hidden projects
+			if ref.IsHidden() && t.Requester == evergreen.GithubPRRequester {
+				grip.Debug(message.Fields{
+					"runner":    RunnerName,
+					"message":   "project disabled but hidden",
+					"outcome":   "not skipping",
+					"task":      t.Id,
+					"requester": t.Requester,
+					"planner":   d.PlannerSettings.Version,
+					"project":   t.Project,
+				})
+			} else {
+				grip.Notice(message.Fields{
+					"runner":  RunnerName,
+					"message": "project disabled",
+					"outcome": "skipping",
+					"task":    t.Id,
+					"planner": d.PlannerSettings.Version,
+					"project": t.Project,
+				})
+				continue
+			}
+		}
+		if ref.IsDispatchingDisabled() {
 			grip.Notice(message.Fields{
-				"runner":               RunnerName,
-				"message":              "project disabled",
-				"outcome":              "skipping",
-				"task":                 t.Id,
-				"planner":              d.PlannerSettings.Version,
-				"project":              t.Project,
-				"enabled":              ref.Enabled,
-				"dispatching_disabled": ref.DispatchingDisabled,
+				"runner":  RunnerName,
+				"message": "project dispatching disabled",
+				"outcome": "skipping",
+				"task":    t.Id,
+				"planner": d.PlannerSettings.Version,
+				"project": t.Project,
 			})
 			continue
 		}
@@ -304,15 +348,38 @@ func ParallelTaskFinder(d distro.Distro) ([]task.Task, error) {
 			continue
 		}
 
-		if !ref.IsEnabled() || ref.IsDispatchingDisabled() {
+		if !ref.IsEnabled() {
+			// PR tasks can still run for hidden projects
+			if ref.IsHidden() && t.Requester == evergreen.GithubPRRequester {
+				grip.Debug(message.Fields{
+					"runner":    RunnerName,
+					"message":   "project disabled but hidden",
+					"outcome":   "not skipping",
+					"task":      t.Id,
+					"requester": t.Requester,
+					"planner":   d.PlannerSettings.Version,
+					"project":   t.Project,
+				})
+			} else {
+				grip.Notice(message.Fields{
+					"runner":  RunnerName,
+					"message": "project disabled",
+					"outcome": "skipping",
+					"task":    t.Id,
+					"planner": d.PlannerSettings.Version,
+					"project": t.Project,
+				})
+				continue
+			}
+		}
+		if ref.IsDispatchingDisabled() {
 			grip.Notice(message.Fields{
-				"runner":               RunnerName,
-				"message":              "project disabled",
-				"outcome":              "skipping",
-				"task":                 t.Id,
-				"project":              t.Project,
-				"enabled":              ref.Enabled,
-				"dispatching_disabled": ref.DispatchingDisabled,
+				"runner":  RunnerName,
+				"message": "project dispatching disabled",
+				"outcome": "skipping",
+				"task":    t.Id,
+				"planner": d.PlannerSettings.Version,
+				"project": t.Project,
 			})
 			continue
 		}

--- a/service/api.go
+++ b/service/api.go
@@ -321,15 +321,18 @@ func (as *APIServer) FetchExpansionsForTask(w http.ResponseWriter, r *http.Reque
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	if projectVars == nil {
-		gimlet.WriteJSON(w, apimodels.ExpansionVars{})
-		return
+	res := apimodels.ExpansionVars{
+		Vars:           map[string]string{},
+		RestrictedVars: map[string]string{},
+		PrivateVars:    map[string]bool{},
 	}
-
-	res := apimodels.ExpansionVars{}
-	res.Vars = projectVars.GetUnrestrictedVars()
-	res.RestrictedVars = projectVars.GetRestrictedVars()
-	res.PrivateVars = projectVars.PrivateVars
+	if projectVars != nil {
+		res.Vars = projectVars.GetUnrestrictedVars()
+		res.RestrictedVars = projectVars.GetRestrictedVars()
+		if projectVars.PrivateVars != nil {
+			res.PrivateVars = projectVars.PrivateVars
+		}
+	}
 
 	v, err := model.VersionFindOne(model.VersionById(t.Version))
 	if err != nil {

--- a/service/api.go
+++ b/service/api.go
@@ -326,12 +326,14 @@ func (as *APIServer) FetchExpansionsForTask(w http.ResponseWriter, r *http.Reque
 		RestrictedVars: map[string]string{},
 		PrivateVars:    map[string]bool{},
 	}
-	if projectVars != nil {
-		res.Vars = projectVars.GetUnrestrictedVars()
-		res.RestrictedVars = projectVars.GetRestrictedVars()
-		if projectVars.PrivateVars != nil {
-			res.PrivateVars = projectVars.PrivateVars
-		}
+	if projectVars == nil {
+		gimlet.WriteJSON(w, res)
+		return
+	}
+	res.Vars = projectVars.GetUnrestrictedVars()
+	res.RestrictedVars = projectVars.GetRestrictedVars()
+	if projectVars.PrivateVars != nil {
+		res.PrivateVars = projectVars.PrivateVars
 	}
 
 	v, err := model.VersionFindOne(model.VersionById(t.Version))

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -486,6 +486,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 		}
 
 		isDisabled := projectRef.IsDispatchingDisabled()
+		// hidden projects can only run PR tasks
 		if !projectRef.IsEnabled() && (queueItem.Requester != evergreen.GithubPRRequester || !projectRef.IsHidden()) {
 			isDisabled = true
 		}

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -485,7 +485,12 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			return nil, false, errors.Wrapf(err, "could not find project ref for next task %s", nextTask.Id)
 		}
 
-		if !projectRef.IsEnabled() || projectRef.IsDispatchingDisabled() {
+		isDisabled := projectRef.IsDispatchingDisabled()
+		if !projectRef.IsEnabled() && (queueItem.Requester != evergreen.GithubPRRequester || !projectRef.IsHidden()) {
+			isDisabled = true
+		}
+
+		if isDisabled {
 			grip.Warning(message.WrapError(taskQueue.DequeueTask(nextTask.Id), message.Fields{
 				"message":              "project has dispatching disabled, but there was an issue dequeuing the task",
 				"distro_id":            nextTask.DistroId,
@@ -495,7 +500,6 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 				"enabled":              projectRef.Enabled,
 				"dispatching_disabled": projectRef.DispatchingDisabled,
 			}))
-
 			continue
 		}
 

--- a/service/project.go
+++ b/service/project.go
@@ -125,7 +125,7 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	matchingRefs, err := model.FindMergedProjectRefsByRepoAndBranch(projRef.Owner, projRef.Repo, projRef.Branch)
+	matchingRefs, err := model.FindMergedEnabledProjectRefsByRepoAndBranch(projRef.Owner, projRef.Repo, projRef.Branch)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
@@ -376,7 +376,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	var conflictingRefs []model.ProjectRef
 	if responseRef.Enabled {
 		if responseRef.PRTestingEnabled || responseRef.GithubChecksEnabled {
-			conflictingRefs, err = model.FindMergedProjectRefsByRepoAndBranch(responseRef.Owner, responseRef.Repo, responseRef.Branch)
+			conflictingRefs, err = model.FindMergedEnabledProjectRefsByRepoAndBranch(responseRef.Owner, responseRef.Repo, responseRef.Branch)
 			if err != nil {
 				uis.LoggedError(w, r, http.StatusInternalServerError, err)
 				return

--- a/units/crons.go
+++ b/units/crons.go
@@ -46,7 +46,7 @@ func PopulateCatchupJobs() amboy.QueueOperation {
 			return nil
 		}
 
-		projects, err := model.FindAllMergedTrackedProjectRefsWithRepoInfo()
+		projects, err := model.FindAllMergedProjectRefsWithRepoInfo()
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -213,7 +213,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		return errors.Wrap(err, "can't find patch project")
 	}
 
-	if !pref.IsEnabled() {
+	if !pref.IsEnabled() && (j.IntentType != patch.GithubIntentType || !pref.IsHidden()) {
 		j.gitHubError = ProjectDisabled
 		return errors.New("project is disabled")
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -213,6 +213,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		return errors.Wrap(err, "can't find patch project")
 	}
 
+	// hidden projects can only run PR patches
 	if !pref.IsEnabled() && (j.IntentType != patch.GithubIntentType || !pref.IsHidden()) {
 		j.gitHubError = ProjectDisabled
 		return errors.New("project is disabled")


### PR DESCRIPTION
If PR testing is set up for the repo, then we still create PRs for branches, even if they aren't enabled. 
I had some trouble deciding if "branch project exists but is disabled" should still create a PR. I decided on yes, because that is still an "untracked branch". 

Potentially RepoRefs should have some option "allow_untracked_branch_prs", as opposed to just checking if it has all the components to run checks, but I'm assuming it doesn't hurt to have checks added? I could be convinced either way. 

"Hidden" projects were an idea from Brian, to avoid lots of skeleton projects, where the PRs aren't attached to each other. i.e. say we do some testing with "new_branch", and then we decide to actually start tracking "new_branch": it would be ideal if the PRs from earlier were still attached to this new project, as opposed to having one "hidden" project and one "visible" project. So when creating new projects now, we should query for hidden documents that we can now expose, so that old and new patches will have the same project ID associated. 