### PR TITLE
EVG-13549: unset needs new agent/agent monitor flag once deploy succeeds

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1328,34 +1328,12 @@ func (h *Host) SetNeedsNewAgent(needsAgent bool) error {
 	return nil
 }
 
-// SetNeedsNewAgentAtomically sets the "needs new agent" flag on the host atomically.
-func (h *Host) SetNeedsNewAgentAtomically(needsAgent bool) error {
-	err := UpdateOne(bson.M{IdKey: h.Id, NeedsNewAgentKey: !needsAgent},
-		bson.M{"$set": bson.M{NeedsNewAgentKey: needsAgent}})
-	if err != nil {
-		return err
-	}
-	h.NeedsNewAgent = needsAgent
-	return nil
-}
-
 // SetNeedsNewAgentMonitor sets the "needs new agent monitor" flag on the host
 // to indicate that the host needs to have the agent monitor deployed.
 func (h *Host) SetNeedsNewAgentMonitor(needsAgentMonitor bool) error {
 	err := UpdateOne(bson.M{IdKey: h.Id},
 		bson.M{"$set": bson.M{NeedsNewAgentMonitorKey: needsAgentMonitor}})
 	if err != nil {
-		return err
-	}
-	h.NeedsNewAgentMonitor = needsAgentMonitor
-	return nil
-}
-
-// SetNeedsNewAgentMonitorAtomically is the same as SetNeedsNewAgentMonitor but
-// performs an atomic update on the host in the database.
-func (h *Host) SetNeedsNewAgentMonitorAtomically(needsAgentMonitor bool) error {
-	if err := UpdateOne(bson.M{IdKey: h.Id, NeedsNewAgentMonitorKey: !needsAgentMonitor},
-		bson.M{"$set": bson.M{NeedsNewAgentMonitorKey: needsAgentMonitor}}); err != nil {
 		return err
 	}
 	h.NeedsNewAgentMonitor = needsAgentMonitor

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -152,7 +152,10 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 		} else {
 			j.AddError(err)
 		}
+		return
 	}
+
+	j.AddError(j.host.SetNeedsNewAgent(false))
 }
 
 func (j *agentDeployJob) getHostMessage() message.Fields {

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -164,7 +164,12 @@ func (j *agentMonitorDeployJob) Run(ctx context.Context) {
 		return
 	}
 
-	j.AddRetryableError(j.startAgentMonitor(ctx, settings))
+	if err := j.startAgentMonitor(ctx, settings); err != nil {
+		j.AddRetryableError(err)
+		return
+	}
+
+	j.AddError(j.host.SetNeedsNewAgentMonitor(false))
 }
 
 // hostDown checks if the host is down.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-13549

* Clear the flag indicating that the host still needs to deploy an agent/agent monitor once the respective job succeeds.
* Remove unused atomic variants of methods.