### PR TITLE
EVG-15639 Alternative approach Create test result sample resolver

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -7304,8 +7304,8 @@ input TestFilter {
 type TaskTestResultSample {
   taskId: String!
   execution: Int!
-  totalTestCount: Int
-  matchingFailedTestNames: [String!]
+  totalTestCount: Int!
+  matchingFailedTestNames: [String!]!
 }
 
 # Array of activated and unactivated versions
@@ -32842,11 +32842,14 @@ func (ec *executionContext) _TaskTestResultSample_totalTestCount(ctx context.Con
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*int)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _TaskTestResultSample_matchingFailedTestNames(ctx context.Context, field graphql.CollectedField, obj *TaskTestResultSample) (ret graphql.Marshaler) {
@@ -32874,11 +32877,14 @@ func (ec *executionContext) _TaskTestResultSample_matchingFailedTestNames(ctx co
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _TestLog_url(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
@@ -46096,8 +46102,14 @@ func (ec *executionContext) _TaskTestResultSample(ctx context.Context, sel ast.S
 			}
 		case "totalTestCount":
 			out.Values[i] = ec._TaskTestResultSample_totalTestCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "matchingFailedTestNames":
 			out.Values[i] = ec._TaskTestResultSample_matchingFailedTestNames(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -280,7 +280,7 @@ type TaskTestResult struct {
 type TaskTestResultSample struct {
 	TaskID                  string   `json:"taskId"`
 	Execution               int      `json:"execution"`
-	TotalTestCount          *int     `json:"totalTestCount"`
+	TotalTestCount          int      `json:"totalTestCount"`
 	MatchingFailedTestNames []string `json:"matchingFailedTestNames"`
 }
 

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -277,6 +277,18 @@ type TaskTestResult struct {
 	TestResults       []*model.APITest `json:"testResults"`
 }
 
+type TaskTestResultSample struct {
+	TaskID                  string   `json:"taskId"`
+	Execution               int      `json:"execution"`
+	TotalTestCount          *int     `json:"totalTestCount"`
+	MatchingFailedTestNames []string `json:"matchingFailedTestNames"`
+}
+
+type TestFilter struct {
+	TestName   string `json:"testName"`
+	TestStatus string `json:"testStatus"`
+}
+
 type UpdateVolumeInput struct {
 	Expiration   *time.Time `json:"expiration"`
 	NoExpiration *bool      `json:"noExpiration"`

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1795,10 +1795,10 @@ func (r *queryResolver) TaskTestSample(ctx context.Context, tasks []string, test
 	}
 	t, err := task.Find(task.ByIds(tasks))
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding task %s: %s", tasks[0], err))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding tasks %s: %s", tasks, err))
 	}
 	if t == nil {
-		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("task %s not found", tasks[0]))
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("tasks %s not found", tasks))
 	}
 	// We can assume that if one of the tasks has cedar results, all of them do
 	if t[0].HasCedarResults {
@@ -1817,7 +1817,7 @@ func (r *queryResolver) TaskTestSample(ctx context.Context, tasks []string, test
 				TaskID:                  utility.FromStringPtr(r.TaskID),
 				Execution:               r.Execution,
 				MatchingFailedTestNames: r.MatchingFailedTestNames,
-				TotalTestCount:          &r.TotalFailedNames,
+				TotalTestCount:          r.TotalFailedNames,
 			}
 			testResultsToReturn = append(testResultsToReturn, tr)
 		}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1789,6 +1789,42 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 	}, nil
 }
 
