### PR TITLE
EVG-16081 remove UseRepoSettings from project input

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -7793,7 +7793,6 @@ input ProjectInput {
   taskAnnotationSettings: TaskAnnotationSettingsInput
 
   hidden: Boolean
-  useRepoSettings: Boolean
 }
 
 
@@ -40102,14 +40101,6 @@ func (ec *executionContext) unmarshalInputProjectInput(ctx context.Context, obj 
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hidden"))
 			it.Hidden, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "useRepoSettings":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("useRepoSettings"))
-			it.UseRepoSettings, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -7791,8 +7791,6 @@ input ProjectInput {
   perfEnabled: Boolean
   buildBaronSettings: BuildBaronSettingsInput
   taskAnnotationSettings: TaskAnnotationSettingsInput
-
-  hidden: Boolean
 }
 
 
@@ -40093,14 +40091,6 @@ func (ec *executionContext) unmarshalInputProjectInput(ctx context.Context, obj 
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("taskAnnotationSettings"))
 			it.TaskAnnotationSettings, err = ec.unmarshalOTaskAnnotationSettingsInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskAnnotationSettings(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "hidden":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hidden"))
-			it.Hidden, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -469,8 +469,6 @@ input ProjectInput {
   perfEnabled: Boolean
   buildBaronSettings: BuildBaronSettingsInput
   taskAnnotationSettings: TaskAnnotationSettingsInput
-
-  hidden: Boolean
 }
 
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -471,7 +471,6 @@ input ProjectInput {
   taskAnnotationSettings: TaskAnnotationSettingsInput
 
   hidden: Boolean
-  useRepoSettings: Boolean
 }
 
 


### PR DESCRIPTION
[EVG-16081](https://jira.mongodb.org/browse/EVG-16081)

### Description 
UseRepoSettings doesn't exist as a field anymore, and also whether or not the project uses repo is handled by a different resolver (AttachToRepo / DetachFromRepo). Also removing Hidden as this is a backend internal field.
