### PR TITLE
EVG-15919 update admins in project ref only if successful

### DIFF
--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1595,7 +1595,9 @@ func TestUpdateAdminRoles(t *testing.T) {
 	}
 	require.NoError(t, p.Insert())
 
-	assert.NoError(t, p.UpdateAdminRoles([]string{newAdmin.Id}, []string{oldAdmin.Id}))
+	modified, err := p.UpdateAdminRoles([]string{newAdmin.Id}, []string{oldAdmin.Id})
+	assert.NoError(t, err)
+	assert.True(t, modified)
 	oldAdminFromDB, err := user.FindOneById(oldAdmin.Id)
 	assert.NoError(t, err)
 	assert.Len(t, oldAdminFromDB.Roles(), 0)
@@ -1608,6 +1610,27 @@ func TestUpdateAdminRolesError(t *testing.T) {
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection, user.Collection))
 	env := evergreen.GetEnvironment()
 	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	oldAdmin := user.DBUser{
+		Id:          "oldAdmin",
+		SystemRoles: []string{"admin"},
+	}
+	require.NoError(t, oldAdmin.Insert())
+	newAdmin := user.DBUser{
+		Id: "newAdmin",
+	}
+	require.NoError(t, newAdmin.Insert())
+	p := ProjectRef{
+		Id:     "proj",
+		Admins: []string{oldAdmin.Id},
+	}
+	require.NoError(t, p.Insert())
+
+	// check that, without a valid role, the whole update fails
+	modified, err := p.UpdateAdminRoles([]string{"nonexistent-user", newAdmin.Id}, []string{"nonexistent-user", oldAdmin.Id})
+	assert.Error(t, err)
+	assert.False(t, modified)
+	assert.Equal(t, p.Admins, []string{oldAdmin.Id})
+
 	rm := env.RoleManager()
 	adminScope := gimlet.Scope{
 		ID:        evergreen.AllProjectsScope,
@@ -1621,22 +1644,11 @@ func TestUpdateAdminRolesError(t *testing.T) {
 		Permissions: adminPermissions,
 	}
 	require.NoError(t, rm.UpdateRole(adminRole))
-	oldAdmin := user.DBUser{
-		Id:          "oldAdmin",
-		SystemRoles: []string{"admin"},
-	}
-	require.NoError(t, oldAdmin.Insert())
-	newAdmin := user.DBUser{
-		Id: "newAdmin",
-	}
-	require.NoError(t, newAdmin.Insert())
-	p := ProjectRef{
-		Id: "proj",
-	}
-	require.NoError(t, p.Insert())
 
 	// check that the existing users have been added and removed while returning an error
-	assert.Error(t, p.UpdateAdminRoles([]string{"nonexistent-user", newAdmin.Id}, []string{"nonexistent-user", oldAdmin.Id}))
+	modified, err = p.UpdateAdminRoles([]string{"nonexistent-user", newAdmin.Id}, []string{"nonexistent-user", oldAdmin.Id})
+	assert.Error(t, err)
+	assert.True(t, modified)
 	oldAdminFromDB, err := user.FindOneById(oldAdmin.Id)
 	assert.NoError(t, err)
 	assert.Len(t, oldAdminFromDB.Roles(), 0)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -251,7 +251,8 @@ func (pc *DBProjectConnector) UpdateAdminRoles(project *model.ProjectRef, toAdd,
 	if project == nil {
 		return errors.New("no project found")
 	}
-	return project.UpdateAdminRoles(toAdd, toDelete)
+	_, err := project.UpdateAdminRoles(toAdd, toDelete)
+	return err
 }
 
 // RemoveAdminFromProjects removes a user from all Admins slices of every project

--- a/service/project.go
+++ b/service/project.go
@@ -811,7 +811,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	toAdd, toRemove := utility.StringSliceSymmetricDifference(projectRef.Admins, origProjectRef.Admins)
-	if err = projectRef.UpdateAdminRoles(toAdd, toRemove); err != nil {
+	if _, err = projectRef.UpdateAdminRoles(toAdd, toRemove); err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}


### PR DESCRIPTION
[EVG-15919](https://jira.mongodb.org/browse/EVG-15919)

### Description 
We partially handled this in https://jira.mongodb.org/browse/EVG-15428 but we didn't handle the case where we exit before even trying to add/remove admins.

### Testing 
Added a case to the test.
