### PR TITLE
EVG-15966 add index to local evergreen

### DIFF
--- a/cmd/load-smoke-data/load-smoke-data.go
+++ b/cmd/load-smoke-data/load-smoke-data.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -58,6 +59,11 @@ func insertFileDocsToDb(ctx context.Context, fn string, catcher grip.Catcher, db
 	// task_logg collection belongs to the logs db
 	if collName == model.TaskLogCollection {
 		collection = logsDb.Collection(collName)
+	}
+	if collName == testresult.Collection { // add the necessary test results index
+		_, err = collection.Indexes().CreateOne(ctx, mongo.IndexModel{
+			Keys: testresult.TestResultsIndex})
+		catcher.Add(err)
 	}
 	scanner := bufio.NewScanner(file)
 	count := 0


### PR DESCRIPTION
[EVG-15966](https://jira.mongodb.org/browse/EVG-15966)

### Description 
Need index to fix e2e tests and local evergreen.

### Testing 
Ran evergreen-local and verified index exists:
```
MongoDB Enterprise rs0:PRIMARY> db.testresults.getIndexes()
[
	{
		"v" : 2,
		"key" : {
			"_id" : 1
		},
		"name" : "_id_",
		"ns" : "evergreen_local.testresults"
	},
	{
		"v" : 2,
		"key" : {
			"task_id" : 1,
			"task_execution" : 1
		},
		"name" : "task_id_1_task_execution_1",
		"ns" : "evergreen_local.testresults"
	}
]
```