### PR TITLE
EVG 15901 Skip BFG creations if all subtask failures are setup-failed or stranded

### DIFF
--- a/trigger/task.go
+++ b/trigger/task.go
@@ -355,7 +355,7 @@ func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, test
 					return nil, errors.Wrapf(err, "error getting execution task")
 				}
 				if executionTask.Details.Status == evergreen.TaskFailed {
-					if executionTask.Details.Description == evergreen.TaskDescriptionStranded {
+					if executionTask.Details.Description == evergreen.TaskDescriptionStranded || executionTask.Details.Description == evergreen.TaskSetupFailed {
 						shouldSkipTicket = true
 					} else {
 						shouldSkipTicket = false

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -345,7 +345,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, testNames string) (*notification.Notification, error) {
 	var payload interface{}
 	if sub.Subscriber.Type == event.JIRAIssueSubscriberType {
-		// We avoid creating BFG ticket in the case that the task is stranded to reduce noise for the Build Baron
+		// We avoid creating BFG ticket in the case that the task is setup-failed or stranded to reduce noise for the Build Baron
 		// If task is display, we skip ticket creation if all execution task failures are only 'stranded'
 		shouldSkipTicket := false
 		if t.task.DisplayOnly {

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -355,13 +355,10 @@ func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, test
 					return nil, errors.Wrapf(err, "error getting execution task")
 				}
 				if executionTask.Details.Status == evergreen.TaskFailed {
-					skipTicket := executionTask.Details.Description == evergreen.TaskDescriptionStranded ||
+					shouldSkipTicket := executionTask.Details.Description == evergreen.TaskDescriptionStranded ||
 						executionTask.Details.Type == evergreen.CommandTypeSetup ||
 						executionTask.IsSystemUnresponsive()
-					if skipTicket {
-						shouldSkipTicket = true
-					} else {
-						shouldSkipTicket = false
+					if !shouldSkipTicket {
 						break
 					}
 				}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -355,7 +355,7 @@ func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, test
 					return nil, errors.Wrapf(err, "error getting execution task")
 				}
 				if executionTask.Details.Status == evergreen.TaskFailed {
-					if executionTask.Details.Description == evergreen.TaskDescriptionStranded || executionTask.Details.Description == evergreen.TaskSetupFailed {
+					if executionTask.Details.Description == evergreen.TaskDescriptionStranded || executionTask.GetDisplayStatus() == evergreen.TaskSetupFailed {
 						shouldSkipTicket = true
 					} else {
 						shouldSkipTicket = false

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -355,7 +355,7 @@ func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, test
 					return nil, errors.Wrapf(err, "error getting execution task")
 				}
 				if executionTask.Details.Status == evergreen.TaskFailed {
-					shouldSkipTicket := executionTask.Details.Description == evergreen.TaskDescriptionStranded ||
+					shouldSkipTicket = executionTask.Details.Description == evergreen.TaskDescriptionStranded ||
 						executionTask.Details.Type == evergreen.CommandTypeSetup ||
 						executionTask.IsSystemUnresponsive()
 					if !shouldSkipTicket {

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -355,7 +355,10 @@ func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, test
 					return nil, errors.Wrapf(err, "error getting execution task")
 				}
 				if executionTask.Details.Status == evergreen.TaskFailed {
-					if executionTask.Details.Description == evergreen.TaskDescriptionStranded || executionTask.GetDisplayStatus() == evergreen.TaskSetupFailed {
+					skipTicket := executionTask.Details.Description == evergreen.TaskDescriptionStranded ||
+						executionTask.Details.Type == evergreen.CommandTypeSetup ||
+						executionTask.IsSystemUnresponsive()
+					if skipTicket {
 						shouldSkipTicket = true
 					} else {
 						shouldSkipTicket = false


### PR DESCRIPTION
[EVG-15901](https://jira.mongodb.org/browse/EVG-<number>)

### Description 
This change prevents BFGs from being created if all subtasks failures are identified as stranded or setup-failed.