### PR TITLE
EVG-15964 Add validation to handle bbProject in the patch route

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -2247,6 +2248,53 @@ func GetBuildBaronSettings(projectId string, version string) (evergreen.BuildBar
 		return evergreen.BuildBaronSettings{}, false
 	}
 	return projectRef.BuildBaronSettings, true
+}
+
+func BbProjectIsValid(projName string, proj evergreen.BuildBaronSettings) error {
+	webHook, _, err := IsWebhookConfigured(projName, "")
+	if err != nil {
+		return err
+	}
+	webhookConfigured := webHook.Endpoint != ""
+
+	if !webhookConfigured && proj.TicketCreateProject == "" && len(proj.TicketSearchProjects) == 0 {
+		return nil
+	}
+	if !webhookConfigured && len(proj.TicketSearchProjects) == 0 {
+		return errors.Errorf("Must provide projects to search")
+	}
+	if !webhookConfigured && proj.TicketCreateProject == "" {
+		return errors.Errorf("Must provide project to create tickets for")
+	}
+	if proj.BFSuggestionServer != "" {
+		if _, err = url.Parse(proj.BFSuggestionServer); err != nil {
+			return errors.Errorf("Failed to parse bf_suggestion_server for project '%s'", projName)
+		}
+		if proj.BFSuggestionUsername == "" && proj.BFSuggestionPassword != "" {
+			return errors.Errorf("Failed validating configuration for project '%s': "+
+				"bf_suggestion_password must be blank if bf_suggestion_username is blank", projName)
+		}
+		if proj.BFSuggestionTimeoutSecs <= 0 {
+			return errors.Errorf("Failed validating configuration for project '%s': "+
+				"bf_suggestion_timeout_secs must be positive", projName)
+		}
+	} else if proj.BFSuggestionUsername != "" || proj.BFSuggestionPassword != "" {
+		return errors.Errorf("Failed validating configuration for project '%s': "+
+			"bf_suggestion_username and bf_suggestion_password must be blank when alt_endpoint_url is blank", projName)
+	} else if proj.BFSuggestionTimeoutSecs != 0 {
+		return errors.Errorf("Failed validating configuration for project '%s': "+
+			"bf_suggestion_timeout_secs must be zero when bf_suggestion_url is blank", projName)
+	}
+	// the webhook cannot be used if the default build baron creation and search is configured
+	if webhookConfigured {
+		if len(proj.TicketCreateProject) != 0 {
+			return errors.Errorf("The custom file ticket webhook and the build baron should not both be configured")
+		}
+		if _, err = url.Parse(webHook.Endpoint); err != nil {
+			return errors.Errorf("Failed to parse webhook endpoint for project")
+		}
+	}
+	return nil
 }
 
 func ValidateTriggerDefinition(definition patch.PatchTriggerDefinition, parentProject string) (patch.PatchTriggerDefinition, error) {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -407,6 +407,11 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(catcher.Resolve(), "error validating triggers"))
 	}
 
+	err = dbModel.BbProjectIsValid(h.newProjectRef.Id, h.newProjectRef.BuildBaronSettings)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "error validating build baron config"))
+	}
+
 	newRevision := utility.FromStringPtr(h.apiNewProjectRef.Revision)
 	if newRevision != "" {
 		if err = h.sc.UpdateProjectRevision(h.project, newRevision); err != nil {

--- a/service/project.go
+++ b/service/project.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/evergreen-ci/evergreen"
@@ -566,7 +565,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Errorf("expected build baron config but was actually '%T'", i))
 		return
 	}
-	err = bbProjectIsValid(projectRef.Id, buildbaronConfig)
+	err = model.BbProjectIsValid(projectRef.Id, buildbaronConfig)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error validating build baron config input"))
 		return
@@ -1013,51 +1012,4 @@ func verifyAliasExists(alias, projectId string, newAliasDefinitions []model.Proj
 		}
 	}
 	return false, nil
