### PR TITLE
EVG-14777: Do not create BFG ticket for stranded tasks

### DIFF
--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -48,6 +48,10 @@ func BbFileTicket(context context.Context, taskId string, execution int) (bool, 
 		taskNotFound = true
 		return taskNotFound, errors.Wrap(err, fmt.Sprintf("task not found for id %s", taskId))
 	}
+	if t.Details.Description == evergreen.TaskDescriptionStranded {
+		// We avoid creating BFG ticket in the case that the task is stranded to reduce noise for the Build Bartender
+		return true, nil
+	}
 	env := evergreen.GetEnvironment()
 	settings := env.Settings()
 	queue := env.RemoteQueue()

--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -48,10 +48,6 @@ func BbFileTicket(context context.Context, taskId string, execution int) (bool, 
 		taskNotFound = true
 		return taskNotFound, errors.Wrap(err, fmt.Sprintf("task not found for id %s", taskId))
 	}
-	if t.Details.Description == evergreen.TaskDescriptionStranded {
-		// We avoid creating BFG ticket in the case that the task is stranded to reduce noise for the Build Bartender
-		return true, nil
-	}
 	env := evergreen.GetEnvironment()
 	settings := env.Settings()
 	queue := env.RemoteQueue()

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -326,7 +326,10 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 
 func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, testNames string) (*notification.Notification, error) {
 	var payload interface{}
-	if sub.Subscriber.Type == event.JIRAIssueSubscriberType && t.task.Details.Description != evergreen.TaskDescriptionStranded {
+	if t.task.Details.Description == evergreen.TaskDescriptionStranded {
+		return nil, nil
+	}
+	if sub.Subscriber.Type == event.JIRAIssueSubscriberType {
 		issueSub, ok := sub.Subscriber.Target.(*event.JIRAIssueSubscriber)
 		if !ok {
 			return nil, errors.Errorf("unexpected target data type: '%T'", sub.Subscriber.Target)

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -326,11 +326,11 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 
 func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, testNames string) (*notification.Notification, error) {
 	var payload interface{}
-	// We avoid creating BFG ticket in the case that the task is stranded to reduce noise for the Build Baron
-	if t.task.Details.Description == evergreen.TaskDescriptionStranded {
-		return nil, nil
-	}
 	if sub.Subscriber.Type == event.JIRAIssueSubscriberType {
+		// We avoid creating BFG ticket in the case that the task is stranded to reduce noise for the Build Baron
+		if t.task.Details.Description == evergreen.TaskDescriptionStranded {
+			return nil, nil
+		}
 		issueSub, ok := sub.Subscriber.Target.(*event.JIRAIssueSubscriber)
 		if !ok {
 			return nil, errors.Errorf("unexpected target data type: '%T'", sub.Subscriber.Target)

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -326,7 +326,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 
 func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, testNames string) (*notification.Notification, error) {
 	var payload interface{}
-	// We avoid creating BFG ticket in the case that the task is stranded to reduce noise for the Build Bartender
+	// We avoid creating BFG ticket in the case that the task is stranded to reduce noise for the Build Baron
 	if t.task.Details.Description == evergreen.TaskDescriptionStranded {
 		return nil, nil
 	}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -326,6 +326,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 
 func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, testNames string) (*notification.Notification, error) {
 	var payload interface{}
+	// We avoid creating BFG ticket in the case that the task is stranded to reduce noise for the Build Bartender
 	if t.task.Details.Description == evergreen.TaskDescriptionStranded {
 		return nil, nil
 	}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -326,7 +326,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 
 func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, testNames string) (*notification.Notification, error) {
 	var payload interface{}
-	if sub.Subscriber.Type == event.JIRAIssueSubscriberType {
+	if sub.Subscriber.Type == event.JIRAIssueSubscriberType && t.task.Details.Description != evergreen.TaskDescriptionStranded {
 		issueSub, ok := sub.Subscriber.Target.(*event.JIRAIssueSubscriber)
 		if !ok {
 			return nil, errors.Errorf("unexpected target data type: '%T'", sub.Subscriber.Target)

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -124,8 +124,8 @@ func TestBuildBreakNotificationsFromRepotracker(t *testing.T) {
 	n, err = NotificationsFromEvent(&e)
 	assert.NoError(err)
 	grip.Error(err)
-	//assert.Len(n, 1)
-	//assert.EqualValues(user.PreferenceSlack, n[0].Subscriber.Type)
+	assert.Len(n, 1)
+	assert.EqualValues(user.PreferenceSlack, n[0].Subscriber.Type)
 }
 
 func TestTaskTriggers(t *testing.T) {
@@ -165,7 +165,6 @@ func (s *taskSuite) SetupTest() {
 		FinishTime:          startTime.Add(20 * time.Minute),
 		RevisionOrderNumber: 1,
 		Requester:           evergreen.RepotrackerVersionRequester,
-		Details:             apimodels.TaskEndDetail{Description: evergreen.TaskDescriptionStranded},
 	}
 	s.NoError(s.task.Insert())
 
@@ -783,6 +782,9 @@ func (s *taskSuite) TestSkipStrandedJIRA() {
 		Owner: "someone",
 	}
 	s.t = s.makeTaskTriggers(s.task.Id, s.task.Execution)
+	s.t.task.Details = apimodels.TaskEndDetail{
+		Description: evergreen.TaskDescriptionStranded,
+	}
 	n, err := s.t.generate(&sub, "", "")
 	s.NoError(err)
 	s.Equal(n, (*notification.Notification)(nil))

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/alertrecord"
@@ -164,11 +163,6 @@ func (s *taskSuite) SetupTest() {
 		FinishTime:          startTime.Add(20 * time.Minute),
 		RevisionOrderNumber: 1,
 		Requester:           evergreen.RepotrackerVersionRequester,
-		Details: apimodels.TaskEndDetail{
-			Status:      evergreen.TaskFailed,
-			Type:        "test",
-			Description: evergreen.TaskDescriptionStranded,
-		},
 	}
 	s.NoError(s.task.Insert())
 
@@ -763,32 +757,6 @@ func (s *taskSuite) tryDoubleTrigger(shouldGenerate bool) {
 	n, err = s.t.taskRegressionByTest(&s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
-}
-
-func (s *taskSuite) TestSkipStrandedJIRA() {
-	sub := event.Subscription{
-		ID:           mgobson.NewObjectId().Hex(),
-		ResourceType: event.ResourceTypeTask,
-		Trigger:      triggerTaskRegressionByTest,
-		Selectors: []event.Selector{
-			{
-				Type: event.SelectorProject,
-				Data: "myproj",
-			},
-		},
-		Subscriber: event.Subscriber{
-			Type:   event.JIRAIssueSubscriberType,
-			Target: "a@b.com",
-		},
-		TriggerData: map[string]string{
-			event.TestRegexKey: "test*",
-		},
-		Owner: "someone",
-	}
-	s.t = s.makeTaskTriggers(s.task.Id, s.task.Execution)
-	n, err := s.t.generate(&sub, "", "")
-	s.NoError(err)
-	s.Equal(n.Payload, nil)
 }
 
 func (s *taskSuite) TestRegressionByTestSimpleRegression() {


### PR DESCRIPTION
[EVG-14777](https://jira.mongodb.org/browse/EVG-14777)

### Description 
BFGs are created when spot hosts are taken by AWS (causing the tasks to end in a stranded state), creating a significant amount of noise for the Build Bartender. Since these are generally not action items and are not indicative of a real issue, a change has been made to skip JIRA creations when this occurs

### Testing
Unit test added asserting that no notification is sent to anyone when a stranded state occurs.