### PR TITLE
EVG-15936: improve host termination for intent hosts

### DIFF
--- a/cloud/cloud_status.go
+++ b/cloud/cloud_status.go
@@ -14,16 +14,17 @@ const (
 	// fulfilled, but it's not yet done booting up.
 	StatusInitializing
 
-	// StatusFailed indicates that an attempt to start the instance has failed;
-	// Could be due to billing, lack of capacity, etc.
+	// StatusFailed indicates that an attempt to start the instance has failed.
+	// This could be due to billing, lack of capacity, etc.
 	StatusFailed
 
 	// StatusRunning means the machine is done booting, and active.
 	StatusRunning
 
-	// StatusStopped indicates that the instance is in the processing of
+	// StatusStopping indicates that the instance is in the processing of
 	// stopping but has not yet stopped completely.
 	StatusStopping
+
 	// StatusStopped indicates that the instance is shut down, but can be
 	// started again.
 	StatusStopped

--- a/cloud/cloud_status.go
+++ b/cloud/cloud_status.go
@@ -3,27 +3,32 @@ package cloud
 type CloudStatus int
 
 const (
-	//Catch-all for unrecognized status codes
+	// StatusUnknown is a catch-all for unrecognized status codes.
 	StatusUnknown = CloudStatus(iota)
 
-	//StatusPending indicates that it is not yet clear if the instance
-	//has been successfully started or not (e.g., pending spot request)
+	// StatusPending indicates that it is not yet clear if the instance has been
+	// successfully started or not (e.g. pending spot request).
 	StatusPending
 
-	//StatusInitializing means the instance request has been successfully
-	//fulfilled, but it's not yet done booting up
+	// StatusInitializing means the instance request has been successfully
+	// fulfilled, but it's not yet done booting up.
 	StatusInitializing
 
-	//StatusFailed indicates that an attempt to start the instance has failed;
-	//Could be due to billing, lack of capacity, etc.
+	// StatusFailed indicates that an attempt to start the instance has failed;
+	// Could be due to billing, lack of capacity, etc.
 	StatusFailed
 
-	//StatusRunning means the machine is done booting, and active
+	// StatusRunning means the machine is done booting, and active.
 	StatusRunning
 
+	// StatusStopped indicates that the instance is in the processing of
+	// stopping but has not yet stopped completely.
 	StatusStopping
+	// StatusStopped indicates that the instance is shut down, but can be
+	// started again.
 	StatusStopped
 
+	// StatusTerminated indicates that the instance is deleted.
 	StatusTerminated
 )
 

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -428,8 +428,7 @@ func (as *APIServer) prepareHostForAgentExit(ctx context.Context, h *host.Host) 
 		// cleaned up. Beyond this short grace period, there's likely a state
 		// mismatch where Evergreen has marked the host terminated but the host
 		// has clearly not been terminated in the cloud.
-		const waitingForTerminationGracePeriod = 10 * time.Minute
-		if time.Now().Sub(h.TerminationTime) > waitingForTerminationGracePeriod {
+		if time.Now().Sub(h.TerminationTime) > 10*time.Minute {
 			grip.Error(message.Fields{
 				"message": "DB-cloud state mismatch - host has been marked terminated in the DB but the host's agent is still running",
 				"host_id": h.Id,

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -361,9 +361,12 @@ func (j *hostTerminationJob) checkAndTerminateCloudHost(ctx context.Context, old
 
 	cloudStatus, err := cloudHost.GetInstanceStatus(ctx)
 	if err != nil {
+		if err == cloud.ErrInstanceNotFound {
+			return j.host.Terminate(evergreen.User, "corresponding cloud host instance does not exist")
+		}
+
 		catcher := grip.NewBasicCatcher()
 		catcher.Add(errors.Wrap(err, "getting cloud host instance status"))
-
 		if !utility.StringSliceContains(evergreen.UpHostStatus, oldStatus) {
 			catcher.Wrap(j.host.Terminate(evergreen.User, "unable to get cloud status for host"), "marking host as terminated")
 		}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15936

### Description 
I was originally going to make it so that hosts that are already marked "terminated" in the DB could be terminated again for intent hosts that are marked terminated before their real hosts come. However, rather than change assumptions around the terminated host state, it seems like it's easier to continue assuming that hosts that are terminated in the DB have also been terminated in the cloud. To maintain the termination assumption, I changed the behavior of a host that checks in after the intent host is already terminated to do the host doc swap and mark the real host as decommissioned, so it actually gets terminated in the cloud.

* Treat terminated intent hosts that are actually alive in the cloud as decommissioned real hosts.
* Log if a host is terminated in the DB but the agent is clearly still alive well after it should have been terminated.
* If a cloud instance does not exist when terminating the host, assume that the cloud instance is already terminated.

### Testing 
Updated existing tests.
