### PR TITLE
EVG-15768 display error when project identifier already exists

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -228,7 +228,7 @@ mciModule.controller(
 
     $scope.findProject = function (identifier) {
       return _.find($scope.trackedProjects, function (project) {
-        return project.identifier == identifier;
+        return project.identifier == identifier || project.id == identifier;
       });
     };
 
@@ -374,7 +374,7 @@ mciModule.controller(
 
       if ($scope.findProject($scope.newProject.identifier)) {
         console.log("project identifier already exists");
-        $scope.newProjectMessage = "Project name already exists.";
+        $scope.newProjectMessage = "Project with this ID or identifier already exists.";
         $scope.newProject = {};
         return;
       }


### PR DESCRIPTION
[EVG-15768 ](https://jira.mongodb.org/browse/EVG-15768)

### Description 
Could make this change more robust but since this is legacy and is mostly just done by our team I think a small fix is best.

### Testing 
Changed logkeeper project to "logkeeper2" and verified that trying to create a new logkeeper returned this error.
![image](https://user-images.githubusercontent.com/26798134/143950038-cb856d07-9777-4921-a9a3-8af3abbff6b9.png)
