### PR TITLE
EVG-15302: pass service flags to helper functions

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -301,7 +301,14 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		ec2Settings.UserData = expanded
 	}
 
-	userData, err := makeUserData(ctx, m.env, h, ec2Settings.UserData, ec2Settings.MergeUserDataParts)
+	settings := *m.settings
+	// Use the latest service flags instead of those cached in the environment.
+	flags, err := evergreen.GetServiceFlags()
+	if err != nil {
+		return errors.Wrap(err, "getting service flags")
+	}
+	settings.ServiceFlags = *flags
+	userData, err := makeUserData(ctx, &settings, h, ec2Settings.UserData, ec2Settings.MergeUserDataParts)
 	if err != nil {
 		return errors.Wrap(err, "could not make user data")
 	}
@@ -483,7 +490,14 @@ func (m *ec2Manager) spawnSpotHost(ctx context.Context, h *host.Host, ec2Setting
 		ec2Settings.UserData = expanded
 	}
 
-	userData, err := makeUserData(ctx, m.env, h, ec2Settings.UserData, ec2Settings.MergeUserDataParts)
+	settings := *m.settings
+	// Use the latest service flags instead of those cached in the environment.
+	flags, err := evergreen.GetServiceFlags()
+	if err != nil {
+		return errors.Wrap(err, "getting service flags")
+	}
+	settings.ServiceFlags = *flags
+	userData, err := makeUserData(ctx, &settings, h, ec2Settings.UserData, ec2Settings.MergeUserDataParts)
 	if err != nil {
 		return errors.Wrap(err, "could not make user data")
 	}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -463,7 +463,14 @@ func (m *ec2FleetManager) uploadLaunchTemplate(ctx context.Context, h *host.Host
 		launchTemplate.SecurityGroups = ec2Settings.getSecurityGroups()
 	}
 
-	userData, err := makeUserData(ctx, m.env, h, ec2Settings.UserData, ec2Settings.MergeUserDataParts)
+	settings := *m.settings
+	// Use the latest service flags instead of those cached in the environment.
+	flags, err := evergreen.GetServiceFlags()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "getting service flags")
+	}
+	settings.ServiceFlags = *flags
+	userData, err := makeUserData(ctx, m.settings, h, ec2Settings.UserData, ec2Settings.MergeUserDataParts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "could not make user data")
 	}

