### PR TITLE
EVG-15263: Fix test results fetching

### DIFF
--- a/apimodels/test_results.go
+++ b/apimodels/test_results.go
@@ -128,7 +128,7 @@ func GetMultiPageCedarTestResults(ctx context.Context, opts GetCedarTestResultsO
 func GetCedarTestResultsStats(ctx context.Context, opts GetCedarTestResultsOptions) (*CedarTestResultsStats, error) {
 	timberOpts := opts.convert()
 	timberOpts.Stats = true
-	data, err := testresults.Get(ctx, opts.convert())
+	data, err := testresults.Get(ctx, timberOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting test results stats from Cedar")
 	}
@@ -147,7 +147,7 @@ func GetCedarTestResultsStats(ctx context.Context, opts GetCedarTestResultsOptio
 func GetCedarTestResultsFailedSample(ctx context.Context, opts GetCedarTestResultsOptions) ([]string, error) {
 	timberOpts := opts.convert()
 	timberOpts.FailedSample = true
-	data, err := testresults.Get(ctx, opts.convert())
+	data, err := testresults.Get(ctx, timberOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting failed test result sample from Cedar")
 	}

--- a/vendor/github.com/evergreen-ci/timber/testresults/get.go
+++ b/vendor/github.com/evergreen-ci/timber/testresults/get.go
@@ -67,8 +67,7 @@ func (opts GetOptions) parse() string {
 		urlString += "/stats"
 	}
 
-	// TODO: (EVG-15263) Remove once Evergreen is using new API formats.
-	params := []string{"stats=true"}
+	var params []string
 	if opts.Execution != nil {
 		params = append(params, fmt.Sprintf("execution=%d", *opts.Execution))
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15263

- Remove TODO from timber.
- Fix unmarshalling bug in `apimodels/test_results.go`.

The bug fix was tested in staging with graphql.
