### PR TITLE
EVG-14121 allow = in parameter values

### DIFF
--- a/operations/patch.go
+++ b/operations/patch.go
@@ -177,12 +177,12 @@ func getParametersFromInput(params []string) ([]patch.Parameter, error) {
 	catcher := grip.NewBasicCatcher()
 	for _, param := range params {
 		pair := strings.Split(param, "=")
-		if len(pair) != 2 {
+		if len(pair) < 2 {
 			catcher.Add(errors.Errorf("problem parsing parameter '%s'", param))
-			continue
 		}
-
-		res = append(res, patch.Parameter{Key: pair[0], Value: pair[1]})
+		key := pair[0]
+		val := strings.Join(pair[1:], "=")
+		res = append(res, patch.Parameter{Key: key, Value: val})
 	}
 	return res, catcher.Resolve()
 }

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1131,7 +1131,7 @@ func validateParameters(p *model.Project) ValidationErrors {
 		if strings.Contains(param.Parameter.Key, "=") {
 			errs = append(errs, ValidationError{
 				Level:   Error,
-				Message: fmt.Sprintf("parameter '%s' cannot contain `=`", param.Parameter.Key),
+				Message: fmt.Sprintf("parameter name '%s' cannot contain `=`", param.Parameter.Key),
 			})
 		}
 		if param.Parameter.Key == "" {


### PR DESCRIPTION
I think I just didn't allow this because I didn't see a reason, and it's the logic we use for other KEY=VALUE pairs, but server has requested to be able to use = in values. I'll update the docs to say = just can't be in the key.
http://evergreen-staging.spruce.s3-website-us-east-1.amazonaws.com/version/6034038db2373615ef3edf12/tasks