### PR TITLE
EVG-13305 make legacy page read-only if using repo settings

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -409,6 +409,7 @@ mciModule.controller('ProjectCtrl', function ($scope, $window, $http, $location,
           files_ignored_from_cache: data.ProjectRef.files_ignored_from_cache,
           disabled_stats_cache: data.ProjectRef.disabled_stats_cache,
           periodic_builds: data.ProjectRef.periodic_builds,
+          use_repo_settings: $scope.projectRef.use_repo_settings,
         };
 
         // Divide aliases into categories

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -95,6 +95,13 @@ Evergreen Projects
         </div>
       </div>
     </div>
+    <div class="panel panel-danger" ng-show="settingsFormData.use_repo_settings">
+      <div class="panel-heading">
+        <i class="fa fa-exclamation-circle"></i>
+        Cannot modify project that is using repo settings. This page is the read-only merge of the repo and branch project.
+        To modify the branch project with the legacy page, please unattach from the repo using the Spruce UI or the API.
+      </div>
+    </div>
     <div ng-show="trackedProjects.length>0"><a class="link" href="/project/[[projectRef.identifier]]/events">Event Log</a></div>
     <form name="settingsForm" ng-submit="saveProject(settingsFormData)">
       <fieldset style="display:inline-block;" ng-disabled="permissions.project_settings<20">
@@ -988,10 +995,11 @@ Evergreen Projects
             <label ng-hide="saveMessage">&nbsp;</label>
           </div>
         </div>
+        <label class="icon fa fa-warning project-error" ng-show="settingsFormData.use_repo_settings">Project using repo settings cannot be modified here.</label>
         <div class="row">
           <div class="col-lg-2">&nbsp;</div>
           <div class="col-lg-4">
-            <input class="btn btn-primary" input ng-disabled="!isDirty || !isBatchTimeValid(settingsFormData.batch_time)" type="submit" value="Save Changes">
+            <input class="btn btn-primary" input ng-disabled="settingsFormData.use_repo_settings || !isDirty || !isBatchTimeValid(settingsFormData.batch_time)" type="submit" value="Save Changes">
           </div>
         </div>
       </fieldset>


### PR DESCRIPTION
Rather than add ng-disabled to _every_ box on the legacy page, I added a warning to the top and bottom of the page that it's currently read only, and disabled the save button. I think it's okay to expect users to use the new UI to detach from repo, if they have a need for this page.

Top:
![image](https://user-images.githubusercontent.com/26798134/110680297-6c82d580-81a6-11eb-8b97-35b4b096f219.png)

Bottom:
![image](https://user-images.githubusercontent.com/26798134/110680317-71e02000-81a6-11eb-9272-63c7b9b55eaa.png)
