### PR TITLE
EVG-15338 print saving project error correctly

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -618,7 +618,11 @@ mciModule.controller(
             $scope.isDirty = false;
           },
           function (resp) {
-            $scope.saveMessage = "Couldn't save project: " + resp.data.error;
+              var message = resp.data;
+            if (resp.data.error !== undefined) {
+                message = resp.data.error;
+            }
+            $scope.saveMessage = "Couldn't save project: " + message;
           }
         );
     };

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -618,10 +618,7 @@ mciModule.controller(
             $scope.isDirty = false;
           },
           function (resp) {
-              var message = resp.data;
-            if (resp.data.error !== undefined) {
-                message = resp.data.error;
-            }
+            const message = resp.data.error ?? resp.data;
             $scope.saveMessage = "Couldn't save project: " + message;
           }
         );


### PR DESCRIPTION
[EVG-15338](https://jira.mongodb.org/browse/EVG-15338)

### Description 
Kind of a bandaid, but fixing the backend to always return the error in the same format is more complicated, and this is soon-to-be legacy anyway.

### Testing
Tested with evergreen local.