### PR TITLE
EVG-15190 use display task ID and facet to get version tasks

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2856,7 +2856,7 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 		// display only is false (i.e. we don't know if it's a display task or not).
 		facet := bson.M{
 			"$facet": bson.M{
-				// we skip lookup for anything we already know is not part of a display task
+				// We skip lookup for anything we already know is not part of a display task
 				"id_empty": []bson.M{
 					{
 						"$match": bson.M{
@@ -2867,7 +2867,7 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 						},
 					},
 				},
-				// no ID and not display task: lookup if it's an execution task for some task, and then filter it out if it is
+				// No ID and not display task: lookup if it's an execution task for some task, and then filter it out if it is
 				"no_id": []bson.M{
 					{
 						"$match": bson.M{
@@ -2891,7 +2891,7 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 		}
 		pipeline = append(pipeline, facet)
 
-		// recombine the tasks so that we can continue the pipeline on the joined tasks
+		// Recombine the tasks so that we can continue the pipeline on the joined tasks
 		recombineTasks := []bson.M{
 			{"$project": bson.M{
 				"tasks": bson.M{
@@ -2905,7 +2905,7 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 		pipeline = append(pipeline, recombineTasks...)
 	}
 	pipeline = append(pipeline, []bson.M{
-		// get any annotation that has at least one issue
+		// Get any annotation that has at least one issue
 		{
 			"$lookup": bson.M{
 				"from": annotations.Collection,
@@ -2935,9 +2935,9 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 			},
 		},
 
-		// add a field for the display status of each task
+		// Add a field for the display status of each task
 		addDisplayStatus,
-		// add data about the base task
+		// Add data about the base task
 		{"$lookup": bson.M{
 			"from": Collection,
 			"let": bson.M{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2852,20 +2852,57 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 	)
 
 	if !opts.IncludeExecutionTasks {
-		pipeline = append(pipeline, []bson.M{
-			// do a self join to filter off execution tasks
-			{"$lookup": bson.M{
-				"from":         Collection,
-				"localField":   IdKey,
-				"foreignField": ExecutionTasksKey,
-				"as":           tempParentKey,
-			}},
-			{
-				"$match": bson.M{
-					tempParentKey: []interface{}{},
+		// Split tasks so that we only look up if the task is an execution task if display task ID is unset and
+		// display only is false (i.e. we don't know if it's a display task or not).
+		facet := bson.M{
+			"$facet": bson.M{
+				// we skip lookup for anything we already know is not part of a display task
+				"id_empty": []bson.M{
+					{
+						"$match": bson.M{
+							"$or": []bson.M{
+								{DisplayTaskIdKey: ""},
+								{DisplayOnlyKey: true},
+							},
+						},
+					},
+				},
+				// no ID and not display task: lookup if it's an execution task for some task, and then filter it out if it is
+				"no_id": []bson.M{
+					{
+						"$match": bson.M{
+							DisplayTaskIdKey: nil,
+							DisplayOnlyKey:   bson.M{"$ne": true},
+						},
+					},
+					{"$lookup": bson.M{
+						"from":         Collection,
+						"localField":   IdKey,
+						"foreignField": ExecutionTasksKey,
+						"as":           tempParentKey,
+					}},
+					{
+						"$match": bson.M{
+							tempParentKey: []interface{}{},
+						},
+					},
 				},
 			},
-		}...)
+		}
+		pipeline = append(pipeline, facet)
+
+		// recombine the tasks so that we can continue the pipeline on the joined tasks
+		recombineTasks := []bson.M{
+			{"$project": bson.M{
+				"tasks": bson.M{
+					"$setUnion": []string{"$no_id", "$id_empty"},
+				}},
+			},
+			{"$unwind": "$tasks"},
+			{"$replaceRoot": bson.M{"newRoot": "$tasks"}},
+		}
+
+		pipeline = append(pipeline, recombineTasks...)
 	}
 	pipeline = append(pipeline, []bson.M{
 		// get any annotation that has at least one issue


### PR DESCRIPTION
[EVG-15190](https://jira.mongodb.org/browse/EVG-15190)

### Description 
If the task has display task ID explicitly set to empty or displayTask is true, we don't have to do the lookup to find out if the task is an execution task, so we use facet to filter those out, and we only lookup execution tasks on the remaining tasks.

### Testing 
Added a unit test.