### PR TITLE
EVG-16275 Update agent to handle admin vars

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -90,7 +90,6 @@ type GetNextTaskDetails struct {
 type ExpansionVars struct {
 	Vars           map[string]string `json:"vars"`
 	RestrictedVars map[string]string `json:"restricted_vars"`
-	AdminOnlyVars  map[string]string `json:"admin_only_vars"`
 	PrivateVars    map[string]bool   `json:"private_vars"`
 }
 

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -216,11 +216,23 @@ func (projectVars *ProjectVars) GetRestrictedVars() map[string]string {
 	return restrictedVars
 }
 
+func (projectVars *ProjectVars) GetAdminOnlyVars() map[string]string {
+	adminOnlyVars := map[string]string{}
+
+	for k, v := range projectVars.Vars {
+		if projectVars.AdminOnlyVars[k] {
+			adminOnlyVars[k] = v
+		}
+	}
+	return adminOnlyVars
+}
+
+// Returns non-restricted and non-admin only vars for now.
 func (projectVars *ProjectVars) GetUnrestrictedVars() map[string]string {
 	safeVars := map[string]string{}
 
 	for k, v := range projectVars.Vars {
-		if !projectVars.RestrictedVars[k] {
+		if !projectVars.RestrictedVars[k] && !projectVars.AdminOnlyVars[k] {
 			safeVars[k] = v
 		}
 	}


### PR DESCRIPTION
[EVG-16275](https://jira.mongodb.org/browse/EVG-16275)

### Description 
update fetch expansions for task by only populating vars with admin only vars if user has admin access 

### Testing 
execution 1 and 2 were done by someone without admin access and doesnt print the admin var
i restarted execution 3 and it printed the expansion 

https://spruce-staging.corp.mongodb.com/version/620ad57eb237361682a73cc7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC