### PR TITLE
EVG-16159 add Fleet options

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -180,11 +180,12 @@ func (s *EC2ProviderSettings) getRegion() string {
 	return evergreen.DefaultEC2Region
 }
 
+// FleetConfig specifies how the EC2 Fleet manager should spawn hosts.
 type FleetConfig struct {
-	// UseOnDemand will use on-demand instances to instantiate hosts. Defaults to spot instances.
+	// UseOnDemand will cause Fleet to use on-demand instances to instantiate hosts. Defaults to spot instances.
 	UseOnDemand bool `mapstructure:"use_on_demand" json:"use_on_demand,omitempty" bson:"use_on_demand,omitempty"`
 
-	// UseCapacityOptimized will use the capacity-optimized allocation strategy for spawning the host. Defaults to the AWS default (lowest-cost).
+	// UseCapacityOptimized will cause Fleet to use the capacity-optimized allocation strategy for spawning hosts. Defaults to the AWS default (lowest-cost).
 	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html for more information about Fleet allocation strategies.
 	UseCapacityOptimized bool `mapstructure:"use_capacity_optimized" json:"use_capacity_optimized,omitempty" bson:"use_capacity_optimized,omitempty"`
 }

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -536,10 +536,15 @@ func (m *ec2FleetManager) requestFleet(ctx context.Context, ec2Settings *EC2Prov
 		},
 		TargetCapacitySpecification: &ec2.TargetCapacitySpecificationRequest{
 			TotalTargetCapacity:       aws.Int64(1),
-			DefaultTargetCapacityType: aws.String(ec2.DefaultTargetCapacityTypeSpot),
+			DefaultTargetCapacityType: ec2Settings.FleetOptions.awsTargetCapacityType(),
 		},
 		Type: aws.String(ec2.FleetTypeInstant),
 	}
+
+	if allocationStrategy := ec2Settings.FleetOptions.awsAllocationStrategy(); allocationStrategy != nil {
+		createFleetInput.SpotOptions = &ec2.SpotOptionsRequest{AllocationStrategy: allocationStrategy}
+	}
+
 	createFleetResponse, err := m.client.CreateFleet(ctx, createFleetInput)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating fleet")

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -108,7 +108,7 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
     'id': 'spot',
     'display': 'Spot'
   }, {
-    'id': 'on-demand-fallback',
+    'id': 'fallback',
     'display': 'Spot with on-demand fallback'
   }, {
     'id': 'on-demand',
@@ -156,7 +156,7 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
         $scope.activeDistro.settings.fleet_options.use_on_demand = false;
         $scope.activeDistro.settings.fallback = false;
         break;
-      case "on-demand-fallback":
+      case "fallback":
         $scope.activeDistro.settings.fleet_options.use_on_demand = false;
         $scope.activeDistro.settings.fallback = true;
         break;
@@ -169,7 +169,7 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
 
   $scope.getFleetInstanceType = function(settings) {
     if (!settings?.fleet_options?.use_on_demand && settings?.fallback) {
-      return "on-demand-fallback";
+      return "fallback";
     }
 
     if (settings?.fleet_options?.use_on_demand && !settings?.fallback) {

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -104,6 +104,17 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
     'display': 'OAuth Token'
   }]
 
+  $scope.fleetInstanceTypes = [{
+    'id': 'spot',
+    'display': 'Spot'
+  }, {
+    'id': 'on-demand-fallback',
+    'display': 'Spot with on-demand fallback'
+  }, {
+    'id': 'on-demand',
+    'display': 'On-demand'
+  }]
+
   $scope.ids = [];
   $scope.keys = [];
   $scope.architectures = [];
@@ -135,6 +146,38 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
       $scope.setActiveDistroId(distroIds[0]);
     }
   };
