### PR TITLE
EVG-6496 Auto update CLI if it is set in client settings before each command

### DIFF
--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -107,12 +108,11 @@ func buildApp() *cli.App {
 		if err != nil {
 			return errors.Wrap(err, "problem loading configuration")
 		}
-		if conf.AutoUpgradeCli {
+		if conf.AutoUpgradeCLI {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			err = operations.DoUpdate(conf, ctx, true, false)
-			if err != nil {
-				return errors.Wrap(err, "problem auto updating CLI")
+			if err = operations.CheckAndUpdateVersion(conf, ctx, true, false); err != nil {
+				fmt.Println("Automatic CLI update failed, continuing command execution")
 			}
 		}
 		return loggingSetup(app.Name, c.String("level"))

--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -111,7 +111,7 @@ func buildApp() *cli.App {
 		if conf.AutoUpgradeCLI {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			if err = operations.CheckAndUpdateVersion(conf, ctx, true, false); err != nil {
+			if err = operations.CheckAndUpdateVersion(conf, ctx, true, false, true); err != nil {
 				fmt.Println("Automatic CLI update failed, continuing command execution")
 			}
 		}

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-01-23"
+	ClientVersion = "2022-01-27"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-02-04"

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-01-27"
+	ClientVersion = "2022-01-23"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-02-04"

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-01-27"
+	ClientVersion = "2022-02-16"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-02-04"

--- a/operations/model.go
+++ b/operations/model.go
@@ -82,7 +82,7 @@ type ClientSettings struct {
 	APIKey                string              `json:"api_key" yaml:"api_key,omitempty"`
 	User                  string              `json:"user" yaml:"user,omitempty"`
 	UncommittedChanges    bool                `json:"patch_uncommitted_changes" yaml:"patch_uncommitted_changes,omitempty"`
-	AutoUpgradeCli        bool                `json:"auto_upgrade_cli" yaml:"auto_upgrade_cli,omitempty"`
+	AutoUpgradeCLI        bool                `json:"auto_upgrade_cli" yaml:"auto_upgrade_cli,omitempty"`
 	PreserveCommits       bool                `json:"preserve_commits" yaml:"preserve_commits,omitempty"`
 	Projects              []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
 	Admin                 ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`
@@ -148,7 +148,7 @@ func (s *ClientSettings) Write(fn string) error {
 // To avoid printing these messages, call getRestCommunicator instead.
 func (s *ClientSettings) setupRestCommunicator(ctx context.Context) client.Communicator {
 	c := s.getRestCommunicator(ctx)
-	printUserMessages(ctx, c, !s.AutoUpgradeCli)
+	printUserMessages(ctx, c, !s.AutoUpgradeCLI)
 	return c
 }
 
@@ -369,4 +369,9 @@ func (s *ClientSettings) SetDefaultProject(cwd, project string) {
 	}
 	s.ProjectsForDirectory[cwd] = project
 	grip.Infof("Project '%s' will be set as the one to use for directory '%s'. To disable automatic defaulting, set 'disable_auto_defaulting' to true.", project, cwd)
+}
+
+func (s *ClientSettings) SetAutoUpgradeCLI() {
+	s.AutoUpgradeCLI = true
+	grip.Info("Evergreen CLI will be automatically updated and installed before each command if a more recent version is detected.")
 }

--- a/operations/model.go
+++ b/operations/model.go
@@ -82,6 +82,7 @@ type ClientSettings struct {
 	APIKey                string              `json:"api_key" yaml:"api_key,omitempty"`
 	User                  string              `json:"user" yaml:"user,omitempty"`
 	UncommittedChanges    bool                `json:"patch_uncommitted_changes" yaml:"patch_uncommitted_changes,omitempty"`
+	AutoUpgradeCli        bool                `json:"auto_upgrade_cli" yaml:"auto_upgrade_cli,omitempty"`
 	PreserveCommits       bool                `json:"preserve_commits" yaml:"preserve_commits,omitempty"`
 	Projects              []ClientProjectConf `json:"projects" yaml:"projects,omitempty"`
 	Admin                 ClientAdminConf     `json:"admin" yaml:"admin,omitempty"`
@@ -147,7 +148,7 @@ func (s *ClientSettings) Write(fn string) error {
 // To avoid printing these messages, call getRestCommunicator instead.
 func (s *ClientSettings) setupRestCommunicator(ctx context.Context) client.Communicator {
 	c := s.getRestCommunicator(ctx)
-	printUserMessages(ctx, c)
+	printUserMessages(ctx, c, !s.AutoUpgradeCli)
 	return c
 }
 
@@ -165,7 +166,7 @@ func (s *ClientSettings) getRestCommunicator(ctx context.Context) client.Communi
 }
 
 // printUserMessages prints any available info messages.
-func printUserMessages(ctx context.Context, c client.Communicator) {
+func printUserMessages(ctx context.Context, c client.Communicator, checkForUpdate bool) {
 	banner, err := c.GetBannerMessage(ctx)
 	if err != nil {
 		grip.Debug(err)
@@ -174,15 +175,17 @@ func printUserMessages(ctx context.Context, c client.Communicator) {
 		grip.Noticef("Banner: %s", banner)
 	}
 
-	update, err := checkUpdate(c, true, false)
-	if err != nil {
-		grip.Debug(err)
-	}
-	if update.needsUpdate {
-		if runtime.GOOS == "windows" {
-			fmt.Fprintf(os.Stderr, "A new version is available. Run '%s get-update' to fetch it.\n", os.Args[0])
-		} else {
-			fmt.Fprintf(os.Stderr, "A new version is available. Run '%s get-update --install' to download and install it.\n", os.Args[0])
+	if checkForUpdate {
+		update, err := checkUpdate(c, true, false)
+		if err != nil {
+			grip.Debug(err)
+		}
+		if update.needsUpdate {
+			if runtime.GOOS == "windows" {
+				fmt.Fprintf(os.Stderr, "A new version is available. Run '%s get-update' to fetch it.\n", os.Args[0])
+			} else {
+				fmt.Fprintf(os.Stderr, "A new version is available. Run '%s get-update --install' to download and install it.\n", os.Args[0])
+			}
 		}
 	}
 }

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -308,7 +308,7 @@ func (p *patchParams) loadAlias(conf *ClientSettings) error {
 				p.Alias, p.Project), false) {
 			conf.SetDefaultAlias(p.Project, p.Alias)
 			if err := conf.Write(""); err != nil {
-				return err
+				return errors.Wrap(err, "error setting default alias")
 			}
 		}
 	} else if len(p.Variants) == 0 || len(p.Tasks) == 0 {
@@ -327,7 +327,7 @@ func (p *patchParams) loadVariants(conf *ClientSettings) error {
 				p.Variants, p.Project), false) {
 			conf.SetDefaultVariants(p.Project, p.Variants...)
 			if err := conf.Write(""); err != nil {
-				return err
+				return errors.Wrap(err, "error setting default variants")
 			}
 		}
 	} else if p.Alias == "" {
@@ -353,7 +353,7 @@ func (p *patchParams) loadTriggerAliases(conf *ClientSettings) error {
 				p.TriggerAliases, p.Project), false) {
 			conf.SetDefaultTriggerAliases(p.Project, p.TriggerAliases)
 			if err := conf.Write(""); err != nil {
-				return err
+				return errors.Wrap(err, "error setting default trigger aliases")
 			}
 		}
 	} else {
@@ -370,7 +370,7 @@ func (p *patchParams) loadTasks(conf *ClientSettings) error {
 				p.Tasks, p.Project), false) {
 			conf.SetDefaultTasks(p.Project, p.Tasks...)
 			if err := conf.Write(""); err != nil {
-				return err
+				return errors.Wrap(err, "error setting default tasks")
 			}
 		}
 	} else if p.Alias == "" {

--- a/operations/update.go
+++ b/operations/update.go
@@ -25,7 +25,7 @@ import (
 func Update() cli.Command {
 	const installFlagName = "install"
 	const forceFlagName = "force"
-	const autoUpgradeFlagName = "auto_update"
+	const autoUpgradeFlagName = "auto"
 
 	return cli.Command{
 		Name:    "get-update",
@@ -41,7 +41,7 @@ func Update() cli.Command {
 				Usage: "download a new CLI even if the current CLI is not out of date",
 			},
 			cli.BoolFlag{
-				Name:  joinFlagNames(autoUpgradeFlagName, "a"),
+				Name:  joinFlagNames(autoUpgradeFlagName),
 				Usage: "setup automatic installations of a new CLI if the current CLI is out of date",
 			},
 		},
@@ -60,7 +60,7 @@ func Update() cli.Command {
 				return errors.Wrap(err, "problem loading configuration")
 			}
 			if !conf.AutoUpgradeCLI && !autoUpgrade {
-				fmt.Printf("Automatic CLI upgrades are not set up, specifying the -%s (-a for short) flag will enable automatic CLI upgrades before each command if the current CLI is out of date.", autoUpgradeFlagName)
+				fmt.Printf("Automatic CLI upgrades are not set up; specifying the -%s flag will enable automatic CLI upgrades before each command if the current CLI is out of date.", autoUpgradeFlagName)
 			}
 			if conf.AutoUpgradeCLI && autoUpgrade {
 				fmt.Printf("Automatic CLI upgrades are already set up, specifying the %s flag is not necessary.", autoUpgradeFlagName)
@@ -77,10 +77,10 @@ func Update() cli.Command {
 	}
 }
 
-// CheckAndUpdateVersion checks if the CLI is up to date, if there is no new CLI version it will simply notify that the current binary is up to date.
+// CheckAndUpdateVersion checks if the CLI is up to date. If there is no new CLI version it will simply notify that the current binary is up to date.
 // If there is a new version available, it will be downloaded, and if doInstall is set the new binary will automatically be replaced at the current path the old binary existed in.
 // Otherwise, it will simply be downloaded and a suggested 'mv' command will be printed so the user can replace the binary at their discretion.
-// Toggling forceUpdate will download a new CLI even if the current CLI is not out of date.
+// Toggling forceUpdate will download a new CLI even if the current CLI does not have an out-of-date CLI version string.
 func CheckAndUpdateVersion(conf *ClientSettings, ctx context.Context, doInstall bool, forceUpdate bool, silent bool) error {
 	client := conf.getRestCommunicator(ctx)
 	defer client.Close()

--- a/operations/update.go
+++ b/operations/update.go
@@ -41,7 +41,7 @@ func Update() cli.Command {
 				Usage: "download a new CLI even if the current CLI is not out of date",
 			},
 			cli.BoolFlag{
-				Name:  joinFlagNames(autoUpgradeFlagName),
+				Name:  autoUpgradeFlagName,
 				Usage: "setup automatic installations of a new CLI if the current CLI is out of date",
 			},
 		},
@@ -60,10 +60,10 @@ func Update() cli.Command {
 				return errors.Wrap(err, "problem loading configuration")
 			}
 			if !conf.AutoUpgradeCLI && !autoUpgrade {
-				fmt.Printf("Automatic CLI upgrades are not set up; specifying the -%s flag will enable automatic CLI upgrades before each command if the current CLI is out of date.", autoUpgradeFlagName)
+				fmt.Println(fmt.Sprintf("Automatic CLI upgrades are not set up; specifying the -%s flag will enable automatic CLI upgrades before each command if the current CLI is out of date.", autoUpgradeFlagName))
 			}
 			if conf.AutoUpgradeCLI && autoUpgrade {
-				fmt.Printf("Automatic CLI upgrades are already set up, specifying the %s flag is not necessary.", autoUpgradeFlagName)
+				fmt.Println(fmt.Sprintf("Automatic CLI upgrades are already set up, specifying the %s flag is not necessary.", autoUpgradeFlagName))
 			}
 			if !conf.AutoUpgradeCLI && autoUpgrade {
 				conf.SetAutoUpgradeCLI()


### PR DESCRIPTION
[EVG-6496](https://jira.mongodb.org/browse/EVG-6496)

### Description 
New property has been added in client settings to optionally automatically update the evergreen CLI before any command is run.

### Testing 
Built CLI locally with new client settings to auto update and tested manually.