### PR TITLE
EVG-16124: Fix SSH command to add public key to existing host and standardize authorized keys file

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -831,12 +831,20 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, opts host.Hos
 	}
 
 	if opts.AddKey != "" {
-		if err := h.AddPubKey(ctx, opts.AddKey); err != nil {
-			catcher.Wrapf(err, "can't add key to host '%s'", h.Id)
+		if err := addPublicKey(ctx, h, opts.AddKey); err != nil {
+			catcher.Wrapf(err, "adding key to host '%s'", h.Id)
 		}
 	}
 
 	return catcher.Resolve()
+}
+
+// addPublicKey adds a public key to the authorized keys for SSH.
+func addPublicKey(ctx context.Context, h *host.Host, key string) error {
+	if logs, err := h.RunSSHCommand(ctx, h.AddPublicKeyScript(key)); err != nil {
+		return errors.Wrap(err, logs)
+	}
+	return nil
 }
 
 // GetInstanceStatuses returns the current status of a slice of EC2 instances.

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -166,7 +165,7 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 	}
 
 	// modify the setup script to add the user's public key
-	d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", so.PublicKey, filepath.Join(d.HomeDir(), ".ssh", "authorized_keys"))
+	d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", so.PublicKey, d.GetAuthorizedKeysFile())
 
 	// fake out replacing spot instances with on-demand equivalents
 	if d.Provider == evergreen.ProviderNameEc2Spot || d.Provider == evergreen.ProviderNameEc2Fleet {

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -463,6 +463,16 @@ func (d *Distro) HomeDir() string {
 	return filepath.Join("/home", d.User)
 }
 
+// GetAuthorizedKeysFile returns the path to the SSH authorized keys file for
+// the distro. If not explicitly set for the distro, it returns the default
+// location of the SSH authorized keys file in the home directory.
+func (d *Distro) GetAuthorizedKeysFile() string {
+	if d.AuthorizedKeysFile == "" {
+		return filepath.Join(d.HomeDir(), ".ssh", "authorized_keys")
+	}
+	return d.AuthorizedKeysFile
+}
+
 // IsParent returns whether the distro is the parent distro for any container pool
 func (d *Distro) IsParent(s *evergreen.Settings) bool {
 	for _, p := range s.ContainerPools.Pools {

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -591,3 +591,23 @@ func TestClientURL(t *testing.T) {
 	expected = "www.example.com/clients/linux_amd64/evergreen"
 	assert.Equal(t, expected, d.ClientURL(settings))
 }
+
+func TestGetAuthorizedKeysFile(t *testing.T) {
+	t.Run("ReturnsDistroAuthorizedKeysFile", func(t *testing.T) {
+		expected := "/path/to/authorized_keys"
+		d := Distro{
+			User:               "user",
+			Arch:               evergreen.ArchLinuxAmd64,
+			AuthorizedKeysFile: expected,
+		}
+		assert.Equal(t, expected, d.GetAuthorizedKeysFile())
+	})
+	t.Run("DefaultsToDistroHomeDirectoryAuthorizedKeysFileIfDistroAuthorizedKeysIsUnset", func(t *testing.T) {
+		expected := "/home/user/.ssh/authorized_keys"
+		d := Distro{
+			User: "user",
+			Arch: evergreen.ArchLinuxAmd64,
+		}
+		assert.Equal(t, expected, d.GetAuthorizedKeysFile())
+	})
+}

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1154,6 +1154,31 @@ func TestSpawnHostSetupCommands(t *testing.T) {
 	assert.Equal(t, expected, cmd)
 }
 
+func TestAddPublicKeyScript(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T, h *Host){
+		"CreatesExpectedScript": func(t *testing.T, h *Host) {
+			expected := "grep -qxF \"public_key\" /home/user/.ssh/authorized_keys || echo \"\npublic_key\" >> /home/user/.ssh/authorized_keys"
+			actual := h.AddPublicKeyScript("public_key")
+			assert.Equal(t, expected, actual)
+		},
+		"TrimsPublicKeysWithNewlinesToSingleLinePublicKey": func(t *testing.T, h *Host) {
+			expected := "grep -qxF \"public_key\" /home/user/.ssh/authorized_keys || echo \"\npublic_key\" >> /home/user/.ssh/authorized_keys"
+			actual := h.AddPublicKeyScript("\npublic_key\n")
+			assert.Equal(t, expected, actual)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			h := &Host{
+				Id: "id",
+				Distro: distro.Distro{
+					User: "user",
+				},
+			}
+			tCase(t, h)
+		})
+	}
+}
+
 func TestCheckUserDataProvisioningStartedCommand(t *testing.T) {
 	for testName, testCase := range map[string]func(t *testing.T, h *Host){
 		"CreatesExpectedCommand": func(t *testing.T, h *Host) {

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -360,7 +359,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	d.Provider = provider
 
 	if publicKey != "" {
-		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", publicKey, filepath.Join(d.HomeDir(), ".ssh", "authorized_keys"))
+		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", publicKey, d.GetAuthorizedKeysFile())
 	}
 
 	// set provider settings


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16124

### Description 
When uploading a public key from a file using the CLI, the file may contain trailing newlines because it's standard for regular files to have a newline at the end. The shell script used to add the public key to the host didn't account for this, so running the script over SSH does not work if there's a newline in the public key text. I trimmed the surrounding newlines in the public key.

I also standardized how the host gets its authorized keys file, since there's a few places where a script adds a public key to the authorized keys file (for host.create, the distro setup script, and this host modification script to add an SSH key). The precedence should be to use the distro authorized key file if explicitly set, or fall back to the default SSH authorized keys file (`~/.ssh/authorized_keys`).

### Testing 
Added unit tests. I verified in staging that adding a key works from the CLI and UI regardless of whether there's surrounding newlines in the file.