### PR TITLE
EVG-16166: container task queue

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -63,7 +63,7 @@ type Task struct {
 	// time information for task
 	// Create - the creation time for the task, derived from the commit time or the patch creation time.
 	// Dispatch - the time the task runner starts up the agent on the host.
-	// Scheduled - the time the commit is scheduled.
+	// Scheduled - the time the task is scheduled.
 	// Start - the time the agent starts the task on the host after spinning it up.
 	// Finish - the time the task was completed on the remote host.
 	// Activated - the time the task was marked as available to be scheduled, automatically or by a developer.

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1855,6 +1855,56 @@ func TestUnattainableSchedulableHostTasksQuery(t *testing.T) {
 	assert.Len(schedulableTasks, 2)
 }
 
+func TestUnattainableScheduledContainerTasksQuery(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(Collection))
+	tasks := []Task{
+		{
+			Id:                "t0",
+			Activated:         true,
+			Status:            evergreen.TaskUndispatched,
+			ExecutionPlatform: ExecutionPlatformContainer,
+			Priority:          0,
+		},
+		{
+			Id:                "t1",
+			Activated:         true,
+			Status:            evergreen.TaskUndispatched,
+			ExecutionPlatform: ExecutionPlatformContainer,
+			Priority:          -1,
+		},
+		{
+			Id:                "t2",
+			Activated:         true,
+			Status:            evergreen.TaskUndispatched,
+			ExecutionPlatform: ExecutionPlatformContainer,
+			Priority:          2,
+		},
+		{
+			Id:                "t3",
+			Activated:         false,
+			Status:            evergreen.TaskUndispatched,
+			ExecutionPlatform: ExecutionPlatformContainer,
+			Priority:          0,
+		},
+		{
+			Id:                "t4",
+			Activated:         false,
+			Status:            evergreen.TaskUndispatched,
+			ExecutionPlatform: ExecutionPlatformHost,
+			Priority:          0,
+		},
+	}
+	for _, task := range tasks {
+		assert.NoError(task.Insert())
+	}
+
+	q := db.Query(ScheduledContainerTasksQuery())
+	schedulableTasks, err := FindAll(q)
+	assert.NoError(err)
+	assert.Len(schedulableTasks, 2)
+}
+
 func TestGetTimeSpent(t *testing.T) {
 	assert := assert.New(t)
 	referenceTime := time.Unix(1136239445, 0)


### PR DESCRIPTION
[EVG-16166](https://jira.mongodb.org/browse/EVG-16166)

### Description 
Query for schedulable container tasks and some basic tests. This can be sorted with q.Sort when needed.


### Testing 
  Basic unit test to ensure we screen out inactivated tasks, tasks with the wrong Execution Platform, and tasks with negative priority.
