### PR TITLE
EVG-15122 Sort tasks to resolve flaky tests

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1917,7 +1917,6 @@ func (r *mutationResolver) ScheduleUndispatchedBaseTasks(ctx context.Context, pa
 	opts := data.TaskFilterOptions{
 		Statuses:              evergreen.TaskFailureStatuses,
 		IncludeExecutionTasks: true,
-		Sorts:                 []task.TasksSortOrder{{Key: task.DisplayNameKey, Order: 1}},
 	}
 	tasks, _, err := r.sc.FindTasksByVersion(patchID, opts)
 	if err != nil {
@@ -1970,7 +1969,7 @@ func (r *mutationResolver) ScheduleUndispatchedBaseTasks(ctx context.Context, pa
 		}
 		scheduledTasks = append(scheduledTasks, task)
 	}
-	// sort scheduledTasks by display name to gurantee the order of the tasks
+	// sort scheduledTasks by display name to guarantee the order of the tasks
 	sort.Slice(scheduledTasks, func(i, j int) bool {
 		return *scheduledTasks[i].DisplayName < *scheduledTasks[j].DisplayName
 	})

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1970,6 +1970,10 @@ func (r *mutationResolver) ScheduleUndispatchedBaseTasks(ctx context.Context, pa
 		}
 		scheduledTasks = append(scheduledTasks, task)
 	}
+	// sort scheduledTasks by display name to gurantee the order of the tasks
+	sort.Slice(scheduledTasks, func(i, j int) bool {
+		return *scheduledTasks[i].DisplayName < *scheduledTasks[j].DisplayName
+	})
 
 	return scheduledTasks, nil
 }


### PR DESCRIPTION
[EVG-15122](https://jira.mongodb.org/browse/EVG-15122)

### Description 
The test that calls this resolver has been extremely flaky since we cannot guarantee the return order of the results. This adds a sort to the end to help guarantee the sort order.
I think fixing the flaky tests outweighs the performance hit the sort adds to the resolver. Since it will rarely be called. 
