### PR TITLE
EVG-15020: add admin settings for pod task and execution roles

### DIFF
--- a/config_cloud.go
+++ b/config_cloud.go
@@ -136,6 +136,8 @@ func (c *AWSPodConfig) Validate() error {
 type ECSConfig struct {
 	// TaskDefinitionPrefix is the prefix for the task definition families.
 	TaskDefinitionPrefix string `bson:"task_definition_prefix,omitempty" json:"task_definition_prefix,omitempty" yaml:"task_definition_prefix,omitempty"`
+	TaskRole             string `bson:"task_role,omitempty" json:"task_role,omitempty" yaml:"task_role,omitempty"`
+	ExecutionRole        string `bson:"execution_role,omitempty" json:"execution_role,omitempty" yaml:"execution_role,omitempty"`
 	// Clusters specify the configuration of each particular ECS cluster.
 	Clusters []ECSClusterConfig `bson:"clusters,omitempty" json:"clusters,omitempty" yaml:"clusters,omitempty"`
 }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1580,8 +1580,9 @@ func (a *APIAWSPodConfig) ToService() (interface{}, error) {
 
 // APIECSConfig represents configuration options for AWS ECS.
 type APIECSConfig struct {
-	Role                 *string               `json:"role"`
 	TaskDefinitionPrefix *string               `json:"task_definition_prefix"`
+	TaskRole             *string               `json:"task_role"`
+	ExecutionRole        *string               `json:"execution_role"`
 	Clusters             []APIECSClusterConfig `json:"clusters"`
 }
 
@@ -1589,6 +1590,8 @@ func (a *APIECSConfig) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case evergreen.ECSConfig:
 		a.TaskDefinitionPrefix = utility.ToStringPtr(v.TaskDefinitionPrefix)
+		a.TaskRole = utility.ToStringPtr(v.TaskRole)
+		a.ExecutionRole = utility.ToStringPtr(v.ExecutionRole)
 		for _, cluster := range v.Clusters {
 			var apiCluster APIECSClusterConfig
 			if err := apiCluster.BuildFromService(cluster); err != nil {
@@ -1619,8 +1622,11 @@ func (a *APIECSConfig) ToService() (interface{}, error) {
 		}
 		clusters = append(clusters, cluster)
 	}
+
 	return evergreen.ECSConfig{
 		TaskDefinitionPrefix: utility.FromStringPtr(a.TaskDefinitionPrefix),
+		TaskRole:             utility.FromStringPtr(a.TaskRole),
+		ExecutionRole:        utility.FromStringPtr(a.ExecutionRole),
 		Clusters:             clusters,
 	}, nil
 }

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -150,6 +150,8 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Providers.AWS.Pod.Role, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.Role))
 	assert.EqualValues(testSettings.Providers.AWS.Pod.Region, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.Region))
 	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.TaskDefinitionPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.TaskDefinitionPrefix))
+	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.TaskRole, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.TaskRole))
+	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.ExecutionRole, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.ExecutionRole))
 	require.Len(apiSettings.Providers.AWS.Pod.ECS.Clusters, len(testSettings.Providers.AWS.Pod.ECS.Clusters))
 	for i := 0; i < len(testSettings.Providers.AWS.Pod.ECS.Clusters); i++ {
 		assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.Clusters[i].Name, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.Clusters[i].Name))

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1659,6 +1659,14 @@ Admin Settings
 										<label>Pod ECS Task Definition Prefix</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.task_definition_prefix">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Pod ECS Task Role</label>
+										<input type="text" ng-model="Settings.providers.aws.pod.ecs.task_role">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
+										<label>Pod ECS Execution Role</label>
+										<input type="text" ng-model="Settings.providers.aws.pod.ecs.execution_role">
+									</md-input-container>
 									<md-card>
 										<md-card-title>
 											<md-card-title-text>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -251,6 +251,8 @@ func MockConfig() *evergreen.Settings {
 					Region: "region",
 					ECS: evergreen.ECSConfig{
 						TaskDefinitionPrefix: "ecs_prefix",
+						TaskRole:             "task_role",
+						ExecutionRole:        "execution_role",
 						Clusters: []evergreen.ECSClusterConfig{
 							{
 								Name:     "cluster_name",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15020

### Description 
Add admin settings to forward to ECS for the task and execution roles. These allow ECS to interact with external services like Secrets Manager, as well as do useful things like allow you to exec into a running container in an ECS task.

### Testing 
Normal admin REST tests. I also verified in local-evergreen that the fields work.