### PR TITLE
EVG-16350 Add MergedFrom to commit queue merge patches

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -172,6 +172,8 @@ type Patch struct {
 	// MergeStatus is only used in gitServePatch to send the status of this
 	// patch on the commit queue to the agent
 	MergeStatus string `json:"merge_status"`
+	// MergedFrom is only used when a merge patch is created from an existing patch.
+	MergedFrom string `bson:"merged_from,omitempty"`
 }
 
 func (p *Patch) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(p) }

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -172,7 +172,8 @@ type Patch struct {
 	// MergeStatus is only used in gitServePatch to send the status of this
 	// patch on the commit queue to the agent
 	MergeStatus string `json:"merge_status"`
-	// MergedFrom is only used when a merge patch is created from an existing patch.
+	// MergedFrom is populated with patch id of the existing patch
+	// the merged patch is based off of.
 	MergedFrom string `bson:"merged_from,omitempty"`
 }
 

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -172,8 +172,8 @@ type Patch struct {
 	// MergeStatus is only used in gitServePatch to send the status of this
 	// patch on the commit queue to the agent
 	MergeStatus string `json:"merge_status"`
-	// MergedFrom is populated with patch id of the existing patch
-	// the merged patch is based off of.
+	// MergedFrom is populated with the patch id of the existing patch
+	// the merged patch is based off of, if applicable.
 	MergedFrom string `bson:"merged_from,omitempty"`
 }
 

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -851,6 +851,7 @@ func MakeMergePatchFromExisting(ctx context.Context, existingPatch *patch.Patch,
 		Alias:                evergreen.CommitQueueAlias,
 		PatchedParserProject: existingPatch.PatchedParserProject,
 		CreateTime:           time.Now(),
+		MergedFrom:           existingPatch.Id.Hex(),
 	}
 
 	if patchDoc.Patches, err = patch.MakeMergePatchPatches(existingPatch, commitMessage); err != nil {

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -193,10 +193,12 @@ buildvariants:
 	newPatch, err := CreatePatchForMerge(context.Background(), existingPatch.Id.Hex(), "")
 	s.NoError(err)
 	s.NotNil(newPatch)
+	s.Equal(utility.FromStringPtr(newPatch.MergedFrom), existingPatch.Id.Hex())
 
 	newPatchDB, err := patch.FindOneId(utility.FromStringPtr(newPatch.Id))
 	s.NoError(err)
 	s.Equal(evergreen.CommitQueueAlias, newPatchDB.Alias)
+	s.Equal(newPatchDB.MergedFrom, existingPatch.Id.Hex())
 }
 
 func (s *CommitQueueSuite) TestMockGetGitHubPR() {

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -44,6 +44,7 @@ type APIPatch struct {
 	ChildPatches            []APIPatch           `json:"child_patches"`
 	ChildPatchAliases       []APIChildPatchAlias `json:"child_patch_aliases,omitempty"`
 	Requester               *string              `json:"requester"`
+	MergedFrom              *string              `json:"merged_from"`
 }
 
 type DownstreamTasks struct {
@@ -114,6 +115,7 @@ func (apiPatch *APIPatch) BuildFromService(h interface{}) error {
 	apiPatch.CreateTime = ToTimePtr(v.CreateTime)
 	apiPatch.StartTime = ToTimePtr(v.StartTime)
 	apiPatch.FinishTime = ToTimePtr(v.FinishTime)
+	apiPatch.MergedFrom = utility.ToStringPtr(v.MergedFrom)
 	builds := make([]*string, 0)
 	for _, b := range v.BuildVariants {
 		builds = append(builds, utility.ToStringPtr(b))

--- a/trigger/payloads_test.go
+++ b/trigger/payloads_test.go
@@ -121,7 +121,7 @@ func (s *payloadSuite) TestEvergreenWebhook() {
 	s.NoError(err)
 	s.Require().NotNil(m)
 
-	s.Len(m.Body, 601)
+	s.Len(m.Body, 620)
 	s.Len(m.Headers, 1)
 }
 


### PR DESCRIPTION
[EVG-16350](https://jira.mongodb.org/browse/EVG-16350)

### Description 
Add MorgedFrom field so that when you enqueue patch from cli or ui, it will contain the patch id of the original patch it was based off

### Testing 
unit test

tested on spruce 
https://evergreen-staging.corp.mongodb.com/rest/v2/patches/623b949e97b1d310aeb0b06d

on cli 
https://evergreen-staging.corp.mongodb.com/rest/v2/patches/623cbaa19dbe3216e5c60c76