### PR TITLE
EVG-14517: reduce logging level for duplicate task check

### DIFF
--- a/units/duplicate_task_check.go
+++ b/units/duplicate_task_check.go
@@ -59,7 +59,7 @@ func (j *duplicateTaskCheckJob) Run(ctx context.Context) {
 		dupTaskToDistros[dup.TaskID] = dup.DistroIDs
 	}
 	if len(dupTaskToDistros) != 0 {
-		grip.Critical(message.Fields{
+		grip.Error(message.Fields{
 			"message":         "tasks are enqueued multiple times in primary task queues",
 			"task_to_distros": dupTaskToDistros,
 			"job":             j.ID(),


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14517

Reduce the log level for this. While this is still a correctness problem and tasks might dispatch multiple times to different hosts, I'm hoping this check can go away, but it requires [EVG-14516](https://jira.mongodb.org/browse/EVG-14516). I'm going to change it to a Splunk alert so that at least we can silence it if it gets too noisy.