### PR TITLE
EVG-16452 ensure private variables aren't overridden

### DIFF
--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -174,8 +174,8 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 	case model.ProjectPageVariablesSection:
 		for key, value := range before.Vars.Vars {
 			// Private variables are redacted in the UI, so re-set to the real value
-			// before updating (assuming the value isn't deleted).
-			if before.Vars.PrivateVars[key] && changes.Vars.PrivateVars[key] {
+			// before updating (assuming the value isn't deleted/re-configured).
+			if before.Vars.PrivateVars[key] && changes.Vars.IsPrivate(key) && changes.Vars.Vars[key] == "" {
 				changes.Vars.Vars[key] = value
 			}
 		}
@@ -219,7 +219,6 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		}
 		catcher.Wrapf(DeleteSubscriptions(projectId, toDelete), "Database error deleting subscriptions")
 	}
-	fmt.Println("GETTING TO SAVE FOR SECTION")
 	modifiedProjectRef, err := model.SaveProjectPageForSection(projectId, newProjectRef, section, isRepo)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error defaulting project ref to repo for section '%s'", section)

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -228,3 +228,11 @@ func DbProjectSubscriptionsToRestModel(subscriptions []event.Subscription) ([]AP
 
 	return apiSubscriptions, catcher.Resolve()
 }
+
+// IsPrivate returns true if the given key is a private variable.
+func (vars *APIProjectVars) IsPrivate(key string) bool {
+	if vars.PrivateVars[key] {
+		return true
+	}
+	return utility.StringSliceContains(vars.PrivateVarsList, key)
+}


### PR DESCRIPTION
[EVG-16452](https://jira.mongodb.org/browse/EVG-16452)

### Description 
Wasn't considering before that the UI would pass values in as PrivateVarsList. Also added a clause to ensure that we don't overwrite the value in the case that the value is purposefully deleted / re-added.

### Testing 
Tried to break manually and also modified unit test (didn't work without my changes).