### PR TITLE
EVG-15336: use ECS task status constants

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -125,7 +125,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: 43815750c2f1d63d1f1de803a8a684ca79ac82d6
   - name: github.com/evergreen-ci/cocoa
-    version: c01c6ca413ec66e814e9cf1f098eddb046f37ebc
+    version: 9633061a7220b184e7bc8908dba9a3da021637e4
   - name: github.com/evergreen-ci/gimlet
     version: 3aa4522aad2fa8ad15755e00441b597d6d54cc5e
   - name: github.com/evergreen-ci/shrub

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -402,7 +402,6 @@ func (sns *ecsSNS) handleNotification(ctx context.Context, notification ecsEvent
 			return nil
 		}
 
-		// TODO (EVG-15336): turn ECS task states into constants.
 		switch notification.Detail.LastStatus {
 		case ecs.TaskStatusProvisioning, ecs.TaskStatusPending, ecs.TaskStatusActivating, ecs.TaskStatusRunning:
 			// No-op because the pod is not considered running until the agent

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/evergreen-ci/cocoa/ecs"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/data"
@@ -403,15 +404,15 @@ func (sns *ecsSNS) handleNotification(ctx context.Context, notification ecsEvent
 
 		// TODO (EVG-15336): turn ECS task states into constants.
 		switch notification.Detail.LastStatus {
-		case "PROVISIONING", "PENDING", "ACTIVATING", "RUNNING":
+		case ecs.TaskStatusProvisioning, ecs.TaskStatusPending, ecs.TaskStatusActivating, ecs.TaskStatusRunning:
 			// No-op because the pod is not considered running until the agent
 			// contacts the app server.
 			return nil
-		case "DEACTIVATING", "STOPPING", "DEPROVISIONING":
+		case ecs.TaskStatusDeactivating, ecs.TaskStatusStopping, ecs.TaskStatusDeprovisioning:
 			// No-op because the pod is preparing to stop but is not yet
 			// stopped.
 			return nil
-		case "STOPPED":
+		case ecs.TaskStatusStopped:
 			reason := notification.Detail.StoppedReason
 			if reason == "" {
 				reason = "stopped due to unknown reason"

--- a/vendor/github.com/evergreen-ci/cocoa/ecs/constant.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs/constant.go
@@ -1,0 +1,31 @@
+package ecs
+
+// Constants represents ECS task states.
+const (
+	// TaskStatusProvisioning indicates that ECS is performing additional work
+	// before launching the task (e.g. provisioning a network interface for
+	// AWSVPC).
+	TaskStatusProvisioning = "PROVISIONING"
+	// TaskStatusPending is a transition state indicating that ECS is waiting
+	// for the container agent to act.
+	TaskStatusPending = "PENDING"
+	// TaskStatusActivating indicates that the task is launched but needs to
+	// perform additional work before the task is fully running (e.g. service
+	// discovery setup).
+	TaskStatusActivating = "ACTIVATING"
+	// TaskStatusRunning indicates that the task is running.
+	TaskStatusRunning = "RUNNING"
+	// TaskStatusDeactivating indicates that the task is preparing to stop but
+	// needs to perform additional work first (e.g. deregistering load balancer
+	// target groups).
+	TaskStatusDeactivating = "DEACTIVATING"
+	// TaskStatusStopping is a transition state indicating that ECS is waiting
+	// for the container agent to act.
+	TaskStatusStopping = "STOPPING"
+	// TaskStatusDeprovisioning indicates that the task is no longer running but
+	// needs to perform additional work before the task is fully stopped (e.g.
+	// detaching the network interface for AWSVPC).
+	TaskStatusDeprovisioning = "DEPROVISIONING"
+	// TaskStatusStopped indicates that the task is stopped.
+	TaskStatusStopped = "STOPPED"
+)

--- a/vendor/github.com/evergreen-ci/cocoa/ecs/pod_creator.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs/pod_creator.go
@@ -339,11 +339,11 @@ func (pc *BasicECSPodCreator) translateECSStatus(status *string) cocoa.ECSStatus
 		return cocoa.StatusUnknown
 	}
 	switch *status {
-	case "PROVISIONING", "PENDING", "ACTIVATING":
+	case TaskStatusProvisioning, TaskStatusPending, TaskStatusActivating:
 		return cocoa.StatusStarting
-	case "RUNNING":
+	case TaskStatusRunning:
 		return cocoa.StatusRunning
-	case "DEACTIVATING", "STOPPING", "DEPROVISIONING":
+	case TaskStatusDeactivating, TaskStatusStopping, TaskStatusDeprovisioning, TaskStatusStopped:
 		return cocoa.StatusStopped
 	default:
 		return cocoa.StatusUnknown


### PR DESCRIPTION
JIra: https://jira.mongodb.org/browse/EVG-15336

### Description 
* Revendor Cocoa.
* Use ECS task status constants instead of hard-coded strings.