### PR TITLE
EVG-16005 Remove webhook check from created_ticket endpoint

### DIFF
--- a/rest/route/annotations.go
+++ b/rest/route/annotations.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/annotations"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/data"
@@ -411,21 +410,6 @@ func (h *createdTicketByTaskPutHandler) Parse(ctx context.Context, r *http.Reque
 	if t == nil {
 		return gimlet.ErrorResponse{
 			Message:    fmt.Sprintf("the task '%s' does not exist", h.taskId),
-			StatusCode: http.StatusBadRequest,
-		}
-	}
-	// if there is no custom webhook configured, return an error because the
-	// purpose of this endpoint is to store the ticket created by the web-hook
-	_, ok, err := model.IsWebhookConfigured(t.Project, t.Version)
-	if err != nil {
-		return gimlet.ErrorResponse{
-			Message:    fmt.Sprintf("Error while retrieving webhook config: '%s'", err.Error()),
-			StatusCode: http.StatusBadRequest,
-		}
-	}
-	if !ok {
-		return gimlet.ErrorResponse{
-			Message:    fmt.Sprintf("there is no webhook configured for '%s'", t.Project),
 			StatusCode: http.StatusBadRequest,
 		}
 	}

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -754,19 +754,13 @@ func TestCreatedTicketByTaskPutHandlerParse(t *testing.T) {
 	jsonBody, err := json.Marshal(ticket)
 	require.NoError(t, err)
 	buffer := bytes.NewBuffer(jsonBody)
-	r, err := http.NewRequest("PUT", "/task/t1/created_ticket?execution=1", buffer)
-	r = gimlet.SetURLVars(r, map[string]string{"task_id": "t1"})
-	assert.NoError(t, err)
-	err = h.Parse(ctx, r)
-	assert.Contains(t, err.Error(), "there is no webhook configured for 'testProject'")
-
 	p.TaskAnnotationSettings = evergreen.AnnotationsSettings{
 		FileTicketWebhook: evergreen.WebHook{
 			Endpoint: "random",
 		},
 	}
 	assert.NoError(t, p.Upsert())
-	r, err = http.NewRequest("PUT", "/task/t1/created_ticket?execution=1", buffer)
+	r, err := http.NewRequest("PUT", "/task/t1/created_ticket?execution=1", buffer)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "t1"})
 	assert.NoError(t, err)
 	assert.NoError(t, h.Parse(ctx, r))


### PR DESCRIPTION
[EVG-16005](https://jira.mongodb.org/browse/EVG-16005)

### Description 
When this endpoint was created, it was only meant to be used in conjunction with a webhook set up to be hooked up to the file ticket button. However, due to a new project to move build failure tickets, a new use case came up that warrants allowing the endpoint to be used independently. 

### Testing 
none 
