### PR TITLE
EVG-14830: add running host count to AWS interrupt logging

### DIFF
--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -191,8 +191,8 @@ func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instan
 	}
 	existingHostCount, err := host.CountRunningHosts(h.Distro.Id)
 	if err != nil {
-		j.AddError(errors.Wrap(err, "database error counting running hosts by h.Distro.Id"))
-		return
+		grip.Warning(errors.Wrap(err, "database error counting running hosts by h.Distro.Id"))
+		existingHostCount = -1
 	}
 
 	grip.Info(message.Fields{

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -189,9 +189,16 @@ func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instan
 			instanceType = stringVal
 		}
 	}
+	existingHostCount, err := host.CountRunningHosts(h.Distro.Id)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "database error counting running hosts by h.Distro.Id"))
+		return
+	}
+
 	grip.Info(message.Fields{
 		"message":       "got interruption warning from AWS",
 		"distro":        h.Distro.Id,
+		"upcount":       existingHostCount,
 		"instance_type": instanceType,
 		"host_id":       h.Id,
 	})

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -196,11 +196,11 @@ func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instan
 	}
 
 	grip.Info(message.Fields{
-		"message":       "got interruption warning from AWS",
-		"distro":        h.Distro.Id,
-		"upcount":       existingHostCount,
-		"instance_type": instanceType,
-		"host_id":       h.Id,
+		"message":            "got interruption warning from AWS",
+		"distro":             h.Distro.Id,
+		"running_host_count": existingHostCount,
+		"instance_type":      instanceType,
+		"host_id":            h.Id,
 	})
 
 	if h.Status == evergreen.HostTerminated {

--- a/rest/route/aws.go
+++ b/rest/route/aws.go
@@ -191,7 +191,7 @@ func (aws *awsSns) handleInstanceInterruptionWarning(ctx context.Context, instan
 	}
 	existingHostCount, err := host.CountRunningHosts(h.Distro.Id)
 	if err != nil {
-		grip.Warning(errors.Wrap(err, "database error counting running hosts by h.Distro.Id"))
+		grip.Error(errors.Wrap(err, "database error counting running hosts by h.Distro.Id"))
 		existingHostCount = -1
 	}
 


### PR DESCRIPTION
[EVG-14830](https://jira.mongodb.org/browse/EVG-14830)

### Description 
Added logging of number of running hosts in order to better understand the impact of AWS instance interruptions.

### Testing 
  Will run in staging before merging
