### PR TITLE
EVG-14007 simplify test_names query

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2270,7 +2270,7 @@ func FindRunnable(distroID string, removeDeps bool) ([]Task, error) {
 	return runnableTasks, nil
 }
 
-// FindVariantsWithTask returns a list of build variants between specified commmits that contain a specific task name
+// FindVariantsWithTask returns a list of build variants between specified commits that contain a specific task name
 func FindVariantsWithTask(taskName, project string, orderMin, orderMax int) ([]string, error) {
 	pipeline := []bson.M{
 		{

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -364,8 +364,9 @@ func (self *taskHistoryIterator) GetDistinctTestNames(numCommits int) ([]string,
 		[]bson.M{
 			{
 				"$match": bson.M{
-					task.BuildVariantKey: bson.M{"$in": self.BuildVariants},
-					task.DisplayNameKey:  self.TaskName,
+					task.ProjectKey:     self.ProjectName,
+					task.DisplayNameKey: self.TaskName,
+					task.RequesterKey:   evergreen.RepotrackerVersionRequester,
 				},
 			},
 			{"$sort": bson.D{{Key: task.RevisionOrderNumberKey, Value: -1}}},

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -365,8 +365,8 @@ func (self *taskHistoryIterator) GetDistinctTestNames(numCommits int) ([]string,
 			{
 				"$match": bson.M{
 					task.ProjectKey:     self.ProjectName,
-					task.DisplayNameKey: self.TaskName,
 					task.RequesterKey:   evergreen.RepotrackerVersionRequester,
+					task.DisplayNameKey: self.TaskName,
 				},
 			},
 			{"$sort": bson.D{{Key: task.RevisionOrderNumberKey, Value: -1}}},

--- a/service/task.go
+++ b/service/task.go
@@ -28,7 +28,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-var NumTestsToSearchForTestNames = 100
+var NumTasksToSearchForTestNames = 10
 
 type uiTaskData struct {
 	Id                   string                  `json:"id"`

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -279,13 +279,7 @@ func (uis *UIServer) taskHistoryTestNames(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	repo, err := model.FindRepository(project.Identifier)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 	stepTime := time.Now()
-
 	taskHistoryIterator := model.NewTaskHistoryIterator(taskName, nil,
 		project.Identifier)
 


### PR DESCRIPTION
It looks like a number of individuals are using this route ([splunk query](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20%22message%22%3D%22got%20test%20names%22%20OR%20%22message%22%3D%22error%20getting%20test%20names%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-7d%40h&latest=now&workload_pool=standard_perf&sid=1614714013.262064)), so I don't think we should get rid of it, but I think some things can be simplified (especially because this route isn't documented so we haven't made any specific promises).
1) It doesn't seem necessary to get the build variants first; By nature of searching the display name in the second query and sorting by revision, we're already filtering the build variants.
2) Added project name to the query because it should speed it up, and added requester because that's part of the build variant query but not the test names query, which seems like an oversight.
3) Changed the number of commits we're looking at from 100 to 10; this was an arbitrary change, but 100 seems excessive. I imagine test_names is used to get recent test names. This should make the lookup much less expensive.

I'll test in staging by running the query pre-changes and post-changes and seeing if there's a difference in speed (update: it's hard to see if this is statistically significant when we have such few tests, but I think we should go for it).