### PR TITLE
EVG-16231: populate the pod allocator jobs

### DIFF
--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -15,23 +15,44 @@ type ContainerTaskQueue struct {
 	position int
 }
 
+// NewContainerTaskQueue returns a populated iterator representing an ordered
+// queue of container tasks that are ready to be allocated a container.
+func NewContainerTaskQueue() (*ContainerTaskQueue, error) {
+	q := &ContainerTaskQueue{}
+	if err := q.populate(); err != nil {
+		return nil, errors.Wrap(err, "initial population of container task queue")
+	}
+	return q, nil
+}
+
 // Next returns the next task that's ready for container allocation. It will
 // return a nil task once there are no tasks remaining in the queue.
-func (q *ContainerTaskQueue) Next() (*task.Task, error) {
-	if q.queue == nil {
-		if err := q.populate(); err != nil {
-			return nil, errors.Wrap(err, "initial population of container task queue")
-		}
-	}
+func (q *ContainerTaskQueue) Next() *task.Task {
 	if q.position >= len(q.queue) {
-		return nil, nil
+		return nil
 	}
 
 	next := q.queue[q.position]
 
 	q.position++
 
-	return &next, nil
+	return &next
+}
+
+// HasNext returns whether or not there are more container tasks that have not
+// yet been returned.
+func (q *ContainerTaskQueue) HasNext() bool {
+	return q.position < len(q.queue)
+}
+
+// Len returns the total number of tasks in the queue.
+func (q *ContainerTaskQueue) Len() int {
+	return len(q.queue)
+}
+
+// Remaining returns the number of tasks that have not yet been returned.
+func (q *ContainerTaskQueue) Remaining() int {
+	return len(q.queue) - q.position
 }
 
 func (q *ContainerTaskQueue) populate() error {

--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -45,13 +45,8 @@ func (q *ContainerTaskQueue) HasNext() bool {
 	return q.position < len(q.queue)
 }
 
-// Len returns the total number of tasks in the queue.
+// Len returns the number of tasks remaining.
 func (q *ContainerTaskQueue) Len() int {
-	return len(q.queue)
-}
-
-// Remaining returns the number of tasks that have not yet been returned.
-func (q *ContainerTaskQueue) Remaining() int {
 	return len(q.queue) - q.position
 }
 

--- a/model/container_task_queue_test.go
+++ b/model/container_task_queue_test.go
@@ -33,7 +33,7 @@ func TestContainerTaskQueue(t *testing.T) {
 		}
 	}
 	checkEmpty := func(t *testing.T, ctq *ContainerTaskQueue) {
-		require.Zero(t, ctq.Remaining())
+		require.Zero(t, ctq.Len())
 		require.False(t, ctq.HasNext())
 		require.Zero(t, ctq.Next())
 	}
@@ -59,22 +59,19 @@ func TestContainerTaskQueue(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, 2, ctq.Len())
-			assert.Equal(t, 2, ctq.Remaining())
 			assert.True(t, ctq.HasNext())
 
 			first := ctq.Next()
 			require.NotZero(t, first)
 			assert.Equal(t, needsAllocation1.Id, first.Id, "should return task in need of allocation with earlier activation time")
 
-			assert.Equal(t, 2, ctq.Len())
-			assert.Equal(t, 1, ctq.Remaining())
+			assert.Equal(t, 1, ctq.Len())
 			assert.True(t, ctq.HasNext())
 
 			second := ctq.Next()
 			require.NotZero(t, second)
 			assert.Equal(t, needsAllocation0.Id, second.Id, "should return task in need of alloation with later activation time")
 
-			assert.Equal(t, 2, ctq.Len())
 			checkEmpty(t, ctq)
 		},
 		"ReturnsNoTask": func(t *testing.T) {
@@ -82,7 +79,6 @@ func TestContainerTaskQueue(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, ctq)
 
-			assert.Zero(t, ctq.Len())
 			checkEmpty(t, ctq)
 		},
 		"DoesNotReturnTaskMissingProject": func(t *testing.T) {
@@ -92,7 +88,6 @@ func TestContainerTaskQueue(t *testing.T) {
 			ctq, err := NewContainerTaskQueue()
 			require.NoError(t, err)
 
-			assert.Zero(t, ctq.Len())
 			checkEmpty(t, ctq)
 		},
 		"DoesNotReturnTaskWithInvalidProject": func(t *testing.T) {
@@ -103,7 +98,6 @@ func TestContainerTaskQueue(t *testing.T) {
 			ctq, err := NewContainerTaskQueue()
 			require.NoError(t, err)
 
-			assert.Zero(t, ctq.Len())
 			checkEmpty(t, ctq)
 		},
 		"DoesNotReturnTaskWithProjectThatDisabledTaskDispatching": func(t *testing.T) {
@@ -118,7 +112,6 @@ func TestContainerTaskQueue(t *testing.T) {
 			ctq, err := NewContainerTaskQueue()
 			require.NoError(t, err)
 
-			assert.Zero(t, ctq.Len())
 			checkEmpty(t, ctq)
 		},
 		"ReturnsPatchTaskWithProjectThatEnabledPatching": func(t *testing.T) {
@@ -135,7 +128,6 @@ func TestContainerTaskQueue(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, 1, ctq.Len())
-			assert.Equal(t, 1, ctq.Remaining())
 			assert.True(t, ctq.HasNext())
 
 			tsk := ctq.Next()
@@ -157,7 +149,6 @@ func TestContainerTaskQueue(t *testing.T) {
 			ctq, err := NewContainerTaskQueue()
 			require.NoError(t, err)
 
-			assert.Zero(t, ctq.Len())
 			checkEmpty(t, ctq)
 		},
 		"DoesNotReturnTaskWithDisabledProject": func(t *testing.T) {
@@ -172,7 +163,6 @@ func TestContainerTaskQueue(t *testing.T) {
 			ctq, err := NewContainerTaskQueue()
 			require.NoError(t, err)
 
-			assert.Zero(t, ctq.Len())
 			checkEmpty(t, ctq)
 		},
 		"ReturnsGitHubTaskInDisabledAndHiddenProject": func(t *testing.T) {
@@ -190,7 +180,6 @@ func TestContainerTaskQueue(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, 1, ctq.Len())
-			assert.Equal(t, 1, ctq.Remaining())
 			assert.True(t, ctq.HasNext())
 
 			tsk := ctq.Next()
@@ -213,7 +202,6 @@ func TestContainerTaskQueue(t *testing.T) {
 			ctq, err := NewContainerTaskQueue()
 			require.NoError(t, err)
 
-			assert.Zero(t, ctq.Len())
 			checkEmpty(t, ctq)
 		},
 	} {

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -62,6 +62,11 @@ func ByExternalID(id string) bson.M {
 	}
 }
 
+// Count counts the number of pods matching the given query.
+func Count(q db.Q) (int, error) {
+	return db.CountQ(Collection, q)
+}
+
 // Find finds all pods matching the given query.
 func Find(q db.Q) ([]Pod, error) {
 	pods := []Pod{}
@@ -123,6 +128,14 @@ func FindByNeedsTermination() ([]Pod, error) {
 // any containers.
 func FindByInitializing() ([]Pod, error) {
 	return Find(db.Query(bson.M{
+		StatusKey: StatusInitializing,
+	}))
+}
+
+// CountByInitializing counts the number of pods that are initializing but have
+// not started any containers.
+func CountByInitializing() (int, error) {
+	return Count(db.Query(bson.M{
 		StatusKey: StatusInitializing,
 	}))
 }

--- a/model/pod/db_test.go
+++ b/model/pod/db_test.go
@@ -134,7 +134,48 @@ func TestFindByInitializing(t *testing.T) {
 			tCase(t)
 		})
 	}
+}
 
+func TestCountByInitializing(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T){
+		"ReturnsZeroForNoMatches": func(t *testing.T) {
+			count, err := CountByInitializing()
+			assert.NoError(t, err)
+			assert.Empty(t, count)
+		},
+		"CountsInitializingPods": func(t *testing.T) {
+			p1 := &Pod{
+				ID:     utility.RandomString(),
+				Status: StatusInitializing,
+			}
+			require.NoError(t, p1.Insert())
+
+			p2 := &Pod{
+				ID:     utility.RandomString(),
+				Status: StatusStarting,
+			}
+			require.NoError(t, p2.Insert())
+
+			p3 := &Pod{
+				ID:     utility.RandomString(),
+				Status: StatusInitializing,
+			}
+			require.NoError(t, p3.Insert())
+
+			count, err := CountByInitializing()
+			require.NoError(t, err)
+			assert.Equal(t, 2, count)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.Clear(Collection))
+			defer func() {
+				assert.NoError(t, db.Clear(Collection))
+			}()
+
+			tCase(t)
+		})
+	}
 }
 
 func TestFindOneByID(t *testing.T) {

--- a/units/crons.go
+++ b/units/crons.go
@@ -1304,17 +1304,6 @@ func PopulatePodAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 				continue
 			}
 
-			// Because the container task queue is ordered solely by activation
-			// time, the next task returned either:
-			// 1. Already has a pod allocator job waiting to run.
-			// 2. Does not have a pod allocator job yet and is the next one in
-			//    line to get a chance to allocate.
-			// The remaining count is accurate as long as the following property
-			// of the container task queue holds: a container task can either
-			// stay in the same position or move closer to the front, but it
-			// cannot move towards the back. Should this property not be the
-			// case, then this simple method of bookkeeping the remaining pods
-			// available to allocate is invalid.
 			remaining--
 		}
 

