### PR TITLE
EVG-15562 Move MergeWithParserProject inside FindMergedProjectRef

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -183,7 +183,7 @@ func (r *queryResolver) MyPublicKeys(ctx context.Context) ([]*restModel.APIPubKe
 }
 
 func (r *taskResolver) Project(ctx context.Context, obj *restModel.APITask) (*restModel.APIProjectRef, error) {
-	pRef, err := r.sc.FindProjectById(*obj.ProjectId, true)
+	pRef, err := r.sc.FindProjectById(*obj.ProjectId, true, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding project ref for project %s: %s", *obj.ProjectId, err.Error()))
 	}
@@ -1273,7 +1273,7 @@ func (r *patchResolver) ID(ctx context.Context, obj *restModel.APIPatch) (string
 }
 
 func (r *patchResolver) PatchTriggerAliases(ctx context.Context, obj *restModel.APIPatch) ([]*restModel.APIPatchTriggerDefinition, error) {
-	projectRef, err := r.sc.FindProjectById(*obj.ProjectId, true)
+	projectRef, err := r.sc.FindProjectById(*obj.ProjectId, true, false)
 	if err != nil || projectRef == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find project: %s : %s", *obj.ProjectId, err))
 	}
@@ -1378,7 +1378,7 @@ func (r *queryResolver) Version(ctx context.Context, id string) (*restModel.APIV
 }
 
 func (r *queryResolver) Project(ctx context.Context, id string) (*restModel.APIProjectRef, error) {
-	project, err := r.sc.FindProjectById(id, true)
+	project, err := r.sc.FindProjectById(id, true, true)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding project by id %s: %s", id, err.Error()))
 	}
@@ -1774,7 +1774,7 @@ func (r *queryResolver) TaskLogs(ctx context.Context, taskID string, execution *
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find task with id %s", taskID))
 	}
 	// need project to get default logger
-	p, err := r.sc.FindProjectById(t.Project, true)
+	p, err := r.sc.FindProjectById(t.Project, true, false)
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("error finding project '%s': %s", t.Project, err.Error()))
 	}
@@ -1971,7 +1971,7 @@ func (r *queryResolver) CommitQueue(ctx context.Context, id string) (*restModel.
 		}
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding commit queue for %s: %s", id, err.Error()))
 	}
-	project, err := r.sc.FindProjectById(id, true)
+	project, err := r.sc.FindProjectById(id, true, true)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding project %s: %s", id, err.Error()))
 	}
@@ -2173,7 +2173,7 @@ func (r *mutationResolver) SaveProjectSettingsForSection(ctx context.Context, ob
 
 func (r *mutationResolver) AttachProjectToRepo(ctx context.Context, projectID string) (*restModel.APIProjectRef, error) {
 	usr := MustHaveUser(ctx)
-	pRef, err := r.sc.FindProjectById(projectID, false)
+	pRef, err := r.sc.FindProjectById(projectID, false, false)
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("error finding project %s: %s", projectID, err.Error()))
 	}
@@ -2193,7 +2193,7 @@ func (r *mutationResolver) AttachProjectToRepo(ctx context.Context, projectID st
 
 func (r *mutationResolver) DetachProjectFromRepo(ctx context.Context, projectID string) (*restModel.APIProjectRef, error) {
 	usr := MustHaveUser(ctx)
-	pRef, err := r.sc.FindProjectById(projectID, false)
+	pRef, err := r.sc.FindProjectById(projectID, false, false)
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("error finding project %s: %s", projectID, err.Error()))
 	}
@@ -2669,7 +2669,7 @@ func (r *mutationResolver) SaveSubscription(ctx context.Context, subscription re
 		}
 		break
 	case "project":
-		p, projectErr := r.sc.FindProjectById(id, false)
+		p, projectErr := r.sc.FindProjectById(id, false, false)
 		if projectErr != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("error finding project by id %s: %s", id, projectErr.Error()))
 		}
