### PR TITLE
EVG-14621: clear the agent monitor flag if the agent monitor is still alive

### DIFF
--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -151,6 +151,13 @@ func (j *agentMonitorDeployJob) Run(ctx context.Context) {
 		return
 	}
 	if alive {
+		grip.Info(message.Fields{
+			"message":   "not deploying a new agent monitor because it is still alive",
+			"host_id":   j.host.Id,
+			"distro_id": j.host.Distro.Id,
+			"job_id":    j.ID(),
+		})
+		j.AddRetryableError(j.host.SetNeedsNewAgentMonitor(false))
 		return
 	}
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14621

The agent monitor deploy job checks if the agent monitor is alive first before attempting to deploy a new one. If it's alive, the needs new agent monitor flag should be cleared to prevent further unnecessary deploys.