### PR TITLE
EVG-15115 Fix flaky test for scheduleUndispatchedBaseTasks

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1891,6 +1891,7 @@ func (r *mutationResolver) ScheduleUndispatchedBaseTasks(ctx context.Context, pa
 	opts := data.TaskFilterOptions{
 		Statuses:              evergreen.TaskFailureStatuses,
 		IncludeExecutionTasks: true,
+		Sorts:                 []task.TasksSortOrder{{Key: task.DisplayNameKey, Order: 1}},
 	}
 	tasks, _, err := r.sc.FindTasksByVersion(patchID, opts)
 	if err != nil {
@@ -1944,11 +1945,6 @@ func (r *mutationResolver) ScheduleUndispatchedBaseTasks(ctx context.Context, pa
 		scheduledTasks = append(scheduledTasks, task)
 	}
 
-	// Sort ensures that tasks are returned in a consistent order
-	sort.Slice(scheduledTasks, func(i, j int) bool {
-		return *scheduledTasks[i].DisplayName < *scheduledTasks[j].DisplayName
-
-	})
 	return scheduledTasks, nil
 }
 

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1943,6 +1943,12 @@ func (r *mutationResolver) ScheduleUndispatchedBaseTasks(ctx context.Context, pa
 		}
 		scheduledTasks = append(scheduledTasks, task)
 	}
+
+	// Sort ensures that tasks are returned in a consistent order
+	sort.Slice(scheduledTasks, func(i, j int) bool {
+		return *scheduledTasks[i].DisplayName < *scheduledTasks[j].DisplayName
+
+	})
 	return scheduledTasks, nil
 }
 


### PR DESCRIPTION
Sometimes this test flakes and switches the order of the results in the return. This sort should ensure they always get returned in the same order.