### PR TITLE
EVG-15379: Set the test_file field as the display test name for the test results API

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -872,29 +872,25 @@ type ComplexityRoot struct {
 	}
 
 	TestLog struct {
-		HTMLDisplayURL func(childComplexity int) int
-		LineNum        func(childComplexity int) int
-		RawDisplayURL  func(childComplexity int) int
-		URL            func(childComplexity int) int
-		URLLobster     func(childComplexity int) int
-		URLRaw         func(childComplexity int) int
+		LineNum    func(childComplexity int) int
+		URL        func(childComplexity int) int
+		URLLobster func(childComplexity int) int
+		URLRaw     func(childComplexity int) int
 	}
 
 	TestResult struct {
-		BaseStatus      func(childComplexity int) int
-		DisplayTestName func(childComplexity int) int
-		Duration        func(childComplexity int) int
-		EndTime         func(childComplexity int) int
-		Execution       func(childComplexity int) int
-		ExitCode        func(childComplexity int) int
-		GroupId         func(childComplexity int) int
-		Id              func(childComplexity int) int
-		LogTestName     func(childComplexity int) int
-		Logs            func(childComplexity int) int
-		StartTime       func(childComplexity int) int
-		Status          func(childComplexity int) int
-		TaskId          func(childComplexity int) int
-		TestFile        func(childComplexity int) int
+		BaseStatus func(childComplexity int) int
+		Duration   func(childComplexity int) int
+		EndTime    func(childComplexity int) int
+		Execution  func(childComplexity int) int
+		ExitCode   func(childComplexity int) int
+		GroupID    func(childComplexity int) int
+		ID         func(childComplexity int) int
+		Logs       func(childComplexity int) int
+		StartTime  func(childComplexity int) int
+		Status     func(childComplexity int) int
+		TaskID     func(childComplexity int) int
+		TestFile   func(childComplexity int) int
 	}
 
 	TicketFields struct {
@@ -5400,26 +5396,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TaskTestResult.TotalTestCount(childComplexity), true
 
-	case "TestLog.htmlDisplayURL":
-		if e.complexity.TestLog.HTMLDisplayURL == nil {
-			break
-		}
-
-		return e.complexity.TestLog.HTMLDisplayURL(childComplexity), true
-
 	case "TestLog.lineNum":
 		if e.complexity.TestLog.LineNum == nil {
 			break
 		}
 
 		return e.complexity.TestLog.LineNum(childComplexity), true
-
-	case "TestLog.rawDisplayURL":
-		if e.complexity.TestLog.RawDisplayURL == nil {
-			break
-		}
-
-		return e.complexity.TestLog.RawDisplayURL(childComplexity), true
 
 	case "TestLog.url":
 		if e.complexity.TestLog.URL == nil {
@@ -5448,13 +5430,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.TestResult.BaseStatus(childComplexity), true
-
-	case "TestResult.displayTestName":
-		if e.complexity.TestResult.DisplayTestName == nil {
-			break
-		}
-
-		return e.complexity.TestResult.DisplayTestName(childComplexity), true
 
 	case "TestResult.duration":
 		if e.complexity.TestResult.Duration == nil {
@@ -5485,25 +5460,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		return e.complexity.TestResult.ExitCode(childComplexity), true
 
 	case "TestResult.groupID":
-		if e.complexity.TestResult.GroupId == nil {
+		if e.complexity.TestResult.GroupID == nil {
 			break
 		}
 
-		return e.complexity.TestResult.GroupId(childComplexity), true
+		return e.complexity.TestResult.GroupID(childComplexity), true
 
 	case "TestResult.id":
-		if e.complexity.TestResult.Id == nil {
+		if e.complexity.TestResult.ID == nil {
 			break
 		}
 
-		return e.complexity.TestResult.Id(childComplexity), true
-
-	case "TestResult.logTestName":
-		if e.complexity.TestResult.LogTestName == nil {
-			break
-		}
-
-		return e.complexity.TestResult.LogTestName(childComplexity), true
+		return e.complexity.TestResult.ID(childComplexity), true
 
 	case "TestResult.logs":
 		if e.complexity.TestResult.Logs == nil {
@@ -5527,11 +5495,11 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		return e.complexity.TestResult.Status(childComplexity), true
 
 	case "TestResult.taskId":
-		if e.complexity.TestResult.TaskId == nil {
+		if e.complexity.TestResult.TaskID == nil {
 			break
 		}
 
-		return e.complexity.TestResult.TaskId(childComplexity), true
+		return e.complexity.TestResult.TaskID(childComplexity), true
 
 	case "TestResult.testFile":
 		if e.complexity.TestResult.TestFile == nil {
@@ -6940,7 +6908,6 @@ type TestResult {
   status: String!
   baseStatus: String
   testFile: String!
-  displayTestName: String
   logs: TestLog!
   exitCode: Int
   startTime: Time
@@ -6948,7 +6915,6 @@ type TestResult {
   endTime: Time
   taskId: String
   execution: Int
-  logTestName: String
 }
 
 type TestLog {
@@ -6956,9 +6922,6 @@ type TestLog {
   urlRaw: String
   urlLobster: String
   lineNum: Int
-  htmlDisplayURL: String @deprecated(reason: "htmlDisplayURL deprecated, use url instead (EVG-15418)")
-  rawDisplayURL: String @deprecated(reason: "rawDisplayURL deprecated, use urlRaw instead (EVG-15418)")
-
 }
 
 type Dependency {
@@ -22236,7 +22199,7 @@ func (ec *executionContext) _Query___type(ctx context.Context, field graphql.Col
 	}
 	res := resTmp.(*introspection.Type)
 	fc.Result = res
-	return ec.marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
+	return ec.marshalO__Type2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -22267,7 +22230,7 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 	}
 	res := resTmp.(*introspection.Schema)
 	fc.Result = res
-	return ec.marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx, field.Selections, res)
+	return ec.marshalO__Schema2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SearchReturnInfo_issues(ctx context.Context, field graphql.CollectedField, obj *thirdparty.SearchReturnInfo) (ret graphql.Marshaler) {
@@ -27525,68 +27488,6 @@ func (ec *executionContext) _TestLog_lineNum(ctx context.Context, field graphql.
 	return ec.marshalOInt2int(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _TestLog_htmlDisplayURL(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:   "TestLog",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.HTMLDisplayURL, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _TestLog_rawDisplayURL(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:   "TestLog",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.RawDisplayURL, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _TestResult_id(ctx context.Context, field graphql.CollectedField, obj *model.APITest) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -27604,7 +27505,7 @@ func (ec *executionContext) _TestResult_id(ctx context.Context, field graphql.Co
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Id, nil
+		return obj.ID, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -27638,7 +27539,7 @@ func (ec *executionContext) _TestResult_groupID(ctx context.Context, field graph
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.GroupId, nil
+		return obj.GroupID, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -27749,37 +27650,6 @@ func (ec *executionContext) _TestResult_testFile(ctx context.Context, field grap
 	res := resTmp.(*string)
 	fc.Result = res
 	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _TestResult_displayTestName(ctx context.Context, field graphql.CollectedField, obj *model.APITest) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:   "TestResult",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.DisplayTestName, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _TestResult_logs(ctx context.Context, field graphql.CollectedField, obj *model.APITest) (ret graphql.Marshaler) {
@@ -27957,7 +27827,7 @@ func (ec *executionContext) _TestResult_taskId(ctx context.Context, field graphq
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.TaskId, nil
+		return obj.TaskID, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -28000,37 +27870,6 @@ func (ec *executionContext) _TestResult_execution(ctx context.Context, field gra
 	res := resTmp.(int)
 	fc.Result = res
 	return ec.marshalOInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _TestResult_logTestName(ctx context.Context, field graphql.CollectedField, obj *model.APITest) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:   "TestResult",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.LogTestName, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _TicketFields_summary(ctx context.Context, field graphql.CollectedField, obj *thirdparty.TicketFields) (ret graphql.Marshaler) {
@@ -31148,7 +30987,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 	}
 	res := resTmp.([]introspection.InputValue)
 	fc.Result = res
-	return ec.marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx, field.Selections, res)
+	return ec.marshalN__InputValue2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___EnumValue_name(ctx context.Context, field graphql.CollectedField, obj *introspection.EnumValue) (ret graphql.Marshaler) {
@@ -31377,7 +31216,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 	}
 	res := resTmp.([]introspection.InputValue)
 	fc.Result = res
-	return ec.marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx, field.Selections, res)
+	return ec.marshalN__InputValue2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.CollectedField, obj *introspection.Field) (ret graphql.Marshaler) {
@@ -31411,7 +31250,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 	}
 	res := resTmp.(*introspection.Type)
 	fc.Result = res
-	return ec.marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
+	return ec.marshalN__Type2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field graphql.CollectedField, obj *introspection.Field) (ret graphql.Marshaler) {
@@ -31575,7 +31414,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 	}
 	res := resTmp.(*introspection.Type)
 	fc.Result = res
-	return ec.marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
+	return ec.marshalN__Type2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField, obj *introspection.InputValue) (ret graphql.Marshaler) {
@@ -31640,7 +31479,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 	}
 	res := resTmp.([]introspection.Type)
 	fc.Result = res
-	return ec.marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx, field.Selections, res)
+	return ec.marshalN__Type2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graphql.CollectedField, obj *introspection.Schema) (ret graphql.Marshaler) {
@@ -31674,7 +31513,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 	}
 	res := resTmp.(*introspection.Type)
 	fc.Result = res
-	return ec.marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
+	return ec.marshalN__Type2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field graphql.CollectedField, obj *introspection.Schema) (ret graphql.Marshaler) {
@@ -31705,7 +31544,7 @@ func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field gr
 	}
 	res := resTmp.(*introspection.Type)
 	fc.Result = res
-	return ec.marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
+	return ec.marshalO__Type2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, field graphql.CollectedField, obj *introspection.Schema) (ret graphql.Marshaler) {
@@ -31736,7 +31575,7 @@ func (ec *executionContext) ___Schema_subscriptionType(ctx context.Context, fiel
 	}
 	res := resTmp.(*introspection.Type)
 	fc.Result = res
-	return ec.marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
+	return ec.marshalO__Type2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Schema_directives(ctx context.Context, field graphql.CollectedField, obj *introspection.Schema) (ret graphql.Marshaler) {
@@ -31770,7 +31609,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 	}
 	res := resTmp.([]introspection.Directive)
 	fc.Result = res
-	return ec.marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx, field.Selections, res)
+	return ec.marshalN__Directive2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Type_kind(ctx context.Context, field graphql.CollectedField, obj *introspection.Type) (ret graphql.Marshaler) {
@@ -31904,7 +31743,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 	}
 	res := resTmp.([]introspection.Field)
 	fc.Result = res
-	return ec.marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx, field.Selections, res)
+	return ec.marshalO__Field2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphql.CollectedField, obj *introspection.Type) (ret graphql.Marshaler) {
@@ -31935,7 +31774,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 	}
 	res := resTmp.([]introspection.Type)
 	fc.Result = res
-	return ec.marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx, field.Selections, res)
+	return ec.marshalO__Type2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field graphql.CollectedField, obj *introspection.Type) (ret graphql.Marshaler) {
@@ -31966,7 +31805,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 	}
 	res := resTmp.([]introspection.Type)
 	fc.Result = res
-	return ec.marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx, field.Selections, res)
+	return ec.marshalO__Type2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphql.CollectedField, obj *introspection.Type) (ret graphql.Marshaler) {
@@ -32004,7 +31843,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 	}
 	res := resTmp.([]introspection.EnumValue)
 	fc.Result = res
-	return ec.marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx, field.Selections, res)
+	return ec.marshalO__EnumValue2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graphql.CollectedField, obj *introspection.Type) (ret graphql.Marshaler) {
@@ -32035,7 +31874,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 	}
 	res := resTmp.([]introspection.InputValue)
 	fc.Result = res
-	return ec.marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx, field.Selections, res)
+	return ec.marshalO__InputValue2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.CollectedField, obj *introspection.Type) (ret graphql.Marshaler) {
@@ -32066,7 +31905,7 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 	}
 	res := resTmp.(*introspection.Type)
 	fc.Result = res
-	return ec.marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
+	return ec.marshalO__Type2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
 }
 
 // endregion **************************** field.gotpl *****************************
