### PR TITLE
EVG-15321 modify delete user route to require resource ID

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -952,6 +952,16 @@ var SuperuserPermissions = []string{
 	PermissionRoleModify,
 }
 
+const (
+	BasicProjectAccessRole = "basic_project_access"
+	BasicDistroAccessRole  = "basic_distro_access"
+)
+
+var BasicAccessRoles = []string{
+	BasicProjectAccessRole,
+	BasicDistroAccessRole,
+}
+
 // Evergreen log types.
 const (
 	LogTypeAgent  = "agent_log"

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -398,6 +398,9 @@ func (u *DBUser) DeleteAllRoles() error {
 }
 
 func (u *DBUser) DeleteRoles(roles []string) error {
+	if len(roles) == 0 {
+		return nil
+	}
 	info, err := db.FindAndModify(
 		Collection,
 		bson.M{IdKey: u.Id},

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -269,6 +269,10 @@ func (h *userPermissionsDeleteHandler) Run(ctx context.Context) gimlet.Responder
 	}
 
 	rolesForResource, err := h.rm.FilterForResource(rolesToCheck, h.resourceId, h.resourceType)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(
+			errors.Wrapf(err, "unable to filter user roles for resource ID '%s'", h.resourceId))
+	}
 	rolesToRemove := []string{}
 	for _, r := range rolesForResource {
 		rolesToRemove = append(rolesToRemove, r.ID)

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -168,6 +168,7 @@ func (h *userPermissionsPostHandler) Run(ctx context.Context) gimlet.Responder {
 
 type deletePermissionsRequest struct {
 	ResourceType string `json:"resource_type"`
+	ResourceId   string `json:"resource_id"`
 }
 
 const allResourceType = "all"
@@ -177,6 +178,7 @@ type userPermissionsDeleteHandler struct {
 	rm           gimlet.RoleManager
 	userID       string
 	resourceType string
+	resourceId   string
 }
 
 func makeDeleteUserPermissions(sc data.Connector, rm gimlet.RoleManager) gimlet.RouteHandler {
@@ -204,8 +206,12 @@ func (h *userPermissionsDeleteHandler) Parse(ctx context.Context, r *http.Reques
 		return errors.Wrap(err, "request body is an invalid format")
 	}
 	h.resourceType = request.ResourceType
+	h.resourceId = request.ResourceId
 	if !utility.StringSliceContains(evergreen.ValidResourceTypes, h.resourceType) && h.resourceType != allResourceType {
 		return errors.New("resource_type is not a valid value")
+	}
+	if h.resourceType != allResourceType && h.resourceId == "" {
+		return errors.New("Must specify a resource ID to delete permissions for unless deleting all permissions")
 	}
 
 	return nil
@@ -226,6 +232,12 @@ func (h *userPermissionsDeleteHandler) Run(ctx context.Context) gimlet.Responder
 	if !valid {
 		return gimlet.MakeJSONInternalErrorResponder(errors.New("user exists, but is of invalid type"))
 	}
+	if dbUser == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			Message:    fmt.Sprintf("no matching DB user for '%s'", h.userID),
+			StatusCode: http.StatusNotFound,
+		})
+	}
 
 	if h.resourceType == allResourceType {
 		err = dbUser.DeleteAllRoles()
@@ -245,27 +257,29 @@ func (h *userPermissionsDeleteHandler) Run(ctx context.Context) gimlet.Responder
 		}))
 		return gimlet.MakeJSONInternalErrorResponder(errors.New("unable to get roles for user"))
 	}
