### PR TITLE
EVG-15773  Do not displays "SETUP FAILURE" when there is a test failure

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -470,12 +470,9 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 	if err != nil {
 		return errors.Wrap(err, "checking for failed tests")
 	}
-	if hasFailedTests {
-		if detailsCopy.Status != evergreen.TaskFailed {
-			detailsCopy.Type = evergreen.CommandTypeTest
-		} else {
-			detailsCopy.Status = evergreen.TaskFailed
-		}
+	if hasFailedTests && detailsCopy.Status != evergreen.TaskFailed {
+		detailsCopy.Type = evergreen.CommandTypeTest
+		detailsCopy.Status = evergreen.TaskFailed
 	}
 
 	if t.Status == detailsCopy.Status {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -473,8 +473,9 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 	if hasFailedTests {
 		if detailsCopy.Status != evergreen.TaskFailed {
 			detailsCopy.Type = evergreen.CommandTypeTest
+		} else {
+			detailsCopy.Status = evergreen.TaskFailed
 		}
-		detailsCopy.Status = evergreen.TaskFailed
 	}
 
 	if t.Status == detailsCopy.Status {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -488,7 +488,9 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 		if detailsCopy.Status == evergreen.TaskSucceeded && count == 0 && t.MustHaveResults {
 			detailsCopy.Status = evergreen.TaskFailed
 			detailsCopy.Description = evergreen.TaskDescriptionNoResults
-			detailsCopy.Type = evergreen.CommandTypeTest
+			if !hasFailedTests {
+				detailsCopy.Type = evergreen.CommandTypeTest
+			}
 		}
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -471,6 +471,9 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 		return errors.Wrap(err, "checking for failed tests")
 	}
 	if hasFailedTests {
+		if detailsCopy.Status != evergreen.TaskFailed {
+			detailsCopy.Type = evergreen.CommandTypeTest
+		}
 		detailsCopy.Status = evergreen.TaskFailed
 	}
 
@@ -488,9 +491,6 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 		if detailsCopy.Status == evergreen.TaskSucceeded && count == 0 && t.MustHaveResults {
 			detailsCopy.Status = evergreen.TaskFailed
 			detailsCopy.Description = evergreen.TaskDescriptionNoResults
-			if !hasFailedTests {
-				detailsCopy.Type = evergreen.CommandTypeTest
-			}
 		}
 	}
 


### PR DESCRIPTION
[EVG-15773 ](https://jira.mongodb.org/browse/EVG-15773 )

### Description 
If a task has a test failure, we want to display "failed" regardless of what the last command type was. 

### Testing 
I'm not sure how to test this, but I'm fairly confident that it will work. 