@@ -37810,10 +37649,6 @@ func (ec *executionContext) _TestLog(ctx context.Context, sel ast.SelectionSet, 
 			out.Values[i] = ec._TestLog_urlLobster(ctx, field, obj)
 		case "lineNum":
 			out.Values[i] = ec._TestLog_lineNum(ctx, field, obj)
-		case "htmlDisplayURL":
-			out.Values[i] = ec._TestLog_htmlDisplayURL(ctx, field, obj)
-		case "rawDisplayURL":
-			out.Values[i] = ec._TestLog_rawDisplayURL(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -37855,8 +37690,6 @@ func (ec *executionContext) _TestResult(ctx context.Context, sel ast.SelectionSe
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "displayTestName":
-			out.Values[i] = ec._TestResult_displayTestName(ctx, field, obj)
 		case "logs":
 			out.Values[i] = ec._TestResult_logs(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -37874,8 +37707,6 @@ func (ec *executionContext) _TestResult(ctx context.Context, sel ast.SelectionSe
 			out.Values[i] = ec._TestResult_taskId(ctx, field, obj)
 		case "execution":
 			out.Values[i] = ec._TestResult_execution(ctx, field, obj)
-		case "logTestName":
-			out.Values[i] = ec._TestResult_logTestName(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -41262,11 +41093,11 @@ func (ec *executionContext) marshalNWebhookHeader2ᚕgithubᚗcomᚋevergreenᚑ
 	return ret
 }
 
-func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
+func (ec *executionContext) marshalN__Directive2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
 	return ec.___Directive(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
+func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirectiveᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Directive) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -41290,7 +41121,7 @@ func (ec *executionContext) marshalN__Directive2ᚕgithubᚗcomᚋ99designsᚋgq
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
+			ret[i] = ec.marshalN__Directive2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -41374,19 +41205,19 @@ func (ec *executionContext) marshalN__DirectiveLocation2ᚕstringᚄ(ctx context
 	return ret
 }
 
-func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
+func (ec *executionContext) marshalN__EnumValue2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v introspection.EnumValue) graphql.Marshaler {
 	return ec.___EnumValue(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
+func (ec *executionContext) marshalN__Field2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx context.Context, sel ast.SelectionSet, v introspection.Field) graphql.Marshaler {
 	return ec.___Field(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
+func (ec *executionContext) marshalN__InputValue2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx context.Context, sel ast.SelectionSet, v introspection.InputValue) graphql.Marshaler {
 	return ec.___InputValue(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -41410,7 +41241,7 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
+			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -41423,11 +41254,11 @@ func (ec *executionContext) marshalN__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 	return ret
 }
 
-func (ec *executionContext) marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+func (ec *executionContext) marshalN__Type2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
 	return ec.___Type(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -41451,7 +41282,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
+			ret[i] = ec.marshalN__Type2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -41464,7 +41295,7 @@ func (ec *executionContext) marshalN__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 	return ret
 }
 
-func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+func (ec *executionContext) marshalN__Type2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "must not be null")
@@ -43360,7 +43191,7 @@ func (ec *executionContext) marshalOWorkstationSetupCommand2ᚕgithubᚗcomᚋev
 	return ret
 }
 
-func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
+func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -43387,7 +43218,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
+			ret[i] = ec.marshalN__EnumValue2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -43400,7 +43231,7 @@ func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgq
 	return ret
 }
 
-func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
+func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Field) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -43427,7 +43258,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalN__Field2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
+			ret[i] = ec.marshalN__Field2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐField(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -43440,7 +43271,7 @@ func (ec *executionContext) marshalO__Field2ᚕgithubᚗcomᚋ99designsᚋgqlgen
 	return ret
 }
 
-func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
+func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.InputValue) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -43467,7 +43298,7 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
+			ret[i] = ec.marshalN__InputValue2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐInputValue(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -43480,22 +43311,22 @@ func (ec *executionContext) marshalO__InputValue2ᚕgithubᚗcomᚋ99designsᚋg
 	return ret
 }
 
-func (ec *executionContext) marshalO__Schema2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v introspection.Schema) graphql.Marshaler {
+func (ec *executionContext) marshalO__Schema2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v introspection.Schema) graphql.Marshaler {
 	return ec.___Schema(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
+func (ec *executionContext) marshalO__Schema2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx context.Context, sel ast.SelectionSet, v *introspection.Schema) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
 	return ec.___Schema(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalO__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
+func (ec *executionContext) marshalO__Type2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v introspection.Type) graphql.Marshaler {
 	return ec.___Type(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
+func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.Type) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -43522,7 +43353,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalN__Type2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
+			ret[i] = ec.marshalN__Type2githubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -43535,7 +43366,7 @@ func (ec *executionContext) marshalO__Type2ᚕgithubᚗcomᚋ99designsᚋgqlgen�
 	return ret
 }
 
-func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
+func (ec *executionContext) marshalO__Type2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋvendorᚋgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx context.Context, sel ast.SelectionSet, v *introspection.Type) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/graphql/integration_spec.json
+++ b/graphql/integration_spec.json
@@ -2858,7 +2858,7 @@
                 "logs": {
                   "url": "https://original-url.com",
                   "urlRaw": "https://original-raw-url.com",
-                  "urlLobster": ""
+                  "urlLobster": null
                 },
                 "id": "19ef7a20a7798219e191d00e"
               }
