### PR TITLE
EVG-14684: Allow test results to be uploaded multiple times

### DIFF
--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -98,16 +98,18 @@ func sendTestResultsToCedar(ctx context.Context, conf *internal.TaskConfig, td c
 		return errors.Wrap(err, "getting this task's display task info")
 	}
 
-	id, err := client.CreateRecord(ctx, makeCedarTestResultsRecord(conf, displayTaskInfo))
-	if err != nil {
-		return errors.Wrap(err, "creating test results record")
+	if conf.CedarTestResultsID == "" {
+		conf.CedarTestResultsID, err = client.CreateRecord(ctx, makeCedarTestResultsRecord(conf, displayTaskInfo))
+		if err != nil {
+			return errors.Wrap(err, "creating test results record")
+		}
 	}
 
-	if err = client.AddResults(ctx, makeCedarTestResults(id, conf.Task, results)); err != nil {
+	if err = client.AddResults(ctx, makeCedarTestResults(conf.CedarTestResultsID, conf.Task, results)); err != nil {
 		return errors.Wrap(err, "adding test results")
 	}
 
-	if err = client.CloseRecord(ctx, id); err != nil {
+	if err = client.CloseRecord(ctx, conf.CedarTestResultsID); err != nil {
 		return errors.Wrap(err, "closing test results record")
 	}
 

--- a/agent/command/results_utils_test.go
+++ b/agent/command/results_utils_test.go
@@ -112,6 +112,7 @@ func TestSendTestResults(t *testing.T) {
 			"Succeeds": func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock) {
 				require.NoError(t, sendTestResults(ctx, comm, logger, conf, results))
 
+				assert.Equal(t, srv.Close.TestResultsRecordId, conf.CedarTestResultsID)
 				checkRecord(t, srv)
 				checkResults(t, srv)
 				assert.NotZero(t, srv.Close.TestResultsRecordId)
@@ -121,6 +122,7 @@ func TestSendTestResults(t *testing.T) {
 				results.Results[0].DisplayTestName = ""
 				require.NoError(t, sendTestResults(ctx, comm, logger, conf, results))
 
+				assert.Equal(t, srv.Close.TestResultsRecordId, conf.CedarTestResultsID)
 				checkRecord(t, srv)
 				checkResults(t, srv)
 				assert.NotZero(t, srv.Close.TestResultsRecordId)
@@ -131,6 +133,7 @@ func TestSendTestResults(t *testing.T) {
 				results.Results[0].LogTestName = ""
 				require.NoError(t, sendTestResults(ctx, comm, logger, conf, results))
 
+				assert.Equal(t, srv.Close.TestResultsRecordId, conf.CedarTestResultsID)
 				checkRecord(t, srv)
 				checkResults(t, srv)
 				assert.NotZero(t, srv.Close.TestResultsRecordId)
@@ -161,6 +164,7 @@ func TestSendTestResults(t *testing.T) {
 			},
 		} {
 			t.Run(testName, func(t *testing.T) {
+				conf.CedarTestResultsID = ""
 				srv := setupCedarServer(ctx, t, comm)
 				testCase(ctx, t, srv.TestResults, comm)
 			})

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -30,6 +30,7 @@ type TaskConfig struct {
 	Timeout              *Timeout
 	TaskSync             evergreen.S3Credentials
 	ModulePaths          map[string]string
+	CedarTestResultsID   string
 
 	mu sync.RWMutex
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-05-18"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-05-21b"
+	AgentVersion = "2021-05-25"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14684

This saves the cedar test results ID in the task config, which lasts for the life time of a task run, and uses the id if it already exists to upload test results to cedar.