### PR TITLE
EVG-16589 disable signing

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -596,7 +596,6 @@ buildvariants:
       RUN_EC2_SPECIFIC_TESTS: true
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.18.tgz
       notary_client_url: https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.1.2/linux_amd64.zip
-      sign_macos: true
     tasks:
       - name: "dist-and-upload-clis"
       - name: "dist-staging"


### PR DESCRIPTION
[EVG-16589](https://jira.mongodb.org/browse/EVG-16589)

### Description 
The signing service is being flaky. Let's stop signing until we can figure out how to mitigate the fallout from signing failing.
