### PR TITLE
EVG-14816: fix smoke test

### DIFF
--- a/agent/system_metrics_test.go
+++ b/agent/system_metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -367,7 +368,12 @@ func TestCollectProcesses(t *testing.T) {
 	assert.NotEmpty(t, procs)
 
 	for _, proc := range procs.Processes {
-		assert.NotZero(t, proc.PID)
+		// Windows sometimes doesn't have PIDs for its processes.
+		if runtime.GOOS == "windows" {
+			assert.NotZero(t, proc.Command)
+		} else {
+			assert.NotZero(t, proc.PID)
+		}
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-07-07"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-07-13"
+	AgentVersion = "2021-07-14"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/glide.lock
+++ b/glide.lock
@@ -192,7 +192,7 @@ imports:
   - name: github.com/robfig/cron
     version: 70971dc81bab3671fde85647b0a1367929f92be8
   - name: github.com/evergreen-ci/utility
-    version: 61daa770937d4cd0462ccb4ccaf3255a2a4da381
+    version: 8a88f29180ba74476c65e36075bc372013e3ac05
 
   - name: github.com/robbiet480/go.sns
     version: ca087b49e1da69fa4f163521cc98b1eaf7b66ffd

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen/agent"
 	"github.com/evergreen-ci/evergreen/agent/command"
-	"github.com/evergreen-ci/evergreen/rest/client"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
@@ -110,13 +109,11 @@ func Agent() cli.Command {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			comm := client.NewCommunicator(c.String(agentAPIServerURLFlagName))
-			defer comm.Close()
-
 			agt, err := agent.New(ctx, opts, c.String(agentAPIServerURLFlagName))
 			if err != nil {
 				return errors.Wrap(err, "problem constructing agent")
 			}
+
 			defer agt.Close()
 
 			go hardShutdownForSignals(ctx, cancel)

--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -175,7 +175,9 @@ OUTER:
 			}
 			if task.Status != evergreen.TaskSucceeded {
 				grip.Infof("found task is status %s", task.Status)
-				task = apimodels.APITask{}
+				task = apimodels.APITask{
+					Status: task.Status,
+				}
 				continue OUTER
 			}
 

--- a/vendor/github.com/evergreen-ci/utility/http.go
+++ b/vendor/github.com/evergreen-ci/utility/http.go
@@ -342,15 +342,19 @@ func RetryRequest(ctx context.Context, r *http.Request, opts RetryOptions) (*htt
 				"max":       opts.MaxAttempts,
 				"wait_secs": b.ForAttempt(float64(attempt)).Seconds(),
 			}))
-		} else if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return true, err
+		}
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			return false, nil
-		} else if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		}
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
 			return false, errors.Errorf("server returned status %d", resp.StatusCode)
 		}
 
 		// if we get here it should most likely be a 5xx status code
 
-		return true, nil
+		return true, errors.Errorf("server returned status %s", resp.StatusCode)
 	}, opts); err != nil {
 		return resp, err
 	}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14816

### Description 
* Revendor utility to fix `RetryRequest`, which was causing errors in the agent.
* Make the system metrics test work in Windows.
* Clean up some dead code in the agent CLI command.
* Improve the smoke test slightly by preserving the task status in between request attempts.

### Testing 
I ran the smoke test.
