### PR TITLE
EVG-14968: Use correct task id and execution when fetching cedar test results

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3191,7 +3191,7 @@ func (t *Task) hasCedarResults() bool {
 			// This is a display task from the old task collection,
 			// we need to look there for its execution tasks.
 			execTasks, err = FindAllOld(db.Query(bson.M{
-				IdKey:        bson.M{"$in": t.ExecutionTasks},
+				OldTaskIdKey: bson.M{"$in": t.ExecutionTasks},
 				ExecutionKey: t.Execution,
 			}))
 		} else {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3189,7 +3189,7 @@ func (t *Task) hasCedarResults() bool {
 		)
 		if t.Archived {
 			// This is a display task from the old task collection,
-			// we need to look their for its execution tasks.
+			// we need to look there for its execution tasks.
 			execTasks, err = FindAllOld(db.Query(bson.M{
 				IdKey:        bson.M{"$in": t.ExecutionTasks},
 				ExecutionKey: t.Execution,

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3145,14 +3145,19 @@ func (t *Task) GetCedarTestResults() ([]TestResult, error) {
 		return nil, nil
 	}
 
+	taskID := t.Id
+	if t.Archived {
+		taskID = t.OldTaskId
+	}
+
 	opts := apimodels.GetCedarTestResultsOptions{
 		BaseURL:   evergreen.GetEnvironment().Settings().Cedar.BaseURL,
 		Execution: t.Execution,
 	}
 	if t.DisplayOnly {
-		opts.DisplayTaskID = t.Id
+		opts.DisplayTaskID = taskID
 	} else {
-		opts.TaskID = t.Id
+		opts.TaskID = taskID
 	}
 
 	cedarResults, err := apimodels.GetCedarTestResults(ctx, opts)
@@ -3178,7 +3183,20 @@ func (t *Task) hasCedarResults() bool {
 	// results in Cedar, this will attempt to update the display task
 	// accordingly.
 	if len(t.ExecutionTasks) > 0 {
-		execTasks, err := FindAll(ByIds(t.ExecutionTasks))
+		var (
+			execTasks []Task
+			err       error
+		)
+		if t.Archived {
+			// This is a display task from the old task collection,
+			// we need to look their for its execution tasks.
+			execTasks, err = FindAllOld(db.Query(bson.M{
+				IdKey:        bson.M{"$in": t.ExecutionTasks},
+				ExecutionKey: t.Execution,
+			}))
+		} else {
+			execTasks, err = FindAll(ByIds(t.ExecutionTasks))
+		}
 		if err != nil {
 			return false
 		}
@@ -3186,13 +3204,12 @@ func (t *Task) hasCedarResults() bool {
 		for _, execTask := range execTasks {
 			if execTask.HasCedarResults {
 				// Attempt to update the display task's
-				// HasCedarResults field.
-				// We will not update the CedarResultsFailed
-				// field since we do want to iterate through
-				// all of the execution tasks and it isn't
-				// really needed for display tasks.
-				// Since we do not want to fail here, we can
-				// ignore the error.
+				// HasCedarResults field. We will not update
+				// the CedarResultsFailed field since we do
+				// want to iterate through all of the execution
+				// tasks and it isn't really needed for display
+				// tasks. Since we do not want to fail here, we
+				// can ignore the error.
 				_ = t.SetHasCedarResults(true, false)
 
 				return true

--- a/service/task.go
+++ b/service/task.go
@@ -177,7 +177,6 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 
 	executionStr := gimlet.GetVars(r)["execution"]
 	archived := false
-	taskId := projCtx.Task.Id
 
 	// if there is an execution number, the task might be in the old_tasks collection, so we
 	// query that collection and set projCtx.Task to the old task if it exists.
@@ -330,7 +329,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	testResults := uis.getTestResults(w, r, projCtx, &uiTask, taskId)
+	testResults := uis.getTestResults(w, r, projCtx, &uiTask)
 
 	if projCtx.Patch != nil {
 		var taskOnBaseCommit *task.Task
@@ -887,7 +886,7 @@ func (uis *UIServer) testLog(w http.ResponseWriter, r *http.Request) {
 	uis.render.Stream(w, http.StatusOK, data, "base", "task_log.html")
 }
 
-func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, projCtx projectContext, uiTask *uiTaskData, taskId string) []task.TestResult {
+func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, projCtx projectContext, uiTask *uiTaskData) []task.TestResult {
 	var err error
 	var testResults []task.TestResult
 
@@ -938,10 +937,9 @@ func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, proj
 		}
 	} else {
 		for _, tr := range projCtx.Context.Task.LocalTestResults {
-			tr.TaskID = taskId
 			uiTask.TestResults = append(uiTask.TestResults, uiTestResult{
 				TestResult: tr,
-				TaskId:     taskId,
+				TaskId:     tr.TaskID,
 			})
 		}
 		testResults = projCtx.Task.LocalTestResults


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14968

We need to use the correct task id (not the old task id) and execution when fetching test results from cedar for archived tasks. 