### PR TITLE
EVG-15466: add distro setting for Jasper service max cgroup tasks

### DIFF
--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -62,6 +62,7 @@ var (
 
 	ResourceLimitsNumFilesKey        = bsonutil.MustHaveTag(ResourceLimits{}, "NumFiles")
 	ResourceLimitsNumProcessesKey    = bsonutil.MustHaveTag(ResourceLimits{}, "NumProcesses")
+	ResourceLimitsNumTasksKey        = bsonutil.MustHaveTag(ResourceLimits{}, "NumTasks")
 	ResourceLimitsVirtualMemoryKBKey = bsonutil.MustHaveTag(ResourceLimits{}, "VirtualMemoryKB")
 	ResourceLimitsLockedMemoryKBKey  = bsonutil.MustHaveTag(ResourceLimits{}, "LockedMemoryKB")
 )

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -106,6 +106,7 @@ type EnvVar struct {
 type ResourceLimits struct {
 	NumFiles        int `bson:"num_files,omitempty" json:"num_files,omitempty" mapstructure:"num_files,omitempty"`
 	NumProcesses    int `bson:"num_processes,omitempty" json:"num_processes,omitempty" mapstructure:"num_processes,omitempty"`
+	NumTasks        int `bson:"num_tasks,omitempty" json:"num_tasks,omitempty" mapstructure:"num_tasks,omitempty"`
 	LockedMemoryKB  int `bson:"locked_memory,omitempty" json:"locked_memory,omitempty" mapstructure:"locked_memory,omitempty"`
 	VirtualMemoryKB int `bson:"virtual_memory,omitempty" json:"virtual_memory,omitempty" mapstructure:"virtual_memory,omitempty"`
 }
@@ -196,7 +197,8 @@ func (d *Distro) ValidateBootstrapSettings() error {
 	catcher.NewWhen(d.IsWindows() && d.BootstrapSettings.ServiceUser == "", "service user cannot be empty for non-legacy Windows bootstrapping")
 
 	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.NumFiles < -1, "max number of files should be a positive number or -1")
-	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.NumProcesses < -1, "max number of files should be a positive number or -1")
+	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.NumProcesses < -1, "max number of processes should be a positive number or -1")
+	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.NumTasks < -1, "max number of tasks should be a positive number or -1")
 	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.LockedMemoryKB < -1, "max locked memory should be a positive number or -1")
 	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.VirtualMemoryKB < -1, "max virtual memory should be a positive number or -1")
 

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -313,6 +313,9 @@ func (h *Host) ForceReinstallJasperCommand(settings *evergreen.Settings) string 
 		if numFiles := h.Distro.BootstrapSettings.ResourceLimits.NumFiles; numFiles != 0 {
 			params = append(params, fmt.Sprintf("--limit_num_files=%d", numFiles))
 		}
