### PR TITLE
EVG-14665 get entire distro queue from DB for job

### DIFF
--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -57,11 +57,11 @@ func NewCheckBlockedTasksJob(distroId string, ts time.Time) amboy.Job {
 }
 
 func (j *checkBlockedTasksJob) Run(ctx context.Context) {
-	queue, err := model.LoadTaskQueue(j.DistroId)
+	queue, err := model.FindDistroTaskQueue(j.DistroId)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "error getting task queue for distro '%s'", j.DistroId))
 	}
-	aliasQueue, err := model.LoadDistroAliasTaskQueue(j.DistroId)
+	aliasQueue, err := model.FindDistroAliasTaskQueue(j.DistroId)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "error getting alias task queue for distro '%s'", j.DistroId))
 	}

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -66,23 +66,17 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 		j.AddError(errors.Wrapf(err, "error getting alias task queue for distro '%s'", j.DistroId))
 	}
 	taskIds := []string{}
-	lenQueue := -1
-	lenAliasQueue := -1
-	if queue != nil {
-		lenQueue = len(queue.Queue)
-		for _, item := range queue.Queue {
-			if !item.IsDispatched && len(item.Dependencies) > 0 {
-				taskIds = append(taskIds, item.Id)
-			}
+	lenQueue := len(queue.Queue)
+	for _, item := range queue.Queue {
+		if !item.IsDispatched && len(item.Dependencies) > 0 {
+			taskIds = append(taskIds, item.Id)
 		}
 	}
 
-	if aliasQueue != nil {
-		lenAliasQueue = len(aliasQueue.Queue)
-		for _, item := range aliasQueue.Queue {
-			if !item.IsDispatched && len(item.Dependencies) > 0 {
-				taskIds = append(taskIds, item.Id)
-			}
+	lenAliasQueue := len(aliasQueue.Queue)
+	for _, item := range aliasQueue.Queue {
+		if !item.IsDispatched && len(item.Dependencies) > 0 {
+			taskIds = append(taskIds, item.Id)
 		}
 	}
 


### PR DESCRIPTION
Definitely learning a lot about an unfamiliar part of the codebase with this job 🤦‍♀️  Evidently there are multiple "get task queue" functions with different purposes; the one I was using was more specific and it doesn't include dependencies, which is something we explicitly need. Find should do what we need, because it just loads in the whole queue.