### PR TITLE
EVG-15202 Add variant tasks to downstream tasks 

### DIFF
--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -50,7 +50,7 @@ type APIPatch struct {
 type DownstreamTasks struct {
 	Project      *string       `json:"project"`
 	Tasks        []*string     `json:"tasks"`
-	VariantTasks []VariantTask `json:"tasks"`
+	VariantTasks []VariantTask `json:"variant_tasks"`
 }
 
 type ChildPatch struct {

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -191,22 +190,8 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 
 	apiPatch.PatchedConfig = utility.ToStringPtr(v.PatchedConfig)
 	apiPatch.CanEnqueueToCommitQueue = v.HasValidGitInfo()
-	//this child apipatch has a child patch
-	// it has variant tasks but no tasks
-	grip.Error(message.Fields{
-		"error":    "chayaMTesting patch.go 196",
-		"v":        v,
-		"apiPatch": apiPatch,
-	})
 
 	downstreamTasks, childPatches, err := getChildPatchesData(v)
-	grip.Error(message.Fields{
-		"error":           "chayaMTesting patch.go 196",
-		"v":               v,
-		"downstreamTasks": downstreamTasks,
-		"childPatches":    childPatches,
-		"err":             err,
-	})
 	if err != nil {
 		return errors.Wrap(err, "error getting downstream tasks")
 	}

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -147,7 +147,13 @@ func TestDownstreamTasks(t *testing.T) {
 		Description: "test",
 		Project:     "mci",
 		Tasks:       []string{"child_task_1", "child_task_2"},
-		Activated:   true,
+		VariantsTasks: []patch.VariantTasks{
+			{
+				Variant: "coverage",
+				Tasks:   []string{"variant_task_1", "variant_task_2"},
+			},
+		},
+		Activated: true,
 	}
 	assert.NoError(childPatch.Insert())
 
@@ -156,4 +162,6 @@ func TestDownstreamTasks(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(*a.DownstreamTasks[0].Project, childPatch.Project)
 	assert.Len(a.DownstreamTasks, 1)
+	assert.Len(a.DownstreamTasks[0].Tasks, 2)
+	assert.Len(a.DownstreamTasks[0].VariantTasks, 1)
 }


### PR DESCRIPTION
[EVG-15202](https://jira.mongodb.org/browse/EVG-15202)

### Description 
It looked like downstream tasks wasn't populating for the api endpoint, but what was really happening was that the downstream patch had no tasks, it only had variant tasks. 

### Testing 
Added to the existing test.
