### PR TITLE
EVG-13560 Don't set xtrace in patch lifecycle

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -239,7 +239,6 @@ func MakePatchedConfig(ctx context.Context, env evergreen.Environment, p *patch.
 
 		// selectively apply the patch to the config file
 		patchCommandStrings := []string{
-			fmt.Sprintf("set -o xtrace"),
 			fmt.Sprintf("set -o errexit"),
 			fmt.Sprintf("git apply --whitespace=fix --include=%v < '%v'",
 				remoteConfigPath, patchFilePath),


### PR DESCRIPTION
It only makes sense to `set -o xtrace` in the agent, since the entire output of the shell script is visible. In the patch lifecycle, this executes on the app server. Since the stderr logger is set to the error level, we end up with xtrace debugging output in Splunk. Instead, we should only log to stderr if there really is an error. 