### PR TITLE
EVG-14767 add debugging for CORS requests

### DIFF
--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -772,6 +772,7 @@ func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.Handler
 			"requester":       requester,
 			"allowed_origins": allowedOrigins,
 			"adding_headers":  utility.StringSliceContains(allowedOrigins, requester),
+			"settings_is_nil": evergreen.GetEnvironment().Settings() == nil,
 		})
 		if len(allowedOrigins) > 0 {
 			// Requests from a GQL client include this header, which must be added to the response to enable CORS

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -766,9 +766,14 @@ func (m *EventLogPermissionsMiddleware) ServeHTTP(rw http.ResponseWriter, r *htt
 
 func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		requester := r.Header.Get("Origin")
+		grip.Debug(message.Fields{
+			"op":              "addCORSHeaders",
+			"requester":       requester,
+			"allowed_origins": allowedOrigins,
+			"adding_headers":  utility.StringSliceContains(allowedOrigins, requester),
+		})
 		if len(allowedOrigins) > 0 {
-			requester := r.Header.Get("Origin")
-
 			// Requests from a GQL client include this header, which must be added to the response to enable CORS
 			gqlHeader := r.Header.Get("Access-Control-Request-Headers")
 


### PR DESCRIPTION
[EVG-14767](https://jira.mongodb.org/browse/EVG-14767)

### Description 
Super unclear why CORS patch requests aren't working for this origin; I imagine if it was broken overall we would have issues with Spruce so? John suggested logging if we're adding this header, in which case something unrelated to us is likely wrong.
