### PR TITLE
EVG-14248 send github statuses on app server

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-08"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-03-15"
+	AgentVersion = "2021-03-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/graphql/tests/abortTask/data.json
+++ b/graphql/tests/abortTask/data.json
@@ -8,7 +8,7 @@
       "build_id": "b1",
       "r": "merge_test",
       "commit_queue_merge": true,
-      "version": "v1"
+      "version": "123456789012345678901234"
     }
   ],
   "builds": [
@@ -22,7 +22,14 @@
   ],
   "versions": [
     {
-      "_id": "v1"
+      "_id": "123456789012345678901234"
+    }
+  ],
+  "patches": [
+    {
+      "_id": {
+        "$oid": "123456789012345678901234"
+      }
     }
   ],
   "project_ref": [
@@ -38,7 +45,13 @@
     {
       "_id": "p1",
       "processing": true,
-      "queue": [{ "version": "v1", "issue": "v1" }]
+      "queue": [
+        {
+          "version": "123456789012345678901234",
+          "issue": "123456789012345678901234",
+          "source": "diff"
+        }
+      ]
     }
   ]
 }

--- a/graphql/tests/unschedulePatchTasks/data.json
+++ b/graphql/tests/unschedulePatchTasks/data.json
@@ -7,7 +7,7 @@
       "r": "patch_request"
     },
     {
-      "_id": "7",
+      "_id": "123456789012345678901234",
       "r": "merge_test",
       "identifier": "p1"
     }
@@ -27,7 +27,7 @@
       "build_id": "7",
       "r": "merge_test",
       "commit_queue_merge": true,
-      "version": "7"
+      "version": "123456789012345678901234"
     }
   ],
   "builds": [
@@ -119,6 +119,11 @@
           "message": ""
         }
       ]
+    },
+    {
+      "_id": {
+        "$oid": "123456789012345678901234"
+      }
     }
   ],
   "project_ref": [
@@ -134,7 +139,13 @@
     {
       "_id": "p1",
       "processing": true,
-      "queue": [{ "version": "7", "issue": "7" }]
+      "queue": [
+        {
+          "version": "123456789012345678901234",
+          "issue": "123456789012345678901234",
+          "source": "diff"
+        }
+      ]
     }
   ]
 }

--- a/graphql/tests/unschedulePatchTasks/queries/commit-queue-dequeue.graphql
+++ b/graphql/tests/unschedulePatchTasks/queries/commit-queue-dequeue.graphql
@@ -1,3 +1,3 @@
 mutation {
-  unschedulePatchTasks(patchId: "7", abort: false)
+  unschedulePatchTasks(patchId: "123456789012345678901234", abort: false)
 }

--- a/graphql/tests/unschedulePatchTasks/results.json
+++ b/graphql/tests/unschedulePatchTasks/results.json
@@ -37,7 +37,7 @@
       "query_file": "commit-queue-dequeue.graphql",
       "result": {
         "data": {
-          "unschedulePatchTasks": "7"
+          "unschedulePatchTasks": "123456789012345678901234"
         }
       }
     }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -617,6 +617,9 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 			if err != nil {
 				return http.StatusInternalServerError, errors.Wrap(err, "unable to find patch")
 			}
+			if p == nil {
+				return http.StatusNotFound, errors.New("patch not found")
+			}
 			err = model.SendCommitQueueResult(p, message.GithubStateError, fmt.Sprintf("deactivated by '%s'", user.DisplayName()))
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "unable to send github status",

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -809,3 +809,40 @@ func restartDiffItem(p patch.Patch, cq *commitqueue.CommitQueue) error {
 	}
 	return nil
 }
+
+func SendCommitQueueResult(p *patch.Patch, status message.GithubState, description string) error {
+	if p.GithubPatchData.PRNumber == 0 {
+		return nil
+	}
+	projectRef, err := FindOneProjectRef(p.Project)
+	if err != nil {
+		return errors.Wrap(err, "unable to find project")
+	}
+	if projectRef == nil {
+		return errors.New("no project found for patch")
+	}
+	url := ""
+	if p.Version != "" {
+		settings, err := evergreen.GetConfig()
+		if err != nil {
+			return errors.Wrap(err, "unable to get settings")
+		}
+		url = fmt.Sprintf("%s/version/%s", settings.Ui.Url, p.Version)
+	}
+	msg := message.GithubStatus{
+		Owner:       projectRef.Owner,
+		Repo:        projectRef.Repo,
+		Ref:         p.GithubPatchData.HeadHash,
+		Context:     commitqueue.GithubContext,
+		State:       status,
+		Description: description,
+		URL:         url,
+	}
+	sender, err := evergreen.GetEnvironment().GetSender(evergreen.SenderGithubStatus)
+	if err != nil {
+		return errors.Wrap(err, "unable to get github sender")
+	}
+	sender.Send(message.NewGithubStatusMessageWithRepo(level.Notice, msg))
+
+	return nil
+}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -448,6 +448,31 @@ func (t *Task) AddDependency(d Dependency) error {
 	)
 }
 
