### PR TITLE
EVG-15125: support shared pod secrets

### DIFF
--- a/cloud/pod_agent_util_test.go
+++ b/cloud/pod_agent_util_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/pod"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +28,12 @@ func TestAgentScript(t *testing.T) {
 					Arch:       pod.ArchAMD64,
 					WorkingDir: workingDir,
 				},
-				Secret: "secret",
+				Secret: pod.Secret{
+					Name:   "name",
+					Value:  "secret",
+					Exists: utility.FalsePtr(),
+					Owned:  utility.TruePtr(),
+				},
 			}
 			cmd := agentScript(settings, p)
 			require.NotZero(t, cmd)
@@ -48,7 +54,12 @@ func TestAgentScript(t *testing.T) {
 					Arch:       pod.ArchAMD64,
 					WorkingDir: workingDir,
 				},
-				Secret: "secret",
+				Secret: pod.Secret{
+					Name:   "name",
+					Value:  "secret",
+					Exists: utility.FalsePtr(),
+					Owned:  utility.TruePtr(),
+				},
 			}
 			cmd := agentScript(settings, p)
 			require.NotZero(t, cmd)
@@ -76,7 +87,12 @@ func TestAgentScript(t *testing.T) {
 					Arch:       pod.ArchAMD64,
 					WorkingDir: workingDir,
 				},
-				Secret: "secret",
+				Secret: pod.Secret{
+					Name:   "name",
+					Value:  "secret",
+					Exists: utility.FalsePtr(),
+					Owned:  utility.TruePtr(),
+				},
 			}
 			cmd := agentScript(settings, p)
 			require.NotZero(t, cmd)
@@ -97,7 +113,12 @@ func TestAgentScript(t *testing.T) {
 					Arch:       pod.ArchAMD64,
 					WorkingDir: workingDir,
 				},
-				Secret: "secret",
+				Secret: pod.Secret{
+					Name:   "name",
+					Value:  "secret",
+					Exists: utility.FalsePtr(),
+					Owned:  utility.TruePtr(),
+				},
 			}
 			cmd := agentScript(settings, p)
 			require.NotZero(t, cmd)

--- a/glide.lock
+++ b/glide.lock
@@ -125,7 +125,7 @@ imports:
   - name: github.com/mongodb/amboy
     version: 1553970ee7418f62c686a17ec859f53ddbd5dffd
   - name: github.com/evergreen-ci/cocoa
