### PR TITLE
EVG-15382: export decommissioned pod status

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -90,7 +90,7 @@ func exportECSPodStatus(s pod.Status) (cocoa.ECSStatus, error) {
 		return cocoa.StatusUnknown, errors.Errorf("a pod that is initializing does not exist in ECS yet")
 	case pod.StatusStarting:
 		return cocoa.StatusStarting, nil
-	case pod.StatusRunning:
+	case pod.StatusRunning, pod.StatusDecommissioned:
 		return cocoa.StatusRunning, nil
 	case pod.StatusTerminated:
 		return cocoa.StatusDeleted, nil

--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -156,6 +156,12 @@ func TestExportECSPodStatus(t *testing.T) {
 		assert.NoError(t, s.Validate())
 		assert.Equal(t, cocoa.StatusRunning, s)
 	})
+	t.Run("SucceedsWithDecommissionedStatus", func(t *testing.T) {
+		s, err := exportECSPodStatus(pod.StatusDecommissioned)
+		require.NoError(t, err)
+		assert.NoError(t, s.Validate())
+		assert.Equal(t, cocoa.StatusRunning, s)
+	})
 	t.Run("SucceedsWithTerminatedStatus", func(t *testing.T) {
 		s, err := exportECSPodStatus(pod.StatusTerminated)
 		require.NoError(t, err)


### PR DESCRIPTION
JIra: https://jira.mongodb.org/browse/EVG-15382

### Description 
Export the decommissioned pod status as running (it plans to shut down, but it's still counted as running).

### Testing 
Unit tests.