### PR TITLE
EVG-16411 consider started exec tasks when updating disp task status

### DIFF
--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3442,7 +3442,7 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	task5 := task.Task{
 		Id:        "task5",
 		Activated: true,
-		Status:    evergreen.TaskUndispatched,
+		Status:    evergreen.TaskDispatched,
 	}
 	assert.NoError(task5.Insert())
 	task6 := task.Task{
@@ -3492,12 +3492,13 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	// test that you can't update a display task
 	assert.Error(UpdateDisplayTaskForTask(&dt))
 
-	// test that a display task with a finished + unstarted task is "started"
+	// test that a display task with a finished + unfinished task is "started"
 	assert.NoError(UpdateDisplayTaskForTask(&task5))
 	dbTask, err = task.FindOne(db.Query(task.ById(dt2.Id)))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.Equal(evergreen.TaskStarted, dbTask.Status)
+	assert.Zero(dbTask.FinishTime)
 
 	// check that the updates above logged an event for the first one
 	events, err := event.Find(event.AllLogCollection, event.TaskEventsForId(dt.Id))


### PR DESCRIPTION
[EVG-16411](https://jira.mongodb.org/browse/EVG-16411)

### Description 
We don't consider dispatched/started tasks when we calculate task status, which means that we keep the top sorted task status (which could be started) but we still update finishTime since we don't have any more new tasks to dispatch. Instead, we should consider dispatchable + running tasks.
### Testing 
Modified test -- failed without changes, passes with changes.
