### PR TITLE
EVG-14357 lookup tagged commit with github API

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -337,14 +337,29 @@ func (gh *githubHookApi) handleGitTag(ctx context.Context, event *github.PushEve
 		}))
 		return err
 	}
-
+	token, err := gh.settings.GetGithubOauthToken()
+	if err != nil {
+		return errors.New("error getting github token")
+	}
 	pusher := event.GetPusher().GetName()
 	tag := model.GitTag{
 		Tag:    strings.TrimPrefix(event.GetRef(), refTags),
 		Pusher: pusher,
 	}
 	ownerAndRepo := strings.Split(event.Repo.GetFullName(), "/")
-	hash := event.HeadCommit.GetID()
+	hash, err := thirdparty.GetTaggedCommitFromGithub(ctx, token, ownerAndRepo[0], ownerAndRepo[1], tag.Tag)
+	if err != nil {
+		grip.Debug(message.WrapError(err, message.Fields{
+			"source":  "github hook",
+			"message": "error getting tagged commit from github",
+			"ref":     event.GetRef(),
+			"event":   gh.eventType,
+			"owner":   ownerAndRepo[0],
+			"repo":    ownerAndRepo[1],
+			"tag":     tag,
+		}))
+		return errors.Wrapf(err, "error getting commit for tag '%s'", tag.Tag)
+	}
 
 	projectRefs, err := gh.sc.FindEnabledProjectRefsByOwnerAndRepo(ownerAndRepo[0], ownerAndRepo[1])
 	if err != nil {
@@ -424,7 +439,7 @@ func (gh *githubHookApi) handleGitTag(ctx context.Context, event *github.PushEve
 					RevisionMessage: existingVersion.Message,
 				}
 				var v *model.Version
-				v, err = gh.createVersionForTag(ctx, pRef, existingVersion, revision, tag)
+				v, err = gh.createVersionForTag(ctx, pRef, existingVersion, revision, tag, token)
 				if err != nil {
 					catcher.Wrapf(err, "error adding new version for tag '%s'", tag.Tag)
 					continue
@@ -461,11 +476,7 @@ func (gh *githubHookApi) handleGitTag(ctx context.Context, event *github.PushEve
 }
 
 func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.ProjectRef, existingVersion *model.Version,
-	revision model.Revision, tag model.GitTag) (*model.Version, error) {
-	token, err := gh.settings.GetGithubOauthToken()
-	if err != nil {
-		return nil, errors.New("error getting github token")
-	}
+	revision model.Revision, tag model.GitTag, token string) (*model.Version, error) {
 	if !pRef.IsGitTagVersionsEnabled() {
 		return nil, nil
 	}
@@ -482,9 +493,8 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 		})
 		return nil, nil
 	}
-	var hasAliases bool
-	var remotePath string
-	hasAliases, remotePath, err = gh.sc.HasMatchingGitTagAliasAndRemotePath(pRef.Id, tag.Tag)
+
+	hasAliases, remotePath, err := gh.sc.HasMatchingGitTagAliasAndRemotePath(pRef.Id, tag.Tag)
 	if err != nil {
 		return nil, err
 	}
@@ -537,6 +547,9 @@ func validatePushTagEvent(event *github.PushEvent) error {
 
 	if event.GetPusher().GetName() == "" {
 		return errors.New("Github pusher missing login name")
+	}
+	if !event.GetCreated() {
+		return errors.New("not a tag creation event")
 	}
 	return nil
 }

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -319,8 +319,7 @@ func (s *GithubWebhookRouteSuite) TestTryDequeueCommitQueueItemForPR() {
 
 func (s *GithubWebhookRouteSuite) TestCreateVersionForTag() {
 	s.NoError(db.ClearCollections(model.ProjectRefCollection, model.VersionCollection))
-	//createVersionForTag(ctx context.Context, pRef model.ProjectRef, existingVersion *model.Version,
-	//revision model.Revision, tag model.GitTag)
+
 	tag := model.GitTag{
 		Tag:    "release",
 		Pusher: "release-bot",
@@ -337,7 +336,7 @@ func (s *GithubWebhookRouteSuite) TestCreateVersionForTag() {
 		GitTagAuthorizedUsers: []string{"release-bot", "not-release-bot"},
 		GitTagVersionsEnabled: utility.TruePtr(),
 	}
-	v, err := s.h.createVersionForTag(context.Background(), pRef, nil, model.Revision{}, tag)
+	v, err := s.h.createVersionForTag(context.Background(), pRef, nil, model.Revision{}, tag, "")
 	s.NoError(err)
 	s.NotNil(v)
 }


### PR DESCRIPTION
The webhook information we get from Github is inconsistent; sometimes HeadCommit doesn't exist, sometimes it contains the wrong hash, etc. There's an API call that will get us tag information just using the tag name, but the library doesn't have a method for it so I'm calling it directly.
Tested this by pushing a lightweight tag and an annotated tag on staging, and verifying that a version was created from the right commit.