### PR TITLE
EVG-14129: Allow expansions in the shell field for shell.exec

### DIFF
--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -248,6 +248,9 @@ func (c *shellExec) doExpansions(exp *util.Expansions) error {
 	c.Script, err = exp.ExpandString(c.Script)
 	catcher.Add(err)
 
+	c.Shell, err = exp.ExpandString(c.Shell)
+	catcher.Add(err)
+
 	for k, v := range c.Env {
 		c.Env[k], err = exp.ExpandString(v)
 		catcher.Add(err)

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-07-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-08-20"
+	AgentVersion = "2021-09-10"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-14129](https://jira.mongodb.org/browse/EVG-14129)

### Description 
User requested to enabled expansions in the shell field for shell.exec commands.  Change has been made to expand the string in the shell field.

### Testing 
Input an expansion for the shell field in self-tests.yml and deployed to staging and confirmed when restarting a task that the field was expanded.