### PR TITLE
EVG-16397 set new filter field

### DIFF
--- a/graphql/tests/saveSubscription/results.json
+++ b/graphql/tests/saveSubscription/results.json
@@ -82,7 +82,7 @@
       "result": {
         "errors": [
           {
-            "message": "error saving subscription: 400 (Bad Request): Invalid regex selectors: Selector had empty type or data",
+            "message": "error saving subscription: 400 (Bad Request): Error parsing request body: setting filter from selectors: selector has an empty type",
             "path": ["saveSubscription"],
             "extensions": { "code": "INTERNAL_SERVER_ERROR" }
           }

--- a/graphql/tests/saveSubscription/results.json
+++ b/graphql/tests/saveSubscription/results.json
@@ -82,7 +82,7 @@
       "result": {
         "errors": [
           {
-            "message": "error saving subscription: 400 (Bad Request): Error parsing request body: setting filter from selectors: selector has an empty type",
+            "message": "error saving subscription: 400 (Bad Request): Error parsing request body: setting filter from selectors: selector has an empty type\nselector '' has no data",
             "path": ["saveSubscription"],
             "extensions": { "code": "INTERNAL_SERVER_ERROR" }
           }

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -133,6 +133,7 @@ type Selector struct {
 	Data string `bson:"data"`
 }
 
+// Filter specifies the event properties that are of interest.
 type Filter struct {
 	Object       string `bson:"object,omitempty"`
 	ID           string `bson:"id,omitempty"`
@@ -175,6 +176,7 @@ func (f *Filter) setFieldFromSelector(selector Selector) error {
 	return nil
 }
 
+// FromSelectors sets the filter's properties from the selectors' data.
 func (f *Filter) FromSelectors(selectors []Selector) error {
 	catcher := grip.NewBasicCatcher()
 	typesSeen := make(map[string]bool)
@@ -194,9 +196,7 @@ func (f *Filter) FromSelectors(selectors []Selector) error {
 		}
 		typesSeen[selector.Type] = true
 
-		if err := f.setFieldFromSelector(selector); err != nil {
-			catcher.Wrap(err, "setting field from selector")
-		}
+		catcher.Wrap(f.setFieldFromSelector(selector), "setting field from selector")
 	}
 
 	return catcher.Resolve()

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -183,18 +183,19 @@ func (f *Filter) FromSelectors(selectors []Selector) error {
 	for _, selector := range selectors {
 		if selector.Type == "" {
 			catcher.New("selector has an empty type")
-			continue
 		}
 		if selector.Data == "" {
 			catcher.Errorf("selector '%s' has no data", selector.Type)
-			continue
 		}
 
 		if typesSeen[selector.Type] {
 			catcher.Errorf("selector type '%s' specified more than once", selector.Type)
-			continue
 		}
 		typesSeen[selector.Type] = true
+
+		if catcher.HasErrors() {
+			continue
+		}
 
 		catcher.Wrap(f.setFieldFromSelector(selector), "setting field from selector")
 	}

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -276,7 +276,7 @@ func (s *subscriptionsSuite) TestRegexSelectorsMatch() {
 func (s *subscriptionsSuite) TestFilterFromSelectors() {
 	for _, sub := range s.subscriptions {
 		filter := Filter{}
-		s.NoError(filter.FromSelectors(append(sub.Selectors, sub.RegexSelectors...)))
+		s.Require().NoError(filter.FromSelectors(append(sub.Selectors, sub.RegexSelectors...)))
 		s.Equal(sub.Filter, filter)
 	}
 

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -63,19 +63,6 @@ func (dc *DBSubscriptionConnector) SaveSubscriptions(owner string, subscriptions
 			}
 		}
 
-		if ok, msg := event.ValidateSelectors(dbSubscription.Selectors); !ok {
-			return gimlet.ErrorResponse{
-				StatusCode: http.StatusBadRequest,
-				Message:    fmt.Sprintf("Invalid selectors: %s", msg),
-			}
-		}
-		if ok, msg := event.ValidateSelectors(dbSubscription.RegexSelectors); !ok {
-			return gimlet.ErrorResponse{
-				StatusCode: http.StatusBadRequest,
-				Message:    fmt.Sprintf("Invalid regex selectors: %s", msg),
-			}
-		}
-
 		err = dbSubscription.Validate()
 		if err != nil {
 			return gimlet.ErrorResponse{

--- a/rest/model/subscriptions.go
+++ b/rest/model/subscriptions.go
@@ -1,10 +1,9 @@
 package model
 
 import (
-	"errors"
-
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
 )
 
 type APISelector struct {
@@ -122,6 +121,10 @@ func (s *APISubscription) ToService() (interface{}, error) {
 			return nil, errors.New("unable to convert selector")
 		}
 		out.RegexSelectors = append(out.RegexSelectors, newSelector)
+	}
+
+	if err = out.Filter.FromSelectors(append(out.Selectors, out.RegexSelectors...)); err != nil {
+		return nil, errors.Wrap(err, "setting filter from selectors")
 	}
 
 	return out, nil

--- a/rest/model/subscriptions_test.go
+++ b/rest/model/subscriptions_test.go
@@ -10,27 +10,37 @@ import (
 
 func TestSubscriptionModels(t *testing.T) {
 	assert := assert.New(t)
+
+	owner := "me"
+	id := "abcde12345"
+	project := "mci"
+
 	subscription := event.Subscription{
 		ID:           mgobson.NewObjectId().Hex(),
 		ResourceType: "atype",
 		Trigger:      "atrigger",
-		Owner:        "me",
+		Owner:        owner,
 		OwnerType:    event.OwnerTypePerson,
 		Selectors: []event.Selector{
 			{
-				Type: "type1",
-				Data: "data1",
+				Type: event.SelectorID,
+				Data: id,
 			},
 		},
 		RegexSelectors: []event.Selector{
 			{
-				Type: "type2",
-				Data: "data2",
+				Type: event.SelectorOwner,
+				Data: owner,
 			},
 			{
-				Type: "type3",
-				Data: "data3",
+				Type: event.SelectorProject,
+				Data: project,
 			},
+		},
+		Filter: event.Filter{
+			ID:      id,
+			Owner:   owner,
+			Project: project,
 		},
 		Subscriber: event.Subscriber{
 			Type:   event.EmailSubscriberType,

--- a/rest/route/subscription_test.go
+++ b/rest/route/subscription_test.go
@@ -54,8 +54,8 @@ func (s *SubscriptionRouteSuite) TestSubscriptionPost() {
 		"owner":         "me",
 		"owner_type":    "person",
 		"selectors": []map[string]string{{
-			"type": "seltype",
-			"data": "seldata",
+			"type": event.SelectorObject,
+			"data": "obj",
 		}},
 		"subscriber": map[string]string{
 			"type":   "slack",
@@ -79,7 +79,7 @@ func (s *SubscriptionRouteSuite) TestSubscriptionPost() {
 	s.NoError(err)
 	s.Require().Len(dbSubscriptions, 1)
 	s.Equal(event.ResourceTypeTask, dbSubscriptions[0].ResourceType)
-	s.Equal("seldata", dbSubscriptions[0].Selectors[0].Data)
+	s.Equal("obj", dbSubscriptions[0].Filter.Object)
 	s.Equal("slack", dbSubscriptions[0].Subscriber.Type)
 
 	// test updating the same subscription
@@ -91,8 +91,8 @@ func (s *SubscriptionRouteSuite) TestSubscriptionPost() {
 		"owner":         "me",
 		"owner_type":    "person",
 		"selectors": []map[string]string{{
-			"type": "seltype",
-			"data": "seldata",
+			"type": event.SelectorObject,
+			"data": "obj",
 		}},
 		"subscriber": map[string]string{
 			"type":   "slack",
@@ -125,8 +125,8 @@ func (s *SubscriptionRouteSuite) TestProjectSubscription() {
 		"owner":         "myproj",
 		"owner_type":    "project",
 		"selectors": []map[string]string{{
-			"type": "seltype",
-			"data": "seldata",
+			"type": event.SelectorObject,
+			"data": "obj",
 		}},
 		"subscriber": map[string]string{
 			"type":   "email",
@@ -149,7 +149,7 @@ func (s *SubscriptionRouteSuite) TestProjectSubscription() {
 	s.NoError(err)
 	s.Require().Len(dbSubscriptions, 1)
 	s.Equal(event.ResourceTypeTask, dbSubscriptions[0].ResourceType)
-	s.Equal("seldata", dbSubscriptions[0].Selectors[0].Data)
+	s.Equal("obj", dbSubscriptions[0].Filter.Object)
 	s.Equal("email", dbSubscriptions[0].Subscriber.Type)
 
 	// test updating the same subscription
@@ -161,8 +161,8 @@ func (s *SubscriptionRouteSuite) TestProjectSubscription() {
 		"owner":         "myproj",
 		"owner_type":    "project",
 		"selectors": []map[string]string{{
-			"type": "seltype",
-			"data": "seldata",
+			"type": event.SelectorObject,
+			"data": "obj",
 		}},
 		"subscriber": map[string]string{
 			"type":   "email",
@@ -208,8 +208,8 @@ func (s *SubscriptionRouteSuite) TestPostUnauthorizedUser() {
 		"owner":         "not_me",
 		"owner_type":    "person",
 		"selectors": []map[string]string{{
-			"type": "seltype",
-			"data": "seldata",
+			"type": event.SelectorObject,
+			"data": "obj",
 		}},
 		"subscriber": map[string]string{
 			"type":   "slack",
@@ -295,7 +295,7 @@ func (s *SubscriptionRouteSuite) TestDisallowedSubscription() {
 		"owner":         "me",
 		"owner_type":    "person",
 		"selectors": []map[string]string{{
-			"type": "object",
+			"type": event.SelectorObject,
 			"data": "version",
 		}},
 		"subscriber": map[string]interface{}{
@@ -325,7 +325,7 @@ func (s *SubscriptionRouteSuite) TestDisallowedSubscription() {
 		"owner":         "me",
 		"owner_type":    "person",
 		"selectors": []map[string]string{{
-			"type": "project",
+			"type": event.SelectorProject,
 			"data": "mci",
 		}},
 		"subscriber": map[string]interface{}{
@@ -353,7 +353,7 @@ func (s *SubscriptionRouteSuite) TestInvalidTriggerData() {
 		"owner":         "me",
 		"owner_type":    "person",
 		"selectors": []map[string]string{{
-			"type": "object",
+			"type": event.SelectorObject,
 			"data": "task",
 		}},
 		"subscriber": map[string]string{
@@ -382,7 +382,7 @@ func (s *SubscriptionRouteSuite) TestInvalidTriggerData() {
 		"owner":         "me",
 		"owner_type":    "person",
 		"selectors": []map[string]string{{
-			"type": "object",
+			"type": event.SelectorObject,
 			"data": "task",
 		}},
 		"subscriber": map[string]string{
@@ -411,7 +411,7 @@ func (s *SubscriptionRouteSuite) TestInvalidTriggerData() {
 		"owner":         "me",
 		"owner_type":    "person",
 		"selectors": []map[string]string{{
-			"type": "object",
+			"type": event.SelectorObject,
 			"data": "task",
 		}},
 		"subscriber": map[string]string{
@@ -440,7 +440,7 @@ func (s *SubscriptionRouteSuite) TestInvalidTriggerData() {
 		"owner":         "me",
 		"owner_type":    "person",
 		"selectors": []map[string]string{{
-			"type": "object",
+			"type": event.SelectorObject,
 			"data": "",
 		}},
 		"subscriber": map[string]string{
@@ -458,7 +458,7 @@ func (s *SubscriptionRouteSuite) TestInvalidTriggerData() {
 	s.Require().Equal(400, resp.Status())
 	respErr, ok = resp.Data().(gimlet.ErrorResponse)
 	s.True(ok)
-	s.Equal("Invalid selectors: Selector had empty type or data", respErr.Message)
+	s.Contains(respErr.Message, "selector 'object' has no data")
 }
 
 func (s *SubscriptionRouteSuite) TestInvalidRegexSelectors() {
@@ -473,7 +473,7 @@ func (s *SubscriptionRouteSuite) TestInvalidRegexSelectors() {
 		"owner":         "me",
 		"owner_type":    "person",
 		"regex_selectors": []map[string]string{{
-			"type": "object",
+			"type": event.SelectorObject,
 			"data": "",
 		}},
 		"subscriber": map[string]string{
@@ -490,7 +490,7 @@ func (s *SubscriptionRouteSuite) TestInvalidRegexSelectors() {
 	s.Equal(400, resp.Status())
 	respErr, ok := resp.Data().(gimlet.ErrorResponse)
 	s.True(ok)
-	s.Equal("Invalid regex selectors: Selector had empty type or data", respErr.Message)
+	s.Contains(respErr.Message, "selector 'object' has no data")
 
 	body[0]["regex_selectors"] = []map[string]string{{
 		"type": "",
@@ -505,7 +505,7 @@ func (s *SubscriptionRouteSuite) TestInvalidRegexSelectors() {
 	s.Equal(400, resp.Status())
 	respErr, ok = resp.Data().(gimlet.ErrorResponse)
 	s.True(ok)
-	s.Equal("Invalid regex selectors: Selector had empty type or data", respErr.Message)
+	s.Contains(respErr.Message, "selector has an empty type")
 }
 
 func (s *SubscriptionRouteSuite) TestRejectSubscriptionWithoutSelectors() {
@@ -533,7 +533,7 @@ func (s *SubscriptionRouteSuite) TestRejectSubscriptionWithoutSelectors() {
 	s.Equal(400, resp.Status())
 	respErr, ok := resp.Data().(gimlet.ErrorResponse)
 	s.True(ok)
-	s.Equal("Error validating subscription: must specify at least 1 selector", respErr.Message)
+	s.Contains(respErr.Message, "no filter parameters specified")
 }
 
 func (s *SubscriptionRouteSuite) TestAcceptSubscriptionWithOnlyRegexSelectors() {
@@ -548,7 +548,7 @@ func (s *SubscriptionRouteSuite) TestAcceptSubscriptionWithOnlyRegexSelectors() 
 		"owner":         "me",
 		"owner_type":    "person",
 		"regex_selectors": []map[string]string{{
-			"type": "object",
+			"type": event.SelectorObject,
 			"data": "data",
 		}},
 		"subscriber": map[string]string{


### PR DESCRIPTION
[EVG-16397](https://jira.mongodb.org/browse/EVG-16397)

### Description 
Add a Filter subdocument to subscription documents. 

My objective is outlined in the ticket. I think this subdocument can be supported by a new, large, compound index. It has an additional advantage that we can just pass regexes to the db instead of fetching everything for the regular selectors and filtering on regexes in the application.

I plan to do this in four stages 
1. This PR duplicates the selectors in a subdocument I think could be supported by an index.
2. I will do a migration to do the same for existing subscription documents.
3. I will open a second PR to change the subscriptions query to use the new field.
4. I will open a third PR to stop saving the selectors array.

I don't plan to remove the selectors array from APISubscriptions so as to preserve the API. But internally we will eventually cease to save the selectors as an array.

### Testing 
I confirmed in staging that I could create a subscription on a random version
```javascript
  {
    _id: '621928a1b237365520f3de7e',
    filter: {
      object: 'version',
      id: 'evg_cfc42b391f1df0da73b73758e58ee50b5a870b27'
    },
    owner_type: 'person',
    type: 'VERSION',
    selectors: [
      { type: 'object', data: 'version' },
      {
        type: 'id',
        data: 'evg_cfc42b391f1df0da73b73758e58ee50b5a870b27'
      }
    ],
    regex_selectors: [],
    trigger_data: {},
    trigger: 'failure',
    subscriber: { type: 'slack', target: '@jonathan.brill' },
    owner: 'jonathan.brill'
  }
```
I also added an "implicit" subscription on the commit queue
```javascript
  {
    _id: '62191219b23736419ef95a31',
    type: 'COMMIT_QUEUE',
    owner: 'jonathan.brill',
    trigger_data: null,
    filter: { owner: 'jonathan.brill' },
    subscriber: { type: 'slack', target: '@jonathan.brill' },
    owner_type: 'person',
    trigger: 'outcome',
    selectors: [ { type: 'owner', data: 'jonathan.brill' } ],
    regex_selectors: null
  }
```
