### PR TITLE
EVG-15863 add loop on error to get version with good config

### DIFF
--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
@@ -159,72 +161,71 @@ func (s *ProjectAliasSuite) TestFindAliasInProject() {
 	s.Len(found, 2)
 }
 
-// TODO: removing test for EVG-15856
-//func (s *ProjectAliasSuite) TestMergeAliasesWithParserProject() {
-//	s.Require().NoError(db.ClearCollections(ProjectAliasCollection, ParserProjectCollection, VersionCollection))
-//	v1 := Version{
-//		Id:         "project-1",
-//		Identifier: "project-1",
-//		Requester:  evergreen.GitTagRequester,
-//	}
-//	a1 := ProjectAlias{
-//		ProjectID: "project-1",
-//		Alias:     evergreen.CommitQueueAlias,
-//	}
-//	a2 := ProjectAlias{
-//		ProjectID: "project-1",
-//		Alias:     evergreen.CommitQueueAlias,
-//	}
-//	a3 := ProjectAlias{
-//		ProjectID: "project-1",
-//		Alias:     evergreen.GithubPRAlias,
-//	}
-//	s.NoError(a1.Upsert())
-//	s.NoError(a2.Upsert())
-//	s.NoError(a3.Upsert())
-//	s.NoError(v1.Insert())
-//
-//	parserProject := &ParserProject{
-//		Id: "project-1",
-//		PatchAliases: []ProjectAlias{
-//			{
-//				ID:        mgobson.NewObjectId(),
-//				ProjectID: "project-1",
-//				Alias:     "alias-2",
-//			},
-//			{
-//				ID:        mgobson.NewObjectId(),
-//				ProjectID: "project-1",
-//				Alias:     "alias-1",
-//			},
-//		},
-//		CommitQueueAliases: []ProjectAlias{
-//			{
-//				ID:        mgobson.NewObjectId(),
-//				ProjectID: "project-1",
-//			},
-//		},
-//	}
-//	s.NoError(parserProject.TryUpsert())
-//
-//	projectAliases, err := FindAliasInProjectOrRepo("project-1", evergreen.CommitQueueAlias)
-//	s.NoError(err)
-//	s.Len(projectAliases, 1)
-//
-//	projectAliases, err = FindAliasInProjectOrRepo("project-1", evergreen.GithubPRAlias)
-//	s.NoError(err)
-//	s.Len(projectAliases, 1)
-//	projectAliases, err = FindAliasInProjectOrRepo("project-1", "alias-1")
-//	s.NoError(err)
-//	s.Len(projectAliases, 1)
-//	projectAliases, err = FindAliasInProjectOrRepo("project-1", "alias-2")
-//	s.NoError(err)
-//	s.Len(projectAliases, 1)
-//
-//	projectAliases, err = FindAliasInProjectOrRepo("project-1", "nonexistent")
-//	s.NoError(err)
-//	s.Len(projectAliases, 0)
-//}
+func (s *ProjectAliasSuite) TestMergeAliasesWithParserProject() {
+	s.Require().NoError(db.ClearCollections(ProjectAliasCollection, ParserProjectCollection, VersionCollection))
+	v1 := Version{
+		Id:         "project-1",
+		Identifier: "project-1",
+		Requester:  evergreen.RepotrackerVersionRequester,
+	}
+	a1 := ProjectAlias{
+		ProjectID: "project-1",
+		Alias:     evergreen.CommitQueueAlias,
+	}
+	a2 := ProjectAlias{
+		ProjectID: "project-1",
+		Alias:     evergreen.CommitQueueAlias,
+	}
+	a3 := ProjectAlias{
+		ProjectID: "project-1",
+		Alias:     evergreen.GithubPRAlias,
+	}
+	s.NoError(a1.Upsert())
+	s.NoError(a2.Upsert())
+	s.NoError(a3.Upsert())
+	s.NoError(v1.Insert())
+
+	parserProject := &ParserProject{
+		Id: "project-1",
+		PatchAliases: []ProjectAlias{
+			{
+				ID:        mgobson.NewObjectId(),
+				ProjectID: "project-1",
+				Alias:     "alias-2",
+			},
+			{
+				ID:        mgobson.NewObjectId(),
+				ProjectID: "project-1",
+				Alias:     "alias-1",
+			},
+		},
+		CommitQueueAliases: []ProjectAlias{
+			{
+				ID:        mgobson.NewObjectId(),
+				ProjectID: "project-1",
+			},
+		},
+	}
+	s.NoError(parserProject.TryUpsert())
+
+	projectAliases, err := FindAliasInProjectOrRepo("project-1", evergreen.CommitQueueAlias)
+	s.NoError(err)
+	s.Len(projectAliases, 1)
+
+	projectAliases, err = FindAliasInProjectOrRepo("project-1", evergreen.GithubPRAlias)
+	s.NoError(err)
+	s.Len(projectAliases, 1)
+	projectAliases, err = FindAliasInProjectOrRepo("project-1", "alias-1")
+	s.NoError(err)
+	s.Len(projectAliases, 1)
+	projectAliases, err = FindAliasInProjectOrRepo("project-1", "alias-2")
+	s.NoError(err)
+	s.Len(projectAliases, 1)
+
+	projectAliases, err = FindAliasInProjectOrRepo("project-1", "nonexistent")
+	s.NoError(err)
+	s.Len(projectAliases, 0)
+}
 
 func (s *ProjectAliasSuite) TestFindAliasInProjectOrRepo() {
 	s.Require().NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection))

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
-	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
@@ -161,71 +159,72 @@ func (s *ProjectAliasSuite) TestFindAliasInProject() {
 	s.Len(found, 2)
 }
 
