### PR TITLE
EVG-15307 disallow project admin duplicates

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -308,6 +308,25 @@ mciModule.controller(
       $scope.isDirty = true;
     };
 
+    $scope.isValidGitTagUser = function(user) {
+        if ($scope.settingsFormData.git_tag_authorized_users === undefined) {
+            return true;
+        }
+        return !$scope.settingsFormData.git_tag_authorized_users.includes(user);
+    }
+    $scope.isValidGitTagTeam = function(team) {
+        if ($scope.settingsFormData.git_tag_authorized_teams === undefined) {
+            return true;
+        }
+        return !$scope.settingsFormData.git_tag_authorized_teams.includes(team);
+    }
+    $scope.isValidAdmin = function(admin) {
+        if ($scope.settingsFormData.admins == undefined) {
+            return true;
+        }
+        return !$scope.settingsFormData.admins.includes(admin);
+    }
+
     $scope.addGitTagTeam = function () {
       $scope.settingsFormData.git_tag_authorized_teams.push(
         $scope.git_tag_team

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -254,9 +254,12 @@ Evergreen Projects
       <div class="form-group">
         <div class="col-lg-4">
           <input ng-model="admin_name" class="form-control" type="text" placeholder="username">
+          <div class="muted small" ng-show="!isValidAdmin(admin_name)">
+            Can't duplicate.
+          </div>
         </div>
         <div class="col-lg-2">
-          <button class="plus-button btn btn-primary" ng-disabled="!(admin_name)" type="button" ng-click="addAdmin()">
+          <button class="plus-button btn btn-primary" ng-disabled="!(admin_name) || !isValidAdmin(admin_name)" type="button" ng-click="addAdmin()">
           <i class="fa fa-plus"></i>
           </button>
         </div>
@@ -604,9 +607,12 @@ Evergreen Projects
           <div class="form-group">
             <div class="col-lg-4">
               <input ng-model="git_tag_user_name" class="form-control" type="text" placeholder="username">
+              <div class="muted small" ng-show="!isValidGitTagUser(git_tag_user_name)">
+                Can't duplicate.
+              </div>
             </div>
             <div class="col-lg-2">
-              <button class="plus-button btn btn-primary" ng-disabled="!(git_tag_user_name)" type="button" ng-click="addGitTagUser()">
+              <button class="plus-button btn btn-primary" ng-disabled="!(git_tag_user_name) || !isValidGitTagUser(git_tag_user_name)" type="button" ng-click="addGitTagUser()">
               <i class="fa fa-plus"></i>
               </button>
             </div>
@@ -631,9 +637,12 @@ Evergreen Projects
           <div class="form-group">
             <div class="col-lg-4">
               <input ng-model="git_tag_team" class="form-control" type="text" placeholder="team name">
+              <div class="muted small" ng-show="!isValidGitTagTeam(git_tag_team)">
+                Can't duplicate.
+              </div>
             </div>
             <div class="col-lg-2">
-              <button class="plus-button btn btn-primary" ng-disabled="!(git_tag_team)" type="button" ng-click="addGitTagTeam()">
+              <button class="plus-button btn btn-primary" ng-disabled="!(git_tag_team) || !isValidGitTagTeam(git_tag_team)" type="button" ng-click="addGitTagTeam()">
               <i class="fa fa-plus"></i>
               </button>
             </div>


### PR DESCRIPTION
[EVG-15307](https://jira.mongodb.org/browse/EVG-15307)

### Description 
Ng-repeat can't handle duplicates, so allowing duplicates to be added causes the admin lists to not display correctly. I added some handling for admin fields and will update the ops-manager-kubernetes to not have duplicates so that this problem goes away for them.

### Testing 
Tested all three fields in staging. (Could theoretically add to more fields but purposefully adding duplicates is a pretty rare thing to do and this page is legacy so I think it's not worth that.)
![image](https://user-images.githubusercontent.com/26798134/139734562-05c66500-8b22-4cc7-8b47-4d91464eed22.png)

