### PR TITLE
EVG-13667 add shell.exec param to execute as string

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-29"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-04-05"
+	AgentVersion = "2021-04-07"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Anna and Jonathan were basically spot on in their explanation of what the problem is. sshing from a script will hijack stdin for the process, but the script itself is being fed to stdin so that will prevent further commands from being fed to the shell

I verified that this works with a test that involves sshing but I don't want to commit a test that uses ssh