### PR TITLE
EVG-15026: add event log for when the pod status changes

### DIFF
--- a/model/event/pod_test.go
+++ b/model/event/pod_test.go
@@ -14,7 +14,7 @@ func TestPodEvents(t *testing.T) {
 			id := "pod_id"
 			oldStatus := "initializing"
 			newStatus := "starting"
-			require.NoError(t, LogPodStatusChanged(id, oldStatus, newStatus))
+			LogPodStatusChanged(id, oldStatus, newStatus)
 
 			events, err := Find(AllLogCollection, MostRecentPodEvents(id, 10))
 			require.NoError(t, err)

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -3,6 +3,7 @@ package pod
 import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -108,9 +109,9 @@ func (p *Pod) UpdateStatus(s Status) error {
 		return err
 	}
 
-	p.Status = s
+	event.LogPodStatusChanged(p.ID, string(p.Status), string(s))
 
-	// TODO (EVG-15026): set up event logging when pod status changes.
+	p.Status = s
 
 	return nil
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15026

### Description 
Add event logging when the pod status changes.

I also squashed the error from `LogPodEvent` so it just logs instead of returning an error to the caller. `LogEvent` can error in some uncommon cases (e.g. if insertion fails), but it doesn't seem important enough to actually return errors to the caller, nor is it really actionable since it's not worth retrying an event log insertion. I'm fine with it being a best-effort event log system.

### Testing 
Tests to ensure the event is logged properly when `(*Pod).UpdateStatus` is called.