### PR TITLE
EVG-7310 remove projectId from validation errors

### DIFF
--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -855,7 +855,7 @@ tasks:
 	s.NoError(err)
 	s.Equal(v.Config, dbVersion.Config)
 	s.Require().Len(dbVersion.Errors, 1)
-	s.Equal("buildvariant 'bv' in project 'mci' must either specify run_on field or have every task specify run_on.", dbVersion.Errors[0])
+	s.Equal("buildvariant 'bv' must either specify run_on field or have every task specify run_on", dbVersion.Errors[0])
 
 	dbBuild, err := build.FindOne(build.ByVersion(v.Id))
 	s.NoError(err)

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -130,12 +130,13 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "database error"))
 		}
 	} else {
+		// we're going in here, and we've provided nothing so the limit is 101
 		tests, err = tgh.sc.FindTestsByTaskId(data.FindTestsByTaskIdOpts{
 			Execution: tgh.testExecution,
 			Limit:     tgh.limit + 1,
-			Statuses:  tgh.testStatus,
+			Statuses:  tgh.testStatus, // we haven't provided a status or execution or test name
 			TaskID:    tgh.taskID,
-			TestID:    tgh.key,
+			TestID:    tgh.key, // TESTID IS KEY
 			TestName:  tgh.testName,
 		})
 		if err != nil {

--- a/service/api.go
+++ b/service/api.go
@@ -592,7 +592,7 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 	if input.Quiet {
 		errs = errs.AtLevel(validator.Error)
 	} else {
-		errs = append(errs, validator.CheckProjectWarnings(project, input.ProjectYaml)...)
+		errs = append(errs, validator.CheckProjectWarnings(project)...)
 	}
 
 	if len(errs) > 0 {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -207,7 +207,7 @@ func getDistrosForProject(projectID string) (ids []string, aliases []string, err
 }
 
 // verify that the project configuration semantics is valid
-func CheckProjectWarnings(project *model.Project, yamlBytes []byte) ValidationErrors {
+func CheckProjectWarnings(project *model.Project) ValidationErrors {
 	validationErrs := ValidationErrors{}
 	for _, projectWarningValidator := range projectWarningValidators {
 		validationErrs = append(validationErrs,
@@ -278,11 +278,9 @@ func validateAllDependenciesSpec(project *model.Project) ValidationErrors {
 					if dependency.Variant == "" || coveredVariants[dependency.Variant] {
 						errs = append(errs,
 							ValidationError{
-								Message: fmt.Sprintf("task '%s' in project '%s' "+
-									"contains the all dependencies (%s)' "+
+								Message: fmt.Sprintf("task '%s' contains the all dependencies (%s)' "+
 									"specification and other explicit dependencies or duplicate variants",
-									task.Name, project.Identifier,
-									model.AllDependencies),
+									task.Name, model.AllDependencies),
 							},
 						)
 					}
@@ -414,8 +412,7 @@ func validateBVFields(project *model.Project) ValidationErrors {
 	if len(project.BuildVariants) == 0 {
 		return ValidationErrors{
 			{
-				Message: fmt.Sprintf("project '%s' must specify at least one "+
-					"buildvariant", project.Identifier),
+				Message: "must specify at least one buildvariant",
 			},
 		}
 	}
@@ -424,17 +421,15 @@ func validateBVFields(project *model.Project) ValidationErrors {
 		if buildVariant.Name == "" {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("project '%s' buildvariant must "+
-						"have a name", project.Identifier),
+					Message: "all buildvariants must have a name",
 				},
 			)
 		}
 		if len(buildVariant.Tasks) == 0 {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("buildvariant '%s' in project '%s' "+
-						"must have at least one task", buildVariant.Name,
-						project.Identifier),
+					Message: fmt.Sprintf("buildvariant '%s' must have at least one task",
+						buildVariant.Name),
 				},
 			)
 		}
@@ -479,10 +474,9 @@ func validateBVFields(project *model.Project) ValidationErrors {
 		if hasTaskWithoutDistro {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("buildvariant '%s' in project '%s' "+
-						"must either specify run_on field or have every task "+
-						"specify run_on.",
-						buildVariant.Name, project.Identifier),
+					Message: fmt.Sprintf("buildvariant '%s' "+
+						"must either specify run_on field or have every task specify run_on",
+						buildVariant.Name),
 				},
 			)
 		}
@@ -498,8 +492,7 @@ func validateProjectFields(project *model.Project) ValidationErrors {
 	if project.BatchTime < 0 {
 		errs = append(errs,
 			ValidationError{
-				Message: fmt.Sprintf("project '%s' must have a "+
-					"non-negative 'batchtime' set", project.Identifier),
+				Message: fmt.Sprintf("'batchtime' must be non-negative"),
 			},
 		)
 	}
@@ -508,8 +501,7 @@ func validateProjectFields(project *model.Project) ValidationErrors {
 		if !utility.StringSliceContains(evergreen.ValidCommandTypes, project.CommandType) {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("project '%s' contains an invalid "+
-						"command type: %s", project.Identifier, project.CommandType),
+					Message: fmt.Sprintf("invalid command type: %s", project.CommandType),
 				},
 			)
 		}
@@ -526,9 +518,8 @@ func checkProjectFields(project *model.Project) ValidationErrors {
 		// in ProjectRef.getBatchTime()
 		errs = append(errs,
 			ValidationError{
-				Message: fmt.Sprintf("project '%s' field 'batchtime' should not exceed %d)",
-					project.Identifier, math.MaxInt32),
-				Level: Warning,
+				Message: fmt.Sprintf("'batchtime' should not exceed %d", math.MaxInt32),
+				Level:   Warning,
 			},
 		)
 	}
@@ -562,19 +553,16 @@ func ensureReferentialIntegrity(project *model.Project, distroIDs []string, dist
 				if task.Name == "" {
 					errs = append(errs,
 						ValidationError{
-							Message: fmt.Sprintf("tasks for buildvariant '%s' "+
-								"in project '%s' must each have a name field",
-								project.Identifier, buildVariant.Name),
+							Message: fmt.Sprintf("tasks for buildvariant '%s' must each have a name field",
+								buildVariant.Name),
 							Level: Error,
 						},
 					)
 				} else {
 					errs = append(errs,
 						ValidationError{
-							Message: fmt.Sprintf("buildvariant '%s' in "+
-								"project '%s' references a non-existent "+
-								"task '%s'", buildVariant.Name,
-								project.Identifier, task.Name),
+							Message: fmt.Sprintf("buildvariant '%s' references a non-existent task '%s'",
+								buildVariant.Name, task.Name),
 							Level: Error,
 						},
 					)
@@ -595,10 +583,9 @@ func ensureReferentialIntegrity(project *model.Project, distroIDs []string, dist
 				if !utility.StringSliceContains(distroIDs, distro) && !utility.StringSliceContains(distroAliases, distro) {
 					errs = append(errs,
 						ValidationError{
-							Message: fmt.Sprintf("task '%s' in buildvariant '%s' in project "+
-								"'%s' references a nonexistent distro '%s'.\n",
-								task.Name, buildVariant.Name,
-								project.Identifier, distro),
+							Message: fmt.Sprintf("task '%s' in buildvariant '%s' "+
+								"references a nonexistent distro '%s'",
+								task.Name, buildVariant.Name, distro),
 							Level: Warning,
 						},
 					)
@@ -609,10 +596,8 @@ func ensureReferentialIntegrity(project *model.Project, distroIDs []string, dist
 			if !utility.StringSliceContains(distroIDs, distro) && !utility.StringSliceContains(distroAliases, distro) {
 				errs = append(errs,
 					ValidationError{
-						Message: fmt.Sprintf("buildvariant '%s' in project "+
-							"'%s' references a nonexistent distro '%s'.\n",
-							buildVariant.Name,
-							project.Identifier, distro),
+						Message: fmt.Sprintf("buildvariant '%s' references a nonexistent distro '%s'",
+							buildVariant.Name, distro),
 						Level: Warning,
 					},
 				)
@@ -724,8 +709,7 @@ func validateBVNames(project *model.Project) ValidationErrors {
 		if _, ok := buildVariantNames[buildVariant.Name]; ok {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("project '%s' buildvariant '%s' already exists",
-						project.Identifier, buildVariant.Name),
+					Message: fmt.Sprintf("buildvariant '%s' already exists", buildVariant.Name),
 				},
 			)
 		}
@@ -734,8 +718,7 @@ func validateBVNames(project *model.Project) ValidationErrors {
 		if dispName == "" {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("project '%s' buildvariant '%s' does not have a display name",
-						project.Identifier, buildVariant.Name),
+					Message: fmt.Sprintf("buildvariant '%s' does not have a display name", buildVariant.Name),
 				},
 			)
 		} else if dispName == evergreen.MergeTaskVariant {
@@ -757,7 +740,7 @@ func validateBVNames(project *model.Project) ValidationErrors {
 	return errs
 }
 
-func checkBVNames(project *model.Project, buildVariant *model.BuildVariant) ValidationErrors {
+func checkBVNames(buildVariant *model.BuildVariant) ValidationErrors {
 	errs := ValidationErrors{}
 
 	// Warn against commas because the CLI allows users to specify
@@ -788,7 +771,7 @@ func checkBVNames(project *model.Project, buildVariant *model.BuildVariant) Vali
 	return errs
 }
 
-func checkLoggerConfig(project *model.Project, task *model.ProjectTask) ValidationErrors {
+func checkLoggerConfig(task *model.ProjectTask) ValidationErrors {
 	errs := ValidationErrors{}
 
 	for _, command := range task.Commands {
@@ -813,9 +796,8 @@ func validateBVTaskNames(project *model.Project) ValidationErrors {
 			if _, ok := buildVariantTasks[task.Name]; ok {
 				errs = append(errs,
 					ValidationError{
-						Message: fmt.Sprintf("task '%s' in buildvariant '%s' "+
-							"in project '%s' already exists",
-							task.Name, buildVariant.Name, project.Identifier),
+						Message: fmt.Sprintf("task '%s' in buildvariant '%s' already exists",
+							task.Name, buildVariant.Name),
 					},
 				)
 			}
@@ -875,7 +857,7 @@ func validateBVBatchTimes(project *model.Project) ValidationErrors {
 	return errs
 }
 
-func checkBVBatchTimes(project *model.Project, buildVariant *model.BuildVariant) ValidationErrors {
+func checkBVBatchTimes(buildVariant *model.BuildVariant) ValidationErrors {
 	errs := ValidationErrors{}
 	// check task batchtimes first
 	for _, t := range buildVariant.Tasks {
@@ -975,9 +957,8 @@ func validatePluginCommands(project *model.Project) ValidationErrors {
 		if commands == nil || len(commands.List()) == 0 {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("'%s' project's '%s' function contains no commands",
-						project.Identifier, funcName),
-					Level: Error,
+					Message: fmt.Sprintf("'%s' function contains no commands", funcName),
+					Level:   Error,
 				},
 			)
 			continue
@@ -986,9 +967,8 @@ func validatePluginCommands(project *model.Project) ValidationErrors {
 		for _, err := range valErrs {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("'%s' project's '%s' definition: %s",
-						project.Identifier, funcName, err.Message),
-					Level: err.Level,
+					Message: fmt.Sprintf("'%s' definition error: %s", funcName, err.Message),
+					Level:   err.Level,
 				},
 			)
 		}
@@ -1009,8 +989,7 @@ func validatePluginCommands(project *model.Project) ValidationErrors {
 		if seen[funcName] {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf(`project '%s' has duplicate definition of "%s"`,
-						project.Identifier, funcName),
+					Message: fmt.Sprintf(`duplicate definition of "%s"`, funcName),
 				},
 			)
 		}
@@ -1049,8 +1028,7 @@ func validateProjectTaskNames(project *model.Project) ValidationErrors {
 		if _, ok := taskNames[task.Name]; ok {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("task '%s' in project '%s' "+
-						"already exists", task.Name, project.Identifier),
+					Message: fmt.Sprintf("task '%s' already exists", task.Name),
 				},
 			)
 		}
@@ -1137,9 +1115,8 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 			if depNames[pair] {
 				errs = append(errs,
 					ValidationError{
-						Message: fmt.Sprintf("project '%s' contains a "+
-							"duplicate dependency '%s' specified for task '%s'",
-							project.Identifier, dep.Name, task.Name),
+						Message: fmt.Sprintf("duplicate dependency '%s' specified for task '%s'",
+							dep.Name, task.Name),
 					},
 				)
 			}
@@ -1152,8 +1129,8 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 			default:
 				errs = append(errs,
 					ValidationError{
-						Message: fmt.Sprintf("project '%s' contains an invalid dependency status for task '%s': %s",
-							project.Identifier, task.Name, dep.Status)})
+						Message: fmt.Sprintf("invalid dependency status for task '%s': %s",
+							task.Name, dep.Status)})
 			}
 
 			// check that name of the dependency task is valid
@@ -1161,18 +1138,16 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 				errs = append(errs,
 					ValidationError{
 						Level: Error,
-						Message: fmt.Sprintf("project '%s' contains a "+
-							"non-existent task name '%s' in dependencies for "+
-							"task '%s'", project.Identifier, dep.Name,
-							task.Name),
+						Message: fmt.Sprintf("non-existent task name '%s' in dependencies for task '%s'",
+							dep.Name, task.Name),
 					},
 				)
 			}
 			if dep.Variant != "" && dep.Variant != model.AllVariants && project.FindBuildVariant(dep.Variant) == nil {
 				errs = append(errs, ValidationError{
 					Level: Error,
-					Message: fmt.Sprintf("project '%s' contains a non-existent variant name '%s' in dependencies for task '%s'",
-						project.Identifier, dep.Variant, task.Name),
+					Message: fmt.Sprintf("non-existent variant name '%s' in dependencies for task '%s'",
+						dep.Variant, task.Name),
 				})
 			}
 
@@ -1181,7 +1156,7 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 	return errs
 }
 
-func checkTaskDependencies(project *model.Project, task *model.ProjectTask, allTasks map[string]model.ProjectTask) ValidationErrors {
+func checkTaskDependencies(task *model.ProjectTask, allTasks map[string]model.ProjectTask) ValidationErrors {
 	errs := ValidationErrors{}
 
 	for _, dep := range task.DependsOn {
@@ -1895,9 +1870,8 @@ func checkTasks(project *model.Project) ValidationErrors {
 		if len(task.Commands) == 0 {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("task '%s' in project '%s' does not "+
-						"contain any commands",
-						task.Name, project.Identifier),
+					Message: fmt.Sprintf("task '%s' does not contain any commands",
+						task.Name),
 					Level: Warning,
 				},
 			)
@@ -1905,16 +1879,16 @@ func checkTasks(project *model.Project) ValidationErrors {
 		if project.ExecTimeoutSecs == 0 && task.ExecTimeoutSecs == 0 && !execTimeoutWarningAdded {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("project '%s' does not "+
-						"have an exec_timeout_secs defined at the top-level or on one or more tasks; these tasks will default to a timeout of %d hours",
-						project.Identifier, int(agent.DefaultExecTimeout.Hours())),
+					Message: fmt.Sprintf("no exec_timeout_secs defined at the top-level or on one or more tasks; "+
+						"these tasks will default to a timeout of %d hours",
+						int(agent.DefaultExecTimeout.Hours())),
 					Level: Warning,
 				},
 			)
 			execTimeoutWarningAdded = true
 		}
-		errs = append(errs, checkLoggerConfig(project, &task)...)
-		errs = append(errs, checkTaskDependencies(project, &task, allTasks)...)
+		errs = append(errs, checkLoggerConfig(&task)...)
+		errs = append(errs, checkTaskDependencies(&task, allTasks)...)
 		errs = append(errs, checkTaskNames(project, &task)...)
 	}
 	if project.Loggers != nil {
@@ -1945,8 +1919,8 @@ func checkBuildVariants(project *model.Project) ValidationErrors {
 				},
 			)
 		}
-		errs = append(errs, checkBVNames(project, &buildVariant)...)
-		errs = append(errs, checkBVBatchTimes(project, &buildVariant)...)
+		errs = append(errs, checkBVNames(&buildVariant)...)
+		errs = append(errs, checkBVBatchTimes(&buildVariant)...)
 	}
 
 	for k, v := range displayNames {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1470,14 +1470,16 @@ func validateTaskSyncSettings(p *model.Project, ref *model.ProjectRef) Validatio
 	var errs ValidationErrors
 	if s3PushCalls := p.TasksThatCallCommand(evergreen.S3PushCommandName); len(s3PushCalls) != 0 {
 		errs = append(errs, ValidationError{
-			Level:   Error,
-			Message: fmt.Sprintf("cannot use %s command in project config when it is disabled by project settings", evergreen.S3PushCommandName),
+			Level: Error,
+			Message: fmt.Sprintf("cannot use %s command in project config when it is disabled by project '%s' settings",
+				ref.Identifier, evergreen.S3PushCommandName),
 		})
 	}
 	if s3PullCalls := p.TasksThatCallCommand(evergreen.S3PullCommandName); len(s3PullCalls) != 0 {
 		errs = append(errs, ValidationError{
-			Level:   Error,
-			Message: fmt.Sprintf("cannot use %s command in project config when it is disabled by project settings", evergreen.S3PullCommandName),
+			Level: Error,
+			Message: fmt.Sprintf("cannot use %s command in project config when it is disabled by project '%s' settings",
+				ref.Identifier, evergreen.S3PullCommandName),
 		})
 	}
 	return errs

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -173,8 +173,8 @@ func TestValidateTaskDependencies(t *testing.T) {
 				},
 			}
 			allTasks := p.FindAllTasksMap()
-			errs := checkTaskDependencies(&p, &p.Tasks[0], allTasks)
-			errs = append(errs, checkTaskDependencies(&p, &p.Tasks[1], allTasks)...)
+			errs := checkTaskDependencies(&p.Tasks[0], allTasks)
+			errs = append(errs, checkTaskDependencies(&p.Tasks[1], allTasks)...)
 			So(len(errs), ShouldEqual, 1)
 			So(errs[0].Level, ShouldEqual, Warning)
 			So(errs[0].Message, ShouldEqual, "Task 't1' depends on non-patchable task 't2'. Neither will run in patches")
@@ -959,7 +959,7 @@ func TestValidateBVNames(t *testing.T) {
 					},
 				}
 				buildVariant := project.BuildVariants[0]
-				So(len(checkBVNames(project, &buildVariant)), ShouldEqual, 1)
+				So(len(checkBVNames(&buildVariant)), ShouldEqual, 1)
 			})
 			Convey("Is the same as the all-dependencies syntax", func() {
 				project := &model.Project{
@@ -968,14 +968,14 @@ func TestValidateBVNames(t *testing.T) {
 					},
 				}
 				buildVariant := project.BuildVariants[0]
-				So(len(checkBVNames(project, &buildVariant)), ShouldEqual, 1)
+				So(len(checkBVNames(&buildVariant)), ShouldEqual, 1)
 			})
 			Convey("Is 'all'", func() {
 				project := &model.Project{
 					BuildVariants: []model.BuildVariant{{Name: "all", DisplayName: "display_name"}},
 				}
 				buildVariant := project.BuildVariants[0]
-				So(len(checkBVNames(project, &buildVariant)), ShouldEqual, 1)
+				So(len(checkBVNames(&buildVariant)), ShouldEqual, 1)
 			})
 		})
 	})
@@ -1072,7 +1072,7 @@ func TestValidateBVBatchTimes(t *testing.T) {
 	// warning if activated to true with batchtime
 	p.BuildVariants[0].Activate = utility.TruePtr()
 	bv := p.BuildVariants[0]
-	assert.Len(t, checkBVBatchTimes(p, &bv), 1)
+	assert.Len(t, checkBVBatchTimes(&bv), 1)
 
 }
 
@@ -2534,7 +2534,7 @@ tasks:
 	pp, _, err = model.LoadProjectInto(ctx, []byte(yml), nil, "", project)
 	assert.NoError(err)
 	assert.NotNil(pp)
-	errs = checkLoggerConfig(project, &project.Tasks[0])
+	errs = checkLoggerConfig(&project.Tasks[0])
 	assert.Len(errs, 0)
 }
 

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -161,7 +161,7 @@ func TestValidateTaskDependencies(t *testing.T) {
 					{Name: "v1", Tasks: []model.BuildVariantTaskUnit{{Name: "1"}, {Name: "2"}, {Name: "tg", IsGroup: true}}},
 				},
 			}
