### PR TITLE
EVG-16070: Fix task count

### DIFF
--- a/graphql/tests/patch/data.json
+++ b/graphql/tests/patch/data.json
@@ -17,23 +17,28 @@
   "tasks": [
     {
       "_id": "1",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "activated": true
     },
     {
       "_id": "2",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "activated": true
     },
     {
       "_id": "3",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "activated": true
     },
     {
       "_id": "4",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "activated": true
     },
     {
       "_id": "5",
-      "version": "5e4ff3abe3c3317e352062e4"
+      "version": "5e4ff3abe3c3317e352062e4",
+      "activated": true
     },
     {
       "_id": "6",

--- a/graphql/tests/patch/results.json
+++ b/graphql/tests/patch/results.json
@@ -28,7 +28,7 @@
         "data": {
           "patch": {
             "id": "5e4ff3abe3c3317e352062e4",
-            "taskCount": 6
+            "taskCount": 5
           }
         }
       }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -379,7 +379,10 @@ func DisplayTasksByVersion(version string) bson.M {
 	// assumes that all ExecutionTasks know of their corresponding DisplayTask (i.e. DisplayTaskIdKey not null or "")
 	return bson.M{
 		"$and": []bson.M{
-			{VersionKey: version},
+			{
+				VersionKey:   version,
+				ActivatedKey: true,
+			},
 			{"$or": []bson.M{
 				{DisplayTaskIdKey: ""},                       // no 'parent' display task
 				{DisplayOnlyKey: true},                       // ...

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -635,23 +635,31 @@ func TestDisplayTasksByVersion(t *testing.T) {
 		Convey("only tasks that are display tasks should be returned", func() {
 			tasks := []Task{
 				{
-					Id:      "one",
-					Version: "v1",
+					Id:        "one",
+					Version:   "v1",
+					Activated: true,
 				},
 				{
 					Id:          "two",
 					Version:     "v1",
 					DisplayOnly: true,
+					Activated:   true,
 				},
 				{
 					Id:            "three",
 					Version:       "v1",
 					DisplayTaskId: utility.ToStringPtr(""),
+					Activated:     true,
 				},
 				{
 					Id:             "four",
 					Version:        "v1",
 					ExecutionTasks: []string{"execution_task_one, execution_task_two"},
+					Activated:      true,
+				},
+				{
+					Id:      "five",
+					Version: "v1",
 				},
 				{
 					Id:            "execution_task_one",
@@ -681,6 +689,11 @@ func TestDisplayTasksByVersion(t *testing.T) {
 			So(dbTasks[1].Id, ShouldNotEqual, "execution_task_two")
 			So(dbTasks[2].Id, ShouldNotEqual, "execution_task_two")
 			So(dbTasks[3].Id, ShouldNotEqual, "execution_task_two")
+
+			So(dbTasks[0].Id, ShouldNotEqual, "five")
+			So(dbTasks[1].Id, ShouldNotEqual, "five")
+			So(dbTasks[2].Id, ShouldNotEqual, "five")
+			So(dbTasks[3].Id, ShouldNotEqual, "five")
 
 		})
 	})


### PR DESCRIPTION
[EVG-16070](https://jira.mongodb.org/browse/EVG-16070)

### Description 
- Only return activated tasks for a patch's total task count; this mimics the query used to calculate the numerator task count [here](https://github.com/evergreen-ci/evergreen/blob/825c4a9103cfd1fb1fa1cf7465185c66f3cdc187/model/task/task.go#L3347-L3350)

### Testing 
- Tested manually in staging: [this patch](https://spruce-staging.corp.mongodb.com/version/622babb2b23736672ef563e7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) has one generated task that I marked as "activated: false"
  - With changes, the page shows 55/55 (correct)
  - Without changes it shows 55/56 (i.e. incorrectly calculates the count for displayed tasks)
- Update unit tests that use query
