### PR TITLE
EVG-14918 Add macos and arm agent builders

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -678,34 +678,33 @@ buildvariants:
       - name: ".agent .test"
       - name: ".cli .test"
 
-- name: ubuntu1604-arm64
-  display_name: Ubuntu 16.04 ARM
-  batchtime: 2880
-  run_on:
-    - ubuntu1604-arm64-small
-  expansions:
-    disable_coverage: yes
-    xc_build: yes
-    goarch: arm64
-    goos: linux
-    gobin: /opt/golang/go1.16/bin/go
-    goroot: /opt/golang/go1.16
-    mongodb_url: https://downloads.mongodb.com/linux/mongodb-linux-arm64-enterprise-ubuntu1604-4.0.3.tgz
-  tasks:
-    - name: ".agent .test"
+  - name: ubuntu1604-arm64
+    display_name: Ubuntu 16.04 ARM
+    batchtime: 2880
+    run_on:
+      - ubuntu1604-arm64-small
+    expansions:
+      disable_coverage: yes
+      xc_build: yes
+      goarch: arm64
+      goos: linux
+      gobin: /opt/golang/go1.16/bin/go
+      goroot: /opt/golang/go1.16
+      mongodb_url: https://downloads.mongodb.com/linux/mongodb-linux-arm64-enterprise-ubuntu1604-4.0.3.tgz
+    tasks:
+      - name: ".agent .test"
 
-- name: osx
-  display_name: OSX
-  batchtime: 2880
-  run_on:
-    - macos-1014
-  expansions:
-    disable_coverage: yes
-    gobin: /opt/golang/go1.16/bin/go
-    goroot: /opt/golang/go1.16
-    mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
-  tasks:
-    mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
-  tasks:
-    - name: ".agent .test"
--
+  - name: osx
+    display_name: OSX
+    batchtime: 2880
+    run_on:
+      - macos-1014
+    expansions:
+      disable_coverage: yes
+      gobin: /opt/golang/go1.16/bin/go
+      goroot: /opt/golang/go1.16
+      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
+    tasks:
+      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
+    tasks:
+      - name: ".agent .test"

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -705,6 +705,4 @@ buildvariants:
       goroot: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     tasks:
-      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
-    tasks:
       - name: ".agent .test"

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -706,3 +706,4 @@ buildvariants:
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     tasks:
       - name: ".agent .test"
+      - name: ".cli .test"

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -677,3 +677,35 @@ buildvariants:
     tasks:
       - name: ".agent .test"
       - name: ".cli .test"
+
+- name: ubuntu1604-arm64
+  display_name: Ubuntu 16.04 ARM
+  batchtime: 2880
+  run_on:
+    - ubuntu1604-arm64-small
+  expansions:
+    disable_coverage: yes
+    xc_build: yes
+    goarch: arm64
+    goos: linux
+    gobin: /opt/golang/go1.16/bin/go
+    goroot: /opt/golang/go1.16
+    mongodb_url: https://downloads.mongodb.com/linux/mongodb-linux-arm64-enterprise-ubuntu1604-4.0.3.tgz
+  tasks:
+    - name: ".agent .test"
+
+- name: osx
+  display_name: OSX
+  batchtime: 2880
+  run_on:
+    - macos-1014
+  expansions:
+    disable_coverage: yes
+    gobin: /opt/golang/go1.16/bin/go
+    goroot: /opt/golang/go1.16
+    mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
+  tasks:
+    mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
+  tasks:
+    - name: ".agent .test"
+-


### PR DESCRIPTION
[EVG-14090](https://jira.mongodb.org/browse/EVG-14090)

### Description 
This adds additional agent builders to verify agent behavior on non-Linux platforms. They are nearly identical to the Windows builder.
