### PR TITLE
EVG-15142 add log for a generate task noop

### DIFF
--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -94,6 +94,10 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 		return errors.Wrap(err, "problem parsing JSON")
 	}
 	if err = comm.GenerateTasks(ctx, td, post); err != nil {
+		if strings.Contains(err.Error(), evergreen.TasksAlreadyGeneratedError) {
+			logger.Task().Info("Tasks have already been generated, nooping.")
+			return nil
+		}
 		return errors.Wrap(err, "Problem posting task data")
 	}
 

--- a/agent/internal/client/host_methods.go
+++ b/agent/internal/client/host_methods.go
@@ -890,7 +890,7 @@ func (c *hostCommunicator) GenerateTasks(ctx context.Context, td TaskData, jsonB
 	info.path = fmt.Sprintf("tasks/%s/generate", td.ID)
 	resp, err := c.retryRequest(ctx, info, jsonBytes)
 	if err != nil {
-		return utility.RespErrorf(resp, "problem sending `generate.tasks` request", err.Error())
+		return utility.RespErrorf(resp, "problem sending `generate.tasks` request: %s", err.Error())
 	}
 	return nil
 }

--- a/agent/internal/client/host_methods.go
+++ b/agent/internal/client/host_methods.go
@@ -888,8 +888,11 @@ func (c *hostCommunicator) GenerateTasks(ctx context.Context, td TaskData, jsonB
 		version:  apiVersion2,
 	}
 	info.path = fmt.Sprintf("tasks/%s/generate", td.ID)
-	_, err := c.retryRequest(ctx, info, jsonBytes)
-	return errors.Wrap(err, "problem sending `generate.tasks` request")
+	resp, err := c.retryRequest(ctx, info, jsonBytes)
+	if err != nil {
+		return utility.RespErrorf(resp, "problem sending `generate.tasks` request", err.Error())
+	}
+	return nil
 }
 
 // GenerateTasksPoll posts new tasks for the `generate.tasks` command.

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-07-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-08-18"
+	AgentVersion = "2021-08-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-07-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-08-17"
+	AgentVersion = "2021-08-18"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/globals.go
+++ b/globals.go
@@ -253,7 +253,8 @@ const (
 
 	DefaultShutdownWaitSeconds = 10
 
-	SaveGenerateTasksError = "error saving config in `generate.tasks`"
+	SaveGenerateTasksError     = "error saving config in `generate.tasks`"
+	TasksAlreadyGeneratedError = "generator already ran and generated tasks"
 )
 
 var InternalAliases []string = []string{

--- a/rest/data/generate.go
+++ b/rest/data/generate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
 	"github.com/pkg/errors"
@@ -21,9 +22,9 @@ func (gc *GenerateConnector) GenerateTasks(ctx context.Context, taskID string, j
 		return errors.Errorf("could not find task %s", taskID)
 	}
 
-	// If a generator has already run, noop.
+	// Don't continue if the generator has already run
 	if t.GeneratedTasks {
-		return nil
+		return errors.New(evergreen.TasksAlreadyGeneratedError)
 	}
 
 	if err = t.SetGeneratedJSON(jsonBytes); err != nil {


### PR DESCRIPTION
[EVG-15142](https://jira.mongodb.org/browse/EVG-15142)

### Description 
Right now we noop if we rerun a generator that has already already generated tasks; this can be confusing to users who expected something to happen, so we've decided to add a log for now.

### Testing 
Tested: https://evergreen-staging.corp.mongodb.com/task/evg_lint_generate_lint_ef19ea1fa0e2ca32b375a46402a2b7bae0bb463f_21_08_18_20_45_49