### PR TITLE
EVG-15259: rename pod lifecycle jobs

### DIFF
--- a/rest/route/pod.go
+++ b/rest/route/pod.go
@@ -82,7 +82,7 @@ func (h *podPostHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "constructing response"))
 	}
 
-	j := units.NewCreatePodJob(h.env, res.ID, utility.RoundPartOfMinute(0).Format(units.TSFormat))
+	j := units.NewPodCreationJob(res.ID, utility.RoundPartOfMinute(0).Format(units.TSFormat))
 	if err := amboy.EnqueueUniqueJob(ctx, h.env.RemoteQueue(), j); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "could not enqueue Amboy job to create pod",

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -119,7 +119,7 @@ func (h *podAgentNextTask) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
-	j := units.NewTerminatePodJob(h.podID, "reached end of pod lifecycle", utility.RoundPartOfMinute(0))
+	j := units.NewPodTerminationJob(h.podID, "reached end of pod lifecycle", utility.RoundPartOfMinute(0))
 	if err := amboy.EnqueueUniqueJob(ctx, h.env.RemoteQueue(), j); err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -62,8 +62,8 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 		PopulateParentDecommissionJobs(),
 		PopulatePeriodicNotificationJobs(1),
 		PopulateUserDataDoneJobs(j.env),
+		PopulatePodCreationJobs(j.env),
 		PopulatePodTerminationJobs(j.env),
-		PopulatePodInitializingJobs(j.env),
 	}
 
 	catcher := grip.NewBasicCatcher()

--- a/units/pod_creation_test.go
+++ b/units/pod_creation_test.go
@@ -18,19 +18,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewCreatePodJob(t *testing.T) {
+func TestNewPodCreationJob(t *testing.T) {
 	podID := utility.RandomString()
 
-	j, ok := NewCreatePodJob(&evgMock.Environment{}, podID, utility.RoundPartOfMinute(0).Format(TSFormat)).(*createPodJob)
+	j, ok := NewPodCreationJob(podID, utility.RoundPartOfMinute(0).Format(TSFormat)).(*podCreationJob)
 	require.True(t, ok)
 
 	assert.NotZero(t, j.ID())
 	assert.Equal(t, podID, j.PodID)
 }
 
-func TestCreatePodJob(t *testing.T) {
-	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, j *createPodJob){
-		"Succeeds": func(ctx context.Context, t *testing.T, j *createPodJob) {
+func TestPodCreationJob(t *testing.T) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, j *podCreationJob){
+		"Succeeds": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			require.NoError(t, j.pod.Insert())
 			assert.Equal(t, pod.StatusInitializing, j.pod.Status)
 
@@ -59,7 +59,7 @@ func TestCreatePodJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusStarting, dbPod.Status)
 		},
-		"FailsWithStartingStatus": func(ctx context.Context, t *testing.T, j *createPodJob) {
+		"FailsWithStartingStatus": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			require.NoError(t, j.pod.Insert())
 			require.NoError(t, j.pod.UpdateStatus(pod.StatusStarting))
 			assert.Equal(t, pod.StatusStarting, j.pod.Status)
@@ -75,7 +75,7 @@ func TestCreatePodJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusStarting, dbPod.Status)
 		},
-		"FailsWithRunningStatus": func(ctx context.Context, t *testing.T, j *createPodJob) {
+		"FailsWithRunningStatus": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			require.NoError(t, j.pod.Insert())
 			require.NoError(t, j.pod.UpdateStatus(pod.StatusRunning))
 			assert.Equal(t, pod.StatusRunning, j.pod.Status)
@@ -91,7 +91,7 @@ func TestCreatePodJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusRunning, dbPod.Status)
 		},
-		"FailsWithTerminatedStatus": func(ctx context.Context, t *testing.T, j *createPodJob) {
+		"FailsWithTerminatedStatus": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			require.NoError(t, j.pod.Insert())
 			require.NoError(t, j.pod.UpdateStatus(pod.StatusTerminated))
 
@@ -106,7 +106,7 @@ func TestCreatePodJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusTerminated, dbPod.Status)
 		},
-		"FailsWhenExportingOpts": func(ctx context.Context, t *testing.T, j *createPodJob) {
+		"FailsWhenExportingOpts": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			j.pod.TaskContainerCreationOpts.Image = ""
 			require.NoError(t, j.pod.Insert())
 
@@ -121,7 +121,7 @@ func TestCreatePodJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusInitializing, dbPod.Status)
 		},
-		"FailsWhenCreatingPod": func(ctx context.Context, t *testing.T, j *createPodJob) {
+		"FailsWhenCreatingPod": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			j.pod.TaskContainerCreationOpts.CPU = 0
 			require.NoError(t, j.pod.Insert())
 
@@ -136,7 +136,7 @@ func TestCreatePodJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusInitializing, dbPod.Status)
 		},
-		"FailsWithMismatchedPlatformOS": func(ctx context.Context, t *testing.T, j *createPodJob) {
+		"FailsWithMismatchedPlatformOS": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			j.pod.TaskContainerCreationOpts.OS = "windows"
 			require.NoError(t, j.pod.Insert())
 
@@ -188,7 +188,7 @@ func TestCreatePodJob(t *testing.T) {
 				},
 			}
 