--- a/cloud/pod_agent_util.go
+++ b/cloud/pod_agent_util.go
@@ -77,11 +77,6 @@ func clientName(p *pod.Pod) string {
 
 // downloadAgentCommands returns the commands to download the agent.
 func downloadAgentCommands(settings *evergreen.Settings, p *pod.Pod) (string, error) {
-	flags, err := evergreen.GetServiceFlags()
-	if err != nil {
-		return "", errors.Wrap(err, "getting service flags")
-	}
-
 	const (
 		curlDefaultNumRetries = 10
 		curlDefaultMaxSecs    = 100
@@ -89,7 +84,7 @@ func downloadAgentCommands(settings *evergreen.Settings, p *pod.Pod) (string, er
 	retryArgs := curlRetryArgs(curlDefaultNumRetries, curlDefaultMaxSecs)
 
 	var curlCmd string
-	if !flags.S3BinaryDownloadsDisabled && settings.PodInit.S3BaseURL != "" {
+	if !settings.ServiceFlags.S3BinaryDownloadsDisabled && settings.PodInit.S3BaseURL != "" {
 		// Attempt to download the agent from S3, but fall back to downloading from
 		// the app server if it fails.
 		curlCmd = fmt.Sprintf("(curl -LO '%s' %s || curl -LO '%s' %s)", s3ClientURL(settings, p), retryArgs, clientURL(settings, p), retryArgs)

--- a/cloud/userdata.go
+++ b/cloud/userdata.go
@@ -226,7 +226,7 @@ func writeUserDataPart(writer *multipart.Writer, u *userData, fileName string) e
 // If mergeParts is true, the provisioning part and the custom part will
 // be combined into a single user data part, so they must be the same type (e.g.
 // if shell scripts, both must be the same shell scripting language).
-func makeUserData(ctx context.Context, env evergreen.Environment, h *host.Host, custom string, mergeParts bool) (string, error) {
+func makeUserData(ctx context.Context, settings *evergreen.Settings, h *host.Host, custom string, mergeParts bool) (string, error) {
 	var err error
 	var customUserData *userData
 	if custom != "" {
@@ -242,8 +242,6 @@ func makeUserData(ctx context.Context, env evergreen.Environment, h *host.Host, 
 		}
 		return "", nil
 	}
-
-	settings := env.Settings()
 
 	provisionOpts, err := h.GenerateFetchProvisioningScriptUserData(settings)
 	if err != nil {

--- a/cloud/userdata_test.go
+++ b/cloud/userdata_test.go
@@ -23,7 +23,7 @@ import (
 func TestMakeUserData(t *testing.T) {
 	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host){
 		"ContainsCommandsToStartHostProvisioning": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host) {
-			userData, err := makeUserData(ctx, env, h, "", false)
+			userData, err := makeUserData(ctx, env.Settings(), h, "", false)
 			require.NoError(t, err)
 
 			opts, err := h.GenerateFetchProvisioningScriptUserData(env.Settings())
@@ -31,21 +31,21 @@ func TestMakeUserData(t *testing.T) {
 			assert.Contains(t, userData, opts.Content)
 		},
 		"PassesWithoutCustomUserData": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host) {
-			userData, err := makeUserData(ctx, env, h, "", false)
+			userData, err := makeUserData(ctx, env.Settings(), h, "", false)
 			require.NoError(t, err)
 			assert.NotEmpty(t, userData)
 		},
 		"PassesWithoutCustomUserDataWithPersistOnWindows": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host) {
 			h.Distro.Arch = evergreen.ArchWindowsAmd64
 			h.Distro.BootstrapSettings.ServiceUser = "user"
-			userData, err := makeUserData(ctx, env, h, "", false)
+			userData, err := makeUserData(ctx, env.Settings(), h, "", false)
 			require.NoError(t, err)
 			assert.NotEmpty(t, userData)
 			assert.Contains(t, userData, persistTag)
 		},
 		"PassesWithCustomUserData": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host) {
 			customUserData := "#!/bin/bash\necho foo"
-			userData, err := makeUserData(ctx, env, h, customUserData, false)
+			userData, err := makeUserData(ctx, env.Settings(), h, customUserData, false)
 			require.NoError(t, err)
 
 			cmd, err := h.CurlCommandWithDefaultRetry(env.Settings())
@@ -55,7 +55,7 @@ func TestMakeUserData(t *testing.T) {
 		"ReturnsUserDataUnmodifiedIfNotProvisioningWithUserData": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host) {
 			h.Distro.BootstrapSettings.Method = distro.BootstrapMethodSSH
 			customUserData := "#!/bin/bash\necho foo"
-			userData, err := makeUserData(ctx, env, h, customUserData, false)
+			userData, err := makeUserData(ctx, env.Settings(), h, customUserData, false)
 			require.NoError(t, err)
 			assert.Equal(t, customUserData, userData)
 		},
@@ -64,14 +64,14 @@ func TestMakeUserData(t *testing.T) {
 			h.Distro.BootstrapSettings.ServiceUser = "user"
 			h.Distro.Arch = evergreen.ArchWindowsAmd64
 			customUserData := "<powershell>\necho foo\n</powershell>"
-			userData, err := makeUserData(ctx, env, h, customUserData, false)
+			userData, err := makeUserData(ctx, env.Settings(), h, customUserData, false)
 			require.NoError(t, err)
 			assert.Contains(t, userData, customUserData)
 			assert.Contains(t, userData, persistTag)
 		},
 		"MergesUserDataPartsIntoOne": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host) {
 			customUserData := "#!/bin/bash\necho foo"
-			userData, err := makeUserData(ctx, env, h, customUserData, true)
+			userData, err := makeUserData(ctx, env.Settings(), h, customUserData, true)
 			require.NoError(t, err)
 
 			cmd, err := h.CurlCommandWithDefaultRetry(env.Settings())
@@ -86,7 +86,7 @@ func TestMakeUserData(t *testing.T) {
 			h.Distro.Arch = evergreen.ArchWindowsAmd64
 			h.Distro.BootstrapSettings.ServiceUser = "user"
 			customUserData := "<powershell>\necho foo\n</powershell>\n<persist>true</persist>"
-			userData, err := makeUserData(ctx, env, h, customUserData, true)
+			userData, err := makeUserData(ctx, env.Settings(), h, customUserData, true)
 			require.NoError(t, err)
 
 			assert.Contains(t, userData, persistTag)

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -93,12 +93,8 @@ func (h *Host) CurlCommandWithDefaultRetry(settings *evergreen.Settings) (string
 }
 
 func (h *Host) curlCommands(settings *evergreen.Settings, curlArgs string) ([]string, error) {
-	flags, err := evergreen.GetServiceFlags()
-	if err != nil {
-		return nil, errors.Wrap(err, "getting service flags")
-	}
 	var curlCmd string
-	if !flags.S3BinaryDownloadsDisabled && settings.HostInit.S3BaseURL != "" {
+	if !settings.ServiceFlags.S3BinaryDownloadsDisabled && settings.HostInit.S3BaseURL != "" {
 		// Attempt to download the agent from S3, but fall back to downloading from
 		// the app server if it fails.
 		// Include -f to return an error code from curl if the HTTP request

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -118,6 +118,8 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 	}
 
 	settings := j.env.Settings()
+	// Use the latest service flags instead of those cached in the environment.
+	settings.ServiceFlags = *flags
 
 	if err = j.host.UpdateLastCommunicated(); err != nil {
 		j.AddRetryableError(errors.Wrapf(err, "error setting LCT on host %s", j.host.Id))

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -117,7 +117,7 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	settings := j.env.Settings()
+	settings := *j.env.Settings()
 	// Use the latest service flags instead of those cached in the environment.
 	settings.ServiceFlags = *flags
 
@@ -148,7 +148,7 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 		}
 	}()
 
-	if err := j.startAgentOnHost(ctx, settings); err != nil {
+	if err := j.startAgentOnHost(ctx, &settings); err != nil {
 		if j.host.Status == evergreen.HostRunning {
 			j.AddRetryableError(err)
 		} else {

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -117,10 +117,6 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	settings := *j.env.Settings()
-	// Use the latest service flags instead of those cached in the environment.
-	settings.ServiceFlags = *flags
-
 	if err = j.host.UpdateLastCommunicated(); err != nil {
 		j.AddRetryableError(errors.Wrapf(err, "error setting LCT on host %s", j.host.Id))
 	}
@@ -147,6 +143,10 @@ func (j *agentDeployJob) Run(ctx context.Context) {
 			j.AddError(errors.Wrapf(disableErr, "error terminating host %s", j.host.Id))
 		}
 	}()
+
+	settings := *j.env.Settings()
+	// Use the latest service flags instead of those cached in the environment.
+	settings.ServiceFlags = *flags
 
 	if err := j.startAgentOnHost(ctx, &settings); err != nil {
 		if j.host.Status == evergreen.HostRunning {

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -142,9 +142,6 @@ func (j *agentMonitorDeployJob) Run(ctx context.Context) {
 		return
 	}()
 
-	settings := j.env.Settings()
-	settings.ServiceFlags = *flags
-
 	var alive bool
 	alive, err = j.checkAgentMonitor(ctx)
 	if err != nil {
@@ -162,17 +159,20 @@ func (j *agentMonitorDeployJob) Run(ctx context.Context) {
 		return
 	}
 
-	if err = j.fetchClient(ctx, settings); err != nil {
+	settings := *j.env.Settings()
+	settings.ServiceFlags = *flags
+
+	if err = j.fetchClient(ctx, &settings); err != nil {
 		j.AddRetryableError(err)
 		return
 	}
 
-	if err = j.runSetupScript(ctx, settings); err != nil {
+	if err = j.runSetupScript(ctx, &settings); err != nil {
 		j.AddError(err)
 		return
 	}
 
-	if err := j.startAgentMonitor(ctx, settings); err != nil {
+	if err := j.startAgentMonitor(ctx, &settings); err != nil {
 		j.AddRetryableError(err)
 		return
 	}

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -76,12 +76,12 @@ func NewAgentMonitorDeployJob(env evergreen.Environment, h host.Host, id string)
 func (j *agentMonitorDeployJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	disabled, err := j.agentStartDisabled()
+	flags, err := evergreen.GetServiceFlags()
 	if err != nil {
-		j.AddRetryableError(err)
+		j.AddRetryableError(errors.Wrap(err, "getting service flags"))
 		return
 	}
-	if disabled {
+	if flags.AgentStartDisabled {
 		grip.Debug(message.Fields{
 			"mode":     "degraded",
 			"host_id":  j.HostID,
@@ -143,6 +143,7 @@ func (j *agentMonitorDeployJob) Run(ctx context.Context) {
 	}()
 
 	settings := j.env.Settings()
+	settings.ServiceFlags = *flags
 
 	var alive bool
 	alive, err = j.checkAgentMonitor(ctx)
@@ -338,17 +339,6 @@ func (j *agentMonitorDeployJob) deployMessage() message.Fields {
 	}
 
 	return m
-}
-
-// agentStartDisabled checks if the agent (and consequently, the agent monitor)
-// should be deployed.
-func (j *agentMonitorDeployJob) agentStartDisabled() (bool, error) {
-	flags, err := evergreen.GetServiceFlags()
-	if err != nil {
-		return false, errors.New("could not get service flags")
-	}
-
-	return flags.AgentStartDisabled, nil
 }
 
 // populateIfUnset populates the unset job fields.

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -113,15 +113,16 @@ func (j *setupHostJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	settings := j.env.Settings()
+	settings := *j.env.Settings()
 	// Use the latest service flags instead of those cached in the environment.
 	flags, err := evergreen.GetServiceFlags()
-	j.AddError(errors.Wrap(err, "getting service flags"))
-	if flags != nil {
-		settings.ServiceFlags = *flags
+	if err != nil {
+		j.AddRetryableError(errors.Wrap(err, "getting service flags"))
+		return
 	}
+	settings.ServiceFlags = *flags
 
-	j.AddError(j.setupHost(ctx, settings))
+	j.AddError(j.setupHost(ctx, &settings))
 }
 
 func (j *setupHostJob) setupHost(ctx context.Context, settings *evergreen.Settings) error {

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -114,6 +114,12 @@ func (j *setupHostJob) Run(ctx context.Context) {
 	}
 
 	settings := j.env.Settings()
+	// Use the latest service flags instead of those cached in the environment.
+	flags, err := evergreen.GetServiceFlags()
+	j.AddError(errors.Wrap(err, "getting service flags"))
+	if flags != nil {
+		settings.ServiceFlags = *flags
+	}
 
 	j.AddError(j.setupHost(ctx, settings))
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15302

### Description 
Pass the service flags into the helper functions that depend on them to avoid having dependencies on global testing state in unit tests. It also avoids the issue where arbitrary functions can ask for the global environment state.