### PR TITLE
EVG-15320: Link to new UI commit queue page in CLI confirmation of commit queue patch submission

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -237,6 +237,11 @@ func (p *Patch) SetMergePatch(newPatchID string) error {
 	)
 }
 
+func (p *Patch) GetCommitQueueURL(uiHost string) string {
+	url := uiHost + "/commit-queue/" + p.Project
+	return url
+}
+
 func (p *Patch) GetURL(uiHost string) string {
 	var url string
 	if p.Activated {

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -291,7 +291,7 @@ func enqueuePatch() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "problem creating a commit queue patch")
 			}
-			patchDisp, err := getAPIPatchDisplay(mergePatch, false, conf.UIServerHost)
+			patchDisp, err := getAPIPatchDisplay(mergePatch, false, "https://spruce.mongodb.com")
 			if err != nil {
 				grip.Errorf("can't print patch display for new patch '%s'", mergePatch.Id)
 			}
@@ -473,7 +473,7 @@ func listCLICommitQueueItem(item restModel.APICommitQueueItem, ac *legacyClient,
 	if p.Author != "" {
 		grip.Infof("Author: %s", p.Author)
 	}
-	disp, err := getPatchDisplay(p, false, uiServerHost)
+	disp, err := getPatchDisplay(p, false, uiServerHost, "")
 	if err != nil {
 		grip.Error(message.WrapError(err, "\terror getting patch display"))
 		return

--- a/operations/patch_list.go
+++ b/operations/patch_list.go
@@ -95,7 +95,7 @@ func PatchList() cli.Command {
 			}
 
 			for _, p := range patches {
-				disp, err := getPatchDisplay(&p, showSummary, conf.UIServerHost)
+				disp, err := getPatchDisplay(&p, showSummary, conf.UIServerHost, "")
 				if err != nil {
 					return err
 				}

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -153,7 +153,7 @@ func (p *patchParams) validateSubmission(diffData *localDiff) error {
 }
 
 func (p *patchParams) displayPatch(conf *ClientSettings, newPatch *patch.Patch) error {
-	patchDisp, err := getPatchDisplay(newPatch, p.ShowSummary, conf.UIServerHost)
+	patchDisp, err := getPatchDisplay(newPatch, p.ShowSummary, conf.UIServerHost, "")
 	if err != nil {
 		return err
 	}
@@ -431,9 +431,11 @@ func validatePatchSize(diff *localDiff, allowLarge bool) error {
 
 // getPatchDisplay returns a human-readable summary representation of a patch object
 // which can be written to the terminal.
-func getPatchDisplay(p *patch.Patch, summarize bool, uiHost string) (string, error) {
+func getPatchDisplay(p *patch.Patch, summarize bool, uiHost string, link string) (string, error) {
 	var out bytes.Buffer
-
+	if link == "" {
+		link = p.GetURL(uiHost)
+	}
 	err := patchDisplayTemplate.Execute(&out, struct {
 		Patch         *patch.Patch
 		ShowSummary   bool
@@ -443,7 +445,7 @@ func getPatchDisplay(p *patch.Patch, summarize bool, uiHost string) (string, err
 		Patch:         p,
 		ShowSummary:   summarize,
 		ShowFinalized: p.IsCommitQueuePatch(),
-		Link:          p.GetURL(uiHost),
+		Link:          link,
 	})
 	if err != nil {
 		return "", err
@@ -461,7 +463,7 @@ func getAPIPatchDisplay(apiPatch *restmodel.APIPatch, summarize bool, uiHost str
 		return "", errors.New("service patch is not a Patch")
 	}
 
-	return getPatchDisplay(&servicePatch, summarize, uiHost)
+	return getPatchDisplay(&servicePatch, summarize, uiHost, servicePatch.GetCommitQueueURL(uiHost))
 }
 
 func isCommitRange(commits string) bool {


### PR DESCRIPTION
[EVG-15320](https://jira.mongodb.org/browse/EVG-15320)

### Description 
Changed enqueue patch command in the commit queue CLI to link to the new UI commit queue page for the project in the CLI.