### PR TITLE
EVG-14953 Fix flakey TestMergeMultipleProjectConfigsBuildVariant

### DIFF
--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2192,7 +2192,13 @@ buildvariants:
 	assert.NoError(t, err)
 	assert.NotNil(t, p1)
 	assert.Equal(t, len(p1.BuildVariants), 2)
-	assert.Equal(t, len(p1.BuildVariants[0].Tasks), 2)
+	if p1.BuildVariants[0].name() == "bv1" {
+		assert.Equal(t, len(p1.BuildVariants[0].Tasks), 2)
+		assert.Equal(t, len(p1.BuildVariants[1].Tasks), 1)
+	} else {
+		assert.Equal(t, len(p1.BuildVariants[0].Tasks), 1)
+		assert.Equal(t, len(p1.BuildVariants[1].Tasks), 2)
+	}
 	err = p1.mergeMultipleProjectConfigs(p3)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
[EVG-14953](https://jira.mongodb.org/browse/EVG-14953)

### Description 
Fix the test because the the build variants may not be added in order

### Testing 
unittest