### PR TITLE
EVG-14369: use scope for host termination job

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -105,7 +105,7 @@ func ModifyHostStatus(ctx context.Context, env evergreen.Environment, queue ambo
 			return "", http.StatusInternalServerError, errors.New(HostTerminationQueueingError)
 		}
 
-		if err := queue.Put(ctx, units.NewHostTerminationJob(env, h, true, fmt.Sprintf("terminated by %s", u.Username()))); err != nil {
+		if err := amboy.EnqueueUniqueJob(ctx, queue, units.NewHostTerminationJob(env, h, true, fmt.Sprintf("terminated by %s", u.Username()))); err != nil {
 			return "", http.StatusInternalServerError, errors.New(HostTerminationQueueingError)
 		}
 		return fmt.Sprintf(HostTerminationQueueingSuccess, h.Id), http.StatusOK, nil

--- a/units/crons.go
+++ b/units/crons.go
@@ -205,7 +205,7 @@ func PopulateHostTerminationJobs(env evergreen.Environment) amboy.QueueOperation
 				})
 				continue
 			}
-			catcher.Add(queue.Put(ctx, NewHostTerminationJob(env, &h, true, "host is expired, decommissioned, or failed to provision")))
+			catcher.Add(amboy.EnqueueUniqueJob(ctx, queue, NewHostTerminationJob(env, &h, true, "host is expired, decommissioned, or failed to provision")))
 		}
 
 		hosts, err = host.AllHostsSpawnedByTasksToTerminate()
@@ -216,8 +216,8 @@ func PopulateHostTerminationJobs(env evergreen.Environment) amboy.QueueOperation
 		}))
 		catcher.Add(err)
 
-		for idx := range hosts {
-			catcher.Add(queue.Put(ctx, NewHostTerminationJob(env, &hosts[idx], true, "host spawned by task has gone out of scope")))
+		for _, h := range hosts {
+			catcher.Add(amboy.EnqueueUniqueJob(ctx, queue, NewHostTerminationJob(env, &h, true, "host spawned by task has gone out of scope")))
 		}
 
 		return catcher.Resolve()

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -231,7 +231,7 @@ func (j *idleHostJob) checkAndTerminateHost(ctx context.Context, h *host.Host) e
 	if terminateReason != "" {
 		j.Terminated++
 		j.TerminatedHosts = append(j.TerminatedHosts, h.Id)
-		return j.env.RemoteQueue().Put(ctx, NewHostTerminationJob(j.env, h, false, terminateReason))
+		return amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), NewHostTerminationJob(j.env, h, false, terminateReason))
 	}
 	return nil
 }

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -169,7 +169,7 @@ func (j *cloudHostReadyJob) terminateUnknownHosts(ctx context.Context, awsErr st
 		if h == nil {
 			continue
 		}
-		catcher.Add(j.env.RemoteQueue().Put(ctx, NewHostTerminationJob(j.env, h, true, "instance ID not found")))
+		catcher.Add(amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), NewHostTerminationJob(j.env, h, true, "instance ID not found")))
 	}
 	return catcher.Resolve()
 }

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -62,7 +62,9 @@ func NewHostTerminationJob(env evergreen.Environment, h *host.Host, terminateIfB
 	j.Reason = reason
 	j.SetPriority(2)
 	ts := utility.RoundPartOfHour(2).Format(TSFormat)
-	j.SetID(fmt.Sprintf("%s.%s.%s", hostTerminationJobName, j.HostID, ts))
+	j.SetID(fmt.Sprintf("%s.%s.%s", hostTerminationJobName, h.Id, ts))
+	j.SetScopes([]string{"%s.%s", hostTerminationJobName, h.Id})
+	j.SetShouldApplyScopesOnEnqueue(true)
 
 	return j
 }

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -118,7 +118,7 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 
 			terminateJob := NewHostTerminationJob(j.env, j.host, true, "failed to mount volume")
 			terminateJob.SetPriority(100)
-			j.AddError(j.env.RemoteQueue().Put(ctx, terminateJob))
+			j.AddError(amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), terminateJob))
 
 			return
 		}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14369

* Use scope for host termination job.
* Ignore duplicate job/job scope errors in all places where it's enqueued.