### PR TITLE
EVG-14263 use mongo driver for test_names aggregation

### DIFF
--- a/model/task_history.go
+++ b/model/task_history.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -179,7 +180,7 @@ func (t TestHistoryParameters) QueryString() string {
 
 type TaskHistoryIterator interface {
 	GetChunk(version *Version, numBefore, numAfter int, include bool) (TaskHistoryChunk, error)
-	GetDistinctTestNames(env evergreen.Environment, numCommits int) ([]string, error)
+	GetDistinctTestNames(env evergreen.Environment, ctx context.Context, numCommits int) ([]string, error)
 }
 
 func NewTaskHistoryIterator(name string, buildVariants []string, projectName string) TaskHistoryIterator {
@@ -353,9 +354,7 @@ func (iter *taskHistoryIterator) GetChunk(v *Version, numBefore, numAfter int, i
 	return chunk, nil
 }
 
-func (self *taskHistoryIterator) GetDistinctTestNames(env evergreen.Environment, numCommits int) ([]string, error) {
-	ctx, cancel := env.Context()
-	defer cancel()
+func (self *taskHistoryIterator) GetDistinctTestNames(env evergreen.Environment, ctx context.Context, numCommits int) ([]string, error) {
 	opts := options.Aggregate().SetBatchSize(0).SetMaxTime(time.Minute)
 	cursor, err := env.DB().Collection(task.Collection).Aggregate(ctx,
 		[]bson.M{

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -281,7 +281,7 @@ func (uis *UIServer) taskHistoryTestNames(w http.ResponseWriter, r *http.Request
 	taskHistoryIterator := model.NewTaskHistoryIterator(taskName, nil,
 		project.Identifier)
 
-	results, err := taskHistoryIterator.GetDistinctTestNames(uis.env, NumTasksToSearchForTestNames)
+	results, err := taskHistoryIterator.GetDistinctTestNames(uis.env, r.Context(), NumTasksToSearchForTestNames)
 	testNamesQueryDuration := time.Now().Sub(stepTime)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error finding test names: `%v`", err.Error()), http.StatusInternalServerError)

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -281,7 +281,7 @@ func (uis *UIServer) taskHistoryTestNames(w http.ResponseWriter, r *http.Request
 	taskHistoryIterator := model.NewTaskHistoryIterator(taskName, nil,
 		project.Identifier)
 
-	results, err := taskHistoryIterator.GetDistinctTestNames(NumTasksToSearchForTestNames)
+	results, err := taskHistoryIterator.GetDistinctTestNames(uis.env, NumTasksToSearchForTestNames)
 	testNamesQueryDuration := time.Now().Sub(stepTime)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error finding test names: `%v`", err.Error()), http.StatusInternalServerError)

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -281,7 +281,7 @@ func (uis *UIServer) taskHistoryTestNames(w http.ResponseWriter, r *http.Request
 	taskHistoryIterator := model.NewTaskHistoryIterator(taskName, nil,
 		project.Identifier)
 
-	results, err := taskHistoryIterator.GetDistinctTestNames(uis.env, r.Context(), NumTasksToSearchForTestNames)
+	results, err := taskHistoryIterator.GetDistinctTestNames(r.Context(), uis.env, NumTasksToSearchForTestNames)
 	testNamesQueryDuration := time.Now().Sub(stepTime)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error finding test names: `%v`", err.Error()), http.StatusInternalServerError)


### PR DESCRIPTION
I'm not sure if this will be faster but we are logging how long the query takes, I can make a graph at some point and see if it improved.

Jonathan recommended using the go driver so that we could cancel if the query takes too long, so we don't get another 71 minute thing. Theoretically that's what SetSocketTimeout was supposed to do, but I couldn't really figure out how anser worked.