### PR TITLE
EVG-13023 revert merging until backwards compatibility is deployed

### DIFF
--- a/model/matrix_smoke_test.go
+++ b/model/matrix_smoke_test.go
@@ -130,7 +130,7 @@ func TestDepsMatrixIntegration(t *testing.T) {
 					So(v.Tags, ShouldContain, "posix")
 					Convey("which should contain a compile", func() {
 						So(v.Tasks[4].Name, ShouldEqual, "compile")
-						So(v.Tasks[4].RunOn, ShouldResemble, []string{"linux_big"})
+						So(v.Tasks[4].Distros, ShouldResemble, []string{"linux_big"})
 						So(v.Tasks[4].DependsOn[0], ShouldResemble, TaskUnitDependency{
 							Name:    "pre-task",
 							Variant: "analysis",

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -117,7 +117,6 @@ type parserTask struct {
 	DependsOn       parserDependencies  `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
 	Commands        []PluginCommandConf `yaml:"commands,omitempty" bson:"commands,omitempty"`
 	Tags            parserStringSlice   `yaml:"tags,omitempty" bson:"tags,omitempty"`
-	RunOn           parserStringSlice   `yaml:"run_on,omitempty" bson:"run_on,omitempty"`
 	Patchable       *bool               `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
 	PatchOnly       *bool               `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
 	AllowForGitTag  *bool               `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
@@ -408,12 +407,12 @@ func (pbvt *parserBVTaskUnit) UnmarshalYAML(unmarshal func(interface{}) error) e
 	if copy.Name == "" {
 		return errors.New("buildvariant task selector must have a name")
 	}
-	// logic for aliasing the "distros" field to "run_on"
-	if len(copy.Distros) > 0 {
-		if len(copy.RunOn) > 0 {
+	// logic for aliasing the "run_on" field to "distros"
+	if len(copy.RunOn) > 0 {
+		if len(copy.Distros) > 0 {
 			return errors.New("cannot use both 'run_on' and 'distros' fields")
 		}
-		copy.RunOn, copy.Distros = copy.Distros, nil
+		copy.Distros, copy.RunOn = copy.RunOn, nil
 	}
 	*pbvt = parserBVTaskUnit(copy)
 	return nil
@@ -670,7 +669,6 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 			ExecTimeoutSecs: pt.ExecTimeoutSecs,
 			Commands:        pt.Commands,
 			Tags:            pt.Tags,
-			RunOn:           pt.RunOn,
 			Patchable:       pt.Patchable,
 			PatchOnly:       pt.PatchOnly,
 			AllowForGitTag:  pt.AllowForGitTag,
@@ -737,7 +735,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			RunOn:         pbv.RunOn,
 			Tags:          pbv.Tags,
 		}
-		bv.Tasks, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
+		bv.Tasks, errs = evaluateBVTasks(tse, tgse, vse, pbv)
 
 		// evaluate any rules passed in during matrix construction
 		for _, r := range pbv.MatrixRules {
@@ -771,7 +769,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 
 				var added []BuildVariantTaskUnit
 				pbv.Tasks = r.AddTasks
-				added, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
+				added, errs = evaluateBVTasks(tse, tgse, vse, pbv)
 				evalErrs = append(evalErrs, errs...)
 				// check for conflicting duplicates
 				for _, t := range added {
@@ -792,7 +790,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 		for _, tg := range tgs {
 			tgMap[tg.Name] = tg
 		}
-		dtse := newDisplayTaskSelectorEvaluator(bv, tasks, tgMap)
+		dtse := newDisplayTaskSelectorEvaluator(bv, tasks, tgs, tgMap)
 
 		// check that display tasks contain real tasks that are not duplicated
 		bvTasks := make(map[string]struct{})        // map of all execution tasks
@@ -854,15 +852,11 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 // evaluating any selectors referencing tasks, and further evaluating any selectors
 // in the DependsOn field of those tasks.
 func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse *variantSelectorEvaluator,
-	pbv parserBV, tasks []parserTask) ([]BuildVariantTaskUnit, []error) {
+	pbv parserBV) ([]BuildVariantTaskUnit, []error) {
 	var evalErrs, errs []error
 	ts := []BuildVariantTaskUnit{}
 	taskUnitsByName := map[string]BuildVariantTaskUnit{}
-	tasksByName := map[string]parserTask{}
-	for _, t := range tasks {
-		tasksByName[t.Name] = t
-	}
-	for _, pbvt := range pbv.Tasks {
+	for _, pt := range pbv.Tasks {
 		// evaluate each task against both the task and task group selectors
 		// only error if both selectors error because each task should only be found
 		// in one or the other
@@ -870,11 +864,11 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 		var err1, err2 error
 		isGroup := false
 		if tse != nil {
-			temp, err1 = tse.evalSelector(ParseSelector(pbvt.Name))
+			temp, err1 = tse.evalSelector(ParseSelector(pt.Name))
 			names = append(names, temp...)
 		}
 		if tgse != nil {
-			temp, err2 = tgse.evalSelector(ParseSelector(pbvt.Name))
+			temp, err2 = tgse.evalSelector(ParseSelector(pt.Name))
 			if len(temp) > 0 {
 				names = append(names, temp...)
 				isGroup = true
@@ -886,21 +880,35 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 		}
 		// create new task definitions--duplicates must have the same status requirements
 		for _, name := range names {
-			parserTask := tasksByName[name]
 			// create a new task by copying the task that selected it,
 			// so we can preserve the "Variant" and "Status" field.
-			t := getParserBuildVariantTaskUnit(name, parserTask, pbvt)
-
-			// Task-level dependencies defined in the variant override variant-level dependencies which override
-			// task-level dependencies defined in the task.
-			var dependsOn parserDependencies
-			if len(pbvt.DependsOn) > 0 {
-				dependsOn = pbvt.DependsOn
-			} else if len(pbv.DependsOn) > 0 {
-				dependsOn = pbv.DependsOn
-			} else if len(parserTask.DependsOn) > 0 {
-				dependsOn = parserTask.DependsOn
+			t := BuildVariantTaskUnit{
+				Name:             name,
+				Patchable:        pt.Patchable,
+				PatchOnly:        pt.PatchOnly,
+				AllowForGitTag:   pt.AllowForGitTag,
+				GitTagOnly:       pt.GitTagOnly,
+				Priority:         pt.Priority,
+				ExecTimeoutSecs:  pt.ExecTimeoutSecs,
+				Stepback:         pt.Stepback,
+				Distros:          pt.Distros,
+				CommitQueueMerge: pt.CommitQueueMerge,
+				CronBatchTime:    pt.CronBatchTime,
+				BatchTime:        pt.BatchTime,
 			}
+
+			// Task-level dependencies in the variant override variant-level dependencies
+			// in the variant. If neither is present, then the BuildVariantTaskUnit unit
+			// will contain no dependencies, so dependencies will come from the task
+			// spec at task creation time.
+			var dependsOn parserDependencies
+			if len(pbv.DependsOn) > 0 {
+				dependsOn = pbv.DependsOn
+			}
+			if len(pt.DependsOn) > 0 {
+				dependsOn = pt.DependsOn
+			}
+
 			t.DependsOn, errs = evaluateDependsOn(tse.tagEval, tgse, vse, dependsOn)
 			evalErrs = append(evalErrs, errs...)
 			t.IsGroup = isGroup
@@ -920,54 +928,6 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 		}
 	}
 	return ts, evalErrs
-}
-
-// getParserBuildVariantTaskUnit combines the parser project's task definition with the build variant task definition.
-// DependsOn will be handled separately.
-func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskUnit) BuildVariantTaskUnit {
-	res := BuildVariantTaskUnit{
-		Name:             name,
-		Patchable:        bvt.Patchable,
-		PatchOnly:        bvt.PatchOnly,
-		AllowForGitTag:   bvt.AllowForGitTag,
-		GitTagOnly:       bvt.GitTagOnly,
-		Priority:         bvt.Priority,
-		ExecTimeoutSecs:  bvt.ExecTimeoutSecs,
-		Stepback:         bvt.Stepback,
-		RunOn:            bvt.RunOn,
-		CommitQueueMerge: bvt.CommitQueueMerge,
-		CronBatchTime:    bvt.CronBatchTime,
-		BatchTime:        bvt.BatchTime,
-	}
-	if res.Priority == 0 {
-		res.Priority = pt.Priority
-	}
-	if res.Patchable == nil {
-		res.Patchable = pt.Patchable
-	}
-	if res.PatchOnly == nil {
-		res.PatchOnly = pt.PatchOnly
-	}
-	if res.AllowForGitTag == nil {
-		res.AllowForGitTag = pt.AllowForGitTag
-	}
-	if res.GitTagOnly == nil {
-		res.GitTagOnly = pt.GitTagOnly
-	}
-	if res.ExecTimeoutSecs == 0 {
-		res.ExecTimeoutSecs = pt.ExecTimeoutSecs
-	}
-	if res.Stepback == nil {
-		res.Stepback = pt.Stepback
-	}
-	if len(res.RunOn) == 0 {
-		// first consider that we may be using the legacy "distros" field
-		res.RunOn = bvt.Distros
-	}
-	if len(res.RunOn) == 0 {
-		res.RunOn = pt.RunOn
-	}
-	return res
 }
 
 // evaluateDependsOn expands any selectors in a dependency definition.

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -898,7 +898,7 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 			}
 
 			// for backwards compatibility of EVG-14282
-			if len(pt.Distros) < 0 {
+			if len(pt.Distros) == 0 {
 				t.Distros = pt.RunOn
 			}
 			// Task-level dependencies in the variant override variant-level dependencies

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -897,6 +897,10 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 				BatchTime:        pt.BatchTime,
 			}
 
+			// for backwards compatibility of EVG-14282
+			if len(pt.Distros) < 0 {
+				t.Distros = pt.RunOn
+			}
 			// Task-level dependencies in the variant override variant-level dependencies
 			// in the variant. If neither is present, then the BuildVariantTaskUnit unit
 			// will contain no dependencies, so dependencies will come from the task

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -285,7 +285,7 @@ func newTaskGroupSelectorEvaluator(groups []parserTaskGroup) *tagSelectorEvaluat
 }
 
 // Display task selector
-func newDisplayTaskSelectorEvaluator(bv BuildVariant, tasks []parserTask, tgMap map[string]TaskGroup) *tagSelectorEvaluator {
+func newDisplayTaskSelectorEvaluator(bv BuildVariant, tasks []parserTask, tgs []TaskGroup, tgMap map[string]TaskGroup) *tagSelectorEvaluator {
 	var selectees []tagged
 	for _, t := range bv.Tasks {
 		if tg, ok := tgMap[t.Name]; ok {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1618,9 +1618,7 @@ func TestVariantTasksForSelectors(t *testing.T) {
 			{
 				Name:         "bv0",
 				DisplayTasks: []patch.DisplayTask{{Name: "dt0", ExecTasks: []string{"t0"}}},
-				Tasks: []BuildVariantTaskUnit{
-					{Name: "t0"},
-					{Name: "t1", DependsOn: []TaskUnitDependency{{Name: "t0", Variant: "bv0"}}}},
+				Tasks:        []BuildVariantTaskUnit{{Name: "t0"}, {Name: "t1"}},
 			},
 		},
 		Tasks: []ProjectTask{

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -1131,7 +1131,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			"message": "successfully created version",
 			"version": v.Id,
 			"hash":    v.Revision,
-			"project": v.Identifier,
+			"project": v.Branch,
 			"runner":  RunnerName,
 		})
 		return nil

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -635,10 +635,10 @@ func createTestRevision(revision string,
 func createTestProject(override1, override2 *int) *model.ParserProject {
 	pp := &model.ParserProject{}
 	pp.AddBuildVariant("bv1", "bv1", "", override1, []string{"t1"})
-	pp.BuildVariants[0].Tasks[0].RunOn = []string{"test-distro-one"}
+	pp.BuildVariants[0].Tasks[0].Distros = []string{"test-distro-one"}
 
 	pp.AddBuildVariant("bv2", "bv2", "", override2, []string{"t1"})
-	pp.BuildVariants[1].Tasks[0].RunOn = []string{"test-distro-one"}
+	pp.BuildVariants[1].Tasks[0].Distros = []string{"test-distro-one"}
 
 	pp.AddTask("t1", nil)
 
@@ -839,7 +839,7 @@ tasks:
 	s.NoError(err)
 	s.Equal(v.Config, dbVersion.Config)
 	s.Require().Len(dbVersion.Errors, 1)
-	s.Equal("buildvariant 'bv' in project 'mci' must either specify run_on field or have every task specify run_on.", dbVersion.Errors[0])
+	s.Equal("buildvariant 'bv' in project 'mci' must either specify run_on field or have every task specify a distro.", dbVersion.Errors[0])
 
 	dbBuild, err := build.FindOne(build.ByVersion(v.Id))
 	s.NoError(err)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -201,19 +201,7 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv",
 						Tasks: []model.BuildVariantTaskUnit{
-							{
-								Name:      "compile",
-								DependsOn: []model.TaskUnitDependency{{Name: "testOne"}},
-							},
-							{
-								Name:      "testOne",
-								DependsOn: []model.TaskUnitDependency{{Name: "compile"}},
-							},
-							{
-								Name:      "testTwo",
-								DependsOn: []model.TaskUnitDependency{{Name: "compile"}},
-							},
-						},
+							{Name: "compile"}, {Name: "testOne"}, {Name: "testTwo"}},
 					},
 				},
 			}
@@ -238,16 +226,7 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{
-								Name:      "testOne",
-								DependsOn: []model.TaskUnitDependency{{Name: "compile"}, {Name: "testTwo"}},
-							},
-							{
-								Name:      "testTwo",
-								DependsOn: []model.TaskUnitDependency{{Name: model.AllDependencies}},
-							},
-						},
+							{Name: "compile"}, {Name: "testOne"}, {Name: "testTwo"}},
 					},
 				},
 			}
@@ -268,8 +247,8 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{{Name: "compile"}, {Name: "hamSteak"}}}}},
+							{Name: "compile"}, {Name: "testOne"}},
+					},
 				},
 			}
 			So(checkDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
@@ -298,22 +277,11 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{
-								Name: "compile",
-							},
-							{
-								Name: "testOne",
-								DependsOn: []model.TaskUnitDependency{
-									{Name: "compile"},
-									{Name: "testSpecial", Variant: "bv2"},
-								},
-							}},
+							{Name: "compile"}, {Name: "testOne"}},
 					},
 					{
-						Name: "bv2",
-						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "testSpecial", DependsOn: []model.TaskUnitDependency{{Name: "testOne", Variant: "bv1"}}}},
-					},
+						Name:  "bv2",
+						Tasks: []model.BuildVariantTaskUnit{{Name: "testSpecial"}}},
 				},
 			}
 			So(checkDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
@@ -338,7 +306,7 @@ func TestCheckDependencyGraph(t *testing.T) {
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
 							{Name: "compile", DependsOn: []model.TaskUnitDependency{{Name: "testOne"}}},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{{Name: "compile"}}},
+							{Name: "testOne"},
 						},
 					},
 				},
