### PR TITLE
EVG-16574 Return Previous commit status for base commits on mainline Commits

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1168,6 +1168,7 @@ type ComplexityRoot struct {
 		Order             func(childComplexity int) int
 		Parameters        func(childComplexity int) int
 		Patch             func(childComplexity int) int
+		PreviousVersion   func(childComplexity int) int
 		Project           func(childComplexity int) int
 		ProjectIdentifier func(childComplexity int) int
 		Repo              func(childComplexity int) int
@@ -1471,6 +1472,7 @@ type VersionResolver interface {
 	TaskCount(ctx context.Context, obj *model.APIVersion) (*int, error)
 	BaseVersionID(ctx context.Context, obj *model.APIVersion) (*string, error)
 	BaseVersion(ctx context.Context, obj *model.APIVersion) (*model.APIVersion, error)
+	PreviousVersion(ctx context.Context, obj *model.APIVersion) (*model.APIVersion, error)
 	VersionTiming(ctx context.Context, obj *model.APIVersion) (*VersionTiming, error)
 
 	TaskStatuses(ctx context.Context, obj *model.APIVersion) ([]string, error)
@@ -7158,6 +7160,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Version.Patch(childComplexity), true
 
+	case "Version.previousVersion":
+		if e.complexity.Version.PreviousVersion == nil {
+			break
+		}
+
+		return e.complexity.Version.PreviousVersion(childComplexity), true
+
 	case "Version.project":
 		if e.complexity.Version.Project == nil {
 			break
@@ -7716,6 +7725,7 @@ type Version {
   taskCount: Int
   baseVersionID: String @deprecated(reason: "baseVersionId is deprecated, use baseVersion.id instead")
   baseVersion: Version
+  previousVersion: Version
   versionTiming: VersionTiming
   parameters: [Parameter!]!
   taskStatuses: [String!]!
@@ -37526,6 +37536,38 @@ func (ec *executionContext) _Version_baseVersion(ctx context.Context, field grap
 	return ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Version_previousVersion(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Version",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Version().PreviousVersion(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.APIVersion)
+	fc.Result = res
+	return ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Version_versionTiming(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -49191,6 +49233,17 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 					}
 				}()
 				res = ec._Version_baseVersion(ctx, field, obj)
+				return res
+			})
+		case "previousVersion":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Version_previousVersion(ctx, field, obj)
 				return res
 			})
 		case "versionTiming":

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3459,8 +3459,7 @@ func (r *taskResolver) BaseTask(ctx context.Context, obj *restModel.APITask) (*r
 	if !ok {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Unable to convert APITask %s to Task", *obj.Id))
 	}
-	fmt.Println("Base task")
-	fmt.Println(t.BaseTask)
+
 	var baseTask *task.Task
 	// BaseTask is sometimes added via aggregation when Task is resolved via GetTasksByVersion.
 	if t.BaseTask.Id != "" {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3881,6 +3881,7 @@ func (r *versionResolver) BuildVariants(ctx context.Context, v *restModel.APIVer
 		opts := task.GetTasksByVersionOptions{
 			Sorts:                          defaultSort,
 			IncludeBaseTasks:               true,
+			IsMainlineCommit:               evergreen.IsPatchRequester(*v.Requester),
 			IncludeBuildVariantDisplayName: false, // we don't need to include buildVariantDisplayName here because this is only used to determine if a task has been activated
 		}
 		tasks, _, err := task.GetTasksByVersion(*v.Id, opts)

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -4056,7 +4056,7 @@ func (r *versionResolver) BaseVersion(ctx context.Context, obj *restModel.APIVer
 
 func (r *versionResolver) PreviousVersion(ctx context.Context, obj *restModel.APIVersion) (*restModel.APIVersion, error) {
 	if !evergreen.IsPatchRequester(utility.FromStringPtr(obj.Requester)) {
-		previousVersion, err := model.VersionFindOne(model.VersionByProjectIdAndOrder(utility.FromStringPtr(obj.Project), obj.Order-1).Sort([]string{"-" + model.VersionRevisionOrderNumberKey}))
+		previousVersion, err := model.VersionFindOne(model.VersionByProjectIdAndOrder(utility.FromStringPtr(obj.Project), obj.Order-1))
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding previous version for `%s`: %s", *obj.Id, err.Error()))
 		}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -4056,7 +4056,7 @@ func (r *versionResolver) BaseVersion(ctx context.Context, obj *restModel.APIVer
 
 func (r *versionResolver) PreviousVersion(ctx context.Context, obj *restModel.APIVersion) (*restModel.APIVersion, error) {
 	if !evergreen.IsPatchRequester(utility.FromStringPtr(obj.Requester)) {
-		previousVersion, err := model.VersionFindOne(model.VersionByProjectIdAndOrder(utility.FromStringPtr(obj.Project), obj.Order-1))
+		previousVersion, err := model.VersionFindOne(model.VersionByProjectIdAndOrder(utility.FromStringPtr(obj.Project), obj.Order-1).Sort([]string{"-" + model.VersionRevisionOrderNumberKey}))
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding previous version for `%s`: %s", *obj.Id, err.Error()))
 		}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1730,7 +1730,7 @@ func (r *queryResolver) PatchTasks(ctx context.Context, patchID string, sorts []
 			taskSorts = append(taskSorts, task.TasksSortOrder{Key: key, Order: order})
 		}
 	}
-	v, err := model.VersionFindOneId(patchID)
+	v, err := model.VersionFindOne(model.VersionById(patchID).WithFields(model.VersionRequesterKey))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while finding version with id: `%s`: %s", patchID, err.Error()))
 	}
@@ -3880,7 +3880,7 @@ func (r *versionResolver) BuildVariants(ctx context.Context, v *restModel.APIVer
 		opts := task.GetTasksByVersionOptions{
 			Sorts:                          defaultSort,
 			IncludeBaseTasks:               true,
-			IsMainlineCommit:               evergreen.IsPatchRequester(*v.Requester),
+			IsMainlineCommit:               evergreen.IsPatchRequester(utility.FromStringPtr(v.Requester)),
 			IncludeBuildVariantDisplayName: false, // we don't need to include buildVariantDisplayName here because this is only used to determine if a task has been activated
 		}
 		tasks, _, err := task.GetTasksByVersion(*v.Id, opts)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -228,6 +228,7 @@ type Version {
   taskCount: Int
   baseVersionID: String @deprecated(reason: "baseVersionId is deprecated, use baseVersion.id instead")
   baseVersion: Version
+  previousVersion: Version
   versionTiming: VersionTiming
   parameters: [Parameter!]!
   taskStatuses: [String!]!

--- a/graphql/tests/task/data.json
+++ b/graphql/tests/task/data.json
@@ -494,6 +494,28 @@
     {
       "_id": "generator_task",
       "display_name": "i am a generator"
+    },
+    {
+      "_id": "mainline_commit_2",
+      "display_name": "mainline_commit_task",
+      "branch": "spruce",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ac",
+      "version": "5e823e1f28baeaa22ae00823d83e03082cd148ac",
+      "r": "gitter_request",
+      "build_variant": "ubuntu1604",
+      "status": "success",
+      "order":2
+    },
+    {
+      "_id": "mainline_commit_1",
+      "display_name": "mainline_commit_task",
+      "branch": "spruce",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ad",
+      "version": "5e823e1f28baeaa22ae00823d83e03082cd148ad",
+      "r": "gitter_request",
+      "build_variant": "ubuntu1604",
+      "status": "failed",
+      "order": 1
     }
   ],
   "hosts": [

--- a/graphql/tests/task/queries/mainlineCommits-baseTask.graphql
+++ b/graphql/tests/task/queries/mainlineCommits-baseTask.graphql
@@ -1,0 +1,10 @@
+{
+    task(taskId: "mainline_commit_2"){
+        id
+        status
+        baseTask {
+            id
+            status
+        }
+    }
+}

--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -559,6 +559,21 @@
           }
         }
       }
+    },
+    {
+      "query_file": "mainlineCommits-baseTask.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "id": "mainline_commit_2",
+            "status": "success",
+            "baseTask": {
+              "id": "mainline_commit_1",
+              "status": "failed"
+            }
+          } 
+        }
+      }
     }
   ]
 }

