### PR TITLE
EVG-14434 don't not set patch params as private

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -350,8 +350,6 @@ func (as *APIServer) FetchExpansionsForTask(w http.ResponseWriter, r *http.Reque
 	params := append(proj.GetParameters(), v.Parameters...)
 	for _, param := range params {
 		res.Vars[param.Key] = param.Value
-		// parameters aren't private
-		res.PrivateVars[param.Key] = false
 	}
 
 	gimlet.WriteJSON(w, res)


### PR DESCRIPTION
yes the double negative is supposed to be there

the problem is that in https://github.com/evergreen-ci/evergreen/blob/50a2312b023bc644415284e0f4d7780f1c2579e6/agent/command/expansion_write.go#L40, we treat having a variable in the private map as being private without checking the value. I didn't want to change that behavior so I instead made the response for patch params consistent with non-private expansions