### PR TITLE
EVG-14080 use merged project in patch route validation

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -190,7 +190,7 @@ imports:
   - name: github.com/robfig/cron
     version: 70971dc81bab3671fde85647b0a1367929f92be8
   - name: github.com/evergreen-ci/utility
-    version: 4582e840f25813bc71566b2379a2ec7f2e247d49
+    version: e4d6d5b88c672031742d8c0710f0ada8a759564a
 
   - name: github.com/robbiet480/go.sns
     version: ca087b49e1da69fa4f163521cc98b1eaf7b66ffd

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -518,11 +518,11 @@ func FindMergedProjectRef(identifier string) (*ProjectRef, error) {
 	return pRef, nil
 }
 
-// MergeProjectRefWithRepo merges the project with the repo that matches it, if one exists.
+// GetProjectRefMergedWithRepo merges the project with the repo that matches it, if one exists.
 // Otherwise, it will return the project as given.
-func MergeProjectRefWithRepo(pRef *ProjectRef) (*ProjectRef, error) {
+func GetProjectRefMergedWithRepo(pRef ProjectRef) (*ProjectRef, error) {
 	if !pRef.UseRepoSettings {
-		return pRef, nil
+		return &pRef, nil
 	}
 	if pRef.RepoRefId != "" {
 		repoRef, err := FindOneRepoRef(pRef.RepoRefId)
@@ -532,17 +532,17 @@ func MergeProjectRefWithRepo(pRef *ProjectRef) (*ProjectRef, error) {
 		if repoRef == nil {
 			return nil, errors.Errorf("repo ref '%s' does not exist", pRef.RepoRefId)
 		}
-		return mergeBranchAndRepoSettings(pRef, repoRef)
+		return mergeBranchAndRepoSettings(&pRef, repoRef)
 	}
 	repoRef, err := FindRepoRefByOwnerAndRepo(pRef.Owner, pRef.Repo)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error finding repo ref for repo '%s/%s'", pRef.Owner, pRef.Repo)
 	}
 	if repoRef == nil {
-		return pRef, nil
+		return &pRef, nil
 	}
 	pRef.RepoRefId = repoRef.Id
-	return mergeBranchAndRepoSettings(pRef, repoRef)
+	return mergeBranchAndRepoSettings(&pRef, repoRef)
 }
 
 // If the setting is not defined in the project, default to the repo settings.

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -518,6 +518,33 @@ func FindMergedProjectRef(identifier string) (*ProjectRef, error) {
 	return pRef, nil
 }
 
+// MergeProjectRefWithRepo merges the project with the repo that matches it, if one exists.
+// Otherwise, it will return the project as given.
+func MergeProjectRefWithRepo(pRef *ProjectRef) (*ProjectRef, error) {
+	if !pRef.UseRepoSettings {
+		return pRef, nil
+	}
+	if pRef.RepoRefId != "" {
+		repoRef, err := FindOneRepoRef(pRef.RepoRefId)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error finding repo ref '%s'", pRef.RepoRefId)
+		}
+		if repoRef == nil {
+			return nil, errors.Errorf("repo ref '%s' does not exist", pRef.RepoRefId)
+		}
+		return mergeBranchAndRepoSettings(pRef, repoRef)
+	}
+	repoRef, err := FindRepoRefByOwnerAndRepo(pRef.Owner, pRef.Repo)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error finding repo ref for repo '%s/%s'", pRef.Owner, pRef.Repo)
+	}
+	if repoRef == nil {
+		return pRef, nil
+	}
+	pRef.RepoRefId = repoRef.Id
+	return mergeBranchAndRepoSettings(pRef, repoRef)
+}
+
 // If the setting is not defined in the project, default to the repo settings.
 func mergeBranchAndRepoSettings(pRef *ProjectRef, repoRef *RepoRef) (*ProjectRef, error) {
 	var err error

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -128,7 +128,7 @@ type MockAliasConnector struct {
 
 // FindAllAliases is a mock implementation for testing.
 func (d *MockAliasConnector) FindProjectAliases(projectId, repoId string, aliasesToAdd []restModel.APIProjectAlias) ([]restModel.APIProjectAlias, error) {
-	return d.Aliases, nil
+	return append(d.Aliases, aliasesToAdd...), nil
 }
 
 func (d *MockAliasConnector) CopyProjectAliases(oldProjectId, newProjectId string) error {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -338,7 +338,7 @@ type Connector interface {
 	EnqueueItem(string, restModel.APICommitQueueItem, bool) (int, error)
 	AddPatchForPr(ctx context.Context, projectRef model.ProjectRef, prNum int, modules []restModel.APIModule, messageOverride string) (string, error)
 	FindCommitQueueForProject(string) (*restModel.APICommitQueue, error)
-	EnableCommitQueue(*model.ProjectRef, model.CommitQueueParams) error
+	EnableCommitQueue(*model.ProjectRef) error
 	CommitQueueRemoveItem(string, string, string) (*restModel.APICommitQueueItem, error)
 	IsItemOnCommitQueue(string, string) (bool, error)
 	CommitQueueClearAll() (int, error)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -143,7 +143,7 @@ func (pc *DBProjectConnector) EnablePRTesting(projectRef *model.ProjectRef) erro
 	return nil
 }
 
-func (pc *DBProjectConnector) EnableCommitQueue(projectRef *model.ProjectRef, commitQueueParams model.CommitQueueParams) error {
+func (pc *DBProjectConnector) EnableCommitQueue(projectRef *model.ProjectRef) error {
 	if ok, err := projectRef.CanEnableCommitQueue(); err != nil {
 		return errors.Wrap(err, "error enabling commit queue")
 	} else if !ok {
@@ -618,7 +618,7 @@ func (pc *MockProjectConnector) EnableWebhooks(ctx context.Context, projectRef *
 	return true, nil
 }
 
-func (pc *MockProjectConnector) EnableCommitQueue(projectRef *model.ProjectRef, commitQueueParams model.CommitQueueParams) error {
+func (pc *MockProjectConnector) EnableCommitQueue(projectRef *model.ProjectRef) error {
 	return nil
 }
 

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -47,7 +47,7 @@ func (cqParams *APICommitQueueParams) BuildFromService(h interface{}) error {
 		return errors.Errorf("Invalid commit queue params of type '%T'", h)
 	}
 
-	cqParams.Enabled = params.Enabled
+	cqParams.Enabled = utility.BoolPtrCopy(params.Enabled)
 	cqParams.MergeMethod = utility.ToStringPtr(params.MergeMethod)
 	cqParams.Message = utility.ToStringPtr(params.Message)
 
@@ -56,7 +56,7 @@ func (cqParams *APICommitQueueParams) BuildFromService(h interface{}) error {
 
 func (cqParams *APICommitQueueParams) ToService() (interface{}, error) {
 	serviceParams := model.CommitQueueParams{}
-	serviceParams.Enabled = cqParams.Enabled
+	serviceParams.Enabled = utility.BoolPtrCopy(cqParams.Enabled)
 	serviceParams.MergeMethod = utility.FromStringPtr(cqParams.MergeMethod)
 	serviceParams.Message = utility.FromStringPtr(cqParams.Message)
 
@@ -71,8 +71,8 @@ type APITaskSyncOptions struct {
 func (opts *APITaskSyncOptions) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case model.TaskSyncOptions:
-		opts.ConfigEnabled = v.ConfigEnabled
-		opts.PatchEnabled = v.PatchEnabled
+		opts.ConfigEnabled = utility.BoolPtrCopy(v.ConfigEnabled)
+		opts.PatchEnabled = utility.BoolPtrCopy(v.PatchEnabled)
 		return nil
 	default:
 		return errors.Errorf("invalid type '%T' for API S3 task sync options", v)
@@ -81,8 +81,8 @@ func (opts *APITaskSyncOptions) BuildFromService(h interface{}) error {
 
 func (opts *APITaskSyncOptions) ToService() (interface{}, error) {
 	return model.TaskSyncOptions{
-		ConfigEnabled: opts.ConfigEnabled,
-		PatchEnabled:  opts.PatchEnabled,
+		ConfigEnabled: utility.BoolPtrCopy(opts.ConfigEnabled),
+		PatchEnabled:  utility.BoolPtrCopy(opts.PatchEnabled),
 	}, nil
 }
 
@@ -231,31 +231,31 @@ func (p *APIProjectRef) ToService() (interface{}, error) {
 		Owner:                 utility.FromStringPtr(p.Owner),
 		Repo:                  utility.FromStringPtr(p.Repo),
 		Branch:                utility.FromStringPtr(p.Branch),
-		Enabled:               p.Enabled,
-		Private:               p.Private,
+		Enabled:               utility.BoolPtrCopy(p.Enabled),
+		Private:               utility.BoolPtrCopy(p.Private),
 		BatchTime:             p.BatchTime,
 		RemotePath:            utility.FromStringPtr(p.RemotePath),
 		Id:                    utility.FromStringPtr(p.Id),
 		Identifier:            utility.FromStringPtr(p.Identifier),
 		DisplayName:           utility.FromStringPtr(p.DisplayName),
-		DeactivatePrevious:    p.DeactivatePrevious,
-		TracksPushEvents:      p.TracksPushEvents,
+		DeactivatePrevious:    utility.BoolPtrCopy(p.DeactivatePrevious),
+		TracksPushEvents:      utility.BoolPtrCopy(p.TracksPushEvents),
 		DefaultLogger:         utility.FromStringPtr(p.DefaultLogger),
-		PRTestingEnabled:      p.PRTestingEnabled,
-		GitTagVersionsEnabled: p.GitTagVersionsEnabled,
-		GithubChecksEnabled:   p.GithubChecksEnabled,
+		PRTestingEnabled:      utility.BoolPtrCopy(p.PRTestingEnabled),
+		GitTagVersionsEnabled: utility.BoolPtrCopy(p.GitTagVersionsEnabled),
+		GithubChecksEnabled:   utility.BoolPtrCopy(p.GithubChecksEnabled),
 		UseRepoSettings:       p.UseRepoSettings,
 		RepoRefId:             utility.FromStringPtr(p.RepoRefId),
 		CommitQueue:           commitQueue.(model.CommitQueueParams),
 		TaskSync:              taskSync,
 		WorkstationConfig:     workstationConfig,
-		Hidden:                p.Hidden,
-		PatchingDisabled:      p.PatchingDisabled,
-		RepotrackerDisabled:   p.RepotrackerDisabled,
-		DispatchingDisabled:   p.DispatchingDisabled,
-		DisabledStatsCache:    p.DisabledStatsCache,
+		Hidden:                utility.BoolPtrCopy(p.Hidden),
+		PatchingDisabled:      utility.BoolPtrCopy(p.PatchingDisabled),
+		RepotrackerDisabled:   utility.BoolPtrCopy(p.RepotrackerDisabled),
+		DispatchingDisabled:   utility.BoolPtrCopy(p.DispatchingDisabled),
+		DisabledStatsCache:    utility.BoolPtrCopy(p.DisabledStatsCache),
 		FilesIgnoredFromCache: utility.FromStringPtrSlice(p.FilesIgnoredFromCache),
-		NotifyOnBuildFailure:  p.NotifyOnBuildFailure,
+		NotifyOnBuildFailure:  utility.BoolPtrCopy(p.NotifyOnBuildFailure),
 		SpawnHostScriptPath:   utility.FromStringPtr(p.SpawnHostScriptPath),
 		Admins:                utility.FromStringPtrSlice(p.Admins),
 		GitTagAuthorizedUsers: utility.FromStringPtrSlice(p.GitTagAuthorizedUsers),
@@ -314,31 +314,31 @@ func (p *APIProjectRef) BuildFromService(v interface{}) error {
 	p.Owner = utility.ToStringPtr(projectRef.Owner)
 	p.Repo = utility.ToStringPtr(projectRef.Repo)
 	p.Branch = utility.ToStringPtr(projectRef.Branch)
-	p.Enabled = projectRef.Enabled
-	p.Private = projectRef.Private
+	p.Enabled = utility.BoolPtrCopy(projectRef.Enabled)
+	p.Private = utility.BoolPtrCopy(projectRef.Private)
 	p.BatchTime = projectRef.BatchTime
 	p.RemotePath = utility.ToStringPtr(projectRef.RemotePath)
 	p.Id = utility.ToStringPtr(projectRef.Id)
 	p.Identifier = utility.ToStringPtr(projectRef.Identifier)
 	p.DisplayName = utility.ToStringPtr(projectRef.DisplayName)
 	p.DeactivatePrevious = projectRef.DeactivatePrevious
-	p.TracksPushEvents = projectRef.TracksPushEvents
+	p.TracksPushEvents = utility.BoolPtrCopy(projectRef.TracksPushEvents)
 	p.DefaultLogger = utility.ToStringPtr(projectRef.DefaultLogger)
-	p.PRTestingEnabled = projectRef.PRTestingEnabled
-	p.GitTagVersionsEnabled = projectRef.GitTagVersionsEnabled
-	p.GithubChecksEnabled = projectRef.GithubChecksEnabled
+	p.PRTestingEnabled = utility.BoolPtrCopy(projectRef.PRTestingEnabled)
+	p.GitTagVersionsEnabled = utility.BoolPtrCopy(projectRef.GitTagVersionsEnabled)
+	p.GithubChecksEnabled = utility.BoolPtrCopy(projectRef.GithubChecksEnabled)
 	p.UseRepoSettings = projectRef.UseRepoSettings
 	p.RepoRefId = utility.ToStringPtr(projectRef.RepoRefId)
 	p.CommitQueue = cq
 	p.TaskSync = taskSync
 	p.WorkstationConfig = workstationConfig
-	p.Hidden = projectRef.Hidden
-	p.PatchingDisabled = projectRef.PatchingDisabled
-	p.RepotrackerDisabled = projectRef.RepotrackerDisabled
-	p.DispatchingDisabled = projectRef.DispatchingDisabled
-	p.DisabledStatsCache = projectRef.DisabledStatsCache
+	p.Hidden = utility.BoolPtrCopy(projectRef.Hidden)
+	p.PatchingDisabled = utility.BoolPtrCopy(projectRef.PatchingDisabled)
+	p.RepotrackerDisabled = utility.BoolPtrCopy(projectRef.RepotrackerDisabled)
+	p.DispatchingDisabled = utility.BoolPtrCopy(projectRef.DispatchingDisabled)
+	p.DisabledStatsCache = utility.BoolPtrCopy(projectRef.DisabledStatsCache)
 	p.FilesIgnoredFromCache = utility.ToStringPtrSlice(projectRef.FilesIgnoredFromCache)
-	p.NotifyOnBuildFailure = projectRef.NotifyOnBuildFailure
+	p.NotifyOnBuildFailure = utility.BoolPtrCopy(projectRef.NotifyOnBuildFailure)
 	p.SpawnHostScriptPath = utility.ToStringPtr(projectRef.SpawnHostScriptPath)
 	p.Admins = utility.ToStringPtrSlice(projectRef.Admins)
 	p.GitTagAuthorizedUsers = utility.ToStringPtrSlice(projectRef.GitTagAuthorizedUsers)

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -309,7 +309,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 
 	// if the project ref doesn't use the repo, then this will just be the same as newProjectRef
 	// used to verify that if something is set to nil in the request, we properly validate using the merged project ref
-	mergedProjectRef, err := dbModel.MergeProjectRefWithRepo(h.newProjectRef)
+	mergedProjectRef, err := dbModel.GetProjectRefMergedWithRepo(*h.newProjectRef)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "error merging project ref"))
 	}

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -138,6 +138,7 @@ func (s *ProjectPatchByIDSuite) TestGitTagVersionsEnabled() {
 		Owner:                 h.originalProject.Owner,
 		Repo:                  h.originalProject.Repo,
 		GitTagAuthorizedUsers: []string{"special"},
+		Restricted:            utility.FalsePtr(),
 	}}
 	s.NoError(repoRef.Add(nil))
 
@@ -158,6 +159,13 @@ func (s *ProjectPatchByIDSuite) TestGitTagVersionsEnabled() {
 	s.NotNil(resp)
 	s.NotNil(resp.Data())
 	s.Require().Equal(http.StatusOK, resp.Status())
+
+	// verify that the repo fields weren't saved with the branch
+	p, err := s.sc.FindProjectById("dimoxinil", false)
+	s.NoError(err)
+	s.Require().NotNil(p)
+	s.Empty(p.GitTagAuthorizedUsers)
+	s.Nil(p.Restricted)
 }
 
 func (s *ProjectPatchByIDSuite) TestUseRepoSettings() {

--- a/vendor/github.com/evergreen-ci/utility/http.go
+++ b/vendor/github.com/evergreen-ci/utility/http.go
@@ -296,7 +296,7 @@ func IsTemporaryError(err error) bool {
 // error message with the HTTP status and raw response body.
 func RespErrorf(resp *http.Response, format string, args ...interface{}) error {
 	if resp == nil {
-		return errors.Errorf(format, args)
+		return errors.Errorf(format, args...)
 	}
 	wrapError := func(err error) error {
 		err = errors.Wrapf(err, "HTTP status code %d", resp.StatusCode)
@@ -348,7 +348,7 @@ func RetryRequest(ctx context.Context, r *http.Request, maxAttempts int, minBack
 			} else if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 				return resp, nil
 			} else if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-				return resp, errors.Errorf("server returned status %f", resp.StatusCode)
+				return resp, errors.Errorf("server returned status %d", resp.StatusCode)
 			}
 
 			// if we get here it should most likely be a 5xx status code

--- a/vendor/github.com/evergreen-ci/utility/optional.go
+++ b/vendor/github.com/evergreen-ci/utility/optional.go
@@ -42,6 +42,7 @@ func FromBoolTPtr(in *bool) bool {
 	return *in
 }
 
+// BoolPtrCopy creates a new pointer with the same value as in.
 func BoolPtrCopy(in *bool) *bool {
 	if in == nil {
 		return nil

--- a/vendor/github.com/evergreen-ci/utility/optional.go
+++ b/vendor/github.com/evergreen-ci/utility/optional.go
@@ -42,6 +42,13 @@ func FromBoolTPtr(in *bool) bool {
 	return *in
 }
 
+func BoolPtrCopy(in *bool) *bool {
+	if in == nil {
+		return nil
+	}
+	return ToBoolPtr(*in)
+}
+
 // ToIntPtr returns a pointer to an int value.
 func ToIntPtr(in int) *int {
 	return &in

--- a/vendor/github.com/evergreen-ci/utility/parsing.go
+++ b/vendor/github.com/evergreen-ci/utility/parsing.go
@@ -44,7 +44,7 @@ func ReadJSON(r io.ReadCloser, target interface{}) error {
 }
 
 // ReadYAMLFile parses yaml into the target argument from the file
-// located at the specifed path.
+// located at the specified path.
 func ReadYAMLFile(path string, target interface{}) error {
 	if !FileExists(path) {
 		return errors.Errorf("file '%s' does not exist", path)
@@ -73,7 +73,7 @@ func ReadYAMLFileStrict(path string, target interface{}) error {
 }
 
 // ReadJSONFile parses json into the target argument from the file
-// located at the specifed path.
+// located at the specified path.
 func ReadJSONFile(path string, target interface{}) error {
 	if !FileExists(path) {
 		return errors.Errorf("file '%s' does not exist", path)

--- a/vendor/github.com/evergreen-ci/utility/slice.go
+++ b/vendor/github.com/evergreen-ci/utility/slice.go
@@ -106,7 +106,7 @@ func GetSetDifference(a, b []string) []string {
 	return d
 }
 
-// IndexOf returns the first occurence of a string in a sorted array
+// IndexOf returns the first occurrence of a string in a sorted array
 func IndexOf(a []string, toFind string) int {
 	i := sort.Search(len(a), func(index int) bool {
 		return strings.Compare(a[index], toFind) >= 0

--- a/vendor/github.com/evergreen-ci/utility/slice.go
+++ b/vendor/github.com/evergreen-ci/utility/slice.go
@@ -23,7 +23,7 @@ func StringSliceContains(slice []string, item string) bool {
 // StringSliceIntersection returns the intersecting elements of slices a and b.
 func StringSliceIntersection(a, b []string) []string {
 	inA := map[string]bool{}
-	out := []string{}
+	var out []string
 	for _, elem := range a {
 		inA[elem] = true
 	}
@@ -44,7 +44,7 @@ func StringSliceSymmetricDifference(a, b []string) ([]string, []string) {
 		mapA[elem] = true
 		mapAcopy[elem] = true
 	}
-	inB := []string{}
+	var inB []string
 	for _, elem := range b {
 		if mapAcopy[elem] { // need to delete from the copy in case B has duplicates of the same value in A
 			delete(mapA, elem)
@@ -52,7 +52,7 @@ func StringSliceSymmetricDifference(a, b []string) ([]string, []string) {
 			inB = append(inB, elem)
 		}
 	}
-	inA := []string{}
+	var inA []string
 	for elem := range mapA {
 		inA = append(inA, elem)
 	}
@@ -63,7 +63,7 @@ func StringSliceSymmetricDifference(a, b []string) ([]string, []string) {
 // Order is preserved.
 func UniqueStrings(slice []string) []string {
 	seen := map[string]bool{}
-	out := []string{}
+	var out []string
 	for _, s := range slice {
 		if seen[s] {
 			continue

--- a/vendor/github.com/evergreen-ci/utility/time.go
+++ b/vendor/github.com/evergreen-ci/utility/time.go
@@ -32,9 +32,16 @@ func FromNanoseconds(duration time.Duration) int64 {
 	return int64(duration) / 1000000
 }
 
-// fromNanoSeconds returns milliseconds of a duration for queries in the database.
+// ToNanoSeconds returns milliseconds of a duration for queries in the database.
 func ToNanoseconds(duration time.Duration) time.Duration {
 	return duration * 1000000
+}
+
+// BSONTime converts a timestamp to how it would be represented in BSON such
+// that, if the resulting timestamp is roundtripped to BSON and back, the
+// timestamps would be identical.
+func BSONTime(t time.Time) time.Time {
+	return t.UTC().Truncate(time.Millisecond)
 }
 
 // FromPythonTime returns a time.Time that corresponds to the float style


### PR DESCRIPTION
For the patch route testing, we should consider the merged project, so we don't incorrectly error about aliases, for example.
In testing this PR I found a couple of bugs:
- Because the service routes passed the bool pointers directly, changing one bool would also change the other, so I made a new utility function.
- Some of the service functions still return an initialized string slice, rather than a nil string slice, for nil input.

If these changes are approved, I'll make a utility PR for those pieces.