### PR TITLE
EVG-15724 handle resetting unfinished display tasks from routes

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1452,6 +1452,9 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 	return errors.Wrap(ResetTaskOrDisplayTask(t, evergreen.User, evergreen.MonitorPackage, &t.Details), "problem resetting task")
 }
 
+// ResetTaskOrDisplayTask is a wrapper for TryResetTask that handles execution and display tasks that are restarted
+// from sources separate from marking the task finished. If an execution task, attempts to restart the display task instead.
+// Marks display tasks as reset when finished and then check if it can be reset immediately.
 func ResetTaskOrDisplayTask(t *task.Task, user, origin string, detail *apimodels.TaskEndDetail) error {
 	taskToReset := *t
 	if taskToReset.IsPartOfDisplay() { // if given an execution task, attempt to restart the full display task

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1449,18 +1449,29 @@ func ClearAndResetStrandedTask(h *host.Host) error {
 		return errors.WithStack(MarkEnd(t, evergreen.MonitorPackage, time.Now(), &t.Details, false))
 	}
 
-	if t.IsPartOfDisplay() {
-		dt, err := t.GetDisplayTask()
+	return errors.Wrap(ResetTaskOrDisplayTask(t, evergreen.User, evergreen.MonitorPackage, &t.Details), "problem resetting task")
+}
+
+func ResetTaskOrDisplayTask(t *task.Task, user, origin string, detail *apimodels.TaskEndDetail) error {
+	taskToReset := *t
+	if taskToReset.IsPartOfDisplay() { // if given an execution task, attempt to restart the full display task
+		dt, err := taskToReset.GetDisplayTask()
 		if err != nil {
 			return errors.Wrap(err, "error getting display task")
 		}
-		if err = dt.SetResetWhenFinished(); err != nil {
+		if dt != nil {
+			taskToReset = *dt
+		}
+	}
+	if taskToReset.DisplayOnly {
+		if err := taskToReset.SetResetWhenFinished(); err != nil {
 			return errors.Wrap(err, "can't mark display task for reset")
 		}
-		return errors.Wrap(checkResetDisplayTask(dt), "can't check display task reset")
+		return errors.Wrap(checkResetDisplayTask(&taskToReset), "can't check display task reset")
 	}
 
-	return errors.Wrap(TryResetTask(t.Id, evergreen.User, evergreen.MonitorPackage, &t.Details), "problem resetting task")
+	return errors.Wrap(TryResetTask(t.Id, user, origin, detail),
+		"reset task error")
 }
 
 // UpdateDisplayTaskForTask updates the status of the given execution task's display task
@@ -1639,7 +1650,7 @@ func checkResetDisplayTask(t *task.Task) error {
 		}
 	}
 	details := &t.Details
-	if details == nil {
+	if details == nil && !t.IsFinished() {
 		details = &apimodels.TaskEndDetail{
 			Type:   evergreen.CommandTypeSystem,
 			Status: evergreen.TaskFailed,

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -202,10 +202,17 @@ func (tc *DBTaskConnector) SetTaskActivated(taskId, user string, activated bool)
 		"Erorr setting task active")
 }
 
-// ResetTask sets the task to be in an unexecuted state and prepares it to be
-// run again.
+// ResetTask sets the task to be in an unexecuted state and prepares it to be run again.
+// If given an execution task, marks the display task for reset.
 func (tc *DBTaskConnector) ResetTask(taskId, username string) error {
-	return errors.Wrap(serviceModel.TryResetTask(taskId, username, evergreen.RESTV2Package, nil),
+	t, err := task.FindOneId(taskId)
+	if err != nil {
+		return errors.Wrapf(err, "problem finding task '%s'", t)
+	}
+	if t == nil {
+		return errors.Errorf("task '%s' not found", t.Id)
+	}
+	return errors.Wrap(serviceModel.ResetTaskOrDisplayTask(t, username, evergreen.RESTV2Package, nil),
 		"Reset task error")
 }
 


### PR DESCRIPTION
[EVG-15724](https://jira.mongodb.org/browse/EVG-15724)

### Description 
Display tasks can't be restarted if they're currently in progress, but that isn't obvious to users who are using rest routes. Display tasks can be marked to be restarted when the whole thing is finished, so I think that's the right thing to do here.

### Testing 
Unit test.
