### PR TITLE
EVG-15304  Add the parent status to collective status in the version resolver

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3154,7 +3154,7 @@ func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion)
 			return status, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch Patch %s: %s", *obj.Id, err.Error()))
 		}
 		if len(p.ChildPatches) > 0 {
-			patchStatuses := []string{}
+			patchStatuses := []string{*p.Status}
 			for _, cp := range p.ChildPatches {
 				patchStatuses = append(patchStatuses, *cp.Status)
 				// add the child patch tasks to tasks so that we can consider their status


### PR DESCRIPTION
[EVG-15304](https://jira.mongodb.org/browse/EVG-15304)

Before: 
![image](https://user-images.githubusercontent.com/13104717/130477770-fc8eafb6-881d-4545-a782-12c2731e8d47.png)

After: 
![image](https://user-images.githubusercontent.com/13104717/130477825-f66d9975-249c-4264-8864-b61ef9949ed0.png)



