### PR TITLE
EVG-15384 use library to handle CORS for rest routes

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -45,6 +45,8 @@ imports:
 
   - name: github.com/stretchr/testify
     version: 890a5c3458b43e6104ff5da8dfa139d013d77544
+  - name: github.com/rs/cors
+    version: 76f58f330d76a55c5badc74f6212e8a15e742c77
 
   - name: github.com/jacobsa/oglematchers
     version: 4fc24f97b5b74022c2a3f4ca7eed57ca29083d3e

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -19,7 +19,6 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -804,7 +803,7 @@ func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.Handler
 			"op":              "addCORSHeaders",
 			"requester":       requester,
 			"allowed_origins": allowedOrigins,
-			"adding_headers":  utility.StringSliceContains(allowedOrigins, requester),
+			"adding_headers":  util.StringContainsSliceRegex(allowedOrigins, requester),
 			"settings_is_nil": evergreen.GetEnvironment().Settings() == nil,
 		})
 		if len(allowedOrigins) > 0 {
@@ -819,13 +818,4 @@ func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.Handler
 		}
 		next(w, r)
 	}
-}
-
-func allowCORS(next http.HandlerFunc) http.HandlerFunc {
-	origins := []string{}
-	settings := evergreen.GetEnvironment().Settings()
-	if settings != nil {
-		origins = settings.Ui.CORSOrigins
-	}
-	return AddCORSHeaders(origins, next)
 }

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -799,7 +799,7 @@ func (m *EventLogPermissionsMiddleware) ServeHTTP(rw http.ResponseWriter, r *htt
 func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		requester := r.Header.Get("Origin")
-		grip.Debug(message.Fields{
+		grip.DebugWhen(requester != "", message.Fields{
 			"op":              "addCORSHeaders",
 			"requester":       requester,
 			"allowed_origins": allowedOrigins,

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/acl"
 	"github.com/mongodb/amboy"
+	"github.com/rs/cors"
 )
 
 const defaultLimit = 100
@@ -52,8 +53,12 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	removeDistroSettings := RequiresDistroPermission(evergreen.PermissionDistroSettings, evergreen.DistroSettingsAdmin)
 	editHosts := RequiresDistroPermission(evergreen.PermissionHosts, evergreen.HostsEdit)
 	cedarTestStats := checkCedarTestStats(settings)
-
-	app.AddWrapper(gimlet.WrapperMiddleware(allowCORS))
+	if settings != nil && len(settings.Ui.CORSOrigins) > 0 {
+		app.AddMiddleware(cors.New(cors.Options{
+			AllowedOrigins:   settings.Ui.CORSOrigins,
+			AllowCredentials: true,
+		}))
+	}
 
 	// Routes
 	app.AddRoute("/").Version(2).Get().RouteHandler(makePlaceHolderManger(sc))

--- a/vendor/github.com/rs/cors/.travis.yml
+++ b/vendor/github.com/rs/cors/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+- 1.9
+- "1.10"
+- tip
+matrix:
+  allow_failures:
+    - go: tip

--- a/vendor/github.com/rs/cors/LICENSE
+++ b/vendor/github.com/rs/cors/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014 Olivier Poitrey <rs@dailymotion.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/rs/cors/README.md
+++ b/vendor/github.com/rs/cors/README.md
@@ -1,0 +1,115 @@
+# Go CORS handler [![godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/rs/cors) [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/rs/cors/master/LICENSE) [![build](https://img.shields.io/travis/rs/cors.svg?style=flat)](https://travis-ci.org/rs/cors) [![Coverage](http://gocover.io/_badge/github.com/rs/cors)](http://gocover.io/github.com/rs/cors)
+
+CORS is a `net/http` handler implementing [Cross Origin Resource Sharing W3 specification](http://www.w3.org/TR/cors/) in Golang.
+
+## Getting Started
+
+After installing Go and setting up your [GOPATH](http://golang.org/doc/code.html#GOPATH), create your first `.go` file. We'll call it `server.go`.
+
+```go
+package main
+
+import (
+    "net/http"
+
+    "github.com/rs/cors"
+)
+
+func main() {
+    mux := http.NewServeMux()
+    mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        w.Write([]byte("{\"hello\": \"world\"}"))
+    })
+
+    // cors.Default() setup the middleware with default options being
+    // all origins accepted with simple methods (GET, POST). See
+    // documentation below for more options.
+    handler := cors.Default().Handler(mux)
+    http.ListenAndServe(":8080", handler)
+}
+```
+
+Install `cors`:
+
+    go get github.com/rs/cors
+
+Then run your server:
+
+    go run server.go
+
+The server now runs on `localhost:8080`:
+
+    $ curl -D - -H 'Origin: http://foo.com' http://localhost:8080/
+    HTTP/1.1 200 OK
+    Access-Control-Allow-Origin: foo.com
+    Content-Type: application/json
+    Date: Sat, 25 Oct 2014 03:43:57 GMT
+    Content-Length: 18
+
+    {"hello": "world"}
+
+### Allow * With Credentials Security Protection
+
+This library has been modified to avoid a well known security issue when configured with `AllowedOrigins` to `*` and `AllowCredentials` to `true`. Such setup used to make the library reflects the request `Origin` header value, working around a security protection embedded into the standard that makes clients to refuse such configuration. This behavior has been removed with [#55](https://github.com/rs/cors/issues/55) and [#57](https://github.com/rs/cors/issues/57).
+
+If you depend on this behavior and understand the implications, you can restore it using the `AllowOriginFunc` with `func(origin string) {return true}`.
+
+Please refer to [#55](https://github.com/rs/cors/issues/55) for more information about the security implications.
+
+### More Examples
+
+* `net/http`: [examples/nethttp/server.go](https://github.com/rs/cors/blob/master/examples/nethttp/server.go)
+* [Goji](https://goji.io): [examples/goji/server.go](https://github.com/rs/cors/blob/master/examples/goji/server.go)
+* [Martini](http://martini.codegangsta.io): [examples/martini/server.go](https://github.com/rs/cors/blob/master/examples/martini/server.go)
+* [Negroni](https://github.com/codegangsta/negroni): [examples/negroni/server.go](https://github.com/rs/cors/blob/master/examples/negroni/server.go)
+* [Alice](https://github.com/justinas/alice): [examples/alice/server.go](https://github.com/rs/cors/blob/master/examples/alice/server.go)
+* [HttpRouter](https://github.com/julienschmidt/httprouter): [examples/httprouter/server.go](https://github.com/rs/cors/blob/master/examples/httprouter/server.go)
+* [Gorilla](http://www.gorillatoolkit.org/pkg/mux): [examples/gorilla/server.go](https://github.com/rs/cors/blob/master/examples/gorilla/server.go)
+* [Buffalo](https://gobuffalo.io): [examples/buffalo/server.go](https://github.com/rs/cors/blob/master/examples/buffalo/server.go)
+* [Gin](https://gin-gonic.github.io/gin): [examples/gin/server.go](https://github.com/rs/cors/blob/master/examples/gin/server.go)
+* [Chi](https://github.com/go-chi/chi): [examples/chi/server.go](https://github.com/rs/cors/blob/master/examples/chi/server.go)
+
+## Parameters
+
+Parameters are passed to the middleware thru the `cors.New` method as follow:
+
+```go
+c := cors.New(cors.Options{
+    AllowedOrigins: []string{"http://foo.com", "http://foo.com:8080"},
+    AllowCredentials: true,
+    // Enable Debugging for testing, consider disabling in production
+    Debug: true,
+})
+
+// Insert the middleware
+handler = c.Handler(handler)
+```
+
+* **AllowedOrigins** `[]string`: A list of origins a cross-domain request can be executed from. If the special `*` value is present in the list, all origins will be allowed. An origin may contain a wildcard (`*`) to replace 0 or more characters (i.e.: `http://*.domain.com`). Usage of wildcards implies a small performance penality. Only one wildcard can be used per origin. The default value is `*`.
+* **AllowOriginFunc** `func (origin string) bool`: A custom function to validate the origin. It takes the origin as an argument and returns true if allowed, or false otherwise. If this option is set, the content of `AllowedOrigins` is ignored.
+* **AllowOriginRequestFunc** `func (r *http.Request origin string) bool`: A custom function to validate the origin. It takes the HTTP Request object and the origin as argument and returns true if allowed or false otherwise. If this option is set, the content of `AllowedOrigins` and `AllowOriginFunc` is ignored
+* **AllowedMethods** `[]string`: A list of methods the client is allowed to use with cross-domain requests. Default value is simple methods (`GET` and `POST`).
+* **AllowedHeaders** `[]string`: A list of non simple headers the client is allowed to use with cross-domain requests.
+* **ExposedHeaders** `[]string`: Indicates which headers are safe to expose to the API of a CORS API specification
+* **AllowCredentials** `bool`: Indicates whether the request can include user credentials like cookies, HTTP authentication or client side SSL certificates. The default is `false`.
+* **MaxAge** `int`: Indicates how long (in seconds) the results of a preflight request can be cached. The default is `0` which stands for no max age.
+* **OptionsPassthrough** `bool`: Instructs preflight to let other potential next handlers to process the `OPTIONS` method. Turn this on if your application handles `OPTIONS`.
+* **Debug** `bool`: Debugging flag adds additional output to debug server side CORS issues.
+
+See [API documentation](http://godoc.org/github.com/rs/cors) for more info.
+
+## Benchmarks
+
+    BenchmarkWithout          20000000    64.6 ns/op      8 B/op    1 allocs/op
+    BenchmarkDefault          3000000      469 ns/op    114 B/op    2 allocs/op
+    BenchmarkAllowedOrigin    3000000      608 ns/op    114 B/op    2 allocs/op
+    BenchmarkPreflight        20000000    73.2 ns/op      0 B/op    0 allocs/op
+    BenchmarkPreflightHeader  20000000    73.6 ns/op      0 B/op    0 allocs/op
+    BenchmarkParseHeaderList  2000000      847 ns/op    184 B/op    6 allocs/op
+    BenchmarkParse…Single     5000000      290 ns/op     32 B/op    3 allocs/op
+    BenchmarkParse…Normalized 2000000      776 ns/op    160 B/op    6 allocs/op
+
+## Licenses
+
+All source code is licensed under the [MIT License](https://raw.github.com/rs/cors/master/LICENSE).

--- a/vendor/github.com/rs/cors/bench_test.go
+++ b/vendor/github.com/rs/cors/bench_test.go
@@ -1,0 +1,88 @@
+package cors
+
+import (
+	"net/http"
+	"testing"
+)
+
+type FakeResponse struct {
+	header http.Header
+}
+
+func (r FakeResponse) Header() http.Header {
+	return r.header
+}
+
+func (r FakeResponse) WriteHeader(n int) {
+}
+
+func (r FakeResponse) Write(b []byte) (n int, err error) {
+	return len(b), nil
+}
+
+func BenchmarkWithout(b *testing.B) {
+	res := FakeResponse{http.Header{}}
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		testHandler.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkDefault(b *testing.B) {
+	res := FakeResponse{http.Header{}}
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "somedomain.com")
+	handler := Default().Handler(testHandler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkAllowedOrigin(b *testing.B) {
+	res := FakeResponse{http.Header{}}
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "somedomain.com")
+	c := New(Options{
+		AllowedOrigins: []string{"somedomain.com"},
+	})
+	handler := c.Handler(testHandler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkPreflight(b *testing.B) {
+	res := FakeResponse{http.Header{}}
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Access-Control-Request-Method", "GET")
+	handler := Default().Handler(testHandler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkPreflightHeader(b *testing.B) {
+	res := FakeResponse{http.Header{}}
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Access-Control-Request-Method", "GET")
+	req.Header.Add("Access-Control-Request-Headers", "Accept")
+	handler := Default().Handler(testHandler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(res, req)
+	}
+}

--- a/vendor/github.com/rs/cors/cors.go
+++ b/vendor/github.com/rs/cors/cors.go
@@ -1,0 +1,424 @@
+/*
+Package cors is net/http handler to handle CORS related requests
+as defined by http://www.w3.org/TR/cors/
+
+You can configure it by passing an option struct to cors.New:
+
+    c := cors.New(cors.Options{
+        AllowedOrigins:   []string{"foo.com"},
+        AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodDelete},
+        AllowCredentials: true,
+    })
+
+Then insert the handler in the chain:
+
+    handler = c.Handler(handler)
+
+See Options documentation for more options.
+
+The resulting handler is a standard net/http handler.
+*/
+package cors
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Options is a configuration container to setup the CORS middleware.
+type Options struct {
+	// AllowedOrigins is a list of origins a cross-domain request can be executed from.
+	// If the special "*" value is present in the list, all origins will be allowed.
+	// An origin may contain a wildcard (*) to replace 0 or more characters
+	// (i.e.: http://*.domain.com). Usage of wildcards implies a small performance penalty.
+	// Only one wildcard can be used per origin.
+	// Default value is ["*"]
+	AllowedOrigins []string
+	// AllowOriginFunc is a custom function to validate the origin. It take the origin
+	// as argument and returns true if allowed or false otherwise. If this option is
+	// set, the content of AllowedOrigins is ignored.
+	AllowOriginFunc func(origin string) bool
+	// AllowOriginFunc is a custom function to validate the origin. It takes the HTTP Request object and the origin as
+	// argument and returns true if allowed or false otherwise. If this option is set, the content of `AllowedOrigins`
+	// and `AllowOriginFunc` is ignored.
+	AllowOriginRequestFunc func(r *http.Request, origin string) bool
+	// AllowedMethods is a list of methods the client is allowed to use with
+	// cross-domain requests. Default value is simple methods (HEAD, GET and POST).
+	AllowedMethods []string
+	// AllowedHeaders is list of non simple headers the client is allowed to use with
+	// cross-domain requests.
+	// If the special "*" value is present in the list, all headers will be allowed.
+	// Default value is [] but "Origin" is always appended to the list.
+	AllowedHeaders []string
+	// ExposedHeaders indicates which headers are safe to expose to the API of a CORS
+	// API specification
+	ExposedHeaders []string
+	// MaxAge indicates how long (in seconds) the results of a preflight request
+	// can be cached
+	MaxAge int
+	// AllowCredentials indicates whether the request can include user credentials like
+	// cookies, HTTP authentication or client side SSL certificates.
+	AllowCredentials bool
+	// OptionsPassthrough instructs preflight to let other potential next handlers to
+	// process the OPTIONS method. Turn this on if your application handles OPTIONS.
+	OptionsPassthrough bool
+	// Debugging flag adds additional output to debug server side CORS issues
+	Debug bool
+}
+
+// Cors http handler
+type Cors struct {
+	// Debug logger
+	Log *log.Logger
+	// Normalized list of plain allowed origins
+	allowedOrigins []string
+	// List of allowed origins containing wildcards
+	allowedWOrigins []wildcard
+	// Optional origin validator function
+	allowOriginFunc func(origin string) bool
+	// Optional origin validator (with request) function
+	allowOriginRequestFunc func(r *http.Request, origin string) bool
+	// Normalized list of allowed headers
+	allowedHeaders []string
+	// Normalized list of allowed methods
+	allowedMethods []string
+	// Normalized list of exposed headers
+	exposedHeaders []string
+	maxAge         int
+	// Set to true when allowed origins contains a "*"
+	allowedOriginsAll bool
+	// Set to true when allowed headers contains a "*"
+	allowedHeadersAll bool
+	allowCredentials  bool
+	optionPassthrough bool
+}
+
+// New creates a new Cors handler with the provided options.
+func New(options Options) *Cors {
+	c := &Cors{
+		exposedHeaders:         convert(options.ExposedHeaders, http.CanonicalHeaderKey),
+		allowOriginFunc:        options.AllowOriginFunc,
+		allowOriginRequestFunc: options.AllowOriginRequestFunc,
+		allowCredentials:       options.AllowCredentials,
+		maxAge:                 options.MaxAge,
+		optionPassthrough:      options.OptionsPassthrough,
+	}
+	if options.Debug {
+		c.Log = log.New(os.Stdout, "[cors] ", log.LstdFlags)
+	}
+
+	// Normalize options
+	// Note: for origins and methods matching, the spec requires a case-sensitive matching.
+	// As it may error prone, we chose to ignore the spec here.
+
+	// Allowed Origins
+	if len(options.AllowedOrigins) == 0 {
+		if options.AllowOriginFunc == nil && options.AllowOriginRequestFunc == nil {
+			// Default is all origins
+			c.allowedOriginsAll = true
+		}
+	} else {
+		c.allowedOrigins = []string{}
+		c.allowedWOrigins = []wildcard{}
+		for _, origin := range options.AllowedOrigins {
+			// Normalize
+			origin = strings.ToLower(origin)
+			if origin == "*" {
+				// If "*" is present in the list, turn the whole list into a match all
+				c.allowedOriginsAll = true
+				c.allowedOrigins = nil
+				c.allowedWOrigins = nil
+				break
+			} else if i := strings.IndexByte(origin, '*'); i >= 0 {
+				// Split the origin in two: start and end string without the *
+				w := wildcard{origin[0:i], origin[i+1:]}
+				c.allowedWOrigins = append(c.allowedWOrigins, w)
+			} else {
+				c.allowedOrigins = append(c.allowedOrigins, origin)
+			}
+		}
+	}
+
+	// Allowed Headers
+	if len(options.AllowedHeaders) == 0 {
+		// Use sensible defaults
+		c.allowedHeaders = []string{"Origin", "Accept", "Content-Type", "X-Requested-With"}
+	} else {
+		// Origin is always appended as some browsers will always request for this header at preflight
+		c.allowedHeaders = convert(append(options.AllowedHeaders, "Origin"), http.CanonicalHeaderKey)
+		for _, h := range options.AllowedHeaders {
+			if h == "*" {
+				c.allowedHeadersAll = true
+				c.allowedHeaders = nil
+				break
+			}
+		}
+	}
+
+	// Allowed Methods
+	if len(options.AllowedMethods) == 0 {
+		// Default is spec's "simple" methods
+		c.allowedMethods = []string{http.MethodGet, http.MethodPost, http.MethodHead}
+	} else {
+		c.allowedMethods = convert(options.AllowedMethods, strings.ToUpper)
+	}
+
+	return c
+}
+
+// Default creates a new Cors handler with default options.
+func Default() *Cors {
+	return New(Options{})
+}
+
+// AllowAll create a new Cors handler with permissive configuration allowing all
+// origins with all standard methods with any header and credentials.
+func AllowAll() *Cors {
+	return New(Options{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{
+			http.MethodHead,
+			http.MethodGet,
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+		},
+		AllowedHeaders:   []string{"*"},
+		AllowCredentials: false,
+	})
+}
+
+// Handler apply the CORS specification on the request, and add relevant CORS headers
+// as necessary.
+func (c *Cors) Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+			c.logf("Handler: Preflight request")
+			c.handlePreflight(w, r)
+			// Preflight requests are standalone and should stop the chain as some other
+			// middleware may not handle OPTIONS requests correctly. One typical example
+			// is authentication middleware ; OPTIONS requests won't carry authentication
+			// headers (see #1)
+			if c.optionPassthrough {
+				h.ServeHTTP(w, r)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		} else {
+			c.logf("Handler: Actual request")
+			c.handleActualRequest(w, r)
+			h.ServeHTTP(w, r)
+		}
+	})
+}
+
+// HandlerFunc provides Martini compatible handler
+func (c *Cors) HandlerFunc(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+		c.logf("HandlerFunc: Preflight request")
+		c.handlePreflight(w, r)
+	} else {
+		c.logf("HandlerFunc: Actual request")
+		c.handleActualRequest(w, r)
+	}
+}
+
+// Negroni compatible interface
+func (c *Cors) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+		c.logf("ServeHTTP: Preflight request")
+		c.handlePreflight(w, r)
+		// Preflight requests are standalone and should stop the chain as some other
+		// middleware may not handle OPTIONS requests correctly. One typical example
+		// is authentication middleware ; OPTIONS requests won't carry authentication
+		// headers (see #1)
+		if c.optionPassthrough {
+			next(w, r)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	} else {
+		c.logf("ServeHTTP: Actual request")
+		c.handleActualRequest(w, r)
+		next(w, r)
+	}
+}
+
+// handlePreflight handles pre-flight CORS requests
+func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
+	headers := w.Header()
+	origin := r.Header.Get("Origin")
+
+	if r.Method != http.MethodOptions {
+		c.logf("  Preflight aborted: %s!=OPTIONS", r.Method)
+		return
+	}
+	// Always set Vary headers
+	// see https://github.com/rs/cors/issues/10,
+	//     https://github.com/rs/cors/commit/dbdca4d95feaa7511a46e6f1efb3b3aa505bc43f#commitcomment-12352001
+	headers.Add("Vary", "Origin")
+	headers.Add("Vary", "Access-Control-Request-Method")
+	headers.Add("Vary", "Access-Control-Request-Headers")
+
+	if origin == "" {
+		c.logf("  Preflight aborted: empty origin")
+		return
+	}
+	if !c.isOriginAllowed(r, origin) {
+		c.logf("  Preflight aborted: origin '%s' not allowed", origin)
+		return
+	}
+
+	reqMethod := r.Header.Get("Access-Control-Request-Method")
+	if !c.isMethodAllowed(reqMethod) {
+		c.logf("  Preflight aborted: method '%s' not allowed", reqMethod)
+		return
+	}
+	reqHeaders := parseHeaderList(r.Header.Get("Access-Control-Request-Headers"))
+	if !c.areHeadersAllowed(reqHeaders) {
+		c.logf("  Preflight aborted: headers '%v' not allowed", reqHeaders)
+		return
+	}
+	if c.allowedOriginsAll {
+		headers.Set("Access-Control-Allow-Origin", "*")
+	} else {
+		headers.Set("Access-Control-Allow-Origin", origin)
+	}
+	// Spec says: Since the list of methods can be unbounded, simply returning the method indicated
+	// by Access-Control-Request-Method (if supported) can be enough
+	headers.Set("Access-Control-Allow-Methods", strings.ToUpper(reqMethod))
+	if len(reqHeaders) > 0 {
+
+		// Spec says: Since the list of headers can be unbounded, simply returning supported headers
+		// from Access-Control-Request-Headers can be enough
+		headers.Set("Access-Control-Allow-Headers", strings.Join(reqHeaders, ", "))
+	}
+	if c.allowCredentials {
+		headers.Set("Access-Control-Allow-Credentials", "true")
+	}
+	if c.maxAge > 0 {
+		headers.Set("Access-Control-Max-Age", strconv.Itoa(c.maxAge))
+	}
+	c.logf("  Preflight response headers: %v", headers)
+}
+
+// handleActualRequest handles simple cross-origin requests, actual request or redirects
+func (c *Cors) handleActualRequest(w http.ResponseWriter, r *http.Request) {
+	headers := w.Header()
+	origin := r.Header.Get("Origin")
+
+	if r.Method == http.MethodOptions {
+		c.logf("  Actual request no headers added: method == %s", r.Method)
+		return
+	}
+	// Always set Vary, see https://github.com/rs/cors/issues/10
+	headers.Add("Vary", "Origin")
+	if origin == "" {
+		c.logf("  Actual request no headers added: missing origin")
+		return
+	}
+	if !c.isOriginAllowed(r, origin) {
+		c.logf("  Actual request no headers added: origin '%s' not allowed", origin)
+		return
+	}
+
+	// Note that spec does define a way to specifically disallow a simple method like GET or
+	// POST. Access-Control-Allow-Methods is only used for pre-flight requests and the
+	// spec doesn't instruct to check the allowed methods for simple cross-origin requests.
+	// We think it's a nice feature to be able to have control on those methods though.
+	if !c.isMethodAllowed(r.Method) {
+		c.logf("  Actual request no headers added: method '%s' not allowed", r.Method)
+
+		return
+	}
+	if c.allowedOriginsAll {
+		headers.Set("Access-Control-Allow-Origin", "*")
+	} else {
+		headers.Set("Access-Control-Allow-Origin", origin)
+	}
+	if len(c.exposedHeaders) > 0 {
+		headers.Set("Access-Control-Expose-Headers", strings.Join(c.exposedHeaders, ", "))
+	}
+	if c.allowCredentials {
+		headers.Set("Access-Control-Allow-Credentials", "true")
+	}
+	c.logf("  Actual response added headers: %v", headers)
+}
+
+// convenience method. checks if debugging is turned on before printing
+func (c *Cors) logf(format string, a ...interface{}) {
+	if c.Log != nil {
+		c.Log.Printf(format, a...)
+	}
+}
+
+// isOriginAllowed checks if a given origin is allowed to perform cross-domain requests
+// on the endpoint
+func (c *Cors) isOriginAllowed(r *http.Request, origin string) bool {
+	if c.allowOriginRequestFunc != nil {
+		return c.allowOriginRequestFunc(r, origin)
+	}
+	if c.allowOriginFunc != nil {
+		return c.allowOriginFunc(origin)
+	}
+	if c.allowedOriginsAll {
+		return true
+	}
+	origin = strings.ToLower(origin)
+	for _, o := range c.allowedOrigins {
+		if o == origin {
+			return true
+		}
+	}
+	for _, w := range c.allowedWOrigins {
+		if w.match(origin) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMethodAllowed checks if a given method can be used as part of a cross-domain request
+// on the endpoing
+func (c *Cors) isMethodAllowed(method string) bool {
+	if len(c.allowedMethods) == 0 {
+		// If no method allowed, always return false, even for preflight request
+		return false
+	}
+	method = strings.ToUpper(method)
+	if method == http.MethodOptions {
+		// Always allow preflight requests
+		return true
+	}
+	for _, m := range c.allowedMethods {
+		if m == method {
+			return true
+		}
+	}
+	return false
+}
+
+// areHeadersAllowed checks if a given list of headers are allowed to used within
+// a cross-domain request.
+func (c *Cors) areHeadersAllowed(requestedHeaders []string) bool {
+	if c.allowedHeadersAll || len(requestedHeaders) == 0 {
+		return true
+	}
+	for _, header := range requestedHeaders {
+		header = http.CanonicalHeaderKey(header)
+		found := false
+		for _, h := range c.allowedHeaders {
+			if h == header {
+				found = true
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/rs/cors/cors_test.go
+++ b/vendor/github.com/rs/cors/cors_test.go
@@ -1,0 +1,539 @@
+package cors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("bar"))
+})
+
+var allHeaders = []string{
+	"Vary",
+	"Access-Control-Allow-Origin",
+	"Access-Control-Allow-Methods",
+	"Access-Control-Allow-Headers",
+	"Access-Control-Allow-Credentials",
+	"Access-Control-Max-Age",
+	"Access-Control-Expose-Headers",
+}
+
+func assertHeaders(t *testing.T, resHeaders http.Header, expHeaders map[string]string) {
+	for _, name := range allHeaders {
+		got := strings.Join(resHeaders[name], ", ")
+		want := expHeaders[name]
+		if got != want {
+			t.Errorf("Response header %q = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func assertResponse(t *testing.T, res *httptest.ResponseRecorder, responseCode int) {
+	if responseCode != res.Code {
+		t.Errorf("assertResponse: expected response code to be %d but got %d. ", responseCode, res.Code)
+	}
+}
+
+func TestSpec(t *testing.T) {
+	cases := []struct {
+		name       string
+		options    Options
+		method     string
+		reqHeaders map[string]string
+		resHeaders map[string]string
+	}{
+		{
+			"NoConfig",
+			Options{
+				// Intentionally left blank.
+			},
+			"GET",
+			map[string]string{},
+			map[string]string{
+				"Vary": "Origin",
+			},
+		},
+		{
+			"MatchAllOrigin",
+			Options{
+				AllowedOrigins: []string{"*"},
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
+				"Vary": "Origin",
+				"Access-Control-Allow-Origin": "*",
+			},
+		},
+		{
+			"MatchAllOriginWithCredentials",
+			Options{
+				AllowedOrigins:   []string{"*"},
+				AllowCredentials: true,
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
+				"Vary": "Origin",
+				"Access-Control-Allow-Origin":      "*",
+				"Access-Control-Allow-Credentials": "true",
+			},
+		},
+		{
+			"AllowedOrigin",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
+				"Vary": "Origin",
+				"Access-Control-Allow-Origin": "http://foobar.com",
+			},
+		},
+		{
+			"WildcardOrigin",
+			Options{
+				AllowedOrigins: []string{"http://*.bar.com"},
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foo.bar.com",
+			},
+			map[string]string{
+				"Vary": "Origin",
+				"Access-Control-Allow-Origin": "http://foo.bar.com",
+			},
+		},
+		{
+			"DisallowedOrigin",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://barbaz.com",
+			},
+			map[string]string{
+				"Vary": "Origin",
+			},
+		},
+		{
+			"DisallowedWildcardOrigin",
+			Options{
+				AllowedOrigins: []string{"http://*.bar.com"},
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foo.baz.com",
+			},
+			map[string]string{
+				"Vary": "Origin",
+			},
+		},
+		{
+			"AllowedOriginFuncMatch",
+			Options{
+				AllowOriginFunc: func(o string) bool {
+					return regexp.MustCompile("^http://foo").MatchString(o)
+				},
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
+				"Vary": "Origin",
+				"Access-Control-Allow-Origin": "http://foobar.com",
+			},
+		},
+		{
+			"AllowOriginRequestFuncMatch",
+			Options{
+				AllowOriginRequestFunc: func(r *http.Request, o string) bool {
+					return regexp.MustCompile("^http://foo").MatchString(o) && r.Header.Get("Authorization") == "secret"
+				},
+			},
+			"GET",
+			map[string]string{
+				"Origin":        "http://foobar.com",
+				"Authorization": "secret",
+			},
+			map[string]string{
+				"Vary": "Origin",
+				"Access-Control-Allow-Origin": "http://foobar.com",
+			},
+		},
+		{
+			"AllowOriginRequestFuncNotMatch",
+			Options{
+				AllowOriginRequestFunc: func(r *http.Request, o string) bool {
+					return regexp.MustCompile("^http://foo").MatchString(o) && r.Header.Get("Authorization") == "secret"
+				},
+			},
+			"GET",
+			map[string]string{
+				"Origin":        "http://foobar.com",
+				"Authorization": "not-secret",
+			},
+			map[string]string{
+				"Vary": "Origin",
+			},
+		},
+		{
+			"MaxAge",
+			Options{
+				AllowedOrigins: []string{"http://example.com/"},
+				AllowedMethods: []string{"GET"},
+				MaxAge:         10,
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                        "http://example.com/",
+				"Access-Control-Request-Method": "GET",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://example.com/",
+				"Access-Control-Allow-Methods": "GET",
+				"Access-Control-Max-Age":       "10",
+			},
+		},
+		{
+			"AllowedMethod",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+				AllowedMethods: []string{"PUT", "DELETE"},
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                        "http://foobar.com",
+				"Access-Control-Request-Method": "PUT",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "PUT",
+			},
+		},
+		{
+			"DisallowedMethod",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+				AllowedMethods: []string{"PUT", "DELETE"},
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                        "http://foobar.com",
+				"Access-Control-Request-Method": "PATCH",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+			},
+		},
+		{
+			"AllowedHeaders",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+				AllowedHeaders: []string{"X-Header-1", "x-header-2"},
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                         "http://foobar.com",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "X-Header-2, X-HEADER-1",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "GET",
+				"Access-Control-Allow-Headers": "X-Header-2, X-Header-1",
+			},
+		},
+		{
+			"DefaultAllowedHeaders",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+				AllowedHeaders: []string{},
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                         "http://foobar.com",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "X-Requested-With",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "GET",
+				"Access-Control-Allow-Headers": "X-Requested-With",
+			},
+		},
+		{
+			"AllowedWildcardHeader",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+				AllowedHeaders: []string{"*"},
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                         "http://foobar.com",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "X-Header-2, X-HEADER-1",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "GET",
+				"Access-Control-Allow-Headers": "X-Header-2, X-Header-1",
+			},
+		},
+		{
+			"DisallowedHeader",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+				AllowedHeaders: []string{"X-Header-1", "x-header-2"},
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                         "http://foobar.com",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "X-Header-3, X-Header-1",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+			},
+		},
+		{
+			"OriginHeader",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                         "http://foobar.com",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "origin",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "GET",
+				"Access-Control-Allow-Headers": "Origin",
+			},
+		},
+		{
+			"ExposedHeader",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+				ExposedHeaders: []string{"X-Header-1", "x-header-2"},
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
+				"Vary": "Origin",
+				"Access-Control-Allow-Origin":   "http://foobar.com",
+				"Access-Control-Expose-Headers": "X-Header-1, X-Header-2",
+			},
+		},
+		{
+			"AllowedCredentials",
+			Options{
+				AllowedOrigins:   []string{"http://foobar.com"},
+				AllowCredentials: true,
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                        "http://foobar.com",
+				"Access-Control-Request-Method": "GET",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":      "http://foobar.com",
+				"Access-Control-Allow-Methods":     "GET",
+				"Access-Control-Allow-Credentials": "true",
+			},
+		},
+		{
+			"OptionPassthrough",
+			Options{
+				OptionsPassthrough: true,
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                        "http://foobar.com",
+				"Access-Control-Request-Method": "GET",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "*",
+				"Access-Control-Allow-Methods": "GET",
+			},
+		},
+		{
+			"NonPreflightOptions",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+			},
+			"OPTIONS",
+			map[string]string{},
+			map[string]string{},
+		},
+	}
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			s := New(tc.options)
+
+			req, _ := http.NewRequest(tc.method, "http://example.com/foo", nil)
+			for name, value := range tc.reqHeaders {
+				req.Header.Add(name, value)
+			}
+
+			t.Run("Handler", func(t *testing.T) {
+				res := httptest.NewRecorder()
+				s.Handler(testHandler).ServeHTTP(res, req)
+				assertHeaders(t, res.Header(), tc.resHeaders)
+			})
+			t.Run("HandlerFunc", func(t *testing.T) {
+				res := httptest.NewRecorder()
+				s.HandlerFunc(res, req)
+				assertHeaders(t, res.Header(), tc.resHeaders)
+			})
+			t.Run("Negroni", func(t *testing.T) {
+				res := httptest.NewRecorder()
+				s.ServeHTTP(res, req, testHandler)
+				assertHeaders(t, res.Header(), tc.resHeaders)
+			})
+
+		})
+	}
+}
+
+func TestDebug(t *testing.T) {
+	s := New(Options{
+		Debug: true,
+	})
+
+	if s.Log == nil {
+		t.Error("Logger not created when debug=true")
+	}
+}
+
+func TestDefault(t *testing.T) {
+	s := Default()
+	if s.Log != nil {
+		t.Error("c.log should be nil when Default")
+	}
+	if !s.allowedOriginsAll {
+		t.Error("c.allowedOriginsAll should be true when Default")
+	}
+	if s.allowedHeaders == nil {
+		t.Error("c.allowedHeaders should be nil when Default")
+	}
+	if s.allowedMethods == nil {
+		t.Error("c.allowedMethods should be nil when Default")
+	}
+}
+
+func TestHandlePreflightInvalidOriginAbortion(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://example.com/")
+
+	s.handlePreflight(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+	})
+}
+
+func TestHandlePreflightNoOptionsAbortion(t *testing.T) {
+	s := New(Options{
+		// Intentionally left blank.
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+
+	s.handlePreflight(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{})
+}
+
+func TestHandleActualRequestAbortsOptionsMethod(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://example.com/")
+
+	s.handleActualRequest(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{})
+}
+
+func TestHandleActualRequestInvalidOriginAbortion(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://example.com/")
+
+	s.handleActualRequest(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+	})
+}
+
+func TestHandleActualRequestInvalidMethodAbortion(t *testing.T) {
+	s := New(Options{
+		AllowedMethods:   []string{"POST"},
+		AllowCredentials: true,
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://example.com/")
+
+	s.handleActualRequest(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+	})
+}
+
+func TestIsMethodAllowedReturnsFalseWithNoMethods(t *testing.T) {
+	s := New(Options{
+		// Intentionally left blank.
+	})
+	s.allowedMethods = []string{}
+	if s.isMethodAllowed("") {
+		t.Error("IsMethodAllowed should return false when c.allowedMethods is nil.")
+	}
+}
+
+func TestIsMethodAllowedReturnsTrueWithOptions(t *testing.T) {
+	s := New(Options{
+		// Intentionally left blank.
+	})
+	if !s.isMethodAllowed("OPTIONS") {
+		t.Error("IsMethodAllowed should return true when c.allowedMethods is nil.")
+	}
+}

--- a/vendor/github.com/rs/cors/examples/alice/server.go
+++ b/vendor/github.com/rs/cors/examples/alice/server.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/justinas/alice"
+	"github.com/rs/cors"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	chain := alice.New(c.Handler).Then(mux)
+	http.ListenAndServe(":8080", chain)
+}

--- a/vendor/github.com/rs/cors/examples/buffalo/server.go
+++ b/vendor/github.com/rs/cors/examples/buffalo/server.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"log"
+
+	"github.com/gobuffalo/buffalo"
+	"github.com/gobuffalo/buffalo/render"
+	"github.com/rs/cors"
+)
+
+var r *render.Engine
+
+func init() {
+	r = render.New(render.Options{})
+}
+
+func main() {
+	app := App()
+	if err := app.Serve(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func App() *buffalo.App {
+	app := buffalo.New(buffalo.Options{
+		PreWares: []buffalo.PreWare{cors.Default().Handler},
+	})
+
+	app.GET("/", HomeHandler)
+
+	return app
+}
+
+func HomeHandler(c buffalo.Context) error {
+	return c.Render(200, r.JSON(map[string]string{"message": "Welcome to Buffalo!"}))
+}

--- a/vendor/github.com/rs/cors/examples/chi/server.go
+++ b/vendor/github.com/rs/cors/examples/chi/server.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/pressly/chi"
+	"github.com/rs/cors"
+)
+
+func main() {
+	r := chi.NewRouter()
+
+	// Use default options
+	r.Use(cors.Default().Handler)
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("welcome"))
+	})
+
+	http.ListenAndServe(":8080", r)
+}

--- a/vendor/github.com/rs/cors/examples/default/server.go
+++ b/vendor/github.com/rs/cors/examples/default/server.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	// Use default options
+	handler := cors.Default().Handler(mux)
+	http.ListenAndServe(":8080", handler)
+}

--- a/vendor/github.com/rs/cors/examples/gin/server.go
+++ b/vendor/github.com/rs/cors/examples/gin/server.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	cors "github.com/rs/cors/wrapper/gin"
+)
+
+func main() {
+	router := gin.Default()
+
+	router.Use(cors.Default())
+	router.GET("/", func(context *gin.Context) {
+		context.JSON(http.StatusOK, gin.H{"hello": "world"})
+	})
+
+	router.Run(":8080")
+}

--- a/vendor/github.com/rs/cors/examples/goji/server.go
+++ b/vendor/github.com/rs/cors/examples/goji/server.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+	"github.com/zenazn/goji"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+	goji.Use(c.Handler)
+
+	goji.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	goji.Serve()
+}

--- a/vendor/github.com/rs/cors/examples/gorilla/server.go
+++ b/vendor/github.com/rs/cors/examples/gorilla/server.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/cors"
+)
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	// Use default options
+	handler := cors.Default().Handler(r)
+	http.ListenAndServe(":8080", handler)
+}

--- a/vendor/github.com/rs/cors/examples/httprouter/server.go
+++ b/vendor/github.com/rs/cors/examples/httprouter/server.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/rs/cors"
+)
+
+func Hello(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte("{\"hello\": \"world\"}"))
+}
+
+func main() {
+	router := httprouter.New()
+	router.GET("/", Hello)
+
+	handler := cors.Default().Handler(router)
+
+	http.ListenAndServe(":8080", handler)
+}

--- a/vendor/github.com/rs/cors/examples/martini/server.go
+++ b/vendor/github.com/rs/cors/examples/martini/server.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/go-martini/martini"
+	"github.com/martini-contrib/render"
+	"github.com/rs/cors"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Use(c.HandlerFunc)
+
+	m.Get("/", func(r render.Render) {
+		r.JSON(200, map[string]interface{}{"hello": "world"})
+	})
+
+	m.Run()
+}

