### PR TITLE
EVG-15837 Update CreateTasksFromGroup to disable correctly

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -366,9 +366,9 @@ func GetVariantsAndTasksFromProject(ctx context.Context, patchedConfig, patchPro
 		tasksForVariant := []model.BuildVariantTaskUnit{}
 		for _, taskFromVariant := range variant.Tasks {
 			// add a task name to the list if it's patchable and not restricted to git tags and not disabled
-			if !taskFromVariant.IsDisabled() && utility.FromBoolTPtr(taskFromVariant.Patchable) && !utility.FromBoolPtr(taskFromVariant.GitTagOnly) {
+			if !taskFromVariant.IsDisabled() && taskFromVariant.SkipOnRequester(evergreen.PatchVersionRequester) {
 				if taskFromVariant.IsGroup {
-					tasksForVariant = append(tasksForVariant, model.CreateTasksFromGroup(taskFromVariant, project)...)
+					tasksForVariant = append(tasksForVariant, model.CreateTasksFromGroup(taskFromVariant, project, evergreen.PatchVersionRequester)...)
 				} else {
 					tasksForVariant = append(tasksForVariant, taskFromVariant)
 				}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -366,7 +366,7 @@ func GetVariantsAndTasksFromProject(ctx context.Context, patchedConfig, patchPro
 		tasksForVariant := []model.BuildVariantTaskUnit{}
 		for _, taskFromVariant := range variant.Tasks {
 			// add a task name to the list if it's patchable and not restricted to git tags and not disabled
-			if !taskFromVariant.IsDisabled() && taskFromVariant.SkipOnRequester(evergreen.PatchVersionRequester) {
+			if !taskFromVariant.IsDisabled() && utility.FromBoolTPtr(taskFromVariant.Patchable) && !utility.FromBoolPtr(taskFromVariant.GitTagOnly) {
 				if taskFromVariant.IsGroup {
 					tasksForVariant = append(tasksForVariant, model.CreateTasksFromGroup(taskFromVariant, project, evergreen.PatchVersionRequester)...)
 				} else {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -767,7 +767,7 @@ func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project, requester stri
 			Activate:         in.Activate,
 			CommitQueueMerge: in.CommitQueueMerge,
 		}
-		if !bvt.IsDisabled() && bvt.SkipOnRequester(requester) {
+		if !bvt.IsDisabled() && !bvt.SkipOnRequester(requester) {
 			bvt.Populate(taskMap[t])
 			tasks = append(tasks, bvt)
 		}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -735,7 +735,7 @@ func CreateBuildFromVersionNoInsert(args BuildCreateArgs) (*build.Build, task.Ta
 	return b, tasksForBuild, nil
 }
 
-func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project) []BuildVariantTaskUnit {
+func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project, requester string) []BuildVariantTaskUnit {
 	tasks := []BuildVariantTaskUnit{}
 	tg := proj.FindTaskGroup(in.Name)
 	if tg == nil {
@@ -767,8 +767,10 @@ func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project) []BuildVariant
 			Activate:         in.Activate,
 			CommitQueueMerge: in.CommitQueueMerge,
 		}
-		bvt.Populate(taskMap[t])
-		tasks = append(tasks, bvt)
+		if !bvt.IsDisabled() && bvt.SkipOnRequester(requester) {
+			bvt.Populate(taskMap[t])
+			tasks = append(tasks, bvt)
+		}
 	}
 	return tasks
 }
@@ -810,7 +812,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 				tasksToCreate = append(tasksToCreate, task)
 			}
 		} else if _, ok := tgMap[task.Name]; ok {
-			tasksFromVariant := CreateTasksFromGroup(task, project)
+			tasksFromVariant := CreateTasksFromGroup(task, project, b.Requester)
 			for _, taskFromVariant := range tasksFromVariant {
 				if task.IsDisabled() || taskFromVariant.SkipOnRequester(b.Requester) {
 					continue

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1993,7 +1993,7 @@ func TestCreateTasksFromGroup(t *testing.T) {
 			},
 		},
 	}
-	bvts := CreateTasksFromGroup(in, p)
+	bvts := CreateTasksFromGroup(in, p, "")
 	assert.Equal("new_dependency", bvts[0].DependsOn[0].Name)
 	assert.Equal("new_dependency", bvts[1].DependsOn[0].Name)
 }

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1993,7 +1993,7 @@ func TestCreateTasksFromGroup(t *testing.T) {
 		TaskGroups: []TaskGroup{
 			{
 				Name:  "name",
-				Tasks: []string{"first_task", "second_task"},
+				Tasks: []string{"first_task", "second_task", "third_task"},
 			},
 		},
 	}

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1985,6 +1985,10 @@ func TestCreateTasksFromGroup(t *testing.T) {
 			{
 				Name: "second_task",
 			},
+			{
+				Name:      "third_task",
+				Patchable: utility.FalsePtr(),
+			},
 		},
 		TaskGroups: []TaskGroup{
 			{
@@ -1993,7 +1997,7 @@ func TestCreateTasksFromGroup(t *testing.T) {
 			},
 		},
 	}
-	bvts := CreateTasksFromGroup(in, p, "")
+	bvts := CreateTasksFromGroup(in, p, evergreen.PatchVersionRequester)
 	assert.Equal("new_dependency", bvts[0].DependsOn[0].Name)
 	assert.Equal("new_dependency", bvts[1].DependsOn[0].Name)
 }

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -348,7 +348,7 @@ func tvToTaskUnit(p *model.Project) map[model.TVPair]model.BuildVariantTaskUnit 
 		tasksToAdd := []model.BuildVariantTaskUnit{}
 		for _, t := range bv.Tasks {
 			if _, ok := taskGroups[t.Name]; ok {
-				tasksToAdd = append(tasksToAdd, model.CreateTasksFromGroup(t, p)...)
+				tasksToAdd = append(tasksToAdd, model.CreateTasksFromGroup(t, p, "")...)
 			} else {
 				tasksToAdd = append(tasksToAdd, t)
 			}
@@ -1575,7 +1575,7 @@ func bvsWithTasksThatCallCommand(p *model.Project, cmd string) (map[string]map[s
 				if tg.TeardownTask != nil {
 					setupAndTeardownCmds = append(setupAndTeardownCmds, p.CommandsRunOnBV(tg.TeardownTask.List(), cmd, bv.Name)...)
 				}
-				for _, tgTask := range model.CreateTasksFromGroup(bvtu, p) {
+				for _, tgTask := range model.CreateTasksFromGroup(bvtu, p, "") {
 					addCmdsForTaskInBV(bvToTasksWithCmds, bv.Name, tgTask.Name, setupAndTeardownCmds)
 					if projTask := p.FindProjectTask(tgTask.Name); projTask != nil {
 						cmds := p.CommandsRunOnBV(projTask.Commands, cmd, bv.Name)


### PR DESCRIPTION
[EVG-15837](https://jira.mongodb.org/browse/EVG-15837)

### Description 
Previously, all taskgroup tasks were showing up on the config page even if they weren't supposed to (ie upload-cli sets patchable to false but still shows up when you create a patch.) The changes fix this problem 

### Testing 
uplad-cli doesn't show up on the config page anymore
https://spruce-staging.corp.mongodb.com/patch/61967796b2373666af059883/configure/tasks
![image](https://user-images.githubusercontent.com/26491602/142484464-c687591f-a636-439a-a94d-757235f469fa.png)

