### PR TITLE
EVG-5312 use build ID instead of variant name to find task group

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -190,9 +190,14 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			}
 
 			if lastTask != nil && lastTask.IsPartOfSingleHostTaskGroup() {
-				tasks, err := task.FindTaskGroupFromBuild(lastTask.BuildVariant, lastTask.TaskGroup)
+				tasks, err := task.FindTaskGroupFromBuild(lastTask.BuildId, lastTask.TaskGroup)
 				if err != nil {
 					j.AddError(errors.Wrapf(err, "can't get task group for task '%s'", lastTask.Id))
+					return
+				}
+				if len(tasks) == 0 {
+					j.AddError(errors.Errorf("no tasks found in task group for task '%s'", lastTask.Id))
+					return
 				}
 				if tasks[len(tasks)-1].Id != lastTask.Id {
 					// If we aren't looking at the last task in the group, then we should mark the whole thing for restart,


### PR DESCRIPTION
[EVG-5312](https://jira.mongodb.org/browse/EVG-5312)

