### PR TITLE
EVG-15097: implement pod REST model

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -54,11 +54,11 @@ func ExportPodStatus(s pod.Status) (cocoa.ECSPodStatus, error) {
 	case pod.StatusInitializing:
 		return "", errors.Errorf("a pod that is initializing does not exist in ECS yet")
 	case pod.StatusStarting:
-		return cocoa.StartingStatus, nil
+		return cocoa.StatusStarting, nil
 	case pod.StatusRunning:
-		return cocoa.RunningStatus, nil
+		return cocoa.StatusRunning, nil
 	case pod.StatusTerminated:
-		return cocoa.DeletedStatus, nil
+		return cocoa.StatusDeleted, nil
 	default:
 		return "", errors.Errorf("no equivalent ECS status for pod status '%s'", s)
 	}

--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -116,17 +116,17 @@ func TestExportPodStatus(t *testing.T) {
 	t.Run("SucceedsWithStartingStatus", func(t *testing.T) {
 		s, err := ExportPodStatus(pod.StatusStarting)
 		require.NoError(t, err)
-		assert.Equal(t, cocoa.StartingStatus, s)
+		assert.Equal(t, cocoa.StatusStarting, s)
 	})
 	t.Run("SucceedsWithRunningStatus", func(t *testing.T) {
 		s, err := ExportPodStatus(pod.StatusRunning)
 		require.NoError(t, err)
-		assert.Equal(t, cocoa.RunningStatus, s)
+		assert.Equal(t, cocoa.StatusRunning, s)
 	})
 	t.Run("SucceedsWithTerminatedStatus", func(t *testing.T) {
 		s, err := ExportPodStatus(pod.StatusTerminated)
 		require.NoError(t, err)
-		assert.Equal(t, cocoa.DeletedStatus, s)
+		assert.Equal(t, cocoa.StatusDeleted, s)
 	})
 	t.Run("FailsWithInitializingStatus", func(t *testing.T) {
 		s, err := ExportPodStatus(pod.StatusInitializing)

--- a/glide.lock
+++ b/glide.lock
@@ -125,7 +125,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: 43815750c2f1d63d1f1de803a8a684ca79ac82d6
   - name: github.com/evergreen-ci/cocoa
-    version: 0e769629f723d572636fcd2facb5e5105e023ae7
+    version: b506293ff3a601a3e97f31d953c852ea2ba0f2b4
   - name: github.com/evergreen-ci/gimlet
     version: 8dca136b41a0e843be10b96d639e8e706e9503ea
   - name: github.com/evergreen-ci/shrub

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -74,7 +74,7 @@ type TaskContainerCreationOptions struct {
 	// EnvSecrets is a mapping of secret names to secret values to expose in the
 	// task's container environment variables. The secret name is the
 	// environment variable name.
-	EnvSecrets map[string]string `bson:"secrets,omitempty" json:"secrets,omitempty"`
+	EnvSecrets map[string]string `bson:"env_secrets,omitempty" json:"env_secrets,omitempty"`
 }
 
 // IsZero implements the bsoncodec.Zeroer interface for the sake of defining the

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -55,8 +55,14 @@ type ResourceInfo struct {
 	SecretIDs []string `bson:"secret_ids" json:"secret_ids"`
 }
 
-// TaskCreationOptions are options to apply to the task's container when
-// creating a pod in the container orchestration service.
+// IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
+// zero value for BSON marshalling.
+func (o ResourceInfo) IsZero() bool {
+	return o.ID == "" && o.DefinitionID == "" && o.Cluster == "" && len(o.SecretIDs) == 0
+}
+
+// TaskContainerCreationOptions are options to apply to the task's container
+// when creating a pod in the container orchestration service.
 type TaskContainerCreationOptions struct {
 	// Image is the image that the task's container will run.
 	Image string `bson:"image" json:"image"`
@@ -80,7 +86,7 @@ type TaskContainerCreationOptions struct {
 // IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
 // zero value for BSON marshalling.
 func (o TaskContainerCreationOptions) IsZero() bool {
-	return o.Image == "" && o.MemoryMB == 0 && o.CPU == 0 && o.Platform == "" && o.EnvVars == nil && o.EnvSecrets == nil
+	return o.Image == "" && o.MemoryMB == 0 && o.CPU == 0 && o.Platform == "" && len(o.EnvVars) == 0 && len(o.EnvSecrets) == 0
 }
 
 // Insert inserts a new pod into the collection.

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/manifest"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/model/reliability"
 	"github.com/evergreen-ci/evergreen/model/stats"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -299,6 +300,8 @@ type Connector interface {
 
 	// CreatePod creates a new pod and returns the result of creating the pod.
 	CreatePod(restModel.APICreatePod) (*restModel.APICreatePodResponse, error)
+	// FindPodByID finds a pod by the given ID.
+	FindPodByID(id string) (*pod.Pod, error)
 	// CheckPodSecret checks that the ID and secret match the server's
 	// stored credentials for the pod.
 	CheckPodSecret(id, secret string) error

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -18,7 +18,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/manifest"
 	"github.com/evergreen-ci/evergreen/model/patch"
-	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/model/reliability"
 	"github.com/evergreen-ci/evergreen/model/stats"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -301,7 +300,7 @@ type Connector interface {
 	// CreatePod creates a new pod and returns the result of creating the pod.
 	CreatePod(restModel.APICreatePod) (*restModel.APICreatePodResponse, error)
 	// FindPodByID finds a pod by the given ID.
-	FindPodByID(id string) (*pod.Pod, error)
+	FindPodByID(id string) (*restModel.APIPod, error)
 	// CheckPodSecret checks that the ID and secret match the server's
 	// stored credentials for the pod.
 	CheckPodSecret(id, secret string) error

--- a/rest/data/pod.go
+++ b/rest/data/pod.go
@@ -49,7 +49,10 @@ func (c *DBPodConnector) CheckPodSecret(id, secret string) error {
 		}
 	}
 	if secret != p.Secret {
-		return errors.New("incorrect pod secret")
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusUnauthorized,
+			Message:    "pod secrets do not match",
+		}
 	}
 	return nil
 }

--- a/rest/data/pod_test.go
+++ b/rest/data/pod_test.go
@@ -24,7 +24,7 @@ func (s *podConnectorSuite) SetupTest() {
 	s.NoError(db.ClearCollections(pod.Collection))
 }
 
-func (s *podConnectorSuite) TeardownTest() {
+func (s *podConnectorSuite) TearDownTest() {
 	s.NoError(db.Clear(pod.Collection))
 }
 

--- a/rest/data/pod_test.go
+++ b/rest/data/pod_test.go
@@ -25,7 +25,7 @@ func (s *podConnectorSuite) SetupTest() {
 }
 
 func (s *podConnectorSuite) TearDownTest() {
-	s.NoError(db.Clear(pod.Collection))
+	s.NoError(db.ClearCollections(pod.Collection))
 }
 
 func (s *podConnectorSuite) TestCreatePod() {
@@ -57,7 +57,6 @@ func (s *podConnectorSuite) TestCreatePod() {
 	s.Require().NoError(err)
 	s.Assert().Equal("secret", podDB.Secret)
 	s.Assert().Equal("env_value", podDB.TaskContainerCreationOpts.EnvVars["env_name"])
-	s.NoError(db.Clear(pod.Collection))
 }
 
 func (s *podConnectorSuite) TestFindPodByIDSucceeds() {

--- a/rest/model/pod.go
+++ b/rest/model/pod.go
@@ -129,13 +129,13 @@ const (
 func (s *APIPodStatus) BuildFromService(ps pod.Status) error {
 	var converted APIPodStatus
 	switch ps {
-	case pod.InitializingStatus:
+	case pod.StatusInitializing:
 		converted = PodStatusInitializing
-	case pod.StartingStatus:
+	case pod.StatusStarting:
 		converted = PodStatusStarting
-	case pod.RunningStatus:
+	case pod.StatusRunning:
 		converted = PodStatusRunning
-	case pod.TerminatedStatus:
+	case pod.StatusTerminated:
 		converted = PodStatusTerminated
 	default:
 		return errors.Errorf("unrecognized pod status '%s'", ps)
@@ -147,13 +147,13 @@ func (s *APIPodStatus) BuildFromService(ps pod.Status) error {
 func (s *APIPodStatus) ToService() (pod.Status, error) {
 	switch *s {
 	case PodStatusInitializing:
-		return pod.InitializingStatus, nil
+		return pod.StatusTerminated, nil
 	case PodStatusStarting:
-		return pod.StartingStatus, nil
+		return pod.StatusStarting, nil
 	case PodStatusRunning:
-		return pod.RunningStatus, nil
+		return pod.StatusRunning, nil
 	case PodStatusTerminated:
-		return pod.TerminatedStatus, nil
+		return pod.StatusTerminated, nil
 	default:
 		return "", errors.Errorf("unrecognized pod status '%s'", s)
 	}
@@ -199,10 +199,10 @@ type APIPodResourceInfo struct {
 }
 
 func (i *APIPodResourceInfo) BuildFromService(info pod.ResourceInfo) {
-	i.ID = utility.ToStringPtr(v.ID)
-	i.DefinitionID = utility.ToStringPtr(v.DefinitionID)
-	i.Cluster = utility.ToStringPtr(v.Cluster)
-	i.SecretIDs = v.SecretIDs
+	i.ID = utility.ToStringPtr(info.ID)
+	i.DefinitionID = utility.ToStringPtr(info.DefinitionID)
+	i.Cluster = utility.ToStringPtr(info.Cluster)
+	i.SecretIDs = info.SecretIDs
 }
 
 func (i *APIPodResourceInfo) ToService() pod.ResourceInfo {

--- a/rest/model/pod.go
+++ b/rest/model/pod.go
@@ -6,6 +6,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
 )
 
 // APIPodEnvVar is the model for environment variables in a container.
@@ -69,4 +70,146 @@ func (p *APICreatePod) ToService() (interface{}, error) {
 			EnvSecrets: secrets,
 		},
 	}, nil
+}
+
+// kim: TODO: populate with all copy-pasted fields
+type APIPod struct {
+	ID                        *string                             `json:"id"`
+	Status                    *APIPodStatus                       `json:"status"`
+	Secret                    *string                             `json:"secret"`
+	TaskContainerCreationOpts *APIPodTaskContainerCreationOptions `json:"task_container_creation_opts"`
+	Resources                 *APIPodResourceInfo
+}
+
+func (p *APIPod) BuildFromService(dbPod *pod.Pod) error {
+	p.ID = utility.ToStringPtr(dbPod.ID)
+	var s APIPodStatus
+	if err := s.BuildFromService(dbPod.Status); err != nil {
+		return errors.Wrap(err, "building status from service")
+	}
+	p.Status = &s
+	p.Secret = utility.ToStringPtr(dbPod.Secret)
+	var taskCreationOpts APIPodTaskContainerCreationOptions
+	taskCreationOpts.BuildFromService(dbPod.TaskContainerCreationOpts)
+	p.TaskContainerCreationOpts = &taskCreationOpts
+	var resources APIPodResourceInfo
+	resources.BuildFromService(dbPod.Resources)
+	p.Resources = &resources
+	return nil
+}
+
+func (p *APIPod) ToService() (*pod.Pod, error) {
+	s, err := p.Status.ToService()
+	if err != nil {
+		return nil, errors.Wrap(err, "converting status to service")
+	}
+	taskCreationOpts, err := p.TaskContainerCreationOpts.ToService()
+	if err != nil {
+		return nil, errors.Wrap(err, "converting task container creation options to service")
+	}
+	resources := p.Resources.ToService()
+	return &pod.Pod{
+		ID:                        utility.FromStringPtr(p.ID),
+		Status:                    s,
+		Secret:                    utility.FromStringPtr(p.Secret),
+		TaskContainerCreationOpts: *taskCreationOpts,
+		Resources:                 resources,
+	}, nil
+}
+
+type APIPodStatus string
+
+const (
+	PodStatusInitializing APIPodStatus = "initializing"
+	PodStatusStarting     APIPodStatus = "starting"
+	PodStatusRunning      APIPodStatus = "running"
+	PodStatusTerminated   APIPodStatus = "terminated"
+)
+
+func (s *APIPodStatus) BuildFromService(ps pod.Status) error {
+	var converted APIPodStatus
+	switch ps {
+	case pod.InitializingStatus:
+		converted = PodStatusInitializing
+	case pod.StartingStatus:
+		converted = PodStatusStarting
+	case pod.RunningStatus:
+		converted = PodStatusRunning
+	case pod.TerminatedStatus:
+		converted = PodStatusTerminated
+	default:
+		return errors.Errorf("unrecognized pod status '%s'", ps)
+	}
+	s = &converted
+	return nil
+}
+
+func (s *APIPodStatus) ToService() (pod.Status, error) {
+	switch *s {
+	case PodStatusInitializing:
+		return pod.InitializingStatus, nil
+	case PodStatusStarting:
+		return pod.StartingStatus, nil
+	case PodStatusRunning:
+		return pod.RunningStatus, nil
+	case PodStatusTerminated:
+		return pod.TerminatedStatus, nil
+	default:
+		return "", errors.Errorf("unrecognized pod status '%s'", s)
+	}
+}
+
+type APIPodTaskContainerCreationOptions struct {
+	Image      *string                `json:"image"`
+	MemoryMB   *int                   `json:"memory_mb"`
+	CPU        *int                   `json:"cpu"`
+	Platform   *evergreen.PodPlatform `json:"platform"`
+	EnvVars    map[string]string      `json:"env_vars"`
+	EnvSecrets map[string]string      `json:"env_secrets"`
+}
+
+func (o *APIPodTaskContainerCreationOptions) BuildFromService(opts pod.TaskContainerCreationOptions) {
+	o.Image = utility.ToStringPtr(opts.Image)
+	o.MemoryMB = utility.ToIntPtr(opts.MemoryMB)
+	o.CPU = utility.ToIntPtr(opts.CPU)
+	o.Platform = &opts.Platform
+	o.EnvVars = opts.EnvVars
+	o.EnvSecrets = opts.EnvSecrets
+}
+
+func (i *APIPodTaskContainerCreationOptions) ToService() (*pod.TaskContainerCreationOptions, error) {
+	if i.Platform == nil {
+		return nil, errors.New("missing platform")
+	}
+	return &pod.TaskContainerCreationOptions{
+		Image:      utility.FromStringPtr(i.Image),
+		MemoryMB:   utility.FromIntPtr(i.MemoryMB),
+		CPU:        utility.FromIntPtr(i.CPU),
+		Platform:   *i.Platform,
+		EnvVars:    i.EnvVars,
+		EnvSecrets: i.EnvSecrets,
+	}, nil
+}
+
+type APIPodResourceInfo struct {
+	ID           *string  `json:"id"`
+	DefinitionID *string  `json:"definition_id"`
+	Cluster      *string  `json:"cluster"`
+	SecretIDs    []string `json:"secret_i_ds"`
+}
+
+func (i *APIPodResourceInfo) BuildFromService(info pod.ResourceInfo) {
+	i.ID = utility.ToStringPtr(v.ID)
+	i.DefinitionID = utility.ToStringPtr(v.DefinitionID)
+	i.Cluster = utility.ToStringPtr(v.Cluster)
+	i.SecretIDs = v.SecretIDs
+}
+
+func (i *APIPodResourceInfo) ToService() pod.ResourceInfo {
+	return pod.ResourceInfo{
+		ID:           utility.FromStringPtr(i.ID),
+		DefinitionID: utility.FromStringPtr(i.DefinitionID),
+		Cluster:      utility.FromStringPtr(i.Cluster),
+		SecretIDs:    i.SecretIDs,
+	}
 }

--- a/rest/model/pod_test.go
+++ b/rest/model/pod_test.go
@@ -3,53 +3,194 @@ package model
 import (
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPodToService(t *testing.T) {
-	apiPod := APICreatePod{
-		Name:   utility.ToStringPtr("id"),
-		Memory: utility.ToIntPtr(128),
-		CPU:    utility.ToIntPtr(128),
-		Image:  utility.ToStringPtr("image"),
-		EnvVars: []*APIPodEnvVar{
-			{
-				Name:   utility.ToStringPtr("name"),
-				Value:  utility.ToStringPtr("value"),
-				Secret: utility.ToBoolPtr(false),
+func TestAPICreatePod(t *testing.T) {
+	t.Run("ToService", func(t *testing.T) {
+		apiPod := APICreatePod{
+			Name:   utility.ToStringPtr("id"),
+			Memory: utility.ToIntPtr(128),
+			CPU:    utility.ToIntPtr(128),
+			Image:  utility.ToStringPtr("image"),
+			EnvVars: []*APIPodEnvVar{
+				{
+					Name:   utility.ToStringPtr("name"),
+					Value:  utility.ToStringPtr("value"),
+					Secret: utility.ToBoolPtr(false),
+				},
+				{
+					Name:   utility.ToStringPtr("name1"),
+					Value:  utility.ToStringPtr("value1"),
+					Secret: utility.ToBoolPtr(false),
+				},
+				{
+					Name:   utility.ToStringPtr("secret_name"),
+					Value:  utility.ToStringPtr("secret_value"),
+					Secret: utility.ToBoolPtr(true),
+				},
 			},
-			{
-				Name:   utility.ToStringPtr("name1"),
-				Value:  utility.ToStringPtr("value1"),
-				Secret: utility.ToBoolPtr(false),
+			Platform: utility.ToStringPtr("linux"),
+			Secret:   utility.ToStringPtr("secret"),
+		}
+
+		res, err := apiPod.ToService()
+		require.NoError(t, err)
+
+		p, ok := res.(pod.Pod)
+		require.True(t, ok)
+
+		assert.Equal(t, utility.FromStringPtr(apiPod.Secret), p.Secret)
+		assert.Equal(t, utility.FromStringPtr(apiPod.Image), p.TaskContainerCreationOpts.Image)
+		assert.Equal(t, utility.FromIntPtr(apiPod.Memory), p.TaskContainerCreationOpts.MemoryMB)
+		assert.Equal(t, utility.FromIntPtr(apiPod.CPU), p.TaskContainerCreationOpts.CPU)
+		assert.Equal(t, utility.FromStringPtr(apiPod.Platform), string(p.TaskContainerCreationOpts.Platform))
+		assert.Equal(t, utility.FromStringPtr(apiPod.Secret), p.Secret)
+		assert.Equal(t, pod.StatusInitializing, p.Status)
+		assert.Len(t, p.TaskContainerCreationOpts.EnvVars, 2)
+		assert.Len(t, p.TaskContainerCreationOpts.EnvSecrets, 1)
+		assert.Equal(t, "value1", p.TaskContainerCreationOpts.EnvVars["name1"])
+		assert.Equal(t, "secret_value", p.TaskContainerCreationOpts.EnvSecrets["secret_name"])
+	})
+}
+
+func TestAPIPod(t *testing.T) {
+	validDBPod := func() pod.Pod {
+		return pod.Pod{
+			ID:     "id",
+			Status: pod.StatusRunning,
+			Secret: "secret",
+			TaskContainerCreationOpts: pod.TaskContainerCreationOptions{
+				Image:    "image",
+				MemoryMB: 128,
+				CPU:      128,
+				EnvVars: map[string]string{
+					"var0": "val0",
+					"var1": "val1",
+				},
+				EnvSecrets: map[string]string{
+					"secret0": "secret_val0",
+					"secret1": "secret_val1",
+				},
 			},
-			{
-				Name:   utility.ToStringPtr("secret_name"),
-				Value:  utility.ToStringPtr("secret_value"),
-				Secret: utility.ToBoolPtr(true),
+			Resources: pod.ResourceInfo{
+				ID:           "id",
+				DefinitionID: "definition_id",
+				Cluster:      "cluster",
+				SecretIDs:    []string{"secret_id0", "secret_id1"},
 			},
-		},
-		Platform: utility.ToStringPtr("linux"),
-		Secret:   utility.ToStringPtr("secret"),
+		}
 	}
 
-	res, err := apiPod.ToService()
-	require.NoError(t, err)
-
-	p, ok := res.(pod.Pod)
-	require.True(t, ok)
-
-	assert.Equal(t, utility.FromStringPtr(apiPod.Secret), p.Secret)
-	assert.Equal(t, utility.FromStringPtr(apiPod.Image), p.TaskContainerCreationOpts.Image)
-	assert.Equal(t, utility.FromIntPtr(apiPod.Memory), p.TaskContainerCreationOpts.MemoryMB)
-	assert.Equal(t, utility.FromIntPtr(apiPod.CPU), p.TaskContainerCreationOpts.CPU)
-	assert.Equal(t, utility.FromStringPtr(apiPod.Platform), string(p.TaskContainerCreationOpts.Platform))
-	assert.Equal(t, utility.FromStringPtr(apiPod.Secret), p.Secret)
-	assert.Len(t, p.TaskContainerCreationOpts.EnvVars, 2)
-	assert.Len(t, p.TaskContainerCreationOpts.EnvSecrets, 1)
-	assert.Equal(t, "value1", p.TaskContainerCreationOpts.EnvVars["name1"])
-	assert.Equal(t, "secret_value", p.TaskContainerCreationOpts.EnvSecrets["secret_name"])
+	validAPIPod := func() APIPod {
+		status := PodStatusRunning
+		platform := evergreen.PodPlatformLinux
+		return APIPod{
+			ID:     utility.ToStringPtr("id"),
+			Status: &status,
+			Secret: utility.ToStringPtr("secret"),
+			TaskContainerCreationOpts: APIPodTaskContainerCreationOptions{
+				Image:    utility.ToStringPtr("image"),
+				MemoryMB: utility.ToIntPtr(128),
+				CPU:      utility.ToIntPtr(128),
+				Platform: &platform,
+				EnvVars: map[string]string{
+					"var0": "val0",
+					"var1": "val1",
+				},
+				EnvSecrets: map[string]string{
+					"secret0": "secret_val0",
+					"secret1": "secret_val1",
+				},
+			},
+			Resources: APIPodResourceInfo{
+				ID:           utility.ToStringPtr("id"),
+				DefinitionID: utility.ToStringPtr("definition_id"),
+				Cluster:      utility.ToStringPtr("cluster"),
+				SecretIDs:    []string{"secret_id0", "secret_id1"},
+			},
+		}
+	}
+	t.Run("ToService", func(t *testing.T) {
+		t.Run("Succeeds", func(t *testing.T) {
+			apiPod := validAPIPod()
+			dbPod, err := apiPod.ToService()
+			require.NoError(t, err)
+			assert.Equal(t, utility.FromStringPtr(apiPod.ID), dbPod.ID)
+			assert.Equal(t, pod.StatusRunning, dbPod.Status)
+			assert.Equal(t, utility.FromStringPtr(apiPod.Secret), dbPod.Secret)
+			assert.Equal(t, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.Image), dbPod.TaskContainerCreationOpts.Image)
+			assert.Equal(t, utility.FromIntPtr(apiPod.TaskContainerCreationOpts.MemoryMB), dbPod.TaskContainerCreationOpts.MemoryMB)
+			assert.Equal(t, utility.FromIntPtr(apiPod.TaskContainerCreationOpts.CPU), dbPod.TaskContainerCreationOpts.CPU)
+			assert.Equal(t, *apiPod.TaskContainerCreationOpts.Platform, dbPod.TaskContainerCreationOpts.Platform)
+			require.NotZero(t, dbPod.TaskContainerCreationOpts.EnvVars)
+			for k, v := range apiPod.TaskContainerCreationOpts.EnvVars {
+				assert.Equal(t, v, dbPod.TaskContainerCreationOpts.EnvVars[k])
+			}
+			require.NotZero(t, dbPod.TaskContainerCreationOpts.EnvSecrets)
+			for k, v := range apiPod.TaskContainerCreationOpts.EnvSecrets {
+				assert.Equal(t, v, dbPod.TaskContainerCreationOpts.EnvSecrets[k])
+			}
+			assert.Equal(t, utility.FromStringPtr(apiPod.Resources.ID), dbPod.Resources.ID)
+			assert.Equal(t, utility.FromStringPtr(apiPod.Resources.DefinitionID), dbPod.Resources.DefinitionID)
+			assert.Equal(t, utility.FromStringPtr(apiPod.Resources.Cluster), dbPod.Resources.Cluster)
+			left, right := utility.StringSliceSymmetricDifference(dbPod.Resources.SecretIDs, apiPod.Resources.SecretIDs)
+			assert.Empty(t, left)
+			assert.Empty(t, right)
+		})
+		t.Run("FailsWithInvalidStatus", func(t *testing.T) {
+			apiPod := validAPIPod()
+			status := APIPodStatus("invalid")
+			apiPod.Status = &status
+			apiPod.TaskContainerCreationOpts.Platform = nil
+			_, err := apiPod.ToService()
+			assert.Error(t, err)
+		})
+		t.Run("FailsWithoutPlatform", func(t *testing.T) {
+			apiPod := validAPIPod()
+			apiPod.TaskContainerCreationOpts.Platform = nil
+			_, err := apiPod.ToService()
+			assert.Error(t, err)
+		})
+	})
+	t.Run("BuildFromService", func(t *testing.T) {
+		t.Run("Succeeds", func(t *testing.T) {
+			dbPod := validDBPod()
+			var apiPod APIPod
+			require.NoError(t, apiPod.BuildFromService(&dbPod))
+			assert.Equal(t, dbPod.ID, utility.FromStringPtr(apiPod.ID))
+			require.NotZero(t, apiPod.Status)
+			assert.Equal(t, PodStatusRunning, *apiPod.Status)
+			assert.Equal(t, dbPod.Secret, utility.FromStringPtr(apiPod.Secret))
+			assert.Equal(t, dbPod.TaskContainerCreationOpts.Image, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.Image))
+			assert.Equal(t, dbPod.TaskContainerCreationOpts.MemoryMB, utility.FromIntPtr(apiPod.TaskContainerCreationOpts.MemoryMB))
+			assert.Equal(t, dbPod.TaskContainerCreationOpts.CPU, utility.FromIntPtr(apiPod.TaskContainerCreationOpts.CPU))
+			require.NotZero(t, apiPod.TaskContainerCreationOpts.Platform)
+			assert.Equal(t, dbPod.TaskContainerCreationOpts.Platform, *apiPod.TaskContainerCreationOpts.Platform)
+			require.NotZero(t, apiPod.TaskContainerCreationOpts.EnvVars)
+			for k, v := range dbPod.TaskContainerCreationOpts.EnvVars {
+				assert.Equal(t, v, apiPod.TaskContainerCreationOpts.EnvVars[k])
+			}
+			require.NotZero(t, apiPod.TaskContainerCreationOpts.EnvSecrets)
+			for k, v := range dbPod.TaskContainerCreationOpts.EnvSecrets {
+				assert.Equal(t, v, apiPod.TaskContainerCreationOpts.EnvSecrets[k])
+			}
+			assert.Equal(t, dbPod.Resources.ID, utility.FromStringPtr(apiPod.Resources.ID))
+			assert.Equal(t, dbPod.Resources.DefinitionID, utility.FromStringPtr(apiPod.Resources.DefinitionID))
+			assert.Equal(t, dbPod.Resources.Cluster, utility.FromStringPtr(apiPod.Resources.Cluster))
+			left, right := utility.StringSliceSymmetricDifference(dbPod.Resources.SecretIDs, apiPod.Resources.SecretIDs)
+			assert.Empty(t, left)
+			assert.Empty(t, right)
+		})
+		t.Run("FailsWithInvalidStatus", func(t *testing.T) {
+			dbPod := validDBPod()
+			dbPod.Status = "invalid"
+			var apiPod APIPod
+			assert.Error(t, apiPod.BuildFromService(&dbPod))
+		})
+	})
 }

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -330,28 +330,19 @@ func (m *podAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, n
 	id := gimlet.GetVars(r)["pod_id"]
 	if id == "" {
 		if id = r.Header.Get(evergreen.PodHeader); id == "" {
-			gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-				StatusCode: http.StatusUnauthorized,
-				Message:    "missing pod ID",
-			}))
+			gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(errors.New("missing pod ID")))
 			return
 		}
 	}
 
 	secret := r.Header.Get(evergreen.PodSecretHeader)
 	if secret == "" {
-		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusUnauthorized,
-			Message:    "missing pod secret",
-		}))
+		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(errors.New("missing pod secret")))
 		return
 	}
 
 	if err := m.sc.CheckPodSecret(id, secret); err != nil {
-		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusUnauthorized,
-			Message:    err.Error(),
-		}))
+		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(err))
 		return
 	}
 

--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -47,7 +47,7 @@ func TestTerminatePodJob(t *testing.T) {
 
 			info, err := j.ecsPod.Info(ctx)
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.DeletedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusDeleted, info.Status)
 		},
 		"SucceedsWithPodFromDB": func(ctx context.Context, t *testing.T, j *terminatePodJob) {
 			require.NoError(t, j.pod.Insert())
@@ -68,7 +68,7 @@ func TestTerminatePodJob(t *testing.T) {
 
 			info, err := j.ecsPod.Info(ctx)
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.DeletedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusDeleted, info.Status)
 		},
 		"FailsWhenDeletingResourcesErrors": func(ctx context.Context, t *testing.T, j *terminatePodJob) {
 			require.NoError(t, j.pod.Insert())

--- a/vendor/github.com/evergreen-ci/cocoa/ecs/pod.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs/pod.go
@@ -126,8 +126,8 @@ func (p *BasicECSPod) Info(ctx context.Context) (*cocoa.ECSPodInfo, error) {
 // Stop stops the running pod without cleaning up any of its underlying
 // resources.
 func (p *BasicECSPod) Stop(ctx context.Context) error {
-	if p.status != cocoa.RunningStatus {
-		return errors.Errorf("pod can only be stopped when status is '%s', but current status is '%s'", cocoa.RunningStatus, p.status)
+	if p.status != cocoa.StatusRunning {
+		return errors.Errorf("pod can only be stopped when status is '%s', but current status is '%s'", cocoa.StatusRunning, p.status)
 	}
 
 	stopTask := &ecs.StopTaskInput{}
@@ -137,7 +137,7 @@ func (p *BasicECSPod) Stop(ctx context.Context) error {
 		return errors.Wrap(err, "stopping pod")
 	}
 
-	p.status = cocoa.StoppedStatus
+	p.status = cocoa.StatusStopped
 
 	return nil
 }
@@ -165,7 +165,7 @@ func (p *BasicECSPod) Delete(ctx context.Context) error {
 		}
 	}
 
-	p.status = cocoa.DeletedStatus
+	p.status = cocoa.StatusDeleted
 
 	return nil
 }

--- a/vendor/github.com/evergreen-ci/cocoa/ecs/pod_creator.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs/pod_creator.go
@@ -90,7 +90,7 @@ func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPo
 	options := NewBasicECSPodOptions().
 		SetClient(m.client).
 		SetVault(m.vault).
-		SetStatus(cocoa.RunningStatus).
+		SetStatus(cocoa.StatusRunning).
 		SetResources(*resources)
 
 	p, err := NewBasicECSPod(options)

--- a/vendor/github.com/evergreen-ci/cocoa/ecs/pod_test.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs/pod_test.go
@@ -34,7 +34,7 @@ func TestBasicECSPod(t *testing.T) {
 		},
 		"InfoIsPopulated": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			res := cocoa.NewECSPodResources().SetTaskID("task_id")
-			stat := cocoa.StartingStatus
+			stat := cocoa.StatusStarting
 			opts := NewBasicECSPodOptions().SetClient(c).SetResources(*res).SetStatus(stat)
 
 			p, err := NewBasicECSPod(opts)
@@ -146,7 +146,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 		assert.Equal(t, *res, *opts.Resources)
 	})
 	t.Run("SetStatus", func(t *testing.T) {
-		stat := cocoa.StartingStatus
+		stat := cocoa.StatusStarting
 		opts := NewBasicECSPodOptions().SetStatus(stat)
 		require.NotNil(t, opts.Status)
 		assert.Equal(t, stat, *opts.Status)
@@ -168,7 +168,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 				SetClient(ecsClient).
 				SetVault(v).
 				SetResources(*res).
-				SetStatus(cocoa.StartingStatus)
+				SetStatus(cocoa.StatusStarting)
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("MissingClientIsInvalid", func(t *testing.T) {
@@ -180,7 +180,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			opts := NewBasicECSPodOptions().
 				SetVault(v).
 				SetResources(*res).
-				SetStatus(cocoa.StartingStatus)
+				SetStatus(cocoa.StatusStarting)
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("MissingVaultIsValid", func(t *testing.T) {
@@ -191,7 +191,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			opts := NewBasicECSPodOptions().
 				SetClient(ecsClient).
 				SetResources(*res).
-				SetStatus(cocoa.StartingStatus)
+				SetStatus(cocoa.StatusStarting)
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("MissingResourcesIsInvalid", func(t *testing.T) {
@@ -203,7 +203,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			opts := NewBasicECSPodOptions().
 				SetVault(v).
 				SetResources(*res).
-				SetStatus(cocoa.StartingStatus)
+				SetStatus(cocoa.StatusStarting)
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("BadResourcesIsInvalid", func(t *testing.T) {
@@ -213,7 +213,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			v := secret.NewBasicSecretsManager(smClient)
 			opts := NewBasicECSPodOptions().
 				SetVault(v).
-				SetStatus(cocoa.StartingStatus)
+				SetStatus(cocoa.StatusStarting)
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("MissingStatusIsInvalid", func(t *testing.T) {

--- a/vendor/github.com/evergreen-ci/cocoa/ecs_pod.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs_pod.go
@@ -105,22 +105,22 @@ func (s *PodSecret) SetOwned(owned bool) *PodSecret {
 type ECSPodStatus string
 
 const (
-	// StartingStatus indicates that the ECS pod is being prepared to run.
-	StartingStatus ECSPodStatus = "starting"
-	// RunningStatus indicates that the ECS pod is actively running.
-	RunningStatus ECSPodStatus = "running"
-	// StoppedStatus indicates the that ECS pod is stopped, but all of its
+	// StatusStarting indicates that the ECS pod is being prepared to run.
+	StatusStarting ECSPodStatus = "starting"
+	// StatusRunning indicates that the ECS pod is actively running.
+	StatusRunning ECSPodStatus = "running"
+	// StatusStopped indicates the that ECS pod is stopped, but all of its
 	// resources are still available.
-	StoppedStatus ECSPodStatus = "stopped"
-	// DeletedStatus indicates that the ECS pod has been cleaned up completely,
+	StatusStopped ECSPodStatus = "stopped"
+	// StatusDeleted indicates that the ECS pod has been cleaned up completely,
 	// including all of its resources.
-	DeletedStatus ECSPodStatus = "deleted"
+	StatusDeleted ECSPodStatus = "deleted"
 )
 
 // Validate checks that the ECS pod status is one of the recognized statuses.
 func (s ECSPodStatus) Validate() error {
 	switch s {
-	case StartingStatus, RunningStatus, StoppedStatus, DeletedStatus:
+	case StatusStarting, StatusRunning, StatusStopped, StatusDeleted:
 		return nil
 	default:
 		return errors.Errorf("unrecognized status '%s'", s)

--- a/vendor/github.com/evergreen-ci/cocoa/ecs_pod_creator.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs_pod_creator.go
@@ -183,7 +183,7 @@ func (o *ECSPodCreationOptions) Validate() error {
 	}
 
 	if o.ExecutionOpts == nil {
-		placementOpts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter(BinpackMemory)
+		placementOpts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamBinpackMemory)
 		o.ExecutionOpts = NewECSPodExecutionOptions().SetPlacementOptions(*placementOpts)
 	}
 
@@ -553,7 +553,7 @@ func (o *ECSPodExecutionOptions) Validate() error {
 	}
 
 	if o.PlacementOpts == nil {
-		o.PlacementOpts = NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter(BinpackMemory)
+		o.PlacementOpts = NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamBinpackMemory)
 	}
 
 	return nil
@@ -602,8 +602,8 @@ func (o *ECSPodPlacementOptions) Validate() error {
 		catcher.Add(o.Strategy.Validate())
 	}
 	if o.Strategy != nil && o.StrategyParameter != nil {
-		catcher.ErrorfWhen(*o.Strategy == BinpackPlacement && *o.StrategyParameter != BinpackMemory && *o.StrategyParameter != BinpackCPU, "strategy parameter cannot be '%s' when the strategy is '%s'", *o.StrategyParameter, *o.Strategy)
-		catcher.ErrorfWhen(*o.Strategy != SpreadPlacement && *o.StrategyParameter == SpreadHost, "strategy parameter cannot be '%s' when the strategy is not '%s'", *o.StrategyParameter, SpreadPlacement)
+		catcher.ErrorfWhen(*o.Strategy == StrategyBinpack && *o.StrategyParameter != StrategyParamBinpackMemory && *o.StrategyParameter != StrategyParamBinpackCPU, "strategy parameter cannot be '%s' when the strategy is '%s'", *o.StrategyParameter, *o.Strategy)
+		catcher.ErrorfWhen(*o.Strategy != StrategySpread && *o.StrategyParameter == StrategyParamSpreadHost, "strategy parameter cannot be '%s' when the strategy is not '%s'", *o.StrategyParameter, StrategySpread)
 	}
 
 	if catcher.HasErrors() {
@@ -611,16 +611,16 @@ func (o *ECSPodPlacementOptions) Validate() error {
 	}
 
 	if o.Strategy == nil {
-		strategy := BinpackPlacement
+		strategy := StrategyBinpack
 		o.Strategy = &strategy
 	}
 
 	if o.Strategy != nil && o.StrategyParameter == nil {
-		if *o.Strategy == BinpackPlacement {
-			o.StrategyParameter = utility.ToStringPtr(BinpackMemory)
+		if *o.Strategy == StrategyBinpack {
+			o.StrategyParameter = utility.ToStringPtr(StrategyParamBinpackMemory)
 		}
-		if *o.Strategy == SpreadPlacement {
-			o.StrategyParameter = utility.ToStringPtr(SpreadHost)
+		if *o.Strategy == StrategySpread {
+			o.StrategyParameter = utility.ToStringPtr(StrategyParamSpreadHost)
 		}
 	}
 
@@ -631,23 +631,23 @@ func (o *ECSPodPlacementOptions) Validate() error {
 type ECSPlacementStrategy string
 
 const (
-	// SpreadPlacement indicates that the ECS pod will be assigned in such a way
+	// StrategySpread indicates that the ECS pod will be assigned in such a way
 	// to achieve an even spread based on the given ECSStrategyParameter.
-	SpreadPlacement ECSPlacementStrategy = ecs.PlacementStrategyTypeSpread
-	// RandomPlacement indicates that the ECS pod should be assigned to a
+	StrategySpread ECSPlacementStrategy = ecs.PlacementStrategyTypeSpread
+	// StrategyRandom indicates that the ECS pod should be assigned to a
 	// container instance randomly.
-	RandomPlacement ECSPlacementStrategy = ecs.PlacementStrategyTypeRandom
-	// BinpackPlacement indicates that the the ECS pod will be placed on a
+	StrategyRandom ECSPlacementStrategy = ecs.PlacementStrategyTypeRandom
+	// StrategyBinpack indicates that the the ECS pod will be placed on a
 	// container instance with the least amount of memory or CPU that will be
 	// sufficient for the pod's requirements if possible.
-	BinpackPlacement ECSPlacementStrategy = ecs.PlacementStrategyTypeBinpack
+	StrategyBinpack ECSPlacementStrategy = ecs.PlacementStrategyTypeBinpack
 )
 
 // Validate checks that the ECS pod status is one of the recognized placement
 // strategies.
 func (s ECSPlacementStrategy) Validate() error {
 	switch s {
-	case SpreadPlacement, RandomPlacement, BinpackPlacement:
+	case StrategySpread, StrategyRandom, StrategyBinpack:
 		return nil
 	default:
 		return errors.Errorf("unrecognized placement strategy '%s'", s)
@@ -659,15 +659,15 @@ func (s ECSPlacementStrategy) Validate() error {
 type ECSStrategyParameter = string
 
 const (
-	// BinpackMemory indicates ECS should optimize its binpacking strategy based
+	// StrategyParamBinpackMemory indicates ECS should optimize its binpacking strategy based
 	// on memory usage.
-	BinpackMemory ECSStrategyParameter = "memory"
-	// BinpackCPU indicates ECS should optimize its binpacking strategy based
+	StrategyParamBinpackMemory ECSStrategyParameter = "memory"
+	// StrategyParamBinpackCPU indicates ECS should optimize its binpacking strategy based
 	// on CPU usage.
-	BinpackCPU ECSStrategyParameter = "cpu"
-	// SpreadHost indicates the ECS should spread pods evenly across all
+	StrategyParamBinpackCPU ECSStrategyParameter = "cpu"
+	// StrategyParamSpreadHost indicates the ECS should spread pods evenly across all
 	// container instances (i.e. hosts).
-	SpreadHost ECSStrategyParameter = "host"
+	StrategyParamSpreadHost ECSStrategyParameter = "host"
 )
 
 // ECSTaskDefinition represents options for an existing ECS task definition.

--- a/vendor/github.com/evergreen-ci/cocoa/ecs_pod_creator_test.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs_pod_creator_test.go
@@ -412,7 +412,7 @@ func TestECSPodExecutionOptions(t *testing.T) {
 		assert.Equal(t, cluster, utility.FromStringPtr(opts.Cluster))
 	})
 	t.Run("SetPlacementOptions", func(t *testing.T) {
-		placementOpts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement)
+		placementOpts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack)
 		opts := NewECSPodExecutionOptions().SetPlacementOptions(*placementOpts)
 		require.NotZero(t, opts.PlacementOpts)
 		assert.Equal(t, *placementOpts, *opts.PlacementOpts)
@@ -455,8 +455,8 @@ func TestECSPodExecutionOptions(t *testing.T) {
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.PlacementOpts)
 			require.NotZero(t, opts.PlacementOpts.Strategy)
-			assert.Equal(t, BinpackPlacement, *opts.PlacementOpts.Strategy)
-			assert.Equal(t, BinpackMemory, utility.FromStringPtr(opts.PlacementOpts.StrategyParameter))
+			assert.Equal(t, StrategyBinpack, *opts.PlacementOpts.Strategy)
+			assert.Equal(t, StrategyParamBinpackMemory, utility.FromStringPtr(opts.PlacementOpts.StrategyParameter))
 		})
 		t.Run("BadPlacementOptionsAreInvalid", func(t *testing.T) {
 			placementOpts := NewECSPodPlacementOptions().SetStrategy("foo")
@@ -473,13 +473,13 @@ func TestECSPodPlacementOptions(t *testing.T) {
 		assert.Zero(t, *opts)
 	})
 	t.Run("SetStrategy", func(t *testing.T) {
-		strategy := BinpackPlacement
+		strategy := StrategyBinpack
 		opts := NewECSPodPlacementOptions().SetStrategy(strategy)
 		require.NotZero(t, opts.Strategy)
 		assert.Equal(t, strategy, *opts.Strategy)
 	})
 	t.Run("SetStrategyParameter", func(t *testing.T) {
-		param := BinpackCPU
+		param := StrategyParamBinpackCPU
 		opts := NewECSPodPlacementOptions().SetStrategyParameter(param)
 		assert.Equal(t, param, utility.FromStringPtr(opts.StrategyParameter))
 	})
@@ -493,57 +493,57 @@ func TestECSPodPlacementOptions(t *testing.T) {
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
 			require.NotZero(t, opts.StrategyParameter)
-			assert.Equal(t, BinpackPlacement, *opts.Strategy)
-			assert.Equal(t, BinpackMemory, *opts.StrategyParameter)
+			assert.Equal(t, StrategyBinpack, *opts.Strategy)
+			assert.Equal(t, StrategyParamBinpackMemory, *opts.StrategyParameter)
 		})
-		t.Run("BinpackStrategyWithoutParameterDefaultsToMemoryBinpacking", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement)
+		t.Run("BinpackWithoutParameterDefaultsToMemoryBinpacking", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, BinpackPlacement, *opts.Strategy)
-			assert.Equal(t, BinpackMemory, utility.FromStringPtr(opts.StrategyParameter))
+			assert.Equal(t, StrategyBinpack, *opts.Strategy)
+			assert.Equal(t, StrategyParamBinpackMemory, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("BinpackStrategyWithMemoryBinpackingIsValid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter(BinpackMemory)
+		t.Run("BinpackWithMemoryBinpackingIsValid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamBinpackMemory)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, BinpackPlacement, *opts.Strategy)
-			assert.Equal(t, BinpackMemory, utility.FromStringPtr(opts.StrategyParameter))
+			assert.Equal(t, StrategyBinpack, *opts.Strategy)
+			assert.Equal(t, StrategyParamBinpackMemory, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("BinpackStrategyWithCPUBinpackingIsValid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter(BinpackCPU)
+		t.Run("BinpackWithCPUBinpackingIsValid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamBinpackCPU)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, BinpackPlacement, *opts.Strategy)
-			assert.Equal(t, BinpackCPU, utility.FromStringPtr(opts.StrategyParameter))
+			assert.Equal(t, StrategyBinpack, *opts.Strategy)
+			assert.Equal(t, StrategyParamBinpackCPU, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("BinpackStrategyWithSpreadHostIsInvalid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter(SpreadHost)
+		t.Run("BinpackWithSpreadHostIsInvalid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamSpreadHost)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("BinpackStrategyWithInvalidParameterIsInvalid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter("foo")
+		t.Run("BinpackWithInvalidParameterIsInvalid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter("foo")
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("SpreadStrategyWithoutParameterDefaultsToHostSpread", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(SpreadPlacement)
+		t.Run("SpreadyWithoutParameterDefaultsToHostSpread", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategySpread)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, SpreadPlacement, *opts.Strategy)
-			assert.Equal(t, SpreadHost, utility.FromStringPtr(opts.StrategyParameter))
+			assert.Equal(t, StrategySpread, *opts.Strategy)
+			assert.Equal(t, StrategyParamSpreadHost, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("SpreadStrategyWithoutWithHostSpreadIsValid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(SpreadPlacement).SetStrategyParameter(SpreadHost)
+		t.Run("SpreadWithHostSpreadIsValid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategySpread).SetStrategyParameter(StrategyParamSpreadHost)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, SpreadPlacement, *opts.Strategy)
-			assert.Equal(t, SpreadHost, utility.FromStringPtr(opts.StrategyParameter))
+			assert.Equal(t, StrategySpread, *opts.Strategy)
+			assert.Equal(t, StrategyParamSpreadHost, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("SpreadStrategyWithCustomParameterIsValid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(SpreadPlacement).SetStrategyParameter("custom")
+		t.Run("SpreadWithCustomParameterIsValid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategySpread).SetStrategyParameter("custom")
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, SpreadPlacement, *opts.Strategy)
+			assert.Equal(t, StrategySpread, *opts.Strategy)
 			assert.Equal(t, "custom", utility.FromStringPtr(opts.StrategyParameter))
 		})
 	})

--- a/vendor/github.com/evergreen-ci/cocoa/internal/testcase/ecs_pod.go
+++ b/vendor/github.com/evergreen-ci/cocoa/internal/testcase/ecs_pod.go
@@ -55,7 +55,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StoppedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusStopped, info.Status)
 		},
 		"StopSucceedsWithSecrets": func(ctx context.Context, t *testing.T, v cocoa.Vault, pc cocoa.ECSPodCreator) {
 			secret := cocoa.NewEnvironmentVariable().
@@ -81,7 +81,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.RunningStatus, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
 			assert.Len(t, info.Resources.Secrets, 2)
 
 			require.NoError(t, p.Stop(ctx))
@@ -89,7 +89,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err = p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StoppedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusStopped, info.Status)
 			require.Len(t, info.Resources.Secrets, 2)
 
 			arn := info.Resources.Secrets[0].Name
@@ -112,7 +112,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotZero(t, info)
-			assert.Equal(t, cocoa.StoppedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusStopped, info.Status)
 
 			require.Error(t, p.Stop(ctx))
 		},
@@ -125,14 +125,14 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.RunningStatus, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
 
 			require.NoError(t, p.Delete(ctx))
 
 			info, err = p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.DeletedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusDeleted, info.Status)
 		},
 		"DeleteSucceedsWithSecrets": func(ctx context.Context, t *testing.T, v cocoa.Vault, pc cocoa.ECSPodCreator) {
 			secret := cocoa.NewEnvironmentVariable().SetName(t.Name()).
@@ -149,7 +149,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.RunningStatus, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
 			require.Len(t, info.Resources.Secrets, 2)
 
 			require.NoError(t, p.Delete(ctx))
@@ -157,7 +157,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err = p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.DeletedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusDeleted, info.Status)
 			require.Len(t, info.Resources.Secrets, 2)
 
 			arn0 := info.Resources.Secrets[0].Name

--- a/vendor/github.com/evergreen-ci/cocoa/internal/testcase/ecs_pod_creator.go
+++ b/vendor/github.com/evergreen-ci/cocoa/internal/testcase/ecs_pod_creator.go
@@ -82,7 +82,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.RunningStatus, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
 		},
 	}
 }
@@ -160,7 +160,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.RunningStatus, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
 		},
 	}
 }


### PR DESCRIPTION
JIra: https://jira.mongodb.org/browse/EVG-15097

### Description 
* Add REST API pod model.
* Add data connector method to find pod by ID.
* Include the status when creating a new DB pod from the REST route to create new pods. 
* Slightly modify some of the HTTP status codes returned when checking a pod ID/secret.
* Revendor cocoa.

### Testing 
Normal REST model and data connector tests.