### PR TITLE
EVG-14976  Display a collective statusPatch in patch api routes 

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -973,10 +973,7 @@ func (r *queryResolver) Patch(ctx context.Context, id string) (*restModel.APIPat
 	}
 
 	if len(patch.ChildPatches) > 0 {
-		allPatches := []restModel.APIPatch{}
-		allPatches = append(allPatches, *patch)
 		for _, cp := range patch.ChildPatches {
-			allPatches = append(allPatches, cp)
 			// add the child patch tasks to tasks so that we can consider their status
 			childPatchTasks, _, err := r.sc.FindTasksByVersion(*cp.Id, opts)
 			if err != nil {
@@ -984,11 +981,6 @@ func (r *queryResolver) Patch(ctx context.Context, id string) (*restModel.APIPat
 			}
 			tasks = append(tasks, childPatchTasks...)
 		}
-		// determine what the main patch status should be given the status of
-		// the child patches
-		sort.Sort(restModel.PatchesByStatus(allPatches))
-		// after sorting, the first patch will be the one with the highest priority
-		patch.Status = allPatches[0].Status
 	}
 	statuses := getAllTaskStatuses(tasks)
 

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -976,13 +976,15 @@ func (p PatchesByCreateTime) Swap(i, j int) {
 	p[i], p[j] = p[j], p[i]
 }
 
-func GetCollectiveStatus(allPatches []Patch) string {
+// GetCollectiveStatus answers the question of what the patch status should be
+// when the patch status and the status of it's children are different
+func GetCollectiveStatus(statuses []string) string {
 	hasCreated := false
 	hasFailure := false
 	hasSuccess := false
 
-	for _, p := range allPatches {
-		switch p.Status {
+	for _, s := range statuses {
+		switch s {
 		case evergreen.PatchStarted:
 			return evergreen.PatchStarted
 		case evergreen.PatchCreated:
@@ -996,9 +998,9 @@ func GetCollectiveStatus(allPatches []Patch) string {
 
 	if !(hasCreated || hasFailure || hasSuccess) {
 		grip.Critical(message.Fields{
-			"message": "An unknown patch status was found",
-			"cause":   "Programmer error: new statuses should be added to GetCollectiveStatus().",
-			"patches": allPatches,
+			"message":  "An unknown patch status was found",
+			"cause":    "Programmer error: new statuses should be added to patch.getCollectiveStatus().",
+			"statuses": statuses,
 		})
 	}
 

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -973,3 +973,33 @@ func (p PatchesByCreateTime) Less(i, j int) bool {
 func (p PatchesByCreateTime) Swap(i, j int) {
 	p[i], p[j] = p[j], p[i]
 }
+
+type PatchesByStatus []Patch
+
+func (p PatchesByStatus) Len() int {
+	return len(p)
+}
+
+func (p PatchesByStatus) Less(i, j int) bool {
+	return p[i].patchStatusPriority() < p[j].patchStatusPriority()
+}
+
+func (p PatchesByStatus) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+
+// patchStatusPriority answers the question of what the patch status should be
+// when the patch status and the status of it's children are different
+func (p *Patch) patchStatusPriority() int {
+	switch p.Status {
+	case evergreen.PatchCreated:
+		return 10
+	case evergreen.PatchStarted:
+		return 20
+	case evergreen.PatchFailed:
+		return 30
+	case evergreen.PatchSucceeded:
+		return 40
+	}
+	return 100
+}

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -995,11 +995,11 @@ func GetCollectiveStatus(allPatches []Patch) string {
 	}
 
 	if !(hasCreated || hasFailure || hasSuccess) {
-		grip.Critical(message.WrapError(errors.New("unknown patch status"), message.Fields{
+		grip.Critical(message.Fields{
 			"message": "An unknown patch status was found",
 			"cause":   "Programmer error: new statuses should be added to GetCollectiveStatus().",
 			"patches": allPatches,
-		}))
+		})
 	}
 
 	if hasCreated && (hasFailure || hasSuccess) {

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -289,14 +289,19 @@ func (p *DBPatchConnector) GetPatchRawPatches(patchID string) (map[string]string
 
 	// set the patch status to the collective status between the parent and child patches
 	if patchDoc.IsParent() {
-		allPatches := []patch.Patch{}
-		allPatches = append(allPatches, *patchDoc)
+		allPatches := []patch.Patch{*patchDoc}
 		for _, childPatchId := range patchDoc.Triggers.ChildPatches {
 			cp, err := patch.FindOneId(childPatchId)
 			if err != nil {
 				return nil, gimlet.ErrorResponse{
 					StatusCode: http.StatusInternalServerError,
 					Message:    errors.Wrap(err, "can't get child patch").Error(),
+				}
+			}
+			if cp == nil {
+				return nil, gimlet.ErrorResponse{
+					StatusCode: http.StatusNotFound,
+					Message:    fmt.Sprintf("child patch with id %s not found", childPatchId),
 				}
 			}
 			allPatches = append(allPatches, *cp)

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
 
@@ -306,9 +305,9 @@ func (p *DBPatchConnector) GetPatchRawPatches(patchID string) (map[string]string
 			}
 			allPatches = append(allPatches, *cp)
 		}
-		sort.Sort(patch.PatchesByStatus(allPatches))
-		// after sorting, the first patch will be the one with the highest priority
-		patchDoc.Status = allPatches[0].Status
+
+		collectiveStatus := patch.GetCollectiveStatus(allPatches)
+		patchDoc.Status = &collectiveStatus
 	}
 
 	if err = patchDoc.FetchPatchFiles(false); err != nil {

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -288,7 +288,7 @@ func (p *DBPatchConnector) GetPatchRawPatches(patchID string) (map[string]string
 
 	// set the patch status to the collective status between the parent and child patches
 	if patchDoc.IsParent() {
-		allPatches := []patch.Patch{*patchDoc}
+		allStatuses := []string{patchDoc.Status}
 		for _, childPatchId := range patchDoc.Triggers.ChildPatches {
 			cp, err := patch.FindOneId(childPatchId)
 			if err != nil {
@@ -303,10 +303,10 @@ func (p *DBPatchConnector) GetPatchRawPatches(patchID string) (map[string]string
 					Message:    fmt.Sprintf("child patch with id %s not found", childPatchId),
 				}
 			}
-			allPatches = append(allPatches, *cp)
+			allStatuses = append(allStatuses, cp.Status)
 		}
 
-		collectiveStatus := patch.GetCollectiveStatus(allPatches)
+		collectiveStatus := patch.GetCollectiveStatus(allStatuses)
 		patchDoc.Status = collectiveStatus
 	}
 

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -306,8 +306,7 @@ func (p *DBPatchConnector) GetPatchRawPatches(patchID string) (map[string]string
 			allStatuses = append(allStatuses, cp.Status)
 		}
 
-		collectiveStatus := patch.GetCollectiveStatus(allStatuses)
-		patchDoc.Status = collectiveStatus
+		patchDoc.Status = patch.GetCollectiveStatus(allStatuses)
 	}
 
 	if err = patchDoc.FetchPatchFiles(false); err != nil {

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -307,7 +307,7 @@ func (p *DBPatchConnector) GetPatchRawPatches(patchID string) (map[string]string
 		}
 
 		collectiveStatus := patch.GetCollectiveStatus(allPatches)
-		patchDoc.Status = &collectiveStatus
+		patchDoc.Status = collectiveStatus
 	}
 
 	if err = patchDoc.FetchPatchFiles(false); err != nil {

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -210,6 +210,8 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 	return errors.WithStack(apiPatch.GithubPatchData.BuildFromService(v.GithubPatchData))
 }
 
+// getCollectiveStatus answers the question of what the patch status should be
+// when the patch status and the status of it's children are different
 func getCollectiveStatus(allPatches []APIPatch) string {
 	hasCreated := false
 	hasFailure := false
@@ -229,11 +231,11 @@ func getCollectiveStatus(allPatches []APIPatch) string {
 	}
 
 	if !(hasCreated || hasFailure || hasSuccess) {
-		grip.Critical(message.WrapError(errors.New("unknown patch status"), message.Fields{
+		grip.Critical(message.Fields{
 			"message": "An unknown patch status was found",
 			"cause":   "Programmer error: new statuses should be added to GetCollectiveStatus().",
 			"patches": allPatches,
-		}))
+		})
 	}
 
 	if hasCreated && (hasFailure || hasSuccess) {

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -192,11 +192,8 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 
 	// set the patch status to the collective status between the parent and child patches
 	if len(childPatches) > 0 {
-		allPatches := []APIPatch{}
-		allPatches = append(allPatches, *apiPatch)
-		for _, cp := range childPatches {
-			allPatches = append(allPatches, cp)
-		}
+		allPatches := []APIPatch{*apiPatch}
+		allPatches = append(allPatches, childPatches...)
 		sort.Sort(PatchesByStatus(allPatches))
 		// after sorting, the first patch will be the one with the highest priority
 		apiPatch.Status = allPatches[0].Status

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -194,10 +194,7 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 	if len(childPatches) > 0 {
 		allPatches := []APIPatch{*apiPatch}
 		allPatches = append(allPatches, childPatches...)
-		collectiveStatus, err := getCollectiveStatus(allPatches)
-		if err != nil {
-			return errors.Wrapf(err, "error getting collective status for  '%s'", *apiPatch.Id)
-		}
+		collectiveStatus := getCollectiveStatus(allPatches)
 		apiPatch.Status = &collectiveStatus
 
 	}


### PR DESCRIPTION
[EVG-14976 ](https://jira.mongodb.org/browse/EVG-14976 )


### Testing 
Manually called the routes and the graphql resolver.