### PR TITLE
EVG-14347 correctly pass provider flag for containers

### DIFF
--- a/agent/task.go
+++ b/agent/task.go
@@ -137,8 +137,6 @@ func (a *Agent) startTask(ctx context.Context, tc *taskContext, complete chan<- 
 		tc.logger.Execution().Info("OOM tracker clearing system messages")
 		if err = tc.oomTracker.Clear(innerCtx); err != nil {
 			tc.logger.Execution().Errorf("error clearing system messages: %s", err)
-			complete <- evergreen.TaskFailed
-			return
 		}
 	}
 

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -366,16 +366,7 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 			pathToExecutable += ".exe"
 		}
 		// Build Evergreen agent command.
-		agentCmdParts = []string{
-			pathToExecutable,
-			"agent",
-			fmt.Sprintf("--api_server=%s", c.evergreenSettings.ApiUrl),
-			fmt.Sprintf("--host_id=%s", containerHost.Id),
-			fmt.Sprintf("--host_secret=%s", containerHost.Secret),
-			fmt.Sprintf("--log_prefix=%s", filepath.Join(containerHost.Distro.WorkDir, "agent")),
-			fmt.Sprintf("--working_directory=%s", containerHost.Distro.WorkDir),
-			"--cleanup",
-		}
+		agentCmdParts = containerHost.AgentCommand(c.evergreenSettings, pathToExecutable)
 		containerHost.DockerOptions.Command = strings.Join(agentCmdParts, "\n")
 	}
 

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-29"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-03-29"
+	AgentVersion = "2021-03-30"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -980,10 +980,14 @@ func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) 
 	})
 }
 
-// AgentCommand returns the arguments to start the agent.
-func (h *Host) AgentCommand(settings *evergreen.Settings) []string {
+// AgentCommand returns the arguments to start the agent. If executablePath is not specified, it
+// will be assumed to be in the regular place (only pass this for container distros)
+func (h *Host) AgentCommand(settings *evergreen.Settings, executablePath string) []string {
+	if executablePath == "" {
+		executablePath = h.Distro.AbsPathCygwinCompatible(h.Distro.HomeDir(), h.Distro.BinaryName())
+	}
 	return []string{
-		h.Distro.AbsPathCygwinCompatible(h.Distro.HomeDir(), h.Distro.BinaryName()),
+		executablePath,
 		"agent",
 		fmt.Sprintf("--api_server=%s", settings.ApiUrl),
 		fmt.Sprintf("--host_id=%s", h.Id),
@@ -1002,7 +1006,7 @@ func (h *Host) AgentMonitorOptions(settings *evergreen.Settings) *options.Create
 	credsPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.JasperCredentialsPath)
 	shellPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.ShellPath)
 
-	args := append(h.AgentCommand(settings), "monitor")
+	args := append(h.AgentCommand(settings, ""), "monitor")
 	args = append(args,
 		fmt.Sprintf("--client_path=%s", clientPath),
 		fmt.Sprintf("--distro=%s", h.Distro.Id),

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -286,7 +286,7 @@ func (j *agentDeployJob) prepRemoteHost(ctx context.Context, settings *evergreen
 // Start the agent process on the specified remote host.
 func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *evergreen.Settings) (string, error) {
 	// build the command to run on the remote machine
-	remoteCmd := strings.Join(j.host.AgentCommand(settings), " ")
+	remoteCmd := strings.Join(j.host.AgentCommand(settings, ""), " ")
 	grip.Info(message.Fields{
 		"message": "starting agent on host",
 		"host_id": j.host.Id,


### PR DESCRIPTION
- consolidate the agent command we use for docker with the one we use for normal hosts
- make a failure to clear the dmesg buffer not fail the task