### PR TITLE
EVG-14855 consider activate in generate-tasks for all requesters

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -675,7 +675,7 @@ func IsGitTagRequester(requester string) bool {
 	return requester == GitTagRequester
 }
 
-func ShouldConsiderDifferentActivations(requester string) bool {
+func ShouldConsiderBatchtime(requester string) bool {
 	return !IsPatchRequester(requester) && requester != AdHocRequester && requester != GitTagRequester
 }
 

--- a/model/generate.go
+++ b/model/generate.go
@@ -210,8 +210,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 	}
 	// For patches and versions triggered by users, activate all builds.
 	// Otherwise activate ones that are not setting batchtime and are not set to false.
-	var batchTimeInfo specificActivationInfo
-	batchTimeInfo = g.findTasksAndVariantsWithSpecificActivations(v.Requester)
+	batchTimeInfo := g.findTasksAndVariantsWithSpecificActivations(v.Requester)
 
 	newTVPairs := TaskVariantPairs{}
 	for _, bv := range g.BuildVariants {

--- a/model/generate.go
+++ b/model/generate.go
@@ -208,8 +208,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 			p.BuildVariants[i].Tasks[j].Priority = t.Priority
 		}
 	}
-	// For patches and versions triggered by users, activate all builds.
-	// Otherwise activate ones that are not setting batchtime and are not set to false.
+	// Only consider batchtime for mainline builds. We should always respect activate if it is set.
 	batchTimeInfo := g.findTasksAndVariantsWithSpecificActivations(v.Requester)
 
 	newTVPairs := TaskVariantPairs{}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -1019,7 +1019,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 
 		activateVariantAt := time.Now()
 		taskStatuses := []model.BatchTimeTaskStatus{}
-		if metadata.TriggerID == "" && evergreen.ShouldConsiderDifferentActivations(v.Requester) {
+		if metadata.TriggerID == "" && evergreen.ShouldConsiderBatchtime(v.Requester) {
 			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(&buildvariant)
 			batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for variant '%s'", buildvariant.Name))
 			// add only tasks that require activation times


### PR DESCRIPTION
[EVG-14855](https://jira.mongodb.org/browse/EVG-14855)

### Description 
I purposefully only considered Activate for certain requesters to match the behavior of cron and batchtime, however these aren't truly doing the same thing. If our generate tasks does purposefully mark things as not activated, even in a patch build, we should respect that (this will make testing much simpler for DAG).
