### PR TITLE
EVG-14823: Include display task ID upon execution task completion

### DIFF
--- a/service/api_task.go
+++ b/service/api_task.go
@@ -310,14 +310,25 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		endTaskResp.ShouldExit = true
 	}
 
-	grip.Info(message.Fields{
+	msg := message.Fields{
 		"message":     "Successfully marked task as finished",
 		"task_id":     t.Id,
 		"execution":   t.Execution,
 		"operation":   "mark end",
 		"duration":    time.Since(finishTime),
 		"should_exit": endTaskResp.ShouldExit,
-	})
+	}
+
+	if t.IsPartOfDisplay() {
+		dt, err := t.GetDisplayTask()
+		if err != nil {
+			grip.Error(errors.Wrapf(err, "can't get display task for task %s", t.Id))
+		} else {
+			msg["display_task_id"] = dt.Id
+		}
+	}
+
+	grip.Info(msg)
 	gimlet.WriteJSON(w, endTaskResp)
 }
 

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -320,12 +320,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if t.IsPartOfDisplay() {
-		dt, err := t.GetDisplayTask()
-		if err != nil {
-			grip.Error(errors.Wrapf(err, "can't get display task for task %s", t.Id))
-		} else {
-			msg["display_task_id"] = dt.Id
-		}
+		msg["display_task_id"] = t.DisplayTask.Id
 	}
 
 	grip.Info(msg)

--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -132,6 +132,15 @@ func (j *collectTaskEndDataJob) Run(ctx context.Context) {
 		"version":              j.task.Version,
 	}
 
+	if j.task.IsPartOfDisplay() {
+		dt, err := j.task.GetDisplayTask()
+		if err != nil {
+			j.AddError(errors.Wrapf(err, "can't get display task for task %s", j.task.Id))
+		} else {
+			msg["display_task_id"] = dt.Id
+		}
+	}
+
 	pRef, err := model.FindOneProjectRef(j.task.Project)
 	if pRef != nil {
 		msg["project_identifier"] = pRef.Identifier

--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -133,12 +133,7 @@ func (j *collectTaskEndDataJob) Run(ctx context.Context) {
 	}
 
 	if j.task.IsPartOfDisplay() {
-		dt, err := j.task.GetDisplayTask()
-		if err != nil {
-			j.AddError(errors.Wrapf(err, "can't get display task for task %s", j.task.Id))
-		} else {
-			msg["display_task_id"] = dt.Id
-		}
+		msg["display_task_id"] = j.task.DisplayTask.Id
 	}
 
 	pRef, err := model.FindOneProjectRef(j.task.Project)


### PR DESCRIPTION
[EVG-14823](https://jira.mongodb.org/browse/EVG-14823)

### Description 
There is currently not a foolproof way to execute a Splunk query that shows only display tasks (rather than execution tasks) and fold in any execution task information under the respective display task entry. Manual queries such as [this](https://mongodb.splunkcloud.com/en-US/app/search/search?earliest=1616370300&latest=1616975100&q=search%20index%3Devergreen%20stat%3Dtask-end-stats%20project%3D%22mongodb-mongo-*%22%20task!%3D%22*burn_in*%22%20requester%3D%22patch_request%22%20build!%3D%22*commit_queue*%22%20task!%3D%22*_gen%22%20%7C%20eval%20task%20%3D%20replace(task%2C%20%22_%5B0-9%5D%2B_%7C_misc_%22%2C%20%22_display_%22)%20%7C%20eval%20task%20%3D%20replace(task%2Cvariant%2C%22%22)%20%7C%20eval%20key%3Dbuild.%22%3A%22.task%20%7C%20stats%20first(task)%20as%20task%2Csum(eval(if(status!%3D%22success%22%2C%201%2C%200)))%20as%20totalcnt%20by%20key%20%7C%20search%20totalcnt%3E0&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=statistics&workload_pool=standard_perf&display.events.fields=%5B%22source%22%2C%22sourcetype%22%2C%22stat%22%2C%22cost%22%2C%22distro%22%2C%22project%22%2C%22provider%22%2C%22task%22%2C%22build%22%2C%22host%22%2C%22task_id%22%2C%22scheduled_time%22%2C%22start_time%22%2C%22current_runtime_secs%22%2C%22abort%22%2C%22error%22%2C%22status%22%2C%22time_waiting%22%2C%22issues%7B%7D%7B%7D%22%5D&display.visualizations.charting.chart=bar&display.page.search.tab=statistics&sid=1625667068.1366964) are possible, however to make this easier a change has been made to include display task information upon completion of execution tasks.
