### PR TITLE
EVG-14522 Return http.Client to pool after github.Client is done

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -254,7 +254,7 @@ func (c *gitFetchProject) buildCloneCommand(ctx context.Context, conf *internal.
 			// proceed if github has confirmed this pr is mergeable. If it hasn't checked, this request
 			// will make it check.
 			// https://docs.github.com/en/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests
-			commitToTest, err = c.waitForMergeableCheck(ctx, logger, opts.owner, opts.repo, conf.GithubPatchData.PRNumber)
+			commitToTest, err = c.waitForMergeableCheck(ctx, opts.owner, opts.repo, conf.GithubPatchData.PRNumber)
 			if err != nil {
 				logger.Task().Error(errors.Wrap(err, "error checking if pull request is mergeable"))
 				commitToTest = conf.GithubPatchData.HeadHash
@@ -290,7 +290,7 @@ func (c *gitFetchProject) buildCloneCommand(ctx context.Context, conf *internal.
 	return gitCommands, nil
 }
 
-func (c *gitFetchProject) waitForMergeableCheck(ctx context.Context, logger client.LoggerProducer, owner, repo string, prNum int) (string, error) {
+func (c *gitFetchProject) waitForMergeableCheck(ctx context.Context, owner, repo string, prNum int) (string, error) {
 	var mergeSHA string
 	err := util.Retry(ctx, func() (bool, error) {
 		pr, _, err := c.githubClient.PullRequests.Get(ctx, owner, repo, prNum)
@@ -298,7 +298,6 @@ func (c *gitFetchProject) waitForMergeableCheck(ctx context.Context, logger clie
 			return false, errors.Wrap(err, "error getting pull request data from Github")
 		}
 		if pr.Mergeable == nil {
-			logger.Execution().Info("Mergeable check not ready")
 			return true, nil
 		}
 		if *pr.Mergeable {
@@ -354,24 +353,12 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 // Execute gets the source code required by the project
 // Retries some number of times before failing
 func (c *gitFetchProject) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
-	var err error
-	// expand the github parameters before running the task
-	if err = util.ExpandValues(c, conf.Expansions); err != nil {
-		return errors.Wrap(err, "error expanding github parameters")
-	}
-
-	var projectMethod string
-	var projectToken string
-	projectMethod, projectToken, err = getProjectMethodAndToken(c.Token, conf.Expansions.Get(evergreen.GlobalGitHubTokenExpansion), conf.Distro.CloneMethod)
-	if err != nil {
-		return errors.Wrap(err, "failed to get method of cloning and token")
-	}
 	httpClient := utility.GetOAuth2HTTPClient(projectToken)
 	defer utility.PutHTTPClient(httpClient)
-	err = util.Retry(
+	err := util.Retry(
 		ctx,
 		func() (bool, error) {
-			err := c.executeLoop(ctx, comm, logger, conf, projectMethod, projectToken)
+			err := c.executeLoop(ctx, comm, logger, conf)
 			if err != nil {
 				return true, err
 			}
@@ -390,8 +377,21 @@ func (c *gitFetchProject) Execute(ctx context.Context, comm client.Communicator,
 	return err
 }
 
-func (c *gitFetchProject) executeLoop(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig, projectMethod, projectToken string) error {
+func (c *gitFetchProject) executeLoop(ctx context.Context,
+	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
+
 	var err error
+	// expand the github parameters before running the task
+	if err = util.ExpandValues(c, conf.Expansions); err != nil {
+		return errors.Wrap(err, "error expanding github parameters")
+	}
+
+	var projectMethod string
+	var projectToken string
+	projectMethod, projectToken, err = getProjectMethodAndToken(c.Token, conf.Expansions.Get(evergreen.GlobalGitHubTokenExpansion), conf.Distro.CloneMethod)
+	if err != nil {
+		return errors.Wrap(err, "failed to get method of cloning and token")
+	}
 	if c.githubClient == nil {
 		c.githubClient = github.NewClient(c.httpClient)
 	}

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-05-18"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-05-20"
+	AgentVersion = "2021-05-21"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Before this change, Execute() called executeLoop() in a loop. executeLoop() created a github.Client if one did not already exist in its receiver. However, to create this github.Client, it first constructed an http.Client by asking for one from the httpClient pool. It deferred putting it back into the pool until the end of executeLoop(). This is a bug. Putting it back in the pool unset its token. The next time the loop in Execute() calls executeLoop(), the http.Client's token was unset.

Separately, this change increases the time between retries for checking the mergeability of a pull request. The GitHub docs explicitly ask that you poll, which we do. However, https://docs.github.com/en/rest/guides/getting-started-with-the-git-database-api does not explain what a reasonable polling interval is. I suspect that EVG-14522 occurred because we only polled for 10 seconds, which is occasionally not enough. This PR changes this to approximately 1 minute.

This could also be the source of some of our GitHub API limits problems. If GitHub becomes slower than 10 seconds to create a test merge commit, then we will spend 10 API requests on each attempt.