### PR TITLE
EVG-14535: add logging to interrupt handling

### DIFF
--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -186,7 +186,7 @@ func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instan
 	grip.Info(message.Fields{
 		"message":       "got interruption warning from AWS",
 		"distro":        h.Distro.Id,
-		"instance_type": h.InstanceType,
+		"instance_type": h.Distro.ProviderSettingsList[0].Lookup("instance_type").StringValue(),
 		"host_id":       h.Id,
 	})
 

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -184,9 +184,10 @@ func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instan
 	}
 
 	grip.Info(message.Fields{
-		"message": "got interruption warning from AWS",
-		"distro":  h.Distro,
-		"host_id": h.Id,
+		"message":       "got interruption warning from AWS",
+		"distro":        h.Distro.Id,
+		"instance_type": h.InstanceType,
+		"host_id":       h.Id,
 	})
 
 	if h.Status == evergreen.HostTerminated {

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -183,10 +183,16 @@ func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instan
 		return nil
 	}
 
+	instanceType := "Empty Distro.ProviderSettingsList, unable to get instance_type"
+	if len(h.Distro.ProviderSettingsList) > 0 {
+		if stringVal, ok := h.Distro.ProviderSettingsList[0].Lookup("instance_type").StringValueOK(); ok {
+			instanceType = stringVal
+		}
+	}
 	grip.Info(message.Fields{
 		"message":       "got interruption warning from AWS",
 		"distro":        h.Distro.Id,
-		"instance_type": h.Distro.ProviderSettingsList[0].Lookup("instance_type").StringValue(),
+		"instance_type": instanceType,
 		"host_id":       h.Id,
 	})
 

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -183,6 +183,12 @@ func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instan
 		return nil
 	}
 
+	grip.Info(message.Fields{
+		"message": "got interruption warning from AWS",
+		"distro":  h.Distro,
+		"host_id": h.Id,
+	})
+
 	if h.Status == evergreen.HostTerminated {
 		return nil
 	}


### PR DESCRIPTION
[EVG-14535](https://jira.mongodb.org/browse/EVG-14535)

### Description 
This is intended as a more precise version of the SNS alert described in the ticket that we can use to see interruptions by distro. We previously only logged in situations where we terminated the host ourselves, but this logs in all cases where we get an alert and are able to match the alert to a host.
