### PR TITLE
EVG-13546: use scopes/retryability in user data done job

### DIFF
--- a/makefile
+++ b/makefile
@@ -63,7 +63,7 @@ uiFiles := $(shell find public/static -not -path "./public/static/app" -name "*.
 
 distArtifacts :=  ./public ./service/templates
 distContents := $(clientBinaries) $(distArtifacts)
-srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "./scripts/*" -not -path "*\#*")
+# srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "./scripts/*" -not -path "*\#*")
 testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
 currentHash := $(shell git rev-parse HEAD)
 agentVersion := $(shell grep "AgentVersion" config.go | tr -d '\tAgentVersion = ' | tr -d '"')

--- a/makefile
+++ b/makefile
@@ -63,7 +63,7 @@ uiFiles := $(shell find public/static -not -path "./public/static/app" -name "*.
 
 distArtifacts :=  ./public ./service/templates
 distContents := $(clientBinaries) $(distArtifacts)
-# srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "./scripts/*" -not -path "*\#*")
+srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "./scripts/*" -not -path "*\#*")
 testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
 currentHash := $(shell git rev-parse HEAD)
 agentVersion := $(shell grep "AgentVersion" config.go | tr -d '\tAgentVersion = ' | tr -d '"')

--- a/units/crons.go
+++ b/units/crons.go
@@ -1144,14 +1144,8 @@ func PopulateUserDataDoneJobs(env evergreen.Environment) amboy.QueueOperation {
 		catcher := grip.NewBasicCatcher()
 		ts := utility.RoundPartOfHour(1)
 		for _, h := range hosts {
-			// kim: TODO: verify that this will return duplicate scope errors
-			// when enqueued but the job is already in the queue.
-			catcher.Add(amboy.EnqueueUniqueJob(ctx, queue, NewUserDataDoneJob(env, h.Id, ts)))
+			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewUserDataDoneJob(env, h.Id, ts)), "host '%s'", h.Id)
 		}
-		grip.Info(message.WrapError(catcher.Resolve(), message.Fields{
-			"message":  "kim: got error when enqueueing job via cron job",
-			"job_type": userDataDoneJobName,
-		}))
 		return catcher.Resolve()
 	}
 }

--- a/units/crons_remote_fifteen_second.go
+++ b/units/crons_remote_fifteen_second.go
@@ -54,8 +54,6 @@ func (j *cronsRemoteFifteenSecondJob) Run(ctx context.Context) {
 		PopulateHostAllocatorJobs(j.env),
 		PopulateAgentDeployJobs(j.env),
 		PopulateAgentMonitorDeployJobs(j.env),
-		// kim: TODO: remove once tested.
-		PopulateUserDataDoneJobs(j.env),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/crons_remote_fifteen_second.go
+++ b/units/crons_remote_fifteen_second.go
@@ -54,6 +54,7 @@ func (j *cronsRemoteFifteenSecondJob) Run(ctx context.Context) {
 		PopulateHostAllocatorJobs(j.env),
 		PopulateAgentDeployJobs(j.env),
 		PopulateAgentMonitorDeployJobs(j.env),
+		// kim: TODO: remove once tested.
 		PopulateUserDataDoneJobs(j.env),
 	}
 

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -60,6 +60,8 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 		PopulateOldestImageRemovalJobs(),
 		PopulateParentDecommissionJobs(),
 		PopulatePeriodicNotificationJobs(1),
+		// kim: TODO: uncomment once tested.
+		// PopulateUserDataDoneJobs(j.env),
 	}
 
 	catcher := grip.NewBasicCatcher()

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -60,8 +60,7 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 		PopulateOldestImageRemovalJobs(),
 		PopulateParentDecommissionJobs(),
 		PopulatePeriodicNotificationJobs(1),
-		// kim: TODO: uncomment once tested.
-		// PopulateUserDataDoneJobs(j.env),
+		PopulateUserDataDoneJobs(j.env),
 	}
 
 	catcher := grip.NewBasicCatcher()

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -52,7 +52,9 @@ func makeUserDataDoneJob() *userDataDoneJob {
 }
 
 // NewUserDataDoneJob creates a job that checks if the host is done provisioning
-// with user data (if bootstrapped with user data).
+// with user data (if bootstrapped with user data). This check only applies to
+// spawn hosts, since hosts running agents check into the server to verify their
+// liveliness.
 func NewUserDataDoneJob(env evergreen.Environment, hostID string, ts time.Time) amboy.Job {
 	j := makeUserDataDoneJob()
 	j.HostID = hostID
@@ -70,12 +72,6 @@ func NewUserDataDoneJob(env evergreen.Environment, hostID string, ts time.Time) 
 }
 
 func (j *userDataDoneJob) Run(ctx context.Context) {
-	grip.Info(message.Fields{
-		"message":    "kim: executing user data done job",
-		"retry_info": j.RetryInfo(),
-		"job_id":     j.ID(),
-		"host_id":    j.HostID,
-	})
 	defer j.MarkComplete()
 
 	if err := j.populateIfUnset(); err != nil {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-13546

* Use scopes on user data done jobs that apply when the job is enqueued.
* Make the job retryable, enqueue it in the set-cloud-hosts-ready job (which is the provisioning step before the user-data-done job runs), and populate the job less often (because set-cloud-hosts-ready will most likely initiate the job).