### PR TITLE
EVG-14298 explicitly use commit title in github api

### DIFF
--- a/agent/command/git_merge_pr.go
+++ b/agent/command/git_merge_pr.go
@@ -100,13 +100,14 @@ func (c *gitMergePr) Execute(ctx context.Context, comm client.Communicator, logg
 
 	mergeOpts := &github.PullRequestOptions{
 		MergeMethod:        conf.ProjectRef.CommitQueue.MergeMethod,
+		CommitTitle:        patchDoc.GithubPatchData.CommitTitle,
 		DontDefaultIfBlank: true, // note this means that we will never merge with the default message (concatenated commit messages)
 	}
 
 	// do the merge
 	var res *github.PullRequestMergeResult
 	res, _, err = githubClient.PullRequests.Merge(githubCtx, conf.ProjectRef.Owner, conf.ProjectRef.Repo,
-		patchDoc.GithubPatchData.PRNumber, patchDoc.GithubPatchData.CommitTitle, mergeOpts)
+		patchDoc.GithubPatchData.PRNumber, patchDoc.GithubPatchData.CommitMessage, mergeOpts)
 	if err != nil {
 		return errors.Wrap(err, "can't access GitHub merge API")
 	}

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-08"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-03-19"
+	AgentVersion = "2021-03-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -862,7 +862,7 @@ func IsMailboxDiff(patchDiff string) bool {
 	return strings.HasPrefix(patchDiff, "From ")
 }
 
-func MakeNewMergePatch(pr *github.PullRequest, projectID, alias, commitTitle string) (*Patch, error) {
+func MakeNewMergePatch(pr *github.PullRequest, projectID, alias, commitTitle, commitMessage string) (*Patch, error) {
 	if pr.User == nil {
 		return nil, errors.New("pr contains no user")
 	}
@@ -899,6 +899,7 @@ func MakeNewMergePatch(pr *github.PullRequest, projectID, alias, commitTitle str
 			BaseBranch:     pr.Base.GetRef(),
 			HeadHash:       pr.Head.GetSHA(),
 			CommitTitle:    commitTitle,
+			CommitMessage:  commitMessage,
 		},
 	}
 

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -163,11 +163,13 @@ func (s *patchSuite) TestMakeMergePatch() {
 		MergeCommitSHA: github.String("abcdef"),
 	}
 
-	p, err := MakeNewMergePatch(pr, "mci", evergreen.CommitQueueAlias, "")
+	p, err := MakeNewMergePatch(pr, "mci", evergreen.CommitQueueAlias, "title", "message")
 	s.NoError(err)
 	s.Equal("mci", p.Project)
 	s.Equal(evergreen.PatchCreated, p.Status)
 	s.Equal(*pr.MergeCommitSHA, p.GithubPatchData.MergeCommitSHA)
+	s.Equal("title", p.GithubPatchData.CommitTitle)
+	s.Equal("message", p.GithubPatchData.CommitMessage)
 }
 
 func (s *patchSuite) TestUpdateGithashProjectAndTasks() {

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -59,8 +59,12 @@ func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef 
 	if err != nil {
 		return "", err
 	}
+	title := ""
+	if pr.Title != nil {
+		title = *pr.Title
+	}
 
-	patchDoc, err := patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias, messageOverride)
+	patchDoc, err := patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias, title, messageOverride)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to make commit queue patch")
 	}

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -59,12 +59,8 @@ func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef 
 	if err != nil {
 		return "", err
 	}
-	title := ""
-	if pr.Title != nil {
-		title = *pr.Title
-	}
 
-	patchDoc, err := patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias, title, messageOverride)
+	patchDoc, err := patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias, pr.GetTitle(), messageOverride)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to make commit queue patch")
 	}

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -48,7 +48,8 @@ type GithubPatch struct {
 	Author         string `bson:"author"`
 	AuthorUID      int    `bson:"author_uid"`
 	MergeCommitSHA string `bson:"merge_commit_sha"`
-	CommitTitle    string `bson:"commit_title"` // named poorly, it's actually the commit message
+	CommitTitle    string `bson:"commit_title"`
+	CommitMessage  string `bson:"commit_message"`
 }
 
 var (

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -349,11 +349,7 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 	}
 
 	if nextItem.PatchId == "" {
-		title := ""
-		if pr.Title != nil {
-			title = *pr.Title
-		}
-		patchDoc, err = patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias, title, nextItem.MessageOverride)
+		patchDoc, err = patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias, pr.GetTitle(), nextItem.MessageOverride)
 		if err != nil {
 			j.logError(err, "can't make patch", nextItem)
 			j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't make patch", ""))

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -349,7 +349,11 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 	}
 
 	if nextItem.PatchId == "" {
-		patchDoc, err = patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias, nextItem.MessageOverride)
+		title := ""
+		if pr.Title != nil {
+			title = *pr.Title
+		}
+		patchDoc, err = patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias, title, nextItem.MessageOverride)
 		if err != nil {
 			j.logError(err, "can't make patch", nextItem)
 			j.AddError(sendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't make patch", ""))


### PR DESCRIPTION
I had thought that github uses the pr title as the commit title if you leave it blank, but apparently this is not always true. I'm now explicitly passing it as the title