### PR TITLE
EVG-14594 store if legacy test results exist for task

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -773,7 +773,7 @@ func FindOne(query db.Q) (*Task, error) {
 		return nil, nil
 	}
 	if err = task.MergeNewTestResults(); err != nil {
-		return nil, errors.Wrap(err, "errors merging new test results")
+		return nil, errors.Wrapf(err, "errors merging new test results for '%s'", task.Id)
 	}
 	return task, err
 }
@@ -953,7 +953,7 @@ func FindOneOld(query db.Q) (*Task, error) {
 		return nil, nil
 	}
 	if err = task.MergeNewTestResults(); err != nil {
-		return nil, errors.Wrap(err, "errors merging new test results")
+		return nil, errors.Wrapf(err, "errors merging new test results for '%s'", task.Id)
 	}
 	return task, err
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -72,6 +72,7 @@ var (
 	GenerateTaskKey             = bsonutil.MustHaveTag(Task{}, "GenerateTask")
 	GeneratedTasksKey           = bsonutil.MustHaveTag(Task{}, "GeneratedTasks")
 	GeneratedByKey              = bsonutil.MustHaveTag(Task{}, "GeneratedBy")
+	HasLegacyResultsKey         = bsonutil.MustHaveTag(Task{}, "HasLegacyResults")
 	HasCedarResultsKey          = bsonutil.MustHaveTag(Task{}, "HasCedarResults")
 	CedarResultsFailedKey       = bsonutil.MustHaveTag(Task{}, "CedarResultsFailed")
 	IsGithubCheckKey            = bsonutil.MustHaveTag(Task{}, "IsGithubCheck")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -86,7 +86,8 @@ type Task struct {
 	MustHaveResults    bool                `bson:"must_have_results,omitempty" json:"must_have_results,omitempty"`
 	HasCedarResults    bool                `bson:"has_cedar_results,omitempty" json:"has_cedar_results,omitempty"`
 	CedarResultsFailed bool                `bson:"cedar_results_failed,omitempty" json:"cedar_results_failed,omitempty"`
-
+	// we use a pointer for HasLegacyResults to verify if this information is cached or we need to look it up
+	HasLegacyResults *bool `bson:"has_legacy_results,omitempty" json:"has_legacy_results,omitempty"`
 	// only relevant if the task is runnin.  the time of the last heartbeat
 	// sent back by the agent
 	LastHeartbeat time.Time `bson:"last_heartbeat" json:"last_heartbeat"`
@@ -1030,6 +1031,20 @@ func (t *Task) SetHasCedarResults(hasCedarResults, failedResults bool) error {
 	)
 }
 
+func (t *Task) SetHasLegacyResults(hasLegacyResults bool) error {
+	t.HasLegacyResults = utility.ToBoolPtr(hasLegacyResults)
+	return UpdateOne(
+		bson.M{
+			IdKey: t.Id,
+		},
+		bson.M{
+			"$set": bson.M{
+				HasLegacyResultsKey: t.HasLegacyResults,
+			},
+		},
+	)
+}
+
 // ActivateTask will set the ActivatedBy field to the caller and set the active state to be true
 func (t *Task) ActivateTask(caller string) ([]Task, error) {
 	t.ActivatedBy = caller
@@ -1343,12 +1358,13 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 		},
 		bson.M{
 			"$set": bson.M{
-				FinishTimeKey: finishTime,
-				StatusKey:     detail.Status,
-				TimeTakenKey:  t.TimeTaken,
-				DetailsKey:    t.Details,
-				StartTimeKey:  t.StartTime,
-				LogsKey:       detail.Logs,
+				FinishTimeKey:       finishTime,
+				StatusKey:           detail.Status,
+				TimeTakenKey:        t.TimeTaken,
+				DetailsKey:          t.Details,
+				StartTimeKey:        t.StartTime,
+				LogsKey:             detail.Logs,
+				HasLegacyResultsKey: t.HasLegacyResults,
 			},
 		})
 
