### PR TITLE
EVG-15656 add gated flag to allow specifying cq patch author

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2021-11-12"
+	ClientVersion = "2021-12-17"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2021-12-02a"

--- a/globals.go
+++ b/globals.go
@@ -819,7 +819,7 @@ var (
 		Description: "Not able to view or edit tasks",
 		Value:       0,
 	}
-	PatchSubmitBot = PermissionLevel{
+	PatchSubmitAdmin = PermissionLevel{
 		Description: "Submit/edit patches, and submit patches on behalf of users",
 		Value:       20,
 	}

--- a/globals.go
+++ b/globals.go
@@ -819,6 +819,10 @@ var (
 		Description: "Not able to view or edit tasks",
 		Value:       0,
 	}
+	PatchSubmitBot = PermissionLevel{
+		Description: "Submit/edit patches, and submit patches on behalf of users",
+		Value:       20,
+	}
 	PatchSubmit = PermissionLevel{
 		Description: "Submit and edit patches",
 		Value:       10,

--- a/operations/http.go
+++ b/operations/http.go
@@ -539,6 +539,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		Parameters        []patch.Parameter  `json:"parameters"`
 		GitMetadata       patch.GitMetadata  `json:"git_metadata"`
 		ReuseDefinition   bool               `json:"reuse_definition"`
+		GithubAuthor      string             `json:"github_author"`
 	}{
 		Description:       incomingPatch.description,
 		Project:           incomingPatch.projectName,
@@ -558,6 +559,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		Parameters:        incomingPatch.parameters,
 		GitMetadata:       incomingPatch.gitMetadata,
 		ReuseDefinition:   incomingPatch.reuseDefinition,
+		GithubAuthor:      incomingPatch.githubAuthor,
 	}
 
 	rPipe, wPipe := io.Pipe()

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -76,6 +76,7 @@ type patchParams struct {
 	TriggerAliases    []string
 	Parameters        []patch.Parameter
 	ReuseDefinition   bool
+	GithubAuthor      string
 }
 
 type patchSubmission struct {
@@ -97,6 +98,7 @@ type patchSubmission struct {
 	backportOf        patch.BackportInfo
 	gitMetadata       patch.GitMetadata
 	reuseDefinition   bool
+	githubAuthor      string
 }
 
 func (p *patchParams) createPatch(ac *legacyClient, diffData *localDiff) (*patch.Patch, error) {
@@ -119,6 +121,7 @@ func (p *patchParams) createPatch(ac *legacyClient, diffData *localDiff) (*patch
 		gitMetadata:       diffData.gitMetadata,
 		reuseDefinition:   p.ReuseDefinition,
 		path:              p.Path,
+		githubAuthor:      p.GithubAuthor,
 	}
 
 	newPatch, err := ac.PutPatch(patchSub)

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -113,10 +113,6 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 
 	patchID := mgobson.NewObjectId()
 	author := dbUser.Id
-	grip.Debug(message.Fields{
-		"message":       "testing user",
-		"github_author": data.GithubAuthor,
-	})
 	if data.GithubAuthor != "" {
 		opts := gimlet.PermissionOpts{
 			Resource:      pref.Id,
@@ -131,6 +127,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		specifiedUser, err := user.FindByGithubName(data.GithubAuthor)
 		if err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error looking for specified author"))
+			return
 		}
 		if specifiedUser != nil {
 			grip.Info(message.Fields{

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -122,7 +122,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 			Resource:      pref.Id,
 			ResourceType:  evergreen.ProjectResourceType,
 			Permission:    evergreen.PermissionPatches,
-			RequiredLevel: evergreen.PatchSubmitBot.Value,
+			RequiredLevel: evergreen.PatchSubmitAdmin.Value,
 		}
 		if !dbUser.HasPermission(opts) {
 			as.LoggedError(w, r, http.StatusUnauthorized, errors.New("user is not authorized to patch on behalf of other users"))

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -7,14 +7,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/model/user"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/evergreen/util"


### PR DESCRIPTION
[EVG-15656](https://jira.mongodb.org/browse/EVG-15656)

### Description 
There's a lot of detail in the ticket but this adds a flag so that the server bot that creates commit queue patches on behalf of server engineers can specify github usernames, so that the patch will correctly be linked to the real author. 

Because this is a strong ability, I'll create a new bot for the server team to use that will have this permission. If the user doesn't have their github username on their profile, the patch will be listed as authored by "Commit Queue Bot User" or something like that, rather than Ethan Zhang, so still a step up.

### Testing 
I created this patch on Brian's behalf. https://spruce-staging.corp.mongodb.com/version/61bcf01697b1d3404fe84ca3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
He also still received notifications from it.