### PR TITLE
EVG-16292 Remove critical logging for LoadProjectInfo

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -586,7 +586,6 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 	for _, path := range intermediateProject.Include {
 		if opts == nil {
 			err = errors.New("Trying to open include files with empty opts")
-			grip.Critical(message.NewError(errors.WithStack(err)))
 			return nil, nil, errors.Wrapf(err, LoadProjectError)
 		}
 		opts.UpdateForFile(path.FileName)


### PR DESCRIPTION
[EVG-16292](https://jira.mongodb.org/browse/EVG-16929)

### Description 
it seems that every time we try to go into the task scheduler for a specific patch it tries to parse a nonexistent yml in sandbox and spams the error. Just getting rid of it should be fine

### Testing 
nothing breaks