### PR TITLE
EVG-16577: do not limit max hosts for generate-lint

### DIFF
--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -20,8 +20,6 @@ const (
 	lintPrefix        = "lint"
 	lintVariant       = "lint"
 	lintGroup         = "lint-group"
-	commitMaxHosts    = 4
-	patchMaxHosts     = 2
 	evergreenLintTask = "evergreen"
 	jsonFilename      = "bin/generate-lint.json"
 	scriptsDir        = "scripts"
@@ -127,9 +125,7 @@ func generateTasks() (*shrub.Configuration, error) {
 		return nil, err
 	}
 	var targets []string
-	var maxHosts int
 	if len(changes) == 0 {
-		maxHosts = commitMaxHosts
 		targets, err = getAllTargets()
 		if err != nil {
 			return nil, err
@@ -138,11 +134,6 @@ func generateTasks() (*shrub.Configuration, error) {
 		targets, err = targetsFromChangedFiles(changes)
 		if err != nil {
 			return nil, err
-		}
-		if len(targets) == 1 {
-			maxHosts = 1
-		} else {
-			maxHosts = patchMaxHosts
 		}
 	}
 
@@ -158,7 +149,7 @@ func generateTasks() (*shrub.Configuration, error) {
 		lintTargets = append(lintTargets, name)
 	}
 
-	group := conf.TaskGroup(lintGroup).SetMaxHosts(maxHosts)
+	group := conf.TaskGroup(lintGroup).SetMaxHosts(len(lintTargets))
 	group.SetupGroup.Command().Type("setup").Command("git.get_project").Param("directory", "evergreen")
 	group.SetupGroup.Command().Type("setup").Command("subprocess.exec").ExtendParams(map[string]interface{}{
 		"working_dir":               "evergreen",

--- a/cmd/generate-lint/generate-lint.go
+++ b/cmd/generate-lint/generate-lint.go
@@ -21,7 +21,7 @@ const (
 	lintVariant       = "lint"
 	lintGroup         = "lint-group"
 	commitMaxHosts    = 4
-	patchMaxHosts     = 1
+	patchMaxHosts     = 2
 	evergreenLintTask = "evergreen"
 	jsonFilename      = "bin/generate-lint.json"
 	scriptsDir        = "scripts"
@@ -135,10 +135,14 @@ func generateTasks() (*shrub.Configuration, error) {
 			return nil, err
 		}
 	} else {
-		maxHosts = patchMaxHosts
 		targets, err = targetsFromChangedFiles(changes)
 		if err != nil {
 			return nil, err
+		}
+		if len(targets) == 1 {
+			maxHosts = 1
+		} else {
+			maxHosts = patchMaxHosts
 		}
 	}
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16577

### Description 
Don't use a single-host task group for patches unless there's only 1 task. The single-host task group behavior is undesirable for patches containing multiple packages to lint, since it prevents other packages from being linted if any lint task fails.

### Testing 
N/A