### PR TITLE
EVG-16196 don't let the waterfall query go back to the beginning of time

### DIFF
--- a/service/waterfall.go
+++ b/service/waterfall.go
@@ -218,6 +218,9 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 
 	numTestResultCalls := 0
 	versionsCheckedCount := 0
+	if numVersionElements > model.MaxMainlineCommitVersionLimit {
+		numVersionElements = model.MaxMainlineCommitVersionLimit
+	}
 	// loop until we have enough from the db
 	for len(finalVersions) < numVersionElements && versionsCheckedCount < model.MaxMainlineCommitVersionLimit {
 

--- a/service/waterfall.go
+++ b/service/waterfall.go
@@ -217,16 +217,15 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 	var lastRolledUpVersion *waterfallVersion
 
 	numTestResultCalls := 0
+	versionsCheckedCount := 0
 	// loop until we have enough from the db
-	for len(finalVersions) < numVersionElements {
+	for len(finalVersions) < numVersionElements && versionsCheckedCount < model.MaxMainlineCommitVersionLimit {
 
 		// fetch the versions and associated builds
 		versionsFromDB, buildsByVersion, tasksByBuild, err :=
-			model.FetchVersionsBuildsAndTasks(project, skip, numVersionElements, showTriggered)
-
+			model.FetchVersionsBuildsAndTasks(project, skip+versionsCheckedCount, numVersionElements, showTriggered)
 		if err != nil {
-			return versionVariantData{}, errors.Wrap(err,
-				"error fetching versions and builds:")
+			return versionVariantData{}, errors.Wrap(err, "fetching versions and builds")
 		}
 
 		// if we've reached the beginning of all versions
@@ -234,8 +233,7 @@ func getVersionsAndVariants(skip, numVersionElements int, project *model.Project
 			break
 		}
 
-		// update the amount skipped
-		skip += len(versionsFromDB)
+		versionsCheckedCount += len(versionsFromDB)
 
 		// create the necessary versions, rolling up inactive ones
 		for _, versionFromDB := range versionsFromDB {

--- a/service/waterfall_test.go
+++ b/service/waterfall_test.go
@@ -37,19 +37,18 @@ func TestGetVersionsAndVariants(t *testing.T) {
 		DisplayName: "old-bv",
 	}).Insert())
 
-	firstTask := &task.Task{
+	require.NoError(t, (&task.Task{
 		Id:        firstTaskID,
 		Version:   firstVersionID,
 		BuildId:   firstBuildID,
 		Activated: true,
-	}
-	require.NoError(t, firstTask.Insert())
+	}).Insert())
 
 	for x := 0; x < model.MaxMainlineCommitVersionLimit; x++ {
 		require.NoError(t, (&model.Version{
 			Id:         fmt.Sprintf("version_%d", x),
 			Requester:  evergreen.RepotrackerVersionRequester,
-			CreateTime: firstCreationTime.Add(time.Duration(x) * time.Second),
+			CreateTime: firstCreationTime.Add(time.Duration(x+1) * time.Second),
 		}).Insert())
 
 		require.NoError(t, (&build.Build{

--- a/service/waterfall_test.go
+++ b/service/waterfall_test.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetVersionsAndVariants(t *testing.T) {
+	require.NoError(t, db.ClearCollections(model.VersionCollection, build.Collection, task.Collection))
+	defer func() {
+		assert.NoError(t, db.ClearCollections(model.VersionCollection, build.Collection, task.Collection))
+	}()
+
+	firstVersionID := "first_version"
+	firstBuildID := "first_build"
+	firstTaskID := "first_task"
+	firstCreationTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	require.NoError(t, (&model.Version{
+		Id:         firstVersionID,
+		Requester:  evergreen.RepotrackerVersionRequester,
+		CreateTime: firstCreationTime,
+	}).Insert())
+
+	require.NoError(t, (&build.Build{
+		Id:          firstBuildID,
+		Version:     firstVersionID,
+		Tasks:       []build.TaskCache{{Id: firstTaskID}},
+		DisplayName: "old-bv",
+	}).Insert())
+
+	firstTask := &task.Task{
+		Id:        firstTaskID,
+		Version:   firstVersionID,
+		BuildId:   firstBuildID,
+		Activated: true,
+	}
+	require.NoError(t, firstTask.Insert())
+
+	for x := 0; x < model.MaxMainlineCommitVersionLimit; x++ {
+		require.NoError(t, (&model.Version{
+			Id:         fmt.Sprintf("version_%d", x),
+			Requester:  evergreen.RepotrackerVersionRequester,
+			CreateTime: firstCreationTime.Add(time.Duration(x) * time.Second),
+		}).Insert())
+
+		require.NoError(t, (&build.Build{
+			Id:      fmt.Sprintf("build_%d", x),
+			Version: fmt.Sprintf("version_%d", x),
+			Tasks:   []build.TaskCache{{Id: fmt.Sprintf("task_%d", x)}},
+		}).Insert())
+
+		require.NoError(t, (&task.Task{
+			Id:        fmt.Sprintf("task_%d", x),
+			Version:   fmt.Sprintf("version_%d", x),
+			BuildId:   fmt.Sprintf("build_%d", x),
+			Activated: true,
+		}).Insert())
+	}
+
+	t.Run("NoFilter", func(t *testing.T) {
+		data, err := getVersionsAndVariants(0, 10, &model.Project{}, "", true)
+		assert.NoError(t, err)
+		assert.Len(t, data.Versions, 10)
+		for _, v := range data.Versions {
+			assert.False(t, v.RolledUp)
+		}
+	})
+
+	t.Run("RequestOverMax", func(t *testing.T) {
+		data, err := getVersionsAndVariants(0, model.MaxMainlineCommitVersionLimit+1, &model.Project{}, "", true)
+		assert.NoError(t, err)
+		assert.Len(t, data.Versions, model.MaxMainlineCommitVersionLimit)
+		for _, v := range data.Versions {
+			assert.False(t, v.RolledUp)
+		}
+	})
+
+	t.Run("BVNotWithinMax", func(t *testing.T) {
+		data, err := getVersionsAndVariants(0, 10, &model.Project{}, "old-bv", true)
+		assert.NoError(t, err)
+		require.Len(t, data.Versions, 1)
+		assert.NotContains(t, data.Versions[0].Ids, "firstVersionID")
+	})
+}


### PR DESCRIPTION
[EVG-16196](https://jira.mongodb.org/browse/EVG-16196)

### Description 
If a user specifies a non-existent bv filter on the legacy waterfall we currently loop on fetching all the versions, builds, and tasks for that project until the dawn of time. This is especially an issue when users iterate on the bv filter until they get one they're satisfied with.
The new UI's solution for this was to [introduce a limit for how many versions we load for an individual waterfall request](https://github.com/evergreen-ci/evergreen/blob/f3df1ec1805054beb3d457e4ff82df8ea6e30bf8/graphql/resolvers.go#L3635-L3642). I adapted this solution for the legacy UI. 

### Testing 
Added unit tests. 
Deployed to staging and verified changes made us not load all the way back to the beginning of time.
