### PR TITLE
EVG-14348 case correctly on patch requesters for fetch

### DIFF
--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -164,7 +164,7 @@ func fetchSource(ctx context.Context, ac, rc *legacyClient, comm client.Communic
 
 	cloneDir := util.CleanForPath(fmt.Sprintf("source-%v", task.Project))
 	var patch *service.RestPatch
-	if task.Requester == evergreen.PatchVersionRequester {
+	if evergreen.IsPatchRequester(task.Requester) {
 		cloneDir = util.CleanForPath(fmt.Sprintf("source-patch-%v_%v", task.PatchNumber, task.Project))
 		patch, err = rc.GetRestPatch(task.PatchId)
 		if err != nil {
@@ -414,7 +414,7 @@ type artifactDownload struct {
 }
 
 func getArtifactFolderName(task *service.RestTask) string {
-	if task.Requester == evergreen.PatchVersionRequester {
+	if evergreen.IsPatchRequester(task.Requester) {
 		return fmt.Sprintf("artifacts-patch-%v_%v_%v", task.PatchNumber, task.BuildVariant, task.DisplayName)
 	}
 

--- a/service/task.go
+++ b/service/task.go
@@ -386,7 +386,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	newUILink := ""
-	if len(uis.Settings.Ui.UIv2Url) > 0 && projCtx.Task.Requester == evergreen.PatchVersionRequester {
+	if len(uis.Settings.Ui.UIv2Url) > 0 && evergreen.IsPatchRequester(projCtx.Task.Requester) {
 		newUILink = fmt.Sprintf("%s/task/%s", uis.Settings.Ui.UIv2Url, projCtx.Task.Id)
 	}
 

--- a/service/version.go
+++ b/service/version.go
@@ -221,7 +221,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 	pluginContext := projCtx.ToPluginContext(uis.Settings, currentUser)
 	pluginContent := getPluginDataAndHTML(uis, plugin.VersionPage, pluginContext)
 	newUILink := ""
-	if len(uis.Settings.Ui.UIv2Url) > 0 && projCtx.Version.Requester == evergreen.PatchVersionRequester {
+	if len(uis.Settings.Ui.UIv2Url) > 0 && evergreen.IsPatchRequester(projCtx.Version.Requester) {
 		newUILink = fmt.Sprintf("%s/version/%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id)
 	}
 	uis.render.WriteResponse(w, http.StatusOK, struct {


### PR DESCRIPTION
[EVG-14348](https://jira.mongodb.org/browse/EVG-14348)

### Description 
We were correctly fetching user changes for hosts created from patches but not from pull requests because the requester check was too limited. Also fixed this for some non-fetch occurences.

### Testing 
Created a host before and after changes and verified that the host before didn't have any user changes, and the host after did.
