### PR TITLE
EVG-15603 avoid marking display task as aborted when aborting for failed task

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1949,6 +1949,8 @@ func AbortVersion(versionId string, reason AbortInfo) error {
 	}
 	if reason.TaskID != "" {
 		q[IdKey] = bson.M{"$ne": reason.TaskID}
+		// if the aborting task is part of a display task, we also don't want to mark it as aborted
+		q[ExecutionTasksKey] = bson.M{"$ne": reason.TaskID}
 	}
 	ids, err := findAllTaskIDs(db.Query(q))
 	if err != nil {


### PR DESCRIPTION
[EVG-15603 ](https://jira.mongodb.org/browse/EVG-15603 )

### Description 
When aborting a version due to a failed task, we take precautions not to mark the failure itself as aborted; we should also do this for the display task itself, if it's an execution task.

### Testing 
Added a unit test.
