### PR TITLE
EVG-15459 Resolve Task Stats in mongodb instead of go

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -244,6 +244,8 @@ models:
         resolver: true
   BuildVariantTuple:
     model: github.com/evergreen-ci/evergreen/model/task.BuildVariantTuple
+  StatusCount:
+    model: github.com/evergreen-ci/evergreen/model/task.StatusCount
   TaskLogs:
     fields:
       eventLogs:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1245,7 +1245,7 @@ type UserResolver interface {
 type VersionResolver interface {
 	Status(ctx context.Context, obj *model.APIVersion) (string, error)
 
-	TaskStatusCounts(ctx context.Context, obj *model.APIVersion, options *BuildVariantOptions) ([]*StatusCount, error)
+	TaskStatusCounts(ctx context.Context, obj *model.APIVersion, options *BuildVariantOptions) ([]*task.StatusCount, error)
 	BuildVariants(ctx context.Context, obj *model.APIVersion, options *BuildVariantOptions) ([]*GroupedBuildVariant, error)
 	IsPatch(ctx context.Context, obj *model.APIVersion) (bool, error)
 	Patch(ctx context.Context, obj *model.APIVersion) (*model.APIPatch, error)
@@ -23239,7 +23239,7 @@ func (ec *executionContext) _SpruceConfig_spawnHost(ctx context.Context, field g
 	return ec.marshalNSpawnHostConfig2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPISpawnHostConfig(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _StatusCount_status(ctx context.Context, field graphql.CollectedField, obj *StatusCount) (ret graphql.Marshaler) {
+func (ec *executionContext) _StatusCount_status(ctx context.Context, field graphql.CollectedField, obj *task.StatusCount) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -23273,7 +23273,7 @@ func (ec *executionContext) _StatusCount_status(ctx context.Context, field graph
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _StatusCount_count(ctx context.Context, field graphql.CollectedField, obj *StatusCount) (ret graphql.Marshaler) {
+func (ec *executionContext) _StatusCount_count(ctx context.Context, field graphql.CollectedField, obj *task.StatusCount) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -30239,9 +30239,9 @@ func (ec *executionContext) _Version_taskStatusCounts(ctx context.Context, field
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.([]*StatusCount)
+	res := resTmp.([]*task.StatusCount)
 	fc.Result = res
-	return ec.marshalOStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐStatusCountᚄ(ctx, field.Selections, res)
+	return ec.marshalOStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐStatusCountᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Version_buildVariants(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
@@ -37075,7 +37075,7 @@ func (ec *executionContext) _SpruceConfig(ctx context.Context, sel ast.Selection
 
 var statusCountImplementors = []string{"StatusCount"}
 
-func (ec *executionContext) _StatusCount(ctx context.Context, sel ast.SelectionSet, obj *StatusCount) graphql.Marshaler {
+func (ec *executionContext) _StatusCount(ctx context.Context, sel ast.SelectionSet, obj *task.StatusCount) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, statusCountImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -40953,11 +40953,11 @@ func (ec *executionContext) unmarshalNSpawnVolumeInput2githubᚗcomᚋevergreen�
 	return ec.unmarshalInputSpawnVolumeInput(ctx, v)
 }
 
-func (ec *executionContext) marshalNStatusCount2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐStatusCount(ctx context.Context, sel ast.SelectionSet, v StatusCount) graphql.Marshaler {
+func (ec *executionContext) marshalNStatusCount2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐStatusCount(ctx context.Context, sel ast.SelectionSet, v task.StatusCount) graphql.Marshaler {
 	return ec._StatusCount(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐStatusCount(ctx context.Context, sel ast.SelectionSet, v *StatusCount) graphql.Marshaler {
+func (ec *executionContext) marshalNStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐStatusCount(ctx context.Context, sel ast.SelectionSet, v *task.StatusCount) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "must not be null")
@@ -43243,7 +43243,7 @@ func (ec *executionContext) marshalOSpruceConfig2ᚖgithubᚗcomᚋevergreenᚑc
 	return ec._SpruceConfig(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalOStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐStatusCountᚄ(ctx context.Context, sel ast.SelectionSet, v []*StatusCount) graphql.Marshaler {
+func (ec *executionContext) marshalOStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐStatusCountᚄ(ctx context.Context, sel ast.SelectionSet, v []*task.StatusCount) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -43270,7 +43270,7 @@ func (ec *executionContext) marshalOStatusCount2ᚕᚖgithubᚗcomᚋevergreen�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐStatusCount(ctx, sel, v[i])
+			ret[i] = ec.marshalNStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐStatusCount(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -216,11 +216,6 @@ type SpawnVolumeInput struct {
 	Host             *string    `json:"host"`
 }
 
-type StatusCount struct {
-	Status string `json:"status"`
-	Count  int    `json:"count"`
-}
-
 type Subscriber struct {
 	GithubPRSubscriber    *model.APIGithubPRSubscriber    `json:"githubPRSubscriber"`
 	GithubCheckSubscriber *model.APIGithubCheckSubscriber `json:"githubCheckSubscriber"`

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1109,7 +1109,8 @@ func (r *patchResolver) TaskStatuses(ctx context.Context, obj *restModel.APIPatc
 		{Key: task.DisplayNameKey, Order: 1},
 	}
 	opts := data.TaskFilterOptions{
-		Sorts: defaultSort,
+		Sorts:            defaultSort,
+		IncludeBaseTasks: false,
 	}
 	tasks, _, err := r.sc.FindTasksByVersion(*obj.Id, opts)
 	if err != nil {
@@ -1285,8 +1286,9 @@ func (r *queryResolver) Patch(ctx context.Context, id string) (*restModel.APIPat
 	if evergreen.IsFinishedPatchStatus(*patch.Status) {
 		failedAndAbortedStatuses := append(evergreen.TaskFailureStatuses, evergreen.TaskAborted)
 		opts := data.TaskFilterOptions{
-			Statuses:        failedAndAbortedStatuses,
-			FieldsToProject: []string{task.DisplayStatusKey},
+			Statuses:         failedAndAbortedStatuses,
+			FieldsToProject:  []string{task.DisplayStatusKey},
+			IncludeBaseTasks: false,
 		}
 		tasks, _, err := r.sc.FindTasksByVersion(id, opts)
 		if err != nil {
@@ -1516,13 +1518,14 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sorts []
 		}
 	}
 	opts := data.TaskFilterOptions{
-		Statuses:     statuses,
-		BaseStatuses: baseStatuses,
-		Variants:     []string{variantParam},
-		TaskNames:    []string{taskNameParam},
-		Page:         pageParam,
-		Limit:        limitParam,
-		Sorts:        taskSorts,
+		Statuses:         statuses,
+		BaseStatuses:     baseStatuses,
+		Variants:         []string{variantParam},
+		TaskNames:        []string{taskNameParam},
+		Page:             pageParam,
+		Limit:            limitParam,
+		Sorts:            taskSorts,
+		IncludeBaseTasks: true,
 	}
 	tasks, count, err := r.sc.FindTasksByVersion(patchID, opts)
 	if err != nil {
@@ -2252,6 +2255,7 @@ func (r *mutationResolver) ScheduleUndispatchedBaseTasks(ctx context.Context, pa
 	opts := data.TaskFilterOptions{
 		Statuses:              evergreen.TaskFailureStatuses,
 		IncludeExecutionTasks: true,
+		IncludeBaseTasks:      false,
 	}
 	tasks, _, err := r.sc.FindTasksByVersion(patchID, opts)
 	if err != nil {
@@ -3308,7 +3312,9 @@ func (r *versionResolver) TaskStatuses(ctx context.Context, v *restModel.APIVers
 		{Key: task.DisplayNameKey, Order: 1},
 	}
 	opts := data.TaskFilterOptions{
-		Sorts: defaultSort,
+		Sorts:            defaultSort,
+		IncludeBaseTasks: false,
+		FieldsToProject:  []string{task.DisplayStatusKey},
 	}
 	tasks, _, err := r.sc.FindTasksByVersion(*v.Id, opts)
 	if err != nil {
@@ -3326,7 +3332,9 @@ func (r *versionResolver) BaseTaskStatuses(ctx context.Context, v *restModel.API
 		{Key: task.DisplayNameKey, Order: 1},
 	}
 	opts := data.TaskFilterOptions{
-		Sorts: defaultSort,
+		Sorts:            defaultSort,
+		IncludeBaseTasks: false,
+		FieldsToProject:  []string{task.DisplayStatusKey},
 	}
 	tasks, _, err := r.sc.FindTasksByVersion(baseVersion.Id, opts)
 	if err != nil {
@@ -3341,11 +3349,12 @@ func (r *versionResolver) TaskStatusCounts(ctx context.Context, v *restModel.API
 		{Key: task.DisplayNameKey, Order: 1},
 	}
 	opts := data.TaskFilterOptions{
-		Statuses:        options.Statuses,
-		Variants:        options.Variants,
-		TaskNames:       options.Tasks,
-		Sorts:           defaultSort,
-		FieldsToProject: []string{task.DisplayStatusKey},
+		Statuses:         options.Statuses,
+		Variants:         options.Variants,
+		TaskNames:        options.Tasks,
+		Sorts:            defaultSort,
+		FieldsToProject:  []string{task.DisplayStatusKey},
+		IncludeBaseTasks: false,
 	}
 
 	tasks, _, err := r.sc.FindTasksByVersion(*v.Id, opts)
@@ -3387,7 +3396,8 @@ func (r *versionResolver) BuildVariants(ctx context.Context, v *restModel.APIVer
 			{Key: task.DisplayNameKey, Order: 1},
 		}
 		opts := data.TaskFilterOptions{
-			Sorts: defaultSort,
+			Sorts:            defaultSort,
+			IncludeBaseTasks: false,
 		}
 		tasks, _, err := r.sc.FindTasksByVersion(*v.Id, opts)
 		if err != nil {
@@ -3519,8 +3529,9 @@ func (r *versionResolver) BaseVersionID(ctx context.Context, obj *restModel.APIV
 func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion) (string, error) {
 	failedAndAbortedStatuses := append(evergreen.TaskFailureStatuses, evergreen.TaskAborted)
 	opts := data.TaskFilterOptions{
-		Statuses:        failedAndAbortedStatuses,
-		FieldsToProject: []string{task.DisplayStatusKey},
+		Statuses:         failedAndAbortedStatuses,
+		FieldsToProject:  []string{task.DisplayStatusKey},
+		IncludeBaseTasks: false,
 	}
 	tasks, _, err := r.sc.FindTasksByVersion(*obj.Id, opts)
 	if err != nil {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3222,10 +3222,10 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 		{"$replaceRoot": bson.M{"newRoot": "$tasks"}},
 	}
 	pipeline = append(pipeline, recombineAnnotationFacet...)
-	pipeline = append(pipeline, []bson.M{
+	pipeline = append(pipeline,
 		// Add a field for the display status of each task
 		addDisplayStatus,
-	}...)
+	)
 	if opts.IncludeBaseTasks {
 		pipeline = append(pipeline, []bson.M{
 			// Add data about the base task

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2727,3 +2727,49 @@ func TestGetTasksByVersionAnnotations(t *testing.T) {
 	assert.Equal(t, tasks[2].Id, "t3")
 	assert.Equal(t, evergreen.TaskFailed, tasks[2].DisplayStatus)
 }
+
+func TestGetTaskStatsByVersion(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
+	t1 := Task{
+		Id:        "t1",
+		Version:   "v1",
+		Execution: 0,
+		Status:    evergreen.TaskSucceeded,
+	}
+	t2 := Task{
+		Id:        "t2",
+		Version:   "v1",
+		Execution: 0,
+		Status:    evergreen.TaskFailed,
+	}
+	t3 := Task{
+		Id:        "t3",
+		Version:   "v1",
+		Execution: 1,
+		Status:    evergreen.TaskSucceeded,
+	}
+	t4 := Task{
+		Id:        "t4",
+		Version:   "v1",
+		Execution: 1,
+		Status:    evergreen.TaskFailed,
+	}
+	t5 := Task{
+		Id:        "t5",
+		Version:   "v1",
+		Execution: 2,
+		Status:    evergreen.TaskStatusPending,
+	}
+	t6 := Task{
+		Id:        "t6",
+		Version:   "v1",
+		Execution: 2,
+		Status:    evergreen.TaskFailed,
+	}
+	assert.NoError(t, db.InsertMany(Collection, t1, t2, t3, t4, t5, t6))
+	opts := GetTasksByVersionOptions{}
+	stats, err := GetTaskStatsByVersion("v1", opts)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(stats))
+
+}

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -250,6 +250,7 @@ type TaskFilterOptions struct {
 	FieldsToProject       []string
 	Sorts                 []task.TasksSortOrder
 	IncludeExecutionTasks bool
+	IncludeBaseTasks      bool
 }
 
 // FindTasksByVersion gets all tasks for a specific version
@@ -265,6 +266,7 @@ func (tc *DBTaskConnector) FindTasksByVersion(versionID string, opts TaskFilterO
 		FieldsToProject:       opts.FieldsToProject,
 		Sorts:                 opts.Sorts,
 		IncludeExecutionTasks: opts.IncludeExecutionTasks,
+		IncludeBaseTasks:      opts.IncludeBaseTasks,
 	}
 	tasks, total, err := task.GetTasksByVersion(versionID, getTaskByVersionOpts)
 	if err != nil {


### PR DESCRIPTION
[EVG-15459](https://jira.mongodb.org/browse/EVG-15459)

### Description 
Refactors GetTasksByVersion query to conditionally include basetask information reducing a $lookup.
Refactors GetTasksByVersion query and moves most of the pipeline into a utility function for reuse.
Use said utility function to create a  new query which calculates task stats in mongodb.

Time to fetch task stats on a patch with >4k tasks 
before: 3.2s
after: 1.2s
### Testing 
Unit tests
Tested in staging.