### PR TITLE
EVG-13967: set cutoff limit for checking user data done on spawn hosts

### DIFF
--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1459,6 +1459,14 @@ func TestFindUserDataSpawnHostsProvisioning(t *testing.T) {
 			require.NoError(t, err)
 			assert.Empty(t, hosts)
 		},
+		"IgnoresSpawnHostsThatProvisionForTooLong": func(t *testing.T, h *Host) {
+			h.ProvisionTime = time.Now().Add(-24 * time.Hour)
+			require.NoError(t, h.Insert())
+
+			hosts, err := FindUserDataSpawnHostsProvisioning()
+			require.NoError(t, err)
+			assert.Empty(t, hosts)
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			require.NoError(t, db.Clear(Collection), "error clearing %s collection", Collection)
@@ -1466,10 +1474,11 @@ func TestFindUserDataSpawnHostsProvisioning(t *testing.T) {
 				assert.NoError(t, db.Clear(Collection))
 			}()
 			h := Host{
-				Id:          "host_id",
-				Status:      evergreen.HostStarting,
-				Provisioned: true,
-				StartedBy:   "user",
+				Id:            "host_id",
+				Status:        evergreen.HostStarting,
+				Provisioned:   true,
+				ProvisionTime: time.Now(),
+				StartedBy:     "user",
 				Distro: distro.Distro{
 					Id: "distro_id",
 					BootstrapSettings: distro.BootstrapSettings{


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13967

This sets a deadline for checking that the spawn host can be transitioned from the "starting" to "running" state. If it exceeds this deadline, it can be assumed that the host is unreachable (although the user can still SSH into it to use it).