### PR TITLE
EVG-15493: add REST route to get pod information

### DIFF
--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -36,7 +36,7 @@ type Type string
 const (
 	// TypeAgent indicates that it is a pod that is running the Evergreen agent
 	// in a container.
-	TypeAgent = "agent"
+	TypeAgent Type = "agent"
 )
 
 // Status represents a possible state for a pod.

--- a/rest/data/pod.go
+++ b/rest/data/pod.go
@@ -169,6 +169,9 @@ func (c *MockPodConnector) FindPodByID(id string) (*model.APIPod, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "finding pod")
 	}
+	if p == nil {
+		return nil, nil
+	}
 
 	var apiPod model.APIPod
 	if err := apiPod.BuildFromService(p); err != nil {

--- a/rest/data/pod_test.go
+++ b/rest/data/pod_test.go
@@ -45,7 +45,7 @@ func TestPodConnector(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, apiPod)
 
-			require.NotZero(t, apiPod.Status)
+			assert.Equal(t, model.PodTypeAgent, apiPod.Type)
 			assert.Equal(t, model.PodStatusInitializing, apiPod.Status)
 			assert.Equal(t, podSecretEnvVar, utility.FromStringPtr(apiPod.Secret.Name))
 			assert.Equal(t, utility.FromStringPtr(p.Secret), utility.FromStringPtr(apiPod.Secret.Value))
@@ -60,6 +60,7 @@ func TestPodConnector(t *testing.T) {
 		"FindPodByIDSucceeds": func(t *testing.T, conn Connector) {
 			p := pod.Pod{
 				ID:     "id",
+				Type:   pod.TypeAgent,
 				Status: pod.StatusInitializing,
 				Secret: pod.Secret{
 					Name:       podSecretEnvVar,
@@ -85,7 +86,8 @@ func TestPodConnector(t *testing.T) {
 		},
 		"FindPodByExternalIDSucceeds": func(t *testing.T, conn Connector) {
 			p := pod.Pod{
-				ID: "id",
+				ID:   "id",
+				Type: pod.TypeAgent,
 				Secret: pod.Secret{
 					Name:       podSecretEnvVar,
 					Value:      "secret_value",
@@ -115,6 +117,7 @@ func TestPodConnector(t *testing.T) {
 		"UpdatePodStatusSucceeds": func(t *testing.T, conn Connector) {
 			p := pod.Pod{
 				ID:     "id",
+				Type:   pod.TypeAgent,
 				Status: pod.StatusRunning,
 			}
 			require.NoError(t, p.Insert())
@@ -136,7 +139,8 @@ func TestPodConnector(t *testing.T) {
 		},
 		"CheckPodSecret": func(t *testing.T, conn Connector) {
 			p := pod.Pod{
-				ID: "id",
+				ID:   "id",
+				Type: pod.TypeAgent,
 				Secret: pod.Secret{
 					Name:       podSecretEnvVar,
 					Value:      "secret_value",

--- a/rest/model/pod.go
+++ b/rest/model/pod.go
@@ -177,16 +177,13 @@ func (t *APIPodType) BuildFromService(pt pod.Type) error {
 }
 
 // ToService converts a REST API pod type into a service-layer pod type.
-func (t *APIPodType) ToService() (*pod.Type, error) {
-	if t == nil {
-		return nil, errors.New("nonexistent pod type")
-	}
+func (t APIPodType) ToService() (*pod.Type, error) {
 	var converted pod.Type
-	switch *t {
+	switch t {
 	case PodTypeAgent:
 		converted = pod.TypeAgent
 	default:
-		return nil, errors.Errorf("unrecognized pod type '%s'", *t)
+		return nil, errors.Errorf("unrecognized pod type '%s'", t)
 	}
 	return &converted, nil
 }
@@ -225,12 +222,9 @@ func (s *APIPodStatus) BuildFromService(ps pod.Status) error {
 }
 
 // ToService converts a REST API pod status into a service-layer pod status.
-func (s *APIPodStatus) ToService() (*pod.Status, error) {
-	if s == nil {
-		return nil, errors.New("nonexistent pod status")
-	}
+func (s APIPodStatus) ToService() (*pod.Status, error) {
 	var converted pod.Status
-	switch *s {
+	switch s {
 	case PodStatusInitializing:
 		converted = pod.StatusInitializing
 	case PodStatusStarting:
@@ -242,7 +236,7 @@ func (s *APIPodStatus) ToService() (*pod.Status, error) {
 	case PodStatusTerminated:
 		converted = pod.StatusTerminated
 	default:
-		return nil, errors.Errorf("unrecognized pod status '%s'", *s)
+		return nil, errors.Errorf("unrecognized pod status '%s'", s)
 	}
 	return &converted, nil
 }

--- a/rest/model/pod.go
+++ b/rest/model/pod.go
@@ -104,6 +104,7 @@ func (p *APICreatePod) splitEnvVars() (envVars map[string]string, secrets map[st
 // APIPod represents a pod to be used and returned from the REST API.
 type APIPod struct {
 	ID                        *string                            `json:"id"`
+	Type                      APIPodType                         `json:"type"`
 	Status                    APIPodStatus                       `json:"status"`
 	Secret                    APIPodSecret                       `json:"secret"`
 	TaskContainerCreationOpts APIPodTaskContainerCreationOptions `json:"task_container_creation_opts"`
@@ -114,11 +115,12 @@ type APIPod struct {
 // BuildFromService converts a service-layer pod model into a REST API model.
 func (p *APIPod) BuildFromService(dbPod *pod.Pod) error {
 	p.ID = utility.ToStringPtr(dbPod.ID)
-	var status APIPodStatus
-	if err := status.BuildFromService(dbPod.Status); err != nil {
+	if err := p.Type.BuildFromService(dbPod.Type); err != nil {
+		return errors.Wrap(err, "building pod type from service")
+	}
+	if err := p.Status.BuildFromService(dbPod.Status); err != nil {
 		return errors.Wrap(err, "building status from service")
 	}
-	p.Status = status
 	p.Secret.BuildFromService(dbPod.Secret)
 	p.TimeInfo.BuildFromService(dbPod.TimeInfo)
 	p.TaskContainerCreationOpts.BuildFromService(dbPod.TaskContainerCreationOpts)
@@ -132,6 +134,10 @@ func (p *APIPod) ToService() (*pod.Pod, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "converting status to service")
 	}
+	t, err := p.Type.ToService()
+	if err != nil {
+		return nil, errors.Wrap(err, "converting pod type to service")
+	}
 	taskCreationOpts, err := p.TaskContainerCreationOpts.ToService()
 	if err != nil {
 		return nil, errors.Wrap(err, "converting task container creation options to service")
@@ -141,12 +147,48 @@ func (p *APIPod) ToService() (*pod.Pod, error) {
 	resources := p.Resources.ToService()
 	return &pod.Pod{
 		ID:                        utility.FromStringPtr(p.ID),
+		Type:                      *t,
 		Status:                    *s,
 		Secret:                    secret,
 		TaskContainerCreationOpts: *taskCreationOpts,
 		TimeInfo:                  timing,
 		Resources:                 resources,
 	}, nil
+}
+
+// APIPodType represents a pod's type.
+type APIPodType string
+
+const (
+	PodTypeAgent APIPodType = "agent"
+)
+
+// BuildFromService converts a service-layer pod type into a REST API pod type.
+func (t *APIPodType) BuildFromService(pt pod.Type) error {
+	var converted APIPodType
+	switch pt {
+	case pod.TypeAgent:
+		converted = PodTypeAgent
+	default:
+		return errors.Errorf("unrecognized pod type '%s'", pt)
+	}
+	*t = converted
+	return nil
+}
+
+// ToService converts a REST API pod type into a service-layer pod type.
+func (t *APIPodType) ToService() (*pod.Type, error) {
+	if t == nil {
+		return nil, errors.New("nonexistent pod type")
+	}
+	var converted pod.Type
+	switch *t {
+	case PodTypeAgent:
+		converted = pod.TypeAgent
+	default:
+		return nil, errors.Errorf("unrecognized pod type '%s'", *t)
+	}
+	return &converted, nil
 }
 
 // APIPodStatus represents a pod's status.

--- a/rest/route/pod.go
+++ b/rest/route/pod.go
@@ -72,7 +72,7 @@ func (h *podPostHandler) validatePayload() error {
 	return catcher.Resolve()
 }
 
-// Run creates a new resource based on the Request-URI and JSON payload.
+// Run creates a new pod based on the request payload.
 func (h *podPostHandler) Run(ctx context.Context) gimlet.Responder {
 	res, err := h.sc.CreatePod(h.p)
 	if err != nil {
@@ -127,7 +127,7 @@ func (h *podGetHandler) Parse(ctx context.Context, r *http.Request) error {
 	return nil
 }
 
-// Run creates a new resource based on the Request-URI and JSON payload.
+// Run finds and returns the REST pod.
 func (h *podGetHandler) Run(ctx context.Context) gimlet.Responder {
 	p, err := h.sc.FindPodByID(h.podID)
 	if err != nil {

--- a/rest/route/pod.go
+++ b/rest/route/pod.go
@@ -41,7 +41,7 @@ func (h *podPostHandler) Factory() gimlet.RouteHandler {
 	}
 }
 
-// Parse fetches the podID and JSON payload from the HTTP request.
+// Parse fetches the pod ID and JSON payload from the HTTP request.
 func (h *podPostHandler) Parse(ctx context.Context, r *http.Request) error {
 	body := utility.NewRequestReader(r)
 	defer body.Close()
@@ -121,7 +121,7 @@ func (h *podGetHandler) Factory() gimlet.RouteHandler {
 	}
 }
 
-// Parse fetches the podID and JSON payload from the HTTP request.
+// Parse fetches the pod ID from the HTTP request.
 func (h *podGetHandler) Parse(ctx context.Context, r *http.Request) error {
 	h.podID = gimlet.GetVars(r)["pod_id"]
 	return nil

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -146,6 +146,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/pods/{pod_id}/agent/setup").Version(2).Get().Wrap(requirePod).RouteHandler(makePodAgentSetup(env.Settings()))
 	app.AddRoute("/pods/{pod_id}/agent/next_task").Version(2).Get().Wrap(requirePod).RouteHandler(makePodAgentNextTask(env, sc))
 	app.AddRoute("/pods").Version(2).Post().Wrap(adminSettings).RouteHandler(makePostPod(env, sc))
+	app.AddRoute("/pods/{pod_id}").Version(2).Get().Wrap(adminSettings).RouteHandler(makeGetPod(env, sc))
 	app.AddRoute("/projects").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchProjectsRoute(sc))
 	app.AddRoute("/projects/test_alias").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetProjectAliasResultsHandler(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Delete().Wrap(requireUser, requireProjectAdmin, editProjectSettings).RouteHandler(makeDeleteProject(sc))

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -219,6 +219,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 					CachedPods: []pod.Pod{
 						{
 							ID:     "id",
+							Type:   pod.TypeAgent,
 							Status: pod.StatusRunning,
 							Resources: pod.ResourceInfo{
 								ExternalID: "external_id",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15493

### Description 
* Add REST route to get a pod by ID. The data model already exists, it just has to be exposed in the API.
    * I made it available only for admins for now, since it's not a feature available for production. I'll change it to use looser permissions once the containers initiative is more production-ready.
* Fix the APIPod data model to include the required pod type field.
* Slightly fix mock pod data connector to have the same behavior as the DB connector for `FindPodByID`.

### Testing 
* Added test for REST route.
* Fixed existing REST tests to require pod type.