### PR TITLE
EVG-14148 log checkUnmarkedBlockingTasks

### DIFF
--- a/model/task_queue_service.go
+++ b/model/task_queue_service.go
@@ -238,7 +238,7 @@ func (d *basicCachedDispatcherImpl) Refresh() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if !shouldRefreshCached(d.ttl, d.lastUpdated, d.distroID) {
+	if !shouldRefreshCached(d.ttl, d.lastUpdated) {
 		return nil
 	}
 
@@ -253,7 +253,7 @@ func (d *basicCachedDispatcherImpl) Refresh() error {
 	return nil
 }
 
-func shouldRefreshCached(ttl time.Duration, lastUpdated time.Time, distroID string) bool {
+func shouldRefreshCached(ttl time.Duration, lastUpdated time.Time) bool {
 	return lastUpdated.IsZero() || time.Since(lastUpdated) > ttl
 }
 

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -283,8 +283,21 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 			"distro_id":                d.distroID,
 		})
 	}
+	var totalDurationCheckingBlockedTasks float64
+	var numCheckBlockedTasks int
+	var numIterated int
+	defer grip.DebugWhen(totalDurationCheckingBlockedTasks > 0, message.Fields{
+		"total_duration_secs": totalDurationCheckingBlockedTasks,
+		"total_operations":    numCheckBlockedTasks,
+		"dispatcher":          DAGDispatcher,
+		"operation":           "checkUnmarkedBlockingTasks",
+		"distro":              d.distroID,
+		"num_iterated":        numIterated,
+		"total_size":          len(d.sorted),
+	})
 	dependencyCaches := make(map[string]task.Task)
 	for i := range d.sorted {
+		numIterated += 1
 		node := d.sorted[i]
 		item := d.getItemByNodeID(node.ID()) // item is a *TaskQueueItem sourced from d.nodeItemMap, which is a map[node.ID()]*TaskQueueItem.
 
@@ -348,8 +361,7 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 
 			if !dependenciesMet {
 				start := time.Now()
-				err = checkUnmarkedBlockingTasks(nextTaskFromDB, dependencyCaches)
-				msg := message.Fields{
+				grip.Warning(message.WrapError(checkUnmarkedBlockingTasks(nextTaskFromDB, dependencyCaches), message.Fields{
 					"dispatcher":    DAGDispatcher,
 					"function":      "FindNextTask",
 					"operation":     "checkUnmarkedBlockingTasks",
@@ -358,9 +370,9 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 					"distro_id":     d.distroID,
 					"duration":      time.Since(start),
 					"duration_secs": time.Since(start).Seconds(),
-				}
-				grip.Warning(message.WrapError(err, msg))
-				grip.DebugWhen(err == nil, msg)
+				}))
+				totalDurationCheckingBlockedTasks += time.Since(start).Seconds()
+				numCheckBlockedTasks += 1
 				continue
 			}
 

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -347,16 +347,20 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 			}
 
 			if !dependenciesMet {
-				grip.Warning(message.WrapError(checkUnmarkedBlockingTasks(nextTaskFromDB, dependencyCaches), message.Fields{
-					"dispatcher": DAGDispatcher,
-					"function":   "FindNextTask",
-					"operation":  "checkUnmarkedBlockingTasks",
-					"message":    "error checking dependencies for task",
-					"outcome":    "skip and continue",
-					"task":       item.Id,
-					"distro_id":  d.distroID,
-				}))
-
+				start := time.Now()
+				err = checkUnmarkedBlockingTasks(nextTaskFromDB, dependencyCaches)
+				msg := message.Fields{
+					"dispatcher":    DAGDispatcher,
+					"function":      "FindNextTask",
+					"operation":     "checkUnmarkedBlockingTasks",
+					"outcome":       "skip and continue",
+					"task":          item.Id,
+					"distro_id":     d.distroID,
+					"duration":      time.Since(start),
+					"duration_secs": time.Since(start).Seconds(),
+				}
+				grip.Warning(message.WrapError(err, msg))
+				grip.DebugWhen(err == nil, msg)
 				continue
 			}
 

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -78,7 +78,7 @@ func (d *basicCachedDAGDispatcherImpl) Refresh() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if !shouldRefreshCached(d.ttl, d.lastUpdated, d.distroID) {
+	if !shouldRefreshCached(d.ttl, d.lastUpdated) {
 		return nil
 	}
 


### PR DESCRIPTION
The amount of time RefreshFindNextTask takes unsurprisingly seems pretty correlated to task queue length, and most of this functions seems pretty optimized. This part of the function seems optional though; I'm wondering if we should move this to a job rather than updating right here. We could also increase the TTL so we refresh less often (we refresh this every minute; this has been the standard though).