### PR TITLE
EVG-15923 Refactor multi return arguments for project configs into single ProjectInfo

### DIFF
--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -647,9 +647,9 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	g := sampleGeneratedProject
 	g.TaskID = "task_that_called_generate_task"
 
-	p, pp, _, err := LoadProjectForVersion(v, "proj", false)
+	projectInfo, err := LoadProjectForVersion(v, "proj", false)
 	s.Require().NoError(err)
-	p, pp, v, err = g.NewVersion(p, pp, v)
+	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	s.Require().NoError(err)
 	s.NoError(g.Save(context.Background(), p, pp, v, &genTask))
 
@@ -746,9 +746,9 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 
 	g := sampleGeneratedProjectAddToBVOnly
 	g.TaskID = "task_that_called_generate_task"
-	p, pp, _, err := LoadProjectForVersion(v, "", false)
+	projectInfo, err := LoadProjectForVersion(v, "", false)
 	s.Require().NoError(err)
-	p, pp, v, err = g.NewVersion(p, pp, v)
+	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	s.NoError(err)
 	s.NoError(g.Save(context.Background(), p, pp, v, &tasksThatExist[0]))
 
@@ -837,9 +837,9 @@ buildvariants:
 		},
 	}
 
-	p, pp, _, err := LoadProjectForVersion(v, "", false)
+	projectInfo, err := LoadProjectForVersion(v, "", false)
 	s.Require().NoError(err)
-	p, pp, v, err = g.NewVersion(p, pp, v)
+	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	s.NoError(err)
 	s.NoError(g.Save(context.Background(), p, pp, v, &t1))
 
@@ -883,9 +883,9 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 
 	g := smallGeneratedProject
 	g.TaskID = "task_that_called_generate_task"
-	p, pp, _, err := LoadProjectForVersion(v, "", false)
+	projectInfo, err := LoadProjectForVersion(v, "", false)
 	s.Require().NoError(err)
-	p, pp, v, err = g.NewVersion(p, pp, v)
+	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	s.Require().NoError(err)
 	s.NoError(g.Save(context.Background(), p, pp, v, &taskThatExists))
 

--- a/model/project.go
+++ b/model/project.go
@@ -1139,11 +1139,11 @@ func FindProjectFromVersionID(versionStr string) (*Project, error) {
 		return nil, errors.Errorf("nil version returned for version '%s'", versionStr)
 	}
 
-	project, _, _, err := LoadProjectForVersion(ver, ver.Identifier, false)
+	projectInfo, err := LoadProjectForVersion(ver, ver.Identifier, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to load project config for version %s", versionStr)
 	}
-	return project, nil
+	return projectInfo.Project, nil
 }
 
 func (p *Project) FindDistroNameForTask(t *task.Task) (string, error) {
@@ -1189,7 +1189,12 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 			continue
 		}
 		if lastGoodVersion != nil {
-			project, _, _, err = LoadProjectForVersion(lastGoodVersion, projectId, true)
+			projectInfo, err := LoadProjectForVersion(lastGoodVersion, projectId, true)
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "Error retrieving project info from "+
+					"last good version for project, %s", lastGoodVersion.Identifier)
+			}
+			project = projectInfo.Project
 			revisionOrderNum = lastGoodVersion.RevisionOrderNumber // look for an older version if the returned version is malformed
 		}
 		if err == nil {

--- a/model/project.go
+++ b/model/project.go
@@ -1182,6 +1182,7 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 	revisionOrderNum := -1 // only specify in the event of failure
 	var err error
 	var lastGoodVersion *Version
+	var projectInfo ProjectInfo
 	for i := 0; i < retryCount; i++ {
 		lastGoodVersion, err = FindVersionByLastKnownGoodConfig(projectId, revisionOrderNum)
 		if err != nil {
@@ -1189,11 +1190,7 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 			continue
 		}
 		if lastGoodVersion != nil {
-			projectInfo, err := LoadProjectForVersion(lastGoodVersion, projectId, true)
-			if err != nil {
-				return nil, nil, errors.Wrapf(err, "Error retrieving project info from "+
-					"last good version for project, %s", lastGoodVersion.Identifier)
-			}
+			projectInfo, err = LoadProjectForVersion(lastGoodVersion, projectId, true)
 			project = projectInfo.Project
 			revisionOrderNum = lastGoodVersion.RevisionOrderNumber // look for an older version if the returned version is malformed
 		}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -521,8 +521,6 @@ func LoadProjectForVersion(v *Version, id string, shouldSave bool) (ProjectInfo,
 		return ProjectInfo{
 			Project:             p,
 			IntermediateProject: pp,
-			Config:              nil,
-			Ref:                 nil,
 		}, err
 	}
 
@@ -555,7 +553,6 @@ func LoadProjectForVersion(v *Version, id string, shouldSave bool) (ProjectInfo,
 		Project:             p,
 		IntermediateProject: pp,
 		Config:              pc,
-		Ref:                 nil,
 	}, nil
 }
 
@@ -785,7 +782,6 @@ func GetProjectFromFile(ctx context.Context, opts GetProjectOpts) (ProjectInfo, 
 		Project:             &config,
 		IntermediateProject: pp,
 		Config:              pc,
-		Ref:                 nil,
 	}, nil
 }
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -501,13 +501,13 @@ func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(interface{}) error) e
 
 // LoadProjectForVersion returns the project for a version, either from the parser project or the config string.
 // If read from the config string and shouldSave is set, the resulting parser project will be saved.
