### PR TITLE
EVG-15206: Add CommitQueue to parser project

### DIFF
--- a/agent/command/git_merge_pr.go
+++ b/agent/command/git_merge_pr.go
@@ -98,6 +98,11 @@ func (c *gitMergePr) Execute(ctx context.Context, comm client.Communicator, logg
 	githubCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	err = conf.ProjectRef.MergeWithParserProject(patchDoc.Version)
+	if err != nil {
+		return errors.Wrap(err, "failed to merge parser project with project ref")
+	}
+
 	mergeOpts := &github.PullRequestOptions{
 		MergeMethod:        conf.ProjectRef.CommitQueue.MergeMethod,
 		CommitTitle:        patchDoc.GithubPatchData.CommitTitle,

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-09-28"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-10-05"
+	AgentVersion = "2021-10-07"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1961,6 +1961,10 @@ func (r *queryResolver) CommitQueue(ctx context.Context, id string) (*restModel.
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding project %s: %s", id, err.Error()))
 	}
+	err = project.MergeWithParserProject("")
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error merging project with parser project %s: %s", id, err.Error()))
+	}
 	if project.CommitQueue.Message != "" {
 		commitQueue.Message = &project.CommitQueue.Message
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -66,7 +66,8 @@ type Project struct {
 	// The below fields can be set for the ProjectRef struct on the project page, or in the project config yaml.
 	// Values for the below fields set on this struct when TranslateProject is called for the project parser will
 	// take precedence over the project page and will be the configs used for a given project during runtime.
-	DeactivatePrevious bool `yaml:"deactivate_previous" bson:"deactivate_previous,omitempty"`
+	DeactivatePrevious bool              `yaml:"deactivate_previous" bson:"deactivate_previous,omitempty"`
+	CommitQueue        CommitQueueParams `yaml:"commit_queue" bson:"commit_queue"`
 
 	// Flag that indicates a project as requiring user authentication
 	Private bool `yaml:"private,omitempty" bson:"private"`

--- a/model/project.go
+++ b/model/project.go
@@ -66,8 +66,8 @@ type Project struct {
 	// The below fields can be set for the ProjectRef struct on the project page, or in the project config yaml.
 	// Values for the below fields set on this struct when TranslateProject is called for the project parser will
 	// take precedence over the project page and will be the configs used for a given project during runtime.
-	DeactivatePrevious bool              `yaml:"deactivate_previous" bson:"deactivate_previous,omitempty"`
-	CommitQueue        CommitQueueParams `yaml:"commit_queue" bson:"commit_queue"`
+	DeactivatePrevious bool               `yaml:"deactivate_previous" bson:"deactivate_previous,omitempty"`
+	CommitQueue        *CommitQueueParams `yaml:"commit_queue" bson:"commit_queue"`
 
 	// Flag that indicates a project as requiring user authentication
 	Private bool `yaml:"private,omitempty" bson:"private"`

--- a/model/project.go
+++ b/model/project.go
@@ -66,8 +66,8 @@ type Project struct {
 	// The below fields can be set for the ProjectRef struct on the project page, or in the project config yaml.
 	// Values for the below fields set on this struct when TranslateProject is called for the project parser will
 	// take precedence over the project page and will be the configs used for a given project during runtime.
-	DeactivatePrevious bool               `yaml:"deactivate_previous" bson:"deactivate_previous,omitempty"`
-	CommitQueue        *CommitQueueParams `yaml:"commit_queue" bson:"commit_queue"`
+	DeactivatePrevious bool               `yaml:"deactivate_previous"    bson:"deactivate_previous,omitempty"`
+	CommitQueue        *CommitQueueParams `yaml:"commit_queue,omitempty" bson:"commit_queue,omitempty"`
 
 	// Flag that indicates a project as requiring user authentication
 	Private bool `yaml:"private,omitempty" bson:"private"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -89,8 +89,8 @@ type ParserProject struct {
 	// The below fields can be set for the ProjectRef struct on the project page, or in the project config yaml.
 	// Values for the below fields set on this struct will take precedence over the project page and will
 	// be the configs used for a given project during runtime.
-	DeactivatePrevious *bool             `yaml:"deactivate_previous" bson:"deactivate_previous,omitempty"`
-	CommitQueue        CommitQueueParams `yaml:"commit_queue" bson:"commit_queue"`
+	DeactivatePrevious *bool              `yaml:"deactivate_previous" bson:"deactivate_previous,omitempty"`
+	CommitQueue        *CommitQueueParams `yaml:"commit_queue" bson:"commit_queue"`
 
 	// List of yamls to merge
 	Include []Include `yaml:"include,omitempty" bson:"include,omitempty"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -89,8 +89,8 @@ type ParserProject struct {
 	// The below fields can be set for the ProjectRef struct on the project page, or in the project config yaml.
 	// Values for the below fields set on this struct will take precedence over the project page and will
 	// be the configs used for a given project during runtime.
-	DeactivatePrevious *bool              `yaml:"deactivate_previous" bson:"deactivate_previous,omitempty"`
-	CommitQueue        *CommitQueueParams `yaml:"commit_queue" bson:"commit_queue"`
+	DeactivatePrevious *bool              `yaml:"deactivate_previous"    bson:"deactivate_previous,omitempty"`
+	CommitQueue        *CommitQueueParams `yaml:"commit_queue,omitempty" bson:"commit_queue,omitempty"`
 
 	// List of yamls to merge
 	Include []Include `yaml:"include,omitempty" bson:"include,omitempty"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -89,7 +89,8 @@ type ParserProject struct {
 	// The below fields can be set for the ProjectRef struct on the project page, or in the project config yaml.
 	// Values for the below fields set on this struct will take precedence over the project page and will
 	// be the configs used for a given project during runtime.
-	DeactivatePrevious *bool `yaml:"deactivate_previous" bson:"deactivate_previous,omitempty"`
+	DeactivatePrevious *bool             `yaml:"deactivate_previous" bson:"deactivate_previous,omitempty"`
+	CommitQueue        CommitQueueParams `yaml:"commit_queue" bson:"commit_queue"`
 
 	// List of yamls to merge
 	Include []Include `yaml:"include,omitempty" bson:"include,omitempty"`
@@ -778,6 +779,7 @@ func TranslateProject(pp *ParserProject) (*Project, error) {
 		BuildBaronSettings:     pp.BuildBaronSettings,
 		PerfEnabled:            utility.FromBoolPtr(pp.PerfEnabled),
 		DeactivatePrevious:     utility.FromBoolPtr(pp.DeactivatePrevious),
+		CommitQueue:            pp.CommitQueue,
 	}
 	catcher := grip.NewBasicCatcher()
 	tse := NewParserTaskSelectorEvaluator(pp.Tasks)

--- a/model/project_parser_merge_functions.go
+++ b/model/project_parser_merge_functions.go
@@ -198,6 +198,12 @@ func (pp *ParserProject) mergeUnique(toMerge *ParserProject) error {
 		pp.DeactivatePrevious = toMerge.DeactivatePrevious
 	}
 
+	if pp.CommitQueue != nil && toMerge.CommitQueue != nil {
+		catcher.New("commit queue settings can only be defined in one yaml")
+	} else if toMerge.CommitQueue != nil {
+		pp.CommitQueue = toMerge.CommitQueue
+	}
+
 	return catcher.Resolve()
 }
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -448,6 +448,9 @@ func (p *ProjectRef) MergeWithParserProject(version string) error {
 		if parserProject.TaskAnnotationSettings != nil {
 			p.TaskAnnotationSettings = *parserProject.TaskAnnotationSettings
 		}
+		if parserProject.CommitQueue != nil {
+			p.CommitQueue = *parserProject.CommitQueue
+		}
 	}
 	return nil
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1300,6 +1300,10 @@ func FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(owner, repo, branch st
 			owner, repo, branch)
 	}
 	for _, p := range projectRefs {
+		err = p.MergeWithParserProject("")
+		if err != nil {
+			return nil, errors.Wrap(err, "can't merge parser project with project ref")
+		}
 		if p.CommitQueue.IsEnabled() {
 			p.checkDefaultLogger()
 			return &p, nil
@@ -2130,6 +2134,10 @@ func (p *ProjectRef) CommitQueueIsOn() error {
 	}
 	if p.IsPatchingDisabled() {
 		catcher.Add(errors.Errorf("patching is disabled for project '%s'", p.Id))
+	}
+	err := p.MergeWithParserProject("")
+	if err != nil {
+		catcher.Add(errors.Wrap(err, "can't merge parser project with project ref"))
 	}
 	if !p.CommitQueue.IsEnabled() {
 		catcher.Add(errors.Errorf("commit queue is disabled for project '%s'", p.Id))

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2138,9 +2138,8 @@ func (p *ProjectRef) CommitQueueIsOn() error {
 	if p.IsPatchingDisabled() {
 		catcher.Add(errors.Errorf("patching is disabled for project '%s'", p.Id))
 	}
-	err := p.MergeWithParserProject("")
-	if err != nil {
-		catcher.Add(errors.Wrap(err, "can't merge parser project with project ref"))
+	if err := p.MergeWithParserProject(""); err != nil {
+		catcher.Wrapf(err, "can't merge parser project with project ref")
 	}
 	if !p.CommitQueue.IsEnabled() {
 		catcher.Add(errors.Errorf("commit queue is disabled for project '%s'", p.Id))

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -419,6 +419,10 @@ func listCommitQueue(ctx context.Context, client client.Communicator, ac *legacy
 	if err != nil {
 		return errors.Wrapf(err, "can't find project for queue id '%s'", projectID)
 	}
+	err = projectRef.MergeWithParserProject("")
+	if err != nil {
+		return errors.Wrap(err, "can't merge parser project with project ref")
+	}
 	cq, err := client.GetCommitQueue(ctx, projectRef.Id)
 	if err != nil {
 		return err
@@ -550,6 +554,10 @@ func (p *mergeParams) uploadMergePatch(conf *ClientSettings, ac *legacyClient) e
 			err = errors.WithStack(err)
 		}
 		return errors.Wrap(err, "can't get project ref")
+	}
+	err = ref.MergeWithParserProject("")
+	if err != nil {
+		return errors.Wrap(err, "can't merge parser project with project ref")
 	}
 	if !ref.CommitQueue.IsEnabled() {
 		return errors.New("commit queue not enabled for project")
@@ -690,7 +698,8 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 
 func showCQMessageForProject(ac *legacyClient, projectID string) {
 	projectRef, _ := ac.GetProjectRef(projectID)
-	if projectRef != nil && projectRef.CommitQueue.Message != "" {
+	err := projectRef.MergeWithParserProject("")
+	if err != nil && projectRef != nil && projectRef.CommitQueue.Message != "" {
 		grip.Info(projectRef.CommitQueue.Message)
 	}
 }

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -698,9 +698,7 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 func showCQMessageForProject(ac *legacyClient, projectID string) {
 	projectRef, _ := ac.GetProjectRef(projectID)
 	if projectRef != nil && projectRef.CommitQueue.Message != "" {
-		if err := projectRef.MergeWithParserProject(""); err != nil {
-			grip.Info(projectRef.CommitQueue.Message)
-		}
+		grip.Info(projectRef.CommitQueue.Message)
 	}
 }
 

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -419,8 +419,7 @@ func listCommitQueue(ctx context.Context, client client.Communicator, ac *legacy
 	if err != nil {
 		return errors.Wrapf(err, "can't find project for queue id '%s'", projectID)
 	}
-	err = projectRef.MergeWithParserProject("")
-	if err != nil {
+	if err = projectRef.MergeWithParserProject(""); err != nil {
 		return errors.Wrap(err, "can't merge parser project with project ref")
 	}
 	cq, err := client.GetCommitQueue(ctx, projectRef.Id)
@@ -698,9 +697,10 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 
 func showCQMessageForProject(ac *legacyClient, projectID string) {
 	projectRef, _ := ac.GetProjectRef(projectID)
-	err := projectRef.MergeWithParserProject("")
-	if err != nil && projectRef != nil && projectRef.CommitQueue.Message != "" {
-		grip.Info(projectRef.CommitQueue.Message)
+	if projectRef != nil && projectRef.CommitQueue.Message != "" {
+		if err := projectRef.MergeWithParserProject(""); err != nil {
+			grip.Info(projectRef.CommitQueue.Message)
+		}
 	}
 }
 

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -345,6 +345,10 @@ func (pc *DBCommitQueueConnector) GetMessageForPatch(patchID string) (string, er
 	if project == nil {
 		return "", errors.New("patch has nonexistent project")
 	}
+	err = project.MergeWithParserProject(requestedPatch.Version)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to merge parser project with project ref")
+	}
 
 	return project.CommitQueue.Message, nil
 }

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -631,6 +631,10 @@ func (pc *MockProjectConnector) GetProjectEventLog(id string, before time.Time, 
 
 func (pc *MockProjectConnector) GetProjectWithCommitQueueByOwnerRepoAndBranch(owner, repo, branch string) (*model.ProjectRef, error) {
 	for _, p := range pc.CachedProjects {
+		err := p.MergeWithParserProject("")
+		if err != nil {
+			return nil, errors.Wrap(err, "can't merge parser project with project ref")
+		}
 		if p.Owner == owner && p.Repo == repo && p.Branch == branch && p.CommitQueue.IsEnabled() {
 			return &p, nil
 		}

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -507,6 +507,10 @@ func (p *APIProjectRef) BuildFromService(v interface{}) error {
 	}
 
 	cq := APICommitQueueParams{}
+	err := projectRef.MergeWithParserProject("")
+	if err != nil {
+		return errors.Wrap(err, "can't merge parser project with project ref")
+	}
 	if err := cq.BuildFromService(projectRef.CommitQueue); err != nil {
 		return errors.Wrap(err, "can't convert commit queue parameters")
 	}

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -412,6 +412,14 @@ func (m *CommitQueueItemOwnerMiddleware) ServeHTTP(rw http.ResponseWriter, r *ht
 		}))
 		return
 	}
+	err = projRef.MergeWithParserProject("")
+	if err != nil {
+		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    err.Error(),
+		}))
+		return
+	}
 
 	if !projRef.CommitQueue.IsEnabled() {
 		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -235,6 +235,10 @@ func (h *projectIDPatchHandler) Parse(ctx context.Context, r *http.Request) erro
 	if err != nil {
 		return errors.Wrap(err, "error finding original project")
 	}
+	err = oldProject.MergeWithParserProject("")
+	if err != nil {
+		return errors.Wrap(err, "can't merge parser project with project ref")
+	}
 	requestProjectRef := &model.APIProjectRef{}
 	if err = requestProjectRef.BuildFromService(*oldProject); err != nil {
 		return errors.Wrap(err, "API error converting from model.ProjectRef to model.APIProjectRef")
@@ -313,6 +317,10 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	mergedProjectRef, err := dbModel.GetProjectRefMergedWithRepo(*h.newProjectRef)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "error merging project ref"))
+	}
+	err = mergedProjectRef.MergeWithParserProject("")
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "failed to merge parser project with project ref"))
 	}
 
 	if h.newProjectRef.IsEnabled() {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -235,10 +235,6 @@ func (h *projectIDPatchHandler) Parse(ctx context.Context, r *http.Request) erro
 	if err != nil {
 		return errors.Wrap(err, "error finding original project")
 	}
-	err = oldProject.MergeWithParserProject("")
-	if err != nil {
-		return errors.Wrap(err, "can't merge parser project with project ref")
-	}
 	requestProjectRef := &model.APIProjectRef{}
 	if err = requestProjectRef.BuildFromService(*oldProject); err != nil {
 		return errors.Wrap(err, "API error converting from model.ProjectRef to model.APIProjectRef")

--- a/rest/route/repo.go
+++ b/rest/route/repo.go
@@ -266,6 +266,10 @@ func (h repoIDPatchHandler) validateBranchesForRepo(ctx context.Context, newRepo
 		return errors.Wrapf(err, "error enabling webhooks for repo '%s'", h.repoName)
 	}
 
+	err = newRepoRef.MergeWithParserProject("")
+	if err != nil {
+		return errors.Wrap(err, "failed to merge parser project with project ref")
+	}
 	catcher := grip.NewBasicCatcher()
 
 	// If we're enabling commit queue testing PR testing, verify that only one enabled project ref per branch has true or nil set.
@@ -277,7 +281,8 @@ func (h repoIDPatchHandler) validateBranchesForRepo(ctx context.Context, newRepo
 		githubCheckIds []string
 	}{}
 	for _, p := range mergedRepos {
-		if !p.IsEnabled() {
+		err = p.MergeWithParserProject("")
+		if !p.IsEnabled() || err != nil {
 			continue
 		}
 		counts := branchInfo[p.Branch]

--- a/rest/route/repo.go
+++ b/rest/route/repo.go
@@ -281,8 +281,7 @@ func (h repoIDPatchHandler) validateBranchesForRepo(ctx context.Context, newRepo
 		githubCheckIds []string
 	}{}
 	for _, p := range mergedRepos {
-		err = p.MergeWithParserProject("")
-		if !p.IsEnabled() || err != nil {
+		if !p.IsEnabled() {
 			continue
 		}
 		counts := branchInfo[p.Branch]

--- a/service/api.go
+++ b/service/api.go
@@ -499,6 +499,11 @@ func (as *APIServer) fetchProjectRef(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("no project found named '%v'", id), http.StatusNotFound)
 		return
 	}
+	if err = projectRef.MergeWithParserProject(""); err != nil {
+		// todo (EVG-15562): incorporate this into FindMergedProjectRef
+		as.LoggedError(w, r, http.StatusInternalServerError, err)
+		return
+	}
 	gimlet.WriteJSON(w, projectRef)
 }
 

--- a/service/project.go
+++ b/service/project.go
@@ -150,6 +150,11 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 	CQConflictingRefs := []string{}
 	githubChecksConflictingRefs := []string{}
 	for _, ref := range matchingRefs {
+		err = ref.MergeWithParserProject("")
+		if err != nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't merge parser project with project ref"))
+			return
+		}
 		if ref.IsPRTestingEnabled() && ref.Id != projRef.Id {
 			PRConflictingRefs = append(PRConflictingRefs, ref.Id)
 		}
@@ -475,6 +480,11 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		if commitQueueParams.IsEnabled() {
 			var projRef *model.ProjectRef
 			projRef, err = model.FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(responseRef.Owner, responseRef.Repo, responseRef.Branch)
+			err = projRef.MergeWithParserProject("")
+			if err != nil {
+				uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't merge parser project with project ref"))
+				return
+			}
 			if err != nil {
 				uis.LoggedError(w, r, http.StatusInternalServerError, err)
 				return

--- a/service/project.go
+++ b/service/project.go
@@ -150,11 +150,6 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 	CQConflictingRefs := []string{}
 	githubChecksConflictingRefs := []string{}
 	for _, ref := range matchingRefs {
-		err = ref.MergeWithParserProject("")
-		if err != nil {
-			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't merge parser project with project ref"))
-			return
-		}
 		if ref.IsPRTestingEnabled() && ref.Id != projRef.Id {
 			PRConflictingRefs = append(PRConflictingRefs, ref.Id)
 		}

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -100,6 +100,11 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 		j.AddError(errors.Errorf("no project found for queue id %s", j.QueueID))
 		return
 	}
+	err = projectRef.MergeWithParserProject("")
+	if err != nil {
+		j.AddError(errors.Wrap(err, "can't merge parser project with project ref"))
+		return
+	}
 	if !projectRef.CommitQueue.IsEnabled() {
 		grip.Info(message.Fields{
 			"source":  "commit queue",

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -214,6 +214,10 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	if pref == nil {
 		return errors.Errorf("no project ref '%s' found", patchDoc.Project)
 	}
+	err = pref.MergeWithParserProject(patchDoc.Version)
+	if err != nil {
+		return errors.Wrap(err, "can't merge parser project with project ref")
+	}
 
 	// hidden projects can only run PR patches
 	if !pref.IsEnabled() && (j.IntentType != patch.GithubIntentType || !pref.IsHidden()) {


### PR DESCRIPTION
[EVG-15206](https://jira.mongodb.org/browse/EVG-15206)

### Description 
Parser project struct has been updated to support commit queue configs in the yaml structure and all relevant places where properties are checked on the commit queue configs for a given project will now be checking a merged project ref struct with any necessary overriding properties from the parser project.