### PR TITLE
EVG-15734: Upgrade Docker to v20.10.11

### DIFF
--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -1,6 +1,3 @@
-//go:build go1.7
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -25,7 +25,6 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -380,16 +379,11 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 		PublishAllPorts: containerHost.DockerOptions.PublishPorts,
 		ExtraHosts:      containerHost.DockerOptions.ExtraHosts,
 	}
-	os, arch := parentHost.Distro.Platform()
-	platformConf := &specs.Platform{
-		OS:           os,
-		Architecture: arch,
-	}
 
 	grip.Info(makeDockerLogMessage("ContainerCreate", parentHost.Id, message.Fields{"image": containerConf.Image}))
 
 	// Build container
-	if _, err := dockerClient.ContainerCreate(ctx, containerConf, hostConf, networkConf, platformConf, containerHost.Id); err != nil {
+	if _, err := dockerClient.ContainerCreate(ctx, containerConf, hostConf, networkConf, nil, containerHost.Id); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":   "Docker create API call failed",
 			"container": containerHost.Id,

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/docker_util.go
+++ b/cloud/docker_util.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/gce_client.go
+++ b/cloud/gce_client.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/gce_test.go
+++ b/cloud/gce_test.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/gce_util.go
+++ b/cloud/gce_util.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/vsphere_client.go
+++ b/cloud/vsphere_client.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/vsphere_mock_test.go
+++ b/cloud/vsphere_mock_test.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/vsphere_test.go
+++ b/cloud/vsphere_test.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/cloud/vsphere_util.go
+++ b/cloud/vsphere_util.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package cloud
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57
 	github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826
 	github.com/mongodb/jasper v0.0.0-20211213143437-1d373fd6f2c6
-	github.com/opencontainers/image-spec v1.0.2
 	golang.org/x/net v0.0.0-20211123203042-d83791d6bcd9 // indirect
 	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
 	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/aws/aws-sdk-go v1.41.16
 	github.com/cheynewallace/tabby v1.1.1
-	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
+	github.com/docker/docker v20.10.11+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evergreen-ci/birch v0.0.0-20211025210128-7f3409c2b515
@@ -44,7 +44,7 @@ require (
 	github.com/urfave/cli v1.22.5
 	github.com/vektah/gqlparser/v2 v2.2.0
 	github.com/vmware/govmomi v0.27.1
-	go.mongodb.org/mongo-driver v1.7.4
+	go.mongodb.org/mongo-driver v1.8.1
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/tools v0.1.7
@@ -64,7 +64,8 @@ require (
 	github.com/evergreen-ci/aviation v0.0.0-20211123195311-5ddfd75b3753 // indirect
 	github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57
 	github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826
-	github.com/mongodb/jasper v0.0.0-20211118154831-ee0b5744e192
+	github.com/mongodb/jasper v0.0.0-20211213143437-1d373fd6f2c6
+	github.com/opencontainers/image-spec v1.0.2
 	golang.org/x/net v0.0.0-20211123203042-d83791d6bcd9 // indirect
 	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
 	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,8 @@ github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TT
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible h1:SiUATuP//KecDjpOK2tvZJgeScYAklvyjfK8JZlU6fo=
-github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.11+incompatible h1:OqzI/g/W54LczvhnccGqniFoQghHx3pklbLuhfXpqGo=
+github.com/docker/docker v20.10.11+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
@@ -742,6 +742,7 @@ github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQ
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
+github.com/moby/term v0.0.0-20200312100748-672ec06f55cd h1:aY7OQNf2XqY/JQ6qREWamhI/81os/agb2BAGpcx5yWI=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -763,8 +764,8 @@ github.com/mongodb/grip v0.0.0-20211028155128-86e6e47bafdb/go.mod h1:0CTWxPoPDJP
 github.com/mongodb/grip v0.0.0-20211101151816-abbea0c0d465/go.mod h1:686LUUoh+vP85XVjr1ZYqC2mk52m138QmCZ4B2HZYkI=
 github.com/mongodb/grip v0.0.0-20211119154157-aca5d459de3f h1:orCkZ5JpxiulZ9S+qf6ljDU1Ugu3Q11PqTbM+/Zm6D4=
 github.com/mongodb/grip v0.0.0-20211119154157-aca5d459de3f/go.mod h1:686LUUoh+vP85XVjr1ZYqC2mk52m138QmCZ4B2HZYkI=
-github.com/mongodb/jasper v0.0.0-20211118154831-ee0b5744e192 h1:/Uqo3Nq/567BZFFZLA/CRG4IR5HCKGuLzc57srhV/bE=
-github.com/mongodb/jasper v0.0.0-20211118154831-ee0b5744e192/go.mod h1:tN7jl317E+1xojD1/DYRrTkQhBqpmkiSm23efJIdCds=
+github.com/mongodb/jasper v0.0.0-20211213143437-1d373fd6f2c6 h1:6uC/rZHvuS+UGglb1q6rFp4EE/0om9hQZb6LlN5pFaM=
+github.com/mongodb/jasper v0.0.0-20211213143437-1d373fd6f2c6/go.mod h1:+2hw73IRiLWBytkhAJkCFa1gYKvFFQ8EYu+HujcSvRk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
@@ -802,8 +803,9 @@ github.com/opencontainers/go-digest v1.0.0-rc1.0.20180430190053-c9281466c8b2/go.
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
+github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -1041,8 +1043,9 @@ go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
 go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
-go.mongodb.org/mongo-driver v1.7.4 h1:sllcioag8Mec0LYkftYWq+cKNPIR4Kqq3iv9ZXY0g/E=
 go.mongodb.org/mongo-driver v1.7.4/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
+go.mongodb.org/mongo-driver v1.8.1 h1:OZE4Wni/SJlrcmSIBRYNzunX5TKxjrTS4jKSnA99oKU=
+go.mongodb.org/mongo-driver v1.8.1/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -1074,6 +1077,7 @@ golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
@@ -1609,6 +1613,7 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/thirdparty/docker/docker_cleanup.go
+++ b/thirdparty/docker/docker_cleanup.go
@@ -14,7 +14,7 @@ import (
 // Cleanup removes all containers, images, and volumes from a Docker instance
 // if a Docker daemon is listening on the default socket
 func Cleanup(ctx context.Context, logger grip.Journaler) error {
-	dockerClient, err := client.NewClientWithOpts()
+	dockerClient, err := client.NewClientWithOpts(client.WithAPIVersionNegotiation())
 	if err != nil {
 		return errors.Wrap(err, "can't get Docker client")
 	}

--- a/thirdparty/docker/docker_cleanup_test.go
+++ b/thirdparty/docker/docker_cleanup_test.go
@@ -34,7 +34,7 @@ func TestCleanup(t *testing.T) {
 			var resp container.ContainerCreateCreatedBody
 			resp, err = dockerClient.ContainerCreate(ctx, &container.Config{
 				Image: "hello-world",
-			}, nil, nil, "")
+			}, nil, nil, nil, "")
 			require.NoError(t, err)
 			require.NoError(t, dockerClient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}))
 			var info types.Info
@@ -72,7 +72,7 @@ func TestCleanup(t *testing.T) {
 		"Cleanup": func(*testing.T) {
 			resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
 				Image: "hello-world",
-			}, nil, nil, "")
+			}, nil, nil, nil, "")
 			require.NoError(t, err)
 			require.NoError(t, dockerClient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}))
 			info, err := dockerClient.Info(ctx)

--- a/thirdparty/docker/docker_cleanup_test.go
+++ b/thirdparty/docker/docker_cleanup_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestCleanup(t *testing.T) {
-	dockerClient, err := client.NewClientWithOpts()
+	dockerClient, err := client.NewClientWithOpts(client.WithAPIVersionNegotiation())
 	require.NoError(t, err)
 	ctx := context.Background()
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15734

### Description 
Upgrade Docker to the latest tagged version and bump Jasper to be compatible with the latest version. Ordinarily, a Go module would allow multiple major versions of a transient Go module dependency (e.g. this repo can use v1 of github.com/urfave/cli but dependent Go modules can use github.com/urfave/cli/v2 without conflicting with this repo). However, because Docker does not use Go modules, we cannot have multiple different major versions of the Docker SDK (hence why the Go modules has the `+incompatible` tag on it), so Evergreen and all its dependencies must agree to use Docker v20 now.

### Testing 
Verified in staging that the container building process still works.