### PR TITLE
EVG-14102: enqueue reprovision job immediately within REST request

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -136,6 +136,10 @@ func GetRestartJasperCallback(ctx context.Context, env evergreen.Environment, us
 			return http.StatusInternalServerError, modifyErr
 		}
 
+		if h.StartedBy == evergreen.User && !h.NeedsNewAgentMonitor {
+			return nil
+		}
+
 		// Enqueue the job immediately, if possible.
 		if err := units.EnqueueHostReprovisioningJob(ctx, env, h); err != nil {
 			grip.Warning(message.WrapError(err, message.Fields{
@@ -154,6 +158,10 @@ func GetReprovisionToNewCallback(ctx context.Context, env evergreen.Environment,
 		modifyErr := h.SetNeedsReprovisionToNew(username)
 		if modifyErr != nil {
 			return http.StatusInternalServerError, modifyErr
+		}
+
+		if h.StartedBy == evergreen.User && !h.NeedsNewAgentMonitor {
+			return nil
 		}
 
 		// Enqueue the job immediately, if possible.

--- a/api/host.go
+++ b/api/host.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -86,11 +88,7 @@ func ModifyHostsWithPermissions(hosts []host.Host, perm map[string]gimlet.Permis
 	return updated, httpStatus, catcher.Resolve()
 }
 
-func ModifyHostStatus(queue amboy.Queue, h *host.Host, newStatus string, notes string, u *user.DBUser) (string, int, error) {
-	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
-
+func ModifyHostStatus(ctx context.Context, env evergreen.Environment, queue amboy.Queue, h *host.Host, newStatus string, notes string, u *user.DBUser) (string, int, error) {
 	currentStatus := h.Status
 
 	if !utility.StringSliceContains(validUpdateToStatuses, newStatus) {
@@ -124,35 +122,65 @@ func ModifyHostStatus(queue amboy.Queue, h *host.Host, newStatus string, notes s
 		if err := h.SetNeedsReprovisionToNew(u.Username()); err != nil {
 			return "", http.StatusInternalServerError, errors.Wrap(err, HostUpdateError)
 		}
+
+		// Enqueue the job immediately, if possible.
+		if err := units.EnqueueHostReprovisioningJob(ctx, env, h); err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"message":           "could not enqueue job to reprovision host",
+				"host_id":           h.Id,
+				"needs_reprovision": h.NeedsReprovision,
+			}))
+		}
+
 		return HostReprovisionConfirm, http.StatusOK, nil
 	}
 
 	return fmt.Sprintf(HostStatusUpdateSuccess, currentStatus, h.Status), http.StatusOK, nil
 }
 
-func GetRestartJasperCallback(username string) func(h *host.Host) (int, error) {
+func GetRestartJasperCallback(ctx context.Context, env evergreen.Environment, username string) func(h *host.Host) (int, error) {
 	return func(h *host.Host) (int, error) {
 		modifyErr := h.SetNeedsJasperRestart(username)
 		if modifyErr != nil {
 			return http.StatusInternalServerError, modifyErr
 		}
+
+		// Enqueue the job immediately, if possible.
+		if err := units.EnqueueHostReprovisioningJob(ctx, env, h); err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"message":           "could not enqueue job to reprovision host",
+				"host_id":           h.Id,
+				"needs_reprovision": h.NeedsReprovision,
+			}))
+		}
+
 		return http.StatusOK, nil
 	}
 }
 
-func GetReprovisionToNewCallback(username string) func(h *host.Host) (int, error) {
+func GetReprovisionToNewCallback(ctx context.Context, env evergreen.Environment, username string) func(h *host.Host) (int, error) {
 	return func(h *host.Host) (int, error) {
 		modifyErr := h.SetNeedsReprovisionToNew(username)
 		if modifyErr != nil {
 			return http.StatusInternalServerError, modifyErr
 		}
+
+		// Enqueue the job immediately, if possible.
+		if err := units.EnqueueHostReprovisioningJob(ctx, env, h); err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"message":           "could not enqueue job to reprovision host",
+				"host_id":           h.Id,
+				"needs_reprovision": h.NeedsReprovision,
+			}))
+		}
+
 		return http.StatusOK, nil
 	}
 }
 
-func GetUpdateHostStatusCallback(rq amboy.Queue, status string, notes string, user *user.DBUser) func(h *host.Host) (httpStatus int, err error) {
+func GetUpdateHostStatusCallback(ctx context.Context, env evergreen.Environment, rq amboy.Queue, status string, notes string, user *user.DBUser) func(h *host.Host) (httpStatus int, err error) {
 	return func(h *host.Host) (httpStatus int, err error) {
-		_, httpStatus, modifyErr := ModifyHostStatus(rq, h, status, notes, user)
+		_, httpStatus, modifyErr := ModifyHostStatus(ctx, env, rq, h, status, notes, user)
 		return httpStatus, modifyErr
 	}
 }

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2081,7 +2081,7 @@ func (r *mutationResolver) RestartJasper(ctx context.Context, hostIds []string) 
 		return 0, mapHTTPStatusToGqlError(ctx, httpStatus, err)
 	}
 