+		if numTasks := h.Distro.BootstrapSettings.ResourceLimits.NumTasks; numTasks != 0 {
+			params = append(params, fmt.Sprintf("--limit_num_tasks=%d", numTasks))
+		}
 		if lockedMem := h.Distro.BootstrapSettings.ResourceLimits.LockedMemoryKB; lockedMem != 0 {
 			params = append(params, fmt.Sprintf("--limit_locked_memory=%d", lockedMem))
 		}

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -425,8 +425,9 @@ func TestJasperCommands(t *testing.T) {
 			h.Distro.BootstrapSettings.ResourceLimits = distro.ResourceLimits{
 				NumProcesses:    1,
 				NumFiles:        2,
-				LockedMemoryKB:  3,
-				VirtualMemoryKB: 4,
+				NumTasks:        3,
+				LockedMemoryKB:  4,
+				VirtualMemoryKB: 5,
 			}
 			cmd := h.ForceReinstallJasperCommand(settings)
 			assert.True(t, strings.HasPrefix(cmd, "sudo /foo/jasper_cli jasper service force-reinstall rpc"))
@@ -436,6 +437,7 @@ func TestJasperCommands(t *testing.T) {
 			assert.Contains(t, cmd, fmt.Sprintf("--user=%s", h.User))
 			assert.Contains(t, cmd, fmt.Sprintf("--limit_num_procs=%d", h.Distro.BootstrapSettings.ResourceLimits.NumProcesses))
 			assert.Contains(t, cmd, fmt.Sprintf("--limit_num_files=%d", h.Distro.BootstrapSettings.ResourceLimits.NumFiles))
+			assert.Contains(t, cmd, fmt.Sprintf("--limit_num_tasks=%d", h.Distro.BootstrapSettings.ResourceLimits.NumTasks))
 			assert.Contains(t, cmd, fmt.Sprintf("--limit_virtual_memory=%d", h.Distro.BootstrapSettings.ResourceLimits.VirtualMemoryKB))
 			assert.Contains(t, cmd, fmt.Sprintf("--limit_locked_memory=%d", h.Distro.BootstrapSettings.ResourceLimits.LockedMemoryKB))
 		},

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -253,6 +253,7 @@ func (e *APIEnvVar) ToService() (interface{}, error) {
 type APIResourceLimits struct {
 	NumFiles        int `json:"num_files"`
 	NumProcesses    int `json:"num_processes"`
+	NumTasks        int `json:"num_tasks"`
 	LockedMemoryKB  int `json:"locked_memory"`
 	VirtualMemoryKB int `json:"virtual_memory"`
 }
@@ -329,6 +330,7 @@ func (s *APIBootstrapSettings) BuildFromService(h interface{}) error {
 	}
 	s.ResourceLimits.NumFiles = settings.ResourceLimits.NumFiles
 	s.ResourceLimits.NumProcesses = settings.ResourceLimits.NumProcesses
+	s.ResourceLimits.NumTasks = settings.ResourceLimits.NumTasks
 	s.ResourceLimits.LockedMemoryKB = settings.ResourceLimits.LockedMemoryKB
 	s.ResourceLimits.VirtualMemoryKB = settings.ResourceLimits.VirtualMemoryKB
 
@@ -377,6 +379,7 @@ func (s *APIBootstrapSettings) ToService() (interface{}, error) {
 	}
 	settings.ResourceLimits.NumFiles = s.ResourceLimits.NumFiles
 	settings.ResourceLimits.NumProcesses = s.ResourceLimits.NumProcesses
+	settings.ResourceLimits.NumTasks = s.ResourceLimits.NumTasks
 	settings.ResourceLimits.LockedMemoryKB = s.ResourceLimits.LockedMemoryKB
 	settings.ResourceLimits.VirtualMemoryKB = s.ResourceLimits.VirtualMemoryKB
 

--- a/rest/model/distro_test.go
+++ b/rest/model/distro_test.go
@@ -79,8 +79,9 @@ func TestDistroToService(t *testing.T) {
 			ResourceLimits: APIResourceLimits{
 				NumFiles:        1,
 				NumProcesses:    2,
-				LockedMemoryKB:  3,
-				VirtualMemoryKB: 4,
+				NumTasks:        3,
+				LockedMemoryKB:  4,
+				VirtualMemoryKB: 5,
 			},
 			PreconditionScripts: []APIPreconditionScript{
 				{
@@ -118,6 +119,7 @@ func TestDistroToService(t *testing.T) {
 	assert.Equal(t, utility.FromStringPtr(apiDistro.BootstrapSettings.Env[0].Value), d.BootstrapSettings.Env[0].Value)
 	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.NumFiles, d.BootstrapSettings.ResourceLimits.NumFiles)
 	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.NumProcesses, d.BootstrapSettings.ResourceLimits.NumProcesses)
+	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.NumTasks, d.BootstrapSettings.ResourceLimits.NumTasks)
 	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.LockedMemoryKB, d.BootstrapSettings.ResourceLimits.LockedMemoryKB)
 	assert.Equal(t, apiDistro.BootstrapSettings.ResourceLimits.VirtualMemoryKB, d.BootstrapSettings.ResourceLimits.VirtualMemoryKB)
 	require.Len(t, d.BootstrapSettings.PreconditionScripts, 1)

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1336,8 +1336,9 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 					"resource_limits": {
 						"num_files": 1,
 						"num_processes": 2,
-						"locked_memory": 3,
-						"virtual_memory": 4
+						"num_tasks": 3,
+						"locked_memory": 4,
+						"virtual_memory": 5
 					},
 					"precondition_scripts": [
 						{
@@ -1414,8 +1415,9 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 	s.Equal([]model.APIEnvVar{{Key: utility.ToStringPtr("envKey"), Value: utility.ToStringPtr("envValue")}}, apiDistro.BootstrapSettings.Env)
 	s.Equal(1, apiDistro.BootstrapSettings.ResourceLimits.NumFiles)
 	s.Equal(2, apiDistro.BootstrapSettings.ResourceLimits.NumProcesses)
-	s.Equal(3, apiDistro.BootstrapSettings.ResourceLimits.LockedMemoryKB)
-	s.Equal(4, apiDistro.BootstrapSettings.ResourceLimits.VirtualMemoryKB)
+	s.Equal(4, apiDistro.BootstrapSettings.ResourceLimits.NumTasks)
+	s.Equal(4, apiDistro.BootstrapSettings.ResourceLimits.LockedMemoryKB)
+	s.Equal(5, apiDistro.BootstrapSettings.ResourceLimits.VirtualMemoryKB)
 	s.Require().Len(apiDistro.BootstrapSettings.PreconditionScripts, 1)
 	s.Equal(utility.ToStringPtr("/tmp/foo"), apiDistro.BootstrapSettings.PreconditionScripts[0].Path)
 	s.Equal(utility.ToStringPtr("echo foo"), apiDistro.BootstrapSettings.PreconditionScripts[0].Script)

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1415,7 +1415,7 @@ func (s *DistroPatchByIDSuite) TestValidFindAndReplaceFullDocument() {
 	s.Equal([]model.APIEnvVar{{Key: utility.ToStringPtr("envKey"), Value: utility.ToStringPtr("envValue")}}, apiDistro.BootstrapSettings.Env)
 	s.Equal(1, apiDistro.BootstrapSettings.ResourceLimits.NumFiles)
 	s.Equal(2, apiDistro.BootstrapSettings.ResourceLimits.NumProcesses)
-	s.Equal(4, apiDistro.BootstrapSettings.ResourceLimits.NumTasks)
+	s.Equal(3, apiDistro.BootstrapSettings.ResourceLimits.NumTasks)
 	s.Equal(4, apiDistro.BootstrapSettings.ResourceLimits.LockedMemoryKB)
 	s.Equal(5, apiDistro.BootstrapSettings.ResourceLimits.VirtualMemoryKB)
 	s.Require().Len(apiDistro.BootstrapSettings.PreconditionScripts, 1)

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -917,6 +917,13 @@ Evergreen - Distros
                 min="-1">
               <div class="icon fa fa-warning distro-error" ng-show="form.numProcesses.$invalid"> Invalid max processes</div><br />
 
+              <label class="muted">Number of Cgroup Tasks:</label>
+              <input type="number" ng-readonly="readOnly" name="numTasks"
+                class="form-control" ng-model="activeDistro.bootstrap_settings.resource_limits.num_tasks"
+                placeholder="Max number of cgroup tasks (threads). Set -1 for unlimited"
+                min="-1">
+              <div class="icon fa fa-warning distro-error" ng-show="form.numTasks.$invalid"> Invalid max cgroup tasks</div><br />
+
               <label class="muted">Locked Memory:</label>
               <input type="number" ng-readonly="readOnly" name="lockedMemoryKB"
                 class="form-control" ng-model="activeDistro.bootstrap_settings.resource_limits.locked_memory"

--- a/validator/distro_validator_test.go
+++ b/validator/distro_validator_test.go
@@ -609,13 +609,15 @@ func TestEnsureValidBootstrapSettings(t *testing.T) {
 				"PositiveValues": func(t *testing.T, s distro.BootstrapSettings) {
 					s.ResourceLimits.NumFiles = 1
 					s.ResourceLimits.NumProcesses = 2
-					s.ResourceLimits.LockedMemoryKB = 3
-					s.ResourceLimits.VirtualMemoryKB = 4
+					s.ResourceLimits.NumTasks = 3
+					s.ResourceLimits.LockedMemoryKB = 4
+					s.ResourceLimits.VirtualMemoryKB = 5
 					assert.Nil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{Arch: evergreen.ArchLinuxAmd64, BootstrapSettings: s}, &evergreen.Settings{}))
 				},
 				"ZeroValues": func(t *testing.T, s distro.BootstrapSettings) {
 					s.ResourceLimits.NumFiles = 0
 					s.ResourceLimits.NumProcesses = 0
+					s.ResourceLimits.NumTasks = 0
 					s.ResourceLimits.LockedMemoryKB = 0
 					s.ResourceLimits.VirtualMemoryKB = 0
 					assert.Nil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{Arch: evergreen.ArchLinuxAmd64, BootstrapSettings: s}, &evergreen.Settings{}))
@@ -623,6 +625,7 @@ func TestEnsureValidBootstrapSettings(t *testing.T) {
 				"UnlimitedResources": func(t *testing.T, s distro.BootstrapSettings) {
 					s.ResourceLimits.NumFiles = -1
 					s.ResourceLimits.NumProcesses = -1
+					s.ResourceLimits.NumTasks = -1
 					s.ResourceLimits.LockedMemoryKB = -1
 					s.ResourceLimits.VirtualMemoryKB = -1
 					assert.Nil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{Arch: evergreen.ArchLinuxAmd64, BootstrapSettings: s}, &evergreen.Settings{}))
@@ -630,6 +633,7 @@ func TestEnsureValidBootstrapSettings(t *testing.T) {
 				"InvalidResourceLimits": func(t *testing.T, s distro.BootstrapSettings) {
 					s.ResourceLimits.NumFiles = -50
 					s.ResourceLimits.NumProcesses = -50
+					s.ResourceLimits.NumTasks = -50
 					s.ResourceLimits.LockedMemoryKB = -50
 					s.ResourceLimits.VirtualMemoryKB = -50
 					assert.NotNil(t, ensureValidBootstrapSettings(ctx, &distro.Distro{Arch: evergreen.ArchLinuxAmd64, BootstrapSettings: s}, &evergreen.Settings{}))


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15466

### Description 
* Add distro setting for Jasper service max cgroup tasks.

### Testing 
* Updated unit tests.
* Tested the distro setting locally.
* Tested that hosts can run with the systemd parameter in staging.