### PR TITLE
EVG-16233: add method to dispatch next container task

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1665,7 +1665,7 @@ func (r *queryResolver) ViewableProjectRefs(ctx context.Context) ([]*GroupedProj
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error getting viewable projects for '%s': '%s'", usr.DispName, err.Error()))
 	}
 
-	projects, err := model.FindProjectRefsByIds(projectIds)
+	projects, err := model.FindProjectRefsByIds(projectIds...)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting projects: %v", err.Error()))
 	}

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -76,7 +76,10 @@ func (e *Environment) Configure(ctx context.Context) error {
 
 	e.JasperProcessManager = jpm
 
-	e.MongoClient, err = mongo.Connect(ctx, options.Client().ApplyURI(e.EvergreenSettings.Database.Url))
+	e.MongoClient, err = mongo.Connect(ctx, options.Client().
+		ApplyURI(e.EvergreenSettings.Database.Url).
+		SetWriteConcern(e.EvergreenSettings.Database.WriteConcernSettings.Resolve()).
+		SetReadConcern(e.EvergreenSettings.Database.ReadConcernSettings.Resolve()))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -152,7 +152,7 @@ func (q *ContainerTaskQueue) getProjectRefs(tasks []task.Task) (map[string]Proje
 		return map[string]ProjectRef{}, nil
 	}
 
-	projRefs, err := FindProjectRefsByIds(projRefIDs)
+	projRefs, err := FindProjectRefsByIds(projRefIDs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project refs for tasks")
 	}

--- a/model/event/pod.go
+++ b/model/event/pod.go
@@ -18,8 +18,11 @@ const (
 	// ResourceTypePod represents a pod as a resource associated with events.
 	ResourceTypePod = "POD"
 
+	// EventPodStatusChange represents an event where a pod's status is
+	// modified.
 	EventPodStatusChange PodEventType = "STATUS_CHANGE"
-	// EventPodAssignedTask represents an event where a pod is assigned a task to run.
+	// EventPodAssignedTask represents an event where a pod is assigned a task
+	// to run.
 	EventPodAssignedTask PodEventType = "ASSIGNED_TASK"
 )
 

--- a/model/event/pod.go
+++ b/model/event/pod.go
@@ -19,12 +19,16 @@ const (
 	ResourceTypePod = "POD"
 
 	EventPodStatusChange PodEventType = "STATUS_CHANGE"
+	// EventPodAssignedTask represents an event where a pod is assigned a task
+	// to run.
+	EventPodAssignedTask PodEventType = "ASSIGNED_TASK"
 )
 
 // podData contains information relevant to a pod event.
 type podData struct {
 	OldStatus string `bson:"old_status,omitempty" json:"old_status,omitempty"`
 	NewStatus string `bson:"new_status,omitempty" json:"new_status,omitempty"`
+	TaskID    string `bson:"task_id,omitempty" json:"task_id,omitempty"`
 }
 
 // LogPodEvent logs an event for a pod to the event log.
@@ -56,4 +60,10 @@ func LogPodStatusChanged(id, oldStatus, newStatus string) {
 		OldStatus: oldStatus,
 		NewStatus: newStatus,
 	})
+}
+
+// LogPodAssignedTask logs an event indicating that the pod has been assigned a
+// task to run.
+func LogPodAssignedTask(id, taskID string) {
+	LogPodEvent(id, EventPodAssignedTask, podData{TaskID: taskID})
 }

--- a/model/event/pod.go
+++ b/model/event/pod.go
@@ -19,8 +19,7 @@ const (
 	ResourceTypePod = "POD"
 
 	EventPodStatusChange PodEventType = "STATUS_CHANGE"
-	// EventPodAssignedTask represents an event where a pod is assigned a task
-	// to run.
+	// EventPodAssignedTask represents an event where a pod is assigned a task to run.
 	EventPodAssignedTask PodEventType = "ASSIGNED_TASK"
 )
 

--- a/model/event/pod_test.go
+++ b/model/event/pod_test.go
@@ -27,6 +27,21 @@ func TestPodEvents(t *testing.T) {
 			assert.Equal(t, oldStatus, data.OldStatus)
 			assert.Equal(t, newStatus, data.NewStatus)
 		},