-}
-
-func bbProjectIsValid(projName string, proj evergreen.BuildBaronSettings) error {
-	webHook, _, err := model.IsWebhookConfigured(projName, "")
-	if err != nil {
-		return err
-	}
-	webhookConfigured := webHook.Endpoint != ""
-
-	if !webhookConfigured && proj.TicketCreateProject == "" && len(proj.TicketSearchProjects) == 0 {
-		return nil
-	}
-	if !webhookConfigured && len(proj.TicketSearchProjects) == 0 {
-		return errors.Errorf("Must provide projects to search")
-	}
-	if !webhookConfigured && proj.TicketCreateProject == "" {
-		return errors.Errorf("Must provide project to create tickets for")
-	}
-	if proj.BFSuggestionServer != "" {
-		if _, err = url.Parse(proj.BFSuggestionServer); err != nil {
-			return errors.Errorf("Failed to parse bf_suggestion_server for project '%s'", projName)
-		}
-		if proj.BFSuggestionUsername == "" && proj.BFSuggestionPassword != "" {
-			return errors.Errorf("Failed validating configuration for project '%s': "+
-				"bf_suggestion_password must be blank if bf_suggestion_username is blank", projName)
-		}
-		if proj.BFSuggestionTimeoutSecs <= 0 {
-			return errors.Errorf("Failed validating configuration for project '%s': "+
-				"bf_suggestion_timeout_secs must be positive", projName)
-		}
-	} else if proj.BFSuggestionUsername != "" || proj.BFSuggestionPassword != "" {
-		return errors.Errorf("Failed validating configuration for project '%s': "+
-			"bf_suggestion_username and bf_suggestion_password must be blank when alt_endpoint_url is blank", projName)
-	} else if proj.BFSuggestionTimeoutSecs != 0 {
-		return errors.Errorf("Failed validating configuration for project '%s': "+
-			"bf_suggestion_timeout_secs must be zero when bf_suggestion_url is blank", projName)
-	}
-	// the webhook cannot be used if the default build baron creation and search is configured
-	if webhookConfigured {
-		if len(proj.TicketCreateProject) != 0 {
-			return errors.Errorf("The custom file ticket webhook and the build baron should not both be configured")
-		}
-		if _, err = url.Parse(webHook.Endpoint); err != nil {
-			return errors.Errorf("Failed to parse webhook endpoint for project")
-		}
-	}
-	return nil
 }

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -45,26 +45,26 @@ func TestValidateBbProject(t *testing.T) {
 		Identifier: "proj1",
 	}
 	assert.NoError(p.Insert())
-	assert.Nil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.Nil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:  "BFG",
 		TicketSearchProjects: []string{"BF", "BFG"},
 	}))
 
-	assert.Nil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.Nil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:  "BFG",
 		TicketSearchProjects: []string{"BF", "BFG"},
 	}))
 
-	assert.Nil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.Nil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:  "BFG",
 		TicketSearchProjects: []string{"BF", "BFG"},
 	}))
 
-	assert.NotNil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.NotNil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject: "BFG",
 	}))
 
-	assert.NotNil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.NotNil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketSearchProjects: []string{"BF", "BFG"},
 	}))
 }
@@ -76,7 +76,7 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 		Identifier: "proj1",
 	}
 	assert.NoError(p.Insert())
-	assert.Nil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.Nil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -85,34 +85,34 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 		BFSuggestionTimeoutSecs: 10,
 	}))
 
-	assert.Nil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.Nil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "https://evergreen.mongodb.com",
 		BFSuggestionTimeoutSecs: 10,
 	}))
 
-	assert.NotNil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.NotNil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:  "BFG",
 		TicketSearchProjects: []string{"BF", "BFG"},
 		BFSuggestionUsername: "user",
 		BFSuggestionPassword: "pass",
 	}))
 
-	assert.NotNil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.NotNil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionTimeoutSecs: 10,
 	}))
 
-	assert.NotNil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.NotNil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "://evergreen.mongodb.com",
 		BFSuggestionTimeoutSecs: 10,
 	}))
 
-	assert.NotNil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.NotNil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -120,14 +120,14 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 		BFSuggestionTimeoutSecs: 10,
 	}))
 
-	assert.NotNil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.NotNil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "https://evergreen.mongodb.com",
 		BFSuggestionTimeoutSecs: 0,
 	}))
 
-	assert.NotNil(bbProjectIsValid("proj1", evergreen.BuildBaronSettings{
+	assert.NotNil(model.BbProjectIsValid("proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "https://evergreen.mongodb.com",


### PR DESCRIPTION
[EVG-15964](https://jira.mongodb.org/browse/EVG-15964)

### Description 
The project patch route now validates whether or not the new project ref has a valid build baron config.
### Testing 
Added unit tests for happy and unhappy route