### PR TITLE
EVG-14807 get github files from correct branch

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1694,7 +1694,7 @@ func GetSetupScriptForTask(ctx context.Context, taskId string) (string, error) {
 		return "", errors.Wrap(err, "error getting project")
 	}
 
-	configFile, err := thirdparty.GetGithubFile(ctx, token, pRef.Owner, pRef.Repo, pRef.SpawnHostScriptPath, "")
+	configFile, err := thirdparty.GetGithubFile(ctx, token, pRef.Owner, pRef.Repo, pRef.SpawnHostScriptPath, pRef.Branch)
 	if err != nil {
 		return "", errors.Wrapf(err,
 			"error fetching spawn host script for '%s' at path '%s'", pRef.Identifier, pRef.SpawnHostScriptPath)

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -313,7 +313,7 @@ func (restapi restAPI) getVersionConfig(w http.ResponseWriter, r *http.Request) 
 			gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "project ref not found"})
 			return
 		}
-		configFile, err := thirdparty.GetGithubFile(r.Context(), oauthToken, pRef.Owner, pRef.Repo, pRef.RemotePath, "")
+		configFile, err := thirdparty.GetGithubFile(r.Context(), oauthToken, pRef.Owner, pRef.Repo, pRef.RemotePath, pRef.Branch)
 		if err != nil {
 			gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "error fetching project file"})
 			return

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -188,16 +188,16 @@ func parseGithubErrorResponse(resp *github.Response) error {
 }
 
 // GetGithubFile returns a struct that contains the contents of files within
-// a repository as Base64 encoded content.
-func GetGithubFile(ctx context.Context, oauthToken, owner, repo, path, hash string) (*github.RepositoryContent, error) {
+// a repository as Base64 encoded content. Ref should be the commit hash or branch (defaults to master).
+func GetGithubFile(ctx context.Context, oauthToken, owner, repo, path, ref string) (*github.RepositoryContent, error) {
 	httpClient := getGithubClient(oauthToken, "GetGithubFile")
 	defer utility.PutHTTPClient(httpClient)
 	client := github.NewClient(httpClient)
 
 	var opt *github.RepositoryContentGetOptions
-	if len(hash) != 0 {
+	if len(ref) != 0 {
 		opt = &github.RepositoryContentGetOptions{
-			Ref: hash,
+			Ref: ref,
 		}
 	}
 

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -111,7 +111,7 @@ func (j *periodicBuildJob) addVersion(ctx context.Context, definition model.Peri
 	if err != nil {
 		return "", errors.Wrap(err, "error getting github token")
 	}
-	configFile, err := thirdparty.GetGithubFile(ctx, token, j.project.Owner, j.project.Repo, definition.ConfigFile, "")
+	configFile, err := thirdparty.GetGithubFile(ctx, token, j.project.Owner, j.project.Repo, definition.ConfigFile, j.project.Branch)
 	if err != nil {
 		return "", errors.Wrap(err, "error getting config file from github")
 	}


### PR DESCRIPTION
[EVG-14807](https://jira.mongodb.org/browse/EVG-14807)

### Description 
In a couple of places (but not all) we mistakenly don't specify the branch from which to get the github files. I think that this field being called `hash` doesn't help, since it implies a commit specifically.

### Description 
Not tested, but the docs and other uses of this function indicate that this is correct (testing will take a lot of setup and I'd like to merge this today).

