### PR TITLE
EVG-15173: provision Windows pods with the agent

### DIFF
--- a/cloud/pod_agent_util_test.go
+++ b/cloud/pod_agent_util_test.go
@@ -29,8 +29,7 @@ func TestAgentScript(t *testing.T) {
 				},
 				Secret: "secret",
 			}
-			cmd, err := agentScript(settings, p)
-			require.NoError(t, err)
+			cmd := agentScript(settings, p)
 			require.NotZero(t, cmd)
 
 			expected := []string{
@@ -51,15 +50,13 @@ func TestAgentScript(t *testing.T) {
 				},
 				Secret: "secret",
 			}
-			cmd, err := agentScript(settings, p)
-			require.NoError(t, err)
+			cmd := agentScript(settings, p)
 			require.NotZero(t, cmd)
 
 			expected := []string{
-				"bash", "-c",
+				"cmd.exe", "/c",
 				"curl -LO 'www.test.com/clients/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100 && " +
-					"chmod +x evergreen.exe && " +
-					"./evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci",
+					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci",
 			}
 			assert.Equal(t, expected, cmd)
 		})
@@ -81,8 +78,7 @@ func TestAgentScript(t *testing.T) {
 				},
 				Secret: "secret",
 			}
-			cmd, err := agentScript(settings, p)
-			require.NoError(t, err)
+			cmd := agentScript(settings, p)
 			require.NotZero(t, cmd)
 
 			expected := []string{
@@ -103,14 +99,12 @@ func TestAgentScript(t *testing.T) {
 				},
 				Secret: "secret",
 			}
-			cmd, err := agentScript(settings, p)
-			require.NoError(t, err)
+			cmd := agentScript(settings, p)
 			require.NotZero(t, cmd)
 			expected := []string{
-				"bash", "-c",
+				"cmd.exe", "/c",
 				fmt.Sprintf("(curl -LO 'https://foo.com/%s/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100 || curl -LO 'www.test.com/clients/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100) && "+
-					"chmod +x evergreen.exe && "+
-					"./evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci", evergreen.BuildRevision),
+					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci", evergreen.BuildRevision),
 			}
 			assert.Equal(t, expected, cmd)
 		})

--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -212,17 +212,13 @@ func ExportECSPodCreationOptions(settings *evergreen.Settings, p *pod.Pod) (*coc
 // exportECSPodContainerDef exports the ECS pod container definition into the
 // equivalent cocoa.ECSContainerDefintion.
 func exportECSPodContainerDef(settings *evergreen.Settings, p *pod.Pod) (*cocoa.ECSContainerDefinition, error) {
-	script, err := agentScript(settings, p)
-	if err != nil {
-		return nil, errors.Wrap(err, "building agent script")
-	}
 	return cocoa.NewECSContainerDefinition().
 		SetName(agentContainerName).
 		SetImage(p.TaskContainerCreationOpts.Image).
 		SetMemoryMB(p.TaskContainerCreationOpts.MemoryMB).
 		SetCPU(p.TaskContainerCreationOpts.CPU).
 		SetWorkingDir(p.TaskContainerCreationOpts.WorkingDir).
-		SetCommand(script).
+		SetCommand(agentScript(settings, p)).
 		SetEnvironmentVariables(exportPodEnvVars(settings.Providers.AWS.Pod.SecretsManager, p)).
 		AddPortMappings(*cocoa.NewPortMapping().SetContainerPort(agentPort)), nil
 }

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -146,7 +146,7 @@ type TaskContainerCreationOptions struct {
 	WorkingDir string `bson:"working_dir,omitempty" json:"working_dir,omitempty"`
 }
 
-// OS represents recognized operating systems for pods.
+// OS represents a recognized operating system for pods.
 type OS string
 
 const (


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15173

### Description 
Modify the script to start the agent in a pod to be compatible with Windows.

### Testing 
Unit tests and tested the batch script in a Windows container. It can't be tested in an end-to-end way with ECS until [BUILD-13642](https://jira.mongodb.org/browse/BUILD-13642) is done.