### PR TITLE
EVG-14328 use project identifier for patch workflow

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -389,6 +389,7 @@ type ComplexityRoot struct {
 		PatchNumber             func(childComplexity int) int
 		Project                 func(childComplexity int) int
 		ProjectId               func(childComplexity int) int
+		ProjectIdentifier       func(childComplexity int) int
 		Status                  func(childComplexity int) int
 		TaskCount               func(childComplexity int) int
 		TaskStatuses            func(childComplexity int) int
@@ -2630,6 +2631,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Patch.ProjectId(childComplexity), true
+
+	case "Patch.projectIdentifier":
+		if e.complexity.Patch.ProjectIdentifier == nil {
+			break
+		}
+
+		return e.complexity.Patch.ProjectIdentifier(childComplexity), true
 
 	case "Patch.status":
 		if e.complexity.Patch.Status == nil {
@@ -5146,6 +5154,7 @@ type Patch {
   id: ID!
   description: String!
   projectID: String!
+  projectIdentifier: String!
   githash: String!
   patchNumber: Int!
   author: String!
@@ -13791,6 +13800,40 @@ func (ec *executionContext) _Patch_projectID(ctx context.Context, field graphql.
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.ProjectId, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Patch_projectIdentifier(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Patch",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ProjectIdentifier, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -26924,6 +26967,11 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "projectID":
 			out.Values[i] = ec._Patch_projectID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "projectIdentifier":
+			out.Values[i] = ec._Patch_projectIdentifier(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -812,6 +812,14 @@ func (r *patchResolver) CommitQueuePosition(ctx context.Context, apiPatch *restM
 	return commitQueuePosition, nil
 }
 
+func (r *patchResolver) ProjectIdentifier(ctx context.Context, apiPatch *restModel.APIPatch) (*string, error) {
+	identifier, err := model.GetIdentifierForProject(*apiPatch.ProjectId)
+	if err != nil {
+		return apiPatch.ProjectId, nil
+	}
+	return utility.ToStringPtr(identifier), nil
+}
+
 func (r *patchResolver) TaskStatuses(ctx context.Context, obj *restModel.APIPatch) ([]string, error) {
 	defaultSort := []task.TasksSortOrder{
 		{Key: task.DisplayNameKey, Order: 1},
@@ -1841,7 +1849,7 @@ func (r *mutationResolver) EnqueuePatch(ctx context.Context, patchID string, com
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error creating new patch: %s", err.Error()))
 	}
 
-	_, err = r.sc.EnqueueItem(utility.FromStringPtr(newPatch.Project), restModel.APICommitQueueItem{Issue: newPatch.Id, Source: utility.ToStringPtr(commitqueue.SourceDiff)}, false)
+	_, err = r.sc.EnqueueItem(utility.FromStringPtr(newPatch.ProjectId), restModel.APICommitQueueItem{Issue: newPatch.Id, Source: utility.ToStringPtr(commitqueue.SourceDiff)}, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error enqueuing new patch: %s", err.Error()))
 	}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -447,6 +447,7 @@ type Patch {
   id: ID!
   description: String!
   projectID: String!
+  projectIdentifier: String!
   githash: String!
   patchNumber: Int!
   author: String!

--- a/graphql/tests/commitQueue/data.json
+++ b/graphql/tests/commitQueue/data.json
@@ -196,6 +196,10 @@
       }
     },
     {
+      "_id": "evergreen",
+      "identifier": "evergreen"
+    },
+    {
       "_id": "cli-queue",
       "identifier": "cli-queue",
       "commit_queue": {

--- a/graphql/tests/patch-taskStatuses/data.json
+++ b/graphql/tests/patch-taskStatuses/data.json
@@ -362,5 +362,23 @@
         "merge_commit_sha": ""
       }
     }
+  ],
+  "project_ref": [
+    {
+      "_id": "evergreen",
+      "identifier": "evergreen"
+    },
+    {
+      "_id": "spruce",
+      "identifier": "spruce"
+    },
+    {
+      "_id": "logkeeper",
+      "identifier": "logkeeper"
+    },
+    {
+      "_id": "sys-perf",
+      "identifier": "sys-perf"
+    }
   ]
 }

--- a/graphql/tests/patch/data.json
+++ b/graphql/tests/patch/data.json
@@ -754,5 +754,27 @@
         "$date": "2020-04-13T19:52:10.216Z"
       }
     }
+  ],
+  "project_ref": [
+    {
+      "_id": "evergreen",
+      "identifier": "evergreen"
+    },
+    {
+      "_id": "spruce",
+      "identifier": "spruce"
+    },
+    {
+      "_id": "logkeeper",
+      "identifier": "logkeeper"
+    },
+    {
+      "_id": "sys-perf",
+      "identifier": "sys-perf"
+    },
+    {
+      "_id": "mongodb-mongo-master",
+      "identifier": "mongodb-mongo-master"
+    }
   ]
 }

--- a/graphql/tests/patchBuildVariants/data.json
+++ b/graphql/tests/patchBuildVariants/data.json
@@ -345,5 +345,15 @@
       "actual_makespan": 0,
       "r": "ad_hoc"
     }
