### PR TITLE
EVG-14700 Fix parent patch notifications showing the child status

### DIFF
--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -145,29 +145,13 @@ func (t *patchTriggers) waitOnChildrenOrSiblings(sub *event.Subscription) (bool,
 	if !(t.patch.IsParent() || (t.patch.IsChild() && subType == event.WaitOnChild)) {
 		return true, nil
 	}
-	isReady := false
 	// get the children or siblings to wait on
-	childrenOrSiblings, parentPatch, err := t.patch.GetPatchFamily()
+	isReady, parentPatch, isFailingStatus, err := checkPatchStatus(t.patch)
 	if err != nil {
-		return isReady, errors.Wrap(err, "error getting child or sibling patches")
+		return false, errors.Errorf("error getting patch status for '%s'", t.patch.Id)
 	}
 
-	// make sure the parent is done, if not, wait for the parent
-	if t.patch.IsChild() {
-		if !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
-			return isReady, nil
-		}
-	}
-	childrenStatus, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)
-	if err != nil {
-		return isReady, errors.Wrap(err, "error getting child or sibling information")
-	}
-	if !evergreen.IsFinishedPatchStatus(childrenStatus) {
-		return isReady, nil
-	}
-	isReady = true
-
-	if childrenStatus == evergreen.PatchFailed {
+	if isFailingStatus {
 		t.data.Status = evergreen.PatchFailed
 	}
 
@@ -177,6 +161,36 @@ func (t *patchTriggers) waitOnChildrenOrSiblings(sub *event.Subscription) (bool,
 		t.patch = parentPatch
 	}
 	return isReady, nil
+
+}
+
+func checkPatchStatus(p *patch.Patch) (bool, *patch.Patch, bool, error) {
+	isReady := false
+	childrenOrSiblings, parentPatch, err := p.GetPatchFamily()
+	if err != nil {
+		return isReady, nil, false, errors.Wrap(err, "error getting child or sibling patches")
+	}
+
+	// make sure the parent is done, if not, wait for the parent
+	if p.IsChild() {
+		if !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
+			return isReady, nil, false, nil
+		}
+	}
+	childrenStatus, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)
+	if err != nil {
+		return isReady, nil, false, errors.Wrap(err, "error getting child or sibling information")
+	}
+	if !evergreen.IsFinishedPatchStatus(childrenStatus) {
+		return isReady, nil, false, nil
+	}
+	isReady = true
+
+	isFailingStatus := false
+	if childrenStatus == evergreen.PatchFailed || (p.IsChild() && parentPatch.Status == evergreen.PatchFailed) {
+		isFailingStatus = true
+	}
+	return isReady, parentPatch, isFailingStatus, err
 
 }
 

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -148,7 +148,7 @@ func (t *patchTriggers) waitOnChildrenOrSiblings(sub *event.Subscription) (bool,
 	// get the children or siblings to wait on
 	isReady, parentPatch, isFailingStatus, err := checkPatchStatus(t.patch)
 	if err != nil {
-		return false, errors.Errorf("error getting patch status for '%s'", t.patch.Id)
+		return false, errors.Wrapf(err, "error getting patch status for '%s'", t.patch.Id)
 	}
 
 	if isFailingStatus {
@@ -161,7 +161,6 @@ func (t *patchTriggers) waitOnChildrenOrSiblings(sub *event.Subscription) (bool,
 		t.patch = parentPatch
 	}
 	return isReady, nil
-
 }
 
 func checkPatchStatus(p *patch.Patch) (bool, *patch.Patch, bool, error) {

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -334,7 +334,7 @@ func (t *versionTriggers) waitOnChildrenOrSiblings() (bool, error) {
 		return isReady, nil
 	}
 	isReady = true
-	if childrenStatus == evergreen.PatchFailed {
+	if childrenStatus == evergreen.PatchFailed || (patchDoc.IsChild() && parentPatch.Status == evergreen.PatchFailed) {
 		t.data.Status = evergreen.PatchFailed
 	}
 

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -315,7 +315,7 @@ func (t *versionTriggers) waitOnChildrenOrSiblings() (bool, error) {
 	// get the collective status
 	isReady, _, isFailingStatus, err := checkPatchStatus(patchDoc)
 	if err != nil {
-		return false, errors.Errorf("error getting patch status for '%s'", patchDoc.Id)
+		return false, errors.Wrapf(err, "error getting patch status for '%s'", patchDoc.Id)
 	}
 
 	if isFailingStatus {

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -312,29 +312,13 @@ func (t *versionTriggers) waitOnChildrenOrSiblings() (bool, error) {
 		return true, nil
 	}
 
-	// get the children or siblings to wait on
-	childrenOrSiblings, parentPatch, err := patchDoc.GetPatchFamily()
+	// get the collective status
+	isReady, _, isFailingStatus, err := checkPatchStatus(patchDoc)
 	if err != nil {
-		return isReady, errors.Wrap(err, "error getting child or sibling patches")
+		return false, errors.Errorf("error getting patch status for '%s'", patchDoc.Id)
 	}
 
-	// make sure the parent is done, if not, wait for the parent
-	if t.version.IsChild() {
-		if !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
-			return isReady, nil
-		}
-	}
-
-	childrenStatus, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)
-	if err != nil {
-		return isReady, errors.Wrap(err, "error getting child or sibling information")
-	}
-	//make sure the children or siblings are done before sending the notification
-	if !evergreen.IsFinishedPatchStatus(childrenStatus) {
-		return isReady, nil
-	}
-	isReady = true
-	if childrenStatus == evergreen.PatchFailed || (patchDoc.IsChild() && parentPatch.Status == evergreen.PatchFailed) {
+	if isFailingStatus {
 		t.data.Status = evergreen.PatchFailed
 	}
 


### PR DESCRIPTION
[EVG-14700](https://jira.mongodb.org/browse/EVG-14700)

### Description 
When a status was sent for a notification for a parent patch that waited on a child patch, it only overwrote the status if the child patch failed. However, in cases when the child finished after the parent and the parent failed, the status would show as success if the child succeeded. This change overwrites the status of the notification to be a collective status between the parent and children. It also extracts some duplicate code out to it's own function. 

### Testing 
Created a [pull request](https://github.com/evergreen-ci/commit-queue-sandbox/pull/233) on commit-queue-sandbox with a child patch, added a notification, and made sure the notification was sent after the child was done. Also watched the statuses being set for tasks on the bottom of the PR to make sure the parent patch showed "running" until the child was done. 