-    version: 9633061a7220b184e7bc8908dba9a3da021637e4
+    version: d44632fb91055d88e16411f9983f273cb3efa5d3
   - name: github.com/evergreen-ci/gimlet
     version: 1f1f7e62a9c468b5290683fab6179ed6ac53f3bf
   - name: github.com/evergreen-ci/shrub

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -43,6 +43,12 @@ var (
 	ContainerResourceInfoExternalIDKey = bsonutil.MustHaveTag(ContainerResourceInfo{}, "ExternalID")
 	ContainerResourceInfoNameKey       = bsonutil.MustHaveTag(ContainerResourceInfo{}, "Name")
 	ContainerResourceInfoSecretIDsKey  = bsonutil.MustHaveTag(ContainerResourceInfo{}, "SecretIDs")
+
+	SecretNameKey       = bsonutil.MustHaveTag(Secret{}, "Name")
+	SecretExternalIDKey = bsonutil.MustHaveTag(Secret{}, "ExternalID")
+	SecretValueKey      = bsonutil.MustHaveTag(Secret{}, "Value")
+	SecretExistsKey     = bsonutil.MustHaveTag(Secret{}, "Exists")
+	SecretOwnedKey      = bsonutil.MustHaveTag(Secret{}, "Owned")
 )
 
 func ByID(id string) bson.M {

--- a/model/pod/db_test.go
+++ b/model/pod/db_test.go
@@ -141,8 +141,13 @@ func TestFindOneByID(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T){
 		"Succeeds": func(t *testing.T) {
 			p := Pod{
-				ID:     "id",
-				Secret: "secret",
+				ID: "id",
+				Secret: Secret{
+					Name:   "name",
+					Value:  "value",
+					Exists: utility.FalsePtr(),
+					Owned:  utility.TruePtr(),
+				},
 			}
 			require.NoError(t, p.Insert())
 
@@ -172,8 +177,13 @@ func TestFindOneByExternalID(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T){
 		"Succeeds": func(t *testing.T) {
 			p := Pod{
-				ID:     "id",
-				Secret: "secret",
+				ID: "id",
+				Secret: Secret{
+					Name:   "name",
+					Value:  "value",
+					Exists: utility.FalsePtr(),
+					Owned:  utility.TruePtr(),
+				},
 				Resources: ResourceInfo{
 					ExternalID: "external_id",
 				},

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -18,7 +18,7 @@ type Pod struct {
 	Status Status `bson:"status"`
 	// Secret is the shared secret between the server and the pod for
 	// authentication when the host is provisioned.
-	Secret string `bson:"secret" json:"secret"`
+	Secret Secret `bson:"secret" json:"secret"`
 	// TaskCreationOpts are options to configure how a task should be
 	// containerized and run in a pod.
 	TaskContainerCreationOpts TaskContainerCreationOptions `bson:"task_creation_opts,omitempty" json:"task_creation_opts,omitempty"`
@@ -140,14 +140,14 @@ type TaskContainerCreationOptions struct {
 	OS OS `bson:"os" json:"os"`
 	// Arch indicates the particular architecture that the pod's containers run
 	// on.
-	Arch Arch ` bson:"arch" json:"arch"`
+	Arch Arch `bson:"arch" json:"arch"`
 	// EnvVars is a mapping of the non-secret environment variables to expose in
 	// the task's container environment.
 	EnvVars map[string]string `bson:"env_vars,omitempty" json:"env_vars,omitempty"`
-	// EnvSecrets is a mapping of secret names to secret values to expose in the
-	// task's container environment variables. The secret name is the
-	// environment variable name.
-	EnvSecrets map[string]string `bson:"env_secrets,omitempty" json:"env_secrets,omitempty"`
+	// EnvSecrets are secret values to expose in the task's container
+	// environment variables. The key is the name of the environment variable
+	// and the value is the configuration for the secret value.
+	EnvSecrets map[string]Secret `bson:"env_secrets,omitempty" json:"env_secrets,omitempty"`
 	// WorkingDir is the working directory for the task's container.
 	WorkingDir string `bson:"working_dir,omitempty" json:"working_dir,omitempty"`
 }
@@ -194,6 +194,33 @@ func (a Arch) Validate() error {
 // zero value for BSON marshalling.
 func (o TaskContainerCreationOptions) IsZero() bool {
 	return o.Image == "" && o.MemoryMB == 0 && o.CPU == 0 && o.OS == "" && o.Arch == "" && len(o.EnvVars) == 0 && len(o.EnvSecrets) == 0
+}
+
+// Secret is a sensitive secret that a pod can access. The secret is managed
+// in an integrated secrets storage service.
+type Secret struct {
+	// Name is the friendly name of the secret.
+	Name string `bson:"name,omitempty" json:"name,omitempty" yaml:"name,omitempty"`
+	// ExternalID is the unique external resource identifier for a secret that
+	// already exists in the secrets storage service.
+	ExternalID string `bson:"external_id,omitempty" json:"external_id,omitempty" yaml:"external_id,omitempty"`
+	// Value is the value of the secret. If the secret does not yet exist, it
+	// will be created; otherwise, this is just a cached copy of the actual
+	// value stored in the secrets storage service.
+	Value string `bson:"new_value,omitempty" json:"new_value,omitempty" yaml:"new_value,omitempty"`
+	// Exists determines whether or not the secret already exists in the secrets
+	// storage service. If this is false, then a new secret will be stored.
+	Exists *bool `bson:"exists,omitempty" json:"exists,omitempty" yaml:"exists,omitempty"`
+	// Owned determines whether or not the secret is owned by its pod. If this
+	// is true, then its lifetime is tied to the pod's lifetime, implying that
+	// when the pod is cleaned up, this secret is also cleaned up.
+	Owned *bool `bson:"owned,omitempty" json:"owned,omitempty" yaml:"owned,omitempty"`
+}
+
+// IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
+// zero value for BSON marshalling.
+func (s Secret) IsZero() bool {
+	return s.Name == "" && s.ExternalID == "" && s.Value == "" && s.Exists == nil && s.Owned == nil
 }
 
 // Insert inserts a new pod into the collection.

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -26,8 +26,13 @@ func TestInsertAndFindOneByID(t *testing.T) {
 		},
 		"InsertSucceedsAndIsFoundByID": func(t *testing.T) {
 			p := Pod{
-				ID:     "id",
-				Secret: "secret",
+				ID: "id",
+				Secret: Secret{
+					Name:   "name",
+					Value:  "value",
+					Exists: utility.FalsePtr(),
+					Owned:  utility.TruePtr(),
+				},
 				Status: StatusRunning,
 				TaskContainerCreationOpts: TaskContainerCreationOptions{
 					Image:    "alpine",

--- a/rest/model/pod.go
+++ b/rest/model/pod.go
@@ -47,8 +47,12 @@ func (p *APICreatePod) ToService() (interface{}, error) {
 	}
 
 	return pod.Pod{
-		ID:     utility.RandomString(),
-		Secret: utility.FromStringPtr(p.Secret),
+		ID: utility.RandomString(),
+		Secret: pod.Secret{
+			Value:  utility.FromStringPtr(p.Secret),
+			Exists: utility.FalsePtr(),
+			Owned:  utility.TruePtr(),
+		},
 		Status: pod.StatusInitializing,
 		TimeInfo: pod.TimeInfo{
 			Initializing: time.Now(),
@@ -70,13 +74,18 @@ func (p *APICreatePod) ToService() (interface{}, error) {
 
 // splitEnvVars splits its environment variables into its non-secret and secret
 // environment variables.
-func (p *APICreatePod) splitEnvVars() (envVars map[string]string, secrets map[string]string) {
+func (p *APICreatePod) splitEnvVars() (envVars map[string]string, secrets map[string]pod.Secret) {
 	envVars = make(map[string]string)
-	secrets = make(map[string]string)
+	secrets = make(map[string]pod.Secret)
 
 	for _, envVar := range p.EnvVars {
 		if utility.FromBoolPtr(envVar.Secret) {
-			secrets[utility.FromStringPtr(envVar.Name)] = utility.FromStringPtr(envVar.Value)
+			secrets[utility.FromStringPtr(envVar.Name)] = pod.Secret{
+				Name:   utility.FromStringPtr(envVar.Name),
+				Value:  utility.FromStringPtr(envVar.Value),
+				Exists: utility.FalsePtr(),
+				Owned:  utility.TruePtr(),
+			}
 		} else {
 			envVars[utility.FromStringPtr(envVar.Name)] = utility.FromStringPtr(envVar.Value)
 		}
@@ -88,8 +97,8 @@ func (p *APICreatePod) splitEnvVars() (envVars map[string]string, secrets map[st
 // APIPod represents a pod to be used and returned from the REST API.
 type APIPod struct {
 	ID                        *string                            `json:"id"`
-	Status                    *APIPodStatus                      `json:"status"`
-	Secret                    *string                            `json:"secret,omitempty"`
+	Status                    APIPodStatus                       `json:"status"`
+	Secret                    APIPodSecret                       `json:"secret,omitempty"`
 	TaskContainerCreationOpts APIPodTaskContainerCreationOptions `json:"task_container_creation_opts,omitempty"`
 	TimeInfo                  APIPodTimeInfo                     `json:"time_info,omitempty"`
 	Resources                 APIPodResourceInfo                 `json:"resources,omitempty"`
@@ -102,8 +111,8 @@ func (p *APIPod) BuildFromService(dbPod *pod.Pod) error {
 	if err := status.BuildFromService(dbPod.Status); err != nil {
 		return errors.Wrap(err, "building status from service")
 	}
-	p.Status = &status
-	p.Secret = utility.ToStringPtr(dbPod.Secret)
+	p.Status = status
+	p.Secret.BuildFromService(dbPod.Secret)
 	p.TimeInfo.BuildFromService(dbPod.TimeInfo)
 	p.TaskContainerCreationOpts.BuildFromService(dbPod.TaskContainerCreationOpts)
 	p.Resources.BuildFromService(dbPod.Resources)
@@ -120,12 +129,13 @@ func (p *APIPod) ToService() (*pod.Pod, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "converting task container creation options to service")
 	}
+	secret := p.Secret.ToService()
 	timing := p.TimeInfo.ToService()
 	resources := p.Resources.ToService()
 	return &pod.Pod{
 		ID:                        utility.FromStringPtr(p.ID),
 		Status:                    *s,
-		Secret:                    utility.FromStringPtr(p.Secret),
+		Secret:                    secret,
 		TaskContainerCreationOpts: *taskCreationOpts,
 		TimeInfo:                  timing,
 		Resources:                 resources,
@@ -191,16 +201,16 @@ func (s *APIPodStatus) ToService() (*pod.Status, error) {
 // APIPodTaskContainerCreationOptions represents options to apply to the task's
 // container when creating a pod.
 type APIPodTaskContainerCreationOptions struct {
-	Image        *string           `json:"image,omitempty"`
-	RepoUsername *string           `json:"repo_username,omitempty"`
-	RepoPassword *string           `json:"repo_password,omitempty"`
-	MemoryMB     *int              `json:"memory_mb,omitempty"`
-	CPU          *int              `json:"cpu,omitempty"`
-	OS           *string           `json:"os,omitempty"`
-	Arch         *string           `json:"arch,omitempty"`
-	EnvVars      map[string]string `json:"env_vars,omitempty"`
-	EnvSecrets   map[string]string `json:"env_secrets,omitempty"`
-	WorkingDir   *string           `json:"working_dir,omitempty"`
+	Image        *string                 `json:"image,omitempty"`
+	RepoUsername *string                 `json:"repo_username,omitempty"`
+	RepoPassword *string                 `json:"repo_password,omitempty"`
+	MemoryMB     *int                    `json:"memory_mb,omitempty"`
+	CPU          *int                    `json:"cpu,omitempty"`
+	OS           *string                 `json:"os,omitempty"`
+	Arch         *string                 `json:"arch,omitempty"`
+	EnvVars      map[string]string       `json:"env_vars,omitempty"`
+	EnvSecrets   map[string]APIPodSecret `json:"env_secrets,omitempty"`
+	WorkingDir   *string                 `json:"working_dir,omitempty"`
 }
 
 // BuildFromService converts service-layer task container creation options into
@@ -214,7 +224,13 @@ func (o *APIPodTaskContainerCreationOptions) BuildFromService(opts pod.TaskConta
 	o.OS = utility.ToStringPtr(string(opts.OS))
 	o.Arch = utility.ToStringPtr(string(opts.Arch))
 	o.EnvVars = opts.EnvVars
-	o.EnvSecrets = opts.EnvSecrets
+	envSecrets := map[string]APIPodSecret{}
+	for name, secret := range opts.EnvSecrets {
+		var s APIPodSecret
+		s.BuildFromService(secret)
+		envSecrets[name] = s
+	}
+	o.EnvSecrets = envSecrets
 	o.WorkingDir = utility.ToStringPtr(opts.WorkingDir)
 }
 
@@ -229,6 +245,10 @@ func (o *APIPodTaskContainerCreationOptions) ToService() (*pod.TaskContainerCrea
 	if err := arch.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid architecture")
 	}
+	envSecrets := map[string]pod.Secret{}
+	for name, secret := range o.EnvSecrets {
+		envSecrets[name] = secret.ToService()
+	}
 	return &pod.TaskContainerCreationOptions{
 		Image:        utility.FromStringPtr(o.Image),
 		RepoUsername: utility.FromStringPtr(o.RepoUsername),
@@ -238,7 +258,7 @@ func (o *APIPodTaskContainerCreationOptions) ToService() (*pod.TaskContainerCrea
 		OS:           os,
 		Arch:         arch,
 		EnvVars:      o.EnvVars,
-		EnvSecrets:   o.EnvSecrets,
+		EnvSecrets:   envSecrets,
 		WorkingDir:   utility.FromStringPtr(o.WorkingDir),
 	}, nil
 }
@@ -328,5 +348,36 @@ func (i *APIContainerResourceInfo) ToService() pod.ContainerResourceInfo {
 		ExternalID: utility.FromStringPtr(i.ExternalID),
 		Name:       utility.FromStringPtr(i.Name),
 		SecretIDs:  i.SecretIDs,
+	}
+}
+
+// APIPodSecret represents a secret associated with a pod returned from the REST
+// API.
+type APIPodSecret struct {
+	Name       *string `json:"name,omitempty"`
+	ExternalID *string `json:"external_id,omitempty"`
+	Value      *string `json:"value,omitempty"`
+	Exists     *bool   `json:"exists,omitempty"`
+	Owned      *bool   `json:"owned,omitempty"`
+}
+
+// BuildFromService converts a service-layer pod secret into a REST API pod
+// secret.
+func (s *APIPodSecret) BuildFromService(secret pod.Secret) {
+	s.Name = utility.ToStringPtr(secret.Name)
+	s.ExternalID = utility.ToStringPtr(secret.ExternalID)
+	s.Value = utility.ToStringPtr(secret.Value)
+	s.Exists = secret.Exists
+	s.Owned = secret.Owned
+}
+
+// ToService converts a REST API pod secret into a service-layer pod secret.
+func (s *APIPodSecret) ToService() pod.Secret {
+	return pod.Secret{
+		Name:       utility.FromStringPtr(s.Name),
+		ExternalID: utility.FromStringPtr(s.ExternalID),
+		Value:      utility.FromStringPtr(s.Value),
+		Exists:     s.Exists,
+		Owned:      s.Owned,
 	}
 }

--- a/rest/model/pod.go
+++ b/rest/model/pod.go
@@ -98,10 +98,10 @@ func (p *APICreatePod) splitEnvVars() (envVars map[string]string, secrets map[st
 type APIPod struct {
 	ID                        *string                            `json:"id"`
 	Status                    APIPodStatus                       `json:"status"`
-	Secret                    APIPodSecret                       `json:"secret,omitempty"`
-	TaskContainerCreationOpts APIPodTaskContainerCreationOptions `json:"task_container_creation_opts,omitempty"`
-	TimeInfo                  APIPodTimeInfo                     `json:"time_info,omitempty"`
-	Resources                 APIPodResourceInfo                 `json:"resources,omitempty"`
+	Secret                    APIPodSecret                       `json:"secret"`
+	TaskContainerCreationOpts APIPodTaskContainerCreationOptions `json:"task_container_creation_opts"`
+	TimeInfo                  APIPodTimeInfo                     `json:"time_info"`
+	Resources                 APIPodResourceInfo                 `json:"resources"`
 }
 
 // BuildFromService converts a service-layer pod model into a REST API model.

--- a/rest/model/pod_test.go
+++ b/rest/model/pod_test.go
@@ -48,7 +48,11 @@ func TestAPICreatePod(t *testing.T) {
 		p, ok := res.(pod.Pod)
 		require.True(t, ok)
 
-		assert.Equal(t, utility.FromStringPtr(apiPod.Secret), p.Secret)
+		assert.Zero(t, p.Secret.Name)
+		assert.Zero(t, p.Secret.ExternalID)
+		assert.Equal(t, utility.FromStringPtr(apiPod.Secret), p.Secret.Value)
+		assert.False(t, utility.FromBoolPtr(p.Secret.Exists))
+		assert.True(t, utility.FromBoolPtr(p.Secret.Owned))
 		assert.Equal(t, utility.FromStringPtr(apiPod.Image), p.TaskContainerCreationOpts.Image)
 		assert.Equal(t, utility.FromStringPtr(apiPod.RepoUsername), p.TaskContainerCreationOpts.RepoUsername)
 		assert.Equal(t, utility.FromStringPtr(apiPod.RepoPassword), p.TaskContainerCreationOpts.RepoPassword)
@@ -57,13 +61,18 @@ func TestAPICreatePod(t *testing.T) {
 		assert.Equal(t, utility.FromStringPtr(apiPod.OS), string(p.TaskContainerCreationOpts.OS))
 		assert.Equal(t, utility.FromStringPtr(apiPod.Arch), string(p.TaskContainerCreationOpts.Arch))
 		assert.Equal(t, utility.FromStringPtr(apiPod.WorkingDir), p.TaskContainerCreationOpts.WorkingDir)
-		assert.Equal(t, utility.FromStringPtr(apiPod.Secret), p.Secret)
 		assert.Equal(t, pod.StatusInitializing, p.Status)
 		assert.NotZero(t, p.TimeInfo.Initializing)
 		assert.Len(t, p.TaskContainerCreationOpts.EnvVars, 2)
 		assert.Len(t, p.TaskContainerCreationOpts.EnvSecrets, 1)
 		assert.Equal(t, "value1", p.TaskContainerCreationOpts.EnvVars["name1"])
-		assert.Equal(t, "secret_value", p.TaskContainerCreationOpts.EnvSecrets["secret_name"])
+		dbPodSecret, ok := p.TaskContainerCreationOpts.EnvSecrets["secret_name"]
+		require.True(t, ok)
+		assert.Equal(t, "secret_name", dbPodSecret.Name)
+		assert.Zero(t, dbPodSecret.ExternalID)
+		assert.Equal(t, "secret_value", dbPodSecret.Value)
+		assert.False(t, utility.FromBoolPtr(dbPodSecret.Exists))
+		assert.True(t, utility.FromBoolPtr(dbPodSecret.Owned))
 	})
 }
 
@@ -72,7 +81,13 @@ func TestAPIPod(t *testing.T) {
 		return pod.Pod{
 			ID:     "id",
 			Status: pod.StatusRunning,
-			Secret: "secret",
+			Secret: pod.Secret{
+				Name:       "secret_name",
+				ExternalID: "external_id",
+				Value:      "secret_value",
+				Exists:     utility.TruePtr(),
+				Owned:      utility.FalsePtr(),
+			},
 			TaskContainerCreationOpts: pod.TaskContainerCreationOptions{
 				Image:        "image",
 				RepoUsername: "username",
@@ -80,12 +95,22 @@ func TestAPIPod(t *testing.T) {
 				MemoryMB:     128,
 				CPU:          128,
 				EnvVars: map[string]string{
-					"var0": "val0",
-					"var1": "val1",
+					"ENV_VAR0": "val0",
+					"ENV_VAR1": "val1",
 				},
-				EnvSecrets: map[string]string{
-					"secret0": "secret_val0",
-					"secret1": "secret_val1",
+				EnvSecrets: map[string]pod.Secret{
+					"SECRET_ENV_VAR0": {
+						Name:   "secret_name0",
+						Value:  "secret_val0",
+						Exists: utility.FalsePtr(),
+						Owned:  utility.TruePtr(),
+					},
+					"SECRET_ENV_VAR1": {
+						Name:   "secret_name1",
+						Value:  "secret_val1",
+						Exists: utility.FalsePtr(),
+						Owned:  utility.TruePtr(),
+					},
 				},
 				WorkingDir: "working_dir",
 			},
@@ -110,11 +135,16 @@ func TestAPIPod(t *testing.T) {
 	}
 
 	validAPIPod := func() APIPod {
-		status := PodStatusRunning
 		return APIPod{
 			ID:     utility.ToStringPtr("id"),
-			Status: &status,
-			Secret: utility.ToStringPtr("secret"),
+			Status: PodStatusRunning,
+			Secret: APIPodSecret{
+				Name:       utility.ToStringPtr("secret_name"),
+				ExternalID: utility.ToStringPtr("external_id"),
+				Value:      utility.ToStringPtr("secret_value"),
+				Exists:     utility.TruePtr(),
+				Owned:      utility.FalsePtr(),
+			},
 			TaskContainerCreationOpts: APIPodTaskContainerCreationOptions{
 				Image:        utility.ToStringPtr("image"),
 				RepoUsername: utility.ToStringPtr("username"),
@@ -124,12 +154,22 @@ func TestAPIPod(t *testing.T) {
 				OS:           utility.ToStringPtr("linux"),
 				Arch:         utility.ToStringPtr("amd64"),
 				EnvVars: map[string]string{
-					"var0": "val0",
-					"var1": "val1",
+					"ENV_VAR0": "val0",
+					"ENV_VAR1": "val1",
 				},
-				EnvSecrets: map[string]string{
-					"secret0": "secret_val0",
-					"secret1": "secret_val1",
+				EnvSecrets: map[string]APIPodSecret{
+					"SECRET_ENV_VAR0": {
+						Name:   utility.ToStringPtr("secret_name0"),
+						Value:  utility.ToStringPtr("secret_val0"),
+						Exists: utility.FalsePtr(),
+						Owned:  utility.TruePtr(),
+					},
+					"SECRET_ENV_VAR1": {
+						Name:   utility.ToStringPtr("secret_name0"),
+						Value:  utility.ToStringPtr("secret_val0"),
+						Exists: utility.FalsePtr(),
+						Owned:  utility.TruePtr(),
+					},
 				},
 				WorkingDir: utility.ToStringPtr("working_dir"),
 			},
@@ -159,7 +199,11 @@ func TestAPIPod(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, utility.FromStringPtr(apiPod.ID), dbPod.ID)
 			assert.Equal(t, pod.StatusRunning, dbPod.Status)
-			assert.Equal(t, utility.FromStringPtr(apiPod.Secret), dbPod.Secret)
+			assert.Equal(t, utility.FromStringPtr(apiPod.Secret.Name), dbPod.Secret.Name)
+			assert.Equal(t, utility.FromStringPtr(apiPod.Secret.ExternalID), dbPod.Secret.ExternalID)
+			assert.Equal(t, utility.FromStringPtr(apiPod.Secret.Value), dbPod.Secret.Value)
+			assert.Equal(t, utility.FromBoolPtr(apiPod.Secret.Exists), utility.FromBoolPtr(dbPod.Secret.Exists))
+			assert.Equal(t, utility.FromBoolPtr(apiPod.Secret.Owned), utility.FromBoolPtr(dbPod.Secret.Owned))
 			assert.Equal(t, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.Image), dbPod.TaskContainerCreationOpts.Image)
 			assert.Equal(t, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.RepoUsername), dbPod.TaskContainerCreationOpts.RepoUsername)
 			assert.Equal(t, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.RepoPassword), dbPod.TaskContainerCreationOpts.RepoPassword)
@@ -173,7 +217,9 @@ func TestAPIPod(t *testing.T) {
 			}
 			require.NotZero(t, dbPod.TaskContainerCreationOpts.EnvSecrets)
 			for k, v := range apiPod.TaskContainerCreationOpts.EnvSecrets {
-				assert.Equal(t, v, dbPod.TaskContainerCreationOpts.EnvSecrets[k])
+				dbPodSecret, ok := dbPod.TaskContainerCreationOpts.EnvSecrets[k]
+				require.True(t, ok)
+				assert.Equal(t, v.ToService(), dbPodSecret)
 			}
 			assert.Equal(t, utility.FromTimePtr(apiPod.TimeInfo.Initializing), dbPod.TimeInfo.Initializing)
 			assert.Equal(t, utility.FromTimePtr(apiPod.TimeInfo.Starting), dbPod.TimeInfo.Starting)
@@ -192,7 +238,7 @@ func TestAPIPod(t *testing.T) {
 		})
 		t.Run("FailsWithInvalidStatus", func(t *testing.T) {
 			apiPod := validAPIPod()
-			apiPod.Status = nil
+			apiPod.Status = "foo"
 			_, err := apiPod.ToService()
 			assert.Error(t, err)
 		})
@@ -216,8 +262,12 @@ func TestAPIPod(t *testing.T) {
 			require.NoError(t, apiPod.BuildFromService(&dbPod))
 			assert.Equal(t, dbPod.ID, utility.FromStringPtr(apiPod.ID))
 			require.NotZero(t, apiPod.Status)
-			assert.Equal(t, PodStatusRunning, *apiPod.Status)
-			assert.Equal(t, dbPod.Secret, utility.FromStringPtr(apiPod.Secret))
+			assert.Equal(t, PodStatusRunning, apiPod.Status)
+			assert.Equal(t, dbPod.Secret.Name, utility.FromStringPtr(apiPod.Secret.Name))
+			assert.Equal(t, dbPod.Secret.ExternalID, utility.FromStringPtr(apiPod.Secret.ExternalID))
+			assert.Equal(t, dbPod.Secret.Value, utility.FromStringPtr(apiPod.Secret.Value))
+			assert.Equal(t, utility.FromBoolPtr(dbPod.Secret.Exists), utility.FromBoolPtr(apiPod.Secret.Exists))
+			assert.Equal(t, utility.FromBoolPtr(dbPod.Secret.Owned), utility.FromBoolPtr(apiPod.Secret.Owned))
 			assert.Equal(t, dbPod.TaskContainerCreationOpts.Image, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.Image))
 			assert.Equal(t, dbPod.TaskContainerCreationOpts.RepoUsername, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.RepoUsername))
 			assert.Equal(t, dbPod.TaskContainerCreationOpts.RepoPassword, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.RepoPassword))
@@ -232,7 +282,9 @@ func TestAPIPod(t *testing.T) {
 			}
 			require.NotZero(t, apiPod.TaskContainerCreationOpts.EnvSecrets)
 			for k, v := range dbPod.TaskContainerCreationOpts.EnvSecrets {
-				assert.Equal(t, v, apiPod.TaskContainerCreationOpts.EnvSecrets[k])
+				apiPodSecret, ok := apiPod.TaskContainerCreationOpts.EnvSecrets[k]
+				require.True(t, ok)
+				assert.Equal(t, v, apiPodSecret.ToService())
 			}
 			assert.Equal(t, dbPod.TimeInfo.Initializing, utility.FromTimePtr(apiPod.TimeInfo.Initializing))
 			assert.Equal(t, dbPod.TimeInfo.Starting, utility.FromTimePtr(apiPod.TimeInfo.Starting))

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -400,7 +400,7 @@ func TestPodAuthMiddleware(t *testing.T) {
 			r := &http.Request{
 				Header: http.Header{
 					evergreen.PodHeader:       []string{p.ID},
-					evergreen.PodSecretHeader: []string{p.Secret},
+					evergreen.PodSecretHeader: []string{p.Secret.Value},
 				},
 			}
 			m.ServeHTTP(rw, r, func(rw http.ResponseWriter, r *http.Request) {})
@@ -428,7 +428,7 @@ func TestPodAuthMiddleware(t *testing.T) {
 		"FailsWithoutPodID": func(t *testing.T, p *pod.Pod, rw *httptest.ResponseRecorder) {
 			r := &http.Request{
 				Header: http.Header{
-					evergreen.PodSecretHeader: []string{p.Secret},
+					evergreen.PodSecretHeader: []string{p.Secret.Value},
 				},
 			}
 			m.ServeHTTP(rw, r, func(rw http.ResponseWriter, r *http.Request) {})
@@ -438,7 +438,7 @@ func TestPodAuthMiddleware(t *testing.T) {
 			r := &http.Request{
 				Header: http.Header{
 					evergreen.PodHeader:       []string{"foo"},
-					evergreen.PodSecretHeader: []string{p.Secret},
+					evergreen.PodSecretHeader: []string{p.Secret.Value},
 				},
 			}
 			m.ServeHTTP(rw, r, func(rw http.ResponseWriter, r *http.Request) {})
@@ -451,8 +451,13 @@ func TestPodAuthMiddleware(t *testing.T) {
 				assert.NoError(t, db.Clear(pod.Collection))
 			}()
 			p := &pod.Pod{
-				ID:     "id",
-				Secret: "secret",
+				ID: "id",
+				Secret: pod.Secret{
+					Name:   "name",
+					Value:  "value",
+					Exists: utility.FalsePtr(),
+					Owned:  utility.TruePtr(),
+				},
 			}
 			require.NoError(t, p.Insert())
 

--- a/units/pod_creation_test.go
+++ b/units/pod_creation_test.go
@@ -61,7 +61,7 @@ func TestPodCreationJob(t *testing.T) {
 				var found bool
 				for k, v := range j.pod.TaskContainerCreationOpts.EnvSecrets {
 					if strings.Contains(utility.FromStringPtr(secret.Name), k) {
-						assert.Equal(t, v, val)
+						assert.Equal(t, v.Value, val)
 						found = true
 						break
 					}
@@ -178,9 +178,17 @@ func TestPodCreationJob(t *testing.T) {
 					CPU:      128,
 					OS:       pod.OSLinux,
 					Arch:     pod.ArchAMD64,
-					EnvSecrets: map[string]string{
-						"s0": utility.RandomString(),
-						"s1": utility.RandomString(),
+					EnvSecrets: map[string]pod.Secret{
+						"SECRET_ENV_VAR0": {
+							Value:  utility.RandomString(),
+							Exists: utility.FalsePtr(),
+							Owned:  utility.TruePtr(),
+						},
+						"SECRET_ENV_VAR1": {
+							Value:  utility.RandomString(),
+							Exists: utility.FalsePtr(),
+							Owned:  utility.TruePtr(),
+						},
 					},
 				},
 			}

--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -132,9 +132,13 @@ func TestPodTerminationJob(t *testing.T) {
 					CPU:      128,
 					OS:       pod.OSLinux,
 					Arch:     pod.ArchAMD64,
-					EnvSecrets: map[string]string{
-						"secret0": utility.RandomString(),
-						"secret1": utility.RandomString(),
+					EnvSecrets: map[string]pod.Secret{
+						"SECRET_ENV_VAR0": {
+							Value: utility.RandomString(),
+						},
+						"SECRET_ENV_VAR1": {
+							Value: utility.RandomString(),
+						},
 					},
 				},
 			}
@@ -156,12 +160,12 @@ func TestPodTerminationJob(t *testing.T) {
 			require.NoError(t, err)
 
 			var envVars []cocoa.EnvironmentVariable
-			for name, val := range p.TaskContainerCreationOpts.EnvSecrets {
+			for name, secret := range p.TaskContainerCreationOpts.EnvSecrets {
 				envVars = append(envVars, *cocoa.NewEnvironmentVariable().
 					SetName(name).
 					SetSecretOptions(*cocoa.NewSecretOptions().
 						SetName(name).
-						SetNewValue(val).
+						SetNewValue(secret.Value).
 						SetOwned(true)))
 			}
 

--- a/vendor/github.com/evergreen-ci/cocoa/awsutil/client_options_test.go
+++ b/vendor/github.com/evergreen-ci/cocoa/awsutil/client_options_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// defaultTestTimeout is the default test timeout for AWS utility tests.
+const defaultTestTimeout = time.Second
+
 func TestClientOptions(t *testing.T) {
 	t.Run("SetCredentials", func(t *testing.T) {
 		creds := credentials.NewEnvCredentials()
@@ -187,7 +190,7 @@ func TestClientOptionsGetCredentials(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, creds)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	resolved, err := creds.GetWithContext(ctx)

--- a/vendor/github.com/evergreen-ci/cocoa/ecs/client_test.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs/client_test.go
@@ -2,8 +2,6 @@ package ecs
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,11 +13,11 @@ import (
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const defaultTestTimeout = time.Minute
 
 func TestECSClient(t *testing.T) {
 	assert.Implements(t, (*cocoa.ECSClient)(nil), &BasicECSClient{})
@@ -44,9 +42,16 @@ func TestECSClient(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
+	defer func() {
+		testutil.CleanupTaskDefinitions(ctx, t, c)
+		testutil.CleanupTasks(ctx, t, c)
+
+		assert.NoError(t, c.Close(ctx))
+	}()
+
 	for tName, tCase := range testcase.ECSClientTaskDefinitionTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			defer c.Close(tctx)
@@ -65,162 +70,26 @@ func TestECSClient(t *testing.T) {
 		},
 		Cpu:    aws.String("128"),
 		Memory: aws.String("4"),
-		Family: aws.String(testutil.NewTaskDefinitionFamily(t.Name())),
+		Family: aws.String(testutil.NewTaskDefinitionFamily(t)),
 	}
 
 	registerOut, err := c.RegisterTaskDefinition(ctx, registerIn)
 	require.NoError(t, err)
 	require.NotZero(t, registerOut)
 	require.NotZero(t, registerOut.TaskDefinition)
-
 	defer func() {
-		taskDefs := cleanupTaskDefinitions(ctx, t, c)
-		grip.InfoWhen(len(taskDefs) > 0, message.Fields{
-			"message":          "cleaned up leftover task definitions",
-			"task_definitions": taskDefs,
-			"test":             t.Name(),
+		_, err := c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
+			TaskDefinition: registerOut.TaskDefinition.TaskDefinitionArn,
 		})
-		tasks := cleanupTasks(ctx, t, c, taskDefs)
-		grip.InfoWhen(len(tasks) > 0, message.Fields{
-			"message": "cleaned up leftover running tasks",
-			"tasks":   tasks,
-			"test":    t.Name(),
-		})
-		require.NoError(t, c.Close(ctx))
+		assert.NoError(t, err)
 	}()
 
 	for tName, tCase := range testcase.ECSClientRegisteredTaskDefinitionTests(*registerIn, *registerOut) {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			tCase(tctx, t, c)
 		})
 	}
-}
-
-// cleanupTaskDefinitions cleans up all existing task definitions for testing
-// teardown.
-func cleanupTaskDefinitions(ctx context.Context, t *testing.T, c cocoa.ECSClient) []string {
-	out, err := c.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
-		Status: aws.String(ecs.TaskDefinitionStatusActive),
-	})
-	require.NoError(t, err)
-	require.NotZero(t, out)
-
-	var taskDefs []string
-
-	for _, arn := range out.TaskDefinitionArns {
-		if arn == nil {
-			continue
-		}
-		taskDefArn := *arn
-		// Ignore task definitions that were not generated with testutil.NewTaskDefinitionFamily.
-		name := strings.Join([]string{testutil.TaskDefinitionPrefix(), "cocoa", t.Name()}, "-")
-		if !strings.Contains(taskDefArn, name) {
-			continue
-		}
-		taskDefs = append(taskDefs, *arn)
-		_, err := c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
-			TaskDefinition: arn,
-		})
-		assert.NoError(t, err)
-	}
-
-	return taskDefs
-}
-
-// cleanupTasks cleans up all tasks for testing teardown. It only cleans up
-// tasks if they are running and are created from one of the given task
-// definitions.
-func cleanupTasks(ctx context.Context, t *testing.T, c cocoa.ECSClient, taskDefs []string) []string {
-	out, err := c.ListTasks(ctx, &ecs.ListTasksInput{
-		Cluster: aws.String(testutil.ECSClusterName()),
-	})
-	require.NoError(t, err)
-	require.NotZero(t, out)
-
-	if len(out.TaskArns) == 0 {
-		return nil
-	}
-
-	describeOut, err := c.DescribeTasks(ctx, &ecs.DescribeTasksInput{
-		Cluster: aws.String(testutil.ECSClusterName()),
-		Tasks:   out.TaskArns,
-	})
-	require.NoError(t, err)
-
-	var tasks []string
-	for _, task := range describeOut.Tasks {
-		if task == nil {
-			continue
-		}
-
-		if task.TaskDefinitionArn == nil {
-			grip.Notice(message.Fields{
-				"message": "cannot check task for test teardown because it does not have a task definition ARN",
-				"context": "cocoa test teardown",
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		}
-		// Ignore tasks started by task definitions outside of the cocoa testing
-		// environment.
-		if taskDef := *task.TaskDefinitionArn; !utility.StringSliceContains(taskDefs, taskDef) {
-			continue
-		}
-
-		if task.LastStatus == nil {
-			grip.Notice(message.Fields{
-				"message": "cannot check task for test teardown because it does not have a status",
-				"context": "cocoa test teardown",
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		}
-
-		status := *task.LastStatus
-		switch status {
-		case "PROVISIONING", "PENDING", "ACTIVATING":
-			grip.Notice(message.Fields{
-				"message": "cannot stop the task because it is in an unstoppable state",
-				"context": "cocoa test teardown",
-				"status":  status,
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		case "RUNNING":
-			if task.DesiredStatus != nil && *task.DesiredStatus == "STOPPED" {
-				continue
-			}
-			if task.TaskArn == nil {
-				grip.Notice(message.Fields{
-					"message": "cannot stop the task because it is missing a task ARN",
-					"context": "cocoa test teardown",
-					"status":  status,
-					"task":    *task,
-					"test":    t.Name(),
-				})
-				continue
-			}
-			_, err := c.StopTask(ctx, &ecs.StopTaskInput{
-				Cluster: aws.String(testutil.ECSClusterName()),
-				Reason:  aws.String(fmt.Sprintf("cocoa test teardown for test '%s'", t.Name())),
-				Task:    task.TaskArn,
-			})
-			if assert.NoError(t, err) {
-				tasks = append(tasks, *task.TaskArn)
-			}
-		case "DEACTIVATING", "STOPPING", "DEPROVISIONING", "STOPPED":
-			continue
-		default:
-			assert.Fail(t, "unrecognized task status '%s'", status)
-		}
-
-	}
-
-	return tasks
 }

--- a/vendor/github.com/evergreen-ci/cocoa/ecs/pod_test.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs/pod_test.go
@@ -3,9 +3,7 @@ package ecs
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/awsutil"
@@ -51,7 +49,7 @@ func TestBasicECSPod(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			hc := utility.GetHTTPClient()
@@ -72,46 +70,42 @@ func TestBasicECSPod(t *testing.T) {
 	}
 }
 
-// TODO (EVG-14979): clean up resources in ECS tests more thoroughly
 func TestECSPod(t *testing.T) {
 	testutil.CheckAWSEnvVarsForECSAndSecretsManager(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	hc := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(hc)
+
+	awsOpts := awsutil.NewClientOptions().
+		SetHTTPClient(hc).
+		SetCredentials(credentials.NewEnvCredentials()).
+		SetRole(testutil.AWSRole()).
+		SetRegion(testutil.AWSRegion())
+
+	c, err := NewBasicECSClient(*awsOpts)
+	require.NoError(t, err)
+	defer func() {
+		testutil.CleanupTaskDefinitions(ctx, t, c)
+		testutil.CleanupTasks(ctx, t, c)
+
+		assert.NoError(t, c.Close(ctx))
+	}()
+
+	smc, err := secret.NewBasicSecretsManagerClient(*awsOpts)
+	require.NoError(t, err)
+	defer func() {
+		testutil.CleanupSecrets(ctx, t, smc)
+
+		assert.NoError(t, smc.Close(ctx))
+	}()
+
 	for tName, tCase := range testcase.ECSPodTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
-
-			hc := utility.GetHTTPClient()
-			defer utility.PutHTTPClient(hc)
-
-			awsOpts := awsutil.NewClientOptions().
-				SetHTTPClient(hc).
-				SetCredentials(credentials.NewEnvCredentials()).
-				SetRole(testutil.AWSRole()).
-				SetRegion(testutil.AWSRegion())
-
-			c, err := NewBasicECSClient(*awsOpts)
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
-
-			smc, err := secret.NewBasicSecretsManagerClient(awsutil.ClientOptions{
-				Creds:  credentials.NewEnvCredentials(),
-				Region: aws.String(testutil.AWSRegion()),
-				Role:   aws.String(testutil.AWSRole()),
-				RetryOpts: &utility.RetryOptions{
-					MaxAttempts: 5,
-				},
-				HTTPClient: hc,
-			})
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, smc.Close(tctx))
-			}()
 
 			v := secret.NewBasicSecretsManager(smc)
 

--- a/vendor/github.com/evergreen-ci/cocoa/ecs_pod.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs_pod.go
@@ -15,7 +15,10 @@ type ECSPod interface {
 	Resources() ECSPodResources
 	// StatusInfo returns the current cached status information for the pod.
 	StatusInfo() ECSPodStatusInfo
-	// TODO (EVG-15161): add GetLatestStatus method to get non-cached status.
+	// LatestStatusInfo returns the latest non-cached status information for the
+	// pod. Implementations should query ECS directly for its most up-to-date
+	// status.
+	LatestStatusInfo(ctx context.Context) (*ECSPodStatusInfo, error)
 	// Stop stops the running pod without cleaning up any of its underlying
 	// resources.
 	Stop(ctx context.Context) error

--- a/vendor/github.com/evergreen-ci/cocoa/ecs_pod_creator.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs_pod_creator.go
@@ -801,6 +801,10 @@ func MergeECSPodExecutionOptions(opts ...ECSPodExecutionOptions) ECSPodExecution
 // ECSPodPlacementOptions represent options to control how an ECS pod is
 // assigned to a container instance.
 type ECSPodPlacementOptions struct {
+	// Group is the name of a logical collection of ECS pods. Pods within the
+	// same group can support additional placement configuration.
+	Group *string
+
 	// Strategy is the overall placement strategy. By default, it uses the
 	// binpack strategy.
 	Strategy *ECSPlacementStrategy
@@ -815,8 +819,12 @@ type ECSPodPlacementOptions struct {
 
 	// InstanceFilter is a set of query expressions that restrict the placement
 	// of the pod to a set of container instances in the cluster that match the
-	// query filter.
-	// Docs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html
+	// query filter. As a special case, if ConstraintDistinctInstance is the
+	// specified filter, it will place each pod in the pod's group on a
+	// different instance. Otherwise, all filters are assumed to use the ECS
+	// cluster query language to filter the candidate set of instances for a
+	// pod. Docs:
+	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html
 	InstanceFilters []string
 }
 
@@ -824,6 +832,12 @@ type ECSPodPlacementOptions struct {
 // should be assigned to a container instance.
 func NewECSPodPlacementOptions() *ECSPodPlacementOptions {
 	return &ECSPodPlacementOptions{}
+}
+
+// SetGroup sets the name of the group that the pod belongs to.
+func (o *ECSPodPlacementOptions) SetGroup(group string) *ECSPodPlacementOptions {
+	o.Group = &group
+	return o
 }
 
 // SetStrategy sets the strategy for placing the pod on a container instance.
@@ -857,12 +871,16 @@ func (o *ECSPodPlacementOptions) AddInstanceFilters(filters ...string) *ECSPodPl
 // valid combination.
 func (o *ECSPodPlacementOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
+
+	catcher.ErrorfWhen(o.Group != nil && *o.Group == "", "cannot specify an empty group name")
+
 	if o.Strategy != nil {
 		catcher.Add(o.Strategy.Validate())
-	}
-	if o.Strategy != nil && o.StrategyParameter != nil {
-		catcher.ErrorfWhen(*o.Strategy == StrategyBinpack && *o.StrategyParameter != StrategyParamBinpackMemory && *o.StrategyParameter != StrategyParamBinpackCPU, "strategy parameter cannot be '%s' when the strategy is '%s'", *o.StrategyParameter, *o.Strategy)
-		catcher.ErrorfWhen(*o.Strategy != StrategySpread && *o.StrategyParameter == StrategyParamSpreadHost, "strategy parameter cannot be '%s' when the strategy is not '%s'", *o.StrategyParameter, StrategySpread)
+
+		if o.StrategyParameter != nil {
+			catcher.ErrorfWhen(*o.Strategy == StrategyBinpack && *o.StrategyParameter != StrategyParamBinpackMemory && *o.StrategyParameter != StrategyParamBinpackCPU, "strategy parameter cannot be '%s' when the strategy is '%s'", *o.StrategyParameter, *o.Strategy)
+			catcher.ErrorfWhen(*o.Strategy != StrategySpread && *o.StrategyParameter == StrategyParamSpreadHost, "strategy parameter cannot be '%s' when the strategy is not '%s'", *o.StrategyParameter, StrategySpread)
+		}
 	}
 
 	if catcher.HasErrors() {
@@ -927,6 +945,13 @@ const (
 	// StrategyParamSpreadHost indicates the ECS should spread pods evenly
 	// across all container instances (i.e. hosts).
 	StrategyParamSpreadHost ECSStrategyParameter = "host"
+)
+
+const (
+	// ConstraintDistinctInstance is a container instance filter indicating that
+	// ECS should place all pods in the same group on different container
+	// instances.
+	ConstraintDistinctInstance = "distinctInstance"
 )
 
 // AWSVPCOptions represent options to configure networking when the network mode

--- a/vendor/github.com/evergreen-ci/cocoa/ecs_pod_creator_test.go
+++ b/vendor/github.com/evergreen-ci/cocoa/ecs_pod_creator_test.go
@@ -943,6 +943,11 @@ func TestECSPodPlacementOptions(t *testing.T) {
 		require.NotZero(t, opts)
 		assert.Zero(t, *opts)
 	})
+	t.Run("SetGroup", func(t *testing.T) {
+		group := "group"
+		opts := NewECSPodPlacementOptions().SetGroup(group)
+		assert.Equal(t, group, utility.FromStringPtr(opts.Group))
+	})
 	t.Run("SetStrategy", func(t *testing.T) {
 		strategy := StrategyBinpack
 		opts := NewECSPodPlacementOptions().SetStrategy(strategy)
@@ -1030,6 +1035,14 @@ func TestECSPodPlacementOptions(t *testing.T) {
 			require.NotZero(t, opts.Strategy)
 			assert.Equal(t, StrategySpread, *opts.Strategy)
 			assert.Equal(t, "custom", utility.FromStringPtr(opts.StrategyParameter))
+		})
+		t.Run("SucceedsWithNonemptyGroupName", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetGroup("group")
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("FailsWithEmptyGroupName", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetGroup("")
+			assert.Error(t, opts.Validate())
 		})
 	})
 }

--- a/vendor/github.com/evergreen-ci/cocoa/internal/testcase/ecs_client.go
+++ b/vendor/github.com/evergreen-ci/cocoa/internal/testcase/ecs_client.go
@@ -41,7 +41,7 @@ func ECSClientTaskDefinitionTests() map[string]ECSClientTestCase {
 				},
 				Cpu:    aws.String("128"),
 				Memory: aws.String("4"),
-				Family: aws.String(testutil.NewTaskDefinitionFamily(t.Name())),
+				Family: aws.String(testutil.NewTaskDefinitionFamily(t)),
 			})
 			require.NoError(t, err)
 			require.NotNil(t, registerOut)
@@ -68,7 +68,7 @@ func ECSClientRegisteredTaskDefinitionTests(registerIn ecs.RegisterTaskDefinitio
 		"RunTaskFailsWithValidButNonexistentInput": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			out, err := c.RunTask(ctx, &ecs.RunTaskInput{
 				Cluster:        aws.String(testutil.ECSClusterName()),
-				TaskDefinition: aws.String(testutil.NewTaskDefinitionFamily(t.Name()) + ":1"),
+				TaskDefinition: aws.String(testutil.NewTaskDefinitionFamily(t) + ":1"),
 			})
 			assert.Error(t, err)
 			assert.Zero(t, out)
@@ -153,8 +153,8 @@ func ECSClientRegisteredTaskDefinitionTests(registerIn ecs.RegisterTaskDefinitio
 				Cluster: aws.String(testutil.ECSClusterName()),
 				Tasks:   []*string{aws.String(utility.RandomString())},
 			})
-			assert.NoError(t, err)
-			assert.NotZero(t, out)
+			require.NoError(t, err)
+			require.NotZero(t, out)
 			assert.NotZero(t, out.Failures)
 			assert.Empty(t, out.Tasks)
 		},
@@ -184,7 +184,7 @@ func ECSClientRegisteredTaskDefinitionTests(registerIn ecs.RegisterTaskDefinitio
 		},
 		"DescribeTaskDefinitionFailsWithNonexistentTaskDefinition": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			out, err := c.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
-				TaskDefinition: aws.String(testutil.NewTaskDefinitionFamily(t.Name())),
+				TaskDefinition: aws.String(testutil.NewTaskDefinitionFamily(t)),
 			})
 			assert.Error(t, err)
 			assert.Zero(t, out)

--- a/vendor/github.com/evergreen-ci/cocoa/internal/testcase/ecs_pod_creator.go
+++ b/vendor/github.com/evergreen-ci/cocoa/internal/testcase/ecs_pod_creator.go
@@ -30,7 +30,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 
 			opts := cocoa.NewECSPodCreationOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
@@ -60,7 +60,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 			envVar := cocoa.NewEnvironmentVariable().
 				SetName("envVar").
 				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName("name")).
+					SetName(testutil.NewSecretName(t)).
 					SetNewValue("value"))
 			containerDef := cocoa.NewECSContainerDefinition().
 				SetImage("image").
@@ -70,12 +70,12 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 
 			opts := cocoa.NewECSPodCreationOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.TaskRole()).
-				SetExecutionRole(testutil.ExecutionRole()).
+				SetTaskRole(testutil.ECSTaskRole()).
+				SetExecutionRole(testutil.ECSExecutionRole()).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -88,7 +88,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetUsername("username").
 				SetPassword("password")
 			creds := cocoa.NewRepositoryCredentials().
-				SetName(testutil.NewSecretName(t.Name())).
+				SetName(testutil.NewSecretName(t)).
 				SetNewCredentials(*storedCreds)
 			containerDef := cocoa.NewECSContainerDefinition().
 				SetImage("image").
@@ -98,12 +98,12 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 
 			opts := cocoa.NewECSPodCreationOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.TaskRole()).
-				SetExecutionRole(testutil.ExecutionRole()).
+				SetTaskRole(testutil.ECSTaskRole()).
+				SetExecutionRole(testutil.ECSExecutionRole()).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -120,7 +120,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 		"CreatePodFailsWithSecretsButNoExecutionRole": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
 			envVar := cocoa.NewEnvironmentVariable().SetName("envVar").
 				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName("name")).
+					SetName(testutil.NewSecretName(t)).
 					SetNewValue("value"))
 			containerDef := cocoa.NewECSContainerDefinition().SetImage("image").
 				AddEnvironmentVariables(*envVar).
@@ -135,9 +135,9 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.TaskRole()).
+				SetTaskRole(testutil.ECSTaskRole()).
 				SetExecutionOptions(*execOpts).
-				SetName(testutil.NewTaskDefinitionFamily(t.Name()))
+				SetName(testutil.NewTaskDefinitionFamily(t))
 			assert.Error(t, opts.Validate())
 
 			p, err := c.CreatePod(ctx, *opts)
@@ -148,7 +148,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 			envVar := cocoa.NewEnvironmentVariable().
 				SetName("envVar").
 				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName("name")).
+					SetName(testutil.NewSecretName(t)).
 					SetNewValue("value").
 					SetOwned(true))
 
@@ -163,12 +163,12 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetCluster(testutil.ECSClusterName())
 
 			opts := cocoa.NewECSPodCreationOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.TaskRole()).
-				SetExecutionRole(testutil.ExecutionRole()).
+				SetTaskRole(testutil.ECSTaskRole()).
+				SetExecutionRole(testutil.ECSExecutionRole()).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -187,7 +187,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetUsername("username").
 				SetPassword("password")
 			creds := cocoa.NewRepositoryCredentials().
-				SetName(testutil.NewSecretName(t.Name())).
+				SetName(testutil.NewSecretName(t)).
 				SetNewCredentials(*storedCreds).
 				SetOwned(true)
 
@@ -202,12 +202,12 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetCluster(testutil.ECSClusterName())
 
 			opts := cocoa.NewECSPodCreationOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.TaskRole()).
-				SetExecutionRole(testutil.ExecutionRole()).
+				SetTaskRole(testutil.ECSTaskRole()).
+				SetExecutionRole(testutil.ECSExecutionRole()).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 

--- a/vendor/github.com/evergreen-ci/cocoa/internal/testcase/secrets_manager_client.go
+++ b/vendor/github.com/evergreen-ci/cocoa/internal/testcase/secrets_manager_client.go
@@ -23,7 +23,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 	return map[string]SecretsManagerClientTestCase{
 		"CreateSecretSucceeds": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			out, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
-				Name:         aws.String(testutil.NewSecretName(t.Name())),
+				Name:         aws.String(testutil.NewSecretName(t)),
 				SecretString: aws.String(utility.RandomString()),
 			})
 			require.NoError(t, err)
@@ -37,7 +37,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 			assert.Zero(t, out)
 		},
 		"GetSecretValueSucceedsWithExistingSecret": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
-			secretName := testutil.NewSecretName(t.Name())
+			secretName := testutil.NewSecretName(t)
 			createOut, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
 				Name:         aws.String(secretName),
 				SecretString: aws.String("foo"),
@@ -64,13 +64,13 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"GetSecretValueFailsWithValidNonexistentSecret": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			out, err := c.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
-				SecretId: aws.String(testutil.NewSecretName(t.Name())),
+				SecretId: aws.String(testutil.NewSecretName(t)),
 			})
 			assert.Error(t, err)
 			assert.Zero(t, out)
 		},
 		"UpdateSecretValueSucceedsWithExistingSecret": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
-			secretName := testutil.NewSecretName(t.Name())
+			secretName := testutil.NewSecretName(t)
 			createOut, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
 				Name:         aws.String(secretName),
 				SecretString: aws.String("bar"),
@@ -104,7 +104,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"UpdateSecretValueFailsWithValidNonexistentSecret": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			out, err := c.UpdateSecretValue(ctx, &secretsmanager.UpdateSecretInput{
-				SecretId:     aws.String(testutil.NewSecretName(t.Name())),
+				SecretId:     aws.String(testutil.NewSecretName(t)),
 				SecretString: aws.String("hello"),
 			})
 			assert.Error(t, err)
@@ -112,7 +112,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"DescribeSecretSucceeds": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			createOut, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
-				Name:         aws.String(testutil.NewSecretName(t.Name())),
+				Name:         aws.String(testutil.NewSecretName(t)),
 				SecretString: aws.String("bar"),
 			})
 			require.NoError(t, err)
@@ -131,7 +131,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"DescribeSecretSucceedsAfterDeletion": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			createOut, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
-				Name:         aws.String(testutil.NewSecretName(t.Name())),
+				Name:         aws.String(testutil.NewSecretName(t)),
 				SecretString: aws.String("bar"),
 			})
 			require.NoError(t, err)
@@ -157,7 +157,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"DescribeSecretFailsWithValidNonexistentSecret": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			out, err := c.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
-				SecretId: aws.String(testutil.NewSecretName(t.Name())),
+				SecretId: aws.String(testutil.NewSecretName(t)),
 			})
 			assert.Error(t, err)
 			assert.Zero(t, out)
@@ -169,7 +169,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"DeleteSecretSucceeds": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			createOut, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
-				Name:         aws.String(testutil.NewSecretName(t.Name())),
+				Name:         aws.String(testutil.NewSecretName(t)),
 				SecretString: aws.String("hello"),
 			})
 			require.NoError(t, err)

--- a/vendor/github.com/evergreen-ci/cocoa/internal/testcase/vault.go
+++ b/vendor/github.com/evergreen-ci/cocoa/internal/testcase/vault.go
@@ -17,7 +17,7 @@ type VaultTestCase func(ctx context.Context, t *testing.T, v cocoa.Vault)
 func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Vault, id string)) map[string]VaultTestCase {
 	return map[string]VaultTestCase{
 		"CreateSecretSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue("hello"))
+			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue("hello"))
 			require.NoError(t, err)
 			require.NotZero(t, id)
 
@@ -29,7 +29,7 @@ func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Va
 			assert.Zero(t, id)
 		},
 		"DeleteSecretWithExistingSecretSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue("hello"))
+			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue("hello"))
 			require.NoError(t, err)
 			require.NotZero(t, id)
 
@@ -39,11 +39,11 @@ func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Va
 			assert.Error(t, v.DeleteSecret(ctx, ""))
 		},
 		"DeleteSecretWithValidNonexistentInputNoops": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			assert.NoError(t, v.DeleteSecret(ctx, testutil.NewSecretName(t.Name())))
+			assert.NoError(t, v.DeleteSecret(ctx, testutil.NewSecretName(t)))
 		},
 		"GetValueWithExistingSecretSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
 			val := "eggs"
-			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue(val))
+			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue(val))
 			require.NoError(t, err)
 			require.NotZero(t, id)
 
@@ -60,12 +60,12 @@ func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Va
 			assert.Zero(t, id)
 		},
 		"GetValueWithValidNonexistentInputFails": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			id, err := v.GetValue(ctx, testutil.NewSecretName(t.Name()))
+			id, err := v.GetValue(ctx, testutil.NewSecretName(t))
 			assert.Error(t, err)
 			assert.Zero(t, id)
 		},
 		"UpdateValueSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue("eggs"))