-			So(validateTaskDependencies(p)[0].Message, ShouldResemble, "project '' contains a non-existent task name 'nonexistent' in dependencies for task '3'")
+			So(validateTaskDependencies(p)[0].Message, ShouldResemble, "non-existent task name 'nonexistent' in dependencies for task '3'")
 		})
 		Convey("depending on a non-patchable task should generate a warning", func() {
 			p := model.Project{
@@ -1251,7 +1251,7 @@ func TestCheckTaskCommands(t *testing.T) {
 			errs := checkTasks(project)
 			So(errs, ShouldNotResemble, ValidationErrors{})
 			So(len(errs), ShouldEqual, 2)
-			assert.Contains(t, errs.String(), "task 'compile' in project '' does not "+
+			assert.Contains(t, errs.String(), "task 'compile' does not "+
 				"contain any commands")
 		})
 		Convey("ensure tasks that have at least one command do not throw any errors",
@@ -1788,7 +1788,7 @@ func TestCheckProjectWarnings(t *testing.T) {
 
 			_, project, err := model.FindLatestVersionWithValidProject(projectRef.Id)
 			So(err, ShouldBeNil)
-			So(CheckProjectWarnings(project, []byte{}), ShouldResemble, ValidationErrors{})
+			So(CheckProjectWarnings(project), ShouldResemble, ValidationErrors{})
 		})
 
 		Reset(func() {
@@ -1823,7 +1823,7 @@ func (s *validateProjectFieldsuite) TestBatchTimeValueMustNonNegative() {
 	validationError := validateProjectFields(&s.project)
 
 	s.Len(validationError, 1)
-	s.Contains(validationError[0].Message, "non-negative 'batchtime'",
+	s.Contains(validationError[0].Message, "'batchtime' must be non-negative",
 		"Project 'batchtime' must not be negative")
 }
 
@@ -2011,7 +2011,7 @@ func TestValidateBVFields(t *testing.T) {
 			}
 			So(validateBVFields(project),
 				ShouldResemble, ValidationErrors{
-					{Level: Error, Message: "buildvariant 'bv1' in project '' must either specify run_on field or have every task specify run_on."},
+					{Level: Error, Message: "buildvariant 'bv1' must either specify run_on field or have every task specify run_on"},
 				})
 		})
 	})
@@ -2233,7 +2233,7 @@ buildvariants:
 	assert.Equal("task_in_a_task_group_1", proj.Tasks[0].DependsOn[0].Name)
 	errors := CheckProjectErrors(&proj, false)
 	assert.Len(errors, 0)
-	warnings := CheckProjectWarnings(&proj, []byte(exampleYml))
+	warnings := CheckProjectWarnings(&proj)
 	assert.Len(warnings, 0)
 }
 
@@ -2286,7 +2286,7 @@ buildvariants:
 	errors := CheckProjectErrors(&proj, false)
 	assert.Len(errors, 1)
 	assert.Equal("dependency error for 'task_in_a_task_group' task: dependency bv/not_in_a_task_group is not present in the project config", errors[0].Error())
-	warnings := CheckProjectWarnings(&proj, []byte(exampleYml))
+	warnings := CheckProjectWarnings(&proj)
 	assert.Len(warnings, 0)
 }
 
