### PR TITLE
EVG-15294 Support pagination for mainline commit waterfall builds.

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -311,6 +311,7 @@ type ComplexityRoot struct {
 
 	MainlineCommits struct {
 		NextPageOrderNumber func(childComplexity int) int
+		PrevPageOrderNumber func(childComplexity int) int
 		Versions            func(childComplexity int) int
 	}
 
@@ -2091,6 +2092,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.MainlineCommits.NextPageOrderNumber(childComplexity), true
+
+	case "MainlineCommits.prevPageOrderNumber":
+		if e.complexity.MainlineCommits.PrevPageOrderNumber == nil {
+			break
+		}
+
+		return e.complexity.MainlineCommits.PrevPageOrderNumber(childComplexity), true
 
 	case "MainlineCommits.versions":
 		if e.complexity.MainlineCommits.Versions == nil {
@@ -5268,6 +5276,7 @@ type Mutation {
 # nextPage represents the last activated order number returned
 type MainlineCommits {
   nextPageOrderNumber: Int
+  prevPageOrderNumber: Int
   versions: [MainlineCommitVersion!]!
 }
 
@@ -12473,6 +12482,37 @@ func (ec *executionContext) _MainlineCommits_nextPageOrderNumber(ctx context.Con
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.NextPageOrderNumber, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _MainlineCommits_prevPageOrderNumber(ctx context.Context, field graphql.CollectedField, obj *MainlineCommits) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "MainlineCommits",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PrevPageOrderNumber, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -28712,6 +28752,8 @@ func (ec *executionContext) _MainlineCommits(ctx context.Context, sel ast.Select
 			out.Values[i] = graphql.MarshalString("MainlineCommits")
 		case "nextPageOrderNumber":
 			out.Values[i] = ec._MainlineCommits_nextPageOrderNumber(ctx, field, obj)
+		case "prevPageOrderNumber":
+			out.Values[i] = ec._MainlineCommits_prevPageOrderNumber(ctx, field, obj)
 		case "versions":
 			out.Values[i] = ec._MainlineCommits_versions(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -105,6 +105,7 @@ type MainlineCommitVersion struct {
 
 type MainlineCommits struct {
 	NextPageOrderNumber *int                     `json:"nextPageOrderNumber"`
+	PrevPageOrderNumber *int                     `json:"prevPageOrderNumber"`
 	Versions            []*MainlineCommitVersion `json:"versions"`
 }
 

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1322,7 +1322,7 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 			}))
 		}
 
-		if cedarBaseTestResults != nil && len(cedarBaseTestResults) > 0 {
+		if len(cedarBaseTestResults) > 0 {
 			for _, t := range cedarBaseTestResults {
 				baseTestStatusMap[t.TestName] = t.Status
 				baseTestStatusMap[t.DisplayTestName] = t.Status
@@ -1359,7 +1359,7 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 	var totalTestCount int
 	var filteredTestCount int
 
-	if cedarTestResults != nil && len(cedarTestResults) > 0 {
+	if len(cedarTestResults) > 0 {
 		filteredTestResults, testCount := FilterSortAndPaginateCedarTestResults(FilterSortAndPaginateCedarTestResultsOpts{
 			GroupID:          groupIdParam,
 			Limit:            limitParam,
@@ -2846,6 +2846,24 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 	})
 	var mainlineCommits MainlineCommits
 	activatedVersionCount := 0
+
+	mostRecentVersion, err := model.GetMostRecentMainlineCommit(projectId)
+
+	if err != nil {
+		// This shouldn't realy happen, but if it does, we should return an error and log it
+		grip.Warning(message.WrapError(err, message.Fields{
+			"message":   "Error getting most recent version",
+			"projectId": projectId,
+		}))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting most recent mainline commit: %s", err.Error()))
+	}
+
+	// If a commit is the most recent version, we return nil for PrevPageOrderNumber since there aren't any other newer versions
+	if mostRecentVersion.RevisionOrderNumber != versions[0].RevisionOrderNumber {
+		// PrevPageOrderNumber is the order number of the first commit on the screen + the amount of commits on the previous page
+		mainlineCommits.PrevPageOrderNumber = utility.ToIntPtr(versions[0].RevisionOrderNumber + limit)
+	}
+
 	for _, v := range versions {
 		if activatedVersionCount == limit {
 			break
@@ -2856,42 +2874,24 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error building APIVersion from service: %s", err.Error()))
 		}
 
-		// If we try to access a version that does not have the Activated flag we must manually verify it
-		// After we verify if a version is activated we cache that field so subsequent queries are faster.
+		// If the version was created before we started caching activation status we must manually verify it and cache that value.
 		if v.Activated == nil {
-			defaultSort := []task.TasksSortOrder{
-				{Key: task.DisplayNameKey, Order: 1},
-			}
-			opts := data.TaskFilterOptions{
-				Sorts: defaultSort,
-			}
-			tasks, _, err := r.sc.FindTasksByVersion(v.Id, opts)
+			err = setVersionActivationStatus(r.sc, &v)
 			if err != nil {
-				return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error fetching tasks for version %s : %s", v.Id, err.Error()))
-			}
-			if !task.AnyActiveTasks(tasks) {
-				err = v.SetNotActivated()
-				if err != nil {
-					return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error updating version activated status for %s, %s", v.Id, err.Error()))
-				}
-			} else {
-				err = v.SetActivated()
-				if err != nil {
-					return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error updating version activated status for %s, %s", v.Id, err.Error()))
-				}
+				return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error setting version activation status: %s", err.Error()))
 			}
 		}
 		mainlineCommitVersion := MainlineCommitVersion{}
 
 		// If a version is activated we append it directly to our returned list of mainlineCommits
-		// If a version is not activated we roll up all the unactivated versions that are sequentially near each other
-		// into a single MainlineCommitVersion and then append it to our returned list
 		if utility.FromBoolPtr(v.Activated) {
 			activatedVersionCount++
-			mainlineCommits.NextPageOrderNumber = &v.RevisionOrderNumber
+			mainlineCommits.NextPageOrderNumber = utility.ToIntPtr(v.RevisionOrderNumber)
 			mainlineCommitVersion.Version = &apiVersion
 
 		} else {
+			// If a version is not activated we roll up all the unactivated versions that are sequentially near each other
+			// into a single MainlineCommitVersion and then append it to our returned list
 			// If we have any versions already we should check the most recent one first otherwise create a new one
 			if len(mainlineCommits.Versions) > 0 {
 				lastMainlineCommit := mainlineCommits.Versions[len(mainlineCommits.Versions)-1]
@@ -2910,7 +2910,7 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 
 		}
 
-		// Only add a mainlineCommit if a new one was added and its not a modified existing RolledUpVersion
+		// Only add a mainlineCommit if a new one was added and it's not a modified existing RolledUpVersion
 		if mainlineCommitVersion.Version != nil || mainlineCommitVersion.RolledUpVersions != nil {
 			mainlineCommits.Versions = append(mainlineCommits.Versions, &mainlineCommitVersion)
 		}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -144,7 +144,8 @@ type Mutation {
 }
 
 # Array of activated and unactivated versions
-# nextPage represents the last activated order number returned
+# nextPageOrderNumber represents the last order number returned and is used for pagination
+# prevPageOrderNumber represents the order number of the previous page and is also used for pagination
 type MainlineCommits {
   nextPageOrderNumber: Int
   prevPageOrderNumber: Int

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -147,6 +147,7 @@ type Mutation {
 # nextPage represents the last activated order number returned
 type MainlineCommits {
   nextPageOrderNumber: Int
+  prevPageOrderNumber: Int
   versions: [MainlineCommitVersion!]!
 }
 

--- a/graphql/tests/mainlineCommits/queries/pagination.graphql
+++ b/graphql/tests/mainlineCommits/queries/pagination.graphql
@@ -4,6 +4,7 @@
       version {
         id
         author
+        order
         buildVariants(options: {}) {
           variant
           displayName
@@ -17,8 +18,11 @@
       rolledUpVersions {
         id
         activated
+        order
       }
     }
+    nextPageOrderNumber
+    prevPageOrderNumber
   }
   page2: mainlineCommits(
     options: { projectID: "evergreen", limit: 1, skipOrderNumber: 5 }
@@ -27,6 +31,7 @@
       version {
         id
         author
+        order
         buildVariants(options: {}) {
           variant
           displayName
@@ -40,7 +45,37 @@
       rolledUpVersions {
         id
         activated
+        order
       }
     }
+  nextPageOrderNumber
+  prevPageOrderNumber
+  }
+    prevPage: mainlineCommits(
+    options: { projectID: "evergreen", limit: 1, skipOrderNumber: 6 }
+  ) {
+    versions {
+      version {
+        id
+        author
+        order
+        buildVariants(options: {}) {
+          variant
+          displayName
+          tasks {
+            id
+            displayName
+            status
+          }
+        }
+      }
+      rolledUpVersions {
+        id
+        activated
+        order
+      }
+    }
+  nextPageOrderNumber
+  prevPageOrderNumber
   }
 }

--- a/graphql/tests/mainlineCommits/results.json
+++ b/graphql/tests/mainlineCommits/results.json
@@ -236,6 +236,7 @@
                         "version": {
                            "id": "evergreen_version5",
                            "author": "mohamed.khelif",
+                           "order": 5,
                            "buildVariants": [
                               {
                                  "variant": "enterprise-ubuntu1604-64",
@@ -252,7 +253,9 @@
                         },
                         "rolledUpVersions": null
                      }
-                  ]
+                  ],
+                  "nextPageOrderNumber": 5,
+                  "prevPageOrderNumber": null
                },
                "page2": {
                   "versions": [
@@ -261,11 +264,13 @@
                         "rolledUpVersions": [
                            {
                               "id": "evergreen_version4",
-                              "activated": false
+                              "activated": false,
+                              "order": 4
                            },
                            {
                               "id": "evergreen_version3",
-                              "activated": false
+                              "activated": false,
+                              "order": 3
                            }
                         ]
                      },
@@ -273,6 +278,7 @@
                         "version": {
                            "id": "evergreen_version2",
                            "author": "mohamed.khelif",
+                           "order": 2,
                            "buildVariants": [
                               {
                                  "variant": "enterprise-ubuntu1604-64",
@@ -294,7 +300,36 @@
                         },
                         "rolledUpVersions": null
                      }
-                  ]
+                  ],
+                  "nextPageOrderNumber": 2,
+                  "prevPageOrderNumber": 5
+               },
+               "prevPage": {
+                  "versions": [
+                     {
+                        "version": {
+                           "id": "evergreen_version5",
+                           "author": "mohamed.khelif",
+                           "order": 5,
+                           "buildVariants": [
+                              {
+                                 "variant": "enterprise-ubuntu1604-64",
+                                 "displayName": "Ubuntu 16.04",
+                                 "tasks": [
+                                    {
+                                       "id": "task_5",
+                                       "displayName": "Some Other Task",
+                                       "status": "success"
+                                    }
+                                 ]
+                              }
+                           ]
+                        },
+                        "rolledUpVersions": null
+                     }
+                  ],
+                  "nextPageOrderNumber": 5,
+                  "prevPageOrderNumber": null
                }
             }
          }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1307,3 +1307,28 @@ func applyVolumeOptions(ctx context.Context, volume host.Volume, volumeOptions r
 	}
 	return nil
 }
+
+func setVersionActivationStatus(sc data.Connector, version *model.Version) error {
+	defaultSort := []task.TasksSortOrder{
+		{Key: task.DisplayNameKey, Order: 1},
+	}
+	opts := data.TaskFilterOptions{
+		Sorts: defaultSort,
+	}
+	tasks, _, err := sc.FindTasksByVersion(version.Id, opts)
+	if err != nil {
+		return errors.Wrapf(err, "error getting tasks for version %s", version.Id)
+	}
+	if !task.AnyActiveTasks(tasks) {
+		err = version.SetNotActivated()
+		if err != nil {
+			return errors.Wrapf(err, fmt.Sprintf("Error updating version activated status for `%s`", version.Id))
+		}
+	} else {
+		err = version.SetActivated()
+		if err != nil {
+			return errors.Wrapf(err, fmt.Sprintf("Error updating version activated status for `%s`", version.Id))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
[EVG-15294](https://jira.mongodb.org/browse/EVG-15294)

### Description 
This will help support pagination when viewing mainline commits on the waterfall and on the task history pages.
One ask from the mainline commits project is to be able to be linked to  a mainline commit at a specific point of time. Since commits are continuously being added to the front of the waterfall.
 Its difficult to be able to use a normal pagination strategy that depends on offsets and limits based on the amount of content on the screen. Since what might be on page 1 one day might be on page 6 the next. 

Luckily we have a field called `Order` Number which represents the position of a commit relative to the others in the waterfall. Using this we can paginate based off of what commit is currently in view. 
`skipOrderNumber` is a param of the mainline commits query that returns the commits prior to the orderNumber passed in
`nextPageOrderNumber` returns what the last commit in view is so when it is passed into the query for `skipOrderNumber` it will return the next pages worth of commits
`prevPageOrderNumber` returns the order number of the previous pages last active commit. Since mainline commits will always return an active commit as the last commit. 
This value will be nil if there are no newer commits.


### Testing 
Wrote unit tests and tested in staging
Demo of pagination
https://user-images.githubusercontent.com/4605522/130142284-f43aaf0f-8d73-4a3e-9964-0d85b7d76ca3.mov
