### PR TITLE
EVG-14530  Evergreen Require signed commits for commit queue

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -116,7 +116,7 @@ type ProjectRef struct {
 
 type CommitQueueParams struct {
 	Enabled       *bool  `bson:"enabled" json:"enabled"`
-	RequireSigned *bool  `json:"require_signed"`
+	RequireSigned *bool  `bson:"require_signed" json:"require_signed"`
 	MergeMethod   string `bson:"merge_method" json:"merge_method"`
 	Message       string `bson:"message,omitempty" json:"message,omitempty"`
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -115,9 +115,10 @@ type ProjectRef struct {
 }
 
 type CommitQueueParams struct {
-	Enabled     *bool  `bson:"enabled" json:"enabled"`
-	MergeMethod string `bson:"merge_method" json:"merge_method"`
-	Message     string `bson:"message,omitempty" json:"message,omitempty"`
+	Enabled       *bool  `bson:"enabled" json:"enabled"`
+	RequireSigned *bool  `json:"require_signed"`
+	MergeMethod   string `bson:"merge_method" json:"merge_method"`
+	Message       string `bson:"message,omitempty" json:"message,omitempty"`
 }
 
 // TaskSyncOptions contains information about which features are allowed for

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -367,6 +367,7 @@ mciModule.controller(
               item.identifier = $scope.newProject.identifier;
               item.pr_testing_enabled = false;
               item.commit_queue.enabled = false;
+              item.commit_queue.require_signed = false;
               item.git_tag_versions_enabled = false;
               item.github_checks_enabled = false;
               item.enabled = false;

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -175,9 +175,10 @@ type APIPeriodicBuildDefinition struct {
 }
 
 type APICommitQueueParams struct {
-	Enabled     *bool   `json:"enabled"`
-	MergeMethod *string `json:"merge_method"`
-	Message     *string `json:"message"`
+	Enabled       *bool   `json:"enabled"`
+	RequireSigned *bool   `json:"require_signed"`
+	MergeMethod   *string `json:"merge_method"`
+	Message       *string `json:"message"`
 }
 
 func (bd *APIPeriodicBuildDefinition) ToService() (interface{}, error) {
@@ -222,6 +223,7 @@ func (cqParams *APICommitQueueParams) BuildFromService(h interface{}) error {
 	}
 
 	cqParams.Enabled = utility.BoolPtrCopy(params.Enabled)
+	cqParams.RequireSigned = utility.BoolPtrCopy(params.RequireSigned)
 	cqParams.MergeMethod = utility.ToStringPtr(params.MergeMethod)
 	cqParams.Message = utility.ToStringPtr(params.Message)
 
@@ -231,6 +233,7 @@ func (cqParams *APICommitQueueParams) BuildFromService(h interface{}) error {
 func (cqParams *APICommitQueueParams) ToService() (interface{}, error) {
 	serviceParams := model.CommitQueueParams{}
 	serviceParams.Enabled = utility.BoolPtrCopy(cqParams.Enabled)
+	serviceParams.RequireSigned = utility.BoolPtrCopy(cqParams.RequireSigned)
 	serviceParams.MergeMethod = utility.FromStringPtr(cqParams.MergeMethod)
 	serviceParams.Message = utility.FromStringPtr(cqParams.Message)
 

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -666,11 +666,9 @@ func (gh *githubHookApi) requireSigned(ctx context.Context, userRepo data.UserRe
 
 	for _, c := range commits {
 		commit := c.GetCommit()
-		if commit.Verification != nil {
-			if !utility.FromBoolPtr(commit.Verification.Verified) &&
-				(utility.FromStringPtr(commit.Verification.Reason) == commitUnsigned) {
-				return errors.Errorf("the commit '%s' is not signed", utility.FromStringPtr(commit.Message))
-			}
+		if commit.Verification != nil && !utility.FromBoolPtr(commit.Verification.Verified) &&
+			(utility.FromStringPtr(commit.Verification.Reason) == commitUnsigned) {
+			return errors.Errorf("the commit '%s' is not signed", utility.FromStringPtr(commit.SHA))
 		}
 
 	}

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -2,6 +2,7 @@ package route
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -29,6 +30,7 @@ const (
 	githubActionOpened      = "opened"
 	githubActionSynchronize = "synchronize"
 	githubActionReopened    = "reopened"
+	commitUnsigned          = "unsigned"
 
 	retryComment = "evergreen retry"
 	refTags      = "refs/tags/"
@@ -590,6 +592,20 @@ func (gh *githubHookApi) commitQueueEnqueue(ctx context.Context, event *github.I
 		return errors.Errorf("no project with commit queue enabled for '%s:%s' tracking branch '%s'", userRepo.Owner, userRepo.Repo, baseBranch)
 	}
 
+	if *projectRef.CommitQueue.RequireSigned {
+		err = gh.requireSigned(ctx, userRepo, *pr.Head.Ref, pr, prNum)
+		if err != nil {
+			sendErr := thirdparty.SendCommitQueueGithubStatus(pr, message.GithubStateFailure, "can't enqueue with unsigned commits", "")
+			grip.Error(message.WrapError(sendErr, message.Fields{
+				"message": "error sending patch creation failure to github",
+				"owner":   userRepo.Owner,
+				"repo":    userRepo.Repo,
+				"pr":      prNum,
+			}))
+			return errors.Wrapf(err, "can't enqueue patch")
+		}
+	}
+
 	patchId, err := gh.sc.AddPatchForPr(ctx, *projectRef, prNum, cqInfo.Modules, cqInfo.MessageOverride)
 	if err != nil {
 		sendErr := thirdparty.SendCommitQueueGithubStatus(pr, message.GithubStateFailure, "failed to create patch", "")
@@ -630,6 +646,31 @@ func (gh *githubHookApi) commitQueueEnqueue(ctx context.Context, event *github.I
 		"message": "failed to queue notification for commit queue push",
 	}))
 
+	return nil
+}
+
+func (gh *githubHookApi) requireSigned(ctx context.Context, userRepo data.UserRepoInfo, baseBranch string, pr *github.PullRequest, prNum int) error {
+	settings, err := gh.sc.GetEvergreenSettings()
+	if err != nil {
+		return errors.Wrap(err, "can't get Evergreen settings")
+	}
+
+	githubToken, err := settings.GetGithubOauthToken()
+	if err != nil {
+		return errors.Wrap(err, "can't get GitHub token from settings")
+	}
+
+	commits, err := thirdparty.GetGithubPullRequestCommits(ctx, githubToken, userRepo.Owner, userRepo.Repo, prNum)
+	if err != nil {
+		return errors.Wrap(err, "can't get GitHub commits")
+	}
+
+	for _, c := range commits {
+		commit := c.GetCommit()
+		if !*commit.Verification.Verified && *commit.Verification.Reason == commitUnsigned {
+			return errors.New(fmt.Sprintf("can't enqueue patch, the commits '%s' is not signed.", *commit.Message))
+		}
+	}
 	return nil
 }
 

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -723,9 +723,13 @@ Evergreen Projects
           </div>
         </div>
         <div id="patch-variants-list-header" class="form-group" ng-show="commitQueueConflicts.length === 0">
-          <div class="col-lg-6">
+          <div class="col-lg-3">
             <input type="checkbox" id="cq-merging-checkbox" ng-model="settingsFormData.commit_queue.enabled" />
             <label for="cq-merging-checkbox">Enable Commit Queue</label>
+          </div>
+          <div class="col-lg-5" ng-show="settingsFormData.commit_queue.enabled" >
+            <input type="checkbox" id="cq-merging-checkbox" ng-model="settingsFormData.commit_queue.require_signed" />
+            <label for="cq-merging-checkbox">Require Signed Commits On Pull Request Merges</label>
           </div>
         </div>
         <div class="form-group" ng-show="commitQueueConflicts.length === 0">

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -748,7 +748,7 @@ func GetGithubPullRequest(ctx context.Context, token, baseOwner, baseRepo string
 }
 
 func GetGithubPullRequestCommits(ctx context.Context, token, owner, repo string, PRNumber int) ([]*github.RepositoryCommit, error) {
-	httpClient := getGithubClientRetryWith404s(token, "GetPullRequestMergeBase")
+	httpClient := getGithubClientRetryWith404s(token, "GetGithubPullRequestCommits")
 	defer utility.PutHTTPClient(httpClient)
 
 	client := github.NewClient(httpClient)

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -747,6 +747,23 @@ func GetGithubPullRequest(ctx context.Context, token, baseOwner, baseRepo string
 	return pr, nil
 }
 
+func GetGithubPullRequestCommits(ctx context.Context, token, owner, repo string, PRNumber int) ([]*github.RepositoryCommit, error) {
+	httpClient := getGithubClientRetryWith404s(token, "GetPullRequestMergeBase")
+	defer utility.PutHTTPClient(httpClient)
+
+	client := github.NewClient(httpClient)
+
+	commits, _, err := client.PullRequests.ListCommits(ctx, owner, repo, PRNumber, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(commits) == 0 {
+		return nil, errors.New("No commits received from github")
+	}
+
+	return commits, nil
+}
+
 // GetGithubPullRequestDiff downloads a diff from a Github Pull Request diff
 func GetGithubPullRequestDiff(ctx context.Context, token string, gh GithubPatch) (string, []Summary, error) {
 	httpClient := getGithubClientRetryWith404s(token, "GetGithubPullRequestDiff")


### PR DESCRIPTION
[EVG-14530](https://jira.mongodb.org/browse/EVG-14530)

### Description 
Allow teams to require that commits be signed before merging prs. 

### Testing 
Tested on staging
![image](https://user-images.githubusercontent.com/13104717/139250285-be5df5a7-d2b1-467e-b9a2-dc9c233de2f1.png)


With unsigned commits: 
![image](https://user-images.githubusercontent.com/13104717/139250230-5573d72e-ada3-49dd-ac3d-879a7897eee4.png)

With signed commits: 
![image](https://user-images.githubusercontent.com/13104717/139250629-d3471e22-10f9-460c-97a1-0bd2196e1ef1.png)