@@ -2877,7 +2877,7 @@
                 "logs": {
                   "url": "https://localhost:8443/test_log/59ef7a2097b1d3148d0004f1#L126",
                   "urlRaw": "https://localhost:8443/test_log/59ef7a2097b1d3148d0004f1?text=true",
-                  "urlLobster": ""
+                  "urlLobster": null
                 },
                 "id": "39ef7a20a7798219e191d00e"
               }

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1504,8 +1504,11 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 
 		if len(cedarBaseTestResults) > 0 {
 			for _, t := range cedarBaseTestResults {
-				baseTestStatusMap[t.TestName] = t.Status
-				baseTestStatusMap[t.DisplayTestName] = t.Status
+				if t.DisplayTestName != "" {
+					baseTestStatusMap[t.DisplayTestName] = t.Status
+				} else {
+					baseTestStatusMap[t.TestName] = t.Status
+				}
 			}
 		} else {
 			baseTestResults, _ := r.sc.FindTestsByTaskId(data.FindTestsByTaskIdOpts{TaskID: baseTask.Id, Execution: baseTask.Execution})
@@ -1560,10 +1563,7 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 				return nil, InternalServerError.Send(ctx, err.Error())
 			}
 
-			baseTestStatus := baseTestStatusMap[utility.FromStringPtr(apiTest.DisplayTestName)]
-			if baseTestStatus == "" {
-				baseTestStatus = baseTestStatusMap[utility.FromStringPtr(apiTest.TestFile)]
-			}
+			baseTestStatus := baseTestStatusMap[utility.FromStringPtr(apiTest.TestFile)]
 			apiTest.BaseStatus = &baseTestStatus
 			testPointers = append(testPointers, &apiTest)
 		}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -689,7 +689,6 @@ type TestResult {
   status: String!
   baseStatus: String
   testFile: String!
-  displayTestName: String
   logs: TestLog!
   exitCode: Int
   startTime: Time
@@ -697,7 +696,6 @@ type TestResult {
   endTime: Time
   taskId: String
   execution: Int
-  logTestName: String
 }
 
 type TestLog {
@@ -705,9 +703,6 @@ type TestLog {
   urlRaw: String
   urlLobster: String
   lineNum: Int
-  htmlDisplayURL: String @deprecated(reason: "htmlDisplayURL deprecated, use url instead (EVG-15418)")
-  rawDisplayURL: String @deprecated(reason: "rawDisplayURL deprecated, use urlRaw instead (EVG-15418)")
-
 }
 
 type Dependency {

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
 )
 
 // APITest contains the data to be returned whenever a test is used in the
@@ -95,4 +96,10 @@ func (at *APITest) BuildFromService(st interface{}) error {
 	}
 
 	return nil
+}
+
+func (at *APITest) ToService() (interface{}, error) {
+	// It is not valid translate an APITest object to a TestResult object
+	// due to data loss.
+	return nil, errors.New("not implemented")
 }

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -9,26 +9,23 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/grip"
 )
 
 // APITest contains the data to be returned whenever a test is used in the
 // API.
 type APITest struct {
-	Id              *string    `json:"test_id"`
-	TaskId          *string    `json:"task_id"`
-	Execution       int        `json:"execution"`
-	GroupId         *string    `json:"group_id,omitempty"`
-	Status          *string    `json:"status"`
-	BaseStatus      *string    `json:"base_status,omitempty"`
-	TestFile        *string    `json:"test_file"`
-	DisplayTestName *string    `json:"display_test_name,omitempty"`
-	Logs            TestLogs   `json:"logs"`
-	ExitCode        int        `json:"exit_code"`
-	StartTime       *time.Time `json:"start_time"`
-	EndTime         *time.Time `json:"end_time"`
-	Duration        float64    `json:"duration"`
-	LogTestName     *string    `json:"log_test_name,omitempty"`
+	ID         *string    `json:"test_id"`
+	TaskID     *string    `json:"task_id"`
+	Execution  int        `json:"execution"`
+	Status     *string    `json:"status"`
+	BaseStatus *string    `json:"base_status,omitempty"`
+	TestFile   *string    `json:"test_file"`
+	GroupID    *string    `json:"group_id,omitempty"`
+	Logs       TestLogs   `json:"logs"`
+	ExitCode   int        `json:"exit_code"`
+	StartTime  *time.Time `json:"start_time"`
+	EndTime    *time.Time `json:"end_time"`
+	Duration   float64    `json:"duration"`
 }
 
 // TestLogs is a struct for storing the information about logs that will be
