### PR TITLE
EVG-15453: add evg-lint as linting tool dependency

### DIFF
--- a/cmd/evg-lint/evg-lint.go
+++ b/cmd/evg-lint/evg-lint.go
@@ -1,0 +1,10 @@
+//go:build tools
+// +build tools
+
+// This is a helper file to track evg-lint as a Go tooling dependency in Go
+// modules.
+// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+
+package tools
+
+import _ "github.com/evergreen-ci/evg-lint/evg-lint"

--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -122,33 +122,25 @@ func getAllTargets() ([]string, error) {
 
 // generateTasks returns a map of tasks to generate.
 func generateTasks() (*shrub.Configuration, error) {
-	// kim: TODO: this forces the linter to run for all packages and confirm
-	// that the linting changes are still green. Revert this once PR is
-	// approved.
-	// changes, err := whatChanged()
-	// if err != nil {
-	//     return nil, err
-	// }
-	// var targets []string
-	// var maxHosts int
-	// if len(changes) == 0 {
-	//     maxHosts = commitMaxHosts
-	//     targets, err = getAllTargets()
-	//     if err != nil {
-	//         return nil, err
-	//     }
-	// } else {
-	//     maxHosts = patchMaxHosts
-	//     targets, err = targetsFromChangedFiles(changes)
-	//     if err != nil {
-	//         return nil, err
-	//     }
-	// }
-	targets, err := getAllTargets()
+	changes, err := whatChanged()
 	if err != nil {
 		return nil, err
 	}
-	maxHosts := commitMaxHosts
+	var targets []string
+	var maxHosts int
+	if len(changes) == 0 {
+		maxHosts = commitMaxHosts
+		targets, err = getAllTargets()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		maxHosts = patchMaxHosts
+		targets, err = targetsFromChangedFiles(changes)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	conf := &shrub.Configuration{}
 	if len(targets) == 0 {

--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -122,25 +122,33 @@ func getAllTargets() ([]string, error) {
 
 // generateTasks returns a map of tasks to generate.
 func generateTasks() (*shrub.Configuration, error) {
-	changes, err := whatChanged()
+	// kim: TODO: this forces the linter to run for all packages and confirm
+	// that the linting changes are still green. Revert this once PR is
+	// approved.
+	// changes, err := whatChanged()
+	// if err != nil {
+	//     return nil, err
+	// }
+	// var targets []string
+	// var maxHosts int
+	// if len(changes) == 0 {
+	//     maxHosts = commitMaxHosts
+	//     targets, err = getAllTargets()
+	//     if err != nil {
+	//         return nil, err
+	//     }
+	// } else {
+	//     maxHosts = patchMaxHosts
+	//     targets, err = targetsFromChangedFiles(changes)
+	//     if err != nil {
+	//         return nil, err
+	//     }
+	// }
+	targets, err := getAllTargets()
 	if err != nil {
 		return nil, err
 	}
-	var targets []string
-	var maxHosts int
-	if len(changes) == 0 {
-		maxHosts = commitMaxHosts
-		targets, err = getAllTargets()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		maxHosts = patchMaxHosts
-		targets, err = targetsFromChangedFiles(changes)
-		if err != nil {
-			return nil, err
-		}
-	}
+	maxHosts := commitMaxHosts
 
 	conf := &shrub.Configuration{}
 	if len(targets) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -61,4 +61,7 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 )
 
-require github.com/mongodb/jasper v0.0.0-20211109153730-344834c07b95
+require (
+	github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57
+	github.com/mongodb/jasper v0.0.0-20211109153730-344834c07b95
+)

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,8 @@ github.com/evergreen-ci/certdepot v0.0.0-20211109153348-d681ebe95b66 h1:1+AnZfWE
 github.com/evergreen-ci/certdepot v0.0.0-20211109153348-d681ebe95b66/go.mod h1:X72gmQuA1g8E1vWg1Jfve3zdHoPxJkpwXDMLV1COs5g=
 github.com/evergreen-ci/cocoa v0.0.0-20211028185655-0a7d8e6e14e7 h1:oOoNbxOopoFVx9s6gcA3KofmAYW8SWW6/DeH2xPOVY0=
 github.com/evergreen-ci/cocoa v0.0.0-20211028185655-0a7d8e6e14e7/go.mod h1:v+7k9KdvzXm8eFS0jQ5ljO++9cEgqUz3tiJPb+1UQSQ=
+github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=
+github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=
 github.com/evergreen-ci/gimlet v0.0.0-20211029160936-5b64c7b33753 h1:VIKaKtaMtTRa6ScX5rA4WCMOKzT6uZDDZozwcLVn7xc=
 github.com/evergreen-ci/gimlet v0.0.0-20211029160936-5b64c7b33753/go.mod h1:57Sr3kCsdBlf9ii/ZYyuNDTzcDLDN7laOyJeIXYPGGs=

--- a/makefile
+++ b/makefile
@@ -344,9 +344,8 @@ ifneq (go,$(gobin))
 # binary in it, the linter won't work properly.
 lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
 endif
-# TODO (EVG-15453): make evg-lint compatible with golangci-lint
 $(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
-	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --lintArgs="--timeout=5m" --packages='$*'
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint -customLinters="$(gobin) run github.com/evergreen-ci/evg-lint/evg-lint -set_exit_status" --lintArgs="--timeout=5m" --packages='$*'
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
 # end test and coverage artifacts


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15453

### Description 
* Add custom evg-lint tool back to linters.
* Track evg-lint as part of Go module dependencies. I used a strategy similar to how [gqlgen](https://github.com/evergreen-ci/evergreen/blob/eb514bf6be86ebcc71eec5b73f22d0f7cdc20f48/cmd/gqlgen/gqlgen.go#L1-L11) is tracked as a tool dependency.

### Testing 
I temporarily modified generate-lint to run on all targets, just to verify that CI tests pass. I'll revert it before merging the PR.

I also did [a test patch](https://spruce.mongodb.com/version/6192985c30661561e3952390/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) to verify that evg-lint was actually running as intended and catching lint issues when I purposely introduced one.