+
+  $scope.setFleetInstanceType = function(instanceType) {
+    if ($scope.activeDistro.settings.fleet_options === undefined) {
+      $scope.activeDistro.settings.fleet_options = {};
+    }
+    switch(instanceType) {
+      case "spot":
+        $scope.activeDistro.settings.fleet_options.use_on_demand = false;
+        $scope.activeDistro.settings.fallback = false;
+        break;
+      case "on-demand-fallback":
+        $scope.activeDistro.settings.fleet_options.use_on_demand = false;
+        $scope.activeDistro.settings.fallback = true;
+        break;
+      case "on-demand":
+        $scope.activeDistro.settings.fleet_options.use_on_demand = true;
+        $scope.activeDistro.settings.fallback = false;
+        break;
+    }
+  }
+
+  $scope.getFleetInstanceType = function(settings) {
+    if (!settings?.fleet_options?.use_on_demand && settings?.fallback) {
+      return "on-demand-fallback";
+    }
+
+    if (settings?.fleet_options?.use_on_demand && !settings?.fallback) {
+      return "on-demand";
+    }
+
+    return "spot";
+  }
 
   $scope.setActiveDistroId = function (id) {
     $location.hash(id);
@@ -740,6 +783,12 @@ mciModule.directive('removeDistro', function () {
 mciModule.filter("providerDisplay", function () {
   return function (provider, scope) {
     return scope.getKeyDisplay('providers', provider);
+  }
+});
+
+mciModule.filter("fleetInstanceTypeDisplay", function () {
+  return function (instanceType, scope) {
+    return scope.getKeyDisplay('fleetInstanceTypes', instanceType);
   }
 });
 

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -168,11 +168,11 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
   }
 
   $scope.getFleetInstanceType = function(settings) {
-    if (!settings?.fleet_options?.use_on_demand && settings?.fallback) {
+    if (!(settings && settings.fleet_options && settings.fleet_options.use_on_demand) && (settings && settings.fallback)) {
       return "fallback";
     }
 
-    if (settings?.fleet_options?.use_on_demand && !settings?.fallback) {
+    if ((settings && settings.fleet_options && settings.fleet_options.use_on_demand) && !(settings && settings.fallback)) {
       return "on-demand";
     }
 

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -424,17 +424,25 @@ Evergreen - Distros
                 <div class="icon fa fa-warning distro-error" ng-show="form.keyName.$dirty && form.keyName.$error.required || form.keyName.$invalid">EC2
                   key name is required</div>
               </div>
-              <div class="distro-label">
-                <div ng-show="activeDistro.provider === 'ec2-fleet'">
-                  <label><input style="margin-right:10px;" ng-disabled="readOnly || activeDistro.settings.fleet_options.use_on_demand" type="checkbox"
-                    name="use_capacity_optimized" ng-model="activeDistro.settings.fleet_options.use_capacity_optimized">Use the capacity-optimized allocation strategy for spot (default: lowest-cost)</label> <br>
-                  <label><input style="margin-right:10px;" ng-disabled="readOnly || activeDistro.settings.fallback" type="checkbox"
-                    name="use_on_demand" ng-model="activeDistro.settings.fleet_options.use_on_demand">Use on-demand instances for all hosts</label> <br>
+              <div ng-show="activeDistro.provider === 'ec2-spot'">
+                <label><input style="margin-right:10px;" ng-disabled="readOnly" type="checkbox"
+                  name="fallback" ng-model="activeDistro.settings.fallback">Fallback to EC2 On-Demand in the case of insufficient capacity </label> <br>
+              </div>
+              <div ng-show="activeDistro.provider === 'ec2-fleet'">
+                <br>
+                <div class="dropdown">
+                  <span class="distro-menu-title">Instance Type:</span>
+                  <button class="btn btn-default dropdown-toggle" ng-disabled="readOnly" type="button" data-toggle="dropdown">
+                    <strong class="distro-menu-item">[[getFleetInstanceType(activeDistro.settings) | fleetInstanceTypeDisplay:this]]<span class="fa fa-caret-down"></span></strong>
+                  </button>
+                  <ul class="dropdown-menu" role="menu" style="margin-left: 60px">
+                    <li ng-click="form.$setDirty();setFleetInstanceType(instance_type.id)" required
+                      ng-repeat="instance_type in fleetInstanceTypes" role="presentation"><a role="menuitem" tabindex="-1">[[instance_type.display]]</a></li>
+                  </ul>
                 </div>
-                <div ng-show="activeDistro.provider == 'ec2-spot' || activeDistro.provider == 'ec2-fleet'">
-                  <label><input style="margin-right:10px;" ng-disabled="readOnly || activeDistro.settings.fleet_options.use_on_demand" type="checkbox"
-                    name="fallback" ng-model="activeDistro.settings.fallback">Fallback to EC2 On-Demand in the case of insufficient capacity </label> <br>
-                </div>
+                <label><input style="margin-right:10px;" ng-disabled="readOnly || activeDistro.settings.fleet_options.use_on_demand" type="checkbox"
+                  name="use_capacity_optimized" ng-model="activeDistro.settings.fleet_options.use_capacity_optimized">Use the capacity-optimized allocation strategy for spot (default: lowest-cost)</label> <br>
+              </div>
                 <label><input style="margin-right:10px;" ng-disabled="readOnly" type="checkbox"
                   name="is_vpc" ng-model="activeDistro.settings.is_vpc">Use security group in an EC2 VPC </label> <br>
               </div>

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -425,8 +425,14 @@ Evergreen - Distros
                   key name is required</div>
               </div>
               <div class="distro-label">
+                <div ng-show="activeDistro.provider === 'ec2-fleet'">
+                  <label><input style="margin-right:10px;" ng-disabled="readOnly || activeDistro.settings.fleet_options.use_on_demand" type="checkbox"
+                    name="use_capacity_optimized" ng-model="activeDistro.settings.fleet_options.use_capacity_optimized">Use the capacity-optimized allocation strategy for spot (default: lowest-cost)</label> <br>
+                  <label><input style="margin-right:10px;" ng-disabled="readOnly || activeDistro.settings.fallback" type="checkbox"
+                    name="use_on_demand" ng-model="activeDistro.settings.fleet_options.use_on_demand">Use on-demand instances for all hosts</label> <br>
+                </div>
                 <div ng-show="activeDistro.provider == 'ec2-spot' || activeDistro.provider == 'ec2-fleet'">
-                  <label><input style="margin-right:10px;" ng-disabled="readOnly" type="checkbox"
+                  <label><input style="margin-right:10px;" ng-disabled="readOnly || activeDistro.settings.fleet_options.use_on_demand" type="checkbox"
                     name="fallback" ng-model="activeDistro.settings.fallback">Fallback to EC2 On-Demand in the case of insufficient capacity </label> <br>
                 </div>
                 <label><input style="margin-right:10px;" ng-disabled="readOnly" type="checkbox"


### PR DESCRIPTION
[EVG-16159](https://jira.mongodb.org/browse/EVG-16159)

### Description 
Add two options to distros using Fleet: 
1. use the capacity-optimized [allocation strategy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html). I'd like to experiment with this option for distros that are getting interrupted a bunch to see if it would be a cheaper alternative to going to on-demand. For example, I spawned three ubuntu1604-small hosts 1) on-demand 2) spot with the regular (lowest-cost) allocation strategy and 3) spot with capacity-optimized. The on-demand host cost $.17/hr, the regular spot cost $0.073/hr and the capacity-optimized was $0.0816/hr. It's not a huge spread with such a small instance (c5.xlarge), but with larger instance types it could net a bigger difference (like a bunch of the *-large distros are m4.4xlarge where it's less than half).
2. add an on-demand option for Fleet. I wanted to experiment with this anyway ([EVG-16306](https://jira.mongodb.org/browse/EVG-16306)) but it's particularly appealing in light of the issues with instances not having enough room in their subnet: with Fleet they'll go in whichever subnet/AZ has room for them.

### Testing 
I started hosts in staging with Fleet set to on-demand, spot capacity-optimized, spot lowest-cost, and spot on-demand fallback.
