### PR TITLE
EVG-14843: set up event logs for pods

### DIFF
--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -200,3 +200,14 @@ func AdminEventsBefore(before time.Time, n int) db.Q {
 func FindAllByResourceID(resourceID string) ([]EventLogEntry, error) {
 	return Find(AllLogCollection, db.Query(bson.M{ResourceIdKey: resourceID}))
 }
+
+// Pod events
+
+// MostRecentPodEvents creates a query to find the n most recent pod events for
+// the given pod ID.
+func MostRecentPodEvents(id string, n int) db.Q {
+	filter := ResourceTypeKeyIs(ResourceTypePod)
+	filter[ResourceIdKey] = id
+
+	return db.Query(filter).Sort([]string{"-" + TimestampKey}).Limit(n)
+}

--- a/model/event/event_registry.go
+++ b/model/event/event_registry.go
@@ -122,3 +122,7 @@ func adminEventDataFactory() interface{} {
 func userEventDataFactory() interface{} {
 	return &userData{}
 }
+
+func podEventDataFactory() interface{} {
+	return &podData{}
+}

--- a/model/event/pod.go
+++ b/model/event/pod.go
@@ -1,0 +1,54 @@
+package event
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	registry.AddType(ResourceTypePod, podEventDataFactory)
+}
+
+// PodEventType represents a type of event related to a pod.
+type PodEventType string
+
+const (
+	// ResourceTypePod represents a pod as a resource associated with events.
+	ResourceTypePod = "POD"
+
+	EventPodStatusChange PodEventType = "STATUS_CHANGE"
+)
+
+// podData contains information relevant to a pod event.
+type podData struct {
+	OldStatus string `bson:"old_status,omitempty" json:"old_status,omitempty"`
+	NewStatus string `bson:"new_status,omitempty" json:"new_status,omitempty\\,omitempty"`
+}
+
+// LogPodEvent logs an event for a pod to the event log.
+func LogPodEvent(id string, kind PodEventType, data podData) error {
+	e := EventLogEntry{
+		Timestamp:    time.Now(),
+		ResourceId:   id,
+		ResourceType: ResourceTypePod,
+		EventType:    string(kind),
+		Data:         data,
+	}
+
+	logger := NewDBEventLogger(AllLogCollection)
+	if err := logger.LogEvent(&e); err != nil {
+		return errors.Wrap(err, "logging pod event")
+	}
+
+	return nil
+}
+
+// LogPodStatusChanged logs an event indicating that the pod's status has been
+// updated.
+func LogPodStatusChanged(id, oldStatus, newStatus string) error {
+	return LogPodEvent(id, EventPodStatusChange, podData{
+		OldStatus: oldStatus,
+		NewStatus: newStatus,
+	})
+}

--- a/model/event/pod.go
+++ b/model/event/pod.go
@@ -23,7 +23,7 @@ const (
 // podData contains information relevant to a pod event.
 type podData struct {
 	OldStatus string `bson:"old_status,omitempty" json:"old_status,omitempty"`
-	NewStatus string `bson:"new_status,omitempty" json:"new_status,omitempty\\,omitempty"`
+	NewStatus string `bson:"new_status,omitempty" json:"new_status,omitempty"`
 }
 
 // LogPodEvent logs an event for a pod to the event log.

--- a/model/event/pod_test.go
+++ b/model/event/pod_test.go
@@ -1,0 +1,39 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPodEvents(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T){
+		"LogPodStatusChanged": func(t *testing.T) {
+			id := "pod_id"
+			oldStatus := "initializing"
+			newStatus := "starting"
+			require.NoError(t, LogPodStatusChanged(id, oldStatus, newStatus))
+
+			events, err := Find(AllLogCollection, MostRecentPodEvents(id, 10))
+			require.NoError(t, err)
+			require.Len(t, events, 1)
+
+			assert.Equal(t, id, events[0].ResourceId)
+			require.NotZero(t, events[0].Data)
+			data, ok := events[0].Data.(*podData)
+			require.True(t, ok)
+			assert.Equal(t, oldStatus, data.OldStatus)
+			assert.Equal(t, newStatus, data.NewStatus)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.Clear(AllLogCollection))
+			defer func() {
+				assert.NoError(t, db.Clear(AllLogCollection))
+			}()
+			tCase(t)
+		})
+	}
+}

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -14,7 +14,7 @@ const (
 
 var (
 	IDKey                        = bsonutil.MustHaveTag(Pod{}, "ID")
-	PodIDKey                     = bsonutil.MustHaveTag(Pod{}, "PodID")
+	ExternalIDKey                = bsonutil.MustHaveTag(Pod{}, "ExternalID")
 	TaskContainerCreationOptsKey = bsonutil.MustHaveTag(Pod{}, "TaskContainerCreationOpts")
 	TimeInfoKey                  = bsonutil.MustHaveTag(Pod{}, "TimeInfo")
 

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -11,11 +11,11 @@ import (
 // about containers running in a container orchestration system.
 type Pod struct {
 	// ID is the unique identifier for the metadata document. This is
-	// semantically unrelated to the PodID.
+	// semantically unrelated to the ExternalID.
 	ID string `bson:"_id" json:"id"`
-	// PodID is the unique resource identifier for the collection of containers
-	// running in the container orchestration service.
-	PodID string `bson:"pod_id" json:"pod_id"`
+	// ExternalID is the unique external resource identifier for the collection
+	// of containers running in the container orchestration service.
+	ExternalID string `bson:"external_id,omitempty" json:"external_id,omitempty"`
 	// TaskCreationOpts are options to configure how a task should be
 	// containerized and run in a pod.
 	TaskContainerCreationOpts TaskContainerCreationOptions `bson:"task_creation_opts,omitempty" json:"task_creation_opts,omitempty"`

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -24,8 +24,8 @@ func TestInsertAndFindOneByID(t *testing.T) {
 		},
 		"InsertSucceedsAndIsFoundByID": func(t *testing.T) {
 			p := Pod{
-				ID:    "id",
-				PodID: "pod_id",
+				ID:         "id",
+				ExternalID: "external_id",
 				TaskContainerCreationOpts: TaskContainerCreationOptions{
 					Image:    "alpine",
 					MemoryMB: 128,
@@ -42,7 +42,7 @@ func TestInsertAndFindOneByID(t *testing.T) {
 			require.NotNil(t, dbPod)
 
 			assert.Equal(t, p.ID, dbPod.ID)
-			assert.Equal(t, p.PodID, dbPod.PodID)
+			assert.Equal(t, p.ExternalID, dbPod.ExternalID)
 			assert.Equal(t, p.TaskContainerCreationOpts, dbPod.TaskContainerCreationOpts)
 			assert.Equal(t, p.TimeInfo, dbPod.TimeInfo)
 		},


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14843

### Description 
* Add support for logging events for pods.
* Rename `PodID` to `ExternalID` in the pod model to make it obvious that it's an external resource identifier and avoid confusion between `ID` and `PodID`.

### Testing 
Standard DB tests.