### PR TITLE
EVG-13490 add versionMetadata field which resolves a version

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2427,6 +2427,7 @@ func (r *taskResolver) FailedTestCount(ctx context.Context, obj *restModel.APITa
 	return failedTestCount, nil
 }
 
+// TODO: DEPRICATE
 func (r *taskResolver) PatchMetadata(ctx context.Context, obj *restModel.APITask) (*PatchMetadata, error) {
 	version, err := r.sc.FindVersionById(*obj.Version)
 	if err != nil {
@@ -2665,6 +2666,18 @@ func (r *taskResolver) BuildVariantDisplayName(ctx context.Context, obj *restMod
 	displayName := b.DisplayName
 	return &displayName, nil
 
+}
+
+func (r *taskResolver) VersionMetadata(ctx context.Context, obj *restModel.APITask) (*restModel.APIVersion, error) {
+	v, err := r.sc.FindVersionById(utility.FromStringPtr(obj.Version))
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Unable to find version id: %s for task: %s", *obj.Version, utility.FromStringPtr(obj.Id)))
+	}
+	apiVersion := &restModel.APIVersion{}
+	if err = apiVersion.BuildFromService(v); err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Unable to convert version: %s to APIVersion", v.Id))
+	}
+	return apiVersion, nil
 }
 
 func (r *queryResolver) BuildBaron(ctx context.Context, taskID string, exec int) (*BuildBaron, error) {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2482,7 +2482,7 @@ func (r *taskResolver) FailedTestCount(ctx context.Context, obj *restModel.APITa
 	return failedTestCount, nil
 }
 
-// TODO: DEPRICATE
+// TODO: deprecated
 func (r *taskResolver) PatchMetadata(ctx context.Context, obj *restModel.APITask) (*PatchMetadata, error) {
 	version, err := r.sc.FindVersionById(*obj.Version)
 	if err != nil {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -734,7 +734,7 @@ type Task {
   latestExecution: Int!
   logs: TaskLogLinks!
   minQueuePosition: Int!
-  patchMetadata: PatchMetadata!
+  patchMetadata: PatchMetadata! @deprecated(reason: "patchMetadata is deprecated. Use versionMetadata instead.")
   patchNumber: Int
   priority: Int
   project: Project
@@ -751,7 +751,8 @@ type Task {
   taskGroupMaxHosts: Int
   timeTaken: Duration
   totalTestCount: Int!
-  version: String!
+  version: String! @deprecated(reason: "version is deprecated. Use versionMetadata instead.")
+  versionMetadata: Version!
 }
 
 type BaseTaskInfo {

--- a/graphql/tests/task/queries/versionMetadata.graphql
+++ b/graphql/tests/task/queries/versionMetadata.graphql
@@ -1,0 +1,8 @@
+{
+  task(taskId: "taskity_task") {
+    id
+    versionMetadata {
+      author
+    }
+  }
+}

--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -140,6 +140,19 @@
       }
     },
     {
+      "query_file": "versionMetadata.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "id": "taskity_task",
+            "versionMetadata": {
+              "author": "brian.samek"
+            }
+          }
+        }
+      }
+    },
+    {
       "query_file": "spawnHostLink.graphql",
       "result": {
         "data": {


### PR DESCRIPTION
[EVG-13490](https://jira.mongodb.org/browse/EVG-13490)

### Description 
Adds a versionMetadata field which resolves versions for tasks. Decided to do it in a backwards compatible way. This will be renamed to version in a follow up PR. Any fields marked deprecated will also be removed in a follow up pr. 


