### PR TITLE
EVG-14053 skip querying for empty execution tasks

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -385,10 +385,13 @@ func DeactivatePreviousTasks(t *task.Task, caller string) error {
 	extraTasks := []task.Task{}
 	if t.DisplayOnly {
 		for _, dt := range allTasks {
+			if len(dt.ExecutionTasks) == 0 { // previous display tasks may not have execution tasks added yet
+				continue
+			}
 			var execTasks []task.Task
 			execTasks, err = task.Find(task.ByIds(dt.ExecutionTasks))
 			if err != nil {
-				return errors.Wrapf(err, "error finding execution tasks to deactivate for task %s", t.Id)
+				return errors.Wrapf(err, "error finding execution tasks to deactivate for task %s", dt.Id)
 			}
 			canDeactivate := true
 			for _, et := range execTasks {


### PR DESCRIPTION
[EVG-14053](https://jira.mongodb.org/browse/EVG-14053)

### Description 
We sometimes hit the MongoDB error "$in needs an array" for https://github.com/evergreen-ci/evergreen/blob/e4eaf62332f77d4b25ae49023d42f0bd1cdc480f/model/task_lifecycle.go#L392. I'm having trouble replicating this state in a unit test 🤷‍♀️  but really we should only be able to get here if execution tasks is empty. This is a feasible state since this error is being logged for generated display tasks (so they may not have execution tasks yet).
