### PR TITLE
EVG-14025 Error loading task when Jira Ticket key does not exist

### DIFF
--- a/rest/model/task_annotations.go
+++ b/rest/model/task_annotations.go
@@ -1,7 +1,9 @@
 package model
 
 import (
+	"log"
 	"net/url"
+	"path"
 	"time"
 
 	"github.com/evergreen-ci/birch"
@@ -174,7 +176,13 @@ func GetJiraTickets(issueLinks []APIIssueLink) ([]*APIIssueLink, error) {
 		urlObject, err := url.Parse(*issue.URL)
 		catcher.Wrap(err, "problem parsing the issue url")
 		if urlObject != nil && urlObject.Host == "jira.mongodb.org" {
-			issue.JiraTicket, err = jiraHandler.GetJIRATicket(*issue.IssueKey)
+			myUrl, err := url.Parse(*issue.URL)
+			if err != nil {
+				log.Fatal(err)
+			}
+			jiraKey := path.Base(myUrl.Path)
+
+			issue.JiraTicket, err = jiraHandler.GetJIRATicket(jiraKey)
 			catcher.Wrap(err, "error getting Jira ticket")
 		}
 		issueToAdd := issue


### PR DESCRIPTION
This is a quick fix that takes the jiraKey from the url to fix this: 
![image-2021-04-21-14-48-13-811](https://user-images.githubusercontent.com/13104717/115617660-ab389f00-a2bf-11eb-904f-5bfe8b680d39.png)


Todo in future tickets: let users leave the display task blank, change how the display text is shown, and validate the key before saving. 