### PR TITLE
EVG-15134 Only resolve statuses for base level patches

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -25,9 +25,6 @@ models:
     model: github.com/evergreen-ci/evergreen/graphql.StringMap
   Patch:
     model: github.com/evergreen-ci/evergreen/rest/model.APIPatch
-    fields:
-      status:
-        resolver: true
   Parameter:
     model: github.com/evergreen-ci/evergreen/rest/model.APIParameter
   ParameterInput:


### PR DESCRIPTION
[EVG-15134](https://jira.mongodb.org/browse/EVG-15134)

### Description 
This reverts a significant performance regression  introduced in https://github.com/evergreen-ci/evergreen/pull/4840 
Patch status will only be calculated when viewing a patch/version page and will not be calculated elsewhere such as the mypatches pages.
Calculating patch status on the my patches page is an expensive operation because it needs to query for every visible patches tasks to determine if a patch should have an aborted status. Which lead to significant load on the db. 

Note: the status on the my patches page has the potential to not be in sync with the patch status on the version page, which represents the same behavior as before  the change in #4840 was introduced so this is not a functionality regression. 

