### PR TITLE
EVG-6846 Return error if a task referenced in buildvariant is also referenced in taskgroup

### DIFF
--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -128,11 +128,11 @@ var sampleGeneratedProject = []string{`
       "name": "lint-rest-route"
     },
     {
-	  "name": "task-group-task1"
-	},
-	{
-	  "name": "task-group-task2"
-	}
+      "name": "task-group-task1"
+    },
+    {
+      "name": "task-group-task2"
+    }
   ],
   "task_groups": [
       {

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -127,7 +127,7 @@ var sampleGeneratedProject = []string{`
       ],
       "name": "lint-rest-route"
     },
-	{
+    {
 	  "name": "task-group-task1"
 	},
 	{

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -128,10 +128,10 @@ var sampleGeneratedProject = []string{`
       "name": "lint-rest-route"
     },
 	{
-		"name": "task-group-task1"
+	  "name": "task-group-task1"
 	},
 	{
-		"name": "task-group-task2"
+	  "name": "task-group-task2"
 	}
   ],
   "task_groups": [

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -126,15 +126,21 @@ var sampleGeneratedProject = []string{`
         }
       ],
       "name": "lint-rest-route"
-    }
+    },
+	{
+		"name": "task-group-task1"
+	},
+	{
+		"name": "task-group-task2"
+	}
   ],
   "task_groups": [
       {
           "name": "my_task_group",
           "max_hosts": 1,
           "tasks": [
-            "lint-command",
-            "lint-rest-route",
+            "task-group-task1",
+            "task-group-task2",
           ]
       },
   ]
@@ -243,7 +249,7 @@ func TestGenerateTasks(t *testing.T) {
 	p = projectInfo.Project
 	assert.NoError(err)
 	require.NotNil(p)
-	assert.Len(p.Tasks, 4)
+	assert.Len(p.Tasks, 6)
 	require.Len(p.BuildVariants, 2)
 	assert.Len(p.BuildVariants[0].Tasks, 1)
 	assert.Len(p.BuildVariants[1].Tasks, 4)
@@ -266,7 +272,7 @@ func TestParseProjects(t *testing.T) {
 	assert.Equal("lint-command", parsed[0].BuildVariants[0].DisplayTasks[0].ExecutionTasks[0])
 	assert.Equal("lint-rest-route", parsed[0].BuildVariants[0].DisplayTasks[0].ExecutionTasks[1])
 	assert.Len(parsed[0].BuildVariants[0].DisplayTasks, 1)
-	assert.Len(parsed[0].Tasks, 2)
+	assert.Len(parsed[0].Tasks, 4)
 	assert.Equal(parsed[0].Tasks[0].Name, "lint-command")
 	assert.Equal(parsed[0].Tasks[1].Name, "lint-rest-route")
 }

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -603,29 +603,29 @@ func ensureReferentialIntegrity(project *model.Project, distroIDs []string, dist
 
 			for _, distro := range task.RunOn {
 				if !utility.StringSliceContains(distroIDs, distro) && !utility.StringSliceContains(distroAliases, distro) {
-					//errs = append(errs,
-					//	ValidationError{
-					//		Message: fmt.Sprintf("task '%s' in buildvariant '%s' in project "+
-					//			"'%s' references a nonexistent distro '%s'.\n",
-					//			task.Name, buildVariant.Name,
-					//			project.Identifier, distro),
-					//		Level: Warning,
-					//	},
-					//)
+					errs = append(errs,
+						ValidationError{
+							Message: fmt.Sprintf("task '%s' in buildvariant '%s' in project "+
+								"'%s' references a nonexistent distro '%s'.\n",
+								task.Name, buildVariant.Name,
+								project.Identifier, distro),
+							Level: Warning,
+						},
+					)
 				}
 			}
 		}
 		for _, distro := range buildVariant.RunOn {
 			if !utility.StringSliceContains(distroIDs, distro) && !utility.StringSliceContains(distroAliases, distro) {
-				//errs = append(errs,
-				//	ValidationError{
-				//		Message: fmt.Sprintf("buildvariant '%s' in project "+
-				//			"'%s' references a nonexistent distro '%s'.\n",
-				//			buildVariant.Name,
-				//			project.Identifier, distro),
-				//		Level: Warning,
-				//	},
-				//)
+				errs = append(errs,
+					ValidationError{
+						Message: fmt.Sprintf("buildvariant '%s' in project "+
+							"'%s' references a nonexistent distro '%s'.\n",
+							buildVariant.Name,
+							project.Identifier, distro),
+						Level: Warning,
+					},
+				)
 			}
 		}
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -597,35 +597,35 @@ func ensureReferentialIntegrity(project *model.Project, distroIDs []string, dist
 					ValidationError{
 						Message: fmt.Sprintf("task '%s' in build variant '%s' is already referenced in a task group",
 							task.Name, buildVariant.Name),
-						Level: Error,
+						Level: Warning,
 					})
 			}
 
 			for _, distro := range task.RunOn {
 				if !utility.StringSliceContains(distroIDs, distro) && !utility.StringSliceContains(distroAliases, distro) {
-					errs = append(errs,
-						ValidationError{
-							Message: fmt.Sprintf("task '%s' in buildvariant '%s' in project "+
-								"'%s' references a nonexistent distro '%s'.\n",
-								task.Name, buildVariant.Name,
-								project.Identifier, distro),
-							Level: Warning,
-						},
-					)
+					//errs = append(errs,
+					//	ValidationError{
+					//		Message: fmt.Sprintf("task '%s' in buildvariant '%s' in project "+
+					//			"'%s' references a nonexistent distro '%s'.\n",
+					//			task.Name, buildVariant.Name,
+					//			project.Identifier, distro),
+					//		Level: Warning,
+					//	},
+					//)
 				}
 			}
 		}
 		for _, distro := range buildVariant.RunOn {
 			if !utility.StringSliceContains(distroIDs, distro) && !utility.StringSliceContains(distroAliases, distro) {
-				errs = append(errs,
-					ValidationError{
-						Message: fmt.Sprintf("buildvariant '%s' in project "+
-							"'%s' references a nonexistent distro '%s'.\n",
-							buildVariant.Name,
-							project.Identifier, distro),
-						Level: Warning,
-					},
-				)
+				//errs = append(errs,
+				//	ValidationError{
+				//		Message: fmt.Sprintf("buildvariant '%s' in project "+
+				//			"'%s' references a nonexistent distro '%s'.\n",
+				//			buildVariant.Name,
+				//			project.Identifier, distro),
+				//		Level: Warning,
+				//	},
+				//)
 			}
 		}
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -547,21 +547,21 @@ func checkProjectFields(project *model.Project) ValidationErrors {
 }
 
 // Ensures that:
