### PR TITLE
Revert "EVG-16157: 6 months TTL on test_results"

### DIFF
--- a/units/data_cleanup_testresults.go
+++ b/units/data_cleanup_testresults.go
@@ -82,7 +82,7 @@ func (j *dataCleanupTestResults) Run(ctx context.Context) {
 	)
 
 	totalDocs, _ := j.env.DB().Collection(testresult.Collection).EstimatedDocumentCount(ctx)
-	timestamp := time.Now().Add(time.Duration(-182*24) * time.Hour)
+	timestamp := time.Now().Add(time.Duration(-365*24) * time.Hour)
 
 LOOP:
 	for {


### PR DESCRIPTION
Reverts evergreen-ci/evergreen#5320 due to poor naming