### PR TITLE
EVG-14505: quarantine static hosts that use up all reprovision attempts

### DIFF
--- a/units/provisioning_convert_host_to_new.go
+++ b/units/provisioning_convert_host_to_new.go
@@ -85,6 +85,12 @@ func (j *convertHostToNewProvisioningJob) Run(ctx context.Context) {
 
 	defer func() {
 		if j.HasErrors() {
+			// Static hosts should be quarantined if they've run out of attempts
+			// to reprovision.
+			if j.RetryInfo().GetRemainingAttempts() == 0 && j.host.Provider == evergreen.ProviderNameStatic {
+				j.AddError(j.host.SetStatusAtomically(evergreen.HostQuarantined, evergreen.User, "static host has run out of attempts to reprovision"))
+			}
+
 			event.LogHostConvertingProvisioningError(j.host.Id, j.Error())
 		}
 	}()


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14505

If the static host can't reprovision after 50 attempts, it's probably safe to assume it's in a bad state.