### PR TITLE
EVG-15394 allow periodic build definitions without alias

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2275,9 +2275,6 @@ func (d *PeriodicBuildDefinition) Validate() error {
 	if d.ConfigFile == "" {
 		catcher.New("A config file must be specified")
 	}
-	if d.Alias == "" {
-		catcher.New("Alias must be specified")
-	}
 
 	if d.ID == "" {
 		d.ID = utility.RandomString()

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1424,7 +1424,7 @@ func TestValidatePeriodicBuildDefinition(t *testing.T) {
 			IntervalHours: 24,
 			ConfigFile:    "foo.yml",
 			Alias:         "",
-		}: false,
+		}: true,
 	}
 
 	for testCase, shouldPass := range testCases {

--- a/public/static/partials/periodic_build_modal.html
+++ b/public/static/partials/periodic_build_modal.html
@@ -1,6 +1,6 @@
 <md-dialog style="width:650px">
     <md-dialog-content>
-        <form">
+        <form>
             <md-card style="width:97.5%">
                 <md-card-title>
                     <div ng-bind="modalTitle()"></div>
@@ -19,7 +19,7 @@
                     <section layout="row" flex>
                         <md-input-container flex=50>
                             <label>Patch Alias:</label>
-                            <input type="text" ng-model="periodic_build.alias" placeholder="my_task_alias" ng-required="true">
+                            <input type="text" ng-model="periodic_build.alias" placeholder="my_task_alias">
                         </md-input-container>
                         <md-input-container flex=50>
                             <label>Message:</label>


### PR DESCRIPTION
[EVG-15394](https://jira.mongodb.org/browse/EVG-15394)

### Description 
We don't actually require an alias here, especially since users can define a completely separate yaml. This is consistent with [documentation](https://github.com/evergreen-ci/evergreen/wiki/Project-and-Distro-Settings#periodic-builds).

### Testing 
Verified I was able to save a periodic build in the DB without error and that it no longer shows up as required on the UI.
![image](https://user-images.githubusercontent.com/26798134/139730868-44e66431-6e10-45c1-9f41-287d9610376d.png)
