### PR TITLE
EVG-14635 remember which generated tasks need to be stepped back

### DIFF
--- a/agent/command/expansion_write.go
+++ b/agent/command/expansion_write.go
@@ -52,5 +52,4 @@ func (c *expansionsWriter) Execute(ctx context.Context,
 	}
 	logger.Task().Infof("expansions written to file (%s)", fn)
 	return nil
-
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-06-21"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-06-16b"
+	AgentVersion = "2021-06-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/generate.go
+++ b/model/generate.go
@@ -282,29 +282,29 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 }
 
 type specificActivationInfo struct {
-	stepbackTasks map[string][]string
-	tasks         map[string][]string // tasks by variant that have batchtime or activate specified
-	variants      []string            // variants that have batchtime or activate specified
+	stepbackTasks      map[string][]string
+	activationTasks    map[string][]string // tasks by variant that have batchtime or activate specified
+	activationVariants []string            // variants that have batchtime or activate specified
 }
 
 func newSpecificActivationInfo() specificActivationInfo {
 	return specificActivationInfo{
-		stepbackTasks: map[string][]string{},
-		tasks:         map[string][]string{},
-		variants:      []string{},
+		stepbackTasks:      map[string][]string{},
+		activationTasks:    map[string][]string{},
+		activationVariants: []string{},
 	}
 }
 
 func (b *specificActivationInfo) variantHasSpecificActivation(variant string) bool {
-	return utility.StringSliceContains(b.variants, variant)
+	return utility.StringSliceContains(b.activationVariants, variant)
 }
 
 func (b *specificActivationInfo) getTasks(variant string) []string {
-	return b.tasks[variant]
+	return b.activationTasks[variant]
 }
 
 func (b *specificActivationInfo) hasTasks() bool {
-	return len(b.tasks) > 0
+	return len(b.activationTasks) > 0
 }
 
 func (b *specificActivationInfo) isStepbackTask(variant, task string) bool {
@@ -313,7 +313,7 @@ func (b *specificActivationInfo) isStepbackTask(variant, task string) bool {
 
 // given some list of tasks, returns the tasks that don't have batchtime
 func (b *specificActivationInfo) tasksWithoutSpecificActivation(taskNames []string, variant string) []string {
-	tasksWithoutSpecificActivation, _ := utility.StringSliceSymmetricDifference(taskNames, b.tasks[variant])
+	tasksWithoutSpecificActivation, _ := utility.StringSliceSymmetricDifference(taskNames, b.activationTasks[variant])
 	return tasksWithoutSpecificActivation
 }
 
@@ -322,9 +322,9 @@ func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester
 	for _, bv := range g.BuildVariants {
 		// only consider batchtime for certain requesters
 		if evergreen.ShouldConsiderBatchtime(requester) && (bv.BatchTime != nil || bv.CronBatchTime != "") {
-			res.variants = append(res.variants, bv.name())
+			res.activationVariants = append(res.activationVariants, bv.name())
 		} else if bv.Activate != nil {
-			res.variants = append(res.variants, bv.name())
+			res.activationVariants = append(res.activationVariants, bv.name())
 		}
 		// regardless of whether the build variant has batchtime, there may be tasks with different batchtime
 		batchTimeTasks := []string{}
@@ -340,7 +340,7 @@ func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester
 			}
 		}
 		if len(batchTimeTasks) > 0 {
-			res.tasks[bv.name()] = batchTimeTasks
+			res.activationTasks[bv.name()] = batchTimeTasks
 		}
 	}
 	return res

--- a/model/generate.go
+++ b/model/generate.go
@@ -209,7 +209,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 		}
 	}
 	// Only consider batchtime for mainline builds. We should always respect activate if it is set.
-	batchTimeInfo := g.findTasksAndVariantsWithSpecificActivations(v.Requester, t)
+	activationInfo := g.findTasksAndVariantsWithSpecificActivations(v.Requester, t)
 
 	newTVPairs := TaskVariantPairs{}
 	for _, bv := range g.BuildVariants {
@@ -264,12 +264,12 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 		return errors.Errorf("project '%s' not found", p.Identifier)
 	}
 
