### PR TITLE
EVG-15353: Use ConverToOld when converting test results

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2106,8 +2106,8 @@ func (t *Task) populateNewTestResults() error {
 	if err != nil {
 		return errors.Wrap(err, "finding test results")
 	}
-	for _, result := range newTestResults {
-		t.LocalTestResults = append(t.LocalTestResults, ConvertToOld(&result))
+	for i := range newTestResults {
+		t.LocalTestResults = append(t.LocalTestResults, ConvertToOld(&newTestResults[i]))
 	}
 	t.testResultsPopulated = true
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2107,19 +2107,7 @@ func (t *Task) populateNewTestResults() error {
 		return errors.Wrap(err, "finding test results")
 	}
 	for _, result := range newTestResults {
-		t.LocalTestResults = append(t.LocalTestResults, TestResult{
-			Status:          result.Status,
-			TestFile:        result.TestFile,
-			DisplayTestName: result.DisplayTestName,
-			GroupID:         result.GroupID,
-			URL:             result.URL,
-			URLRaw:          result.URLRaw,
-			LogId:           result.LogID,
-			LineNum:         result.LineNum,
-			ExitCode:        result.ExitCode,
-			StartTime:       result.StartTime,
-			EndTime:         result.EndTime,
-		})
+		t.LocalTestResults = append(t.LocalTestResults, ConvertToOld(result))
 	}
 	t.testResultsPopulated = true
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2107,7 +2107,7 @@ func (t *Task) populateNewTestResults() error {
 		return errors.Wrap(err, "finding test results")
 	}
 	for _, result := range newTestResults {
-		t.LocalTestResults = append(t.LocalTestResults, ConvertToOld(result))
+		t.LocalTestResults = append(t.LocalTestResults, ConvertToOld(&result))
 	}
 	t.testResultsPopulated = true
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15353

Not using this function caused a bug in the UI because we were not setting the `TaskID` field.
