### PR TITLE
EVG-14332 add notification for failed or blocked task

### DIFF
--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -66,6 +66,7 @@ const (
 	TriggerGithubCheckOutcome        = "github-check-outcome"
 	TriggerFailure                   = "failure"
 	TriggerSuccess                   = "success"
+	TriggerBlocked                   = "blocked"
 	TriggerRegression                = "regression"
 	TriggerExceedsDuration           = "exceeds-duration"
 	TriggerRuntimeChangeByPercent    = "runtime-change"
@@ -298,7 +299,7 @@ func IsSubscriptionAllowed(sub Subscription) (bool, string) {
 	return true, ""
 }
 
-func ValidateSelectors(subscriber Subscriber, selectors []Selector) (bool, string) {
+func ValidateSelectors(selectors []Selector) (bool, string) {
 	for i := range selectors {
 		if len(selectors[i].Type) == 0 || len(selectors[i].Data) == 0 {
 			return false, "Selector had empty type or data"

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -66,7 +66,6 @@ const (
 	TriggerGithubCheckOutcome        = "github-check-outcome"
 	TriggerFailure                   = "failure"
 	TriggerSuccess                   = "success"
-	TriggerBlocked                   = "blocked"
 	TriggerRegression                = "regression"
 	TriggerExceedsDuration           = "exceeds-duration"
 	TriggerRuntimeChangeByPercent    = "runtime-change"

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -128,7 +128,6 @@ func LogTaskRestarted(taskId string, execution int, userId string) {
 	logTaskEvent(taskId, TaskRestarted, TaskEventData{Execution: execution, UserId: userId})
 }
 
-// TODO: should we also log what task blocked it? (Would only want to log it then if it's blocked for the first time I think)
 func LogTaskBlocked(taskId string, execution int) {
 	logTaskEvent(taskId, TaskBlocked, TaskEventData{Execution: execution})
 }

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -10,6 +10,7 @@ import (
 func init() {
 	registry.AddType(ResourceTypeTask, taskEventDataFactory)
 	registry.AllowSubscription(ResourceTypeTask, TaskFinished)
+	registry.AllowSubscription(ResourceTypeTask, TaskBlocked)
 }
 
 const (
@@ -17,20 +18,21 @@ const (
 	ResourceTypeTask = "TASK"
 
 	// event types
-	TaskCreated                 = "TASK_CREATED"
-	TaskDispatched              = "TASK_DISPATCHED"
-	TaskUndispatched            = "TASK_UNDISPATCHED"
-	TaskStarted                 = "TASK_STARTED"
-	TaskFinished                = "TASK_FINISHED"
-	TaskRestarted               = "TASK_RESTARTED"
-	TaskActivated               = "TASK_ACTIVATED"
-	TaskDeactivated             = "TASK_DEACTIVATED"
-	TaskAbortRequest            = "TASK_ABORT_REQUEST"
-	TaskScheduled               = "TASK_SCHEDULED"
-	TaskPriorityChanged         = "TASK_PRIORITY_CHANGED"
-	TaskJiraAlertCreated        = "TASK_JIRA_ALERT_CREATED"
-	TaskDepdendenciesOverridden = "TASK_DEPENDENCIES_OVERRIDDEN"
-	MergeTaskUnscheduled        = "MERGE_TASK_UNSCHEDULED"
+	TaskCreated                = "TASK_CREATED"
+	TaskDispatched             = "TASK_DISPATCHED"
+	TaskUndispatched           = "TASK_UNDISPATCHED"
+	TaskStarted                = "TASK_STARTED"
+	TaskFinished               = "TASK_FINISHED"
+	TaskBlocked                = "TASK_BLOCKED"
+	TaskRestarted              = "TASK_RESTARTED"
+	TaskActivated              = "TASK_ACTIVATED"
+	TaskDeactivated            = "TASK_DEACTIVATED"
+	TaskAbortRequest           = "TASK_ABORT_REQUEST"
+	TaskScheduled              = "TASK_SCHEDULED"
+	TaskPriorityChanged        = "TASK_PRIORITY_CHANGED"
+	TaskJiraAlertCreated       = "TASK_JIRA_ALERT_CREATED"
+	TaskDependenciesOverridden = "TASK_DEPENDENCIES_OVERRIDDEN"
+	MergeTaskUnscheduled       = "MERGE_TASK_UNSCHEDULED"
 )
 
 // implements Data
@@ -126,6 +128,11 @@ func LogTaskRestarted(taskId string, execution int, userId string) {
 	logTaskEvent(taskId, TaskRestarted, TaskEventData{Execution: execution, UserId: userId})
 }
 
+// TODO: should we also log what task blocked it? (Would only want to log it then if it's blocked for the first time I think)
+func LogTaskBlocked(taskId string, execution int) {
+	logTaskEvent(taskId, TaskBlocked, TaskEventData{Execution: execution})
+}
+
 func LogTaskActivated(taskId string, execution int, userId string) {
 	logTaskEvent(taskId, TaskActivated, TaskEventData{Execution: execution, UserId: userId})
 }
@@ -150,7 +157,7 @@ func LogTaskScheduled(taskId string, execution int, scheduledTime time.Time) {
 }
 
 func LogTaskDependenciesOverridden(taskId string, execution int, userID string) {
-	logTaskEvent(taskId, TaskDepdendenciesOverridden,
+	logTaskEvent(taskId, TaskDependenciesOverridden,
 		TaskEventData{Execution: execution, UserId: userID})
 }
 

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1266,7 +1266,7 @@ func FindProjectForTask(taskID string) (string, error) {
 	return t.Project, nil
 }
 
-func UpdateAllMatchingDependenciesForTask(taskId, dependencyId string, unattainable bool) error {
+func updateAllMatchingDependenciesForTask(taskId, dependencyId string, unattainable bool) error {
 	env := evergreen.GetEnvironment()
 	ctx, cancel := env.Context()
 	defer cancel()

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -575,7 +575,7 @@ func UpdateBlockedDependencies(t *task.Task) error {
 	}
 
 	for _, dependentTask := range dependentTasks {
-		if err = dependentTask.MarkUnattainableDependency(t, true); err != nil {
+		if err = dependentTask.MarkUnattainableDependency(t.Id, true); err != nil {
 			return errors.Wrap(err, "error marking dependency unattainable")
 		}
 		if err = UpdateBlockedDependencies(&dependentTask); err != nil {
@@ -601,7 +601,7 @@ func UpdateUnblockedDependencies(t *task.Task, logIDs bool, caller string) error
 	}
 
 	for _, blockedTask := range blockedTasks {
-		if err = blockedTask.MarkUnattainableDependency(t, false); err != nil {
+		if err = blockedTask.MarkUnattainableDependency(t.Id, false); err != nil {
 			return errors.Wrap(err, "error marking dependency attainable")
 		}
 		if err = UpdateUnblockedDependencies(&blockedTask, logIDs, caller); err != nil {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3733,6 +3733,7 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 	assert.NoError(err)
 	assert.True(dbExecTask.DependsOn[0].Unattainable)
 
+	// one event inserted for every updated task
 	events, err := event.Find(event.AllLogCollection, db.Q{})
 	assert.NoError(err)
 	assert.Len(events, 4)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2829,7 +2829,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 
 	e, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
 	assert.NoError(err)
-	assert.Len(e, 3)
+	assert.Len(e, 4)
 }
 
 func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
@@ -2901,7 +2901,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 
 	e, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
 	assert.NoError(err)
-	assert.Len(e, 3)
+	assert.Len(e, 4)
 }
 
 func TestClearAndResetStrandedTask(t *testing.T) {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3616,7 +3616,7 @@ tasks:
 
 func TestUpdateBlockedDependencies(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.ClearCollections(task.Collection, build.Collection))
+	assert.NoError(db.ClearCollections(task.Collection, build.Collection, event.AllLogCollection))
 
 	b := build.Build{Id: "build0"}
 	tasks := []task.Task{
@@ -3732,6 +3732,11 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 	dbExecTask, err := task.FindOneId(execTask.Id)
 	assert.NoError(err)
 	assert.True(dbExecTask.DependsOn[0].Unattainable)
+
+	events, err := event.Find(event.AllLogCollection, db.Q{})
+	assert.NoError(err)
+	assert.Len(events, 4)
+
 }
 
 func TestUpdateUnblockedDependencies(t *testing.T) {

--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -273,14 +273,14 @@ mciModule.controller('TaskCtrl', function ($scope, $rootScope, $now, $timeout, $
       label: "this task fails",
     },
     {
+      trigger: "task-failed-or-blocked",
+      resource_type: "TASK",
+      label: "this task fails or is blocked",
+    },
+    {
       trigger: "success",
       resource_type: "TASK",
       label: "this task succeeds",
-    },
-    {
-      trigger: "blocked",
-      resource_type: "TASK",
-      label: "this task is blocked",
     },
     {
       trigger: "exceeds-duration",

--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -278,6 +278,11 @@ mciModule.controller('TaskCtrl', function ($scope, $rootScope, $now, $timeout, $
       label: "this task succeeds",
     },
     {
+      trigger: "blocked",
+      resource_type: "TASK",
+      label: "this task is blocked",
+    },
+    {
       trigger: "exceeds-duration",
       resource_type: "TASK",
       label: "the runtime for this task exceeds some duration",

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -60,13 +60,13 @@ func (dc *DBSubscriptionConnector) SaveSubscriptions(owner string, subscriptions
 			}
 		}
 
-		if ok, msg := event.ValidateSelectors(dbSubscription.Subscriber, dbSubscription.Selectors); !ok {
+		if ok, msg := event.ValidateSelectors(dbSubscription.Selectors); !ok {
 			return gimlet.ErrorResponse{
 				StatusCode: http.StatusBadRequest,
 				Message:    fmt.Sprintf("Invalid selectors: %s", msg),
 			}
 		}
-		if ok, msg := event.ValidateSelectors(dbSubscription.Subscriber, dbSubscription.RegexSelectors); !ok {
+		if ok, msg := event.ValidateSelectors(dbSubscription.RegexSelectors); !ok {
 			return gimlet.ErrorResponse{
 				StatusCode: http.StatusBadRequest,
 				Message:    fmt.Sprintf("Invalid regex selectors: %s", msg),

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -278,7 +278,7 @@ func (s *taskSuite) SetupTest() {
 			Type:   event.JIRACommentSubscriberType,
 			Target: "A-3",
 		}),
-		event.NewSubscriptionByID(event.ResourceTypeTask, event.TriggerBlocked, s.event.ResourceId, apiSub),
+		event.NewSubscriptionByID(event.ResourceTypeTask, triggerTaskFailedOrBlocked, s.event.ResourceId, apiSub),
 	}
 
 	for i := range s.subs {
@@ -290,7 +290,7 @@ func (s *taskSuite) SetupTest() {
 	}
 	s.NoError(ui.Set())
 
-	s.t = makeTaskFinishedTriggers().(*taskTriggers)
+	s.t = makeTaskTriggers().(*taskTriggers)
 	s.t.event = &s.event
 	s.t.data = s.data
 	s.t.task = &s.task
@@ -472,7 +472,7 @@ func (s *taskSuite) TestOutcome() {
 	s.NotNil(n)
 }
 
-func (s *taskSuite) TestBlocked() {
+func (s *taskSuite) TestFailedOrBlocked() {
 	s.data.Status = evergreen.TaskUndispatched
 	s.t.task.DependsOn = []task.Dependency{
 		{
@@ -483,12 +483,12 @@ func (s *taskSuite) TestBlocked() {
 			Unattainable: false,
 		},
 	}
-	n, err := s.t.taskBlocked(&s.subs[7])
+	n, err := s.t.taskFailedOrBlocked(&s.subs[7])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.t.task.DependsOn[0].Unattainable = true
-	n, err = s.t.taskBlocked(&s.subs[7])
+	n, err = s.t.taskFailedOrBlocked(&s.subs[7])
 	s.NoError(err)
 	s.NotNil(n)
 }
@@ -1069,7 +1069,7 @@ func (s *taskSuite) TestRegressionByTestWithRegex() {
 }
 
 func (s *taskSuite) makeTaskTriggers(id string, execution int) *taskTriggers {
-	t := makeTaskFinishedTriggers()
+	t := makeTaskTriggers()
 	e := event.EventLogEntry{
 		ResourceId: id,
 		Data: &event.TaskEventData{

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -387,13 +387,13 @@ func (s *taskSuite) TestAllTriggers() {
 
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)
-	s.Len(n, 4)
+	s.Len(n, 5)
 
 	s.task.DisplayOnly = true
 	s.NoError(db.Update(task.Collection, bson.M{"_id": s.task.Id}, &s.task))
 	n, err = NotificationsFromEvent(&s.event)
 	s.NoError(err)
-	s.Len(n, 3)
+	s.Len(n, 4)
 }
 
 func (s *taskSuite) TestAbortedTaskDoesNotNotify() {


### PR DESCRIPTION
[EVG-14332](https://jira.mongodb.org/browse/EVG-14332)

### Description 
Notify if the task is failed or blocked. (Could've made this just notify on blocked; I thought a bit about the reporter's use case / general use case for this and I think failed + blocked does make the most sense, but the work to add "just blocked" would be similar to this if it's ever requested in the future.)

### Testing 
 Tested in staging on both legacy and spruce for blocked and failed (slack and email).

Spruce
![image](https://user-images.githubusercontent.com/26798134/128553900-8ac9f83c-ec65-4176-bdd0-61e21e6eeb13.png)

Legacy
![image](https://user-images.githubusercontent.com/26798134/128553941-2506bcd6-05ff-49fc-96bd-2bf811843c06.png)

Slack
![image](https://user-images.githubusercontent.com/26798134/128553793-2a484758-496f-4f86-9f8e-2c4c6647576c.png)

Email
![image](https://user-images.githubusercontent.com/26798134/128553841-12b7bca8-6ab7-4864-8011-ab60f30a0e76.png)