-	tasksInExistingBuilds, err := addNewTasks(ctx, batchTimeInfo, v, p, newTVPairsForExistingVariants, syncAtEndOpts, projectRef.Identifier, g.TaskID)
+	tasksInExistingBuilds, err := addNewTasks(ctx, activationInfo, v, p, newTVPairsForExistingVariants, syncAtEndOpts, projectRef.Identifier, g.TaskID)
 	if err != nil {
 		return errors.Wrap(err, "errors adding new tasks")
 	}
 
-	_, tasksInNewBuilds, err := addNewBuilds(ctx, batchTimeInfo, v, p, newTVPairsForNewVariants, syncAtEndOpts, projectRef, g.TaskID)
+	_, tasksInNewBuilds, err := addNewBuilds(ctx, activationInfo, v, p, newTVPairsForNewVariants, syncAtEndOpts, projectRef, g.TaskID)
 	if err != nil {
 		return errors.Wrap(err, "errors adding new builds")
 	}
@@ -282,14 +282,16 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 }
 
 type specificActivationInfo struct {
-	tasks    map[string][]string // tasks by variant that have batchtime or activate specified
-	variants []string            // variants that have batchtime or activate specified
+	stepbackTasks map[string][]string
+	tasks         map[string][]string // tasks by variant that have batchtime or activate specified
+	variants      []string            // variants that have batchtime or activate specified
 }
 
 func newSpecificActivationInfo() specificActivationInfo {
 	return specificActivationInfo{
-		tasks:    map[string][]string{},
-		variants: []string{},
+		stepbackTasks: map[string][]string{},
+		tasks:         map[string][]string{},
+		variants:      []string{},
 	}
 }
 