--- a/vendor/github.com/rs/cors/examples/negroni/server.go
+++ b/vendor/github.com/rs/cors/examples/negroni/server.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/codegangsta/negroni"
+	"github.com/rs/cors"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	n := negroni.Classic()
+	n.Use(c)
+	n.UseHandler(mux)
+	n.Run(":3000")
+}

--- a/vendor/github.com/rs/cors/examples/nethttp/server.go
+++ b/vendor/github.com/rs/cors/examples/nethttp/server.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	http.ListenAndServe(":8080", c.Handler(handler))
+}

--- a/vendor/github.com/rs/cors/examples/openbar/server.go
+++ b/vendor/github.com/rs/cors/examples/openbar/server.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins:   []string{"*"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE"},
+		AllowCredentials: true,
+	})
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	http.ListenAndServe(":8080", c.Handler(h))
+}

--- a/vendor/github.com/rs/cors/go.mod
+++ b/vendor/github.com/rs/cors/go.mod
@@ -1,0 +1,1 @@
+module github.com/rs/cors

--- a/vendor/github.com/rs/cors/utils.go
+++ b/vendor/github.com/rs/cors/utils.go
@@ -1,0 +1,71 @@
+package cors
+
+import "strings"
+
+const toLower = 'a' - 'A'
+
+type converter func(string) string
+
+type wildcard struct {
+	prefix string
+	suffix string
+}
+
+func (w wildcard) match(s string) bool {
+	return len(s) >= len(w.prefix)+len(w.suffix) && strings.HasPrefix(s, w.prefix) && strings.HasSuffix(s, w.suffix)
+}
+
+// convert converts a list of string using the passed converter function
+func convert(s []string, c converter) []string {
+	out := []string{}
+	for _, i := range s {
+		out = append(out, c(i))
+	}
+	return out
+}
+
+// parseHeaderList tokenize + normalize a string containing a list of headers
+func parseHeaderList(headerList string) []string {
+	l := len(headerList)
+	h := make([]byte, 0, l)
+	upper := true
+	// Estimate the number headers in order to allocate the right splice size
+	t := 0
+	for i := 0; i < l; i++ {
+		if headerList[i] == ',' {
+			t++
+		}
+	}
+	headers := make([]string, 0, t)
+	for i := 0; i < l; i++ {
+		b := headerList[i]
+		switch {
+		case b >= 'a' && b <= 'z':
+			if upper {
+				h = append(h, b-toLower)
+			} else {
+				h = append(h, b)
+			}
+		case b >= 'A' && b <= 'Z':
+			if !upper {
+				h = append(h, b+toLower)
+			} else {
+				h = append(h, b)
+			}
+		case b == '-' || b == '_' || (b >= '0' && b <= '9'):
+			h = append(h, b)
+		}
+
+		if b == ' ' || b == ',' || i == l-1 {
+			if len(h) > 0 {
+				// Flush the found header
+				headers = append(headers, string(h))
+				h = h[:0]
+				upper = true
+			}
+		} else {
+			upper = b == '-' || b == '_'
+		}
+	}
+	return headers
+}

