### PR TITLE
EVG-13467 assign values to repo ref that are common across branch projects

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -519,6 +519,9 @@ func recursivelySetUndefinedFields(structToSet, structToDefaultFrom reflect.Valu
 }
 
 func setRepoFieldsFromProjects(repoRef *RepoRef, projectRefs []ProjectRef) {
+	if len(projectRefs) == 0 {
+		return
+	}
 	reflectedRepo := reflect.ValueOf(repoRef).Elem().Field(0) // specifically references the ProjectRef part of RepoRef
 	for i := 0; i < reflectedRepo.NumField(); i++ {
 		// for each field in the repo, look at each field in the project ref
@@ -540,8 +543,8 @@ func setRepoFieldsFromProjects(repoRef *RepoRef, projectRefs []ProjectRef) {
 	}
 }
 
-func (p *ProjectRef) createNewRepoRef(u *user.DBUser) (*RepoRef, error) {
-	repoRef := &RepoRef{ProjectRef{
+func (p *ProjectRef) createNewRepoRef(u *user.DBUser) (repoRef *RepoRef, err error) {
+	repoRef = &RepoRef{ProjectRef{
 		Id:      mgobson.NewObjectId().Hex(),
 		Owner:   p.Owner,
 		Repo:    p.Repo,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -627,11 +627,21 @@ func getCommonAliases(projectIds []string) (ProjectAliases, error) {
 
 func aliasSliceContains(slice []ProjectAlias, item ProjectAlias) bool {
 	for _, each := range slice {
-		if each.RemotePath == item.RemotePath && each.Alias == item.Alias && each.GitTag == item.GitTag &&
-			each.Variant == item.Variant && reflect.DeepEqual(each.VariantTags, item.VariantTags) &&
-			each.Task == item.Task && reflect.DeepEqual(each.TaskTags, item.TaskTags) {
-			return true
+		if each.RemotePath != item.RemotePath || each.Alias != item.Alias || each.GitTag != item.GitTag ||
+			each.Variant != item.Variant || each.Task != item.Task {
+			continue
 		}
+
+		if len(each.VariantTags) != len(item.VariantTags) || len(each.TaskTags) != len(item.TaskTags) {
+			continue
+		}
+		if len(each.VariantTags) != len(utility.StringSliceIntersection(each.VariantTags, item.VariantTags)) {
+			continue
+		}
+		if len(each.TaskTags) != len(utility.StringSliceIntersection(each.TaskTags, item.TaskTags)) {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -350,21 +350,9 @@ func (p *ProjectRef) AddToRepoScope(user *user.DBUser) error {
 			return errors.Wrapf(err, "error finding repo ref '%s'", p.RepoRefId)
 		}
 		if repoRef == nil {
-			repoRef = &RepoRef{ProjectRef{
-				Id:      mgobson.NewObjectId().Hex(),
-				Admins:  []string{user.Username()},
-				Owner:   p.Owner,
-				Repo:    p.Repo,
-				Enabled: utility.TruePtr(),
-			}}
-			// creates scope and give user admin access to repo
-			if err = repoRef.Add(user); err != nil {
-				return errors.Wrapf(err, "problem adding new repo repo ref for '%s/%s'", p.Owner, p.Repo)
-			}
-			newProjectVars := ProjectVars{Id: repoRef.Id}
-
-			if err = newProjectVars.Insert(); err != nil {
-				return errors.Wrap(err, "error inserting blank project variables for repo")
+			repoRef, err = p.createNewRepoRef(user)
+			if err != nil {
+				return errors.Wrapf(err, "error creating new repo ref")
 			}
 		}
 		p.RepoRefId = repoRef.Id
@@ -528,6 +516,168 @@ func recursivelySetUndefinedFields(structToSet, structToDefaultFrom reflect.Valu
 			recursivelySetUndefinedFields(branchField, structToDefaultFrom.Field(i))
 		}
 	}
+}
+
+func setRepoFieldsFromProjects(repoRef *RepoRef, projectRefs []ProjectRef) {
+	reflectedRepo := reflect.ValueOf(repoRef).Elem().Field(0) // specifically references the ProjectRef part of RepoRef
+	for i := 0; i < reflectedRepo.NumField(); i++ {
+		// for each field in the repo, look at each field in the project ref
+		var firstVal reflect.Value
+		allEqual := true
+		for j, pRef := range projectRefs {
+			reflectedBranchField := reflect.ValueOf(pRef).Field(i)
+			if j == 0 {
+				firstVal = reflectedBranchField
+			} else if !reflect.DeepEqual(firstVal.Interface(), reflectedBranchField.Interface()) {
+				allEqual = false
+				break
+			}
+		}
+		// if we got to the end of the loop, then all values are the same, so we can assign it to reflectedRepo
+		if allEqual {
+			reflectedRepo.Field(i).Set(firstVal)
+		}
+	}
+}
+
+func (p *ProjectRef) createNewRepoRef(u *user.DBUser) (*RepoRef, error) {
+	repoRef := &RepoRef{ProjectRef{
+		Id:      mgobson.NewObjectId().Hex(),
+		Owner:   p.Owner,
+		Repo:    p.Repo,
+		Enabled: utility.TruePtr(),
+		Admins:  []string{},
+	}}
+
+	allEnabledProjects, err := FindMergedEnabledProjectRefsByOwnerAndRepo(p.Owner, p.Repo)
+	if err != nil {
+		return nil, errors.Wrap(err, "error finding all enabled projects")
+	}
+	// for every setting in the project ref, if all enabled projects have the same setting, then use that
+	defer func() {
+		err = recovery.HandlePanicWithError(recover(), err, "project and repo structures do not match")
+	}()
+	setRepoFieldsFromProjects(repoRef, allEnabledProjects)
+	repoRef.Admins = append(repoRef.Admins, u.Username())
+
+	// creates scope and give user admin access to repo
+	if err = repoRef.Add(u); err != nil {
+		return nil, errors.Wrapf(err, "problem adding new repo repo ref for '%s/%s'", p.Owner, p.Repo)
+	}
+	enabledProjectIds := []string{}
+	for _, p := range allEnabledProjects {
+		enabledProjectIds = append(enabledProjectIds, p.Id)
+	}
+	commonProjectVars, err := getCommonProjectVariables(enabledProjectIds)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting common project variables")
+	}
+	commonProjectVars.Id = repoRef.Id
+	if err = commonProjectVars.Insert(); err != nil {
+		return nil, errors.Wrap(err, "error inserting project variables for repo")
+	}
+
+	commonAliases, err := getCommonAliases(enabledProjectIds)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting common project aliases")
+	}
+	for _, a := range commonAliases {
+		a.ProjectID = repoRef.Id
+		if err = a.Upsert(); err != nil {
+			return nil, errors.Wrapf(err, "error upserting alias for repo")
+		}
+	}
+
+	return repoRef, nil
+}
+
+func getCommonAliases(projectIds []string) (ProjectAliases, error) {
+	commonAliases := map[string]ProjectAlias{} // use map for easy removal of non-common aliases
+	for i, id := range projectIds {
+		aliases, err := FindAliasesForProject(id)
+		if err != nil {
+			return nil, errors.Wrap(err, "error finding aliases for project")
+		}
+		if i == 0 {
+			for _, a := range aliases {
+				commonAliases[a.ID.Hex()] = a
+			}
+			continue
+		}
+		for _, commonAlias := range commonAliases {
+			// look to see if this alias exists in the each project and if not remove it
+			if !aliasSliceContains(aliases, commonAlias) {
+				delete(commonAliases, commonAlias.ID.Hex())
+			}
+		}
+		if len(commonAliases) == 0 {
+			return nil, nil
+		}
+	}
+
+	res := ProjectAliases{}
+	for _, a := range commonAliases {
+		res = append(res, a)
+	}
+	return res, nil
+}
+
+func aliasSliceContains(slice []ProjectAlias, item ProjectAlias) bool {
+	for _, each := range slice {
+		if each.RemotePath == item.RemotePath && each.Alias == item.Alias && each.GitTag == item.GitTag &&
+			each.Variant == item.Variant && reflect.DeepEqual(each.VariantTags, item.VariantTags) &&
+			each.Task == item.Task && reflect.DeepEqual(each.TaskTags, item.TaskTags) {
+			return true
+		}
+	}
+	return false
+}
+
+func getCommonProjectVariables(projectIds []string) (*ProjectVars, error) {
+	// add in project variables and aliases here
+	commonProjectVariables := map[string]string{}
+	commonPrivate := map[string]bool{}
+	commonRestricted := map[string]bool{}
+	for i, id := range projectIds {
+		vars, err := FindOneProjectVars(id)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error finding variables for project '%s'", id)
+		}
+		if vars == nil {
+			continue
+		}
+		if i == 0 {
+			if vars.Vars != nil {
+				commonProjectVariables = vars.Vars
+			}
+			if vars.PrivateVars != nil {
+				commonPrivate = vars.PrivateVars
+			}
+			if vars.RestrictedVars != nil {
+				commonRestricted = vars.RestrictedVars
+			}
+			continue
+		}
+		for key := range commonProjectVariables {
+			// if the key is private/restricted in any of the projects, make it private/restricted in the repo
+			if _, ok := vars.Vars[key]; ok {
+				if vars.PrivateVars[key] {
+					commonPrivate[key] = true
+				}
+				if vars.RestrictedVars[key] {
+					commonRestricted[key] = true
+				}
+			} else {
+				// remove any variables from the common set that aren't in all the project refs
+				delete(commonProjectVariables, key)
+			}
+		}
+	}
+	return &ProjectVars{
+		Vars:           commonProjectVariables,
+		PrivateVars:    commonPrivate,
+		RestrictedVars: commonRestricted,
+	}, nil
 }
 
 func FindIdForProject(identifier string) (string, error) {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -336,6 +336,7 @@ func TestFindProjectRefsByRepoAndBranch(t *testing.T) {
 func TestCreateNewRepoRef(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, user.Collection,
 		evergreen.ScopeCollection, ProjectVarsCollection))
+	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 	doc1 := &ProjectRef{
 		Id:                    "id1",
 		Owner:                 "mongodb",
@@ -605,7 +606,7 @@ func TestFindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t *testing.T) {
 	}
 	repoDoc := &RepoRef{ProjectRef{Id: "my_repo"}}
 	assert.NoError(doc.Insert())
-	assert.NoError(repoDoc.Insert())
+	assert.NoError(repoDoc.Upsert())
 
 	projectRef, err = FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch("mongodb", "mci", "not_main")
 	assert.NoError(err)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -335,7 +335,7 @@ func TestFindProjectRefsByRepoAndBranch(t *testing.T) {
 
 func TestCreateNewRepoRef(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, user.Collection,
-		evergreen.ScopeCollection, ProjectVarsCollection))
+		evergreen.ScopeCollection, ProjectVarsCollection, ProjectAliasCollection))
 	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 	doc1 := &ProjectRef{
 		Id:                    "id1",
@@ -381,10 +381,13 @@ func TestCreateNewRepoRef(t *testing.T) {
 		{
 			Id: doc1.Id,
 			Vars: map[string]string{
-				"hello": "world",
-				"sdc":   "buggy",
-				"roses": "red",
-				"ever":  "green",
+				"hello":        "world",
+				"sdc":          "buggy",
+				"violets":      "nah",
+				"roses":        "red",
+				"ever":         "green",
+				"also":         "this one",
+				"this is only": "in one doc",
 			},
 			PrivateVars: map[string]bool{
 				"sdc": true,

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -43,7 +43,7 @@ func TestFindMergedProjectVars(t *testing.T) {
 		Owner: "mongodb",
 		Repo:  "test_repo",
 	}}
-	require.NoError(t, repo.Insert())
+	require.NoError(t, repo.Upsert())
 
 	project0 := ProjectRef{
 		Id:              "project_0",

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -60,15 +60,16 @@ var (
 )
 
 func (r *RepoRef) Add(creator *user.DBUser) error {
-	err := db.Insert(RepoRefCollection, r)
+	err := r.Upsert()
 	if err != nil {
-		return errors.Wrap(err, "Error inserting repo ref")
+		return errors.Wrap(err, "Error upserting repo ref")
 	}
 	return r.AddPermissions(creator)
 }
 
+// Insert is included here so ProjectRef.Insert() isn't mistakenly used.
 func (r *RepoRef) Insert() error {
-	return db.Insert(RepoRefCollection, r)
+	return errors.New("insert not supported for repoRef")
 }
 
 // Upsert updates the project ref in the db if an entry already exists,

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -548,7 +548,7 @@ func TestDeleteProject(t *testing.T) {
 			Enabled: utility.TruePtr(),
 		},
 	}
-	assert.NoError(t, repo.Insert())
+	assert.NoError(t, repo.Upsert())
 
 	// Projects expected to be successfully deleted
 	numGoodProjects := 2

--- a/rest/route/repo_test.go
+++ b/rest/route/repo_test.go
@@ -35,7 +35,7 @@ func TestGetRepoIDHandler(t *testing.T) {
 			Enabled: utility.TruePtr(),
 		},
 	}
-	require.NoError(t, repoRef.Insert())
+	require.NoError(t, repoRef.Upsert())
 
 	repoVars := &dbModel.ProjectVars{
 		Id:   repoRef.Id,
@@ -91,7 +91,7 @@ func TestPatchRepoIDHandler(t *testing.T) {
 			Enabled: utility.TruePtr(),
 		},
 	}
-	assert.NoError(t, repoRef.Insert())
+	assert.NoError(t, repoRef.Upsert())
 	hook := dbModel.GithubHook{
 		HookID: 1,
 		Owner:  repoRef.Owner,


### PR DESCRIPTION
This was your idea @john-m-liu but a stakeholder asked recently if something like this would be possible so that works out. If a value is common across all projects (including aliases/variables), then it's assigned to the repo ref as well. This doesn't actually work for embedded structs (i.e. it's not recursive), but I think this is close enough, since it's mostly meant to be helpful.