### PR TITLE
EVG-15353: Project task_id and execution for test results FindByTaskIDAndExecution query

### DIFF
--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -101,9 +101,6 @@ func FilterByTaskIDAndExecution(taskID string, execution int) db.Q {
 	return db.Query(bson.M{
 		TaskIDKey:    taskID,
 		ExecutionKey: execution,
-	}).Project(bson.M{
-		TaskIDKey:    0,
-		ExecutionKey: 0,
 	})
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15353

We need these fields for route generation in the legacy UI. There is also no reason not to project them.