### PR TITLE
EVG-15739 allow filtering task notifications by build variant

### DIFF
--- a/public/static/js/subscriptions.js
+++ b/public/static/js/subscriptions.js
@@ -424,7 +424,11 @@ function buildRegexSelectors() {
 
 function taskRegexSelectors() {
   return [{
-    type: "display-name",
-    type_label: "Task Name",
-  }];
+      type: "display-name",
+      type_label: "Task Name",
+    },
+    {
+      type: "build-variant",
+      type_label: "Build Variant Name",
+    }];
 }

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -214,6 +214,10 @@ func (t *taskTriggers) Selectors() []event.Selector {
 			Data: t.task.DisplayName,
 		},
 		{
+			Type: event.SelectorBuildVariant,
+			Data: t.task.BuildVariant,
+		},
+		{
 			Type: event.SelectorRequester,
 			Data: t.task.Requester,
 		},


### PR DESCRIPTION
[EVG-15739](https://jira.mongodb.org/browse/EVG-15739)

### Description 
I'm pleasantly surprised with how easy this was to add. The framework is set and the task document already stores build variant so adding it as a selector allows us to case on it.

### Testing 
Added a subscription on the lint variant from the project page. Restarted a lint task and a non-lint task and confirmed that only the lint one sent a notification.
![image](https://user-images.githubusercontent.com/26798134/144140932-77b4e7c5-9111-4647-b59c-22826cdb5896.png)
The subscription:
```
{
	"_id" : "61a6a497b2373648ab6c4eb1",
	"selectors" : [
		{
			"type" : "project",
			"data" : "mci"
		},
		{
			"type" : "requester",
			"data" : "gitter_request"
		}
	],
	"regex_selectors" : [
		{
			"type" : "build-variant",
			"data" : "lint"
		}
	],
	"subscriber" : {
		"type" : "slack",
		"target" : "@annie.black"
	},
	"owner" : "mci",
	"owner_type" : "project",
	"trigger_data" : {
		"requester" : "gitter_request"
	},
	"type" : "TASK",
	"trigger" : "outcome"
}
```

![image](https://user-images.githubusercontent.com/26798134/144140951-8a271fba-59f4-474c-bf0f-bef7731b1a11.png)