@@ -2345,7 +2345,7 @@ buildvariants:
 	assert.Equal(errors[0].Level, Error)
 	assert.Equal("execution task 'display_three' has prefix 'display_' which is invalid",
 		errors[0].Message)
-	warnings := CheckProjectWarnings(&proj, []byte(exampleYml))
+	warnings := CheckProjectWarnings(&proj)
 	assert.Len(warnings, 0)
 }
 
@@ -2580,7 +2580,7 @@ buildvariants:
 	assert.NotNil(pp)
 	errs := CheckProjectErrors(&proj, false)
 	assert.Len(errs, 0, "no errors were found")
-	errs = CheckProjectWarnings(&proj, []byte(exampleYml))
+	errs = CheckProjectWarnings(&proj)
 	assert.Len(errs, 2, "two warnings were found")
 	assert.NoError(CheckProjectConfigurationIsValid(&proj, &model.ProjectRef{}), "no errors are reported because they are warnings")
 


### PR DESCRIPTION
[EVG-7310](https://jira.mongodb.org/browse/EVG-7310)

### Description 
Kind of snuck this into the epic, but right now we print projectId for most validation; this isn't super useful because in many cases there isn't a project Identifier (since people use validation from the CLI), so we just print `project ''` which is pretty useless (also in non-CLI cases we typically error with the project id anyway). 

I did add printing the project ID for the settings that rely on it (i.e. task sync).
