### PR TITLE
EVG-16428 Allow custom container resource aliases defined on project page and in yaml

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -313,15 +313,6 @@ type ContainerSystem struct {
 	WindowsVersion  evergreen.WindowsVersion  `yaml:"windows_version,omitempty" bson:"windows_version"`
 }
 
-// ContainerResources specifies the computing resources given to the container.
-// MemoryMB is the memory (in MB) that the container will be allocated, and
-// CPU is the CPU units that will be allocated. 1024 CPU units is
-// equivalent to 1vCPU.
-type ContainerResources struct {
-	MemoryMB int `yaml:"memory_mb,omitempty" bson:"memory_mb"`
-	CPU      int `yaml:"cpu,omitempty" bson:"cpu"`
-}
-
 type Module struct {
 	Name   string `yaml:"name,omitempty" bson:"name"`
 	Branch string `yaml:"branch,omitempty" bson:"branch"`

--- a/model/project_configs.go
+++ b/model/project_configs.go
@@ -36,6 +36,7 @@ type ProjectConfigFields struct {
 	TaskSync               *TaskSyncOptions               `yaml:"task_sync,omitempty" bson:"task_sync,omitempty"`
 	GithubTriggerAliases   []string                       `yaml:"github_trigger_aliases,omitempty" bson:"github_trigger_aliases,omitempty"`
 	PeriodicBuilds         []PeriodicBuildDefinition      `yaml:"periodic_builds,omitempty" bson:"periodic_builds,omitempty"`
+	ContainerSizes         map[string]ContainerResources  `yaml:"container_sizes,omitempty" bson:"container_sizes,omitempty"`
 }
 
 // Comment above is used by the linter to detect the end of the struct.

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -107,6 +107,9 @@ type ProjectRef struct {
 	BuildBaronSettings evergreen.BuildBaronSettings `bson:"build_baron_settings,omitempty" json:"build_baron_settings,omitempty" yaml:"build_baron_settings,omitempty"`
 	PerfEnabled        *bool                        `bson:"perf_enabled,omitempty" json:"perf_enabled,omitempty" yaml:"perf_enabled,omitempty"`
 
+	// Container settings
+	ContainerSizes map[string]ContainerResources `bson:"container_sizes,omitempty" json:"container_sizes,omitempty" yaml:"container_sizes,omitempty"`
+
 	RepoRefId string `bson:"repo_ref_id" json:"repo_ref_id" yaml:"repo_ref_id"`
 
 	// The following fields are used by Evergreen and are not discoverable.
@@ -454,6 +457,7 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) error {
 		pRefToMerge := ProjectRef{
 			PeriodicBuilds:       projectConfig.PeriodicBuilds,
 			GithubTriggerAliases: projectConfig.GithubTriggerAliases,
+			ContainerSizes:       projectConfig.ContainerSizes,
 		}
 		if projectConfig.WorkstationConfig != nil {
 			pRefToMerge.WorkstationConfig = *projectConfig.WorkstationConfig

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -147,6 +147,15 @@ type AlertConfig struct {
 	Settings bson.M `bson:"settings" json:"settings"`
 }
 
+// ContainerResources specifies the computing resources given to the container.
+// MemoryMB is the memory (in MB) that the container will be allocated, and
+// CPU is the CPU units that will be allocated. 1024 CPU units is
+// equivalent to 1vCPU.
+type ContainerResources struct {
+	MemoryMB int `yaml:"memory_mb,omitempty" bson:"memory_mb" json:"memory_mb"`
+	CPU      int `yaml:"cpu,omitempty" bson:"cpu" json:"cpu"`
+}
+
 type TriggerDefinition struct {
 	// completion of specified task(s) in the project listed here will cause a build in the current project
 	Project string `bson:"project" json:"project"`

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -152,8 +152,8 @@ type AlertConfig struct {
 // CPU is the CPU units that will be allocated. 1024 CPU units is
 // equivalent to 1vCPU.
 type ContainerResources struct {
-	MemoryMB int `yaml:"memory_mb,omitempty" bson:"memory_mb" json:"memory_mb"`
-	CPU      int `yaml:"cpu,omitempty" bson:"cpu" json:"cpu"`
+	MemoryMB int `bson:"memory_mb,omitempty" json:"memory_mb" yaml:"memory_mb"`
+	CPU      int `bson:"cpu,omitempty" json:"cpu" yaml:"cpu"`
 }
 
 type TriggerDefinition struct {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1916,4 +1916,15 @@ func TestMergeWithProjectConfig(t *testing.T) {
 	assert.Equal(t, 1, projectRef.ContainerSizes["small"].CPU)
 	assert.Equal(t, 2, projectRef.ContainerSizes["large"].CPU)
 
+	projectRef.ContainerSizes = map[string]ContainerResources{
+		"xlarge": ContainerResources{
+			MemoryMB: 800,
+			CPU:      4,
+		},
+	}
+	err = projectRef.MergeWithProjectConfig("version1")
+	assert.NoError(t, err)
+	require.NotNil(t, projectRef)
+	assert.Equal(t, 4, projectRef.ContainerSizes["xlarge"].CPU)
+
 }

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1876,6 +1876,16 @@ func TestMergeWithProjectConfig(t *testing.T) {
 					{Command: "overridden"},
 				},
 			},
+			ContainerSizes: map[string]ContainerResources{
+				"small": ContainerResources{
+					MemoryMB: 200,
+					CPU:      1,
+				},
+				"large": ContainerResources{
+					MemoryMB: 400,
+					CPU:      2,
+				},
+			},
 			BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
@@ -1903,5 +1913,7 @@ func TestMergeWithProjectConfig(t *testing.T) {
 	assert.Equal(t, "EVG", projectRef.BuildBaronSettings.TicketCreateProject)
 	assert.Equal(t, []string{"one", "two"}, projectRef.GithubTriggerAliases)
 	assert.Equal(t, "p1", projectRef.PeriodicBuilds[0].ID)
+	assert.Equal(t, 1, projectRef.ContainerSizes["small"].CPU)
+	assert.Equal(t, 2, projectRef.ContainerSizes["large"].CPU)
 
 }

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -530,12 +530,12 @@ mciModule.controller(
             disabled_stats_cache: data.ProjectRef.disabled_stats_cache,
             periodic_builds: data.ProjectRef.periodic_builds,
             container_sizes: data.ProjectRef.container_sizes || {},
-            container_size_names: [],
             use_repo_settings: $scope.projectRef.use_repo_settings,
             build_baron_settings: data.ProjectRef.build_baron_settings || {},
             task_annotation_settings: data.ProjectRef.task_annotation_settings || {},
             perf_enabled: data.ProjectRef.perf_enabled || false,
           };
+          $scope.settingsFormData.container_size_names = Object.keys($scope.settingsFormData.container_sizes)
           // Divide aliases into categories
           $scope.settingsFormData.github_pr_aliases = $scope.aliases.filter(
             function (d) {
@@ -634,6 +634,10 @@ mciModule.controller(
     };
 
     $scope.saveProject = function () {
+        _.each($scope.settingsFormData.container_sizes, function (size) {
+            size.cpu = parseInt(size.cpu)
+            size.memory_mb = parseInt(size.memory_mb)
+        });
       $scope.settingsFormData.batch_time = parseInt(
         $scope.settingsFormData.batch_time
       );

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -529,6 +529,8 @@ mciModule.controller(
             github_trigger_aliases: data.ProjectRef.github_trigger_aliases || [],
             disabled_stats_cache: data.ProjectRef.disabled_stats_cache,
             periodic_builds: data.ProjectRef.periodic_builds,
+            container_sizes: data.ProjectRef.container_sizes || {},
+            container_size_names: [],
             use_repo_settings: $scope.projectRef.use_repo_settings,
             build_baron_settings: data.ProjectRef.build_baron_settings || {},
             task_annotation_settings: data.ProjectRef.task_annotation_settings || {},
@@ -668,6 +670,10 @@ mciModule.controller(
 
       if ($scope.patch_alias) {
         $scope.addPatchAlias();
+      }
+
+      if ($scope.container_size) {
+        $scope.addContainerSize();
       }
 
       $scope.settingsFormData.subscriptions = _.filter(
@@ -812,6 +818,22 @@ mciModule.controller(
       $scope.invalidPatchAliasMessage = "";
     };
 
+    $scope.addContainerSize = function () {
+      if (!$scope.validContainerSize($scope.container_size)) {
+        $scope.invalidContainerSizeMessage =
+          "A valid container size must have a name, memory and cpu properties.";
+          return;
+      }
+      var item = Object.assign({}, $scope.container_size);
+      $scope.settingsFormData.container_sizes[item.name] = {
+          "memory_mb": item.memory_mb,
+          "cpu": item.cpu,
+      }
+      $scope.settingsFormData.container_size_names = Object.keys($scope.settingsFormData.container_sizes)
+      delete $scope.container_size;
+      $scope.invalidContainerSizeMessage = "";
+    };
+
     $scope.addWorkstationCommand = function () {
       if (!$scope.settingsFormData.workstation_config) {
         $scope.settingsFormData.workstation_config = {};
@@ -880,6 +902,14 @@ mciModule.controller(
       $scope.settingsFormData.patch_aliases.splice(i, 1);
       $scope.isDirty = true;
     };
+
+      $scope.removeContainerSize = function (name) {
+          if ($scope.settingsFormData.container_sizes[name]) {
+              delete $scope.settingsFormData.container_sizes[name]
+              $scope.settingsFormData.container_size_names = Object.keys($scope.settingsFormData.container_sizes)
+          }
+          $scope.isDirty = true;
+      };
 
     $scope.removeProjectTrigger = function (i) {
       if ($scope.project_triggers[i]) {
@@ -1108,6 +1138,11 @@ mciModule.controller(
     $scope.validPatchAlias = function (alias) {
       // Same as GitHub alias, but with alias required
       return $scope.validPatchDefinition(alias) && alias.alias;
+    };
+
+    $scope.validContainerSize = function (container_size) {
+      // Same as GitHub alias, but with alias required
+      return container_size && container_size.cpu && container_size.memory_mb;
     };
 
     $scope.validWorkstationCommand = function (obj) {

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -381,9 +381,6 @@ mciModule.controller(
 
       // if copyProject is set, copy the current project
       if ($scope.newProject.copyProject) {
-        $scope.settingsFormData.batch_time = parseInt(
-          $scope.settingsFormData.batch_time
-        );
         $http
           .put("/project/" + $scope.newProject.identifier, $scope.newProject)
           .then(
@@ -494,7 +491,7 @@ mciModule.controller(
             cedar_test_results_enabled: $scope.projectRef.cedar_test_results_enabled,
             remote_path: $scope.projectRef.remote_path,
             spawn_host_script_path: $scope.projectRef.spawn_host_script_path,
-            batch_time: parseInt($scope.projectRef.batch_time),
+            batch_time: $scope.projectRef.batch_time,
             deactivate_previous: $scope.projectRef.deactivate_previous,
             relative_url: $scope.projectRef.relative_url,
             branch_name: $scope.projectRef.branch_name || "main",
@@ -634,13 +631,6 @@ mciModule.controller(
     };
 
     $scope.saveProject = function () {
-        _.each($scope.settingsFormData.container_sizes, function (size) {
-            size.cpu = parseInt(size.cpu)
-            size.memory_mb = parseInt(size.memory_mb)
-        });
-      $scope.settingsFormData.batch_time = parseInt(
-        $scope.settingsFormData.batch_time
-      );
       $scope.settingsFormData.triggers = $scope.project_triggers;
       $scope.settingsFormData.patch_trigger_aliases =
         $scope.patch_trigger_aliases;
@@ -825,7 +815,7 @@ mciModule.controller(
     $scope.addContainerSize = function () {
       if (!$scope.validContainerSize($scope.container_size)) {
         $scope.invalidContainerSizeMessage =
-          "A valid container size must have a name, memory and cpu properties.";
+          "A valid container size must have a name, memory and CPU properties.";
           return;
       }
       var item = Object.assign({}, $scope.container_size);
@@ -1145,7 +1135,6 @@ mciModule.controller(
     };
 
     $scope.validContainerSize = function (container_size) {
-      // Same as GitHub alias, but with alias required
       return container_size && container_size.cpu && container_size.memory_mb;
     };
 

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -532,7 +532,6 @@ mciModule.controller(
             task_annotation_settings: data.ProjectRef.task_annotation_settings || {},
             perf_enabled: data.ProjectRef.perf_enabled || false,
           };
-          $scope.settingsFormData.container_size_names = Object.keys($scope.settingsFormData.container_sizes)
           // Divide aliases into categories
           $scope.settingsFormData.github_pr_aliases = $scope.aliases.filter(
             function (d) {
@@ -823,7 +822,6 @@ mciModule.controller(
           "memory_mb": item.memory_mb,
           "cpu": item.cpu,
       }
-      $scope.settingsFormData.container_size_names = Object.keys($scope.settingsFormData.container_sizes)
       delete $scope.container_size;
       $scope.invalidContainerSizeMessage = "";
     };
@@ -900,7 +898,6 @@ mciModule.controller(
       $scope.removeContainerSize = function (name) {
           if ($scope.settingsFormData.container_sizes[name]) {
               delete $scope.settingsFormData.container_sizes[name]
-              $scope.settingsFormData.container_size_names = Object.keys($scope.settingsFormData.container_sizes)
           }
           $scope.isDirty = true;
       };
@@ -1135,7 +1132,8 @@ mciModule.controller(
     };
 
     $scope.validContainerSize = function (container_size) {
-      return container_size && container_size.cpu && container_size.memory_mb;
+      return container_size && container_size.cpu && container_size.memory_mb
+          && container_size.cpu > 0 && container_size.memory_mb > 0;
     };
 
     $scope.validWorkstationCommand = function (obj) {

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/db/mgo/bson"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/distro"
@@ -330,7 +329,6 @@ tasks:
 	assert.NoError(t, d.Insert())
 
 	p := &model.Project{}
-	ctx = context.Background()
 	pp, err := model.LoadProjectInto(ctx, []byte(simpleYml), nil, "testproject", p)
 	assert.NoError(t, err)
 

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -268,8 +268,6 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 func TestBatchTimeForTasks(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(model.VersionCollection, distro.Collection, model.ParserProjectCollection,
 		build.Collection, task.Collection, model.ProjectConfigCollection), ShouldBeNil)
 

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -266,6 +266,10 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 }
 
 func TestBatchTimeForTasks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := testutil.NewEnvironment(ctx, t)
+	evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(model.VersionCollection, distro.Collection, model.ParserProjectCollection,
 		build.Collection, task.Collection, model.ProjectConfigCollection), ShouldBeNil)
 
@@ -328,7 +332,7 @@ tasks:
 	assert.NoError(t, d.Insert())
 
 	p := &model.Project{}
-	ctx := context.Background()
+	ctx = context.Background()
 	pp, err := model.LoadProjectInto(ctx, []byte(simpleYml), nil, "testproject", p)
 	assert.NoError(t, err)
 

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -378,26 +378,16 @@ type APIContainerResources struct {
 	CPU      *int `bson:"cpu" json:"cpu"`
 }
 
-func (cr *APIContainerResources) BuildFromService(h interface{}) error {
-	var def model.ContainerResources
-	switch h.(type) {
-	case model.ContainerResources:
-		def = h.(model.ContainerResources)
-	case *model.ContainerResources:
-		def = *h.(*model.ContainerResources)
-	default:
-		return errors.Errorf("Invalid container resources of type '%T'", h)
-	}
-	cr.MemoryMB = utility.ToIntPtr(def.MemoryMB)
-	cr.CPU = utility.ToIntPtr(def.CPU)
-	return nil
+func (cr *APIContainerResources) BuildFromService(h model.ContainerResources) {
+	cr.MemoryMB = utility.ToIntPtr(h.MemoryMB)
+	cr.CPU = utility.ToIntPtr(h.CPU)
 }
 
-func (cr *APIContainerResources) ToService() (interface{}, error) {
-	containerResources := model.ContainerResources{}
-	containerResources.MemoryMB = utility.FromIntPtr(cr.MemoryMB)
-	containerResources.CPU = utility.FromIntPtr(cr.CPU)
-	return containerResources, nil
+func (cr *APIContainerResources) ToService() model.ContainerResources {
+	return model.ContainerResources{
+		MemoryMB: utility.FromIntPtr(cr.MemoryMB),
+		CPU:      utility.FromIntPtr(cr.CPU),
+	}
 }
 
 type APIWorkstationSetupCommand struct {

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -178,8 +178,8 @@ func (t *APITaskSpecifier) ToService() (interface{}, error) {
 type APIPeriodicBuildDefinition struct {
 	ID            *string    `json:"id"`
 	ConfigFile    *string    `json:"config_file"`
-	IntervalHours *int       `son:"interval_hours"`
-	Alias         *string    `son:"alias,omitempty"`
+	IntervalHours *int       `json:"interval_hours"`
+	Alias         *string    `json:"alias,omitempty"`
 	Message       *string    `json:"message,omitempty"`
 	NextRunTime   *time.Time `json:"next_run_time,omitempty"`
 }
@@ -371,6 +371,33 @@ func (opts *APITaskSyncOptions) ToService() (interface{}, error) {
 type APIWorkstationConfig struct {
 	SetupCommands []APIWorkstationSetupCommand `bson:"setup_commands" json:"setup_commands"`
 	GitClone      *bool                        `bson:"git_clone" json:"git_clone"`
+}
+
+type APIContainerResources struct {
+	MemoryMB *int `bson:"memory_mb" json:"memory_mb"`
+	CPU      *int `bson:"cpu" json:"cpu"`
+}
+
+func (cr *APIContainerResources) BuildFromService(h interface{}) error {
+	var def model.ContainerResources
+	switch h.(type) {
+	case model.ContainerResources:
+		def = h.(model.ContainerResources)
+	case *model.ContainerResources:
+		def = *h.(*model.ContainerResources)
+	default:
+		return errors.Errorf("Invalid container resources of type '%T'", h)
+	}
+	cr.MemoryMB = utility.ToIntPtr(def.MemoryMB)
+	cr.CPU = utility.ToIntPtr(def.CPU)
+	return nil
+}
+
+func (cr *APIContainerResources) ToService() (interface{}, error) {
+	containerResources := model.ContainerResources{}
+	containerResources.MemoryMB = utility.FromIntPtr(cr.MemoryMB)
+	containerResources.CPU = utility.FromIntPtr(cr.CPU)
+	return containerResources, nil
 }
 
 type APIWorkstationSetupCommand struct {

--- a/service/project.go
+++ b/service/project.go
@@ -247,10 +247,10 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Project not found", http.StatusNotFound)
 		return
 	}
-	if projectRef.UseRepoSettings() {
-		http.Error(w, "can't modify branch projects here", http.StatusBadRequest)
-		return
-	}
+	//if projectRef.UseRepoSettings() {
+	//	http.Error(w, "can't modify branch projects here", http.StatusBadRequest)
+	//	return
+	//}
 	id = projectRef.Id
 	origProjectRef := *projectRef
 

--- a/service/project.go
+++ b/service/project.go
@@ -297,22 +297,22 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			Provider string                 `json:"provider"`
 			Settings map[string]interface{} `json:"settings"`
 		} `json:"alert_config"`
-		NotifyOnBuildFailure    bool                                `json:"notify_on_failure"`
-		ForceRepotrackerRun     bool                                `json:"force_repotracker_run"`
-		DeactivateStepbackTasks bool                                `json:"deactivate_stepback_tasks"`
-		Subscriptions           []restModel.APISubscription         `json:"subscriptions,omitempty"`
-		DeleteSubscriptions     []string                            `json:"delete_subscriptions"`
-		Triggers                []model.TriggerDefinition           `json:"triggers,omitempty"`
-		PatchTriggerAliases     []patch.PatchTriggerDefinition      `json:"patch_trigger_aliases,omitempty"`
-		GithubTriggerAliases    []string                            `json:"github_trigger_aliases,omitempty"`
-		FilesIgnoredFromCache   []string                            `json:"files_ignored_from_cache,omitempty"`
-		DisabledStatsCache      bool                                `json:"disabled_stats_cache"`
-		PeriodicBuilds          []*model.PeriodicBuildDefinition    `json:"periodic_builds,omitempty"`
-		WorkstationConfig       restModel.APIWorkstationConfig      `json:"workstation_config"`
-		PerfEnabled             bool                                `json:"perf_enabled"`
-		BuildBaronSettings      restModel.APIBuildBaronSettings     `json:"build_baron_settings"`
-		TaskAnnotationSettings  restModel.APITaskAnnotationSettings `json:"task_annotation_settings"`
-		ContainerSizes          map[string]model.ContainerResources `json:"container_sizes"`
+		NotifyOnBuildFailure    bool                                       `json:"notify_on_failure"`
+		ForceRepotrackerRun     bool                                       `json:"force_repotracker_run"`
+		DeactivateStepbackTasks bool                                       `json:"deactivate_stepback_tasks"`
+		Subscriptions           []restModel.APISubscription                `json:"subscriptions,omitempty"`
+		DeleteSubscriptions     []string                                   `json:"delete_subscriptions"`
+		Triggers                []model.TriggerDefinition                  `json:"triggers,omitempty"`
+		PatchTriggerAliases     []patch.PatchTriggerDefinition             `json:"patch_trigger_aliases,omitempty"`
+		GithubTriggerAliases    []string                                   `json:"github_trigger_aliases,omitempty"`
+		FilesIgnoredFromCache   []string                                   `json:"files_ignored_from_cache,omitempty"`
+		DisabledStatsCache      bool                                       `json:"disabled_stats_cache"`
+		PeriodicBuilds          []*model.PeriodicBuildDefinition           `json:"periodic_builds,omitempty"`
+		WorkstationConfig       restModel.APIWorkstationConfig             `json:"workstation_config"`
+		PerfEnabled             bool                                       `json:"perf_enabled"`
+		BuildBaronSettings      restModel.APIBuildBaronSettings            `json:"build_baron_settings"`
+		TaskAnnotationSettings  restModel.APITaskAnnotationSettings        `json:"task_annotation_settings"`
+		ContainerSizes          map[string]restModel.APIContainerResources `json:"container_sizes"`
 	}{}
 
 	if err = utility.ReadJSON(utility.NewRequestReader(r), &responseRef); err != nil {
@@ -575,6 +575,21 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	containerSizes := map[string]model.ContainerResources{}
+	for key, apiContainerResource := range responseRef.ContainerSizes {
+		i, err = apiContainerResource.ToService()
+		if err != nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error validating container resource input"))
+			return
+		}
+		containerResource, ok := i.(model.ContainerResources)
+		if !ok {
+			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Errorf("expected container resources but was actually '%T'", i))
+			return
+		}
+		containerSizes[key] = containerResource
+	}
+
 	catcher := grip.NewSimpleCatcher()
 	for i := range responseRef.Triggers {
 		catcher.Add(responseRef.Triggers[i].Validate(id))
@@ -585,6 +600,14 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	}
 	for i, buildDef := range responseRef.PeriodicBuilds {
 		catcher.Wrapf(buildDef.Validate(), "invalid periodic build definition on line %d", i+1)
+	}
+	for _, containerResource := range responseRef.ContainerSizes {
+		if *containerResource.CPU <= 0 {
+			catcher.New("container resource CPU must be a positive integer")
+		}
+		if *containerResource.MemoryMB <= 0 {
+			catcher.New("container resource Memory MB must be a positive integer")
+		}
 	}
 	if catcher.HasErrors() {
 		uis.LoggedError(w, r, http.StatusBadRequest, catcher.Resolve())
@@ -631,7 +654,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectRef.DisabledStatsCache = &responseRef.DisabledStatsCache
 	projectRef.PeriodicBuilds = []model.PeriodicBuildDefinition{}
 	projectRef.PerfEnabled = &responseRef.PerfEnabled
-	projectRef.ContainerSizes = responseRef.ContainerSizes
+	projectRef.ContainerSizes = containerSizes
 	if hook != nil {
 		projectRef.TracksPushEvents = utility.TruePtr()
 	}

--- a/service/project.go
+++ b/service/project.go
@@ -312,6 +312,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		PerfEnabled             bool                                `json:"perf_enabled"`
 		BuildBaronSettings      restModel.APIBuildBaronSettings     `json:"build_baron_settings"`
 		TaskAnnotationSettings  restModel.APITaskAnnotationSettings `json:"task_annotation_settings"`
+		ContainerSizes          map[string]model.ContainerResources `json:"container_sizes"`
 	}{}
 
 	if err = utility.ReadJSON(utility.NewRequestReader(r), &responseRef); err != nil {
@@ -630,6 +631,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectRef.DisabledStatsCache = &responseRef.DisabledStatsCache
 	projectRef.PeriodicBuilds = []model.PeriodicBuildDefinition{}
 	projectRef.PerfEnabled = &responseRef.PerfEnabled
+	projectRef.ContainerSizes = responseRef.ContainerSizes
 	if hook != nil {
 		projectRef.TracksPushEvents = utility.TruePtr()
 	}

--- a/service/project.go
+++ b/service/project.go
@@ -247,10 +247,10 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Project not found", http.StatusNotFound)
 		return
 	}
-	//if projectRef.UseRepoSettings() {
-	//	http.Error(w, "can't modify branch projects here", http.StatusBadRequest)
-	//	return
-	//}
+	if projectRef.UseRepoSettings() {
+		http.Error(w, "can't modify branch projects here", http.StatusBadRequest)
+		return
+	}
 	id = projectRef.Id
 	origProjectRef := *projectRef
 

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -968,6 +968,54 @@ Evergreen Projects
           </div>
         </div>
       </div>
+      <!-- Custom container resource aliases -->
+      <div class="variables">
+        <div class="form-group">
+          <div class="col-header col-lg-6 form-control-static">
+            <h3>Container Sizes</h3>
+            <div class="muted small">Specify custom computing resource configurations for running tasks in containers. Memory field denotes the memory (in MB) that the container will be allocated, and CPU is the CPU units that will be allocated. 1024 CPU units is equivalent to 1vCPU.</div>
+          </div>
+        </div>
+        <div id="container-sizes-list-header" class="form-group">
+          <div class="col-lg-2"> <label class="control-label"> Name </label> </div>
+          <div class="col-lg-2"> <label class="control-label"> Memory MB </label> </div>
+          <div class="col-lg-2"> <label class="control-label"> CPU </label> </div>
+          <div class="col-lg-2"></div>
+        </div>
+        <div id="container-sizes-list" class="form-group" ng-repeat="obj in settingsFormData.container_sizes track by $index">
+          <div class="col-lg-2">
+            <input class="form-control" ng-model="settingsFormData.container_size_names[$index]" type="text" placeholder="name">
+          </div>
+          <div class="col-lg-2">
+            <input class="form-control" ng-model="obj.memory_mb" type="text" placeholder="memory mb">
+          </div>
+          <div class="col-lg-2">
+            <input class="form-control" ng-model="obj.cpu" type="text" placeholder="cpu">
+          </div>
+          <div class="col-lg-2">
+            <button class="btn btn-default btn-danger" type="button" ng-click="removeContainerSize(settingsFormData.container_size_names[$index])">
+              <i class="fa fa-trash"></i>
+            </button>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-lg-2">
+            <input ng-model="container_size.name" class="form-control" type="text" placeholder="name">
+          </div>
+          <div class="col-lg-2">
+            <input ng-model="container_size.memory_mb" class="form-control" type="text" placeholder="memory mb">
+          </div>
+          <div class="col-lg-2">
+            <input ng-model="container_size.cpu" class="form-control" type="text" placeholder="cpu">
+          </div>
+          <div class="col-lg-2">
+            <button class="plus-button btn btn-primary " ng-disabled="!validContainerSize(container_size)" type="button" ng-click="addContainerSize()">
+              <i class="fa fa-plus"></i>
+            </button>
+            <label class="distro-error">[[invalidContainerSizeMessage]]</label>
+          </div>
+        </div>
+      </div>
       <!-- Commands for Virtual Workstations -->
       <div class="variables">
         <div class="form-group">

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -982,9 +982,9 @@ Evergreen Projects
           <div class="col-lg-2"> <label class="control-label"> CPU </label> </div>
           <div class="col-lg-2"></div>
         </div>
-        <div id="container-sizes-list" class="form-group" ng-repeat="obj in settingsFormData.container_sizes track by $index">
+        <div id="container-sizes-list" class="form-group" ng-repeat="(name, obj) in settingsFormData.container_sizes track by $index">
           <div class="col-lg-2">
-            <input class="form-control" ng-model="settingsFormData.container_size_names[$index]" type="text" placeholder="name">
+            <input class="form-control" ng-model="name" type="text" placeholder="name">
           </div>
           <div class="col-lg-2">
             <input class="form-control" ng-model="obj.memory_mb" type="number" placeholder="memory mb">
@@ -993,7 +993,7 @@ Evergreen Projects
             <input class="form-control" ng-model="obj.cpu" type="number" placeholder="cpu">
           </div>
           <div class="col-lg-2">
-            <button class="btn btn-default btn-danger" type="button" ng-click="removeContainerSize(settingsFormData.container_size_names[$index])">
+            <button class="btn btn-default btn-danger" type="button" ng-click="removeContainerSize(name)">
               <i class="fa fa-trash"></i>
             </button>
           </div>

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -173,7 +173,7 @@ Evergreen Projects
         <label class="control-label">Batch Time (min)</label>
       </div>
       <div class="col-lg-4">
-        <input class="form-control" type="text" ng-model="settingsFormData.batch_time">
+        <input class="form-control" type="number" ng-model="settingsFormData.batch_time">
         <label class="icon fa fa-warning project-error" ng-show="!isBatchTimeValid(settingsFormData.batch_time)">&nbsp;Batch time must be a number, &gt;=0.</label>
       </div>
     </div>
@@ -987,10 +987,10 @@ Evergreen Projects
             <input class="form-control" ng-model="settingsFormData.container_size_names[$index]" type="text" placeholder="name">
           </div>
           <div class="col-lg-2">
-            <input class="form-control" ng-model="obj.memory_mb" type="text" placeholder="memory mb">
+            <input class="form-control" ng-model="obj.memory_mb" type="number" placeholder="memory mb">
           </div>
           <div class="col-lg-2">
-            <input class="form-control" ng-model="obj.cpu" type="text" placeholder="cpu">
+            <input class="form-control" ng-model="obj.cpu" type="number" placeholder="cpu">
           </div>
           <div class="col-lg-2">
             <button class="btn btn-default btn-danger" type="button" ng-click="removeContainerSize(settingsFormData.container_size_names[$index])">
@@ -1003,10 +1003,10 @@ Evergreen Projects
             <input ng-model="container_size.name" class="form-control" type="text" placeholder="name">
           </div>
           <div class="col-lg-2">
-            <input ng-model="container_size.memory_mb" class="form-control" type="text" placeholder="memory mb">
+            <input ng-model="container_size.memory_mb" class="form-control" type="number" placeholder="memory mb">
           </div>
           <div class="col-lg-2">
-            <input ng-model="container_size.cpu" class="form-control" type="text" placeholder="cpu">
+            <input ng-model="container_size.cpu" class="form-control" type="number" placeholder="cpu">
           </div>
           <div class="col-lg-2">
             <button class="plus-button btn btn-primary " ng-disabled="!validContainerSize(container_size)" type="button" ng-click="addContainerSize()">


### PR DESCRIPTION
[EVG-16428](https://jira.mongodb.org/browse/EVG-16428)

### Description 
Added a form on the projects page allowing users to define default container resource sizes that are referenced by an alias. These can be saved to the project ref. Then, when the 'size' property is set on a container in YAML, the resource specs from the same name will be retrieved from the project ref at runtime.
### Testing 
Updated existing unit tests.