### PR TITLE
EVG-16331: remove event notifier batch size setting

### DIFF
--- a/config_alerts_notify.go
+++ b/config_alerts_notify.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	DefaultEventProcessingLimit    = 1000
 	DefaultBufferIntervalSeconds   = 60
 	DefaultBufferTargetPerInterval = 20
 )
@@ -17,7 +16,6 @@ const (
 type NotifyConfig struct {
 	BufferTargetPerInterval int        `bson:"buffer_target_per_interval" json:"buffer_target_per_interval" yaml:"buffer_target_per_interval"`
 	BufferIntervalSeconds   int        `bson:"buffer_interval_seconds" json:"buffer_interval_seconds" yaml:"buffer_interval_seconds"`
-	EventProcessingLimit    int        `bson:"event_processing_limit" json:"event_processing_limit" yaml:"event_processing_limit"`
 	SMTP                    SMTPConfig `bson:"smtp" json:"smtp" yaml:"smtp"`
 }
 
@@ -68,10 +66,6 @@ func (c *NotifyConfig) ValidateAndDefault() error {
 	if jobsPerSecond > maxNotificationsPerSecond {
 		return errors.Errorf("maximum notification jobs per second is %d", maxNotificationsPerSecond)
 
-	}
-
-	if c.EventProcessingLimit <= 0 {
-		c.EventProcessingLimit = DefaultEventProcessingLimit
 	}
 
 	return nil

--- a/config_test.go
+++ b/config_test.go
@@ -576,7 +576,6 @@ func (s *AdminSuite) TestNotifyConfig() {
 
 	config.BufferIntervalSeconds = 1
 	config.BufferTargetPerInterval = 2
-	config.EventProcessingLimit = 1
 	s.NoError(config.Set())
 
 	settings, err = GetConfig()

--- a/model/event/event_test.go
+++ b/model/event/event_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	amboyRegistry "github.com/mongodb/amboy/registry"
@@ -341,7 +340,7 @@ func (s *eventSuite) TestFindUnprocessedEvents() {
 	for i := range data {
 		s.NoError(db.Insert(AllLogCollection, data[i]))
 	}
-	events, err := FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
+	events, err := FindUnprocessedEvents(-1)
 	s.NoError(err)
 	s.Len(events, 1)
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -838,7 +838,7 @@ func TestUpdateVersionGithubStatus(t *testing.T) {
 
 	assert.NoError(t, updateVersionGithubStatus(v, builds))
 
-	e, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
+	e, err := event.FindUnprocessedEvents(-1)
 	assert.NoError(t, err)
 	require.Len(t, e, 1)
 }
@@ -860,7 +860,7 @@ func TestUpdateBuildGithubStatus(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.BuildSucceeded, b.GithubCheckStatus)
 
-	e, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
+	e, err := event.FindUnprocessedEvents(-1)
 	assert.NoError(t, err)
 	require.Len(t, e, 1)
 }
@@ -2889,7 +2889,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(evergreen.BuildFailed, b.Status)
 
-	e, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
+	e, err := event.FindUnprocessedEvents(-1)
 	assert.NoError(err)
 	assert.Len(e, 7)
 }
@@ -2960,7 +2960,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	assert.NoError(err)
 	assert.Equal(evergreen.BuildFailed, b.Status)
 
-	e, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
+	e, err := event.FindUnprocessedEvents(-1)
 	assert.NoError(err)
 	assert.Len(e, 4)
 }
@@ -3032,7 +3032,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(evergreen.BuildFailed, b.Status)
 
-	e, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
+	e, err := event.FindUnprocessedEvents(-1)
 	assert.NoError(err)
 	assert.Len(e, 4)
 }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1146,7 +1146,6 @@ func (a *APILogBuffering) ToService() (interface{}, error) {
 type APINotifyConfig struct {
 	BufferTargetPerInterval int           `json:"buffer_target_per_interval"`
 	BufferIntervalSeconds   int           `json:"buffer_interval_seconds"`
-	EventProcessingLimit    int           `json:"event_processing_limit"`
 	SMTP                    APISMTPConfig `json:"smtp"`
 }
 
@@ -1159,7 +1158,6 @@ func (a *APINotifyConfig) BuildFromService(h interface{}) error {
 		}
 		a.BufferTargetPerInterval = v.BufferTargetPerInterval
 		a.BufferIntervalSeconds = v.BufferIntervalSeconds
-		a.EventProcessingLimit = v.EventProcessingLimit
 	default:
 		return errors.Errorf("%T is not a supported type", h)
 	}
@@ -1174,7 +1172,6 @@ func (a *APINotifyConfig) ToService() (interface{}, error) {
 	return evergreen.NotifyConfig{
 		BufferTargetPerInterval: a.BufferTargetPerInterval,
 		BufferIntervalSeconds:   a.BufferIntervalSeconds,
-		EventProcessingLimit:    a.EventProcessingLimit,
 		SMTP:                    smtp.(evergreen.SMTPConfig),
 	}, nil
 }

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1567,10 +1567,6 @@ Admin Settings
 										<label>Notifications Rate Limit Time Interval (seconds)</label>
 										<input type="number" ng-model="Settings.notify.buffer_interval_seconds">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
-										<label>Event Processing Limit (events per job)</label>
-										<input type="number" ng-model="Settings.notify.event_processing_limit">
-									</md-input-container>
 								</md-card-content>
 							</md-card>
 							<md-card flex=50 id="triggers" style="height:180px">

--- a/units/spawnhost_expiration_warning_test.go
+++ b/units/spawnhost_expiration_warning_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/alertrecord"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -49,7 +48,7 @@ func (s *spawnHostExpirationSuite) SetupTest() {
 func (s *spawnHostExpirationSuite) TestAlerts() {
 	ctx := context.Background()
 	s.j.Run(ctx)
-	events, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
+	events, err := event.FindUnprocessedEvents(-1)
 	s.NoError(err)
 	s.Len(events, 3)
 }
@@ -58,7 +57,7 @@ func (s *spawnHostExpirationSuite) TestCanceledJob() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	s.j.Run(ctx)
-	events, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
+	events, err := event.FindUnprocessedEvents(-1)
 	s.NoError(err)
 	s.Len(events, 0)
 }

--- a/units/volume_expiration_warning_test.go
+++ b/units/volume_expiration_warning_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/alertrecord"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -29,7 +28,7 @@ func TestVolumeExpiration(t *testing.T) {
 	j := makeVolumeExpirationWarningsJob()
 	j.Run(context.Background())
 
-	events, err := event.FindUnprocessedEvents(evergreen.DefaultEventProcessingLimit)
+	events, err := event.FindUnprocessedEvents(-1)
 	assert.NoError(t, err)
 	// one event each for v0, v1, v2
 	assert.Len(t, events, 3)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16331

### Description
Since the event notifier change in #5377 seems to have succeeded, the event notifier no longer batch processes events, so the flag is unnecessary.

### Testing
Updated tests that depended on default batch size.