-func LoadProjectForVersion(v *Version, id string, shouldSave bool) (*Project, *ParserProject, *ProjectConfig, error) {
+func LoadProjectForVersion(v *Version, id string, shouldSave bool) (ProjectInfo, error) {
 	var pp *ParserProject
 	var err error
 
 	pp, err = ParserProjectFindOneById(v.Id)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "error finding parser project")
+		return ProjectInfo{}, errors.Wrap(err, "error finding parser project")
 	}
 
 	// if parser project config number is old then we should default to legacy
@@ -518,18 +518,23 @@ func LoadProjectForVersion(v *Version, id string, shouldSave bool) (*Project, *P
 		pp.Identifier = utility.ToStringPtr(id)
 		var p *Project
 		p, err = TranslateProject(pp)
-		return p, pp, nil, err
+		return ProjectInfo{
+			Project:             p,
+			IntermediateProject: pp,
+			Config:              nil,
+			Ref:                 nil,
+		}, nil
 	}
 
 	if v.Config == "" {
-		return nil, nil, nil, errors.New("version has no config")
+		return ProjectInfo{}, errors.New("version has no config")
 	}
 	p := &Project{}
 	// opts empty because project yaml with `include` will not hit this case
 	ctx := context.Background()
 	pp, pc, err := LoadProjectInto(ctx, []byte(v.Config), nil, id, p)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "error loading project")
+		return ProjectInfo{}, errors.Wrap(err, "error loading project")
 	}
 	pp.Id = v.Id
 	pp.Identifier = utility.ToStringPtr(id)
@@ -543,10 +548,15 @@ func LoadProjectForVersion(v *Version, id string, shouldSave bool) (*Project, *P
 				"version": v.Id,
 				"message": "error inserting parser project for version",
 			}))
-			return nil, nil, nil, errors.Wrap(err, "error updating version with project")
+			return ProjectInfo{}, errors.Wrap(err, "error updating version with project")
 		}
 	}
