### PR TITLE
EVG-16407 Update task_stats route to check last_run

### DIFF
--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -459,7 +459,7 @@ func (tsh *taskStatsHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "Failed to retrieve stats status"))
 		}
-		if statsStatus.ProcessedTasksUntil.After(tsh.filter.AfterDate) {
+		if statsStatus.ProcessedTasksUntil.Before(tsh.filter.AfterDate) {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 				Message:    "stats for this project have not been generated yet",
 				StatusCode: http.StatusServiceUnavailable,

--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -459,9 +459,9 @@ func (tsh *taskStatsHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "Failed to retrieve stats status"))
 		}
-		if time.Since(statsStatus.LastJobRun).Hours() > time.Duration.Hours(24) {
+		if statsStatus.ProcessedTasksUntil.After(tsh.filter.AfterDate) {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-				Message:    "stats for this project have not been generated in the last 24 hours",
+				Message:    "stats for this project have not been generated yet",
 				StatusCode: http.StatusServiceUnavailable,
 			})
 		}

--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -453,6 +453,19 @@ func (tsh *taskStatsHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "Failed to retrieve the task stats"))
 	}
+	if len(taskStatsResult) == 0 {
+		// Lookup last sync date for project
+		statsStatus, err := stats.GetStatsStatus(tsh.filter.Project)
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "Failed to retrieve stats status"))
+		}
+		if time.Since(statsStatus.LastJobRun).Hours() > time.Duration.Hours(24) {
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				Message:    "stats for this project have not been generated in the last 24 hours",
+				StatusCode: http.StatusServiceUnavailable,
+			})
+		}
+	}
 
 	resp := gimlet.NewResponseBuilder()
 	if err = resp.SetFormat(gimlet.JSON); err != nil {

--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -454,14 +454,13 @@ func (tsh *taskStatsHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "Failed to retrieve the task stats"))
 	}
 	if len(taskStatsResult) == 0 {
-		// Lookup last sync date for project
 		statsStatus, err := stats.GetStatsStatus(tsh.filter.Project)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "Failed to retrieve stats status"))
 		}
 		if statsStatus.ProcessedTasksUntil.Before(tsh.filter.AfterDate) {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-				Message:    "stats for this project have not been generated yet",
+				Message:    "stats for this time range have not been generated yet",
 				StatusCode: http.StatusServiceUnavailable,
 			})
 		}


### PR DESCRIPTION
[EVG-16407](https://jira.mongodb.org/browse/EVG-16407)

### Description 
when task stats returns nothing, it now looks up when the last time they were generated and returns 503 if it has not been run in the last 24 hours 

### Testing 
https://evergreen-staging.corp.mongodb.com/rest/v2/projects/sandbox/task_stats?tasks=thistaskdoesn%27texistlol

<img width="380" alt="image" src="https://user-images.githubusercontent.com/26491602/160873009-8728c6f8-540c-4474-9752-1c1c5668a8bc.png">
