### PR TITLE
EVG-14869: Bump github.com/mongodb/amboy from v0.0.0-20211101172957-63ecb128b0be to v0.0.0-20211213142319-cd190dc4cf43

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/99designs/gqlgen v0.14.0
 	github.com/PuerkitoBio/rehttp v1.1.0
-	github.com/aws/aws-sdk-go v1.41.16
+	github.com/aws/aws-sdk-go v1.42.21
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
 	github.com/docker/go-connections v0.4.0
@@ -30,7 +30,7 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.2
-	github.com/mongodb/amboy v0.0.0-20211101172957-63ecb128b0be
+	github.com/mongodb/amboy v0.0.0-20211213142319-cd190dc4cf43
 	github.com/mongodb/anser v0.0.0-20211117165837-ac44bc8e3e4f
 	github.com/mongodb/ftdc v0.0.0-20211028165431-67f017692185
 	github.com/mongodb/grip v0.0.0-20211119154157-aca5d459de3f
@@ -44,7 +44,7 @@ require (
 	github.com/urfave/cli v1.22.5
 	github.com/vektah/gqlparser/v2 v2.2.0
 	github.com/vmware/govmomi v0.27.1
-	go.mongodb.org/mongo-driver v1.7.4
+	go.mongodb.org/mongo-driver v1.8.1
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/tools v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/aws/aws-sdk-go v1.41.11/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm
 github.com/aws/aws-sdk-go v1.41.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.41.16 h1:rNbPreEO4K2b8LwhHOe5+iNRH3Ih35L+H9U5tLdcevo=
 github.com/aws/aws-sdk-go v1.41.16/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.42.21 h1:ffd+rwCDBiJMYqNssW+oe9uPes4gQNfbYH9vH2Y1fo0=
+github.com/aws/aws-sdk-go v1.42.21/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -751,6 +753,8 @@ github.com/mongodb/amboy v0.0.0-20200527191935-07fdffff5b8c/go.mod h1:SfpzZNF2KZ
 github.com/mongodb/amboy v0.0.0-20211101161704-2b42087d24e6/go.mod h1:aYcnjrBUtbgB+naQ6FlVltCdprHv9Td2GOkQkZUqPvY=
 github.com/mongodb/amboy v0.0.0-20211101172957-63ecb128b0be h1:Mp3Ug8NdkteeINBvMgO30E32Jdz4qkl+j/ylhkzCMDU=
 github.com/mongodb/amboy v0.0.0-20211101172957-63ecb128b0be/go.mod h1:aYcnjrBUtbgB+naQ6FlVltCdprHv9Td2GOkQkZUqPvY=
+github.com/mongodb/amboy v0.0.0-20211213142319-cd190dc4cf43 h1:PBBtZwdO6kBWps5RiiQAIMm+GZ90u17Euw3qqqrhN8s=
+github.com/mongodb/amboy v0.0.0-20211213142319-cd190dc4cf43/go.mod h1:UhFnhbpO0GkcQEDFUeonNzKga17AkqXIjMc/NBQEPEc=
 github.com/mongodb/anser v0.0.0-20190422213746-1fb43a6d9968/go.mod h1:ESqf0zBEuYrqL0xADbIAFgdEOaBFpwZ4tkzY84ge+QA=
 github.com/mongodb/anser v0.0.0-20211116195831-fdc43007b59f/go.mod h1:jDikxuo5FKbiTMAb8B5AMT3QqFSNrim2+GiRTSCdazU=
 github.com/mongodb/anser v0.0.0-20211117165837-ac44bc8e3e4f h1:9ZK45c6cDom20/qplcvgmvLpY2z0/KcyvOkB+YqUkxw=
@@ -1043,6 +1047,8 @@ go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489/go.mod h1:yVHk9ub3C
 go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
 go.mongodb.org/mongo-driver v1.7.4 h1:sllcioag8Mec0LYkftYWq+cKNPIR4Kqq3iv9ZXY0g/E=
 go.mongodb.org/mongo-driver v1.7.4/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
+go.mongodb.org/mongo-driver v1.8.1 h1:OZE4Wni/SJlrcmSIBRYNzunX5TKxjrTS4jKSnA99oKU=
+go.mongodb.org/mongo-driver v1.8.1/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -1074,6 +1080,7 @@ golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,6 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.41.11/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.41.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-github.com/aws/aws-sdk-go v1.41.16 h1:rNbPreEO4K2b8LwhHOe5+iNRH3Ih35L+H9U5tLdcevo=
-github.com/aws/aws-sdk-go v1.41.16/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.42.21 h1:ffd+rwCDBiJMYqNssW+oe9uPes4gQNfbYH9vH2Y1fo0=
 github.com/aws/aws-sdk-go v1.42.21/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
@@ -751,8 +749,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mongodb/amboy v0.0.0-20200527191935-07fdffff5b8c/go.mod h1:SfpzZNF2KZUT5zO0/q4eUqW+EQe64MiY8xXmkBHZDqk=
 github.com/mongodb/amboy v0.0.0-20211101161704-2b42087d24e6/go.mod h1:aYcnjrBUtbgB+naQ6FlVltCdprHv9Td2GOkQkZUqPvY=
-github.com/mongodb/amboy v0.0.0-20211101172957-63ecb128b0be h1:Mp3Ug8NdkteeINBvMgO30E32Jdz4qkl+j/ylhkzCMDU=
-github.com/mongodb/amboy v0.0.0-20211101172957-63ecb128b0be/go.mod h1:aYcnjrBUtbgB+naQ6FlVltCdprHv9Td2GOkQkZUqPvY=
 github.com/mongodb/amboy v0.0.0-20211213142319-cd190dc4cf43 h1:PBBtZwdO6kBWps5RiiQAIMm+GZ90u17Euw3qqqrhN8s=
 github.com/mongodb/amboy v0.0.0-20211213142319-cd190dc4cf43/go.mod h1:UhFnhbpO0GkcQEDFUeonNzKga17AkqXIjMc/NBQEPEc=
 github.com/mongodb/anser v0.0.0-20190422213746-1fb43a6d9968/go.mod h1:ESqf0zBEuYrqL0xADbIAFgdEOaBFpwZ4tkzY84ge+QA=
@@ -1045,7 +1041,6 @@ go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
 go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
-go.mongodb.org/mongo-driver v1.7.4 h1:sllcioag8Mec0LYkftYWq+cKNPIR4Kqq3iv9ZXY0g/E=
 go.mongodb.org/mongo-driver v1.7.4/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
 go.mongodb.org/mongo-driver v1.8.1 h1:OZE4Wni/SJlrcmSIBRYNzunX5TKxjrTS4jKSnA99oKU=
 go.mongodb.org/mongo-driver v1.8.1/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=

--- a/rest/data/generate_test.go
+++ b/rest/data/generate_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,7 +78,6 @@ func newMockJob() *mockJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/building_container_image.go
+++ b/units/building_container_image.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -50,8 +49,6 @@ func makeBuildingContainerImageJob() *buildingContainerImageJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/cache_historical_test_data.go
+++ b/units/cache_historical_test_data.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/stats"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -60,7 +59,6 @@ func makeCacheHistoricalTestDataJob() *cacheHistoricalTestDataJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 )
@@ -42,7 +41,6 @@ func makeCheckBlockedTasksJob() *checkBlockedTasksJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -18,7 +18,6 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/v34/github"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -52,8 +51,6 @@ func makeCommitQueueJob() *commitQueueJob {
 			},
 		},
 	}
