### PR TITLE
EVG-15193: fix commit-queue merge failing when used with --preserve-commits 

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -882,7 +882,7 @@ func MakeMergePatchPatches(existingPatch *Patch, commitMessage string) ([]Module
 		if err != nil {
 			return nil, errors.Wrap(err, "can't fetch patch contents")
 		}
-		if modulePatch.IsMbox {
+		if IsMailboxDiff(diff) {
 			newModulePatches = append(newModulePatches, modulePatch)
 			continue
 		}


### PR DESCRIPTION
[EVG-15193](https://jira.mongodb.org/browse/EVG-15193)

### Description 
This fixes the bug by not adding metadata to the diff it it's already there. However, the flow is not very user friendly. Instead of  applying the commit message, it adds all the commits individually and the specified commit message doesn't show up anywhere. It also added a commit with the title "testParam". it's all the way down when looking at git log. I'm not well acquainted with --preserve-commits so I'm not sure if it's a bug, and if it is, if it's our bug. 

<img width="1436" alt="Pasted Graphic 6" src="https://user-images.githubusercontent.com/13104717/136843341-40079dd1-38cb-42cb-9c5b-989e7790040a.png">

![image](https://user-images.githubusercontent.com/13104717/136843645-c2e43a5f-e072-4deb-89fe-44cebe003609.png)


### Testing 
Tested manually on staging using the sandbox repo
the patch: https://spruce-staging.corp.mongodb.com/version/616488639dbe325c91e8d98a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC