### PR TITLE
EVG-13554 disallow blank distros in config

### DIFF
--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -354,6 +354,8 @@ func (s *CommitQueueSuite) TestMockCommitQueueClearAll() {
 
 func (s *CommitQueueSuite) TestAddMergeTaskAndVariant() {
 	config, err := evergreen.GetConfig()
+	config.CommitQueue.MergeTaskDistro = "d"
+	s.NoError(config.CommitQueue.Set())
 	s.NoError(err)
 	s.NoError(db.ClearCollections(distro.Collection))
 	s.NoError((&distro.Distro{

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -321,6 +321,7 @@ func (j *commitQueueJob) TryUnstick(ctx context.Context, cq *commitqueue.CommitQ
 	return
 }
 
+// TODO EVG-14087: delete in favor of copy in rest/data
 func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueue.CommitQueue, nextItem commitqueue.CommitQueueItem, projectRef *model.ProjectRef, githubToken string) {
 	var patchDoc *patch.Patch
 	pr, dequeue, err := checkPR(ctx, githubToken, nextItem.Issue, projectRef.Owner, projectRef.Repo)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -417,22 +417,26 @@ func ensureHasNecessaryBVFields(project *model.Project) ValidationErrors {
 			)
 		}
 		for _, task := range buildVariant.Tasks {
-			if len(task.Distros) == 0 {
-				hasTaskWithoutDistro = true
-				break
-			} else {
-				for _, d := range task.Distros {
-					if d == "" {
-						errs = append(errs,
-							ValidationError{
-								Message: fmt.Sprintf("task '%s' has a blank distro", task.Name),
-							},
-						)
-					}
+			taskHasValidDistro := false
+			for _, d := range task.Distros {
+				if d != "" {
+					taskHasValidDistro = true
+					break
 				}
 			}
+			if !taskHasValidDistro {
+				hasTaskWithoutDistro = true
+				break
+			}
 		}
-		if hasTaskWithoutDistro && len(buildVariant.RunOn) == 0 {
+		hasValidRunOn := false
+		for _, runOn := range buildVariant.RunOn {
+			if runOn != "" {
+				hasValidRunOn = true
+				break
+			}
+		}
+		if hasTaskWithoutDistro && !hasValidRunOn {
 			errs = append(errs,
 				ValidationError{
 					Message: fmt.Sprintf("buildvariant '%s' in project '%s' "+
@@ -441,15 +445,6 @@ func ensureHasNecessaryBVFields(project *model.Project) ValidationErrors {
 						buildVariant.Name, project.Identifier),
 				},
 			)
-		}
-		for _, runOn := range buildVariant.RunOn {
-			if runOn == "" {
-				errs = append(errs,
-					ValidationError{
-						Message: fmt.Sprintf("variant '%s' has a blank run_on distro", buildVariant.Name),
-					},
-				)
-			}
 		}
 	}
 	return errs

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -420,6 +420,16 @@ func ensureHasNecessaryBVFields(project *model.Project) ValidationErrors {
 			if len(task.Distros) == 0 {
 				hasTaskWithoutDistro = true
 				break
+			} else {
+				for _, d := range task.Distros {
+					if d == "" {
+						errs = append(errs,
+							ValidationError{
+								Message: fmt.Sprintf("task '%s' has a blank distro", task.Name),
+							},
+						)
+					}
+				}
 			}
 		}
 		if hasTaskWithoutDistro && len(buildVariant.RunOn) == 0 {
@@ -431,6 +441,15 @@ func ensureHasNecessaryBVFields(project *model.Project) ValidationErrors {
 						buildVariant.Name, project.Identifier),
 				},
 			)
+		}
+		for _, runOn := range buildVariant.RunOn {
+			if runOn == "" {
+				errs = append(errs,
+					ValidationError{
+						Message: fmt.Sprintf("variant '%s' has a blank run_on distro", buildVariant.Name),
+					},
+				)
+			}
 		}
 	}
 	return errs

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1867,6 +1867,26 @@ func TestEnsureHasNecessaryBVFields(t *testing.T) {
 			So(ensureHasNecessaryBVFields(project),
 				ShouldResemble, ValidationErrors{})
 		})
+		Convey("blank distros should generate errors", func() {
+			project := &model.Project{
+				BuildVariants: model.BuildVariants{
+					{
+						Name:  "bv1",
+						RunOn: []string{""},
+						Tasks: []model.BuildVariantTaskUnit{
+							{
+								Name:    "t1",
+								Distros: []string{""}},
+						},
+					},
+				},
+			}
+			So(ensureHasNecessaryBVFields(project),
+				ShouldResemble, ValidationErrors{
+					{Level: Error, Message: "task 't1' has a blank distro"},
+					{Level: Error, Message: "variant 'bv1' has a blank run_on distro"},
+				})
+		})
 	})
 }
 func TestTaskValidation(t *testing.T) {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1883,8 +1883,7 @@ func TestEnsureHasNecessaryBVFields(t *testing.T) {
 			}
 			So(ensureHasNecessaryBVFields(project),
 				ShouldResemble, ValidationErrors{
-					{Level: Error, Message: "task 't1' has a blank distro"},
-					{Level: Error, Message: "variant 'bv1' has a blank run_on distro"},
+					{Level: Error, Message: "buildvariant 'bv1' in project '' must either specify run_on field or have every task specify a distro."},
 				})
 		})
 	})


### PR DESCRIPTION
The problem was that the script which created the generated config had a bug which resulted a distro array with a null entry (in json). You might expect that this hits a type error when we try to unmarshal the json into a struct with a type of []string, but it does not. There is some churn in https://github.com/golang/go/issues/33835 as to whether that's a bug or not and how to handle it, but this validation should work around that and also seems reasonable enough to add