### PR TITLE
EVG-13030: Resolve taskStatusCounts for Patch gql type

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -498,6 +498,7 @@ type ComplexityRoot struct {
 		ProjectIdentifier       func(childComplexity int) int
 		Status                  func(childComplexity int) int
 		TaskCount               func(childComplexity int) int
+		TaskStatusCounts        func(childComplexity int, options *BuildVariantOptions) int
 		TaskStatuses            func(childComplexity int) int
 		Tasks                   func(childComplexity int) int
 		Time                    func(childComplexity int) int
@@ -1235,6 +1236,7 @@ type PatchResolver interface {
 	BaseTaskStatuses(ctx context.Context, obj *model.APIPatch) ([]string, error)
 
 	PatchTriggerAliases(ctx context.Context, obj *model.APIPatch) ([]*model.APIPatchTriggerDefinition, error)
+	TaskStatusCounts(ctx context.Context, obj *model.APIPatch, options *BuildVariantOptions) ([]*task.StatusCount, error)
 }
 type ProjectResolver interface {
 	IsFavorite(ctx context.Context, obj *model.APIProjectRef) (bool, error)
@@ -3558,6 +3560,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Patch.TaskCount(childComplexity), true
+
+	case "Patch.taskStatusCounts":
+		if e.complexity.Patch.TaskStatusCounts == nil {
+			break
+		}
+
+		args, err := ec.field_Patch_taskStatusCounts_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Patch.TaskStatusCounts(childComplexity, args["options"].(*BuildVariantOptions)), true
 
 	case "Patch.taskStatuses":
 		if e.complexity.Patch.TaskStatuses == nil {
@@ -7855,6 +7869,7 @@ type Patch {
   baseTaskStatuses: [String!]!
   canEnqueueToCommitQueue: Boolean!
   patchTriggerAliases: [PatchTriggerAlias!]!
+  taskStatusCounts(options: BuildVariantOptions): [StatusCount!]
 }
 
 type Build {
@@ -9601,6 +9616,21 @@ func (ec *executionContext) field_Mutation_updateVolume_args(ctx context.Context
 		}
 	}
 	args["updateVolumeInput"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Patch_taskStatusCounts_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *BuildVariantOptions
+	if tmp, ok := rawArgs["options"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("options"))
+		arg0, err = ec.unmarshalOBuildVariantOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBuildVariantOptions(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["options"] = arg0
 	return args, nil
 }
 
@@ -20266,6 +20296,45 @@ func (ec *executionContext) _Patch_patchTriggerAliases(ctx context.Context, fiel
 	res := resTmp.([]*model.APIPatchTriggerDefinition)
 	fc.Result = res
 	return ec.marshalNPatchTriggerAlias2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIPatchTriggerDefinitionᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Patch_taskStatusCounts(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Patch",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Patch_taskStatusCounts_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Patch().TaskStatusCounts(rctx, obj, args["options"].(*BuildVariantOptions))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*task.StatusCount)
+	fc.Result = res
+	return ec.marshalOStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐStatusCountᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _PatchDuration_makespan(ctx context.Context, field graphql.CollectedField, obj *PatchDuration) (ret graphql.Marshaler) {
@@ -42322,6 +42391,17 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
+				return res
+			})
+		case "taskStatusCounts":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Patch_taskStatusCounts(ctx, field, obj)
 				return res
 			})
 		default:

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3558,7 +3558,6 @@ func (r *versionResolver) BaseTaskStatuses(ctx context.Context, v *restModel.API
 	return getAllTaskStatuses(tasks), nil
 }
 
-// Returns task status counts (a mapping between status and the number of tasks with that status) for a version.
 func (r *versionResolver) TaskStatusCounts(ctx context.Context, v *restModel.APIVersion, options *BuildVariantOptions) ([]*task.StatusCount, error) {
 	stats, err := getTaskStatusCountsForVersion(*v.Id, options)
 	if err != nil {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1237,6 +1237,14 @@ func (r *patchResolver) BaseTaskStatuses(ctx context.Context, obj *restModel.API
 	return getAllTaskStatuses(baseTasks), nil
 }
 
+func (r *patchResolver) TaskStatusCounts(ctx context.Context, obj *restModel.APIPatch, options *BuildVariantOptions) ([]*task.StatusCount, error) {
+	stats, err := getTaskStatusCountsForVersion(*obj.Id, options)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting version task stats: %s", err.Error()))
+	}
+	return stats, nil
+}
+
 func (r *patchResolver) Builds(ctx context.Context, obj *restModel.APIPatch) ([]*restModel.APIBuild, error) {
 	builds, err := build.FindBuildsByVersions([]string{*obj.Version})
 	if err != nil {
@@ -3552,18 +3560,10 @@ func (r *versionResolver) BaseTaskStatuses(ctx context.Context, v *restModel.API
 
 // Returns task status counts (a mapping between status and the number of tasks with that status) for a version.
 func (r *versionResolver) TaskStatusCounts(ctx context.Context, v *restModel.APIVersion, options *BuildVariantOptions) ([]*task.StatusCount, error) {
-	opts := task.GetTasksByVersionOptions{
-		IncludeBaseTasks:      false,
-		IncludeExecutionTasks: false,
-		TaskNames:             options.Tasks,
-		Variants:              options.Variants,
-		Statuses:              options.Statuses,
-	}
-	stats, err := task.GetTaskStatsByVersion(*v.Id, opts)
+	stats, err := getTaskStatusCountsForVersion(*v.Id, options)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting version task stats: %s", err.Error()))
 	}
-
 	return stats, nil
 }
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -830,6 +830,7 @@ type Patch {
   baseTaskStatuses: [String!]!
   canEnqueueToCommitQueue: Boolean!
   patchTriggerAliases: [PatchTriggerAlias!]!
+  taskStatusCounts(options: BuildVariantOptions): [StatusCount!]
 }
 
 type Build {

--- a/graphql/tests/patch/data.json
+++ b/graphql/tests/patch/data.json
@@ -17,27 +17,33 @@
   "tasks": [
     {
       "_id": "1",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "status": "success"
     },
     {
       "_id": "2",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "status": "success"
     },
     {
       "_id": "3",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "status": "success"
     },
     {
       "_id": "4",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "status": "success"
     },
     {
       "_id": "5",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "status": "success"
     },
     {
       "_id": "6",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "status": "failed"
     },
     {
       "_id": "evergreen_lint_generate_lint_5e823e1f28baeaa22ae00823d83e03082cd148ab_20_02_20_20_37_06",

--- a/graphql/tests/patch/queries/taskStatusCounts.graphql
+++ b/graphql/tests/patch/queries/taskStatusCounts.graphql
@@ -1,0 +1,9 @@
+{
+  patch(id: "5e4ff3abe3c3317e352062e4") {
+    id
+    taskStatusCounts(options: {}){
+        status
+        count
+    }
+  }
+}

--- a/graphql/tests/patch/results.json
+++ b/graphql/tests/patch/results.json
@@ -296,6 +296,26 @@
           }
         }
       }
+    },
+    {
+      "query_file": "taskStatusCounts.graphql",
+      "result": {
+        "data": {
+          "patch": {
+            "id": "5e4ff3abe3c3317e352062e4",
+            "taskStatusCounts": [
+              {
+                "status": "failed",
+                "count": 1
+              },
+              {
+                "status": "success",
+                "count": 5
+              }
+            ]
+          }
+        }
+      }
     }
   ]
 }

--- a/graphql/tests/user/queries/patches-taskStatusCounts.graphql
+++ b/graphql/tests/user/queries/patches-taskStatusCounts.graphql
@@ -1,0 +1,13 @@
+{
+  user {
+    patches(patchesInput: { includeCommitQueue: true }) {
+      patches {
+        taskStatusCounts {
+          status
+          count
+        }
+      }
+      filteredPatchCount
+    }
+  }
+}

--- a/graphql/tests/user/results.json
+++ b/graphql/tests/user/results.json
@@ -178,6 +178,38 @@
           }
         }
       }
