### PR TITLE
EVG-16170: only consider host tasks for the distro scheduler

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -45,6 +45,7 @@ var (
 	OverrideDependenciesKey     = bsonutil.MustHaveTag(Task{}, "OverrideDependencies")
 	NumDepsKey                  = bsonutil.MustHaveTag(Task{}, "NumDependents")
 	DisplayNameKey              = bsonutil.MustHaveTag(Task{}, "DisplayName")
+	ExecutionPlatformKey        = bsonutil.MustHaveTag(Task{}, "ExecutionPlatform")
 	HostIdKey                   = bsonutil.MustHaveTag(Task{}, "HostId")
 	AgentVersionKey             = bsonutil.MustHaveTag(Task{}, "AgentVersion")
 	ExecutionKey                = bsonutil.MustHaveTag(Task{}, "Execution")
@@ -701,26 +702,51 @@ func BySubsetAborted(ids []string) bson.M {
 	}
 }
 
+// ByExecutionPlatform returns the query to find tasks matching the given
+// execution platform. If the empty string is given, the task is assumed to be
+// the default of ExecutionPlatformHost.
+func ByExecutionPlatform(platform ExecutionPlatform) bson.M {
+	switch platform {
+	case "", ExecutionPlatformHost:
+		return bson.M{
+			"$or": []bson.M{
+				{ExecutionPlatformKey: bson.M{"$exists": false}},
+				{ExecutionPlatformKey: platform},
+			},
+		}
+	case ExecutionPlatformContainer:
+		return bson.M{
+			ExecutionPlatformKey: platform,
+		}
+	default:
+		return bson.M{}
+	}
+}
+
 var (
 	IsDispatchedOrStarted = bson.M{
 		StatusKey: bson.M{"$in": []string{evergreen.TaskStarted, evergreen.TaskDispatched}},
 	}
 )
 
