### PR TITLE
EVG-15966 hint paginated test results queries

### DIFF
--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -348,3 +348,22 @@ func Aggregate(collection string, pipeline interface{}, out interface{}) error {
 
 	return errors.WithStack(pipe.All(out))
 }
+
+// AggregateWithHint runs aggregate and takes in a hint (example structure: {key: 1, key2: 1})
+func AggregateWithHint(collection string, pipeline interface{}, hint interface{}, out interface{}) error {
+	session, db, err := GetGlobalSessionFactory().GetSession()
+	if err != nil {
+		err = errors.Wrap(err, "error establishing db connection")
+		grip.Error(err)
+		return err
+	}
+	defer session.Close()
+
+	// NOTE: with the legacy driver, this function unset the
+	// socket timeout, which isn't really an option here. (other
+	// operations had a 90s timeout, which is no longer specified)
+
+	pipe := db.C(collection).Pipe(pipeline).Hint(hint)
+
+	return errors.WithStack(pipe.All(out))
+}

--- a/graphql/integration_atomic_test.go
+++ b/graphql/integration_atomic_test.go
@@ -21,10 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/model/testresult"
-
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/graphql"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -32,6 +30,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/service"
 	"github.com/evergreen-ci/evergreen/testutil"

--- a/graphql/integration_atomic_test.go
+++ b/graphql/integration_atomic_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/testresult"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/graphql"
 	"github.com/evergreen-ci/evergreen/model"
@@ -111,6 +114,10 @@ func setup(t *testing.T, state *atomicGraphQLState) {
 	}
 
 	require.NoError(t, usr.UpdateAPIKey(apiKey))
+	require.NoError(t, env.DB().CreateCollection(ctx, testresult.Collection))
+	require.NoError(t, db.EnsureIndex(testresult.Collection, mongo.IndexModel{
+		Keys: testresult.TestResultsIndex}))
+
 	// Create scope and role collection to avoid RoleManager from trying to create them in a collection https://jira.mongodb.org/browse/EVG-15499
 	require.NoError(t, env.DB().CreateCollection(ctx, evergreen.ScopeCollection))
 	require.NoError(t, env.DB().CreateCollection(ctx, evergreen.RoleCollection))

--- a/graphql/integration_test.go
+++ b/graphql/integration_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/service"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -63,6 +65,9 @@ func (s *graphQLSuite) SetupSuite() {
 	s.url = server.URL
 	s.apiKey = apiKey
 	s.apiUser = apiUser
+
+	s.Require().NoError(db.EnsureIndex(testresult.Collection, mongo.IndexModel{
+		Keys: testresult.TestResultsIndex}))
 }
 
 func (s *graphQLSuite) TestQueries() {

--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -178,7 +178,7 @@ type TestResultsFilterSortPaginateOpts struct {
 	TestName string
 }
 
-var testResultsIndex = bson.D{
+var TestResultsIndex = bson.D{
 	{
 		Key:   TaskIDKey,
 		Value: 1,
@@ -256,7 +256,7 @@ func TestResultsFilterSortPaginate(opts TestResultsFilterSortPaginateOpts) ([]Te
 	if opts.Limit > 0 {
 		pipeline = append(pipeline, bson.M{"$limit": opts.Limit})
 	}
-	err := db.AggregateWithHint(Collection, pipeline, testResultsIndex, &tests)
+	err := db.AggregateWithHint(Collection, pipeline, TestResultsIndex, &tests)
 	if err != nil {
 		return nil, err
 	}

--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -148,36 +148,6 @@ func Aggregate(pipeline []bson.M, results interface{}) error {
 		results)
 }
 
-// TestResultsQuery is a query for returning test results to the REST v2 API.
-func TestResultsQuery(taskIds []string, testId, testName, status string, limit, execution int) db.Q {
-	match := bson.M{
-		TaskIDKey:    bson.M{"$in": taskIds},
-		ExecutionKey: execution,
-	}
-	if status != "" {
-		match[StatusKey] = status
-	}
-	if testName != "" {
-		match[TestFileKey] = testName
-	}
-	if testId != "" {
-		match[IDKey] = bson.M{"$gte": mgobson.ObjectId(testId)}
-	}
-
-	q := db.Query(match).Project(bson.M{
-		TaskIDKey:    0,
-		ExecutionKey: 0,
-	})
-
-	// Don't sort if unlimited EVG-13965.
-	if limit > 0 {
-		q = q.Limit(limit)
-		q = q.Sort([]string{IDKey})
-	}
-
-	return q
-}
-
 func TestResultCount(taskIds []string, testName string, statuses []string, execution int) (int, error) {
 	filter := bson.M{
 		TaskIDKey:    bson.M{"$in": taskIds},
@@ -206,6 +176,17 @@ type TestResultsFilterSortPaginateOpts struct {
 	TaskIDs  []string
 	TestID   string
 	TestName string
+}
+
+var testResultsIndex = bson.D{
+	{
+		Key:   TaskIDKey,
+		Value: 1,
+	},
+	{
+		Key:   ExecutionKey,
+		Value: 1,
+	},
 }
 
 // TestResultsFilterSortPaginate is a query for returning test results from supplied TaskIDs.
@@ -275,7 +256,7 @@ func TestResultsFilterSortPaginate(opts TestResultsFilterSortPaginateOpts) ([]Te
 	if opts.Limit > 0 {
 		pipeline = append(pipeline, bson.M{"$limit": opts.Limit})
 	}
-	err := db.Aggregate(Collection, pipeline, &tests)
+	err := db.AggregateWithHint(Collection, pipeline, testResultsIndex, &tests)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/data/test_test.go
+++ b/rest/data/test_test.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"testing"
 
+	"go.mongodb.org/mongo-driver/mongo"
+
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -145,7 +147,8 @@ func TestGetTestCountByTaskIdAndFilter(t *testing.T) {
 func TestFindTestsByTaskId(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, testresult.Collection))
-
+	assert.NoError(db.EnsureIndex(testresult.Collection, mongo.IndexModel{
+		Keys: testresult.TestResultsIndex}))
 	serviceContext := &DBConnector{}
 
 	emptyTask := &task.Task{
@@ -167,7 +170,6 @@ func TestFindTestsByTaskId(t *testing.T) {
 	}
 	last := len(testObjects) - 1
 	sort.StringSlice(testObjects).Sort()
-
 	for i := 0; i < numTasks; i++ {
 		id := fmt.Sprintf("task_%d", i)
 		testTask := &task.Task{


### PR DESCRIPTION
[EVG-15966](https://jira.mongodb.org/browse/EVG-15966)

### Description 
For the /tasks/<task_id>/tests route, we pass in a TestId, which causes mongo to use the _id index (very slow) instead of the task_id / execution index -- ordering the query with TestId last doesn't fix this. Created a new function to hint at the right index to use.

### Testing 
Tested with the commandline that this index _does_ improve queries significantly, tested on staging and confirmed it passes existing tests.