@@ -38,26 +35,18 @@ type TestLogs struct {
 	URLRaw     *string `json:"url_raw"`
 	URLLobster *string `json:"url_lobster,omitempty"`
 	LineNum    int     `json:"line_num"`
-	LogId      *string `json:"log_id,omitempty"`
-
-	// TODO: (EVG-15418): Remove once spruce is updated.
-	HTMLDisplayURL *string `json:"url_raw_display"`
-	RawDisplayURL  *string `json:"url_html_display"`
+	LogID      *string `json:"log_id,omitempty"`
 }
 
 func (at *APITest) BuildFromService(st interface{}) error {
 	switch v := st.(type) {
 	case *testresult.TestResult:
-		at.Id = utility.ToStringPtr(v.ID.Hex())
+		at.ID = utility.ToStringPtr(v.ID.Hex())
 		at.Execution = v.Execution
 		if v.GroupID != "" {
-			at.GroupId = utility.ToStringPtr(v.GroupID)
+			at.GroupID = utility.ToStringPtr(v.GroupID)
 		}
 		at.Status = utility.ToStringPtr(v.Status)
-		at.TestFile = utility.ToStringPtr(v.TestFile)
-		if v.DisplayTestName != "" {
-			at.DisplayTestName = utility.ToStringPtr(v.DisplayTestName)
-		}
 		at.ExitCode = v.ExitCode
 		startTime := utility.FromPythonTime(v.StartTime)
 		endTime := utility.FromPythonTime(v.EndTime)
@@ -66,79 +55,44 @@ func (at *APITest) BuildFromService(st interface{}) error {
 		at.EndTime = ToTimePtr(endTime)
 
 		tr := task.ConvertToOld(v)
+		at.TestFile = utility.ToStringPtr(tr.GetDisplayTestName())
 		at.Logs = TestLogs{
-			URL:        utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerHTML)),
-			URLRaw:     utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerRaw)),
-			URLLobster: utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerLobster)),
-			LineNum:    v.LineNum,
-
-			// TODO: (EVG-15418) Remove after spruce is updated.
-			HTMLDisplayURL: utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerHTML)),
-			RawDisplayURL:  utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerRaw)),
+			URL:     utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerHTML)),
+			URLRaw:  utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerRaw)),
+			LineNum: v.LineNum,
+		}
+		if lobsterURL := tr.GetLogURL(evergreen.LogViewerLobster); lobsterURL != "" {
+			at.Logs.URLLobster = utility.ToStringPtr(lobsterURL)
 		}
 		if v.LogID != "" {
-			at.Logs.LogId = utility.ToStringPtr(v.LogID)
+			at.Logs.LogID = utility.ToStringPtr(v.LogID)
 		}
