### PR TITLE
EVG-15384 Support pre-flight options requests for all POST routes.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -127,7 +127,7 @@ imports:
   - name: github.com/evergreen-ci/cocoa
     version: 9633061a7220b184e7bc8908dba9a3da021637e4
   - name: github.com/evergreen-ci/gimlet
-    version: 3aa4522aad2fa8ad15755e00441b597d6d54cc5e
+    version: 1f1f7e62a9c468b5290683fab6179ed6ac53f3bf
   - name: github.com/evergreen-ci/shrub
     version: 005df8abf87f20331677ecfaa19744efb99eb80b
   - name: github.com/evergreen-ci/pail

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -799,9 +799,8 @@ func (m *EventLogPermissionsMiddleware) ServeHTTP(rw http.ResponseWriter, r *htt
 func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		requester := r.Header.Get("Origin")
-		grip.Debug(message.Fields{
+		grip.DebugWhen(requester != "", message.Fields{
 			"op":              "addCORSHeaders",
-			"request":         r,
 			"requester":       requester,
 			"allowed_origins": allowedOrigins,
 			"adding_headers":  util.StringContainsSliceRegex(allowedOrigins, requester),

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -19,7 +19,6 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -802,10 +801,12 @@ func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.Handler
 		requester := r.Header.Get("Origin")
 		grip.Debug(message.Fields{
 			"op":              "addCORSHeaders",
+			"request":         r,
 			"requester":       requester,
 			"allowed_origins": allowedOrigins,
-			"adding_headers":  utility.StringSliceContains(allowedOrigins, requester),
+			"adding_headers":  util.StringContainsSliceRegex(allowedOrigins, requester),
 			"settings_is_nil": evergreen.GetEnvironment().Settings() == nil,
+			"headers":         r.Header,
 		})
 		if len(allowedOrigins) > 0 {
 			// Requests from a GQL client include this header, which must be added to the response to enable CORS
@@ -815,6 +816,7 @@ func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.Handler
 				w.Header().Add("Access-Control-Allow-Credentials", "true")
 				w.Header().Add("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PATCH, PUT")
 				w.Header().Add("Access-Control-Allow-Headers", fmt.Sprintf("%s, %s, %s", evergreen.APIKeyHeader, evergreen.APIUserHeader, gqlHeader))
+				w.Header().Add("Access-Control-Max-Age", "600")
 			}
 		}
 		next(w, r)

--- a/rest/route/options.go
+++ b/rest/route/options.go
@@ -7,7 +7,7 @@ import (
 	"github.com/evergreen-ci/gimlet"
 )
 
-// optionsHandler is a RequestHandler for resolving options requests
+// optionsHandler is a RequestHandler for resolving options requests.
 type optionsHandler struct {
 }
 
@@ -24,8 +24,8 @@ func (h *optionsHandler) Parse(ctx context.Context, r *http.Request) error {
 	return nil
 }
 
-// Execute returns an empty json response to the options request
-// The options request only looks for a 200 status code so the response value is not relevant
+// Execute returns an empty json response to the options request.
+// The options request only looks for a 200 status code so the response value is not relevant.
 func (h *optionsHandler) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewJSONResponse(struct{}{})
 }

--- a/rest/route/options.go
+++ b/rest/route/options.go
@@ -1,0 +1,31 @@
+package route
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/evergreen-ci/gimlet"
+)
+
+// optionsHandler is a RequestHandler for resolving options requests
+type optionsHandler struct {
+}
+
+func makeOptionsHandler() gimlet.RouteHandler {
+	return &optionsHandler{}
+}
+
+// Handler returns a pointer to a new optionsHandler.
+func (h *optionsHandler) Factory() gimlet.RouteHandler {
+	return &optionsHandler{}
+}
+
+func (h *optionsHandler) Parse(ctx context.Context, r *http.Request) error {
+	return nil
+}
+
+// Execute returns an empty json response to the options request
+// The options request only looks for a 200 status code so the response value is not relevant
+func (h *optionsHandler) Run(ctx context.Context) gimlet.Responder {
+	return gimlet.NewJSONResponse(struct{}{})
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -1,9 +1,6 @@
 package route
 
 import (
-	"context"
-	"net/http"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
@@ -213,7 +210,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/versions/{version_id}/restart").Version(2).Post().Wrap(checkUser, editTasks).RouteHandler(makeRestartVersion(sc))
 	app.AddRoute("/versions/{version_id}/annotations").Version(2).Get().Wrap(checkUser, viewAnnotations).RouteHandler(makeFetchAnnotationsByVersion(sc))
 
-	// Add an options method to every POST request to handle pre-flight Options requests
+	// Add an options method to every POST request to handle pre-flight Options requests.
 	// These requests must not check for credentials and just validate whether a route exists
 	// And allows requests from a origin.
 	for _, route := range app.Routes() {
@@ -221,27 +218,4 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 			app.AddRoute(route.GetRoute()).Version(2).Options().RouteHandler(makeOptionsHandler())
 		}
 	}
-}
-
-// optionsHandler is a RequestHandler for resolving options requests
-type optionsHandler struct {
-}
-
-func makeOptionsHandler() gimlet.RouteHandler {
-	return &optionsHandler{}
-}
-
-// Handler returns a pointer to a new optionsHandler.
-func (h *optionsHandler) Factory() gimlet.RouteHandler {
-	return &optionsHandler{}
-}
-
-func (h *optionsHandler) Parse(ctx context.Context, r *http.Request) error {
-	return nil
-}
-
-// Execute returns an empty json response to the options request
-// The options request only looks for a 200 status code so the response value is not relevant
-func (h *optionsHandler) Run(ctx context.Context) gimlet.Responder {
-	return gimlet.NewJSONResponse(struct{}{})
 }

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -57,7 +57,6 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	cedarTestStats := checkCedarTestStats(settings)
 
 	app.AddWrapper(gimlet.WrapperMiddleware(allowCORS))
-	// app.AddWrapper(gimlet.WrapperMiddleware(passThroughOptions))
 
 	// Routes
 	app.AddRoute("/").Version(2).Get().RouteHandler(makePlaceHolderManger(sc))

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -1169,6 +1169,23 @@ func TestParentTaskInfo(t *testing.T) {
 	}
 }
 
+func TestOptionsRequest(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(task.Collection))
+
+	route := "/rest/v2/tasks/test/restart"
+	_, err := http.NewRequest("OPTIONS", route, nil)
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	tbh := &optionsHandler{}
+	resp := tbh.Run(ctx)
+	data, ok := resp.Data().(interface{})
+	assert.True(t, ok)
+	assert.Equal(t, data, struct{}{})
+	assert.Equal(t, resp.Status(), http.StatusOK)
+
+}
+
 func validatePaginatedResponse(t *testing.T, h gimlet.RouteHandler, expected []model.Model, pages *gimlet.ResponsePages) {
 	if !assert.NotNil(t, h) {
 		return

--- a/vendor/github.com/evergreen-ci/gimlet/app_routing.go
+++ b/vendor/github.com/evergreen-ci/gimlet/app_routing.go
@@ -88,6 +88,10 @@ func (a *APIApp) PrefixRoute(p string) *APIRoute {
 	return route
 }
 
+func (a *APIApp) Routes() []*APIRoute {
+	return a.routes
+}
+
 // Route allows you to set or reset the route path on an existing route.
 func (r *APIRoute) Route(route string) *APIRoute {
 	r.route = route
@@ -275,4 +279,18 @@ func (r *APIRoute) Method(m string) *APIRoute {
 	default:
 		return r
 	}
+}
+
+func (r *APIRoute) HasMethod(method string) bool {
+	for _, m := range r.methods {
+		if m.String() == method {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *APIRoute) GetRoute() string {
+	return r.route
 }

--- a/vendor/github.com/evergreen-ci/gimlet/app_routing_test.go
+++ b/vendor/github.com/evergreen-ci/gimlet/app_routing_test.go
@@ -249,3 +249,14 @@ func (s *RoutingSuite) TestRouteWrapperMutators() {
 	r.ClearWrappers()
 	s.Len(r.wrappers, 0)
 }
+
+func (s *RoutingSuite) TestRouteInfo() {
+	r := s.app.AddRoute("/foo")
+	s.Len(s.app.Routes(), 1)
+	s.Equal(r.GetRoute(), "/foo")
+	bar := s.app.AddRoute("/bar").Post()
+	s.Len(s.app.Routes(), 2)
+	s.Equal(bar.GetRoute(), "/bar")
+	s.True(bar.HasMethod("POST"))
+	s.False(bar.HasMethod("GET"))
+}


### PR DESCRIPTION
[EVG-15384](https://jira.mongodb.org/browse/EVG-15384)

### Description 
This adds support for [pre-flight OPTION](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) requests for all POST request routes on the `/rest/v2` endpoints.

These requests are used to verify that CORS requirements are satisfied, Before the actual POST requests are sent. 

I've also added a header that should prevent the client from sending this type of request more then once every 10 minutes (Which is the max time i can set)

This is dependent on revendoring https://github.com/evergreen-ci/gimlet/pull/98 
### Testing 
Tested in staging and wrote unit tests