### PR TITLE
EVG-14557: Revendor timber and update cedar client connection

### DIFF
--- a/agent/internal/client/client.go
+++ b/agent/internal/client/client.go
@@ -154,17 +154,17 @@ func (c *communicatorImpl) GetLoggerProducer(ctx context.Context, td TaskData, c
 
 	exec, senders, err := c.makeSender(ctx, td, config.Agent, apimodels.AgentLogPrefix, evergreen.LogTypeAgent)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making agent logger")
+		return nil, errors.Wrap(err, "making agent logger")
 	}
 	underlying = append(underlying, senders...)
 	task, senders, err := c.makeSender(ctx, td, config.Task, apimodels.TaskLogPrefix, evergreen.LogTypeTask)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making task logger")
+		return nil, errors.Wrap(err, "making task logger")
 	}
 	underlying = append(underlying, senders...)
 	system, senders, err := c.makeSender(ctx, td, config.System, apimodels.SystemLogPrefix, evergreen.LogTypeSystem)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making system logger")
+		return nil, errors.Wrap(err, "making system logger")
 	}
 	underlying = append(underlying, senders...)
 
@@ -200,7 +200,7 @@ func (c *communicatorImpl) makeSender(ctx context.Context, td TaskData, opts []L
 		case model.FileLogSender:
 			sender, err = send.NewPlainFileLogger(prefix, opt.Filepath, levelInfo)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "error creating file logger")
+				return nil, nil, errors.Wrap(err, "creating file logger")
 			}
 
 			underlyingBufferedSenders = append(underlyingBufferedSenders, sender)
@@ -212,7 +212,7 @@ func (c *communicatorImpl) makeSender(ctx context.Context, td TaskData, opts []L
 			}
 			sender, err = send.NewSplunkLogger(prefix, info, levelInfo)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "error creating splunk logger")
+				return nil, nil, errors.Wrap(err, "creating splunk logger")
 			}
 			underlyingBufferedSenders = append(underlyingBufferedSenders, sender)
 			sender = send.NewBufferedSender(newAnnotatedWrapper(td.ID, prefix, sender), bufferDuration, bufferSize)
@@ -226,7 +226,7 @@ func (c *communicatorImpl) makeSender(ctx context.Context, td TaskData, opts []L
 			}
 			sender, err = send.NewBuildlogger(opt.BuilderID, &config, levelInfo)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "error creating logkeeper logger")
+				return nil, nil, errors.Wrap(err, "creating logkeeper logger")
 			}
 			underlyingBufferedSenders = append(underlyingBufferedSenders, sender)
 			sender = send.NewBufferedSender(sender, bufferDuration, bufferSize)
@@ -245,11 +245,11 @@ func (c *communicatorImpl) makeSender(ctx context.Context, td TaskData, opts []L
 		case model.BuildloggerLogSender:
 			tk, err := c.GetTask(ctx, td)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "error setting up buildlogger sender")
+				return nil, nil, errors.Wrap(err, "setting up buildlogger sender")
 			}
 
 			if err = c.createCedarGRPCConn(ctx); err != nil {
-				return nil, nil, errors.Wrap(err, "error setting up cedar grpc connection")
+				return nil, nil, errors.Wrap(err, "setting up cedar grpc connection")
 			}
 
 			timberOpts := &buildlogger.LoggerOptions{
@@ -268,7 +268,7 @@ func (c *communicatorImpl) makeSender(ctx context.Context, td TaskData, opts []L
 			}
 			sender, err = buildlogger.NewLoggerWithContext(ctx, opt.BuilderID, levelInfo, timberOpts)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "error creating buildlogger logger")
+				return nil, nil, errors.Wrap(err, "creating buildlogger logger")
 			}
 		default:
 			sender = newEvergreenLogSender(ctx, c, prefix, td, bufferSize, bufferDuration)
