### PR TITLE
EVG-15085: Correctly save github trigger aliases

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1661,7 +1661,6 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 					projectRefPRTestingEnabledKey:       p.PRTestingEnabled,
 					projectRefManualPRTestingEnabledKey: p.ManualPRTestingEnabled,
 					projectRefGithubChecksEnabledKey:    p.GithubChecksEnabled,
-					projectRefGithubTriggerAliasesKey:   p.PatchTriggerAliases,
 					projectRefGitTagVersionsEnabledKey:  p.GitTagVersionsEnabled,
 					ProjectRefGitTagAuthorizedUsersKey:  p.GitTagAuthorizedUsers,
 					ProjectRefGitTagAuthorizedTeamsKey:  p.GitTagAuthorizedTeams,
@@ -1694,7 +1693,8 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 			bson.M{ProjectRefIdKey: projectId},
 			bson.M{
 				"$set": bson.M{
-					projectRefPatchTriggerAliasesKey: p.PatchTriggerAliases,
+					projectRefPatchTriggerAliasesKey:  p.PatchTriggerAliases,
+					projectRefGithubTriggerAliasesKey: p.GithubTriggerAliases,
 				},
 			})
 	case ProjectPagePeriodicBuildsSection:


### PR DESCRIPTION
Relates to UI ticket [EVG-15085](https://jira.mongodb.org/browse/EVG-15085)

### Description 
- GitHub trigger aliases are configured on the patch alias page—the GitHub/Commit Queue page just presents them in a read-only version. This field should be updated with the patch alias page.

### Testing 
- Tested locally
