### PR TITLE
EVG-15056 create new routes to attach/detach repos

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -521,7 +521,6 @@ func (p *ProjectRef) DetachFromRepo(u *user.DBUser) error {
 	if err = p.RemoveFromRepoScope(); err != nil {
 		return err
 	}
-	p.RepoRefId = ""
 
 	mergedProject, err := FindMergedProjectRef(p.Id, "", false)
 	if err != nil {
@@ -615,7 +614,6 @@ func (p *ProjectRef) AttachToNewRepo(u *user.DBUser) error {
 		if err := p.RemoveFromRepoScope(); err != nil {
 			return errors.Wrapf(err, "error removing project from old repo scope")
 		}
-		p.RepoRefId = "" // will reassign this in add
 		if err := p.AddToRepoScope(u); err != nil {
 			return errors.Wrapf(err, "error addding project to new repo scope")
 		}
@@ -648,8 +646,11 @@ func (p *ProjectRef) RemoveFromRepoScope() error {
 	if err := removeViewRepoPermissionsFromBranchAdmins(p.RepoRefId, p.Admins); err != nil {
 		return errors.Wrap(err, "error removing view repo permissions from branch admins")
 	}
-	return errors.Wrapf(rm.RemoveResourceFromScope(GetRepoAdminScope(p.RepoRefId), p.Id),
-		"error removing from repo '%s' admin scope", p.Repo)
+	if err := rm.RemoveResourceFromScope(GetRepoAdminScope(p.RepoRefId), p.Id); err != nil {
+		return errors.Wrapf(err, "error removing from repo '%s' admin scope", p.Repo)
+	}
+	p.RepoRefId = ""
+	return nil
 }
 
 func (p *ProjectRef) AddPermissions(creator *user.DBUser) error {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -223,7 +223,7 @@ func (h *attachProjectToRepoHandler) Parse(ctx context.Context, r *http.Request)
 	if err != nil {
 		return errors.Wrap(err, "error finding project")
 	}
-	if h.project.RepoRefId != "" {
+	if h.project.UseRepoSettings() {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    "project is already attached to repo",
@@ -273,7 +273,7 @@ func (h *detachProjectFromRepoHandler) Parse(ctx context.Context, r *http.Reques
 	if err != nil {
 		return errors.Wrap(err, "error finding project")
 	}
-	if h.project.RepoRefId == "" {
+	if !h.project.UseRepoSettings() {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    "project isn't attached to a repo",

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -290,26 +290,6 @@ func (h *detachProjectFromRepoHandler) Run(ctx context.Context) gimlet.Responder
 	return gimlet.NewJSONResponse(struct{}{})
 }
 
-/*
-
-	// if the user explicitly set useRepoSettings, update the repo accordingly
-	if h.apiNewProjectRef.UseRepoSettings != nil {
-		useRepoSettings := utility.FromBoolPtr(h.apiNewProjectRef.UseRepoSettings)
-		// the user set it to false, and it was previously true - remove
-		if !useRepoSettings && h.newProjectRef.RepoRefId != "" {
-			if err = h.newProjectRef.RemoveFromRepoScope(); err != nil {
-				return gimlet.MakeJSONInternalErrorResponder(err)
-			}
-			// the user set it to true, and it was previously false - add
-		} else if useRepoSettings && h.newProjectRef.RepoRefId == "" {
-			if err = h.newProjectRef.AddToRepoScope(h.user); err != nil {
-				return gimlet.MakeJSONInternalErrorResponder(err)
-			}
-		}
-	}
-
-*/
-
 ////////////////////////////////////////////////////////////////////////
 //
 // PATCH /rest/v2/projects/{project_id}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -192,6 +192,126 @@ func (h *legacyVersionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 
 ////////////////////////////////////////////////////////////////////////
 //
+// POST /rest/v2/projects/{project_id}/attach_to_repo
+
+type attachProjectToRepoHandler struct {
+	project *dbModel.ProjectRef
+	user    *user.DBUser
+
+	sc data.Connector
+}
+
+func makeAttachProjectToRepoHandler(sc data.Connector) gimlet.RouteHandler {
+	return &attachProjectToRepoHandler{
+		sc: sc,
+	}
+}
+
+func (h *attachProjectToRepoHandler) Factory() gimlet.RouteHandler {
+	return &attachProjectToRepoHandler{
+		sc: h.sc,
+	}
+}
+
+// Parse fetches the project's identifier from the http request.
+func (h *attachProjectToRepoHandler) Parse(ctx context.Context, r *http.Request) error {
+	projectIdentifier := gimlet.GetVars(r)["project_id"]
+	h.user = MustHaveUser(ctx)
+
+	var err error
+	h.project, err = h.sc.FindProjectById(projectIdentifier, false, false)
+	if err != nil {
+		return errors.Wrap(err, "error finding project")
+	}
+	if h.project.RepoRefId != "" {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    "project is already attached to repo",
+		}
+	}
+	return nil
+}
+
+func (h *attachProjectToRepoHandler) Run(ctx context.Context) gimlet.Responder {
+	if err := h.project.AttachToRepo(h.user); err != nil {
+		return gimlet.MakeJSONErrorResponder(err)
+	}
+
+	return gimlet.NewJSONResponse(struct{}{})
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+// POST /rest/v2/projects/{project_id}/detach_from_repo
+
+type detachProjectFromRepoHandler struct {
+	project *dbModel.ProjectRef
+	user    *user.DBUser
+
+	sc data.Connector
+}
+
+func makeDetachProjectFromRepoHandler(sc data.Connector) gimlet.RouteHandler {
+	return &detachProjectFromRepoHandler{
+		sc: sc,
+	}
+}
+
+func (h *detachProjectFromRepoHandler) Factory() gimlet.RouteHandler {
+	return &detachProjectFromRepoHandler{
+		sc: h.sc,
+	}
+}
+
+// Parse fetches the project's identifier from the http request.
+func (h *detachProjectFromRepoHandler) Parse(ctx context.Context, r *http.Request) error {
+	projectIdentifier := gimlet.GetVars(r)["project_id"]
+	h.user = MustHaveUser(ctx)
+
+	var err error
+	h.project, err = h.sc.FindProjectById(projectIdentifier, false, false)
+	if err != nil {
+		return errors.Wrap(err, "error finding project")
+	}
+	if h.project.RepoRefId == "" {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    "project isn't attached to a repo",
+		}
+	}
+	return nil
+}
+
+func (h *detachProjectFromRepoHandler) Run(ctx context.Context) gimlet.Responder {
+	if err := h.project.DetachFromRepo(h.user); err != nil {
+		return gimlet.MakeJSONErrorResponder(err)
+	}
+
+	return gimlet.NewJSONResponse(struct{}{})
+}
+
+/*
+
+	// if the user explicitly set useRepoSettings, update the repo accordingly
+	if h.apiNewProjectRef.UseRepoSettings != nil {
+		useRepoSettings := utility.FromBoolPtr(h.apiNewProjectRef.UseRepoSettings)
+		// the user set it to false, and it was previously true - remove
+		if !useRepoSettings && h.newProjectRef.RepoRefId != "" {
+			if err = h.newProjectRef.RemoveFromRepoScope(); err != nil {
+				return gimlet.MakeJSONInternalErrorResponder(err)
+			}
+			// the user set it to true, and it was previously false - add
+		} else if useRepoSettings && h.newProjectRef.RepoRefId == "" {
+			if err = h.newProjectRef.AddToRepoScope(h.user); err != nil {
+				return gimlet.MakeJSONInternalErrorResponder(err)
+			}
+		}
+	}
+
+*/
+
+////////////////////////////////////////////////////////////////////////
+//
 // PATCH /rest/v2/projects/{project_id}
 
 type projectIDPatchHandler struct {
@@ -430,31 +550,13 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 
-	// if owner/repo has changed or we're toggling repo settings off, update scope
-	if h.newProjectRef.Owner != h.originalProject.Owner || h.newProjectRef.Repo != h.originalProject.Repo ||
-		(!h.newProjectRef.UseRepoSettings() && h.originalProject.UseRepoSettings()) {
+	// if owner/repo has changed and the project is attached to repo, update scope and repo accordingly
+	if h.newProjectRef.UseRepoSettings() && h.ownerRepoChanged() {
 		if err = h.newProjectRef.RemoveFromRepoScope(); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "error removing project from old repo scope"))
 		}
-		if err = h.newProjectRef.AddToRepoScope(h.user); err != nil {
+		if err = h.newProjectRef.AddToRepoScope(h.user); err != nil { // will re-add using the new owner/repo
 			return gimlet.MakeJSONInternalErrorResponder(err)
-		}
-	}
-
-	// if the user explicitly set useRepoSettings, update the repo accordingly
-	if h.apiNewProjectRef.UseRepoSettings != nil {
-		useRepoSettings := utility.FromBoolPtr(h.apiNewProjectRef.UseRepoSettings)
-		// the user set it to false, and it was previously true - remove
-		if !useRepoSettings && h.newProjectRef.RepoRefId != "" {
-			if err = h.newProjectRef.RemoveFromRepoScope(); err != nil {
-				return gimlet.MakeJSONInternalErrorResponder(err)
-			}
-			h.newProjectRef.RepoRefId = ""
-			// the user set it to true, and it was previously false - add
-		} else if useRepoSettings && h.newProjectRef.RepoRefId == "" {
-			if err = h.newProjectRef.AddToRepoScope(h.user); err != nil {
-				return gimlet.MakeJSONInternalErrorResponder(err)
-			}
 		}
 	}
 
@@ -511,6 +613,10 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "Cannot set HTTP status code to %d", http.StatusOK))
 	}
 	return responder
+}
+
+func (h projectIDPatchHandler) ownerRepoChanged() bool {
+	return h.newProjectRef.Owner != h.originalProject.Owner || h.newProjectRef.Repo != h.originalProject.Repo
 }
 
 // verify for a given alias that either the user has added a new definition or there is a pre-existing definition

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -826,7 +826,7 @@ func TestDetachProjectFromRepo(t *testing.T) {
 	}
 	assert.NoError(t, projVars.Insert())
 
-	repoRef := &serviceModel.RepoRef{serviceModel.ProjectRef{
+	repoRef := &serviceModel.RepoRef{ProjectRef: serviceModel.ProjectRef{
 		Id:                    "myRepo",
 		Owner:                 "evergreen-ci",
 		Repo:                  "evergreen",

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -152,6 +152,8 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}").Version(2).Delete().Wrap(requireUser, requireProjectAdmin, editProjectSettings).RouteHandler(makeDeleteProject(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Get().Wrap(requireUser, addProject, viewProjectSettings).RouteHandler(makeGetProjectByID(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Patch().Wrap(requireUser, addProject, requireProjectAdmin, editProjectSettings).RouteHandler(makePatchProjectByID(sc, env.Settings()))
+	app.AddRoute("/projects/{project_id}/attach_to_repo").Version(2).Post().Wrap(requireUser, addProject, requireProjectAdmin, editProjectSettings).RouteHandler(makeAttachProjectToRepoHandler(sc))
+	app.AddRoute("/projects/{project_id}/detach_from_repo").Version(2).Post().Wrap(requireUser, addProject, requireProjectAdmin, editProjectSettings).RouteHandler(makeDetachProjectFromRepoHandler(sc))
 	app.AddRoute("/projects/{project_id}/repotracker").Version(2).Post().Wrap(requireUser, addProject).RouteHandler(makeRunRepotrackerForProject(sc))
 	app.AddRoute("/projects/{project_id}").Version(2).Put().Wrap(createProject).RouteHandler(makePutProjectByID(sc))
 	app.AddRoute("/projects/{project_id}/copy").Version(2).Post().Wrap(requireUser, addProject, createProject, requireProjectAdmin, editProjectSettings).RouteHandler(makeCopyProject(sc))


### PR DESCRIPTION
[EVG-15056](https://jira.mongodb.org/browse/EVG-15056)

### Description 
In my opinion, the PATCH project route is doing too much. To have attach/detach behavior be consistent with what's in the new UI, they work best as their own route. Because no one is using this yet, this won't break any workflows.

### Testing 
Created new tests and modified old tests to use the new routes.