### PR TITLE
EVG-15949 Introduce toggle to allow version control for project configs

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -44,24 +44,25 @@ type ProjectRef struct {
 	// Identifier must be unique, but is modifiable. Used by users.
 	Identifier string `bson:"identifier" json:"identifier" yaml:"identifier"`
 
-	DisplayName          string              `bson:"display_name" json:"display_name,omitempty" yaml:"display_name"`
-	Enabled              *bool               `bson:"enabled,omitempty" json:"enabled,omitempty" yaml:"enabled"`
-	Private              *bool               `bson:"private,omitempty" json:"private,omitempty" yaml:"private"`
-	Restricted           *bool               `bson:"restricted,omitempty" json:"restricted,omitempty" yaml:"restricted"`
-	Owner                string              `bson:"owner_name" json:"owner_name" yaml:"owner"`
-	Repo                 string              `bson:"repo_name" json:"repo_name" yaml:"repo"`
-	Branch               string              `bson:"branch_name" json:"branch_name" yaml:"branch"`
-	RemotePath           string              `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
-	PatchingDisabled     *bool               `bson:"patching_disabled,omitempty" json:"patching_disabled,omitempty"`
-	RepotrackerDisabled  *bool               `bson:"repotracker_disabled,omitempty" json:"repotracker_disabled,omitempty" yaml:"repotracker_disabled"`
-	DispatchingDisabled  *bool               `bson:"dispatching_disabled,omitempty" json:"dispatching_disabled,omitempty" yaml:"dispatching_disabled"`
-	PRTestingEnabled     *bool               `bson:"pr_testing_enabled,omitempty" json:"pr_testing_enabled,omitempty" yaml:"pr_testing_enabled"`
-	GithubChecksEnabled  *bool               `bson:"github_checks_enabled,omitempty" json:"github_checks_enabled,omitempty" yaml:"github_checks_enabled"`
-	BatchTime            int                 `bson:"batch_time" json:"batch_time" yaml:"batchtime"`
-	DeactivatePrevious   *bool               `bson:"deactivate_previous,omitempty" json:"deactivate_previous,omitempty" yaml:"deactivate_previous"`
-	DefaultLogger        string              `bson:"default_logger" json:"default_logger" yaml:"default_logger"`
-	NotifyOnBuildFailure *bool               `bson:"notify_on_failure,omitempty" json:"notify_on_failure,omitempty"`
-	Triggers             []TriggerDefinition `bson:"triggers" json:"triggers"`
+	DisplayName           string              `bson:"display_name" json:"display_name,omitempty" yaml:"display_name"`
+	Enabled               *bool               `bson:"enabled,omitempty" json:"enabled,omitempty" yaml:"enabled"`
+	Private               *bool               `bson:"private,omitempty" json:"private,omitempty" yaml:"private"`
+	Restricted            *bool               `bson:"restricted,omitempty" json:"restricted,omitempty" yaml:"restricted"`
+	Owner                 string              `bson:"owner_name" json:"owner_name" yaml:"owner"`
+	Repo                  string              `bson:"repo_name" json:"repo_name" yaml:"repo"`
+	Branch                string              `bson:"branch_name" json:"branch_name" yaml:"branch"`
+	RemotePath            string              `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
+	PatchingDisabled      *bool               `bson:"patching_disabled,omitempty" json:"patching_disabled,omitempty"`
+	RepotrackerDisabled   *bool               `bson:"repotracker_disabled,omitempty" json:"repotracker_disabled,omitempty" yaml:"repotracker_disabled"`
+	DispatchingDisabled   *bool               `bson:"dispatching_disabled,omitempty" json:"dispatching_disabled,omitempty" yaml:"dispatching_disabled"`
+	VersionControlEnabled *bool               `bson:"version_control_enabled,omitempty" json:"version_control_enabled,omitempty" yaml:"version_control_enabled"`
+	PRTestingEnabled      *bool               `bson:"pr_testing_enabled,omitempty" json:"pr_testing_enabled,omitempty" yaml:"pr_testing_enabled"`
+	GithubChecksEnabled   *bool               `bson:"github_checks_enabled,omitempty" json:"github_checks_enabled,omitempty" yaml:"github_checks_enabled"`
+	BatchTime             int                 `bson:"batch_time" json:"batch_time" yaml:"batchtime"`
+	DeactivatePrevious    *bool               `bson:"deactivate_previous,omitempty" json:"deactivate_previous,omitempty" yaml:"deactivate_previous"`
+	DefaultLogger         string              `bson:"default_logger" json:"default_logger" yaml:"default_logger"`
+	NotifyOnBuildFailure  *bool               `bson:"notify_on_failure,omitempty" json:"notify_on_failure,omitempty"`
+	Triggers              []TriggerDefinition `bson:"triggers" json:"triggers"`
 	// all aliases defined for the project
 	PatchTriggerAliases []patch.PatchTriggerDefinition `bson:"patch_trigger_aliases" json:"patch_trigger_aliases"`
 	// all PatchTriggerAliases applied to github patch intents
@@ -756,7 +757,7 @@ func FindMergedProjectRef(identifier string, version string, includeProjectConfi
 			return nil, errors.Wrapf(err, "error merging repo ref '%s' for project '%s'", repoRef.RepoRefId, pRef.Identifier)
 		}
 	}
