### PR TITLE
EVG-15307 consider patch aliases as overridden even if one doesn't match

### DIFF
--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -135,7 +135,7 @@ func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, bo
 		}
 		return nil, numPatchAliases > 0, nil
 	}
-	return out, true, nil
+	return out, len(out) > 0, nil
 }
 
 // Returns true if we have an alias match or the alias doesn't match but

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -208,14 +208,23 @@ func (s *ProjectAliasSuite) TestMergeAliasesWithParserProject() {
 	}
 	s.NoError(parserProject.TryUpsert())
 
-	projectAliases, err := FindAliasesForProjectFromDb("project-1")
+	projectAliases, err := FindAliasInProjectOrRepo("project-1", evergreen.CommitQueueAlias)
 	s.NoError(err)
-	s.Len(projectAliases, 4)
-	aliasMap := aliasesToMap(projectAliases)
-	s.Len(aliasMap[evergreen.CommitQueueAlias], 1)
-	s.Len(aliasMap[evergreen.GithubPRAlias], 1)
-	s.Len(aliasMap["alias-1"], 1)
-	s.Len(aliasMap["alias-2"], 1)
+	s.Len(projectAliases, 1)
+
+	projectAliases, err = FindAliasInProjectOrRepo("project-1", evergreen.GithubPRAlias)
+	s.NoError(err)
+	s.Len(projectAliases, 1)
+	projectAliases, err = FindAliasInProjectOrRepo("project-1", "alias-1")
+	s.NoError(err)
+	s.Len(projectAliases, 1)
+	projectAliases, err = FindAliasInProjectOrRepo("project-1", "alias-2")
+	s.NoError(err)
+	s.Len(projectAliases, 1)
+
+	projectAliases, err = FindAliasInProjectOrRepo("project-1", "nonexistent")
+	s.NoError(err)
+	s.Len(projectAliases, 0)
 }
 
 func (s *ProjectAliasSuite) TestFindAliasInProjectOrRepo() {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -412,7 +412,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NoError(t, repoAlias.Upsert())
 
 			assert.NoError(t, pRef.DetachFromRepo(dbUser))
-			aliases, err := FindAllAliasesForProject(pRef.Id)
+			aliases, err := FindAliasesForProjectFromDb(pRef.Id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 1)
 			assert.Equal(t, aliases[0].Alias, projectAlias.Alias)
@@ -424,7 +424,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NoError(t, RemoveProjectAlias(projectAlias.ID.Hex()))
 
 			assert.NoError(t, pRef.DetachFromRepo(dbUser))
-			aliases, err = FindAllAliasesForProject(pRef.Id)
+			aliases, err = FindAliasesForProjectFromDb(pRef.Id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 1)
 			assert.Equal(t, aliases[0].Alias, repoAlias.Alias)
@@ -443,7 +443,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NoError(t, UpsertAliasesForProject(repoAliases, pRef.RepoRefId))
 
 			assert.NoError(t, pRef.DetachFromRepo(dbUser))
-			aliases, err := FindAllAliasesForProject(pRef.Id)
+			aliases, err := FindAliasesForProjectFromDb(pRef.Id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 3)
 			gitTagCount := 0
@@ -623,7 +623,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.NotEmpty(t, varsFromDb.Id)
 		},
 		ProjectPageGithubAndCQSection: func(t *testing.T, id string) {
-			aliases, err := FindAllAliasesForProject(id)
+			aliases, err := FindAliasesForProjectFromDb(id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 5)
 			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGithubAndCQSection, "me"))
@@ -634,7 +634,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Nil(t, pRefFromDb.PRTestingEnabled)
 			assert.Nil(t, pRefFromDb.GithubChecksEnabled)
 			assert.Nil(t, pRefFromDb.GitTagAuthorizedUsers)
-			aliases, err = FindAllAliasesForProject(id)
+			aliases, err = FindAliasesForProjectFromDb(id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 1)
 			// assert that only patch aliases are left
