### PR TITLE
EVG-12547 stepback earlier tasks in single host task group

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -801,7 +801,7 @@ func evalStepback(t *task.Task, caller, status string, deactivatePrevious bool) 
 		}
 
 		if t.IsPartOfSingleHostTaskGroup() {
-			// stepback earlier task group tasks as well
+			// Stepback earlier task group tasks as well because these need to be run sequentially.
 			catcher := grip.NewBasicCatcher()
 			tasks, err := task.FindTaskGroupFromBuild(t.BuildId, t.TaskGroup)
 			if err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -796,11 +796,31 @@ func evalStepback(t *task.Task, caller, status string, deactivatePrevious bool) 
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		if shouldStepBack {
-			if err = doStepback(t); err != nil {
-				return errors.Wrap(err, "Error during step back")
-			}
+		if !shouldStepBack {
+			return nil
 		}
+
+		if t.IsPartOfSingleHostTaskGroup() {
+			// stepback earlier task group tasks as well
+			catcher := grip.NewBasicCatcher()
+			tasks, err := task.FindTaskGroupFromBuild(t.BuildId, t.TaskGroup)
+			if err != nil {
+				return errors.Wrapf(err, "can't get task group for task '%s'", t.Id)
+			}
+			if len(tasks) == 0 {
+				return errors.Errorf("no tasks in task group '%s' for task '%s'", t.TaskGroup, t.Id)
+			}
+			for _, tgTask := range tasks {
+				catcher.Wrapf(doStepback(&tgTask), "error stepping back task group task '%s'", tgTask.DisplayName)
+				if tgTask.Id == t.Id {
+					break // don't need to stepback later tasks in the group
+				}
+			}
+
+			return catcher.Resolve()
+		}
+		return errors.Wrap(doStepback(t), "error during stepback")
+
 	} else if deactivatePrevious && status == evergreen.TaskSucceeded {
 		// if the task was successful, ignore running previous
 		// activated tasks for this buildvariant


### PR DESCRIPTION
[EVG-12547](https://jira.mongodb.org/browse/EVG-12547)

### Description 
Tasks in single host task groups typically need to run sequentially on the same host in order to work. When we stepback a failed task (to see if it succeeds on a previous version), we currently only activate the one task, which means that single-host task group tasks are bound to fail. Instead we should activate the earlier tasks in the group (we don't need to activate the later ones to determine stepback).

### Testing 
Unit test.
