### PR TITLE
EVG-13676 support expansions in module prefixes

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -565,7 +565,7 @@ func (a *Agent) endTaskResponse(tc *taskContext, status string, message string) 
 		description = tc.getCurrentCommand().DisplayName()
 		cmdType = tc.getCurrentCommand().Type()
 	}
-	return &apimodels.TaskEndDetail{
+	detail := &apimodels.TaskEndDetail{
 		Description:     description,
 		Type:            cmdType,
 		TimedOut:        tc.hadTimedOut(),
@@ -575,10 +575,11 @@ func (a *Agent) endTaskResponse(tc *taskContext, status string, message string) 
 		Status:          status,
 		Message:         message,
 		Logs:            tc.logs,
-		Modules: apimodels.ModuleCloneInfo{
-			Prefixes: tc.taskConfig.ModulePaths,
-		},
 	}
+	if tc.taskConfig != nil {
+		detail.Modules.Prefixes = tc.taskConfig.ModulePaths
+	}
+	return detail
 }
 
 func (a *Agent) runPostTaskCommands(ctx context.Context, tc *taskContext) {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -575,6 +575,9 @@ func (a *Agent) endTaskResponse(tc *taskContext, status string, message string) 
 		Status:          status,
 		Message:         message,
 		Logs:            tc.logs,
+		Modules: apimodels.ModuleCloneInfo{
+			Prefixes: tc.taskConfig.ModulePaths,
+		},
 	}
 }
 

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -486,7 +486,7 @@ func (c *gitFetchProject) executeLoop(ctx context.Context,
 			continue
 		}
 
-		moduleBase := filepath.ToSlash(filepath.Join(module.Prefix, module.Name))
+		moduleBase := filepath.ToSlash(filepath.Join(expandModulePrefix(conf, module.Name, module.Prefix, logger), module.Name))
 
 		var revision string
 		if conf.Task.Requester == evergreen.MergeTestRequester {
@@ -761,7 +761,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 				continue
 			}
 
-			dir = filepath.Join(c.Directory, module.Prefix, module.Name)
+			dir = filepath.Join(c.Directory, expandModulePrefix(conf, module.Name, module.Prefix, logger), module.Name)
 		}
 
 		if len(patchPart.PatchSet.Patch) == 0 {

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -105,7 +105,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 			logger.Execution().Errorf("No module found for %s", modulePatch.ModuleName)
 			continue
 		}
-		moduleBase := filepath.Join(module.Prefix, module.Name)
+		moduleBase := filepath.Join(expandModulePrefix(conf, module.Name, module.Prefix, logger), module.Name)
 
 		checkoutCommand = fmt.Sprintf("git checkout %s", module.Branch)
 		logger.Execution().Debugf("git checkout command: %s", checkoutCommand)

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -99,6 +99,7 @@ func (s *GitGetProjectSuite) SetupTest() {
 	s.taskConfig2, err = agentutil.MakeTaskConfigFromModelData(s.settings, s.modelData2)
 	s.Require().NoError(err)
 	s.taskConfig2.Expansions = util.NewExpansions(s.settings.Credentials)
+	s.taskConfig2.Expansions.Put("prefixpath", "hello")
 	//SetupAPITestData always creates BuildVariant with no modules so this line works around that
 	s.taskConfig2.BuildVariant.Modules = []string{"sample"}
 	s.modelData2.Task.Requester = evergreen.PatchVersionRequester
@@ -377,13 +378,14 @@ func (s *GitGetProjectSuite) TestValidateGitCommands() {
 		}
 	}
 	cmd := exec.Command("git", "rev-parse", "HEAD")
-	cmd.Dir = conf.WorkDir + "/src/module/sample/"
+	cmd.Dir = conf.WorkDir + "/src/hello/module/sample/"
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err = cmd.Run()
 	s.NoError(err)
 	ref := strings.Trim(out.String(), "\n") // revision that we actually checked out
 	s.Equal(refToCompare, ref)
+	s.Equal("hello/module", conf.ModulePaths["sample"])
 }
 
 func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
@@ -688,7 +690,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionSetModule() {
 	}
 
 	cmd := exec.Command("git", "rev-parse", "HEAD")
-	cmd.Dir = conf.WorkDir + "/src/module/sample/"
+	cmd.Dir = conf.WorkDir + "/src/hello/module/sample/"
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err = cmd.Run()
@@ -706,6 +708,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionSetModule() {
 		}
 	}
 	s.True(foundMsg)
+	s.Equal("hello/module", conf.ModulePaths["sample"])
 }
 
 func (s *GitGetProjectSuite) TestCorrectModuleRevisionManifest() {
@@ -731,7 +734,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionManifest() {
 	}
 
 	cmd := exec.Command("git", "rev-parse", "HEAD")
-	cmd.Dir = conf.WorkDir + "/src/module/sample/"
+	cmd.Dir = conf.WorkDir + "/src/hello/module/sample/"
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err = cmd.Run()
@@ -749,6 +752,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionManifest() {
 		}
 	}
 	s.True(foundMsg)
