### PR TITLE
EVG-15513: Attach child project identifier to patch trigger alias

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -504,12 +504,13 @@ type ComplexityRoot struct {
 	}
 
 	PatchTriggerAlias struct {
-		Alias          func(childComplexity int) int
-		ChildProject   func(childComplexity int) int
-		ParentAsModule func(childComplexity int) int
-		Status         func(childComplexity int) int
-		TaskSpecifiers func(childComplexity int) int
-		VariantsTasks  func(childComplexity int) int
+		Alias                  func(childComplexity int) int
+		ChildProject           func(childComplexity int) int
+		ChildProjectIdentifier func(childComplexity int) int
+		ParentAsModule         func(childComplexity int) int
+		Status                 func(childComplexity int) int
+		TaskSpecifiers         func(childComplexity int) int
+		VariantsTasks          func(childComplexity int) int
 	}
 
 	Patches struct {
@@ -3389,6 +3390,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PatchTriggerAlias.ChildProject(childComplexity), true
+
+	case "PatchTriggerAlias.childProjectIdentifier":
+		if e.complexity.PatchTriggerAlias.ChildProjectIdentifier == nil {
+			break
+		}
+
+		return e.complexity.PatchTriggerAlias.ChildProjectIdentifier(childComplexity), true
 
 	case "PatchTriggerAlias.parentAsModule":
 		if e.complexity.PatchTriggerAlias.ParentAsModule == nil {
@@ -6802,6 +6810,7 @@ type ChildPatchAlias {
 type PatchTriggerAlias {
   alias: String!
   childProject: String!
+  childProjectIdentifier: String!
   taskSpecifiers: [TaskSpecifier]
   status: String
   parentAsModule: String
@@ -18335,6 +18344,40 @@ func (ec *executionContext) _PatchTriggerAlias_childProject(ctx context.Context,
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.ChildProject, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PatchTriggerAlias_childProjectIdentifier(ctx context.Context, field graphql.CollectedField, obj *model.APIPatchTriggerDefinition) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "PatchTriggerAlias",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ChildProjectIdentifier, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -35492,6 +35535,11 @@ func (ec *executionContext) _PatchTriggerAlias(ctx context.Context, sel ast.Sele
 			}
 		case "childProject":
 			out.Values[i] = ec._PatchTriggerAlias_childProject(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "childProjectIdentifier":
+			out.Values[i] = ec._PatchTriggerAlias_childProjectIdentifier(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1171,10 +1171,17 @@ func (r *patchResolver) PatchTriggerAliases(ctx context.Context, obj *restModel.
 				Tasks: utility.ToStringPtrSlice(vt.Tasks),
 			})
 		}
+
+		identifier, err := model.GetIdentifierForProject(alias.ChildProject)
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Problem getting child project identifier: %v", err.Error()))
+		}
+
 		aliases = append(aliases, &restModel.APIPatchTriggerDefinition{
-			Alias:         utility.ToStringPtr(alias.Alias),
-			ChildProject:  utility.ToStringPtr(alias.ChildProject),
-			VariantsTasks: variantsTasks,
+			Alias:                  utility.ToStringPtr(alias.Alias),
+			ChildProject:           utility.ToStringPtr(alias.ChildProject),
+			ChildProjectIdentifier: utility.ToStringPtr(identifier),
+			VariantsTasks:          variantsTasks,
 		})
 	}
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -532,6 +532,7 @@ type ChildPatchAlias {
 type PatchTriggerAlias {
   alias: String!
   childProject: String!
+  childProjectIdentifier: String!
   taskSpecifiers: [TaskSpecifier]
   status: String
   parentAsModule: String

--- a/graphql/tests/patch/queries/patch-trigger-aliases.graphql
+++ b/graphql/tests/patch/queries/patch-trigger-aliases.graphql
@@ -3,6 +3,7 @@
     patchTriggerAliases {
       alias
       childProject
+      childProjectIdentifier
       variantsTasks {
         name
         tasks

--- a/graphql/tests/patch/results.json
+++ b/graphql/tests/patch/results.json
@@ -270,6 +270,7 @@
               {
                 "alias": "test-alias",
                 "childProject": "spruce",
+                "childProjectIdentifier": "spruce",
                 "variantsTasks": [
                   {
                     "name": "ubuntu1804",

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -74,12 +74,13 @@ func (t *APITriggerDefinition) BuildFromService(h interface{}) error {
 }
 
 type APIPatchTriggerDefinition struct {
-	Alias          *string            `json:"alias"`
-	ChildProject   *string            `json:"child_project"`
-	TaskSpecifiers []APITaskSpecifier `json:"task_specifiers"`
-	Status         *string            `json:"status,omitempty"`
-	ParentAsModule *string            `json:"parent_as_module,omitempty"`
-	VariantsTasks  []VariantTask      `json:"variants_tasks,omitempty"`
+	Alias                  *string            `json:"alias"`
+	ChildProject           *string            `json:"child_project"`
+	ChildProjectIdentifier *string            `json:"child_project_identifier"`
+	TaskSpecifiers         []APITaskSpecifier `json:"task_specifiers"`
+	Status                 *string            `json:"status,omitempty"`
+	ParentAsModule         *string            `json:"parent_as_module,omitempty"`
+	VariantsTasks          []VariantTask      `json:"variants_tasks,omitempty"`
 }
 
 func (t *APIPatchTriggerDefinition) BuildFromService(h interface{}) error {


### PR DESCRIPTION
[EVG-15513](https://jira.mongodb.org/browse/EVG-15513)

### Description 
- Add `childProjectIdentifier` field to be returned with patch trigger aliases

### Testing 
- Update unit test
- Tested on staging & playground