### PR TITLE
EVG-14007 sort to use correct index

### DIFF
--- a/model/task_history.go
+++ b/model/task_history.go
@@ -369,7 +369,7 @@ func (self *taskHistoryIterator) GetDistinctTestNames(numCommits int) ([]string,
 					task.DisplayNameKey: self.TaskName,
 				},
 			},
-			{"$sort": bson.D{{Key: task.RevisionOrderNumberKey, Value: -1}}},
+			{"$sort": bson.D{{Key: task.CreateTimeKey, Value: -1}}},
 			{"$limit": numCommits},
 			{"$lookup": bson.M{
 				"from":         testresult.Collection,


### PR DESCRIPTION
So we use the index branch_1_r_1_display_name_1_create_time_1
