### PR TITLE
EVG-16148 Handle nil pointer dereference for home volumes 

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -125,19 +125,19 @@ func (r *hostResolver) DistroID(ctx context.Context, obj *restModel.APIHost) (*s
 }
 
 func (r *hostResolver) HomeVolume(ctx context.Context, obj *restModel.APIHost) (*restModel.APIVolume, error) {
-	if utility.FromStringPtr(obj.HomeVolumeID) == "" {
+	if utility.FromStringPtr(obj.HomeVolumeID) != "" {
 		volId := utility.FromStringPtr(obj.HomeVolumeID)
 		volume, err := r.sc.FindVolumeById(volId)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting volume %s: %s", volId, err.Error()))
 		}
 		if volume == nil {
-			grip.Warning(message.WrapError(err, message.Fields{
-				"message":   "Error could not find the volume associated with this host",
+			grip.Error(message.Fields{
+				"message":   "could not find the volume associated with this host",
 				"ticket":    "EVG-16149",
 				"host_id":   obj.Id,
 				"volume_id": volId,
-			}))
+			})
 			return nil, nil
 		}
 		apiVolume := &restModel.APIVolume{}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -132,6 +132,11 @@ func (r *hostResolver) HomeVolume(ctx context.Context, obj *restModel.APIHost) (
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting volume %s: %s", volId, err.Error()))
 		}
 		if volume == nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"message":   "Error could not find the volume associated with this host",
+				"host_id":   obj.Id,
+				"volume_id": volId,
+			}))
 			return nil, nil
 		}
 		apiVolume := &restModel.APIVolume{}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -134,6 +134,7 @@ func (r *hostResolver) HomeVolume(ctx context.Context, obj *restModel.APIHost) (
 		if volume == nil {
 			grip.Warning(message.WrapError(err, message.Fields{
 				"message":   "Error could not find the volume associated with this host",
+				"ticket":    "EVG-16149",
 				"host_id":   obj.Id,
 				"volume_id": volId,
 			}))

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -125,11 +125,14 @@ func (r *hostResolver) DistroID(ctx context.Context, obj *restModel.APIHost) (*s
 }
 
 func (r *hostResolver) HomeVolume(ctx context.Context, obj *restModel.APIHost) (*restModel.APIVolume, error) {
-	if obj.HomeVolumeID != nil && *obj.HomeVolumeID != "" {
-		volId := *obj.HomeVolumeID
+	if utility.FromStringPtr(obj.HomeVolumeID) == "" {
+		volId := utility.FromStringPtr(obj.HomeVolumeID)
 		volume, err := r.sc.FindVolumeById(volId)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting volume %s: %s", volId, err.Error()))
+		}
+		if volume == nil {
+			return nil, nil
 		}
 		apiVolume := &restModel.APIVolume{}
 		err = apiVolume.BuildFromService(volume)


### PR DESCRIPTION
[EVG-16148](https://jira.mongodb.org/browse/EVG-16148)

### Description 
This bit of code technically shouldn't be hit. But since it is causing nil pointer errors i've included this as a fix. I've opened EVG-16149 to look into why we are not finding volumes for some hosts. 