### PR TITLE
EVG-14930 Fetch unmatching commits 

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -639,7 +639,7 @@ type ComplexityRoot struct {
 		HostEvents               func(childComplexity int, hostID string, hostTag *string, limit *int, page *int) int
 		Hosts                    func(childComplexity int, hostID *string, distroID *string, currentTaskID *string, statuses []string, startedBy *string, sortBy *HostSortBy, sortDir *SortDirection, page *int, limit *int) int
 		InstanceTypes            func(childComplexity int) int
-		MainlineCommits          func(childComplexity int, options MainlineCommitsOptions) int
+		MainlineCommits          func(childComplexity int, options MainlineCommitsOptions, buildVariantOptions *BuildVariantOptions) int
 		MyHosts                  func(childComplexity int) int
 		MyPublicKeys             func(childComplexity int) int
 		MyVolumes                func(childComplexity int) int
@@ -1175,7 +1175,7 @@ type QueryResolver interface {
 	TaskQueueDistros(ctx context.Context) ([]*TaskQueueDistro, error)
 	BuildBaron(ctx context.Context, taskID string, execution int) (*BuildBaron, error)
 	BbGetCreatedTickets(ctx context.Context, taskID string) ([]*thirdparty.JiraTicket, error)
-	MainlineCommits(ctx context.Context, options MainlineCommitsOptions) (*MainlineCommits, error)
+	MainlineCommits(ctx context.Context, options MainlineCommitsOptions, buildVariantOptions *BuildVariantOptions) (*MainlineCommits, error)
 	TaskNamesForBuildVariant(ctx context.Context, projectID string, buildVariant string) ([]string, error)
 	BuildVariantsForTaskName(ctx context.Context, projectID string, taskName string) ([]*task.BuildVariantTuple, error)
 	ProjectSettings(ctx context.Context, identifier string) (*model.APIProjectSettings, error)
@@ -4159,7 +4159,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.MainlineCommits(childComplexity, args["options"].(MainlineCommitsOptions)), true
+		return e.complexity.Query.MainlineCommits(childComplexity, args["options"].(MainlineCommitsOptions), args["buildVariantOptions"].(*BuildVariantOptions)), true
 
 	case "Query.myHosts":
 		if e.complexity.Query.MyHosts == nil {
@@ -6416,7 +6416,7 @@ type Query {
   taskQueueDistros: [TaskQueueDistro!]!
   buildBaron(taskId: String!, execution: Int!): BuildBaron!
   bbGetCreatedTickets(taskId: String!): [JiraTicket!]!
-  mainlineCommits(options: MainlineCommitsOptions!): MainlineCommits
+  mainlineCommits(options: MainlineCommitsOptions!, buildVariantOptions: BuildVariantOptions): MainlineCommits
   taskNamesForBuildVariant(projectId: String!, buildVariant: String!): [String!]
   buildVariantsForTaskName(projectId: String!, taskName: String!): [BuildVariantTuple]
   projectSettings(identifier: String!): ProjectSettings!
@@ -8677,6 +8677,14 @@ func (ec *executionContext) field_Query_mainlineCommits_args(ctx context.Context
 		}
 	}
 	args["options"] = arg0
+	var arg1 *BuildVariantOptions
+	if tmp, ok := rawArgs["buildVariantOptions"]; ok {
+		arg1, err = ec.unmarshalOBuildVariantOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBuildVariantOptions(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["buildVariantOptions"] = arg1
 	return args, nil
 }
 
@@ -22542,7 +22550,7 @@ func (ec *executionContext) _Query_mainlineCommits(ctx context.Context, field gr
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().MainlineCommits(rctx, args["options"].(MainlineCommitsOptions))
+		return ec.resolvers.Query().MainlineCommits(rctx, args["options"].(MainlineCommitsOptions), args["buildVariantOptions"].(*BuildVariantOptions))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graphql/query_test.go
+++ b/graphql/query_test.go
@@ -1,0 +1,122 @@
+package graphql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/graphql"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	testutil.Setup()
+}
+
+const projectId = "evergreen"
+
+func getContext(t *testing.T) context.Context {
+	const email = "testuser@mongodb.com"
+	const accessToken = "access_token"
+	const refreshToken = "refresh_token"
+	ctx := context.Background()
+	usr, err := user.GetOrCreateUser(apiUser, "Mohamed Khelif", email, accessToken, refreshToken, []string{})
+	require.NoError(t, err)
+	require.NotNil(t, usr)
+
+	ctx = gimlet.AttachUser(ctx, usr)
+	require.NotNil(t, ctx)
+	return ctx
+}
+
+func populateMainlineCommits(t *testing.T) {
+	require.NoError(t, db.ClearCollections(model.VersionCollection, task.Collection))
+	for i := 0; i < 10; i++ {
+		versionId := fmt.Sprintf("v%d", i)
+		// Every other version is activated
+		isActivated := i%2 == 0
+		v := &model.Version{
+			Id:                  versionId,
+			Requester:           evergreen.RepotrackerVersionRequester,
+			Activated:           utility.ToBoolPtr(isActivated),
+			Branch:              projectId,
+			RevisionOrderNumber: 10 - i,
+			Identifier:          projectId,
+		}
+		require.NoError(t, v.Insert())
+		if isActivated {
+			// Every third version should have a task with a failure. This emulates filtering by task status
+			hasFailure := i%3 == 0
+			for j := 0; j < 10; j++ {
+				aTask := &task.Task{
+					Id:          fmt.Sprintf("t%d_%s", j, versionId),
+					Version:     versionId,
+					DisplayName: fmt.Sprintf("%s_%d", "lint", j),
+				}
+				if hasFailure {
+					aTask.Status = evergreen.TaskFailed
+				} else {
+					aTask.Status = evergreen.TaskSucceeded
+				}
+				require.NoError(t, aTask.Insert())
+			}
+		}
+	}
+}
+
+func TestMainlineCommits(t *testing.T) {
+	setupPermissions(t, &atomicGraphQLState{})
+	populateMainlineCommits(t)
+	config := graphql.New("/graphql")
+	require.NotNil(t, config)
+	ctx := getContext(t)
+
+	ref := model.ProjectRef{
+		Id:         projectId,
+		Identifier: "evergreen",
+	}
+	require.NoError(t, ref.Insert())
+
+	// Should return all mainline commits while folding up inactive ones when there are no filters
+	mainlineCommitOptions := graphql.MainlineCommitsOptions{
+		ProjectID:       projectId,
+		SkipOrderNumber: nil,
+		Limit:           utility.ToIntPtr(3),
+	}
+	buildVariantOptions := graphql.BuildVariantOptions{}
+	res, err := config.Resolvers.Query().MainlineCommits(ctx, mainlineCommitOptions, &buildVariantOptions)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.Equal(t, 6, utility.FromIntPtr(res.NextPageOrderNumber))
+	require.Nil(t, res.PrevPageOrderNumber)
+	require.Equal(t, 5, len(res.Versions))
+
+	buildVariantOptions = graphql.BuildVariantOptions{
+		Statuses: []string{evergreen.TaskFailed},
+	}
+	res, err = config.Resolvers.Query().MainlineCommits(ctx, mainlineCommitOptions, &buildVariantOptions)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.Equal(t, 4, utility.FromIntPtr(res.NextPageOrderNumber))
+	require.Nil(t, res.PrevPageOrderNumber)
+	require.Equal(t, 4, len(res.Versions))
+
+	require.Nil(t, res.Versions[0].RolledUpVersions)
+
+	require.NotNil(t, res.Versions[0].Version)
+
+	require.NotNil(t, res.Versions[1].RolledUpVersions)
+	require.Equal(t, 5, len(res.Versions[1].RolledUpVersions))
+
+	require.NotNil(t, res.Versions[2].Version)
+}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3294,7 +3294,7 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 				shouldCollapse = true
 			}
 		}
-		// If a version matches our filter critera we append it directly to our returned list of mainlineCommits
+		// If a version matches our filter criteria we append it directly to our returned list of mainlineCommits
 		if !shouldCollapse {
 			matchingVersionCount++
 			mainlineCommits.NextPageOrderNumber = utility.ToIntPtr(v.RevisionOrderNumber)

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3332,10 +3332,10 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 			mainlineCommits.Versions = append(mainlineCommits.Versions, &mainlineCommitVersion)
 		}
 		index++
+		// If we have exhausted all of our versions we should fetch some more.
 		if index == len(versions) {
 			skipOrderNumber := versions[len(versions)-1].RevisionOrderNumber
 			opts := model.MainlineCommitVersionOptions{
-				Activated:       true,
 				Limit:           limit,
 				SkipOrderNumber: skipOrderNumber,
 			}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3245,17 +3245,17 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 	index := 0
 	versionsCheckedCount := 0
 
-	// We will loop through each version returned from GetMainlineCommitVersionsWithOptions and see if there is a commit that matches the filter paramaters (if any)
-	// If there is a match, we will add it to the array of versions to be returned to the user,
-	// If there are no matches, we will call GetMainlineCommitVersionsWithOptions again with the next order number to check and repeat the process
+	// We will loop through each version returned from GetMainlineCommitVersionsWithOptions and see if there is a commit that matches the filter parameters (if any).
+	// If there is a match, we will add it to the array of versions to be returned to the user.
+	// If there are not enough matches to satisfy our limit, we will call GetMainlineCommitVersionsWithOptions again with the next order number to check and repeat the process.
 	for matchingVersionCount < limit {
-		// If we no longer have any more versions to check break out and return what we have
-		if index >= len(versions) {
+		// If we no longer have any more versions to check break out and return what we have.
+		if len(versions) == 0 {
 			break
 		}
-		// If we have checked more versions than the MaxMainlineCommitVersionLimit then break out and return what we have
+		// If we have checked more versions than the MaxMainlineCommitVersionLimit then break out and return what we have.
 		if versionsCheckedCount >= model.MaxMainlineCommitVersionLimit {
-			// Return an error if we did not find any versions that match
+			// Return an error if we did not find any versions that match.
 			if matchingVersionCount == 0 {
 				return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Matching version not found in %d most recent versions", model.MaxMainlineCommitVersionLimit))
 			}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -74,7 +74,7 @@ type Query {
   taskQueueDistros: [TaskQueueDistro!]!
   buildBaron(taskId: String!, execution: Int!): BuildBaron!
   bbGetCreatedTickets(taskId: String!): [JiraTicket!]!
-  mainlineCommits(options: MainlineCommitsOptions!): MainlineCommits
+  mainlineCommits(options: MainlineCommitsOptions!, buildVariantOptions: BuildVariantOptions): MainlineCommits
   taskNamesForBuildVariant(projectId: String!, buildVariant: String!): [String!]
   buildVariantsForTaskName(projectId: String!, taskName: String!): [BuildVariantTuple]
   projectSettings(identifier: String!): ProjectSettings!

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1227,3 +1227,9 @@ func setVersionActivationStatus(sc data.Connector, version *model.Version) error
 		return errors.Wrapf(version.SetActivated(), "Error updating version activated status for `%s`", version.Id)
 	}
 }
+func (buildVariantOptions *BuildVariantOptions) isPopulated() bool {
+	if buildVariantOptions == nil {
+		return false
+	}
+	return len(buildVariantOptions.Tasks) > 0 || len(buildVariantOptions.Variants) > 0 || len(buildVariantOptions.Statuses) > 0
+}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3083,7 +3083,7 @@ type HasMatchingTasksOptions struct {
 	Statuses  []string
 }
 
-// HasMatchingTasks returns true if the version has tasks with the given statuses,
+// HasMatchingTasks returns true if the version has tasks with the given statuses
 func HasMatchingTasks(versionID string, opts HasMatchingTasksOptions) (bool, error) {
 	options := GetTasksByVersionOptions{
 		TaskNames: opts.TaskNames,

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3077,6 +3077,42 @@ func GetTaskStatsByVersion(versionID string, opts GetTasksByVersionOptions) ([]*
 	return StatusCount, nil
 }
 
+type HasMatchingTasksOptions struct {
+	TaskNames []string
+	Variants  []string
+	Statuses  []string
+}
+
+// HasMatchingTasks returns true if the version has tasks with the given statuses,
+func HasMatchingTasks(versionID string, opts HasMatchingTasksOptions) (bool, error) {
+	options := GetTasksByVersionOptions{
+		TaskNames: opts.TaskNames,
+		Variants:  opts.Variants,
+		Statuses:  opts.Statuses,
+	}
+	pipeline := getTasksByVersionPipeline(versionID, options)
+	pipeline = append(pipeline, bson.M{"$count": "count"})
+	env := evergreen.GetEnvironment()
+	ctx, cancel := env.Context()
+	defer cancel()
+	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline)
+	if err != nil {
+		return false, err
+	}
+	type Count struct {
+		Count int `bson:"count"`
+	}
+	count := []*Count{}
+	err = cursor.All(ctx, &count)
+	if err != nil {
+		return false, err
+	}
+	if len(count) == 0 {
+		return false, nil
+	}
+	return count[0].Count > 0, nil
+}
+
 func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) []bson.M {
 	var match bson.M = bson.M{}
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2773,3 +2773,56 @@ func TestGetTaskStatsByVersion(t *testing.T) {
 	assert.Equal(t, 3, len(stats))
 
 }
+
+func TestHasMatchingTasks(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
+	t1 := Task{
+		Id:        "t1",
+		Version:   "v1",
+		Execution: 0,
+		Status:    evergreen.TaskSucceeded,
+	}
+	t2 := Task{
+		Id:        "t2",
+		Version:   "v1",
+		Execution: 0,
+		Status:    evergreen.TaskFailed,
+	}
+	t3 := Task{
+		Id:        "t3",
+		Version:   "v1",
+		Execution: 1,
+		Status:    evergreen.TaskSucceeded,
+	}
+	t4 := Task{
+		Id:        "t4",
+		Version:   "v1",
+		Execution: 1,
+		Status:    evergreen.TaskFailed,
+	}
+	t5 := Task{
+		Id:        "t5",
+		Version:   "v1",
+		Execution: 2,
+		Status:    evergreen.TaskStatusPending,
+	}
+	t6 := Task{
+		Id:        "t6",
+		Version:   "v1",
+		Execution: 2,
+		Status:    evergreen.TaskFailed,
+	}
+	assert.NoError(t, db.InsertMany(Collection, t1, t2, t3, t4, t5, t6))
+	opts := HasMatchingTasksOptions{
+		Statuses: []string{evergreen.TaskFailed},
+	}
+	hasMatchingTasks, err := HasMatchingTasks("v1", opts)
+	assert.NoError(t, err)
+	assert.True(t, hasMatchingTasks)
+
+	opts.Statuses = []string{evergreen.TaskWillRun}
+
+	hasMatchingTasks, err = HasMatchingTasks("v1", opts)
+	assert.NoError(t, err)
+	assert.False(t, hasMatchingTasks)
+}

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -444,38 +444,31 @@ func TestGetMainlineCommitVersionsWithOptions(t *testing.T) {
 		CreateTime:          start.Add(-2 * time.Minute),
 	}
 	assert.NoError(t, v.Insert())
+
 	opts := MainlineCommitVersionOptions{
-		Limit:     4,
-		Activated: true,
+		Limit: 4,
 	}
 	versions, err := GetMainlineCommitVersionsWithOptions(p.Id, opts)
 	assert.NoError(t, err)
-	assert.Len(t, versions, 2)
+	assert.Len(t, versions, 4)
 	assert.EqualValues(t, "my_version", versions[0].Id)
+	assert.EqualValues(t, "your_version", versions[1].Id)
+	assert.EqualValues(t, "another_version", versions[2].Id)
+	assert.EqualValues(t, "yet_another_version", versions[3].Id)
 
 	opts = MainlineCommitVersionOptions{
 		Limit:           4,
-		Activated:       true,
 		SkipOrderNumber: 10,
 	}
 	versions, err = GetMainlineCommitVersionsWithOptions(p.Id, opts)
 	assert.NoError(t, err)
-	assert.Len(t, versions, 1)
+	assert.Len(t, versions, 3)
 	assert.EqualValues(t, "your_version", versions[0].Id)
-
-	opts = MainlineCommitVersionOptions{
-		Limit:     4,
-		Activated: false,
-	}
-	versions, err = GetMainlineCommitVersionsWithOptions(p.Id, opts)
-	assert.NoError(t, err)
-	assert.Len(t, versions, 2)
-	assert.EqualValues(t, "another_version", versions[0].Id)
-	assert.EqualValues(t, "yet_another_version", versions[1].Id)
+	assert.EqualValues(t, "another_version", versions[1].Id)
+	assert.EqualValues(t, "yet_another_version", versions[2].Id)
 
 	opts = MainlineCommitVersionOptions{
 		Limit:           4,
-		Activated:       false,
 		SkipOrderNumber: 8,
 	}
 	versions, err = GetMainlineCommitVersionsWithOptions(p.Id, opts)


### PR DESCRIPTION
[EVG-14930](https://jira.mongodb.org/browse/EVG-14930)

### Description 
This works the same way as https://github.com/evergreen-ci/evergreen/pull/5038 But is a little more refined and less error prone.
We will stop fetching mainline commits after we have searched 300 commits. To prevent endlessly checking the versions collections

### Testing 
I wrote some programmatic graphql tests. Instead of the static comparison based ones we use elsewhere