-	if includeProjectConfig {
+	if includeProjectConfig && *pRef.VersionControlEnabled {
 		err = pRef.MergeWithProjectConfig(version)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Unable to merge project config with project ref %s", pRef.Identifier)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -307,6 +307,10 @@ func (p *ProjectRef) DoesTrackPushEvents() bool {
 	return utility.FromBoolPtr(p.TracksPushEvents)
 }
 
+func (p *ProjectRef) IsVersionControlEnabled() bool {
+	return utility.FromBoolPtr(p.VersionControlEnabled)
+}
+
 func (p *ProjectRef) IsPerfEnabled() bool {
 	return utility.FromBoolPtr(p.PerfEnabled)
 }
@@ -757,7 +761,7 @@ func FindMergedProjectRef(identifier string, version string, includeProjectConfi
 			return nil, errors.Wrapf(err, "error merging repo ref '%s' for project '%s'", repoRef.RepoRefId, pRef.Identifier)
 		}
 	}
-	if includeProjectConfig && *pRef.VersionControlEnabled {
+	if includeProjectConfig && pRef.IsVersionControlEnabled() {
 		err = pRef.MergeWithProjectConfig(version)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Unable to merge project config with project ref %s", pRef.Identifier)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -74,6 +74,7 @@ func TestFindMergedProjectRef(t *testing.T) {
 		PatchingDisabled:      utility.FalsePtr(),
 		RepotrackerDisabled:   utility.TruePtr(),
 		DeactivatePrevious:    utility.TruePtr(),
+		VersionControlEnabled: utility.TruePtr(),
 		PRTestingEnabled:      nil,
 		GitTagVersionsEnabled: nil,
 		GitTagAuthorizedTeams: []string{},

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -504,6 +504,7 @@ mciModule.controller(
             restricted: $scope.projectRef.restricted,
             patching_disabled: $scope.projectRef.patching_disabled,
             dispatching_disabled: $scope.projectRef.dispatching_disabled,
+            version_control_enabled: $scope.projectRef.version_control_enabled,
             task_sync: $scope.projectRef.task_sync,
             repotracker_disabled: $scope.projectRef.repotracker_disabled,
             alert_config: $scope.projectRef.alert_config || {},

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -463,6 +463,7 @@ type APIProjectRef struct {
 	PatchingDisabled            *bool                     `json:"patching_disabled"`
 	RepotrackerDisabled         *bool                     `json:"repotracker_disabled"`
 	DispatchingDisabled         *bool                     `json:"dispatching_disabled"`
+	VersionControlEnabled       *bool                     `json:"version_control_enabled"`
 	DisabledStatsCache          *bool                     `json:"disabled_stats_cache"`
 	FilesIgnoredFromCache       []*string                 `json:"files_ignored_from_cache"`
 	Admins                      []*string                 `json:"admins"`

--- a/service/project.go
+++ b/service/project.go
@@ -303,6 +303,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		PatchingDisabled        bool                           `json:"patching_disabled"`
 		RepotrackerDisabled     bool                           `json:"repotracker_disabled"`
 		DispatchingDisabled     bool                           `json:"dispatching_disabled"`
+		VersionControlEnabled   bool                           `json:"version_control_enabled"`
 		AlertConfig             map[string][]struct {
 			Provider string                 `json:"provider"`
 			Settings map[string]interface{} `json:"settings"`
@@ -627,6 +628,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectRef.TaskAnnotationSettings = taskannotationsConfig
 	projectRef.PatchingDisabled = &responseRef.PatchingDisabled
 	projectRef.DispatchingDisabled = &responseRef.DispatchingDisabled
+	projectRef.VersionControlEnabled = &responseRef.VersionControlEnabled
 	projectRef.RepotrackerDisabled = &responseRef.RepotrackerDisabled
 	projectRef.NotifyOnBuildFailure = &responseRef.NotifyOnBuildFailure
 	projectRef.Triggers = responseRef.Triggers

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -130,6 +130,8 @@ Evergreen Projects
       <div class="col-lg-6">
         <input type="checkbox" id="version-control-enabled-checkbox" ng-model="settingsFormData.version_control_enabled" />
         <label for="version-control-enabled-checkbox">Enable Config Version Control</label>
+<!--        todo: write documentation and provide link below-->
+        <div class="muted small">Allow defining of <a href="">these properties</a> on this page in config yaml rather than exclusively in this UI.</div>
       </div>
     </div>
     <div id="dispatching-disabled" class="form-group">

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -331,7 +331,7 @@ Evergreen Projects
           <input type="checkbox" id="version-control-enabled-checkbox" ng-model="settingsFormData.version_control_enabled" />
           <label for="version-control-enabled-checkbox">Enable Config Version Control</label>
           <!--        todo: write documentation and provide link below-->
-          <div class="muted small">Allow defining of <a href="">these properties</a> on this page in config yaml rather than exclusively in this UI.</div>
+          <div class="muted small">Allow defining of <a href="https://github.com/evergreen-ci/evergreen/wiki/Project-and-Distro-Settings#version-control">these properties</a> on this page in config yaml rather than exclusively in this UI.</div>
         </div>
       </div>
     </div>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -126,6 +126,12 @@ Evergreen Projects
         </div>
       </div>
     </div>
+    <div id="version-control-enabled" class="form-group">
+      <div class="col-lg-6">
+        <input type="checkbox" id="version-control-enabled-checkbox" ng-model="settingsFormData.version_control_enabled" />
+        <label for="version-control-enabled-checkbox">Enable Config Version Control</label>
+      </div>
+    </div>
     <div id="dispatching-disabled" class="form-group">
       <div class="col-lg-6">
         <input type="checkbox" id="dispatching-disabled-checkbox" ng-model="settingsFormData.dispatching_disabled" />

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -126,14 +126,6 @@ Evergreen Projects
         </div>
       </div>
     </div>
-    <div id="version-control-enabled" class="form-group">
-      <div class="col-lg-6">
-        <input type="checkbox" id="version-control-enabled-checkbox" ng-model="settingsFormData.version_control_enabled" />
-        <label for="version-control-enabled-checkbox">Enable Config Version Control</label>
-<!--        todo: write documentation and provide link below-->
-        <div class="muted small">Allow defining of <a href="">these properties</a> on this page in config yaml rather than exclusively in this UI.</div>
-      </div>
-    </div>
     <div id="dispatching-disabled" class="form-group">
       <div class="col-lg-6">
         <input type="checkbox" id="dispatching-disabled-checkbox" ng-model="settingsFormData.dispatching_disabled" />
@@ -325,6 +317,21 @@ Evergreen Projects
         <div class="col-lg-6">
           <input type="checkbox" id="enable-cedar-test-results-checkbox" ng-model="settingsFormData.cedar_test_results_enabled"/>
           <label for="enable-cedar-test-results-checkbox">Enable Cedar Test Results</label>
+        </div>
+      </div>
+    </div>
+    <div class="variables">
+      <div class="form-group">
+        <div class="col-header col-lg-8 form-control-static">
+          <h3>Version Control</h3>
+        </div>
+      </div>
+      <div id="version-control-enabled" class="form-group">
+        <div class="col-lg-6">
+          <input type="checkbox" id="version-control-enabled-checkbox" ng-model="settingsFormData.version_control_enabled" />
+          <label for="version-control-enabled-checkbox">Enable Config Version Control</label>
+          <!--        todo: write documentation and provide link below-->
+          <div class="muted small">Allow defining of <a href="">these properties</a> on this page in config yaml rather than exclusively in this UI.</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
[EVG-15949](https://jira.mongodb.org/browse/EVG-15949)

### Description 
Introduced a toggle on the project page when unset, we will not bother to attempt to unmarshal a project's config yaml into new config properties in order to improve performance and preserve resources.
### Testing 
Toggled in staging with toggle unset, confirmed no entry to project_configs DB occurred even when yaml was configured with new props.