-
 	case *apimodels.CedarTestResult:
-		at.Id = utility.ToStringPtr(v.TestName)
+		at.ID = utility.ToStringPtr(v.TestName)
 		at.Execution = v.Execution
 		if v.GroupID != "" {
-			at.GroupId = utility.ToStringPtr(v.GroupID)
+			at.GroupID = utility.ToStringPtr(v.GroupID)
 		}
 		at.Status = utility.ToStringPtr(v.Status)
-		at.TestFile = utility.ToStringPtr(v.TestName)
-		if v.DisplayTestName != "" {
-			at.DisplayTestName = utility.ToStringPtr(v.DisplayTestName)
-		}
 		at.StartTime = utility.ToTimePtr(v.Start)
 		at.EndTime = utility.ToTimePtr(v.End)
 		at.Duration = v.End.Sub(v.Start).Seconds()
-		if v.LogTestName != "" {
-			at.LogTestName = utility.ToStringPtr(v.LogTestName)
-		}
 
 		tr := task.ConvertCedarTestResult(*v)
+		at.TestFile = utility.ToStringPtr(tr.GetDisplayTestName())
 		at.Logs = TestLogs{
-			URL:        utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerHTML)),
-			URLRaw:     utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerRaw)),
-			URLLobster: utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerLobster)),
-			LineNum:    v.LineNum,
-
-			// TODO: (EVG-15418) Remove after spruce is updated.
-			HTMLDisplayURL: utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerHTML)),
-			RawDisplayURL:  utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerRaw)),
+			URL:     utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerHTML)),
+			URLRaw:  utility.ToStringPtr(tr.GetLogURL(evergreen.LogViewerRaw)),
+			LineNum: v.LineNum,
 		}
