### PR TITLE
EVG-14886: use default authorization server for Okta

### DIFF
--- a/auth/okta.go
+++ b/auth/okta.go
@@ -20,6 +20,7 @@ func NewOktaUserManager(conf *evergreen.OktaConfig, evgURL, loginDomain string) 
 		ClientSecret:         conf.ClientSecret,
 		RedirectURI:          strings.TrimRight(evgURL, "/") + "/login/redirect/callback",
 		Issuer:               conf.Issuer,
+		Scopes:               conf.Scopes,
 		UserGroup:            conf.UserGroup,
 		CookiePath:           "/",
 		CookieDomain:         loginDomain,

--- a/config_auth.go
+++ b/config_auth.go
@@ -62,11 +62,12 @@ type LDAPConfig struct {
 }
 
 type OktaConfig struct {
-	ClientID           string `bson:"client_id" json:"client_id" yaml:"client_id"`
-	ClientSecret       string `bson:"client_secret" json:"client_secret" yaml:"client_secret"`
-	Issuer             string `bson:"issuer" json:"issuer" yaml:"issuer"`
-	UserGroup          string `bson:"user_group" json:"user_group" yaml:"user_group"`
-	ExpireAfterMinutes int    `bson:"expire_after_minutes" json:"expire_after_minutes" yaml:"expire_after_minutes"`
+	ClientID           string   `bson:"client_id" json:"client_id" yaml:"client_id"`
+	ClientSecret       string   `bson:"client_secret" json:"client_secret" yaml:"client_secret"`
+	Issuer             string   `bson:"issuer" json:"issuer" yaml:"issuer"`
+	Scopes             []string `bson:"scopes" json:"scopes" yaml:"scopes"`
+	UserGroup          string   `bson:"user_group" json:"user_group" yaml:"user_group"`
+	ExpireAfterMinutes int      `bson:"expire_after_minutes" json:"expire_after_minutes" yaml:"expire_after_minutes"`
 }
 
 // GithubAuthConfig contains settings for interacting with Github Authentication

--- a/config_test.go
+++ b/config_test.go
@@ -293,6 +293,7 @@ func (s *AdminSuite) TestAuthConfig() {
 			ClientID:           "id",
 			ClientSecret:       "secret",
 			Issuer:             "issuer",
+			Scopes:             []string{"openid", "email", "profile", "offline_access"},
 			UserGroup:          "group",
 			ExpireAfterMinutes: 60,
 		},

--- a/glide.lock
+++ b/glide.lock
@@ -125,7 +125,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: 43815750c2f1d63d1f1de803a8a684ca79ac82d6
   - name: github.com/evergreen-ci/gimlet
-    version: 5fbd893c2d4d34fcbbd8e8e9c65810f41a955e66
+    version: 8dca136b41a0e843be10b96d639e8e706e9503ea
   - name: github.com/evergreen-ci/shrub
     version: 005df8abf87f20331677ecfaa19744efb99eb80b
   - name: github.com/evergreen-ci/pail

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -501,6 +501,41 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     return ($scope.validAuthKinds.indexOf(kind) < 0);
   }
 
