### PR TITLE
EVG-15791: resolve baseTaskId in baseTaskMetadata gql type

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -100,6 +100,7 @@ type ComplexityRoot struct {
 
 	BaseTaskMetadata struct {
 		BaseTaskDuration func(childComplexity int) int
+		BaseTaskID       func(childComplexity int) int
 		BaseTaskLink     func(childComplexity int) int
 	}
 
@@ -1493,6 +1494,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.BaseTaskMetadata.BaseTaskDuration(childComplexity), true
+
+	case "BaseTaskMetadata.baseTaskId":
+		if e.complexity.BaseTaskMetadata.BaseTaskID == nil {
+			break
+		}
+
+		return e.complexity.BaseTaskMetadata.BaseTaskID(childComplexity), true
 
 	case "BaseTaskMetadata.baseTaskLink":
 		if e.complexity.BaseTaskMetadata.BaseTaskLink == nil {
@@ -7753,6 +7761,7 @@ type PatchMetadata {
 type BaseTaskMetadata {
   baseTaskDuration: Duration
   baseTaskLink: String!
+  baseTaskId: String!
 }
 
 type AbortInfo {
@@ -10551,6 +10560,40 @@ func (ec *executionContext) _BaseTaskMetadata_baseTaskLink(ctx context.Context, 
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.BaseTaskLink, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _BaseTaskMetadata_baseTaskId(ctx context.Context, field graphql.CollectedField, obj *BaseTaskMetadata) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "BaseTaskMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BaseTaskID, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -37279,6 +37322,11 @@ func (ec *executionContext) _BaseTaskMetadata(ctx context.Context, sel ast.Selec
 			out.Values[i] = ec._BaseTaskMetadata_baseTaskDuration(ctx, field, obj)
 		case "baseTaskLink":
 			out.Values[i] = ec._BaseTaskMetadata_baseTaskLink(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "baseTaskId":
+			out.Values[i] = ec._BaseTaskMetadata_baseTaskId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -26,6 +26,7 @@ type AbortInfo struct {
 type BaseTaskMetadata struct {
 	BaseTaskDuration *model.APIDuration `json:"baseTaskDuration"`
 	BaseTaskLink     string             `json:"baseTaskLink"`
+	BaseTaskID       string             `json:"baseTaskId"`
 }
 
 type BaseTaskResult struct {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3004,6 +3004,7 @@ func (r *taskResolver) BaseTaskMetadata(ctx context.Context, at *restModel.APITa
 	baseTaskMetadata := BaseTaskMetadata{
 		BaseTaskLink:     fmt.Sprintf("%s/task/%s", config.Ui.Url, baseTask.Id),
 		BaseTaskDuration: &dur,
+		BaseTaskID:       baseTask.Id,
 	}
 	if baseTask.TimeTaken == 0 {
 		baseTaskMetadata.BaseTaskDuration = nil

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -927,7 +927,8 @@ type PatchMetadata {
 
 type BaseTaskMetadata {
   baseTaskDuration: Duration
-  baseTaskLink: String!
+  baseTaskLink: String! @deprecated(reason: "baseTaskLink is deprecated and should not be used")
+  baseTaskId: String!
 }
 
 type AbortInfo {

--- a/graphql/tests/task/queries/baseTaskMetadata.graphql
+++ b/graphql/tests/task/queries/baseTaskMetadata.graphql
@@ -3,6 +3,7 @@
     baseTaskMetadata {
       baseTaskDuration
       baseTaskLink
+      baseTaskId
     }
   }
 }

--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -7,7 +7,8 @@
           "task": {
             "baseTaskMetadata": {
               "baseTaskDuration": 30000000,
-              "baseTaskLink": "/task/base-task-1"
+              "baseTaskLink": "/task/base-task-1",
+              "baseTaskId": "base-task-1"
             }
           }
         }


### PR DESCRIPTION
[EVG-15791](https://jira.mongodb.org/browse/EVG-15791)

### Description 
This will be used to generate a spruce link on the task details metadata card

