### PR TITLE
EVG-14513 add validator change for backwards compatability

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -531,7 +532,7 @@ func (as *APIServer) listVariants(w http.ResponseWriter, r *http.Request) {
 func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Request) {
 	body := util.NewRequestReader(r)
 	defer body.Close()
-	yamlBytes, err := ioutil.ReadAll(body)
+	bytes, err := ioutil.ReadAll(body)
 	if err != nil {
 		gimlet.WriteJSONError(w, fmt.Sprintf("Error reading request body: %v", err))
 		return
@@ -539,13 +540,23 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 
 	project := &model.Project{}
 	validationErr := validator.ValidationError{}
-	if _, err = model.LoadProjectInto(yamlBytes, "", project); err != nil {
-		validationErr.Message = err.Error()
-		gimlet.WriteJSONError(w, validator.ValidationErrors{validationErr})
-		return
+	if _, err = model.LoadProjectInto(bytes, "", project); err != nil {
+		// try the new validation input format before erroring
+		input := validator.ValidationInput{}
+		if err2 := json.Unmarshal(bytes, &input); err2 != nil {
+			// return original error, since the format is likely not ValidationInput
+			validationErr.Message = err.Error()
+			gimlet.WriteJSONError(w, validator.ValidationErrors{validationErr})
+			return
+		}
+		if _, err = model.LoadProjectInto(input.ProjectYaml, "", project); err != nil {
+			validationErr.Message = err.Error()
+			gimlet.WriteJSONError(w, validator.ValidationErrors{validationErr})
+			return
+		}
 	}
 
-	errs := validator.CheckYamlStrict(yamlBytes)
+	errs := validator.CheckYamlStrict(bytes)
 	errs = append(errs, validator.CheckProjectSyntax(project)...)
 	errs = append(errs, validator.CheckProjectSemantics(project)...)
 	if len(errs) > 0 {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -91,6 +91,12 @@ func (v ValidationErrors) AtLevel(level ValidationErrorLevel) ValidationErrors {
 	return errs
 }
 
+type ValidationInput struct {
+	ProjectYaml []byte `json:"project_yaml" yaml:"project_yaml"`
+	Quiet       bool   `json:"quiet" yaml:"quiet"`
+	IncludeLong bool   `json:"include_long" yaml:"include_long"`
+}
+
 // Functions used to validate the syntax of a project configuration file.
 var projectSyntaxValidators = []projectValidator{
 	ensureHasNecessaryBVFields,


### PR DESCRIPTION
To be deployed ahead of https://github.com/evergreen-ci/evergreen/pull/4701 so if that needs to be reverted, we'll have this baked in to be able to read the ValidationInput format.