### PR TITLE
EVG-15653 periodic builds should create a stub version when there's an error

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -258,7 +258,7 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 					Errors:   projErr.Errors,
 				}
 				if len(versionErrs.Errors) > 0 {
-					stubVersion, dbErr := shellVersionFromRevision(ctx, ref, model.VersionMetadata{Revision: revisions[i]})
+					stubVersion, dbErr := ShellVersionFromRevision(ctx, ref, model.VersionMetadata{Revision: revisions[i]})
 					if dbErr != nil {
 						grip.Error(message.WrapError(dbErr, message.Fields{
 							"message":            "error creating shell version",
@@ -695,7 +695,7 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 	}
 
 	// create a version document
-	v, err := shellVersionFromRevision(ctx, projectInfo.Ref, metadata)
+	v, err := ShellVersionFromRevision(ctx, projectInfo.Ref, metadata)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shell version")
 	}
@@ -772,7 +772,7 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 
 // shellVersionFromRevision populates a new Version with metadata from a model.Revision.
 // Does not populate its config or store anything in the database.
-func shellVersionFromRevision(ctx context.Context, ref *model.ProjectRef, metadata model.VersionMetadata) (*model.Version, error) {
+func ShellVersionFromRevision(ctx context.Context, ref *model.ProjectRef, metadata model.VersionMetadata) (*model.Version, error) {
 	var u *user.DBUser
 	var err error
 	if metadata.Revision.AuthorGithubUID != 0 {

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -1166,7 +1166,7 @@ func TestShellVersionFromRevisionGitTags(t *testing.T) {
 		GitTagVersionsEnabled: utility.TruePtr(),
 	}
 	assert.NoError(t, evergreen.UpdateConfig(testutil.TestConfig()))
-	v, err := shellVersionFromRevision(context.TODO(), pRef, metadata)
+	v, err := ShellVersionFromRevision(context.TODO(), pRef, metadata)
 	assert.NoError(t, err)
 	require.NotNil(t, v)
 	assert.Equal(t, evergreen.GitTagRequester, v.Requester)

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/repotracker"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
@@ -97,13 +98,57 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 			"definition": j.DefinitionID,
 		}))
 	}()
+	versionID, versionError := j.addVersion(ctx, *definition)
 
-	versionID, err := j.addVersion(ctx, *definition)
+	if versionError != nil {
+		// if the version fails to be added, create a stub version and
+		// log an event so users can get notified when notifications are configured
+		metadata := model.VersionMetadata{
+			IsAdHoc:         true,
+			Message:         definition.Message,
+			PeriodicBuildID: definition.ID,
+			Alias:           definition.Alias,
+		}
+		stubVersion, dbErr := repotracker.ShellVersionFromRevision(ctx, j.project, metadata)
+		if dbErr != nil {
+			grip.Error(message.WrapError(dbErr, message.Fields{
+				"message":            "error creating stub version for periodic build",
+				"runner":             periodicBuildJobName,
+				"project":            j.project,
+				"project_identifier": j.project.Identifier,
+				"definitionID":       j.DefinitionID,
+			}))
+		}
+		if stubVersion == nil {
+			j.AddError(versionError)
+			return
+		}
+		stubVersion.Errors = []string{versionError.Error()}
+		insertError := stubVersion.Insert()
+		if err != nil {
+			grip.Error(message.WrapError(insertError, message.Fields{
+				"message":            "error inserting stub version for periodic build",
+				"runner":             periodicBuildJobName,
+				"project":            j.project,
+				"project_identifier": j.project.Identifier,
+				"definitionID":       j.DefinitionID,
+			}))
+		}
+		event.LogVersionStateChangeEvent(stubVersion.Id, evergreen.VersionFailed)
+
+		j.AddError(versionError)
+		return
+	}
+
+	err = model.SetVersionActivation(versionID, true, evergreen.User)
 	if err != nil {
+		// if the version fails to activate, log an event so users
+		// can get notified when notifications are configured
+		event.LogVersionStateChangeEvent(versionID, evergreen.VersionFailed)
 		j.AddError(err)
 		return
 	}
-	j.AddError(model.SetVersionActivation(versionID, true, evergreen.User))
+
 }
 
 func (j *periodicBuildJob) addVersion(ctx context.Context, definition model.PeriodicBuildDefinition) (string, error) {


### PR DESCRIPTION
[EVG-15653](https://jira.mongodb.org/browse/EVG-15653)

### Description 
This creates a stub version when a periodic build version fails so that people who have notifications configured will know that it failed instead of it failing silently. 

### Testing 
tested on staging 

![image](https://user-images.githubusercontent.com/13104717/142632950-7d878dbe-0b4e-4371-909d-a9722b86622c.png)
[stub version](https://evergreen-staging.corp.mongodb.com/version/6197aa60b23736685749e4e2)

