### PR TITLE
EVG-15412 pass a pointer to the slice itself

### DIFF
--- a/units/util.go
+++ b/units/util.go
@@ -29,8 +29,8 @@ func HandlePoisonedHost(ctx context.Context, env evergreen.Environment, h *host.
 				return errors.Wrap(err, "error getting containers")
 			}
 
-			for _, container := range containers {
-				catcher.Add(DisableAndNotifyPoisonedHost(ctx, env, &container, reason))
+			for i := range containers {
+				catcher.Add(DisableAndNotifyPoisonedHost(ctx, env, &containers[i], reason))
 			}
 			catcher.Add(DisableAndNotifyPoisonedHost(ctx, env, parent, reason))
 		}


### PR DESCRIPTION
[EVG-15412](https://jira.mongodb.org/browse/EVG-15412)

### Description 
A pointer to the iterator variable is getting passed into the job which, in the test, is a local queue that runs the actual job in parallel using the host pointer.
I changed it to pass a pointer to the slice so the caller won't be writing to the host variable that the job is reading.

### Testing 
 I ran the test locally with the race detector and it didn't detect a race.