@@ -378,35 +346,22 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
-								{Name: "compile"},
-								{Name: "testSpecial", Variant: "bv2"},
-							}}},
+							{Name: "compile"}, {Name: "testOne"}},
 					},
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "testSpecial", DependsOn: []model.TaskUnitDependency{{Name: "testOne", Variant: model.AllVariants}}},
-						},
+							{Name: "testSpecial"}},
 					},
 					{
 						Name: "bv3",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
-								{Name: "compile"},
-								{Name: "testSpecial", Variant: "bv2"},
-							}}},
+							{Name: "compile"}, {Name: "testOne"}},
 					},
 					{
 						Name: "bv4",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
-								{Name: "compile"},
-								{Name: "testSpecial", Variant: "bv2"},
-							}}},
+							{Name: "compile"}, {Name: "testOne"}},
 					},
 				},
 			}
@@ -436,37 +391,12 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{
-								Name: "compile",
-							},
-							{
-								Name: "testOne",
-								DependsOn: []model.TaskUnitDependency{
-									{Name: "compile", Variant: model.AllVariants},
-									{Name: "testTwo"},
-								},
-							}},
+							{Name: "compile"}, {Name: "testOne"}},
 					},
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{
-								Name: "compile",
-							},
-							{
-								Name: "testOne",
-								DependsOn: []model.TaskUnitDependency{
-									{Name: "compile", Variant: model.AllVariants},
-									{Name: "testTwo"},
-								},
-							},
-							{
-								Name: "testTwo",
-								DependsOn: []model.TaskUnitDependency{
-									{Name: model.AllDependencies, Variant: model.AllVariants},
-								},
-							},
-						},
+							{Name: "compile"}, {Name: "testOne"}, {Name: "testTwo"}},
 					},
 				},
 			}
