### PR TITLE
EVG-14923: Allow encoded special characters in evergreen URLs

### DIFF
--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -455,11 +455,11 @@ func getFailedTestsFromTemplate(t task.Task) ([]task.TestResult, error) {
 }
 
 func taskLink(uiBase string, taskID string, execution int) string {
-	return fmt.Sprintf("%s/task/%s/%d", uiBase, taskID, execution)
+	return fmt.Sprintf("%s/task/%s/%d", uiBase, url.PathEscape(taskID), execution)
 }
 
 func taskLogLink(uiBase string, taskID string, execution int) string {
-	return fmt.Sprintf("%s/task_log_raw/%s/%d?type=T", uiBase, taskID, execution)
+	return fmt.Sprintf("%s/task_log_raw/%s/%d?type=T", uiBase, url.PathEscape(taskID), execution)
 }
 
 func buildLink(uiBase string, buildID string, hasPatch bool) string {

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -455,11 +455,11 @@ func getFailedTestsFromTemplate(t task.Task) ([]task.TestResult, error) {
 }
 
 func taskLink(uiBase string, taskID string, execution int) string {
-	return fmt.Sprintf("%s/task/%s/%d", uiBase, url.PathEscape(taskID), execution)
+	return fmt.Sprintf("%s/task/%s/%d", uiBase, taskID, execution)
 }
 
 func taskLogLink(uiBase string, taskID string, execution int) string {
-	return fmt.Sprintf("%s/task_log_raw/%s/%d?type=T", uiBase, url.PathEscape(taskID), execution)
+	return fmt.Sprintf("%s/task_log_raw/%s/%d?type=T", uiBase, taskID, execution)
 }
 
 func buildLink(uiBase string, buildID string, hasPatch bool) string {

--- a/vendor/github.com/evergreen-ci/gimlet/parsing.go
+++ b/vendor/github.com/evergreen-ci/gimlet/parsing.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-
+	"net/url"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
@@ -18,7 +18,15 @@ const maxRequestSize = 16 * 1024 * 1024 // 16 MB
 // passed to the method in the URL. Use this helper function when
 // writing handler functions.
 func GetVars(r *http.Request) map[string]string {
-	return mux.Vars(r)
+	vars := mux.Vars(r)
+	for k, v := range vars {
+		unescapedVar, err := url.PathUnescape(v)
+		if(err != nil){
+			return nil
+		}
+		vars[k] = unescapedVar
+	}
+	return vars
 }
 
 // SetURLVars sets URL variables for testing purposes only.


### PR DESCRIPTION
[EVG-14923](https://jira.mongodb.org/browse/EVG-14923)

### Description 
From the linked ticket, users have encountered task not found errors when clicking on the JIRA tickets generated from build failures due to the task name having special characters.  Change has been made to remove special character encoding on these link generating functions to enable special characters in urls

