### PR TITLE
EVG-15333: exclude container instance state changes from SNS notifications

### DIFF
--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -35,7 +35,6 @@ const (
 	instanceStateChangeType = "EC2 Instance State-change Notification"
 
 	ecsTaskStateChangeType              = "ECS Task State Change"
-	ecsContainerInstanceStateChangeType = "ECS Container Instance State Change"
 )
 
 type baseSNS struct {
@@ -423,10 +422,6 @@ func (sns *ecsSNS) handleNotification(ctx context.Context, notification ecsEvent
 				Message:    fmt.Sprintf("unrecognized status '%s'", notification.Detail.LastStatus),
 			}
 		}
-	case ecsContainerInstanceStateChangeType:
-		// TODO (EVG-15333): remove this no-op once the event rule excludes
-		// container instance state changes.
-		return nil
 	default:
 		grip.Error(message.Fields{
 			"message":         "received an unknown notification detail type",

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -34,7 +34,7 @@ const (
 	interruptionWarningType = "EC2 Spot Instance Interruption Warning"
 	instanceStateChangeType = "EC2 Instance State-change Notification"
 
-	ecsTaskStateChangeType              = "ECS Task State Change"
+	ecsTaskStateChangeType = "ECS Task State Change"
 )
 
 type baseSNS struct {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15333

### Description 
I originally misconfigured the event rules to send both ECS task state changes and ECS container instance state change, but we only care about state changes related to ECS tasks, not the hosts running in ECS. I fixed the event rule to exclude the host state changes, so we don't need to no-op on this event type anymore.

### Testing 
I verified in the AWS EventBridge console that the event patterns excluded container instance state changes from the events sent to SNS notifications.
