### PR TITLE
EVG-15935 fix unmarshal yaml strict for validator

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -401,7 +401,7 @@ func appendTasks(pairs TaskVariantPairs, bv parserBV, p *Project) TaskVariantPai
 func (g *GeneratedProject) addGeneratedProjectToConfig(intermediateProject *ParserProject, config string, cachedProject projectMaps) (*ParserProject, error) {
 	var err error
 	if intermediateProject == nil {
-		intermediateProject, err = createIntermediateProject([]byte(config))
+		intermediateProject, err = createIntermediateProject([]byte(config), false)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error creating intermediate project")
 		}

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -41,7 +41,7 @@ buildvariants:
       set:
         tags: "gotcha_boy"
 `
-			p, err := createIntermediateProject([]byte(axes))
+			p, err := createIntermediateProject([]byte(axes), false)
 			So(err, ShouldBeNil)
 			axis := p.Axes[0]
 			So(axis.Id, ShouldEqual, "os")
@@ -77,7 +77,7 @@ buildvariants:
     - blue
     - green
 `
-			p, err := createIntermediateProject([]byte(simple))
+			p, err := createIntermediateProject([]byte(simple), false)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix
@@ -108,7 +108,7 @@ buildvariants:
 - name: "single_variant"
   tasks: "*"
 `
-			p, err := createIntermediateProject([]byte(simple))
+			p, err := createIntermediateProject([]byte(simple), false)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -569,7 +569,11 @@ func GetProjectFromBSON(data []byte) (*Project, error) {
 // If reading from a version config, LoadProjectForVersion should be used to persist the resulting parser project.
 // opts is used to look up files on github if the main parser project has an Include.
 func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, identifier string, project *Project) (*ParserProject, *ProjectConfig, error) {
-	intermediateProject, err := createIntermediateProject(data)
+	unmarshalStrict := false
+	if opts != nil {
+		unmarshalStrict = opts.UnmarshalStrict
+	}
+	intermediateProject, err := createIntermediateProject(data, unmarshalStrict)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, LoadProjectError)
 	}
@@ -604,7 +608,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		if err != nil {
 			return intermediateProject, config, errors.Wrapf(err, "%s: failed to retrieve file '%s'", LoadProjectError, path.FileName)
 		}
-		add, err := createIntermediateProject(yaml)
+		add, err := createIntermediateProject(yaml, opts.UnmarshalStrict)
 		if err != nil {
 			return intermediateProject, config, errors.Wrapf(err, LoadProjectError)
 		}
@@ -635,14 +639,15 @@ const (
 )
 
 type GetProjectOpts struct {
-	Ref          *ProjectRef
-	PatchOpts    *PatchOpts
-	LocalModules map[string]string
-	RemotePath   string
-	Revision     string
-	Token        string
-	ReadFileFrom string
-	Identifier   string
+	Ref             *ProjectRef
+	PatchOpts       *PatchOpts
+	LocalModules    map[string]string
+	RemotePath      string
+	Revision        string
+	Token           string
+	ReadFileFrom    string
+	Identifier      string
+	UnmarshalStrict bool
 }
 
 type PatchOpts struct {
@@ -795,17 +800,33 @@ func GetProjectFromFile(ctx context.Context, opts GetProjectOpts) (ProjectInfo, 
 // createIntermediateProject marshals the supplied YAML into our
 // intermediate project representation (i.e. before selectors or
 // matrix logic has been evaluated).
-func createIntermediateProject(yml []byte) (*ParserProject, error) {
-	p := &ParserProject{}
-	if err := util.UnmarshalYAMLWithFallback(yml, p); err != nil {
-		yamlErr := thirdparty.YAMLFormatError{Message: err.Error()}
-		return nil, errors.Wrap(yamlErr, "error unmarshalling into parser project")
+// If unmarshalStrict is true, use the strict version of unmarshalling.
+func createIntermediateProject(yml []byte, unmarshalStrict bool) (*ParserProject, error) {
+	p := ParserProject{}
+	if unmarshalStrict {
+		strictProjectWithVariables := struct {
+			ParserProject `yaml:"pp,inline"`
+			// Variables is only used to suppress yaml unmarshalling errors related
+			// to a non-existent variables field.
+			Variables interface{} `yaml:"variables,omitempty" bson:"-"`
+		}{}
+
+		if err := util.UnmarshalYAMLStrictWithFallback(yml, &strictProjectWithVariables); err != nil {
+			return nil, err
+		}
+		p = strictProjectWithVariables.ParserProject
+	} else {
+		if err := util.UnmarshalYAMLWithFallback(yml, &p); err != nil {
+			yamlErr := thirdparty.YAMLFormatError{Message: err.Error()}
+			return nil, errors.Wrap(yamlErr, "error unmarshalling into parser project")
+		}
 	}
+
 	if p.Functions == nil {
 		p.Functions = map[string]*YAMLCommandSet{}
 	}
 
-	return p, nil
+	return &p, nil
 }
 
 // TranslateProject converts our intermediate project representation into

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -90,7 +90,7 @@ func FindParametersForVersion(v *Version) ([]patch.Parameter, error) {
 		if v.Config == "" {
 			return nil, errors.New("version has no config")
 		}
-		pp, err = createIntermediateProject([]byte(v.Config))
+		pp, err = createIntermediateProject([]byte(v.Config), false)
 		if err != nil {
 			return nil, errors.Wrap(err, "error parsing legacy config")
 		}
@@ -109,7 +109,7 @@ func FindExpansionsForVariant(v *Version, variant string) (util.Expansions, erro
 		if v.Config == "" {
 			return nil, errors.New("version has no config")
 		}
-		pp, err = createIntermediateProject([]byte(v.Config))
+		pp, err = createIntermediateProject([]byte(v.Config), false)
 		if err != nil {
 			return nil, errors.Wrap(err, "error parsing legacy config")
 		}

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1058,7 +1058,7 @@ tasks:
   depends_on:
     - name: dist-test
 `
-	intermediate, err := createIntermediateProject([]byte(projYml))
+	intermediate, err := createIntermediateProject([]byte(projYml), false)
 	s.NoError(err)
 	marshaled, err := yaml.Marshal(intermediate)
 	s.NoError(err)

--- a/operations/validate.go
+++ b/operations/validate.go
@@ -115,6 +115,9 @@ func validateFile(path string, ac *legacyClient, quiet, includeLong bool, localM
 		LocalModules: localModuleMap,
 		ReadFileFrom: model.ReadFromLocal,
 	}
+	if !quiet {
+		opts.UnmarshalStrict = true
+	}
 	pp, _, err := model.LoadProjectInto(ctx, confFile, opts, "", project)
 	if err != nil {
 		return errors.Wrapf(err, "%s is an invalid configuration", path)

--- a/operations/validate.go
+++ b/operations/validate.go
@@ -147,6 +147,7 @@ func validateFile(path string, ac *legacyClient, quiet, includeLong bool, localM
 	return nil
 }
 
+// loadProjectIntoWithValidation returns a warning (instead of an error) if there's an error with unmarshalling strictly
 func loadProjectIntoWithValidation(ctx context.Context, data []byte, opts *model.GetProjectOpts,
 	project *model.Project) (*model.ParserProject, validator.ValidationErrors) {
 	errs := validator.ValidationErrors{}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -528,6 +528,8 @@ tasks:
   - name: s3-fake-destination-optional
     commands:
       - func: copy-fake-destination-optional
+    commands:
+      - func: copy-fake-destination-optional
   - name: test-repotracker
     tags: ["db", "test"]
     commands:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -528,8 +528,6 @@ tasks:
   - name: s3-fake-destination-optional
     commands:
       - func: copy-fake-destination-optional
-    commands:
-      - func: copy-fake-destination-optional
   - name: test-repotracker
     tags: ["db", "test"]
     commands:

--- a/util/yaml.go
+++ b/util/yaml.go
@@ -3,9 +3,12 @@ package util
 import (
 	"bytes"
 
+	"github.com/pkg/errors"
 	yaml2 "gopkg.in/yaml.v2"
 	"gopkg.in/yaml.v3"
 )
+
+const UnmarshalStrictError = "error unmarshalling yaml strict"
 
 // UnmarshalYAMLWithFallback attempts to use yaml v3 to unmarshal, but on failure attempts yaml v2. If this
 // succeeds then we can assume in is outdated yaml and requires v2, otherwise we only return the error relevant to the
@@ -29,7 +32,7 @@ func UnmarshalYAMLStrictWithFallback(in []byte, out interface{}) error {
 	d.KnownFields(true)
 	if err := d.Decode(out); err != nil {
 		if err2 := yaml2.UnmarshalStrict(in, out); err2 != nil {
-			return err
+			return errors.Wrap(err, UnmarshalStrictError)
 		}
 	}
 	return nil

--- a/util/yaml.go
+++ b/util/yaml.go
@@ -13,7 +13,7 @@ import (
 func UnmarshalYAMLWithFallback(in []byte, out interface{}) error {
 	err := yaml.Unmarshal(in, out)
 	if err != nil {
-		// try the older version of yaml before erroring, in case it's just an oudated yaml
+		// try the older version of yaml before erroring, in case it's just an outdated yaml
 		if err2 := yaml2.Unmarshal(in, out); err2 != nil {
 			return err
 		}

--- a/util/yaml_test.go
+++ b/util/yaml_test.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalYAMLStrictWithFallback(t *testing.T) {
+	smallYml := `
+top_level:
+    field: first
+    field: duplicated
+`
+
+	type TinyStruct struct {
+		Something string `yaml:"something"`
+	}
+	type SmallStruct struct {
+		TopLevel   map[string]string `yaml:"top_level"`
+		SomeList   []string          `yaml:"some_list"`
+		TinyPieces []TinyStruct      `yaml:"tiny_pieces"`
+	}
+	// duplicate map items should error
+	var myStruct SmallStruct
+	err := UnmarshalYAMLStrictWithFallback([]byte(smallYml), &myStruct)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already defined")
+
+	// duplicate struct items should error
+	smallYml = `
+top_level:
+    field: yee
+top_level:
+    field: ohno
+`
+	err = UnmarshalYAMLStrictWithFallback([]byte(smallYml), &myStruct)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already defined")
+
+	// duplicate lists should error
+	smallYml = `
+some_list:
+  - my item
+some_list:
+  - my other item
+`
+	err = UnmarshalYAMLStrictWithFallback([]byte(smallYml), &myStruct)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already defined")
+
+	// nested duplicate lists should error
+	type LargerStruct struct {
+		Pieces []SmallStruct `yaml:"pieces"`
+	}
+	var largeStruct LargerStruct
+	smallYml = `
+pieces:
+- tiny_pieces:
+  - something: old
+  tiny_pieces:
+  - something: blue
+`
+	err = UnmarshalYAMLStrictWithFallback([]byte(smallYml), &largeStruct)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already defined")
+	fmt.Println(err)
+
+}

--- a/util/yaml_test.go
+++ b/util/yaml_test.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnmarshalYAMLStrictWithFallback(t *testing.T) {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -95,6 +95,7 @@ func (v ValidationErrors) AtLevel(level ValidationErrorLevel) ValidationErrors {
 	return errs
 }
 
+// HasError returns true if any of the errors are at the error level.
 func (v ValidationErrors) HasError() bool {
 	for _, err := range v {
 		if err.Level == Error {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -199,7 +199,6 @@ func getDistrosForProject(projectID string) (ids []string, aliases []string, err
 // verify that the project configuration semantics is valid
 func CheckProjectWarnings(project *model.Project, yamlBytes []byte) ValidationErrors {
 	validationErrs := ValidationErrors{}
-	validationErrs = append(validationErrs, CheckYamlStrict(yamlBytes)...)
 	for _, projectWarningValidator := range projectWarningValidators {
 		validationErrs = append(validationErrs,
 			projectWarningValidator(project)...)
@@ -236,25 +235,6 @@ func CheckProjectSettings(p *model.Project, ref *model.ProjectRef) ValidationErr
 		errs = append(errs, validateSettings(p, ref)...)
 	}
 	return errs
-}
-
-func CheckYamlStrict(yamlBytes []byte) ValidationErrors {
-	validationErrs := ValidationErrors{}
-	// check strict yaml, i.e warn if there are missing fields
-	strictProjectWithVariables := struct {
-		model.ParserProject `yaml:"pp,inline"`
-		// Variables is only used to suppress yaml unmarshalling errors related
-		// to a non-existent variables field.
-		Variables interface{} `yaml:"variables,omitempty" bson:"-"`
-	}{}
-
-	if err := util.UnmarshalYAMLStrictWithFallback(yamlBytes, &strictProjectWithVariables); err != nil {
-		validationErrs = append(validationErrs, ValidationError{
-			Level:   Warning,
-			Message: err.Error(),
-		})
-	}
-	return validationErrs
 }
 
 // checks if the project configuration has errors

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -95,6 +95,15 @@ func (v ValidationErrors) AtLevel(level ValidationErrorLevel) ValidationErrors {
 	return errs
 }
 
+func (v ValidationErrors) HasError() bool {
+	for _, err := range v {
+		if err.Level == Error {
+			return true
+		}
+	}
+	return false
+}
+
 type ValidationInput struct {
 	ProjectYaml []byte `json:"project_yaml" yaml:"project_yaml"`
 	Quiet       bool   `json:"quiet" yaml:"quiet"`

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2237,60 +2237,6 @@ buildvariants:
 	assert.Len(warnings, 0)
 }
 
-func TestYamlStrict(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	require.NoError(db.Clear(distro.Collection))
-	d := distro.Distro{Id: "example_distro"}
-	require.NoError(d.Insert())
-	exampleYml := `
-exec_timeout_secs: 100
-tasks:
-- name: task1
-  exec_timeout_secs: 100
-  commands:
-  - command: shell.exec
-    params:
-      script: echo test
-buildvariants:
-- name: "bv"
-  display_name: "bv_display"
-  run_on: "example_distro"
-  not_a_field: true
-  tasks:
-  - name: task1
-`
-	proj := model.Project{}
-	ctx := context.Background()
-	pp, _, err := model.LoadProjectInto(ctx, []byte(exampleYml), nil, "example_project", &proj)
-	assert.NotNil(proj)
-	assert.NotNil(pp)
-	assert.NoError(err)
-	errors := CheckProjectErrors(&proj, false)
-	assert.Len(errors, 0)
-	warnings := CheckProjectWarnings(&proj, []byte(exampleYml))
-	assert.Len(warnings, 1)
-	assert.Contains(warnings[0].Message, "field not_a_field not found")
-	assert.Equal(warnings[0].Level, Warning)
-
-	yamlWithVariables := `
-variables:
-tasks:
-- name: task1
-  commands:
-  - command: shell.exec
-    params:
-      script: echo test
-buildvariants:
-- name: "bv"
-  display_name: "bv_display"
-  run_on: "example_distro"
-  tasks:
-  - name: task1
-`
-	assert.Empty(CheckYamlStrict([]byte(yamlWithVariables)))
-}
-
 func TestTaskGroupWithDependencyOutsideGroupWarning(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
[EVG-15935](https://jira.mongodb.org/browse/EVG-15935)

### Description 
Before, we passed the project yaml directly to the API server to validate, so CheckYamlStrict worked. Now however, we LoadProjectInto locally in order to capture any included files, so by the time we get to CheckYamlStrict, we have a broken yaml file.

### Testing 
Tested locally with a broken file (using --quiet and without).
```
evergreen (EVG-15935) $ egl validate self-tests.yml
Banner: This is an important notification
WARNING: error unmarshalling strictly: load project error(s): yaml: unmarshal errors:
  line 531: mapping key "commands" already defined at line 529
<continues on to validate the file>
```
```
evergreen (EVG-15935) $ egl validate self-tests.yml -q
Banner: This is an important notification
self-tests.yml is valid
```
_Alternatively_ we can just make this a breaking error. I'm a bit torn; it doesn't seem like this breaks any existing configurations, but we typically don't use unmarshal strict. If we make this a real validation error, we should start using strict _everywhere_ to avoid projects getting into a bad state.