### PR TITLE
EVG-15171 Implement restart-failed

### DIFF
--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -86,6 +86,8 @@ type cliIntent struct {
 	GitInfo *GitMetadata `bson:"git_info,omitempty"`
 
 	ReuseDefinition bool `bson:"reuse_definition"`
+
+	RepeatFailed bool `bson:"repeat_failed"`
 }
 
 // BSON fields for the patches
@@ -165,6 +167,10 @@ func (c *cliIntent) ReusePreviousPatchDefinition() bool {
 	return c.ReuseDefinition
 }
 
+func (c *cliIntent) RepeatFailedTasksAndVariants() bool {
+	return c.RepeatFailed
+}
+
 func (g *cliIntent) RequesterIdentity() string {
 	return evergreen.PatchVersionRequester
 }
@@ -223,6 +229,7 @@ type CLIIntentParams struct {
 	Alias           string
 	TriggerAliases  []string
 	ReuseDefinition bool
+	RepeatFailed    bool
 	SyncParams      SyncAtEndOptions
 }
 
@@ -282,6 +289,7 @@ func NewCliIntent(params CLIIntentParams) (Intent, error) {
 		BackportOf:      params.BackportOf,
 		GitInfo:         params.GitInfo,
 		ReuseDefinition: params.ReuseDefinition,
+		RepeatFailed:    params.RepeatFailed,
 	}, nil
 }
 

--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -85,7 +85,7 @@ type cliIntent struct {
 	// GitInfo contains information about the author's git environment
 	GitInfo *GitMetadata `bson:"git_info,omitempty"`
 
-	ReuseDefinition bool `bson:"reuse_definition"`
+	RepeatDefinition bool `bson:"reuse_definition"`
 
 	RepeatFailed bool `bson:"repeat_failed"`
 }
@@ -164,7 +164,7 @@ func (c *cliIntent) ShouldFinalizePatch() bool {
 }
 
 func (c *cliIntent) ReusePreviousPatchDefinition() bool {
-	return c.ReuseDefinition
+	return c.RepeatDefinition
 }
 
 func (c *cliIntent) RepeatFailedTasksAndVariants() bool {
@@ -213,24 +213,24 @@ func (c *cliIntent) NewPatch() *Patch {
 }
 
 type CLIIntentParams struct {
-	User            string
-	Path            string
-	Project         string
-	BaseGitHash     string
-	Module          string
-	PatchContent    string
-	Description     string
-	Finalize        bool
-	BackportOf      BackportInfo
-	GitInfo         *GitMetadata
-	Parameters      []Parameter
-	Variants        []string
-	Tasks           []string
-	Alias           string
-	TriggerAliases  []string
-	ReuseDefinition bool
-	RepeatFailed    bool
-	SyncParams      SyncAtEndOptions
+	User             string
+	Path             string
+	Project          string
+	BaseGitHash      string
+	Module           string
+	PatchContent     string
+	Description      string
+	Finalize         bool
+	BackportOf       BackportInfo
+	GitInfo          *GitMetadata
+	Parameters       []Parameter
+	Variants         []string
+	Tasks            []string
+	Alias            string
+	TriggerAliases   []string
+	RepeatDefinition bool
+	RepeatFailed     bool
+	SyncParams       SyncAtEndOptions
 }
 
 func NewCliIntent(params CLIIntentParams) (Intent, error) {
@@ -270,26 +270,26 @@ func NewCliIntent(params CLIIntentParams) (Intent, error) {
 	}
 
 	return &cliIntent{
-		DocumentID:      mgobson.NewObjectId().Hex(),
-		IntentType:      CliIntentType,
-		PatchContent:    params.PatchContent,
-		Path:            params.Path,
-		Description:     params.Description,
-		BuildVariants:   params.Variants,
-		Tasks:           params.Tasks,
-		Parameters:      params.Parameters,
-		SyncAtEndOpts:   params.SyncParams,
-		User:            params.User,
-		ProjectID:       params.Project,
-		BaseHash:        params.BaseGitHash,
-		Finalize:        params.Finalize,
-		Module:          params.Module,
-		Alias:           params.Alias,
-		TriggerAliases:  params.TriggerAliases,
-		BackportOf:      params.BackportOf,
-		GitInfo:         params.GitInfo,
-		ReuseDefinition: params.ReuseDefinition,
-		RepeatFailed:    params.RepeatFailed,
+		DocumentID:       mgobson.NewObjectId().Hex(),
+		IntentType:       CliIntentType,
+		PatchContent:     params.PatchContent,
+		Path:             params.Path,
+		Description:      params.Description,
+		BuildVariants:    params.Variants,
+		Tasks:            params.Tasks,
+		Parameters:       params.Parameters,
+		SyncAtEndOpts:    params.SyncParams,
+		User:             params.User,
+		ProjectID:        params.Project,
+		BaseHash:         params.BaseGitHash,
+		Finalize:         params.Finalize,
+		Module:           params.Module,
+		Alias:            params.Alias,
+		TriggerAliases:   params.TriggerAliases,
+		BackportOf:       params.BackportOf,
+		GitInfo:          params.GitInfo,
+		RepeatDefinition: params.RepeatDefinition,
+		RepeatFailed:     params.RepeatFailed,
 	}, nil
 }
 

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -305,7 +305,7 @@ func PatchesByProject(projectId string, ts time.Time, limit int) db.Q {
 	}).Sort([]string{"-" + CreateTimeKey}).Limit(limit)
 }
 
