### PR TITLE
EVG-12604 add expansion to indicate a task was stepped back

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -300,16 +300,24 @@ func (b *specificActivationInfo) variantHasSpecificActivation(variant string) bo
 	return utility.StringSliceContains(b.activationVariants, variant)
 }
 
-func (b *specificActivationInfo) getTasks(variant string) []string {
+func (b *specificActivationInfo) getActivationTasks(variant string) []string {
 	return b.activationTasks[variant]
 }
 
-func (b *specificActivationInfo) hasTasks() bool {
+func (b *specificActivationInfo) getStepbackTasks(variant string) []string {
+	return b.stepbackTasks[variant]
+}
+
+func (b *specificActivationInfo) hasActivationTasks() bool {
 	return len(b.activationTasks) > 0
 }
 
 func (b *specificActivationInfo) isStepbackTask(variant, task string) bool {
 	return utility.StringSliceContains(b.stepbackTasks[variant], task)
+}
+
+func (b *specificActivationInfo) taskHasSpecificActivation(variant, task string) bool {
+	return utility.StringSliceContains(b.activationTasks[variant], task)
 }
 
 // given some list of tasks, returns the tasks that don't have batchtime

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -877,13 +877,15 @@ func TestCreateBuildFromVersion(t *testing.T) {
 		Convey("if a non-empty list of TasksWithBatchTime is passed in, only the specified tasks should be activated", func() {
 			batchTimeTasks := []string{"taskA", "taskB"}
 			args := BuildCreateArgs{
-				Project:            *project,
-				Version:            *v,
-				TaskIDs:            table,
-				BuildName:          buildVar1.Name,
-				ActivateBuild:      true,
-				TaskNames:          []string{"taskA", "taskB", "taskC", "taskD"}, // excluding display tasks
-				TasksWithBatchTime: batchTimeTasks,
+				Project:       *project,
+				Version:       *v,
+				TaskIDs:       table,
+				BuildName:     buildVar1.Name,
+				ActivateBuild: true,
+				TaskNames:     []string{"taskA", "taskB", "taskC", "taskD"}, // excluding display tasks
+				ActivationInfo: specificActivationInfo{activationTasks: map[string][]string{
+					buildVar1.Name: batchTimeTasks},
+				},
 			}
 			build, tasks, err := CreateBuildFromVersionNoInsert(args)
 			So(err, ShouldBeNil)

--- a/model/project.go
+++ b/model/project.go
@@ -890,7 +890,9 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 	expansions.Put("project", projectRef.Identifier)
 	expansions.Put("project_identifier", projectRef.Identifier) // TODO: depreciate
 	expansions.Put("project_id", projectRef.Id)
-
+	if t.ActivatedBy == evergreen.StepbackTaskActivator {
+		expansions.Put("is_stepback", "true")
+	}
 	if t.TriggerID != "" {
 		expansions.Put("trigger_event_identifier", t.TriggerID)
 		expansions.Put("trigger_event_type", t.TriggerType)


### PR DESCRIPTION
[EVG-12604 ](https://jira.mongodb.org/browse/EVG-12604)

### Description 
The bulk of this work was actually to refactor task creation a bit for generated tasks to ensure that stepped back tasks have the correct ActivatedBy set.

### Testing
Stepped back a [regular task](https://evergreen-staging.corp.mongodb.com/task_log_raw/sandbox_ubuntu1604_unit_tests_1a682bce4da50d4548f3f4de87912e799f85b68f_21_08_16_18_36_57/0?type=T#L68) and verified expansion was set.
Stepped back a generator task and then the [generated task](https://evergreen-staging.corp.mongodb.com/task_log_raw/sandbox_ubuntu1604_task_to_add_via_generator_78f4c89f1e19d153feecf2f7a35a1f9b50ab8f80_21_08_16_19_41_36/0?type=T#L68) and verified expansion was set.