### PR TITLE
EVG-15764 Limit taskNamesByBuildVariant query to last 50 versions

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3249,7 +3249,7 @@ func (r *queryResolver) TaskNamesForBuildVariant(ctx context.Context, projectId 
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting repository for '%s': %s", projectId, err.Error()))
 	}
 	if repo == nil {
-		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("could not find repository '%s'", projectId))
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("could not find repository '%s'", pid))
 	}
 	buildVariantTasks, err := task.FindTaskNamesByBuildVariant(projectId, buildVariant, repo.RevisionOrderNumber)
 	if err != nil {

--- a/graphql/tests/taskNamesForBuildVariant/data.json
+++ b/graphql/tests/taskNamesForBuildVariant/data.json
@@ -5,28 +5,46 @@
             "display_name" : "test-agent",
             "build_variant": "ubuntu1604",
             "branch": "evergreen",
-            "r": "gitter_request"
+            "r": "gitter_request",
+            "order": 1
         },
         {
             "_id": "t2",
             "display_name" : "dist",
             "build_variant": "ubuntu1604",
             "branch": "evergreen",
-            "r": "gitter_request"
+            "r": "gitter_request",
+            "order": 1
         },
         {
             "_id": "t3",
             "display_name" : "test-graphql",
             "build_variant": "ubuntu1604",
             "branch": "evergreen",
-            "r": "gitter_request"
+            "r": "gitter_request",
+            "order": 1
         },
         {
             "_id": "t4",
             "display_name" : "test-agent",
             "build_variant": "osx",
             "branch": "evergreen",
-            "r": "gitter_request"
+            "r": "gitter_request",
+            "order": 1
+        }
+    ],
+    "project_ref": [
+        {
+            "_id": "evergreen",
+            "identifier": "evergreen",
+            "branch": "main",
+            "display_name": "Evergreen"
+        }
+    ],
+    "repo_revisions": [
+        {
+            "_id": "evergreen",
+            "last_commit_number": 1
         }
     ]
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -964,7 +964,7 @@ func FindTaskNamesByBuildVariant(projectId string, buildVariant string, repoOrde
 				{DisplayTaskIdKey: ""},
 			},
 			"$and": []bson.M{
-				{RevisionOrderNumberKey: bson.M{"$gte": repoOrderNumber - VersionLimit}},
+				{RevisionOrderNumberKey: bson.M{"$gt": repoOrderNumber - VersionLimit}},
 				{RevisionOrderNumberKey: bson.M{"$lte": repoOrderNumber}},
 			},
 		},

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -953,7 +953,7 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 }
 
 // FindTaskNamesByBuildVariant returns a list of unique task names for a given build variant