--- a/units/crons.go
+++ b/units/crons.go
@@ -1260,6 +1260,8 @@ func PopulateDataCleanupJobs(env evergreen.Environment) amboy.QueueOperation {
 	}
 }
 
+// PopulatePodAllocatorJobs returns the queue operation to enqueue jobs to
+// allocate pods to tasks.
 func PopulatePodAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
 		flags, err := evergreen.GetServiceFlags()
@@ -1307,9 +1309,9 @@ func PopulatePodAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 			remaining--
 		}
 
-		grip.InfoWhen(remaining <= 0 && ctq.Remaining() > 0, message.Fields{
-			"message":   "reached max parallel pod request limit, not allocating any more",
-			"remaining": ctq.Remaining(),
+		grip.InfoWhen(remaining <= 0 && ctq.Len() > 0, message.Fields{
+			"message":             "reached max parallel pod request limit, not allocating any more",
+			"num_remaining_tasks": ctq.Len(),
 		})
 
 		return catcher.Resolve()

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -79,14 +79,14 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 	appCtx, _ := j.env.Context()
 	hcqueue, err := j.env.RemoteQueueGroup().Get(appCtx, "service.host.create")
 	if err != nil {
-		catcher.Add(errors.Wrap(err, "error getting host create queue"))
+		catcher.Wrap(err, "getting host create queue")
 	} else {
 		catcher.Add(PopulateHostCreationJobs(j.env, 0)(ctx, hcqueue))
 	}
 
 	commitQueueQueue, err := j.env.RemoteQueueGroup().Get(appCtx, "service.commitqueue")
 	if err != nil {
-		catcher.Add(errors.Wrap(err, "error getting commit queue queue"))
+		catcher.Wrap(err, "getting commit queue queue")
 	} else {
 		catcher.Add(PopulateCommitQueueJobs(j.env)(ctx, commitQueueQueue))
 	}

--- a/units/pod_allocator_test.go
+++ b/units/pod_allocator_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/model/pod/dispatcher"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/amboy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,8 +28,24 @@ func TestPodAllocatorJob(t *testing.T) {
 		assert.NoError(t, db.ClearCollections(task.Collection, pod.Collection, dispatcher.Collection, event.AllLogCollection))
 	}()
 
+	var originalPodInit evergreen.PodInitConfig
+	require.NoError(t, originalPodInit.Get(evergreen.GetEnvironment()))
+	originalFlags, err := evergreen.GetServiceFlags()
+	require.NoError(t, err)
+	// Since the tests depend on modifying the global environment, reset it to
+	// its initial state afterwards.
+	defer func() {
+		require.NoError(t, originalPodInit.Set())
+		require.NoError(t, originalFlags.Set())
+	}()
+
 	env := &mock.Environment{}
 	require.NoError(t, env.Configure(ctx))
+
+	env.EvergreenSettings.ServiceFlags.PodAllocatorDisabled = false
+	require.NoError(t, env.EvergreenSettings.ServiceFlags.Set())
+	env.EvergreenSettings.PodInit.MaxParallelPodRequests = 10
+	require.NoError(t, env.EvergreenSettings.PodInit.Set())
 
 	// Pod allocation uses a multi-document transaction, which requires the
 	// collections to exist first before any documents can be inserted.
@@ -119,6 +137,47 @@ func TestPodAllocatorJob(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Empty(t, taskEvents)
 		},
+		"RunNoopsWhenPodAllocationIsDisabled": func(ctx context.Context, t *testing.T, j *podAllocatorJob, tsk task.Task) {
+			originalFlags := env.EvergreenSettings.ServiceFlags
+			defer func() {
+				assert.NoError(t, originalFlags.Set())
+			}()
+			env.EvergreenSettings.ServiceFlags.PodAllocatorDisabled = true
+			require.NoError(t, env.EvergreenSettings.ServiceFlags.Set())
+
+			j.task = &tsk
+			require.NoError(t, tsk.Insert())
+
+			j.Run(ctx)
+			assert.True(t, j.RetryInfo().ShouldRetry())
+
+			dbTask, err := task.FindOneId(tsk.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbTask)
+			assert.Equal(t, evergreen.TaskContainerUnallocated, dbTask.Status)
+		},
+		"RunNoopsWhenMaxParallelPodRequestLimitIsReached": func(ctx context.Context, t *testing.T, j *podAllocatorJob, tsk task.Task) {
+			originalPodInit := env.EvergreenSettings.PodInit
+			defer func() {
+				assert.NoError(t, originalPodInit.Set())
+			}()
+			env.EvergreenSettings.PodInit.MaxParallelPodRequests = 1
+			require.NoError(t, env.EvergreenSettings.PodInit.Set())
+
+			initializing := getInitializingPod(t)
+			require.NoError(t, initializing.Insert())
+
+			j.task = &tsk
+			require.NoError(t, tsk.Insert())
+
+			j.Run(ctx)
+			assert.True(t, j.RetryInfo().ShouldRetry())
+
+			dbTask, err := task.FindOneId(tsk.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbTask)
+			assert.Equal(t, evergreen.TaskContainerUnallocated, dbTask.Status, "container task should not have been allocated because of max parallel pod request limit")
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 10*time.Second)
@@ -126,15 +185,167 @@ func TestPodAllocatorJob(t *testing.T) {
 
 			require.NoError(t, db.ClearCollections(task.Collection, pod.Collection, dispatcher.Collection, event.AllLogCollection))
 
-			tsk := task.Task{
-				Id:        "task0",
-				Activated: true,
-				Status:    evergreen.TaskContainerUnallocated,
-			}
+			tsk := getTaskThatNeedsContainerAllocation()
 			j := NewPodAllocatorJob(tsk.Id, utility.RoundPartOfMinute(0).Format(TSFormat))
 			allocatorJob := j.(*podAllocatorJob)
 			allocatorJob.env = env
 			tCase(tctx, t, allocatorJob, tsk)
 		})
 	}
