### PR TITLE
EVG-5312 add improvements to task group restart logic

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -246,9 +246,9 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 		msg := fmt.Sprintf("Task '%v' reached max execution (%v):", t.Id, evergreen.MaxTaskExecution)
 		if origin == evergreen.UIPackage || origin == evergreen.RESTV2Package {
 			grip.Debugln(msg, "allowing exception for", user)
-		} else {
-			grip.Debugln(msg, "marking as failed")
+		} else if !t.IsFinished() {
 			if detail != nil {
+				grip.Debugln(msg, "marking as failed")
 				if t.DisplayOnly {
 					for _, etId := range t.ExecutionTasks {
 						execTask, err = task.FindOneId(etId)
@@ -262,7 +262,12 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 				}
 				return errors.WithStack(MarkEnd(t, origin, time.Now(), detail, false))
 			} else {
-				panic(fmt.Sprintf("TryResetTask called with nil TaskEndDetail by %s", origin))
+				grip.Critical(message.Fields{
+					"message":     "TryResetTask called with nil TaskEndDetail",
+					"origin":      origin,
+					"task_id":     taskId,
+					"task_status": t.Status,
+				})
 			}
 		}
 	}

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -188,8 +188,8 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			if err != nil {
 				j.AddError(errors.Wrapf(err, "error finding last task '%s'", j.host.LastTask))
 			}
-
-			if lastTask != nil && lastTask.IsPartOfSingleHostTaskGroup() {
+			// Only try to restart the task group if it was successful and should have continued executing.
+			if lastTask != nil && lastTask.IsPartOfSingleHostTaskGroup() && lastTask.Status == evergreen.TaskSucceeded {
 				tasks, err := task.FindTaskGroupFromBuild(lastTask.BuildId, lastTask.TaskGroup)
 				if err != nil {
 					j.AddError(errors.Wrapf(err, "can't get task group for task '%s'", lastTask.Id))


### PR DESCRIPTION
[EVG-5312](https://jira.mongodb.org/browse/EVG-5312)

### Description 
Made a couple of changes: 
Should consider whether the task group failed and stopped execution purposefully before trying to restart (see https://evergreen.mongodb.com/task/mongodb_mongo_master_suse15_compile_dist_test_a1028f6738bcf0059f8e243b154208a8c2a8b499_21_09_15_10_17_58/9).

It seems like an error to me that we error if TryResetTask is called with nil TaskEndDetails. We don't do that later on in the file (297-302). I think this was a holdover from when TryResetTask always failed and restarted; I think we can just don't encounter it often since it's in this "hit max executions" block.

