### PR TITLE
EVG-15970 filter exec tasks out of waterfall query

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1773,7 +1773,8 @@ func FetchVersionsBuildsAndTasks(project *Project, skip int, numVersions int, sh
 		buildsByVersion[build.Version] = append(buildsByVersion[build.Version], build)
 	}
 
-	tasksFromDb, err := task.FindAll(task.ByVersions(versionIds).WithFields(task.StatusFields...))
+	// Filter out execution tasks because they'll be dropped when iterating through the build task cache anyway.
+	tasksFromDb, err := task.FindAll(task.NonExecutionTasksByVersions(versionIds).WithFields(task.StatusFields...))
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error fetching tasks from database")
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -376,6 +376,22 @@ func ByVersions(versions []string) db.Q {
 	return db.Query(bson.M{VersionKey: bson.M{"$in": versions}})
 }
 
+// NonExecutionTasksByVersion will filter out newer execution tasks that store if they have a display task.
+// Old execution tasks without display task ID populated will still be returned.
+func NonExecutionTasksByVersions(versions []string) db.Q {
+	return db.Query(bson.M{
+		VersionKey: bson.M{"$in": versions},
+		"$or": []bson.M{
+			{
+				DisplayTaskIdKey: bson.M{"$exists": false},
+			},
+			{
+				DisplayTaskIdKey: "",
+			},
+		},
+	})
+}
+
 // ByIdsBuildIdAndStatus creates a query to return tasks with a certain build id and statuses
 func ByIdsAndStatus(taskIds []string, statuses []string) db.Q {
 	return db.Query(bson.M{


### PR DESCRIPTION
[EVG-15970](https://jira.mongodb.org/browse/EVG-15970)

### Description 
The legacy waterfall has been causing CPU spikes; although we don't want to dedicate a lot of time to fixing the legacy queries, since the spruce UI is almost done, Jonathan identified loading the tasks as a big bottleneck, and we can make that less expensive by filtering out execution tasks, since we only use the display task statuses.

### Testing 
Wrote a unit test.
