### PR TITLE
EVG-14818: add admin settings for pods in AWS

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -945,3 +945,23 @@ const (
 	LogTypeTask   = "task_log"
 	LogTypeSystem = "system_log"
 )
+
+// PodPlatform represents recognized platforms for pods.
+type PodPlatform string
+
+const (
+	// LinuxPodPlatform is the platform to run pods with Linux containers.
+	LinuxPodPlatform PodPlatform = "linux"
+	// WindowsPodPlatform is the platform to run pods with Windows containers.
+	WindowsPodPlatform PodPlatform = "windows"
+)
+
+// Validate checks that the given pod platform is recognized.
+func (p PodPlatform) Validate() error {
+	switch p {
+	case LinuxPodPlatform, WindowsPodPlatform:
+		return nil
+	default:
+		return errors.Errorf("unrecognized pod platform '%s'", p)
+	}
+}

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -18,12 +18,12 @@ var (
 	TaskContainerCreationOptsKey = bsonutil.MustHaveTag(Pod{}, "TaskContainerCreationOpts")
 	TimeInfoKey                  = bsonutil.MustHaveTag(Pod{}, "TimeInfo")
 
-	TaskContainerCreationOptsImageKey              = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "Image")
-	TaskContainerCreationOptsMemoryMBKey           = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "MemoryMB")
-	TaskContainerCreationOptsCPUKey                = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "CPU")
-	TaskContainerCreationOptsIsWindowsContainerKey = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "IsWindows")
-	TaskContainerCreationOptsEnvVarsKey            = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "EnvVars")
-	TaskContainerCreationOptsSecretsKey            = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "EnvSecrets")
+	TaskContainerCreationOptsImageKey    = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "Image")
+	TaskContainerCreationOptsMemoryMBKey = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "MemoryMB")
+	TaskContainerCreationOptsCPUKey      = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "CPU")
+	TaskContainerCreationOptsPlatformKey = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "Platform")
+	TaskContainerCreationOptsEnvVarsKey  = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "EnvVars")
+	TaskContainerCreationOptsSecretsKey  = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "EnvSecrets")
 
 	TimeInfoInitializedKey = bsonutil.MustHaveTag(TimeInfo{}, "Initialized")
 	TimeInfoStartedKey     = bsonutil.MustHaveTag(TimeInfo{}, "Started")

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -3,6 +3,7 @@ package pod
 import (
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -34,9 +35,8 @@ type TaskContainerCreationOptions struct {
 	// CPU is the CPU units that the task will be allocated. 1024 CPU units is
 	// equivalent to 1vCPU.
 	CPU int `bson:"cpu" json:"cpu"`
-	// IsWindows indicates whether or not the task will run in a Windows
-	// container.
-	IsWindows bool `bson:"is_windows" json:"is_windows"`
+	// Platform indicates which particular platform the pod's containers run on.
+	Platform evergreen.PodPlatform `bson:"platform" json:"platform"`
 	// EnvVars is a mapping of the non-secret environment variables to expose in
 	// the task's container environment.
 	EnvVars map[string]string `bson:"env_vars,omitempty" json:"env_vars,omitempty"`
@@ -49,7 +49,7 @@ type TaskContainerCreationOptions struct {
 // IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
 // zero value for BSON marshalling.
 func (o TaskContainerCreationOptions) IsZero() bool {
-	return o.Image == "" && o.MemoryMB == 0 && o.CPU == 0 && !o.IsWindows && o.EnvVars == nil && o.EnvSecrets == nil
+	return o.Image == "" && o.MemoryMB == 0 && o.CPU == 0 && o.Platform == "" && o.EnvVars == nil && o.EnvSecrets == nil
 }
 
 // TimeInfo represents timing information about the pod.

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -246,27 +246,38 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     if ($scope.Settings.providers === null || $scope.Settings.provider === undefined) {
       $scope.Settings.providers = {
         "aws": {
-          "ecs": {
-            "clusters": []
+          "pod": {
+            "ecs": {
+              "clusters": []
+            }
           }
         }
       };
     }
     if ($scope.Settings.providers.aws === null || $scope.Settings.provider.aws === undefined) {
       $scope.Settings.providers.aws = {
+        "pod": {
+          "ecs": {
+            "clusters": []
+          }
+        }
+      };
+    }
+    if ($scope.Settings.providers.aws.pod === null || $scope.Settings.provider.aws.pod === undefined) {
+      $scope.Settings.providers.aws.pod = {
         "ecs": {
           "clusters": []
         }
       };
     }
-    if ($scope.Settings.providers.aws.ecs === null || $scope.Settings.provider.aws.ecs === undefined) {
-      $scope.Settings.providers.aws.ecs = {
+    if ($scope.Settings.providers.aws.pod.ecs === null || $scope.Settings.provider.aws.pod.ecs === undefined) {
+      $scope.Settings.providers.aws.pod.ecs = {
         "clusters": []
       };
     }
 
-    if ($scope.Settings.providers.aws.ecs.clusters == null || $scope.Settings.providers.aws.ecs.cluster === undefined) {
-      $scope.Settings.providers.aws.ecs.clusters = [];
+    if ($scope.Settings.providers.aws.pod.ecs.clusters == null || $scope.Settings.providers.aws.pod.ecs.cluster === undefined) {
+      $scope.Settings.providers.aws.pod.ecs.clusters = [];
     }
 
     if (!$scope.validECSCluster($scope.new_ecs_cluster)) {
@@ -274,7 +285,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
       return
     }
 
-    $scope.Settings.providers.aws.ecs.clusters.push($scope.new_ecs_cluster);
+    $scope.Settings.providers.aws.pod.ecs.clusters.push($scope.new_ecs_cluster);
     $scope.new_ecs_cluster = {};
     $scope.invalidECSCluster = "";
   }
@@ -284,7 +295,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
   }
 
   $scope.deleteECSCluster = function (index) {
-    $scope.Settings.providers.aws.ecs.clusters.splice(index, 1);
+    $scope.Settings.providers.aws.pod.ecs.clusters.splice(index, 1);
   }
 
   $scope.clearAllUserTokens = function () {

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -242,6 +242,51 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     return subnet && subnet.az && subnet.subnet_id;
   }
 
+  $scope.addECSCluster = function () {
+    if ($scope.Settings.providers === null || $scope.Settings.provider === undefined) {
+      $scope.Settings.providers = {
+        "aws": {
+          "ecs": {
+            "clusters": []
+          }
+        }
+      };
+    }
+    if ($scope.Settings.providers.aws === null || $scope.Settings.provider.aws === undefined) {
+      $scope.Settings.providers.aws = {
+        "ecs": {
+          "clusters": []
+        }
+      };
+    }
+    if ($scope.Settings.providers.aws.ecs === null || $scope.Settings.provider.aws.ecs === undefined) {
+      $scope.Settings.providers.aws.ecs = {
+        "clusters": []
+      };
+    }
+
+    if ($scope.Settings.providers.aws.ecs.clusters == null || $scope.Settings.providers.aws.ecs.cluster === undefined) {
+      $scope.Settings.providers.aws.ecs.clusters = [];
+    }
+
+    if (!$scope.validECSCluster($scope.new_ecs_cluster)) {
+      $scope.invalidECSCluster = "ECS cluster name, platform, and region are required.";
+      return
+    }
+
+    $scope.Settings.providers.aws.ecs.clusters.push($scope.new_ecs_cluster);
+    $scope.new_ecs_cluster = {};
+    $scope.invalidECSCluster = "";
+  }
+
+  $scope.validECSCluster = function (item) {
+    return item && item.name && item.platform && item.region;
+  }
+
+  $scope.deleteECSCluster = function (index) {
+    $scope.Settings.providers.aws.ecs.clusters.splice(index, 1);
+  }
+
   $scope.clearAllUserTokens = function () {
     if (!confirm("This will log out all users from all existing sessions. Continue?"))
       return

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -16,6 +16,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     $scope.restartLavender = true;
     $scope.ValidThemes = ["announcement", "information", "warning", "important"];
     $scope.validAuthKinds = ["ldap", "okta", "naive", "only_api", "allow_service_users", "github"];
+    $scope.validECSPlatforms = ["linux", "windows"];
     $("#restart-modal").on("hidden.bs.modal", $scope.enableSubmit);
   }
 
@@ -243,7 +244,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
   }
 
   $scope.addECSCluster = function () {
-    if ($scope.Settings.providers === null || $scope.Settings.provider === undefined) {
+    if ($scope.Settings.providers === null || $scope.Settings.providers === undefined) {
       $scope.Settings.providers = {
         "aws": {
           "pod": {
@@ -254,7 +255,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
         }
       };
     }
-    if ($scope.Settings.providers.aws === null || $scope.Settings.provider.aws === undefined) {
+    if ($scope.Settings.providers.aws === null || $scope.Settings.providers.aws === undefined) {
       $scope.Settings.providers.aws = {
         "pod": {
           "ecs": {
@@ -263,25 +264,25 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
         }
       };
     }
-    if ($scope.Settings.providers.aws.pod === null || $scope.Settings.provider.aws.pod === undefined) {
+    if ($scope.Settings.providers.aws.pod === null || $scope.Settings.providers.aws.pod === undefined) {
       $scope.Settings.providers.aws.pod = {
         "ecs": {
           "clusters": []
         }
       };
     }
-    if ($scope.Settings.providers.aws.pod.ecs === null || $scope.Settings.provider.aws.pod.ecs === undefined) {
+    if ($scope.Settings.providers.aws.pod.ecs === null || $scope.Settings.providers.aws.pod.ecs === undefined) {
       $scope.Settings.providers.aws.pod.ecs = {
         "clusters": []
       };
     }
 
-    if ($scope.Settings.providers.aws.pod.ecs.clusters == null || $scope.Settings.providers.aws.pod.ecs.cluster === undefined) {
+    if ($scope.Settings.providers.aws.pod.ecs.clusters == null || $scope.Settings.providers.aws.pod.ecs.clusters === undefined) {
       $scope.Settings.providers.aws.pod.ecs.clusters = [];
     }
 
     if (!$scope.validECSCluster($scope.new_ecs_cluster)) {
-      $scope.invalidECSCluster = "ECS cluster name, platform, and region are required.";
+      $scope.invalidECSCluster = "ECS cluster name and platform are required.";
       return
     }
 
@@ -291,7 +292,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
   }
 
   $scope.validECSCluster = function (item) {
-    return item && item.name && item.platform && item.region;
+    return item && item.name && item.platform;
   }
 
   $scope.deleteECSCluster = function (index) {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1515,6 +1515,7 @@ func (a *APIS3Credentials) ToService() (interface{}, error) {
 	}, nil
 }
 
+// APIAWSPodConfig represents configuration options for pods running in AWS.
 type APIAWSPodConfig struct {
 	Role           *string                  `json:"role"`
 	Region         *string                  `json:"region"`
@@ -1602,6 +1603,7 @@ func (a *APIECSConfig) ToService() (interface{}, error) {
 	if a == nil {
 		return nil, nil
 	}
+
 	var clusters []evergreen.ECSClusterConfig
 	for _, apiCluster := range a.Clusters {
 		i, err := apiCluster.ToService()
@@ -1651,7 +1653,6 @@ func (a *APIECSClusterConfig) ToService() (interface{}, error) {
 // Manager.
 type APISecretsManagerConfig struct {
 	SecretPrefix *string `json:"secret_prefix"`
-	Region       *string `json:"region"`
 }
 
 func (a *APISecretsManagerConfig) BuildFromService(h interface{}) error {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1578,7 +1578,7 @@ func (a *APIAWSPodConfig) ToService() (interface{}, error) {
 type APIECSConfig struct {
 	Role                 *string               `json:"role"`
 	TaskDefinitionPrefix *string               `json:"task_definition_prefix"`
-	Clusters             []APIECSClusterConfig `json:"cluster"`
+	Clusters             []APIECSClusterConfig `json:"clusters"`
 }
 
 func (a *APIECSConfig) BuildFromService(h interface{}) error {

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -147,6 +147,15 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Key, utility.FromStringPtr(apiSettings.Providers.AWS.TaskSyncRead.Key))
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Secret, utility.FromStringPtr(apiSettings.Providers.AWS.TaskSyncRead.Secret))
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Bucket, utility.FromStringPtr(apiSettings.Providers.AWS.TaskSync.Bucket))
+	assert.EqualValues(testSettings.Providers.AWS.ECS.Role, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.Role))
+	assert.EqualValues(testSettings.Providers.AWS.ECS.TaskDefinitionPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.TaskDefinitionPrefix))
+	assert.EqualValues(testSettings.Providers.AWS.ECS.TaskDefinitionPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.TaskDefinitionPrefix))
+	require.Len(apiSettings.Providers.AWS.ECS.Clusters, len(testSettings.Providers.AWS.ECS.Clusters))
+	for i := 0; i < len(testSettings.Providers.AWS.ECS.Clusters); i++ {
+		assert.Equal(testSettings.Providers.AWS.ECS.Clusters[i].Name, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.Clusters[i].Name))
+		assert.Equal(testSettings.Providers.AWS.ECS.Clusters[i].Platform, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.Clusters[i].Platform))
+		assert.Equal(testSettings.Providers.AWS.ECS.Clusters[i].Region, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.Clusters[i].Region))
+	}
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, utility.FromStringPtr(apiSettings.Providers.Docker.APIVersion))
 	assert.EqualValues(testSettings.Providers.GCE.ClientEmail, utility.FromStringPtr(apiSettings.Providers.GCE.ClientEmail))
 	assert.EqualValues(testSettings.Providers.OpenStack.IdentityEndpoint, utility.FromStringPtr(apiSettings.Providers.OpenStack.IdentityEndpoint))

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -147,15 +147,15 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Key, utility.FromStringPtr(apiSettings.Providers.AWS.TaskSyncRead.Key))
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Secret, utility.FromStringPtr(apiSettings.Providers.AWS.TaskSyncRead.Secret))
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Bucket, utility.FromStringPtr(apiSettings.Providers.AWS.TaskSync.Bucket))
-	assert.EqualValues(testSettings.Providers.AWS.ECS.Role, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.Role))
-	assert.EqualValues(testSettings.Providers.AWS.ECS.TaskDefinitionPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.TaskDefinitionPrefix))
-	assert.EqualValues(testSettings.Providers.AWS.ECS.TaskDefinitionPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.TaskDefinitionPrefix))
-	require.Len(apiSettings.Providers.AWS.ECS.Clusters, len(testSettings.Providers.AWS.ECS.Clusters))
-	for i := 0; i < len(testSettings.Providers.AWS.ECS.Clusters); i++ {
-		assert.Equal(testSettings.Providers.AWS.ECS.Clusters[i].Name, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.Clusters[i].Name))
-		assert.Equal(testSettings.Providers.AWS.ECS.Clusters[i].Platform, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.Clusters[i].Platform))
-		assert.Equal(testSettings.Providers.AWS.ECS.Clusters[i].Region, utility.FromStringPtr(apiSettings.Providers.AWS.ECS.Clusters[i].Region))
+	assert.EqualValues(testSettings.Providers.AWS.Pod.Role, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.Role))
+	assert.EqualValues(testSettings.Providers.AWS.Pod.Region, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.Region))
+	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.TaskDefinitionPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.TaskDefinitionPrefix))
+	require.Len(apiSettings.Providers.AWS.Pod.ECS.Clusters, len(testSettings.Providers.AWS.Pod.ECS.Clusters))
+	for i := 0; i < len(testSettings.Providers.AWS.Pod.ECS.Clusters); i++ {
+		assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.Clusters[i].Name, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.Clusters[i].Name))
+		assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.Clusters[i].Platform, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.Clusters[i].Platform))
 	}