-
+		if lobsterURL := tr.GetLogURL(evergreen.LogViewerLobster); lobsterURL != "" {
+			at.Logs.URLLobster = utility.ToStringPtr(lobsterURL)
+		}
 	case string:
-		at.TaskId = utility.ToStringPtr(v)
+		at.TaskID = utility.ToStringPtr(v)
 	default:
 		return fmt.Errorf("incorrect type '%v' when creating APITest", v)
 	}
 
 	return nil
-}
-
-func (at *APITest) ToService() (interface{}, error) {
-	catcher := grip.NewBasicCatcher()
-	start, err := FromTimePtr(at.StartTime)
-	catcher.Add(err)
-	end, err := FromTimePtr(at.EndTime)
-	catcher.Add(err)
-	if catcher.HasErrors() {
-		return nil, catcher.Resolve()
-	}
-	return &testresult.TestResult{
-		Status:          utility.FromStringPtr(at.Status),
-		TestFile:        utility.FromStringPtr(at.TestFile),
-		DisplayTestName: utility.FromStringPtr(at.DisplayTestName),
-		URL:             utility.FromStringPtr(at.Logs.URL),
-		URLRaw:          utility.FromStringPtr(at.Logs.URLRaw),
-		LogID:           utility.FromStringPtr(at.Logs.LogId),
-		LineNum:         at.Logs.LineNum,
-		ExitCode:        at.ExitCode,
-		StartTime:       utility.ToPythonTime(start),
-		EndTime:         utility.ToPythonTime(end),
-		GroupID:         utility.FromStringPtr(at.GroupId),
-	}, nil
 }

