### PR TITLE
EVG-15671 fix small bugs with copy and patch project routes

### DIFF
--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -47,7 +47,7 @@ func (sc *DBConnector) CopyProject(ctx context.Context, opts CopyProjectOpts) (*
 	oldIdentifier := projectToCopy.Identifier
 	projectToCopy.Identifier = opts.NewProjectIdentifier
 	projectToCopy.Enabled = utility.FalsePtr()
-	projectToCopy.PRTestingEnabled = nil
+	projectToCopy.PRTestingEnabled = utility.FalsePtr()
 	projectToCopy.CommitQueue.Enabled = nil
 	u := gimlet.GetUser(ctx).(*user.DBUser)
 	if err := sc.CreateProject(projectToCopy, u); err != nil {

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -590,7 +590,7 @@ func (p *APIProjectRef) ToService() (interface{}, error) {
 	// Copy periodic builds
 	if p.PeriodicBuilds != nil {
 		builds := []model.PeriodicBuildDefinition{}
-		for _, t := range p.Triggers {
+		for _, t := range p.PeriodicBuilds {
 			i, err = t.ToService()
 			if err != nil {
 				return nil, errors.Wrap(err, "cannot convert API periodic build")


### PR DESCRIPTION
[EVG-15671](https://jira.mongodb.org/browse/EVG-15671)

### Description 
We were having an issue copying and then enabling a project due to PR testing issues; while I was able to replicate this when the issue came up, I wasn't able to today; to be safe, I think we _should_ mark PR testing enabled as false explicitly, since for now we are enforcing that this can only be enabled once per branch.

I also introduced a bug to patch route by incorrectly copying periodic build definitions; this is fixed.

### Testing 
Tested on local.