### PR TITLE
EVG-16398 just get authorID

### DIFF
--- a/model/version_db.go
+++ b/model/version_db.go
@@ -50,6 +50,7 @@ var (
 	VersionPeriodicBuildIDKey     = bsonutil.MustHaveTag(Version{}, "PeriodicBuildID")
 	VersionActivatedKey           = bsonutil.MustHaveTag(Version{}, "Activated")
 	VersionAbortedKey             = bsonutil.MustHaveTag(Version{}, "Aborted")
+	VersionAuthorIDKey            = bsonutil.MustHaveTag(Version{}, "AuthorID")
 )
 
 // ById returns a db.Q object which will filter on {_id : <the id param>}
@@ -344,6 +345,18 @@ func AddSatisfiedTrigger(versionID, definitionID string) error {
 				VersionSatisfiedTriggersKey: definitionID,
 			},
 		})
+}
+
+func GetVersionAuthorID(versionID string) (string, error) {
+	v, err := VersionFindOne(VersionById(versionID).WithFields(VersionAuthorIDKey))
+	if err != nil {
+		return "", errors.Wrapf(err, "getting version '%s'", versionID)
+	}
+	if v == nil {
+		return "", errors.Errorf("no version found for ID '%s'", versionID)
+	}
+
+	return v.AuthorID, nil
 }
 
 func FindLastPeriodicBuild(projectID, definitionID string) (*Version, error) {

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -39,7 +39,9 @@ func TestVersionByMostRecentNonIgnored(t *testing.T) {
 }
 
 func TestGetVersionAuthorID(t *testing.T) {
-	defer db.ClearCollections(VersionCollection)
+	defer func() {
+		assert.NoError(t, db.ClearCollections(VersionCollection))
+	}()
 
 	for name, test := range map[string]func(*testing.T){
 		"HasAuthorID": func(t *testing.T) {

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -37,3 +37,35 @@ func TestVersionByMostRecentNonIgnored(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, v.Id, "v1")
 }
+
+func TestGetVersionAuthorID(t *testing.T) {
+	defer db.ClearCollections(VersionCollection)
+
+	for name, test := range map[string]func(*testing.T){
+		"HasAuthorID": func(t *testing.T) {
+			assert.NoError(t, (&Version{
+				Id:       "v0",
+				AuthorID: "me",
+			}).Insert())
+			author, err := GetVersionAuthorID("v0")
+			assert.NoError(t, err)
+			assert.Equal(t, "me", author)
+		},
+		"NoVersion": func(t *testing.T) {
+			author, err := GetVersionAuthorID("v0")
+			assert.Error(t, err)
+			assert.Empty(t, author)
+		},
+		"EmptyAuthorID": func(t *testing.T) {
+			assert.NoError(t, (&Version{
+				Id: "v0",
+			}).Insert())
+			author, err := GetVersionAuthorID("v0")
+			assert.NoError(t, err)
+			assert.Empty(t, author)
+		},
+	} {
+		assert.NoError(t, db.ClearCollections(VersionCollection))
+		t.Run(name, test)
+	}
+}


### PR DESCRIPTION
[EVG-16398](https://jira.mongodb.org/browse/EVG-16398)

### Description 
We fetch the version for every task event when all we really need is the author id. I don't think this will make a huge difference. Maybe it could matter if lots of tasks fail at the same time... Like a mongodb-mongo-* version could be 1.5MB these days.
```
mci:SECONDARY> Object.bsonsize(db.versions.findOne({_id:"mongodb_mongo_v5.2_bfdbbb2a3ce0bfa598ea89a5d8e80a9d683e3931"}))
1425573
```

### Testing 
Added a unit test.
