### PR TITLE
EVG-14524: exclude test-cloud from MacOS buildvariant

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -652,6 +652,7 @@ buildvariants:
       - name: "js-test"
       - name: "verify-agent-version-update"
       - name: "docker-cleanup"
+      - name: test-cloud
 
   - name: race-detector
     display_name: Race Detector
@@ -666,7 +667,6 @@ buildvariants:
       test_timeout: 15m
     tasks:
       - name: ".test"
-      - name: test-cloud
 
   - name: lint
     display_name: Lint

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -447,7 +447,7 @@ tasks:
     tags: ["db", "test"]
     name: test-db
   - <<: *run-go-test-suite-with-docker
-    tags: ["db", "test"]
+    tags: ["db"]
     name: test-cloud
   - <<: *run-go-test-suite
     tags: ["nodb", "test"]
@@ -666,6 +666,7 @@ buildvariants:
       test_timeout: 15m
     tasks:
       - name: ".test"
+      - name: test-cloud
 
   - name: lint
     display_name: Lint


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14524

MacOS doesn't run Docker, so skip the cloud provider tests.