### PR TITLE
EVG-14227 remove duplicate params from test

### DIFF
--- a/config_test/project/mci-test.yml
+++ b/config_test/project/mci-test.yml
@@ -15,7 +15,6 @@ tasks:
     - command: git.get_project
       params:
         directory: src
-      params:
         working_dir: src
         script: echo "kano"
 buildvariants:


### PR DESCRIPTION
Some of our tests read this file from github; with yaml-v3, it's an error to have duplicate keys in a map (which seems reasonable). I'd like to make sure all the tests pass on the [yaml revendor](https://github.com/evergreen-ci/evergreen/pull/4638/files) before testing against all configs (if we can't use the new yaml yet because other configs have duplicate keys, then I think we'll have to hold off, but I'd like to make sure there are no other unit testable bugs before going through that process).