### PR TITLE
EVG-16039 schedule/unschedule task group tasks when activating/deactivating one

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1724,7 +1724,7 @@ func GetRecursiveDependenciesUp(tasks []Task, depCache map[string]Task) ([]Task,
 		return nil, nil
 	}
 
-	deps, err := Find(ByIds(tasksToFind).WithFields(IdKey, DependsOnKey, ExecutionKey, BuildIdKey))
+	deps, err := Find(ByIds(tasksToFind).WithFields(IdKey, DependsOnKey, ExecutionKey, BuildIdKey, StatusKey, TaskGroupKey))
 	if err != nil {
 		return nil, errors.Wrap(err, "can't get dependencies")
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -94,12 +94,19 @@ func SetActiveState(t *task.Task, caller string, active bool) error {
 		// If the task was not activated by step back, and either the caller is not evergreen
 		// or the task was originally activated by evergreen, deactivate the task
 	} else if !evergreen.IsSystemActivator(caller) || evergreen.IsSystemActivator(t.ActivatedBy) {
-		// We are trying to deactivate this task
-		// So we check if the person trying to deactivate is evergreen.
-		// If it is not, then we can deactivate it.
-		// Otherwise, if it was originally activated by evergreen, anything can
-		// deactivate it.
 		var err error
+		// deactivate later tasks in the group as well, since they won't succeed without this one
+		if t.IsPartOfSingleHostTaskGroup() {
+			tasksInGroup, err := task.FindTaskGroupFromBuild(t.BuildId, t.TaskGroup)
+			if err != nil {
+				return errors.Wrapf(err, "error finding task group '%s'", t.TaskGroup)
+			}
+			for _, taskInGroup := range tasksInGroup {
+				if taskInGroup.TaskGroupOrder > t.TaskGroupOrder {
+					originalTasks = append(originalTasks, taskInGroup)
+				}
+			}
+		}
 		err = task.DeactivateTasks(originalTasks, caller)
 		if err != nil {
 			return errors.Wrap(err, "error deactivating task")

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -279,6 +279,60 @@ func TestSetActiveState(t *testing.T) {
 			So(dtFromDb.Activated, ShouldBeTrue)
 		})
 	})
+	Convey("with a task that is part of a task group", t, func() {
+		require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection),
+			"Error clearing task and build collections")
+		b := &build.Build{
+			Id:      "build",
+			Version: "version",
+		}
+		So(b.Insert(), ShouldBeNil)
+		taskDef := &task.Task{ // should restart
+			Id:                "task1",
+			Activated:         true,
+			BuildId:           b.Id,
+			Status:            evergreen.TaskFailed,
+			DistroId:          "arch",
+			Version:           "version",
+			TaskGroup:         "tg",
+			TaskGroupMaxHosts: 1,
+			TaskGroupOrder:    1,
+		}
+		So(taskDef.Insert(), ShouldBeNil)
+
+		taskDef.Id = "task2"
+		taskDef.Activated = false
+		taskDef.Status = evergreen.TaskUndispatched
+		taskDef.TaskGroupOrder = 2
+		So(taskDef.Insert(), ShouldBeNil) // should be scheduled
+
+		taskDef.Id = "task4"
+		taskDef.TaskGroupOrder = 4
+		So(taskDef.Insert(), ShouldBeNil) //should not be activated
+
+		taskDef.Id = "task3"
+		taskDef.TaskGroupOrder = 3
+		So(taskDef.Insert(), ShouldBeNil) // the task we're activating
+
+		So(SetActiveState(taskDef, "test", true), ShouldBeNil)
+
+		taskGroup, err := task.FindTaskGroupFromBuild(b.Id, taskDef.TaskGroup)
+		So(err, ShouldBeNil)
+		So(taskGroup, ShouldHaveLength, 4)
+		for _, t := range taskGroup {
+			if t.TaskGroupOrder < 4 {
+				So(t.Activated, ShouldBeTrue)
+				So(t.Status, ShouldEqual, evergreen.TaskUndispatched)
+			} else {
+				So(t.Activated, ShouldBeFalse)
+			}
+			if t.TaskGroupOrder == 1 { // the first task should be restarted
+				So(t.Execution, ShouldEqual, 1)
+			} else {
+				So(t.Execution, ShouldEqual, 0)
+			}
+		}
+	})
 }
 
 func TestActivatePreviousTask(t *testing.T) {


### PR DESCRIPTION
[EVG-16039](https://jira.mongodb.org/browse/EVG-16039)

### Description 
The Activating interaction can be seen here: task group task 2 was [scheduled by the user](https://evergreen.mongodb.com/task/mongodb_mongo_v4.4_macos_stitch_support_run_tests_a17699e50a4d75d91b5788baa7eb15916341b905_21_12_24_16_20_52/0#/log/EV) but because [task group task 1](https://evergreen.mongodb.com/task/mongodb_mongo_v4.4_macos_stitch_support_install_tests_a17699e50a4d75d91b5788baa7eb15916341b905_21_12_24_16_20_52#/log/EV) had already been scheduled and run successfully a previous day, this wasn't reset and so didn't run with task group task 1.

Also handling the deactivating case (if task group task 1 is deactivated, then task group task 2 should also be deactivated). https://jira.mongodb.org/browse/BF-23865

### Testing 
Added unit tests.