### PR TITLE
EVG-15293 Add a requireEditProjectSettings middleware to gqlgen

### DIFF
--- a/graphql/integration_atomic_test.go
+++ b/graphql/integration_atomic_test.go
@@ -185,7 +185,7 @@ func setup(t *testing.T, state *atomicGraphQLState) {
 		ID:        "projectAdmin",
 		Name:      "projectAdminScope",
 		Type:      evergreen.ProjectResourceType,
-		Resources: []string{"testProject"},
+		Resources: []string{"projectId"},
 	}
 
 	err = roleManager.AddScope(superUserScope)

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3707,7 +3707,7 @@ func New(apiURL string) Config {
 		if user.HasPermission(opts) {
 			return next(ctx)
 		}
-		return nil, Forbidden.Send(ctx, fmt.Sprintf("user %s is not a project admin and does not have permission to access this resolver", user.Username()))
+		return nil, Forbidden.Send(ctx, fmt.Sprintf("user %s does not have permission to access this resolver for the project %s", user.Username(), *projectId))
 	}
 	return c
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,4 +1,7 @@
 directive @requireSuperUser on FIELD_DEFINITION 
+directive @requireEditProjectSettings(
+  projectId: String
+) on FIELD_DEFINITION
 
 type Query {
   userPatches(
@@ -77,15 +80,15 @@ type Query {
   mainlineCommits(options: MainlineCommitsOptions!): MainlineCommits
   taskNamesForBuildVariant(projectId: String!, buildVariant: String!): [String!]
   buildVariantsForTaskName(projectId: String!, taskName: String!): [BuildVariantTuple]
-  projectSettings(identifier: String!): ProjectSettings!
+  projectSettings(identifier: String!): ProjectSettings! @requireEditProjectSettings(projectId: projectId)
 }
 
 type Mutation {
   addFavoriteProject(identifier: String!): Project!
   removeFavoriteProject(identifier: String!): Project!
   createProject(project: ProjectInput!): Project! @requireSuperUser
-  attachProjectToRepo(projectId: String!): Project!
-  detachProjectFromRepo(projectId: String!): Project!
+  attachProjectToRepo(projectId: String!): Project! @requireEditProjectSettings(projectId: projectId)
+  detachProjectFromRepo(projectId: String!): Project! @requireEditProjectSettings(projectId: projectId)
   schedulePatch(patchId: String!, configure: PatchConfigure!): Patch!
   schedulePatchTasks(patchId: String!): String
   unschedulePatchTasks(patchId: String!, abort: Boolean!): String


### PR DESCRIPTION
[EVG-15293](https://jira.mongodb.org/browse/EVG-15293)

### Description 
This adds a @requireEditProjectSettings directive that checks if a user is authorized to edit a project. After discussing middlewares with Annie I realized that it would be nice to have a more generic middleware that takes in the Resource type, Setting type and Value so we basically only ever need one middleware. However, since all the work was already done, and this is all we need for now, this is good for now and we can make it more generic when we add a requireViewProjectSettings or next time we add another one. 

### Testing 
Added a test. 
