### PR TITLE
EVG-14249 add exec tasks without checking if they're newly generated

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -981,7 +981,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 		}
 		if !createAll && !utility.StringSliceContains(displayNames, dt.Name) {
 			// this display task already exists, but may need to be updated
-			execTaskIdsToAdd := []string{}
+			execTaskIds := []string{}
 			for _, et := range dt.ExecTasks {
 				execTaskId := execTable.GetId(b.BuildVariant, et)
 				if execTaskId == "" {
@@ -996,13 +996,11 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 					})
 					continue
 				}
-				if taskMap[execTaskId] != nil { // this is a new exec task and we need to update
-					execTaskIdsToAdd = append(execTaskIdsToAdd, execTaskId)
-				}
+				execTaskIds = append(execTaskIds, execTaskId)
 			}
-			grip.Error(message.WrapError(task.AddExecTasksToDisplayTask(id, execTaskIdsToAdd), message.Fields{
+			grip.Error(message.WrapError(task.AddExecTasksToDisplayTask(id, execTaskIds), message.Fields{
 				"message":      "problem adding exec tasks to display tasks",
-				"exec_tasks":   execTaskIdsToAdd,
+				"exec_tasks":   execTaskIds,
 				"display_task": dt.Name,
 				"build_id":     b.Id,
 			}))

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3015,7 +3015,7 @@ func AddExecTasksToDisplayTask(displayTaskId string, execTasks []string) error {
 
 	return UpdateOne(
 		bson.M{IdKey: displayTaskId},
-		bson.M{"$push": bson.M{
+		bson.M{"$addToSet": bson.M{
 			ExecutionTasksKey: bson.M{"$each": execTasks},
 		}},
 	)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2327,6 +2327,7 @@ func TestAddExecTasksToDisplayTask(t *testing.T) {
 	}
 	assert.NoError(t, dt1.Insert())
 
+	// no tasks to add
 	assert.NoError(t, AddExecTasksToDisplayTask(dt1.Id, []string{}))
 	dtFromDB, err := FindOneId(dt1.Id)
 	assert.NoError(t, err)
@@ -2335,7 +2336,8 @@ func TestAddExecTasksToDisplayTask(t *testing.T) {
 	assert.Contains(t, dtFromDB.ExecutionTasks, "et1")
 	assert.Contains(t, dtFromDB.ExecutionTasks, "et2")
 
-	assert.NoError(t, AddExecTasksToDisplayTask(dt1.Id, []string{"et3", "et4"}))
+	// new and existing tasks to add (existing tasks not duplicated)
+	assert.NoError(t, AddExecTasksToDisplayTask(dt1.Id, []string{"et2", "et3", "et4"}))
 	dtFromDB, err = FindOneId(dt1.Id)
 	assert.NoError(t, err)
 	assert.NotNil(t, dtFromDB)


### PR DESCRIPTION
I made a mistake in my previous PR: here I was assuming that any task that has been added to the display task would be a newly generated task, but that's not even the case I'm testing; here it's the generator task itself that's being put into the display task. The [createDisplayTask](https://github.com/evergreen-ci/evergreen/blob/f9f3ae2eb91b28d307064a20f64dbaed0e772428/model/lifecycle.go#L1422) function assumes that every execution task that has an ID in the execTable can be added directly to the display task, so we can make that assumption too.