### PR TITLE
EVG-14567 skip notifications patch isReady check for non-patches

### DIFF
--- a/trigger/version.go
+++ b/trigger/version.go
@@ -174,7 +174,7 @@ func (t *versionTriggers) versionOutcome(sub *event.Subscription) (*notification
 		return nil, nil
 	}
 
-	isReady, err := t.waitOnChildrenOrSiblings(sub)
+	isReady, err := t.waitOnChildrenOrSiblings()
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (t *versionTriggers) versionFailure(sub *event.Subscription) (*notification
 		return nil, nil
 	}
 
-	isReady, err := t.waitOnChildrenOrSiblings(sub)
+	isReady, err := t.waitOnChildrenOrSiblings()
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (t *versionTriggers) versionSuccess(sub *event.Subscription) (*notification
 		return nil, nil
 	}
 
-	isReady, err := t.waitOnChildrenOrSiblings(sub)
+	isReady, err := t.waitOnChildrenOrSiblings()
 	if err != nil {
 		return nil, err
 	}
@@ -293,14 +293,18 @@ func (t *versionTriggers) versionRegression(sub *event.Subscription) (*notificat
 	return nil, nil
 }
 
-func (t *versionTriggers) waitOnChildrenOrSiblings(sub *event.Subscription) (bool, error) {
+func (t *versionTriggers) waitOnChildrenOrSiblings() (bool, error) {
+	// only patches have to wait on children/siblings
+	if !evergreen.IsPatchRequester(t.version.Requester) {
+		return true, nil
+	}
 	isReady := false
 	patchDoc, err := patch.FindOne(patch.ByVersion(t.version.Id))
 	if err != nil {
 		return isReady, errors.Wrapf(err, "error getting patchDoc '%s'", t.version.Id)
 	}
 	if patchDoc == nil {
-		return isReady, errors.Errorf("patchDoc '%s' not found for ", t.version.Id)
+		return isReady, errors.Errorf("patchDoc '%s' not found", t.version.Id)
 	}
 
 	// don't wait on children or siblings if the patch is a regular patch

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -301,10 +301,10 @@ func (t *versionTriggers) waitOnChildrenOrSiblings() (bool, error) {
 	isReady := false
 	patchDoc, err := patch.FindOne(patch.ByVersion(t.version.Id))
 	if err != nil {
-		return isReady, errors.Wrapf(err, "error getting patchDoc '%s'", t.version.Id)
+		return isReady, errors.Wrapf(err, "error getting patch '%s'", t.version.Id)
 	}
 	if patchDoc == nil {
-		return isReady, errors.Errorf("patchDoc '%s' not found", t.version.Id)
+		return isReady, errors.Errorf("patch '%s' not found", t.version.Id)
 	}
 
 	// don't wait on children or siblings if the patch is a regular patch
@@ -341,10 +341,10 @@ func (t *versionTriggers) waitOnChildrenOrSiblings() (bool, error) {
 	if t.version.IsChild() {
 		parentVersion, err := t.version.GetParentVersion()
 		if err != nil {
-			return isReady, errors.Wrap(err, "error getting parentVersion")
+			return isReady, errors.Wrap(err, "error getting parent version")
 		}
 		if parentVersion == nil {
-			return isReady, errors.Errorf("parentVersion not found for '%s'", t.version.Id)
+			return isReady, errors.Errorf("parent version not found for '%s'", t.version.Id)
 		}
 		t.version = parentVersion
 


### PR DESCRIPTION
[EVG-14567 ](https://jira.mongodb.org/browse/EVG-14567 )

### Description 
Periodic build notifications aren't sending, because non-patches (waterfall builds, periodic builds, git tag versions) don't have patches, so isReady is being set to false.

### Testing 
Not tested; reasoned over.
