### PR TITLE
EVG-14450 add stepback to the commit queue

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -622,7 +622,7 @@ func AbortPatchesWithGithubPatchData(createdBefore time.Time, closed bool, newPa
 				if mergeTask == nil {
 					return errors.New("no merge task found")
 				}
-				catcher.Add(DequeueAndRestart(mergeTask, evergreen.APIServerTaskActivator, "new push to pull request"))
+				catcher.Add(DequeueAndRestartForTask(nil, mergeTask, message.GithubStateFailure, evergreen.APIServerTaskActivator, "new push to pull request"))
 			} else if err = CancelPatch(&p, task.AbortInfo{User: evergreen.GithubPatchUser, NewVersion: newPatch, PRClosed: closed}); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"source":         "github hook",

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1616,6 +1616,29 @@ func AbortTasksForVersion(versionId string, taskIds []string, caller string) err
 	return err
 }
 
+// HasUnfinishedTaskForVersion returns true if there are any scheduled but
+// unfinished tasks matching the given conditions.
+func HasUnfinishedTaskForVersions(versionIds []string, taskName, variantName string) (bool, error) {
+	count, err := Count(
+		db.Query(bson.M{
+			VersionKey:      bson.M{"$in": versionIds},
+			DisplayNameKey:  taskName,
+			BuildVariantKey: variantName,
+			StatusKey:       bson.M{"$in": evergreen.TaskUncompletedStatuses},
+		}))
+	return count > 0, err
+}
+
+// FindTaskForVersion returns a task matching the given version and task info.
+func FindTaskForVersion(versionId, taskName, variantName string) (*Task, error) {
+	return FindOne(
+		db.Query(bson.M{
+			VersionKey:      versionId,
+			DisplayNameKey:  taskName,
+			BuildVariantKey: variantName,
+		}))
+}
+
 func AddHostCreateDetails(taskId, hostId string, execution int, hostCreateError error) error {
 	if hostCreateError == nil {
 		return nil

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -118,10 +118,6 @@ func SetActiveState(t *task.Task, caller string, active bool) error {
 		}
 
 		if t.Requester == evergreen.MergeTestRequester {
-			_, err = commitqueue.RemoveCommitQueueItemForVersion(t.Project, t.Version, caller)
-			if err != nil {
-				return err
-			}
 			p, err := patch.FindOneId(t.Version)
 			if err != nil {
 				return errors.Wrap(err, "unable to find patch")
@@ -129,14 +125,8 @@ func SetActiveState(t *task.Task, caller string, active bool) error {
 			if p == nil {
 				return errors.New("patch not found")
 			}
-			err = SendCommitQueueResult(p, message.GithubStateError, fmt.Sprintf("deactivated by '%s'", caller))
-			grip.Error(message.WrapError(err, message.Fields{
-				"message": "unable to send github status",
-				"patch":   t.Version,
-			}))
-			err = RestartItemsAfterVersion(nil, t.Project, t.Version, caller)
-			if err != nil {
-				return errors.Wrap(err, "error restarting later commit queue items")
+			if err = DequeueAndRestartForTask(nil, t, message.GithubStateError, caller, fmt.Sprintf("deactivated by '%s'", caller)); err != nil {
+				return err
 			}
 		}
 	} else {
@@ -657,40 +647,6 @@ func UpdateUnblockedDependencies(t *task.Task, logIDs bool, caller string) error
 	return nil
 }
 
-func DequeueAndRestart(t *task.Task, caller, reason string) error {
-	cq, err := commitqueue.FindOneId(t.Project)
-	if err != nil {
-		return errors.Wrapf(err, "can't get commit queue for id '%s'", t.Project)
-	}
-	if cq == nil {
-		return errors.Errorf("no commit queue found for '%s'", t.Project)
-	}
-
-	// this must be done before dequeuing so that we know which entries to restart
-	if err = RestartItemsAfterVersion(cq, t.Project, t.Version, caller); err != nil {
-		return errors.Wrap(err, "unable to restart versions")
-	}
-
-	if err = tryDequeueAndAbortCommitQueueVersion(t, *cq, caller); err != nil {
-		return err
-	}
-
-	p, err := patch.FindOneId(t.Version)
-	if err != nil {
-		return errors.Wrap(err, "unable to find patch")
-	}
-	if p == nil {
-		return errors.New("patch not found")
-	}
-	err = SendCommitQueueResult(p, message.GithubStateFailure, reason)
-	grip.Error(message.WrapError(err, message.Fields{
-		"message": "unable to send github status",
-		"patch":   t.Version,
-	}))
-
-	return nil
-}
-
 func RestartItemsAfterVersion(cq *commitqueue.CommitQueue, project, version, caller string) error {
 	if cq == nil {
 		var err error
@@ -727,21 +683,47 @@ func RestartItemsAfterVersion(cq *commitqueue.CommitQueue, project, version, cal
 	return catcher.Resolve()
 }
 
-func tryDequeueAndAbortCommitQueueVersion(t *task.Task, cq commitqueue.CommitQueue, caller string) error {
-	p, err := patch.FindOne(patch.ByVersion(t.Version))
+// DequeueAndRestartForTask restarts all items after the given task's version, aborts/dequeues the current version,
+// and sends an updated status to GitHub.
+func DequeueAndRestartForTask(cq *commitqueue.CommitQueue, t *task.Task, githubState message.GithubState, caller, reason string) error {
+	if cq == nil {
+		var err error
+		cq, err = commitqueue.FindOneId(t.Project)
+		if err != nil {
+			return errors.Wrapf(err, "can't get commit queue for id '%s'", t.Project)
+		}
+		if cq == nil {
+			return errors.Errorf("no commit queue found for '%s'", t.Project)
+		}
+	}
+	// this must be done before dequeuing so that we know which entries to restart
+	if err := RestartItemsAfterVersion(cq, t.Project, t.Version, caller); err != nil {
+		return errors.Wrap(err, "unable to restart versions")
+	}
+
+	p, err := patch.FindOneId(t.Version)
 	if err != nil {
-		return errors.Wrapf(err, "error finding patch")
+		return errors.Wrap(err, "unable to find patch")
 	}
 	if p == nil {
-		return errors.Errorf("No patch for task")
+		return errors.New("patch not found")
+	}
+	if err := tryDequeueAndAbortCommitQueueVersion(p, *cq, t.Id, caller); err != nil {
+		return err
 	}
 
-	if !p.IsCommitQueuePatch() {
-		return nil
-	}
+	err = SendCommitQueueResult(p, githubState, reason)
+	grip.Error(message.WrapError(err, message.Fields{
+		"message": "unable to send github status",
+		"patch":   t.Version,
+	}))
 
+	return nil
+}
+
+func tryDequeueAndAbortCommitQueueVersion(p *patch.Patch, cq commitqueue.CommitQueue, taskId string, caller string) error {
 	issue := p.Id.Hex()
-	err = removeNextMergeTaskDependency(cq, issue)
+	err := removeNextMergeTaskDependency(cq, issue)
 	grip.Error(message.WrapError(err, message.Fields{
 		"message": "error removing dependency",
 		"patch":   issue,
@@ -756,7 +738,7 @@ func tryDequeueAndAbortCommitQueueVersion(t *task.Task, cq commitqueue.CommitQue
 		"caller":  caller,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "can't remove and prevent merge for item '%s' from queue '%s'", t.Version, t.Project)
+		return errors.Wrapf(err, "can't remove and prevent merge for item '%s' from queue '%s'", p.Version, p.Project)
 	}
 	if removed == nil {
 		return errors.Errorf("no commit queue entry removed for '%s'", issue)
@@ -771,7 +753,7 @@ func tryDequeueAndAbortCommitQueueVersion(t *task.Task, cq commitqueue.CommitQue
 	}
 
 	event.LogCommitQueueConcludeTest(p.Id.Hex(), evergreen.MergeTestFailed)
-	return errors.Wrapf(CancelPatch(p, task.AbortInfo{TaskID: t.Id, User: caller}), "Error aborting failed commit queue patch")
+	return errors.Wrapf(CancelPatch(p, task.AbortInfo{TaskID: taskId, User: caller}), "Error aborting failed commit queue patch")
 }
 
 // removeNextMergeTaskDependency basically removes the given merge task from a linked list of

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -118,13 +118,6 @@ func SetActiveState(t *task.Task, caller string, active bool) error {
 		}
 
 		if t.Requester == evergreen.MergeTestRequester {
-			p, err := patch.FindOneId(t.Version)
-			if err != nil {
-				return errors.Wrap(err, "unable to find patch")
-			}
-			if p == nil {
-				return errors.New("patch not found")
-			}
 			if err = DequeueAndRestartForTask(nil, t, message.GithubStateError, caller, fmt.Sprintf("deactivated by '%s'", caller)); err != nil {
 				return err
 			}

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -224,13 +225,13 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if t.Requester == evergreen.MergeTestRequester && details.Status != evergreen.TaskSucceeded && !t.Aborted {
-		if err = model.DequeueAndRestart(t, APIServerLockTitle, fmt.Sprintf("task '%s' failed", t.DisplayName)); err != nil {
-			err = errors.Wrapf(err, "Error dequeueing and aborting failed commit queue version")
+	if t.Requester == evergreen.MergeTestRequester {
+		if err = handleEndTaskForCommitQueueTask(t, details.Status); err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}
 	}
+
 	// the task was aborted if it is still in undispatched.
 	// the active state should be inactive.
 	if details.Status == evergreen.TaskUndispatched {
@@ -238,8 +239,8 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 			grip.Warningf("task %v is active and undispatched after being marked as finished", t.Id)
 			return
 		}
-		message := fmt.Sprintf("task %v has been aborted and will not run", t.Id)
-		grip.Infof(message)
+		abortMsg := fmt.Sprintf("task %v has been aborted and will not run", t.Id)
+		grip.Infof(abortMsg)
 		endTaskResp = &apimodels.EndTaskResponse{}
 		gimlet.WriteJSON(w, endTaskResp)
 		return
@@ -317,6 +318,74 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 
 	grip.Info(msg)
 	gimlet.WriteJSON(w, endTaskResp)
+}
+
+func handleEndTaskForCommitQueueTask(t *task.Task, status string) error {
+	cq, err := commitqueue.FindOneId(t.Project)
+	if err != nil {
+		return errors.Wrapf(err, "can't get commit queue for id '%s'", t.Project)
+	}
+	if cq == nil {
+		return errors.Errorf("no commit queue found for '%s'", t.Project)
+	}
+	if status != evergreen.TaskSucceeded && !t.Aborted {
+		return dequeueAndRestartWithStepback(cq, t, APIServerLockTitle, fmt.Sprintf("task '%s' failed", t.DisplayName))
+	} else if status == evergreen.TaskSucceeded {
+		// Query for all cq version tasks after this one; they may have been waiting to see if this
+		// one was the cause of the failure, in which case we should dequeue and restart.
+		foundVersion := false
+		for _, item := range cq.Queue {
+			if item.Version == "" {
+				return nil // no longer looking at scheduled versions
+			}
+			if item.Version == t.Version {
+				foundVersion = true
+				continue
+			}
+			if foundVersion {
+				laterTask, err := task.FindTaskForVersion(item.Version, t.DisplayName, t.BuildVariant)
+				if err != nil {
+					return errors.Wrapf(err, "error finding task for version '%s'", item.Version)
+				}
+				if laterTask == nil {
+					return errors.Errorf("couldn't find task for version '%s'", item.Version)
+				}
+				if evergreen.IsFailedTaskStatus(laterTask.Status) {
+					// Because our task is successful, this task should have failed so we dequeue.
+					return dequeueAndRestartWithStepback(cq, laterTask, APIServerLockTitle,
+						fmt.Sprintf("task '%s' failed and was not impacted by previous task", t.DisplayName))
+				}
+				if !evergreen.IsFinishedTaskStatus(laterTask.Status) {
+					// When this task finishes, it will handle stepping back any later commit queue item, so we're done.
+					return nil
+				}
+			}
+
+		}
+	}
+	return nil
+}
+
+// dequeueAndRestartWithStepback dequeues the current task and restarts later tasks, if earlier tasks have all run.
+// Otherwise, the failure may be a result of those untested commits so we will wait for the earlier tasks to run
+// and handle dequeuing (merge still won't run for failed task versions because of dependencies).
+func dequeueAndRestartWithStepback(cq *commitqueue.CommitQueue, t *task.Task, caller, reason string) error {
+	if i := cq.FindItem(t.Version); i > 0 {
+		prevVersions := []string{}
+		for j := 0; j < i; j++ {
+			prevVersions = append(prevVersions, cq.Queue[j].Version)
+		}
+		// if any of the commit queue tasks higher on the queue haven't finished, then they will handle dequeuing.
+		previousTaskNeedsToRun, err := task.HasUnfinishedTaskForVersions(prevVersions, t.DisplayName, t.BuildVariant)
+		if err != nil {
+			return errors.Wrap(err, "error checking early commit queue tasks")
+		}
+		if previousTaskNeedsToRun {
+			return nil
+		}
+		// Otherwise, continue on and dequeue.
+	}
+	return model.DequeueAndRestartForTask(cq, t, message.GithubStateFailure, caller, reason)
 }
 
 // fixIntentHostRunningAgent handles an exceptional case in which an ephemeral

--- a/service/build.go
+++ b/service/build.go
@@ -177,11 +177,6 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if projCtx.Build.Requester == evergreen.MergeTestRequester {
-			_, err = commitqueue.RemoveCommitQueueItemForVersion(projCtx.ProjectRef.Id, projCtx.Build.Version, user.Id)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
 			p, err := patch.FindOneId(projCtx.Build.Version)
 			if err != nil {
 				http.Error(w, "Error finding patch", http.StatusInternalServerError)
@@ -197,6 +192,11 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 				"patch":   projCtx.Build.Version,
 			}))
 			err = model.RestartItemsAfterVersion(nil, projCtx.Build.Project, projCtx.Build.Version, user.Id)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_, err = commitqueue.RemoveCommitQueueItemForVersion(projCtx.ProjectRef.Id, projCtx.Build.Version, user.Id)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -245,11 +245,6 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if !putParams.Active && projCtx.Build.Requester == evergreen.MergeTestRequester {
-			_, err = commitqueue.RemoveCommitQueueItemForVersion(projCtx.ProjectRef.Id, projCtx.Build.Version, user.Id)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
 			p, err := patch.FindOneId(projCtx.Build.Version)
 			if err != nil {
 				http.Error(w, "Error finding patch", http.StatusInternalServerError)
@@ -265,6 +260,11 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 				"patch":   projCtx.Build.Version,
 			}))
 			err = model.RestartItemsAfterVersion(nil, projCtx.Build.Project, projCtx.Build.Version, user.Id)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_, err = commitqueue.RemoveCommitQueueItemForVersion(projCtx.ProjectRef.Id, projCtx.Build.Version, user.Id)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return

--- a/service/version.go
+++ b/service/version.go
@@ -256,7 +256,7 @@ func (uis *UIServer) modifyVersion(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	httpStatus, err := graphql.ModifyVersion(*projCtx.Version, *user, projCtx.ProjectRef, modifications)
+	httpStatus, err := graphql.ModifyVersion(*projCtx.Version, *user, modifications)
 	if err != nil {
 		http.Error(w, err.Error(), httpStatus)
 		return


### PR DESCRIPTION
[EVG-14450](https://jira.mongodb.org/browse/EVG-14450)

### Description 
* Added stepback to the commit queue: this is described more in the ticket but if previous versions on the queue haven't run yet, we don't know if the failure is due to that commit or not, so dequeuing the current version may be the wrong thing to do, and then the user has to go through the process again.
* Lightly refactored some code to have less duplication and to possibly fix errors where we aren't restarting versions because we dequeue the item before looking for which versions to restart.

### Testing 
Added a test to cover all the scenarios I can think of, will also try to test at least one or two of them on staging.