+		"LogPodAssignedTask": func(t *testing.T) {
+			podID := "pod_id"
+			taskID := "task_id"
+			LogPodAssignedTask(podID, taskID)
+
+			events, err := Find(AllLogCollection, MostRecentPodEvents(podID, 10))
+			require.NoError(t, err)
+			require.Len(t, events, 1)
+
+			assert.Equal(t, podID, events[0].ResourceId)
+			require.NotZero(t, events[0].Data)
+			data, ok := events[0].Data.(*podData)
+			require.True(t, ok)
+			assert.Equal(t, taskID, data.TaskID)
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.Clear(AllLogCollection))

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -42,7 +42,7 @@ const (
 type TaskEventData struct {
 	Execution int    `bson:"execution" json:"execution"`
 	HostId    string `bson:"h_id,omitempty" json:"host_id,omitempty"`
-	PodID     string `bson:"pod_id,omitempty", json:"pod_id,omitempty"`
+	PodID     string `bson:"pod_id,omitempty" json:"pod_id,omitempty"`
 	UserId    string `bson:"u_id,omitempty" json:"user_id,omitempty"`
 	Status    string `bson:"s,omitempty" json:"status,omitempty"`
 	JiraIssue string `bson:"jira,omitempty" json:"jira,omitempty"`

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -42,6 +42,7 @@ const (
 type TaskEventData struct {
 	Execution int    `bson:"execution" json:"execution"`
 	HostId    string `bson:"h_id,omitempty" json:"host_id,omitempty"`
+	PodID     string `bson:"pod_id,omitempty", json:"pod_id,omitempty"`
 	UserId    string `bson:"u_id,omitempty" json:"user_id,omitempty"`
 	Status    string `bson:"s,omitempty" json:"status,omitempty"`
 	JiraIssue string `bson:"jira,omitempty" json:"jira,omitempty"`
@@ -108,12 +109,26 @@ func LogTaskCreated(taskId string, execution int) {
 	logTaskEvent(taskId, TaskCreated, TaskEventData{Execution: execution})
 }
 
-func LogTaskDispatched(taskId string, execution int, hostId string) {
+// LogHostTaskDispatched logs an event for a host task being dispatched.
+func LogHostTaskDispatched(taskId string, execution int, hostId string) {
 	logTaskEvent(taskId, TaskDispatched, TaskEventData{Execution: execution, HostId: hostId})
 }
 
-func LogTaskUndispatched(taskId string, execution int, hostId string) {
+// LogContainerTaskDispatched logs an event for a container task being
+// dispatched to a pod.
+func LogContainerTaskDispatched(taskID string, execution int, podID string) {
+	logTaskEvent(taskID, TaskDispatched, TaskEventData{Execution: execution, PodID: podID})
+}
+
+// LogHostTaskUndispatched logs an event for a host being marked undispatched.
+func LogHostTaskUndispatched(taskId string, execution int, hostId string) {
 	logTaskEvent(taskId, TaskUndispatched, TaskEventData{Execution: execution, HostId: hostId})
+}
+
+// LogContainerTaskDispatched logs an event for a container task being marked
+// unallocated.
+func LogContainerTaskUnallocated(taskID string, execution int, podID string) {
+	logTaskEvent(taskID, TaskUndispatched, TaskEventData{Execution: execution, PodID: podID})
 }
 
 func LogTaskStarted(taskId string, execution int) {

--- a/model/event/task_event_test.go
+++ b/model/event/task_event_test.go
@@ -30,9 +30,9 @@ func TestLoggingTaskEvents(t *testing.T) {
 
 			LogTaskCreated(taskId, 1)
 			time.Sleep(1 * time.Millisecond)
-			LogTaskDispatched(taskId, 1, hostId)
+			LogHostTaskDispatched(taskId, 1, hostId)
 			time.Sleep(1 * time.Millisecond)
-			LogTaskUndispatched(taskId, 1, hostId)
+			LogHostTaskUndispatched(taskId, 1, hostId)
 			time.Sleep(1 * time.Millisecond)
 			LogTaskStarted(taskId, 1)
 			time.Sleep(1 * time.Millisecond)

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -17,10 +17,12 @@ const (
 
 var (
 	IDKey                        = bsonutil.MustHaveTag(Pod{}, "ID")
+	TypeKey                      = bsonutil.MustHaveTag(Pod{}, "Type")
 	StatusKey                    = bsonutil.MustHaveTag(Pod{}, "Status")
 	TaskContainerCreationOptsKey = bsonutil.MustHaveTag(Pod{}, "TaskContainerCreationOpts")
 	TimeInfoKey                  = bsonutil.MustHaveTag(Pod{}, "TimeInfo")
 	ResourcesKey                 = bsonutil.MustHaveTag(Pod{}, "Resources")
+	RunningTaskKey               = bsonutil.MustHaveTag(Pod{}, "RunningTask")
 
 	TaskContainerCreationOptsImageKey    = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "Image")
 	TaskContainerCreationOptsMemoryMBKey = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "MemoryMB")

--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -139,10 +139,3 @@ func Allocate(ctx context.Context, env evergreen.Environment, t *task.Task, p *p
 
 	return pd, nil
 }
-
-// GetGroupID returns the pod dispatcher group ID for the task.
-func GetGroupID(t *task.Task) string {
-	// TODO (PM-2618): handle task units that represent task groups rather than
-	// standalone tasks.
-	return t.Id
-}

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -1,10 +1,21 @@
 package dispatcher
 
 import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/pod"
+	"github.com/evergreen-ci/evergreen/model/task"
 	adb "github.com/mongodb/anser/db"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // PodDispatcher represents a set of tasks that are dispatched to a set of pods
@@ -73,4 +84,158 @@ func (pd *PodDispatcher) UpsertAtomically() (*adb.ChangeInfo, error) {
 	}
 	pd.ModificationCount++
 	return change, nil
+}
+
+// AssignNextTask assigns the given pod the next available task to run.
+// kim: TODO: test
+func (pd *PodDispatcher) AssignNextTask(p *pod.Pod) (*task.Task, error) {
+	// kim: NOTE: all DB ops should be atomic and double-check state. Maybe need
+	// to use transaction.
+	env := evergreen.GetEnvironment()
+	ctx, cancel := env.Context()
+	defer cancel()
+
+	grip.WarningWhen(len(pd.TaskIDs) > 1, message.Fields{
+		"message":    "programmatic error: task groups are not supported yet, so dispatcher should have at most 1 container task to dispatch",
+		"pod":        p.ID,
+		"dispatcher": pd.ID,
+		"tasks":      pd.TaskIDs,
+	})
+	for len(pd.TaskIDs) > 0 {
+		taskID := pd.TaskIDs[0]
+		t, err := task.FindOneId(taskID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding task '%s'", taskID)
+		}
+		if t == nil {
+			// Task does not exist, so just dequeue it.
+			if err := pd.pop(ctx, env); err != nil {
+				return nil, errors.Wrapf(err, "popping nonexistent task '%s' from dispatch queue", taskID)
+			}
+			grip.Notice(message.Fields{
+				"message":    "task does not exist - removing it from the dispatch queue",
+				"outcome":    "dequeueing",
+				"context":    "pod group task dispatcher",
+				"pod":        p.ID,
+				"task":       taskID,
+				"dispatcher": pd.ID,
+			})
+			continue
+		}
+
+		if !t.IsContainerDispatchable() {
+			grip.Notice(message.Fields{
+				"message":    "task in dispatch queue is not dispatchable",
+				"outcome":    "dequeueing",
+				"context":    "pod group task dispatcher",
+				"pod":        p.ID,
+				"task":       taskID,
+				"dispatcher": pd.ID,
+			})
+			if err := pd.pop(ctx, env); err != nil {
+				return nil, errors.Wrapf(err, "popping undispatchable task '%s' from dispatch queue", taskID)
+			}
+			continue
+		}
+
+		// kim: TODO: Check if task is runnable (status is container allocated,
+		// activated, not disabled, dependencies are met) and not disabled by
+		// project - if not, dequeue task. If task is not in runnable state
+		// (i.e. container-allocated, activated, not disabled, dependencies
+		// met), it should be safe to dequeue the task since any
+		// container-unallocated task would later allocate until it's finally
+		// container-allocated.
+		refs, err := model.FindProjectRefsByIds(t.Project)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding project ref '%s' for task '%s'", t.Project, t.Id)
+		}
+		if len(refs) == 0 {
+			grip.Notice(message.Fields{
+				"message":    "project ref does not exist for task in dispatch queue",
+				"outcome":    "dequeueing",
+				"context":    "pod group task dispatcher",
+				"pod":        p.ID,
+				"task":       t.Id,
+				"project":    t.Project,
+				"dispatcher": pd.ID,
+			})
+			// Project does not exist, so dequeue the task.
+			if err := pd.pop(ctx, env); err != nil {
+				return nil, errors.Wrapf(err, "popping task '%s' with nonexistent project ref '%s'", t.Id, t.Project)
+			}
+			continue
+		}
+		ref := refs[0]
+
+		// Disabled projects generally are not allowed to run tasks. The one
+		// exception is that GitHub PR tasks are still allowed to run for
+		// disabled hidden projects.
+		if !ref.IsEnabled() && (t.Requester != evergreen.GithubPRRequester || !ref.IsHidden()) {
+			return nil, errors.Wrapf(err, "popping task '%s' when its project ref '%s' is disabled", t.Id, ref.Id)
+		}
+		if ref.IsDispatchingDisabled() {
+			if err := pd.pop(ctx, env); err != nil {
+				return nil, errors.Wrapf(err, "popping task '%s' when its project ref '%s' has disabled dispatching", t.Id, ref.Id)
+			}
+			continue
+		}
+
+		session, err := env.Client().StartSession()
+		if err != nil {
+			return nil, errors.Wrap(err, "starting transaction session")
+		}
+		defer session.EndSession(ctx)
+
+		dispatchTaskToPod := func(sesCtx mongo.SessionContext) (interface{}, error) {
+			if err := p.SetRunningTask(ctx, env, t.Id); err != nil {
+				return nil, errors.Wrap(err, "setting pod's running task")
+			}
+
+			if err := t.MarkAsContainerDispatched(ctx, env); err != nil {
+				return nil, errors.Wrap(err, "marking task as dispatched")
+			}
+
+			if err := pd.pop(ctx, env); err != nil {
+				return nil, errors.Wrap(err, "popping task from dispatch queue")
+			}
+
+			return nil, nil
+		}
+
+		if _, err := session.WithTransaction(ctx, dispatchTaskToPod); err != nil {
+			return nil, errors.Wrapf(err, "dispatching task '%s' to pod '%s'", t.Id, p.ID)
+		}
+
+		event.LogPodAssignedTask(p.ID, taskID)
+
+		return t, nil
+	}
+
+	return nil, nil
+}
+
+// kim: TODO: test
+func (pd *PodDispatcher) pop(ctx context.Context, env evergreen.Environment) (err error) {
+	oldTaskIDs := pd.TaskIDs
+	pd.TaskIDs = pd.TaskIDs[1:]
+	defer func() {
+		if err != nil {
+			pd.TaskIDs = oldTaskIDs
+		}
+	}()
+	res, err := env.DB().Collection(Collection).UpdateOne(ctx, pd.atomicUpsertQuery(), pd.atomicUpsertUpdate())
+	if err != nil {
+		return errors.Wrap(err, "upserting dispatcher")
+	}
+	if res.ModifiedCount == 0 {
+		return errors.New("dispatcher was not updated")
+	}
+	return nil
+}
+
+// GetGroupID returns the pod dispatcher group ID for the task.
+func GetGroupID(t *task.Task) string {
+	// TODO (PM-2618): handle task units that represent task groups rather than
+	// standalone tasks.
+	return t.Id
 }

--- a/model/pod/dispatcher/dispatcher_test.go
+++ b/model/pod/dispatcher/dispatcher_test.go
@@ -125,6 +125,9 @@ func TestAssignNextTask(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
 	defer func() {
 		assert.NoError(t, db.ClearCollections(Collection, pod.Collection, task.Collection, event.AllLogCollection))
 	}()
@@ -288,6 +291,7 @@ func TestAssignNextTask(t *testing.T) {
 			require.NotZero(t, nextTask)
 			assert.Equal(t, dispatchableTask0.Id, nextTask.Id)
 
+			checkTaskUnallocated(t, params.task)
 			checkTaskDispatchedToPod(t, dispatchableTask0, params.pod)
 			checkDispatcherTasks(t, params.dispatcher, []string{dispatchableTask1.Id})
 		},
@@ -362,13 +366,7 @@ func TestAssignNextTask(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 10*time.Second)
-			defer tcancel()
-
 			require.NoError(t, db.ClearCollections(Collection, pod.Collection, task.Collection, event.AllLogCollection))
-
-			env := &mock.Environment{}
-			require.NoError(t, env.Configure(tctx))
 
 			p := pod.Pod{
 				ID:           utility.RandomString(),

--- a/model/pod/dispatcher/dispatcher_test.go
+++ b/model/pod/dispatcher/dispatcher_test.go
@@ -1,9 +1,17 @@
 package dispatcher
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/pod"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
@@ -109,6 +117,276 @@ func TestUpsertAtomically(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(Collection))
 			tCase(t, NewPodDispatcher("group0", []string{"task0"}, []string{"pod0"}))
+		})
+	}
+}
+
+func TestAssignNextTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection, pod.Collection, task.Collection, event.AllLogCollection))
+	}()
+	getDispatchableTask := func() task.Task {
+		return task.Task{
+			Id:                utility.RandomString(),
+			Activated:         true,
+			ActivatedTime:     time.Now(),
+			Status:            evergreen.TaskContainerAllocated,
+			ExecutionPlatform: task.ExecutionPlatformContainer,
+			DisplayTaskId:     utility.ToStringPtr(""),
+		}
+	}
+	getProjectRef := func() model.ProjectRef {
+		return model.ProjectRef{
+			Id:         utility.RandomString(),
+			Identifier: utility.RandomString(),
+			Enabled:    utility.TruePtr(),
+		}
+	}
+
+	type testCaseParams struct {
+		env        evergreen.Environment
+		dispatcher PodDispatcher
+		pod        pod.Pod
+		task       task.Task
+		ref        model.ProjectRef
+	}
+
+	checkTaskDispatchedToPod := func(t *testing.T, tsk task.Task, p pod.Pod) {
+		dbTask, err := task.FindOneId(tsk.Id)
+		require.NoError(t, err)
+		require.NotZero(t, dbTask)
+		assert.Equal(t, evergreen.TaskDispatched, dbTask.Status)
+		assert.False(t, utility.IsZeroTime(dbTask.DispatchTime))
+		assert.False(t, utility.IsZeroTime(dbTask.LastHeartbeat))
+		assert.Equal(t, p.AgentVersion, dbTask.AgentVersion)
+
+		dbPod, err := pod.FindOneByID(p.ID)
+		require.NoError(t, err)
+		require.NotZero(t, dbPod)
+		assert.Equal(t, tsk.Id, dbPod.RunningTask)
+
+		taskEvents, err := event.FindAllByResourceID(dbTask.Id)
+		require.NoError(t, err)
+		require.Len(t, taskEvents, 1)
+		assert.Equal(t, event.TaskDispatched, taskEvents[0].EventType)
+
+		podEvents, err := event.FindAllByResourceID(p.ID)
+		require.NoError(t, err)
+		require.Len(t, podEvents, 1)
+		assert.Equal(t, string(event.EventPodAssignedTask), podEvents[0].EventType)
+	}
+
+	checkTaskUnallocated := func(t *testing.T, tsk task.Task) {
+		dbTask, err := task.FindOneId(tsk.Id)
+		require.NoError(t, err)
+		require.NotZero(t, dbTask)
+		assert.Equal(t, evergreen.TaskContainerUnallocated, dbTask.Status)
+	}
+
+	checkDispatcherTasks := func(t *testing.T, pd PodDispatcher, taskIDs []string) {
+		dbDispatcher, err := FindOneByID(pd.ID)
+		require.NoError(t, err)
+		require.NotZero(t, dbDispatcher)
+
+		require.Len(t, pd.TaskIDs, len(taskIDs))
+		for i := range taskIDs {
+			assert.Equal(t, taskIDs[i], pd.TaskIDs[i])
+		}
+	}
+
+	for tName, tCase := range map[string]func(t *testing.T, params testCaseParams){
+		"DispatchesTask": func(t *testing.T, params testCaseParams) {
+			require.NoError(t, params.dispatcher.Insert())
+			require.NoError(t, params.pod.Insert())
+			require.NoError(t, params.task.Insert())
+			require.NoError(t, params.ref.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			require.NoError(t, err)
+			require.NotZero(t, nextTask)
+			assert.Equal(t, params.task.Id, nextTask.Id)
+
+			checkTaskDispatchedToPod(t, params.task, params.pod)
+			checkDispatcherTasks(t, params.dispatcher, nil)
+		},
+		"DispatchesTaskInDisabledHiddenProject": func(t *testing.T, params testCaseParams) {
+			params.task.Requester = evergreen.GithubPRRequester
+			params.ref.Enabled = utility.FalsePtr()
+			params.ref.Hidden = utility.TruePtr()
+			require.NoError(t, params.dispatcher.Insert())
+			require.NoError(t, params.pod.Insert())
+			require.NoError(t, params.task.Insert())
+			require.NoError(t, params.ref.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			require.NoError(t, err)
+			require.NotZero(t, nextTask)
+			assert.Equal(t, params.task.Id, nextTask.Id)
+
+			checkTaskDispatchedToPod(t, params.task, params.pod)
+			checkDispatcherTasks(t, params.dispatcher, nil)
+		},
+		"DequeuesNonexistentTaskAndDoesNotDispatchIt": func(t *testing.T, params testCaseParams) {
+			require.NoError(t, params.dispatcher.Insert())
+			require.NoError(t, params.pod.Insert())
+			require.NoError(t, params.ref.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			assert.NoError(t, err)
+			assert.Zero(t, nextTask)
+
+			dbTask, err := task.FindOneId(params.task.Id)
+			assert.NoError(t, err)
+			assert.Zero(t, dbTask)
+			checkDispatcherTasks(t, params.dispatcher, nil)
+		},
+		"DequeuesTaskWithNonexistentProjectAndDoesNotDispatchIt": func(t *testing.T, params testCaseParams) {
+			require.NoError(t, params.task.Insert())
+			require.NoError(t, params.dispatcher.Insert())
+			require.NoError(t, params.pod.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			assert.NoError(t, err)
+			assert.Zero(t, nextTask)
+
+			checkTaskUnallocated(t, params.task)
+			checkDispatcherTasks(t, params.dispatcher, nil)
+		},
+		"DequeuesDeactivatedTaskAndDoesNotDispatchIt": func(t *testing.T, params testCaseParams) {
+			params.task.Activated = false
+			require.NoError(t, params.dispatcher.Insert())
+			require.NoError(t, params.pod.Insert())
+			require.NoError(t, params.task.Insert())
+			require.NoError(t, params.ref.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			assert.NoError(t, err)
+			assert.Zero(t, nextTask)
+
+			checkTaskUnallocated(t, params.task)
+			checkDispatcherTasks(t, params.dispatcher, nil)
+		},
+		"DequeuesUndispatchableTaskAndReturnsNextDispatchableTask": func(t *testing.T, params testCaseParams) {
+			params.task.Activated = false
+			dispatchableTask0 := getDispatchableTask()
+			dispatchableTask0.Project = params.ref.Id
+			dispatchableTask1 := getDispatchableTask()
+			dispatchableTask1.Project = params.ref.Id
+			params.dispatcher.TaskIDs = append(params.dispatcher.TaskIDs, dispatchableTask0.Id, dispatchableTask1.Id)
+			require.NoError(t, params.dispatcher.Insert())
+			require.NoError(t, params.pod.Insert())
+			require.NoError(t, params.task.Insert())
+			require.NoError(t, dispatchableTask0.Insert())
+			require.NoError(t, dispatchableTask1.Insert())
+			require.NoError(t, params.ref.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			require.NoError(t, err)
+			require.NotZero(t, nextTask)
+			assert.Equal(t, dispatchableTask0.Id, nextTask.Id)
+
+			checkTaskDispatchedToPod(t, dispatchableTask0, params.pod)
+			checkDispatcherTasks(t, params.dispatcher, []string{dispatchableTask1.Id})
+		},
+		"DequeuesTaskWithUndispatchableStatusAndDoesNotDispatchIt": func(t *testing.T, params testCaseParams) {
+			require.NoError(t, params.pod.Insert())
+			params.task.Status = evergreen.TaskContainerUnallocated
+			require.NoError(t, params.task.Insert())
+			require.NoError(t, params.ref.Insert())
+			require.NoError(t, params.dispatcher.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			assert.NoError(t, err)
+			assert.Zero(t, nextTask)
+
+			checkTaskUnallocated(t, params.task)
+			checkDispatcherTasks(t, params.dispatcher, nil)
+		},
+		"DequeuesDisabledTaskAndDoesNotDispatchIt": func(t *testing.T, params testCaseParams) {
+			require.NoError(t, params.pod.Insert())
+			params.task.Priority = evergreen.DisabledTaskPriority
+			require.NoError(t, params.task.Insert())
+			require.NoError(t, params.ref.Insert())
+			require.NoError(t, params.dispatcher.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			assert.NoError(t, err)
+			assert.Zero(t, nextTask)
+
+			checkTaskUnallocated(t, params.task)
+			checkDispatcherTasks(t, params.dispatcher, nil)
+		},
+		"DequeuesTaskInDisabledProjectAndDoesNotDispatchIt": func(t *testing.T, params testCaseParams) {
+			params.ref.Enabled = utility.FalsePtr()
+			require.NoError(t, params.pod.Insert())
+			require.NoError(t, params.task.Insert())
+			require.NoError(t, params.ref.Insert())
+			require.NoError(t, params.dispatcher.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			assert.NoError(t, err)
+			assert.Zero(t, nextTask)
+
+			checkTaskUnallocated(t, params.task)
+			checkDispatcherTasks(t, params.dispatcher, nil)
+		},
+		"DequeuesTaskInProjectWithDispatchingDisabledAndDoesNotDispatchIt": func(t *testing.T, params testCaseParams) {
+			params.ref.DispatchingDisabled = utility.TruePtr()
+			require.NoError(t, params.pod.Insert())
+			require.NoError(t, params.task.Insert())
+			require.NoError(t, params.ref.Insert())
+			require.NoError(t, params.dispatcher.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			assert.NoError(t, err)
+			assert.Zero(t, nextTask)
+
+			checkTaskUnallocated(t, params.task)
+			checkDispatcherTasks(t, params.dispatcher, nil)
+		},
+		"FailsWithPodInStateThatCannotRunTasks": func(t *testing.T, params testCaseParams) {
+			params.pod.Status = pod.StatusDecommissioned
+			require.NoError(t, params.pod.Insert())
+			require.NoError(t, params.task.Insert())
+			require.NoError(t, params.ref.Insert())
+			require.NoError(t, params.dispatcher.Insert())
+
+			nextTask, err := params.dispatcher.AssignNextTask(params.env, &params.pod)
+			assert.Error(t, err)
+			assert.Zero(t, nextTask)
+
+			checkDispatcherTasks(t, params.dispatcher, []string{params.task.Id})
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, 10*time.Second)
+			defer tcancel()
+
+			require.NoError(t, db.ClearCollections(Collection, pod.Collection, task.Collection, event.AllLogCollection))
+
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(tctx))
+
+			p := pod.Pod{
+				ID:           utility.RandomString(),
+				Status:       pod.StatusRunning,
+				AgentVersion: evergreen.AgentVersion,
+			}
+			tsk := getDispatchableTask()
+			ref := getProjectRef()
+			tsk.Project = ref.Id
+			pd := NewPodDispatcher(GetGroupID(&tsk), []string{tsk.Id}, []string{p.ID})
+
+			tCase(t, testCaseParams{
+				env:        env,
+				dispatcher: pd,
+				pod:        p,
+				task:       tsk,
+				ref:        ref,
+			})
 		})
 	}
 }

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -29,6 +29,9 @@ type Pod struct {
 	TimeInfo TimeInfo `bson:"time_info,omitempty" json:"time_info,omitempty"`
 	// Resources are external resources that are owned and managed by this pod.
 	Resources ResourceInfo `bson:"resource_info,omitempty" json:"resource_info,omitempty"`
+	// AgentVersion is the version of the agent running on this pod if it's a
+	// pod that runs tasks.
+	AgentVersion string `bson:"agent_version,omitempty" json:"agent_version,omitempty"`
 	// RunningTask is the ID of the task currently running on the pod.
 	RunningTask string `bson:"running_task,omitempty" json:"running_task,omitempty"`
 }
@@ -428,8 +431,7 @@ func (p *Pod) GetSecret() (*Secret, error) {
 	return &s, nil
 }
 
-// SetRunningTask sets the current task to dispatch to the pod.
-// kim: TODO: test
+// SetRunningTask sets the task to dispatch to the pod.
 func (p *Pod) SetRunningTask(ctx context.Context, env evergreen.Environment, taskID string) error {
 	query := bson.M{
 		IDKey:          p.ID,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1114,7 +1114,10 @@ func FindAllMergedProjectRefs() ([]ProjectRef, error) {
 	return FindProjectRefsQ(bson.M{})
 }
 
-func FindProjectRefsByIds(ids []string) ([]ProjectRef, error) {
+func FindProjectRefsByIds(ids ...string) ([]ProjectRef, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
 	return FindProjectRefsQ(bson.M{
 		ProjectRefIdKey: bson.M{
 			"$in": ids,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -768,7 +768,13 @@ func schedulableHostTasksQuery() bson.M {
 // FindNeedsContainerAllocation returns all container tasks that are waiting for
 // a container to be allocated to them sorted by activation time.
 func FindNeedsContainerAllocation() ([]Task, error) {
-	q := bson.M{
+	q := shouldContainerTaskDispatchQuery()
+	q[StatusKey] = evergreen.TaskContainerUnallocated
+	return FindAll(db.Query(q).Sort([]string{ActivatedTimeKey}))
+}
+
+func shouldContainerTaskDispatchQuery() bson.M {
+	return bson.M{
 		ActivatedKey:         true,
 		StatusKey:            evergreen.TaskContainerUnallocated,
 		ExecutionPlatformKey: ExecutionPlatformContainer,
@@ -788,7 +794,6 @@ func FindNeedsContainerAllocation() ([]Task, error) {
 			{OverrideDependenciesKey: true},
 		},
 	}
-	return FindAll(db.Query(q).Sort([]string{ActivatedTimeKey}))
 }
 
 // TasksByProjectAndCommitPipeline fetches the pipeline to get the retrieve all tasks

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -776,7 +776,6 @@ func FindNeedsContainerAllocation() ([]Task, error) {
 func shouldContainerTaskDispatchQuery() bson.M {
 	return bson.M{
 		ActivatedKey:         true,
-		StatusKey:            evergreen.TaskContainerUnallocated,
 		ExecutionPlatformKey: ExecutionPlatformContainer,
 		PriorityKey:          bson.M{"$gt": evergreen.DisabledTaskPriority},
 		"$or": []bson.M{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -966,16 +966,6 @@ func (t *Task) MarkAsContainerDispatched(ctx context.Context, env evergreen.Envi
 	t.LastHeartbeat = dispatchedAt
 	t.AgentVersion = agentVersion
 
-	if t.IsPartOfDisplay() {
-		dt, err := t.GetDisplayTask()
-		if err != nil {
-			return errors.Wrap(err, "updating display task")
-		}
-		if dt != nil && utility.IsZeroTime(dt.DispatchTime) {
-			return errors.Wrap(dt.MarkAsContainerDispatched(ctx, env, agentVersion, dispatchedAt), "marking parent display task as dispatched")
-		}
-	}
-
 	return nil
 }
 
@@ -1015,7 +1005,12 @@ func (t *Task) MarkAsContainerUnallocated(ctx context.Context, env evergreen.Env
 		StatusKey: t.Status,
 	}, bson.M{
 		"$set": bson.M{
-			StatusKey: evergreen.TaskContainerUnallocated,
+			StatusKey:        evergreen.TaskContainerUnallocated,
+			DispatchTimeKey:  utility.ZeroTime,
+			LastHeartbeatKey: utility.ZeroTime,
+		},
+		"$unset": bson.M{
+			AgentVersionKey: 1,
 		},
 	})
 	if err != nil {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1021,6 +1021,8 @@ func (t *Task) MarkAsContainerUnallocated(ctx context.Context, env evergreen.Env
 	}
 
 	t.Status = evergreen.TaskContainerUnallocated
+	t.DispatchTime = utility.ZeroTime
+	t.LastHeartbeat = utility.ZeroTime
 
 	return nil
 }

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/annotations"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -2109,6 +2110,154 @@ func TestDeactivateTasks(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func getDispatchableContainerTask() Task {
+	return Task{
+		Id:                utility.RandomString(),
+		Activated:         true,
+		ActivatedTime:     time.Now(),
+		Status:            evergreen.TaskContainerAllocated,
+		ExecutionPlatform: ExecutionPlatformContainer,
+	}
+}
+
+func TestMarkAsContainerDispatched(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	defer func() {
+		assert.NoError(t, db.Clear(Collection))
+	}()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	checkTaskDispatched := func(t *testing.T, taskID string) {
+		dbTask, err := FindOneId(taskID)
+		require.NoError(t, err)
+		require.NotZero(t, dbTask)
+		assert.Equal(t, evergreen.TaskDispatched, dbTask.Status)
+		assert.False(t, utility.IsZeroTime(dbTask.DispatchTime))
+		assert.False(t, utility.IsZeroTime(dbTask.LastHeartbeat))
+		assert.Equal(t, evergreen.AgentVersion, dbTask.AgentVersion)
+	}
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task){
+		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			require.NoError(t, tsk.Insert())
+
+			require.NoError(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+			checkTaskDispatched(t, tsk.Id)
+		},
+		"MarksBothTaskAndItsParentDisplayTaskAsDispatched": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			dt := getDispatchableContainerTask()
+			require.NoError(t, dt.Insert())
+			tsk.DisplayTaskId = utility.ToStringPtr(dt.Id)
+			require.NoError(t, tsk.Insert())
+
+			require.NoError(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+			checkTaskDispatched(t, tsk.Id)
+			checkTaskDispatched(t, dt.Id)
+		},
+		"FailsWithTaskWithoutContainerAllocatedStatus": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			tsk.Status = evergreen.TaskContainerUnallocated
+			require.NoError(t, tsk.Insert())
+
+			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+		},
+		"FailsWithDeactivatedTasks": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			tsk.Activated = false
+			require.NoError(t, tsk.Insert())
+
+			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+		},
+		"FailsWithDisabledTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			tsk.Priority = evergreen.DisabledTaskPriority
+			require.NoError(t, tsk.Insert())
+
+			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+		},
+		"FailsWithUnmetDependencies": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			tsk.DependsOn = []Dependency{
+				{TaskId: "task", Finished: true, Unattainable: true},
+			}
+			require.NoError(t, tsk.Insert())
+
+			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+		},
+		"FailsWithNonexistentTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			require.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+
+			dbTask, err := FindOneId(tsk.Id)
+			assert.NoError(t, err)
+			assert.Zero(t, dbTask)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithCancel(ctx)
+			defer tcancel()
+
+			require.NoError(t, db.Clear(Collection))
+
+			tCase(tctx, t, env, getDispatchableContainerTask())
+		})
+	}
+}
+
+func TestMarkAsContainerUnallocated(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	defer func() {
+		assert.NoError(t, db.Clear(Collection))
+	}()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	checkTaskUnallocated := func(t *testing.T, taskID string) {
+		dbTask, err := FindOneId(taskID)
+		require.NoError(t, err)
+		require.NotZero(t, dbTask)
+		assert.Equal(t, evergreen.TaskDispatched, dbTask.Status)
+		assert.True(t, utility.IsZeroTime(dbTask.DispatchTime))
+		assert.True(t, utility.IsZeroTime(dbTask.LastHeartbeat))
+		assert.Equal(t, evergreen.AgentVersion, dbTask.AgentVersion)
+	}
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task){
+		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			require.NoError(t, tsk.Insert())
+
+			require.NoError(t, tsk.MarkAsContainerUnallocated(ctx, env))
+			checkTaskUnallocated(t, tsk.Id)
+		},
+		"FailsWithDifferentDBTaskStatus": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			tsk.Status = evergreen.TaskContainerUnallocated
+			require.NoError(t, tsk.Insert())
+			tsk.Status = evergreen.TaskContainerAllocated
+
+			assert.Error(t, tsk.MarkAsContainerUnallocated(ctx, env))
+		},
+		"FailsWithNonexistentTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			require.Error(t, tsk.MarkAsContainerUnallocated(ctx, env))
+
+			dbTask, err := FindOneId(tsk.Id)
+			assert.NoError(t, err)
+			assert.Zero(t, dbTask)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithCancel(ctx)
+			defer tcancel()
+
+			tsk := getDispatchableContainerTask()
+			require.NoError(t, db.Clear(Collection))
+
+			tCase(tctx, t, env, tsk)
+		})
 	}
 }
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1541,7 +1541,7 @@ func UpdateDisplayTaskForTask(t *task.Task) error {
 		if execTask.IsFinished() {
 			hasFinishedTasks = true
 			// Need to consider tasks that have been dispatched since the last exec task finished.
-		} else if (execTask.IsDispatchable() || execTask.IsAbortable()) && !execTask.Blocked() {
+		} else if (execTask.IsHostDispatchable() || execTask.IsAbortable()) && !execTask.Blocked() {
 			hasTasksToRun = true
 		}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1221,12 +1221,11 @@ func MarkStart(t *task.Task, updates *StatusChanges) error {
 // MarkHostTaskUndispatched marks a task as no longer dispatched to a host. If
 // it's part of a display task, update the display task as necessary.
 func MarkHostTaskUndispatched(t *task.Task) error {
-	// record that the task as undispatched on the host
 	if err := t.MarkAsHostUndispatched(); err != nil {
 		return errors.WithStack(err)
 	}
-	// the task was successfully dispatched, log the event
-	event.LogTaskUndispatched(t.Id, t.Execution, t.HostId)
+
+	event.LogHostTaskUndispatched(t.Id, t.Execution, t.HostId)
 
 	if t.IsPartOfDisplay() {
 		return UpdateDisplayTaskForTask(t)
@@ -1238,13 +1237,12 @@ func MarkHostTaskUndispatched(t *task.Task) error {
 // MarkHostTaskDispatched marks a task as being dispatched to the host. If it's
 // part of a display task, update the display task as necessary.
 func MarkHostTaskDispatched(t *task.Task, h *host.Host) error {
-	// record that the task was dispatched on the host
 	if err := t.MarkAsHostDispatched(h.Id, h.Distro.Id, h.AgentRevision, time.Now()); err != nil {
 		return errors.Wrapf(err, "error marking task %s as dispatched "+
 			"on host %s", t.Id, h.Id)
 	}
-	// the task was successfully dispatched, log the event
-	event.LogTaskDispatched(t.Id, t.Execution, h.Id)
+
+	event.LogHostTaskDispatched(t.Id, t.Execution, h.Id)
 
 	if t.IsPartOfDisplay() {
 		return UpdateDisplayTaskForTask(t)

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -681,10 +681,10 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 		}
 
 		// validate that the task can be run, if not fetch the next one in the queue.
-		if !nextTask.IsDispatchable() {
+		if !nextTask.IsHostDispatchable() {
 			// Dequeue the task so we don't get it on another iteration of the loop.
 			grip.Warning(message.WrapError(taskQueue.DequeueTask(nextTask.Id), message.Fields{
-				"message":   "nextTask.IsDispatchable() is false, but there was an issue dequeuing the task",
+				"message":   "nextTask.IsHostDispatchable() is false, but there was an issue dequeuing the task",
 				"distro_id": d.Id,
 				"task_id":   nextTask.Id,
 				"host_id":   currentHost.Id,
@@ -816,7 +816,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 						if tgTask.TaskGroupOrder == nextTask.TaskGroupOrder {
 							break
 						}
-						if tgTask.TaskGroupOrder < nextTask.TaskGroupOrder && tgTask.IsDispatchable() && !tgTask.Blocked() {
+						if tgTask.TaskGroupOrder < nextTask.TaskGroupOrder && tgTask.IsHostDispatchable() && !tgTask.Blocked() {
 							dispatchRace = fmt.Sprintf("an earlier task ('%s') in the task group is still dispatchable", tgTask.DisplayName)
 						}
 					}
@@ -1265,7 +1265,7 @@ func sendBackRunningTask(h *host.Host, response apimodels.NextTaskResponse, w ht
 	}
 
 	// if the task can be dispatched and activated dispatch it
-	if t.IsDispatchable() {
+	if t.IsHostDispatchable() {
 		err = errors.WithStack(model.MarkHostTaskDispatched(t, h))
 		if err != nil {
 			grip.Error(errors.Wrapf(err, "error while marking task %s as dispatched for host %s", t.Id, h.Id))

--- a/service/project.go
+++ b/service/project.go
@@ -32,7 +32,7 @@ func (uis *UIServer) filterViewableProjects(u *user.DBUser) ([]model.ProjectRef,
 	if err != nil {
 		return nil, err
 	}
-	projects, err := model.FindProjectRefsByIds(projectIds)
+	projects, err := model.FindProjectRefsByIds(projectIds...)
 	if err != nil {
 		return nil, err
 	}

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -42,8 +42,8 @@ func Setup() {
 		path := filepath.Join(evergreen.FindEvergreenHome(), TestDir, TestSettings)
 		env, err := evergreen.NewEnvironment(ctx, path, nil)
 		grip.EmergencyPanic(message.WrapError(err, message.Fields{
-			"note": "could not initialize test environment",
-			"path": filepath.Join(evergreen.FindEvergreenHome(), TestDir, TestSettings),
+			"message": "could not initialize test environment",
+			"path":    filepath.Join(evergreen.FindEvergreenHome(), TestDir, TestSettings),
 		}))
 
 		evergreen.SetEnvironment(env)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16233

### Description 
* Add method to dispatch the next task to a pod. For now, there are no task groups, so the dispatcher should only ever have at most one task to dispatch.
    * If a task is found to be undispatchable (e.g. the user disabled the task after a pod was already requested for it), remove it from the queue when looking for next task to dispatch and revert its status to container-unallocated.
    * This is still missing a bit of correctness functionality around 1. double-checking if dependencies are still met when dispatching ([EVG-16549](https://jira.mongodb.org/browse/EVG-16549)) and 2. ensuring display tasks get updated when the execution task is dispatched ([EVG-16631](https://jira.mongodb.org/browse/EVG-16631)).
* Rename some methods that are specific to host tasks.

### Testing 
New unit tests.
