### PR TITLE
EVG-14963: Add host create details when host is externally terminated

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1406,13 +1406,14 @@ func AbortTasksForVersion(versionId string, taskIds []string, caller string) err
 	return err
 }
 
-func AddHostCreateDetails(taskId, hostId string, hostCreateError error) error {
+func AddHostCreateDetails(taskId, hostId string, execution int, hostCreateError error) error {
 	if hostCreateError == nil {
 		return nil
 	}
 	err := UpdateOne(
 		bson.M{
-			IdKey: taskId,
+			IdKey:        taskId,
+			ExecutionKey: execution,
 		},
 		bson.M{"$push": bson.M{
 			HostCreateDetailsKey: HostCreateDetail{HostId: hostId, Error: hostCreateError.Error()},

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1717,10 +1717,10 @@ func TestGetTimeSpent(t *testing.T) {
 
 func TestAddHostCreateDetails(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
-	task := Task{Id: "t1"}
+	task := Task{Id: "t1", Execution: 0}
 	assert.NoError(t, task.Insert())
 	errToSave := errors.Wrapf(errors.New("InsufficientCapacityError"), "error trying to start host")
-	assert.NoError(t, AddHostCreateDetails(task.Id, "h1", errToSave))
+	assert.NoError(t, AddHostCreateDetails(task.Id, "h1", 0, errToSave))
 	dbTask, err := FindOneId(task.Id)
 	assert.NoError(t, err)
 	assert.NotNil(t, dbTask)
@@ -1728,7 +1728,7 @@ func TestAddHostCreateDetails(t *testing.T) {
 	assert.Equal(t, dbTask.HostCreateDetails[0].HostId, "h1")
 	assert.Contains(t, dbTask.HostCreateDetails[0].Error, "InsufficientCapacityError")
 
-	assert.NoError(t, AddHostCreateDetails(task.Id, "h2", errToSave))
+	assert.NoError(t, AddHostCreateDetails(task.Id, "h2", 0, errToSave))
 	dbTask, err = FindOneId(task.Id)
 	assert.NoError(t, err)
 	assert.NotNil(t, dbTask)

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -138,7 +138,7 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 			return false, errors.New("non-agent host is not already terminated and should not be terminated")
 		}
 		if h.RunningTask != "" {
-			if err := task.AddHostCreateDetails(h.RunningTask, h.Id, ctx.Err()); err != nil {
+			if err := task.AddHostCreateDetails(h.RunningTask, h.Id, errors.New("error adding host create error details")); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"message":      "error adding host create error details",
 					"cloud_status": cloudStatus.String(),

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -137,8 +137,8 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 		if cloudStatus != cloud.StatusTerminated && (h.UserHost || h.StartedBy != evergreen.User) {
 			return false, errors.New("non-agent host is not already terminated and should not be terminated")
 		}
-		if h.RunningTask != "" {
-			if err := task.AddHostCreateDetails(h.RunningTask, h.Id, errors.New("host was externally terminated")); err != nil {
+		if h.SpawnOptions.SpawnedByTask {
+			if err := task.AddHostCreateDetails(h.SpawnOptions.TaskID, h.Id, errors.New("host was externally terminated")); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"message":      "error adding host create error details",
 					"cloud_status": cloudStatus.String(),

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -137,14 +137,15 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 		if cloudStatus != cloud.StatusTerminated && (h.UserHost || h.StartedBy != evergreen.User) {
 			return false, errors.New("non-agent host is not already terminated and should not be terminated")
 		}
-
-		if err := task.AddHostCreateDetails(h.StartedBy, h.Id, ctx.Err()); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"message":      "error adding host create error details",
-				"cloud_status": cloudStatus.String(),
-				"host_id":      h.Id,
-				"task_id":      h.StartedBy,
-			}))
+		if h.RunningTask != "" {
+			if err := task.AddHostCreateDetails(h.RunningTask, h.Id, ctx.Err()); err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"message":      "error adding host create error details",
+					"cloud_status": cloudStatus.String(),
+					"host_id":      h.Id,
+					"task_id":      h.StartedBy,
+				}))
+			}
 		}
 		event.LogHostTerminatedExternally(h.Id, h.Status)
 

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -138,7 +138,7 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 			return false, errors.New("non-agent host is not already terminated and should not be terminated")
 		}
 		if h.SpawnOptions.SpawnedByTask {
-			if err := task.AddHostCreateDetails(h.SpawnOptions.TaskID, h.Id, errors.New("host was externally terminated")); err != nil {
+			if err := task.AddHostCreateDetails(h.SpawnOptions.TaskID, h.Id, h.SpawnOptions.TaskExecutionNumber, errors.New("host was externally terminated")); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"message":      "error adding host create error details",
 					"cloud_status": cloudStatus.String(),

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -187,8 +187,8 @@ func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Mana
 		event.LogHostTerminatedExternally(h.Id, h.Status)
 
 		catcher := grip.NewBasicCatcher()
-		if h.RunningTask != "" {
-			if err := task.AddHostCreateDetails(h.RunningTask, h.Id, errors.New("host was externally terminated")); err != nil {
+		if h.SpawnOptions.SpawnedByTask {
+			if err := task.AddHostCreateDetails(h.SpawnOptions.TaskID, h.Id, errors.New("host was externally terminated")); err != nil {
 				catcher.Wrap(err, "error adding host create error details")
 			}
 		}

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -188,7 +188,7 @@ func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Mana
 
 		catcher := grip.NewBasicCatcher()
 		if h.SpawnOptions.SpawnedByTask {
-			if err := task.AddHostCreateDetails(h.SpawnOptions.TaskID, h.Id, errors.New("host was externally terminated")); err != nil {
+			if err := task.AddHostCreateDetails(h.SpawnOptions.TaskID, h.Id, h.SpawnOptions.TaskExecutionNumber, errors.New("host was externally terminated")); err != nil {
 				catcher.Wrap(err, "error adding host create error details")
 			}
 		}

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -218,7 +218,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 
 	defer func() {
 		if j.RetryInfo().GetRemainingAttempts() == 0 && j.HasErrors() && (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) && j.host.SpawnOptions.SpawnedByTask {
-			if err := task.AddHostCreateDetails(j.host.StartedBy, j.host.Id, j.Error()); err != nil {
+			if err := task.AddHostCreateDetails(j.host.StartedBy, j.host.Id, j.host.SpawnOptions.TaskExecutionNumber, j.Error()); err != nil {
 				j.AddError(errors.Wrapf(err, "error adding host create error details"))
 			}
 		}


### PR DESCRIPTION
[EVG-14963](https://jira.mongodb.org/browse/EVG-14963)

### Description 
Currently hosts that are spawned by a task that are terminated externally cause host.list to timeout since they are not included in the host details property on a task, and when an external termination occurs the terminated host is not included in the list of hosts associated with a given task.  A change has been made to add a host's details to a given task when it is terminated externally.