-// 1. a referenced task within a buildvariant task object exists in
-// the set of project tasks and is not referenced in the task group of the buildvariant
-// 2. any referenced distro exists within the current setting's distro directory
+// 1. A referenced task within a buildvariant task object exists in the set of project
+// tasks and is not referenced in the task group of the buildvariant.
+// 2. Any referenced distro exists within the current setting's distro directory
 func ensureReferentialIntegrity(project *model.Project, distroIDs []string, distroAliases []string) ValidationErrors {
 	errs := ValidationErrors{}
 	// create a set of all the task names
 	allTaskNames := map[string]bool{}
-	taskGroupTaskSet := map[string]bool{}
+	taskGroupTaskSet := map[string]string{}
 	for _, task := range project.Tasks {
 		allTaskNames[task.Name] = true
 	}
 	for _, taskGroup := range project.TaskGroups {
 		allTaskNames[taskGroup.Name] = true
 		for _, task := range taskGroup.Tasks {
-			taskGroupTaskSet[task] = true
+			taskGroupTaskSet[task] = taskGroup.Name
 		}
 	}
 
@@ -595,8 +595,8 @@ func ensureReferentialIntegrity(project *model.Project, distroIDs []string, dist
 			if _, ok := taskGroupTaskSet[task.Name]; ok {
 				errs = append(errs,
 					ValidationError{
-						Message: fmt.Sprintf("task '%s' in build variant '%s' is already referenced in a task group",
-							task.Name, buildVariant.Name),
+						Message: fmt.Sprintf("task '%s' in build variant '%s' is already referenced in task group '%s'",
+							task.Name, buildVariant.Name, taskGroupTaskSet[task.Name]),
 						Level: Warning,
 					})
 			}

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -3817,7 +3817,7 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 				},
 			},
 			expectErr:      true,
-			expectedErrMsg: "task 'task1' in build variant 'ubuntu' is already referenced in a task group",
+			expectedErrMsg: "task 'task1' in build variant 'ubuntu' is already referenced in task group 'task1-and-task2'",
 		},
 		"Task group after task": {
 			project: model.Project{
@@ -3849,7 +3849,7 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 				},
 			},
 			expectErr:      true,
-			expectedErrMsg: "task 'task2' in build variant 'ubuntu' is already referenced in a task group",
+			expectedErrMsg: "task 'task2' in build variant 'ubuntu' is already referenced in task group 'task1-and-task2'",
 		},
 		"Task group and task not in task group": {
 			project: model.Project{
@@ -3912,7 +3912,7 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 				},
 			},
 			expectErr:      true,
-			expectedErrMsg: "task 'task1' in build variant 'ubuntu' is already referenced in a task group",
+			expectedErrMsg: "task 'task1' in build variant 'ubuntu' is already referenced in task group 'task1-and-task2'",
 		},
 		"Multiple task group": {
 			project: model.Project{

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -3953,7 +3953,6 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
 			errs := ensureReferentialIntegrity(&testCase.project, []string{}, []string{})
-			fmt.Println("Errors: ", errs)
 			if testCase.expectErr {
 				assert.Equal(t, errs[0].Message, testCase.expectedErrMsg)
 			} else {


### PR DESCRIPTION
[EVG-6846](https://jira.mongodb.org/browse/EVG-6846)

### Description 
Return error if task referenced in a buildvariant is also referenced in a task group in the buildvariant

### Testing 
Updated unit tests.