### PR TITLE
EVG-14997: Merge test results audit

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2704,7 +2704,7 @@ func (r *taskResolver) ExecutionTasksFull(ctx context.Context, obj *restModel.AP
 		execT, err := task.FindOneIdAndExecutionWithDisplayStatus(execTaskID, &t.Execution)
 		if err != nil {
 			// The task is not found, possibly because the execution is out of sync with the display task. Get the latest instead.
-			execT, err = task.FindOne(task.ById(execTaskID))
+			execT, err = task.FindOneIdAndExecutionWithDisplayStatus(execTaskID, nil)
 			if err != nil {
 				return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting execution task with id: %s : %s", execTaskID, err.Error()))
 			}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -807,7 +807,7 @@ func mapHTTPStatusToGqlError(ctx context.Context, httpStatus int, err error) *gq
 }
 
 func isTaskBlocked(ctx context.Context, at *restModel.APITask) (*bool, error) {
-	t, err := task.FindOneIdNewOrOld(*at.Id)
+	t, err := task.FindOneIdNewOrOldNoMerge(*at.Id)
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, err.Error())
 	}

--- a/model/scheduler_stats.go
+++ b/model/scheduler_stats.go
@@ -265,7 +265,7 @@ func CreateAllHostUtilizationBuckets(daysBack, granularity int) ([]HostUtilizati
 		return nil, err
 	}
 
