### PR TITLE
EVG 15012 Return warning errors if tasks have no timeout

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -131,6 +131,7 @@ var projectSemanticValidators = []projectValidator{
 	checkTaskCommands,
 	checkTaskGroups,
 	checkLoggerConfig,
+	checkTaskTimeout,
 }
 
 var projectSettingsValidators = []projectSettingsValidator{
@@ -1897,4 +1898,22 @@ func parseS3PullParameters(c model.PluginCommandConf) (task, bv string, err erro
 		return "", "", errors.Errorf("command '%s' was supplied parameter '%s' but is not a string argument, got %T", c.Command, paramName, i)
 	}
 	return task, bv, nil
+}
+
+// checkTaskTimeout checks if all tasks contains a timeout
+func checkTaskTimeout(project *model.Project) ValidationErrors {
+	errs := ValidationErrors{}
+	for _, task := range project.Tasks {
+		if task.ExecTimeoutSecs == 0 {
+			errs = append(errs,
+				ValidationError{
+					Message: fmt.Sprintf("task '%s' in project '%s' does not "+
+						"contain an exec_timeout_secs",
+						task.Name, project.Identifier),
+					Level: Warning,
+				},
+			)
+		}
+	}
+	return errs
 }

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1911,11 +1911,12 @@ func checkTaskTimeout(project *model.Project) ValidationErrors {
 			errs = append(errs,
 				ValidationError{
 					Message: fmt.Sprintf("task '%s' in project '%s' does not "+
-						"have an exec_timeout_secs defined; the task will default to a timeout of 6 hours",
+						"have an exec_timeout_secs defined; the task will default to a timeout of 6 hours\n",
 						task.Name, project.Identifier),
 					Level: Warning,
 				},
 			)
+			break
 		}
 	}
 

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1906,30 +1906,18 @@ func checkTaskTimeout(project *model.Project) ValidationErrors {
 	if project.ExecTimeoutSecs > 0 {
 		return errs
 	}
-	taskNames := []string{}
 	for _, task := range project.Tasks {
 		if task.ExecTimeoutSecs == 0 {
-			taskNames = append(taskNames, task.Name)
+			errs = append(errs,
+				ValidationError{
+					Message: fmt.Sprintf("task '%s' in project '%s' does not "+
+						"have an exec_timeout_secs defined; the task will default to a timeout of 6 hours",
+						task.Name, project.Identifier),
+					Level: Warning,
+				},
+			)
 		}
 	}
-	if len(taskNames) == 1 {
-		errs = append(errs,
-			ValidationError{
-				Message: fmt.Sprintf("task '%s' in project '%s' does not "+
-					"have an exec_timeout_secs defined",
-					taskNames[0], project.Identifier),
-				Level: Warning,
-			},
-		)
-	} else if len(taskNames) > 1 {
-		errs = append(errs,
-			ValidationError{
-				Message: fmt.Sprintf("tasks '%s' in project '%s' do not "+
-					"have an exec_timeout_secs defined",
-					strings.Join(taskNames, ", "), project.Identifier),
-				Level: Warning,
-			},
-		)
-	}
+
 	return errs
 }

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1903,16 +1903,10 @@ func parseS3PullParameters(c model.PluginCommandConf) (task, bv string, err erro
 // checkTaskTimeout checks if all tasks contain a timeout
 func checkTaskTimeout(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
-	if project.ExecTimeoutSecs == 0 {
-		errs = append(errs,
-			ValidationError{
-				Message: fmt.Sprintf("roject '%s' does not "+
-					"contain an exec_timeout_secs",
-					project.Identifier),
-				Level: Warning,
-			},
-		)
+	if project.ExecTimeoutSecs > 0 {
+		return errs
 	}
+
 	for _, task := range project.Tasks {
 		if task.ExecTimeoutSecs == 0 {
 			errs = append(errs,

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1906,18 +1906,30 @@ func checkTaskTimeout(project *model.Project) ValidationErrors {
 	if project.ExecTimeoutSecs > 0 {
 		return errs
 	}
-
+	taskNames := []string{}
 	for _, task := range project.Tasks {
 		if task.ExecTimeoutSecs == 0 {
-			errs = append(errs,
-				ValidationError{
-					Message: fmt.Sprintf("task '%s' in project '%s' does not "+
-						"contain an exec_timeout_secs",
-						task.Name, project.Identifier),
-					Level: Warning,
-				},
-			)
+			taskNames = append(taskNames, task.Name)
 		}
+	}
+	if len(taskNames) == 1 {
+		errs = append(errs,
+			ValidationError{
+				Message: fmt.Sprintf("task '%s' in project '%s' does not "+
+					"have an exec_timeout_secs defined",
+					taskNames[0], project.Identifier),
+				Level: Warning,
+			},
+		)
+	} else if len(taskNames) > 1 {
+		errs = append(errs,
+			ValidationError{
+				Message: fmt.Sprintf("tasks '%s' in project '%s' do not "+
+					"have an exec_timeout_secs defined",
+					strings.Join(taskNames, ", "), project.Identifier),
+				Level: Warning,
+			},
+		)
 	}
 	return errs
 }

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1903,6 +1903,16 @@ func parseS3PullParameters(c model.PluginCommandConf) (task, bv string, err erro
 // checkTaskTimeout checks if all tasks contain a timeout
 func checkTaskTimeout(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
+	if project.ExecTimeoutSecs == 0 {
+		errs = append(errs,
+			ValidationError{
+				Message: fmt.Sprintf("roject '%s' does not "+
+					"contain an exec_timeout_secs",
+					project.Identifier),
+				Level: Warning,
+			},
+		)
+	}
 	for _, task := range project.Tasks {
 		if task.ExecTimeoutSecs == 0 {
 			errs = append(errs,

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1910,9 +1910,9 @@ func checkTaskTimeout(project *model.Project) ValidationErrors {
 		if task.ExecTimeoutSecs == 0 {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("task '%s' in project '%s' does not "+
-						"have an exec_timeout_secs defined; the task will default to a timeout of 6 hours\n",
-						task.Name, project.Identifier),
+					Message: fmt.Sprintf("project '%s' does not "+
+						"have an exec_timeout_secs defined on one or more tasks; these tasks will default to a timeout of 6 hours",
+						project.Identifier),
 					Level: Warning,
 				},
 			)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1900,7 +1900,7 @@ func parseS3PullParameters(c model.PluginCommandConf) (task, bv string, err erro
 	return task, bv, nil
 }
 
-// checkTaskTimeout checks if all tasks contains a timeout
+// checkTaskTimeout checks if all tasks contain a timeout
 func checkTaskTimeout(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
 	for _, task := range project.Tasks {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2157,16 +2157,20 @@ func TestTaskNotInTaskGroupDependsOnTaskInTaskGroup(t *testing.T) {
 	d := distro.Distro{Id: "example_distro"}
 	require.NoError(d.Insert())
 	exampleYml := `
+exec_timeout_secs: 100
 tasks:
 - name: not_in_a_task_group
+  exec_timeout_secs: 100
   commands:
   - command: shell.exec
   depends_on:
   - name: task_in_a_task_group_1
 - name: task_in_a_task_group_1
+  exec_timeout_secs: 100
   commands:
   - command: shell.exec
 - name: task_in_a_task_group_2
+  exec_timeout_secs: 100
   commands:
   - command: shell.exec
 task_groups:
@@ -2210,8 +2214,10 @@ func TestYamlStrict(t *testing.T) {
 	d := distro.Distro{Id: "example_distro"}
 	require.NoError(d.Insert())
 	exampleYml := `
+exec_timeout_secs: 100
 tasks:
 - name: task1
+  exec_timeout_secs: 100
   commands:
   - command: shell.exec
 buildvariants:
@@ -2262,15 +2268,18 @@ func TestTaskGroupWithDependencyOutsideGroupWarning(t *testing.T) {
 	exampleYml := `
 tasks:
 - name: not_in_a_task_group
+  exec_timeout_secs: 100
   commands:
   - command: shell.exec
 - name: task_in_a_task_group
+  exec_timeout_secs: 100
   commands:
   - command: shell.exec
   depends_on:
   - name: not_in_a_task_group
 task_groups:
 - name: example_task_group
+  exec_timeout_secs: 100 
   tasks:
   - task_in_a_task_group
 buildvariants:
@@ -2310,12 +2319,15 @@ func TestDisplayTaskExecutionTasksNameValidation(t *testing.T) {
 	exampleYml := `
 tasks:
 - name: one
+  exec_timeout_secs: 100 
   commands:
   - command: shell.exec
 - name: two
+  exec_timeout_secs: 100 
   commands:
   - command: shell.exec
 - name: display_three
+  exec_timeout_secs: 100 
   commands:
   - command: shell.exec
 buildvariants:

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2319,9 +2319,11 @@ func TestDisplayTaskExecutionTasksNameValidation(t *testing.T) {
 	exampleYml := `
 tasks:
 - name: one
+  exec_timeout_secs: 100
   commands:
   - command: shell.exec
 - name: two
+  exec_timeout_secs: 100
   commands:
   - command: shell.exec
 - name: display_three

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2319,11 +2319,9 @@ func TestDisplayTaskExecutionTasksNameValidation(t *testing.T) {
 	exampleYml := `
 tasks:
 - name: one
-  exec_timeout_secs: 100 
   commands:
   - command: shell.exec
 - name: two
-  exec_timeout_secs: 100 
   commands:
   - command: shell.exec
 - name: display_three


### PR DESCRIPTION
[EVG-15012](https://jira.mongodb.org/browse/EVG-15012)

### Description 
This PR contains a function that returns warning validation errors if not all tasks have timeouts set.

### Testing
Modified some unit tests in `project_validator_test.go` 