### PR TITLE
EVG-16150 Add option to fail or noop s3.put if file already exists

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -10,12 +10,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/model/artifact"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
@@ -85,10 +87,14 @@ type s3put struct {
 	// for missing files.
 	Optional string `mapstructure:"optional" plugin:"expand"`
 
+	// NoOverwrite, when set to true, will not upload files if they already exist in s3
+	NoOverwrite string `mapstructure:"no_overwrite" plugin:"expand"`
+
 	// workDir sets the working directory relative to which s3put should look for files to upload.
 	// workDir will be empty if an absolute path is provided to the file.
-	workDir     string
-	skipMissing bool
+	workDir         string
+	skipMissing     bool
+	noOverwriteBool bool
 
 	bucket pail.Bucket
 
@@ -190,6 +196,15 @@ func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 		}
 	} else {
 		s3pc.skipMissing = false
+	}
+
+	if s3pc.NoOverwrite != "" {
+		s3pc.noOverwriteBool, err = strconv.ParseBool(s3pc.NoOverwrite)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	} else {
+		s3pc.noOverwriteBool = false
 	}
 	return nil
 }
@@ -338,6 +353,18 @@ retryLoop:
 				}
 
 				fpath = filepath.Join(filepath.Join(s3pc.workDir, s3pc.LocalFilesIncludeFilterPrefix), fpath)
+
+				if s3pc.noOverwriteBool {
+					// check if the file exists
+					exists, err := s3pc.fileExists(remoteName)
+					if err != nil {
+						return errors.Wrapf(err, "error checking if file %s exists", remoteName)
+					}
+					if exists {
+						logger.Task().Infof("noop: file '%s' already exists. Continuing to upload other files.", fpath)
+						continue uploadLoop
+					}
+				}
 				err = s3pc.bucket.Upload(ctx, remoteName, fpath)
 				if err != nil {
 					// retry errors other than "file doesn't exist", which we handle differently based on what
@@ -463,4 +490,27 @@ func (s3pc *s3put) isPrivate(visibility string) bool {
 func (s3pc *s3put) isPublic() bool {
 	return (s3pc.Visibility == "" || s3pc.Visibility == artifact.Public) &&
 		(s3pc.Permissions == s3.BucketCannedACLPublicRead || s3pc.Permissions == s3.BucketCannedACLPublicReadWrite)
+}
+
+func (s3pc *s3put) fileExists(remoteName string) (bool, error) {
+	requestParams := thirdparty.RequestParams{
+		Bucket:    s3pc.Bucket,
+		FileKey:   remoteName,
+		AwsKey:    s3pc.AwsKey,
+		AwsSecret: s3pc.AwsSecret,
+	}
+	_, err := thirdparty.GetHeadObject(requestParams)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case thirdparty.NotFoundError:
+				return false, nil
+			default:
+				return false, errors.Wrapf(err, "error getting head object for: %s", remoteName)
+			}
+		} else {
+			return false, errors.Wrapf(err, "error reading error while getting head object '%s'", remoteName)
+		}
+	}
+	return true, nil
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2022-03-01"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-02-14"
+	AgentVersion = "2022-03-08"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-16150](https://jira.mongodb.org/browse/EVG-16150)

### Description 
This adds a no_overwrite flag that can be added to the s3.put command to skip files that already exist. 

### Testing 
I [tested it on staging](https://spruce-staging.corp.mongodb.com/version/622775a19dbe323e09f7d4c2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) by adding the no_overwrite flag and restarting the task. The first run has the file, the second one doesn't and prints the noop message. 