### PR TITLE
EVG-15915 Fix terminated spawn host is marked as running

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1162,13 +1162,13 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 	if err != nil {
 		// fetch the instance to get the current status, since it may have changed
 		// since we saved the previous status
-		currentStatus, err := m.GetInstanceStatus(ctx, h)
-		if err != nil {
-			return errors.Wrap(err, "error getting instance status after stopping error")
+		currentStatus, currentStatusErr := m.GetInstanceStatus(ctx, h)
+		if currentStatusErr != nil {
+			return errors.Wrap(currentStatusErr, "error getting instance status after stopping error")
 		}
 
-		if err2 := h.SetStatus(currentStatus.String(), user, ""); err2 != nil {
-			return errors.Wrapf(err2, "failed to revert status from stopping to '%s'", currentStatus)
+		if currentStatusErr = h.SetStatus(currentStatus.String(), user, ""); currentStatusErr != nil {
+			return errors.Wrapf(currentStatusErr, "failed to revert status from stopping to '%s'", currentStatus)
 		}
 		return errors.Wrapf(err, "error stopping EC2 instance '%s'", h.Id)
 	}
@@ -1192,12 +1192,12 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 		})
 
 	if err != nil {
-		currentStatus, err := m.GetInstanceStatus(ctx, h)
-		if err != nil {
-			return errors.Wrap(err, "error getting instance status after stopping error")
+		currentStatus, currentStatusErr := m.GetInstanceStatus(ctx, h)
+		if currentStatusErr != nil {
+			return errors.Wrap(currentStatusErr, "error getting instance status after stopping error")
 		}
-		if err2 := h.SetStatus(currentStatus.String(), user, ""); err2 != nil {
-			return errors.Wrapf(err2, "failed to revert status from stopping to '%s'", currentStatus)
+		if currentStatusErr := h.SetStatus(currentStatus.String(), user, ""); currentStatusErr != nil {
+			return errors.Wrapf(currentStatusErr, "failed to revert status from stopping to '%s'", currentStatus)
 		}
 		return errors.Wrap(err, "error checking if spawnhost stopped")
 	}

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1162,12 +1162,12 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 	if err != nil {
 		// fetch the instance to get the current status, since it may have changed
 		// since we saved the previous status
-		instance, err = m.client.GetInstanceInfo(ctx, h.Id)
+		currentStatus, err := m.GetInstanceStatus(ctx, h)
 		if err != nil {
-			return errors.Wrap(err, "error getting instance info after stopping error")
+			return errors.Wrap(err, "error getting instance status after stopping error")
 		}
-		currentStatus := *instance.State.Name
-		if err2 := h.SetStatus(currentStatus, user, ""); err2 != nil {
+
+		if err2 := h.SetStatus(currentStatus.String(), user, ""); err2 != nil {
 			return errors.Wrapf(err2, "failed to revert status from stopping to '%s'", currentStatus)
 		}
 		return errors.Wrapf(err, "error stopping EC2 instance '%s'", h.Id)
@@ -1192,12 +1192,11 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 		})
 
 	if err != nil {
-		instance, err = m.client.GetInstanceInfo(ctx, h.Id)
+		currentStatus, err := m.GetInstanceStatus(ctx, h)
 		if err != nil {
-			return errors.Wrap(err, "error getting instance info after stopping error")
+			return errors.Wrap(err, "error getting instance status after stopping error")
 		}
-		currentStatus := *instance.State.Name
-		if err2 := h.SetStatus(currentStatus, user, ""); err2 != nil {
+		if err2 := h.SetStatus(currentStatus.String(), user, ""); err2 != nil {
 			return errors.Wrapf(err2, "failed to revert status from stopping to '%s'", currentStatus)
 		}
 		return errors.Wrap(err, "error checking if spawnhost stopped")


### PR DESCRIPTION
[EVG-15915](https://jira.mongodb.org/browse/EVG-15915)

### Description 
A user ran into an issue where a host was labeled as running when they tried to click on the trash button of an already terminating host. 

### Testing 
I tried stopping and then pausing a few hosts on staging with and without my changes. The ones that stuck around as running (despite actually being stopped) are ones spawned without my changes. 
![image](https://user-images.githubusercontent.com/13104717/151258499-15eac18f-8ec9-4c87-a274-bbc67afdaec9.png)