+	assert.EqualValues(testSettings.Providers.AWS.Pod.SecretsManager.SecretPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.SecretsManager.SecretPrefix))
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, utility.FromStringPtr(apiSettings.Providers.Docker.APIVersion))
 	assert.EqualValues(testSettings.Providers.GCE.ClientEmail, utility.FromStringPtr(apiSettings.Providers.GCE.ClientEmail))
 	assert.EqualValues(testSettings.Providers.OpenStack.IdentityEndpoint, utility.FromStringPtr(apiSettings.Providers.OpenStack.IdentityEndpoint))

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1601,19 +1601,23 @@ Admin Settings
 										<textarea ng-model="Settings.providers.aws.allowed_instance_types"
 											ng-list="&#10;" ng-trim="false" rows="3" md-select-on-focus></textarea>
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Allowed Regions</label>
 										<textarea ng-model="Settings.providers.aws.allowed_regions" ng-list="&#10;"
 											ng-trim="false" rows="3" md-select-on-focus></textarea>
 									</md-input-container>
-                  <!-- kim: TODO: add ECS/Secrets Manager settings -->
-									<md-input-container class="control" style="width:45%;">
-										<label>ECS Role</label>
-										<input type="text" ng-model="Settings.providers.aws.ecs.role">
+                  <!-- kim: TODO: add pod settings along with ECS/Secrets Manager settings -->
+                  <md-input-container class="control" style="width:45%;margin-left:50px">
+										<label>Pod Role</label>
+										<input type="text" ng-model="Settings.providers.aws.pod.role">
+									</md-input-container>
+                  <md-input-container class="control" style="width:45%;">
+										<label>Pod Region</label>
+										<input type="text" ng-model="Settings.providers.aws.pod.region">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>ECS Task Definition Prefix</label>
-										<input type="text" ng-model="Settings.providers.aws.ecs.task_definition_prefix">
+										<input type="text" ng-model="Settings.providers.aws.pod.ecs.task_definition_prefix">
 									</md-input-container>
                   <md-card>
 										<md-card-title>
