### PR TITLE
EVG-16010 update subscription selector project ID when copying

### DIFF
--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -209,9 +209,9 @@ func (dc *DBSubscriptionConnector) CopyProjectSubscriptions(oldProject, newProje
 	for _, sub := range subs {
 		sub.Owner = newProject
 		sub.ID = ""
-		for _, selector := range sub.Selectors {
+		for i, selector := range sub.Selectors {
 			if selector.Type == event.SelectorProject && selector.Data == oldProject {
-				selector.Data = newProject
+				sub.Selectors[i].Data = newProject
 			}
 		}
 		catcher.Add(sub.Upsert())

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -209,6 +209,11 @@ func (dc *DBSubscriptionConnector) CopyProjectSubscriptions(oldProject, newProje
 	for _, sub := range subs {
 		sub.Owner = newProject
 		sub.ID = ""
+		for _, selector := range sub.Selectors {
+			if selector.Type == event.SelectorProject && selector.Data == oldProject {
+				selector.Data = newProject
+			}
+		}
 		catcher.Add(sub.Upsert())
 	}
 	return catcher.Resolve()


### PR DESCRIPTION
[EVG-16010](https://jira.mongodb.org/browse/EVG-16010)

### Description 
When copying subscriptions using the rest routes, need to update the selector ID as well, or else we notify using the wrong project (this is already handled in the UI).

### Testing 
Added unit test.