### PR TITLE
EVG-6963 return a client error instead of a database duplicate key error

### DIFF
--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
 	dbModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
@@ -570,6 +571,9 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 
 		queue := evergreen.GetEnvironment().RemoteQueue()
 		if err = queue.Put(ctx, j); err != nil {
+			if db.IsDuplicateKey(err) {
+				return gimlet.MakeJSONErrorResponder(errors.Errorf("Repotracker is already scheduled to run for project '%s'", h.project))
+			}
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "problem creating catchup job"))
 		}
 	}


### PR DESCRIPTION
[EVG-6963 ](https://jira.mongodb.org/browse/EVG-6963)

### Description 
When there is a race, users can see "duplicate key error collection: amboy.evg.service.jobs". This checks if it's a duplicate error and if it is, returns a more descriptive error. 

### Testing 
I was not able to duplicate this error. 
