### PR TITLE
EVG-13974: Update status diff on the task page to support cedar test results

### DIFF
--- a/model/status_diff.go
+++ b/model/status_diff.go
@@ -122,8 +122,8 @@ func getTestUrl(tr *task.TestResult) string {
 	if tr.LogId != "" {
 		return TestLogPath + tr.LogId
 	}
-	if tr.TaskID != "" && tr.TestName() != "" {
-		return fmt.Sprintf("%s%s/%d/%s?group_id=%s", TestLogPath, tr.TaskID, tr.Execution, tr.TestName(), tr.GroupID)
+	if tr.TaskID != "" && tr.GetLogTestName() != "" {
+		return fmt.Sprintf("%s%s/%d/%s?group_id=%s", TestLogPath, tr.TaskID, tr.Execution, tr.GetLogTestName(), tr.GroupID)
 	}
 
 	return ""
@@ -183,14 +183,14 @@ func StatusDiffTests(original, patch []task.TestResult) []TestStatusDiff {
 
 	originalMap := make(map[string]task.TestResult)
 	for _, test := range original {
-		originalMap[test.TestName()] = test
+		originalMap[test.GetDisplayTestName()] = test
 	}
 
 	for _, test := range patch {
-		baseTest := originalMap[test.TestName()]
+		baseTest := originalMap[test.GetDisplayTestName()]
 
 		// Get the base name for windows/non-windows paths.
-		testName := path.Base(strings.Replace(test.TestName(), "\\", "/", -1))
+		testName := path.Base(strings.Replace(test.GetDisplayTestName(), "\\", "/", -1))
 		diff = append(diff, TestStatusDiff{
 			Name:     testName,
 			Diff:     StatusDiff{baseTest.Status, test.Status},

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -296,6 +296,14 @@ type TestResult struct {
 	LogTestName string `json:"log_test_name" bson:"log_test_name"`
 }
 
+func (tr *TestResult) TestName() string {
+	if tr.LogTestName != "" {
+		return tr.LogTestName
+	}
+
+	return tr.TestFile
+}
+
 type DisplayTaskCache struct {
 	execToDisplay map[string]*Task
 	displayTasks  []*Task

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -296,9 +296,22 @@ type TestResult struct {
 	LogTestName string `json:"log_test_name" bson:"log_test_name"`
 }
 
-func (tr *TestResult) TestName() string {
+// GetLogTestName returns the name of the test in the logging backend. This is
+// used for test logs in cedar where the name of the test in the logging
+// service may differ from that in the test results service.
+func (tr *TestResult) GetLogTestName() string {
 	if tr.LogTestName != "" {
 		return tr.LogTestName
+	}
+
+	return tr.TestFile
+}
+
+// GetDisplayTestName returns the name of the test that should be displayed in
+// the UI. In most cases, this will just be TestFile.
+func (tr *TestResult) GetDisplayTestName() string {
+	if tr.DisplayTestName != "" {
+		return tr.DisplayTestName
 	}
 
 	return tr.TestFile

--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -354,8 +354,6 @@ mciModule.controller('TaskCtrl', function ($scope, $rootScope, $now, $timeout, $
   $scope.getURL = function (testResult, isRaw) {
     var url = (isRaw) ? testResult.url_raw : testResult.url;
     let prefix = '/test_log/';
-    var group_id = '?group_id=';
-    group_id += (testResult.group_id) ? testResult.group_id : ""
     let raw = 'text=true';
     let lineNum = '#L' + (testResult.line_num || 0);
     if (url == '' && testResult.log_id) {
@@ -365,6 +363,8 @@ mciModule.controller('TaskCtrl', function ($scope, $rootScope, $now, $timeout, $
         url = prefix + testResult.log_id + lineNum;
       }
     } else if (url == '') {
+      var group_id = '?group_id='
+      group_id += (testResult.group_id) ? testResult.group_id : ""
       var test_name = (testResult.log_test_name) ? testResult.log_test_name : testResult.test_file;
       url = prefix + testResult.task_id + '/' + testResult.execution + '/' + test_name + group_id
       if (isRaw) {

--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -354,19 +354,20 @@ mciModule.controller('TaskCtrl', function ($scope, $rootScope, $now, $timeout, $
   $scope.getURL = function (testResult, isRaw) {
     var url = (isRaw) ? testResult.url_raw : testResult.url;
     let prefix = '/test_log/';
-    let raw = '?text=true';
+    let group_id = '?group_id=' + testResult.group_id
+    let raw = 'text=true';
     let lineNum = '#L' + (testResult.line_num || 0);
     if (url == '' && testResult.log_id) {
       if (isRaw) {
-        url = prefix + testResult.log_id + raw;
+        url = prefix + testResult.log_id + '?' +  raw;
       } else  {
         url = prefix + testResult.log_id + lineNum;
       }
     } else if (url == '') {
       var test_name = (testResult.log_test_name) ? testResult.log_test_name : testResult.test_file;
-      url = prefix + testResult.task_id + '/' + testResult.execution + '/' + test_name;
+      url = prefix + testResult.task_id + '/' + testResult.execution + '/' + test_name + group_id
       if (isRaw) {
-          url  += raw;
+          url  += '&' + raw;
       } else {
           url += lineNum;
       }

--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -354,7 +354,8 @@ mciModule.controller('TaskCtrl', function ($scope, $rootScope, $now, $timeout, $
   $scope.getURL = function (testResult, isRaw) {
     var url = (isRaw) ? testResult.url_raw : testResult.url;
     let prefix = '/test_log/';
-    let group_id = '?group_id=' + testResult.group_id
+    var group_id = '?group_id=';
+    group_id += (testResult.group_id) ? testResult.group_id : ""
     let raw = 'text=true';
     let lineNum = '#L' + (testResult.line_num || 0);
     if (url == '' && testResult.log_id) {

--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -511,7 +511,7 @@ mciModule.controller('TaskCtrl', function ($scope, $rootScope, $now, $timeout, $
       var testResult = t.test_result;
       testResult.time_taken = testResult.end - testResult.start;
       totalTestTime += testResult.time_taken;
-      testResult.display_name = testResult.display_test_name ? testResult.display_test_name: $filter('endOfPath')(testResult.test_file);
+      testResult.display_name = testResult.display_test_name ? $filter('endOfPath')(testResult.display_test_name): $filter('endOfPath')(testResult.test_file);
     });
     $scope.totalTestTimeNano = totalTestTime * 1000 * 1000 * 1000;
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13974

I ran a patch resmoke patch build and realized that the current status diff on the patch task page does not support cedar test results. This fixes it.

@khelif96 I am not sure if this is also the case on the spruce UI, so just wanted to bring it to your attention in case it is.