-	return p, pp, pc, nil
+	return ProjectInfo{
+		Project:             p,
+		IntermediateProject: pp,
+		Config:              pc,
+		Ref:                 nil,
+	}, nil
 }
 
 func GetProjectFromBSON(data []byte) (*Project, error) {
@@ -760,18 +770,23 @@ func getFileForPatchDiff(ctx context.Context, opts GetProjectOpts) ([]byte, erro
 	return projectFileBytes, nil
 }
 
-func GetProjectFromFile(ctx context.Context, opts GetProjectOpts) (*Project, *ParserProject, *ProjectConfig, error) {
+func GetProjectFromFile(ctx context.Context, opts GetProjectOpts) (ProjectInfo, error) {
 	fileContents, err := retrieveFile(ctx, opts)
 	if err != nil {
-		return nil, nil, nil, err
+		return ProjectInfo{}, err
 	}
 
 	config := Project{}
 	pp, pc, err := LoadProjectInto(ctx, fileContents, &opts, opts.Ref.Id, &config)
 	if err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "error parsing config file for '%s'", opts.Ref.Id)
+		return ProjectInfo{}, errors.Wrapf(err, "error parsing config file for '%s'", opts.Ref.Id)
 	}
-	return &config, pp, pc, nil
+	return ProjectInfo{
+		Project:             &config,
+		IntermediateProject: pp,
+		Config:              pc,
+		Ref:                 nil,
+	}, nil
 }
 
 // createIntermediateProject marshals the supplied YAML into our

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -523,7 +523,7 @@ func LoadProjectForVersion(v *Version, id string, shouldSave bool) (ProjectInfo,
 			IntermediateProject: pp,
 			Config:              nil,
 			Ref:                 nil,
-		}, nil
+		}, err
 	}
 
 	if v.Config == "" {

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -88,6 +89,8 @@ func Patch() cli.Command {
 		Flags:   getPatchFlags(),
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().String(confFlagName)
+			fmt.Println(confPath)
+			fmt.Println("malik")
 			args := c.Args()
 			params := &patchParams{
 				Project:           c.String(projectFlagName),

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -89,8 +88,6 @@ func Patch() cli.Command {
 		Flags:   getPatchFlags(),
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().String(confFlagName)
-			fmt.Println(confPath)
-			fmt.Println("malik")
 			args := c.Args()
 			params := &patchParams{
 				Project:           c.String(projectFlagName),

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -57,7 +57,7 @@ func githubCommitToRevision(repoCommit *github.RepositoryCommit) model.Revision 
 
 // GetRemoteConfig fetches the contents of a remote github repository's
 // configuration data as at a given revision
-func (gRepoPoller *GithubRepositoryPoller) GetRemoteConfig(ctx context.Context, projectFileRevision string) (*model.Project, *model.ParserProject, *model.ProjectConfig, error) {
+func (gRepoPoller *GithubRepositoryPoller) GetRemoteConfig(ctx context.Context, projectFileRevision string) (model.ProjectInfo, error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/repotracker/github_poller_test.go
+++ b/repotracker/github_poller_test.go
@@ -222,23 +222,23 @@ func TestGetRemoteConfig(t *testing.T) {
 
 			Convey("The config file at the requested revision should be "+
 				"exactly what is returned", func() {
-				projectConfig, _, _, err := self.GetRemoteConfig(ctx, firstRemoteConfigRef)
+				projectInfo, err := self.GetRemoteConfig(ctx, firstRemoteConfigRef)
 				require.NoError(t, err, "Error fetching github "+
 					"configuration file")
-				So(projectConfig, ShouldNotBeNil)
-				So(len(projectConfig.Tasks), ShouldEqual, 0)
-				projectConfig, _, _, err = self.GetRemoteConfig(ctx, secondRemoteConfigRef)
+				So(projectInfo.Project, ShouldNotBeNil)
+				So(len(projectInfo.Project.Tasks), ShouldEqual, 0)
+				projectInfo, err = self.GetRemoteConfig(ctx, secondRemoteConfigRef)
 				require.NoError(t, err, "Error fetching github "+
 					"configuration file")
-				So(projectConfig, ShouldNotBeNil)
-				So(len(projectConfig.Tasks), ShouldEqual, 1)
+				So(projectInfo.Project, ShouldNotBeNil)
+				So(len(projectInfo.Project.Tasks), ShouldEqual, 1)
 			})
 			Convey("an invalid revision should return an error", func() {
-				_, _, _, err := self.GetRemoteConfig(ctx, "firstRemoteConfRef")
+				_, err := self.GetRemoteConfig(ctx, "firstRemoteConfRef")
 				So(err, ShouldNotBeNil)
 			})
 			Convey("an invalid project configuration should error out", func() {
-				_, _, _, err := self.GetRemoteConfig(ctx, badRemoteConfigRef)
+				_, err := self.GetRemoteConfig(ctx, badRemoteConfigRef)
 				So(err, ShouldNotBeNil)
 			})
 		})

--- a/repotracker/mock_poller.go
+++ b/repotracker/mock_poller.go
@@ -43,10 +43,10 @@ func (d *mockRepoPoller) GetChangedFiles(_ context.Context, commitRevision strin
 	return nil, nil
 }
 
-func (d *mockRepoPoller) GetRemoteConfig(_ context.Context, revision string) (*model.Project, *model.ParserProject, *model.ProjectConfig, error) {
+func (d *mockRepoPoller) GetRemoteConfig(_ context.Context, revision string) (model.ProjectInfo, error) {
 	d.ConfigGets++
 	if d.nextError != nil {
-		return nil, nil, nil, d.clearError()
+		return model.ProjectInfo{}, d.clearError()
 	}
 	if d.badDistro != "" {
 		// change the target distros if we've called addBadDistro, creating a validation warning
@@ -56,9 +56,13 @@ func (d *mockRepoPoller) GetRemoteConfig(_ context.Context, revision string) (*m
 
 	p, err := model.TranslateProject(d.parserProject)
 	if err != nil {
-		return nil, nil, nil, errors.Wrapf(err, model.TranslateProjectError)
+		return model.ProjectInfo{}, errors.Wrapf(err, model.TranslateProjectError)
 	}
-	return p, d.parserProject, &model.ProjectConfig{}, nil
+	return model.ProjectInfo{
+		Project:             p,
+		IntermediateProject: d.parserProject,
+		Config:              &model.ProjectConfig{},
+	}, nil
 }
 
 func (d *mockRepoPoller) GetRevisionsSince(revision string, maxRevisionsToSearch int) ([]model.Revision, error) {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -289,6 +289,14 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 					"project_identifier": ref.Identifier,
 					"revision":           revision,
 				}))
+				if pInfo.Project == nil {
+					grip.Error(message.WrapError(err, message.Fields{
+						"message":            fmt.Sprintf("unable to find project config for revision %s", revision),
+						"runner":             RunnerName,
+						"project":            ref.Id,
+						"project_identifier": ref.Identifier,
+					}))
+				}
 				return err
 			}
 		}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -289,16 +289,16 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 					"project_identifier": ref.Identifier,
 					"revision":           revision,
 				}))
-				if pInfo.Project == nil {
-					grip.Error(message.WrapError(err, message.Fields{
-						"message":            fmt.Sprintf("unable to find project config for revision %s", revision),
-						"runner":             RunnerName,
-						"project":            ref.Id,
-						"project_identifier": ref.Identifier,
-					}))
-				}
 				return err
 			}
+		} else if pInfo.Project == nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message":            fmt.Sprintf("unable to find project config for revision %s", revision),
+				"runner":             RunnerName,
+				"project":            ref.Id,
+				"project_identifier": ref.Identifier,
+			}))
+			return err
 		}
 
 		// "Ignore" a version if all changes are to ignored files

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -292,16 +292,6 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 				return err
 			}
 		}
