### PR TITLE
EVG-14585 update version/patch status only if build has changed

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -826,6 +826,9 @@ func getBuildStatus(buildTasks []task.Task) string {
 
 	// started but not finished
 	for _, t := range buildTasks {
+		if t.Status == evergreen.TaskStarted {
+			return evergreen.BuildStarted
+		}
 		if t.Activated && !t.Blocked() && !t.IsFinished() {
 			return evergreen.BuildStarted
 		}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -606,7 +606,7 @@ func TestUpdateBuildStatusForTaskReset(t *testing.T) {
 	displayName := "testName"
 	b := &build.Build{
 		Id:        "buildtest",
-		Status:    evergreen.BuildStarted,
+		Status:    evergreen.BuildFailed,
 		Version:   "abc",
 		Activated: true,
 	}
@@ -640,6 +640,9 @@ func TestUpdateBuildStatusForTaskReset(t *testing.T) {
 	assert.NoError(t, anotherTask.Insert())
 
 	assert.NoError(t, UpdateBuildAndVersionStatusForTask(&testTask))
+	dbBuild, err := build.FindOneId(b.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, evergreen.BuildStarted, dbBuild.Status)
 	dbVersion, err := VersionFindOneId(v.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.VersionStarted, dbVersion.Status)


### PR DESCRIPTION
[EVG-14585](https://jira.mongodb.org/browse/EVG-14585)

### Description 
Users have frequently been getting duplicate notifications since around the time [EVG-12953](https://jira.mongodb.org/browse/EVG-12953) was deployed, typically when patches are aborted or cancelled by Evergreen or users (one successful, one failed). I believe this is happening because when we abort patches, we first only update the [build activation](https://github.com/evergreen-ci/evergreen/blob/8da959940db4bf5417b3abaef599c68b0a8f1453/model/patch_lifecycle.go#L558). But then when we eventually [update statuses](https://github.com/evergreen-ci/evergreen/blob/bd6c848583d4a65d600c403371d6f65c75ccaf67/model/task_lifecycle.go#L1013) we don't consider [unactivated builds](https://github.com/evergreen-ci/evergreen/blob/bd6c848583d4a65d600c403371d6f65c75ccaf67/model/task_lifecycle.go#L919); however the unactivated build hasn't actually been marked failed yet so we continue to the successful case, and then re-mark the status as failed when the build is marked failed moments after. 

One option here is to fix the getVersionStatus logic to return VersionStarted if `!b.Activated && b.Status == evergreen.BuildStarted`; I'm just concerned that this might be a legitimate case sometimes so I didn't add that (but I still can). 

Instead, I opted to only consider version/patch updates if the build status has changed. If a build status hasn't changed I'm not sure how the version/patch could've changed. 
