### PR TITLE
EVG-16166: implement container task queue

### DIFF
--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -74,7 +74,7 @@ func (q *ContainerTaskQueue) filterByProjectRefSettings(tasks []task.Task) ([]ta
 			// GitHub PR tasks are still allowed to run for disabled hidden
 			// projects.
 			if t.Requester == evergreen.GithubPRRequester && ref.IsHidden() {
-				grip.Info(message.Fields{
+				grip.Debug(message.Fields{
 					"message": "queueing task because GitHub PRs are allowed to run tasks for projects that are both hidden and disabled",
 					"outcome": "not skipping",
 					"task":    t.Id,
@@ -82,9 +82,9 @@ func (q *ContainerTaskQueue) filterByProjectRefSettings(tasks []task.Task) ([]ta
 					"context": "container task queue",
 				})
 			} else {
-				grip.Info(message.Fields{
+				grip.Debug(message.Fields{
 					"message": "skipping task because project is disabled",
-					"outcome": "not skipping",
+					"outcome": "skipping",
 					"task":    t.Id,
 					"project": t.Project,
 					"context": "container task queue",
@@ -94,7 +94,7 @@ func (q *ContainerTaskQueue) filterByProjectRefSettings(tasks []task.Task) ([]ta
 		}
 
 		if ref.IsDispatchingDisabled() {
-			grip.Info(message.Fields{
+			grip.Debug(message.Fields{
 				"message": "skipping task because dispatching is disabled for its project",
 				"outcome": "skipping",
 				"task":    t.Id,
@@ -105,7 +105,7 @@ func (q *ContainerTaskQueue) filterByProjectRefSettings(tasks []task.Task) ([]ta
 		}
 
 		if t.IsPatchRequest() && ref.IsPatchingDisabled() {
-			grip.Info(message.Fields{
+			grip.Debug(message.Fields{
 				"message": "skipping task because patch testing is disabled for its project",
 				"outcome": "skipping",
 				"task":    t.Id,

--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -1,0 +1,150 @@
+package model
+
+import (
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+)
+
+// ContainerTaskQueue represents an iterator that represents an ordered queue of
+// container tasks that are ready be allocated a container.
+type ContainerTaskQueue struct {
+	queue    []task.Task
+	position int
+}
+
+// Next returns the next task that's ready for container allocation. It will
+// return a nil task once there are no tasks remaining in the queue.
+func (q *ContainerTaskQueue) Next() (*task.Task, error) {
+	if q.queue == nil {
+		if err := q.populate(); err != nil {
+			return nil, errors.Wrap(err, "initial population of container task queue")
+		}
+	}
+	if q.position >= len(q.queue) {
+		return nil, nil
+	}
+
+	next := q.queue[q.position]
+
+	q.position++
+
+	return &next, nil
+}
+
+func (q *ContainerTaskQueue) populate() error {
+	candidates, err := task.FindNeedsContainerAllocation()
+	if err != nil {
+		return errors.Wrap(err, "finding candidate container tasks for allocation")
+	}
+
+	readyForAllocation, err := q.filterByProjectRefSettings(candidates)
+	if err != nil {
+		return errors.Wrap(err, "filtering candidate container tasks for allocation by project ref settings")
+	}
+
+	q.queue = readyForAllocation
+
+	return nil
+}
+
+func (q *ContainerTaskQueue) filterByProjectRefSettings(tasks []task.Task) ([]task.Task, error) {
+	projRefs, err := q.getProjectRefs(tasks)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting project refs")
+	}
+
+	var readyForAllocation []task.Task
+	for _, t := range tasks {
+		ref, ok := projRefs[t.Project]
+		if !ok {
+			grip.Warning(message.Fields{
+				"message": "skipping task that is a candidate for allocation because did not find the project associated with it",
+				"outcome": "skipping",
+				"task":    t.Id,
+				"project": t.Project,
+				"context": "container task queue",
+			})
+			continue
+		}
+
+		if !ref.IsEnabled() {
+			// GitHub PR tasks are still allowed to run for disabled hidden
+			// projects.
+			if t.Requester == evergreen.GithubPRRequester && ref.IsHidden() {
+				grip.Info(message.Fields{
+					"message": "queueing task because GitHub PRs are allowed to run tasks for projects that are both hidden and disabled",
+					"outcome": "not skipping",
+					"task":    t.Id,
+					"project": t.Project,
+					"context": "container task queue",
+				})
+			} else {
+				grip.Info(message.Fields{
+					"message": "skipping task because project is disabled",
+					"outcome": "not skipping",
+					"task":    t.Id,
+					"project": t.Project,
+					"context": "container task queue",
+				})
+				continue
+			}
+		}
+
+		if ref.IsDispatchingDisabled() {
+			grip.Info(message.Fields{
+				"message": "skipping task because dispatching is disabled for its project",
+				"outcome": "skipping",
+				"task":    t.Id,
+				"project": t.Project,
+				"context": "container task queue",
+			})
+			continue
+		}
+
+		if t.IsPatchRequest() && ref.IsPatchingDisabled() {
+			grip.Info(message.Fields{
+				"message": "skipping task because patch testing is disabled for its project",
+				"outcome": "skipping",
+				"task":    t.Id,
+				"project": t.Project,
+				"context": "container task queue",
+			})
+			continue
+		}
+
+		readyForAllocation = append(readyForAllocation, t)
+	}
+
+	return readyForAllocation, nil
+}
+
+func (q *ContainerTaskQueue) getProjectRefs(tasks []task.Task) (map[string]ProjectRef, error) {
+	seenProjRefIDs := map[string]struct{}{}
+	var projRefIDs []string
+	for _, t := range tasks {
+		if _, ok := seenProjRefIDs[t.Project]; ok {
+			continue
+		}
+		projRefIDs = append(projRefIDs, t.Project)
+		seenProjRefIDs[t.Project] = struct{}{}
+	}
+
+	if len(projRefIDs) == 0 {
+		return map[string]ProjectRef{}, nil
+	}
+
+	projRefs, err := FindProjectRefsByIds(projRefIDs)
+	if err != nil {
+		return nil, errors.Wrap(err, "finding project refs for tasks")
+	}
+
+	projRefsByID := map[string]ProjectRef{}
+	for _, ref := range projRefs {
+		projRefsByID[ref.Id] = ref
+	}
+
+	return projRefsByID, nil
+}

--- a/model/container_task_queue_test.go
+++ b/model/container_task_queue_test.go
@@ -1,0 +1,192 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerTaskQueueNext(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(task.Collection, ProjectRefCollection))
+	}()
+	getTaskThatNeedsContainerAllocation := func() task.Task {
+		return task.Task{
+			Id:                utility.RandomString(),
+			Activated:         true,
+			ActivatedTime:     time.Now(),
+			Status:            evergreen.TaskContainerUnallocated,
+			ExecutionPlatform: task.ExecutionPlatformContainer,
+		}
+	}
+	getProjectRef := func() ProjectRef {
+		return ProjectRef{
+			Id:         utility.RandomString(),
+			Identifier: utility.RandomString(),
+			Enabled:    utility.TruePtr(),
+		}
+	}
+	for tName, tCase := range map[string]func(t *testing.T){
+		"ReturnsAllTasksThatNeedContainerAllocationInOrderOfActivation": func(t *testing.T) {
+			ref := getProjectRef()
+			require.NoError(t, ref.Insert())
+
+			needsAllocation0 := getTaskThatNeedsContainerAllocation()
+			needsAllocation0.Project = ref.Id
+			require.NoError(t, needsAllocation0.Insert())
+
+			doesNotNeedAllocation := getTaskThatNeedsContainerAllocation()
+			doesNotNeedAllocation.Status = evergreen.TaskContainerAllocated
+			require.NoError(t, doesNotNeedAllocation.Insert())
+
+			needsAllocation1 := getTaskThatNeedsContainerAllocation()
+			needsAllocation1.Project = ref.Id
+			needsAllocation1.ActivatedTime = time.Now().Add(-time.Hour)
+			require.NoError(t, needsAllocation1.Insert())
+
+			var ctq ContainerTaskQueue
+
+			first, err := ctq.Next()
+			require.NoError(t, err)
+			require.NotZero(t, first)
+			assert.Equal(t, needsAllocation1.Id, first.Id, "should return task in need of allocation with earlier activation time")
+
+			second, err := ctq.Next()
+			require.NoError(t, err)
+			require.NotZero(t, first)
+			assert.Equal(t, needsAllocation0.Id, second.Id, "should return task in need of alloation with later activation time")
+
+			third, err := ctq.Next()
+			require.NoError(t, err)
+			assert.Zero(t, third)
+		},
+		"ReturnsNoTask": func(t *testing.T) {
+			var ctq ContainerTaskQueue
+			tsk, err := ctq.Next()
+			require.NoError(t, err)
+			assert.Zero(t, tsk)
+		},
+		"DoesNotReturnTaskMissingProject": func(t *testing.T) {
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			require.NoError(t, needsAllocation.Insert())
+
+			var ctq ContainerTaskQueue
+			tsk, err := ctq.Next()
+			require.NoError(t, err)
+			assert.Zero(t, tsk)
+		},
+		"DoesNotReturnTaskWithInvalidProject": func(t *testing.T) {
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			needsAllocation.Project = "foo"
+			require.NoError(t, needsAllocation.Insert())
+
+			var ctq ContainerTaskQueue
+			tsk, err := ctq.Next()
+			require.NoError(t, err)
+			assert.Zero(t, tsk)
+		},
+		"DoesNotReturnTaskWithProjectThatDisabledTaskDispatching": func(t *testing.T) {
+			ref := getProjectRef()
+			ref.DispatchingDisabled = utility.TruePtr()
+			require.NoError(t, ref.Insert())
+
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			needsAllocation.Project = ref.Id
+			require.NoError(t, needsAllocation.Insert())
+
+			var ctq ContainerTaskQueue
+			tsk, err := ctq.Next()
+			require.NoError(t, err)
+			assert.Zero(t, tsk)
+		},
+		"ReturnsPatchTaskWithProjectThatEnabledPatching": func(t *testing.T) {
+			ref := getProjectRef()
+			ref.PatchingDisabled = utility.FalsePtr()
+			require.NoError(t, ref.Insert())
+
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			needsAllocation.Requester = evergreen.PatchVersionRequester
+			needsAllocation.Project = ref.Id
+			require.NoError(t, needsAllocation.Insert())
+
+			var ctq ContainerTaskQueue
+			tsk, err := ctq.Next()
+			require.NoError(t, err)
+			require.NotZero(t, tsk)
+			assert.Equal(t, needsAllocation.Id, tsk.Id)
+		},
+		"DoesNotReturnPatchTaskWithProjectThatDisabledPatching": func(t *testing.T) {
+			ref := getProjectRef()
+			ref.PatchingDisabled = utility.TruePtr()
+			require.NoError(t, ref.Insert())
+
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			needsAllocation.Requester = evergreen.PatchVersionRequester
+			needsAllocation.Project = ref.Id
+			require.NoError(t, needsAllocation.Insert())
+
+			var ctq ContainerTaskQueue
+			tsk, err := ctq.Next()
+			require.NoError(t, err)
+			assert.Zero(t, tsk)
+		},
+		"DoesNotReturnTaskWithDisabledProject": func(t *testing.T) {
+			ref := getProjectRef()
+			ref.Enabled = utility.FalsePtr()
+			require.NoError(t, ref.Insert())
+
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			needsAllocation.Project = ref.Id
+			require.NoError(t, needsAllocation.Insert())
+
+			var ctq ContainerTaskQueue
+			tsk, err := ctq.Next()
+			require.NoError(t, err)
+			assert.Zero(t, tsk)
+		},
+		"ReturnsGitHubTaskInDisabledAndHiddenProject": func(t *testing.T) {
+			ref := getProjectRef()
+			ref.Enabled = utility.FalsePtr()
+			ref.Hidden = utility.TruePtr()
+			require.NoError(t, ref.Insert())
+
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			needsAllocation.Requester = evergreen.GithubPRRequester
+			needsAllocation.Project = ref.Id
+			require.NoError(t, needsAllocation.Insert())
+
+			var ctq ContainerTaskQueue
+			tsk, err := ctq.Next()
+			require.NoError(t, err)
+			require.NotZero(t, tsk)
+			assert.Equal(t, needsAllocation.Id, tsk.Id)
+		},
+		"DoesNotReturnNonGitHubTaskInDisabledAndHiddenProject": func(t *testing.T) {
+			ref := getProjectRef()
+			ref.Enabled = utility.FalsePtr()
+			ref.Hidden = utility.TruePtr()
+			require.NoError(t, ref.Insert())
+
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			needsAllocation.Requester = evergreen.PatchVersionRequester
+			needsAllocation.Project = ref.Id
+			require.NoError(t, needsAllocation.Insert())
+
+			var ctq ContainerTaskQueue
+			tsk, err := ctq.Next()
+			require.NoError(t, err)
+			assert.Zero(t, tsk)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(task.Collection, ProjectRefCollection))
+			tCase(t)
+		})
+	}
+}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -766,6 +766,32 @@ func schedulableHostTasksQuery() bson.M {
 	return q
 }
 
+// FindNeedsContainerAllocation returns all container tasks that are waiting for
+// a container to be allocated to them sorted by activation time.
+func FindNeedsContainerAllocation() ([]Task, error) {
+	q := bson.M{
+		ActivatedKey:         true,
+		StatusKey:            evergreen.TaskContainerUnallocated,
+		ExecutionPlatformKey: ExecutionPlatformContainer,
+		PriorityKey:          bson.M{"$gt": evergreen.DisabledTaskPriority},
+		"$or": []bson.M{
+			{
+				DependsOnKey: bson.M{"$size": 0},
+			},
+			{
+				// Containers can only be allocated for tasks whose dependencies
+				// are all met. All dependencies are met if they're all finished
+				// running and are still attainable (i.e. the dependency's
+				// required status matched the task's actual ending status).
+				bsonutil.GetDottedKeyName(DependsOnKey, DependencyFinishedKey):     true,
+				bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey): bson.M{"$ne": true},
+			},
+			{OverrideDependenciesKey: true},
+		},
+	}
+	return FindAll(db.Query(q).Sort([]string{ActivatedTimeKey}))
+}
+
 // TasksByProjectAndCommitPipeline fetches the pipeline to get the retrieve all tasks
 // associated with a given project and commit hash.
 func TasksByProjectAndCommitPipeline(projectId, commitHash, taskId, taskStatus string, limit int) []bson.M {

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -378,7 +378,7 @@ func (j *hostTerminationJob) checkAndTerminateCloudHost(ctx context.Context, old
 
 	if cloudStatus == cloud.StatusTerminated {
 		grip.Warning(message.Fields{
-			"message":  "attempted to terminated an already terminated host",
+			"message":  "attempted to terminate an already terminated host",
 			"theory":   "external termination",
 			"host_id":  j.host.Id,
 			"provider": j.host.Distro.Provider,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16166

### Description 
* Add queue wrapper to get the next container task to be allocated a container.
    * Add query to get tasks that need allocation.
    * Check project ref to ensure the task is allowed to run. I mostly duplicated [the host scheduler's existing checks](https://github.com/evergreen-ci/evergreen/blob/1adeffd04b411b798ec9cb29c8c8b2b68cf8df0b/scheduler/task_finder.go#L68-L147).

### Testing 
Added unit tests.