-func (s *ProjectAliasSuite) TestMergeAliasesWithParserProject() {
-	s.Require().NoError(db.ClearCollections(ProjectAliasCollection, ParserProjectCollection, VersionCollection))
-	v1 := Version{
-		Id:         "project-1",
-		Identifier: "project-1",
-		Requester:  evergreen.GitTagRequester,
-	}
-	a1 := ProjectAlias{
-		ProjectID: "project-1",
-		Alias:     evergreen.CommitQueueAlias,
-	}
-	a2 := ProjectAlias{
-		ProjectID: "project-1",
-		Alias:     evergreen.CommitQueueAlias,
-	}
-	a3 := ProjectAlias{
-		ProjectID: "project-1",
-		Alias:     evergreen.GithubPRAlias,
-	}
-	s.NoError(a1.Upsert())
-	s.NoError(a2.Upsert())
-	s.NoError(a3.Upsert())
-	s.NoError(v1.Insert())
-
-	parserProject := &ParserProject{
-		Id: "project-1",
-		PatchAliases: []ProjectAlias{
-			{
-				ID:        mgobson.NewObjectId(),
-				ProjectID: "project-1",
-				Alias:     "alias-2",
-			},
-			{
-				ID:        mgobson.NewObjectId(),
-				ProjectID: "project-1",
-				Alias:     "alias-1",
-			},
-		},
-		CommitQueueAliases: []ProjectAlias{
-			{
-				ID:        mgobson.NewObjectId(),
-				ProjectID: "project-1",
-			},
-		},
-	}
-	s.NoError(parserProject.TryUpsert())
-
-	projectAliases, err := FindAliasInProjectOrRepo("project-1", evergreen.CommitQueueAlias)
-	s.NoError(err)
-	s.Len(projectAliases, 1)
-
-	projectAliases, err = FindAliasInProjectOrRepo("project-1", evergreen.GithubPRAlias)
-	s.NoError(err)
-	s.Len(projectAliases, 1)
-	projectAliases, err = FindAliasInProjectOrRepo("project-1", "alias-1")
-	s.NoError(err)
-	s.Len(projectAliases, 1)
-	projectAliases, err = FindAliasInProjectOrRepo("project-1", "alias-2")
-	s.NoError(err)
-	s.Len(projectAliases, 1)
-
-	projectAliases, err = FindAliasInProjectOrRepo("project-1", "nonexistent")
-	s.NoError(err)
-	s.Len(projectAliases, 0)
-}
+// TODO: removing test for EVG-15856
+//func (s *ProjectAliasSuite) TestMergeAliasesWithParserProject() {
+//	s.Require().NoError(db.ClearCollections(ProjectAliasCollection, ParserProjectCollection, VersionCollection))
+//	v1 := Version{
+//		Id:         "project-1",
+//		Identifier: "project-1",
+//		Requester:  evergreen.GitTagRequester,
+//	}
+//	a1 := ProjectAlias{
+//		ProjectID: "project-1",
+//		Alias:     evergreen.CommitQueueAlias,
+//	}
+//	a2 := ProjectAlias{
+//		ProjectID: "project-1",
+//		Alias:     evergreen.CommitQueueAlias,
+//	}
+//	a3 := ProjectAlias{
+//		ProjectID: "project-1",
+//		Alias:     evergreen.GithubPRAlias,
+//	}
+//	s.NoError(a1.Upsert())
+//	s.NoError(a2.Upsert())
+//	s.NoError(a3.Upsert())
+//	s.NoError(v1.Insert())
+//
+//	parserProject := &ParserProject{
+//		Id: "project-1",
+//		PatchAliases: []ProjectAlias{
+//			{
+//				ID:        mgobson.NewObjectId(),
+//				ProjectID: "project-1",
+//				Alias:     "alias-2",
+//			},
+//			{
+//				ID:        mgobson.NewObjectId(),
+//				ProjectID: "project-1",
+//				Alias:     "alias-1",
+//			},
+//		},
+//		CommitQueueAliases: []ProjectAlias{
+//			{
+//				ID:        mgobson.NewObjectId(),
+//				ProjectID: "project-1",
+//			},
+//		},
+//	}
+//	s.NoError(parserProject.TryUpsert())
+//
+//	projectAliases, err := FindAliasInProjectOrRepo("project-1", evergreen.CommitQueueAlias)
+//	s.NoError(err)
+//	s.Len(projectAliases, 1)
+//
+//	projectAliases, err = FindAliasInProjectOrRepo("project-1", evergreen.GithubPRAlias)
+//	s.NoError(err)
+//	s.Len(projectAliases, 1)
+//	projectAliases, err = FindAliasInProjectOrRepo("project-1", "alias-1")
+//	s.NoError(err)
+//	s.Len(projectAliases, 1)
+//	projectAliases, err = FindAliasInProjectOrRepo("project-1", "alias-2")
+//	s.NoError(err)
+//	s.Len(projectAliases, 1)
+//
+//	projectAliases, err = FindAliasInProjectOrRepo("project-1", "nonexistent")
+//	s.NoError(err)
+//	s.Len(projectAliases, 0)
+//}
 
 func (s *ProjectAliasSuite) TestFindAliasInProjectOrRepo() {
 	s.Require().NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection))

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -66,7 +66,7 @@ var VersionAll = db.Query(bson.D{})
 
 // FindVersionByLastKnownGoodConfig filters on versions with valid (i.e., have no errors) config for the given project.
 func FindVersionByLastKnownGoodConfig(projectId string, revisionOrderNumber int) (*Version, error) {
-	retryLimit := 50
+	const retryLimit = 50
 	q := bson.M{
 		VersionIdentifierKey: projectId,
 		VersionRequesterKey:  evergreen.RepotrackerVersionRequester,

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -83,11 +83,10 @@ func FindVersionByLastKnownGoodConfig(projectId string, revisionOrderNumber int)
 		if v == nil || len(v.Errors) == 0 {
 			return v, nil
 		}
-		// try again with the new revision order number
+		// Try again with the new revision order number if error exists for version.
+		// We don't include this in the query in order to use an index for identifier, requester, and order number.
 		revisionOrderNumber = v.RevisionOrderNumber
 	}
-
-	// if errors exist on the most recent version, try again, using the new revision order number
 
 	return nil, errors.Errorf("couldn't finding version with good config in last %d commits", retryLimit)
 }


### PR DESCRIPTION
[EVG-15863](https://jira.mongodb.org/browse/EVG-15863)

### Description 
If the returned version has errors, try again.
Could also return all the versions right away, but really in almost all cases error _is_ empty, so I think it's reasonable to push the additional work off unless we've actually hit a problem.

### Testing 
Verifying that existing tests pass.
