### PR TITLE
EVG-16253 upgrade mongodb version for tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -385,7 +385,7 @@ mongodb/.get-mongodb:
 get-mongodb:mongodb/.get-mongodb
 	@touch $<
 start-mongod:mongodb/.get-mongodb
-	./mongodb/mongod --dbpath ./mongodb/db_files --port 27017 --replSet evg --smallfiles --oplogSize 10
+	./mongodb/mongod --dbpath ./mongodb/db_files --port 27017 --replSet evg --oplogSize 10
 	@echo "waiting for mongod to start up"
 start-mongod-auth:mongodb/.get-mongodb
 	./mongodb/mongod --auth --dbpath ./mongodb/db_files --port 27017 --replSet evg --oplogSize 10
@@ -393,6 +393,8 @@ start-mongod-auth:mongodb/.get-mongodb
 init-rs:mongodb/.get-mongodb
 	./mongodb/mongo --eval 'rs.initiate()'
 	sleep 30
+set-mongo-fcv:mongodb/.get-mongodb
+	./mongodb/mongo --eval 'db.adminCommand({setFeatureCompatibilityVersion: "$(FCV)"})'
 init-auth:mongodb/.get-mongodb
 	./mongodb/mongo --host `./mongodb/mongo --quiet --eval "db.isMaster()['primary']"` cmd/mongo-auth/create_auth_user.js
 check-mongod:mongodb/.get-mongodb

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -238,53 +238,16 @@ functions:
         background: true
         working_dir: evergreen
         command: make start-mongod
-    - command: subprocess.exec
-      type: setup
-      params:
-        working_dir: evergreen
-        command: make check-mongod
-    - command: subprocess.exec
-      type: setup
-      params:
-        working_dir: evergreen
-        command: make init-rs
-    - command: subprocess.exec
-      type: setup
-      params:
         env:
+          AUTH_ENABLED: ${with_auth}
+    - command: subprocess.exec
+      type: setup
+      params:
+        working_dir: evergreen
+        command: make configure-mongod
+        env:
+          AUTH_ENABLED: ${with_auth}
           FCV: "4.0"
-        working_dir: evergreen
-        command: make set-mongo-fcv
-  setup-mongodb-auth:
-    - command: subprocess.exec
-      type: setup
-      params:
-        env:
-          MONGODB_URL: ${mongodb_url}
-          DECOMPRESS: ${decompress}
-        working_dir: evergreen
-        command: make get-mongodb
-    - command: subprocess.exec
-      type: setup
-      params:
-        background: true
-        working_dir: evergreen
-        command: make start-mongod-auth
-    - command: subprocess.exec
-      type: setup
-      params:
-        working_dir: evergreen
-        command: make check-mongod
-    - command: subprocess.exec
-      type: setup
-      params:
-        working_dir: evergreen
-        command: make init-rs
-    - command: subprocess.exec
-      type: setup
-      params:
-        working_dir: evergreen
-        command: make init-auth
 
   setup-docker-host:
     - command: host.create
@@ -588,7 +551,8 @@ tasks:
     commands:
       - func: get-project-and-modules
       - func: setup-credentials
-      - func: setup-mongodb-auth
+      - func: setup-mongodb
+        vars: { with_auth: "1"}
       - func: run-make
         vars:
           target: "test-evergreen"

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -248,6 +248,13 @@ functions:
       params:
         working_dir: evergreen
         command: make init-rs
+    - command: subprocess.exec
+      type: setup
+      params:
+        env:
+          FCV: "4.0"
+        working_dir: evergreen
+        command: make set-mongo-fcv
   setup-mongodb-auth:
     - command: subprocess.exec
       type: setup

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -573,8 +573,8 @@ buildvariants:
   - name: ubuntu1604
     display_name: Ubuntu 16.04
     run_on:
-      - ubuntu1604-test
-      - ubuntu1604-build
+      - ubuntu1604-small
+      - ubuntu1604-large
     expansions:
       goos: linux
       goarch: amd64
@@ -596,8 +596,8 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector
     run_on:
-      - ubuntu1604-test
-      - ubuntu1604-build
+      - ubuntu1604-small
+      - ubuntu1604-large
     expansions:
       GOROOT: /opt/golang/go1.16
       RUN_EC2_SPECIFIC_TESTS: true

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -610,7 +610,7 @@ buildvariants:
       nodebin: /opt/node/bin
       GOROOT: /opt/golang/go1.16
       RUN_EC2_SPECIFIC_TESTS: true
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.18.tgz
     tasks:
       - name: "dist-and-upload-clis"
       - name: "dist-staging"
@@ -625,12 +625,12 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector
     run_on:
-      - archlinux-new-small
-      - archlinux-new-large
+      - ubuntu1604-test
+      - ubuntu1604-build
     expansions:
       GOROOT: /opt/golang/go1.16
       RUN_EC2_SPECIFIC_TESTS: true
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.18.tgz
       race_detector: true
       test_timeout: 15m
     tasks:
@@ -654,25 +654,25 @@ buildvariants:
     expansions:
       GOROOT: c:/golang/go1.16
       RUN_EC2_SPECIFIC_TESTS: true
-      mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.3.zip
+      mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2012plus-4.2.18.zip
       extension: ".exe"
       archiveExt: ".zip"
     tasks:
       - name: ".agent .test"
       - name: ".cli .test"
 
-  - name: ubuntu1604-arm64
-    display_name: Ubuntu 16.04 ARM
+  - name: ubuntu1804-arm64
+    display_name: Ubuntu 18.04 ARM
     batchtime: 2880
     run_on:
-      - ubuntu1604-arm64-large
+      - ubuntu1804-arm64-large
     expansions:
       xc_build: yes
       goarch: arm64
       goos: linux
       GOROOT: /opt/golang/go1.16
       RUN_EC2_SPECIFIC_TESTS: true
-      mongodb_url: https://downloads.mongodb.com/linux/mongodb-linux-arm64-enterprise-ubuntu1604-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-4.2.18.tgz
     tasks:
       - name: ".agent .test"
 
@@ -683,7 +683,7 @@ buildvariants:
       - macos-1014
     expansions:
       GOROOT: /opt/golang/go1.16
-      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.2.18.tgz
     tasks:
       - name: ".agent .test"
       - name: ".cli .test"


### PR DESCRIPTION
[EVG-16253](https://jira.mongodb.org/browse/EVG-16253)

### Description 
* Change the db versions for each variant to 4.2.18. Because mongo doesn't package a precompiled tarball for 4.2 on Ubuntu16.04 ARM I changed that variant to Ubuntu 18.04 ARM. There's also no tarball for Arch. We could experiment with using one of the tarballs for another Linux distro but (as Brian noted on the ticket) there's no compelling reason to run race-detector on Arch so it will run on Ubuntu. It made sense to me to run on Ubuntu 16.04 because the app servers run on it and we're running the non-race tests on it already.
* Use the current distro names for ubuntu1604 (small instead of test and large instead of build). It means the same thing at the end of the day, but why not use the distros' proper names?
* Set the fCV of the db to match what's running in prod. If this makes it through code review I'll open a ticket to remove it once we move the db.
* Consolidate the self-tests.yml functions to setup mongodb with and without auth.

### Testing 
I can still run tests in a patch 😺.
