### PR TITLE
EVG-14665 make evergreen (ever)green

### DIFF
--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -164,24 +164,28 @@ func (s *CommitQueueSuite) TestCommitQueueClearAll() {
 }
 
 func (s *CommitQueueSuite) TestIsAuthorizedToPatchAndMerge() {
-	s.ctx = &DBConnector{}
-	ctx := context.Background()
-
-	args := UserRepoInfo{
+	args1 := UserRepoInfo{
 		Username: "evrg-bot-webhook",
 		Owner:    "evergreen-ci",
 		Repo:     "evergreen",
 	}
-	authorized, err := s.ctx.IsAuthorizedToPatchAndMerge(ctx, s.settings, args)
-	s.NoError(err)
-	s.True(authorized)
-
-	args = UserRepoInfo{
+	args2 := UserRepoInfo{
 		Username: "octocat",
 		Owner:    "evergreen-ci",
 		Repo:     "evergreen",
 	}
-	authorized, err = s.ctx.IsAuthorizedToPatchAndMerge(ctx, s.settings, args)
+	c := &MockCommitQueueConnector{
+		UserPermissions: map[UserRepoInfo]string{
+			args1: "admin",
+			args2: "read",
+		},
+	}
+	ctx := context.Background()
+	authorized, err := c.IsAuthorizedToPatchAndMerge(ctx, s.settings, args1)
+	s.NoError(err)
+	s.True(authorized)
+
+	authorized, err = c.IsAuthorizedToPatchAndMerge(ctx, s.settings, args2)
 	s.NoError(err)
 	s.False(authorized)
 }

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -84,6 +84,13 @@ func (s *GithubWebhookRouteSuite) SetupTest() {
 			Queue: map[string][]restModel.APICommitQueueItem{
 				"bth": []restModel.APICommitQueueItem{},
 			},
+			UserPermissions: map[data.UserRepoInfo]string{
+				data.UserRepoInfo{
+					Username: "baxterthehacker",
+					Owner:    "baxterthehacker",
+					Repo:     "public-repo",
+				}: "write",
+			},
 		},
 	}
 


### PR DESCRIPTION
[EVG-14665](https://jira.mongodb.org/browse/EVG-14665)
I realize the title is silly but I had to.

### Description 
Some of our tests are failing since we switched out the Github APIs. Really unit tests shouldn't rely on third party libraries, this is part of why we have mocks. One of the failing tests lends itself well to a mock so I created a function for it; the other one relies heavily on Github/isn't really a useful test without it, so I removed it.

### Testing 
Verifying that the failing tests no longer fail.