--- a/rest/model/test_test.go
+++ b/rest/model/test_test.go
@@ -38,17 +38,15 @@ func TestTestBuildFromService(t *testing.T) {
 				otr := task.ConvertToOld(input)
 
 				output := &APITest{
-					Id:        utility.ToStringPtr(input.ID.Hex()),
+					ID:        utility.ToStringPtr(input.ID.Hex()),
 					Execution: input.Execution,
 					Status:    utility.ToStringPtr(input.Status),
 					TestFile:  utility.ToStringPtr(input.TestFile),
 					Logs: TestLogs{
-						URL:            utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
-						URLRaw:         utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
-						URLLobster:     utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerLobster)),
-						LineNum:        15,
-						HTMLDisplayURL: utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
-						RawDisplayURL:  utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
+						URL:        utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
+						URLRaw:     utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
+						URLLobster: utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerLobster)),
+						LineNum:    15,
 					},
 					ExitCode:  1,
 					StartTime: utility.ToTimePtr(start),
@@ -78,20 +76,17 @@ func TestTestBuildFromService(t *testing.T) {
 				otr := task.ConvertToOld(input)
 
 				output := &APITest{
-					Id:              utility.ToStringPtr(input.ID.Hex()),
-					Execution:       input.Execution,
-					TestFile:        utility.ToStringPtr(input.TestFile),
-					DisplayTestName: utility.ToStringPtr(input.DisplayTestName),
-					GroupId:         utility.ToStringPtr(input.GroupID),
-					Status:          utility.ToStringPtr(input.Status),
+					ID:        utility.ToStringPtr(input.ID.Hex()),
+					Execution: input.Execution,
+					TestFile:  utility.ToStringPtr(input.DisplayTestName),
+					GroupID:   utility.ToStringPtr(input.GroupID),
+					Status:    utility.ToStringPtr(input.Status),
 					Logs: TestLogs{
-						URL:            utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
-						URLRaw:         utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
-						URLLobster:     utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerLobster)),
-						LineNum:        15,
-						LogId:          utility.ToStringPtr(input.LogID),
-						HTMLDisplayURL: utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
-						RawDisplayURL:  utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
+						URL:        utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
+						URLRaw:     utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
+						URLLobster: nil,
+						LineNum:    15,
+						LogID:      utility.ToStringPtr(input.LogID),
 					},
 					ExitCode:  1,
 					StartTime: utility.ToTimePtr(start),
