### PR TITLE
EVG-13548: apply scopes on enqueue and retry in create host job

### DIFF
--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -217,7 +217,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 	}
 
 	defer func() {
-		if j.HasErrors() && (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) && j.host.SpawnOptions.SpawnedByTask {
+		if j.RetryInfo().GetRemainingAttempts() == 0 && j.HasErrors() && (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) && j.host.SpawnOptions.SpawnedByTask {
 			if err := task.AddHostCreateDetails(j.host.StartedBy, j.host.Id, j.Error()); err != nil {
 				j.AddError(errors.Wrapf(err, "error adding host create error details"))
 			}

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -324,6 +324,9 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 			return errors.Wrap(err, "problem building container image")
 		}
 		if !ready {
+			j.UpdateRetryInfo(amboy.JobRetryOptions{
+				NeedsRetry: utility.TruePtr(),
+			})
 			return nil
 		}
 	}

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -217,7 +217,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 	}
 
 	defer func() {
-		if (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) && j.host.SpawnOptions.SpawnedByTask {
+		if j.HasErrors() && (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) && j.host.SpawnOptions.SpawnedByTask {
 			if err := task.AddHostCreateDetails(j.host.StartedBy, j.host.Id, j.Error()); err != nil {
 				j.AddError(errors.Wrapf(err, "error adding host create error details"))
 			}

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -33,11 +33,8 @@ func init() {
 }
 
 type createHostJob struct {
-	HostID string `bson:"host_id" json:"host_id" yaml:"host_id"`
-	// kim; TODO: delete
-	// CurrentAttempt    int    `bson:"current_attempt" json:"current_attempt" yaml:"current_attempt"`
-	// MaxAttempts    int    `bson:"max_attempts" json:"max_attempts" yaml:"max_attempts"`
-	BuildImageStarted bool `bson:"build_image_started" json:"build_image_started" yaml:"build_image_started"`
+	HostID            string `bson:"host_id" json:"host_id" yaml:"host_id"`
+	BuildImageStarted bool   `bson:"build_image_started" json:"build_image_started" yaml:"build_image_started"`
 	job.Base          `bson:"metadata" json:"metadata" yaml:"metadata"`
 
 	start time.Time
@@ -70,11 +67,8 @@ func NewHostCreateJob(env evergreen.Environment, h host.Host, id string, current
 	j.SetShouldApplyScopesOnEnqueue(true)
 	j.BuildImageStarted = buildImageStarted
 	j.UpdateTimeInfo(amboy.JobTimeInfo{
-		MaxTime: j.host.SpawnOptions.TimeoutSetup.Sub(time.Now()),
+		DispatchBy: j.host.SpawnOptions.TimeoutSetup,
 	})
-	// kim: TODO: delete
-	// j.CurrentAttempt = currentAttempt
-	// j.MaxAttempts = j.host.SpawnOptions.Retries
 	var wait time.Duration
 	var maxAttempts int
 	if h.ParentID != "" {
@@ -128,8 +122,6 @@ func (j *createHostJob) Run(ctx context.Context) {
 			grip.Warning(message.Fields{
 				"host_id": j.HostID,
 				"task_id": j.TaskID,
-				// kim: TODO: delete
-				// "attempt": j.CurrentAttempt,
 				"attempt": j.RetryInfo().CurrentAttempt,
 				"job":     j.ID(),
 				"message": "could not find host",
@@ -158,9 +150,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 		removeHostIntent := false
 		if numHosts > j.host.Distro.HostAllocatorSettings.MaximumHosts {
 			grip.Info(message.Fields{
-				"host_id": j.HostID,
-				// kim: TODO: delete
-				// "attempt":   j.CurrentAttempt,
+				"host_id":   j.HostID,
 				"attempt":   j.RetryInfo().CurrentAttempt,
 				"distro":    j.host.Distro.Id,
 				"job":       j.ID(),
@@ -182,9 +172,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 		if allRunningDynamicHosts > j.env.Settings().HostInit.MaxTotalDynamicHosts && !lowHostNumException {
 
 			grip.Info(message.Fields{
-				"host_id": j.HostID,
-				// kim: TODO: delete
-				// "attempt":                 j.CurrentAttempt,
+				"host_id":                 j.HostID,
 				"attempt":                 j.RetryInfo().CurrentAttempt,
 				"distro":                  j.host.Distro.Id,
 				"job":                     j.ID(),
@@ -202,9 +190,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 
 			j.AddError(err)
 			grip.Error(message.WrapError(err, message.Fields{
-				"host_id": j.HostID,
-				// kim: TODO: delete
-				// "attempt":  j.CurrentAttempt,
+				"host_id":  j.HostID,
 				"attempt":  j.RetryInfo().CurrentAttempt,
 				"distro":   j.host.Distro.Id,
 				"job":      j.ID(),
@@ -218,9 +204,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 
 		if j.selfThrottle() {
 			grip.Debug(message.Fields{
-				"host_id": j.HostID,
-				// kim: TODO: delete
-				// "attempt":  j.CurrentAttempt,
+				"host_id":  j.HostID,
 				"attempt":  j.RetryInfo().CurrentAttempt,
 				"distro":   j.host.Distro.Id,
 				"job":      j.ID(),
@@ -233,22 +217,13 @@ func (j *createHostJob) Run(ctx context.Context) {
 	}
 
 	defer func() {
-		if j.RetryInfo().CurrentAttempt+1 >= j.RetryInfo().GetMaxAttempts() &&
-			(j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) &&
-			j.host.SpawnOptions.SpawnedByTask {
+		if (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) && j.host.SpawnOptions.SpawnedByTask {
 			if err := task.AddHostCreateDetails(j.host.StartedBy, j.host.Id, j.Error()); err != nil {
 				j.AddError(errors.Wrapf(err, "error adding host create error details"))
 			}
 		}
 	}()
-	// kim: TODO: delete and do this during initialization.
-	// if j.TimeInfo().MaxTime == 0 && !j.host.SpawnOptions.TimeoutSetup.IsZero() {
-	//     j.UpdateTimeInfo(amboy.JobTimeInfo{
-	//         MaxTime: j.host.SpawnOptions.TimeoutSetup.Sub(j.start),
-	//     })
-	// }
-	// kim: TODO: delete
-	// j.AddError(j.createHost(ctx))
+
 	j.AddRetryableError(j.createHost(ctx))
 }
 
@@ -304,8 +279,6 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		"job":          j.ID(),
 		"attempt":      j.RetryInfo().CurrentAttempt,
 		"max_attempts": j.RetryInfo().MaxAttempts,
-		// kim: TODO: delete,
-		// "max_attempts": j.MaxAttempts,
 	})
 
 	mgrOpts, err := cloud.GetManagerOptions(j.host.Distro)
@@ -341,16 +314,11 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		return nil
 	}
 
-	// kim; TODO: delete and replace j.AddError with j.AddRetryableError.
-	// defer j.tryRequeue(ctx)
-
 	// Containers should wait on image builds, checking to see if the parent
 	// already has the image. If it does not, it should download it and wait
 	// on the job until it is finished downloading.
 	if j.host.ParentID != "" {
 		var ready bool
-		// kim: TODO: delete and set during initialization
-		// j.MaxAttempts = maxPollAttempts
 		ready, err = j.isImageBuilt(ctx)
 		if err != nil {
 			return errors.Wrap(err, "problem building container image")
@@ -456,52 +424,6 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	return nil
 }
 
-// kim: TODO: delete
-// func (j *createHostJob) tryRequeue(ctx context.Context) {
-//     if j.shouldRetryCreateHost(ctx) && j.env.RemoteQueue().Info().Started {
-//         // job := NewHostCreateJob(j.env, *j.host, fmt.Sprintf("attempt-%d", j.CurrentAttempt+1), j.CurrentAttempt+1, j.BuildImageStarted)
-//         job := NewHostCreateJob(j.env, *j.host, fmt.Sprintf("attempt-%d", j.CurrentAttempt+1), j.CurrentAttempt+1, j.BuildImageStarted)
-//         wait := time.Minute
-//         if j.host.ParentID != "" {
-//             wait = 10 * time.Second
-//         }
-//         maxTime := j.TimeInfo().MaxTime - (time.Since(j.start)) - time.Minute
-//         if maxTime < 0 {
-//             maxTime = 0
-//         }
-//         job.UpdateTimeInfo(amboy.JobTimeInfo{
-//             WaitUntil: j.start.Add(wait),
-//             MaxTime:   maxTime,
-//         })
-//         err := j.env.RemoteQueue().Put(ctx, job)
-//         grip.Error(message.WrapError(err, message.Fields{
-//             "message": "failed to requeue setup job",
-//             "host_id": j.host.Id,
-//             "job":     j.ID(),
-//             "distro":  j.host.Distro.Id,
-//             // kim: TODO: delete
-//             // "attempts": j.CurrentAttempt,
-//             "attempts": j.RetryInfo().CurrentAttempt,
-//         }))
-//         j.AddError(err)
-//     } else if j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding {
-//         if j.host.SpawnOptions.SpawnedByTask {
-//             if err := task.AddHostCreateDetails(j.host.StartedBy, j.host.Id, j.Error()); err != nil {
-//                 j.AddError(errors.Wrapf(err, "error adding host create error details"))
-//             }
-//         }
-//     }
-// }
-
-// kim: TODO: delete
-// func (j *createHostJob) shouldRetryCreateHost(ctx context.Context) bool {
-//     return j.RetryInfo().CurrentAttempt < j.RetryInfo().GetMaxAttempts() &&
-//         (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding)
-//     // return j.CurrentAttempt < j.MaxAttempts &&
-//     //     (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) &&
-//     //     ctx.Err() == nil
-// }
-
 func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 	parent, err := j.host.GetParent()
 	if err != nil {
@@ -521,11 +443,9 @@ func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 	}
 	if ok := parent.ContainerImages[j.host.DockerOptions.Image]; ok {
 		grip.Info(message.Fields{
-			"message": "image already exists, will start container",
-			"host_id": j.host.Id,
-			"image":   j.host.DockerOptions.Image,
-			// kim: TODO: delete
-			// "attempts": j.CurrentAttempt,
+			"message":  "image already exists, will start container",
+			"host_id":  j.host.Id,
+			"image":    j.host.DockerOptions.Image,
 			"attempts": j.RetryInfo().CurrentAttempt,
 			"job":      j.ID(),
 		})
@@ -535,11 +455,9 @@ func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 	//  If the image is not already present on the parent, run job to build the new image
 	if !j.BuildImageStarted {
 		grip.Info(message.Fields{
-			"message": "image not on host, will import image",
-			"host_id": j.host.Id,
-			"image":   j.host.DockerOptions.Image,
-			// kim: TODO: delete
-			// "attempts": j.CurrentAttempt,
+			"message":  "image not on host, will import image",
+			"host_id":  j.host.Id,
+			"image":    j.host.DockerOptions.Image,
 			"attempts": j.RetryInfo().CurrentAttempt,
 			"job":      j.ID(),
 		})


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-13548

* Apply scopes on enqueue and use built-in retries for create host job instead of relying on custom logic.
    * I changed how MaxTime works so it no longer does this weird math that [sets MaxTime and subtracts a minute](https://github.com/evergreen-ci/evergreen/compare/main...Kimchelly:EVG-13548_create_host_scope_on_enqueue?expand=1#diff-6b133b12148c168c83fab4e96d489178b67f63cf8122f991429464d0c8a331c8L419), but I don't think it's consequential to remove this because it hasn't caused any issues up to now and MaxTime didn't work until recently anyways.
* Add host create errors whenever the job errors rather than when the job fails to re-enqueue. @ablack12 I don't know if populating errors every time the job errors will cause any issues with host.list, so let me know if adding host create details like this is not what it should do.