### PR TITLE
EVG-15273: implement GetNextTask in agent pod communicator

### DIFF
--- a/agent/internal/client/pod_methods.go
+++ b/agent/internal/client/pod_methods.go
@@ -98,7 +98,22 @@ func (c *podCommunicator) FetchExpansionVars(ctx context.Context, taskData TaskD
 
 // GetNextTask returns a next task response by getting the next task for a given host.
 func (c *podCommunicator) GetNextTask(ctx context.Context, details *apimodels.GetNextTaskDetails) (*apimodels.NextTaskResponse, error) {
-	return nil, errors.New("TODO: implement")
+	info := requestInfo{
+		method:  http.MethodGet,
+		version: apiVersion2,
+		path:    fmt.Sprintf("pods/%s/agent/next_task", c.podID),
+	}
+	resp, err := c.retryRequest(ctx, info, nil)
+	if err != nil {
+		return nil, utility.RespErrorf(resp, "getting next task: %s", err.Error())
+	}
+
+	var nextTask apimodels.NextTaskResponse
+	if err := utility.ReadJSON(resp.Body, &nextTask); err != nil {
+		return nil, errors.Wrap(err, "reading next task from response")
+	}
+
+	return &nextTask, nil
 }
 
 // GetCedarConfig returns the cedar service information including the base URL,

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-07-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-08-06"
+	AgentVersion = "2021-08-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
JIra: https://jira.mongodb.org/browse/EVG-15273

### Description 
Implement GetNextTask for the agent's communicator when running in a pod. The REST route already exists, it was just never hooked up to the agent. 

### Testing 
N/A
