### PR TITLE
EVG-14148 move checking dependencies into a job

### DIFF
--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -315,9 +315,9 @@ func (self *TaskQueue) Save() error {
 	return updateTaskQueue(self.Distro, self.Queue, self.DistroQueueInfo)
 }
 
-func (self *TaskQueue) FindNextTask(spec TaskSpec) *TaskQueueItem {
+func (self *TaskQueue) FindNextTask(spec TaskSpec) (*TaskQueueItem, []string) {
 	if self.Length() == 0 {
-		return nil
+		return nil, nil
 	}
 	// With a spec, find a matching task.
 	if spec.Group != "" && spec.Project != "" && spec.BuildVariant != "" && spec.Version != "" {
@@ -337,7 +337,7 @@ func (self *TaskQueue) FindNextTask(spec TaskSpec) *TaskQueueItem {
 			if it.Group != spec.Group {
 				continue
 			}
-			return &it
+			return &it, nil
 		}
 	}
 
@@ -346,7 +346,7 @@ func (self *TaskQueue) FindNextTask(spec TaskSpec) *TaskQueueItem {
 	for _, it := range self.Queue {
 		// Always return a task if the task group is empty.
 		if it.Group == "" {
-			return &it
+			return &it, nil
 		}
 
 		// If we already determined that this task group is not runnable, continue.
@@ -367,10 +367,10 @@ func (self *TaskQueue) FindNextTask(spec TaskSpec) *TaskQueueItem {
 			GroupMaxHosts: it.GroupMaxHosts,
 		}
 		if shouldRun := shouldRunTaskGroup(it.Id, spec); shouldRun {
-			return &it
+			return &it, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func updateTaskQueue(distro string, taskQueue []TaskQueueItem, distroQueueInfo DistroQueueInfo) error {

--- a/model/task_queue_service.go
+++ b/model/task_queue_service.go
@@ -60,48 +60,16 @@ func (s *taskDispatchService) FindNextTask(distroID string, spec TaskSpec) (*Tas
 }
 
 func (s *taskDispatchService) RefreshFindNextTask(distroID string, spec TaskSpec) (*TaskQueueItem, error) {
-	start := time.Now()
 	distroDispatchService, err := s.ensureQueue(distroID)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	grip.DebugWhen(time.Since(start).Seconds() > 1, message.Fields{
-		"step":            "RefreshFindNextTask",
-		"distro":          distroID,
-		"dispatcher_type": distroDispatchService.Type(),
-		"op":              "ensureQueue",
-		"duration":        time.Since(start),
-		"duration_secs":   time.Since(start).Seconds(),
-	})
-	start = time.Now()
 
 	if err := distroDispatchService.Refresh(); err != nil {
 		return nil, errors.WithStack(err)
 	}
-	grip.DebugWhen(time.Since(start).Seconds() > 1, message.Fields{
-		"step":            "RefreshFindNextTask",
-		"distro":          distroID,
-		"dispatcher_type": distroDispatchService.Type(),
-		"op":              "Refresh",
-		"duration":        time.Since(start),
-		"duration_secs":   time.Since(start).Seconds(),
-	})
-	start = time.Now()
 
-	item := distroDispatchService.FindNextTask(spec)
-	msg := message.Fields{
-		"step":            "RefreshFindNextTask",
-		"distro":          distroID,
-		"dispatcher_type": distroDispatchService.Type(),
-		"op":              "FindNextTask",
-		"duration":        time.Since(start),
-		"duration_secs":   time.Since(start).Seconds(),
-	}
-	if item != nil {
-		msg["item"] = item.Id
-	}
-	grip.DebugWhen(time.Since(start).Seconds() > 1, msg)
-	return item, nil
+	return distroDispatchService.FindNextTask(spec), nil
 }
 
 func (s *taskDispatchService) Refresh(distroID string) error {
@@ -199,7 +167,7 @@ func newDistroTaskDispatchService(taskQueue TaskQueue, typeName string, ttl time
 		ttl:      ttl,
 		typeName: typeName,
 	}
-	start := time.Now()
+
 	if taskQueue.Length() != 0 {
 		d.rebuild(taskQueue.Queue)
 	}
@@ -214,8 +182,6 @@ func newDistroTaskDispatchService(taskQueue TaskQueue, typeName string, ttl time
 		"num_schedulableunits": len(d.units),
 		"num_orders":           len(d.order),
 		"num_taskqueueitems":   taskQueue.Length(),
-		"duration":             time.Since(start),
-		"duration_secs":        time.Since(start).Seconds(),
 	})
 
 	return d

--- a/model/task_queue_service.go
+++ b/model/task_queue_service.go
@@ -16,14 +16,14 @@ import (
 )
 
 type TaskQueueItemDispatcher interface {
-	FindNextTask(string, TaskSpec) (*TaskQueueItem, error)
+	FindNextTask(string, TaskSpec) (*TaskQueueItem, []string, error) // optionally returns a list of tasks to check dependencies for
 	Refresh(string) error
-	RefreshFindNextTask(string, TaskSpec) (*TaskQueueItem, error)
+	RefreshFindNextTask(string, TaskSpec) (*TaskQueueItem, []string, error)
 }
 
 type CachedDispatcher interface {
 	Refresh() error
-	FindNextTask(TaskSpec) *TaskQueueItem
+	FindNextTask(TaskSpec) (*TaskQueueItem, []string)
 	Type() string
 	CreatedAt() time.Time
 }
@@ -50,26 +50,27 @@ func NewTaskDispatchAliasService(ttl time.Duration) TaskQueueItemDispatcher {
 	}
 }
 
-func (s *taskDispatchService) FindNextTask(distroID string, spec TaskSpec) (*TaskQueueItem, error) {
+func (s *taskDispatchService) FindNextTask(distroID string, spec TaskSpec) (*TaskQueueItem, []string, error) {
 	distroDispatchService, err := s.ensureQueue(distroID)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
-
-	return distroDispatchService.FindNextTask(spec), nil
+	item, dependencies := distroDispatchService.FindNextTask(spec)
+	return item, dependencies, nil
 }
 
-func (s *taskDispatchService) RefreshFindNextTask(distroID string, spec TaskSpec) (*TaskQueueItem, error) {
+func (s *taskDispatchService) RefreshFindNextTask(distroID string, spec TaskSpec) (*TaskQueueItem, []string, error) {
 	distroDispatchService, err := s.ensureQueue(distroID)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
 	if err := distroDispatchService.Refresh(); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
-	return distroDispatchService.FindNextTask(spec), nil
+	item, dependencies := distroDispatchService.FindNextTask(spec)
+	return item, dependencies, nil
 }
 
 func (s *taskDispatchService) Refresh(distroID string) error {
@@ -273,13 +274,13 @@ func (d *basicCachedDispatcherImpl) rebuild(items []TaskQueueItem) {
 }
 
 // FindNextTask returns the next dispatchable task in the queue.
-func (d *basicCachedDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueItem {
+func (d *basicCachedDispatcherImpl) FindNextTask(spec TaskSpec) (*TaskQueueItem, []string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	if len(d.units) == 0 && len(d.order) > 0 {
 		d.order = []string{}
-		return nil
+		return nil, nil
 	}
 
 	var unit schedulableUnit
@@ -290,7 +291,7 @@ func (d *basicCachedDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueItem {
 		unit, ok = d.units[compositeGroupID(spec.Group, spec.BuildVariant, spec.Project, spec.Version)]
 		if ok {
 			if next = d.nextTaskGroupTask(unit); next != nil {
-				return next
+				return next, nil
 			}
 		}
 		// If the task group is not present in the schedulableUnit map, then all its tasks are considered dispatched.
@@ -326,7 +327,7 @@ func (d *basicCachedDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueItem {
 					"schedulableunit_num_tasks":     len(unit.tasks),
 				})
 
-				return nil
+				return nil, nil
 			}
 
 			// A non-task group schedulableUnit's tasks ([]TaskQueueItem) only contains a single element.
@@ -341,7 +342,7 @@ func (d *basicCachedDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueItem {
 					"task_id":    item.Id,
 					"distro_id":  d.distroID,
 				}))
-				return nil
+				return nil, nil
 			}
 			if nextTaskFromDB == nil {
 				grip.Warning(message.Fields{
@@ -351,7 +352,7 @@ func (d *basicCachedDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueItem {
 					"task_id":    item.Id,
 					"distro_id":  d.distroID,
 				})
-				return nil
+				return nil, nil
 			}
 
 			var dependenciesMet bool
@@ -372,7 +373,7 @@ func (d *basicCachedDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueItem {
 				continue
 			}
 
-			return &unit.tasks[0]
+			return &unit.tasks[0], nil
 		}
 
 		if unit.runningHosts < unit.maxHosts {
@@ -396,20 +397,20 @@ func (d *basicCachedDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueItem {
 					"taskspec_project":              spec.Project,
 					"taskspec_version":              spec.Version,
 				}))
-				return nil
+				return nil, nil
 			}
 			unit.runningHosts = numHosts
 			d.units[schedulableUnitID] = unit
 
 			if unit.runningHosts < unit.maxHosts {
 				if next = d.nextTaskGroupTask(unit); next != nil {
-					return next
+					return next, nil
 				}
 			}
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 func compositeGroupID(group, variant, project, version string) string {

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -40,7 +40,7 @@ func newDistroTaskDAGDispatchService(taskQueue TaskQueue, ttl time.Duration) (*b
 		distroID: taskQueue.Distro,
 		ttl:      ttl,
 	}
-	start := time.Now()
+
 	if taskQueue.Length() != 0 {
 		if err := d.rebuild(taskQueue.Queue); err != nil {
 			return nil, errors.Wrapf(err, "error creating newDistroTaskDAGDispatchService for distro '%s'", taskQueue.Distro)
@@ -57,8 +57,6 @@ func newDistroTaskDAGDispatchService(taskQueue TaskQueue, ttl time.Duration) (*b
 		"num_task_groups":           len(d.taskGroups),
 		"num_taskqueueitems":        taskQueue.Length(),
 		"sorted_num_taskqueueitems": len(d.sorted),
-		"duration":                  time.Since(start),
-		"duration_secs":             time.Since(start).Seconds(),
 	})
 
 	return d, nil

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -512,5 +512,11 @@ func CheckUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.T
 		}
 	}
 
+	grip.Debug(message.Fields{
+		"message":                            "checked unmarked blocking tasks",
+		"blocking_tasks_updated":             len(blockingTasks),
+		"blocking_deactivated_tasks_updated": len(blockingDeactivatedTasks),
+		"exec_task":                          t.IsPartOfDisplay(),
+	})
 	return catcher.Resolve()
 }

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -246,8 +246,8 @@ func (d *basicCachedDAGDispatcherImpl) rebuild(items []TaskQueueItem) error {
 	return nil
 }
 
-// FindNextTask returns the next dispatchable task in the queue.
-func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueItem {
+// FindNextTask returns the next dispatchable task in the queue, and returns the tasks that need to be checked for dependencies.
+func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) (*TaskQueueItem, []string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	// If the host just ran a task group, give it one back.
@@ -262,7 +262,7 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 				taskGroupTask := d.getItemByNodeID(node.ID())
 				taskGroupTask.IsDispatched = true
 
-				return next
+				return next, nil
 			}
 		}
 		// If the task group is not present in the TaskGroups map, then all its tasks are considered dispatched.
@@ -281,9 +281,8 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 			"distro_id":                d.distroID,
 		})
 	}
-	var totalDurationCheckingBlockedTasks float64
-	var numCheckBlockedTasks int
 	var numIterated int
+	taskIdsToCheckBlocked := []string{}
 	dependencyCaches := make(map[string]task.Task)
 	for i := range d.sorted {
 		numIterated += 1
@@ -314,7 +313,7 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 					"task_id":    item.Id,
 					"distro_id":  d.distroID,
 				}))
-				return nil
+				return nil, nil
 			}
 			if nextTaskFromDB == nil {
 				grip.Warning(message.Fields{
@@ -324,7 +323,7 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 					"task_id":    item.Id,
 					"distro_id":  d.distroID,
 				})
-				return nil
+				return nil, nil
 			}
 
 			// Cache the task as dispatched from the in-memory queue's point of view.
@@ -349,32 +348,10 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 			}
 
 			if !dependenciesMet {
-				start := time.Now()
-				grip.Warning(message.WrapError(checkUnmarkedBlockingTasks(nextTaskFromDB, dependencyCaches), message.Fields{
-					"dispatcher":    DAGDispatcher,
-					"function":      "FindNextTask",
-					"operation":     "checkUnmarkedBlockingTasks",
-					"outcome":       "skip and continue",
-					"task":          item.Id,
-					"distro_id":     d.distroID,
-					"duration":      time.Since(start),
-					"duration_secs": time.Since(start).Seconds(),
-				}))
-				totalDurationCheckingBlockedTasks += time.Since(start).Seconds()
-				numCheckBlockedTasks += 1
+				taskIdsToCheckBlocked = append(taskIdsToCheckBlocked, nextTaskFromDB.Id)
 				continue
 			}
-			grip.Debug(message.Fields{
-				"total_duration_secs": totalDurationCheckingBlockedTasks,
-				"total_operations":    numCheckBlockedTasks,
-				"dispatcher":          DAGDispatcher,
-				"operation":           "checkUnmarkedBlockingTasks",
-				"distro":              d.distroID,
-				"num_iterated":        numIterated,
-				"total_size":          len(d.sorted),
-				"task":                item.Id,
-			})
-			return item
+			return item, taskIdsToCheckBlocked
 		}
 
 		// For a task group task, do some arithmetic to see if the group's next task is dispatchable.
@@ -397,7 +374,7 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 					"version":    item.Version,
 					"distro_id":  d.distroID,
 				}))
