### PR TITLE
EVG-14605: log an event when check user data done job fails to verify that a spawn host is provisioned

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -123,7 +123,7 @@ imports:
   - name: github.com/mongodb/grip
     version: d883a62b49faf8279c9209d28db88858a103177e
   - name: github.com/mongodb/amboy
-    version: 806a100c9ba430ab2a5889daed39d90954246699
+    version: 39b112dd61c55244c9b39d23a4b1008520152962
   - name: github.com/evergreen-ci/gimlet
     version: 330e9e955820a5e846d9acd67539c2884527486a
   - name: github.com/evergreen-ci/shrub

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -214,9 +214,9 @@ func LogHostTaskPidSet(hostId string, taskPid string) {
 	LogHostEvent(hostId, EventHostTaskPidSet, HostEventData{TaskPid: taskPid})
 }
 
-// LogProvisionFailed is used when Evergreen gives up on spawning a host after
-// several retries
-func LogProvisionFailed(hostId string, setupLogs string) {
+// LogHostProvisionFailed is used when Evergreen gives up on provisioning a host
+// after several retries.
+func LogHostProvisionFailed(hostId string, setupLogs string) {
 	LogHostEvent(hostId, EventHostProvisionFailed, HostEventData{Logs: setupLogs})
 }
 

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -353,7 +353,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	})
 
 	if utility.StringSliceContains(evergreen.ProvisioningHostStatus, prevStatus) && j.host.TaskCount == 0 {
-		event.LogProvisionFailed(j.HostID, fmt.Sprintf("terminating host in status '%s'", prevStatus))
+		event.LogHostProvisionFailed(j.HostID, fmt.Sprintf("terminating host in status '%s'", prevStatus))
 		grip.Info(message.Fields{
 			"message":     "provisioning failure",
 			"status":      prevStatus,

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -261,7 +261,7 @@ func (j *agentDeployJob) prepRemoteHost(ctx context.Context, settings *evergreen
 	}
 
 	if output, err = j.host.RunSSHCommand(ctx, j.host.SetupCommand()); err != nil {
-		event.LogProvisionFailed(j.host.Id, output)
+		event.LogHostProvisionFailed(j.host.Id, output)
 
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error running setup script",

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -413,7 +413,7 @@ func (j *setupHostJob) provisionHost(ctx context.Context, settings *evergreen.Se
 
 	err := j.runHostSetup(ctx, settings)
 	if err != nil {
-		event.LogProvisionFailed(j.host.Id, "")
+		event.LogHostProvisionFailed(j.host.Id, "")
 		grip.Error(message.WrapError(j.host.SetUnprovisioned(), message.Fields{
 			"operation":       "setting host unprovisioned",
 			"current_attempt": j.RetryInfo().CurrentAttempt,
@@ -464,7 +464,7 @@ func (j *setupHostJob) provisionHost(ctx context.Context, settings *evergreen.Se
 			catcher := grip.NewBasicCatcher()
 			catcher.Wrapf(err, "running distro setup script on remote host: %s", logs)
 			catcher.Wrap(j.host.SetUnprovisioned(), "setting host unprovisioned after distro setup script failed")
-			event.LogProvisionFailed(j.host.Id, logs)
+			event.LogHostProvisionFailed(j.host.Id, logs)
 			return catcher.Resolve()
 		}
 

--- a/vendor/github.com/mongodb/amboy/interface.go
+++ b/vendor/github.com/mongodb/amboy/interface.go
@@ -456,11 +456,6 @@ type RetryHandlerOptions struct {
 	// default maximum capacity. If MaxCapacity is -1, it will have unlimited
 	// capacity.
 	MaxCapacity int
-	// Disabled is a function that allows users to dynamically determine whether
-	// or not the retry handler should run. If it returns true, the retry
-	// handler will not automatically handle retrying jobs. By default, this
-	// will always return false.
-	Disabled func() bool
 }
 
 // Validate checks that all retry handler options are valid.
@@ -484,9 +479,6 @@ func (opts *RetryHandlerOptions) Validate() error {
 	}
 	if opts.MaxCapacity == 0 {
 		opts.MaxCapacity = 4096
-	}
-	if opts.Disabled == nil {
-		opts.Disabled = func() bool { return false }
 	}
 	return nil
 }

--- a/vendor/github.com/mongodb/amboy/job/base.go
+++ b/vendor/github.com/mongodb/amboy/job/base.go
@@ -58,6 +58,7 @@ func (b *Base) MarkComplete() {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
+	b.status.InProgress = false
 	b.status.Completed = true
 }
 

--- a/vendor/github.com/mongodb/amboy/queue/dispatcher.go
+++ b/vendor/github.com/mongodb/amboy/queue/dispatcher.go
@@ -213,6 +213,7 @@ func pingJobLock(ctx context.Context, q amboy.Queue, j amboy.Job) error {
 		case <-ticker.C:
 			status := j.Status()
 			status.InProgress = true
+			status.Completed = false
 			j.SetStatus(status)
 
 			if err := j.Lock(q.ID(), q.Info().LockTimeout); err != nil {

--- a/vendor/github.com/mongodb/amboy/queue/limited_serializable.go
+++ b/vendor/github.com/mongodb/amboy/queue/limited_serializable.go
@@ -698,10 +698,6 @@ func (q *limitedSizeSerializableLocal) monitorStaleRetryingJobs(ctx context.Cont
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			if q.opts.Retryable.Disabled() {
-				timer.Reset(monitorInterval)
-				continue
-			}
 			q.handleStaleRetryingJobs(ctx)
 			timer.Reset(monitorInterval)
 		}
@@ -712,9 +708,6 @@ func (q *limitedSizeSerializableLocal) handleStaleRetryingJobs(ctx context.Conte
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 	for _, j := range q.storage {
-		if q.opts.Retryable.Disabled() {
-			return
-		}
 		if !j.RetryInfo().ShouldRetry() {
 			continue
 		}

--- a/vendor/github.com/mongodb/amboy/queue/remote_base.go
+++ b/vendor/github.com/mongodb/amboy/queue/remote_base.go
@@ -539,15 +539,7 @@ func (q *remoteBase) monitorStaleRetryingJobs(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			if q.opts.retryable.Disabled() {
-				continue
-			}
-
 			for j := range q.driver.RetryableJobs(ctx, retryableJobStaleRetrying) {
-				if q.opts.retryable.Disabled() {
-					break
-				}
-
 				grip.Error(message.WrapError(q.retryHandler.Put(ctx, j), message.Fields{
 					"message":  "could not enqueue stale retrying job",
 					"service":  "amboy.queue.mdb",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14605

If the job to check when user data provisioning is done uses up all its retries, then it's likely that the host failed to provision and the host won't be transitioned from starting to running. In this case, log a host event indicating that provisioning failed.