### PR TITLE
EVG-14371: use scopes in commit queue job

### DIFF
--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -63,7 +63,7 @@ func NewCommitQueueJob(env evergreen.Environment, queueID string, id string) amb
 	job.env = env
 	job.SetID(fmt.Sprintf("%s:%s_%s", commitQueueJobName, queueID, id))
 	job.SetShouldApplyScopesOnEnqueue(true)
-	job.SetScopes([]string{queueID})
+	job.SetScopes([]string{fmt.Sprintf("%s.%s", commitQueueJobName, queueID)})
 
 	return job
 }

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -62,6 +62,8 @@ func NewCommitQueueJob(env evergreen.Environment, queueID string, id string) amb
 	job.QueueID = queueID
 	job.env = env
 	job.SetID(fmt.Sprintf("%s:%s_%s", commitQueueJobName, queueID, id))
+	job.SetShouldApplyScopesOnEnqueue(true)
+	job.SetScopes([]string{queueID})
 
 	return job
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14371

### Description 
It should be invalid for multiple commit queue jobs to run concurrently for the same project. However, since it doesn't have scopes right now and it gets enqueued frequently (once per minute), if a job doesn't run within the minute it was enqueued, another one might be enqueued and run concurrently. Use scopes to ensure this does not occur.