### PR TITLE
EVG-16176: add method to create new intent pod for tasks

### DIFF
--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -18,7 +18,6 @@ const (
 var (
 	IDKey                        = bsonutil.MustHaveTag(Pod{}, "ID")
 	StatusKey                    = bsonutil.MustHaveTag(Pod{}, "Status")
-	SecretKey                    = bsonutil.MustHaveTag(Pod{}, "Secret")
 	TaskContainerCreationOptsKey = bsonutil.MustHaveTag(Pod{}, "TaskContainerCreationOpts")
 	TimeInfoKey                  = bsonutil.MustHaveTag(Pod{}, "TimeInfo")
 	ResourcesKey                 = bsonutil.MustHaveTag(Pod{}, "Resources")

--- a/model/pod/db_test.go
+++ b/model/pod/db_test.go
@@ -141,20 +141,15 @@ func TestFindOneByID(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T){
 		"Succeeds": func(t *testing.T) {
 			p := Pod{
-				ID: "id",
-				Secret: Secret{
-					Name:   "name",
-					Value:  "value",
-					Exists: utility.FalsePtr(),
-					Owned:  utility.TruePtr(),
-				},
+				ID:     "id",
+				Status: StatusInitializing,
 			}
 			require.NoError(t, p.Insert())
 
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
 			assert.Equal(t, p.ID, dbPod.ID)
-			assert.Equal(t, p.Secret, dbPod.Secret)
+			assert.Equal(t, p.Status, dbPod.Status)
 		},
 		"ReturnsNilWithNonexistentPod": func(t *testing.T) {
 			p, err := FindOneByID("nonexistent")
@@ -177,13 +172,8 @@ func TestFindOneByExternalID(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T){
 		"Succeeds": func(t *testing.T) {
 			p := Pod{
-				ID: "id",
-				Secret: Secret{
-					Name:   "name",
-					Value:  "value",
-					Exists: utility.FalsePtr(),
-					Owned:  utility.TruePtr(),
-				},
+				ID:     "id",
+				Status: StatusStarting,
 				Resources: ResourceInfo{
 					ExternalID: "external_id",
 				},
@@ -193,7 +183,7 @@ func TestFindOneByExternalID(t *testing.T) {
 			dbPod, err := FindOneByExternalID(p.Resources.ExternalID)
 			require.NoError(t, err)
 			assert.Equal(t, p.ID, dbPod.ID)
-			assert.Equal(t, p.Secret, dbPod.Secret)
+			assert.Equal(t, p.Status, dbPod.Status)
 		},
 		"ReturnsNilWithNonexistentPod": func(t *testing.T) {
 			p, err := FindOneByExternalID("nonexistent")

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -6,7 +6,9 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // Pod represents a related collection of containers. This model holds metadata
@@ -18,9 +20,6 @@ type Pod struct {
 	Type Type `bson:"type" json:"type"`
 	// Status is the current state of the pod.
 	Status Status `bson:"status"`
-	// Secret is the shared secret between the server and the pod for
-	// authentication when the host is provisioned.
-	Secret Secret `bson:"secret" json:"secret"`
 	// TaskCreationOpts are options to configure how a task should be
 	// containerized and run in a pod.
 	TaskContainerCreationOpts TaskContainerCreationOptions `bson:"task_creation_opts,omitempty" json:"task_creation_opts,omitempty"`
@@ -30,6 +29,108 @@ type Pod struct {
 	Resources ResourceInfo `bson:"resource_info,omitempty" json:"resource_info,omitempty"`
 	// RunningTask is the ID of the task currently running on the pod.
 	RunningTask string `bson:"running_task,omitempty" json:"running_task,omitempty"`
+}
+
+// TaskIntentPodOptions represents options to create an intent pod that runs
+// container tasks.
+type TaskIntentPodOptions struct {
+	// ID is the pod identifier. If unspecified, it defaults to a new BSON
+	// object ID.
+	ID string
+	// Secret is the shared secret value between the server and the pod for
+	// authentication when the host is provisioned. If unspecified, it defaults
+	// to a random string.
+	Secret string
+
+	// The remaining fields correspond to the ones in
+	// TaskContainerCreationOptions.
+
+	CPU            int
+	MemoryMB       int
+	OS             OS
+	Arch           Arch
+	WindowsVersion WindowsVersion
+	Image          string
+	WorkingDir     string
+	RepoUsername   string
+	RepoPassword   string
+}
+
+// Validate checks that the options to create a task intent pod are valid and
+// sets defaults if possible.
+func (o *TaskIntentPodOptions) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(o.CPU <= 0, "CPU must be a positive non-zero value")
+	catcher.NewWhen(o.MemoryMB <= 0, "memory must be a positive non-zero value")
+	catcher.Wrap(o.OS.Validate(), "invalid OS")
+	catcher.Wrap(o.Arch.Validate(), "invalid arch")
+	if o.OS == OSWindows {
+		catcher.Wrap(o.WindowsVersion.Validate(), "must specify a valid Windows version")
+	}
+	catcher.NewWhen(o.Image == "", "missing image")
+	catcher.NewWhen(o.WorkingDir == "", "missing working directory")
+
+	if catcher.HasErrors() {
+		return catcher.Resolve()
+	}
+
+	if o.ID == "" {
+		o.ID = primitive.NewObjectID().Hex()
+	}
+	if o.Secret == "" {
+		o.Secret = utility.RandomString()
+	}
+
+	return nil
+}
+
+const (
+	// PodIDEnvVar is the name of the environment variable containing the pod
+	// ID.
+	PodIDEnvVar = "POD_ID"
+	// PodIDEnvVar is the name of the environment variable containing the shared
+	// secret between the server and the pod.
+	PodSecretEnvVar = "POD_SECRET"
+)
+
+// NewTaskIntentPod creates a new intent pod to run container tasks from the
+// given initialization options.
+func NewTaskIntentPod(opts TaskIntentPodOptions) (*Pod, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid options")
+	}
+
+	p := Pod{
+		ID:     opts.ID,
+		Status: StatusInitializing,
+		Type:   TypeAgent,
+		TaskContainerCreationOpts: TaskContainerCreationOptions{
+			CPU:            opts.CPU,
+			MemoryMB:       opts.MemoryMB,
+			OS:             opts.OS,
+			Arch:           opts.Arch,
+			WindowsVersion: opts.WindowsVersion,
+			Image:          opts.Image,
+			WorkingDir:     opts.WorkingDir,
+			RepoUsername:   opts.RepoUsername,
+			RepoPassword:   opts.RepoPassword,
+		},
+		TimeInfo: TimeInfo{
+			Initializing: time.Now(),
+		},
+	}
+	p.TaskContainerCreationOpts.EnvVars = map[string]string{
+		PodIDEnvVar: opts.ID,
+	}
+	p.TaskContainerCreationOpts.EnvSecrets = map[string]Secret{
+		PodSecretEnvVar: {
+			Value:  opts.Secret,
+			Exists: utility.FalsePtr(),
+			Owned:  utility.TruePtr(),
+		},
+	}
+
+	return &p, nil
 }
 
 // Type is the type of pod.
@@ -249,7 +350,7 @@ type Secret struct {
 	// Value is the value of the secret. If the secret does not yet exist, it
 	// will be created; otherwise, this is just a cached copy of the actual
 	// value stored in the secrets storage service.
-	Value string `bson:"new_value,omitempty" json:"new_value,omitempty" yaml:"new_value,omitempty"`
+	Value string `bson:"value,omitempty" json:"value,omitempty" yaml:"value,omitempty"`
 	// Exists determines whether or not the secret already exists in the secrets
 	// storage service. If this is false, then a new secret will be stored.
 	Exists *bool `bson:"exists,omitempty" json:"exists,omitempty" yaml:"exists,omitempty"`
@@ -313,4 +414,14 @@ func (p *Pod) UpdateResources(info ResourceInfo) error {
 	p.Resources = info
 
 	return nil
+}
+
+// GetSecret returns the shared secret between the server and the pod. If the
+// secret is unset, this will return an error.
+func (p *Pod) GetSecret() (*Secret, error) {
+	s, ok := p.TaskContainerCreationOpts.EnvSecrets[PodSecretEnvVar]
+	if !ok {
+		return nil, errors.New("pod does not have a secret")
+	}
+	return &s, nil
 }

--- a/rest/route/pod_test.go
+++ b/rest/route/pod_test.go
@@ -28,14 +28,10 @@ func TestPostPod(t *testing.T) {
 				"memory": 128,
 				"cpu": 128,
 				"image": "image",
-				"env_vars": [{
-					"name": "env_name",
-					"value": "env_val",
-					"secret": false
-				}],
 				"os": "windows",
 				"arch": "arm64",
 				"windows_version": "SERVER_2022",
+				"working_dir": "/",
 				"secret": "secret"
 			}`)
 			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
@@ -48,106 +44,15 @@ func TestPostPod(t *testing.T) {
 			assert.EqualValues(t, pod.ArchARM64, ph.p.Arch)
 			assert.EqualValues(t, pod.WindowsVersionServer2022, ph.p.WindowsVersion)
 			assert.Equal(t, "secret", utility.FromStringPtr(ph.p.Secret))
-			assert.Equal(t, "env_name", utility.FromStringPtr(ph.p.EnvVars[0].Name))
-			assert.Equal(t, "env_val", utility.FromStringPtr(ph.p.EnvVars[0].Value))
-			assert.Equal(t, false, utility.FromBoolPtr(ph.p.EnvVars[0].Secret))
-		},
-		"ParseSucceedsWithSecrets": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"memory": 128,
-				"cpu": 128,
-				"image": "image",
-				"env_vars": [{
-					"name": "secret_name",
-					"value": "secret_val",
-					"secret": true
-				}],
-				"os": "linux",
-				"arch": "arm64",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.NoError(t, ph.Parse(ctx, req))
-			assert.Equal(t, 128, utility.FromIntPtr(ph.p.Memory))
-			assert.Equal(t, 128, utility.FromIntPtr(ph.p.CPU))
-			assert.Equal(t, "image", utility.FromStringPtr(ph.p.Image))
-			assert.EqualValues(t, "linux", ph.p.OS)
-			assert.EqualValues(t, "arm64", ph.p.Arch)
-			assert.Equal(t, "secret", utility.FromStringPtr(ph.p.Secret))
-			assert.Equal(t, "secret_name", utility.FromStringPtr(ph.p.EnvVars[0].Name))
-			assert.Equal(t, "secret_val", utility.FromStringPtr(ph.p.EnvVars[0].Value))
-			assert.Equal(t, true, utility.FromBoolPtr(ph.p.EnvVars[0].Secret))
-		},
-		"ParseFailsWithInvalidJSON": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"memory": 128,
-				"cpu": 128,,,
-				"image": "image",
-				"env_vars": [],
-				"os": "linux",
-				"arch": "arm64",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.Error(t, ph.Parse(ctx, req))
-		},
-		"ParseFailsWithMissingInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"cpu": 128,
-				"image": "image",
-				"env_vars": [],
-				"os": "linux",
-				"arch": "arm64",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.Error(t, ph.Parse(ctx, req))
-		},
-		"ParseFailsWithMissingEnvVarInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"cpu": 128,
-				"image": "image",
-				"env_vars": [{
-					"value": "secret_val",
-					"secret": true
-				}],
-				"os": "linux",
-				"arch": "arm64",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.Error(t, ph.Parse(ctx, req))
-		},
-		"ParseFailsWithInvalidInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
-			json := []byte(`{
-				"memory": -1,
-				"cpu": 128,
-				"image": "image",
-				"env_vars": [],
-				"os": "linux",
-				"arch": "arm64",
-				"secret": "secret"
-			}`)
-			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
-			require.NoError(t, err)
-			require.Error(t, ph.Parse(ctx, req))
 		},
 		"RunSucceedsWithValidInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
 			json := []byte(`{
 				"memory": 128,
 				"cpu": 128,
 				"image": "image",
-				"env_vars": [{
-					"name": "env_name",
-					"value": "env_val",
-					"secret": false
-				}],
 				"os": "linux",
 				"arch": "arm64",
+				"working_dir": "/",
 				"secret": "secret"
 			}`)
 
@@ -157,6 +62,22 @@ func TestPostPod(t *testing.T) {
 			resp := ph.Run(ctx)
 			require.NotNil(t, resp.Data())
 			assert.Equal(t, http.StatusCreated, resp.Status())
+		},
+		"RunFailsWithInvalidInput": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
+			json := []byte(`{
+				"image": "image",
+				"os": "linux",
+				"arch": "arm64",
+				"working_dir": "/",
+				"secret": "secret"
+			}`)
+
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/pods", bytes.NewBuffer(json))
+			require.NoError(t, err)
+			require.NoError(t, ph.Parse(ctx, req))
+			resp := ph.Run(ctx)
+			require.NotNil(t, resp.Data())
+			assert.True(t, resp.Status() > 400, "input should be rejected")
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16176

### Description 
* Add method to create new intent pod for a task.
* Remove `Secret` field from pods. It was originally used to represent the agent secret, but it shouldn't be necessary to have a separate field for it since it already has to be stored in the secret environment variables. I removed it to reduce the duplication in the data model.

### Testing 
Updated existing unit tests and added new ones for `NewTaskIntentPod`.