### PR TITLE
EVG-15948 set remote path correctly for included yamls

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -600,8 +600,14 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		}
 		var yaml []byte
 		opts.Identifier = identifier
+		opts.RemotePath = path.FileName
+		grip.Debug(message.Fields{
+			"message":     "retrieving included yaml file",
+			"remote_path": opts.RemotePath,
+			"read_from":   opts.ReadFileFrom,
+			"module":      path.Module,
+		})
 		if path.Module != "" {
-			opts.RemotePath = path.FileName
 			yaml, err = retrieveFileForModule(ctx, *opts, intermediateProject.Modules, path.Module)
 		} else {
 			yaml, err = retrieveFile(ctx, *opts)


### PR DESCRIPTION
[EVG-15948](https://jira.mongodb.org/browse/EVG-15948)

### Description 
A mistake was made when adding the module functionality to only set RemotePath in that case. I corrected this, and added some logging to make debugging any issues with include easier in the future.

### Testing 
Tested by running validate and creating a patch with an included file, similar to the user's. (Example: https://spruce-staging.corp.mongodb.com/patch/61ba4b7f9dbe327410f3fac6/configure/tasks)