@@ -2035,6 +2051,9 @@ func (t *Task) MergeNewTestResults() error {
 			StartTime:       result.StartTime,
 			EndTime:         result.EndTime,
 		})
+	}
+	if t.HasLegacyResults == nil { // cache results so we know if we should call this in the future
+		return t.SetHasLegacyResults(len(newTestResults) > 0)
 	}
 	return nil
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2057,8 +2057,8 @@ func (t *Task) MergeNewTestResults() error {
 		})
 	}
 
-	// store whether or not results exist so we know if we should look them up in the future
-	if t.HasLegacyResults == nil {
+	// Store whether or not results exist so we know if we should look them up in the future.
+	if t.HasLegacyResults == nil && !t.Archived {
 		return t.SetHasLegacyResults(len(newTestResults) > 0)
 	}
 	return nil

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2033,6 +2033,10 @@ func (t *Task) MergeNewTestResults() error {
 	if t.Archived {
 		id = t.OldTaskId
 	}
+	if !evergreen.IsFinishedTaskStatus(t.Status) || t.Status != evergreen.TaskStarted {
+		return nil // task won't have test results
+	}
+
 	newTestResults, err := testresult.FindByTaskIDAndExecution(id, t.Execution)
 	if err != nil {
 		return errors.Wrap(err, "problem finding test results")

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2136,6 +2136,22 @@ func TestSetDisabledPriority(t *testing.T) {
 	}
 }
 
+func TestSetHasLegacyResults(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection))
+
+	task := Task{Id: "t1"}
+	assert.NoError(t, task.Insert())
+	assert.NoError(t, task.SetHasLegacyResults(true))
+
+	assert.True(t, utility.FromBoolPtr(task.HasLegacyResults))
+
+	taskFromDb, err := FindOneId("t1")
+	assert.NoError(t, err)
+	assert.NotNil(t, taskFromDb)
+	assert.NotNil(t, taskFromDb.HasLegacyResults)
+	assert.True(t, utility.FromBoolPtr(taskFromDb.HasLegacyResults))
+}
+
 func TestDisplayStatus(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	t1 := Task{

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1047,7 +1047,8 @@ func TestFindOneIdOldOrNew(t *testing.T) {
 	require.NoError(db.ClearCollections(Collection, OldCollection))
 
 	taskDoc := Task{
-		Id: "task",
+		Id:     "task",
+		Status: evergreen.TaskSucceeded,
 	}
 	require.NoError(taskDoc.Insert())
 	require.NoError(taskDoc.Archive())

--- a/model/task/task_testresult_test.go
+++ b/model/task/task_testresult_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/stretchr/testify/suite"
@@ -98,6 +99,7 @@ func (s *TaskTestResultSuite) TestNoOldNewTestResults() {
 		Project:    fmt.Sprintf("project-%d", 10),
 		Revision:   fmt.Sprintf("revision-%d", 10),
 		Execution:  3,
+		Status:     evergreen.TaskSucceeded,
 	}
 	err := t.Insert()
 	s.Require().NoError(err)
@@ -150,6 +152,7 @@ func (s *TaskTestResultSuite) TestArchivedTask() {
 		Project:    fmt.Sprintf("project-%d", 20),
 		Revision:   fmt.Sprintf("revision-%d", 20),
 		Execution:  3,
+		Status:     evergreen.TaskFailed,
 	}
 	err := t.Insert()
 	s.NoError(err)


### PR DESCRIPTION
[EVG-14594](https://jira.mongodb.org/browse/EVG-14594)

### Description 
This PR does two things:
1. Sets a global limit for how many testresults DB calls we can make
2. Caches whether or not we should be looking up testresults at all

Since we're phasing off of storing testresults in the DB, this shouldn't add too much to the DB, but in the meantime it should speed up how the waterfall handles testresults (I decided to do this bc, looking at the data from the last three rows of the nodeJS waterfall, we were calling this function over 2500 times for tasks that don't even have failing tests.

### Testing 
Added a unit test and opened in local to verify the information gets cached as expected.
