### PR TITLE
EVG-13552: set scope and retries in spawn host task data setup script job

### DIFF
--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -536,7 +536,7 @@ func (j *setupHostJob) provisionHost(ctx context.Context, settings *evergreen.Se
 		}
 		if j.host.ProvisionOptions != nil && j.host.ProvisionOptions.SetupScript != "" {
 			// Don't wait on setup script to finish, particularly for hosts waiting on task data.
-			j.AddError(j.env.RemoteQueue().Put(ctx, NewHostSetupScriptJob(j.env, j.host, 0)))
+			j.AddError(j.env.RemoteQueue().Put(ctx, NewHostSetupScriptJob(j.env, j.host)))
 		}
 	}
 

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -135,7 +135,7 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 	if j.host.ProvisionOptions != nil && j.host.ProvisionOptions.SetupScript != "" {
 		// Run the spawn host setup script in a separate job to avoid forcing
 		// this job to wait for task data to be loaded.
-		j.AddError(j.env.RemoteQueue().Put(ctx, NewHostSetupScriptJob(j.env, j.host, 0)))
+		j.AddError(j.env.RemoteQueue().Put(ctx, NewHostSetupScriptJob(j.env, j.host)))
 	}
 
 	j.finishJob()


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-13552

* Use scopes and retries in job that runs a script after task data has been fetched on a host.
* Remove custom retry logic.