### PR TITLE
EVG-13687 add spot termination hook

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -427,7 +427,7 @@ func (a *Agent) runTask(ctx context.Context, tc *taskContext) (bool, error) {
 
 	go a.startIdleTimeoutWatch(tskCtx, tc, innerCancel)
 	if utility.StringSliceContains(evergreen.ProviderSpotEc2Type, a.opts.CloudProvider) {
-		go a.startSpotTerminationWatcher(tskCtx)
+		go a.startEarlyTerminationWatcher(tskCtx, tc, agentutil.SpotHostWillTerminateSoon, agentutil.ExitAgent, nil)
 	}
 
 	complete := make(chan string)

--- a/agent/task.go
+++ b/agent/task.go
@@ -261,8 +261,12 @@ func (tc *taskContext) setCurrentIdleTimeout(cmd command.Command) {
 	}
 
 	tc.setIdleTimeout(timeout)
-	tc.logger.Execution().Debugf("Set idle timeout for '%s' (%s) to %s",
-		tc.currentCommand.DisplayName(), tc.currentCommand.Type(), tc.getIdleTimeout())
+	if tc.currentCommand != nil {
+		tc.logger.Execution().Debugf("Set idle timeout for '%s' (%s) to %s",
+			tc.currentCommand.DisplayName(), tc.currentCommand.Type(), tc.getIdleTimeout())
+	} else {
+		tc.logger.Execution().Debugf("Set current idle timeout to %s", tc.getIdleTimeout())
+	}
 }
 
 func (tc *taskContext) getCurrentTimeout() time.Duration {

--- a/agent/util/ec2.go
+++ b/agent/util/ec2.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
@@ -23,4 +24,9 @@ func SpotHostWillTerminateSoon() bool {
 		return true
 	}
 	return false
+}
+
+func ExitAgent() {
+	grip.Info("Spot instance terminating, so agent is exiting")
+	os.Exit(1)
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-26"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-03-23"
+	AgentVersion = "2021-03-29"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/project.go
+++ b/model/project.go
@@ -49,6 +49,7 @@ type Project struct {
 	Pre               *YAMLCommandSet            `yaml:"pre,omitempty" bson:"pre"`
 	Post              *YAMLCommandSet            `yaml:"post,omitempty" bson:"post"`
 	Timeout           *YAMLCommandSet            `yaml:"timeout,omitempty" bson:"timeout"`
+	EarlyTermination  *YAMLCommandSet            `yaml:"early_termination,omitempty" bson:"early_termination,omitempty"`
 	CallbackTimeout   int                        `yaml:"callback_timeout_secs,omitempty" bson:"callback_timeout_secs"`
 	Modules           ModuleList                 `yaml:"modules,omitempty" bson:"modules"`
 	BuildVariants     BuildVariants              `yaml:"buildvariants,omitempty" bson:"build_variants"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -68,6 +68,7 @@ type ParserProject struct {
 	Pre                *YAMLCommandSet            `yaml:"pre,omitempty" bson:"pre,omitempty"`
 	Post               *YAMLCommandSet            `yaml:"post,omitempty" bson:"post,omitempty"`
 	Timeout            *YAMLCommandSet            `yaml:"timeout,omitempty" bson:"timeout,omitempty"`
+	EarlyTermination   *YAMLCommandSet            `yaml:"early_termination,omitempty" bson:"early_termination,omitempty"`
 	CallbackTimeout    int                        `yaml:"callback_timeout_secs,omitempty" bson:"callback_timeout_secs,omitempty"`
 	Modules            []Module                   `yaml:"modules,omitempty" bson:"modules,omitempty"`
 	BuildVariants      []parserBV                 `yaml:"buildvariants,omitempty" bson:"buildvariants,omitempty"`
@@ -592,6 +593,7 @@ func TranslateProject(pp *ParserProject) (*Project, error) {
 		Parameters:        pp.Parameters,
 		Pre:               pp.Pre,
 		Post:              pp.Post,
+		EarlyTermination:  pp.EarlyTermination,
 		Timeout:           pp.Timeout,
 		CallbackTimeout:   pp.CallbackTimeout,
 		Modules:           pp.Modules,

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -33,6 +33,7 @@ var (
 	ParserProjectParametersKey        = bsonutil.MustHaveTag(ParserProject{}, "Parameters")
 	ParserProjectPreKey               = bsonutil.MustHaveTag(ParserProject{}, "Pre")
 	ParserProjectPostKey              = bsonutil.MustHaveTag(ParserProject{}, "Post")
+	ParserProjectEarlyTerminationKey  = bsonutil.MustHaveTag(ParserProject{}, "EarlyTermination")
 	ParserProjectTimeoutKey           = bsonutil.MustHaveTag(ParserProject{}, "Timeout")
 	ParserProjectCallbackTimeoutKey   = bsonutil.MustHaveTag(ParserProject{}, "CallbackTimeout")
 	ParserProjectModulesKey           = bsonutil.MustHaveTag(ParserProject{}, "Modules")
@@ -96,6 +97,7 @@ func setAllFieldsUpdate(pp *ParserProject) interface{} {
 			ParserProjectPreKey:               pp.Pre,
 			ParserProjectPostKey:              pp.Post,
 			ParserProjectTimeoutKey:           pp.Timeout,
+			ParserProjectEarlyTerminationKey:  pp.EarlyTermination,
 			ParserProjectCallbackTimeoutKey:   pp.CallbackTimeout,
 			ParserProjectModulesKey:           pp.Modules,
 			ParserProjectBuildVariantsKey:     pp.BuildVariants,

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -955,18 +955,19 @@ func validatePluginCommands(project *model.Project) ValidationErrors {
 	}
 
 	if project.Pre != nil {
-		// validate project pre section
 		errs = append(errs, validateCommands("pre", project, project.Pre.List())...)
 	}
 
 	if project.Post != nil {
-		// validate project post section
 		errs = append(errs, validateCommands("post", project, project.Post.List())...)
 	}
 
 	if project.Timeout != nil {
-		// validate project timeout section
 		errs = append(errs, validateCommands("timeout", project, project.Timeout.List())...)
+	}
+
+	if project.EarlyTermination != nil {
+		errs = append(errs, validateCommands("early termination", project, project.EarlyTermination.List())...)
 	}
 
 	// validate project tasks section


### PR DESCRIPTION
This adds a yaml hook that you can define to be run when we detect that a spot instance is going to be taken away. Also refactored that part to be more testable and named slightly more generically