### PR TITLE
EVG-12802 notarize cli for macOS

### DIFF
--- a/cmd/sign-executable/go.mod
+++ b/cmd/sign-executable/go.mod
@@ -1,0 +1,8 @@
+module github.com/evergreen-ci/evergreen/cmd/sign-executable
+
+go 1.16
+
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/urfave/cli v1.22.5
+)

--- a/cmd/sign-executable/go.sum
+++ b/cmd/sign-executable/go.sum
@@ -1,0 +1,15 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
+github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/cmd/sign-executable/sign-executable.go
+++ b/cmd/sign-executable/sign-executable.go
@@ -23,13 +23,13 @@ const (
 )
 
 func zipFile(inputFilePath, destinationPath string) error {
-	zipFile, err := os.Create(destinationPath)
+	outputFile, err := os.Create(destinationPath)
 	if err != nil {
 		return errors.Wrap(err, "creating zip file")
 	}
-	defer zipFile.Close()
+	defer outputFile.Close()
 
-	zipWriter := zip.NewWriter(zipFile)
+	zipWriter := zip.NewWriter(outputFile)
 	defer zipWriter.Close()
 
 	inputFile, err := os.Open(inputFilePath)
@@ -57,7 +57,7 @@ func zipFile(inputFilePath, destinationPath string) error {
 	return errors.Wrap(err, "copying input file into zip file")
 }
 
-func zipFileToFile(file *zip.File, destination string) error {
+func extractToFile(file *zip.File, destination string) error {
 	fileReader, err := file.Open()
 	if err != nil {
 		return errors.Wrap(err, "opening zip file")
@@ -88,7 +88,7 @@ func extractFileFromZip(zipBytes []byte, targetFile, destination string) error {
 			continue
 		}
 		targetFound = true
-		if err = zipFileToFile(file, destination); err != nil {
+		if err = extractToFile(file, destination); err != nil {
 			return errors.Wrap(err, "extracting zip file")
 		}
 	}
@@ -101,7 +101,7 @@ func extractFileFromZip(zipBytes []byte, targetFile, destination string) error {
 }
 
 func downloadZip(ctx context.Context, downloadURL string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "making get request")
 	}

--- a/cmd/sign-executable/sign-executable.go
+++ b/cmd/sign-executable/sign-executable.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+const (
+	getClientSubcommand  = "get-client"
+	signSubcommand       = "sign"
+	notaryClientFilename = "macnotary"
+)
+
+func zipFile(inputFilePath, destinationPath string) error {
+	zipFile, err := os.Create(destinationPath)
+	if err != nil {
+		return errors.Wrap(err, "creating zip file")
+	}
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	defer zipWriter.Close()
+
+	inputFile, err := os.Open(inputFilePath)
+	if err != nil {
+		return errors.Wrapf(err, "opening input file '%s'", inputFilePath)
+	}
+	defer inputFile.Close()
+
+	fileInfo, err := inputFile.Stat()
+	if err != nil {
+		return errors.Wrap(err, "getting info for input file")
+	}
+
+	header, err := zip.FileInfoHeader(fileInfo)
+	if err != nil {
+		return errors.Wrap(err, "making header from file info")
+	}
+	header.Method = zip.Deflate
+
+	writer, err := zipWriter.CreateHeader(header)
+	if err != nil {
+		return errors.Wrap(err, "writing header to zip file")
+	}
+	_, err = io.Copy(writer, inputFile)
+	return errors.Wrap(err, "copying input file into zip file")
+}
+
+func zipFileToFile(file *zip.File, destination string) error {
+	fileReader, err := file.Open()
+	if err != nil {
+		return errors.Wrap(err, "opening zip file")
+	}
+	defer fileReader.Close()
+
+	contents, err := io.ReadAll(fileReader)
+	if err != nil {
+		return errors.Wrap(err, "reading zip file")
+	}
+
+	return errors.Wrap(os.WriteFile(destination, contents, file.Mode()), "writing zip contents to file")
+}
+
+func extractFileFromZip(zipBytes []byte, targetFile, destination string) error {
+	reader := bytes.NewReader(zipBytes)
+	zipReader, err := zip.NewReader(reader, reader.Size())
+	if err != nil {
+		return errors.Wrap(err, "getting zip reader")
+	}
+
+	targetFound := false
+	for _, file := range zipReader.File {
+		if path.Base(file.Name) != targetFile {
+			continue
+		}
+		if file.FileInfo().IsDir() {
+			continue
+		}
+		targetFound = true
+		if err = zipFileToFile(file, destination); err != nil {
+			return errors.Wrap(err, "extracting zip file")
+		}
+	}
+
+	if !targetFound {
+		return errors.Errorf("target file not in the archive")
+	}
+
+	return nil
+}
+
+func downloadZip(ctx context.Context, downloadURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "making get request")
+	}
+	req.Header.Add("Content-Type", "application/zip")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "making request")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("got '%d' status code", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading response body")
+	}
+
+	return body, nil
+}
+
+func signWithNotaryClient(ctx context.Context, zipToSignPath, destinationPath string, opts signOpts) error {
+	args := []string{
+		"--url",
+		opts.notaryServerURL,
+		"--file",
+		zipToSignPath,
+		"--mode",
+		"notarizeAndSign",
+		"--bundleId",
+		opts.bundleID,
+		"--out-path",
+		destinationPath,
+	}
+	if opts.notaryKey != "" {
+		args = append(args, "--key-id", opts.notaryKey)
+	}
+	if opts.notarySecret != "" {
+		args = append(args, "--secret", opts.notarySecret)
+	}
+
+	cmd := exec.CommandContext(ctx, opts.notaryClientPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return errors.Wrap(cmd.Run(), "running notary client")
+}
+
+func downloadClient(ctx context.Context, opts fetchClientOpts) error {
+	clientZipBytes, err := downloadZip(ctx, opts.notaryClientDownloadURL)
+	if err != nil {
+		return errors.Wrap(err, "downloading client")
+	}
+
+	if err = extractFileFromZip(clientZipBytes, notaryClientFilename, opts.destination); err != nil {
+		return errors.Wrap(err, "unzipping client")
+	}
+
+	return os.Chmod(opts.destination, 0755)
+}
+
+func signExecutable(ctx context.Context, opts signOpts) error {
+	tempDir, err := ioutil.TempDir("", "evergreen")
+	if err != nil {
+		return errors.Wrap(err, "creating temp dir")
+	}
+	defer os.RemoveAll(tempDir)
+
+	toSignPath := path.Join(tempDir, "evergreen.zip")
+	if err := zipFile(opts.executablePath, toSignPath); err != nil {
+		return errors.Wrapf(err, "compressing '%s'", opts.executablePath)
+	}
+
+	signedZipPath := path.Join(tempDir, "evergreen_signed.zip")
+	if err = signWithNotaryClient(ctx, toSignPath, signedZipPath, opts); err != nil {
+		return errors.Wrap(err, "signing with client")
+	}
+
+	signedZip, err := os.ReadFile(signedZipPath)
+	if err != nil {
+		return errors.Wrap(err, "reading signed zip")
+	}
+
+	return extractFileFromZip(signedZip, path.Base(opts.executablePath), opts.outputPath)
+}
+
+type signOpts struct {
+	notaryClientPath string
+	notaryServerURL  string
+	bundleID         string
+	executablePath   string
+	outputPath       string
+	notaryKey        string
+	notarySecret     string
+}
+
+type fetchClientOpts struct {
+	notaryClientDownloadURL string
+	destination             string
+}
+
+func main() {
+	var fetchOpts fetchClientOpts
+	var signOpts signOpts
+	ctx := context.Background()
+
+	app := &cli.App{
+		Commands: []cli.Command{
+			{
+				Name:  getClientSubcommand,
+				Usage: "fetch the notary client",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "destination",
+						Usage:       "`PATH` to save the client",
+						Destination: &fetchOpts.destination,
+						Value:       path.Join(".", notaryClientFilename),
+					},
+					&cli.StringFlag{
+						Name:        "download-url",
+						Usage:       "`URL` to GET the client from",
+						Destination: &fetchOpts.notaryClientDownloadURL,
+						Required:    true,
+					},
+				},
+				Action: func(c *cli.Context) error {
+					return downloadClient(ctx, fetchOpts)
+				},
+			},
+			{
+				Name:  signSubcommand,
+				Usage: "sign an executable",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "client",
+						Usage:       "`PATH` to the notary client",
+						Destination: &signOpts.notaryClientPath,
+						Required:    true,
+					},
+					&cli.StringFlag{
+						Name:        "server-url",
+						Usage:       "`PATH` to the notary server",
+						Destination: &signOpts.notaryServerURL,
+						Required:    true,
+					},
+					&cli.StringFlag{
+						Name:        "bundle-id",
+						Usage:       "`BUNDLE-ID` to sign with",
+						Destination: &signOpts.bundleID,
+						Required:    true,
+					},
+					&cli.StringFlag{
+						Name:        "executable",
+						Usage:       "`PATH` to the executable to sign",
+						Destination: &signOpts.executablePath,
+						Required:    true,
+					},
+					&cli.StringFlag{
+						Name:        "output",
+						Usage:       "`PATH` to output the signed executable. If omitted the input executable will be overwritten",
+						Destination: &signOpts.outputPath,
+					},
+					&cli.StringFlag{
+						Name:        "notary-key",
+						Usage:       "`KEY` to authenticate with the notary server. If omitted the notary client will check the value of MACOS_NOTARY_KEY in the environment",
+						Destination: &signOpts.notaryKey,
+					},
+					&cli.StringFlag{
+						Name:        "notary-secret",
+						Usage:       "`SECRET` to authenticate with the notary server. If omitted the notary client will check the value of MACOS_NOTARY_SECRET in the environment",
+						Destination: &signOpts.notarySecret,
+					},
+				},
+				Action: func(c *cli.Context) error {
+					if signOpts.outputPath == "" {
+						signOpts.outputPath = signOpts.executablePath
+					}
+					return signExecutable(ctx, signOpts)
+				},
+			},
+		},
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/makefile
+++ b/makefile
@@ -228,11 +228,9 @@ $(buildDir)/.npmSetup:
 
 # distribution targets and implementation
 $(buildDir)/build-cross-compile:cmd/build-cross-compile/build-cross-compile.go makefile
