### PR TITLE
EVG-15899 fix this project's a panic

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1203,7 +1203,7 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 	}
 
 	if lastGoodVersion == nil {
-		return nil, nil, errors.WithStack(errors.Errorf("could not find a valid version for project %s", projectId))
+		return nil, nil, errors.WithStack(errors.Wrapf(err, "could not find a valid version for project %s", projectId))
 	}
 
 	return nil, nil, errors.Wrapf(err, "Error loading project from "+

--- a/model/project.go
+++ b/model/project.go
@@ -1202,6 +1202,10 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 		}))
 	}
 
+	if lastGoodVersion == nil {
+		return nil, nil, errors.WithStack(errors.Errorf("could not find a valid version for project %s", projectId))
+	}
+
 	return nil, nil, errors.Wrapf(err, "Error loading project from "+
 		"last good version for project, %s", lastGoodVersion.Identifier)
 }


### PR DESCRIPTION
[EVG-15899](https://jira.mongodb.org/browse/EVG-15899)

### Description 
If a project does not yet have any versions created for it, it panics when trying to load the event log and waterfall. I added a check to make sure that there is a valid version. 

### Testing 
none