+  $scope.addOktaScope = function () {
+    if ($scope.Settings.auth === null || $scope.Settings.auth === undefined) {
+      $scope.Settings.auth = {
+        "okta": {
+          "scopes": []
+        }
+      };
+    }
+    if ($scope.Settings.auth.okta === null || $scope.Settings.auth.okta === undefined) {
+      $scope.Settings.auth.okta = {
+        "scopes": []
+      };
+    }
+    if ($scope.Settings.auth.okta.scopes === null || $scope.Settings.auth.okta.scopes === undefined) {
+      $scope.Settings.auth.okta.scopes = [];
+    }
+
+    if (!$scope.validOktaScope($scope.new_okta_scope)) {
+      $scope.invalidScope = "Scope cannot be empty.";
+      return
+    }
+
+    $scope.Settings.auth.okta.scopes.push($scope.new_okta_scope);
+    $scope.new_okta_scope = "";
+    $scope.invalidOktaScope = "";
+  }
+
+  $scope.deleteOktaScope = function (index) {
+    $scope.Settings.auth.okta.scopes.splice(index, 1);
+  }
+
+  $scope.validOktaScope = function (scope) {
+    return scope;
+  }
+
   $scope.addExpansion = function (chip) {
     var obj = {};
     pieces = chip.split(":");

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -664,11 +664,12 @@ func (a *APILDAPConfig) ToService() (interface{}, error) {
 }
 
 type APIOktaConfig struct {
-	ClientID           *string `json:"client_id"`
-	ClientSecret       *string `json:"client_secret"`
-	Issuer             *string `json:"issuer"`
-	UserGroup          *string `json:"user_group"`
-	ExpireAfterMinutes int     `json:"expire_after_minutes"`
+	ClientID           *string  `json:"client_id"`
+	ClientSecret       *string  `json:"client_secret"`
+	Issuer             *string  `json:"issuer"`
+	Scopes             []string `json:"scopes"`
+	UserGroup          *string  `json:"user_group"`
+	ExpireAfterMinutes int      `json:"expire_after_minutes"`
 }
 
 func (a *APIOktaConfig) BuildFromService(h interface{}) error {
@@ -680,6 +681,7 @@ func (a *APIOktaConfig) BuildFromService(h interface{}) error {
 		a.ClientID = utility.ToStringPtr(v.ClientID)
 		a.ClientSecret = utility.ToStringPtr(v.ClientSecret)
 		a.Issuer = utility.ToStringPtr(v.Issuer)
+		a.Scopes = v.Scopes
 		a.UserGroup = utility.ToStringPtr(v.UserGroup)
 		a.ExpireAfterMinutes = v.ExpireAfterMinutes
 		return nil
@@ -696,6 +698,7 @@ func (a *APIOktaConfig) ToService() (interface{}, error) {
 		ClientID:           utility.FromStringPtr(a.ClientID),
 		ClientSecret:       utility.FromStringPtr(a.ClientSecret),
 		Issuer:             utility.FromStringPtr(a.Issuer),
+		Scopes:             a.Scopes,
 		UserGroup:          utility.FromStringPtr(a.UserGroup),
 		ExpireAfterMinutes: a.ExpireAfterMinutes,
 	}, nil

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -939,6 +939,42 @@ Admin Settings
 										<label>Issuer</label>
 										<input type="text" ng-model="Settings.auth.okta.issuer">
 									</md-input-container>
+									<md-card style="margin-bottom:20px;">
+										<md-card-title>
+											<md-card-title-text>
+												<span>Scopes</span>
+											</md-card-title-text>
+										</md-card-title>
+										<md-card-content>
+											<div id="okta-scopes-list" class="form-group"
+												ng-repeat="(index, scope) in Settings.auth.okta.scopes">
+												<section layout="row" flex>
+													<md-input-container class="control" flex=25>
+														<input class="control" type="text" ng-model="scope" placeholder="Scope Name">
+													</md-input-container>
+													<div style="margin-top: 1%;">
+														<button class="btn btn-default btn-danger" type="button"
+															style="float: left" ng-click="deleteOktaScope(index)">
+															<i class="fa fa-trash"></i>
+														</button>
+													</div>
+												</section>
+											</div>
+											<section layout="row" flex>
+												<md-input-container class="control" flex=25>
+													<input class="control" type="text" ng-model="new_okta_scope" placeholder="Scope Name">
+												</md-input-container>
+												<div style="margin-top: 1%;">
+													<button class="plus-button btn btn-primary"
+														ng-disabled="!validOktaScope(new_okta_scope)" type="button"
+														style="float: left" ng-click="addOktaScope()">
+														<i class="fa fa-plus"></i>
+													</button>
+													<label class="control">[[ invalidOktaScope ]]</label>
+												</div>
+											</section>
+										</md-card-content>
+									</md-card>
 									<md-input-container class="control" style="width:45%;">
 										<label>User Group</label>
 										<input type="text" ng-model="Settings.auth.okta.user_group">

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -133,6 +133,7 @@ func MockConfig() *evergreen.Settings {
 				ClientID:           "id",
 				ClientSecret:       "secret",
 				Issuer:             "issuer",
+				Scopes:             []string{"openid", "email", "profile", "offline_access"},
 				UserGroup:          "group",
 				ExpireAfterMinutes: 60,
 			},


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14886

### Description 
* Revendor Gimlet for Okta authorization server switch.
* Create admin setting for the Okta scopes to request when authorizing the user and pass the scopes to Okta.

Since we're switching to a new authorization server, all the current tokens that we're using to maintain user sessions will be invalid after cutting over. I'll coordinate a time and email for merging this PR, switching over, and logging everyone out once this is approved.

### Testing 
I tested the admin settings in local Evergreen. I also verified that I can log into Evergreen through the new Okta authorization server after logging out.