@@ -1623,7 +1627,7 @@ Admin Settings
 										</md-card-title>
 										<md-card-content>
 											<div id="ec2-list" class="form-group"
-												ng-repeat="(index, cluster) in Settings.providers.aws.ecs.clusters">
+												ng-repeat="(index, cluster) in Settings.providers.aws.pod.ecs.clusters">
 												<section layout="row" flex>
 													<md-input-container class="control" flex=25>
 														<input class="control" type="text" ng-model="cluster.name"
@@ -1670,12 +1674,8 @@ Admin Settings
 										</md-card-content>
 									</md-card>
 									<md-input-container class="control" style="width:45%;">
-										<label>Secrets Manager Secret Prefix</label>
-										<input type="text" ng-model="Settings.providers.aws.secrets_manager.secret_prefix">
-									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
-										<label>Secrets Manager Region</label>
-										<input type="text" ng-model="Settings.providers.aws.ecs.task_definition_prefix">
+										<label>Pod Secrets Manager Secret Prefix</label>
+										<input type="text" ng-model="Settings.providers.aws.pod.secrets_manager.secret_prefix">
 									</md-input-container>
 								</md-card-content>
 							</md-card>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1588,15 +1588,15 @@ Admin Settings
 										<label>Task Read-Only S3 Bucket</label>
 										<input type="text" ng-model="Settings.providers.aws.task_sync_read.bucket">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%">
