### PR TITLE
EVG-15060 save project settings for section

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2246,7 +2246,7 @@ func (r *mutationResolver) SaveSubscription(ctx context.Context, subscription re
 	default:
 		return false, InputValidationError.Send(ctx, "Selectors do not indicate a target version, build, project, or task ID")
 	}
-	err = r.sc.SaveSubscriptions(username, []restModel.APISubscription{subscription})
+	err = r.sc.SaveSubscriptions(username, []restModel.APISubscription{subscription}, false)
 	if err != nil {
 		return false, InternalServerError.Send(ctx, fmt.Sprintf("error saving subscription: %s", err.Error()))
 	}

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -20,7 +20,7 @@ const (
 	EventTypeProjectAdded    = "PROJECT_ADDED"
 )
 
-type ProjectSettingsEvent struct {
+type ProjectSettings struct {
 	ProjectRef         ProjectRef           `bson:"proj_ref" json:"proj_ref"`
 	GitHubHooksEnabled bool                 `bson:"github_hooks_enabled" json:"github_hooks_enabled"`
 	Vars               ProjectVars          `bson:"vars" json:"vars"`
@@ -29,9 +29,9 @@ type ProjectSettingsEvent struct {
 }
 
 type ProjectChangeEvent struct {
-	User   string               `bson:"user" json:"user"`
-	Before ProjectSettingsEvent `bson:"before" json:"before"`
-	After  ProjectSettingsEvent `bson:"after" json:"after"`
+	User   string          `bson:"user" json:"user"`
+	Before ProjectSettings `bson:"before" json:"before"`
+	After  ProjectSettings `bson:"after" json:"after"`
 }
 
 type ProjectChangeEvents []ProjectChangeEventEntry
@@ -145,7 +145,15 @@ func LogProjectAdded(projectId, username string) error {
 	return LogProjectEvent(EventTypeProjectAdded, projectId, ProjectChangeEvent{User: username})
 }
 
-func LogProjectModified(projectId, username string, before, after *ProjectSettingsEvent) error {
+func GetAndLogProjectModified(id, userId string, before *ProjectSettings) error {
+	after, err := GetProjectSettingsById(id)
+	if err != nil {
+		return errors.Wrap(err, "error getting after project settings event")
+	}
+	return errors.Wrapf(LogProjectModified(id, userId, before, after), "error logging project modified")
+}
+
+func LogProjectModified(projectId, username string, before, after *ProjectSettings) error {
 	if before == nil || after == nil {
 		return nil
 	}

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -28,8 +28,8 @@ const (
 	username  = "me"
 )
 
-func getMockProjectSettings() ProjectSettingsEvent {
-	return ProjectSettingsEvent{
+func getMockProjectSettings() ProjectSettings {
+	return ProjectSettings{
 		ProjectRef: ProjectRef{
 			Owner:   "admin",
 			Enabled: utility.TruePtr(),

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -131,7 +131,7 @@ func (pc *DBAliasConnector) UpdateAliasesForSection(projectId string, updatedAli
 		if shouldSkipAliasForSection(section, originalAlias.Alias) {
 			continue
 		}
-		id := originalAlias.ID.String()
+		id := originalAlias.ID.Hex()
 		if _, ok := aliasesIdMap[id]; !ok {
 			catcher.Add(model.RemoveProjectAlias(id))
 		}

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
@@ -107,6 +108,49 @@ func (d *DBAliasConnector) UpdateProjectAliases(projectId string, aliases []rest
 	return catcher.Resolve()
 }
 
+// should be called in the resolver
+func (pc *DBAliasConnector) UpdateAliasesForSection(projectId string, updatedAliases []restModel.APIProjectAlias,
+	originalAliases []model.ProjectAlias, section model.ProjectRefSection) (bool, error) {
+	aliasesIdMap := map[string]bool{}
+	aliasesToUpdate := []restModel.APIProjectAlias{}
+
+	for _, a := range updatedAliases {
+		if shouldSkipAliasForSection(section, utility.FromStringPtr(a.Alias)) {
+			continue
+		}
+		aliasesToUpdate = append(aliasesToUpdate, a)
+		aliasesIdMap[utility.FromStringPtr(a.ID)] = true
+	}
+	if err := pc.UpdateProjectAliases(projectId, aliasesToUpdate); err != nil {
+		return false, errors.Wrap(err, "error updating project aliasesToUpdate")
+	}
+	catcher := grip.NewBasicCatcher()
+	// delete any aliasesToUpdate that were in the list before but are not now
+	for _, originalAlias := range originalAliases {
+		// only look at the relevant aliases to update
+		if shouldSkipAliasForSection(section, originalAlias.Alias) {
+			continue
+		}
+		id := originalAlias.ID.String()
+		if _, ok := aliasesIdMap[id]; !ok {
+			catcher.Add(model.RemoveProjectAlias(id))
+		}
+	}
+	return true, catcher.Resolve()
+}
+
+func shouldSkipAliasForSection(section model.ProjectRefSection, alias string) bool {
+	// if we're updating internal aliases, skip non-internal aliases
+	if section == model.ProjectRefGithubAndCQSection && !utility.StringSliceContains(evergreen.InternalAliases, alias) {
+		return true
+	}
+	// if we're updating patch aliases, skip internal aliases
+	if section == model.ProjectRefPatchAliasSection && utility.StringSliceContains(evergreen.InternalAliases, alias) {
+		return true
+	}
+	return false
+}
+
 //  GetMatchingGitTagAliasesForProject returns matching git tag aliases that match the given git tag
 func (d *DBAliasConnector) HasMatchingGitTagAliasAndRemotePath(projectId, tag string) (bool, string, error) {
 	aliases, err := model.FindMatchingGitTagAliasesInProject(projectId, tag)
@@ -138,6 +182,12 @@ func (d *MockAliasConnector) CopyProjectAliases(oldProjectId, newProjectId strin
 func (d *MockAliasConnector) UpdateProjectAliases(projectId string, aliases []restModel.APIProjectAlias) error {
 	return nil
 }
+
+func (pc *MockAliasConnector) UpdateAliasesForSection(projectId string, updatedAliases []restModel.APIProjectAlias,
+	originalAliases []model.ProjectAlias, section model.ProjectRefSection) (bool, error) {
+	return false, nil
+}
+
 func (d *MockAliasConnector) HasMatchingGitTagAliasAndRemotePath(projectId, tag string) (bool, string, error) {
 	if len(d.Aliases) == 1 && utility.FromStringPtr(d.Aliases[0].RemotePath) != "" {
 		return true, utility.FromStringPtr(d.Aliases[0].RemotePath), nil

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -122,7 +122,7 @@ func (pc *DBAliasConnector) UpdateAliasesForSection(projectId string, updatedAli
 		aliasesIdMap[utility.FromStringPtr(a.ID)] = true
 	}
 	if err := pc.UpdateProjectAliases(projectId, aliasesToUpdate); err != nil {
-		return false, errors.Wrap(err, "error updating project aliasesToUpdate")
+		return false, errors.Wrap(err, "error updating project aliases")
 	}
 	catcher := grip.NewBasicCatcher()
 	// delete any aliasesToUpdate that were in the list before but are not now

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -235,5 +235,5 @@ func (a *AliasSuite) TestUpdateAliasesForSection() {
 	a.True(modified)
 	aliasesFromDb, err = model.FindAliasesForProject("project_id")
 	a.NoError(err)
-	a.Len(aliasesFromDb, 3) // adds internal alias
+	a.Len(aliasesFromDb, 4) // adds internal alias
 }

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -9,6 +9,7 @@ import (
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/suite"
+	mgobson "gopkg.in/mgo.v2/bson"
 )
 
 type AliasSuite struct {
@@ -56,10 +57,11 @@ func (a *AliasSuite) SetupTest() {
 			Variant:   "variant",
 			Task:      "task",
 		},
-		{ProjectID: "repo_id",
-			Alias:   "from_repo",
-			Variant: "repo_variant",
-			Task:    "repo_task",
+		{
+			ProjectID: "repo_id",
+			Alias:     "from_repo",
+			Variant:   "repo_variant",
+			Task:      "repo_task",
 		},
 	}
 	for _, v := range aliases {
@@ -185,4 +187,53 @@ func (a *AliasSuite) TestHasMatchingGitTagAliasAndRemotePath() {
 	a.NoError(err)
 	a.True(hasAliases)
 	a.Equal("file.yml", path)
+}
+
+func (a *AliasSuite) TestUpdateAliasesForSection() {
+	originalAliases, err := model.FindAliasesForProject("project_id")
+	a.NoError(err)
+	a.Len(originalAliases, 3)
+
+	// delete one alias, add one alias, modify one alias
+	aliasToKeep := restModel.APIProjectAlias{}
+	a.NoError(aliasToKeep.BuildFromService(originalAliases[0]))
+	aliasToModify := restModel.APIProjectAlias{}
+	a.NoError(aliasToModify.BuildFromService(originalAliases[1]))
+	aliasToModify.Alias = utility.ToStringPtr("this is a new alias")
+
+	newAlias := restModel.APIProjectAlias{
+		ID:      utility.ToStringPtr(mgobson.NewObjectId().Hex()),
+		Alias:   utility.ToStringPtr("patchAlias"),
+		Variant: utility.ToStringPtr("var"),
+		Task:    utility.ToStringPtr("task"),
+	}
+	newInternalAlias := restModel.APIProjectAlias{
+		ID:      utility.ToStringPtr(mgobson.NewObjectId().Hex()),
+		Alias:   utility.ToStringPtr(evergreen.CommitQueueAlias), //internal alias shouldn't be added
+		Variant: utility.ToStringPtr("var"),
+		Task:    utility.ToStringPtr("task"),
+	}
+
+	updatedAliases := []restModel.APIProjectAlias{aliasToKeep, aliasToModify, newAlias, newInternalAlias}
+	modified, err := a.sc.UpdateAliasesForSection("project_id", updatedAliases, originalAliases, model.ProjectRefPatchAliasSection)
+	a.NoError(err)
+	a.True(modified)
+
+	aliasesFromDb, err := model.FindAliasesForProject("project_id")
+	a.NoError(err)
+	a.Len(aliasesFromDb, 3)
+	for _, alias := range aliasesFromDb {
+		a.NotEqual(alias.ID, originalAliases[2].ID)         // removed the alias that we didn't add to the new alias list
+		a.NotEqual(alias.Alias, evergreen.CommitQueueAlias) // didn't add the internal alias on the patch alias section
+		if alias.ID == originalAliases[1].ID {              // verify we modified the second alias
+			a.Equal(alias.Alias, "this is a new alias")
+		}
+	}
+
+	modified, err = a.sc.UpdateAliasesForSection("project_id", updatedAliases, originalAliases, model.ProjectRefGithubAndCQSection)
+	a.NoError(err)
+	a.True(modified)
+	aliasesFromDb, err = model.FindAliasesForProject("project_id")
+	a.NoError(err)
+	a.Len(aliasesFromDb, 3) // adds internal alias
 }

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -312,6 +312,10 @@ type Connector interface {
 	CopyProjectAliases(string, string) error
 	// UpdateProjectAliases upserts/deletes aliases for the given project
 	UpdateProjectAliases(string, []restModel.APIProjectAlias) error
+	// UpdateAliasesForSection, given a project, a list of current aliases, a list of previous aliases, and a project page section,
+	// upserts any current aliases, and deletes any aliases that existed previously but not anymore (only
+	// considers the aliases that are relevant for the section).
+	UpdateAliasesForSection(string, []restModel.APIProjectAlias, []model.ProjectAlias, model.ProjectRefSection) (bool, error)
 	// HasMatchingGitTagAliasAndRemotePath returns true if the project has aliases defined that match the given tag, and
 	// returns the remote path if applicable
 	HasMatchingGitTagAliasAndRemotePath(string, string) (bool, string, error)
@@ -328,8 +332,10 @@ type Connector interface {
 	// GeneratePoll checks to see if a `generate.tasks` job has finished.
 	GeneratePoll(context.Context, string, amboy.QueueGroup) (bool, []string, error)
 
-	// SaveSubscriptions saves a set of notification subscriptions
-	SaveSubscriptions(string, []restModel.APISubscription) error
+	// SaveSubscriptions, given an owner, a list of current subscriptions, a list of previous subscriptions, and an isProject boolean,
+	// upserts the given set of API subscriptions (if the owner is a project type, verify that all current subscriptions have
+	// the right owner and owner type) and deletes any subscriptions that existed previously but not anymore.
+	SaveSubscriptions(string, []restModel.APISubscription, bool) error
 	// GetSubscriptions returns the subscriptions that belong to a user
 	GetSubscriptions(string, event.OwnerType) ([]restModel.APISubscription, error)
 	DeleteSubscriptions(string, []string) error
@@ -375,8 +381,8 @@ type Connector interface {
 	// GetDockerStatus returns the status of the given docker container
 	GetDockerStatus(context.Context, string, *host.Host, *evergreen.Settings) (*cloud.ContainerStatus, error)
 
-	//GetProjectSettingsEvent returns the ProjectSettingsEvents of the given identifier and ProjectRef
-	GetProjectSettingsEvent(p *model.ProjectRef) (*model.ProjectSettingsEvent, error)
+	//GetProjectSettings returns the ProjectSettings of the given identifier and ProjectRef
+	GetProjectSettings(p *model.ProjectRef) (*model.ProjectSettings, error)
 
 	// CompareTasks returns the order that the given tasks would be scheduled, along with the scheduling logic.
 	CompareTasks([]string, bool) ([]string, map[string]map[string]string, error)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -144,7 +144,6 @@ func (pc *DBProjectConnector) SaveProjectSettingsForSection(ctx context.Context,
 		modified = true
 	}
 
-	// How do we know here if ProjectRef should be nil or not? Or should we just pass in the project and update regardless of whether or not it's changed (like the API route?)
 	modifiedProjectRef, err := model.SaveProjectRefForSection(projectId, newProjectRef, section)
 	if err != nil {
 		return errors.Wrapf(err, "error defaulting project ref to repo for section '%s'", section)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -84,6 +84,7 @@ func (pc *DBProjectConnector) UpdateRepo(repoRef *model.RepoRef) error {
 // related to the specified section. This handles project ref, webhooks, auth, and project variables.
 func (pc *DBProjectConnector) SaveProjectSettingsForSection(ctx context.Context, projectId string, changes *restModel.APIProjectSettings,
 	section model.ProjectRefSection, userId string) error {
+	// TODO: this function should only be called after project setting changes have been validated in the resolver or by the front end
 	before, err := model.GetProjectSettingsById(projectId)
 	if err != nil {
 		return errors.Wrap(err, "error getting before project settings event")
@@ -141,7 +142,7 @@ func (pc *DBProjectConnector) SaveProjectSettingsForSection(ctx context.Context,
 			return errors.Wrapf(err, "Database error updating variables for project '%s'", projectId)
 		}
 	}
-	// save project ref only after the rest of the section has been validated.
+
 	// How do we know here if ProjectRef should be nil or not? Or should we just pass in the project and update regardless of whether or not it's changed (like the API route?)
 	modifiedProjectRef, err := model.SaveProjectRefForSection(projectId, newProjectRef, section)
 	if err != nil {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -113,6 +113,7 @@ func (pc *DBProjectConnector) SaveProjectSettingsForSection(ctx context.Context,
 				return errors.Wrapf(err, "Error enabling webhooks for project '%s'", projectId)
 			}
 		}
+		modified = true
 	case model.ProjectRefAccessSection:
 		// For any admins that are only in the original settings, remove access.
 		// For any admins that are only in the updated settings, give them access.
@@ -141,6 +142,7 @@ func (pc *DBProjectConnector) SaveProjectSettingsForSection(ctx context.Context,
 		if err = pc.UpdateProjectVars(projectId, &changes.Vars, false); err != nil { // destructively modifies vars
 			return errors.Wrapf(err, "Database error updating variables for project '%s'", projectId)
 		}
+		modified = true
 	}
 
 	// How do we know here if ProjectRef should be nil or not? Or should we just pass in the project and update regardless of whether or not it's changed (like the API route?)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -130,8 +130,7 @@ func (pc *DBProjectConnector) SaveProjectSettingsForSection(ctx context.Context,
 		}
 
 	case model.ProjectRefVariablesSection:
-		// Remove any variables that only exist in the original settings. (It's possible we can send this information
-		// from the UI in the future instead)
+		// Remove any variables that only exist in the original settings.
 		toDelete := []string{}
 		for key, _ := range before.Vars.Vars {
 			if _, ok := changes.Vars.Vars[key]; !ok {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -80,6 +80,81 @@ func (pc *DBProjectConnector) UpdateRepo(repoRef *model.RepoRef) error {
 	return nil
 }
 
+// SaveProjectSettingsForSection passes in the existing state of the project page, but saves only the pieces
+// related to the specified section. This handles project ref, webhooks, auth, and project variables.
+func (pc *DBProjectConnector) SaveProjectSettingsForSection(ctx context.Context, projectId string, changes *restModel.APIProjectSettings,
+	section model.ProjectRefSection, userId string) error {
+	before, err := model.GetProjectSettingsById(projectId)
+	if err != nil {
+		return errors.Wrap(err, "error getting before project settings event")
+	}
+	v, err := changes.ProjectRef.ToService()
+	if err != nil {
+		return errors.Wrap(err, "error converting project ref")
+	}
+	newProjectRef := v.(*model.ProjectRef)
+	// if the project ref doesn't use the repo, then this will just be the same as newProjectRef
+	// used to verify that if something is set to nil in the request, we properly validate using the merged project ref
+	mergedProjectRef, err := model.GetProjectRefMergedWithRepo(*newProjectRef)
+	if err != nil {
+		return errors.Wrapf(err, "error merging project ref")
+	}
+
+	catcher := grip.NewBasicCatcher()
+	modified := false
+	switch section {
+	// aliases and notifications use a different connector and should be handled separated
+	case model.ProjectRefGeneralSection:
+		// check if webhook is enabled if the owner/repo has changed
+		if mergedProjectRef.Owner != before.ProjectRef.Owner || mergedProjectRef.Repo != before.ProjectRef.Repo {
+			_, err = pc.EnableWebhooks(ctx, mergedProjectRef)
+			if err != nil {
+				return errors.Wrapf(err, "Error enabling webhooks for project '%s'", projectId)
+			}
+		}
+	case model.ProjectRefAccessSection:
+		// For any admins that are only in the original settings, remove access.
+		// For any admins that are only in the updated settings, give them access.
+		adminsToDelete, adminsToAdd := utility.StringSliceSymmetricDifference(before.ProjectRef.Admins, mergedProjectRef.Admins)
+		if err = pc.UpdateAdminRoles(newProjectRef, adminsToAdd, adminsToDelete); err != nil {
+			return errors.Wrap(err, "error updating admin roles")
+		}
+		modified = true
+		if !before.ProjectRef.IsRestricted() && mergedProjectRef.IsRestricted() {
+			catcher.Wrap(before.ProjectRef.MakeRestricted(), "error making project restricted")
+		}
+		if before.ProjectRef.IsRestricted() && !mergedProjectRef.IsRestricted() {
+			catcher.Wrap(before.ProjectRef.MakeUnrestricted(), "error making unrestricted")
+		}
+
+	case model.ProjectRefVariablesSection:
+		// Remove any variables that only exist in the original settings. (It's possible we can send this information
+		// from the UI in the future instead)
+		toDelete := []string{}
+		for key, _ := range before.Vars.Vars {
+			if _, ok := changes.Vars.Vars[key]; !ok {
+				toDelete = append(toDelete, key)
+			}
+		}
+		changes.Vars.VarsToDelete = toDelete
+		if err = pc.UpdateProjectVars(projectId, &changes.Vars, false); err != nil { // destructively modifies vars
+			return errors.Wrapf(err, "Database error updating variables for project '%s'", projectId)
+		}
+	}
+	// save project ref only after the rest of the section has been validated.
+	// How do we know here if ProjectRef should be nil or not? Or should we just pass in the project and update regardless of whether or not it's changed (like the API route?)
+	modifiedProjectRef, err := model.SaveProjectRefForSection(projectId, newProjectRef, section)
+	if err != nil {
+		return errors.Wrapf(err, "error defaulting project ref to repo for section '%s'", section)
+	}
+
+	if modified || modifiedProjectRef {
+		catcher.Add(model.GetAndLogProjectModified(projectId, userId, before))
+	}
+
+	return errors.Wrapf(catcher.Resolve(), "error saving section '%s'", section)
+}
+
 func (pc *DBProjectConnector) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string, token string) (*model.Project, *model.ParserProject, error) {
 	opts := model.GetProjectOpts{
 		Ref:        &pRef,
@@ -276,7 +351,7 @@ func (pc *DBProjectConnector) UpdateProjectVarsByValue(toReplace, replacement, u
 					for k, v := range project.Vars {
 						originalVars[k] = v
 					}
-					before := model.ProjectSettingsEvent{
+					before := model.ProjectSettings{
 						Vars: model.ProjectVars{
 							Id:   project.Id,
 							Vars: originalVars,
@@ -289,7 +364,7 @@ func (pc *DBProjectConnector) UpdateProjectVarsByValue(toReplace, replacement, u
 						catcher.Wrapf(err, "problem overwriting variables for project '%s'", project.Id)
 					}
 
-					after := model.ProjectSettingsEvent{
+					after := model.ProjectSettings{
 						Vars: model.ProjectVars{
 							Id:   project.Id,
 							Vars: project.Vars,
@@ -361,8 +436,8 @@ func (ac *DBProjectConnector) FindEnabledProjectRefsByOwnerAndRepo(owner, repo s
 	return model.FindMergedEnabledProjectRefsByOwnerAndRepo(owner, repo)
 }
 
-func (pc *DBProjectConnector) GetProjectSettingsEvent(p *model.ProjectRef) (*model.ProjectSettingsEvent, error) {
-	return model.GetProjectSettingsEvents(p)
+func (pc *DBProjectConnector) GetProjectSettings(p *model.ProjectRef) (*model.ProjectSettings, error) {
+	return model.GetProjectSettings(p)
 }
 
 func (pc *DBProjectConnector) GetProjectAliasResults(p *model.Project, alias string, includeDeps bool) ([]restModel.APIVariantTasks, error) {
@@ -658,11 +733,11 @@ func (pc *MockProjectConnector) UpdateProjectRevision(projectID, revision string
 	return nil
 }
 
-func (pc *MockProjectConnector) GetProjectSettingsEvent(p *model.ProjectRef) (*model.ProjectSettingsEvent, error) {
+func (pc *MockProjectConnector) GetProjectSettings(p *model.ProjectRef) (*model.ProjectSettings, error) {
 	if len(p.Owner) == 0 || len(p.Repo) == 0 {
 		return nil, errors.New("Owner and repository must not be empty strings")
 	}
-	return &model.ProjectSettingsEvent{}, nil
+	return &model.ProjectSettings{}, nil
 }
 
 func (pc *MockProjectConnector) GetProjectAliasResults(*model.Project, string, bool) ([]restModel.APIVariantTasks, error) {

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -5,15 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/model/user"
-
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/gimlet"
-
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/user"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -643,7 +643,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			Admins:          []string{"oldAdmin"},
 		}
 		assert.NoError(t, pRef.Insert())
-		repoRef := model.RepoRef{model.ProjectRef{
+		repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
 			Id:         pRef.RepoRefId,
 			Restricted: utility.TruePtr(),
 		}}

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -1,8 +1,14 @@
 package data
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"github.com/evergreen-ci/evergreen/model/user"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/gimlet"
 
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
@@ -33,8 +39,8 @@ const (
 	projEventCount = 10
 )
 
-func getMockProjectSettings() model.ProjectSettingsEvent {
-	return model.ProjectSettingsEvent{
+func getMockProjectSettings() model.ProjectSettings {
+	return model.ProjectSettings{
 		ProjectRef: model.ProjectRef{
 			Owner:   "admin",
 			Enabled: utility.TruePtr(),
@@ -348,7 +354,7 @@ func (s *ProjectConnectorGetSuite) TestGetProjectWithCommitQueueByOwnerRepoAndBr
 	s.NotNil(projRef)
 }
 
-func (s *ProjectConnectorGetSuite) TestGetProjectSettingsEvent() {
+func (s *ProjectConnectorGetSuite) TestGetProjectSettings() {
 	projRef := &model.ProjectRef{
 		Owner:   "admin",
 		Enabled: utility.TruePtr(),
@@ -357,12 +363,12 @@ func (s *ProjectConnectorGetSuite) TestGetProjectSettingsEvent() {
 		Admins:  []string{},
 		Repo:    "SomeRepo",
 	}
-	projectSettingsEvent, err := s.ctx.GetProjectSettingsEvent(projRef)
+	projectSettingsEvent, err := s.ctx.GetProjectSettings(projRef)
 	s.NoError(err)
 	s.NotNil(projectSettingsEvent)
 }
 
-func (s *ProjectConnectorGetSuite) TestGetProjectSettingsEventNoRepo() {
+func (s *ProjectConnectorGetSuite) TestGetProjectSettingsNoRepo() {
 	projRef := &model.ProjectRef{
 		Owner:   "admin",
 		Enabled: utility.TruePtr(),
@@ -370,7 +376,7 @@ func (s *ProjectConnectorGetSuite) TestGetProjectSettingsEventNoRepo() {
 		Id:      projectId,
 		Admins:  []string{},
 	}
-	projectSettingsEvent, err := s.ctx.GetProjectSettingsEvent(projRef)
+	projectSettingsEvent, err := s.ctx.GetProjectSettings(projRef)
 	s.NotNil(err)
 	s.Nil(projectSettingsEvent)
 }
@@ -536,4 +542,164 @@ func TestGetProjectAliasResults(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, variantTasks, 1)
 	assert.Len(t, variantTasks[0].Tasks, 2)
+}
+
+func TestSaveProjectSettingsForSection(t *testing.T) {
+	dc := &DBProjectConnector{}
+	ctx := context.Background()
+	rm := evergreen.GetEnvironment().RoleManager()
+
+	for name, test := range map[string]func(t *testing.T, ref model.ProjectRef){
+		model.ProjectRefGeneralSection: func(t *testing.T, ref model.ProjectRef) {
+			assert.Empty(t, ref.SpawnHostScriptPath)
+
+			ref.SpawnHostScriptPath = "my script path"
+			apiProjectRef := restModel.APIProjectRef{}
+			assert.NoError(t, apiProjectRef.BuildFromService(ref))
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			// ensure that we're saving settings without a special case
+			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectRefGeneralSection, "me"))
+			pRefFromDB, err := model.FindOneProjectRef(ref.Id)
+			assert.NoError(t, err)
+			assert.NotNil(t, pRefFromDB)
+			assert.NotEmpty(t, pRefFromDB.SpawnHostScriptPath)
+		},
+		model.ProjectRefAccessSection: func(t *testing.T, ref model.ProjectRef) {
+			newAdmin := user.DBUser{
+				Id: "newAdmin",
+			}
+			require.NoError(t, newAdmin.Insert())
+			ref.Restricted = nil // should now default to the repo value
+			ref.Admins = []string{"oldAdmin", newAdmin.Id}
+			apiProjectRef := restModel.APIProjectRef{}
+			assert.NoError(t, apiProjectRef.BuildFromService(ref))
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectRefAccessSection, "me"))
+			pRefFromDB, err := model.FindOneProjectRef(ref.Id)
+			assert.NoError(t, err)
+			assert.NotNil(t, pRefFromDB)
+			assert.Nil(t, pRefFromDB.Restricted)
+			assert.Equal(t, pRefFromDB.Admins, ref.Admins)
+
+			mergedProject, err := model.FindMergedProjectRef(ref.Id)
+			assert.NoError(t, err)
+			assert.NotNil(t, mergedProject)
+			assert.True(t, mergedProject.IsRestricted())
+
+			restrictedScope, err := rm.GetScope(ctx, evergreen.RestrictedProjectsScope)
+			assert.NoError(t, err)
+			assert.NotNil(t, restrictedScope)
+			assert.Contains(t, restrictedScope.Resources, ref.Id)
+
+			unrestrictedScope, err := rm.GetScope(ctx, evergreen.UnrestrictedProjectsScope)
+			assert.NoError(t, err)
+			assert.NotNil(t, unrestrictedScope)
+			assert.NotContains(t, unrestrictedScope.Resources, ref.Id)
+
+			newAdminFromDB, err := user.FindOneById("newAdmin")
+			assert.NoError(t, err)
+			assert.NotNil(t, newAdminFromDB)
+			assert.Contains(t, newAdminFromDB.Roles(), "admin")
+		},
+		model.ProjectRefVariablesSection: func(t *testing.T, ref model.ProjectRef) {
+			// remove a variable, modify a variable, add a variable
+			updatedVars := &model.ProjectVars{
+				Id:          ref.Id,
+				Vars:        map[string]string{"it": "me", "banana": "phone"},
+				PrivateVars: map[string]bool{"banana": true},
+			}
+			apiProjectVars := restModel.APIProjectVars{}
+			assert.NoError(t, apiProjectVars.BuildFromService(updatedVars))
+			apiChanges := &restModel.APIProjectSettings{
+				Vars: apiProjectVars,
+			}
+			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectRefVariablesSection, "me"))
+			varsFromDb, err := model.FindOneProjectVars(updatedVars.Id)
+			assert.NoError(t, err)
+			assert.NotNil(t, varsFromDb)
+			assert.Equal(t, varsFromDb.Vars["it"], "me")
+			assert.Equal(t, varsFromDb.Vars["banana"], "phone")
+			assert.Equal(t, varsFromDb.Vars["hello"], "")
+			assert.False(t, varsFromDb.PrivateVars["it"])
+			assert.False(t, varsFromDb.PrivateVars["hello"])
+			assert.True(t, varsFromDb.PrivateVars["banana"])
+		},
+	} {
+		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
+			event.SubscriptionsCollection, event.AllLogCollection, evergreen.ScopeCollection, user.Collection))
+		_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+
+		pRef := model.ProjectRef{
+			Id:              "myId",
+			Owner:           "evergreen-ci",
+			Repo:            "evergreen",
+			Restricted:      utility.FalsePtr(),
+			UseRepoSettings: true,
+			RepoRefId:       "myRepoId",
+			Admins:          []string{"oldAdmin"},
+		}
+		assert.NoError(t, pRef.Insert())
+		repoRef := model.RepoRef{model.ProjectRef{
+			Id:         pRef.RepoRefId,
+			Restricted: utility.TruePtr(),
+		}}
+		assert.NoError(t, repoRef.Upsert())
+
+		pVars := model.ProjectVars{
+			Id:          pRef.Id,
+			Vars:        map[string]string{"hello": "world", "it": "adele"},
+			PrivateVars: map[string]bool{"hello": true},
+		}
+		assert.NoError(t, pVars.Insert())
+		// add scopes
+		allProjectsScope := gimlet.Scope{
+			ID:        evergreen.AllProjectsScope,
+			Resources: []string{},
+		}
+		assert.NoError(t, rm.AddScope(allProjectsScope))
+		restrictedScope := gimlet.Scope{
+			ID:          evergreen.RestrictedProjectsScope,
+			Resources:   []string{repoRef.Id},
+			ParentScope: evergreen.AllProjectsScope,
+		}
+		assert.NoError(t, rm.AddScope(restrictedScope))
+		unrestrictedScope := gimlet.Scope{
+			ID:          evergreen.UnrestrictedProjectsScope,
+			Resources:   []string{pRef.Id},
+			ParentScope: evergreen.AllProjectsScope,
+		}
+		assert.NoError(t, rm.AddScope(unrestrictedScope))
+		adminScope := gimlet.Scope{
+			ID:        "project_scope",
+			Resources: []string{pRef.Id},
+			Type:      evergreen.ProjectResourceType,
+		}
+		assert.NoError(t, rm.AddScope(adminScope))
+
+		adminRole := gimlet.Role{
+			ID:    "admin",
+			Scope: adminScope.ID,
+			Permissions: gimlet.Permissions{
+				evergreen.PermissionProjectSettings: evergreen.ProjectSettingsEdit.Value,
+				evergreen.PermissionTasks:           evergreen.TasksAdmin.Value,
+				evergreen.PermissionPatches:         evergreen.PatchSubmit.Value,
+				evergreen.PermissionLogs:            evergreen.LogsView.Value,
+			},
+		}
+		require.NoError(t, rm.UpdateRole(adminRole))
+		oldAdmin := user.DBUser{
+			Id:          "oldAdmin",
+			SystemRoles: []string{"admin"},
+		}
+		require.NoError(t, oldAdmin.Insert())
+
+		t.Run(name, func(t *testing.T) {
+			test(t, pRef)
+		})
+	}
+
 }

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -17,7 +17,7 @@ import (
 
 type DBSubscriptionConnector struct{}
 
-func (dc *DBSubscriptionConnector) SaveSubscriptions(owner string, subscriptions []restModel.APISubscription) error {
+func (dc *DBSubscriptionConnector) SaveSubscriptions(owner string, subscriptions []restModel.APISubscription, isProjectOwner bool) error {
 	dbSubscriptions := []event.Subscription{}
 	for _, subscription := range subscriptions {
 		subscriptionInterface, err := subscription.ToService()
@@ -33,6 +33,10 @@ func (dc *DBSubscriptionConnector) SaveSubscriptions(owner string, subscriptions
 				StatusCode: http.StatusInternalServerError,
 				Message:    "Error parsing subscription interface",
 			}
+		}
+		if isProjectOwner {
+			dbSubscription.OwnerType = event.OwnerTypeProject
+			dbSubscription.Owner = owner
 		}
 
 		if !trigger.ValidateTrigger(dbSubscription.ResourceType, dbSubscription.Trigger) {
@@ -218,7 +222,7 @@ func (mc *MockSubscriptionConnector) GetSubscriptions(owner string, ownerType ev
 	return mc.MockSubscriptions, nil
 }
 
-func (mc *MockSubscriptionConnector) SaveSubscriptions(owner string, subscriptions []restModel.APISubscription) error {
+func (mc *MockSubscriptionConnector) SaveSubscriptions(owner string, subscriptions []restModel.APISubscription, isProjectOwner bool) error {
 	for _, sub := range subscriptions {
 		mc.MockSubscriptions = append(mc.MockSubscriptions, sub)
 	}

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -81,15 +81,15 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 	for name, test := range map[string]func(t *testing.T, subs []restModel.APISubscription){
 		"InvalidSubscription": func(t *testing.T, subs []restModel.APISubscription) {
 			subs[0].RegexSelectors[0].Data = utility.ToStringPtr("")
-			assert.Error(t, c.SaveSubscriptions("me", []restModel.APISubscription{subs[0]}))
+			assert.Error(t, c.SaveSubscriptions("me", []restModel.APISubscription{subs[0]}, false))
 		},
 		"ValidSubscription": func(t *testing.T, subs []restModel.APISubscription) {
-			assert.NoError(t, c.SaveSubscriptions("me", []restModel.APISubscription{subs[0]}))
+			assert.NoError(t, c.SaveSubscriptions("me", []restModel.APISubscription{subs[0]}, false))
 		},
 		"ModifyExistingSubscription": func(t *testing.T, subs []restModel.APISubscription) {
 			newData := utility.ToStringPtr("5678")
 			subs[1].Selectors[0].Data = newData
-			assert.NoError(t, c.SaveSubscriptions("my-project", []restModel.APISubscription{subs[1]}))
+			assert.NoError(t, c.SaveSubscriptions("my-project", []restModel.APISubscription{subs[1]}, true))
 
 			dbSubs, err := c.GetSubscriptions("my-project", event.OwnerTypeProject)
 			assert.NoError(t, err)

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -78,7 +78,7 @@ func (e *APIProjectEvent) ToService() (interface{}, error) {
 	return nil, errors.New("ToService not implemented for APIProjectEvent")
 }
 
-func DbProjectSettingsToRestModel(settings model.ProjectSettingsEvent) (APIProjectSettings, error) {
+func DbProjectSettingsToRestModel(settings model.ProjectSettings) (APIProjectSettings, error) {
 	apiProjectRef := APIProjectRef{}
 	if err := apiProjectRef.BuildFromService(settings.ProjectRef); err != nil {
 		return APIProjectSettings{}, err

--- a/rest/model/project_event_test.go
+++ b/rest/model/project_event_test.go
@@ -16,8 +16,8 @@ const (
 	username  = "me"
 )
 
-func getMockProjectSettings() model.ProjectSettingsEvent {
-	return model.ProjectSettingsEvent{
+func getMockProjectSettings() model.ProjectSettings {
+	return model.ProjectSettings{
 		ProjectRef: model.ProjectRef{
 			Owner:   "admin",
 			Enabled: utility.TruePtr(),

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -162,7 +162,7 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "can't make subscription"))
 		}
-		if err = h.sc.SaveSubscriptions(user.Username(), []model.APISubscription{subscription}); err != nil {
+		if err = h.sc.SaveSubscriptions(user.Username(), []model.APISubscription{subscription}, false); err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "can't save subscription"))
 		}
 	}
@@ -306,7 +306,7 @@ func (h *hostStopHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "can't make subscription"))
 		}
-		if err = h.sc.SaveSubscriptions(user.Username(), []model.APISubscription{subscription}); err != nil {
+		if err = h.sc.SaveSubscriptions(user.Username(), []model.APISubscription{subscription}, false); err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "can't save subscription"))
 		}
 	}
@@ -388,7 +388,7 @@ func (h *hostStartHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "can't make subscription"))
 		}
-		if err = h.sc.SaveSubscriptions(user.Username(), []model.APISubscription{subscription}); err != nil {
+		if err = h.sc.SaveSubscriptions(user.Username(), []model.APISubscription{subscription}, false); err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "can't save subscription"))
 		}
 	}

--- a/rest/route/subscription.go
+++ b/rest/route/subscription.go
@@ -44,7 +44,7 @@ func (s *subscriptionPostHandler) Parse(ctx context.Context, r *http.Request) er
 }
 
 func (s *subscriptionPostHandler) Run(ctx context.Context) gimlet.Responder {
-	err := s.sc.SaveSubscriptions(MustHaveUser(ctx).Username(), *s.Subscriptions)
+	err := s.sc.SaveSubscriptions(MustHaveUser(ctx).Username(), *s.Subscriptions, false)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}

--- a/service/project.go
+++ b/service/project.go
@@ -729,7 +729,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 
 	username := dbUser.DisplayName()
 
-	before := &model.ProjectSettingsEvent{
+	before := &model.ProjectSettings{
 		ProjectRef:         origProjectRef,
 		GitHubHooksEnabled: origGithubWebhookEnabled,
 		Vars:               origProjectVars,
@@ -739,7 +739,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 
 	currentAliases, _ := model.FindAliasesForProject(id)
 	currentSubscriptions, _ := event.FindSubscriptionsByOwner(projectRef.Id, event.OwnerTypeProject)
-	after := &model.ProjectSettingsEvent{
+	after := &model.ProjectSettings{
 		ProjectRef:         *projectRef,
 		GitHubHooksEnabled: hook != nil,
 		Vars:               *projectVars,


### PR DESCRIPTION
[EVG-15060](https://jira.mongodb.org/browse/EVG-15060)

### Description 
In order to use the existing connectors for this function, we need to split the operations by the type of connector it's part of. I made GetProjectSettingsBySection to handle all of the DBProjectConnector operations, and then separately made a new alias function and modified the subscription function, so these can all be called by the resolver. 
(The alternative to this would be to move all the logic for the connectors into model functions and not use connectors at all, but I think that's messier in the long run.)

### Testing 
Added tests to the new project settings function and the alias function.