### PR TITLE
EVG-14449 use project name in notifications

### DIFF
--- a/trigger/build.go
+++ b/trigger/build.go
@@ -282,6 +282,10 @@ func (t *buildTriggers) makeData(sub *event.Subscription, pastTenseOverride stri
 	if err := api.BuildFromService(*t.build); err != nil {
 		return nil, errors.Wrap(err, "error building json model")
 	}
+	projectName := t.build.Project
+	if api.ProjectIdentifier != nil {
+		projectName = utility.FromStringPtr(api.ProjectIdentifier)
+	}
 
 	data := commonTemplateData{
 		ID:              t.build.Id,
@@ -289,7 +293,7 @@ func (t *buildTriggers) makeData(sub *event.Subscription, pastTenseOverride stri
 		SubscriptionID:  sub.ID,
 		DisplayName:     t.build.DisplayName,
 		Object:          event.ObjectBuild,
-		Project:         t.build.Project,
+		Project:         projectName,
 		URL:             buildLink(t.uiConfig.Url, t.build.Id, evergreen.IsPatchRequester(t.build.Requester)),
 		PastTenseStatus: t.data.Status,
 		apiModel:        &api,

--- a/trigger/commit_queue.go
+++ b/trigger/commit_queue.go
@@ -3,6 +3,8 @@ package trigger
 import (
 	"fmt"
 
+	"github.com/evergreen-ci/evergreen/model"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
@@ -92,6 +94,11 @@ func (t *commitQueueTriggers) makeData(sub *event.Subscription) (*commonTemplate
 	if t.patch.Version != "" {
 		url = fmt.Sprintf("%s/version/%s", t.uiConfig.Url, t.patch.Version)
 	}
+	projectName := t.patch.Project
+	identifier, err := model.GetIdentifierForProject(t.patch.Project)
+	if err != nil && identifier != "" {
+		projectName = identifier
+	}
 	data := commonTemplateData{
 		ID:              t.patch.Id.Hex(),
 		EventID:         t.event.ID,
@@ -99,7 +106,7 @@ func (t *commitQueueTriggers) makeData(sub *event.Subscription) (*commonTemplate
 		DisplayName:     t.patch.Id.Hex(),
 		Description:     text,
 		Object:          "merge",
-		Project:         t.patch.Project,
+		Project:         projectName,
 		URL:             url,
 		PastTenseStatus: t.data.Status,
 	}

--- a/trigger/commit_queue.go
+++ b/trigger/commit_queue.go
@@ -3,9 +3,8 @@ package trigger
 import (
 	"fmt"
 
-	"github.com/evergreen-ci/evergreen/model"
-
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/evergreen/model/patch"
@@ -96,7 +95,7 @@ func (t *commitQueueTriggers) makeData(sub *event.Subscription) (*commonTemplate
 	}
 	projectName := t.patch.Project
 	identifier, err := model.GetIdentifierForProject(t.patch.Project)
-	if err != nil && identifier != "" {
+	if err == nil && identifier != "" {
 		projectName = identifier
 	}
 	data := commonTemplateData{

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -270,6 +270,10 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 	if err := api.BuildFromService(*t.patch); err != nil {
 		return nil, errors.Wrap(err, "error building json model")
 	}
+	projectName := t.patch.Project
+	if api.ProjectIdentifier != nil {
+		projectName = utility.FromStringPtr(api.ProjectIdentifier)
+	}
 
 	data := commonTemplateData{
 		ID:                t.patch.Id.Hex(),
@@ -278,7 +282,7 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 		DisplayName:       t.patch.Id.Hex(),
 		Description:       t.patch.Description,
 		Object:            event.ObjectPatch,
-		Project:           t.patch.Project,
+		Project:           projectName,
 		URL:               versionLink(t.uiConfig.Url, t.patch.Version, true),
 		PastTenseStatus:   t.data.Status,
 		apiModel:          &api,

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -270,7 +270,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 		SubscriptionID:  sub.ID,
 		DisplayName:     displayName,
 		Object:          "task",
-		Project:         t.task.Project,
+		Project:         projectRef.Identifier,
 		URL:             taskLink(t.uiConfig.Url, t.task.Id, t.task.Execution),
 		PastTenseStatus: status,
 		apiModel:        &api,

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -105,13 +105,17 @@ func (t *versionTriggers) makeData(sub *event.Subscription, pastTenseOverride st
 	if err := api.BuildFromService(t.version); err != nil {
 		return nil, errors.Wrap(err, "error building json model")
 	}
+	projectName := t.version.Identifier
+	if api.ProjectIdentifier != nil {
+		projectName = utility.FromStringPtr(api.ProjectIdentifier)
+	}
 	data := commonTemplateData{
 		ID:                t.version.Id,
 		EventID:           t.event.ID,
 		SubscriptionID:    sub.ID,
 		DisplayName:       t.version.Id,
 		Object:            event.ObjectVersion,
-		Project:           t.version.Identifier,
+		Project:           projectName,
 		URL:               versionLink(t.uiConfig.Url, t.version.Id, evergreen.IsPatchRequester(t.version.Requester)),
 		PastTenseStatus:   t.data.Status,
 		apiModel:          &api,


### PR DESCRIPTION
Changed this for all the notifications (this affects the templates [here](https://github.com/evergreen-ci/evergreen/blob/29ab59687b2dcff93f3530d1d8571c7830cb8bd8/trigger/payloads.go#L65) (everywhere with `.Project`)