### PR TITLE
EVG-16024 reintroduce shortcircuit for SetHasCedarResults

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1150,7 +1150,7 @@ func (t *Task) SetHasCedarResults(hasCedarResults, failedResults bool) error {
 		return err
 	}
 
-	if t.IsPartOfDisplay() {
+	if !t.DisplayOnly && t.IsPartOfDisplay() {
 		displayTask, err := t.GetDisplayTask()
 		if err != nil {
 			return errors.Wrap(err, "getting display task")


### PR DESCRIPTION
[EVG-16024 ](https://jira.mongodb.org/browse/EVG-16024)

### Description 
Removing this line possibly caused an issue with the deploy this morning.