### PR TITLE
EVG-15840 Return the response of the s3 copy command

### DIFF
--- a/agent/internal/client/host_methods.go
+++ b/agent/internal/client/host_methods.go
@@ -802,7 +802,11 @@ func (c *hostCommunicator) S3Copy(ctx context.Context, taskData TaskData, req *a
 		return "", utility.RespErrorf(resp, "failed to copy file in S3 for task %s: %s", taskData.ID, err.Error())
 	}
 	defer resp.Body.Close()
-	return "", nil
+	out, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrapf(err, "problem reading results from body for %s", taskData.ID)
+	}
+	return string(out), nil
 }
 
 func (c *hostCommunicator) KeyValInc(ctx context.Context, taskData TaskData, kv *model.KeyVal) error {

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2021-11-01"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2021-11-12"
+	AgentVersion = "2021-11-13"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-15840](https://jira.mongodb.org/browse/EVG-15840)

### Description 
This returns the response string so that the taskLogger can actually pick it up [here](https://github.com/evergreen-ci/evergreen/blob/main/agent/command/s3_copy.go#L206) when it checks if the response string is there. Until this change, the response string was always "".

### Testing 
[Tested on staging ](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu1604_s3_fake_destination_optional_patch_7e0cce4bf0fe845220526732bae0677256643421_618e278097b1d3305b7dcc04_21_11_12_08_36_31/logs?execution=0)
