### PR TITLE
get project id for name

### DIFF
--- a/model/stats/db.go
+++ b/model/stats/db.go
@@ -133,8 +133,8 @@ type DbTestStatsId struct {
 	Date         time.Time `bson:"date"`
 }
 
-// dbTestStats represents the hourly_test_stats and daily_test_stats documents.
-type dbTestStats struct {
+// DbTestStats represents the hourly_test_stats and daily_test_stats documents.
+type DbTestStats struct {
 	Id              DbTestStatsId    `bson:"_id"`
 	NumPass         int              `bson:"num_pass"`
 	NumFail         int              `bson:"num_fail"`
@@ -143,8 +143,8 @@ type dbTestStats struct {
 	LastID          mgobson.ObjectId `bson:"last_id"`
 }
 
-func (d *dbTestStats) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(d) }
-func (d *dbTestStats) UnmarshalBSON(in []byte) error { return mgobson.Unmarshal(in, d) }
+func (d *DbTestStats) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(d) }
+func (d *DbTestStats) UnmarshalBSON(in []byte) error { return mgobson.Unmarshal(in, d) }
 
 var (
 	// BSON fields for the test stats id struct
@@ -157,12 +157,12 @@ var (
 	dbTestStatsIdDateKey         = bsonutil.MustHaveTag(DbTestStatsId{}, "Date")
 
 	// BSON fields for the test stats struct
-	dbTestStatsIdKey              = bsonutil.MustHaveTag(dbTestStats{}, "Id")
-	dbTestStatsNumPassKey         = bsonutil.MustHaveTag(dbTestStats{}, "NumPass")
-	dbTestStatsNumFailKey         = bsonutil.MustHaveTag(dbTestStats{}, "NumFail")
-	dbTestStatsAvgDurationPassKey = bsonutil.MustHaveTag(dbTestStats{}, "AvgDurationPass")
-	dbTestStatsLastUpdateKey      = bsonutil.MustHaveTag(dbTestStats{}, "LastUpdate")
-	dbTestStatsLastIDKey          = bsonutil.MustHaveTag(dbTestStats{}, "LastID")
+	dbTestStatsIdKey              = bsonutil.MustHaveTag(DbTestStats{}, "Id")
+	dbTestStatsNumPassKey         = bsonutil.MustHaveTag(DbTestStats{}, "NumPass")
+	dbTestStatsNumFailKey         = bsonutil.MustHaveTag(DbTestStats{}, "NumFail")
+	dbTestStatsAvgDurationPassKey = bsonutil.MustHaveTag(DbTestStats{}, "AvgDurationPass")
+	dbTestStatsLastUpdateKey      = bsonutil.MustHaveTag(DbTestStats{}, "LastUpdate")
+	dbTestStatsLastIDKey          = bsonutil.MustHaveTag(DbTestStats{}, "LastID")
 
 	// BSON dotted field names for test stats id elements
 	DbTestStatsIdTestFileKeyFull     = bsonutil.GetDottedKeyName(dbTestStatsIdKey, dbTestStatsIdTestFileKey)
@@ -1057,8 +1057,8 @@ func makeSum(condition bson.M) bson.M {
 // Functions to access pre-computed stats documents for testing. //
 ///////////////////////////////////////////////////////////////////
 
-func GetDailyTestDoc(id DbTestStatsId) (*dbTestStats, error) {
-	doc := dbTestStats{}
+func GetDailyTestDoc(id DbTestStatsId) (*DbTestStats, error) {
+	doc := DbTestStats{}
 	q := db.Query(bson.M{dbTestStatsIdKey: id})
 	err := db.FindOneQ(DailyTestStatsCollection, q, &doc)
 	if adb.ResultsNotFound(err) {
@@ -1067,8 +1067,8 @@ func GetDailyTestDoc(id DbTestStatsId) (*dbTestStats, error) {
 	return &doc, err
 }
 
-func GetHourlyTestDoc(id DbTestStatsId) (*dbTestStats, error) {
-	doc := dbTestStats{}
+func GetHourlyTestDoc(id DbTestStatsId) (*DbTestStats, error) {
+	doc := DbTestStats{}
 	q := db.Query(bson.M{dbTestStatsIdKey: id})
 	err := db.FindOneQ(HourlyTestStatsCollection, q, &doc)
 	if adb.ResultsNotFound(err) {

--- a/model/stats/stats_test.go
+++ b/model/stats/stats_test.go
@@ -338,7 +338,7 @@ func (s *statsSuite) TestGenerateDailyTestStatsFromHourly() {
 	s.Equal(float64(4), doc.AvgDurationPass)
 	s.WithinDuration(jobTime, doc.LastUpdate, 0)
 
-	var lastTestResult *dbTestStats
+	var lastTestResult *DbTestStats
 	lastTestResult, err = s.getLastHourlyTestStat(testStatsID)
 	s.NoError(err)
 	s.Equal(lastTestResult.LastID, doc.LastID)
@@ -800,8 +800,8 @@ func (s *statsSuite) getLastTestResult(testStatsID DbTestStatsId) (*testresult.T
 	return lastTestResult, err
 }
 
-func (s *statsSuite) getLastHourlyTestStat(testStatsID DbTestStatsId) (*dbTestStats, error) {
-	testResults := &dbTestStats{}
+func (s *statsSuite) getLastHourlyTestStat(testStatsID DbTestStatsId) (*DbTestStats, error) {
+	testResults := &DbTestStats{}
 
 	start := utility.GetUTCDay(testStatsID.Date)
 	end := start.Add(24 * time.Hour)

--- a/rest/data/reliability.go
+++ b/rest/data/reliability.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/reliability"
-	"github.com/evergreen-ci/evergreen/rest/model"
+	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 )
@@ -13,15 +14,23 @@ import (
 type TaskReliabilityConnector struct{}
 
 // GetTaskReliabilityScores queries the service backend to retrieve the task reliability scores that match the given filter.
-func (sc *TaskReliabilityConnector) GetTaskReliabilityScores(filter reliability.TaskReliabilityFilter) ([]model.APITaskReliability, error) {
+func (sc *TaskReliabilityConnector) GetTaskReliabilityScores(filter reliability.TaskReliabilityFilter) ([]restModel.APITaskReliability, error) {
+	if filter.Project != "" {
+		projectID, err := model.GetIdForProject(filter.Project)
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting project id for '%s'", filter.Project)
+		}
+		filter.Project = projectID
+	}
+
 	serviceStatsResult, err := reliability.GetTaskReliabilityScores(filter)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get task stats from service API")
 	}
 
-	apiStatsResult := make([]model.APITaskReliability, len(serviceStatsResult))
+	apiStatsResult := make([]restModel.APITaskReliability, len(serviceStatsResult))
 	for i, serviceStats := range serviceStatsResult {
-		ats := model.APITaskReliability{}
+		ats := restModel.APITaskReliability{}
 		err = ats.BuildFromService(&serviceStats)
 		if err != nil {
 			return nil, errors.Wrap(err, "Model error")
@@ -32,11 +41,11 @@ func (sc *TaskReliabilityConnector) GetTaskReliabilityScores(filter reliability.
 }
 
 type MockTaskReliabilityConnector struct {
-	CachedTaskReliability []model.APITaskReliability
+	CachedTaskReliability []restModel.APITaskReliability
 }
 
 // GetTaskReliabilityScores returns the cached task stats, only enforcing the Limit field of the filter.
-func (msc *MockTaskReliabilityConnector) GetTaskReliabilityScores(filter reliability.TaskReliabilityFilter) ([]model.APITaskReliability, error) {
+func (msc *MockTaskReliabilityConnector) GetTaskReliabilityScores(filter reliability.TaskReliabilityFilter) ([]restModel.APITaskReliability, error) {
 	if filter.Limit > len(msc.CachedTaskReliability) {
 		return msc.CachedTaskReliability, nil
 	} else {
@@ -46,10 +55,10 @@ func (msc *MockTaskReliabilityConnector) GetTaskReliabilityScores(filter reliabi
 
 // SetTaskReliabilityScores sets the cached task stats by generating 'numStats' stats.
 func (msc *MockTaskReliabilityConnector) SetTaskReliabilityScores(baseTaskName string, numStats int) {
-	msc.CachedTaskReliability = make([]model.APITaskReliability, numStats)
+	msc.CachedTaskReliability = make([]restModel.APITaskReliability, numStats)
 	day := utility.GetUTCDay(time.Now()).Format("2006-01-02")
 	for i := 0; i < numStats; i++ {
-		msc.CachedTaskReliability[i] = model.APITaskReliability{
+		msc.CachedTaskReliability[i] = restModel.APITaskReliability{
 			TaskName:     utility.ToStringPtr(fmt.Sprintf("%v%v", baseTaskName, i)),
 			BuildVariant: utility.ToStringPtr("variant"),
 			Distro:       utility.ToStringPtr("distro"),

--- a/rest/data/reliability_test.go
+++ b/rest/data/reliability_test.go
@@ -3,10 +3,15 @@ package data
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/reliability"
 	"github.com/evergreen-ci/evergreen/model/stats"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMockGetTaskReliability(t *testing.T) {
@@ -41,4 +46,42 @@ func TestMockGetTaskReliability(t *testing.T) {
 			assert.Equal(date, doc.Date)
 		}
 	}
+}
+
+func TestGetTaskReliability(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
+	}()
+	assert.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
+
+	stat := stats.DbTaskStats{
+		Id: stats.DbTaskStatsId{
+			Project:   "projectID",
+			TaskName:  "t0",
+			Date:      time.Date(2022, 02, 15, 0, 0, 0, 0, time.UTC),
+			Requester: evergreen.RepotrackerVersionRequester,
+		},
+	}
+	assert.NoError(t, db.Insert(stats.DailyTaskStatsCollection, stat))
+	projectRef := model.ProjectRef{
+		Id:         "projectID",
+		Identifier: "projectName",
+	}
+	assert.NoError(t, projectRef.Insert())
+
+	sc := TaskReliabilityConnector{}
+	filter := reliability.TaskReliabilityFilter{}
+	filter.Project = "projectName"
+	filter.GroupNumDays = 1
+	filter.Requesters = []string{evergreen.RepotrackerVersionRequester}
+	filter.Sort = stats.SortLatestFirst
+	filter.GroupBy = stats.GroupByTask
+	filter.AfterDate = time.Time{}
+	filter.BeforeDate = time.Date(2022, 02, 16, 0, 0, 0, 0, time.UTC)
+	filter.Limit = 1
+	filter.Tasks = []string{"t0"}
+	scores, err := sc.GetTaskReliabilityScores(filter)
+
+	assert.NoError(t, err)
+	require.Len(t, scores, 1)
 }

--- a/rest/data/stats.go
+++ b/rest/data/stats.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/stats"
-	"github.com/evergreen-ci/evergreen/rest/model"
+	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 )
@@ -13,15 +14,23 @@ import (
 type StatsConnector struct{}
 
 // GetTestStats queries the service backend to retrieve the test stats that match the given filter.
-func (sc *StatsConnector) GetTestStats(filter stats.StatsFilter) ([]model.APITestStats, error) {
+func (sc *StatsConnector) GetTestStats(filter stats.StatsFilter) ([]restModel.APITestStats, error) {
+	if filter.Project != "" {
+		projectID, err := model.GetIdForProject(filter.Project)
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting project id for '%s'", filter.Project)
+		}
+		filter.Project = projectID
+	}
+
 	serviceStatsResult, err := stats.GetTestStats(filter)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get test stats from service API")
 	}
 
-	apiStatsResult := make([]model.APITestStats, len(serviceStatsResult))
+	apiStatsResult := make([]restModel.APITestStats, len(serviceStatsResult))
 	for i, serviceStats := range serviceStatsResult {
-		ats := model.APITestStats{}
+		ats := restModel.APITestStats{}
 		err = ats.BuildFromService(&serviceStats)
 		if err != nil {
 			return nil, errors.Wrap(err, "Model error")
@@ -32,15 +41,23 @@ func (sc *StatsConnector) GetTestStats(filter stats.StatsFilter) ([]model.APITes
 }
 
 // GetTaskStats queries the service backend to retrieve the task stats that match the given filter.
-func (sc *StatsConnector) GetTaskStats(filter stats.StatsFilter) ([]model.APITaskStats, error) {
+func (sc *StatsConnector) GetTaskStats(filter stats.StatsFilter) ([]restModel.APITaskStats, error) {
+	if filter.Project != "" {
+		projectID, err := model.GetIdForProject(filter.Project)
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting project id for '%s'", filter.Project)
+		}
+		filter.Project = projectID
+	}
+
 	serviceStatsResult, err := stats.GetTaskStats(filter)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get task stats from service API")
 	}
 
-	apiStatsResult := make([]model.APITaskStats, len(serviceStatsResult))
+	apiStatsResult := make([]restModel.APITaskStats, len(serviceStatsResult))
 	for i, serviceStats := range serviceStatsResult {
-		ats := model.APITaskStats{}
+		ats := restModel.APITaskStats{}
 		err = ats.BuildFromService(&serviceStats)
 		if err != nil {
 			return nil, errors.Wrap(err, "Model error")
@@ -51,12 +68,12 @@ func (sc *StatsConnector) GetTaskStats(filter stats.StatsFilter) ([]model.APITas
 }
 
 type MockStatsConnector struct {
-	CachedTestStats []model.APITestStats
-	CachedTaskStats []model.APITaskStats
+	CachedTestStats []restModel.APITestStats
+	CachedTaskStats []restModel.APITaskStats
 }
 
 // GetTestStats returns the cached test stats, only enforcing the Limit field of the filter.
-func (msc *MockStatsConnector) GetTestStats(filter stats.StatsFilter) ([]model.APITestStats, error) {
+func (msc *MockStatsConnector) GetTestStats(filter stats.StatsFilter) ([]restModel.APITestStats, error) {
 	if filter.Limit > len(msc.CachedTestStats) {
 		return msc.CachedTestStats, nil
 	} else {
@@ -65,7 +82,7 @@ func (msc *MockStatsConnector) GetTestStats(filter stats.StatsFilter) ([]model.A
 }
 
 // GetTaskStats returns the cached task stats, only enforcing the Limit field of the filter.
-func (msc *MockStatsConnector) GetTaskStats(filter stats.StatsFilter) ([]model.APITaskStats, error) {
+func (msc *MockStatsConnector) GetTaskStats(filter stats.StatsFilter) ([]restModel.APITaskStats, error) {
 	if filter.Limit > len(msc.CachedTaskStats) {
 		return msc.CachedTaskStats, nil
 	} else {
@@ -75,10 +92,10 @@ func (msc *MockStatsConnector) GetTaskStats(filter stats.StatsFilter) ([]model.A
 
 // SetTestStats sets the cached test stats by generating 'numStats' stats.
 func (msc *MockStatsConnector) SetTestStats(baseTestName string, numStats int) {
-	msc.CachedTestStats = make([]model.APITestStats, numStats)
+	msc.CachedTestStats = make([]restModel.APITestStats, numStats)
 	day := utility.GetUTCDay(time.Now()).Format("2006-01-02")
 	for i := 0; i < numStats; i++ {
-		msc.CachedTestStats[i] = model.APITestStats{
+		msc.CachedTestStats[i] = restModel.APITestStats{
 			TestFile:     utility.ToStringPtr(fmt.Sprintf("%v%v", baseTestName, i)),
 			TaskName:     utility.ToStringPtr("task"),
 			BuildVariant: utility.ToStringPtr("variant"),
@@ -90,10 +107,10 @@ func (msc *MockStatsConnector) SetTestStats(baseTestName string, numStats int) {
 
 // SetTaskStats sets the cached task stats by generating 'numStats' stats.
 func (msc *MockStatsConnector) SetTaskStats(baseTaskName string, numStats int) {
-	msc.CachedTaskStats = make([]model.APITaskStats, numStats)
+	msc.CachedTaskStats = make([]restModel.APITaskStats, numStats)
 	day := utility.GetUTCDay(time.Now()).Format("2006-01-02")
 	for i := 0; i < numStats; i++ {
-		msc.CachedTaskStats[i] = model.APITaskStats{
+		msc.CachedTaskStats[i] = restModel.APITaskStats{
 			TaskName:     utility.ToStringPtr(fmt.Sprintf("%v%v", baseTaskName, i)),
 			BuildVariant: utility.ToStringPtr("variant"),
 			Distro:       utility.ToStringPtr("distro"),

--- a/rest/data/stats_test.go
+++ b/rest/data/stats_test.go
@@ -3,9 +3,15 @@ package data
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/stats"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMockGetTestStats(t *testing.T) {
@@ -67,4 +73,79 @@ func TestMockGetTaskStats(t *testing.T) {
 			assert.Equal(date, doc.Date)
 		}
 	}
+}
+
+func TestGetTaskStats(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
+	}()
+	assert.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
+
+	stat := stats.DbTaskStats{
+		Id: stats.DbTaskStatsId{
+			Project:   "projectID",
+			TaskName:  "t0",
+			Date:      time.Date(2022, 02, 15, 0, 0, 0, 0, time.UTC),
+			Requester: evergreen.RepotrackerVersionRequester,
+		},
+	}
+	assert.NoError(t, db.Insert(stats.DailyTaskStatsCollection, stat))
+	projectRef := model.ProjectRef{
+		Id:         "projectID",
+		Identifier: "projectName",
+	}
+	assert.NoError(t, projectRef.Insert())
+
+	sc := StatsConnector{}
+	stats, err := sc.GetTaskStats(stats.StatsFilter{
+		Project:      "projectName",
+		GroupNumDays: 1,
+		Requesters:   []string{evergreen.RepotrackerVersionRequester},
+		Sort:         stats.SortLatestFirst,
+		GroupBy:      stats.GroupByTask,
+		AfterDate:    time.Time{},
+		BeforeDate:   time.Date(2022, 02, 16, 0, 0, 0, 0, time.UTC),
+		Limit:        1,
+		Tasks:        []string{"t0"},
+	})
+	assert.NoError(t, err)
+	require.Len(t, stats, 1)
+}
+
+func TestGetTestStats(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(stats.DailyTestStatsCollection, model.ProjectRefCollection))
+	}()
+	assert.NoError(t, db.ClearCollections(stats.DailyTestStatsCollection, model.ProjectRefCollection))
+
+	stat := stats.DbTestStats{
+		Id: stats.DbTestStatsId{
+			Project:   "projectID",
+			TaskName:  "t0",
+			Date:      time.Date(2022, 02, 15, 0, 0, 0, 0, time.UTC),
+			Requester: evergreen.RepotrackerVersionRequester,
+		},
+		LastID: bson.NewObjectId(),
+	}
+	assert.NoError(t, db.Insert(stats.DailyTestStatsCollection, stat))
+	projectRef := model.ProjectRef{
+		Id:         "projectID",
+		Identifier: "projectName",
+	}
+	assert.NoError(t, projectRef.Insert())
+
+	sc := StatsConnector{}
+	stats, err := sc.GetTestStats(stats.StatsFilter{
+		Project:      "projectName",
+		GroupNumDays: 1,
+		Requesters:   []string{evergreen.RepotrackerVersionRequester},
+		Sort:         stats.SortLatestFirst,
+		GroupBy:      stats.GroupByTask,
+		AfterDate:    time.Time{},
+		BeforeDate:   time.Date(2022, 02, 16, 0, 0, 0, 0, time.UTC),
+		Limit:        1,
+		Tasks:        []string{"t0"},
+	})
+	assert.NoError(t, err)
+	require.Len(t, stats, 1)
 }


### PR DESCRIPTION
[EVG-15129](https://jira.mongodb.org/browse/EVG-15129)

### Description 
Replace the filters' project name project id. The specific queries in the ticket no longer return results because there's a TTL index on the collections, but the point holds for current stats. 

### Testing 
Added tests. Also tested in staging that [this route](https://evergreen-staging.corp.mongodb.com/rest/v2/projects/sandbox/task_stats?tasks=batchtime_task&after_date=2021-10-01&before_date=2022-01-30) doesn't work without my changes, but gets a bunch of results when the changes are deployed.