@@ -303,6 +305,10 @@ func (b *specificActivationInfo) getTasks(variant string) []string {
 
 func (b *specificActivationInfo) hasTasks() bool {
 	return len(b.tasks) > 0
+}
+
+func (b *specificActivationInfo) isStepbackTask(variant, task string) bool {
+	return utility.StringSliceContains(b.stepbackTasks[variant], task)
 }
 
 // given some list of tasks, returns the tasks that don't have batchtime
@@ -324,6 +330,7 @@ func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester
 		batchTimeTasks := []string{}
 		for _, bvt := range bv.Tasks {
 			if isStepbackTask(generatorTask, bv.Name, bvt.Name) {
+				res.stepbackTasks[bv.Name] = append(res.stepbackTasks[bv.Name], bvt.Name)
 				continue // don't consider batchtime/activation if we're stepping back this generated task
 			}
 			if evergreen.ShouldConsiderBatchtime(requester) && (bvt.BatchTime != nil || bvt.CronBatchTime != "") {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1478,7 +1478,7 @@ func sortLayer(layer []task.Task, idToDisplayName map[string]string) []task.Task
 // Given a patch version and a list of variant/task pairs, creates the set of new builds that
 // do not exist yet out of the set of pairs. No tasks are added for builds which already exist
 // (see AddNewTasksForPatch). New builds/tasks are activated depending on their batchtime.
-func addNewBuilds(ctx context.Context, batchTimeInfo specificActivationInfo, v *Version, p *Project,
+func addNewBuilds(ctx context.Context, activationInfo specificActivationInfo, v *Version, p *Project,
 	tasks TaskVariantPairs, syncAtEndOpts patch.SyncAtEndOptions, projectRef *ProjectRef, generatedBy string) ([]string, []string, error) {
 
 	taskIdTables, err := getTaskIdTables(v, p, tasks, projectRef.Identifier)
@@ -1512,8 +1512,8 @@ func addNewBuilds(ctx context.Context, batchTimeInfo specificActivationInfo, v *
 		// Extract the unique set of task names for the variant we're about to create
 		taskNames := tasks.ExecTasks.TaskNames(pair.Variant)
 		displayNames := tasks.DisplayTasks.TaskNames(pair.Variant)
-		activateVariant := !batchTimeInfo.variantHasSpecificActivation(pair.Variant)
-		tasksWithBatchtime := batchTimeInfo.getTasks(pair.Variant)
+		activateVariant := !activationInfo.variantHasSpecificActivation(pair.Variant)
+		tasksWithBatchtime := activationInfo.getTasks(pair.Variant)
 		buildArgs := BuildCreateArgs{
 			Project:            *p,
 			Version:            *v,
@@ -1613,7 +1613,7 @@ func addNewBuilds(ctx context.Context, batchTimeInfo specificActivationInfo, v *
 
 // Given a version and set of variant/task pairs, creates any tasks that don't exist yet,
 // within the set of already existing builds.
-func addNewTasks(ctx context.Context, batchTimeInfo specificActivationInfo, v *Version, p *Project, pairs TaskVariantPairs,
+func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *Version, p *Project, pairs TaskVariantPairs,
 	syncAtEndOpts patch.SyncAtEndOptions, projectIdentifier string, generatedBy string) ([]string, error) {
 	if v.BuildIds == nil {
 		return nil, nil
@@ -1681,7 +1681,7 @@ func addNewTasks(ctx context.Context, batchTimeInfo specificActivationInfo, v *V
 		if len(tasksToAdd) == 0 && len(displayTasksToAdd) == 0 { // no tasks to add, so we do nothing.
 			continue
 		}
-		batchTimeTasks := batchTimeInfo.getTasks(b.BuildVariant)
+		batchTimeTasks := activationInfo.getTasks(b.BuildVariant)
 		// Add the new set of tasks to the build.
 		_, tasks, err := addTasksToBuild(ctx, &b, p, v, tasksToAdd, displayTasksToAdd, batchTimeTasks, generatedBy, tasksInBuild, syncAtEndOpts, distroAliases, taskIdTables)
 		if err != nil {
@@ -1693,6 +1693,9 @@ func addNewTasks(ctx context.Context, batchTimeInfo specificActivationInfo, v *V
 			if t.Activated {
 				b.Activated = true
 			}
+			if t.Activated && activationInfo.isStepbackTask(t.BuildVariant, t.DisplayName) {
+				event.LogTaskActivated(t.Id, t.Execution, evergreen.StepbackTaskActivator)
+			}
 		}
 		// update build activation status if tasks have since been activated
 		if !wasActivated && b.Activated {
@@ -1701,7 +1704,7 @@ func addNewTasks(ctx context.Context, batchTimeInfo specificActivationInfo, v *V
 			}
 		}
 	}
-	if batchTimeInfo.hasTasks() {
+	if activationInfo.hasTasks() {
 		grip.Error(message.WrapError(v.UpdateBuildVariants(), message.Fields{
 			"message": "unable to add batchtime tasks",
 			"version": v.Id,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -79,15 +79,16 @@ var (
 	HostCreateDetailsKey        = bsonutil.MustHaveTag(Task{}, "HostCreateDetails")
 
 	// GeneratedJSONKey is no longer used but must be kept for old tasks.
-	GeneratedJSONKey           = bsonutil.MustHaveTag(Task{}, "GeneratedJSON")
-	GeneratedJSONAsStringKey   = bsonutil.MustHaveTag(Task{}, "GeneratedJSONAsString")
-	GenerateTasksErrorKey      = bsonutil.MustHaveTag(Task{}, "GenerateTasksError")
-	ResetWhenFinishedKey       = bsonutil.MustHaveTag(Task{}, "ResetWhenFinished")
-	LogsKey                    = bsonutil.MustHaveTag(Task{}, "Logs")
-	CommitQueueMergeKey        = bsonutil.MustHaveTag(Task{}, "CommitQueueMerge")
-	DisplayStatusKey           = bsonutil.MustHaveTag(Task{}, "DisplayStatus")
-	BaseTaskKey                = bsonutil.MustHaveTag(Task{}, "BaseTask")
-	BuildVariantDisplayNameKey = bsonutil.MustHaveTag(Task{}, "BuildVariantDisplayName")
+	GeneratedJSONKey            = bsonutil.MustHaveTag(Task{}, "GeneratedJSON")
+	GeneratedJSONAsStringKey    = bsonutil.MustHaveTag(Task{}, "GeneratedJSONAsString")
+	GenerateTasksErrorKey       = bsonutil.MustHaveTag(Task{}, "GenerateTasksError")
+	GeneratedTasksToStepbackKey = bsonutil.MustHaveTag(Task{}, "GeneratedTasksToStepback")
+	ResetWhenFinishedKey        = bsonutil.MustHaveTag(Task{}, "ResetWhenFinished")
+	LogsKey                     = bsonutil.MustHaveTag(Task{}, "Logs")
+	CommitQueueMergeKey         = bsonutil.MustHaveTag(Task{}, "CommitQueueMerge")
+	DisplayStatusKey            = bsonutil.MustHaveTag(Task{}, "DisplayStatus")
+	BaseTaskKey                 = bsonutil.MustHaveTag(Task{}, "BaseTask")
+	BuildVariantDisplayNameKey  = bsonutil.MustHaveTag(Task{}, "BuildVariantDisplayName")
 
 	// BSON fields for the test result struct
 	TestResultStatusKey    = bsonutil.MustHaveTag(TestResult{}, "Status")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -190,6 +190,9 @@ type Task struct {
 	GeneratedJSONAsString []string `bson:"generated_json,omitempty" json:"generated_json,omitempty"`
 	// GenerateTasksError any encountered while generating tasks.
 	GenerateTasksError string `bson:"generate_error,omitempty" json:"generate_error,omitempty"`
+	// GeneratedTasksToStepback is only populated if we want to override activation for these generated tasks, because of stepback.
+	// Maps the build variant to a list of task names.
+	GeneratedTasksToStepback map[string][]string `bson:"generated_tasks_to_stepback,omitempty" json:"generated_tasks_to_stepback,omitempty"`
 
 	// Fields set if triggered by an upstream build
 	TriggerID    string `bson:"trigger_id,omitempty" json:"trigger_id,omitempty"`
@@ -865,6 +868,20 @@ func (t *Task) SetGeneratedJSON(json []json.RawMessage) error {
 		bson.M{
 			"$set": bson.M{
 				GeneratedJSONAsStringKey: s,
+			},
+		},
+	)
+}
+
+// SetGeneratedTasksToStepback adds a task to stepback after activation
+func (t *Task) SetGeneratedTasksToStepback(buildVariantName, taskName string) error {
+	return UpdateOne(
+		bson.M{
+			IdKey: t.Id,
+		},
+		bson.M{
+			"$addToSet": bson.M{
+				bsonutil.GetDottedKeyName(GeneratedTasksToStepbackKey, buildVariantName): taskName,
 			},
 		},
 	)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -467,7 +467,7 @@ func doStepback(t *task.Task) error {
 	}
 
 	// activate the previous task to pinpoint regression
-	return errors.WithStack(activatePreviousTask(t.Id, evergreen.StepbackTaskActivator, ""))
+	return errors.WithStack(activatePreviousTask(t.Id, evergreen.StepbackTaskActivator, nil))
 }
 
 // MarkEnd updates the task as being finished, performs a stepback if necessary, and updates the build status


### PR DESCRIPTION
[EVG-14635](https://jira.mongodb.org/browse/EVG-14635)

### Description 
In a previous commit I added some logic to verify that we step back the generated task only if the tasks haven't been generated yet. However, I realized we also need to remember _which_ tasks to stepback (for example, if taskA is the task we need to stepback, but task_gen sets it to `activate: false` by default, we need to know to ignore that).

### Testing 
Added a unit test, tested in staging: [this failing generated task](https://evergreen-staging.corp.mongodb.com/task/sandbox_ubuntu1604_task_to_add_via_generator_e2023555d09c1bbcfbaa7660361e5a3e9747fc51_21_06_23_15_02_03) stepped back [this generator](https://evergreen-staging.corp.mongodb.com/task/sandbox_release_my_first_generator_9d0a02ad32777f19f22e90b18e41ec9b0b58fbe0_21_06_23_15_00_18) which activated [the generated task](https://evergreen-staging.corp.mongodb.com/task/sandbox_ubuntu1604_task_to_add_via_generator_9d0a02ad32777f19f22e90b18e41ec9b0b58fbe0_21_06_23_15_00_18) despite being explicitly unactivated in the yaml.