+    },
+    {
+      "query_file": "patches-taskStatusCounts.graphql",
+      "result": {
+        "data": {
+          "user": {
+            "patches": {
+              "patches": [
+                {
+                  "taskStatusCounts": []
+                },
+                {
+                  "taskStatusCounts": []
+                },
+                {
+                  "taskStatusCounts": []
+                },
+                {
+                  "taskStatusCounts": []
+                },
+                {
+                  "taskStatusCounts": []
+                },
+                {
+                  "taskStatusCounts": []
+                }
+              ],
+              "filteredPatchCount": 6
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1296,10 +1296,14 @@ func getTaskStatusCountsForVersion(versionId string, options *BuildVariantOption
 	opts := task.GetTasksByVersionOptions{
 		IncludeBaseTasks:      false,
 		IncludeExecutionTasks: false,
-		TaskNames:             options.Tasks,
-		Variants:              options.Variants,
-		Statuses:              options.Statuses,
 	}
+
+	if options != nil {
+		opts.Variants = options.Variants
+		opts.TaskNames = options.Tasks
+		opts.Statuses = options.Statuses
+	}
+
 	stats, err := task.GetTaskStatsByVersion(versionId, opts)
 	if err != nil {
 		return nil, err

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1290,3 +1290,19 @@ func getAPISubscriptionsForProject(ctx context.Context, projectId string) ([]*re
 	}
 	return res, nil
 }
+
+func getTaskStatusCountsForVersion(versionId string, options *BuildVariantOptions) ([]*task.StatusCount, error) {
+	opts := task.GetTasksByVersionOptions{
+		IncludeBaseTasks:      false,
+		IncludeExecutionTasks: false,
+		TaskNames:             options.Tasks,
+		Variants:              options.Variants,
+		Statuses:              options.Statuses,
+	}
+	stats, err := task.GetTaskStatsByVersion(versionId, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1291,6 +1291,7 @@ func getAPISubscriptionsForProject(ctx context.Context, projectId string) ([]*re
 	return res, nil
 }
 
+// Returns task status counts (a mapping between status and the number of tasks with that status) for a version.
 func getTaskStatusCountsForVersion(versionId string, options *BuildVariantOptions) ([]*task.StatusCount, error) {
 	opts := task.GetTasksByVersionOptions{
 		IncludeBaseTasks:      false,


### PR DESCRIPTION
[EVG-13030](https://jira.mongodb.org/browse/EVG-13030)

### Description 
This field will be used  to display task counts on the user and project patches page. 
https://mongodb.invisionapp.com/console/Evergreen-Version-2---Updated-Typography-cknazaa9t9fbb01xljqq8o8q1/cknaznc5ia0su01xlly201tfo/play
### Testing 
integration tests
