### PR TITLE
EVG-15163 Fix cannot annotate tasks that have been retried

### DIFF
--- a/rest/route/annotations.go
+++ b/rest/route/annotations.go
@@ -254,8 +254,19 @@ func (h *annotationByTaskPutHandler) Parse(ctx context.Context, r *http.Request)
 		}
 	}
 
+	body := util.NewRequestReader(r)
+	defer body.Close()
+	err = json.NewDecoder(body).Decode(&h.annotation)
+	if err != nil {
+		return gimlet.ErrorResponse{
+			Message:    fmt.Sprintf("API error while unmarshalling JSON: '%s'", err.Error()),
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
 	// check if the task exists
-	t, err := task.FindOne(task.ById(h.taskId))
+	// t, err := task.FindOne(task.ById(h.taskId))
+	t, err := task.FindByIdExecution(h.taskId, h.annotation.TaskExecution)
 	if err != nil {
 		return errors.Wrap(err, "error finding task")
 	}
@@ -268,16 +279,6 @@ func (h *annotationByTaskPutHandler) Parse(ctx context.Context, r *http.Request)
 	if !evergreen.IsFailedTaskStatus(t.Status) {
 		return gimlet.ErrorResponse{
 			Message:    fmt.Sprintf("cannot create annotation when task status is '%s'", t.Status),
-			StatusCode: http.StatusBadRequest,
-		}
-	}
-
-	body := util.NewRequestReader(r)
-	defer body.Close()
-	err = json.NewDecoder(body).Decode(&h.annotation)
-	if err != nil {
-		return gimlet.ErrorResponse{
-			Message:    fmt.Sprintf("API error while unmarshalling JSON: '%s'", err.Error()),
 			StatusCode: http.StatusBadRequest,
 		}
 	}
@@ -383,7 +384,7 @@ func (h *createdTicketByTaskPutHandler) Parse(ctx context.Context, r *http.Reque
 	h.execution = execution
 
 	// check if the task exists
-	t, err := task.FindByIdExecution(h.taskId, &h.execution)
+	t, err := task.FindOne(task.ById(h.taskId))
 	if err != nil {
 		return errors.Wrap(err, "error finding task")
 	}

--- a/rest/route/annotations.go
+++ b/rest/route/annotations.go
@@ -383,7 +383,7 @@ func (h *createdTicketByTaskPutHandler) Parse(ctx context.Context, r *http.Reque
 	h.execution = execution
 
 	// check if the task exists
-	t, err := task.FindOne(task.ById(h.taskId))
+	t, err := task.FindByIdExecution(h.taskId, &h.execution)
 	if err != nil {
 		return errors.Wrap(err, "error finding task")
 	}

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -468,8 +468,8 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 	jsonBody, err = json.Marshal(a)
 	buffer = bytes.NewBuffer(jsonBody)
 
-	r, err = http.NewRequest("PUT", "/task/TaskFailedId/annotations", buffer)
-	r = gimlet.SetURLVars(r, map[string]string{"task_id": "TaskFailedId"})
+	r, err = http.NewRequest("PUT", "/task/TaskSystemFailedId/annotations", buffer)
+	r = gimlet.SetURLVars(r, map[string]string{"task_id": "TaskSystemFailedId"})
 	assert.NoError(t, err)
 	err = h.Parse(ctx, r)
 	assert.Contains(t, err.Error(), "TaskID must equal the taskId specified in the annotation")


### PR DESCRIPTION
[EVG-15163](https://jira.mongodb.org/browse/EVG-15163)

### Description 
This fetches a task by execution so that the status restriction applies to the execution in question and not the latest one. 
### Testing 
Tested in staging and made sure it doesn't fail with a task that first failed and then didn't. 