-// FindFailedCommitQueuePatchesInTimeRange returns failed patches if they started within range,
+// FindFailedCommitQueuePatchesinTimeRange returns failed patches if they started within range,
 // or if they were never started but finished within time range. (i.e. timed out)
 func FindFailedCommitQueuePatchesinTimeRange(projectID string, startTime, endTime time.Time) ([]Patch, error) {
 	query := bson.M{

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -305,9 +305,9 @@ func PatchesByProject(projectId string, ts time.Time, limit int) db.Q {
 	}).Sort([]string{"-" + CreateTimeKey}).Limit(limit)
 }
 
-// FindFailedCommitQueuePatchesinTimeRange returns failed patches if they started within range,
+// FindFailedCommitQueuePatchesInTimeRange returns failed patches if they started within range,
 // or if they were never started but finished within time range. (i.e. timed out)
-func FindFailedCommitQueuePatchesinTimeRange(projectID string, startTime, endTime time.Time) ([]Patch, error) {
+func FindFailedCommitQueuePatchesInTimeRange(projectID string, startTime, endTime time.Time) ([]Patch, error) {
 	query := bson.M{
 		ProjectKey: projectID,
 		StatusKey:  evergreen.PatchFailed,

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -221,6 +221,10 @@ func (g *githubIntent) ReusePreviousPatchDefinition() bool {
 	return false
 }
 
+func (g *githubIntent) RepeatFailedTasksAndVariants() bool {
+	return false
+}
+
 func (g *githubIntent) RequesterIdentity() string {
 	return evergreen.GithubPRRequester
 }

--- a/model/patch/intent.go
+++ b/model/patch/intent.go
@@ -35,6 +35,10 @@ type Intent interface {
 	// as the previous patch submitted for this project by the user.
 	ReusePreviousPatchDefinition() bool
 
+	// RepeatFailedTasksAndVariants gives the patch the tasks/variants
+	// from the previous patch that had failed.
+	RepeatFailedTasksAndVariants() bool
+
 	// GetAlias defines the variants and tasks this intent should run on.
 	GetAlias() string
 

--- a/model/patch/trigger_intent.go
+++ b/model/patch/trigger_intent.go
@@ -78,6 +78,10 @@ func (t *TriggerIntent) ReusePreviousPatchDefinition() bool {
 	return false
 }
 
+func (g *TriggerIntent) RepeatFailedTasksAndVariants() bool {
+	return false
+}
+
 func (t *TriggerIntent) GetAlias() string {
 	// triggers have no alias
 	return ""

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -792,7 +792,7 @@ func MakeMergePatchFromExisting(ctx context.Context, existingPatch *patch.Patch,
 }
 
 func RetryCommitQueueItems(projectID string, opts RestartOptions) ([]string, []string, error) {
-	patches, err := patch.FindFailedCommitQueuePatchesinTimeRange(projectID, opts.StartTime, opts.EndTime)
+	patches, err := patch.FindFailedCommitQueuePatchesInTimeRange(projectID, opts.StartTime, opts.EndTime)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error finding failed commit queue patches for project in time range")
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -398,11 +398,13 @@ func FailedTasksByVersion(version string) bson.M {
 	}
 }
 
-func FailedTasksByVersionAndBV(version string, variant string) bson.M {
+func FailedExecutionTasksByVersionAndBV(version string, variant string) bson.M {
 	return bson.M{
-		VersionKey:      version,
-		BuildVariantKey: variant,
-		StatusKey:       bson.M{"$in": evergreen.TaskFailureStatuses},
+		VersionKey:       version,
+		BuildVariantKey:  variant,
+		StatusKey:        bson.M{"$in": evergreen.TaskFailureStatuses},
+		DisplayOnlyKey:   false,
+		DisplayTaskIdKey: nil,
 	}
 }
 

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -400,11 +400,14 @@ func FailedTasksByVersion(version string) bson.M {
 
 func FailedExecutionTasksByVersionAndBV(version string, variant string) bson.M {
 	return bson.M{
-		VersionKey:       version,
-		BuildVariantKey:  variant,
-		StatusKey:        bson.M{"$in": evergreen.TaskFailureStatuses},
-		DisplayOnlyKey:   false,
-		DisplayTaskIdKey: nil,
+		VersionKey:      version,
+		BuildVariantKey: variant,
+		StatusKey:       bson.M{"$in": evergreen.TaskFailureStatuses},
+		DisplayOnlyKey:  bson.M{"$ne": true},
+		"$or": []bson.M{
+			{DisplayTaskIdKey: bson.M{"$exists": false}},
+			{DisplayTaskIdKey: ""},
+		},
 	}
 }
 

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -398,25 +398,11 @@ func FailedTasksByVersion(version string) bson.M {
 	}
 }
 
-func FailedExecutionTasksByVersionAndBV(version string, variant string) bson.M {
+func FailedTasksByVersionAndBV(version string, variant string) bson.M {
 	return bson.M{
 		VersionKey:      version,
 		BuildVariantKey: variant,
 		StatusKey:       bson.M{"$in": evergreen.TaskFailureStatuses},
-		DisplayOnlyKey:  bson.M{"$ne": true},
-		"$or": []bson.M{
-			{DisplayTaskIdKey: bson.M{"$exists": false}},
-			{DisplayTaskIdKey: ""},
-		},
-	}
-}
-
-func FailedDisplayTasksByVersionAndBV(version string, variant string) bson.M {
-	return bson.M{
-		VersionKey:      version,
-		BuildVariantKey: variant,
-		StatusKey:       bson.M{"$in": evergreen.TaskFailureStatuses},
-		DisplayOnlyKey:  true,
 	}
 }
 

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -411,6 +411,15 @@ func FailedExecutionTasksByVersionAndBV(version string, variant string) bson.M {
 	}
 }
 
+func FailedDisplayTasksByVersionAndBV(version string, variant string) bson.M {
+	return bson.M{
+		VersionKey:      version,
+		BuildVariantKey: variant,
+		StatusKey:       bson.M{"$in": evergreen.TaskFailureStatuses},
+		DisplayOnlyKey:  true,
+	}
+}
+
 // ByVersion produces a query that returns tasks for the given version.
 func ByVersions(versions []string) bson.M {
 	return bson.M{VersionKey: bson.M{"$in": versions}}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -398,6 +398,14 @@ func FailedTasksByVersion(version string) bson.M {
 	}
 }
 
+func FailedTasksByVersionAndBV(version string, variant string) bson.M {
+	return bson.M{
+		VersionKey:      version,
+		BuildVariantKey: variant,
+		StatusKey:       bson.M{"$in": evergreen.TaskFailureStatuses},
+	}
+}
+
 // ByVersion produces a query that returns tasks for the given version.
 func ByVersions(versions []string) bson.M {
 	return bson.M{VersionKey: bson.M{"$in": versions}}

--- a/operations/http.go
+++ b/operations/http.go
@@ -539,7 +539,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		TriggerAliases    []string           `json:"trigger_aliases"`
 		Parameters        []patch.Parameter  `json:"parameters"`
 		GitMetadata       patch.GitMetadata  `json:"git_metadata"`
-		ReuseDefinition   bool               `json:"reuse_definition"`
+		RepeatDefinition  bool               `json:"reuse_definition"`
 		RepeatFailed      bool               `json:"repeat_failed"`
 		GithubAuthor      string             `json:"github_author"`
 	}{
@@ -560,7 +560,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		TriggerAliases:    incomingPatch.triggerAliases,
 		Parameters:        incomingPatch.parameters,
 		GitMetadata:       incomingPatch.gitMetadata,
-		ReuseDefinition:   incomingPatch.reuseDefinition,
+		RepeatDefinition:  incomingPatch.repeatDefinition,
 		RepeatFailed:      incomingPatch.repeatFailed,
 		GithubAuthor:      incomingPatch.githubAuthor,
 	}

--- a/operations/http.go
+++ b/operations/http.go
@@ -540,6 +540,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		Parameters        []patch.Parameter  `json:"parameters"`
 		GitMetadata       patch.GitMetadata  `json:"git_metadata"`
 		ReuseDefinition   bool               `json:"reuse_definition"`
+		RepeatFailed      bool               `json:"repeat_failed"`
 		GithubAuthor      string             `json:"github_author"`
 	}{
 		Description:       incomingPatch.description,
@@ -560,6 +561,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		Parameters:        incomingPatch.parameters,
 		GitMetadata:       incomingPatch.gitMetadata,
 		ReuseDefinition:   incomingPatch.reuseDefinition,
+		RepeatFailed:      incomingPatch.repeatFailed,
 		GithubAuthor:      incomingPatch.githubAuthor,
 	}
 

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -62,7 +62,7 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 				Usage: "use all of the same tasks/variants defined for the last patch you scheduled for this project",
 			},
 			cli.BoolFlag{
-				Name:  joinFlagNames(repeatFailedDefinitionFlag, "failed", "rf"),
+				Name:  joinFlagNames(repeatFailedDefinitionFlag, "rf"),
 				Usage: "use only the failed tasks/variants defined for the last patch you scheduled for this project",
 			},
 			cli.StringFlag{

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	patchDescriptionFlagName = "description"
-	patchVerboseFlagName     = "verbose"
-	patchTriggerAliasFlag    = "trigger-alias"
-	reuseDefinitionFlag      = "reuse"
+	patchDescriptionFlagName   = "description"
+	patchVerboseFlagName       = "verbose"
+	patchTriggerAliasFlag      = "trigger-alias"
+	reuseDefinitionFlag        = "reuse"
+	repeatFailedDefinitionFlag = "repeat-failed"
 )
 
 func getPatchFlags(flags ...cli.Flag) []cli.Flag {
@@ -58,7 +59,11 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 			},
 			cli.BoolFlag{
 				Name:  reuseDefinitionFlag,
-				Usage: "use the same tasks/variants defined for the last patch you scheduled for this project",
+				Usage: "use all of the same tasks/variants defined for the last patch you scheduled for this project",
+			},
+			cli.BoolFlag{
+				Name:  repeatFailedDefinitionFlag,
+				Usage: "use only the failed tasks/variants defined for the last patch you scheduled for this project",
 			},
 			cli.StringFlag{
 				Name:  pathFlagName,
@@ -111,6 +116,7 @@ func Patch() cli.Command {
 				PreserveCommits:   c.Bool(preserveCommitsFlag),
 				TriggerAliases:    utility.SplitCommas(c.StringSlice(patchTriggerAliasFlag)),
 				ReuseDefinition:   c.Bool(reuseDefinitionFlag),
+				RepeatFailed:      c.Bool(repeatFailedDefinitionFlag),
 			}
 
 			var err error
@@ -127,7 +133,7 @@ func Patch() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "problem loading configuration")
 			}
-			if params.ReuseDefinition && (len(params.Tasks) > 0 || len(params.Variants) > 0) {
+			if (params.ReuseDefinition || params.RepeatFailed) && (len(params.Tasks) > 0 || len(params.Variants) > 0) {
 				return errors.Errorf("can't define tasks/variants when reusing previous patch's tasks and variants")
 			}
 

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -75,7 +75,7 @@ type patchParams struct {
 	BackportOf        patch.BackportInfo
 	TriggerAliases    []string
 	Parameters        []patch.Parameter
-	ReuseDefinition   bool
+	RepeatDefinition  bool
 	RepeatFailed      bool
 	GithubAuthor      string
 }
@@ -98,7 +98,7 @@ type patchSubmission struct {
 	triggerAliases    []string
 	backportOf        patch.BackportInfo
 	gitMetadata       patch.GitMetadata
-	reuseDefinition   bool
+	repeatDefinition  bool
 	repeatFailed      bool
 	githubAuthor      string
 }
@@ -121,7 +121,7 @@ func (p *patchParams) createPatch(ac *legacyClient, diffData *localDiff) (*patch
 		parameters:        p.Parameters,
 		triggerAliases:    p.TriggerAliases,
 		gitMetadata:       diffData.gitMetadata,
-		reuseDefinition:   p.ReuseDefinition,
+		repeatDefinition:  p.RepeatDefinition,
 		repeatFailed:      p.RepeatFailed,
 		path:              p.Path,
 		githubAuthor:      p.GithubAuthor,

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -76,6 +76,7 @@ type patchParams struct {
 	TriggerAliases    []string
 	Parameters        []patch.Parameter
 	ReuseDefinition   bool
+	RepeatFailed      bool
 	GithubAuthor      string
 }
 
@@ -98,6 +99,7 @@ type patchSubmission struct {
 	backportOf        patch.BackportInfo
 	gitMetadata       patch.GitMetadata
 	reuseDefinition   bool
+	repeatFailed      bool
 	githubAuthor      string
 }
 
@@ -120,6 +122,7 @@ func (p *patchParams) createPatch(ac *legacyClient, diffData *localDiff) (*patch
 		triggerAliases:    p.TriggerAliases,
 		gitMetadata:       diffData.gitMetadata,
 		reuseDefinition:   p.ReuseDefinition,
+		repeatFailed:      p.RepeatFailed,
 		path:              p.Path,
 		githubAuthor:      p.GithubAuthor,
 	}

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -59,7 +59,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		TriggerAliases    []string           `json:"trigger_aliases"`
 		Alias             string             `json:"alias"`
 		RepeatFailed      bool               `json:"repeat_failed"`
-		ReuseDefinition   bool               `json:"reuse_definition"`
+		RepeatDefinition  bool               `json:"reuse_definition"`
 		GithubAuthor      string             `json:"github_author"`
 	}{}
 	if err := utility.ReadJSON(utility.NewRequestReaderWithSize(r, patch.SizeLimit), &data); err != nil {
@@ -148,23 +148,23 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	intent, err := patch.NewCliIntent(patch.CLIIntentParams{
-		User:            author,
-		Project:         pref.Id,
-		Path:            data.Path,
-		BaseGitHash:     data.Githash,
-		Module:          r.FormValue("module"),
-		PatchContent:    patchString,
-		Description:     data.Description,
-		Finalize:        data.Finalize,
-		Parameters:      data.Parameters,
-		Variants:        data.Variants,
-		Tasks:           data.Tasks,
-		Alias:           data.Alias,
-		TriggerAliases:  data.TriggerAliases,
-		BackportOf:      data.BackportInfo,
-		GitInfo:         data.GitMetadata,
-		ReuseDefinition: data.ReuseDefinition,
-		RepeatFailed:    data.RepeatFailed,
+		User:             author,
+		Project:          pref.Id,
+		Path:             data.Path,
+		BaseGitHash:      data.Githash,
+		Module:           r.FormValue("module"),
+		PatchContent:     patchString,
+		Description:      data.Description,
+		Finalize:         data.Finalize,
+		Parameters:       data.Parameters,
+		Variants:         data.Variants,
+		Tasks:            data.Tasks,
+		Alias:            data.Alias,
+		TriggerAliases:   data.TriggerAliases,
+		BackportOf:       data.BackportInfo,
+		GitInfo:          data.GitMetadata,
+		RepeatDefinition: data.RepeatDefinition,
+		RepeatFailed:     data.RepeatFailed,
 		SyncParams: patch.SyncAtEndOptions{
 			BuildVariants: data.SyncBuildVariants,
 			Tasks:         data.SyncTasks,

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -58,6 +58,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		Finalize          bool               `json:"finalize"`
 		TriggerAliases    []string           `json:"trigger_aliases"`
 		Alias             string             `json:"alias"`
+		RepeatFailed      bool               `json:"repeat_failed"`
 		ReuseDefinition   bool               `json:"reuse_definition"`
 		GithubAuthor      string             `json:"github_author"`
 	}{}
@@ -163,6 +164,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		BackportOf:      data.BackportInfo,
 		GitInfo:         data.GitMetadata,
 		ReuseDefinition: data.ReuseDefinition,
+		RepeatFailed:    data.RepeatFailed,
 		SyncParams: patch.SyncAtEndOptions{
 			BuildVariants: data.SyncBuildVariants,
 			Tasks:         data.SyncTasks,

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -494,7 +494,7 @@ func (j *patchIntentProcessor) getPreviousPatchDefinition(project *model.Project
 }
 
 func getPreviousFailedTasksAndDisplayTasks(tasksInProjectVariant []string, displayTasksInProjectVariant []string, vt patch.VariantTasks, version string) ([]string, []patch.DisplayTask, error) {
-	failedTasks, err := task.FindAll(db.Query(task.FailedTasksByVersionAndBV(version, vt.Variant)))
+	failedTasks, err := task.FindAll(db.Query(task.FailedExecutionTasksByVersionAndBV(version, vt.Variant)))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error querying for failed tasks from previous patch")
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -284,14 +284,14 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 
 	if j.intent.ReusePreviousPatchDefinition() {
-		patchDoc.VariantsTasks, err = j.getPreviousPatchDefinition(project)
+		patchDoc.VariantsTasks, err = j.getPreviousPatchDefinition(project, false)
 		if err != nil {
 			return err
 		}
 	}
 
 	if j.intent.RepeatFailedTasksAndVariants() {
-		patchDoc.VariantsTasks, err = j.getPreviousPatchFailures(project)
+		patchDoc.VariantsTasks, err = j.getPreviousPatchDefinition(project, true)
 		if err != nil {
 			return err
 		}
@@ -457,7 +457,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	return catcher.Resolve()
 }
 
-func (j *patchIntentProcessor) getPreviousPatchDefinition(project *model.Project) ([]patch.VariantTasks, error) {
+func (j *patchIntentProcessor) getPreviousPatchDefinition(project *model.Project, failedOnly bool) ([]patch.VariantTasks, error) {
 	previousPatch, err := patch.FindOne(patch.MostRecentPatchByUserAndProject(j.user.Username(), project.Identifier))
 	if err != nil {
 		return nil, errors.Wrap(err, "error querying for most recent patch")
@@ -465,21 +465,23 @@ func (j *patchIntentProcessor) getPreviousPatchDefinition(project *model.Project
 	if previousPatch == nil {
 		return nil, errors.Errorf("no previous patch available")
 	}
-
 	var res []patch.VariantTasks
+	if failedOnly && !(previousPatch.Status == evergreen.PatchFailed) {
+		return res, nil
+	}
 	for _, vt := range previousPatch.VariantsTasks {
 		tasksInProjectVariant := project.FindTasksForVariant(vt.Variant)
 		displayTasksInProjectVariant := project.FindDisplayTasksForVariant(vt.Variant)
-
-		// I want the subset of vt.tasks that exists in tasksForVariant
-		tasks := utility.StringSliceIntersection(tasksInProjectVariant, vt.Tasks)
 		var displayTasks []patch.DisplayTask
-		for _, dt := range vt.DisplayTasks {
-			if utility.StringSliceContains(displayTasksInProjectVariant, dt.Name) {
-				displayTasks = append(displayTasks, patch.DisplayTask{Name: dt.Name})
+		var tasks []string
+		if failedOnly {
+			tasks, displayTasks, err = getPreviousFailedTasksAndDisplayTasks(tasksInProjectVariant, displayTasksInProjectVariant, vt, previousPatch.Version)
+			if err != nil {
+				return nil, err
 			}
+		} else {
+			tasks, displayTasks = getPreviousTasksAndDisplayTasks(tasksInProjectVariant, displayTasksInProjectVariant, vt)
 		}
-
 		if len(tasks)+len(displayTasks) > 0 {
 			res = append(res, patch.VariantTasks{
 				Variant:      vt.Variant,
@@ -491,55 +493,43 @@ func (j *patchIntentProcessor) getPreviousPatchDefinition(project *model.Project
 	return res, nil
 }
 
-func (j *patchIntentProcessor) getPreviousPatchFailures(project *model.Project) ([]patch.VariantTasks, error) {
-	previousPatch, err := patch.FindOne(patch.MostRecentPatchByUserAndProject(j.user.Username(), project.Identifier))
+func getPreviousFailedTasksAndDisplayTasks(tasksInProjectVariant []string, displayTasksInProjectVariant []string, vt patch.VariantTasks, version string) ([]string, []patch.DisplayTask, error) {
+	failedTasks, err := task.FindAll(db.Query(task.FailedTasksByVersionAndBV(version, vt.Variant)))
 	if err != nil {
-		return nil, errors.Wrap(err, "error querying for most recent patch")
-	}
-	if previousPatch == nil {
-		return nil, errors.Errorf("no previous patch available")
+		return nil, nil, errors.Wrap(err, "error querying for failed tasks from previous patch")
 	}
 
-	var res []patch.VariantTasks
+	failedTaskNames := make([]string, 0, len(failedTasks))
+	for _, failedTask := range failedTasks {
+		if !failedTask.DisplayOnly && !failedTask.IsPartOfDisplay() {
+			failedTaskNames = append(failedTaskNames, failedTask.DisplayName)
+		}
+	}
 
-	if previousPatch.Status == evergreen.PatchFailed {
-		for _, vt := range previousPatch.VariantsTasks {
-			failedTasks, err := task.FindAll(db.Query(task.FailedTasksByVersionAndBV(previousPatch.Version, vt.Variant)))
-			if err != nil {
-				return nil, errors.Wrap(err, "error querying for failed tasks from previous patch")
-			}
-			tasksInProjectVariant := project.FindTasksForVariant(vt.Variant)
-
-			failedTaskNames := make([]string, 0, len(failedTasks))
-			for _, failedTask := range failedTasks {
-				if !failedTask.DisplayOnly && !failedTask.IsPartOfDisplay() {
-					failedTaskNames = append(failedTaskNames, failedTask.DisplayName)
-				}
-			}
-
-			var displayTasks []patch.DisplayTask
-			displayTasksInProjectVariant := project.FindDisplayTasksForVariant(vt.Variant)
-			for _, dt := range vt.DisplayTasks {
-				for _, failedTask := range failedTasks {
-					if failedTask.DisplayName == dt.Name && failedTask.DisplayOnly && utility.StringSliceContains(displayTasksInProjectVariant, dt.Name) {
-						displayTasks = append(displayTasks, patch.DisplayTask{Name: dt.Name})
-					}
-				}
-			}
-
-			// I want the subset of vt.tasks that exists in tasksForVariant
-			tasks := utility.StringSliceIntersection(tasksInProjectVariant, failedTaskNames)
-
-			if len(tasks)+len(displayTasks) > 0 {
-				res = append(res, patch.VariantTasks{
-					Variant:      vt.Variant,
-					Tasks:        tasks,
-					DisplayTasks: displayTasks,
-				})
+	var displayTasks []patch.DisplayTask
+	for _, dt := range vt.DisplayTasks {
+		for _, failedTask := range failedTasks {
+			if failedTask.DisplayName == dt.Name && failedTask.DisplayOnly && utility.StringSliceContains(displayTasksInProjectVariant, dt.Name) {
+				displayTasks = append(displayTasks, patch.DisplayTask{Name: dt.Name})
 			}
 		}
 	}
-	return res, nil
+
+	// I want the subset of vt.tasks that exists in tasksForVariant
+	tasks := utility.StringSliceIntersection(tasksInProjectVariant, failedTaskNames)
+	return tasks, displayTasks, nil
+}
+
+func getPreviousTasksAndDisplayTasks(tasksInProjectVariant []string, displayTasksInProjectVariant []string, vt patch.VariantTasks) ([]string, []patch.DisplayTask) {
+	// I want the subset of vt.tasks that exists in tasksForVariant
+	tasks := utility.StringSliceIntersection(tasksInProjectVariant, vt.Tasks)
+	var displayTasks []patch.DisplayTask
+	for _, dt := range vt.DisplayTasks {
+		if utility.StringSliceContains(displayTasksInProjectVariant, dt.Name) {
+			displayTasks = append(displayTasks, patch.DisplayTask{Name: dt.Name})
+		}
+	}
+	return tasks, displayTasks
 }
 
 func ProcessTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *model.ProjectRef, env evergreen.Environment, aliasNames []string) ([]string, error) {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/evergreen/model/task"
 	"strings"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/validator"
@@ -502,14 +502,27 @@ func (j *patchIntentProcessor) getPreviousPatchFailures(project *model.Project) 
 
 	var res []patch.VariantTasks
 
+	grip.Info(message.Fields{
+		"message":       "MALIK",
+		"previousPatch": previousPatch,
+	})
+
 	if previousPatch.Status == evergreen.PatchFailed {
 		for _, vt := range previousPatch.VariantsTasks {
 			failedTasks, err := task.FindAll(db.Query(task.FailedTasksByVersionAndBV(previousPatch.Version, vt.Variant)))
+			grip.Info(message.Fields{
+				"message":     "MALIK",
+				"failedTasks": failedTasks,
+			})
 			if err != nil {
 				return nil, errors.Wrap(err, "error querying for failed tasks from previous patch")
 			}
-
 			tasksInProjectVariant := project.FindTasksForVariant(vt.Variant)
+			grip.Info(message.Fields{
+				"message":               "MALIK",
+				"tasksInProjectVariant": tasksInProjectVariant,
+			})
+
 			failedTaskNames := make([]string, 0, len(failedTasks))
 			for _, failedTask := range failedTasks {
 				if !failedTask.DisplayOnly && !failedTask.IsPartOfDisplay() {
@@ -526,6 +539,14 @@ func (j *patchIntentProcessor) getPreviousPatchFailures(project *model.Project) 
 					}
 				}
 			}
+			grip.Info(message.Fields{
+				"message":                      "MALIK",
+				"displayTasksInProjectVariant": displayTasksInProjectVariant,
+			})
+			grip.Info(message.Fields{
+				"message":      "MALIK",
+				"displayTasks": displayTasks,
+			})
 
 			// I want the subset of vt.tasks that exists in tasksForVariant
 			tasks := utility.StringSliceIntersection(tasksInProjectVariant, failedTaskNames)

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -502,26 +502,13 @@ func (j *patchIntentProcessor) getPreviousPatchFailures(project *model.Project) 
 
 	var res []patch.VariantTasks
 
-	grip.Info(message.Fields{
-		"message":       "MALIK",
-		"previousPatch": previousPatch,
-	})
-
 	if previousPatch.Status == evergreen.PatchFailed {
 		for _, vt := range previousPatch.VariantsTasks {
 			failedTasks, err := task.FindAll(db.Query(task.FailedTasksByVersionAndBV(previousPatch.Version, vt.Variant)))
-			grip.Info(message.Fields{
-				"message":     "MALIK",
-				"failedTasks": failedTasks,
-			})
 			if err != nil {
 				return nil, errors.Wrap(err, "error querying for failed tasks from previous patch")
 			}
 			tasksInProjectVariant := project.FindTasksForVariant(vt.Variant)
-			grip.Info(message.Fields{
-				"message":               "MALIK",
-				"tasksInProjectVariant": tasksInProjectVariant,
-			})
 
 			failedTaskNames := make([]string, 0, len(failedTasks))
 			for _, failedTask := range failedTasks {
@@ -539,14 +526,6 @@ func (j *patchIntentProcessor) getPreviousPatchFailures(project *model.Project) 
 					}
 				}
 			}
-			grip.Info(message.Fields{
-				"message":                      "MALIK",
-				"displayTasksInProjectVariant": displayTasksInProjectVariant,
-			})
-			grip.Info(message.Fields{
-				"message":      "MALIK",
-				"displayTasks": displayTasks,
-			})
 
 			// I want the subset of vt.tasks that exists in tasksForVariant
 			tasks := utility.StringSliceIntersection(tasksInProjectVariant, failedTaskNames)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -2,7 +2,6 @@ package units
 
 import (
 	"context"
-	"github.com/evergreen-ci/evergreen/model/task"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/thirdparty"

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -291,11 +291,11 @@ func (s *PatchIntentUnitsSuite) TestGetPreviousPatchDefinition() {
 	}).Insert())
 
 	intent, err := patch.NewCliIntent(patch.CLIIntentParams{
-		User:            "me",
-		Project:         s.project,
-		BaseGitHash:     s.hash,
-		Description:     s.desc,
-		ReuseDefinition: true,
+		User:             "me",
+		Project:          s.project,
+		BaseGitHash:      s.hash,
+		Description:      s.desc,
+		RepeatDefinition: true,
 	})
 	s.NoError(err)
 	j := NewPatchIntentProcessor(mgobson.NewObjectId(), intent).(*patchIntentProcessor)
@@ -314,7 +314,7 @@ func (s *PatchIntentUnitsSuite) TestGetPreviousPatchDefinition() {
 			DisplayTasks: []patch.DisplayTask{{Name: "dt2"}},
 		},
 	}}
-	vt, err := j.getPreviousPatchDefinition(&project)
+	vt, err := j.getPreviousPatchDefinition(&project, false)
 	s.NoError(err)
 	s.Require().Len(vt, 2)
 	s.Equal("bv1", vt[0].Variant)


### PR DESCRIPTION
[EVG-15171](https://jira.mongodb.org/browse/EVG-15171)

### Description 
Introduce repeat-failed, a flag on the CLI patch command that will repeat only the failed tasks and build variants from the most recent patch (if any).
### Testing 
Tested in staging on sandbox project when the most recent patch was failed, and saw the previously failed tasks were automatically selected.