### PR TITLE
EVG-14269 add validation check for task run_on field

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -391,6 +391,7 @@ tasks:
   - <<: *run-build
     name: dist-staging
     patch_only: true
+    run_on: archlinux-new-small
 
   - <<: *run-smoke-test
     name: smoke-test-task

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1931,6 +1931,33 @@ func TestEnsureHasNecessaryBVFields(t *testing.T) {
 				ShouldEqual, 1)
 		})
 		Convey("no error should be thrown if the buildvariant does not "+
+			"have a run_on field specified but the task definition has a "+
+			"distro field specified", func() {
+			project := &model.Project{
+				Identifier: "projectId",
+				BuildVariants: []model.BuildVariant{
+					{
+						Name: "import",
+						Tasks: []model.BuildVariantTaskUnit{
+							{
+								Name: "silhouettes",
+							},
+						},
+					},
+				},
+				Tasks: []model.ProjectTask{
+					{
+						Name: "silhouettes",
+						RunOn: []string{
+							"echoes",
+						},
+					},
+				},
+			}
+			So(ensureHasNecessaryBVFields(project),
+				ShouldResemble, ValidationErrors{})
+		})
+		Convey("no error should be thrown if the buildvariant does not "+
 			"have a run_on field specified but all tasks within it have a "+
 			"distro field specified", func() {
 			project := &model.Project{


### PR DESCRIPTION
[EVG-14269](https://jira.mongodb.org/browse/EVG-14269)

### Description 
The work for specifying run_on for a task was actually done in EVG-13023 but we should add this to the validation. I also rearranged this validation a bit so that we can short-circuit if possible.

### Testing 
Added a unit test and [created a patch](https://spruce.mongodb.com/task/evergreen_ubuntu1604_dist_staging_patch_852a461d576e6e63091d465cabc6c58f8f0f0718_60b79fae0ae606776bbfec05_21_06_02_15_12_01/logs?execution=0) with a different run_on set at the task definition level.

