### PR TITLE
EVG-15555 Add aborted field to version

### DIFF
--- a/model/build/build.go
+++ b/model/build/build.go
@@ -47,6 +47,7 @@ type Build struct {
 	DisplayName         string        `bson:"display_name" json:"display_name,omitempty"`
 	PredictedMakespan   time.Duration `bson:"predicted_makespan" json:"predicted_makespan,omitempty"`
 	ActualMakespan      time.Duration `bson:"actual_makespan" json:"actual_makespan,omitempty"`
+	Aborted             bool          `bson:"aborted" json:"aborted,omitempty"`
 
 	// The status of the subset of the build that's used for github checks
 	GithubCheckStatus string `bson:"github_check_status,omitempty" json:"github_check_status,omitempty"`

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -919,6 +919,13 @@ func UpdateBuildStatus(b *build.Build) (bool, error) {
 		return false, errors.Wrapf(err, "getting tasks in build '%s'", b.Id)
 	}
 
+	b.Aborted = false
+	for _, t := range buildTasks {
+		if t.Aborted {
+			b.Aborted = true
+			break
+		}
+	}
 	buildStatus := getBuildStatus(buildTasks)
 
 	if buildStatus == b.Status {
@@ -1003,6 +1010,13 @@ func UpdateVersionStatus(v *Version) (string, error) {
 	builds, err := build.Find(build.ByVersion(v.Id).WithFields(build.ActivatedKey, build.StatusKey, build.IsGithubCheckKey))
 	if err != nil {
 		return "", errors.Wrapf(err, "getting builds for version '%s'", v.Id)
+	}
+
+	for _, b := range builds {
+		if b.Aborted {
+			v.Aborted = true
+			break
+		}
 	}
 	versionStatus := getVersionStatus(builds)
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -780,6 +780,76 @@ func TestUpdateBuildStatusForTaskReset(t *testing.T) {
 	assert.Equal(t, evergreen.VersionStarted, data.Status)
 }
 
+func TestUpdateBuildAndVersionStatusForTaskAbort(t *testing.T) {
+	require.NoError(t, db.ClearCollections(task.Collection, build.Collection, VersionCollection, event.AllLogCollection),
+		"Error clearing task and build collections")
+	displayName := "testName"
+	b1 := &build.Build{
+		Id:        "buildtest1",
+		Status:    evergreen.BuildFailed,
+		Version:   "abc",
+		Activated: true,
+	}
+	b2 := &build.Build{
+		Id:        "buildtest2",
+		Status:    evergreen.BuildSucceeded,
+		Version:   "abc",
+		Activated: true,
+	}
+	v := &Version{
+		Id:     b1.Version,
+		Status: evergreen.VersionFailed,
+	}
+	testTask := task.Task{
+		Id:          "testone",
+		DisplayName: displayName,
+		Activated:   true,
+		BuildId:     b1.Id,
+		Project:     "sample",
+		Status:      evergreen.TaskStarted,
+		Version:     b1.Version,
+	}
+	anotherTask := task.Task{
+		Id:          "two",
+		DisplayName: displayName,
+		Activated:   true,
+		BuildId:     b2.Id,
+		Project:     "sample",
+		Status:      evergreen.TaskFailed,
+		StartTime:   time.Now().Add(-time.Hour),
+		Version:     b2.Version,
+	}
+
+	assert.NoError(t, b1.Insert())
+	assert.NoError(t, b2.Insert())
+	assert.NoError(t, v.Insert())
+	assert.NoError(t, testTask.Insert())
+	assert.NoError(t, anotherTask.Insert())
+
+	assert.NoError(t, UpdateBuildAndVersionStatusForTask(&testTask))
+	dbBuild1, err := build.FindOneId(b1.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, false, dbBuild1.Aborted)
+	dbBuild2, err := build.FindOneId(b2.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, false, dbBuild2.Aborted)
+	dbVersion, err := VersionFindOneId(v.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, false, dbVersion.Aborted)
+
+	assert.NoError(t, testTask.SetAborted(task.AbortInfo{}))
+	assert.NoError(t, UpdateBuildAndVersionStatusForTask(&testTask))
+	dbBuild1, err = build.FindOneId(b1.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, true, dbBuild1.Aborted)
+	dbBuild2, err = build.FindOneId(b2.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, false, dbBuild2.Aborted)
+	dbVersion, err = VersionFindOneId(v.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, true, dbVersion.Aborted)
+}
+
 func TestGetBuildStatus(t *testing.T) {
 	// the build isn't started until a task starts running
 	buildTasks := []task.Task{

--- a/model/version.go
+++ b/model/version.go
@@ -37,6 +37,7 @@ type Version struct {
 	Branch              string               `bson:"branch_name" json:"branch_name,omitempty"`
 	BuildVariants       []VersionBuildStatus `bson:"build_variants_status,omitempty" json:"build_variants_status,omitempty"`
 	PeriodicBuildID     string               `bson:"periodic_build_id,omitempty" json:"periodic_build_id,omitempty"`
+	Aborted             bool                 `bson:"aborted,omitempty" json:"aborted,omitempty"`
 
 	// This stores whether or not a version has tasks which were activated.
 	// We use a bool ptr in order to to distinguish the unset value from the default value


### PR DESCRIPTION
[EVG-15555](https://jira.mongodb.org/browse/EVG-15555)

### Description 
updatebuildstatus loops through tasks and update versionstatus looks through those builds and checks for any aborted tasks

### Testing 
unit test