+                  <md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Default Security Group</label>
 										<input type="text" ng-model="Settings.providers.aws.default_security_group">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Total EBS Volume Size Per User</label>
 										<input type="number" ng-model="Settings.providers.aws.max_volume_size">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px">
 										<label>Allowed Instance Types</label>
 										<textarea ng-model="Settings.providers.aws.allowed_instance_types"
 											ng-list="&#10;" ng-trim="false" rows="3" md-select-on-focus></textarea>
@@ -1605,6 +1605,77 @@ Admin Settings
 										<label>Allowed Regions</label>
 										<textarea ng-model="Settings.providers.aws.allowed_regions" ng-list="&#10;"
 											ng-trim="false" rows="3" md-select-on-focus></textarea>
+									</md-input-container>
+                  <!-- kim: TODO: add ECS/Secrets Manager settings -->
+									<md-input-container class="control" style="width:45%;">
+										<label>ECS Role</label>
+										<input type="text" ng-model="Settings.providers.aws.ecs.role">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
+										<label>ECS Task Definition Prefix</label>
+										<input type="text" ng-model="Settings.providers.aws.ecs.task_definition_prefix">
+									</md-input-container>
+                  <md-card>
+										<md-card-title>
+											<md-card-title-text>
+												<span>ECS Clusters</span>
+											</md-card-title-text>
+										</md-card-title>
+										<md-card-content>
+											<div id="ec2-list" class="form-group"
+												ng-repeat="(index, cluster) in Settings.providers.aws.ecs.clusters">
+												<section layout="row" flex>
+													<md-input-container class="control" flex=25>
+														<input class="control" type="text" ng-model="cluster.name"
+															placeholder="Name">
+													</md-input-container>
+													<md-input-container class="control" flex=25>
+														<input class="control" type="text" ng-model="cluster.platform"
+															placeholder="Platform (linux, windows)">
+													</md-input-container>
+													<md-input-container class="control" flex=25>
+														<input class="control" type="text" ng-model="cluster.region"
+															placeholder="Region">
+													</md-input-container>
+													<div style="margin-top: 1%;">
+														<button class="btn btn-default btn-danger" type="button"
+															style="float: left" ng-click="deleteECSCluster(index)">
+															<i class="fa fa-trash"></i>
+														</button>
+													</div>
+												</section>
+											</div>
+											<section layout="row" flex>
+												<md-input-container class="control" flex=25>
+													<input class="control" type="text" ng-model="new_ecs_cluster.name"
+														placeholder="Name">
+												</md-input-container>
+												<md-input-container class="control" flex=50>
+													<input class="control" type="text" ng-model="new_ecs_cluster.platform"
+														placeholder="Platform (linux, windows)">
+												</md-input-container>
+												<md-input-container class="control" flex=50>
+													<input class="control" type="text" ng-model="new_ecs_cluster.region"
+														placeholder="Region">
+												</md-input-container>
+												<div style="margin-top: 1%;">
+													<button class="plus-button btn btn-primary"
+														ng-disabled="!(new_ecs_cluster)" type="button"
+														style="float: left" ng-click="addECSCluster()">
+														<i class="fa fa-plus"></i>
+													</button>
+													<label class="control">[[ invalidECSCluster ]]</label>
+												</div>
+											</section>
+										</md-card-content>
+									</md-card>
+									<md-input-container class="control" style="width:45%;">
+										<label>Secrets Manager Secret Prefix</label>
+										<input type="text" ng-model="Settings.providers.aws.secrets_manager.secret_prefix">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
+										<label>Secrets Manager Region</label>
+										<input type="text" ng-model="Settings.providers.aws.ecs.task_definition_prefix">
 									</md-input-container>
 								</md-card-content>
 							</md-card>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -680,7 +680,7 @@ Admin Settings
 									<md-input-container class="control" style="width:45%;">
 										<label>Generate Task Factor (0 to 100 inclusive)</label>
 										<input type="number" step="1" min="0" max="100"
