### PR TITLE
EVG-16154 merge buildvariants without using pointers

### DIFF
--- a/model/project_parser_merge_functions.go
+++ b/model/project_parser_merge_functions.go
@@ -188,27 +188,27 @@ func (pp *ParserProject) mergeUnique(toMerge *ParserProject) error {
 func (pp *ParserProject) mergeBuildVariant(toMerge *ParserProject) error {
 	catcher := grip.NewBasicCatcher()
 
-	bvs := map[string]*parserBV{}
+	bvs := map[string]parserBV{}
 	for _, bv := range pp.BuildVariants {
 		newBv := bv
-		bvs[bv.Name] = &newBv
+		bvs[bv.Name] = newBv
 	}
 	for _, bv := range toMerge.BuildVariants {
-		if _, ok := bvs[bv.Name]; ok {
+		if currentBV, ok := bvs[bv.Name]; ok {
 			if !bv.canMerge() {
 				catcher.Errorf("build variant '%s' has been declared already", bv.Name)
 			} else {
-				bvs[bv.Name].Tasks = append(bvs[bv.Name].Tasks, bv.Tasks...)
-				bvs[bv.Name].DisplayTasks = append(bvs[bv.Name].DisplayTasks, bv.DisplayTasks...)
+				currentBV.Tasks = append(bvs[bv.Name].Tasks, bv.Tasks...)
+				currentBV.DisplayTasks = append(bvs[bv.Name].DisplayTasks, bv.DisplayTasks...)
+				bvs[bv.Name] = currentBV
 			}
 		} else {
-			pp.BuildVariants = append(pp.BuildVariants, bv)
-			bvs[bv.Name] = &bv
+			bvs[bv.Name] = bv
 		}
 	}
 	pp.BuildVariants = make([]parserBV, 0, len(bvs))
 	for _, bv := range bvs {
-		pp.BuildVariants = append(pp.BuildVariants, *bv)
+		pp.BuildVariants = append(pp.BuildVariants, bv)
 	}
 
 	return catcher.Resolve()

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1952,10 +1952,11 @@ func TestMergeUniqueFail(t *testing.T) {
 }
 
 func TestMergeBuildVariant(t *testing.T) {
+	bvExisting := "a_variant"
 	main := &ParserProject{
 		BuildVariants: []parserBV{
 			parserBV{
-				Name: "a_variant",
+				Name: bvExisting,
 				Tasks: parserBVTaskUnits{
 					parserBVTaskUnit{
 						Name:      "say-bye",
@@ -1971,11 +1972,12 @@ func TestMergeBuildVariant(t *testing.T) {
 			},
 		},
 	}
-
+	bvNew1 := "another_variant"
+	bvNew2 := "one_more_variant"
 	add := &ParserProject{
 		BuildVariants: []parserBV{
 			parserBV{
-				Name: "a_variant",
+				Name: bvExisting,
 				Tasks: parserBVTaskUnits{
 					parserBVTaskUnit{
 						Name: "add this task",
@@ -1983,7 +1985,7 @@ func TestMergeBuildVariant(t *testing.T) {
 				},
 			},
 			parserBV{
-				Name:      "another_variant",
+				Name:      bvNew1,
 				BatchTime: &bvBatchTime,
 				Tasks: parserBVTaskUnits{
 					parserBVTaskUnit{
@@ -2001,13 +2003,31 @@ func TestMergeBuildVariant(t *testing.T) {
 					},
 				},
 			},
+			parserBV{
+				Name: bvNew2,
+				Tasks: parserBVTaskUnits{
+					parserBVTaskUnit{
+						Name:      "say-bye",
+						BatchTime: &taskBatchTime,
+					},
+				},
+			},
 		},
 	}
 
 	err := main.mergeBuildVariant(add)
 	assert.NoError(t, err)
-	assert.Equal(t, len(main.BuildVariants), 2)
-	assert.Equal(t, len(main.BuildVariants[0].Tasks), 2)
+	require.Equal(t, len(main.BuildVariants), 3)
+	bvNames := []string{}
+	for _, bv := range main.BuildVariants {
+		if bv.Name == bvNew1 {
+			assert.Equal(t, len(bv.Tasks), 2)
+		}
+		bvNames = append(bvNames, bv.Name)
+	}
+	assert.Contains(t, bvNames, bvExisting)
+	assert.Contains(t, bvNames, bvNew1)
+	assert.Contains(t, bvNames, bvNew2)
 }
 
 func TestMergeBuildVariantFail(t *testing.T) {


### PR DESCRIPTION
[EVG-16154](https://jira.mongodb.org/browse/EVG-16154)

### Description 
Because we were using pointers to merge build variants, the parserBVs we save to the map are all overwritten to be the last pp.BuildVariants. By not using pointers, we fix this problem and avoid running into it for this operation in the future.

### Testing 
Added a unit test that failed before the fix (bvNew2 didn't exist but bvNew1 existed twice).