### PR TITLE
EVG-13030: Query version on patch

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1227,6 +1227,7 @@ type MutationResolver interface {
 }
 type PatchResolver interface {
 	AuthorDisplayName(ctx context.Context, obj *model.APIPatch) (string, error)
+	Version(ctx context.Context, obj *model.APIPatch) (*model.APIVersion, error)
 
 	Duration(ctx context.Context, obj *model.APIPatch) (*PatchDuration, error)
 	Time(ctx context.Context, obj *model.APIPatch) (*PatchTime, error)
@@ -7875,7 +7876,7 @@ type Patch {
   patchNumber: Int!
   author: String!
   authorDisplayName: String!
-  version: String!
+  version: Version
   status: String!
   variants: [String!]!
   tasks: [String!]!
@@ -19704,28 +19705,25 @@ func (ec *executionContext) _Patch_version(ctx context.Context, field graphql.Co
 		Object:     "Patch",
 		Field:      field,
 		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 	}
 
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Version, nil
+		return ec.resolvers.Patch().Version(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(*model.APIVersion)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Patch_status(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
@@ -42375,10 +42373,16 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 				return res
 			})
 		case "version":
-			out.Values[i] = ec._Patch_version(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Patch_version(ctx, field, obj)
+				return res
+			})
 		case "status":
 			out.Values[i] = ec._Patch_status(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1180,6 +1180,21 @@ func (r *mutationResolver) DetachVolumeFromHost(ctx context.Context, volumeID st
 
 type patchResolver struct{ *Resolver }
 
+func (r *patchResolver) Version(ctx context.Context, obj *restModel.APIPatch) (*restModel.APIVersion, error) {
+	if utility.FromStringPtr(obj.Version) == "" {
+		return nil, nil
+	}
+	v, err := r.sc.FindVersionById(*obj.Version)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while finding version with id: `%s`: %s", *obj.Version, err.Error()))
+	}
+	apiVersion := restModel.APIVersion{}
+	if err = apiVersion.BuildFromService(v); err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error building APIVersion from service for `%s`: %s", *obj.Version, err.Error()))
+	}
+	return &apiVersion, nil
+}
+
 func (r *patchResolver) CommitQueuePosition(ctx context.Context, apiPatch *restModel.APIPatch) (*int, error) {
 	var commitQueuePosition *int
 	if *apiPatch.Alias == evergreen.CommitQueueAlias {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -811,7 +811,7 @@ type Patch {
   patchNumber: Int!
   author: String!
   authorDisplayName: String!
-  version: String!
+  version: Version
   status: String!
   variants: [String!]!
   tasks: [String!]!

--- a/graphql/tests/patch/queries/empty-version.graphql
+++ b/graphql/tests/patch/queries/empty-version.graphql
@@ -1,0 +1,7 @@
+{
+  patch(id: "5c74085f32f41738270aeba8") {
+    version {
+        id
+    }
+  }
+}

--- a/graphql/tests/patch/queries/version.graphql
+++ b/graphql/tests/patch/queries/version.graphql
@@ -1,0 +1,7 @@
+{
+  patch(id: "9e4ff3abe3c3317e352062e4") {
+    version {
+        id
+    }
+  }
+}

--- a/graphql/tests/patch/results.json
+++ b/graphql/tests/patch/results.json
@@ -1,5 +1,27 @@
 {
   "tests": [
+    { 
+      "query_file": "empty-version.graphql",
+      "result": {
+        "data": {
+          "patch": {
+            "version": null
+          }
+        }
+      }
+    },
+    {
+      "query_file": "version.graphql",
+      "result": {
+        "data": {
+          "patch": {
+            "version": {
+              "id": "5dd2e89cd1fe07048e43bb9c"
+            }
+          }
+        }
+      }
+    },
     {
       "query_file": "taskCount.graphql",
       "result": {


### PR DESCRIPTION
[EVG-13030](https://jira.mongodb.org/browse/EVG-13030)

### Description 
Query a patches version to allow access to the taskStatusCounts from the user and project patches query
