### PR TITLE
EVG-15456 check for nil cmds when validating

### DIFF
--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -147,7 +147,7 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		cmds, ok := funcs[name]
 		if !ok {
 			errs = append(errs, fmt.Sprintf("function '%s' not found in project functions", name))
-		} else {
+		} else if cmds != nil {
 			for i, c := range cmds.List() {
 				if c.Function != "" {
 					errs = append(errs, fmt.Sprintf("can not reference a function within a "+

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-07-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-09-20"
+	AgentVersion = "2021-09-27"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-15456](https://jira.mongodb.org/browse/EVG-15456)

### Description 
Didn't make cmds length an error because we check for this elsewhere and add an error so it would be duplicate info; at this point we should just make sure we don't panic.

### Testing 
Tested with local evergreen.
![image](https://user-images.githubusercontent.com/26798134/134957330-b6dcfe2b-a339-456f-8476-e1a5bab5c5ef.png)
