### PR TITLE
EVG-14767: Support regex when allowing CORS

### DIFF
--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -810,8 +810,7 @@ func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.Handler
 		if len(allowedOrigins) > 0 {
 			// Requests from a GQL client include this header, which must be added to the response to enable CORS
 			gqlHeader := r.Header.Get("Access-Control-Request-Headers")
-
-			if utility.StringSliceContains(allowedOrigins, requester) {
+			if util.StringContainsSliceRegex(allowedOrigins, requester) {
 				w.Header().Add("Access-Control-Allow-Origin", requester)
 				w.Header().Add("Access-Control-Allow-Credentials", "true")
 				w.Header().Add("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PATCH, PUT")

--- a/util/strings.go
+++ b/util/strings.go
@@ -94,3 +94,18 @@ func CoalesceString(in ...string) string {
 func CoalesceStrings(inArray []string, inStrs ...string) string {
 	return CoalesceString(CoalesceString(inArray...), CoalesceString(inStrs...))
 }
+
+// StringContainsSliceRegex determines if a string matches a regex in a slice
+func StringContainsSliceRegex(slice []string, item string) bool {
+	if len(slice) == 0 {
+		return false
+	}
+
+	for idx := range slice {
+		matched, err := regexp.MatchString(slice[idx], item)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
+}

--- a/util/strings.go
+++ b/util/strings.go
@@ -97,12 +97,8 @@ func CoalesceStrings(inArray []string, inStrs ...string) string {
 
 // StringContainsSliceRegex determines if a string matches a regex in a slice
 func StringContainsSliceRegex(slice []string, item string) bool {
-	if len(slice) == 0 {
-		return false
-	}
-
-	for idx := range slice {
-		matched, err := regexp.MatchString(slice[idx], item)
+	for _, sliceItem := range slice {
+		matched, err := regexp.MatchString(sliceItem, item)
 		if err == nil && matched {
 			return true
 		}

--- a/util/strings_test.go
+++ b/util/strings_test.go
@@ -40,8 +40,9 @@ func TestCoalesce(t *testing.T) {
 }
 
 func TestStringContainsSliceRegex(t *testing.T) {
-	assert := assert.New(t)
 	domains := []string{".*.corp.mongodb.com", "https://something.mongodb.com"}
-	assert.Equal(true, StringContainsSliceRegex(domains, "https://patch-analysis-ui.server-tig.staging.corp.mongodb.com"))
-	assert.Equal(true, StringContainsSliceRegex(domains, "https://something.mongodb.com"))
+	assert.Equal(t, true, StringContainsSliceRegex(domains, "https://patch-analysis-ui.server-tig.staging.corp.mongodb.com"))
+	assert.Equal(t, true, StringContainsSliceRegex(domains, "https://something.mongodb.com"))
+	assert.Equal(t, false, StringContainsSliceRegex(domains, "corp.mongodb.com"))
+	assert.Equal(t, false, StringContainsSliceRegex(domains, "https://something-else.mongodb.com"))
 }

--- a/util/strings_test.go
+++ b/util/strings_test.go
@@ -38,3 +38,10 @@ func TestCoalesce(t *testing.T) {
 	assert.Equal("one", CoalesceStrings(nil, "", "one", "two"))
 	assert.Equal("", CoalesceStrings(nil, "", ""))
 }
+
+func TestStringContainsSliceRegex(t *testing.T) {
+	assert := assert.New(t)
+	domains := []string{".*.corp.mongodb.com", "https://something.mongodb.com"}
+	assert.Equal(true, StringContainsSliceRegex(domains, "https://patch-analysis-ui.server-tig.staging.corp.mongodb.com"))
+	assert.Equal(true, StringContainsSliceRegex(domains, "https://something.mongodb.com"))
+}


### PR DESCRIPTION
[EVG-14767](https://jira.mongodb.org/browse/EVG-14767)

### Description 
A change has been made to allow regexes when adding CORS, because currently we only apply if a request url exactly matches what we have in the allowedOrigins defined on the admin page.  Now exact strings and regexes will both match and apply CORS.

### Testing 
Added unit test certifying behavior