### PR TITLE
EVG-16196 longer debounce

### DIFF
--- a/public/static/app/waterfall/waterfall.jsx
+++ b/public/static/app/waterfall/waterfall.jsx
@@ -130,7 +130,7 @@ class Root extends React.PureComponent {
     this.handleTaskFilter = this.handleTaskFilter.bind(this);
     this.loadDataPortion = this.loadDataPortion.bind(this);
     this.loadDataPortion();
-    this.loadDataPortion = _.debounce(this.loadDataPortion, 100)
+    this.loadDataPortion = _.debounce(this.loadDataPortion, 1000)
     this.loadData = this.loadData.bind(this);
   }
 

--- a/public/static/dist/js/waterfall/waterfall.js
+++ b/public/static/dist/js/waterfall/waterfall.js
@@ -160,7 +160,7 @@ var Root = function (_React$PureComponent2) {
     _this2.handleTaskFilter = _this2.handleTaskFilter.bind(_this2);
     _this2.loadDataPortion = _this2.loadDataPortion.bind(_this2);
     _this2.loadDataPortion();
-    _this2.loadDataPortion = _.debounce(_this2.loadDataPortion, 100);
+    _this2.loadDataPortion = _.debounce(_this2.loadDataPortion, 1000);
     _this2.loadData = _this2.loadData.bind(_this2);
     return _this2;
   }


### PR DESCRIPTION
[EVG-16196](https://jira.mongodb.org/browse/EVG-16196)

### Description 
I noticed that as I was typing a bv filter on the legacy waterfall almost every keystroke made another request for waterfall data (and the results of all but the last are discarded). 
![Screen Shot 2022-03-02 at 11 08 10 AM](https://user-images.githubusercontent.com/17027265/156400714-db848d75-ee06-46f5-a313-49e899accc92.png)

It makes more sense to me to only request the data when the user is done typing. The debounce function is supposed to do this, but 100ms is too short. This PR extends it to a second.

### Testing 
When I deployed this to staging the wait after I finished typing seemed appropriate.

