### PR TITLE
EVG-15334 Handle 16 mb limit on unpaginated requests

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -888,15 +888,6 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 		},
 	}
 
-	// sort by most recent version to get the most recent display names for the build variants first
-	sortByOrderNumber := bson.M{
-		"$sort": bson.M{
-			CreateTimeKey: -1,
-		},
-	}
-
-	pipeline = append(pipeline, sortByOrderNumber)
-
 	// group the build variants by unique build variant names and get a build id for each
 	groupByBuildVariant := bson.M{
 		"$group": bson.M{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3049,12 +3049,12 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 			results = taskAndCountResults[0].Tasks
 		}
 	} else {
-		TaskResults := []Task{}
-		err = cursor.All(ctx, &TaskResults)
+		taskResults := []Task{}
+		err = cursor.All(ctx, &taskResults)
 		if err != nil {
 			return nil, 0, err
 		}
-		results = TaskResults
+		results = taskResults
 		count = len(results)
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2969,10 +2969,10 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 		})
 	}
 
-	sortPipeline := []bson.M{}
-
-	sortFields := bson.D{}
 	if len(opts.Sorts) > 0 {
+		sortPipeline := []bson.M{}
+
+		sortFields := bson.D{}
 		for _, singleSort := range opts.Sorts {
 			if singleSort.Key == DisplayStatusKey || singleSort.Key == BaseTaskStatusKey {
 				sortPipeline = append(sortPipeline, addStatusColorSort((singleSort.Key)))
@@ -2981,14 +2981,14 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 				sortFields = append(sortFields, bson.E{Key: singleSort.Key, Value: singleSort.Order})
 			}
 		}
+		sortFields = append(sortFields, bson.E{Key: IdKey, Value: 1})
+
+		sortPipeline = append(sortPipeline, bson.M{
+			"$sort": sortFields,
+		})
+
+		pipeline = append(pipeline, sortPipeline...)
 	}
-	sortFields = append(sortFields, bson.E{Key: IdKey, Value: 1})
-
-	sortPipeline = append(sortPipeline, bson.M{
-		"$sort": sortFields,
-	})
-
-	pipeline = append(pipeline, sortPipeline...)
 
 	if len(opts.FieldsToProject) > 0 {
 		fieldKeys := bson.M{}

--- a/model/task_build_variant_names_test.go
+++ b/model/task_build_variant_names_test.go
@@ -64,28 +64,11 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		RevisionOrderNumber: 1,
 	}
 	assert.NoError(t, t3.Insert())
-	b4 := build.Build{
-		Id:          "b4",
-		DisplayName: "Ubuntu 16.04 NEW",
-	}
-	assert.NoError(t, b4.Insert())
-	t4 := task.Task{
-		Id:                  "t4",
-		Status:              evergreen.TaskFailed,
-		BuildVariant:        "ubuntu1604",
-		DisplayName:         "test-agent",
-		Project:             "evergreen",
-		Requester:           evergreen.RepotrackerVersionRequester,
-		BuildId:             "b4",
-		CreateTime:          time.Now(),
-		RevisionOrderNumber: 1,
-	}
-	assert.NoError(t, t4.Insert())
 	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1)
 	assert.NoError(t, err)
 	assert.Equal(t, []*task.BuildVariantTuple{
 		{DisplayName: "OSX", BuildVariant: "osx"},
-		{DisplayName: "Ubuntu 16.04 NEW", BuildVariant: "ubuntu1604"},
+		{DisplayName: "Ubuntu 16.04", BuildVariant: "ubuntu1604"},
 		{DisplayName: "Windows 64 bit", BuildVariant: "windows"},
 	}, taskBuildVariants)
 }


### PR DESCRIPTION
[EVG-15334](https://jira.mongodb.org/browse/EVG-15334)

### Description 
We would hit  the 16 mb document limit if we try to load a large version with allot of tasks in the `$facet` stage. 
When we would make non limited/paginated requests to this query all of the returned tasks would be embedded in one document causing it to exceed the 16 mb document limit mongodb imposes.  

We can get around this by not using the `$facet` if the results are not paginated. Instead computing the total count in go (Because we have access to all of the results in this scenario).  

This allows us to preserve the advantages the `$facet` provided (Not needing to perform 2 queries to fetch the count without the pagination) While also avoiding the document size limit in the scenarios where we would run into them.

### Testing 
Staging and existing unit tests