### PR TITLE
EVG-14232 Return error when shell.exec command is specified without a script

### DIFF
--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -52,7 +52,7 @@ func init() {
 		evergreen.S3PushCommandName:     s3PushFactory,
 		evergreen.S3PullCommandName:     s3PullFactory,
 		"shell.cleanup":                 shellCleanupFactory,
-		"shell.exec":                    shellExecFactory,
+		evergreen.ShellExecCommandName:  shellExecFactory,
 		"shell.track":                   shellTrackFactory,
 		"subprocess.exec":               subprocessExecFactory,
 		"subprocess.scripting":          subprocessScriptingFactory,

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	agentutil "github.com/evergreen-ci/evergreen/agent/util"
@@ -77,7 +78,7 @@ type shellExec struct {
 }
 
 func shellExecFactory() Command { return &shellExec{} }
-func (*shellExec) Name() string { return "shell.exec" }
+func (*shellExec) Name() string { return evergreen.ShellExecCommandName }
 
 // ParseParams reads in the command's parameters.
 func (c *shellExec) ParseParams(params map[string]interface{}) error {

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2022-01-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-01-04"
+	AgentVersion = "2022-01-10"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/globals.go
+++ b/globals.go
@@ -460,6 +460,7 @@ const (
 	HostCreateCommandName    = "host.create"
 	S3PushCommandName        = "s3.push"
 	S3PullCommandName        = "s3.pull"
+	ShellExecCommandName     = "shell.exec"
 )
 
 type SenderKey int

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -982,7 +982,7 @@ func validateCommands(section string, project *model.Project,
 				Message: fmt.Sprintf("cannot specify both command '%s' and function '%s'", cmd.Command, cmd.Function),
 			})
 		}
-		if cmd.Command == "shell.exec" && cmd.Params["script"] == nil {
+		if cmd.Command == evergreen.ShellExecCommandName && cmd.Params["script"] == nil {
 			errs = append(errs, ValidationError{
 				Level:   Warning,
 				Message: fmt.Sprintf("%s section: command '%s' specified without a script", section, cmd.Command),

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1026,6 +1026,7 @@ func validatePluginCommands(project *model.Project) ValidationErrors {
 					ValidationError{
 						Message: fmt.Sprintf("can not reference a function within a "+
 							"function: '%s' referenced within '%s'", c.Function, funcName),
+						Level: Warning,
 					},
 				)
 

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1016,6 +1016,7 @@ func validatePluginCommands(project *model.Project) ValidationErrors {
 				ValidationError{
 					Message: fmt.Sprintf("'%s' project's '%s' definition: %s",
 						project.Identifier, funcName, err),
+					Level: err.Level,
 				},
 			)
 		}
@@ -1026,7 +1027,6 @@ func validatePluginCommands(project *model.Project) ValidationErrors {
 					ValidationError{
 						Message: fmt.Sprintf("can not reference a function within a "+
 							"function: '%s' referenced within '%s'", c.Function, funcName),
-						Level: Warning,
 					},
 				)
 

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1015,7 +1015,7 @@ func validatePluginCommands(project *model.Project) ValidationErrors {
 			errs = append(errs,
 				ValidationError{
 					Message: fmt.Sprintf("'%s' project's '%s' definition: %s",
-						project.Identifier, funcName, err),
+						project.Identifier, funcName, err.Message),
 					Level: err.Level,
 				},
 			)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -984,8 +984,8 @@ func validateCommands(section string, project *model.Project,
 		}
 		if cmd.Command == "shell.exec" && cmd.Params["script"] == nil {
 			errs = append(errs, ValidationError{
-				Level:   Error,
-				Message: fmt.Sprintf("cannot specify command '%s' without a script", cmd.Command),
+				Level:   Warning,
+				Message: fmt.Sprintf("%s section: command '%s' specified without a script", section, cmd.Command),
 			})
 		}
 	}
@@ -1018,6 +1018,18 @@ func validatePluginCommands(project *model.Project) ValidationErrors {
 						project.Identifier, funcName, err),
 				},
 			)
+		}
+
+		for _, c := range commands.List() {
+			if c.Function != "" {
+				errs = append(errs,
+					ValidationError{
+						Message: fmt.Sprintf("can not reference a function within a "+
+							"function: '%s' referenced within '%s'", c.Function, funcName),
+					},
+				)
+
+			}
 		}
 
 		// this checks for duplicate function definitions in the project.

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -982,6 +982,12 @@ func validateCommands(section string, project *model.Project,
 				Message: fmt.Sprintf("cannot specify both command '%s' and function '%s'", cmd.Command, cmd.Function),
 			})
 		}
+		if cmd.Command == "shell.exec" && cmd.Params["script"] == nil {
+			errs = append(errs, ValidationError{
+				Level:   Error,
+				Message: fmt.Sprintf("cannot specify command '%s' without a script", cmd.Command),
+			})
+		}
 	}
 	return errs
 }
@@ -1012,18 +1018,6 @@ func validatePluginCommands(project *model.Project) ValidationErrors {
 						project.Identifier, funcName, err),
 				},
 			)
-		}
-
-		for _, c := range commands.List() {
-			if c.Function != "" {
-				errs = append(errs,
-					ValidationError{
-						Message: fmt.Sprintf("can not reference a function within a "+
-							"function: '%s' referenced within '%s'", c.Function, funcName),
-					},
-				)
-
-			}
 		}
 
 		// this checks for duplicate function definitions in the project.

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -985,7 +985,7 @@ func validateCommands(section string, project *model.Project,
 		if cmd.Command == evergreen.ShellExecCommandName && cmd.Params["script"] == nil {
 			errs = append(errs, ValidationError{
 				Level:   Warning,
-				Message: fmt.Sprintf("%s section: command '%s' specified without a script", section, cmd.Command),
+				Message: fmt.Sprintf("%s section: command '%s' specified without a script.", section, cmd.Command),
 			})
 		}
 	}

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2163,16 +2163,22 @@ tasks:
   exec_timeout_secs: 100
   commands:
   - command: shell.exec
+    params:
+      script: echo test
   depends_on:
   - name: task_in_a_task_group_1
 - name: task_in_a_task_group_1
   exec_timeout_secs: 100
   commands:
   - command: shell.exec
+    params:
+      script: echo test
 - name: task_in_a_task_group_2
   exec_timeout_secs: 100
   commands:
   - command: shell.exec
+    params:
+      script: echo test
 task_groups:
 - name: example_task_group
   max_hosts: 1
@@ -2220,6 +2226,8 @@ tasks:
   exec_timeout_secs: 100
   commands:
   - command: shell.exec
+    params:
+      script: echo test
 buildvariants:
 - name: "bv"
   display_name: "bv_display"
@@ -2249,6 +2257,8 @@ tasks:
 - name: task1
   commands:
   - command: shell.exec
+    params:
+      script: echo test
 buildvariants:
 - name: "bv"
   display_name: "bv_display"
@@ -2271,10 +2281,14 @@ tasks:
   exec_timeout_secs: 100
   commands:
   - command: shell.exec
+    params:
+      script: echo test
 - name: task_in_a_task_group
   exec_timeout_secs: 100
   commands:
   - command: shell.exec
+    params:
+      script: echo test
   depends_on:
   - name: not_in_a_task_group
 task_groups:
@@ -2322,14 +2336,21 @@ tasks:
   exec_timeout_secs: 100
   commands:
   - command: shell.exec
+    params:
+      script: |
+        echo "test"
 - name: two
   exec_timeout_secs: 100
   commands:
   - command: shell.exec
+    params:
+      script: echo "test"
 - name: display_three
   exec_timeout_secs: 100 
   commands:
   - command: shell.exec
+    params:
+      script: echo "test"
 buildvariants:
 - name: "bv"
   display_name: "bv_display"
@@ -2564,9 +2585,15 @@ tasks:
 - name: one
   commands:
   - command: shell.exec
+    params: 
+      script: | 
+        echo test
 - name: two
   commands:
   - command: shell.exec
+    params:
+      script: |
+        echo test
 buildvariants:
 - name: "bv-1"
   display_name: "bv_display"


### PR DESCRIPTION
[EVG-14232](https://jira.mongodb.org/browse/EVG-14232)

### Description 
Modify validateCommands to also return an error when command shell.exec is specified without a script.
