### PR TITLE
EVG-14602 Add apollo tracing support to graphql server

### DIFF
--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/apollotracing"
-	"github.com/99designs/gqlgen/graphql/handler/extension"
-	"github.com/99designs/gqlgen/graphql/handler/lru"
 )
 
 // Handler returns a gimlet http handler func used as the gql route handler
@@ -14,7 +12,6 @@ func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
 	srv := handler.NewDefaultServer(NewExecutableSchema(New(apiURL)))
 
 	// Apollo tracing support https://github.com/apollographql/apollo-tracing
-	srv.Use(extension.AutomaticPersistedQuery{Cache: lru.New(100)})
 	srv.Use(apollotracing.Tracer{})
 
 	return srv.ServeHTTP

--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -4,11 +4,18 @@ import (
 	"net/http"
 
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/apollotracing"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/lru"
 )
 
 // Handler returns a gimlet http handler func used as the gql route handler
 func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
 	srv := handler.NewDefaultServer(NewExecutableSchema(New(apiURL)))
+
+	// Apollo tracing support https://github.com/apollographql/apollo-tracing
+	srv.Use(extension.AutomaticPersistedQuery{Cache: lru.New(100)})
+	srv.Use(apollotracing.Tracer{})
 
 	return srv.ServeHTTP
 }

--- a/graphql/integration_atomic_test.go
+++ b/graphql/integration_atomic_test.go
@@ -172,6 +172,16 @@ func makeTestsInDirectory(t *testing.T, state *atomicGraphQLState) func(t *testi
 				require.NoError(t, err)
 				b, err := ioutil.ReadAll(resp.Body)
 				require.NoError(t, err)
+
+				// Remove apollo tracing data from test responses
+				var bJSON map[string]json.RawMessage
+				err = json.Unmarshal(b, &bJSON)
+				require.NoError(t, err)
+
+				delete(bJSON, "extensions")
+				b, err = json.Marshal(bJSON)
+				require.NoError(t, err)
+
 				pass := assert.JSONEq(t, string(testCase.Result), string(b), "test failure, more details below (whitespace will not line up)")
 				if !pass {
 					var actual bytes.Buffer

--- a/graphql/integration_test.go
+++ b/graphql/integration_test.go
@@ -90,6 +90,16 @@ func (s *graphQLSuite) TestQueries() {
 			require.NoError(t, err)
 			b, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
+
+			// Remove apollo tracing data from test responses
+			var bJSON map[string]json.RawMessage
+			err = json.Unmarshal(b, &bJSON)
+			require.NoError(t, err)
+
+			delete(bJSON, "extensions")
+			b, err = json.Marshal(bJSON)
+			require.NoError(t, err)
+
 			assert.JSONEq(t, string(testCase.Result), string(b), fmt.Sprintf("expected %s but got %s", string(testCase.Result), string(b)))
 		}
 


### PR DESCRIPTION
This adds tooling to support query performance analysis in the graphql playground. 
https://github.com/apollographql/apollo-tracing
![image](https://user-images.githubusercontent.com/4605522/117847930-cf4d2780-b250-11eb-827d-61748683ab7c.png)
