### PR TITLE
EVG-16291: check for context errors during host status check

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -361,7 +361,7 @@ func (j *hostTerminationJob) checkAndTerminateCloudHost(ctx context.Context, old
 
 	cloudStatus, err := cloudHost.GetInstanceStatus(ctx)
 	if err != nil {
-		if errors.Cause(err) == context.Canceled {
+		if utility.IsContextError(errors.Cause(err)) {
 			return errors.Wrap(err, "checking cloud host status")
 		}
 		if err == cloud.ErrInstanceNotFound {

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -152,22 +152,6 @@ func TestHostTerminationJob(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
 		},
-		"ContextErrorDoesNotTerminateHost": func(ctx context.Context, t *testing.T, env *mock.Environment, mcp cloud.MockProvider, h *host.Host) {
-			require.NoError(t, h.Insert())
-
-			ctx, cancel := context.WithCancel(ctx)
-			cancel()
-
-			currentStatus := h.Status
-			j, ok := NewHostTerminationJob(env, h, true, "foo").(*hostTerminationJob)
-			require.True(t, ok)
-			require.Error(t, j.checkAndTerminateCloudHost(ctx, currentStatus))
-
-			dbHost, err := host.FindOneId(h.Id)
-			require.NoError(t, err)
-			require.NotZero(t, dbHost)
-			assert.Equal(t, currentStatus, dbHost.Status)
-		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(host.Collection, event.AllLogCollection), "error clearing host collection")


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16291

### Description 
If the cloud host status check fails because the context errors, the host should not be marked as terminated in the DB. The job will be re-enqueued to retry terminating the host later.

### Testing 
There's no tests due to the difficulty of testing context cancellation behavior at a specific line in the job, but it's not difficult to verify correctness just by inspection. Testing with the mock provider is difficult since it ignores the context and doesn't make network requests, but using a real cloud provider would also be difficult to simulate.