### PR TITLE
EVG-15467: Add degraded mode casing on EnqueuePatchSubscriberType

### DIFF
--- a/units/event_send.go
+++ b/units/event_send.go
@@ -163,6 +163,9 @@ func (j *eventSendJob) checkDegradedMode(n *notification.Notification) error {
 	case event.EmailSubscriberType:
 		return checkFlag(j.flags.EmailNotificationsDisabled)
 
+	case event.EnqueuePatchSubscriberType:
+		return checkFlag(j.flags.CommitQueueDisabled)
+
 	default:
 		return errors.Errorf("unknown subscriber type: %s", n.Subscriber.Type)
 	}


### PR DESCRIPTION
[EVG-15467](https://jira.mongodb.org/browse/EVG-15467)

### Description 
Degraded mode notification casing appears to have been accidentally removed, causing errors such as the one linked in the above ticket. 