### PR TITLE
EVG-14310 add activated option to tasks/variants

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -672,7 +672,7 @@ func IsGitTagRequester(requester string) bool {
 	return requester == GitTagRequester
 }
 
-func ShouldConsiderBatchtime(requester string) bool {
+func ShouldConsiderDifferentActivations(requester string) bool {
 	return requester != AdHocRequester && requester != GitTagRequester
 }
 

--- a/globals.go
+++ b/globals.go
@@ -673,7 +673,7 @@ func IsGitTagRequester(requester string) bool {
 }
 
 func ShouldConsiderDifferentActivations(requester string) bool {
-	return requester != AdHocRequester && requester != GitTagRequester
+	return !IsPatchRequester(requester) && requester != AdHocRequester && requester != GitTagRequester
 }
 
 // Permissions-related constants

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -190,6 +190,9 @@ func (b *Build) UpdateGithubCheckStatus(status string) error {
 }
 
 func (b *Build) SetIsGithubCheck() error {
+	if b.IsGithubCheck {
+		return nil
+	}
 	b.IsGithubCheck = true
 	return UpdateOne(
 		bson.M{IdKey: b.Id},

--- a/model/generate.go
+++ b/model/generate.go
@@ -208,7 +208,8 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 			p.BuildVariants[i].Tasks[j].Priority = t.Priority
 		}
 	}
-	// for patches and versions triggered by users, activate all builds. Otherwise activate ones that are not setting batchtime.
+	// For patches and versions triggered by users, activate all builds.
+	// Otherwise activate ones that are not setting batchtime and are not set to false.
 	var batchTimeInfo batchTimeTasksAndVariants
 	if !evergreen.IsPatchRequester(v.Requester) && evergreen.ShouldConsiderBatchtime(v.Requester) {
 		batchTimeInfo = g.findTasksAndVariantsWithBatchTime()
@@ -316,13 +317,13 @@ func (b *batchTimeTasksAndVariants) tasksWithoutBatchTime(taskNames []string, va
 func (g *GeneratedProject) findTasksAndVariantsWithBatchTime() batchTimeTasksAndVariants {
 	res := newBatchTimeTasksAndVariants()
 	for _, bv := range g.BuildVariants {
-		if bv.BatchTime != nil || bv.CronBatchTime != "" {
+		if bv.BatchTime != nil || bv.CronBatchTime != "" || bv.Activate != nil {
 			res.variants = append(res.variants, bv.name())
 		}
 		// regardless of whether the build variant has batchtime, there may be tasks with different batchtime
 		batchTimeTasks := []string{}
 		for _, bvt := range bv.Tasks {
-			if bvt.BatchTime != nil || bvt.CronBatchTime != "" {
+			if bvt.BatchTime != nil || bvt.CronBatchTime != "" || bvt.Activate != nil {
 				batchTimeTasks = append(batchTimeTasks, bvt.Name)
 			}
 		}

--- a/model/generate.go
+++ b/model/generate.go
@@ -211,7 +211,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 	// For patches and versions triggered by users, activate all builds.
 	// Otherwise activate ones that are not setting batchtime and are not set to false.
 	var batchTimeInfo specificActivationInfo
-	if !evergreen.IsPatchRequester(v.Requester) && evergreen.ShouldConsiderDifferentActivations(v.Requester) {
+	if evergreen.ShouldConsiderDifferentActivations(v.Requester) {
 		batchTimeInfo = g.findTasksAndVariantsWithSpecificActivations()
 	}
 	newTVPairs := TaskVariantPairs{}

--- a/model/generate.go
+++ b/model/generate.go
@@ -212,7 +212,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 	// Otherwise activate ones that are not setting batchtime and are not set to false.
 	var batchTimeInfo specificActivationInfo
 	if !evergreen.IsPatchRequester(v.Requester) && evergreen.ShouldConsiderDifferentActivations(v.Requester) {
-		batchTimeInfo = g.findTasksAndVariantsWithDifferentActivations()
+		batchTimeInfo = g.findTasksAndVariantsWithSpecificActivations()
 	}
 	newTVPairs := TaskVariantPairs{}
 	for _, bv := range g.BuildVariants {
@@ -300,7 +300,7 @@ func (b *specificActivationInfo) variantHasSpecificActivation(variant string) bo
 	return utility.StringSliceContains(b.variants, variant)
 }
 
-func (b *specificActivationInfo) GetTasks(variant string) []string {
+func (b *specificActivationInfo) getTasks(variant string) []string {
 	return b.tasks[variant]
 }
 
@@ -314,7 +314,7 @@ func (b *specificActivationInfo) tasksWithoutSpecificActivation(taskNames []stri
 	return tasksWithoutSpecificActivation
 }
 
-func (g *GeneratedProject) findTasksAndVariantsWithDifferentActivations() specificActivationInfo {
+func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations() specificActivationInfo {
 	res := newSpecificActivationInfo()
 	for _, bv := range g.BuildVariants {
 		if bv.BatchTime != nil || bv.CronBatchTime != "" || bv.Activate != nil {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1652,7 +1652,9 @@ func addNewTasks(ctx context.Context, batchTimeInfo batchTimeTasksAndVariants, v
 			existingTasksIndex[t.DisplayName] = info
 		}
 		projectBV := p.FindBuildVariant(b.BuildVariant)
-		b.Activated = utility.FromBoolTPtr(projectBV.Activate) // activate unless explicitly set otherwise
+		if projectBV != nil {
+			b.Activated = utility.FromBoolTPtr(projectBV.Activate) // activate unless explicitly set otherwise
+		}
 
 		// build a list of tasks that haven't been created yet for the given variant, but have
 		// a record in the TVPairSet indicating that it should exist

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1513,7 +1513,7 @@ func addNewBuilds(ctx context.Context, batchTimeInfo specificActivationInfo, v *
 		taskNames := tasks.ExecTasks.TaskNames(pair.Variant)
 		displayNames := tasks.DisplayTasks.TaskNames(pair.Variant)
 		activateVariant := !batchTimeInfo.variantHasSpecificActivation(pair.Variant)
-		tasksWithBatchtime := batchTimeInfo.GetTasks(pair.Variant)
+		tasksWithBatchtime := batchTimeInfo.getTasks(pair.Variant)
 		buildArgs := BuildCreateArgs{
 			Project:            *p,
 			Version:            *v,
@@ -1681,7 +1681,7 @@ func addNewTasks(ctx context.Context, batchTimeInfo specificActivationInfo, v *V
 		if len(tasksToAdd) == 0 && len(displayTasksToAdd) == 0 { // no tasks to add, so we do nothing.
 			continue
 		}
-		batchTimeTasks := batchTimeInfo.GetTasks(b.BuildVariant)
+		batchTimeTasks := batchTimeInfo.getTasks(b.BuildVariant)
 		// Add the new set of tasks to the build.
 		_, tasks, err := addTasksToBuild(ctx, &b, p, v, tasksToAdd, displayTasksToAdd, batchTimeTasks, generatedBy, tasksInBuild, syncAtEndOpts, distroAliases, taskIdTables)
 		if err != nil {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -94,7 +94,7 @@ func ValidateTVPairs(p *Project, in []TVPair) error {
 // (see AddNewTasksForPatch).
 func AddNewBuildsForPatch(ctx context.Context, p *patch.Patch, patchVersion *Version, project *Project,
 	tasks TaskVariantPairs, pRef *ProjectRef) error {
-	_, _, err := addNewBuilds(ctx, batchTimeTasksAndVariants{}, patchVersion, project, tasks, p.SyncAtEndOpts, pRef, "")
+	_, _, err := addNewBuilds(ctx, specificActivationInfo{}, patchVersion, project, tasks, p.SyncAtEndOpts, pRef, "")
 	return errors.Wrap(err, "can't add new builds")
 }
 
@@ -102,7 +102,7 @@ func AddNewBuildsForPatch(ctx context.Context, p *patch.Patch, patchVersion *Ver
 // within the set of already existing builds.
 func AddNewTasksForPatch(ctx context.Context, p *patch.Patch, patchVersion *Version, project *Project,
 	pairs TaskVariantPairs, projectIdentifier string) error {
-	_, err := addNewTasks(ctx, batchTimeTasksAndVariants{}, patchVersion, project, pairs, p.SyncAtEndOpts, projectIdentifier, "")
+	_, err := addNewTasks(ctx, specificActivationInfo{}, patchVersion, project, pairs, p.SyncAtEndOpts, projectIdentifier, "")
 	return errors.Wrap(err, "can't add new tasks")
 }
 

--- a/model/project.go
+++ b/model/project.go
@@ -110,6 +110,8 @@ type BuildVariantTaskUnit struct {
 	// If CronBatchTime is not empty, then override the project settings with cron syntax,
 	// with BatchTime and CronBatchTime being mutually exclusive.
 	CronBatchTime string `yaml:"cron,omitempty" bson:"cron,omitempty"`
+	// If Activate is set to false, then we don't initially activate the task.
+	Activate *bool `yaml:"activate,omitempty" bson:"activate,omitempty"`
 }
 
 func (b BuildVariant) Get(name string) (BuildVariantTaskUnit, error) {
@@ -242,6 +244,9 @@ type BuildVariant struct {
 	// If CronBatchTime is not empty, then override the project settings with cron syntax,
 	// with BatchTime and CronBatchTime being mutually exclusive.
 	CronBatchTime string `yaml:"cron,omitempty" bson:"cron,omitempty"`
+
+	// If Activate is set to false, then we don't initially activate the build variant.
+	Activate *bool `yaml:"activate,omitempty" bson:"activate,omitempty"`
 
 	// Use a *bool so that there are 3 possible states:
 	//   1. nil   = not overriding the project setting (default)
@@ -1148,7 +1153,7 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 }
 
 func (bvt *BuildVariantTaskUnit) HasBatchTime() bool {
-	return bvt.CronBatchTime != "" || bvt.BatchTime != nil
+	return bvt.CronBatchTime != "" || bvt.BatchTime != nil || bvt.Activate != nil
 }
 
 func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -318,6 +318,8 @@ type parserBV struct {
 	Tasks         parserBVTaskUnits  `yaml:"tasks,omitempty" bson:"tasks,omitempty"`
 	DisplayTasks  []displayTask      `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
 	DependsOn     parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
+	// If Activate is set to false, then we don't initially activate the build variant.
+	Activate *bool `yaml:"activate,omitempty" bson:"activate,omitempty"`
 
 	// internal matrix stuff
 	MatrixId  string      `yaml:"matrix_id,omitempty" bson:"matrix_id,omitempty"`
@@ -386,6 +388,8 @@ type parserBVTaskUnit struct {
 	// If CronBatchTime is not empty, then override the project settings with cron syntax,
 	// with BatchTime and CronBatchTime being mutually exclusive.
 	CronBatchTime string `yaml:"cron,omitempty" bson:"cron,omitempty"`
+	// If Activate is set to false, then we don't initially activate the task.
+	Activate *bool `yaml:"activate,omitempty" bson:"activate,omitempty"`
 }
 
 // UnmarshalYAML allows the YAML parser to read both a single selector string or
@@ -737,6 +741,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			Push:          pbv.Push,
 			BatchTime:     pbv.BatchTime,
 			CronBatchTime: pbv.CronBatchTime,
+			Activate:      pbv.Activate,
 			Stepback:      pbv.Stepback,
 			RunOn:         pbv.RunOn,
 			Tags:          pbv.Tags,
@@ -942,6 +947,7 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 		CommitQueueMerge: bvt.CommitQueueMerge,
 		CronBatchTime:    bvt.CronBatchTime,
 		BatchTime:        bvt.BatchTime,
+		Activate:         bvt.Activate,
 	}
 	if res.Priority == 0 {
 		res.Priority = pt.Priority

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -262,6 +262,26 @@ buildvariants:
 	})
 }
 
+func TestIntermediateProjectWithActivated(t *testing.T) {
+	yml := `
+tasks:
+- name: "t1"
+buildvariants:
+- name: "v1"
+  activated: false 
+  run_on: "distro1"
+  tasks: 
+  - name: "t1"
+    activated: true
+`
+	p, err := createIntermediateProject([]byte(yml))
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+	bv := p.BuildVariants[0]
+	assert.False(t, utility.FromBoolTPtr(bv.Activate))
+	assert.True(t, utility.FromBoolPtr(bv.Tasks[0].Activate))
+}
+
 func TestTranslateTasks(t *testing.T) {
 	parserProject := &ParserProject{
 		BuildVariants: []parserBV{{

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -262,17 +262,17 @@ buildvariants:
 	})
 }
 
-func TestIntermediateProjectWithActivated(t *testing.T) {
+func TestIntermediateProjectWithActivate(t *testing.T) {
 	yml := `
 tasks:
 - name: "t1"
 buildvariants:
 - name: "v1"
-  activated: false 
+  activate: false 
   run_on: "distro1"
   tasks: 
   - name: "t1"
-    activated: true
+    activate: true
 `
 	p, err := createIntermediateProject([]byte(yml))
 	assert.NoError(t, err)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1284,8 +1284,16 @@ func GetActivationTimeWithCron(curTime time.Time, cronBatchTime string) (time.Ti
 
 func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Time, error) {
 	defaultRes := time.Now()
+	// if we don't want to activate the build, set batchtime to the zero time
+	if !utility.FromBoolTPtr(variant.Activate) {
+		return utility.ZeroTime, nil
+	}
 	if variant.CronBatchTime != "" {
 		return GetActivationTimeWithCron(time.Now(), variant.CronBatchTime)
+	}
+	// if activated explicitly set to true and we don't have batchtime, then we want to just activate now
+	if utility.FromBoolPtr(variant.Activate) && variant.BatchTime == nil {
+		return time.Now(), nil
 	}
 
 	lastActivated, err := VersionFindOne(VersionByLastVariantActivation(p.Id, variant.Name).WithFields(VersionBuildVariantsKey))
@@ -1311,8 +1319,16 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Ti
 
 func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit) (time.Time, error) {
 	defaultRes := time.Now()
+	// if we don't want to activate the task, set batchtime to the zero time
+	if !utility.FromBoolTPtr(t.Activate) {
+		return utility.ZeroTime, nil
+	}
 	if t.CronBatchTime != "" {
 		return GetActivationTimeWithCron(time.Now(), t.CronBatchTime)
+	}
+	// if activated explicitly set to true and we don't have batchtime, then we want to just activate now
+	if utility.FromBoolPtr(t.Activate) && t.BatchTime == nil {
+		return time.Now(), nil
 	}
 
 	lastActivated, err := VersionFindOne(VersionByLastTaskActivation(p.Id, t.Variant, t.Name).WithFields(VersionBuildVariantsKey))

--- a/model/version.go
+++ b/model/version.go
@@ -241,7 +241,7 @@ type ActivationStatus struct {
 }
 
 func (s *ActivationStatus) ShouldActivate(now time.Time) bool {
-	return !s.Activated && now.After(s.ActivateAt) && !s.ActivateAt.IsZero()
+	return !s.Activated && now.After(s.ActivateAt) && !s.ActivateAt.IsZero() && !utility.IsZeroTime(s.ActivateAt)
 }
 
 // VersionMetadata is used to pass information about upstream versions to downstream version creation

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -994,6 +994,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			TaskCreateTime:      v.CreateTime,
 			GithubChecksAliases: aliasesMatchingVariant,
 		}
+
 		b, tasks, err := model.CreateBuildFromVersionNoInsert(args)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
@@ -1044,7 +1045,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}
 
 		grip.Debug(message.Fields{
-			"message":            "activating build",
+			"message":            "created build",
 			"name":               buildvariant.Name,
 			"project":            projectInfo.Ref.Id,
 			"project_identifier": projectInfo.Ref.Identifier,
@@ -1158,11 +1159,12 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			return errors.Wrapf(err, "error committing transaction for version '%s'", v.Id)
 		}
 		grip.Info(message.Fields{
-			"message": "successfully created version",
-			"version": v.Id,
-			"hash":    v.Revision,
-			"project": v.Identifier,
-			"runner":  RunnerName,
+			"message":         "successfully created version",
+			"version":         v.Id,
+			"hash":            v.Revision,
+			"project":         v.Identifier,
+			"tasks_to_create": tasksToCreate,
+			"runner":          RunnerName,
 		})
 		return nil
 	}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -1019,7 +1019,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 
 		activateVariantAt := time.Now()
 		taskStatuses := []model.BatchTimeTaskStatus{}
-		if metadata.TriggerID == "" && evergreen.ShouldConsiderBatchtime(v.Requester) {
+		if metadata.TriggerID == "" && evergreen.ShouldConsiderDifferentActivations(v.Requester) {
 			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(&buildvariant)
 			batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for variant '%s'", buildvariant.Name))
 			// add only tasks that require activation times

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -817,6 +817,15 @@ func validateBVBatchTimes(project *model.Project) ValidationErrors {
 	for _, buildVariant := range project.BuildVariants {
 		// check task batchtimes first
 		for _, t := range buildVariant.Tasks {
+			// setting explicitly to true with batchtime will use batchtime
+			if utility.FromBoolPtr(t.Activate) && (t.CronBatchTime != "" || t.BatchTime != nil) {
+				errs = append(errs,
+					ValidationError{
+						Message: fmt.Sprintf("task '%s' for variant '%s' activation ignored since batchtime specified",
+							t.Name, buildVariant.Name),
+						Level: Warning,
+					})
+			}
 			if t.CronBatchTime == "" {
 				continue
 			}
@@ -839,6 +848,13 @@ func validateBVBatchTimes(project *model.Project) ValidationErrors {
 			}
 		}
 
+		if utility.FromBoolPtr(buildVariant.Activate) && (buildVariant.CronBatchTime != "" || buildVariant.BatchTime != nil) {
+			errs = append(errs,
+				ValidationError{
+					Message: fmt.Sprintf("variant '%s' activation ignored since batchtime specified", buildVariant.Name),
+					Level:   Warning,
+				})
+		}
 		if buildVariant.CronBatchTime == "" {
 			continue
 		}

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1056,6 +1056,11 @@ func TestValidateBVBatchTimes(t *testing.T) {
 
 	p.BuildVariants[0].Tasks[0].BatchTime = nil
 	assert.Len(t, validateBVBatchTimes(p), 0)
+
+	// warning if activated to true with batchtime
+	p.BuildVariants[0].Activate = utility.TruePtr()
+	assert.Len(t, validateBVBatchTimes(p), 1)
+
 }
 
 func TestValidateBVsContainTasks(t *testing.T) {


### PR DESCRIPTION
This allows `"activate": true` or `"activate": false` to be provided from a generator or from the yaml. The default for `activate` is `true`. This can be given at the build variant and the task level, where the task configuration overrides the build variant. If a task is a dependency for an activated task or has a batchtime then an `"activate": false` would be ignored. This should also cover https://jira.mongodb.org/browse/EVG-1579 (although it adds a new field rather than having a zero batchtime field, it actually does work by specifying the zero field for batchtime and using the existing batchtime activation logic).

Tested this with different configurations of yaml on sandbox staging, as well as modifying sandbox's evergreen.json.