### PR TITLE
EVG-14736 unset CedarResultsFailed when the task is reset

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1478,10 +1478,11 @@ func resetTaskUpdate(t *Task) bson.M {
 			LastHeartbeatKey:       utility.ZeroTime,
 		},
 		"$unset": bson.M{
-			DetailsKey:           "",
-			HasCedarResultsKey:   "",
-			ResetWhenFinishedKey: "",
-			AgentVersionKey:      "",
+			DetailsKey:            "",
+			HasCedarResultsKey:    "",
+			CedarResultsFailedKey: "",
+			ResetWhenFinishedKey:  "",
+			AgentVersionKey:       "",
 		},
 	}
 	return update


### PR DESCRIPTION
[EVG-14736](https://jira.mongodb.org/browse/EVG-14736)

### Description 
The field is set when a task has a failing test but not reset when the task is reset so all subsequent executions fail

