### PR TITLE
EVG-13023 consider legacy parser project case

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -961,6 +961,10 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 		res.Stepback = pt.Stepback
 	}
 	if len(res.RunOn) == 0 {
+		// first consider that we may be using the legacy "distros" field
+		res.RunOn = bvt.Distros
+	}
+	if len(res.RunOn) == 0 {
 		res.RunOn = pt.RunOn
 	}
 	return res


### PR DESCRIPTION
I tested this by inserting a "legacy" document into the DB and then running validation; it fails without this change, and passes with it.