--- a/vendor/github.com/rs/cors/utils_test.go
+++ b/vendor/github.com/rs/cors/utils_test.go
@@ -1,0 +1,86 @@
+package cors
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWildcard(t *testing.T) {
+	w := wildcard{"foo", "bar"}
+	if !w.match("foobar") {
+		t.Error("foo*bar should match foobar")
+	}
+	if !w.match("foobazbar") {
+		t.Error("foo*bar should match foobazbar")
+	}
+	if w.match("foobaz") {
+		t.Error("foo*bar should not match foobaz")
+	}
+
+	w = wildcard{"foo", "oof"}
+	if w.match("foof") {
+		t.Error("foo*oof should not match foof")
+	}
+}
+
+func TestConvert(t *testing.T) {
+	s := convert([]string{"A", "b", "C"}, strings.ToLower)
+	e := []string{"a", "b", "c"}
+	if s[0] != e[0] || s[1] != e[1] || s[2] != e[2] {
+		t.Errorf("%v != %v", s, e)
+	}
+}
+
+func TestParseHeaderList(t *testing.T) {
+	h := parseHeaderList("header, second-header, THIRD-HEADER, Numb3r3d-H34d3r")
+	e := []string{"Header", "Second-Header", "Third-Header", "Numb3r3d-H34d3r"}
+	if h[0] != e[0] || h[1] != e[1] || h[2] != e[2] {
+		t.Errorf("%v != %v", h, e)
+	}
+}
+
+func TestParseHeaderListEmpty(t *testing.T) {
+	if len(parseHeaderList("")) != 0 {
+		t.Error("should be empty sclice")
+	}
+	if len(parseHeaderList(" , ")) != 0 {
+		t.Error("should be empty sclice")
+	}
+}
+
+func BenchmarkParseHeaderList(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseHeaderList("header, second-header, THIRD-HEADER")
+	}
+}
+
+func BenchmarkParseHeaderListSingle(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseHeaderList("header")
+	}
+}
+
+func BenchmarkParseHeaderListNormalized(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseHeaderList("Header1, Header2, Third-Header")
+	}
+}
+
+func BenchmarkWildcard(b *testing.B) {
+	w := wildcard{"foo", "bar"}
+	b.Run("match", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			w.match("foobazbar")
+		}
+	})
+	b.Run("too short", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			w.match("fobar")
+		}
+	})
+}