@@ -3037,7 +3037,7 @@ func (r *taskResolver) IsPerfPluginEnabled(ctx context.Context, obj *restModel.A
 		return model.IsPerfEnabledForProject(*obj.ProjectId), nil
 	} else {
 		var perfPlugin *plugin.PerfPlugin
-		pRef, err := r.sc.FindProjectById(*obj.ProjectId, false)
+		pRef, err := r.sc.FindProjectById(*obj.ProjectId, false, false)
 		if err != nil {
 			return false, err
 		}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1273,7 +1273,7 @@ func (r *patchResolver) ID(ctx context.Context, obj *restModel.APIPatch) (string
 }
 
 func (r *patchResolver) PatchTriggerAliases(ctx context.Context, obj *restModel.APIPatch) ([]*restModel.APIPatchTriggerDefinition, error) {
-	projectRef, err := r.sc.FindProjectById(*obj.ProjectId, true, false)
+	projectRef, err := r.sc.FindProjectById(*obj.ProjectId, true, true)
 	if err != nil || projectRef == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find project: %s : %s", *obj.ProjectId, err))
 	}
@@ -1378,7 +1378,7 @@ func (r *queryResolver) Version(ctx context.Context, id string) (*restModel.APIV
 }
 
 func (r *queryResolver) Project(ctx context.Context, id string) (*restModel.APIProjectRef, error) {
-	project, err := r.sc.FindProjectById(id, true, true)
+	project, err := r.sc.FindProjectById(id, true, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding project by id %s: %s", id, err.Error()))
 	}
@@ -1774,7 +1774,7 @@ func (r *queryResolver) TaskLogs(ctx context.Context, taskID string, execution *
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find task with id %s", taskID))
 	}
 	// need project to get default logger
-	p, err := r.sc.FindProjectById(t.Project, true, false)
+	p, err := r.sc.FindProjectById(t.Project, true, true)
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("error finding project '%s': %s", t.Project, err.Error()))
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -556,7 +556,6 @@ type VersionModifications struct {
 }
 
 func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectRef, modifications VersionModifications) (int, error) {
-	projId := ""
 	switch modifications.Action {
 	case Restart:
 		if modifications.VersionsToRestart == nil { // to maintain backwards compatibility with legacy Ui and support the deprecated restartPatch resolver
@@ -582,14 +581,16 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 			}
 		}
 		if !modifications.Active && version.Requester == evergreen.MergeTestRequester {
+			var projId string
 			if proj == nil {
-				projId, err := model.GetIdForProject(version.Identifier)
+				id, err := model.GetIdForProject(version.Identifier)
 				if err != nil {
 					return http.StatusNotFound, errors.Errorf("error getting project ref: %s", err.Error())
 				}
-				if projId == "" {
+				if id == "" {
 					return http.StatusNotFound, errors.Errorf("project %s does not exist", version.Branch)
 				}
+				projId = id
 			} else {
 				projId = proj.Id
 			}
@@ -615,6 +616,7 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 			}
 		}
 	case SetPriority:
+		var projId string
 		if proj == nil {
 			projId, err := model.GetIdForProject(version.Identifier)
 			if err != nil {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -240,7 +240,7 @@ func SchedulePatch(ctx context.Context, patchId string, version *model.Version, 
 	// can't interrupt the db operations here
 	newCxt := context.Background()
 
-	projectRef, err := model.FindMergedProjectRef(project.Identifier, p.Version)
+	projectRef, err := model.FindMergedProjectRef(project.Identifier, &p.Version)
 	if err != nil {
 		return errors.Wrap(err, "unable to find project ref"), http.StatusInternalServerError, "", ""
 	}
@@ -582,7 +582,7 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 		}
 		if !modifications.Active && version.Requester == evergreen.MergeTestRequester {
 			if proj == nil {
-				projRef, err := model.FindMergedProjectRef(version.Identifier, version.Id)
+				projRef, err := model.FindMergedProjectRef(version.Identifier, &version.Id)
 				if err != nil {
 					return http.StatusNotFound, errors.Errorf("error getting project ref: %s", err.Error())
 				}
@@ -614,7 +614,7 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 		}
 	case SetPriority:
 		if proj == nil {
-			projRef, err := model.FindMergedProjectRef(version.Identifier, version.Id)
+			projRef, err := model.FindMergedProjectRef(version.Identifier, &version.Id)
 			if err != nil {
 				return http.StatusNotFound, errors.Errorf("error getting project ref: %s", err)
 			}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -240,7 +240,7 @@ func SchedulePatch(ctx context.Context, patchId string, version *model.Version, 
 	// can't interrupt the db operations here
 	newCxt := context.Background()
 
-	projectRef, err := model.FindMergedProjectRef(project.Identifier, &p.Version)
+	projectRef, err := model.FindMergedProjectRef(project.Identifier, p.Version, true)
 	if err != nil {
 		return errors.Wrap(err, "unable to find project ref"), http.StatusInternalServerError, "", ""
 	}
@@ -582,7 +582,7 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 		}
 		if !modifications.Active && version.Requester == evergreen.MergeTestRequester {
 			if proj == nil {
-				projRef, err := model.FindMergedProjectRef(version.Identifier, &version.Id)
+				projRef, err := model.FindMergedProjectRef(version.Identifier, version.Id, true)
 				if err != nil {
 					return http.StatusNotFound, errors.Errorf("error getting project ref: %s", err.Error())
 				}
@@ -614,7 +614,7 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 		}
 	case SetPriority:
 		if proj == nil {
-			projRef, err := model.FindMergedProjectRef(version.Identifier, &version.Id)
+			projRef, err := model.FindMergedProjectRef(version.Identifier, version.Id, true)
 			if err != nil {
 				return http.StatusNotFound, errors.Errorf("error getting project ref: %s", err)
 			}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -240,7 +240,7 @@ func SchedulePatch(ctx context.Context, patchId string, version *model.Version, 
 	// can't interrupt the db operations here
 	newCxt := context.Background()
 
-	projectRef, err := model.FindMergedProjectRef(project.Identifier)
+	projectRef, err := model.FindMergedProjectRef(project.Identifier, p.Version)
 	if err != nil {
 		return errors.Wrap(err, "unable to find project ref"), http.StatusInternalServerError, "", ""
 	}
@@ -582,7 +582,7 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 		}
 		if !modifications.Active && version.Requester == evergreen.MergeTestRequester {
 			if proj == nil {
-				projRef, err := model.FindMergedProjectRef(version.Identifier)
+				projRef, err := model.FindMergedProjectRef(version.Identifier, version.Id)
 				if err != nil {
 					return http.StatusNotFound, errors.Errorf("error getting project ref: %s", err.Error())
 				}
@@ -614,7 +614,7 @@ func ModifyVersion(version model.Version, user user.DBUser, proj *model.ProjectR
 		}
 	case SetPriority:
 		if proj == nil {
-			projRef, err := model.FindMergedProjectRef(version.Identifier)
+			projRef, err := model.FindMergedProjectRef(version.Identifier, version.Id)
 			if err != nil {
 				return http.StatusNotFound, errors.Errorf("error getting project ref: %s", err)
 			}

--- a/model/context.go
+++ b/model/context.go
@@ -47,7 +47,7 @@ func LoadContext(taskId, buildId, versionId, patchId, projectId string) (Context
 	// Try to load project for the ID we found, and set cookie with it for subsequent requests
 	if len(projectId) > 0 {
 		// Also lookup the ProjectRef itself and add it to context.
-		ctx.ProjectRef, err = FindMergedProjectRef(projectId)
+		ctx.ProjectRef, err = FindMergedProjectRef(projectId, versionId)
 		if err != nil {
 			return ctx, err
 		}

--- a/model/context.go
+++ b/model/context.go
@@ -47,7 +47,7 @@ func LoadContext(taskId, buildId, versionId, patchId, projectId string) (Context
 	// Try to load project for the ID we found, and set cookie with it for subsequent requests
 	if len(projectId) > 0 {
 		// Also lookup the ProjectRef itself and add it to context.
-		ctx.ProjectRef, err = FindMergedProjectRef(projectId, versionId)
+		ctx.ProjectRef, err = FindMergedProjectRef(projectId, &versionId)
 		if err != nil {
 			return ctx, err
 		}

--- a/model/context.go
+++ b/model/context.go
@@ -47,7 +47,7 @@ func LoadContext(taskId, buildId, versionId, patchId, projectId string) (Context
 	// Try to load project for the ID we found, and set cookie with it for subsequent requests
 	if len(projectId) > 0 {
 		// Also lookup the ProjectRef itself and add it to context.
-		ctx.ProjectRef, err = FindMergedProjectRef(projectId, &versionId)
+		ctx.ProjectRef, err = FindMergedProjectRef(projectId, versionId, true)
 		if err != nil {
 			return ctx, err
 		}

--- a/model/generate.go
+++ b/model/generate.go
@@ -256,7 +256,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 		}
 		syncAtEndOpts = patchDoc.SyncAtEndOpts
 	}
-	projectRef, err := FindMergedProjectRef(p.Identifier, &v.Id)
+	projectRef, err := FindMergedProjectRef(p.Identifier, v.Id, true)
 	if err != nil {
 		return errors.Wrap(err, "unable to find project ref")
 	}

--- a/model/generate.go
+++ b/model/generate.go
@@ -256,7 +256,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 		}
 		syncAtEndOpts = patchDoc.SyncAtEndOpts
 	}
-	projectRef, err := FindMergedProjectRef(p.Identifier)
+	projectRef, err := FindMergedProjectRef(p.Identifier, v.Id)
 	if err != nil {
 		return errors.Wrap(err, "unable to find project ref")
 	}

--- a/model/generate.go
+++ b/model/generate.go
@@ -256,7 +256,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 		}
 		syncAtEndOpts = patchDoc.SyncAtEndOpts
 	}
-	projectRef, err := FindMergedProjectRef(p.Identifier, v.Id)
+	projectRef, err := FindMergedProjectRef(p.Identifier, &v.Id)
 	if err != nil {
 		return errors.Wrap(err, "unable to find project ref")
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -535,7 +535,7 @@ func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 	var pRef *ProjectRef
 	var githubCheckAliases ProjectAliases
 	if v.Requester == evergreen.RepotrackerVersionRequester {
-		pRef, err = FindMergedProjectRef(project.Identifier, &v.Id)
+		pRef, err = FindMergedProjectRef(project.Identifier, v.Id, true)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to find project ref")
 		}
@@ -579,7 +579,7 @@ func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 	batchTimeTaskStatuses := []BatchTimeTaskStatus{}
 	tasksWithActivationTime := activationInfo.getActivationTasks(b.BuildVariant)
 	if len(tasksWithActivationTime) > 0 && pRef == nil {
-		pRef, err = FindMergedProjectRef(project.Identifier, &v.Id)
+		pRef, err = FindMergedProjectRef(project.Identifier, v.Id, true)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to find project ref")
 		}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -535,7 +535,7 @@ func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 	var pRef *ProjectRef
 	var githubCheckAliases ProjectAliases
 	if v.Requester == evergreen.RepotrackerVersionRequester {
-		pRef, err = FindMergedProjectRef(project.Identifier, v.Id)
+		pRef, err = FindMergedProjectRef(project.Identifier, &v.Id)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to find project ref")
 		}
@@ -579,7 +579,7 @@ func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 	batchTimeTaskStatuses := []BatchTimeTaskStatus{}
 	tasksWithActivationTime := activationInfo.getActivationTasks(b.BuildVariant)
 	if len(tasksWithActivationTime) > 0 && pRef == nil {
-		pRef, err = FindMergedProjectRef(project.Identifier, v.Id)
+		pRef, err = FindMergedProjectRef(project.Identifier, &v.Id)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to find project ref")
 		}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -535,7 +535,7 @@ func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 	var pRef *ProjectRef
 	var githubCheckAliases ProjectAliases
 	if v.Requester == evergreen.RepotrackerVersionRequester {
-		pRef, err = FindMergedProjectRef(project.Identifier)
+		pRef, err = FindMergedProjectRef(project.Identifier, v.Id)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to find project ref")
 		}
@@ -579,7 +579,7 @@ func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 	batchTimeTaskStatuses := []BatchTimeTaskStatus{}
 	tasksWithActivationTime := activationInfo.getActivationTasks(b.BuildVariant)
 	if len(tasksWithActivationTime) > 0 && pRef == nil {
-		pRef, err = FindMergedProjectRef(project.Identifier)
+		pRef, err = FindMergedProjectRef(project.Identifier, v.Id)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to find project ref")
 		}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -456,7 +456,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 }
 
 func getLoadProjectOptsForPatch(p *patch.Patch, githubOauthToken string) (*ProjectRef, *GetProjectOpts, error) {
-	projectRef, err := FindMergedProjectRef(p.Project, p.Version)
+	projectRef, err := FindMergedProjectRef(p.Project, &p.Version)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
@@ -678,7 +678,7 @@ func MakeMergePatchFromExisting(ctx context.Context, existingPatch *patch.Patch,
 	}
 
 	// verify the commit queue is on
-	projectRef, err := FindMergedProjectRef(existingPatch.Project, existingPatch.Version)
+	projectRef, err := FindMergedProjectRef(existingPatch.Project, &existingPatch.Version)
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't get project ref '%s'", existingPatch.Project)
 	}
@@ -858,7 +858,7 @@ func SendCommitQueueResult(p *patch.Patch, status message.GithubState, descripti
 	if p.GithubPatchData.PRNumber == 0 {
 		return nil
 	}
-	projectRef, err := FindMergedProjectRef(p.Project, p.Version)
+	projectRef, err := FindMergedProjectRef(p.Project, &p.Version)
 	if err != nil {
 		return errors.Wrap(err, "unable to find project")
 	}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -456,7 +456,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 }
 
 func getLoadProjectOptsForPatch(p *patch.Patch, githubOauthToken string) (*ProjectRef, *GetProjectOpts, error) {
-	projectRef, err := FindMergedProjectRef(p.Project, &p.Version)
+	projectRef, err := FindMergedProjectRef(p.Project, p.Version, true)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
@@ -678,7 +678,7 @@ func MakeMergePatchFromExisting(ctx context.Context, existingPatch *patch.Patch,
 	}
 
 	// verify the commit queue is on
-	projectRef, err := FindMergedProjectRef(existingPatch.Project, &existingPatch.Version)
+	projectRef, err := FindMergedProjectRef(existingPatch.Project, existingPatch.Version, true)
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't get project ref '%s'", existingPatch.Project)
 	}
@@ -858,7 +858,7 @@ func SendCommitQueueResult(p *patch.Patch, status message.GithubState, descripti
 	if p.GithubPatchData.PRNumber == 0 {
 		return nil
 	}
-	projectRef, err := FindMergedProjectRef(p.Project, &p.Version)
+	projectRef, err := FindMergedProjectRef(p.Project, p.Version, true)
 	if err != nil {
 		return errors.Wrap(err, "unable to find project")
 	}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -456,7 +456,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 }
 
 func getLoadProjectOptsForPatch(p *patch.Patch, githubOauthToken string) (*ProjectRef, *GetProjectOpts, error) {
-	projectRef, err := FindMergedProjectRef(p.Project)
+	projectRef, err := FindMergedProjectRef(p.Project, p.Version)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
@@ -678,7 +678,7 @@ func MakeMergePatchFromExisting(ctx context.Context, existingPatch *patch.Patch,
 	}
 
 	// verify the commit queue is on
-	projectRef, err := FindMergedProjectRef(existingPatch.Project)
+	projectRef, err := FindMergedProjectRef(existingPatch.Project, existingPatch.Version)
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't get project ref '%s'", existingPatch.Project)
 	}
@@ -858,7 +858,7 @@ func SendCommitQueueResult(p *patch.Patch, status message.GithubState, descripti
 	if p.GithubPatchData.PRNumber == 0 {
 		return nil
 	}
-	projectRef, err := FindMergedProjectRef(p.Project)
+	projectRef, err := FindMergedProjectRef(p.Project, p.Version)
 	if err != nil {
 		return errors.Wrap(err, "unable to find project")
 	}

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -60,28 +60,6 @@ func ParserProjectFindOneById(id string) (*ParserProject, error) {
 	return ParserProjectFindOne(ParserProjectById(id))
 }
 
-// ParserProjectFindOneIdWithFields returns a parser project with the given ID, projecting only
-// the given fields.
-func ParserProjectFindOneIdWithFields(id string, projected ...string) (*ParserProject, error) {
-	pp := &ParserProject{}
-	query := db.Query(bson.M{ParserProjectIdKey: id})
-
-	if len(projected) > 0 {
-		query = query.WithFields(projected...)
-	}
-
-	err := db.FindOneQ(ParserProjectCollection, query, pp)
-
-	if adb.ResultsNotFound(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, errors.Wrap(err, "")
-	}
-
-	return pp, nil
-}
-
 // ParserProjectFindOne finds a parser project with a given query.
 func ParserProjectFindOne(query db.Q) (*ParserProject, error) {
 	project := &ParserProject{}
@@ -109,10 +87,10 @@ func ParserProjectByVersion(projectId string, version string) (*ParserProject, e
 		version = lastGoodVersion.Id
 		lookupVersion = true
 	}
-	parserProject, err := ParserProjectFindOneIdWithFields(version,
+	parserProject, err := ParserProjectFindOne(ParserProjectById(version).WithFields(
 		ParserProjectPerfEnabledKey, ProjectRefDeactivatePreviousKey, ParserProjectTaskAnnotationSettingsKey, ParserProjectBuildBaronSettingsKey,
 		ParserProjectCommitQueueAliasesKey, ParserProjectPatchAliasesKey, ParserProjectGitHubChecksAliasesKey, ParserProjectGitTagAliasesKey,
-		ParserProjectGitHubPRAliasesKey)
+		ParserProjectGitHubPRAliasesKey))
 	if err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{
 			"message":        "Error retrieving parser project for version",

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/evergreen"
-	mgobson "gopkg.in/mgo.v2/bson"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
@@ -13,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -21,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
+	mgobson "gopkg.in/mgo.v2/bson"
 	"gopkg.in/yaml.v3"
 )
 

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/evergreen"
+	mgobson "gopkg.in/mgo.v2/bson"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
@@ -1676,6 +1678,80 @@ func TestMergeUnorderedUnique(t *testing.T) {
 	assert.Equal(t, len(main.Parameters), 2)
 	assert.Equal(t, len(main.Modules), 2)
 	assert.Equal(t, len(main.Functions), 4)
+}
+
+func TestParserProjectFindOneIdWithFields(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(ParserProjectCollection))
+	pp := &ParserProject{
+		Id: "version1",
+		Tasks: []parserTask{
+			{Name: "my_task", PatchOnly: utility.TruePtr(), ExecTimeoutSecs: 15},
+			{Name: "your_task", GitTagOnly: utility.FalsePtr(), Stepback: utility.TruePtr(), RunOn: []string{"a different distro"}},
+			{Name: "tg_task", PatchOnly: utility.TruePtr(), RunOn: []string{"a different distro"}},
+		},
+		TaskGroups: []parserTaskGroup{
+			{
+				Name:  "my_tg",
+				Tasks: []string{"tg_task"},
+			},
+		},
+		Parameters: []ParameterInfo{
+			{
+				Parameter: patch.Parameter{
+					Key:   "key",
+					Value: "val",
+				},
+			},
+		},
+		Modules: []Module{
+			{
+				Name: "my_module",
+			},
+		},
+		Functions: map[string]*YAMLCommandSet{
+			"func1": &YAMLCommandSet{
+				SingleCommand: &PluginCommandConf{
+					Command: "single_command",
+				},
+			},
+			"func2": &YAMLCommandSet{
+				MultiCommand: []PluginCommandConf{
+					{
+						Command: "multi_command1",
+					}, {
+						Command: "multi_command2",
+					},
+				},
+			},
+		},
+		TaskAnnotationSettings: &evergreen.AnnotationsSettings{
+			FileTicketWebHook: evergreen.WebHook{
+				Endpoint: "random2",
+			},
+		},
+		DeactivatePrevious: utility.TruePtr(),
+		CommitQueueAliases: []ProjectAlias{
+			ProjectAlias{
+				ID:        mgobson.NewObjectId(),
+				ProjectID: projectId,
+				Alias:     "alias1",
+				Variant:   "ubuntu",
+				Task:      "subcommand",
+			},
+		},
+	}
+	assert.NoError(t, pp.Insert())
+
+	ppSelectedFields, err := ParserProjectByVersion("", "version1")
+	assert.NoError(t, err)
+	assert.Nil(t, ppSelectedFields.Tasks)
+	assert.Nil(t, ppSelectedFields.Modules)
+	assert.Nil(t, ppSelectedFields.TaskGroups)
+	assert.Nil(t, ppSelectedFields.Parameters)
+	assert.Nil(t, ppSelectedFields.Tasks)
+	assert.NotNil(t, ppSelectedFields.TaskAnnotationSettings)
+	assert.NotNil(t, ppSelectedFields.DeactivatePrevious)
+	assert.NotNil(t, ppSelectedFields.CommitQueueAliases)
 }
 
 func TestMergeUnorderedUniqueFail(t *testing.T) {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -499,7 +499,7 @@ func (p *ProjectRef) DetachFromRepo(u *user.DBUser) error {
 	p.UseRepoSettings = false
 	p.RepoRefId = ""
 
-	mergedProject, err := FindMergedProjectRef(p.Id)
+	mergedProject, err := FindMergedProjectRef(p.Id, "")
 	if err != nil {
 		return errors.Wrap(err, "error finding merged project ref")
 	}
@@ -707,7 +707,7 @@ func FindBranchProjectRef(identifier string) (*ProjectRef, error) {
 }
 
 // FindMergedProjectRef also finds the repo ref settings and merges relevant fields.
-func FindMergedProjectRef(identifier string) (*ProjectRef, error) {
+func FindMergedProjectRef(identifier string, version string) (*ProjectRef, error) {
 	pRef, err := FindBranchProjectRef(identifier)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error finding project ref '%s'", identifier)
@@ -725,10 +725,10 @@ func FindMergedProjectRef(identifier string) (*ProjectRef, error) {
 		}
 		pRef, err = mergeBranchAndRepoSettings(pRef, repoRef)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error merging repo ref '%s' for project '%s'", repoRef.RepoRefId, identifier)
+			return nil, errors.Wrapf(err, "error merging repo ref '%s' for project '%s'", repoRef.RepoRefId, pRef.Identifier)
 		}
 	}
-	err = pRef.MergeWithParserProject("")
+	err = pRef.MergeWithParserProject(version)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Unable to merge parser project with project ref %s", pRef.Identifier)
 	}
@@ -1401,7 +1401,7 @@ func GetProjectSettings(p *ProjectRef) (*ProjectSettings, error) {
 }
 
 func IsPerfEnabledForProject(projectId string) bool {
-	projectRef, err := FindMergedProjectRef(projectId)
+	projectRef, err := FindMergedProjectRef(projectId, "")
 	if err != nil || projectRef == nil {
 		return false
 	}
@@ -2129,7 +2129,7 @@ func GetProjectRefForTask(taskId string) (*ProjectRef, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding project")
 	}
-	pRef, err := FindMergedProjectRef(projectId)
+	pRef, err := FindMergedProjectRef(projectId, "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting project '%s'", projectId)
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -723,7 +723,14 @@ func FindMergedProjectRef(identifier string) (*ProjectRef, error) {
 		if repoRef == nil {
 			return nil, errors.Errorf("repo ref '%s' does not exist for project '%s'", pRef.RepoRefId, pRef.Identifier)
 		}
-		return mergeBranchAndRepoSettings(pRef, repoRef)
+		pRef, err = mergeBranchAndRepoSettings(pRef, repoRef)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error merging repo ref '%s' for project '%s'", repoRef.RepoRefId, identifier)
+		}
+	}
+	err = pRef.MergeWithParserProject("")
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to merge parser project with project ref %s", pRef.Identifier)
 	}
 	return pRef, nil
 }
@@ -1396,10 +1403,6 @@ func GetProjectSettings(p *ProjectRef) (*ProjectSettings, error) {
 func IsPerfEnabledForProject(projectId string) bool {
 	projectRef, err := FindMergedProjectRef(projectId)
 	if err != nil || projectRef == nil {
-		return false
-	}
-	err = projectRef.MergeWithParserProject("")
-	if err != nil {
 		return false
 	}
 	return projectRef.IsPerfEnabled()

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -115,7 +115,7 @@ func TestFindMergedProjectRef(t *testing.T) {
 	}}
 	assert.NoError(t, repoRef.Upsert())
 
-	mergedProject, err := FindMergedProjectRef("ident", "ident")
+	mergedProject, err := FindMergedProjectRef("ident", utility.ToStringPtr("ident"))
 	assert.NoError(t, err)
 	require.NotNil(t, mergedProject)
 	assert.Equal(t, "ident", mergedProject.Id)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -115,7 +115,7 @@ func TestFindMergedProjectRef(t *testing.T) {
 	}}
 	assert.NoError(t, repoRef.Upsert())
 
-	mergedProject, err := FindMergedProjectRef("ident")
+	mergedProject, err := FindMergedProjectRef("ident", "ident")
 	assert.NoError(t, err)
 	require.NotNil(t, mergedProject)
 	assert.Equal(t, "ident", mergedProject.Id)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -115,7 +115,7 @@ func TestFindMergedProjectRef(t *testing.T) {
 	}}
 	assert.NoError(t, repoRef.Upsert())
 
-	mergedProject, err := FindMergedProjectRef("ident", utility.ToStringPtr("ident"))
+	mergedProject, err := FindMergedProjectRef("ident", "ident", true)
 	assert.NoError(t, err)
 	require.NotNil(t, mergedProject)
 	assert.Equal(t, "ident", mergedProject.Id)

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -159,7 +159,7 @@ func IsWebhookConfigured(project string, version string) (evergreen.WebHook, boo
 		return evergreen.WebHook{}, false, err
 	}
 	if flags.PluginAdminPageDisabled {
-		projectRef, err := model.FindMergedProjectRef(project)
+		projectRef, err := model.FindMergedProjectRef(project, version)
 		if err != nil || projectRef == nil {
 			return evergreen.WebHook{}, false, errors.Errorf("Unable to find merged project ref for project %s", project)
 		}
@@ -223,7 +223,7 @@ func BbGetProject(settings *evergreen.Settings, projectId string, version string
 				return *parserProject.BuildBaronSettings, true
 			}
 		}
-		projectRef, err := model.FindMergedProjectRef(projectId)
+		projectRef, err := model.FindMergedProjectRef(projectId, version)
 		if err != nil || projectRef == nil {
 			return evergreen.BuildBaronSettings{}, false
 		}

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -163,10 +163,6 @@ func IsWebhookConfigured(project string, version string) (evergreen.WebHook, boo
 		if err != nil || projectRef == nil {
 			return evergreen.WebHook{}, false, errors.Errorf("Unable to find merged project ref for project %s", project)
 		}
-		err = projectRef.MergeWithParserProject(version)
-		if err != nil {
-			return evergreen.WebHook{}, false, errors.Errorf("Unable to merge parser project with project ref %s", project)
-		}
 		webHook = projectRef.TaskAnnotationSettings.FileTicketWebHook
 	} else {
 		bbProject, _ := BbGetProject(evergreen.GetEnvironment().Settings(), project, "")

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -159,7 +159,7 @@ func IsWebhookConfigured(project string, version string) (evergreen.WebHook, boo
 		return evergreen.WebHook{}, false, err
 	}
 	if flags.PluginAdminPageDisabled {
-		projectRef, err := model.FindMergedProjectRef(project, version)
+		projectRef, err := model.FindMergedProjectRef(project, &version)
 		if err != nil || projectRef == nil {
 			return evergreen.WebHook{}, false, errors.Errorf("Unable to find merged project ref for project %s", project)
 		}
@@ -223,7 +223,7 @@ func BbGetProject(settings *evergreen.Settings, projectId string, version string
 				return *parserProject.BuildBaronSettings, true
 			}
 		}
-		projectRef, err := model.FindMergedProjectRef(projectId, version)
+		projectRef, err := model.FindMergedProjectRef(projectId, &version)
 		if err != nil || projectRef == nil {
 			return evergreen.BuildBaronSettings{}, false
 		}

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -159,7 +159,7 @@ func IsWebhookConfigured(project string, version string) (evergreen.WebHook, boo
 		return evergreen.WebHook{}, false, err
 	}
 	if flags.PluginAdminPageDisabled {
-		projectRef, err := model.FindMergedProjectRef(project, &version)
+		projectRef, err := model.FindMergedProjectRef(project, version, true)
 		if err != nil || projectRef == nil {
 			return evergreen.WebHook{}, false, errors.Errorf("Unable to find merged project ref for project %s", project)
 		}
@@ -223,7 +223,7 @@ func BbGetProject(settings *evergreen.Settings, projectId string, version string
 				return *parserProject.BuildBaronSettings, true
 			}
 		}
-		projectRef, err := model.FindMergedProjectRef(projectId, &version)
+		projectRef, err := model.FindMergedProjectRef(projectId, version, true)
 		if err != nil || projectRef == nil {
 			return evergreen.BuildBaronSettings{}, false
 		}

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -338,7 +338,7 @@ func (pc *DBCommitQueueConnector) GetMessageForPatch(patchID string) (string, er
 	if requestedPatch == nil {
 		return "", errors.New("no patch found")
 	}
-	project, err := model.FindMergedProjectRef(requestedPatch.Project)
+	project, err := model.FindMergedProjectRef(requestedPatch.Project, requestedPatch.Version)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to find project for patch")
 	}

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -338,7 +338,7 @@ func (pc *DBCommitQueueConnector) GetMessageForPatch(patchID string) (string, er
 	if requestedPatch == nil {
 		return "", errors.New("no patch found")
 	}
-	project, err := model.FindMergedProjectRef(requestedPatch.Project, requestedPatch.Version)
+	project, err := model.FindMergedProjectRef(requestedPatch.Project, &requestedPatch.Version)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to find project for patch")
 	}

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -338,7 +338,7 @@ func (pc *DBCommitQueueConnector) GetMessageForPatch(patchID string) (string, er
 	if requestedPatch == nil {
 		return "", errors.New("no patch found")
 	}
-	project, err := model.FindMergedProjectRef(requestedPatch.Project, &requestedPatch.Version)
+	project, err := model.FindMergedProjectRef(requestedPatch.Project, requestedPatch.Version, true)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to find project for patch")
 	}

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -102,8 +102,8 @@ type Connector interface {
 	// CopyProjectVars copies the variables for the first project to the second
 	CopyProjectVars(string, string) error
 
-	// Find the project matching the given ProjectId. Includes repo settings if set.
-	FindProjectById(string, bool) (*model.ProjectRef, error)
+	// Find the project matching the given ProjectId. Includes repo settings and parser project settings if set.
+	FindProjectById(string, bool, bool) (*model.ProjectRef, error)
 	// Create/Update a project the given projectRef
 	CreateProject(*model.ProjectRef, *user.DBUser) error
 	UpdateProject(*model.ProjectRef) error

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -24,11 +24,13 @@ import (
 type DBProjectConnector struct{}
 
 // FindProjectById queries the database for the project matching the projectRef.Id.
-func (pc *DBProjectConnector) FindProjectById(id string, includeRepo bool) (*model.ProjectRef, error) {
+func (pc *DBProjectConnector) FindProjectById(id string, includeRepo bool, includeParserProject bool) (*model.ProjectRef, error) {
 	var p *model.ProjectRef
 	var err error
-	if includeRepo {
-		p, err = model.FindMergedProjectRef(id, "")
+	if includeRepo && includeParserProject {
+		p, err = model.FindMergedProjectRef(id, utility.ToStringPtr(""))
+	} else if includeRepo {
+		p, err = model.FindMergedProjectRef(id, nil)
 	} else {
 		p, err = model.FindBranchProjectRef(id)
 	}
@@ -79,7 +81,7 @@ func (pc *DBProjectConnector) UpdateProject(projectRef *model.ProjectRef) error 
 }
 
 func (sc *DBProjectConnector) VerifyUniqueProject(name string) error {
-	_, err := sc.FindProjectById(name, false)
+	_, err := sc.FindProjectById(name, false, false)
 	if err == nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -434,7 +436,7 @@ type MockProjectConnector struct {
 	CachedEvents   []restModel.APIProjectEvent
 }
 
-func (pc *MockProjectConnector) FindProjectById(projectId string, includeRepo bool) (*model.ProjectRef, error) {
+func (pc *MockProjectConnector) FindProjectById(projectId string, includeRepo bool, includeParserProject bool) (*model.ProjectRef, error) {
 	for _, p := range pc.CachedProjects {
 		if p.Id == projectId || p.Identifier == projectId {
 			return &p, nil
@@ -513,7 +515,7 @@ func (pc *MockProjectConnector) UpdateProject(projectRef *model.ProjectRef) erro
 }
 
 func (sc *MockProjectConnector) VerifyUniqueProject(name string) error {
-	_, err := sc.FindProjectById(name, false)
+	_, err := sc.FindProjectById(name, false, false)
 	if err == nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -28,7 +28,7 @@ func (pc *DBProjectConnector) FindProjectById(id string, includeRepo bool) (*mod
 	var p *model.ProjectRef
 	var err error
 	if includeRepo {
-		p, err = model.FindMergedProjectRef(id)
+		p, err = model.FindMergedProjectRef(id, "")
 	} else {
 		p, err = model.FindBranchProjectRef(id)
 	}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -28,9 +28,9 @@ func (pc *DBProjectConnector) FindProjectById(id string, includeRepo bool, inclu
 	var p *model.ProjectRef
 	var err error
 	if includeRepo && includeParserProject {
-		p, err = model.FindMergedProjectRef(id, utility.ToStringPtr(""))
+		p, err = model.FindMergedProjectRef(id, "", true)
 	} else if includeRepo {
-		p, err = model.FindMergedProjectRef(id, nil)
+		p, err = model.FindMergedProjectRef(id, "", false)
 	} else {
 		p, err = model.FindBranchProjectRef(id)
 	}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -24,7 +24,7 @@ type CopyProjectOpts struct {
 }
 
 func (sc *DBConnector) CopyProject(ctx context.Context, opts CopyProjectOpts) (*restModel.APIProjectRef, error) {
-	projectToCopy, err := sc.FindProjectById(opts.ProjectIdToCopy, false)
+	projectToCopy, err := sc.FindProjectById(opts.ProjectIdToCopy, false, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Database error finding project '%s'", opts.ProjectIdToCopy)
 	}
@@ -204,7 +204,7 @@ func (sc *MockConnector) SaveProjectSettingsForSection(ctx context.Context, proj
 }
 
 func (sc *MockConnector) CopyProject(ctx context.Context, opts CopyProjectOpts) (*restModel.APIProjectRef, error) {
-	projectToCopy, err := sc.FindProjectById(opts.ProjectIdToCopy, false)
+	projectToCopy, err := sc.FindProjectById(opts.ProjectIdToCopy, false, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Database error finding project '%s'", opts.ProjectIdToCopy)
 	}

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -62,13 +62,13 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			assert.Equal(t, repoRefFromDb.Admins, ref.Admins)
 
 			// should be restricted
-			projectThatDefaults, err := model.FindMergedProjectRef("myId", utility.ToStringPtr(""))
+			projectThatDefaults, err := model.FindMergedProjectRef("myId", "", true)
 			assert.NoError(t, err)
 			assert.NotNil(t, projectThatDefaults)
 			assert.True(t, projectThatDefaults.IsRestricted())
 
 			// should not be restricted
-			projectThatDoesNotDefault, err := model.FindMergedProjectRef("myId2", utility.ToStringPtr(""))
+			projectThatDoesNotDefault, err := model.FindMergedProjectRef("myId2", "", true)
 			assert.NoError(t, err)
 			assert.NotNil(t, projectThatDoesNotDefault)
 			assert.False(t, projectThatDoesNotDefault.IsRestricted())
@@ -274,7 +274,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Nil(t, pRefFromDB.Restricted)
 			assert.Equal(t, pRefFromDB.Admins, ref.Admins)
 
-			mergedProject, err := model.FindMergedProjectRef(ref.Id, utility.ToStringPtr(""))
+			mergedProject, err := model.FindMergedProjectRef(ref.Id, "", true)
 			assert.NoError(t, err)
 			assert.NotNil(t, mergedProject)
 			assert.True(t, mergedProject.IsRestricted())

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -62,13 +62,13 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			assert.Equal(t, repoRefFromDb.Admins, ref.Admins)
 
 			// should be restricted
-			projectThatDefaults, err := model.FindMergedProjectRef("myId")
+			projectThatDefaults, err := model.FindMergedProjectRef("myId", "")
 			assert.NoError(t, err)
 			assert.NotNil(t, projectThatDefaults)
 			assert.True(t, projectThatDefaults.IsRestricted())
 
 			// should not be restricted
-			projectThatDoesNotDefault, err := model.FindMergedProjectRef("myId2")
+			projectThatDoesNotDefault, err := model.FindMergedProjectRef("myId2", "")
 			assert.NoError(t, err)
 			assert.NotNil(t, projectThatDoesNotDefault)
 			assert.False(t, projectThatDoesNotDefault.IsRestricted())
@@ -274,7 +274,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Nil(t, pRefFromDB.Restricted)
 			assert.Equal(t, pRefFromDB.Admins, ref.Admins)
 
-			mergedProject, err := model.FindMergedProjectRef(ref.Id)
+			mergedProject, err := model.FindMergedProjectRef(ref.Id, "")
 			assert.NoError(t, err)
 			assert.NotNil(t, mergedProject)
 			assert.True(t, mergedProject.IsRestricted())

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -62,13 +62,13 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			assert.Equal(t, repoRefFromDb.Admins, ref.Admins)
 
 			// should be restricted
-			projectThatDefaults, err := model.FindMergedProjectRef("myId", "")
+			projectThatDefaults, err := model.FindMergedProjectRef("myId", utility.ToStringPtr(""))
 			assert.NoError(t, err)
 			assert.NotNil(t, projectThatDefaults)
 			assert.True(t, projectThatDefaults.IsRestricted())
 
 			// should not be restricted
-			projectThatDoesNotDefault, err := model.FindMergedProjectRef("myId2", "")
+			projectThatDoesNotDefault, err := model.FindMergedProjectRef("myId2", utility.ToStringPtr(""))
 			assert.NoError(t, err)
 			assert.NotNil(t, projectThatDoesNotDefault)
 			assert.False(t, projectThatDoesNotDefault.IsRestricted())
@@ -274,7 +274,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Nil(t, pRefFromDB.Restricted)
 			assert.Equal(t, pRefFromDB.Admins, ref.Admins)
 
-			mergedProject, err := model.FindMergedProjectRef(ref.Id, "")
+			mergedProject, err := model.FindMergedProjectRef(ref.Id, utility.ToStringPtr(""))
 			assert.NoError(t, err)
 			assert.NotNil(t, mergedProject)
 			assert.True(t, mergedProject.IsRestricted())

--- a/rest/route/commit_queue.go
+++ b/rest/route/commit_queue.go
@@ -87,7 +87,7 @@ func (cq *commitQueueDeleteItemHandler) Parse(ctx context.Context, r *http.Reque
 }
 
 func (cq *commitQueueDeleteItemHandler) Run(ctx context.Context) gimlet.Responder {
-	projectRef, err := cq.sc.FindProjectById(cq.project, true)
+	projectRef, err := cq.sc.FindProjectById(cq.project, true, false)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "can't find project '%s'", cq.project))
 	}

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -629,7 +629,7 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 		return []string{repoID}, http.StatusOK, nil
 	}
 
-	projectRef, err := model.FindMergedProjectRef(projectID, &versionID)
+	projectRef, err := model.FindMergedProjectRef(projectID, versionID, true)
 	if err != nil {
 		return nil, http.StatusNotFound, errors.WithStack(err)
 	}

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -629,7 +629,7 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 		return []string{repoID}, http.StatusOK, nil
 	}
 
-	projectRef, err := model.FindMergedProjectRef(projectID)
+	projectRef, err := model.FindMergedProjectRef(projectID, versionID)
 	if err != nil {
 		return nil, http.StatusNotFound, errors.WithStack(err)
 	}

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -629,7 +629,7 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 		return []string{repoID}, http.StatusOK, nil
 	}
 
-	projectRef, err := model.FindMergedProjectRef(projectID, versionID)
+	projectRef, err := model.FindMergedProjectRef(projectID, &versionID)
 	if err != nil {
 		return nil, http.StatusNotFound, errors.WithStack(err)
 	}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -978,7 +978,7 @@ func (p *GetPatchTriggerAliasHandler) Parse(ctx context.Context, r *http.Request
 }
 
 func (p *GetPatchTriggerAliasHandler) Run(ctx context.Context) gimlet.Responder {
-	proj, err := dbModel.FindMergedProjectRef(p.projectID, utility.ToStringPtr(""))
+	proj, err := dbModel.FindMergedProjectRef(p.projectID, "", true)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error getting project",

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -976,7 +976,7 @@ func (p *GetPatchTriggerAliasHandler) Parse(ctx context.Context, r *http.Request
 }
 
 func (p *GetPatchTriggerAliasHandler) Run(ctx context.Context) gimlet.Responder {
-	proj, err := dbModel.FindMergedProjectRef(p.projectID)
+	proj, err := dbModel.FindMergedProjectRef(p.projectID, "")
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error getting project",

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -231,7 +231,7 @@ func (h *projectIDPatchHandler) Parse(ctx context.Context, r *http.Request) erro
 		return errors.Wrap(err, "Argument read error")
 	}
 
-	oldProject, err := h.sc.FindProjectById(h.project, false)
+	oldProject, err := h.sc.FindProjectById(h.project, false, false)
 	if err != nil {
 		return errors.Wrap(err, "error finding original project")
 	}
@@ -552,7 +552,7 @@ func (h *projectIDPutHandler) Parse(ctx context.Context, r *http.Request) error 
 
 // creates a new resource based on the Request-URI and JSON payload and returns a http.StatusCreated (201)
 func (h *projectIDPutHandler) Run(ctx context.Context) gimlet.Responder {
-	p, err := h.sc.FindProjectById(h.projectName, false)
+	p, err := h.sc.FindProjectById(h.projectName, false, false)
 	if err != nil && err.(gimlet.ErrorResponse).StatusCode != http.StatusNotFound {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "Database error for find() by project '%s'", h.projectName))
 	}
@@ -723,9 +723,10 @@ func (h *projectDeleteHandler) Run(ctx context.Context) gimlet.Responder {
 // GET /rest/v2/projects/{project_id}
 
 type projectIDGetHandler struct {
-	projectName string
-	includeRepo bool
-	sc          data.Connector
+	projectName          string
+	includeRepo          bool
+	includeParserProject bool
+	sc                   data.Connector
 }
 
 func makeGetProjectByID(sc data.Connector) gimlet.RouteHandler {
@@ -743,11 +744,12 @@ func (h *projectIDGetHandler) Factory() gimlet.RouteHandler {
 func (h *projectIDGetHandler) Parse(ctx context.Context, r *http.Request) error {
 	h.projectName = gimlet.GetVars(r)["project_id"]
 	h.includeRepo = r.URL.Query().Get("includeRepo") == "true"
+	h.includeParserProject = r.URL.Query().Get("includeParserProject") == "true"
 	return nil
 }
 
 func (h *projectIDGetHandler) Run(ctx context.Context) gimlet.Responder {
-	project, err := h.sc.FindProjectById(h.projectName, h.includeRepo)
+	project, err := h.sc.FindProjectById(h.projectName, h.includeRepo, h.includeParserProject)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
@@ -976,7 +978,7 @@ func (p *GetPatchTriggerAliasHandler) Parse(ctx context.Context, r *http.Request
 }
 
 func (p *GetPatchTriggerAliasHandler) Run(ctx context.Context) gimlet.Responder {
-	proj, err := dbModel.FindMergedProjectRef(p.projectID, "")
+	proj, err := dbModel.FindMergedProjectRef(p.projectID, utility.ToStringPtr(""))
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error getting project",

--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -103,12 +103,12 @@ func (p *copyVariablesHandler) Parse(ctx context.Context, r *http.Request) error
 }
 
 func (p *copyVariablesHandler) Run(ctx context.Context) gimlet.Responder {
-	copyToProject, err := p.sc.FindProjectById(p.opts.CopyTo, false) // ensure project is existing
+	copyToProject, err := p.sc.FindProjectById(p.opts.CopyTo, false, false) // ensure project is existing
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error finding project '%s'", p.opts.CopyTo))
 	}
 
-	copyFromProject, err := p.sc.FindProjectById(p.copyFrom, false) // ensure project is existing
+	copyFromProject, err := p.sc.FindProjectById(p.copyFrom, false, false) // ensure project is existing
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error finding project '%s'", p.copyFrom))
 	}

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -103,10 +103,10 @@ func (s *ProjectCopySuite) TestCopyToNewProject() {
 	s.Require().Len(newProject.Admins, 1)
 	s.Equal("my-user", utility.FromStringPtr(newProject.Admins[0]))
 
-	res, err := s.route.sc.FindProjectById("projectC", false)
+	res, err := s.route.sc.FindProjectById("projectC", false, false)
 	s.NoError(err)
 	s.NotNil(res)
-	res, err = s.route.sc.FindProjectById("projectA", false)
+	res, err = s.route.sc.FindProjectById("projectA", false, false)
 	s.NoError(err)
 	s.NotNil(res)
 	vars, err := s.route.sc.FindProjectVarsById(utility.FromStringPtr(newProject.Id), "", false)

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -729,7 +729,7 @@ func TestDeleteProject(t *testing.T) {
 		resp := pdh.Run(ctx)
 		assert.Equal(t, http.StatusOK, resp.Status())
 
-		hiddenProj, err := serviceModel.FindMergedProjectRef(projects[i].Id)
+		hiddenProj, err := serviceModel.FindMergedProjectRef(projects[i].Id, "")
 		assert.NoError(t, err)
 		skeletonProj := serviceModel.ProjectRef{
 			Id:              projects[i].Id,

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -729,7 +729,7 @@ func TestDeleteProject(t *testing.T) {
 		resp := pdh.Run(ctx)
 		assert.Equal(t, http.StatusOK, resp.Status())
 
-		hiddenProj, err := serviceModel.FindMergedProjectRef(projects[i].Id, utility.ToStringPtr(""))
+		hiddenProj, err := serviceModel.FindMergedProjectRef(projects[i].Id, "", true)
 		assert.NoError(t, err)
 		skeletonProj := serviceModel.ProjectRef{
 			Id:              projects[i].Id,

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -154,7 +154,7 @@ func (s *ProjectPatchByIDSuite) TestGitTagVersionsEnabled() {
 	s.Require().Equal(http.StatusOK, resp.Status())
 
 	// verify that the repo fields weren't saved with the branch
-	p, err := s.sc.FindProjectById("dimoxinil", false)
+	p, err := s.sc.FindProjectById("dimoxinil", false, false)
 	s.NoError(err)
 	s.Require().NotNil(p)
 	s.Empty(p.GitTagAuthorizedUsers)
@@ -183,7 +183,7 @@ func (s *ProjectPatchByIDSuite) TestUseRepoSettings() {
 	s.NotNil(resp.Data())
 	s.Equal(resp.Status(), http.StatusOK)
 
-	p, err := s.sc.FindProjectById("dimoxinil", true)
+	p, err := s.sc.FindProjectById("dimoxinil", true, false)
 	s.NoError(err)
 	s.True(p.UseRepoSettings)
 	s.NotEmpty(p.RepoRefId)
@@ -218,7 +218,7 @@ func (s *ProjectPatchByIDSuite) TestFilesIgnoredFromCache() {
 	s.NotNil(resp.Data())
 	s.Equal(resp.Status(), http.StatusOK)
 
-	p, err := s.sc.FindProjectById("dimoxinil", true)
+	p, err := s.sc.FindProjectById("dimoxinil", true, false)
 	s.NoError(err)
 	s.False(p.FilesIgnoredFromCache == nil)
 	s.Len(p.FilesIgnoredFromCache, 0)
@@ -252,7 +252,7 @@ func (s *ProjectPatchByIDSuite) TestPatchTriggerAliases() {
 	s.NotNil(resp.Data())
 	s.Equal(resp.Status(), http.StatusOK)
 
-	p, err := s.sc.FindProjectById("dimoxinil", true)
+	p, err := s.sc.FindProjectById("dimoxinil", true, false)
 	s.NoError(err)
 	s.False(p.PatchTriggerAliases == nil)
 	s.Len(p.PatchTriggerAliases, 1)
@@ -269,7 +269,7 @@ func (s *ProjectPatchByIDSuite) TestPatchTriggerAliases() {
 	s.NotNil(resp.Data())
 	s.Equal(resp.Status(), http.StatusOK)
 
-	p, err = s.sc.FindProjectById("dimoxinil", true)
+	p, err = s.sc.FindProjectById("dimoxinil", true, false)
 	s.NoError(err)
 	s.NotNil(p.PatchTriggerAliases)
 	s.Len(p.PatchTriggerAliases, 0)
@@ -284,7 +284,7 @@ func (s *ProjectPatchByIDSuite) TestPatchTriggerAliases() {
 	s.NotNil(resp.Data())
 	s.Equal(resp.Status(), http.StatusOK)
 
-	p, err = s.sc.FindProjectById("dimoxinil", true)
+	p, err = s.sc.FindProjectById("dimoxinil", true, false)
 	s.NoError(err)
 	s.Nil(p.PatchTriggerAliases)
 }
@@ -370,7 +370,7 @@ func (s *ProjectPutSuite) TestRunNewWithValidEntity() {
 	s.NotNil(resp.Data())
 	s.Equal(resp.Status(), http.StatusCreated)
 
-	p, err := h.sc.FindProjectById("nutsandgum", false)
+	p, err := h.sc.FindProjectById("nutsandgum", false, false)
 	s.NoError(err)
 	s.Require().NotNil(p)
 	s.NotEqual("nutsandgum", p.Id)
@@ -729,7 +729,7 @@ func TestDeleteProject(t *testing.T) {
 		resp := pdh.Run(ctx)
 		assert.Equal(t, http.StatusOK, resp.Status())
 
-		hiddenProj, err := serviceModel.FindMergedProjectRef(projects[i].Id, "")
+		hiddenProj, err := serviceModel.FindMergedProjectRef(projects[i].Id, utility.ToStringPtr(""))
 		assert.NoError(t, err)
 		skeletonProj := serviceModel.ProjectRef{
 			Id:              projects[i].Id,

--- a/rest/route/version_create.go
+++ b/rest/route/version_create.go
@@ -52,7 +52,7 @@ func (h *versionCreateHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	projectInfo := &model.ProjectInfo{}
 	var err error
-	projectInfo.Ref, err = h.sc.FindProjectById(h.ProjectID, true)
+	projectInfo.Ref, err = h.sc.FindProjectById(h.ProjectID, true, true)
 	if err != nil {
 		return gimlet.NewJSONErrorResponse(err)
 	}

--- a/service/api.go
+++ b/service/api.go
@@ -223,7 +223,7 @@ func (as *APIServer) GetParserProject(w http.ResponseWriter, r *http.Request) {
 func (as *APIServer) GetProjectRef(w http.ResponseWriter, r *http.Request) {
 	t := MustHaveTask(r)
 
-	p, err := model.FindMergedProjectRef(t.Project, "")
+	p, err := model.FindMergedProjectRef(t.Project, &t.Version)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
@@ -490,7 +490,7 @@ func (as *APIServer) Heartbeat(w http.ResponseWriter, r *http.Request) {
 // fetchProjectRef returns a project ref given the project identifier
 func (as *APIServer) fetchProjectRef(w http.ResponseWriter, r *http.Request) {
 	id := gimlet.GetVars(r)["identifier"]
-	projectRef, err := model.FindMergedProjectRef(id, "")
+	projectRef, err := model.FindMergedProjectRef(id, utility.ToStringPtr(""))
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/service/api.go
+++ b/service/api.go
@@ -223,7 +223,7 @@ func (as *APIServer) GetParserProject(w http.ResponseWriter, r *http.Request) {
 func (as *APIServer) GetProjectRef(w http.ResponseWriter, r *http.Request) {
 	t := MustHaveTask(r)
 
-	p, err := model.FindMergedProjectRef(t.Project)
+	p, err := model.FindMergedProjectRef(t.Project, "")
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
@@ -490,7 +490,7 @@ func (as *APIServer) Heartbeat(w http.ResponseWriter, r *http.Request) {
 // fetchProjectRef returns a project ref given the project identifier
 func (as *APIServer) fetchProjectRef(w http.ResponseWriter, r *http.Request) {
 	id := gimlet.GetVars(r)["identifier"]
-	projectRef, err := model.FindMergedProjectRef(id)
+	projectRef, err := model.FindMergedProjectRef(id, "")
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/service/api.go
+++ b/service/api.go
@@ -223,7 +223,7 @@ func (as *APIServer) GetParserProject(w http.ResponseWriter, r *http.Request) {
 func (as *APIServer) GetProjectRef(w http.ResponseWriter, r *http.Request) {
 	t := MustHaveTask(r)
 
-	p, err := model.FindMergedProjectRef(t.Project, &t.Version)
+	p, err := model.FindMergedProjectRef(t.Project, t.Version, true)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
@@ -490,7 +490,7 @@ func (as *APIServer) Heartbeat(w http.ResponseWriter, r *http.Request) {
 // fetchProjectRef returns a project ref given the project identifier
 func (as *APIServer) fetchProjectRef(w http.ResponseWriter, r *http.Request) {
 	id := gimlet.GetVars(r)["identifier"]
-	projectRef, err := model.FindMergedProjectRef(id, utility.ToStringPtr(""))
+	projectRef, err := model.FindMergedProjectRef(id, "", true)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -63,7 +63,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		as.LoggedError(w, r, http.StatusBadRequest, err)
 		return
 	}
-	pref, err := model.FindMergedProjectRef(data.Project, "")
+	pref, err := model.FindMergedProjectRef(data.Project, utility.ToStringPtr(""))
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrapf(err, "project '%s' is not specified", data.Project))
 		return

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -63,7 +63,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		as.LoggedError(w, r, http.StatusBadRequest, err)
 		return
 	}
-	pref, err := model.FindMergedProjectRef(data.Project)
+	pref, err := model.FindMergedProjectRef(data.Project, "")
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrapf(err, "project '%s' is not specified", data.Project))
 		return

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -63,7 +63,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		as.LoggedError(w, r, http.StatusBadRequest, err)
 		return
 	}
-	pref, err := model.FindMergedProjectRef(data.Project, utility.ToStringPtr(""))
+	pref, err := model.FindMergedProjectRef(data.Project, "", true)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrapf(err, "project '%s' is not specified", data.Project))
 		return

--- a/service/api_plugin_manifest.go
+++ b/service/api_plugin_manifest.go
@@ -18,7 +18,7 @@ import (
 func (as *APIServer) manifestLoadHandler(w http.ResponseWriter, r *http.Request) {
 	task := MustHaveTask(r)
 
-	projectRef, err := model.FindMergedProjectRef(task.Project, &task.Version)
+	projectRef, err := model.FindMergedProjectRef(task.Project, task.Version, true)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError,
 			errors.Wrapf(err, "error finding project '%s'", task.Project))

--- a/service/api_plugin_manifest.go
+++ b/service/api_plugin_manifest.go
@@ -18,7 +18,7 @@ import (
 func (as *APIServer) manifestLoadHandler(w http.ResponseWriter, r *http.Request) {
 	task := MustHaveTask(r)
 
-	projectRef, err := model.FindMergedProjectRef(task.Project)
+	projectRef, err := model.FindMergedProjectRef(task.Project, task.Version)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError,
 			errors.Wrapf(err, "error finding project '%s'", task.Project))

--- a/service/api_plugin_manifest.go
+++ b/service/api_plugin_manifest.go
@@ -18,7 +18,7 @@ import (
 func (as *APIServer) manifestLoadHandler(w http.ResponseWriter, r *http.Request) {
 	task := MustHaveTask(r)
 
-	projectRef, err := model.FindMergedProjectRef(task.Project, task.Version)
+	projectRef, err := model.FindMergedProjectRef(task.Project, &task.Version)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError,
 			errors.Wrapf(err, "error finding project '%s'", task.Project))

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -194,7 +194,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projectRef, err := model.FindMergedProjectRef(t.Project)
+	projectRef, err := model.FindMergedProjectRef(t.Project, t.Version)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 	}
@@ -495,7 +495,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			continue
 		}
 
-		projectRef, err := model.FindMergedProjectRef(nextTask.Project)
+		projectRef, err := model.FindMergedProjectRef(nextTask.Project, nextTask.Version)
 		errMsg := message.Fields{
 			"task_id":            nextTask.Id,
 			"message":            "could not find project ref for next task, skipping",

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -194,7 +194,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projectRef, err := model.FindMergedProjectRef(t.Project, &t.Version)
+	projectRef, err := model.FindMergedProjectRef(t.Project, t.Version, true)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 	}
@@ -495,7 +495,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			continue
 		}
 
-		projectRef, err := model.FindMergedProjectRef(nextTask.Project, &nextTask.Version)
+		projectRef, err := model.FindMergedProjectRef(nextTask.Project, nextTask.Version, true)
 		errMsg := message.Fields{
 			"task_id":            nextTask.Id,
 			"message":            "could not find project ref for next task, skipping",

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -194,7 +194,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projectRef, err := model.FindMergedProjectRef(t.Project, t.Version)
+	projectRef, err := model.FindMergedProjectRef(t.Project, &t.Version)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 	}
@@ -495,7 +495,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			continue
 		}
 
-		projectRef, err := model.FindMergedProjectRef(nextTask.Project, nextTask.Version)
+		projectRef, err := model.FindMergedProjectRef(nextTask.Project, &nextTask.Version)
 		errMsg := message.Fields{
 			"task_id":            nextTask.Id,
 			"message":            "could not find project ref for next task, skipping",

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -223,12 +223,6 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// mark task as finished
-	err = projectRef.MergeWithParserProject(t.Version)
-	if err != nil {
-		err = errors.Wrapf(err, "Unable to merge parser project with project ref %s", t.Project)
-		as.LoggedError(w, r, http.StatusInternalServerError, err)
-		return
-	}
 	deactivatePrevious := utility.FromBoolPtr(projectRef.DeactivatePrevious)
 	err = model.MarkEnd(t, APIServerLockTitle, finishTime, details, deactivatePrevious)
 	if err != nil {

--- a/service/project.go
+++ b/service/project.go
@@ -87,7 +87,7 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if projRef.UseRepoSettings {
-		projRef, err = model.FindMergedProjectRef(projRef.Id)
+		projRef, err = model.FindMergedProjectRef(projRef.Id, "")
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusNotFound, err)
 			return

--- a/service/project.go
+++ b/service/project.go
@@ -87,7 +87,7 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if projRef.UseRepoSettings {
-		projRef, err = model.FindMergedProjectRef(projRef.Id, "")
+		projRef, err = model.FindMergedProjectRef(projRef.Id, nil)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusNotFound, err)
 			return

--- a/service/project.go
+++ b/service/project.go
@@ -87,7 +87,7 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if projRef.UseRepoSettings {
-		projRef, err = model.FindMergedProjectRef(projRef.Id, nil)
+		projRef, err = model.FindMergedProjectRef(projRef.Id, "", false)
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusNotFound, err)
 			return

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -68,7 +68,7 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting evergreen settings")
 	}
-	upstreamProject, err := model.FindMergedProjectRef(args.SourceVersion.Identifier, &args.SourceVersion.Id)
+	upstreamProject, err := model.FindMergedProjectRef(args.SourceVersion.Identifier, args.SourceVersion.Id, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding project ref")
 	}

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -68,7 +68,7 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting evergreen settings")
 	}
-	upstreamProject, err := model.FindMergedProjectRef(args.SourceVersion.Identifier)
+	upstreamProject, err := model.FindMergedProjectRef(args.SourceVersion.Identifier, pp.Id)
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding project ref")
 	}

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -68,7 +68,7 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting evergreen settings")
 	}
-	upstreamProject, err := model.FindMergedProjectRef(args.SourceVersion.Identifier, pp.Id)
+	upstreamProject, err := model.FindMergedProjectRef(args.SourceVersion.Identifier, &args.SourceVersion.Id)
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding project ref")
 	}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -255,7 +255,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 	}
 	hasPatch := evergreen.IsPatchRequester(buildDoc.Requester)
 
-	projectRef, err := model.FindMergedProjectRef(t.task.Project, &t.task.Version)
+	projectRef, err := model.FindMergedProjectRef(t.task.Project, t.task.Version, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch project ref while building email payload")
 	}
@@ -964,7 +964,7 @@ func JIRATaskPayload(subID, project, uiUrl, eventID, testNames string, t *task.T
 		return nil, errors.New("could not find version while building jira task payload")
 	}
 
-	projectRef, err := model.FindMergedProjectRef(t.Project, &t.Version)
+	projectRef, err := model.FindMergedProjectRef(t.Project, t.Version, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "error fetching project ref while building jira task payload")
 	}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -255,7 +255,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 	}
 	hasPatch := evergreen.IsPatchRequester(buildDoc.Requester)
 
-	projectRef, err := model.FindMergedProjectRef(t.task.Project, t.task.Version)
+	projectRef, err := model.FindMergedProjectRef(t.task.Project, &t.task.Version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch project ref while building email payload")
 	}
@@ -964,7 +964,7 @@ func JIRATaskPayload(subID, project, uiUrl, eventID, testNames string, t *task.T
 		return nil, errors.New("could not find version while building jira task payload")
 	}
 
-	projectRef, err := model.FindMergedProjectRef(t.Project, t.Version)
+	projectRef, err := model.FindMergedProjectRef(t.Project, &t.Version)
 	if err != nil {
 		return nil, errors.Wrap(err, "error fetching project ref while building jira task payload")
 	}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -255,7 +255,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 	}
 	hasPatch := evergreen.IsPatchRequester(buildDoc.Requester)
 
-	projectRef, err := model.FindMergedProjectRef(t.task.Project)
+	projectRef, err := model.FindMergedProjectRef(t.task.Project, t.task.Version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch project ref while building email payload")
 	}
@@ -964,7 +964,7 @@ func JIRATaskPayload(subID, project, uiUrl, eventID, testNames string, t *task.T
 		return nil, errors.New("could not find version while building jira task payload")
 	}
 
-	projectRef, err := model.FindMergedProjectRef(t.Project)
+	projectRef, err := model.FindMergedProjectRef(t.Project, t.Version)
 	if err != nil {
 		return nil, errors.Wrap(err, "error fetching project ref while building jira task payload")
 	}

--- a/units/cache_historical_test_data.go
+++ b/units/cache_historical_test_data.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/utility"
 	"regexp"
 	"strings"
 	"time"
@@ -189,7 +188,7 @@ func reportTiming(fn func()) time.Duration {
 }
 
 func getTasksToIgnore(projectId string) ([]*regexp.Regexp, error) {
-	ref, err := model.FindMergedProjectRef(projectId, utility.ToStringPtr(""))
+	ref, err := model.FindMergedProjectRef(projectId, "", true)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not get project ref")
 	}

--- a/units/cache_historical_test_data.go
+++ b/units/cache_historical_test_data.go
@@ -188,7 +188,7 @@ func reportTiming(fn func()) time.Duration {
 }
 
 func getTasksToIgnore(projectId string) ([]*regexp.Regexp, error) {
-	ref, err := model.FindMergedProjectRef(projectId)
+	ref, err := model.FindMergedProjectRef(projectId, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not get project ref")
 	}

--- a/units/cache_historical_test_data.go
+++ b/units/cache_historical_test_data.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/utility"
 	"regexp"
 	"strings"
 	"time"
@@ -188,7 +189,7 @@ func reportTiming(fn func()) time.Duration {
 }
 
 func getTasksToIgnore(projectId string) ([]*regexp.Regexp, error) {
-	ref, err := model.FindMergedProjectRef(projectId, "")
+	ref, err := model.FindMergedProjectRef(projectId, utility.ToStringPtr(""))
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not get project ref")
 	}

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -91,7 +91,7 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 	}
 
 	// stop if project is disabled
-	projectRef, err := model.FindMergedProjectRef(j.QueueID, nil)
+	projectRef, err := model.FindMergedProjectRef(j.QueueID, "", false)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "can't find project for queue id %s", j.QueueID))
 		return

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -91,7 +91,7 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 	}
 
 	// stop if project is disabled
-	projectRef, err := model.FindMergedProjectRef(j.QueueID, "")
+	projectRef, err := model.FindMergedProjectRef(j.QueueID, nil)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "can't find project for queue id %s", j.QueueID))
 		return

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -91,7 +91,7 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 	}
 
 	// stop if project is disabled
-	projectRef, err := model.FindMergedProjectRef(j.QueueID)
+	projectRef, err := model.FindMergedProjectRef(j.QueueID, "")
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "can't find project for queue id %s", j.QueueID))
 		return

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -154,7 +154,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		"job":           j.ID(),
 		"version":       t.Version,
 	})
-	pref, err := model.FindMergedProjectRef(t.Project)
+	pref, err := model.FindMergedProjectRef(t.Project, t.Version)
 	if err != nil {
 		return j.handleError(pp, v, errors.WithStack(err))
 	}

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -154,7 +154,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		"job":           j.ID(),
 		"version":       t.Version,
 	})
-	pref, err := model.FindMergedProjectRef(t.Project, t.Version)
+	pref, err := model.FindMergedProjectRef(t.Project, &t.Version)
 	if err != nil {
 		return j.handleError(pp, v, errors.WithStack(err))
 	}

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -154,7 +154,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		"job":           j.ID(),
 		"version":       t.Version,
 	})
-	pref, err := model.FindMergedProjectRef(t.Project, &t.Version)
+	pref, err := model.FindMergedProjectRef(t.Project, t.Version, true)
 	if err != nil {
 		return j.handleError(pp, v, errors.WithStack(err))
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -207,7 +207,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		patchDoc.DisplayNewUI = true
 	}
 
-	pref, err := model.FindMergedProjectRef(patchDoc.Project, &patchDoc.Version)
+	pref, err := model.FindMergedProjectRef(patchDoc.Project, patchDoc.Version, true)
 	if err != nil {
 		return errors.Wrap(err, "can't find patch project")
 	}
@@ -562,7 +562,7 @@ func (j *patchIntentProcessor) buildCliPatchDoc(ctx context.Context, patchDoc *p
 		}))
 	}()
 
-	projectRef, err := model.FindMergedProjectRef(patchDoc.Project, &patchDoc.Version)
+	projectRef, err := model.FindMergedProjectRef(patchDoc.Project, patchDoc.Version, true)
 	if err != nil {
 		return errors.Wrapf(err, "Could not find project ref '%s'", patchDoc.Project)
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -207,7 +207,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		patchDoc.DisplayNewUI = true
 	}
 
-	pref, err := model.FindMergedProjectRef(patchDoc.Project, patchDoc.Version)
+	pref, err := model.FindMergedProjectRef(patchDoc.Project, &patchDoc.Version)
 	if err != nil {
 		return errors.Wrap(err, "can't find patch project")
 	}
@@ -562,7 +562,7 @@ func (j *patchIntentProcessor) buildCliPatchDoc(ctx context.Context, patchDoc *p
 		}))
 	}()
 
-	projectRef, err := model.FindMergedProjectRef(patchDoc.Project, patchDoc.Version)
+	projectRef, err := model.FindMergedProjectRef(patchDoc.Project, &patchDoc.Version)
 	if err != nil {
 		return errors.Wrapf(err, "Could not find project ref '%s'", patchDoc.Project)
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -207,7 +207,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		patchDoc.DisplayNewUI = true
 	}
 
-	pref, err := model.FindMergedProjectRef(patchDoc.Project)
+	pref, err := model.FindMergedProjectRef(patchDoc.Project, patchDoc.Version)
 	if err != nil {
 		return errors.Wrap(err, "can't find patch project")
 	}
@@ -562,7 +562,7 @@ func (j *patchIntentProcessor) buildCliPatchDoc(ctx context.Context, patchDoc *p
 		}))
 	}()
 
-	projectRef, err := model.FindMergedProjectRef(patchDoc.Project)
+	projectRef, err := model.FindMergedProjectRef(patchDoc.Project, patchDoc.Version)
 	if err != nil {
 		return errors.Wrapf(err, "Could not find project ref '%s'", patchDoc.Project)
 	}

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -69,7 +69,7 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 	var err error
-	j.project, err = model.FindMergedProjectRef(j.ProjectID, "")
+	j.project, err = model.FindMergedProjectRef(j.ProjectID, utility.ToStringPtr(""))
 	if err != nil {
 		j.AddError(errors.Wrap(err, "error finding project"))
 		return

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -69,7 +69,7 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 	var err error
-	j.project, err = model.FindMergedProjectRef(j.ProjectID)
+	j.project, err = model.FindMergedProjectRef(j.ProjectID, "")
 	if err != nil {
 		j.AddError(errors.Wrap(err, "error finding project"))
 		return

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -69,7 +69,7 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 	var err error
-	j.project, err = model.FindMergedProjectRef(j.ProjectID, utility.ToStringPtr(""))
+	j.project, err = model.FindMergedProjectRef(j.ProjectID, "", true)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "error finding project"))
 		return

--- a/units/repotracker.go
+++ b/units/repotracker.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/utility"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
@@ -90,7 +91,7 @@ func (j *repotrackerJob) Run(ctx context.Context) {
 		return
 	}
 
-	ref, err := model.FindMergedProjectRef(j.ProjectID, "")
+	ref, err := model.FindMergedProjectRef(j.ProjectID, utility.ToStringPtr(""))
 	if err != nil {
 		j.AddError(err)
 		return

--- a/units/repotracker.go
+++ b/units/repotracker.go
@@ -3,8 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/utility"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/repotracker"
@@ -91,7 +89,7 @@ func (j *repotrackerJob) Run(ctx context.Context) {
 		return
 	}
 
-	ref, err := model.FindMergedProjectRef(j.ProjectID, utility.ToStringPtr(""))
+	ref, err := model.FindMergedProjectRef(j.ProjectID, "", true)
 	if err != nil {
 		j.AddError(err)
 		return

--- a/units/repotracker.go
+++ b/units/repotracker.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/repotracker"

--- a/units/repotracker.go
+++ b/units/repotracker.go
@@ -90,7 +90,7 @@ func (j *repotrackerJob) Run(ctx context.Context) {
 		return
 	}
 
-	ref, err := model.FindMergedProjectRef(j.ProjectID)
+	ref, err := model.FindMergedProjectRef(j.ProjectID, "")
 	if err != nil {
 		j.AddError(err)
 		return


### PR DESCRIPTION
[EVG-15562](https://jira.mongodb.org/browse/EVG-15562)
[EVG-15722](https://jira.mongodb.org/browse/EVG-15722)

### Description 
MergeWithParserProject had begun to use widespread across the codebase right after a call to FindMergedProjectRef is made.  It makes more sense to simply merge the parser project and project ref at the same time we return FindMergedProjectRef.

### Testing 
Modified unit test for FindMergedProjectRef 