### PR TITLE
EVG-14767 add allow-methods header

### DIFF
--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -781,6 +781,7 @@ func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.Handler
 			if utility.StringSliceContains(allowedOrigins, requester) {
 				w.Header().Add("Access-Control-Allow-Origin", requester)
 				w.Header().Add("Access-Control-Allow-Credentials", "true")
+				w.Header().Add("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PATCH, PUT")
 				w.Header().Add("Access-Control-Allow-Headers", fmt.Sprintf("%s, %s, %s", evergreen.APIKeyHeader, evergreen.APIUserHeader, gqlHeader))
 			}
 		}


### PR DESCRIPTION
[EVG-14767](https://jira.mongodb.org/browse/EVG-14767)

### Description 
Apparently by default only some methods are allowed (i.e. not patch) so allow more methods.
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests

### Testing 
We aren't able to test this in staging so it needs to be deployed.
