### PR TITLE
EVG-15461: terminate intent pods

### DIFF
--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -78,20 +78,9 @@ func TestPodTerminationJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.NotEqual(t, pod.StatusTerminated, dbPod.Status)
 		},
-		"FailsWhenPodStatusUpdateErrors": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
-			require.NoError(t, j.pod.Insert())
+		"TerminatesWithoutDeletingResourcesForIntentPod": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
 			j.pod.Status = pod.StatusInitializing
-
-			j.Run(ctx)
-			require.Error(t, j.Error())
-
-			dbPod, err := pod.FindOneByID(j.PodID)
-			require.NoError(t, err)
-			require.NotZero(t, dbPod)
-			assert.NotEqual(t, pod.StatusTerminated, j.pod.Status)
-		},
-		"TerminatesWithoutDeletingResourcesForInitializingPod": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
-			j.pod.Status = pod.StatusInitializing
+			j.pod.Resources = pod.ResourceInfo{}
 			require.NoError(t, j.pod.Insert())
 
 			j.Run(ctx)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15461

### Description 
Intent pods don't have any backing resources in ECS or Secrets Manager, so there's no way to create a Cocoa pod from an Evergreen intent pod. During pod termination, intent pods can skip the deletion of the backing cloud resources, so all they have to do is be marked as terminated.

### Testing 
Updated the job tests.