-	@GOOS="" GOARCH="" $(gobin) build -o $@ $<
-	@echo $(gobin) build -o $@ $<
+	$(gobin) build -o $@ $<
 $(buildDir)/make-tarball:cmd/make-tarball/make-tarball.go
 	$(gobin) build -o $@ $<
-	@echo $(gobin) build -o $@ $<
 
 $(buildDir)/sign-executable:cmd/sign-executable/sign-executable.go
 	$(gobin) build -o $@ $<

--- a/makefile
+++ b/makefile
@@ -185,12 +185,10 @@ coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).
 
 # lint setup targets
 $(buildDir)/.lintSetup:$(buildDir)/golangci-lint
-	@mkdir -p $(buildDir)
 	@touch $@
 $(buildDir)/golangci-lint:
 	@curl --retry 10 --retry-max-time 120 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1 && touch $@
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
-	@mkdir -p $(buildDir)
 	$(gobin) build -ldflags "-w" -o $@ $<
 # end lint setup targets
 
@@ -223,7 +221,6 @@ $(buildDir)/expansions.yml:$(buildDir)/parse-host-file
 
 # npm setup
 $(buildDir)/.npmSetup:
-	@mkdir -p $(buildDir)
 	cd $(nodeDir) && $(if $(NODE_BIN_PATH),export PATH=${PATH}:$(NODE_BIN_PATH) && ,)npm install
 	touch $@
 # end npm setup
