### PR TITLE
EVG-16397 set filter where it's not set

### DIFF
--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -712,6 +712,7 @@ func NewExpiringBuildOutcomeSubscriptionByVersion(versionID string, sub Subscrib
 				Data: versionID,
 			},
 		},
+		Filter:      Filter{InVersion: versionID},
 		Subscriber:  sub,
 		LastUpdated: time.Now(),
 	}
@@ -727,6 +728,7 @@ func NewGithubCheckBuildOutcomeSubscriptionByVersion(versionID string, sub Subsc
 				Data: versionID,
 			},
 		},
+		Filter:      Filter{InVersion: versionID},
 		Subscriber:  sub,
 		LastUpdated: time.Now(),
 	}
@@ -745,6 +747,10 @@ func NewSpawnHostOutcomeByOwner(owner string, sub Subscriber) Subscription {
 				Type: SelectorOwner,
 				Data: owner,
 			},
+		},
+		Filter: Filter{
+			Object: ObjectHost,
+			Owner:  owner,
 		},
 		Subscriber: sub,
 	}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -538,21 +538,27 @@ func AddBuildBreakSubscriptions(v *model.Version, projectRef *model.ProjectRef) 
 		LastUpdated:  time.Now(),
 		Selectors: []event.Selector{
 			{
-				Type: "object",
-				Data: "task",
+				Type: event.SelectorObject,
+				Data: event.ObjectTask,
 			},
 			{
-				Type: "project",
+				Type: event.SelectorProject,
 				Data: projectRef.Id,
 			},
 			{
-				Type: "requester",
+				Type: event.SelectorRequester,
 				Data: evergreen.RepotrackerVersionRequester,
 			},
 			{
-				Type: "in-version",
+				Type: event.SelectorInVersion,
 				Data: v.Id,
 			},
+		},
+		Filter: event.Filter{
+			Object:    event.ObjectTask,
+			Project:   projectRef.Id,
+			Requester: evergreen.RepotrackerVersionRequester,
+			InVersion: v.Id,
 		},
 	}
 	subscribers := []event.Subscriber{}

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -78,7 +78,7 @@ func (dc *DBSubscriptionConnector) SaveSubscriptions(owner string, subscriptions
 			//find all children, iterate through them
 			var versionId string
 			for _, selector := range dbSubscription.Selectors {
-				if selector.Type == "id" {
+				if selector.Type == event.SelectorID {
 					versionId = selector.Data
 				}
 			}
@@ -93,9 +93,10 @@ func (dc *DBSubscriptionConnector) SaveSubscriptions(owner string, subscriptions
 			for _, childPatchId := range children {
 				childDbSubscription := dbSubscription
 				childDbSubscription.LastUpdated = time.Now()
+				childDbSubscription.Filter.ID = childPatchId
 				var selectors []event.Selector
 				for _, selector := range dbSubscription.Selectors {
-					if selector.Type == "id" {
+					if selector.Type == event.SelectorID {
 						selector.Data = childPatchId
 					}
 					selectors = append(selectors, selector)

--- a/service/project.go
+++ b/service/project.go
@@ -679,17 +679,22 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				Data: projectRef.Id,
 			},
 		}
+		subscription.Filter.Project = projectRef.Id
+
 		if subscription.TriggerData != nil && subscription.TriggerData[event.SelectorRequester] != "" {
 			subscription.Selectors = append(subscription.Selectors, event.Selector{
 				Type: event.SelectorRequester,
 				Data: subscription.TriggerData[event.SelectorRequester],
 			})
+			subscription.Filter.Requester = subscription.TriggerData[event.SelectorRequester]
 		} else {
 			subscription.Selectors = append(subscription.Selectors, event.Selector{
 				Type: event.SelectorRequester,
 				Data: evergreen.RepotrackerVersionRequester,
 			})
+			subscription.Filter.Requester = evergreen.RepotrackerVersionRequester
 		}
+
 		subscription.OwnerType = event.OwnerTypeProject
 		if subscription.Owner != projectRef.Id {
 			subscription.Owner = projectRef.Id


### PR DESCRIPTION
[EVG-16397](https://jira.mongodb.org/browse/EVG-16397)

### Description 
I didn't do due diligence in #5431 and I missed several places where the filter field wasn't being set 😳 . Hopefully this PR catches them all.

I toyed with the idea of validating the filter field matches the selectors in [Upsert](https://github.com/evergreen-ci/evergreen/blob/1adeffd04b411b798ec9cb29c8c8b2b68cf8df0b/model/event/subscriptions.go#L289), but I'm not sure we want to include validation logic in a db operation. Once this merges and I do the migration I can check manually in prod after a bit to make sure there aren't any new ones that don't have it set. It doesn't protect us from future developers adding subscriptions that don't set filter, but I'm not sure of a good way to do that.

### Testing 
None...