--- a/graphql/tests/version/data.json
+++ b/graphql/tests/version/data.json
@@ -177,7 +177,43 @@
       "r": "gitter_request",
       "author_id": "trey.granderson"
     },
-    {"_id":"spruce_e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d","create_time":{"$date":{"$numberLong":"1608660785000"}},"start_time":{"$date":{"$numberLong":"1608660866659"}},"finish_time":{"$date":{"$numberLong":"1608664451646"}},"gitspec":"e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d","author":"Chaya Malik","author_email":"chaya.malik@mongodb.com","message":"EVG-13168 Display Issues and Suspected Issues (#560)","status":"success","order":{"$numberInt":"655"},"config":"","config_number":{"$numberInt":"0"},"ignored":false,"owner_name":"evergreen-ci","repo_name":"spruce","branch_name":"master","repo_kind":"github","build_variants_status":[{"build_variant":"ubuntu1604","build_id":"spruce_ubuntu1604_e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d_20_12_22_18_13_05","activated":true,"activate_at":{"$date":{"$numberLong":"1608660788454"}}}],"builds":["spruce_ubuntu1604_e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d_20_12_22_18_13_05"],"identifier":"spruce","remote":false,"remote_path":".evergreen.yml","r":"gitter_request","author_id":"chaya.malik"}
+    {"_id":"spruce_e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d","create_time":{"$date":{"$numberLong":"1608660785000"}},"start_time":{"$date":{"$numberLong":"1608660866659"}},"finish_time":{"$date":{"$numberLong":"1608664451646"}},"gitspec":"e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d","author":"Chaya Malik","author_email":"chaya.malik@mongodb.com","message":"EVG-13168 Display Issues and Suspected Issues (#560)","status":"success","order":{"$numberInt":"655"},"config":"","config_number":{"$numberInt":"0"},"ignored":false,"owner_name":"evergreen-ci","repo_name":"spruce","branch_name":"master","repo_kind":"github","build_variants_status":[{"build_variant":"ubuntu1604","build_id":"spruce_ubuntu1604_e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d_20_12_22_18_13_05","activated":true,"activate_at":{"$date":{"$numberLong":"1608660788454"}}}],"builds":["spruce_ubuntu1604_e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d_20_12_22_18_13_05"],"identifier":"spruce","remote":false,"remote_path":".evergreen.yml","r":"gitter_request","author_id":"chaya.malik"},
+    {
+	"_id" : "spruce_a7906eed65f88ae436ddb5c19096969f198a9efe",
+	"create_time" : {"$date": "2020-12-22T22:01:40Z"},
+	"start_time" : {"$date":"2020-12-22T22:04:51.380Z"},
+	"finish_time" : {"$date":"2020-12-23T01:46:43.817Z"},
+	"gitspec" : "a7906eed65f88ae436ddb5c19096969f198a9efe",
+	"author" : "Arjun Patel",
+	"author_email" : "arjun.patel@mongodb.com",
+	"message" : "EVG-13229: Project Patches Page (#555)",
+	"status" : "success",
+	"order" : 656,
+	"config" : "",
+	"config_number" : 0,
+	"ignored" : false,
+	"owner_name" : "evergreen-ci",
+	"repo_name" : "spruce",
+	"branch_name" : "master",
+	"repo_kind" : "github",
+	"build_variants_status" : [
+		{
+			"build_variant" : "ubuntu1604",
+			"build_id" : "spruce_ubuntu1604_a7906eed65f88ae436ddb5c19096969f198a9efe_20_12_22_22_01_40",
+			"activated" : true,
+			"activate_at" : {"$date": "2020-12-22T22:01:43.735Z"}
+		}
+	],
+	"builds" : [
+		"spruce_ubuntu1604_a7906eed65f88ae436ddb5c19096969f198a9efe_20_12_22_22_01_40"
+	],
+	"identifier" : "spruce",
+	"remote" : false,
+	"remote_path" : ".evergreen.yml",
+	"r" : "gitter_request",
+	"author_id" : "arjun.patel",
+	"activated" : true
+}
   ],
   "tasks": [
     {

--- a/graphql/tests/version/queries/previousVersion.graphql
+++ b/graphql/tests/version/queries/previousVersion.graphql
@@ -1,0 +1,8 @@
+{
+    version(id: "spruce_a7906eed65f88ae436ddb5c19096969f198a9efe"){
+        id
+        previousVersion {
+            id
+        }
+    }
+}

--- a/graphql/tests/version/results.json
+++ b/graphql/tests/version/results.json
@@ -110,6 +110,19 @@
           }
         }
       }
