### PR TITLE
EVG-15584: only set goos/goarch if the Go binary is available

### DIFF
--- a/makefile
+++ b/makefile
@@ -69,8 +69,14 @@ unixPlatforms := linux_amd64 darwin_amd64 $(if $(STAGING_ONLY),,darwin_arm64 lin
 windowsPlatforms := windows_amd64
 
 
-goos := $(shell $(gobin) env GOOS)
-goarch := $(shell $(gobin) env GOARCH)
+goos := $(GOOS)
+goarch := $(GOARCH)
+ifeq ($(goos),)
+goos := $(shell $(gobin) env GOOS 2> /dev/null)
+endif
+ifeq ($(goarch),)
+goarch := $(shell $(gobin) env GOARCH 2> /dev/null)
+endif
 
 clientBuildDir := clients
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15584

### Description 
This is mostly to reduce noise in the task logs. If the Go binary is not in the PATH (e.g. the mongod setup targets don't set them), setting the GOOS/GOARCH for the local CLI will fail. GOOS/GOARCH only used for the local binary and cross-compilation, so they should only be set for make targets that actually use Go in some way.

### Testing 
I checked that the CI tests pass and don't output the error `make: go: No such file or directory` in the task log.
