### PR TITLE
EVG-15779 add logging when creating github hook

### DIFF
--- a/model/github_hook.go
+++ b/model/github_hook.go
@@ -6,15 +6,14 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/github"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -124,6 +123,7 @@ func SetupNewGithubHook(ctx context.Context, settings evergreen.Settings, owner 
 		return nil, errors.New("unexpected data from github")
 	}
 	grip.Debug(message.Fields{
+		"ticket":            "EVG-15779",
 		"setup new webhook": respHook,
 		"owner":             owner,
 		"repo":              repo,

--- a/model/github_hook.go
+++ b/model/github_hook.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/utility"
@@ -120,6 +123,11 @@ func SetupNewGithubHook(ctx context.Context, settings evergreen.Settings, owner 
 	if resp.StatusCode != http.StatusCreated || respHook == nil || respHook.ID == nil {
 		return nil, errors.New("unexpected data from github")
 	}
+	grip.Debug(message.Fields{
+		"setup new webhook": respHook,
+		"owner":             owner,
+		"repo":              repo,
+	})
 	hook := &GithubHook{
 		HookID: int(respHook.GetID()),
 		Owner:  owner,

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -114,9 +114,9 @@ func FindAliasesForRepo(repoId string) ([]ProjectAlias, error) {
 	return out, nil
 }
 
-// findAliasInRepo finds all aliases with a given name for a repo.
+// findMatchingAliasForRepo finds all aliases with a given name for a repo.
 // Typically FindAliasInProjectOrRepo should be used.
-func findAliasInRepo(repoID, alias string) ([]ProjectAlias, error) {
+func findMatchingAliasForRepo(repoID, alias string) ([]ProjectAlias, error) {
 	var out []ProjectAlias
 	q := db.Query(bson.M{
 		projectIDKey: repoID,
@@ -129,29 +129,10 @@ func findAliasInRepo(repoID, alias string) ([]ProjectAlias, error) {
 	return out, nil
 }
 
-// findAliasInProject finds all aliases with a given name for a project.
+// findMatchingAliasForProjectRef finds all aliases with a given name for a project.
 // Typically FindAliasInProjectOrRepo should be used.
-func findAliasInProject(projectID, alias string) ([]ProjectAlias, error) {
-	parserProject, err := ParserProjectByVersion(projectID, "")
-	if err != nil {
-		return nil, errors.Wrap(err, "error finding project parser")
-	}
-	if parserProject != nil {
-		parserProjectAliases := aliasesToMap(getFullParserProjectAliases(parserProject))
-		if parserProjectAliases[alias] != nil {
-			return parserProjectAliases[alias], nil
-		}
-	}
-	dbAliases, err := findAliasInProjectFromDb(projectID, alias)
-	if err != nil {
-		return nil, err
-	}
-	return dbAliases, nil
-}
-
-// findAliasInProjectFromDb finds all aliases with a given name for a project without checking the parser project.
-// Typically FindAliasInProjectOrRepo should be used.
-func findAliasInProjectFromDb(projectID, alias string) ([]ProjectAlias, error) {
+// Returns true if we should continue to checking repo.
+func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, bool, error) {
 	var out []ProjectAlias
 	q := db.Query(bson.M{
 		projectIDKey: projectID,
@@ -159,9 +140,42 @@ func findAliasInProjectFromDb(projectID, alias string) ([]ProjectAlias, error) {
 	})
 	err := db.FindAllQ(ProjectAliasCollection, q, &out)
 	if err != nil {
-		return nil, errors.Wrap(err, "error finding project aliases")
+		return nil, false, errors.Wrap(err, "error finding project aliases")
 	}
-	return out, nil
+
+	if len(out) == 0 && IsPatchAlias(alias) {
+		// return true if any patch aliases are defined
+		numPatchAliases, err := countPatchAliasesForProjectRef(projectID)
+		if err != nil {
+			return nil, false, errors.Wrap(err, "error counting patch aliases")
+		}
+		return nil, numPatchAliases > 0, nil
+	}
+	return out, false, nil
+}
+
+// Returns true if the alias doesn't match but is defined.
+func findAliasInParserProject(projectID, alias string) ([]ProjectAlias, bool, error) {
+	// if alias is a PATCH ALIAS, we want to know if it has ANY patch aliases.
+	parserProject, err := ParserProjectByVersion(projectID, "")
+	if err != nil {
+		return nil, false, errors.Wrap(err, "error finding project parser")
+	}
+	if parserProject != nil {
+		parserProjectAliases := aliasesToMap(getFullParserProjectAliases(parserProject))
+		if parserProjectAliases[alias] != nil {
+			return parserProjectAliases[alias], true, nil
+		}
+	}
+	aliasesDefined := IsPatchAlias(alias) && len(parserProject.PatchAliases) > 0
+	return nil, aliasesDefined, nil
+}
+
+func countPatchAliasesForProjectRef(projectID string) (int, error) {
+	return db.Count(ProjectAliasCollection, bson.M{
+		projectIDKey: projectID,
+		aliasKey:     bson.M{"$nin": evergreen.InternalAliases},
+	})
 }
 
 func aliasesToMap(aliases []ProjectAlias) map[string][]ProjectAlias {
@@ -221,7 +235,7 @@ func mergeAliases(parserProject *ParserProject, databaseAliases []ProjectAlias) 
 // FindAliasInProjectOrRepo finds all aliases with a given name for a project.
 // If the project has no aliases, the repo is checked for aliases.
 func FindAliasInProjectOrRepo(projectID, alias string) ([]ProjectAlias, error) {
-	aliases, err := findAliasInProject(projectID, alias)
+	aliases, err := findMatchingAliasForProjectRef(projectID, alias)
 	if err != nil {
 		return aliases, errors.Wrapf(err, "error finding aliases for project '%s'", projectID)
 	}
@@ -234,7 +248,7 @@ func FindAliasInProjectOrRepo(projectID, alias string) ([]ProjectAlias, error) {
 // FindAliasInProjectOrRepoFromDb finds all aliases with a given name for a project without merging with parser project.
 // If the project has no aliases, the repo is checked for aliases.
 func FindAliasInProjectOrRepoFromDb(projectID, alias string) ([]ProjectAlias, error) {
-	aliases, err := findAliasInProjectFromDb(projectID, alias)
+	aliases, err := findMatchingAliasForProjectRef(projectID, alias)
 	if err != nil {
 		return aliases, errors.Wrapf(err, "error finding aliases for project '%s'", projectID)
 	}
@@ -256,7 +270,7 @@ func tryGetRepoAliases(projectID string, alias string, aliases []ProjectAlias) (
 		return aliases, nil
 	}
 
-	aliases, err = findAliasInRepo(project.RepoRefId, alias)
+	aliases, err = findMatchingAliasForRepo(project.RepoRefId, alias)
 	if err != nil {
 		return aliases, errors.Wrapf(err, "error finding aliases for repo '%s'", project.RepoRefId)
 	}
@@ -338,6 +352,10 @@ func RemoveProjectAlias(id string) error {
 		return errors.Wrapf(err, "failed to remove project alias %s", id)
 	}
 	return nil
+}
+
+func IsPatchAlias(alias string) bool {
+	return !utility.StringSliceContains(evergreen.InternalAliases, alias)
 }
 
 func (a ProjectAliases) HasMatchingGitTag(tag string) (bool, error) {

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -155,7 +155,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProject() {
 	s.NoError(a2.Upsert())
 	s.NoError(a3.Upsert())
 
-	found, err := findAliasInProject("project-1", "alias-1")
+	found, err := findMatchingAliasForProjectRef("project-1", "alias-1")
 	s.NoError(err)
 	s.Len(found, 2)
 }

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
@@ -142,11 +141,11 @@ func (pc *DBAliasConnector) UpdateAliasesForSection(projectId string, updatedAli
 
 func shouldSkipAliasForSection(section model.ProjectPageSection, alias string) bool {
 	// if we're updating internal aliases, skip non-internal aliases
-	if section == model.ProjectPageGithubAndCQSection && !utility.StringSliceContains(evergreen.InternalAliases, alias) {
+	if section == model.ProjectPageGithubAndCQSection && model.IsPatchAlias(alias) {
 		return true
 	}
 	// if we're updating patch aliases, skip internal aliases
-	if section == model.ProjectPagePatchAliasSection && utility.StringSliceContains(evergreen.InternalAliases, alias) {
+	if section == model.ProjectPagePatchAliasSection && !model.IsPatchAlias(alias) {
 		return true
 	}
 	return false

--- a/service/project.go
+++ b/service/project.go
@@ -395,7 +395,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			if err = hook.Insert(); err != nil {
-				// A github hook as been created, but we couldn't
+				// A github hook has been created, but we couldn't
 				// save the hook ID in our database. This needs
 				// manual attention for clean up
 				grip.Error(message.WrapError(err, message.Fields{


### PR DESCRIPTION
[EVG-15779](https://jira.mongodb.org/browse/EVG-15779)

### Description 
Given logging and the fact that we _do_ have a github hook ID in the DB, I kind of feel like this was a github issue, or that errors are now returned to us in ways we don't know how to process, so I'd like to log this body.