+			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue("eggs"))
 			require.NoError(t, err)
 			require.NotZero(t, id)
 
@@ -83,7 +83,7 @@ func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Va
 			assert.Error(t, v.UpdateValue(ctx, *cocoa.NewNamedSecret()))
 		},
 		"UpdateValueWithValidNonexistentInputFails": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			assert.Error(t, v.UpdateValue(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue("leaf")))
+			assert.Error(t, v.UpdateValue(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue("leaf")))
 		},
 	}
 }

--- a/vendor/github.com/evergreen-ci/cocoa/internal/testutil/aws.go
+++ b/vendor/github.com/evergreen-ci/cocoa/internal/testutil/aws.go
@@ -1,0 +1,27 @@
+package testutil
+
+import (
+	"os"
+
+	"github.com/evergreen-ci/utility"
+)
+
+// runtimeNamespace is a random string generated during testing runtime that
+// acts as a namespace for this particular runtime's tests. It is used to
+// namespace AWS resources (e.g. secrets, task definitions). This avoids an
+// issue where the tests can be running concurrently on different machines and
+// may interfere with each other due to the way AWS resources are cleaned up at
+// the end of tests. For example, if one machine is running the ECS tests and at
+// the same time, another machine is cleaning up the resources for the same ECS
+// tests, they should not affect one another.
+var runtimeNamespace = utility.RandomString()
+
+// AWSRegion returns the AWS region from the environment variable.
+func AWSRegion() string {
+	return os.Getenv("AWS_REGION")
+}
+
+// AWSRole returns the AWS IAM role from the environment variable.
+func AWSRole() string {
+	return os.Getenv("AWS_ROLE")
+}

