### PR TITLE
EVG-13986 handle restricted better for repos and projects

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -688,6 +688,7 @@ const (
 
 	AllProjectsScope          = "all_projects"
 	UnrestrictedProjectsScope = "unrestricted_projects"
+	RestrictedProjectsScope   = "restricted_projects"
 	AllDistrosScope           = "all_distros"
 )
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -38,31 +38,34 @@ import (
 // Booleans that can be defined from both the repo and branch must be pointers, so that branch configurations can specify when to default to the repo.
 type ProjectRef struct {
 	// Id is the unmodifiable unique ID for the configuration, used internally.
-	Id                   string              `bson:"_id" json:"id" yaml:"id"`
-	DisplayName          string              `bson:"display_name" json:"display_name" yaml:"display_name"`
-	Enabled              *bool               `bson:"enabled" json:"enabled" yaml:"enabled"`
-	Private              *bool               `bson:"private" json:"private" yaml:"private"`
-	Restricted           *bool               `bson:"restricted" json:"restricted" yaml:"restricted"`
+	Id string `bson:"_id" json:"id" yaml:"id"`
+	// Identifier must be unique, but is modifiable. Used by users.
+	Identifier string `bson:"identifier" json:"identifier" yaml:"identifier"`
+
+	DisplayName          string              `bson:"display_name" json:"display_name,omitempty" yaml:"display_name"`
+	Enabled              *bool               `bson:"enabled,omitempty" json:"enabled,omitempty" yaml:"enabled"`
+	Private              *bool               `bson:"private,omitempty" json:"private,omitempty" yaml:"private"`
+	Restricted           *bool               `bson:"restricted,omitempty" json:"restricted,omitempty" yaml:"restricted"`
 	Owner                string              `bson:"owner_name" json:"owner_name" yaml:"owner"`
 	Repo                 string              `bson:"repo_name" json:"repo_name" yaml:"repo"`
 	Branch               string              `bson:"branch_name" json:"branch_name" yaml:"branch"`
 	RemotePath           string              `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
-	PatchingDisabled     *bool               `bson:"patching_disabled" json:"patching_disabled"`
-	RepotrackerDisabled  *bool               `bson:"repotracker_disabled" json:"repotracker_disabled" yaml:"repotracker_disabled"`
-	DispatchingDisabled  *bool               `bson:"dispatching_disabled" json:"dispatching_disabled" yaml:"dispatching_disabled"`
-	PRTestingEnabled     *bool               `bson:"pr_testing_enabled" json:"pr_testing_enabled" yaml:"pr_testing_enabled"`
-	GithubChecksEnabled  *bool               `bson:"github_checks_enabled" json:"github_checks_enabled" yaml:"github_checks_enabled"`
+	PatchingDisabled     *bool               `bson:"patching_disabled,omitempty" json:"patching_disabled,omitempty"`
+	RepotrackerDisabled  *bool               `bson:"repotracker_disabled,omitempty" json:"repotracker_disabled,omitempty" yaml:"repotracker_disabled"`
+	DispatchingDisabled  *bool               `bson:"dispatching_disabled,omitempty" json:"dispatching_disabled,omitempty" yaml:"dispatching_disabled"`
+	PRTestingEnabled     *bool               `bson:"pr_testing_enabled,omitempty" json:"pr_testing_enabled,omitempty" yaml:"pr_testing_enabled"`
+	GithubChecksEnabled  *bool               `bson:"github_checks_enabled,omitempty" json:"github_checks_enabled,omitempty" yaml:"github_checks_enabled"`
 	BatchTime            int                 `bson:"batch_time" json:"batch_time" yaml:"batchtime"`
-	DeactivatePrevious   *bool               `bson:"deactivate_previous" json:"deactivate_previous" yaml:"deactivate_previous"`
+	DeactivatePrevious   *bool               `bson:"deactivate_previous,omitempty" json:"deactivate_previous,omitempty" yaml:"deactivate_previous"`
 	DefaultLogger        string              `bson:"default_logger" json:"default_logger" yaml:"default_logger"`
-	NotifyOnBuildFailure *bool               `bson:"notify_on_failure" json:"notify_on_failure"`
+	NotifyOnBuildFailure *bool               `bson:"notify_on_failure,omitempty" json:"notify_on_failure,omitempty"`
 	Triggers             []TriggerDefinition `bson:"triggers" json:"triggers"`
 	// all aliases defined for the project
 	PatchTriggerAliases []patch.PatchTriggerDefinition `bson:"patch_trigger_aliases" json:"patch_trigger_aliases"`
 	// all PatchTriggerAliases applied to github patch intents
 	GithubTriggerAliases    []string                  `bson:"github_trigger_aliases" json:"github_trigger_aliases"`
 	PeriodicBuilds          []PeriodicBuildDefinition `bson:"periodic_builds" json:"periodic_builds"`
-	CedarTestResultsEnabled *bool                     `bson:"cedar_test_results_enabled" json:"cedar_test_results_enabled" yaml:"cedar_test_results_enabled"`
+	CedarTestResultsEnabled *bool                     `bson:"cedar_test_results_enabled,omitempty" json:"cedar_test_results_enabled,omitempty" yaml:"cedar_test_results_enabled"`
 	CommitQueue             CommitQueueParams         `bson:"commit_queue" json:"commit_queue" yaml:"commit_queue"`
 
 	// Admins contain a list of users who are able to access the projects page.
@@ -70,9 +73,6 @@ type ProjectRef struct {
 
 	// SpawnHostScriptPath is a path to a script to optionally be run by users on hosts triggered from tasks.
 	SpawnHostScriptPath string `bson:"spawn_host_script_path" json:"spawn_host_script_path" yaml:"spawn_host_script_path"`
-
-	// Identifier must be unique, but is modifiable. Used by users.
-	Identifier string `bson:"identifier" json:"identifier" yaml:"identifier"`
 
 	// TracksPushEvents, if true indicates that Repotracker is triggered by Github PushEvents for this project.
 	// If a repo is enabled and this is what creates the hook, then TracksPushEvents will be set at the repo level.
@@ -84,7 +84,7 @@ type ProjectRef struct {
 	// GitTagAuthorizedUsers contains a list of users who are able to create versions from git tags.
 	GitTagAuthorizedUsers []string `bson:"git_tag_authorized_users" json:"git_tag_authorized_users"`
 	GitTagAuthorizedTeams []string `bson:"git_tag_authorized_teams" json:"git_tag_authorized_teams"`
-	GitTagVersionsEnabled *bool    `bson:"git_tag_versions_enabled" json:"git_tag_versions_enabled"`
+	GitTagVersionsEnabled *bool    `bson:"git_tag_versions_enabled,omitempty" json:"git_tag_versions_enabled,omitempty"`
 
 	// RepoDetails contain the details of the status of the consistency
 	// between what is in GitHub and what is in Evergreen
@@ -92,14 +92,14 @@ type ProjectRef struct {
 
 	// List of regular expressions describing files to ignore when caching historical test results
 	FilesIgnoredFromCache []string `bson:"files_ignored_from_cache" json:"files_ignored_from_cache"`
-	DisabledStatsCache    *bool    `bson:"disabled_stats_cache" json:"disabled_stats_cache"`
+	DisabledStatsCache    *bool    `bson:"disabled_stats_cache,omitempty" json:"disabled_stats_cache,omitempty"`
 
 	// List of commands
 	WorkstationConfig WorkstationConfig `bson:"workstation_config,omitempty" json:"workstation_config,omitempty"`
 
 	// The following fields are used by Evergreen and are not discoverable.
 	// Hidden determines whether or not the project is discoverable/tracked in the UI
-	Hidden *bool `bson:"hidden" json:"hidden"`
+	Hidden *bool `bson:"hidden,omitempty" json:"hidden,omitempty"`
 
 	// This is a temporary flag to enable individual projects to use repo settings
 	UseRepoSettings bool   `bson:"use_repo_settings" json:"use_repo_settings" yaml:"use_repo_settings"`
@@ -368,36 +368,37 @@ func (p *ProjectRef) GetPatchTriggerAlias(aliasName string) (patch.PatchTriggerD
 
 func (p *ProjectRef) AddToRepoScope(user *user.DBUser) error {
 	rm := evergreen.GetEnvironment().RoleManager()
-	if p.RepoRefId == "" {
-		repoRef, err := FindRepoRefByOwnerAndRepo(p.Owner, p.Repo)
+	repoRef, err := FindRepoRefByOwnerAndRepo(p.Owner, p.Repo)
+	if err != nil {
+		return errors.Wrapf(err, "error finding repo ref '%s'", p.RepoRefId)
+	}
+	if repoRef == nil {
+		repoRef, err = p.createNewRepoRef(user)
 		if err != nil {
-			return errors.Wrapf(err, "error finding repo ref '%s'", p.RepoRefId)
-		}
-		if repoRef == nil {
-			repoRef, err = p.createNewRepoRef(user)
-			if err != nil {
-				return errors.Wrapf(err, "error creating new repo ref")
-			}
-		}
-		p.RepoRefId = repoRef.Id
-	} else {
-		// if the repo exists, then the scope also exists, so add this project ID to the scope, and give the user repo admin access
-		repoRole := GetRepoAdminRole(p.RepoRefId)
-		if user != nil && !utility.StringSliceContains(user.Roles(), repoRole) {
-			if err := user.AddRole(repoRole); err != nil {
-				return errors.Wrapf(err, "error adding admin role to repo '%s'", user.Username())
-			}
-			if err := addAdminToRepo(p.RepoRefId, user.Username()); err != nil {
-				return errors.Wrapf(err, "error adding user as repo admin")
-			}
-		}
-		if err := rm.AddResourceToScope(GetRepoScope(p.RepoRefId), p.Id); err != nil {
-			return errors.Wrapf(err, "error adding resource to repo '%s' scope", p.RepoRefId)
+			return errors.Wrapf(err, "error creating new repo ref")
 		}
 	}
+	if p.RepoRefId == "" {
+		p.RepoRefId = repoRef.Id
+	}
 
-	return errors.Wrapf(addViewRepoPermissionsToBranchAdmins(p.RepoRefId, p.Admins),
-		"error giving branch '%s' admins view permission for repo '%s'", p.Id, p.RepoRefId)
+	// add the project to the repo admin scope
+	if err := rm.AddResourceToScope(GetRepoAdminScope(p.RepoRefId), p.Id); err != nil {
+		return errors.Wrapf(err, "error adding resource to repo '%s' admin scope", p.RepoRefId)
+	}
+	// only give branch admins view access if the repo isn't restricted
+	if !repoRef.IsRestricted() {
+		if err := addViewRepoPermissionsToBranchAdmins(p.RepoRefId, p.Admins); err != nil {
+			return errors.Wrapf(err, "error giving branch '%s' admins view permission for repo '%s'", p.Id, p.RepoRefId)
+		}
+	}
+	// if the branch is unrestricted, add it to this scope so users who requested all-repo permissions have access
+	if !p.IsRestricted() {
+		if err := rm.AddResourceToScope(GetUnrestrictedBranchProjectsScope(p.RepoRefId), p.Id); err != nil {
+			return errors.Wrap(err, "error adding resource to unrestricted branches scope")
+		}
+	}
+	return nil
 }
 
 func (p *ProjectRef) RemoveFromRepoScope() error {
@@ -405,27 +406,34 @@ func (p *ProjectRef) RemoveFromRepoScope() error {
 		return nil
 	}
 	rm := evergreen.GetEnvironment().RoleManager()
-	return rm.RemoveResourceFromScope(GetRepoScope(p.RepoRefId), p.Id)
+	if !p.IsRestricted() {
+		if err := rm.RemoveResourceFromScope(GetUnrestrictedBranchProjectsScope(p.RepoRefId), p.Id); err != nil {
+			return errors.Wrap(err, "error removing resource from unrestricted branches scope")
+		}
+	}
+	if err := removeViewRepoPermissionsFromBranchAdmins(p.RepoRefId, p.Admins); err != nil {
+		return errors.Wrap(err, "error removing view repo permissions from branch admins")
+	}
+	return errors.Wrapf(rm.RemoveResourceFromScope(GetRepoAdminScope(p.RepoRefId), p.Id),
+		"error removing from repo '%s' admin scope", p.Repo)
 }
 
 func (p *ProjectRef) AddPermissions(creator *user.DBUser) error {
 	rm := evergreen.GetEnvironment().RoleManager()
-	// if the branch is restricted, then it's not accessible to repo admins, so we don't use the repo scope
 	parentScope := evergreen.UnrestrictedProjectsScope
-	if p.UseRepoSettings {
-		parentScope = GetRepoScope(p.RepoRefId)
-	}
 	if p.IsRestricted() {
-		parentScope = evergreen.AllProjectsScope
+		parentScope = evergreen.RestrictedProjectsScope
+	}
+	if err := rm.AddResourceToScope(parentScope, p.Id); err != nil {
+		return errors.Wrapf(err, "unable to add '%s' to the '%s' scope", p.Id, parentScope)
 	}
 
 	// add scope for the branch-level project configurations
 	newScope := gimlet.Scope{
-		ID:          fmt.Sprintf("project_%s", p.Id),
-		Resources:   []string{p.Id},
-		Name:        p.Id,
-		Type:        evergreen.ProjectResourceType,
-		ParentScope: parentScope,
+		ID:        fmt.Sprintf("project_%s", p.Id),
+		Resources: []string{p.Id},
+		Name:      p.Id,
+		Type:      evergreen.ProjectResourceType,
 	}
 	if err := rm.AddScope(newScope); err != nil {
 		return errors.Wrapf(err, "error adding scope for project '%s'", p.Id)
@@ -596,9 +604,6 @@ func setRepoFieldsFromProjects(repoRef *RepoRef, projectRefs []ProjectRef) {
 
 func (p *ProjectRef) createNewRepoRef(u *user.DBUser) (repoRef *RepoRef, err error) {
 	repoRef = &RepoRef{ProjectRef{
-		Id:      mgobson.NewObjectId().Hex(),
-		Owner:   p.Owner,
-		Repo:    p.Repo,
 		Enabled: utility.TruePtr(),
 		Admins:  []string{},
 	}}
@@ -612,12 +617,18 @@ func (p *ProjectRef) createNewRepoRef(u *user.DBUser) (repoRef *RepoRef, err err
 		err = recovery.HandlePanicWithError(recover(), err, "project and repo structures do not match")
 	}()
 	setRepoFieldsFromProjects(repoRef, allEnabledProjects)
-	repoRef.Admins = append(repoRef.Admins, u.Username())
+	if !utility.StringSliceContains(repoRef.Admins, u.Username()) {
+		repoRef.Admins = append(repoRef.Admins, u.Username())
+	}
+	// some fields shouldn't be set from projects
+	repoRef.Id = mgobson.NewObjectId().Hex()
+	repoRef.UseRepoSettings = false
 
 	// creates scope and give user admin access to repo
 	if err = repoRef.Add(u); err != nil {
 		return nil, errors.Wrapf(err, "problem adding new repo repo ref for '%s/%s'", p.Owner, p.Repo)
 	}
+
 	enabledProjectIds := []string{}
 	for _, p := range allEnabledProjects {
 		enabledProjectIds = append(enabledProjectIds, p.Id)
@@ -1398,37 +1409,43 @@ func RemoveAdminFromProjects(toDelete string) error {
 	return catcher.Resolve()
 }
 
-func (p *ProjectRef) MakeRestricted(ctx context.Context) error {
+func (p *ProjectRef) MakeRestricted() error {
 	rm := evergreen.GetEnvironment().RoleManager()
-	// attempt to remove the resource from the repo (which will also remove from its parent)
-	// if the repo scope doesn't exist then we'll remove only from unrestricted
-
-	scopeId := GetRepoScope(p.RepoRefId)
-	scope, err := rm.GetScope(ctx, scopeId)
-	if err != nil {
-		return errors.Wrapf(err, "error looking for repo scope")
+	// remove from the unrestricted branch project scope (if it exists)
+	if p.UseRepoSettings {
+		scopeId := GetUnrestrictedBranchProjectsScope(p.RepoRefId)
+		if err := rm.RemoveResourceFromScope(scopeId, p.Id); err != nil {
+			return errors.Wrap(err, "error removing resource from unrestricted branches scope")
+		}
 	}
-	if scope != nil {
-		return errors.Wrap(rm.RemoveResourceFromScope(scopeId, p.Id), "error removing resource from scope")
-	}
-	return errors.Wrapf(rm.RemoveResourceFromScope(evergreen.UnrestrictedProjectsScope, p.Id), "unable to remove %s from list of unrestricted projects", p.Id)
 
+	if err := rm.RemoveResourceFromScope(evergreen.UnrestrictedProjectsScope, p.Id); err != nil {
+		return errors.Wrapf(err, "unable to remove %s from list of unrestricted projects", p.Id)
+	}
+	if err := rm.AddResourceToScope(evergreen.RestrictedProjectsScope, p.Id); err != nil {
+		return errors.Wrapf(err, "unable to add %s to list of restricted projects", p.Id)
+	}
+
+	return nil
 }
 
-func (p *ProjectRef) MakeUnrestricted(ctx context.Context) error {
+func (p *ProjectRef) MakeUnrestricted() error {
 	rm := evergreen.GetEnvironment().RoleManager()
-	// attempt to add the resource to the repo (which will also add to its parent)
-	// if the repo scope doesn't exist then we'll add only to unrestricted
+	// remove from the unrestricted branch project scope (if it exists)
+	if p.UseRepoSettings {
+		scopeId := GetUnrestrictedBranchProjectsScope(p.RepoRefId)
+		if err := rm.AddResourceToScope(scopeId, p.Id); err != nil {
+			return errors.Wrap(err, "error adding resource to unrestricted branches scope")
+		}
+	}
 
-	scopeId := GetRepoScope(p.RepoRefId)
-	scope, err := rm.GetScope(ctx, scopeId)
-	if err != nil {
-		return errors.Wrapf(err, "error looking for repo scope")
+	if err := rm.RemoveResourceFromScope(evergreen.RestrictedProjectsScope, p.Id); err != nil {
+		return errors.Wrapf(err, "unable to remove %s from list of restricted projects", p.Id)
 	}
-	if scope != nil {
-		return errors.Wrap(rm.AddResourceToScope(scopeId, p.Id), "error adding resource to scope")
+	if err := rm.AddResourceToScope(evergreen.UnrestrictedProjectsScope, p.Id); err != nil {
+		return errors.Wrapf(err, "unable to add %s to list of unrestricted projects", p.Id)
 	}
-	return errors.Wrapf(rm.AddResourceToScope(evergreen.UnrestrictedProjectsScope, p.Id), "unable to add %s to list of unrestricted projects", p.Id)
+	return nil
 }
 
 func (p *ProjectRef) UpdateAdminRoles(toAdd, toRemove []string) error {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -623,6 +623,9 @@ func (p *ProjectRef) createNewRepoRef(u *user.DBUser) (repoRef *RepoRef, err err
 	// some fields shouldn't be set from projects
 	repoRef.Id = mgobson.NewObjectId().Hex()
 	repoRef.UseRepoSettings = false
+	// set explicitly in case no project is enabled
+	repoRef.Owner = p.Owner
+	repoRef.Repo = p.Repo
 
 	// creates scope and give user admin access to repo
 	if err = repoRef.Add(u); err != nil {

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -246,10 +246,10 @@ func (r *RepoRef) MakeRestricted(branchProjects []ProjectRef) error {
 			return errors.Wrapf(err, "error removing resource '%s' from unrestricted branches scope", p.Id)
 		}
 		if err := rm.RemoveResourceFromScope(evergreen.UnrestrictedProjectsScope, p.Id); err != nil {
-			return errors.Wrapf(err, "error removing resource '%s' from unrestricted projects scope")
+			return errors.Wrapf(err, "error removing resource '%s' from unrestricted projects scope", p.Id)
 		}
 		if err := rm.AddResourceToScope(evergreen.RestrictedProjectsScope, p.Id); err != nil {
-			return errors.Wrapf(err, "error adding resource '%s' to restricted projects scope")
+			return errors.Wrapf(err, "error adding resource '%s' to restricted projects scope", p.Id)
 		}
 
 		// get branch admins that aren't repo admins and remove view repo permissions

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -150,34 +150,45 @@ func FindRepoRefByOwnerAndRepo(owner, repoName string) (*RepoRef, error) {
 func (r *RepoRef) AddPermissions(creator *user.DBUser) error {
 	rm := evergreen.GetEnvironment().RoleManager()
 
-	newScope := gimlet.Scope{
-		ID:          GetRepoScope(r.Id),
-		Resources:   []string{r.Id},
-		Name:        r.Id,
-		Type:        evergreen.ProjectResourceType,
-		ParentScope: evergreen.UnrestrictedProjectsScope,
+	adminScope := gimlet.Scope{
+		ID:        GetRepoAdminScope(r.Id),
+		Resources: []string{r.Id},
+		Name:      r.Id,
+		Type:      evergreen.ProjectResourceType,
 	}
-	if err := rm.AddScope(newScope); err != nil {
+	if err := rm.AddScope(adminScope); err != nil {
 		return errors.Wrapf(err, "error adding scope for repo project '%s'", r.Id)
 	}
 
+	// will be used to request permissions at the repo level
+	unrestrictedBranchesScope := gimlet.Scope{
+		ID:        GetUnrestrictedBranchProjectsScope(r.Id),
+		Resources: []string{}, // will add resources by project
+		Type:      evergreen.ProjectResourceType,
+	}
 	newAdminRole := gimlet.Role{
 		ID:          GetRepoAdminRole(r.Id),
-		Scope:       newScope.ID,
+		Scope:       adminScope.ID,
 		Permissions: adminPermissions,
 	}
+	if err := rm.AddScope(unrestrictedBranchesScope); err != nil {
+		return errors.Wrapf(err, "error adding scope for repo project '%s'", r.Id)
+	}
 	// Create view role for project branch admins
-	newViewRole := gimlet.Role{
-		ID:    GetViewRepoRole(r.Id),
-		Scope: newScope.ID,
-		Permissions: gimlet.Permissions{
-			evergreen.PermissionProjectSettings: evergreen.ProjectSettingsView.Value,
-		},
+	if !r.IsRestricted() {
+		newViewRole := gimlet.Role{
+			ID:    GetViewRepoRole(r.Id),
+			Scope: adminScope.ID,
+			Permissions: gimlet.Permissions{
+				evergreen.PermissionProjectSettings: evergreen.ProjectSettingsView.Value,
+			},
+		}
+
+		if err := rm.UpdateRole(newViewRole); err != nil {
+			return errors.Wrapf(err, "error adding view role for repo project '%s'", r.Id)
+		}
 	}
 
-	if err := rm.UpdateRole(newViewRole); err != nil {
-		return errors.Wrapf(err, "error adding view role for repo project '%s'", r.Id)
-	}
 	if err := rm.UpdateRole(newAdminRole); err != nil {
 		return errors.Wrapf(err, "error adding admin role for repo project '%s'", r.Id)
 	}
@@ -202,6 +213,66 @@ func addViewRepoPermissionsToBranchAdmins(repoRefID string, admins []string) err
 			}
 		}
 	}
+	return nil
+}
+
+// this uses the view repo role specifically, so if the user has this permission through mana then it stays
+func removeViewRepoPermissionsFromBranchAdmins(repoRefID string, admins []string) error {
+	catcher := grip.NewBasicCatcher()
+	viewRole := GetViewRepoRole(repoRefID)
+	for _, admin := range admins {
+		adminUser, err := user.FindOneById(admin)
+		// ignore errors finding user, since project lists may be outdated
+		if err == nil && adminUser != nil {
+			if err = adminUser.RemoveRole(viewRole); err != nil {
+				catcher.Wrapf(err, "error removing role '%s' from user '%s'", viewRole, admin)
+			}
+		}
+	}
+	return nil
+}
+
+func (r *RepoRef) MakeRestricted(branchProjects []ProjectRef) error {
+	rm := evergreen.GetEnvironment().RoleManager()
+	scopeId := GetUnrestrictedBranchProjectsScope(r.Id)
+	// if the branch project is now restricted, remove it from the unrestricted scope
+	for _, p := range branchProjects {
+		if !p.IsRestricted() {
+			continue
+		}
+		if err := rm.RemoveResourceFromScope(scopeId, p.Id); err != nil {
+			return errors.Wrapf(err, "error removing resource '%s' from unrestricted branches scope", p.Id)
+		}
+		if err := rm.RemoveResourceFromScope(evergreen.UnrestrictedProjectsScope, p.Id); err != nil {
+			return errors.Wrapf(err, "error removing resource '%s' from unrestricted projects scope")
+		}
+		if err := rm.AddResourceToScope(evergreen.RestrictedProjectsScope, p.Id); err != nil {
+			return errors.Wrapf(err, "error adding resource '%s' to restricted projects scope")
+		}
+	}
+	return nil
+}
+
+func (r *RepoRef) MakeUnrestricted(branchProjects []ProjectRef) error {
+	rm := evergreen.GetEnvironment().RoleManager()
+	scopeId := GetUnrestrictedBranchProjectsScope(r.Id)
+
+	// if the branch project is now unrestricted, add it to the unrestricted scopes
+	for _, p := range branchProjects {
+		if p.IsRestricted() {
+			continue
+		}
+		if err := rm.AddResourceToScope(scopeId, p.Id); err != nil {
+			return errors.Wrapf(err, "error adding resource '%s' to unrestricted branches scope", p.Id)
+		}
+		if err := rm.RemoveResourceFromScope(evergreen.RestrictedProjectsScope, p.Id); err != nil {
+			return errors.Wrapf(err, "error removing resource '%s' from restricted projects scope")
+		}
+		if err := rm.AddResourceToScope(evergreen.UnrestrictedProjectsScope, p.Id); err != nil {
+			return errors.Wrapf(err, "error adding resource '%s' to unrestricted projects scope")
+		}
+	}
+
 	return nil
 }
 
@@ -250,8 +321,14 @@ func addAdminToRepo(repoId, admin string) error {
 	)
 }
 
-func GetRepoScope(repoId string) string {
-	return fmt.Sprintf("repo_%s", repoId)
+// GetUnrestrictedBranchProjectsScope returns the scope ID that includes the unrestricted branches for this project.
+func GetUnrestrictedBranchProjectsScope(repoId string) string {
+	return fmt.Sprintf("unrestricted_branches_%s", repoId)
+}
+
+// GetRepoAdminScope returns the scope ID that includes all branch projects, regardless of restricted/unrestricted.
+func GetRepoAdminScope(repoId string) string {
+	return fmt.Sprintf("admin_repo_%s", repoId)
 }
 
 func GetRepoAdminRole(repoId string) string {

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -273,10 +273,10 @@ func (r *RepoRef) MakeUnrestricted(branchProjects []ProjectRef) error {
 			return errors.Wrapf(err, "error adding resource '%s' to unrestricted branches scope", p.Id)
 		}
 		if err := rm.RemoveResourceFromScope(evergreen.RestrictedProjectsScope, p.Id); err != nil {
-			return errors.Wrapf(err, "error removing resource '%s' from restricted projects scope")
+			return errors.Wrapf(err, "error removing resource '%s' from restricted projects scope", p.Id)
 		}
 		if err := rm.AddResourceToScope(evergreen.UnrestrictedProjectsScope, p.Id); err != nil {
-			return errors.Wrapf(err, "error adding resource '%s' to unrestricted projects scope")
+			return errors.Wrapf(err, "error adding resource '%s' to unrestricted projects scope", p.Id)
 		}
 		// get branch admins that aren't repo admins and remove add repo permissions
 		_, adminsToModify := utility.StringSliceSymmetricDifference(r.Admins, p.Admins)

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -305,7 +305,7 @@ func (u *DBUser) AddRole(role string) error {
 		return nil
 	}
 	update := bson.M{
-		"$push": bson.M{RolesKey: role},
+		"$addToSet": bson.M{RolesKey: role},
 	}
 	if err := UpdateOne(bson.M{IdKey: u.Id}, update); err != nil {
 		return err

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -83,7 +83,7 @@ func (t *APITriggerDefinition) BuildFromService(h interface{}) error {
 	t.GenerateFile = utility.ToStringPtr(triggerDef.GenerateFile)
 	t.Command = utility.ToStringPtr(triggerDef.Command)
 	t.Alias = utility.ToStringPtr(triggerDef.Alias)
-	t.DateCutoff = t.DateCutoff
+	t.DateCutoff = triggerDef.DateCutoff
 	return nil
 }
 

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
@@ -30,10 +32,89 @@ type APITriggerDefinition struct {
 	Alias             *string `json:"alias"`
 }
 
+type APIPeriodicBuildDefinition struct {
+	ID            *string    `json:"id"`
+	ConfigFile    *string    `json:"config_file"`
+	IntervalHours *int       `son:"interval_hours"`
+	Alias         *string    `son:"alias,omitempty"`
+	Message       *string    `json:"message,omitempty"`
+	NextRunTime   *time.Time `json:"next_run_time,omitempty"`
+}
+
 type APICommitQueueParams struct {
 	Enabled     *bool   `json:"enabled"`
 	MergeMethod *string `json:"merge_method"`
 	Message     *string `json:"message"`
+}
+
+func (t *APITriggerDefinition) ToService() (interface{}, error) {
+	return model.TriggerDefinition{
+		Project:           utility.FromStringPtr(t.Project),
+		Level:             utility.FromStringPtr(t.Level),
+		DefinitionID:      utility.FromStringPtr(t.DefinitionID),
+		BuildVariantRegex: utility.FromStringPtr(t.BuildVariantRegex),
+		TaskRegex:         utility.FromStringPtr(t.TaskRegex),
+		Status:            utility.FromStringPtr(t.Status),
+		ConfigFile:        utility.FromStringPtr(t.ConfigFile),
+		GenerateFile:      utility.FromStringPtr(t.GenerateFile),
+		Command:           utility.FromStringPtr(t.Command),
+		Alias:             utility.FromStringPtr(t.Alias),
+		DateCutoff:        t.DateCutoff,
+	}, nil
+}
+
+func (t *APITriggerDefinition) BuildFromService(h interface{}) error {
+	var triggerDef model.TriggerDefinition
+	switch h.(type) {
+	case model.TriggerDefinition:
+		triggerDef = h.(model.TriggerDefinition)
+	case *model.PeriodicBuildDefinition:
+		triggerDef = *h.(*model.TriggerDefinition)
+	default:
+		return errors.Errorf("Invalid trigger definition of type '%T'", h)
+	}
+	t.Project = utility.ToStringPtr(triggerDef.Project)
+	t.Level = utility.ToStringPtr(triggerDef.Level)
+	t.DefinitionID = utility.ToStringPtr(triggerDef.DefinitionID)
+	t.BuildVariantRegex = utility.ToStringPtr(triggerDef.BuildVariantRegex)
+	t.TaskRegex = utility.ToStringPtr(triggerDef.TaskRegex)
+	t.Status = utility.ToStringPtr(triggerDef.Status)
+	t.ConfigFile = utility.ToStringPtr(triggerDef.ConfigFile)
+	t.GenerateFile = utility.ToStringPtr(triggerDef.GenerateFile)
+	t.Command = utility.ToStringPtr(triggerDef.Command)
+	t.Alias = utility.ToStringPtr(triggerDef.Alias)
+	t.DateCutoff = t.DateCutoff
+	return nil
+}
+
+func (bd *APIPeriodicBuildDefinition) ToService() (interface{}, error) {
+	buildDef := model.PeriodicBuildDefinition{}
+	buildDef.ID = utility.FromStringPtr(bd.ID)
+	buildDef.ConfigFile = utility.FromStringPtr(bd.ConfigFile)
+	buildDef.IntervalHours = utility.FromIntPtr(bd.IntervalHours)
+	buildDef.Alias = utility.FromStringPtr(bd.Alias)
+	buildDef.Message = utility.FromStringPtr(bd.Message)
+	buildDef.NextRunTime = utility.FromTimePtr(bd.NextRunTime)
+	return buildDef, nil
+}
+
+func (bd *APIPeriodicBuildDefinition) BuildFromService(h interface{}) error {
+	var params model.PeriodicBuildDefinition
+	switch h.(type) {
+	case model.PeriodicBuildDefinition:
+		params = h.(model.PeriodicBuildDefinition)
+	case *model.PeriodicBuildDefinition:
+		params = *h.(*model.PeriodicBuildDefinition)
+	default:
+		return errors.Errorf("Invalid commit queue params of type '%T'", h)
+	}
+	bd.ID = utility.ToStringPtr(params.ID)
+	bd.ConfigFile = utility.ToStringPtr(params.ConfigFile)
+	bd.IntervalHours = utility.ToIntPtr(params.IntervalHours)
+	bd.Alias = utility.ToStringPtr(params.Alias)
+	bd.Message = utility.ToStringPtr(params.Message)
+	bd.NextRunTime = utility.ToTimePtr(params.NextRunTime)
+	return nil
 }
 
 func (cqParams *APICommitQueueParams) BuildFromService(h interface{}) error {
@@ -173,6 +254,7 @@ type APIProjectRef struct {
 	PRTestingEnabled            *bool                `json:"pr_testing_enabled"`
 	GitTagVersionsEnabled       *bool                `json:"git_tag_versions_enabled"`
 	GithubChecksEnabled         *bool                `json:"github_checks_enabled"`
+	CedarTestResultsEnabled     *bool                `json:"cedar_test_results_enabled"`
 	UseRepoSettings             bool                 `json:"use_repo_settings"`
 	RepoRefId                   *string              `json:"repo_ref_id"`
 	DefaultLogger               *string              `json:"default_logger"`
@@ -191,14 +273,17 @@ type APIProjectRef struct {
 	GitTagAuthorizedTeams       []*string            `json:"git_tag_authorized_teams" bson:"git_tag_authorized_teams"`
 	DeleteGitTagAuthorizedTeams []*string            `json:"delete_git_tag_authorized_teams,omitempty" bson:"delete_git_tag_authorized_teams,omitempty"`
 	NotifyOnBuildFailure        *bool                `json:"notify_on_failure"`
+	Restricted                  *bool                `json:"restricted"`
 
-	Revision            *string                `json:"revision"`
-	Triggers            []APITriggerDefinition `json:"triggers"`
-	Aliases             []APIProjectAlias      `json:"aliases"`
-	Variables           APIProjectVars         `json:"variables"`
-	WorkstationConfig   APIWorkstationConfig   `json:"workstation_config"`
-	Subscriptions       []APISubscription      `json:"subscriptions"`
-	DeleteSubscriptions []*string              `json:"delete_subscriptions,omitempty"`
+	Revision             *string                      `json:"revision"`
+	Triggers             []APITriggerDefinition       `json:"triggers"`
+	GithubTriggerAliases []*string                    `json:"github_trigger_aliases"`
+	Aliases              []APIProjectAlias            `json:"aliases"`
+	Variables            APIProjectVars               `json:"variables"`
+	WorkstationConfig    APIWorkstationConfig         `json:"workstation_config"`
+	Subscriptions        []APISubscription            `json:"subscriptions"`
+	DeleteSubscriptions  []*string                    `json:"delete_subscriptions,omitempty"`
+	PeriodicBuilds       []APIPeriodicBuildDefinition `json:"periodic_builds,omitempty"`
 }
 
 // ToService returns a service layer ProjectRef using the data from APIProjectRef
@@ -233,6 +318,7 @@ func (p *APIProjectRef) ToService() (interface{}, error) {
 		Branch:                utility.FromStringPtr(p.Branch),
 		Enabled:               utility.BoolPtrCopy(p.Enabled),
 		Private:               utility.BoolPtrCopy(p.Private),
+		Restricted:            utility.BoolPtrCopy(p.Restricted),
 		BatchTime:             p.BatchTime,
 		RemotePath:            utility.FromStringPtr(p.RemotePath),
 		Id:                    utility.FromStringPtr(p.Id),
@@ -260,26 +346,42 @@ func (p *APIProjectRef) ToService() (interface{}, error) {
 		Admins:                utility.FromStringPtrSlice(p.Admins),
 		GitTagAuthorizedUsers: utility.FromStringPtrSlice(p.GitTagAuthorizedUsers),
 		GitTagAuthorizedTeams: utility.FromStringPtrSlice(p.GitTagAuthorizedTeams),
+		GithubTriggerAliases:  utility.FromStringPtrSlice(p.GithubTriggerAliases),
 	}
 
 	// Copy triggers
-	triggers := []model.TriggerDefinition{}
-	for _, t := range p.Triggers {
-		triggers = append(triggers, model.TriggerDefinition{
-			Project:           utility.FromStringPtr(t.Project),
-			Level:             utility.FromStringPtr(t.Level),
-			DefinitionID:      utility.FromStringPtr(t.DefinitionID),
-			BuildVariantRegex: utility.FromStringPtr(t.BuildVariantRegex),
-			TaskRegex:         utility.FromStringPtr(t.TaskRegex),
-			Status:            utility.FromStringPtr(t.Status),
-			ConfigFile:        utility.FromStringPtr(t.ConfigFile),
-			GenerateFile:      utility.FromStringPtr(t.GenerateFile),
-			Command:           utility.FromStringPtr(t.Command),
-			Alias:             utility.FromStringPtr(t.Alias),
-			DateCutoff:        t.DateCutoff,
-		})
+	if p.Triggers != nil {
+		triggers := []model.TriggerDefinition{}
+		for _, t := range p.Triggers {
+			i, err = t.ToService()
+			if err != nil {
+				return nil, errors.Wrap(err, "cannot convert API trigger definition")
+			}
+			newTrigger, ok := i.(model.TriggerDefinition)
+			if !ok {
+				return nil, errors.Errorf("expected trigger definition but was actually '%T'", i)
+			}
+			triggers = append(triggers, newTrigger)
+		}
+		projectRef.Triggers = triggers
 	}
-	projectRef.Triggers = triggers
+
+	// Copy periodic builds
+	if p.PeriodicBuilds != nil {
+		builds := []model.PeriodicBuildDefinition{}
+		for _, t := range p.Triggers {
+			i, err = t.ToService()
+			if err != nil {
+				return nil, errors.Wrap(err, "cannot convert API periodic build")
+			}
+			newBuild, ok := i.(model.PeriodicBuildDefinition)
+			if !ok {
+				return nil, errors.Errorf("expected periodic build definition but was actually '%T'", i)
+			}
+			builds = append(builds, newBuild)
+		}
+		projectRef.PeriodicBuilds = builds
+	}
 
 	return &projectRef, nil
 }
@@ -316,6 +418,7 @@ func (p *APIProjectRef) BuildFromService(v interface{}) error {
 	p.Branch = utility.ToStringPtr(projectRef.Branch)
 	p.Enabled = utility.BoolPtrCopy(projectRef.Enabled)
 	p.Private = utility.BoolPtrCopy(projectRef.Private)
+	p.Restricted = utility.BoolPtrCopy(projectRef.Restricted)
 	p.BatchTime = projectRef.BatchTime
 	p.RemotePath = utility.ToStringPtr(projectRef.RemotePath)
 	p.Id = utility.ToStringPtr(projectRef.Id)
@@ -343,25 +446,33 @@ func (p *APIProjectRef) BuildFromService(v interface{}) error {
 	p.Admins = utility.ToStringPtrSlice(projectRef.Admins)
 	p.GitTagAuthorizedUsers = utility.ToStringPtrSlice(projectRef.GitTagAuthorizedUsers)
 	p.GitTagAuthorizedTeams = utility.ToStringPtrSlice(projectRef.GitTagAuthorizedTeams)
+	p.GithubTriggerAliases = utility.ToStringPtrSlice(projectRef.GithubTriggerAliases)
 
 	// Copy triggers
-	triggers := []APITriggerDefinition{}
-	for _, t := range projectRef.Triggers {
-		triggers = append(triggers, APITriggerDefinition{
-			Project:           utility.ToStringPtr(t.Project),
-			Level:             utility.ToStringPtr(t.Level),
-			DefinitionID:      utility.ToStringPtr(t.DefinitionID),
-			BuildVariantRegex: utility.ToStringPtr(t.BuildVariantRegex),
-			TaskRegex:         utility.ToStringPtr(t.TaskRegex),
-			Status:            utility.ToStringPtr(t.Status),
-			ConfigFile:        utility.ToStringPtr(t.ConfigFile),
-			GenerateFile:      utility.ToStringPtr(t.GenerateFile),
-			Command:           utility.ToStringPtr(t.Command),
-			Alias:             utility.ToStringPtr(t.Alias),
-			DateCutoff:        t.DateCutoff,
-		})
+	if projectRef.Triggers != nil {
+		triggers := []APITriggerDefinition{}
+		for _, t := range projectRef.Triggers {
+			apiTrigger := APITriggerDefinition{}
+			if err := apiTrigger.BuildFromService(t); err != nil {
+				return err
+			}
+			triggers = append(triggers, apiTrigger)
+		}
+		p.Triggers = triggers
 	}
-	p.Triggers = triggers
+
+	// copy periodic builds
+	if projectRef.PeriodicBuilds != nil {
+		periodicBuilds := []APIPeriodicBuildDefinition{}
+		for _, pb := range projectRef.PeriodicBuilds {
+			periodicBuild := APIPeriodicBuildDefinition{}
+			if err := periodicBuild.BuildFromService(pb); err != nil {
+				return err
+			}
+			periodicBuilds = append(periodicBuilds)
+		}
+		p.PeriodicBuilds = periodicBuilds
+	}
 
 	return nil
 }

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -296,6 +296,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	adminsToDelete := utility.FromStringPtrSlice(h.apiNewProjectRef.DeleteAdmins)
+	adminsToAdd := h.newProjectRef.Admins
 	allAdmins := utility.UniqueStrings(append(h.originalProject.Admins, h.newProjectRef.Admins...)) // get original and new admin
 	h.newProjectRef.Admins, _ = utility.StringSliceSymmetricDifference(allAdmins, adminsToDelete)   // add users that are in allAdmins and not in adminsToDelete
 
@@ -460,7 +461,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error updating aliases for project '%s'", h.project))
 	}
 
-	if err = h.sc.UpdateAdminRoles(h.newProjectRef, h.newProjectRef.Admins, adminsToDelete); err != nil {
+	if err = h.sc.UpdateAdminRoles(h.newProjectRef, adminsToAdd, adminsToDelete); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "Database error updating admins for project '%s'", h.project))
 	}
 	for i := range h.apiNewProjectRef.Subscriptions {

--- a/rest/route/repo.go
+++ b/rest/route/repo.go
@@ -170,7 +170,8 @@ func (h *repoIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 
 	// update admins
 	adminsToDelete := utility.FromStringPtrSlice(h.apiNewRepoRef.DeleteAdmins)
-	allAdmins := utility.UniqueStrings(append(h.originalRepo.Admins, h.newRepoRef.Admins...))  // get original and new admin
+	adminsToAdd := h.newRepoRef.Admins
+	allAdmins := utility.UniqueStrings(append(h.originalRepo.Admins, adminsToAdd...))          // get original and new admin
 	h.newRepoRef.Admins, _ = utility.StringSliceSymmetricDifference(allAdmins, adminsToDelete) // add users that are in allAdmins and not in adminsToDelete
 
 	usersToDelete := utility.FromStringPtrSlice(h.apiNewRepoRef.DeleteGitTagAuthorizedUsers)
@@ -185,12 +186,24 @@ func (h *repoIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
-	if err = h.validateBranchesForRepo(ctx, h.newRepoRef, repoAliases); err != nil {
+	// get every project that uses the repo, and merge them
+	branchProjects, err := dbModel.FindMergedProjectRefsForRepo(h.newRepoRef)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "error finding branch projects for repo"))
+	}
+	if err = h.validateBranchesForRepo(ctx, h.newRepoRef, branchProjects, repoAliases); err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
 	if h.originalRepo.Restricted != h.newRepoRef.Restricted {
-		// TODO: handle in EVG-13986
+		if h.newRepoRef.IsRestricted() {
+			err = h.newRepoRef.MakeRestricted(branchProjects)
+		} else {
+			err = h.newRepoRef.MakeUnrestricted(branchProjects)
+		}
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(err)
+		}
 	}
 
 	// complete all updates
@@ -204,7 +217,7 @@ func (h *repoIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error updating aliases for project '%s'", h.repoName))
 	}
 
-	if err = h.sc.UpdateAdminRoles(&h.newRepoRef.ProjectRef, h.newRepoRef.Admins, adminsToDelete); err != nil {
+	if err = h.newRepoRef.UpdateAdminRoles(adminsToAdd, adminsToDelete); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "Database error updating admins for project '%s'", h.repoName))
 	}
 	for i := range h.apiNewRepoRef.Subscriptions {
@@ -244,18 +257,13 @@ func (h *repoIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	return responder
 }
 
-func (h repoIDPatchHandler) validateBranchesForRepo(ctx context.Context, newRepoRef *dbModel.RepoRef, aliases []model.APIProjectAlias) error {
+func (h repoIDPatchHandler) validateBranchesForRepo(ctx context.Context, newRepoRef *dbModel.RepoRef, mergedRepos []dbModel.ProjectRef, aliases []model.APIProjectAlias) error {
 	hasHook, err := h.sc.EnableWebhooks(ctx, &newRepoRef.ProjectRef)
 	if err != nil {
 		return errors.Wrapf(err, "error enabling webhooks for repo '%s'", h.repoName)
 	}
 
 	catcher := grip.NewBasicCatcher()
-	// get every project that uses the repo, and merge them
-	pRefs, err := dbModel.FindMergedProjectRefsForRepo(newRepoRef)
-	if err != nil {
-		return errors.Wrapf(err, "error finding branch projects for repo")
-	}
 
 	// If we're enabling commit queue testing PR testing, verify that only one enabled project ref per branch has true or nil set.
 	// If anything that uses webhooks is enabled, ensure that webhooks are configured.
@@ -265,7 +273,7 @@ func (h repoIDPatchHandler) validateBranchesForRepo(ctx context.Context, newRepo
 		gitTagIds      []string
 		githubCheckIds []string
 	}{}
-	for _, p := range pRefs {
+	for _, p := range mergedRepos {
 		if !p.IsEnabled() {
 			continue
 		}

--- a/service/project.go
+++ b/service/project.go
@@ -245,6 +245,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	id = projectRef.Id
 	origProjectRef := *projectRef
 
+	// TODO: should this use pointer booleans? otherwise the copy isn't quite right for repo projects
 	responseRef := struct {
 		Id                      string                         `json:"id"`
 		Identifier              string                         `json:"identifier"`

--- a/service/project.go
+++ b/service/project.go
@@ -245,7 +245,6 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	id = projectRef.Id
 	origProjectRef := *projectRef
 
-	// TODO: should this use pointer booleans? otherwise the copy isn't quite right for repo projects
 	responseRef := struct {
 		Id                      string                         `json:"id"`
 		Identifier              string                         `json:"identifier"`

--- a/service/project.go
+++ b/service/project.go
@@ -759,9 +759,9 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 
 	if origProjectRef.Restricted != projectRef.Restricted {
 		if projectRef.IsRestricted() {
-			err = projectRef.MakeRestricted(ctx)
+			err = projectRef.MakeRestricted()
 		} else {
-			err = projectRef.MakeUnrestricted(ctx)
+			err = projectRef.MakeUnrestricted()
 		}
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)

--- a/testdata/local/scopes.json
+++ b/testdata/local/scopes.json
@@ -1,3 +1,6 @@
+{ "_id" : "all_projects", "name" : "all projects", "type" : "project", "resources": ["logkeeper", "evergreen", "sys-perf"] }
+{ "_id" : "unrestricted_projects", "name" : "unrestricted projects", "type" : "project", "parent" : "all_projects", "resources": ["logkeeper", "evergreen", "sys-perf"] }
+{ "_id" : "restricted_projects", "name" : "restricted projects", "type" : "project", "parent" : "all_projects", "resources": [] }
 { "_id" : "logkeeper", "name" : "logkeeper project", "type" : "project", "resources" : [ "logkeeper" ] }
 { "_id" : "evergreen", "name" : "evergreen project", "type" : "project", "resources" : [ "evergreen" ] }
 { "_id" : "sys-perf", "name" : "sys-perf project", "type" : "project", "resources" : [ "sys-perf" ] }


### PR DESCRIPTION
[EVG-13986](https://jira.mongodb.org/browse/EVG-13986)

### Description 
Sorry this is a kind of complicated PR. Let me know if this explanation could do with an in-person chat.
Right now we have an unrestricted projects scope, with an "all projects" scope parent. The issue is that when we move a project out of the unrestricted scope, we also remove it from "all projects". John said we were evidently also supposed to have a "restricted" projects scope (so the union of restricted & unrestricted would equal all_projects). So when this PR is approved I will add this scope (with the restricted projects) to staging/prod, and add them back to all_projects.

In terms of repos and projects: we want projects that don't have restricted/unrestricted explicitly defined to inherit the repo setting. I handled this by not adding repos to restricted/unrestricted but instead moving around the branch pointers when the setting changes.

### Testing 
I tested this by hitting the local API routes in as many ways as I could think of, and writing a unit test that checks scopes/projects/repos.
