### PR TITLE
EVG-16161 filter bot users out of users/permissions role

### DIFF
--- a/model/user/db.go
+++ b/model/user/db.go
@@ -189,11 +189,15 @@ func FindByRole(role string) ([]DBUser, error) {
 	return res, errors.Wrapf(err, "error finding users with role '%s'", role)
 }
 
-func FindByRoles(roles []string) ([]DBUser, error) {
+// FindUsersByRoles returns only real users (i.e. omits API only users).
+func FindUsersByRoles(roles []string) ([]DBUser, error) {
 	res := []DBUser{}
 	err := db.FindAllQ(
 		Collection,
-		db.Query(bson.M{RolesKey: bson.M{"$in": roles}}),
+		db.Query(bson.M{
+			RolesKey:   bson.M{"$in": roles},
+			OnlyAPIKey: bson.M{"$ne": true},
+		}),
 		&res,
 	)
 	return res, errors.Wrapf(err, "error finding users with roles '%v'", roles)

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -189,8 +189,8 @@ func FindByRole(role string) ([]DBUser, error) {
 	return res, errors.Wrapf(err, "error finding users with role '%s'", role)
 }
 
-// FindUsersByRoles returns only real users (i.e. omits API only users).
-func FindUsersByRoles(roles []string) ([]DBUser, error) {
+// FindHumanUsersByRoles returns human users that have any of the given roles.
+func FindHumanUsersByRoles(roles []string) ([]DBUser, error) {
 	res := []DBUser{}
 	err := db.FindAllQ(
 		Collection,

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -376,7 +376,7 @@ func (h *allUsersPermissionsGetHandler) Run(ctx context.Context) gimlet.Responde
 		}
 	}
 	// get users with roles
-	usersWithRoles, err := user.FindByRoles(roleIds)
+	usersWithRoles, err := user.FindUsersByRoles(roleIds)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "error finding users for roles '%v'", roleIds))
 	}

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -376,7 +376,7 @@ func (h *allUsersPermissionsGetHandler) Run(ctx context.Context) gimlet.Responde
 		}
 	}
 	// get users with roles
-	usersWithRoles, err := user.FindUsersByRoles(roleIds)
+	usersWithRoles, err := user.FindHumanUsersByRoles(roleIds)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "error finding users for roles '%v'", roleIds))
 	}

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -486,12 +486,20 @@ func TestGetUsersForResourceId(t *testing.T) {
 		},
 	}
 	u3 := user.DBUser{
-		Id: "nobody",
+		Id:      "nobody",
+		OnlyAPI: false,
 		SystemRoles: []string{
 			"other_project_access",
 		},
 	}
-	assert.NoError(t, db.InsertMany(user.Collection, u1, u2, u3))
+	u4 := user.DBUser{ // should never be returned
+		Id:      "Data",
+		OnlyAPI: true,
+		SystemRoles: []string{
+			"bot_access",
+		},
+	}
+	assert.NoError(t, db.InsertMany(user.Collection, u1, u2, u3, u4))
 	basicRole := gimlet.Role{
 		ID:    "basic_project_access",
 		Scope: "some_projects",
@@ -517,9 +525,17 @@ func TestGetUsersForResourceId(t *testing.T) {
 			evergreen.PermissionTasks: evergreen.TasksView.Value,
 		},
 	}
+	botRole := gimlet.Role{
+		ID:    "bot_access",
+		Scope: "all_projects",
+		Permissions: gimlet.Permissions{
+			evergreen.PermissionPatches: evergreen.PatchSubmitAdmin.Value,
+		},
+	}
 	assert.NoError(t, rm.UpdateRole(basicRole))
 	assert.NoError(t, rm.UpdateRole(superRole))
 	assert.NoError(t, rm.UpdateRole(otherRole))
+	assert.NoError(t, rm.UpdateRole(botRole))
 	someScope := gimlet.Scope{
 		ID:        "some_projects",
 		Type:      evergreen.ProjectResourceType,


### PR DESCRIPTION
[EVG-16161](https://jira.mongodb.org/browse/EVG-16161)

### Description 
Some permissions we may choose to only give to bots (for example, https://github.com/evergreen-ci/evergreen/blob/8e010917fc3774e4f32d8c2843c6d23cbed623a5/globals.go#L834) which is breaking mana's assumptions about our permissions. That being said, they don't really need to know about bots so we can just filter them out. Will also add to documentation.

### Testing 
Added a unit test.
