### PR TITLE
EVG-14676 check identifier and ID when getting build baron

### DIFF
--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -51,7 +51,7 @@ func BbFileTicket(context context.Context, taskId string, execution int) (bool, 
 	env := evergreen.GetEnvironment()
 	settings := env.Settings()
 	queue := env.RemoteQueue()
-	bbProject, ok := BbProjectForTask(settings, t.Project)
+	bbProject, ok := BbGetProject(settings, t.Project)
 	if !ok {
 		return taskNotFound, errors.Errorf("error finding build baron plugin for task '%s'", taskId)
 	}
@@ -79,7 +79,7 @@ func BbFileTicket(context context.Context, taskId string, execution int) (bool, 
 }
 
 func IsWebhookConfigured(t *task.Task) bool {
-	bbProject, _ := BbProjectForTask(evergreen.GetEnvironment().Settings(), t.Project)
+	bbProject, _ := BbGetProject(evergreen.GetEnvironment().Settings(), t.Project)
 	webHook := bbProject.TaskAnnotationSettings.FileTicketWebHook
 	return webHook.Endpoint != ""
 }
@@ -193,7 +193,7 @@ func GetSearchReturnInfo(taskId string, exec string) (*thirdparty.SearchReturnIn
 		return nil, bbConfig, err
 	}
 	settings := evergreen.GetEnvironment().Settings()
-	bbProj, ok := BbProjectForTask(settings, t.Project)
+	bbProj, ok := BbGetProject(settings, t.Project)
 	if !ok {
 		// build baron project not found, meaning it's not configured for
 		// either regular build baron or for a custom ticket filing webhook
@@ -253,9 +253,8 @@ func BbGetConfig(settings *evergreen.Settings) map[string]evergreen.BuildBaronPr
 	return projects
 }
 
-func BbProjectForTask(settings *evergreen.Settings, projectId string) (evergreen.BuildBaronProject, bool) {
+func BbGetProject(settings *evergreen.Settings, projectId string) (evergreen.BuildBaronProject, bool) {
 	buildBaronProjects := BbGetConfig(settings)
-	//if there is a custom web-hook, use that
 	bbProject, ok := buildBaronProjects[projectId]
 	if !ok {
 		// project may be stored under the identifier rather than the ID

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -94,6 +94,9 @@ func (bbp *BuildBaronPlugin) GetPanelConfig() (*PanelConfig, error) {
 				},
 				DataFunc: func(context UIContext) (interface{}, error) {
 					enabled := len(bbp.opts.Projects[context.ProjectRef.Id].TicketSearchProjects) > 0
+					if !enabled {
+						enabled = len(bbp.opts.Projects[context.ProjectRef.Identifier].TicketSearchProjects) > 0
+					}
 					return struct {
 						Enabled bool `json:"enabled"`
 					}{enabled}, nil

--- a/plugin/perf.go
+++ b/plugin/perf.go
@@ -53,9 +53,10 @@ func (pp *PerfPlugin) GetPanelConfig() (*PanelConfig, error) {
 				Position:  PageCenter,
 				PanelHTML: template.HTML(panelHTML),
 				DataFunc: func(context UIContext) (interface{}, error) {
+					enabled := utility.StringSliceContains(pp.Projects, context.ProjectRef.Id) || utility.StringSliceContains(pp.Projects, context.ProjectRef.Identifier)
 					return struct {
 						Enabled bool `json:"enabled"`
-					}{utility.StringSliceContains(pp.Projects, context.ProjectRef.Id)}, nil
+					}{Enabled: enabled}, nil
 				},
 			},
 		},


### PR DESCRIPTION
Truly the build baron plugin should use the ID but I'm not sure where that's generated; is it user generated? Do we construct it somewhere? @malikchaya2 may have context on that. If that's something that we can use to use IDs instead of identifiers then we should, because if identifiers change then the plugin project name would also need to change, but if it's not something we can control then we should just both as a "better safe than sorry". 