### PR TITLE
EVG-15267 use directories consistently for applying module patches

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -778,7 +778,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 				continue
 			}
 
-			dir = filepath.Join(c.Directory, expandModulePrefix(conf, module.Name, module.Prefix, logger), module.Name)
+			dir = filepath.ToSlash(filepath.Join(expandModulePrefix(conf, module.Name, module.Prefix, logger), module.Name))
 		}
 
 		if len(patchPart.PatchSet.Patch) == 0 {
@@ -789,7 +789,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 			logger.Execution().Info("Applying patch with git...")
 
 		} else {
-			logger.Execution().Info("Applying module patch with git...")
+			logger.Execution().Infof("Applying '%s' module patch with git...", patchPart.ModuleName)
 		}
 
 		// create a temporary folder and store patch files on disk,
@@ -818,7 +818,8 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 		patchCommandStrings = append(patchCommandStrings, applyCommand)
 		cmdsJoined := strings.Join(patchCommandStrings, "\n")
 
-		cmd := jpm.CreateCommand(ctx).Directory(conf.WorkDir).Add([]string{"bash", "-c", cmdsJoined}).
+		cmd := jpm.CreateCommand(ctx).Add([]string{"bash", "-c", cmdsJoined}).
+			Directory(filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory))).
 			SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Task().GetSender())
 
 		if err = cmd.Run(ctx); err != nil {

--- a/config.go
+++ b/config.go
@@ -32,10 +32,10 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2021-07-20"
+	ClientVersion = "2021-09-09"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-08-20"
+	AgentVersion = "2021-09-09"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -50,7 +50,7 @@ const LoadProjectError = "load project error(s)"
 // configuration YAML. It implements the Unmarshaler interface
 // to allow for flexible handling.
 type ParserProject struct {
-	// Id and ConfigUpdateNumber are not pointers because they are only used internally
+	// Id and ConfigdUpdateNumber are not pointers because they are only used internally
 	Id                     string                         `yaml:"_id" bson:"_id"` // should be the same as the version's ID
 	ConfigUpdateNumber     int                            `yaml:"config_number,omitempty" bson:"config_number,omitempty"`
 	Enabled                *bool                          `yaml:"enabled,omitempty" bson:"enabled,omitempty"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -50,7 +50,7 @@ const LoadProjectError = "load project error(s)"
 // configuration YAML. It implements the Unmarshaler interface
 // to allow for flexible handling.
 type ParserProject struct {
-	// Id and ConfigdUpdateNumber are not pointers because they are only used internally
+	// Id and ConfigUpdateNumber are not pointers because they are only used internally
 	Id                     string                         `yaml:"_id" bson:"_id"` // should be the same as the version's ID
 	ConfigUpdateNumber     int                            `yaml:"config_number,omitempty" bson:"config_number,omitempty"`
 	Enabled                *bool                          `yaml:"enabled,omitempty" bson:"enabled,omitempty"`

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -58,7 +58,7 @@ func PatchSetModule() cli.Command {
 
 			existingPatch, err := ac.GetPatch(patchID)
 			if err != nil {
-				return errors.Wrapf(err, "problem getting patch '%s'", existingPatch.Id)
+				return errors.Wrapf(err, "problem getting patch '%s'", patchID)
 			}
 			if existingPatch.IsCommitQueuePatch() {
 				return errors.New("Use `commit-queue set-module` instead of `set-module` for commit queue patches")


### PR DESCRIPTION
[EVG-15267](https://jira.mongodb.org/browse/EVG-15267)

### Description 
Commands aren't my strong suite so I'm only partially convinced this makes sense but:
It seems like when we clone the module, we setup the command directory and the module directory using different paths than when we apply the patch. This works for the non `${workdir}` case but not for the other case I think because of how we order things. By using the same scheme as when we clone the module, this works for both cases. (I think.)

Adding Kim to review because she'll probably understand this the best.

### Testing 
[Patch](https://spruce-staging.corp.mongodb.com/task/sandbox_ubuntu1604_unit_tests_patch_92f8580018375186b1129c7599ee2db76c1605be_613a83e09dbe3251f4f7e817_21_09_09_22_00_30/logs?execution=0&logtype=agent) with `prefix ../../src`
[Patch](https://spruce-staging.corp.mongodb.com/task/sandbox_ubuntu1604_unit_tests_patch_92f8580018375186b1129c7599ee2db76c1605be_613a852797b1d342a4a20007_21_09_09_22_05_56/logs?execution=0&logtype=agent) with `prefix ${workdir}/src`
Note that these succeed regardless of git.get_project since it's a pre_task command for this project, but there are no errors in the logs.