### PR TITLE
EVG-13505 mark if setup group has been completed in agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -294,6 +294,11 @@ func (a *Agent) prepareNextTask(ctx context.Context, nextTask *apimodels.NextTas
 }
 
 func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) bool {
+	// we didn't run setup group yet
+	if !tc.ranSetupGroup {
+		return true
+	}
+
 	// next task has a standalone task or a new build
 	if tc.taskConfig == nil ||
 		nextTask.TaskGroup == "" ||
@@ -313,10 +318,7 @@ func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) 
 		}
 		return true
 	}
-	// next task has the same task group, but we didn't run setup group yet
-	if !tc.ranSetupGroup {
-		return true
-	}
+
 	return false
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -66,7 +66,7 @@ type taskContext struct {
 	systemMetricsCollector *systemMetricsCollector
 	task                   client.TaskData
 	taskGroup              string
-	runGroupSetup          bool
+	ranSetupGroup          bool
 	taskConfig             *internal.TaskConfig
 	taskDirectory          string
 	logDirectories         map[string]interface{}
@@ -274,10 +274,10 @@ LOOP:
 }
 
 func (a *Agent) prepareNextTask(ctx context.Context, nextTask *apimodels.NextTaskResponse, tc *taskContext) *taskContext {
-	setupGroup := false
+	shouldSetupGroup := false
 	taskDirectory := tc.taskDirectory
-	if nextTaskHasDifferentTaskGroupOrBuild(nextTask, tc) {
-		setupGroup = true
+	if shouldRunSetupGroup(nextTask, tc) {
+		shouldSetupGroup = true
 		taskDirectory = ""
 		a.runPostGroupCommands(ctx, tc)
 	}
@@ -287,18 +287,21 @@ func (a *Agent) prepareNextTask(ctx context.Context, nextTask *apimodels.NextTas
 			Secret: nextTask.TaskSecret,
 		},
 		taskGroup:     nextTask.TaskGroup,
-		runGroupSetup: setupGroup,
+		ranSetupGroup: !shouldSetupGroup,
 		taskDirectory: taskDirectory,
 		oomTracker:    jasper.NewOOMTracker(),
 	}
 }
 
