### PR TITLE
EVG-15682: remove unused DISABLE_COVERAGE flag

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -183,7 +183,6 @@ functions:
         AWS_KEY: ${aws_key}
         AWS_SECRET: ${aws_secret}
         DEBUG_ENABLED: ${debug}
-        DISABLE_COVERAGE: ${disable_coverage}
         DOCKER_HOST: ${docker_host}
         EVERGREEN_ALL: "true"
         GOARCH: ${goarch}
@@ -593,7 +592,6 @@ buildvariants:
       - ubuntu1604-test
       - ubuntu1604-build
     expansions:
-      disable_coverage: yes
       goos: linux
       goarch: amd64
       nodebin: /opt/node/bin
@@ -639,7 +637,6 @@ buildvariants:
       - windows-64-vs2017-small
       - windows-64-vs2017-large
     expansions:
-      disable_coverage: yes
       GOROOT: c:/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.3.zip
       extension: ".exe"
@@ -654,7 +651,6 @@ buildvariants:
     run_on:
       - ubuntu1604-arm64-small
     expansions:
-      disable_coverage: yes
       xc_build: yes
       goarch: arm64
       goos: linux
@@ -669,7 +665,6 @@ buildvariants:
     run_on:
       - macos-1014
     expansions:
-      disable_coverage: yes
       GOROOT: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     tasks:


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15682

### Description 
Other Evergreen repos use the `DISABLE_COVERAGE` environment variable to test with code coverage. However, Evergreen performs coverage tests slightly differently, so it doesn't rely on `DISABLE_COVERAGE` when producing `output.%.coverage` files.

### Testing 
N/A
