### PR TITLE
EVG-14828 Use milliseconds for total time

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -545,7 +545,7 @@ func generateBuildVariants(sc data.Connector, versionId string, searchVariants [
 		"timeToBuildTasksMS": timeToBuildTasks.Milliseconds(),
 		"timeToGroupTasksMS": timeToGroupTasks.Milliseconds(),
 		"timeToSortTasksMS":  timeToSortTasks.Milliseconds(),
-		"totalTime":          totalTime,
+		"totalTimeMS":        totalTime.Milliseconds(),
 		"versionId":          versionId,
 		"taskCount":          len(tasks),
 		"buildVariantCount":  len(result),


### PR DESCRIPTION
[EVG-14828](https://jira.mongodb.org/browse/EVG-14828)

### Description 
This value should have been in milliseconds as well
