### PR TITLE
EVG-16315 Fix build variants logging as pushing when being skipped

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2022-01-27"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-02-10"
+	AgentVersion = "2022-02-14"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-16315](https://jira.mongodb.org/browse/EVG-16315)

### Description 
Because we logged a push event before checking if the build variant will run, in the case where a build variant was skipped, by the time it got to the build variant that was truly trying to push the file, it would no-op, because the db thought that the task already pushed. 

### Testing 
None right now, but will coordinate with the right people to get this tested once it's deployed. 
