### PR TITLE
EVG-16074: improve agent monitor logging

### DIFF
--- a/service/api_task.go
+++ b/service/api_task.go
@@ -288,7 +288,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
 		if err = currentHost.StopAgentMonitor(ctx, as.env); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
+			grip.Warning(message.WrapError(err, message.Fields{
 				"message":       "problem stopping agent monitor",
 				"host_id":       currentHost.Id,
 				"operation":     "end_task",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16074

### Description 
* Reduce log level during end task when attempting to shut down the monitor if host ran multiple consecutive tasks that system failed. In this case, the host may be in a bad state, so the host may not even be reachable to shut down the agent monitor in the first place.
* Move a log that checks the number of running agent monitors. This log is a state verification check that there should be at most one agent monitor process running on a task host at any given time. However, this can't be checked without iterating through all the processes returned from `withTaggedProcs` and totaling up the number. Since it requires some iteration, I moved it to the outer functions, which already iterate through the inputs anyways.

### Testing
N/A