### PR TITLE
PERF-2165 use denylist regex for expanded metrics

### DIFF
--- a/public/static/app/perf-bb/ExpandedMetricsSignalProcessingController.js
+++ b/public/static/app/perf-bb/ExpandedMetricsSignalProcessingController.js
@@ -6,9 +6,10 @@ mciModule.controller('ExpandedMetricsSignalProcessingController', function (
   $scope.totalPages = 1;
   $scope.projectId = $routeParams.projectId;
   $scope.measurementRegex = 'Latency50thPercentile|Latency95thPercentile';
-  $scope.taskRegex = 'mixed_writes_replica|large_scale_model|big_update|service_architecture_workloads|out_of_cache_scanner';
-  // This is essentially "not containing ActorFinished/ActorStarted/Setup/Cleanup"
-  $scope.testRegex = '^(?!.*(ActorFinished|ActorStarted|Setup|Cleanup))';
+  // Look at all tasks except genny_canaries.
+  $scope.taskRegex = '^(?!.*(genny_canaries).*)';
+  // Don't look at any test-specific canaries (eg. canary_InsertBigDocs.ActorFinished).
+  $scope.testRegex = '^(?!.*(canary_|Cleanup).*)';
   $scope.hazardValues = [
     'Major Regression',
     'Moderate Regression',


### PR DESCRIPTION
Looking through the discussion on the ticket, it seemed like we wanted to use a denylist and only block canaries, so I've done just that.

I don't actually know how to test this stuff, hoping someone with UI experience can show me how to. 

Also in the ticket, Brad had some ideas about using a [script](https://github.com/10gen/dev-prod-perf/blob/noisy_metrics/users/jim.oleary/dsiutils/README.md#find-potentially-noisy-metrics) to think about what we should disable/enable. That seems like a more complex solution that we could think about in the future, but I avoided doing that for now. We'd have to think about where to add the script, how often to run it, how to pipe the results into the regex etc.. 