### PR TITLE
EVG-14564 log information about failing API requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-05-18"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-05-21"
+	AgentVersion = "2021-05-21b"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Legacy test logs and attach files is sometimes returning "unexpected end of JSON input" which is confusing since we're using the same structs on both sides. 