-			var env evgMock.Environment
+			env := &evgMock.Environment{}
 			require.NoError(t, env.Configure(ctx))
 			var envClusters []evergreen.ECSClusterConfig
 			for name := range cocoaMock.GlobalECSService.Clusters {
@@ -199,10 +199,11 @@ func TestCreatePodJob(t *testing.T) {
 			}
 			env.EvergreenSettings.Providers.AWS.Pod.ECS.Clusters = envClusters
 
-			j, ok := NewCreatePodJob(&env, p.ID, utility.RoundPartOfMinute(0).Format(TSFormat)).(*createPodJob)
+			j, ok := NewPodCreationJob(p.ID, utility.RoundPartOfMinute(0).Format(TSFormat)).(*podCreationJob)
 			require.True(t, ok)
 
 			j.pod = &p
+			j.env = env
 
 			j.smClient = &cocoaMock.SecretsManagerClient{}
 			defer func() {

--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewTerminatePodJob(t *testing.T) {
+func TestNewPodTerminationJob(t *testing.T) {
 	podID := "id"
 	reason := "reason"
-	j, ok := NewTerminatePodJob(podID, reason, utility.RoundPartOfMinute(0)).(*terminatePodJob)
+	j, ok := NewPodTerminationJob(podID, reason, utility.RoundPartOfMinute(0)).(*podTerminationJob)
 	require.True(t, ok)
 
 	assert.NotZero(t, j.ID())
@@ -27,9 +27,9 @@ func TestNewTerminatePodJob(t *testing.T) {
 	assert.Equal(t, podID, j.PodID)
 }
 
-func TestTerminatePodJob(t *testing.T) {
-	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, j *terminatePodJob){
-		"TerminatesAndDeletesResourcesForRunningPod": func(ctx context.Context, t *testing.T, j *terminatePodJob) {
+func TestPodTerminationJob(t *testing.T) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, j *podTerminationJob){
+		"TerminatesAndDeletesResourcesForRunningPod": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
 			require.NoError(t, j.pod.Insert())
 
 			j.Run(ctx)
@@ -46,7 +46,7 @@ func TestTerminatePodJob(t *testing.T) {
 
 			assert.Equal(t, cocoa.StatusDeleted, j.ecsPod.StatusInfo().Status)
 		},
-		"SucceedsWithPodFromDB": func(ctx context.Context, t *testing.T, j *terminatePodJob) {
+		"SucceedsWithPodFromDB": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
 			require.NoError(t, j.pod.Insert())
 			j.pod = nil
 			j.ecsPod = nil
@@ -65,7 +65,7 @@ func TestTerminatePodJob(t *testing.T) {
 
 			assert.Equal(t, cocoa.StatusDeleted, j.ecsPod.StatusInfo().Status)
 		},
-		"FailsWhenDeletingResourcesErrors": func(ctx context.Context, t *testing.T, j *terminatePodJob) {
+		"FailsWhenDeletingResourcesErrors": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
 			require.NoError(t, j.pod.Insert())
 			j.pod.Resources.ExternalID = utility.RandomString()
 			j.ecsPod = nil
@@ -78,7 +78,7 @@ func TestTerminatePodJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.NotEqual(t, pod.StatusTerminated, dbPod.Status)
 		},
-		"FailsWhenPodStatusUpdateErrors": func(ctx context.Context, t *testing.T, j *terminatePodJob) {
+		"FailsWhenPodStatusUpdateErrors": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
 			require.NoError(t, j.pod.Insert())
 			j.pod.Status = pod.StatusInitializing
 
@@ -90,7 +90,7 @@ func TestTerminatePodJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.NotEqual(t, pod.StatusTerminated, j.pod.Status)
 		},
-		"TerminatesWithoutDeletingResourcesForInitializingPod": func(ctx context.Context, t *testing.T, j *terminatePodJob) {
+		"TerminatesWithoutDeletingResourcesForInitializingPod": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
 			j.pod.Status = pod.StatusInitializing
 			require.NoError(t, j.pod.Insert())
 
@@ -102,7 +102,7 @@ func TestTerminatePodJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusTerminated, dbPod.Status)
 		},
-		"NoopsforTerminatedPod": func(ctx context.Context, t *testing.T, j *terminatePodJob) {
+		"NoopsforTerminatedPod": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
 			j.pod.Status = pod.StatusTerminated
 			require.NoError(t, j.pod.Insert())
 
@@ -150,7 +150,7 @@ func TestTerminatePodJob(t *testing.T) {
 				},
 			}
 
-			j, ok := NewTerminatePodJob(p.ID, "reason", utility.RoundPartOfMinute(0)).(*terminatePodJob)
+			j, ok := NewPodTerminationJob(p.ID, "reason", utility.RoundPartOfMinute(0)).(*podTerminationJob)
 			require.True(t, ok)
 			j.pod = &p
 			j.smClient = &mock.SecretsManagerClient{}


### PR DESCRIPTION
JIra: https://jira.mongodb.org/browse/EVG-15259

### Description 
Make the naming scheme consistent for the pod jobs and their file names. This is to reduce the amount of confusion for pods that's accrued over the naming scheme of host lifecycle jobs (e.g. the host termination job is `units/host_termination.go`, the create host job is `units/provisioning_create_host.go`, the set cloud hosts ready job is `units/host_status.go`).

The name change won't affect staging or prod because pods are still being tested and neither environment is running these jobs.

### Testing 
N/A