### PR TITLE
EVG-15660: remove omitempty fields from admin settings

### DIFF
--- a/config_alerts_notify.go
+++ b/config_alerts_notify.go
@@ -38,10 +38,6 @@ func (c *NotifyConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = NotifyConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}
@@ -100,10 +96,6 @@ func (c *AlertsConfig) Get(env Environment) error {
 		}
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
-
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = AlertsConfig{}
 
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")

--- a/config_amboy.go
+++ b/config_amboy.go
@@ -75,10 +75,6 @@ func (c *AmboyConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = AmboyConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_api.go
+++ b/config_api.go
@@ -43,10 +43,6 @@ func (c *APIConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = APIConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_auth.go
+++ b/config_auth.go
@@ -121,10 +121,6 @@ func (c *AuthConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = AuthConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_cedar.go
+++ b/config_cedar.go
@@ -30,10 +30,6 @@ func (c *CedarConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = CedarConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -33,10 +33,6 @@ func (c *CloudProviders) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = CloudProviders{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}
@@ -122,9 +118,9 @@ func (c *S3Credentials) Validate() error {
 // AWSPodConfig represents configuration for using pods backed by AWS.
 type AWSPodConfig struct {
 	// Role is the role to assume to make API calls that manage pods.
-	Role string `bson:"role,omitempty" json:"role,omitempty" yaml:"role,omitempty"`
+	Role string `bson:"role" json:"role" yaml:"role"`
 	// Region is the region where the pods are managed.
-	Region string `bson:"region,omitempty" json:"region,omitempty" yaml:"region,omitempty"`
+	Region string `bson:"region" json:"region" yaml:"region"`
 	// ECS represents configuration for using AWS ECS to manage pods.
 	ECS ECSConfig `bson:"ecs" json:"ecs" yaml:"ecs"`
 	// SecretsManager represents configuration for using AWS Secrets Manager
@@ -140,22 +136,22 @@ func (c *AWSPodConfig) Validate() error {
 // ECSConfig represents configuration for AWS ECS.
 type ECSConfig struct {
 	// TaskDefinitionPrefix is the prefix for the task definition families.
-	TaskDefinitionPrefix string `bson:"task_definition_prefix,omitempty" json:"task_definition_prefix,omitempty" yaml:"task_definition_prefix,omitempty"`
+	TaskDefinitionPrefix string `bson:"task_definition_prefix" json:"task_definition_prefix" yaml:"task_definition_prefix"`
 	// TaskRole is the IAM role that ECS tasks can assume to make AWS requests.
-	TaskRole string `bson:"task_role,omitempty" json:"task_role,omitempty" yaml:"task_role,omitempty"`
+	TaskRole string `bson:"task_role" json:"task_role" yaml:"task_role"`
 	// ExecutionRole is the IAM role that ECS container instances can assume to
 	// make AWS requests.
-	ExecutionRole string `bson:"execution_role,omitempty" json:"execution_role,omitempty" yaml:"execution_role,omitempty"`
+	ExecutionRole string `bson:"execution_role" json:"execution_role" yaml:"execution_role"`
 	// AWSVPC specifies configuration when ECS tasks use AWSVPC networking.
-	AWSVPC AWSVPCConfig `bson:"awsvpc,omitempty" json:"awsvpc,omitempty" yaml:"awsvpc,omitempty"`
+	AWSVPC AWSVPCConfig `bson:"awsvpc" json:"awsvpc" yaml:"awsvpc"`
 	// Clusters specify the configuration of each particular ECS cluster.
-	Clusters []ECSClusterConfig `bson:"clusters,omitempty" json:"clusters,omitempty" yaml:"clusters,omitempty"`
+	Clusters []ECSClusterConfig `bson:"clusters" json:"clusters" yaml:"clusters"`
 }
 
 // AWSVPCConfig represents configuration when using AWSVPC networking in ECS.
 type AWSVPCConfig struct {
-	Subnets        []string `bson:"subnets,omitempty" json:"subnets,omitempty" yaml:"subnets,omitempty"`
-	SecurityGroups []string `bson:"security_groups,omitempty" json:"security_groups,omitempty" yaml:"security_groups,omitempty"`
+	Subnets        []string `bson:"subnets" json:"subnets" yaml:"subnets"`
+	SecurityGroups []string `bson:"security_groups" json:"security_groups" yaml:"security_groups"`
 }
 
 // Validate checks that the required ECS configuration options are given.
@@ -171,9 +167,9 @@ func (c *ECSConfig) Validate() error {
 // cluster.
 type ECSClusterConfig struct {
 	// Name is the ECS cluster name.
-	Name string `bson:"name,omitempty" json:"name,omitempty" yaml:"name,omitempty"`
+	Name string `bson:"name" json:"name" yaml:"name"`
 	// Platform is the platform supported by the cluster.
-	Platform ECSClusterPlatform `bson:"platform,omitempty" json:"platform,omitempty" yaml:"platform,omitempty"`
+	Platform ECSClusterPlatform `bson:"platform" json:"platform" yaml:"platform"`
 }
 
 // Validate checks that the ECS cluster configuration has the required fields
@@ -188,7 +184,7 @@ func (c *ECSClusterConfig) Validate() error {
 // SecretsManagerConfig represents configuration for AWS Secrets Manager.
 type SecretsManagerConfig struct {
 	// SecretPrefix is the prefix for secret names.
-	SecretPrefix string `bson:"secret_prefix,omitempty" json:"secret_prefix,omitempty" yaml:"secret_prefix,omitempty"`
+	SecretPrefix string `bson:"secret_prefix" json:"secret_prefix" yaml:"secret_prefix"`
 }
 
 // DockerConfig stores auth info for Docker.

--- a/config_commitqueue.go
+++ b/config_commitqueue.go
@@ -39,10 +39,6 @@ func (c *CommitQueueConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = CommitQueueConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_containerpools.go
+++ b/config_containerpools.go
@@ -41,10 +41,6 @@ func (c *ContainerPoolsConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = ContainerPoolsConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_hostinit.go
+++ b/config_hostinit.go
@@ -34,10 +34,6 @@ func (c *HostInitConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = HostInitConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_jasper.go
+++ b/config_jasper.go
@@ -42,10 +42,6 @@ func (c *HostJasperConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = HostJasperConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_jira.go
+++ b/config_jira.go
@@ -46,10 +46,6 @@ func (c *JiraConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = JiraConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_jira_notifications.go
+++ b/config_jira_notifications.go
@@ -42,10 +42,6 @@ func (c *JIRANotificationsConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = JIRANotificationsConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_logger.go
+++ b/config_logger.go
@@ -40,10 +40,6 @@ func (c *LoggerConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = LoggerConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_newrelic.go
+++ b/config_newrelic.go
@@ -31,10 +31,6 @@ func (c *NewRelicConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = NewRelicConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_podinit.go
+++ b/config_podinit.go
@@ -31,10 +31,6 @@ func (c *PodInitConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section '%s'", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = PodInitConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_repotracker.go
+++ b/config_repotracker.go
@@ -30,10 +30,6 @@ func (c *RepoTrackerConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = RepoTrackerConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_scheduler.go
+++ b/config_scheduler.go
@@ -46,10 +46,6 @@ func (c *SchedulerConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = SchedulerConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -59,10 +59,6 @@ func (c *ServiceFlags) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = ServiceFlags{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_slack.go
+++ b/config_slack.go
@@ -31,10 +31,6 @@ func (c *SlackConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = SlackConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_spawnhost.go
+++ b/config_spawnhost.go
@@ -29,10 +29,6 @@ func (c *SpawnHostConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = SpawnHostConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_triggers.go
+++ b/config_triggers.go
@@ -26,10 +26,6 @@ func (c *TriggerConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = TriggerConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}

--- a/config_ui.go
+++ b/config_ui.go
@@ -41,10 +41,6 @@ func (c *UIConfig) Get(env Environment) error {
 		return errors.Wrapf(err, "error retrieving section %s", c.SectionId())
 	}
 
-	// Clear the struct because Decode will not set fields that are omitempty to
-	// the zero value if they're zero in the database.
-	*c = UIConfig{}
-
 	if err := res.Decode(c); err != nil {
 		return errors.Wrap(err, "problem decoding result")
 	}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15660

### Description
The reason the scheduler code breaks is because it attempts to retrieve the all the admin settings from the DB, which no other piece of code does. I don't really get why the admin settings panic when the go driver is supposed to handle zero slices/maps properly, but I don't think it's worth digging into because our admin settings logic is too complicated to be worth debugging when there's an easy fix.

I was originally hoping to have a way to support omitempty fields in the admin settings. Unfortunately, the way we've written the admins settings would make it more hassle to support omitempty fields since it's different from the current norm which is to never omitempty any fields in the config. I just removed omitempty entirely from the pod config since it's the easiest fix.

Not using omitempty goes against [the go driver's recommended best practices that you use omitempty with slices and maps](https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.3/bson#hdr-Structs), but for now it's not worth trying to get the admin settings to follow the recommendations.

### Testing 
N/A
