### PR TITLE
EVG-13075 Failed Downstream patches should show a failed badge for the upstream patch

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -972,23 +972,25 @@ func (r *queryResolver) Patch(ctx context.Context, id string) (*restModel.APIPat
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch tasks for patch :%s ", err.Error()))
 	}
 
-	statuses := getAllTaskStatuses(tasks)
-
 	if len(patch.ChildPatches) > 0 {
 		allPatches := []restModel.APIPatch{}
 		allPatches = append(allPatches, *patch)
-		// add the status of the child patches to the task statuses
-		// so that they get filtered for aborted
 		for _, cp := range patch.ChildPatches {
 			allPatches = append(allPatches, cp)
-			statuses = append(statuses, *cp.Status)
+			// add the child patch tasks to tasks so that we can consider their status
+			childPatchTasks, _, err := r.sc.FindTasksByVersion(*cp.Id, opts)
+			if err != nil {
+				return nil, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch tasks for patch :%s ", err.Error()))
+			}
+			tasks = append(tasks, childPatchTasks...)
 		}
-		// determine what the patch status should be given the status of
+		// determine what the main patch status should be given the status of
 		// the child patches
 		sort.Sort(restModel.PatchesByStatus(allPatches))
 		// after sorting, the first patch will be the one with the highest priority
 		patch.Status = allPatches[0].Status
 	}
+	statuses := getAllTaskStatuses(tasks)
 
 	// If theres an aborted task we should set the patch status to aborted if there are no other failures
 	if utility.StringSliceContains(statuses, evergreen.TaskAborted) {

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -323,3 +323,33 @@ func (g *githubPatch) ToService() (interface{}, error) {
 	res.Author = utility.FromStringPtr(g.Author)
 	return res, nil
 }
+
+type PatchesByStatus []APIPatch
+
+func (p PatchesByStatus) Len() int {
+	return len(p)
+}
+
+func (p PatchesByStatus) Less(i, j int) bool {
+	return p[i].patchStatusPriority() < p[j].patchStatusPriority()
+}
+
+func (p PatchesByStatus) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+
+// patchStatusPriority answers the question of what the patch status should be
+// when the patch status and the status of it's children are different
+func (p *APIPatch) patchStatusPriority() int {
+	switch *p.Status {
+	case evergreen.PatchCreated:
+		return 10
+	case evergreen.PatchStarted:
+		return 20
+	case evergreen.PatchFailed:
+		return 30
+	case evergreen.PatchSucceeded:
+		return 40
+	}
+	return 100
+}


### PR DESCRIPTION
[EVG-13075](https://jira.mongodb.org/browse/EVG-13075)

### Description 
A patch that has child patches should display a status that reflects the status of the child patches. 

### Testing 
Tested using the graphql playground with the following query: 
`query Patch {
    patch(
      id: "60ec9d6d9dbe322c63945089"
    ) {
    id
    status
    childPatches{
      id
      status
    }
  }
}`
