### PR TITLE
EVG-16318 Update task activatedBy at task creation

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1297,6 +1297,8 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 	}
 	if isStepback {
 		t.ActivatedBy = evergreen.StepbackTaskActivator
+	} else if t.Activated {
+		t.ActivatedBy = v.Author
 	}
 	if buildVarTask.IsGroup {
 		tg := project.FindTaskGroup(buildVarTask.GroupName)


### PR DESCRIPTION
[EVG-16318](https://jira.mongodb.org/browse/EVG-16318)

### Description 
activatedBy was empty at task creation unless it was a stepback task 
now it will be populated 

### Testing 
started a task on staging 

https://evergreen-staging.corp.mongodb.com/rest/v2/tasks/sandbox_ubuntu1604_bynntask_patch_82cbc667ad4bc2f073b2e43e138b039f792cdc6b_620ab1cdb2373605bcc860e1_22_02_14_19_47_30?execution=0

