### PR TITLE
EVG-15222 allow immutable project ID to be user specified

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -351,7 +351,18 @@ func (projectRef *ProjectRef) Insert() error {
 }
 
 func (p *ProjectRef) Add(creator *user.DBUser) error {
-	p.Id = mgobson.NewObjectId().Hex()
+	if p.Id != "" {
+		// verify that this is a unique ID
+		conflictingRef, err := FindOneProjectRef(p.Id)
+		if err != nil {
+			return errors.Wrap(err, "error checking for conflicting project ref")
+		}
+		if conflictingRef != nil {
+			return errors.New("ID already being used as ID or identifier for another project")
+		}
+	} else {
+		p.Id = mgobson.NewObjectId().Hex()
+	}
 
 	// if a hidden project exists for this configuration, use that ID
 	if p.Owner != "" && p.Repo != "" && p.Branch != "" {

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -1378,16 +1378,34 @@ mciModule.controller(
 mciModule.directive("adminNewProject", function () {
   return {
     restrict: "E",
-    template: '<div class="row">' +
-      '<div class="col-lg-12">' +
-      "Enter project name " +
-      '<form style="display: inline" ng-submit="addProject()">' +
-      '<input type="text" id="project-name" placeholder="project name" ng-model="newProject.identifier">' +
-      ' <input type="checkbox" id="copy-project" ng-model="newProject.copyProject">' +
-      " Duplicate current project" +
-      "</form>" +
-      '<button type="submit" class="btn btn-primary" style="float: right; margin-left: 10px;" ng-click="addProject()">Create Project</button>' +
-      "</div>" +
-      "</div>",
+    template: '' +
+      '<div class="row">' +
+        '<div class="col-lg-12">' +
+         "Enter project identifier " +
+          '<input type="text" id="project-name" placeholder="project name" ng-model="newProject.identifier">' +
+        "</div>" +
+      '</div>' +
+      '<div class="row">' +
+        '<div class="col-lg-12">' +
+          "Optionally enter immutable project ID " +
+          '<div class="muted small">' +
+            "(Used by Evergreen internally. Defaults to a random hash.)" +
+          '</div>' +
+          '<input type="text" id="project-name" placeholder="immutable project ID" ng-model="newProject.id">' +
+        '</div>' +
+      '</div>' +
+      '<div class="row">' +
+        '<div class="col-lg-12">' +
+        '<form style="display: inline">' +
+          '<input type="checkbox" id="copy-project" ng-model="newProject.copyProject">' +
+          " Duplicate current project " +
+        "</form>" +
+        '</div>' +
+      '</div>' +
+      '<div class="row">'  +
+        '<div class="col-lg-12">' +
+          '<button type="submit" class="btn btn-primary" style="float: right; margin-left: 10px;" ng-disabled="!newProject.identifier" ng-click="addProject()">Create Project</button>' +
+        '</div>' +
+      '</div>',
   };
 });

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -557,12 +557,12 @@ func (h *projectIDPutHandler) Parse(ctx context.Context, r *http.Request) error 
 func (h *projectIDPutHandler) Run(ctx context.Context) gimlet.Responder {
 	p, err := h.sc.FindProjectById(h.projectName, false)
 	if err != nil && err.(gimlet.ErrorResponse).StatusCode != http.StatusNotFound {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "Database error for find() by project id '%s'", h.projectName))
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "Database error for find() by project '%s'", h.projectName))
 	}
 	if p != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
-			Message:    fmt.Sprintf("cannot create project with id '%s'", h.projectName),
+			Message:    fmt.Sprintf("cannot create project with identifier '%s'", h.projectName),
 		})
 	}
 

--- a/service/project.go
+++ b/service/project.go
@@ -548,7 +548,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projectRef.Id = id
+	projectRef.Id = id // TODO: what
 	projectRef.Identifier = responseRef.Identifier
 	projectRef.DisplayName = responseRef.DisplayName
 	projectRef.RemotePath = responseRef.RemotePath
@@ -785,9 +785,9 @@ func (uis *UIServer) addProject(w http.ResponseWriter, r *http.Request) {
 	dbUser := MustHaveUser(r)
 	_ = MustHaveProjectContext(r)
 
-	id := gimlet.GetVars(r)["project_id"]
+	identifier := gimlet.GetVars(r)["project_id"]
 
-	projectRef, err := model.FindOneProjectRef(id)
+	projectRef, err := model.FindOneProjectRef(identifier)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
@@ -796,8 +796,20 @@ func (uis *UIServer) addProject(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Project already exists", http.StatusBadRequest)
 		return
 	}
+	newProject := model.ProjectRef{Identifier: identifier}
 
-	newProject := model.ProjectRef{Identifier: id}
+	// the immutable ID may have optionally been passed in
+	projectWithId := struct {
+		Id string `json:"id"`
+	}{}
+
+	if err = utility.ReadJSON(util.NewRequestReader(r), &projectWithId); err != nil {
+		http.Error(w, fmt.Sprintf("Error parsing request body %v", err), http.StatusInternalServerError)
+		return
+	}
+	if projectWithId.Id != "" {
+		newProject.Id = projectWithId.Id
+	}
 
 	err = newProject.Add(dbUser)
 	if err != nil {
@@ -820,8 +832,8 @@ func (uis *UIServer) addProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	username := dbUser.DisplayName()
-	if err = model.LogProjectAdded(id, username); err != nil {
-		grip.Infof("Could not log new project %s", id)
+	if err = model.LogProjectAdded(identifier, username); err != nil {
+		grip.Infof("Could not log new project %s", identifier)
 	}
 
 	allProjects, err := uis.filterViewableProjects(dbUser)
@@ -835,7 +847,7 @@ func (uis *UIServer) addProject(w http.ResponseWriter, r *http.Request) {
 		Available   bool
 		ProjectId   string
 		AllProjects []model.ProjectRef
-	}{true, id, allProjects}
+	}{true, identifier, allProjects}
 
 	gimlet.WriteJSON(w, data)
 }


### PR DESCRIPTION
[EVG-15222](https://jira.mongodb.org/browse/EVG-15222)

### Description 
Originally we didn't allow this to be user-specified _because_ it is immutable; once an ID is taken it can never be used as an identifier for a different project, even if the identifier for this project is changed. In theory this was fine since we transitioned IDs to be evergreen internal and identifiers to be used externally; however, there are some dev prod teams that also rely on Evergreen internals and this has caused problems. They would like their projects to be able to specify something immutable because they don't have any use case for changing it. 

Although it's a risk to allow users to do something that they might want to change later and can't, this was already the behavior of identifier, and our users are engineers so they should understand the significance of an immutable project ID.

I recognize that this modal could be prettier, but since we're not supporting this page soon I don't think it's worth the time.
![Screen Shot 2021-08-24 at 11 49 27 AM](https://user-images.githubusercontent.com/26798134/130649941-4e62ee04-d4fc-4f2d-b23b-1e0a539cba13.png)

### Testing 
Tested with local that I could specify my immutable ID:
![Screen Shot 2021-08-24 at 11 49 10 AM](https://user-images.githubusercontent.com/26798134/130649986-39b35fbb-0555-4368-bade-a342a6de97e3.png)
