### PR TITLE
EVG-15147 Don't test slack auth

### DIFF
--- a/vendor/github.com/mongodb/grip/send/slack.go
+++ b/vendor/github.com/mongodb/grip/send/slack.go
@@ -41,9 +41,9 @@ func NewSlackLogger(opts *SlackOptions, token string, l LevelInfo) (Sender, erro
 		return nil, err
 	}
 
-	if _, err := s.opts.client.AuthTest(); err != nil {
-		return nil, fmt.Errorf("slack authentication error: %v", err)
-	}
+	// if _, err := s.opts.client.AuthTest(); err != nil {
+	// 	return nil, fmt.Errorf("slack authentication error: %v", err)
+	// }
 
 	fallback := log.New(os.Stdout, "", log.LstdFlags)
 	if err := s.SetErrorHandler(ErrorHandlerFromLogger(fallback)); err != nil {


### PR DESCRIPTION
[EVG-15147](https://jira.mongodb.org/browse/EVG-15147)

### Description 
Don't test slack auth.  This is a temporary fix to ensure that we can deploy the app without slack integration.