-	job.SetDependency(dependency.NewAlways())
-
 	return job
 }
 

--- a/units/crons_remote_fifteen_minute.go
+++ b/units/crons_remote_fifteen_minute.go
@@ -7,7 +7,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -36,7 +35,6 @@ func NewCronRemoteFifteenMinuteJob() amboy.Job {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	j.SetID(fmt.Sprintf("%s.%s", cronsRemoteFifteenMinuteJobName, utility.RoundPartOfHour(15).Format(TSFormat)))
 	return j
 }

--- a/units/crons_remote_fifteen_second.go
+++ b/units/crons_remote_fifteen_second.go
@@ -7,7 +7,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -36,7 +35,6 @@ func NewCronRemoteFifteenSecondJob() amboy.Job {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	j.SetID(fmt.Sprintf("%s.%s", cronsRemoteFifteenSecondJobName, utility.RoundPartOfMinute(15).Format(TSFormat)))
 	return j
 }

--- a/units/crons_remote_five_minute.go
+++ b/units/crons_remote_five_minute.go
@@ -7,7 +7,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -36,7 +35,6 @@ func NewCronRemoteFiveMinuteJob() amboy.Job {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	j.SetID(fmt.Sprintf("%s.%s", cronsRemoteFiveMinuteJobName, utility.RoundPartOfHour(5).Format(TSFormat)))
 	return j
 }

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -7,7 +7,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -36,7 +35,6 @@ func NewCronRemoteHourJob() amboy.Job {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	j.SetID(fmt.Sprintf("%s.%s", cronsRemoteHourJobName, utility.RoundPartOfHour(0).Format(TSFormat)))
 	return j
 }

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -7,7 +7,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -36,7 +35,6 @@ func NewCronRemoteMinuteJob() amboy.Job {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	j.SetID(fmt.Sprintf("%s.%s", cronsRemoteMinuteJobName, utility.RoundPartOfMinute(0).Format(TSFormat)))
 	return j
 }

