### PR TITLE
EVG-14997: Fetch test results lazily

### DIFF
--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -269,23 +269,27 @@ func BbGetProject(settings *evergreen.Settings, projectId string) (evergreen.Bui
 func BbGetTask(taskId string, executionString string) (*task.Task, error) {
 	execution, err := strconv.Atoi(executionString)
 	if err != nil {
-		return nil, errors.Wrap(err, "Invalid execution number")
+		return nil, errors.Wrap(err, "invalid execution number")
 	}
+
 	t, err := task.FindOneIdOldOrNew(taskId, execution)
 	if err != nil {
-		return nil, errors.Wrap(err, "problem finding task")
+		return nil, errors.Wrap(err, "finding task")
 	}
 	if t == nil {
-		return nil, errors.Errorf("No task found for taskId: %s and execution: %d", taskId, execution)
+		return nil, errors.Errorf("no task found for task id: %s and execution: %d", taskId, execution)
 	}
+
 	if t.DisplayOnly {
 		t.LocalTestResults, err = t.GetTestResultsForDisplayTask()
 		if err != nil {
-			return nil, errors.Wrapf(err, "Problem finding test results for display task '%s'", t.Id)
+			return nil, errors.Wrapf(err, "finding test results for display task '%s'", t.Id)
 		}
 	}
+
 	return t, nil
 }
+
 func (js *JiraSuggest) GetTimeout() time.Duration {
 	// This function is never called because we are willing to wait forever for the fallback handler
 	// to return JIRA ticket results.

--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -42,7 +42,6 @@ func BbFileTicket(context context.Context, taskId string, execution int) (bool, 
 	t, err := task.FindOne(task.ById(taskId))
 	if err != nil {
 		return taskNotFound, err
-
 	}
 	if t == nil {
 		taskNotFound = true

--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -280,14 +280,7 @@ func BbGetTask(taskId string, executionString string) (*task.Task, error) {
 		return nil, errors.Errorf("no task found for task id: %s and execution: %d", taskId, execution)
 	}
 
-	if t.DisplayOnly {
-		t.LocalTestResults, err = t.GetTestResultsForDisplayTask()
-		if err != nil {
-			return nil, errors.Wrapf(err, "finding test results for display task '%s'", t.Id)
-		}
-	}
-
-	return t, nil
+	return t, errors.Wrap(t.PopulateTestResults(), "populating test results")
 }
 
 func (js *JiraSuggest) GetTimeout() time.Duration {

--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -279,7 +279,11 @@ func BbGetTask(taskId string, executionString string) (*task.Task, error) {
 		return nil, errors.Errorf("no task found for task id: %s and execution: %d", taskId, execution)
 	}
 
-	return t, errors.Wrap(t.PopulateTestResults(), "populating test results")
+	if err = t.PopulateTestResults(); err != nil {
+		return nil, errors.Wrap(err, "populating test results")
+	}
+
+	return t, nil
 }
 
 func (js *JiraSuggest) GetTimeout() time.Duration {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -807,7 +807,7 @@ func mapHTTPStatusToGqlError(ctx context.Context, httpStatus int, err error) *gq
 }
 
 func isTaskBlocked(ctx context.Context, at *restModel.APITask) (*bool, error) {
-	t, err := task.FindOneIdNewOrOldNoMerge(*at.Id)
+	t, err := task.FindOneIdNewOrOld(*at.Id)
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, err.Error())
 	}

--- a/model/context.go
+++ b/model/context.go
@@ -97,11 +97,11 @@ func (ctx *Context) populateTaskBuildVersion(taskId, buildId, versionId string) 
 	var err error
 	// Fetch task if there's a task ID present; if we find one, populate build/version IDs from it
 	if len(taskId) > 0 {
-		ctx.Task, err = task.FindOne(task.ById(taskId))
+		ctx.Task, err = task.FindOneId(taskId)
 		if err != nil || ctx.Task == nil {
 			// if no task found, see if this is an old task
 			var tasks []task.Task
-			tasks, err = task.FindOld(task.ById(taskId))
+			tasks, err = task.FindOldNoMerge(task.ById(taskId))
 			if err != nil {
 				return "", err
 			}

--- a/model/context.go
+++ b/model/context.go
@@ -101,7 +101,7 @@ func (ctx *Context) populateTaskBuildVersion(taskId, buildId, versionId string) 
 		if err != nil || ctx.Task == nil {
 			// if no task found, see if this is an old task
 			var tasks []task.Task
-			tasks, err = task.FindOldNoMerge(task.ById(taskId))
+			tasks, err = task.FindOld(task.ById(taskId))
 			if err != nil {
 				return "", err
 			}

--- a/model/scheduler_stats.go
+++ b/model/scheduler_stats.go
@@ -265,7 +265,7 @@ func CreateAllHostUtilizationBuckets(daysBack, granularity int) ([]HostUtilizati
 		return nil, err
 	}
 
-	oldTasks, err := task.FindOldNoMerge(task.ByTimeRun(bounds.StartTime, bounds.EndTime))
+	oldTasks, err := task.FindOld(task.ByTimeRun(bounds.StartTime, bounds.EndTime))
 	if err != nil {
 		return nil, err
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -922,8 +922,8 @@ func FindOne(query db.Q) (*Task, error) {
 	if task == nil {
 		return nil, nil
 	}
-	if err = task.MergeNewTestResults(); err != nil {
-		return nil, errors.Wrapf(err, "errors merging new test results for '%s'", task.Id)
+	if err = task.MergeTestResults(); err != nil {
+		return nil, errors.Wrapf(err, "errors merging test results for '%s'", task.Id)
 	}
 	return task, err
 }
@@ -1150,8 +1150,8 @@ func FindOneOld(query db.Q) (*Task, error) {
 	if task == nil {
 		return nil, nil
 	}
-	if err = task.MergeNewTestResults(); err != nil {
-		return nil, errors.Wrapf(err, "errors merging new test results for '%s'", task.Id)
+	if err = task.MergeTestResults(); err != nil {
+		return nil, errors.Wrapf(err, "errors merging test results for '%s'", task.Id)
 	}
 	return task, err
 }
@@ -1184,7 +1184,7 @@ func FindOld(query db.Q) ([]Task, error) {
 	}
 
 	for i, task := range tasks {
-		if err = task.MergeNewTestResults(); err != nil {
+		if err = task.MergeTestResults(); err != nil {
 			return nil, errors.Wrap(err, "error merging new test results")
 		}
 		tasks[i] = task
@@ -1214,8 +1214,8 @@ func FindOldWithDisplayTasks(query db.Q) ([]Task, error) {
 	}
 
 	for i, task := range tasks {
-		if err = task.MergeNewTestResults(); err != nil {
-			return nil, errors.Wrap(err, "error merging new test results")
+		if err = task.MergeTestResults(); err != nil {
+			return nil, errors.Wrap(err, "error merging test results")
 		}
 		tasks[i] = task
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -922,7 +922,7 @@ func FindOne(query db.Q) (*Task, error) {
 	if task == nil {
 		return nil, nil
 	}
-	if err = task.MergeTestResults(); err != nil {
+	if err = task.PopulateTestResults(); err != nil {
 		return nil, errors.Wrapf(err, "errors merging test results for '%s'", task.Id)
 	}
 	return task, err
@@ -1150,7 +1150,7 @@ func FindOneOld(query db.Q) (*Task, error) {
 	if task == nil {
 		return nil, nil
 	}
-	if err = task.MergeTestResults(); err != nil {
+	if err = task.PopulateTestResults(); err != nil {
 		return nil, errors.Wrapf(err, "errors merging test results for '%s'", task.Id)
 	}
 	return task, err
@@ -1184,7 +1184,7 @@ func FindOld(query db.Q) ([]Task, error) {
 	}
 
 	for i, task := range tasks {
-		if err = task.MergeTestResults(); err != nil {
+		if err = task.PopulateTestResults(); err != nil {
 			return nil, errors.Wrap(err, "error merging new test results")
 		}
 		tasks[i] = task
@@ -1214,7 +1214,7 @@ func FindOldWithDisplayTasks(query db.Q) ([]Task, error) {
 	}
 
 	for i, task := range tasks {
-		if err = task.MergeTestResults(); err != nil {
+		if err = task.PopulateTestResults(); err != nil {
 			return nil, errors.Wrap(err, "error merging test results")
 		}
 		tasks[i] = task

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -903,8 +903,8 @@ func FindTaskNamesByBuildVariant(projectId string, buildVariant string) ([]strin
 
 // DB Boilerplate
 
-// FindOneNoMerge is a FindOne without merging test results.
-func FindOneNoMerge(query db.Q) (*Task, error) {
+// FindOne returns a single task that satisfies the query.
+func FindOne(query db.Q) (*Task, error) {
 	task := &Task{}
 	err := db.FindOneQ(Collection, query, task)
 	if adb.ResultsNotFound(err) {
@@ -913,21 +913,7 @@ func FindOneNoMerge(query db.Q) (*Task, error) {
 	return task, err
 }
 
-// FindOne returns one task that satisfies the query.
-func FindOne(query db.Q) (*Task, error) {
-	task, err := FindOneNoMerge(query)
-	if err != nil {
-		return nil, errors.Wrap(err, "error finding task")
-	}
-	if task == nil {
-		return nil, nil
-	}
-	if err = task.PopulateTestResults(); err != nil {
-		return nil, errors.Wrapf(err, "errors merging test results for '%s'", task.Id)
-	}
-	return task, err
-}
-
+// FindOneId returns a single task with the given ID.
 func FindOneId(id string) (*Task, error) {
 	task := &Task{}
 	query := db.Query(bson.M{IdKey: id})
@@ -943,6 +929,8 @@ func FindOneId(id string) (*Task, error) {
 	return task, nil
 }
 
+// FindByIdExecution returns a single task with the given ID and execution. If
+// execution is nil, the latest execution is returned.
 func FindByIdExecution(id string, execution *int) (*Task, error) {
 	if execution == nil {
 		return FindOneId(id)
@@ -950,6 +938,7 @@ func FindByIdExecution(id string, execution *int) (*Task, error) {
 	return FindOneIdAndExecution(id, *execution)
 }
 
+// FindOneIdAndExecution returns a single task with the given ID and execution.
 func FindOneIdAndExecution(id string, execution int) (*Task, error) {
 	task := &Task{}
 	query := db.Query(bson.M{
@@ -959,16 +948,17 @@ func FindOneIdAndExecution(id string, execution int) (*Task, error) {
 	err := db.FindOneQ(Collection, query, task)
 
 	if adb.ResultsNotFound(err) {
-		return FindOneOldNoMergeByIdAndExecution(id, execution)
+		return FindOneOldByIdAndExecution(id, execution)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "error finding task by id and execution")
+		return nil, errors.Wrap(err, "finding task by id and execution")
 	}
 
 	return task, nil
 }
 
-// FindOneIdAndExecutionWithDisplayStatus is FindOneIdAndExecution with display statuses added
+// FindOneIdAndExecutionWithDisplayStatus returns a single task with the given
+// ID and execution, with display statuses added.
 func FindOneIdAndExecutionWithDisplayStatus(id string, execution *int) (*Task, error) {
 	tasks := []Task{}
 	match := bson.M{
@@ -982,18 +972,20 @@ func FindOneIdAndExecutionWithDisplayStatus(id string, execution *int) (*Task, e
 		addDisplayStatus,
 	}
 	if err := Aggregate(pipeline, &tasks); err != nil {
-		return nil, errors.Wrap(err, "Couldnt find task")
+		return nil, errors.Wrap(err, "finding task")
 	}
 	if len(tasks) != 0 {
 		t := tasks[0]
 		return &t, nil
 	}
-	return FindOneOldNoMergeByIdAndExecutionWithDisplayStatus(id, execution)
 
+	return FindOneOldByIdAndExecutionWithDisplayStatus(id, execution)
 }
 
-// FindOneOldNoMergeByIdAndExecutionWithDisplayStatus is a FindOneOldNoMergeByIdAndExecution with display statuses added
-func FindOneOldNoMergeByIdAndExecutionWithDisplayStatus(id string, execution *int) (*Task, error) {
+// FindOneOldByIdAndExecutionWithDisplayStatus returns a single task with the
+// given ID and execution from the old tasks collection, with display statuses
+// added.
+func FindOneOldByIdAndExecutionWithDisplayStatus(id string, execution *int) (*Task, error) {
 	tasks := []Task{}
 	match := bson.M{
 		OldTaskIdKey: id,
@@ -1007,17 +999,19 @@ func FindOneOldNoMergeByIdAndExecutionWithDisplayStatus(id string, execution *in
 	}
 
 	if err := db.Aggregate(OldCollection, pipeline, &tasks); err != nil {
-		return nil, errors.Wrap(err, "Couldn't find task")
+		return nil, errors.Wrap(err, "finding task")
 	}
 	if len(tasks) != 0 {
 		t := tasks[0]
 		return &t, nil
 	}
-	return nil, errors.New("cant find task")
+
+	return nil, errors.New("task not found")
 }
 
-// FindOneOldNoMerge is a FindOneOld without merging test results.
-func FindOneOldNoMerge(query db.Q) (*Task, error) {
+// FindOneOld returns a single task from the old tasks collection that
+// satifisfies the given query.
+func FindOneOld(query db.Q) (*Task, error) {
 	task := &Task{}
 	err := db.FindOneQ(OldCollection, query, task)
 	if adb.ResultsNotFound(err) {
@@ -1026,15 +1020,18 @@ func FindOneOldNoMerge(query db.Q) (*Task, error) {
 	return task, err
 }
 
-// FindOneOldNoMergeByIdAndExecution finds a task from the old tasks collection without test results.
-func FindOneOldNoMergeByIdAndExecution(id string, execution int) (*Task, error) {
+// FindOneOldByIdAndExecution returns a single task from the old tasks
+// collection with the given ID and execution.
+func FindOneOldByIdAndExecution(id string, execution int) (*Task, error) {
 	query := db.Query(bson.M{
 		OldTaskIdKey: id,
 		ExecutionKey: execution,
 	})
-	return FindOneOldNoMerge(query)
+	return FindOneOld(query)
 }
 
+// FindOneIdWithFields returns a single task with the given ID, projecting only
+// the given fields.
 func FindOneIdWithFields(id string, projected ...string) (*Task, error) {
 	task := &Task{}
 	query := db.Query(bson.M{IdKey: id})
@@ -1073,6 +1070,8 @@ func findAllTaskIDs(q db.Q) ([]string, error) {
 	return ids, nil
 }
 
+// FindStuckDispatching returns all "stuck" tasks. A task is considered stuck
+// if it has a "dispatched" status for more than 30 minutes.
 func FindStuckDispatching() ([]Task, error) {
 	tasks, err := FindAll(db.Query(bson.M{
 		StatusKey:       evergreen.TaskDispatched,
@@ -1141,24 +1140,9 @@ func FindMergeTaskForVersion(versionId string) (*Task, error) {
 	return task, err
 }
 
-// FindOneOld returns one task from the old tasks collection that satisfies the query.
-func FindOneOld(query db.Q) (*Task, error) {
-	task, err := FindOneOldNoMerge(query)
-	if err != nil {
-		return nil, errors.Wrap(err, "error finding task")
-	}
-	if task == nil {
-		return nil, nil
-	}
-	if err = task.PopulateTestResults(); err != nil {
-		return nil, errors.Wrapf(err, "errors merging test results for '%s'", task.Id)
-	}
-	return task, err
-}
-
-// FindOldNoMerge returns all task from the old tasks collection that satisfies
-// the query without merging test results.
-func FindOldNoMerge(query db.Q) ([]Task, error) {
+// FindOld returns all non-display tasks from the old tasks collection that
+// satisfy the given query.
+func FindOld(query db.Q) ([]Task, error) {
 	tasks := []Task{}
 	err := db.FindAllQ(OldCollection, query, &tasks)
 	if adb.ResultsNotFound(err) {
@@ -1175,27 +1159,9 @@ func FindOldNoMerge(query db.Q) ([]Task, error) {
 	return tasks, err
 }
 
-// FindOld returns all task from the old tasks collection that satisfies the
-// query and merges test results.
-func FindOld(query db.Q) ([]Task, error) {
-	tasks, err := FindOldNoMerge(query)
-	if err != nil {
-		return nil, err
-	}
-
-	for i, task := range tasks {
-		if err = task.PopulateTestResults(); err != nil {
-			return nil, errors.Wrap(err, "error merging new test results")
-		}
-		tasks[i] = task
-	}
-
-	return tasks, nil
-}
-
-// FindOldWithDisplayTasksNoMerge finds display and execution tasks in the old
-// collection without merging test results.
-func FindOldWithDisplayTasksNoMerge(query db.Q) ([]Task, error) {
+// FindOldWithDisplayTasks returns all display and execution tasks from the old
+// collection that satisfy the given query.
+func FindOldWithDisplayTasks(query db.Q) ([]Task, error) {
 	tasks := []Task{}
 	err := db.FindAllQ(OldCollection, query, &tasks)
 	if adb.ResultsNotFound(err) {
@@ -1205,38 +1171,8 @@ func FindOldWithDisplayTasksNoMerge(query db.Q) ([]Task, error) {
 	return tasks, err
 }
 
-// FindOldWithDisplayTasks finds display and execution tasks in the old
-// collection and merges test results.
-func FindOldWithDisplayTasks(query db.Q) ([]Task, error) {
-	tasks, err := FindOldWithDisplayTasksNoMerge(query)
-	if err != nil {
-		return nil, err
-	}
-
-	for i, task := range tasks {
-		if err = task.PopulateTestResults(); err != nil {
-			return nil, errors.Wrap(err, "error merging test results")
-		}
-		tasks[i] = task
-	}
-
-	return tasks, nil
-}
-
-// FindOneIdOldOrNewNoMerge attempts to find a given task ID by first looking
-// in the old collection, then the tasks collection, without merging test
-// results.
-func FindOneIdOldOrNewNoMerge(id string, execution int) (*Task, error) {
-	task, err := FindOneOldNoMerge(ById(MakeOldID(id, execution)))
-	if task == nil || err != nil {
-		return FindOneNoMerge(ById(id))
-	}
-
-	return task, err
-}
-
-// FindOneIdOldOrNew attempts to find a given task ID by first looking in the
-// old collection, then the tasks collection and merges test results.
+// FindOneIdOldOrNew returns a single task with the given ID and execution,
+// first looking in the old tasks collection, then the tasks collection.
 func FindOneIdOldOrNew(id string, execution int) (*Task, error) {
 	task, err := FindOneOld(ById(MakeOldID(id, execution)))
 	if task == nil || err != nil {
@@ -1246,20 +1182,8 @@ func FindOneIdOldOrNew(id string, execution int) (*Task, error) {
 	return task, err
 }
 
-// FindOneIdNewOrOldNoMerge attempts to find a given task ID by first looking
-// in the tasks collection, then the old tasks collection, without merging test
-// results.
-func FindOneIdNewOrOldNoMerge(id string) (*Task, error) {
-	task, err := FindOneNoMerge(ById(id))
-	if task == nil || err != nil {
-		return FindOneOldNoMerge(ById(id))
-	}
-
-	return task, err
-}
-
-// FindOneIdNewOrOld attempts to find a given task ID by first looking in the
-// tasks collection, then the old tasks collection and merges test results.
+// FindOneIdNewOrOld returns a single task with the given ID and execution,
+// first looking in the tasks collection, then the old tasks collection.
 func FindOneIdNewOrOld(id string) (*Task, error) {
 	task, err := FindOne(ById(id))
 	if task == nil || err != nil {
@@ -1405,7 +1329,7 @@ func Count(query db.Q) (int, error) {
 }
 
 func FindProjectForTask(taskID string) (string, error) {
-	t, err := FindOneNoMerge(ById(taskID).Project(bson.M{ProjectKey: 1}))
+	t, err := FindOne(ById(taskID).Project(bson.M{ProjectKey: 1}))
 	if err != nil {
 		return "", err
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -705,7 +705,7 @@ func (t *Task) PreviousCompletedTask(project string, statuses []string) (*Task, 
 	if len(statuses) == 0 {
 		statuses = evergreen.CompletedStatuses
 	}
-	return FindOneNoMerge(ByBeforeRevisionWithStatusesAndRequesters(t.RevisionOrderNumber, statuses, t.BuildVariant,
+	return FindOne(ByBeforeRevisionWithStatusesAndRequesters(t.RevisionOrderNumber, statuses, t.BuildVariant,
 		t.DisplayName, project, evergreen.SystemVersionRequesterTypes).Sort([]string{"-" + RevisionOrderNumberKey}))
 }
 
@@ -2454,9 +2454,9 @@ func (t *Task) GetDisplayTask() (*Task, error) {
 	var dt *Task
 	var err error
 	if t.Archived {
-		dt, err = FindOneOldNoMerge(ByExecutionTask(t.OldTaskId))
+		dt, err = FindOneOld(ByExecutionTask(t.OldTaskId))
 	} else {
-		dt, err = FindOneNoMerge(ByExecutionTask(t.Id))
+		dt, err = FindOne(ByExecutionTask(t.Id))
 	}
 	if err != nil {
 		return nil, err

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2134,10 +2134,11 @@ func (t *Task) populateTestResultsForDisplayTask() error {
 		return errors.Errorf("%s is not a display task", t.Id)
 	}
 
-	_, err := MergeTestResultsBulk([]Task{*t}, nil)
+	out, err := MergeTestResultsBulk([]Task{*t}, nil)
 	if err != nil {
 		return errors.Wrap(err, "merging test results for display task")
 	}
+	t.LocalTestResults = out[0].LocalTestResults
 	t.testResultsPopulated = true
 
 	return nil

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -209,6 +209,8 @@ type Task struct {
 	CanSync       bool             `bson:"can_sync" json:"can_sync"`
 	SyncAtEndOpts SyncAtEndOptions `bson:"sync_at_end_opts,omitempty" json:"sync_at_end_opts,omitempty"`
 
+	// testResultsPopulated is a local field that indicates whether the
+	// task's test results are successfully cached in LocalTestResults.
 	testResultsPopulated bool
 }
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1024,8 +1024,9 @@ func (t *Task) SetAborted(reason AbortInfo) error {
 
 // SetHasCedarResults sets the HasCedarResults field of the task to
 // hasCedarResults and, if failedResults is true, sets CedarResultsFailed to
-// true. An error is returned if hasCedarResults is false and failedResults is
-// true as this is an invalid state. Note that if failedResults is false,
+// true. If the task is part of a display task, the display tasks's fields are
+// also set. An error is returned if hasCedarResults is false and failedResults
+// is true as this is an invalid state. Note that if failedResults is false,
 // CedarResultsFailed is not set. This is because in cases where separate calls
 // to attach test results are made, only one call needs to have a test failure
 // for the CedarResultsFailed to be set to true.
@@ -1043,14 +1044,22 @@ func (t *Task) SetHasCedarResults(hasCedarResults, failedResults bool) error {
 		set[CedarResultsFailedKey] = true
 	}
 
-	return UpdateOne(
+	if err := UpdateOne(
 		bson.M{
 			IdKey: t.Id,
 		},
 		bson.M{
 			"$set": set,
 		},
-	)
+	); err != nil {
+		return err
+	}
+
+	if !t.DisplayOnly && t.IsPartOfDisplay() {
+		return t.DisplayTask.SetHasCedarResults(hasCedarResults, failedResults)
+	}
+
+	return nil
 }
 
 func (t *Task) SetHasLegacyResults(hasLegacyResults bool) error {
@@ -2049,9 +2058,9 @@ func (t *Task) makeArchivedTask() *Task {
 
 // Aggregation
 
-// MergeNewTestResults returns the task with both old (embedded in
-// the tasks collection) and new (from the testresults collection) test results
-// merged in the Task's LocalTestResults field.
+// MergeNewTestResults returns the task with both old (embedded in the tasks
+// collection) and new (from the testresults collection) test results merged in
+// the Task's LocalTestResults field.
 func (t *Task) MergeNewTestResults() error {
 	id := t.Id
 	if t.Archived {
@@ -2088,17 +2097,41 @@ func (t *Task) MergeNewTestResults() error {
 	return nil
 }
 
-// GetTestResultsForDisplayTask returns the test results for the execution tasks
-// for a display task.
+// MergeTestResults returns the task with both old (embedded in the tasks
+// collection) and new (from the testresults collection) OR Cedar test results
+// merged in the Task's LocalTestResults field.
+func (t *Task) MergeTestResults() error {
+	if !t.hasCedarResults() {
+		return t.MergeNewTestResults()
+	}
+
+	results, err := t.GetCedarTestResults()
+	if err != nil {
+		return errors.Wrap(err, "getting test results from cedar")
+	}
+	t.LocalTestResults = append(t.LocalTestResults, results...)
+
+	return nil
+}
+
+// GetTestResultsForDisplayTask returns the test results for the execution
+// tasks for a display task.
 func (t *Task) GetTestResultsForDisplayTask() ([]TestResult, error) {
 	if !t.DisplayOnly {
 		return nil, errors.Errorf("%s is not a display task", t.Id)
 	}
-	tasks, err := MergeTestResultsBulk([]Task{*t}, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "error merging test results for display task")
+
+	if !t.hasCedarResults() {
+		tasks, err := MergeTestResultsBulk([]Task{*t}, nil)
+		return tasks[0].LocalTestResults, errors.Wrap(err, "error merging test results for display task")
 	}
-	return tasks[0].LocalTestResults, nil
+
+	var err error
+	if len(t.LocalTestResults) == 0 {
+		t.LocalTestResults, err = t.GetCedarTestResults()
+	}
+
+	return t.LocalTestResults, err
 }
 
 // SetResetWhenFinished requests that a display task or single-host task group
@@ -3123,6 +3156,93 @@ func (t *Task) SetNumDependents() error {
 	return UpdateOne(bson.M{
 		IdKey: t.Id,
 	}, update)
+}
+
+func AddExecTasksToDisplayTask(displayTaskId string, execTasks []string) error {
+	if len(execTasks) == 0 {
+		return nil
+	}
+
+	return UpdateOne(
+		bson.M{IdKey: displayTaskId},
+		bson.M{"$addToSet": bson.M{
+			ExecutionTasksKey: bson.M{"$each": execTasks},
+		}},
+	)
+}
+
+////////////////
+// Cedar Helpers
+////////////////
+
+// Get CedarTestResults fetches the task's test results from the Cedar service.
+// If the task does not have test results in Cedar, (nil, nil) is returned. If
+// the task is a display task, all of its execution tasks' test results are
+// returned.
+func (t *Task) GetCedarTestResults() ([]TestResult, error) {
+	ctx, cancel := evergreen.GetEnvironment().Context()
+	defer cancel()
+
+	if !t.hasCedarResults() {
+		return nil, nil
+	}
+
+	opts := apimodels.GetCedarTestResultsOptions{
+		BaseURL:   evergreen.GetEnvironment().Settings().Cedar.BaseURL,
+		Execution: t.Execution,
+	}
+	if t.DisplayOnly {
+		opts.DisplayTaskID = t.Id
+	} else {
+		opts.TaskID = t.Id
+	}
+
+	cedarResults, err := apimodels.GetCedarTestResults(ctx, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting test results from cedar")
+	}
+
+	results := make([]TestResult, len(cedarResults))
+	for i, result := range cedarResults {
+		results[i] = ConvertCedarTestResult(result)
+	}
+
+	return results, nil
+}
+
+func (t *Task) hasCedarResults() bool {
+	if !t.DisplayOnly || t.HasCedarResults {
+		return t.HasCedarResults
+	}
+
+	// Older display tasks may incorrectly indicate that they do not have
+	// test results in Cedar. In the case that the execution tasks have
+	// results in Cedar, this will attempt to update the display task
+	// accordingly.
+	if len(t.ExecutionTasks) > 0 {
+		execTasks, err := FindAll(ByIds(t.ExecutionTasks))
+		if err != nil {
+			return false
+		}
+
+		for _, execTask := range execTasks {
+			if execTask.HasCedarResults {
+				// Attempt to update the display task's
+				// HasCedarResults field.
+				// We will not update the CedarResultsFailed
+				// field since we do want to iterate through
+				// all of the execution tasks and it isn't
+				// really needed for display tasks.
+				// Since we do not want to fail here, we can
+				// ignore the error.
+				_ = t.SetHasCedarResults(true, false)
+
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // ConvertCedarTestResult converts a CedarTestResult struct into a TestResult

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3187,14 +3187,19 @@ func (t *Task) GetCedarTestResults() ([]TestResult, error) {
 		return nil, nil
 	}
 
+	taskID := t.Id
+	if t.Archived {
+		taskID = t.OldTaskId
+	}
+
 	opts := apimodels.GetCedarTestResultsOptions{
 		BaseURL:   evergreen.GetEnvironment().Settings().Cedar.BaseURL,
 		Execution: t.Execution,
 	}
 	if t.DisplayOnly {
-		opts.DisplayTaskID = t.Id
+		opts.DisplayTaskID = taskID
 	} else {
-		opts.TaskID = t.Id
+		opts.TaskID = taskID
 	}
 
 	cedarResults, err := apimodels.GetCedarTestResults(ctx, opts)
@@ -3220,7 +3225,20 @@ func (t *Task) hasCedarResults() bool {
 	// results in Cedar, this will attempt to update the display task
 	// accordingly.
 	if len(t.ExecutionTasks) > 0 {
-		execTasks, err := FindAll(ByIds(t.ExecutionTasks))
+		var (
+			execTasks []Task
+			err       error
+		)
+		if t.Archived {
+			// This is a display task from the old task collection,
+			// we need to look there for its execution tasks.
+			execTasks, err = FindAllOld(db.Query(bson.M{
+				OldTaskIdKey: bson.M{"$in": t.ExecutionTasks},
+				ExecutionKey: t.Execution,
+			}))
+		} else {
+			execTasks, err = FindAll(ByIds(t.ExecutionTasks))
+		}
 		if err != nil {
 			return false
 		}
@@ -3228,13 +3246,12 @@ func (t *Task) hasCedarResults() bool {
 		for _, execTask := range execTasks {
 			if execTask.HasCedarResults {
 				// Attempt to update the display task's
-				// HasCedarResults field.
-				// We will not update the CedarResultsFailed
-				// field since we do want to iterate through
-				// all of the execution tasks and it isn't
-				// really needed for display tasks.
-				// Since we do not want to fail here, we can
-				// ignore the error.
+				// HasCedarResults field. We will not update
+				// the CedarResultsFailed field since we do
+				// want to iterate through all of the execution
+				// tasks and it isn't really needed for display
+				// tasks. Since we do not want to fail here, we
+				// can ignore the error.
 				_ = t.SetHasCedarResults(true, false)
 
 				return true

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1112,14 +1112,12 @@ func TestFindOneIdOldOrNew(t *testing.T) {
 	require.NotNil(task00)
 	assert.Equal("task_0", task00.Id)
 	assert.Equal(0, task00.Execution)
-	assert.Len(task00.LocalTestResults, 1)
 
 	task01, err := FindOneIdOldOrNew("task", 1)
 	assert.NoError(err)
 	require.NotNil(task01)
 	assert.Equal("task", task01.Id)
 	assert.Equal(1, task01.Execution)
-	assert.Len(task01.LocalTestResults, 1)
 }
 
 func TestPopulateTestResultsForDisplayTask(t *testing.T) {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -903,7 +903,7 @@ func TestFindOneIdAndExecutionWithDisplayStatus(t *testing.T) {
 
 	// Should fetch tasks from the old collection
 	assert.NoError(taskDoc.Archive())
-	task, err = FindOneOldNoMergeByIdAndExecution(taskDoc.Id, 0)
+	task, err = FindOneOldByIdAndExecution(taskDoc.Id, 0)
 	assert.NoError(err)
 	assert.NotNil(task)
 	task, err = FindOneIdAndExecutionWithDisplayStatus(taskDoc.Id, utility.ToIntPtr(0))

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1122,7 +1122,7 @@ func TestFindOneIdOldOrNew(t *testing.T) {
 	assert.Len(task01.LocalTestResults, 1)
 }
 
-func TestGetTestResultsForDisplayTask(t *testing.T) {
+func TestPopulateTestResultsForDisplayTask(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection, testresult.Collection))
 	dt := Task{
@@ -1136,10 +1136,9 @@ func TestGetTestResultsForDisplayTask(t *testing.T) {
 		TestFile: "myTest",
 	}
 	assert.NoError(test.Insert())
-	results, err := dt.GetTestResultsForDisplayTask()
-	assert.NoError(err)
-	assert.Len(results, 1)
-	assert.Equal("myTest", results[0].TestFile)
+	require.NoError(t, dt.populateTestResultsForDisplayTask())
+	require.Len(t, dt.LocalTestResults, 1)
+	assert.Equal("myTest", dt.LocalTestResults[0].TestFile)
 }
 
 func TestBlocked(t *testing.T) {

--- a/model/task/task_testresult_test.go
+++ b/model/task/task_testresult_test.go
@@ -74,7 +74,7 @@ func (s *TaskTestResultSuite) SetupTest() {
 }
 
 func (s *TaskTestResultSuite) TestNoOldNoNewTestResults() {
-	t, err := FindOneNoMerge(ById(s.tasks[2].Id))
+	t, err := FindOne(ById(s.tasks[2].Id))
 	s.NoError(err)
 
 	err = t.MergeNewTestResults()
@@ -127,7 +127,7 @@ func (s *TaskTestResultSuite) TestNoOldNewTestResults() {
 		s.NoError(err)
 	}
 
-	t, err = FindOneNoMerge(ById("taskid-10"))
+	t, err = FindOne(ById("taskid-10"))
 	s.NoError(err)
 
 	err = t.MergeNewTestResults()
@@ -182,7 +182,7 @@ func (s *TaskTestResultSuite) TestArchivedTask() {
 		s.NoError(err)
 	}
 
-	t, err = FindOneOldNoMerge(ById("taskid-20_3"))
+	t, err = FindOneOld(ById("taskid-20_3"))
 	s.NoError(err)
 
 	err = t.MergeNewTestResults()

--- a/model/task/task_testresult_test.go
+++ b/model/task/task_testresult_test.go
@@ -77,8 +77,7 @@ func (s *TaskTestResultSuite) TestNoOldNoNewTestResults() {
 	t, err := FindOne(ById(s.tasks[2].Id))
 	s.NoError(err)
 
-	err = t.MergeNewTestResults()
-	s.NoError(err)
+	s.NoError(t.PopulateTestResults())
 
 	s.Equal("taskid-2", t.Id)
 	s.Equal("secret-2", t.Secret)
@@ -130,8 +129,7 @@ func (s *TaskTestResultSuite) TestNoOldNewTestResults() {
 	t, err = FindOne(ById("taskid-10"))
 	s.NoError(err)
 
-	err = t.MergeNewTestResults()
-	s.NoError(err)
+	s.NoError(t.PopulateTestResults())
 
 	s.Equal("taskid-10", t.Id)
 	s.Equal("secret-10", t.Secret)
@@ -185,8 +183,7 @@ func (s *TaskTestResultSuite) TestArchivedTask() {
 	t, err = FindOneOld(ById("taskid-20_3"))
 	s.NoError(err)
 
-	err = t.MergeNewTestResults()
-	s.NoError(err)
+	s.NoError(t.PopulateTestResults())
 
 	s.Equal("taskid-20_3", t.Id)
 	s.Equal("secret-20", t.Secret)

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -459,7 +459,7 @@ func (self *taskHistoryIterator) GetFailedTests(aggregatedTasks adb.Results) (ma
 
 	// create the mapping of the task id to the list of failed tasks
 	for _, task := range tasks {
-		if err := task.MergeNewTestResults(); err != nil {
+		if err := task.PopulateTestResults(); err != nil {
 			return nil, err
 		}
 		for _, test := range task.LocalTestResults {

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -804,7 +804,7 @@ func testHistoryV2Results(params *TestHistoryParameters) ([]task.Task, error) {
 	if err != nil {
 		return nil, err
 	}
-	oldTasks, err := task.FindOldNoMerge(db.Query(tasksQuery).Project(projection))
+	oldTasks, err := task.FindOld(db.Query(tasksQuery).Project(projection))
 	if err != nil {
 		return nil, err
 	}

--- a/model/task_json.go
+++ b/model/task_json.go
@@ -106,7 +106,7 @@ func GetDistinctTagNames(projectId string) ([]TaskJSONTag, error) {
 // GetTags finds TaskJSONs that have tags in the project associated with a
 // given task.
 func GetTaskJSONTags(taskId string) ([]TagContainer, error) {
-	t, err := task.FindOneNoMerge(task.ById(taskId))
+	t, err := task.FindOne(task.ById(taskId))
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func GetTaskJSONById(taskId, name string) (TaskJSON, error) {
 // GetTaskJSONForVariant finds a task by name and variant and finds
 // the document in the json collection associated with that task's id.
 func GetTaskJSONForVariant(version, variantId, taskName, name string) (TaskJSON, error) {
-	foundTask, err := task.FindOneNoMerge(db.Query(bson.M{task.VersionKey: version, task.BuildVariantKey: variantId,
+	foundTask, err := task.FindOne(db.Query(bson.M{task.VersionKey: version, task.BuildVariantKey: variantId,
 		task.DisplayNameKey: taskName}))
 	if err != nil {
 		return TaskJSON{}, err
@@ -250,7 +250,7 @@ func GetTaskJSONTagsForTask(project, buildVariant, taskName, name string) ([]Tas
 }
 
 func DeleteTaskJSONTagFromTask(taskId, name string) error {
-	t, err := task.FindOneNoMerge(task.ById(taskId))
+	t, err := task.FindOne(task.ById(taskId))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -263,7 +263,7 @@ func DeleteTaskJSONTagFromTask(taskId, name string) error {
 }
 
 func SetTaskJSONTagForTask(taskId, name, tag string) error {
-	t, err := task.FindOneNoMerge(task.ById(taskId))
+	t, err := task.FindOne(task.ById(taskId))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -162,7 +162,7 @@ func activatePreviousTask(taskId, caller string, originalStepbackTask *task.Task
 	}
 
 	// find previous task limiting to just the last one
-	prevTask, err := task.FindOneNoMerge(task.ByBeforeRevision(t.RevisionOrderNumber, t.BuildVariant, t.DisplayName, t.Project, t.Requester))
+	prevTask, err := task.FindOne(task.ByBeforeRevision(t.RevisionOrderNumber, t.BuildVariant, t.DisplayName, t.Project, t.Requester))
 	if err != nil {
 		return errors.Wrap(err, "Error finding previous task")
 	}
@@ -198,7 +198,7 @@ func resetManyTasks(tasks []task.Task, caller string, logIDs bool) error {
 
 // reset task finds a task, attempts to archive it, and resets the task and resets the TaskCache in the build as well.
 func resetTask(taskId, caller string, logIDs bool) error {
-	t, err := task.FindOneNoMerge(task.ById(taskId))
+	t, err := task.FindOne(task.ById(taskId))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -223,7 +223,7 @@ func resetTask(taskId, caller string, logIDs bool) error {
 
 // TryResetTask resets a task
 func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) error {
-	t, err := task.FindOneNoMerge(task.ById(taskId))
+	t, err := task.FindOne(task.ById(taskId))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -1409,7 +1409,7 @@ func UpdateDisplayTask(t *task.Task) error {
 	}
 
 	// refresh task status from db in case of race
-	taskWithStatus, err := task.FindOneNoMerge(task.ById(t.Id).WithFields(task.StatusKey))
+	taskWithStatus, err := task.FindOne(task.ById(t.Id).WithFields(task.StatusKey))
 	if err != nil {
 		return errors.Wrap(err, "error refreshing task status from db")
 	}

--- a/model/task_start_estimation.go
+++ b/model/task_start_estimation.go
@@ -138,7 +138,7 @@ func createSimulatorModel(taskQueue TaskQueue, hosts []host.Host) *estimatedTime
 			if h.RunningTask == "" {
 				estimator.hosts = append(estimator.hosts, estimatedHost{timeToCompletion: 0})
 			} else {
-				t, err := task.FindOneNoMerge(task.ById(h.RunningTask))
+				t, err := task.FindOne(task.ById(h.RunningTask))
 				if err != nil {
 					grip.Error(message.WrapError(err, message.Fields{
 						"message": "retrieving tasks for task start estimation simulator",

--- a/plugin/attach_plugin.go
+++ b/plugin/attach_plugin.go
@@ -79,7 +79,7 @@ func (self *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 								return nil, errors.Wrap(err, "error signing urls")
 							}
 							var execTask *task.Task
-							execTask, err = task.FindOne(task.ById(execTaskID))
+							execTask, err = task.FindOneId(execTaskID)
 							if err != nil {
 								return nil, err
 							}

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -121,7 +121,7 @@ func (tc *DBTaskConnector) FindTasksByIds(ids []string) ([]task.Task, error) {
 }
 
 func (tc *DBTaskConnector) FindOldTasksByIDWithDisplayTasks(id string) ([]task.Task, error) {
-	ts, err := task.FindOldWithDisplayTasksNoMerge(task.ByOldTaskID(id))
+	ts, err := task.FindOldWithDisplayTasks(task.ByOldTaskID(id))
 	if err != nil {
 		return nil, err
 	}

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -250,7 +250,7 @@ func (vc *DBVersionConnector) GetVersionsAndVariants(skip, numVersionElements in
 // addFailedAndStartedTests adds all of the failed tests associated with a task
 func addFailedAndStartedTests(rows map[string]restModel.BuildList, failedAndStartedTasks []task.Task) error {
 	for i := range failedAndStartedTasks {
-		if err := failedAndStartedTasks[i].MergeNewTestResults(); err != nil {
+		if err := failedAndStartedTasks[i].MergeTestResults(); err != nil {
 			return errors.Wrap(err, "error merging test results")
 		}
 	}

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -250,8 +250,8 @@ func (vc *DBVersionConnector) GetVersionsAndVariants(skip, numVersionElements in
 // addFailedAndStartedTests adds all of the failed tests associated with a task
 func addFailedAndStartedTests(rows map[string]restModel.BuildList, failedAndStartedTasks []task.Task) error {
 	for i := range failedAndStartedTasks {
-		if err := failedAndStartedTasks[i].MergeTestResults(); err != nil {
-			return errors.Wrap(err, "error merging test results")
+		if err := failedAndStartedTasks[i].PopulateTestResults(); err != nil {
+			return errors.Wrap(err, "populating test results")
 		}
 	}
 

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -443,7 +443,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			return nil, false, nil
 		}
 
-		nextTask, err := task.FindOneNoMerge(task.ById(queueItem.Id))
+		nextTask, err := task.FindOne(task.ById(queueItem.Id))
 		if err != nil {
 			grip.DebugWhen(queueItem.Group != "", message.Fields{
 				"message":            "error retrieving next task",

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -195,6 +195,10 @@ func (restapi restAPI) getTaskStatus(w http.ResponseWriter, r *http.Request) {
 		gimlet.WriteJSONResponse(w, http.StatusNotFound, responseError{Message: "error finding task"})
 		return
 	}
+	if err := task.PopulateTestResults(); err != nil {
+		gimlet.WriteJSONResponse(w, http.StatusNotFound, responseError{Message: "error populating test results"})
+		return
+	}
 
 	result := taskStatusContent{
 		Id:     task.Id,

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -297,7 +297,7 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if putParams.UseTaskConfig {
-		t, err := task.FindOneNoMerge(task.ById(putParams.Task))
+		t, err := task.FindOne(task.ById(putParams.Task))
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, errors.New("Error finding task"))
 			return

--- a/service/task.go
+++ b/service/task.go
@@ -891,6 +891,11 @@ func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, proj
 	var err error
 	var testResults []task.TestResult
 
+	if err := projCtx.Task.PopulateTestResults(); err != nil {
+		uis.LoggedError(w, r, http.StatusInternalServerError, err)
+		return nil
+	}
+
 	uiTask.TestResults = []uiTestResult{}
 	if uiTask.DisplayOnly {
 		execTaskDisplayNameMap := map[string]string{}
@@ -921,12 +926,6 @@ func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, proj
 				TimeTaken: et.TimeTaken,
 				Status:    et.ResultStatus(),
 			})
-		}
-
-		testResults, err = projCtx.Task.GetTestResultsForDisplayTask()
-		if err != nil {
-			uis.LoggedError(w, r, http.StatusInternalServerError, err)
-			return nil
 		}
 
 		for _, tr := range testResults {

--- a/service/task.go
+++ b/service/task.go
@@ -339,12 +339,13 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}
-		if err := taskOnBaseCommit.PopulateTestResults(); err != nil {
-			uis.LoggedError(w, r, http.StatusInternalServerError, err)
-			return
-		}
 		taskPatch := &uiPatch{Patch: *projCtx.Patch}
 		if taskOnBaseCommit != nil {
+			if err = taskOnBaseCommit.PopulateTestResults(); err != nil {
+				uis.LoggedError(w, r, http.StatusInternalServerError, err)
+				return
+			}
+
 			taskPatch.BaseTaskId = taskOnBaseCommit.Id
 			taskPatch.BaseTimeTaken = taskOnBaseCommit.TimeTaken
 			testResultsOnBaseCommit = taskOnBaseCommit.LocalTestResults

--- a/service/task.go
+++ b/service/task.go
@@ -344,14 +344,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		if taskOnBaseCommit != nil {
 			taskPatch.BaseTaskId = taskOnBaseCommit.Id
 			taskPatch.BaseTimeTaken = taskOnBaseCommit.TimeTaken
-
 			testResultsOnBaseCommit = taskOnBaseCommit.LocalTestResults
-			if len(testResultsOnBaseCommit) == 0 {
-				cedarTestResults := uis.getCedarTestResults(ctx, taskOnBaseCommit, taskOnBaseCommit.Id)
-				for _, tr := range cedarTestResults {
-					testResultsOnBaseCommit = append(testResultsOnBaseCommit, task.ConvertCedarTestResult(tr))
-				}
-			}
 		}
 		taskPatch.StatusDiffs = model.StatusDiffTests(testResultsOnBaseCommit, testResults)
 		uiTask.PatchInfo = taskPatch
@@ -896,14 +889,12 @@ func (uis *UIServer) testLog(w http.ResponseWriter, r *http.Request) {
 }
 
 func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, projCtx projectContext, uiTask *uiTaskData, taskId string) []task.TestResult {
-	ctx := r.Context()
 	var err error
 	var testResults []task.TestResult
 
 	uiTask.TestResults = []uiTestResult{}
-	execTasks := []task.Task{}
-	execTaskIDs := []string{}
 	if uiTask.DisplayOnly {
+		execTaskDisplayNameMap := map[string]string{}
 		for _, t := range projCtx.Task.ExecutionTasks {
 			var et *task.Task
 			if uiTask.Archived {
@@ -923,101 +914,42 @@ func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, proj
 				})
 				continue
 			}
-			execTasks = append(execTasks, *et)
-			execTaskIDs = append(execTaskIDs, t)
+
+			execTaskDisplayNameMap[t] = et.DisplayName
+			uiTask.ExecutionTasks = append(uiTask.ExecutionTasks, uiExecTask{
+				Id:        t,
+				Name:      et.DisplayName,
+				TimeTaken: et.TimeTaken,
+				Status:    et.ResultStatus(),
+			})
 		}
 
-		execTaskDisplayNameMap := map[string]string{}
-		execTasks, err = task.MergeTestResultsBulk(execTasks, nil)
+		testResults, err = projCtx.Task.GetTestResultsForDisplayTask()
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return nil
 		}
-		for i, execTask := range execTasks {
-			execTaskDisplayNameMap[execTask.Id] = execTask.DisplayName
-			uiTask.ExecutionTasks = append(uiTask.ExecutionTasks, uiExecTask{
-				Id:        execTaskIDs[i],
-				Name:      execTask.DisplayName,
-				TimeTaken: execTask.TimeTaken,
-				Status:    execTask.ResultStatus(),
-			})
-		}
 
-		// Check cedar first.
-		cedarTestResults := uis.getCedarTestResults(ctx, projCtx.Task, taskId)
-		for _, tr := range cedarTestResults {
-			testResults = append(testResults, task.ConvertCedarTestResult(tr))
+		for _, tr := range testResults {
 			uiTask.TestResults = append(uiTask.TestResults, uiTestResult{
-				TestResult: testResults[len(testResults)-1],
+				TestResult: tr,
 				TaskId:     tr.TaskID,
 				TaskName:   execTaskDisplayNameMap[tr.TaskID],
 			})
 		}
-
-		// Cedar test results not found, fall back to evergreen test
-		// results.
-		if len(cedarTestResults) == 0 {
-			for i, execTask := range execTasks {
-				testResults = append(testResults, execTask.LocalTestResults...)
-				for _, tr := range execTask.LocalTestResults {
-					uiTask.TestResults = append(uiTask.TestResults, uiTestResult{
-						TestResult: tr,
-						TaskId:     execTaskIDs[i],
-						TaskName:   execTask.DisplayName,
-					})
-				}
-			}
-		}
 	} else {
-		// Check cedar first.
-		cedarTestResults := uis.getCedarTestResults(ctx, projCtx.Task, taskId)
-		for _, tr := range cedarTestResults {
-			testResults = append(testResults, task.ConvertCedarTestResult(tr))
+		for _, tr := range projCtx.Context.Task.LocalTestResults {
+			tr.TaskID = taskId
 			uiTask.TestResults = append(uiTask.TestResults, uiTestResult{
-				TestResult: testResults[len(testResults)-1],
+				TestResult: tr,
 				TaskId:     taskId,
 			})
 		}
-
-		// Cedar test results not found, fall back to evergreen
-		// test results.
-		if len(cedarTestResults) == 0 {
-			for _, tr := range projCtx.Context.Task.LocalTestResults {
-				tr.TaskID = taskId
-				uiTask.TestResults = append(uiTask.TestResults, uiTestResult{
-					TestResult: tr,
-					TaskId:     taskId,
-				})
-			}
-
-			testResults = projCtx.Task.LocalTestResults
-		}
+		testResults = projCtx.Task.LocalTestResults
 
 		if uiTask.PartOfDisplay {
 			uiTask.DisplayTaskID = projCtx.Task.DisplayTask.Id
 		}
-	}
-
-	return testResults
-}
-
-func (uis *UIServer) getCedarTestResults(ctx context.Context, t *task.Task, taskID string) []apimodels.CedarTestResult {
-	opts := apimodels.GetCedarTestResultsOptions{
-		BaseURL:   uis.Settings.Cedar.BaseURL,
-		Execution: t.Execution,
-	}
-	if t.DisplayOnly {
-		opts.DisplayTaskID = taskID
-	} else {
-		opts.TaskID = taskID
-	}
-	testResults, err := apimodels.GetCedarTestResults(ctx, opts)
-	if err != nil {
-		grip.Warning(message.WrapError(err, message.Fields{
-			"task_id":   taskID,
-			"execution": t.Execution,
-			"message":   "problem getting cedar test results, using evergreen test results",
-		}))
 	}
 
 	return testResults

--- a/service/task.go
+++ b/service/task.go
@@ -339,6 +339,10 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}
+		if err := taskOnBaseCommit.PopulateTestResults(); err != nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, err)
+			return
+		}
 		taskPatch := &uiPatch{Patch: *projCtx.Patch}
 		if taskOnBaseCommit != nil {
 			taskPatch.BaseTaskId = taskOnBaseCommit.Id
@@ -902,7 +906,7 @@ func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, proj
 		for _, t := range projCtx.Task.ExecutionTasks {
 			var et *task.Task
 			if uiTask.Archived {
-				et, err = task.FindOneOldNoMergeByIdAndExecution(t, projCtx.Task.Execution)
+				et, err = task.FindOneOldByIdAndExecution(t, projCtx.Task.Execution)
 			} else {
 				et, err = task.FindOneId(t)
 			}

--- a/service/task.go
+++ b/service/task.go
@@ -177,7 +177,6 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 
 	executionStr := gimlet.GetVars(r)["execution"]
 	archived := false
-	taskId := projCtx.Task.Id
 
 	// if there is an execution number, the task might be in the old_tasks collection, so we
 	// query that collection and set projCtx.Task to the old task if it exists.
@@ -330,7 +329,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	testResults := uis.getTestResults(w, r, projCtx, &uiTask, taskId)
+	testResults := uis.getTestResults(w, r, projCtx, &uiTask)
 
 	if projCtx.Patch != nil {
 		var taskOnBaseCommit *task.Task
@@ -888,7 +887,7 @@ func (uis *UIServer) testLog(w http.ResponseWriter, r *http.Request) {
 	uis.render.Stream(w, http.StatusOK, data, "base", "task_log.html")
 }
 
-func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, projCtx projectContext, uiTask *uiTaskData, taskId string) []task.TestResult {
+func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, projCtx projectContext, uiTask *uiTaskData) []task.TestResult {
 	var err error
 	var testResults []task.TestResult
 
@@ -939,10 +938,9 @@ func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, proj
 		}
 	} else {
 		for _, tr := range projCtx.Context.Task.LocalTestResults {
-			tr.TaskID = taskId
 			uiTask.TestResults = append(uiTask.TestResults, uiTestResult{
 				TestResult: tr,
-				TaskId:     taskId,
+				TaskId:     tr.TaskID,
 			})
 		}
 		testResults = projCtx.Task.LocalTestResults

--- a/service/waterfall.go
+++ b/service/waterfall.go
@@ -383,8 +383,8 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 					// only call the legacy function if we need to, i.e. we aren't using cedar, we know there are legacy results,
 					// or we don't know because we haven't cached this information yet.
 					if !t.HasCedarResults && utility.FromBoolTPtr(t.HasLegacyResults) && numTestResultCalls < maxTestResultCalls {
-						if err = t.MergeNewTestResults(); err != nil {
-							return versionVariantData{}, errors.Wrap(err, "error merging test results")
+						if err = t.PopulateTestResults(); err != nil {
+							return versionVariantData{}, errors.Wrap(err, "populating test results")
 						}
 						numTestResultCalls++
 					}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -84,12 +84,12 @@ func taskFinishedTwoOrMoreDaysAgo(taskID string, sub *event.Subscription) (bool,
 	if renotify == "" || err != nil || !found {
 		renotifyInterval = 48
 	}
-	t, err := task.FindOneNoMerge(task.ById(taskID).WithFields(task.FinishTimeKey))
+	t, err := task.FindOne(task.ById(taskID).WithFields(task.FinishTimeKey))
 	if err != nil {
 		return false, errors.Wrapf(err, "error finding task '%s'", taskID)
 	}
 	if t == nil {
-		t, err = task.FindOneOldNoMerge(task.ById(taskID).WithFields(task.FinishTimeKey))
+		t, err = task.FindOneOld(task.ById(taskID).WithFields(task.FinishTimeKey))
 		if err != nil {
 			return false, errors.Wrapf(err, "error finding old task '%s'", taskID)
 		}
@@ -159,7 +159,7 @@ func (t *taskTriggers) Fetch(e *event.EventLogEntry) error {
 		return errors.Wrap(err, "Failed to fetch ui config")
 	}
 
-	t.task, err = task.FindOneIdOldOrNewNoMerge(e.ResourceId, t.data.Execution)
+	t.task, err = task.FindOneIdOldOrNew(e.ResourceId, t.data.Execution)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch task")
 	}
@@ -576,7 +576,7 @@ func isTaskRegression(sub *event.Subscription, t *task.Task) (bool, *alertrecord
 		return false, nil, nil
 	}
 
-	previousTask, err := task.FindOneNoMerge(task.ByBeforeRevisionWithStatusesAndRequesters(t.RevisionOrderNumber,
+	previousTask, err := task.FindOne(task.ByBeforeRevisionWithStatusesAndRequesters(t.RevisionOrderNumber,
 		evergreen.CompletedStatuses, t.BuildVariant, t.DisplayName, t.Project, evergreen.SystemVersionRequesterTypes).Sort([]string{"-" + task.RevisionOrderNumberKey}))
 	if err != nil {
 		return false, nil, errors.Wrap(err, "error fetching previous task")
@@ -828,7 +828,7 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 	}
 
 	catcher := grip.NewBasicCatcher()
-	previousCompleteTask, err := task.FindOneNoMerge(task.ByBeforeRevisionWithStatusesAndRequesters(t.task.RevisionOrderNumber,
+	previousCompleteTask, err := task.FindOne(task.ByBeforeRevisionWithStatusesAndRequesters(t.task.RevisionOrderNumber,
 		evergreen.CompletedStatuses, t.task.BuildVariant, t.task.DisplayName, t.task.Project, evergreen.SystemVersionRequesterTypes).Sort([]string{"-" + task.RevisionOrderNumberKey}))
 	if err != nil {
 		return nil, errors.Wrap(err, "error fetching previous task")
@@ -1027,7 +1027,7 @@ func (t *taskTriggers) buildBreak(sub *event.Subscription) (*notification.Notifi
 	if t.task.TriggerID != "" && sub.Owner != "" { // don't notify committer for a triggered build
 		return nil, nil
 	}
-	previousTask, err := task.FindOneNoMerge(task.ByBeforeRevisionWithStatusesAndRequesters(t.task.RevisionOrderNumber,
+	previousTask, err := task.FindOne(task.ByBeforeRevisionWithStatusesAndRequesters(t.task.RevisionOrderNumber,
 		evergreen.CompletedStatuses, t.task.BuildVariant, t.task.DisplayName, t.task.Project, evergreen.SystemVersionRequesterTypes).Sort([]string{"-" + task.RevisionOrderNumberKey}))
 	if err != nil {
 		return nil, errors.Wrap(err, "error fetching previous task")

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -850,7 +850,7 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 			}
 			t.oldTestResults = mapTestResultsByTestFile(results)
 		} else {
-			if err = previousCompleteTask.MergeNewTestResults(); err != nil {
+			if err = previousCompleteTask.MergeTestResults(); err != nil {
 				return nil, errors.Wrapf(err, "can't get test results for previous task '%s'", previousCompleteTask.Id)
 			}
 			t.oldTestResults = mapTestResultsByTestFile(previousCompleteTask.LocalTestResults)

--- a/trigger/task_jira.go
+++ b/trigger/task_jira.go
@@ -187,14 +187,18 @@ func makeSummaryPrefix(t *task.Task, failed int) string {
 }
 
 func (j *jiraBuilder) build() (*message.JiraIssue, error) {
+	if err := j.data.Task.PopulateTestResults(); err != nil {
+		return nil, errors.Wrap(err, "populating test results")
+	}
+
 	j.data.SpecificTaskStatus = j.data.Task.GetDisplayStatus()
 	description, err := j.getDescription()
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating description")
+		return nil, errors.Wrap(err, "creating description")
 	}
 	summary, err := j.getSummary()
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating summary")
+		return nil, errors.Wrap(err, "creating summary")
 	}
 
 	fields := map[string]interface{}{}

--- a/trigger/task_jira_test.go
+++ b/trigger/task_jira_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -451,6 +452,7 @@ func TestCustomFields(t *testing.T) {
 					{TestFile: testName2, Status: evergreen.TestFailedStatus, LogId: "123"},
 					{TestFile: testName3, Status: evergreen.TestSucceededStatus},
 				},
+				HasLegacyResults: utility.ToBoolPtr(true),
 			},
 			Host:  &host.Host{Id: hostId, Host: hostDNS},
 			Build: &build.Build{DisplayName: buildName, Id: buildId},
@@ -558,7 +560,7 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		data: jiraTemplateData{
-			Task:    &task.Task{Status: evergreen.TaskSucceeded},
+			Task:    &task.Task{Status: evergreen.TaskSucceeded, HasLegacyResults: utility.ToBoolPtr(true)},
 			Project: &model.ProjectRef{},
 			Build:   &build.Build{},
 			Version: &model.Version{Revision: "abcdefgh"},

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -1349,20 +1349,20 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 	tr.task = &tasks[0]
 	notification, err = tr.taskRegressionByTest(&event.Subscription{ID: "s1", Subscriber: subscriber, Trigger: "t1"})
 	assert.NoError(t, err)
-	assert.NotNil(t, notification)
+	require.NotNil(t, notification)
 	assert.Equal(t, "dt0_0", notification.Metadata.TaskID)
 
-	// don't alert on the second run of the display task for a different execution task (et1) that contains the same test (f0)
-	tr.task = &tasks[3]
-	notification, err = tr.taskRegressionByTest(&event.Subscription{ID: "s1", Subscriber: subscriber, Trigger: "t1"})
-	assert.NoError(t, err)
-	assert.Nil(t, notification)
-
 	// alert for the second run of the display task with the same execution task (et0) failing with a new test (f1)
+	tr.task = &tasks[3]
 	newResult := testresult.TestResult{TaskID: "et0_1", TestFile: "f1", Status: evergreen.TestFailedStatus}
 	assert.NoError(t, newResult.Insert())
 	notification, err = tr.taskRegressionByTest(&event.Subscription{ID: "s1", Subscriber: subscriber, Trigger: "t1"})
 	assert.NoError(t, err)
-	assert.NotNil(t, notification)
+	require.NotNil(t, notification)
 	assert.Equal(t, "dt0_1", notification.Metadata.TaskID)
+
+	// don't alert on the second run of the display task for a different execution task (et1) that contains the same test (f0)
+	notification, err = tr.taskRegressionByTest(&event.Subscription{ID: "s1", Subscriber: subscriber, Trigger: "t1"})
+	assert.NoError(t, err)
+	assert.Nil(t, notification)
 }

--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -78,7 +78,7 @@ func (j *collectTaskEndDataJob) Run(ctx context.Context) {
 	}
 	// The task was restarted before the job ran.
 	if j.task == nil {
-		j.task, err = task.FindOneOldNoMergeByIdAndExecution(j.TaskID, j.Execution)
+		j.task, err = task.FindOneOldByIdAndExecution(j.TaskID, j.Execution)
 		j.AddError(err)
 		if err != nil {
 			return


### PR DESCRIPTION
EVG-14997: https://jira.mongodb.org/browse/EVG-14997

- Lazily fetch test results.
- Remove all test results merging in task DB functions.
- Create new `PopulateTestResults` which populates the task's `LocalTestResults` field (even if it is a display task).
- Add a new local field, `testResultsPopulated`, to the `Task` struct to avoid populating test results more than once.
- Call `PopulateTestResults` where needed (this is the riskiest part of the PR).