### PR TITLE
EVG-16095 Ignore all filter for statuses

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -291,22 +291,6 @@ var TaskStatuses = []string{
 	TaskTimedOut,
 }
 
-// FilterValidTaskStatuses returns a slice of task statuses that are valid and are searchable.
-// It returns an empty array if emptyArrayForAll is true
-func FilterValidTaskStatuses(statuses []string, emptyArrayForAll bool) []string {
-	var filteredStatuses []string
-	if emptyArrayForAll && utility.StringSliceContains(statuses, TaskAll) {
-		return []string{}
-	}
-	for _, status := range statuses {
-		if !utility.StringSliceContains(TaskStatuses, status) {
-			continue
-		}
-		filteredStatuses = append(filteredStatuses, status)
-	}
-	return filteredStatuses
-}
-
 var InternalAliases = []string{
 	CommitQueueAlias,
 	GithubPRAlias,

--- a/globals.go
+++ b/globals.go
@@ -88,6 +88,9 @@ const (
 	// This is not an official task status; it is used by the front end to indicate that there is a linked issue in the annotation
 	TaskKnownIssue = "known-issue"
 
+	// This is not an official task status; it is used by the front end to indicate that the filter should apply to all of the tasks
+	TaskAll = "all"
+
 	// Task Command Types
 	CommandTypeTest   = "test"
 	CommandTypeSystem = "system"
@@ -271,6 +274,38 @@ const (
 	KeyTooLargeToIndexError    = "key too large to index"
 	InvalidDivideInputError    = "$divide only supports numeric types"
 )
+
+var TaskStatuses = []string{
+	TaskStarted,
+	TaskSucceeded,
+	TaskFailed,
+	TaskSystemFailed,
+	TaskTestTimedOut,
+	TaskSetupFailed,
+	TaskAborted,
+	TaskStatusBlocked,
+	TaskStatusPending,
+	TaskKnownIssue,
+	TaskSystemUnresponse,
+	TaskSystemTimedOut,
+	TaskTimedOut,
+}
+
+// FilterValidTaskStatuses returns a slice of task statuses that are valid and are searchable.
+// It returns an empty array if emptyArrayForAll is true
+func FilterValidTaskStatuses(statuses []string, emptyArrayForAll bool) []string {
+	var filteredStatuses []string
+	if emptyArrayForAll && utility.StringSliceContains(statuses, TaskAll) {
+		return []string{}
+	}
+	for _, status := range statuses {
+		if !utility.StringSliceContains(TaskStatuses, status) {
+			continue
+		}
+		filteredStatuses = append(filteredStatuses, status)
+	}
+	return filteredStatuses
+}
 
 var InternalAliases = []string{
 	CommitQueueAlias,

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1671,8 +1671,8 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sorts []
 	}
 
 	opts := data.TaskFilterOptions{
-		Statuses:               statuses,
-		BaseStatuses:           baseStatuses,
+		Statuses:               evergreen.FilterValidTaskStatuses(statuses, true),
+		BaseStatuses:           evergreen.FilterValidTaskStatuses(baseStatuses, true),
 		Variants:               []string{variantParam},
 		TaskNames:              []string{taskNameParam},
 		Page:                   pageParam,
@@ -3763,7 +3763,7 @@ func (r *versionResolver) TaskStatusCounts(ctx context.Context, v *restModel.API
 		IncludeExecutionTasks: false,
 		TaskNames:             options.Tasks,
 		Variants:              options.Variants,
-		Statuses:              options.Statuses,
+		Statuses:              evergreen.FilterValidTaskStatuses(options.Statuses, true),
 	}
 	stats, err := task.GetTaskStatsByVersion(*v.Id, opts)
 	if err != nil {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1671,8 +1671,8 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sorts []
 	}
 
 	opts := data.TaskFilterOptions{
-		Statuses:               evergreen.FilterValidTaskStatuses(statuses, true),
-		BaseStatuses:           evergreen.FilterValidTaskStatuses(baseStatuses, true),
+		Statuses:               getValidTaskStatusesFilter(statuses),
+		BaseStatuses:           getValidTaskStatusesFilter(baseStatuses),
 		Variants:               []string{variantParam},
 		TaskNames:              []string{taskNameParam},
 		Page:                   pageParam,
@@ -3632,7 +3632,7 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 			opts := task.HasMatchingTasksOptions{
 				TaskNames: buildVariantOptions.Tasks,
 				Variants:  buildVariantOptions.Variants,
-				Statuses:  buildVariantOptions.Statuses,
+				Statuses:  getValidTaskStatusesFilter(buildVariantOptions.Statuses),
 			}
 			hasTasks, err := task.HasMatchingTasks(v.Id, opts)
 			if err != nil {
@@ -3763,7 +3763,7 @@ func (r *versionResolver) TaskStatusCounts(ctx context.Context, v *restModel.API
 		IncludeExecutionTasks: false,
 		TaskNames:             options.Tasks,
 		Variants:              options.Variants,
-		Statuses:              evergreen.FilterValidTaskStatuses(options.Statuses, true),
+		Statuses:              getValidTaskStatusesFilter(options.Statuses),
 	}
 	stats, err := task.GetTaskStatsByVersion(*v.Id, opts)
 	if err != nil {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -483,7 +483,7 @@ func generateBuildVariants(sc data.Connector, versionId string, searchVariants [
 		{Key: task.DisplayNameKey, Order: 1},
 	}
 	opts := data.TaskFilterOptions{
-		Statuses:         statuses,
+		Statuses:         evergreen.FilterValidTaskStatuses(statuses, true),
 		Variants:         searchVariants,
 		TaskNames:        searchTasks,
 		Sorts:            defaultSort,

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1415,11 +1415,5 @@ func getValidTaskStatusesFilter(statuses []string) []string {
 		return filteredStatuses
 	}
 	filteredStatuses = utility.StringSliceIntersection(evergreen.TaskStatuses, statuses)
-	for _, status := range statuses {
-		if !utility.StringSliceContains(evergreen.TaskStatuses, status) {
-			continue
-		}
-		filteredStatuses = append(filteredStatuses, status)
-	}
 	return filteredStatuses
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3131,7 +3131,7 @@ func HasMatchingTasks(versionID string, opts HasMatchingTasksOptions) (bool, err
 	options := GetTasksByVersionOptions{
 		TaskNames: opts.TaskNames,
 		Variants:  opts.Variants,
-		Statuses:  evergreen.FilterValidTaskStatuses(opts.Statuses, true),
+		Statuses:  opts.Statuses,
 	}
 	pipeline := getTasksByVersionPipeline(versionID, options)
 	pipeline = append(pipeline, bson.M{"$count": "count"})

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3357,14 +3357,12 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 		})
 	}
 
-	if opts.IncludeBaseTasks {
-		if len(opts.BaseStatuses) > 0 {
-			pipeline = append(pipeline, bson.M{
-				"$match": bson.M{
-					BaseTaskStatusKey: bson.M{"$in": opts.BaseStatuses},
-				},
-			})
-		}
+	if opts.IncludeBaseTasks && len(opts.BaseStatuses) > 0 {
+		pipeline = append(pipeline, bson.M{
+			"$match": bson.M{
+				BaseTaskStatusKey: bson.M{"$in": opts.BaseStatuses},
+			},
+		})
 	}
 
 	return pipeline

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2989,17 +2989,6 @@ func GetTasksByVersion(versionID string, opts GetTasksByVersionOptions) ([]Task,
 
 	pipeline := getTasksByVersionPipeline(versionID, opts)
 
-	if len(opts.BaseStatuses) > 0 {
-		// If we are filtering for all statuses it is more performant to not include the status filter
-		if !utility.StringSliceContains(opts.BaseStatuses, "all") {
-			pipeline = append(pipeline, bson.M{
-				"$match": bson.M{
-					BaseTaskStatusKey: bson.M{"$in": opts.BaseStatuses},
-				},
-			})
-		}
-	}
-
 	if len(opts.Sorts) > 0 {
 		sortPipeline := []bson.M{}
 
@@ -3319,6 +3308,16 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 		addDisplayStatus,
 	)
 	if opts.IncludeBaseTasks {
+		if len(opts.BaseStatuses) > 0 {
+			// If we are filtering for all statuses it is more performant to not include the status filter
+			if !utility.StringSliceContains(opts.BaseStatuses, "all") {
+				pipeline = append(pipeline, bson.M{
+					"$match": bson.M{
+						BaseTaskStatusKey: bson.M{"$in": opts.BaseStatuses},
+					},
+				})
+			}
+		}
 		pipeline = append(pipeline, []bson.M{
 			// Add data about the base task
 			{"$lookup": bson.M{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3308,16 +3308,6 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 		addDisplayStatus,
 	)
 	if opts.IncludeBaseTasks {
-		if len(opts.BaseStatuses) > 0 {
-			// If we are filtering for all statuses it is more performant to not include the status filter
-			if !utility.StringSliceContains(opts.BaseStatuses, "all") {
-				pipeline = append(pipeline, bson.M{
-					"$match": bson.M{
-						BaseTaskStatusKey: bson.M{"$in": opts.BaseStatuses},
-					},
-				})
-			}
-		}
 		pipeline = append(pipeline, []bson.M{
 			// Add data about the base task
 			{"$lookup": bson.M{
@@ -3367,6 +3357,19 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 					DisplayStatusKey: bson.M{"$in": opts.Statuses},
 				},
 			})
+		}
+	}
+
+	if opts.IncludeBaseTasks {
+		if len(opts.BaseStatuses) > 0 {
+			// If we are filtering for all statuses it is more performant to not include the status filter
+			if !utility.StringSliceContains(opts.BaseStatuses, "all") {
+				pipeline = append(pipeline, bson.M{
+					"$match": bson.M{
+						BaseTaskStatusKey: bson.M{"$in": opts.BaseStatuses},
+					},
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
[EVG-16095](https://jira.mongodb.org/browse/EVG-16095)

### Description 
If a user includes "all" in a task filter they want all of the matching task statuses so we should ignore that field in the `$match` stage of the pipeline since we don't want to filter anything out. 