### PR TITLE
EVG-15197  Don't error if child version doesn't exist when modifying

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -775,7 +775,7 @@ func ModifyVersionHandler(ctx context.Context, dataConnector data.Connector, pat
 						return ResourceNotFound.Send(ctx, fmt.Sprintf("child patch '%s' not found ", childPatchId))
 					}
 					// only modify the child patch if it is finalized
-					if p.Activated {
+					if p.Version != "" {
 						err = ModifyVersionHandler(ctx, dataConnector, childPatchId, modifications)
 						if err != nil {
 							return errors.Wrap(mapHTTPStatusToGqlError(ctx, httpStatus, err), fmt.Sprintf("error modifying child patch '%s'", patchID))

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -767,10 +767,21 @@ func ModifyVersionHandler(ctx context.Context, dataConnector data.Connector, pat
 			}
 			if p.IsParent() {
 				for _, childPatchId := range p.Triggers.ChildPatches {
-					err = ModifyVersionHandler(ctx, dataConnector, childPatchId, modifications)
+					p, err := patch.FindOneId(childPatchId)
 					if err != nil {
-						return errors.Wrap(mapHTTPStatusToGqlError(ctx, httpStatus, err), fmt.Sprintf("error modifying child patch '%s'", patchID))
+						return ResourceNotFound.Send(ctx, fmt.Sprintf("error finding child patch %s: %s", childPatchId, err.Error()))
 					}
+					if p == nil {
+						return ResourceNotFound.Send(ctx, fmt.Sprintf("child patch '%s' not found ", childPatchId))
+					}
+					// only modify the child patch if it is finalized
+					if p.Activated {
+						err = ModifyVersionHandler(ctx, dataConnector, childPatchId, modifications)
+						if err != nil {
+							return errors.Wrap(mapHTTPStatusToGqlError(ctx, httpStatus, err), fmt.Sprintf("error modifying child patch '%s'", patchID))
+						}
+					}
+
 				}
 			}
 


### PR DESCRIPTION
[EVG-15197](https://jira.mongodb.org/browse/EVG-15197)

### Description 
This checks if a child patch is finalized before making modifications to avoid errors. 

### Testing 
Tested by creating a patch with a not finalized child patch in staging and changing the priority with no errors. 
