### PR TITLE
EVG-16064: Ensure on-demand intent hosts send their instance ID

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2022-01-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-01-10"
+	AgentVersion = "2022-01-13"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/globals.go
+++ b/globals.go
@@ -421,13 +421,15 @@ var (
 		ProviderNameDocker,
 	}
 
+	// ProviderSpotEc2Type includes all cloud provider types that manage EC2
+	// spot instances.
 	ProviderSpotEc2Type = []string{
 		ProviderNameEc2Auto,
 		ProviderNameEc2Spot,
 		ProviderNameEc2Fleet,
 	}
 
-	// ProviderEC2Type includes all that cloud provider types that manage EC2
+	// ProviderEc2Type includes all cloud provider types that manage EC2
 	// instances.
 	ProviderEc2Type = []string{
 		ProviderNameEc2Auto,

--- a/globals.go
+++ b/globals.go
@@ -421,16 +421,25 @@ var (
 		ProviderNameDocker,
 	}
 
-	SystemVersionRequesterTypes = []string{
-		RepotrackerVersionRequester,
-		TriggerRequester,
-		GitTagRequester,
-	}
-
 	ProviderSpotEc2Type = []string{
 		ProviderNameEc2Auto,
 		ProviderNameEc2Spot,
 		ProviderNameEc2Fleet,
+	}
+
+	// ProviderEC2Type includes all that cloud provider types that manage EC2
+	// instances.
+	ProviderEc2Type = []string{
+		ProviderNameEc2Auto,
+		ProviderNameEc2Spot,
+		ProviderNameEc2Fleet,
+		ProviderNameEc2OnDemand,
+	}
+
+	SystemVersionRequesterTypes = []string{
+		RepotrackerVersionRequester,
+		TriggerRequester,
+		GitTagRequester,
 	}
 )
 

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -297,11 +297,8 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-// GenerateName generates a unique instance name for a distro.
+// GenerateName generates a unique instance name for a host in a distro.
 func (d *Distro) GenerateName() string {
-	// gceMaxNameLength is the maximum length of an instance name permitted by GCE.
-	const gceMaxNameLength = 63
-
 	switch d.Provider {
 	case evergreen.ProviderNameStatic:
 		return "static"
@@ -312,6 +309,9 @@ func (d *Distro) GenerateName() string {
 	name := fmt.Sprintf("evg-%s-%s-%d", d.Id, time.Now().Format(evergreen.NameTimeFormat), rand.Int())
 
 	if d.Provider == evergreen.ProviderNameGce {
+		// gceMaxNameLength is the maximum length of an instance name permitted by GCE.
+		const gceMaxNameLength = 63
+
 		// Ensure all characters in tags are on the allowlist
 		r, _ := regexp.Compile("[^a-z0-9_-]+")
 		name = string(r.ReplaceAll([]byte(strings.ToLower(name)), []byte("")))

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -424,6 +424,9 @@ func (h *Host) NeedsPortBindings() bool {
 	return h.DockerOptions.PublishPorts && h.PortBindings == nil
 }
 
+// IsIntentHostId returns whether or not the host ID is for an intent host
+// backed by an ephemeral cloud host. This function does not work for intent
+// hosts representing Docker containers.
 func IsIntentHostId(id string) bool {
 	return strings.HasPrefix(id, "evg-")
 }
@@ -758,6 +761,7 @@ func (h *Host) ResetLastCommunicated() error {
 	return nil
 }
 
+// Terminate marks a host as terminated and sets the termination time.
 func (h *Host) Terminate(user, reason string) error {
 	err := h.SetTerminated(user, reason)
 	if err != nil {

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -137,6 +137,7 @@ func TestHostTerminationJob(t *testing.T) {
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
 		},
 		"NoopsWithAlreadyTerminatedIntentHost": func(ctx context.Context, t *testing.T, env *mock.Environment, mcp cloud.MockProvider, h *host.Host) {
+			// The ID must be a valid intent host ID.
 			h.Id = h.Distro.GenerateName()
 			h.Status = evergreen.HostTerminated
 			require.NoError(t, h.Insert())

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -110,7 +110,7 @@ func TestHostTerminationJob(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.NotEqual(t, evergreen.HostRunning, dbHost.Status)
 		},
-		"TerminatesUninitializedIntentHost": func(ctx context.Context, t *testing.T, env *mock.Environment, mcp cloud.MockProvider, h *host.Host) {
+		"MarksUninitializedIntentHostAsTerminated": func(ctx context.Context, t *testing.T, env *mock.Environment, mcp cloud.MockProvider, h *host.Host) {
 			h.Status = evergreen.HostUninitialized
 			require.NoError(t, h.Insert())
 
@@ -123,8 +123,22 @@ func TestHostTerminationJob(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
 		},
-		"TerminatesBuildingFailedIntentHost": func(ctx context.Context, t *testing.T, env *mock.Environment, mcp cloud.MockProvider, h *host.Host) {
+		"MarksBuildingFailedIntentHostAsTerminated": func(ctx context.Context, t *testing.T, env *mock.Environment, mcp cloud.MockProvider, h *host.Host) {
 			h.Status = evergreen.HostBuildingFailed
+			require.NoError(t, h.Insert())
+
+			j := NewHostTerminationJob(env, h, true, "foo")
+			j.Run(ctx)
+			require.NoError(t, j.Error())
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
+		},
+		"NoopsWithAlreadyTerminatedIntentHost": func(ctx context.Context, t *testing.T, env *mock.Environment, mcp cloud.MockProvider, h *host.Host) {
+			h.Id = h.Distro.GenerateName()
+			h.Status = evergreen.HostTerminated
 			require.NoError(t, h.Insert())
 
 			j := NewHostTerminationJob(env, h, true, "foo")


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16064

### Description 
The EC2 instance ID wasn't being sent by agents running in on-demand hosts because I accidentally excluded it from the filter in `(*agent.Agent).getEC2InstanceID`. This caused an issue where the intent host's agent would check in to the app server but wouldn't send its instance ID. Without an instance ID, we can't do anything to the host, so we couldn't do the host doc swap to turn it into a real host to actually run tasks, nor could we terminate it during the host termination job.

* Fix the agent logic to send the instance ID for on-demand hosts. This will also fix the handful of on-demand intent hosts that are currently unable to send an instance ID.
* Retry fetching the instance ID on every agent request for the next task in case previous attempts failed. This makes it less likely that the agent remains in a bad state if the EC2 instance metadata is temporarily unavailable for whatever reason.
* Make re-termination of intent hosts that are already terminated idempotent by no-oping.
* Improve docs on some existing methods.

### Testing 
Updated existing tests for proper intent host termination.
