### PR TITLE
EVG-14088: Support config expansions in attach.xunit_results

### DIFF
--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -44,6 +45,10 @@ func (c *xunitResults) ParseParams(params map[string]interface{}) error {
 
 // Expand the parameter appropriately
 func (c *xunitResults) expandParams(conf *internal.TaskConfig) error {
+	if err := util.ExpandValues(c, conf.Expansions); err != nil {
+		return errors.Wrap(err, "error expanding params")
+	}
+
 	if c.File != "" {
 		c.Files = append(c.Files, c.File)
 	}
@@ -65,7 +70,7 @@ func (c *xunitResults) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
 	if err := c.expandParams(conf); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	errChan := make(chan error)

--- a/agent/command/results_xunit_test.go
+++ b/agent/command/results_xunit_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	agentutil "github.com/evergreen-ci/evergreen/agent/internal/testutil"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
 	modelutil "github.com/evergreen-ci/evergreen/model/testutil"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -197,5 +199,40 @@ func TestXUnitParseAndUpload(t *testing.T) {
 				}
 			}
 		}
+	})
+}
+
+func TestExpandParams(t *testing.T) {
+
+	Convey("With an xunitResults command and a task config", t, func() {
+
+		var cmd *xunitResults
+		var conf *internal.TaskConfig
+
+		Convey("when expanding the command's params", func() {
+
+			cmd = &xunitResults{}
+			conf = &internal.TaskConfig{
+				Expansions: util.NewExpansions(map[string]string{}),
+			}
+
+			Convey("all appropriate values should be expanded, if they"+
+				" contain expansions", func() {
+
+				cmd.File = "${file}"
+
+				conf.Expansions.Update(
+					map[string]string{
+						"file": "filecontent",
+					},
+				)
+
+				So(cmd.expandParams(conf), ShouldBeNil)
+				So(cmd.File, ShouldEqual, "filecontent")
+
+			})
+
+		})
+
 	})
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-07-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-07-20"
+	AgentVersion = "2021-07-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2789,6 +2789,8 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 		taskNamesAsRegex := strings.Join(opts.TaskNames, "|")
 		match[DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex, "$options": "i"}
 	}
+	// Activated Time is needed to filter out generated tasks that have been generated but not yet activated
+	match[ActivatedTimeKey] = bson.M{"$ne": utility.ZeroTime}
 	match[VersionKey] = versionID
 	const tempParentKey = "_parent"
 	pipeline := []bson.M{}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2789,8 +2789,6 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 		taskNamesAsRegex := strings.Join(opts.TaskNames, "|")
 		match[DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex, "$options": "i"}
 	}
-	// Activated Time is needed to filter out generated tasks that have been generated but not yet activated
-	match[ActivatedTimeKey] = bson.M{"$ne": utility.ZeroTime}
 	match[VersionKey] = versionID
 	const tempParentKey = "_parent"
 	pipeline := []bson.M{}


### PR DESCRIPTION
[EVG-14088](https://jira.mongodb.org/browse/EVG-14088)

### Description 
User has notified [here](https://github.com/mongodb/mongo-php-driver/pull/1200) expansions on specific properties for attach.xunit_results does not work.  In Evergreen the "file" and "files" properties are indeed expanded and support expansions, but no other properties in the input are expanded.  Change has been made to expand any appropriate properties in the input.