### PR TITLE
EVG-14151 add setup group logging

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -294,24 +294,17 @@ func (a *Agent) prepareNextTask(ctx context.Context, nextTask *apimodels.NextTas
 }
 
 func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) bool {
-	// we didn't run setup group yet
 	setupGroup := false
 	var msg string
-	if !tc.ranSetupGroup {
+	if !tc.ranSetupGroup { // we didn't run setup group yet
 		msg = "running setup group because we haven't yet"
 		setupGroup = true
-	}
-
-	// next task has a standalone task or a new build
-	if tc.taskConfig == nil ||
+	} else if tc.taskConfig == nil ||
 		nextTask.TaskGroup == "" ||
-		nextTask.Build != tc.taskConfig.Task.BuildId {
+		nextTask.Build != tc.taskConfig.Task.BuildId { // next task has a standalone task or a new build
 		msg = "running setup group because we have a new independent task"
 		setupGroup = true
-	}
-
-	// next task has a different task group
-	if nextTask.TaskGroup != tc.taskGroup {
+	} else if nextTask.TaskGroup != tc.taskGroup { // next task has a different task group
 		if tc.logger != nil && nextTask.TaskGroup == tc.taskConfig.Task.TaskGroup {
 			tc.logger.Task().Warning(message.Fields{
 				"message":                 "programmer error: task group in task context doesn't match task",

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -296,6 +296,7 @@ func (a *Agent) prepareNextTask(ctx context.Context, nextTask *apimodels.NextTas
 func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) bool {
 	// we didn't run setup group yet
 	if !tc.ranSetupGroup {
+		tc.logger.Task().Debug("running setup group because we haven't yet")
 		return true
 	}
 
@@ -303,6 +304,7 @@ func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) 
 	if tc.taskConfig == nil ||
 		nextTask.TaskGroup == "" ||
 		nextTask.Build != tc.taskConfig.Task.BuildId {
+		tc.logger.Task().Debug("running setup group because we have a new independent task")
 		return true
 	}
 
@@ -316,6 +318,7 @@ func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) 
 				"next_task_task_group":    nextTask.TaskGroup,
 			})
 		}
+		tc.logger.Task().Debug("running setup group because new task group")
 		return true
 	}
 

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-08"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-03-18"
+	AgentVersion = "2021-03-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/public/static/partials/hostevent.html
+++ b/public/static/partials/hostevent.html
@@ -52,8 +52,8 @@
         </div>
     </span>
     <span ng-switch-when="HOST_PROVISIONED">Marked as <b>provisioned</b></span>
-    <span ng-switch-when="HOST_RUNNING_TASK_SET">Assigned to run task <a href="/task/[[eventLogObj.data.task_id]]/[[eventLogObj.data.execution]]">[[eventLogObj.data.task_id | shortenString:false:50:' ...']]</a></span>
-    <span ng-switch-when="HOST_RUNNING_TASK_CLEARED">Current running task cleared (was: <a href="/task/[[eventLogObj.data.task_id]]/[[eventLogObj.data.execution]]">[[eventLogObj.data.task_id | shortenString:false:50:' ...']]</a></span>
+    <span ng-switch-when="HOST_RUNNING_TASK_SET">Assigned to run task <a href="/task/[[eventLogObj.data.task_id]]/[[eventLogObj.data.execution]]">[[eventLogObj.data.task_id | shortenString:false:100:' ...']]</a></span>
+    <span ng-switch-when="HOST_RUNNING_TASK_CLEARED">Current running task cleared (was: <a href="/task/[[eventLogObj.data.task_id]]/[[eventLogObj.data.execution]]">[[eventLogObj.data.task_id | shortenString:false:100:' ...']]</a></span>
     <span ng-switch-when="HOST_TASK_PID_SET">PID of running task set to <b>[[eventLogObj.data.task_pid]]</b></span>
     <span ng-switch-when="HOST_MONITOR_FLAG">Flagged for termination because:
       <span ng-switch="eventLogObj.data.monitor">
@@ -83,7 +83,7 @@
         <pre>[[eventLogObj.data.logs]]</pre>
       </div>
     </span>
-    <span ng-switch-when="HOST_TASK_FINISHED">Task <a href="/task/[[eventLogObj.data.task_id]]/[[eventLogObj.data.execution]]">[[eventLogObj.data.task_id | shortenString:false:50:'...']]</a> completed with status: <b>[[eventLogObj.data.task_status]]</b></span>
+    <span ng-switch-when="HOST_TASK_FINISHED">Task <a href="/task/[[eventLogObj.data.task_id]]/[[eventLogObj.data.execution]]">[[eventLogObj.data.task_id | shortenString:false:100:'...']]</a> completed with status: <b>[[eventLogObj.data.task_status]]</b></span>
     <span ng-switch-when="HOST_EXPIRATION_WARNING_SENT">Expiration warning sent</span>
   </div>
   <div class="clearfix"></div>


### PR DESCRIPTION
It's _possible_ that BF-20000 could be fixed by the recent changes to setup group logic, but I think those changes made setup group _less_ strict, not more strict. I'd like to add logging to figure out why we're deciding to run setup group, when another task in the task group had already run immediately before. 