### PR TITLE
EVG-14474 don't default compare HEAD when specifying commit range

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2021-03-29"
+	ClientVersion = "2021-04-27"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2021-04-27"

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -144,11 +144,16 @@ func mergeCommand() cli.Command {
 		Action: func(c *cli.Context) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
+			ref := c.String(refFlagName)
+			commits := c.String(commitsFlagName)
+			if commits != "" {
+				ref = ""
+			}
 
 			params := mergeParams{
 				project:     c.String(projectFlagName),
-				ref:         c.String(refFlagName),
-				commits:     c.String(commitsFlagName),
+				ref:         ref,
+				commits:     commits,
 				id:          c.String(resumeFlagName),
 				pause:       c.Bool(pauseFlagName),
 				skipConfirm: c.Bool(yesFlagName),


### PR DESCRIPTION
I still can't see how this ever worked and went back to about HEAD~1000 to verify that the problem is there too. We clearly don't expect the ref flag to be passed with the commits flag (https://github.com/evergreen-ci/evergreen/blob/433529c8e1a85d82f0fcc98bed808d61be647ce1/operations/commit_queue.go#L142) but the ref flag has a default, so if you pass the commit flag at all we get into a bad state