### PR TITLE
EVG-14656 add patch trigger definitions to API project refs

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1726,7 +1726,7 @@ func ValidateTriggerDefinition(definition patch.PatchTriggerDefinition, parentPr
 
 	childProjectId, err := GetIdForProject(definition.ChildProject)
 	if err != nil {
-		return definition, errors.Wrapf(err, "error finding child project %s", definition.ChildProject)
+		return definition, errors.Wrapf(err, "error finding child project '%s'", definition.ChildProject)
 	}
 
 	if !utility.StringSliceContains([]string{"", AllStatuses, evergreen.PatchSucceeded, evergreen.PatchFailed}, definition.Status) {

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -90,6 +90,7 @@ func (t *APIPatchTriggerDefinition) BuildFromService(h interface{}) error {
 	default:
 		return errors.Errorf("Invalid patch trigger definition of type '%T'", h)
 	}
+	t.ChildProject = utility.ToStringPtr(def.ChildProject)
 	t.Alias = utility.ToStringPtr(def.Alias)
 	t.Status = utility.ToStringPtr(def.Status)
 	t.ParentAsModule = utility.ToStringPtr(def.ParentAsModule)
@@ -108,6 +109,7 @@ func (t *APIPatchTriggerDefinition) BuildFromService(h interface{}) error {
 func (t *APIPatchTriggerDefinition) ToService() (interface{}, error) {
 	trigger := patch.PatchTriggerDefinition{}
 
+	trigger.ChildProject = utility.FromStringPtr(t.ChildProject)
 	trigger.Status = utility.FromStringPtr(t.Status)
 	trigger.Alias = utility.FromStringPtr(t.Alias)
 	trigger.ParentAsModule = utility.FromStringPtr(t.ParentAsModule)
@@ -393,6 +395,9 @@ func (p *APIProjectRef) ToService() (interface{}, error) {
 
 	// Copy triggers
 	var triggers []model.TriggerDefinition
+	if p.PatchTriggerAliases != nil {
+		triggers = []model.TriggerDefinition{}
+	}
 	for _, t := range p.Triggers {
 		i, err = t.ToService()
 		if err != nil {
@@ -407,6 +412,9 @@ func (p *APIProjectRef) ToService() (interface{}, error) {
 	projectRef.Triggers = triggers
 
 	var patchTriggers []patch.PatchTriggerDefinition
+	if p.PatchTriggerAliases != nil {
+		patchTriggers = []patch.PatchTriggerDefinition{}
+	}
 	for _, t := range p.PatchTriggerAliases {
 		i, err = t.ToService()
 		if err != nil {

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -231,13 +231,77 @@ func (s *ProjectPatchByIDSuite) TestFilesIgnoredFromCache() {
 	s.Len(p.FilesIgnoredFromCache, 0)
 }
 
+func (s *ProjectPatchByIDSuite) TestPatchTriggerAliases() {
+	s.NoError(db.Clear(serviceModel.ProjectRefCollection))
+	ctx := context.Background()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "Test1"})
+	h := s.rm.(*projectIDPatchHandler)
+	h.user = &user.DBUser{Id: "me"}
+
+	jsonBody := []byte(`{"patch_trigger_aliases": [{"child_project": "child", "task_specifiers": [ {"task_regex": ".*", "variant_regex": ".*" }]}]}`)
+	req, _ := http.NewRequest("PATCH", "http://example.com/api/rest/v2/projects/dimoxinil", bytes.NewBuffer(jsonBody))
+	req = gimlet.SetURLVars(req, map[string]string{"project_id": "dimoxinil"})
+	s.NoError(s.rm.Parse(ctx, req))
+	s.NotNil(s.rm.(*projectIDPatchHandler).user)
+
+	resp := s.rm.Run(ctx)
+	s.NotNil(resp)
+	s.NotNil(resp.Data())
+	s.Equal(resp.Status(), http.StatusBadRequest) // child project doesn't exist yet
+
+	childProject := serviceModel.ProjectRef{
+		Id:         "firstborn",
+		Identifier: "child",
+	}
+	s.NoError(childProject.Insert())
+	resp = s.rm.Run(ctx)
+	s.NotNil(resp)
+	s.NotNil(resp.Data())
+	s.Equal(resp.Status(), http.StatusOK)
+
+	p, err := s.sc.FindProjectById("dimoxinil", true)
+	s.NoError(err)
+	s.False(p.PatchTriggerAliases == nil)
+	s.Len(p.PatchTriggerAliases, 1)
+	s.Equal(p.PatchTriggerAliases[0].ChildProject, "firstborn") // saves ID
+
+	jsonBody = []byte(`{"patch_trigger_aliases": []}`) // empty list isn't nil
+	req, _ = http.NewRequest("PATCH", "http://example.com/api/rest/v2/projects/dimoxinil", bytes.NewBuffer(jsonBody))
+	req = gimlet.SetURLVars(req, map[string]string{"project_id": "dimoxinil"})
+	s.NoError(s.rm.Parse(ctx, req))
+	s.NotNil(s.rm.(*projectIDPatchHandler).user)
+
+	resp = s.rm.Run(ctx)
+	s.NotNil(resp)
+	s.NotNil(resp.Data())
+	s.Equal(resp.Status(), http.StatusOK)
+
+	p, err = s.sc.FindProjectById("dimoxinil", true)
+	s.NoError(err)
+	s.NotNil(p.PatchTriggerAliases)
+	s.Len(p.PatchTriggerAliases, 0)
+
+	jsonBody = []byte(`{"patch_trigger_aliases": null}`)
+	req, _ = http.NewRequest("PATCH", "http://example.com/api/rest/v2/projects/dimoxinil", bytes.NewBuffer(jsonBody))
+	req = gimlet.SetURLVars(req, map[string]string{"project_id": "dimoxinil"})
+	s.NoError(s.rm.Parse(ctx, req))
+	s.NotNil(s.rm.(*projectIDPatchHandler).user)
+	resp = s.rm.Run(ctx)
+	s.NotNil(resp)
+	s.NotNil(resp.Data())
+	s.Equal(resp.Status(), http.StatusOK)
+
+	p, err = s.sc.FindProjectById("dimoxinil", true)
+	s.NoError(err)
+	s.Nil(p.PatchTriggerAliases)
+}
+
 ////////////////////////////////////////////////////////////////////////
 //
 // Tests for PUT /rest/v2/projects/{project_id}
 
 type ProjectPutSuite struct {
 	sc *data.MockConnector
-	// data data.MockProjectConnector
 	rm gimlet.RouteHandler
 
 	suite.Suite

--- a/rest/route/repo.go
+++ b/rest/route/repo.go
@@ -164,6 +164,13 @@ func (h *repoIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 			h.newRepoRef.Triggers[i].DefinitionID = utility.RandomString()
 		}
 	}
+	for i := range h.newRepoRef.PatchTriggerAliases {
+		h.newRepoRef.PatchTriggerAliases[i], err = dbModel.ValidateTriggerDefinition(h.newRepoRef.PatchTriggerAliases[i], h.newRepoRef.Id)
+		catcher.Add(err)
+	}
+	for i, buildDef := range h.newRepoRef.PeriodicBuilds {
+		catcher.Wrapf(buildDef.Validate(), "invalid periodic build definition on line %d", i+1)
+	}
 	if catcher.HasErrors() {
 		return gimlet.MakeJSONErrorResponder(catcher.Resolve())
 	}


### PR DESCRIPTION
[EVG-14656](https://jira.mongodb.org/browse/EVG-14656)

### Description 
We neglected to add PatchTriggerAliases to the APIProjectRef, meaning it can't be modified using the API.

### Testing 
Added a unit test.

### TODO
After merging, will add to documentation.