### PR TITLE
EVG-13919 Expose triggering Git commit hash as expansion

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -982,6 +982,7 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 			expansions.Put("github_org", p.GithubPatchData.BaseOwner)
 			expansions.Put("github_repo", p.GithubPatchData.BaseRepo)
 			expansions.Put("github_author", p.GithubPatchData.Author)
+			expansions.Put("github_merge_commit", p.GithubPatchData.MergeCommitSHA)
 		}
 	} else {
 		expansions.Put("revision_order_id", strconv.Itoa(v.RevisionOrderNumber))

--- a/model/project.go
+++ b/model/project.go
@@ -982,7 +982,7 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 			expansions.Put("github_org", p.GithubPatchData.BaseOwner)
 			expansions.Put("github_repo", p.GithubPatchData.BaseRepo)
 			expansions.Put("github_author", p.GithubPatchData.Author)
-			expansions.Put("github_merge_commit", p.GithubPatchData.MergeCommitSHA)
+			expansions.Put("github_commit", p.GithubPatchData.MergeCommitSHA)
 		}
 	} else {
 		expansions.Put("revision_order_id", strconv.Itoa(v.RevisionOrderNumber))

--- a/model/project.go
+++ b/model/project.go
@@ -982,7 +982,7 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 			expansions.Put("github_org", p.GithubPatchData.BaseOwner)
 			expansions.Put("github_repo", p.GithubPatchData.BaseRepo)
 			expansions.Put("github_author", p.GithubPatchData.Author)
-			expansions.Put("github_commit", p.GithubPatchData.MergeCommitSHA)
+			expansions.Put("github_commit", p.GithubPatchData.HeadHash)
 		}
 	} else {
 		expansions.Put("revision_order_id", strconv.Itoa(v.RevisionOrderNumber))

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -424,11 +424,11 @@ buildvariants:
 	patchDoc := &patch.Patch{
 		Version: v.Id,
 		GithubPatchData: thirdparty.GithubPatch{
-			PRNumber:       42,
-			BaseOwner:      "evergreen-ci",
-			BaseRepo:       "evergreen",
-			Author:         "octocat",
-			MergeCommitSHA: "abc123",
+			PRNumber:  42,
+			BaseOwner: "evergreen-ci",
+			BaseRepo:  "evergreen",
+			Author:    "octocat",
+			HeadHash:  "abc123",
 		},
 	}
 	assert.NoError(patchDoc.Insert())

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -361,6 +361,7 @@ buildvariants:
 	assert.False(expansions.Exists("github_repo"))
 	assert.False(expansions.Exists("github_author"))
 	assert.False(expansions.Exists("github_pr_number"))
+	assert.False(expansions.Exists("github_commit"))
 	assert.Equal("lie", expansions.Get("cake"))
 
 	assert.NoError(VersionUpdateOne(bson.M{VersionIdKey: v.Id}, bson.M{
@@ -380,6 +381,7 @@ buildvariants:
 	assert.False(expansions.Exists("github_repo"))
 	assert.False(expansions.Exists("github_author"))
 	assert.False(expansions.Exists("github_pr_number"))
+	assert.False(expansions.Exists("github_commit"))
 	assert.False(expansions.Exists("triggered_by_git_tag"))
 	require.NoError(t, db.ClearCollections(patch.Collection))
 
@@ -408,7 +410,7 @@ buildvariants:
 	require.NoError(t, p.Insert())
 	expansions, err = PopulateExpansions(taskDoc, &h, oauthToken)
 	assert.NoError(err)
-	assert.Len(map[string]string(expansions), 26)
+	assert.Len(map[string]string(expansions), 27)
 	assert.Equal("true", expansions.Get("is_patch"))
 	assert.Equal("github_pr", expansions.Get("requester"))
 	assert.False(expansions.Exists("is_commit_queue"))
@@ -416,27 +418,30 @@ buildvariants:
 	assert.True(expansions.Exists("github_repo"))
 	assert.True(expansions.Exists("github_author"))
 	assert.True(expansions.Exists("github_pr_number"))
+	assert.True(expansions.Exists("github_commit"))
 	require.NoError(t, db.ClearCollections(patch.Collection))
 
 	patchDoc := &patch.Patch{
 		Version: v.Id,
 		GithubPatchData: thirdparty.GithubPatch{
-			PRNumber:  42,
-			BaseOwner: "evergreen-ci",
-			BaseRepo:  "evergreen",
-			Author:    "octocat",
+			PRNumber:       42,
+			BaseOwner:      "evergreen-ci",
+			BaseRepo:       "evergreen",
+			Author:         "octocat",
+			MergeCommitSHA: "abc123",
 		},
 	}
 	assert.NoError(patchDoc.Insert())
 
 	expansions, err = PopulateExpansions(taskDoc, &h, oauthToken)
 	assert.NoError(err)
-	assert.Len(map[string]string(expansions), 26)
+	assert.Len(map[string]string(expansions), 27)
 	assert.Equal("github_pr", expansions.Get("requester"))
 	assert.Equal("true", expansions.Get("is_patch"))
 	assert.Equal("evergreen", expansions.Get("github_repo"))
 	assert.Equal("octocat", expansions.Get("github_author"))
 	assert.Equal("42", expansions.Get("github_pr_number"))
+	assert.Equal("abc123", expansions.Get("github_commit"))
 	assert.Equal("wut?", expansions.Get("github_org"))
 
 	upstreamTask := task.Task{
@@ -455,7 +460,7 @@ buildvariants:
 	taskDoc.TriggerType = ProjectTriggerLevelTask
 	expansions, err = PopulateExpansions(taskDoc, &h, oauthToken)
 	assert.NoError(err)
-	assert.Len(map[string]string(expansions), 34)
+	assert.Len(map[string]string(expansions), 35)
 	assert.Equal(taskDoc.TriggerID, expansions.Get("trigger_event_identifier"))
 	assert.Equal(taskDoc.TriggerType, expansions.Get("trigger_event_type"))
 	assert.Equal(upstreamTask.Revision, expansions.Get("trigger_revision"))


### PR DESCRIPTION
[EVG-13919](https://jira.mongodb.org/browse/EVG-13919)

### Description 
add github_merge_commit to expansion

### Testing 
added unittest
 [trying to make pr on commit-queue-merge](https://evergreen-staging.corp.mongodb.com/task/sandbox_ubuntu1604_unit_tests_patch_1796475006a20fc8898fb59f30010631f0ef2784_60c25735b2373644ebd21234_21_06_10_18_18_11)