-				return nil
+				return nil, nil
 			}
 
 			taskGroupUnit.runningHosts = numHosts
@@ -408,32 +385,12 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec) *TaskQueueIte
 					taskGroupTask := d.getItemByNodeID(node.ID()) // *TaskQueueItem
 					taskGroupTask.IsDispatched = true
 
-					grip.Debug(message.Fields{
-						"total_duration_secs": totalDurationCheckingBlockedTasks,
-						"total_operations":    numCheckBlockedTasks,
-						"dispatcher":          DAGDispatcher,
-						"operation":           "checkUnmarkedBlockingTasks",
-						"distro":              d.distroID,
-						"num_iterated":        numIterated,
-						"total_size":          len(d.sorted),
-						"task":                next.Id,
-					})
-					return next
+					return next, taskIdsToCheckBlocked
 				}
 			}
 		}
 	}
-	grip.Debug(message.Fields{
-		"total_duration_secs": totalDurationCheckingBlockedTasks,
-		"total_operations":    numCheckBlockedTasks,
-		"dispatcher":          DAGDispatcher,
-		"operation":           "checkUnmarkedBlockingTasks",
-		"distro":              d.distroID,
-		"num_iterated":        numIterated,
-		"total_size":          len(d.sorted),
-		"task":                "none",
-	})
-	return nil
+	return nil, taskIdsToCheckBlocked
 }
 
 func (d *basicCachedDAGDispatcherImpl) nextTaskGroupTask(unit schedulableUnit) *TaskQueueItem {
@@ -500,10 +457,10 @@ func (d *basicCachedDAGDispatcherImpl) nextTaskGroupTask(unit schedulableUnit) *
 		}
 
 		if !dependenciesMet {
-			grip.Warning(message.WrapError(checkUnmarkedBlockingTasks(nextTaskFromDB, dependencyCaches), message.Fields{
+			grip.Warning(message.WrapError(CheckUnmarkedBlockingTasks(nextTaskFromDB, dependencyCaches), message.Fields{
 				"dispatcher": DAGDispatcher,
 				"function":   "nextTaskGroupTask",
-				"operation":  "checkUnmarkedBlockingTasks",
+				"operation":  "CheckUnmarkedBlockingTasks",
 				"message":    "error checking dependencies for task",
 				"outcome":    "skip and continue",
 				"task":       nextTaskQueueItem.Id,
@@ -524,7 +481,7 @@ func (d *basicCachedDAGDispatcherImpl) nextTaskGroupTask(unit schedulableUnit) *
 	return nil
 }
 
-func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.Task) error {
+func CheckUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.Task) error {
 	catcher := grip.NewBasicCatcher()
 
 	blockingTasks, err := t.RefreshBlockedDependencies(dependencyCaches)

--- a/model/task_queue_service_test.go
+++ b/model/task_queue_service_test.go
@@ -229,13 +229,13 @@ func (s *taskDAGDispatchServiceSuite) TestOutsideTasksWithTaskGroupDependencies(
 	spec := TaskSpec{}
 
 	// 3 successive calls (regardless of the TaskSpec passed) will dispatch 3 task group tasks, per TaskGroupOrder.
-	next := service.FindNextTask(spec)
+	next, _ := service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("taskgroup_task2", next.Id) // TaskGroupOrder: 1
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("taskgroup_task4", next.Id) // TaskGroupOrder: 2
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("taskgroup_task3", next.Id) // TaskGroupOrder: 3
 
@@ -252,21 +252,21 @@ func (s *taskDAGDispatchServiceSuite) TestOutsideTasksWithTaskGroupDependencies(
 	s.Require().NoError(err)
 
 	// "external_task5" can now be dispatched as its dependency "taskgroup_task3" has completed successfully.
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("external_task5", next.Id)
 
 	// The final task group task "taskgroup_task1" is dispatched
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("taskgroup_task1", next.Id)
 
 	// There are no more tasks to dispatch.
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
 }
 
@@ -490,14 +490,14 @@ func (s *taskDAGDispatchServiceSuite) TestIntraTaskGroupDependencies() {
 	spec := TaskSpec{}
 
 	// Only "task2" can be dispatched - the other 3 tasks cannot be dispatched as they all have unmet dependencies.
-	next := service.FindNextTask(spec)
+	next, _ := service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("task2", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
 
 	// "task2" completes with "status": evergreen.TaskSucceeded.
@@ -513,12 +513,12 @@ func (s *taskDAGDispatchServiceSuite) TestIntraTaskGroupDependencies() {
 	s.Require().NoError(err)
 
 	// Only "task4" can be dispatched - the other 2 tasks cannot be dispatched as they have unmet dependencies.
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("task4", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
 
 	// "task4" completes with "status": evergreen.TaskSucceeded
@@ -534,10 +534,10 @@ func (s *taskDAGDispatchServiceSuite) TestIntraTaskGroupDependencies() {
 	s.Require().NoError(err)
 
 	// Only "task3" can be dispatched - the remaining task cannot be dispatched as it has an unmet dependency.
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("task3", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
 
 	// "task4" completes with "status": evergreen.TaskSucceeded
@@ -553,10 +553,10 @@ func (s *taskDAGDispatchServiceSuite) TestIntraTaskGroupDependencies() {
 	s.Require().NoError(err)
 
 	// Finally, "task1" can be dispatched - all 3 of its dependencies have been satisfied.
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("task1", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
 }
 
@@ -957,10 +957,10 @@ func (s *taskDAGDispatchServiceSuite) TestAddingEdgeWithMissingNodes() {
 
 	spec := TaskSpec{}
 
-	next := service.FindNextTask(spec)
+	next, _ := service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("1", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
 
 	t1.Status = evergreen.TaskSucceeded
@@ -985,15 +985,15 @@ func (s *taskDAGDispatchServiceSuite) TestAddingEdgeWithMissingNodes() {
 	err = service.rebuild(s.taskQueue.Queue)
 	s.Require().NoError(err)
 
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("3", next.Id)
 
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("2", next.Id)
 
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().Nil(next)
 
 	t2.DependsOn = []task.Dependency{
@@ -1057,11 +1057,11 @@ func (s *taskDAGDispatchServiceSuite) TestAddingEdgeWithMissingNodes() {
 	service, err = newDistroTaskDAGDispatchService(s.taskQueue, time.Minute)
 	s.NoError(err)
 
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("1", next.Id)
 
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("3", next.Id)
 }
@@ -1070,79 +1070,79 @@ func (s *taskDAGDispatchServiceSuite) TestNextTaskForDefaultTaskSpec() {
 	service, err := newDistroTaskDAGDispatchService(s.taskQueue, time.Minute)
 	spec := TaskSpec{}
 	s.NoError(err)
-	next := service.FindNextTask(spec)
+	next, _ := service.FindNextTask(spec)
 	s.NotNil(next)
 	// First, a standalone task
 	s.Equal("0", next.Id)
 	// Then all 20 tasks from "group_1_variant_1_project_1_version_1"
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("1", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("6", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("11", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("16", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("21", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("26", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("31", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("36", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("41", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("46", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("51", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("56", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("61", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("66", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("71", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("76", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("81", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("86", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("91", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("96", next.Id)
 	// The all the tasks from "group_2_variant_1_project_1_version_1"
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("2", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("7", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.NotNil(next)
 	s.Equal("12", next.Id)
 	// .....
@@ -1199,7 +1199,7 @@ func (s *taskDAGDispatchServiceSuite) TestSingleHostTaskGroupsBlock() {
 		Version:      "version_1",
 		Project:      "project_1",
 	}
-	next := service.FindNextTask(spec)
+	next, _ := service.FindNextTask(spec)
 	s.Require().Nil(next)
 }
 
@@ -1232,7 +1232,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 			Version:      "version_1",
 			Project:      "project_1",
 		}
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Require().NotNil(next)
 		s.Equal(fmt.Sprintf("%d", 5*i+1), next.Id)
 		s.Require().NoError(setTaskStatus(next.Id, evergreen.TaskSucceeded))
@@ -1247,7 +1247,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 			Version:      "version_1",
 			Project:      "project_1",
 		}
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Equal(fmt.Sprintf("%d", 5*i+2), next.Id)
 		s.Require().NoError(setTaskStatus(next.Id, evergreen.TaskSucceeded))
 	}
@@ -1261,7 +1261,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 			Version:      "version_1",
 			Project:      "project_1",
 		}
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Equal(fmt.Sprintf("%d", 5*i+3), next.Id)
 		s.Require().NoError(setTaskStatus(next.Id, evergreen.TaskSucceeded))
 	}
@@ -1275,7 +1275,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 			Version:      "version_2",
 			Project:      "project_1",
 		}
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Equal(fmt.Sprintf("%d", 5*i+4), next.Id)
 		s.Require().NoError(setTaskStatus(next.Id, evergreen.TaskSucceeded))
 	}
@@ -1289,7 +1289,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 			Version:      "version_1",
 			Project:      "project_1",
 		}
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Equal(fmt.Sprintf("%d", 5*i+26), next.Id)
 		s.Require().NoError(setTaskStatus(next.Id, evergreen.TaskSucceeded))
 	}
@@ -1306,7 +1306,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 
 	// Make a request for another task, passing an "empty" TaskSpec{} - the returned task should should be TaskQueueItem.Id 0 and be a standalone task.
 	spec = TaskSpec{}
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Equal("0", next.Id)
 	s.Equal("", next.Group)
 
@@ -1318,7 +1318,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 	// task ids: ["51", "56", "61", "66", "71", "76", "81", "86", "91", "96"]
 	// All 20 tasks for taskGroupTasks "group_1_variant_1_project_1_version_1" have been dispatched.
 	for i := 0; i < 10; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		nextInt, err = strconv.Atoi(next.Id)
 		s.NoError(err)
 		s.True(nextInt > currentID)
@@ -1336,7 +1336,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 	// All 20 tasks for taskGroupTasks "group_2_variant_1_project_1_version_1" have been dispatched.
 	currentID = 0
 	for i := 0; i < 15; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		nextInt, err = strconv.Atoi(next.Id)
 		s.NoError(err)
 		s.True(nextInt > currentID)
@@ -1354,7 +1354,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 	// All 20 tasks for taskGroupTasks group_1_variant_2_project_1_version_1" have been dispatched.
 	currentID = 0
 	for i := 0; i < 15; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		nextInt, err = strconv.Atoi(next.Id)
 		s.NoError(err)
 		s.True(nextInt > currentID)
@@ -1372,7 +1372,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 	// All 20 tasks for taskGroupTasks "group_1_variant_1_project_1_version_2" have been dispatched.
 	currentID = 0
 	for i := 0; i < 15; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		nextInt, err = strconv.Atoi(next.Id)
 		s.NoError(err)
 		s.True(nextInt > currentID)
@@ -1389,7 +1389,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTask() {
 	// The dispatch order of the 19 standalone tasks is dependent on the Node order of basicCachedDAGDispatcherImpl.sorted (for our particular set of test tasks and dependencies)
 	expectedStandaloneTaskOrder := []string{"5", "10", "15", "20", "25", "30", "50", "45", "40", "35", "55", "60", "80", "75", "70", "65", "85", "90", "95"}
 	for i := 0; i < 19; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Equal(expectedStandaloneTaskOrder[i], next.Id)
 		s.Equal("", next.Group)
 		s.Require().NoError(setTaskStatus(next.Id, evergreen.TaskSucceeded))
@@ -1417,9 +1417,9 @@ func (s *taskDAGDispatchServiceSuite) TestTaskGroupTasksRunningHostsVersusMaxHos
 	s.NoError(e)
 
 	spec := TaskSpec{}
-	next := service.FindNextTask(spec)
+	next, _ := service.FindNextTask(spec)
 	s.Equal("0", next.Id)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	// The next task, according to the order of basicCachedDAGDispatcherImpl.sorted is from task group "group_1_variant_1_version_1".
 	// However, runningHosts < maxHosts is false for this task group, so we cannot dispatch this task.
 	s.NotEqual("1", next.Id)
@@ -1429,7 +1429,7 @@ func (s *taskDAGDispatchServiceSuite) TestTaskGroupTasksRunningHostsVersusMaxHos
 	s.Equal("variant_1", next.BuildVariant)
 	s.Equal("version_1", next.Version)
 	s.Equal("project_1", next.Project)
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	// Same situation again - so we dispatch the next task from "group_2_variant_1_project_1_version_1".
 	s.Equal("7", next.Id)
 	s.Equal("group_2", next.Group)
@@ -1477,7 +1477,7 @@ func (s *taskDAGDispatchServiceSuite) TestTaskGroupWithExternalDependency() {
 	taskGroupID := compositeGroupID(spec.Group, spec.BuildVariant, spec.Project, spec.Version)
 	taskGroup := service.taskGroups[taskGroupID]
 
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal(expectedOrder[0], next.Id)
 	s.Equal("1", taskGroup.tasks[0].Id)
@@ -1488,7 +1488,7 @@ func (s *taskDAGDispatchServiceSuite) TestTaskGroupWithExternalDependency() {
 	s.Equal(false, taskGroup.tasks[2].IsDispatched)
 
 	for i := 1; i < 5; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Require().NotNil(next)
 		s.Equal(expectedOrder[i], next.Id)
 		s.Equal(expectedOrder[i], taskGroup.tasks[i+1].Id)
@@ -1531,13 +1531,13 @@ func (s *taskDAGDispatchServiceSuite) TestTaskGroupWithExternalDependency() {
 		"96",
 	}
 	for i := 0; i < 15; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Require().NotNil(next)
 		s.Equal(expectedOrder[i], next.Id)
 	}
 
 	// All the tasks within taskGroup "group_1_variant_1_project_1_version_1" has now been dispatched.
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Require().NotNil(next)
 	s.Equal("0", next.Id)
 	s.Equal("", next.Group)
@@ -1589,7 +1589,7 @@ func (s *taskDAGDispatchServiceSuite) TestSingleHostTaskGroupOrdering() {
 	expectedOrder := []string{"1", "3", "0", "4", "2"}
 
 	for i := 0; i < 5; i++ {
-		next := service.FindNextTask(spec)
+		next, _ := service.FindNextTask(spec)
 		s.Require().NotNil(next)
 		s.Equal(expectedOrder[i], next.Id)
 	}
@@ -1787,10 +1787,10 @@ func (s *taskDispatchServiceSuite) TestEmptyService() {
 		},
 	}
 	service := newDistroTaskDispatchService(s.taskQueue, "", time.Minute)
-	next := service.FindNextTask(TaskSpec{})
+	next, _ := service.FindNextTask(TaskSpec{})
 	s.Require().NotNil(next)
 	s.Equal("a-standalone-task", next.Id)
-	next = service.FindNextTask(TaskSpec{})
+	next, _ = service.FindNextTask(TaskSpec{})
 	s.Nil(next)
 	s.Empty(service.order) // slice is emptied when map is emptied
 }
@@ -1846,7 +1846,7 @@ func (s *taskDispatchServiceSuite) TestSingleHostTaskGroupsBlock() {
 		Project:      "project_1",
 		Version:      "version_1",
 	}
-	next := service.FindNextTask(spec)
+	next, _ := service.FindNextTask(spec)
 	s.Nil(next)
 	s.Empty(service.units)
 }
@@ -1915,7 +1915,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 			Version:      "version_1",
 			Project:      "project_1",
 		}
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Require().NotNil(next)
 		s.Equal(fmt.Sprintf("%d", 5*i+1), next.Id)
 	}
@@ -1928,7 +1928,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 			Version:      "version_1",
 			Project:      "project_1",
 		}
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Equal(fmt.Sprintf("%d", 5*i+2), next.Id)
 	}
 
@@ -1940,7 +1940,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 			Version:      "version_1",
 			Project:      "project_1",
 		}
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Equal(fmt.Sprintf("%d", 5*i+3), next.Id)
 	}
 
@@ -1952,7 +1952,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 			Version:      "version_2",
 			Project:      "project_1",
 		}
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Equal(fmt.Sprintf("%d", 5*i+4), next.Id)
 	}
 
@@ -1964,7 +1964,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 			Version:      "version_1",
 			Project:      "project_1",
 		}
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		s.Equal(fmt.Sprintf("%d", 5*i+26), next.Id)
 	}
 
@@ -1984,7 +1984,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 		Version:      "version_1",
 		Project:      "project_2",
 	}
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Equal("0", next.Id)
 	currentID := 0
 	var nextInt int
@@ -1992,7 +1992,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 
 	// Dispatch the remaining 10 tasks from the task group schedulableUnit "group_1_variant_1_project_1_version_1".
 	for i := 0; i < 10; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		nextInt, err = strconv.Atoi(next.Id)
 		s.NoError(err)
 		s.True(nextInt > currentID)
@@ -2008,7 +2008,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 	// The corresponding schedulableUnit represents another task group; dispatch its remaining 15 tasks.
 	currentID = 0
 	for i := 0; i < 15; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		nextInt, err = strconv.Atoi(next.Id)
 		s.NoError(err)
 		s.True(nextInt > currentID)
@@ -2024,7 +2024,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 	// The corresponding schedulableUnit represents another task group; dispatch its remaining 15 tasks.
 	currentID = 0
 	for i := 0; i < 15; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		nextInt, err = strconv.Atoi(next.Id)
 		s.NoError(err)
 		s.True(nextInt > currentID)
@@ -2040,7 +2040,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 	// The corresponding schedulableUnit represents another task group; dispatch its remaining 15 tasks.
 	currentID = 0
 	for i := 0; i < 15; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		nextInt, err = strconv.Atoi(next.Id)
 		s.NoError(err)
 		s.True(nextInt > currentID)
@@ -2054,7 +2054,7 @@ func (s *taskDispatchServiceSuite) TestFindNextTask() {
 	// The remaining 19 schedulableUnits represent individual, standalone tasks. Dispatch the rest of these non-task group tasks.
 	currentID = 0
 	for i := 0; i < 19; i++ {
-		next = service.FindNextTask(spec)
+		next, _ = service.FindNextTask(spec)
 		nextInt, err = strconv.Atoi(next.Id)
 		s.NoError(err)
 		s.True(nextInt > currentID)
@@ -2101,14 +2101,14 @@ func (s *taskDispatchServiceSuite) TestSchedulableUnitsRunningHostsVersusMaxHost
 	// basicCachedDispatcherImpl.units["group_2_variant_1_project_1_version_1"].maxHosts = 2
 	//////////////////////////////////////////////////////////////////////////////
 	spec := TaskSpec{}
-	next := service.FindNextTask(spec)
+	next, _ := service.FindNextTask(spec)
 	s.Equal("0", next.Id)
 	s.Equal("", next.Group)
 
 	// basicCachedDispatcherImpl.order's ([]string) next value is "group_1_variant_1_project_1_version_1".
 	// However, runningHosts < maxHosts is false for its corresponding schedulableUnit, so we cannot dispatch one of its tasks
 	// On to basicCachedDispatcherImpl.order's next value: "group_2_variant_1_project_1_version_1" - we can dispatch a task from its corresponding schedulableUnit
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Equal("2", next.Id)
 	s.Equal("group_2", next.Group)
 	s.Equal("variant_1", next.BuildVariant)
@@ -2117,7 +2117,7 @@ func (s *taskDispatchServiceSuite) TestSchedulableUnitsRunningHostsVersusMaxHost
 	s.Equal(2, next.GroupMaxHosts)
 
 	// Same situation again - so we dispatch the next task for the schedulableUnit "group_2_variant_1_project_1_version_1"
-	next = service.FindNextTask(spec)
+	next, _ = service.FindNextTask(spec)
 	s.Equal("7", next.Id)
 	s.Equal("group_2", next.Group)
 	s.Equal("variant_1", next.BuildVariant)

--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -122,19 +122,30 @@ func TestFindTask(t *testing.T) {
 	}
 
 	// ensure that it's always the first task if the group name isn't specified
-	assert.Equal("one", q.FindNextTask(TaskSpec{}).Id)
-	assert.Equal("one", q.FindNextTask(TaskSpec{BuildVariant: "a"}).Id)
-	assert.Equal("one", q.FindNextTask(TaskSpec{Project: "a"}).Id)
-	assert.Equal("one", q.FindNextTask(TaskSpec{Version: "b"}).Id)
-	assert.Equal("one", q.FindNextTask(TaskSpec{BuildVariant: "a", Project: "a"}).Id)
-	assert.Equal("one", q.FindNextTask(TaskSpec{BuildVariant: "a", Version: "b"}).Id)
-	assert.Equal("one", q.FindNextTask(TaskSpec{Project: "a", Version: "b"}).Id)
+	item, _ := q.FindNextTask(TaskSpec{})
+	assert.Equal("one", item.Id)
+	item, _ = q.FindNextTask(TaskSpec{BuildVariant: "a"})
+	assert.Equal("one", item.Id)
+	item, _ = q.FindNextTask(TaskSpec{Project: "a"})
+	assert.Equal("one", item.Id)
+	item, _ = q.FindNextTask(TaskSpec{Version: "b"})
+	assert.Equal("one", item.Id)
+	item, _ = q.FindNextTask(TaskSpec{BuildVariant: "a", Project: "a"})
+	assert.Equal("one", item.Id)
+	item, _ = q.FindNextTask(TaskSpec{BuildVariant: "a", Version: "b"})
+	assert.Equal("one", item.Id)
+	item, _ = q.FindNextTask(TaskSpec{Project: "a", Version: "b"})
+	assert.Equal("one", item.Id)
 
 	// ensure that we can get the task groups that we expect
-	assert.Equal("five", q.FindNextTask(TaskSpec{Group: "foo", Project: "aa", Version: "bb", BuildVariant: "a"}).Id)
-	assert.Equal("one", q.FindNextTask(TaskSpec{Group: "foo", Project: "a", Version: "b", BuildVariant: "a"}).Id)
-	assert.Equal("six", q.FindNextTask(TaskSpec{Group: "bar", Project: "aa", Version: "bb", BuildVariant: "a"}).Id)
-	assert.Equal("two", q.FindNextTask(TaskSpec{Group: "bar", Project: "a", Version: "b", BuildVariant: "a"}).Id)
+	item, _ = q.FindNextTask(TaskSpec{Group: "foo", Project: "aa", Version: "bb", BuildVariant: "a"})
+	assert.Equal("five", item.Id)
+	item, _ = q.FindNextTask(TaskSpec{Group: "foo", Project: "a", Version: "b", BuildVariant: "a"})
+	assert.Equal("one", item.Id)
+	item, _ = q.FindNextTask(TaskSpec{Group: "bar", Project: "aa", Version: "bb", BuildVariant: "a"})
+	assert.Equal("six", item.Id)
+	item, _ = q.FindNextTask(TaskSpec{Group: "bar", Project: "a", Version: "b", BuildVariant: "a"})
+	assert.Equal("two", item.Id)
 }
 
 func TestBlockTaskGroupTasks(t *testing.T) {
@@ -314,7 +325,7 @@ func TestFindNextTaskEmptySpec(t *testing.T) {
 			TaskQueueItem{Id: "first_item"},
 		},
 	}
-	next := queue.FindNextTask(TaskSpec{})
+	next, _ := queue.FindNextTask(TaskSpec{})
 	assert.NotNil(next)
 	assert.Equal("first_item", next.Id)
 
@@ -331,13 +342,13 @@ func TestFindNextTaskEmptySpec(t *testing.T) {
 			},
 		},
 	}
-	next = queue.FindNextTask(TaskSpec{})
+	next, _ = queue.FindNextTask(TaskSpec{})
 	assert.NotNil(next)
 	assert.Equal("first_item", next.Id)
 
 	// Don't return a task if it's running on more than maxhosts
 	queue.Queue[0].GroupMaxHosts = 1
-	next = queue.FindNextTask(TaskSpec{})
+	next, _ = queue.FindNextTask(TaskSpec{})
 	assert.Nil(next)
 
 	// Check that all four fields must match to be in task group.
@@ -347,32 +358,32 @@ func TestFindNextTaskEmptySpec(t *testing.T) {
 	//
 	// All four match:
 	queue.Queue[0].GroupMaxHosts = 1
-	next = queue.FindNextTask(TaskSpec{})
+	next, _ = queue.FindNextTask(TaskSpec{})
 	assert.Nil(next)
 	// Group does not match.
 	tmp := queue.Queue[0].Group
 	queue.Queue[0].Group = "foo"
-	next = queue.FindNextTask(TaskSpec{})
+	next, _ = queue.FindNextTask(TaskSpec{})
 	assert.NotNil(next)
 	assert.Equal("first_item", next.Id)
 	queue.Queue[0].Group = tmp
 	// BuildVariant does not match.
 	tmp = queue.Queue[0].BuildVariant
 	queue.Queue[0].BuildVariant = "foo"
-	next = queue.FindNextTask(TaskSpec{})
+	next, _ = queue.FindNextTask(TaskSpec{})
 	assert.NotNil(next)
 	assert.Equal("first_item", next.Id)
 	queue.Queue[0].BuildVariant = tmp
 	// Version does not match.
 	tmp = queue.Queue[0].Version
 	queue.Queue[0].Version = "foo"
-	next = queue.FindNextTask(TaskSpec{})
+	next, _ = queue.FindNextTask(TaskSpec{})
 	assert.NotNil(next)
 	assert.Equal("first_item", next.Id)
 	queue.Queue[0].Version = tmp
 	// Project does not match.
 	queue.Queue[0].Project = "foo"
-	next = queue.FindNextTask(TaskSpec{})
+	next, _ = queue.FindNextTask(TaskSpec{})
 	assert.NotNil(next)
 	assert.Equal("first_item", next.Id)
 }
@@ -435,7 +446,7 @@ func TestFindNextTaskWithLastTask(t *testing.T) {
 			},
 		},
 	}
-	next := queue.FindNextTask(TaskSpec{})
+	next, _ := queue.FindNextTask(TaskSpec{})
 	assert.Nil(next)
 }
 

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -411,14 +411,27 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 		}
 
 		var queueItem *model.TaskQueueItem
+		var taskIdsToCheckBlocked []string
 		switch d.DispatcherSettings.Version {
 		case evergreen.DispatcherVersionRevised, evergreen.DispatcherVersionRevisedWithDependencies:
-			queueItem, err = dispatcher.RefreshFindNextTask(d.Id, spec)
+			queueItem, taskIdsToCheckBlocked, err = dispatcher.RefreshFindNextTask(d.Id, spec)
 			if err != nil {
 				return nil, false, errors.Wrap(err, "problem getting next task")
 			}
 		default:
-			queueItem = taskQueue.FindNextTask(spec)
+			queueItem, taskIdsToCheckBlocked = taskQueue.FindNextTask(spec)
+		}
+		if len(taskIdsToCheckBlocked) > 0 {
+			env := evergreen.GetEnvironment()
+			j := units.NewCheckBlockedTasksJob(d.Id, taskIdsToCheckBlocked)
+			if err = env.RemoteQueue().Put(ctx, j); err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"message":                   "problem putting new CheckBlockedTasks job",
+					"distro_id":                 d.Id,
+					"tasks_to_check":            taskIdsToCheckBlocked,
+					"distro_dispatcher_version": d.DispatcherSettings.Version,
+				}))
+			}
 		}
 		grip.DebugWhen(currentHost.Distro.Id == distroToMonitor, message.Fields{
 			"message":     "assignNextAvailableTask performance",

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -420,14 +420,11 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 		default:
 			queueItem = taskQueue.FindNextTask(spec)
 		}
-		grip.DebugWhen(currentHost.Distro.Id == distroToMonitor || time.Now().Sub(stepStart).Seconds() > 1, message.Fields{
-			"message":            "assignNextAvailableTask performance",
-			"step":               "RefreshFindNextTask",
-			"duration_ns":        time.Now().Sub(stepStart),
-			"duration_secs":      time.Now().Sub(stepStart).Seconds(),
-			"run_id":             runId,
-			"distro":             currentHost.Distro.Id,
-			"dispatcher_version": d.DispatcherSettings.Version,
+		grip.DebugWhen(currentHost.Distro.Id == distroToMonitor, message.Fields{
+			"message":     "assignNextAvailableTask performance",
+			"step":        "RefreshFindNextTask",
+			"duration_ns": time.Now().Sub(stepStart),
+			"run_id":      runId,
 		})
 		stepStart = time.Now()
 		if queueItem == nil {

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -3,10 +3,10 @@ package units
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/mongodb/amboy"
@@ -48,7 +48,7 @@ func makeCheckBlockedTasksJob() *checkBlockedTasksJob {
 func NewCheckBlockedTasksJob(distroId string, taskIDs []string) amboy.Job {
 	job := makeCheckBlockedTasksJob()
 	job.TaskIDs = taskIDs
-	job.SetID(fmt.Sprintf("%s:%s:%s", checkBlockedTasks, distroId, time.Now().String()))
+	job.SetID(fmt.Sprintf("%s:%s:%s", checkBlockedTasks, distroId, bson.NewObjectId().Hex()))
 	return job
 }
 

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -1,0 +1,67 @@
+package units
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/task"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/dependency"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+)
+
+const (
+	checkBlockedTasks = "check_blocked_tasks"
+)
+
+func init() {
+	registry.AddJobType(checkBlockedTasks, func() amboy.Job { return makeCheckBlockedTasksJob() })
+}
+
+type checkBlockedTasksJob struct {
+	TaskIDs  []string `bson:"task_ids" json:"task_ids" yaml:"task_ids"`
+	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
+	env      evergreen.Environment
+}
+
+func makeCheckBlockedTasksJob() *checkBlockedTasksJob {
+	j := &checkBlockedTasksJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    checkBlockedTasks,
+				Version: 0,
+			},
+		},
+	}
+	j.SetDependency(dependency.NewAlways())
+	return j
+}
+
+// NewCheckBlockedTasksJob creates a job to run repotracker against a repository.
+// The code creating this job is responsible for verifying that the project
+// should track push events
+func NewCheckBlockedTasksJob(distroId string, taskIDs []string) amboy.Job {
+	job := makeCheckBlockedTasksJob()
+	job.TaskIDs = taskIDs
+	job.SetID(fmt.Sprintf("%s:%s:%s", checkBlockedTasks, distroId, time.Now().String()))
+	return job
+}
+
+func (j *checkBlockedTasksJob) Run(ctx context.Context) {
+	tasksToCheck, err := task.Find(task.ByIds(j.TaskIDs))
+	if err != nil {
+		j.AddError(err)
+		return
+	}
+
+	dependencyCache := map[string]task.Task{}
+	for _, t := range tasksToCheck {
+		j.AddError(model.CheckUnmarkedBlockingTasks(&t, dependencyCache))
+	}
+
+}


### PR DESCRIPTION
Rational is from [this logging](https://mongodb.splunkcloud.com/en-US/account/login?return_to=%2Fen-US%2Fapp%2Fsearch%2Fsearch%3Fq%3Dsearch%2520index%253Devergreen%2520%2522operation%2522%253D%2522checkUnmarkedBlockingTasks%2522%2520%257C%2520sort%2520-total_duration_secs%26display.page.search.mode%3Dverbose%26dispatch.sample_ratio%3D1%26earliest%3D-24h%2540h%26latest%3Dnow%26workload_pool%3Dstandard_perf%26display.page.search.tab%3Devents%26display.general.type%3Devents%26sid%3D1617978301.626792); sometimes checkUnmarkedBlockingTasks is more than 2 or even 3 minutes; it seems like it's not actually necessary to be done right in the function, since we just continue anyway, so pushing it out to a job should improve things.