### PR TITLE
EVG-14908: add middleware to check pod secret

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -334,6 +334,8 @@ const (
 	TaskSecretHeader    = "Task-Secret"
 	HostHeader          = "Host-Id"
 	HostSecretHeader    = "Host-Secret"
+	PodHeader           = "Pod-Id"
+	PodSecretHeader     = "Pod-Secret"
 	ContentTypeHeader   = "Content-Type"
 	ContentTypeValue    = "application/json"
 	ContentLengthHeader = "Content-Length"

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -14,6 +14,7 @@ const (
 
 var (
 	IDKey                        = bsonutil.MustHaveTag(Pod{}, "ID")
+	SecretKey                    = bsonutil.MustHaveTag(Pod{}, "Secret")
 	ExternalIDKey                = bsonutil.MustHaveTag(Pod{}, "ExternalID")
 	TaskContainerCreationOptsKey = bsonutil.MustHaveTag(Pod{}, "TaskContainerCreationOpts")
 	TimeInfoKey                  = bsonutil.MustHaveTag(Pod{}, "TimeInfo")

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -17,6 +17,9 @@ type Pod struct {
 	// ExternalID is the unique external resource identifier for the collection
 	// of containers running in the container orchestration service.
 	ExternalID string `bson:"external_id,omitempty" json:"external_id,omitempty"`
+	// Secret is the shared secret between the server and the pod for
+	// authentication when the host is provisioned.
+	Secret string `bson:"secret" json:"secret"`
 	// TaskCreationOpts are options to configure how a task should be
 	// containerized and run in a pod.
 	TaskContainerCreationOpts TaskContainerCreationOptions `bson:"task_creation_opts,omitempty" json:"task_creation_opts,omitempty"`

--- a/rest/data/impl.go
+++ b/rest/data/impl.go
@@ -13,6 +13,7 @@ type DBConnector struct {
 	DBContextConnector
 	DBDistroConnector
 	DBHostConnector
+	DBPodConnector
 	DBTestConnector
 	DBBuildConnector
 	DBVersionConnector
@@ -48,6 +49,7 @@ type MockConnector struct {
 	MockContextConnector
 	MockDistroConnector
 	MockHostConnector
+	MockPodConnector
 	MockTestConnector
 	MockBuildConnector
 	MockVersionConnector

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -296,6 +296,10 @@ type Connector interface {
 
 	CheckHostSecret(string, *http.Request) (int, error)
 
+	// CheckPodSecret checks that the ID and secret match the server's
+	// stored credentials for the pod.
+	CheckPodSecret(id, secret string) error
+
 	// FindProjectAliases queries the database to find all aliases (including or excluding those specified).
 	// Includes repo aliases if repoId is provided.
 	FindProjectAliases(string, string, []restModel.APIProjectAlias) ([]restModel.APIProjectAlias, error)

--- a/rest/data/pod.go
+++ b/rest/data/pod.go
@@ -1,0 +1,42 @@
+package data
+
+import (
+	"github.com/evergreen-ci/evergreen/model/pod"
+	"github.com/pkg/errors"
+)
+
+// DBPodConnector implements the pod-related methods from the connector via
+// interactions with the database.
+type DBPodConnector struct{}
+
+// CheckPodSecret checks for a pod with a matching ID and secret in the
+// database.
+func (c *DBPodConnector) CheckPodSecret(id, secret string) error {
+	p, err := pod.FindOneByID(id)
+	if err != nil {
+		return err
+	}
+	if p == nil {
+		return errors.New("pod does not exist")
+	}
+	if secret != p.Secret {
+		return errors.New("pod secrets do not match")
+	}
+	return nil
+}
+
+type MockPodConnector struct {
+	CachedPods []pod.Pod
+}
+
+func (c *MockPodConnector) CheckPodSecret(id, secret string) error {
+	for _, p := range c.CachedPods {
+		if id != p.ID {
+			continue
+		}
+		if secret != p.Secret {
+			return errors.New("pod secrets do not match")
+		}
+	}
+	return errors.New("pod does not exist")
+}

--- a/rest/data/pod.go
+++ b/rest/data/pod.go
@@ -20,11 +20,13 @@ func (c *DBPodConnector) CheckPodSecret(id, secret string) error {
 		return errors.New("pod does not exist")
 	}
 	if secret != p.Secret {
-		return errors.New("pod secrets do not match")
+		return errors.New("incorrect pod secret")
 	}
 	return nil
 }
 
+// MockPodConnector implements the pod-related methods from the connector via an
+// in-memory cache of pods.
 type MockPodConnector struct {
 	CachedPods []pod.Pod
 }
@@ -35,7 +37,7 @@ func (c *MockPodConnector) CheckPodSecret(id, secret string) error {
 			continue
 		}
 		if secret != p.Secret {
-			return errors.New("pod secrets do not match")
+			return errors.New("incorrect pod secret")
 		}
 	}
 	return errors.New("pod does not exist")

--- a/rest/data/pod_test.go
+++ b/rest/data/pod_test.go
@@ -1,0 +1,33 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/model/pod"
+	"github.com/stretchr/testify/suite"
+)
+
+type podConnectorSuite struct {
+	suite.Suite
+	conn Connector
+}
+
+func TestPodConnectorSuite(t *testing.T) {
+	s := &podConnectorSuite{conn: &DBConnector{}}
+	suite.Run(t, s)
+}
+
+func (s *podConnectorSuite) TestCheckPodSecret() {
+	p := pod.Pod{
+		ID:     "id",
+		Secret: "secret",
+	}
+	s.Require().NoError(p.Insert())
+
+	s.NoError(s.conn.CheckPodSecret("id", "secret"))
+	s.Error(s.conn.CheckPodSecret("", ""))
+	s.Error(s.conn.CheckPodSecret("id", ""))
+	s.Error(s.conn.CheckPodSecret("id", "bad_secret"))
+	s.Error(s.conn.CheckPodSecret("", "secret"))
+	s.Error(s.conn.CheckPodSecret("bad_id", "secret"))
+}

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -320,6 +320,8 @@ type podAuthMiddleware struct {
 	sc data.Connector
 }
 
+// NewPodAuthMiddleware returns a middleware that verifies the request's pod ID
+// and secret.
 func NewPodAuthMiddleware(sc data.Connector) gimlet.Middleware {
 	return &podAuthMiddleware{sc: sc}
 }

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -316,6 +316,46 @@ func (m *hostAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, 
 	next(rw, r)
 }
 
+type podAuthMiddleware struct {
+	sc data.Connector
+}
+
+func NewPodAuthMiddleware(sc data.Connector) gimlet.Middleware {
+	return &podAuthMiddleware{sc: sc}
+}
+
+func (m *podAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	id := gimlet.GetVars(r)["pod_id"]
+	if id == "" {
+		if id = r.Header.Get(evergreen.PodHeader); id == "" {
+			gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusUnauthorized,
+				Message:    "missing pod ID",
+			}))
+			return
+		}
+	}
+
+	secret := r.Header.Get(evergreen.PodSecretHeader)
+	if secret == "" {
+		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusUnauthorized,
+			Message:    "missing pod secret",
+		}))
+		return
+	}
+
+	if err := m.sc.CheckPodSecret(id, secret); err != nil {
+		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusUnauthorized,
+			Message:    err.Error(),
+		}))
+		return
+	}
+
+	next(rw, r)
+}
+
 func NewTaskAuthMiddleware(sc data.Connector) gimlet.Middleware {
 	return &TaskAuthMiddleware{
 		sc: sc,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14908

### Description 
* Add secret to pod data model, which will be generated when the pod is created in the container service.
* Add middleware to check pod ID and secret are valid when a pod contacts the app server.

### Testing 
Standard tests for the DB connector and middleware.