--- a/vendor/github.com/rs/cors/wrapper/gin/gin.go
+++ b/vendor/github.com/rs/cors/wrapper/gin/gin.go
@@ -1,0 +1,50 @@
+// Package cors/wrapper/gin provides gin.HandlerFunc to handle CORS related
+// requests as a wrapper of github.com/rs/cors handler.
+package gin
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/cors"
+)
+
+// Options is a configuration container to setup the CORS middleware.
+type Options = cors.Options
+
+// corsWrapper is a wrapper of cors.Cors handler which preserves information
+// about configured 'optionPassthrough' option.
+type corsWrapper struct {
+	*cors.Cors
+	optionPassthrough bool
+}
+
+// build transforms wrapped cors.Cors handler into Gin middleware.
+func (c corsWrapper) build() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		c.HandlerFunc(ctx.Writer, ctx.Request)
+		if !c.optionPassthrough &&
+			ctx.Request.Method == http.MethodOptions &&
+			ctx.GetHeader("Access-Control-Request-Method") != "" {
+			// Abort processing next Gin middlewares.
+			ctx.AbortWithStatus(http.StatusOK)
+		}
+	}
+}
+
+// AllowAll creates a new CORS Gin middleware with permissive configuration
+// allowing all origins with all standard methods with any header and
+// credentials.
+func AllowAll() gin.HandlerFunc {
+	return corsWrapper{Cors: cors.AllowAll()}.build()
+}
+
+// Default creates a new CORS Gin middleware with default options.
+func Default() gin.HandlerFunc {
+	return corsWrapper{Cors: cors.Default()}.build()
+}
+
+// New creates a new CORS Gin middleware with the provided options.
+func New(options Options) gin.HandlerFunc {
+	return corsWrapper{cors.New(options), options.OptionsPassthrough}.build()
+}

