### PR TITLE
EVG-14187 Add necessary fields to allow transition to Task type

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -402,10 +402,12 @@ type ComplexityRoot struct {
 	}
 
 	PatchBuildVariantTask struct {
-		BaseStatus func(childComplexity int) int
-		ID         func(childComplexity int) int
-		Name       func(childComplexity int) int
-		Status     func(childComplexity int) int
+		BaseStatus  func(childComplexity int) int
+		DisplayName func(childComplexity int) int
+		Execution   func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Name        func(childComplexity int) int
+		Status      func(childComplexity int) int
 	}
 
 	PatchDuration struct {
@@ -670,6 +672,7 @@ type ComplexityRoot struct {
 		BuildVariant            func(childComplexity int) int
 		BuildVariantDisplayName func(childComplexity int) int
 		DisplayName             func(childComplexity int) int
+		Execution               func(childComplexity int) int
 		ExecutionTasksFull      func(childComplexity int) int
 		ID                      func(childComplexity int) int
 		Status                  func(childComplexity int) int
@@ -2691,6 +2694,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PatchBuildVariantTask.BaseStatus(childComplexity), true
 
+	case "PatchBuildVariantTask.displayName":
+		if e.complexity.PatchBuildVariantTask.DisplayName == nil {
+			break
+		}
+
+		return e.complexity.PatchBuildVariantTask.DisplayName(childComplexity), true
+
+	case "PatchBuildVariantTask.execution":
+		if e.complexity.PatchBuildVariantTask.Execution == nil {
+			break
+		}
+
+		return e.complexity.PatchBuildVariantTask.Execution(childComplexity), true
+
 	case "PatchBuildVariantTask.id":
 		if e.complexity.PatchBuildVariantTask.ID == nil {
 			break
@@ -4114,6 +4131,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TaskResult.DisplayName(childComplexity), true
 
+	case "TaskResult.execution":
+		if e.complexity.TaskResult.Execution == nil {
+			break
+		}
+
+		return e.complexity.TaskResult.Execution(childComplexity), true
+
 	case "TaskResult.executionTasksFull":
 		if e.complexity.TaskResult.ExecutionTasksFull == nil {
 			break
@@ -4997,6 +5021,8 @@ type PatchBuildVariant {
 
 type PatchBuildVariantTask {
   id: ID!
+  execution: Int!
+  displayName: String!
   name: String!
   status: String!
   baseStatus: String
@@ -5112,6 +5138,7 @@ input ParameterInput {
 
 type TaskResult {
   id: ID!
+  execution: Int!
   aborted: Boolean!
   displayName: String!
   version: String!
@@ -14514,6 +14541,74 @@ func (ec *executionContext) _PatchBuildVariantTask_id(ctx context.Context, field
 	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _PatchBuildVariantTask_execution(ctx context.Context, field graphql.CollectedField, obj *PatchBuildVariantTask) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchBuildVariantTask",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Execution, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PatchBuildVariantTask_displayName(ctx context.Context, field graphql.CollectedField, obj *PatchBuildVariantTask) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchBuildVariantTask",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DisplayName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _PatchBuildVariantTask_name(ctx context.Context, field graphql.CollectedField, obj *PatchBuildVariantTask) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -20738,6 +20833,40 @@ func (ec *executionContext) _TaskResult_id(ctx context.Context, field graphql.Co
 	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _TaskResult_execution(ctx context.Context, field graphql.CollectedField, obj *TaskResult) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "TaskResult",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Execution, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _TaskResult_aborted(ctx context.Context, field graphql.CollectedField, obj *TaskResult) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -26643,6 +26772,16 @@ func (ec *executionContext) _PatchBuildVariantTask(ctx context.Context, sel ast.
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "execution":
+			out.Values[i] = ec._PatchBuildVariantTask_execution(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "displayName":
+			out.Values[i] = ec._PatchBuildVariantTask_displayName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "name":
 			out.Values[i] = ec._PatchBuildVariantTask_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -28432,6 +28571,11 @@ func (ec *executionContext) _TaskResult(ctx context.Context, sel ast.SelectionSe
 			out.Values[i] = graphql.MarshalString("TaskResult")
 		case "id":
 			out.Values[i] = ec._TaskResult_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "execution":
+			out.Values[i] = ec._TaskResult_execution(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -91,10 +91,12 @@ type PatchBuildVariant struct {
 }
 
 type PatchBuildVariantTask struct {
-	ID         string  `json:"id"`
-	Name       string  `json:"name"`
-	Status     string  `json:"status"`
-	BaseStatus *string `json:"baseStatus"`
+	ID          string  `json:"id"`
+	Execution   int     `json:"execution"`
+	DisplayName string  `json:"displayName"`
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	BaseStatus  *string `json:"baseStatus"`
 }
 
 type PatchConfigure struct {
@@ -211,6 +213,7 @@ type TaskQueueDistro struct {
 
 type TaskResult struct {
 	ID                      string           `json:"id"`
+	Execution               int              `json:"execution"`
 	Aborted                 bool             `json:"aborted"`
 	DisplayName             string           `json:"displayName"`
 	Version                 string           `json:"version"`

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1451,9 +1451,10 @@ func (r *queryResolver) PatchBuildVariants(ctx context.Context, patchID string) 
 	for _, task := range tasks {
 		baseTask := task.BaseTask
 		t := PatchBuildVariantTask{
-			ID:     task.Id,
-			Name:   task.DisplayName,
-			Status: task.GetDisplayStatus(),
+			ID:          task.Id,
+			Name:        task.DisplayName,
+			DisplayName: task.DisplayName,
+			Status:      task.GetDisplayStatus(),
 		}
 		if baseTask.Status != "" {
 			t.BaseStatus = &baseTask.Status

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -399,6 +399,8 @@ type PatchBuildVariant {
 
 type PatchBuildVariantTask {
   id: ID!
+  execution: Int!
+  displayName: String!
   name: String!
   status: String!
   baseStatus: String
@@ -514,6 +516,7 @@ input ParameterInput {
 
 type TaskResult {
   id: ID!
+  execution: Int!
   aborted: Boolean!
   displayName: String!
   version: String!


### PR DESCRIPTION
This is the first in a series of PRs that will allow us to migrate all of our subset task fields( `PatchBuildVariantTask`, `TaskResul`t) to be Full fledged Task fields.

This first pr adds a few of the `Task` Fields to the subset task fields. Most importantly `execution` which apollo uses to identify `Task` objects.