### PR TITLE
EVG-15099  Update priority for child patches when updating the parent 

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -714,9 +714,6 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 		if err != nil {
 			return http.StatusInternalServerError, errors.Wrapf(err, "error getting patch '%s'", version.Id)
 		}
-		if p == nil {
-			return http.StatusNotFound, errors.Errorf("patch %s does not exist", version.Id)
-		}
 		for _, childPatchId := range p.Triggers.ChildPatches {
 			if err := model.SetVersionPriority(childPatchId, modifications.Priority, user.Id); err != nil {
 				return http.StatusInternalServerError, errors.Wrapf(err, "error setting priority for child patch '%s'", childPatchId)

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -714,9 +714,11 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 		if err != nil {
 			return http.StatusInternalServerError, errors.Wrapf(err, "error getting patch '%s'", version.Id)
 		}
-		for _, childPatchId := range p.Triggers.ChildPatches {
-			if err := model.SetVersionPriority(childPatchId, modifications.Priority, user.Id); err != nil {
-				return http.StatusInternalServerError, errors.Wrapf(err, "error setting priority for child patch '%s'", childPatchId)
+		if p != nil {
+			for _, childPatchId := range p.Triggers.ChildPatches {
+				if err := model.SetVersionPriority(childPatchId, modifications.Priority, user.Id); err != nil {
+					return http.StatusInternalServerError, errors.Wrapf(err, "error setting priority for child patch '%s'", childPatchId)
+				}
 			}
 		}
 	default:

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -709,6 +709,19 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 		if err := model.SetVersionPriority(version.Id, modifications.Priority, user.Id); err != nil {
 			return http.StatusInternalServerError, errors.Errorf("error setting version priority: %s", err)
 		}
+		// update priority for child patches
+		p, err := patch.FindOneId(version.Id)
+		if err != nil {
+			return http.StatusInternalServerError, errors.Wrapf(err, "error getting patch '%s'", version.Id)
+		}
+		if p == nil {
+			return http.StatusNotFound, errors.Errorf("patch %s does not exist", version.Id)
+		}
+		for _, childPatchId := range p.Triggers.ChildPatches {
+			if err := model.SetVersionPriority(childPatchId, modifications.Priority, user.Id); err != nil {
+				return http.StatusInternalServerError, errors.Wrapf(err, "error setting priority for child patch '%s'", childPatchId)
+			}
+		}
 	default:
 		return http.StatusBadRequest, errors.Errorf("Unrecognized action: %v", modifications.Action)
 	}


### PR DESCRIPTION
[EVG-15099](https://jira.mongodb.org/browse/EVG-15099)

### Description 
If someone sets the priority for a patch, it should also set the priority for child patches 

### Note 
This will only update the patch priority if the child patch has already been created. In the case where the child patch waits on the parent to finish in order to finalize, the child patch won't have that priority. I don't know if this is significant enough to warrant a bigger refactor to be able to store the priority and then add it when the child gets created. 

### Testing 
Manually tested on staging. 
