### PR TITLE
EVG-15262: terminate stale initializing pods

### DIFF
--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -93,15 +93,15 @@ func FindByNeedsTermination() ([]Pod, error) {
 	return Find(bson.M{
 		"$or": []bson.M{
 			{
-				StatusKey: StatusDecommissioned,
-			},
-			{
-				bsonutil.GetDottedKeyName(TimeInfoKey, TimeInfoStartingKey): bson.M{"$lte": staleCutoff},
-				StatusKey: StatusStarting,
-			},
-			{
 				StatusKey: StatusInitializing,
 				bsonutil.GetDottedKeyName(TimeInfoKey, TimeInfoInitializingKey): bson.M{"$lte": staleCutoff},
+			},
+			{
+				StatusKey: StatusStarting,
+				bsonutil.GetDottedKeyName(TimeInfoKey, TimeInfoStartingKey): bson.M{"$lte": staleCutoff},
+			},
+			{
+				StatusKey: StatusDecommissioned,
 			},
 		},
 	})

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -40,6 +40,9 @@ const (
 	StatusStarting Status = "starting"
 	// StatusRunning indicates that the pod's containers are running.
 	StatusRunning Status = "running"
+	// StatusDecommissioned indicates that the pod is currently running but will
+	// be terminated shortly.
+	StatusDecommissioned Status = "decommissioned"
 	// StatusTerminated indicates that all of the pod's containers and
 	// associated resources have been deleted.
 	StatusTerminated Status = "terminated"

--- a/units/crons.go
+++ b/units/crons.go
@@ -1273,7 +1273,7 @@ func PopulatePodCreationJobs(env evergreen.Environment) amboy.QueueOperation {
 
 func PopulatePodTerminationJobs(env evergreen.Environment) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
-		pods, err := pod.FindByStaleStarting()
+		pods, err := pod.FindByNeedsTermination()
 		if err != nil {
 			return errors.Wrap(err, "finding pods that have been stuck starting for too long")
 		}

--- a/units/pod_creation.go
+++ b/units/pod_creation.go
@@ -14,7 +14,6 @@ import (
 	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -83,27 +82,14 @@ func (j *podCreationJob) Run(ctx context.Context) {
 			j.AddError(j.ecsClient.Close(ctx))
 		}
 
-		if j.pod != nil {
-			// kim: TODO: check that message.WrapError formats as desired.
-			if j.pod.Status == pod.StatusInitializing && (j.RetryInfo().GetRemainingAttempts() == 0 || !j.RetryInfo().ShouldRetry()) {
-				if err := j.pod.UpdateStatus(pod.StatusDecommissioned); err != nil {
-					j.AddError(message.WrapError(err, message.Fields{
-						"message": "could not set pod to decommissioned after failing to start",
-						"pod_id":  j.PodID,
-					}))
-				}
-			}
+		if j.pod != nil && j.pod.Status == pod.StatusInitializing && (j.RetryInfo().GetRemainingAttempts() == 0 || !j.RetryInfo().ShouldRetry()) {
+			j.AddError(errors.Wrap(j.pod.UpdateStatus(pod.StatusDecommissioned), "updating pod status to decommissioned after pod failed to start"))
 		}
 	}()
 	if err := j.populateIfUnset(ctx); err != nil {
 		j.AddRetryableError(err)
 		return
 	}
-
-	// j.AddError(message.WrapError(errors.New("kim: some test error"), message.Fields{
-	//     "message": "kim: testing error format in Splunk",
-	//     "pod_id":  j.PodID,
-	// }))
 
 	settings := *j.env.Settings()
 	// Use the latest service flags instead of those cached in the environment.

--- a/units/pod_creation_test.go
+++ b/units/pod_creation_test.go
@@ -124,23 +124,7 @@ func TestPodCreationJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusTerminated, dbPod.Status)
 		},
-		"FailsWithBadContainerOptions": func(ctx context.Context, t *testing.T, j *podCreationJob) {
-			j.pod.TaskContainerCreationOpts = pod.TaskContainerCreationOptions{}
-			require.NoError(t, j.pod.Insert())
-
-			j.Run(ctx)
-			require.Error(t, j.Error())
-			require.Zero(t, j.ecsPod)
-			require.Zero(t, j.pod.Resources)
-			assert.Len(t, cocoaMock.GlobalSecretCache, 0)
-			assert.Len(t, cocoaMock.GlobalECSService.Clusters[clusterName], 0)
-
-			dbPod, err := pod.FindOneByID(j.PodID)
-			require.NoError(t, err)
-			require.NotZero(t, dbPod)
-			assert.Equal(t, pod.StatusInitializing, dbPod.Status)
-		},
-		"DecommissionsInitializingPodWithNoMoreAttempts": func(ctx context.Context, t *testing.T, j *podCreationJob) {
+		"DecommissionsInitializingPodWithBadContainerOptions": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			j.pod.TaskContainerCreationOpts = pod.TaskContainerCreationOptions{}
 			require.NoError(t, j.pod.Insert())
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15262

### Description 
* Add decommissioned status to mean that the pod intends on terminating.
* Terminate pods that have been initializing for too long without successfully being started in ECS.
* Terminate pods that run out of attempts to start in ECS.

### Testing 
DB tests and Amboy job tests.