### PR TITLE
EVG-13888: add scope and retries to generate tasks job

### DIFF
--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -200,7 +200,7 @@ func TestGenerateTasks(t *testing.T) {
 	projectRef := model.ProjectRef{Id: "mci", Identifier: "mci_identifier"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob("sample_task", "1")
+	j := NewGenerateTasksJob(sampleTask)
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 	tasks := []task.Task{}
@@ -356,7 +356,7 @@ buildvariants:
 	projectRef := model.ProjectRef{Id: "mci"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob("generator", "1")
+	j := NewGenerateTasksJob(sampleTask)
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 
@@ -386,7 +386,7 @@ func TestMarkGeneratedTasksError(t *testing.T) {
 	}
 	require.NoError(t, sampleTask.Insert())
 
-	j := NewGenerateTasksJob(sampleTask.Id, "1")
+	j := NewGenerateTasksJob(sampleTask)
 	j.Run(context.Background())
 	assert.Error(t, j.Error())
 	dbTask, err := task.FindOneId(sampleTask.Id)


### PR DESCRIPTION
The logic for this is mostly pulled from #4336.

* Add scope to generate tasks using version ID to serialize generate task jobs within a version.
* Move the job from the queue group to the regular queue.