--- a/units/data_cleanup_test_logs.go
+++ b/units/data_cleanup_test_logs.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -41,9 +40,6 @@ func makeTestLogsCleanupJob() *dataCleanupTestLogs {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/data_cleanup_testresults.go
+++ b/units/data_cleanup_testresults.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -43,9 +42,6 @@ func makeTestResultsCleanupJob() *dataCleanupTestResults {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/deco_host_notify.go
+++ b/units/deco_host_notify.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -42,8 +41,6 @@ func makeDecoHostsNotifyJob() *decoHostNotifyJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/duplicate_task_check.go
+++ b/units/duplicate_task_check.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -34,7 +33,6 @@ func makeDuplicateTaskCheckJob() *duplicateTaskCheckJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -18,7 +18,6 @@ import (
 	"github.com/evergreen-ci/evergreen/trigger"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -54,8 +53,6 @@ func makeEventNotifierJob() *eventNotifierJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/event_send.go
+++ b/units/event_send.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -44,8 +43,6 @@ func makeEventSendJob() *eventSendJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/validator"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	adb "github.com/mongodb/anser/db"
@@ -45,8 +44,6 @@ func makeGenerateTaskJob() *generateTasksJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -75,7 +74,6 @@ func makeGithubStatusUpdateJob() *githubStatusUpdateJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	j.SetPriority(1)
 	return j
 }

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen/scheduler"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -49,9 +48,6 @@ func makeHostAllocatorJob() *hostAllocatorJob {
 			},
 		},
 	}
-
-	job.SetDependency(dependency.NewAlways())
-
 	return job
 }
 

--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -55,9 +54,6 @@ func makeHostDrawdownJob() *hostDrawdownJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
-	j.SetPriority(2)
-
 	return j
 }
 
@@ -68,6 +64,7 @@ func NewHostDrawdownJob(env evergreen.Environment, drawdownInfo DrawdownInfo, ts
 	jobID := fmt.Sprintf("%s.%s.%s", hostDrawdownJobName, drawdownInfo.DistroID, ts)
 	j.SetID(jobID)
 	j.SetScopes([]string{jobID})
+	j.SetPriority(2)
 	return j
 }
 

--- a/units/host_execute.go
+++ b/units/host_execute.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -46,7 +45,6 @@ func makeHostExecuteJob() *hostExecuteJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/host_monitoring_container_state.go
+++ b/units/host_monitoring_container_state.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/pkg/errors"
@@ -42,8 +41,6 @@ func makeHostMonitorContainerStateJob() *hostMonitorContainerStateJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -45,8 +44,6 @@ func makeHostMonitorExternalState() *hostMonitorExternalStateCheckJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -58,15 +57,13 @@ func makeIdleHostJob() *idleHostJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
-	j.SetPriority(2)
-
 	return j
 }
 
 func NewIdleHostTerminationJob(env evergreen.Environment, id string) amboy.Job {
 	j := makeIdleHostJob()
 	j.env = env
+	j.SetPriority(2)
 	j.SetID(fmt.Sprintf("%s.%s", idleHostJobName, id))
 	return j
 }

