### PR TITLE
EVG-15836 Fix s3_copy

### DIFF
--- a/agent/agent_command_test.go
+++ b/agent/agent_command_test.go
@@ -114,42 +114,6 @@ func (s *CommandSuite) TestShellExec() {
 	s.Equal(s.tc.task.Secret, taskData.Secret)
 }
 
-func (s *CommandSuite) TestS3Copy() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	taskID := "s3copy"
-	s.tc.task.ID = taskID
-	s.Require().NoError(s.a.startLogging(ctx, s.tc))
-	defer s.a.removeTaskDirectory(s.tc)
-	_, err := s.a.runTask(ctx, s.tc)
-	s.Require().NoError(err)
-
-	s.Require().NoError(s.tc.logger.Close())
-	messages := s.mockCommunicator.GetMockMessages()
-	s.Len(messages, 1)
-	foundSuccessLogMessage := false
-	foundS3CopyLogMessage := false
-	for _, msg := range messages[taskID] {
-		if msg.Message == "Task completed - SUCCESS." {
-			foundSuccessLogMessage = true
-		}
-		if strings.HasPrefix(msg.Message, "Finished 's3Copy.copy'") {
-			foundS3CopyLogMessage = true
-		}
-	}
-	s.True(foundSuccessLogMessage)
-	s.True(foundS3CopyLogMessage)
-
-	detail := s.mockCommunicator.GetEndTaskDetail()
-	s.Equal("success", detail.Status)
-	s.False(detail.TimedOut)
-
-	taskData := s.mockCommunicator.EndTaskResult.TaskData
-	s.Equal(taskID, taskData.ID)
-	s.Equal(s.tc.task.Secret, taskData.Secret)
-}
-
 func TestEndTaskSyncCommands(t *testing.T) {
 	s3PushFound := func(cmds *model.YAMLCommandSet) bool {
 		for _, cmd := range cmds.List() {

--- a/agent/command/s3_copy.go
+++ b/agent/command/s3_copy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -13,21 +14,40 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
 	"github.com/mitchellh/mapstructure"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
+)
+
+const (
+	pushLogSuccess = "success"
+	pushLogFailed  = "failed"
 )
 
 // The S3CopyPlugin consists of zero or more files that are to be copied
 // from one location in S3 to the other.
 type s3copy struct {
-	// AwsKey & AwsSecret are provided to make it possible to transfer
-	// files to/from any bucket using the appropriate keys for each
-	AwsKey    string `mapstructure:"aws_key" plugin:"expand" json:"aws_key"`
-	AwsSecret string `mapstructure:"aws_secret" plugin:"expand" json:"aws_secret"`
-
+	// AwsKey and AwsSecret are the user's credentials for
+	// authenticating interactions with s3.
+	AwsKey    string `mapstructure:"aws_key" plugin:"expand"`
+	AwsSecret string `mapstructure:"aws_secret" plugin:"expand"`
 	// An array of file copy configurations
 	S3CopyFiles []*s3CopyFile `mapstructure:"s3_copy_files" plugin:"expand"`
+
+	// Bucket is the s3 bucket to use when storing the desired file
+	Bucket string `mapstructure:"bucket" plugin:"expand"`
+
+	// Permissions is the ACL to apply to the uploaded file. See:
+	//  http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+	// for some examples.
+	Permissions string `mapstructure:"permissions"`
+
+	// ContentType is the MIME type of the uploaded file.
+	//  E.g. text/html, application/pdf, image/jpeg, ...
+	ContentType string `mapstructure:"content_type" plugin:"expand"`
+
 	base
 }
 
@@ -78,102 +98,132 @@ type s3Loc struct {
 func s3CopyFactory() Command   { return &s3copy{} }
 func (c *s3copy) Name() string { return "s3Copy.copy" }
 
-// ParseParams decodes the S3 push command parameters that are
-// specified as part of an S3CopyPlugin command; this is required
-// to satisfy the 'Command' interface
+// ParseParams decodes the S3 push command parameters
 func (c *s3copy) ParseParams(params map[string]interface{}) error {
-	if err := mapstructure.Decode(params, c); err != nil {
-		return errors.Wrapf(err, "error decoding %v params", c.Name())
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           c,
+	})
+	if err != nil {
+		return errors.WithStack(err)
 	}
-	if err := c.validateParams(); err != nil {
-		return errors.Wrapf(err, "error validating %v params", c.Name())
+
+	if err := decoder.Decode(params); err != nil {
+		return errors.Wrapf(err, "error decoding %s params", c.Name())
 	}
-	return nil
+
+	return c.validate()
 }
 
 // validateParams is a helper function that ensures all
 // the fields necessary for carrying out an S3 copy operation are present
-func (c *s3copy) validateParams() error {
+func (c *s3copy) validate() error {
+	catcher := grip.NewSimpleCatcher()
+
+	// make sure the command params are valid
 	if c.AwsKey == "" {
-		return errors.New("s3 AWS key cannot be blank")
+		catcher.New("aws_key cannot be blank")
 	}
 	if c.AwsSecret == "" {
-		return errors.New("s3 AWS secret cannot be blank")
+		catcher.New("aws_secret cannot be blank")
 	}
+
 	for _, s3CopyFile := range c.S3CopyFiles {
+		if s3CopyFile.Source.Path == "" {
+			catcher.New("s3 source path cannot be blank")
+		}
+		if s3CopyFile.Destination.Path == "" {
+			catcher.New("s3 destination path cannot be blank")
+		}
+		if s3CopyFile.Permissions == "" {
+			s3CopyFile.Permissions = s3.BucketCannedACLPublicRead
+		}
 		if s3CopyFile.Source.Region == "" {
 			s3CopyFile.Source.Region = endpoints.UsEast1RegionID
 		}
 		if s3CopyFile.Destination.Region == "" {
 			s3CopyFile.Destination.Region = endpoints.UsEast1RegionID
 		}
-		if s3CopyFile.Source.Bucket == "" {
-			return errors.New("s3 source bucket cannot be blank")
+		// make sure both buckets are valid
+		if err := validateS3BucketName(s3CopyFile.Source.Bucket); err != nil {
+			catcher.Wrapf(err, "source bucket '%v' is invalid", s3CopyFile.Source.Bucket)
 		}
-		if s3CopyFile.Destination.Bucket == "" {
-			return errors.New("s3 destination bucket cannot be blank")
-		}
-		if s3CopyFile.Source.Path == "" {
-			return errors.New("s3 source path cannot be blank")
-		}
-		if s3CopyFile.Destination.Path == "" {
-			return errors.New("s3 destination path cannot be blank")
-		}
-		if s3CopyFile.Permissions == "" {
-			s3CopyFile.Permissions = s3.BucketCannedACLPublicRead
+		if err := validateS3BucketName(s3CopyFile.Destination.Bucket); err != nil {
+			catcher.Wrapf(err, "destination bucket '%v' is invalid", s3CopyFile.Destination.Bucket)
 		}
 
-		err := validateS3BucketName(s3CopyFile.Source.Bucket)
-		if err != nil {
-			return errors.Wrapf(err, "source bucket '%v' is invalid",
-				s3CopyFile.Source.Bucket)
-		}
-
-		err = validateS3BucketName(s3CopyFile.Destination.Bucket)
-		if err != nil {
-			return errors.Wrapf(err, "destination bucket '%v' is invalid",
-				s3CopyFile.Destination.Bucket)
-		}
 	}
 
-	return nil
+	return catcher.Resolve()
 }
 
-// Execute carries out the s3copy command - this is required
-// to satisfy the 'Command' interface
+// Implementation of Execute.  Expands the parameters, and then copies the
+// resource from one s3 bucket to another one.
 func (c *s3copy) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
-	// expand the S3 copy parameters before running the task
+	// expand necessary params
 	if err := util.ExpandValues(c, conf.Expansions); err != nil {
 		return errors.WithStack(err)
 	}
+	// re-validate command here, in case an expansion is not defined
+	if err := c.validate(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	errChan := make(chan error)
 	go func() {
-		errChan <- errors.WithStack(c.s3Copy(ctx, comm, logger, conf))
+		errChan <- errors.WithStack(c.copyWithRetry(ctx, comm, logger, conf))
 	}()
 
 	select {
 	case err := <-errChan:
-		return errors.WithStack(err)
+		return err
 	case <-ctx.Done():
 		logger.Execution().Info("Received signal to terminate execution of S3 copy command")
 		return nil
 	}
+
 }
 
-// S3Copy is responsible for carrying out the core of the S3CopyPlugin's
-// function - it makes an API calls to copy a given staged file to it's final
-// production destination
-func (c *s3copy) s3Copy(ctx context.Context,
+func (c *s3copy) copyWithRetry(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
+	backoffCounter := getS3OpBackoff()
+	timer := time.NewTimer(0)
+	defer timer.Stop()
 
 	td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
 
 	var foundDottedBucketName bool
 
+	client := utility.GetHTTPClient()
+	client.Timeout = 10 * time.Minute
+	defer utility.PutHTTPClient(client)
 	for _, s3CopyFile := range c.S3CopyFiles {
+		timer.Reset(0)
+
+		s3CopyReq := apimodels.S3CopyRequest{
+			S3SourceRegion:      s3CopyFile.Source.Region,
+			S3SourceBucket:      s3CopyFile.Source.Bucket,
+			S3SourcePath:        s3CopyFile.Source.Path,
+			S3DestinationRegion: s3CopyFile.Destination.Region,
+			S3DestinationBucket: s3CopyFile.Destination.Bucket,
+			S3DestinationPath:   s3CopyFile.Destination.Path,
+			S3DisplayName:       s3CopyFile.DisplayName,
+			S3Permissions:       s3CopyFile.Permissions,
+		}
+		newPushLog, err := comm.NewPush(ctx, td, &s3CopyReq)
+		if err != nil {
+			return errors.Wrap(err, "error adding pushlog")
+		}
+		if newPushLog.TaskId == "" {
+			logger.Task().Infof("noop, this version is currently in the process of trying to push, or has already succeeded in pushing the file: '%s/%s'", s3CopyFile.Destination.Bucket, s3CopyFile.Destination.Path)
+			continue
+		}
+
 		if len(s3CopyFile.BuildVariants) > 0 && !utility.StringSliceContains(
 			s3CopyFile.BuildVariants, conf.BuildVariant.Name) {
 			continue
@@ -188,43 +238,76 @@ func (c *s3copy) s3Copy(ctx context.Context,
 			s3CopyFile.Source.Path, s3CopyFile.Destination.Bucket,
 			s3CopyFile.Destination.Path)
 
-		s3CopyReq := apimodels.S3CopyRequest{
-			AwsKey:              c.AwsKey,
-			AwsSecret:           c.AwsSecret,
-			S3SourceRegion:      s3CopyFile.Source.Region,
-			S3SourceBucket:      s3CopyFile.Source.Bucket,
-			S3SourcePath:        s3CopyFile.Source.Path,
-			S3DestinationRegion: s3CopyFile.Destination.Region,
-			S3DestinationBucket: s3CopyFile.Destination.Bucket,
-			S3DestinationPath:   s3CopyFile.Destination.Path,
-			S3DisplayName:       s3CopyFile.DisplayName,
-			S3Permissions:       s3CopyFile.Permissions,
+		s3CopyReq.AwsKey = c.AwsKey
+		s3CopyReq.AwsSecret = c.AwsSecret
+
+		// Now copy the file into the permanent location
+		srcOpts := pail.S3Options{
+			Credentials: pail.CreateAWSCredentials(s3CopyReq.AwsKey, s3CopyReq.AwsSecret, ""),
+			Region:      s3CopyReq.S3SourceRegion,
+			Name:        s3CopyReq.S3SourceBucket,
+			Permissions: pail.S3Permissions(s3CopyReq.S3Permissions),
 		}
 
-		responseString, err := comm.S3Copy(ctx, td, &s3CopyReq)
-
-		if responseString != "" {
-			logger.Task().Infof("s3Copy response: %s", responseString)
-		}
-
+		srcBucket, err := pail.NewS3MultiPartBucketWithHTTPClient(client, srcOpts)
 		if err != nil {
-			err = errors.Wrap(err, "s3 push copy failed")
-			logger.Execution().Error(err)
+			connectionErr := errors.Wrap(err, "S3 copy failed, could not establish connection to source bucket")
+			logger.Task().Error(connectionErr)
+			return connectionErr
+		}
 
-			if s3CopyFile.Optional {
-				logger.Execution().Errorf("file '%s' is optional, continuing",
-					s3CopyFile.DisplayName)
-				continue
-			} else {
-				return errors.Wrapf(err, "failed to push %s to %s",
-					s3CopyFile.Source.Path, s3CopyFile.Destination.Bucket)
+		if err := srcBucket.Check(ctx); err != nil {
+			return errors.Wrap(err, "invalid bucket")
+		}
+		destOpts := pail.S3Options{
+			Credentials: pail.CreateAWSCredentials(s3CopyReq.AwsKey, s3CopyReq.AwsSecret, ""),
+			Region:      s3CopyReq.S3DestinationRegion,
+			Name:        s3CopyReq.S3DestinationBucket,
+			Permissions: pail.S3Permissions(s3CopyReq.S3Permissions),
+		}
+		destBucket, err := pail.NewS3MultiPartBucket(destOpts)
+		if err != nil {
+			connectionErr := errors.Wrap(err, "S3 copy failed, could not establish connection to destination bucket")
+			logger.Task().Error(connectionErr)
+			return connectionErr
+		}
+	retryLoop:
+		for i := 0; i < maxS3OpAttempts; i++ {
+			select {
+			case <-ctx.Done():
+				return errors.New("s3 copy operation canceled")
+			case <-timer.C:
+				copyOpts := pail.CopyOptions{
+					SourceKey:         s3CopyReq.S3SourcePath,
+					DestinationKey:    s3CopyReq.S3DestinationPath,
+					DestinationBucket: destBucket,
+				}
+				err = srcBucket.Copy(ctx, copyOpts)
+				if err != nil {
+					newPushLog.Status = pushLogFailed
+					if err := comm.UpdatePushStatus(ctx, td, newPushLog); err != nil {
+						return errors.Wrap(err, "updating pushlog status failed for task")
+					}
+					if s3CopyFile.Optional {
+						logger.Execution().Errorf("S3 push copy failed to copy '%s' to '%s'. File is optional, continuing \n error: %v",
+							s3CopyFile.Source.Path, s3CopyFile.Destination.Bucket, err)
+						timer.Reset(backoffCounter.Duration())
+						continue retryLoop
+					} else {
+						return errors.Wrapf(err, "S3 push copy failed to copy '%s' to '%s'. File is not optional, exiting \n error",
+							s3CopyFile.Source.Path, s3CopyFile.Destination.Bucket)
+					}
+				} else {
+					newPushLog.Status = pushLogSuccess
+					if err := comm.UpdatePushStatus(ctx, td, newPushLog); err != nil {
+						return errors.Wrap(err, "updating pushlog status success for task")
+					}
+					if err = c.attachFiles(ctx, comm, logger, td, s3CopyReq); err != nil {
+						return errors.WithStack(err)
+					}
+					break retryLoop
+				}
 			}
-
-		}
-
-		err = c.attachFiles(ctx, comm, logger, td, s3CopyReq)
-		if err != nil {
-			return errors.WithStack(err)
 		}
 		if !foundDottedBucketName && strings.Contains(s3CopyReq.S3DestinationBucket, ".") {
 			logger.Task().Warning("destination bucket names containing dots that are created after Sept. 30, 2020 are not guaranteed to have valid attached URLs")
@@ -237,33 +320,26 @@ func (c *s3copy) s3Copy(ctx context.Context,
 	return nil
 }
 
-// AttachTaskFiles is responsible for sending the
+// attachFiles is responsible for sending the
 // specified file to the API Server
 func (c *s3copy) attachFiles(ctx context.Context, comm client.Communicator,
 	logger client.LoggerProducer, td client.TaskData, request apimodels.S3CopyRequest) error {
 
 	remotePath := filepath.ToSlash(request.S3DestinationPath)
 	fileLink := agentutil.S3DefaultURL(request.S3DestinationBucket, remotePath)
-
 	displayName := request.S3DisplayName
-
 	if displayName == "" {
 		displayName = filepath.Base(request.S3SourcePath)
 	}
-
 	logger.Execution().Infof("attaching file with name %v", displayName)
-
 	file := artifact.File{
 		Name: displayName,
 		Link: fileLink,
 	}
-
 	files := []*artifact.File{&file}
-
 	if err := comm.AttachFiles(ctx, td, files); err != nil {
 		return errors.Wrap(err, "Attach files failed")
 	}
-
 	logger.Execution().Info("API attach files call succeeded")
 	return nil
 }

--- a/agent/command/s3_copy.go
+++ b/agent/command/s3_copy.go
@@ -249,9 +249,9 @@ func (c *s3copy) copyWithRetry(ctx context.Context,
 
 		srcBucket, err := pail.NewS3MultiPartBucketWithHTTPClient(client, srcOpts)
 		if err != nil {
-			connectionErr := errors.Wrap(err, "S3 copy failed, could not establish connection to source bucket")
-			logger.Task().Error(connectionErr)
-			return connectionErr
+			bucketErr := errors.Wrap(err, "S3 copy failed, could not establish connection to source bucket")
+			logger.Task().Error(bucketErr)
+			return bucketErr
 		}
 
 		if err := srcBucket.Check(ctx); err != nil {

--- a/agent/command/s3_copy_test.go
+++ b/agent/command/s3_copy_test.go
@@ -2,61 +2,67 @@ package command
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
-	agentutil "github.com/evergreen-ci/evergreen/agent/internal/testutil"
 	"github.com/evergreen-ci/evergreen/model"
-	modelutil "github.com/evergreen-ci/evergreen/model/testutil"
-	"github.com/evergreen-ci/evergreen/testutil"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestS3CopyPluginExecution(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := evergreen.GetEnvironment()
-	testConfig := env.Settings()
-	testutil.ConfigureIntegrationTest(t, testConfig, "TestS3CopyPluginExecution")
-
-	comm := client.NewMock("http://localhost.com")
-
-	Convey("With a SimpleRegistry and test project file", t, func() {
-		version := &model.Version{
-			Id: "versionId",
-		}
-		So(version.Insert(), ShouldBeNil)
-
-		pwd := testutil.GetDirectoryOfFile()
-		configFile := filepath.Join(pwd, "testdata", "plugin_s3_copy.yml")
-		modelData, err := modelutil.SetupAPITestData(testConfig, "copyTask", "linux-64", configFile, modelutil.NoPatch)
-		require.NoError(t, err, "failed to setup test data")
-		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
-		require.NoError(t, err)
-		conf.WorkDir = pwd
-		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
-		So(err, ShouldBeNil)
-
-		require.True(t, len(testConfig.Providers.AWS.EC2Keys) > 0)
-		conf.Expansions.Update(map[string]string{
-			"aws_key":    testConfig.Providers.AWS.EC2Keys[0].Key,
-			"aws_secret": testConfig.Providers.AWS.EC2Keys[0].Secret,
-		})
-
-		Convey("the s3 copy command should execute successfully", func() {
-			for _, task := range conf.Project.Tasks {
-				for _, command := range task.Commands {
-					pluginCmds, err := Render(command, conf.Project.Functions)
-					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
-					So(pluginCmds, ShouldNotBeNil)
-					So(err, ShouldBeNil)
-					err = pluginCmds[0].Execute(ctx, comm, logger, conf)
-					So(err, ShouldBeNil)
-				}
+func TestS3CopyExecute(t *testing.T) {
+	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, c *s3copy, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig){
+		"FailsWithNoContentsToPull": func(ctx context.Context, t *testing.T, c *s3copy, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
+			assert.Error(t, c.Execute(ctx, comm, logger, conf))
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			conf := &internal.TaskConfig{
+				Task: &task.Task{
+					Id:           "id",
+					Project:      "project",
+					Version:      "version",
+					BuildVariant: "build_variant",
+					DisplayName:  "display_name",
+				},
+				BuildVariant: &model.BuildVariant{
+					Name: "build_variant",
+				},
+				ProjectRef: &model.ProjectRef{
+					Id: "project_identifier",
+					TaskSync: model.TaskSyncOptions{
+						ConfigEnabled: utility.TruePtr(),
+					},
+				},
+				TaskSync: evergreen.S3Credentials{
+					Key:    "key",
+					Secret: "secret",
+					Bucket: "bucket",
+				},
 			}
+			comm := client.NewMock("localhost")
+			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{
+				ID:     conf.Task.Id,
+				Secret: conf.Task.Secret,
+			}, nil)
+			require.NoError(t, err)
+
+			c := &s3copy{S3CopyFiles: []*s3CopyFile{
+				{
+					Source: s3Loc{
+						Bucket: "bucket",
+						Path:   "path",
+					},
+				},
+			}}
+			require.NoError(t, err)
+			testCase(ctx, t, c, comm, logger, conf)
 		})
-	})
+	}
 }

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -86,9 +86,10 @@ type Communicator interface {
 	GetPatchFile(context.Context, TaskData, string) (string, error)
 
 	// The following operations are used by
+	NewPush(context.Context, TaskData, *apimodels.S3CopyRequest) (*model.PushLog, error)
+	UpdatePushStatus(context.Context, TaskData, *model.PushLog) error
 	AttachFiles(context.Context, TaskData, []*artifact.File) error
 	GetManifest(context.Context, TaskData) (*manifest.Manifest, error)
-	S3Copy(context.Context, TaskData, *apimodels.S3CopyRequest) (string, error)
 	KeyValInc(context.Context, TaskData, *model.KeyVal) error
 
 	// these are for the taskdata/json plugin that saves perf data

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -411,6 +411,14 @@ func (c *Mock) SetDownstreamParams(ctx context.Context, downstreamParams []patch
 	return nil
 }
 
+func (c *Mock) NewPush(ctx context.Context, td TaskData, req *apimodels.S3CopyRequest) (*serviceModel.PushLog, error) {
+	return nil, nil
+}
+
+func (c *Mock) UpdatePushStatus(ctx context.Context, td TaskData, pushlog *serviceModel.PushLog) error {
+	return nil
+}
+
 // SendTestLog posts a test log for a communicator's task. Is a
 // noop if the test Log is nil.
 func (c *Mock) SendTestLog(ctx context.Context, td TaskData, log *serviceModel.TestLog) (string, error) {
@@ -423,10 +431,6 @@ func (c *Mock) SendTestLog(ctx context.Context, td TaskData, log *serviceModel.T
 
 func (c *Mock) GetManifest(ctx context.Context, td TaskData) (*manifest.Manifest, error) {
 	return &manifest.Manifest{}, nil
-}
-
-func (c *Mock) S3Copy(ctx context.Context, td TaskData, req *apimodels.S3CopyRequest) (string, error) {
-	return "", nil
 }
 
 func (c *Mock) KeyValInc(ctx context.Context, td TaskData, kv *serviceModel.KeyVal) error {

--- a/agent/internal/client/pod_methods.go
+++ b/agent/internal/client/pod_methods.go
@@ -211,12 +211,16 @@ func (c *podCommunicator) SetDownstreamParams(ctx context.Context, downstreamPar
 	return errors.New("TODO: implement")
 }
 
-func (c *podCommunicator) GetManifest(ctx context.Context, taskData TaskData) (*manifest.Manifest, error) {
+func (c *podCommunicator) NewPush(context.Context, TaskData, *apimodels.S3CopyRequest) (*model.PushLog, error) {
 	return nil, errors.New("TODO: implement")
 }
 
-func (c *podCommunicator) S3Copy(ctx context.Context, taskData TaskData, req *apimodels.S3CopyRequest) (string, error) {
-	return "", errors.New("TODO: implement")
+func (c *podCommunicator) UpdatePushStatus(context.Context, TaskData, *model.PushLog) error {
+	return errors.New("TODO: implement")
+}
+
+func (c *podCommunicator) GetManifest(ctx context.Context, taskData TaskData) (*manifest.Manifest, error) {
+	return nil, errors.New("TODO: implement")
 }
 
 func (c *podCommunicator) KeyValInc(ctx context.Context, taskData TaskData, kv *model.KeyVal) error {

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2022-01-27"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-01-31"
+	AgentVersion = "2022-02-03"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/push.go
+++ b/model/push.go
@@ -15,7 +15,6 @@ import (
 const (
 	PushlogCollection = "pushes"
 	PushLogSuccess    = "success"
-	PushLogFailed     = "failed"
 )
 
 type PushLog struct {

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -194,8 +194,6 @@ tasks:
           s3_copy_files:
               - {'source': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}', 'bucket': 'mciuploads'},
                 'destination': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}-copy', 'bucket': 'mciuploads'}}
-              - {'source': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}-2', 'bucket': 'mciuploads'},
-                'destination': {'path': 'evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}-copy-2', 'bucket': 'mciuploads'}}
 buildvariants:
   - name: localhost
     display_name: localhost

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -346,14 +346,6 @@ functions:
           set -o xtrace
           rm evergreen/bin/output.*
           rm evergreen/bin/jstests/*.xml
-  copy-fake-destination-optional:
-    - command: s3Copy.copy
-      params:
-        aws_key: fake
-        aws_secret: fake
-        s3_copy_files:
-            - {'source': {'path': 'fakesource', 'bucket': 'fake-bucket-1'},
-               'destination': {'path': 'fakefile', 'bucket': 'evg-test-bucket-2'}}
 
 #######################################
 #                Tasks                #
@@ -525,9 +517,12 @@ tasks:
   - <<: *run-go-test-suite-with-mongodb-useast
     tags: ["db", "test"]
     name: test-graphql
-  - name: s3-fake-destination-optional
+  - name: docker-cleanup
     commands:
-      - func: copy-fake-destination-optional
+      - func: get-project-and-modules
+      - func: setup-credentials
+      - func: run-make
+        vars: { target: "test-thirdparty-docker" }
   - name: test-repotracker
     tags: ["db", "test"]
     commands:
@@ -623,7 +618,7 @@ buildvariants:
       - name: ".test"
       - name: "js-test"
       - name: ".linter"
-      - name: "s3-fake-destination-optional"
+      - name: "docker-cleanup"
       - name: test-db-auth
       - name: test-cloud
 

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -346,6 +346,14 @@ functions:
           set -o xtrace
           rm evergreen/bin/output.*
           rm evergreen/bin/jstests/*.xml
+  copy-fake-destination-optional:
+    - command: s3Copy.copy
+      params:
+        aws_key: fake
+        aws_secret: fake
+        s3_copy_files:
+            - {'source': {'path': 'fakesource', 'bucket': 'fake-bucket-1'},
+               'destination': {'path': 'fakefile', 'bucket': 'evg-test-bucket-2'}}
 
 #######################################
 #                Tasks                #
@@ -517,12 +525,9 @@ tasks:
   - <<: *run-go-test-suite-with-mongodb-useast
     tags: ["db", "test"]
     name: test-graphql
-  - name: docker-cleanup
+  - name: s3-fake-destination-optional
     commands:
-      - func: get-project-and-modules
-      - func: setup-credentials
-      - func: run-make
-        vars: { target: "test-thirdparty-docker" }
+      - func: copy-fake-destination-optional
   - name: test-repotracker
     tags: ["db", "test"]
     commands:
@@ -618,7 +623,7 @@ buildvariants:
       - name: ".test"
       - name: "js-test"
       - name: ".linter"
-      - name: "docker-cleanup"
+      - name: "s3-fake-destination-optional"
       - name: test-db-auth
       - name: test-cloud
 

--- a/service/api.go
+++ b/service/api.go
@@ -440,6 +440,86 @@ func (as *APIServer) SetDownstreamParams(w http.ResponseWriter, r *http.Request)
 	gimlet.WriteJSON(w, fmt.Sprintf("Downstream patches for %v have successfully been set", p.Id))
 }
 
+// NewPush updates when a task is pushing to s3 for s3 copy
+func (as *APIServer) NewPush(w http.ResponseWriter, r *http.Request) {
+	task := MustHaveTask(r)
+	s3CopyReq := &apimodels.S3CopyRequest{}
+
+	if err := utility.ReadJSON(utility.NewRequestReader(r), s3CopyReq); err != nil {
+		as.LoggedError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	// Get the version for this task, so we can check if it has
+	// any already-done pushes
+	v, err := model.VersionFindOne(model.VersionById(task.Version))
+	if err != nil {
+		as.LoggedError(w, r, http.StatusInternalServerError,
+			errors.Wrapf(err, "problem querying task %s with version id %s",
+				task.Id, task.Version))
+		return
+	}
+
+	// Check for an already-pushed file with this same file path,
+	// but from a conflicting or newer commit sequence num
+	if v == nil {
+		as.LoggedError(w, r, http.StatusNotFound,
+			errors.Errorf("no version found for '%s'", task.Id))
+		return
+	}
+
+	copyToLocation := strings.Join([]string{s3CopyReq.S3DestinationBucket, s3CopyReq.S3DestinationPath}, "/")
+
+	newestPushLog, err := model.FindPushLogAfter(copyToLocation, v.RevisionOrderNumber)
+	if err != nil {
+		as.LoggedError(w, r, http.StatusInternalServerError,
+			errors.Wrapf(err, "problem querying for push log at '%s' for '%s'",
+				copyToLocation, task.Id))
+		return
+	}
+	if newestPushLog != nil {
+		// the error is not being returned in order to avoid a retry
+		grip.Warningln("conflict with existing pushed file:", copyToLocation)
+		gimlet.WriteJSON(w, nil)
+		return
+	}
+
+	// It's now safe to put the file in its permanent location.
+	newPushLog := model.NewPushLog(v, task, copyToLocation)
+	if err = newPushLog.Insert(); err != nil {
+		as.LoggedError(w, r, http.StatusInternalServerError,
+			errors.Wrapf(err, "failed to create new push log: %+v", newPushLog))
+	}
+	gimlet.WriteJSON(w, newPushLog)
+}
+
+// UpdatePushStatus updates the status for a file that a task is pushing to s3 for s3 copy
+func (as *APIServer) UpdatePushStatus(w http.ResponseWriter, r *http.Request) {
+	task := MustHaveTask(r)
+	pushLog := &model.PushLog{}
+	err := utility.ReadJSON(utility.NewRequestReader(r), pushLog)
+	if err != nil {
+		as.LoggedError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	err = errors.Wrapf(pushLog.UpdateStatus(pushLog.Status),
+		"updating pushlog status failed for task %s", task.Id)
+	if err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"task":      task.Id,
+			"project":   task.Project,
+			"version":   task.Version,
+			"execution": task.Execution,
+		}))
+		as.LoggedError(w, r, http.StatusInternalServerError,
+			errors.Wrapf(err, "updating pushlog status failed for task %s", task.Id))
+		return
+	}
+
+	gimlet.WriteJSON(w, nil)
+}
+
 // AppendTaskLog appends the received logs to the task's internal logs.
 func (as *APIServer) AppendTaskLog(w http.ResponseWriter, r *http.Request) {
 	if as.GetSettings().ServiceFlags.TaskLoggingDisabled {
@@ -705,6 +785,8 @@ func (as *APIServer) GetServiceApp() *gimlet.APIApp {
 	app.Route().Version(2).Route("/task/{taskId}/parser_project").Wrap(requireTaskSecret).Handler(as.GetParserProject).Get()
 	app.Route().Version(2).Route("/task/{taskId}/project_ref").Wrap(requireTaskSecret).Handler(as.GetProjectRef).Get()
 	app.Route().Version(2).Route("/task/{taskId}/expansions").Wrap(requireTask, requireHost).Handler(as.GetExpansions).Get()
+	app.Route().Version(2).Route("/task/{taskId}/new_push").Wrap(requireTaskSecret).Handler(as.NewPush).Post()
+	app.Route().Version(2).Route("/task/{taskId}/update_push_status").Wrap(requireTaskSecret).Handler(as.UpdatePushStatus).Post()
 
 	// plugins
 	app.Route().Version(2).Prefix("/task/{taskId}").Route("/git/patchfile/{patchfile_id}").Wrap(requireTaskSecret).Handler(as.gitServePatchFile).Get()

--- a/service/api_plugin_s3copy.go
+++ b/service/api_plugin_s3copy.go
@@ -134,7 +134,8 @@ func (as *APIServer) s3copyPlugin(w http.ResponseWriter, r *http.Request) {
 		})
 
 	if err != nil {
-		grip.Error(errors.Wrap(errors.WithStack(newPushLog.UpdateStatus(model.PushLogFailed)), "updating pushlog status failed"))
+		// this is not using a constant because the code will be removed soon
+		grip.Error(errors.Wrap(errors.WithStack(newPushLog.UpdateStatus("failed")), "updating pushlog status failed"))
 
 		as.LoggedError(w, r, http.StatusInternalServerError,
 			errors.Wrapf(err, "S3 copy failed for task %s", task.Id))

--- a/service/api_plugin_s3copy.go
+++ b/service/api_plugin_s3copy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// TODO: <EVG-16254> remove this code
 const (
 	s3CopyRetryMinDelay = 5 * time.Second
 	s3CopyAttempts      = 5


### PR DESCRIPTION
[EVG-15836](https://jira.mongodb.org/browse/EVG-15836)

### Description 
This was merged to main before because it broke the smoke test. After testing, we realized that the source of that break was the added lines to the smoke test. [EVG-16241](uhttps://jira.mongodb.org/browse/EVG-16241) was created to address that. This PR merges what was merged before (the first commit), plus a removal of the additional lines to agent.yml, and a removal of a test in self-test.yml that shouldn't have been committed. 

### Testing 
Tested with patches on staging. 
[smoke test patch](https://spruce-staging.corp.mongodb.com/version/61fab1cfb237367ee0cbcfb6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[a patch with a fake key that should fail](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu1604_copy_should_succeed_patch_1e78e1f484cda40069403e82d1887ee670f82d1d_61faae5bb237367ee0cbce2b_22_02_02_16_16_40/logs?execution=0)
[a patch that should succeed](https://spruce-staging.corp.mongodb.com/version/61faaf329dbe32539cf15a38/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (I verified that the upload was done).