### PR TITLE
EVG-16024 set displayTaskId to empty for display tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1334,6 +1334,7 @@ func createDisplayTask(id string, displayName string, execTasks []string, bv *Bu
 		TriggerID:           v.TriggerID,
 		TriggerType:         v.TriggerType,
 		TriggerEvent:        v.TriggerEvent,
+		DisplayTaskId:       utility.ToStringPtr(""),
 	}
 	return t, nil
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1150,7 +1150,7 @@ func (t *Task) SetHasCedarResults(hasCedarResults, failedResults bool) error {
 		return err
 	}
 
-	if !t.DisplayOnly && t.IsPartOfDisplay() {
+	if t.IsPartOfDisplay() {
 		displayTask, err := t.GetDisplayTask()
 		if err != nil {
 			return errors.Wrap(err, "getting display task")
@@ -2552,6 +2552,9 @@ func (t *Task) IsPartOfSingleHostTaskGroup() bool {
 }
 
 func (t *Task) IsPartOfDisplay() bool {
+	if t.DisplayOnly {
+		return false
+	}
 	// if display task ID is nil, we need to check manually if we have an execution task
 	if t.DisplayTaskId == nil {
 		dt, err := t.GetDisplayTask()

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2552,9 +2552,6 @@ func (t *Task) IsPartOfSingleHostTaskGroup() bool {
 }
 
 func (t *Task) IsPartOfDisplay() bool {
-	if t.DisplayOnly {
-		return false
-	}
 	// if display task ID is nil, we need to check manually if we have an execution task
 	if t.DisplayTaskId == nil {
 		dt, err := t.GetDisplayTask()


### PR DESCRIPTION
[EVG-16024](https://jira.mongodb.org/browse/EVG-16024)

### Description 
We explicitly set DisplayTaskId at creation for tasks but not display tasks, which means we go through GetDisplayTask for them even though they won't ever have one. 

We could also check in IsPartOfDisplay that DisplayOnly is false, however I think populating DisplayTaskId as much as possible is best for the UI, and effectively does the same thing in IsPartOfDisplay. 