### PR TITLE
EVG-15586 Limit task history to last 50 columns

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3207,7 +3207,11 @@ func (r *queryResolver) TaskNamesForBuildVariant(ctx context.Context, projectId 
 }
 
 func (r *queryResolver) BuildVariantsForTaskName(ctx context.Context, projectId string, taskName string) ([]*task.BuildVariantTuple, error) {
-	repo, err := model.FindRepository(projectId)
+	pid, err := model.GetIdForProject(projectId)
+	if err != nil {
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find project with id: %s", projectId))
+	}
+	repo, err := model.FindRepository(pid)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting repository for '%s': %s", projectId, err.Error()))
 	}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3207,7 +3207,14 @@ func (r *queryResolver) TaskNamesForBuildVariant(ctx context.Context, projectId 
 }
 
 func (r *queryResolver) BuildVariantsForTaskName(ctx context.Context, projectId string, taskName string) ([]*task.BuildVariantTuple, error) {
-	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask(projectId, taskName)
+	repo, err := model.FindRepository(projectId)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting repository for '%s': %s", projectId, err.Error()))
+	}
+	if repo == nil {
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("could not find repository '%s'", projectId))
+	}
+	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask(projectId, taskName, repo.RevisionOrderNumber)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting build variant tasks for task '%s': %s", taskName, err.Error()))
 	}

--- a/graphql/tests/buildVariantsForTaskName/data.json
+++ b/graphql/tests/buildVariantsForTaskName/data.json
@@ -6,7 +6,8 @@
             "build_variant": "ubuntu1604",
             "branch": "evergreen",
             "r": "gitter_request",
-            "build_id": "b1"
+            "build_id": "b1",
+            "order": 1
         },
         {
             "_id": "t2",
@@ -14,7 +15,8 @@
             "build_variant": "ubuntu1604",
             "branch": "evergreen",
             "r": "gitter_request",
-            "build_id": "b1"
+            "build_id": "b1",
+            "order": 1
         },
         {
             "_id": "t3",
@@ -22,7 +24,8 @@
             "build_variant": "ubuntu1604",
             "branch": "evergreen",
             "r": "gitter_request",
-            "build_id": "b1"
+            "build_id": "b1",
+            "order": 1
             
         },
         {
@@ -31,7 +34,8 @@
             "build_variant": "osx",
             "branch": "evergreen",
             "r": "gitter_request",
-            "build_id": "b2"
+            "build_id": "b2",
+            "order": 1
         }
     ],
     "builds": [
@@ -42,6 +46,20 @@
         {
             "_id": "b2",
             "display_name": "OSX"
+        }
+    ],
+    "project_ref": [
+        {
+            "_id": "evergreen",
+            "identifier": "evergreen",
+            "branch": "main",
+            "display_name": "Evergreen"
+        }
+    ],
+    "repo_revisions": [
+        {
+            "_id": "evergreen",
+            "last_commit_number": 1
         }
     ]
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -869,9 +869,11 @@ type BuildVariantTuple struct {
 	DisplayName  string `bson:"display_name"`
 }
 
