### PR TITLE
EVG-15060 modify save section to work for repo

### DIFF
--- a/model/project_event.go
+++ b/model/project_event.go
@@ -145,8 +145,8 @@ func LogProjectAdded(projectId, username string) error {
 	return LogProjectEvent(EventTypeProjectAdded, projectId, ProjectChangeEvent{User: username})
 }
 
-func GetAndLogProjectModified(id, userId string, before *ProjectSettings) error {
-	after, err := GetProjectSettingsById(id)
+func GetAndLogProjectModified(id, userId string, isRepo bool, before *ProjectSettings) error {
+	after, err := GetProjectSettingsById(id, isRepo)
 	if err != nil {
 		return errors.Wrap(err, "error getting after project settings event")
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -515,8 +515,8 @@ func TestDetachFromRepo(t *testing.T) {
 
 func TestDefaultRepoBySection(t *testing.T) {
 	for name, test := range map[string]func(t *testing.T, id string){
-		ProjectRefGeneralSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectRefGeneralSection, "me"))
+		ProjectPageGeneralSection: func(t *testing.T, id string) {
+			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGeneralSection, "me"))
 
 			pRefFromDb, err := FindOneProjectRef(id)
 			assert.NoError(t, err)
@@ -528,8 +528,8 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Nil(t, pRefFromDb.TaskSync.ConfigEnabled)
 			assert.Nil(t, pRefFromDb.FilesIgnoredFromCache)
 		},
-		ProjectRefAccessSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectRefAccessSection, "me"))
+		ProjectPageAccessSection: func(t *testing.T, id string) {
+			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageAccessSection, "me"))
 
 			pRefFromDb, err := FindOneProjectRef(id)
 			assert.NoError(t, err)
@@ -538,8 +538,8 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Nil(t, pRefFromDb.Restricted)
 			assert.Nil(t, pRefFromDb.Admins)
 		},
-		ProjectRefVariablesSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectRefVariablesSection, "me"))
+		ProjectPageVariablesSection: func(t *testing.T, id string) {
+			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageVariablesSection, "me"))
 
 			varsFromDb, err := FindOneProjectVars(id)
 			assert.NoError(t, err)
@@ -549,11 +549,11 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Nil(t, varsFromDb.RestrictedVars)
 			assert.NotEmpty(t, varsFromDb.Id)
 		},
-		ProjectRefGithubAndCQSection: func(t *testing.T, id string) {
+		ProjectPageGithubAndCQSection: func(t *testing.T, id string) {
 			aliases, err := FindAliasesForProject(id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 5)
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectRefGithubAndCQSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGithubAndCQSection, "me"))
 
 			pRefFromDb, err := FindOneProjectRef(id)
 			assert.NoError(t, err)
@@ -569,19 +569,19 @@ func TestDefaultRepoBySection(t *testing.T) {
 				assert.NotContains(t, evergreen.InternalAliases, a.Alias)
 			}
 		},
-		ProjectRefNotificationsSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectRefNotificationsSection, "me"))
+		ProjectPageNotificationsSection: func(t *testing.T, id string) {
+			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageNotificationsSection, "me"))
 			pRefFromDb, err := FindOneProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
 			assert.Nil(t, pRefFromDb.NotifyOnBuildFailure)
 		},
-		ProjectRefPatchAliasSection: func(t *testing.T, id string) {
+		ProjectPagePatchAliasSection: func(t *testing.T, id string) {
 			aliases, err := FindAliasesForProject(id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 5)
 
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectRefPatchAliasSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(id, ProjectPagePatchAliasSection, "me"))
 			pRefFromDb, err := FindOneProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
@@ -595,23 +595,23 @@ func TestDefaultRepoBySection(t *testing.T) {
 				assert.Contains(t, evergreen.InternalAliases, a.Alias)
 			}
 		},
-		ProjectRefTriggersSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectRefTriggersSection, "me"))
+		ProjectPageTriggersSection: func(t *testing.T, id string) {
+			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageTriggersSection, "me"))
 			pRefFromDb, err := FindOneProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
 			assert.Nil(t, pRefFromDb.Triggers)
 		},
-		ProjectRefWorkstationsSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectRefWorkstationsSection, "me"))
+		ProjectPageWorkstationsSection: func(t *testing.T, id string) {
+			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageWorkstationsSection, "me"))
 			pRefFromDb, err := FindOneProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
 			assert.Nil(t, pRefFromDb.WorkstationConfig.GitClone)
 			assert.Nil(t, pRefFromDb.WorkstationConfig.SetupCommands)
 		},
-		ProjectRefPeriodicBuildsSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectRefPeriodicBuildsSection, "me"))
+		ProjectPagePeriodicBuildsSection: func(t *testing.T, id string) {
+			assert.NoError(t, DefaultSectionToRepo(id, ProjectPagePeriodicBuildsSection, "me"))
 			pRefFromDb, err := FindOneProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -110,7 +110,7 @@ func (d *DBAliasConnector) UpdateProjectAliases(projectId string, aliases []rest
 
 // should be called in the resolver
 func (pc *DBAliasConnector) UpdateAliasesForSection(projectId string, updatedAliases []restModel.APIProjectAlias,
-	originalAliases []model.ProjectAlias, section model.ProjectRefSection) (bool, error) {
+	originalAliases []model.ProjectAlias, section model.ProjectPageSection) (bool, error) {
 	aliasesIdMap := map[string]bool{}
 	aliasesToUpdate := []restModel.APIProjectAlias{}
 
@@ -139,13 +139,13 @@ func (pc *DBAliasConnector) UpdateAliasesForSection(projectId string, updatedAli
 	return true, catcher.Resolve()
 }
 
-func shouldSkipAliasForSection(section model.ProjectRefSection, alias string) bool {
+func shouldSkipAliasForSection(section model.ProjectPageSection, alias string) bool {
 	// if we're updating internal aliases, skip non-internal aliases
-	if section == model.ProjectRefGithubAndCQSection && !utility.StringSliceContains(evergreen.InternalAliases, alias) {
+	if section == model.ProjectPageGithubAndCQSection && !utility.StringSliceContains(evergreen.InternalAliases, alias) {
 		return true
 	}
 	// if we're updating patch aliases, skip internal aliases
-	if section == model.ProjectRefPatchAliasSection && utility.StringSliceContains(evergreen.InternalAliases, alias) {
+	if section == model.ProjectPagePatchAliasSection && utility.StringSliceContains(evergreen.InternalAliases, alias) {
 		return true
 	}
 	return false
@@ -184,7 +184,7 @@ func (d *MockAliasConnector) UpdateProjectAliases(projectId string, aliases []re
 }
 
 func (pc *MockAliasConnector) UpdateAliasesForSection(projectId string, updatedAliases []restModel.APIProjectAlias,
-	originalAliases []model.ProjectAlias, section model.ProjectRefSection) (bool, error) {
+	originalAliases []model.ProjectAlias, section model.ProjectPageSection) (bool, error) {
 	return false, nil
 }
 

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -215,7 +215,7 @@ func (a *AliasSuite) TestUpdateAliasesForSection() {
 	}
 
 	updatedAliases := []restModel.APIProjectAlias{aliasToKeep, aliasToModify, newAlias, newInternalAlias}
-	modified, err := a.sc.UpdateAliasesForSection("project_id", updatedAliases, originalAliases, model.ProjectRefPatchAliasSection)
+	modified, err := a.sc.UpdateAliasesForSection("project_id", updatedAliases, originalAliases, model.ProjectPagePatchAliasSection)
 	a.NoError(err)
 	a.True(modified)
 
@@ -230,7 +230,7 @@ func (a *AliasSuite) TestUpdateAliasesForSection() {
 		}
 	}
 
-	modified, err = a.sc.UpdateAliasesForSection("project_id", updatedAliases, originalAliases, model.ProjectRefGithubAndCQSection)
+	modified, err = a.sc.UpdateAliasesForSection("project_id", updatedAliases, originalAliases, model.ProjectPageGithubAndCQSection)
 	a.NoError(err)
 	a.True(modified)
 	aliasesFromDb, err = model.FindAliasesForProject("project_id")

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -315,7 +315,7 @@ type Connector interface {
 	// UpdateAliasesForSection, given a project, a list of current aliases, a list of previous aliases, and a project page section,
 	// upserts any current aliases, and deletes any aliases that existed previously but not anymore (only
 	// considers the aliases that are relevant for the section).
-	UpdateAliasesForSection(string, []restModel.APIProjectAlias, []model.ProjectAlias, model.ProjectRefSection) (bool, error)
+	UpdateAliasesForSection(string, []restModel.APIProjectAlias, []model.ProjectAlias, model.ProjectPageSection) (bool, error)
 	// HasMatchingGitTagAliasAndRemotePath returns true if the project has aliases defined that match the given tag, and
 	// returns the remote path if applicable
 	HasMatchingGitTagAliasAndRemotePath(string, string) (bool, string, error)
@@ -383,6 +383,9 @@ type Connector interface {
 
 	//GetProjectSettings returns the ProjectSettings of the given identifier and ProjectRef
 	GetProjectSettings(p *model.ProjectRef) (*model.ProjectSettings, error)
+	// SaveProjectSettingsForSection saves the given UI page section and logs it for the given user. If isRepo is true, uses
+	// RepoRef related functions and collection instead of ProjectRef.
+	SaveProjectSettingsForSection(context.Context, string, *restModel.APIProjectSettings, model.ProjectPageSection, bool, string) error
 
 	// CompareTasks returns the order that the given tasks would be scheduled, along with the scheduling logic.
 	CompareTasks([]string, bool) ([]string, map[string]map[string]string, error)

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -542,13 +542,189 @@ func TestGetProjectAliasResults(t *testing.T) {
 	assert.Len(t, variantTasks[0].Tasks, 2)
 }
 
+func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
+	dc := &DBProjectConnector{}
+	ctx := context.Background()
+	rm := evergreen.GetEnvironment().RoleManager()
+
+	for name, test := range map[string]func(t *testing.T, ref model.RepoRef){
+		model.ProjectPageGeneralSection: func(t *testing.T, ref model.RepoRef) {
+			assert.Empty(t, ref.SpawnHostScriptPath)
+
+			ref.SpawnHostScriptPath = "my script path"
+			apiProjectRef := restModel.APIProjectRef{}
+			assert.NoError(t, apiProjectRef.BuildFromService(ref.ProjectRef))
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			// ensure that we're saving settings without a special case
+			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, true, "me"))
+			repoRefFromDB, err := model.FindOneRepoRef(ref.Id)
+			assert.NoError(t, err)
+			assert.NotNil(t, repoRefFromDB)
+			assert.NotEmpty(t, repoRefFromDB.SpawnHostScriptPath)
+		},
+		model.ProjectPageAccessSection: func(t *testing.T, ref model.RepoRef) {
+			newAdmin := user.DBUser{
+				Id: "newAdmin",
+			}
+			require.NoError(t, newAdmin.Insert())
+			ref.Restricted = utility.TruePtr() // should also flip the project that defaults to this repo
+			ref.Admins = []string{"oldAdmin", newAdmin.Id}
+			apiProjectRef := restModel.APIProjectRef{}
+			assert.NoError(t, apiProjectRef.BuildFromService(ref.ProjectRef))
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageAccessSection, true, "me"))
+			repoRefFromDb, err := model.FindOneRepoRef(ref.Id)
+			assert.NoError(t, err)
+			assert.NotNil(t, repoRefFromDb)
+			assert.True(t, repoRefFromDb.IsRestricted())
+			assert.Equal(t, repoRefFromDb.Admins, ref.Admins)
+
+			// should be restricted
+			projectThatDefaults, err := model.FindMergedProjectRef("myId")
+			assert.NoError(t, err)
+			assert.NotNil(t, projectThatDefaults)
+			assert.True(t, projectThatDefaults.IsRestricted())
+
+			// should not be restricted
+			projectThatDoesNotDefault, err := model.FindMergedProjectRef("myId2")
+			assert.NoError(t, err)
+			assert.NotNil(t, projectThatDoesNotDefault)
+			assert.False(t, projectThatDoesNotDefault.IsRestricted())
+
+			restrictedScope, err := rm.GetScope(ctx, evergreen.RestrictedProjectsScope)
+			assert.NoError(t, err)
+			assert.NotNil(t, restrictedScope)
+			assert.Contains(t, restrictedScope.Resources, projectThatDefaults.Id)
+
+			unrestrictedScope, err := rm.GetScope(ctx, evergreen.UnrestrictedProjectsScope)
+			assert.NoError(t, err)
+			assert.NotNil(t, unrestrictedScope)
+			assert.NotContains(t, unrestrictedScope.Resources, projectThatDefaults.Id)
+
+			newAdminFromDB, err := user.FindOneById("newAdmin")
+			assert.NoError(t, err)
+			assert.NotNil(t, newAdminFromDB)
+			assert.Contains(t, newAdminFromDB.Roles(), model.GetRepoAdminRole(ref.Id))
+		},
+		model.ProjectPageVariablesSection: func(t *testing.T, ref model.RepoRef) {
+			// remove a variable, modify a variable, add a variable
+			updatedVars := &model.ProjectVars{
+				Id:          ref.Id,
+				Vars:        map[string]string{"it": "me", "banana": "phone"},
+				PrivateVars: map[string]bool{"banana": true},
+			}
+			apiProjectVars := restModel.APIProjectVars{}
+			assert.NoError(t, apiProjectVars.BuildFromService(updatedVars))
+			apiChanges := &restModel.APIProjectSettings{
+				Vars: apiProjectVars,
+			}
+			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageVariablesSection, true, "me"))
+			varsFromDb, err := model.FindOneProjectVars(updatedVars.Id)
+			assert.NoError(t, err)
+			assert.NotNil(t, varsFromDb)
+			assert.Equal(t, varsFromDb.Vars["it"], "me")
+			assert.Equal(t, varsFromDb.Vars["banana"], "phone")
+			assert.Equal(t, varsFromDb.Vars["hello"], "")
+			assert.False(t, varsFromDb.PrivateVars["it"])
+			assert.False(t, varsFromDb.PrivateVars["hello"])
+			assert.True(t, varsFromDb.PrivateVars["banana"])
+		},
+	} {
+		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
+			event.SubscriptionsCollection, event.AllLogCollection, evergreen.ScopeCollection, user.Collection))
+		_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+
+		repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
+			Id:         "myRepoId",
+			Owner:      "evergreen-ci",
+			Repo:       "evergreen",
+			Restricted: utility.FalsePtr(),
+			Admins:     []string{"oldAdmin"},
+		}}
+		assert.NoError(t, repoRef.Upsert())
+
+		pRefThatDefaults := model.ProjectRef{
+			Id:              "myId",
+			Owner:           "evergreen-ci",
+			Repo:            "evergreen",
+			UseRepoSettings: true,
+			RepoRefId:       "myRepoId",
+			Admins:          []string{"oldAdmin"},
+		}
+		assert.NoError(t, pRefThatDefaults.Upsert())
+
+		pRefThatDoesNotDefault := model.ProjectRef{
+			Id:    "myId2",
+			Owner: "evergreen-ci",
+			Repo:  "evergreen",
+		}
+		assert.NoError(t, pRefThatDoesNotDefault.Upsert())
+
+		pVars := model.ProjectVars{
+			Id:          repoRef.Id,
+			Vars:        map[string]string{"hello": "world", "it": "adele"},
+			PrivateVars: map[string]bool{"hello": true},
+		}
+		assert.NoError(t, pVars.Insert())
+		// add scopes
+		allProjectsScope := gimlet.Scope{
+			ID:        evergreen.AllProjectsScope,
+			Resources: []string{},
+		}
+		assert.NoError(t, rm.AddScope(allProjectsScope))
+		restrictedScope := gimlet.Scope{
+			ID:          evergreen.RestrictedProjectsScope,
+			Resources:   []string{},
+			ParentScope: evergreen.AllProjectsScope,
+		}
+		assert.NoError(t, rm.AddScope(restrictedScope))
+		unrestrictedScope := gimlet.Scope{
+			ID:          evergreen.UnrestrictedProjectsScope,
+			Resources:   []string{pRefThatDefaults.Id, pRefThatDoesNotDefault.Id},
+			ParentScope: evergreen.AllProjectsScope,
+		}
+		assert.NoError(t, rm.AddScope(unrestrictedScope))
+		adminScope := gimlet.Scope{
+			ID:        "project_scope",
+			Resources: []string{pRefThatDefaults.Id},
+			Type:      evergreen.ProjectResourceType,
+		}
+		assert.NoError(t, rm.AddScope(adminScope))
+
+		adminRole := gimlet.Role{
+			ID:    "admin",
+			Scope: adminScope.ID,
+			Permissions: gimlet.Permissions{
+				evergreen.PermissionProjectSettings: evergreen.ProjectSettingsEdit.Value,
+				evergreen.PermissionTasks:           evergreen.TasksAdmin.Value,
+				evergreen.PermissionPatches:         evergreen.PatchSubmit.Value,
+				evergreen.PermissionLogs:            evergreen.LogsView.Value,
+			},
+		}
+		require.NoError(t, rm.UpdateRole(adminRole))
+		oldAdmin := user.DBUser{
+			Id:          "oldAdmin",
+			SystemRoles: []string{"admin"},
+		}
+		require.NoError(t, oldAdmin.Insert())
+
+		t.Run(name, func(t *testing.T) {
+			test(t, repoRef)
+		})
+	}
+}
+
 func TestSaveProjectSettingsForSection(t *testing.T) {
 	dc := &DBProjectConnector{}
 	ctx := context.Background()
 	rm := evergreen.GetEnvironment().RoleManager()
 
 	for name, test := range map[string]func(t *testing.T, ref model.ProjectRef){
-		model.ProjectRefGeneralSection: func(t *testing.T, ref model.ProjectRef) {
+		model.ProjectPageGeneralSection: func(t *testing.T, ref model.ProjectRef) {
 			assert.Empty(t, ref.SpawnHostScriptPath)
 
 			ref.SpawnHostScriptPath = "my script path"
@@ -558,13 +734,13 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 				ProjectRef: apiProjectRef,
 			}
 			// ensure that we're saving settings without a special case
-			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectRefGeneralSection, "me"))
+			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me"))
 			pRefFromDB, err := model.FindOneProjectRef(ref.Id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDB)
 			assert.NotEmpty(t, pRefFromDB.SpawnHostScriptPath)
 		},