@@ -117,17 +112,15 @@ func TestTestBuildFromService(t *testing.T) {
 				otr := task.ConvertCedarTestResult(*input)
 
 				output := &APITest{
-					Id:        utility.ToStringPtr(input.TestName),
+					ID:        utility.ToStringPtr(input.TestName),
 					Execution: input.Execution,
 					TestFile:  utility.ToStringPtr(input.TestName),
 					Status:    utility.ToStringPtr(input.Status),
 					Logs: TestLogs{
-						URL:            utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
-						URLRaw:         utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
-						URLLobster:     utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerLobster)),
-						LineNum:        15,
-						HTMLDisplayURL: utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
-						RawDisplayURL:  utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
+						URL:        utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
+						URLRaw:     utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
+						URLLobster: utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerLobster)),
+						LineNum:    15,
 					},
 					StartTime: utility.ToTimePtr(start),
 					EndTime:   utility.ToTimePtr(end),
@@ -155,20 +148,16 @@ func TestTestBuildFromService(t *testing.T) {
 				otr := task.ConvertCedarTestResult(*input)
 
 				output := &APITest{
-					Id:              utility.ToStringPtr(input.TestName),
-					Execution:       input.Execution,
-					TestFile:        utility.ToStringPtr(input.TestName),
-					DisplayTestName: utility.ToStringPtr(input.DisplayTestName),
-					GroupId:         utility.ToStringPtr(input.GroupID),
-					Status:          utility.ToStringPtr(input.Status),
-					LogTestName:     utility.ToStringPtr(input.LogTestName),
+					ID:        utility.ToStringPtr(input.TestName),
+					Execution: input.Execution,
+					TestFile:  utility.ToStringPtr(input.DisplayTestName),
+					GroupID:   utility.ToStringPtr(input.GroupID),
+					Status:    utility.ToStringPtr(input.Status),
 					Logs: TestLogs{
-						URL:            utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
-						URLRaw:         utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
-						URLLobster:     utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerLobster)),
-						LineNum:        15,
-						HTMLDisplayURL: utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
-						RawDisplayURL:  utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
+						URL:        utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerHTML)),
+						URLRaw:     utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerRaw)),
+						URLLobster: utility.ToStringPtr(otr.GetLogURL(evergreen.LogViewerLobster)),
+						LineNum:    15,
 					},
 					StartTime: utility.ToTimePtr(start),
 					EndTime:   utility.ToTimePtr(end),
@@ -182,7 +171,7 @@ func TestTestBuildFromService(t *testing.T) {
 			name: "TaskID",
 			io: func() (interface{}, *APITest) {
 				output := &APITest{
-					TaskId: utility.ToStringPtr("task"),
+					TaskID: utility.ToStringPtr("task"),
 				}
 
 				return "task", output


### PR DESCRIPTION
[EVG-15379](https://jira.mongodb.org/browse/EVG-15379)

Once the spruce UI uses the test log URLs generated by the test results API, we can set `test_file` to the display test name rather than the unique test name used for backend purposes (downstream users do not really need to be aware of these non human readable names).

This PR should not be merged until [EVG-15418](https://jira.mongodb.org/browse/EVG-15418) is completed and spruce is deployed.
