### PR TITLE
EVG-14631 log error output before returning from git push

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -451,14 +451,15 @@ func (c *gitFetchProject) executeLoop(ctx context.Context,
 	}
 	logger.Execution().Debug(fmt.Sprintf("Commands are: %s", redactedCmds))
 
-	if err = fetchSourceCmd.Run(ctx); err != nil {
-		errorOutput := stdErr.String()
-		if errorOutput != "" {
-			if opts.token != "" {
-				errorOutput = strings.Replace(errorOutput, opts.token, "[redacted oauth token]", -1)
-			}
-			logger.Execution().Error(errorOutput)
+	err = fetchSourceCmd.Run(ctx)
+	errorOutput := stdErr.String()
+	if errorOutput != "" {
+		if opts.token != "" {
+			errorOutput = strings.Replace(errorOutput, opts.token, "[redacted oauth token]", -1)
 		}
+		logger.Execution().Error(errorOutput)
+	}
+	if err != nil {
 		return errors.Wrap(err, "problem running fetch command")
 	}
 

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -164,8 +164,10 @@ func (c *gitPush) pushPatch(ctx context.Context, logger client.LoggerProducer, p
 		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorWriter(stdErr)
 	err := cmd.Run(ctx)
 	errorOutput := stdErr.String()
-	if errorOutput != "" && p.token != "" {
-		errorOutput = strings.Replace(errorOutput, p.token, "[redacted oauth token]", -1)
+	if errorOutput != "" {
+		if p.token != "" {
+			errorOutput = strings.Replace(errorOutput, p.token, "[redacted oauth token]", -1)
+		}
 		logger.Execution().Error(errorOutput)
 	}
 	if err != nil {

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -163,13 +163,12 @@ func (c *gitPush) pushPatch(ctx context.Context, logger client.LoggerProducer, p
 	cmd := jpm.CreateCommand(ctx).Directory(p.directory).Append(pushCommand).
 		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorWriter(stdErr)
 	if err := cmd.Run(ctx); err != nil {
+		errorOutput := stdErr.String()
+		if errorOutput != "" && p.token != "" {
+			errorOutput = strings.Replace(errorOutput, p.token, "[redacted oauth token]", -1)
+			logger.Execution().Error(errorOutput)
+		}
 		return errors.Wrap(err, "can't push to remote")
-	}
-
-	errorOutput := stdErr.String()
-	if errorOutput != "" && p.token != "" {
-		errorOutput = strings.Replace(errorOutput, p.token, "[redacted oauth token]", -1)
-		logger.Execution().Error(errorOutput)
 	}
 
 	return nil

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -162,12 +162,13 @@ func (c *gitPush) pushPatch(ctx context.Context, logger client.LoggerProducer, p
 	logger.Execution().Debugf("git push command: %s", pushCommand)
 	cmd := jpm.CreateCommand(ctx).Directory(p.directory).Append(pushCommand).
 		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorWriter(stdErr)
-	if err := cmd.Run(ctx); err != nil {
-		errorOutput := stdErr.String()
-		if errorOutput != "" && p.token != "" {
-			errorOutput = strings.Replace(errorOutput, p.token, "[redacted oauth token]", -1)
-			logger.Execution().Error(errorOutput)
-		}
+	err := cmd.Run(ctx)
+	errorOutput := stdErr.String()
+	if errorOutput != "" && p.token != "" {
+		errorOutput = strings.Replace(errorOutput, p.token, "[redacted oauth token]", -1)
+		logger.Execution().Error(errorOutput)
+	}
+	if err != nil {
 		return errors.Wrap(err, "can't push to remote")
 	}
 

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-06-11"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-06-16"
+	AgentVersion = "2021-06-16b"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-14631](https://jira.mongodb.org/browse/EVG-14631)

### Description 
Sometimes we log exit code 128 with no context. This is likely some internal error, but we were returning before logging the error message that describes the issue, so we haven't been giving any information on if this is something users should be concerned with or not.
