### PR TITLE
EVG-15092: convert platform into OS and architecture

### DIFF
--- a/config_cloud.go
+++ b/config_cloud.go
@@ -157,7 +157,7 @@ type ECSClusterConfig struct {
 	// Name is the ECS cluster name.
 	Name string `bson:"name,omitempty" json:"name,omitempty" yaml:"name,omitempty"`
 	// Platform is the platform supported by the cluster.
-	Platform PodPlatform `bson:"platform,omitempty" json:"platform,omitempty" yaml:"platform,omitempty"`
+	Platform ECSClusterPlatform `bson:"platform,omitempty" json:"platform,omitempty" yaml:"platform,omitempty"`
 }
 
 // Validate checks that the ECS cluster configuration has the required fields
@@ -165,7 +165,7 @@ type ECSClusterConfig struct {
 func (c *ECSClusterConfig) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(c.Name == "", "must specify a cluster name")
-	catcher.Add(c.Platform.Validate())
+	catcher.Wrap(c.Platform.Validate(), "invalid platform")
 	return catcher.Resolve()
 }
 

--- a/globals.go
+++ b/globals.go
@@ -948,22 +948,18 @@ const (
 	LogTypeSystem = "system_log"
 )
 
-// PodPlatform represents recognized platforms for pods.
-type PodPlatform string
+type ECSClusterPlatform string
 
 const (
-	// PodPlatformLinux is the platform to run pods with Linux containers.
-	PodPlatformLinux PodPlatform = "linux"
-	// PodPlatformWindows is the platform to run pods with Windows containers.
-	PodPlatformWindows PodPlatform = "windows"
+	ECSClusterPlatformLinux   = "linux"
+	ECSClusterPlatformWindows = "windows"
 )
 
-// Validate checks that the given pod platform is recognized.
-func (p PodPlatform) Validate() error {
+func (p ECSClusterPlatform) Validate() error {
 	switch p {
-	case PodPlatformLinux, PodPlatformWindows:
+	case ECSClusterPlatformLinux, ECSClusterPlatformWindows:
 		return nil
 	default:
-		return errors.Errorf("unrecognized pod platform '%s'", p)
+		return errors.Errorf("unrecognized ECS cluster platform '%s'", p)
 	}
 }

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -22,7 +22,8 @@ var (
 	TaskContainerCreationOptsImageKey    = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "Image")
 	TaskContainerCreationOptsMemoryMBKey = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "MemoryMB")
 	TaskContainerCreationOptsCPUKey      = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "CPU")
-	TaskContainerCreationOptsPlatformKey = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "Platform")
+	TaskContainerCreationOptsOSKey       = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "OS")
+	TaskContainerCreationOptsArchKey     = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "Arch")
 	TaskContainerCreationOptsEnvVarsKey  = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "EnvVars")
 	TaskContainerCreationOptsSecretsKey  = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "EnvSecrets")
 

--- a/rest/data/pod.go
+++ b/rest/data/pod.go
@@ -119,7 +119,7 @@ func translatePod(p model.APICreatePod) (*pod.Pod, error) {
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
-			Message:    fmt.Sprintf("API error converting from model.APICreatePod to pod.Pod"),
+			Message:    errors.Wrap(err, "API error converting from model.APICreatePod to pod.Pod").Error(),
 		}
 	}
 

--- a/rest/data/pod_test.go
+++ b/rest/data/pod_test.go
@@ -46,8 +46,9 @@ func (s *podConnectorSuite) TestCreatePod() {
 				Secret: utility.ToBoolPtr(true),
 			},
 		},
-		Platform: utility.ToStringPtr("linux"),
-		Secret:   utility.ToStringPtr("secret"),
+		OS:     utility.ToStringPtr("linux"),
+		Arch:   utility.ToStringPtr("amd64"),
+		Secret: utility.ToStringPtr("secret"),
 	}
 	res, err := s.conn.CreatePod(p)
 	s.Require().NoError(err)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1652,9 +1652,13 @@ func (a *APIECSClusterConfig) ToService() (interface{}, error) {
 	if a == nil {
 		return nil, nil
 	}
+	p := evergreen.ECSClusterPlatform(utility.FromStringPtr(a.Platform))
+	if err := p.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid platform")
+	}
 	return evergreen.ECSClusterConfig{
 		Name:     utility.FromStringPtr(a.Name),
-		Platform: evergreen.PodPlatform(utility.FromStringPtr(a.Platform)),
+		Platform: p,
 	}, nil
 }
 

