### PR TITLE
EVG-14617: revendor amboy

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -501,7 +501,6 @@ func (e *envState) initQueues(ctx context.Context) []error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(e.localQueue == nil, "local queue is not defined")
 	catcher.NewWhen(e.notificationsQueue == nil, "notification queue is not defined")
-	catcher.NewWhen(e.notificationsQueue == nil, "notification queue is not defined")
 
 	if e.localQueue != nil {
 		catcher.Add(e.localQueue.Start(ctx))

--- a/glide.lock
+++ b/glide.lock
@@ -121,7 +121,7 @@ imports:
   - name: github.com/mongodb/grip
     version: d883a62b49faf8279c9209d28db88858a103177e
   - name: github.com/mongodb/amboy
-    version: 39b112dd61c55244c9b39d23a4b1008520152962
+    version: 4ce920c4d6786f247e28dab752b53b478663b9c2
   - name: github.com/evergreen-ci/gimlet
     version: 330e9e955820a5e846d9acd67539c2884527486a
   - name: github.com/evergreen-ci/shrub

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -68,6 +68,8 @@ func NewHostAllocatorJob(env evergreen.Environment, distroID string, timestamp t
 func (j *hostAllocatorJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
+	j.env = evergreen.GetEnvironment()
+
 	config, err := evergreen.GetConfig()
 	if err != nil {
 		j.AddError(errors.Wrap(err, "Can't get evergreen configuration"))

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -68,7 +68,9 @@ func NewHostAllocatorJob(env evergreen.Environment, distroID string, timestamp t
 func (j *hostAllocatorJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	j.env = evergreen.GetEnvironment()
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
 
 	config, err := evergreen.GetConfig()
 	if err != nil {

--- a/vendor/github.com/mongodb/amboy/queue/dispatcher.go
+++ b/vendor/github.com/mongodb/amboy/queue/dispatcher.go
@@ -26,12 +26,17 @@ type Dispatcher interface {
 	// Complete relinquishes the worker's exclusive ownership of the job. It may
 	// optionally update metadata indicating that the job is finished.
 	Complete(context.Context, amboy.Job)
+	// Close cleans up all resources used by the Dispatcher and releases all
+	// actively-dispatched jobs. Jobs should not be dispatchable after this is
+	// called.
+	Close(context.Context) error
 }
 
 type dispatcherImpl struct {
-	queue amboy.Queue
-	mutex sync.Mutex
-	cache map[string]dispatcherInfo
+	queue  amboy.Queue
+	mutex  sync.Mutex
+	cache  map[string]dispatcherInfo
+	closed bool
 }
 
 // NewDispatcher constructs a default dispatching implementation.
@@ -61,7 +66,11 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, j amboy.Job) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	if info, ok := d.popInfo(j); ok {
+	if d.closed {
+		return errors.New("dispatcher is closed")
+	}
+
+	if info, ok := d.popInfo(j.ID()); ok {
 		grip.Debug(message.Fields{
 			"message":  "re-dispatching job that has already been dispatched",
 			"queue_id": d.queue.ID(),
@@ -136,7 +145,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, j amboy.Job) error {
 
 func (d *dispatcherImpl) Release(ctx context.Context, j amboy.Job) {
 	d.mutex.Lock()
-	info, ok := d.popInfo(j)
+	info, ok := d.popInfo(j.ID())
 	if !ok {
 		d.mutex.Unlock()
 		return
@@ -155,15 +164,15 @@ func (d *dispatcherImpl) Release(ctx context.Context, j amboy.Job) {
 // popInfo retrieves and removes information related to the dispatch of a job,
 // returning the removed information to the caller and whether or not the
 // information was found.
-func (d *dispatcherImpl) popInfo(j amboy.Job) (dispatcherInfo, bool) {
-	info, ok := d.cache[j.ID()]
-	delete(d.cache, j.ID())
+func (d *dispatcherImpl) popInfo(jobID string) (dispatcherInfo, bool) {
+	info, ok := d.cache[jobID]
+	delete(d.cache, jobID)
 	return info, ok
 }
 
 func (d *dispatcherImpl) Complete(ctx context.Context, j amboy.Job) {
 	d.mutex.Lock()
-	info, ok := d.popInfo(j)
+	info, ok := d.popInfo(j.ID())
 	if !ok {
 		d.mutex.Unlock()
 		return
@@ -185,6 +194,30 @@ func (d *dispatcherImpl) Complete(ctx context.Context, j amboy.Job) {
 		"queue_id": d.queue.ID(),
 		"service":  "amboy.queue.dispatcher",
 	}))
+}
+
+// Close releases all jobs currently locked by the dispatcher and waits for
+// all ping threads to exit.
+func (d *dispatcherImpl) Close(ctx context.Context) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	if d.closed {
+		return nil
+	}
+
+	d.closed = true
+
+	catcher := grip.NewBasicCatcher()
+	for jobID := range d.cache {
+		info, ok := d.popInfo(jobID)
+		if !ok {
+			continue
+		}
+		catcher.Wrapf(d.waitForPing(ctx, info), "waiting for job ping to complete for job '%s'", jobID)
+	}
+
+	return catcher.Resolve()
 }
 
 // waitForPing cancels the dispatcher ping for a job and waits for the pinger to

--- a/vendor/github.com/mongodb/amboy/queue/driver.go
+++ b/vendor/github.com/mongodb/amboy/queue/driver.go
@@ -13,7 +13,7 @@ import (
 type remoteQueueDriver interface {
 	ID() string
 	Open(context.Context) error
-	Close()
+	Close(context.Context) error
 
 	// Get finds a job by job ID. For retryable jobs, this returns the latest
 	// job attempt.

--- a/vendor/github.com/mongodb/amboy/queue/queue_test.go
+++ b/vendor/github.com/mongodb/amboy/queue/queue_test.go
@@ -201,12 +201,15 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 				}
 
 				closer := func(ctx context.Context) error {
+					catcher := grip.NewBasicCatcher()
 					d := rq.Driver()
 					if d != nil {
-						d.Close()
+						catcher.Add(d.Close(ctx))
 					}
 
-					return client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx)
+					catcher.Add(client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx))
+
+					return catcher.Resolve()
 				}
 
 				return q, closer, nil
@@ -240,12 +243,16 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 				}
 
 				closer := func(ctx context.Context) error {
+					catcher := grip.NewBasicCatcher()
+
 					d := rq.Driver()
 					if d != nil {
-						d.Close()
+						catcher.Add(d.Close(ctx))
 					}
 
-					return client.Database(opts.MDB.DB).Collection(addGroupSuffix(name)).Drop(ctx)
+					catcher.Add(client.Database(opts.MDB.DB).Collection(addGroupSuffix(name)).Drop(ctx))
+
+					return catcher.Resolve()
 				}
 
 				return q, closer, nil
@@ -278,12 +285,15 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 				}
 
 				closer := func(ctx context.Context) error {
+					catcher := grip.NewBasicCatcher()
 					d := rq.Driver()
 					if d != nil {
-						d.Close()
+						catcher.Add(d.Close(ctx))
 					}
 
-					return client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx)
+					catcher.Add(client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx))
+
+					return catcher.Resolve()
 				}
 
 				return q, closer, nil
@@ -316,12 +326,15 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 				}
 
 				closer := func(ctx context.Context) error {
+					catcher := grip.NewBasicCatcher()
 					d := rq.Driver()
 					if d != nil {
-						d.Close()
+						catcher.Add(d.Close(ctx))
 					}
 
-					return client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx)
+					catcher.Add(client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx))
+
+					return catcher.Resolve()
 				}
 
 				return q, closer, nil

--- a/vendor/github.com/mongodb/amboy/queue/remote.go
+++ b/vendor/github.com/mongodb/amboy/queue/remote.go
@@ -47,10 +47,9 @@ func (opts *MongoDBQueueCreationOptions) Validate() error {
 }
 
 func (opts *MongoDBQueueCreationOptions) build(ctx context.Context) (amboy.RetryableQueue, error) {
-	var driver remoteQueueDriver
-	var err error
 
 	var q remoteQueue
+	var err error
 	qOpts := remoteOptions{
 		numWorkers: opts.Size,
 		retryable:  opts.Retryable,
@@ -65,6 +64,7 @@ func (opts *MongoDBQueueCreationOptions) build(ctx context.Context) (amboy.Retry
 		}
 	}
 
+	var driver remoteQueueDriver
 	if opts.Client == nil {
 		if opts.MDB.UseGroups {
 			driver, err = newMongoGroupDriver(opts.Name, opts.MDB, opts.MDB.GroupName)

--- a/vendor/github.com/mongodb/amboy/queue/remote_base.go
+++ b/vendor/github.com/mongodb/amboy/queue/remote_base.go
@@ -39,6 +39,7 @@ type remoteBase struct {
 	dispatched   map[string]struct{}
 	runner       amboy.Runner
 	retryHandler amboy.RetryHandler
+	cancel       context.CancelFunc
 	mutex        sync.RWMutex
 }
 
@@ -446,6 +447,8 @@ func (q *remoteBase) Start(ctx context.Context) error {
 		return errors.New("cannot start queue with an uninitialized runner")
 	}
 
+	ctx, q.cancel = context.WithCancel(ctx)
+
 	err := q.runner.Start(ctx)
 	if err != nil {
 		return errors.Wrap(err, "problem starting runner in remote queue")
@@ -470,7 +473,26 @@ func (q *remoteBase) Start(ctx context.Context) error {
 	return nil
 }
 
+// Close closes all resources owned by the queue and stops any further
+// processing of the queue's work.
 func (q *remoteBase) Close(ctx context.Context) {
+	if q.cancel != nil {
+		q.cancel()
+	}
+	if q.dispatcher != nil {
+		grip.Warning(message.WrapError(q.dispatcher.Close(ctx), message.Fields{
+			"message":  "dispatcher closed with errors",
+			"service":  "amboy.queue.mdb",
+			"queue_id": q.ID(),
+		}))
+	}
+	if q.driver != nil {
+		grip.Warning(message.WrapError(q.driver.Close(ctx), message.Fields{
+			"message":  "driver closed with errors",
+			"service":  "amboy.queue.mdb",
+			"queue_id": q.ID(),
+		}))
+	}
 	if r := q.Runner(); r != nil {
 		r.Close(ctx)
 	}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14617

* Revendor amboy to 4ce920c4d6786f247e28dab752b53b478663b9c2.
* Remove unnecessary duplicate check in global environment setup.
* Fix a bug in the host allocator where it can panic because the environment is never initialized.