### PR TITLE
EVG-15369: Fix SchedulePatch in legacy UI

### DIFF
--- a/service/patch.go
+++ b/service/patch.go
@@ -94,7 +94,7 @@ func (uis *UIServer) schedulePatchUI(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusUnauthorized, errors.New("Not authorized to schedule patch"))
 	}
 	patchUpdateReq := graphql.PatchUpdate{}
-	if err := utility.ReadJSON(util.NewRequestReader(r), &patchUpdateReq.VariantsTasks); err != nil {
+	if err := utility.ReadJSON(util.NewRequestReader(r), &patchUpdateReq); err != nil {
 		uis.LoggedError(w, r, http.StatusBadRequest, err)
 	}
 


### PR DESCRIPTION
[EVG-15369](https://jira.mongodb.org/browse/EVG-15369)

### Description 
- Fix target type of ReadJSON operation; the request includes `description` and `variants_tasks` fields, so it should just be read into type `PatchUpdate`

### Testing 
- Tested on staging