--- a/rest/route/pod.go
+++ b/rest/route/pod.go
@@ -1,0 +1,115 @@
+package route
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+)
+
+////////////////////////////////////////////////
+//
+// POST /rest/v2/pods
+
+type podPostHandler struct {
+	sc data.Connector
+	p  model.APICreatePod
+}
+
+func makePostPod(sc data.Connector) gimlet.RouteHandler {
+	return &podPostHandler{
+		sc: sc,
+		p:  model.APICreatePod{},
+	}
+}
+
+func (h *podPostHandler) Factory() gimlet.RouteHandler {
+	return &podPostHandler{
+		sc: h.sc,
+		p:  model.APICreatePod{},
+	}
+}
+
+// Parse fetches the podID and JSON payload from the HTTP request.
+func (h *podPostHandler) Parse(ctx context.Context, r *http.Request) error {
+	body := util.NewRequestReader(r)
+	defer body.Close()
+
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		return errors.Wrap(err, "Argument read error")
+	}
+
+	if err := json.Unmarshal(b, &h.p); err != nil {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    fmt.Sprintf("API error while unmarshalling JSON"),
+		}
+	}
+
+	if utility.FromStringPtr(h.p.Image) == "" {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintln("Invalid API input: missing or empty image input"),
+		}
+	}
+	if utility.FromStringPtr(h.p.OS) == "" {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintln("Invalid API input: missing or empty OS"),
+		}
+	}
+	if utility.FromStringPtr(h.p.Arch) == "" {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintln("Invalid API input: missing or empty architecture"),
+		}
+	}
+	if utility.FromIntPtr(h.p.CPU) <= 0 {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintln("Invalid API input: missing or invalid CPU"),
+		}
+	}
+	if utility.FromIntPtr(h.p.Memory) <= 0 {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintln("Invalid API input: missing or invalid memory"),
+		}
+	}
+
+	for _, envVar := range h.p.EnvVars {
+		if utility.FromStringPtr(envVar.Name) == "" {
+			return gimlet.ErrorResponse{
+				StatusCode: http.StatusBadRequest,
+				Message:    fmt.Sprintf("Invalid API input: missing or empty environment variable name"),
+			}
+		}
+	}
+
+	return nil
+}
+
+// Run creates a new resource based on the Request-URI and JSON payload.
+func (h *podPostHandler) Run(ctx context.Context) gimlet.Responder {
+	res, err := h.sc.CreatePod(h.p)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Creating new pod"))
+	}
+
+	responder := gimlet.NewJSONResponse(res)
+
+	if err := responder.SetStatus(http.StatusCreated); err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "Cannot set HTTP status code to %d", http.StatusCreated))
+	}
+
+	return responder
+}

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -2,17 +2,12 @@ package route
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/rest/data"
-	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/units"
-	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
@@ -129,95 +124,4 @@ func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	return gimlet.NewJSONResponse(apimodels.NextTaskResponse{})
-}
-
-////////////////////////////////////////////////
-//
-// POST /rest/v2/pods
-
-type podPostHandler struct {
-	body []byte
-	sc   data.Connector
-	p    model.APICreatePod
-}
-
-func makePostPod(sc data.Connector) gimlet.RouteHandler {
-	return &podPostHandler{
-		sc: sc,
-		p:  model.APICreatePod{},
-	}
-}
-
-func (h *podPostHandler) Factory() gimlet.RouteHandler {
-	return &podPostHandler{
-		sc: h.sc,
-		p:  model.APICreatePod{},
-	}
-}
-
-// Parse fetches the podID and JSON payload from the HTTP request.
-func (h *podPostHandler) Parse(ctx context.Context, r *http.Request) error {
-	body := util.NewRequestReader(r)
-	defer body.Close()
-
-	b, err := ioutil.ReadAll(body)
-	if err != nil {
-		return errors.Wrap(err, "Argument read error")
-	}
-
-	if err := json.Unmarshal(b, &h.p); err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    fmt.Sprintf("API error while unmarshalling JSON"),
-		}
-	}
-
-	if utility.FromStringPtr(h.p.Image) == "" {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    fmt.Sprintln("Invalid API input: missing or empty image input"),
-		}
-	} else if utility.FromStringPtr(h.p.Platform) == "" {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    fmt.Sprintln("Invalid API input: missing or empty platform"),
-		}
-	} else if utility.FromIntPtr(h.p.CPU) <= 0 {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    fmt.Sprintln("Invalid API input: missing or invalid CPU"),
-		}
-	} else if utility.FromIntPtr(h.p.Memory) <= 0 {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    fmt.Sprintln("Invalid API input: missing or invalid memory"),
-		}
-	}
-
-	for _, envVar := range h.p.EnvVars {
-		if utility.FromStringPtr(envVar.Name) == "" {
-			return gimlet.ErrorResponse{
-				StatusCode: http.StatusBadRequest,
-				Message:    fmt.Sprintf("Invalid API input: missing or empty environment variable name"),
-			}
-		}
-	}
-
-	return nil
-}
-
-// Run creates a new resource based on the Request-URI and JSON payload.
-func (h *podPostHandler) Run(ctx context.Context) gimlet.Responder {
-	res, err := h.sc.CreatePod(h.p)
-	if err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Creating new pod"))
-	}
-
-	responder := gimlet.NewJSONResponse(res)
-
-	if err := responder.SetStatus(http.StatusCreated); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "Cannot set HTTP status code to %d", http.StatusCreated))
-	}
-
-	return responder
 }

