### PR TITLE
EVG-15305: reset global config after admin settings test

### DIFF
--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip/level"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -33,7 +34,10 @@ type AdminDataSuite struct {
 func TestDataConnectorSuite(t *testing.T) {
 	s := new(AdminDataSuite)
 	s.ctx = &DBConnector{}
-	require.NoError(t, db.ClearCollections(evergreen.ConfigCollection, task.Collection, task.OldCollection, build.Collection, model.VersionCollection, event.AllLogCollection), "Error clearing collections")
+	require.NoError(t, db.ClearCollections(evergreen.ConfigCollection, task.Collection, task.OldCollection, build.Collection, model.VersionCollection, event.AllLogCollection), "clearing collections")
+	defer func() {
+		assert.NoError(t, db.ClearCollections(evergreen.ConfigCollection, task.Collection, task.OldCollection, build.Collection, model.VersionCollection, event.AllLogCollection), "clearing collections")
+	}()
 	b := &build.Build{
 		Id:      "buildtest",
 		Status:  evergreen.BuildStarted,

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -42,7 +42,10 @@ type AdminRouteSuite struct {
 func TestAdminRouteSuiteWithDB(t *testing.T) {
 	s := new(AdminRouteSuite)
 	s.sc = &data.DBConnector{}
-	require.NoError(t, db.ClearCollections(evergreen.ConfigCollection), "Error clearing collections")
+	require.NoError(t, db.ClearCollections(evergreen.ConfigCollection), "clearing collections")
+	defer func() {
+		assert.NoError(t, db.ClearCollections(evergreen.ConfigCollection), "clearing collections")
+	}()
 
 	// run the rest of the tests
 	suite.Run(t, s)


### PR DESCRIPTION
JIra: https://jira.mongodb.org/browse/EVG-15305

### Description 
Clear the admin settings in the DB after they've been modified in admin settings tests. This fixes an issue where updating the DB admin settings in one test can affect unrelated tests that depend on DB state, like service flags.