### PR TITLE
EVG-13884 nil pointer dereference fix

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1156,7 +1156,7 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 	}
 	opts := apimodels.GetCedarTestResultsOptions{
 		BaseURL:   evergreen.GetEnvironment().Settings().Cedar.BaseURL,
-		Execution: *execution,
+		Execution: dbTask.Execution,
 	}
 	if len(dbTask.ExecutionTasks) > 0 {
 		opts.DisplayTaskID = taskID


### PR DESCRIPTION
Noticed a nil pointer error being thrown when fetching task tests without an execution