### PR TITLE
EVG-15680 Fix windows test

### DIFF
--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -971,8 +971,8 @@ func (s *GitGetProjectSuite) TestGetJoinedWithDirectory() {
 		WorkDir: "/foo",
 	}
 	s.Equal("/foo/bar", filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)))
-	var err error
-	c.Directory, err = filepath.Abs("/bar") // Call filepath.Abs for Windows
+	absDir, err := filepath.Abs("/bar") // Call filepath.Abs for Windows c:\
 	s.NoError(err)
-	s.Equal("/bar", filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)))
+	c.Directory = absDir
+	s.Equal(absDir, filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)))
 }

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -970,7 +970,7 @@ func (s *GitGetProjectSuite) TestGetJoinedWithDirectory() {
 	conf := internal.TaskConfig{
 		WorkDir: "/foo",
 	}
-	s.Equal(c.getJoinedWithDirectory(conf.WorkDir), "/foo/bar")
+	s.Equal(filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)), "/foo/bar")
 	c.Directory = "/bar"
-	s.Equal(c.getJoinedWithDirectory(conf.WorkDir), "/bar")
+	s.Equal(filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)), "/bar")
 }

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -970,9 +970,9 @@ func (s *GitGetProjectSuite) TestGetJoinedWithDirectory() {
 	conf := internal.TaskConfig{
 		WorkDir: "/foo",
 	}
-	s.Equal("/foo/bar", filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)))
+	s.Equal(filepath.ToSlash("/foo/bar"), filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)))
 	absDir, err := filepath.Abs("/bar") // Call filepath.Abs for Windows c:\
 	s.NoError(err)
 	c.Directory = absDir
-	s.Equal(absDir, filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)))
+	s.Equal(filepath.ToSlash(absDir), filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)))
 }

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -970,7 +970,9 @@ func (s *GitGetProjectSuite) TestGetJoinedWithDirectory() {
 	conf := internal.TaskConfig{
 		WorkDir: "/foo",
 	}
-	s.Equal(filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)), "/foo/bar")
-	c.Directory = "/bar"
-	s.Equal(filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)), "/bar")
+	s.Equal("/foo/bar", filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)))
+	var err error
+	c.Directory, err = filepath.Abs("/bar") // Call filepath.Abs for Windows
+	s.NoError(err)
+	s.Equal("/bar", filepath.ToSlash(c.getJoinedWithDirectory(conf.WorkDir)))
 }


### PR DESCRIPTION
[EVG-15680](https://jira.mongodb.org/browse/EVG-15680)

### Description 
Fix windows tests, since Windows uses different slashes.

### Testing 
The test broke. I fixed it.
