### PR TITLE
EVG-16415 Use project id instead of identifier for history queries

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3542,7 +3542,7 @@ func (r *queryResolver) TaskNamesForBuildVariant(ctx context.Context, projectId 
 	if repo == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("could not find repository '%s'", pid))
 	}
-	buildVariantTasks, err := task.FindTaskNamesByBuildVariant(projectId, buildVariant, repo.RevisionOrderNumber)
+	buildVariantTasks, err := task.FindTaskNamesByBuildVariant(pid, buildVariant, repo.RevisionOrderNumber)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting tasks for '%s': %s", buildVariant, err.Error()))
 	}
@@ -3564,7 +3564,7 @@ func (r *queryResolver) BuildVariantsForTaskName(ctx context.Context, projectId 
 	if repo == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("could not find repository '%s'", projectId))
 	}
-	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask(projectId, taskName, repo.RevisionOrderNumber)
+	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask(pid, taskName, repo.RevisionOrderNumber)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting build variant tasks for task '%s': %s", taskName, err.Error()))
 	}


### PR DESCRIPTION
[EVG-16415](https://jira.mongodb.org/browse/EVG-16415)

### Description 
I made the dumb mistake and used project identifier to find tasks instead of the id and wrongfully blamed matrices. Crisis averted. 
