### PR TITLE
EVG-14159: Send cedar test results status to task

### DIFF
--- a/agent/command/results_utils_test.go
+++ b/agent/command/results_utils_test.go
@@ -29,7 +29,7 @@ func TestSendTestResults(t *testing.T) {
 				TestFile:        "test",
 				DisplayTestName: "display",
 				GroupID:         "group",
-				Status:          "status",
+				Status:          "pass",
 				URL:             "https://url.com",
 				LogTestName:     "log_test_name",
 				LineNum:         123,
@@ -110,12 +110,24 @@ func TestSendTestResults(t *testing.T) {
 
 		for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock){
 			"Succeeds": func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock) {
-				require.NoError(t, sendTestResults(ctx, comm, logger, conf, results))
+				t.Run("PassingResults", func(t *testing.T) {
+					require.NoError(t, sendTestResults(ctx, comm, logger, conf, results))
 
-				assert.Equal(t, srv.Close.TestResultsRecordId, conf.CedarTestResultsID)
-				checkRecord(t, srv)
-				checkResults(t, srv)
-				assert.NotZero(t, srv.Close.TestResultsRecordId)
+					assert.Equal(t, srv.Close.TestResultsRecordId, conf.CedarTestResultsID)
+					checkRecord(t, srv)
+					checkResults(t, srv)
+					assert.NotZero(t, srv.Close.TestResultsRecordId)
+					assert.True(t, comm.HasCedarResults)
+					assert.False(t, comm.CedarResultsFailed)
+				})
+				t.Run("FailingResults", func(t *testing.T) {
+					results.Results[0].Status = evergreen.TestFailedStatus
+					require.NoError(t, sendTestResults(ctx, comm, logger, conf, results))
+
+					assert.True(t, comm.HasCedarResults)
+					assert.True(t, comm.CedarResultsFailed)
+					results.Results[0].Status = "pass"
+				})
 			},
 			"SucceedsNoDisplayTestName": func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock) {
 				displayTestName := results.Results[0].DisplayTestName
@@ -126,6 +138,8 @@ func TestSendTestResults(t *testing.T) {
 				checkRecord(t, srv)
 				checkResults(t, srv)
 				assert.NotZero(t, srv.Close.TestResultsRecordId)
+				assert.True(t, comm.HasCedarResults)
+				assert.False(t, comm.CedarResultsFailed)
 				results.Results[0].DisplayTestName = displayTestName
 			},
 			"SucceedsNoLogTestName": func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock) {
@@ -137,6 +151,8 @@ func TestSendTestResults(t *testing.T) {
 				checkRecord(t, srv)
 				checkResults(t, srv)
 				assert.NotZero(t, srv.Close.TestResultsRecordId)
+				assert.True(t, comm.HasCedarResults)
+				assert.False(t, comm.CedarResultsFailed)
 				results.Results[0].LogTestName = logTestName
 			},
 			"FailsIfCreatingRecordFails": func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock) {
@@ -166,6 +182,8 @@ func TestSendTestResults(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				conf.CedarTestResultsID = ""
 				srv := setupCedarServer(ctx, t, comm)
+				comm.HasCedarResults = false
+				comm.CedarResultsFailed = false
 				testCase(ctx, t, srv.TestResults, comm)
 			})
 		}

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -70,8 +70,8 @@ type Communicator interface {
 	// creates it if it doesn't exist.
 	GetCedarGRPCConn(context.Context) (*grpc.ClientConn, error)
 	// SetHasCedarResults sets the HasCedarResults flag to true in the
-	// task.
-	SetHasCedarResults(context.Context, TaskData) error
+	// task and sets CedarResultsFailed if there are failed results.
+	SetHasCedarResults(context.Context, TaskData, bool) error
 
 	// GetAgentSetupData populates an agent with the necessary data, including
 	// secrets.

--- a/agent/internal/client/methods.go
+++ b/agent/internal/client/methods.go
@@ -559,7 +559,7 @@ func (c *communicatorImpl) SetHasCedarResults(ctx context.Context, taskData Task
 		taskData: &taskData,
 		version:  apiVersion2,
 	}
-	info.path = fmt.Sprintf("tasks/%s/set_has_cedar_results?failed=%s", taskData.ID, failed)
+	info.path = fmt.Sprintf("tasks/%s/set_has_cedar_results?failed=%v", taskData.ID, failed)
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {
 		return utility.RespErrorf(resp, "failed to set HasCedarResults for task %s: %s", taskData.ID, err.Error())

--- a/agent/internal/client/methods.go
+++ b/agent/internal/client/methods.go
@@ -559,8 +559,8 @@ func (c *communicatorImpl) SetHasCedarResults(ctx context.Context, taskData Task
 		taskData: &taskData,
 		version:  apiVersion2,
 	}
-	info.path = fmt.Sprintf("tasks/%s/set_has_cedar_results?failed=%v", taskData.ID, failed)
-	resp, err := c.retryRequest(ctx, info, nil)
+	info.path = fmt.Sprintf("tasks/set_has_cedar_results")
+	resp, err := c.retryRequest(ctx, info, &apimodels.CedarTestResultsTaskInfo{TaskID: taskData.ID, Failed: failed})
 	if err != nil {
 		return utility.RespErrorf(resp, "failed to set HasCedarResults for task %s: %s", taskData.ID, err.Error())
 	}

--- a/agent/internal/client/methods.go
+++ b/agent/internal/client/methods.go
@@ -553,13 +553,13 @@ func (c *communicatorImpl) SendTestResults(ctx context.Context, taskData TaskDat
 
 // SetHasCedarResults sets the HasCedarResults flag to true in the given task
 // in the database.
-func (c *communicatorImpl) SetHasCedarResults(ctx context.Context, taskData TaskData) error {
+func (c *communicatorImpl) SetHasCedarResults(ctx context.Context, taskData TaskData, failed bool) error {
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
 		version:  apiVersion2,
 	}
-	info.path = fmt.Sprintf("tasks/%s/set_has_cedar_results", taskData.ID)
+	info.path = fmt.Sprintf("tasks/%s/set_has_cedar_results?failed=%s", taskData.ID, failed)
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {
 		return utility.RespErrorf(resp, "failed to set HasCedarResults for task %s: %s", taskData.ID, err.Error())

--- a/agent/internal/client/methods.go
+++ b/agent/internal/client/methods.go
@@ -559,8 +559,8 @@ func (c *communicatorImpl) SetHasCedarResults(ctx context.Context, taskData Task
 		taskData: &taskData,
 		version:  apiVersion2,
 	}
-	info.path = fmt.Sprintf("tasks/set_has_cedar_results")
-	resp, err := c.retryRequest(ctx, info, &apimodels.CedarTestResultsTaskInfo{TaskID: taskData.ID, Failed: failed})
+	info.path = fmt.Sprintf("tasks/%s/set_has_cedar_results", taskData.ID)
+	resp, err := c.retryRequest(ctx, info, &apimodels.CedarTestResultsTaskInfo{Failed: failed})
 	if err != nil {
 		return utility.RespErrorf(resp, "failed to set HasCedarResults for task %s: %s", taskData.ID, err.Error())
 	}

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -57,12 +57,13 @@ type Mock struct {
 
 	CedarGRPCConn *grpc.ClientConn
 
-	AttachedFiles    map[string][]*artifact.File
-	LogID            string
-	LocalTestResults *task.LocalTestResults
-	HasCedarResults  bool
-	TestLogs         []*serviceModel.TestLog
-	TestLogCount     int
+	AttachedFiles      map[string][]*artifact.File
+	LogID              string
+	LocalTestResults   *task.LocalTestResults
+	HasCedarResults    bool
+	CedarResultsFailed bool
+	TestLogs           []*serviceModel.TestLog
+	TestLogCount       int
 
 	// data collected by mocked methods
 	logMessages      map[string][]apimodels.LogMessage
@@ -386,8 +387,11 @@ func (c *Mock) SendTestResults(ctx context.Context, td TaskData, results *task.L
 }
 
 // SetHasCedarResults sets the HasCedarResults flag in the task.
-func (c *Mock) SetHasCedarResults(ctx context.Context, td TaskData) error {
+func (c *Mock) SetHasCedarResults(ctx context.Context, td TaskData, failed bool) error {
 	c.HasCedarResults = true
+	if failed {
+		c.CedarResultsFailed = true
+	}
 	return nil
 }
 

--- a/apimodels/cedar_models.go
+++ b/apimodels/cedar_models.go
@@ -6,3 +6,8 @@ type CedarConfig struct {
 	Username string `json:"username"`
 	APIKey   string `json:"api_key,omitempty"`
 }
+
+type CedarTestResultsTaskInfo struct {
+	TaskID string `json:"task_id"`
+	Failed bool   `json:"failed"`
+}

--- a/apimodels/cedar_models.go
+++ b/apimodels/cedar_models.go
@@ -8,6 +8,5 @@ type CedarConfig struct {
 }
 
 type CedarTestResultsTaskInfo struct {
-	TaskID string `json:"task_id"`
-	Failed bool   `json:"failed"`
+	Failed bool `json:"failed"`
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-05-18"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-05-25"
+	AgentVersion = "2021-05-26"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-05-18"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-05-26"
+	AgentVersion = "2021-05-27"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -73,6 +73,7 @@ var (
 	GeneratedTasksKey           = bsonutil.MustHaveTag(Task{}, "GeneratedTasks")
 	GeneratedByKey              = bsonutil.MustHaveTag(Task{}, "GeneratedBy")
 	HasCedarResultsKey          = bsonutil.MustHaveTag(Task{}, "HasCedarResults")
+	CedarResultsFailedKey       = bsonutil.MustHaveTag(Task{}, "CedarResultsFailed")
 	IsGithubCheckKey            = bsonutil.MustHaveTag(Task{}, "IsGithubCheck")
 	HostCreateDetailsKey        = bsonutil.MustHaveTag(Task{}, "HostCreateDetails")
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1001,7 +1001,7 @@ func (t *Task) SetAborted(reason AbortInfo) error {
 
 func (t *Task) SetHasCedarResults(hasCedarResults, failedResults bool) error {
 	if !hasCedarResults && failedResults {
-		errors.New("cannot set CedarResultsFailed to true when HasCedarResults is false")
+		return errors.New("cannot set CedarResultsFailed to true when HasCedarResults is false")
 	}
 
 	t.HasCedarResults = hasCedarResults

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -999,6 +999,13 @@ func (t *Task) SetAborted(reason AbortInfo) error {
 	)
 }
 
+// SetHasCedarResults sets the HasCedarResults field of the task to
+// hasCedarResults and, if failedResults is true, sets CedarResultsFailed to
+// true. An error is returned if hasCedarResults is false and failedResults is
+// true as this is an invalid state. Note that if failedResults is false,
+// nothing is set. This is because in cases where separate calls to attach test
+// results are made, only one call needs to have a test failure for the
+// CedarResultsFailed to be set to true.
 func (t *Task) SetHasCedarResults(hasCedarResults, failedResults bool) error {
 	if !hasCedarResults && failedResults {
 		return errors.New("cannot set CedarResultsFailed to true when HasCedarResults is false")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -75,16 +75,17 @@ type Task struct {
 	ActivatedTime       time.Time `bson:"activated_time" json:"activated_time"`
 	DependenciesMetTime time.Time `bson:"dependencies_met_time,omitempty" json:"dependencies_met_time,omitempty"`
 
-	Version           string              `bson:"version" json:"version,omitempty"`
-	Project           string              `bson:"branch" json:"branch,omitempty"`
-	Revision          string              `bson:"gitspec" json:"gitspec"`
-	Priority          int64               `bson:"priority" json:"priority"`
-	TaskGroup         string              `bson:"task_group" json:"task_group"`
-	TaskGroupMaxHosts int                 `bson:"task_group_max_hosts,omitempty" json:"task_group_max_hosts,omitempty"`
-	TaskGroupOrder    int                 `bson:"task_group_order,omitempty" json:"task_group_order,omitempty"`
-	Logs              *apimodels.TaskLogs `bson:"logs,omitempty" json:"logs,omitempty"`
-	MustHaveResults   bool                `bson:"must_have_results,omitempty" json:"must_have_results,omitempty"`
-	HasCedarResults   bool                `bson:"has_cedar_results,omitempty" json:"has_cedar_results,omitempty"`
+	Version            string              `bson:"version" json:"version,omitempty"`
+	Project            string              `bson:"branch" json:"branch,omitempty"`
+	Revision           string              `bson:"gitspec" json:"gitspec"`
+	Priority           int64               `bson:"priority" json:"priority"`
+	TaskGroup          string              `bson:"task_group" json:"task_group"`
+	TaskGroupMaxHosts  int                 `bson:"task_group_max_hosts,omitempty" json:"task_group_max_hosts,omitempty"`
+	TaskGroupOrder     int                 `bson:"task_group_order,omitempty" json:"task_group_order,omitempty"`
+	Logs               *apimodels.TaskLogs `bson:"logs,omitempty" json:"logs,omitempty"`
+	MustHaveResults    bool                `bson:"must_have_results,omitempty" json:"must_have_results,omitempty"`
+	HasCedarResults    bool                `bson:"has_cedar_results,omitempty" json:"has_cedar_results,omitempty"`
+	CedarResultsFailed bool                `bson:"cedar_results_failed,omitempty" json:"cedar_results_failed,omitempty"`
 
 	// only relevant if the task is runnin.  the time of the last heartbeat
 	// sent back by the agent
@@ -648,14 +649,18 @@ func (t *Task) AllDependenciesSatisfied(cache map[string]Task) (bool, error) {
 	return true, nil
 }
 
-// HasFailedTests iterates through a tasks' tests and returns true if
-// that task had any failed tests.
+// HasFailedTests returns true if the task had any failed tests.
 func (t *Task) HasFailedTests() bool {
 	for _, test := range t.LocalTestResults {
 		if test.Status == evergreen.TestFailedStatus {
 			return true
 		}
 	}
+
+	if t.HasCedarResults && t.CedarResultsFailed {
+		return true
+	}
+
 	return false
 }
 
@@ -994,16 +999,26 @@ func (t *Task) SetAborted(reason AbortInfo) error {
 	)
 }
 
-func (t *Task) SetHasCedarResults(hasCedarResults bool) error {
+func (t *Task) SetHasCedarResults(hasCedarResults, failedResults bool) error {
+	if !hasCedarResults && failedResults {
+		errors.New("cannot set CedarResultsFailed to true when HasCedarResults is false")
+	}
+
 	t.HasCedarResults = hasCedarResults
+	set := bson.M{
+		HasCedarResultsKey: hasCedarResults,
+	}
+	if failedResults {
+		t.CedarResultsFailed = true
+		set[CedarResultsFailedKey] = true
+	}
+
 	return UpdateOne(
 		bson.M{
 			IdKey: t.Id,
 		},
 		bson.M{
-			"$set": bson.M{
-				HasCedarResultsKey: hasCedarResults,
-			},
+			"$set": set,
 		},
 	)
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1003,9 +1003,9 @@ func (t *Task) SetAborted(reason AbortInfo) error {
 // hasCedarResults and, if failedResults is true, sets CedarResultsFailed to
 // true. An error is returned if hasCedarResults is false and failedResults is
 // true as this is an invalid state. Note that if failedResults is false,
-// nothing is set. This is because in cases where separate calls to attach test
-// results are made, only one call needs to have a test failure for the
-// CedarResultsFailed to be set to true.
+// CedarResultsFailed is not set. This is because in cases where separate calls
+// to attach test results are made, only one call needs to have a test failure
+// for the CedarResultsFailed to be set to true.
 func (t *Task) SetHasCedarResults(hasCedarResults, failedResults bool) error {
 	if !hasCedarResults && failedResults {
 		return errors.New("cannot set CedarResultsFailed to true when HasCedarResults is false")

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -184,7 +184,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/tasks/{task_id}/restart").Version(2).Post().Wrap(addProject, checkUser, editTasks).RouteHandler(makeTaskRestartHandler(sc))
 	app.AddRoute("/tasks/{task_id}/tests").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestsForTask(sc))
 	app.AddRoute("/tasks/{task_id}/sync_path").Version(2).Get().Wrap(checkUser).RouteHandler(makeTaskSyncPathGetHandler(sc))
-	app.AddRoute("/tasks/set_has_cedar_results").Version(2).Post().Wrap(checkTask).RouteHandler(makeTaskSetHasCedarResultsHandler(sc))
+	app.AddRoute("/tasks/{task_id}/set_has_cedar_results").Version(2).Post().Wrap(checkTask).RouteHandler(makeTaskSetHasCedarResultsHandler(sc))
 	app.AddRoute("/task/sync_read_credentials").Version(2).Get().Wrap(checkUser).RouteHandler(makeTaskSyncReadCredentialsGetHandler(sc))
 	app.AddRoute("/user/settings").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchUserConfig())
 	app.AddRoute("/user/settings").Version(2).Post().Wrap(checkUser).RouteHandler(makeSetUserConfig(sc))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -184,7 +184,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/tasks/{task_id}/restart").Version(2).Post().Wrap(addProject, checkUser, editTasks).RouteHandler(makeTaskRestartHandler(sc))
 	app.AddRoute("/tasks/{task_id}/tests").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestsForTask(sc))
 	app.AddRoute("/tasks/{task_id}/sync_path").Version(2).Get().Wrap(checkUser).RouteHandler(makeTaskSyncPathGetHandler(sc))
-	app.AddRoute("/tasks/{task_id}/set_has_cedar_results").Version(2).Post().Wrap(checkTask).RouteHandler(makeTaskSetHasCedarResultsHandler(sc))
+	app.AddRoute("/tasks/set_has_cedar_results").Version(2).Post().Wrap(checkTask).RouteHandler(makeTaskSetHasCedarResultsHandler(sc))
 	app.AddRoute("/task/sync_read_credentials").Version(2).Get().Wrap(checkUser).RouteHandler(makeTaskSyncReadCredentialsGetHandler(sc))
 	app.AddRoute("/user/settings").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchUserConfig())
 	app.AddRoute("/user/settings").Version(2).Post().Wrap(checkUser).RouteHandler(makeSetUserConfig(sc))

--- a/rest/route/task.go
+++ b/rest/route/task.go
@@ -418,6 +418,7 @@ func (rh *taskSyncPathGetHandler) Run(ctx context.Context) gimlet.Responder {
 
 type taskSetHasCedarResultsHandler struct {
 	taskID string
+	failed bool
 	sc     data.Connector
 }
 
@@ -435,6 +436,8 @@ func (rh *taskSetHasCedarResultsHandler) Factory() gimlet.RouteHandler {
 
 func (rh *taskSetHasCedarResultsHandler) Parse(ctx context.Context, r *http.Request) error {
 	rh.taskID = gimlet.GetVars(r)["task_id"]
+	vals := r.URL.Query()
+	rh.failed = vals.Get("failed") == "true"
 	return nil
 }
 
@@ -444,7 +447,7 @@ func (rh *taskSetHasCedarResultsHandler) Run(ctx context.Context) gimlet.Respond
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "could not find task with ID '%s'", rh.taskID))
 	}
 
-	if err = t.SetHasCedarResults(true); err != nil {
+	if err = t.SetHasCedarResults(true, rh.failed); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "failed to set HasCedarResults flag for task with ID '%s'", rh.taskID))
 	}
 	return gimlet.NewTextResponse("HasCedarResults flag set in task")

--- a/rest/route/task.go
+++ b/rest/route/task.go
@@ -414,7 +414,7 @@ func (rh *taskSyncPathGetHandler) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewTextResponse(t.S3Path(t.BuildVariant, t.DisplayName))
 }
 
-// GET /tasks/{task_id}/set_has_cedar_results
+// POST /tasks/{task_id}/set_has_cedar_results
 
 type taskSetHasCedarResultsHandler struct {
 	taskID string

--- a/rest/route/task.go
+++ b/rest/route/task.go
@@ -414,11 +414,12 @@ func (rh *taskSyncPathGetHandler) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewTextResponse(t.S3Path(t.BuildVariant, t.DisplayName))
 }
 
-// POST /tasks/set_has_cedar_results
+// POST /tasks/{task_id}/set_has_cedar_results
 
 type taskSetHasCedarResultsHandler struct {
-	info apimodels.CedarTestResultsTaskInfo
-	sc   data.Connector
+	taskID string
+	info   apimodels.CedarTestResultsTaskInfo
+	sc     data.Connector
 }
 
 func makeTaskSetHasCedarResultsHandler(sc data.Connector) gimlet.RouteHandler {
@@ -434,25 +435,23 @@ func (rh *taskSetHasCedarResultsHandler) Factory() gimlet.RouteHandler {
 }
 
 func (rh *taskSetHasCedarResultsHandler) Parse(ctx context.Context, r *http.Request) error {
+	rh.taskID = gimlet.GetVars(r)["task_id"]
+
 	if err := gimlet.GetJSON(r.Body, &rh.info); err != nil {
 		return errors.Wrap(err, "unmarshaling the request body")
-	}
-
-	if rh.info.TaskID == "" {
-		return errors.New("must specify a task ID")
 	}
 
 	return nil
 }
 
 func (rh *taskSetHasCedarResultsHandler) Run(ctx context.Context) gimlet.Responder {
-	t, err := rh.sc.FindTaskById(rh.info.TaskID)
+	t, err := rh.sc.FindTaskById(rh.taskID)
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "could not find task with ID '%s'", rh.info.TaskID))
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "could not find task with ID '%s'", rh.taskID))
 	}
 
 	if err = t.SetHasCedarResults(true, rh.info.Failed); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "failed to set HasCedarResults flag for task with ID '%s'", rh.info.TaskID))
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "failed to set HasCedarResults flag for task with ID '%s'", rh.taskID))
 	}
 	return gimlet.NewTextResponse("HasCedarResults flag set in task")
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14159

This sets a new field `CedarResultsFailed` in Task to `true` if any of the test results sent to cedar failed. This way the task can correctly mark itself as `Failed` in `MarkEnd`.
I also ran a task with failing tests in staging and checked the DB to assert that `CedarResultsFailed` was set to `true` and that it was not set for tasks with passing tests.