### PR TITLE
EVG-15178 update activation time for display tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -868,6 +868,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 		if !createAll && !utility.StringSliceContains(displayNames, dt.Name) {
 			// this display task already exists, but may need to be updated
 			execTaskIds := []string{}
+			displayTaskActivated := false
 			for _, et := range dt.ExecTasks {
 				execTaskId := execTable.GetId(b.BuildVariant, et)
 				if execTaskId == "" {
@@ -883,8 +884,11 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 					continue
 				}
 				execTaskIds = append(execTaskIds, execTaskId)
+				if execTask, ok := taskMap[execTaskId]; ok && execTask.Activated {
+					displayTaskActivated = true
+				}
 			}
-			grip.Error(message.WrapError(task.AddExecTasksToDisplayTask(id, execTaskIds), message.Fields{
+			grip.Error(message.WrapError(task.AddExecTasksToDisplayTask(id, execTaskIds, displayTaskActivated), message.Fields{
 				"message":      "problem adding exec tasks to display tasks",
 				"exec_tasks":   execTaskIds,
 				"display_task": dt.Name,

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2438,12 +2438,13 @@ func TestAddExecTasksToDisplayTask(t *testing.T) {
 	dt1 := Task{
 		Id:             "dt1",
 		DisplayOnly:    true,
+		Activated:      false,
 		ExecutionTasks: []string{"et1", "et2"},
 	}
 	assert.NoError(t, dt1.Insert())
 
 	// no tasks to add
-	assert.NoError(t, AddExecTasksToDisplayTask(dt1.Id, []string{}))
+	assert.NoError(t, AddExecTasksToDisplayTask(dt1.Id, []string{}, false))
 	dtFromDB, err := FindOneId(dt1.Id)
 	assert.NoError(t, err)
 	assert.NotNil(t, dtFromDB)
@@ -2452,7 +2453,7 @@ func TestAddExecTasksToDisplayTask(t *testing.T) {
 	assert.Contains(t, dtFromDB.ExecutionTasks, "et2")
 
 	// new and existing tasks to add (existing tasks not duplicated)
-	assert.NoError(t, AddExecTasksToDisplayTask(dt1.Id, []string{"et2", "et3", "et4"}))
+	assert.NoError(t, AddExecTasksToDisplayTask(dt1.Id, []string{"et2", "et3", "et4"}, true))
 	dtFromDB, err = FindOneId(dt1.Id)
 	assert.NoError(t, err)
 	assert.NotNil(t, dtFromDB)
@@ -2461,4 +2462,6 @@ func TestAddExecTasksToDisplayTask(t *testing.T) {
 	assert.Contains(t, dtFromDB.ExecutionTasks, "et2")
 	assert.Contains(t, dtFromDB.ExecutionTasks, "et3")
 	assert.Contains(t, dtFromDB.ExecutionTasks, "et4")
+	assert.True(t, dtFromDB.Activated)
+	assert.False(t, utility.IsZeroTime(dtFromDB.ActivatedTime))
 }

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1361,6 +1361,9 @@ func UpdateDisplayTask(t *task.Task) error {
 		// if any of the execution tasks are scheduled, the display task is too
 		if execTask.Activated {
 			t.Activated = true
+			if utility.IsZeroTime(t.ActivatedTime) {
+				t.ActivatedTime = time.Now()
+			}
 		}
 		if execTask.IsFinished() {
 			hasFinishedTasks = true
@@ -1391,10 +1394,11 @@ func UpdateDisplayTask(t *task.Task) error {
 	}
 
 	update := bson.M{
-		task.StatusKey:    statusTask.Status,
-		task.ActivatedKey: t.Activated,
-		task.TimeTakenKey: timeTaken,
-		task.DetailsKey:   statusTask.Details,
+		task.StatusKey:        statusTask.Status,
+		task.ActivatedKey:     t.Activated,
+		task.ActivatedTimeKey: t.ActivatedTime,
+		task.TimeTakenKey:     timeTaken,
+		task.DetailsKey:       statusTask.Details,
 	}
 
 	if startTime != time.Unix(1<<62, 0) {


### PR DESCRIPTION
[EVG-15178](https://jira.mongodb.org/browse/EVG-15178)

### Description 
Robert has a patch where the [display task](https://spruce.mongodb.com/task/mongodb_mongo_master_enterprise_rhel_80_64_bit_dynamic_required_display_generator_tasks_patch_4ce48b4608b0b3e0528b4faba0d1dc0075f71c32_610a7ce89ccd4e1d78c30a2f_21_08_04_11_42_16/execution-tasks?execution=0&sorts=STATUS%3AASC) has no activation time, even though execution tasks ran. I wasn't able to create a minimum viable example of how this happened, but I did some code reading of where Activated gets set (bc that _is_ setfor this task) and found two places where we don't consider activationTime but should. When this is in prod, I can re-create the server patch and see if the problem still occurs (but either way this is a necessary change).

### Testing 
 I modified a unit test to check that this doesn't break anything. 
