### PR TITLE
EVG-14862 add commit messages to patches API

### DIFF
--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -68,10 +68,11 @@ type FileDiff struct {
 }
 
 type APIModulePatch struct {
-	BranchName *string    `json:"branch_name"`
-	HTMLLink   *string    `json:"html_link"`
-	RawLink    *string    `json:"raw_link"`
-	FileDiffs  []FileDiff `json:"file_diffs"`
+	BranchName     *string    `json:"branch_name"`
+	HTMLLink       *string    `json:"html_link"`
+	RawLink        *string    `json:"raw_link"`
+	CommitMessages []*string  `json:"commit_messages"`
+	FileDiffs      []FileDiff `json:"file_diffs"`
 }
 
 type APIParameter struct {
@@ -166,10 +167,11 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 				fileDiffs = append(fileDiffs, fileDiff)
 			}
 			apiModPatch := APIModulePatch{
-				BranchName: &branchName,
-				HTMLLink:   &htmlLink,
-				RawLink:    &rawLink,
-				FileDiffs:  fileDiffs,
+				BranchName:     &branchName,
+				HTMLLink:       &htmlLink,
+				RawLink:        &rawLink,
+				FileDiffs:      fileDiffs,
+				CommitMessages: utility.ToStringPtrSlice(modPatch.PatchSet.CommitMessages),
 			}
 			codeChanges = append(codeChanges, apiModPatch)
 		}


### PR DESCRIPTION
[EVG-14862](https://jira.mongodb.org/browse/EVG-14862)

### Description 
This will be a more reliable way for server to get the commit messages for the validate_commit_messages task.

### Testing 
Tested with local.
![Screen Shot 2021-06-30 at 10 35 50 AM](https://user-images.githubusercontent.com/26798134/123980134-4f5d5700-d98f-11eb-921c-b4808ad8b1e9.png)