@@ -490,11 +420,8 @@ func TestCheckDependencyGraph(t *testing.T) {
 				},
 				BuildVariants: []model.BuildVariant{
 					{
-						Name: "bv",
-						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{{Name: "testOne"}}},
-						},
+						Name:  "bv",
+						Tasks: []model.BuildVariantTaskUnit{{Name: "compile"}, {Name: "testOne"}},
 					},
 				},
 			}
@@ -530,9 +457,7 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{{Name: "compile"}}},
-							{Name: "testTwo", DependsOn: []model.TaskUnitDependency{{Name: "compile"}}}},
+							{Name: "compile"}, {Name: "testOne"}, {Name: "testTwo"}},
 					},
 				},
 			}
@@ -561,25 +486,12 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{
-								Name: "testOne",
-								DependsOn: []model.TaskUnitDependency{
-									{Name: "compile", Variant: "bv2"},
-								},
-							},
-						},
+							{Name: "testOne"}},
 					},
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{
-								Name: "testSpecial",
-								DependsOn: []model.TaskUnitDependency{
-									{Name: "compile"},
-									{Name: "testOne", Variant: "bv1"}},
-							},
-						},
+							{Name: "compile"}, {Name: "testSpecial"}},
 					},
 				},
 			}
@@ -606,20 +518,12 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
-								{Name: "compile", Variant: model.AllVariants},
-							}},
-						},
+							{Name: "compile"}, {Name: "testOne"}},
 					},
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testTwo", DependsOn: []model.TaskUnitDependency{
-								{Name: model.AllDependencies},
-							}},
-						},
+							{Name: "compile"}, {Name: "testTwo"}},
 					},
 				},
 			}
