### PR TITLE
EVG-15248: enqueue pod creation job in REST route

### DIFF
--- a/rest/route/pod.go
+++ b/rest/route/pod.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -18,21 +22,22 @@ import (
 // POST /rest/v2/pods
 
 type podPostHandler struct {
-	sc data.Connector
-	p  model.APICreatePod
+	env evergreen.Environment
+	sc  data.Connector
+	p   model.APICreatePod
 }
 
-func makePostPod(sc data.Connector) gimlet.RouteHandler {
+func makePostPod(env evergreen.Environment, sc data.Connector) gimlet.RouteHandler {
 	return &podPostHandler{
-		sc: sc,
-		p:  model.APICreatePod{},
+		env: env,
+		sc:  sc,
 	}
 }
 
 func (h *podPostHandler) Factory() gimlet.RouteHandler {
 	return &podPostHandler{
-		sc: h.sc,
-		p:  model.APICreatePod{},
+		env: h.env,
+		sc:  h.sc,
 	}
 }
 
@@ -75,6 +80,16 @@ func (h *podPostHandler) Run(ctx context.Context) gimlet.Responder {
 	responder, err := gimlet.NewBasicResponder(http.StatusCreated, gimlet.JSON, res)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "constructing response"))
+	}
+
+	j := units.NewCreatePodJob(h.env, res.ID, utility.RoundPartOfMinute(0).Format(units.TSFormat))
+	if err := amboy.EnqueueUniqueJob(ctx, h.env.RemoteQueue(), j); err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "could not enqueue Amboy job to create pod",
+			"pod_id":  res.ID,
+			"job_id":  j.ID(),
+			"route":   "/rest/v2/pods",
+		}))
 	}
 
 	return responder

--- a/rest/route/pod_test.go
+++ b/rest/route/pod_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
@@ -159,8 +160,10 @@ func TestPostPod(t *testing.T) {
 			defer cancel()
 
 			sc := &data.MockConnector{}
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(ctx))
 
-			p := makePostPod(sc)
+			p := makePostPod(env, sc)
 			require.NotZero(t, p)
 
 			tCase(ctx, t, p.(*podPostHandler))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -142,7 +142,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/pods/{pod_id}/agent/cedar_config").Version(2).Get().Wrap(checkPod).RouteHandler(makePodAgentCedarConfig(env.Settings()))
 	app.AddRoute("/pods/{pod_id}/agent/setup").Version(2).Get().Wrap(checkPod).RouteHandler(makePodAgentSetup(env.Settings()))
 	app.AddRoute("/pods/{pod_id}/agent/next_task").Version(2).Get().Wrap(checkPod).RouteHandler(makePodAgentNextTask(env, sc))
-	app.AddRoute("/pods").Version(2).Post().Wrap(adminSettings).RouteHandler(makePostPod(sc))
+	app.AddRoute("/pods").Version(2).Post().Wrap(adminSettings).RouteHandler(makePostPod(env, sc))
 	app.AddRoute("/projects").Version(2).Get().Wrap(checkUser).RouteHandler(makeFetchProjectsRoute(sc))
 	app.AddRoute("/projects/test_alias").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetProjectAliasResultsHandler(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Delete().Wrap(checkUser, checkProjectAdmin, editProjectSettings).RouteHandler(makeDeleteProject(sc))

--- a/units/crons.go
+++ b/units/crons.go
@@ -1241,7 +1241,7 @@ func PopulatePodInitializingJobs(env evergreen.Environment) amboy.QueueOperation
 
 		catcher := grip.NewBasicCatcher()
 		for _, p := range pods {
-			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewCreatePodJob(env, &p, utility.RoundPartOfMinute(0).Format(TSFormat))), "enqueueing job to create pod %s", p.ID)
+			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewCreatePodJob(env, p.ID, utility.RoundPartOfMinute(0).Format(TSFormat))), "enqueueing job to create pod %s", p.ID)
 		}
 
 		return catcher.Resolve()

--- a/units/pod_creation.go
+++ b/units/pod_creation.go
@@ -56,10 +56,9 @@ func makeCreatePodJob() *createPodJob {
 }
 
 // NewCreatePodJob creates a job that starts the given pod.
-func NewCreatePodJob(env evergreen.Environment, p *pod.Pod, id string) amboy.Job {
+func NewCreatePodJob(env evergreen.Environment, podID, id string) amboy.Job {
 	j := makeCreatePodJob()
-	j.pod = p
-	j.PodID = p.ID
+	j.PodID = podID
 	j.env = env
 	j.SetID(fmt.Sprintf("%s.%s.%s", createPodJobName, j.PodID, id))
 	j.SetScopes([]string{fmt.Sprintf("%s.%s", createPodJobName, j.PodID), podLifecycleScope(j.PodID)})

--- a/units/pod_creation_test.go
+++ b/units/pod_creation_test.go
@@ -20,17 +20,12 @@ import (
 
 func TestNewCreatePodJob(t *testing.T) {
 	podID := utility.RandomString()
-	p := pod.Pod{
-		ID:     podID,
-		Status: pod.StatusInitializing,
-	}
 
-	j, ok := NewCreatePodJob(&evgMock.Environment{}, &p, utility.RoundPartOfMinute(0).Format(TSFormat)).(*createPodJob)
+	j, ok := NewCreatePodJob(&evgMock.Environment{}, podID, utility.RoundPartOfMinute(0).Format(TSFormat)).(*createPodJob)
 	require.True(t, ok)
 
 	assert.NotZero(t, j.ID())
 	assert.Equal(t, podID, j.PodID)
-	assert.Equal(t, pod.StatusInitializing, j.pod.Status)
 }
 
 func TestCreatePodJob(t *testing.T) {
@@ -193,7 +188,7 @@ func TestCreatePodJob(t *testing.T) {
 				},
 			}
 
-			env := evgMock.Environment{}
+			var env evgMock.Environment
 			require.NoError(t, env.Configure(ctx))
 			var envClusters []evergreen.ECSClusterConfig
 			for name := range cocoaMock.GlobalECSService.Clusters {
@@ -204,7 +199,7 @@ func TestCreatePodJob(t *testing.T) {
 			}
 			env.EvergreenSettings.Providers.AWS.Pod.ECS.Clusters = envClusters
 
-			j, ok := NewCreatePodJob(&env, &p, utility.RoundPartOfMinute(0).Format(TSFormat)).(*createPodJob)
+			j, ok := NewCreatePodJob(&env, p.ID, utility.RoundPartOfMinute(0).Format(TSFormat)).(*createPodJob)
 			require.True(t, ok)
 
 			j.pod = &p


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15248

### Description 
Enqueue the pod creation job as soon as the pod document is created in the REST route. The periodic cron job will still populate it if the REST route fails to enqueue it (e.g. because the context cancels).

### Testing 
N/A
