### PR TITLE
EVG-14924: Fetch cedar test results for tasks.

### DIFF
--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -269,23 +269,27 @@ func BbGetProject(settings *evergreen.Settings, projectId string) (evergreen.Bui
 func BbGetTask(taskId string, executionString string) (*task.Task, error) {
 	execution, err := strconv.Atoi(executionString)
 	if err != nil {
-		return nil, errors.Wrap(err, "Invalid execution number")
+		return nil, errors.Wrap(err, "invalid execution number")
 	}
+
 	t, err := task.FindOneIdOldOrNew(taskId, execution)
 	if err != nil {
-		return nil, errors.Wrap(err, "problem finding task")
+		return nil, errors.Wrap(err, "finding task")
 	}
 	if t == nil {
-		return nil, errors.Errorf("No task found for taskId: %s and execution: %d", taskId, execution)
+		return nil, errors.Errorf("no task found for task id: %s and execution: %d", taskId, execution)
 	}
+
 	if t.DisplayOnly {
 		t.LocalTestResults, err = t.GetTestResultsForDisplayTask()
 		if err != nil {
-			return nil, errors.Wrapf(err, "Problem finding test results for display task '%s'", t.Id)
+			return nil, errors.Wrapf(err, "finding test results for display task '%s'", t.Id)
 		}
 	}
+
 	return t, nil
 }
+
 func (js *JiraSuggest) GetTimeout() time.Duration {
 	// This function is never called because we are willing to wait forever for the fallback handler
 	// to return JIRA ticket results.

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -823,8 +823,8 @@ func FindOne(query db.Q) (*Task, error) {
 	if task == nil {
 		return nil, nil
 	}
-	if err = task.MergeNewTestResults(); err != nil {
-		return nil, errors.Wrapf(err, "errors merging new test results for '%s'", task.Id)
+	if err = task.MergeTestResults(); err != nil {
+		return nil, errors.Wrapf(err, "errors merging test results for '%s'", task.Id)
 	}
 	return task, err
 }
@@ -1051,8 +1051,8 @@ func FindOneOld(query db.Q) (*Task, error) {
 	if task == nil {
 		return nil, nil
 	}
-	if err = task.MergeNewTestResults(); err != nil {
-		return nil, errors.Wrapf(err, "errors merging new test results for '%s'", task.Id)
+	if err = task.MergeTestResults(); err != nil {
+		return nil, errors.Wrapf(err, "errors merging test results for '%s'", task.Id)
 	}
 	return task, err
 }
@@ -1065,8 +1065,8 @@ func FindOld(query db.Q) ([]Task, error) {
 		return nil, nil
 	}
 	for i, task := range tasks {
-		if err = task.MergeNewTestResults(); err != nil {
-			return nil, errors.Wrap(err, "error merging new test results")
+		if err = task.MergeTestResults(); err != nil {
+			return nil, errors.Wrap(err, "error merging test results")
 		}
 		tasks[i] = task
 	}
@@ -1089,8 +1089,8 @@ func FindOldWithDisplayTasks(query db.Q) ([]Task, error) {
 		return nil, nil
 	}
 	for i, task := range tasks {
-		if err = task.MergeNewTestResults(); err != nil {
-			return nil, errors.Wrap(err, "error merging new test results")
+		if err = task.MergeTestResults(); err != nil {
+			return nil, errors.Wrap(err, "error merging test results")
 		}
 		tasks[i] = task
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2034,9 +2034,9 @@ func (t *Task) makeArchivedTask() *Task {
 
 // Aggregation
 
-// MergeNewTestResults returns the task with both old (embedded in
-// the tasks collection) and new (from the testresults collection) test results
-// merged in the Task's LocalTestResults field.
+// MergeNewTestResults returns the task with both old (embedded in the tasks
+// collection) and new (from the testresults collection) test results merged in
+// the Task's LocalTestResults field.
 func (t *Task) MergeNewTestResults() error {
 	id := t.Id
 	if t.Archived {
@@ -2073,16 +2073,40 @@ func (t *Task) MergeNewTestResults() error {
 	return nil
 }
 
-// GetTestResultsForDisplayTask returns the test results for the execution tasks
-// for a display task.
+// MergeTestResults returns the task with both old (embedded in the tasks
+// collection) and new (from the testresults collection) OR Cedar test results
+// merged in the Task's LocalTestResults field.
+func (t *Task) MergeTestResults() error {
+	if t.HasCedarResults {
+		results, err := t.GetCedarTestResults()
+		if err != nil {
+			return errors.Wrap(err, "getting test results from cedar")
+
+		}
+		t.LocalTestResults = append(t.LocalTestResults, results...)
+
+		return nil
+	}
+
+	return t.MergeNewTestResults()
+}
+
+// GetTestResultsForDisplayTask returns the test results for the execution
+// tasks for a display task.
 func (t *Task) GetTestResultsForDisplayTask() ([]TestResult, error) {
 	if !t.DisplayOnly {
 		return nil, errors.Errorf("%s is not a display task", t.Id)
 	}
+
+	if t.HasCedarResults {
+		return t.LocalTestResults, nil
+	}
+
 	tasks, err := MergeTestResultsBulk([]Task{*t}, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error merging test results for display task")
 	}
+
 	return tasks[0].LocalTestResults, nil
 }
 
@@ -3083,6 +3107,63 @@ func (t *Task) SetNumDependents() error {
 	}, update)
 }
 
+func AddExecTasksToDisplayTask(displayTaskId string, execTasks []string) error {
+	if len(execTasks) == 0 {
+		return nil
+	}
+
+	return UpdateOne(
+		bson.M{IdKey: displayTaskId},
+		bson.M{"$addToSet": bson.M{
+			ExecutionTasksKey: bson.M{"$each": execTasks},
+		}},
+	)
+}
+
+////////////////
+// Cedar Helpers
+////////////////
+
+// Get CedarTestResults fetches the task's test results from the Cedar service.
+// If the task does not have test results in Cedar, (nil, nil) is returned. If
+// the task is a display task, all of its execution tasks' test results are
+// returned.
+func (t *Task) GetCedarTestResults() ([]TestResult, error) {
+	ctx, cancel := evergreen.GetEnvironment().Context()
+	defer cancel()
+
+	if !t.HasCedarResults {
+		return nil, nil
+	}
+
+	config, err := evergreen.GetConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "getting global config")
+	}
+
+	opts := apimodels.GetCedarTestResultsOptions{
+		BaseURL:   config.Cedar.BaseURL,
+		Execution: t.Execution,
+	}
+	if t.DisplayOnly {
+		opts.DisplayTaskID = t.Id
+	} else {
+		opts.TaskID = t.Id
+	}
+
+	cedarResults, err := apimodels.GetCedarTestResults(ctx, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting test results from cedar")
+	}
+
+	results := make([]TestResult, len(cedarResults))
+	for i, result := range cedarResults {
+		results[i] = ConvertCedarTestResult(result)
+	}
+
+	return results, nil
+}
+
 // ConvertCedarTestResult converts a CedarTestResult struct into a TestResult
 // struct.
 func ConvertCedarTestResult(result apimodels.CedarTestResult) TestResult {
@@ -3100,17 +3181,4 @@ func ConvertCedarTestResult(result apimodels.CedarTestResult) TestResult {
 		EndTime:         float64(result.End.Unix()),
 		Status:          result.Status,
 	}
-}
-
-func AddExecTasksToDisplayTask(displayTaskId string, execTasks []string) error {
-	if len(execTasks) == 0 {
-		return nil
-	}
-
-	return UpdateOne(
-		bson.M{IdKey: displayTaskId},
-		bson.M{"$addToSet": bson.M{
-			ExecutionTasksKey: bson.M{"$each": execTasks},
-		}},
-	)
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3136,13 +3136,8 @@ func (t *Task) GetCedarTestResults() ([]TestResult, error) {
 		return nil, nil
 	}
 
-	config, err := evergreen.GetConfig()
-	if err != nil {
-		return nil, errors.Wrap(err, "getting global config")
-	}
-
 	opts := apimodels.GetCedarTestResultsOptions{
-		BaseURL:   config.Cedar.BaseURL,
+		BaseURL:   evergreen.GetEnvironment().Settings().Cedar.BaseURL,
 		Execution: t.Execution,
 	}
 	if t.DisplayOnly {

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -250,7 +250,7 @@ func (vc *DBVersionConnector) GetVersionsAndVariants(skip, numVersionElements in
 // addFailedAndStartedTests adds all of the failed tests associated with a task
 func addFailedAndStartedTests(rows map[string]restModel.BuildList, failedAndStartedTasks []task.Task) error {
 	for i := range failedAndStartedTasks {
-		if err := failedAndStartedTasks[i].MergeNewTestResults(); err != nil {
+		if err := failedAndStartedTasks[i].MergeTestResults(); err != nil {
 			return errors.Wrap(err, "error merging test results")
 		}
 	}

--- a/service/task.go
+++ b/service/task.go
@@ -344,14 +344,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		if taskOnBaseCommit != nil {
 			taskPatch.BaseTaskId = taskOnBaseCommit.Id
 			taskPatch.BaseTimeTaken = taskOnBaseCommit.TimeTaken
-
 			testResultsOnBaseCommit = taskOnBaseCommit.LocalTestResults
-			if len(testResultsOnBaseCommit) == 0 {
-				cedarTestResults := uis.getCedarTestResults(ctx, taskOnBaseCommit, taskOnBaseCommit.Id)
-				for _, tr := range cedarTestResults {
-					testResultsOnBaseCommit = append(testResultsOnBaseCommit, task.ConvertCedarTestResult(tr))
-				}
-			}
 		}
 		taskPatch.StatusDiffs = model.StatusDiffTests(testResultsOnBaseCommit, testResults)
 		uiTask.PatchInfo = taskPatch
@@ -895,14 +888,12 @@ func (uis *UIServer) testLog(w http.ResponseWriter, r *http.Request) {
 }
 
 func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, projCtx projectContext, uiTask *uiTaskData, taskId string) []task.TestResult {
-	ctx := r.Context()
 	var err error
 	var testResults []task.TestResult
 
 	uiTask.TestResults = []uiTestResult{}
-	execTasks := []task.Task{}
-	execTaskIDs := []string{}
 	if uiTask.DisplayOnly {
+		execTaskDisplayNameMap := map[string]string{}
 		for _, t := range projCtx.Task.ExecutionTasks {
 			var et *task.Task
 			if uiTask.Archived {
@@ -922,101 +913,42 @@ func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, proj
 				})
 				continue
 			}
-			execTasks = append(execTasks, *et)
-			execTaskIDs = append(execTaskIDs, t)
+
+			execTaskDisplayNameMap[t] = et.DisplayName
+			uiTask.ExecutionTasks = append(uiTask.ExecutionTasks, uiExecTask{
+				Id:        t,
+				Name:      et.DisplayName,
+				TimeTaken: et.TimeTaken,
+				Status:    et.ResultStatus(),
+			})
 		}
 
-		execTaskDisplayNameMap := map[string]string{}
-		execTasks, err = task.MergeTestResultsBulk(execTasks, nil)
+		testResults, err = projCtx.Task.GetTestResultsForDisplayTask()
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return nil
 		}
-		for i, execTask := range execTasks {
-			execTaskDisplayNameMap[execTask.Id] = execTask.DisplayName
-			uiTask.ExecutionTasks = append(uiTask.ExecutionTasks, uiExecTask{
-				Id:        execTaskIDs[i],
-				Name:      execTask.DisplayName,
-				TimeTaken: execTask.TimeTaken,
-				Status:    execTask.ResultStatus(),
-			})
-		}
 
-		// Check cedar first.
-		cedarTestResults := uis.getCedarTestResults(ctx, projCtx.Task, taskId)
-		for _, tr := range cedarTestResults {
-			testResults = append(testResults, task.ConvertCedarTestResult(tr))
+		for _, tr := range testResults {
 			uiTask.TestResults = append(uiTask.TestResults, uiTestResult{
-				TestResult: testResults[len(testResults)-1],
+				TestResult: tr,
 				TaskId:     tr.TaskID,
 				TaskName:   execTaskDisplayNameMap[tr.TaskID],
 			})
 		}
-
-		// Cedar test results not found, fall back to evergreen test
-		// results.
-		if len(cedarTestResults) == 0 {
-			for i, execTask := range execTasks {
-				testResults = append(testResults, execTask.LocalTestResults...)
-				for _, tr := range execTask.LocalTestResults {
-					uiTask.TestResults = append(uiTask.TestResults, uiTestResult{
-						TestResult: tr,
-						TaskId:     execTaskIDs[i],
-						TaskName:   execTask.DisplayName,
-					})
-				}
-			}
-		}
 	} else {
-		// Check cedar first.
-		cedarTestResults := uis.getCedarTestResults(ctx, projCtx.Task, taskId)
-		for _, tr := range cedarTestResults {
-			testResults = append(testResults, task.ConvertCedarTestResult(tr))
+		for _, tr := range projCtx.Context.Task.LocalTestResults {
+			tr.TaskID = taskId
 			uiTask.TestResults = append(uiTask.TestResults, uiTestResult{
-				TestResult: testResults[len(testResults)-1],
+				TestResult: tr,
 				TaskId:     taskId,
 			})
 		}
-
-		// Cedar test results not found, fall back to evergreen
-		// test results.
-		if len(cedarTestResults) == 0 {
-			for _, tr := range projCtx.Context.Task.LocalTestResults {
-				tr.TaskID = taskId
-				uiTask.TestResults = append(uiTask.TestResults, uiTestResult{
-					TestResult: tr,
-					TaskId:     taskId,
-				})
-			}
-
-			testResults = projCtx.Task.LocalTestResults
-		}
+		testResults = projCtx.Task.LocalTestResults
 
 		if uiTask.PartOfDisplay {
 			uiTask.DisplayTaskID = projCtx.Task.DisplayTask.Id
 		}
-	}
-
-	return testResults
-}
-
-func (uis *UIServer) getCedarTestResults(ctx context.Context, t *task.Task, taskID string) []apimodels.CedarTestResult {
-	opts := apimodels.GetCedarTestResultsOptions{
-		BaseURL:   uis.Settings.Cedar.BaseURL,
-		Execution: t.Execution,
-	}
-	if t.DisplayOnly {
-		opts.DisplayTaskID = taskID
-	} else {
-		opts.TaskID = taskID
-	}
-	testResults, err := apimodels.GetCedarTestResults(ctx, opts)
-	if err != nil {
-		grip.Warning(message.WrapError(err, message.Fields{
-			"task_id":   taskID,
-			"execution": t.Execution,
-			"message":   "problem getting cedar test results, using evergreen test results",
-		}))
 	}
 
 	return testResults

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -804,7 +804,7 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 			}
 			t.oldTestResults = mapTestResultsByTestFile(results)
 		} else {
-			if err = previousCompleteTask.MergeNewTestResults(); err != nil {
+			if err = previousCompleteTask.MergeTestResults(); err != nil {
 				return nil, errors.Wrapf(err, "can't get test results for previous task '%s'", previousCompleteTask.Id)
 			}
 			t.oldTestResults = mapTestResultsByTestFile(previousCompleteTask.LocalTestResults)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14924

I updated the task struct in model to also fetch and merge cedar test results wherever we merge new test results. I also fixed the display task test results issue that was causing the original issue from this ticket and cleaned up the legacy UI. 
I tested in staging that the test results are rendered properly with their logs. Upon deploy, we should watch out for display task UI pages since we don't have those in staging. 
