### PR TITLE
EVG-16401 Lower permission requirements for copy projects API

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -156,7 +156,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}/detach_from_repo").Version(2).Post().Wrap(requireUser, addProject, requireProjectAdmin, editProjectSettings).RouteHandler(makeDetachProjectFromRepoHandler())
 	app.AddRoute("/projects/{project_id}/repotracker").Version(2).Post().Wrap(requireUser, addProject).RouteHandler(makeRunRepotrackerForProject())
 	app.AddRoute("/projects/{project_id}").Version(2).Put().Wrap(createProject).RouteHandler(makePutProjectByID())
-	app.AddRoute("/projects/{project_id}/copy").Version(2).Post().Wrap(requireUser, addProject, createProject, requireProjectAdmin, editProjectSettings).RouteHandler(makeCopyProject())
+	app.AddRoute("/projects/{project_id}/copy").Version(2).Post().Wrap(requireUser, addProject, requireProjectAdmin, editProjectSettings).RouteHandler(makeCopyProject())
 	app.AddRoute("/projects/{project_id}/copy/variables").Version(2).Post().Wrap(requireUser, addProject, requireProjectAdmin, editProjectSettings).RouteHandler(makeCopyVariables())
 	app.AddRoute("/projects/{project_id}/events").Version(2).Get().Wrap(requireUser, addProject, requireProjectAdmin, viewProjectSettings).RouteHandler(makeFetchProjectEvents(opts.URL))
 	app.AddRoute("/projects/{project_id}/patches").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makePatchesByProjectRoute(opts.URL))


### PR DESCRIPTION
[EVG-16401](https://jira.mongodb.org/browse/EVG-16401)

### Description 
This removes the createProject middleware which is what makes user require superUser access to use the copyProject route. We don't want that, we want anyone with admin access to be able to copy a project. 

### Testing 
none
