### PR TITLE
EVG-13984 correctly wrap CORS middleware

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -51,9 +51,8 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	removeDistroSettings := RequiresDistroPermission(evergreen.PermissionDistroSettings, evergreen.DistroSettingsAdmin)
 	editHosts := RequiresDistroPermission(evergreen.PermissionHosts, evergreen.HostsEdit)
 	cedarTestStats := checkCedarTestStats(settings)
-	allowCORS := gimlet.WrapperMiddleware(allowCORS)
 
-	app.AddMiddleware(allowCORS)
+	app.AddWrapper(gimlet.WrapperMiddleware(allowCORS))
 
 	// Routes
 	app.AddRoute("/").Version(2).Get().RouteHandler(makePlaceHolderManger(sc))


### PR DESCRIPTION
so I don't exactly understand the difference between what was there before and now, just that the handler wasn't called before but it is now