+func (r *queryResolver) TaskTestSample(ctx context.Context, tasks []string, testFilters []*TestFilter) ([]*TaskTestResultSample, error) {
+	if len(tasks) == 0 {
+		return nil, nil
+	}
+	t, err := task.Find(task.ByIds(tasks))
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding task %s: %s", tasks[0], err))
+	}
+	if t == nil {
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("task %s not found", tasks[0]))
+	}
+	// We can assume that if one of the tasks has cedar results, all of them do
+	if t[0].HasCedarResults {
+		failingTests := []string{}
+		for _, f := range testFilters {
+			failingTests = append(failingTests, f.TestName)
+		}
+
+		results, err := getCedarFailedTestResultsSample(ctx, t, failingTests)
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting test results sample: %s", err))
+		}
+		testResultsToReturn := []*TaskTestResultSample{}
+		for _, r := range results {
+			tr := &TaskTestResultSample{
+				TaskID:                  utility.FromStringPtr(r.TaskID),
+				Execution:               r.Execution,
+				MatchingFailedTestNames: r.MatchingFailedTestNames,
+				TotalTestCount:          &r.TotalFailedNames,
+			}
+			testResultsToReturn = append(testResultsToReturn, tr)
+		}
+		return testResultsToReturn, nil
+	}
+	return nil, nil
+}
 func (r *queryResolver) TaskFiles(ctx context.Context, taskID string, execution *int) (*TaskFiles, error) {
 	emptyTaskFiles := TaskFiles{
 		FileCount:    0,

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1800,7 +1800,7 @@ func (r *queryResolver) TaskTestSample(ctx context.Context, tasks []string, test
 	if t == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("tasks %s not found", tasks))
 	}
-	// We can assume that if one of the tasks has cedar results, all of them do
+	// We can assume that if one of the tasks has cedar results, all of them do.
 	if t[0].HasCedarResults {
 		failingTests := []string{}
 		for _, f := range testFilters {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -30,6 +30,10 @@ type Query {
     statuses: [String!]! = []
     groupId: String = ""
   ): TaskTestResult!
+  taskTestSample(
+    tasks: [String!]!
+    filters: [TestFilter!]!
+  ): [TaskTestResultSample!]
   taskFiles(taskId: String!, execution: Int): TaskFiles!
   user(userId: String): User!
   taskLogs(taskId: String!, execution: Int): TaskLogs!
@@ -159,6 +163,18 @@ input VersionToRestart {
   taskIds: [String!]!
 }
 
+input TestFilter {
+  testName: String!
+  testStatus: String!
+}
+
+# This will represent failing test results on the task history pages.
+type TaskTestResultSample {
+  taskId: String!
+  execution: Int!
+  totalTestCount: Int
+  matchingFailedTestNames: [String!]
+}
 
 # Array of activated and unactivated versions
 # nextPageOrderNumber represents the last order number returned and is used for pagination

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -172,8 +172,8 @@ input TestFilter {
 type TaskTestResultSample {
   taskId: String!
   execution: Int!
-  totalTestCount: Int
-  matchingFailedTestNames: [String!]
+  totalTestCount: Int!
+  matchingFailedTestNames: [String!]!
 }
 
 # Array of activated and unactivated versions

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/event"
 
 	"github.com/evergreen-ci/evergreen"
@@ -541,6 +542,35 @@ func generateBuildVariants(sc data.Connector, versionId string, searchVariants [
 		"buildVariantCount": len(result),
 	})
 	return result, nil
+}
+
+// getFailedTestResultsSample returns a sample of failed test results for the given tasks that match the supplied testFilters
+func getCedarFailedTestResultsSample(ctx context.Context, tasks []task.Task, testFilters []string) ([]apimodels.CedarFailedTestResultsSample, error) {
+	if len(tasks) == 0 {
+		return nil, nil
+	}
+	cedarTaskInfo := []apimodels.CedarTaskInfo{}
+	for _, t := range tasks {
+		cedarTestOption := apimodels.CedarTaskInfo{
+			TaskID:      t.Id,
+			Execution:   t.Execution,
+			DisplayTask: t.DisplayOnly,
+		}
+		cedarTaskInfo = append(cedarTaskInfo, cedarTestOption)
+	}
+	cedarFailedTestSampleOpts := apimodels.CedarFailedTestSampleOptions{
+		Tasks:        cedarTaskInfo,
+		RegexFilters: testFilters,
+	}
+	opts := apimodels.GetCedarFailedTestResultsSampleOptions{
+		BaseURL:       evergreen.GetEnvironment().Settings().Cedar.BaseURL,
+		SampleOptions: cedarFailedTestSampleOpts,
+	}
+	results, err := apimodels.GetCedarFilteredFailedSamples(ctx, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting cedar filtered failed samples")
+	}
+	return results, nil
 }
 
 type VersionModificationAction string

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -551,12 +551,11 @@ func getCedarFailedTestResultsSample(ctx context.Context, tasks []task.Task, tes
 	}
 	taskFilters := []apimodels.CedarTaskInfo{}
 	for _, t := range tasks {
-		taskFilter := apimodels.CedarTaskInfo{
+		taskFilters = append(taskFilters, apimodels.CedarTaskInfo{
 			TaskID:      t.Id,
 			Execution:   t.Execution,
 			DisplayTask: t.DisplayOnly,
-		}
-		taskFilters = append(taskFilters, taskFilter)
+		})
 	}
 
 	opts := apimodels.GetCedarFailedTestResultsSampleOptions{

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -549,26 +549,26 @@ func getCedarFailedTestResultsSample(ctx context.Context, tasks []task.Task, tes
 	if len(tasks) == 0 {
 		return nil, nil
 	}
-	cedarTaskInfo := []apimodels.CedarTaskInfo{}
+	taskFilters := []apimodels.CedarTaskInfo{}
 	for _, t := range tasks {
-		cedarTestOption := apimodels.CedarTaskInfo{
+		taskFilter := apimodels.CedarTaskInfo{
 			TaskID:      t.Id,
 			Execution:   t.Execution,
 			DisplayTask: t.DisplayOnly,
 		}
-		cedarTaskInfo = append(cedarTaskInfo, cedarTestOption)
+		taskFilters = append(taskFilters, taskFilter)
 	}
-	cedarFailedTestSampleOpts := apimodels.CedarFailedTestSampleOptions{
-		Tasks:        cedarTaskInfo,
-		RegexFilters: testFilters,
-	}
+
 	opts := apimodels.GetCedarFailedTestResultsSampleOptions{
-		BaseURL:       evergreen.GetEnvironment().Settings().Cedar.BaseURL,
-		SampleOptions: cedarFailedTestSampleOpts,
+		BaseURL: evergreen.GetEnvironment().Settings().Cedar.BaseURL,
+		SampleOptions: apimodels.CedarFailedTestSampleOptions{
+			Tasks:        taskFilters,
+			RegexFilters: testFilters,
+		},
 	}
 	results, err := apimodels.GetCedarFilteredFailedSamples(ctx, opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting cedar filtered failed samples")
+		return nil, errors.Wrap(err, "getting cedar filtered failed samples")
 	}
 	return results, nil
 }


### PR DESCRIPTION
[EVG-15639](https://jira.mongodb.org/browse/EVG-15639)

### Description 
This is an alternative approach to #5239 which gives us more flexibility when fetching test results and avoids needing to refresh all the data when a new filter is applied. 

