### PR TITLE
EVG-15192 Merge getTasksByVersion queries into one

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2933,9 +2933,9 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 				sortFields = append(sortFields, bson.E{Key: singleSort.Key, Value: singleSort.Order})
 			}
 		}
-	} else {
-		sortFields = append(sortFields, bson.E{Key: IdKey, Value: 1})
 	}
+	sortFields = append(sortFields, bson.E{Key: IdKey, Value: 1})
+
 	sortAndPaginatePipeline = append(sortAndPaginatePipeline, bson.M{
 		"$sort": sortFields,
 	})

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2958,7 +2958,7 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 		})
 	}
 
-	// Use a $facet to perform seperate aggregations for $count and to sort and paginate the results in the same query
+	// Use a $facet to perform separate aggregations for $count and to sort and paginate the results in the same query
 	tasksAndCountPipeline := bson.M{
 		"$facet": bson.M{
 			"count": []bson.M{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2958,6 +2958,7 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 		})
 	}
 
+	// Use a $facet to perform seperate aggregations for $count and to sort and paginate the results in the same query
 	tasksAndCountPipeline := bson.M{
 		"$facet": bson.M{
 			"count": []bson.M{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2958,7 +2958,7 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 		})
 	}
 
-	countAndResults := bson.M{
+	tasksAndCountPipeline := bson.M{
 		"$facet": bson.M{
 			"count": []bson.M{
 				{"$count": "count"},
@@ -2967,7 +2967,7 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 		},
 	}
 
-	pipeline = append(pipeline, countAndResults)
+	pipeline = append(pipeline, tasksAndCountPipeline)
 
 	type TasksAndCount struct {
 		Tasks []Task           `bson:"tasks"`


### PR DESCRIPTION
[EVG-15192](https://jira.mongodb.org/browse/EVG-15192)

### Description 
Instead of performing two queries to fetch tasks and to fetch the matching task count. Perform only one query by merging the separate pipelines using `$facet`

### Testing 
Reused existing tests since this is a refactor instead of a feature change.