### PR TITLE
EVG-14925: Set base revision when changing branches instead of asking user for confirmation

### DIFF
--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -205,7 +205,7 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 			grip.Info(message.Fields{
 				"source":             "github poller",
 				"message":            "updating new base revision",
-				"revision":           revision,
+				"old_revision":       revision,
 				"new_revision":       baseRevision,
 				"project":            gRepoPoller.ProjectRef.Id,
 				"project_identifier": gRepoPoller.ProjectRef.Identifier,
@@ -214,9 +214,7 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 			if err != nil {
 				return nil, errors.Wrap(err, "error updating last revision")
 			}
-			gRepoPoller.ProjectRef.RepotrackerError.Exists = false
-			gRepoPoller.ProjectRef.RepotrackerError.InvalidRevision = ""
-			gRepoPoller.ProjectRef.RepotrackerError.MergeBaseRevision = ""
+			gRepoPoller.ProjectRef.RepotrackerError = revisionDetails
 		}
 
 		if err = gRepoPoller.ProjectRef.Upsert(); err != nil {

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -188,6 +188,9 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 				"unable to find a suggested merge base commit for revision %v, must fix on projects settings page",
 				revision)
 			gRepoPoller.ProjectRef.RepotrackerError = revisionDetails
+			if err = gRepoPoller.ProjectRef.Upsert(); err != nil {
+				return []model.Revision{}, errors.Wrap(err, "unable to update projectRef revision details")
+			}
 			return []model.Revision{}, revisionError
 		} else {
 			// automatically set the newly found base revision as base revision and append revisions
@@ -214,11 +217,6 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 			if err != nil {
 				return nil, errors.Wrap(err, "error updating last revision")
 			}
-			gRepoPoller.ProjectRef.RepotrackerError = revisionDetails
-		}
-
-		if err = gRepoPoller.ProjectRef.Upsert(); err != nil {
-			return []model.Revision{}, errors.Wrap(err, "unable to update projectRef revision details")
 		}
 	}
 

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -202,8 +202,14 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 			}
 			revisions = append(revisions, githubCommitToRevision(commit))
 
-			grip.Infof("Base revision, %v not found, updating %v as new base revision",
-				revision, baseRevision)
+			grip.Info(message.Fields{
+				"source":             "github poller",
+				"message":            "updating new base revision",
+				"revision":           revision,
+				"new_revision":       baseRevision,
+				"project":            gRepoPoller.ProjectRef.Id,
+				"project_identifier": gRepoPoller.ProjectRef.Identifier,
+			})
 			err = model.UpdateLastRevision(gRepoPoller.ProjectRef.Id, baseRevision)
 			if err != nil {
 				return nil, errors.Wrap(err, "error updating last revision")


### PR DESCRIPTION
[EVG-14925](https://jira.mongodb.org/browse/EVG-14925)

### Description 
When a user switches branches in their project, Evergreen reports on the project page that the user should enter a new base revision, and provides a base revision for the user who can then choose to confirm on the project page and set the base revision manually. A change has been made in the case that a base revision is found for the new branch, it will be set as the base revision automatically instead of waiting for the user to visit the project page and confirm the revision manually.