@@ -646,22 +550,12 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
-								{Name: "compile", Variant: model.AllVariants},
-							}},
-						},
+							{Name: "compile"}, {Name: "testOne"}},
 					},
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
-								{Name: "compile", Variant: model.AllVariants},
-							}},
-							{Name: "testTwo", DependsOn: []model.TaskUnitDependency{
-								{Name: model.AllDependencies, Variant: model.AllVariants}},
-							}},
+							{Name: "compile"}, {Name: "testOne"}, {Name: "testTwo"}},
 					},
 				},
 			}
@@ -692,54 +586,94 @@ func TestValidateTaskRuns(t *testing.T) {
 	}
 	Convey("When a task is patchable, not patch-only, and not git-tag-only, no error should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].Patchable = utility.TruePtr()
-		project.BuildVariants[0].Tasks[0].PatchOnly = utility.FalsePtr()
-		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.FalsePtr()
-		So(len(validateTaskRuns(project)), ShouldEqual, 0)
+		project.Tasks[0].Patchable = utility.TruePtr()
+		project.Tasks[0].PatchOnly = utility.FalsePtr()
+		project.Tasks[0].GitTagOnly = utility.FalsePtr()
 	})
 	Convey("When a task is not patchable, no error should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
+		project.Tasks[0].Patchable = utility.FalsePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 0)
 	})
 	Convey("When a task is patch-only, no error should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
+		project.Tasks[0].PatchOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 0)
 	})
 	Convey("When a task is git-tag-only, no error should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
+		project.Tasks[0].GitTagOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 0)
 	})
 	Convey("When a task is not patchable and not patch-only, no error should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
-		project.BuildVariants[0].Tasks[0].PatchOnly = utility.FalsePtr()
+		project.Tasks[0].Patchable = utility.FalsePtr()
+		project.Tasks[0].PatchOnly = utility.FalsePtr()
 	})
 	Convey("When a task is not patchable and patch-only, an error should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
-		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
+		project.Tasks[0].Patchable = utility.FalsePtr()
+		project.Tasks[0].PatchOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 1)
 	})
 	Convey("When a task is patchable and git-tag-only, an error should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].Patchable = utility.TruePtr()
-		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
+		project.Tasks[0].Patchable = utility.TruePtr()
+		project.Tasks[0].GitTagOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 1)
 	})
 	Convey("When a task is patch-only and git-tag-only, an error should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
-		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
+		project.Tasks[0].PatchOnly = utility.TruePtr()
+		project.Tasks[0].GitTagOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 1)
 	})
 	Convey("When a task is not allowed for git tags and git-tag-only, an error should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].AllowForGitTag = utility.FalsePtr()
+		project.Tasks[0].AllowForGitTag = utility.FalsePtr()
+		project.Tasks[0].GitTagOnly = utility.TruePtr()
+		So(len(validateTaskRuns(project)), ShouldEqual, 1)
+	})
+	Convey("When a task is not allowed for git tags and the variant is git-tag-only, an error should be thrown", t, func() {
+		project := makeProject()
+		project.Tasks[0].AllowForGitTag = utility.FalsePtr()
 		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 1)
+	})
+	Convey("When a task is git-tag-only and the variant is not allowed for git tags, an error should be thrown", t, func() {
+		project := makeProject()
+		project.Tasks[0].GitTagOnly = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].AllowForGitTag = utility.FalsePtr()
+		So(len(validateTaskRuns(project)), ShouldEqual, 1)
+	})
+	Convey("When a task is patch-only and the build variant task unit is not patchable, an error should be thrown", t, func() {
+		project := makeProject()
+		project.Tasks[0].PatchOnly = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
+		So(len(validateTaskRuns(project)), ShouldEqual, 1)
+	})
+	Convey("When a task is not patchable and the build variant task unit is patch-only, an error should be thrown", t, func() {
+		project := makeProject()
+		project.Tasks[0].Patchable = utility.FalsePtr()
+		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
+		So(len(validateTaskRuns(project)), ShouldEqual, 1)
+	})
+	Convey("When a task is patch-only and the build variant task unit is git-tag-only, an error should be thrown", t, func() {
+		project := makeProject()
+		project.Tasks[0].PatchOnly = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
+		So(len(validateTaskRuns(project)), ShouldEqual, 1)
+	})
+	Convey("When a task is patchable and the build variant task unit is git-tag-only, an error should be thrown", t, func() {
+		project := makeProject()
+		project.Tasks[0].Patchable = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
+		So(len(validateTaskRuns(project)), ShouldEqual, 1)
+	})
+	Convey("When the build variant task unit is not patchable and patch-only, an error should be thrown", t, func() {
+		project := makeProject()
+		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
+		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
 	})
 }
 
