### PR TITLE
EVG-14776: Fetch cedar base test result in TaskTests GQL resolver

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1300,6 +1300,7 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 	var filteredTestCount int
 
 	baseTask, err := dbTask.FindTaskOnBaseCommit()
+	hasCedarResults := cedarTestResults != nil
 	if baseTask != nil {
 		baseTaskLatestExec, _ := task.GetLatestExecution(baseTask.Id)
 		grip.Warning(message.Fields{
@@ -1309,6 +1310,7 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 			"dbTaskexecution":         dbTask.Execution,
 			"baseTaskExecution":       baseTask.Execution,
 			"baseTaskLatestExeuction": baseTaskLatestExec,
+			"hasCedarTestResults":     hasCedarResults
 			"numBaseTasks":            len(baseTask.ExecutionTasks),
 		})
 	} else {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1276,13 +1276,12 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find task with id %s", taskID))
 	}
 
-	// Get the base test statuses
 	baseTask, err := dbTask.FindTaskOnBaseCommit()
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding base task for task %s: %s", taskID, err))
 	}
 	baseTestStatusMap := make(map[string]string)
-
+	// Populate baseTestStatusMap
 	if baseTask != nil {
 		baseTaskLatestExec, err := task.GetLatestExecution(baseTask.Id)
 		if err != nil {
@@ -1322,7 +1321,7 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 		}
 	}
 
