### PR TITLE
EVG-14249 add generated et IDs to existing dts

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3005,3 +3005,16 @@ func ConvertCedarTestResult(result apimodels.CedarTestResult) TestResult {
 		Status:          result.Status,
 	}
 }
+
+func AddExecTasksToDisplayTask(displayTaskId string, execTasks []string) error {
+	if len(execTasks) == 0 {
+		return nil
+	}
+
+	return UpdateOne(
+		bson.M{IdKey: displayTaskId},
+		bson.M{"$push": bson.M{
+			ExecutionTasksKey: bson.M{"$each": execTasks},
+		}},
+	)
+}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2317,3 +2317,31 @@ func TestAddParentDisplayTasks(t *testing.T) {
 	assert.Equal(t, "et4", tasks[3].Id)
 	assert.Equal(t, dt2.Id, tasks[3].DisplayTask.Id)
 }
+
+func TestAddExecTasksToDisplayTask(t *testing.T) {
+	assert.NoError(t, db.Clear(Collection))
+	dt1 := Task{
+		Id:             "dt1",
+		DisplayOnly:    true,
+		ExecutionTasks: []string{"et1", "et2"},
+	}
+	assert.NoError(t, dt1.Insert())
+
+	assert.NoError(t, AddExecTasksToDisplayTask(dt1.Id, []string{}))
+	dtFromDB, err := FindOneId(dt1.Id)
+	assert.NoError(t, err)
+	assert.NotNil(t, dtFromDB)
+	assert.Len(t, dtFromDB.ExecutionTasks, 2)
+	assert.Contains(t, dtFromDB.ExecutionTasks, "et1")
+	assert.Contains(t, dtFromDB.ExecutionTasks, "et2")
+
+	assert.NoError(t, AddExecTasksToDisplayTask(dt1.Id, []string{"et3", "et4"}))
+	dtFromDB, err = FindOneId(dt1.Id)
+	assert.NoError(t, err)
+	assert.NotNil(t, dtFromDB)
+	assert.Len(t, dtFromDB.ExecutionTasks, 4)
+	assert.Contains(t, dtFromDB.ExecutionTasks, "et1")
+	assert.Contains(t, dtFromDB.ExecutionTasks, "et2")
+	assert.Contains(t, dtFromDB.ExecutionTasks, "et3")
+	assert.Contains(t, dtFromDB.ExecutionTasks, "et4")
+}


### PR DESCRIPTION
Part one of this ticket was to make sure the project was stored correctly (i.e. new execution tasks were added to the display task definitions). Now we need to actually add them to the existing display task document; I think that'll be the last step, but the easiest way to test this is with the server project on prod.