+  ],
+  "project_ref": [
+    {
+      "_id": "evergreen",
+      "identifier": "evergreen"
+    },
+    {
+      "_id": "mci",
+      "identifier": "mci"
+    }
   ]
 }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -445,7 +445,7 @@ func GetVariantsAndTasksFromProject(patchedConfig string, patchProject string) (
 
 // GetPatchProjectVariantsAndTasksForUI gets the variants and tasks for a project for a patch id
 func GetPatchProjectVariantsAndTasksForUI(ctx context.Context, apiPatch *restModel.APIPatch) (*PatchProject, error) {
-	patchProjectVariantsAndTasks, err := GetVariantsAndTasksFromProject(*apiPatch.PatchedConfig, *apiPatch.Project)
+	patchProjectVariantsAndTasks, err := GetVariantsAndTasksFromProject(*apiPatch.PatchedConfig, *apiPatch.ProjectId)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting project variants and tasks for patch %s: %s", *apiPatch.Id, err.Error()))
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -749,6 +749,17 @@ func GetIdForProject(identifier string) (string, error) {
 	return pRef.Id, nil
 }
 
+func GetIdentifierForProject(id string) (string, error) {
+	pRef, err := findOneProjectRefQ(byId(id).WithFields(ProjectRefIdentifierKey))
+	if err != nil {
+		return "", err
+	}
+	if pRef == nil {
+		return "", errors.Errorf("project '%s' does not exist", id)
+	}
+	return pRef.Identifier, nil
+}
+
 func CountProjectRefsWithIdentifier(identifier string) (int, error) {
 	return db.CountQ(ProjectRefCollection, byId(identifier))
 }

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -48,7 +48,7 @@ func (pc *DBPatchConnector) FindPatchesByProject(projectId string, ts time.Time,
 		apiPatch := restModel.APIPatch{}
 		err = apiPatch.BuildFromService(p)
 		if err != nil {
-			return nil, errors.Wrap(err, "problem fetching converting patch")
+			return nil, errors.Wrap(err, "problem converting patch")
 		}
 		apiPatches = append(apiPatches, apiPatch)
 	}
@@ -76,7 +76,7 @@ func (pc *DBPatchConnector) FindPatchById(patchId string) (*restModel.APIPatch, 
 	apiPatch := restModel.APIPatch{}
 	err = apiPatch.BuildFromService(*p)
 	if err != nil {
-		return nil, errors.Wrap(err, "problem fetching converting patch")
+		return nil, errors.Wrap(err, "problem converting patch")
 	}
 
 	return &apiPatch, nil
@@ -234,7 +234,7 @@ func (pc *DBPatchConnector) FindPatchesByUser(user string, ts time.Time, limit i
 		apiPatch := restModel.APIPatch{}
 		err = apiPatch.BuildFromService(p)
 		if err != nil {
-			return nil, errors.Wrap(err, "problem fetching converting patch")
+			return nil, errors.Wrap(err, "problem converting patch")
 		}
 		apiPatches = append(apiPatches, apiPatch)
 	}

--- a/rest/data/patch_test.go
+++ b/rest/data/patch_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	dbModel "github.com/evergreen-ci/evergreen/model"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/patch"
@@ -51,7 +53,10 @@ func TestPatchConnectorFetchByProjectSuite(t *testing.T) {
 				return err
 			}
 		}
-
+		pRef1 := dbModel.ProjectRef{Id: "project1", Identifier: "project_one"}
+		pRef2 := dbModel.ProjectRef{Id: "project2", Identifier: "project_two"}
+		assert.NoError(t, pRef1.Insert())
+		assert.NoError(t, pRef2.Insert())
 		return nil
 	}
 

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -5,9 +5,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/model"
-
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
@@ -178,11 +177,13 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 		return errors.Wrap(err, "error getting downstream tasks")
 	}
 	apiPatch.DownstreamTasks = downstreamTasks
