### PR TITLE
EVG-16066: prevent concurrent user-initiated spawn host modifications

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1167,7 +1167,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 			return errors.Wrap(currentStatusErr, "error getting instance status after stopping error")
 		}
 
-		if currentStatusErr = h.SetStatus(currentStatus.String(), user, ""); currentStatusErr != nil {
+		if currentStatusErr = h.SetStatus(currentStatus.String(), user, "reverting to the most up-to-date host status"); currentStatusErr != nil {
 			return errors.Wrapf(currentStatusErr, "failed to revert status from stopping to '%s'", currentStatus)
 		}
 		return errors.Wrapf(err, "error stopping EC2 instance '%s'", h.Id)
@@ -1182,10 +1182,11 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 			if err != nil {
 				return false, errors.Wrap(err, "error getting instance info")
 			}
-			if ec2StatusToEvergreenStatus(*instance.State.Name) == StatusStopped {
+			status := ec2StatusToEvergreenStatus(*instance.State.Name)
+			if status == StatusStopped {
 				return false, nil
 			}
-			return true, errors.New("host is not stopped")
+			return true, errors.Errorf("host is not stopped, current status is '%s'", status)
 		}, utility.RetryOptions{
 			MaxAttempts: checkSuccessAttempts,
 			MinDelay:    checkSuccessInitPeriod,
@@ -1196,7 +1197,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 		if currentStatusErr != nil {
 			return errors.Wrap(currentStatusErr, "error getting instance status after stopping error")
 		}
-		if currentStatusErr := h.SetStatus(currentStatus.String(), user, ""); currentStatusErr != nil {
+		if currentStatusErr := h.SetStatus(currentStatus.String(), user, "reverting to the most up-to-date host status"); currentStatusErr != nil {
 			return errors.Wrapf(currentStatusErr, "failed to revert status from stopping to '%s'", currentStatus)
 		}
 		return errors.Wrap(err, "error checking if spawnhost stopped")

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1167,7 +1167,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 			return errors.Wrap(currentStatusErr, "error getting instance status after stopping error")
 		}
 
-		if currentStatusErr = h.SetStatus(currentStatus.String(), user, "reverting to the most up-to-date host status"); currentStatusErr != nil {
+		if currentStatusErr = h.SetStatusAtomically(currentStatus.String(), user, "reverting to the most up-to-date host status"); currentStatusErr != nil {
 			return errors.Wrapf(currentStatusErr, "failed to revert status from stopping to '%s'", currentStatus)
 		}
 		return errors.Wrapf(err, "error stopping EC2 instance '%s'", h.Id)
@@ -1197,7 +1197,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 		if currentStatusErr != nil {
 			return errors.Wrap(currentStatusErr, "error getting instance status after stopping error")
 		}
-		if currentStatusErr := h.SetStatus(currentStatus.String(), user, "reverting to the most up-to-date host status"); currentStatusErr != nil {
+		if currentStatusErr := h.SetStatusAtomically(currentStatus.String(), user, "reverting to the most up-to-date host status"); currentStatusErr != nil {
 			return errors.Wrapf(currentStatusErr, "failed to revert status from stopping to '%s'", currentStatus)
 		}
 		return errors.Wrap(err, "error checking if spawnhost stopped")

--- a/units/spawnhost_modify.go
+++ b/units/spawnhost_modify.go
@@ -11,10 +11,50 @@ import (
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
+
+const (
+	spawnHostStatusChangeScopeName = "spawn-host-status-change"
+)
+
+// CloudHostModification is a helper to perform cloud manager operations on
+// a single host.
+type CloudHostModification struct {
+	HostID string `bson:"host_id" json:"host_id" yaml:"host_id"`
+	UserID string `bson:"user_id" json:"user_id" yaml:"user_id"`
+
+	host *host.Host
+	env  evergreen.Environment
+}
+
+func (m *CloudHostModification) modifyHost(ctx context.Context, op func(mgr cloud.Manager, h *host.Host, user string) error) error {
+	if m.env == nil {
+		m.env = evergreen.GetEnvironment()
+	}
+
+	var err error
+	if m.host == nil {
+		m.host, err = host.FindOneByIdOrTag(m.HostID)
+		if err != nil {
+			return errors.Wrap(err, "finding host")
+		}
+		if m.host == nil {
+			return errors.Wrap(err, "host not found")
+		}
+	}
+
+	mgrOpts, err := cloud.GetManagerOptions(m.host.Distro)
+	if err != nil {
+		return errors.Wrap(err, "getting cloud manager options")
+	}
+	cloudManager, err := cloud.GetManager(ctx, m.env, mgrOpts)
+	if err != nil {
+		return errors.Wrap(err, "getting cloud manager")
+	}
+
+	return op(cloudManager, m.host, m.UserID)
+}
 
 const (
 	spawnhostModifyName = "spawnhost-modify"
@@ -26,12 +66,13 @@ func init() {
 }
 
 type spawnhostModifyJob struct {
-	HostID        string                 `bson:"host_id" json:"host_id" yaml:"host_id"`
-	ModifyOptions host.HostModifyOptions `bson:"modify_options" json:"modify_options" yaml:"modify_options"`
-	job.Base      `bson:"job_base" json:"job_base" yaml:"job_base"`
+	// TODO (EVG-16066): remove HostID.
+	HostID                string                 `bson:"host_id" json:"host_id" yaml:"host_id"`
+	ModifyOptions         host.HostModifyOptions `bson:"modify_options" json:"modify_options" yaml:"modify_options"`
+	CloudHostModification `bson:"base_spawn_host_modification" json:"base_spawn_host_modification" yaml:"base_spawn_host_modification"`
+	job.Base              `bson:"job_base" json:"job_base" yaml:"job_base"`
 
-	host *host.Host
-	env  evergreen.Environment
+	env evergreen.Environment
 }
 
 func makeSpawnhostModifyJob() *spawnhostModifyJob {
@@ -49,56 +90,32 @@ func makeSpawnhostModifyJob() *spawnhostModifyJob {
 func NewSpawnhostModifyJob(h *host.Host, changes host.HostModifyOptions, ts string) amboy.Job {
 	j := makeSpawnhostModifyJob()
 	j.SetID(fmt.Sprintf("%s.%s.%s", spawnhostModifyName, h.Id, ts))
-	j.HostID = h.Id
 	j.ModifyOptions = changes
+	j.CloudHostModification.HostID = h.Id
 	return j
 }
 
 func (j *spawnhostModifyJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	if j.env == nil {
-		j.env = evergreen.GetEnvironment()
+	// Setting the base field is for temporary backward compatibility with
+	// pending jobs already stored in the DB.
+	// TODO (EVG-16066): remove this check once all old versions of the job are
+	// complete.
+	if j.HostID != "" {
+		j.CloudHostModification.HostID = j.HostID
 	}
 
-	var err error
-	if j.host == nil {
-		j.host, err = host.FindOneByIdOrTag(j.HostID)
-		if err != nil {
-			j.AddError(err)
-			return
+	if err := j.CloudHostModification.modifyHost(ctx, func(mgr cloud.Manager, h *host.Host, user string) error {
+		if err := mgr.ModifyHost(ctx, h, j.ModifyOptions); err != nil {
+			event.LogHostModifyFinished(h.Id, false)
+			return errors.Wrapf(err, "modifying spawn host '%s'", h.Id)
 		}
-		if j.host == nil {
-			j.AddError(fmt.Errorf("could not find host %s for job %s", j.HostID, j.ID()))
-			return
-		}
-	}
 
-	grip.Info(message.Fields{
-		"message": "modifying spawnhost",
-		"job_id":  j.ID(),
-		"host_id": j.HostID,
-		"changes": j.ModifyOptions,
-	})
-
-	mgrOpts, err := cloud.GetManagerOptions(j.host.Distro)
-	if err != nil {
-		j.AddError(errors.Wrapf(err, "can't get ManagerOpts for '%s'", j.host.Id))
+		event.LogHostModifyFinished(h.Id, true)
+		return nil
+	}); err != nil {
+		j.AddError(err)
 		return
 	}
-	cloudManager, err := cloud.GetManager(ctx, j.env, mgrOpts)
-	if err != nil {
-		j.AddError(errors.Wrap(err, "error getting cloud manager for spawnhost modify job"))
-		return
-	}
-
-	// Modify spawnhost using the cloud manager
-	if err := cloudManager.ModifyHost(ctx, j.host, j.ModifyOptions); err != nil {
-		j.AddError(errors.Wrap(err, "error modifying spawnhost using cloud manager"))
-		event.LogHostModifyFinished(j.host.Id, false)
-		return
-	}
-
-	event.LogHostModifyFinished(j.host.Id, true)
-	return
 }

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -72,7 +72,7 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 		j.CloudHostModification.UserID = j.UserID
 	}
 
-	if err := j.CloudHostModification.modifyHost(ctx, func(mgr cloud.Manager, h *host.Host, user string) error {
+	startCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.StartInstance(ctx, h, user); err != nil {
 			event.LogHostStartFinished(h.Id, false)
 			return errors.Wrapf(err, "starting spawn host '%s'", h.Id)
@@ -81,7 +81,8 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 		event.LogHostStartFinished(h.Id, true)
 
 		return nil
-	}); err != nil {
+	}
+	if err := j.CloudHostModification.modifyHost(ctx, startCloudHost); err != nil {
 		j.AddError(err)
 		return
 	}

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -24,9 +24,12 @@ func init() {
 }
 
 type spawnhostStartJob struct {
-	HostID   string `bson:"host_id" json:"host_id" yaml:"host_id"`
-	UserID   string `bson:"user_id" json:"user_id" yaml:"user_id"`
-	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
+	// TODO (EVG-16066): remove HostID and UserID since they are no longer
+	// necessary, except for temporary backward compatibility.
+	HostID                string `bson:"host_id" json:"host_id" yaml:"host_id"`
+	UserID                string `bson:"user_id" json:"user_id" yaml:"user_id"`
+	CloudHostModification `bson:"cloud_host_modification" json:"cloud_host_modification" yaml:"cloud_host_modification"`
+	job.Base              `bson:"job_base" json:"job_base" yaml:"job_base"`
 
 	host *host.Host
 	env  evergreen.Environment
@@ -44,52 +47,42 @@ func makeSpawnhostStartJob() *spawnhostStartJob {
 	return j
 }
 
+// NewSpawnhostStartJob returns a job to start a stopped spawn host.
 func NewSpawnhostStartJob(h *host.Host, user, ts string) amboy.Job {
 	j := makeSpawnhostStartJob()
 	j.SetID(fmt.Sprintf("%s.%s.%s.%s", spawnhostStartName, user, h.Id, ts))
-	j.HostID = h.Id
-	j.UserID = user
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", spawnHostStatusChangeScopeName, h.Id)})
+	j.SetEnqueueAllScopes(true)
+	j.CloudHostModification.HostID = h.Id
+	j.CloudHostModification.UserID = user
 	return j
 }
 
 func (j *spawnhostStartJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	if j.env == nil {
-		j.env = evergreen.GetEnvironment()
+	// Setting the base fields are for temporary backward compatibility with
+	// pending jobs already stored in the DB.
+	// TODO (EVG-16066): remove this check once all old versions of the job are
+	// complete.
+	if j.HostID != "" {
+		j.CloudHostModification.HostID = j.HostID
+	}
+	if j.UserID != "" {
+		j.CloudHostModification.UserID = j.UserID
 	}
 
-	var err error
-	if j.host == nil {
-		j.host, err = host.FindOneByIdOrTag(j.HostID)
-		if err != nil {
-			j.AddError(err)
-			return
+	if err := j.CloudHostModification.modifyHost(ctx, func(mgr cloud.Manager, h *host.Host, user string) error {
+		if err := mgr.StartInstance(ctx, h, user); err != nil {
+			event.LogHostStartFinished(h.Id, false)
+			return errors.Wrapf(err, "starting spawn host '%s'", h.Id)
 		}
-		if j.host == nil {
-			j.AddError(fmt.Errorf("could not find host %s for job %s", j.HostID, j.ID()))
-			return
-		}
-	}
 
-	mgrOpts, err := cloud.GetManagerOptions(j.host.Distro)
-	if err != nil {
-		j.AddError(errors.Wrapf(err, "can't get ManagerOpts for '%s'", j.host.Id))
+		event.LogHostStartFinished(h.Id, true)
+
+		return nil
+	}); err != nil {
+		j.AddError(err)
 		return
 	}
-	cloudManager, err := cloud.GetManager(ctx, j.env, mgrOpts)
-	if err != nil {
-		j.AddError(errors.Wrap(err, "error getting cloud manager for spawnhost start job"))
-		return
-	}
-
-	// Start instance using the cloud manager
-	if err := cloudManager.StartInstance(ctx, j.host, j.UserID); err != nil {
-		j.AddError(errors.Wrap(err, "error starting spawnhost using cloud manager"))
-		event.LogHostStartFinished(j.host.Id, false)
-		return
-	}
-
-	event.LogHostStartFinished(j.host.Id, true)
-	return
 }

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -24,9 +24,12 @@ func init() {
 }
 
 type spawnhostStopJob struct {
-	HostID   string `bson:"host_id" json:"host_id" yaml:"host_id"`
-	UserID   string `bson:"user_id" json:"user_id" yaml:"user_id"`
-	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
+	// TODO (EVG-16066): remove HostID and UserID since they are no longer
+	// necessary, except for temporary backward compatibility.
+	HostID                string `bson:"host_id" json:"host_id" yaml:"host_id"`
+	UserID                string `bson:"user_id" json:"user_id" yaml:"user_id"`
+	CloudHostModification `bson:"cloud_host_modification" json:"cloud_host_modification" yaml:"cloud_host_modification"`
+	job.Base              `bson:"job_base" json:"job_base" yaml:"job_base"`
 
 	host *host.Host
 	env  evergreen.Environment
@@ -44,52 +47,42 @@ func makeSpawnhostStopJob() *spawnhostStopJob {
 	return j
 }
 
+// NewSpawnhostStopJob returns a job to stop a running spawn host.
 func NewSpawnhostStopJob(h *host.Host, user, ts string) amboy.Job {
 	j := makeSpawnhostStopJob()
 	j.SetID(fmt.Sprintf("%s.%s.%s.%s", spawnhostStopName, user, h.Id, ts))
-	j.HostID = h.Id
-	j.UserID = user
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", spawnHostStatusChangeScopeName, h.Id)})
+	j.SetEnqueueAllScopes(true)
+	j.CloudHostModification.HostID = h.Id
+	j.CloudHostModification.UserID = user
 	return j
 }
 
 func (j *spawnhostStopJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	if j.env == nil {
-		j.env = evergreen.GetEnvironment()
+	// Setting the base fields are for temporary backward compatibility with
+	// pending jobs already stored in the DB.
+	// TODO (EVG-16066): remove this check once all old versions of the job are
+	// complete.
+	if j.HostID != "" {
+		j.CloudHostModification.HostID = j.HostID
+	}
+	if j.UserID != "" {
+		j.CloudHostModification.UserID = j.UserID
 	}
 
-	var err error
-	if j.host == nil {
-		j.host, err = host.FindOneByIdOrTag(j.HostID)
-		if err != nil {
-			j.AddError(err)
-			return
+	if err := j.CloudHostModification.modifyHost(ctx, func(mgr cloud.Manager, h *host.Host, user string) error {
+		if err := mgr.StopInstance(ctx, h, user); err != nil {
+			event.LogHostStopFinished(h.Id, false)
+			return errors.Wrapf(err, "stopping spawn host '%s'", h.Id)
 		}
-		if j.host == nil {
-			j.AddError(fmt.Errorf("could not find host %s for job %s", j.HostID, j.ID()))
-			return
-		}
-	}
 
-	mgrOpts, err := cloud.GetManagerOptions(j.host.Distro)
-	if err != nil {
-		j.AddError(errors.Wrapf(err, "can't get ManagerOpts for '%s'", j.host.Id))
+		event.LogHostStopFinished(h.Id, true)
+
+		return nil
+	}); err != nil {
+		j.AddError(err)
 		return
 	}
-	cloudManager, err := cloud.GetManager(ctx, j.env, mgrOpts)
-	if err != nil {
-		j.AddError(errors.Wrap(err, "error getting cloud manager for spawnhost stop job"))
-		return
-	}
-
-	// Stop instance using the cloud manager
-	if err := cloudManager.StopInstance(ctx, j.host, j.UserID); err != nil {
-		j.AddError(errors.Wrap(err, "error stopping spawnhost using cloud manager"))
-		event.LogHostStopFinished(j.host.Id, false)
-		return
-	}
-
-	event.LogHostStopFinished(j.host.Id, true)
-	return
 }

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -72,7 +72,7 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 		j.CloudHostModification.UserID = j.UserID
 	}
 
-	if err := j.CloudHostModification.modifyHost(ctx, func(mgr cloud.Manager, h *host.Host, user string) error {
+	stopCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.StopInstance(ctx, h, user); err != nil {
 			event.LogHostStopFinished(h.Id, false)
 			return errors.Wrapf(err, "stopping spawn host '%s'", h.Id)
@@ -81,7 +81,8 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 		event.LogHostStopFinished(h.Id, true)
 
 		return nil
-	}); err != nil {
+	}
+	if err := j.CloudHostModification.modifyHost(ctx, stopCloudHost); err != nil {
 		j.AddError(err)
 		return
 	}

--- a/units/spawnhost_terminate.go
+++ b/units/spawnhost_terminate.go
@@ -1,0 +1,63 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+)
+
+const spawnHostTerminationJobName = "spawnhost-termination"
+
+func init() {
+	registry.AddJobType(spawnHostTerminationJobName, func() amboy.Job {
+		return makeSpawnHostTerminationJob()
+	})
+}
+
+type spawnHostTerminationJob struct {
+	CloudHostModification `bson:"cloud_host_modification" json:"cloud_host_modification" yaml:"cloud_host_modification"`
+	job.Base              `bson:"job_base" json:"job_base" yaml:"job_base"`
+}
+
+func makeSpawnHostTerminationJob() *spawnHostTerminationJob {
+	j := &spawnHostTerminationJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    spawnHostTerminationJobName,
+				Version: 0,
+			},
+		},
+	}
+	return j
+}
+
+// NewSpawnHostTerminationJob returns a job to terminate a spawn host.
+func NewSpawnHostTerminationJob(h *host.Host, user, ts string) amboy.Job {
+	j := makeSpawnHostTerminationJob()
+	j.SetID(fmt.Sprintf("%s.%s.%s", spawnHostTerminationJobName, h.Id, ts))
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", spawnHostStatusChangeScopeName, h.Id)})
+	j.SetEnqueueAllScopes(true)
+	j.CloudHostModification.HostID = h.Id
+	j.CloudHostModification.UserID = user
+	return j
+}
+
+func (j *spawnHostTerminationJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	if err := j.CloudHostModification.modifyHost(ctx, func(mgr cloud.Manager, h *host.Host, user string) error {
+		if err := mgr.TerminateInstance(ctx, h, user, "user requested spawn host termination"); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		j.AddError(err)
+		return
+	}
+}

--- a/units/spawnhost_terminate.go
+++ b/units/spawnhost_terminate.go
@@ -50,13 +50,14 @@ func NewSpawnHostTerminationJob(h *host.Host, user, ts string) amboy.Job {
 func (j *spawnHostTerminationJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	if err := j.CloudHostModification.modifyHost(ctx, func(mgr cloud.Manager, h *host.Host, user string) error {
+	terminateCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.TerminateInstance(ctx, h, user, "user requested spawn host termination"); err != nil {
 			return err
 		}
 
 		return nil
-	}); err != nil {
+	}
+	if err := j.CloudHostModification.modifyHost(ctx, terminateCloudHost); err != nil {
 		j.AddError(err)
 		return
 	}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16066

### Description 
The unexpirable spawn host ended up in an unusual state because the user attempted to terminate and stop the host at the same time. The host ended up being terminated in AWS but marked as running in the DB. I changed the jobs that allow users to manually modify spawn hosts so that only one can happen at a time. For example, if the user tries to terminate the host in the UI, any attempt to stop/start the host from the UI will error while it's in progress.

* Use scopes to ensure host start/stop/terminate requests from the user do not cause host concurrency problems when modifying the host.
    * User-initiated spawn host termination now happens asynchronously in a job rather than synchronously with the UI request.
* Clean up a bunch of copy-pasted code across the spawn host start/stop/modify jobs. This is backwards compatible with the existing jobs. Once this is merged and deployed, the deletion TODOs can be done in a follow-up PR.
* Add more useful logs in host start/stop about status updates in failure cases (e.g. failure to stop the host).

### Testing 
Updated unit tests and verified that it works as expected in staging.