### PR TITLE
EVG-14883 Remove unused variants from YAML

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -365,34 +365,10 @@ functions:
 #######################################
 
 tasks:
-  - name: coverage
-    tags: ["report"]
-    commands:
-      - command: git.get_project
-        type: setup
-        params:
-          directory: gopath/src/github.com/evergreen-ci/evergreen
-          token: ${github_token}
-          shallow_clone: false
-      - func: run-make
-        vars:
-          target: get-go-imports
-      - func: setup-credentials
-      - func: setup-mongodb
-      - func: run-make
-        vars:
-          target: build
-      - func: run-make
-        vars:
-          target: "coverage-html"
-          make_args: "-k"
-          tz: "America/New_York"
-
   - <<: *run-build
     name: dist-staging
     patch_only: true
     run_on: archlinux-new-small
-
   - <<: *run-smoke-test
     name: smoke-test-task
     tags: ["smoke"]
@@ -403,13 +379,12 @@ tasks:
     name: smoke-test-agent-monitor
     tags: ["smoke"]
   - <<: *run-generate-lint
-
   - <<: *run-go-test-suite
     name: js-test
   - <<: *run-build
     name: dist
   - <<: *run-go-test-suite
-    tags: ["nodb", "test", "agent"]
+    tags: ["nodb", "test"]
     name: test-thirdparty-docker
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
@@ -418,7 +393,7 @@ tasks:
     tags: ["db", "test"]
     name: test-rest-route
   - <<: *run-go-test-suite-with-mongodb
-    tags: ["db", "test", "agent"]
+    tags: ["db", "test"]
     name: test-rest-client
   - <<: *run-go-test-suite-with-mongodb
     name: test-rest-model
@@ -442,10 +417,10 @@ tasks:
     tags: ["db", "test", "cli"]
     name: test-operations
   - <<: *run-go-test-suite
-    tags: ["nodb", "test", "cli"]
+    tags: ["nodb", "test"]
     name: test-operations-metabuild-generator
   - <<: *run-go-test-suite
-    tags: ["nodb", "test", "cli"]
+    tags: ["nodb", "test"]
     name: test-operations-metabuild-model
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
@@ -466,7 +441,7 @@ tasks:
     tags: ["db", "test"]
     name: test-evergreen
   - <<: *run-go-test-suite-with-mongodb
-    tags: ["db", "test", "agent"]
+    tags: ["db", "test"]
     name: test-thirdparty
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
@@ -687,34 +662,6 @@ buildvariants:
     tasks:
       - name: generate-lint
 
-  - name: coverage
-    display_name: Coverage
-    run_on:
-      - archlinux-new-small
-      - archlinux-new-large
-    expansions:
-      gobin: /opt/golang/go1.16/bin/go
-      goroot: /opt/golang/go1.16
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
-      test_timeout: 15m
-    tasks:
-      - name: ".report"
-        stepback: false
-
-  - name: osx
-    display_name: OSX
-    batchtime: 2880
-    run_on:
-      - macos-1014
-    expansions:
-      disable_coverage: yes
-      gobin: /opt/golang/go1.16/bin/go
-      goroot: /opt/golang/go1.16
-      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
-    tasks:
-      - name: "dist"
-      - name: ".test"
-
   - name: windows
     display_name: Windows
     run_on:
@@ -730,19 +677,3 @@ buildvariants:
     tasks:
       - name: ".agent .test"
       - name: ".cli .test"
-
-  - name: ubuntu1604-arm64
-    display_name: Ubuntu 16.04 ARM
-    batchtime: 2880
-    run_on:
-      - ubuntu1604-arm64-small
-    expansions:
-      disable_coverage: yes
-      xc_build: yes
-      goarch: arm64
-      goos: linux
-      gobin: /opt/golang/go1.16/bin/go
-      goroot: /opt/golang/go1.16
-      mongodb_url: https://downloads.mongodb.com/linux/mongodb-linux-arm64-enterprise-ubuntu1604-4.0.3.tgz
-    tasks:
-      - name: ".agent .test"


### PR DESCRIPTION
[EVG-14883 ](https://jira.mongodb.org/browse/EVG-14883 )

### Description 
This removes variants that I believe we don't use:
- Coverage has been broken for a while. No one seems to mind.
- Windows need only run agent tests. Other tasks on Windows are broken without it mattering.
- ARM seems unnecessary. We don't test zSeries or PPC.
- We don't check OSX. I don't think it has ever caught anything.

Given that we don't use cgo, I think it's unlikely we ever need these. Arguably
we could remove Windows entirely, but I opted to leave it.

### Testing 
I ran a full patch to demo https://spruce.mongodb.com/version/60d4e585d1fe075d114393e2/.
