### PR TITLE
EVG-15335 Update host extension error messages

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -324,10 +324,9 @@ func ModifySpawnHost(ctx context.Context, env evergreen.Environment, host *host.
 func MakeExtendedSpawnHostExpiration(host *host.Host, extendBy time.Duration) (time.Time, error) {
 	if err := host.PastMaxExpiration(extendBy); err != nil {
 		return time.Time{}, err
-	} else {
-		newExp := host.ExpirationTime.Add(extendBy)
-		return newExp, nil
 	}
+	newExp := host.ExpirationTime.Add(extendBy)
+	return newExp, nil
 }
 
 func modifySpawnHostProviderSettings(d distro.Distro, settings *evergreen.Settings, region, volumeID string) ([]*birch.Document, error) {

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -324,15 +324,10 @@ func ModifySpawnHost(ctx context.Context, env evergreen.Environment, host *host.
 func MakeExtendedSpawnHostExpiration(host *host.Host, extendBy time.Duration) (time.Time, error) {
 	if err := host.PastMaxExpiration(extendBy); err != nil {
 		return time.Time{}, err
+	} else {
+		newExp := host.ExpirationTime.Add(extendBy)
+		return newExp, nil
 	}
-
-	newExp := host.ExpirationTime.Add(extendBy)
-	remainingDuration := newExp.Sub(time.Now()) //nolint
-	if remainingDuration > evergreen.MaxSpawnHostExpirationDurationHours {
-		return time.Time{}, errors.Errorf("Can not extend host '%s' expiration by '%s'. Maximum host duration is limited to %s", host.Id, extendBy.String(), evergreen.MaxSpawnHostExpirationDurationHours.String())
-	}
-
-	return newExp, nil
 }
 
 func modifySpawnHostProviderSettings(d distro.Distro, settings *evergreen.Settings, region, volumeID string) ([]*birch.Document, error) {

--- a/cloud/spawn_test.go
+++ b/cloud/spawn_test.go
@@ -45,19 +45,6 @@ func TestMakeExtendedHostExpiration(t *testing.T) {
 	assert.NoError(err, expTime.Format(time.RFC3339))
 }
 
-func TestMakeExtendedHostExpirationFailsBeyondOneWeek(t *testing.T) {
-	assert := assert.New(t)
-
-	h := host.Host{
-		CreationTime:   time.Now(),
-		ExpirationTime: time.Now().Add(12 * time.Hour),
-	}
-
-	expTime, err := MakeExtendedSpawnHostExpiration(&h, 24*14*time.Hour)
-	assert.Zero(expTime)
-	assert.Error(err, expTime.Format(time.RFC3339))
-}
-
 func TestMakeExtendedHostExpirationFailsPastMax(t *testing.T) {
 	assert := assert.New(t)
 
@@ -69,7 +56,7 @@ func TestMakeExtendedHostExpirationFailsPastMax(t *testing.T) {
 	expTime, err := MakeExtendedSpawnHostExpiration(&h, time.Hour)
 	assert.Zero(expTime)
 	assert.Error(err)
-	assert.Contains(err.Error(), "cannot be extended further")
+	assert.Contains(err.Error(), "cannot be extended more than")
 
 	h.CreationTime = time.Now().Add(-25 * time.Hour * 24)
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1869,12 +1869,9 @@ func (h *Host) UpdateParentIDs() error {
 // than the new 30 day expiration (unless it is set to unexpirable again #loophole)
 func (h *Host) PastMaxExpiration(extension time.Duration) error {
 	maxExpirationTime := h.CreationTime.Add(evergreen.SpawnHostExpireDays * time.Hour * 24)
-	if h.ExpirationTime.After(maxExpirationTime) {
-		return errors.New("Spawn host cannot be extended further")
-	}
-
 	proposedTime := h.ExpirationTime.Add(extension)
-	if proposedTime.After(maxExpirationTime) {
+
+	if h.ExpirationTime.After(maxExpirationTime) || proposedTime.After(maxExpirationTime) {
 		return errors.Errorf("Spawn host cannot be extended more than %d days past creation", evergreen.SpawnHostExpireDays)
 	}
 	return nil


### PR DESCRIPTION
[EVG-15335](https://jira.mongodb.org/browse/EVG-15335)

### Description 
Previous behavior: 
does not allow hosts to be extended 30 past their creation dates
can only extend up to 2 weeks from the current time 

Now: 
only checks that you can't extend the host beyond 30 days after creation

### Testing 
![image](https://user-images.githubusercontent.com/26491602/154754113-4709d3f9-c42f-46cb-8514-6033123e7eeb.png)