### PR TITLE
EVG-14373: fix fmt.Sprintf in scopes

### DIFF
--- a/units/distro_overallocated_terminations.go
+++ b/units/distro_overallocated_terminations.go
@@ -63,7 +63,7 @@ func NewHostDrawdownJob(env evergreen.Environment, drawdownInfo DrawdownInfo, id
 	j.DrawdownInfo = drawdownInfo
 	j.env = env
 	j.SetID(fmt.Sprintf("%s.%s", hostDrawdownJobName, id))
-	j.SetScopes([]string{"%s.%s", hostDrawdownJobName, id})
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", hostDrawdownJobName, id)})
 	return j
 }
 

--- a/units/reauthorize_user.go
+++ b/units/reauthorize_user.go
@@ -60,7 +60,7 @@ func NewReauthorizeUserJob(env evergreen.Environment, u *user.DBUser, id string)
 	j.env = env
 	j.user = u
 	j.SetPriority(1)
-	j.SetScopes([]string{fmt.Sprintf("reauthorize.%s", u.Username())})
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", reauthorizeUserJobName, u.Username())})
 	j.SetShouldApplyScopesOnEnqueue(true)
 	j.UpdateRetryInfo(amboy.JobRetryOptions{
 		Retryable:   utility.TruePtr(),

--- a/units/spawnhost_expiration_check.go
+++ b/units/spawnhost_expiration_check.go
@@ -47,7 +47,7 @@ func makeSpawnhostExpirationCheckJob() *spawnhostExpirationCheckJob {
 func NewSpawnhostExpirationCheckJob(ts string, h *host.Host) amboy.Job {
 	j := makeSpawnhostExpirationCheckJob()
 	j.SetID(fmt.Sprintf("%s.%s.%s", spawnhostExpirationCheckName, h.Id, ts))
-	j.SetScopes([]string{"%s.%s", spawnhostExpirationCheckName, h.Id})
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", spawnhostExpirationCheckName, h.Id)})
 	j.SetShouldApplyScopesOnEnqueue(true)
 	j.HostID = h.Id
 	return j


### PR DESCRIPTION
* Use fmt.Sprintf in scope for spawn host expiration job.
* There's a new job written recently by @hhoke that also doesn't have fmt.Sprintf, so I just fixed it.