### PR TITLE
EVG-13023 reintroduce merging task and bv task def when parsing project

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -852,7 +852,7 @@ func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project) []BuildVariant
 			GitTagOnly:       in.GitTagOnly,
 			Priority:         in.Priority,
 			DependsOn:        in.DependsOn,
-			Distros:          in.Distros,
+			RunOn:            in.RunOn,
 			ExecTimeoutSecs:  in.ExecTimeoutSecs,
 			Stepback:         in.Stepback,
 			CommitQueueMerge: in.CommitQueueMerge,
@@ -890,11 +890,8 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 	}
 
 	for _, task := range buildVariant.Tasks {
-		// get the task spec out of the project
-		taskSpec := project.GetSpecForTask(task.Name)
 		// sanity check that the config isn't malformed
-		if taskSpec.Name != "" {
-			task.Populate(taskSpec)
+		if task.Name != "" && !task.IsGroup {
 			if task.SkipOnRequester(b.Requester) {
 				continue
 			}
@@ -1297,7 +1294,7 @@ func getTaskCreateTime(projectId string, v *Version) (time.Time, error) {
 func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Project, buildVariant *BuildVariant,
 	b *build.Build, v *Version, dat distro.AliasLookupTable, createTime time.Time, activateTask bool, githubChecksAliases ProjectAliases) (*task.Task, error) {
 
-	buildVarTask.Distros = dat.Expand(buildVarTask.Distros)
+	buildVarTask.RunOn = dat.Expand(buildVarTask.RunOn)
 	buildVariant.RunOn = dat.Expand(buildVariant.RunOn)
 
 	var (
@@ -1305,11 +1302,11 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 		distroAliases []string
 	)
 
-	if len(buildVarTask.Distros) > 0 {
-		distroID = buildVarTask.Distros[0]
+	if len(buildVarTask.RunOn) > 0 {
+		distroID = buildVarTask.RunOn[0]
 
-		if len(buildVarTask.Distros) > 1 {
-			distroAliases = append(distroAliases, buildVarTask.Distros[1:]...)
+		if len(buildVarTask.RunOn) > 1 {
+			distroAliases = append(distroAliases, buildVarTask.RunOn[1:]...)
 		}
 
 	} else if len(buildVariant.RunOn) > 0 {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -760,45 +760,49 @@ func TestCreateBuildFromVersion(t *testing.T) {
 			"Error clearing test collection")
 
 		// the mock build variant we'll be using. runs all three tasks
-		buildVar1 := BuildVariant{
+		buildVar1 := parserBV{
 			Name:        "buildVar",
 			DisplayName: "Build Variant",
 			RunOn:       []string{"arch"},
-			Tasks: []BuildVariantTaskUnit{
+			Tasks: parserBVTaskUnits{
 				{Name: "taskA"}, {Name: "taskB"}, {Name: "taskC"}, {Name: "taskD"},
 			},
-			DisplayTasks: []patch.DisplayTask{
-				patch.DisplayTask{
+			DisplayTasks: []displayTask{
+				displayTask{
 					Name: "bv1DisplayTask1",
-					ExecTasks: []string{
+					ExecutionTasks: []string{
 						"taskA",
 						"taskB",
 					},
 				},
-				patch.DisplayTask{
+				displayTask{
 					Name: "bv1DisplayTask2",
-					ExecTasks: []string{
+					ExecutionTasks: []string{
 						"taskC",
 						"taskD",
 					},
 				},
 			},
 		}
-		buildVar2 := BuildVariant{
+		buildVar2 := parserBV{
 			Name:        "buildVar2",
 			DisplayName: "Build Variant 2",
-			Tasks: []BuildVariantTaskUnit{
+			Tasks: parserBVTaskUnits{
 				{Name: "taskA"}, {Name: "taskB"}, {Name: "taskC"}, {Name: "taskE"},
 			},
 		}
-		buildVar3 := BuildVariant{
+		buildVar3 := parserBV{
 			Name:        "buildVar3",
 			DisplayName: "Build Variant 3",
-			Tasks: []BuildVariantTaskUnit{
+			Tasks: parserBVTaskUnits{
 				{
 					// wait for the first BV's taskA to complete
-					Name:      "taskA",
-					DependsOn: []TaskUnitDependency{{Name: "taskA", Variant: "buildVar"}},
+					Name: "taskA",
+					DependsOn: parserDependencies{
+						{TaskSelector: taskSelector{Name: "taskA",
+							Variant: &variantSelector{StringSelector: "buildVar"}},
+						},
+					},
 				},
 			},
 		}
@@ -812,46 +816,51 @@ func TestCreateBuildFromVersion(t *testing.T) {
 			Variant: ".*"}
 		So(alias.Upsert(), ShouldBeNil)
 		mustHaveResults := true
-		project := &Project{
+		parserProject := &ParserProject{
 			Identifier: "projectName",
-			Tasks: []ProjectTask{
+			Tasks: []parserTask{
 				{
 					Name:      "taskA",
 					Priority:  5,
 					Tags:      []string{"tag1", "tag2"},
-					DependsOn: []TaskUnitDependency{},
+					DependsOn: nil,
 				},
 				{
-					Name:      "taskB",
-					Tags:      []string{"tag1", "tag2"},
-					DependsOn: []TaskUnitDependency{{Name: "taskA", Variant: "buildVar"}},
+					Name: "taskB",
+					Tags: []string{"tag1", "tag2"},
+					DependsOn: parserDependencies{
+						{TaskSelector: taskSelector{Name: "taskA",
+							Variant: &variantSelector{StringSelector: "buildVar"}},
+						},
+					},
 				},
 				{
 					Name: "taskC",
 					Tags: []string{"tag1", "tag2", "pull-requests"},
-					DependsOn: []TaskUnitDependency{
-						{Name: "taskA"},
-						{Name: "taskB"},
+					DependsOn: parserDependencies{
+						{TaskSelector: taskSelector{Name: "taskA"}},
+						{TaskSelector: taskSelector{Name: "taskB"}},
 					},
 				},
 				{
-					Name:            "taskD",
-					Tags:            []string{"tag1", "tag2"},
-					DependsOn:       []TaskUnitDependency{{Name: AllDependencies}},
+					Name: "taskD",
+					Tags: []string{"tag1", "tag2"},
+					DependsOn: parserDependencies{
+						{TaskSelector: taskSelector{Name: AllDependencies}},
+					},
 					MustHaveResults: &mustHaveResults,
 				},
 				{
 					Name: "taskE",
 					Tags: []string{"tag1", "tag2"},
-					DependsOn: []TaskUnitDependency{
-						{
-							Name:    AllDependencies,
-							Variant: AllVariants,
+					DependsOn: parserDependencies{
+						{TaskSelector: taskSelector{Name: AllDependencies,
+							Variant: &variantSelector{StringSelector: AllVariants}},
 						},
 					},
 				},
 			},
-			BuildVariants: []BuildVariant{buildVar1, buildVar2, buildVar3},
+			BuildVariants: []parserBV{buildVar1, buildVar2, buildVar3},
 		}
 
 		// the mock version we'll be using
@@ -878,6 +887,9 @@ func TestCreateBuildFromVersion(t *testing.T) {
 		}
 		So(v.Insert(), ShouldBeNil)
 
+		project, err := TranslateProject(parserProject)
+		So(err, ShouldBeNil)
+		So(project, ShouldNotBeNil)
 		table := NewTaskIdTable(project, v, "", "")
 		tt := table.ExecutionTasks
 		dt := table.DisplayTasks
@@ -2112,7 +2124,7 @@ func TestCreateTasksFromGroup(t *testing.T) {
 		GroupName:       "task_group",
 		Priority:        0,
 		DependsOn:       []TaskUnitDependency{{Name: "new_dependency"}},
-		Distros:         []string{},
+		RunOn:           []string{},
 		ExecTimeoutSecs: 0,
 	}
 	p := &Project{

--- a/model/matrix_smoke_test.go
+++ b/model/matrix_smoke_test.go
@@ -130,7 +130,7 @@ func TestDepsMatrixIntegration(t *testing.T) {
 					So(v.Tags, ShouldContain, "posix")
 					Convey("which should contain a compile", func() {
 						So(v.Tasks[4].Name, ShouldEqual, "compile")
-						So(v.Tasks[4].Distros, ShouldResemble, []string{"linux_big"})
+						So(v.Tasks[4].RunOn, ShouldResemble, []string{"linux_big"})
 						So(v.Tasks[4].DependsOn[0], ShouldResemble, TaskUnitDependency{
 							Name:    "pre-task",
 							Variant: "analysis",

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -394,21 +394,28 @@ func shouldContainPair(actual interface{}, expected ...interface{}) string {
 
 func TestIncludeDependencies(t *testing.T) {
 	Convey("With a project task config with cross-variant dependencies", t, func() {
-		p := &Project{
-			Tasks: []ProjectTask{
+		parserProject := &ParserProject{
+			Tasks: []parserTask{
 				{Name: "t1"},
-				{Name: "t2", DependsOn: []TaskUnitDependency{{Name: "t1"}}},
+				{Name: "t2", DependsOn: parserDependencies{{TaskSelector: taskSelector{Name: "t1"}}}},
 				{Name: "t3"},
 				{Name: "t4", Patchable: new(bool)},
-				{Name: "t5", DependsOn: []TaskUnitDependency{{Name: "t4"}}},
+				{Name: "t5", DependsOn: parserDependencies{{TaskSelector: taskSelector{Name: "t4"}}}},
 			},
-			BuildVariants: []BuildVariant{
-				{Name: "v1", Tasks: []BuildVariantTaskUnit{{Name: "t1"}, {Name: "t2"}}},
-				{Name: "v2", Tasks: []BuildVariantTaskUnit{
-					{Name: "t3", DependsOn: []TaskUnitDependency{{Name: "t2", Variant: "v1"}}}, {Name: "t4"}, {Name: "t5"}},
-				},
+			BuildVariants: []parserBV{
+				{Name: "v1", Tasks: []parserBVTaskUnit{{Name: "t1"}, {Name: "t2"}}},
+				{Name: "v2", Tasks: []parserBVTaskUnit{
+					{Name: "t3", DependsOn: parserDependencies{
+						{TaskSelector: taskSelector{Name: "t2", Variant: &variantSelector{StringSelector: "v1"}}},
+					}},
+					{Name: "t4"},
+					{Name: "t5"},
+				}},
 			},
 		}
+		p, err := TranslateProject(parserProject)
+		So(err, ShouldBeNil)
+		So(p, ShouldNotBeNil)
 
 		Convey("a patch against v1/t1 should remain unchanged", func() {
 			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t1"}}, evergreen.PatchVersionRequester)
@@ -441,21 +448,32 @@ func TestIncludeDependencies(t *testing.T) {
 	})
 
 	Convey("With a project task config with * selectors", t, func() {
-		p := &Project{
-			Tasks: []ProjectTask{
+		parserProject := &ParserProject{
+			Tasks: []parserTask{
 				{Name: "t1"},
 				{Name: "t2"},
-				{Name: "t3", DependsOn: []TaskUnitDependency{{Name: AllDependencies}}},
-				{Name: "t4", DependsOn: []TaskUnitDependency{{Name: "t3", Variant: AllVariants}}},
-				{Name: "t5", DependsOn: []TaskUnitDependency{{Name: AllDependencies, Variant: AllVariants}}},
+				{Name: "t3", DependsOn: parserDependencies{{TaskSelector: taskSelector{Name: AllDependencies}}}},
+				{Name: "t4", DependsOn: parserDependencies{
+					{TaskSelector: taskSelector{
+						Name: "t3", Variant: &variantSelector{StringSelector: AllVariants},
+					}},
+				}},
+				{Name: "t5", DependsOn: parserDependencies{
+					{TaskSelector: taskSelector{
+						Name: AllDependencies, Variant: &variantSelector{StringSelector: AllVariants},
+					}},
+				}},
 			},
-			BuildVariants: []BuildVariant{
-				{Name: "v1", Tasks: []BuildVariantTaskUnit{{Name: "t1"}, {Name: "t2"}, {Name: "t3"}}},
-				{Name: "v2", Tasks: []BuildVariantTaskUnit{{Name: "t1"}, {Name: "t2"}, {Name: "t3"}}},
-				{Name: "v3", Tasks: []BuildVariantTaskUnit{{Name: "t4"}}},
-				{Name: "v4", Tasks: []BuildVariantTaskUnit{{Name: "t5"}}},
+			BuildVariants: []parserBV{
+				{Name: "v1", Tasks: []parserBVTaskUnit{{Name: "t1"}, {Name: "t2"}, {Name: "t3"}}},
+				{Name: "v2", Tasks: []parserBVTaskUnit{{Name: "t1"}, {Name: "t2"}, {Name: "t3"}}},
+				{Name: "v3", Tasks: []parserBVTaskUnit{{Name: "t4"}}},
+				{Name: "v4", Tasks: []parserBVTaskUnit{{Name: "t5"}}},
 			},
 		}
+		p, err := TranslateProject(parserProject)
+		So(err, ShouldBeNil)
+		So(p, ShouldNotBeNil)
 
 		Convey("a patch against v1/t3 should include t2 and t1", func() {
 			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t3"}}, evergreen.PatchVersionRequester)
@@ -496,18 +514,23 @@ func TestIncludeDependencies(t *testing.T) {
 	})
 
 	Convey("With a project task config with cyclical requirements", t, func() {
-		all := []BuildVariantTaskUnit{{Name: "1"}, {Name: "2"}, {Name: "3"}}
-		p := &Project{
-			Tasks: []ProjectTask{
-				{Name: "1", DependsOn: []TaskUnitDependency{{Name: "2"}, {Name: "3"}}},
-				{Name: "2", DependsOn: []TaskUnitDependency{{Name: "1"}, {Name: "3"}}},
-				{Name: "3", DependsOn: []TaskUnitDependency{{Name: "2"}, {Name: "1"}}},
+		all := []parserBVTaskUnit{{Name: "1"}, {Name: "2"}, {Name: "3"}}
+		parserProject := &ParserProject{
+			Tasks: []parserTask{
+				{Name: "1", DependsOn: parserDependencies{{TaskSelector: taskSelector{Name: "2"}}, {TaskSelector: taskSelector{Name: "3"}}}},
+				{Name: "2", DependsOn: parserDependencies{{TaskSelector: taskSelector{Name: "1"}}, {TaskSelector: taskSelector{Name: "3"}}}},
+				{Name: "3", DependsOn: parserDependencies{{TaskSelector: taskSelector{Name: "2"}}, {TaskSelector: taskSelector{Name: "1"}}}},
 			},
-			BuildVariants: []BuildVariant{
+			BuildVariants: []parserBV{
 				{Name: "v1", Tasks: all},
 				{Name: "v2", Tasks: all},
 			},
 		}
+
+		p, err := TranslateProject(parserProject)
+		So(err, ShouldBeNil)
+		So(p, ShouldNotBeNil)
+
 		Convey("all tasks should be scheduled no matter which is initially added", func() {
 			Convey("for '1'", func() {
 				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "1"}}, evergreen.PatchVersionRequester)
@@ -536,19 +559,22 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 	})
 	Convey("With a task that depends on task groups", t, func() {
-		p := &Project{
-			Tasks: []ProjectTask{
-				{Name: "a", DependsOn: []TaskUnitDependency{{Name: "*", Variant: "*"}}},
+		parserProject := &ParserProject{
+			Tasks: []parserTask{
+				{Name: "a", DependsOn: parserDependencies{{TaskSelector: taskSelector{Name: "*", Variant: &variantSelector{StringSelector: "*"}}}}},
 				{Name: "b"},
 			},
-			TaskGroups: []TaskGroup{
+			TaskGroups: []parserTaskGroup{
 				{Name: "task-group", Tasks: []string{"b"}},
 			},
-			BuildVariants: []BuildVariant{
-				{Name: "variant-with-group", Tasks: []BuildVariantTaskUnit{{Name: "task-group"}}},
-				{Name: "initial-variant", Tasks: []BuildVariantTaskUnit{{Name: "a"}}},
+			BuildVariants: []parserBV{
+				{Name: "variant-with-group", Tasks: []parserBVTaskUnit{{Name: "task-group"}}},
+				{Name: "initial-variant", Tasks: []parserBVTaskUnit{{Name: "a"}}},
 			},
 		}
+		p, err := TranslateProject(parserProject)
+		So(err, ShouldBeNil)
+		So(p, ShouldNotBeNil)
 
 		initDep := TVPair{TaskName: "a", Variant: "initial-variant"}
 		pairs, _ := IncludeDependencies(p, []TVPair{initDep}, evergreen.PatchVersionRequester)

--- a/model/project.go
+++ b/model/project.go
@@ -94,8 +94,7 @@ type BuildVariantTaskUnit struct {
 	DependsOn      []TaskUnitDependency `yaml:"depends_on,omitempty" bson:"depends_on"`
 
 	// the distros that the task can be run on
-	Distros []string `yaml:"distros,omitempty" bson:"distros"`
-
+	RunOn []string `yaml:"run_on,omitempty" bson:"run_on"`
 	// currently unsupported (TODO EVG-578)
 	ExecTimeoutSecs int   `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs"`
 	Stepback        *bool `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
@@ -146,6 +145,9 @@ func (bvt *BuildVariantTaskUnit) Populate(pt ProjectTask) {
 	if len(bvt.DependsOn) == 0 {
 		bvt.DependsOn = pt.DependsOn
 	}
+	if len(bvt.RunOn) == 0 {
+		bvt.RunOn = pt.RunOn
+	}
 	if bvt.Priority == 0 {
 		bvt.Priority = pt.Priority
 	}
@@ -168,6 +170,7 @@ func (bvt *BuildVariantTaskUnit) Populate(pt ProjectTask) {
 	if bvt.Stepback == nil {
 		bvt.Stepback = pt.Stepback
 	}
+
 }
 
 // UnmarshalYAML allows tasks to be referenced as single selector strings.
@@ -494,6 +497,7 @@ type ProjectTask struct {
 	DependsOn       []TaskUnitDependency `yaml:"depends_on,omitempty" bson:"depends_on"`
 	Commands        []PluginCommandConf  `yaml:"commands,omitempty" bson:"commands"`
 	Tags            []string             `yaml:"tags,omitempty" bson:"tags"`
+	RunOn           []string             `yaml:"run_on,omitempty" bson:"run_on"`
 	// Use a *bool so that there are 3 possible states:
 	//   1. nil   = not overriding the project setting (default)
 	//   2. true  = overriding the project setting with true
@@ -1082,8 +1086,8 @@ func (p *Project) FindDistroNameForTask(t *task.Task) (string, error) {
 
 	var distro string
 
-	if len(bvt.Distros) > 0 {
-		distro = bvt.Distros[0]
+	if len(bvt.RunOn) > 0 {
+		distro = bvt.RunOn[0]
 	} else if len(bv.RunOn) > 0 {
 		distro = bv.RunOn[0]
 	} else {
@@ -1148,7 +1152,6 @@ func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit
 		if bvt.Name == task {
 			bvt.Variant = variant
 			if projectTask := p.FindProjectTask(task); projectTask != nil {
-				bvt.Populate(*projectTask)
 				return &bvt
 			} else if _, exists := tgMap[task]; exists {
 				return &bvt
@@ -1158,6 +1161,7 @@ func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit
 			for _, t := range tg.Tasks {
 				if t == task {
 					bvt.Variant = variant
+					// task group tasks need to be repopulated from the task list
 					bvt.Populate(*p.FindProjectTask(task))
 					return &bvt
 				}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -117,6 +117,7 @@ type parserTask struct {
 	DependsOn       parserDependencies  `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
 	Commands        []PluginCommandConf `yaml:"commands,omitempty" bson:"commands,omitempty"`
 	Tags            parserStringSlice   `yaml:"tags,omitempty" bson:"tags,omitempty"`
+	RunOn           parserStringSlice   `yaml:"run_on,omitempty" bson:"run_on,omitempty"`
 	Patchable       *bool               `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
 	PatchOnly       *bool               `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
 	AllowForGitTag  *bool               `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
@@ -407,12 +408,12 @@ func (pbvt *parserBVTaskUnit) UnmarshalYAML(unmarshal func(interface{}) error) e
 	if copy.Name == "" {
 		return errors.New("buildvariant task selector must have a name")
 	}
-	// logic for aliasing the "run_on" field to "distros"
-	if len(copy.RunOn) > 0 {
-		if len(copy.Distros) > 0 {
+	// logic for aliasing the "distros" field to "run_on"
+	if len(copy.Distros) > 0 {
+		if len(copy.RunOn) > 0 {
 			return errors.New("cannot use both 'run_on' and 'distros' fields")
 		}
-		copy.Distros, copy.RunOn = copy.RunOn, nil
+		copy.RunOn, copy.Distros = copy.Distros, nil
 	}
 	*pbvt = parserBVTaskUnit(copy)
 	return nil
@@ -671,6 +672,7 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 			ExecTimeoutSecs: pt.ExecTimeoutSecs,
 			Commands:        pt.Commands,
 			Tags:            pt.Tags,
+			RunOn:           pt.RunOn,
 			Patchable:       pt.Patchable,
 			PatchOnly:       pt.PatchOnly,
 			AllowForGitTag:  pt.AllowForGitTag,
@@ -737,7 +739,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			RunOn:         pbv.RunOn,
 			Tags:          pbv.Tags,
 		}
-		bv.Tasks, errs = evaluateBVTasks(tse, tgse, vse, pbv)
+		bv.Tasks, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
 
 		// evaluate any rules passed in during matrix construction
 		for _, r := range pbv.MatrixRules {
@@ -771,7 +773,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 
 				var added []BuildVariantTaskUnit
 				pbv.Tasks = r.AddTasks
-				added, errs = evaluateBVTasks(tse, tgse, vse, pbv)
+				added, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
 				evalErrs = append(evalErrs, errs...)
 				// check for conflicting duplicates
 				for _, t := range added {
@@ -792,7 +794,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 		for _, tg := range tgs {
 			tgMap[tg.Name] = tg
 		}
-		dtse := newDisplayTaskSelectorEvaluator(bv, tasks, tgs, tgMap)
+		dtse := newDisplayTaskSelectorEvaluator(bv, tasks, tgMap)
 
 		// check that display tasks contain real tasks that are not duplicated
 		bvTasks := make(map[string]struct{})        // map of all execution tasks
@@ -854,11 +856,15 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 // evaluating any selectors referencing tasks, and further evaluating any selectors
 // in the DependsOn field of those tasks.
 func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse *variantSelectorEvaluator,
-	pbv parserBV) ([]BuildVariantTaskUnit, []error) {
+	pbv parserBV, tasks []parserTask) ([]BuildVariantTaskUnit, []error) {
 	var evalErrs, errs []error
 	ts := []BuildVariantTaskUnit{}
 	taskUnitsByName := map[string]BuildVariantTaskUnit{}
-	for _, pt := range pbv.Tasks {
+	tasksByName := map[string]parserTask{}
+	for _, t := range tasks {
+		tasksByName[t.Name] = t
+	}
+	for _, pbvt := range pbv.Tasks {
 		// evaluate each task against both the task and task group selectors
 		// only error if both selectors error because each task should only be found
 		// in one or the other
@@ -866,11 +872,11 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 		var err1, err2 error
 		isGroup := false
 		if tse != nil {
-			temp, err1 = tse.evalSelector(ParseSelector(pt.Name))
+			temp, err1 = tse.evalSelector(ParseSelector(pbvt.Name))
 			names = append(names, temp...)
 		}
 		if tgse != nil {
-			temp, err2 = tgse.evalSelector(ParseSelector(pt.Name))
+			temp, err2 = tgse.evalSelector(ParseSelector(pbvt.Name))
 			if len(temp) > 0 {
 				names = append(names, temp...)
 				isGroup = true
@@ -882,39 +888,21 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 		}
 		// create new task definitions--duplicates must have the same status requirements
 		for _, name := range names {
+			parserTask := tasksByName[name]
 			// create a new task by copying the task that selected it,
 			// so we can preserve the "Variant" and "Status" field.
-			t := BuildVariantTaskUnit{
-				Name:             name,
-				Patchable:        pt.Patchable,
-				PatchOnly:        pt.PatchOnly,
-				AllowForGitTag:   pt.AllowForGitTag,
-				GitTagOnly:       pt.GitTagOnly,
-				Priority:         pt.Priority,
-				ExecTimeoutSecs:  pt.ExecTimeoutSecs,
-				Stepback:         pt.Stepback,
-				Distros:          pt.Distros,
-				CommitQueueMerge: pt.CommitQueueMerge,
-				CronBatchTime:    pt.CronBatchTime,
-				BatchTime:        pt.BatchTime,
-			}
+			t := getParserBuildVariantTaskUnit(name, parserTask, pbvt)
 
-			// for backwards compatibility of EVG-14282
-			if len(pt.Distros) == 0 {
-				t.Distros = pt.RunOn
-			}
-			// Task-level dependencies in the variant override variant-level dependencies
-			// in the variant. If neither is present, then the BuildVariantTaskUnit unit
-			// will contain no dependencies, so dependencies will come from the task
-			// spec at task creation time.
+			// Task-level dependencies defined in the variant override variant-level dependencies which override
+			// task-level dependencies defined in the task.
 			var dependsOn parserDependencies
-			if len(pbv.DependsOn) > 0 {
+			if len(pbvt.DependsOn) > 0 {
+				dependsOn = pbvt.DependsOn
+			} else if len(pbv.DependsOn) > 0 {
 				dependsOn = pbv.DependsOn
+			} else if len(parserTask.DependsOn) > 0 {
+				dependsOn = parserTask.DependsOn
 			}
-			if len(pt.DependsOn) > 0 {
-				dependsOn = pt.DependsOn
-			}
-
 			t.DependsOn, errs = evaluateDependsOn(tse.tagEval, tgse, vse, dependsOn)
 			evalErrs = append(evalErrs, errs...)
 			t.IsGroup = isGroup
@@ -934,6 +922,54 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 		}
 	}
 	return ts, evalErrs
+}
+
+// getParserBuildVariantTaskUnit combines the parser project's task definition with the build variant task definition.
+// DependsOn will be handled separately.
+func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskUnit) BuildVariantTaskUnit {
+	res := BuildVariantTaskUnit{
+		Name:             name,
+		Patchable:        bvt.Patchable,
+		PatchOnly:        bvt.PatchOnly,
+		AllowForGitTag:   bvt.AllowForGitTag,
+		GitTagOnly:       bvt.GitTagOnly,
+		Priority:         bvt.Priority,
+		ExecTimeoutSecs:  bvt.ExecTimeoutSecs,
+		Stepback:         bvt.Stepback,
+		RunOn:            bvt.RunOn,
+		CommitQueueMerge: bvt.CommitQueueMerge,
+		CronBatchTime:    bvt.CronBatchTime,
+		BatchTime:        bvt.BatchTime,
+	}
+	if res.Priority == 0 {
+		res.Priority = pt.Priority
+	}
+	if res.Patchable == nil {
+		res.Patchable = pt.Patchable
+	}
+	if res.PatchOnly == nil {
+		res.PatchOnly = pt.PatchOnly
+	}
+	if res.AllowForGitTag == nil {
+		res.AllowForGitTag = pt.AllowForGitTag
+	}
+	if res.GitTagOnly == nil {
+		res.GitTagOnly = pt.GitTagOnly
+	}
+	if res.ExecTimeoutSecs == 0 {
+		res.ExecTimeoutSecs = pt.ExecTimeoutSecs
+	}
+	if res.Stepback == nil {
+		res.Stepback = pt.Stepback
+	}
+	if len(res.RunOn) == 0 {
+		// first consider that we may be using the legacy "distros" field
+		res.RunOn = bvt.Distros
+	}
+	if len(res.RunOn) == 0 {
+		res.RunOn = pt.RunOn
+	}
+	return res
 }
 
 // evaluateDependsOn expands any selectors in a dependency definition.

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/utility"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -225,8 +226,8 @@ buildvariants:
 			p, err := createIntermediateProject([]byte(single))
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
-			So(p.BuildVariants[0].Tasks[0].Distros[0], ShouldEqual, "test")
-			So(p.BuildVariants[0].Tasks[0].RunOn, ShouldBeNil)
+			So(p.BuildVariants[0].Tasks[0].RunOn[0], ShouldEqual, "test")
+			So(p.BuildVariants[0].Tasks[0].Distros, ShouldBeNil)
 		})
 		Convey("a file that uses run_on AND distros for BVTasks should not parse", func() {
 			single := `
@@ -259,6 +260,63 @@ buildvariants:
 			So(bv.Tasks[0].CommitQueueMerge, ShouldBeTrue)
 		})
 	})
+}
+
+func TestTranslateTasks(t *testing.T) {
+	parserProject := &ParserProject{
+		BuildVariants: []parserBV{{
+			Name: "bv",
+			Tasks: parserBVTaskUnits{
+				{
+					Name:            "my_task",
+					ExecTimeoutSecs: 30,
+				},
+				{
+					Name:       "your_task",
+					GitTagOnly: utility.TruePtr(),
+				},
+				{
+					Name:            "my_tg",
+					RunOn:           []string{"my_distro"},
+					ExecTimeoutSecs: 20,
+				},
+			}},
+		},
+		Tasks: []parserTask{
+			{Name: "my_task", PatchOnly: utility.TruePtr(), ExecTimeoutSecs: 15},
+			{Name: "your_task", GitTagOnly: utility.FalsePtr(), Stepback: utility.TruePtr(), RunOn: []string{"a different distro"}},
+			{Name: "tg_task", PatchOnly: utility.TruePtr(), RunOn: []string{"a different distro"}},
+		},
+		TaskGroups: []parserTaskGroup{{
+			Name:  "my_tg",
+			Tasks: []string{"tg_task"},
+		}},
+	}
+	out, err := TranslateProject(parserProject)
+	assert.NoError(t, err)
+	assert.NotNil(t, out)
+	require.Len(t, out.Tasks, 3)
+	require.Len(t, out.BuildVariants, 1)
+	require.Len(t, out.BuildVariants[0].Tasks, 3)
+	assert.Equal(t, "my_task", out.BuildVariants[0].Tasks[0].Name)
+	assert.Equal(t, 30, out.BuildVariants[0].Tasks[0].ExecTimeoutSecs)
+	assert.True(t, utility.FromBoolPtr(out.BuildVariants[0].Tasks[0].PatchOnly))
+	assert.Equal(t, "your_task", out.BuildVariants[0].Tasks[1].Name)
+	assert.True(t, utility.FromBoolPtr(out.BuildVariants[0].Tasks[1].GitTagOnly))
+	assert.True(t, utility.FromBoolPtr(out.BuildVariants[0].Tasks[1].Stepback))
+	assert.Contains(t, out.BuildVariants[0].Tasks[1].RunOn, "a different distro")
+
+	assert.Equal(t, "my_tg", out.BuildVariants[0].Tasks[2].Name)
+	bvt := out.FindTaskForVariant("my_tg", "bv")
+	assert.NotNil(t, bvt)
+	assert.Nil(t, bvt.PatchOnly)
+	assert.Contains(t, bvt.RunOn, "my_distro")
+	assert.Equal(t, 20, bvt.ExecTimeoutSecs)
+
+	bvt = out.FindTaskForVariant("tg_task", "bv")
+	assert.NotNil(t, bvt)
+	assert.True(t, utility.FromBoolPtr(bvt.PatchOnly))
+	assert.Contains(t, bvt.RunOn, "my_distro")
 }
 
 func TestTranslateDependsOn(t *testing.T) {
@@ -370,7 +428,7 @@ func TestTranslateBuildVariants(t *testing.T) {
 	})
 }
 
-func parserTaskSelectorTaskEval(tse *taskSelectorEvaluator, tasks parserBVTaskUnits, expected []BuildVariantTaskUnit) {
+func parserTaskSelectorTaskEval(tse *taskSelectorEvaluator, tasks parserBVTaskUnits, taskDefs []parserTask, expected []BuildVariantTaskUnit) {
 	names := []string{}
 	exp := []string{}
 	for _, t := range tasks {
@@ -383,7 +441,7 @@ func parserTaskSelectorTaskEval(tse *taskSelectorEvaluator, tasks parserBVTaskUn
 	Convey(fmt.Sprintf("tasks [%v] should evaluate to [%v]",
 		strings.Join(names, ", "), strings.Join(exp, ", ")), func() {
 		pbv := parserBV{Tasks: tasks}
-		ts, errs := evaluateBVTasks(tse, nil, vse, pbv)
+		ts, errs := evaluateBVTasks(tse, nil, vse, pbv, taskDefs)
 		if expected != nil {
 			So(errs, ShouldBeNil)
 		} else {
@@ -421,25 +479,30 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 			Convey("should evaluate valid tasks pointers properly", func() {
 				parserTaskSelectorTaskEval(tse,
 					parserBVTaskUnits{{Name: "white"}},
+					taskDefs,
 					[]BuildVariantTaskUnit{{Name: "white"}})
 				parserTaskSelectorTaskEval(tse,
 					parserBVTaskUnits{{Name: "red", Priority: 500}, {Name: ".secondary"}},
+					taskDefs,
 					[]BuildVariantTaskUnit{{Name: "red", Priority: 500}, {Name: "orange"}, {Name: "purple"}, {Name: "green"}})
 				parserTaskSelectorTaskEval(tse,
 					parserBVTaskUnits{
 						{Name: "orange", Distros: []string{"d1"}},
 						{Name: ".warm .secondary", Distros: []string{"d1"}}},
-					[]BuildVariantTaskUnit{{Name: "orange", Distros: []string{"d1"}}})
+					taskDefs,
+					[]BuildVariantTaskUnit{{Name: "orange", RunOn: []string{"d1"}}})
 				parserTaskSelectorTaskEval(tse,
 					parserBVTaskUnits{
 						{Name: "orange", Distros: []string{"d1"}},
 						{Name: "!.warm .secondary", Distros: []string{"d1"}}},
+					taskDefs,
 					[]BuildVariantTaskUnit{
-						{Name: "orange", Distros: []string{"d1"}},
-						{Name: "purple", Distros: []string{"d1"}},
-						{Name: "green", Distros: []string{"d1"}}})
+						{Name: "orange", RunOn: []string{"d1"}},
+						{Name: "purple", RunOn: []string{"d1"}},
+						{Name: "green", RunOn: []string{"d1"}}})
 				parserTaskSelectorTaskEval(tse,
 					parserBVTaskUnits{{Name: "*"}},
+					taskDefs,
 					[]BuildVariantTaskUnit{
 						{Name: "red"}, {Name: "blue"}, {Name: "yellow"},
 						{Name: "orange"}, {Name: "purple"}, {Name: "green"},
@@ -449,6 +512,7 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 					parserBVTaskUnits{
 						{Name: "red", Priority: 100},
 						{Name: "!.warm .secondary", Priority: 100}},
+					taskDefs,
 					[]BuildVariantTaskUnit{
 						{Name: "red", Priority: 100},
 						{Name: "purple", Priority: 100},
@@ -1161,7 +1225,7 @@ buildvariants:
 	assert.Len(proj.BuildVariants, 3)
 
 	assert.Len(proj.BuildVariants[0].Tasks, 2)
-	assert.Nil(proj.BuildVariants[0].Tasks[0].PatchOnly)
+	assert.True(*proj.BuildVariants[0].Tasks[0].PatchOnly)
 	assert.False(*proj.BuildVariants[0].Tasks[1].PatchOnly)
 
 	assert.Len(proj.BuildVariants[1].Tasks, 2)
@@ -1207,7 +1271,7 @@ buildvariants:
 
 	assert.Len(t, proj.BuildVariants, 3)
 	assert.Len(t, proj.BuildVariants[0].Tasks, 2)
-	assert.Nil(t, proj.BuildVariants[0].Tasks[0].AllowForGitTag)
+	assert.True(t, *proj.BuildVariants[0].Tasks[0].AllowForGitTag) // loaded from task
 	assert.False(t, *proj.BuildVariants[0].Tasks[1].AllowForGitTag)
 
 	assert.Len(t, proj.BuildVariants[1].Tasks, 2)
@@ -1251,7 +1315,7 @@ buildvariants:
 	assert.Len(t, proj.BuildVariants, 3)
 
 	assert.Len(t, proj.BuildVariants[0].Tasks, 2)
-	assert.Nil(t, proj.BuildVariants[0].Tasks[0].GitTagOnly)
+	assert.True(t, *proj.BuildVariants[0].Tasks[0].GitTagOnly) // loaded from task
 	assert.False(t, *proj.BuildVariants[0].Tasks[1].GitTagOnly)
 
 	assert.Len(t, proj.BuildVariants[1].Tasks, 2)

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -285,7 +285,7 @@ func newTaskGroupSelectorEvaluator(groups []parserTaskGroup) *tagSelectorEvaluat
 }
 
 // Display task selector
-func newDisplayTaskSelectorEvaluator(bv BuildVariant, tasks []parserTask, tgs []TaskGroup, tgMap map[string]TaskGroup) *tagSelectorEvaluator {
+func newDisplayTaskSelectorEvaluator(bv BuildVariant, tasks []parserTask, tgMap map[string]TaskGroup) *tagSelectorEvaluator {
 	var selectees []tagged
 	for _, t := range bv.Tasks {
 		if tg, ok := tgMap[t.Name]; ok {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1618,7 +1618,9 @@ func TestVariantTasksForSelectors(t *testing.T) {
 			{
 				Name:         "bv0",
 				DisplayTasks: []patch.DisplayTask{{Name: "dt0", ExecTasks: []string{"t0"}}},
-				Tasks:        []BuildVariantTaskUnit{{Name: "t0"}, {Name: "t1"}},
+				Tasks: []BuildVariantTaskUnit{
+					{Name: "t0"},
+					{Name: "t1", DependsOn: []TaskUnitDependency{{Name: "t0", Variant: "bv0"}}}},
 			},
 		},
 		Tasks: []ProjectTask{

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -1131,7 +1131,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			"message": "successfully created version",
 			"version": v.Id,
 			"hash":    v.Revision,
-			"project": v.Branch,
+			"project": v.Identifier,
 			"runner":  RunnerName,
 		})
 		return nil

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -635,10 +635,10 @@ func createTestRevision(revision string,
 func createTestProject(override1, override2 *int) *model.ParserProject {
 	pp := &model.ParserProject{}
 	pp.AddBuildVariant("bv1", "bv1", "", override1, []string{"t1"})
-	pp.BuildVariants[0].Tasks[0].Distros = []string{"test-distro-one"}
+	pp.BuildVariants[0].Tasks[0].RunOn = []string{"test-distro-one"}
 
 	pp.AddBuildVariant("bv2", "bv2", "", override2, []string{"t1"})
-	pp.BuildVariants[1].Tasks[0].Distros = []string{"test-distro-one"}
+	pp.BuildVariants[1].Tasks[0].RunOn = []string{"test-distro-one"}
 
 	pp.AddTask("t1", nil)
 
@@ -839,7 +839,7 @@ tasks:
 	s.NoError(err)
 	s.Equal(v.Config, dbVersion.Config)
 	s.Require().Len(dbVersion.Errors, 1)
-	s.Equal("buildvariant 'bv' in project 'mci' must either specify run_on field or have every task specify a distro.", dbVersion.Errors[0])
+	s.Equal("buildvariant 'bv' in project 'mci' must either specify run_on field or have every task specify run_on.", dbVersion.Errors[0])
 
 	dbBuild, err := build.FindOne(build.ByVersion(v.Id))
 	s.NoError(err)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -336,7 +336,6 @@ func tvToTaskUnit(p *model.Project) map[model.TVPair]model.BuildVariantTaskUnit 
 			}
 		}
 		for _, t := range tasksToAdd {
-			t.Populate(p.GetSpecForTask(t.Name))
 			t.Variant = bv.Name
 			node := model.TVPair{
 				Variant:  bv.Name,
@@ -418,7 +417,7 @@ func ensureHasNecessaryBVFields(project *model.Project) ValidationErrors {
 		}
 		for _, task := range buildVariant.Tasks {
 			taskHasValidDistro := false
-			for _, d := range task.Distros {
+			for _, d := range task.RunOn {
 				if d != "" {
 					taskHasValidDistro = true
 					break
@@ -429,19 +428,19 @@ func ensureHasNecessaryBVFields(project *model.Project) ValidationErrors {
 				break
 			}
 		}
-		hasValidRunOn := false
+		bvHasValidDistro := false
 		for _, runOn := range buildVariant.RunOn {
 			if runOn != "" {
-				hasValidRunOn = true
+				bvHasValidDistro = true
 				break
 			}
 		}
-		if hasTaskWithoutDistro && !hasValidRunOn {
+		if hasTaskWithoutDistro && !bvHasValidDistro {
 			errs = append(errs,
 				ValidationError{
 					Message: fmt.Sprintf("buildvariant '%s' in project '%s' "+
 						"must either specify run_on field or have every task "+
-						"specify a distro.",
+						"specify run_on.",
 						buildVariant.Name, project.Identifier),
 				},
 			)
@@ -529,7 +528,7 @@ func ensureReferentialIntegrity(project *model.Project, distroIDs []string, dist
 				}
 			}
 			buildVariantTasks[task.Name] = true
-			for _, distro := range task.Distros {
+			for _, distro := range task.RunOn {
 				if !utility.StringSliceContains(distroIDs, distro) && !utility.StringSliceContains(distroAliases, distro) {
 					errs = append(errs,
 						ValidationError{

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -201,7 +201,19 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}, {Name: "testTwo"}},
+							{
+								Name:      "compile",
+								DependsOn: []model.TaskUnitDependency{{Name: "testOne"}},
+							},
+							{
+								Name:      "testOne",
+								DependsOn: []model.TaskUnitDependency{{Name: "compile"}},
+							},
+							{
+								Name:      "testTwo",
+								DependsOn: []model.TaskUnitDependency{{Name: "compile"}},
+							},
+						},
 					},
 				},
 			}
@@ -226,7 +238,16 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}, {Name: "testTwo"}},
+							{Name: "compile"},
+							{
+								Name:      "testOne",
+								DependsOn: []model.TaskUnitDependency{{Name: "compile"}, {Name: "testTwo"}},
+							},
+							{
+								Name:      "testTwo",
+								DependsOn: []model.TaskUnitDependency{{Name: model.AllDependencies}},
+							},
+						},
 					},
 				},
 			}
@@ -247,8 +268,8 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}},
-					},
+							{Name: "compile"},
+							{Name: "testOne", DependsOn: []model.TaskUnitDependency{{Name: "compile"}, {Name: "hamSteak"}}}}},
 				},
 			}
 			So(checkDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
@@ -277,11 +298,22 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}},
+							{
+								Name: "compile",
+							},
+							{
+								Name: "testOne",
+								DependsOn: []model.TaskUnitDependency{
+									{Name: "compile"},
+									{Name: "testSpecial", Variant: "bv2"},
+								},
+							}},
 					},
 					{
-						Name:  "bv2",
-						Tasks: []model.BuildVariantTaskUnit{{Name: "testSpecial"}}},
+						Name: "bv2",
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "testSpecial", DependsOn: []model.TaskUnitDependency{{Name: "testOne", Variant: "bv1"}}}},
+					},
 				},
 			}
 			So(checkDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
@@ -306,7 +338,7 @@ func TestCheckDependencyGraph(t *testing.T) {
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
 							{Name: "compile", DependsOn: []model.TaskUnitDependency{{Name: "testOne"}}},
-							{Name: "testOne"},
+							{Name: "testOne", DependsOn: []model.TaskUnitDependency{{Name: "compile"}}},
 						},
 					},
 				},
@@ -346,22 +378,35 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}},
+							{Name: "compile"},
+							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
+								{Name: "compile"},
+								{Name: "testSpecial", Variant: "bv2"},
+							}}},
 					},
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "testSpecial"}},
+							{Name: "testSpecial", DependsOn: []model.TaskUnitDependency{{Name: "testOne", Variant: model.AllVariants}}},
+						},
 					},
 					{
 						Name: "bv3",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}},
+							{Name: "compile"},
+							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
+								{Name: "compile"},
+								{Name: "testSpecial", Variant: "bv2"},
+							}}},
 					},
 					{
 						Name: "bv4",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}},
+							{Name: "compile"},
+							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
+								{Name: "compile"},
+								{Name: "testSpecial", Variant: "bv2"},
+							}}},
 					},
 				},
 			}
@@ -391,12 +436,37 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}},
+							{
+								Name: "compile",
+							},
+							{
+								Name: "testOne",
+								DependsOn: []model.TaskUnitDependency{
+									{Name: "compile", Variant: model.AllVariants},
+									{Name: "testTwo"},
+								},
+							}},
 					},
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}, {Name: "testTwo"}},
+							{
+								Name: "compile",
+							},
+							{
+								Name: "testOne",
+								DependsOn: []model.TaskUnitDependency{
+									{Name: "compile", Variant: model.AllVariants},
+									{Name: "testTwo"},
+								},
+							},
+							{
+								Name: "testTwo",
+								DependsOn: []model.TaskUnitDependency{
+									{Name: model.AllDependencies, Variant: model.AllVariants},
+								},
+							},
+						},
 					},
 				},
 			}
@@ -420,8 +490,11 @@ func TestCheckDependencyGraph(t *testing.T) {
 				},
 				BuildVariants: []model.BuildVariant{
 					{
-						Name:  "bv",
-						Tasks: []model.BuildVariantTaskUnit{{Name: "compile"}, {Name: "testOne"}},
+						Name: "bv",
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "compile"},
+							{Name: "testOne", DependsOn: []model.TaskUnitDependency{{Name: "testOne"}}},
+						},
 					},
 				},
 			}
@@ -457,7 +530,9 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}, {Name: "testTwo"}},
+							{Name: "compile"},
+							{Name: "testOne", DependsOn: []model.TaskUnitDependency{{Name: "compile"}}},
+							{Name: "testTwo", DependsOn: []model.TaskUnitDependency{{Name: "compile"}}}},
 					},
 				},
 			}
@@ -486,12 +561,25 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "testOne"}},
+							{
+								Name: "testOne",
+								DependsOn: []model.TaskUnitDependency{
+									{Name: "compile", Variant: "bv2"},
+								},
+							},
+						},
 					},
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testSpecial"}},
+							{Name: "compile"},
+							{
+								Name: "testSpecial",
+								DependsOn: []model.TaskUnitDependency{
+									{Name: "compile"},
+									{Name: "testOne", Variant: "bv1"}},
+							},
+						},
 					},
 				},
 			}
