### PR TITLE
EVG-16131 attach.xunit_results shouldn't upload logs if a test is skipped

### DIFF
--- a/agent/command/results_xunit_parser.go
+++ b/agent/command/results_xunit_parser.go
@@ -122,7 +122,6 @@ func (tc testCase) toModelTestResultAndLog(conf *internal.TaskConfig) (task.Test
 		log = tc.Error.toBasicTestLog("ERROR")
 	case tc.Skipped != nil:
 		res.Status = evergreen.TestSkippedStatus
-		log = tc.Skipped.toBasicTestLog("SKIPPED")
 	default:
 		res.Status = evergreen.TestSucceededStatus
 	}

--- a/agent/command/results_xunit_test.go
+++ b/agent/command/results_xunit_test.go
@@ -163,7 +163,7 @@ func TestXUnitParseAndUpload(t *testing.T) {
 		assert.NoError(logger.Close())
 
 		messages := comm.GetMockMessages()[conf.Task.Id]
-		successMessage := "Attach test logs succeeded for 201 of 201 files"
+		successMessage := "Attach test logs succeeded for 12 of 12 files"
 		found := false
 		for _, message := range messages {
 			if successMessage == message.Message {
@@ -191,7 +191,7 @@ func TestXUnitParseAndUpload(t *testing.T) {
 					assert.NotEmpty(r.TestName)
 					assert.NotEmpty(r.DisplayTestName)
 					assert.NotEmpty(r.LogTestName)
-					if r.Status != evergreen.TestSucceededStatus {
+					if r.Status == evergreen.TestFailedStatus {
 						assert.NotEqual(r.DisplayTestName, r.LogTestName)
 					}
 					assert.NotEmpty(r.Status)

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2022-01-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-01-26"
+	AgentVersion = "2022-01-31"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-16131](https://jira.mongodb.org/browse/EVG-16131)

### Description 
If a test is skipped, we don't want to upload a log file. 

### Testing 
Existing unit tests -- made sure that the 12 of 12 files is the correct number 