### PR TITLE
EVG-15839 fix confusing s3_copy task log "noop file exists" message

### DIFF
--- a/service/api_plugin_s3copy.go
+++ b/service/api_plugin_s3copy.go
@@ -68,7 +68,7 @@ func (as *APIServer) s3copyPlugin(w http.ResponseWriter, r *http.Request) {
 		grip.Warningln("conflict with existing pushed file:", copyToLocation)
 		gimlet.WriteJSON(w, gimlet.ErrorResponse{
 			StatusCode: http.StatusOK,
-			Message:    fmt.Sprintf("noop, file %s exists", copyToLocation),
+			Message:    fmt.Sprintf("noop, this version is currently in the process of trying to push, or has already succeeded in pushing the file: '%s'", copyToLocation),
 		})
 		return
 	}


### PR DESCRIPTION
[EVG-15839](https://jira.mongodb.org/browse/EVG-15839)

### Description 
Whenever s3Copy finds a push event for a file in a version with the status "success" or "pushing", it no-ops instead of trying to push again the same file again. The message it logged to the task: "noop, file filename.tgz exists" was sometimes confusing and inaccurate. If a file was still in the "pushing" state and later failed, the file doesn't truly exist, we are simply not pushing again because we are waiting on that process to finish. 

### Testing 
Tested something similar on staging