+	s.Equal("hello/module", conf.ModulePaths["sample"])
 }
 
 func (s *GitGetProjectSuite) TearDownSuite() {

--- a/agent/command/testdata/git/test_config.yml
+++ b/agent/command/testdata/git/test_config.yml
@@ -6,25 +6,25 @@ enabled: true
 batch_time: 180
 
 tasks:
-    - name: testtask1
-      commands:
-        - command: git.get_project
-          params:
-            directory: src
-            token: ${github}
+  - name: testtask1
+    commands:
+      - command: git.get_project
+        params:
+          directory: src
+          token: ${github}
 
 modules:
-- name: sample
-  repo: https://github.com/evergreen-ci/sample.git
-  ref: cf46076567e4949f9fc68e0634139d4ac495c89b
-  prefix: module
+  - name: sample
+    repo: https://github.com/evergreen-ci/sample.git
+    ref: cf46076567e4949f9fc68e0634139d4ac495c89b
+    prefix: ${prefixpath}/module
 
 buildvariants:
-- name: linux-64
-  display_name: Linux 64-bit
-  modules:
-    - sample
-  test_flags: --continue-on-failure
-  expansions:
-    blah: "blah"
-  push: true
+  - name: linux-64
+    display_name: Linux 64-bit
+    modules:
+      - sample
+    test_flags: --continue-on-failure
+    expansions:
+      blah: "blah"
+    push: true

--- a/agent/command/util.go
+++ b/agent/command/util.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/pkg/errors"
 )
 
@@ -39,4 +41,18 @@ func createEnclosingDirectoryIfNeeded(path string) error {
 	}
 
 	return nil
+}
+
+func expandModulePrefix(conf *internal.TaskConfig, module, prefix string, logger client.LoggerProducer) string {
+	modulePrefix, err := conf.Expansions.ExpandString(prefix)
+	if err != nil {
+		modulePrefix = prefix
+		logger.Task().Errorf("module prefix '%s' can't be expanded: %s", prefix, err.Error())
+		logger.Task().Warning("will attempt to check out into the module prefix verbatim")
+	}
+	if conf.ModulePaths == nil {
+		conf.ModulePaths = map[string]string{}
+	}
+	conf.ModulePaths[module] = modulePrefix
+	return modulePrefix
 }

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -29,6 +29,7 @@ type TaskConfig struct {
 	GithubPatchData      thirdparty.GithubPatch
 	Timeout              *Timeout
 	TaskSync             evergreen.S3Credentials
+	ModulePaths          map[string]string
 
 	mu sync.RWMutex
 }

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -34,8 +34,8 @@ type HeartbeatResponse struct {
 	Abort bool `json:"abort,omitempty"`
 }
 
-// TaskEndDetail contains data sent from the agent to the
-// API server after each task run.
+// TaskEndDetail contains data sent from the agent to the API server after each task run.
+// This should be used to store data relating to what happened when the task ran
 type TaskEndDetail struct {
 	Status          string          `bson:"status,omitempty" json:"status,omitempty"`
 	Message         string          `bson:"message,omitempty" json:"message,omitempty"`
@@ -46,6 +46,7 @@ type TaskEndDetail struct {
 	TimeoutDuration time.Duration   `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty"`
 	OOMTracker      *OOMTrackerInfo `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
 	Logs            *TaskLogs       `bson:"-" json:"logs,omitempty"`
+	Modules         ModuleCloneInfo `bson:"modules,omitempty" json:"modules,omitempty"`
 }
 
 type OOMTrackerInfo struct {
@@ -62,6 +63,10 @@ type TaskLogs struct {
 type LogInfo struct {
 	Command string `bson:"command" json:"command"`
 	URL     string `bson:"url" json:"url"`
+}
+
+type ModuleCloneInfo struct {
+	Prefixes map[string]string `bson:"prefixes,omitempty" json:"prefixes,omitempty"`
 }
 
 type TaskEndDetails struct {

--- a/config.go
+++ b/config.go
@@ -32,10 +32,10 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2021-04-27"
+	ClientVersion = "2021-04-28"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-04-27"
+	AgentVersion = "2021-04-28"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -295,7 +295,12 @@ func cloneSource(task *service.RestTask, project *model.ProjectRef, config *mode
 			}
 		}
 
-		moduleBase := filepath.Join(cloneDir, module.Prefix, module.Name)
+		modulePrefix := module.Prefix
+		if task.ModulePaths != nil && task.ModulePaths[module.Name] != "" {
+			modulePrefix = task.ModulePaths[module.Name]
+		}
+
+		moduleBase := filepath.Join(cloneDir, modulePrefix, module.Name)
 		fmt.Printf("Fetching module %v at %v\n", moduleName, module.Branch)
 		owner, repo, err := thirdparty.ParseGitUrl(module.Repo)
 		if err != nil {

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -54,6 +54,7 @@ type RestTask struct {
 	MinQueuePos         int                   `json:"min_queue_pos"`
 	PatchNumber         int                   `json:"patch_number,omitempty"`
 	PatchId             string                `json:"patch_id,omitempty"`
+	ModulePaths         map[string]string     `json:"module_paths,omitempty"`
 
 	// Artifacts and binaries
 	Files []taskFile `json:"files"`
@@ -122,6 +123,7 @@ func (restapi restAPI) getTaskInfo(w http.ResponseWriter, r *http.Request) {
 	destTask.Aborted = srcTask.Aborted
 	destTask.TimeTaken = srcTask.TimeTaken
 	destTask.ExpectedDuration = srcTask.ExpectedDuration
+	destTask.ModulePaths = srcTask.Details.Modules.Prefixes
 
 	var err error
 	destTask.MinQueuePos, err = model.FindMinimumQueuePositionForTask(destTask.Id)


### PR DESCRIPTION
- expand the module prefix string in git.get_project and git.push
- write the expanded string to the task end details
- modify the fetch CLI command to get the module prefix from the task end details if it's there