### PR TITLE
EVG-12407 Only allow patchable tasks in configure view

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -181,7 +181,9 @@ func getPatchProjectVariantsAndTasksForUI(ctx context.Context, apiPatch *restMod
 		}
 		projTasks := []string{}
 		for _, taskUnit := range buildVariant.Tasks {
-			projTasks = append(projTasks, taskUnit.Name)
+			if utility.FromBoolPtr(taskUnit.Patchable) {
+				projTasks = append(projTasks, taskUnit.Name)
+			}
 		}
 		for _, displayTask := range buildVariant.DisplayTasks {
 			projTasks = append(projTasks, displayTask.Name)

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -181,7 +181,7 @@ func getPatchProjectVariantsAndTasksForUI(ctx context.Context, apiPatch *restMod
 		}
 		projTasks := []string{}
 		for _, taskUnit := range buildVariant.Tasks {
-			if utility.FromBoolPtr(taskUnit.Patchable) {
+			if !taskUnit.IsDisabled() && utility.FromBoolTPtr(taskUnit.Patchable) && !utility.FromBoolPtr(taskUnit.GitTagOnly) {
 				projTasks = append(projTasks, taskUnit.Name)
 			}
 		}


### PR DESCRIPTION
[EVG-12407](https://jira.mongodb.org/browse/EVG-12407)

### Description 
Only allow tasks that have the patchable flag set. I would assume this value is true by default for all patchable tasks could someone on app confirm?

