### PR TITLE
EVG-15430 add route to get users for role

### DIFF
--- a/model/user/db.go
+++ b/model/user/db.go
@@ -179,6 +179,17 @@ func FindByGithubName(name string) (*DBUser, error) {
 	return &u, nil
 }
 
+func FindByRole(role string) ([]DBUser, error) {
+	res := []DBUser{}
+	err := db.FindAllQ(
+		Collection,
+		db.Query(bson.M{RolesKey: role}),
+		&res,
+	)
+	return res, errors.Wrapf(err, "error finding users with role '%s'", role)
+
+}
+
 // GetPatchUser gets a user from their GitHub UID. If no such user is found, it
 // defaults to the global GitHub pull request user.
 func GetPatchUser(gitHubUID int) (*DBUser, error) {

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -171,6 +171,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/repos/{repo_id}").Version(2).Patch().Wrap(checkUser, checkRepoAdmin, editProjectSettings).RouteHandler(makePatchRepoByID(sc, env.Settings()))
 	app.AddRoute("/roles").Version(2).Get().Wrap(checkUser).RouteHandler(acl.NewGetAllRolesHandler(env.RoleManager()))
 	app.AddRoute("/roles").Version(2).Post().Wrap(checkUser).RouteHandler(acl.NewUpdateRoleHandler(env.RoleManager()))
+	app.AddRoute("/roles/{role_id}/users").Version(2).Get().Wrap(checkUser).RouteHandler(makeGetUsersWithRole(sc))
 	app.AddRoute("/scheduler/compare_tasks").Version(2).Post().Wrap(checkUser).RouteHandler(makeCompareTasksRoute(sc))
 	app.AddRoute("/status/cli_version").Version(2).Get().RouteHandler(makeFetchCLIVersionRoute(sc))
 	app.AddRoute("/status/hosts/distros").Version(2).Get().Wrap(checkUser).RouteHandler(makeHostStatusByDistroRoute(sc))


### PR DESCRIPTION
[EVG-15430](https://jira.mongodb.org/browse/EVG-15430)

### Description 
Add a route for mana to use to return all of the users that have a given role.

### Testing 
Added unit test and tested on local.