### PR TITLE
EVG-15555 Add aborted field to version

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1094,7 +1094,11 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 		return errors.Wrapf(err, "updating version '%s' status", taskVersion.Id)
 	}
 	if t.Aborted {
-		taskVersion.SetAborted()
+		err = taskVersion.SetAborted()
+		if err != nil {
+			return errors.Wrapf(err, "updating version '%s' as aborted", taskVersion.Id)
+		}
+
 	}
 
 	if evergreen.IsPatchRequester(taskVersion.Requester) {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1080,6 +1080,9 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 	if err != nil {
 		return errors.Wrapf(err, "updating version '%s' status", taskVersion.Id)
 	}
+	if t.Aborted {
+		taskVersion.SetAborted()
+	}
 
 	if evergreen.IsPatchRequester(taskVersion.Requester) {
 		p, err := patch.FindOneId(taskVersion.Id)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -344,6 +344,19 @@ func AbortTask(taskId, caller string) error {
 	if err = SetActiveState(t, caller, false); err != nil {
 		return err
 	}
+
+	v, err := VersionFindOneId(t.Version)
+	if err != nil {
+		return err
+	}
+	if v == nil {
+		return errors.Errorf("version '%s' doesn't exist", t.Version)
+	}
+	err = v.SetAborted()
+	if err != nil {
+		return err
+	}
+
 	event.LogTaskAbortRequest(t.Id, t.Execution, caller)
 	return t.SetAborted(task.AbortInfo{User: caller})
 }

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1564,6 +1564,9 @@ func TestAbortTask(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(testTask.Activated, ShouldEqual, false)
 			So(testTask.Aborted, ShouldEqual, true)
+			testVersion, err := VersionFindOneId(testTask.Version)
+			So(err, ShouldBeNil)
+			So(testVersion.Aborted, ShouldEqual, utility.TruePtr())
 		})
 		Convey("a task that is finished should error when aborting", func() {
 			So(AbortTask(finishedTask.Id, userName), ShouldNotBeNil)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1566,7 +1566,7 @@ func TestAbortTask(t *testing.T) {
 			So(testTask.Aborted, ShouldEqual, true)
 			testVersion, err := VersionFindOneId(testTask.Version)
 			So(err, ShouldBeNil)
-			So(testVersion.Aborted, ShouldEqual, utility.TruePtr())
+			So(testVersion.IsAborted(), ShouldEqual, true)
 		})
 		Convey("a task that is finished should error when aborting", func() {
 			So(AbortTask(finishedTask.Id, userName), ShouldNotBeNil)

--- a/model/version.go
+++ b/model/version.go
@@ -37,6 +37,7 @@ type Version struct {
 	Branch              string               `bson:"branch_name" json:"branch_name,omitempty"`
 	BuildVariants       []VersionBuildStatus `bson:"build_variants_status,omitempty" json:"build_variants_status,omitempty"`
 	PeriodicBuildID     string               `bson:"periodic_build_id,omitempty" json:"periodic_build_id,omitempty"`
+	Aborted             *bool                `bson:"abort,omitempty" json:"abort,omitempty"`
 
 	// This stores whether or not a version has tasks which were activated.
 	// We use a bool ptr in order to to distinguish the unset value from the default value
@@ -153,6 +154,32 @@ func (self *Version) SetNotActivated() error {
 			},
 		},
 	)
+}
+
+func (self *Version) SetAborted() error {
+	self.Aborted = utility.TruePtr()
+	return VersionUpdateOne(
+		bson.M{VersionIdKey: self.Id},
+		bson.M{
+			"$set": bson.M{
+				VersionAbortedKey: true,
+			},
+		},
+	)
+
+}
+
+func (self *Version) SetNotAborted() error {
+	self.Aborted = utility.FalsePtr()
+	return VersionUpdateOne(
+		bson.M{VersionIdKey: self.Id},
+		bson.M{
+			"$set": bson.M{
+				VersionAbortedKey: false,
+			},
+		},
+	)
+
 }
 
 func (self *Version) Insert() error {

--- a/model/version.go
+++ b/model/version.go
@@ -182,6 +182,10 @@ func (self *Version) SetNotAborted() error {
 
 }
 
+func (self *Version) IsAborted() bool {
+	return utility.FromBoolPtr(self.Aborted)
+}
+
 func (self *Version) Insert() error {
 	return db.Insert(VersionCollection, self)
 }

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -49,6 +49,7 @@ var (
 	VersionSatisfiedTriggersKey   = bsonutil.MustHaveTag(Version{}, "SatisfiedTriggers")
 	VersionPeriodicBuildIDKey     = bsonutil.MustHaveTag(Version{}, "PeriodicBuildID")
 	VersionActivatedKey           = bsonutil.MustHaveTag(Version{}, "Activated")
+	VersionAbortedKey             = bsonutil.MustHaveTag(Version{}, "Aborted")
 )
 
 // ById returns a db.Q object which will filter on {_id : <the id param>}

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -30,6 +30,7 @@ type APIVersion struct {
 	Requester          *string        `json:"requester"`
 	Errors             []*string      `json:"errors"`
 	Activated          *bool          `json:"activated"`
+	Aborted            *bool          `json:"aborted"`
 }
 
 type buildDetail struct {
@@ -60,6 +61,7 @@ func (apiVersion *APIVersion) BuildFromService(h interface{}) error {
 	apiVersion.Requester = utility.ToStringPtr(v.Requester)
 	apiVersion.Errors = utility.ToStringPtrSlice(v.Errors)
 	apiVersion.Activated = v.Activated
+	apiVersion.Aborted = v.Aborted
 
 	var bd buildDetail
 	for _, t := range v.BuildVariants {


### PR DESCRIPTION
[EVG-15555](https://jira.mongodb.org/browse/EVG-15555)

### Description 
version now keeps track of whether a task has been aborted or not. 
it updates in both the AbortTask function and updatebuildandversionstatus function that is is called in mark end of a task.
not sure if we need it in both places but that seems safer 

### Testing 
unit test