### PR TITLE
EVG-16541 allow empty list for workstation commands

### DIFF
--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -448,6 +448,24 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			require.Len(t, subsFromDb, 1)
 			assert.Equal(t, subsFromDb[0].Trigger, event.TriggerSuccess)
 		},
+		model.ProjectPageWorkstationsSection: func(t *testing.T, ref model.ProjectRef) {
+			assert.Nil(t, ref.WorkstationConfig.SetupCommands)
+			apiProjectRef := restModel.APIProjectRef{
+				WorkstationConfig: restModel.APIWorkstationConfig{
+					GitClone:      utility.TruePtr(),
+					SetupCommands: []restModel.APIWorkstationSetupCommand{}, // empty list should still save
+				},
+			}
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageWorkstationsSection, false, "me")
+			assert.NoError(t, err)
+			assert.NotNil(t, settings)
+			assert.NotNil(t, settings.ProjectRef.WorkstationConfig.SetupCommands)
+			assert.Empty(t, settings.ProjectRef.WorkstationConfig.SetupCommands)
+			assert.True(t, utility.FromBoolPtr(settings.ProjectRef.WorkstationConfig.GitClone))
+		},
 	} {
 		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
 			event.SubscriptionsCollection, event.AllLogCollection, evergreen.ScopeCollection, user.Collection))

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -381,6 +381,9 @@ type APIWorkstationSetupCommand struct {
 func (c *APIWorkstationConfig) ToService() (interface{}, error) {
 	res := model.WorkstationConfig{}
 	res.GitClone = utility.BoolPtrCopy(c.GitClone)
+	if c.SetupCommands != nil {
+		res.SetupCommands = []model.WorkstationSetupCommand{}
+	}
 	for _, apiCmd := range c.SetupCommands {
 		cmd := model.WorkstationSetupCommand{}
 		cmd.Command = utility.FromStringPtr(apiCmd.Command)
@@ -400,12 +403,16 @@ func (c *APIWorkstationConfig) BuildFromService(h interface{}) error {
 	}
 
 	c.GitClone = utility.BoolPtrCopy(config.GitClone)
+	if config.SetupCommands != nil {
+		c.SetupCommands = []APIWorkstationSetupCommand{}
+	}
 	for _, cmd := range config.SetupCommands {
 		apiCmd := APIWorkstationSetupCommand{}
 		apiCmd.Command = utility.ToStringPtr(cmd.Command)
 		apiCmd.Directory = utility.ToStringPtr(cmd.Directory)
 		c.SetupCommands = append(c.SetupCommands, apiCmd)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
[EVG-16541](https://jira.mongodb.org/browse/EVG-16541)

### Description 
Allow empty list for workstation commands instead of setting back to nil.

### Testing 
New unit test which failed without changes.
