### PR TITLE
EVG-14655 return clearer errors for set-module

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2021-10-26"
+	ClientVersion = "2021-11-01"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2021-10-20"

--- a/operations/http.go
+++ b/operations/http.go
@@ -683,21 +683,21 @@ func (ac *legacyClient) GetOptimalMakespans(numberBuilds int, csv bool) (io.Read
 	return resp.Body, nil
 }
 
-// GetPatchModules retrieves a list of modules available for a given patch.
-func (ac *legacyClient) GetPatchModules(patchId, projectId string) ([]string, error) {
+// GetPatchModules retrieves a list of modules available for a given patch, along with the project identifier.
+func (ac *legacyClient) GetPatchModules(patchId, projectId string) ([]string, string, error) {
 	var out []string
 
 	resp, err := ac.get(fmt.Sprintf("patches/%s/%s/modules", patchId, projectId), nil)
 	if err != nil {
-		return out, err
+		return out, "", err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, client.AuthError
+		return nil, "", client.AuthError
 	}
 	if resp.StatusCode != http.StatusOK {
-		return out, NewAPIError(resp)
+		return out, "", NewAPIError(resp)
 	}
 
 	data := struct {
@@ -707,11 +707,10 @@ func (ac *legacyClient) GetPatchModules(patchId, projectId string) ([]string, er
 
 	err = utility.ReadJSON(resp.Body, &data)
 	if err != nil {
-		return out, err
+		return out, "", err
 	}
-	out = data.Modules
 
-	return out, nil
+	return data.Modules, data.Project, nil
 }
 
 // GetRecentVersions retrieves a list of recent versions for a project,

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -84,13 +84,14 @@ func PatchSetModule() cli.Command {
 			moduleBranch, err := getModuleBranch(module, proj)
 			if err != nil {
 				grip.Error(err)
-				mods, merr := ac.GetPatchModules(patchID, existingPatch.Project)
+				mods, projectIdentifier, merr := ac.GetPatchModules(patchID, existingPatch.Project)
 				if merr != nil {
 					return errors.Wrap(merr, "errors fetching list of available modules")
 				}
 
 				if len(mods) != 0 {
-					grip.Noticef("known modules includes:\n\t%s", strings.Join(mods, "\n\t"))
+					return errors.Errorf("Could not find module named '%s' for project '%s', select correct module from:\n\t%s",
+						module, projectIdentifier, strings.Join(mods, "\n\t"))
 				}
 
 				return errors.Errorf("could not set specified module: \"%s\"", module)
@@ -129,18 +130,18 @@ func PatchSetModule() cli.Command {
 			}
 			err = ac.UpdatePatchModule(params)
 			if err != nil {
-				mods, err := ac.GetPatchModules(patchID, existingPatch.Project)
+				mods, projectIdentifier, err := ac.GetPatchModules(patchID, existingPatch.Project)
 				var msg string
 				if err != nil {
-					msg = fmt.Sprintf("could not find module named %s or retrieve list of modules",
+					msg = fmt.Sprintf("Could not find module named '%s' for this project",
 						module)
 				} else if len(mods) == 0 {
-					msg = fmt.Sprintf("could not find modules for this project. %s is not a module. "+
+					msg = fmt.Sprintf("Project '%s' has no configured modules."+
 						"see the evergreen configuration file for module configuration.",
-						module)
+						projectIdentifier)
 				} else {
-					msg = fmt.Sprintf("could not find module named '%s', select correct module from:\n\t%s",
-						module, strings.Join(mods, "\n\t"))
+					msg = fmt.Sprintf("Could not find module named '%s' for project '%s', select correct module from:\n\t%s",
+						module, projectIdentifier, strings.Join(mods, "\n\t"))
 				}
 				grip.Error(msg)
 				return err

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -88,7 +88,11 @@ func PatchSetModule() cli.Command {
 				if merr != nil {
 					return errors.Wrap(merr, "errors fetching list of available modules")
 				}
-
+				if len(mods) == 0 {
+					return errors.Errorf("Project '%s' has no configured modules. "+
+						"See the evergreen configuration file for module configuration.",
+						projectIdentifier)
+				}
 				if len(mods) != 0 {
 					return errors.Errorf("Could not find module named '%s' for project '%s', select correct module from:\n\t%s",
 						module, projectIdentifier, strings.Join(mods, "\n\t"))
@@ -136,8 +140,8 @@ func PatchSetModule() cli.Command {
 					msg = fmt.Sprintf("Could not find module named '%s' for this project",
 						module)
 				} else if len(mods) == 0 {
-					msg = fmt.Sprintf("Project '%s' has no configured modules."+
-						"see the evergreen configuration file for module configuration.",
+					msg = fmt.Sprintf("Project '%s' has no configured modules. "+
+						"See the evergreen configuration file for module configuration.",
 						projectIdentifier)
 				} else {
 					msg = fmt.Sprintf("Could not find module named '%s' for project '%s', select correct module from:\n\t%s",

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -89,12 +89,12 @@ func PatchSetModule() cli.Command {
 					return errors.Wrap(merr, "errors fetching list of available modules")
 				}
 				if len(mods) == 0 {
-					return errors.Errorf("Project '%s' has no configured modules. "+
-						"See the evergreen configuration file for module configuration.",
+					return errors.Errorf("Project '%s' has no configured modules. Specify different project or "+
+						"see the evergreen configuration file for module configuration.",
 						projectIdentifier)
 				}
 				if len(mods) != 0 {
-					return errors.Errorf("Could not find module named '%s' for project '%s', select correct module from:\n\t%s",
+					return errors.Errorf("Could not find module named '%s' for project '%s'; specify different project or select correct module from:\n\t%s",
 						module, projectIdentifier, strings.Join(mods, "\n\t"))
 				}
 
@@ -140,11 +140,11 @@ func PatchSetModule() cli.Command {
 					msg = fmt.Sprintf("Could not find module named '%s' for this project",
 						module)
 				} else if len(mods) == 0 {
-					msg = fmt.Sprintf("Project '%s' has no configured modules. "+
-						"See the evergreen configuration file for module configuration.",
+					msg = fmt.Sprintf("Project '%s' has no configured modules. Specify different project or "+
+						"see the evergreen configuration file for module configuration.",
 						projectIdentifier)
 				} else {
-					msg = fmt.Sprintf("Could not find module named '%s' for project '%s', select correct module from:\n\t%s",
+					msg = fmt.Sprintf("Could not find module named '%s' for project '%s'. Specify different project or select correct module from:\n\t%s",
 						module, projectIdentifier, strings.Join(mods, "\n\t"))
 				}
 				grip.Error(msg)

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -93,12 +93,8 @@ func PatchSetModule() cli.Command {
 						"see the evergreen configuration file for module configuration.",
 						projectIdentifier)
 				}
-				if len(mods) != 0 {
-					return errors.Errorf("Could not find module named '%s' for project '%s'; specify different project or select correct module from:\n\t%s",
-						module, projectIdentifier, strings.Join(mods, "\n\t"))
-				}
-
-				return errors.Errorf("could not set specified module: \"%s\"", module)
+				return errors.Errorf("Could not find module named '%s' for project '%s'; specify different project or select correct module from:\n\t%s",
+					module, projectIdentifier, strings.Join(mods, "\n\t"))
 			}
 
 			if uncommittedOk || conf.UncommittedChanges {

--- a/service/api.go
+++ b/service/api.go
@@ -147,7 +147,7 @@ func (as *APIServer) checkProject(next http.HandlerFunc) http.HandlerFunc {
 		}
 		if p == nil {
 			as.LoggedError(w, r, http.StatusNotFound,
-				errors.Errorf("can't find project: %s", p.Identifier))
+				errors.Errorf("can't find config for : %s", projectRef.Id))
 			return
 		}
 

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -446,12 +446,16 @@ func (as *APIServer) listPatchModules(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
-
+	projectName := project.Identifier // this might be the ID, so use identifier if we can
+	identifier, _ := model.GetIdentifierForProject(project.Identifier)
+	if identifier != "" {
+		projectName = identifier
+	}
 	data := struct {
 		Project string   `json:"project"`
 		Modules []string `json:"modules"`
 	}{
-		Project: project.Identifier,
+		Project: projectName,
 	}
 
 	mods := map[string]struct{}{}

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -468,6 +468,9 @@ func (as *APIServer) listPatchModules(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, m := range p.Patches {
+		if m.ModuleName == "" {
+			continue
+		}
 		mods[m.ModuleName] = struct{}{}
 	}
 


### PR DESCRIPTION
[EVG-14655](https://jira.mongodb.org/browse/EVG-14655)

### Description 
I think the difficulty with the error is that it doesn't say what project you're using or specify that the project itself may be the problem, so I added some detail.

### Testing 
tested using local.
```
$ ../evergreen/clients/darwin_amd64/evergreen -c ~/.evergreen-local.yml set-module -i 5f74d99ab2373627c047c5e5 -m dsi  -y
module 'dsi' unknown or not found
Project 'evergreen' has no configured modules. Specify different project or see the evergreen configuration file for module configuration.

$ clients/darwin_amd64/evergreen set-module -i 61689cf1c9ec443f692bd8b0 -m dsi -y
module 'dsi' unknown or not found
Could not find module named 'dsi' for project 'spruce'. Specify different project or select correct module from:
	evergreen
```