### PR TITLE
TIG-3231: Iframe for new trend charts, plus url and sizing fixed.

### DIFF
--- a/public/static/app/common/constants.js
+++ b/public/static/app/common/constants.js
@@ -145,6 +145,7 @@ mciModule
   .constant('CEDAR_APP_URL', 'https://cedar.mongodb.com')
   .constant("PERFORMANCE_ANALYSIS_AND_TRIAGE_API", {
     BASE:'https://signal-processing-service.server-tig.prod.corp.mongodb.com',
+    UI:'https://performance-monitoring-and-analysis-latest.server-tig.prod.corp.mongodb.com',
     CHANGE_POINTS_BY_VERSION: '/change_points/project/{projectId}/by_version',
     AUTH_URL: 'https://login.corp.mongodb.com/login',
     TRIAGE_POINTS: '/change_points/triage/mark'

--- a/public/static/app/perf/perf.js
+++ b/public/static/app/perf/perf.js
@@ -12,7 +12,7 @@ const findIndex = function (list, predicate) {
 };
 
 mciModule.controller('PerfController', function PerfController(
-  $scope, $window, $http, $location, $filter, ChangePointsService,
+  $scope, $window, $http, $location, $filter, ChangePointsService, PERFORMANCE_ANALYSIS_AND_TRIAGE_API, $sce,
   DrawPerfTrendChart, PROCESSED_TYPE, Settings,
   TestSample, CANARY_EXCLUSION_REGEX, ApiTaskdata,
   loadBuildFailures, loadChangePoints, loadTrendData,
@@ -41,7 +41,6 @@ $http.get(templateUrl).success(function(template) {
   $scope.trendResults = [];
   $scope.jiraHost = $window.jiraHost
   $scope.threadsToSelect = {};
-
   $scope.isGraphHidden = function (k) {
     return $scope.hiddenGraphs[k] == true
   }
@@ -180,10 +179,11 @@ $http.get(templateUrl).success(function(template) {
   }
 
   // needed to do Math.abs in the template code.
-  $scope.user = $window.user
+  $scope.user = $window.user;
   $scope.Math = $window.Math;
   $scope.conf = $window.plugins["perf"];
   $scope.task = $window.task_data;
+  $scope.newTrendChartsUi = $sce.trustAsResourceUrl(PERFORMANCE_ANALYSIS_AND_TRIAGE_API.UI + "/task/" + ($scope.task ? $scope.task.id : null) + "/performanceData");
   $scope.tablemode = 'maxthroughput';
   $scope.threadLevelsRadio = {
     options: [{

--- a/service/templates/task_perf_data.html
+++ b/service/templates/task_perf_data.html
@@ -195,6 +195,14 @@
     }
   </style>
   <div class="panel perf-panel" ng-if="conf.enabled && !!perfSample">
+    <iframe
+            width="100%"
+            height="1000px"
+            src="[[newTrendChartsUi]]"
+            title="Task Performance Data"
+    ></iframe>
+  </div>
+  <div class="panel perf-panel" ng-if="conf.enabled && !!perfSample">
     <div class="pull-right text-right">
       <div ng-show="!!perfTagData.tag"><i class="fa fa-tag"></i>&nbsp;Tagged as&nbsp;<div class="label label-primary">[[perfTagData.tag]]</div><i class="fa fa-times" ng-click="deleteTag()"></i></div>
       <div ng-show="!perfTagData.tag">


### PR DESCRIPTION
[TIG-3231](https://jira.mongodb.org/browse/TIG-3231)

### Description 
Adds back the new trend charts iframe, but now handles sizing and url trusting properly. I'm using the same sizing spruce uses for these trend charts (100% of parent container width, 1000px height), for reference.

### Testing 
I was able to get a local version working and saw that this didn't affect the log section showing up. I also did a temporary hack to enable viewing this new panel without it being configured, and that also didn't affect the log section. I think it should be good to go, now.