### PR TITLE
EVG-14509: Increase git tag triggered version check interval

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -389,9 +389,9 @@ func (gh *githubHookApi) handleGitTag(ctx context.Context, event *github.PushEve
 	foundVersion := map[string]bool{}
 
 	const (
-		checkVersionAttempts      = 5
-		checkVersionRetryMinDelay = 100 * time.Millisecond
-		checkVersionRetryMaxDelay = 3 * time.Second
+		checkVersionAttempts      = 10
+		checkVersionRetryMinDelay = 200 * time.Millisecond
+		checkVersionRetryMaxDelay = 12 * time.Second
 	)
 
 	catcher := grip.NewBasicCatcher()

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -389,9 +389,9 @@ func (gh *githubHookApi) handleGitTag(ctx context.Context, event *github.PushEve
 	foundVersion := map[string]bool{}
 
 	const (
-		checkVersionAttempts      = 10
-		checkVersionRetryMinDelay = 200 * time.Millisecond
-		checkVersionRetryMaxDelay = 12 * time.Second
+		checkVersionAttempts      = 5
+		checkVersionRetryMinDelay = 3500 * time.Millisecond
+		checkVersionRetryMaxDelay = 15 * time.Second
 	)
 
 	catcher := grip.NewBasicCatcher()


### PR DESCRIPTION
[EVG-14509](https://jira.mongodb.org/browse/EVG-14509)

### Description 
The current retry logic to wait for a version on a given tagged commit does not always wait a sufficient length of time for a version to appear under a given tagged commit.  This could potentially cause a version to not be recognized simply due to not waiting long enough (current logic waits only slightly more than 1 second).  Change has been made to set 30 seconds rather than 1 second as the upper limit to wait before giving up on checking for a version.
### Testing 
Locally tested the current retry options for handling tags and confirmed with time delta print statements that the total retry wait time was typically ~1.3 seconds (accounting for jitter).  Modified the same options locally and confirmed that the new total wait time is ~30 seconds which should be a sufficient window to wait for a version if there is one coming.