### PR TITLE
EVG-15738 Add DisplayTasksByVersion query to get correct TotalTaskCount

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1266,7 +1266,7 @@ func (r *patchResolver) Time(ctx context.Context, obj *restModel.APIPatch) (*Pat
 }
 
 func (r *patchResolver) TaskCount(ctx context.Context, obj *restModel.APIPatch) (*int, error) {
-	taskCount, err := task.Count(task.ByVersion(*obj.Id))
+	taskCount, err := task.Count(task.DisplayTasksByVersion(*obj.Id))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting task count for patch %s: %s", *obj.Id, err.Error()))
 	}
@@ -3601,7 +3601,7 @@ func (r *versionResolver) ChildVersions(ctx context.Context, v *restModel.APIVer
 }
 
 func (r *versionResolver) TaskCount(ctx context.Context, obj *restModel.APIVersion) (*int, error) {
-	taskCount, err := task.Count(task.ByVersion(*obj.Id))
+	taskCount, err := task.Count(task.DisplayTasksByVersion(*obj.Id))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting task count for version `%s`: %s", *obj.Id, err.Error()))
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -341,8 +341,15 @@ func ByActivation(active bool) db.Q {
 
 // ByVersion creates a query to return tasks with a certain build id
 func ByVersion(version string) db.Q {
+	return db.Query(bson.M{
+		VersionKey: version,
+	})
+}
+
+// DisplayTasksByVersion produces a query that returns all display tasks for the given version.
+func DisplayTasksByVersion(version string) db.Q {
 	// assumes that all ExecutionTasks know of their corresponding DisplayTask (i.e. DisplayTaskIdKey not null or "")
-	getDisplayTasksQuery := bson.M{
+	displayTasksQuery := bson.M{
 		"$and": []bson.M{
 			{VersionKey: version},
 			{"$or": []bson.M{
@@ -354,8 +361,7 @@ func ByVersion(version string) db.Q {
 			},
 		},
 	}
-
-	return db.Query(getDisplayTasksQuery)
+	return db.Query(displayTasksQuery)
 }
 
 // FailedTasksByVersion produces a query that returns all failed tasks for the given version.

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -354,8 +354,8 @@ func DisplayTasksByVersion(version string) db.Q {
 			{VersionKey: version},
 			{"$or": []bson.M{
 				{DisplayTaskIdKey: ""},                       // no 'parent' display task
-				{DisplayTaskIdKey: nil},                      // ...
 				{DisplayOnlyKey: true},                       // ...
+				{DisplayTaskIdKey: nil},                      // ...
 				{ExecutionTasksKey: bson.M{"$exists": true}}, // has execution tasks
 			},
 			},

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -448,6 +448,63 @@ func TestFindTasksByIds(t *testing.T) {
 	})
 }
 
+func TestDisplayTasksByVersion(t *testing.T) {
+	Convey("When calling DisplayTasksByVersion...", t, func() {
+		So(db.Clear(Collection), ShouldBeNil)
+		Convey("only tasks that are display tasks should be returned", func() {
+			tasks := []Task{
+				{
+					Id:      "one",
+					Version: "v1",
+				},
+				{
+					Id:          "two",
+					Version:     "v1",
+					DisplayOnly: true,
+				},
+				{
+					Id:            "three",
+					Version:       "v1",
+					DisplayTaskId: utility.ToStringPtr(""),
+				},
+				{
+					Id:             "four",
+					Version:        "v1",
+					ExecutionTasks: []string{"execution_task_one, execution_task_two"},
+				},
+				{
+					Id:            "execution_task_one",
+					Version:       "v1",
+					DisplayTaskId: utility.ToStringPtr("four"),
+				},
+				{
+					Id:            "execution_task_two",
+					Version:       "v1",
+					DisplayTaskId: utility.ToStringPtr("four"),
+				},
+			}
+
+			for _, task := range tasks {
+				So(task.Insert(), ShouldBeNil)
+			}
+
+			dbTasks, err := FindAll(DisplayTasksByVersion("v1"))
+			So(err, ShouldBeNil)
+			So(len(dbTasks), ShouldEqual, 4)
+			So(dbTasks[0].Id, ShouldNotEqual, "execution_task_one")
+			So(dbTasks[1].Id, ShouldNotEqual, "execution_task_one")
+			So(dbTasks[2].Id, ShouldNotEqual, "execution_task_one")
+			So(dbTasks[3].Id, ShouldNotEqual, "execution_task_one")
+
+			So(dbTasks[0].Id, ShouldNotEqual, "execution_task_two")
+			So(dbTasks[1].Id, ShouldNotEqual, "execution_task_two")
+			So(dbTasks[2].Id, ShouldNotEqual, "execution_task_two")
+			So(dbTasks[3].Id, ShouldNotEqual, "execution_task_two")
+
+		})
+	})
+}
+
 func TestFailedTasksByVersion(t *testing.T) {
 	Convey("When calling FailedTasksByVersion...", t, func() {
 		So(db.Clear(Collection), ShouldBeNil)


### PR DESCRIPTION
[EVG-15738](https://jira.mongodb.org/browse/EVG-15738)

### Description 
This PR introduces a new function `DisplayTasksByVersion` (in `model/task/db.go`) which finds the display tasks for a given version. This function is used to correct the task count displayed on the front end, which previously mistakenly counted execution tasks in the total task count.

**Note**:  There is no corresponding Spruce PR, as this change automatically affects the numbers displayed on front end.

### Screenshot
(Previously, this page would say `1/4 tasks`.)

<img width="1493" alt="Screen Shot 2021-11-10 at 11 25 47 AM" src="https://user-images.githubusercontent.com/47064971/141153066-ef75d393-9bb9-49e6-9f2a-0bd5972ee356.png">

### Testing 
- Added `TestDisplayTasksByVersion` in `model/task/task_test.go`
