### PR TITLE
EVG-15356: Send log to splunk when user offboards

### DIFF
--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -400,6 +400,13 @@ func (ch *offboardUserHandler) Run(ctx context.Context) gimlet.Responder {
 	opts := model.APIHostParams{
 		UserSpawned: true,
 	}
+	if !ch.dryRun {
+		grip.Info(message.Fields{
+			"message": "executing user offboarding",
+			"context": "user offboarding",
+			"user":    ch.user,
+		})
+	}
 	// returns all up-hosts for user
 	hosts, err := ch.sc.FindHostsInRange(opts, ch.user)
 	if err != nil {

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -400,13 +400,6 @@ func (ch *offboardUserHandler) Run(ctx context.Context) gimlet.Responder {
 	opts := model.APIHostParams{
 		UserSpawned: true,
 	}
-	if !ch.dryRun {
-		grip.Info(message.Fields{
-			"message": "executing user offboarding",
-			"context": "user offboarding",
-			"user":    ch.user,
-		})
-	}
 	// returns all up-hosts for user
 	hosts, err := ch.sc.FindHostsInRange(opts, ch.user)
 	if err != nil {
@@ -443,6 +436,13 @@ func (ch *offboardUserHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	if !ch.dryRun {
+		grip.Info(message.Fields{
+			"message":            "executing user offboarding",
+			"user":               ch.user,
+			"terminated_hosts":   toTerminate.TerminatedHosts,
+			"terminated_volumes": toTerminate.TerminatedVolumes,
+		})
+
 		grip.Error(message.WrapError(ch.sc.RemoveAdminFromProjects(ch.user), message.Fields{
 			"message": "could not remove user as an admin",
 			"context": "user offboarding",


### PR DESCRIPTION
[EVG-15356](https://jira.mongodb.org/browse/EVG-15356)

### Description 
There is currently no record in Splunk when we offboard users.  Added logging to track who we offboard and when.