### PR TITLE
EVG-15391 Allow non-admin users to override dependencies for patches

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -435,8 +435,12 @@ func (r *taskResolver) CanOverrideDependencies(ctx context.Context, at *restMode
 		RequiredLevel: evergreen.TasksAdmin.Value,
 		Resource:      *at.ProjectId,
 	}
-	if len(at.DependsOn) > 0 && (currentUser.HasPermission(requiredPermission) ||
-		utility.StringSliceContains(evergreen.PatchRequesters, utility.FromStringPtr(at.Requester))) {
+	overrideRequesters := []string{
+		evergreen.PatchVersionRequester,
+		evergreen.GithubPRRequester,
+	}
+	if len(at.DependsOn) > 0 && (utility.StringSliceContains(overrideRequesters, utility.FromStringPtr(at.Requester)) ||
+		currentUser.HasPermission(requiredPermission)) {
 		return true, nil
 	}
 	return false, nil

--- a/public/static/js/task_admin.js
+++ b/public/static/js/task_admin.js
@@ -25,6 +25,7 @@ mciModule.controller('AdminOptionsCtrl', ['$scope', '$window', '$rootScope', 'mc
         $scope.canSchedule = !$scope.task.activated && !$scope.canRestart && !$scope.isAborted;
         $scope.canUnschedule = $scope.task.activated && ($scope.task.status == "undispatched") ;
         $scope.canSetPriority = ($scope.task.status == "undispatched");
+        $scope.canOverrideDependencies = ($scope.task.r == "patch_request" || $scope.task.r == "github_pull_request" || $window.permissions.project_tasks>=30);
 	};
 
     function doModalSuccess(message, data, reload){

--- a/service/task.go
+++ b/service/task.go
@@ -769,7 +769,11 @@ func (uis *UIServer) taskModify(w http.ResponseWriter, r *http.Request) {
 		gimlet.WriteJSON(w, projCtx.Task)
 		return
 	case "override_dependencies":
-		if !projCtx.Task.IsPatchRequest() && !taskAdmin {
+		overrideRequesters := []string{
+			evergreen.PatchVersionRequester,
+			evergreen.GithubPRRequester,
+		}
+		if !utility.StringSliceContains(overrideRequesters, projCtx.Task.Requester) && !taskAdmin {
 			http.Error(w, "not authorized to override dependencies", http.StatusUnauthorized)
 			return
 		}

--- a/service/templates/task.html
+++ b/service/templates/task.html
@@ -142,7 +142,7 @@ Evergreen - {{Trunc .Task.Revision 10}} / {{.Task.BuildVariantDisplay}} / {{.Tas
                       <li>
                         <a tabindex="-1" href="#" ng-click="addSubscription()">Add Notification</a>
                       </li>
-                      <li ng-show="!task.override_dependencies && task.depends_on && task.depends_on.length > 0 && permissions.project_tasks>=30">
+                      <li ng-show="!task.override_dependencies && task.depends_on && task.depends_on.length > 0 && canOverrideDependencies">
                         <a tabindex="-1" href="#" ng-click="overrideDependencies()">Override Dependencies</a>
                       </li>
                     </ul>


### PR DESCRIPTION
[EVG-15391](https://jira.mongodb.org/browse/EVG-15391)

### Description 
non-admins can override dependencies in patches

### Testing 
tested on staging that non-admins can click the button (even on spruce) but cannot on waterfall tasks