### PR TITLE
EVG-13893 Add Known Issue display status to task query

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -71,6 +71,9 @@ const (
 	TaskStatusBlocked = "blocked"
 	TaskStatusPending = "pending"
 
+	// This is not an official task status; it is used by the front end to indicate that there is a linked issue in the annotation
+	TaskKnownIssue = "known-issue"
+
 	// Task Command Types
 	CommandTypeTest   = "test"
 	CommandTypeSystem = "system"

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -149,7 +149,7 @@ var (
 					"case": bson.M{
 						"$ne": []interface{}{
 							bson.M{
-								"$size": bson.M{"$ifNull": []interface{}{"$annotation_doc", []bson.M{}}},
+								"$size": bson.M{"$ifNull": []interface{}{"$annotation_docs", []bson.M{}}},
 							}, 0,
 						},
 					},

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -147,6 +147,12 @@ var (
 			"branches": []bson.M{
 				{
 					"case": bson.M{
+						"$ne": []interface{}{"$annotation_doc", bson.TypeNull},
+					},
+					"then": evergreen.TaskKnownIssue,
+				},
+				{
+					"case": bson.M{
 						"$eq": []interface{}{"$" + AbortedKey, true},
 					},
 					"then": evergreen.TaskAborted,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -147,7 +147,11 @@ var (
 			"branches": []bson.M{
 				{
 					"case": bson.M{
-						"$ne": []interface{}{"$annotation_doc", bson.TypeNull},
+						"$ne": []interface{}{
+							bson.M{
+								"$size": bson.M{"$ifNull": []interface{}{"$annotation_doc", []bson.M{}}},
+							}, 0,
+						},
 					},
 					"then": evergreen.TaskKnownIssue,
 				},

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2760,7 +2760,11 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 											"$eq": []string{"$" + annotations.TaskExecutionKey, "$$task_annotation_execution"},
 										},
 										{
-											"$gt": []interface{}{"$" + annotations.IssuesKey, 0},
+											"$ne": []interface{}{
+												bson.M{
+													"$size": bson.M{"$ifNull": []interface{}{"$" + annotations.IssuesKey, []bson.M{}}},
+												}, 0,
+											},
 										},
 									},
 								},
@@ -2806,12 +2810,10 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 			},
 		}...,
 	)
-
 	// Add the build variant display name to the returned subset of results if it wasn't added earlier
 	if variant == "" {
 		pipeline = append(pipeline, AddBuildVariantDisplayName...)
 	}
-
 	if len(statuses) > 0 {
 		pipeline = append(pipeline, bson.M{
 			"$match": bson.M{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2768,7 +2768,7 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 									},
 								},
 							}}},
-					"as": "annotation_doc",
+					"as": "annotation_docs",
 				},
 			},
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -56,9 +56,8 @@ var (
 )
 
 type Task struct {
-	Id     string                       `bson:"_id" json:"id"`
-	Secret string                       `bson:"secret" json:"secret"`
-	Ann    []annotations.TaskAnnotation `bson:"annotation_doc" json:"annotation_doc"`
+	Id     string `bson:"_id" json:"id"`
+	Secret string `bson:"secret" json:"secret"`
 
 	// time information for task
 	// create - the creation time for the task, derived from the commit time or the patch creation time.

--- a/rest/data/task_test.go
+++ b/rest/data/task_test.go
@@ -84,9 +84,9 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByIdAndExecution() {
 
 func (s *TaskConnectorFetchByIdSuite) TestFindByVersion() {
 	s.Require().NoError(db.ClearCollections(task.Collection, task.OldCollection, annotations.Collection))
-	task_known := &task.Task{
+	task_known_2 := &task.Task{
 		Id:        "task_known",
-		Execution: 0,
+		Execution: 2,
 		Version:   "version_known",
 	}
 	task_not_known := &task.Task{
@@ -107,18 +107,23 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByVersion() {
 		Version:   "version_with_empty_issues",
 		Status:    evergreen.TaskFailed,
 	}
-	s.NoError(task_known.Insert())
+	s.NoError(task_known_2.Insert())
 	s.NoError(task_not_known.Insert())
 	s.NoError(task_no_annotation.Insert())
 	s.NoError(task_with_empty_issues.Insert())
 
 	issue := annotations.IssueLink{URL: "https://issuelink.com", IssueKey: "EVG-1234", Source: &annotations.Source{Author: "chaya.malik"}}
 
-	a_with_issue := annotations.TaskAnnotation{TaskId: "task_known", TaskExecution: 0, Issues: []annotations.IssueLink{issue}}
+	a_execution_0 := annotations.TaskAnnotation{TaskId: "task_known", TaskExecution: 0, SuspectedIssues: []annotations.IssueLink{issue}}
+	a_execution_1 := annotations.TaskAnnotation{TaskId: "task_known", TaskExecution: 1, SuspectedIssues: []annotations.IssueLink{issue}}
+	a_execution_2 := annotations.TaskAnnotation{TaskId: "task_known", TaskExecution: 2, Issues: []annotations.IssueLink{issue}}
+
 	a_with__suspected_issue := annotations.TaskAnnotation{TaskId: "task_not_known", TaskExecution: 0, SuspectedIssues: []annotations.IssueLink{issue}}
 	a_with_empty_issues := annotations.TaskAnnotation{TaskId: "task_not_known", TaskExecution: 0, Issues: []annotations.IssueLink{}, SuspectedIssues: []annotations.IssueLink{issue}}
 
-	s.NoError(a_with_issue.Upsert())
+	s.NoError(a_execution_0.Upsert())
+	s.NoError(a_execution_1.Upsert())
+	s.NoError(a_execution_2.Upsert())
 	s.NoError(a_with__suspected_issue.Upsert())
 	s.NoError(a_with_empty_issues.Upsert())
 


### PR DESCRIPTION
[EVG-13893](https://jira.mongodb.org/browse/EVG-13893)

This adds "known-issue" as the display status if there is a task annotation in the task annotation collection that matches the taskId, execution, and has at least one issue in the issue list. 

**Testing**
Tested with both a unit test, and by pushing the changes to staging and querying PatchTasks for  patchId: "6049134597b1d353b0ea9ce5" which has a task with a status of "known-issue". 

![image](https://user-images.githubusercontent.com/13104717/119364613-12f65700-bc7d-11eb-803e-940b25093667.png)

[Spruce changes](https://github.com/evergreen-ci/spruce/pull/753)