### PR TITLE
EVG-14221 patch author should have annotation access

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -77,7 +77,6 @@ type ComplexityRoot struct {
 		SuspectedIssues   func(childComplexity int) int
 		TaskExecution     func(childComplexity int) int
 		TaskId            func(childComplexity int) int
-		UserCanModify     func(childComplexity int) int
 		WebhookConfigured func(childComplexity int) int
 	}
 
@@ -781,7 +780,6 @@ type AnnotationResolver interface {
 	Issues(ctx context.Context, obj *model.APITaskAnnotation) ([]*model.APIIssueLink, error)
 	SuspectedIssues(ctx context.Context, obj *model.APITaskAnnotation) ([]*model.APIIssueLink, error)
 	CreatedIssues(ctx context.Context, obj *model.APITaskAnnotation) ([]*model.APIIssueLink, error)
-	UserCanModify(ctx context.Context, obj *model.APITaskAnnotation) (*bool, error)
 	WebhookConfigured(ctx context.Context, obj *model.APITaskAnnotation) (bool, error)
 }
 type HostResolver interface {
@@ -1047,13 +1045,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Annotation.TaskId(childComplexity), true
-
-	case "Annotation.userCanModify":
-		if e.complexity.Annotation.UserCanModify == nil {
-			break
-		}
-
-		return e.complexity.Annotation.UserCanModify(childComplexity), true
 
 	case "Annotation.webhookConfigured":
 		if e.complexity.Annotation.WebhookConfigured == nil {
@@ -5604,7 +5595,6 @@ type Annotation {
   issues: [IssueLink]
   suspectedIssues: [IssueLink]
   createdIssues: [IssueLink]
-  userCanModify: Boolean
   webhookConfigured: Boolean!
 }
 
@@ -7380,37 +7370,6 @@ func (ec *executionContext) _Annotation_createdIssues(ctx context.Context, field
 	res := resTmp.([]*model.APIIssueLink)
 	fc.Result = res
 	return ec.marshalOIssueLink2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIIssueLink(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Annotation_userCanModify(ctx context.Context, field graphql.CollectedField, obj *model.APITaskAnnotation) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:   "Annotation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Annotation().UserCanModify(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*bool)
-	fc.Result = res
-	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Annotation_webhookConfigured(ctx context.Context, field graphql.CollectedField, obj *model.APITaskAnnotation) (ret graphql.Marshaler) {
@@ -25106,17 +25065,6 @@ func (ec *executionContext) _Annotation(ctx context.Context, sel ast.SelectionSe
 					}
 				}()
 				res = ec._Annotation_createdIssues(ctx, field, obj)
-				return res
-			})
-		case "userCanModify":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Annotation_userCanModify(ctx, field, obj)
 				return res
 			})
 		case "webhookConfigured":

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2512,6 +2512,9 @@ func (r *taskResolver) CanModifyAnnotation(ctx context.Context, obj *restModel.A
 		if err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("error finding patch for task: %s", err.Error()))
 		}
+		if p == nil {
+			return false, InternalServerError.Send(ctx, "patch for task doesn't exist")
+		}
 		if p.Author == authUser.Username() {
 			return true, nil
 		}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	patchmodel "github.com/evergreen-ci/evergreen/model/patch"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/api"
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -22,6 +20,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/model/user"
@@ -2508,7 +2507,7 @@ func (r *taskResolver) CanModifyAnnotation(ctx context.Context, obj *restModel.A
 		return true, nil
 	}
 	if utility.StringSliceContains(evergreen.PatchRequesters, utility.FromStringPtr(obj.Requester)) {
-		p, err := patchmodel.FindOneId(utility.FromStringPtr(obj.Version))
+		p, err := patch.FindOneId(utility.FromStringPtr(obj.Version))
 		if err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("error finding patch for task: %s", err.Error()))
 		}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -953,7 +953,6 @@ type Annotation {
   issues: [IssueLink]
   suspectedIssues: [IssueLink]
   createdIssues: [IssueLink]
-  userCanModify: Boolean
   webhookConfigured: Boolean!
 }
 


### PR DESCRIPTION
Right now this only applies to the UI. Extending it to the API routes would require messing with the middleware, which is pretty complicated and I argue unnecessary. This is something we could maybe revisit if someone is having an issue, but I don't expect this.