### PR TITLE
EVG-16066: remove spawn host modification fallback

### DIFF
--- a/units/spawnhost_modify.go
+++ b/units/spawnhost_modify.go
@@ -66,8 +66,6 @@ func init() {
 }
 
 type spawnhostModifyJob struct {
-	// TODO (EVG-16066): remove HostID.
-	HostID                string                 `bson:"host_id" json:"host_id" yaml:"host_id"`
 	ModifyOptions         host.HostModifyOptions `bson:"modify_options" json:"modify_options" yaml:"modify_options"`
 	CloudHostModification `bson:"cloud_host_modification" json:"cloud_host_modification" yaml:"cloud_host_modification"`
 	job.Base              `bson:"job_base" json:"job_base" yaml:"job_base"`
@@ -97,14 +95,6 @@ func NewSpawnhostModifyJob(h *host.Host, changes host.HostModifyOptions, ts stri
 
 func (j *spawnhostModifyJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
-
-	// Setting the base field is for temporary backward compatibility with
-	// pending jobs already stored in the DB.
-	// TODO (EVG-16066): remove this check once all old versions of the job are
-	// complete.
-	if j.HostID != "" {
-		j.CloudHostModification.HostID = j.HostID
-	}
 
 	modifyCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.ModifyHost(ctx, h, j.ModifyOptions); err != nil {

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -24,10 +24,6 @@ func init() {
 }
 
 type spawnhostStartJob struct {
-	// TODO (EVG-16066): remove HostID and UserID since they are no longer
-	// necessary, except for temporary backward compatibility.
-	HostID                string `bson:"host_id" json:"host_id" yaml:"host_id"`
-	UserID                string `bson:"user_id" json:"user_id" yaml:"user_id"`
 	CloudHostModification `bson:"cloud_host_modification" json:"cloud_host_modification" yaml:"cloud_host_modification"`
 	job.Base              `bson:"job_base" json:"job_base" yaml:"job_base"`
 
@@ -60,17 +56,6 @@ func NewSpawnhostStartJob(h *host.Host, user, ts string) amboy.Job {
 
 func (j *spawnhostStartJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
-
-	// Setting the base fields are for temporary backward compatibility with
-	// pending jobs already stored in the DB.
-	// TODO (EVG-16066): remove this check once all old versions of the job are
-	// complete.
-	if j.HostID != "" {
-		j.CloudHostModification.HostID = j.HostID
-	}
-	if j.UserID != "" {
-		j.CloudHostModification.UserID = j.UserID
-	}
 
 	startCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.StartInstance(ctx, h, user); err != nil {

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -24,10 +24,6 @@ func init() {
 }
 
 type spawnhostStopJob struct {
-	// TODO (EVG-16066): remove HostID and UserID since they are no longer
-	// necessary, except for temporary backward compatibility.
-	HostID                string `bson:"host_id" json:"host_id" yaml:"host_id"`
-	UserID                string `bson:"user_id" json:"user_id" yaml:"user_id"`
 	CloudHostModification `bson:"cloud_host_modification" json:"cloud_host_modification" yaml:"cloud_host_modification"`
 	job.Base              `bson:"job_base" json:"job_base" yaml:"job_base"`
 
@@ -60,17 +56,6 @@ func NewSpawnhostStopJob(h *host.Host, user, ts string) amboy.Job {
 
 func (j *spawnhostStopJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
-
-	// Setting the base fields are for temporary backward compatibility with
-	// pending jobs already stored in the DB.
-	// TODO (EVG-16066): remove this check once all old versions of the job are
-	// complete.
-	if j.HostID != "" {
-		j.CloudHostModification.HostID = j.HostID
-	}
-	if j.UserID != "" {
-		j.CloudHostModification.UserID = j.UserID
-	}
 
 	stopCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.StopInstance(ctx, h, user); err != nil {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16066

### Description 
Remove unneeded fallback fields for spawn host modification jobs. They should not be necessary since the actual change (#5382) is now deployed.

### Testing 
N/A