### PR TITLE
EVG-15274 add display task ID to existing execution tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -899,7 +899,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 		}
 
 		// update existing exec tasks
-		grip.Error(message.WrapError(task.DisplayTaskIdToExecTasks(id, execTasksThatNeedParentId), message.Fields{
+		grip.Error(message.WrapError(task.AddDisplayTaskIdToExecTasks(id, execTasksThatNeedParentId), message.Fields{
 			"message":              "problem adding display task ID to exec tasks",
 			"exec_tasks_to_update": execTasksThatNeedParentId,
 			"display_task_id":      id,

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -706,7 +706,7 @@ func CreateBuildFromVersionNoInsert(args BuildCreateArgs) (*build.Build, task.Ta
 	// create task caches for all of the tasks, and place them into the build
 	tasks := []task.Task{}
 	for _, taskP := range tasksForBuild {
-		if taskP.DisplayTask != nil {
+		if taskP.IsPartOfDisplay() {
 			continue // don't add execution parts of display tasks to the UI cache
 		}
 		tasks = append(tasks, *taskP)

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -870,6 +870,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 		execTasksThatNeedParentId := []string{}
 		execTaskIds := []string{}
 		displayTaskActivated := false
+		displayTaskAlreadyExists := !createAll && !utility.StringSliceContains(displayNames, dt.Name)
 
 		// get display task activations status and update exec tasks
 		for _, et := range dt.ExecTasks {
@@ -882,7 +883,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 					"available_tasks":             execTable,
 					"project":                     project.Identifier,
 					"display_task":                id,
-					"display_task_already_exists": true,
+					"display_task_already_exists": displayTaskAlreadyExists,
 				})
 				continue
 			}
@@ -907,7 +908,6 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 			"build_id":             b.Id,
 		}))
 
-		displayTaskAlreadyExists := !createAll && !utility.StringSliceContains(displayNames, dt.Name)
 		// existing display task may need to be updated
 		if displayTaskAlreadyExists {
 			grip.Error(message.WrapError(task.AddExecTasksToDisplayTask(id, execTaskIds, displayTaskActivated), message.Fields{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3255,6 +3255,20 @@ func (t *Task) SetNumDependents() error {
 	}, update)
 }
 
+func DisplayTaskIdToExecTasks(displayTaskId string, execTasksToUpdate []string) error {
+	if len(execTasksToUpdate) == 0 {
+		return nil
+	}
+	_, err := UpdateAll(bson.M{
+		IdKey: bson.M{"$in": execTasksToUpdate},
+	},
+		bson.M{"$set": bson.M{
+			DisplayTaskIdKey: displayTaskId,
+		}},
+	)
+	return err
+}
+
 func AddExecTasksToDisplayTask(displayTaskId string, execTasks []string, displayTaskActivated bool) error {
 	if len(execTasks) == 0 {
 		return nil

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3255,7 +3255,7 @@ func (t *Task) SetNumDependents() error {
 	}, update)
 }
 
-func DisplayTaskIdToExecTasks(displayTaskId string, execTasksToUpdate []string) error {
+func AddDisplayTaskIdToExecTasks(displayTaskId string, execTasksToUpdate []string) error {
 	if len(execTasksToUpdate) == 0 {
 		return nil
 	}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2613,6 +2613,40 @@ func TestAddParentDisplayTasks(t *testing.T) {
 	assert.Equal(t, dt2.Id, tasks[3].DisplayTask.Id)
 }
 
+func TestAddDisplayTaskIdToExecTasks(t *testing.T) {
+	assert.NoError(t, db.Clear(Collection))
+	t1 := &Task{
+		Id:            "t1",
+		DisplayTaskId: utility.ToStringPtr(""),
+	}
+	t2 := &Task{
+		Id:            "t2",
+		DisplayTaskId: nil,
+	}
+	t3 := &Task{
+		Id:            "t3",
+		DisplayTaskId: utility.ToStringPtr(""),
+	}
+	assert.NoError(t, t1.Insert())
+	assert.NoError(t, t2.Insert())
+	assert.NoError(t, t3.Insert())
+
+	assert.NoError(t, AddDisplayTaskIdToExecTasks("dt", []string{t1.Id, t2.Id}))
+
+	var err error
+	t1, err = FindOneId(t1.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, utility.FromStringPtr(t1.DisplayTaskId), "dt")
+
+	t2, err = FindOneId(t2.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, utility.FromStringPtr(t2.DisplayTaskId), "dt")
+
+	t3, err = FindOneId(t3.Id)
+	assert.NoError(t, err)
+	assert.NotEqual(t, utility.FromStringPtr(t3.DisplayTaskId), "dt")
+}
+
 func TestAddExecTasksToDisplayTask(t *testing.T) {
 	assert.NoError(t, db.Clear(Collection))
 	dt1 := Task{

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -235,6 +235,7 @@ func (at *APITask) BuildFromService(t interface{}) error {
 			Aborted:                 v.Aborted,
 			CanSync:                 v.CanSync,
 			MustHaveResults:         v.MustHaveResults,
+			ParentTaskId:            utility.FromStringPtr(v.DisplayTaskId),
 			SyncAtEndOpts: APISyncAtEndOptions{
 				Enabled:  v.SyncAtEndOpts.Enabled,
 				Statuses: v.SyncAtEndOpts.Statuses,


### PR DESCRIPTION
[EVG-EVG-15274](https://jira.mongodb.org/browse/EVG-15274)

### Description 
When I made this display task ID change, I didn't think to update tasks that already exist but are only now being made into execution tasks. But also I decided to just refactor this section (which per Julian's retro he mentioned we shouldn't do whoops 😅  but it's a small ish refactor; I'll call out the actual change for the fix in a comment)

### Testing 
Added a unit test. I'm honestly having trouble replicating this bug on staging; I'm not sure if it's the way the tasks are generated on the server project or what. I do suspect this will fix the problem, I've read over it a few times and it does seem like _a_ bug if not _the_ bug so I think it's worth deploying and seeing what happens, but let me know what you think.
