### PR TITLE
EVG-16168: add field for task execution platform

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1291,6 +1291,9 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 		CommitQueueMerge:    buildVarTask.CommitQueueMerge,
 		IsGithubCheck:       isGithubCheck,
 		DisplayTaskId:       utility.ToStringPtr(""), // this will be overridden if the task is an execution task
+		// TODO (EVG-16169): set ExecutionMode based on whether or not the task
+		// is running in a host or container.
+		ExecutionMode: task.ExecutionModeHost,
 	}
 	if isStepback {
 		t.ActivatedBy = evergreen.StepbackTaskActivator

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1291,9 +1291,9 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 		CommitQueueMerge:    buildVarTask.CommitQueueMerge,
 		IsGithubCheck:       isGithubCheck,
 		DisplayTaskId:       utility.ToStringPtr(""), // this will be overridden if the task is an execution task
-		// TODO (EVG-16169): set ExecutionMode based on whether or not the task
+		// TODO (EVG-16169): set ExecutionPlatform based on whether or not the task
 		// is running in a host or container.
-		ExecutionMode: task.ExecutionModeHost,
+		ExecutionPlatform: task.ExecutionPlatformHost,
 	}
 	if isStepback {
 		t.ActivatedBy = evergreen.StepbackTaskActivator

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -956,6 +956,26 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 		})
 
+		Convey("execution mode should be populated for execution tasks", func() {
+			args := BuildCreateArgs{
+				Project:       *project,
+				Version:       *v,
+				TaskIDs:       table,
+				BuildName:     buildVar1.Name,
+				ActivateBuild: false,
+			}
+			build, tasks, err := CreateBuildFromVersionNoInsert(args)
+			So(err, ShouldBeNil)
+			So(build.Id, ShouldNotEqual, "")
+			for _, t := range tasks {
+				if t.DisplayOnly {
+					So(t.Execution, ShouldBeZeroValue)
+				} else {
+					So(t.ExecutionMode, ShouldEqual, task.ExecutionModeHost)
+				}
+			}
+		})
+
 		Convey("the build should contain task caches that correspond exactly"+
 			" to the tasks created", func() {
 

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -971,7 +971,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 				if t.DisplayOnly {
 					So(t.Execution, ShouldBeZeroValue)
 				} else {
-					So(t.ExecutionMode, ShouldEqual, task.ExecutionModeHost)
+					So(t.ExecutionPlatform, ShouldEqual, task.ExecutionPlatformHost)
 				}
 			}
 		})

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -685,9 +685,9 @@ func TestAddNewPatch(t *testing.T) {
 	assert.Equal(dbTasks[3].DisplayName, "task3")
 	for _, t := range dbTasks {
 		if t.DisplayOnly {
-			assert.Zero(t.ExecutionMode)
+			assert.Zero(t.ExecutionPlatform)
 		} else {
-			assert.Equal(task.ExecutionModeHost, t.ExecutionMode)
+			assert.Equal(task.ExecutionPlatformHost, t.ExecutionPlatform)
 		}
 		assert.Equal(t.CreateTime.UTC(), baseCommitTime)
 	}

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -683,8 +683,13 @@ func TestAddNewPatch(t *testing.T) {
 	assert.Equal(dbTasks[1].DisplayName, "task1")
 	assert.Equal(dbTasks[2].DisplayName, "task2")
 	assert.Equal(dbTasks[3].DisplayName, "task3")
-	for _, task := range dbTasks {
-		assert.Equal(task.CreateTime.UTC(), baseCommitTime)
+	for _, t := range dbTasks {
+		if t.DisplayOnly {
+			assert.Zero(t.ExecutionMode)
+		} else {
+			assert.Equal(task.ExecutionModeHost, t.ExecutionMode)
+		}
+		assert.Equal(t.CreateTime.UTC(), baseCommitTime)
 	}
 }
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -117,6 +117,9 @@ type Task struct {
 	// The host the task was run on. This value is empty for display tasks
 	HostId string `bson:"host_id" json:"host_id"`
 
+	// ExecutionMode determines the execution environment that the task runs in.
+	ExecutionMode ExecutionMode `bson:"execution_mode,omitempty" json:"execution_mode,omitempty"`
+
 	// The version of the agent this task was run on.
 	AgentVersion string `bson:"agent_version,omitempty" json:"agent_version,omitempty"`
 
@@ -213,6 +216,16 @@ type Task struct {
 	// task's test results are successfully cached in LocalTestResults.
 	testResultsPopulated bool
 }
+
+// ExecutionMode indicates the type of environment that the task runs in.
+type ExecutionMode string
+
+const (
+	// ExecutionModeHost indicates that the task runs in a host.
+	ExecutionModeHost ExecutionMode = "host"
+	// ExecutionModeContainer indicates that the task runs in a container.
+	ExecutionModeContainer ExecutionMode = "container"
+)
 
 func (t *Task) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(t) }
 func (t *Task) UnmarshalBSON(in []byte) error { return mgobson.Unmarshal(in, t) }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -117,8 +117,8 @@ type Task struct {
 	// The host the task was run on. This value is empty for display tasks
 	HostId string `bson:"host_id" json:"host_id"`
 
-	// ExecutionMode determines the execution environment that the task runs in.
-	ExecutionMode ExecutionMode `bson:"execution_mode,omitempty" json:"execution_mode,omitempty"`
+	// ExecutionPlatform determines the execution environment that the task runs in.
+	ExecutionPlatform ExecutionPlatform `bson:"execution_mode,omitempty" json:"execution_mode,omitempty"`
 
 	// The version of the agent this task was run on.
 	AgentVersion string `bson:"agent_version,omitempty" json:"agent_version,omitempty"`
@@ -217,14 +217,14 @@ type Task struct {
 	testResultsPopulated bool
 }
 
-// ExecutionMode indicates the type of environment that the task runs in.
-type ExecutionMode string
+// ExecutionPlatform indicates the type of environment that the task runs in.
+type ExecutionPlatform string
 
 const (
-	// ExecutionModeHost indicates that the task runs in a host.
-	ExecutionModeHost ExecutionMode = "host"
-	// ExecutionModeContainer indicates that the task runs in a container.
-	ExecutionModeContainer ExecutionMode = "container"
+	// ExecutionPlatformHost indicates that the task runs in a host.
+	ExecutionPlatformHost ExecutionPlatform = "host"
+	// ExecutionPlatformContainer indicates that the task runs in a container.
+	ExecutionPlatformContainer ExecutionPlatform = "container"
 )
 
 func (t *Task) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(t) }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -117,8 +117,9 @@ type Task struct {
 	// The host the task was run on. This value is empty for display tasks
 	HostId string `bson:"host_id" json:"host_id"`
 
-	// ExecutionPlatform determines the execution environment that the task runs in.
-	ExecutionPlatform ExecutionPlatform `bson:"execution_mode,omitempty" json:"execution_mode,omitempty"`
+	// ExecutionPlatform determines the execution environment that the task runs
+	// in.
+	ExecutionPlatform ExecutionPlatform `bson:"execution_platform,omitempty" json:"execution_platform,omitempty"`
 
 	// The version of the agent this task was run on.
 	AgentVersion string `bson:"agent_version,omitempty" json:"agent_version,omitempty"`


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16168

### Description 
Add a field to distinguish a task running in a container from a task running in a host. This field is currently set to host mode for any newly-created execution task, although it should eventually be set based on the YAML config.

### Testing 
Updated unit tests to verify that it's set when execution tasks are first created.