### PR TITLE
EVG-13841 Move execution task lookup to later stage of pipeline

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2681,13 +2681,7 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 				tempParentKey: []interface{}{},
 			},
 		},
-		// expand execution tasks in display tasks
-		{"$lookup": bson.M{
-			"from":         Collection,
-			"localField":   ExecutionTasksKey,
-			"foreignField": IdKey,
-			"as":           ExecutionTasksFullKey,
-		}},
+
 		// add a field for the display status of each task
 		addDisplayStatus,
 		// add data about the base task
@@ -2777,6 +2771,13 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 			"$project": fieldKeys,
 		})
 	}
+	// expand execution tasks in display tasks
+	pipeline = append(pipeline, bson.M{"$lookup": bson.M{
+		"from":         Collection,
+		"localField":   ExecutionTasksKey,
+		"foreignField": IdKey,
+		"as":           ExecutionTasksFullKey,
+	}})
 	tasks := []Task{}
 	env := evergreen.GetEnvironment()
 	ctx, cancel := env.Context()


### PR DESCRIPTION
Query Execution time for fetching tasks for https://spruce.mongodb.com/version/5ea9c9fc7742ae2842c23bb3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Before this change: 2127 ms
After this change: 435 ms