### PR TITLE
EVG-14431 Make githubContext for child patches less unique 

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -682,6 +682,23 @@ func (p *Patch) IsParent() bool {
 	return len(p.Triggers.ChildPatches) > 0
 }
 
+func (p *Patch) GetPatchIndex(parentPatch *Patch) (int, error) {
+	if !p.IsChild() {
+		return -1, nil
+	}
+	if parentPatch == nil {
+		return -1, errors.New(fmt.Sprintf("parent patch does not exist"))
+	}
+	siblings := parentPatch.Triggers.ChildPatches
+
+	for index, patch := range siblings {
+		if p.Id.Hex() == patch {
+			return index, nil
+		}
+	}
+	return -1, nil
+}
+
 func (p *Patch) GetPatchFamily() ([]string, *Patch, error) {
 	var childrenOrSiblings []string
 	var parentPatch *Patch

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -2,7 +2,6 @@ package trigger
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -360,13 +359,11 @@ func (t *patchTriggers) generate(sub *event.Subscription) (*notification.Notific
 }
 
 func (t *patchTriggers) getGithubContext() (string, error) {
-	pRef, err := model.FindOneProjectRef(t.patch.Project)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to find project ref")
+	projectIdentifier, err := model.GetIdentifierForProject(t.patch.Project)
+	if err != nil { // default to ID
+		projectIdentifier = t.patch.Project
 	}
-	if pRef == nil {
-		return "", errors.Errorf("project '%s' not found", t.patch.Project)
-	}
+
 	parentPatch, err := patch.FindOneId(t.patch.Triggers.ParentPatch)
 	if err != nil {
 		return "", errors.Wrap(err, "can't get parent patch")
@@ -380,9 +377,9 @@ func (t *patchTriggers) getGithubContext() (string, error) {
 	}
 	var githubContext string
 	if patchIndex == 0 || patchIndex == -1 {
-		githubContext = fmt.Sprintf("evergreen/%s", pRef.Identifier)
+		githubContext = fmt.Sprintf("evergreen/%s", projectIdentifier)
 	} else {
-		githubContext = fmt.Sprintf("evergreen/%s/%s", pRef.Identifier, strconv.Itoa(patchIndex))
+		githubContext = fmt.Sprintf("evergreen/%s/%d", projectIdentifier, patchIndex)
 	}
 	return githubContext, nil
 }


### PR DESCRIPTION
The child patches used to appear as evergreen/project/lastFourOfChildPatchId. This didn't work with "evergreen retry" since it creates a new version, and the new child patch didn't overwrite the previous one since the context was different. 