### PR TITLE
EVG-15166: Remove premature return statement from stats iterators

### DIFF
--- a/units/cache_historical_test_data.go
+++ b/units/cache_historical_test_data.go
@@ -225,8 +225,8 @@ func (c *cacheHistoricalJobContext) updateHourlyAndDailyStats(ctx context.Contex
 		})
 		if err != nil {
 			grip.Warning(message.WrapError(err, message.Fields{
+				"message":    "error iterating over hourly stats",
 				"project_id": c.ProjectID,
-				"job_time":   c.JobTime,
 			}))
 		}
 	}
@@ -240,8 +240,8 @@ func (c *cacheHistoricalJobContext) updateHourlyAndDailyStats(ctx context.Contex
 		})
 		if err != nil {
 			grip.Warning(message.WrapError(err, message.Fields{
+				"message":    "serror iterating over daily stats",
 				"project_id": c.ProjectID,
-				"job_time":   c.JobTime,
 			}))
 		}
 	}

--- a/units/cache_historical_test_data.go
+++ b/units/cache_historical_test_data.go
@@ -224,7 +224,10 @@ func (c *cacheHistoricalJobContext) updateHourlyAndDailyStats(ctx context.Contex
 			c.catcher.Add(err)
 		})
 		if err != nil {
-			return timingInfo
+			grip.Warning(message.WrapError(err, message.Fields{
+				"project_id": c.ProjectID,
+				"job_time":   c.JobTime,
+			}))
 		}
 	}
 
@@ -236,7 +239,10 @@ func (c *cacheHistoricalJobContext) updateHourlyAndDailyStats(ctx context.Contex
 			c.catcher.Add(err)
 		})
 		if err != nil {
-			return timingInfo
+			grip.Warning(message.WrapError(err, message.Fields{
+				"project_id": c.ProjectID,
+				"job_time":   c.JobTime,
+			}))
 		}
 	}
 


### PR DESCRIPTION
[EVG-15166](https://jira.mongodb.org/browse/EVG-15166)

### Description 
Currently When we're failing to process test stats it's preventing us from processing task stats. Since we return early when we hit an error in the hourly stats, we never actually get to processing daily task results. In one observed case when there was a test name long enough that one of these indexes exceeds the WT 1024 byte limit, and this will continue to cause an error until Evergreen upgrades to Mongo 4.4 from 4.0.  A change has been made to add logging to notify if a certain test stat has failed to process and continue processing the rest of the stats instead of stopping and returning once a single error is found.
### Testing 
Deployed change to staging and enabled the cache historical statistics, and saw that there was not any [unexpected behavior](index="evergreen-staging" "Generating daily test stats") in the logs and that task stats were [properly generated](https://evergreen-staging.corp.mongodb.com/rest/v2/projects/mci/test_stats?after_date=2021-06-01&before_date=2021-08-22&tasks=test-agent) still.
