### PR TITLE
EVG-14064 Set patch status to aborted if theres an aborted task

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -942,6 +942,17 @@ func (r *queryResolver) Patch(ctx context.Context, id string) (*restModel.APIPat
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}
+	tasks, _, err := r.sc.FindTasksByVersion(id, []string{}, []string{}, "", "", 0, 0, []string{task.DisplayStatusKey}, []task.TasksSortOrder{})
+	statuses := getAllTaskStatuses(tasks)
+
+	// If theres an aborted task we should set the patch status to aborted if there are no other failures
+	if utility.StringSliceContains(statuses, evergreen.TaskAborted) {
+		if len(utility.StringSliceIntersection(statuses, evergreen.TaskFailureStatuses)) == 0 {
+			abortedStatus := evergreen.TaskAborted
+			patch.Status = &abortedStatus
+		}
+	}
+
 	return patch, nil
 }
 

--- a/graphql/tests/patch/data.json
+++ b/graphql/tests/patch/data.json
@@ -116,6 +116,11 @@
           "task": null
         }
       }
+    },
+    {
+      "_id": "8",
+      "version": "9e4ff3abe3c3317e352063e3",
+      "status": "aborted"
     }
   ],
   "builds": [
@@ -735,6 +740,57 @@
       },
       "desc": "NO BASE COMMIT PATCH",
       "branch": "mongodb-mongo-master"
+    },
+        {
+      "_id": {
+        "$oid": "9e4ff3abe3c3317e352063e3"
+      },
+      "desc": "'evergreen-ci/spruce' pull request #700 by khelif96: Test out aborted patch statuses",
+      "branch": "spruce",
+      "githash": "3b53f9b61226491cd31113c773d66e351957ed29",
+      "patch_number": 20,
+      "author": "mohamed.khelif",
+      "version": "5dd2e89cd1fe07048e43bb9c",
+      "status": "failed",
+      "create_time": {
+        "$date": "2019-11-18T18:53:15Z"
+      },
+      "start_time": {
+        "$date": "2019-11-18T18:54:15.734Z"
+      },
+      "finish_time": {
+        "$date": "2019-11-18T18:57:15.053Z"
+      },
+      "build_variants": [
+        "ubuntu1804"
+      ],
+      "tasks": [
+        "compile"
+
+      ],
+      "variants_tasks": [
+        {
+          "variant": "ubuntu1804",
+          "tasks": [
+            "compile"
+          ],
+          "displaytasks": []
+        }
+      ],
+      "activated": true,
+      "alias": "__github",
+      "github_patch_data": {
+        "pr_number": 27,
+        "base_owner": "evergreen-ci",
+        "base_repo": "spruce",
+        "base_branch": "main",
+        "head_owner": "evergreen-ci",
+        "head_repo": "spruce",
+        "head_hash": "2b37dacf86f9d4d1545faaba37c7c5693202e645",
+        "author": "khelif96",
+        "author_uid": 123456,
+        "merge_commit_sha": ""
+      }
     }
   ],
   "commit_queue": [

--- a/graphql/tests/patch/queries/abortedPatchTasks.graphql
+++ b/graphql/tests/patch/queries/abortedPatchTasks.graphql
@@ -1,0 +1,5 @@
+{
+  patch(id: "9e4ff3abe3c3317e352063e3") {
+    status
+  }
+}

--- a/graphql/tests/patch/results.json
+++ b/graphql/tests/patch/results.json
@@ -218,6 +218,16 @@
           }
         }
       }
+    },
+    {
+      "query_file": "abortedPatchTasks.graphql",
+      "result": {
+        "data": {
+          "patch": {
+            "status": "aborted"
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
If a patch contains an aborted task and no other failures we should display its status as aborted.

In response to the thread here https://jira.mongodb.org/browse/EVG-14064

Corresponding spruce PR here https://github.com/evergreen-ci/spruce/pull/718