### PR TITLE
EVG-13303 use update all to remove admins from project

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1407,8 +1407,10 @@ func RemoveAdminFromProjects(toDelete string) error {
 	}
 
 	catcher := grip.NewBasicCatcher()
-	catcher.Add(db.Update(ProjectRefCollection, bson.M{}, projectUpdate))
-	catcher.Add(db.Update(RepoRefCollection, bson.M{}, repoUpdate))
+	_, err := db.UpdateAll(ProjectRefCollection, bson.M{}, projectUpdate)
+	catcher.Add(errors.Wrap(err, "error updating projects"))
+	_, err = db.UpdateAll(RepoRefCollection, bson.M{}, repoUpdate)
+	catcher.Add(errors.Wrap(err, "error updating repos"))
 	return catcher.Resolve()
 }
 


### PR DESCRIPTION
[EVG-13303](https://jira.mongodb.org/browse/EVG-13303)

### Description 
Update was only updating the first project that it found, whereas we want to pull the user from any document.

### Testing 
Added a unit test.