--- a/units/host_monitoring_last_container_finish_time.go
+++ b/units/host_monitoring_last_container_finish_time.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 )
@@ -35,8 +34,6 @@ func makeLastContainerFinishTimeJob() *lastContainerFinishTimeJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/host_monitoring_parent_decommission.go
+++ b/units/host_monitoring_parent_decommission.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 )
@@ -39,8 +38,6 @@ func makeParentDecommissionJob() *parentDecommissionJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/host_setup_script.go
+++ b/units/host_setup_script.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/pkg/errors"
@@ -41,7 +40,6 @@ func makeHostSetupScriptJob() *hostSetupScriptJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/host_stats.go
+++ b/units/host_stats.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -50,8 +49,6 @@ func makeHostStats() *hostStatsJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -59,8 +58,6 @@ func makeCloudHostReadyJob() *cloudHostReadyJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	adb "github.com/mongodb/anser/db"
@@ -49,8 +48,6 @@ func makeHostTerminationJob() *hostTerminationJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/jasper_cleanup.go
+++ b/units/jasper_cleanup.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 )
@@ -45,7 +44,6 @@ func makeJasperManagerCleanup() *jasperManagerCleanup {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/oldest_image_removal.go
+++ b/units/oldest_image_removal.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/pkg/errors"
@@ -47,8 +46,6 @@ func makeOldestImageRemovalJob() *oldestImageRemovalJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -17,7 +17,6 @@ import (
 	"github.com/evergreen-ci/evergreen/validator"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -72,8 +71,6 @@ func makePatchIntentProcessor() *patchIntentProcessor {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -47,8 +46,6 @@ func makePeriodicBuildsJob() *periodicBuildJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/pod_creation.go
+++ b/units/pod_creation.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/pkg/errors"
@@ -50,8 +49,6 @@ func makePodCreationJob() *podCreationJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -54,7 +53,6 @@ func makePodTerminationJob() *podTerminationJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -47,8 +46,6 @@ func makeAgentDeployJob() *agentDeployJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -48,8 +47,6 @@ func makeAgentMonitorDeployJob() *agentMonitorDeployJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/provisioning_convert_host_to_legacy.go
+++ b/units/provisioning_convert_host_to_legacy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -43,7 +42,6 @@ func makeConvertHostToLegacyProvisioningJob() *convertHostToLegacyProvisioningJo
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/provisioning_convert_host_to_new.go
+++ b/units/provisioning_convert_host_to_new.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -46,7 +45,6 @@ func makeConvertHostToNewProvisioningJob() *convertHostToNewProvisioningJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -51,8 +50,6 @@ func makeCreateHostJob() *createHostJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/provisioning_restart_jasper.go
+++ b/units/provisioning_restart_jasper.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -50,7 +49,6 @@ func makeRestartJasperJob() *restartJasperJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -19,7 +19,6 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -60,8 +59,6 @@ func makeSetupHostJob() *setupHostJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -47,8 +46,6 @@ func makeUserDataDoneJob() *userDataDoneJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/reauthorize_user.go
+++ b/units/reauthorize_user.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -47,8 +46,6 @@ func makeReauthorizeUserJob() *reauthorizeUserJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/repotracker.go
+++ b/units/repotracker.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/repotracker"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -40,7 +39,6 @@ func makeRepotrackerJob() *repotrackerJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/scheduler.go
+++ b/units/scheduler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/scheduler"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -38,9 +37,6 @@ func makeDistroSchedulerJob() *distroSchedulerJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/scheduler_alias.go
+++ b/units/scheduler_alias.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/scheduler"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -40,9 +39,6 @@ func makeDistroAliasSchedulerJob() *distroAliasSchedulerJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
-
 	return j
 }
 

--- a/units/spawnhost_expiration_check.go
+++ b/units/spawnhost_expiration_check.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/pkg/errors"
@@ -40,7 +39,6 @@ func makeSpawnhostExpirationCheckJob() *spawnhostExpirationCheckJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/spawnhost_expiration_warning.go
+++ b/units/spawnhost_expiration_warning.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -41,7 +40,6 @@ func makeSpawnhostExpirationWarningsJob() *spawnhostExpirationWarningsJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/spawnhost_modify.go
+++ b/units/spawnhost_modify.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -44,7 +43,6 @@ func makeSpawnhostModifyJob() *spawnhostModifyJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/pkg/errors"
@@ -42,7 +41,6 @@ func makeSpawnhostStartJob() *spawnhostStartJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/pkg/errors"
@@ -42,7 +41,6 @@ func makeSpawnhostStopJob() *spawnhostStopJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/ssh_keys_update_cloud.go
+++ b/units/ssh_keys_update_cloud.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -41,7 +40,6 @@ func makeCloudUpdateSSHKeysJob() *cloudUpdateSSHKeysJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/ssh_keys_update_local.go
+++ b/units/ssh_keys_update_local.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/pkg/errors"
@@ -36,7 +35,6 @@ func makeLocalUpdateSSHKeysJob() *localUpdateSSHKeysJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/ssh_keys_update_static.go
+++ b/units/ssh_keys_update_static.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -41,7 +40,6 @@ func makeStaticUpdateSSHKeysJob() *staticUpdateSSHKeysJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/stats_amboy.go
+++ b/units/stats_amboy.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/management"
 	"github.com/mongodb/amboy/queue"
@@ -63,8 +62,6 @@ func makeAmboyStatsCollector() *amboyStatsCollector {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/stats_host.go
+++ b/units/stats_host.go
@@ -7,7 +7,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -47,7 +46,6 @@ func makeHostStatsCollector() *hostStatsCollector {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/stats_host_idle.go
+++ b/units/stats_host_idle.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -51,7 +50,6 @@ func newHostIdleJob() *collectHostIdleDataJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/stats_latency.go
+++ b/units/stats_latency.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -48,8 +47,6 @@ func makeLatencyStatsCollector() *latencyStatsCollector {
 		},
 		Duration: latencyStatsCollectorInterval,
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/stats_notifications.go
+++ b/units/stats_notifications.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -41,20 +40,18 @@ func makeNotificationsStatsCollector() *notificationsStatsCollector {
 		},
 		logger: logging.MakeGrip(grip.GetSender()),
 	}
-	j.SetDependency(dependency.NewAlways())
-	j.SetPriority(-1)
-	j.UpdateTimeInfo(amboy.JobTimeInfo{
-		MaxTime: time.Minute,
-	})
 
 	return j
 }
 
 func NewNotificationStatsCollector(id string) amboy.Job {
-	job := makeNotificationsStatsCollector()
-	job.SetID(fmt.Sprintf("%s-%s", notificationsStatsCollectorJobName, id))
-
-	return job
+	j := makeNotificationsStatsCollector()
+	j.SetID(fmt.Sprintf("%s-%s", notificationsStatsCollectorJobName, id))
+	j.SetPriority(-1)
+	j.UpdateTimeInfo(amboy.JobTimeInfo{
+		MaxTime: time.Minute,
+	})
+	return j
 }
 
 func (j *notificationsStatsCollector) Run(ctx context.Context) {

--- a/units/stats_queue.go
+++ b/units/stats_queue.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -42,7 +41,6 @@ func makeQueueStatsCollector() *queueStatsCollector {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/stats_sysinfo.go
+++ b/units/stats_sysinfo.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -42,7 +41,6 @@ func makeSysInfoStatsCollector() *sysInfoStatsCollector {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/stats_task.go
+++ b/units/stats_task.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -49,8 +48,6 @@ func makeTaskStatsCollector() *taskStatsCollector {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -46,7 +45,6 @@ func newTaskEndJob() *collectTaskEndDataJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -55,8 +54,6 @@ func makeTaskExecutionTimeoutMonitorJob() *taskExecutionTimeoutJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 
@@ -236,8 +233,6 @@ func makeTaskExecutionTimeoutPopulateJob() *taskExecutionTimeoutPopulationJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/task_stranded_cleanup.go
+++ b/units/task_stranded_cleanup.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -38,8 +37,6 @@ func makeStrandedTaskCleanupJob() *taskStrandedCleanupJob {
 			},
 		},
 	}
-
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/tasks_restart.go
+++ b/units/tasks_restart.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -34,7 +33,6 @@ func makeTaskRestartJob() *restartTasksJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/version_activation_catchup.go
+++ b/units/version_activation_catchup.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/repotracker"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -41,7 +40,6 @@ func makeVersionActivationCatchupJob() *versionActivationCatchup {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 
 }

--- a/units/volume_deletion_job.go
+++ b/units/volume_deletion_job.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/pkg/errors"
@@ -41,7 +40,6 @@ func makeVolumeDeletionJob() *volumeDeletionJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/volume_expiration_check.go
+++ b/units/volume_expiration_check.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/pkg/errors"
@@ -42,7 +41,6 @@ func makeVolumeExpirationCheckJob() *volumeExpirationCheckJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 

--- a/units/volume_expiration_warning.go
+++ b/units/volume_expiration_warning.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
@@ -41,7 +40,6 @@ func makeVolumeExpirationWarningsJob() *volumeExpirationWarningsJob {
 			},
 		},
 	}
-	j.SetDependency(dependency.NewAlways())
 	return j
 }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14869

### Description 
* Bump Amboy so that setting the dependency manager for jobs is optional (defaults to `dependency.NewAlways()`).
* Remove explicit setting of `dependency.NewAlways()` in jobs.

### Testing 
Tested in staging to make sure jobs still ran properly.
