### PR TITLE
EVG-14583: avoid panic if dialing cedar errors

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-04-30"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-05-06"
+	AgentVersion = "2021-05-07"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14583

The smoke test is panicking because the system metrics client is attempting to dial into cedar without any credentials. The gRPC call to the health check panics if the connection passed in is `nil`. Therefore, only attempt to dial the health endpoint if `DialCedar` doesn't error.