### PR TITLE
EVG-13811: Ensure default security group is available during host.create

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -192,7 +192,6 @@ const (
 	ExpireOnFormat                      = "2006-01-02"
 	DefaultMaxSpawnHostsPerUser         = 3
 	DefaultSpawnHostExpiration          = 24 * time.Hour
-	DefaultSecurityGroup                = "sg-097bff6dd0d1d31d0"
 	SpawnHostNoExpirationDuration       = 7 * 24 * time.Hour
 	MaxSpawnHostExpirationDurationHours = 24 * time.Hour * 14
 	UnattachedVolumeExpiration          = 24 * time.Hour * 30

--- a/globals.go
+++ b/globals.go
@@ -192,6 +192,7 @@ const (
 	ExpireOnFormat                      = "2006-01-02"
 	DefaultMaxSpawnHostsPerUser         = 3
 	DefaultSpawnHostExpiration          = 24 * time.Hour
+	DefaultSecurityGroup                = "sg-097bff6dd0d1d31d0"
 	SpawnHostNoExpirationDuration       = 7 * 24 * time.Hour
 	MaxSpawnHostExpirationDurationHours = 24 * time.Hour * 14
 	UnattachedVolumeExpiration          = 24 * time.Hour * 30

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -390,15 +390,11 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		ec2Settings.UserData = createHost.UserdataCommand
 	}
 
-	defaultSg := evergreen.GetEnvironment().Settings().Providers.AWS.DefaultSecurityGroup
-
 	// Always override distro security group with provided security group.
 	if len(createHost.SecurityGroups) > 0 {
 		ec2Settings.SecurityGroupIDs = createHost.SecurityGroups
-	} else if ec2Settings.SecurityGroupIDs == nil || len(ec2Settings.SecurityGroupIDs) == 0 {
-		ec2Settings.SecurityGroupIDs = []string{defaultSg}
 	} else {
-		ec2Settings.SecurityGroupIDs = append(ec2Settings.SecurityGroupIDs, defaultSg)
+		ec2Settings.SecurityGroupIDs = append(ec2Settings.SecurityGroupIDs, evergreen.GetEnvironment().Settings().Providers.AWS.DefaultSecurityGroup)
 	}
 
 	ec2Settings.IPv6 = createHost.IPv6

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -390,13 +390,15 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		ec2Settings.UserData = createHost.UserdataCommand
 	}
 
+	defaultSg := evergreen.GetEnvironment().Settings().Providers.AWS.DefaultSecurityGroup
+
 	// Always override distro security group with provided security group.
 	if len(createHost.SecurityGroups) > 0 {
 		ec2Settings.SecurityGroupIDs = createHost.SecurityGroups
 	} else if ec2Settings.SecurityGroupIDs == nil || len(ec2Settings.SecurityGroupIDs) == 0 {
-		ec2Settings.SecurityGroupIDs = []string{evergreen.DefaultSecurityGroup}
+		ec2Settings.SecurityGroupIDs = []string{defaultSg}
 	} else {
-		ec2Settings.SecurityGroupIDs = append(ec2Settings.SecurityGroupIDs, evergreen.DefaultSecurityGroup)
+		ec2Settings.SecurityGroupIDs = append(ec2Settings.SecurityGroupIDs, defaultSg)
 	}
 
 	ec2Settings.IPv6 = createHost.IPv6

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -393,6 +393,10 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	// Always override distro security group with provided security group.
 	if len(createHost.SecurityGroups) > 0 {
 		ec2Settings.SecurityGroupIDs = createHost.SecurityGroups
+	} else if ec2Settings.SecurityGroupIDs == nil || len(ec2Settings.SecurityGroupIDs) == 0 {
+		ec2Settings.SecurityGroupIDs = []string{evergreen.DefaultSecurityGroup}
+	} else {
+		ec2Settings.SecurityGroupIDs = append(ec2Settings.SecurityGroupIDs, evergreen.DefaultSecurityGroup)
 	}
 
 	ec2Settings.IPv6 = createHost.IPv6

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -308,8 +308,9 @@ buildvariants:
 			assert.NoError(t, ec2Settings.FromDistroSettings(h.Distro, ""))
 			assert.NotEmpty(t, ec2Settings.KeyName)
 			assert.InDelta(t, time.Now().Add(evergreen.DefaultSpawnHostExpiration).Unix(), h.ExpirationTime.Unix(), float64(1*time.Millisecond))
-			require.Len(t, ec2Settings.SecurityGroupIDs, 1)
+			require.Len(t, ec2Settings.SecurityGroupIDs, 2)
 			assert.Equal(t, "sg-distro", ec2Settings.SecurityGroupIDs[0]) // if not overridden, stick with ec2 security group
+			assert.Equal(t, "sg-097bff6dd0d1d31d0", ec2Settings.SecurityGroupIDs[1])
 			assert.Equal(t, distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 		}
 	})

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -310,7 +310,6 @@ buildvariants:
 			assert.InDelta(t, time.Now().Add(evergreen.DefaultSpawnHostExpiration).Unix(), h.ExpirationTime.Unix(), float64(1*time.Millisecond))
 			require.Len(t, ec2Settings.SecurityGroupIDs, 2)
 			assert.Equal(t, "sg-distro", ec2Settings.SecurityGroupIDs[0]) // if not overridden, stick with ec2 security group
-			assert.Equal(t, "sg-097bff6dd0d1d31d0", ec2Settings.SecurityGroupIDs[1])
 			assert.Equal(t, distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 		}
 	})


### PR DESCRIPTION
[EVG-13811](https://jira.mongodb.org/browse/EVG-13811)

### Description 
Users currently need to manually add sg-097bff6dd0d1d31d0 as a security group before running host.create.  To prevent further confusion in the future this has been automatically added as a security group so this no longer needs to be done manually.
### Testing 
Ensured default security group is added in unit test in host_create_test.go