-	oldTasks, err := task.FindOld(task.ByTimeRun(bounds.StartTime, bounds.EndTime))
+	oldTasks, err := task.FindOldNoMerge(task.ByTimeRun(bounds.StartTime, bounds.EndTime))
 	if err != nil {
 		return nil, err
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1175,7 +1175,8 @@ func FindOldNoMerge(query db.Q) ([]Task, error) {
 	return tasks, err
 }
 
-// FindOld returns all task from the old tasks collection that satisfies the query.
+// FindOld returns all task from the old tasks collection that satisfies the
+// query and merges test results.
 func FindOld(query db.Q) ([]Task, error) {
 	tasks, err := FindOldNoMerge(query)
 	if err != nil {
@@ -1205,7 +1206,7 @@ func FindOldWithDisplayTasksNoMerge(query db.Q) ([]Task, error) {
 }
 
 // FindOldWithDisplayTasks finds display and execution tasks in the old
-// collection.
+// collection and merges test results.
 func FindOldWithDisplayTasks(query db.Q) ([]Task, error) {
 	tasks, err := FindOldWithDisplayTasksNoMerge(query)
 	if err != nil {
@@ -1235,7 +1236,7 @@ func FindOneIdOldOrNewNoMerge(id string, execution int) (*Task, error) {
 }
 
 // FindOneIdOldOrNew attempts to find a given task ID by first looking in the
-// old collection, then the tasks collection.
+// old collection, then the tasks collection and merges test results.
 func FindOneIdOldOrNew(id string, execution int) (*Task, error) {
 	task, err := FindOneOld(ById(MakeOldID(id, execution)))
 	if task == nil || err != nil {
@@ -1258,7 +1259,7 @@ func FindOneIdNewOrOldNoMerge(id string) (*Task, error) {
 }
 
 // FindOneIdNewOrOld attempts to find a given task ID by first looking in the
-// tasks collection, then the old tasks collection.
+// tasks collection, then the old tasks collection and merges test results.
 func FindOneIdNewOrOld(id string) (*Task, error) {
 	task, err := FindOne(ById(id))
 	if task == nil || err != nil {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1207,7 +1207,7 @@ func FindOldWithDisplayTasksNoMerge(query db.Q) ([]Task, error) {
 // FindOldWithDisplayTasks finds display and execution tasks in the old
 // collection.
 func FindOldWithDisplayTasks(query db.Q) ([]Task, error) {
-	tasks, err := FindOldWithDisplayTasks(query)
+	tasks, err := FindOldWithDisplayTasksNoMerge(query)
 	if err != nil {
 		return nil, err
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2425,9 +2425,9 @@ func (t *Task) GetDisplayTask() (*Task, error) {
 	var dt *Task
 	var err error
 	if t.Archived {
-		dt, err = FindOneOld(ByExecutionTask(t.OldTaskId))
+		dt, err = FindOneOldNoMerge(ByExecutionTask(t.OldTaskId))
 	} else {
-		dt, err = FindOne(ByExecutionTask(t.Id))
+		dt, err = FindOneNoMerge(ByExecutionTask(t.Id))
 	}
 	if err != nil {
 		return nil, err

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -804,7 +804,7 @@ func testHistoryV2Results(params *TestHistoryParameters) ([]task.Task, error) {
 	if err != nil {
 		return nil, err
 	}
-	oldTasks, err := task.FindOld(db.Query(tasksQuery).Project(projection))
+	oldTasks, err := task.FindOldNoMerge(db.Query(tasksQuery).Project(projection))
 	if err != nil {
 		return nil, err
 	}

--- a/model/task_json.go
+++ b/model/task_json.go
@@ -106,7 +106,7 @@ func GetDistinctTagNames(projectId string) ([]TaskJSONTag, error) {
 // GetTags finds TaskJSONs that have tags in the project associated with a
 // given task.
 func GetTaskJSONTags(taskId string) ([]TagContainer, error) {
-	t, err := task.FindOne(task.ById(taskId))
+	t, err := task.FindOneNoMerge(task.ById(taskId))
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func GetTaskJSONById(taskId, name string) (TaskJSON, error) {
 // GetTaskJSONForVariant finds a task by name and variant and finds
 // the document in the json collection associated with that task's id.
 func GetTaskJSONForVariant(version, variantId, taskName, name string) (TaskJSON, error) {
-	foundTask, err := task.FindOne(db.Query(bson.M{task.VersionKey: version, task.BuildVariantKey: variantId,
+	foundTask, err := task.FindOneNoMerge(db.Query(bson.M{task.VersionKey: version, task.BuildVariantKey: variantId,
 		task.DisplayNameKey: taskName}))
 	if err != nil {
 		return TaskJSON{}, err
@@ -250,7 +250,7 @@ func GetTaskJSONTagsForTask(project, buildVariant, taskName, name string) ([]Tas
 }
 
 func DeleteTaskJSONTagFromTask(taskId, name string) error {
-	t, err := task.FindOne(task.ById(taskId))
+	t, err := task.FindOneNoMerge(task.ById(taskId))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -263,7 +263,7 @@ func DeleteTaskJSONTagFromTask(taskId, name string) error {
 }
 
 func SetTaskJSONTagForTask(taskId, name, tag string) error {
-	t, err := task.FindOne(task.ById(taskId))
+	t, err := task.FindOneNoMerge(task.ById(taskId))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -153,7 +153,7 @@ func SetActiveStateById(id, user string, active bool) error {
 // originalStepbackTask is only specified if we're first activating the generator for a generated task.
 func activatePreviousTask(taskId, caller string, originalStepbackTask *task.Task) error {
 	// find the task first
-	t, err := task.FindOne(task.ById(taskId))
+	t, err := task.FindOneId(taskId)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -162,7 +162,7 @@ func activatePreviousTask(taskId, caller string, originalStepbackTask *task.Task
 	}
 
 	// find previous task limiting to just the last one
-	prevTask, err := task.FindOne(task.ByBeforeRevision(t.RevisionOrderNumber, t.BuildVariant, t.DisplayName, t.Project, t.Requester))
+	prevTask, err := task.FindOneNoMerge(task.ByBeforeRevision(t.RevisionOrderNumber, t.BuildVariant, t.DisplayName, t.Project, t.Requester))
 	if err != nil {
 		return errors.Wrap(err, "Error finding previous task")
 	}
@@ -247,7 +247,7 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 			if detail != nil {
 				if t.DisplayOnly {
 					for _, etId := range t.ExecutionTasks {
-						execTask, err = task.FindOne(task.ById(etId))
+						execTask, err = task.FindOneId(etId)
 						if err != nil {
 							return errors.Wrap(err, "error finding execution task")
 						}
@@ -272,7 +272,7 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 			if t.DisplayOnly {
 				execTasks := map[string]string{}
 				for _, et := range t.ExecutionTasks {
-					execTask, err = task.FindOne(task.ById(et))
+					execTask, err = task.FindOneId(et)
 					if err != nil {
 						continue
 					}
@@ -311,7 +311,7 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 }
 
 func AbortTask(taskId, caller string) error {
-	t, err := task.FindOne(task.ById(taskId))
+	t, err := task.FindOneId(taskId)
 	if err != nil {
 		return err
 	}
@@ -396,7 +396,7 @@ func DeactivatePreviousTasks(t *task.Task, caller string) error {
 // otherwise. Note that the setting is obtained from the top-level
 // project, if not explicitly set on the task.
 func getStepback(taskId string) (bool, error) {
-	t, err := task.FindOne(task.ById(taskId))
+	t, err := task.FindOneId(taskId)
 	if err != nil {
 		return false, errors.Wrapf(err, "problem finding task %s", taskId)
 	}
@@ -1278,7 +1278,7 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 		return nil
 	}
 
-	t, err := task.FindOne(task.ById(h.RunningTask))
+	t, err := task.FindOneId(h.RunningTask)
 	if err != nil {
 		return errors.Wrapf(err, "database error clearing task '%s' from host '%s'",
 			t.Id, h.Id)
@@ -1317,7 +1317,7 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 		if t.DisplayOnly {
 			for _, etID := range t.ExecutionTasks {
 				var execTask *task.Task
-				execTask, err = task.FindOne(task.ById(etID))
+				execTask, err = task.FindOneId(etID)
 				if err != nil {
 					return errors.Wrap(err, "error finding execution task")
 				}

--- a/model/validate.go
+++ b/model/validate.go
@@ -32,7 +32,7 @@ func ValidateTask(taskId string, checkSecret bool, r *http.Request) (*task.Task,
 	if taskId == "" {
 		return nil, http.StatusBadRequest, errors.New("missing task id")
 	}
-	t, err := task.FindOne(task.ById(taskId))
+	t, err := task.FindOneId(taskId)
 	if err != nil {
 		return nil, http.StatusInternalServerError, err
 	}

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -24,7 +24,7 @@ type DBTaskConnector struct{}
 // FindTaskById uses the service layer's task type to query the backing database for
 // the task with the given taskId.
 func (tc *DBTaskConnector) FindTaskById(taskId string) (*task.Task, error) {
-	t, err := task.FindOne(task.ById(taskId))
+	t, err := task.FindOneId(taskId)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (tc *DBTaskConnector) FindTasksByIds(ids []string) ([]task.Task, error) {
 }
 
 func (tc *DBTaskConnector) FindOldTasksByIDWithDisplayTasks(id string) ([]task.Task, error) {
-	ts, err := task.FindOldWithDisplayTasks(task.ByOldTaskID(id))
+	ts, err := task.FindOldWithDisplayTasksNoMerge(task.ByOldTaskID(id))
 	if err != nil {
 		return nil, err
 	}

--- a/rest/route/annotations.go
+++ b/rest/route/annotations.go
@@ -265,7 +265,6 @@ func (h *annotationByTaskPutHandler) Parse(ctx context.Context, r *http.Request)
 	}
 
 	// check if the task exists
-	// t, err := task.FindOne(task.ById(h.taskId))
 	t, err := task.FindByIdExecution(h.taskId, h.annotation.TaskExecution)
 	if err != nil {
 		return errors.Wrap(err, "error finding task")
@@ -384,7 +383,7 @@ func (h *createdTicketByTaskPutHandler) Parse(ctx context.Context, r *http.Reque
 	h.execution = execution
 
 	// check if the task exists
-	t, err := task.FindOne(task.ById(h.taskId))
+	t, err := task.FindOneId(h.taskId)
 	if err != nil {
 		return errors.Wrap(err, "error finding task")
 	}

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -1044,7 +1044,7 @@ func handleOldAgentRevision(response apimodels.NextTaskResponse, details *apimod
 func sendBackRunningTask(h *host.Host, response apimodels.NextTaskResponse, w http.ResponseWriter) {
 	var err error
 	var t *task.Task
-	t, err = task.FindOne(task.ById(h.RunningTask))
+	t, err = task.FindOneId(h.RunningTask)
 	if err != nil {
 		err = errors.Wrapf(err, "error getting running task %s", h.RunningTask)
 		grip.Error(err)

--- a/service/host.go
+++ b/service/host.go
@@ -74,7 +74,7 @@ func (uis *UIServer) hostPage(w http.ResponseWriter, r *http.Request) {
 	}
 	runningTask := &task.Task{}
 	if h.RunningTask != "" {
-		runningTask, err = task.FindOne(task.ById(h.RunningTask))
+		runningTask, err = task.FindOneId(h.RunningTask)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -90,7 +90,7 @@ func (uis *UIServer) spawnPage(w http.ResponseWriter, r *http.Request) {
 	}
 	var setupScriptPath string
 	if len(r.FormValue("task_id")) > 0 {
-		spawnTask, err = task.FindOne(task.ById(r.FormValue("task_id")))
+		spawnTask, err = task.FindOneId(r.FormValue("task_id"))
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError,
 				errors.Wrapf(err, "Error finding task '%s'", r.FormValue("task_id")))

--- a/service/stats.go
+++ b/service/stats.go
@@ -204,7 +204,7 @@ func (uis *UIServer) taskTimingJSON(w http.ResponseWriter, r *http.Request) {
 
 		if beforeTaskId != "" {
 			var t *task.Task
-			t, err = task.FindOne(task.ById(beforeTaskId))
+			t, err = task.FindOneId(beforeTaskId)
 			if err != nil {
 				uis.LoggedError(w, r, http.StatusNotFound, err)
 				return

--- a/service/task.go
+++ b/service/task.go
@@ -218,7 +218,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		tId = projCtx.Task.OldTaskId
 
 		// Get total number of executions for executions drop down
-		mostRecentExecution, err := task.FindOne(task.ById(tId))
+		mostRecentExecution, err := task.FindOneId(tId)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError,
 				errors.Wrapf(err, "Error finding most recent execution by id %s", tId))
@@ -410,7 +410,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func getAbortedBy(abortedByTaskId string) (*abortedByDisplay, error) {
-	abortedTask, err := task.FindOne(task.ById(abortedByTaskId))
+	abortedTask, err := task.FindOneId(abortedByTaskId)
 	if err != nil {
 		return nil, errors.Wrap(err, "problem getting abortedBy task")
 	}

--- a/service/ui_plugin_perf_json.go
+++ b/service/ui_plugin_perf_json.go
@@ -96,7 +96,7 @@ func perfGetCommit(w http.ResponseWriter, r *http.Request) {
 func perfGetTaskHistory(w http.ResponseWriter, r *http.Request) {
 	vars := gimlet.GetVars(r)
 
-	t, err := task.FindOne(task.ById(vars["task_id"]))
+	t, err := task.FindOneId(vars["task_id"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -159,7 +159,7 @@ func (t *taskTriggers) Fetch(e *event.EventLogEntry) error {
 		return errors.Wrap(err, "Failed to fetch ui config")
 	}
 
-	t.task, err = task.FindOneIdOldOrNew(e.ResourceId, t.data.Execution)
+	t.task, err = task.FindOneIdOldOrNewNoMerge(e.ResourceId, t.data.Execution)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch task")
 	}


### PR DESCRIPTION
EVG-14997: https://jira.mongodb.org/browse/EVG-14997

This replaces task DB functions that merge test results with the "NoMerge" equivalent versions of those functions where test results are not really needed. In a subsequent PR, I will add back the changes to merge cedar test results and we want to avoid making unnecessary calls to cedar (and downloading potentially large test result sets) when we do not need to.

Since this affects the task lifecycle, triggers, and UI I am putting multiple people on the PR for more eyeballs.