### PR TITLE
EVG-14889: Update admin roles when copying over project

### DIFF
--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -74,6 +74,7 @@ func (p *projectCopyHandler) Run(ctx context.Context) gimlet.Responder {
 	projectToCopy.Enabled = utility.FalsePtr()
 	projectToCopy.PRTestingEnabled = nil
 	projectToCopy.CommitQueue.Enabled = nil
+	adminsToAdd := projectToCopy.Admins
 	u := gimlet.GetUser(ctx).(*user.DBUser)
 	if err = p.sc.CreateProject(projectToCopy, u); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error creating project for id '%s'", p.newProject))
@@ -92,6 +93,10 @@ func (p *projectCopyHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	if err = p.sc.CopyProjectSubscriptions(oldId, projectToCopy.Id); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error copying subscriptions from project '%s'", p.oldProject))
+	}
+	//update admins
+	if err = p.sc.UpdateAdminRoles(projectToCopy, adminsToAdd, nil); err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "Database error updating admins for project '%s'", p.oldProject))
 	}
 
 	return gimlet.NewJSONResponse(apiProjectRef)


### PR DESCRIPTION
[EVG-14889](https://jira.mongodb.org/browse/EVG-14889)

### Description 
Executing the endpoint to copy an existing project over to a new project was seen to result in the newly created project not having the appropriate admin roles set (and users that ought to have been entitled were not able to view the project in Evergreen's UI). The copying action did not re-set the existing admin roles from the old project onto the new project, so the new project had the correct list of names in the Admins property, but those roles were not actually set.  A change has been made to update the roles for the newly copied over project at the end of the copying function.