### PR TITLE
EVG-16194 add resolver for conflicting refs

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -260,6 +260,8 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.APINotificationPreferences
   GithubUserInput:
     model: github.com/evergreen-ci/evergreen/rest/model.APIGithubUser
+  GithubProjectConflicts:
+    model: github.com/evergreen-ci/evergreen/model.GithubProjectConflicts
   ClientConfig:
     model: github.com/evergreen-ci/evergreen/rest/model.APIClientConfig
   ClientBinary:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -236,6 +236,12 @@ type ComplexityRoot struct {
 		Repo     func(childComplexity int) int
 	}
 
+	GithubProjectConflicts struct {
+		CommitCheckIdentifiers func(childComplexity int) int
+		CommitQueueIdentifiers func(childComplexity int) int
+		PRTestingIdentifiers   func(childComplexity int) int
+	}
+
 	GithubUser struct {
 		LastKnownAs func(childComplexity int) int
 		UID         func(childComplexity int) int
@@ -683,6 +689,7 @@ type ComplexityRoot struct {
 		CommitQueue              func(childComplexity int, id string) int
 		DistroTaskQueue          func(childComplexity int, distroID string) int
 		Distros                  func(childComplexity int, onlySpawnable bool) int
+		GithubProjectConflicts   func(childComplexity int, projectID string) int
 		HasVersion               func(childComplexity int, id string) int
 		Host                     func(childComplexity int, hostID string) int
 		HostEvents               func(childComplexity int, hostID string, hostTag *string, limit *int, page *int) int
@@ -1312,6 +1319,7 @@ type QueryResolver interface {
 	Version(ctx context.Context, id string) (*model.APIVersion, error)
 	Projects(ctx context.Context) ([]*GroupedProjects, error)
 	ViewableProjectRefs(ctx context.Context) ([]*GroupedProjects, error)
+	GithubProjectConflicts(ctx context.Context, projectID string) (*model1.GithubProjectConflicts, error)
 	Project(ctx context.Context, projectID string) (*model.APIProjectRef, error)
 	PatchTasks(ctx context.Context, patchID string, sorts []*SortOrder, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string, includeEmptyActivation *bool) (*PatchTasks, error)
 	TaskTests(ctx context.Context, taskID string, execution *int, sortCategory *TestSortCategory, sortDirection *SortDirection, page *int, limit *int, testName *string, statuses []string, groupID *string) (*TaskTestResult, error)
@@ -2117,6 +2125,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GithubPRSubscriber.Repo(childComplexity), true
+
+	case "GithubProjectConflicts.commitCheckIdentifiers":
+		if e.complexity.GithubProjectConflicts.CommitCheckIdentifiers == nil {
+			break
+		}
+
+		return e.complexity.GithubProjectConflicts.CommitCheckIdentifiers(childComplexity), true
+
+	case "GithubProjectConflicts.commitQueueIdentifiers":
+		if e.complexity.GithubProjectConflicts.CommitQueueIdentifiers == nil {
+			break
+		}
+
+		return e.complexity.GithubProjectConflicts.CommitQueueIdentifiers(childComplexity), true
+
+	case "GithubProjectConflicts.prTestingIdentifiers":
+		if e.complexity.GithubProjectConflicts.PRTestingIdentifiers == nil {
+			break
+		}
+
+		return e.complexity.GithubProjectConflicts.PRTestingIdentifiers(childComplexity), true
 
 	case "GithubUser.lastKnownAs":
 		if e.complexity.GithubUser.LastKnownAs == nil {
@@ -4543,6 +4572,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Distros(childComplexity, args["onlySpawnable"].(bool)), true
+
+	case "Query.githubProjectConflicts":
+		if e.complexity.Query.GithubProjectConflicts == nil {
+			break
+		}
+
+		args, err := ec.field_Query_githubProjectConflicts_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.GithubProjectConflicts(childComplexity, args["projectId"].(string)), true
 
 	case "Query.hasVersion":
 		if e.complexity.Query.HasVersion == nil {
@@ -7347,6 +7388,7 @@ type Query {
   version(id: String!): Version!
   projects: [GroupedProjects]!
   viewableProjectRefs: [GroupedProjects]!
+  githubProjectConflicts(projectId: String!): GithubProjectConflicts!
   project(projectId: String!): Project!
   patchTasks(
     patchId: String!
@@ -8452,6 +8494,12 @@ type GroupedProjects {
   name: String! @deprecated(reason: "name is deprecated. Use groupDisplayName instead.")
   repo: RepoRef
   projects: [Project!]!
+}
+
+type GithubProjectConflicts {
+  commitQueueIdentifiers: [String!]
+  prTestingIdentifiers: [String!]
+  commitCheckIdentifiers: [String!]
 }
 
 type ProjectSettings {
@@ -10207,6 +10255,21 @@ func (ec *executionContext) field_Query_distros_args(ctx context.Context, rawArg
 		}
 	}
 	args["onlySpawnable"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_githubProjectConflicts_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["projectId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectId"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["projectId"] = arg0
 	return args, nil
 }
 
@@ -14140,6 +14203,102 @@ func (ec *executionContext) _GithubPRSubscriber_prNumber(ctx context.Context, fi
 	res := resTmp.(int)
 	fc.Result = res
 	return ec.marshalOInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GithubProjectConflicts_commitQueueIdentifiers(ctx context.Context, field graphql.CollectedField, obj *model1.GithubProjectConflicts) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "GithubProjectConflicts",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CommitQueueIdentifiers, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GithubProjectConflicts_prTestingIdentifiers(ctx context.Context, field graphql.CollectedField, obj *model1.GithubProjectConflicts) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "GithubProjectConflicts",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PRTestingIdentifiers, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GithubProjectConflicts_commitCheckIdentifiers(ctx context.Context, field graphql.CollectedField, obj *model1.GithubProjectConflicts) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "GithubProjectConflicts",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CommitCheckIdentifiers, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _GithubUser_uid(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubUser) (ret graphql.Marshaler) {
@@ -24924,6 +25083,48 @@ func (ec *executionContext) _Query_viewableProjectRefs(ctx context.Context, fiel
 	res := resTmp.([]*GroupedProjects)
 	fc.Result = res
 	return ec.marshalNGroupedProjects2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedProjects(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_githubProjectConflicts(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_githubProjectConflicts_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().GithubProjectConflicts(rctx, args["projectId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model1.GithubProjectConflicts)
+	fc.Result = res
+	return ec.marshalNGithubProjectConflicts2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGithubProjectConflicts(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_project(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -42706,6 +42907,34 @@ func (ec *executionContext) _GithubPRSubscriber(ctx context.Context, sel ast.Sel
 	return out
 }
 
+var githubProjectConflictsImplementors = []string{"GithubProjectConflicts"}
+
+func (ec *executionContext) _GithubProjectConflicts(ctx context.Context, sel ast.SelectionSet, obj *model1.GithubProjectConflicts) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, githubProjectConflictsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GithubProjectConflicts")
+		case "commitQueueIdentifiers":
+			out.Values[i] = ec._GithubProjectConflicts_commitQueueIdentifiers(ctx, field, obj)
+		case "prTestingIdentifiers":
+			out.Values[i] = ec._GithubProjectConflicts_prTestingIdentifiers(ctx, field, obj)
+		case "commitCheckIdentifiers":
+			out.Values[i] = ec._GithubProjectConflicts_commitCheckIdentifiers(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var githubUserImplementors = []string{"GithubUser"}
 
 func (ec *executionContext) _GithubUser(ctx context.Context, sel ast.SelectionSet, obj *model.APIGithubUser) graphql.Marshaler {
@@ -45220,6 +45449,20 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_viewableProjectRefs(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "githubProjectConflicts":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_githubProjectConflicts(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
@@ -49189,6 +49432,20 @@ func (ec *executionContext) marshalNFileDiff2ᚕgithubᚗcomᚋevergreenᚑciᚋ
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalNGithubProjectConflicts2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGithubProjectConflicts(ctx context.Context, sel ast.SelectionSet, v model1.GithubProjectConflicts) graphql.Marshaler {
+	return ec._GithubProjectConflicts(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNGithubProjectConflicts2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGithubProjectConflicts(ctx context.Context, sel ast.SelectionSet, v *model1.GithubProjectConflicts) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._GithubProjectConflicts(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNGroupedBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariantᚄ(ctx context.Context, sel ast.SelectionSet, v []*GroupedBuildVariant) graphql.Marshaler {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1616,7 +1616,6 @@ func (r *queryResolver) Projects(ctx context.Context) ([]*GroupedProjects, error
 func (r *queryResolver) ViewableProjectRefs(ctx context.Context) ([]*GroupedProjects, error) {
 	usr := MustHaveUser(ctx)
 	projectIds, err := usr.GetViewableProjectSettings()
-
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error getting viewable projects for '%s': '%s'", usr.DispName, err.Error()))
 	}
@@ -1631,6 +1630,22 @@ func (r *queryResolver) ViewableProjectRefs(ctx context.Context) ([]*GroupedProj
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error grouping project: %s", err.Error()))
 	}
 	return groupedProjects, nil
+}
+
+func (r *queryResolver) GithubProjectConflicts(ctx context.Context, projectID string) (*model.GithubProjectConflicts, error) {
+	pRef, err := model.FindMergedProjectRef(projectID, "", false)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error getting project: %v", err.Error()))
+	}
+	if pRef == nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("project '%s' not found", projectID))
+	}
+
+	conflicts, err := pRef.GetGithubProjectConflicts()
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error getting project conflicts: %v", err.Error()))
+	}
+	return &conflicts, nil
 }
 
 func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sorts []*SortOrder, page *int, limit *int, statuses []string, baseStatuses []string, variant *string, taskName *string, includeEmptyActivation *bool) (*PatchTasks, error) {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -8,6 +8,7 @@ type Query {
   version(id: String!): Version!
   projects: [GroupedProjects]!
   viewableProjectRefs: [GroupedProjects]!
+  githubProjectConflicts(projectId: String!): GithubProjectConflicts!
   project(projectId: String!): Project!
   patchTasks(
     patchId: String!
@@ -1113,6 +1114,12 @@ type GroupedProjects {
   name: String! @deprecated(reason: "name is deprecated. Use groupDisplayName instead.")
   repo: RepoRef
   projects: [Project!]!
+}
+
+type GithubProjectConflicts {
+  commitQueueIdentifiers: [String!]
+  prTestingIdentifiers: [String!]
+  commitCheckIdentifiers: [String!]
 }
 
 type ProjectSettings {

--- a/graphql/tests/githubProjectConflicts/data.json
+++ b/graphql/tests/githubProjectConflicts/data.json
@@ -1,0 +1,90 @@
+{
+        "project_ref": [
+      {
+        "_id": "mci",
+        "owner_name": "evergreen-ci",
+        "repo_name": "evergreen",
+        "branch_name": "main",
+        "enabled": true,
+        "pr_testing_enabled": false,
+        "commit_queue": {
+          "enabled": false
+        },
+        "github_checks_enabled": true
+      },
+      {
+        "_id": "mci-copy",
+        "identifier": "some-features-enabled",
+        "owner_name": "evergreen-ci",
+        "repo_name": "evergreen",
+        "branch_name": "main",
+        "enabled": true,
+        "pr_testing_enabled": false,
+        "commit_queue": {
+          "enabled": true
+        },
+        "github_checks_enabled": true
+      },
+      {
+        "_id": "not-enabled",
+        "identifier": "not-enabled",
+        "owner_name": "evergreen-ci",
+        "repo_name": "evergreen",
+        "branch_name": "main",
+        "enabled": false,
+        "pr_testing_enabled": true,
+        "commit_queue": {
+          "enabled": true
+        },
+        "github_checks_enabled": true
+      },
+      {
+        "_id": "features-not-enabled",
+        "identifier": "features-not-enabled",
+        "owner_name": "evergreen-ci",
+        "repo_name": "evergreen",
+        "branch_name": "main",
+        "enabled": true,
+        "pr_testing_enabled": false,
+        "commit_queue": {
+          "enabled": false
+        },
+        "github_checks_enabled": false
+      },
+      {
+        "_id": "1234",
+        "identifier": "enabled_on_repo",
+        "owner_name": "evergreen-ci",
+        "repo_name": "evergreen",
+        "branch_name": "",
+        "repo_ref_id": "mci-repo"
+      },
+      {
+        "_id": "wrong-repo",
+        "identifier": "wrong-repo",
+        "owner_name": "evergreen-ci",
+        "repo_name": "logkeeper",
+        "branch_name": "main",
+        "enabled": true,
+        "pr_testing_enabled": true,
+        "commit_queue": {
+          "enabled": true
+        },
+        "github_checks_enabled": true
+      }
+    ],
+    "repo_ref": [
+      {
+        "_id": "mci-repo",
+        "owner_name": "evergreen-ci",
+        "repo_name": "evergreen",
+        "branch_name": "main",
+        "enabled": true,
+        "pr_testing_enabled": true,
+        "commit_queue": {
+          "enabled": true
+        },
+        "github_checks_enabled": true
+      }
+    ]
+}

--- a/graphql/tests/githubProjectConflicts/queries/conflicts.graphql
+++ b/graphql/tests/githubProjectConflicts/queries/conflicts.graphql
@@ -1,0 +1,7 @@
+{
+  githubProjectConflicts(projectId: "mci") {
+      commitQueueIdentifiers
+      prTestingIdentifiers
+      commitCheckIdentifiers
+  }
+}

--- a/graphql/tests/githubProjectConflicts/queries/no-conflicts.graphql
+++ b/graphql/tests/githubProjectConflicts/queries/no-conflicts.graphql
@@ -1,0 +1,7 @@
+{
+    githubProjectConflicts(projectId: "wrong-repo") {
+        commitQueueIdentifiers
+        prTestingIdentifiers
+        commitCheckIdentifiers
+    }
+}

--- a/graphql/tests/githubProjectConflicts/results.json
+++ b/graphql/tests/githubProjectConflicts/results.json
@@ -1,0 +1,27 @@
+{
+  "tests": [{
+    "query_file": "conflicts.graphql",
+    "result": {
+      "data": {
+        "githubProjectConflicts": {
+          "commitQueueIdentifiers": ["some-features-enabled", "enabled_on_repo"],
+          "prTestingIdentifiers": ["enabled_on_repo"],
+          "commitCheckIdentifiers": ["some-features-enabled", "enabled_on_repo"]
+        }
+      }
+    }
+  },
+  {
+    "query_file": "no-conflicts.graphql",
+    "result": {
+      "data": {
+        "githubProjectConflicts": {
+          "commitQueueIdentifiers": null,
+          "prTestingIdentifiers": null,
+          "commitCheckIdentifiers": null
+        }
+      }
+    }
+  }
+  ]
+}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1576,7 +1576,7 @@ func (projectRef *ProjectRef) CanEnableCommitQueue() (bool, error) {
 	if err != nil {
 		return false, errors.Wrapf(err, "database error finding github conflicts")
 	}
-	if len(conflicts.PRTestingIdentifiers) > 0 {
+	if len(conflicts.CommitQueueIdentifiers) > 0 {
 		return false, nil
 	}
 	return true, nil

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -184,6 +184,12 @@ type WorkstationSetupCommand struct {
 	Directory string `bson:"directory" json:"directory" yaml:"directory"`
 }
 
+type GithubProjectConflicts struct {
+	CommitQueueIdentifiers []string
+	PRTestingIdentifiers   []string
+	CommitCheckIdentifiers []string
+}
+
 func (a AlertConfig) GetSettingsMap() map[string]string {
 	ret := make(map[string]string)
 	for k, v := range a.Settings {
@@ -1141,12 +1147,24 @@ func byOwnerAndRepo(owner, repoName string) bson.M {
 		ProjectRefRepoKey:  repoName,
 	}
 }
-func byOwnerRepoAndBranch(owner, repoName, branch string) bson.M {
-	return bson.M{
-		ProjectRefOwnerKey:  owner,
-		ProjectRefRepoKey:   repoName,
-		ProjectRefBranchKey: branch,
+
+// byOwnerRepoAndBranch excepts an owner, repoName, and branch.
+// If includeUndefinedBranches is set, also returns projects with an empty branch, so this can
+// be populated by the repo elsewhere.
+func byOwnerRepoAndBranch(owner, repoName, branch string, includeUndefinedBranches bool) bson.M {
+	q := bson.M{
+		ProjectRefOwnerKey: owner,
+		ProjectRefRepoKey:  repoName,
 	}
+	if includeUndefinedBranches {
+		q["$or"] = []bson.M{
+			{ProjectRefBranchKey: ""},
+			{ProjectRefBranchKey: branch},
+		}
+	} else {
+		q[ProjectRefBranchKey] = branch
+	}
+	return q
 }
 
 func byId(identifier string) db.Q {
@@ -1163,14 +1181,17 @@ func byId(identifier string) db.Q {
 func FindMergedEnabledProjectRefsByRepoAndBranch(owner, repoName, branch string) ([]ProjectRef, error) {
 	projectRefs := []ProjectRef{}
 
-	pipeline := []bson.M{{"$match": byOwnerRepoAndBranch(owner, repoName, branch)}}
+	pipeline := []bson.M{{"$match": byOwnerRepoAndBranch(owner, repoName, branch, true)}}
 	pipeline = append(pipeline, projectRefPipelineForValueIsBool(ProjectRefEnabledKey, RepoRefEnabledKey, true)...)
 	err := db.Aggregate(ProjectRefCollection, pipeline, &projectRefs)
 	if err != nil {
 		return nil, err
 	}
-
-	return addLoggerAndRepoSettingsToProjects(projectRefs)
+	mergedProjects, err := addLoggerAndRepoSettingsToProjects(projectRefs)
+	if err != nil {
+		return nil, err
+	}
+	return filterProjectsByBranch(mergedProjects, branch), nil
 }
 
 // FindMergedProjectRefsThatUseRepoSettingsByRepoAndBranch finds ProjectRef with matching repo/branch that
@@ -1178,15 +1199,28 @@ func FindMergedEnabledProjectRefsByRepoAndBranch(owner, repoName, branch string)
 func FindMergedProjectRefsThatUseRepoSettingsByRepoAndBranch(owner, repoName, branch string) ([]ProjectRef, error) {
 	projectRefs := []ProjectRef{}
 
-	q := byOwnerRepoAndBranch(owner, repoName, branch)
+	q := byOwnerRepoAndBranch(owner, repoName, branch, true)
 	q[ProjectRefRepoRefIdKey] = bson.M{"$exists": true, "$ne": ""}
 	pipeline := []bson.M{{"$match": q}}
 	err := db.Aggregate(ProjectRefCollection, pipeline, &projectRefs)
 	if err != nil {
 		return nil, err
 	}
+	mergedProjects, err := addLoggerAndRepoSettingsToProjects(projectRefs)
+	if err != nil {
+		return nil, err
+	}
+	return filterProjectsByBranch(mergedProjects, branch), nil
+}
 
-	return addLoggerAndRepoSettingsToProjects(projectRefs)
+func filterProjectsByBranch(pRefs []ProjectRef, branch string) []ProjectRef {
+	res := []ProjectRef{}
+	for _, p := range pRefs {
+		if p.Branch == branch {
+			res = append(res, p)
+		}
+	}
+	return res
 }
 
 func FindBranchAdminsForRepo(repoId string) ([]string, error) {
@@ -1348,7 +1382,8 @@ func FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(owner, repo, branch st
 }
 
 func FindHiddenProjectRefByOwnerRepoAndBranch(owner, repo, branch string) (*ProjectRef, error) {
-	q := byOwnerRepoAndBranch(owner, repo, branch)
+	// don't need to include undefined branches here since hidden projects explicitly define them
+	q := byOwnerRepoAndBranch(owner, repo, branch, false)
 	q[ProjectRefHiddenKey] = true
 
 	return findOneProjectRefQ(db.Query(q))
@@ -1537,11 +1572,11 @@ func FindProjectRefs(key string, limit int, sortDir int) ([]ProjectRef, error) {
 }
 
 func (projectRef *ProjectRef) CanEnableCommitQueue() (bool, error) {
-	resultRef, err := FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(projectRef.Owner, projectRef.Repo, projectRef.Branch)
+	conflicts, err := projectRef.GetGithubProjectConflicts()
 	if err != nil {
-		return false, errors.Wrapf(err, "database error finding project by repo and branch")
+		return false, errors.Wrapf(err, "database error finding github conflicts")
 	}
-	if resultRef != nil && resultRef.Id != projectRef.Id {
+	if len(conflicts.PRTestingIdentifiers) > 0 {
 		return false, nil
 	}
 	return true, nil
@@ -1868,6 +1903,37 @@ func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit) (time.Tim
 		}
 	}
 	return defaultRes, nil
+}
+
+// GetGithubProjectConflicts returns any potential conflicts; i.e. regardless of whether or not p has something enabled,
+// returns the project identifiers that it _would_ conflict with if it did.
+func (p *ProjectRef) GetGithubProjectConflicts() (GithubProjectConflicts, error) {
+	res := GithubProjectConflicts{}
+	// return early for projects that don't need to consider conflicts
+	if p.Owner == "" || p.Repo == "" || p.Branch == "" {
+		return res, nil
+	}
+
+	matchingProjects, err := FindMergedEnabledProjectRefsByRepoAndBranch(p.Owner, p.Repo, p.Branch)
+	if err != nil {
+		return res, errors.Wrap(err, "error getting conflicting projects")
+	}
+
+	for _, conflictingRef := range matchingProjects {
+		if conflictingRef.Id == p.Id {
+			continue
+		}
+		if conflictingRef.IsPRTestingEnabled() {
+			res.PRTestingIdentifiers = append(res.PRTestingIdentifiers, conflictingRef.Identifier)
+		}
+		if conflictingRef.CommitQueue.IsEnabled() {
+			res.CommitQueueIdentifiers = append(res.CommitQueueIdentifiers, conflictingRef.Identifier)
+		}
+		if conflictingRef.IsGithubChecksEnabled() {
+			res.CommitCheckIdentifiers = append(res.CommitCheckIdentifiers, conflictingRef.Identifier)
+		}
+	}
+	return res, nil
 }
 
 func (p *ProjectRef) ValidateOwnerAndRepo(validOrgs []string) error {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -164,14 +164,13 @@ func (pc *DBProjectConnector) EnableWebhooks(ctx context.Context, projectRef *mo
 }
 
 func (pc *DBProjectConnector) EnablePRTesting(projectRef *model.ProjectRef) error {
-	conflictingRefs, err := model.FindMergedEnabledProjectRefsByRepoAndBranch(projectRef.Owner, projectRef.Repo, projectRef.Branch)
+	conflicts, err := projectRef.GetGithubProjectConflicts()
 	if err != nil {
 		return errors.Wrap(err, "error finding project refs")
 	}
-	for _, ref := range conflictingRefs {
-		if ref.IsPRTestingEnabled() && ref.Id != projectRef.Id {
-			return errors.Errorf("Cannot enable PR Testing in this repo, must disable in other projects first")
-		}
+	if len(conflicts.PRTestingIdentifiers) > 0 {
+		return errors.Errorf("Cannot enable PR Testing in this repo, must disable in other projects first")
+
 	}
 	return nil
 }

--- a/service/project.go
+++ b/service/project.go
@@ -166,24 +166,11 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	matchingRefs, err := model.FindMergedEnabledProjectRefsByRepoAndBranch(projRef.Owner, projRef.Repo, projRef.Branch)
+
+	conflicts, err := projRef.GetGithubProjectConflicts()
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
-	}
-	PRConflictingRefs := []string{}
-	CQConflictingRefs := []string{}
-	githubChecksConflictingRefs := []string{}
-	for _, ref := range matchingRefs {
-		if ref.IsPRTestingEnabled() && ref.Id != projRef.Id {
-			PRConflictingRefs = append(PRConflictingRefs, ref.Id)
-		}
-		if ref.CommitQueue.IsEnabled() && ref.Id != projRef.Id {
-			CQConflictingRefs = append(CQConflictingRefs, ref.Id)
-		}
-		if ref.IsGithubChecksEnabled() && ref.Id != projRef.Id {
-			githubChecksConflictingRefs = append(githubChecksConflictingRefs, ref.Id)
-		}
 	}
 	var hook *model.GithubHook
 	hook, err = model.FindGithubHook(projRef.Owner, projRef.Repo)
@@ -225,8 +212,8 @@ func (uis *UIServer) projectPage(w http.ResponseWriter, r *http.Request) {
 		GithubValidOrgs             []string                    `json:"github_valid_orgs"`
 		Subscriptions               []restModel.APISubscription `json:"subscriptions"`
 		Permissions                 gimlet.Permissions          `json:"permissions"`
-	}{projRef, projVars, projectAliases, PRConflictingRefs,
-		CQConflictingRefs, githubChecksConflictingRefs, hook != nil, settings.GithubOrgs, apiSubscriptions, permissions}
+	}{projRef, projVars, projectAliases, conflicts.PRTestingIdentifiers,
+		conflicts.CommitQueueIdentifiers, conflicts.CommitCheckIdentifiers, hook != nil, settings.GithubOrgs, apiSubscriptions, permissions}
 
 	// the project context has all projects so make the ui list using all projects
 	gimlet.WriteJSON(w, data)


### PR DESCRIPTION
[EVG-16194](https://jira.mongodb.org/browse/EVG-16194)

### Description 
Added backend function and resolver to get github conflicts for a project. Used this new function in some existing backend functions. 

Also fixed a bug where we query the ProjectRef collection for branch directly (whereas this can be set from the repo as well).

### Testing 
Added unit tests and ensuring existing tests pass.