### PR TITLE
EVG-14649: do not track processes in mock environment

### DIFF
--- a/mock/environment.go
+++ b/mock/environment.go
@@ -71,7 +71,7 @@ func (e *Environment) Configure(ctx context.Context) error {
 
 	e.InternalSender = send.MakeInternalLogger()
 
-	jpm, err := jasper.NewSynchronizedManager(true)
+	jpm, err := jasper.NewSynchronizedManager(false)
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14649

Setting true vs false here toggles whether or not Jasper's child processes are terminated in the mock environment using cgroups in Linux/job objects in Windows, which might help clean up child processes better. Since we can't even use those features in CI tests, I just disabled them.