### PR TITLE
EVG-13464: Fix unit agent-command tests

### DIFF
--- a/agent/command/results_utils_test.go
+++ b/agent/command/results_utils_test.go
@@ -208,8 +208,8 @@ func TestSendTestLog(t *testing.T) {
 					for _, data := range srv.Data {
 						require.Len(t, data, 1)
 						require.Len(t, data[0].Lines, 2)
-						assert.Equal(t, strings.Trim(log.Lines[0], "\n"), data[0].Lines[0].Data)
-						assert.Equal(t, strings.Trim(log.Lines[1], "\n"), data[0].Lines[1].Data)
+						assert.EqualValues(t, strings.Trim(log.Lines[0], "\n"), data[0].Lines[0].Data)
+						assert.EqualValues(t, strings.Trim(log.Lines[1], "\n"), data[0].Lines[1].Data)
 					}
 
 				},


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13464

I missed these broken unit tests because I wrote them off as flaky agent-command tests. Since we are now using the buildlogger protobuf file that takes `[]byte` instead of `string` we need to use `assert.EqualValues` instead of `assert.Equal` in the unit tests when comparing the input and output.