### PR TITLE
EVG-15709 Clear necessary fields between task executions

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1623,11 +1623,13 @@ func resetTaskUpdate(t *Task) bson.M {
 			LastHeartbeatKey:       utility.ZeroTime,
 		},
 		"$unset": bson.M{
-			DetailsKey:            "",
-			HasCedarResultsKey:    "",
-			CedarResultsFailedKey: "",
-			ResetWhenFinishedKey:  "",
-			AgentVersionKey:       "",
+			DetailsKey:              "",
+			HasCedarResultsKey:      "",
+			CedarResultsFailedKey:   "",
+			ResetWhenFinishedKey:    "",
+			AgentVersionKey:         "",
+			HostCreateDetailsKey:    "",
+			OverrideDependenciesKey: "",
 		},
 	}
 	return update

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1606,6 +1606,8 @@ func resetTaskUpdate(t *Task) bson.M {
 		t.ResetWhenFinished = false
 		t.HostId = ""
 		t.AgentVersion = ""
+		t.HostCreateDetails = []HostCreateDetail{}
+		t.OverrideDependencies = false
 	}
 	update := bson.M{
 		"$set": bson.M{


### PR DESCRIPTION
[EVG-15709](https://jira.mongodb.org/browse/EVG-15709)

### Description 
This clears host_create_details and override_dependencies. The ticket comment also also asks to clear task_failure_details: I'm not sure if that refers to task.details which is already being cleared, or something else. 

### Testing 
None, because there is no existing test to add to. 
