### PR TITLE
EVG-15118 Modifying a version should also modify the child patches 

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -766,11 +766,7 @@ func ModifyVersionHandler(ctx context.Context, dataConnector data.Connector, pat
 				return ResourceNotFound.Send(ctx, fmt.Sprintf("patch not found %s: %s", patchID, err.Error()))
 			}
 			if p.IsParent() {
-				childPatchIds := []string{}
-				if p != nil && err != nil {
-					childPatchIds = p.Triggers.ChildPatches
-				}
-				for _, childPatchId := range childPatchIds {
+				for _, childPatchId := range p.Triggers.ChildPatches {
 					err = ModifyVersionHandler(ctx, dataConnector, childPatchId, modifications)
 					if err != nil {
 						return errors.Wrap(mapHTTPStatusToGqlError(ctx, httpStatus, err), fmt.Sprintf("error modifying child patch '%s'", patchID))

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -753,7 +753,7 @@ func ModifyVersionHandler(ctx context.Context, dataConnector data.Connector, pat
 		return mapHTTPStatusToGqlError(ctx, httpStatus, err)
 	}
 
-	if version.Requester == evergreen.PatchVersionRequester || version.Requester == evergreen.GithubPRRequester {
+	if evergreen.IsPatchRequester(version.Requester) {
 		// restart is handled through graphql because we need the user to specify
 		// which downstream tasks they want to restart
 		if modifications.Action != Restart {
@@ -763,7 +763,7 @@ func ModifyVersionHandler(ctx context.Context, dataConnector data.Connector, pat
 				return ResourceNotFound.Send(ctx, fmt.Sprintf("error finding patch %s: %s", patchID, err.Error()))
 			}
 			if p == nil {
-				return ResourceNotFound.Send(ctx, fmt.Sprintf("patch not found %s: %s", patchID, err.Error()))
+				return ResourceNotFound.Send(ctx, fmt.Sprintf("patch '%s' not found ", patchID))
 			}
 			if p.IsParent() {
 				for _, childPatchId := range p.Triggers.ChildPatches {


### PR DESCRIPTION
[EVG-15118](https://jira.mongodb.org/browse/EVG-15118)

### Description 
This takes care of scheduling/unscheduling tasks for child patches when it's done for the parent patch. It made more sense to do it ModifyVersionHandler where it handles but scheduling/unscheduling and set priority so that code does not have to be repeated (especially with all the casing). Restart is handled separately because we need to take input from the user. 

### Testing 
Will test in staging 