+    },
+    {
+      "query_file": "previousVersion.graphql",
+      "result": {
+        "data": {
+          "version": {
+              "id": "spruce_a7906eed65f88ae436ddb5c19096969f198a9efe",
+              "previousVersion": {
+                "id": "spruce_e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d"
+              }
+            }
+        }
+      }
     }
   ]
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -474,6 +474,18 @@ func ByCommit(revision, buildVariant, displayName, project, requester string) bs
 	}
 }
 
+// ByPreviousCommit creates a query on Evergreen as the requester on a previous revision with the same buildVariant, displayName and project
+func ByPreviousCommit(revision, buildVariant, displayName, project, requester string, order int) bson.M {
+	return bson.M{
+		RevisionKey:            revision,
+		RequesterKey:           requester,
+		BuildVariantKey:        buildVariant,
+		DisplayNameKey:         displayName,
+		ProjectKey:             project,
+		RevisionOrderNumberKey: order - 1,
+	}
+}
+
 func ByVersionsForNameAndVariant(versions, displayNames []string, buildVariant string) bson.M {
 	return bson.M{
 		VersionKey: bson.M{

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -475,9 +475,8 @@ func ByCommit(revision, buildVariant, displayName, project, requester string) bs
 }
 
 // ByPreviousCommit creates a query on Evergreen as the requester on a previous revision with the same buildVariant, displayName and project
-func ByPreviousCommit(revision, buildVariant, displayName, project, requester string, order int) bson.M {
+func ByPreviousCommit(buildVariant, displayName, project, requester string, order int) bson.M {
 	return bson.M{
-		RevisionKey:            revision,
 		RequesterKey:           requester,
 		BuildVariantKey:        buildVariant,
 		DisplayNameKey:         displayName,

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -839,7 +839,7 @@ func (t *Task) FindTaskOnBaseCommit() (*Task, error) {
 }
 
 func (t *Task) FindTaskOnPreviousCommit() (*Task, error) {
-	return FindOne(db.Query(ByPreviousCommit(t.Revision, t.BuildVariant, t.DisplayName, t.Project, evergreen.RepotrackerVersionRequester, t.RevisionOrderNumber)))
+	return FindOne(db.Query(ByPreviousCommit(t.BuildVariant, t.DisplayName, t.Project, evergreen.RepotrackerVersionRequester, t.RevisionOrderNumber)))
 }
 
 // FindIntermediateTasks returns the tasks from most recent to least recent between two tasks.
@@ -3532,7 +3532,9 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 		// If we are request a mainline commits base task we want to use the previous commit instead.
 		if opts.IsMainlineCommit {
 			baseCommitMatch = append(baseCommitMatch, bson.M{
-				"$lt": []string{"$" + RevisionOrderNumberKey, "$$" + RevisionOrderNumberKey},
+				"$eq": []interface{}{"$" + RevisionOrderNumberKey, bson.M{
+					"$subtract": []interface{}{"$$" + RevisionOrderNumberKey, 1},
+				}},
 			})
 		} else {
 			baseCommitMatch = append(baseCommitMatch, bson.M{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3529,7 +3529,7 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 			{"$eq": []string{"$" + DisplayNameKey, "$$" + DisplayNameKey}},
 		}
 
-		// If we are request a mainline commits base task we want to use the previous commit instead.
+		// If we are requesting a mainline commit's base task we want to use the previous commit instead.
 		if opts.IsMainlineCommit {
 			baseCommitMatch = append(baseCommitMatch, bson.M{
 				"$eq": []interface{}{"$" + RevisionOrderNumberKey, bson.M{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -838,6 +838,10 @@ func (t *Task) FindTaskOnBaseCommit() (*Task, error) {
 	return FindOne(db.Query(ByCommit(t.Revision, t.BuildVariant, t.DisplayName, t.Project, evergreen.RepotrackerVersionRequester)))
 }
 
+func (t *Task) FindTaskOnPreviousCommit() (*Task, error) {
+	return FindOne(db.Query(ByPreviousCommit(t.Revision, t.BuildVariant, t.DisplayName, t.Project, evergreen.RepotrackerVersionRequester, t.RevisionOrderNumber)))
+}
+
 // FindIntermediateTasks returns the tasks from most recent to least recent between two tasks.
 func (current *Task) FindIntermediateTasks(previous *Task) ([]Task, error) {
 	intermediateTasks, err := Find(ByIntermediateRevisions(previous.RevisionOrderNumber, current.RevisionOrderNumber, current.BuildVariant,
@@ -3097,6 +3101,7 @@ type GetTasksByVersionOptions struct {
 	IncludeBaseTasks               bool
 	IncludeEmptyActivation         bool
 	IncludeBuildVariantDisplayName bool
+	IsMainlineCommit               bool
 }
 
 // GetTasksByVersion gets all tasks for a specific version
@@ -3519,25 +3524,37 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 		addDisplayStatus,
 	)
 	if opts.IncludeBaseTasks {
+		baseCommitMatch := []bson.M{
+			{"$eq": []string{"$" + BuildVariantKey, "$$" + BuildVariantKey}},
+			{"$eq": []string{"$" + DisplayNameKey, "$$" + DisplayNameKey}},
+		}
+
+		// If we are request a mainline commits base task we want to use the previous commit instead.
+		if opts.IsMainlineCommit {
+			baseCommitMatch = append(baseCommitMatch, bson.M{
+				"$lt": []string{"$" + RevisionOrderNumberKey, "$$" + RevisionOrderNumberKey},
+			})
+		} else {
+			baseCommitMatch = append(baseCommitMatch, bson.M{
+				"$eq": []string{"$" + RevisionKey, "$$" + RevisionKey},
+			})
+		}
 		pipeline = append(pipeline, []bson.M{
 			// Add data about the base task
 			{"$lookup": bson.M{
 				"from": Collection,
 				"let": bson.M{
-					RevisionKey:     "$" + RevisionKey,
-					BuildVariantKey: "$" + BuildVariantKey,
-					DisplayNameKey:  "$" + DisplayNameKey,
+					RevisionKey:            "$" + RevisionKey,
+					BuildVariantKey:        "$" + BuildVariantKey,
+					DisplayNameKey:         "$" + DisplayNameKey,
+					RevisionOrderNumberKey: "$" + RevisionOrderNumberKey,
 				},
 				"as": BaseTaskKey,
 				"pipeline": []bson.M{
 					{"$match": bson.M{
 						RequesterKey: evergreen.RepotrackerVersionRequester,
 						"$expr": bson.M{
-							"$and": []bson.M{
-								{"$eq": []string{"$" + RevisionKey, "$$" + RevisionKey}},
-								{"$eq": []string{"$" + BuildVariantKey, "$$" + BuildVariantKey}},
-								{"$eq": []string{"$" + DisplayNameKey, "$$" + DisplayNameKey}},
-							},
+							"$and": baseCommitMatch,
 						},
 					}},
 					{"$project": bson.M{

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2471,6 +2471,7 @@ func TestGetTasksByVersionBaseTasks(t *testing.T) {
 		Status:              evergreen.TaskSucceeded,
 		RevisionOrderNumber: 1,
 		Requester:           evergreen.RepotrackerVersionRequester,
+		Revision:            "abc123",
 	}
 	t2 := Task{
 		Id:           "t2",
@@ -2480,6 +2481,7 @@ func TestGetTasksByVersionBaseTasks(t *testing.T) {
 		Execution:    0,
 		Status:       evergreen.TaskFailed,
 		Requester:    evergreen.GithubPRRequester,
+		Revision:     "abc123",
 	}
 
 	t3 := Task{
@@ -2491,6 +2493,7 @@ func TestGetTasksByVersionBaseTasks(t *testing.T) {
 		Status:              evergreen.TaskFailed,
 		RevisionOrderNumber: 2,
 		Requester:           evergreen.RepotrackerVersionRequester,
+		Revision:            "abc125",
 	}
 	assert.NoError(t, db.InsertMany(Collection, t1, t2, t3))
 

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -128,7 +128,7 @@ func VersionByProjectIdAndOrder(projectId string, revisionOrderNumber int) db.Q 
 			VersionRequesterKey: bson.M{
 				"$in": evergreen.SystemVersionRequesterTypes,
 			},
-		})
+		}).Sort([]string{"-" + VersionRevisionOrderNumberKey})
 }
 
 // ByLastVariantActivation finds the most recent non-patch, non-ignored


### PR DESCRIPTION
[EVG-16574](https://jira.mongodb.org/browse/EVG-16574)

### Description 
The base task field will now return the previously run commits status for a particular task for mainline commits

### Testing 
On staging and locally and with tests
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/4605522/160155652-fdb6fc72-ee00-4fa5-b41f-53aee00bbdd0.png">
