### PR TITLE
EVG-15285: Filter mongo-stored test results by display test name

### DIFF
--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -249,7 +249,12 @@ func TestResultsFilterSortPaginate(opts TestResultsFilterSortPaginateOpts) ([]Te
 	pipeline = append(pipeline, bson.M{"$project": project})
 
 	if opts.TestName != "" {
-		matchTestName := bson.M{"$match": bson.M{TestFileKey: bson.M{"$regex": opts.TestName, "$options": "i"}}}
+		matchTestName := bson.M{"$match": bson.M{
+			"$or": []bson.M{
+				{TestFileKey: bson.M{"$regex": opts.TestName, "$options": "i"}},
+				{DisplayTestNameKey: bson.M{"$regex": opts.TestName, "$options": "i"}},
+			},
+		}}
 		pipeline = append(pipeline, matchTestName)
 	}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15285

I tested that I didn't break the filtering on both legacy and spruce staging UIs.