### PR TITLE
EVG-14465-2 add logging to check blocked tasks job

### DIFF
--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -538,7 +538,7 @@ func TestFindDistroTaskQueue(t *testing.T) {
 		},
 	}
 	taskQueueItems := []TaskQueueItem{
-		{Id: "a"},
+		{Id: "a", Dependencies: []string{"b"}},
 		{Id: "b"},
 		{Id: "c"},
 		{Id: "d"},
@@ -556,6 +556,7 @@ func TestFindDistroTaskQueue(t *testing.T) {
 	assert.Equal(distroID, taskQueueOut.Distro)
 	assert.Len(taskQueueOut.Queue, 8)
 	assert.Equal(taskQueueOut.DistroQueueInfo.Length, 8)
+	assert.Len(taskQueueOut.Queue[0].Dependencies, 1)
 	assert.Len(taskQueueOut.DistroQueueInfo.TaskGroupInfos, 1)
 	assert.Equal(taskQueueOut.DistroQueueInfo.TaskGroupInfos[0].Name, "taskGroupInfo1")
 	assert.Equal(taskQueueOut.DistroQueueInfo.TaskGroupInfos[0].Count, 8)

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -66,7 +66,10 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 		j.AddError(errors.Wrapf(err, "error getting alias task queue for distro '%s'", j.DistroId))
 	}
 	taskIds := []string{}
+	lenQueue := -1
+	lenAliasQueue := -1
 	if queue != nil {
+		lenQueue = len(queue.Queue)
 		for _, item := range queue.Queue {
 			if !item.IsDispatched && len(item.Dependencies) > 0 {
 				taskIds = append(taskIds, item.Id)
@@ -75,6 +78,7 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 	}
 
 	if aliasQueue != nil {
+		lenAliasQueue = len(aliasQueue.Queue)
 		for _, item := range aliasQueue.Queue {
 			if !item.IsDispatched && len(item.Dependencies) > 0 {
 				taskIds = append(taskIds, item.Id)
@@ -83,6 +87,14 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 	}
 
 	if len(taskIds) == 0 {
+		grip.Debug(message.Fields{
+			"message":         "no task IDs found for distro",
+			"len_queue":       lenQueue,
+			"len_alias_queue": lenAliasQueue,
+			"distro":          j.DistroId,
+			"job":             j.ID(),
+			"source":          checkBlockedTasks,
+		})
 		return
 	}
 
@@ -93,20 +105,39 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 	}
 
 	dependencyCache := map[string]task.Task{}
+	numTasksModified := 0
+	numChecksThatUpdatedTasks := 0
 	for _, t := range tasksToCheck {
-		j.AddError(checkUnmarkedBlockingTasks(&t, dependencyCache))
+		numModified, err := checkUnmarkedBlockingTasks(&t, dependencyCache)
+		j.AddError(err)
+		numTasksModified += numModified
+		if numTasksModified > 0 {
+			numChecksThatUpdatedTasks += 1
+		}
 	}
+	grip.Debug(message.Fields{
+		"message":             "finished check blocked tasks job",
+		"len_queue":           lenQueue,
+		"len_alias_queue":     lenAliasQueue,
+		"len_tasks":           len(tasksToCheck),
+		"len_task_ids":        len(taskIds),
+		"task_ids":            taskIds,
+		"num_tasks_modified":  numTasksModified,
+		"num_updating_checks": numChecksThatUpdatedTasks,
+		"job":                 j.ID(),
+		"source":              checkBlockedTasks,
+	})
 }
 
-func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.Task) error {
+func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.Task) (int, error) {
 	catcher := grip.NewBasicCatcher()
 
 	dependenciesMet, err := t.DependenciesMet(dependencyCaches)
 	if err != nil {
-		return errors.Wrapf(err, "error checking if dependencies met for task '%s'", t.Id)
+		return 0, errors.Wrapf(err, "error checking if dependencies met for task '%s'", t.Id)
 	}
 	if dependenciesMet {
-		return nil
+		return 0, nil
 	}
 
 	blockingTasks, err := t.RefreshBlockedDependencies(dependencyCaches)
@@ -137,12 +168,13 @@ func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.T
 		}
 	}
 
-	grip.DebugWhen(len(blockingTasks)+len(blockingDeactivatedTasks) > 0, message.Fields{
+	numModified := len(blockingTasks) + len(blockingDeactivatedTasks)
+	grip.DebugWhen(numModified > 0, message.Fields{
 		"message":                            "checked unmarked blocking tasks",
 		"blocking_tasks_updated":             len(blockingTasks),
 		"blocking_deactivated_tasks_updated": len(blockingDeactivatedTasks),
 		"exec_task":                          t.IsPartOfDisplay(),
 		"source":                             checkBlockedTasks,
 	})
-	return catcher.Resolve()
+	return numModified, catcher.Resolve()
 }

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -112,7 +112,7 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 		j.AddError(err)
 		numTasksModified += numModified
 		if numTasksModified > 0 {
-			numChecksThatUpdatedTasks += 1
+			numChecksThatUpdatedTasks++
 		}
 	}
 	grip.Debug(message.Fields{
@@ -126,6 +126,7 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 		"num_updating_checks": numChecksThatUpdatedTasks,
 		"job":                 j.ID(),
 		"source":              checkBlockedTasks,
+		"distro":              j.DistroId,
 	})
 }
 


### PR DESCRIPTION
So, this job isn't doing anything right now (it's taking absolutely [no time to execute](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20%22job_type%22%3D%22check_blocked_tasks%22%20%7C%20timechart%20avg(dispatch_secs)%20span%3D15m&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-14d%40d&latest=now&workload_pool=standard_perf&display.page.search.tab=visualizations&display.general.type=visualizations&sid=1619801084.270734) relative to when the job was initially introduced) but I have no idea why really. The function itself is the same as it [was when it was introduced](https://github.com/evergreen-ci/evergreen/commit/18b8936a5109dfce40df16829fa00fd85f919b02), and similar to how it worked in the original function, and similar to how RefreshFindNextTask works, we're iterating through every item, and if it's not dispatched and has dependencies that aren't met, then we call checkUnmarkedBlocking tasks. I think we aren't coming out of that without any IDs though and I'm not sure why, so I'm adding logging to get more information (unless someone else sees something I'm missing!)

Unfortunately I don't think we can default to re-adding this back into the scheduler, bc now that so many tasks aren't marked FindNextTask would take a really long time.