### PR TITLE
EVG-15230: add field to distinguish pod types

### DIFF
--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -14,6 +14,8 @@ import (
 type Pod struct {
 	// ID is the unique identifier for the metadata document.
 	ID string `bson:"_id" json:"id"`
+	// Type indicates the type of pod that this is.
+	Type Type `bson:"type" json:"type"`
 	// Status is the current state of the pod.
 	Status Status `bson:"status"`
 	// Secret is the shared secret between the server and the pod for
@@ -27,6 +29,15 @@ type Pod struct {
 	// Resources are external resources that are owned and managed by this pod.
 	Resources ResourceInfo `bson:"resource_info,omitempty" json:"resource_info,omitempty"`
 }
+
+// Type is the type of pod.
+type Type string
+
+const (
+	// TypeAgent indicates that it is a pod that is running the Evergreen agent
+	// in a container.
+	TypeAgent = "agent"
+)
 
 // Status represents a possible state for a pod.
 type Status string

--- a/rest/data/pod.go
+++ b/rest/data/pod.go
@@ -266,6 +266,7 @@ const (
 // addAgentPodSettings adds any pod configuration that is necessary to run the
 // agent.
 func addAgentPodSettings(p *pod.Pod) {
+	p.Type = pod.TypeAgent
 	if p.Secret.Name == "" {
 		p.Secret.Name = podSecretEnvVar
 	}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15230

### Description 
I added a field to distinguish the type of pod. While there's only one type of pod today for running agents, it's reasonable to assume that there will be more uses aside from running agents in the future (e.g. spawn pods).

This is future-proofing against the pain point that's arisen with multiplexing many different types of host on a single data model, where the different hosts are distinguished using a variety of fields so that different pieces of code only operate on the "right" type of host. For example, container parents have their own field `HasContainers`, containers have their own field `ParentID`, spawn hosts are distinguished with a combination of fields, hosts running agents are distinguished by checking if the host user is "mci". To avoid the proliferation of several type-determining strings/booleans and reduce the complexity of querying for a "type" of pod, I added a single field that should accomplish the same goal of distinguishing between different resource purposes.

### Testing 
N/A
