### PR TITLE
EVG-15934 Add hint to UnscheduleStaleUnderwaterTasks

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -21,7 +21,7 @@ const (
 )
 
 var (
-	ActivatedTasksByDistroIndex = bson.D{
+	activatedTasksByDistroIndex = bson.D{
 		{Key: DistroIdKey, Value: 1},
 		{Key: StatusKey, Value: 1},
 		{Key: ActivatedKey, Value: 1},

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -21,6 +21,15 @@ const (
 )
 
 var (
+	ActivatedTasksByDistroIndex = bson.D{
+		{Key: DistroIdKey, Value: 1},
+		{Key: StatusKey, Value: 1},
+		{Key: ActivatedKey, Value: 1},
+		{Key: PriorityKey, Value: 1},
+	}
+)
+
+var (
 	// BSON fields for the task struct
 	IdKey                       = bsonutil.MustHaveTag(Task{}, "Id")
 	SecretKey                   = bsonutil.MustHaveTag(Task{}, "Secret")
@@ -1520,6 +1529,18 @@ func UpdateAll(query interface{}, update interface{}) (*adb.ChangeInfo, error) {
 		query,
 		update,
 	)
+}
+
+func UpdateAllWithHint(query interface{}, update interface{}, hint interface{}) (*adb.ChangeInfo, error) {
+	env := evergreen.GetEnvironment()
+	ctx, cancel := env.Context()
+	defer cancel()
+	res, err := env.DB().Collection(Collection).UpdateMany(ctx, query, update, options.Update().SetHint(hint))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &adb.ChangeInfo{Updated: int(res.ModifiedCount)}, nil
 }
 
 // Remove deletes the task of the given id from the database

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1075,7 +1075,9 @@ func UnscheduleStaleUnderwaterHostTasks(distroID string) (int, error) {
 		},
 	}
 
-	info, err := UpdateAll(query, update)
+	// Force the query to use 'distro_1_status_1_activated_1_priority_1'
+	// instead of defaulting to 'status_1_depends_on.status_1_depends_on.unattainable_1'.
+	info, err := UpdateAllWithHint(query, update, ActivatedTasksByDistroIndex)
 	if err != nil {
 		return 0, errors.Wrap(err, "problem unscheduling stale underwater tasks")
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1077,7 +1077,7 @@ func UnscheduleStaleUnderwaterHostTasks(distroID string) (int, error) {
 
 	// Force the query to use 'distro_1_status_1_activated_1_priority_1'
 	// instead of defaulting to 'status_1_depends_on.status_1_depends_on.unattainable_1'.
-	info, err := UpdateAllWithHint(query, update, ActivatedTasksByDistroIndex)
+	info, err := UpdateAllWithHint(query, update, activatedTasksByDistroIndex)
 	if err != nil {
 		return 0, errors.Wrap(err, "problem unscheduling stale underwater tasks")
 	}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1487,7 +1487,7 @@ func TestUnscheduleStaleUnderwaterHostTasksNoDistro(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 	require.NoError(t, db.EnsureIndex(Collection,
-		mongo.IndexModel{Keys: ActivatedTasksByDistroIndex}))
+		mongo.IndexModel{Keys: activatedTasksByDistroIndex}))
 
 	t1 := Task{
 		Id:            "t1",
@@ -1523,7 +1523,7 @@ func TestUnscheduleStaleUnderwaterHostTasksNoDistro(t *testing.T) {
 func TestUnscheduleStaleUnderwaterHostTasksWithDistro(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection, distro.Collection))
 	require.NoError(t, db.EnsureIndex(Collection,
-		mongo.IndexModel{Keys: ActivatedTasksByDistroIndex}))
+		mongo.IndexModel{Keys: activatedTasksByDistroIndex}))
 
 	t1 := Task{
 		Id:            "t1",
@@ -1551,7 +1551,7 @@ func TestUnscheduleStaleUnderwaterHostTasksWithDistro(t *testing.T) {
 func TestUnscheduleStaleUnderwaterHostTasksWithDistroAlias(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection, distro.Collection))
 	require.NoError(t, db.EnsureIndex(Collection,
-		mongo.IndexModel{Keys: ActivatedTasksByDistroIndex}))
+		mongo.IndexModel{Keys: activatedTasksByDistroIndex}))
 
 	t1 := Task{
 		Id:            "t1",

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1486,6 +1486,9 @@ func TestBulkInsert(t *testing.T) {
 func TestUnscheduleStaleUnderwaterHostTasksNoDistro(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
+	require.NoError(t, db.EnsureIndex(Collection,
+		mongo.IndexModel{Keys: ActivatedTasksByDistroIndex}))
+
 	t1 := Task{
 		Id:            "t1",
 		Status:        evergreen.TaskUndispatched,
@@ -1495,9 +1498,23 @@ func TestUnscheduleStaleUnderwaterHostTasksNoDistro(t *testing.T) {
 	}
 	assert.NoError(t1.Insert())
 
+	t2 := Task{
+		Id:            "t2",
+		Status:        evergreen.TaskUndispatched,
+		Activated:     true,
+		Priority:      0,
+		ActivatedTime: time.Time{},
+	}
+	assert.NoError(t2.Insert())
+
 	_, err := UnscheduleStaleUnderwaterHostTasks("")
 	assert.NoError(err)
 	dbTask, err := FindOneId("t1")
+	assert.NoError(err)
+	assert.False(dbTask.Activated)
+	assert.EqualValues(-1, dbTask.Priority)
+
+	dbTask, err = FindOneId("t2")
 	assert.NoError(err)
 	assert.False(dbTask.Activated)
 	assert.EqualValues(-1, dbTask.Priority)
@@ -1505,6 +1522,9 @@ func TestUnscheduleStaleUnderwaterHostTasksNoDistro(t *testing.T) {
 
 func TestUnscheduleStaleUnderwaterHostTasksWithDistro(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection, distro.Collection))
+	require.NoError(t, db.EnsureIndex(Collection,
+		mongo.IndexModel{Keys: ActivatedTasksByDistroIndex}))
+
 	t1 := Task{
 		Id:            "t1",
 		Status:        evergreen.TaskUndispatched,
@@ -1530,6 +1550,9 @@ func TestUnscheduleStaleUnderwaterHostTasksWithDistro(t *testing.T) {
 
 func TestUnscheduleStaleUnderwaterHostTasksWithDistroAlias(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection, distro.Collection))
+	require.NoError(t, db.EnsureIndex(Collection,
+		mongo.IndexModel{Keys: ActivatedTasksByDistroIndex}))
+
 	t1 := Task{
 		Id:            "t1",
 		Status:        evergreen.TaskUndispatched,


### PR DESCRIPTION
[EVG-15934](https://jira.mongodb.org/browse/EVG-15934)

### Description 
add hint to unschedule underwater tasks because using the wrong index was slowing it down 

### Testing 
ran the query on db 
unit tests