### PR TITLE
EVG-16154 check patch type to change where to read included files from

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -712,6 +712,12 @@ func (p *Patch) IsParent() bool {
 	return len(p.Triggers.ChildPatches) > 0
 }
 
+// ShouldPatchFileWithDiff returns true if the patch should read locally
+// (i.e. is not a PR or CQ patch) and the config has changed.
+func (p *Patch) ShouldPatchFileWithDiff(path string) bool {
+	return !(p.IsGithubPRPatch() || p.IsPRMergePatch()) && p.ConfigChanged(path)
+}
+
 func (p *Patch) GetPatchIndex(parentPatch *Patch) (int, error) {
 	if !p.IsChild() {
 		return -1, nil

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -712,7 +712,7 @@ func (p *Patch) IsParent() bool {
 	return len(p.Triggers.ChildPatches) > 0
 }
 
-// ShouldPatchFileWithDiff returns true if the patch should read locally
+// ShouldPatchFileWithDiff returns true if the patch should read with diff
 // (i.e. is not a PR or CQ patch) and the config has changed.
 func (p *Patch) ShouldPatchFileWithDiff(path string) bool {
 	return !(p.IsGithubPRPatch() || p.IsPRMergePatch()) && p.ConfigChanged(path)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -155,7 +155,7 @@ func GetPatchedProject(ctx context.Context, p *patch.Patch, githubOauthToken str
 	}
 
 	// apply remote configuration patch if needed
-	if !(p.IsGithubPRPatch() || p.IsPRMergePatch()) && p.ConfigChanged(path) {
+	if p.ShouldPatchFileWithDiff(path) {
 		opts.ReadFileFrom = ReadFromPatchDiff
 		projectFileBytes, err = MakePatchedConfig(ctx, env, p, path, string(projectFileBytes))
 		if err != nil {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -585,14 +585,8 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 			grip.Critical(message.NewError(errors.WithStack(err)))
 			return nil, nil, errors.Wrapf(err, LoadProjectError)
 		}
-		// read from the patch diff if a change has been made in any of the include files
-		if opts.ReadFileFrom == ReadFromPatch || opts.ReadFileFrom == ReadFromPatchDiff {
-			if opts.PatchOpts.patch != nil && opts.PatchOpts.patch.ShouldPatchFileWithDiff(path.FileName) {
-				opts.ReadFileFrom = ReadFromPatchDiff
-			} else {
-				opts.ReadFileFrom = ReadFromPatch
-			}
-		}
+		opts.UpdateForFile(path.FileName)
+
 		var yaml []byte
 		opts.Identifier = identifier
 		opts.RemotePath = path.FileName
@@ -654,6 +648,19 @@ type GetProjectOpts struct {
 type PatchOpts struct {
 	patch *patch.Patch
 	env   evergreen.Environment
+}
+
+// UpdateNewFile modifies ReadFileInto to read from the patch diff
+// if the included file has been modified
+func (opts *GetProjectOpts) UpdateForFile(path string) {
+	if opts.ReadFileFrom == ReadFromPatch || opts.ReadFileFrom == ReadFromPatchDiff {
+		if opts.PatchOpts.patch != nil && opts.PatchOpts.patch.ShouldPatchFileWithDiff(path) {
+			opts.ReadFileFrom = ReadFromPatchDiff
+		} else {
+			opts.ReadFileFrom = ReadFromPatch
+		}
+	}
+	return
 }
 
 func retrieveFile(ctx context.Context, opts GetProjectOpts) ([]byte, error) {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -650,8 +650,8 @@ type PatchOpts struct {
 	env   evergreen.Environment
 }
 
-// UpdateNewFile modifies ReadFileInto to read from the patch diff
-// if the included file has been modified
+// UpdateNewFile modifies ReadFileFrom to read from the patch diff
+// if the included file has been modified.
 func (opts *GetProjectOpts) UpdateForFile(path string) {
 	if opts.ReadFileFrom == ReadFromPatch || opts.ReadFileFrom == ReadFromPatchDiff {
 		if opts.PatchOpts.patch != nil && opts.PatchOpts.patch.ShouldPatchFileWithDiff(path) {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -587,7 +587,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		}
 		// read from the patch diff if a change has been made in any of the include files
 		if opts.ReadFileFrom == ReadFromPatch || opts.ReadFileFrom == ReadFromPatchDiff {
-			if opts.PatchOpts.patch != nil && opts.PatchOpts.patch.ConfigChanged(path.FileName) {
+			if opts.PatchOpts.patch != nil && opts.PatchOpts.patch.ShouldPatchFileWithDiff(path.FileName) {
 				opts.ReadFileFrom = ReadFromPatchDiff
 			} else {
 				opts.ReadFileFrom = ReadFromPatch

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -2237,7 +2237,7 @@ buildvariants:
 }
 
 func TestUpdateForFile(t *testing.T) {
-	project_parser_test.gop := &patch.Patch{
+	p := &patch.Patch{
 		Id: "p1",
 		Patches: []patch.ModulePatch{
 			{


### PR DESCRIPTION
[EVG-16154](https://jira.mongodb.org/browse/EVG-16154)

### Description 
Cloud was running into [an error with their PR ](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20metadata.level%3E%3D70%2050266&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=1642715100&latest=1642719600&workload_pool=standard_perf&sid=1642774620.4540347), which was suspicious because this path should only be used for CLI patches.

### Testing 
https://github.com/evergreen-ci/commit-queue-sandbox/pull/332 didn't create a patch until these changes were added to staging.
