### PR TITLE
EVG-16128 warn users about immutable ID if copying perf project

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -1475,7 +1475,7 @@ mciModule.directive("adminNewProject", function () {
         '<div class="col-lg-12">' +
           "Optionally enter immutable project ID " +
           '<div class="muted small">' +
-            "(Used by Evergreen internally and defaults to a random hash; should only be user-specified with good reason. Cannot be changed!)" +
+            "(Used by Evergreen internally and defaults to a random hash; should only be user-specified with good reason, such as if the project will be using performance tooling. Cannot be changed!)" +
           '</div>' +
           '<div class="warning-text" ng-show="newProject.copyProject && projectRef.perf_enabled">' +
                "When copying a project using performance, the immutable project ID should be set to match the identifier." +

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -1321,7 +1321,7 @@ mciModule.controller(
       };
     }
 
-    function comebineDateTime(date, time) {
+    function combineDateTime(date, time) {
       date.setHours(time.getHours());
       date.setMinutes(time.getMinutes());
 
@@ -1347,7 +1347,7 @@ mciModule.controller(
         if (update.delete) {
           $scope.periodic_builds.splice(update.periodicBuildIndex, 1);
         } else {
-          update.periodic_build.next_run_time = comebineDateTime(
+          update.periodic_build.next_run_time = combineDateTime(
             update.periodic_build.start_date,
             update.periodic_build.start_time
           );
@@ -1476,6 +1476,9 @@ mciModule.directive("adminNewProject", function () {
           "Optionally enter immutable project ID " +
           '<div class="muted small">' +
             "(Used by Evergreen internally and defaults to a random hash; should only be user-specified with good reason. Cannot be changed!)" +
+          '</div>' +
+          '<div class="warning-text" ng-show="newProject.copyProject && projectRef.perf_enabled">' +
+               "When copying a project using performance, the immutable project ID should be set to match the identifier." +
           '</div>' +
           '<input type="text" id="project-name" placeholder="immutable project ID" ng-model="newProject.id">' +
         '</div>' +


### PR DESCRIPTION
[EVG-16128](https://jira.mongodb.org/browse/EVG-16128)

### Description 
Warn users from copying a project with different ID and identifier that they may want to make them the same if relying on Performance. (This is likely a temporary measure, pending https://jira.mongodb.org/browse/EVG-16179, so not currently planning on extending to the new UI).

### Testing 
![image](https://user-images.githubusercontent.com/26798134/151432335-cdd0795e-6642-4e29-828a-0d9e09093a56.png)