@@ -518,12 +606,20 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}},
+							{Name: "compile"},
+							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
+								{Name: "compile", Variant: model.AllVariants},
+							}},
+						},
 					},
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testTwo"}},
+							{Name: "compile"},
+							{Name: "testTwo", DependsOn: []model.TaskUnitDependency{
+								{Name: model.AllDependencies},
+							}},
+						},
 					},
 				},
 			}
@@ -550,12 +646,22 @@ func TestCheckDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}},
+							{Name: "compile"},
+							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
+								{Name: "compile", Variant: model.AllVariants},
+							}},
+						},
 					},
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"}, {Name: "testOne"}, {Name: "testTwo"}},
+							{Name: "compile"},
+							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
+								{Name: "compile", Variant: model.AllVariants},
+							}},
+							{Name: "testTwo", DependsOn: []model.TaskUnitDependency{
+								{Name: model.AllDependencies, Variant: model.AllVariants}},
+							}},
 					},
 				},
 			}
@@ -586,94 +692,54 @@ func TestValidateTaskRuns(t *testing.T) {
 	}
 	Convey("When a task is patchable, not patch-only, and not git-tag-only, no error should be thrown", t, func() {
 		project := makeProject()
-		project.Tasks[0].Patchable = utility.TruePtr()
-		project.Tasks[0].PatchOnly = utility.FalsePtr()
-		project.Tasks[0].GitTagOnly = utility.FalsePtr()
+		project.BuildVariants[0].Tasks[0].Patchable = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].PatchOnly = utility.FalsePtr()
+		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.FalsePtr()
+		So(len(validateTaskRuns(project)), ShouldEqual, 0)
 	})
 	Convey("When a task is not patchable, no error should be thrown", t, func() {
 		project := makeProject()
-		project.Tasks[0].Patchable = utility.FalsePtr()
+		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 0)
 	})
 	Convey("When a task is patch-only, no error should be thrown", t, func() {
 		project := makeProject()
-		project.Tasks[0].PatchOnly = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 0)
 	})
 	Convey("When a task is git-tag-only, no error should be thrown", t, func() {
 		project := makeProject()
-		project.Tasks[0].GitTagOnly = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 0)
 	})
 	Convey("When a task is not patchable and not patch-only, no error should be thrown", t, func() {
 		project := makeProject()
-		project.Tasks[0].Patchable = utility.FalsePtr()
-		project.Tasks[0].PatchOnly = utility.FalsePtr()
+		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
+		project.BuildVariants[0].Tasks[0].PatchOnly = utility.FalsePtr()
 	})
 	Convey("When a task is not patchable and patch-only, an error should be thrown", t, func() {
 		project := makeProject()
-		project.Tasks[0].Patchable = utility.FalsePtr()
-		project.Tasks[0].PatchOnly = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
+		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 1)
 	})
 	Convey("When a task is patchable and git-tag-only, an error should be thrown", t, func() {
 		project := makeProject()
-		project.Tasks[0].Patchable = utility.TruePtr()
-		project.Tasks[0].GitTagOnly = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].Patchable = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 1)
 	})
 	Convey("When a task is patch-only and git-tag-only, an error should be thrown", t, func() {
 		project := makeProject()
-		project.Tasks[0].PatchOnly = utility.TruePtr()
-		project.Tasks[0].GitTagOnly = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
+		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 1)
 	})
 	Convey("When a task is not allowed for git tags and git-tag-only, an error should be thrown", t, func() {
 		project := makeProject()
-		project.Tasks[0].AllowForGitTag = utility.FalsePtr()
-		project.Tasks[0].GitTagOnly = utility.TruePtr()
-		So(len(validateTaskRuns(project)), ShouldEqual, 1)
-	})
-	Convey("When a task is not allowed for git tags and the variant is git-tag-only, an error should be thrown", t, func() {
-		project := makeProject()
-		project.Tasks[0].AllowForGitTag = utility.FalsePtr()
-		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
-		So(len(validateTaskRuns(project)), ShouldEqual, 1)
-	})
-	Convey("When a task is git-tag-only and the variant is not allowed for git tags, an error should be thrown", t, func() {
-		project := makeProject()
-		project.Tasks[0].GitTagOnly = utility.TruePtr()
 		project.BuildVariants[0].Tasks[0].AllowForGitTag = utility.FalsePtr()
-		So(len(validateTaskRuns(project)), ShouldEqual, 1)
-	})
-	Convey("When a task is patch-only and the build variant task unit is not patchable, an error should be thrown", t, func() {
-		project := makeProject()
-		project.Tasks[0].PatchOnly = utility.TruePtr()
-		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
-		So(len(validateTaskRuns(project)), ShouldEqual, 1)
-	})
-	Convey("When a task is not patchable and the build variant task unit is patch-only, an error should be thrown", t, func() {
-		project := makeProject()
-		project.Tasks[0].Patchable = utility.FalsePtr()
-		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
-		So(len(validateTaskRuns(project)), ShouldEqual, 1)
-	})
-	Convey("When a task is patch-only and the build variant task unit is git-tag-only, an error should be thrown", t, func() {
-		project := makeProject()
-		project.Tasks[0].PatchOnly = utility.TruePtr()
 		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
 		So(len(validateTaskRuns(project)), ShouldEqual, 1)
-	})
-	Convey("When a task is patchable and the build variant task unit is git-tag-only, an error should be thrown", t, func() {
-		project := makeProject()
-		project.Tasks[0].Patchable = utility.TruePtr()
-		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
-		So(len(validateTaskRuns(project)), ShouldEqual, 1)
-	})
-	Convey("When the build variant task unit is not patchable and patch-only, an error should be thrown", t, func() {
-		project := makeProject()
-		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
-		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
 	})
 }
 
