### PR TITLE
EVG-15680 Fix join with absolute clone directory

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -577,7 +577,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 
 	stdErr := noopWriteCloser{&bytes.Buffer{}}
 	err = jpm.CreateCommand(ctx).Add([]string{"bash", "-c", strings.Join(moduleCmds, "\n")}).
-		Directory(filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory))).
+		Directory(filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir))).
 		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorWriter(stdErr).Run(ctx)
 
 	errOutput := stdErr.String()
@@ -864,7 +864,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 		cmdsJoined := strings.Join(patchCommandStrings, "\n")
 
 		cmd := jpm.CreateCommand(ctx).Add([]string{"bash", "-c", cmdsJoined}).
-			Directory(filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory))).
+			Directory(filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir))).
 			SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Task().GetSender())
 
 		if err = cmd.Run(ctx); err != nil {
@@ -872,6 +872,17 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 		}
 	}
 	return nil
+}
+
+// getJoinedWithDirectory joins the passed path A with c.Directory B like this:
+//   if B is relative, return A+B.
+//   if B is absolute, return B.
+// We use this because *gitFetchDirectory.Directory might be absolute.
+func (c *gitFetchProject) getJoinedWithDirectory(path string) string {
+	if filepath.IsAbs(c.Directory) {
+		return c.Directory
+	}
+	return filepath.Join(path, c.Directory)
 }
 
 func isGitHubPRModulePatch(conf *internal.TaskConfig, modulePatch *patch.ModulePatch) bool {

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -877,7 +877,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 // getJoinedWithDirectory joins the passed path A with c.Directory B like this:
 //   if B is relative, return A+B.
 //   if B is absolute, return B.
-// We use this because *gitFetchDirectory.Directory might be absolute.
+// We use this because *gitFetchProject.Directory might be absolute.
 func (c *gitFetchProject) getJoinedWithDirectory(path string) string {
 	if filepath.IsAbs(c.Directory) {
 		return c.Directory

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -962,3 +962,15 @@ index edc0c34..8e82862 100644
 	}
 	s.True(foundSuccessMessage, "did not see the following in task output: %s", successMessage)
 }
+
+func (s *GitGetProjectSuite) TestGetJoinedWithDirectory() {
+	c := &gitFetchProject{
+		Directory: "bar",
+	}
+	conf := internal.TaskConfig{
+		WorkDir: "/foo",
+	}
+	s.Equal(c.getJoinedWithDirectory(conf.WorkDir), "/foo/bar")
+	c.Directory = "/bar"
+	s.Equal(c.getJoinedWithDirectory(conf.WorkDir), "/bar")
+}

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-11-01"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-11-09"
+	AgentVersion = "2021-11-10"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-15680](https://jira.mongodb.org/browse/EVG-15680)

### Description 
Sometimes the clone directory is absolute. In those cases we shouldn't merge it with the working directory.

### Testing 
I added a unit test for the new directory function, but I didn't see a way to test the full code path.
