### PR TITLE
EVG-14227 fetch all-configs from github

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2021-06-04"
+	ClientVersion = "2021-06-11"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2021-06-11-b"

--- a/operations/admin_all_configs.go
+++ b/operations/admin_all_configs.go
@@ -82,30 +82,30 @@ func fetchAndWriteConfigs(c *legacyClient, projects []model.ProjectRef, useLegac
 			ConfigFile: p.RemotePath,
 		}
 		if exists := configDownloaded[repo]; exists {
-			grip.Infof("Configuration for project %s already downloaded", p.Identifier)
+			grip.Infof("Configuration for project '%s' already downloaded", p.Identifier)
 			continue
 		}
-		grip.Infof("Downloading configuration for %s", p.Identifier)
+		grip.Infof("Downloading configuration for '%s'", p.Identifier)
 		versions, err := c.GetRecentVersions(p.Id)
 		if err != nil {
-			catcher.Wrapf(err, "failed to fetch recent versions for %s", p.Identifier)
+			catcher.Wrapf(err, "failed to fetch recent versions for '%s'", p.Identifier)
 			continue
 		}
 		if len(versions) == 0 {
-			catcher.Errorf("WARNING: project %s has no versions", p.Identifier)
+			catcher.Errorf("WARNING: project '%s' has no versions", p.Identifier)
 			continue
 		}
 
 		config, err := c.GetConfig(versions[0], useLegacy)
 		if err != nil {
-			catcher.Wrapf(err, "failed to fetch config for project %s, version %s", p.Identifier, versions[0])
+			catcher.Wrapf(err, "failed to fetch config for project '%s', version '%s'", p.Identifier, versions[0])
 			continue
 		}
 		configDownloaded[repo] = true
 
 		err = ioutil.WriteFile(p.Identifier+".yml", config, 0644)
 		if err != nil {
-			catcher.Wrapf(err, "failed to write configuration for project %s", p.Identifier)
+			catcher.Wrapf(err, "failed to write configuration for project '%s'", p.Identifier)
 		}
 	}
 

--- a/operations/http.go
+++ b/operations/http.go
@@ -302,9 +302,9 @@ func (ac *legacyClient) GetPatchedConfig(patchId string) (*model.Project, error)
 }
 
 // GetConfig fetches the config yaml from the API server for a given project ID.
-func (ac *legacyClient) GetConfig(versionId string, useLegacy bool) ([]byte, error) {
+func (ac *legacyClient) GetConfig(versionId string, shouldFetch bool) ([]byte, error) {
 	path := fmt.Sprintf("versions/%v/config", versionId)
-	if !useLegacy {
+	if shouldFetch {
 		path = fmt.Sprintf("%s?latest_parser=true", path)
 	}
 	resp, err := ac.get(path, nil)

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -324,6 +324,10 @@ func (restapi restAPI) getVersionConfig(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		_, err = w.Write(fileContents)
+		if err != nil {
+			gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "unable to write config file"})
+			return
+		}
 	}
 	var config []byte
 	pp, err := model.ParserProjectFindOneById(projCtx.Version.Id)


### PR DESCRIPTION
[EVG-14227](https://jira.mongodb.org/browse/EVG-14227)

### Description 
So my previous attempt to test yamls using all-configs with yaml v3 didn't catch the problems because we were using the project that we'd previously parsed and stored in the DB. Instead, we need to fetch the config directly from github so it's untouched.

This will result in a lot of API calls so it might be expensive; I'm going to call it at kind of an off time I think.

### Testing 
Tested via staging.
