### PR TITLE
EVG-14685: replace Logkeeper lobster links with Evg in the legacy ui task page

### DIFF
--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -375,7 +375,11 @@ mciModule.controller('TaskCtrl', function ($scope, $rootScope, $now, $timeout, $
         url += lineNum;
       }
     }
-
+    const deprecatedLogkeeperLobsterURL = "https://logkeeper.mongodb.org";
+    const isLogkeeperLink = url.includes(`${deprecatedLogkeeperLobsterURL}/build`);
+    if(isLogkeeperLink) {
+      url = url.replace(deprecatedLogkeeperLobsterURL, `${window.evgBaseUrl}/lobster`);
+    }
     return url;
   };
 

--- a/service/task.go
+++ b/service/task.go
@@ -398,6 +398,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uis.render.WriteResponse(w, http.StatusOK, struct {
+		EvgBaseUrl    string
 		Task          uiTaskData
 		Host          *host.Host
 		PluginContent pluginData
@@ -405,7 +406,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		Permissions   gimlet.Permissions
 		NewUILink     string
 		ViewData
-	}{uiTask, taskHost, pluginContent, uis.Settings.Jira.Host, permissions, newUILink, uis.GetCommonViewData(w, r, false, true)}, "base", "task.html", "base_angular.html", "menu.html")
+	}{uis.Settings.Ui.Url, uiTask, taskHost, pluginContent, uis.Settings.Jira.Host, permissions, newUILink, uis.GetCommonViewData(w, r, false, true)}, "base", "task.html", "base_angular.html", "menu.html")
 }
 
 func getAbortedBy(abortedByTaskId string) (*abortedByDisplay, error) {

--- a/service/templates/task.html
+++ b/service/templates/task.html
@@ -7,6 +7,7 @@ window.plugins = {{.PluginContent.Data}};
 window.jiraHost = {{.JiraHost}};
 window.hasBanner = {{ne .Banner ""}};
 window.user = {{.User}};
+window.evgBaseUrl = {{.EvgBaseUrl}}
 </script>
 <script type="text/javascript" src="{{Static "js" "subscriptions.js"}}?hash={{ BuildRevision }}"></script>
 <script type="text/javascript" src="{{Static "js" "task.js"}}?hash={{ BuildRevision }}"></script>


### PR DESCRIPTION
[EVG-14685](https://jira.mongodb.org/browse/EVG-14685)

### Description 
We use a similar logic in spruce for the tests table [here](https://github.com/evergreen-ci/spruce/blob/main/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx#L276-L278)