-		model.ProjectRefAccessSection: func(t *testing.T, ref model.ProjectRef) {
+		model.ProjectPageAccessSection: func(t *testing.T, ref model.ProjectRef) {
 			newAdmin := user.DBUser{
 				Id: "newAdmin",
 			}
@@ -576,7 +752,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectRefAccessSection, "me"))
+			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageAccessSection, false, "me"))
 			pRefFromDB, err := model.FindOneProjectRef(ref.Id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDB)
@@ -603,7 +779,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NotNil(t, newAdminFromDB)
 			assert.Contains(t, newAdminFromDB.Roles(), "admin")
 		},
-		model.ProjectRefVariablesSection: func(t *testing.T, ref model.ProjectRef) {
+		model.ProjectPageVariablesSection: func(t *testing.T, ref model.ProjectRef) {
 			// remove a variable, modify a variable, add a variable
 			updatedVars := &model.ProjectVars{
 				Id:          ref.Id,
@@ -615,7 +791,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges := &restModel.APIProjectSettings{
 				Vars: apiProjectVars,
 			}
-			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectRefVariablesSection, "me"))
+			assert.NoError(t, dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageVariablesSection, false, "me"))
 			varsFromDb, err := model.FindOneProjectVars(updatedVars.Id)
 			assert.NoError(t, err)
 			assert.NotNil(t, varsFromDb)

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -308,8 +308,8 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	allAuthorizedTeams := utility.UniqueStrings(append(h.originalProject.GitTagAuthorizedTeams, h.newProjectRef.GitTagAuthorizedTeams...))
 	h.newProjectRef.GitTagAuthorizedTeams, _ = utility.StringSliceSymmetricDifference(allAuthorizedTeams, teamsToDelete)
 
-	// if the project ref doesn't use the repo, then this will just be the same as newProjectRef
-	// used to verify that if something is set to nil in the request, we properly validate using the merged project ref
+	// If the project ref doesn't use the repo, then this will just be the same as newProjectRef.
+	// Used to verify that if something is set to nil in the request, we properly validate using the merged project ref.
 	mergedProjectRef, err := dbModel.GetProjectRefMergedWithRepo(*h.newProjectRef)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "error merging project ref"))


### PR DESCRIPTION
[EVG-15060](https://jira.mongodb.org/browse/EVG-15060)

### Description 
The only thing that really needs to operate differently for RepoRef is the Access section, since we need to use the repo functions and not the project functions. Wasn't sure if I should pass in repo outside of project settings or as a new field 🤔  but in most cases we really can just use the ProjectRef. I think we can re-evaluate refactoring project settings in the future.

### Testing 
Quite a unit test.