-											   ng-model="Settings.scheduler.generate_task_factor">
+												 ng-model="Settings.scheduler.generate_task_factor">
 									</md-input-container>
 									<md-input-container class="control" style="width:170px;">
 										<md-checkbox ng-model="Settings.scheduler.group_versions">
@@ -1588,7 +1588,7 @@ Admin Settings
 										<label>Task Read-Only S3 Bucket</label>
 										<input type="text" ng-model="Settings.providers.aws.task_sync_read.bucket">
 									</md-input-container>
-                  <md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Default Security Group</label>
 										<input type="text" ng-model="Settings.providers.aws.default_security_group">
 									</md-input-container>
@@ -1596,50 +1596,50 @@ Admin Settings
 										<label>Total EBS Volume Size Per User</label>
 										<input type="number" ng-model="Settings.providers.aws.max_volume_size">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px">
+									<br />
+									<md-input-container class="control" style="width:45%;">
 										<label>Allowed Instance Types</label>
 										<textarea ng-model="Settings.providers.aws.allowed_instance_types"
 											ng-list="&#10;" ng-trim="false" rows="3" md-select-on-focus></textarea>
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px">
 										<label>Allowed Regions</label>
 										<textarea ng-model="Settings.providers.aws.allowed_regions" ng-list="&#10;"
 											ng-trim="false" rows="3" md-select-on-focus></textarea>
 									</md-input-container>
