### PR TITLE
EVG-16448: atomically update host during termination

### DIFF
--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
@@ -272,7 +273,6 @@ func TestUpdatingHostStatus(t *testing.T) {
 			host, err = FindOne(ById(host.Id))
 			So(err, ShouldBeNil)
 			So(host.Status, ShouldEqual, evergreen.HostRunning)
-
 		})
 
 		Convey("if the host is terminated, the status update should fail"+
@@ -285,11 +285,79 @@ func TestUpdatingHostStatus(t *testing.T) {
 			host, err = FindOne(ById(host.Id))
 			So(err, ShouldBeNil)
 			So(host.Status, ShouldEqual, evergreen.HostTerminated)
-
 		})
-
 	})
+}
 
+func TestSetStatusAndFields(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection, event.AllLogCollection))
+	}()
+	for tName, tCase := range map[string]func(t *testing.T, h *Host){
+		"FailsIfHostDoesNotExist": func(t *testing.T, h *Host) {
+			assert.Error(t, h.SetStatusAndFields(evergreen.HostDecommissioned, bson.M{}, evergreen.User, ""))
+
+			dbHost, err := FindOneId(h.Id)
+			assert.NoError(t, err)
+			assert.Zero(t, dbHost)
+		},
+		"DoesNotUpdatesAnyFieldsIfStatusIsIdentical": func(t *testing.T, h *Host) {
+			require.NoError(t, h.Insert())
+
+			currentStatus := h.Status
+			newDisplayName := "new-display-name"
+			require.NoError(t, h.SetStatusAndFields(currentStatus, bson.M{DisplayNameKey: newDisplayName}, evergreen.User, ""))
+
+			dbHost, err := FindOneId(h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, currentStatus, dbHost.Status, "host status should not be updated when host status is identical")
+			assert.Zero(t, dbHost.DisplayName, "display name should not be updated when host status is identical")
+		},
+		"UpdatesOnlyStatus": func(t *testing.T, h *Host) {
+			require.NoError(t, h.Insert())
+			newStatus := evergreen.HostQuarantined
+			require.NoError(t, h.SetStatusAndFields(newStatus, bson.M{}, evergreen.User, ""))
+
+			dbHost, err := FindOneId(h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, newStatus, dbHost.Status)
+		},
+		"UpdatesStatusAndAdditionalFields": func(t *testing.T, h *Host) {
+			require.NoError(t, h.Insert())
+
+			newStatus := evergreen.HostQuarantined
+			newDisplayName := "new-display-name"
+			require.NoError(t, h.SetStatusAndFields(newStatus, bson.M{DisplayNameKey: newDisplayName}, evergreen.User, ""))
+
+			dbHost, err := FindOneId(h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, newStatus, dbHost.Status)
+			assert.Equal(t, newDisplayName, dbHost.DisplayName)
+		},
+		"FailsForAlreadyTerminatedHost": func(t *testing.T, h *Host) {
+			h.Status = evergreen.HostTerminated
+			require.NoError(t, h.Insert())
+
+			assert.Error(t, h.SetStatusAndFields(evergreen.HostRunning, bson.M{}, evergreen.User, ""))
+
+			dbHost, err := FindOneId(h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, evergreen.HostTerminated, dbHost.Status, "terminated host should remain terminated")
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(Collection, event.AllLogCollection))
+			h := Host{
+				Id:     "host",
+				Status: evergreen.HostRunning,
+			}
+			tCase(t, &h)
+		})
+	}
 }
 
 func TestSetStopped(t *testing.T) {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16448

### Description 
Host termination does two updates - one to set the status, and another to set the termination time and unset the volumes. Since it's not atomic, it's possible for the host to be terminated in the DB, but no termination time is set yet. This temporary mismatch can cause [this](https://github.com/evergreen-ci/evergreen/blob/2406d863f1422c46b46ebd4abd2e9f19a12cad74/service/api_task.go#L500-L506) to log spuriously when the agent requests the next task.

* Atomically update the host to terminated using a single update.
* Refactor `SetStatus` to handle setting additional fields in the update.

### Testing 
Added unit tests for `SetStatusAndFields`.
