### PR TITLE
EVG-13566 tweak check for procs to kill in agent

### DIFF
--- a/agent/util/subtree_linux.go
+++ b/agent/util/subtree_linux.go
@@ -161,13 +161,13 @@ func executableInWorkingDir(pid int, workingDir string, logger grip.Journaler) b
 		return false
 	}
 
-	executablePath, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+	cmdInfo, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 	if err != nil {
 		if !os.IsPermission(err) {
-			logger.Infof("Could not get executable path for process %d", pid)
+			logger.Infof("Could not get executable path for process %d: %s", pid, err.Error())
 		}
 		return false
 	}
 
-	return strings.HasPrefix(executablePath, workingDir)
+	return strings.HasPrefix(string(cmdInfo), workingDir)
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-03-29"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-04-07"
+	AgentVersion = "2021-04-20"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
- read the executable of the process we're going to kill without actually reading the symlink, which might avoid the error in the ticket
- log the error that's returned to help with debugging