### PR TITLE
EVG-15279 use facet to conditionally lookup annotations

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2944,37 +2944,67 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 
 		pipeline = append(pipeline, recombineTasks...)
 	}
-	pipeline = append(pipeline, []bson.M{
-		// Get any annotation that has at least one issue
-		{
-			"$lookup": bson.M{
-				"from": annotations.Collection,
-				"let":  bson.M{"task_annotation_id": "$" + IdKey, "task_annotation_execution": "$" + ExecutionKey},
-				"pipeline": []bson.M{
-					{
-						"$match": bson.M{
-							"$expr": bson.M{
-								"$and": []bson.M{
-									{
-										"$eq": []string{"$" + annotations.TaskIdKey, "$$task_annotation_id"},
-									},
-									{
-										"$eq": []string{"$" + annotations.TaskExecutionKey, "$$task_annotation_execution"},
-									},
-									{
-										"$ne": []interface{}{
-											bson.M{
-												"$size": bson.M{"$ifNull": []interface{}{"$" + annotations.IssuesKey, []bson.M{}}},
-											}, 0,
+
+	statusFacet := bson.M{
+		"$facet": bson.M{
+			// We skip annotation lookup for non-failed tasks, because these can't have annotations
+			"not_failed": []bson.M{
+				{
+					"$match": bson.M{
+						StatusKey: bson.M{"$nin": evergreen.TaskFailureStatuses},
+					},
+				},
+			},
+			// for failed tasks, get any annotation that has at least one issue
+			"failed": []bson.M{
+				{
+					"$match": bson.M{
+						StatusKey: bson.M{"$in": evergreen.TaskFailureStatuses},
+					},
+				},
+				{
+					"$lookup": bson.M{
+						"from": annotations.Collection,
+						"let":  bson.M{"task_annotation_id": "$" + IdKey, "task_annotation_execution": "$" + ExecutionKey},
+						"pipeline": []bson.M{
+							{
+								"$match": bson.M{
+									"$expr": bson.M{
+										"$and": []bson.M{
+											{
+												"$eq": []string{"$" + annotations.TaskIdKey, "$$task_annotation_id"},
+											},
+											{
+												"$eq": []string{"$" + annotations.TaskExecutionKey, "$$task_annotation_execution"},
+											},
+											{
+												"$ne": []interface{}{
+													bson.M{
+														"$size": bson.M{"$ifNull": []interface{}{"$" + annotations.IssuesKey, []bson.M{}}},
+													}, 0,
+												},
+											},
 										},
 									},
-								},
-							},
-						}}},
-				"as": "annotation_docs",
+								}}},
+						"as": "annotation_docs",
+					},
+				},
 			},
 		},
-
+	}
+	pipeline = append(pipeline, statusFacet)
+	recombineStatusFacet := []bson.M{
+		{"$project": bson.M{
+			"tasks": bson.M{
+				"$setUnion": []string{"$not_failed", "$failed"},
+			}},
+		},
+		{"$unwind": "$tasks"},
+		{"$replaceRoot": bson.M{"newRoot": "$tasks"}},
+	}
+	pipeline = append(pipeline, recombineStatusFacet...)
+	pipeline = append(pipeline, []bson.M{
 		// Add a field for the display status of each task
 		addDisplayStatus,
 		// Add data about the base task

--- a/rest/data/task_test.go
+++ b/rest/data/task_test.go
@@ -88,6 +88,7 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByVersion() {
 		Id:        "task_known",
 		Execution: 2,
 		Version:   "version_known",
+		Status:    evergreen.TaskSucceeded,
 	}
 	task_not_known := &task.Task{
 		Id:        "task_not_known",
@@ -131,7 +132,8 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByVersion() {
 
 	task, _, err := s.ctx.FindTasksByVersion("version_known", opts)
 	s.NoError(err)
-	s.Equal(evergreen.TaskKnownIssue, task[0].DisplayStatus)
+	// ignore annotation for successful task
+	s.Equal(evergreen.TaskSucceeded, task[0].DisplayStatus)
 
 	// test with empty issues list
 	task, _, err = s.ctx.FindTasksByVersion("version_not_known", opts)


### PR DESCRIPTION
[EVG-15279 ](https://jira.mongodb.org/browse/EVG-15279 )

### Description 
Use facet so we don't have to lookup annotations for successful tasks.

### Testing 
Added a test that succeeds before and after changes.
