### PR TITLE
EVG-13655 remove repo poller

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -69,7 +69,6 @@ var (
 	alertsKey                        = bsonutil.MustHaveTag(ServiceFlags{}, "AlertsDisabled")
 	agentStartKey                    = bsonutil.MustHaveTag(ServiceFlags{}, "AgentStartDisabled")
 	repotrackerKey                   = bsonutil.MustHaveTag(ServiceFlags{}, "RepotrackerDisabled")
-	repoPollerKey                    = bsonutil.MustHaveTag(ServiceFlags{}, "RepoPollerDisabled")
 	schedulerKey                     = bsonutil.MustHaveTag(ServiceFlags{}, "SchedulerDisabled")
 	githubPRTestingDisabledKey       = bsonutil.MustHaveTag(ServiceFlags{}, "GithubPRTestingDisabled")
 	cliUpdatesDisabledKey            = bsonutil.MustHaveTag(ServiceFlags{}, "CLIUpdatesDisabled")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -16,7 +16,6 @@ type ServiceFlags struct {
 	AlertsDisabled                bool `bson:"alerts_disabled" json:"alerts_disabled"`
 	AgentStartDisabled            bool `bson:"agent_start_disabled" json:"agent_start_disabled"`
 	RepotrackerDisabled           bool `bson:"repotracker_disabled" json:"repotracker_disabled"`
-	RepoPollerDisabled            bool `bson:"repo_poller_disabled" json:"repo_poller_disabled"`
 	SchedulerDisabled             bool `bson:"scheduler_disabled" json:"scheduler_disabled"`
 	GithubPRTestingDisabled       bool `bson:"github_pr_testing_disabled" json:"github_pr_testing_disabled"`
 	CLIUpdatesDisabled            bool `bson:"cli_updates_disabled" json:"cli_updates_disabled"`
@@ -77,7 +76,6 @@ func (c *ServiceFlags) Set() error {
 			alertsKey:                        c.AlertsDisabled,
 			agentStartKey:                    c.AgentStartDisabled,
 			repotrackerKey:                   c.RepotrackerDisabled,
-			repoPollerKey:                    c.RepoPollerDisabled,
 			schedulerKey:                     c.SchedulerDisabled,
 			githubPRTestingDisabledKey:       c.GithubPRTestingDisabled,
 			cliUpdatesDisabledKey:            c.CLIUpdatesDisabled,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -818,28 +818,6 @@ func addLoggerAndRepoSettingsToProjects(pRefs []ProjectRef) ([]ProjectRef, error
 	return pRefs, nil
 }
 
-func FindAllMergedProjectRefsWithRepoInfo() ([]ProjectRef, error) {
-	projectRefs := []ProjectRef{}
-	err := db.FindAll(
-		ProjectRefCollection,
-		bson.M{
-			ProjectRefOwnerKey:  bson.M{"$exists": true, "$ne": ""},
-			ProjectRefRepoKey:   bson.M{"$exists": true, "$ne": ""},
-			ProjectRefBranchKey: bson.M{"$exists": true, "$ne": ""},
-		},
-		db.NoProjection,
-		db.NoSort,
-		db.NoSkip,
-		db.NoLimit,
-		&projectRefs,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return addLoggerAndRepoSettingsToProjects(projectRefs)
-}
-
 // FindAllMergedProjectRefs returns all project refs in the db, with repo ref information merged
 func FindAllMergedProjectRefs() ([]ProjectRef, error) {
 	projectRefs := []ProjectRef{}

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1668,7 +1668,6 @@ type APIServiceFlags struct {
 	AlertsDisabled                bool `json:"alerts_disabled"`
 	AgentStartDisabled            bool `json:"agent_start_disabled"`
 	RepotrackerDisabled           bool `json:"repotracker_disabled"`
-	RepoPollerDisabled            bool `json:"repo_poller_disabled"`
 	SchedulerDisabled             bool `json:"scheduler_disabled"`
 	GithubPRTestingDisabled       bool `json:"github_pr_testing_disabled"`
 	CLIUpdatesDisabled            bool `json:"cli_updates_disabled"`
@@ -1929,7 +1928,6 @@ func (as *APIServiceFlags) BuildFromService(h interface{}) error {
 		as.AlertsDisabled = v.AlertsDisabled
 		as.AgentStartDisabled = v.AgentStartDisabled
 		as.RepotrackerDisabled = v.RepotrackerDisabled
-		as.RepoPollerDisabled = v.RepoPollerDisabled
 		as.SchedulerDisabled = v.SchedulerDisabled
 		as.GithubPRTestingDisabled = v.GithubPRTestingDisabled
 		as.CLIUpdatesDisabled = v.CLIUpdatesDisabled
@@ -1966,7 +1964,6 @@ func (as *APIServiceFlags) ToService() (interface{}, error) {
 		AlertsDisabled:                as.AlertsDisabled,
 		AgentStartDisabled:            as.AgentStartDisabled,
 		RepotrackerDisabled:           as.RepotrackerDisabled,
-		RepoPollerDisabled:            as.RepoPollerDisabled,
 		SchedulerDisabled:             as.SchedulerDisabled,
 		GithubPRTestingDisabled:       as.GithubPRTestingDisabled,
 		CLIUpdatesDisabled:            as.CLIUpdatesDisabled,

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -209,17 +209,6 @@ Admin Settings
 												</td>
 											</tr>
 											<tr>
-												<td>Poll Github repositories</td>
-												<td colspan="2">
-													<md-radio-group
-															data-ng-model="Settings.service_flags.repo_poller_disabled"
-															layout="row">
-														<md-radio-button data-ng-value="false"></md-radio-button>
-														<md-radio-button data-ng-value="true"></md-radio-button>
-													</md-radio-group>
-												</td>
-											</tr>
-											<tr>
 												<td>Schedule tasks</td>
 												<td colspan="2">
 													<md-radio-group

--- a/units/crons_remote_fifteen_minute.go
+++ b/units/crons_remote_fifteen_minute.go
@@ -48,7 +48,6 @@ func (j *cronsRemoteFifteenMinuteJob) Run(ctx context.Context) {
 	}
 
 	ops := []amboy.QueueOperation{
-		PopulateCatchupJobs(),
 		PopulateHostStatJobs(30),
 		PopulatePeriodicBuilds(),
 		PopulateReauthorizationJobs(j.env),


### PR DESCRIPTION
Disabled the repo poller a couple of months ago to verify it wouldn't be an issue to take it out. (https://jira.mongodb.org/browse/EVG-13594). 