### PR TITLE
EVG-14368: check provisioning user data hosts for external termination

### DIFF
--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -216,6 +216,36 @@ func TestMonitorHosts(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(len(found), ShouldEqual, 0)
 		})
+		Convey("a non-user data provisioned host with no reachability check should not return", func() {
+			require.NoError(t, db.Clear(Collection), "clearing collection '%s'", Collection)
+			h := Host{
+				Id:        "id",
+				Status:    evergreen.HostStarting,
+				StartedBy: evergreen.User,
+			}
+			So(h.Insert(), ShouldBeNil)
+			found, err := Find(ByNotMonitoredSince(now))
+			So(err, ShouldBeNil)
+			So(len(found), ShouldEqual, 0)
+		})
+		Convey("a user data provisioned host with no reachability check should return", func() {
+			require.NoError(t, db.Clear(Collection), "clearing collection '%s'", Collection)
+			h := Host{
+				Id:          "id",
+				Status:      evergreen.HostStarting,
+				StartedBy:   evergreen.User,
+				Provisioned: true,
+				Distro: distro.Distro{
+					BootstrapSettings: distro.BootstrapSettings{
+						Method: distro.BootstrapMethodUserData,
+					},
+				},
+			}
+			So(h.Insert(), ShouldBeNil)
+			found, err := Find(ByNotMonitoredSince(now))
+			So(err, ShouldBeNil)
+			So(len(found), ShouldEqual, 1)
+		})
 	})
 }
 

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
@@ -117,7 +118,8 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 
 	switch cloudStatus {
 	case cloud.StatusRunning:
-		if h.Status != evergreen.HostRunning {
+		userDataProvisioning := h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData && h.Status == evergreen.HostStarting
+		if h.Status != evergreen.HostRunning && !userDataProvisioning {
 			grip.Info(message.Fields{
 				"op_id":   id,
 				"message": "found running host with incorrect status",


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14368

If a user data provisioned host is externally terminated while it's preparing the host to run the agent, it would be misattributed to the host failing to provision when the cloud provider actually took away the host. This adds a check for external termination on hosts provisioning with user data before they've started the agent.