-func nextTaskHasDifferentTaskGroupOrBuild(nextTask *apimodels.NextTaskResponse, tc *taskContext) bool {
+func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) bool {
+	// next task has a standalone task or a new build
 	if tc.taskConfig == nil ||
 		nextTask.TaskGroup == "" ||
 		nextTask.Build != tc.taskConfig.Task.BuildId {
 		return true
 	}
+
+	// next task has a different task group
 	if nextTask.TaskGroup != tc.taskGroup {
 		if tc.logger != nil && nextTask.TaskGroup == tc.taskConfig.Task.TaskGroup {
 			tc.logger.Task().Warning(message.Fields{
@@ -308,6 +311,10 @@ func nextTaskHasDifferentTaskGroupOrBuild(nextTask *apimodels.NextTaskResponse, 
 				"next_task_task_group":    nextTask.TaskGroup,
 			})
 		}
+		return true
+	}
+	// next task has the same task group, but we didn't run setup group yet
+	if !tc.ranSetupGroup {
 		return true
 	}
 	return false

--- a/agent/agent_command_test.go
+++ b/agent/agent_command_test.go
@@ -76,7 +76,7 @@ func (s *CommandSuite) TestShellExec() {
 
 	taskID := "shellexec"
 	s.tc.task.ID = taskID
-	s.tc.runGroupSetup = true
+	s.tc.ranSetupGroup = false
 
 	s.NoError(s.a.startLogging(ctx, s.tc))
 	defer s.a.removeTaskDirectory(s.tc)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -63,7 +63,7 @@ func (s *AgentSuite) SetupTest() {
 			Task:    &task.Task{},
 		},
 		taskModel:     &task.Task{},
-		runGroupSetup: true,
+		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -583,7 +583,7 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	}
 	tc.taskDirectory = "task_directory"
 	tc = s.a.prepareNextTask(context.Background(), nextTask, tc)
-	s.True(tc.runGroupSetup, "if the next task is not in a group, runGroupSetup should be true")
+	s.False(tc.ranSetupGroup, "if the next task is not in a group, ranSetupGroup should be false")
 	s.Equal("", tc.taskGroup)
 	s.Empty(tc.taskDirectory)
 
@@ -598,8 +598,21 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	tc.logger, err = s.a.comm.GetLoggerProducer(context.Background(), s.tc.task, nil)
 	s.NoError(err)
 	tc.taskDirectory = "task_directory"
+	tc.ranSetupGroup = false
 	tc = s.a.prepareNextTask(context.Background(), nextTask, tc)
-	s.False(tc.runGroupSetup, "if the next task is in the same group as the previous task, runGroupSetup should be false")
+	s.False(tc.ranSetupGroup, "if the next task is in the same group as the previous task but ranSetupGroup was false, ranSetupGroup should be false")
+	s.Equal("foo", tc.taskGroup)
+	s.Equal("", tc.taskDirectory)
+
+	tc.taskConfig = &internal.TaskConfig{
+		Task: &task.Task{
+			Version: "version_name",
+		},
+	}
+	tc.ranSetupGroup = true
+	tc.taskDirectory = "task_directory"
+	tc = s.a.prepareNextTask(context.Background(), nextTask, tc)
+	s.True(tc.ranSetupGroup, "if the next task is in the same group as the previous task and we already ran the setup group, ranSetupGroup should be true")
 	s.Equal("foo", tc.taskGroup)
 	s.Equal("task_directory", tc.taskDirectory)
 
@@ -618,7 +631,7 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	tc.taskDirectory = "task_directory"
 	tc.taskModel = &task.Task{}
 	tc = s.a.prepareNextTask(context.Background(), nextTask, tc)
-	s.True(tc.runGroupSetup, "if the next task in the same version but a different build, runSetupGroup should be true")
+	s.False(tc.ranSetupGroup, "if the next task in the same version but a different build, ranSetupGroup should be false")
 	s.Equal("bar", tc.taskGroup)
 	s.Empty(tc.taskDirectory)
 }
@@ -705,7 +718,7 @@ task_groups:
 
 func (s *AgentSuite) TestGroupPreGroupCommandsFail() {
 	s.tc.taskGroup = "task_group_name"
-	s.tc.runGroupSetup = true
+	s.tc.ranSetupGroup = false
 	projYml := `
 task_groups:
 - name: task_group_name

--- a/agent/agent_timeout_test.go
+++ b/agent/agent_timeout_test.go
@@ -70,7 +70,7 @@ func (s *TimeoutSuite) TestExecTimeoutProject() {
 			Secret: taskSecret,
 		},
 		taskModel:     &task.Task{},
-		runGroupSetup: true,
+		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
 	// Windows may not have finished deleting task directories when
@@ -140,7 +140,7 @@ func (s *TimeoutSuite) TestExecTimeoutTask() {
 			Secret: taskSecret,
 		},
 		taskModel:     &task.Task{},
-		runGroupSetup: true,
+		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
 	// Windows may not have finished deleting task directories when
@@ -207,7 +207,7 @@ func (s *TimeoutSuite) TestIdleTimeoutFunc() {
 			Secret: taskSecret,
 		},
 		taskModel:     &task.Task{},
-		runGroupSetup: true,
+		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
 	// Windows may not have finished deleting task directories when
@@ -274,7 +274,7 @@ func (s *TimeoutSuite) TestIdleTimeoutCommand() {
 			Secret: taskSecret,
 		},
 		taskModel:     &task.Task{},
-		runGroupSetup: true,
+		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
 	// Windows may not have finished deleting task directories when
@@ -341,7 +341,7 @@ func (s *TimeoutSuite) TestDynamicIdleTimeout() {
 			Secret: taskSecret,
 		},
 		taskModel:     &task.Task{},
-		runGroupSetup: true,
+		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
 	// Windows may not have finished deleting task directories when
@@ -408,7 +408,7 @@ func (s *TimeoutSuite) TestDynamicExecTimeoutTask() {
 			Secret: taskSecret,
 		},
 		taskModel:     &task.Task{},
-		runGroupSetup: true,
+		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
 	// Windows may not have finished deleting task directories when

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -67,7 +67,7 @@ func TestCommandFileLogging(t *testing.T) {
 			ID:     taskID,
 			Secret: taskSecret,
 		},
-		runGroupSetup: true,
+		ranSetupGroup: false,
 		taskConfig: &internal.TaskConfig{
 			Task:         task,
 			BuildVariant: &model.BuildVariant{Name: "bv"},
@@ -203,7 +203,7 @@ func TestStartLoggingErrors(t *testing.T) {
 			ID:     "logging_error",
 			Secret: "secret",
 		},
-		runGroupSetup: true,
+		ranSetupGroup: false,
 		taskConfig:    &internal.TaskConfig{},
 		project:       project,
 		taskModel:     &task.Task{},

--- a/agent/task.go
+++ b/agent/task.go
@@ -107,7 +107,7 @@ func (a *Agent) startTask(ctx context.Context, tc *taskContext, complete chan<- 
 		return
 	}
 
-	if tc.runGroupSetup {
+	if !tc.ranSetupGroup {
 		tc.taskDirectory, err = a.createTaskDirectory(tc)
 		if err != nil {
 			tc.logger.Execution().Errorf("error creating task directory: %s", err)
@@ -178,7 +178,7 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 	tc.logger.Task().Info("Running pre-task commands.")
 	opts := runCommandsOptions{}
 
-	if tc.runGroupSetup {
+	if !tc.ranSetupGroup {
 		var ctx2 context.Context
 		var cancel context.CancelFunc
 		taskGroup, err := tc.taskConfig.GetTaskGroup(tc.taskGroup)
@@ -204,6 +204,7 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 			}
 			tc.logger.Task().Infof("Finished running setup_group for '%s'.", taskGroup.Name)
 		}
+		tc.ranSetupGroup = true
 	}
 
 	taskGroup, err := tc.taskConfig.GetTaskGroup(tc.taskGroup)

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-08"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-03-15"
+	AgentVersion = "2021-03-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Currently we maintain if the setup group needs to be run. This tweaks the definition a bit to maintain if the setup group _has_ been run, and if it hasn't we assume it needs to be run. This is for task groups, where the first task on a host may have system failed for other reasons; we want the next task for that group on the host to try to run setup group.