-	scopesIds := []string{}
-	for _, role := range roles {
-		scopesIds = append(scopesIds, role.Scope)
-	}
-	applicableScopes, err := h.rm.FilterScopesByResourceType(scopesIds, h.resourceType)
-	if err != nil {
-		grip.Error(message.WrapError(err, message.Fields{
-			"message": "error filtering scopes",
-		}))
-		return gimlet.MakeJSONInternalErrorResponder(errors.New("unable to find applicable scopes for user"))
-	}
-	rolesToRemove := []string{}
-	scopesToRemove := []string{}
-	for _, scope := range applicableScopes {
-		scopesToRemove = append(scopesToRemove, scope.ID)
-	}
-	for _, role := range roles {
-		if utility.StringSliceContains(scopesToRemove, role.Scope) {
-			rolesToRemove = append(rolesToRemove, role.ID)
+	rolesToCheck := []gimlet.Role{}
+	// don't remove basic access, just special access
+	for _, r := range roles {
+		if !utility.StringSliceContains(evergreen.BasicAccessRoles, r.ID) {
+			rolesToCheck = append(rolesToCheck, r)
 		}
 	}
+	if len(rolesToCheck) == 0 {
+		gimlet.NewJSONResponse(struct{}{})
+	}
+
+	rolesForResource, err := h.rm.FilterForResource(rolesToCheck, h.resourceId, h.resourceType)
+	rolesToRemove := []string{}
+	for _, r := range rolesForResource {
+		rolesToRemove = append(rolesToRemove, r.ID)
+	}
+
+	grip.Info(message.Fields{
+		"removed_roles": rolesToRemove,
+		"user":          dbUser.Id,
+		"resource_type": h.resourceType,
+		"resource_id":   h.resourceId,
+	})
 	err = dbUser.DeleteRoles(rolesToRemove)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -256,19 +256,21 @@ func TestDeleteUserPermissions(t *testing.T) {
 	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection}).Err()
 	u := user.DBUser{
 		Id:          "user",
-		SystemRoles: []string{"role1", "role2", "role3"},
+		SystemRoles: []string{"role1", "role2", "role3", evergreen.BasicProjectAccessRole},
 	}
 	require.NoError(t, u.Insert())
 	require.NoError(t, rm.AddScope(gimlet.Scope{ID: "scope1", Resources: []string{"resource1"}, Type: "project"}))
 	require.NoError(t, rm.AddScope(gimlet.Scope{ID: "scope2", Resources: []string{"resource2"}, Type: "project"}))
 	require.NoError(t, rm.AddScope(gimlet.Scope{ID: "scope3", Resources: []string{"resource3"}, Type: "distro"}))
+	require.NoError(t, rm.AddScope(gimlet.Scope{ID: evergreen.AllProjectsScope, Resources: []string{"resource1", "resource2"}, Type: "project"}))
 	require.NoError(t, rm.UpdateRole(gimlet.Role{ID: "role1", Scope: "scope1"}))
 	require.NoError(t, rm.UpdateRole(gimlet.Role{ID: "role2", Scope: "scope2"}))
 	require.NoError(t, rm.UpdateRole(gimlet.Role{ID: "role3", Scope: "scope3"}))
+	require.NoError(t, rm.UpdateRole(gimlet.Role{ID: evergreen.BasicProjectAccessRole, Scope: evergreen.AllProjectsScope}))
 	handler := userPermissionsDeleteHandler{sc: &data.DBConnector{}, rm: rm, userID: u.Id}
 	ctx := context.Background()
 
-	body := `{ "resource_type": "project" }`
+	body := `{ "resource_type": "project", "resource_id": "resource1" }`
 	request, err := http.NewRequest(http.MethodDelete, "", bytes.NewBuffer([]byte(body)))
 	request = gimlet.SetURLVars(request, map[string]string{"user_id": u.Id})
 	require.NoError(t, err)
@@ -277,8 +279,9 @@ func TestDeleteUserPermissions(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.Status())
 	dbUser, err := user.FindOneById(u.Id)
 	require.NoError(t, err)
-	assert.Len(t, dbUser.SystemRoles, 1)
-	assert.Equal(t, "role3", dbUser.SystemRoles[0])
+	assert.Len(t, dbUser.SystemRoles, 3)
+	assert.NotContains(t, dbUser.SystemRoles, "role1")
+	assert.Contains(t, dbUser.SystemRoles, evergreen.BasicProjectAccessRole)
 
 	body = `{ "resource_type": "all" }`
 	request, err = http.NewRequest(http.MethodDelete, "", bytes.NewBuffer([]byte(body)))


### PR DESCRIPTION
[EVG-15321](https://jira.mongodb.org/browse/EVG-15321)

### Description 
We made this route for Mana but they were told that we would accept a resource ID, and apparently we don't, which means that no matter what we're deleting a ton of resources for users. We should only delete roles relevant to the resource, and we should ignore the basic roles so that the user can remain a basic user of Evergreen.

### Testing 
Fixed unit test.
