### PR TITLE
EVG-14159: Allow duplicate test names in cedar test results

### DIFF
--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -172,8 +171,11 @@ func makeCedarTestResults(id string, t *task.Task, results *task.LocalTestResult
 		if r.DisplayTestName == "" {
 			r.DisplayTestName = r.TestFile
 		}
+		if r.LogTestName == "" {
+			r.LogTestName = r.TestFile
+		}
 		rs.Results = append(rs.Results, testresults.Result{
-			TestName:        fmt.Sprintf("%s-%s", r.TestFile, utility.RandomString()),
+			TestName:        utility.RandomString(),
 			DisplayTestName: r.DisplayTestName,
 			GroupID:         r.GroupID,
 			Status:          r.Status,

--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -167,8 +167,12 @@ func makeCedarTestResultsRecord(t *task.Task, displayTaskInfo *apimodels.Display
 func makeCedarTestResults(id string, t *task.Task, results *task.LocalTestResults) testresults.Results {
 	rs := testresults.Results{ID: id}
 	for _, r := range results.Results {
+		uniqueTestName := r.TestFile + ts
+		if r.DisplayTestName == "" {
+			r.DisplayTestName = r.TestFile
+		}
 		rs.Results = append(rs.Results, testresults.Result{
-			TestName:        r.TestFile,
+			TestName:        uniqueTestName,
 			DisplayTestName: r.DisplayTestName,
 			GroupID:         r.GroupID,
 			Status:          r.Status,

--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/timber/buildlogger"
 	"github.com/evergreen-ci/timber/testresults"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/send"
@@ -167,12 +169,11 @@ func makeCedarTestResultsRecord(t *task.Task, displayTaskInfo *apimodels.Display
 func makeCedarTestResults(id string, t *task.Task, results *task.LocalTestResults) testresults.Results {
 	rs := testresults.Results{ID: id}
 	for _, r := range results.Results {
-		uniqueTestName := r.TestFile + ts
 		if r.DisplayTestName == "" {
 			r.DisplayTestName = r.TestFile
 		}
 		rs.Results = append(rs.Results, testresults.Result{
-			TestName:        uniqueTestName,
+			TestName:        fmt.Sprintf("%s-%s", r.TestFile, utility.RandomString()),
 			DisplayTestName: r.DisplayTestName,
 			GroupID:         r.GroupID,
 			Status:          r.Status,

--- a/apimodels/test_results.go
+++ b/apimodels/test_results.go
@@ -53,8 +53,16 @@ func GetCedarTestResults(ctx context.Context, opts GetCedarTestResultsOptions) (
 	}
 
 	testResults := []CedarTestResult{}
-	if err = json.Unmarshal(data, &testResults); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal test results for from cedar")
+	if opts.TestName != "" {
+		testResult := CedarTestResult{}
+		if err = json.Unmarshal(data, &testResult); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal test result for from cedar")
+		}
+		testResults = append(testResults, testResult)
+	} else {
+		if err = json.Unmarshal(data, &testResults); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal test results for from cedar")
+		}
 	}
 
 	return testResults, nil

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-29"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-03-30"
+	AgentVersion = "2021-04-05"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -122,6 +122,8 @@ type Connector interface {
 	// for paginating through the results.
 	FindTasksByProjectAndCommit(string, string, string, string, int) ([]task.Task, error)
 
+	// FindTestById returns a single test result with the given id.
+	FindTestById(string) ([]testresult.TestResult, error)
 	// FindTestsByTaskId is a method to find a set of tests that correspond to
 	// a given task. It takes a taskId, testId to start from, test name and status to filter,
 	// limit, and sort to provide additional control over the results.

--- a/rest/data/test_test.go
+++ b/rest/data/test_test.go
@@ -11,8 +11,46 @@ import (
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	mgobson "gopkg.in/mgo.v2/bson"
 )
+
+func TestFindTestById(t *testing.T) {
+	tests := []testresult.TestResult{
+		testresult.TestResult{
+			ID:        mgobson.ObjectIdHex("507f191e810c19729de860ea"),
+			TaskID:    "task",
+			Execution: 0,
+			Status:    "pass",
+		}, testresult.TestResult{
+			ID:        mgobson.ObjectIdHex("407f191e810c19729de860ea"),
+			TaskID:    "task",
+			Execution: 0,
+			Status:    "pass",
+		}, testresult.TestResult{
+			ID:        mgobson.ObjectIdHex("307f191e810c19729de860ea"),
+			TaskID:    "task",
+			Execution: 0,
+			Status:    "pass",
+		},
+	}
+	for _, test := range tests {
+		require.NoError(t, test.Insert())
+	}
+
+	sc := &DBConnector{}
+	t.Run("Success", func(t *testing.T) {
+		results, err := sc.FindTestById(tests[0].ID.Hex())
+		assert.NoError(t, err)
+		require.NotEmpty(t, results)
+		assert.Equal(t, tests[0], results[0])
+	})
+	t.Run("InvalidID", func(t *testing.T) {
+		results, err := sc.FindTestById("invalid")
+		assert.Error(t, err)
+		assert.Empty(t, results)
+	})
+}
 
 func TestFindTestsByTaskId(t *testing.T) {
 	assert := assert.New(t)

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -90,6 +90,7 @@ func (at *APITest) BuildFromService(st interface{}) error {
 			at.Logs.RawDisplayURL = &dispString
 		}
 	case *apimodels.CedarTestResult:
+		at.Id = utility.ToStringPtr(v.TestName)
 		at.Execution = v.Execution
 		at.LineNum = v.LineNum
 		at.Status = utility.ToStringPtr(v.Status)
@@ -113,9 +114,6 @@ func (at *APITest) BuildFromService(st interface{}) error {
 			HTMLDisplayURL: utility.ToStringPtr(fmt.Sprintf("/test_log/%s/%d/%s?group_id=%s#L%d", v.TaskID, v.Execution, testName, v.GroupID, v.LineNum)),
 		}
 
-		// Need to generate a consistent id for test results.
-		testResultID := fmt.Sprintf("ceder_test_%s_%d_%s_%s_%s", v.TaskID, v.Execution, v.TestName, v.Start, v.GroupID)
-		at.Id = utility.ToStringPtr(testResultID)
 		if v.GroupID != "" {
 			at.GroupId = utility.ToStringPtr(v.GroupID)
 		}

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -23,6 +23,7 @@ type testGetHandler struct {
 	taskID        string
 	displayTask   bool
 	testStatus    string
+	testID        string
 	testName      string
 	testExecution int
 	key           string
@@ -73,6 +74,7 @@ func (tgh *testGetHandler) Parse(ctx context.Context, r *http.Request) error {
 
 	tgh.testStatus = vals.Get("status")
 	tgh.key = vals.Get("start_at")
+	tgh.testID = vals.Get("test_id")
 	tgh.testName = vals.Get("test_name")
 	tgh.limit, err = getLimit(vals)
 	if err != nil {
@@ -92,6 +94,9 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 	opts := apimodels.GetCedarTestResultsOptions{
 		BaseURL:   evergreen.GetEnvironment().Settings().Cedar.BaseURL,
 		Execution: tgh.testExecution,
+		// When testID is populated, that means the user wants to fetch
+		// a single test by the unique test name stored in cedar.
+		TestName: tgh.testID,
 	}
 	if tgh.displayTask {
 		opts.DisplayTaskID = tgh.taskID
@@ -99,17 +104,24 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 		opts.TaskID = tgh.taskID
 	}
 	cedarTestResults, err := apimodels.GetCedarTestResults(ctx, opts)
-	if err == nil {
-		startAt, err := strconv.Atoi(tgh.key)
-		if err != nil {
-			return gimlet.MakeJSONErrorResponder(errors.New("invalid start_at"))
+	if err == nil && tgh.testID == "" {
+		startAt := 0
+		if tgh.key != "" {
+			startAt, err = strconv.Atoi(tgh.key)
+			if err != nil {
+				return gimlet.MakeJSONErrorResponder(errors.New("invalid start_at"))
+			}
+		}
+		testStatuses := []string{}
+		if tgh.testStatus != "" {
+			testStatuses = append(testStatuses, tgh.testStatus)
 		}
 
 		var filteredCount int
 		cedarTestResults, filteredCount = graphql.FilterSortAndPaginateCedarTestResults(
 			cedarTestResults,
 			tgh.testName,
-			[]string{tgh.testStatus},
+			testStatuses,
 			"",
 			1,
 			startAt,
@@ -119,25 +131,31 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 		if startAt*tgh.limit < filteredCount {
 			key = fmt.Sprintf("%d", startAt+1)
 		}
-	} else {
+	} else if err != nil {
+		// No cedar test results, fall back to the database.
 		grip.Warning(message.WrapError(err, message.Fields{
 			"task_id": tgh.taskID,
 			"message": "problem getting cedar test results",
 		}))
 
-		// No cedar test results, fall back to the database.
-		tests, err = tgh.sc.FindTestsByTaskId(tgh.taskID, tgh.key, tgh.testName, tgh.testStatus, tgh.limit+1, tgh.testExecution)
-		if err != nil {
-			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "database error"))
-		}
+		if tgh.testID != "" {
+			// When testID is populated, search the test results
+			// collection for the given id.
+			tests, err = tgh.sc.FindTestById(tgh.testID)
+		} else {
+			tests, err = tgh.sc.FindTestsByTaskId(tgh.taskID, tgh.key, tgh.testName, tgh.testStatus, tgh.limit+1, tgh.testExecution)
+			if err != nil {
+				return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "database error"))
+			}
 
-		lastIndex := len(tests)
-		if lastIndex > tgh.limit {
-			key = string(tests[tgh.limit].ID)
-			lastIndex = tgh.limit
+			lastIndex := len(tests)
+			if lastIndex > tgh.limit {
+				key = string(tests[tgh.limit].ID)
+				lastIndex = tgh.limit
+			}
+			// Truncate the hosts to just those that will be returned.
+			tests = tests[:lastIndex]
 		}
-		// Truncate the hosts to just those that will be returned.
-		tests = tests[:lastIndex]
 	}
 
 	return tgh.buildResponse(cedarTestResults, tests, key)

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -156,7 +156,8 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 				key = string(tests[tgh.limit].ID)
 				lastIndex = tgh.limit
 			}
-			// Truncate the hosts to just those that will be returned.
+			// Truncate the test results to just those that will be
+			// returned.
 			tests = tests[:lastIndex]
 		}
 	}

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -142,6 +142,9 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 			// When testID is populated, search the test results
 			// collection for the given id.
 			tests, err = tgh.sc.FindTestById(tgh.testID)
+			if err != nil {
+				return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "database error"))
+			}
 		} else {
 			tests, err = tgh.sc.FindTestsByTaskId(tgh.taskID, tgh.key, tgh.testName, tgh.testStatus, tgh.limit+1, tgh.testExecution)
 			if err != nil {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14159

- Set the test name field for cedar test results to a random unique id and set the display test name and log test name to the test file name if they are not already set.
- Add a new parameter `test_id` to the `rest/v2/tasks/{task_id}/tests` to fetch tests by the unique test id (since test names can be duplicated and lobster uses this route to fetch individual test results).