### PR TITLE
EVG-16230 Improve smoke test for s3Copy

### DIFF
--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -194,6 +194,12 @@ tasks:
           s3_copy_files:
               - {'source': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}', 'bucket': 'mciuploads'},
                 'destination': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}-copy', 'bucket': 'mciuploads'}}
+              - {'source': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}-2', 'bucket': 'mciuploads'},
+                'destination': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}-copy-2', 'bucket': 'mciuploads'}}
+              - {'source': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}-2', 'bucket': 'mciuploads'},
+                'destination': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}-copy-2', 'bucket': 'mciuploads'}}   
+              - {'source': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}-3', 'bucket': 'mciuploads'},
+                'destination': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}-copy-3', 'bucket': 'mciuploads'}}          
 
 buildvariants:
   - name: localhost


### PR DESCRIPTION
[EVG-16230](https://jira.mongodb.org/browse/EVG-16230)

### Description 
This adds more files to the s3copy command so that it can detect problems with looping over files. It also contains a duplicate so that it has to noop. Merging it will make it possible to test [5306](https://github.com/evergreen-ci/evergreen/pull/5306) with a patch build

### Testing 
existing test