### PR TITLE
EVG-14251 change pr check in git.get_project to handle HEAD moving

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -22,6 +22,7 @@ import (
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
+	"github.com/google/go-github/github"
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
@@ -55,6 +56,7 @@ type gitFetchProject struct {
 	CommitterName  string `mapstructure:"committer_name"`
 	CommitterEmail string `mapstructure:"committer_email"`
 
+	githubClient *github.Client
 	base
 }
 
@@ -226,7 +228,7 @@ func (c *gitFetchProject) ParseParams(params map[string]interface{}) error {
 	return nil
 }
 
-func (c *gitFetchProject) buildCloneCommand(conf *internal.TaskConfig, opts cloneOpts) ([]string, error) {
+func (c *gitFetchProject) buildCloneCommand(ctx context.Context, conf *internal.TaskConfig, opts cloneOpts) ([]string, error) {
 	gitCommands := []string{
 		"set -o xtrace",
 		"set -o errexit",
@@ -243,12 +245,14 @@ func (c *gitFetchProject) buildCloneCommand(conf *internal.TaskConfig, opts clon
 	if conf.GithubPatchData.PRNumber != 0 {
 		var ref, commitToTest, branchName string
 		if conf.Task.Requester == evergreen.MergeTestRequester {
-			// GitHub creates a ref at refs/pull/[pr number]/merge
-			// pointing to the test merge commit they generate
-			// See: https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests
-			// and: https://docs.travis-ci.com/user/pull-requests/#my-pull-request-isnt-being-built
+			// proceed if github has checked if this pr is mergeable. If it hasn't checked, this request
+			// will make it check. If it's not mergeable (ie. conflict), proceed and let the merge fail
+			// https://docs.github.com/en/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests
+			commitToTest, err = c.waitForMergeableCheck(ctx, opts.owner, opts.repo, conf.GithubPatchData.PRNumber)
+			if err != nil {
+				return nil, err
+			}
 			ref = "merge"
-			commitToTest = conf.GithubPatchData.MergeCommitSHA
 			branchName = fmt.Sprintf("evg-merge-test-%s", utility.RandomString())
 		} else {
 			// Github creates a ref called refs/pull/[pr number]/head
@@ -257,11 +261,13 @@ func (c *gitFetchProject) buildCloneCommand(conf *internal.TaskConfig, opts clon
 			commitToTest = conf.GithubPatchData.HeadHash
 			branchName = fmt.Sprintf("evg-pr-test-%s", utility.RandomString())
 		}
-		gitCommands = append(gitCommands, []string{
-			fmt.Sprintf(`git fetch origin "pull/%d/%s:%s"`, conf.GithubPatchData.PRNumber, ref, branchName),
-			fmt.Sprintf(`git checkout "%s"`, branchName),
-			fmt.Sprintf("git reset --hard %s", commitToTest),
-		}...)
+		if commitToTest != "" {
+			gitCommands = append(gitCommands, []string{
+				fmt.Sprintf(`git fetch origin "pull/%d/%s:%s"`, conf.GithubPatchData.PRNumber, ref, branchName),
+				fmt.Sprintf(`git checkout "%s"`, branchName),
+				fmt.Sprintf("git reset --hard %s", commitToTest),
+			}...)
+		}
 
 	} else {
 		if opts.shallowClone {
@@ -274,6 +280,27 @@ func (c *gitFetchProject) buildCloneCommand(conf *internal.TaskConfig, opts clon
 	gitCommands = append(gitCommands, "git log --oneline -n 10")
 
 	return gitCommands, nil
+}
+
+func (c *gitFetchProject) waitForMergeableCheck(ctx context.Context, owner, repo string, prNum int) (string, error) {
+	var mergeSHA string
+	err := util.Retry(ctx, func() (bool, error) {
+		pr, _, err := c.githubClient.PullRequests.Get(ctx, owner, repo, prNum)
+		if err != nil {
+			return false, errors.Wrap(err, "error getting pull request data from Github")
+		}
+		if pr.Mergeable == nil {
+			return true, nil
+		}
+		if *pr.Mergeable {
+			mergeSHA = *pr.MergeCommitSHA
+		} else {
+			return false, errors.New("pull request is not mergeable")
+		}
+		return false, nil
+	}, 10, time.Second, time.Second)
+
+	return mergeSHA, err
 }
 
 func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opts cloneOpts, ref string, modulePatch *patch.ModulePatch) ([]string, error) {
@@ -314,6 +341,15 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 // Execute gets the source code required by the project
 // Retries some number of times before failing
 func (c *gitFetchProject) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
+	if c.githubClient == nil {
+		token := c.Token
+		if token == "" {
+			token = conf.Expansions.Get(evergreen.GlobalGitHubTokenExpansion)
+		}
+		httpClient := utility.GetOAuth2HTTPClient(token)
+		defer utility.PutHTTPClient(httpClient)
+		c.githubClient = github.NewClient(httpClient)
+	}
 	err := util.Retry(
 		ctx,
 		func() (bool, error) {
@@ -369,7 +405,7 @@ func (c *gitFetchProject) executeLoop(ctx context.Context,
 		return errors.Wrap(err, "could not validate options for cloning")
 	}
 
-	gitCommands, err := c.buildCloneCommand(conf, opts)
+	gitCommands, err := c.buildCloneCommand(ctx, conf, opts)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -246,7 +246,7 @@ func (c *gitFetchProject) buildCloneCommand(ctx context.Context, conf *internal.
 		var ref, commitToTest, branchName string
 		if conf.Task.Requester == evergreen.MergeTestRequester {
 			// proceed if github has checked if this pr is mergeable. If it hasn't checked, this request
-			// will make it check. If it's not mergeable (ie. conflict), proceed and let the merge fail
+			// will make it check. If it's not mergeable (ie. conflict), proceed and let the merge fail in git.merge_pr
 			// https://docs.github.com/en/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests
 			commitToTest, err = c.waitForMergeableCheck(ctx, opts.owner, opts.repo, conf.GithubPatchData.PRNumber)
 			if err != nil {
@@ -292,7 +292,7 @@ func (c *gitFetchProject) waitForMergeableCheck(ctx context.Context, owner, repo
 		if pr.Mergeable == nil {
 			return true, nil
 		}
-		if *pr.Mergeable {
+		if *pr.Mergeable && pr.MergeCommitSHA != nil {
 			mergeSHA = *pr.MergeCommitSHA
 		} else {
 			return false, errors.New("pull request is not mergeable")

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -159,7 +159,7 @@ func (s *GitGetProjectSuite) TestBuildCloneCommandUsesHTTPS() {
 		token:  c.Token,
 	}
 	s.Require().NoError(opts.setLocation())
-	cmds, _ := c.buildCloneCommand(conf, opts)
+	cmds, _ := c.buildCloneCommand(context.Background(), conf, opts)
 	s.Equal("git clone https://PROJECTTOKEN:x-oauth-basic@github.com/deafgoat/mci_test.git 'dir' --branch 'master'", cmds[5])
 }
 
@@ -178,7 +178,7 @@ func (s *GitGetProjectSuite) TestBuildCloneCommandWithHTTPSNeedsToken() {
 		token:  "",
 	}
 	s.Require().NoError(opts.setLocation())
-	_, err := c.buildCloneCommand(conf, opts)
+	_, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.Error(err)
 }
 
@@ -197,7 +197,7 @@ func (s *GitGetProjectSuite) TestBuildCloneCommandUsesSSH() {
 		dir:    c.Directory,
 	}
 	s.Require().NoError(opts.setLocation())
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.Require().NoError(err)
 	s.Equal("git clone 'git@github.com:deafgoat/mci_test.git' 'dir' --branch 'main'", cmds[3])
 }
@@ -215,7 +215,7 @@ func (s *GitGetProjectSuite) TestBuildCloneCommandDefaultCloneMethodUsesSSH() {
 		dir:    c.Directory,
 	}
 	s.Require().NoError(opts.setLocation())
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.Require().NoError(err)
 	s.Equal("git clone 'git@github.com:evergreen-ci/sample.git' 'dir' --branch 'main'", cmds[3])
 }
@@ -485,7 +485,7 @@ func (s *GitGetProjectSuite) TestBuildCommand() {
 		dir:    c.Directory,
 	}
 	s.Require().NoError(opts.setLocation())
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.NoError(err)
 	s.Require().Len(cmds, 7)
 	s.Equal("set -o xtrace", cmds[0])
@@ -502,7 +502,7 @@ func (s *GitGetProjectSuite) TestBuildCommand() {
 	opts.token = c.Token
 	s.Require().NoError(opts.setLocation())
 	s.Require().NoError(err)
-	cmds, err = c.buildCloneCommand(conf, opts)
+	cmds, err = c.buildCloneCommand(context.Background(), conf, opts)
 	s.NoError(err)
 	s.Require().Len(cmds, 10)
 	s.Equal("set -o xtrace", cmds[0])
@@ -532,7 +532,7 @@ func (s *GitGetProjectSuite) TestBuildCommandForPullRequests() {
 	}
 	s.Require().NoError(opts.setLocation())
 
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.NoError(err)
 	s.Require().Len(cmds, 9)
 	s.True(strings.HasPrefix(cmds[5], "git fetch origin \"pull/9001/head:evg-pr-test-"))
@@ -555,7 +555,7 @@ func (s *GitGetProjectSuite) TestBuildCommandForPRMergeTests() {
 		dir:    c.Directory,
 	}
 	s.Require().NoError(opts.setLocation())
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.NoError(err)
 	s.Require().Len(cmds, 9)
 	s.True(strings.HasPrefix(cmds[5], "git fetch origin \"pull/9001/merge:evg-merge-test-"))
@@ -583,7 +583,7 @@ func (s *GitGetProjectSuite) TestBuildCommandForCLIMergeTests() {
 	s.Require().NoError(opts.setLocation())
 
 	s.taskConfig2.Task.Requester = evergreen.MergeTestRequester
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.NoError(err)
 	s.Len(cmds, 9)
 	s.True(strings.HasSuffix(cmds[5], fmt.Sprintf("--branch '%s'", s.taskConfig2.ProjectRef.Branch)))

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -541,29 +541,6 @@ func (s *GitGetProjectSuite) TestBuildCommandForPullRequests() {
 	s.Equal("git log --oneline -n 10", cmds[8])
 }
 
-func (s *GitGetProjectSuite) TestBuildCommandForPRMergeTests() {
-	conf := s.taskConfig4
-	c := gitFetchProject{
-		Directory: "dir",
-	}
-
-	opts := cloneOpts{
-		method: distro.CloneMethodLegacySSH,
-		branch: conf.ProjectRef.Branch,
-		owner:  conf.ProjectRef.Owner,
-		repo:   conf.ProjectRef.Repo,
-		dir:    c.Directory,
-	}
-	s.Require().NoError(opts.setLocation())
-	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
-	s.NoError(err)
-	s.Require().Len(cmds, 9)
-	s.True(strings.HasPrefix(cmds[5], "git fetch origin \"pull/9001/merge:evg-merge-test-"))
-	s.True(strings.HasPrefix(cmds[6], "git checkout \"evg-merge-test-"))
-	s.Equal("git reset --hard abcdef", cmds[7])
-	s.Equal("git log --oneline -n 10", cmds[8])
-}
-
 func (s *GitGetProjectSuite) TestBuildCommandForCLIMergeTests() {
 	conf := s.taskConfig2
 	c := gitFetchProject{

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-08"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-03-10"
+	AgentVersion = "2021-03-11"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
This changes the existing code that checks out github's hidden merge branch to more closely match their recommendation in https://docs.github.com/en/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests. We poll that (with a timeout of 10 secs) until they either tell us the pr is definitely mergeable or not. If it's mergeable we get the most up-to-date merge hash