### PR TITLE
EVG-15436: Do not store URL in xunit test results

### DIFF
--- a/agent/command/results_xunit_parser.go
+++ b/agent/command/results_xunit_parser.go
@@ -139,8 +139,6 @@ func (tc testCase) toModelTestResultAndLog(conf *internal.TaskConfig) (task.Test
 		log.Task = conf.Task.Id
 		log.TaskExecution = conf.Task.Execution
 
-		// update the URL of the result to the expected log URL
-		res.URL = log.URL()
 		res.LogTestName = log.Name
 	}
 

--- a/agent/command/results_xunit_parser_test.go
+++ b/agent/command/results_xunit_parser_test.go
@@ -252,8 +252,6 @@ func TestXMLToModelConversion(t *testing.T) {
 				Convey("and logs should be of the proper form", func() {
 					So(logs[0].Name, ShouldNotEqual, "")
 					So(len(logs[0].Lines), ShouldNotEqual, 0)
-					So(logs[0].URL(), ShouldContainSubstring,
-						"TEST/5/test.test_auth.TestAuthURIOptions.test_uri_options")
 				})
 			})
 		})

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-07-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-09-14"
+	AgentVersion = "2021-09-20"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -349,6 +349,12 @@ func (tr TestResult) GetLogURL(viewer evergreen.LogViewer) string {
 				return strings.Replace(tr.URL, deprecatedLobsterURL, root, 1)
 			}
 
+			// Some test results may have internal URLs that are
+			// missing the root.
+			if err := util.CheckURL(tr.URL); err != nil {
+				return root + tr.URL
+			}
+
 			return tr.URL
 		}
 
@@ -385,6 +391,12 @@ func (tr TestResult) GetLogURL(viewer evergreen.LogViewer) string {
 		)
 	default:
 		if tr.URLRaw != "" {
+			// Some test results may have internal URLs that are
+			// missing the root.
+			if err := util.CheckURL(tr.URL); err != nil {
+				return root + tr.URL
+			}
+
 			return tr.URLRaw
 		}
 

--- a/model/test_log.go
+++ b/model/test_log.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -100,14 +99,4 @@ func (self *TestLog) Validate() error {
 	default:
 		return nil
 	}
-}
-
-// URL returns the path to access the log based on its current fields.
-// Does not error if fields are not set.
-func (self *TestLog) URL() string {
-	return fmt.Sprintf("/test_log/%v/%v/%v",
-		self.Task,
-		self.TaskExecution,
-		self.Name,
-	)
 }


### PR DESCRIPTION
[EVG-15436](https://jira.mongodb.org/browse/EVG-15436)

We should not store internal test log URLs for test results since we generate them [here](https://github.com/evergreen-ci/evergreen/blob/main/model/task/task.go#L341). 
