### PR TITLE
EVG-5312 decommission hosts running task groups carefully

### DIFF
--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
@@ -122,6 +123,31 @@ func (j *hostDrawdownJob) checkAndTerminateHost(ctx context.Context, h *host.Hos
 	exitEarly, err := checkTerminationExemptions(ctx, h, j.env, j.Type().Name, j.ID())
 	if exitEarly || err != nil {
 		return err
+	}
+
+	// don't drawdown hosts that are running task groups
+	if h.RunningTaskGroup != "" {
+		t, err := task.FindOneId(h.RunningTask)
+		if err != nil {
+			return errors.Wrap(err, "error finding running task")
+		}
+		if t == nil {
+			return errors.Errorf("could not find running task '%s'", h.RunningTask)
+		}
+		if t.IsPartOfSingleHostTaskGroup() {
+			return nil
+		}
+	} else if h.LastGroup != "" && h.RunningTask == "" { // if we're currently running a task not in a group, then we already know the group is finished running.
+		t, err := task.FindOneId(h.LastTask)
+		if err != nil {
+			return errors.Wrap(err, "error finding last task")
+		}
+		if t == nil {
+			return errors.Errorf("could not find last task '%s'", h.LastTask)
+		}
+		if t.IsPartOfSingleHostTaskGroup() {
+			return nil
+		}
 	}
 
 	idleTime := h.IdleTime()

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
@@ -180,9 +181,29 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		} else {
 			return
 		}
+	} else {
+		// Consider if the host is in between running a single-host task group
+		if j.host.LastGroup != "" {
+			lastTask, err := task.FindOneId(j.host.LastTask)
+			if err != nil {
+				j.AddError(errors.Wrapf(err, "error finding last task '%s'", j.host.LastTask))
+			}
+
+			if lastTask != nil && lastTask.IsPartOfSingleHostTaskGroup() {
+				tasks, err := task.FindTaskGroupFromBuild(lastTask.BuildVariant, lastTask.TaskGroup)
+				if err != nil {
+					j.AddError(errors.Wrapf(err, "can't get task group for task '%s'", lastTask.Id))
+				}
+				if tasks[len(tasks)-1].Id != lastTask.Id {
+					// If we aren't looking at the last task in the group, then we should mark the whole thing for restart,
+					// because later tasks in the group need to run on the same host as the earlier ones.
+					j.AddError(errors.Wrap(model.TryResetTask(lastTask.Id, evergreen.User, evergreen.MonitorPackage, nil), "problem resetting task"))
+				}
+			}
+		}
+
 	}
-	// set host as decommissioned in DB so no new task will be
-	// assigned
+	// set host as decommissioned in DB so no new task will be assigned
 	prevStatus := j.host.Status
 	if err = j.host.SetDecommissioned(evergreen.User, "host will be terminated shortly, preventing task dispatch"); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{


### PR DESCRIPTION
[EVG-5312](https://jira.mongodb.org/browse/EVG-5312)

### Description 
We've had a few build failures where a host is decommissioned in-between running tasks in a task group, and then later tasks in the group fail.

I wrote drawdown and termination to be slightly different because I think drawdown is meant more to deallocate when we don't need things (so it's safe to just not deallocate), whereas for termination we may truly want to terminate the host, so in this case I just mark the task group for reset rather than preventing the termination of the host. We can try and implement them more similarly though if this doesn't seem reasonable.