+func (t *Task) RemoveDependency(dependencyId string) error {
+	found := false
+	for i := len(t.DependsOn) - 1; i >= 0; i-- {
+		d := t.DependsOn[i]
+		if d.TaskId == dependencyId {
+			t.DependsOn = append(t.DependsOn[:i], t.DependsOn[i+1:]...)
+			found = true
+			break
+		}
+	}
+	if !found {
+		return errors.Errorf("dependency '%s' not found", dependencyId)
+	}
+
+	query := bson.M{IdKey: t.Id}
+	update := bson.M{
+		"$pull": bson.M{
+			DependsOnKey: bson.M{
+				DependencyTaskIdKey: dependencyId,
+			},
+		},
+	}
+	return db.Update(Collection, query, update)
+}
+
 // Checks whether the dependencies for the task have all completed successfully.
 // If any of the dependencies exist in the map that is passed in, they are
 // used to check rather than fetching from the database. All queries

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1520,6 +1520,20 @@ func TestAddDependency(t *testing.T) {
 	updated, err = FindOneId(t1.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, len(depTaskIds)+1, len(updated.DependsOn))
+
+	assert.NoError(t, t1.RemoveDependency("td3"))
+	for _, d := range t1.DependsOn {
+		if d.TaskId == "td3" {
+			assert.Fail(t, "did not remove dependency from in-memory task")
+		}
+	}
+	updated, err = FindOneId(t1.Id)
+	assert.NoError(t, err)
+	for _, d := range updated.DependsOn {
+		if d.TaskId == "td3" {
+			assert.Fail(t, "did not remove dependency from db task")
+		}
+	}
 }
 
 func TestFindAllMarkedUnattainableDependencies(t *testing.T) {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1686,6 +1686,9 @@ func TestDequeueAndRestart(t *testing.T) {
 		Status:           evergreen.TaskSucceeded,
 		Requester:        evergreen.MergeTestRequester,
 		CommitQueueMerge: true,
+		DependsOn: []task.Dependency{
+			{TaskId: t2.Id, Status: "*"},
+		},
 	}
 	assert.NoError(t, t3.Insert())
 	b1 := build.Build{
@@ -1768,6 +1771,7 @@ func TestDequeueAndRestart(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, dbTask3.Execution)
 	assert.Equal(t, evergreen.TaskUndispatched, dbTask3.Status)
+	assert.Len(t, dbTask3.DependsOn, 0)
 }
 
 func TestMarkStart(t *testing.T) {

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -527,6 +527,17 @@ func (pc *DBCommitQueueConnector) ConcludeMerge(patchID, status string) error {
 	if found == nil {
 		return errors.Errorf("item '%s' did not exist on the queue", item)
 	}
+	githubStatus := message.GithubStateFailure
+	description := "merge test failed"
+	if status == evergreen.MergeTestSucceeded {
+		githubStatus = message.GithubStateSuccess
+		description = "merge test succeeded"
+	}
+	err = model.SendCommitQueueResult(p, githubStatus, description)
+	grip.Error(message.WrapError(err, message.Fields{
+		"message": "unable to send github status",
+		"patch":   patchID,
+	}))
 	return nil
 }
 

--- a/service/build.go
+++ b/service/build.go
@@ -186,6 +186,10 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "Error finding patch", http.StatusInternalServerError)
 				return
 			}
+			if p == nil {
+				http.Error(w, "Patch not found", http.StatusNotFound)
+				return
+			}
 			err = model.SendCommitQueueResult(p, message.GithubStateError, fmt.Sprintf("deactivated by '%s'", user.DisplayName()))
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "unable to send github status",
@@ -248,6 +252,10 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 			p, err := patch.FindOneId(projCtx.Build.Version)
 			if err != nil {
 				http.Error(w, "Error finding patch", http.StatusInternalServerError)
+				return
+			}
+			if p == nil {
+				http.Error(w, "Patch not found", http.StatusNotFound)
 				return
 			}
 			err = model.SendCommitQueueResult(p, message.GithubStateError, fmt.Sprintf("deactivated by '%s'", user.DisplayName()))

--- a/service/build.go
+++ b/service/build.go
@@ -12,11 +12,13 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/plugin"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -179,6 +181,16 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
+			p, err := patch.FindOneId(projCtx.Build.Version)
+			if err != nil {
+				http.Error(w, "Error finding patch", http.StatusInternalServerError)
+				return
+			}
+			err = model.SendCommitQueueResult(p, message.GithubStateError, fmt.Sprintf("deactivated by '%s'", user.DisplayName()))
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "unable to send github status",
+				"patch":   projCtx.Build.Version,
+			}))
 			err = model.RestartItemsAfterVersion(nil, projCtx.Build.Project, projCtx.Build.Version, user.Id)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -233,6 +245,16 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
+			p, err := patch.FindOneId(projCtx.Build.Version)
+			if err != nil {
+				http.Error(w, "Error finding patch", http.StatusInternalServerError)
+				return
+			}
+			err = model.SendCommitQueueResult(p, message.GithubStateError, fmt.Sprintf("deactivated by '%s'", user.DisplayName()))
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "unable to send github status",
+				"patch":   projCtx.Build.Version,
+			}))
 			err = model.RestartItemsAfterVersion(nil, projCtx.Build.Project, projCtx.Build.Version, user.Id)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -665,19 +665,13 @@ func addMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 	}
 
 	// Merge task depends on all the tasks already in the patch
-	status := ""
-	if source == commitqueue.SourcePullRequest {
-		// for pull requests we need to run the merge task at the end even if something
-		// fails, so that it can tell github something failed
-		status = model.AllStatuses
-	}
 	dependencies := []model.TaskUnitDependency{}
 	for _, vt := range patchDoc.VariantsTasks {
 		for _, t := range vt.Tasks {
 			dependencies = append(dependencies, model.TaskUnitDependency{
 				Name:    t,
 				Variant: vt.Variant,
-				Status:  status,
+				Status:  "",
 			})
 		}
 	}


### PR DESCRIPTION
The bulk of this fixes a problem where the current behavior of unscheduling the entire version when a commit queue task fails causes us to not update github with the failure (the status will remain the yellow circle) because the merge task does not run, and previously the merge task is what updated github with the outcome of the commit queue patch. This moves that logic to the app server.

Also fixed some related bugs I found while testing, which I'll annotate