### PR TITLE
EVG-16435: Add DefaultSectionToRepo mutation

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2444,6 +2444,15 @@ func (r *mutationResolver) SaveRepoSettingsForSection(ctx context.Context, obj *
 	return changes, nil
 }
 
+func (r *mutationResolver) DefaultSectionToRepo(ctx context.Context, projectId string, section ProjectSettingsSection) (*string, error) {
+	usr := MustHaveUser(ctx)
+	if err := model.DefaultSectionToRepo(projectId, model.ProjectPageSection(section), usr.Username()); err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error defaulting to repo for section: %s", err.Error()))
+	}
+
+	return &projectId, nil
+}
+
 func (r *mutationResolver) AttachProjectToRepo(ctx context.Context, projectID string) (*restModel.APIProjectRef, error) {
 	usr := MustHaveUser(ctx)
 	pRef, err := r.sc.FindProjectById(projectID, false, false)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -100,6 +100,7 @@ type Mutation {
   attachProjectToNewRepo(project: MoveProjectInput!): Project!
   saveProjectSettingsForSection(projectSettings: ProjectSettingsInput, section: ProjectSettingsSection!): ProjectSettings!
   saveRepoSettingsForSection(repoSettings: RepoSettingsInput, section: ProjectSettingsSection!): RepoSettings!
+  defaultSectionToRepo(projectId: String! @requireProjectAccess(access: EDIT), section: ProjectSettingsSection!): String
   attachProjectToRepo(projectId: String! @requireProjectAccess(access: EDIT)): Project!
   detachProjectFromRepo(projectId: String! @requireProjectAccess(access: EDIT)): Project!
   forceRepotrackerRun(projectId: String! @requireProjectAccess(access: EDIT)): Boolean!

--- a/graphql/tests/defaultSectionToRepo/data.json
+++ b/graphql/tests/defaultSectionToRepo/data.json
@@ -1,0 +1,34 @@
+{
+  "project_ref": [
+    {
+      "_id" : "sandbox_project_id",
+      "identifier" : "sandbox",
+      "display_name" : "Sandbox",
+      "enabled" : null,
+      "owner_name" : "evergreen-ci",
+      "repo_name" : "commit-queue-sandbox",
+      "branch_name" : "main",
+      "admins": ["me"],
+      "repo_ref_id": "repo_id"
+    },
+    {
+      "_id" : "evergreen_id",
+      "identifier" : "evergreen",
+      "display_name" : "Sandbox"
+    }
+  ],
+  "repo_ref":[
+    {
+      "_id": "repo_id",
+      "owner_name": "evergreen-ci",
+      "repo_name": "commit-queue-sandbox"
+    }
+  ],
+  "project_vars": [
+    {
+      "_id": "sandbox_project_id",
+      "vars": {"hello": "world", "foo":  "bar"},
+      "private_vars": {"hello":  true, "foo":  false}
+    }
+  ]
+}

--- a/graphql/tests/defaultSectionToRepo/queries/defaultSectionToRepo.graphql
+++ b/graphql/tests/defaultSectionToRepo/queries/defaultSectionToRepo.graphql
@@ -1,0 +1,3 @@
+mutation {
+    defaultSectionToRepo(projectId: "sandbox_project_id", section: GENERAL)
+}

--- a/graphql/tests/defaultSectionToRepo/queries/noAdmin.graphql
+++ b/graphql/tests/defaultSectionToRepo/queries/noAdmin.graphql
@@ -1,0 +1,3 @@
+mutation {
+    defaultSectionToRepo(projectId: "evergreen_id", section: GENERAL)
+}

--- a/graphql/tests/defaultSectionToRepo/queries/unattachedProject.graphql
+++ b/graphql/tests/defaultSectionToRepo/queries/unattachedProject.graphql
@@ -1,0 +1,3 @@
+mutation {
+    defaultSectionToRepo(projectId: "repo_id", section: GENERAL)
+}

--- a/graphql/tests/defaultSectionToRepo/results.json
+++ b/graphql/tests/defaultSectionToRepo/results.json
@@ -1,0 +1,51 @@
+{
+  "tests": [
+    {
+      "query_file": "defaultSectionToRepo.graphql",
+      "result": {
+        "data": {
+          "defaultSectionToRepo": "sandbox_project_id"
+        }
+      }
+    },
+    {
+      "query_file": "unattachedProject.graphql",
+      "result": {
+        "data": {
+          "defaultSectionToRepo": null
+        },
+        "errors": [
+          {
+            "message": "error defaulting to repo for section: error getting before project settings event: couldn't find project ref",
+            "path": [
+              "defaultSectionToRepo"
+            ],
+            "extensions": {
+              "code": "INTERNAL_SERVER_ERROR"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "query_file": "noAdmin.graphql",
+      "result": {
+        "data": {
+          "defaultSectionToRepo": null
+        },
+        "errors": [
+          {
+            "message": "user testuser does not have permission to access settings for the project evergreen_id",
+            "path": [
+              "defaultSectionToRepo",
+              "projectId"
+            ],
+            "extensions": {
+              "code": "FORBIDDEN"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
[EVG-16435](https://jira.mongodb.org/browse/EVG-16435)

### Description 
- Add GraphQL mutation for calling `DefaultSectionToRepo`

### Testing 
- Added unit tests
- Tested manually in GraphQL playground