### PR TITLE
EVG-14251 change pr check in git.get_project to handle HEAD moving

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -121,14 +121,18 @@ func getProjectMethodAndToken(projectToken, globalToken, globalCloneMethod strin
 		token, err := parseToken(projectToken)
 		return distro.CloneMethodOAuth, token, err
 	}
+	token, err := parseToken(globalToken)
+	if err != nil {
+		return distro.CloneMethodLegacySSH, "", err
+	}
 
 	switch globalCloneMethod {
 	// No clone method specified is equivalent to using legacy SSH.
 	case "", distro.CloneMethodLegacySSH:
-		return distro.CloneMethodLegacySSH, "", nil
+		return distro.CloneMethodLegacySSH, token, nil
 	case distro.CloneMethodOAuth:
-		if globalToken == "" {
-			return "", "", errors.New("cannot clone using OAuth if global token is empty")
+		if token == "" {
+			return distro.CloneMethodLegacySSH, "", errors.New("cannot clone using OAuth if global token is empty")
 		}
 		token, err := parseToken(globalToken)
 		return distro.CloneMethodOAuth, token, err

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -159,7 +159,7 @@ func (s *GitGetProjectSuite) TestBuildCloneCommandUsesHTTPS() {
 		token:  c.Token,
 	}
 	s.Require().NoError(opts.setLocation())
-	cmds, _ := c.buildCloneCommand(conf, opts)
+	cmds, _ := c.buildCloneCommand(context.Background(), conf, opts)
 	s.Equal("git clone https://PROJECTTOKEN:x-oauth-basic@github.com/deafgoat/mci_test.git 'dir' --branch 'master'", cmds[5])
 }
 
@@ -178,7 +178,7 @@ func (s *GitGetProjectSuite) TestBuildCloneCommandWithHTTPSNeedsToken() {
 		token:  "",
 	}
 	s.Require().NoError(opts.setLocation())
-	_, err := c.buildCloneCommand(conf, opts)
+	_, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.Error(err)
 }
 
@@ -197,7 +197,7 @@ func (s *GitGetProjectSuite) TestBuildCloneCommandUsesSSH() {
 		dir:    c.Directory,
 	}
 	s.Require().NoError(opts.setLocation())
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.Require().NoError(err)
 	s.Equal("git clone 'git@github.com:deafgoat/mci_test.git' 'dir' --branch 'main'", cmds[3])
 }
@@ -215,7 +215,7 @@ func (s *GitGetProjectSuite) TestBuildCloneCommandDefaultCloneMethodUsesSSH() {
 		dir:    c.Directory,
 	}
 	s.Require().NoError(opts.setLocation())
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.Require().NoError(err)
 	s.Equal("git clone 'git@github.com:evergreen-ci/sample.git' 'dir' --branch 'main'", cmds[3])
 }
@@ -485,7 +485,7 @@ func (s *GitGetProjectSuite) TestBuildCommand() {
 		dir:    c.Directory,
 	}
 	s.Require().NoError(opts.setLocation())
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.NoError(err)
 	s.Require().Len(cmds, 7)
 	s.Equal("set -o xtrace", cmds[0])
@@ -502,7 +502,7 @@ func (s *GitGetProjectSuite) TestBuildCommand() {
 	opts.token = c.Token
 	s.Require().NoError(opts.setLocation())
 	s.Require().NoError(err)
-	cmds, err = c.buildCloneCommand(conf, opts)
+	cmds, err = c.buildCloneCommand(context.Background(), conf, opts)
 	s.NoError(err)
 	s.Require().Len(cmds, 10)
 	s.Equal("set -o xtrace", cmds[0])
@@ -532,35 +532,12 @@ func (s *GitGetProjectSuite) TestBuildCommandForPullRequests() {
 	}
 	s.Require().NoError(opts.setLocation())
 
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.NoError(err)
 	s.Require().Len(cmds, 9)
 	s.True(strings.HasPrefix(cmds[5], "git fetch origin \"pull/9001/head:evg-pr-test-"))
 	s.True(strings.HasPrefix(cmds[6], "git checkout \"evg-pr-test-"))
 	s.Equal("git reset --hard 55ca6286e3e4f4fba5d0448333fa99fc5a404a73", cmds[7])
-	s.Equal("git log --oneline -n 10", cmds[8])
-}
-
-func (s *GitGetProjectSuite) TestBuildCommandForPRMergeTests() {
-	conf := s.taskConfig4
-	c := gitFetchProject{
-		Directory: "dir",
-	}
-
-	opts := cloneOpts{
-		method: distro.CloneMethodLegacySSH,
-		branch: conf.ProjectRef.Branch,
-		owner:  conf.ProjectRef.Owner,
-		repo:   conf.ProjectRef.Repo,
-		dir:    c.Directory,
-	}
-	s.Require().NoError(opts.setLocation())
-	cmds, err := c.buildCloneCommand(conf, opts)
-	s.NoError(err)
-	s.Require().Len(cmds, 9)
-	s.True(strings.HasPrefix(cmds[5], "git fetch origin \"pull/9001/merge:evg-merge-test-"))
-	s.True(strings.HasPrefix(cmds[6], "git checkout \"evg-merge-test-"))
-	s.Equal("git reset --hard abcdef", cmds[7])
 	s.Equal("git log --oneline -n 10", cmds[8])
 }
 
@@ -583,7 +560,7 @@ func (s *GitGetProjectSuite) TestBuildCommandForCLIMergeTests() {
 	s.Require().NoError(opts.setLocation())
 
 	s.taskConfig2.Task.Requester = evergreen.MergeTestRequester
-	cmds, err := c.buildCloneCommand(conf, opts)
+	cmds, err := c.buildCloneCommand(context.Background(), conf, opts)
 	s.NoError(err)
 	s.Len(cmds, 9)
 	s.True(strings.HasSuffix(cmds[5], fmt.Sprintf("--branch '%s'", s.taskConfig2.ProjectRef.Branch)))

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -861,7 +861,7 @@ func (s *GitGetProjectSuite) TestGetProjectMethodAndToken() {
 	method, token, err = getProjectMethodAndToken("", "", distro.CloneMethodOAuth)
 	s.Error(err)
 	s.Equal("", token)
-	s.Equal("", method)
+	s.Equal(distro.CloneMethodLegacySSH, method)
 
 	method, token, err = getProjectMethodAndToken("", "", distro.CloneMethodLegacySSH)
 	s.NoError(err)

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-08"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-03-11"
+	AgentVersion = "2021-03-15"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-08"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-03-10"
+	AgentVersion = "2021-03-11"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
sooo I can't really explain why this works in staging but not prod. The main change here is the assumption that the problem is in fact due to a malformed github token. From messing with the API manually, it's actually quite difficult to repro the same 401 error because we were requesting a public repo. The only way I could get the same error was to send a malformed token. This takes the token from a place we know is working (which is probably where it should have been all along)