### PR TITLE
EVG-1822 Update set-module command to not require patch id

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-03-01"
+	ClientVersion = "2022-03-11"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-03-08"

--- a/operations/http.go
+++ b/operations/http.go
@@ -256,27 +256,6 @@ func (ac *legacyClient) GetPatch(patchId string) (*patch.Patch, error) {
 	return &res, nil
 }
 
-// GetLatestPatchByUser gets the latest patch from the given user id and returns it as a Patch.
-func (ac *legacyClient) GetLatestPatchByUser(userId string) (*patch.Patch, error) {
-	resp, err := ac.get2(fmt.Sprintf("users/%v/patches?limit=1", userId), nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, client.AuthError
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, NewAPIError(resp)
-	}
-	patches := []patch.Patch{}
-	if err := utility.ReadJSON(resp.Body, &patches); err != nil {
-		return nil, err
-	}
-	return &patches[0], nil
-}
-
 // GetProjectRef requests project details from the API server for a given project ID.
 func (ac *legacyClient) GetProjectRef(projectId string) (*model.ProjectRef, error) {
 	resp, err := ac.get(fmt.Sprintf("/ref/%s", projectId), nil)

--- a/operations/http.go
+++ b/operations/http.go
@@ -256,6 +256,27 @@ func (ac *legacyClient) GetPatch(patchId string) (*patch.Patch, error) {
 	return &res, nil
 }
 
+// GetLatestPatchByUser gets the latest patch from the given user id and returns it as a Patch.
+func (ac *legacyClient) GetLatestPatchByUser(userId string) (*patch.Patch, error) {
+	resp, err := ac.get2(fmt.Sprintf("users/%v/patches?limit=1", userId), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, client.AuthError
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, NewAPIError(resp)
+	}
+	patches := []patch.Patch{}
+	if err := utility.ReadJSON(resp.Body, &patches); err != nil {
+		return nil, err
+	}
+	return &patches[0], nil
+}
+
 // GetProjectRef requests project details from the API server for a given project ID.
 func (ac *legacyClient) GetProjectRef(projectId string) (*model.ProjectRef, error) {
 	resp, err := ac.get(fmt.Sprintf("/ref/%s", projectId), nil)

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -64,8 +64,11 @@ func PatchSetModule() cli.Command {
 			var existingPatch *patch.Patch
 			if patchID == "" {
 				patchList, err := ac.GetPatches(1)
-				if err != nil || len(patchList) != 1 {
+				if err != nil {
 					return errors.Wrapf(err, "problem getting patches from user")
+				}
+				if len(patchList) == 0 {
+					return errors.New("no patches found from user")
 				}
 				existingPatch = &patchList[0]
 				patchID = existingPatch.Id.Hex()

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -19,11 +19,15 @@ func PatchSetModule() cli.Command {
 		Name:    "patch-set-module",
 		Aliases: []string{"set-module"},
 		Usage:   "update or add module to an existing patch",
-		Flags: mergeFlagSlices(addPatchIDFlag(), addModuleFlag(), addSkipConfirmFlag(), addRefFlag(), addUncommittedChangesFlag(),
+		Flags: mergeFlagSlices(addModuleFlag(), addSkipConfirmFlag(), addRefFlag(), addUncommittedChangesFlag(),
 			addPatchFinalizeFlag(), addPreserveCommitsFlag(
 				cli.BoolFlag{
 					Name:  largeFlagName,
 					Usage: "enable submitting larger patches (>16MB)",
+				},
+				cli.StringFlag{
+					Name:  joinFlagNames(patchIDFlagName, "id", "i"),
+					Usage: "specify the ID of a patch (defaults to user's latest submitted patch)",
 				})),
 		Before: mergeBeforeFuncs(
 			autoUpdateCLI,
@@ -60,7 +64,7 @@ func PatchSetModule() cli.Command {
 			var existingPatch *patch.Patch
 			if patchID == "" {
 				patchList, err := ac.GetPatches(1)
-				if err != nil {
+				if err != nil || len(patchList) != 1 {
 					return errors.Wrapf(err, "problem getting patches from user")
 				}
 				existingPatch = &patchList[0]

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -27,7 +28,6 @@ func PatchSetModule() cli.Command {
 		Before: mergeBeforeFuncs(
 			autoUpdateCLI,
 			setPlainLogger,
-			requirePatchIDFlag,
 			requireModuleFlag,
 			mutuallyExclusiveArgs(false, uncommittedChangesFlag, preserveCommitsFlag),
 		),
@@ -57,14 +57,23 @@ func PatchSetModule() cli.Command {
 				return errors.Wrap(err, "problem accessing evergreen service")
 			}
 
-			existingPatch, err := ac.GetPatch(patchID)
+			var existingPatch *patch.Patch
+			if patchID == "" {
+				patchList, err := ac.GetPatches(1)
+				if err != nil {
+					return errors.Wrapf(err, "problem getting patches from user")
+				}
+				existingPatch = &patchList[0]
+				patchID = existingPatch.Id.Hex()
+			} else {
+				existingPatch, err = ac.GetPatch(patchID)
+			}
 			if err != nil {
 				return errors.Wrapf(err, "problem getting patch '%s'", patchID)
 			}
 			if existingPatch.IsCommitQueuePatch() {
 				return errors.New("Use `commit-queue set-module` instead of `set-module` for commit queue patches")
 			}
-
 			preserveCommits = preserveCommits || conf.PreserveCommits
 			if !skipConfirm {
 				var keepGoing bool
@@ -76,12 +85,10 @@ func PatchSetModule() cli.Command {
 					return errors.New("patch aborted")
 				}
 			}
-
 			proj, err := rc.GetPatchedConfig(patchID)
 			if err != nil {
 				return err
 			}
-
 			moduleBranch, err := getModuleBranch(module, proj)
 			if err != nil {
 				grip.Error(err)


### PR DESCRIPTION
[EVG-1822](https://jira.mongodb.org/browse/EVG-1822)

### Description 
set-module now defaults to the user's latest patch when not given a patch id

### Testing 
added evergreen as module patch to spruce patch

![image](https://user-images.githubusercontent.com/26491602/157697214-46c354f7-a6a7-4cbf-b252-0ef053d7c873.png)
https://spruce.mongodb.com/version/6229a92261837d493fdce229/changes?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC