### PR TITLE
EVG-14326 don't restart unstarted versions in commit queue

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -537,7 +537,7 @@ func AbortPatchesWithGithubPatchData(createdBefore time.Time, closed bool, newPa
 
 	catcher := grip.NewSimpleCatcher()
 	for i, _ := range patches {
-		if patches[i].Version != "" {
+		if patches[i].Version != "" && patches[i].Alias != evergreen.CommitQueueAlias {
 			if err = CancelPatch(&patches[i], task.AbortInfo{User: evergreen.GithubPatchUser, NewVersion: newPatch, PRClosed: closed}); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"source":         "github hook",

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -547,8 +547,7 @@ func AbortPatchesWithGithubPatchData(createdBefore time.Time, closed bool, newPa
 					return errors.New("no merge task found")
 				}
 				catcher.Add(DequeueAndRestart(mergeTask, "new push to pull request"))
-			}
-			if err = CancelPatch(&p, task.AbortInfo{User: evergreen.GithubPatchUser, NewVersion: newPatch, PRClosed: closed}); err != nil {
+			} else if err = CancelPatch(&p, task.AbortInfo{User: evergreen.GithubPatchUser, NewVersion: newPatch, PRClosed: closed}); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"source":         "github hook",
 					"created_before": createdBefore.String(),

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -705,7 +705,14 @@ func RestartItemsAfterVersion(cq *commitqueue.CommitQueue, project, version, cal
 		}
 		if item.Version == version {
 			foundItem = true
-		} else if foundItem {
+		} else if foundItem && item.Version != "" {
+			grip.Info(message.Fields{
+				"message":            "restarting items due to commit queue failure",
+				"failing_version":    version,
+				"restarting_version": item.Version,
+				"project":            project,
+				"caller":             caller,
+			})
 			// this block executes on all items after the given task
 			catcher.Add(RestartTasksInVersion(item.Version, true, caller))
 		}

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -281,14 +281,18 @@ func (j *commitQueueJob) TryUnstick(ctx context.Context, cq *commitqueue.CommitQ
 	if mergeTask != nil {
 		// check that the merge task can run. Assume that if we're here the merge task
 		// should in fact run (ie. has not been dequeued due to a task failure)
-		if !mergeTask.Activated {
+		if !mergeTask.Activated || mergeTask.Priority < 0 {
 			grip.Error(message.Fields{
-				"message": "merge task is inactive",
-				"project": mergeTask.Project,
-				"task":    mergeTask.Id,
-				"source":  "commit queue",
-				"job_id":  j.ID(),
+				"message":  "merge task is not dispatchable",
+				"project":  mergeTask.Project,
+				"task":     mergeTask.Id,
+				"active":   mergeTask.Activated,
+				"priority": mergeTask.Priority,
+				"source":   "commit queue",
+				"job_id":   j.ID(),
 			})
+			j.dequeue(cq, nextItem)
+			event.LogCommitQueueConcludeTest(nextItem.Version, evergreen.EnqueueFailed)
 		}
 		if mergeTask.Blocked() {
 			grip.Error(message.Fields{
@@ -298,15 +302,6 @@ func (j *commitQueueJob) TryUnstick(ctx context.Context, cq *commitqueue.CommitQ
 				"dependencies": mergeTask.DependsOn,
 				"source":       "commit queue",
 				"job_id":       j.ID(),
-			})
-		}
-		if mergeTask.Priority < 0 {
-			grip.Error(message.Fields{
-				"message": "merge task is disabled",
-				"project": mergeTask.Project,
-				"task":    mergeTask.Id,
-				"source":  "commit queue",
-				"job_id":  j.ID(),
 			})
 		}
 	}


### PR DESCRIPTION
nope, the problem is actually that users are either manually restarting things in the commit queue, or pushing to prs that abort the commit queue merge