@@ -288,21 +288,34 @@ func (c *communicatorImpl) createCedarGRPCConn(ctx context.Context) error {
 	if c.cedarGRPCClient == nil {
 		cc, err := c.GetCedarConfig(ctx)
 		if err != nil {
-			return errors.Wrap(err, "error setting up buildlogger sender")
+			return errors.Wrap(err, "getting cedar config")
 		}
 
+		// TODO (EVG-14557): Remove TLS dial option fallback once cedar
+		// gRPC is on api auth.
+		catcher := grip.NewBasicCatcher()
 		dialOpts := timber.DialCedarOptions{
 			BaseAddress: cc.BaseURL,
 			RPCPort:     cc.RPCPort,
 			Username:    cc.Username,
-			Password:    cc.Password,
 			APIKey:      cc.APIKey,
 			Retries:     10,
 		}
 		c.cedarGRPCClient, err = timber.DialCedar(ctx, c.cedarHTTPClient, dialOpts)
-		if err != nil {
-			return errors.Wrap(err, "error creating cedar grpc client connection")
+		if err == nil {
+			return nil
 		}
+		catcher.Add(errors.Wrap(err, "creating cedar grpc client connection without TLS"))
+
+		// Try again, this time with TLS.
+		dialOpts.TLS = true
+		c.cedarGRPCClient, err = timber.DialCedar(ctx, c.cedarHTTPClient, dialOpts)
+		if err == nil {
+			return nil
+		}
+		catcher.Add(errors.Wrap(err, "creating cedar grpc client connection with TLS"))
+
+		return catcher.Resolve()
 	}
 
 	return nil

--- a/agent/internal/client/methods.go
+++ b/agent/internal/client/methods.go
@@ -364,7 +364,7 @@ func (c *communicatorImpl) GetCedarConfig(ctx context.Context) (*apimodels.Cedar
 // creates it if it doesn't exist.
 func (c *communicatorImpl) GetCedarGRPCConn(ctx context.Context) (*grpc.ClientConn, error) {
 	if err := c.createCedarGRPCConn(ctx); err != nil {
-		return nil, errors.Wrap(err, "error setting up cedar grpc connection")
+		return nil, errors.Wrap(err, "setting up cedar grpc connection")
 	}
 	return c.cedarGRPCClient, nil
 }

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -264,7 +264,6 @@ func (c *Mock) GetCedarConfig(ctx context.Context) (*apimodels.CedarConfig, erro
 		BaseURL:  "base_url",
 		RPCPort:  "1000",
 		Username: "user",
-		Password: "password",
 		APIKey:   "api_key",
 	}, nil
 }

--- a/apimodels/cedar_models.go
+++ b/apimodels/cedar_models.go
@@ -4,6 +4,5 @@ type CedarConfig struct {
 	BaseURL  string `json:"base_url"`
 	RPCPort  string `json:"rpc_port"`
 	Username string `json:"username"`
-	Password string `json:"password,omitempty"`
 	APIKey   string `json:"api_key,omitempty"`
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-04-30"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-04-28"
+	AgentVersion = "2021-05-05"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config_cedar.go
+++ b/config_cedar.go
@@ -8,11 +8,10 @@ import (
 )
 
 type CedarConfig struct {
-	BaseURL  string `bson:"base_url" json:"base_url" yaml:"base_url"`
-	RPCPort  string `bson:"rpc_port" json:"rpc_port" yaml:"rpc_port"`
-	User     string `bson:"user" json:"user" yaml:"user"`
-	Password string `bson:"password" json:"password" yaml:"password"`
-	APIKey   string `bson:"api_key" json:"api_key" yaml:"api_key"`
+	BaseURL string `bson:"base_url" json:"base_url" yaml:"base_url"`
+	RPCPort string `bson:"rpc_port" json:"rpc_port" yaml:"rpc_port"`
+	User    string `bson:"user" json:"user" yaml:"user"`
+	APIKey  string `bson:"api_key" json:"api_key" yaml:"api_key"`
 }
 
 func (*CedarConfig) SectionId() string { return "cedar" }
@@ -48,7 +47,6 @@ func (c *CedarConfig) Set() error {
 			"base_url": c.BaseURL,
 			"rpc_port": c.RPCPort,
 			"user":     c.User,
-			"password": c.Password,
 			"api_key":  c.APIKey,
 		},
 	}, options.Update().SetUpsert(true))

--- a/glide.lock
+++ b/glide.lock
@@ -133,7 +133,7 @@ imports:
   - name: go.mongodb.org/mongo-driver
     version: 6760875fa58e0fa5518c992582efa6d807960d6c
   - name: github.com/evergreen-ci/timber
-    version: 8aa0f63237a9afe6b8edf6cdab2b400c1049f559
+    version: 892fb44e4198fb6552dc1ff8ac076c67bb423a2c
   - name: github.com/evergreen-ci/poplar
     version: 098cea7cb6dc183c69a96c882da4e370858c0aa3
   - name: github.com/evergreen-ci/juniper

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -585,11 +585,10 @@ func (a *APIAuthConfig) ToService() (interface{}, error) {
 }
 
 type APICedarConfig struct {
-	BaseURL  *string `json:"base_url"`
-	RPCPort  *string `json:"rpc_port"`
-	User     *string `json:"user"`
-	Password *string `json:"password"`
-	APIKey   *string `json:"api_key"`
+	BaseURL *string `json:"base_url"`
+	RPCPort *string `json:"rpc_port"`
+	User    *string `json:"user"`
+	APIKey  *string `json:"api_key"`
 }
 
 func (a *APICedarConfig) BuildFromService(h interface{}) error {
@@ -598,7 +597,6 @@ func (a *APICedarConfig) BuildFromService(h interface{}) error {
 		a.BaseURL = utility.ToStringPtr(v.BaseURL)
 		a.RPCPort = utility.ToStringPtr(v.RPCPort)
 		a.User = utility.ToStringPtr(v.User)
-		a.Password = utility.ToStringPtr(v.Password)
 		a.APIKey = utility.ToStringPtr(v.APIKey)
 	default:
 		return errors.Errorf("%T is not a supported type", h)
@@ -608,11 +606,10 @@ func (a *APICedarConfig) BuildFromService(h interface{}) error {
 
 func (a *APICedarConfig) ToService() (interface{}, error) {
 	return evergreen.CedarConfig{
-		BaseURL:  utility.FromStringPtr(a.BaseURL),
-		RPCPort:  utility.FromStringPtr(a.RPCPort),
-		User:     utility.FromStringPtr(a.User),
-		Password: utility.FromStringPtr(a.Password),
-		APIKey:   utility.FromStringPtr(a.APIKey),
+		BaseURL: utility.FromStringPtr(a.BaseURL),
+		RPCPort: utility.FromStringPtr(a.RPCPort),
+		User:    utility.FromStringPtr(a.User),
+		APIKey:  utility.FromStringPtr(a.APIKey),
 	}, nil
 }
 

--- a/service/api.go
+++ b/service/api.go
@@ -644,7 +644,6 @@ func (as *APIServer) GetServiceApp() *gimlet.APIApp {
 	// legacy routes.
 	app.Route().Version(2).Route("/agent/setup").Wrap(checkHost).Handler(as.agentSetup).Get()
 	app.Route().Version(2).Route("/agent/next_task").Wrap(checkHost).Handler(as.NextTask).Get()
-	app.Route().Version(2).Route("/agent/buildlogger_info").Wrap(checkHost).Handler(as.Cedar).Get()
 	app.Route().Version(2).Route("/agent/cedar_config").Wrap(checkHost).Handler(as.Cedar).Get()
 	app.Route().Version(2).Route("/task/{taskId}/end").Wrap(checkTaskSecret, checkHost).Handler(as.EndTask).Post()
 	app.Route().Version(2).Route("/task/{taskId}/start").Wrap(checkTaskSecret, checkHost).Handler(as.StartTask).Post()

--- a/service/api_cedar.go
+++ b/service/api_cedar.go
@@ -12,7 +12,6 @@ func (as *APIServer) Cedar(w http.ResponseWriter, r *http.Request) {
 		BaseURL:  as.Settings.Cedar.BaseURL,
 		RPCPort:  as.Settings.Cedar.RPCPort,
 		Username: as.Settings.Cedar.User,
-		Password: as.Settings.Cedar.Password,
 		APIKey:   as.Settings.Cedar.APIKey,
 	})
 }

--- a/service/api_cedar_test.go
+++ b/service/api_cedar_test.go
@@ -22,7 +22,6 @@ func TestCedar(t *testing.T) {
 	conf.Cedar.BaseURL = "cedar.mongodb.com"
 	conf.Cedar.RPCPort = "7070"
 	conf.Cedar.User = "user"
-	conf.Cedar.Password = "pass"
 	conf.Cedar.APIKey = "api_key"
 	queue := evergreen.GetEnvironment().LocalQueue()
 	as, err := NewAPIServer(evergreen.GetEnvironment(), queue)
@@ -58,6 +57,5 @@ func TestCedar(t *testing.T) {
 	assert.Equal(t, "cedar.mongodb.com", cc.BaseURL)
 	assert.Equal(t, "7070", cc.RPCPort)
 	assert.Equal(t, "user", cc.Username)
-	assert.Equal(t, "pass", cc.Password)
 	assert.Equal(t, "api_key", cc.APIKey)
 }

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1285,10 +1285,6 @@ Admin Settings
 										<input type="text" ng-model="Settings.cedar.user">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
-										<label>Password</label>
-										<input type="text" ng-model="Settings.cedar.password">
-									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
 										<label>API Key</label>
 										<input type="text" ng-model="Settings.cedar.api_key">
 									</md-input-container>

--- a/vendor/github.com/evergreen-ci/timber/evergreen.yaml
+++ b/vendor/github.com/evergreen-ci/timber/evergreen.yaml
@@ -132,7 +132,7 @@ buildvariants:
       RACE_DETECTOR: true
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
-      - archlinux-test
+      - archlinux-new-small
     tasks:
       - name: ".test"
 
@@ -143,7 +143,7 @@ buildvariants:
       GOROOT: /opt/golang/go1.13
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
-      - archlinux-test
+      - archlinux-new-small
     tasks:
       - name: ".report"
 

--- a/vendor/github.com/evergreen-ci/timber/glide.lock
+++ b/vendor/github.com/evergreen-ci/timber/glide.lock
@@ -4,7 +4,7 @@ imports:
 - name: github.com/mongodb/grip
   version: 7b77abce30e2f707b37c8321f192e5a83c597e7f
 - name: github.com/evergreen-ci/aviation
-  version: e576e1538fbf9207f2abb3ded217d5b633f5e379
+  version: 256d15da171ec80bed08a43bd40e4b3a590bbc13
 - name: go.mongodb.org/mongo-driver
   version: 305bc4a5e4131420fe8ba5628e6faa9e6ade4e86
 - name: github.com/evergreen-ci/utility

--- a/vendor/github.com/evergreen-ci/timber/makefile
+++ b/vendor/github.com/evergreen-ci/timber/makefile
@@ -106,6 +106,7 @@ vendor-clean:
 	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/pkg/errors/
 	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/stretchr/testify/
 	rm -rf vendor/github.com/evergreen-ci/aviation/vendor/google.golang.org/grpc/
+	rm -rf vendor/github.com/evergreen-ci/aviation/vendor/google.golang.org/genproto/
 	rm -rf vendor/github.com/evergreen-ci/aviation/vendor/github.com/mongodb/grip/
 	rm -rf vendor/github.com/evergreen-ci/aviation/vendor/github.com/pkg/errors/
 	rm -rf vendor/github.com/evergreen-ci/aviation/vendor/github.com/stretchr/testify/

--- a/vendor/github.com/evergreen-ci/timber/setup.go
+++ b/vendor/github.com/evergreen-ci/timber/setup.go
@@ -36,9 +36,9 @@ func (opts ConnectionOptions) Validate() error {
 		(opts.DialOpts.BaseAddress != "" && opts.DialOpts.RPCPort == "") {
 		return errors.New("must provide both base address and rpc port or neither")
 	}
-	hasAuth := opts.DialOpts.Username != "" && (opts.DialOpts.APIKey != "" || opts.DialOpts.Password != "")
+	hasAuth := opts.DialOpts.Username != "" && (opts.DialOpts.APIKey != "")
 	if !hasAuth && opts.DialOpts.BaseAddress == "" {
-		return errors.New("must specify username and api key/password, or address and port for an insecure connection")
+		return errors.New("must specify username and api key, or address and port for an insecure connection")
 	}
 	return nil
 }

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/.golangci.yml
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/.golangci.yml
@@ -12,4 +12,4 @@ linters:
 
 linters-settings:
   govet:
-    check-shadowing: true
+    check-shadowing: false

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/auth.go
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/auth.go
@@ -2,6 +2,7 @@ package aviation
 
 import (
 	"context"
+	"strings"
 
 	"github.com/evergreen-ci/gimlet"
 	"google.golang.org/grpc"
@@ -12,88 +13,81 @@ import (
 // TODO: add interceptors to provide "role required" and "group
 // member" using gimlet.Authenticator
 
-func MakeAuthenticationRequiredUnaryInterceptor(um gimlet.UserManager, conf gimlet.UserMiddlewareConfiguration) grpc.UnaryServerInterceptor {
+func MakeAuthenticationRequiredUnaryInterceptor(um gimlet.UserManager, conf gimlet.UserMiddlewareConfiguration, ignore ...string) grpc.UnaryServerInterceptor {
+	ignoreMap := getIgnoreMap(ignore)
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		meta, ok := metadata.FromIncomingContext(ctx)
-		if !ok {
-			return nil, grpc.Errorf(codes.Unauthenticated, "missing metadata from context")
+		if info == nil || !ignoreMap[info.FullMethod] {
+			if err := checkUser(ctx, um, conf); err != nil {
+				return nil, err
+			}
 		}
-
-		var (
-			authDataAPIKey string
-			authDataName   string
-		)
-
-		// Grab API auth details from header
-		if len(meta[conf.HeaderKeyName]) > 0 {
-			authDataAPIKey = meta[conf.HeaderKeyName][0]
-		}
-		if len(meta[conf.HeaderUserName]) > 0 {
-			authDataName = meta[conf.HeaderUserName][0]
-		}
-
-		if len(authDataAPIKey) == 0 {
-			return nil, grpc.Errorf(codes.Unauthenticated, "user key not provided")
-		}
-
-		usr, err := um.GetUserByID(authDataName)
-		if err != nil {
-			return nil, grpc.Errorf(codes.Unauthenticated, "problem finding user: %+v", err)
-		}
-
-		if usr == nil {
-			return nil, grpc.Errorf(codes.Unauthenticated, "user not found")
-		}
-
-		if usr.GetAPIKey() != authDataAPIKey {
-			return nil, grpc.Errorf(codes.Unauthenticated, "incorrect credentials")
-		}
-
-		ctx = SetRequestUser(ctx, usr)
 
 		return handler(ctx, req)
 	}
 }
 
-func MakeAuthenticationRequiredStreamInterceptor(um gimlet.UserManager, conf gimlet.UserMiddlewareConfiguration) grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
-		ctx := stream.Context()
-
-		meta, ok := metadata.FromIncomingContext(ctx)
-		if !ok {
-			return grpc.Errorf(codes.Unauthenticated, "missing metadata from context")
-		}
-
-		var (
-			authDataAPIKey string
-			authDataName   string
-		)
-
-		// Grab API auth details from header
-		if len(meta[conf.HeaderKeyName]) > 0 {
-			authDataAPIKey = meta[conf.HeaderKeyName][0]
-		}
-		if len(meta[conf.HeaderUserName]) > 0 {
-			authDataName = meta[conf.HeaderUserName][0]
-		}
-
-		if len(authDataAPIKey) == 0 {
-			return grpc.Errorf(codes.Unauthenticated, "user key not provided")
-		}
-
-		usr, err := um.GetUserByID(authDataName)
-		if err != nil {
-			return grpc.Errorf(codes.Unauthenticated, "problem finding user: %+v", err)
-		}
-
-		if usr == nil {
-			return grpc.Errorf(codes.Unauthenticated, "user not found")
-		}
-
-		if usr.GetAPIKey() != authDataAPIKey {
-			return grpc.Errorf(codes.Unauthenticated, "incorrect credentials")
+func MakeAuthenticationRequiredStreamInterceptor(um gimlet.UserManager, conf gimlet.UserMiddlewareConfiguration, ignore ...string) grpc.StreamServerInterceptor {
+	ignoreMap := getIgnoreMap(ignore)
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if info == nil || !ignoreMap[info.FullMethod] {
+			if err := checkUser(stream.Context(), um, conf); err != nil {
+				return err
+			}
 		}
 
 		return handler(srv, stream)
 	}
+}
+
+func getIgnoreMap(ignore []string) map[string]bool {
+	ignoreMap := map[string]bool{}
+	for _, method := range ignore {
+		ignoreMap[method] = true
+	}
+
+	return ignoreMap
+}
+
+func checkUser(ctx context.Context, um gimlet.UserManager, conf gimlet.UserMiddlewareConfiguration) error {
+	meta, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return grpc.Errorf(codes.Unauthenticated, "missing metadata from context")
+	}
+
+	var (
+		authDataAPIKey string
+		authDataName   string
+	)
+
+	// We need to set these to lower case since grpc sets all of
+	// the context metadata keys to lowercase.
+	headerKeyName := strings.ToLower(conf.HeaderKeyName)
+	headerUserName := strings.ToLower(conf.HeaderUserName)
+
+	// Grab API auth details from header.
+	if len(meta[headerKeyName]) > 0 {
+		authDataAPIKey = meta[headerKeyName][0]
+	}
+	if len(meta[headerUserName]) > 0 {
+		authDataName = meta[headerUserName][0]
+	}
+
+	if len(authDataAPIKey) == 0 {
+		return grpc.Errorf(codes.Unauthenticated, "user key not provided")
+	}
+
+	usr, err := um.GetUserByID(authDataName)
+	if err != nil {
+		return grpc.Errorf(codes.Unauthenticated, "finding user: %+v", err)
+	}
+
+	if usr == nil {
+		return grpc.Errorf(codes.Unauthenticated, "user not found")
+	}
+
+	if usr.GetAPIKey() != authDataAPIKey {
+		return grpc.Errorf(codes.Unauthenticated, "incorrect credentials")
+	}
+
+	return nil
 }

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/auth_test.go
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/auth_test.go
@@ -14,8 +14,8 @@ func TestAuthRequiredInterceptors(t *testing.T) {
 	const (
 		username       = "testUser"
 		userAPIKey     = "123abc"
-		headerUserName = "UserName"
-		headerKeyName  = "KeyName"
+		headerUserName = "user"
+		headerKeyName  = "key"
 	)
 
 	user := gimlet.NewBasicUser(username, "test", "test@test.com", userAPIKey, nil)

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/cmd/run-linter/run-linter.go
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/cmd/run-linter/run-linter.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -79,18 +78,21 @@ func main() {
 	packages = strings.Split(strings.Replace(packageList, "-", "/", -1), " ")
 	dirname, _ := os.Getwd()
 	cwd := filepath.Base(dirname)
-	lintArgs += fmt.Sprintf(" --concurrency=%d", runtime.NumCPU()/2)
 
 	for _, pkg := range packages {
 		pkgDir := "./"
 		if cwd != pkg {
 			pkgDir += pkg
 		}
-		args := []string{lintBin, "run", lintArgs, pkgDir}
+		splitLintArgs := strings.Split(lintArgs, " ")
+		args := []string{lintBin, "run"}
+		args = append(args, splitLintArgs...)
+		args = append(args, pkgDir)
 
 		startAt := time.Now()
-		cmd := strings.Join(args, " ")
-		out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dirname
+		out, err := cmd.CombinedOutput()
 		r := &result{
 			cmd:      strings.Join(args, " "),
 			name:     "lint-" + strings.Replace(pkg, "/", "-", -1),
@@ -98,9 +100,14 @@ func main() {
 			duration: time.Since(startAt),
 			output:   strings.Split(string(out), "\n"),
 		}
+
 		for _, linter := range customLinters {
 			customLinterStart := time.Now()
-			out, err = exec.Command("sh", "-c", fmt.Sprintf("%s %s", linter, pkgDir)).CombinedOutput()
+			linterArgs := strings.Split(linter, " ")
+			linterArgs = append(linterArgs, pkgDir)
+			cmd := exec.Command(linterArgs[0], linterArgs[1:]...)
+			cmd.Dir = dirname
+			out, err := cmd.CombinedOutput()
 			r.passed = r.passed && err == nil
 			r.duration += time.Since(customLinterStart)
 			r.output = append(r.output, strings.Split(string(out), "\n")...)

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/dial_test.go
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/dial_test.go
@@ -39,6 +39,45 @@ func TestDial(t *testing.T) {
 			hasErr: true,
 		},
 		{
+			name: "MissingCA",
+			opts: DialOptions{
+				Address: "rpcAddress",
+				Retries: 10,
+				CrtFile: filepath.Join("testdata", "user.crt"),
+				KeyFile: filepath.Join("testdata", "user.key"),
+			},
+			hasErr: true,
+		},
+		{
+			name: "UsernameAndAPIKeyNoAPIUserHeader",
+			opts: DialOptions{
+				Address:      "rpcAddress",
+				Username:     "username",
+				APIKey:       "apikey",
+				APIKeyHeader: "api-key",
+			},
+			hasErr: true,
+		},
+		{
+			name: "UsernameAndAPIKeyNoAPIKeyHeader",
+			opts: DialOptions{
+				Address:       "rpcAddress",
+				Username:      "username",
+				APIKey:        "apikey",
+				APIUserHeader: "api-user",
+			},
+			hasErr: true,
+		},
+		{
+			name: "UsernameAndAPIKeyNoHeaders",
+			opts: DialOptions{
+				Address:  "rpcAddress",
+				Username: "username",
+				APIKey:   "apikey",
+			},
+			hasErr: true,
+		},
+		{
 			name: "CertFiles",
 			opts: DialOptions{
 				Address: "rpcAddress",
@@ -53,6 +92,36 @@ func TestDial(t *testing.T) {
 			opts: DialOptions{
 				Address: "rpcAddress",
 				TLSConf: tlsConf,
+			},
+			expectedOpts: 1,
+		},
+		{
+			name: "UsernameAndAPIKeyWithTLS",
+			opts: DialOptions{
+				Address:       "rpcAddress",
+				TLSConf:       tlsConf,
+				Username:      "username",
+				APIKey:        "apikey",
+				APIUserHeader: "api-user",
+				APIKeyHeader:  "api-key",
+			},
+			expectedOpts: 2,
+		},
+		{
+			name: "UsernameAndAPIKeyNoTLS",
+			opts: DialOptions{
+				Address:       "rpcAddress",
+				Username:      "username",
+				APIKey:        "apikey",
+				APIUserHeader: "api-user",
+				APIKeyHeader:  "api-key",
+			},
+			expectedOpts: 2,
+		},
+		{
+			name: "NoAuth",
+			opts: DialOptions{
+				Address: "rpcAddress",
 			},
 			expectedOpts: 1,
 		},

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/glide.lock
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/glide.lock
@@ -8,7 +8,9 @@ imports:
 - name: github.com/pkg/errors
   version: 27936f6d90f9c8e1145f11ed52ffffbfdb9e0af7
 - name: google.golang.org/grpc
-  version: 77ce7bc228475a8f28dc50a9d74ac4994fc019e7
+  version: ac54eec90516cee50fc6b9b113b34628a85f976f
+- name: google.golang.org/genproto
+  version: 082222b4a5c572e33e82ee9162d1352c7cf38682
 - name: github.com/stretchr/testify
   version: 34c6fa2dc70986bccbbffcc6130f6920a924b075
 - name: github.com/jpillora/backoff

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/makefile
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/makefile
@@ -1,30 +1,59 @@
+name := aviation
 buildDir := build
 srcFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "*\#*")
 testFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
 
-testPackages := ./ ./services
-packages := aviation services
-#
-# override the go binary path if set
-ifneq (,$(GO_BIN_PATH))
+packages := $(name) services
+
+# start environment setup
 gobin := $(GO_BIN_PATH)
-else
+ifeq ($(gobin),)
 gobin := go
 endif
+gopath := $(GOPATH)
+gocache := $(abspath $(buildDir)/.cache)
+goroot := $(GOROOT)
+ifeq ($(OS),Windows_NT)
+gocache := $(shell cygpath -m $(gocache))
+gopath := $(shell cygpath -m $(gopath))
+goroot := $(shell cygpath -m $(goroot))
+endif
 
+export GOPATH := $(gopath)
+export GOCACHE := $(gocache)
+export GOROOT := $(goroot)
+# end environment setup
+
+# Ensure the build directory exists, since most targets require it.
+$(shell mkdir -p $(buildDir))
 
 # start lint setup targets
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/.lintSetup $(buildDir)/run-linter
-$(buildDir)/.lintSetup:$(buildDir)/golangci-lint
-	@mkdir -p $(buildDir)
-	@touch $@
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.10.2 >/dev/null 2>&1 && touch $@
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
-	@mkdir -p $(buildDir)
+	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.30.0 >/dev/null 2>&1 && touch $@
+$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	$(gobin) build -o $@ $<
 # end lint setup targets
 
+
+# userfacing targets for basic build and development operations
+test-%: $(buildDir)/output.%.test
+	
+coverage-%: $(buildDir)/output.%.coverage
+	
+html-coverage-%: $(buildDir)/output.%.coverage.html
+	
+lint-%: $(buildDir)/output.%.lint
+	
+
+compile $(buildDir): $(srcFiles)
+	$(gobin) build $(subst $(name),,$(subst -,/,$(foreach target,$(packages),./$(target))))
+test:$(foreach target,$(packages),$(buildDir)/output.$(target).test)
+	
+lint:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
+
+.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).test)
+.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 
 testArgs := -v
 ifneq (,$(RUN_TEST))
@@ -42,26 +71,21 @@ endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif
+
 # test execution and output handlers
 $(buildDir)/output.%.test:$(buildDir) .FORCE
-	$(gobin) test $(testArgs) $(testPackages)$(if $(subst $(name),,$*),$*,) | tee $@
-	@! grep -s -q -e "^FAIL" $@ && ! grep -s -q "^WARNING: DATA RACE" $@
-$(buildDir)/output.test:$(buildDir) .FORCE
-	$(gobin) test $(testArgs) $(testPackages)... | tee $@
+	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 	@! grep -s -q -e "^FAIL" $@ && ! grep -s -q "^WARNING: DATA RACE" $@
 $(buildDir)/output.%.coverage:$(buildDir) .FORCE
-	$(gobin) test $(testArgs) $(testPackages)$(if $(subst $(name),,$*),$*,) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
+	$(gobin) test $(testArgs) -covermode=count -coverprofile ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
 #  targets to generate gotest output from the linter.
+# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
 $(buildDir)/output.%.lint:$(buildDir)/run-linter $(buildDir)/ .FORCE
-	@./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
-$(buildDir)/output.lint:$(buildDir)/run-linter $(buildDir)/ .FORCE
-	@./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$(packages)'
+	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 #  targets to process and generate coverage reports
-$(buildDir):$(srcFiles) compile
-	@mkdir -p $@
 # end test and coverage artifacts
 
 
@@ -80,20 +104,10 @@ phony += vendor-clean
 
 clean:
 	rm -rf $(lintDeps)
-
-
-# userfacing targets for basic build and development operations
-compile:
-	$(gobin) build $(testPackages)
-test:$(buildDir)/output.test
-	
-benchmark:
-	$(gobin) test -v -benchmem -bench=. -run="Benchmark.*" -timeout=20m
-lint:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
+clean-results:
+	rm -rf $(buildDir)/output.*
 
 phony += lint build test coverage coverage-html
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
-.PRECIOUS:$(buildDir)/output.lint
 # end front-ends
 
 

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/retry.go
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/retry.go
@@ -53,7 +53,7 @@ func MakeRetryUnaryClientInterceptor(maxRetries int) grpc.UnaryClientInterceptor
 			"message":       "GRPC client retries exceeded or canceled",
 			"method":        method,
 			"total_retries": i,
-			"time_elasped":  timeElapsed,
+			"time_elapsed":  timeElapsed,
 		}))
 		return lastErr
 	}
@@ -102,7 +102,7 @@ func MakeRetryStreamClientInterceptor(maxRetries int) grpc.StreamClientIntercept
 			"message":       "GRPC client retries exceeded or canceled",
 			"method":        method,
 			"total_retries": i,
-			"time_elasped":  timeElapsed,
+			"time_elapsed":  timeElapsed,
 		}))
 		return nil, lastErr
 	}

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/retry_test.go
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/retry_test.go
@@ -67,7 +67,7 @@ func TestMakeUnaryClientInterceptor(t *testing.T) {
 			expectedMaxTime:  1000 * time.Millisecond,
 		},
 		{
-			name: "RetrySucess",
+			name: "RetrySuccess",
 			grpcCodes: []codes.Code{
 				codes.Unknown,
 				codes.ResourceExhausted,

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/services/cedar.go
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/services/cedar.go
@@ -3,56 +3,55 @@ package services
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
 
 	"github.com/evergreen-ci/aviation"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
+// API headers for the cedar service.
+const (
+	APIUserHeader = "Api-User"
+	APIKeyHeader  = "Api-Key"
+)
+
 // DialCedarOptions describes the options for the DialCedar function. The base
 // address defaults to `cedar.mongodb.com` and the RPC port to 7070. If a base
-// address is provided the RPC port must also be provided. The username and
-// either password or API key must always be provided.
+// address is provided the RPC port must also be provided. The username and API
+// key must always be provided.
 type DialCedarOptions struct {
 	BaseAddress string
 	RPCPort     string
 	Username    string
-	Password    string
 	APIKey      string
+	TLS         bool
 	Retries     int
 }
 
 func (opts *DialCedarOptions) validate() error {
-	if opts.Username == "" || (opts.Password == "" && opts.APIKey == "") {
-		return errors.New("must provide username and password or API key")
-	}
+	catcher := grip.NewBasicCatcher()
 
 	if opts.BaseAddress == "" {
 		opts.BaseAddress = "cedar.mongodb.com"
 		opts.RPCPort = "7070"
 	}
 
-	if opts.RPCPort == "" {
-		return errors.New("must provide the RPC port")
-	}
+	catcher.AddWhen(opts.Username == "" || opts.APIKey == "", errors.New("must provide username and API key"))
+	catcher.AddWhen(opts.RPCPort == "", errors.New("must provide the RPC port"))
 
-	return nil
+	return catcher.Resolve()
 }
 
 type userCredentials struct {
 	Username string `json:"username"`
-	Password string `json:"password,omitempty"`
 	apiKey   string
 }
-
-const (
-	APIUserHeader = "Api-User"
-	APIKeyHeader  = "Api-Key"
-)
 
 // DialCedar is a convenience function for creating a RPC client connection
 // with cedar via gRPC.
@@ -65,32 +64,38 @@ func DialCedar(ctx context.Context, client *http.Client, opts *DialCedarOptions)
 
 	creds := &userCredentials{
 		Username: opts.Username,
-		Password: opts.Password,
 		apiKey:   opts.APIKey,
 	}
 
-	ca, err := makeCedarCertRequest(ctx, client, http.MethodGet, httpAddress+"/rest/v1/admin/ca", nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "problem getting cedar root cert")
-	}
-	crt, err := makeCedarCertRequest(ctx, client, http.MethodPost, httpAddress+"/rest/v1/admin/users/certificate", creds)
-	if err != nil {
-		return nil, errors.Wrap(err, "problem getting cedar user cert")
-	}
-	key, err := makeCedarCertRequest(ctx, client, http.MethodPost, httpAddress+"/rest/v1/admin/users/certificate/key", creds)
-	if err != nil {
-		return nil, errors.Wrap(err, "problem getting cedar user key")
-	}
+	var tlsConf *tls.Config
+	if opts.TLS {
+		ca, err := makeCedarCertRequest(ctx, client, http.MethodGet, httpAddress+"/rest/v1/admin/ca", nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting cedar root cert")
+		}
+		crt, err := makeCedarCertRequest(ctx, client, http.MethodPost, httpAddress+"/rest/v1/admin/users/certificate", creds)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting cedar user cert")
+		}
+		key, err := makeCedarCertRequest(ctx, client, http.MethodPost, httpAddress+"/rest/v1/admin/users/certificate/key", creds)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting cedar user key")
+		}
 
-	tlsConf, err := aviation.GetClientTLSConfig(ca, crt, key)
-	if err != nil {
-		return nil, errors.Wrap(err, "problem creating TLS config")
+		tlsConf, err = aviation.GetClientTLSConfig(ca, crt, key)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating TLS config")
+		}
 	}
 
 	return aviation.Dial(ctx, aviation.DialOptions{
-		Address: opts.BaseAddress + ":" + opts.RPCPort,
-		Retries: opts.Retries,
-		TLSConf: tlsConf,
+		Address:       opts.BaseAddress + ":" + opts.RPCPort,
+		Retries:       opts.Retries,
+		Username:      opts.Username,
+		APIKey:        opts.APIKey,
+		APIUserHeader: APIUserHeader,
+		APIKeyHeader:  APIKeyHeader,
+		TLSConf:       tlsConf,
 	})
 }
 
