### PR TITLE
EVG-16175: (partial) addition of new task status and concomitant changes for trigger, scheduler, and graphql

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -57,13 +57,16 @@ const (
 	TaskUnscheduled  = "unscheduled"
 	// TaskWillRun is a subset of TaskUndispatched and is only used in the UI
 	TaskWillRun = "will-run"
-
-	// TaskStarted indicates a task is running on an agent
-	TaskStarted = "started"
+	// TaskContainerAllocated indicates that a tasks's container has been requested
+	// from the cloud provider but hasn't started yet
+	TaskContainerAllocated = "container-allocated"
 
 	// TaskDispatched indicates that an agent has received the task, but
 	// the agent has not yet told Evergreen that it's running the task
 	TaskDispatched = "dispatched"
+
+	// TaskStarted indicates a task is running on an agent
+	TaskStarted = "started"
 
 	// The task statuses below indicate that a task has finished.
 	TaskSucceeded = "success"

--- a/globals.go
+++ b/globals.go
@@ -291,7 +291,7 @@ var TaskNonGenericFailureStatuses = []string{
 
 // TaskFailureStatuses represents all the ways that a task can fail, inclusive of system failures
 // and task failures.
-var TaskFailureStatuses = append(TaskNonGenericFailureStatuses, TaskFailed)
+var TaskFailureStatuses = append([]string{TaskFailed}, TaskNonGenericFailureStatuses...)
 
 var TaskUnstartedStatuses = []string{
 	TaskInactive,

--- a/globals.go
+++ b/globals.go
@@ -58,7 +58,7 @@ const (
 	// TaskWillRun is a subset of TaskUndispatched and is only used in the UI
 	TaskWillRun = "will-run"
 	// TaskContainerAllocated indicates that a tasks's container has been requested
-	// from the cloud provider but hasn't started yet
+	// from the cloud provider but hasn't started yet.
 	TaskContainerAllocated = "container-allocated"
 
 	// TaskDispatched indicates that an agent has received the task, but

--- a/globals.go
+++ b/globals.go
@@ -293,6 +293,7 @@ var TaskUnstartedStatuses []string = []string{
 	TaskInactive,
 	TaskUnstarted,
 	TaskUndispatched,
+	TaskContainerAllocated,
 }
 
 func IsUnstartedTaskStatus(status string) bool {
@@ -677,9 +678,9 @@ var (
 	}
 
 	// constant arrays for db update logic
-	AbortableStatuses   = []string{TaskStarted, TaskDispatched}
+	AbortableStatuses   = []string{TaskStarted, TaskDispatched, TaskContainerAllocated}
 	CompletedStatuses   = []string{TaskSucceeded, TaskFailed}
-	UncompletedStatuses = []string{TaskStarted, TaskUnstarted, TaskUndispatched, TaskDispatched, TaskConflict}
+	UncompletedStatuses = []string{TaskStarted, TaskUnstarted, TaskUndispatched, TaskDispatched, TaskConflict, TaskContainerAllocated}
 
 	SyncStatuses = []string{TaskSucceeded, TaskFailed}
 

--- a/globals.go
+++ b/globals.go
@@ -65,7 +65,7 @@ const (
 	// the agent has not yet told Evergreen that it's running the task
 	TaskDispatched = "dispatched"
 
-	// TaskStarted indicates a task is running on an agent
+	// TaskStarted indicates a task is running on an agent.
 	TaskStarted = "started"
 
 	// The task statuses below indicate that a task has finished.
@@ -272,14 +272,15 @@ const (
 	InvalidDivideInputError    = "$divide only supports numeric types"
 )
 
-var InternalAliases []string = []string{
+var InternalAliases = []string{
 	CommitQueueAlias,
 	GithubPRAlias,
 	GithubChecksAlias,
 	GitTagAlias,
 }
 
-var TaskSystemFailureStatuses []string = []string{
+// TaskNonGenericFailureStatuses represents some kind of specific abnormal failure mode.
+var TaskNonGenericFailureStatuses = []string{
 	TaskTimedOut,
 	TaskSystemFailed,
 	TaskTestTimedOut,
@@ -288,9 +289,11 @@ var TaskSystemFailureStatuses []string = []string{
 	TaskSystemTimedOut,
 }
 
-var TaskFailureStatuses []string = append([]string{TaskFailed}, TaskSystemFailureStatuses...)
+// TaskFailureStatuses represents all the ways that a task can fail, inclusive of system failures
+// and task failures.
+var TaskFailureStatuses = append(TaskNonGenericFailureStatuses, TaskFailed)
 
-var TaskUnstartedStatuses []string = []string{
+var TaskUnstartedStatuses = []string{
 	TaskInactive,
 	TaskUnstarted,
 	TaskUndispatched,
@@ -679,9 +682,13 @@ var (
 	}
 
 	// constant arrays for db update logic
-	AbortableStatuses   = []string{TaskStarted, TaskDispatched, TaskContainerAllocated}
-	CompletedStatuses   = []string{TaskSucceeded, TaskFailed}
-	UncompletedStatuses = []string{TaskStarted, TaskUnstarted, TaskUndispatched, TaskDispatched, TaskConflict, TaskInactive, TaskContainerAllocated}
+	// TaskAbortableStatuses have been picked up by an agent but may or may not have started.
+	TaskAbortableStatuses = []string{TaskStarted, TaskDispatched}
+	// TaskCompletedStatuses have not experienced some sort of system failure and
+	// are in a finished state.
+	TaskCompletedStatuses = []string{TaskSucceeded, TaskFailed}
+	// TaskUncompletedStatuses are all statuses that do not represent a finished state.
+	TaskUncompletedStatuses = []string{TaskStarted, TaskUnstarted, TaskUndispatched, TaskDispatched, TaskConflict, TaskInactive, TaskContainerAllocated}
 
 	SyncStatuses = []string{TaskSucceeded, TaskFailed}
 

--- a/globals.go
+++ b/globals.go
@@ -279,15 +279,16 @@ var InternalAliases []string = []string{
 	GitTagAlias,
 }
 
-var TaskFailureStatuses []string = []string{
+var TaskSystemFailureStatuses []string = []string{
 	TaskTimedOut,
-	TaskFailed,
 	TaskSystemFailed,
 	TaskTestTimedOut,
 	TaskSetupFailed,
 	TaskSystemUnresponse,
 	TaskSystemTimedOut,
 }
+
+var TaskFailureStatuses []string = append([]string{TaskFailed}, TaskSystemFailureStatuses...)
 
 var TaskUnstartedStatuses []string = []string{
 	TaskInactive,
@@ -680,7 +681,7 @@ var (
 	// constant arrays for db update logic
 	AbortableStatuses   = []string{TaskStarted, TaskDispatched, TaskContainerAllocated}
 	CompletedStatuses   = []string{TaskSucceeded, TaskFailed}
-	UncompletedStatuses = []string{TaskStarted, TaskUnstarted, TaskUndispatched, TaskDispatched, TaskConflict, TaskContainerAllocated}
+	UncompletedStatuses = []string{TaskStarted, TaskUnstarted, TaskUndispatched, TaskDispatched, TaskConflict, TaskInactive, TaskContainerAllocated}
 
 	SyncStatuses = []string{TaskSucceeded, TaskFailed}
 

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3278,7 +3278,7 @@ func (r *taskResolver) CanSchedule(ctx context.Context, obj *restModel.APITask) 
 }
 
 func (r *taskResolver) CanUnschedule(ctx context.Context, obj *restModel.APITask) (bool, error) {
-	return obj.Activated && *obj.Status == evergreen.TaskUndispatched, nil
+	return obj.Activated && *obj.Status == evergreen.TaskUndispatched || *obj.Status == evergreen.TaskContainerAllocated, nil
 }
 
 func (r *taskResolver) CanSetPriority(ctx context.Context, obj *restModel.APITask) (bool, error) {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3278,7 +3278,7 @@ func (r *taskResolver) CanSchedule(ctx context.Context, obj *restModel.APITask) 
 }
 
 func (r *taskResolver) CanUnschedule(ctx context.Context, obj *restModel.APITask) (bool, error) {
-	return obj.Activated && *obj.Status == evergreen.TaskUndispatched || *obj.Status == evergreen.TaskContainerAllocated, nil
+	return (obj.Activated && *obj.Status == evergreen.TaskUndispatched) || *obj.Status == evergreen.TaskContainerAllocated, nil
 }
 
 func (r *taskResolver) CanSetPriority(ctx context.Context, obj *restModel.APITask) (bool, error) {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -770,8 +770,7 @@ func canRestartTask(ctx context.Context, at *restModel.APITask) (*bool, error) {
 	if err != nil {
 		return nil, err
 	}
-	nonrestartableStatuses := evergreen.TaskUncompletedStatuses
-	canRestart := !utility.StringSliceContains(nonrestartableStatuses, *at.Status) || at.Aborted || (at.DisplayOnly && *taskBlocked)
+	canRestart := !utility.StringSliceContains(evergreen.TaskUncompletedStatuses, *at.Status) || at.Aborted || (at.DisplayOnly && *taskBlocked)
 	isExecTask, err := isExecutionTask(ctx, at) // Cant restart execution tasks.
 	if err != nil {
 		return nil, err

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -770,7 +770,7 @@ func canRestartTask(ctx context.Context, at *restModel.APITask) (*bool, error) {
 	if err != nil {
 		return nil, err
 	}
-	nonrestartableStatuses := []string{evergreen.TaskStarted, evergreen.TaskUnstarted, evergreen.TaskUndispatched, evergreen.TaskDispatched, evergreen.TaskInactive}
+	nonrestartableStatuses := []string{evergreen.TaskStarted, evergreen.TaskUnstarted, evergreen.TaskUndispatched, evergreen.TaskDispatched, evergreen.TaskInactive, evergreen.TaskContainerAllocated}
 	canRestart := !utility.StringSliceContains(nonrestartableStatuses, *at.Status) || at.Aborted || (at.DisplayOnly && *taskBlocked)
 	isExecTask, err := isExecutionTask(ctx, at) // Cant restart execution tasks.
 	if err != nil {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -770,7 +770,7 @@ func canRestartTask(ctx context.Context, at *restModel.APITask) (*bool, error) {
 	if err != nil {
 		return nil, err
 	}
-	nonrestartableStatuses := []string{evergreen.TaskStarted, evergreen.TaskUnstarted, evergreen.TaskUndispatched, evergreen.TaskDispatched, evergreen.TaskInactive, evergreen.TaskContainerAllocated}
+	nonrestartableStatuses := evergreen.TaskUncompletedStatuses
 	canRestart := !utility.StringSliceContains(nonrestartableStatuses, *at.Status) || at.Aborted || (at.DisplayOnly && *taskBlocked)
 	isExecTask, err := isExecutionTask(ctx, at) // Cant restart execution tasks.
 	if err != nil {

--- a/model/audit.go
+++ b/model/audit.go
@@ -189,7 +189,7 @@ func CheckStuckHosts() ([]StuckHostInconsistency, error) {
 		{"$lookup": bson.M{"from": task.Collection, "localField": host.RunningTaskKey,
 			"foreignField": task.IdKey, "as": HostTaskKey}},
 		{"$unwind": "$" + HostTaskKey},
-		{"$match": bson.M{HostTaskKey + "." + task.StatusKey: bson.M{"$in": evergreen.CompletedStatuses}}},
+		{"$match": bson.M{HostTaskKey + "." + task.StatusKey: bson.M{"$in": evergreen.TaskCompletedStatuses}}},
 		{"$project": bson.M{
 			StuckHostKey:            "$" + host.IdKey,
 			StuckHostRunningTaskKey: "$" + host.RunningTaskKey,

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -211,7 +211,7 @@ func ByRecentlyFinishedWithMakespans(limit int) db.Q {
 		},
 		PredictedMakespanKey: bson.M{"$gt": 0},
 		ActualMakespanKey:    bson.M{"$gt": 0},
-		StatusKey:            bson.M{"$in": evergreen.CompletedStatuses},
+		StatusKey:            bson.M{"$in": evergreen.TaskCompletedStatuses},
 	}).Sort([]string{RevisionOrderNumberKey}).Limit(limit)
 }
 

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -343,7 +343,7 @@ func allHostsSpawnedByFinishedTasks() ([]Host, error) {
 			"$or": []bson.M{
 				// If the task is finished, then its host should be terminated.
 				{
-					bsonutil.GetDottedKeyName(runningTasks, task.StatusKey): bson.M{"$in": evergreen.CompletedStatuses},
+					bsonutil.GetDottedKeyName(runningTasks, task.StatusKey): bson.M{"$in": evergreen.TaskCompletedStatuses},
 				},
 
 				// If the task execution number is greater than the host's task

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -293,7 +293,7 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 			return errors.WithStack(err)
 		}
 	}
-	finishedTasks, err := task.FindAll(db.Query(task.ByIdsAndStatus(taskIds, evergreen.CompletedStatuses)))
+	finishedTasks, err := task.FindAll(db.Query(task.ByIdsAndStatus(taskIds, evergreen.TaskCompletedStatuses)))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -409,7 +409,7 @@ func RestartBuild(buildId string, taskIds []string, abortInProgress bool, caller
 	}
 
 	// restart all the 'not in-progress' tasks for the build
-	tasks, err := task.FindAll(db.Query(task.ByIdsAndStatus(taskIds, evergreen.CompletedStatuses)))
+	tasks, err := task.FindAll(db.Query(task.ByIdsAndStatus(taskIds, evergreen.TaskCompletedStatuses)))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1544,7 +1544,7 @@ func updateAllMatchingDependenciesForTask(taskId, dependencyId string, unattaina
 func AbortTasksForBuild(buildId string, taskIds []string, caller string) error {
 	q := bson.M{
 		BuildIdKey: buildId,
-		StatusKey:  bson.M{"$in": evergreen.AbortableStatuses},
+		StatusKey:  bson.M{"$in": evergreen.TaskAbortableStatuses},
 	}
 	if len(taskIds) > 0 {
 		q[IdKey] = bson.M{"$in": taskIds}
@@ -1566,7 +1566,7 @@ func AbortTasksForVersion(versionId string, taskIds []string, caller string) err
 		bson.M{
 			VersionKey: versionId,
 			IdKey:      bson.M{"$in": taskIds},
-			StatusKey:  bson.M{"$in": evergreen.AbortableStatuses},
+			StatusKey:  bson.M{"$in": evergreen.TaskAbortableStatuses},
 		},
 		bson.M{"$set": bson.M{
 			AbortedKey:   true,

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -804,7 +804,7 @@ func (t *Task) CountSimilarFailingTasks() (int, error) {
 // build variant + display name combination as the specified task
 func (t *Task) PreviousCompletedTask(project string, statuses []string) (*Task, error) {
 	if len(statuses) == 0 {
-		statuses = evergreen.CompletedStatuses
+		statuses = evergreen.TaskCompletedStatuses
 	}
 	query := db.Query(ByBeforeRevisionWithStatusesAndRequesters(t.RevisionOrderNumber, statuses, t.BuildVariant,
 		t.DisplayName, project, evergreen.SystemVersionRequesterTypes)).Sort([]string{"-" + RevisionOrderNumberKey})
@@ -1921,7 +1921,7 @@ func (t *Task) MarkUnattainableDependency(dependencyId string, unattainable bool
 func AbortBuild(buildId string, reason AbortInfo) error {
 	q := bson.M{
 		BuildIdKey: buildId,
-		StatusKey:  bson.M{"$in": evergreen.AbortableStatuses},
+		StatusKey:  bson.M{"$in": evergreen.TaskAbortableStatuses},
 	}
 	if reason.TaskID != "" {
 		q[IdKey] = bson.M{"$ne": reason.TaskID}
@@ -1959,7 +1959,7 @@ func AbortBuild(buildId string, reason AbortInfo) error {
 func AbortVersion(versionId string, reason AbortInfo) error {
 	q := bson.M{
 		VersionKey: versionId,
-		StatusKey:  bson.M{"$in": evergreen.AbortableStatuses},
+		StatusKey:  bson.M{"$in": evergreen.TaskAbortableStatuses},
 	}
 	if reason.TaskID != "" {
 		q[IdKey] = bson.M{"$ne": reason.TaskID}
@@ -2415,7 +2415,7 @@ func FindRunnable(distroID string, removeDeps bool) ([]Task, error) {
 							{"$and": []bson.M{
 								{"$eq": bson.A{"$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyStatusKey), "*"}},
 								{"$or": []bson.M{
-									{"$in": bson.A{"$" + bsonutil.GetDottedKeyName(dependencyKey, StatusKey), evergreen.CompletedStatuses}},
+									{"$in": bson.A{"$" + bsonutil.GetDottedKeyName(dependencyKey, StatusKey), evergreen.TaskCompletedStatuses}},
 									{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(dependencyKey, DependsOnKey, DependencyUnattainableKey)},
 								}},
 							}},

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -484,6 +484,7 @@ func makeRandomTasks() []task.Task {
 		evergreen.TaskSystemTimedOut,
 		evergreen.TaskTestTimedOut,
 		evergreen.TaskConflict,
+		evergreen.TaskContainerAllocated,
 	}
 
 	numTasks := rand.Intn(10) + 10

--- a/service/stats.go
+++ b/service/stats.go
@@ -157,7 +157,7 @@ func (uis *UIServer) taskTimingJSON(w http.ResponseWriter, r *http.Request) {
 	if onlySuccessful == "true" {
 		statuses = []string{evergreen.TaskSucceeded}
 	} else {
-		statuses = evergreen.CompletedStatuses
+		statuses = evergreen.TaskCompletedStatuses
 	}
 
 	// if its all tasks find the build

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -30,21 +30,17 @@ func (t *buildTriggers) taskStatusToDesc() string {
 	other := 0
 	noReport := 0
 	for _, t := range t.tasks {
-		switch t.Status {
-		case evergreen.TaskSucceeded:
+		switch {
+		case t.Status == evergreen.TaskSucceeded:
 			success++
 
-		case evergreen.TaskFailed:
+		case t.Status == evergreen.TaskFailed:
 			failed++
 
-		case evergreen.TaskSystemFailed, evergreen.TaskTimedOut,
-			evergreen.TaskSystemUnresponse, evergreen.TaskSystemTimedOut,
-			evergreen.TaskTestTimedOut:
+		case utility.StringSliceContains(evergreen.TaskSystemFailureStatuses, t.Status):
 			systemError++
 
-		case evergreen.TaskStarted, evergreen.TaskUnstarted,
-			evergreen.TaskUndispatched, evergreen.TaskDispatched,
-			evergreen.TaskConflict, evergreen.TaskInactive:
+		case utility.StringSliceContains(evergreen.UncompletedStatuses, t.Status):
 			noReport++
 
 		default:

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -37,10 +37,10 @@ func (t *buildTriggers) taskStatusToDesc() string {
 		case t.Status == evergreen.TaskFailed:
 			failed++
 
-		case utility.StringSliceContains(evergreen.TaskSystemFailureStatuses, t.Status):
+		case utility.StringSliceContains(evergreen.TaskNonGenericFailureStatuses, t.Status):
 			systemError++
 
-		case utility.StringSliceContains(evergreen.UncompletedStatuses, t.Status):
+		case utility.StringSliceContains(evergreen.TaskUncompletedStatuses, t.Status):
 			noReport++
 
 		default:

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -37,7 +37,7 @@ func (t *buildTriggers) taskStatusToDesc() string {
 		case t.Status == evergreen.TaskFailed:
 			failed++
 
-		case utility.StringSliceContains(evergreen.TaskNonGenericFailureStatuses, t.Status):
+		case statusIsSystemFailure(t.Status):
 			systemError++
 
 		case utility.StringSliceContains(evergreen.TaskUncompletedStatuses, t.Status):
@@ -68,6 +68,14 @@ func (t *buildTriggers) taskStatusToDesc() string {
 	}
 
 	return appendTime(t.build, desc)
+}
+
+func statusIsSystemFailure(status string) bool {
+	systemFailures := []string{evergreen.TaskSystemFailed, evergreen.TaskTimedOut,
+		evergreen.TaskSystemUnresponse, evergreen.TaskSystemTimedOut,
+		evergreen.TaskTestTimedOut,
+	}
+	return utility.StringSliceContains(systemFailures, status)
 }
 
 func taskStatusSubformat(n int, verb string) string {

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -453,7 +453,7 @@ func (t *taskTriggers) taskOutcome(sub *event.Subscription) (*notification.Notif
 		return nil, nil
 	}
 
-	if t.data.Status != evergreen.TaskSucceeded && !evergreen.IsFailedTaskStatus(t.data.Status) {
+	if t.data.Status != evergreen.TaskSucceeded && !isFailedTaskStatus(t.data.Status) {
 		return nil, nil
 	}
 
@@ -469,7 +469,7 @@ func (t *taskTriggers) taskFailure(sub *event.Subscription) (*notification.Notif
 		return nil, nil
 	}
 
-	if !evergreen.IsFailedTaskStatus(t.data.Status) {
+	if !isFailedTaskStatus(t.data.Status) {
 		return nil, nil
 	}
 
@@ -849,7 +849,7 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 		return nil, errors.Wrap(err, "populating test results for task")
 	}
 
-	if !utility.StringSliceContains(evergreen.SystemVersionRequesterTypes, t.task.Requester) || !evergreen.IsFailedTaskStatus(t.task.Status) {
+	if !utility.StringSliceContains(evergreen.SystemVersionRequesterTypes, t.task.Requester) || !isFailedTaskStatus(t.task.Status) {
 		return nil, nil
 	}
 	if !matchingFailureType(sub.TriggerData[keyFailureType], t.task.Details.Type) {

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -761,7 +761,7 @@ func (t *taskTriggers) taskRuntimeChange(sub *event.Subscription) (*notification
 }
 
 func isFailedTaskStatus(status string) bool {
-	return status == evergreen.TaskFailed || status == evergreen.TaskSystemFailed || status == evergreen.TaskTestTimedOut
+	return utility.StringSliceContains(evergreen.TaskFailureStatuses, status)
 }
 
 func isTestStatusRegression(oldStatus, newStatus string) bool {


### PR DESCRIPTION
[EVG-16175](https://jira.mongodb.org/browse/EVG-16175)

### Description 
I added a TaskContainerAllocated status to differentiate between container tasks that were ready to run but waiting for a container, and that are ready to run with the container allocated. This required several downstream changes, which will be made in parts. 

### Testing 
https://spruce.mongodb.com/version/61fbe1f02fbabe23af018894/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
