### PR TITLE
EVG-14146 use taskID and execution for instead of annotation ID

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -320,7 +320,7 @@ type ComplexityRoot struct {
 		EditAnnotationNote        func(childComplexity int, taskID string, execution int, originalMessage string, newMessage string) int
 		EditSpawnHost             func(childComplexity int, spawnHost *EditSpawnHostInput) int
 		EnqueuePatch              func(childComplexity int, patchID string, commitMessage *string) int
-		MoveAnnotationIssue       func(childComplexity int, annotationID string, apiIssue model.APIIssueLink, isIssue bool) int
+		MoveAnnotationIssue       func(childComplexity int, taskID string, execution int, apiIssue model.APIIssueLink, isIssue bool) int
 		RemoveAnnotationIssue     func(childComplexity int, taskID string, execution int, apiIssue model.APIIssueLink, isIssue bool) int
 		RemoveFavoriteProject     func(childComplexity int, identifier string) int
 		RemoveItemFromCommitQueue func(childComplexity int, commitQueueID string, issue string) int
@@ -805,7 +805,7 @@ type MutationResolver interface {
 	RestartTask(ctx context.Context, taskID string) (*model.APITask, error)
 	SaveSubscription(ctx context.Context, subscription model.APISubscription) (bool, error)
 	EditAnnotationNote(ctx context.Context, taskID string, execution int, originalMessage string, newMessage string) (bool, error)
-	MoveAnnotationIssue(ctx context.Context, annotationID string, apiIssue model.APIIssueLink, isIssue bool) (bool, error)
+	MoveAnnotationIssue(ctx context.Context, taskID string, execution int, apiIssue model.APIIssueLink, isIssue bool) (bool, error)
 	AddAnnotationIssue(ctx context.Context, taskID string, execution int, apiIssue model.APIIssueLink, isIssue bool) (bool, error)
 	RemoveAnnotationIssue(ctx context.Context, taskID string, execution int, apiIssue model.APIIssueLink, isIssue bool) (bool, error)
 	RemoveItemFromCommitQueue(ctx context.Context, commitQueueID string, issue string) (*string, error)
@@ -2134,7 +2134,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.MoveAnnotationIssue(childComplexity, args["annotationId"].(string), args["apiIssue"].(model.APIIssueLink), args["isIssue"].(bool)), true
+		return e.complexity.Mutation.MoveAnnotationIssue(childComplexity, args["taskId"].(string), args["execution"].(int), args["apiIssue"].(model.APIIssueLink), args["isIssue"].(bool)), true
 
 	case "Mutation.removeAnnotationIssue":
 		if e.complexity.Mutation.RemoveAnnotationIssue == nil {
@@ -4734,7 +4734,8 @@ type Mutation {
     newMessage: String!
   ): Boolean!
   moveAnnotationIssue(
-    annotationId: String!
+    taskId: String!
+    execution: Int!
     apiIssue: IssueLinkInput!
     isIssue: Boolean!
   ): Boolean!
@@ -5832,29 +5833,37 @@ func (ec *executionContext) field_Mutation_moveAnnotationIssue_args(ctx context.
 	var err error
 	args := map[string]interface{}{}
 	var arg0 string
-	if tmp, ok := rawArgs["annotationId"]; ok {
+	if tmp, ok := rawArgs["taskId"]; ok {
 		arg0, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["annotationId"] = arg0
-	var arg1 model.APIIssueLink
+	args["taskId"] = arg0
+	var arg1 int
+	if tmp, ok := rawArgs["execution"]; ok {
+		arg1, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["execution"] = arg1
+	var arg2 model.APIIssueLink
 	if tmp, ok := rawArgs["apiIssue"]; ok {
-		arg1, err = ec.unmarshalNIssueLinkInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIIssueLink(ctx, tmp)
+		arg2, err = ec.unmarshalNIssueLinkInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIIssueLink(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["apiIssue"] = arg1
-	var arg2 bool
+	args["apiIssue"] = arg2
+	var arg3 bool
 	if tmp, ok := rawArgs["isIssue"]; ok {
-		arg2, err = ec.unmarshalNBoolean2bool(ctx, tmp)
+		arg3, err = ec.unmarshalNBoolean2bool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["isIssue"] = arg2
+	args["isIssue"] = arg3
 	return args, nil
 }
 
@@ -12428,7 +12437,7 @@ func (ec *executionContext) _Mutation_moveAnnotationIssue(ctx context.Context, f
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().MoveAnnotationIssue(rctx, args["annotationId"].(string), args["apiIssue"].(model.APIIssueLink), args["isIssue"].(bool))
+		return ec.resolvers.Mutation().MoveAnnotationIssue(rctx, args["taskId"].(string), args["execution"].(int), args["apiIssue"].(model.APIIssueLink), args["isIssue"].(bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1913,16 +1913,16 @@ func (r *mutationResolver) EditAnnotationNote(ctx context.Context, taskID string
 
 // MoveAnnotationIssue moves an issue for the annotation. If isIssue is set, it removes the issue from Issues and adds it
 // to Suspected Issues, otherwise vice versa.
-func (r *mutationResolver) MoveAnnotationIssue(ctx context.Context, annotationID string, apiIssue restModel.APIIssueLink, isIssue bool) (bool, error) {
+func (r *mutationResolver) MoveAnnotationIssue(ctx context.Context, taskID string, execution int, apiIssue restModel.APIIssueLink, isIssue bool) (bool, error) {
 	usr := MustHaveUser(ctx)
 	issue := restModel.APIIssueLinkToService(apiIssue)
 	if isIssue {
-		if err := annotations.MoveIssueToSuspectedIssue(annotationID, *issue, usr.Username()); err != nil {
+		if err := annotations.MoveIssueToSuspectedIssue(taskID, execution, *issue, usr.Username()); err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("couldn't move issue to suspected issues: %s", err.Error()))
 		}
 		return true, nil
 	} else {
-		if err := annotations.MoveSuspectedIssueToIssue(annotationID, *issue, usr.Username()); err != nil {
+		if err := annotations.MoveSuspectedIssueToIssue(taskID, execution, *issue, usr.Username()); err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("couldn't move issue to suspected issues: %s", err.Error()))
 		}
 		return true, nil

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -93,7 +93,8 @@ type Mutation {
     newMessage: String!
   ): Boolean!
   moveAnnotationIssue(
-    annotationId: String!
+    taskId: String!
+    execution: Int!
     apiIssue: IssueLinkInput!
     isIssue: Boolean!
   ): Boolean!

--- a/graphql/tests/annotations/queries/moveIssueToSuspectedIssue.graphql
+++ b/graphql/tests/annotations/queries/moveIssueToSuspectedIssue.graphql
@@ -1,6 +1,7 @@
 mutation {
   moveAnnotationIssue(
-    annotationId: "5e4aa5abe3c3317e35201abc"
+    taskId: "task-1234"
+    execution: 0
     apiIssue: { url: "https://link.com", issueKey: "EVG-1212" }
     isIssue: true
   )

--- a/graphql/tests/annotations/queries/moveSuspectedIssueToIssue.graphql
+++ b/graphql/tests/annotations/queries/moveSuspectedIssueToIssue.graphql
@@ -1,6 +1,7 @@
 mutation {
   moveAnnotationIssue(
-    annotationId: "5e4aa5abe3c3317e35201abc"
+    taskId: "task-1234"
+    execution: 0
     apiIssue: { url: "https://link.com", issueKey: "EVG-2121" }
     isIssue: false
   )

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -88,7 +88,7 @@ func TestAnnotationsByBuildHandlerRun(t *testing.T) {
 		},
 	}
 	for _, a := range annotations {
-		assert.NoError(t, a.Insert())
+		assert.NoError(t, a.Upsert())
 	}
 
 	resp = h.Run(ctx)
@@ -180,7 +180,7 @@ func TestAnnotationsByVersionHandlerRun(t *testing.T) {
 		},
 	}
 	for _, a := range annotations {
-		assert.NoError(t, a.Insert())
+		assert.NoError(t, a.Upsert())
 	}
 
 	resp = h.Run(ctx)
@@ -286,7 +286,7 @@ func TestAnnotationByTaskGetHandlerRun(t *testing.T) {
 	}
 
 	for _, a := range annotations {
-		assert.NoError(t, a.Insert())
+		assert.NoError(t, a.Upsert())
 	}
 
 	// get the latest execution : 1

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -449,6 +449,9 @@ tasks:
     name: test-model-alertrecord
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
+    name: test-model-annotations
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
     name: test-model-artifact
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]


### PR DESCRIPTION
This would go with https://github.com/evergreen-ci/spruce/pull/687. 

We weren't actually running annotation tests in ubuntu1604, which explains why they only broke in coverage. Because annotation IDs are stored in the DB as object IDs, but we access them as strings, we can't insert annotations the way we currently do in tests. The options were either to 1) switch to using taskId and execution like the other queries, or 2) change annotation IDs to be bson.ObjectIds in the code. Both require a change in spruce and evergreen, so I chose the first for consistency. 

This would need to be deployed with spruce so if we don't do that anymore then I guess we make a separate mutation? I'd argue for just deploying at the same time, since only the "Move Issue" button would be broken until the deploy is done.