### PR TITLE
EVG-14894: add cocoa pod conversion helpers

### DIFF
--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -14,9 +14,10 @@ const (
 
 var (
 	IDKey                        = bsonutil.MustHaveTag(Pod{}, "ID")
+	StatusKey                    = bsonutil.MustHaveTag(Pod{}, "Status")
 	SecretKey                    = bsonutil.MustHaveTag(Pod{}, "Secret")
-	ExternalIDKey                = bsonutil.MustHaveTag(Pod{}, "ExternalID")
 	TaskContainerCreationOptsKey = bsonutil.MustHaveTag(Pod{}, "TaskContainerCreationOpts")
+	ResourcesKey                 = bsonutil.MustHaveTag(Pod{}, "Resources")
 	TimeInfoKey                  = bsonutil.MustHaveTag(Pod{}, "TimeInfo")
 
 	TaskContainerCreationOptsImageKey    = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "Image")
@@ -32,9 +33,9 @@ var (
 )
 
 // FindOne finds one pod by the given query.
-func FindOne(query db.Q) (*Pod, error) {
+func FindOne(q bson.M) (*Pod, error) {
 	var p Pod
-	err := db.FindOneQ(Collection, query, &p)
+	err := db.FindOneQ(Collection, db.Query(q), &p)
 	if adb.ResultsNotFound(err) {
 		return nil, nil
 	}
@@ -43,10 +44,24 @@ func FindOne(query db.Q) (*Pod, error) {
 
 // FindOneByID finds one pod by its ID.
 func FindOneByID(id string) (*Pod, error) {
-	query := db.Query(bson.M{IDKey: id})
-	p, err := FindOne(query)
+	p, err := FindOne(ByID(id))
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding pod '%s'", id)
 	}
 	return p, nil
+}
+
+func ByID(id string) bson.M {
+	return bson.M{
+		IDKey: id,
+	}
+}
+
+// UpdateOne updates one pod.
+func UpdateOne(query interface{}, update interface{}) error {
+	return db.Update(
+		Collection,
+		query,
+		update,
+	)
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14894

### Description 
I broke the pod termination job into two separate PRs to make it easier to digest.

* Refactor the pod DB model slightly to make it easier to separate AWS resource dependencies.
* Add pod statuses (subject to change, but they should be similar-ish to the ones for hosts).
* Add conversion helpers to translate a pod DB model into its cocoa in-memory representation to use the cocoa API.
* Add function to update pod status in the DB.
### Testing 
  < add a description of how you tested it >
