### PR TITLE
EVG-14366 Allow FindPatchesByProject to search by ProjectIdentifiers

### DIFF
--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -39,7 +39,11 @@ type DBPatchConnector struct{}
 // FindPatchesByProject uses the service layer's patches type to query the backing database for
 // the patches.
 func (pc *DBPatchConnector) FindPatchesByProject(projectId string, ts time.Time, limit int) ([]restModel.APIPatch, error) {
+	apiPatches := []restModel.APIPatch{}
 	id, err := model.GetIdForProject(projectId)
+	if id == "" {
+		return apiPatches, nil
+	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "problem fetching project with id %s", projectId)
 	}
@@ -47,7 +51,6 @@ func (pc *DBPatchConnector) FindPatchesByProject(projectId string, ts time.Time,
 	if err != nil {
 		return nil, errors.Wrapf(err, "problem fetching patches for project %s", id)
 	}
-	apiPatches := []restModel.APIPatch{}
 	for _, p := range patches {
 		apiPatch := restModel.APIPatch{}
 		err = apiPatch.BuildFromService(p)

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -41,9 +41,6 @@ type DBPatchConnector struct{}
 func (pc *DBPatchConnector) FindPatchesByProject(projectId string, ts time.Time, limit int) ([]restModel.APIPatch, error) {
 	apiPatches := []restModel.APIPatch{}
 	id, err := model.GetIdForProject(projectId)
-	if id == "" {
-		return apiPatches, nil
-	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "problem fetching project with id %s", projectId)
 	}
@@ -355,7 +352,7 @@ func (hp *MockPatchConnector) FindPatchesByProject(projectId string, ts time.Tim
 		}
 	}
 	if id == "" {
-		return patchesToReturn, nil
+		return nil, errors.Errorf("failed to find project '%s'", projectId)
 	}
 	for i := len(hp.CachedPatches) - 1; i >= 0; i-- {
 		p := hp.CachedPatches[i]

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -352,7 +352,7 @@ func (hp *MockPatchConnector) FindPatchesByProject(projectId string, ts time.Tim
 		}
 	}
 	if id == "" {
-		return nil, errors.Errorf("project with identifier %s not found", projectId)
+		return patchesToReturn, nil
 	}
 	for i := len(hp.CachedPatches) - 1; i >= 0; i-- {
 		p := hp.CachedPatches[i]

--- a/rest/data/patch_test.go
+++ b/rest/data/patch_test.go
@@ -168,7 +168,7 @@ func (s *PatchConnectorFetchByProjectSuite) TestProjectNonexistentFail() {
 	s.Error(err)
 }
 
-func (s *PatchConnectorFetchByProjectSuite) TestPatchNonexistentFail() {
+func (s *PatchConnectorFetchByProjectSuite) TestEmptyPatchesOkay() {
 	patches, err := s.ctx.FindPatchesByProject("project4", s.time, 1)
 	s.NoError(err)
 	s.Len(patches, 0)

--- a/rest/data/patch_test.go
+++ b/rest/data/patch_test.go
@@ -57,9 +57,11 @@ func TestPatchConnectorFetchByProjectSuite(t *testing.T) {
 		pRef1 := dbModel.ProjectRef{Id: "project1", Identifier: "project_one"}
 		pRef2 := dbModel.ProjectRef{Id: "project2", Identifier: "project_two"}
 		pRef3 := dbModel.ProjectRef{Id: "project3", Identifier: "project_three"}
+		pRef4 := dbModel.ProjectRef{Id: "project4", Identifier: "project_four"}
 		assert.NoError(t, pRef1.Insert())
 		assert.NoError(t, pRef2.Insert())
 		assert.NoError(t, pRef3.Insert())
+		assert.NoError(t, pRef4.Insert())
 		return nil
 	}
 
@@ -81,6 +83,8 @@ func TestMockPatchConnectorFetchByProjectSuite(t *testing.T) {
 		proj2Identifier := "project_two"
 		proj3 := "project3"
 		proj3Identifier := "project_three"
+		proj4 := "project4"
+		proj4Identifier := "project_four"
 		nowPlus2 := s.time.Add(time.Second * 2)
 		nowPlus4 := s.time.Add(time.Second * 4)
 		nowPlus6 := s.time.Add(time.Second * 6)
@@ -101,6 +105,7 @@ func TestMockPatchConnectorFetchByProjectSuite(t *testing.T) {
 				{Id: &proj1, Identifier: &proj1Identifier},
 				{Id: &proj2, Identifier: &proj2Identifier},
 				{Id: &proj3, Identifier: &proj3Identifier},
+				{Id: &proj4, Identifier: &proj4Identifier},
 			},
 		},
 		}
@@ -158,8 +163,13 @@ func (s *PatchConnectorFetchByProjectSuite) TestFetchTooFew() {
 	s.Equal(s.time.Add(time.Second*10), *patches[0].CreateTime)
 }
 
-func (s *PatchConnectorFetchByProjectSuite) TestFetchNonexistentFail() {
-	patches, err := s.ctx.FindPatchesByProject("zzz", s.time, 1)
+func (s *PatchConnectorFetchByProjectSuite) TestProjectNonexistentFail() {
+	_, err := s.ctx.FindPatchesByProject("zzz", s.time, 1)
+	s.Error(err)
+}
+
+func (s *PatchConnectorFetchByProjectSuite) TestPatchNonexistentFail() {
+	patches, err := s.ctx.FindPatchesByProject("project4", s.time, 1)
 	s.NoError(err)
 	s.Len(patches, 0)
 }

--- a/rest/data/patch_test.go
+++ b/rest/data/patch_test.go
@@ -76,7 +76,9 @@ func TestMockPatchConnectorFetchByProjectSuite(t *testing.T) {
 		s.time = time.Date(2009, time.November, 10, 23, 0, 0, 0, time.Local)
 
 		proj1 := "project1"
+		proj1Identifier := "project_one"
 		proj2 := "project2"
+		proj2Identifier := "project_two"
 		proj3 := "project3"
 		proj3Identifier := "project_three"
 		nowPlus2 := s.time.Add(time.Second * 2)
@@ -94,6 +96,11 @@ func TestMockPatchConnectorFetchByProjectSuite(t *testing.T) {
 				{ProjectId: &proj2, CreateTime: &nowPlus8},
 				{ProjectId: &proj1, CreateTime: &nowPlus10},
 				{ProjectId: &proj3, ProjectIdentifier: &proj3Identifier, CreateTime: &nowPlus12},
+			},
+			CachedProjectRefs: []model.APIProjectRef{
+				{Id: &proj1, Identifier: &proj1Identifier},
+				{Id: &proj2, Identifier: &proj2Identifier},
+				{Id: &proj3, Identifier: &proj3Identifier},
 			},
 		},
 		}

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -101,7 +101,9 @@ func TestPatchesByProjectSuite(t *testing.T) {
 func (s *PatchesByProjectSuite) SetupSuite() {
 	s.now = time.Date(2009, time.November, 10, 23, 0, 0, 0, time.FixedZone("", 0))
 	proj1 := "project1"
+	proj1Identifier := "project_one"
 	proj2 := "project2"
+	proj2Identifier := "project_two"
 	nowPlus2 := s.now.Add(time.Second * 2)
 	nowPlus4 := s.now.Add(time.Second * 4)
 	nowPlus6 := s.now.Add(time.Second * 6)
@@ -115,6 +117,10 @@ func (s *PatchesByProjectSuite) SetupSuite() {
 			{ProjectId: &proj1, CreateTime: &nowPlus6},
 			{ProjectId: &proj2, CreateTime: &nowPlus8},
 			{ProjectId: &proj1, CreateTime: &nowPlus10},
+		},
+		CachedProjectRefs: []model.APIProjectRef{
+			{Id: &proj1, Identifier: &proj1Identifier},
+			{Id: &proj2, Identifier: &proj2Identifier},
 		},
 	}
 	s.sc = &data.MockConnector{

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -104,6 +104,8 @@ func (s *PatchesByProjectSuite) SetupSuite() {
 	proj1Identifier := "project_one"
 	proj2 := "project2"
 	proj2Identifier := "project_two"
+	proj3 := "project3"
+	proj3Identifier := "project_three"
 	nowPlus2 := s.now.Add(time.Second * 2)
 	nowPlus4 := s.now.Add(time.Second * 4)
 	nowPlus6 := s.now.Add(time.Second * 6)
@@ -121,6 +123,7 @@ func (s *PatchesByProjectSuite) SetupSuite() {
 		CachedProjectRefs: []model.APIProjectRef{
 			{Id: &proj1, Identifier: &proj1Identifier},
 			{Id: &proj2, Identifier: &proj2Identifier},
+			{Id: &proj3, Identifier: &proj3Identifier},
 		},
 	}
 	s.sc = &data.MockConnector{
@@ -141,6 +144,16 @@ func (s *PatchesByProjectSuite) TestPaginatorShouldSucceedIfNoResults() {
 	resp := s.route.Run(context.Background())
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status(), "%+v", resp.Data())
+}
+
+func (s *PatchesByProjectSuite) TestPaginatorShouldFailIfNoProject() {
+	s.route.projectId = "zzz"
+	s.route.key = s.now
+	s.route.limit = 1
+
+	resp := s.route.Run(context.Background())
+	s.NotNil(resp)
+	s.Equal(http.StatusBadRequest, resp.Status())
 }
 
 func (s *PatchesByProjectSuite) TestPaginatorShouldReturnResultsIfDataExists() {


### PR DESCRIPTION
[EVG-14366](https://jira.mongodb.org/browse/EVG-14366)

### Description 
FindPatchesByProject can now search even if it's given an identifier

### Testing 
unittest