### PR TITLE
EVG-16447 Update admin only variable access to mainline commits

### DIFF
--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -223,7 +223,8 @@ func (projectVars *ProjectVars) GetRestrictedVars() map[string]string {
 	return restrictedVars
 }
 
-// GetAdminOnlyVars will change to GetVars on EVG-16045 after removing restricted vars.
+// GetAdminOnlyVars currently returns admin only variables for mainline commits and project admins.
+// Will change to GetVars on EVG-16045 after removing restricted vars.
 func (projectVars *ProjectVars) GetAdminOnlyVars(t *task.Task) map[string]string {
 	adminOnlyVars := map[string]string{}
 	if utility.StringSliceContains(evergreen.SystemVersionRequesterTypes, t.Requester) {
@@ -235,10 +236,10 @@ func (projectVars *ProjectVars) GetAdminOnlyVars(t *task.Task) map[string]string
 	} else if t.ActivatedBy != "" {
 		u, err := user.FindOneById(t.ActivatedBy)
 		if err != nil {
-			grip.Error(message.Fields{
-				"error":   err,
-				"message": fmt.Sprintf("problem with fetching user '%s' for task '%s'", t.ActivatedBy, t.Id),
-			})
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": fmt.Sprintf("problem with fetching user '%s'", t.ActivatedBy),
+				"task_id": t.Id,
+			}))
 			return adminOnlyVars
 		}
 		if u != nil {

--- a/service/api.go
+++ b/service/api.go
@@ -344,13 +344,7 @@ func (as *APIServer) FetchExpansionsForTask(w http.ResponseWriter, r *http.Reque
 		as.LoggedError(w, r, http.StatusNotFound, errors.New("version not found"))
 		return
 	}
-
-	adminVars, err := projectVars.GetAdminOnlyVars(t)
-	if err != nil {
-		as.LoggedError(w, r, http.StatusNotFound, err)
-		return
-	}
-	for key, val := range adminVars {
+	for key, val := range projectVars.GetAdminOnlyVars(t) {
 		res.Vars[key] = val
 	}
 	projParams, err := model.FindParametersForVersion(v)


### PR DESCRIPTION
[EVG-16447](https://jira.mongodb.org/browse/EVG-16447)

### Description 
allow repotracker requesters to access admin only vars

### Testing 
took away minna's admin role and verified that her patches cant access admin vars but commits can 
https://evergreen-staging.corp.mongodb.com/task/sandbox_ubuntu1604_bynntask_14619adff2ad781b915772f1a1a5107e9f397ff9_22_03_03_17_02_44