### PR TITLE
EVG-14670: Prevent users from viewing global_github_oauth_token expansion

### DIFF
--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"github.com/evergreen-ci/evergreen"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -172,6 +173,9 @@ func defaultAndApplyExpansionsToEnv(env map[string]string, opts modifyEnvOptions
 	expansions := opts.expansions.Map()
 	if opts.addExpansionsToEnv {
 		for k, v := range expansions {
+			if k == evergreen.GlobalGitHubTokenExpansion {
+				continue
+			}
 			env[k] = v
 		}
 	}

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -2,12 +2,12 @@ package command
 
 import (
 	"context"
-	"github.com/evergreen-ci/evergreen"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	agentutil "github.com/evergreen-ci/evergreen/agent/util"
@@ -174,6 +174,8 @@ func defaultAndApplyExpansionsToEnv(env map[string]string, opts modifyEnvOptions
 	if opts.addExpansionsToEnv {
 		for k, v := range expansions {
 			if k == evergreen.GlobalGitHubTokenExpansion {
+				//users should not be able to use the global github token expansion
+				//as it can result in the breaching of Evergreen's GitHub API limit
 				continue
 			}
 			env[k] = v

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -183,7 +183,7 @@ func defaultAndApplyExpansionsToEnv(env map[string]string, opts modifyEnvOptions
 	}
 
 	for _, expName := range opts.includeExpansionsInEnv {
-		if val, ok := expansions[expName]; ok {
+		if val, ok := expansions[expName]; ok && expName != evergreen.GlobalGitHubTokenExpansion {
 			env[expName] = val
 		}
 	}

--- a/agent/command/expansion_test.go
+++ b/agent/command/expansion_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"github.com/evergreen-ci/evergreen"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -83,9 +84,10 @@ func TestExpansionWriter(t *testing.T) {
 	assert.NoError(err)
 	tc := &internal.TaskConfig{
 		Expansions: &util.Expansions{
-			"foo":      "bar",
-			"baz":      "qux",
-			"password": "hunter2",
+			"foo":                                "bar",
+			"baz":                                "qux",
+			"password":                           "hunter2",
+			evergreen.GlobalGitHubTokenExpansion: "sample_token",
 		},
 		Redacted: map[string]bool{
 			"password": true,

--- a/agent/command/expansion_test.go
+++ b/agent/command/expansion_test.go
@@ -2,11 +2,11 @@ package command
 
 import (
 	"context"
-	"github.com/evergreen-ci/evergreen"
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/model"

--- a/agent/command/expansion_write.go
+++ b/agent/command/expansion_write.go
@@ -2,10 +2,10 @@ package command
 
 import (
 	"context"
-	"github.com/evergreen-ci/evergreen"
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/mitchellh/mapstructure"
@@ -39,6 +39,8 @@ func (c *expansionsWriter) Execute(ctx context.Context,
 	for k, v := range conf.Expansions.Map() {
 		_, ok := conf.Redacted[k]
 		if (ok && !c.Redacted) || k == evergreen.GlobalGitHubTokenExpansion {
+			//users should not be able to use the global github token expansion
+			//as it can result in the breaching of Evergreen's GitHub API limit
 			continue
 		}
 		expansions[k] = v

--- a/agent/command/expansion_write.go
+++ b/agent/command/expansion_write.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"github.com/evergreen-ci/evergreen"
 	"io/ioutil"
 	"path/filepath"
 
@@ -37,7 +38,7 @@ func (c *expansionsWriter) Execute(ctx context.Context,
 	expansions := map[string]string{}
 	for k, v := range conf.Expansions.Map() {
 		_, ok := conf.Redacted[k]
-		if ok && !c.Redacted {
+		if (ok && !c.Redacted) || k == evergreen.GlobalGitHubTokenExpansion {
 			continue
 		}
 		expansions[k] = v

--- a/agent/command/scripting.go
+++ b/agent/command/scripting.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/evergreen"
 	"io"
 	"os"
 	"path/filepath"
@@ -294,6 +295,9 @@ func (c *scriptingExec) doExpansions(exp *util.Expansions) error {
 	expansions := exp.Map()
 	if c.AddExpansionsToEnv {
 		for k, v := range expansions {
+			if k == evergreen.GlobalGitHubTokenExpansion {
+				continue
+			}
 			c.Env[k] = v
 		}
 	}

--- a/agent/command/scripting.go
+++ b/agent/command/scripting.go
@@ -305,7 +305,7 @@ func (c *scriptingExec) doExpansions(exp *util.Expansions) error {
 	}
 
 	for _, ei := range c.IncludeExpansionsInEnv {
-		if val, ok := expansions[ei]; ok {
+		if val, ok := expansions[ei]; ok && ei != evergreen.GlobalGitHubTokenExpansion {
 			c.Env[ei] = val
 		}
 	}

--- a/agent/command/scripting.go
+++ b/agent/command/scripting.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/evergreen"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/model"
@@ -296,6 +296,8 @@ func (c *scriptingExec) doExpansions(exp *util.Expansions) error {
 	if c.AddExpansionsToEnv {
 		for k, v := range expansions {
 			if k == evergreen.GlobalGitHubTokenExpansion {
+				//users should not be able to use the global github token expansion
+				//as it can result in the breaching of Evergreen's GitHub API limit
 				continue
 			}
 			c.Env[k] = v

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-06-28"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-07-01"
+	AgentVersion = "2021-07-02"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-14670](https://jira.mongodb.org/browse/EVG-14670)

### Description 
Users are currently able to discover Evergreen's global_github_oauth_token expansion, which if they use can result in our GitHub API limit to be reached.  A change has been made to prevent this expansion to be written to expansion lists in yaml files and from shell.exec. 

### Testing 
Modified unit test in expansion_test.go to include global_github_oauth_token as an expansion and confirm it is not written to any file