### PR TITLE
EVG-15479, EVG-15495: remove GO_BIN_PATH and fix linter PATH

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,27 +19,20 @@ lobsterTempDir := $(abspath $(buildDir))/lobster-temp
 # end project configuration
 
 # start go runtime settings
-ifneq (,$(GO_BIN_PATH))
-  gobin := $(GO_BIN_PATH)
- else
-  gobin := $(shell if [ -x /opt/golang/go1.16/bin/go ]; then echo /opt/golang/go1.16/bin/go; fi)
-  ifeq (,$(gobin))
-    gobin := go
-  endif
+gobin := go
+ifneq (,$(GOROOT))
+gobin := $(GOROOT)/bin/go
 endif
 
-gopath := $(GOPATH)
-gocache := $(abspath $(buildDir)/.cache)
 ifeq ($(OS),Windows_NT)
-	ifneq (,$(gopath))
-		gopath := $(shell cygpath -m $(gopath))
-	endif
-	gocache := $(shell cygpath -m $(gocache))
+gobin := $(shell cygpath $(gobin))
+export GOCACHE := $(shell cygpath -m $(abspath $(buildDir)/.cache))
+export GOLANGCI_LINT_CACHE := $(shell cygpath -m $(abspath $(buildDir)/.lint-cache))
+export GOPATH := $(shell cygpath -m $(GOPATH))
+export GOROOT := $(shell cygpath -m $(GOROOT))
 endif
 
 export GO111MODULE := off
-export GOPATH := $(gopath)
-export GOCACHE := $(gocache)
 # end go runtime settings
 
 
@@ -520,9 +513,13 @@ $(buildDir)/output.%.coverage:$(tmpDir) .FORCE
 	$(testRunEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && go tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 #  targets to generate gotest output from the linter.
-# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter $(testSrcFiles) .FORCE
-	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin="$(buildDir)/golangci-lint" --lintArgs="--timeout=2m" --customLinters="$(gopath)/bin/evg-lint -set_exit_status" --packages='$*'
+ifneq (go,$(gobin))
+# We have to handle the PATH specially for linting in CI, because if the PATH has a different version of the Go
+# binary in it, the linter won't work properly.
+lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
+endif
+$(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
 # end test and coverage artifacts
@@ -579,4 +576,4 @@ check-mongod:mongodb/.get-mongodb
 # configure special (and) phony targets
 .FORCE:
 .PHONY:$(phony) .FORCE
-.DEFAULT_GOAL:build
+.DEFAULT_GOAL := build

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -212,7 +212,6 @@ functions:
         DOCKER_HOST: ${docker_host}
         EVERGREEN_ALL: "true"
         GOARCH: ${goarch}
-        GO_BIN_PATH: ${gobin}
         GOOS: ${goos}
         GOPATH: ${workdir}/gopath
         GOROOT: ${goroot}
@@ -324,7 +323,6 @@ functions:
         command: make parse-host-file
         env:
           HOST_FILE: spawned_hosts.json
-          GO_BIN_PATH: ${gobin}
           GOROOT: ${goroot}
     - command: expansions.update
       params:
@@ -594,7 +592,6 @@ tasks:
             LOCAL_PATH: clients
             EXCLUDE_PATTERN: .cache
             REMOTE_PATH: evergreen/clients/${project}/${revision}
-            GO_BIN_PATH: ${gobin}
             GOPATH: ${workdir}/gopath
             GOROOT: ${goroot}
   - name: verify-agent-version-update
@@ -644,7 +641,6 @@ buildvariants:
       goos: linux
       goarch: amd64
       nodebin: /opt/node/bin
-      gobin: /opt/golang/go1.16/bin/go
       goroot: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
     tasks:
@@ -664,7 +660,6 @@ buildvariants:
       - archlinux-new-small
       - archlinux-new-large
     expansions:
-      gobin: /opt/golang/go1.16/bin/go
       goroot: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
       race_detector: true
@@ -679,7 +674,6 @@ buildvariants:
       - archlinux-new-small
       - archlinux-new-large
     expansions:
-      gobin: /opt/golang/go1.16/bin/go
       goroot: /opt/golang/go1.16
     tasks:
       - name: generate-lint
@@ -691,7 +685,6 @@ buildvariants:
       - windows-64-vs2017-large
     expansions:
       disable_coverage: yes
-      gobin: /cygdrive/c/golang/go1.16/bin/go
       goroot: c:/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.3.zip
       extension: ".exe"
@@ -710,7 +703,6 @@ buildvariants:
       xc_build: yes
       goarch: arm64
       goos: linux
-      gobin: /opt/golang/go1.16/bin/go
       goroot: /opt/golang/go1.16
       mongodb_url: https://downloads.mongodb.com/linux/mongodb-linux-arm64-enterprise-ubuntu1604-4.0.3.tgz
     tasks:
@@ -723,7 +715,6 @@ buildvariants:
       - macos-1014
     expansions:
       disable_coverage: yes
-      gobin: /opt/golang/go1.16/bin/go
       goroot: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     tasks:


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-15479
https://jira.mongodb.org/browse/EVG-15495

* Remove GO_BIN_PATH. CI tests now depend on GOROOT to tell them which Go version to use and which Go binary to use.
* Set the GOLANGCI_LINT_CACHE, which is used to control where golangci-lint caches information. By default, golangci-lint will use the user's cache directory (usually in the home directory). This prevents the CI linter from writing outside of the working directory.
* Fix setting the PATH variable for the linter.
* Clean up and standardize the makefile.