--- a/vendor/github.com/evergreen-ci/cocoa/internal/testutil/ecs.go
+++ b/vendor/github.com/evergreen-ci/cocoa/internal/testutil/ecs.go
@@ -1,16 +1,29 @@
 package testutil
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"strings"
+	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/stretchr/testify/assert"
 )
 
 // NewTaskDefinitionFamily makes a new test family for a task definition with a
 // common prefix, the given name, and a random string.
-func NewTaskDefinitionFamily(name string) string {
-	return strings.Join([]string{TaskDefinitionPrefix(), "cocoa", strings.ReplaceAll(name, "/", "-"), utility.RandomString()}, "-")
+func NewTaskDefinitionFamily(t *testing.T) string {
+	return strings.Join([]string{taskDefinitionFamily(t), utility.RandomString()}, "-")
+}
+
+func taskDefinitionFamily(t *testing.T) string {
+	return strings.Join([]string{strings.TrimSuffix(TaskDefinitionPrefix(), "-"), projectName, runtimeNamespace, strings.ReplaceAll(t.Name(), "/", "-")}, "-")
 }
 
 // TaskDefinitionPrefix returns the prefix name for task definitions from the
@@ -24,22 +37,132 @@ func ECSClusterName() string {
 	return os.Getenv("AWS_ECS_CLUSTER")
 }
 
-// AWSRegion returns the AWS region from the environment variable.
-func AWSRegion() string {
-	return os.Getenv("AWS_REGION")
-}
-
-// AWSRole returns the AWS IAM role from the environment variable.
-func AWSRole() string {
-	return os.Getenv("AWS_ROLE")
-}
-
-// TaskRole returns the AWS task role from the environment variable.
-func TaskRole() string {
+// ECSTaskRole returns the ECS task role from the environment variable.
+func ECSTaskRole() string {
 	return os.Getenv("AWS_ECS_TASK_ROLE")
 }
 
-// ExecutionRole returns the AWS execution role from the environment variable.
-func ExecutionRole() string {
+// ECSExecutionRole returns the ECS execution role from the environment
+// variable.
+func ECSExecutionRole() string {
 	return os.Getenv("AWS_ECS_EXECUTION_ROLE")
+}
+
+// CleanupTaskDefinitions cleans up all existing task definitions used in a
+// test.
+func CleanupTaskDefinitions(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
+	for token := cleanupTaskDefinitionsWithToken(ctx, t, c, nil); token != nil; token = cleanupTaskDefinitionsWithToken(ctx, t, c, token) {
+	}
+}
+
+// cleanupTaskDefinitionsWithToken cleans up active task definitions used in
+// Cocoa tests based on the results from the pagination token.
+func cleanupTaskDefinitionsWithToken(ctx context.Context, t *testing.T, c cocoa.ECSClient, token *string) (nextToken *string) {
+	out, err := c.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
+		Status:    aws.String(ecs.TaskDefinitionStatusActive),
+		NextToken: token,
+	})
+	if !assert.NoError(t, err) {
+		return nil
+	}
+	if !assert.NotZero(t, out) {
+		return nil
+	}
+
+	for _, arn := range out.TaskDefinitionArns {
+		if arn == nil {
+			continue
+		}
+
+		taskDefARN := *arn
+
+		// Ignore task definitions that were not generated within this test.
+		name := taskDefinitionFamily(t)
+		if !strings.Contains(taskDefARN, name) {
+			continue
+		}
+
+		_, err := c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
+			TaskDefinition: arn,
+		})
+		if assert.NoError(t, err) {
+			grip.Info(message.Fields{
+				"message": "cleaned up leftover task definition",
+				"arn":     taskDefARN,
+				"test":    t.Name(),
+			})
+		}
+	}
+
+	return out.NextToken
+}
+
+// CleanupTasks cleans up all tasks used in the Cocoa cluster.
+func CleanupTasks(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
+	for token := cleanupTasksWithToken(ctx, t, c, nil); token != nil; token = cleanupTasksWithToken(ctx, t, c, token) {
+	}
+}
+
+// cleanupTasksWithToken cleans up running tasks used in the Cocoa cluster based
+// on the results from the pagination token.
+func cleanupTasksWithToken(ctx context.Context, t *testing.T, c cocoa.ECSClient, token *string) (nextToken *string) {
+	out, err := c.ListTasks(ctx, &ecs.ListTasksInput{
+		Cluster: aws.String(ECSClusterName()),
+	})
+	if !assert.NoError(t, err) {
+		return nil
+	}
+	if !assert.NotZero(t, out) {
+		return nil
+	}
+	if len(out.TaskArns) == 0 {
+		return nil
+	}
+
+	describeOut, err := c.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+		Cluster: aws.String(ECSClusterName()),
+		Tasks:   out.TaskArns,
+	})
+	if !assert.NoError(t, err) {
+		return nil
+	}
+	if !assert.NotZero(t, out) {
+		return nil
+	}
+
+	for _, task := range describeOut.Tasks {
+		if task == nil {
+			continue
+		}
+		if task.TaskArn == nil {
+			continue
+		}
+		if task.TaskDefinitionArn == nil {
+			continue
+		}
+
+		// Ignore tasks created from task definitions not generated within this
+		// test.
+		taskDef := taskDefinitionFamily(t)
+		if !strings.Contains(*task.TaskDefinitionArn, taskDef) {
+			continue
+		}
+
+		arn := *task.TaskArn
+
+		_, err := c.StopTask(ctx, &ecs.StopTaskInput{
+			Cluster: aws.String(ECSClusterName()),
+			Reason:  aws.String(fmt.Sprintf("cocoa test teardown for test '%s'", t.Name())),
+			Task:    task.TaskArn,
+		})
+		if assert.NoError(t, err) {
+			grip.Info(message.Fields{
+				"message": "cleaned up leftover task",
+				"arn":     arn,
+				"test":    t.Name(),
+			})
+		}
+	}
+
+	return out.NextToken
 }

