### PR TITLE
EVG-15032 use display task ID after checking if display task

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -22,6 +22,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/rolemanager"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -994,7 +995,8 @@ func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, proj
 		}
 
 		if uiTask.PartOfDisplay {
-			uiTask.DisplayTaskID = projCtx.Task.DisplayTask.Id
+			// Display task ID would've been populated when setting PartOfDisplay.
+			uiTask.DisplayTaskID = utility.FromStringPtr(projCtx.Task.DisplayTaskId)
 		}
 	}
 


### PR DESCRIPTION
[EVG-15032 ](https://jira.mongodb.org/browse/EVG-15032 )

### Description 
https://mongodb.slack.com/archives/C866SR2LR/p1629136301026000
Can't use display task since it will be nil if displayTaskId was already set.
