### PR TITLE
EVG-16397 remove regex selectors from filter

### DIFF
--- a/graphql/tests/saveSubscription/results.json
+++ b/graphql/tests/saveSubscription/results.json
@@ -82,7 +82,7 @@
       "result": {
         "errors": [
           {
-            "message": "error saving subscription: 400 (Bad Request): Error parsing request body: setting filter from selectors: selector has an empty type\nselector '' has no data",
+            "message": "error saving subscription: 400 (Bad Request): Error validating subscription: selector has an empty type\nselector '' has no data",
             "path": ["saveSubscription"],
             "extensions": { "code": "INTERNAL_SERVER_ERROR" }
           }

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -374,8 +374,8 @@ func IsSubscriptionAllowed(sub Subscription) (bool, string) {
 	return true, ""
 }
 
-func (s *Subscription) ValidateFilter() error {
-	if s.Filter == (Filter{}) {
+func (s *Subscription) ValidateSelectors() error {
+	if s.Filter == (Filter{}) && len(s.RegexSelectors) == 0 {
 		return errors.New("no filter parameters specified")
 	}
 
@@ -399,7 +399,7 @@ func (s *Subscription) Validate() error {
 		s.Subscriber.Type == JIRACommentSubscriberType {
 		catcher.New("JIRA comment subscription not allowed for all tasks in the project")
 	}
-	catcher.Add(s.ValidateFilter())
+	catcher.Add(s.ValidateSelectors())
 	catcher.Add(s.runCustomValidation())
 	catcher.Add(s.Subscriber.Validate())
 	return catcher.Resolve()

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -389,7 +389,7 @@ func (s *Subscription) ValidateSelectors() error {
 		}
 	}
 
-	return nil
+	return catcher.Resolve()
 }
 
 func (s *Subscription) Validate() error {

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -375,8 +375,18 @@ func IsSubscriptionAllowed(sub Subscription) (bool, string) {
 }
 
 func (s *Subscription) ValidateSelectors() error {
+	catcher := grip.NewBasicCatcher()
 	if s.Filter == (Filter{}) {
-		return errors.New("no filter parameters specified")
+		catcher.New("no filter parameters specified")
+	}
+
+	for _, selector := range s.RegexSelectors {
+		if selector.Type == "" {
+			catcher.New("selector has an empty type")
+		}
+		if selector.Data == "" {
+			catcher.Errorf("selector '%s' has no data", selector.Type)
+		}
 	}
 
 	return nil

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -375,7 +375,7 @@ func IsSubscriptionAllowed(sub Subscription) (bool, string) {
 }
 
 func (s *Subscription) ValidateSelectors() error {
-	if s.Filter == (Filter{}) && len(s.RegexSelectors) == 0 {
+	if s.Filter == (Filter{}) {
 		return errors.New("no filter parameters specified")
 	}
 

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -84,8 +84,7 @@ func (s *subscriptionsSuite) SetupTest() {
 				},
 			},
 			Filter: Filter{
-				ID:      "something",
-				Project: "else$",
+				ID: "something",
 			},
 			Subscriber: Subscriber{
 				Type:   EmailSubscriberType,
@@ -276,7 +275,7 @@ func (s *subscriptionsSuite) TestRegexSelectorsMatch() {
 func (s *subscriptionsSuite) TestFilterFromSelectors() {
 	for _, sub := range s.subscriptions {
 		filter := Filter{}
-		s.Require().NoError(filter.FromSelectors(append(sub.Selectors, sub.RegexSelectors...)))
+		s.Require().NoError(filter.FromSelectors(sub.Selectors))
 		s.Equal(sub.Filter, filter)
 	}
 
@@ -284,13 +283,13 @@ func (s *subscriptionsSuite) TestFilterFromSelectors() {
 	s.Error(filter.FromSelectors([]Selector{{Type: "non-existent-type"}}))
 }
 
-func (s *subscriptionsSuite) TestValidateFilter() {
+func (s *subscriptionsSuite) TestValidateSelectors() {
 	for _, sub := range s.subscriptions {
-		s.NoError(sub.ValidateFilter())
+		s.NoError(sub.ValidateSelectors())
 	}
 
 	noFilterParams := Subscription{}
-	s.Error(noFilterParams.ValidateFilter())
+	s.Error(noFilterParams.ValidateSelectors())
 }
 
 func (s *subscriptionsSuite) TestFromSelectors() {

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -121,7 +121,7 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 					Trigger:      "outcome",
 					Selectors: []event.Selector{
 						{
-							Type: "id",
+							Type: event.SelectorID,
 							Data: "1234",
 						},
 					},
@@ -138,7 +138,7 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 					Trigger:      "outcome",
 					Selectors: []event.Selector{
 						{
-							Type: "id",
+							Type: event.SelectorID,
 							Data: "1234",
 						},
 					},
@@ -153,9 +153,9 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 				Trigger:      utility.ToStringPtr("outcome"),
 				Owner:        utility.ToStringPtr("me"),
 				OwnerType:    utility.ToStringPtr(string(event.OwnerTypePerson)),
-				RegexSelectors: []restModel.APISelector{
+				Selectors: []restModel.APISelector{
 					{
-						Type: utility.ToStringPtr("object"),
+						Type: utility.ToStringPtr(event.SelectorObject),
 						Data: utility.ToStringPtr("object_data"),
 					},
 				},
@@ -169,9 +169,9 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 				Trigger:      utility.ToStringPtr("outcome"),
 				Owner:        utility.ToStringPtr("me"),
 				OwnerType:    utility.ToStringPtr(string(event.OwnerTypeProject)),
-				RegexSelectors: []restModel.APISelector{
+				Selectors: []restModel.APISelector{
 					{
-						Type: utility.ToStringPtr("object"),
+						Type: utility.ToStringPtr(event.SelectorObject),
 						Data: utility.ToStringPtr("object_data"),
 					},
 				},

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -90,7 +90,7 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 	c := &DBSubscriptionConnector{}
 	for name, test := range map[string]func(t *testing.T, subs []restModel.APISubscription){
 		"InvalidSubscription": func(t *testing.T, subs []restModel.APISubscription) {
-			subs[0].RegexSelectors[0].Data = utility.ToStringPtr("")
+			subs[0].Selectors[0].Data = utility.ToStringPtr("")
 			assert.Error(t, c.SaveSubscriptions("me", []restModel.APISubscription{subs[0]}, false))
 		},
 		"ValidSubscription": func(t *testing.T, subs []restModel.APISubscription) {

--- a/rest/model/subscriptions.go
+++ b/rest/model/subscriptions.go
@@ -111,6 +111,10 @@ func (s *APISubscription) ToService() (interface{}, error) {
 		}
 		out.Selectors = append(out.Selectors, newSelector)
 	}
+	if err = out.Filter.FromSelectors(out.Selectors); err != nil {
+		return nil, errors.Wrap(err, "setting filter from selectors")
+	}
+
 	for _, selector := range s.RegexSelectors {
 		selectorInterface, err := selector.ToService()
 		if err != nil {
@@ -121,10 +125,6 @@ func (s *APISubscription) ToService() (interface{}, error) {
 			return nil, errors.New("unable to convert selector")
 		}
 		out.RegexSelectors = append(out.RegexSelectors, newSelector)
-	}
-
-	if err = out.Filter.FromSelectors(append(out.Selectors, out.RegexSelectors...)); err != nil {
-		return nil, errors.Wrap(err, "setting filter from selectors")
 	}
 
 	return out, nil

--- a/rest/model/subscriptions_test.go
+++ b/rest/model/subscriptions_test.go
@@ -38,9 +38,7 @@ func TestSubscriptionModels(t *testing.T) {
 			},
 		},
 		Filter: event.Filter{
-			ID:      id,
-			Owner:   owner,
-			Project: project,
+			ID: id,
 		},
 		Subscriber: event.Subscriber{
 			Type:   event.EmailSubscriberType,

--- a/rest/route/subscription_test.go
+++ b/rest/route/subscription_test.go
@@ -472,6 +472,10 @@ func (s *SubscriptionRouteSuite) TestInvalidRegexSelectors() {
 		"trigger":       "outcome",
 		"owner":         "me",
 		"owner_type":    "person",
+		"selectors": []map[string]string{{
+			"type": event.SelectorID,
+			"data": "abc123",
+		}},
 		"regex_selectors": []map[string]string{{
 			"type": event.SelectorObject,
 			"data": "",

--- a/service/project.go
+++ b/service/project.go
@@ -669,18 +669,18 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		subscription := subscriptionIface.(event.Subscription)
 		subscription.Selectors = []event.Selector{
 			{
-				Type: "project",
+				Type: event.SelectorProject,
 				Data: projectRef.Id,
 			},
 		}
 		if subscription.TriggerData != nil && subscription.TriggerData[event.SelectorRequester] != "" {
 			subscription.Selectors = append(subscription.Selectors, event.Selector{
-				Type: "requester",
+				Type: event.SelectorRequester,
 				Data: subscription.TriggerData[event.SelectorRequester],
 			})
 		} else {
 			subscription.Selectors = append(subscription.Selectors, event.Selector{
-				Type: "requester",
+				Type: event.SelectorRequester,
 				Data: evergreen.RepotrackerVersionRequester,
 			})
 		}


### PR DESCRIPTION
[EVG-16397](https://jira.mongodb.org/browse/EVG-16397)

### Description 
It was overly ambitious to think the regex selector matching could be pushed to the db. I got confused by the direction: we aren't matching a regex to a string in the document. Rather, we're matching a string to a regex in the document.
It's possible we can do something down the line with [$regexFind](https://docs.mongodb.com/manual/reference/operator/aggregation/regexFind/) but it's a 4.2 feature.

My plan is to 
1. deploy this
2. run `db.subscriptions.updateMany({}, {$unset: {filter:""}}` (maybe starting with a few to make sure I'm not dropping the db) to clear all the filter fields
3. rerun the migration script with the lines to set the regex field removed

### Testing 
  None.