@@ -1936,7 +1870,7 @@ func TestEnsureHasNecessaryBVFields(t *testing.T) {
 						Tasks: []model.BuildVariantTaskUnit{
 							{
 								Name: "silhouettes",
-								RunOn: []string{
+								Distros: []string{
 									"echoes",
 								},
 							},
@@ -1955,15 +1889,15 @@ func TestEnsureHasNecessaryBVFields(t *testing.T) {
 						RunOn: []string{""},
 						Tasks: []model.BuildVariantTaskUnit{
 							{
-								Name:  "t1",
-								RunOn: []string{""}},
+								Name:    "t1",
+								Distros: []string{""}},
 						},
 					},
 				},
 			}
 			So(ensureHasNecessaryBVFields(project),
 				ShouldResemble, ValidationErrors{
-					{Level: Error, Message: "buildvariant 'bv1' in project '' must either specify run_on field or have every task specify run_on."},
+					{Level: Error, Message: "buildvariant 'bv1' in project '' must either specify run_on field or have every task specify a distro."},
 				})
 		})
 	})
@@ -2795,27 +2729,13 @@ func TestTVToTaskUnit(t *testing.T) {
 							{
 								Name:             "compile",
 								CommitQueueMerge: true,
-								ExecTimeoutSecs:  10,
-								DependsOn: []model.TaskUnitDependency{
-									{
-										Name:    "setup",
-										Variant: "rhel",
-									},
-								},
 							},
 						},
 					}, {
 						Name: "suse",
 						Tasks: []model.BuildVariantTaskUnit{
 							{
-								Name:            "compile",
-								ExecTimeoutSecs: 10,
-								DependsOn: []model.TaskUnitDependency{
-									{
-										Name:    "setup",
-										Variant: "rhel",
-									},
-								},
+								Name: "compile",
 							},
 						},
 					},
@@ -2922,7 +2842,7 @@ func TestTVToTaskUnit(t *testing.T) {
 				assert.Equal(t, expectedTaskUnit.Patchable, taskUnit.Patchable, expectedTaskUnit.Name)
 				assert.Equal(t, expectedTaskUnit.PatchOnly, taskUnit.PatchOnly)
 				assert.Equal(t, expectedTaskUnit.Priority, taskUnit.Priority)
-				missingActual, missingExpected := utility.StringSliceSymmetricDifference(expectedTaskUnit.RunOn, taskUnit.RunOn)
+				missingActual, missingExpected := utility.StringSliceSymmetricDifference(expectedTaskUnit.Distros, taskUnit.Distros)
 				assert.Empty(t, missingActual)
 				assert.Empty(t, missingExpected)
 				assert.Len(t, taskUnit.DependsOn, len(expectedTaskUnit.DependsOn))


### PR DESCRIPTION
Revert parser project logic because it won't be backwards compatible. Then we can deploy the real logic on Monday, with this check baked in, in case of revert. This should also fix the existing "must either specify" errors.