### PR TITLE
EVG-14283: Notifications for patch outcome, success, and failure should take the child patch into account

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -277,6 +277,10 @@ func IsFailedTaskStatus(status string) bool {
 	return utility.StringSliceContains(TaskFailureStatuses, status)
 }
 
+func IsFinishedPatchStatus(status string) bool {
+	return status == PatchFailed || status == PatchSucceeded
+}
+
 // evergreen package names
 const (
 	UIPackage      = "EVERGREEN_UI"

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -574,19 +574,6 @@ func (p *Patch) SetActivation(activated bool) error {
 	)
 }
 
-// SetActivated sets the patch status in the db
-func (p *Patch) SetStatus(status string) error {
-	p.Status = status
-	return UpdateOne(
-		bson.M{IdKey: p.Id},
-		bson.M{
-			"$set": bson.M{
-				StatusKey: status,
-			},
-		},
-	)
-}
-
 // UpdateModulePatch adds or updates a module within a patch.
 func (p *Patch) UpdateModulePatch(modulePatch ModulePatch) error {
 	// update the in-memory patch
@@ -679,6 +666,27 @@ func (p *Patch) IsChild() bool {
 
 func (p *Patch) IsParent() bool {
 	return len(p.Triggers.ChildPatches) > 0
+}
+
+func (p *Patch) GetPatchFamily() ([]string, *Patch, error) {
+	var childrenOrSiblings []string
+	var parentPatch *Patch
+	var err error
+	if p.IsParent() {
+		childrenOrSiblings = p.Triggers.ChildPatches
+	}
+	if p.IsChild() {
+		parentPatchId := p.Triggers.ParentPatch
+		parentPatch, err = FindOneId(parentPatchId)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "can't get parent patch")
+		}
+		if parentPatch == nil {
+			return nil, nil, errors.Errorf(fmt.Sprintf("parent patch '%s' does not exist", parentPatchId))
+		}
+		childrenOrSiblings = parentPatch.Triggers.ChildPatches
+	}
+	return childrenOrSiblings, parentPatch, nil
 }
 
 func (p *Patch) SetParametersFromParent() error {

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -574,6 +574,19 @@ func (p *Patch) SetActivation(activated bool) error {
 	)
 }
 
+// SetActivated sets the patch status in the db
+func (p *Patch) SetStatus(status string) error {
+	p.Status = status
+	return UpdateOne(
+		bson.M{IdKey: p.Id},
+		bson.M{
+			"$set": bson.M{
+				StatusKey: status,
+			},
+		},
+	)
+}
+
 // UpdateModulePatch adds or updates a module within a patch.
 func (p *Patch) UpdateModulePatch(modulePatch ModulePatch) error {
 	// update the in-memory patch

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -118,48 +118,48 @@ func (t *patchTriggers) patchOutcome(sub *event.Subscription) (*notification.Not
 		}
 	}
 
-	if t.patch.IsParent() || t.patch.IsChild() {
-		// check that the parent and all children are done. only the last patch to finish should send the notification
-		var childrenOrSiblings []string
-		var collectiveStatus string
-		if t.patch.IsParent() {
-			childrenOrSiblings = t.patch.Triggers.ChildPatches
-		} else {
-			parentPatchId := t.patch.Triggers.ParentPatch
-			parentPatch, err := patch.FindOneId(parentPatchId)
-			if err != nil {
-				return nil, errors.Wrap(err, "can't get parent patch")
-			}
-			if parentPatch == nil {
-				return nil, errors.Errorf(fmt.Sprintf("parent patch '%s' does not exist", parentPatchId))
-			}
-			if parentPatch.Status != evergreen.PatchSucceeded && parentPatch.Status != evergreen.PatchFailed {
-				// We want to make sure that the children didn't finish before the parent
-				return nil, nil
-			}
-			collectiveStatus = parentPatch.Status
-			childrenOrSiblings = parentPatch.Triggers.ChildPatches
-		}
-		for _, childPatch := range childrenOrSiblings {
-			childPatchDoc, err := patch.FindOneId(childPatch)
-			if err != nil {
-				return nil, errors.Wrapf(err, "error getting tasks for child patch '%s'", childPatch)
-			}
-			if childPatchDoc == nil {
-				continue
-			}
-			if childPatchDoc.Status != evergreen.PatchSucceeded && childPatchDoc.Status != evergreen.PatchFailed {
-				// if any child is not done yet, we want to return nothing and wait for the patch that is last to complete
-				return nil, nil
-			} else if childPatchDoc.Status == evergreen.PatchFailed {
-				collectiveStatus = evergreen.PatchFailed
-			}
-		}
-		//no unfinished patches left
-		err := t.patch.SetStatus(collectiveStatus)
+	if t.patch.IsParent() || (t.patch.IsChild() && sub.Subscriber.Type == event.ParentWaitOnChildSubscriberType) {
+		// get the children or siblings to wait on
+		childrenOrSiblings, parentPatch, err := t.patch.GetPatchFamily()
 		if err != nil {
-			return nil, errors.Wrap(err, "error setting status")
+			return nil, errors.Wrap(err, "error getting child or sibling patches")
 		}
+
+		childrenStatus, unreadyChild, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)
+		if err != nil {
+			return nil, errors.Wrap(err, "error getting child or sibling information")
+		}
+		//make sure the children or siblings are done before sending the notification
+		if !evergreen.IsFinishedPatchStatus(childrenStatus) {
+			parentId := t.patch.Id.Hex()
+			if t.patch.IsChild() {
+				parentId = parentPatch.Id.Hex()
+			}
+			// if there is still a child or sibling that's not done, subscribe on it and don't create the notification
+			err = subscribeOnChild(parentId, unreadyChild.Id.Hex(), sub)
+			if err != nil {
+				return nil, errors.Wrap(err, "error subscribing on child patch")
+			}
+			return nil, nil
+		}
+
+		if childrenStatus == evergreen.PatchFailed {
+			t.data.Status = evergreen.PatchFailed
+		}
+
+		// convert the subscription to the right type
+		if sub.Subscriber.Type == event.ParentWaitOnChildSubscriberType {
+			t.patch = parentPatch
+			target, ok := sub.Subscriber.Target.(*event.ParentWaitOnChildSubscriber)
+			if !ok {
+				return nil, errors.Errorf("target '%s' didn't not have expected type", sub.Subscriber.Target)
+			}
+			target.OriginalSub.LastUpdated = time.Now()
+
+			newSub := event.NewExpiringPatchOutcomeSubscription(parentPatch.Id.Hex(), target.OriginalSub.Subscriber)
+			return t.generate(&newSub)
+		}
+
 	}
 	return t.generate(sub)
 }
