### PR TITLE
EVG-14205 log when version has large number of activated tasks

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -137,6 +137,9 @@ const (
 
 	DisabledTaskPriority = int64(-1)
 
+	// if a patch has NumTasksForLargePatch number of tasks or greater, we log to splunk for investigation
+	NumTasksForLargePatch = 10000
+
 	// LogMessage struct versions
 	LogmessageFormatTimestamp = 1
 	LogmessageCurrentVersion  = LogmessageFormatTimestamp

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -462,7 +462,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 			"message":             "version has large number of activated tasks",
 			"op":                  "finalize patch",
 			"num_tasks_activated": numTasksActivated,
-			"total_tasks":         tasksToInsert,
+			"total_tasks":         len(tasksToInsert),
 			"version":             patchVersion.Id,
 		})
 	}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -451,6 +451,21 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 			}
 		}
 	}
+	if len(tasksToInsert) > evergreen.NumTasksForLargePatch {
+		numTasksActivated := 0
+		for _, t := range tasksToInsert {
+			if t.Activated {
+				numTasksActivated++
+			}
+		}
+		grip.Info(message.Fields{
+			"message":             "version has large number of activated tasks",
+			"op":                  "finalize patch",
+			"num_tasks_activated": numTasksActivated,
+			"total_tasks":         tasksToInsert,
+			"version":             patchVersion.Id,
+		})
+	}
 
 	return patchVersion, nil
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1209,6 +1209,13 @@ func FindTasksFromVersions(versionIds []string) ([]Task, error) {
 		WithFields(IdKey, DisplayNameKey, StatusKey, TimeTakenKey, VersionKey, BuildVariantKey, AbortedKey, AbortInfoKey))
 }
 
