### PR TITLE
EVG-14261 remove project admin check in old UI

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -123,7 +123,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: c3275e3384e78a425594f29013af7c2a06fc53ae
   - name: github.com/evergreen-ci/gimlet
-    version: e776d7761204367d688b726f199a2beb7bf682f8
+    version: 330e9e955820a5e846d9acd67539c2884527486a
   - name: github.com/evergreen-ci/shrub
     version: 005df8abf87f20331677ecfaa19744efb99eb80b
   - name: github.com/evergreen-ci/pail

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -824,10 +824,22 @@ func addLoggerAndRepoSettingsToProjects(pRefs []ProjectRef) ([]ProjectRef, error
 
 // FindAllMergedProjectRefs returns all project refs in the db, with repo ref information merged
 func FindAllMergedProjectRefs() ([]ProjectRef, error) {
+	return FindProjectRefsQ(bson.M{})
+}
+
+func FindProjectRefsByIds(ids []string) ([]ProjectRef, error) {
+	return FindProjectRefsQ(bson.M{
+		ProjectRefIdKey: bson.M{
+			"$in": ids,
+		},
+	})
+}
+
+func FindProjectRefsQ(filter bson.M) ([]ProjectRef, error) {
 	projectRefs := []ProjectRef{}
 	err := db.FindAll(
 		ProjectRefCollection,
-		bson.M{},
+		filter,
 		db.NoProjection,
 		db.NoSort,
 		db.NoSkip,

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -3,7 +3,6 @@ mciModule.controller(
   function ($scope, $window, $http, $location, $mdDialog, timeUtil) {
     $scope.availableTriggers = $window.availableTriggers;
     $scope.userId = $window.user.Id;
-    $scope.isAdmin = $window.isAdmin;
     $scope.create = $window.canCreate;
     $scope.validDefaultLoggers = $window.validDefaultLoggers;
 

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -137,15 +137,6 @@ func isAdmin(u gimlet.User, project *model.ProjectRef) bool {
 	})
 }
 
-func hasViewPermission(u gimlet.User, project *model.ProjectRef) bool {
-	return u.HasPermission(gimlet.PermissionOpts{
-		Resource:      project.Id,
-		ResourceType:  evergreen.ProjectResourceType,
-		Permission:    evergreen.PermissionProjectSettings,
-		RequiredLevel: evergreen.ProjectSettingsView.Value,
-	})
-}
-
 func (uis *UIServer) ownsHost(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := gimlet.GetUser(r.Context())

--- a/service/project.go
+++ b/service/project.go
@@ -31,7 +31,9 @@ func (uis *UIServer) filterViewableProjects(u gimlet.User) ([]model.ProjectRef, 
 	ctx, cancel := env.Context()
 	defer cancel()
 	projectIds, err := rolemanager.FindAllowedResources(ctx, env.RoleManager(), u.Roles(), evergreen.ProjectResourceType, evergreen.PermissionProjectSettings, evergreen.ProjectSettingsView.Value)
-
+	if err != nil {
+		return nil, err
+	}
 	projects, err := model.FindProjectRefsByIds(projectIds)
 	if err != nil {
 		return nil, err

--- a/service/project.go
+++ b/service/project.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
@@ -28,19 +27,10 @@ import (
 // filterViewableProjects iterates through a list of projects and returns a list of all the projects that a user
 // is authorized to view
 func (uis *UIServer) filterViewableProjects(u gimlet.User) ([]model.ProjectRef, error) {
-	start := time.Now()
 	allProjects, err := model.FindAllMergedProjectRefs()
 	if err != nil {
 		return nil, err
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"func":        "filterViewableProjects",
-		"step":        "FindAllMergedProjectRefs",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
 	authorizedProjects := []model.ProjectRef{}
 	// only returns projects for which the user is authorized to see.
 	for _, project := range allProjects {
@@ -48,14 +38,6 @@ func (uis *UIServer) filterViewableProjects(u gimlet.User) ([]model.ProjectRef, 
 			authorizedProjects = append(authorizedProjects, project)
 		}
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"func":        "filterViewableProjects",
-		"step":        "hasViewPermission",
-		"len":         len(allProjects),
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
 	return authorizedProjects, nil
 
 }
@@ -87,8 +69,6 @@ func (uis *UIServer) projectsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
-	start := time.Now()
-	beginning := start
 	_ = MustHaveProjectContext(r)
 	u := MustHaveUser(r)
 
@@ -115,14 +95,6 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "start",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
 
 	// Replace ChildProject IDs of PatchTriggerAliases with the ChildProject's Identifier
 	for i, t := range projRef.PatchTriggerAliases {
@@ -142,14 +114,6 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 		}
 		projRef.PatchTriggerAliases[i].ChildProject = childProject.Identifier
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "PatchTriggerAliases",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
 
 	var projVars *model.ProjectVars
 	if projRef.UseRepoSettings {
@@ -166,14 +130,6 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	projVars = projVars.RedactPrivateVars()
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "find proj vars",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
 
 	projectAliases, err := model.FindAliasesForProject(projRef.Id)
 	if err != nil {
@@ -187,28 +143,11 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "FindAliasesForProject",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
-
 	matchingRefs, err := model.FindMergedEnabledProjectRefsByRepoAndBranch(projRef.Owner, projRef.Repo, projRef.Branch)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "FindMergedEnabledProjectRefsByRepoAndBranch",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
 	PRConflictingRefs := []string{}
 	CQConflictingRefs := []string{}
 	githubChecksConflictingRefs := []string{}
@@ -223,15 +162,6 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 			githubChecksConflictingRefs = append(githubChecksConflictingRefs, ref.Id)
 		}
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "find refs",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
-
 	var hook *model.GithubHook
 	if projRef.Owner != "" && projRef.Repo != "" {
 		hook, err = model.FindGithubHook(projRef.Owner, projRef.Repo)
@@ -240,28 +170,11 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "FindGithubHook",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
-
 	subscriptions, err := event.FindSubscriptionsByOwner(projRef.Id, event.OwnerTypeProject)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "FindSubscriptionsByOwner",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
 	apiSubscriptions := make([]restModel.APISubscription, len(subscriptions))
 	for i := range subscriptions {
 		if err = apiSubscriptions[i].BuildFromService(subscriptions[i]); err != nil {
@@ -275,14 +188,6 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "HighestPermissionsForRoles",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
 	settings, err := evergreen.GetConfig()
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
@@ -304,20 +209,6 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 
 	// the project context has all projects so make the ui list using all projects
 	gimlet.WriteJSON(w, data)
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "return data",
-		"duration":    time.Since(start),
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"project":     projRef.Id,
-		"step":        "get project data",
-		"duration":    time.Since(beginning),
-		"duration_ns": time.Since(beginning).Nanoseconds(),
-	})
 }
 
 // ProjectNotFound calls WriteHTML with the invalid-project page. It should be called whenever the

--- a/service/templates/menu.html
+++ b/service/templates/menu.html
@@ -72,9 +72,7 @@ window.NewUILink = {{.NewUILink}};
           </a>
           <ul class="dropdown-menu">
             <li><a ng-href="/distros">Distros</a></li>
-            {{if .ProjectData.IsAdmin }}
             <li><a ng-href="/projects##[[project]]">Projects</a></li>
-            {{end}}
             <li><a href="/spawn">Hosts</a></li>
             <li><a href="/patches/mine">Patches</a></li>
             <li class="divider"></li>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -3,7 +3,6 @@
   window.allTrackedProjects = {{.AllProjects}};
   {{if .User}}
   window.user = {{.User}};
-  window.isAdmin = {{.ProjectData.IsAdmin}};
   {{end}}
   window.canCreate = {{.CanCreate}};
   window.validDefaultLoggers = {{.ValidDefaultLoggers}};

--- a/vendor/github.com/evergreen-ci/gimlet/.golangci.yml
+++ b/vendor/github.com/evergreen-ci/gimlet/.golangci.yml
@@ -12,4 +12,4 @@ linters:
 
 linters-settings:
   govet:
-    check-shadowing: true
+    check-shadowing: false

--- a/vendor/github.com/evergreen-ci/gimlet/cmd/run-linter/run-linter.go
+++ b/vendor/github.com/evergreen-ci/gimlet/cmd/run-linter/run-linter.go
@@ -103,7 +103,9 @@ func main() {
 
 		for _, linter := range customLinters {
 			customLinterStart := time.Now()
-			cmd := exec.Command(linter, pkgDir)
+			linterArgs := strings.Split(linter, " ")
+			linterArgs = append(linterArgs, pkgDir)
+			cmd := exec.Command(linterArgs[0], linterArgs[1:]...)
 			cmd.Dir = dirname
 			out, err := cmd.CombinedOutput()
 			r.passed = r.passed && err == nil

--- a/vendor/github.com/evergreen-ci/gimlet/middleware_auth.go
+++ b/vendor/github.com/evergreen-ci/gimlet/middleware_auth.go
@@ -291,6 +291,7 @@ func (rp *requiresPermissionHandler) ServeHTTP(rw http.ResponseWriter, r *http.R
 	if ok := rp.checkPermissions(rw, r.Context(), resources); !ok {
 		return
 	}
+
 	next(rw, r)
 }
 

--- a/vendor/github.com/evergreen-ci/gimlet/middleware_auth.go
+++ b/vendor/github.com/evergreen-ci/gimlet/middleware_auth.go
@@ -3,7 +3,6 @@ package gimlet
 import (
 	"context"
 	"net/http"
-	"time"
 
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -270,8 +269,6 @@ func (rp *requiresPermissionHandler) ServeHTTP(rw http.ResponseWriter, r *http.R
 	var resources []string
 	var status int
 	var err error
-	start := time.Now()
-	begin := start
 	if rp.opts.ResourceFunc != nil {
 		resources, status, err = rp.opts.ResourceFunc(r)
 		if err != nil {
@@ -286,14 +283,6 @@ func (rp *requiresPermissionHandler) ServeHTTP(rw http.ResponseWriter, r *http.R
 			}
 		}
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"resources":   resources,
-		"step":        "ResourceFunc",
-		"func":        "requiresPermissionHandler",
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	start = time.Now()
 
 	if len(resources) == 0 {
 		http.Error(rw, "no resources found", http.StatusNotFound)
@@ -302,21 +291,6 @@ func (rp *requiresPermissionHandler) ServeHTTP(rw http.ResponseWriter, r *http.R
 	if ok := rp.checkPermissions(rw, r.Context(), resources); !ok {
 		return
 	}
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"resources":   resources,
-		"step":        "ResourceFunc",
-		"func":        "requiresPermissionHandler",
-		"duration_ns": time.Since(start).Nanoseconds(),
-	})
-	grip.Debug(message.Fields{
-		"ticket":      "EVG-14261",
-		"resources":   resources,
-		"step":        "total",
-		"func":        "requiresPermissionHandler",
-		"duration_ns": time.Since(begin).Nanoseconds(),
-	})
-
 	next(rw, r)
 }
 

--- a/vendor/github.com/evergreen-ci/gimlet/rolemanager/role_manager.go
+++ b/vendor/github.com/evergreen-ci/gimlet/rolemanager/role_manager.go
@@ -923,3 +923,44 @@ func MakeRoleWithPermissions(rm gimlet.RoleManager, resourceType string, resourc
 
 	return &newRole, nil
 }
+
+// FindAllowedResources takes a list of roles and a permission to check in those roles. It returns
+// a list of all resources that the given roles have access to with the given permission check.
+// It answers the question "Given this list of roles (likely from a single user), what resources
+// can they access, given this permission check?"
+func FindAllowedResources(ctx context.Context, rm gimlet.RoleManager, roles []string, resourceType, requiredPermission string, requiredLevel int) ([]string, error) {
+	if resourceType == "" {
+		return nil, errors.New("must specify a resource type")
+	}
+	if requiredPermission == "" {
+		return nil, errors.New("must specify a required permission")
+	}
+	allowedResources := map[string]bool{}
+	roleDocs, err := rm.GetRoles(roles)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting roles")
+	}
+	for _, role := range roleDocs {
+		level := role.Permissions[requiredPermission]
+		if level < requiredLevel {
+			continue
+		}
+		scope, err := rm.GetScope(ctx, role.Scope)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to get scope '%s'", role.Scope)
+		}
+		if scope == nil {
+			return nil, errors.Errorf("scope '%s' not found", role.Scope)
+		}
+		if scope.Type == resourceType {
+			for _, resource := range scope.Resources {
+				allowedResources[resource] = true
+			}
+		}
+	}
+	deduplicatedResources := []string{}
+	for resource := range allowedResources {
+		deduplicatedResources = append(deduplicatedResources, resource)
+	}
+	return deduplicatedResources, nil
+}


### PR DESCRIPTION
This fixes the easier half of the ticket. We're no longer checking all projects to see if the user is the admin of at least 1, to see if the "projects" option should show in the menu. This means that someone who is an admin in no projects still sees the dropdown option which will lead to the "Awkward..." page. It's not the ideal experience but I think it's fine. It should noticeably decrease the load time on every page

Also this exposes an existing bug where someone with no roles will hit a runtime error on the projects page, but someone with no roles would have bigger problems anyway

Ok also added the second half, which reduces the number of queries we do on the project page