### PR TITLE
EVG-14856 Refactor execution task resolver to perform one query instead of several

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3095,7 +3095,7 @@ func (r *taskResolver) ExecutionTasksFull(ctx context.Context, obj *restModel.AP
 	if len(obj.ExecutionTasks) == 0 {
 		return nil, nil
 	}
-	tasks, err := task.ByExecutionTasksAndMaxExecution(obj.ExecutionTasks, obj.Execution)
+	tasks, err := task.FindByExecutionTasksAndMaxExecution(obj.ExecutionTasks, obj.Execution)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding execution tasks for task: %s : %s", *obj.Id, err.Error()))
 	}
@@ -3104,7 +3104,7 @@ func (r *taskResolver) ExecutionTasksFull(ctx context.Context, obj *restModel.AP
 		apiTask := &restModel.APITask{}
 		err = apiTask.BuildFromService(&t)
 		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Unable to convert task %s to APITask : %s", t.Id, err))
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Unable to convert task %s to APITask : %s", t.Id, err.Error()))
 		}
 		apiTasks = append(apiTasks, apiTask)
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -814,7 +814,7 @@ func GetRecentTaskStats(period time.Duration, nameKey string) ([]StatusItem, err
 
 // ByExecutionTasksAndMaxExecution returns the tasks corresponding to the passed in taskIds and execution,
 // or the most recent executions of those tasks if they do not have a matching execution
-func ByExecutionTasksAndMaxExecution(taskIds []string, execution int) ([]Task, error) {
+func ByExecutionTasksAndMaxExecution(taskIds []*string, execution int) ([]Task, error) {
 	pipeline := []bson.M{}
 	match := bson.M{
 		"$match": bson.M{
@@ -838,8 +838,9 @@ func ByExecutionTasksAndMaxExecution(taskIds []string, execution int) ([]Task, e
 	}
 	missingTasks := []string{}
 	for _, taskId := range taskIds {
-		if _, ok := taskMap[taskId]; !ok {
-			missingTasks = append(missingTasks, taskId)
+		tId := utility.FromStringPtr(taskId)
+		if _, ok := taskMap[tId]; !ok {
+			missingTasks = append(missingTasks, tId)
 		}
 	}
 	if len(missingTasks) > 0 {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -857,13 +857,6 @@ func ByExecutionTasksAndMaxExecution(taskIds []*string, execution int) ([]Task, 
 			},
 		}
 		oldTaskPipeline = append(oldTaskPipeline, match)
-		// filter by the old taskids that have the highest execution
-		sort := bson.M{
-			"$sort": bson.M{
-				ExecutionKey: -1,
-			},
-		}
-		oldTaskPipeline = append(oldTaskPipeline, sort)
 		if err := db.Aggregate(OldCollection, oldTaskPipeline, &oldTasks); err != nil {
 			return nil, errors.Wrap(err, "error finding tasks in old tasks collection")
 		}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2773,3 +2773,140 @@ func TestGetTaskStatsByVersion(t *testing.T) {
 	assert.Equal(t, 3, len(stats))
 
 }
+
+func TestByExecutionTasksAndMaxExecution(t *testing.T) {
+	t.Run("Fetching latest execution with same executions", func(t *testing.T) {
+		assert.NoError(t, db.ClearCollections(Collection, OldCollection))
+		t1 := Task{
+			Id:        "t1",
+			Version:   "v1",
+			Execution: 1,
+			Status:    evergreen.TaskSucceeded,
+		}
+		assert.NoError(t, db.Insert(Collection, t1))
+
+		ot1 := t1
+		ot1.Execution = 0
+		ot1 = *ot1.makeArchivedTask()
+		assert.NoError(t, db.Insert(OldCollection, ot1))
+
+		t2 := Task{
+			Id:        "t2",
+			Version:   "v1",
+			Execution: 1,
+			Status:    evergreen.TaskSucceeded,
+		}
+		assert.NoError(t, db.Insert(Collection, t2))
+		ot2 := t2
+		ot2.Execution = 0
+		ot2 = *ot2.makeArchivedTask()
+		assert.NoError(t, db.Insert(OldCollection, ot2))
+
+		tasks, err := ByExecutionTasksAndMaxExecution([]string{"t1", "t2"}, 1)
+		tasks = convertOldTasksIntoTasks(tasks)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(tasks))
+		assertTasksAreEqual(t, t1, tasks[0], 1)
+		assertTasksAreEqual(t, t2, tasks[1], 1)
+	})
+	t.Run("Fetching latest execution with mismatching executions", func(t *testing.T) {
+		assert.NoError(t, db.ClearCollections(Collection, OldCollection))
+		t1 := Task{
+			Id:        "t1",
+			Version:   "v1",
+			Execution: 2,
+			Status:    evergreen.TaskSucceeded,
+		}
+		assert.NoError(t, db.Insert(Collection, t1))
+
+		ot1 := t1
+		ot1.Execution = 1
+		ot1 = *ot1.makeArchivedTask()
+		assert.NoError(t, db.Insert(OldCollection, ot1))
+
+		ot1.Execution = 1
+		ot1 = *ot1.makeArchivedTask()
+		assert.NoError(t, db.Insert(OldCollection, ot1))
+
+		t2 := Task{
+			Id:        "t2",
+			Version:   "v1",
+			Execution: 1,
+			Status:    evergreen.TaskSucceeded,
+		}
+		assert.NoError(t, db.Insert(Collection, t2))
+		ot2 := t2
+		ot2.Execution = 0
+		ot2 = *ot2.makeArchivedTask()
+		assert.NoError(t, db.Insert(OldCollection, ot2))
+
+		tasks, err := ByExecutionTasksAndMaxExecution([]string{"t1", "t2"}, 2)
+		tasks = convertOldTasksIntoTasks(tasks)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(tasks))
+		assertTasksAreEqual(t, t1, tasks[0], 2)
+		assertTasksAreEqual(t, t2, tasks[1], 1)
+	})
+	t.Run("Fetching older executions with same execution", func(t *testing.T) {
+		assert.NoError(t, db.ClearCollections(Collection, OldCollection))
+		t1 := Task{
+			Id:        "t1",
+			Version:   "v1",
+			Execution: 2,
+			Status:    evergreen.TaskSucceeded,
+		}
+		assert.NoError(t, db.Insert(Collection, t1))
+
+		ot1 := t1
+		ot1.Execution = 1
+		ot1 = *ot1.makeArchivedTask()
+		assert.NoError(t, db.Insert(OldCollection, ot1))
+
+		ot1.Execution = 0
+		ot1 = *ot1.makeArchivedTask()
+		assert.NoError(t, db.Insert(OldCollection, ot1))
+
+		t2 := Task{
+			Id:        "t2",
+			Version:   "v1",
+			Execution: 2,
+			Status:    evergreen.TaskSucceeded,
+		}
+		assert.NoError(t, db.Insert(Collection, t2))
+
+		ot2 := t2
+		ot2.Execution = 1
+		ot2 = *ot2.makeArchivedTask()
+		assert.NoError(t, db.Insert(OldCollection, ot2))
+
+		ot2.Execution = 0
+		ot2 = *ot2.makeArchivedTask()
+		assert.NoError(t, db.Insert(OldCollection, ot2))
+
+		tasks, err := ByExecutionTasksAndMaxExecution([]string{"t1", "t2"}, 1)
+		tasks = convertOldTasksIntoTasks(tasks)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(tasks))
+		assertTasksAreEqual(t, t1, tasks[0], 1)
+		assertTasksAreEqual(t, t2, tasks[1], 1)
+	})
+
+}
+
+func convertOldTasksIntoTasks(tasks []Task) []Task {
+	updatedTasks := []Task{}
+	for _, t := range tasks {
+		if t.OldTaskId != "" {
+			t.Id = t.OldTaskId
+		}
+		updatedTasks = append(updatedTasks, t)
+	}
+	return updatedTasks
+}
+
+func assertTasksAreEqual(t *testing.T, expected, actual Task, exectedExecution int) {
+	assert.Equal(t, expected.Id, actual.Id)
+	assert.Equal(t, expected.Version, actual.Version)
+	assert.Equal(t, expected.Status, actual.Status)
+	assert.Equal(t, exectedExecution, actual.Execution)
+}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2803,7 +2803,7 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 		ot2 = *ot2.makeArchivedTask()
 		assert.NoError(t, db.Insert(OldCollection, ot2))
 
-		tasks, err := ByExecutionTasksAndMaxExecution(tasksToFetch, 1)
+		tasks, err := FindByExecutionTasksAndMaxExecution(tasksToFetch, 1)
 		tasks = convertOldTasksIntoTasks(tasks)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(tasks))
@@ -2841,7 +2841,7 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 		ot2 = *ot2.makeArchivedTask()
 		assert.NoError(t, db.Insert(OldCollection, ot2))
 
-		tasks, err := ByExecutionTasksAndMaxExecution(tasksToFetch, 2)
+		tasks, err := FindByExecutionTasksAndMaxExecution(tasksToFetch, 2)
 		tasks = convertOldTasksIntoTasks(tasks)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(tasks))
@@ -2884,7 +2884,7 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 		ot2 = *ot2.makeArchivedTask()
 		assert.NoError(t, db.Insert(OldCollection, ot2))
 
-		tasks, err := ByExecutionTasksAndMaxExecution(tasksToFetch, 1)
+		tasks, err := FindByExecutionTasksAndMaxExecution(tasksToFetch, 1)
 		tasks = convertOldTasksIntoTasks(tasks)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(tasks))

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2775,6 +2775,7 @@ func TestGetTaskStatsByVersion(t *testing.T) {
 }
 
 func TestByExecutionTasksAndMaxExecution(t *testing.T) {
+	tasksToFetch := []*string{utility.ToStringPtr("t1"), utility.ToStringPtr("t2")}
 	t.Run("Fetching latest execution with same executions", func(t *testing.T) {
 		assert.NoError(t, db.ClearCollections(Collection, OldCollection))
 		t1 := Task{
@@ -2802,7 +2803,7 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 		ot2 = *ot2.makeArchivedTask()
 		assert.NoError(t, db.Insert(OldCollection, ot2))
 
-		tasks, err := ByExecutionTasksAndMaxExecution([]string{"t1", "t2"}, 1)
+		tasks, err := ByExecutionTasksAndMaxExecution(tasksToFetch, 1)
 		tasks = convertOldTasksIntoTasks(tasks)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(tasks))
@@ -2840,7 +2841,7 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 		ot2 = *ot2.makeArchivedTask()
 		assert.NoError(t, db.Insert(OldCollection, ot2))
 
-		tasks, err := ByExecutionTasksAndMaxExecution([]string{"t1", "t2"}, 2)
+		tasks, err := ByExecutionTasksAndMaxExecution(tasksToFetch, 2)
 		tasks = convertOldTasksIntoTasks(tasks)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(tasks))
@@ -2883,7 +2884,7 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 		ot2 = *ot2.makeArchivedTask()
 		assert.NoError(t, db.Insert(OldCollection, ot2))
 
-		tasks, err := ByExecutionTasksAndMaxExecution([]string{"t1", "t2"}, 1)
+		tasks, err := ByExecutionTasksAndMaxExecution(tasksToFetch, 1)
 		tasks = convertOldTasksIntoTasks(tasks)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(tasks))


### PR DESCRIPTION
[EVG-14856](https://jira.mongodb.org/browse/EVG-14856)

### Description 
Refactors the execution tasks resolver to perform between 1-2 db calls instead of several for each execution task.  
For an improvement of  O(N) -> O(1) db calls in the best case scenario where all executions line up.
And O(2N) -> O(2) when the executions are mismatching. 

### Testing 
  Unit tests
