### PR TITLE
EVG-16391 Add will run to taskStatus list

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -292,6 +292,9 @@ var TaskStatuses = []string{
 	TaskSystemUnresponse,
 	TaskSystemTimedOut,
 	TaskTimedOut,
+	TaskWillRun,
+	TaskUnscheduled,
+	TaskUndispatched,
 }
 
 var InternalAliases = []string{


### PR DESCRIPTION
[EVG-16391](https://jira.mongodb.org/browse/EVG-16391)

### Description 
Will run and a few other task statuses were missing from the TaskStatuses list. They are used [here](https://github.com/evergreen-ci/evergreen/blob/73ba9f83725d2edbce41efa2995fad2317043b89/graphql/util.go#L1433-L1440) to determine what filters we can apply. 