-	identifier, err := model.GetIdentifierForProject(v.Project)
-	if err != nil {
-		return errors.Wrapf(err, "error getting project '%s'", v.Project)
+	if v.Project != "" {
+		identifier, err := model.GetIdentifierForProject(v.Project)
+		if err != nil {
+			return errors.Wrapf(err, "error getting project '%s'", v.Project)
+		}
+		apiPatch.ProjectIdentifier = utility.ToStringPtr(identifier)
 	}
-	apiPatch.ProjectIdentifier = utility.ToStringPtr(identifier)
 
 	return errors.WithStack(apiPatch.GithubPatchData.BuildFromService(v.GithubPatchData))
 }

--- a/trigger/patch_test.go
+++ b/trigger/patch_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	dbModel "github.com/evergreen-ci/evergreen/model"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -34,13 +36,18 @@ func (s *patchSuite) SetupSuite() {
 }
 
 func (s *patchSuite) SetupTest() {
-	s.NoError(db.ClearCollections(event.AllLogCollection, patch.Collection, event.SubscriptionsCollection))
+	s.NoError(db.ClearCollections(event.AllLogCollection, patch.Collection, event.SubscriptionsCollection, dbModel.ProjectRefCollection))
 	startTime := time.Now().Truncate(time.Millisecond)
 
 	patchID := mgobson.ObjectIdHex("5aeb4514f27e4f9984646d97")
 
 	childPatchId := "5aab4514f27e4f9984646d97"
 
+	pRef := dbModel.ProjectRef{
+		Id:         "test",
+		Identifier: "testing",
+	}
+	s.NoError(pRef.Insert())
 	s.patch = patch.Patch{
 		Id:         patchID,
 		Project:    "test",

--- a/trigger/payloads_test.go
+++ b/trigger/payloads_test.go
@@ -110,7 +110,7 @@ func (s *payloadSuite) TestEvergreenWebhook() {
 	s.NoError(err)
 	s.Require().NotNil(m)
 
-	s.Len(m.Body, 552)
+	s.Len(m.Body, 563)
 	s.Len(m.Headers, 1)
 }
 

--- a/units/crons_event_test.go
+++ b/units/crons_event_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/model"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -50,7 +52,8 @@ func (s *cronsEventSuite) TearDownSuite() {
 }
 
 func (s *cronsEventSuite) SetupTest() {
-	s.NoError(db.ClearCollections(event.AllLogCollection, evergreen.ConfigCollection, notification.Collection, event.SubscriptionsCollection, patch.Collection))
+	s.NoError(db.ClearCollections(event.AllLogCollection, evergreen.ConfigCollection, notification.Collection,
+		event.SubscriptionsCollection, patch.Collection, model.ProjectRefCollection))
 
 	events := []event.EventLogEntry{
 		{
@@ -201,6 +204,11 @@ func (s *cronsEventSuite) TestEndToEnd() {
 	}
 	s.NoError(p.Insert())
 
+	pRef := model.ProjectRef{
+		Id:         "test",
+		Identifier: "testing",
+	}
+	s.NoError(pRef.Insert())
 	e := event.EventLogEntry{
 		ResourceType: event.ResourceTypePatch,
 		EventType:    event.PatchStateChange,


### PR DESCRIPTION
For this example, ID is "evergreen" and Identifier is "my_evergreen". This needs to be deployed before the spruce changes.
Patch Page: 
![image](https://user-images.githubusercontent.com/26798134/113900652-0df84980-979c-11eb-8c77-2ac28ab80165.png)
Task Page:
![image](https://user-images.githubusercontent.com/26798134/113900678-15b7ee00-979c-11eb-82ae-485526518d7f.png)
My Patches Page:
![image](https://user-images.githubusercontent.com/26798134/113900761-28cabe00-979c-11eb-94a9-3e37672fe6d2.png)
