### PR TITLE
EVG-13889 fetch by instance type

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -419,7 +419,7 @@ func (m *ec2Manager) setNextSubnet(ctx context.Context, h *host.Host) error {
 		return errors.Wrap(err, "can't get provider settings")
 	}
 
-	supportingSubnets, err := typeCache.subnetsWithInstanceType(ctx, m.settings, m.client, h.InstanceType, ec2Settings.getRegion())
+	supportingSubnets, err := typeCache.subnetsWithInstanceType(ctx, m.settings, m.client, instanceRegionPair{instanceType: h.InstanceType, region: ec2Settings.getRegion()})
 	if err != nil {
 		return errors.Wrapf(err, "can't get supported subnets for instance type '%s'", h.InstanceType)
 	}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -54,6 +54,7 @@ func (c instanceTypeSubnetCache) subnetsWithInstanceType(ctx context.Context, se
 }
 
 func (c instanceTypeSubnetCache) getAZs(ctx context.Context, settings *evergreen.Settings, client AWSClient, instanceRegion instanceRegionPair) ([]string, error) {
+	// DescribeInstanceTypeOfferings only returns AZs in the client's region
 	output, err := client.DescribeInstanceTypeOfferings(ctx, &ec2.DescribeInstanceTypeOfferingsInput{
 		LocationType: aws.String(ec2.LocationTypeAvailabilityZone),
 		Filters: []*ec2.Filter{

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -20,61 +20,62 @@ import (
 )
 
 type instanceTypeSubnetCache struct {
-	instanceTypeToSubnets map[string][]evergreen.Subnet
-	built                 bool
+	instanceTypeToSubnets map[instanceRegionPair][]evergreen.Subnet
+}
+type instanceRegionPair struct {
+	instanceType string
+	region       string
 }
 
 var typeCache *instanceTypeSubnetCache
 
 func init() {
 	typeCache = &instanceTypeSubnetCache{}
-	typeCache.instanceTypeToSubnets = make(map[string][]evergreen.Subnet)
+	typeCache.instanceTypeToSubnets = make(map[instanceRegionPair][]evergreen.Subnet)
 }
 
-func (c *instanceTypeSubnetCache) subnetsWithInstanceType(ctx context.Context, settings *evergreen.Settings, client AWSClient, instanceType, region string) ([]evergreen.Subnet, error) {
-	if !c.built {
-		if err := c.Build(ctx, settings, client); err != nil {
-			return nil, errors.Wrap(err, "can't build AZ cache")
-		}
+func (c *instanceTypeSubnetCache) subnetsWithInstanceType(ctx context.Context, settings *evergreen.Settings, client AWSClient, instanceRegion instanceRegionPair) ([]evergreen.Subnet, error) {
+	if subnets, ok := typeCache.instanceTypeToSubnets[instanceRegion]; ok {
+		return subnets, nil
 	}
 
-	subnets := make([]evergreen.Subnet, 0, len(c.instanceTypeToSubnets[instanceType]))
-	for _, subnet := range c.instanceTypeToSubnets[instanceType] {
-		if AztoRegion(subnet.AZ) == region {
+	supportingAZs, err := c.getAZs(ctx, settings, client, instanceRegion)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't get supporting AZs")
+	}
+
+	subnets := make([]evergreen.Subnet, 0, len(supportingAZs))
+	for _, subnet := range settings.Providers.AWS.Subnets {
+		if utility.StringSliceContains(supportingAZs, subnet.AZ) {
 			subnets = append(subnets, subnet)
 		}
 	}
+	c.instanceTypeToSubnets[instanceRegion] = subnets
+
 	return subnets, nil
 }
 
-func (c *instanceTypeSubnetCache) Build(ctx context.Context, settings *evergreen.Settings, client AWSClient) error {
-	subnets := settings.Providers.AWS.Subnets
-	if len(subnets) == 0 {
-		return errors.New("no AWS subnets were configured")
+func (c *instanceTypeSubnetCache) getAZs(ctx context.Context, settings *evergreen.Settings, client AWSClient, instanceRegion instanceRegionPair) ([]string, error) {
+	output, err := client.DescribeInstanceTypeOfferings(ctx, &ec2.DescribeInstanceTypeOfferingsInput{
+		LocationType: aws.String(ec2.LocationTypeAvailabilityZone),
+		Filters: []*ec2.Filter{
+			{Name: aws.String("instance-type"), Values: []*string{aws.String(instanceRegion.instanceType)}},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "can't get instance types for '%s' in '%s'", instanceRegion.instanceType, instanceRegion.region)
 	}
-
-	for _, subnet := range subnets {
-		output, err := client.DescribeInstanceTypeOfferings(ctx, &ec2.DescribeInstanceTypeOfferingsInput{
-			LocationType: aws.String(ec2.LocationTypeAvailabilityZone),
-			Filters: []*ec2.Filter{
-				{Name: aws.String("location"), Values: []*string{aws.String(subnet.AZ)}},
-			},
-		})
-		if err != nil {
-			return errors.Wrapf(err, "can't get instance types for '%s'", subnet.AZ)
-		}
-		if output == nil {
-			return errors.Errorf("DescribeInstanceTypeOfferings returned nil output for AZ '%s'", subnet.AZ)
-		}
-		for _, offering := range output.InstanceTypeOfferings {
-			if offering != nil && offering.InstanceType != nil {
-				c.instanceTypeToSubnets[*offering.InstanceType] = append(c.instanceTypeToSubnets[*offering.InstanceType], subnet)
-			}
+	if output == nil {
+		return nil, errors.Errorf("DescribeInstanceTypeOfferings returned nil output for AZ '%s' in '%s'", instanceRegion.instanceType, instanceRegion.region)
+	}
+	supportingAZs := make([]string, 0, len(output.InstanceTypeOfferings))
+	for _, offering := range output.InstanceTypeOfferings {
+		if offering != nil && offering.Location != nil {
+			supportingAZs = append(supportingAZs, *offering.Location)
 		}
 	}
 
-	c.built = true
-	return nil
+	return supportingAZs, nil
 }
 
 type EC2FleetManagerOptions struct {
@@ -566,7 +567,7 @@ func (m *ec2FleetManager) makeOverrides(ctx context.Context, ec2Settings *EC2Pro
 		return nil, errors.New("no AWS subnets were configured")
 	}
 
-	supportingSubnets, err := typeCache.subnetsWithInstanceType(ctx, m.settings, m.client, ec2Settings.InstanceType, ec2Settings.getRegion())
+	supportingSubnets, err := typeCache.subnetsWithInstanceType(ctx, m.settings, m.client, instanceRegionPair{instanceType: ec2Settings.InstanceType, region: ec2Settings.getRegion()})
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't get AZs supporting instance type '%s'", ec2Settings.InstanceType)
 	}

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -87,7 +87,7 @@ func TestFleet(t *testing.T) {
 			assert.Equal(t, "ami", *mockClient.CreateLaunchTemplateInput.LaunchTemplateData.ImageId)
 		},
 		"RequestFleet": func(*testing.T) {
-			ec2Settings := &EC2ProviderSettings{VpcName: "my_vpc"}
+			ec2Settings := &EC2ProviderSettings{VpcName: "my_vpc", InstanceType: "instanceType0"}
 
 			instanceID, err := m.requestFleet(context.Background(), ec2Settings, aws.String("templateID"), aws.Int64(1))
 			assert.NoError(t, err)
@@ -103,7 +103,7 @@ func TestFleet(t *testing.T) {
 			}
 			overrides, err := m.makeOverrides(context.Background(), ec2Settings)
 			assert.NoError(t, err)
-			assert.Len(t, overrides, 1)
+			require.Len(t, overrides, 1)
 			assert.Equal(t, "subnet-654321", *overrides[0].SubnetId)
 
 			ec2Settings = &EC2ProviderSettings{
@@ -170,16 +170,11 @@ func TestFleet(t *testing.T) {
 				Provider: evergreen.ProviderNameEc2Fleet,
 			},
 		}
-
+		typeCache[instanceRegionPair{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}] = []evergreen.Subnet{{SubnetID: "subnet-654321"}}
+		typeCache[instanceRegionPair{instanceType: "not_supported", region: evergreen.DefaultEC2Region}] = []evergreen.Subnet{}
 		m = &ec2FleetManager{
 			EC2FleetManagerOptions: &EC2FleetManagerOptions{
-				client: &awsClientMock{
-					DescribeInstanceTypeOfferingsOutput: &ec2.DescribeInstanceTypeOfferingsOutput{
-						InstanceTypeOfferings: []*ec2.InstanceTypeOffering{
-							{InstanceType: aws.String("instanceType0")},
-						},
-					},
-				},
+				client: &awsClientMock{},
 				region: "test-region",
 			},
 			credentials: credentials.NewStaticCredentialsFromCreds(credentials.Value{
@@ -203,8 +198,8 @@ func TestFleet(t *testing.T) {
 }
 
 func TestInstanceTypeAZCache(t *testing.T) {
-	cache := instanceTypeSubnetCache{instanceTypeToSubnets: make(map[instanceRegionPair][]evergreen.Subnet)}
-	defaultRegionclient := &awsClientMock{
+	cache := instanceTypeSubnetCache{}
+	defaultRegionClient := &awsClientMock{
 		DescribeInstanceTypeOfferingsOutput: &ec2.DescribeInstanceTypeOfferingsOutput{
 			InstanceTypeOfferings: []*ec2.InstanceTypeOffering{
 				{
@@ -217,18 +212,19 @@ func TestInstanceTypeAZCache(t *testing.T) {
 	settings := &evergreen.Settings{}
 	settings.Providers.AWS.Subnets = []evergreen.Subnet{{SubnetID: "sn0", AZ: evergreen.DefaultEBSAvailabilityZone}}
 
-	azsWithInstanceType, err := cache.subnetsWithInstanceType(context.Background(), settings, defaultRegionclient, instanceRegionPair{instanceType: "instanceType0", region: evergreen.DefaultEC2Region})
+	azsWithInstanceType, err := cache.subnetsWithInstanceType(context.Background(), settings, defaultRegionClient, instanceRegionPair{instanceType: "instanceType0", region: evergreen.DefaultEC2Region})
 	assert.NoError(t, err)
 	assert.Len(t, azsWithInstanceType, 1)
 	assert.Equal(t, "sn0", azsWithInstanceType[0].SubnetID)
 
 	// cache is populated
-	subnets, ok := cache.instanceTypeToSubnets[instanceRegionPair{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}]
+	subnets, ok := cache[instanceRegionPair{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}]
 	assert.True(t, ok)
 	assert.Len(t, subnets, 1)
 
 	// unsupported instance type
-	azsWithInstanceType, err = cache.subnetsWithInstanceType(context.Background(), settings, defaultRegionclient, instanceRegionPair{instanceType: "not_supported", region: evergreen.DefaultEC2Region})
+	defaultRegionClient.DescribeInstanceTypeOfferingsOutput = &ec2.DescribeInstanceTypeOfferingsOutput{}
+	azsWithInstanceType, err = cache.subnetsWithInstanceType(context.Background(), settings, defaultRegionClient, instanceRegionPair{instanceType: "not_supported", region: evergreen.DefaultEC2Region})
 	assert.NoError(t, err)
 	assert.Empty(t, azsWithInstanceType)
 }

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1387,7 +1387,7 @@ func (s *EC2Suite) TestGetEC2Key() {
 
 func (s *EC2Suite) TestSetNextSubnet() {
 	s.Require().NoError(db.Clear(host.Collection))
-	typeCache.instanceTypeToSubnets = map[instanceRegionPair][]evergreen.Subnet{
+	typeCache = map[instanceRegionPair][]evergreen.Subnet{
 		{instanceType: "instance-type0", region: evergreen.DefaultEC2Region}: {
 			{SubnetID: "sn0", AZ: evergreen.DefaultEC2Region + "a"},
 			{SubnetID: "sn1", AZ: evergreen.DefaultEC2Region + "b"},

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1387,13 +1387,12 @@ func (s *EC2Suite) TestGetEC2Key() {
 
 func (s *EC2Suite) TestSetNextSubnet() {
 	s.Require().NoError(db.Clear(host.Collection))
-	typeCache.built = true
-	typeCache.instanceTypeToSubnets = map[string][]evergreen.Subnet{
-		"instance-type0": {
+	typeCache.instanceTypeToSubnets = map[instanceRegionPair][]evergreen.Subnet{
+		{instanceType: "instance-type0", region: evergreen.DefaultEC2Region}: {
 			{SubnetID: "sn0", AZ: evergreen.DefaultEC2Region + "a"},
 			{SubnetID: "sn1", AZ: evergreen.DefaultEC2Region + "b"},
 		},
-		"instance-type1": {
+		{instanceType: "instance-type1", region: evergreen.DefaultEC2Region}: {
 			{SubnetID: "sn0", AZ: evergreen.DefaultEC2Region + "a"},
 		},
 	}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-13889

When you ask AWS for all the instance types supported in an AZ they seem to leave some out. For example, if you run this from the command line
```
aws ec2 describe-instance-type-offerings --location-type availability-zone --filters Name=availability-zone,Values=us-east-1a
```
the list returned doesn't include a1.2xlarge.

Getting all the AZs that support a particular instance type works, though
```
aws ec2 describe-instance-type-offerings --location-type availability-zone --filters Name=instance-type,Values=a1.2xlarge
```

The downside to doing it this way is that we need to do one API call for each instance type as opposed to one for each AZ. This might not make such a difference, though, since distros use the same instance type.