### PR TITLE
EVG-15278 Return parentPatch if available

### DIFF
--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -173,7 +173,7 @@ func checkPatchStatus(p *patch.Patch) (bool, *patch.Patch, bool, error) {
 	// make sure the parent is done, if not, wait for the parent
 	if p.IsChild() {
 		if !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
-			return isReady, nil, false, nil
+			return isReady, parentPatch, false, nil
 		}
 	}
 	childrenStatus, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -167,7 +167,7 @@ func checkPatchStatus(p *patch.Patch) (bool, *patch.Patch, bool, error) {
 	isReady := false
 	childrenOrSiblings, parentPatch, err := p.GetPatchFamily()
 	if err != nil {
-		return isReady, nil, false, errors.Wrap(err, "error getting child or sibling patches")
+		return isReady, parentPatch, false, errors.Wrap(err, "error getting child or sibling patches")
 	}
 
 	// make sure the parent is done, if not, wait for the parent
@@ -178,10 +178,10 @@ func checkPatchStatus(p *patch.Patch) (bool, *patch.Patch, bool, error) {
 	}
 	childrenStatus, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)
 	if err != nil {
-		return isReady, nil, false, errors.Wrap(err, "error getting child or sibling information")
+		return isReady, parentPatch, false, errors.Wrap(err, "error getting child or sibling information")
 	}
 	if !evergreen.IsFinishedPatchStatus(childrenStatus) {
-		return isReady, nil, false, nil
+		return isReady, parentPatch, false, nil
 	}
 	isReady = true
 


### PR DESCRIPTION
[EVG-15278](https://jira.mongodb.org/browse/EVG-15278)

### Description 
The original bug reported in the ticket was actually not really a bug. The version resolver accidentally left the parent patch status out of the calculation, so the patch status always showed the child status _only_ instead of a collective status. This mimicked the patch not waiting on the parent, but it wasn't actually the case. Once the resolver was fixed, this "bug" went away. However, in my investigation I noticed something that either has hidden problems or is bound to cause a problem at some point, so I fixed it here. 

### Testing 
I noticed that the parent patch was null in splunk logs where I didn't expect it to be, and after this change, it no longer showed up as null in that case.  
