### PR TITLE
EVG-15091 consider if tg tasks are blocked before waiting on them

### DIFF
--- a/service/api_task.go
+++ b/service/api_task.go
@@ -591,7 +591,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 				if minTaskGroupOrderNum != 0 && minTaskGroupOrderNum < nextTask.TaskGroupOrder {
 					dispatchRace = fmt.Sprintf("current task is order %d but another host is running %d", nextTask.TaskGroupOrder, minTaskGroupOrderNum)
 				} else if nextTask.TaskGroupOrder > 1 {
-					// if the previous task in the group has yet to run and should run, then wait for it
+					// If the previous task in the group has yet to run and should run, then wait for it.
 					tgTasks, err := task.FindTaskGroupFromBuild(nextTask.BuildId, nextTask.TaskGroup)
 					if err != nil {
 						return nil, false, errors.WithStack(err)
@@ -600,7 +600,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 						if tgTask.TaskGroupOrder == nextTask.TaskGroupOrder {
 							break
 						}
-						if tgTask.TaskGroupOrder < nextTask.TaskGroupOrder && tgTask.IsDispatchable() {
+						if tgTask.TaskGroupOrder < nextTask.TaskGroupOrder && tgTask.IsDispatchable() && !tgTask.Blocked() {
 							dispatchRace = fmt.Sprintf("an earlier task ('%s') in the task group is still dispatchable", tgTask.DisplayName)
 						}
 					}


### PR DESCRIPTION
[EVG-15091](https://jira.mongodb.org/browse/EVG-15091)

### Description 
When tasks are blocked, they aren't marked as unactivated (this is purposeful because they could become unblocked). However, we shouldn't wait on them if later tasks in the group are scheduled. We ran into this error when a later task group task was set to override dependencies; instead it just got stuck at the top of the queue because it was waiting on the previous task group task which was also blocked.

### Testing 
[This task](https://evergreen-staging.corp.mongodb.com/task/evg_ubuntu1604_test_cloud_patch_ccbdfbe1ca4c5e72baed4d0505b6b058566c89b4_61083e9a97b1d31e62c81c7b_21_08_02_18_51_19) was on the queue but not being dispatched (and was logging errors) until I pushed my changes, and then was dispatched.
