### PR TITLE
EVG-14665 mark deactivated if dependency is blocked

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -578,7 +578,7 @@ func (t *Task) RefreshBlockedDependencies(depCache map[string]Task) ([]Task, err
 	return blockedDeps, nil
 }
 
-func (t *Task) BlockedOnDeactivatedDependency(depCache map[string]Task) ([]string, error) {
+func (t *Task) BlockedOnDeactivatedOrBlockedDependency(depCache map[string]Task) ([]string, error) {
 	_, err := t.populateDependencyTaskCache(depCache)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -598,7 +598,7 @@ func (t *Task) BlockedOnDeactivatedDependency(depCache map[string]Task) ([]strin
 			depTask = *foundTask
 			depCache[depTask.Id] = depTask
 		}
-		if !depTask.IsFinished() && !depTask.Activated {
+		if !depTask.IsFinished() && (!depTask.Activated || depTask.Blocked()) {
 			blockingDeps = append(blockingDeps, depTask.Id)
 		}
 	}

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -466,13 +466,15 @@ type APISyncAtEndOptions struct {
 }
 
 type APIDependency struct {
-	TaskId string `bson:"_id" json:"id"`
-	Status string `bson:"status" json:"status"`
+	TaskId       string `bson:"_id" json:"id"`
+	Status       string `bson:"status" json:"status"`
+	Unattainable bool   `bson:"unattainable" json:"unattainable"`
 }
 
 func (ad *APIDependency) BuildFromService(dep task.Dependency) {
 	ad.TaskId = dep.TaskId
 	ad.Status = dep.Status
+	ad.Unattainable = dep.Unattainable
 }
 
 func (ad *APIDependency) ToService() (interface{}, error) {

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -149,7 +149,7 @@ func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.T
 		}
 	}
 
-	blockingDeactivatedTasks, err := t.BlockedOnDeactivatedDependency(dependencyCaches)
+	blockingDeactivatedTasks, err := t.BlockedOnDeactivatedOrBlockedDependency(dependencyCaches)
 	catcher.Add(errors.Wrap(err, "can't get blocked status"))
 	if err == nil && len(blockingDeactivatedTasks) > 0 {
 		var deactivatedDependencies []task.Task

--- a/units/check_blocked_tasks_test.go
+++ b/units/check_blocked_tasks_test.go
@@ -1,0 +1,102 @@
+package units
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckUnmarkedBlockingTasksWithDeactivatedTask(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(task.Collection, build.Collection))
+	t1 := &task.Task{
+		Id:        "t1",
+		BuildId:   "b1",
+		Activated: true,
+		DependsOn: []task.Dependency{
+			{
+				TaskId: "t2",
+				Status: evergreen.TaskSucceeded,
+			},
+		},
+	}
+	t2 := &task.Task{
+		Id:        "t2",
+		BuildId:   "b1",
+		Status:    evergreen.TaskUndispatched,
+		Activated: false,
+	}
+	b1 := build.Build{
+		Id: "b1",
+	}
+	assert.NoError(t, t1.Insert())
+	assert.NoError(t, t2.Insert())
+	assert.NoError(t, b1.Insert())
+	depCache := map[string]task.Task{}
+	modified, err := checkUnmarkedBlockingTasks(t1, depCache)
+	assert.NoError(t, err)
+	assert.Equal(t, modified, 1)
+	t1FromDb, err := task.FindOneId("t1")
+	assert.NoError(t, err)
+	assert.NotNil(t, t1FromDb)
+	assert.False(t, t1FromDb.Activated)
+}
+
+func TestCheckUnmarkedBlockingTasksWithBlockedTask(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(task.Collection, build.Collection))
+	t1 := &task.Task{
+		Id:        "t1",
+		BuildId:   "b1",
+		Activated: true,
+		DependsOn: []task.Dependency{
+			{
+				TaskId:       "t2",
+				Status:       evergreen.TaskSucceeded,
+				Unattainable: false,
+			},
+		},
+	}
+	t2 := &task.Task{
+		Id:        "t2",
+		BuildId:   "b1",
+		Activated: true,
+		Status:    evergreen.TaskUndispatched,
+		DependsOn: []task.Dependency{
+			{
+				TaskId:       "t3",
+				Status:       evergreen.TaskSucceeded,
+				Unattainable: true,
+			},
+		},
+	}
+	t3 := &task.Task{
+		Id:        "t3",
+		Status:    evergreen.TaskFailed,
+		Activated: true,
+	}
+	b1 := build.Build{
+		Id: "b1",
+		Tasks: []build.TaskCache{
+			{Id: "t1"},
+			{Id: "t2"},
+			{Id: "t3"},
+		},
+	}
+	assert.NoError(t, t1.Insert())
+	assert.NoError(t, t2.Insert())
+	assert.NoError(t, t3.Insert())
+	assert.NoError(t, b1.Insert())
+	depCache := map[string]task.Task{}
+
+	modified, err := checkUnmarkedBlockingTasks(t1, depCache)
+	assert.NoError(t, err)
+	assert.Equal(t, modified, 2)
+
+	t1FromDb, err := task.FindOneId("t1")
+	assert.NoError(t, err)
+	assert.NotNil(t, t1FromDb)
+	assert.False(t, t1FromDb.Activated)
+}


### PR DESCRIPTION
Another change I'd like to propose, although we could wait until we see the results of the logging to know if it's necessary.

The test TestCheckUnmarkedBlockingTasksWithBlockedTask is currently the state of a lot of tasks in our queue: 
**t1 (activated) depends on t2 (activated, blocked) depends on t3 (activated, failed).**
Only t1 will be on the queue. I'm not sure how we currently know to not put t2 on the queue at all, except that maybe since it's obviously blocked it's fine.

I'm also not sure how we got into a state that can't be solved by our existing job. My theory is that the order that the with-dependencies-scheduler would correctly mark t2 as deactivated, such that t1 would also be deactivated, or that we deleted a job during the outage that should've handled this, and now things are in a weird state.

Even though we didn't before and theoretically shouldn't need to, I don't see why this change would cause any problems; if a task is blocked on a blocked task, then it maybe makes sense to deactivate (unless we're meant to leave it activated in case it unblocks? but then I imagine t1 would also still be on the queue).

Sorry for the text wall!