### PR TITLE
EVG-14108 reset more data when restarting tasks

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -581,8 +581,9 @@ var (
 	}
 
 	// constant arrays for db update logic
-	AbortableStatuses = []string{TaskStarted, TaskDispatched}
-	CompletedStatuses = []string{TaskSucceeded, TaskFailed}
+	AbortableStatuses   = []string{TaskStarted, TaskDispatched}
+	CompletedStatuses   = []string{TaskSucceeded, TaskFailed}
+	UncompletedStatuses = []string{TaskStarted, TaskUnstarted, TaskUndispatched, TaskDispatched, TaskConflict, TaskInactive}
 
 	SyncStatuses = []string{TaskSucceeded, TaskFailed}
 

--- a/globals.go
+++ b/globals.go
@@ -583,7 +583,7 @@ var (
 	// constant arrays for db update logic
 	AbortableStatuses   = []string{TaskStarted, TaskDispatched}
 	CompletedStatuses   = []string{TaskSucceeded, TaskFailed}
-	UncompletedStatuses = []string{TaskStarted, TaskUnstarted, TaskUndispatched, TaskDispatched, TaskConflict, TaskInactive}
+	UncompletedStatuses = []string{TaskStarted, TaskUnstarted, TaskUndispatched, TaskDispatched, TaskConflict}
 
 	SyncStatuses = []string{TaskSucceeded, TaskFailed}
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -471,15 +471,14 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 	// only need to do one update per-build instead of one per-task here.
 	// Doesn't seem to be possible as-is because $ can only apply to one array element matched per
 	// document.
-	err = build.SetBuildStartedForTasks(tasksToRestart, caller)
-	if err != nil {
+	if err = build.SetBuildStartedForTasks(tasksToRestart, caller); err != nil {
 		return errors.Wrapf(err, "error setting builds started")
 	}
 	version, err := VersionFindOneId(versionId)
 	if err != nil {
 		return errors.Wrap(err, "unable to find version")
 	}
-	return errors.Wrap(version.ChangeStatus(evergreen.VersionStarted), "unable to change version status")
+	return errors.Wrap(version.UpdateStatus(evergreen.VersionStarted), "unable to change version status")
 }
 
 // RestartBuild restarts completed tasks associated with a given buildId.

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1858,6 +1858,9 @@ func TestVersionRestart(t *testing.T) {
 		assert.Equal(evergreen.TaskUndispatched, t.Status)
 		assert.True(t.Activated)
 	}
+	dbVersion, err := VersionFindOneId("version")
+	assert.NoError(err)
+	assert.Equal(evergreen.VersionStarted, dbVersion.Status)
 
 	// test that aborting in-progress tasks works correctly
 	assert.NoError(resetTaskData())
@@ -1870,6 +1873,9 @@ func TestVersionRestart(t *testing.T) {
 	assert.Equal("test", dbTask.AbortInfo.User)
 	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
 	assert.True(dbTask.Activated)
+	dbVersion, err = VersionFindOneId("version")
+	assert.NoError(err)
+	assert.Equal(evergreen.VersionStarted, dbVersion.Status)
 
 	// test that not aborting in-progress tasks does not reset them
 	assert.NoError(resetTaskData())
@@ -1880,6 +1886,9 @@ func TestVersionRestart(t *testing.T) {
 	assert.NotNil(dbTask)
 	assert.False(dbTask.Aborted)
 	assert.Equal(evergreen.TaskDispatched, dbTask.Status)
+	dbVersion, err = VersionFindOneId("version")
+	assert.NoError(err)
+	assert.Equal(evergreen.VersionStarted, dbVersion.Status)
 }
 
 func TestDisplayTaskRestart(t *testing.T) {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1367,11 +1367,14 @@ func (t *Task) Reset() error {
 			ScheduledTimeKey:       utility.ZeroTime,
 			FinishTimeKey:          utility.ZeroTime,
 			DependenciesMetTimeKey: utility.ZeroTime,
+			LastHeartbeatKey:       utility.ZeroTime,
 		},
 		"$unset": bson.M{
 			DetailsKey:           "",
 			ResetWhenFinishedKey: "",
 			HasCedarResultsKey:   "",
+			HostIdKey:            "",
+			AgentVersionKey:      "",
 		},
 	}
 
@@ -1394,16 +1397,21 @@ func ResetTasks(taskIds []string) error {
 			"$set": bson.M{
 				ActivatedKey:           true,
 				SecretKey:              utility.RandomString(),
+				HostIdKey:              "",
 				StatusKey:              evergreen.TaskUndispatched,
 				DispatchTimeKey:        utility.ZeroTime,
 				StartTimeKey:           utility.ZeroTime,
 				ScheduledTimeKey:       utility.ZeroTime,
 				FinishTimeKey:          utility.ZeroTime,
 				DependenciesMetTimeKey: utility.ZeroTime,
+				TimeTakenKey:           utility.ZeroTime,
 			},
 			"$unset": bson.M{
-				DetailsKey:         "",
-				HasCedarResultsKey: "",
+				DetailsKey:           "",
+				HasCedarResultsKey:   "",
+				ResetWhenFinishedKey: "",
+				CostKey:              "",
+				SpawnedHostCostKey:   "",
 			},
 		},
 	)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -849,6 +849,9 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 	if err != nil {
 		return errors.Wrap(err, "error finding version")
 	}
+	if v == nil {
+		return errors.Errorf("version '%s' not found", b.Version)
+	}
 
 	if b.Status == evergreen.BuildCreated || unfinishedTasks > 0 {
 		if err = b.UpdateStatus(evergreen.BuildStarted); err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -857,7 +857,7 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 		if err = b.UpdateStatus(evergreen.BuildStarted); err != nil {
 			return errors.Wrap(err, "Error updating build status")
 		}
-		if err = v.ChangeStatus(evergreen.VersionStarted); err != nil {
+		if err = v.UpdateStatus(evergreen.VersionStarted); err != nil {
 			return errors.Wrap(err, "unable to update version status")
 		}
 		updates.BuildNewStatus = evergreen.BuildStarted
@@ -917,7 +917,7 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 		if err != nil {
 			return errors.Wrap(err, "error updating build status")
 		}
-		if err = v.ChangeStatus(evergreen.VersionCreated); err != nil {
+		if err = v.UpdateStatus(evergreen.VersionCreated); err != nil {
 			return errors.Wrap(err, "unable to update version status")
 		}
 		updates.BuildNewStatus = evergreen.BuildCreated

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -853,7 +853,7 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 		return errors.Errorf("version '%s' not found", b.Version)
 	}
 
-	if b.Status == evergreen.BuildCreated || unfinishedTasks > 0 {
+	if b.Status == evergreen.BuildCreated || (unfinishedTasks > 0 && finishedTasks > 0) {
 		if err = b.UpdateStatus(evergreen.BuildStarted); err != nil {
 			return errors.Wrap(err, "Error updating build status")
 		}
@@ -911,7 +911,6 @@ func UpdateBuildAndVersionStatusForTask(taskId string, updates *StatusChanges) e
 		}
 	}
 
-	// this is helpful for when we restart a compile task
 	if finishedTasks == 0 {
 		err = b.UpdateStatus(evergreen.BuildCreated)
 		if err != nil {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2523,7 +2523,6 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 
 	updates := StatusChanges{}
 	assert.NoError(MarkEnd(testTask, "", time.Now(), details, false, &updates))
-	assert.Empty(updates.BuildNewStatus)
 	assert.False(updates.BuildComplete)
 	assert.Empty(updates.VersionNewStatus)
 	assert.False(updates.VersionComplete)
@@ -2537,7 +2536,6 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 
 	updates = StatusChanges{}
 	assert.NoError(MarkEnd(anotherTask, "", time.Now(), details, false, &updates))
-	assert.Empty(updates.BuildNewStatus)
 	assert.False(updates.BuildComplete)
 	assert.Empty(updates.VersionNewStatus)
 	assert.False(updates.VersionComplete)
@@ -2551,7 +2549,6 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 
 	updates = StatusChanges{}
 	assert.NoError(MarkEnd(exeTask0, "", time.Now(), details, false, &updates))
-	assert.Empty(updates.BuildNewStatus)
 	assert.False(updates.BuildComplete)
 	assert.Empty(updates.VersionNewStatus)
 	assert.False(updates.VersionComplete)
@@ -2581,7 +2578,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 
 	e, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
 	assert.NoError(err)
-	assert.Len(e, 7)
+	assert.Len(e, 10)
 }
 
 func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *testing.T) {
@@ -2762,7 +2759,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 }
 
 func TestClearAndResetStrandedTask(t *testing.T) {
-	require.NoError(t, db.ClearCollections(host.Collection, task.Collection, task.OldCollection, build.Collection), t, "error clearing collection")
+	require.NoError(t, db.ClearCollections(host.Collection, task.Collection, task.OldCollection, build.Collection, VersionCollection), t, "error clearing collection")
 	assert := assert.New(t)
 
 	runningTask := &task.Task{
@@ -2787,8 +2784,13 @@ func TestClearAndResetStrandedTask(t *testing.T) {
 				Id: "t",
 			},
 		},
+		Version: "version",
 	}
 	assert.NoError(b.Insert())
+	v := Version{
+		Id: b.Version,
+	}
+	assert.NoError(v.Insert())
 
 	assert.NoError(ClearAndResetStrandedTask(h))
 	runningTask, err := task.FindOne(task.ById("t"))

--- a/model/version.go
+++ b/model/version.go
@@ -107,7 +107,7 @@ func (v *Version) AddSatisfiedTrigger(definitionID string) error {
 	return errors.Wrap(AddSatisfiedTrigger(v.Id, definitionID), "error adding satisfied trigger")
 }
 
-func (v *Version) ChangeStatus(newStatus string) error {
+func (v *Version) UpdateStatus(newStatus string) error {
 	if v == nil {
 		return errors.New("version is nil")
 	}

--- a/model/version.go
+++ b/model/version.go
@@ -108,6 +108,9 @@ func (v *Version) AddSatisfiedTrigger(definitionID string) error {
 }
 
 func (v *Version) ChangeStatus(newStatus string) error {
+	if v == nil {
+		return errors.New("version is nil")
+	}
 	if v.Status == newStatus {
 		return nil
 	}

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -115,6 +115,7 @@ func (s *VersionConnectorSuite) SetupTest() {
 	versions := []*model.Version{
 		{Id: "version1"},
 		{Id: "version2"},
+		{Id: "version3"},
 	}
 
 	tasks := []*task.Task{
@@ -236,6 +237,7 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 	if s.isMock { // mock method not implemented
 		return
 	}
+	s.NoError(db.ClearCollections(model.ProjectRefCollection))
 
 	projRef := model.ProjectRef{
 		Id: "proj",


### PR DESCRIPTION
- Looked through the list of fields in the task data model and added more that are reset when you restart a task. The problem with the host not getting cleared was always present on the old task page, but no one reported it
- When a task is restarted, also reset the status of the build and version to "started" if it wasn't that already
- When all tasks in a version are restarted, also reset the status of the version to "started." Both of these status changes can have some non-obvious side effects, but I think they're the right change to make. The inconsistency was not noticeable in the old UI even though the old data model always had this problem, because we did not show a version status at all