### PR TITLE
EVG-13799 more sanity checks in commit queue job

### DIFF
--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -31,11 +31,12 @@ type CommitQueueItem struct {
 	Issue   string `bson:"issue"`
 	PatchId string `bson:"patch_id,omitempty"`
 	// Version is the ID of the version that is running the patch. It's also used to determine what entries are processing
-	Version         string    `bson:"version,omitempty"`
-	EnqueueTime     time.Time `bson:"enqueue_time"`
-	Modules         []Module  `bson:"modules"`
-	MessageOverride string    `bson:"message_override"`
-	Source          string    `bson:"source"`
+	Version             string    `bson:"version,omitempty"`
+	EnqueueTime         time.Time `bson:"enqueue_time"`
+	ProcessingStartTime time.Time `bson:"process_start_time"`
+	Modules             []Module  `bson:"modules"`
+	MessageOverride     string    `bson:"message_override"`
+	Source              string    `bson:"source"`
 }
 
 func (i *CommitQueueItem) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(i) }

--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -33,7 +33,7 @@ type CommitQueueItem struct {
 	// Version is the ID of the version that is running the patch. It's also used to determine what entries are processing
 	Version             string    `bson:"version,omitempty"`
 	EnqueueTime         time.Time `bson:"enqueue_time"`
-	ProcessingStartTime time.Time `bson:"process_start_time"`
+	ProcessingStartTime time.Time `bson:"processing_start_time"`
 	Modules             []Module  `bson:"modules"`
 	MessageOverride     string    `bson:"message_override"`
 	Source              string    `bson:"source"`

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -2,6 +2,7 @@ package commitqueue
 
 import (
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -103,6 +104,7 @@ func (s *CommitQueueSuite) TestUpdateVersion() {
 
 	item := s.q.Queue[0]
 	item.Version = "my_version"
+	now := time.Now()
 	s.NoError(s.q.UpdateVersion(item))
 
 	dbq, err := FindOneId("mci")
@@ -111,6 +113,7 @@ func (s *CommitQueueSuite) TestUpdateVersion() {
 
 	s.Equal(item.Issue, dbq.Queue[0].Issue)
 	s.Equal(item.Version, dbq.Queue[0].Version)
+	s.InDelta(now.Unix(), dbq.Queue[0].ProcessingStartTime.Unix(), float64(1*time.Millisecond))
 }
 
 func (s *CommitQueueSuite) TestNext() {

--- a/model/commitqueue/db.go
+++ b/model/commitqueue/db.go
@@ -1,6 +1,8 @@
 package commitqueue
 
 import (
+	"time"
+
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
@@ -13,11 +15,12 @@ const Collection = "commit_queue"
 
 var (
 	// bson fields for the CommitQueue struct
-	IdKey          = bsonutil.MustHaveTag(CommitQueue{}, "ProjectID")
-	QueueKey       = bsonutil.MustHaveTag(CommitQueue{}, "Queue")
-	IssueKey       = bsonutil.MustHaveTag(CommitQueueItem{}, "Issue")
-	VersionKey     = bsonutil.MustHaveTag(CommitQueueItem{}, "Version")
-	EnqueueTimeKey = bsonutil.MustHaveTag(CommitQueueItem{}, "EnqueueTime")
+	IdKey                  = bsonutil.MustHaveTag(CommitQueue{}, "ProjectID")
+	QueueKey               = bsonutil.MustHaveTag(CommitQueue{}, "Queue")
+	IssueKey               = bsonutil.MustHaveTag(CommitQueueItem{}, "Issue")
+	VersionKey             = bsonutil.MustHaveTag(CommitQueueItem{}, "Version")
+	EnqueueTimeKey         = bsonutil.MustHaveTag(CommitQueueItem{}, "EnqueueTime")
+	ProcessingStartTimeKey = bsonutil.MustHaveTag(CommitQueueItem{}, "ProcessingStartTime")
 )
 
 func updateOne(query interface{}, update interface{}) error {
@@ -99,7 +102,10 @@ func addVersionID(id string, item CommitQueueItem) error {
 			bsonutil.GetDottedKeyName(QueueKey, IssueKey): item.Issue,
 		},
 		bson.M{
-			"$set": bson.M{bsonutil.GetDottedKeyName(QueueKey, "$", VersionKey): item.Version},
+			"$set": bson.M{
+				bsonutil.GetDottedKeyName(QueueKey, "$", VersionKey):             item.Version,
+				bsonutil.GetDottedKeyName(QueueKey, "$", ProcessingStartTimeKey): time.Now(),
+			},
 		})
 }
 

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -151,13 +151,13 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 
 	for _, nextItem := range nextItems {
 		// log time waiting in queue
-		timeWaiting := time.Now().Sub(nextItem.EnqueueTime)
 		grip.Info(message.Fields{
 			"source":       "commit queue",
 			"job_id":       j.ID(),
 			"item_id":      nextItem.Issue,
 			"project_id":   cq.ProjectID,
-			"time_waiting": timeWaiting.Seconds(),
+			"time_waiting": time.Now().Sub(nextItem.EnqueueTime).Seconds(),
+			"time_elapsed": time.Now().Sub(nextItem.ProcessingStartTime).Seconds(),
 			"queue_length": len(cq.Queue),
 			"message":      "started testing commit queue item",
 		})
@@ -268,6 +268,35 @@ func (j *commitQueueJob) TryUnstick(ctx context.Context, cq *commitqueue.CommitQ
 			j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "commit queue entry was stuck with no patch", ""))
 		}
 		return
+	}
+
+	mergeTask, err := task.FindMergeTaskForVersion(nextItem.Version)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "unable to find merge task for version"))
+	}
+	if mergeTask != nil {
+		// check that the merge task can run. Assume that if we're here the merge task
+		// should in fact run (ie. has not been dequeued due to a task failure)
+		if !mergeTask.Activated {
+			grip.Error(message.Fields{
+				"message": "merge task is inactive",
+				"project": mergeTask.Project,
+				"task":    mergeTask.Id,
+				"source":  "commit queue",
+				"job_id":  j.ID(),
+			})
+			j.AddError(model.SetActiveState(mergeTask, evergreen.APIServerTaskActivator, true))
+		}
+		if mergeTask.Blocked() {
+			grip.Critical(message.Fields{
+				"message":      "merge task is blocked",
+				"project":      mergeTask.Project,
+				"task":         mergeTask.Id,
+				"dependencies": mergeTask.DependsOn,
+				"source":       "commit queue",
+				"job_id":       j.ID(),
+			})
+		}
 	}
 
 	// patch is done


### PR DESCRIPTION
- add the processing start time back in to the data model, but it needs to be item-specific now
- add a check that the merge task is scheduled and not blocked in the commit queue job