### PR TITLE
EVG-15481 filter out basic roles from permissions route

### DIFF
--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -445,7 +445,9 @@ func (h *userPermissionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 	if u == nil {
 		return gimlet.NewJSONErrorResponse(errors.New("user not found"))
 	}
-	permissions, err := rolemanager.PermissionSummaryForRoles(ctx, u.Roles(), h.rm)
+	rolesToSearch, _ := utility.StringSliceSymmetricDifference(u.SystemRoles, evergreen.BasicAccessRoles)
+	// filter out the roles that everybody has automatically
+	permissions, err := rolemanager.PermissionSummaryForRoles(ctx, rolesToSearch, h.rm)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error getting permission summary",

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -303,7 +303,7 @@ func TestGetUserPermissions(t *testing.T) {
 	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 	u := user.DBUser{
 		Id:          "user",
-		SystemRoles: []string{"role1"},
+		SystemRoles: []string{"role1", evergreen.BasicProjectAccessRole, evergreen.BasicDistroAccessRole},
 	}
 	require.NoError(t, u.Insert())
 	require.NoError(t, rm.AddScope(gimlet.Scope{ID: "scope1", Resources: []string{"resource1"}, Type: "project"}))


### PR DESCRIPTION
[EVG-15481](https://jira.mongodb.org/browse/EVG-15481)

### Description 
This route returns all projects that the user has permissions for, and what the highest permissions are. Since every user by default has basic project access to almost every project, this return is super long and pretty unnecessary. Mana 2 wants to filter the basic project access out.

### Testing 
Added basic roles to test and verified the result didn't have them.