### PR TITLE
EVG-15711 Do not allow enabling CQ in parser project

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -426,7 +426,9 @@ func (p *ProjectRef) MergeWithParserProject(version string) error {
 			p.WorkstationConfig = *parserProject.WorkstationConfig
 		}
 		if parserProject.CommitQueue != nil {
+			enabled := p.CommitQueue.IsEnabled()
 			p.CommitQueue = *parserProject.CommitQueue
+			p.CommitQueue.Enabled = utility.ToBoolPtr(enabled)
 		}
 	}
 	return nil

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1874,7 +1874,7 @@ func TestMergeWithParserProject(t *testing.T) {
 			},
 		},
 		CommitQueue: &CommitQueueParams{
-			Enabled:     utility.TruePtr(),
+			Enabled:     utility.FalsePtr(),
 			MergeMethod: "message2",
 		},
 		WorkstationConfig: &WorkstationConfig{
@@ -1897,4 +1897,5 @@ func TestMergeWithParserProject(t *testing.T) {
 	assert.False(t, *projectRef.WorkstationConfig.GitClone)
 	assert.Equal(t, "overridden", projectRef.WorkstationConfig.SetupCommands[0].Command)
 	assert.Equal(t, "message2", projectRef.CommitQueue.MergeMethod)
+	assert.True(t, projectRef.CommitQueue.IsEnabled())
 }


### PR DESCRIPTION
[EVG-15711](https://jira.mongodb.org/browse/EVG-15711)

### Description 
As change to the scope of the epic, only the project page should allow for enabling of the commit queue.  Change has been made to always use the enabled value for commit queue settings from the project ref and never take it from the parser project.
### Testing 
Updated existing unit tests.