### PR TITLE
EVG-13777 tweak versions for project logic

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -363,7 +363,7 @@ func GetVersionsWithOptions(projectId string, opts GetVersionsOptions) ([]Versio
 		if opts.ByBuildVariant != "" {
 			// filter out versions that don't have this variant activated
 			matchBuildVariantActivated := bson.M{
-				"build_variants.activated": true,
+				bsonutil.GetDottedKeyName("build_variants", build.ActivatedKey): true,
 			}
 			pipeline = append(pipeline, bson.M{"$match": matchBuildVariantActivated})
 		}

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -193,8 +193,13 @@ func TestBuildVariantsStatusUnmarshal(t *testing.T) {
 }
 
 func TestGetVersionsWithOptions(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection))
+	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, ProjectRefCollection))
 	start := time.Now()
+	p := ProjectRef{
+		Id:         "my_project",
+		Identifier: "my_ident",
+	}
+	assert.NoError(t, p.Insert())
 	v := Version{
 		Id:                  "my_version",
 		Identifier:          "my_project",
@@ -279,7 +284,7 @@ func TestGetVersionsWithOptions(t *testing.T) {
 	}
 	assert.NoError(t, t2.Insert())
 	opts := GetVersionsOptions{IncludeBuilds: true, IncludeTasks: true, Requester: evergreen.RepotrackerVersionRequester}
-	versions, err := GetVersionsWithOptions("my_project", opts)
+	versions, err := GetVersionsWithOptions("my_ident", opts)
 	assert.NoError(t, err)
 	require.Len(t, versions, 3)
 	assert.Equal(t, "my_version", versions[0].Id)
@@ -288,7 +293,7 @@ func TestGetVersionsWithOptions(t *testing.T) {
 	require.Len(t, versions[0].Builds[1].Tasks, 1)
 
 	opts.ByBuildVariant = "my_bv"
-	versions, err = GetVersionsWithOptions("my_project", opts)
+	versions, err = GetVersionsWithOptions("my_ident", opts)
 	assert.NoError(t, err)
 	require.Len(t, versions, 1)
 	require.Len(t, versions[0].Builds, 1)
@@ -298,7 +303,7 @@ func TestGetVersionsWithOptions(t *testing.T) {
 	require.Len(t, versions[0].Builds[0].Tasks, 1)
 
 	opts = GetVersionsOptions{Limit: 1, Requester: evergreen.RepotrackerVersionRequester}
-	versions, err = GetVersionsWithOptions("my_project", opts)
+	versions, err = GetVersionsWithOptions("my_ident", opts)
 	assert.NoError(t, err)
 	require.Len(t, versions, 1)
 	assert.Equal(t, versions[0].Id, "my_version")

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -196,9 +196,10 @@ func TestGetVersionsWithOptions(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection))
 	start := time.Now()
 	v := Version{
-		Id:         "my_version",
-		Identifier: "my_project",
-		Requester:  evergreen.RepotrackerVersionRequester,
+		Id:                  "my_version",
+		Identifier:          "my_project",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		RevisionOrderNumber: 10,
 		BuildVariants: []VersionBuildStatus{
 			{
 				BuildId:      "bv1",
@@ -213,10 +214,11 @@ func TestGetVersionsWithOptions(t *testing.T) {
 	}
 	assert.NoError(t, v.Insert())
 	v = Version{
-		Id:         "your_version",
-		Identifier: "my_project",
-		Requester:  evergreen.RepotrackerVersionRequester,
-		CreateTime: start.Add(-1 * time.Minute),
+		Id:                  "your_version",
+		Identifier:          "my_project",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		RevisionOrderNumber: 9,
+		CreateTime:          start.Add(-1 * time.Minute),
 		BuildVariants: []VersionBuildStatus{
 			{
 				BuildId: "bv_not_activated",
@@ -225,10 +227,11 @@ func TestGetVersionsWithOptions(t *testing.T) {
 	}
 	assert.NoError(t, v.Insert())
 	v = Version{
-		Id:         "another_version",
-		Requester:  evergreen.RepotrackerVersionRequester,
-		Identifier: "my_project",
-		CreateTime: start.Add(-2 * time.Minute),
+		Id:                  "another_version",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		RevisionOrderNumber: 8,
+		Identifier:          "my_project",
+		CreateTime:          start.Add(-2 * time.Minute),
 	}
 	assert.NoError(t, v.Insert())
 
@@ -275,7 +278,7 @@ func TestGetVersionsWithOptions(t *testing.T) {
 		BuildId:     "bv2",
 	}
 	assert.NoError(t, t2.Insert())
-	opts := GetVersionsOptions{IncludeBuilds: true, IncludeTasks: true}
+	opts := GetVersionsOptions{IncludeBuilds: true, IncludeTasks: true, Requester: evergreen.RepotrackerVersionRequester}
 	versions, err := GetVersionsWithOptions("my_project", opts)
 	assert.NoError(t, err)
 	require.Len(t, versions, 3)
@@ -294,7 +297,7 @@ func TestGetVersionsWithOptions(t *testing.T) {
 	assert.Equal(t, versions[0].Builds[0].Activated, true)
 	require.Len(t, versions[0].Builds[0].Tasks, 1)
 
-	opts = GetVersionsOptions{Limit: 1}
+	opts = GetVersionsOptions{Limit: 1, Requester: evergreen.RepotrackerVersionRequester}
 	versions, err = GetVersionsWithOptions("my_project", opts)
 	assert.NoError(t, err)
 	require.Len(t, versions, 1)
@@ -302,14 +305,14 @@ func TestGetVersionsWithOptions(t *testing.T) {
 	assert.Len(t, versions[0].Builds, 0)
 	assert.Len(t, versions[0].BuildVariants, 2)
 
-	opts = GetVersionsOptions{Skip: 1}
+	opts = GetVersionsOptions{Skip: 1, Requester: evergreen.RepotrackerVersionRequester}
 	versions, err = GetVersionsWithOptions("my_project", opts)
 	assert.NoError(t, err)
 	require.Len(t, versions, 2)
 	assert.Equal(t, versions[0].Id, "your_version")
 	assert.Equal(t, versions[1].Id, "another_version")
 
-	opts = GetVersionsOptions{VersionToStartAt: "your_version"}
+	opts = GetVersionsOptions{StartAfter: 10, Requester: evergreen.RepotrackerVersionRequester}
 	versions, err = GetVersionsWithOptions("my_project", opts)
 	assert.NoError(t, err)
 	require.Len(t, versions, 2)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -114,7 +114,6 @@ type Connector interface {
 	GetProjectVersionsWithOptions(string, model.GetVersionsOptions) ([]restModel.APIVersion, error)
 	GetProjectEventLog(string, time.Time, int) ([]restModel.APIProjectEvent, error)
 	CreateVersionFromConfig(context.Context, *model.ProjectInfo, model.VersionMetadata, bool) (*model.Version, error)
-	GetVersionsInProject(string, string, int, int) ([]restModel.APIVersion, error)
 
 	// Given a version and a project ID, return the translated project and the intermediate project.
 	LoadProjectForVersion(*model.Version, string) (*model.Project, *model.ParserProject, error)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -302,26 +302,6 @@ func (ac *DBProjectConnector) FindEnabledProjectRefsByOwnerAndRepo(owner, repo s
 	return model.FindMergedEnabledProjectRefsByOwnerAndRepo(owner, repo)
 }
 
-func (ac *DBProjectConnector) GetVersionsInProject(identifier, requester string, limit, startOrder int) ([]restModel.APIVersion, error) {
-	projectId, err := model.FindIdForProject(identifier)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error finding project '%s'", identifier)
-	}
-	versions, err := model.VersionFind(model.VersionsByRequesterOrdered(projectId, requester, limit, startOrder))
-	if err != nil {
-		return nil, errors.Wrap(err, "error finding versions")
-	}
-	catcher := grip.NewBasicCatcher()
-	out := []restModel.APIVersion{}
-	for _, dbVersion := range versions {
-		restVersion := restModel.APIVersion{}
-		catcher.Add(restVersion.BuildFromService(&dbVersion))
-		out = append(out, restVersion)
-	}
-
-	return out, catcher.Resolve()
-}
-
 func (pc *DBProjectConnector) GetProjectSettingsEvent(p *model.ProjectRef) (*model.ProjectSettingsEvent, error) {
 	hook, err := model.FindGithubHook(p.Owner, p.Repo)
 	if err != nil {
@@ -628,10 +608,6 @@ func (pc *MockProjectConnector) EnablePRTesting(projectRef *model.ProjectRef) er
 
 func (pc *MockProjectConnector) UpdateProjectRevision(projectID, revision string) error {
 	return nil
-}
-
-func (ac *MockProjectConnector) GetVersionsInProject(project, requester string, limit, startOrder int) ([]restModel.APIVersion, error) {
-	return nil, nil
 }
 
 func (pc *MockProjectConnector) GetProjectSettingsEvent(p *model.ProjectRef) (*model.ProjectSettingsEvent, error) {

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -25,7 +25,7 @@ type APIVersion struct {
 	Branch             *string        `json:"branch"`
 	Parameters         []APIParameter `json:"parameters"`
 	BuildVariantStatus []buildDetail  `json:"build_variants_status"`
-	Builds             []APIBuild     `json:"builds"`
+	Builds             []APIBuild     `json:"builds,omitempty"`
 	Requester          *string        `json:"requester"`
 	Errors             []*string      `json:"errors"`
 }

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -788,8 +788,8 @@ func (h *projectIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 const defaultVersionLimit = 20
 
 type getProjectVersionsHandler struct {
-	project string
-	opts    dbModel.GetVersionsOptions
+	projectName string
+	opts        dbModel.GetVersionsOptions
 
 	sc data.Connector
 }
@@ -807,7 +807,7 @@ func (h *getProjectVersionsHandler) Factory() gimlet.RouteHandler {
 }
 
 func (h *getProjectVersionsHandler) Parse(ctx context.Context, r *http.Request) error {
-	h.project = gimlet.GetVars(r)["project_id"]
+	h.projectName = gimlet.GetVars(r)["project_id"]
 	params := r.URL.Query()
 
 	// body is optional
@@ -864,7 +864,7 @@ func (h *getProjectVersionsHandler) Parse(ctx context.Context, r *http.Request) 
 }
 
 func (h *getProjectVersionsHandler) Run(ctx context.Context) gimlet.Responder {
-	versions, err := h.sc.GetProjectVersionsWithOptions(h.project, h.opts)
+	versions, err := h.sc.GetProjectVersionsWithOptions(h.projectName, h.opts)
 
 	resp, err := gimlet.NewBasicResponder(http.StatusOK, gimlet.JSON, versions)
 	if err != nil {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -865,6 +865,9 @@ func (h *getProjectVersionsHandler) Parse(ctx context.Context, r *http.Request) 
 
 func (h *getProjectVersionsHandler) Run(ctx context.Context) gimlet.Responder {
 	versions, err := h.sc.GetProjectVersionsWithOptions(h.projectName, h.opts)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "error getting versions"))
+	}
 
 	resp, err := gimlet.NewBasicResponder(http.StatusOK, gimlet.JSON, versions)
 	if err != nil {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -193,94 +193,6 @@ func (h *legacyVersionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 
 ////////////////////////////////////////////////////////////////////////
 //
-// GET /rest/v2/projects/{project_id}/versions
-
-const defaultVersionLimit = 10
-
-type versionsGetHandler struct {
-	opts    dbModel.GetVersionsOptions
-	project string
-
-	sc data.Connector
-}
-
-func makeFetchProjectVersions(sc data.Connector) gimlet.RouteHandler {
-	return &versionsGetHandler{
-		sc: sc,
-	}
-}
-
-func (h *versionsGetHandler) Factory() gimlet.RouteHandler {
-	return &versionsGetHandler{
-		sc: h.sc,
-	}
-}
-
-func (h *versionsGetHandler) Parse(ctx context.Context, r *http.Request) error {
-	h.project = gimlet.GetVars(r)["project_id"]
-	if err := gimlet.GetJSON(r.Body, &h.opts); err != nil {
-		return errors.Wrap(err, "error parsing request body")
-	}
-	if h.opts.IncludeTasks && !h.opts.IncludeBuilds {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    "can't include tasks without builds",
-		}
-	}
-	if h.opts.Limit == 0 {
-		h.opts.Limit = defaultVersionLimit
-	}
-	h.opts.Limit += 1 // for pagination
-	return nil
-}
-
-func (h *versionsGetHandler) Run(ctx context.Context) gimlet.Responder {
-	pRefId, err := dbModel.FindIdForProject(h.project)
-	if err != nil {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    "Project not found",
-		})
-	}
-
-	versions, err := h.sc.GetProjectVersionsWithOptions(pRefId, h.opts)
-	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(err)
-	}
-	resp := gimlet.NewResponseBuilder()
-	if err = resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONErrorResponder(err)
-	}
-	if len(versions) == h.opts.Limit {
-		paginationVersion := versions[len(versions)-1]
-		versions = versions[:len(versions)-1] // drop the pagination version
-		err = resp.SetPages(&gimlet.ResponsePages{
-			Next: &gimlet.Page{
-				Relation:        "next",
-				LimitQueryParam: "limit",
-				KeyQueryParam:   "start_at",
-				BaseURL:         h.sc.GetURL(),
-				Key:             utility.FromStringPtr(paginationVersion.Id),
-				Limit:           h.opts.Limit - 1,
-			},
-		})
-		if err != nil {
-			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err,
-				"problem paginating response"))
-		}
-	}
-	if err = resp.AddData(versions); err != nil {
-		return gimlet.MakeJSONErrorResponder(err)
-	}
-
-	if err = resp.SetStatus(http.StatusOK); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(err)
-	}
-	return resp
-}
-
-////////////////////////////////////////////////////////////////////////
-//
 // PATCH /rest/v2/projects/{project_id}
 
 type projectIDPatchHandler struct {
@@ -869,12 +781,17 @@ func (h *projectIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewJSONResponse(projectModel)
 }
 
+////////////////////////////////////////////////////////////////////////
+//
+// GET /rest/v2/projects/{project_id}/versions
+
+const defaultVersionLimit = 20
+
 type getProjectVersionsHandler struct {
-	projectName string
-	sc          data.Connector
-	startOrder  int
-	limit       int
-	requester   string
+	project string
+	opts    dbModel.GetVersionsOptions
+
+	sc data.Connector
 }
 
 func makeGetProjectVersionsHandler(sc data.Connector) gimlet.RouteHandler {
@@ -890,56 +807,71 @@ func (h *getProjectVersionsHandler) Factory() gimlet.RouteHandler {
 }
 
 func (h *getProjectVersionsHandler) Parse(ctx context.Context, r *http.Request) error {
-	h.projectName = gimlet.GetVars(r)["project_id"]
+	h.project = gimlet.GetVars(r)["project_id"]
 	params := r.URL.Query()
 
+	// body is optional
+	b, _ := ioutil.ReadAll(r.Body)
+	if len(b) > 0 {
+		if err := json.Unmarshal(b, &h.opts); err != nil {
+			return errors.Wrap(err, "error parsing request body")
+		}
+	}
+
+	if h.opts.IncludeTasks && !h.opts.IncludeBuilds {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    "can't include tasks without builds",
+		}
+	}
+
+	// get some options from the query parameters for legacy usage
 	limitStr := params.Get("limit")
-	if limitStr == "" {
-		h.limit = 20
-	} else {
+	if limitStr != "" {
 		limit, err := strconv.Atoi(limitStr)
 		if err != nil {
 			return errors.Wrap(err, "'limit' query parameter must be a valid integer")
 		}
-		if limit < 1 {
-			return errors.New("'limit' must be a positive integer")
-		}
-		h.limit = limit
+		h.opts.Limit = limit
+	}
+	if h.opts.Limit < 1 {
+		return errors.New("'limit' must be a positive integer")
+	}
+	if h.opts.Limit == 0 {
+		h.opts.Limit = defaultVersionLimit
 	}
 
 	startStr := params.Get("start")
-	if startStr == "" {
-		h.startOrder = 0
-	} else {
+	if startStr != "" {
 		startOrder, err := strconv.Atoi(params.Get("start"))
 		if err != nil {
 			return errors.Wrap(err, "'start' query parameter must be a valid integer")
 		}
-		if startOrder < 0 {
-			return errors.New("'start' must be a non-negative integer")
-		}
-		h.startOrder = startOrder
+		h.opts.StartAfter = startOrder
+	}
+	if h.opts.StartAfter < 0 {
+		return errors.New("'start' must be a non-negative integer")
 	}
 
-	h.requester = params.Get("requester")
-	if h.requester == "" {
-		return errors.New("'requester' must be one of patch_request, gitter_request, github_pull_request, merge_test, ad_hoc")
+	requester := params.Get("requester")
+	if requester != "" {
+		h.opts.Requester = requester
+	}
+	if h.opts.Requester == "" {
+		h.opts.Requester = evergreen.RepotrackerVersionRequester
 	}
 	return nil
 }
 
 func (h *getProjectVersionsHandler) Run(ctx context.Context) gimlet.Responder {
-	versions, err := h.sc.GetVersionsInProject(h.projectName, h.requester, h.limit, h.startOrder)
-	if err != nil {
-		return gimlet.MakeJSONErrorResponder(err)
-	}
+	versions, err := h.sc.GetProjectVersionsWithOptions(h.project, h.opts)
 
 	resp, err := gimlet.NewBasicResponder(http.StatusOK, gimlet.JSON, versions)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "error constructing response"))
 	}
 
-	if len(versions) >= h.limit {
+	if len(versions) >= h.opts.Limit {
 		err = resp.SetPages(&gimlet.ResponsePages{
 			Next: &gimlet.Page{
 				Relation:        "next",
@@ -947,7 +879,7 @@ func (h *getProjectVersionsHandler) Run(ctx context.Context) gimlet.Responder {
 				KeyQueryParam:   "start",
 				BaseURL:         h.sc.GetURL(),
 				Key:             strconv.Itoa(versions[len(versions)-1].Order),
-				Limit:           h.limit,
+				Limit:           h.opts.Limit,
 			},
 		})
 

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -544,7 +544,7 @@ func getMockProjectsConnector() *data.MockConnector {
 
 func TestGetProjectVersions(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.Clear(serviceModel.VersionCollection))
+	assert.NoError(db.ClearCollections(serviceModel.VersionCollection, serviceModel.ProjectRefCollection))
 	const projectId = "proj"
 	project := serviceModel.ProjectRef{
 		Id:         projectId,
@@ -581,10 +581,12 @@ func TestGetProjectVersions(t *testing.T) {
 	assert.NoError(v4.Insert())
 
 	h := getProjectVersionsHandler{
-		project:   "something-else",
-		requester: evergreen.AdHocRequester,
-		sc:        &data.DBConnector{},
-		limit:     20,
+		projectName: "something-else",
+		sc:          &data.DBConnector{},
+		opts: serviceModel.GetVersionsOptions{
+			Requester: evergreen.AdHocRequester,
+			Limit:     20,
+		},
 	}
 
 	resp := h.Run(context.Background())

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -581,10 +581,10 @@ func TestGetProjectVersions(t *testing.T) {
 	assert.NoError(v4.Insert())
 
 	h := getProjectVersionsHandler{
-		projectName: "something-else",
-		requester:   evergreen.AdHocRequester,
-		sc:          &data.DBConnector{},
-		limit:       20,
+		project:   "something-else",
+		requester: evergreen.AdHocRequester,
+		sc:        &data.DBConnector{},
+		limit:     20,
 	}
 
 	resp := h.Run(context.Background())

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -154,7 +154,6 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}/events").Version(2).Get().Wrap(checkUser, addProject, checkProjectAdmin, viewProjectSettings).RouteHandler(makeFetchProjectEvents(sc))
 	app.AddRoute("/projects/{project_id}/patches").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makePatchesByProjectRoute(sc))
 	app.AddRoute("/projects/{project_id}/recent_versions").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchProjectVersionsLegacy(sc))
-	app.AddRoute("/projects/{project_id}/versions").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeFetchProjectVersions(sc))
 	app.AddRoute("/projects/{project_id}/revisions/{commit_hash}/tasks").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeTasksByProjectAndCommitHandler(sc))
 	app.AddRoute("/projects/{project_id}/task_reliability").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetProjectTaskReliability(sc))
 	app.AddRoute("/projects/{project_id}/task_stats").Version(2).Get().Wrap(checkUser, viewTasks).RouteHandler(makeGetProjectTaskStats(sc))


### PR DESCRIPTION
1. I realized this was doing all versions, not just repotracker versions.
2. If we choose ByBuildVariant, we should filter out versions that don't have that build variant activated, I would guess.
3. I want to drop the task cache if we don't have IncludeTasks, because we aren't guaranteeing that the task cache is accurate.