### PR TITLE
EVG-15979 redact private variables in the UI

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -450,7 +450,7 @@ func (r *projectSettingsResolver) GithubWebhooksEnabled(ctx context.Context, obj
 }
 
 func (r *projectSettingsResolver) Vars(ctx context.Context, obj *restModel.APIProjectSettings) (*restModel.APIProjectVars, error) {
-	return getAPIVarsForProject(ctx, utility.FromStringPtr(obj.ProjectRef.Id))
+	return getRedactedAPIVarsForProject(ctx, utility.FromStringPtr(obj.ProjectRef.Id))
 }
 
 func (r *projectSettingsResolver) Aliases(ctx context.Context, obj *restModel.APIProjectSettings) ([]*restModel.APIProjectAlias, error) {
@@ -469,7 +469,7 @@ func (r *repoSettingsResolver) GithubWebhooksEnabled(ctx context.Context, obj *r
 }
 
 func (r *repoSettingsResolver) Vars(ctx context.Context, obj *restModel.APIProjectSettings) (*restModel.APIProjectVars, error) {
-	return getAPIVarsForProject(ctx, utility.FromStringPtr(obj.ProjectRef.Id))
+	return getRedactedAPIVarsForProject(ctx, utility.FromStringPtr(obj.ProjectRef.Id))
 }
 
 func (r *repoSettingsResolver) Aliases(ctx context.Context, obj *restModel.APIProjectSettings) ([]*restModel.APIProjectAlias, error) {

--- a/graphql/tests/projectSettings/results.json
+++ b/graphql/tests/projectSettings/results.json
@@ -118,7 +118,7 @@
         "data": {
           "projectSettings": {
             "vars": {
-              "vars": {"hello": "world", "foo":  "bar"},
+              "vars": {"hello": "", "foo":  "bar"},
               "privateVars": ["hello"]
             }
           }

--- a/graphql/tests/repoSettings/results.json
+++ b/graphql/tests/repoSettings/results.json
@@ -115,7 +115,7 @@
         "data": {
           "repoSettings": {
             "vars": {
-              "vars": {"hello": "world", "foo":  "bar"},
+              "vars": {"hello": "", "foo":  "bar"},
               "privateVars": ["hello"]
             }
           }

--- a/graphql/tests/saveProjectSettingsForSection/results.json
+++ b/graphql/tests/saveProjectSettingsForSection/results.json
@@ -11,7 +11,7 @@
               "spawnHostScriptPath": ""
             },
             "vars": {
-              "vars": {"hello": "world", "foo":  "bar"}
+              "vars": {"hello": "", "foo":  "bar"}
             }
           }
         }
@@ -23,7 +23,7 @@
         "data": {
           "saveProjectSettingsForSection": {
             "vars": {
-              "vars": {"goodbye":  "now"},
+              "vars": {"goodbye":  ""},
               "privateVars": ["goodbye"]
             }
           }

--- a/graphql/tests/saveRepoSettingsForSection/queries/generalSection.graphql
+++ b/graphql/tests/saveRepoSettingsForSection/queries/generalSection.graphql
@@ -16,6 +16,7 @@ mutation {
         }
         vars {
             vars ## should be unchanged
+            privateVars
         }
     }
 }

--- a/graphql/tests/saveRepoSettingsForSection/results.json
+++ b/graphql/tests/saveRepoSettingsForSection/results.json
@@ -11,7 +11,9 @@
               "spawnHostScriptPath": ""
             },
             "vars": {
-              "vars": {"hello": "something-different"}
+              "vars": {"hello": ""},
+              "privateVars": ["hello"]
+
             }
           }
         }
@@ -23,7 +25,7 @@
         "data": {
           "saveRepoSettingsForSection": {
             "vars": {
-              "vars": {"goodbye":  "now"},
+              "vars": {"goodbye":  ""},
               "privateVars": ["goodbye"]
             }
           }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1265,7 +1265,7 @@ func (buildVariantOptions *BuildVariantOptions) isPopulated() bool {
 	return len(buildVariantOptions.Tasks) > 0 || len(buildVariantOptions.Variants) > 0 || len(buildVariantOptions.Statuses) > 0
 }
 
-func getAPIVarsForProject(ctx context.Context, projectId string) (*restModel.APIProjectVars, error) {
+func getRedactedAPIVarsForProject(ctx context.Context, projectId string) (*restModel.APIProjectVars, error) {
 	vars, err := model.FindOneProjectVars(projectId)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding project vars for '%s': %s", projectId, err.Error()))
@@ -1273,6 +1273,7 @@ func getAPIVarsForProject(ctx context.Context, projectId string) (*restModel.API
 	if vars == nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("vars for '%s' don't exist", projectId))
 	}
+	vars = vars.RedactPrivateVars()
 	res := &restModel.APIProjectVars{}
 	if err = res.BuildFromService(vars); err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("problem building APIProjectVars from service: %s", err.Error()))

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -344,6 +344,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			settings, err := dc.SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageVariablesSection, false, "me")
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
+			assert.Equal(t, settings.Vars.Vars["banana"], "") // confirm that this is redacted
 			varsFromDb, err := model.FindOneProjectVars(updatedVars.Id)
 			assert.NoError(t, err)
 			assert.NotNil(t, varsFromDb)


### PR DESCRIPTION
[EVG-15979](https://jira.mongodb.org/browse/EVG-15979)

### Description 
After discussion with Sophie, determined that private variables should be redacted before sending to the UI, and the backend save function should ensure that these are still saved correctly. This assumes that private variable values cannot be modified on the UI.

To do this, changed the UpdateProjectVars function to overwrite the existing variables object (i.e. using Upsert instead of FindAndModify) bc since the UI is sending the new variables and not the diff this is actually easier to reason about.

### Testing 
Added to the frontend and backend tests.