### PR TITLE
EVG-15283: Query by all system activator statuses when setting build and task activation

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -512,6 +512,11 @@ var (
 		MergeTestRequester,
 	}
 
+	SystemActivators = []string{
+		DefaultTaskActivator,
+		APIServerTaskActivator,
+	}
+
 	// UpHostStatus is a list of all host statuses that are considered up.
 	UpHostStatus = []string{
 		HostRunning,
@@ -668,7 +673,8 @@ func FindEvergreenHome() string {
 
 // IsSystemActivator returns true when the task activator is Evergreen.
 func IsSystemActivator(caller string) bool {
-	return caller == DefaultTaskActivator || caller == APIServerTaskActivator
+	//check is caller in list, same for task activation
+	return utility.StringSliceContains(SystemActivators, caller)
 }
 
 func IsPatchRequester(requester string) bool {

--- a/globals.go
+++ b/globals.go
@@ -673,7 +673,6 @@ func FindEvergreenHome() string {
 
 // IsSystemActivator returns true when the task activator is Evergreen.
 func IsSystemActivator(caller string) bool {
-	//check is caller in list, same for task activation
 	return utility.StringSliceContains(SystemActivators, caller)
 }
 

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -142,7 +142,7 @@ func (b *Build) PreviousSuccessful() (*Build, error) {
 func UpdateActivation(buildIds []string, active bool, caller string) error {
 	query := bson.M{IdKey: bson.M{"$in": buildIds}}
 	if !active && evergreen.IsSystemActivator(caller) {
-		query[ActivatedByKey] = caller
+		query[ActivatedByKey] = bson.M{"$in": evergreen.SystemActivators}
 	}
 
 	_, err := UpdateAllBuilds(

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -120,7 +120,7 @@ func setTaskActivationForBuilds(buildIds []string, active bool, ignoreTasks []st
 		}
 		// if the caller is the default task activator only deactivate tasks that have not been activated by a user
 		if evergreen.IsSystemActivator(caller) {
-			query[task.ActivatedByKey] = caller
+			query[task.ActivatedByKey] = bson.M{"$in": evergreen.SystemActivators}
 		}
 
 		tasks, err := task.FindAll(db.Query(query).WithFields(task.IdKey, task.ExecutionKey))


### PR DESCRIPTION
[EVG-15283](https://jira.mongodb.org/browse/EVG-15283)

### Description 
Was observed that build and task statuses were not being properly set to inactive when a patch has been dequeued from the commit queue, because the query to retrieve the builds and tasks were querying by an incorrect system activator (apiserver instead of default).  Change has been made to introduce a list of system activators in globals.go and query by all activators in this list instead of a single value.