### PR TITLE
Revert "EVG-13888: add scope and retries to generate tasks job (#4640)"

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -672,17 +672,33 @@ func PopulateAgentMonitorDeployJobs(env evergreen.Environment) amboy.QueueOperat
 
 // PopulateGenerateTasksJobs populates generate.tasks jobs for tasks that have started running their generate.tasks command.
 func PopulateGenerateTasksJobs(env evergreen.Environment) amboy.QueueOperation {
-	return func(ctx context.Context, q amboy.Queue) error {
+	return func(_ context.Context, _ amboy.Queue) error {
+		ctx := context.Background()
+		var q amboy.Queue
+		var ok bool
+		var err error
+
+		catcher := grip.NewBasicCatcher()
 		tasks, err := task.GenerateNotRun()
 		if err != nil {
 			return errors.Wrap(err, "problem getting tasks that need generators run")
 		}
 
-		catcher := grip.NewBasicCatcher()
+		versions := map[string]amboy.Queue{}
+
+		ts := utility.RoundPartOfHour(1).Format(TSFormat)
+		group := env.RemoteQueueGroup()
 		for _, t := range tasks {
-			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, q, NewGenerateTasksJob(t)), "task '%s'", t.Id)
+			if q, ok = versions[t.Version]; !ok {
+				q, err = group.Get(ctx, t.Version)
+				if err != nil {
+					return errors.Wrapf(err, "problem getting queue for version %s", t.Version)
+				}
+				versions[t.Version] = q
+			}
+			catcher.Add(q.Put(ctx, NewGenerateTasksJob(t.Id, ts)))
 		}
-		return errors.Wrap(catcher.Resolve(), "populating generate tasks")
+		return catcher.Resolve()
 	}
 }
 

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -200,7 +200,7 @@ func TestGenerateTasks(t *testing.T) {
 	projectRef := model.ProjectRef{Id: "mci", Identifier: "mci_identifier"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob(sampleTask)
+	j := NewGenerateTasksJob("sample_task", "1")
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 	tasks := []task.Task{}
@@ -356,7 +356,7 @@ buildvariants:
 	projectRef := model.ProjectRef{Id: "mci"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob(sampleTask)
+	j := NewGenerateTasksJob("generator", "1")
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 
@@ -386,7 +386,7 @@ func TestMarkGeneratedTasksError(t *testing.T) {
 	}
 	require.NoError(t, sampleTask.Insert())
 
-	j := NewGenerateTasksJob(sampleTask)
+	j := NewGenerateTasksJob(sampleTask.Id, "1")
 	j.Run(context.Background())
 	assert.Error(t, j.Error())
 	dbTask, err := task.FindOneId(sampleTask.Id)


### PR DESCRIPTION
It seems like there are a lot of system failures in the server waterfall caused by timeouts during generate tasks. I don't see anything amiss in amboy itself and the generate tasks jobs are running quickly, so I feel like this is an issue with the version-level lock contention.