-		if pInfo.Project == nil {
-			msg := fmt.Sprintf("unable to find project config for revision %s", revision)
-			grip.Error(message.WrapError(err, message.Fields{
-				"message":            msg,
-				"runner":             RunnerName,
-				"project":            ref.Id,
-				"project_identifier": ref.Identifier,
-			}))
-			return errors.New(msg)
-		}
 
 		// "Ignore" a version if all changes are to ignored files
 		var ignore bool

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -249,16 +249,6 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 
 		var versionErrs *VersionErrors
 		pInfo, err := repoTracker.GetProjectConfig(ctx, revision)
-		if pInfo.Project == nil {
-			msg := fmt.Sprintf("unable to find project config for revision %s", revision)
-			grip.Error(message.WrapError(err, message.Fields{
-				"message":            msg,
-				"runner":             RunnerName,
-				"project":            ref.Id,
-				"project_identifier": ref.Identifier,
-			}))
-			return errors.New(msg)
-		}
 		if err != nil {
 			// this is an error that implies the file is invalid - create a version and store the error
 			projErr, isProjErr := err.(projectConfigError)
@@ -301,6 +291,16 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 				}))
 				return err
 			}
+		}
+		if pInfo.Project == nil {
+			msg := fmt.Sprintf("unable to find project config for revision %s", revision)
+			grip.Error(message.WrapError(err, message.Fields{
+				"message":            msg,
+				"runner":             RunnerName,
+				"project":            ref.Id,
+				"project_identifier": ref.Identifier,
+			}))
+			return errors.New(msg)
 		}
 
 		// "Ignore" a version if all changes are to ignored files

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -292,12 +292,12 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 				return err
 			}
 		} else if pInfo.Project == nil {
-			grip.Error(message.WrapError(err, message.Fields{
+			grip.Error(message.Fields{
 				"message":            fmt.Sprintf("unable to find project config for revision %s", revision),
 				"runner":             RunnerName,
 				"project":            ref.Id,
 				"project_identifier": ref.Identifier,
-			}))
+			})
 			return err
 		}
 

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -172,7 +172,7 @@ func makeProjectAndExpansionsFromTask(t *task.Task) (*model.Project, *util.Expan
 	if v == nil {
 		return nil, nil, errors.New("version doesn't exist")
 	}
-	proj, _, _, err := model.LoadProjectForVersion(v, v.Identifier, true)
+	projectInfo, err := model.LoadProjectForVersion(v, v.Identifier, true)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error loading project")
 	}