+}
+
+func TestPopulatePodAllocatorJobs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	getProjectRef := func() model.ProjectRef {
+		return model.ProjectRef{
+			Id:         utility.RandomString(),
+			Identifier: utility.RandomString(),
+			Enabled:    utility.TruePtr(),
+		}
+	}
+
+	// Pod allocation uses a multi-document transaction, which requires
+	// the collections to exist first before any documents can be
+	// inserted.
+	require.NoError(t, db.CreateCollections(task.Collection, pod.Collection, dispatcher.Collection))
+	defer func() {
+		assert.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection, pod.Collection, dispatcher.Collection))
+	}()
+
+	var originalPodInit evergreen.PodInitConfig
+	require.NoError(t, originalPodInit.Get(evergreen.GetEnvironment()))
+	originalFlags, err := evergreen.GetServiceFlags()
+	require.NoError(t, err)
+	// Since the tests depend on modifying the global environment, reset it to
+	// its initial state afterwards.
+	defer func() {
+		require.NoError(t, originalPodInit.Set())
+		require.NoError(t, originalFlags.Set())
+	}()
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment){
+		"CreatesNoPodAllocatorsWithoutTasksNeedingContainerAllocation": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+			ref := getProjectRef()
+			require.NoError(t, ref.Insert())
+			doesNotNeedAllocation := getTaskThatNeedsContainerAllocation()
+			doesNotNeedAllocation.Status = evergreen.TaskContainerAllocated
+			doesNotNeedAllocation.Project = ref.Id
+			require.NoError(t, doesNotNeedAllocation.Insert())
+
+			require.NoError(t, PopulatePodAllocatorJobs(env)(ctx, env.Remote))
+
+			assert.Zero(t, env.Remote.Stats(ctx))
+		},
+		"AllocatesTaskNeedingContainerAllocation": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+			ref := getProjectRef()
+			require.NoError(t, ref.Insert())
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			needsAllocation.Project = ref.Id
+			require.NoError(t, needsAllocation.Insert())
+
+			require.NoError(t, PopulatePodAllocatorJobs(env)(ctx, env.Remote))
+
+			stats := env.Remote.Stats(ctx)
+			assert.Equal(t, stats.Total, 1)
+
+			require.True(t, amboy.WaitInterval(ctx, env.Remote, 100*time.Millisecond), "pod allocator should have finished running")
+
+			dbTask, err := task.FindOneId(needsAllocation.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbTask)
+			assert.Equal(t, evergreen.TaskContainerAllocated, dbTask.Status)
+
+			pd, err := dispatcher.FindOneByGroupID(needsAllocation.Id)
+			require.NoError(t, err)
+			require.NotZero(t, pd, "pod dispatcher should have been allocated for task")
+			require.Len(t, pd.TaskIDs, 1)
+			assert.Equal(t, needsAllocation.Id, pd.TaskIDs[0])
+			require.Len(t, pd.PodIDs, 1)
+
+			p, err := pod.FindOneByID(pd.PodIDs[0])
+			require.NoError(t, err)
+			require.NotZero(t, p, "intent pod should have been allocated for task")
+		},
+		"StopsEnqueueingJobsWhenMaxParallelPodRequestLimitIsReached": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+			originalPodInit := env.EvergreenSettings.PodInit
+			defer func() {
+				require.NoError(t, originalPodInit.Set())
+			}()
+			env.EvergreenSettings.PodInit.MaxParallelPodRequests = 1
+			require.NoError(t, env.EvergreenSettings.PodInit.Set())
+
+			initializing := getInitializingPod(t)
+			require.NoError(t, initializing.Insert())
+
+			ref := getProjectRef()
+			require.NoError(t, ref.Insert())
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			needsAllocation.Project = ref.Id
+			require.NoError(t, needsAllocation.Insert())
+
+			require.NoError(t, PopulatePodAllocatorJobs(env)(ctx, env.Remote))
+
+			assert.Zero(t, env.Remote.Stats(ctx), "should not enqueue more pod allocator jobs when max parallel pod request limit is reached")
+		},
+		"DoesNotEnqueueJobsWhenDisabled": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+			originalFlags := env.EvergreenSettings.ServiceFlags
+			defer func() {
+				assert.NoError(t, originalFlags.Set())
+			}()
+			env.EvergreenSettings.ServiceFlags.PodAllocatorDisabled = true
+			require.NoError(t, env.EvergreenSettings.ServiceFlags.Set())
+
+			ref := getProjectRef()
+			require.NoError(t, ref.Insert())
+			needsAllocation := getTaskThatNeedsContainerAllocation()
+			needsAllocation.Project = ref.Id
+			require.NoError(t, needsAllocation.Insert())
+
+			require.NoError(t, PopulatePodAllocatorJobs(env)(ctx, env.Remote))
+
+			assert.Zero(t, env.Remote.Stats(ctx), "pod allocator job should not be created when max parallel pod requset limit is reached")
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, 10*time.Second)
+			defer tcancel()
+
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(tctx))
+
+			env.EvergreenSettings.ServiceFlags.PodAllocatorDisabled = false
+			require.NoError(t, env.EvergreenSettings.ServiceFlags.Set())
+			env.EvergreenSettings.PodInit.MaxParallelPodRequests = 100
+			require.NoError(t, env.EvergreenSettings.PodInit.Set())
+
+			require.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection, pod.Collection, dispatcher.Collection))
+
+			tCase(tctx, t, env)
+		})
+	}
+}
+
+func getTaskThatNeedsContainerAllocation() task.Task {
+	return task.Task{
+		Id:                utility.RandomString(),
+		Activated:         true,
+		ActivatedTime:     time.Now(),
+		Status:            evergreen.TaskContainerUnallocated,
+		ExecutionPlatform: task.ExecutionPlatformContainer,
+	}
+}
+
+func getInitializingPod(t *testing.T) pod.Pod {
+	initializing, err := pod.NewTaskIntentPod(pod.TaskIntentPodOptions{
+		CPU:        1024,
+		MemoryMB:   1024,
+		OS:         pod.OSLinux,
+		Arch:       pod.ArchAMD64,
+		Image:      "image",
+		WorkingDir: "/",
+	})
+	require.NoError(t, err)
+	return *initializing
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16231

### Description 
* Add some helper methods to container task queue.
* Populate pod allocator jobs in remote queue group from container task queue.
* Add service flag for disabling pod allocation.
* Respect max parallel pod request limit in cron populator and in the pod allocator job itself. 
* I noticed an oddity where the mock.Environment uses the mock DB sessions but allows the usage of a real MongoDB client, so I just switched it to use the MongoDB client session.

### Testing 
Added unit tests. Also added an integration test between the container task queue, cron populator, and pod allocation.