@@ -105,7 +110,7 @@ func makeCedarCertRequest(ctx context.Context, client *http.Client, method, url 
 	}
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
-		return nil, errors.Wrap(err, "problem creating http request")
+		return nil, errors.Wrap(err, "creating http request")
 	}
 	req = req.WithContext(ctx)
 
@@ -116,13 +121,13 @@ func makeCedarCertRequest(ctx context.Context, client *http.Client, method, url 
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "problem with request")
+		return nil, errors.Wrap(err, "creating request")
 	}
 	defer resp.Body.Close()
 
 	out, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "problem reading response")
+		return nil, errors.Wrap(err, "reading response")
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/services/cedar_test.go
+++ b/vendor/github.com/evergreen-ci/timber/vendor/github.com/evergreen-ci/aviation/services/cedar_test.go
@@ -15,12 +15,12 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		opts := &DialCedarOptions{
 			BaseAddress: "base",
 			RPCPort:     "9090",
-			Password:    "password",
+			APIKey:      "apiKey",
 			Retries:     10,
 		}
 		assert.Error(t, opts.validate())
 	})
-	t.Run("NoPasswordOrAPIKey", func(t *testing.T) {
+	t.Run("NoAPIKey", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			BaseAddress: "base",
 			RPCPort:     "9090",
@@ -33,7 +33,7 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		opts := &DialCedarOptions{
 			BaseAddress: "base",
 			Username:    "username",
-			Password:    "password",
+			APIKey:      "apiKey",
 			Retries:     10,
 		}
 		assert.Error(t, opts.validate())
@@ -41,7 +41,7 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 	t.Run("DefaultBaseAddressAndClient", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			Username: "username",
-			Password: "password",
+			APIKey:   "apiKey",
 			Retries:  10,
 		}
 		assert.NoError(t, opts.validate())
@@ -49,21 +49,6 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		assert.Equal(t, "7070", opts.RPCPort)
 	})
 	t.Run("ConfiguredOptions", func(t *testing.T) {
-		opts := &DialCedarOptions{
-			BaseAddress: "base",
-			RPCPort:     "9090",
-			Username:    "username",
-			Password:    "password",
-			Retries:     10,
-		}
-		assert.NoError(t, opts.validate())
-		assert.Equal(t, "base", opts.BaseAddress)
-		assert.Equal(t, "9090", opts.RPCPort)
-		assert.Equal(t, "username", opts.Username)
-		assert.Equal(t, "password", opts.Password)
-		assert.Equal(t, 10, opts.Retries)
-	})
-	t.Run("ConfiguredOptionsWithAPIKey", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			BaseAddress: "base",
 			RPCPort:     "9090",
@@ -83,12 +68,13 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 func TestDialCedar(t *testing.T) {
 	ctx := context.TODO()
 	username := os.Getenv("AUTH_USERNAME")
-	password := os.Getenv("AUTH_PASSWORD")
+	apiKey := os.Getenv("API_KEY")
 
 	t.Run("ConnectToCedar", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			Username: username,
-			Password: password,
+			APIKey:   apiKey,
+			TLS:      true,
 			Retries:  10,
 		}
 		conn, err := DialCedar(ctx, http.DefaultClient, opts)
@@ -101,7 +87,8 @@ func TestDialCedar(t *testing.T) {
 			BaseAddress: "cedar.mongo.com",
 			RPCPort:     "7070",
 			Username:    username,
-			Password:    password,
+			APIKey:      apiKey,
+			TLS:         true,
 		}
 		conn, err := DialCedar(ctx, http.DefaultClient, opts)
 		assert.Error(t, err)
@@ -110,7 +97,8 @@ func TestDialCedar(t *testing.T) {
 	t.Run("IncorrectUsernameAndPassword", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			Username: "bad_user",
-			Password: "bad_password",
+			APIKey:   "bad_key",
+			TLS:      true,
 			Retries:  10,
 		}
 		conn, err := DialCedar(ctx, http.DefaultClient, opts)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14557

Adds temporary code fallback code that sets up the cedar grpc client connection without TLS first then with TLS if it fails so we don't break a bunch of tasks as we switch over.