### PR TITLE
EVG-15117: hasTestResult gql field

### DIFF
--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -87,6 +87,11 @@ type GroupedProjects struct {
 	Projects []*model.APIProjectRef `json:"projects"`
 }
 
+type HasTestResultInput struct {
+	TestName string `json:"testName"`
+	Status   string `json:"status"`
+}
+
 type HostEvents struct {
 	EventLogEntries []*model.HostAPIEventLogEntry `json:"eventLogEntries"`
 	Count           int                           `json:"count"`

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -701,6 +701,11 @@ type AbortInfo {
   prClosed: Boolean!
 }
 
+input HasTestResultInput {
+  testName: String!
+  status: String!
+}
+
 type Task {
   aborted: Boolean!
   abortInfo: AbortInfo
@@ -766,6 +771,7 @@ type Task {
   totalTestCount: Int!
   version: String! @deprecated(reason: "version is deprecated. Use versionMetadata instead.")
   versionMetadata: Version!
+  hasTestResult(options: [HasTestResultInput!]!): Boolean!
 }
 
 type BaseTaskInfo {


### PR DESCRIPTION
[EVG-15117](https://jira.mongodb.org/browse/EVG-15117)

### Description 
The hasTestResult field will be used to determine whether the task status icon on the history pages should be shown as active or opaque. 

### Testing 
The best way to test is to push these code changes to staging and query for hasTestResult in the [gql playground](https://evergreen-staging.corp.mongodb.com/graphql). 
You can verify the result of the query by examining test names/statuses in cedar staging (https://cedar.staging.build.10gen.cc/rest/v1/test_results/task_id/<test_name>). 