-                  <!-- kim: TODO: add pod settings along with ECS/Secrets Manager settings -->
-                  <md-input-container class="control" style="width:45%;margin-left:50px">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod Role</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.role">
 									</md-input-container>
-                  <md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Pod Region</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.region">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Pod Secrets Manager Secret Prefix</label>
+										<input type="text" ng-model="Settings.providers.aws.pod.secrets_manager.secret_prefix">
+									</md-input-container>
 									<md-input-container class="control" style="width:45%; margin-left:50px;">
-										<label>ECS Task Definition Prefix</label>
+										<label>Pod ECS Task Definition Prefix</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.task_definition_prefix">
 									</md-input-container>
-                  <md-card>
+									<md-card>
 										<md-card-title>
 											<md-card-title-text>
-												<span>ECS Clusters</span>
+												<span>Pod ECS Clusters</span>
 											</md-card-title-text>
 										</md-card-title>
 										<md-card-content>
-											<div id="ec2-list" class="form-group"
-												ng-repeat="(index, cluster) in Settings.providers.aws.pod.ecs.clusters">
+											<div id="ecs-clusters" class="form-group" ng-repeat="(index, cluster) in Settings.providers.aws.pod.ecs.clusters">
 												<section layout="row" flex>
 													<md-input-container class="control" flex=25>
