### PR TITLE
EVG-14853: Add TaskStatusCounts field to Version resolver

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -551,6 +551,11 @@ type ComplexityRoot struct {
 		Ui          func(childComplexity int) int
 	}
 
+	StatusCount struct {
+		Count  func(childComplexity int) int
+		Status func(childComplexity int) int
+	}
+
 	Task struct {
 		AbortInfo               func(childComplexity int) int
 		Aborted                 func(childComplexity int) int
@@ -778,21 +783,22 @@ type ComplexityRoot struct {
 	}
 
 	Version struct {
-		Activated     func(childComplexity int) int
-		Author        func(childComplexity int) int
-		Branch        func(childComplexity int) int
-		BuildVariants func(childComplexity int, options *BuildVariantOptions) int
-		CreateTime    func(childComplexity int) int
-		FinishTime    func(childComplexity int) int
-		Id            func(childComplexity int) int
-		Message       func(childComplexity int) int
-		Order         func(childComplexity int) int
-		Project       func(childComplexity int) int
-		Repo          func(childComplexity int) int
-		Requester     func(childComplexity int) int
-		Revision      func(childComplexity int) int
-		StartTime     func(childComplexity int) int
-		Status        func(childComplexity int) int
+		Activated        func(childComplexity int) int
+		Author           func(childComplexity int) int
+		Branch           func(childComplexity int) int
+		BuildVariants    func(childComplexity int, options *BuildVariantOptions) int
+		CreateTime       func(childComplexity int) int
+		FinishTime       func(childComplexity int) int
+		Id               func(childComplexity int) int
+		Message          func(childComplexity int) int
+		Order            func(childComplexity int) int
+		Project          func(childComplexity int) int
+		Repo             func(childComplexity int) int
+		Requester        func(childComplexity int) int
+		Revision         func(childComplexity int) int
+		StartTime        func(childComplexity int) int
+		Status           func(childComplexity int) int
+		TaskStatusCounts func(childComplexity int) int
 	}
 
 	Volume struct {
@@ -978,6 +984,7 @@ type UserResolver interface {
 	Patches(ctx context.Context, obj *model.APIDBUser, patchesInput PatchesInput) (*Patches, error)
 }
 type VersionResolver interface {
+	TaskStatusCounts(ctx context.Context, obj *model.APIVersion) ([]*StatusCount, error)
 	BuildVariants(ctx context.Context, obj *model.APIVersion, options *BuildVariantOptions) ([]*GroupedBuildVariant, error)
 }
 type VolumeResolver interface {
@@ -3479,6 +3486,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SpruceConfig.Ui(childComplexity), true
 
+	case "StatusCount.count":
+		if e.complexity.StatusCount.Count == nil {
+			break
+		}
+
+		return e.complexity.StatusCount.Count(childComplexity), true
+
+	case "StatusCount.status":
+		if e.complexity.StatusCount.Status == nil {
+			break
+		}
+
+		return e.complexity.StatusCount.Status(childComplexity), true
+
 	case "Task.abortInfo":
 		if e.complexity.Task.AbortInfo == nil {
 			break
@@ -4735,6 +4756,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Version.Status(childComplexity), true
 
+	case "Version.taskStatusCounts":
+		if e.complexity.Version.TaskStatusCounts == nil {
+			break
+		}
+
+		return e.complexity.Version.TaskStatusCounts(childComplexity), true
+
 	case "Volume.availabilityZone":
 		if e.complexity.Volume.AvailabilityZone == nil {
 			break
@@ -5056,7 +5084,12 @@ type Version {
   branch: String!
   requester: String!
   activated: Boolean
+  taskStatusCounts: [StatusCount!]
   buildVariants(options: BuildVariantOptions): [GroupedBuildVariant]
+}
+type StatusCount {
+  status: String!
+  count: Int!
 }
 
 input BuildVariantOptions {
@@ -18073,6 +18106,74 @@ func (ec *executionContext) _SpruceConfig_spawnHost(ctx context.Context, field g
 	return ec.marshalNSpawnHostConfig2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPISpawnHostConfig(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _StatusCount_status(ctx context.Context, field graphql.CollectedField, obj *StatusCount) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "StatusCount",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _StatusCount_count(ctx context.Context, field graphql.CollectedField, obj *StatusCount) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "StatusCount",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Count, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Task_aborted(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -23843,6 +23944,37 @@ func (ec *executionContext) _Version_activated(ctx context.Context, field graphq
 	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Version_taskStatusCounts(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Version",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Version().TaskStatusCounts(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*StatusCount)
+	fc.Result = res
+	return ec.marshalOStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐStatusCountᚄ(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Version_buildVariants(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -29223,6 +29355,38 @@ func (ec *executionContext) _SpruceConfig(ctx context.Context, sel ast.Selection
 	return out
 }
 
+var statusCountImplementors = []string{"StatusCount"}
+
+func (ec *executionContext) _StatusCount(ctx context.Context, sel ast.SelectionSet, obj *StatusCount) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, statusCountImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("StatusCount")
+		case "status":
+			out.Values[i] = ec._StatusCount_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "count":
+			out.Values[i] = ec._StatusCount_count(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var taskImplementors = []string{"Task"}
 
 func (ec *executionContext) _Task(ctx context.Context, sel ast.SelectionSet, obj *model.APITask) graphql.Marshaler {
@@ -30614,6 +30778,17 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "activated":
 			out.Values[i] = ec._Version_activated(ctx, field, obj)
+		case "taskStatusCounts":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Version_taskStatusCounts(ctx, field, obj)
+				return res
+			})
 		case "buildVariants":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -32357,6 +32532,20 @@ func (ec *executionContext) marshalNSpawnHostStatusActions2githubᚗcomᚋevergr
 
 func (ec *executionContext) unmarshalNSpawnVolumeInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSpawnVolumeInput(ctx context.Context, v interface{}) (SpawnVolumeInput, error) {
 	return ec.unmarshalInputSpawnVolumeInput(ctx, v)
+}
+
+func (ec *executionContext) marshalNStatusCount2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐStatusCount(ctx context.Context, sel ast.SelectionSet, v StatusCount) graphql.Marshaler {
+	return ec._StatusCount(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐStatusCount(ctx context.Context, sel ast.SelectionSet, v *StatusCount) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._StatusCount(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {
@@ -34126,6 +34315,46 @@ func (ec *executionContext) marshalOSpruceConfig2ᚖgithubᚗcomᚋevergreenᚑc
 		return graphql.Null
 	}
 	return ec._SpruceConfig(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐStatusCountᚄ(ctx context.Context, sel ast.SelectionSet, v []*StatusCount) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐStatusCount(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
 }
 
 func (ec *executionContext) unmarshalOString2string(ctx context.Context, v interface{}) (string, error) {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -208,6 +208,11 @@ type SpawnVolumeInput struct {
 	Host             *string    `json:"host"`
 }
 
+type StatusCount struct {
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+}
+
 type TaskFiles struct {
 	FileCount    int             `json:"fileCount"`
 	GroupedFiles []*GroupedFiles `json:"groupedFiles"`

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2690,6 +2690,34 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 
 type versionResolver struct{ *Resolver }
 
+// Returns task status counts (a mapping between status and the number of tasks with that status) for a version.
+func (r *versionResolver) TaskStatusCounts(ctx context.Context, v *restModel.APIVersion) ([]*StatusCount, error) {
+	tasks, _, err := r.sc.FindTasksByVersion(*v.Id, data.TaskFilterOptions{})
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error fetching tasks for version %s : %s", *v.Id, err.Error()))
+	}
+
+	statusCountsMap := map[string]int{}
+	for _, task := range tasks {
+		if val, exist := statusCountsMap[task.GetDisplayStatus()]; exist {
+			statusCountsMap[task.GetDisplayStatus()] = val + 1
+		} else {
+			statusCountsMap[task.GetDisplayStatus()] = 1
+		}
+	}
+
+	statusCountsArr := []*StatusCount{}
+	for statusName, statusCount := range statusCountsMap {
+		sc := StatusCount{
+			Status: statusName,
+			Count:  statusCount,
+		}
+		statusCountsArr = append(statusCountsArr, &sc)
+	}
+
+	return statusCountsArr, nil
+}
+
 // Returns grouped build variants for a version. Will not return build variants for unactivated versions
 func (r *versionResolver) BuildVariants(ctx context.Context, v *restModel.APIVersion, options *BuildVariantOptions) ([]*GroupedBuildVariant, error) {
 	// If activated is nil in the db we should resolve it and cache it for subsequent queries. There is a very low likely hood of this field being hit

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -164,7 +164,12 @@ type Version {
   branch: String!
   requester: String!
   activated: Boolean
+  taskStatusCounts: [StatusCount!]
   buildVariants(options: BuildVariantOptions): [GroupedBuildVariant]
+}
+type StatusCount {
+  status: String!
+  count: Int!
 }
 
 input BuildVariantOptions {

--- a/graphql/tests/mainlineCommits/queries/commit-taskStatusCounts.graphql
+++ b/graphql/tests/mainlineCommits/queries/commit-taskStatusCounts.graphql
@@ -1,0 +1,20 @@
+{
+  mainlineCommits(options: { projectID: "evergreen" }) {
+    versions {
+      version {
+        id
+        taskStatusCounts {
+          status
+          count
+        }
+      }
+      rolledUpVersions {
+        id
+        taskStatusCounts {
+          status
+          count
+        }
+      }
+    }
+  }
+}

--- a/graphql/tests/mainlineCommits/results.json
+++ b/graphql/tests/mainlineCommits/results.json
@@ -335,11 +335,11 @@
                            "id": "evergreen_version2",
                            "taskStatusCounts": [
                               {
-                                 "status": "success",
+                                 "status": "failed",
                                  "count": 1
                               },
                               {
-                                 "status": "failed",
+                                 "status": "success",
                                  "count": 1
                               }
                            ]

--- a/graphql/tests/mainlineCommits/results.json
+++ b/graphql/tests/mainlineCommits/results.json
@@ -1,367 +1,367 @@
 {
-  "tests": [
-    {
-      "query_file": "no-filters.graphql",
-      "result": {
-        "data": {
-          "mainlineCommits": {
-            "versions": [
-              {
-                "version": {
-                  "id": "evergreen_version5",
-                  "author": "mohamed.khelif",
-                  "buildVariants": [
-                    {
-                      "variant": "enterprise-ubuntu1604-64",
-                      "displayName": "Ubuntu 16.04",
-                      "tasks": [
-                        {
-                          "id": "task_5",
-                          "displayName": "Some Other Task",
-                          "status": "success"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "rolledUpVersions": null
-              },
-              {
-                "version": null,
-                "rolledUpVersions": [
-                  {
-                    "id": "evergreen_version4",
-                    "activated": false
-                  },
-                  {
-                    "id": "evergreen_version3",
-                    "activated": false
-                  }
-                ]
-              },
-              {
-                "version": {
-                  "id": "evergreen_version2",
-                  "author": "mohamed.khelif",
-                  "buildVariants": [
-                    {
-                      "variant": "enterprise-ubuntu1604-64",
-                      "displayName": "Ubuntu 16.04",
-                      "tasks": [
-                        {
-                          "id": "task_4",
-                          "displayName": "Some Other Task",
-                          "status": "success"
+   "tests": [
+      {
+         "query_file": "no-filters.graphql",
+         "result": {
+            "data": {
+               "mainlineCommits": {
+                  "versions": [
+                     {
+                        "version": {
+                           "id": "evergreen_version5",
+                           "author": "mohamed.khelif",
+                           "buildVariants": [
+                              {
+                                 "variant": "enterprise-ubuntu1604-64",
+                                 "displayName": "Ubuntu 16.04",
+                                 "tasks": [
+                                    {
+                                       "id": "task_5",
+                                       "displayName": "Some Other Task",
+                                       "status": "success"
+                                    }
+                                 ]
+                              }
+                           ]
                         },
-                        {
-                          "id": "task_3",
-                          "displayName": "Some Task",
-                          "status": "failed"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "rolledUpVersions": null
-              },
-              {
-                "version": {
-                  "id": "evergreen_version1",
-                  "author": "mohamed.khelif",
-                  "buildVariants": [
-                    {
-                      "variant": "enterprise-ubuntu1604-64",
-                      "displayName": "Ubuntu 16.04",
-                      "tasks": [
-                        {
-                          "id": "task_2",
-                          "displayName": "Some Other Task",
-                          "status": "success"
+                        "rolledUpVersions": null
+                     },
+                     {
+                        "version": null,
+                        "rolledUpVersions": [
+                           {
+                              "id": "evergreen_version4",
+                              "activated": false
+                           },
+                           {
+                              "id": "evergreen_version3",
+                              "activated": false
+                           }
+                        ]
+                     },
+                     {
+                        "version": {
+                           "id": "evergreen_version2",
+                           "author": "mohamed.khelif",
+                           "buildVariants": [
+                              {
+                                 "variant": "enterprise-ubuntu1604-64",
+                                 "displayName": "Ubuntu 16.04",
+                                 "tasks": [
+                                    {
+                                       "id": "task_4",
+                                       "displayName": "Some Other Task",
+                                       "status": "success"
+                                    },
+                                    {
+                                       "id": "task_3",
+                                       "displayName": "Some Task",
+                                       "status": "failed"
+                                    }
+                                 ]
+                              }
+                           ]
                         },
-                        {
-                          "id": "task_1",
-                          "displayName": "Some Task",
-                          "status": "success"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "rolledUpVersions": null
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "query_file": "task-filter.graphql",
-      "result": {
-        "data": {
-          "mainlineCommits": {
-            "versions": [
-              {
-                "version": {
-                  "id": "evergreen_version5",
-                  "author": "mohamed.khelif",
-                  "buildVariants": []
-                },
-                "rolledUpVersions": null
-              },
-              {
-                "version": null,
-                "rolledUpVersions": [
-                  {
-                    "id": "evergreen_version4",
-                    "activated": false
-                  },
-                  {
-                    "id": "evergreen_version3",
-                    "activated": false
-                  }
-                ]
-              },
-              {
-                "version": {
-                  "id": "evergreen_version2",
-                  "author": "mohamed.khelif",
-                  "buildVariants": [
-                    {
-                      "variant": "enterprise-ubuntu1604-64",
-                      "displayName": "Ubuntu 16.04",
-                      "tasks": [
-                        {
-                          "id": "task_3",
-                          "displayName": "Some Task",
-                          "status": "failed"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "rolledUpVersions": null
-              },
-              {
-                "version": {
-                  "id": "evergreen_version1",
-                  "author": "mohamed.khelif",
-                  "buildVariants": [
-                    {
-                      "variant": "enterprise-ubuntu1604-64",
-                      "displayName": "Ubuntu 16.04",
-                      "tasks": [
-                        {
-                          "id": "task_1",
-                          "displayName": "Some Task",
-                          "status": "success"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "rolledUpVersions": null
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "query_file": "status-filter.graphql",
-      "result": {
-        "data": {
-          "mainlineCommits": {
-            "versions": [
-              {
-                "version": {
-                  "id": "evergreen_version5",
-                  "author": "mohamed.khelif",
-                  "buildVariants": []
-                },
-                "rolledUpVersions": null
-              },
-              {
-                "version": null,
-                "rolledUpVersions": [
-                  {
-                    "id": "evergreen_version4",
-                    "activated": false
-                  },
-                  {
-                    "id": "evergreen_version3",
-                    "activated": false
-                  }
-                ]
-              },
-              {
-                "version": {
-                  "id": "evergreen_version2",
-                  "author": "mohamed.khelif",
-                  "buildVariants": [
-                    {
-                      "variant": "enterprise-ubuntu1604-64",
-                      "displayName": "Ubuntu 16.04",
-                      "tasks": [
-                        {
-                          "id": "task_3",
-                          "displayName": "Some Task",
-                          "status": "failed"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "rolledUpVersions": null
-              },
-              {
-                "version": {
-                  "id": "evergreen_version1",
-                  "author": "mohamed.khelif",
-                  "buildVariants": []
-                },
-                "rolledUpVersions": null
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "query_file": "pagination.graphql",
-      "result": {
-        "data": {
-          "page1": {
-            "versions": [
-              {
-                "version": {
-                  "id": "evergreen_version5",
-                  "author": "mohamed.khelif",
-                  "buildVariants": [
-                    {
-                      "variant": "enterprise-ubuntu1604-64",
-                      "displayName": "Ubuntu 16.04",
-                      "tasks": [
-                        {
-                          "id": "task_5",
-                          "displayName": "Some Other Task",
-                          "status": "success"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "rolledUpVersions": null
-              }
-            ]
-          },
-          "page2": {
-            "versions": [
-              {
-                "version": null,
-                "rolledUpVersions": [
-                  {
-                    "id": "evergreen_version4",
-                    "activated": false
-                  },
-                  {
-                    "id": "evergreen_version3",
-                    "activated": false
-                  }
-                ]
-              },
-              {
-                "version": {
-                  "id": "evergreen_version2",
-                  "author": "mohamed.khelif",
-                  "buildVariants": [
-                    {
-                      "variant": "enterprise-ubuntu1604-64",
-                      "displayName": "Ubuntu 16.04",
-                      "tasks": [
-                        {
-                          "id": "task_4",
-                          "displayName": "Some Other Task",
-                          "status": "success"
+                        "rolledUpVersions": null
+                     },
+                     {
+                        "version": {
+                           "id": "evergreen_version1",
+                           "author": "mohamed.khelif",
+                           "buildVariants": [
+                              {
+                                 "variant": "enterprise-ubuntu1604-64",
+                                 "displayName": "Ubuntu 16.04",
+                                 "tasks": [
+                                    {
+                                       "id": "task_2",
+                                       "displayName": "Some Other Task",
+                                       "status": "success"
+                                    },
+                                    {
+                                       "id": "task_1",
+                                       "displayName": "Some Task",
+                                       "status": "success"
+                                    }
+                                 ]
+                              }
+                           ]
                         },
-                        {
-                          "id": "task_3",
-                          "displayName": "Some Task",
-                          "status": "failed"
-                        }
-                      ]
-                    }
+                        "rolledUpVersions": null
+                     }
                   ]
-                },
-                "rolledUpVersions": null
-              }
-            ]
-          }
-        }
+               }
+            }
+         }
+      },
+      {
+         "query_file": "task-filter.graphql",
+         "result": {
+            "data": {
+               "mainlineCommits": {
+                  "versions": [
+                     {
+                        "version": {
+                           "id": "evergreen_version5",
+                           "author": "mohamed.khelif",
+                           "buildVariants": []
+                        },
+                        "rolledUpVersions": null
+                     },
+                     {
+                        "version": null,
+                        "rolledUpVersions": [
+                           {
+                              "id": "evergreen_version4",
+                              "activated": false
+                           },
+                           {
+                              "id": "evergreen_version3",
+                              "activated": false
+                           }
+                        ]
+                     },
+                     {
+                        "version": {
+                           "id": "evergreen_version2",
+                           "author": "mohamed.khelif",
+                           "buildVariants": [
+                              {
+                                 "variant": "enterprise-ubuntu1604-64",
+                                 "displayName": "Ubuntu 16.04",
+                                 "tasks": [
+                                    {
+                                       "id": "task_3",
+                                       "displayName": "Some Task",
+                                       "status": "failed"
+                                    }
+                                 ]
+                              }
+                           ]
+                        },
+                        "rolledUpVersions": null
+                     },
+                     {
+                        "version": {
+                           "id": "evergreen_version1",
+                           "author": "mohamed.khelif",
+                           "buildVariants": [
+                              {
+                                 "variant": "enterprise-ubuntu1604-64",
+                                 "displayName": "Ubuntu 16.04",
+                                 "tasks": [
+                                    {
+                                       "id": "task_1",
+                                       "displayName": "Some Task",
+                                       "status": "success"
+                                    }
+                                 ]
+                              }
+                           ]
+                        },
+                        "rolledUpVersions": null
+                     }
+                  ]
+               }
+            }
+         }
+      },
+      {
+         "query_file": "status-filter.graphql",
+         "result": {
+            "data": {
+               "mainlineCommits": {
+                  "versions": [
+                     {
+                        "version": {
+                           "id": "evergreen_version5",
+                           "author": "mohamed.khelif",
+                           "buildVariants": []
+                        },
+                        "rolledUpVersions": null
+                     },
+                     {
+                        "version": null,
+                        "rolledUpVersions": [
+                           {
+                              "id": "evergreen_version4",
+                              "activated": false
+                           },
+                           {
+                              "id": "evergreen_version3",
+                              "activated": false
+                           }
+                        ]
+                     },
+                     {
+                        "version": {
+                           "id": "evergreen_version2",
+                           "author": "mohamed.khelif",
+                           "buildVariants": [
+                              {
+                                 "variant": "enterprise-ubuntu1604-64",
+                                 "displayName": "Ubuntu 16.04",
+                                 "tasks": [
+                                    {
+                                       "id": "task_3",
+                                       "displayName": "Some Task",
+                                       "status": "failed"
+                                    }
+                                 ]
+                              }
+                           ]
+                        },
+                        "rolledUpVersions": null
+                     },
+                     {
+                        "version": {
+                           "id": "evergreen_version1",
+                           "author": "mohamed.khelif",
+                           "buildVariants": []
+                        },
+                        "rolledUpVersions": null
+                     }
+                  ]
+               }
+            }
+         }
+      },
+      {
+         "query_file": "pagination.graphql",
+         "result": {
+            "data": {
+               "page1": {
+                  "versions": [
+                     {
+                        "version": {
+                           "id": "evergreen_version5",
+                           "author": "mohamed.khelif",
+                           "buildVariants": [
+                              {
+                                 "variant": "enterprise-ubuntu1604-64",
+                                 "displayName": "Ubuntu 16.04",
+                                 "tasks": [
+                                    {
+                                       "id": "task_5",
+                                       "displayName": "Some Other Task",
+                                       "status": "success"
+                                    }
+                                 ]
+                              }
+                           ]
+                        },
+                        "rolledUpVersions": null
+                     }
+                  ]
+               },
+               "page2": {
+                  "versions": [
+                     {
+                        "version": null,
+                        "rolledUpVersions": [
+                           {
+                              "id": "evergreen_version4",
+                              "activated": false
+                           },
+                           {
+                              "id": "evergreen_version3",
+                              "activated": false
+                           }
+                        ]
+                     },
+                     {
+                        "version": {
+                           "id": "evergreen_version2",
+                           "author": "mohamed.khelif",
+                           "buildVariants": [
+                              {
+                                 "variant": "enterprise-ubuntu1604-64",
+                                 "displayName": "Ubuntu 16.04",
+                                 "tasks": [
+                                    {
+                                       "id": "task_4",
+                                       "displayName": "Some Other Task",
+                                       "status": "success"
+                                    },
+                                    {
+                                       "id": "task_3",
+                                       "displayName": "Some Task",
+                                       "status": "failed"
+                                    }
+                                 ]
+                              }
+                           ]
+                        },
+                        "rolledUpVersions": null
+                     }
+                  ]
+               }
+            }
+         }
+      },
+      {
+         "query_file": "commit-taskStatusCounts.graphql",
+         "result": {
+            "data": {
+               "mainlineCommits": {
+                  "versions": [
+                     {
+                        "version": {
+                           "id": "evergreen_version5",
+                           "taskStatusCounts": [
+                              {
+                                 "status": "success",
+                                 "count": 1
+                              }
+                           ]
+                        },
+                        "rolledUpVersions": null
+                     },
+                     {
+                        "version": null,
+                        "rolledUpVersions": [
+                           {
+                              "id": "evergreen_version4",
+                              "taskStatusCounts": []
+                           },
+                           {
+                              "id": "evergreen_version3",
+                              "taskStatusCounts": []
+                           }
+                        ]
+                     },
+                     {
+                        "version": {
+                           "id": "evergreen_version2",
+                           "taskStatusCounts": [
+                              {
+                                 "status": "success",
+                                 "count": 1
+                              },
+                              {
+                                 "status": "failed",
+                                 "count": 1
+                              }
+                           ]
+                        },
+                        "rolledUpVersions": null
+                     },
+                     {
+                        "version": {
+                           "id": "evergreen_version1",
+                           "taskStatusCounts": [
+                              {
+                                 "status": "success",
+                                 "count": 2
+                              }
+                           ]
+                        },
+                        "rolledUpVersions": null
+                     }
+                  ]
+               }
+            }
+         }
       }
-    },
-    {
-      "query_file": "commit-taskStatusCounts.graphql",
-      "result": {
-        "data": {
-          "mainlineCommits": {
-            "versions": [
-              {
-                "version": {
-                  "id": "evergreen_version5",
-                  "taskStatusCounts": [
-                    {
-                      "status": "success",
-                      "count": 1
-                    }
-                  ]
-                },
-                "rolledUpVersions": null
-              },
-              {
-                "version": null,
-                "rolledUpVersions": [
-                  {
-                    "id": "evergreen_version4",
-                    "taskStatusCounts": []
-                  },
-                  {
-                    "id": "evergreen_version3",
-                    "taskStatusCounts": []
-                  }
-                ]
-              },
-              {
-                "version": {
-                  "id": "evergreen_version2",
-                  "taskStatusCounts": [
-                    {
-                      "status": "success",
-                      "count": 1
-                    },
-                    {
-                      "status": "failed",
-                      "count": 1
-                    }
-                  ]
-                },
-                "rolledUpVersions": null
-              },
-              {
-                "version": {
-                  "id": "evergreen_version1",
-                  "taskStatusCounts": [
-                    {
-                      "status": "success",
-                      "count": 2
-                    }
-                  ]
-                },
-                "rolledUpVersions": null
-              }
-            ]
-          }
-        }
-      }
-    }
-  ]
+   ]
 }

--- a/graphql/tests/mainlineCommits/results.json
+++ b/graphql/tests/mainlineCommits/results.json
@@ -1,307 +1,367 @@
 {
-   "tests":[
-      {
-         "query_file":"no-filters.graphql",
-         "result":{
-            "data":{
-               "mainlineCommits":{
-                  "versions":[
-                     {
-                        "version": {
-                           "id": "evergreen_version5",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                              {
-                                 "variant": "enterprise-ubuntu1604-64",
-                                 "displayName":"Ubuntu 16.04",
-                                 "tasks": [
-                                    {
-                                       "id": "task_5",
-                                       "displayName": "Some Other Task",
-                                       "status": "success"
-                                    }
-                                 ]
-                              }
-                           ]
-                        },
-                        "rolledUpVersions": null
-                     },
-                     {
-                        "version":null,
-                        "rolledUpVersions":[
-                           {
-                              "id": "evergreen_version4",
-                              "activated": false
-                           },
-                           {
-                              "id":"evergreen_version3",
-                              "activated":false
-                           }
-                        ]
-                     },
-                     {
-                        "version":{
-                           "id":"evergreen_version2",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                              {
-                                 "variant":"enterprise-ubuntu1604-64",
-                                 "displayName":"Ubuntu 16.04",
-                                 "tasks":[
-                                    {
-                                       "id":"task_4",
-                                       "displayName":"Some Other Task",
-                                       "status":"success"
-                                    },
-                                    {
-                                       "id":"task_3",
-                                       "displayName":"Some Task",
-                                       "status":"failed"
-                                    }
-                                 ]
-                              }
-                           ]
-                        },
-                        "rolledUpVersions":null
-                     },
-                     {
-                        "version":{
-                           "id":"evergreen_version1",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                              {
-                                 "variant":"enterprise-ubuntu1604-64",
-                                 "displayName":"Ubuntu 16.04",
-                                 "tasks":[
-                                    {
-                                       "id":"task_2",
-                                       "displayName":"Some Other Task",
-                                       "status":"success"
-                                    },
-                                    {
-                                       "id":"task_1",
-                                       "displayName":"Some Task",
-                                       "status":"success"
-                                    }
-                                 ]
-                              }
-                           ]
-                        },
-                        "rolledUpVersions":null
-                     }
+  "tests": [
+    {
+      "query_file": "no-filters.graphql",
+      "result": {
+        "data": {
+          "mainlineCommits": {
+            "versions": [
+              {
+                "version": {
+                  "id": "evergreen_version5",
+                  "author": "mohamed.khelif",
+                  "buildVariants": [
+                    {
+                      "variant": "enterprise-ubuntu1604-64",
+                      "displayName": "Ubuntu 16.04",
+                      "tasks": [
+                        {
+                          "id": "task_5",
+                          "displayName": "Some Other Task",
+                          "status": "success"
+                        }
+                      ]
+                    }
                   ]
-               }
-            }
-         }
-      },
-      {
-         "query_file":"task-filter.graphql",
-         "result":{
-            "data":{
-               "mainlineCommits":{
-                  "versions":[
-                                          {
-                        "version": {
-                           "id": "evergreen_version5",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                           ]
+                },
+                "rolledUpVersions": null
+              },
+              {
+                "version": null,
+                "rolledUpVersions": [
+                  {
+                    "id": "evergreen_version4",
+                    "activated": false
+                  },
+                  {
+                    "id": "evergreen_version3",
+                    "activated": false
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "id": "evergreen_version2",
+                  "author": "mohamed.khelif",
+                  "buildVariants": [
+                    {
+                      "variant": "enterprise-ubuntu1604-64",
+                      "displayName": "Ubuntu 16.04",
+                      "tasks": [
+                        {
+                          "id": "task_4",
+                          "displayName": "Some Other Task",
+                          "status": "success"
                         },
-                        "rolledUpVersions": null
-                     },                     
-                     {
-                        "version":null,
-                        "rolledUpVersions":[
-                           {
-                              "id": "evergreen_version4",
-                              "activated": false
-                           },
-                           {
-                              "id":"evergreen_version3",
-                              "activated":false
-                           }
-                        ]
-                     },
-                     {
-                        "version":{
-                           "id":"evergreen_version2",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                              {
-                                 "variant":"enterprise-ubuntu1604-64",
-                                 "displayName":"Ubuntu 16.04",
-                                 "tasks":[
-                                    {
-                                       "id":"task_3",
-                                       "displayName":"Some Task",
-                                       "status":"failed"
-                                    }
-                                 ]
-                              }
-                           ]
-                        },
-                        "rolledUpVersions":null
-                     },
-                     {
-                        "version":{
-                           "id":"evergreen_version1",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                              {
-                                 "variant":"enterprise-ubuntu1604-64",
-                                 "displayName":"Ubuntu 16.04",
-                                 "tasks":[
-                                    {
-                                       "id":"task_1",
-                                       "displayName":"Some Task",
-                                       "status":"success"
-                                    }
-                                 ]
-                              }
-                           ]
-                        },
-                        "rolledUpVersions":null
-                     }
+                        {
+                          "id": "task_3",
+                          "displayName": "Some Task",
+                          "status": "failed"
+                        }
+                      ]
+                    }
                   ]
-               }
-            }
-         }
-      },
-      {
-         "query_file":"status-filter.graphql",
-         "result":{
-            "data":{
-               "mainlineCommits":{
-                  "versions":[
-                                                               {
-                        "version": {
-                           "id": "evergreen_version5",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                           ]
+                },
+                "rolledUpVersions": null
+              },
+              {
+                "version": {
+                  "id": "evergreen_version1",
+                  "author": "mohamed.khelif",
+                  "buildVariants": [
+                    {
+                      "variant": "enterprise-ubuntu1604-64",
+                      "displayName": "Ubuntu 16.04",
+                      "tasks": [
+                        {
+                          "id": "task_2",
+                          "displayName": "Some Other Task",
+                          "status": "success"
                         },
-                        "rolledUpVersions": null
-                     },                     
-                     {
-                        "version":null,
-                        "rolledUpVersions":[
-                           {
-                              "id": "evergreen_version4",
-                              "activated": false
-                           },
-                           {
-                              "id":"evergreen_version3",
-                              "activated":false
-                           }
-                        ]
-                     },
-                     {
-                        "version":{
-                           "id":"evergreen_version2",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                              {
-                                 "variant":"enterprise-ubuntu1604-64",
-                                 "displayName":"Ubuntu 16.04",
-                                 "tasks":[
-                                    {
-                                       "id":"task_3",
-                                       "displayName":"Some Task",
-                                       "status":"failed"
-                                    }
-                                 ]
-                              }
-                           ]
-                        },
-                        "rolledUpVersions":null
-                     },
-                     {
-                        "version":{
-                           "id":"evergreen_version1",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                              
-                           ]
-                        },
-                        "rolledUpVersions":null
-                     }
+                        {
+                          "id": "task_1",
+                          "displayName": "Some Task",
+                          "status": "success"
+                        }
+                      ]
+                    }
                   ]
-               }
-            }
-         }
-      },
-      {
-         "query_file":"pagination.graphql",
-         "result":{
-            "data":{
-               "page1":{
-                  "versions":[
-                                                               {
-                        "version": {
-                           "id": "evergreen_version5",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                              {
-                                 "variant": "enterprise-ubuntu1604-64",
-                                 "displayName":"Ubuntu 16.04",
-                                 "tasks": [
-                                    {
-                                       "id": "task_5",
-                                       "displayName": "Some Other Task",
-                                       "status": "success"
-                                    }
-                                 ]
-                              }
-                           ]
-                        },
-                        "rolledUpVersions": null
-                     }
-                  ]
-               },
-               "page2":{
-                  "versions":[
-                                          {
-                        "version":null,
-                        "rolledUpVersions":[
-                           {
-                              "id": "evergreen_version4",
-                              "activated": false
-                           },
-                           {
-                              "id":"evergreen_version3",
-                              "activated":false
-                           }
-                        ]
-                     },
-                     {
-                        "version":{
-                           "id":"evergreen_version2",
-                           "author":"mohamed.khelif",
-                           "buildVariants":[
-                              {
-                                 "variant":"enterprise-ubuntu1604-64",
-                                 "displayName":"Ubuntu 16.04",
-                                 "tasks":[
-                                    {
-                                       "id":"task_4",
-                                       "displayName":"Some Other Task",
-                                       "status":"success"
-                                    },
-                                    {
-                                       "id":"task_3",
-                                       "displayName":"Some Task",
-                                       "status":"failed"
-                                    }
-                                 ]
-                              }
-                           ]
-                        },
-                        "rolledUpVersions":null
-                     }
-                  ]
-               }
-            }
-         }
+                },
+                "rolledUpVersions": null
+              }
+            ]
+          }
+        }
       }
-   ]
+    },
+    {
+      "query_file": "task-filter.graphql",
+      "result": {
+        "data": {
+          "mainlineCommits": {
+            "versions": [
+              {
+                "version": {
+                  "id": "evergreen_version5",
+                  "author": "mohamed.khelif",
+                  "buildVariants": []
+                },
+                "rolledUpVersions": null
+              },
+              {
+                "version": null,
+                "rolledUpVersions": [
+                  {
+                    "id": "evergreen_version4",
+                    "activated": false
+                  },
+                  {
+                    "id": "evergreen_version3",
+                    "activated": false
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "id": "evergreen_version2",
+                  "author": "mohamed.khelif",
+                  "buildVariants": [
+                    {
+                      "variant": "enterprise-ubuntu1604-64",
+                      "displayName": "Ubuntu 16.04",
+                      "tasks": [
+                        {
+                          "id": "task_3",
+                          "displayName": "Some Task",
+                          "status": "failed"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "rolledUpVersions": null
+              },
+              {
+                "version": {
+                  "id": "evergreen_version1",
+                  "author": "mohamed.khelif",
+                  "buildVariants": [
+                    {
+                      "variant": "enterprise-ubuntu1604-64",
+                      "displayName": "Ubuntu 16.04",
+                      "tasks": [
+                        {
+                          "id": "task_1",
+                          "displayName": "Some Task",
+                          "status": "success"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "rolledUpVersions": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "status-filter.graphql",
+      "result": {
+        "data": {
+          "mainlineCommits": {
+            "versions": [
+              {
+                "version": {
+                  "id": "evergreen_version5",
+                  "author": "mohamed.khelif",
+                  "buildVariants": []
+                },
+                "rolledUpVersions": null
+              },
+              {
+                "version": null,
+                "rolledUpVersions": [
+                  {
+                    "id": "evergreen_version4",
+                    "activated": false
+                  },
+                  {
+                    "id": "evergreen_version3",
+                    "activated": false
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "id": "evergreen_version2",
+                  "author": "mohamed.khelif",
+                  "buildVariants": [
+                    {
+                      "variant": "enterprise-ubuntu1604-64",
+                      "displayName": "Ubuntu 16.04",
+                      "tasks": [
+                        {
+                          "id": "task_3",
+                          "displayName": "Some Task",
+                          "status": "failed"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "rolledUpVersions": null
+              },
+              {
+                "version": {
+                  "id": "evergreen_version1",
+                  "author": "mohamed.khelif",
+                  "buildVariants": []
+                },
+                "rolledUpVersions": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "pagination.graphql",
+      "result": {
+        "data": {
+          "page1": {
+            "versions": [
+              {
+                "version": {
+                  "id": "evergreen_version5",
+                  "author": "mohamed.khelif",
+                  "buildVariants": [
+                    {
+                      "variant": "enterprise-ubuntu1604-64",
+                      "displayName": "Ubuntu 16.04",
+                      "tasks": [
+                        {
+                          "id": "task_5",
+                          "displayName": "Some Other Task",
+                          "status": "success"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "rolledUpVersions": null
+              }
+            ]
+          },
+          "page2": {
+            "versions": [
+              {
+                "version": null,
+                "rolledUpVersions": [
+                  {
+                    "id": "evergreen_version4",
+                    "activated": false
+                  },
+                  {
+                    "id": "evergreen_version3",
+                    "activated": false
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "id": "evergreen_version2",
+                  "author": "mohamed.khelif",
+                  "buildVariants": [
+                    {
+                      "variant": "enterprise-ubuntu1604-64",
+                      "displayName": "Ubuntu 16.04",
+                      "tasks": [
+                        {
+                          "id": "task_4",
+                          "displayName": "Some Other Task",
+                          "status": "success"
+                        },
+                        {
+                          "id": "task_3",
+                          "displayName": "Some Task",
+                          "status": "failed"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "rolledUpVersions": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "commit-taskStatusCounts.graphql",
+      "result": {
+        "data": {
+          "mainlineCommits": {
+            "versions": [
+              {
+                "version": {
+                  "id": "evergreen_version5",
+                  "taskStatusCounts": [
+                    {
+                      "status": "success",
+                      "count": 1
+                    }
+                  ]
+                },
+                "rolledUpVersions": null
+              },
+              {
+                "version": null,
+                "rolledUpVersions": [
+                  {
+                    "id": "evergreen_version4",
+                    "taskStatusCounts": []
+                  },
+                  {
+                    "id": "evergreen_version3",
+                    "taskStatusCounts": []
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "id": "evergreen_version2",
+                  "taskStatusCounts": [
+                    {
+                      "status": "success",
+                      "count": 1
+                    },
+                    {
+                      "status": "failed",
+                      "count": 1
+                    }
+                  ]
+                },
+                "rolledUpVersions": null
+              },
+              {
+                "version": {
+                  "id": "evergreen_version1",
+                  "taskStatusCounts": [
+                    {
+                      "status": "success",
+                      "count": 2
+                    }
+                  ]
+                },
+                "rolledUpVersions": null
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
[EVG-14853](https://jira.mongodb.org/browse/EVG-14853)

### Description 
* Added a new field called taskStatusCounts to Version. This field is used on the new waterfall page to help display the active commit barcharts. 
* Added a resolver function to calculate taskStatusCounts for a version.

### Testing 
* Added graphql test called `commit-taskStatusCounts` for querying a version's taskStatusCounts field
