### PR TITLE
EVG-14028 set maxtime for TaskHistory queries

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -174,7 +174,7 @@ imports:
   - name: github.com/evergreen-ci/birch
     version: 9279ecfa890703259ea90af5d1c1fac4e9869bb2
   - name: github.com/mongodb/anser
-    version: 8f3e5cdbbb8779fdb021c9ffcd9cd514d6688464
+    version: 7c3b6870adfb65e15f5b130bae0adbb7efc67718
   - name: github.com/mongodb/ftdc
     version: fd0bfc553fcbcdfdb56f202df39992382971c3a1
 

--- a/model/task_history.go
+++ b/model/task_history.go
@@ -400,10 +400,13 @@ func (self *taskHistoryIterator) GetDistinctTestNames(ctx context.Context, numCo
 	for iter.Next(&res) {
 		names = append(names, res["_id"].(string))
 		if ctx.Err() != nil {
-			_ = iter.Close()
-			return nil, errors.Wrap(ctx.Err(), "iterating results")
+			catcher := grip.NewBasicCatcher()
+			catcher.Add(errors.Wrap(ctx.Err(), "iterating results"))
+			catcher.Add(iter.Close())
+			return nil, catcher.Resolve()
 		}
 	}
+	sort.Strings(names)
 
 	return names, nil
 }

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -281,7 +281,7 @@ func (uis *UIServer) taskHistoryTestNames(w http.ResponseWriter, r *http.Request
 	taskHistoryIterator := model.NewTaskHistoryIterator(taskName, nil,
 		project.Identifier)
 
-	results, err := taskHistoryIterator.GetDistinctTestNames(NumTasksToSearchForTestNames)
+	results, err := taskHistoryIterator.GetDistinctTestNames(r.Context(), NumTasksToSearchForTestNames)
 	testNamesQueryDuration := time.Now().Sub(stepTime)
 	msg := message.Fields{
 		"message":               "got test names",

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -281,7 +281,7 @@ func (uis *UIServer) taskHistoryTestNames(w http.ResponseWriter, r *http.Request
 	taskHistoryIterator := model.NewTaskHistoryIterator(taskName, nil,
 		project.Identifier)
 
-	results, err := taskHistoryIterator.GetDistinctTestNames(r.Context(), uis.env, NumTasksToSearchForTestNames)
+	results, err := taskHistoryIterator.GetDistinctTestNames(NumTasksToSearchForTestNames)
 	testNamesQueryDuration := time.Now().Sub(stepTime)
 	msg := message.Fields{
 		"message":               "got test names",

--- a/vendor/github.com/mongodb/anser/db/interface.go
+++ b/vendor/github.com/mongodb/anser/db/interface.go
@@ -9,7 +9,6 @@ type Session interface {
 	Copy() Session
 	Close()
 	DB(string) Database
-	SetSocketTimeout(time.Duration)
 	Error() error
 }
 
@@ -24,7 +23,7 @@ type Database interface {
 // mgo.Collection type.
 type Collection interface {
 	DropCollection() error
-	Pipe(interface{}) Results
+	Pipe(interface{}) Aggregation
 	Find(interface{}) Query
 	FindId(interface{}) Query
 	Count() (int, error)
@@ -50,6 +49,13 @@ type Query interface {
 	// name of the index as a string or the index specification as a document.
 	Hint(interface{}) Query
 	Apply(Change, interface{}) (*ChangeInfo, error)
+	MaxTime(time.Duration) Query
+	Results
+}
+
+type Aggregation interface {
+	Hint(interface{}) Aggregation
+	MaxTime(time.Duration) Aggregation
 	Results
 }
 
@@ -79,8 +85,7 @@ type Iterator interface {
 }
 
 // Results reflect the output of a database operation and is part of
-// the query interface, and is returned by the pipeline (e.g
-// aggregation operation.)
+// the query interface
 type Results interface {
 	All(interface{}) error
 	One(interface{}) error


### PR DESCRIPTION
[EVG-14028](https://jira.mongodb.org/browse/EVG-14028)

### Description 
Now that MaxTime is part of anser I redid the effort from #4500 to use it instead of using the driver directly. 

Another consideration is that we will no longer be passing the request's context to the mongo driver, but rather the application context. On the one hand this is bad because it means that if a call to `iter.Next()` (getMore) is taking a long time the operation won't get killed when the request dies but rather when maxtime passes on the server side (i.e. a minute after it starts). On the other hand, routinely killing an operation on the server by killing the driver's context apparently isn't good for server performance (I wrote more about this in [the anser PR](https://github.com/mongodb/anser/pull/43#issuecomment-897110393)). My judgement is that the combination of maxtime on the server side with checking `ctx.Err()` between calls to Next should be sufficient.

I thought of watching the ctx in a separate goroutine and closing the iterator/cursor when we see the ctx is cancelled. This would have all the advantages: the cursor is closed immediately when the request is over even if Next is blocked on getting a slow batch of results from the server. However, [the driver says](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#Cursor) a cursor isn't goroutine safe so I hesitate to do this.

### Testing 
  I'll try out the task_history page in staging when staging becomes available 😄 