@@ -231,17 +228,14 @@ $(buildDir)/.npmSetup:
 
 # distribution targets and implementation
 $(buildDir)/build-cross-compile:cmd/build-cross-compile/build-cross-compile.go makefile
-	@mkdir -p $(buildDir)
 	@GOOS="" GOARCH="" $(gobin) build -o $@ $<
 	@echo $(gobin) build -o $@ $<
 $(buildDir)/make-tarball:cmd/make-tarball/make-tarball.go
-	@mkdir -p $(buildDir)
-	@GOOS="" GOARCH="" $(gobin) build -o $@ $<
+	$(gobin) build -o $@ $<
 	@echo $(gobin) build -o $@ $<
 
 $(buildDir)/sign-executable:cmd/sign-executable/sign-executable.go
-	@mkdir -p $(buildDir)
-	@GOOS="" GOARCH="" $(gobin) build -o $@ $<
+	$(gobin) build -o $@ $<
 $(buildDir)/macnotary:$(buildDir)/sign-executable
 	./$< get-client --download-url $(NOTARY_CLIENT_URL) --destination $@
 $(clientBuildDir)/%/.signed:$(buildDir)/sign-executable $(clientBuildDir)/%/$(unixBinaryBasename) $(buildDir)/macnotary

--- a/makefile
+++ b/makefile
@@ -228,9 +228,9 @@ $(buildDir)/.npmSetup:
 
 # distribution targets and implementation
 $(buildDir)/build-cross-compile:cmd/build-cross-compile/build-cross-compile.go makefile
