### PR TITLE
EVG-15017: Add closure over the value of notification_target string to fix notification logging

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -636,11 +636,11 @@ func (e *envState) initSenders(ctx context.Context) error {
 			if err == nil {
 				return
 			}
-
+			notificationTarget := name
 			grip.Error(message.WrapError(err, message.Fields{
 				"notification":        m.String(),
 				"message_type":        fmt.Sprintf("%T", m),
-				"notification_target": name.String(),
+				"notification_target": notificationTarget.String(),
 				"event":               m,
 			}))
 		}))

--- a/environment.go
+++ b/environment.go
@@ -632,15 +632,15 @@ func (e *envState) initSenders(ctx context.Context) error {
 	catcher := grip.NewBasicCatcher()
 	for name, s := range e.senders {
 		catcher.Add(s.SetLevel(levelInfo))
+		tempName := name
 		catcher.Add(s.SetErrorHandler(func(err error, m message.Composer) {
 			if err == nil {
 				return
 			}
-			notificationTarget := name
 			grip.Error(message.WrapError(err, message.Fields{
 				"notification":        m.String(),
 				"message_type":        fmt.Sprintf("%T", m),
-				"notification_target": notificationTarget.String(),
+				"notification_target": tempName.String(),
 				"event":               m,
 			}))
 		}))


### PR DESCRIPTION
[EVG-15017](https://jira.mongodb.org/browse/EVG-15017)

### Description 
All notification error messages in Splunk had the “notification_target” field randomly be that of another sender. It was noticed that the [error handler function](https://github.com/evergreen-ci/evergreen/blob/d89485d34a375362759111dea41afe32d1acdbca/environment.go#L633-L647) was a closure around the name variable which gets changed on each iteration of the loop. A fix was made to give each iteration a local copy of the name variable to close around.

### Testing 
Change was deployed to staging and a notification was set up to send a slack message to a nonsensical channel when a task restarted.  When the channel_not_found error was triggered [as expected](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen-staging%22%20channel_not_found&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=rt-1h&latest=rt&sid=rt_1628186064.3770454), we confirmed that the notification_target was "slack" as it should be instead of some other sender type
