### PR TITLE
EVG-14747 increase generate tasks task/version limit

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	maxGeneratedBuildVariants = 100
-	maxGeneratedTasks         = 2000
+	maxGeneratedBuildVariants = 200
+	maxGeneratedTasks         = 25000
 )
 
 // GeneratedProject is a subset of the Project type, and is generated from the


### PR DESCRIPTION
[EVG-14747](https://jira.mongodb.org/browse/EVG-14747)

### Description 
This might be a temporary change; right now on the config side it's taking 25 minutes to generate all tasks/variants, which may be unacceptable (David is doing some refactoring to reduce it). We're interested to see how long it takes Evergreen / if it stresses out the system, so we need to increase these limits so that Evergreen actually generates the tasks.
