### PR TITLE
EVG-16196 set maxTime on fetching tasks for the waterfall

### DIFF
--- a/db/query.go
+++ b/db/query.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"time"
+
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -12,6 +14,7 @@ type Q struct {
 	skip       int
 	limit      int
 	hint       interface{} // should be bson.D of the index keys or string name of the hint
+	maxTime    time.Duration
 }
 
 // Query creates a db.Q for the given MongoDB query. The filter
@@ -63,6 +66,12 @@ func (q Q) Limit(limit int) Q {
 	return q
 }
 
+// MaxTime sets the maxTime for a query to time out the query on the db server.
+func (q Q) MaxTime(maxTime time.Duration) Q {
+	q.maxTime = maxTime
+	return q
+}
+
 // Hint sets the hint for a query to determine what index will be used. The hint
 // can be either the index as an ordered document of the keys or a
 func (q Q) Hint(hint interface{}) Q {
@@ -86,6 +95,7 @@ func FindOneQ(collection string, q Q, out interface{}) error {
 		Skip(q.skip).
 		Limit(1).
 		Hint(q.hint).
+		MaxTime(q.maxTime).
 		One(out)
 }
 
@@ -104,6 +114,7 @@ func FindAllQ(collection string, q Q, out interface{}) error {
 		Skip(q.skip).
 		Limit(q.limit).
 		Hint(q.hint).
+		MaxTime(q.maxTime).
 		All(out)
 }
 

--- a/model/project.go
+++ b/model/project.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -30,6 +31,8 @@ const (
 	// DefaultCommandType is a system configuration option that is used to
 	// differentiate between setup related commands and actual testing commands.
 	DefaultCommandType = evergreen.CommandTypeTest
+
+	waterfallTasksQueryMaxTime = time.Minute
 )
 
 type Project struct {
@@ -1809,7 +1812,8 @@ func FetchVersionsBuildsAndTasks(project *Project, skip int, numVersions int, sh
 	}
 
 	// Filter out execution tasks because they'll be dropped when iterating through the build task cache anyway.
-	tasksFromDb, err := task.FindAll(db.Query(task.NonExecutionTasksByVersions(versionIds)).WithFields(task.StatusFields...))
+	// maxTime ensures the query won't go on indefinitely when the request is cancelled.
+	tasksFromDb, err := task.FindAll(db.Query(task.NonExecutionTasksByVersions(versionIds)).WithFields(task.StatusFields...).MaxTime(waterfallTasksQueryMaxTime))
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error fetching tasks from database")
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -32,7 +32,7 @@ const (
 	// differentiate between setup related commands and actual testing commands.
 	DefaultCommandType = evergreen.CommandTypeTest
 
-	waterfallTasksQueryMaxTime = time.Minute
+	waterfallTasksQueryMaxTime = 90 * time.Second
 )
 
 type Project struct {


### PR DESCRIPTION
[EVG-16196](https://jira.mongodb.org/browse/EVG-16196)

### Description 
Setting a maxTime on the query seems like the most straightforward way to prevent a single app server ending up underwater for hours.
I set the timeout at 90 seconds since the load balancer will have certainly killed the waterfall request by then (a bit longer than one minute in keeping with Annie/John's suggestion [here](https://github.com/evergreen-ci/evergreen/pull/4961#discussion_r693194303)).

### Testing 
I can still load the waterfall in staging. (fwiw)