-	$(gobin) build -o $@ $<
+	GOOS="" GOARCH="" $(gobin) build -o $@ $<
 $(buildDir)/make-tarball:cmd/make-tarball/make-tarball.go
-	$(gobin) build -o $@ $<
+	GOOS="" GOARCH="" $(gobin) build -o $@ $<
 
 $(buildDir)/sign-executable:cmd/sign-executable/sign-executable.go
 	$(gobin) build -o $@ $<

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -47,7 +47,6 @@ variables:
       - func: run-make
         vars:
           target: "${task_name}"
-          sign_macos: true
       - command: s3.put
         type: system
         params:
@@ -594,6 +593,7 @@ buildvariants:
       RUN_EC2_SPECIFIC_TESTS: true
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.18.tgz
       notary_client_url: https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.1.2/linux_amd64.zip
+      sign_macos: true
     tasks:
       - name: "dist-and-upload-clis"
       - name: "dist-staging"

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -45,7 +45,9 @@ variables:
     commands:
       - func: get-project-and-modules
       - func: run-make
-        vars: { target: "${task_name}" }
+        vars:
+          target: "${task_name}"
+          sign_macos: true
       - command: s3.put
         type: system
         params:
@@ -205,6 +207,12 @@ functions:
         VENDOR_PKG: "github.com/${trigger_repo_owner}/${trigger_repo_name}"
         VENDOR_REVISION: ${trigger_revision}
         XC_BUILD: ${xc_build}
+        NOTARY_CLIENT_URL: ${notary_client_url}
+        NOTARY_SERVER_URL: ${notary_server_url}
+        MACOS_NOTARY_KEY: ${notary_server_key}
+        MACOS_NOTARY_SECRET: ${notary_server_secret}
+        EVERGREEN_BUNDLE_ID: ${evergreen_bundle_id}
+        SIGN_MACOS: ${sign_macos}
 
   setup-credentials:
     command: subprocess.exec
@@ -326,6 +334,8 @@ tasks:
     name: dist-staging
     patch_only: true
     run_on: archlinux-new-small
+  - <<: *run-build
+    name: dist
   - <<: *run-smoke-test
     name: smoke-test-task
     tags: ["smoke"]
@@ -338,8 +348,6 @@ tasks:
   - <<: *run-generate-lint
   - <<: *run-go-test-suite
     name: js-test
-  - <<: *run-build
-    name: dist
   - <<: *run-go-test-suite
     tags: ["nodb", "test"]
     name: test-thirdparty-docker
@@ -585,6 +593,7 @@ buildvariants:
       GOROOT: /opt/golang/go1.16
       RUN_EC2_SPECIFIC_TESTS: true
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.18.tgz
+      notary_client_url: https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.1.2/linux_amd64.zip
     tasks:
       - name: "dist-and-upload-clis"
       - name: "dist-staging"


### PR DESCRIPTION
[EVG-12802](https://jira.mongodb.org/browse/EVG-12802)

### Description 
Add a go script to call the notary client to sign the macOS clients. Developers at their desks can still run `make dist` without signing because the makefile only signs the executables when the `SIGN_MACOS` variable is set in the environment.
I really wanted to include the notary client as a go module in the signing script, but it lives in a private org and its owner wasn't comfortable moving it somewhere public. Instead the script downloads the appropriate release from s3 and cmd.Exec's it.

### Testing 
I added the variables to staging, built a dist, deployed it to staging, and downloaded the CLI. My laptop was able to run the CLI.
