### PR TITLE
EVG-16418 replaces /s in git tags

### DIFF
--- a/util/strings.go
+++ b/util/strings.go
@@ -24,6 +24,7 @@ func CleanForPath(name string) string {
 func CleanName(name string) string {
 	name = strings.Replace(name, "-", "_", -1)
 	name = strings.Replace(name, " ", "_", -1)
+	name = strings.Replace(name, "/", "_", -1)
 	return name
 }
 


### PR DESCRIPTION
[EVG-16418](https://jira.mongodb.org/browse/EVG-16418)

### Description 
Slashes in version and task names break a lot of things.

### Testing
validated on staging https://spruce-staging.corp.mongodb.com/version/620d357597b1d34aca2b71d1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC