### PR TITLE
EVG-16071 Use DefaultExecTimeout global variable in agent package

### DIFF
--- a/agent/global.go
+++ b/agent/global.go
@@ -22,7 +22,7 @@ const (
 	// is allowed to run for, even if it is not idle. This default is used
 	// if exec_timeout_secs is not specified in the project file.
 	// exec_timeout_secs can be specified only at the project and task level.
-	defaultExecTimeout = 6 * time.Hour
+	DefaultExecTimeout = 6 * time.Hour
 
 	// defaultHeartbeatInterval is the interval after which agent sends a
 	// heartbeat to API server.

--- a/agent/task.go
+++ b/agent/task.go
@@ -391,7 +391,7 @@ func (tc *taskContext) getExecTimeout() time.Duration {
 	tc.RLock()
 	defer tc.RUnlock()
 	if tc.taskConfig == nil {
-		return defaultExecTimeout
+		return DefaultExecTimeout
 	}
 	if dynamicTimeout := tc.taskConfig.GetExecTimeout(); dynamicTimeout > 0 {
 		return time.Duration(dynamicTimeout) * time.Second
@@ -402,7 +402,7 @@ func (tc *taskContext) getExecTimeout() time.Duration {
 	if tc.taskConfig.Project.ExecTimeoutSecs > 0 {
 		return time.Duration(tc.taskConfig.Project.ExecTimeoutSecs) * time.Second
 	}
-	return defaultExecTimeout
+	return DefaultExecTimeout
 }
 
 func (tc *taskContext) setTaskConfig(taskConfig *internal.TaskConfig) {

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2022-01-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-01-04"
+	AgentVersion = "2022-01-10"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/globals.go
+++ b/globals.go
@@ -267,8 +267,6 @@ const (
 	TasksAlreadyGeneratedError = "generator already ran and generated tasks"
 	KeyTooLargeToIndexError    = "key too large to index"
 	InvalidDivideInputError    = "$divide only supports numeric types"
-
-	DefaultExecTimeout = 6 * time.Hour
 )
 
 var InternalAliases []string = []string{

--- a/globals.go
+++ b/globals.go
@@ -267,6 +267,8 @@ const (
 	TasksAlreadyGeneratedError = "generator already ran and generated tasks"
 	KeyTooLargeToIndexError    = "key too large to index"
 	InvalidDivideInputError    = "$divide only supports numeric types"
+
+	DefaultExecTimeout = 6 * time.Hour
 )
 
 var InternalAliases []string = []string{

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/agent"
 	"github.com/evergreen-ci/evergreen/agent/command"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
@@ -1913,7 +1914,7 @@ func checkTaskTimeout(project *model.Project) ValidationErrors {
 				ValidationError{
 					Message: fmt.Sprintf("project '%s' does not "+
 						"have an exec_timeout_secs defined at the top-level or on one or more tasks; these tasks will default to a timeout of %d",
-						project.Identifier, evergreen.DefaultExecTimeout),
+						project.Identifier, agent.DefaultExecTimeout),
 					Level: Warning,
 				},
 			)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1914,7 +1914,7 @@ func checkTaskTimeout(project *model.Project) ValidationErrors {
 				ValidationError{
 					Message: fmt.Sprintf("project '%s' does not "+
 						"have an exec_timeout_secs defined at the top-level or on one or more tasks; these tasks will default to a timeout of %d hours",
-						project.Identifier, agent.DefaultExecTimeout/time.Hour),
+						project.Identifier, int(agent.DefaultExecTimeout.Hours())),
 					Level: Warning,
 				},
 			)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1912,7 +1912,7 @@ func checkTaskTimeout(project *model.Project) ValidationErrors {
 			errs = append(errs,
 				ValidationError{
 					Message: fmt.Sprintf("project '%s' does not "+
-						"have an exec_timeout_secs defined on one or more tasks; these tasks will default to a timeout of %d",
+						"have an exec_timeout_secs defined at the top-level or on one or more tasks; these tasks will default to a timeout of %d",
 						project.Identifier, evergreen.DefaultExecTimeout),
 					Level: Warning,
 				},

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1912,8 +1912,8 @@ func checkTaskTimeout(project *model.Project) ValidationErrors {
 			errs = append(errs,
 				ValidationError{
 					Message: fmt.Sprintf("project '%s' does not "+
-						"have an exec_timeout_secs defined on one or more tasks; these tasks will default to a timeout of 6 hours",
-						project.Identifier),
+						"have an exec_timeout_secs defined on one or more tasks; these tasks will default to a timeout of %d",
+						project.Identifier, evergreen.DefaultExecTimeout),
 					Level: Warning,
 				},
 			)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1913,8 +1913,8 @@ func checkTaskTimeout(project *model.Project) ValidationErrors {
 			errs = append(errs,
 				ValidationError{
 					Message: fmt.Sprintf("project '%s' does not "+
-						"have an exec_timeout_secs defined at the top-level or on one or more tasks; these tasks will default to a timeout of %d",
-						project.Identifier, agent.DefaultExecTimeout),
+						"have an exec_timeout_secs defined at the top-level or on one or more tasks; these tasks will default to a timeout of %d hours",
+						project.Identifier, agent.DefaultExecTimeout/time.Hour),
 					Level: Warning,
 				},
 			)


### PR DESCRIPTION
[EVG-16071](https://jira.mongodb.org/browse/EVG-16071)

### Description 
Use `DefaultExecTimeout` global variable in agent package in log message

