### PR TITLE
EVG-14373: use scopes in distro scheduler jobs

### DIFF
--- a/units/scheduler.go
+++ b/units/scheduler.go
@@ -50,8 +50,9 @@ func NewDistroSchedulerJob(env evergreen.Environment, distroID string, ts time.T
 	j := makeDistroSchedulerJob()
 	j.DistroID = distroID
 	j.SetID(fmt.Sprintf("%s.%s.%s", schedulerJobName, distroID, ts.Format(TSFormat)))
+	j.SetScopes([]string{"%s.%s", schedulerJobName, distroID})
+	j.SetShouldApplyScopesOnEnqueue(true)
 
-	j.env = env
 	return j
 }
 
@@ -72,10 +73,6 @@ func (j *distroSchedulerJob) Run(ctx context.Context) {
 			"job_type": j.Type().Name,
 		})
 		return
-	}
-
-	if j.env == nil {
-		j.env = evergreen.GetEnvironment()
 	}
 
 	settings, err := evergreen.GetConfig()

--- a/units/scheduler.go
+++ b/units/scheduler.go
@@ -27,8 +27,6 @@ func init() {
 type distroSchedulerJob struct {
 	DistroID string `bson:"distro_id" json:"distro_id" yaml:"distro_id"`
 	job.Base `bson:"metadata" json:"metadata" yaml:"metadata"`
-
-	env evergreen.Environment
 }
 
 func makeDistroSchedulerJob() *distroSchedulerJob {

--- a/units/scheduler_alias.go
+++ b/units/scheduler_alias.go
@@ -50,6 +50,8 @@ func NewDistroAliasSchedulerJob(distroID string, ts time.Time) amboy.Job {
 	j := makeDistroAliasSchedulerJob()
 	j.DistroID = distroID
 	j.SetID(fmt.Sprintf("%s.%s.%s", schedulerAliasJobName, distroID, ts.Format(TSFormat)))
+	j.SetScopes([]string{"%s.%s", schedulerAliasJobName, distroID})
+	j.SetShouldApplyScopesOnEnqueue(true)
 
 	return j
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14373

* Add scopes for distro (i.e. primary task queue) and distro alias (i.e. secondary task queue) schedulers.
* Removed unused field from distro scheduler job.