@@ -650,7 +650,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Nil(t, pRefFromDb.NotifyOnBuildFailure)
 		},
 		ProjectPagePatchAliasSection: func(t *testing.T, id string) {
-			aliases, err := FindAllAliasesForProject(id)
+			aliases, err := FindAliasesForProjectFromDb(id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 5)
 
@@ -660,7 +660,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.NotNil(t, pRefFromDb)
 			assert.Nil(t, pRefFromDb.PatchTriggerAliases)
 
-			aliases, err = FindAllAliasesForProject(id)
+			aliases, err = FindAliasesForProjectFromDb(id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 4)
 			// assert that no patch aliases are left

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
@@ -142,11 +141,11 @@ func (pc *DBAliasConnector) UpdateAliasesForSection(projectId string, updatedAli
 
 func shouldSkipAliasForSection(section model.ProjectPageSection, alias string) bool {
 	// if we're updating internal aliases, skip non-internal aliases
-	if section == model.ProjectPageGithubAndCQSection && !utility.StringSliceContains(evergreen.InternalAliases, alias) {
+	if section == model.ProjectPageGithubAndCQSection && model.IsPatchAlias(alias) {
 		return true
 	}
 	// if we're updating patch aliases, skip internal aliases
-	if section == model.ProjectPagePatchAliasSection && utility.StringSliceContains(evergreen.InternalAliases, alias) {
+	if section == model.ProjectPagePatchAliasSection && !model.IsPatchAlias(alias) {
 		return true
 	}
 	return false

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -190,7 +190,7 @@ func (a *AliasSuite) TestHasMatchingGitTagAliasAndRemotePath() {
 }
 
 func (a *AliasSuite) TestUpdateAliasesForSection() {
-	originalAliases, err := model.FindAllAliasesForProject("project_id")
+	originalAliases, err := model.FindAliasesForProjectFromDb("project_id")
 	a.NoError(err)
 	a.Len(originalAliases, 3)
 
@@ -219,7 +219,7 @@ func (a *AliasSuite) TestUpdateAliasesForSection() {
 	a.NoError(err)
 	a.True(modified)
 
-	aliasesFromDb, err := model.FindAllAliasesForProject("project_id")
+	aliasesFromDb, err := model.FindAliasesForProjectFromDb("project_id")
 	a.NoError(err)
 	a.Len(aliasesFromDb, 3)
 	for _, alias := range aliasesFromDb {
@@ -233,7 +233,7 @@ func (a *AliasSuite) TestUpdateAliasesForSection() {
 	modified, err = a.sc.UpdateAliasesForSection("project_id", updatedAliases, originalAliases, model.ProjectPageGithubAndCQSection)
 	a.NoError(err)
 	a.True(modified)
-	aliasesFromDb, err = model.FindAllAliasesForProject("project_id")
+	aliasesFromDb, err = model.FindAliasesForProjectFromDb("project_id")
 	a.NoError(err)
 	a.Len(aliasesFromDb, 4) // adds internal alias
 }

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -743,7 +743,7 @@ func TestDeleteProject(t *testing.T) {
 		}
 		assert.Equal(t, skeletonProj, *hiddenProj)
 
-		projAliases, err := serviceModel.FindAllAliasesForProject(projects[i].Id)
+		projAliases, err := serviceModel.FindAliasesForProjectFromDb(projects[i].Id)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(projAliases))
 


### PR DESCRIPTION
[EVG-15307](https://jira.mongodb.org/browse/EVG-15307)

### Description 
I realized there's a bug with how patch aliases work for project/repo; right now we check "do we have a matching alias" and if we don't we check the next level (parser project -> project -> repo). This works for internal aliases like __github_alias, however patch aliases can be named anything. If the project overrides the repo by defining patch alias "alias1" and "alias2", we shouldn't continue to check the repo when "alias3" doesn't show up.

Alternatively we can change the design to have patch aliases work like project variables 😬  But maybe let's start with this and reconsider the design if needed?

### Testing 
Added a unit test case and verified existing tests pass.
