### PR TITLE
EVG-15381: add options for pod private repository credentials

### DIFF
--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -123,6 +123,12 @@ func (i ContainerResourceInfo) IsZero() bool {
 type TaskContainerCreationOptions struct {
 	// Image is the image that the task's container will run.
 	Image string `bson:"image" json:"image"`
+	// RepoUsername is the username of the repository containing the image. This
+	// is only necessary if it is a private repository.
+	RepoUsername string `bson:"repo_username,omitempty" json:"repo_username,omitempty"`
+	// RepoPassword is the password of the repository containing the image. This
+	// is only necessary if it is a private repository.
+	RepoPassword string `bson:"repo_password,omitempty" json:"repo_password,omitempty"`
 	// MemoryMB is the memory (in MB) that the task's container will be
 	// allocated.
 	MemoryMB int `bson:"memory_mb" json:"memory_mb"`

--- a/rest/model/pod.go
+++ b/rest/model/pod.go
@@ -17,15 +17,17 @@ type APIPodEnvVar struct {
 
 // APICreatePod is the model to create a new pod.
 type APICreatePod struct {
-	Name       *string         `json:"name"`
-	Memory     *int            `json:"memory"`
-	CPU        *int            `json:"cpu"`
-	Image      *string         `json:"image"`
-	EnvVars    []*APIPodEnvVar `json:"env_vars"`
-	OS         *string         `json:"os"`
-	Arch       *string         `json:"arch"`
-	Secret     *string         `json:"secret"`
-	WorkingDir *string         `json:"working_dir"`
+	Name         *string         `json:"name"`
+	Memory       *int            `json:"memory"`
+	CPU          *int            `json:"cpu"`
+	Image        *string         `json:"image"`
+	RepoUsername *string         `json:"repo_username"`
+	RepoPassword *string         `json:"repo_password"`
+	EnvVars      []*APIPodEnvVar `json:"env_vars"`
+	OS           *string         `json:"os"`
+	Arch         *string         `json:"arch"`
+	Secret       *string         `json:"secret"`
+	WorkingDir   *string         `json:"working_dir"`
 }
 
 type APICreatePodResponse struct {
@@ -52,14 +54,16 @@ func (p *APICreatePod) ToService() (interface{}, error) {
 			Initializing: time.Now(),
 		},
 		TaskContainerCreationOpts: pod.TaskContainerCreationOptions{
-			Image:      utility.FromStringPtr(p.Image),
-			MemoryMB:   utility.FromIntPtr(p.Memory),
-			CPU:        utility.FromIntPtr(p.CPU),
-			OS:         os,
-			Arch:       arch,
-			EnvVars:    envVars,
-			EnvSecrets: secrets,
-			WorkingDir: utility.FromStringPtr(p.WorkingDir),
+			Image:        utility.FromStringPtr(p.Image),
+			RepoUsername: utility.FromStringPtr(p.RepoUsername),
+			RepoPassword: utility.FromStringPtr(p.RepoPassword),
+			MemoryMB:     utility.FromIntPtr(p.Memory),
+			CPU:          utility.FromIntPtr(p.CPU),
+			OS:           os,
+			Arch:         arch,
+			EnvVars:      envVars,
+			EnvSecrets:   secrets,
+			WorkingDir:   utility.FromStringPtr(p.WorkingDir),
 		},
 	}, nil
 }
@@ -187,20 +191,24 @@ func (s *APIPodStatus) ToService() (*pod.Status, error) {
 // APIPodTaskContainerCreationOptions represents options to apply to the task's
 // container when creating a pod.
 type APIPodTaskContainerCreationOptions struct {
-	Image      *string           `json:"image,omitempty"`
-	MemoryMB   *int              `json:"memory_mb,omitempty"`
-	CPU        *int              `json:"cpu,omitempty"`
-	OS         *string           `json:"os,omitempty"`
-	Arch       *string           `json:"arch,omitempty"`
-	EnvVars    map[string]string `json:"env_vars,omitempty"`
-	EnvSecrets map[string]string `json:"env_secrets,omitempty"`
-	WorkingDir *string           `json:"working_dir,omitempty"`
+	Image        *string           `json:"image,omitempty"`
+	RepoUsername *string           `json:"repo_username,omitempty"`
+	RepoPassword *string           `json:"repo_password,omitempty"`
+	MemoryMB     *int              `json:"memory_mb,omitempty"`
+	CPU          *int              `json:"cpu,omitempty"`
+	OS           *string           `json:"os,omitempty"`
+	Arch         *string           `json:"arch,omitempty"`
+	EnvVars      map[string]string `json:"env_vars,omitempty"`
+	EnvSecrets   map[string]string `json:"env_secrets,omitempty"`
+	WorkingDir   *string           `json:"working_dir,omitempty"`
 }
 
 // BuildFromService converts service-layer task container creation options into
 // REST API task container creation options.
 func (o *APIPodTaskContainerCreationOptions) BuildFromService(opts pod.TaskContainerCreationOptions) {
 	o.Image = utility.ToStringPtr(opts.Image)
+	o.RepoUsername = utility.ToStringPtr(opts.RepoUsername)
+	o.RepoPassword = utility.ToStringPtr(opts.RepoPassword)
 	o.MemoryMB = utility.ToIntPtr(opts.MemoryMB)
 	o.CPU = utility.ToIntPtr(opts.CPU)
 	o.OS = utility.ToStringPtr(string(opts.OS))
@@ -222,14 +230,16 @@ func (o *APIPodTaskContainerCreationOptions) ToService() (*pod.TaskContainerCrea
 		return nil, errors.Wrap(err, "invalid architecture")
 	}
 	return &pod.TaskContainerCreationOptions{
-		Image:      utility.FromStringPtr(o.Image),
-		MemoryMB:   utility.FromIntPtr(o.MemoryMB),
-		CPU:        utility.FromIntPtr(o.CPU),
-		OS:         os,
-		Arch:       arch,
-		EnvVars:    o.EnvVars,
-		EnvSecrets: o.EnvSecrets,
-		WorkingDir: utility.FromStringPtr(o.WorkingDir),
+		Image:        utility.FromStringPtr(o.Image),
+		RepoUsername: utility.FromStringPtr(o.RepoUsername),
+		RepoPassword: utility.FromStringPtr(o.RepoPassword),
+		MemoryMB:     utility.FromIntPtr(o.MemoryMB),
+		CPU:          utility.FromIntPtr(o.CPU),
+		OS:           os,
+		Arch:         arch,
+		EnvVars:      o.EnvVars,
+		EnvSecrets:   o.EnvSecrets,
+		WorkingDir:   utility.FromStringPtr(o.WorkingDir),
 	}, nil
 }
 

--- a/rest/model/pod_test.go
+++ b/rest/model/pod_test.go
@@ -13,10 +13,12 @@ import (
 func TestAPICreatePod(t *testing.T) {
 	t.Run("ToService", func(t *testing.T) {
 		apiPod := APICreatePod{
-			Name:   utility.ToStringPtr("id"),
-			Memory: utility.ToIntPtr(128),
-			CPU:    utility.ToIntPtr(128),
-			Image:  utility.ToStringPtr("image"),
+			Name:         utility.ToStringPtr("id"),
+			Memory:       utility.ToIntPtr(128),
+			CPU:          utility.ToIntPtr(128),
+			Image:        utility.ToStringPtr("image"),
+			RepoUsername: utility.ToStringPtr("username"),
+			RepoPassword: utility.ToStringPtr("password"),
 			EnvVars: []*APIPodEnvVar{
 				{
 					Name:   utility.ToStringPtr("name"),
@@ -48,6 +50,8 @@ func TestAPICreatePod(t *testing.T) {
 
 		assert.Equal(t, utility.FromStringPtr(apiPod.Secret), p.Secret)
 		assert.Equal(t, utility.FromStringPtr(apiPod.Image), p.TaskContainerCreationOpts.Image)
+		assert.Equal(t, utility.FromStringPtr(apiPod.RepoUsername), p.TaskContainerCreationOpts.RepoUsername)
+		assert.Equal(t, utility.FromStringPtr(apiPod.RepoPassword), p.TaskContainerCreationOpts.RepoPassword)
 		assert.Equal(t, utility.FromIntPtr(apiPod.Memory), p.TaskContainerCreationOpts.MemoryMB)
 		assert.Equal(t, utility.FromIntPtr(apiPod.CPU), p.TaskContainerCreationOpts.CPU)
 		assert.Equal(t, utility.FromStringPtr(apiPod.OS), string(p.TaskContainerCreationOpts.OS))
@@ -70,9 +74,11 @@ func TestAPIPod(t *testing.T) {
 			Status: pod.StatusRunning,
 			Secret: "secret",
 			TaskContainerCreationOpts: pod.TaskContainerCreationOptions{
-				Image:    "image",
-				MemoryMB: 128,
-				CPU:      128,
+				Image:        "image",
+				RepoUsername: "username",
+				RepoPassword: "password",
+				MemoryMB:     128,
+				CPU:          128,
 				EnvVars: map[string]string{
 					"var0": "val0",
 					"var1": "val1",
@@ -110,11 +116,13 @@ func TestAPIPod(t *testing.T) {
 			Status: &status,
 			Secret: utility.ToStringPtr("secret"),
 			TaskContainerCreationOpts: APIPodTaskContainerCreationOptions{
-				Image:    utility.ToStringPtr("image"),
-				MemoryMB: utility.ToIntPtr(128),
-				CPU:      utility.ToIntPtr(128),
-				OS:       utility.ToStringPtr("linux"),
-				Arch:     utility.ToStringPtr("amd64"),
+				Image:        utility.ToStringPtr("image"),
+				RepoUsername: utility.ToStringPtr("username"),
+				RepoPassword: utility.ToStringPtr("password"),
+				MemoryMB:     utility.ToIntPtr(128),
+				CPU:          utility.ToIntPtr(128),
+				OS:           utility.ToStringPtr("linux"),
+				Arch:         utility.ToStringPtr("amd64"),
 				EnvVars: map[string]string{
 					"var0": "val0",
 					"var1": "val1",
@@ -153,6 +161,8 @@ func TestAPIPod(t *testing.T) {
 			assert.Equal(t, pod.StatusRunning, dbPod.Status)
 			assert.Equal(t, utility.FromStringPtr(apiPod.Secret), dbPod.Secret)
 			assert.Equal(t, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.Image), dbPod.TaskContainerCreationOpts.Image)
+			assert.Equal(t, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.RepoUsername), dbPod.TaskContainerCreationOpts.RepoUsername)
+			assert.Equal(t, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.RepoPassword), dbPod.TaskContainerCreationOpts.RepoPassword)
 			assert.Equal(t, utility.FromIntPtr(apiPod.TaskContainerCreationOpts.MemoryMB), dbPod.TaskContainerCreationOpts.MemoryMB)
 			assert.Equal(t, utility.FromIntPtr(apiPod.TaskContainerCreationOpts.CPU), dbPod.TaskContainerCreationOpts.CPU)
 			assert.Equal(t, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.OS), string(dbPod.TaskContainerCreationOpts.OS))
@@ -209,6 +219,8 @@ func TestAPIPod(t *testing.T) {
 			assert.Equal(t, PodStatusRunning, *apiPod.Status)
 			assert.Equal(t, dbPod.Secret, utility.FromStringPtr(apiPod.Secret))
 			assert.Equal(t, dbPod.TaskContainerCreationOpts.Image, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.Image))
+			assert.Equal(t, dbPod.TaskContainerCreationOpts.RepoUsername, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.RepoUsername))
+			assert.Equal(t, dbPod.TaskContainerCreationOpts.RepoPassword, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.RepoPassword))
 			assert.Equal(t, dbPod.TaskContainerCreationOpts.MemoryMB, utility.FromIntPtr(apiPod.TaskContainerCreationOpts.MemoryMB))
 			assert.Equal(t, dbPod.TaskContainerCreationOpts.CPU, utility.FromIntPtr(apiPod.TaskContainerCreationOpts.CPU))
 			assert.Equal(t, string(dbPod.TaskContainerCreationOpts.OS), utility.FromStringPtr(apiPod.TaskContainerCreationOpts.OS))


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15381

### Description 
* Add REST route options to pass credentials to access private Docker repositories in ECS.

### Testing 
* Updated tests for the REST to DB model conversion and propagating the credentials to Cocoa during pod creation.
* Verified that pulling from a private repository with ECS works as expected in staging.