### PR TITLE
typo GetProvierCounts -> GetProviderCounts

### DIFF
--- a/model/host/stats.go
+++ b/model/host/stats.go
@@ -91,7 +91,7 @@ func GetStatsByDistro() (DistroStats, error) {
 	return stats, nil
 }
 
-// GetProvierCounts returns data on the number of hosts by different provider stats.
+// GetProviderCounts returns data on the number of hosts by different provider stats.
 func GetProviderCounts() (ProviderStats, error) {
 	stats := []StatsByProvider{}
 	if err := db.Aggregate(Collection, statsByProviderPipeline(), &stats); err != nil {


### PR DESCRIPTION
Not ticket-driven, but I encountered it when writing EVG-14805.

### Description 
 GetProvierCounts -> GetProviderCounts
### Testing 
  none