### PR TITLE
EVG-14941 Only return activated generated tasks for the tasks table

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -873,7 +873,8 @@ func FindOneIdAndExecution(id string, execution int) (*Task, error) {
 func FindOneIdAndExecutionWithDisplayStatus(id string, execution *int) (*Task, error) {
 	tasks := []Task{}
 	match := bson.M{
-		IdKey: id,
+		IdKey:        id,
+		ActivatedKey: true,
 	}
 	if execution != nil {
 		match[ExecutionKey] = *execution

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -873,8 +873,7 @@ func FindOneIdAndExecution(id string, execution int) (*Task, error) {
 func FindOneIdAndExecutionWithDisplayStatus(id string, execution *int) (*Task, error) {
 	tasks := []Task{}
 	match := bson.M{
-		IdKey:        id,
-		ActivatedKey: true,
+		IdKey: id,
 	}
 	if execution != nil {
 		match[ExecutionKey] = *execution

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2804,6 +2804,7 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 				bson.M{BuildVariantDisplayNameKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
 				bson.M{BuildVariantKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
 			},
+			ActivatedKey: true,
 		}
 	}
 	if len(taskNames) > 0 {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2804,13 +2804,13 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 				bson.M{BuildVariantDisplayNameKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
 				bson.M{BuildVariantKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
 			},
-			ActivatedKey: true,
 		}
 	}
 	if len(taskNames) > 0 {
 		taskNamesAsRegex := strings.Join(taskNames, "|")
 		match[DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex, "$options": "i"}
 	}
+	match[ActivatedTimeKey] = bson.M{"$ne": utility.ZeroTime}
 	match[VersionKey] = versionID
 	const tempParentKey = "_parent"
 	pipeline := []bson.M{}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2810,7 +2810,7 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 		taskNamesAsRegex := strings.Join(taskNames, "|")
 		match[DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex, "$options": "i"}
 	}
-	// Activated Time is needed to filter out generated tasks that have been activated but will not run
+	// Activated Time is needed to filter out generated tasks that have been generated but not yet activated
 	match[ActivatedTimeKey] = bson.M{"$ne": utility.ZeroTime}
 	match[VersionKey] = versionID
 	const tempParentKey = "_parent"

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2810,6 +2810,7 @@ func GetTasksByVersion(versionID string, sortBy []TasksSortOrder, statuses []str
 		taskNamesAsRegex := strings.Join(taskNames, "|")
 		match[DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex, "$options": "i"}
 	}
+	// Activated Time is needed to filter out generated tasks that have been activated but will not run
 	match[ActivatedTimeKey] = bson.M{"$ne": utility.ZeroTime}
 	match[VersionKey] = versionID
 	const tempParentKey = "_parent"


### PR DESCRIPTION
[EVG-14941](https://jira.mongodb.org/browse/EVG-14941)

### Description 
The tasks table shouldn't return any tasks that aren't activated. This scenario is relevant to generated tasks that are generated with out actually being activated.
