### PR TITLE
EVG-15113: re-add pod timing information

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -77,8 +77,8 @@ func ExportPodResources(info pod.ResourceInfo) cocoa.ECSPodResources {
 
 	res := cocoa.NewECSPodResources().SetSecrets(secrets)
 
-	if info.ID != "" {
-		res.SetTaskID(info.ID)
+	if info.ExternalID != "" {
+		res.SetTaskID(info.ExternalID)
 	}
 
 	if info.DefinitionID != "" {

--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -89,7 +89,7 @@ func TestExportPod(t *testing.T) {
 				ID:     "id",
 				Status: pod.StatusRunning,
 				Resources: pod.ResourceInfo{
-					ID:           "task_id",
+					ExternalID:   "task_id",
 					DefinitionID: "task_def_id",
 					Cluster:      "cluster",
 					SecretIDs:    []string{"secret"},
@@ -147,7 +147,7 @@ func TestExportPodResources(t *testing.T) {
 	t.Run("SetsTaskID", func(t *testing.T) {
 		id := "task_id"
 		r := ExportPodResources(pod.ResourceInfo{
-			ID: id,
+			ExternalID: id,
 		})
 		assert.Equal(t, id, utility.FromStringPtr(r.TaskID))
 		assert.Zero(t, r.TaskDefinition)

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -17,6 +17,7 @@ var (
 	StatusKey                    = bsonutil.MustHaveTag(Pod{}, "Status")
 	SecretKey                    = bsonutil.MustHaveTag(Pod{}, "Secret")
 	TaskContainerCreationOptsKey = bsonutil.MustHaveTag(Pod{}, "TaskContainerCreationOpts")
+	TimeInfoKey                  = bsonutil.MustHaveTag(Pod{}, "TimeInfo")
 	ResourcesKey                 = bsonutil.MustHaveTag(Pod{}, "Resources")
 
 	TaskContainerCreationOptsImageKey    = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "Image")
@@ -27,10 +28,14 @@ var (
 	TaskContainerCreationOptsEnvVarsKey  = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "EnvVars")
 	TaskContainerCreationOptsSecretsKey  = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "EnvSecrets")
 
-	ResourceInfoID           = bsonutil.MustHaveTag(ResourceInfo{}, "ID")
-	ResourceInfoDefinitionID = bsonutil.MustHaveTag(ResourceInfo{}, "DefinitionID")
-	ResourceInfoCluster      = bsonutil.MustHaveTag(ResourceInfo{}, "Cluster")
-	ResourceInfoSecretIDs    = bsonutil.MustHaveTag(ResourceInfo{}, "SecretIDs")
+	TimeInfoInitializingKey     = bsonutil.MustHaveTag(TimeInfo{}, "Initializing")
+	TimeInfoStartingKey         = bsonutil.MustHaveTag(TimeInfo{}, "Starting")
+	TimeInfoLastCommunicatedKey = bsonutil.MustHaveTag(TimeInfo{}, "LastCommunicated")
+
+	ResourceInfoExternalIDKey   = bsonutil.MustHaveTag(ResourceInfo{}, "ExternalID")
+	ResourceInfoDefinitionIDKey = bsonutil.MustHaveTag(ResourceInfo{}, "DefinitionID")
+	ResourceInfoClusterKey      = bsonutil.MustHaveTag(ResourceInfo{}, "Cluster")
+	ResourceInfoSecretIDsKey    = bsonutil.MustHaveTag(ResourceInfo{}, "SecretIDs")
 )
 
 // FindOne finds one pod by the given query.

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -182,8 +182,13 @@ func (p *Pod) Remove() error {
 	)
 }
 
-// UpdateStatus updates the pod status.
+// UpdateStatus updates the pod status. If the new status is identical to the
+// current one, this is a no-op.
 func (p *Pod) UpdateStatus(s Status) error {
+	if p.Status == s {
+		return nil
+	}
+
 	byIDAndStatus := ByID(p.ID)
 	byIDAndStatus[StatusKey] = p.Status
 

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -1,8 +1,12 @@
 package pod
 
 import (
+	"time"
+
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/anser/bsonutil"
 	"github.com/pkg/errors"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -10,8 +14,7 @@ import (
 // Pod represents a related collection of containers. This model holds metadata
 // about containers running in a container orchestration system.
 type Pod struct {
-	// ID is the unique identifier for the metadata document. This is
-	// semantically unrelated to the ExternalID.
+	// ID is the unique identifier for the metadata document.
 	ID string `bson:"_id" json:"id"`
 	// Status is the current state of the pod.
 	Status Status `bson:"pod_status"`
@@ -21,8 +24,10 @@ type Pod struct {
 	// TaskCreationOpts are options to configure how a task should be
 	// containerized and run in a pod.
 	TaskContainerCreationOpts TaskContainerCreationOptions `bson:"task_creation_opts,omitempty" json:"task_creation_opts,omitempty"`
-	// Resources are external resources that are managed by this pod.
-	Resources ResourceInfo `bson:"ecs_info" json:"ecs_info"`
+	// TimeInfo contains timing information for the pod's lifecycle.
+	TimeInfo TimeInfo `bson:"time_info,omitempty" json:"time_info,omitempty"`
+	// Resources are external resources that are owned and managed by this pod.
+	Resources ResourceInfo `bson:"resource_info,omitempty" json:"resource_info,omitempty"`
 }
 
 // Status represents a possible state that a pod can be in.
@@ -50,25 +55,46 @@ func (s Status) Validate() error {
 	}
 }
 
+// TimeInfo represents timing information about the pod.
+type TimeInfo struct {
+	// Initializing is the time when this pod was initialized and is waiting to
+	// be created in the container orchestration service. This should correspond
+	// with the time when the pod transitions to the "initializing" status.
+	Initializing time.Time `bson:"initializing,omitempty" json:"initializing,omitempty"`
+	// Starting is the time when this pod was actually requested to start its
+	// containers. This should correspond with the time when the pod transitions
+	// to the "starting" status.
+	Starting time.Time `bson:"starting,omitempty" json:"starting,omitempty"`
+	// LastCommunicated is the last time that the pod connected to the
+	// application server or the application server connected to the pod. This
+	// is used as one indicator of liveliness.
+	LastCommunicated time.Time `bson:"last_communicated,omitempty" json:"last_communicated,omitempty"`
+}
+
+// IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
+// zero value for BSON marshalling.
+func (i TimeInfo) IsZero() bool {
+	return i.Initializing.IsZero() && i.Starting.IsZero() && i.LastCommunicated.IsZero()
+}
+
 // ResourceInfo represents information about external resources associated with
 // a pod.
 type ResourceInfo struct {
-	// ID is the unique resource identifier for the collection of containers
-	// running.
-	ID string `bson:"external_id,omitempty" json:"external_id,omitempty"`
+	// ExternalID is the unique resource identifier for the aggregate collection
+	// of containers running for the pod in the container service.
+	ExternalID string `bson:"external_id,omitempty" json:"external_id,omitempty"`
 	// DefinitionID is the resource identifier for the pod definition template.
-	DefinitionID string `bson:"definition_id" json:"definition_id"`
-	// Cluster is the name of the cluster where the containers are running.
-	Cluster string `bson:"cluster" json:"cluster"`
-	// SecretIDs are the resource identifiers for the secrets owned by this pod
-	// in Secrets Manager.
-	SecretIDs []string `bson:"secret_ids" json:"secret_ids"`
+	DefinitionID string `bson:"definition_id,omitempty" json:"definition_id,omitempty"`
+	// Cluster is the namespace where the containers are running.
+	Cluster string `bson:"cluster,omitempty" json:"cluster,omitempty"`
+	// SecretIDs are the resource identifiers for the secrets owned by this pod.
+	SecretIDs []string `bson:"secret_ids,omitempty" json:"secret_ids,omitempty"`
 }
 
 // IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
 // zero value for BSON marshalling.
 func (o ResourceInfo) IsZero() bool {
-	return o.ID == "" && o.DefinitionID == "" && o.Cluster == "" && len(o.SecretIDs) == 0
+	return o.ExternalID == "" && o.DefinitionID == "" && o.Cluster == "" && len(o.SecretIDs) == 0
 }
 
 // TaskContainerCreationOptions are options to apply to the task's container
@@ -161,8 +187,17 @@ func (p *Pod) UpdateStatus(s Status) error {
 	byIDAndStatus := ByID(p.ID)
 	byIDAndStatus[StatusKey] = p.Status
 
+	updated := utility.BSONTime(time.Now())
+	setFields := bson.M{StatusKey: s}
+	switch s {
+	case StatusInitializing:
+		setFields[bsonutil.GetDottedKeyName(TimeInfoKey, TimeInfoInitializingKey)] = updated
+	case StatusStarting:
+		setFields[bsonutil.GetDottedKeyName(TimeInfoKey, TimeInfoStartingKey)] = updated
+	}
+
 	if err := UpdateOne(byIDAndStatus, bson.M{
-		"$set": bson.M{StatusKey: s},
+		"$set": setFields,
 	}); err != nil {
 		return err
 	}
@@ -170,6 +205,12 @@ func (p *Pod) UpdateStatus(s Status) error {
 	event.LogPodStatusChanged(p.ID, string(p.Status), string(s))
 
 	p.Status = s
+	switch s {
+	case StatusInitializing:
+		p.TimeInfo.Initializing = updated
+	case StatusStarting:
+		p.TimeInfo.Starting = updated
+	}
 
 	return nil
 }

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -115,6 +115,13 @@ func (j *terminatePodJob) Run(ctx context.Context) {
 	if err := j.pod.UpdateStatus(pod.StatusTerminated); err != nil {
 		j.AddError(errors.Wrap(err, "marking pod as terminated"))
 	}
+
+	grip.Info(message.Fields{
+		"message":                    "successfully terminated pod",
+		"pod":                        j.PodID,
+		"termination_attempt_reason": j.Reason,
+		"job":                        j.ID(),
+	})
 }
 
 func (j *terminatePodJob) populateIfUnset(ctx context.Context) error {

--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -71,7 +71,7 @@ func TestTerminatePodJob(t *testing.T) {
 		},
 		"FailsWhenDeletingResourcesErrors": func(ctx context.Context, t *testing.T, j *terminatePodJob) {
 			require.NoError(t, j.pod.Insert())
-			j.pod.Resources.ID = utility.RandomString()
+			j.pod.Resources.ExternalID = utility.RandomString()
 			j.ecsPod = nil
 
 			j.Run(ctx)
@@ -199,7 +199,7 @@ func TestTerminatePodJob(t *testing.T) {
 
 			info, err := j.ecsPod.Info(ctx)
 			require.NoError(t, err)
-			j.pod.Resources.ID = utility.FromStringPtr(info.Resources.TaskID)
+			j.pod.Resources.ExternalID = utility.FromStringPtr(info.Resources.TaskID)
 			j.pod.Resources.DefinitionID = utility.FromStringPtr(info.Resources.TaskDefinition.ID)
 			j.pod.Resources.Cluster = utility.FromStringPtr(info.Resources.Cluster)
 			for _, secret := range info.Resources.Secrets {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15113

### Description 
* Re-add the pod timing information to the DB model and include it in the REST model.
* Set the relevant pod timing information when the status is updated. 
* Rename the resource ID to external ID for future-proofing, because we're going to have to also store individual container IDs later on. I couldn't really come up with a more appropriate name (pod ID would be confusing, task ID already means something in the Evergreen code base, group ID would also be confusing because there are task groups in ECS).
* Fix some minor BSON tag mismatches.

### Testing 
Updated the existing DB/REST tests.