### PR TITLE
EVG-15661 improve fetching expansions for variants (with matrices)

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1041,12 +1041,12 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 	for _, e := range h.Distro.Expansions {
 		expansions.Put(e.Key, e.Value)
 	}
-	proj, _, err := LoadProjectForVersion(v, t.Project, false)
+
+	bvExpansions, err := FindExpansionsForVariant(v, t.BuildVariant)
 	if err != nil {
-		return nil, errors.Wrap(err, "error unmarshalling project")
+		return nil, errors.Wrap(err, "error getting expansions for variant")
 	}
-	bv := proj.FindBuildVariant(t.BuildVariant)
-	expansions.Update(bv.Expansions)
+	expansions.Update(bvExpansions)
 	return expansions, nil
 }
 

--- a/model/project_matrix.go
+++ b/model/project_matrix.go
@@ -247,6 +247,15 @@ func evaluateAxisTags(ase *axisSelectorEvaluator, axis string, selectors []strin
 	return out, errs
 }
 
+func GetVariantsWithMatrices(ase *axisSelectorEvaluator, axes []matrixAxis, bvs []parserBV) ([]parserBV, []error) {
+	if ase == nil {
+		ase = NewAxisSelectorEvaluator(axes)
+	}
+	regularBVs, matrices := sieveMatrixVariants(bvs)
+	matrixBVs, errs := buildMatrixVariants(axes, ase, matrices)
+	return append(regularBVs, matrixBVs...), errs
+}
+
 // buildMatrixVariants takes in a list of axis definitions, an axisSelectorEvaluator, and a slice of
 // matrix definitions. It returns a slice of parserBuildVariants constructed according to
 // our matrix specification.

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/util"
-	"github.com/k0kubun/pp"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -113,7 +112,6 @@ buildvariants:
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix
-			pp.Println(p)
 			So(m1.Id, ShouldEqual, "test")
 			So(p.BuildVariants[1].Name, ShouldEqual, "single_variant")
 			So(p.BuildVariants[1].Tasks, ShouldResemble, parserBVTaskUnits{parserBVTaskUnit{Name: "*"}})

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/k0kubun/pp"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -112,6 +113,7 @@ buildvariants:
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix
+			pp.Println(p)
 			So(m1.Id, ShouldEqual, "test")
 			So(p.BuildVariants[1].Name, ShouldEqual, "single_variant")
 			So(p.BuildVariants[1].Tasks, ShouldResemble, parserBVTaskUnits{parserBVTaskUnit{Name: "*"}})

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -827,11 +827,8 @@ func TranslateProject(pp *ParserProject) (*Project, error) {
 	tse := NewParserTaskSelectorEvaluator(pp.Tasks)
 	tgse := newTaskGroupSelectorEvaluator(pp.TaskGroups)
 	ase := NewAxisSelectorEvaluator(pp.Axes)
-	regularBVs, matrices := sieveMatrixVariants(pp.BuildVariants)
-
-	matrixVariants, errs := buildMatrixVariants(pp.Axes, ase, matrices)
+	buildVariants, errs := GetVariantsWithMatrices(ase, pp.Axes, pp.BuildVariants)
 	catcher.Extend(errs)
-	buildVariants := append(regularBVs, matrixVariants...)
 	vse := NewVariantSelectorEvaluator(buildVariants, ase)
 	proj.Tasks, proj.TaskGroups, errs = evaluateTaskUnits(tse, tgse, vse, pp.Tasks, pp.TaskGroups)
 	catcher.Extend(errs)

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
@@ -65,9 +66,25 @@ func ParserProjectFindOne(query db.Q) (*ParserProject, error) {
 	return project, err
 }
 
+// ParserProjectById returns a query to find a parser project by id.
+func ParserProjectById(id string) db.Q {
+	return db.Query(bson.M{ParserProjectIdKey: id})
+}
+
+// ParserProjectUpsertOne updates one project
+func ParserProjectUpsertOne(query interface{}, update interface{}) error {
+	_, err := db.Upsert(
+		ParserProjectCollection,
+		query,
+		update,
+	)
+
+	return err
+}
+
 // ParserProjectByVersion finds a parser project with a given version.
-// If version is empty the last known good config will be returned
-func ParserProjectByVersion(projectId string, version string) (*ParserProject, error) {
+// If version is empty the last known good config will be returned.
+func ParserProjectByVersion(projectId, version string) (*ParserProject, error) {
 	lookupVersion := false
 	if version == "" {
 		lastGoodVersion, err := FindVersionByLastKnownGoodConfig(projectId, -1)
@@ -95,20 +112,27 @@ func ParserProjectByVersion(projectId string, version string) (*ParserProject, e
 	return parserProject, nil
 }
 
-// ParserProjectById returns a query to find a parser project by id.
-func ParserProjectById(id string) db.Q {
-	return db.Query(bson.M{ParserProjectIdKey: id})
-}
+func FindExpansionsForVariant(v *Version, variant string) (util.Expansions, error) {
+	pp, err := ParserProjectFindOne(ParserProjectById(v.Id).WithFields(ParserProjectConfigNumberKey, ParserProjectBuildVariantsKey))
+	if err != nil {
+		return nil, errors.Wrap(err, "error finding parser project")
+	}
 
-// UpdateOne updates one project
-func ParserProjectUpsertOne(query interface{}, update interface{}) error {
-	_, err := db.Upsert(
-		ParserProjectCollection,
-		query,
-		update,
-	)
-
-	return err
+	if pp == nil || pp.ConfigUpdateNumber < v.ConfigUpdateNumber { // legacy case
+		if v.Config == "" {
+			return nil, errors.New("version has no config")
+		}
+		pp, err = createIntermediateProject([]byte(v.Config))
+		if err != nil {
+			return nil, errors.Wrap(err, "error parsing legacy config")
+		}
+	}
+	for _, bv := range pp.BuildVariants {
+		if bv.Name == variant {
+			return bv.Expansions, nil
+		}
+	}
+	return nil, errors.Errorf("error finding variant")
 }
 
 func checkConfigNumberQuery(id string, configNum int) bson.M {

--- a/model/project_parser_db_test.go
+++ b/model/project_parser_db_test.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindExpansionsForVariant(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(ParserProjectCollection))
+	pp := ParserProject{
+		Id: "v1",
+		BuildVariants: []parserBV{
+			{
+				Name:       "myBV",
+				Expansions: util.Expansions{"hello": "world", "goodbye": "mars"},
+			},
+			{
+				Name:       "yourBV",
+				Expansions: util.Expansions{"milky": "way"},
+			},
+		},
+	}
+
+	v := &Version{Id: "v1"}
+	assert.NoError(t, pp.TryUpsert())
+	expansions, err := FindExpansionsForVariant(v, "myBV")
+	assert.NoError(t, err)
+	assert.Equal(t, expansions["hello"], "world")
+	assert.Equal(t, expansions["goodbye"], "mars")
+	assert.Empty(t, expansions["milky"])
+}

--- a/model/project_parser_db_test.go
+++ b/model/project_parser_db_test.go
@@ -12,6 +12,26 @@ func TestFindExpansionsForVariant(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(ParserProjectCollection))
 	pp := ParserProject{
 		Id: "v1",
+		Axes: []matrixAxis{
+			{
+				Id: "version",
+				Values: []axisValue{
+					{
+						Id:        "latest",
+						Variables: util.Expansions{"VERSION": "latest"},
+					},
+				},
+			},
+			{
+				Id: "os",
+				Values: []axisValue{
+					{
+						Id:        "windows-64",
+						Variables: util.Expansions{"OS": "windows-64"},
+					},
+				},
+			},
+		},
 		BuildVariants: []parserBV{
 			{
 				Name:       "myBV",
@@ -20,6 +40,19 @@ func TestFindExpansionsForVariant(t *testing.T) {
 			{
 				Name:       "yourBV",
 				Expansions: util.Expansions{"milky": "way"},
+			},
+			{
+				Matrix: &matrix{
+					Id: "test",
+					Spec: matrixDefinition{
+						"os": parserStringSlice{
+							"*",
+						},
+						"version": parserStringSlice{
+							"*",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -31,4 +64,9 @@ func TestFindExpansionsForVariant(t *testing.T) {
 	assert.Equal(t, expansions["hello"], "world")
 	assert.Equal(t, expansions["goodbye"], "mars")
 	assert.Empty(t, expansions["milky"])
+	expansions, err = FindExpansionsForVariant(v, "test__version~latest_os~windows-64")
+	assert.NoError(t, err)
+	assert.Equal(t, expansions["VERSION"], "latest")
+	assert.Equal(t, expansions["OS"], "windows-64")
+
 }

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -185,9 +185,9 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 		return nil, errors.Errorf("criterion '%v' is invalid: %v", sc, sc.Validate())
 
 	case sc.name == SelectAll: // special * case
-		names := []string{}
-		for _, item := range tse.items {
-			names = append(names, item.name())
+		names := make([]string, len(tse.items))
+		for i, item := range tse.items {
+			names[i] = item.name()
 		}
 		return names, nil
 
@@ -203,9 +203,9 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 		if len(taggedItems) == 0 {
 			return nil, errors.Errorf("nothing has the tag '%v'", sc.name)
 		}
-		names := []string{}
-		for _, item := range taggedItems {
-			names = append(names, item.name())
+		names := make([]string, len(taggedItems))
+		for i, item := range taggedItems {
+			names[i] = item.name()
 		}
 		return names, nil
 


### PR DESCRIPTION
[EVG-15661](https://jira.mongodb.org/browse/EVG-15661)

### Description 
Didn't consider that variants can be created from matrix definitions. Included this from translateProject.

### Testing 
I'm a bit put out that I had to slightly learn matrices to unit test this.
