### PR TITLE
EVG-15847: reduce likelihood of linter timeout

### DIFF
--- a/makefile
+++ b/makefile
@@ -346,7 +346,7 @@ lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
 endif
 # TODO (EVG-15453): make evg-lint compatible with golangci-lint
 $(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
-	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --lintArgs="--timeout=2m" --packages='$*'
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --lintArgs="--timeout=5m" --packages='$*'
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
 # end test and coverage artifacts

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -619,7 +619,6 @@ buildvariants:
   - name: lint
     display_name: Lint
     run_on:
-      - archlinux-new-small
       - archlinux-new-large
     expansions:
       GOROOT: /opt/golang/go1.16


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15847

### Description 
The linter is very slow on the first task in the lint task group because the lint cache starts out cold on the host.

* Use -large distro so that it runs faster.
* Bump the timeout so the linter can still succeed if it's unavoidably slow.