### PR TITLE
EVG-16157: 6 months TTL on test_results

### DIFF
--- a/units/data_cleanup_testresults.go
+++ b/units/data_cleanup_testresults.go
@@ -82,7 +82,7 @@ func (j *dataCleanupTestResults) Run(ctx context.Context) {
 	)
 
 	totalDocs, _ := j.env.DB().Collection(testresult.Collection).EstimatedDocumentCount(ctx)
-	timestamp := time.Now().Add(time.Duration(-365*24) * time.Hour)
+	timestamp := time.Now().Add(time.Duration(-182*24) * time.Hour)
 
 LOOP:
 	for {


### PR DESCRIPTION
[EVG-16157](https://jira.mongodb.org/browse/EVG-16157)

### Description 
This will reduce the size of the collection, and will make it easier to delete once we migrate to cedar.

### Testing 
I did not
