### PR TITLE
EVG-14645: forward arbitrary SSH args and add dry run flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-01-20"
+	ClientVersion = "2022-01-27"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-01-26"

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -635,7 +635,7 @@ Examples:
 			}
 
 			if dryRun {
-				fmt.Printf("Going to execute the following command: %s\n", strings.Join(args, " "))
+				fmt.Printf("Going to execute the following command:\n%s\n", strings.Join(args, " "))
 				return nil
 			}
 
@@ -1548,7 +1548,7 @@ func hostFindBy() cli.Command {
 			hostUser := utility.FromStringPtr(host.StartedBy)
 			link := fmt.Sprintf("%s/host/%s", conf.UIServerHost, hostId)
 			fmt.Printf(`
-		 ID : %s
+	     ID : %s
 	   Link : %s
 	   User : %s
 `, hostId, link, hostUser)
@@ -1714,7 +1714,7 @@ func buildRsyncCommand(opts rsyncOpts) (*jasper.Command, error) {
 		cmdWithoutDryRun := make([]string, len(args[:dryRunIndex]), len(args)-1)
 		_ = copy(cmdWithoutDryRun, args[:dryRunIndex])
 		cmdWithoutDryRun = append(cmdWithoutDryRun, args[dryRunIndex+1:]...)
-		fmt.Printf("Going to execute the following command: %s\n", strings.Join(cmdWithoutDryRun, " "))
+		fmt.Printf("Going to execute the following command:\n%s\n", strings.Join(cmdWithoutDryRun, " "))
 	}
 	logLevel := level.Info
 	stdout, err := send.NewPlainLogger("stdout", send.LevelInfo{Threshold: logLevel, Default: logLevel})

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -582,7 +582,6 @@ Examples:
 * SSH into a host (i-abcdef12345) and pass additional arguments to the SSH binary to use verbose mode (-vvv) and run a command (echo hello world):
 	evergreen host ssh --host i-abcdef12345 -- -vvv "echo hello world"
 `,
-		ArgsUsage: "[-- other_ssh_arguments]",
 		Flags: addHostFlag(
 			cli.StringFlag{
 				Name:  joinFlagNames(identityFlagName, "i"),

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -563,15 +563,34 @@ func hostStart() cli.Command {
 func hostSSH() cli.Command {
 	const (
 		identityFlagName = "identity_file"
+		dryRunFlagName   = "dry-run"
 	)
 
 	return cli.Command{
 		Name:  "ssh",
 		Usage: "ssh into a spawn host",
+		UsageText: `
+SSH into a host by its ID and optionally pass arbitrary additional parameters to the SSH binary.
+
+Examples:
+* SSH into a host (i-abcdef12345) by ID:
+	evergreen host ssh --host i-abcdef12345
+
+* As a special case, if you pass a single argument, it will be interpreted as the host ID:
+	evergreen host ssh i-abcdef12345
+
+* SSH into a host (i-abcdef12345) and pass additional arguments to the SSH binary to use verbose mode (-vvv) and run a command (echo hello world):
+	evergreen host ssh --host i-abcdef12345 -- -vvv "echo hello world"
+`,
+		ArgsUsage: "[-- other_ssh_arguments]",
 		Flags: addHostFlag(
 			cli.StringFlag{
 				Name:  joinFlagNames(identityFlagName, "i"),
 				Usage: "Path to a specific identity (private key), for ssh -i",
+			},
+			cli.BoolFlag{
+				Name:  dryRunFlagName,
+				Usage: "show the SSH command that would run if executed, but do not actually execute it",
 			},
 		),
 		Before: mergeBeforeFuncs(setPlainLogger, requireHostFlag),
@@ -580,6 +599,7 @@ func hostSSH() cli.Command {
 			confPath := c.Parent().Parent().String(confFlagName)
 			hostID := c.String(hostFlagName)
 			key := c.String(identityFlagName)
+			dryRun := c.Bool(dryRunFlagName)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -607,6 +627,18 @@ func hostSSH() cli.Command {
 			if key != "" {
 				args = append(args, "-i", key)
 			}
+
+			// Append the arbitrary additional SSH args unless it's the special
+			// case where it's a single arg and it's the host ID.
+			if c.NArg() > 1 || c.NArg() == 1 && c.Args().Get(0) != hostID {
+				args = append(args, c.Args()...)
+			}
+
+			if dryRun {
+				fmt.Printf("Going to execute the following command: %s\n", strings.Join(args, " "))
+				return nil
+			}
+
 			return jasper.NewCommand().Add(args).SetErrorWriter(os.Stderr).SetOutputWriter(os.Stdout).SetInput(os.Stdin).Run(ctx)
 		},
 	}
@@ -1516,7 +1548,7 @@ func hostFindBy() cli.Command {
 			hostUser := utility.FromStringPtr(host.StartedBy)
 			link := fmt.Sprintf("%s/host/%s", conf.UIServerHost, hostId)
 			fmt.Printf(`
-	     ID : %s
+		 ID : %s
 	   Link : %s
 	   User : %s
 `, hostId, link, hostUser)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14645

### Description 
Allow users to pass whatever flags they want to the SSH binary as additional parameters. I also added a dry run flag to display the SSH command that will run without actually running the command, which is useful for debugging. `evergreen host rsync` has a similar dry run flag.

`evergreen host ssh -i <identity_file>` is now redundant since it's equivalent to `evergreen host ssh --host <host_id> -- -i <identity_file>`, but I kept it for backward compatibility.

### Testing 
SSH is hard to test, so I just manually tested that it still works the way it's used today and the additional arguments are forwarded as expected.