### PR TITLE
EVG-13893 Expose 'Known Issue' status of tasks on patch/version details

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1947,10 +1947,16 @@ func (r *mutationResolver) MoveAnnotationIssue(ctx context.Context, taskID strin
 		if err := annotations.MoveIssueToSuspectedIssue(taskID, execution, *issue, usr.Username()); err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("couldn't move issue to suspected issues: %s", err.Error()))
 		}
+		if err := annotations.SetPatchKnownOrUnknown(nil, taskID); err != nil {
+			return false, InputValidationError.Send(ctx, fmt.Sprintf("error setting known failure for patch: %s", err.Error()))
+		}
 		return true, nil
 	} else {
 		if err := annotations.MoveSuspectedIssueToIssue(taskID, execution, *issue, usr.Username()); err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("couldn't move issue to suspected issues: %s", err.Error()))
+		}
+		if err := annotations.SetPatchKnownOrUnknown(nil, taskID); err != nil {
+			return false, InputValidationError.Send(ctx, fmt.Sprintf("error setting known failure for patch: %s", err.Error()))
 		}
 		return true, nil
 	}
@@ -1968,6 +1974,9 @@ func (r *mutationResolver) AddAnnotationIssue(ctx context.Context, taskID string
 	if isIssue {
 		if err := annotations.AddIssueToAnnotation(taskID, execution, *issue, usr.Username()); err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("couldn't add issue: %s", err.Error()))
+		}
+		if err := annotations.SetPatchKnownOrUnknown(nil, taskID); err != nil {
+			return false, InputValidationError.Send(ctx, fmt.Sprintf("error setting known failure for patch: %s", err.Error()))
 		}
 		return true, nil
 	} else {
@@ -1987,10 +1996,16 @@ func (r *mutationResolver) RemoveAnnotationIssue(ctx context.Context, taskID str
 		if err := annotations.RemoveIssueFromAnnotation(taskID, execution, *issue); err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("couldn't delete issue: %s", err.Error()))
 		}
+		if err := annotations.SetPatchKnownOrUnknown(nil, taskID); err != nil {
+			return false, InputValidationError.Send(ctx, fmt.Sprintf("error setting known failure for patch: %s", err.Error()))
+		}
 		return true, nil
 	} else {
 		if err := annotations.RemoveSuspectedIssueFromAnnotation(taskID, execution, *issue); err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("couldn't delete suspected issue: %s", err.Error()))
+		}
+		if err := annotations.SetPatchKnownOrUnknown(nil, taskID); err != nil {
+			return false, InputValidationError.Send(ctx, fmt.Sprintf("error setting known failure for patch: %s", err.Error()))
 		}
 		return true, nil
 	}

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -29,6 +29,7 @@ var (
 	NumberKey           = bsonutil.MustHaveTag(Patch{}, "PatchNumber")
 	VersionKey          = bsonutil.MustHaveTag(Patch{}, "Version")
 	StatusKey           = bsonutil.MustHaveTag(Patch{}, "Status")
+	KnownIssueKey       = bsonutil.MustHaveTag(Patch{}, "KnownIssue")
 	CreateTimeKey       = bsonutil.MustHaveTag(Patch{}, "CreateTime")
 	StartTimeKey        = bsonutil.MustHaveTag(Patch{}, "StartTime")
 	FinishTimeKey       = bsonutil.MustHaveTag(Patch{}, "FinishTime")

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -144,6 +144,7 @@ type Patch struct {
 	Author          string                 `bson:"author"`
 	Version         string                 `bson:"version"`
 	Status          string                 `bson:"status"`
+	KnownIssue      bool                   `bson:"known_issue"`
 	CreateTime      time.Time              `bson:"create_time"`
 	StartTime       time.Time              `bson:"start_time"`
 	FinishTime      time.Time              `bson:"finish_time"`
@@ -318,6 +319,18 @@ func (p *Patch) SetParameters(parameters []Parameter) error {
 		bson.M{
 			"$set": bson.M{
 				ParametersKey: parameters,
+			},
+		},
+	)
+}
+
+func (p *Patch) SetIsKnown(isKnown bool) error {
+	p.KnownIssue = isKnown
+	return UpdateOne(
+		bson.M{IdKey: p.Id},
+		bson.M{
+			"$set": bson.M{
+				KnownIssueKey: isKnown,
 			},
 		},
 	)

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -27,6 +27,7 @@ type APIPatch struct {
 	Author                  *string           `json:"author"`
 	Version                 *string           `json:"version"`
 	Status                  *string           `json:"status"`
+	KnownIssue              bool              `bson:"known_issue"`
 	CreateTime              *time.Time        `json:"create_time"`
 	StartTime               *time.Time        `json:"start_time"`
 	FinishTime              *time.Time        `json:"finish_time"`
@@ -95,6 +96,7 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 	apiPatch.Author = utility.ToStringPtr(v.Author)
 	apiPatch.Version = utility.ToStringPtr(v.Version)
 	apiPatch.Status = utility.ToStringPtr(v.Status)
+	apiPatch.KnownIssue = v.KnownIssue
 	apiPatch.CreateTime = ToTimePtr(v.CreateTime)
 	apiPatch.StartTime = ToTimePtr(v.StartTime)
 	apiPatch.FinishTime = ToTimePtr(v.FinishTime)
@@ -226,6 +228,7 @@ func (apiPatch *APIPatch) ToService() (interface{}, error) {
 	res.Author = utility.FromStringPtr(apiPatch.Author)
 	res.Version = utility.FromStringPtr(apiPatch.Version)
 	res.Status = utility.FromStringPtr(apiPatch.Status)
+	res.KnownIssue = apiPatch.KnownIssue
 	res.Alias = utility.FromStringPtr(apiPatch.Alias)
 	res.Activated = apiPatch.Activated
 	res.CreateTime, err = FromTimePtr(apiPatch.CreateTime)


### PR DESCRIPTION
This will eventually be used to display a 'Known Issues' badge on the patch details page in Spruce. 