### PR TITLE
EVG-15661 error on document too large in generate.tasks

### DIFF
--- a/db/errors.go
+++ b/db/errors.go
@@ -22,3 +22,10 @@ func IsDuplicateKey(err error) bool {
 
 	return false
 }
+
+func IsDocumentLimit(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(errors.Cause(err).Error(), "an inserted document is too large")
+}

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -184,6 +184,10 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	if adb.ResultsNotFound(err) || db.IsDuplicateKey(err) {
 		return err
 	}
+	// If the document hit the size limit, retrying won't help.
+	if db.IsDocumentLimit(err) {
+		return err
+	}
 	if err != nil {
 		return errors.Wrap(err, evergreen.SaveGenerateTasksError)
 	}


### PR DESCRIPTION
[EVG-15661](https://jira.mongodb.org/browse/EVG-15661)

### Description 
Right now we retry on generate task errors because they typically indicate a one-off problem or a race. https://github.com/evergreen-ci/evergreen/blob/dc4c61b055979da5ea702744554bf7e9fc4f5dd7/agent/command/generate.go#L120
