### PR TITLE
EVG-14977 Unhide Adding and creating Patch Trigger Aliases

### DIFF
--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -484,7 +484,7 @@ Evergreen Projects
       </div>
       <div>
         <!--  Github Trigger Aliases  -->
-        <div id="github-trigger-alias" style="display: none;">
+        <div id="github-trigger-alias">
           <div class="h4">Add Github Trigger Alias </div>
           <div class="muted small">Add previously defined patch trigger aliases that add tasks from other projects to patches</div>
           <div class="form-group">
@@ -856,7 +856,7 @@ Evergreen Projects
         </div>
       </div>
       <!-- Patch Trigger Aliases -->
-      <div class="variables" style="display: none;">
+      <div class="variables">
         <div class="form-group">
           <div class="col-header col-lg-6 form-control-static">
             <h3>Patch Trigger Aliases</h3>


### PR DESCRIPTION
[EVG-14977 ](https://jira.mongodb.org/browse/EVG-14977)

### Description 
This was kept hidden till now so that users don't start using it before it is ready. While the feature is not yet fully ready to role out, at this point, a user using it won't break it, and they'll already see the downstream tasks on the patch page. 

### Testing 
none
