### PR TITLE
EVG-16338 error saving a project if github conflicts exist

### DIFF
--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
@@ -83,36 +84,55 @@ func (sc *DBConnector) SaveProjectSettingsForSection(ctx context.Context, projec
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting before project settings event")
 	}
+
 	v, err := changes.ProjectRef.ToService()
 	if err != nil {
 		return nil, errors.Wrap(err, "error converting project ref")
 	}
 	newProjectRef := v.(*model.ProjectRef)
-	// If the project ref doesn't use the repo, or we're using a repo ref, then this will just be the same as newProjectRef.
-	// Used to verify that if something is set to nil in the request, we properly validate using the merged project ref.
+
+	// If the project ref doesn't use the repo, or we're using a repo ref, then this will just be the same as the passed in ref.
+	// Used to verify that if something is set to nil, we properly validate using the merged project ref.
 	mergedProjectRef, err := model.GetProjectRefMergedWithRepo(*newProjectRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error merging project ref")
+	}
+	mergedBeforeRef, err := model.GetProjectRefMergedWithRepo(before.ProjectRef)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting the original merged project ref")
 	}
 
 	catcher := grip.NewBasicCatcher()
 	modified := false
 	switch section {
 	case model.ProjectPageGeneralSection:
-		// check if webhook is enabled if the owner/repo has changed
-		if mergedProjectRef.Owner != before.ProjectRef.Owner || mergedProjectRef.Repo != before.ProjectRef.Repo {
+		// only need to check Github conflicts once so we use else if statements to handle this
+		if mergedProjectRef.Owner != mergedBeforeRef.Owner || mergedProjectRef.Repo != mergedBeforeRef.Repo {
+			if err = handleGithubConflicts(mergedProjectRef, "Changing owner/repo"); err != nil {
+				return nil, err
+			}
+			// check if webhook is enabled if the owner/repo has changed
 			_, err = sc.EnableWebhooks(ctx, mergedProjectRef)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Error enabling webhooks for project '%s'", projectId)
 			}
+			modified = true
+		} else if mergedProjectRef.IsEnabled() && !mergedBeforeRef.IsEnabled() {
+			if err = handleGithubConflicts(mergedProjectRef, "Enabling project"); err != nil {
+				return nil, err
+			}
+		} else if mergedProjectRef.Branch != mergedBeforeRef.Branch {
+			if err = handleGithubConflicts(mergedProjectRef, "Changing branch"); err != nil {
+				return nil, err
+			}
 		}
-		modified = true
+
 	case model.ProjectPageAccessSection:
 		// For any admins that are only in the original settings, remove access.
 		// For any admins that are only in the updated settings, give them access.
-		adminsToDelete, adminsToAdd := utility.StringSliceSymmetricDifference(before.ProjectRef.Admins, mergedProjectRef.Admins)
-		makeRestricted := !before.ProjectRef.IsRestricted() && mergedProjectRef.IsRestricted()
-		makeUnrestricted := before.ProjectRef.IsRestricted() && !mergedProjectRef.IsRestricted()
+		adminsToDelete, adminsToAdd := utility.StringSliceSymmetricDifference(mergedBeforeRef.Admins, mergedProjectRef.Admins)
+		makeRestricted := !mergedBeforeRef.IsRestricted() && mergedProjectRef.IsRestricted()
+		makeUnrestricted := mergedBeforeRef.IsRestricted() && !mergedProjectRef.IsRestricted()
 		if isRepo {
 			modified = true
 			// For repos, we need to use the repo ref functions, as they update different scopes/roles.
@@ -139,11 +159,11 @@ func (sc *DBConnector) SaveProjectSettingsForSection(ctx context.Context, projec
 				}
 			}
 			if makeRestricted {
-				catcher.Wrap(before.ProjectRef.MakeRestricted(), "error making branch restricted")
+				catcher.Wrap(mergedBeforeRef.MakeRestricted(), "error making branch restricted")
 				modified = true
 			}
 			if makeUnrestricted {
-				catcher.Wrap(before.ProjectRef.MakeUnrestricted(), "error making branch unrestricted")
+				catcher.Wrap(mergedBeforeRef.MakeUnrestricted(), "error making branch unrestricted")
 				modified = true
 			}
 		}
@@ -159,7 +179,14 @@ func (sc *DBConnector) SaveProjectSettingsForSection(ctx context.Context, projec
 			return nil, errors.Wrapf(err, "Database error updating variables for project '%s'", projectId)
 		}
 		modified = true
-	case model.ProjectPageGithubAndCQSection, model.ProjectPagePatchAliasSection:
+	case model.ProjectPageGithubAndCQSection:
+		if err = handleGithubConflicts(mergedProjectRef, "Toggling GitHub features"); err != nil {
+			return nil, err
+		}
+
+		modified, err = sc.UpdateAliasesForSection(projectId, changes.Aliases, before.Aliases, section)
+		catcher.Add(err)
+	case model.ProjectPagePatchAliasSection:
 		modified, err = sc.UpdateAliasesForSection(projectId, changes.Aliases, before.Aliases, section)
 		catcher.Add(err)
 	case model.ProjectPageNotificationsSection:
@@ -201,4 +228,31 @@ func (sc *DBConnector) SaveProjectSettingsForSection(ctx context.Context, projec
 		}
 	}
 	return &res, errors.Wrapf(catcher.Resolve(), "error saving section '%s'", section)
+}
+
+func handleGithubConflicts(pRef *model.ProjectRef, reason string) error {
+	if !pRef.IsPRTestingEnabled() && !pRef.CommitQueue.IsEnabled() && !pRef.IsGithubChecksEnabled() {
+		return nil // if nothing is toggled on, then there's no reason to look for conflicts
+	}
+	conflictMsgs := []string{}
+	conflicts, err := pRef.GetGithubProjectConflicts()
+	if err != nil {
+		return errors.Wrapf(err, "error getting github project conflicts")
+	}
+
+	if pRef.IsPRTestingEnabled() && len(conflicts.PRTestingIdentifiers) > 0 {
+		conflictMsgs = append(conflictMsgs, "PR testing")
+	}
+	if pRef.CommitQueue.IsEnabled() && len(conflicts.CommitQueueIdentifiers) > 0 {
+		conflictMsgs = append(conflictMsgs, "the commit queue")
+	}
+	if pRef.IsGithubChecksEnabled() && len(conflicts.CommitCheckIdentifiers) > 0 {
+		conflictMsgs = append(conflictMsgs, "commit checks")
+	}
+
+	if len(conflictMsgs) > 0 {
+		return errors.Errorf("%s would create conflicts for %s. Please turn off these settings or address conflicts and try again.",
+			reason, strings.Join(conflictMsgs, " and "))
+	}
+	return nil
 }


### PR DESCRIPTION
[EVG-16338](https://jira.mongodb.org/browse/EVG-16338)

### Description 
The UI handles this but we're adding to the backend in case things race and just to be careful. Enabling a project or a toggle, or changing owner/repo/branch are things that could affect this.
### Testing 
Added a test.