-	// try getting testresults from cedar
+	// try getting test results from cedar
 	opts := apimodels.GetCedarTestResultsOptions{
 		BaseURL:   evergreen.GetEnvironment().Settings().Cedar.BaseURL,
 		Execution: dbTask.Execution,
@@ -1346,8 +1345,8 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 	var totalTestCount int
 	var filteredTestCount int
 
-	// Put testresults into an arrar of testPointers and save the total and filtered test count to return
-	if cedarTestResults != nil || len(cedarTestResults) > 0 {
+	// Put testresults into an array of testPointers and save the total and filtered test count to return
+	if cedarTestResults != nil && len(cedarTestResults) > 0 {
 		filteredTestResults, testCount := FilterSortAndPaginateCedarTestResults(FilterSortAndPaginateCedarTestResultsOpts{
 			GroupID:     groupIdParam,
 			Limit:       limitParam,

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1241,6 +1241,10 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 			break
 		case TestSortCategoryStartTime:
 			sortBy = testresult.StartTimeKey
+			break
+		case TestSortCategoryBaseStatus:
+			sortBy = "base_status"
+			break
 		}
 	}
 
@@ -1342,14 +1346,15 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 
 	if cedarTestResults != nil && len(cedarTestResults) > 0 {
 		filteredTestResults, testCount := FilterSortAndPaginateCedarTestResults(FilterSortAndPaginateCedarTestResultsOpts{
-			GroupID:     groupIdParam,
-			Limit:       limitParam,
-			Page:        pageParam,
-			SortBy:      sortBy,
-			SortDir:     sortDir,
-			Statuses:    statusesParam,
-			TestName:    testNameParam,
-			TestResults: cedarTestResults,
+			GroupID:          groupIdParam,
+			Limit:            limitParam,
+			Page:             pageParam,
+			SortBy:           sortBy,
+			SortDir:          sortDir,
+			Statuses:         statusesParam,
+			TestName:         testNameParam,
+			TestResults:      cedarTestResults,
+			BaseTestStatuses: baseTestStatusMap,
 		})
 		for _, t := range filteredTestResults {
 			apiTest := restModel.APITest{}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -36,14 +36,15 @@ import (
 )
 
 type FilterSortAndPaginateCedarTestResultsOpts struct {
-	GroupID     string
-	Limit       int
-	Page        int
-	SortBy      string
-	SortDir     int
-	Statuses    []string
-	TestName    string
-	TestResults []apimodels.CedarTestResult
+	GroupID          string
+	Limit            int
+	Page             int
+	SortBy           string
+	SortDir          int
+	Statuses         []string
+	TestName         string
+	TestResults      []apimodels.CedarTestResult
+	BaseTestStatuses map[string]string
 }
 
 // FilterSortAndPaginateCedarTestResults takes an array of CedarTestResult objects and returns a filtered sorted and paginated version of that array.
@@ -98,10 +99,17 @@ func FilterSortAndPaginateCedarTestResults(opts FilterSortAndPaginateCedarTestRe
 			sort.SliceStable(filteredAndSortedTestResults, func(i, j int) bool {
 				testResultI := filteredAndSortedTestResults[i]
 				testResultJ := filteredAndSortedTestResults[j]
-				if opts.SortDir == 1 {
-					return testResultI.TestName < testResultJ.TestName
+				if testResultI.DisplayTestName != "" && testResultJ.DisplayTestName != "" {
+					if opts.SortDir == 1 {
+						return testResultI.DisplayTestName < testResultJ.DisplayTestName
+					}
+					return testResultI.DisplayTestName > testResultJ.DisplayTestName
+				} else {
+					if opts.SortDir == 1 {
+						return testResultI.TestName < testResultJ.TestName
+					}
+					return testResultI.TestName > testResultJ.TestName
 				}
-				return testResultI.TestName > testResultJ.TestName
 			})
 			break
 		case testresult.StatusKey:
@@ -112,6 +120,24 @@ func FilterSortAndPaginateCedarTestResults(opts FilterSortAndPaginateCedarTestRe
 					return testResultI.Status < testResultJ.Status
 				}
 				return testResultI.Status > testResultJ.Status
+			})
+			break
+		case "base_status":
+			sort.SliceStable(filteredAndSortedTestResults, func(i, j int) bool {
+				testResultI := filteredAndSortedTestResults[i]
+				testResultJ := filteredAndSortedTestResults[j]
+
+				if testResultI.DisplayTestName != "" && testResultJ.DisplayTestName != "" {
+					if opts.SortDir == 1 {
+						return opts.BaseTestStatuses[testResultI.DisplayTestName] < opts.BaseTestStatuses[testResultJ.DisplayTestName]
+					}
+					return opts.BaseTestStatuses[testResultI.DisplayTestName] > opts.BaseTestStatuses[testResultJ.DisplayTestName]
+				} else {
+					if opts.SortDir == 1 {
+						return opts.BaseTestStatuses[testResultI.TestName] < opts.BaseTestStatuses[testResultJ.TestName]
+					}
+					return opts.BaseTestStatuses[testResultI.TestName] > opts.BaseTestStatuses[testResultJ.TestName]
+				}
 			})
 			break
 		}

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -46,6 +46,12 @@ func TestFilterSortAndPaginateCedarTestResults(t *testing.T) {
 			GroupID:  "llama",
 		},
 	}
+	baseTestStatusMap := map[string]string{
+		"A test": "Pass",
+		"B test": "Fail",
+		"C test": "Pass",
+		"D test": "Fail",
+	}
 
 	for _, test := range []struct {
 		name            string
@@ -147,17 +153,30 @@ func TestFilterSortAndPaginateCedarTestResults(t *testing.T) {
 			expectedResults: testResults[3:],
 			expectedCount:   4,
 		},
+		{
+			name:    "SortByBaseStatus",
+			sortBy:  "base_status",
+			sortDir: 1,
+			expectedResults: []apimodels.CedarTestResult{
+				testResults[1],
+				testResults[3],
+				testResults[0],
+				testResults[2],
+			},
+			expectedCount: 4,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			results, count := FilterSortAndPaginateCedarTestResults(FilterSortAndPaginateCedarTestResultsOpts{
-				GroupID:     test.groupId,
-				Limit:       test.limitParam,
-				Page:        test.pageParam,
-				SortBy:      test.sortBy,
-				SortDir:     test.sortDir,
-				Statuses:    test.statuses,
-				TestName:    test.testName,
-				TestResults: testResults,
+				GroupID:          test.groupId,
+				Limit:            test.limitParam,
+				Page:             test.pageParam,
+				SortBy:           test.sortBy,
+				SortDir:          test.sortDir,
+				Statuses:         test.statuses,
+				TestName:         test.testName,
+				TestResults:      testResults,
+				BaseTestStatuses: baseTestStatusMap,
 			})
 			assert.Equal(t, test.expectedResults, results)
 			assert.Equal(t, test.expectedCount, count)


### PR DESCRIPTION
[EVG-14776](https://jira.mongodb.org/browse/EVG-EVG-14776)

### Description 
These code changes: 
- fetch base test results before test results and utilizes the correct key (DisplayTestName instead of TestFile) to map a cedar test result to its base test status. 
-  request cedar first and evergreen second for tests and base tests separately. 
- utilizes the latest base task execution to fetch base test results
- handle sorting cedar tests by base status. That feature hasn't existed [based on the original resolver params](https://github.com/evergreen-ci/evergreen/blob/main/graphql/resolvers.go#L1268-L1280) ([Ticket](https://jira.mongodb.org/browse/EVG-15131)). 

  The [DisplayTestName field coming from Cedar](https://github.com/evergreen-ci/evergreen/blob/7d87de9adf5fa6d75ba25f73d40add20bf7fcac0/agent/command/results_utils.go#L179) is not considered unique amongst test results belonging to a task ID and execution. This means that base test statuses with the same DisplayTestName could be rolled up into one status. 
This is also true for base test statuses fetched from Evergreen since we rely on the TestFile field [here](https://github.com/evergreen-ci/evergreen/blob/main/model/testresult/testresult.go#L28) which is also [not guaranteed to be unique](https://mongodb.slack.com/archives/G64DEE8DA/p1627486420106900). 
### Testing 
Our gql test framework cannot talk to cedar. The best way to test these changes is in staging and viewing the base tests for this task: https://spruce-staging.corp.mongodb.com/task/evg_ubuntu1604_test_evergreen_patch_4462298c72df80ec0e9baf072d0ade4f3af621e8_60fec9ae97b1d34f9196cbfc_21_07_26_14_43_51/tests?execution=0&page=0
status data displayed from cedar and displayed in the staging UI can verified from the cedar staging endpoint: https://cedar.staging.build.10gen.cc/rest/v1/test_results/task_id/{taskId}