### PR TITLE
EVG-15596: do not set build directory TMPDIR for makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -62,6 +62,9 @@ export CGO_ENABLED := 0
 endif
 # end go runtime settings
 
+# Ensure the build directory exists, since most targets require it.
+$(shell mkdir -p $(buildDir))
+
 # start evergreen specific configuration
 
 unixPlatforms := linux_amd64 darwin_amd64 $(if $(STAGING_ONLY),,darwin_arm64 linux_s390x linux_arm64 linux_ppc64le)

--- a/makefile
+++ b/makefile
@@ -1,7 +1,6 @@
 # start project configuration
 name := evergreen
 buildDir := bin
-tmpDir := $(abspath $(buildDir)/tmp)
 nodeDir := public
 packages := $(name) agent agent-command agent-util agent-internal agent-internal-client operations cloud cloud-userdata
 packages += db util plugin units graphql thirdparty thirdparty-docker auth scheduler model validator service repotracker cmd-codegen-core mock
@@ -296,11 +295,6 @@ endif
 ifneq (,$(SETTINGS_OVERRIDE))
 testRunEnv += SETTINGS_OVERRIDE=$(SETTINGS_OVERRIDE)
 endif
-ifneq (,$(TMPDIR))
-testRunEnv += TMPDIR=$(TMPDIR)
-else
-testRunEnv += TMPDIR=$(tmpDir)
-endif
 ifneq (,$(RUN_TEST))
 testArgs += -run='$(RUN_TEST)'
 dlvArgs += -test.run='$(RUN_TEST)'
@@ -326,16 +320,14 @@ testArgs += -ldflags="$(ldFlags) -X=github.com/evergreen-ci/evergreen/testutil.E
 #  targets to run any tests in the top-level package
 $(buildDir):
 	mkdir -p $@
-$(tmpDir):$(buildDir)
-	mkdir -p $@
-$(buildDir)/output.%.test:$(tmpDir) .FORCE
+$(buildDir)/output.%.test: .FORCE
 	$(testRunEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) 2>&1 | tee $@
 # Codegen is special because it requires that the repository be compiled for goimports to resolve imports properly.
-$(buildDir)/output.cmd-codegen-core.test: $(tmpDir) build-codegen .FORCE
+$(buildDir)/output.cmd-codegen-core.test: build-codegen .FORCE
 	$(testRunEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) 2>&1 | tee $@
-$(buildDir)/output-dlv.%.test:$(tmpDir) .FORCE
+$(buildDir)/output-dlv.%.test: .FORCE
 	$(testRunEnv) dlv test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -- $(dlvArgs) 2>&1 | tee $@
-$(buildDir)/output.%.coverage:$(tmpDir) .FORCE
+$(buildDir)/output.%.coverage: .FORCE
 	$(testRunEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && go tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 #  targets to generate gotest output from the linter.
@@ -359,7 +351,7 @@ update-lobster: clean-lobster
 
 # clean and other utility targets
 clean: clean-lobster
-	rm -rf $(buildDir) $(clientBuildDir) $(tmpDir)
+	rm -rf $(buildDir) $(clientBuildDir)
 phony += clean
 
 gqlgen:


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15596

### Description 
`TMPDIR` is only useful in CI tests where writing outside of the working directory is not advised. For local development, `TMPDIR` is typically set and if not, defaults to `/tmp`, which seems reasonable. For CI tests, `TMPDIR` is set by default in the environment, so it should be safe to run tests without explicitly setting it. Therefore, it's not necessary to point `TMPDIR` to a path within the working directory anymore.

This also fixes `TestMakePatchedConfig` in `make test-model`, which fails if `TMPDIR` is not set and uses the makefile default of `bin/tmp`. That test relies on using git apply, but git apply behaves differently when the path is within an already git-controlled directory (`bin/tmp`) compared to when it's written outside of a git directory (`/tmp`). It only behaves correctly when the temporary directory is outside of the Evergreen git repo directory.

### Testing
I ran `test-model` locally.
