### PR TITLE
EVG-15488: fix pod CPU architecture constraint

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -261,7 +261,7 @@ func exportECSPodArch(arch pod.Arch) string {
 }
 
 const (
-	ecsCPUArchConstraint = "ecs.cpu-architecture"
+	ecsCPUArchConstraint = "attribute:ecs.cpu-architecture"
 )
 
 // exportECSPodExecutionOptions exports the ECS configuration into

--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -406,7 +406,7 @@ func TestExportECSPodCreationOptions(t *testing.T) {
 		assert.Equal(t, settings.Providers.AWS.Pod.ECS.AWSVPC.SecurityGroups, opts.ExecutionOpts.AWSVPCOpts.SecurityGroups)
 		require.NotZero(t, opts.ExecutionOpts.PlacementOpts)
 		require.Len(t, opts.ExecutionOpts.PlacementOpts.InstanceFilters, 1)
-		assert.Equal(t, "ecs.cpu-architecture == x86_64", opts.ExecutionOpts.PlacementOpts.InstanceFilters[0])
+		assert.Equal(t, "attribute:ecs.cpu-architecture == x86_64", opts.ExecutionOpts.PlacementOpts.InstanceFilters[0])
 
 		assert.True(t, strings.HasPrefix(utility.FromStringPtr(opts.Name), settings.Providers.AWS.Pod.ECS.TaskDefinitionPrefix))
 		assert.Contains(t, utility.FromStringPtr(opts.Name), p.ID)

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -308,7 +308,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
   }
 
   $scope.deleteAWSVPCSubnet = function (index) {
-    $scope.Settings.providers.aws.pod.ecs.awsvpc.subnets.split(index, 1);
+    $scope.Settings.providers.aws.pod.ecs.awsvpc.subnets.splice(index, 1);
   }
 
   $scope.addAWSVPCSecurityGroup = function () {
@@ -376,7 +376,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
   }
 
   $scope.deleteAWSVPCSecurityGroup = function (index) {
-    $scope.Settings.providers.aws.pod.ecs.awsvpc.security_groups.split(index, 1);
+    $scope.Settings.providers.aws.pod.ecs.awsvpc.security_groups.splice(index, 1);
   }
 
   $scope.addECSCluster = function () {


### PR DESCRIPTION
JIra: https://jira.mongodb.org/browse/EVG-15488

### Description 
* Fix the placement constraint string to enforce that a pod runs on a host with a particular architecture.
* Fix a bug in the admin page where the delete buttons didn't work for AWSVPC subnets and security groups.