### PR TITLE
EVG-14418 add patchId to commit queue for enqueue button

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1865,8 +1865,11 @@ func (r *mutationResolver) EnqueuePatch(ctx context.Context, patchID string, com
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error creating new patch: %s", err.Error()))
 	}
-
-	_, err = r.sc.EnqueueItem(utility.FromStringPtr(newPatch.ProjectId), restModel.APICommitQueueItem{Issue: newPatch.Id, Source: utility.ToStringPtr(commitqueue.SourceDiff)}, false)
+	item := restModel.APICommitQueueItem{
+		Issue:   newPatch.Id,
+		PatchId: newPatch.Id,
+		Source:  utility.ToStringPtr(commitqueue.SourceDiff)}
+	_, err = r.sc.EnqueueItem(utility.FromStringPtr(newPatch.ProjectId), item, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error enqueuing new patch: %s", err.Error()))
 	}


### PR DESCRIPTION
[EVG-14418](https://jira.mongodb.org/browse/EVG-14418)

### Description 
We need to always provide a patchId when it's not a PR commit queue patch. I thought I'd caught all of the cases for this, but I missed when a patch is created from an existing patch (which I believe is the case described in this ticket). 
