### PR TITLE
EVG-5840: Remove 404 exceptions when receiving an empty patch array

### DIFF
--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -219,13 +219,6 @@ func (p *patchesByUserHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Database error"))
 	}
 
-	if len(patches) == 0 {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			Message:    "no patches found",
-			StatusCode: http.StatusNotFound,
-		})
-	}
-
 	resp := gimlet.NewResponseBuilder()
 	if err = resp.SetFormat(gimlet.JSON); err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
@@ -313,13 +306,6 @@ func (p *patchesByProjectHandler) Run(ctx context.Context) gimlet.Responder {
 	patches, err := p.sc.FindPatchesByProject(p.projectId, p.key, p.limit+1)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Database error"))
-	}
-
-	if len(patches) == 0 {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			Message:    "no patches found",
-			StatusCode: http.StatusNotFound,
-		})
 	}
 
 	resp := gimlet.NewResponseBuilder()

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -127,15 +127,14 @@ func (s *PatchesByProjectSuite) SetupTest() {
 	s.route = makePatchesByProjectRoute(s.sc).(*patchesByProjectHandler)
 }
 
-func (s *PatchesByProjectSuite) TestPaginatorShouldErrorIfNoResults() {
+func (s *PatchesByProjectSuite) TestPaginatorShouldSucceedIfNoResults() {
 	s.route.projectId = "project3"
 	s.route.key = s.now
 	s.route.limit = 1
 
 	resp := s.route.Run(context.Background())
 	s.NotNil(resp)
-	s.Equal(http.StatusNotFound, resp.Status())
-	s.Contains(resp.Data().(gimlet.ErrorResponse).Message, "no patches found")
+	s.Equal(http.StatusOK, resp.Status(), "%+v", resp.Data())
 }
 
 func (s *PatchesByProjectSuite) TestPaginatorShouldReturnResultsIfDataExists() {
@@ -428,15 +427,14 @@ func (s *PatchesByUserSuite) SetupTest() {
 	}
 }
 
-func (s *PatchesByUserSuite) TestPaginatorShouldErrorIfNoResults() {
+func (s *PatchesByUserSuite) TestPaginatorShouldSucceedIfNoResults() {
 	s.route.user = "zzz"
 	s.route.key = s.now
 	s.route.limit = 1
 
 	resp := s.route.Run(context.Background())
 	s.NotNil(resp)
-	s.Equal(http.StatusNotFound, resp.Status())
-	s.Contains(resp.Data().(gimlet.ErrorResponse).Message, "no patches found")
+	s.Equal(http.StatusOK, resp.Status(), "%+v", resp.Data())
 }
 
 func (s *PatchesByUserSuite) TestPaginatorShouldReturnResultsIfDataExists() {


### PR DESCRIPTION
[EVG-5840](https://jira.mongodb.org/browse/EVG-5840)

### Description 
This removes an error handling condition where a 404 not found exception was being thrown in the case where no patches for a given project are found.  Since this is a valid case a change has been made to instead return 200 OK and an empty list if this occurs.
### Testing 
Tested with mock data locally where a dummy project had no patches associated and observed that the behavior went from 404 exception to 200 OK after the change was made, and the endpoints behavior for other test projects was not affected.