### PR TITLE
EVG-14370: use scopes for oldest image removal job

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -306,9 +306,9 @@ func PopulateOldestImageRemovalJobs() amboy.QueueOperation {
 
 		// Create oldestImageJob when images take up too much disk space
 		for _, p := range parents {
-			catcher.Add(queue.Put(ctx, NewOldestImageRemovalJob(&p, evergreen.ProviderNameDocker, ts)))
+			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewOldestImageRemovalJob(&p, evergreen.ProviderNameDocker, ts)), "parent host '%s'", p.Id)
 		}
-		return catcher.Resolve()
+		return errors.Wrap(catcher.Resolve(), "populating remove oldest image jobs")
 	}
 }
 

--- a/units/oldest_image_removal.go
+++ b/units/oldest_image_removal.go
@@ -59,7 +59,9 @@ func NewOldestImageRemovalJob(h *host.Host, providerName, id string) amboy.Job {
 	j.Provider = providerName
 	j.HostID = h.Id
 
-	j.SetID(fmt.Sprintf("%s.%s", oldestImageRemovalJobName, id))
+	j.SetID(fmt.Sprintf("%s.%s.%s", oldestImageRemovalJobName, h.Id, id))
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", oldestImageRemovalJobName, h.Id)})
+	j.SetShouldApplyScopesOnEnqueue(true)
 	return j
 }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14370

Use scopes for job to remove oldest image from a Docker parent host.