### PR TITLE
EVG-16167: create pod group dispatch queue data model

### DIFF
--- a/model/pod/dispatcher/doc.go
+++ b/model/pod/dispatcher/doc.go
@@ -1,0 +1,3 @@
+// Package dispatcher models a queue of tasks that are dispatched to a group of
+// pods.
+package dispatcher

--- a/model/pod/dispatcher/queue.go
+++ b/model/pod/dispatcher/queue.go
@@ -1,0 +1,15 @@
+package dispatcher
+
+// PodDispatcher represents a queue of tasks that are dispatched to a set of
+// pods that can run those tasks.
+type PodDispatcher struct {
+	// ID is the unique identifier for this dispatch queue.
+	ID string `bson:"_id" json:"id"`
+	// GroupID is the unique identifier for the set of tasks that should run in
+	// this dispatch queue.
+	GroupID string `bson:"group_id" json:"group_id"`
+	// PodIDs are the identifiers for the pods that run the tasks.
+	PodIDs []string `bson:"pod_ids" json:"pod_ids"`
+	// Tasks is the queue of tasks to run.
+	Tasks []string `bson:"tasks" json:"tasks"`
+}

--- a/model/pod/doc.go
+++ b/model/pod/doc.go
@@ -1,0 +1,3 @@
+// Package pod models a single pod (a group of containers), which can run
+// container tasks.
+package pod


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16167

### Description 
* Add the data model representing the dispatcher that decides which task/task group runs on a particular set of pods.
* Add package documentation.

### Testing 
N/A