### PR TITLE
EVG-14817: add pod next task route and rename pod enums

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -51,13 +51,13 @@ func ExportPod(p *pod.Pod, c cocoa.ECSClient, v cocoa.Vault) (cocoa.ECSPod, erro
 // ExportStatus exports the pod status to the equivalent cocoa.ECSPodStatus.
 func ExportPodStatus(s pod.Status) (cocoa.ECSPodStatus, error) {
 	switch s {
-	case pod.InitializingStatus:
+	case pod.StatusInitializing:
 		return "", errors.Errorf("a pod that is initializing does not exist in ECS yet")
-	case pod.StartingStatus:
+	case pod.StatusStarting:
 		return cocoa.StartingStatus, nil
-	case pod.RunningStatus:
+	case pod.StatusRunning:
 		return cocoa.RunningStatus, nil
-	case pod.TerminatedStatus:
+	case pod.StatusTerminated:
 		return cocoa.DeletedStatus, nil
 	default:
 		return "", errors.Errorf("no equivalent ECS status for pod status '%s'", s)

--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -87,7 +87,7 @@ func TestExportPod(t *testing.T) {
 
 			p := pod.Pod{
 				ID:     "id",
-				Status: pod.RunningStatus,
+				Status: pod.StatusRunning,
 				Resources: pod.ResourceInfo{
 					ID:           "task_id",
 					DefinitionID: "task_def_id",
@@ -114,22 +114,22 @@ func TestExportPod(t *testing.T) {
 
 func TestExportPodStatus(t *testing.T) {
 	t.Run("SucceedsWithStartingStatus", func(t *testing.T) {
-		s, err := ExportPodStatus(pod.StartingStatus)
+		s, err := ExportPodStatus(pod.StatusStarting)
 		require.NoError(t, err)
 		assert.Equal(t, cocoa.StartingStatus, s)
 	})
 	t.Run("SucceedsWithRunningStatus", func(t *testing.T) {
-		s, err := ExportPodStatus(pod.RunningStatus)
+		s, err := ExportPodStatus(pod.StatusRunning)
 		require.NoError(t, err)
 		assert.Equal(t, cocoa.RunningStatus, s)
 	})
 	t.Run("SucceedsWithTerminatedStatus", func(t *testing.T) {
-		s, err := ExportPodStatus(pod.TerminatedStatus)
+		s, err := ExportPodStatus(pod.StatusTerminated)
 		require.NoError(t, err)
 		assert.Equal(t, cocoa.DeletedStatus, s)
 	})
 	t.Run("FailsWithInitializingStatus", func(t *testing.T) {
-		s, err := ExportPodStatus(pod.InitializingStatus)
+		s, err := ExportPodStatus(pod.StatusInitializing)
 		assert.Error(t, err)
 		assert.Zero(t, s)
 	})

--- a/globals.go
+++ b/globals.go
@@ -952,16 +952,16 @@ const (
 type PodPlatform string
 
 const (
-	// LinuxPodPlatform is the platform to run pods with Linux containers.
-	LinuxPodPlatform PodPlatform = "linux"
-	// WindowsPodPlatform is the platform to run pods with Windows containers.
-	WindowsPodPlatform PodPlatform = "windows"
+	// PodPlatformLinux is the platform to run pods with Linux containers.
+	PodPlatformLinux PodPlatform = "linux"
+	// PodPlatformWindows is the platform to run pods with Windows containers.
+	PodPlatformWindows PodPlatform = "windows"
 )
 
 // Validate checks that the given pod platform is recognized.
 func (p PodPlatform) Validate() error {
 	switch p {
-	case LinuxPodPlatform, WindowsPodPlatform:
+	case PodPlatformLinux, PodPlatformWindows:
 		return nil
 	default:
 		return errors.Errorf("unrecognized pod platform '%s'", p)

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -28,15 +28,15 @@ type Pod struct {
 type Status string
 
 const (
-	// InitializingStatus indicates that a pod is waiting to be created.
-	InitializingStatus Status = "initializing"
-	// StartingStatus indicates that a pod's containers are starting.
-	StartingStatus Status = "starting"
-	// Running indicates that the pod's containers are running.
-	RunningStatus Status = "running"
-	// TerminatedStatus indicates that the pod's containers have been
+	// StatusInitializing indicates that a pod is waiting to be created.
+	StatusInitializing Status = "initializing"
+	// StatusStarting indicates that a pod's containers are starting.
+	StatusStarting Status = "starting"
+	// StatusRunning indicates that the pod's containers are running.
+	StatusRunning Status = "running"
+	// StatusTerminated indicates that the pod's containers have been
 	// deleted.
-	TerminatedStatus Status = "terminated"
+	StatusTerminated Status = "terminated"
 )
 
 // ResourceInfo represents information about external resources associated with

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -25,7 +25,7 @@ func TestInsertAndFindOneByID(t *testing.T) {
 			p := Pod{
 				ID:     "id",
 				Secret: "secret",
-				Status: RunningStatus,
+				Status: StatusRunning,
 				TaskContainerCreationOpts: TaskContainerCreationOptions{
 					Image:    "alpine",
 					MemoryMB: 128,
@@ -105,8 +105,8 @@ func TestUpdateStatus(t *testing.T) {
 		"SucceedsWithInitializingStatus": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, p.UpdateStatus(InitializingStatus))
-			assert.Equal(t, InitializingStatus, p.Status)
+			require.NoError(t, p.UpdateStatus(StatusInitializing))
+			assert.Equal(t, StatusInitializing, p.Status)
 
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -116,8 +116,8 @@ func TestUpdateStatus(t *testing.T) {
 		"SucceedsWithStartingStatus": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, p.UpdateStatus(StartingStatus))
-			assert.Equal(t, StartingStatus, p.Status)
+			require.NoError(t, p.UpdateStatus(StatusStarting))
+			assert.Equal(t, StatusStarting, p.Status)
 
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -127,8 +127,8 @@ func TestUpdateStatus(t *testing.T) {
 		"SucceedsWithRunningStatus": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, p.UpdateStatus(RunningStatus))
-			assert.Equal(t, RunningStatus, p.Status)
+			require.NoError(t, p.UpdateStatus(StatusRunning))
+			assert.Equal(t, StatusRunning, p.Status)
 
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -138,8 +138,8 @@ func TestUpdateStatus(t *testing.T) {
 		"SucceedsWithTerminatedStatus": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, p.UpdateStatus(TerminatedStatus))
-			assert.Equal(t, TerminatedStatus, p.Status)
+			require.NoError(t, p.UpdateStatus(StatusTerminated))
+			assert.Equal(t, StatusTerminated, p.Status)
 
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestUpdateStatus(t *testing.T) {
 			assert.Equal(t, p.Status, dbPod.Status)
 		},
 		"FailsWithNonexistentPod": func(t *testing.T, p Pod) {
-			assert.Error(t, p.UpdateStatus(TerminatedStatus))
+			assert.Error(t, p.UpdateStatus(StatusTerminated))
 
 			dbPod, err := FindOneByID(p.ID)
 			assert.NoError(t, err)
@@ -157,15 +157,15 @@ func TestUpdateStatus(t *testing.T) {
 			require.NoError(t, p.Insert())
 
 			require.NoError(t, UpdateOne(ByID(p.ID), bson.M{
-				"$set": bson.M{StatusKey: InitializingStatus},
+				"$set": bson.M{StatusKey: StatusInitializing},
 			}))
 
-			assert.Error(t, p.UpdateStatus(TerminatedStatus))
+			assert.Error(t, p.UpdateStatus(StatusTerminated))
 
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
 			require.NotZero(t, dbPod)
-			assert.Equal(t, InitializingStatus, dbPod.Status)
+			assert.Equal(t, StatusInitializing, dbPod.Status)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
@@ -175,7 +175,7 @@ func TestUpdateStatus(t *testing.T) {
 			}()
 			tCase(t, Pod{
 				ID:     "id",
-				Status: RunningStatus,
+				Status: StatusRunning,
 			})
 		})
 	}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -141,6 +141,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/patches/{patch_id}/merge_patch").Version(2).Put().Wrap(checkUser, addProject, submitPatches, checkCommitQueueItemOwner).RouteHandler(makeMergePatch(sc))
 	app.AddRoute("/pods/{pod_id}/agent/cedar_config").Version(2).Get().Wrap(checkPod).RouteHandler(makePodAgentCedarConfig(env.Settings()))
 	app.AddRoute("/pods/{pod_id}/agent/setup").Version(2).Get().Wrap(checkPod).RouteHandler(makePodAgentSetup(env.Settings()))
+	app.AddRoute("/pods/{pod_id}/agent/next_task").Version(2).Get().Wrap(checkPod).RouteHandler(makePodAgentNextTask(env, sc))
 	app.AddRoute("/projects").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchProjectsRoute(sc))
 	app.AddRoute("/projects/test_alias").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetProjectAliasResultsHandler(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Delete().Wrap(checkUser, checkProjectAdmin, editProjectSettings).RouteHandler(makeDeleteProject(sc))

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -254,7 +254,7 @@ func MockConfig() *evergreen.Settings {
 						Clusters: []evergreen.ECSClusterConfig{
 							{
 								Name:     "cluster_name",
-								Platform: evergreen.LinuxPodPlatform,
+								Platform: evergreen.PodPlatformLinux,
 							},
 						},
 					},


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-14817
https://jira.mongodb.org/browse/EVG-15098

### Description 
* Add next task REST route, which does nothing other than attempt to clean up the pod since this is the end of the POC's pod lifecycle.
* Rename pod enums to be type-prefixed instead of type-suffixed.

### Testing 
Normal tests for REST routes.