-func scheduleableTasksQuery() bson.M {
-	return bson.M{
+func schedulableHostTasksQuery() bson.M {
+	q := bson.M{
 		ActivatedKey: true,
 		StatusKey:    evergreen.TaskUndispatched,
 
 		// Filter out tasks disabled by negative priority
 		PriorityKey: bson.M{"$gt": evergreen.DisabledTaskPriority},
-
+	}
+	q["$and"] = []bson.M{
+		ByExecutionPlatform(ExecutionPlatformHost),
 		// Filter tasks containing unattainable dependencies
-		"$or": []bson.M{
+		{"$or": []bson.M{
 			{bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey): bson.M{"$ne": true}},
 			{OverrideDependenciesKey: true},
-		},
+		}},
 	}
+
+	return q
 }
 
 // TasksByProjectAndCommitPipeline fetches the pipeline to get the retrieve all tasks

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -107,10 +107,10 @@ type Task struct {
 	OverrideDependencies     bool         `bson:"override_dependencies,omitempty" json:"override_dependencies,omitempty"`
 
 	// DistroAliases refer to the optional secondary distros that can be
-	// associated with a task. This is used for running tasks in case there
-	// is excess capcacity in a distro. Despite the variable name, this is a
-	// distinct concept from actual distro aliases (i.e. alternative distro
-	// names).
+	// associated with a task. This is used for running tasks in case there are
+	// idle hosts in a distro with an empty primary queue. Despite the variable
+	// name, this is a distinct concept from actual distro aliases (i.e.
+	// alternative distro names).
 	// TODO (EVG-15148): rename this to represent secondary distros.
 	DistroAliases []string `bson:"distro_aliases,omitempty" json:"distro_aliases,omitempty"`
 
@@ -1052,8 +1052,8 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 	return nil
 }
 
-// Removes host tasks older than the unscheduable threshold (e.g. one weeks)
-// from the scheduler queue.
+// Removes host tasks older than the unscheduable threshold (e.g. one week) from
+// the scheduler queue.
 //
 // If you pass an empty string as an argument to this function, this operation
 // will select tasks from all distros.

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -106,6 +106,12 @@ type Task struct {
 	NumDependents            int          `bson:"num_dependents,omitempty" json:"num_dependents,omitempty"`
 	OverrideDependencies     bool         `bson:"override_dependencies,omitempty" json:"override_dependencies,omitempty"`
 
+	// DistroAliases refer to the optional secondary distros that can be
+	// associated with a task. This is used for running tasks in case there
+	// is excess capcacity in a distro. Despite the variable name, this is a
+	// distinct concept from actual distro aliases (i.e. alternative distro
+	// names).
+	// TODO (EVG-15148): rename this to represent secondary distros.
 	DistroAliases []string `bson:"distro_aliases,omitempty" json:"distro_aliases,omitempty"`
 
 	// Human-readable name
@@ -1046,13 +1052,13 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 	return nil
 }
 
-// Removes tasks older than the unscheduable threshold (e.g. one
-// weeks) from the scheduler queue.
+// Removes host tasks older than the unscheduable threshold (e.g. one weeks)
+// from the scheduler queue.
 //
-// If you pass an empty string as an argument to this function, this
-// operation will select tasks from all distros.
-func UnscheduleStaleUnderwaterTasks(distroID string) (int, error) {
-	query := scheduleableTasksQuery()
+// If you pass an empty string as an argument to this function, this operation
+// will select tasks from all distros.
+func UnscheduleStaleUnderwaterHostTasks(distroID string) (int, error) {
+	query := schedulableHostTasksQuery()
 
 	if err := addApplicableDistroFilter(distroID, DistroIdKey, query); err != nil {
 		return 0, errors.WithStack(err)
@@ -2312,8 +2318,10 @@ func MergeTestResultsBulk(tasks []Task, query *db.Q) ([]Task, error) {
 	return out, nil
 }
 
-func FindSchedulable(distroID string) ([]Task, error) {
-	query := scheduleableTasksQuery()
+// FindHostSchedulable finds all tasks that can be scheduled for a distro
+// primary queue.
+func FindHostSchedulable(distroID string) ([]Task, error) {
+	query := schedulableHostTasksQuery()
 
 	if err := addApplicableDistroFilter(distroID, DistroIdKey, query); err != nil {
 		return nil, errors.WithStack(err)
@@ -2341,8 +2349,10 @@ func addApplicableDistroFilter(id string, fieldName string, query bson.M) error 
 	return nil
 }
 
-func FindSchedulableForAlias(id string) ([]Task, error) {
-	q := scheduleableTasksQuery()
+// FindHostSchedulableForAlias finds all tasks that can be scheduled for a
+// distro secondary queue.
+func FindHostSchedulableForAlias(id string) ([]Task, error) {
+	q := schedulableHostTasksQuery()
 
 	if err := addApplicableDistroFilter(id, DistroAliasesKey, q); err != nil {
 		return nil, errors.WithStack(err)
@@ -2356,8 +2366,11 @@ func FindSchedulableForAlias(id string) ([]Task, error) {
 	return FindAll(db.Query(q))
 }
 
-func FindRunnable(distroID string, removeDeps bool) ([]Task, error) {
-	match := scheduleableTasksQuery()
+// FindHostRunnable finds all hosts that can be scheduled for a distro with an
+// additional consideration for whether the task's dependencies are met. If
+// removeDeps is true, tasks with unmet dependencies are excluded.
+func FindHostRunnable(distroID string, removeDeps bool) ([]Task, error) {
+	match := schedulableHostTasksQuery()
 	var d distro.Distro
 	var err error
 	if distroID != "" {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1459,7 +1459,7 @@ func TestBulkInsert(t *testing.T) {
 	}
 }
 
-func TestUnscheduleStaleUnderwaterTasksNoDistro(t *testing.T) {
+func TestUnscheduleStaleUnderwaterHostTasksNoDistro(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 	t1 := Task{
@@ -1471,7 +1471,7 @@ func TestUnscheduleStaleUnderwaterTasksNoDistro(t *testing.T) {
 	}
 	assert.NoError(t1.Insert())
 
-	_, err := UnscheduleStaleUnderwaterTasks("")
+	_, err := UnscheduleStaleUnderwaterHostTasks("")
 	assert.NoError(err)
 	dbTask, err := FindOneId("t1")
 	assert.NoError(err)
@@ -1479,7 +1479,7 @@ func TestUnscheduleStaleUnderwaterTasksNoDistro(t *testing.T) {
 	assert.EqualValues(-1, dbTask.Priority)
 }
 
-func TestUnscheduleStaleUnderwaterTasksWithDistro(t *testing.T) {
+func TestUnscheduleStaleUnderwaterHostTasksWithDistro(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection, distro.Collection))
 	t1 := Task{
 		Id:            "t1",
@@ -1496,7 +1496,7 @@ func TestUnscheduleStaleUnderwaterTasksWithDistro(t *testing.T) {
 	}
 	require.NoError(t, d.Insert())
 
-	_, err := UnscheduleStaleUnderwaterTasks("d0")
+	_, err := UnscheduleStaleUnderwaterHostTasks("d0")
 	assert.NoError(t, err)
 	dbTask, err := FindOneId("t1")
 	assert.NoError(t, err)
@@ -1504,7 +1504,7 @@ func TestUnscheduleStaleUnderwaterTasksWithDistro(t *testing.T) {
 	assert.EqualValues(t, -1, dbTask.Priority)
 }
 
-func TestUnscheduleStaleUnderwaterTasksWithDistroAlias(t *testing.T) {
+func TestUnscheduleStaleUnderwaterHostTasksWithDistroAlias(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection, distro.Collection))
 	t1 := Task{
 		Id:            "t1",
@@ -1522,7 +1522,7 @@ func TestUnscheduleStaleUnderwaterTasksWithDistroAlias(t *testing.T) {
 	}
 	require.NoError(t, d.Insert())
 
-	_, err := UnscheduleStaleUnderwaterTasks("d0")
+	_, err := UnscheduleStaleUnderwaterHostTasks("d0")
 	assert.NoError(t, err)
 	dbTask, err := FindOneId("t1")
 	assert.NoError(t, err)
@@ -1748,7 +1748,7 @@ func TestFindAllMarkedUnattainableDependencies(t *testing.T) {
 	assert.Len(unattainableTasks, 1)
 }
 
-func TestUnattainableScheduleableTasksQuery(t *testing.T) {
+func TestUnattainableSchedulableHostTasksQuery(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 	tasks := []Task{
@@ -1802,7 +1802,7 @@ func TestUnattainableScheduleableTasksQuery(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	q := db.Query(scheduleableTasksQuery())
+	q := db.Query(schedulableHostTasksQuery())
 	schedulableTasks, err := FindAll(q)
 	assert.NoError(err)
 	assert.Len(schedulableTasks, 2)

--- a/scheduler/host_allocator.go
+++ b/scheduler/host_allocator.go
@@ -9,9 +9,10 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 )
 
-// HostAllocator is responsible for determining how many new hosts should be spun up.
-// the first return int is this number, and the second return int is the rough number of free hosts
-type HostAllocator func(context.Context, *HostAllocatorData) (int, int, error)
+// HostAllocator is responsible for determining how many new hosts should be
+// spun up. The first returned int is this number, and the second returned int
+// is the rough number of free hosts.
+type HostAllocator func(context.Context, *HostAllocatorData) (newHostsNeeded int, estimatedFreeHosts int, err error)
 
 type HostAllocatorData struct {
 	Distro          distro.Distro

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -321,7 +321,7 @@ func generateIntentHost(d distro.Distro, pool *evergreen.ContainerPool) (*host.H
 
 // pass the empty string to unschedule all distros.
 func underwaterUnschedule(distroID string) error {
-	num, err := task.UnscheduleStaleUnderwaterTasks(distroID)
+	num, err := task.UnscheduleStaleUnderwaterHostTasks(distroID)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/scheduler/task_finder.go
+++ b/scheduler/task_finder.go
@@ -31,14 +31,14 @@ func GetTaskFinder(version string) TaskFinder {
 }
 
 func RunnableTasksPipeline(d distro.Distro) ([]task.Task, error) {
-	return task.FindRunnable(d.Id, d.DispatcherSettings.Version != evergreen.DispatcherVersionRevisedWithDependencies)
+	return task.FindHostRunnable(d.Id, d.DispatcherSettings.Version != evergreen.DispatcherVersionRevisedWithDependencies)
 }
 
 // The old Task finderDBTaskFinder, with the dependency check implemented in Go,
 // instead of using $graphLookup
 func LegacyFindRunnableTasks(d distro.Distro) ([]task.Task, error) {
 	// find all of the undispatched tasks
-	undispatchedTasks, err := task.FindSchedulable(d.Id)
+	undispatchedTasks, err := task.FindHostSchedulable(d.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func LegacyFindRunnableTasks(d distro.Distro) ([]task.Task, error) {
 }
 
 func AlternateTaskFinder(d distro.Distro) ([]task.Task, error) {
-	undispatchedTasks, err := task.FindSchedulable(d.Id)
+	undispatchedTasks, err := task.FindHostSchedulable(d.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -274,15 +274,15 @@ func AlternateTaskFinder(d distro.Distro) ([]task.Task, error) {
 
 	}
 	grip.Info(message.WrapError(catcher.Resolve(), message.Fields{
-		"runner":             RunnerName,
-		"scheduleable_tasks": len(undispatchedTasks),
+		"runner":            RunnerName,
+		"schedulable_tasks": len(undispatchedTasks),
 	}))
 
 	return runnabletasks, nil
 }
 
 func ParallelTaskFinder(d distro.Distro) ([]task.Task, error) {
-	undispatchedTasks, err := task.FindSchedulable(d.Id)
+	undispatchedTasks, err := task.FindHostSchedulable(d.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -421,9 +421,9 @@ func ParallelTaskFinder(d distro.Distro) ([]task.Task, error) {
 		runnabletasks = append(runnabletasks, t)
 	}
 	grip.Info(message.WrapError(catcher.Resolve(), message.Fields{
-		"runner":             RunnerName,
-		"planner":            d.PlannerSettings.Version,
-		"scheduleable_tasks": len(undispatchedTasks),
+		"runner":            RunnerName,
+		"planner":           d.PlannerSettings.Version,
+		"schedulable_tasks": len(undispatchedTasks),
 	}))
 
 	return runnabletasks, nil
@@ -443,8 +443,9 @@ func getProjectRefCache() (map[string]model.ProjectRef, error) {
 	return out, nil
 }
 
-// GetRunnableTasksAndVersions finds tasks whose versions have already been
-// created, and returns those tasks, as well as a map of version IDs to versions.
+// FilterTasksWithVersionCache finds tasks whose versions have already been
+// created, and returns those tasks, as well as a map of version IDs to
+// versions.
 func FilterTasksWithVersionCache(tasks []task.Task) ([]task.Task, map[string]model.Version, error) {
 	ids := make(map[string]struct{})
 

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/anser/bsonutil"
 	"github.com/smartystreets/goconvey/convey/reporting"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
@@ -36,7 +37,7 @@ type TaskFinderSuite struct {
 
 func TestDBTaskFinder(t *testing.T) {
 	s := new(TaskFinderSuite)
-	s.FindRunnableTasks = func(d distro.Distro) ([]task.Task, error) { return task.FindRunnable(d.Id, true) }
+	s.FindRunnableTasks = func(d distro.Distro) ([]task.Task, error) { return task.FindHostRunnable(d.Id, true) }
 
 	suite.Run(t, s)
 }
@@ -116,6 +117,15 @@ func (s *TaskFinderSuite) TestInactiveTasksNeverReturned() {
 	// finding the runnable tasks should return four tasks
 	runnableTasks, err := s.FindRunnableTasks(s.distro)
 	s.NoError(err)
+	s.Len(runnableTasks, 4)
+}
+
+func (s *TaskFinderSuite) TestContainerTasksAreExcluded() {
+	s.tasks[3].ExecutionPlatform = task.ExecutionPlatformContainer
+	s.insertTasks()
+
+	runnableTasks, err := s.FindRunnableTasks(s.distro)
+	s.Require().NoError(err)
 	s.Len(runnableTasks, 4)
 }
 
@@ -261,10 +271,10 @@ func (s *TaskFinderComparisonSuite) SetupTest() {
 	defer cancel()
 	_, err := env.DB().Collection(task.Collection).Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{
-			Keys: bson.D{{Key: "activated", Value: 1}, {Key: "status", Value: 1}, {Key: "priority", Value: 1}},
+			Keys: bson.D{{Key: task.ActivatedKey, Value: 1}, {Key: task.StatusKey, Value: 1}, {Key: task.PriorityKey, Value: 1}},
 		},
 		{
-			Keys: bson.D{{Key: "depends_on._id", Value: 1}},
+			Keys: bson.D{{Key: bsonutil.GetDottedKeyName(task.DependsOnKey, task.DependencyTaskIdKey), Value: 1}},
 		},
 	})
 	s.Require().NoError(err)

--- a/units/scheduler_alias.go
+++ b/units/scheduler_alias.go
@@ -72,7 +72,7 @@ func (j *distroAliasSchedulerJob) Run(ctx context.Context) {
 	}
 
 	startAt := time.Now()
-	tasks, err := task.FindSchedulableForAlias(j.DistroID)
+	tasks, err := task.FindHostSchedulableForAlias(j.DistroID)
 	j.AddError(errors.Wrap(err, "problem finding tasks"))
 	if tasks == nil {
 		return


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16170

### Description
* Check for host execution platform in distro scheduler queries. I'm going to build the relevant indexes in staging/prod after this is approved but before it's merged.
* Rename some task find functions to clarify that they're only for host tasks.
* Add/fix some documentation in the scheduler package.

### Testing 
Updated existing unit tests.