### PR TITLE
EVG-14850 add ipv4 address field to hosts

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1203,6 +1203,7 @@ func (m *ec2Manager) StartInstance(ctx context.Context, h *host.Host, user strin
 	}
 
 	var instance *ec2.Instance
+
 	// Check whether instance is running
 	err = utility.Retry(
 		ctx,

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -23,6 +23,7 @@ import (
 )
 
 const MockIPV6 = "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47"
+const MockIPV4 = "12.34.56.78"
 
 var noReservationError = errors.New("no reservation returned for instance")
 
@@ -1226,7 +1227,8 @@ func (c *awsClientMock) DescribeInstances(ctx context.Context, input *ec2.Descri
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
-						PublicDnsName: aws.String("public_dns_name"),
+						PublicDnsName:   aws.String("public_dns_name"),
+						PublicIpAddress: aws.String(MockIPV4),
 						NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 							&ec2.InstanceNetworkInterface{
 								Ipv6Addresses: []*ec2.InstanceIpv6Address{
@@ -1303,8 +1305,9 @@ func (c *awsClientMock) StartInstances(ctx context.Context, input *ec2.StartInst
 		Placement: &ec2.Placement{
 			AvailabilityZone: aws.String("us-east-1a"),
 		},
-		PublicDnsName: aws.String("public_dns_name"),
-		LaunchTime:    aws.Time(time.Now()),
+		PublicDnsName:   aws.String("public_dns_name"),
+		PublicIpAddress: aws.String("12.34.56.78"),
+		LaunchTime:      aws.Time(time.Now()),
 	}
 	return &ec2.StartInstancesOutput{}, nil
 }
@@ -1486,6 +1489,7 @@ func (c *awsClientMock) GetInstanceInfo(ctx context.Context, id string) (*ec2.In
 	instance.InstanceType = aws.String("m3.4xlarge")
 	instance.LaunchTime = aws.Time(time.Now())
 	instance.PublicDnsName = aws.String("public_dns_name")
+	instance.PublicIpAddress = aws.String(MockIPV4)
 	ipv6 := ec2.InstanceIpv6Address{}
 	ipv6.SetIpv6Address(MockIPV6)
 	instance.NetworkInterfaces = []*ec2.InstanceNetworkInterface{

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -777,6 +777,7 @@ func (s *EC2Suite) TestStartInstance() {
 			Id:     "host-stopped",
 			Status: evergreen.HostStopped,
 			Host:   "old_dns_name",
+			IPv4:   "1.1.1.1",
 		},
 	}
 	for _, h := range hosts {
@@ -790,6 +791,7 @@ func (s *EC2Suite) TestStartInstance() {
 	s.NoError(err)
 	s.Equal(evergreen.HostRunning, found.Status)
 	s.Equal("public_dns_name", found.Host)
+	s.Equal("12.34.56.78", found.IPv4)
 }
 
 func (s *EC2Suite) TestIsUp() {
@@ -1020,7 +1022,8 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
-						PublicDnsName: aws.String("public_dns_name_2"),
+						PublicDnsName:   aws.String("public_dns_name_2"),
+						PublicIpAddress: aws.String("2.2.2.2"),
 						Placement: &ec2.Placement{
 							AvailabilityZone: aws.String("us-east-1a"),
 						},
@@ -1042,7 +1045,8 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
-						PublicDnsName: aws.String("public_dns_name_1"),
+						PublicDnsName:   aws.String("public_dns_name_1"),
+						PublicIpAddress: aws.String("1.1.1.1"),
 						Placement: &ec2.Placement{
 							AvailabilityZone: aws.String("us-east-1a"),
 						},
@@ -1074,7 +1078,8 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
-						PublicDnsName: aws.String("public_dns_name_3"),
+						PublicDnsName:   aws.String("public_dns_name_3"),
+						PublicIpAddress: aws.String("3.3.3.3"),
 						Placement: &ec2.Placement{
 							AvailabilityZone: aws.String("us-east-1a"),
 						},
@@ -1121,8 +1126,11 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 	})
 
 	s.Equal("public_dns_name_1", hosts[1].Host)
+	s.Equal("1.1.1.1", hosts[1].IPv4)
 	s.Equal("public_dns_name_2", hosts[2].Host)
+	s.Equal("2.2.2.2", hosts[2].IPv4)
 	s.Equal("public_dns_name_3", hosts[3].Host)
+	s.Equal("3.3.3.3", hosts[3].IPv4)
 
 	s.Equal("i-3", hosts[2].ExternalIdentifier)
 }
@@ -1161,7 +1169,8 @@ func (s *EC2Suite) TestGetInstanceStatusesTerminate() {
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
-						PublicDnsName: aws.String("public_dns_name_2"),
+						PublicDnsName:   aws.String("public_dns_name_2"),
+						PublicIpAddress: aws.String("2.2.2.2"),
 						Placement: &ec2.Placement{
 							AvailabilityZone: aws.String("us-east-1a"),
 						},
@@ -1247,6 +1256,7 @@ func (s *EC2Suite) TestCacheHostData() {
 		},
 	}
 	instance.PublicDnsName = aws.String("public_dns_name")
+	instance.PublicIpAddress = aws.String("12.34.56.78")
 
 	s.NoError(cacheHostData(s.ctx, s.h, instance, ec2m.client))
 
@@ -1266,6 +1276,7 @@ func (s *EC2Suite) TestCacheHostData() {
 	s.Equal(*instance.Placement.AvailabilityZone, h.Zone)
 	s.True(instance.LaunchTime.Equal(h.StartTime))
 	s.Equal("2001:0db8:85a3:0000:0000:8a2e:0370:7334", h.IP)
+	s.Equal("12.34.56.78", h.IPv4)
 	s.Equal([]host.VolumeAttachment{
 		{
 			VolumeID:   "volume_id",

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -317,10 +317,14 @@ func cacheHostData(ctx context.Context, h *host.Host, instance *ec2.Instance, cl
 	if instance.PublicDnsName == nil {
 		return errors.New("instance missing public dns name")
 	}
+	if instance.PublicIpAddress == nil {
+		return errors.New("instance missing public ip address")
+	}
 	h.Zone = *instance.Placement.AvailabilityZone
 	h.StartTime = *instance.LaunchTime
 	h.Host = *instance.PublicDnsName
 	h.Volumes = makeVolumeAttachments(instance.BlockDeviceMappings)
+	h.IPv4 = *instance.PublicIpAddress
 
 	if err := h.CacheHostData(); err != nil {
 		return errors.Wrap(err, "error updating host document in db")

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2021-07-16"
+	ClientVersion = "2021-07-20"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2021-07-20"

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -35,6 +35,7 @@ var (
 	DistroKey                          = bsonutil.MustHaveTag(Host{}, "Distro")
 	ProviderKey                        = bsonutil.MustHaveTag(Host{}, "Provider")
 	IPKey                              = bsonutil.MustHaveTag(Host{}, "IP")
+	IPv4Key                            = bsonutil.MustHaveTag(Host{}, "IPv4")
 	ProvisionedKey                     = bsonutil.MustHaveTag(Host{}, "Provisioned")
 	ProvisionTimeKey                   = bsonutil.MustHaveTag(Host{}, "ProvisionTime")
 	ExtIdKey                           = bsonutil.MustHaveTag(Host{}, "ExternalIdentifier")
@@ -574,7 +575,12 @@ func ById(id string) db.Q {
 
 // ByIP produces a query that returns a host with the given ip address.
 func ByIP(ip string) db.Q {
-	return db.Query(bson.M{IPKey: ip})
+	return db.Query(bson.M{
+		"$or": []bson.M{
+			{IPKey: ip},
+			{IPv4Key: ip},
+		},
+	})
 }
 
 // ByDistroIDOrAliasesRunning returns a query that returns all hosts with

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -37,7 +37,9 @@ type Host struct {
 	Tag             string        `bson:"tag" json:"tag"`
 	Distro          distro.Distro `bson:"distro" json:"distro"`
 	Provider        string        `bson:"host_type" json:"host_type"`
-	IP              string        `bson:"ip_address" json:"ip_address"`
+	// IP holds the ipv6 address when applicable
+	IP   string `bson:"ip_address" json:"ip_address"`
+	IPv4 string `bson:"ipv4_address" json:"ipv4_address"`
 
 	// secondary (external) identifier for the host
 	ExternalIdentifier string `bson:"ext_identifier" json:"ext_identifier"`
@@ -1465,6 +1467,7 @@ func (h *Host) CacheHostData() error {
 				StartTimeKey: h.StartTime,
 				VolumesKey:   h.Volumes,
 				DNSKey:       h.Host,
+				IPv4Key:      h.IPv4,
 			},
 		},
 	)

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -1472,7 +1472,7 @@ func hostFindBy() cli.Command {
 			}
 
 			hostId := utility.FromStringPtr(host.Id)
-			hostUser := utility.FromStringPtr(host.User)
+			hostUser := utility.FromStringPtr(host.StartedBy)
 			link := fmt.Sprintf("%s/host/%s", conf.UIServerHost, hostId)
 			fmt.Printf(`
 	     ID : %s

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -365,7 +365,7 @@ func (hc *MockHostConnector) FindHostById(id string) (*host.Host, error) {
 
 func (hc *MockHostConnector) FindHostByIpAddress(ip string) (*host.Host, error) {
 	for _, h := range hc.CachedHosts {
-		if h.IP == ip {
+		if h.IP == ip || h.IPv4 == ip {
 			return &h, nil
 		}
 	}

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -28,6 +28,7 @@ func TestListHostsForTask(t *testing.T) {
 			Id:     "1",
 			Host:   "1.com",
 			IP:     "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47",
+			IPv4:   "12.34.56.78",
 			Status: evergreen.HostRunning,
 			SpawnOptions: host.SpawnOptions{
 				TaskID: "task_1",
@@ -88,6 +89,7 @@ func TestListHostsForTask(t *testing.T) {
 	assert.Equal("4.com", found[0].Host)
 	assert.Equal("1.com", found[1].Host)
 	assert.Equal("abcd:1234:459c:2d00:cfe4:843b:1d60:8e47", found[1].IP)
+	assert.Equal("12.34.56.78", found[1].IPv4)
 }
 
 func TestCreateHostsFromTask(t *testing.T) {

--- a/rest/model/createhost.go
+++ b/rest/model/createhost.go
@@ -9,6 +9,7 @@ import (
 type CreateHost struct {
 	DNSName    *string `json:"dns_name,omitempty"`
 	IP         *string `json:"ip_address,omitempty"`
+	IPv4       *string `json:"ipv4_address,omitempty"`
 	InstanceID *string `json:"instance_id,omitempty"`
 
 	HostID       *string      `json:"host_id,omitempty"`
@@ -23,6 +24,7 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 	case host.Host:
 		createHost.DNSName = utility.ToStringPtr(v.Host)
 		createHost.IP = utility.ToStringPtr(v.IP)
+		createHost.IPv4 = utility.ToStringPtr(v.IPv4)
 
 		// container
 		if v.ParentID != "" {
@@ -40,6 +42,7 @@ func (createHost *CreateHost) BuildFromService(h interface{}) error {
 	case *host.Host:
 		createHost.DNSName = utility.ToStringPtr(v.Host)
 		createHost.IP = utility.ToStringPtr(v.IP)
+		createHost.IPv4 = utility.ToStringPtr(v.IPv4)
 
 		// container
 		if v.ParentID != "" {

--- a/rest/model/createhost_test.go
+++ b/rest/model/createhost_test.go
@@ -14,6 +14,7 @@ func TestCreateHostBuildFromService(t *testing.T) {
 		Host:               "foo.com",
 		ExternalIdentifier: "sir-123",
 		IP:                 "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47",
+		IPv4:               "12.34.56.78",
 	}
 	c := &CreateHost{}
 	err := c.BuildFromService(h)
@@ -21,6 +22,7 @@ func TestCreateHostBuildFromService(t *testing.T) {
 	assert.Equal(utility.FromStringPtr(c.DNSName), h.Host)
 	assert.Equal(utility.FromStringPtr(c.InstanceID), h.ExternalIdentifier)
 	assert.Equal(utility.FromStringPtr(c.IP), h.IP)
+	assert.Equal(utility.FromStringPtr(c.IPv4), h.IPv4)
 }
 
 func TestCreateHostBuildFromServiceWithContainer(t *testing.T) {

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -621,7 +621,7 @@ func (h *hostIpAddressGetHandler) Run(ctx context.Context) gimlet.Responder {
 	if host == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("host with ip address '%s' not found", h.IP),
+			Message:    fmt.Sprintf("host with ip address '%s' may not exist or may not have IP address stored", h.IP),
 		})
 	}
 


### PR DESCRIPTION
[EVG-14850](https://jira.mongodb.org/browse/EVG-14850)

### Description 
added new field on Hosts struct and a way to insert ipv4 addresses to database 

### Testing 
added ipv4 to relavent unittests 

spawned host in staging
![image](https://user-images.githubusercontent.com/26491602/126004529-a06505e9-6f47-47f6-9ead-f0dcabeceb14.png)

new query works for both ips
![image](https://user-images.githubusercontent.com/26491602/126205178-232e179b-2498-46b8-937a-ea1aea167db7.png)
