### PR TITLE
EVG-16410 modify PatchTriggerAliasInput to accurately reflect the input

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -8051,9 +8051,9 @@ input PatchTriggerAliasInput {
 }
 
 input TaskSpecifierInput {
-  patchAlias: String
-  taskRegex: String
-  variantRegex: String
+  patchAlias: String!
+  taskRegex: String!
+  variantRegex: String!
 }
 
 input ProjectVarsInput {
@@ -41764,7 +41764,7 @@ func (ec *executionContext) unmarshalInputTaskSpecifierInput(ctx context.Context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("patchAlias"))
-			it.PatchAlias, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.PatchAlias, err = ec.unmarshalNString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -41772,7 +41772,7 @@ func (ec *executionContext) unmarshalInputTaskSpecifierInput(ctx context.Context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("taskRegex"))
-			it.TaskRegex, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.TaskRegex, err = ec.unmarshalNString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -41780,7 +41780,7 @@ func (ec *executionContext) unmarshalInputTaskSpecifierInput(ctx context.Context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("variantRegex"))
-			it.VariantRegex, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.VariantRegex, err = ec.unmarshalNString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -554,7 +554,6 @@ type ComplexityRoot struct {
 
 	PatchTriggerAlias struct {
 		Alias                  func(childComplexity int) int
-		ChildProject           func(childComplexity int) int
 		ChildProjectId         func(childComplexity int) int
 		ChildProjectIdentifier func(childComplexity int) int
 		ParentAsModule         func(childComplexity int) int
@@ -3861,13 +3860,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PatchTriggerAlias.Alias(childComplexity), true
-
-	case "PatchTriggerAlias.childProject":
-		if e.complexity.PatchTriggerAlias.ChildProject == nil {
-			break
-		}
-
-		return e.complexity.PatchTriggerAlias.ChildProject(childComplexity), true
 
 	case "PatchTriggerAlias.childProjectId":
 		if e.complexity.PatchTriggerAlias.ChildProjectId == nil {
@@ -8271,7 +8263,6 @@ type ChildPatchAlias {
 
 type PatchTriggerAlias {
   alias: String!
-  childProject: String @deprecated
   childProjectId: String!
   childProjectIdentifier: String!
   taskSpecifiers: [TaskSpecifier]
@@ -21902,38 +21893,6 @@ func (ec *executionContext) _PatchTriggerAlias_alias(ctx context.Context, field 
 	res := resTmp.(*string)
 	fc.Result = res
 	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _PatchTriggerAlias_childProject(ctx context.Context, field graphql.CollectedField, obj *model.APIPatchTriggerDefinition) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "PatchTriggerAlias",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ChildProject, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _PatchTriggerAlias_childProjectId(ctx context.Context, field graphql.CollectedField, obj *model.APIPatchTriggerDefinition) (ret graphql.Marshaler) {
@@ -45021,8 +44980,6 @@ func (ec *executionContext) _PatchTriggerAlias(ctx context.Context, sel ast.Sele
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "childProject":
-			out.Values[i] = ec._PatchTriggerAlias_childProject(ctx, field, obj)
 		case "childProjectId":
 			out.Values[i] = ec._PatchTriggerAlias_childProjectId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -8052,18 +8052,16 @@ input WorkstationSetupCommandInput {
 
 input PatchTriggerAliasInput {
   alias: String!
-  childProjectId: String!
   childProjectIdentifier: String!
-  taskSpecifiers: [TaskSpecifierInput]
+  taskSpecifiers: [TaskSpecifierInput!]!
   status: String
   parentAsModule: String
-  variantsTasks: [VariantTaskInput]!
 }
 
 input TaskSpecifierInput {
-  patchAlias: String!
-  taskRegex: String!
-  variantRegex: String!
+  patchAlias: String
+  taskRegex: String
+  variantRegex: String
 }
 
 input ProjectVarsInput {
@@ -40284,14 +40282,6 @@ func (ec *executionContext) unmarshalInputPatchTriggerAliasInput(ctx context.Con
 			if err != nil {
 				return it, err
 			}
-		case "childProjectId":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("childProjectId"))
-			it.ChildProjectId, err = ec.unmarshalNString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
 		case "childProjectIdentifier":
 			var err error
 
@@ -40304,7 +40294,7 @@ func (ec *executionContext) unmarshalInputPatchTriggerAliasInput(ctx context.Con
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("taskSpecifiers"))
-			it.TaskSpecifiers, err = ec.unmarshalOTaskSpecifierInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifier(ctx, v)
+			it.TaskSpecifiers, err = ec.unmarshalNTaskSpecifierInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifierᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -40321,14 +40311,6 @@ func (ec *executionContext) unmarshalInputPatchTriggerAliasInput(ctx context.Con
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("parentAsModule"))
 			it.ParentAsModule, err = ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "variantsTasks":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("variantsTasks"))
-			it.VariantsTasks, err = ec.unmarshalNVariantTaskInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐVariantTask(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -41823,7 +41805,7 @@ func (ec *executionContext) unmarshalInputTaskSpecifierInput(ctx context.Context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("patchAlias"))
-			it.PatchAlias, err = ec.unmarshalNString2ᚖstring(ctx, v)
+			it.PatchAlias, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -41831,7 +41813,7 @@ func (ec *executionContext) unmarshalInputTaskSpecifierInput(ctx context.Context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("taskRegex"))
-			it.TaskRegex, err = ec.unmarshalNString2ᚖstring(ctx, v)
+			it.TaskRegex, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -41839,7 +41821,7 @@ func (ec *executionContext) unmarshalInputTaskSpecifierInput(ctx context.Context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("variantRegex"))
-			it.VariantRegex, err = ec.unmarshalNString2ᚖstring(ctx, v)
+			it.VariantRegex, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -51866,6 +51848,32 @@ func (ec *executionContext) marshalNTaskSortCategory2githubᚗcomᚋevergreenᚑ
 	return v
 }
 
+func (ec *executionContext) unmarshalNTaskSpecifierInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifier(ctx context.Context, v interface{}) (model.APITaskSpecifier, error) {
+	res, err := ec.unmarshalInputTaskSpecifierInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNTaskSpecifierInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifierᚄ(ctx context.Context, v interface{}) ([]model.APITaskSpecifier, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]model.APITaskSpecifier, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNTaskSpecifierInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifier(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
 func (ec *executionContext) marshalNTaskSyncOptions2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSyncOptions(ctx context.Context, sel ast.SelectionSet, v model.APITaskSyncOptions) graphql.Marshaler {
 	return ec._TaskSyncOptions(ctx, sel, &v)
 }
@@ -52117,27 +52125,6 @@ func (ec *executionContext) marshalNVariantTask2ᚕgithubᚗcomᚋevergreenᚑci
 	wg.Wait()
 
 	return ret
-}
-
-func (ec *executionContext) unmarshalNVariantTaskInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐVariantTask(ctx context.Context, v interface{}) ([]model.VariantTask, error) {
-	var vSlice []interface{}
-	if v != nil {
-		if tmp1, ok := v.([]interface{}); ok {
-			vSlice = tmp1
-		} else {
-			vSlice = []interface{}{v}
-		}
-	}
-	var err error
-	res := make([]model.VariantTask, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOVariantTaskInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐVariantTask(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
 }
 
 func (ec *executionContext) unmarshalNVariantTasks2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐVariantTasksᚄ(ctx context.Context, v interface{}) ([]*VariantTasks, error) {
@@ -54430,35 +54417,6 @@ func (ec *executionContext) marshalOTaskSpecifier2ᚕgithubᚗcomᚋevergreenᚑ
 	return ret
 }
 
-func (ec *executionContext) unmarshalOTaskSpecifierInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifier(ctx context.Context, v interface{}) (model.APITaskSpecifier, error) {
-	res, err := ec.unmarshalInputTaskSpecifierInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalOTaskSpecifierInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifier(ctx context.Context, v interface{}) ([]model.APITaskSpecifier, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var vSlice []interface{}
-	if v != nil {
-		if tmp1, ok := v.([]interface{}); ok {
-			vSlice = tmp1
-		} else {
-			vSlice = []interface{}{v}
-		}
-	}
-	var err error
-	res := make([]model.APITaskSpecifier, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOTaskSpecifierInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifier(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
 func (ec *executionContext) unmarshalOTaskSyncOptionsInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSyncOptions(ctx context.Context, v interface{}) (model.APITaskSyncOptions, error) {
 	res, err := ec.unmarshalInputTaskSyncOptionsInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -54668,11 +54626,6 @@ func (ec *executionContext) unmarshalOUserSettingsInput2ᚖgithubᚗcomᚋevergr
 
 func (ec *executionContext) marshalOVariantTask2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐVariantTask(ctx context.Context, sel ast.SelectionSet, v model.VariantTask) graphql.Marshaler {
 	return ec._VariantTask(ctx, sel, &v)
-}
-
-func (ec *executionContext) unmarshalOVariantTaskInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐVariantTask(ctx context.Context, v interface{}) (model.VariantTask, error) {
-	res, err := ec.unmarshalInputVariantTaskInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx context.Context, sel ast.SelectionSet, v []*model.APIVersion) graphql.Marshaler {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1444,7 +1444,6 @@ func (r *patchResolver) PatchTriggerAliases(ctx context.Context, obj *restModel.
 
 		aliases = append(aliases, &restModel.APIPatchTriggerDefinition{
 			Alias:                  utility.ToStringPtr(alias.Alias),
-			ChildProject:           utility.ToStringPtr(alias.ChildProject),
 			ChildProjectId:         utility.ToStringPtr(alias.ChildProject),
 			ChildProjectIdentifier: utility.ToStringPtr(identifier),
 			VariantsTasks:          variantsTasks,

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -608,18 +608,16 @@ input WorkstationSetupCommandInput {
 
 input PatchTriggerAliasInput {
   alias: String!
-  childProjectId: String!
   childProjectIdentifier: String!
-  taskSpecifiers: [TaskSpecifierInput]
+  taskSpecifiers: [TaskSpecifierInput!]!
   status: String
   parentAsModule: String
-  variantsTasks: [VariantTaskInput]!
 }
 
 input TaskSpecifierInput {
-  patchAlias: String!
-  taskRegex: String!
-  variantRegex: String!
+  patchAlias: String
+  taskRegex: String
+  variantRegex: String
 }
 
 input ProjectVarsInput {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -827,7 +827,6 @@ type ChildPatchAlias {
 
 type PatchTriggerAlias {
   alias: String!
-  childProject: String @deprecated
   childProjectId: String!
   childProjectIdentifier: String!
   taskSpecifiers: [TaskSpecifier]

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -615,9 +615,9 @@ input PatchTriggerAliasInput {
 }
 
 input TaskSpecifierInput {
-  patchAlias: String
-  taskRegex: String
-  variantRegex: String
+  patchAlias: String!
+  taskRegex: String!
+  variantRegex: String!
 }
 
 input ProjectVarsInput {

--- a/graphql/tests/projectSettings/data.json
+++ b/graphql/tests/projectSettings/data.json
@@ -19,7 +19,7 @@
       "patch_trigger_aliases" : [
         {
           "alias" : "my_alias_sandbox",
-          "child_project" : "mci",
+          "child_project" : "vars_test",
           "task_specifiers" : [
             {
               "task_regex" : "test-util",

--- a/graphql/tests/projectSettings/queries/project-settings-project.graphql
+++ b/graphql/tests/projectSettings/queries/project-settings-project.graphql
@@ -28,7 +28,7 @@
             }
             patchTriggerAliases {
                 alias
-                childProject
+                childProjectIdentifier
                 taskSpecifiers {
                     taskRegex
                     variantRegex

--- a/graphql/tests/projectSettings/results.json
+++ b/graphql/tests/projectSettings/results.json
@@ -28,7 +28,7 @@
               "patchTriggerAliases" : [
                 {
                   "alias" : "my_alias_sandbox",
-                  "childProject" : "mci",
+                  "childProjectIdentifier" : "varsTest",
                   "taskSpecifiers": [
                     {
                       "taskRegex" : "test-util",

--- a/graphql/tests/repoSettings/data.json
+++ b/graphql/tests/repoSettings/data.json
@@ -17,7 +17,7 @@
       "patch_trigger_aliases" : [
         {
           "alias" : "my_alias_sandbox",
-          "child_project" : "mci",
+          "child_project" : "vars_test",
           "task_specifiers" : [
             {
               "task_regex" : "test-util",
@@ -69,6 +69,13 @@
         "git_clone" : false
       },
       "hidden" : false
+    }
+  ],
+  "project_ref": [
+    {
+      "_id" : "vars_test",
+      "identifier" : "varsTest",
+      "display_name" : "Vars test"
     }
   ],
   "project_aliases": [

--- a/graphql/tests/repoSettings/queries/repo-settings-project.graphql
+++ b/graphql/tests/repoSettings/queries/repo-settings-project.graphql
@@ -26,7 +26,7 @@
             }
             patchTriggerAliases {
                 alias
-                childProject
+                childProjectIdentifier
                 taskSpecifiers {
                     taskRegex
                     variantRegex

--- a/graphql/tests/repoSettings/results.json
+++ b/graphql/tests/repoSettings/results.json
@@ -26,7 +26,7 @@
               "patchTriggerAliases" : [
                 {
                   "alias" : "my_alias_sandbox",
-                  "childProject" : "mci",
+                  "childProjectIdentifier" : "varsTest",
                   "taskSpecifiers": [
                     {
                       "taskRegex" : "test-util",

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -187,7 +187,7 @@ func (sc *DBConnector) SaveProjectSettingsForSection(ctx context.Context, projec
 		modified, err = sc.UpdateAliasesForSection(projectId, changes.Aliases, before.Aliases, section)
 		catcher.Add(err)
 	case model.ProjectPagePatchAliasSection:
-		for i := range changes.ProjectRef.PatchTriggerAliases {
+		for i := range mergedProjectRef.PatchTriggerAliases {
 			mergedProjectRef.PatchTriggerAliases[i], err = model.ValidateTriggerDefinition(mergedProjectRef.PatchTriggerAliases[i], projectId)
 			catcher.Add(err)
 		}
@@ -215,7 +215,7 @@ func (sc *DBConnector) SaveProjectSettingsForSection(ctx context.Context, projec
 		}
 		catcher.Wrapf(sc.DeleteSubscriptions(projectId, toDelete), "Database error deleting subscriptions")
 	}
-
+	fmt.Println("GETTING TO SAVE FOR SECTION")
 	modifiedProjectRef, err := model.SaveProjectPageForSection(projectId, newProjectRef, section, isRepo)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error defaulting project ref to repo for section '%s'", section)

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -187,6 +187,13 @@ func (sc *DBConnector) SaveProjectSettingsForSection(ctx context.Context, projec
 		modified, err = sc.UpdateAliasesForSection(projectId, changes.Aliases, before.Aliases, section)
 		catcher.Add(err)
 	case model.ProjectPagePatchAliasSection:
+		for i := range changes.ProjectRef.PatchTriggerAliases {
+			mergedProjectRef.PatchTriggerAliases[i], err = model.ValidateTriggerDefinition(mergedProjectRef.PatchTriggerAliases[i], projectId)
+			catcher.Add(err)
+		}
+		if catcher.HasErrors() {
+			return nil, errors.Wrap(catcher.Resolve(), "error validating patch trigger aliases")
+		}
 		modified, err = sc.UpdateAliasesForSection(projectId, changes.Aliases, before.Aliases, section)
 		catcher.Add(err)
 	case model.ProjectPageNotificationsSection:

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -266,7 +266,7 @@ func (s *ProjectPatchByIDSuite) TestPatchTriggerAliases() {
 	h := s.rm.(*projectIDPatchHandler)
 	h.user = &user.DBUser{Id: "me"}
 
-	jsonBody := []byte(`{"patch_trigger_aliases": [{"child_project": "child", "task_specifiers": [ {"task_regex": ".*", "variant_regex": ".*" }]}]}`)
+	jsonBody := []byte(`{"patch_trigger_aliases": [{"child_project_identifier": "child", "task_specifiers": [ {"task_regex": ".*", "variant_regex": ".*" }]}]}`)
 	req, _ := http.NewRequest("PATCH", "http://example.com/api/rest/v2/projects/dimoxinil", bytes.NewBuffer(jsonBody))
 	req = gimlet.SetURLVars(req, map[string]string{"project_id": "dimoxinil"})
 	s.NoError(s.rm.Parse(ctx, req))


### PR DESCRIPTION
[EVG-16410](https://jira.mongodb.org/browse/EVG-16410)

### Description 
Also changed TaskSpecifierInput items to be nullable, because on the legacy UI it's either patchAlias OR taskRegex and variantRegex, but if that seems wrong I'll change it back!
