### PR TITLE
EVG-15676 log generate task errors at a lower level

### DIFF
--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -283,14 +283,14 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 		"version":       t.Version,
 	}))
 	if err != nil && !shouldNoop {
-		grip.Error(message.WrapError(err, message.Fields{
+		isSaveErr := strings.Contains(err.Error(), evergreen.SaveGenerateTasksError) // we already log save errors to the user
+		grip.DebugWhen(!isSaveErr, message.WrapError(err, message.Fields{
 			"message":       "generate.tasks finished with errors",
 			"operation":     "generate.tasks",
 			"duration_secs": time.Since(start).Seconds(),
 			"task":          t.Id,
 			"job":           j.ID(),
 			"version":       t.Version,
-			"is_save_error": strings.Contains(err.Error(), evergreen.SaveGenerateTasksError),
 		}))
 	}
 

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -290,7 +290,7 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 			"task":          t.Id,
 			"job":           j.ID(),
 			"version":       t.Version,
-			"is_save_error": strings.Contains(err.Error(), evergreen.SaveGenerateTasksError)
+			"is_save_error": strings.Contains(err.Error(), evergreen.SaveGenerateTasksError),
 		}))
 	}
 

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -283,14 +283,14 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 		"version":       t.Version,
 	}))
 	if err != nil && !shouldNoop {
-		isSaveErr := strings.Contains(err.Error(), evergreen.SaveGenerateTasksError) // we already log save errors to the user
-		grip.DebugWhen(!isSaveErr, message.WrapError(err, message.Fields{
+		grip.Debug(message.WrapError(err, message.Fields{
 			"message":       "generate.tasks finished with errors",
 			"operation":     "generate.tasks",
 			"duration_secs": time.Since(start).Seconds(),
 			"task":          t.Id,
 			"job":           j.ID(),
 			"version":       t.Version,
+			"is_save_error": strings.Contains(err.Error(), evergreen.SaveGenerateTasksError)
 		}))
 	}
 


### PR DESCRIPTION
[EVG-15676](https://jira.mongodb.org/browse/EVG-15676)

### Description 
We send errors saving to the task logs so we don't need to always log in order to debug tasks; if the job overall fails due to this error we'll still log it to splunk with the job. Also should log at a lower level since this doesn't demonstrate an application error necessarily.

