### PR TITLE
EVG-16496 reorder patch insertion and trigger processing

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -360,7 +360,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		return err
 	}
 
-	if _, err = ProcessTriggerAliases(ctx, patchDoc, pref, j.env, patchDoc.Triggers.Aliases); err != nil {
+	if err = ProcessTriggerAliases(ctx, patchDoc, pref, j.env, patchDoc.Triggers.Aliases); err != nil {
 		return errors.Wrap(err, "problem processing trigger aliases")
 	}
 
@@ -531,9 +531,9 @@ func getPreviousTasksAndDisplayTasks(tasksInProjectVariant []string, displayTask
 	return tasks, displayTasks
 }
 
-func ProcessTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *model.ProjectRef, env evergreen.Environment, aliasNames []string) ([]string, error) {
+func ProcessTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *model.ProjectRef, env evergreen.Environment, aliasNames []string) error {
 	if len(aliasNames) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	type aliasGroup struct {
@@ -545,7 +545,7 @@ func ProcessTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *mode
 	for _, aliasName := range aliasNames {
 		alias, found := projectRef.GetPatchTriggerAlias(aliasName)
 		if !found {
-			return nil, errors.Errorf("patch trigger alias '%s' is not defined", aliasName)
+			return errors.Errorf("patch trigger alias '%s' is not defined", aliasName)
 		}
 
 		// group patches on project, status, parentAsModule
@@ -558,7 +558,6 @@ func ProcessTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *mode
 	}
 
 	triggerIntents := make([]patch.Intent, 0, len(aliasGroups))
-	childPatchIds := make([]string, 0, len(aliasGroups))
 	for group, definitions := range aliasGroups {
 		triggerIntent := patch.NewTriggerIntent(patch.TriggerIntentOptions{
 			ParentID:       p.Id.Hex(),
@@ -571,18 +570,20 @@ func ProcessTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *mode
 		})
 
 		if err := triggerIntent.Insert(); err != nil {
-			return nil, errors.Wrap(err, "problem inserting trigger intent")
+			return errors.Wrap(err, "problem inserting trigger intent")
 		}
 
 		triggerIntents = append(triggerIntents, triggerIntent)
-		childPatchIds = append(childPatchIds, triggerIntent.ID())
+		p.Triggers.ChildPatches = append(p.Triggers.ChildPatches, triggerIntent.ID())
 	}
-	p.Triggers.ChildPatches = append(p.Triggers.ChildPatches, childPatchIds...)
+	if err := p.SetChildPatches(); err != nil {
+		return errors.Wrap(err, "setting child patch ids")
+	}
 
 	for _, intent := range triggerIntents {
 		triggerIntent, ok := intent.(*patch.TriggerIntent)
 		if !ok {
-			return nil, errors.Errorf("intent '%s' didn't not have expected type '%T'", intent.ID(), intent)
+			return errors.Errorf("intent '%s' didn't not have expected type '%T'", intent.ID(), intent)
 		}
 
 		job := NewPatchIntentProcessor(mgobson.ObjectIdHex(intent.ID()), intent)
@@ -591,15 +592,16 @@ func ProcessTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *mode
 			// we need the child patch intents to exist when the parent patch is finalized.
 			job.Run(ctx)
 			if err := job.Error(); err != nil {
-				return nil, errors.Wrap(err, "problem processing child patch")
+				return errors.Wrap(err, "problem processing child patch")
 			}
 		} else {
 			if err := env.RemoteQueue().Put(ctx, job); err != nil {
-				return nil, errors.Wrap(err, "problem enqueueing child patch processing")
+				return errors.Wrap(err, "problem enqueueing child patch processing")
 			}
 		}
 	}
-	return childPatchIds, nil
+
+	return nil
 }
 
 func (j *patchIntentProcessor) buildCliPatchDoc(ctx context.Context, patchDoc *patch.Patch, githubOauthToken string) error {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -356,12 +356,12 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 	patchDoc.Id = j.PatchID
 
-	if _, err = ProcessTriggerAliases(ctx, patchDoc, pref, j.env, patchDoc.Triggers.Aliases); err != nil {
-		return errors.Wrap(err, "problem processing trigger aliases")
-	}
-
 	if err = patchDoc.Insert(); err != nil {
 		return err
+	}
+
+	if _, err = ProcessTriggerAliases(ctx, patchDoc, pref, j.env, patchDoc.Triggers.Aliases); err != nil {
+		return errors.Wrap(err, "problem processing trigger aliases")
 	}
 
 	if patchDoc.IsGithubPRPatch() {

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -697,8 +697,10 @@ func (s *PatchIntentUnitsSuite) TestProcessTriggerAliases() {
 	s.NoError(err)
 
 	s.Len(p.Triggers.ChildPatches, 0)
-	childPatchIds, err := ProcessTriggerAliases(ctx, p, projectRef, s.env, []string{"patch-alias"})
-	s.NoError(err)
-	s.Len(childPatchIds, 1)
+	s.NoError(ProcessTriggerAliases(ctx, p, projectRef, s.env, []string{"patch-alias"}))
 	s.Len(p.Triggers.ChildPatches, 1)
+
+	dbPatch, err := patch.FindOneId(p.Id.Hex())
+	s.NoError(err)
+	s.Equal(p.Triggers.ChildPatches, dbPatch.Triggers.ChildPatches)
 }

--- a/units/schedule_patch.go
+++ b/units/schedule_patch.go
@@ -45,14 +45,10 @@ func SchedulePatch(ctx context.Context, patchId string, version *model.Version, 
 	newCxt := context.Background()
 	// Process additional patch trigger aliases added via UI.
 	// Child patches created with the CLI --trigger-alias flag go through a separate flow, so ensure that new child patches are also created before the parent is finalized.
-	childPatchIds, err := ProcessTriggerAliases(ctx, p, projectRef, evergreen.GetEnvironment(), patchUpdateReq.PatchTriggerAliases)
-	if err != nil {
+	if err := ProcessTriggerAliases(ctx, p, projectRef, evergreen.GetEnvironment(), patchUpdateReq.PatchTriggerAliases); err != nil {
 		return http.StatusInternalServerError, errors.Wrap(err, "Error processing patch trigger aliases")
 	}
-	if len(childPatchIds) > 0 {
-		if err = p.SetChildPatches(); err != nil {
-			return http.StatusInternalServerError, errors.Wrapf(err, "error attaching child patches '%s'", p.Id.Hex())
-		}
+	if len(patchUpdateReq.PatchTriggerAliases) > 0 {
 		p.Triggers.Aliases = patchUpdateReq.PatchTriggerAliases
 		if err = p.SetTriggerAliases(); err != nil {
 			return http.StatusInternalServerError, errors.Wrapf(err, "error attaching trigger aliases '%s'", p.Id.Hex())


### PR DESCRIPTION
[EVG-16496](https://jira.mongodb.org/browse/EVG-16496)

### Description 
It looks to me like the parent's changes aren't being applied to spruce because the alias doesn't specify the module they should be applied as. I think we want it to look like this:
![Screen Shot 2022-03-22 at 6 23 33 PM](https://user-images.githubusercontent.com/17027265/159586616-d3b3754d-c88c-4ea7-90f2-cbf12eacff7f.png)


This was broken, though, for the case of finalizing the patch from the CLI. When we went looking for the parent patch [here](https://github.com/evergreen-ci/evergreen/blob/f64f66e3635f1711d483ad65dac155c386281032/units/patch_intent.go#L857) it wasn't there because [it only got inserted after](https://github.com/evergreen-ci/evergreen/blob/f64f66e3635f1711d483ad65dac155c386281032/units/patch_intent.go#L359-L365). This PR switches the order of when the child intents get processed and when the parent patch is inserted. This necessitated updating the parent patch's child patch ids since the patch was already inserted.

### Testing 
On staging the patch was created with the parent module applied.
