### PR TITLE
EVG-14973  Hide child patches from showing up as a patch

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -12,6 +12,7 @@ import (
 const (
 	User            = "mci"
 	GithubPatchUser = "github_pull_request"
+	ParentPatchUser = "parent_patch"
 
 	HostRunning         = "running"
 	HostTerminated      = "terminated"

--- a/model/patch/trigger_intent.go
+++ b/model/patch/trigger_intent.go
@@ -60,7 +60,7 @@ func (t *TriggerIntent) GetType() string {
 func (t *TriggerIntent) NewPatch() *Patch {
 	return &Patch{
 		Id:       mgobson.ObjectIdHex(t.Id),
-		Author:   t.Author,
+		Author:   evergreen.ParentPatchUser,
 		Triggers: TriggerInfo{ParentPatch: t.ParentID},
 		Status:   evergreen.PatchCreated,
 		Project:  t.ProjectID,


### PR DESCRIPTION
[EVG-14973](https://jira.mongodb.org/browse/EVG-14973)

### Description 
Add a parent_patch user and use that for child patches so that they don't show up on the myPatches page. 

### Testing 
Tested by adding the parent_patch user to staging, creating a patch with child patches, and making sure that they show up in the right places. 
