### PR TITLE
EVG-15797 Handle empty task status errors

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1469,13 +1469,13 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 		"execution": t.Execution,
 		"project":   t.Project,
 		"details":   t.Details,
-		"status":    detail.Status,
 	})
 	if detail.Status == "" {
-		grip.Error(message.Fields{
-			"error":   errors.WithStack(errors.New("task end details status detected as empty, marking status as failed")),
+		grip.Error(message.WrapError(errors.WithStack(errors.New("task status is empty, marking as failed")), message.Fields{
+			"message": "empty task details",
 			"details": detail,
-		})
+			"task_id": t.Id,
+		}))
 		detail.Status = evergreen.TaskFailed
 	}
 	return UpdateOne(

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1469,7 +1469,15 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 		"execution": t.Execution,
 		"project":   t.Project,
 		"details":   t.Details,
+		"status":    detail.Status,
 	})
+	if detail.Status == "" {
+		grip.Error(message.Fields{
+			"error":   errors.WithStack(errors.New("task end details status detected as empty, marking status as failed")),
+			"details": detail,
+		})
+		detail.Status = evergreen.TaskFailed
+	}
 	return UpdateOne(
 		bson.M{
 			IdKey: t.Id,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -242,6 +242,13 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 		} else if !t.IsFinished() {
 			if detail != nil {
 				grip.Debugln(msg, "marking as failed")
+				if detail.Status == "" {
+					grip.Error(message.Fields{
+						"error":   errors.WithStack(errors.New("task end details status detected as empty, marking status as failed")),
+						"details": detail,
+					})
+					detail.Status = evergreen.TaskFailed
+				}
 				if t.DisplayOnly {
 					for _, etId := range t.ExecutionTasks {
 						execTask, err = task.FindOneId(etId)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -243,10 +243,11 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 			if detail != nil {
 				grip.Debugln(msg, "marking as failed")
 				if detail.Status == "" {
-					grip.Error(message.Fields{
-						"error":   errors.WithStack(errors.New("task end details status detected as empty, marking status as failed")),
+					grip.Error(message.WrapError(errors.WithStack(errors.New("task status is empty, marking as failed")), message.Fields{
+						"message": "empty task details",
 						"details": detail,
-					})
+						"task_id": t.Id,
+					}))
 					detail.Status = evergreen.TaskFailed
 				}
 				if t.DisplayOnly {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -242,14 +242,6 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 		} else if !t.IsFinished() {
 			if detail != nil {
 				grip.Debugln(msg, "marking as failed")
-				if detail.Status == "" {
-					grip.Error(message.WrapError(errors.WithStack(errors.New("task status is empty, marking as failed")), message.Fields{
-						"message": "empty task details",
-						"details": detail,
-						"task_id": t.Id,
-					}))
-					detail.Status = evergreen.TaskFailed
-				}
 				if t.DisplayOnly {
 					for _, etId := range t.ExecutionTasks {
 						execTask, err = task.FindOneId(etId)

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -309,6 +309,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		"operation":   "mark end",
 		"duration":    time.Since(finishTime),
 		"should_exit": endTaskResp.ShouldExit,
+		"status":      details.Status,
 	}
 
 	if dt != nil {

--- a/units/task_stranded_cleanup.go
+++ b/units/task_stranded_cleanup.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -81,7 +82,12 @@ func (j *taskStrandedCleanupJob) Run(ctx context.Context) {
 		if time.Since(t.CreateTime) >= 2*7*24*time.Hour {
 			tasksToDeactivate = append(tasksToDeactivate, t)
 		} else {
-			j.AddError(model.TryResetTask(t.Id, evergreen.User, j.ID(), &t.Details))
+			details := &apimodels.TaskEndDetail{
+				Type:        evergreen.CommandTypeSystem,
+				Status:      evergreen.TaskFailed,
+				Description: evergreen.TaskDescriptionStranded,
+			}
+			j.AddError(model.TryResetTask(t.Id, evergreen.User, j.ID(), details))
 		}
 	}
 	if len(tasksToDeactivate) > 0 {

--- a/units/task_stranded_cleanup.go
+++ b/units/task_stranded_cleanup.go
@@ -3,10 +3,10 @@ package units
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/evergreen/apimodels"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"


### PR DESCRIPTION
[EVG-15797](https://jira.mongodb.org/browse/EVG-15797)

### Description 
Added additional error logging when a task status is set to an empty string, and in these cases set the status to failed in order to preserve UI functionality.  Changed stranded task cleanup job to pass in a hardcoded details struct instead of &t.Details since an initial investigation indicated this might be an issue.