### PR TITLE
EVG-15725 Only add files if S3 Copy succeeded

### DIFF
--- a/agent/command/s3_copy.go
+++ b/agent/command/s3_copy.go
@@ -207,10 +207,15 @@ func (c *s3copy) s3Copy(ctx context.Context,
 			logger.Task().Infof("s3Copy response: %s", responseString)
 		}
 
-		if err != nil {
+		if err == nil {
+			//only upload files to the task if they copied successfully
+			err = c.attachFiles(ctx, comm, logger, td, s3CopyReq)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		} else {
 			err = errors.Wrap(err, "s3 push copy failed")
 			logger.Execution().Error(err)
-
 			if s3CopyFile.Optional {
 				logger.Execution().Errorf("file '%s' is optional, continuing",
 					s3CopyFile.DisplayName)
@@ -222,10 +227,6 @@ func (c *s3copy) s3Copy(ctx context.Context,
 
 		}
 
-		err = c.attachFiles(ctx, comm, logger, td, s3CopyReq)
-		if err != nil {
-			return errors.WithStack(err)
-		}
 		if !foundDottedBucketName && strings.Contains(s3CopyReq.S3DestinationBucket, ".") {
 			logger.Task().Warning("destination bucket names containing dots that are created after Sept. 30, 2020 are not guaranteed to have valid attached URLs")
 			foundDottedBucketName = true

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-11-01"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-11-10"
+	AgentVersion = "2021-11-12"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-15725](https://jira.mongodb.org/browse/EVG-15725)

### Description 
Right now, we upload files to the test even if s3_copy didn't succeed, or if it succeeded because it's optional, but didn't truly copy over. This is very confusing to users, especially if a file of that name already exists in the destination bucket, but it's not truly related to the test since the copy failed. 

### Testing 
Tested in staging. The first execution failed and has 0 files and the second execution succeeded and has 1 file. 
https://spruce-staging.corp.mongodb.com/task/evg_ubuntu1604_s3_fake_destination_optional_patch_7e0cce4bf0fe845220526732bae0677256643421_618d9094b237364acb006453_21_11_11_21_52_38/logs?execution=0