### PR TITLE
EVG-14821 add dependencies for activated generated tasks only

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -264,17 +264,18 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 		return errors.Errorf("project '%s' not found", p.Identifier)
 	}
 
-	tasksInExistingBuilds, err := addNewTasks(ctx, activationInfo, v, p, newTVPairsForExistingVariants, syncAtEndOpts, projectRef.Identifier, g.TaskID)
+	activatedTasksInExistingBuilds, err := addNewTasks(ctx, activationInfo, v, p, newTVPairsForExistingVariants, syncAtEndOpts, projectRef.Identifier, g.TaskID)
 	if err != nil {
 		return errors.Wrap(err, "errors adding new tasks")
 	}
 
-	_, tasksInNewBuilds, err := addNewBuilds(ctx, activationInfo, v, p, newTVPairsForNewVariants, syncAtEndOpts, projectRef, g.TaskID)
+	activatedTasksInNewBuilds, err := addNewBuilds(ctx, activationInfo, v, p, newTVPairsForNewVariants, syncAtEndOpts, projectRef, g.TaskID)
 	if err != nil {
 		return errors.Wrap(err, "errors adding new builds")
 	}
 
-	if err = addDependencies(t, append(tasksInExistingBuilds, tasksInNewBuilds...)); err != nil {
+	// only want to add dependencies to activated tasks
+	if err = addDependencies(t, append(activatedTasksInExistingBuilds, activatedTasksInNewBuilds...)); err != nil {
 		return errors.Wrap(err, "error adding dependencies")
 	}
 

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -94,7 +94,7 @@ func ValidateTVPairs(p *Project, in []TVPair) error {
 // (see AddNewTasksForPatch).
 func AddNewBuildsForPatch(ctx context.Context, p *patch.Patch, patchVersion *Version, project *Project,
 	tasks TaskVariantPairs, pRef *ProjectRef) error {
-	_, _, err := addNewBuilds(ctx, specificActivationInfo{}, patchVersion, project, tasks, p.SyncAtEndOpts, pRef, "")
+	_, err := addNewBuilds(ctx, specificActivationInfo{}, patchVersion, project, tasks, p.SyncAtEndOpts, pRef, "")
 	return errors.Wrap(err, "can't add new builds")
 }
 


### PR DESCRIPTION
[EVG-14821](https://jira.mongodb.org/browse/EVG-14821)

### Description 
Currently if a task depends on a generator, the task will also depend on the generated tasks. This shouldn't include intentionally unactivated generated tasks, or else we're blocked indefinitely.

### Testing 
Verified [release was blocked](https://evergreen-staging.corp.mongodb.com/task/sandbox_release_test_release_patch_e2023555d09c1bbcfbaa7660361e5a3e9747fc51_60dcaddcb237360b39f8d6db_21_06_30_17_46_28) by the unactivated dependency before changes, and [was not blocked](https://evergreen-staging.corp.mongodb.com/task/sandbox_release_test_release_patch_e2023555d09c1bbcfbaa7660361e5a3e9747fc51_60dcb67097b1d30a9023cb35_21_06_30_18_23_32) after changes.

