### PR TITLE
EVG-15267 Apply module patches consistently with cloning them

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -826,7 +826,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 				continue
 			}
 
-			dir = filepath.Join(c.Directory, expandModulePrefix(conf, module.Name, module.Prefix, logger), module.Name)
+			dir = filepath.ToSlash(filepath.Join(expandModulePrefix(conf, module.Name, module.Prefix, logger), module.Name))
 		}
 
 		if len(patchPart.PatchSet.Patch) == 0 {
@@ -866,7 +866,8 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 		patchCommandStrings = append(patchCommandStrings, applyCommand)
 		cmdsJoined := strings.Join(patchCommandStrings, "\n")
 
-		cmd := jpm.CreateCommand(ctx).Directory(conf.WorkDir).Add([]string{"bash", "-c", cmdsJoined}).
+		cmd := jpm.CreateCommand(ctx).Add([]string{"bash", "-c", cmdsJoined}).
+			Directory(filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory))).
 			SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Task().GetSender())
 
 		if err = cmd.Run(ctx); err != nil {

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -773,13 +773,13 @@ func (c *gitFetchProject) getApplyCommand(patchFile string) (string, error) {
 
 // getPatchCommands, given a module patch of a patch, will return the appropriate list of commands that
 // need to be executed, except for apply. If the patch is empty it will not apply the patch.
-func getPatchCommands(modulePatch patch.ModulePatch, conf *internal.TaskConfig, dir, patchPath string) []string {
+func getPatchCommands(modulePatch patch.ModulePatch, conf *internal.TaskConfig, moduleDir, patchPath string) []string {
 	patchCommands := []string{
 		fmt.Sprintf("set -o xtrace"),
 		fmt.Sprintf("set -o errexit"),
 	}
-	if dir != "" {
-		patchCommands = append(patchCommands, fmt.Sprintf("cd '%s'", dir))
+	if moduleDir != "" {
+		patchCommands = append(patchCommands, fmt.Sprintf("cd '%s'", moduleDir))
 	}
 	if conf.Task.Requester != evergreen.MergeTestRequester {
 		patchCommands = append(patchCommands, fmt.Sprintf("git reset --hard '%s'", modulePatch.Githash))

--- a/agent/command/git_patch_test.go
+++ b/agent/command/git_patch_test.go
@@ -163,16 +163,16 @@ func TestGetPatchCommands(t *testing.T) {
 
 	cmds := getPatchCommands(modulePatch, &internal.TaskConfig{Task: &task.Task{}}, "/teapot", "/tmp/bestest.patch")
 
-	assert.Len(cmds, 5)
-	assert.Equal("cd '/teapot'", cmds[3])
-	assert.Equal("git reset --hard 'a4aa03d0472d8503380479b76aef96c044182822'", cmds[4])
+	assert.Len(cmds, 4)
+	assert.Equal("cd '/teapot'", cmds[2])
+	assert.Equal("git reset --hard 'a4aa03d0472d8503380479b76aef96c044182822'", cmds[3])
 
 	modulePatch.PatchSet.Patch = "bestest code"
 	cmds = getPatchCommands(modulePatch, &internal.TaskConfig{Task: &task.Task{}}, "/teapot", "/tmp/bestest.patch")
-	assert.Len(cmds, 6)
-	assert.Equal("git apply --stat '/tmp/bestest.patch' || true", cmds[5])
-
-	cmds = getPatchCommands(modulePatch, &internal.TaskConfig{Task: &task.Task{Requester: evergreen.MergeTestRequester}}, "/teapot", "/tmp/bestest.patch")
 	assert.Len(cmds, 5)
 	assert.Equal("git apply --stat '/tmp/bestest.patch' || true", cmds[4])
+
+	cmds = getPatchCommands(modulePatch, &internal.TaskConfig{Task: &task.Task{Requester: evergreen.MergeTestRequester}}, "/teapot", "/tmp/bestest.patch")
+	assert.Len(cmds, 4)
+	assert.Equal("git apply --stat '/tmp/bestest.patch' || true", cmds[3])
 }

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -91,6 +91,7 @@ func (s *GitGetProjectSuite) SetupTest() {
 	s.modelData1, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath1, modelutil.NoPatch)
 	s.Require().NoError(err)
 	s.taskConfig1, err = agentutil.MakeTaskConfigFromModelData(s.settings, s.modelData1)
+	s.Require().NoError(err)
 	s.taskConfig1.Expansions = util.NewExpansions(map[string]string{evergreen.GlobalGitHubTokenExpansion: fmt.Sprintf("token " + globalGitHubToken)})
 	s.Require().NoError(err)
 
@@ -136,12 +137,14 @@ func (s *GitGetProjectSuite) SetupTest() {
 	s.taskConfig5, err = agentutil.MakeTaskConfigFromModelData(s.settings, s.modelData5)
 	s.Require().NoError(err)
 
-	s.modelData6, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath4, modelutil.InlinePatch)
+	s.modelData6, err = modelutil.SetupAPITestData(s.settings, "testtask1", "linux-64", configPath4, modelutil.InlinePatch)
+	s.Require().NoError(err)
 	s.modelData6.Task.Requester = evergreen.MergeTestRequester
 	s.Require().NoError(err)
 	s.taskConfig6, err = agentutil.MakeTaskConfigFromModelData(s.settings, s.modelData6)
 	s.Require().NoError(err)
 	s.taskConfig6.Expansions = util.NewExpansions(map[string]string{evergreen.GlobalGitHubTokenExpansion: fmt.Sprintf("token " + globalGitHubToken)})
+	s.taskConfig6.BuildVariant.Modules = []string{"evergreen"}
 }
 
 func (s *GitGetProjectSuite) TestBuildCloneCommandUsesHTTPS() {
@@ -912,7 +915,7 @@ func (s *GitGetProjectSuite) TestMergeMultiplePatches() {
 	ctx := context.WithValue(context.Background(), "patch", &patch.Patch{
 		Id: "p",
 		Patches: []patch.ModulePatch{
-			{Githash: "d0d878e81b303fd2abbf09331e54af41d6cd0c7d", PatchSet: patch.PatchSet{PatchFileId: "patchfile1"}},
+			{Githash: "d0d878e81b303fd2abbf09331e54af41d6cd0c7d", PatchSet: patch.PatchSet{PatchFileId: "patchfile1"}, ModuleName: "evergreen"},
 		},
 	})
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/agent/command/testdata/git/additional_patch.yml
+++ b/agent/command/testdata/git/additional_patch.yml
@@ -14,16 +14,16 @@ tasks:
           token: ${github}
 
 modules:
-  - name: enterprise
-    repo: https://github.com/10gen/mongo-enterprise-modules.git
+  - name: evergreen
+    repo: https://github.com/deafgoat/mci_test.git
     prefix: src/mongo/db/modules
-    branch: v2.6
+    branch: master
 
 buildvariants:
   - name: linux-64
     display_name: Linux 64-bit
     modules:
-      - enterprise
+      - evergreen
     test_flags: --continue-on-failure
     expansions:
       blah: "blah"

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-10-19"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-10-15"
+	AgentVersion = "2021-10-20"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -58,7 +58,7 @@ func PatchSetModule() cli.Command {
 
 			existingPatch, err := ac.GetPatch(patchID)
 			if err != nil {
-				return errors.Wrapf(err, "problem getting patch '%s'", existingPatch.Id)
+				return errors.Wrapf(err, "problem getting patch '%s'", patchID)
 			}
 			if existingPatch.IsCommitQueuePatch() {
 				return errors.New("Use `commit-queue set-module` instead of `set-module` for commit queue patches")


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-15267

Please see https://github.com/evergreen-ci/evergreen/pull/5083 for a longer discussion. Those fixes are cherry-picked in https://github.com/evergreen-ci/evergreen/pull/5114/commits/4e15e54472fe49a277cea407ef6241108c118cdd. The additional fixes in this ticket are these:
- https://github.com/evergreen-ci/evergreen/pull/5114/commits/8455e47d66a39c20b1dc156073dcc0e3d8474cae  addresses incorrectly handling the directory for modules from earlier in the function where we originally made changes.
- https://github.com/evergreen-ci/evergreen/pull/5114/commits/dd9e8e2363cd71f8b974e422b5597227e54c39a9 fixes a test, as I also removed the "ls" in this ticket, which was extraneous and scheduled to be removed in https://jira.mongodb.org/browse/EVG-15574.
- https://github.com/evergreen-ci/evergreen/pull/5114/commits/cc5fc6bc83e5d4cae64dad30737efe64387cff93 bumps the module string.

I tested this in staging, validating that a patch did in fact succeed, whereas when we deployed this in prod it had failed.