### PR TITLE
EVG-14147 change input to offboard user route

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2519,7 +2519,9 @@ func (h *Host) MarkShouldExpire(expireOnValue string) error {
 
 	h.NoExpiration = false
 	h.ExpirationTime = time.Now().Add(evergreen.DefaultSpawnHostExpiration)
-	h.addTag(makeExpireOnTag(expireOnValue), true)
+	if expireOnValue != "" {
+		h.addTag(makeExpireOnTag(expireOnValue), true)
+	}
 	return UpdateOne(bson.M{
 		IdKey: h.Id,
 	},

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/evergreen-ci/evergreen/model/user"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/data"
@@ -372,6 +374,20 @@ func (ch *offboardUserHandler) Parse(ctx context.Context, r *http.Request) error
 			StatusCode: http.StatusBadRequest,
 		}
 	}
+	u, err := ch.sc.FindUserById(ch.user)
+	if err != nil {
+		return gimlet.ErrorResponse{
+			Message:    "problem finding user",
+			StatusCode: http.StatusInternalServerError,
+		}
+	}
+	if u.(*user.DBUser) == nil {
+		return gimlet.ErrorResponse{
+			Message:    "user not found",
+			StatusCode: http.StatusNotFound,
+		}
+	}
+
 	vals := r.URL.Query()
 	ch.dryRun = vals.Get("dry_run") == "true"
 

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -190,7 +190,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/user/settings").Version(2).Post().Wrap(checkUser).RouteHandler(makeSetUserConfig(sc))
 	app.AddRoute("/users/{user_id}/hosts").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchHosts(sc))
 	app.AddRoute("/users/{user_id}/patches").Version(2).Get().Wrap(checkUser).RouteHandler(makeUserPatchHandler(sc))
-	app.AddRoute("/users/{user_id}/offboard_user").Version(2).Post().Wrap(checkUser, editRoles).RouteHandler(makeOffboardUser(sc, env))
+	app.AddRoute("/users/offboard_user").Version(2).Post().Wrap(checkUser, editRoles).RouteHandler(makeOffboardUser(sc, env))
 	app.AddRoute("/users/{user_id}/permissions").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetUserPermissions(sc, evergreen.GetEnvironment().RoleManager()))
 	app.AddRoute("/users/{user_id}/permissions").Version(2).Post().Wrap(checkUser, editRoles).RouteHandler(makeModifyUserPermissions(sc, evergreen.GetEnvironment().RoleManager()))
 	app.AddRoute("/users/{user_id}/permissions").Version(2).Delete().Wrap(checkUser, editRoles).RouteHandler(makeDeleteUserPermissions(sc, evergreen.GetEnvironment().RoleManager()))


### PR DESCRIPTION
I also intended to create a job to terminate the hosts, in case it took too long and the route timed out, but I forgot that we had switched to modifying expiration instead of terminating the host directly, in order to speed up the process. I'd like to push this even more by only modifying the DB NoExpiration field, (Jonathan's [original suggestion](https://jira.mongodb.org/browse/EVG-12852)), so that we don't keep pushing out the expiration date in AWS, and the host/volume will expire naturally. This prevents us from relying on AWS speed at all.