@@ -170,6 +170,42 @@ func (t *patchTriggers) patchFailure(sub *event.Subscription) (*notification.Not
 	}
 
 	return t.generate(sub)
+}
+
+func getChildrenOrSiblingsReadiness(childrenOrSiblings []string) (string, *patch.Patch, error) {
+	childrenStatus := evergreen.PatchSucceeded
+	for _, childPatch := range childrenOrSiblings {
+		childPatchDoc, err := patch.FindOneId(childPatch)
+		if err != nil {
+			return "", nil, errors.Wrapf(err, "error getting tasks for child patch '%s'", childPatch)
+		}
+		if childPatchDoc == nil {
+			return "", nil, errors.Wrapf(err, "child patch '%s' not found", childPatch)
+		}
+		if childPatchDoc.Status == evergreen.PatchFailed {
+			childrenStatus = evergreen.PatchFailed
+		}
+		if !evergreen.IsFinishedPatchStatus(childPatchDoc.Status) {
+			return childPatchDoc.Status, childPatchDoc, nil
+		}
+	}
+	return childrenStatus, nil, nil
+
+}
+
+func subscribeOnChild(parentId, childPatchId string, sub *event.Subscription) error {
+	waitOnChildSubscriber := event.NewParentWaitOnChildSubscriber(event.ParentWaitOnChildSubscriber{
+		ParentPatchId: parentId,
+		ChildPatchId:  childPatchId,
+		Requester:     "patch_outcome_notification",
+		OriginalSub:   sub,
+	})
+	childPatchSub := event.NewExpiringPatchOutcomeSubscription(childPatchId, waitOnChildSubscriber)
+	err := childPatchSub.Upsert()
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert patch subscription for child patch %s", childPatchId)
+	}
+	return nil
 }
 
 func finalizeChildPatch(sub *event.Subscription) error {
@@ -306,7 +342,6 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 			},
 		},
 	})
-
 	return &data, nil
 }
 
@@ -320,6 +355,5 @@ func (t *patchTriggers) generate(sub *event.Subscription) (*notification.Notific
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build notification")
 	}
-
 	return notification.New(t.event.ID, sub.Trigger, &sub.Subscriber, payload)
 }

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -361,6 +361,13 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		}
 		if patchDoc.IsParent() {
 			for _, childPatch := range patchDoc.Triggers.ChildPatches {
+				ghSub := event.NewGithubStatusAPISubscriber(event.GithubPullRequestSubscriber{
+					Owner:    patchDoc.GithubPatchData.BaseOwner,
+					Repo:     patchDoc.GithubPatchData.BaseRepo,
+					PRNumber: patchDoc.GithubPatchData.PRNumber,
+					Ref:      patchDoc.GithubPatchData.HeadHash,
+					ChildId:  childPatch,
+				})
 				patchSub := event.NewExpiringPatchOutcomeSubscription(childPatch, ghSub)
 				if err = patchSub.Upsert(); err != nil {
 					catcher.Add(errors.Wrap(err, "failed to insert child patch subscription for Github PR"))


### PR DESCRIPTION
todo: test on staging again. It does not seem to be waiting to send the notification. 