--- a/rest/route/pod_agent_test.go
+++ b/rest/route/pod_agent_test.go
@@ -1,7 +1,6 @@
 package route
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 	"testing"
@@ -9,10 +8,8 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/mock"
-	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip/send"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -203,157 +200,6 @@ func TestPodAgentNextTask(t *testing.T) {
 			require.True(t, ok)
 
 			tCase(ctx, t, rh, env)
-		})
-	}
-}
-
-func TestPostPod(t *testing.T) {
-	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, ph *podPostHandler){
-		"FactorySucceeds": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			copied := ph.Factory()
-			assert.NotZero(t, copied)
-			_, ok := copied.(*podPostHandler)
-			assert.True(t, ok)
-		},
-		"ParseSucceeds": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"memory": 128,
-				"cpu": 128,
-				"image": "image",
-				"env_vars": [{
-					"name": "env_name",
-					"value": "env_val",
-					"secret": false
-				}],
-				"platform": "linux",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPut, "https://example.com/rest/v2/pods/123abc", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.NoError(t, ph.Parse(ctx, req))
-			assert.Equal(t, 128, utility.FromIntPtr(ph.p.Memory))
-			assert.Equal(t, 128, utility.FromIntPtr(ph.p.CPU))
-			assert.Equal(t, "image", utility.FromStringPtr(ph.p.Image))
-			assert.Equal(t, "linux", utility.FromStringPtr(ph.p.Platform))
-			assert.Equal(t, "secret", utility.FromStringPtr(ph.p.Secret))
-			assert.Equal(t, "env_name", utility.FromStringPtr(ph.p.EnvVars[0].Name))
-			assert.Equal(t, "env_val", utility.FromStringPtr(ph.p.EnvVars[0].Value))
-			assert.Equal(t, false, utility.FromBoolPtr(ph.p.EnvVars[0].Secret))
-		},
-		"ParseSucceedsWithSecrets": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"memory": 128,
-				"cpu": 128,
-				"image": "image",
-				"env_vars": [{
-					"name": "secret_name",
-					"value": "secret_val",
-					"secret": true
-				}],
-				"platform": "linux",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPut, "https://example.com/rest/v2/pods/123abc", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.NoError(t, ph.Parse(ctx, req))
-			assert.Equal(t, "secret_name", utility.FromStringPtr(ph.p.EnvVars[0].Name))
-			assert.Equal(t, "secret_val", utility.FromStringPtr(ph.p.EnvVars[0].Value))
-			assert.Equal(t, true, utility.FromBoolPtr(ph.p.EnvVars[0].Secret))
-		},
-		"ParseFailsWithInvalidJSON": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"memory": 128,
-				"cpu": 128,,,
-				"image": "image",
-				"env_vars": [],
-				"platform": "linux",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPut, "https://example.com/rest/v2/pods/123abc", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.Error(t, ph.Parse(ctx, req))
-		},
-		"ParseFailsWithMissingInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"cpu": 128,
-				"image": "image",
-				"env_vars": [],
-				"platform": "linux",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPut, "https://example.com/rest/v2/pods/123abc", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.Error(t, ph.Parse(ctx, req))
-		},
-		"ParseFailsWithMissingEnvVarInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"cpu": 128,
-				"image": "image",
-				"env_vars": [{
-					"value": "secret_val",
-					"secret": true
-				}],
-				"platform": "linux",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPut, "https://example.com/rest/v2/pods/123abc", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.Error(t, ph.Parse(ctx, req))
-		},
-		"ParseFailsWithInvalidInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"memory": -1,
-				"cpu": 128,
-				"image": "image",
-				"env_vars": [],
-				"platform": "linux",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPut, "https://example.com/rest/v2/pods/123abc", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.Error(t, ph.Parse(ctx, req))
-		},
-		"RunSucceedsWithValidInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"memory": 128,
-				"cpu": 128,
-				"image": "image",
-				"env_vars": [{
-					"name": "env_name",
-					"value": "env_val",
-					"secret": false
-				}],
-				"platform": "linux",
-				"secret": "secret"
-			}`)
-			ph.body = json
-
-			resp := ph.Run(ctx)
-			require.NotNil(t, resp.Data())
-			assert.Equal(t, http.StatusCreated, resp.Status())
-		},
-	} {
-		t.Run(tName, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			sc := &data.MockConnector{
-				MockPodConnector: data.MockPodConnector{
-					CachedPods: []pod.Pod{
-						{
-							ID: "pod1",
-						},
-						{
-							ID: "pod2",
-						},
-					},
-				},
-			}
-
-			p := makePostPod(sc)
-			require.NotZero(t, p)
-
-			tCase(ctx, t, p.(*podPostHandler))
 		})
 	}
 }

--- a/rest/route/pod_test.go
+++ b/rest/route/pod_test.go
@@ -1,0 +1,169 @@
+package route
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostPod(t *testing.T) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, ph *podPostHandler){
+		"FactorySucceeds": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
+			copied := ph.Factory()
+			assert.NotZero(t, copied)
+			_, ok := copied.(*podPostHandler)
+			assert.True(t, ok)
+		},
+		"ParseSucceeds": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
+			json := []byte(`{
+				"memory": 128,
+				"cpu": 128,
+				"image": "image",
+				"env_vars": [{
+					"name": "env_name",
+					"value": "env_val",
+					"secret": false
+				}],
+				"os": "linux",
+				"arch": "arm64",
+				"secret": "secret"
+			}`)
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
+			require.NoError(t, err)
+			require.NoError(t, ph.Parse(ctx, req))
+			assert.Equal(t, 128, utility.FromIntPtr(ph.p.Memory))
+			assert.Equal(t, 128, utility.FromIntPtr(ph.p.CPU))
+			assert.Equal(t, "image", utility.FromStringPtr(ph.p.Image))
+			assert.Equal(t, "linux", utility.FromStringPtr(ph.p.OS))
+			assert.Equal(t, "arm64", utility.FromStringPtr(ph.p.Arch))
+			assert.Equal(t, "secret", utility.FromStringPtr(ph.p.Secret))
+			assert.Equal(t, "env_name", utility.FromStringPtr(ph.p.EnvVars[0].Name))
+			assert.Equal(t, "env_val", utility.FromStringPtr(ph.p.EnvVars[0].Value))
+			assert.Equal(t, false, utility.FromBoolPtr(ph.p.EnvVars[0].Secret))
+		},
+		"ParseSucceedsWithSecrets": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
+			json := []byte(`{
+				"memory": 128,
+				"cpu": 128,
+				"image": "image",
+				"env_vars": [{
+					"name": "secret_name",
+					"value": "secret_val",
+					"secret": true
+				}],
+				"os": "linux",
+				"arch": "arm64",
+				"secret": "secret"
+			}`)
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
+			require.NoError(t, err)
+			require.NoError(t, ph.Parse(ctx, req))
+			assert.Equal(t, 128, utility.FromIntPtr(ph.p.Memory))
+			assert.Equal(t, 128, utility.FromIntPtr(ph.p.CPU))
+			assert.Equal(t, "image", utility.FromStringPtr(ph.p.Image))
+			assert.Equal(t, "linux", utility.FromStringPtr(ph.p.OS))
+			assert.Equal(t, "arm64", utility.FromStringPtr(ph.p.Arch))
+			assert.Equal(t, "secret", utility.FromStringPtr(ph.p.Secret))
+			assert.Equal(t, "secret_name", utility.FromStringPtr(ph.p.EnvVars[0].Name))
+			assert.Equal(t, "secret_val", utility.FromStringPtr(ph.p.EnvVars[0].Value))
+			assert.Equal(t, true, utility.FromBoolPtr(ph.p.EnvVars[0].Secret))
+		},
+		"ParseFailsWithInvalidJSON": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
+			json := []byte(`{
+				"memory": 128,
+				"cpu": 128,,,
+				"image": "image",
+				"env_vars": [],
+				"os": "linux",
+				"arch": "arm64",
+				"secret": "secret"
+			}`)
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
+			require.NoError(t, err)
+			require.Error(t, ph.Parse(ctx, req))
+		},
+		"ParseFailsWithMissingInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
+			json := []byte(`{
+				"cpu": 128,
+				"image": "image",
+				"env_vars": [],
+				"os": "linux",
+				"arch": "arm64",
+				"secret": "secret"
+			}`)
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
+			require.NoError(t, err)
+			require.Error(t, ph.Parse(ctx, req))
+		},
+		"ParseFailsWithMissingEnvVarInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
+			json := []byte(`{
+				"cpu": 128,
+				"image": "image",
+				"env_vars": [{
+					"value": "secret_val",
+					"secret": true
+				}],
+				"os": "linux",
+				"arch": "arm64",
+				"secret": "secret"
+			}`)
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
+			require.NoError(t, err)
+			require.Error(t, ph.Parse(ctx, req))
+		},
+		"ParseFailsWithInvalidInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
+			json := []byte(`{
+				"memory": -1,
+				"cpu": 128,
+				"image": "image",
+				"env_vars": [],
+				"os": "linux",
+				"arch": "arm64",
+				"secret": "secret"
+			}`)
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
+			require.NoError(t, err)
+			require.Error(t, ph.Parse(ctx, req))
+		},
+		"RunSucceedsWithValidInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
+			json := []byte(`{
+				"memory": 128,
+				"cpu": 128,
+				"image": "image",
+				"env_vars": [{
+					"name": "env_name",
+					"value": "env_val",
+					"secret": false
+				}],
+				"os": "linux",
+				"arch": "arm64",
+				"secret": "secret"
+			}`)
+
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
+			require.NoError(t, err)
+			require.NoError(t, ph.Parse(ctx, req))
+			resp := ph.Run(ctx)
+			require.NotNil(t, resp.Data())
+			assert.Equal(t, http.StatusCreated, resp.Status())
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			sc := &data.MockConnector{}
+
+			p := makePostPod(sc)
+			require.NotZero(t, p)
+
+			tCase(ctx, t, p.(*podPostHandler))
+		})
+	}
+}

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -256,7 +256,7 @@ func MockConfig() *evergreen.Settings {
 						Clusters: []evergreen.ECSClusterConfig{
 							{
 								Name:     "cluster_name",
-								Platform: evergreen.PodPlatformLinux,
+								Platform: evergreen.ECSClusterPlatformLinux,
 							},
 						},
 					},

--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/ecs"
 	"github.com/evergreen-ci/cocoa/mock"
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -146,7 +145,8 @@ func TestTerminatePodJob(t *testing.T) {
 					Image:    "image",
 					MemoryMB: 128,
 					CPU:      128,
-					Platform: evergreen.PodPlatformLinux,
+					OS:       pod.OSLinux,
+					Arch:     pod.ArchAMD64,
 					EnvSecrets: map[string]string{
 						"secret0": utility.RandomString(),
 						"secret1": utility.RandomString(),


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15092

### Description 
Split the platform into OS and architecture, which will help us in choosing which agent to download on the host. It's also necessary to know the OS to assign the pod to the correct cluster.

I also fixed some minor issues in the REST route to create pods.

### Testing 
Normal REST and DB model tests.