### PR TITLE
EVG-16358 prevent un-specified parameters from overwriting expansions

### DIFF
--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -181,7 +181,11 @@ func (pp *ParserProject) UpsertWithConfigNumber(updateNum int) error {
 func (pp *ParserProject) GetParameters() []patch.Parameter {
 	res := []patch.Parameter{}
 	for _, param := range pp.Parameters {
-		res = append(res, param.Parameter)
+		// If the key doesn't exist the value will default to "" anyway; this prevents
+		// an un-specified parameter from overwriting lower-priority expansions.
+		if param.Parameter.Value != "" {
+			res = append(res, param.Parameter)
+		}
 	}
 	return res
 }

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -181,11 +181,7 @@ func (pp *ParserProject) UpsertWithConfigNumber(updateNum int) error {
 func (pp *ParserProject) GetParameters() []patch.Parameter {
 	res := []patch.Parameter{}
 	for _, param := range pp.Parameters {
-		// If the key doesn't exist the value will default to "" anyway; this prevents
-		// an un-specified parameter from overwriting lower-priority expansions.
-		if param.Parameter.Value != "" {
-			res = append(res, param.Parameter)
-		}
+		res = append(res, param.Parameter)
 	}
 	return res
 }

--- a/service/api.go
+++ b/service/api.go
@@ -360,7 +360,7 @@ func (as *APIServer) FetchExpansionsForTask(w http.ResponseWriter, r *http.Reque
 		}
 	}
 	for _, param := range v.Parameters {
-		// We will overwite empty values here since these were explicitly user-specified.
+		// We will overwrite empty values here since these were explicitly user-specified.
 		res.Vars[param.Key] = param.Value
 	}
 

--- a/service/api.go
+++ b/service/api.go
@@ -352,8 +352,15 @@ func (as *APIServer) FetchExpansionsForTask(w http.ResponseWriter, r *http.Reque
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	params := append(projParams, v.Parameters...)
-	for _, param := range params {
+	for _, param := range projParams {
+		// If the key doesn't exist the value will default to "" anyway; this prevents
+		// an un-specified parameter from overwriting lower-priority expansions.
+		if param.Value != "" {
+			res.Vars[param.Key] = param.Value
+		}
+	}
+	for _, param := range v.Parameters {
+		// We will overwite empty values here since these were explicitly user-specified.
 		res.Vars[param.Key] = param.Value
 	}
 


### PR DESCRIPTION
[EVG-16358](https://jira.mongodb.org/browse/EVG-16358)

### Description 
Users should be able to define parameter descriptions without requiring a default, in which case we shouldn't overwrite existing ones.

### Testing 
No existing test to update here.