### PR TITLE
EVG-14488: add distro architecture for MacOS ARM64

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -444,6 +444,7 @@ func (k SenderKey) String() string {
 // Recognized architectures, should be in the form ${GOOS}_${GOARCH}.
 const (
 	ArchDarwinAmd64  = "darwin_amd64"
+	ArchDarwinArm64  = "darwin_arm64"
 	ArchLinux386     = "linux_386"
 	ArchLinuxPpc64le = "linux_ppc64le"
 	ArchLinuxS390x   = "linux_s390x"
@@ -588,6 +589,7 @@ var (
 		ArchLinuxArm64:   "Linux ARM 64-bit",
 		ArchWindows386:   "Windows 32-bit",
 		ArchDarwinAmd64:  "OSX 64-bit",
+		ArchDarwinArm64:  "OSX ARM 64-bit",
 		ArchLinuxAmd64:   "Linux 64-bit",
 		ArchLinux386:     "Linux 32-bit",
 	}

--- a/makefile
+++ b/makefile
@@ -48,7 +48,7 @@ export GOCACHE := $(gocache)
 
 # start evergreen specific configuration
 
-unixPlatforms := linux_amd64 darwin_amd64 $(if $(STAGING_ONLY),,linux_s390x linux_arm64 linux_ppc64le)
+unixPlatforms := linux_amd64 darwin_amd64 $(if $(STAGING_ONLY),,darwin_arm64 linux_s390x linux_arm64 linux_ppc64le)
 windowsPlatforms := windows_amd64
 
 

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -446,7 +446,7 @@ func (d *Distro) HomeDir() string {
 	if d.User == "root" {
 		return filepath.Join("/", d.User)
 	}
-	if d.Arch == evergreen.ArchDarwinAmd64 {
+	if d.Arch == evergreen.ArchDarwinAmd64 || d.Arch == evergreen.ArchDarwinArm64 {
 		return filepath.Join("/Users", d.User)
 	}
 	return filepath.Join("/home", d.User)

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -613,7 +613,6 @@ buildvariants:
     expansions:
       goos: linux
       goarch: amd64
-      # TODO (EVG-13513): update to go1.16 once it's available (needs BUILD-12977).
       gobin: /opt/golang/go1.13/bin/go
       goroot: /opt/golang/go1.13
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
@@ -631,9 +630,8 @@ buildvariants:
       - archlinux-new-small
       - archlinux-new-large
     expansions:
-      # TODO (EVG-13513): update to go1.16 once it's available (needs BUILD-12977).
-      gobin: /opt/golang/go1.13/bin/go
-      goroot: /opt/golang/go1.13
+      gobin: /opt/golang/go1.16/bin/go
+      goroot: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
       race_detector: true
       test_timeout: 15m
@@ -646,9 +644,8 @@ buildvariants:
       - archlinux-new-small
       - archlinux-new-large
     expansions:
-      # TODO (EVG-13513): update to go1.16 once it's available (needs BUILD-12977).
-      gobin: /opt/golang/go1.13/bin/go
-      goroot: /opt/golang/go1.13
+      gobin: /opt/golang/go1.16/bin/go
+      goroot: /opt/golang/go1.16
     tasks:
       - name: generate-lint
 
@@ -658,9 +655,8 @@ buildvariants:
       - archlinux-new-small
       - archlinux-new-large
     expansions:
-      # TODO (EVG-13513): update to go1.16 once it's available (needs BUILD-12977).
-      gobin: /opt/golang/go1.13/bin/go
-      goroot: /opt/golang/go1.13
+      gobin: /opt/golang/go1.16/bin/go
+      goroot: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
       test_timeout: 15m
     tasks:


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14488

* Add distro support to use MacOS ARM64 agents.
* Run archlinux tests on go1.16.