### PR TITLE
EVG-14451 Check for empty FileInfo

### DIFF
--- a/agent/util/archive_tar.go
+++ b/agent/util/archive_tar.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/mongodb/grip"
@@ -28,6 +29,10 @@ FileLoop:
 	for file := range pathsToAdd {
 		if ctx.Err() != nil {
 			return numFilesArchived, errors.Wrap(ctx.Err(), "timeout when building archive")
+		}
+		if reflect.ValueOf(file.Info).IsNil() {
+			logger.Warningf("Could not get FileInfo for %s, ignoring", file.Path)
+			continue
 		}
 
 		var intarball string

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-06-11"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-06-11-b"
+	AgentVersion = "2021-06-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-14451](https://jira.mongodb.org/browse/EVG-14451)

I believe the problem is that `BuildArchive` https://github.com/evergreen-ci/evergreen/blob/b11532bc99dd2151d1f9d835556bc41fcc69ff58/agent/util/archive_tar.go#L20 calls `streamArchiveContents` https://github.com/evergreen-ci/evergreen/blob/b11532bc99dd2151d1f9d835556bc41fcc69ff58/agent/util/archive.go#L43, which returns a channel of `ArchiveContentFile` https://github.com/evergreen-ci/evergreen/blob/b11532bc99dd2151d1f9d835556bc41fcc69ff58/agent/util/archive.go#L16, which contains `os.FileInfo`, which is an interface. This means that `Mode()` panics if the interface points to a nil value https://github.com/evergreen-ci/evergreen/blob/b11532bc99dd2151d1f9d835556bc41fcc69ff58/agent/util/archive_tar.go#L37.

The problem is we don't check the error returned by `WalkFunc` https://github.com/evergreen-ci/evergreen/blob/b11532bc99dd2151d1f9d835556bc41fcc69ff58/agent/util/archive.go#L117. In many cases the solution would be to return the error from `WalkFunc` and check that error, since presumably that's the case when `os.FileInfo` points to a nil value. However, `streamArchiveContents` creates a goroutine and returns a channel. This means that when the function returns the error is not yet set.

My solution was to use reflection to check that `os.FileInfo` doesn't point to a nil value. I'm pretty torn about this and am open to suggestions. I'd like to avoid a large refactor, but I also think reflection is not a great answer.