--- a/vendor/github.com/rs/cors/wrapper/gin/gin_test.go
+++ b/vendor/github.com/rs/cors/wrapper/gin/gin_test.go
@@ -1,0 +1,76 @@
+package gin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/cors"
+)
+
+func init() {
+	gin.SetMode(gin.ReleaseMode)
+}
+
+func TestAllowAllNotNil(t *testing.T) {
+	handler := AllowAll()
+	if handler == nil {
+		t.Error("Should not return nil Gin handler")
+	}
+}
+
+func TestDefaultNotNil(t *testing.T) {
+	handler := Default()
+	if handler == nil {
+		t.Error("Should not return nil Gin handler")
+	}
+}
+
+func TestNewNotNil(t *testing.T) {
+	handler := New(Options{})
+	if handler == nil {
+		t.Error("Should not return nil Gin handler")
+	}
+}
+
+func TestCorsWrapper_buildAbortsWhenPreflight(t *testing.T) {
+	res := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(res)
+	ctx.Request, _ = http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	ctx.Request.Header.Add("Origin", "http://example.com/")
+	ctx.Request.Header.Add("Access-Control-Request-Method", "POST")
+	ctx.Status(http.StatusAccepted)
+	res.Code = http.StatusAccepted
+
+	handler := corsWrapper{Cors: cors.New(Options{
+		// Intentionally left blank.
+	})}.build()
+
+	handler(ctx)
+
+	if !ctx.IsAborted() {
+		t.Error("Should abort on preflight requests")
+	}
+	if res.Code != http.StatusOK {
+		t.Error("Should abort with 200 OK status")
+	}
+}
+
+func TestCorsWrapper_buildNotAbortsWhenPassthrough(t *testing.T) {
+	res := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(res)
+	ctx.Request, _ = http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	ctx.Request.Header.Add("Origin", "http://example.com/")
+	ctx.Request.Header.Add("Access-Control-Request-Method", "POST")
+
+	handler := corsWrapper{cors.New(Options{
+		OptionsPassthrough: true,
+	}), true}.build()
+
+	handler(ctx)
+
+	if ctx.IsAborted() {
+		t.Error("Should not abort when OPTIONS passthrough enabled")
+	}
+}


### PR DESCRIPTION
[EVG-15384](https://jira.mongodb.org/browse/EVG-15384)

### Description 
TIPS is having trouble getting POST/OPTIONS requests to work with CORS. We've tried modifying the headers but haven't seen success. This is how cedar apparently handles CORS and TIPS says that it's working correctly so switching to that to see if it fixes anything.

### Testing 
Unfortunately I don't believe we have a way of testing this.
