### PR TITLE
EVG-14840 Fetch latest execution task if the display task's current execution doesn't exist  

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2514,7 +2514,11 @@ func (r *taskResolver) ExecutionTasksFull(ctx context.Context, obj *restModel.AP
 	for _, execTaskID := range t.ExecutionTasks {
 		execT, err := task.FindOneIdAndExecutionWithDisplayStatus(execTaskID, &t.Execution)
 		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting execution task with id: %s : %s", execTaskID, err.Error()))
+			// The task is not found, possibly because the execution is out of sync with the display task. Get the latest instead.
+			execT, err = task.FindOne(task.ById(execTaskID))
+			if err != nil {
+				return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting execution task with id: %s : %s", execTaskID, err.Error()))
+			}
 		}
 		if execT != nil {
 			apiTask := &restModel.APITask{}


### PR DESCRIPTION
[EVG-14840](https://jira.mongodb.org/browse/EVG-14840)

### Description 
If an execution task only runs on the second execution of a display task (when it is restarted), then the execution task's execution will not be the same as the display tasks's execution. 
### Testing 
[Tested on staging](http://evergreen-staging.spruce.s3-website-us-east-1.amazonaws.com/version/60e4620197b1d32239314179/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
