### PR TITLE
EVG-15405: Use merged parser project and project ref struct for properties that are shared between them

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1216,7 +1216,3 @@ func evaluateDependsOn(tse *tagSelectorEvaluator, tgse *tagSelectorEvaluator, vs
 	}
 	return newDeps, evalErrs
 }
-
-func (p *ParserProject) ShouldDeactivatePrevious() bool {
-	return utility.FromBoolPtr(p.DeactivatePrevious)
-}

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -54,33 +54,6 @@ func ParserProjectFindOneById(id string) (*ParserProject, error) {
 	return ParserProjectFindOne(ParserProjectById(id))
 }
 
-func ParserProjectFindOneByVersion(projectId string, version string) (*ParserProject, error) {
-	lookupVersion := false
-	if version == "" {
-		lastGoodVersion, err := FindVersionByLastKnownGoodConfig(projectId, -1)
-		if err != nil || lastGoodVersion == nil {
-			return nil, errors.Wrapf(err, "Unable to retrieve last good version for project '%s'", projectId)
-		}
-		version = lastGoodVersion.Id
-		lookupVersion = true
-	}
-	parserProject, err := ParserProjectFindOneById(version)
-	if err != nil {
-		grip.Debug(message.Fields{
-			"message":        "error retrieving parser project by version",
-			"project_id":     projectId,
-			"version":        version,
-			"lookup_version": lookupVersion,
-			"err":            err.Error(),
-		})
-		return nil, errors.Wrapf(err, "Error retrieving parser project for version '%s'", version)
-	}
-	if parserProject == nil {
-		return nil, errors.Errorf("Unable to find parser project for project '%s'", projectId)
-	}
-	return parserProject, nil
-}
-
 // ParserProjectFindOne finds a parser project with a given query.
 func ParserProjectFindOne(query db.Q) (*ParserProject, error) {
 	project := &ParserProject{}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -415,7 +415,7 @@ func (p *ProjectRef) GetMergedConfig(version string) *MergedProjectConfig {
 	if version == "" {
 		lastGoodVersion, err := FindVersionByLastKnownGoodConfig(p.Id, -1)
 		if err != nil || lastGoodVersion == nil {
-			return nil, errors.Wrapf(err, "Unable to retrieve last good version for project '%s'", p.Id)
+			return nil
 		}
 		version = lastGoodVersion.Id
 		lookupVersion = true

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -410,7 +410,7 @@ func (p *ProjectRef) GetPatchTriggerAlias(aliasName string) (patch.PatchTriggerD
 
 // MergeWithParserProject looks up the parser project with the given project ref id and modifies
 // the project ref scanning for any properties that can be set on both project ref and project parser.
-// Any values that are set at the project parser level will override the project ref settings in the returned struct.
+// Any values that are set at the project parser level will be set on the project ref.
 func (p *ProjectRef) MergeWithParserProject(version string) error {
 	flags, err := evergreen.GetServiceFlags()
 	if err != nil {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -412,13 +412,6 @@ func (p *ProjectRef) GetPatchTriggerAlias(aliasName string) (patch.PatchTriggerD
 // the project ref scanning for any properties that can be set on both project ref and project parser.
 // Any values that are set at the project parser level will be set on the project ref.
 func (p *ProjectRef) MergeWithParserProject(version string) error {
-	flags, err := evergreen.GetServiceFlags()
-	if err != nil {
-		return errors.Wrap(err, "error getting service flags")
-	}
-	if !flags.PluginAdminPageDisabled {
-		return nil
-	}
 	lookupVersion := false
 	if version == "" {
 		lastGoodVersion, err := FindVersionByLastKnownGoodConfig(p.Id, -1)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -408,6 +408,13 @@ func (p *ProjectRef) GetPatchTriggerAlias(aliasName string) (patch.PatchTriggerD
 // a merged project ref that scans for any properties that can be set on both project ref and project parser.
 // Any values that are set at the project parser level will override the project ref settings in the returned struct.
 func (p *ProjectRef) MergeWithParserProject(version string) (*ProjectRef, error) {
+	flags, err := evergreen.GetServiceFlags()
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting service flags")
+	}
+	if !flags.PluginAdminPageDisabled {
+		return p, nil
+	}
 	lookupVersion := false
 	if version == "" {
 		lastGoodVersion, err := FindVersionByLastKnownGoodConfig(p.Id, -1)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -436,14 +436,16 @@ func (p *ProjectRef) GetMergedConfig(version string) *MergedProjectConfig {
 	perfEnabled := p.PerfEnabled
 	deactivatePrevious := p.DeactivatePrevious
 	taskAnnotationSettings := p.TaskAnnotationSettings
-	if parserProject.PerfEnabled != nil {
-		perfEnabled = parserProject.PerfEnabled
-	}
-	if parserProject.DeactivatePrevious != nil {
-		perfEnabled = parserProject.DeactivatePrevious
-	}
-	if parserProject.TaskAnnotationSettings != nil {
-		taskAnnotationSettings = *parserProject.TaskAnnotationSettings
+	if parserProject != nil {
+		if parserProject.PerfEnabled != nil {
+			perfEnabled = parserProject.PerfEnabled
+		}
+		if parserProject.DeactivatePrevious != nil {
+			perfEnabled = parserProject.DeactivatePrevious
+		}
+		if parserProject.TaskAnnotationSettings != nil {
+			taskAnnotationSettings = *parserProject.TaskAnnotationSettings
+		}
 	}
 	mergedConfig.PerfEnabled = perfEnabled
 	mergedConfig.DeactivatePrevious = deactivatePrevious

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -76,14 +76,14 @@ func TestMergeWithParserProject(t *testing.T) {
 	}
 	assert.NoError(t, projectRef.Insert())
 	assert.NoError(t, parserProject.Insert())
-	mergedProject, err := projectRef.MergeWithParserProject("v1")
+	err := projectRef.MergeWithParserProject("v1")
 	assert.NoError(t, err)
-	require.NotNil(t, mergedProject)
-	assert.Equal(t, "ident", mergedProject.Id)
+	require.NotNil(t, projectRef)
+	assert.Equal(t, "ident", projectRef.Id)
 
-	assert.True(t, *mergedProject.DeactivatePrevious)
-	assert.True(t, *mergedProject.PerfEnabled)
-	assert.Equal(t, "random2", mergedProject.TaskAnnotationSettings.FileTicketWebHook.Endpoint)
+	assert.True(t, *projectRef.DeactivatePrevious)
+	assert.True(t, *projectRef.PerfEnabled)
+	assert.Equal(t, "random2", projectRef.TaskAnnotationSettings.FileTicketWebHook.Endpoint)
 }
 
 func TestFindMergedProjectRef(t *testing.T) {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -50,42 +50,6 @@ func TestFindOneProjectRef(t *testing.T) {
 	assert.Equal(projectRefFromDB.DefaultLogger, "buildlogger")
 }
 
-func TestMergeWithParserProject(t *testing.T) {
-	require.NoError(t, db.ClearCollections(ProjectRefCollection, ParserProjectCollection),
-		"Error clearing collection")
-
-	projectRef := &ProjectRef{
-		Owner:              "mongodb",
-		Id:                 "ident",
-		PerfEnabled:        utility.TruePtr(),
-		DeactivatePrevious: utility.FalsePtr(),
-		TaskAnnotationSettings: evergreen.AnnotationsSettings{
-			FileTicketWebHook: evergreen.WebHook{
-				Endpoint: "random1",
-			},
-		},
-	}
-	parserProject := &ParserProject{
-		Id:                 "v1",
-		DeactivatePrevious: utility.TruePtr(),
-		TaskAnnotationSettings: &evergreen.AnnotationsSettings{
-			FileTicketWebHook: evergreen.WebHook{
-				Endpoint: "random2",
-			},
-		},
-	}
-	assert.NoError(t, projectRef.Insert())
-	assert.NoError(t, parserProject.Insert())
-	err := projectRef.MergeWithParserProject("v1")
-	assert.NoError(t, err)
-	require.NotNil(t, projectRef)
-	assert.Equal(t, "ident", projectRef.Id)
-
-	assert.True(t, *projectRef.DeactivatePrevious)
-	assert.True(t, *projectRef.PerfEnabled)
-	assert.Equal(t, "random2", projectRef.TaskAnnotationSettings.FileTicketWebHook.Endpoint)
-}
-
 func TestFindMergedProjectRef(t *testing.T) {
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection),
 		"Error clearing collection")
@@ -1771,4 +1735,40 @@ func TestPointers(t *testing.T) {
 	assert.False(t, utility.FromBoolTPtr(pointerRef.PtrBool))
 	assert.NotNil(t, pointerRef.PtrStruct)
 	assert.True(t, pointerRef.PtrStruct.ShouldGitClone())
+}
+
+func TestMergeWithParserProject(t *testing.T) {
+	require.NoError(t, db.ClearCollections(ProjectRefCollection, ParserProjectCollection),
+		"Error clearing collection")
+
+	projectRef := &ProjectRef{
+		Owner:              "mongodb",
+		Id:                 "ident",
+		PerfEnabled:        utility.TruePtr(),
+		DeactivatePrevious: utility.FalsePtr(),
+		TaskAnnotationSettings: evergreen.AnnotationsSettings{
+			FileTicketWebHook: evergreen.WebHook{
+				Endpoint: "random1",
+			},
+		},
+	}
+	parserProject := &ParserProject{
+		Id:                 "version1",
+		DeactivatePrevious: utility.TruePtr(),
+		TaskAnnotationSettings: &evergreen.AnnotationsSettings{
+			FileTicketWebHook: evergreen.WebHook{
+				Endpoint: "random2",
+			},
+		},
+	}
+	assert.NoError(t, projectRef.Insert())
+	assert.NoError(t, parserProject.Insert())
+	err := projectRef.MergeWithParserProject("version1")
+	assert.NoError(t, err)
+	require.NotNil(t, projectRef)
+	assert.Equal(t, "ident", projectRef.Id)
+
+	assert.True(t, *projectRef.DeactivatePrevious)
+	assert.True(t, *projectRef.PerfEnabled)
+	assert.Equal(t, "random2", projectRef.TaskAnnotationSettings.FileTicketWebHook.Endpoint)
 }

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -165,7 +165,11 @@ func IsWebhookConfigured(project string, version string) (evergreen.WebHook, boo
 		if err != nil || projectRef == nil {
 			return evergreen.WebHook{}, false, errors.Errorf("Unable to find merged project ref for project %s", project)
 		}
-		webHook = projectRef.GetProjectParserMergedProjectRef(version).TaskAnnotationSettings.FileTicketWebHook
+		mergedProjectRef, err := projectRef.MergeWithParserProject(version)
+		if err != nil || mergedProjectRef == nil {
+			return evergreen.WebHook{}, false, errors.Errorf("Unable to merge parser project with project ref %s", project)
+		}
+		webHook = mergedProjectRef.TaskAnnotationSettings.FileTicketWebHook
 	} else {
 		bbProject, _ := BbGetProject(evergreen.GetEnvironment().Settings(), project)
 		webHook = bbProject.TaskAnnotationSettings.FileTicketWebHook

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -165,7 +165,7 @@ func IsWebhookConfigured(project string, version string) (evergreen.WebHook, boo
 		if err != nil || projectRef == nil {
 			return evergreen.WebHook{}, false, errors.Errorf("Unable to find merged project ref for project %s", project)
 		}
-		webHook = projectRef.GetMergedConfig(version).TaskAnnotationSettings.FileTicketWebHook
+		webHook = projectRef.GetProjectParserMergedProjectRef(version).TaskAnnotationSettings.FileTicketWebHook
 	} else {
 		bbProject, _ := BbGetProject(evergreen.GetEnvironment().Settings(), project)
 		webHook = bbProject.TaskAnnotationSettings.FileTicketWebHook

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -165,11 +165,11 @@ func IsWebhookConfigured(project string, version string) (evergreen.WebHook, boo
 		if err != nil || projectRef == nil {
 			return evergreen.WebHook{}, false, errors.Errorf("Unable to find merged project ref for project %s", project)
 		}
-		mergedProjectRef, err := projectRef.MergeWithParserProject(version)
-		if err != nil || mergedProjectRef == nil {
+		err = projectRef.MergeWithParserProject(version)
+		if err != nil {
 			return evergreen.WebHook{}, false, errors.Errorf("Unable to merge parser project with project ref %s", project)
 		}
-		webHook = mergedProjectRef.TaskAnnotationSettings.FileTicketWebHook
+		webHook = projectRef.TaskAnnotationSettings.FileTicketWebHook
 	} else {
 		bbProject, _ := BbGetProject(evergreen.GetEnvironment().Settings(), project)
 		webHook = bbProject.TaskAnnotationSettings.FileTicketWebHook

--- a/plugin/perf.go
+++ b/plugin/perf.go
@@ -71,7 +71,7 @@ func isPerfEnabled(projectRef model.ProjectRef, projects []string) bool {
 		return false
 	}
 	if flags.PluginAdminPageDisabled {
-		return model.IsPerfEnabledForProject(projectRef.Id)
+		return utility.FromBoolPtr(projectRef.GetMergedConfig("").PerfEnabled)
 	} else {
 		return utility.StringSliceContains(projects, projectRef.Id) || utility.StringSliceContains(projects, projectRef.Identifier)
 	}

--- a/plugin/perf.go
+++ b/plugin/perf.go
@@ -71,7 +71,7 @@ func isPerfEnabled(projectRef model.ProjectRef, projects []string) bool {
 		return false
 	}
 	if flags.PluginAdminPageDisabled {
-		return utility.FromBoolPtr(projectRef.GetMergedConfig("").PerfEnabled)
+		return model.IsPerfEnabledForProject(projectRef.Id)
 	} else {
 		return utility.StringSliceContains(projects, projectRef.Id) || utility.StringSliceContains(projects, projectRef.Identifier)
 	}

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -203,12 +203,6 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projectParser, err := model.ParserProjectFindOneByVersion(t.Project, t.Version)
-	if err != nil {
-		as.LoggedError(w, r, http.StatusInternalServerError, err)
-		// Not returning here in case of legacy versions that do not have a parser project
-	}
-
 	// For a single-host task group, if a task fails, block and dequeue later tasks in that group.
 	// Call before MarkEnd so the version is marked finished when this is the last task in the version
 	// to finish
@@ -229,10 +223,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// mark task as finished
-	deactivatePrevious := projectRef.ShouldDeactivatePrevious()
-	if projectParser != nil && projectParser.ShouldDeactivatePrevious() {
-		deactivatePrevious = true
-	}
+	deactivatePrevious := utility.FromBoolPtr(projectRef.GetMergedConfig(t.Version).DeactivatePrevious)
 	err = model.MarkEnd(t, APIServerLockTitle, finishTime, details, deactivatePrevious)
 	if err != nil {
 		err = errors.Wrapf(err, "Error calling mark finish on task %v", t.Id)

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -223,7 +223,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// mark task as finished
-	deactivatePrevious := utility.FromBoolPtr(projectRef.GetMergedConfig(t.Version).DeactivatePrevious)
+	deactivatePrevious := utility.FromBoolPtr(projectRef.GetProjectParserMergedProjectRef(t.Version).DeactivatePrevious)
 	err = model.MarkEnd(t, APIServerLockTitle, finishTime, details, deactivatePrevious)
 	if err != nil {
 		err = errors.Wrapf(err, "Error calling mark finish on task %v", t.Id)

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -223,13 +223,13 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// mark task as finished
-	mergedProjectRef, err := projectRef.MergeWithParserProject(t.Version)
-	if err != nil || mergedProjectRef == nil {
+	err = projectRef.MergeWithParserProject(t.Version)
+	if err != nil {
 		err = errors.Wrapf(err, "Unable to merge parser project with project ref %s", t.Project)
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	deactivatePrevious := utility.FromBoolPtr(mergedProjectRef.DeactivatePrevious)
+	deactivatePrevious := utility.FromBoolPtr(projectRef.DeactivatePrevious)
 	err = model.MarkEnd(t, APIServerLockTitle, finishTime, details, deactivatePrevious)
 	if err != nil {
 		err = errors.Wrapf(err, "Error calling mark finish on task %v", t.Id)


### PR DESCRIPTION
[EVG-15405](https://jira.mongodb.org/browse/EVG-15405)

### Description 
With the introduction of the Expose Configuration Options to Users project, there are many places where we retrieve a parser project, check if certain properties are defined, and if not default to the settings on the project ref.  Initially it seemed like it would be cleaner to merge the parser project ref into a single entity on the backend, and refer to this merged struct for all project settings related operations.  The work involved in this however would likely require a larger refactoring of both our database schemas and would fundamentally change the way we view projects from a backend standpoint which is out of scope for this project.  

To improve code cleanliness and readability, a new struct has been introduced that holds all of the shared properties between a project ref and a parser project, and when these properties' configs are required elsewhere in the project, we return this merged struct which will have the appropriate value (whether it comes from parser project or project ref).