@@ -1870,7 +1936,7 @@ func TestEnsureHasNecessaryBVFields(t *testing.T) {
 						Tasks: []model.BuildVariantTaskUnit{
 							{
 								Name: "silhouettes",
-								Distros: []string{
+								RunOn: []string{
 									"echoes",
 								},
 							},
@@ -1889,15 +1955,15 @@ func TestEnsureHasNecessaryBVFields(t *testing.T) {
 						RunOn: []string{""},
 						Tasks: []model.BuildVariantTaskUnit{
 							{
-								Name:    "t1",
-								Distros: []string{""}},
+								Name:  "t1",
+								RunOn: []string{""}},
 						},
 					},
 				},
 			}
 			So(ensureHasNecessaryBVFields(project),
 				ShouldResemble, ValidationErrors{
-					{Level: Error, Message: "buildvariant 'bv1' in project '' must either specify run_on field or have every task specify a distro."},
+					{Level: Error, Message: "buildvariant 'bv1' in project '' must either specify run_on field or have every task specify run_on."},
 				})
 		})
 	})
@@ -2729,13 +2795,27 @@ func TestTVToTaskUnit(t *testing.T) {
 							{
 								Name:             "compile",
 								CommitQueueMerge: true,
+								ExecTimeoutSecs:  10,
+								DependsOn: []model.TaskUnitDependency{
+									{
+										Name:    "setup",
+										Variant: "rhel",
+									},
+								},
 							},
 						},
 					}, {
 						Name: "suse",
 						Tasks: []model.BuildVariantTaskUnit{
 							{
-								Name: "compile",
+								Name:            "compile",
+								ExecTimeoutSecs: 10,
+								DependsOn: []model.TaskUnitDependency{
+									{
+										Name:    "setup",
+										Variant: "rhel",
+									},
+								},
 							},
 						},
 					},
@@ -2842,7 +2922,7 @@ func TestTVToTaskUnit(t *testing.T) {
 				assert.Equal(t, expectedTaskUnit.Patchable, taskUnit.Patchable, expectedTaskUnit.Name)
 				assert.Equal(t, expectedTaskUnit.PatchOnly, taskUnit.PatchOnly)
 				assert.Equal(t, expectedTaskUnit.Priority, taskUnit.Priority)
-				missingActual, missingExpected := utility.StringSliceSymmetricDifference(expectedTaskUnit.Distros, taskUnit.Distros)
+				missingActual, missingExpected := utility.StringSliceSymmetricDifference(expectedTaskUnit.RunOn, taskUnit.RunOn)
 				assert.Empty(t, missingActual)
 				assert.Empty(t, missingExpected)
 				assert.Len(t, taskUnit.DependsOn, len(expectedTaskUnit.DependsOn))


### PR DESCRIPTION
This reverts commit b3bea4f09c6be8e90eb138b1cd04e7f9fd112f7f.

Backwards compatibility is now baked in, so if we do need to revert this commit, the old code will know how to handle the project saved with "run_on" as opposed to "distros".