### PR TITLE
EVG-15225: remove single quotes from agent curl command for Windows

### DIFF
--- a/cloud/pod_agent_util.go
+++ b/cloud/pod_agent_util.go
@@ -64,9 +64,11 @@ func downloadAgentCommands(settings *evergreen.Settings, p *pod.Pod) string {
 	if !settings.ServiceFlags.S3BinaryDownloadsDisabled && settings.PodInit.S3BaseURL != "" {
 		// Attempt to download the agent from S3, but fall back to downloading
 		// from the app server if it fails.
-		curlCmd = fmt.Sprintf("(curl -LO '%s' %s || curl -LO '%s' %s)", s3ClientURL(settings, p), retryArgs, clientURL(settings, p), retryArgs)
+		// Include -f to return an error code from curl if the HTTP request
+		// fails (e.g. it receives 403 Forbidden or 404 Not Found).
+		curlCmd = fmt.Sprintf("(curl -fLO %s %s || curl -fLO %s %s)", s3ClientURL(settings, p), retryArgs, clientURL(settings, p), retryArgs)
 	} else {
-		curlCmd = fmt.Sprintf("curl -LO '%s' %s", clientURL(settings, p), retryArgs)
+		curlCmd = fmt.Sprintf("curl -fLO %s %s", clientURL(settings, p), retryArgs)
 	}
 
 	return curlCmd

--- a/cloud/pod_agent_util_test.go
+++ b/cloud/pod_agent_util_test.go
@@ -34,7 +34,7 @@ func TestAgentScript(t *testing.T) {
 
 			expected := []string{
 				"bash", "-c",
-				"curl -LO 'www.test.com/clients/linux_amd64/evergreen' --retry 10 --retry-max-time 100 && " +
+				"curl -fLO 'www.test.com/clients/linux_amd64/evergreen' --retry 10 --retry-max-time 100 && " +
 					"chmod +x evergreen && " +
 					"./evergreen agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci",
 			}
@@ -55,7 +55,7 @@ func TestAgentScript(t *testing.T) {
 
 			expected := []string{
 				"cmd.exe", "/c",
-				"curl -LO 'www.test.com/clients/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100 && " +
+				"curl -fLO 'www.test.com/clients/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100 && " +
 					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci",
 			}
 			assert.Equal(t, expected, cmd)
@@ -83,7 +83,7 @@ func TestAgentScript(t *testing.T) {
 
 			expected := []string{
 				"bash", "-c",
-				fmt.Sprintf("(curl -LO 'https://foo.com/%s/linux_amd64/evergreen' --retry 10 --retry-max-time 100 || curl -LO 'www.test.com/clients/linux_amd64/evergreen' --retry 10 --retry-max-time 100) && "+
+				fmt.Sprintf("(curl -fLO 'https://foo.com/%s/linux_amd64/evergreen' --retry 10 --retry-max-time 100 || curl -fLO 'www.test.com/clients/linux_amd64/evergreen' --retry 10 --retry-max-time 100) && "+
 					"chmod +x evergreen && "+
 					"./evergreen agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci", evergreen.BuildRevision),
 			}
@@ -103,7 +103,7 @@ func TestAgentScript(t *testing.T) {
 			require.NotZero(t, cmd)
 			expected := []string{
 				"cmd.exe", "/c",
-				fmt.Sprintf("(curl -LO 'https://foo.com/%s/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100 || curl -LO 'www.test.com/clients/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100) && "+
+				fmt.Sprintf("(curl -fLO 'https://foo.com/%s/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100 || curl -fLO 'www.test.com/clients/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100) && "+
 					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci", evergreen.BuildRevision),
 			}
 			assert.Equal(t, expected, cmd)

--- a/cloud/pod_agent_util_test.go
+++ b/cloud/pod_agent_util_test.go
@@ -34,7 +34,7 @@ func TestAgentScript(t *testing.T) {
 
 			expected := []string{
 				"bash", "-c",
-				"curl -fLO 'www.test.com/clients/linux_amd64/evergreen' --retry 10 --retry-max-time 100 && " +
+				"curl -fLO www.test.com/clients/linux_amd64/evergreen --retry 10 --retry-max-time 100 && " +
 					"chmod +x evergreen && " +
 					"./evergreen agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci",
 			}
@@ -55,7 +55,7 @@ func TestAgentScript(t *testing.T) {
 
 			expected := []string{
 				"cmd.exe", "/c",
-				"curl -fLO 'www.test.com/clients/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100 && " +
+				"curl -fLO www.test.com/clients/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100 && " +
 					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci",
 			}
 			assert.Equal(t, expected, cmd)
@@ -83,7 +83,7 @@ func TestAgentScript(t *testing.T) {
 
 			expected := []string{
 				"bash", "-c",
-				fmt.Sprintf("(curl -fLO 'https://foo.com/%s/linux_amd64/evergreen' --retry 10 --retry-max-time 100 || curl -fLO 'www.test.com/clients/linux_amd64/evergreen' --retry 10 --retry-max-time 100) && "+
+				fmt.Sprintf("(curl -fLO https://foo.com/%s/linux_amd64/evergreen --retry 10 --retry-max-time 100 || curl -fLO www.test.com/clients/linux_amd64/evergreen --retry 10 --retry-max-time 100) && "+
 					"chmod +x evergreen && "+
 					"./evergreen agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci", evergreen.BuildRevision),
 			}
@@ -103,7 +103,7 @@ func TestAgentScript(t *testing.T) {
 			require.NotZero(t, cmd)
 			expected := []string{
 				"cmd.exe", "/c",
-				fmt.Sprintf("(curl -fLO 'https://foo.com/%s/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100 || curl -fLO 'www.test.com/clients/windows_amd64/evergreen.exe' --retry 10 --retry-max-time 100) && "+
+				fmt.Sprintf("(curl -fLO https://foo.com/%s/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100 || curl -fLO www.test.com/clients/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100) && "+
 					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci", evergreen.BuildRevision),
 			}
 			assert.Equal(t, expected, cmd)

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -99,9 +99,9 @@ func (h *Host) curlCommands(settings *evergreen.Settings, curlArgs string) ([]st
 		// the app server if it fails.
 		// Include -f to return an error code from curl if the HTTP request
 		// fails (e.g. it receives 403 Forbidden or 404 Not Found).
-		curlCmd = fmt.Sprintf("(curl -fLO '%s'%s || curl -LO '%s'%s)", h.Distro.S3ClientURL(settings), curlArgs, h.Distro.ClientURL(settings), curlArgs)
+		curlCmd = fmt.Sprintf("(curl -fLO %s%s || curl -fLO %s%s)", h.Distro.S3ClientURL(settings), curlArgs, h.Distro.ClientURL(settings), curlArgs)
 	} else {
-		curlCmd += fmt.Sprintf("curl -LO '%s'%s", h.Distro.ClientURL(settings), curlArgs)
+		curlCmd += fmt.Sprintf("curl -fLO %s%s", h.Distro.ClientURL(settings), curlArgs)
 	}
 	return []string{
 		fmt.Sprintf("cd %s", h.Distro.HomeDir()),
@@ -363,7 +363,7 @@ func (h *Host) fetchJasperCommands(config evergreen.HostJasperConfig) []string {
 	extractedFile := h.jasperBinaryFileName(config)
 	return []string{
 		fmt.Sprintf("cd %s", h.Distro.BootstrapSettings.JasperBinaryDir),
-		fmt.Sprintf("curl -LO '%s/%s' %s", config.URL, downloadedFile, curlRetryArgs(curlDefaultNumRetries, curlDefaultMaxSecs)),
+		fmt.Sprintf("curl -fLO %s/%s %s", config.URL, downloadedFile, curlRetryArgs(curlDefaultNumRetries, curlDefaultMaxSecs)),
 		fmt.Sprintf("tar xzf '%s'", downloadedFile),
 		fmt.Sprintf("chmod +x '%s'", extractedFile),
 		fmt.Sprintf("rm -f '%s'", downloadedFile),

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -48,7 +48,7 @@ func TestCurlCommand(t *testing.T) {
 				},
 				User: "user",
 			}
-			expected := "cd /home/user && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' && chmod +x evergreen.exe"
+			expected := "cd /home/user && curl -fLO www.example.com/clients/windows_amd64/evergreen.exe && chmod +x evergreen.exe"
 			cmd, err := h.CurlCommand(settings)
 			require.NoError(t, err)
 			assert.Equal(expected, cmd)
@@ -61,7 +61,7 @@ func TestCurlCommand(t *testing.T) {
 				},
 				User: "user",
 			}
-			expected := "cd /home/user && curl -LO 'www.example.com/clients/linux_amd64/evergreen' && chmod +x evergreen"
+			expected := "cd /home/user && curl -fLO www.example.com/clients/linux_amd64/evergreen && chmod +x evergreen"
 			cmd, err := h.CurlCommand(settings)
 			require.NoError(t, err)
 			assert.Equal(expected, cmd)
@@ -81,7 +81,7 @@ func TestCurlCommand(t *testing.T) {
 				},
 				User: "user",
 			}
-			expected := fmt.Sprintf("cd /home/user && (curl -fLO 'https://foo.com/%s/windows_amd64/evergreen.exe' || curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe') && chmod +x evergreen.exe", evergreen.BuildRevision)
+			expected := fmt.Sprintf("cd /home/user && (curl -fLO https://foo.com/%s/windows_amd64/evergreen.exe || curl -fLO www.example.com/clients/windows_amd64/evergreen.exe) && chmod +x evergreen.exe", evergreen.BuildRevision)
 			cmd, err := h.CurlCommand(settings)
 			require.NoError(t, err)
 			assert.Equal(expected, cmd)
@@ -94,7 +94,7 @@ func TestCurlCommand(t *testing.T) {
 				},
 				User: "user",
 			}
-			expected := fmt.Sprintf("cd /home/user && (curl -fLO 'https://foo.com/%s/linux_amd64/evergreen' || curl -LO 'www.example.com/clients/linux_amd64/evergreen') && chmod +x evergreen", evergreen.BuildRevision)
+			expected := fmt.Sprintf("cd /home/user && (curl -fLO https://foo.com/%s/linux_amd64/evergreen || curl -fLO www.example.com/clients/linux_amd64/evergreen) && chmod +x evergreen", evergreen.BuildRevision)
 			cmd, err := h.CurlCommand(settings)
 			require.NoError(t, err)
 			assert.Equal(expected, cmd)
@@ -116,7 +116,7 @@ func TestCurlCommandWithRetry(t *testing.T) {
 				},
 				User: "user",
 			}
-			expected := "cd /home/user && curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10 && chmod +x evergreen.exe"
+			expected := "cd /home/user && curl -fLO www.example.com/clients/windows_amd64/evergreen.exe --retry 5 --retry-max-time 10 && chmod +x evergreen.exe"
 			cmd, err := h.CurlCommandWithRetry(settings, 5, 10)
 			require.NoError(t, err)
 			assert.Equal(t, expected, cmd)
@@ -129,7 +129,7 @@ func TestCurlCommandWithRetry(t *testing.T) {
 				},
 				User: "user",
 			}
-			expected := "cd /home/user && curl -LO 'www.example.com/clients/linux_amd64/evergreen' --retry 5 --retry-max-time 10 && chmod +x evergreen"
+			expected := "cd /home/user && curl -fLO www.example.com/clients/linux_amd64/evergreen --retry 5 --retry-max-time 10 && chmod +x evergreen"
 			cmd, err := h.CurlCommandWithRetry(settings, 5, 10)
 			require.NoError(t, err)
 			assert.Equal(t, expected, cmd)
@@ -149,7 +149,7 @@ func TestCurlCommandWithRetry(t *testing.T) {
 				},
 				User: "user",
 			}
-			expected := fmt.Sprintf("cd /home/user && (curl -fLO 'https://foo.com/%s/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10 || curl -LO 'www.example.com/clients/windows_amd64/evergreen.exe' --retry 5 --retry-max-time 10) && chmod +x evergreen.exe", evergreen.BuildRevision)
+			expected := fmt.Sprintf("cd /home/user && (curl -fLO https://foo.com/%s/windows_amd64/evergreen.exe --retry 5 --retry-max-time 10 || curl -fLO www.example.com/clients/windows_amd64/evergreen.exe --retry 5 --retry-max-time 10) && chmod +x evergreen.exe", evergreen.BuildRevision)
 			cmd, err := h.CurlCommandWithRetry(settings, 5, 10)
 			require.NoError(t, err)
 			assert.Equal(t, expected, cmd)
@@ -162,7 +162,7 @@ func TestCurlCommandWithRetry(t *testing.T) {
 				},
 				User: "user",
 			}
-			expected := fmt.Sprintf("cd /home/user && (curl -fLO 'https://foo.com/%s/linux_amd64/evergreen' --retry 5 --retry-max-time 10 || curl -LO 'www.example.com/clients/linux_amd64/evergreen' --retry 5 --retry-max-time 10) && chmod +x evergreen", evergreen.BuildRevision)
+			expected := fmt.Sprintf("cd /home/user && (curl -fLO https://foo.com/%s/linux_amd64/evergreen --retry 5 --retry-max-time 10 || curl -fLO www.example.com/clients/linux_amd64/evergreen --retry 5 --retry-max-time 10) && chmod +x evergreen", evergreen.BuildRevision)
 			cmd, err := h.CurlCommandWithRetry(settings, 5, 10)
 			require.NoError(t, err)
 			assert.Equal(t, expected, cmd)
@@ -274,7 +274,7 @@ func TestJasperCommands(t *testing.T) {
 		"VerifyBaseFetchCommands": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			expectedCmds := []string{
 				"cd /foo",
-				fmt.Sprintf("curl -LO 'www.example.com/download_file-linux-amd64-abc123.tar.gz' --retry %d --retry-max-time %d", curlDefaultNumRetries, curlDefaultMaxSecs),
+				fmt.Sprintf("curl -fLO www.example.com/download_file-linux-amd64-abc123.tar.gz --retry %d --retry-max-time %d", curlDefaultNumRetries, curlDefaultMaxSecs),
 				"tar xzf 'download_file-linux-amd64-abc123.tar.gz'",
 				"chmod +x 'jasper_cli'",
 				"rm -f 'download_file-linux-amd64-abc123.tar.gz'",
@@ -498,7 +498,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 		"VerifyBaseFetchCommands": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			expectedCmds := []string{
 				"cd /foo",
-				fmt.Sprintf("curl -LO 'www.example.com/download_file-windows-amd64-abc123.tar.gz' --retry %d --retry-max-time %d", curlDefaultNumRetries, curlDefaultMaxSecs),
+				fmt.Sprintf("curl -fLO www.example.com/download_file-windows-amd64-abc123.tar.gz --retry %d --retry-max-time %d", curlDefaultNumRetries, curlDefaultMaxSecs),
 				"tar xzf 'download_file-windows-amd64-abc123.tar.gz'",
 				"chmod +x 'jasper_cli.exe'",
 				"rm -f 'download_file-windows-amd64-abc123.tar.gz'",

--- a/model/host/stats_test.go
+++ b/model/host/stats_test.go
@@ -19,7 +19,7 @@ func insertTestDocuments() error {
 				Id:       "debian",
 				Provider: evergreen.ProviderNameEc2Auto,
 			},
-			RunningTask: "foo",
+			RunningTask: "baz",
 			StartedBy:   evergreen.User,
 		},
 		Host{
@@ -86,6 +86,9 @@ func insertTestDocuments() error {
 func TestHostStatsByProvider(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
+	defer func() {
+		assert.NoError(db.ClearCollections(Collection))
+	}()
 	assert.NoError(insertTestDocuments())
 
 	result := ProviderStats{}
@@ -102,13 +105,14 @@ func TestHostStatsByProvider(t *testing.T) {
 	sort.Slice(alt, func(i, j int) bool { return alt[i].Provider < alt[j].Provider })
 	sort.Slice(result, func(i, j int) bool { return result[i].Provider < result[j].Provider })
 	assert.Equal(alt, result)
-
-	assert.NoError(db.ClearCollections(Collection))
 }
 
 func TestHostStatsByDistro(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
+	defer func() {
+		assert.NoError(db.ClearCollections(Collection))
+	}()
 	assert.NoError(insertTestDocuments())
 
 	result := DistroStats{}
@@ -133,6 +137,4 @@ func TestHostStatsByDistro(t *testing.T) {
 	sort.Slice(alt, func(i, j int) bool { return alt[i].Distro < alt[j].Distro })
 	sort.Slice(result, func(i, j int) bool { return result[i].Distro < result[j].Distro })
 	assert.Equal(alt, result)
-
-	assert.NoError(db.ClearCollections(Collection))
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15225

### Description
* Remove quotation marks from URL being curled because Windows batch scripts don't allow single quotes. The quotes shouldn't be necessary for the bash/batch script to have valid syntax.
* Fix [a test](https://github.com/evergreen-ci/evergreen/pull/5050/files#diff-2567873892e2fae0771c76fc6d952f51827126e55f8840e253c9e26736268d20R22) that breaks if the `host.running_tasks` unique index exists (which is created by [this test](https://github.com/evergreen-ci/evergreen/blob/0ac37d2251e9fa6833e214944c77058955ea43f3/units/host_monitoring_idle_termination_test.go#L45)). @hhoke 

### Testing 
Updated the unit tests.