### PR TITLE
EVG-16157 Change test logs TTL to 6 months

### DIFF
--- a/units/data_cleanup_test_logs.go
+++ b/units/data_cleanup_test_logs.go
@@ -81,7 +81,7 @@ func (j *dataCleanupTestLogs) Run(ctx context.Context) {
 
 	totalDocs, _ := j.env.DB().Collection(model.TestLogCollection).EstimatedDocumentCount(ctx)
 
-	timestamp := time.Now().Add(time.Duration(-365*24) * time.Hour)
+	timestamp := time.Now().Add(time.Duration(-182*24) * time.Hour)
 LOOP:
 	for {
 		select {


### PR DESCRIPTION
Since we changed the test results TTL to 6 months, we should also change the test logs TTL.