### PR TITLE
EVG-14776: resolve cedar base test status in TaskTests resolver

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1299,16 +1299,15 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 	var totalTestCount int
 	var filteredTestCount int
 
+	baseTask, err := dbTask.FindTaskOnBaseCommit()
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding base task for task %s: %s", taskID, err))
+	}
+	baseTestStatusMap := make(map[string]string)
 	if cedarTestResults == nil {
-		baseTask, err := dbTask.FindTaskOnBaseCommit()
-		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding base task with id %s: %s", taskID, err))
-		}
-
 		var taskExecution int
 		taskExecution = dbTask.Execution
 
-		baseTestStatusMap := make(map[string]string)
 		if baseTask != nil {
 			baseTestResults, _ := r.sc.FindTestsByTaskId(data.FindTestsByTaskIdOpts{TaskID: baseTask.Id, Execution: taskExecution})
 			for _, t := range baseTestResults {
@@ -1360,6 +1359,30 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting filtered test count: %s", err.Error()))
 		}
 	} else {
+		if baseTask != nil {
+			baseTestResultOpts := apimodels.GetCedarTestResultsOptions{
+				BaseURL:   evergreen.GetEnvironment().Settings().Cedar.BaseURL,
+				Execution: dbTask.Execution,
+			}
+
+			if len(baseTask.ExecutionTasks) > 0 {
+				baseTestResultOpts.DisplayTaskID = baseTask.Id
+			} else {
+				baseTestResultOpts.TaskID = baseTask.Id
+			}
+
+			cedarBaseTestResults, err := apimodels.GetCedarTestResults(ctx, baseTestResultOpts)
+			if err != nil {
+				grip.Warning(message.WrapError(err, message.Fields{
+					"task_id": baseTask.Id,
+					"message": "problem getting cedar test results",
+				}))
+			}
+			for _, t := range cedarBaseTestResults {
+				baseTestStatusMap[t.TestName] = t.Status
+			}
+		}
+
 		filteredTestResults, testCount := FilterSortAndPaginateCedarTestResults(FilterSortAndPaginateCedarTestResultsOpts{
 			GroupID:     groupIdParam,
 			Limit:       limitParam,
@@ -1386,7 +1409,8 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 				formattedURL := fmt.Sprintf("%s%s", r.sc.GetURL(), *apiTest.Logs.RawDisplayURL)
 				apiTest.Logs.RawDisplayURL = &formattedURL
 			}
-
+			baseTestStatus := baseTestStatusMap[*apiTest.TestFile]
+			apiTest.BaseStatus = &baseTestStatus
 			testPointers = append(testPointers, &apiTest)
 		}
 


### PR DESCRIPTION
[EVG-14776](https://jira.mongodb.org/browse/EVG-14776)

### Description 
Resolves base test statuses when the gql TaskTests query utilizes cedar 

### Testing 
It seems that the best way to test is in staging since our gql test framework cannot talk to cedar