### PR TITLE
EVG-14418 consider the commit queue issue for the patch ID

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1559,6 +1559,7 @@ func (r *queryResolver) CommitQueue(ctx context.Context, id string) (*restModel.
 		} else if utility.FromStringPtr(item.PatchId) != "" {
 			patchId = utility.FromStringPtr(item.PatchId)
 		}
+
 		if patchId != "" {
 			p, err := r.sc.FindPatchById(patchId)
 			if err != nil {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -637,7 +637,7 @@ func (e *EnqueuePatch) Send() error {
 		return errors.Wrap(err, "problem making merge patch")
 	}
 
-	_, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: mergePatch.Id.Hex(), Source: commitqueue.SourceDiff})
+	_, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: mergePatch.Id.Hex(), PatchId: mergePatch.Id.Hex(), Source: commitqueue.SourceDiff})
 
 	return errors.Wrap(err, "can't enqueue item")
 }
@@ -819,7 +819,7 @@ func restartDiffItem(p patch.Patch, cq *commitqueue.CommitQueue) error {
 	if err = newPatch.Insert(); err != nil {
 		return errors.Wrap(err, "error inserting patch")
 	}
-	if _, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: newPatch.Id.Hex(), Source: commitqueue.SourceDiff}); err != nil {
+	if _, err = cq.Enqueue(commitqueue.CommitQueueItem{Issue: newPatch.Id.Hex(), PatchId: newPatch.Id.Hex(), Source: commitqueue.SourceDiff}); err != nil {
 		return errors.Wrap(err, "error enqueuing item")
 	}
 	return nil

--- a/rest/route/commit_queue.go
+++ b/rest/route/commit_queue.go
@@ -209,7 +209,8 @@ func (cq *commitQueueEnqueueItemHandler) Run(ctx context.Context) gimlet.Respond
 	if patchEmpty {
 		return gimlet.MakeJSONErrorResponder(errors.New("can't enqueue item, patch is empty"))
 	}
-	position, err := cq.sc.EnqueueItem(cq.project, model.APICommitQueueItem{Issue: utility.ToStringPtr(cq.item), Source: utility.ToStringPtr(commitqueue.SourceDiff)}, cq.force)
+	patchId := utility.ToStringPtr(cq.item)
+	position, err := cq.sc.EnqueueItem(cq.project, model.APICommitQueueItem{Issue: patchId, PatchId: patchId, Source: utility.ToStringPtr(commitqueue.SourceDiff)}, cq.force)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "can't enqueue item"))
 	}


### PR DESCRIPTION
When we enqueue patch commit queue items we don't set patchID, just the Issue (we use patchID for PRs I believe), so we don't display them correctly unless the version is created (in which case versionID is set and we correctly populate patchId here). 
We could just check issue ID in the CommitQueue resolver in addition to version and issue rather than populating patchID, but I think it's confusing to maintain a field that exists for both sources but is only maintained for one.

Context: patchId is the source of this bug because without it we default to the "Pull Request #\<issue\>" format [in Spruce](https://github.com/evergreen-ci/spruce/blob/15f0bc7839be439712b7b597b0cce75c3cda95f7/src/pages/commitqueue/CommitQueueCard.tsx#L74)