### PR TITLE
EVG-15488: constrain pod placement according to compatible CPU architecture

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -186,7 +186,7 @@ const (
 // cocoa.ECSPodExecutionOptions.
 func ExportECSPodCreationOptions(settings *evergreen.Settings, p *pod.Pod) (*cocoa.ECSPodCreationOptions, error) {
 	ecsConf := settings.Providers.AWS.Pod.ECS
-	execOpts, err := exportECSPodExecutionOptions(ecsConf, p.TaskContainerCreationOpts.OS)
+	execOpts, err := exportECSPodExecutionOptions(ecsConf, p.TaskContainerCreationOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "exporting pod execution options")
 	}
@@ -247,9 +247,26 @@ func exportECSPodContainerDef(settings *evergreen.Settings, p *pod.Pod) (*cocoa.
 	return def, nil
 }
 
+// podArchToECSArch exports a pod container CPU architecture to an ECS
+// CPU architecture.
+func exportECSPodArch(arch pod.Arch) string {
+	switch arch {
+	case pod.ArchAMD64:
+		return "x86_64"
+	case pod.ArchARM64:
+		return "arm64"
+	default:
+		return ""
+	}
+}
+
+const (
+	ecsCPUArchConstraint = "ecs.cpu-architecture"
+)
+
 // exportECSPodExecutionOptions exports the ECS configuration into
 // cocoa.ECSPodExecutionOptions.
-func exportECSPodExecutionOptions(ecsConfig evergreen.ECSConfig, podOS pod.OS) (*cocoa.ECSPodExecutionOptions, error) {
+func exportECSPodExecutionOptions(ecsConfig evergreen.ECSConfig, containerOpts pod.TaskContainerCreationOptions) (*cocoa.ECSPodExecutionOptions, error) {
 	opts := cocoa.NewECSPodExecutionOptions()
 
 	if len(ecsConfig.AWSVPC.Subnets) != 0 || len(ecsConfig.AWSVPC.SecurityGroups) != 0 {
@@ -258,13 +275,18 @@ func exportECSPodExecutionOptions(ecsConfig evergreen.ECSConfig, podOS pod.OS) (
 			SetSecurityGroups(ecsConfig.AWSVPC.SecurityGroups))
 	}
 
+	if arch := exportECSPodArch(containerOpts.Arch); arch != "" {
+		archConstraint := fmt.Sprintf("%s == %s", ecsCPUArchConstraint, arch)
+		opts.SetPlacementOptions(*cocoa.NewECSPodPlacementOptions().AddInstanceFilters(archConstraint))
+	}
+
 	for _, cluster := range ecsConfig.Clusters {
-		if string(podOS) == string(cluster.Platform) {
+		if string(containerOpts.OS) == string(cluster.Platform) {
 			return opts.SetCluster(cluster.Name), nil
 		}
 	}
 
-	return nil, errors.Errorf("pod OS ('%s') did not match any ECS cluster platforms", string(podOS))
+	return nil, errors.Errorf("pod OS ('%s') did not match any ECS cluster platforms", string(containerOpts.OS))
 }
 
 // podAWSOptions creates options to initialize an AWS client for pod management.

--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -329,8 +329,8 @@ func TestExportECSPodCreationOptions(t *testing.T) {
 				Image:      "image",
 				MemoryMB:   128,
 				CPU:        128,
-				OS:         "linux",
-				Arch:       "amd64",
+				OS:         pod.OSLinux,
+				Arch:       pod.ArchAMD64,
 				WorkingDir: "/root",
 				EnvVars: map[string]string{
 					"name": "value",
@@ -385,6 +385,9 @@ func TestExportECSPodCreationOptions(t *testing.T) {
 		require.NotZero(t, opts.ExecutionOpts.AWSVPCOpts)
 		assert.Equal(t, settings.Providers.AWS.Pod.ECS.AWSVPC.Subnets, opts.ExecutionOpts.AWSVPCOpts.Subnets)
 		assert.Equal(t, settings.Providers.AWS.Pod.ECS.AWSVPC.SecurityGroups, opts.ExecutionOpts.AWSVPCOpts.SecurityGroups)
+		require.NotZero(t, opts.ExecutionOpts.PlacementOpts)
+		require.Len(t, opts.ExecutionOpts.PlacementOpts.InstanceFilters, 1)
+		assert.Equal(t, "ecs.cpu-architecture == x86_64", opts.ExecutionOpts.PlacementOpts.InstanceFilters[0])
 
 		assert.True(t, strings.HasPrefix(utility.FromStringPtr(opts.Name), settings.Providers.AWS.Pod.ECS.TaskDefinitionPrefix))
 		assert.Contains(t, utility.FromStringPtr(opts.Name), p.ID)


### PR DESCRIPTION
JIra: https://jira.mongodb.org/browse/EVG-15225

### Description 
Containers target a particular CPU architecture, so ensure that pods get assigned to compatible hosts.

### Testing 
Updated cloud unit tests.