-func FindTaskNamesByBuildVariant(projectId string, buildVariant string) ([]string, error) {
+func FindTaskNamesByBuildVariant(projectId string, buildVariant string, repoOrderNumber int) ([]string, error) {
 	pipeline := []bson.M{
 		{"$match": bson.M{
 			ProjectKey:      projectId,
@@ -962,6 +962,10 @@ func FindTaskNamesByBuildVariant(projectId string, buildVariant string) ([]strin
 			"$or": []bson.M{
 				{DisplayTaskIdKey: bson.M{"$exists": false}},
 				{DisplayTaskIdKey: ""},
+			},
+			"$and": []bson.M{
+				{RevisionOrderNumberKey: bson.M{"$gte": repoOrderNumber - VersionLimit}},
+				{RevisionOrderNumberKey: bson.M{"$lte": repoOrderNumber}},
 			},
 		},
 		},

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2375,42 +2375,46 @@ func TestFindTaskNamesByBuildVariant(t *testing.T) {
 	Convey("Should return unique task names for a given build variant", t, func() {
 		assert.NoError(t, db.ClearCollections(Collection))
 		t1 := Task{
-			Id:           "t1",
-			Status:       evergreen.TaskSucceeded,
-			BuildVariant: "ubuntu1604",
-			DisplayName:  "dist",
-			Project:      "evergreen",
-			Requester:    evergreen.RepotrackerVersionRequester,
+			Id:                  "t1",
+			Status:              evergreen.TaskSucceeded,
+			BuildVariant:        "ubuntu1604",
+			DisplayName:         "dist",
+			Project:             "evergreen",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			RevisionOrderNumber: 1,
 		}
 		assert.NoError(t, t1.Insert())
 		t2 := Task{
-			Id:           "t2",
-			Status:       evergreen.TaskSucceeded,
-			BuildVariant: "ubuntu1604",
-			DisplayName:  "test-agent",
-			Project:      "evergreen",
-			Requester:    evergreen.RepotrackerVersionRequester,
+			Id:                  "t2",
+			Status:              evergreen.TaskSucceeded,
+			BuildVariant:        "ubuntu1604",
+			DisplayName:         "test-agent",
+			Project:             "evergreen",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			RevisionOrderNumber: 1,
 		}
 		assert.NoError(t, t2.Insert())
 		t3 := Task{
-			Id:           "t3",
-			Status:       evergreen.TaskSucceeded,
-			BuildVariant: "ubuntu1604",
-			DisplayName:  "test-graphql",
-			Project:      "evergreen",
-			Requester:    evergreen.RepotrackerVersionRequester,
+			Id:                  "t3",
+			Status:              evergreen.TaskSucceeded,
+			BuildVariant:        "ubuntu1604",
+			DisplayName:         "test-graphql",
+			Project:             "evergreen",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			RevisionOrderNumber: 1,
 		}
 		assert.NoError(t, t3.Insert())
 		t4 := Task{
-			Id:           "t4",
-			Status:       evergreen.TaskFailed,
-			BuildVariant: "ubuntu1604",
-			DisplayName:  "test-graphql",
-			Project:      "evergreen",
-			Requester:    evergreen.RepotrackerVersionRequester,
+			Id:                  "t4",
+			Status:              evergreen.TaskFailed,
+			BuildVariant:        "ubuntu1604",
+			DisplayName:         "test-graphql",
+			Project:             "evergreen",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			RevisionOrderNumber: 1,
 		}
 		assert.NoError(t, t4.Insert())
-		buildVariantTask, err := FindTaskNamesByBuildVariant("evergreen", "ubuntu1604")
+		buildVariantTask, err := FindTaskNamesByBuildVariant("evergreen", "ubuntu1604", 1)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"dist", "test-agent", "test-graphql"}, buildVariantTask)
 
@@ -2418,42 +2422,46 @@ func TestFindTaskNamesByBuildVariant(t *testing.T) {
 	Convey("Should only include tasks that appear on mainline commits", t, func() {
 		assert.NoError(t, db.ClearCollections(Collection))
 		t1 := Task{
-			Id:           "t1",
-			Status:       evergreen.TaskSucceeded,
-			BuildVariant: "ubuntu1604",
-			DisplayName:  "test-patch-only",
-			Project:      "evergreen",
-			Requester:    evergreen.PatchVersionRequester,
+			Id:                  "t1",
+			Status:              evergreen.TaskSucceeded,
+			BuildVariant:        "ubuntu1604",
+			DisplayName:         "test-patch-only",
+			Project:             "evergreen",
+			Requester:           evergreen.PatchVersionRequester,
+			RevisionOrderNumber: 1,
 		}
 		assert.NoError(t, t1.Insert())
 		t2 := Task{
-			Id:           "t2",
-			Status:       evergreen.TaskSucceeded,
-			BuildVariant: "ubuntu1604",
-			DisplayName:  "test-graphql",
-			Project:      "evergreen",
-			Requester:    evergreen.RepotrackerVersionRequester,
+			Id:                  "t2",
+			Status:              evergreen.TaskSucceeded,
+			BuildVariant:        "ubuntu1604",
+			DisplayName:         "test-graphql",
+			Project:             "evergreen",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			RevisionOrderNumber: 1,
 		}
 		assert.NoError(t, t2.Insert())
 		t3 := Task{
-			Id:           "t3",
-			Status:       evergreen.TaskSucceeded,
-			BuildVariant: "ubuntu1604",
-			DisplayName:  "dist",
-			Project:      "evergreen",
-			Requester:    evergreen.PatchVersionRequester,
+			Id:                  "t3",
+			Status:              evergreen.TaskSucceeded,
+			BuildVariant:        "ubuntu1604",
+			DisplayName:         "dist",
+			Project:             "evergreen",
+			Requester:           evergreen.PatchVersionRequester,
+			RevisionOrderNumber: 1,
 		}
 		assert.NoError(t, t3.Insert())
 		t4 := Task{
-			Id:           "t4",
-			Status:       evergreen.TaskFailed,
-			BuildVariant: "ubuntu1604",
-			DisplayName:  "test-something",
-			Project:      "evergreen",
-			Requester:    evergreen.RepotrackerVersionRequester,
+			Id:                  "t4",
+			Status:              evergreen.TaskFailed,
+			BuildVariant:        "ubuntu1604",
+			DisplayName:         "test-something",
+			Project:             "evergreen",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			RevisionOrderNumber: 1,
 		}
 		assert.NoError(t, t4.Insert())
-		buildVariantTasks, err := FindTaskNamesByBuildVariant("evergreen", "ubuntu1604")
+		buildVariantTasks, err := FindTaskNamesByBuildVariant("evergreen", "ubuntu1604", 1)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"test-graphql", "test-something"}, buildVariantTasks)
 	})


### PR DESCRIPTION
[EVG-15764](https://jira.mongodb.org/browse/EVG-15764)

### Description 
This adds the same limits as #5144 to the taskNamesByBuildVariant query
