### PR TITLE
EVG-15960 fetch parameters directly for fetch_vars

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -829,10 +829,9 @@ func evalStepback(t *task.Task, caller, status string, deactivatePrevious bool) 
 		}
 		return errors.Wrap(doStepback(t), "error during stepback")
 
-	} else if deactivatePrevious && status == evergreen.TaskSucceeded {
-		// if the task was successful, ignore running previous
-		// activated tasks for this buildvariant
-
+	} else if status == evergreen.TaskSucceeded && deactivatePrevious && t.Requester == evergreen.RepotrackerVersionRequester {
+		// if the task was successful and is a mainline commit (not git tag or project trigger),
+		// ignore running previous activated tasks for this buildvariant
 		if err := DeactivatePreviousTasks(t, caller); err != nil {
 			return errors.Wrap(err, "Error deactivating previous task")
 		}

--- a/service/api.go
+++ b/service/api.go
@@ -346,12 +346,12 @@ func (as *APIServer) FetchExpansionsForTask(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	proj, _, err := model.LoadProjectForVersion(v, t.Project, false)
+	projParams, err := model.FindParametersForVersion(v)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	params := append(proj.GetParameters(), v.Parameters...)
+	params := append(projParams, v.Parameters...)
 	for _, param := range params {
 		res.Vars[param.Key] = param.Value
 	}


### PR DESCRIPTION
[EVG-15960](https://jira.mongodb.org/browse/EVG-15960)

### Description 
Avoid using LoadProjectForVersion when the ParserProject exists, since we can just look it up directly, and the translation doesn't affect this.