+func CountActivatedTasksForVersion(versionId string) (int, error) {
+	return Count(db.Query(bson.M{
+		VersionKey:   versionId,
+		ActivatedKey: true,
+	}))
+}
+
 func FindTaskGroupFromBuild(buildId, taskGroup string) ([]Task, error) {
 	tasks, err := Find(db.Query(bson.M{
 		BuildIdKey:   buildId,

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -160,7 +160,7 @@ func mergeCommand() cli.Command {
 				large:       c.Bool(largeFlagName),
 				force:       c.Bool(forceFlagName),
 			}
-			if params.force && !params.skipConfirm && !confirm("Forcing item to front of queue will be reported. Continue? (y/n)", false) {
+			if params.force && !params.skipConfirm && !confirm("Forcing item to front of queue will be reported. Continue? (y/N)", false) {
 				return errors.New("Merge aborted.")
 			}
 			conf, err := NewClientSettings(c.Parent().Parent().String(confFlagName))
@@ -276,7 +276,7 @@ func enqueuePatch() cli.Command {
 				}
 			}
 			if multipleCommits && !skipConfirm &&
-				!confirm("Original patch has multiple commits (these will be tested together but merged separately). Continue? (y/n):", false) {
+				!confirm("Original patch has multiple commits (these will be tested together but merged separately). Continue? (y/N):", false) {
 				return errors.New("enqueue aborted")
 			}
 
@@ -560,7 +560,7 @@ func (p *mergeParams) uploadMergePatch(conf *ClientSettings, ac *legacyClient) e
 		return errors.Wrap(err, "can't get commit count")
 	}
 	if commitCount > 1 && !p.skipConfirm &&
-		!confirm("Commit queue patch has multiple commits (these will be tested together but merged separately). Continue? (y/n):", false) {
+		!confirm("Commit queue patch has multiple commits (these will be tested together but merged separately). Continue? (y/N):", false) {
 		return errors.New("patch aborted")
 	}
 
@@ -632,7 +632,7 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 		return errors.New("No commits for module")
 	}
 	if commitCount > 1 && !p.skipConfirm &&
-		!confirm("Commit queue module patch has multiple commits (these will be tested together but merged separately). Continue? (y/n):", false) {
+		!confirm("Commit queue module patch has multiple commits (these will be tested together but merged separately). Continue? (y/N):", false) {
 		return errors.New("module patch aborted")
 	}
 
@@ -668,7 +668,7 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 	if !p.skipConfirm {
 		grip.InfoWhen(diffData.patchSummary != "", diffData.patchSummary)
 		grip.InfoWhen(diffData.log != "", diffData.log)
-		if !confirm("This is a summary of the patch to be submitted. Continue? (y/n):", true) {
+		if !confirm("This is a summary of the patch to be submitted. Continue? (Y/n):", true) {
 			return nil
 		}
 	}

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -1176,7 +1176,7 @@ func hostRunCommand() cli.Command {
 				}
 
 				if !skipConfirm {
-					if !confirm(fmt.Sprintf("The script will run on %d host(s), \n%s\nContinue? (y/n): ", len(hostIDs), strings.Join(hostIDs, "\n")), true) {
+					if !confirm(fmt.Sprintf("The script will run on %d host(s), \n%s\nContinue? (Y/n): ", len(hostIDs), strings.Join(hostIDs, "\n")), true) {
 						return nil
 					}
 				}
@@ -1557,13 +1557,13 @@ func sanityCheckRsync(localPath, remotePath string, pull bool) bool {
 	remotePathIsDir := strings.HasSuffix(remotePath, "/")
 
 	if localPathIsDir && !pull {
-		ok := confirm(fmt.Sprintf("The local directory '%s' will overwrite any existing contents in the remote directory '%s'. Continue? (y/n)", localPath, remotePath), false)
+		ok := confirm(fmt.Sprintf("The local directory '%s' will overwrite any existing contents in the remote directory '%s'. Continue? (y/N)", localPath, remotePath), false)
 		if !ok {
 			return false
 		}
 	}
 	if remotePathIsDir && pull {
-		ok := confirm(fmt.Sprintf("The remote directory '%s' will overwrite any existing contents in the local directory '%s'. Continue? (y/n)", remotePath, localPath), false)
+		ok := confirm(fmt.Sprintf("The remote directory '%s' will overwrite any existing contents in the local directory '%s'. Continue? (y/N)", remotePath, localPath), false)
 		if !ok {
 			return false
 		}

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -137,6 +137,9 @@ func Patch() cli.Command {
 				if err != nil {
 					return errors.Wrap(err, "can't test for uncommitted changes")
 				}
+				if keepGoing && utility.StringSliceContains(params.Variants, "all") && utility.StringSliceContains(params.Tasks, "all") {
+					keepGoing = confirm(`For some projects, scheduling all tasks/variants may result in a very large patch build. Continue? (Y/n)`, true)
+				}
 				if !keepGoing {
 					return errors.New("patch aborted")
 				}

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -116,7 +116,7 @@ func PatchSetModule() cli.Command {
 					fmt.Println(diffData.patchSummary)
 				}
 
-				if !confirm("This is a summary of the patch to be submitted. Continue? (y/n):", true) {
+				if !confirm("This is a summary of the patch to be submitted. Continue? (Y/n):", true) {
 					return nil
 				}
 			}

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -135,7 +135,7 @@ func (p *patchParams) validateSubmission(diffData *localDiff) error {
 		return err
 	}
 	if !p.SkipConfirm && len(diffData.fullPatch) == 0 {
-		if !confirm("Patch submission is empty. Continue? (y/n)", true) {
+		if !confirm("Patch submission is empty. Continue? (Y/n)", true) {
 			return errors.New("patch aborted")
 		}
 	} else if !p.SkipConfirm && diffData.patchSummary != "" {
@@ -144,7 +144,7 @@ func (p *patchParams) validateSubmission(diffData *localDiff) error {
 			grip.Info(diffData.log)
 		}
 
-		if !confirm("This is a summary of the patch to be submitted. Continue? (y/n):", true) {
+		if !confirm("This is a summary of the patch to be submitted. Continue? (Y/n):", true) {
 			return errors.New("patch aborted")
 		}
 	}

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -297,6 +297,19 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 	}
 	if !shouldNoop {
 		j.AddError(task.MarkGeneratedTasks(j.TaskID))
+		activatedTasks, err := task.CountActivatedTasksForVersion(t.Version)
+		if err != nil {
+			j.AddError(err)
+			return
+		}
+		if activatedTasks > evergreen.NumTasksForLargePatch {
+			grip.Info(message.Fields{
+				"message":             "version has large number of activated tasks",
+				"op":                  "generate.tasks",
+				"num_tasks_activated": activatedTasks,
+				"version":             t.Version,
+			})
+		}
 	}
 }
 

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -297,19 +297,22 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 	}
 	if !shouldNoop {
 		j.AddError(task.MarkGeneratedTasks(j.TaskID))
-		activatedTasks, err := task.CountActivatedTasksForVersion(t.Version)
-		if err != nil {
-			j.AddError(err)
-			return
+		if t.IsPatchRequest() {
+			activatedTasks, err := task.CountActivatedTasksForVersion(t.Version)
+			if err != nil {
+				j.AddError(err)
+				return
+			}
+			if activatedTasks > evergreen.NumTasksForLargePatch {
+				grip.Info(message.Fields{
+					"message":             "patch has large number of activated tasks",
+					"op":                  "generate.tasks",
+					"num_tasks_activated": activatedTasks,
+					"version":             t.Version,
+				})
+			}
 		}
-		if activatedTasks > evergreen.NumTasksForLargePatch {
-			grip.Info(message.Fields{
-				"message":             "version has large number of activated tasks",
-				"op":                  "generate.tasks",
-				"num_tasks_activated": activatedTasks,
-				"version":             t.Version,
-			})
-		}
+
 	}
 }
 


### PR DESCRIPTION
[EVG-14205](https://jira.mongodb.org/browse/EVG-14205)

### Description 
Logging in patch creation and generate tasks. Chose to define the initial number at which we log at as a global, but since we log the num_tasks_activated we can modify what to alert on based on this rather than needing code changes. 

Chose this number based off of some aggregations: the largest waterfall version between October 1 and October 14th had 24545 tasks; for patches this was 13815. A required builders patch build is more likely to be about 5000 activated tasks. I may initially set the Splunk alert for 15,000.
