### PR TITLE
EVG-15423: resolve open-redirect issue by merging initial path slashes

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -127,7 +127,7 @@ imports:
   - name: github.com/evergreen-ci/cocoa
     version: 9633061a7220b184e7bc8908dba9a3da021637e4
   - name: github.com/evergreen-ci/gimlet
-    version: 1f1f7e62a9c468b5290683fab6179ed6ac53f3bf
+    version: 31cad9d4fe5899f5952d7b5114f4fbbf6ddca953
   - name: github.com/evergreen-ci/shrub
     version: 005df8abf87f20331677ecfaa19744efb99eb80b
   - name: github.com/evergreen-ci/pail

--- a/vendor/github.com/evergreen-ci/gimlet/vendor/github.com/urfave/negroni/static.go
+++ b/vendor/github.com/evergreen-ci/gimlet/vendor/github.com/urfave/negroni/static.go
@@ -65,6 +65,9 @@ func (s *Static) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	if fi.IsDir() {
 		// redirect if missing trailing slash
 		if !strings.HasSuffix(r.URL.Path, "/") {
+			if strings.HasPrefix(r.URL.Path, "//") {
+				r.URL.Path = "/" + strings.TrimLeft(r.URL.Path, "/")
+			}
 			http.Redirect(rw, r, r.URL.Path+"/", http.StatusFound)
 			return
 		}

--- a/vendor/github.com/evergreen-ci/gimlet/vendor/github.com/urfave/negroni/static.go
+++ b/vendor/github.com/evergreen-ci/gimlet/vendor/github.com/urfave/negroni/static.go
@@ -65,6 +65,7 @@ func (s *Static) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	if fi.IsDir() {
 		// redirect if missing trailing slash
 		if !strings.HasSuffix(r.URL.Path, "/") {
+			//avoid open redirect issue if path starts with double slash EVG-15423
 			if strings.HasPrefix(r.URL.Path, "//") {
 				r.URL.Path = "/" + strings.TrimLeft(r.URL.Path, "/")
 			}


### PR DESCRIPTION
[EVG-15423](https://jira.mongodb.org/browse/EVG-15423)

### Description 
Revendor gimlet (already PR'd) to avoid open redirect issue.

### Testing 
 Ran on staging without errors, fixed redirect issue.
