### PR TITLE
EVG-15212: Fix build baron HTML error for disabled projects

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -789,7 +789,7 @@ func (e *envState) ClientConfig() *ClientConfig {
 	return &config
 }
 
-type BuildBaronProject struct {
+type BuildBaronSettings struct {
 	// todo: reconfigure the BuildBaronConfigured check to use TicketSearchProjects instead
 
 	TicketCreateProject  string   `mapstructure:"ticket_create_project" bson:"ticket_create_project"`
@@ -848,7 +848,7 @@ func (e *envState) SaveConfig() error {
 		if pluginName == "buildbaron" {
 			for fieldName, field := range plugin {
 				if fieldName == "projects" {
-					var projects map[string]BuildBaronProject
+					var projects map[string]BuildBaronSettings
 					err := mapstructure.Decode(field, &projects)
 					if err != nil {
 						return errors.Wrap(err, "problem decoding buildbaron projects")

--- a/graphql/ui_plugin_build_baron.go
+++ b/graphql/ui_plugin_build_baron.go
@@ -48,7 +48,7 @@ func BbFileTicket(context context.Context, taskId string, execution int) (bool, 
 	env := evergreen.GetEnvironment()
 	settings := env.Settings()
 	queue := env.RemoteQueue()
-	bbProject, ok := plugin.BbGetProject(settings, t.Project)
+	bbProject, ok := plugin.BbGetProject(settings, t.Project, t.Version)
 	if !ok {
 		return taskNotFound, errors.Errorf("error finding build baron plugin for task '%s'", taskId)
 	}
@@ -187,7 +187,7 @@ func GetSearchReturnInfo(taskId string, exec string) (*thirdparty.SearchReturnIn
 		return nil, bbConfig, err
 	}
 	settings := evergreen.GetEnvironment().Settings()
-	bbProj, ok := plugin.BbGetProject(settings, t.Project)
+	bbProj, ok := plugin.BbGetProject(settings, t.Project, t.Version)
 	if !ok {
 		// build baron project not found, meaning it's not configured for
 		// either regular build baron or for a custom ticket filing webhook
@@ -275,7 +275,7 @@ type MultiSourceSuggest struct {
 }
 
 type JiraSuggest struct {
-	BbProj      evergreen.BuildBaronProject
+	BbProj      evergreen.BuildBaronSettings
 	JiraHandler thirdparty.JiraHandler
 }
 

--- a/model/project.go
+++ b/model/project.go
@@ -60,6 +60,7 @@ type Project struct {
 	ExecTimeoutSecs        int                            `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs"`
 	Loggers                *LoggerConfig                  `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
 	TaskAnnotationSettings *evergreen.AnnotationsSettings `yaml:"task_annotation_settings,omitempty" bson:"task_annotation_settings,omitempty"`
+	BuildBaronSettings     *evergreen.BuildBaronSettings  `yaml:"build_baron_settings,omitempty" bson:"build_baron_settings,omitempty"`
 	PerfEnabled            bool                           `yaml:"perf_enabled,omitempty" bson:"perf_enabled,omitempty"`
 
 	// The below fields can be set for the ProjectRef struct on the project page, or in the project config yaml.

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -83,6 +83,7 @@ type ParserProject struct {
 	Loggers                *LoggerConfig                  `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
 	CreateTime             time.Time                      `yaml:"create_time,omitempty" bson:"create_time,omitempty"`
 	TaskAnnotationSettings *evergreen.AnnotationsSettings `yaml:"task_annotation_settings,omitempty" bson:"task_annotation_settings,omitempty"`
+	BuildBaronSettings     *evergreen.BuildBaronSettings  `yaml:"build_baron_settings,omitempty" bson:"build_baron_settings,omitempty"`
 	PerfEnabled            *bool                          `yaml:"perf_enabled,omitempty" bson:"perf_enabled,omitempty"`
 
 	// The below fields can be set for the ProjectRef struct on the project page, or in the project config yaml.
@@ -770,6 +771,7 @@ func TranslateProject(pp *ParserProject) (*Project, error) {
 		ExecTimeoutSecs:        utility.FromIntPtr(pp.ExecTimeoutSecs),
 		Loggers:                pp.Loggers,
 		TaskAnnotationSettings: pp.TaskAnnotationSettings,
+		BuildBaronSettings:     pp.BuildBaronSettings,
 		PerfEnabled:            utility.FromBoolPtr(pp.PerfEnabled),
 		DeactivatePrevious:     utility.FromBoolPtr(pp.DeactivatePrevious),
 	}

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -46,6 +46,7 @@ var (
 	ParserProjectAxesKey                   = bsonutil.MustHaveTag(ParserProject{}, "Axes")
 	ParserProjectCreateTimeKey             = bsonutil.MustHaveTag(ParserProject{}, "CreateTime")
 	ParserProjectTaskAnnotationSettingsKey = bsonutil.MustHaveTag(ParserProject{}, "TaskAnnotationSettings")
+	ParserProjectBuildBaronSettingsKey     = bsonutil.MustHaveTag(ParserProject{}, "BuildBaronSettings")
 	ParserProjectPerfEnabledKey            = bsonutil.MustHaveTag(ParserProject{}, "PerfEnabled")
 )
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -102,7 +102,8 @@ type ProjectRef struct {
 	TaskAnnotationSettings evergreen.AnnotationsSettings `bson:"task_annotation_settings,omitempty" bson:"task_annotation_settings,omitempty"`
 
 	// Plugin settings
-	PerfEnabled *bool `bson:"perf_enabled,omitempty" json:"perf_enabled,omitempty" yaml:"perf_enabled,omitempty"`
+	BuildBaronSettings evergreen.BuildBaronSettings `bson:"build_baron_settings,omitempty" json:"build_baron_settings,omitempty" yaml:"build_baron_settings,omitempty"`
+	PerfEnabled        *bool                        `bson:"perf_enabled,omitempty" json:"perf_enabled,omitempty" yaml:"perf_enabled,omitempty"`
 
 	// This is a temporary flag to enable individual projects to use repo settings
 	UseRepoSettings bool   `bson:"use_repo_settings" json:"use_repo_settings" yaml:"use_repo_settings"`
@@ -235,6 +236,7 @@ var (
 	projectRefPeriodicBuildsKey          = bsonutil.MustHaveTag(ProjectRef{}, "PeriodicBuilds")
 	projectRefWorkstationConfigKey       = bsonutil.MustHaveTag(ProjectRef{}, "WorkstationConfig")
 	projectRefTaskAnnotationSettingsKey  = bsonutil.MustHaveTag(ProjectRef{}, "TaskAnnotationSettings")
+	projectRefBuildBaronSettingsKey      = bsonutil.MustHaveTag(ProjectRef{}, "BuildBaronSettings")
 	projectRefPerfEnabledKey             = bsonutil.MustHaveTag(ProjectRef{}, "PerfEnabled")
 
 	commitQueueEnabledKey       = bsonutil.MustHaveTag(CommitQueueParams{}, "Enabled")

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -138,10 +138,13 @@ func (bbp *BuildBaronPlugin) GetPanelConfig() (*PanelConfig, error) {
 					template.HTML(`<script type="text/javascript" src="/static/plugins/buildbaron/js/task_build_baron.js"></script>`),
 				},
 				DataFunc: func(context UIContext) (interface{}, error) {
-					enabled := len(bbp.opts.Projects[context.ProjectRef.Id].TicketSearchProjects) > 0
-					if !enabled {
-						enabled = len(bbp.opts.Projects[context.ProjectRef.Identifier].TicketSearchProjects) > 0
+					bbSettings, ok := BbGetProject(evergreen.GetEnvironment().Settings(), context.ProjectRef.Id, "")
+					if !ok {
+						return struct {
+							Enabled bool `json:"enabled"`
+						}{false}, nil
 					}
+					enabled := len(bbSettings.TicketSearchProjects) > 0
 					return struct {
 						Enabled bool `json:"enabled"`
 					}{enabled}, nil

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -139,12 +139,7 @@ func (bbp *BuildBaronPlugin) GetPanelConfig() (*PanelConfig, error) {
 				},
 				DataFunc: func(context UIContext) (interface{}, error) {
 					bbSettings, ok := BbGetProject(evergreen.GetEnvironment().Settings(), context.ProjectRef.Id, "")
-					if !ok {
-						return struct {
-							Enabled bool `json:"enabled"`
-						}{false}, nil
-					}
-					enabled := len(bbSettings.TicketSearchProjects) > 0
+					enabled := ok && len(bbSettings.TicketSearchProjects) > 0
 					return struct {
 						Enabled bool `json:"enabled"`
 					}{enabled}, nil

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -175,7 +175,7 @@ func IsWebhookConfigured(project string, version string) (evergreen.WebHook, boo
 			webHook = projectRef.TaskAnnotationSettings.FileTicketWebHook
 		}
 	} else {
-		bbProject, _ := BbGetProject(evergreen.GetEnvironment().Settings(), project)
+		bbProject, _ := BbGetProject(evergreen.GetEnvironment().Settings(), project, "")
 		webHook = bbProject.TaskAnnotationSettings.FileTicketWebHook
 		if webHook.Endpoint != "" && bbProject.TicketCreateProject != "" {
 			return evergreen.WebHook{}, false, errors.Errorf("The custom file ticket webhook and the build baron TicketCreateProject should not both be configured")

--- a/plugin/build_baron_test.go
+++ b/plugin/build_baron_test.go
@@ -1,14 +1,14 @@
 package plugin
 
 import (
-	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildBaronPluginConfigure(t *testing.T) {

--- a/plugin/build_baron_test.go
+++ b/plugin/build_baron_test.go
@@ -1,6 +1,10 @@
 package plugin
 
 import (
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -12,8 +16,8 @@ func TestBuildBaronPluginConfigure(t *testing.T) {
 
 	bbPlugin := BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketCreateProject:  "BFG",
 				TicketSearchProjects: []string{"BF", "BFG"},
 			},
@@ -23,12 +27,12 @@ func TestBuildBaronPluginConfigure(t *testing.T) {
 
 	bbPlugin = BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj1": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj1": evergreen.BuildBaronSettings{
 				TicketCreateProject:  "BFG",
 				TicketSearchProjects: []string{"BF", "BFG"},
 			},
-			"proj2": evergreen.BuildBaronProject{
+			"proj2": evergreen.BuildBaronSettings{
 				TicketCreateProject:  "BFG",
 				TicketSearchProjects: []string{"BF", "BFG"},
 			},
@@ -38,8 +42,8 @@ func TestBuildBaronPluginConfigure(t *testing.T) {
 
 	bbPlugin = BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketCreateProject: "BFG",
 			},
 		},
@@ -48,8 +52,8 @@ func TestBuildBaronPluginConfigure(t *testing.T) {
 
 	bbPlugin = BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketSearchProjects: []string{"BF", "BFG"},
 			},
 		},
@@ -62,8 +66,8 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 
 	bbPlugin := BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -77,8 +81,8 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 
 	bbPlugin = BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -90,8 +94,8 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 
 	bbPlugin = BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketCreateProject:  "BFG",
 				TicketSearchProjects: []string{"BF", "BFG"},
 				BFSuggestionUsername: "user",
@@ -103,8 +107,8 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 
 	bbPlugin = BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionTimeoutSecs: 10,
@@ -115,8 +119,8 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 
 	bbPlugin = BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "://evergreen.mongodb.com",
@@ -128,8 +132,8 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 
 	bbPlugin = BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -142,8 +146,8 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 
 	bbPlugin = BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -155,8 +159,8 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 
 	bbPlugin = BuildBaronPlugin{}
 	assert.Nil(bbPlugin.Configure(map[string]interface{}{
-		"Projects": map[string]evergreen.BuildBaronProject{
-			"proj": evergreen.BuildBaronProject{
+		"Projects": map[string]evergreen.BuildBaronSettings{
+			"proj": evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -165,4 +169,58 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 		},
 	}))
 	assert.Len(bbPlugin.opts.Projects, 0)
+}
+
+func TestBbGetProject(t *testing.T) {
+	require.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection, model.ParserProjectCollection),
+		"Error clearing task collections")
+
+	myProject := model.ProjectRef{
+		Id: "proj",
+		BuildBaronSettings: evergreen.BuildBaronSettings{
+			TicketCreateProject: "BFG",
+		},
+	}
+	myProject2 := model.ProjectRef{
+		Id: "proj2",
+		BuildBaronSettings: evergreen.BuildBaronSettings{
+			TicketCreateProject: "123",
+		},
+	}
+	myProjectParser := model.ParserProject{
+		Id: "proj2",
+		BuildBaronSettings: &evergreen.BuildBaronSettings{
+			TicketCreateProject: "ABC",
+		},
+	}
+	testTask := task.Task{
+		Id:        "testone",
+		Activated: true,
+		Project:   "proj",
+		Version:   "v1",
+	}
+	testTask2 := task.Task{
+		Id:        "testtwo",
+		Activated: true,
+		Project:   "proj2",
+		Version:   "proj2",
+	}
+
+	assert.NoError(t, testTask.Insert())
+	assert.NoError(t, myProject.Insert())
+	assert.NoError(t, myProject2.Insert())
+	assert.NoError(t, myProjectParser.Insert())
+
+	env := evergreen.GetEnvironment().Settings()
+	flags := evergreen.ServiceFlags{
+		PluginAdminPageDisabled: true,
+	}
+	assert.NoError(t, evergreen.SetServiceFlags(flags))
+
+	bbProj, ok1 := BbGetProject(env, testTask.Project, testTask.Version)
+	bbProj2, ok2 := BbGetProject(env, testTask2.Project, testTask2.Version)
+	assert.True(t, ok1)
+	assert.True(t, ok2)
+	assert.Equal(t, bbProj.TicketCreateProject, "BFG")
+	assert.Equal(t, bbProj2.TicketCreateProject, "ABC")
 }

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -757,7 +757,7 @@ func TestCreatedTicketByTaskPutHandlerParse(t *testing.T) {
 
 	plugins := evergreen.PluginConfig{
 		"buildbaron": {
-			"projects": map[string]evergreen.BuildBaronProject{
+			"projects": map[string]evergreen.BuildBaronSettings{
 				testProject: {
 					TaskAnnotationSettings: evergreen.AnnotationsSettings{
 						FileTicketWebHook: evergreen.WebHook{

--- a/service/ui.go
+++ b/service/ui.go
@@ -37,12 +37,11 @@ type UIServer struct {
 	// The root URL of the server, used in redirects for instance.
 	RootURL string
 
-	umconf             gimlet.UserMiddlewareConfiguration
-	Settings           evergreen.Settings
-	CookieStore        *sessions.CookieStore
-	clientConfig       *evergreen.ClientConfig
-	jiraHandler        thirdparty.JiraHandler
-	buildBaronProjects map[string]evergreen.BuildBaronProject
+	umconf       gimlet.UserMiddlewareConfiguration
+	Settings     evergreen.Settings
+	CookieStore  *sessions.CookieStore
+	clientConfig *evergreen.ClientConfig
+	jiraHandler  thirdparty.JiraHandler
 
 	hostCache map[string]hostCacheItem
 
@@ -89,16 +88,15 @@ func NewUIServer(env evergreen.Environment, queue amboy.Queue, home string, fo T
 	}
 
 	uis := &UIServer{
-		Settings:           *settings,
-		env:                env,
-		queue:              queue,
-		Home:               home,
-		clientConfig:       evergreen.GetEnvironment().ClientConfig(),
-		CookieStore:        sessions.NewCookieStore([]byte(settings.Ui.Secret)),
-		buildBaronProjects: plugin.BbGetConfig(settings),
-		render:             gimlet.NewHTMLRenderer(ropts),
-		renderText:         gimlet.NewTextRenderer(ropts),
-		jiraHandler:        thirdparty.NewJiraHandler(*settings.Jira.Export()),
+		Settings:     *settings,
+		env:          env,
+		queue:        queue,
+		Home:         home,
+		clientConfig: evergreen.GetEnvironment().ClientConfig(),
+		CookieStore:  sessions.NewCookieStore([]byte(settings.Ui.Secret)),
+		render:       gimlet.NewHTMLRenderer(ropts),
+		renderText:   gimlet.NewTextRenderer(ropts),
+		jiraHandler:  thirdparty.NewJiraHandler(*settings.Jira.Export()),
 		umconf: gimlet.UserMiddlewareConfiguration{
 			HeaderKeyName:  evergreen.APIKeyHeader,
 			HeaderUserName: evergreen.APIUserHeader,


### PR DESCRIPTION
[EVG-15212](https://jira.mongodb.org/browse/EVG-15212)

### Description 
Was observed [here](https://mongodb.slack.com/archives/C0V896UV8/p1630698656157000) that a user was unexpectedly seeing build baron UI panels showing up on all tasks regardless of whether or not they were failed or not.  Rolled back the change and tested locally, found that the UI panel was rendering due to a null pointer exception on the frontend.  Before the rollback a change was made to return a nil object in the case we are unable to retrieve the build baron config settings when rendering the UI panel config.  Change has been made to return a struct with enabled: false to prevent conf.enabled from throwing a null pointer exception when this occurs.  The initial EVG-15212 changes have also been un-reverted.
### Testing 
Checking out the old branch with this change showed the same HTML error where build baron panels were shown when they should not.  Added this change and tested locally and in staging and the issue was gone.