### PR TITLE
EVG-15543 use timestamp for project activation

### DIFF
--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -11,9 +11,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func DoProjectActivation(id string) (bool, error) {
-	// fetch the most recent, non-ignored version to activate
-	activateVersion, err := VersionFindOne(VersionByMostRecentNonIgnored(id))
+func DoProjectActivation(id string, ts time.Time) (bool, error) {
+	// fetch the most recent, non-ignored version (before the given time) to activate
+	activateVersion, err := VersionFindOne(VersionByMostRecentNonIgnored(id, ts))
 	if err != nil {
 		return false, errors.WithStack(err)
 	}

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -225,8 +226,8 @@ func VersionBySystemRequesterOrdered(projectId string, startOrder int) db.Q {
 }
 
 // ByMostRecentNonIgnored finds all non-ignored versions within a project,
-// ordered by most recently created to oldest.
-func VersionByMostRecentNonIgnored(projectId string) db.Q {
+// ordered by most recently created to oldest, before a given time.
+func VersionByMostRecentNonIgnored(projectId string, ts time.Time) db.Q {
 	return db.Query(
 		bson.M{
 			VersionRequesterKey: bson.M{
@@ -234,6 +235,7 @@ func VersionByMostRecentNonIgnored(projectId string) db.Q {
 			},
 			VersionIdentifierKey: projectId,
 			VersionIgnoredKey:    bson.M{"$ne": true},
+			VersionCreateTimeKey: bson.M{"$lte": ts},
 		},
 	).Sort([]string{"-" + VersionRevisionOrderNumberKey})
 }

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionByMostRecentNonIgnored(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(VersionCollection))
+	ts := time.Now()
+	v1 := Version{
+		Id:         "v1",
+		Identifier: "proj",
+		Requester:  evergreen.RepotrackerVersionRequester,
+		CreateTime: ts,
+	}
+	v2 := Version{
+		Id:         "v2",
+		Identifier: "proj",
+		Requester:  evergreen.RepotrackerVersionRequester,
+		CreateTime: ts.Add(-2 * time.Minute), // created too early
+	}
+	v3 := Version{
+		Id:         "v3",
+		Identifier: "proj",
+		Requester:  evergreen.RepotrackerVersionRequester,
+		CreateTime: ts.Add(time.Second), // created too late
+	}
+
+	assert.NoError(t, db.InsertMany(VersionCollection, v1, v2, v3))
+
+	v, err := VersionFindOne(VersionByMostRecentNonIgnored("proj", ts))
+	assert.NoError(t, err)
+	assert.Equal(t, v.Id, "v1")
+}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -188,7 +188,7 @@ func (repoTracker *RepoTracker) FetchRevisions(ctx context.Context) error {
 			return errors.WithStack(err)
 		}
 	}
-	ok, err := model.DoProjectActivation(projectRef.Id)
+	ok, err := model.DoProjectActivation(projectRef.Id, time.Now())
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":            "problem activating recent commit for project",

--- a/repotracker/wrappers.go
+++ b/repotracker/wrappers.go
@@ -2,6 +2,7 @@ package repotracker
 
 import (
 	"context"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
@@ -69,11 +70,11 @@ func CollectRevisionsForProject(ctx context.Context, conf *evergreen.Settings, p
 	return nil
 }
 
-func ActivateBuildsForProject(project model.ProjectRef) (bool, error) {
+func ActivateBuildsForProject(project model.ProjectRef, ts time.Time) (bool, error) {
 	if !project.IsEnabled() {
 		return false, errors.Errorf("project disabled: %s", project.Id)
 	}
-	ok, err := model.DoProjectActivation(project.Id)
+	ok, err := model.DoProjectActivation(project.Id, ts)
 	if err != nil {
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message":            "problem activating recent commit for project",
@@ -81,6 +82,7 @@ func ActivateBuildsForProject(project model.ProjectRef) (bool, error) {
 			"mode":               "catch up",
 			"project":            project.Id,
 			"project_identifier": project.Identifier,
+			"timestamp_used":     ts,
 		}))
 
 		return false, errors.WithStack(err)

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -93,7 +93,7 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error adding build break subscriptions")
 	}
-	_, err = model.DoProjectActivation(args.DownstreamProject.Id)
+	_, err = model.DoProjectActivation(args.DownstreamProject.Id, time.Now())
 	if err != nil {
 		return nil, errors.Wrapf(err, "error activating project %s", args.DownstreamProject.Id)
 	}


### PR DESCRIPTION
[EVG-15543](https://jira.mongodb.org/browse/EVG-15543)

### Description 
If we have a cron for tasks/variants to be activated at 8 pm daily, the 8 pm project-activation job should get the most recent version (from before 8 pm), which is set to be activated at 8 pm (this job runs every 10 minutes). However, if the job takes a minute to get there, and a new commit is pushed at 8:01 pm, we'll instead look at _this_ version since we just look at the most recent. Since this commit was pushed after 8 pm, the cron for it will be set to 8 pm for the NEXT day -- this is correct, however now we miss our window for activating the current day.

By using the timestamp that the job represents, we avoid this race. 

### Testing 
Added a unit test to verify I didn't break the query.
