### PR TITLE
EVG-16251, EVG-16260: reduce duplicate event processing and limit the max parallel events processed

### DIFF
--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -76,6 +76,23 @@ func FindUnprocessedEvents(limit int) ([]EventLogEntry, error) {
 	return out, nil
 }
 
+// FindByID finds a single event matching the given event ID.
+func FindByID(eventID string) (*EventLogEntry, error) {
+	query := bson.M{
+		idKey: eventID,
+	}
+
+	var e EventLogEntry
+	if err := db.FindOneQ(AllLogCollection, db.Query(query), &e); err != nil {
+		if adb.ResultsNotFound(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "finding event by ID")
+	}
+	return &e, nil
+}
+
+// FindEventsByIDs finds all events that match the given event IDs.
 func FindEventsByIDs(events []string) ([]EventLogEntry, error) {
 	query := bson.M{
 		idKey: bson.M{

--- a/model/event/event_test.go
+++ b/model/event/event_test.go
@@ -246,6 +246,23 @@ func (s *eventSuite) TestFindResourceTypeIn() {
 	})
 }
 
+func (s *eventSuite) TestFindByID() {
+	logger := NewDBEventLogger(AllLogCollection)
+	e := &EventLogEntry{
+		ID:           mgobson.NewObjectId().Hex(),
+		ResourceType: ResourceTypeHost,
+		ResourceId:   "TEST1",
+		EventType:    "TEST2",
+		Timestamp:    time.Now().Round(time.Millisecond).Truncate(time.Millisecond),
+		Data:         NewEventFromType(ResourceTypeHost),
+	}
+	s.Require().NoError(logger.LogEvent(e))
+	dbEvent, err := FindByID(e.ID)
+	s.Require().NoError(err)
+	s.Require().NotZero(dbEvent)
+	s.Equal(e.ResourceId, dbEvent.ResourceId)
+}
+
 func (s *eventSuite) TestMarkProcessed() {
 	startTime := time.Now()
 

--- a/units/crons.go
+++ b/units/crons.go
@@ -102,7 +102,7 @@ func PopulateEventSendJobs(env evergreen.Environment) amboy.QueueOperation {
 
 		if flags.EventProcessingDisabled {
 			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
-				"message": "alerts disabled",
+				"message": "notifications disabled",
 				"impact":  "not processing alerts for notifications",
 				"mode":    "degraded",
 			})
@@ -122,8 +122,8 @@ func PopulateEventNotifierJobs(env evergreen.Environment) amboy.QueueOperation {
 
 		if flags.EventProcessingDisabled {
 			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
-				"message": "alerts disabled",
-				"impact":  "not processing alerts for notifications",
+				"message": "event processing disabled",
+				"impact":  "not processing events",
 				"mode":    "degraded",
 			})
 			return nil

--- a/units/crons_event_test.go
+++ b/units/crons_event_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/evergreen/model/patch"
@@ -24,8 +25,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -41,9 +40,6 @@ func TestEventCrons(t *testing.T) {
 	s := &cronsEventSuite{}
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
-	env := evergreen.GetEnvironment()
-	require.NoError(t, env.RemoteQueue().Start(s.ctx))
-	s.env = env
 	suite.Run(t, s)
 }
 
@@ -52,7 +48,11 @@ func (s *cronsEventSuite) TearDownSuite() {
 }
 
 func (s *cronsEventSuite) SetupTest() {
-	s.NoError(db.ClearCollections(event.AllLogCollection, evergreen.ConfigCollection, notification.Collection,
+	env := &mock.Environment{}
+	s.Require().NoError(env.Configure(s.ctx))
+	s.env = env
+
+	s.Require().NoError(db.ClearCollections(event.AllLogCollection, evergreen.ConfigCollection, notification.Collection,
 		event.SubscriptionsCollection, patch.Collection, model.ProjectRefCollection))
 
 	events := []event.EventLogEntry{
@@ -130,7 +130,7 @@ func (s *cronsEventSuite) TestDegradedMode() {
 	// degraded mode shouldn't process events
 	logger := event.NewDBEventLogger(event.AllLogCollection)
 	s.NoError(logger.LogEvent(&e))
-	s.NoError(PopulateEventAlertProcessing(s.env)(s.ctx, s.env.RemoteQueue()))
+	s.NoError(PopulateEventNotifierJobs(s.env)(s.ctx, s.env.LocalQueue()))
 
 	out, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
 	s.NoError(err)
@@ -151,9 +151,9 @@ func (s *cronsEventSuite) TestSenderDegradedModeDoesntDispatchJobs() {
 
 	s.NoError(notification.InsertMany(s.n...))
 
-	startingStats := evergreen.GetEnvironment().RemoteQueue().Stats(ctx)
+	startingStats := s.env.LocalQueue().Stats(ctx)
 
-	s.NoError(dispatchNotifications(ctx, s.n, s.env.RemoteQueue(), &flags))
+	s.NoError(dispatchNotifications(ctx, s.n, s.env.LocalQueue(), &flags))
 
 	out := []notification.Notification{}
 	s.NoError(db.FindAllQ(notification.Collection, db.Q{}, &out))
@@ -162,7 +162,7 @@ func (s *cronsEventSuite) TestSenderDegradedModeDoesntDispatchJobs() {
 		s.Equal("sender disabled", out[i].Error)
 	}
 
-	stats := evergreen.GetEnvironment().RemoteQueue().Stats(ctx)
+	stats := s.env.LocalQueue().Stats(ctx)
 	s.Equal(startingStats.Running, stats.Running)
 	s.Equal(startingStats.Blocked, stats.Blocked)
 	s.Equal(startingStats.Completed, stats.Completed)
@@ -274,15 +274,13 @@ func (s *cronsEventSuite) TestEndToEnd() {
 
 	go httpServer(ln, handler)
 
-	env := evergreen.GetEnvironment()
-	q := env.LocalQueue()
-	s.NoError(PopulateEventAlertProcessing(s.env)(s.ctx, q))
+	q := s.env.RemoteQueue()
+	s.NoError(PopulateEventNotifierJobs(s.env)(s.ctx, q))
 
-	grip.Info("waiting for dispatches")
+	// Wait for event notifier to finish.
 	amboy.WaitInterval(s.ctx, q, 10*time.Millisecond)
-	grip.Info("waiting for senders")
-	amboy.Wait(s.ctx, q)
-	grip.Info("senders are done")
+	// Wait for event send to finish.
+	amboy.WaitInterval(s.ctx, q, 10*time.Millisecond)
 
 	out := []notification.Notification{}
 	s.NoError(db.FindAllQ(notification.Collection, db.Q{}, &out))
@@ -294,19 +292,17 @@ func (s *cronsEventSuite) TestEndToEnd() {
 
 func (s *cronsEventSuite) TestDispatchUnprocessedNotifications() {
 	s.NoError(notification.InsertMany(s.n...))
-	env := evergreen.GetEnvironment()
 	flags, err := evergreen.GetServiceFlags()
 	s.NoError(err)
-	origStats := evergreen.GetEnvironment().LocalQueue().Stats(s.ctx)
+	origStats := s.env.LocalQueue().Stats(s.ctx)
 
-	s.NoError(dispatchUnprocessedNotifications(s.ctx, env.LocalQueue(), flags))
+	s.NoError(dispatchUnprocessedNotifications(s.ctx, s.env.LocalQueue(), flags))
 
-	stats := evergreen.GetEnvironment().LocalQueue().Stats(s.ctx)
+	stats := s.env.LocalQueue().Stats(s.ctx)
 	s.Equal(origStats.Total+6, stats.Total)
 }
 
 func (s *cronsEventSuite) TestBatchingCanCount() {
-	env := evergreen.GetEnvironment()
 	notifSettings := evergreen.NotifyConfig{
 		EventProcessingLimit: 2,
 	}
@@ -343,11 +339,11 @@ func (s *cronsEventSuite) TestBatchingCanCount() {
 	for _, evt := range events {
 		s.NoError(logger.LogEvent(&evt))
 	}
-	origStats := evergreen.GetEnvironment().LocalQueue().Stats(s.ctx)
-	s.NoError(PopulateEventAlertProcessing(s.env)(s.ctx, env.LocalQueue()))
+	origStats := s.env.LocalQueue().Stats(s.ctx)
+	s.NoError(PopulateEventNotifierJobs(s.env)(s.ctx, s.env.LocalQueue()))
 
-	stats := evergreen.GetEnvironment().LocalQueue().Stats(s.ctx)
-	s.Equal(origStats.Total+3, stats.Total)
+	stats := s.env.LocalQueue().Stats(s.ctx)
+	s.Equal(origStats.Total+len(events), stats.Total)
 }
 
 func httpServer(ln net.Listener, handler *mockWebhookHandler) {
@@ -422,8 +418,4 @@ func (m *mockWebhookHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		"signature": string(sig),
 		"body":      string(body),
 	})
-}
-
-func TestChecksum(t *testing.T) {
-	assert.Equal(t, "19cc02f26df43cc571bc9ed7b0c4d29224a3ec229529221725ef76d021c8326f", sha256sum([]string{"abc", "def", "ghi"}))
 }

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -50,7 +50,7 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 		PopulateBackgroundStatsJobs(j.env, 0),
 		PopulateContainerStateJobs(j.env),
 		PopulateDataCleanupJobs(j.env),
-		PopulateEventAlertProcessing(j.env),
+		PopulateEventSendJobs(j.env),
 		PopulateGenerateTasksJobs(j.env),
 		PopulateHostMonitoring(j.env),
 		PopulateHostTerminationJobs(j.env),
@@ -88,6 +88,13 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 		catcher.Add(errors.Wrap(err, "error getting commit queue queue"))
 	} else {
 		catcher.Add(PopulateCommitQueueJobs(j.env)(ctx, commitQueueQueue))
+	}
+
+	eventNotifierQueue, err := j.env.RemoteQueueGroup().Get(appCtx, "service.event.notifier")
+	if err != nil {
+		catcher.Wrap(err, "getting event notifier queue")
+	} else {
+		catcher.Add(PopulateEventNotifierJobs(j.env)(ctx, eventNotifierQueue))
 	}
 
 	j.ErrorCount = catcher.Len()

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -74,7 +74,8 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 		catcher.Add(op(ctx, queue))
 	}
 
-	// Create dedicated queues for host creation and commit queue jobs
+	// Create dedicated queues for host creation, event notifier, and commit
+	// queue jobs.
 	appCtx, _ := j.env.Context()
 	hcqueue, err := j.env.RemoteQueueGroup().Get(appCtx, "service.host.create")
 	if err != nil {

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -131,16 +131,16 @@ func (j *eventNotifierJob) processEvent(ctx context.Context, e *event.EventLogEn
 	totalDuration := endTime.Sub(startTime)
 
 	grip.Info(message.Fields{
-		"job_id":     j.ID(),
-		"job_type":   j.Type().Name,
-		"operation":  "events-processing",
-		"message":    "event-stats",
-		"event_id":   j.EventID,
-		"start_time": startTime.String(),
-		"end_time":   endTime.String(),
-		"duration":   totalDuration.Seconds(),
-		"has_errors": catcher.HasErrors(),
-		"num_errors": catcher.Len(),
+		"job_id":        j.ID(),
+		"job_type":      j.Type().Name,
+		"operation":     "events-processing",
+		"message":       "event-stats",
+		"event_id":      j.EventID,
+		"start_time":    startTime.String(),
+		"end_time":      endTime.String(),
+		"duration_secs": totalDuration.Seconds(),
+		"has_errors":    catcher.HasErrors(),
+		"num_errors":    catcher.Len(),
 	})
 
 	return catcher.Resolve()
@@ -176,7 +176,7 @@ func (j *eventNotifierJob) processEventTriggers(e *event.EventLogEntry) (n []not
 		"event_id":      e.ID,
 		"event_type":    e.ResourceType,
 		"notifications": len(n),
-		"duration":      time.Now().Sub(startDebug).Seconds(),
+		"duration_secs": time.Now().Sub(startDebug).Seconds(),
 		"stat":          "notifications-from-event",
 	})
 
@@ -191,14 +191,14 @@ func (j *eventNotifierJob) processEventTriggers(e *event.EventLogEntry) (n []not
 
 	v, err := trigger.EvalProjectTriggers(e, trigger.TriggerDownstreamVersion)
 	grip.Info(message.Fields{
-		"job_id":     j.ID(),
-		"job_type":   j.Type().Name,
-		"source":     "events-processing",
-		"message":    "project triggers evaluated",
-		"event_id":   e.ID,
-		"event_type": e.ResourceType,
-		"duration":   time.Now().Sub(startDebug).Seconds(),
-		"stat":       "eval-project-triggers",
+		"job_id":        j.ID(),
+		"job_type":      j.Type().Name,
+		"source":        "events-processing",
+		"message":       "project triggers evaluated",
+		"event_id":      e.ID,
+		"event_type":    e.ResourceType,
+		"duration_secs": time.Now().Sub(startDebug).Seconds(),
+		"stat":          "eval-project-triggers",
 	})
 	versions := []string{}
 	for _, version := range v {

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -113,7 +113,7 @@ func (j *eventNotifierJob) processEvent(ctx context.Context, e *event.EventLogEn
 	catcher.Add(logger.MarkProcessed(e))
 
 	if err = notification.InsertMany(n...); err != nil {
-		// consider that duplicate key errors are expected
+		// Consider that duplicate key errors are expected.
 		shouldLogError := !db.IsDuplicateKey(err)
 		grip.ErrorWhen(shouldLogError, message.WrapError(err, message.Fields{
 			"job_id":        j.ID(),

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -2,13 +2,7 @@ package units
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"runtime"
-	"sort"
-	"strings"
-	"sync"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -22,7 +16,6 @@ import (
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
-	"github.com/mongodb/grip/recovery"
 	"github.com/mongodb/grip/sometimes"
 	"github.com/pkg/errors"
 )
@@ -37,11 +30,11 @@ const (
 
 type eventNotifierJob struct {
 	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
-	q        amboy.Queue
 	env      evergreen.Environment
+	q        amboy.Queue
 	flags    *evergreen.ServiceFlags
 
-	Events []string `bson:"events"`
+	EventID string `bson:"event_id"`
 }
 
 func makeEventNotifierJob() *eventNotifierJob {
@@ -56,19 +49,23 @@ func makeEventNotifierJob() *eventNotifierJob {
 	return j
 }
 
-func NewEventNotifierJob(env evergreen.Environment, q amboy.Queue, id string, events []string) amboy.Job {
+func NewEventNotifierJob(env evergreen.Environment, q amboy.Queue, eventID, ts string) amboy.Job {
 	j := makeEventNotifierJob()
-	j.q = q
 	j.env = env
+	j.q = q
 
-	j.SetID(fmt.Sprintf("%s.%s", eventNotifierName, id))
-	j.Events = events
+	j.SetID(fmt.Sprintf("%s.%s.%s", eventNotifierName, eventID, ts))
+	j.EventID = eventID
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", eventNotifierName, eventID)})
+	j.SetEnqueueAllScopes(true)
 
 	return j
 }
 
 func (j *eventNotifierJob) Run(ctx context.Context) {
-	if len(j.Events) == 0 {
+	// TODO (EVG-16260): remove this line. This line is only necessary to ensure
+	// that the old batched version of the event notifier job no-ops.
+	if j.EventID == "" {
 		return
 	}
 	if j.env == nil {
@@ -76,10 +73,6 @@ func (j *eventNotifierJob) Run(ctx context.Context) {
 	}
 	if j.q == nil {
 		j.q = j.env.RemoteQueue()
-	}
-	if j.q == nil || !j.q.Info().Started {
-		j.AddError(errors.New("evergreen environment not setup correctly"))
-		return
 	}
 	var err error
 	j.flags, err = evergreen.GetServiceFlags()
@@ -95,64 +88,44 @@ func (j *eventNotifierJob) Run(ctx context.Context) {
 		return
 	}
 
-	events, err := event.FindEventsByIDs(j.Events)
+	e, err := event.FindByID(j.EventID)
 	if err != nil {
 		j.AddError(err)
 		return
 	}
+	if e == nil {
+		return
+	}
+	if !e.ProcessedAt.IsZero() {
+		return
+	}
 
-	j.AddError(j.dispatchLoop(ctx, events))
+	j.AddError(j.processEvent(ctx, e))
 }
 
-func (j *eventNotifierJob) dispatchLoop(ctx context.Context, events []event.EventLogEntry) error {
-	// TODO: in the future we may want to split up this job so
-	// that the parallelism is pushed up to amboy rather than down
-	// into this job.
+func (j *eventNotifierJob) processEvent(ctx context.Context, e *event.EventLogEntry) error {
 	startTime := time.Now()
 	logger := event.NewDBEventLogger(event.AllLogCollection)
 	catcher := grip.NewSimpleCatcher()
 
-	input := make(chan event.EventLogEntry, len(events))
-	for _, e := range events {
-		select {
-		case input <- e:
-			continue
-		case <-ctx.Done():
-			return errors.New("operation aborted")
-		}
+	n, err := j.processEventTriggers(e)
+	catcher.Add(err)
+	catcher.Add(logger.MarkProcessed(e))
+
+	if err = notification.InsertMany(n...); err != nil {
+		// consider that duplicate key errors are expected
+		shouldLogError := !db.IsDuplicateKey(err)
+		grip.ErrorWhen(shouldLogError, message.WrapError(err, message.Fields{
+			"job_id":        j.ID(),
+			"job_type":      j.Type().Name,
+			"source":        "events-processing",
+			"notifications": n,
+			"message":       "can't insert notifications",
+		}))
+		catcher.AddWhen(shouldLogError, err)
 	}
-	close(input)
 
-	wg := &sync.WaitGroup{}
-	for i := 0; i < runtime.NumCPU(); i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			defer recovery.LogStackTraceAndContinue("problem during notification dispatch")
-
-			for e := range input {
-				n, err := j.tryProcessOneEvent(&e)
-				catcher.Add(err)
-				catcher.Add(logger.MarkProcessed(&e))
-
-				if err = notification.InsertMany(n...); err != nil {
-					// consider that duplicate key errors are expected
-					shouldLogError := !db.IsDuplicateKey(err)
-					grip.ErrorWhen(shouldLogError, message.WrapError(err, message.Fields{
-						"job_id":        j.ID(),
-						"job_type":      j.Type().Name,
-						"source":        "events-processing",
-						"notifications": n,
-						"message":       "can't insert notifications",
-					}))
-					catcher.AddWhen(shouldLogError, err)
-				}
-
-				catcher.Add(dispatchNotifications(ctx, n, j.q, j.flags))
-			}
-		}()
-	}
-	wg.Wait()
+	catcher.Add(dispatchNotifications(ctx, n, j.q, j.flags))
 
 	endTime := time.Now()
 	totalDuration := endTime.Sub(startTime)
@@ -162,10 +135,10 @@ func (j *eventNotifierJob) dispatchLoop(ctx context.Context, events []event.Even
 		"job_type":   j.Type().Name,
 		"operation":  "events-processing",
 		"message":    "event-stats",
+		"event_id":   j.EventID,
 		"start_time": startTime.String(),
 		"end_time":   endTime.String(),
 		"duration":   totalDuration.Seconds(),
-		"n":          len(events),
 		"has_errors": catcher.HasErrors(),
 		"num_errors": catcher.Len(),
 	})
@@ -173,7 +146,7 @@ func (j *eventNotifierJob) dispatchLoop(ctx context.Context, events []event.Even
 	return catcher.Resolve()
 }
 
-func (j *eventNotifierJob) tryProcessOneEvent(e *event.EventLogEntry) (n []notification.Notification, err error) {
+func (j *eventNotifierJob) processEventTriggers(e *event.EventLogEntry) (n []notification.Notification, err error) {
 	if e == nil {
 		return nil, errors.New("nil event")
 	}
@@ -203,7 +176,7 @@ func (j *eventNotifierJob) tryProcessOneEvent(e *event.EventLogEntry) (n []notif
 		"event_id":      e.ID,
 		"event_type":    e.ResourceType,
 		"notifications": len(n),
-		"duration":      time.Now().Sub(startDebug),
+		"duration":      time.Now().Sub(startDebug).Seconds(),
 		"stat":          "notifications-from-event",
 	})
 
@@ -224,7 +197,7 @@ func (j *eventNotifierJob) tryProcessOneEvent(e *event.EventLogEntry) (n []notif
 		"message":    "project triggers evaluated",
 		"event_id":   e.ID,
 		"event_type": e.ResourceType,
-		"duration":   time.Now().Sub(startDebug),
+		"duration":   time.Now().Sub(startDebug).Seconds(),
 		"stat":       "eval-project-triggers",
 	})
 	versions := []string{}
@@ -286,10 +259,4 @@ func notificationIsEnabled(flags *evergreen.ServiceFlags, n *notification.Notifi
 	}
 
 	return false
-}
-
-func sha256sum(ids []string) string {
-	sort.Strings(ids)
-	sum := sha256.Sum256([]byte(strings.Join(ids, "")))
-	return hex.EncodeToString(sum[:])
 }


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-16251
https://jira.mongodb.org/browse/EVG-16260

### Description
This is supposed to make the more efficient by reducing the duplicate events processed during times when there are a lot of unprocessed events, while also throttling the max number of events that can be simultaneously processed in parallel to avoid overloading the DB.

This change is risky, so I'm going to do the deploy after it's merged. If this doesn't work (e.g. the parallel processing limit is too high/low), the only work to rollback should be reverting this change and marking some jobs in the queue group complete.

* Process individual events instead of batches of events in the event notifier.
    * It now ignores the event processing batch size. This batch size can be removed from the admin settings at a later point if this change actually works.
* Use scopes on each event notifier to prevent duplicate event/subscriptions processing.
* Move the event notifier to the queue group and give it a temporarily hard-coded set of options that will throttle the event processing rate. The throttling is indirectly achieved due to the fact that there's a fixed number of Amboy workers per app server and fixed number of app servers. I did some calculations and it seems like under normal load, the apps can process 100 events in parallel with no issues, so I set the number of workers to achieve the same level of throughput as under normal load situations.
* Do some trivial logging changes since some durations were logged in seconds, while others were logged in nanoseconds.

### Testing 
* Updated existing tests.
* Manually tested in staging by creating a few hundred unprocessed events to verify that the events were still processed as expected and with a reasonable-looking throughput.