### PR TITLE
EVG-15263: Do not expose internal cedar test results fields via task API

### DIFF
--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -74,8 +74,8 @@ type APITask struct {
 	CanSync                 bool                `json:"can_sync,omitempty"`
 	SyncAtEndOpts           APISyncAtEndOptions `json:"sync_at_end_opts"`
 	Ami                     *string             `json:"ami"`
-	HasCedarResults         bool                `json:"has_cedar_results"`
-	CedarResultsFailed      bool                `json:"cedar_results_failed"`
+	HasCedarResults         bool                `json:"-"`
+	CedarResultsFailed      bool                `json:"-"`
 	MustHaveResults         bool                `json:"must_have_test_results"`
 	BaseTask                APIBaseTaskInfo     `json:"base_task"`
 }

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -74,10 +74,12 @@ type APITask struct {
 	CanSync                 bool                `json:"can_sync,omitempty"`
 	SyncAtEndOpts           APISyncAtEndOptions `json:"sync_at_end_opts"`
 	Ami                     *string             `json:"ami"`
-	HasCedarResults         bool                `json:"-"`
-	CedarResultsFailed      bool                `json:"-"`
 	MustHaveResults         bool                `json:"must_have_test_results"`
 	BaseTask                APIBaseTaskInfo     `json:"base_task"`
+	// These fields are used by graphql gen, but do not need to be exposed
+	// via Evergreen's user-facing API.
+	HasCedarResults    bool `json:"-"`
+	CedarResultsFailed bool `json:"-"`
 }
 
 type APIAbortInfo struct {


### PR DESCRIPTION
EVG-15263: https://jira.mongodb.org/browse/EVG-15263