-// FindUniqueBuildVariantNamesByTask returns a list of unique build variants names and their display names for a given task name,
-// it tries to return the most recent display name for each build variant to avoid duplicates from display names changing
-// it only checks the last 50 versions that ran for a given task name
+const VERSION_LIMIT = 50
+
+// FindUniqueBuildVariantNamesByTask returns a list of unique build variants names and their display names for a given task name.
+// It attempts to return the most recent display name for each build variant to avoid returning duplicates caused by display names changing.
+// It only checks the last 50 versions that ran for a given task name.
 func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOrderNumber int) ([]*BuildVariantTuple, error) {
 	pipeline := []bson.M{
 		{"$match": bson.M{
@@ -879,7 +881,7 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 			DisplayNameKey: taskName,
 			RequesterKey:   bson.M{"$in": evergreen.SystemVersionRequesterTypes},
 			"$and": []bson.M{
-				{RevisionOrderNumberKey: bson.M{"$gte": repoOrderNumber - 50}},
+				{RevisionOrderNumberKey: bson.M{"$gte": repoOrderNumber - VERSION_LIMIT}},
 				{RevisionOrderNumberKey: bson.M{"$lte": repoOrderNumber}},
 			},
 		},
@@ -957,7 +959,7 @@ func FindTaskNamesByBuildVariant(projectId string, buildVariant string) ([]strin
 			ProjectKey:       projectId,
 			BuildVariantKey:  buildVariant,
 			RequesterKey:     bson.M{"$in": evergreen.SystemVersionRequesterTypes},
-			DisplayTaskIdKey: bson.M{"$exists": false}, // ignore execution tasks
+			DisplayTaskIdKey: "", // ignore execution tasks
 		},
 		},
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -956,10 +956,13 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 func FindTaskNamesByBuildVariant(projectId string, buildVariant string) ([]string, error) {
 	pipeline := []bson.M{
 		{"$match": bson.M{
-			ProjectKey:       projectId,
-			BuildVariantKey:  buildVariant,
-			RequesterKey:     bson.M{"$in": evergreen.SystemVersionRequesterTypes},
-			DisplayTaskIdKey: "", // ignore execution tasks
+			ProjectKey:      projectId,
+			BuildVariantKey: buildVariant,
+			RequesterKey:    bson.M{"$in": evergreen.SystemVersionRequesterTypes},
+			"$or": []bson.M{
+				{DisplayTaskIdKey: bson.M{"$exists": false}},
+				{DisplayTaskIdKey: ""},
+			},
 		},
 		},
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -869,7 +869,7 @@ type BuildVariantTuple struct {
 	DisplayName  string `bson:"display_name"`
 }
 
-const VERSION_LIMIT = 50
+const VersionLimit = 50
 
 // FindUniqueBuildVariantNamesByTask returns a list of unique build variants names and their display names for a given task name.
 // It attempts to return the most recent display name for each build variant to avoid returning duplicates caused by display names changing.
@@ -881,7 +881,7 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 			DisplayNameKey: taskName,
 			RequesterKey:   bson.M{"$in": evergreen.SystemVersionRequesterTypes},
 			"$and": []bson.M{
-				{RevisionOrderNumberKey: bson.M{"$gte": repoOrderNumber - VERSION_LIMIT}},
+				{RevisionOrderNumberKey: bson.M{"$gte": repoOrderNumber - VersionLimit}},
 				{RevisionOrderNumberKey: bson.M{"$lte": repoOrderNumber}},
 			},
 		},

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -954,11 +954,13 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 func FindTaskNamesByBuildVariant(projectId string, buildVariant string) ([]string, error) {
 	pipeline := []bson.M{
 		{"$match": bson.M{
-			ProjectKey:      projectId,
-			BuildVariantKey: buildVariant,
-			RequesterKey:    bson.M{"$in": evergreen.SystemVersionRequesterTypes}},
+			ProjectKey:       projectId,
+			BuildVariantKey:  buildVariant,
+			RequesterKey:     bson.M{"$in": evergreen.SystemVersionRequesterTypes},
 			DisplayTaskIdKey: bson.M{"$exists": false}, // ignore execution tasks
-		}}
+		},
+		},
+	}
 
 	group := bson.M{
 		"$group": bson.M{

--- a/model/task_build_variant_names_test.go
+++ b/model/task_build_variant_names_test.go
@@ -19,14 +19,15 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 	}
 	assert.NoError(t, b1.Insert())
 	t1 := task.Task{
-		Id:           "t1",
-		Status:       evergreen.TaskSucceeded,
-		BuildVariant: "ubuntu1604",
-		DisplayName:  "test-agent",
-		Project:      "evergreen",
-		Requester:    evergreen.RepotrackerVersionRequester,
-		BuildId:      "b1",
-		CreateTime:   time.Now().Add(-time.Hour),
+		Id:                  "t1",
+		Status:              evergreen.TaskSucceeded,
+		BuildVariant:        "ubuntu1604",
+		DisplayName:         "test-agent",
+		Project:             "evergreen",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		BuildId:             "b1",
+		CreateTime:          time.Now().Add(-time.Hour),
+		RevisionOrderNumber: 1,
 	}
 	assert.NoError(t, t1.Insert())
 	b2 := build.Build{
@@ -35,14 +36,15 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 	}
 	assert.NoError(t, b2.Insert())
 	t2 := task.Task{
-		Id:           "t2",
-		Status:       evergreen.TaskSucceeded,
-		BuildVariant: "osx",
-		DisplayName:  "test-agent",
-		Project:      "evergreen",
-		Requester:    evergreen.RepotrackerVersionRequester,
-		BuildId:      "b2",
-		CreateTime:   time.Now().Add(-time.Hour),
+		Id:                  "t2",
+		Status:              evergreen.TaskSucceeded,
+		BuildVariant:        "osx",
+		DisplayName:         "test-agent",
+		Project:             "evergreen",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		BuildId:             "b2",
+		CreateTime:          time.Now().Add(-time.Hour),
+		RevisionOrderNumber: 1,
 	}
 	assert.NoError(t, t2.Insert())
 	b3 := build.Build{
@@ -51,14 +53,15 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 	}
 	assert.NoError(t, b3.Insert())
 	t3 := task.Task{
-		Id:           "t3",
-		Status:       evergreen.TaskSucceeded,
-		BuildVariant: "windows",
-		DisplayName:  "test-agent",
-		Project:      "evergreen",
-		Requester:    evergreen.RepotrackerVersionRequester,
-		BuildId:      "b3",
-		CreateTime:   time.Now().Add(-time.Hour),
+		Id:                  "t3",
+		Status:              evergreen.TaskSucceeded,
+		BuildVariant:        "windows",
+		DisplayName:         "test-agent",
+		Project:             "evergreen",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		BuildId:             "b3",
+		CreateTime:          time.Now().Add(-time.Hour),
+		RevisionOrderNumber: 1,
 	}
 	assert.NoError(t, t3.Insert())
 	b4 := build.Build{
@@ -67,17 +70,18 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 	}
 	assert.NoError(t, b4.Insert())
 	t4 := task.Task{
-		Id:           "t4",
-		Status:       evergreen.TaskFailed,
-		BuildVariant: "ubuntu1604",
-		DisplayName:  "test-agent",
-		Project:      "evergreen",
-		Requester:    evergreen.RepotrackerVersionRequester,
-		BuildId:      "b4",
-		CreateTime:   time.Now(),
+		Id:                  "t4",
+		Status:              evergreen.TaskFailed,
+		BuildVariant:        "ubuntu1604",
+		DisplayName:         "test-agent",
+		Project:             "evergreen",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		BuildId:             "b4",
+		CreateTime:          time.Now(),
+		RevisionOrderNumber: 1,
 	}
 	assert.NoError(t, t4.Insert())
-	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent")
+	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1)
 	assert.NoError(t, err)
 	assert.Equal(t, []*task.BuildVariantTuple{
 		{DisplayName: "OSX", BuildVariant: "osx"},


### PR DESCRIPTION
[EVG-15586](https://jira.mongodb.org/browse/EVG-15586)

### Description 
Fetching build variants  for the `buildVariantForTaskName` query was painfully slow. Since it would check every task ever created for a project through out its entire existence to get the build variants that ran and then it would do a $lookup to fetch the proper display names for build variants. 
This was super slow because the Shier amount of data it needed to check. I opted to limit it to only check the last 50 versions for a project.  Which is the same amount of versions we check on the legacy task history page https://github.com/evergreen-ci/evergreen/blob/0d5ea465c5e102ed76e2648570f61a1fd1f151ba/service/task_history.go#L97

Also added a check to the `taskNamesForBuildVariant` query that should omit execution tasks from being displayed as one of the possible column types. Since we also omit those in the query that returns the actual test results.
### Testing 
Tested the query on the prod db which was dramatically quicker to resolve.