### PR TITLE
EVG-16052 Add project command for assume role

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -465,8 +465,6 @@ func (a *Agent) runTask(ctx context.Context, tc *taskContext) (bool, error) {
 		tc.logger = client.NewSingleChannelLogHarness("agent.error", a.defaultLogger)
 		return a.handleTaskResponse(tskCtx, tc, evergreen.TaskFailed, "")
 	}
-	taskConfig.TaskSync = a.opts.SetupData.TaskSync
-	taskConfig.EC2Keys = a.opts.SetupData.EC2Keys
 	tc.setTaskConfig(taskConfig)
 
 	if err = a.startLogging(ctx, tc); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -466,6 +466,7 @@ func (a *Agent) runTask(ctx context.Context, tc *taskContext) (bool, error) {
 		return a.handleTaskResponse(tskCtx, tc, evergreen.TaskFailed, "")
 	}
 	taskConfig.TaskSync = a.opts.SetupData.TaskSync
+	taskConfig.EC2Keys = a.opts.SetupData.EC2Keys
 	tc.setTaskConfig(taskConfig)
 
 	if err = a.startLogging(ctx, tc); err != nil {

--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -19,10 +18,10 @@ import (
 )
 
 const (
-	AwsAccessKeyId     = "AWS_ACCESS_KEY_ID"
-	AwsSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
-	AwsSessionToken    = "AWS_SESSION_TOKEN"
-	AwsRoleExpiration  = "AWS_ROLE_EXPIRATION"
+	AWSAccessKeyId     = "AWS_ACCESS_KEY_ID"
+	AWSSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
+	AWSSessionToken    = "AWS_SESSION_TOKEN"
+	AWSRoleExpiration  = "AWS_ROLE_EXPIRATION"
 )
 
 type ec2AssumeRole struct {
@@ -61,6 +60,7 @@ func (r *ec2AssumeRole) validate() error {
 		catcher.New("must specify role ARN")
 	}
 
+	// 0 will default duration time to 15 minutes
 	if r.DurationSeconds < 0 {
 		catcher.New("cannot specify a non-positive duration")
 	}
@@ -100,7 +100,7 @@ func (r *ec2AssumeRole) Execute(ctx context.Context,
 	}))
 
 	creds := stscreds.NewCredentials(session1, r.RoleARN, func(arp *stscreds.AssumeRoleProvider) {
-		arp.RoleSessionName = fmt.Sprintf("evergreen_%s_%d", conf.Task.DisplayName, conf.Task.Execution)
+		arp.RoleSessionName = time.Now().String()
 		if r.ExternalId != "" {
 			arp.ExternalID = utility.ToStringPtr(r.ExternalId)
 		}
@@ -122,9 +122,9 @@ func (r *ec2AssumeRole) Execute(ctx context.Context,
 		return errors.WithStack(err)
 	}
 
-	conf.Expansions.Put(AwsAccessKeyId, credValues.AccessKeyID)
-	conf.Expansions.Put(AwsSecretAccessKey, credValues.SecretAccessKey)
-	conf.Expansions.Put(AwsSessionToken, credValues.SessionToken)
-	conf.Expansions.Put(AwsRoleExpiration, expTime.String())
+	conf.Expansions.Put(AWSAccessKeyId, credValues.AccessKeyID)
+	conf.Expansions.Put(AWSSecretAccessKey, credValues.SecretAccessKey)
+	conf.Expansions.Put(AWSSessionToken, credValues.SessionToken)
+	conf.Expansions.Put(AWSRoleExpiration, expTime.String())
 	return nil
 }

--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -1,0 +1,120 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/utility"
+	"github.com/mitchellh/mapstructure"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+type ec2AssumeRole struct {
+	// The Amazon Resource Name (ARN) of the role to assume.
+	// Required.
+	RoleARN string `mapstructure:"role_arn" plugin:"expand"`
+
+	// A unique identifier that might be required when you assume a role in another account.
+	// This variable will only be accessible by admins and mainline.
+	ExternalId string `mapstructure:"external_id" plugin:"expand"`
+
+	// An IAM policy in JSON format that you want to use as an inline session policy.
+	Policy string `mapstructure:"policy" plugin:"expand"`
+
+	// The duration, in seconds, of the role session.
+	// Defaults to 900s (15 minutes).
+	DurationSeconds int `mapstructure:"duration_seconds"`
+
+	base
+}
+
+func ec2AssumeRoleFactory() Command   { return &ec2AssumeRole{} }
+func (r *ec2AssumeRole) Name() string { return "ec2.assume_role" }
+
+func (r *ec2AssumeRole) ParseParams(params map[string]interface{}) error {
+	if err := mapstructure.Decode(params, r); err != nil {
+		return errors.Wrapf(err, "error parsing '%s' params", r.Name())
+	}
+
+	return r.validate()
+}
+
+func (r *ec2AssumeRole) validate() error {
+	catcher := grip.NewSimpleCatcher()
+
+	if r.RoleARN == "" {
+		catcher.New("must specify role ARN")
+	}
+
+	return catcher.Resolve()
+}
+
+func (r *ec2AssumeRole) Execute(ctx context.Context,
+	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
+	if err := util.ExpandValues(r, conf.Expansions); err != nil {
+		return errors.WithStack(err)
+	}
+	// Re-validate the command here, in case an expansion is not defined.
+	if err := r.validate(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if len(conf.EC2Keys) == 0 {
+		return errors.New("no EC2 keys in config")
+	}
+
+	key := conf.EC2Keys[0].Key
+	secret := conf.EC2Keys[0].Secret
+
+	// Error if key or secret are blank
+	if key == "" || secret == "" {
+		return errors.New("AWS ID and Secret must not be blank")
+	}
+
+	defaultCreds := credentials.NewStaticCredentialsFromCreds(credentials.Value{
+		AccessKeyID:     key,
+		SecretAccessKey: secret,
+	})
+
+	session := session.Must(session.NewSession(&aws.Config{
+		Credentials: defaultCreds,
+	}))
+
+	creds := stscreds.NewCredentials(session, r.RoleARN, func(arp *stscreds.AssumeRoleProvider) {
+		arp.RoleSessionName = fmt.Sprintf("evergreen_%s_%d", conf.Task.DisplayName, conf.Task.Execution)
+		if r.ExternalId != "" {
+			arp.ExternalID = utility.ToStringPtr(r.ExternalId)
+		}
+		if r.Policy != "" {
+			arp.Policy = utility.ToStringPtr(r.Policy)
+		}
+		if r.DurationSeconds != 0 {
+			arp.Duration = time.Duration(r.DurationSeconds) * time.Second
+		}
+	})
+
+	credValues, err := creds.Get()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	expTime, err := creds.ExpiresAt()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	conf.Expansions.Put("AWS_ACCESS_KEY_ID", credValues.AccessKeyID)
+	conf.Expansions.Put("AWS_SECRET_ACCESS_KEY", credValues.SecretAccessKey)
+	conf.Expansions.Put("AWS_SESSION_TOKEN", credValues.SessionToken)
+	conf.Expansions.Put("AWS_ROLE_EXPIRATION", expTime.String())
+	return nil
+}

--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -87,7 +87,7 @@ func (r *ec2AssumeRole) Execute(ctx context.Context,
 
 	// Error if key or secret are blank
 	if key == "" || secret == "" {
-		return errors.New("AWS ID and Secret must not be blank")
+		return errors.New("AWS ID and Secret could not be retrieved")
 	}
 
 	defaultCreds := credentials.NewStaticCredentialsFromCreds(credentials.Value{

--- a/agent/command/assume_ec2_role_test.go
+++ b/agent/command/assume_ec2_role_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Testec2AssumeRoleExecute(t *testing.T) {
+func TestEc2AssumeRoleExecute(t *testing.T) {
 	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, c *ec2AssumeRole, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig){
 		"FailsWithNoARN": func(ctx context.Context, t *testing.T, c *ec2AssumeRole, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
 			assert.Error(t, c.Execute(ctx, comm, logger, conf))

--- a/agent/command/assume_ec2_role_test.go
+++ b/agent/command/assume_ec2_role_test.go
@@ -1,0 +1,62 @@
+package command
+
+import (
+	"context"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Testec2AssumeRoleExecute(t *testing.T) {
+	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, c *ec2AssumeRole, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig){
+		"FailsWithNoARN": func(ctx context.Context, t *testing.T, c *ec2AssumeRole, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
+			assert.Error(t, c.Execute(ctx, comm, logger, conf))
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			conf := &internal.TaskConfig{
+				Task: &task.Task{
+					Id:           "id",
+					Project:      "project",
+					Version:      "version",
+					BuildVariant: "build_variant",
+					DisplayName:  "display_name",
+				},
+				BuildVariant: &model.BuildVariant{
+					Name: "build_variant",
+				},
+				ProjectRef: &model.ProjectRef{
+					Id: "project_identifier",
+					TaskSync: model.TaskSyncOptions{
+						ConfigEnabled: utility.TruePtr(),
+					},
+				},
+				EC2Keys: []evergreen.EC2Key{
+					evergreen.EC2Key{
+						Key:    "aaaaaaaaaa",
+						Secret: "bbbbbbbbbbb",
+					},
+				},
+			}
+			comm := client.NewMock("localhost")
+			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{
+				ID:     conf.Task.Id,
+				Secret: conf.Task.Secret,
+			}, nil)
+			require.NoError(t, err)
+
+			c := &ec2AssumeRole{}
+			require.NoError(t, err)
+			testCase(ctx, t, c, comm, logger, conf)
+		})
+	}
+}

--- a/agent/command/expansion_write.go
+++ b/agent/command/expansion_write.go
@@ -16,9 +16,9 @@ import (
 var (
 	expansionsToRedact = []string{
 		evergreen.GlobalGitHubTokenExpansion,
-		AwsAccessKeyId,
-		AwsSecretAccessKey,
-		AwsSessionToken,
+		AWSAccessKeyId,
+		AWSSecretAccessKey,
+		AWSSessionToken,
 	}
 )
 

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -27,6 +27,7 @@ func init() {
 		evergreen.AttachXUnitResultsCommandName: xunitResultsFactory,
 		evergreen.AttachArtifactsCommandName:    attachArtifactsFactory,
 		evergreen.HostCreateCommandName:         createHostFactory,
+		"ec2.assume_role":                       ec2AssumeRoleFactory,
 		"host.list":                             listHostFactory,
 		"expansions.fetch_vars":                 fetchVarsFactory,
 		"expansions.update":                     updateExpansionsFactory,

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -28,6 +28,7 @@ type TaskConfig struct {
 	GithubPatchData    thirdparty.GithubPatch
 	Timeout            *Timeout
 	TaskSync           evergreen.S3Credentials
+	EC2Keys            []evergreen.EC2Key
 	ModulePaths        map[string]string
 	CedarTestResultsID string
 

--- a/agent/task.go
+++ b/agent/task.go
@@ -382,8 +382,6 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 		return nil, err
 	}
 	taskConfig.Redacted = tc.expVars.PrivateVars
-
-	grip.Info("Populating AWS credentials.")
 	taskConfig.TaskSync = a.opts.SetupData.TaskSync
 	taskConfig.EC2Keys = a.opts.SetupData.EC2Keys
 

--- a/agent/task.go
+++ b/agent/task.go
@@ -382,6 +382,11 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 		return nil, err
 	}
 	taskConfig.Redacted = tc.expVars.PrivateVars
+
+	grip.Info("Populating AWS credentials.")
+	taskConfig.TaskSync = a.opts.SetupData.TaskSync
+	taskConfig.EC2Keys = a.opts.SetupData.EC2Keys
+
 	return taskConfig, nil
 }
 

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -100,6 +100,7 @@ type AgentSetupData struct {
 	S3Secret          string                  `json:"s3_secret"`
 	S3Bucket          string                  `json:"s3_bucket"`
 	TaskSync          evergreen.S3Credentials `json:"task_sync"`
+	EC2Keys           []evergreen.EC2Key      `json:"ec2_keys"`
 	LogkeeperURL      string                  `json:"logkeeper_url"`
 }
 

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-03-11"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-03-14"
+	AgentVersion = "2022-03-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/service/api_status.go
+++ b/service/api_status.go
@@ -197,6 +197,7 @@ func (as *APIServer) agentSetup(w http.ResponseWriter, r *http.Request) {
 		S3Secret:          as.Settings.Providers.AWS.S3.Secret,
 		S3Bucket:          as.Settings.Providers.AWS.S3.Bucket,
 		TaskSync:          as.Settings.Providers.AWS.TaskSync,
+		EC2Keys:           as.Settings.Providers.AWS.EC2Keys,
 		LogkeeperURL:      as.Settings.LoggerConfig.LogkeeperURL,
 	}
 	gimlet.WriteJSON(w, out)


### PR DESCRIPTION
[EVG-16052](https://jira.mongodb.org/browse/EVG-16052)

### Description 
added project command that calls assume role given ARN and returns credentials as expansions

### Testing 
very basic unit test

![image](https://user-images.githubusercontent.com/26491602/159083542-5e849b90-4735-4e8a-bf3b-789facf1cbd7.png)


<img width="1026" alt="image" src="https://user-images.githubusercontent.com/26491602/159083271-c5bb084c-406e-4739-9af1-6f54a7ccf422.png">

https://spruce-staging.corp.mongodb.com/task/sandbox_ubuntu1604_bynntask_patch_33f13782b26be2bd33a48d378fb2293db7316034_6234f34bb237367d9ac27d7c_22_03_18_21_02_10/logs?execution=0

testing secrets manager 
![image](https://user-images.githubusercontent.com/26491602/159507309-c762f676-42d2-43ae-b575-ac5c9e7ce105.png)

![image](https://user-images.githubusercontent.com/26491602/159507403-3c019c0f-0e1c-4ae1-8f3c-54e0f0b8cbb3.png)
