### PR TITLE
EVG-15396: Fix historical test stats aggregation to include display test names

### DIFF
--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -801,7 +801,7 @@ func (filter StatsFilter) buildMatchStageForTask() bson.M {
 	// with jasper (SERVER-54315), test names are now random UUIDs with
 	// with a human-readble display name. For the period between
 	// 09/01/21-09/13/21, the historical test stats calculations failed to
-	// for this (EVG-15396). We should ignored any test stats affected by
+	// for this (EVG-15396). We should ignore any test stats affected by
 	// this bug.
 	affectedVariants := []string{
 		"enterprise-rhel-80-64-bit",

--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -801,8 +801,8 @@ func (filter StatsFilter) buildMatchStageForTask() bson.M {
 	// with jasper (SERVER-54315), test names are now random UUIDs with
 	// with a human-readble display name. For the period between
 	// 09/01/21-09/13/21, the historical test stats calculations failed to
-	// for this (EVG-15396). We should ignore any test stats affected by
-	// this bug.
+	// account for this (EVG-15396). We should ignore any test stats
+	// affected by this bug.
 	affectedVariants := []string{
 		"enterprise-rhel-80-64-bit",
 		"enterprise-rhel-80-64-bit-dynamic-required",

--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -800,7 +800,7 @@ func (filter StatsFilter) buildMatchStageForTask() bson.M {
 	// After cutting over the below build variants to use resmoke spawned
 	// with jasper (SERVER-54315), test names are now random UUIDs with
 	// with a human-readble display name. For the period between
-	// 09/01/21-09/13/21, the historical test stats aggregation failed to
+	// 09/01/21-09/13/21, the historical test stats calculations failed to
 	// for this (EVG-15396). We should ignored any test stats affected by
 	// this bug.
 	affectedVariants := []string{

--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -601,46 +601,6 @@ func (filter StatsFilter) buildMatchStageForTest() bson.M {
 		DbTestStatsIdRequesterKeyFull: bson.M{"$in": filter.Requesters},
 	}
 
-	// After cutting over the below build variants to use resmoke spawned
-	// with jasper (SERVER-54315), test names are now random UUIDs with
-	// with a human-readble display name. For the period between
-	// 09/01/21-09/14/21, the historical test stats calculations failed to
-	// account for this (EVG-15396). We should ignore any test stats
-	// affected by this bug.
-	//
-	// TODO: (EVG-15396) Remove this code once all affected test stats TTL
-	// on 03/14/2022.
-	affectedVariants := []string{
-		"enterprise-rhel-80-64-bit",
-		"enterprise-rhel-80-64-bit-dynamic-required",
-	}
-	if len(filter.BuildVariants) == 0 || len(utility.StringSliceIntersection(filter.BuildVariants, affectedVariants)) > 0 {
-		or := []bson.M{
-			{
-				"$and": []bson.M{
-					{DbTaskStatsIdBuildVariantKeyFull: bson.M{"$in": affectedVariants}},
-					{DbTaskStatsIdDateKeyFull: bson.M{
-						"$lt": time.Date(2021, time.September, 1, 0, 0, 0, 0, time.UTC),
-						"$gt": time.Date(2021, time.September, 14, 0, 0, 0, 0, time.UTC),
-					}},
-				},
-			},
-			{
-				DbTaskStatsIdBuildVariantKeyFull: bson.M{"$nin": affectedVariants},
-			},
-		}
-		if filter.StartAt != nil {
-			match["$and"] = []bson.M{
-				{"$or": or},
-				{"$or": filter.buildTestPaginationOrBranches()},
-			}
-		} else {
-			match["$or"] = or
-		}
-	} else if filter.StartAt != nil {
-		match["$or"] = filter.buildTestPaginationOrBranches()
-	}
-
 	if len(filter.Tests) > 0 {
 		match[DbTestStatsIdTestFileKeyFull] = BuildMatchArrayExpression(filter.Tests)
 	}
@@ -652,6 +612,10 @@ func (filter StatsFilter) buildMatchStageForTest() bson.M {
 	}
 	if len(filter.Distros) > 0 {
 		match[DbTestStatsIdDistroKeyFull] = BuildMatchArrayExpression(filter.Distros)
+	}
+
+	if filter.StartAt != nil {
+		match["$or"] = filter.buildTestPaginationOrBranches()
 	}
 
 	return bson.M{"$match": match}

--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -800,21 +800,24 @@ func (filter StatsFilter) buildMatchStageForTask() bson.M {
 	// After cutting over the below build variants to use resmoke spawned
 	// with jasper (SERVER-54315), test names are now random UUIDs with
 	// with a human-readble display name. For the period between
-	// 09/01/21-09/13/21, the historical test stats calculations failed to
+	// 09/01/21-09/14/21, the historical test stats calculations failed to
 	// account for this (EVG-15396). We should ignore any test stats
 	// affected by this bug.
+	//
+	// TODO: (EVG-15396) Remove this code once all affected test stats TTL
+	// on 03/14/2022.
 	affectedVariants := []string{
 		"enterprise-rhel-80-64-bit",
 		"enterprise-rhel-80-64-bit-dynamic-required",
 	}
-	if len(filter.Tasks) == 0 || len(utility.StringSliceIntersection(filter.Tasks, affectedVariants)) > 0 {
+	if len(filter.BuildVariants) == 0 || len(utility.StringSliceIntersection(filter.BuildVariants, affectedVariants)) > 0 {
 		match["$or"] = []bson.M{
 			{
 				"$and": []bson.M{
 					{DbTaskStatsIdBuildVariantKeyFull: bson.M{"$in": affectedVariants}},
 					{DbTaskStatsIdDateKeyFull: bson.M{
 						"$lt": time.Date(2021, time.September, 1, 0, 0, 0, 0, time.UTC),
-						"$gt": time.Date(2021, time.September, 13, 0, 0, 0, 0, time.UTC),
+						"$gt": time.Date(2021, time.September, 14, 0, 0, 0, 0, time.UTC),
 					}},
 				},
 			},

--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -654,10 +654,6 @@ func (filter StatsFilter) buildMatchStageForTest() bson.M {
 		match[DbTestStatsIdDistroKeyFull] = BuildMatchArrayExpression(filter.Distros)
 	}
 
-	if filter.StartAt != nil {
-		match["$or"] = filter.buildTestPaginationOrBranches()
-	}
-
 	return bson.M{"$match": match}
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15396

- Use display test name in historical test stat calculations.
- Exclude stats of the two affected build variants during the affected period from historical test stat queries.