### PR TITLE
TIG-3231: Point to stable deployment of performance tooling.

### DIFF
--- a/public/static/app/common/constants.js
+++ b/public/static/app/common/constants.js
@@ -145,7 +145,7 @@ mciModule
   .constant('CEDAR_APP_URL', 'https://cedar.mongodb.com')
   .constant("PERFORMANCE_ANALYSIS_AND_TRIAGE_API", {
     BASE:'https://signal-processing-service.server-tig.prod.corp.mongodb.com',
-    UI:'https://performance-monitoring-and-analysis-latest.server-tig.prod.corp.mongodb.com',
+    UI:'https://performance-monitoring-and-analysis.server-tig.prod.corp.mongodb.com',
     CHANGE_POINTS_BY_VERSION: '/change_points/project/{projectId}/by_version',
     AUTH_URL: 'https://login.corp.mongodb.com/login',
     TRIAGE_POINTS: '/change_points/triage/mark'


### PR DESCRIPTION
[TIG-3231](https://jira.mongodb.org/browse/TIG-3231)

### Description 
Fixing the url for performance tooling, we were using the latest version rather than the stable version.

### Testing 
I verified that https://performance-monitoring-and-analysis.server-tig.prod.corp.mongodb.com is the proper URL to use here.
