### PR TITLE
EVG-14219 Continue on error in stats collector

### DIFF
--- a/agent/stats.go
+++ b/agent/stats.go
@@ -78,6 +78,7 @@ func (sc *StatsCollector) logStats(ctx context.Context, exp *util.Expansions) {
 			case <-timer.C:
 				runStartedAt := time.Now()
 				err := sc.jasper.CreateCommand(ctx).Append(sc.Cmds...).
+					ContinueOnError(true).
 					SetOutputSender(level.Info, sc.logger.System().GetSender()).
 					SetErrorSender(level.Error, sc.logger.System().GetSender()).
 					Run(ctx)

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-07-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-08-17"
+	AgentVersion = "2021-08-19b"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-14219](https://jira.mongodb.org/browse/EVG-14219)

### Description 
Currently the stats collector doesn't run later commands if an earlier one
fails. This adds the ContinueOnError jasper option so that they all run.

### Testing 
Since this is internal jasper behavior, I did not test this.
