### PR TITLE
EVG-15957: improve idle termination message readability

### DIFF
--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -173,12 +173,11 @@ func (j *idleHostJob) checkAndTerminateHost(ctx context.Context, h *host.Host) e
 	}
 
 	// if we haven't heard from the host or it's been idle for longer than the cutoff, we should terminate
-	terminateReason := ""
-
+	var terminateReason string
 	if communicationTime >= idleThreshold {
-		terminateReason = fmt.Sprintf("host is idle or unreachable, communication time %d over threshold minutes %d", communicationTime, idleThreshold)
+		terminateReason = fmt.Sprintf("host is idle or unreachable, communication time %s over threshold time %s", communicationTime.String(), idleThreshold)
 	} else if idleTime >= idleThreshold {
-		terminateReason = fmt.Sprintf("host is idle or unreachable, idleTime %d over threshold minutes %d", idleTime, idleThreshold)
+		terminateReason = fmt.Sprintf("host is idle or unreachable, idle time %s over threshold time %s", idleTime, idleThreshold)
 	}
 	if terminateReason != "" {
 		j.Terminated++


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15957

### Description 
This improves the message formatting in the event logs. The time durations are currently expressed in nanoseconds in the logs, so I changed it to the human-readable hours-minutes-seconds string format (e.g. 5h20m10s).