-														<input class="control" type="text" ng-model="cluster.name"
-															placeholder="Name">
+														<input class="control" type="text" ng-model="cluster.name" placeholder="Name">
 													</md-input-container>
+													<br />
 													<md-input-container class="control" flex=25>
-														<input class="control" type="text" ng-model="cluster.platform"
-															placeholder="Platform (linux, windows)">
-													</md-input-container>
-													<md-input-container class="control" flex=25>
-														<input class="control" type="text" ng-model="cluster.region"
-															placeholder="Region">
+														<md-select ng-model="cluster.platform">
+															<md-option ng-repeat="platform in validECSPlatforms" value="[[platform]]">[[platform]]</md-option>
+														</md-select>
 													</md-input-container>
 													<div style="margin-top: 1%;">
 														<button class="btn btn-default btn-danger" type="button"
@@ -1654,17 +1654,15 @@ Admin Settings
 													<input class="control" type="text" ng-model="new_ecs_cluster.name"
 														placeholder="Name">
 												</md-input-container>
-												<md-input-container class="control" flex=50>
-													<input class="control" type="text" ng-model="new_ecs_cluster.platform"
-														placeholder="Platform (linux, windows)">
-												</md-input-container>
-												<md-input-container class="control" flex=50>
-													<input class="control" type="text" ng-model="new_ecs_cluster.region"
-														placeholder="Region">
+												<br />
+												<md-input-container class="control" flex=25>
+													<md-select ng-model="new_ecs_cluster.platform">
+														<md-option ng-repeat="platform in validECSPlatforms" value="[[platform]]">[[platform]]</md-option>
+													</md-select>
 												</md-input-container>
 												<div style="margin-top: 1%;">
 													<button class="plus-button btn btn-primary"
