### PR TITLE
EVG-16239: rename host task dispatch functions

### DIFF
--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2068,7 +2068,7 @@ func TestCreateTasksFromGroup(t *testing.T) {
 	assert.Equal("new_dependency", bvts[1].DependsOn[0].Name)
 }
 
-func TestMarkAsDispatched(t *testing.T) {
+func TestMarkAsHostDispatched(t *testing.T) {
 
 	var (
 		taskId       string
@@ -2104,8 +2104,7 @@ func TestMarkAsDispatched(t *testing.T) {
 			" the task, the host it is on, and the build it is a part of"+
 			" should be set to reflect this", func() {
 
-			// mark the task as dispatched
-			So(taskDoc.MarkAsDispatched(hostId, distroId, agentVersion, time.Now()), ShouldBeNil)
+			So(taskDoc.MarkAsHostDispatched(hostId, distroId, agentVersion, time.Now()), ShouldBeNil)
 
 			// make sure the task's fields were updated, both in ©memory and
 			// in the db

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -854,11 +854,12 @@ func (t *Task) cacheExpectedDuration() error {
 	)
 }
 
-// Mark that the task has been dispatched onto a particular host. Sets the
-// running task field on the host and the host id field on the task. If the host
-// is part of a display task, the display task is also marked as dispatched to a
-// host. Returns an error if any of the database updates fail.
-func (t *Task) MarkAsHostDispatched(hostId, distroId, agentRevision string, dispatchTime time.Time) error {
+// MarkAsHostDispatched marks that the task has been dispatched onto a
+// particular host. If the task is part of a display task, the display task is
+// also marked as dispatched to a host. Returns an error if any of the database
+// updates fail.
+func (t *Task) MarkAsHostDispatched(hostId, distroId, agentRevision string,
+	dispatchTime time.Time) error {
 	t.DispatchTime = dispatchTime
 	t.Status = evergreen.TaskDispatched
 	t.HostId = hostId

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -855,9 +855,10 @@ func (t *Task) cacheExpectedDuration() error {
 }
 
 // Mark that the task has been dispatched onto a particular host. Sets the
-// running task field on the host and the host id field on the task.
-// Returns an error if any of the database updates fail.
-func (t *Task) MarkAsDispatched(hostId, distroId, agentRevision string, dispatchTime time.Time) error {
+// running task field on the host and the host id field on the task. If the host
+// is part of a display task, the display task is also marked as dispatched to a
+// host. Returns an error if any of the database updates fail.
+func (t *Task) MarkAsHostDispatched(hostId, distroId, agentRevision string, dispatchTime time.Time) error {
 	t.DispatchTime = dispatchTime
 	t.Status = evergreen.TaskDispatched
 	t.HostId = hostId
@@ -890,16 +891,15 @@ func (t *Task) MarkAsDispatched(hostId, distroId, agentRevision string, dispatch
 
 	//when dispatching an execution task, mark its parent as dispatched
 	if dt, _ := t.GetDisplayTask(); dt != nil && dt.DispatchTime == utility.ZeroTime {
-		return dt.MarkAsDispatched("", "", "", dispatchTime)
+		return dt.MarkAsHostDispatched("", "", "", dispatchTime)
 	}
 	return nil
 }
 
-// MarkAsUndispatched marks that the task has been undispatched from a
-// particular host. Unsets the running task field on the host and the
-// host id field on the task
-// Returns an error if any of the database updates fail.
-func (t *Task) MarkAsUndispatched() error {
+// MarkAsHostUndispatched marks that the host task is undispatched. If the task
+// is already dispatched to a host, it unsets the host ID field on the task. It
+// returns an error if any of the database updates fail.
+func (t *Task) MarkAsHostUndispatched() error {
 	// then, update the task document
 	t.Status = evergreen.TaskUndispatched
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1185,9 +1185,12 @@ func MarkStart(t *task.Task, updates *StatusChanges) error {
 	return nil
 }
 
-func MarkTaskUndispatched(t *task.Task) error {
+// MarkHostTaskUndispatched marks a task as no longer dispatched to a host. If
+// it's part of a display task, update the display task as necessary as a result
+// of marking this task as undispatched.
+func MarkHostTaskUndispatched(t *task.Task) error {
 	// record that the task as undispatched on the host
-	if err := t.MarkAsUndispatched(); err != nil {
+	if err := t.MarkAsHostUndispatched(); err != nil {
 		return errors.WithStack(err)
 	}
 	// the task was successfully dispatched, log the event
@@ -1200,9 +1203,12 @@ func MarkTaskUndispatched(t *task.Task) error {
 	return nil
 }
 
-func MarkTaskDispatched(t *task.Task, h *host.Host) error {
+// MarkHostTaskDispatched marks a task as being dispatched to the host. If it's
+// part of a display task, update the display task as necessary as a result of
+// marking this task as dispatched.
+func MarkHostTaskDispatched(t *task.Task, h *host.Host) error {
 	// record that the task was dispatched on the host
-	if err := t.MarkAsDispatched(h.Id, h.Distro.Id, h.AgentRevision, time.Now()); err != nil {
+	if err := t.MarkAsHostDispatched(h.Id, h.Distro.Id, h.AgentRevision, time.Now()); err != nil {
 		return errors.Wrapf(err, "error marking task %s as dispatched "+
 			"on host %s", t.Id, h.Id)
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1186,8 +1186,7 @@ func MarkStart(t *task.Task, updates *StatusChanges) error {
 }
 
 // MarkHostTaskUndispatched marks a task as no longer dispatched to a host. If
-// it's part of a display task, update the display task as necessary as a result
-// of marking this task as undispatched.
+// it's part of a display task, update the display task as necessary.
 func MarkHostTaskUndispatched(t *task.Task) error {
 	// record that the task as undispatched on the host
 	if err := t.MarkAsHostUndispatched(); err != nil {
@@ -1204,8 +1203,7 @@ func MarkHostTaskUndispatched(t *task.Task) error {
 }
 
 // MarkHostTaskDispatched marks a task as being dispatched to the host. If it's
-// part of a display task, update the display task as necessary as a result of
-// marking this task as dispatched.
+// part of a display task, update the display task as necessary.
 func MarkHostTaskDispatched(t *task.Task, h *host.Host) error {
 	// record that the task was dispatched on the host
 	if err := t.MarkAsHostDispatched(h.Id, h.Distro.Id, h.AgentRevision, time.Now()); err != nil {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2005,7 +2005,7 @@ func TestMarkUndispatched(t *testing.T) {
 		So(v.Insert(), ShouldBeNil)
 		Convey("when calling MarkStart, the task, version and build should be updated", func() {
 			var err error
-			So(MarkTaskUndispatched(testTask), ShouldBeNil)
+			So(MarkHostTaskUndispatched(testTask), ShouldBeNil)
 			testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
 			So(err, ShouldBeNil)
 			So(testTask.Status, ShouldEqual, evergreen.TaskUndispatched)
@@ -2043,7 +2043,7 @@ func TestMarkDispatched(t *testing.T) {
 				},
 				AgentRevision: "testAgentVersion",
 			}
-			So(MarkTaskDispatched(testTask, sampleHost), ShouldBeNil)
+			So(MarkHostTaskDispatched(testTask, sampleHost), ShouldBeNil)
 			var err error
 			testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
 			So(err, ShouldBeNil)

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -1065,7 +1065,7 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 
 	// otherwise we've dispatched a task, so we
 	// mark the task as dispatched
-	if err := model.MarkTaskDispatched(nextTask, h); err != nil {
+	if err := model.MarkHostTaskDispatched(nextTask, h); err != nil {
 		err = errors.WithStack(err)
 		grip.Error(err)
 		gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
@@ -1242,7 +1242,7 @@ func sendBackRunningTask(h *host.Host, response apimodels.NextTaskResponse, w ht
 
 	// if the task can be dispatched and activated dispatch it
 	if t.IsDispatchable() {
-		err = errors.WithStack(model.MarkTaskDispatched(t, h))
+		err = errors.WithStack(model.MarkHostTaskDispatched(t, h))
 		if err != nil {
 			grip.Error(errors.Wrapf(err, "error while marking task %s as dispatched for host %s", t.Id, h.Id))
 			gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16239

### Description 
Rename some dispatch/undispatch task functions that only apply to tasks running in hosts. Instead of "undispatched", tasks that are waiting to run on a container use the "container-unallocated" status. Tasks that are sent to a container to run will still enter the "dispatched" state, but will require slightly different logic.

### Testing 
N/A
