### PR TITLE
EVG-14292 only log notifications when insert error isn't duplicate error

### DIFF
--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/evergreen/trigger"
@@ -138,7 +139,8 @@ func (j *eventNotifierJob) dispatchLoop(ctx context.Context, events []event.Even
 				catcher.Add(logger.MarkProcessed(&e))
 
 				if err = notification.InsertMany(n...); err != nil {
-					grip.Error(message.WrapError(err, message.Fields{
+					// consider that duplicate key errors are expected
+					grip.ErrorWhen(!db.IsDuplicateKey(err), message.WrapError(err, message.Fields{
 						"job_id":        j.ID(),
 						"job_type":      j.Type().Name,
 						"source":        "events-processing",


### PR DESCRIPTION
[EVG-14292](https://jira.mongodb.org/browse/EVG-14292)

### Description 
Right now we actually typically log these errors twice because we also add it to the job; we really only need to log here when the error is unexpected (because we also log notifications). It appears that we [do expect duplicate insert errors](https://github.com/evergreen-ci/evergreen/blob/9316e9aad79073b2e37dcca13314f76cfa56e4fa/model/notification/db.go#L103), so we shouldn't log these specifically.