-	hostsUpdated, httpStatus, err := api.ModifyHostsWithPermissions(hosts, permissions, api.GetRestartJasperCallback(user.Username()))
+	hostsUpdated, httpStatus, err := api.ModifyHostsWithPermissions(hosts, permissions, api.GetRestartJasperCallback(ctx, evergreen.GetEnvironment(), user.Username()))
 	if err != nil {
 		return 0, mapHTTPStatusToGqlError(ctx, httpStatus, errors.Errorf("error marking selected hosts as needing Jasper service restarted: %s", err.Error()))
 	}
@@ -2099,7 +2099,7 @@ func (r *mutationResolver) UpdateHostStatus(ctx context.Context, hostIds []strin
 
 	rq := evergreen.GetEnvironment().RemoteQueue()
 
-	hostsUpdated, httpStatus, err := api.ModifyHostsWithPermissions(hosts, permissions, api.GetUpdateHostStatusCallback(rq, status, *notes, user))
+	hostsUpdated, httpStatus, err := api.ModifyHostsWithPermissions(hosts, permissions, api.GetUpdateHostStatusCallback(ctx, evergreen.GetEnvironment(), rq, status, *notes, user))
 	if err != nil {
 		return 0, mapHTTPStatusToGqlError(ctx, httpStatus, err)
 	}

--- a/makefile
+++ b/makefile
@@ -456,7 +456,10 @@ lint-%:$(buildDir)/output.%.lint
 testRunDeps := $(name)
 testArgs := -v
 dlvArgs := -test.v
-testRunEnv := EVGHOME=$(shell pwd) GOCONVEY_REPORTER=silent GOPATH=$(gopath)
+testRunEnv := EVGHOME=$(shell pwd) GOPATH=$(gopath)
+ifeq (,$(GOCONVEY_REPORTER))
+	testRunEnv += GOCONVEY_REPORTER=silent
+endif
 ifeq ($(OS),Windows_NT)
 testRunEnv := EVGHOME=$(shell cygpath -m `pwd`) GOPATH=$(gopath)
 endif

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1022,11 +1022,8 @@ func (h *Host) SetNeedsReprovisionToNew(user string) error {
 	if h.StartedBy == evergreen.User && !h.NeedsNewAgentMonitor {
 		return nil
 	}
-	if err := h.MarkAsReprovisioning(); err != nil {
-		return err
-	}
 
-	return nil
+	return h.MarkAsReprovisioning()
 }
 
 func (h *Host) setAwaitingReprovisionToNew(user string) error {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1022,7 +1022,11 @@ func (h *Host) SetNeedsReprovisionToNew(user string) error {
 	if h.StartedBy == evergreen.User && !h.NeedsNewAgentMonitor {
 		return nil
 	}
-	return h.MarkAsReprovisioning()
+	if err := h.MarkAsReprovisioning(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (h *Host) setAwaitingReprovisionToNew(user string) error {

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -322,33 +322,18 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 }
 
 // prepareForReprovision readies host for reprovisioning.
-func prepareForReprovision(ctx context.Context, env evergreen.Environment, settings *evergreen.Settings, h *host.Host, w http.ResponseWriter) error {
+func prepareForReprovision(ctx context.Context, env evergreen.Environment, h *host.Host) error {
 	if err := h.MarkAsReprovisioning(); err != nil {
 		return errors.Wrap(err, "error marking host as ready for reprovisioning")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	ts := utility.RoundPartOfMinute(0).Format(units.TSFormat)
-	switch h.NeedsReprovision {
-	case host.ReprovisionToLegacy:
-		if err := env.RemoteQueue().Put(ctx, units.NewConvertHostToLegacyProvisioningJob(env, *h, ts, 0)); err != nil {
-			grip.Warning(message.WrapError(err, "problem enqueueing jobs to reprovision host to legacy"))
-		}
-	case host.ReprovisionToNew:
-		if err := env.RemoteQueue().Put(ctx, units.NewConvertHostToNewProvisioningJob(env, *h, ts, 0)); err != nil {
-			grip.Warning(message.WrapError(err, "problem enqueueing jobs to reprovision host to new"))
-		}
-	case host.ReprovisionJasperRestart:
-		expiration, err := h.JasperCredentialsExpiration(ctx, env)
-		if err != nil {
-			grip.Warning(message.WrapError(err, "problem getting credentials expiration time"))
-		}
-		ts := utility.RoundPartOfMinute(0).Format(units.TSFormat)
-		if err := env.RemoteQueue().Put(ctx, units.NewJasperRestartJob(env, *h, expiration, h.Distro.BootstrapSettings.Communication == distro.CommunicationMethodRPC, ts, 0)); err != nil {
-			grip.Warning(message.WrapError(err, "problem enqueueing jobs to restart Jasper"))
-		}
+	// Enqueue the job immediately, if possible.
+	if err := units.EnqueueHostReprovisioningJob(ctx, env, h); err != nil {
+		grip.Warning(message.WrapError(err, message.Fields{
+			"message":           "could not enqueue job to reprovision host",
+			"host_id":           h.Id,
+			"needs_reprovision": h.NeedsReprovision,
+		}))
 	}
 
 	return nil
@@ -705,7 +690,7 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	var response apimodels.NextTaskResponse
-	if responded := handleReprovisioning(ctx, as.env, as.env.Settings(), response, h, w); responded {
+	if responded := handleReprovisioning(ctx, as.env, h, response, w); responded {
 		return
 	}
 
@@ -970,7 +955,7 @@ func getDetails(response apimodels.NextTaskResponse, h *host.Host, w http.Respon
 	return details, false
 }
 
-func handleReprovisioning(ctx context.Context, env evergreen.Environment, settings *evergreen.Settings, response apimodels.NextTaskResponse, h *host.Host, w http.ResponseWriter) (responded bool) {
+func handleReprovisioning(ctx context.Context, env evergreen.Environment, h *host.Host, response apimodels.NextTaskResponse, w http.ResponseWriter) (responded bool) {
 	if h.NeedsReprovision == host.ReprovisionNone {
 		return false
 	}
@@ -993,7 +978,7 @@ func handleReprovisioning(ctx context.Context, env evergreen.Environment, settin
 		}))
 	}
 
-	if err := prepareForReprovision(ctx, env, settings, h, w); err != nil {
+	if err := prepareForReprovision(ctx, env, h); err != nil {
 		gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
 		return true
 	}

--- a/service/api_task_test.go
+++ b/service/api_task_test.go
@@ -1248,7 +1248,7 @@ func TestTaskLifecycleEndpoints(t *testing.T) {
 		sampleHost := host.Host{
 			Id: hostId,
 			Distro: distro.Distro{
-				Provider: evergreen.ProviderNameEc2Auto,
+				Provider: evergreen.ProviderNameMock,
 			},
 			Secret:                hostSecret,
 			RunningTask:           task1.Id,

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -26,7 +26,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	env := mock.Environment{}
+	env := &mock.Environment{}
 	assert.NoError(env.Configure(ctx))
 	require.NoError(db.ClearCollections(host.Collection, event.AllLogCollection), "error clearing collections")
 
@@ -37,7 +37,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 		require.NoError(h.Insert())
 		opts := uiParams{Action: "updateStatus", Status: evergreen.HostQuarantined, Notes: "because I can"}
 
-		result, httpStatus, err := api.ModifyHostStatus(env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
+		result, httpStatus, err := api.ModifyHostStatus(ctx, env, env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
 		require.NoError(err)
 		assert.Equal(http.StatusOK, httpStatus)
 		assert.Equal(result, fmt.Sprintf(api.HostStatusUpdateSuccess, evergreen.HostRunning, evergreen.HostQuarantined))
@@ -63,7 +63,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 		}
 		require.NoError(h.Insert())
 
-		_, httpStatus, err := api.ModifyHostStatus(env.LocalQueue(), &h, evergreen.HostRunning, "", &user)
+		_, httpStatus, err := api.ModifyHostStatus(ctx, env, env.LocalQueue(), &h, evergreen.HostRunning, "", &user)
 		require.NoError(err)
 		assert.Equal(http.StatusOK, httpStatus)
 		assert.Equal(h.Status, evergreen.HostProvisioning)
@@ -74,7 +74,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 		h := host.Host{Id: "h3", Status: evergreen.HostRunning, Provider: evergreen.ProviderNameStatic}
 		opts := uiParams{Action: "updateStatus", Status: evergreen.HostDecommissioned}
 
-		_, _, err := api.ModifyHostStatus(env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
+		_, _, err := api.ModifyHostStatus(ctx, env, env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
 		assert.Error(err)
 		assert.Contains(err.Error(), api.DecommissionStaticHostError)
 	})
@@ -83,7 +83,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 		h := host.Host{Id: "h4", Status: evergreen.HostRunning, Provider: evergreen.ProviderNameStatic}
 		opts := uiParams{Action: "updateStatus", Status: "undefined"}
 
-		_, _, err := api.ModifyHostStatus(env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
+		_, _, err := api.ModifyHostStatus(ctx, env, env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
 		assert.Error(err)
 		assert.Contains(err.Error(), fmt.Sprintf(api.InvalidStatusError, "undefined"))
 	})

--- a/units/util.go
+++ b/units/util.go
@@ -56,7 +56,7 @@ func EnqueueHostReprovisioningJob(ctx context.Context, env evergreen.Environment
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	ts := utility.RoundPartOfMinute(0).Format(TSFormat)
+	ts := utility.RoundPartOfHour(15).Format(TSFormat)
 
 	switch h.NeedsReprovision {
 	case host.ReprovisionToLegacy:


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14102

* Enqueue the reprovisioning job ASAP when initiated from a REST request. Before this, the cron job would only check if the job needs to reprovision once an hour, so after clicking the UI button, you would have to wait an hour for it to reprovision.
    * Do some small refactoring to unify the logic to enqueue reprovisioning jobs.
* Minor change to the makefile to only set `GOCONVEY_REPORTER` if it's not already set (because sometimes, it's actually helpful to see the output from goconvey).