--- a/vendor/github.com/evergreen-ci/cocoa/internal/testutil/secret.go
+++ b/vendor/github.com/evergreen-ci/cocoa/internal/testutil/secret.go
@@ -1,23 +1,85 @@
 package testutil
 
 import (
-	"fmt"
+	"context"
 	"os"
 	"path"
+	"strings"
+	"testing"
 
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/stretchr/testify/assert"
 )
 
 const projectName = "cocoa"
 
 // NewSecretName creates a new test secret name with a common prefix, the given
-// name, and a random string.
-func NewSecretName(name string) string {
-	return fmt.Sprint(path.Join(SecretPrefix(), projectName, name, utility.RandomString()))
+// test's name, and a random string.
+func NewSecretName(t *testing.T) string {
+	return path.Join(secretName(t), utility.RandomString())
+}
+
+func secretName(t *testing.T) string {
+	return path.Join(strings.TrimSuffix(SecretPrefix(), "/"), projectName, runtimeNamespace, t.Name())
 }
 
 // SecretPrefix returns the prefix name for secrets from the environment
 // variable.
 func SecretPrefix() string {
 	return os.Getenv("AWS_SECRET_PREFIX")
+}
+
+// CleanupSecrets cleans up all existing secrets used in a test.
+func CleanupSecrets(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
+	for token := cleanupSecretsWithToken(ctx, t, c, nil); token != nil; token = cleanupSecretsWithToken(ctx, t, c, token) {
+	}
+}
+
+// cleanupSecretsWithToken cleans up existing secrets used in Cocoa tests based
+// on the results from the pagination token.
+func cleanupSecretsWithToken(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient, token *string) (nextToken *string) {
+	out, err := c.ListSecrets(ctx, &secretsmanager.ListSecretsInput{
+		NextToken: token,
+	})
+	if !assert.NoError(t, err) {
+		return nil
+	}
+	if !assert.NotZero(t, out) {
+		return nil
+	}
+
+	for _, secret := range out.SecretList {
+		if secret == nil {
+			continue
+		}
+		if secret.ARN == nil {
+			continue
+		}
+
+		arn := *secret.ARN
+
+		// Ignore secrets that were not generated within this test.
+		name := secretName(t)
+		if !strings.Contains(arn, name) {
+			continue
+		}
+
+		_, err := c.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
+			ForceDeleteWithoutRecovery: utility.TruePtr(),
+			SecretId:                   &arn,
+		})
+		if assert.NoError(t, err) {
+			grip.Info(message.Fields{
+				"message": "cleaned up leftover secret",
+				"arn":     arn,
+				"test":    t.Name(),
+			})
+		}
+	}
+
+	return out.NextToken
 }

