### PR TITLE
EVG-16558 stop storing duplicate params in the DB

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -396,10 +396,11 @@ type PluginCommandConf struct {
 	// TimeoutSecs indicates the maximum duration the command is allowed to run for.
 	TimeoutSecs int `yaml:"timeout_secs,omitempty" bson:"timeout_secs,omitempty"`
 
-	// Params are used to supply configuration specific information.
-	Params map[string]interface{} `yaml:"params,omitempty" bson:"params,omitempty"`
+	// Params is used to define params in the yaml and parser project,
+	// but is not stored in the DB (instead see ParamsYAML).
+	Params map[string]interface{} `yaml:"params,omitempty" bson:"-"`
 
-	// YAML string of Params to store in database
+	// ParamsYAML is the marshalled Params to store in the database, to preserve nested interfaces.
 	ParamsYAML string `yaml:"params_yaml,omitempty" bson:"params_yaml,omitempty"`
 
 	// Vars defines variables that can be used within commands.
@@ -459,8 +460,8 @@ func (c *PluginCommandConf) UnmarshalBSON(in []byte) error {
 	return c.unmarshalParams()
 }
 
-// we maintain Params for backwards compatibility, but we read from YAML when available, as the
-// given params could be corrupted from the roundtrip
+// We read from YAML when available, as the given params could be corrupted from the roundtrip.
+// If params is passed, then it means that we haven't yet stored this in the DB.
 func (c *PluginCommandConf) unmarshalParams() error {
 	if c.ParamsYAML != "" {
 		out := map[string]interface{}{}

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1698,6 +1698,7 @@ func checkProjectPersists(t *testing.T, yml []byte) {
 	for i, f := range pp.Functions {
 		list := f.List()
 		for j := range list {
+			assert.NotEmpty(t, list[j].Params)
 			assert.EqualValues(t, list[j].Params, newPP.Functions[i].List()[j].Params)
 		}
 	}


### PR DESCRIPTION
[EVG-16558](https://jira.mongodb.org/browse/EVG-16558)

### Description 
SO I realized that we've been storing both Params and ParamsYAML in the DB, and only storing one of these would reduce yaml sizes. 
The reason we store ParamsYAML is because Params is a `map[string]interface{}`, but mongoDB doesn't handle nested interfaces well and this data can become corrupted, so in order to save ParserProject in it's own collection we needed a different way to store it.

The reason we kept Params is just so that, while ParserProject was in development, reverting the work wouldn't leave the parser project string in a state that we wouldn't know how to interpret (i.e. ParamsYAML only). 

It's possible that a few old versions created during the time we were migrating to ParserProject will have issues with this, but since we're still reading Params in from the YAML and most of these read from the version ParserProject yaml string I don't foresee any issues.

### Testing 
Tested in staging that [new ](https://evergreen-staging.corp.mongodb.com/version/623b4d7a9dbe320a169bf4ba)and old patches work with this change, as well as validate, and verified in the DB that paramsYAML was no longer being stored. 
