### PR TITLE
EVG-16243 Remove CQ and several toggles from project configs

### DIFF
--- a/model/project_configs.go
+++ b/model/project_configs.go
@@ -29,12 +29,7 @@ type ProjectConfig struct {
 	GitHubChecksAliases    []ProjectAlias                 `yaml:"github_checks_aliases,omitempty" bson:"github_checks_aliases,omitempty"`
 	PatchAliases           []ProjectAlias                 `yaml:"patch_aliases,omitempty" bson:"patch_aliases,omitempty"`
 	DeactivatePrevious     *bool                          `yaml:"deactivate_previous,omitempty" bson:"deactivate_previous,omitempty"`
-	PRTestingEnabled       *bool                          `yaml:"pr_testing_enabled,omitempty" bson:"pr_testing_enabled,omitempty"`
-	ManualPRTestingEnabled *bool                          `yaml:"manual_pr_testing_enabled,omitempty" bson:"manual_pr_testing_enabled,omitempty"`
-	GithubChecksEnabled    *bool                          `yaml:"github_checks_enabled,omitempty" bson:"github_checks_enabled,omitempty"`
-	GitTagVersionsEnabled  *bool                          `yaml:"git_tag_versions_enabled,omitempty" bson:"git_tag_versions_enabled,omitempty"`
 	WorkstationConfig      *WorkstationConfig             `yaml:"workstation_config,omitempty" bson:"workstation_config,omitempty"`
-	CommitQueue            *CommitQueueParams             `yaml:"commit_queue,omitempty" bson:"commit_queue,omitempty"`
 	TaskSync               *TaskSyncOptions               `yaml:"task_sync,omitempty" bson:"task_sync,omitempty"`
 	GithubTriggerAliases   []string                       `yaml:"github_trigger_aliases,omitempty" bson:"github_trigger_aliases,omitempty"`
 	PeriodicBuilds         []PeriodicBuildDefinition      `yaml:"periodic_builds,omitempty" bson:"periodic_builds,omitempty"`

--- a/model/project_configs.go
+++ b/model/project_configs.go
@@ -22,13 +22,11 @@ type ProjectConfig struct {
 	// be the configs used for a given project during runtime.
 	TaskAnnotationSettings *evergreen.AnnotationsSettings `yaml:"task_annotation_settings,omitempty" bson:"task_annotation_settings,omitempty"`
 	BuildBaronSettings     *evergreen.BuildBaronSettings  `yaml:"build_baron_settings,omitempty" bson:"build_baron_settings,omitempty"`
-	PerfEnabled            *bool                          `yaml:"perf_enabled,omitempty" bson:"perf_enabled,omitempty"`
 	CommitQueueAliases     []ProjectAlias                 `yaml:"commit_queue_aliases,omitempty" bson:"commit_queue_aliases,omitempty"`
 	GitHubPRAliases        []ProjectAlias                 `yaml:"github_pr_aliases,omitempty" bson:"github_pr_aliases,omitempty"`
 	GitTagAliases          []ProjectAlias                 `yaml:"git_tag_aliases,omitempty" bson:"git_tag_aliases,omitempty"`
 	GitHubChecksAliases    []ProjectAlias                 `yaml:"github_checks_aliases,omitempty" bson:"github_checks_aliases,omitempty"`
 	PatchAliases           []ProjectAlias                 `yaml:"patch_aliases,omitempty" bson:"patch_aliases,omitempty"`
-	DeactivatePrevious     *bool                          `yaml:"deactivate_previous,omitempty" bson:"deactivate_previous,omitempty"`
 	WorkstationConfig      *WorkstationConfig             `yaml:"workstation_config,omitempty" bson:"workstation_config,omitempty"`
 	TaskSync               *TaskSyncOptions               `yaml:"task_sync,omitempty" bson:"task_sync,omitempty"`
 	GithubTriggerAliases   []string                       `yaml:"github_trigger_aliases,omitempty" bson:"github_trigger_aliases,omitempty"`

--- a/model/project_configs_test.go
+++ b/model/project_configs_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +28,6 @@ task_groups:
   - command: shell.exec
     params:
       script: "echo hi"
-deactivate_previous: true
 build_baron_settings:
   ticket_create_project: BF
   ticket_search_projects: ["BF"]
@@ -42,6 +40,5 @@ commit_queue_aliases:
 	pc, err = createProjectConfig([]byte(projYml))
 	assert.Nil(t, err)
 	assert.NotNil(t, pc)
-	assert.True(t, utility.FromBoolPtr(pc.DeactivatePrevious))
 	assert.Equal(t, "BF", pc.BuildBaronSettings.TicketCreateProject)
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -465,8 +465,8 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) error {
 		reflectedRef := reflect.ValueOf(p).Elem()
 		reflectedConfig := reflect.ValueOf(pRefToMerge)
 		recursivelySetUndefinedFields(reflectedRef, reflectedConfig)
-		p.PerfEnabled = projectConfig.PerfEnabled
-		p.DeactivatePrevious = projectConfig.DeactivatePrevious
+		p.PerfEnabled = utility.ToBoolPtr(utility.FromBoolPtr(projectConfig.PerfEnabled) || utility.FromBoolPtr(p.PerfEnabled))
+		p.DeactivatePrevious = utility.ToBoolPtr(utility.FromBoolPtr(projectConfig.DeactivatePrevious) || utility.FromBoolPtr(p.DeactivatePrevious))
 	}
 	return err
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -465,8 +465,6 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) error {
 		reflectedRef := reflect.ValueOf(p).Elem()
 		reflectedConfig := reflect.ValueOf(pRefToMerge)
 		recursivelySetUndefinedFields(reflectedRef, reflectedConfig)
-		p.PerfEnabled = utility.ToBoolPtr(utility.FromBoolPtr(projectConfig.PerfEnabled) || utility.FromBoolPtr(p.PerfEnabled))
-		p.DeactivatePrevious = utility.ToBoolPtr(utility.FromBoolPtr(projectConfig.DeactivatePrevious) || utility.FromBoolPtr(p.DeactivatePrevious))
 	}
 	return err
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -447,14 +447,8 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) error {
 			err = recovery.HandlePanicWithError(recover(), err, "project ref and project config structures do not match")
 		}()
 		pRefToMerge := ProjectRef{
-			DeactivatePrevious:     projectConfig.DeactivatePrevious,
-			PerfEnabled:            projectConfig.PerfEnabled,
-			PRTestingEnabled:       projectConfig.PRTestingEnabled,
-			ManualPRTestingEnabled: projectConfig.ManualPRTestingEnabled,
-			GithubChecksEnabled:    projectConfig.GithubChecksEnabled,
-			GitTagVersionsEnabled:  projectConfig.GitTagVersionsEnabled,
-			PeriodicBuilds:         projectConfig.PeriodicBuilds,
-			GithubTriggerAliases:   projectConfig.GithubTriggerAliases,
+			PeriodicBuilds:       projectConfig.PeriodicBuilds,
+			GithubTriggerAliases: projectConfig.GithubTriggerAliases,
 		}
 		if projectConfig.WorkstationConfig != nil {
 			pRefToMerge.WorkstationConfig = *projectConfig.WorkstationConfig
@@ -465,15 +459,14 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) error {
 		if projectConfig.TaskAnnotationSettings != nil {
 			pRefToMerge.TaskAnnotationSettings = *projectConfig.TaskAnnotationSettings
 		}
-		if projectConfig.CommitQueue != nil {
-			pRefToMerge.CommitQueue = *projectConfig.CommitQueue
-		}
 		if projectConfig.TaskSync != nil {
 			pRefToMerge.TaskSync = *projectConfig.TaskSync
 		}
 		reflectedRef := reflect.ValueOf(p).Elem()
 		reflectedConfig := reflect.ValueOf(pRefToMerge)
 		recursivelySetUndefinedFields(reflectedRef, reflectedConfig)
+		p.PerfEnabled = projectConfig.PerfEnabled
+		p.DeactivatePrevious = projectConfig.DeactivatePrevious
 	}
 	return err
 }

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -54,8 +54,7 @@ func TestFindMergedProjectRef(t *testing.T) {
 		"Error clearing collection")
 
 	projectConfig := &ProjectConfig{
-		Id:                 "ident",
-		DeactivatePrevious: utility.FalsePtr(),
+		Id: "ident",
 		TaskAnnotationSettings: &evergreen.AnnotationsSettings{
 			FileTicketWebhook: evergreen.WebHook{
 				Endpoint: "random2",
@@ -136,7 +135,6 @@ func TestFindMergedProjectRef(t *testing.T) {
 
 	assert.True(t, mergedProject.WorkstationConfig.ShouldGitClone())
 	assert.Len(t, mergedProject.WorkstationConfig.SetupCommands, 1)
-	assert.True(t, *mergedProject.DeactivatePrevious)
 	assert.Equal(t, "random2", mergedProject.TaskAnnotationSettings.FileTicketWebhook.Endpoint)
 }
 
@@ -1870,9 +1868,7 @@ func TestMergeWithProjectConfig(t *testing.T) {
 		},
 	}
 	projectConfig := &ProjectConfig{
-		Id:                 "version1",
-		PerfEnabled:        utility.TruePtr(),
-		DeactivatePrevious: utility.TruePtr(),
+		Id: "version1",
 		TaskAnnotationSettings: &evergreen.AnnotationsSettings{
 			FileTicketWebhook: evergreen.WebHook{
 				Endpoint: "random2",
@@ -1901,8 +1897,6 @@ func TestMergeWithProjectConfig(t *testing.T) {
 	require.NotNil(t, projectRef)
 	assert.Equal(t, "ident", projectRef.Id)
 
-	assert.True(t, *projectRef.DeactivatePrevious)
-	assert.True(t, *projectRef.PerfEnabled)
 	assert.Equal(t, "random1", projectRef.TaskAnnotationSettings.FileTicketWebhook.Endpoint)
 	assert.True(t, *projectRef.WorkstationConfig.GitClone)
 	assert.Equal(t, "expeliarmus", projectRef.WorkstationConfig.SetupCommands[0].Command)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1864,29 +1864,19 @@ func TestMergeWithProjectConfig(t *testing.T) {
 				{Command: "expeliarmus"},
 			},
 		},
-		CommitQueue: CommitQueueParams{
-			Enabled:     utility.TruePtr(),
-			MergeMethod: "message1",
-		},
 		BuildBaronSettings: evergreen.BuildBaronSettings{
 			TicketCreateProject:  "EVG",
 			TicketSearchProjects: []string{"BF", "BFG"},
 		},
 	}
 	projectConfig := &ProjectConfig{
-		Id:                    "version1",
-		PerfEnabled:           utility.TruePtr(),
-		DeactivatePrevious:    utility.TruePtr(),
-		PRTestingEnabled:      utility.TruePtr(),
-		GitTagVersionsEnabled: utility.TruePtr(),
+		Id:                 "version1",
+		PerfEnabled:        utility.TruePtr(),
+		DeactivatePrevious: utility.TruePtr(),
 		TaskAnnotationSettings: &evergreen.AnnotationsSettings{
 			FileTicketWebhook: evergreen.WebHook{
 				Endpoint: "random2",
 			},
-		},
-		CommitQueue: &CommitQueueParams{
-			Enabled:     utility.TruePtr(),
-			MergeMethod: "message2",
 		},
 		WorkstationConfig: &WorkstationConfig{
 			GitClone: utility.FalsePtr(),
@@ -1905,19 +1895,17 @@ func TestMergeWithProjectConfig(t *testing.T) {
 	}
 	assert.NoError(t, projectRef.Insert())
 	assert.NoError(t, projectConfig.Insert())
+
 	err := projectRef.MergeWithProjectConfig("version1")
 	assert.NoError(t, err)
 	require.NotNil(t, projectRef)
 	assert.Equal(t, "ident", projectRef.Id)
 
-	assert.False(t, *projectRef.DeactivatePrevious)
+	assert.True(t, *projectRef.DeactivatePrevious)
 	assert.True(t, *projectRef.PerfEnabled)
-	assert.True(t, *projectRef.PRTestingEnabled)
-	assert.True(t, *projectRef.GitTagVersionsEnabled)
 	assert.Equal(t, "random1", projectRef.TaskAnnotationSettings.FileTicketWebhook.Endpoint)
 	assert.True(t, *projectRef.WorkstationConfig.GitClone)
 	assert.Equal(t, "expeliarmus", projectRef.WorkstationConfig.SetupCommands[0].Command)
-	assert.Equal(t, "message1", projectRef.CommitQueue.MergeMethod)
 
 	assert.Equal(t, "https://evergreen.mongodb.com", projectRef.BuildBaronSettings.BFSuggestionServer)
 	assert.Equal(t, 10, projectRef.BuildBaronSettings.BFSuggestionTimeoutSecs)

--- a/operations/model.go
+++ b/operations/model.go
@@ -82,7 +82,6 @@ type ClientSettings struct {
 	APIKey                string              `json:"api_key" yaml:"api_key,omitempty"`
 	User                  string              `json:"user" yaml:"user,omitempty"`
 	UncommittedChanges    bool                `json:"patch_uncommitted_changes" yaml:"patch_uncommitted_changes,omitempty"`
-	AutoUpgradeCli        bool                `json:"auto_upgrade_cli" yaml:"auto_upgrade_cli,omitempty"`
 	PreserveCommits       bool                `json:"preserve_commits" yaml:"preserve_commits,omitempty"`
 	Projects              []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
 	Admin                 ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`

--- a/operations/model.go
+++ b/operations/model.go
@@ -82,6 +82,7 @@ type ClientSettings struct {
 	APIKey                string              `json:"api_key" yaml:"api_key,omitempty"`
 	User                  string              `json:"user" yaml:"user,omitempty"`
 	UncommittedChanges    bool                `json:"patch_uncommitted_changes" yaml:"patch_uncommitted_changes,omitempty"`
+	AutoUpgradeCli        bool                `json:"auto_upgrade_cli" yaml:"auto_upgrade_cli,omitempty"`
 	PreserveCommits       bool                `json:"preserve_commits" yaml:"preserve_commits,omitempty"`
 	Projects              []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
 	Admin                 ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`


### PR DESCRIPTION
[EVG-16243](https://jira.mongodb.org/browse/EVG-16243)

### Description 
Commit queue params and several toggles related to github project configurations have been removed from the newly exposed set of configurations, since enabling these properties via version control may lead to unexpected behavior when restarting old tasks that have their config yaml version conflicting with what is set on the project page.  Two toggles have been kept: perf enabled and deactivate previous, since it looks as though keeping these under version control would not be problematic.
### Testing 
Modified existing unit tests.