### PR TITLE
Revert "EVG-14823: Include display task ID upon execution task completion"

### DIFF
--- a/service/api_task.go
+++ b/service/api_task.go
@@ -310,20 +310,14 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		endTaskResp.ShouldExit = true
 	}
 
-	msg := message.Fields{
+	grip.Info(message.Fields{
 		"message":     "Successfully marked task as finished",
 		"task_id":     t.Id,
 		"execution":   t.Execution,
 		"operation":   "mark end",
 		"duration":    time.Since(finishTime),
 		"should_exit": endTaskResp.ShouldExit,
-	}
-
-	if t.IsPartOfDisplay() {
-		msg["display_task_id"] = t.DisplayTask.Id
-	}
-
-	grip.Info(msg)
+	})
 	gimlet.WriteJSON(w, endTaskResp)
 }
 

--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -132,10 +132,6 @@ func (j *collectTaskEndDataJob) Run(ctx context.Context) {
 		"version":              j.task.Version,
 	}
 
-	if j.task.IsPartOfDisplay() {
-		msg["display_task_id"] = j.task.DisplayTask.Id
-	}
-
 	pRef, err := model.FindOneProjectRef(j.task.Project)
 	if pRef != nil {
 		msg["project_identifier"] = pRef.Identifier


### PR DESCRIPTION
Reverts evergreen-ci/evergreen#4812 due to broken task test-service on Race Detector https://evergreen.mongodb.com/task/evergreen_race_detector_test_service_b8d7c2d5227d17bb9a7f1535c09e52b57a698ca7_21_07_08_18_36_59