--- a/vendor/github.com/evergreen-ci/cocoa/mock/ecs_client.go
+++ b/vendor/github.com/evergreen-ci/cocoa/mock/ecs_client.go
@@ -126,6 +126,7 @@ type ECSTask struct {
 	TaskDef     ECSTaskDefinition
 	Cluster     *string
 	Containers  []ECSContainer
+	Group       *string
 	ExecEnabled *bool
 	Status      *string
 	GoalStatus  *string
@@ -147,6 +148,7 @@ func newECSTask(in *ecs.RunTaskInput, taskDef ECSTaskDefinition) ECSTask {
 		ARN:         utility.ToStringPtr(id.String()),
 		Cluster:     in.Cluster,
 		ExecEnabled: in.EnableExecuteCommand,
+		Group:       in.Group,
 		Status:      utility.ToStringPtr(ecs.DesiredStatusPending),
 		GoalStatus:  utility.ToStringPtr(ecs.DesiredStatusRunning),
 		Created:     utility.ToTimePtr(time.Now()),
@@ -166,6 +168,7 @@ func (t *ECSTask) export() *ecs.Task {
 		TaskArn:              t.ARN,
 		ClusterArn:           t.Cluster,
 		EnableExecuteCommand: t.ExecEnabled,
+		Group:                t.Group,
 		Tags:                 exportTags(t.Tags),
 		TaskDefinitionArn:    t.TaskDef.ARN,
 		Cpu:                  t.TaskDef.CPU,
@@ -695,6 +698,9 @@ func (c *ECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.S
 	task.StopCode = utility.ToStringPtr(ecs.TaskStopCodeUserInitiated)
 	task.StopReason = in.Reason
 	task.Stopped = utility.ToTimePtr(time.Now())
+	for i := range task.Containers {
+		task.Containers[i].Status = utility.ToStringPtr(ecs.DesiredStatusStopped)
+	}
 
 	cluster[utility.FromStringPtr(in.Task)] = task
 

--- a/vendor/github.com/evergreen-ci/cocoa/mock/ecs_client_test.go
+++ b/vendor/github.com/evergreen-ci/cocoa/mock/ecs_client_test.go
@@ -2,8 +2,6 @@ package mock
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -12,12 +10,12 @@ import (
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
-	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// defaultTestTimeout is the default test timeout for mock tests.
+const defaultTestTimeout = time.Second
 
 func TestECSClient(t *testing.T) {
 	assert.Implements(t, (*cocoa.ECSClient)(nil), &ECSClient{})
@@ -27,12 +25,14 @@ func TestECSClient(t *testing.T) {
 
 	c := &ECSClient{}
 	defer func() {
+		cleanupECSAndSecretsManagerCache()
+
 		assert.NoError(t, c.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.ECSClientTaskDefinitionTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()
@@ -51,7 +51,7 @@ func TestECSClient(t *testing.T) {
 		},
 		Cpu:    aws.String("128"),
 		Memory: aws.String("4"),
-		Family: aws.String(testutil.NewTaskDefinitionFamily(t.Name())),
+		Family: aws.String(testutil.NewTaskDefinitionFamily(t)),
 	}
 
 	registerOut, err := c.RegisterTaskDefinition(ctx, registerIn)
@@ -59,154 +59,14 @@ func TestECSClient(t *testing.T) {
 	require.NotZero(t, registerOut)
 	require.NotZero(t, registerOut.TaskDefinition)
 
-	defer func() {
-		taskDefs := cleanupTaskDefinitions(ctx, t, c)
-		grip.InfoWhen(len(taskDefs) > 0, message.Fields{
-			"message":          "cleaned up leftover task definitions",
-			"task_definitions": taskDefs,
-			"test":             t.Name(),
-		})
-		tasks := cleanupTasks(ctx, t, c, taskDefs)
-		grip.InfoWhen(len(tasks) > 0, message.Fields{
-			"message": "cleaned up leftover running tasks",
-			"tasks":   tasks,
-			"test":    t.Name(),
-		})
-		require.NoError(t, c.Close(ctx))
-	}()
-
 	for tName, tCase := range testcase.ECSClientRegisteredTaskDefinitionTests(*registerIn, *registerOut) {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
+
+			cleanupECSAndSecretsManagerCache()
 
 			tCase(tctx, t, c)
 		})
 	}
-}
-
-// cleanupTaskDefinitions cleans up all existing task definitions for testing
-// teardown.
-func cleanupTaskDefinitions(ctx context.Context, t *testing.T, c cocoa.ECSClient) []string {
-	out, err := c.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
-		Status: aws.String(ecs.TaskDefinitionStatusActive),
-	})
-	require.NoError(t, err)
-	require.NotZero(t, out)
-
-	var taskDefs []string
-
-	for _, arn := range out.TaskDefinitionArns {
-		if arn == nil {
-			continue
-		}
-		taskDefArn := *arn
-		// Ignore task definitions that were not generated with testutil.NewTaskDefinitionFamily.
-		name := strings.Join([]string{testutil.TaskDefinitionPrefix(), "cocoa", t.Name()}, "-")
-		if !strings.Contains(taskDefArn, name) {
-			continue
-		}
-		taskDefs = append(taskDefs, *arn)
-		_, err := c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
-			TaskDefinition: arn,
-		})
-		assert.NoError(t, err)
-	}
-
-	return taskDefs
-}
-
-// cleanupTasks cleans up all tasks for testing teardown. It only cleans up
-// tasks if they are running and are created from one of the given task
-// definitions.
-func cleanupTasks(ctx context.Context, t *testing.T, c cocoa.ECSClient, taskDefs []string) []string {
-	out, err := c.ListTasks(ctx, &ecs.ListTasksInput{
-		Cluster: aws.String(testutil.ECSClusterName()),
-	})
-	require.NoError(t, err)
-	require.NotZero(t, out)
-
-	if len(out.TaskArns) == 0 {
-		return nil
-	}
-
-	describeOut, err := c.DescribeTasks(ctx, &ecs.DescribeTasksInput{
-		Cluster: aws.String(testutil.ECSClusterName()),
-		Tasks:   out.TaskArns,
-	})
-	require.NoError(t, err)
-
-	var tasks []string
-	for _, task := range describeOut.Tasks {
-		if task == nil {
-			continue
-		}
-
-		if task.TaskDefinitionArn == nil {
-			grip.Notice(message.Fields{
-				"message": "cannot check task for test teardown because it does not have a task definition ARN",
-				"context": "cocoa test teardown",
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		}
-		// Ignore tasks started by task definitions outside of the cocoa testing
-		// environment.
-		if taskDef := *task.TaskDefinitionArn; !utility.StringSliceContains(taskDefs, taskDef) {
-			continue
-		}
-
-		if task.LastStatus == nil {
-			grip.Notice(message.Fields{
-				"message": "cannot check task for test teardown because it does not have a status",
-				"context": "cocoa test teardown",
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		}
-
-		status := *task.LastStatus
-		switch status {
-		case "PROVISIONING", "PENDING", "ACTIVATING":
-			grip.Notice(message.Fields{
-				"message": "cannot stop the task because it is in an unstoppable state",
-				"context": "cocoa test teardown",
-				"status":  status,
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		case "RUNNING":
-			if task.DesiredStatus != nil && *task.DesiredStatus == "STOPPED" {
-				continue
-			}
-			if task.TaskArn == nil {
-				grip.Notice(message.Fields{
-					"message": "cannot stop the task because it is missing a task ARN",
-					"context": "cocoa test teardown",
-					"status":  status,
-					"task":    *task,
-					"test":    t.Name(),
-				})
-				continue
-			}
-			_, err := c.StopTask(ctx, &ecs.StopTaskInput{
-				Cluster: aws.String(testutil.ECSClusterName()),
-				Reason:  aws.String(fmt.Sprintf("cocoa test teardown for test '%s'", t.Name())),
-				Task:    task.TaskArn,
-			})
-			if assert.NoError(t, err) {
-				tasks = append(tasks, *task.TaskArn)
-			}
-		case "DEACTIVATING", "STOPPING", "DEPROVISIONING", "STOPPED":
-			continue
-		default:
-			assert.Fail(t, "unrecognized task status '%s'", status)
-		}
-
-	}
-
-	return tasks
 }

--- a/vendor/github.com/evergreen-ci/cocoa/mock/ecs_pod.go
+++ b/vendor/github.com/evergreen-ci/cocoa/mock/ecs_pod.go
@@ -13,7 +13,10 @@ type ECSPod struct {
 
 	ResourcesOutput *cocoa.ECSPodResources
 
-	StatusOutput *cocoa.ECSPodStatusInfo
+	StatusInfoOutput *cocoa.ECSPodStatusInfo
+
+	LatestStatusInfoOutput *cocoa.ECSPodStatusInfo
+	LatestStatusInfoError  error
 
 	StopError error
 
@@ -31,11 +34,22 @@ func NewECSPod(p cocoa.ECSPod) *ECSPod {
 // output can be customized. By default, it will return the result of the
 // backing ECS pod.
 func (p *ECSPod) StatusInfo() cocoa.ECSPodStatusInfo {
-	if p.StatusOutput != nil {
-		return *p.StatusOutput
+	if p.StatusInfoOutput != nil {
+		return *p.StatusInfoOutput
 	}
 
 	return p.ECSPod.StatusInfo()
+}
+
+// LatestStatusInfo returns the mock latest status information about the pod.
+// The mock output can be customized. By default, it will return the result of
+// the backing ECS pod.
+func (p *ECSPod) LatestStatusInfo(ctx context.Context) (*cocoa.ECSPodStatusInfo, error) {
+	if p.LatestStatusInfoOutput != nil || p.LatestStatusInfoError != nil {
+		return p.LatestStatusInfoOutput, p.LatestStatusInfoError
+	}
+
+	return p.ECSPod.LatestStatusInfo(ctx)
 }
 
 // Resources returns mock resource information about the pod. The mock output

--- a/vendor/github.com/evergreen-ci/cocoa/mock/secrets_manager_client_test.go
+++ b/vendor/github.com/evergreen-ci/cocoa/mock/secrets_manager_client_test.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
@@ -18,7 +17,7 @@ func TestSecretsManagerClient(t *testing.T) {
 
 	for tName, tCase := range testcase.SecretsManagerClientTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()

--- a/vendor/github.com/evergreen-ci/cocoa/mock/secrets_manager_vault_test.go
+++ b/vendor/github.com/evergreen-ci/cocoa/mock/secrets_manager_vault_test.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
@@ -26,7 +25,7 @@ func TestVaultWithSecretsManager(t *testing.T) {
 
 	for tName, tCase := range testcase.VaultTests(cleanupSecret) {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()

--- a/vendor/github.com/evergreen-ci/cocoa/secret/secrets_manager_client.go
+++ b/vendor/github.com/evergreen-ci/cocoa/secret/secrets_manager_client.go
@@ -154,6 +154,34 @@ func (c *BasicSecretsManagerClient) DescribeSecret(ctx context.Context, in *secr
 		}, *c.opts.RetryOpts); err != nil {
 		return nil, err
 	}
+
+	return out, nil
+}
+
+// ListSecrets lists the metadata information for secrets matching the filters.
+func (c *BasicSecretsManagerClient) ListSecrets(ctx context.Context, in *secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error) {
+	if err := c.setup(); err != nil {
+		return nil, errors.Wrap(err, "setting up client")
+	}
+
+	var out *secretsmanager.ListSecretsOutput
+	var err error
+	msg := awsutil.MakeAPILogMessage("ListSecrets", in)
+	if err := utility.Retry(
+		ctx,
+		func() (bool, error) {
+			out, err = c.sm.ListSecretsWithContext(ctx, in)
+			if awsErr, ok := err.(awserr.Error); ok {
+				grip.Debug(message.WrapError(awsErr, msg))
+				if c.isNonRetryableErrorCode(awsErr.Code()) {
+					return false, err
+				}
+			}
+			return true, err
+		}, *c.opts.RetryOpts); err != nil {
+		return nil, err
+	}
+
 	return out, nil
 }
 

--- a/vendor/github.com/evergreen-ci/cocoa/secrets_manager_client.go
+++ b/vendor/github.com/evergreen-ci/cocoa/secrets_manager_client.go
@@ -16,6 +16,9 @@ type SecretsManagerClient interface {
 	GetSecretValue(ctx context.Context, in *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
 	// DescribeSecret gets metadata information about a secret.
 	DescribeSecret(ctx context.Context, in *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error)
+	// ListSecrets lists all metadata information for secrets matching the
+	// filters.
+	ListSecrets(ctx context.Context, in *secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error)
 	// UpdateSecret updates the value of an existing secret.
 	UpdateSecretValue(ctx context.Context, in *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error)
 	// DeleteSecret deletes an existing secret.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15125

### Description 
* Support pods that may or may not own their secrets from creation to deletion. This is necessary since future work will include making fewer calls to Secrets Manager, so secrets will be pre-generated and shared between multiple pods.
* Revendor Cocoa.

### Testing 
Updated DB, REST, and cloud util tests.