### PR TITLE
EVG-15341: Return 404 when error encountered finding merged project ref

### DIFF
--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -631,7 +631,7 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 
 	projectRef, err := model.FindMergedProjectRef(projectID)
 	if err != nil {
-		return nil, http.StatusInternalServerError, errors.WithStack(err)
+		return nil, http.StatusNotFound, errors.WithStack(err)
 	}
 	if projectRef == nil {
 		return nil, http.StatusNotFound, errors.Errorf("error finding the project '%s'", projectID)

--- a/service/project.go
+++ b/service/project.go
@@ -89,7 +89,7 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 	if projRef.UseRepoSettings {
 		projRef, err = model.FindMergedProjectRef(projRef.Id)
 		if err != nil {
-			uis.LoggedError(w, r, http.StatusInternalServerError, err)
+			uis.LoggedError(w, r, http.StatusNotFound, err)
 			return
 		}
 	}


### PR DESCRIPTION
[EVG-15341](https://jira.mongodb.org/browse/EVG-15341)

### Description 
Currently all routes that use urlVarsToProjectScopes in the middleware such as this [endpoint](https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#get-versions-for-a-project) return a 500 internal server error when a merged project ref is unable to be found. Change has been made to return a 404 in this case instead.
### Testing 
Deployed to staging and confirmed that the route now returns 404 for an invalid project.  Attached screenshot.