@@ -192,12 +192,15 @@ func makeProjectAndExpansionsFromTask(t *task.Task) (*model.Project, *util.Expan
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error populating expansions")
 	}
-	params := append(proj.GetParameters(), v.Parameters...)
+	var params []patch.Parameter
+	if projectInfo.Project != nil {
+		params = append(projectInfo.Project.GetParameters(), v.Parameters...)
+	}
 	if err = updateExpansions(&expansions, t.Project, params); err != nil {
 		return nil, nil, errors.Wrap(err, "error updating expansions")
 	}
 
-	return proj, &expansions, nil
+	return projectInfo.Project, &expansions, nil
 }
 
 // updateExpansions updates expansions with project variables and patch

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -192,10 +192,10 @@ func makeProjectAndExpansionsFromTask(t *task.Task) (*model.Project, *util.Expan
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error populating expansions")
 	}
-	var params []patch.Parameter
-	if projectInfo.Project != nil {
-		params = append(projectInfo.Project.GetParameters(), v.Parameters...)
+	if projectInfo.Project == nil {
+		projectInfo.Project = &model.Project{}
 	}
+	params := append(projectInfo.Project.GetParameters(), v.Parameters...)
 	if err = updateExpansions(&expansions, t.Project, params); err != nil {
 		return nil, nil, errors.Wrap(err, "error updating expansions")
 	}

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -116,7 +116,7 @@ type Connector interface {
 	UpdateRepo(*model.RepoRef) error
 
 	// GetProjectFromFile finds the file for the projectRef and returns the translated project, using the given token
-	GetProjectFromFile(context.Context, model.ProjectRef, string, string) (*model.Project, *model.ParserProject, *model.ProjectConfig, error)
+	GetProjectFromFile(context.Context, model.ProjectRef, string, string) (model.ProjectInfo, error)
 
 	// EnableWebhooks creates a webhook for the project's owner/repo if one does not exist.
 	// If unable to setup the new webhook, returns false but no error.
@@ -141,7 +141,7 @@ type Connector interface {
 	CreateVersionFromConfig(context.Context, *model.ProjectInfo, model.VersionMetadata, bool) (*model.Version, error)
 
 	// Given a version and a project ID, return the translated project and the intermediate project.
-	LoadProjectForVersion(*model.Version, string) (*model.Project, *model.ParserProject, *model.ProjectConfig, error)
+	LoadProjectForVersion(*model.Version, string) (model.ProjectInfo, error)
 	// FindByProjectAndCommit is a method to find a set of tasks which ran as part of
 	// certain version in a project. It takes the projectId, commit hash, and a taskId
 	// for paginating through the results.

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -112,7 +112,7 @@ func (pc *DBProjectConnector) UpdateRepo(repoRef *model.RepoRef) error {
 	return nil
 }
 
-func (pc *DBProjectConnector) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string, token string) (*model.Project, *model.ParserProject, *model.ProjectConfig, error) {
+func (pc *DBProjectConnector) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string, token string) (model.ProjectInfo, error) {
 	opts := model.GetProjectOpts{
 		Ref:        &pRef,
 		Revision:   pRef.Branch,
@@ -557,7 +557,7 @@ func (pc *MockProjectConnector) RemoveAdminFromProjects(toDelete string) error {
 	return nil
 }
 
-func (pc *MockProjectConnector) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string, token string) (*model.Project, *model.ParserProject, *model.ProjectConfig, error) {
+func (pc *MockProjectConnector) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string, token string) (model.ProjectInfo, error) {
 	config := `
 buildvariants:
 - name: v1
@@ -575,7 +575,12 @@ tasks:
 		ReadFileFrom: model.ReadFromLocal,
 	}
 	pp, pConfig, err := model.LoadProjectInto(ctx, []byte(config), opts, pRef.Id, p)
-	return p, pp, pConfig, err
+	return model.ProjectInfo{
+		Project:             p,
+		IntermediateProject: pp,
+		Config:              pConfig,
+		Ref:                 nil,
+	}, err
 }
 
 func (pc *MockProjectConnector) FindProjectVarsById(id, repoId string, redact bool) (*restModel.APIProjectVars, error) {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -579,7 +579,6 @@ tasks:
 		Project:             p,
 		IntermediateProject: pp,
 		Config:              pConfig,
-		Ref:                 nil,
 	}, err
 }
 

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -389,7 +389,6 @@ func (mvc *MockVersionConnector) LoadProjectForVersion(v *model.Version, project
 			Project:             p,
 			IntermediateProject: pp,
 			Config:              pc,
-			Ref:                 nil,
 		}, err
 	}
 	return model.ProjectInfo{}, errors.New("no project for version")

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -57,7 +57,7 @@ func (vc *DBVersionConnector) RestartVersion(versionId string, caller string) er
 	return model.RestartTasksInVersion(versionId, true, caller)
 }
 
-func (bc *DBVersionConnector) LoadProjectForVersion(v *model.Version, projectId string) (*model.Project, *model.ParserProject, *model.ProjectConfig, error) {
+func (bc *DBVersionConnector) LoadProjectForVersion(v *model.Version, projectId string) (model.ProjectInfo, error) {
 	return model.LoadProjectForVersion(v, projectId, false)
 }
 
@@ -380,14 +380,19 @@ func (mvc *MockVersionConnector) CreateVersionFromConfig(ctx context.Context, pr
 	}, nil
 }
 
-func (mvc *MockVersionConnector) LoadProjectForVersion(v *model.Version, projectId string) (*model.Project, *model.ParserProject, *model.ProjectConfig, error) {
+func (mvc *MockVersionConnector) LoadProjectForVersion(v *model.Version, projectId string) (model.ProjectInfo, error) {
 	if v.Config != "" {
 		p := &model.Project{}
 		ctx := context.Background()
 		pp, pc, err := model.LoadProjectInto(ctx, []byte(v.Config), nil, projectId, p)
-		return p, pp, pc, err
+		return model.ProjectInfo{
+			Project:             p,
+			IntermediateProject: pp,
+			Config:              pc,
+			Ref:                 nil,
+		}, err
 	}
-	return nil, nil, nil, errors.New("no project for version")
+	return model.ProjectInfo{}, errors.New("no project for version")
 }
 
 func (mvc *MockVersionConnector) GetProjectVersionsWithOptions(projectId string, opts model.GetVersionsOptions) ([]restModel.APIVersion, error) {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -509,7 +509,7 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 		GitTag:     tag,
 		RemotePath: remotePath,
 	}
-	info := &model.ProjectInfo{Ref: &pRef}
+	var projectInfo model.ProjectInfo
 	if remotePath != "" {
 		// run everything in the yaml that's provided
 		if gh.settings == nil {
@@ -518,20 +518,20 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 				return nil, errors.New("error getting settings config")
 			}
 		}
-		info.Project, info.IntermediateProject, info.Config, err = gh.sc.GetProjectFromFile(ctx, pRef, remotePath, token)
+		projectInfo, err = gh.sc.GetProjectFromFile(ctx, pRef, remotePath, token)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to unmarshal yaml config")
 		}
 	} else {
 		// use the standard project config with the git tag alias
-		info.Project, info.IntermediateProject, info.Config, err = gh.sc.LoadProjectForVersion(existingVersion, pRef.Id)
+		projectInfo, err = gh.sc.LoadProjectForVersion(existingVersion, pRef.Id)
 		if err != nil {
 			return nil, errors.Wrapf(err, "problem getting project for  '%s'", pRef.Identifier)
 		}
 		metadata.Alias = evergreen.GitTagAlias
 	}
-
-	return gh.sc.CreateVersionFromConfig(ctx, info, metadata, true)
+	projectInfo.Ref = &pRef
+	return gh.sc.CreateVersionFromConfig(ctx, &projectInfo, metadata, true)
 }
 
 func validatePushTagEvent(event *github.PushEvent) error {

--- a/service/api_plugin_manifest.go
+++ b/service/api_plugin_manifest.go
@@ -46,12 +46,12 @@ func (as *APIServer) manifestLoadHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	projectInfo, err := model.LoadProjectForVersion(v, v.Identifier, false)
-	if projectInfo.Project == nil {
-		as.LoggedError(w, r, http.StatusNotFound, errors.New("unable to find project for version"))
-		return
-	}
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrap(err, "error loading project from version"))
+		return
+	}
+	if projectInfo.Project == nil {
+		as.LoggedError(w, r, http.StatusNotFound, errors.New("unable to find project for version"))
 		return
 	}
 

--- a/service/api_plugin_manifest.go
+++ b/service/api_plugin_manifest.go
@@ -45,20 +45,23 @@ func (as *APIServer) manifestLoadHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	var project *model.Project
-	project, _, _, err = model.LoadProjectForVersion(v, v.Identifier, false)
+	projectInfo, err := model.LoadProjectForVersion(v, v.Identifier, false)
+	if projectInfo.Project == nil {
+		as.LoggedError(w, r, http.StatusNotFound, errors.New("unable to find project for version"))
+		return
+	}
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrap(err, "error loading project from version"))
 		return
 	}
 
-	if currentManifest != nil && project.Modules.IsIdentical(*currentManifest) {
+	if currentManifest != nil && projectInfo.Project.Modules.IsIdentical(*currentManifest) {
 		gimlet.WriteJSON(w, currentManifest)
 		return
 	}
 
 	// attempt to insert a manifest after making GitHub API calls
-	manifest, err := repotracker.CreateManifest(*v, project, projectRef, &as.Settings)
+	manifest, err := repotracker.CreateManifest(*v, projectInfo.Project, projectRef, &as.Settings)
 	if err != nil {
 		if apiErr, ok := errors.Cause(err).(thirdparty.APIRequestError); ok && apiErr.StatusCode == http.StatusNotFound {
 			as.LoggedError(w, r, http.StatusBadRequest, errors.Wrap(err, "manifest resource not found"))

--- a/trigger/project_triggers_test.go
+++ b/trigger/project_triggers_test.go
@@ -76,14 +76,14 @@ func TestMakeDownstreamConfigFromCommand(t *testing.T) {
 	identifier := "project"
 	cmd := "echo hi"
 
-	proj, pp, err := makeDownstreamProjectFromCommand(identifier, cmd, "generate.json")
+	projInfo, err := makeDownstreamProjectFromCommand(identifier, cmd, "generate.json")
 	assert.NoError(err)
-	assert.NotNil(proj)
-	assert.NotNil(pp)
-	assert.Equal(identifier, proj.Identifier)
+	assert.NotNil(projInfo.Project)
+	assert.NotNil(projInfo.IntermediateProject)
+	assert.Equal(identifier, projInfo.Project.Identifier)
 	foundCommand := false
 	foundFile := false
-	for _, t := range proj.Tasks {
+	for _, t := range projInfo.Project.Tasks {
 		for _, c := range t.Commands {
 			if c.Command == "subprocess.exec" {
 				foundCommand = true
@@ -100,7 +100,7 @@ func TestMakeDownstreamConfigFromCommand(t *testing.T) {
 
 	foundCommand = false
 	foundFile = false
-	for _, t := range pp.Tasks {
+	for _, t := range projInfo.IntermediateProject.Tasks {
 		for _, c := range t.Commands {
 			if c.Command == "subprocess.exec" {
 				foundCommand = true

--- a/trigger/project_triggers_test.go
+++ b/trigger/project_triggers_test.go
@@ -57,15 +57,15 @@ func TestMakeDownstreamConfigFromFile(t *testing.T) {
 		Owner: "evergreen-ci",
 		Repo:  "evergreen",
 	}
-	proj, pp, _, err := makeDownstreamProjectFromFile(ref, "trigger/testdata/downstream_config.yml")
+	projectInfo, err := makeDownstreamProjectFromFile(ref, "trigger/testdata/downstream_config.yml")
 	assert.NoError(err)
-	assert.NotNil(proj)
-	assert.NotNil(pp)
-	assert.Equal(ref.Id, proj.Identifier)
-	assert.Len(proj.Tasks, 2)
-	assert.Equal("task1", proj.Tasks[0].Name)
-	assert.Len(proj.BuildVariants, 1)
-	assert.Equal("something", proj.BuildVariants[0].DisplayName)
+	assert.NotNil(projectInfo.Project)
+	assert.NotNil(projectInfo.IntermediateProject)
+	assert.Equal(ref.Id, projectInfo.Project.Identifier)
+	assert.Len(projectInfo.Project.Tasks, 2)
+	assert.Equal("task1", projectInfo.Project.Tasks[0].Name)
+	assert.Len(projectInfo.Project.BuildVariants, 1)
+	assert.Equal("something", projectInfo.Project.BuildVariants[0].DisplayName)
 }
 
 func TestMakeDownstreamConfigFromCommand(t *testing.T) {

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -76,7 +76,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	if v == nil {
 		return errors.Errorf("unable to find version %s", t.Version)
 	}
-	p, pp, _, err := model.LoadProjectForVersion(v, t.Project, false)
+	projectInfo, err := model.LoadProjectForVersion(v, t.Project, false)
 	if err != nil {
 		return errors.Wrapf(err, "error getting project for version %s", t.Version)
 	}
@@ -138,7 +138,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	start = time.Now()
 	g.TaskID = j.TaskID
 
-	p, pp, v, err = g.NewVersion(p, pp, v)
+	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	if err != nil {
 		return j.handleError(pp, v, errors.WithStack(err))
 	}

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -227,7 +227,8 @@ func TestGenerateTasks(t *testing.T) {
 	// Make sure first project was not changed
 	v, err := model.VersionFindOneId("random_version")
 	assert.NoError(err)
-	p, _, _, err := model.LoadProjectForVersion(v, "mci", true)
+	projectInfo, err := model.LoadProjectForVersion(v, "mci", true)
+	p := projectInfo.Project
 	assert.NoError(err)
 	require.NotNil(p)
 	assert.Len(p.Tasks, 2)
@@ -238,7 +239,8 @@ func TestGenerateTasks(t *testing.T) {
 	// Verify second project was changed
 	v, err = model.VersionFindOneId("sample_version")
 	assert.NoError(err)
-	p, _, _, err = model.LoadProjectForVersion(v, "mci", true)
+	projectInfo, err = model.LoadProjectForVersion(v, "mci", true)
+	p = projectInfo.Project
 	assert.NoError(err)
 	require.NotNil(p)
 	assert.Len(p.Tasks, 4)


### PR DESCRIPTION
[EVG-15923](https://jira.mongodb.org/browse/EVG-15923)

### Description 
There are instances now across the codebase where 4 part function returns are being used (ProjectRef, ProjectParser, ProjectConfig, error).  To clean this up these methods will now be returning ProjectInfo struct which contains a thruple of the 3 aforementioned structs.
### Testing 
Modified existing unit tests