### PR TITLE
EVG-14660 Update notifications to use new ui link when possible

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -154,7 +154,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	if r.FormValue("redirect_spruce_users") == "true" {
 		if u := gimlet.GetUser(r.Context()); u != nil {
 			usr, ok := u.(*user.DBUser)
-			if ok && usr.Settings.UseSpruceOptions.SpruceV1 {
+			if ok && usr != nil && usr.Settings.UseSpruceOptions.SpruceV1 {
 				http.Redirect(w, r, fmt.Sprintf("%s/task/%s", uis.Settings.Ui.UIv2Url, projCtx.Task.Id), http.StatusTemporaryRedirect)
 				return
 			}

--- a/service/task.go
+++ b/service/task.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/plugin"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
@@ -151,10 +152,12 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
 
 	if r.FormValue("redirect_spruce_users") == "true" {
-		user := MustHaveUser(r)
-		if user.Settings.UseSpruceOptions.SpruceV1 {
-			http.Redirect(w, r, fmt.Sprintf("%s/task/%s", uis.Settings.Ui.UIv2Url, projCtx.Task.Id), http.StatusTemporaryRedirect)
-			return
+		if u := gimlet.GetUser(r.Context()); u != nil {
+			usr, ok := u.(*user.DBUser)
+			if ok && usr.Settings.UseSpruceOptions.SpruceV1 {
+				http.Redirect(w, r, fmt.Sprintf("%s/task/%s", uis.Settings.Ui.UIv2Url, projCtx.Task.Id), http.StatusTemporaryRedirect)
+				return
+			}
 		}
 	}
 

--- a/service/version.go
+++ b/service/version.go
@@ -30,7 +30,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 	if r.FormValue("redirect_spruce_users") == "true" {
 		if u := gimlet.GetUser(r.Context()); u != nil {
 			usr, ok := u.(*user.DBUser)
-			if ok && usr.Settings.UseSpruceOptions.SpruceV1 {
+			if ok && usr != nil && usr.Settings.UseSpruceOptions.SpruceV1 {
 				http.Redirect(w, r, fmt.Sprintf("%s/version/%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id), http.StatusTemporaryRedirect)
 				return
 			}

--- a/service/version.go
+++ b/service/version.go
@@ -30,7 +30,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 	if r.FormValue("redirect_spruce_users") == "true" {
 		if u := gimlet.GetUser(r.Context()); u != nil {
 			usr, ok := u.(*user.DBUser)
-			if ok && usr != nil && usr.Settings.UseSpruceOptions.SpruceV1 {
+			if ok && usr.Settings.UseSpruceOptions.SpruceV1 {
 				http.Redirect(w, r, fmt.Sprintf("%s/version/%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id), http.StatusTemporaryRedirect)
 				return
 			}

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -438,7 +438,7 @@ func getFailedTestsFromTemplate(t task.Task) ([]task.TestResult, error) {
 }
 
 func taskLink(uiBase string, taskID string, execution int) string {
-	return fmt.Sprintf("%s/task/%s/%d", uiBase, url.PathEscape(taskID), execution)
+	return fmt.Sprintf("%s/task/%s/%d/?redirect_spruce_users=true", uiBase, url.PathEscape(taskID), execution)
 }
 
 func taskLogLink(uiBase string, taskID string, execution int) string {

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -438,7 +438,7 @@ func getFailedTestsFromTemplate(t task.Task) ([]task.TestResult, error) {
 }
 
 func taskLink(uiBase string, taskID string, execution int) string {
-	return fmt.Sprintf("%s/task/%s/%d/?redirect_spruce_users=true", uiBase, url.PathEscape(taskID), execution)
+	return fmt.Sprintf("%s/task/%s/%d?redirect_spruce_users=true", uiBase, url.PathEscape(taskID), execution)
 }
 
 func taskLogLink(uiBase string, taskID string, execution int) string {

--- a/trigger/task_jira_test.go
+++ b/trigger/task_jira_test.go
@@ -342,7 +342,7 @@ func TestJIRADescription(t *testing.T) {
 			So(logfiles, ShouldContain, j.data.Task.LocalTestResults[1].GetLogURL(evergreen.LogViewerHTML))
 
 			So(len(taskURLs), ShouldEqual, 1)
-			So(taskURLs, ShouldContain, "http://evergreen.ui/task/t1%21/0/?redirect_spruce_users=true")
+			So(taskURLs, ShouldContain, "http://evergreen.ui/task/t1%21/0?redirect_spruce_users=true")
 		})
 
 		Convey("can generate a description for a task with no host", func() {
@@ -355,11 +355,11 @@ func TestJIRADescription(t *testing.T) {
 			j.data.Task.Id = "new_task#!"
 			desc, err := j.getDescription()
 			So(err, ShouldBeNil)
-			So(strings.Contains(desc, "http://evergreen.ui/task/new_task%23%21/0/?redirect_spruce_users=true"), ShouldBeTrue)
+			So(strings.Contains(desc, "http://evergreen.ui/task/new_task%23%21/0?redirect_spruce_users=true"), ShouldBeTrue)
 			j.data.Task.OldTaskId = "old_task_id"
 			desc, err = j.getDescription()
 			So(err, ShouldBeNil)
-			So(strings.Contains(desc, "http://evergreen.ui/task/old_task_id/0/?redirect_spruce_users=true"), ShouldBeTrue)
+			So(strings.Contains(desc, "http://evergreen.ui/task/old_task_id/0?redirect_spruce_users=true"), ShouldBeTrue)
 		})
 		Convey("execution tasks use display task's metadata", func() {
 			j.data.Task.DisplayTask = &task.Task{
@@ -380,7 +380,7 @@ func TestJIRADescription(t *testing.T) {
 
 			desc, err := j.getDescription()
 			So(err, ShouldBeNil)
-			So(strings.Contains(desc, "http://evergreen.ui/task/t1%21/0/?redirect_spruce_users=true"), ShouldBeTrue)
+			So(strings.Contains(desc, "http://evergreen.ui/task/t1%21/0?redirect_spruce_users=true"), ShouldBeTrue)
 			So(strings.Contains(desc, "shouldn't be here"), ShouldBeFalse)
 		})
 		Convey("display tasks have links to execution task logs", func() {

--- a/trigger/task_jira_test.go
+++ b/trigger/task_jira_test.go
@@ -342,7 +342,7 @@ func TestJIRADescription(t *testing.T) {
 			So(logfiles, ShouldContain, j.data.Task.LocalTestResults[1].GetLogURL(evergreen.LogViewerHTML))
 
 			So(len(taskURLs), ShouldEqual, 1)
-			So(taskURLs, ShouldContain, "http://evergreen.ui/task/t1%21/0")
+			So(taskURLs, ShouldContain, "http://evergreen.ui/task/t1%21/0/?redirect_spruce_users=true")
 		})
 
 		Convey("can generate a description for a task with no host", func() {
@@ -355,11 +355,11 @@ func TestJIRADescription(t *testing.T) {
 			j.data.Task.Id = "new_task#!"
 			desc, err := j.getDescription()
 			So(err, ShouldBeNil)
-			So(strings.Contains(desc, "http://evergreen.ui/task/new_task%23%21/0"), ShouldBeTrue)
+			So(strings.Contains(desc, "http://evergreen.ui/task/new_task%23%21/0/?redirect_spruce_users=true"), ShouldBeTrue)
 			j.data.Task.OldTaskId = "old_task_id"
 			desc, err = j.getDescription()
 			So(err, ShouldBeNil)
-			So(strings.Contains(desc, "http://evergreen.ui/task/old_task_id/0"), ShouldBeTrue)
+			So(strings.Contains(desc, "http://evergreen.ui/task/old_task_id/0/?redirect_spruce_users=true"), ShouldBeTrue)
 		})
 		Convey("execution tasks use display task's metadata", func() {
 			j.data.Task.DisplayTask = &task.Task{
@@ -380,7 +380,7 @@ func TestJIRADescription(t *testing.T) {
 
 			desc, err := j.getDescription()
 			So(err, ShouldBeNil)
-			So(strings.Contains(desc, "http://evergreen.ui/task/t1%21/0"), ShouldBeTrue)
+			So(strings.Contains(desc, "http://evergreen.ui/task/t1%21/0/?redirect_spruce_users=true"), ShouldBeTrue)
 			So(strings.Contains(desc, "shouldn't be here"), ShouldBeFalse)
 		})
 		Convey("display tasks have links to execution task logs", func() {


### PR DESCRIPTION
[EVG-14660](https://jira.mongodb.org/browse/EVG-14660)

### Description 
links now have `?redirect_spruce_users=true`

### Testing 
on staging 
![image](https://user-images.githubusercontent.com/26491602/140236195-18b881dc-df12-4a7c-b24e-8eb07e440847.png)
https://evergreen-staging.corp.mongodb.com//task/evg_lint_generate_lint_e47bb73265e2eb443ea129a3b444336a3da1d53b_21_10_22_21_07_36/1/?redirect_spruce_users=true

caused a user not found panic once but im not sure what triggered it 