-														ng-disabled="!(new_ecs_cluster)" type="button"
+														ng-disabled="!validECSCluster(new_ecs_cluster)" type="button"
 														style="float: left" ng-click="addECSCluster()">
 														<i class="fa fa-plus"></i>
 													</button>
@@ -1673,10 +1671,6 @@ Admin Settings
 											</section>
 										</md-card-content>
 									</md-card>
-									<md-input-container class="control" style="width:45%;">
-										<label>Pod Secrets Manager Secret Prefix</label>
-										<input type="text" ng-model="Settings.providers.aws.pod.secrets_manager.secret_prefix">
-									</md-input-container>
 								</md-card-content>
 							</md-card>
 
@@ -1846,7 +1840,7 @@ Admin Settings
 										<label>Log path</label>
 										<input type="text" ng-model="Settings.log_path">
 									</md-input-container>
-								        <md-input-container class="control" style="width:45%;">
+										<md-input-container class="control" style="width:45%;">
 										<label>Shutdown Wait(seconds)</label>
 										<input type="number" ng-model="Settings.shutdown_wait_seconds">
 									</md-input-container>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -245,20 +245,21 @@ func MockConfig() *evergreen.Settings {
 					Secret: "task_sync_read_secret",
 					Bucket: "task_sync_bucket",
 				},
-				ECS: evergreen.ECSConfig{
-					Role:                 "ecs_role",
-					TaskDefinitionPrefix: "ecs_prefix",
-					Clusters: []evergreen.ECSClusterConfig{
-						{
-							Name:     "cluster_name",
-							Platform: evergreen.LinuxPodPlatform,
-							Region:   "cluster_region",
+				Pod: evergreen.AWSPodConfig{
+					Role:   "role",
+					Region: "region",
+					ECS: evergreen.ECSConfig{
+						TaskDefinitionPrefix: "ecs_prefix",
+						Clusters: []evergreen.ECSClusterConfig{
+							{
+								Name:     "cluster_name",
+								Platform: evergreen.LinuxPodPlatform,
+							},
 						},
 					},
-				},
-				SecretsManager: evergreen.SecretsManagerConfig{
-					SecretPrefix: "secret_prefix",
-					Region:       "secret_role",
+					SecretsManager: evergreen.SecretsManagerConfig{
+						SecretPrefix: "secret_prefix",
+					},
 				},
 			},
 			Docker: evergreen.DockerConfig{

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -245,6 +245,21 @@ func MockConfig() *evergreen.Settings {
 					Secret: "task_sync_read_secret",
 					Bucket: "task_sync_bucket",
 				},
+				ECS: evergreen.ECSConfig{
+					Role:                 "ecs_role",
+					TaskDefinitionPrefix: "ecs_prefix",
+					Clusters: []evergreen.ECSClusterConfig{
+						{
+							Name:     "cluster_name",
+							Platform: evergreen.LinuxPodPlatform,
+							Region:   "cluster_region",
+						},
+					},
+				},
+				SecretsManager: evergreen.SecretsManagerConfig{
+					SecretPrefix: "secret_prefix",
+					Region:       "secret_role",
+				},
 			},
 			Docker: evergreen.DockerConfig{
 				APIVersion: "docker_version",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14857

### Description 
Create admin settings specific to pods in AWS that use Secrets Manager and ECS.

### Testing 
Standard admin settings tests. I also tested it manually in local evergreen to verify that the admin page works as expected.