### PR TITLE
EVG-15080: Add projects and repos to project_vars collection

### DIFF
--- a/testdata/local/project_vars.json
+++ b/testdata/local/project_vars.json
@@ -2,3 +2,7 @@
 {"_id":"sys-perf","vars":{},"private_vars":{}}
 {"_id":"evergreen","vars":{},"private_vars":{}}
 {"_id":"performance","vars":{},"private_vars":{}}
+{"_id":"mongodb-mongo-master","vars":{},"private_vars":{}}
+{"_id":"mongodb-mongo-test","vars":{},"private_vars":{}}
+{"_id":"spruce","vars":{},"private_vars":{}}
+{"_id":"602d70a2b2373672ee493184","vars":{},"private_vars":{}}


### PR DESCRIPTION
Facilitates development for [EVG-15080](https://jira.mongodb.org/browse/EVG-15080)

### Description 
The ProjectSettings resolver [returns an error](https://github.com/evergreen-ci/evergreen/blob/635f00135284b39a864edcd5c7fbe6a7cb6ee2a3/graphql/util.go#L1273-L1275) if a project/repo does not have a corresponding document in the `project_vars` collection. This PR assumes that this is enforced on prod and is just a matter of invalid local data. (If not, we should consider not erroring here.)

Create a document for all projects in the project_ref collection, and repos in the repo_ref collection, so that they have usable settings pages.