### PR TITLE
EVG-12806 skip assigning task to host if the AMI is outdated

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -68,6 +68,19 @@ func (d *Distro) NewDistroData() DistroData {
 	return res
 }
 
+func (d *Distro) GetDefaultAMI() string {
+	if len(d.ProviderSettingsList) == 0 {
+		return ""
+	}
+	settingsDoc, err := d.GetProviderSettingByRegion(evergreen.DefaultEC2Region)
+	// An error indicates that settings aren't set up to have a relevant AMI.
+	if err != nil {
+		return ""
+	}
+	ami, _ := settingsDoc.Lookup("ami").StringValueOK()
+	return ami
+}
+
 // BootstrapSettings encapsulates all settings related to bootstrapping hosts.
 type BootstrapSettings struct {
 	// Required

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -99,6 +99,25 @@ func TestIsParent(t *testing.T) {
 	assert.False(d3.IsParent(settings))
 }
 
+func TestGetDefaultAMI(t *testing.T) {
+	d := Distro{
+		Id: "d1",
+		ProviderSettingsList: []*birch.Document{
+			birch.NewDocument(
+				birch.EC.String("ami", "ami-1234"),
+				birch.EC.String("region", "us-west-1"),
+			),
+		},
+	}
+	assert.Empty(t, d.GetDefaultAMI(), "")
+
+	d.ProviderSettingsList = append(d.ProviderSettingsList, birch.NewDocument(
+		birch.EC.String("ami", "ami-5678"),
+		birch.EC.String("region", evergreen.DefaultEC2Region),
+	))
+	assert.Equal(t, d.GetDefaultAMI(), "ami-5678")
+}
+
 func TestValidateContainerPoolDistros(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.Clear(Collection))

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -558,7 +558,7 @@ func TestLogDistroModifiedWithDistroData(t *testing.T) {
 		},
 	}
 	event.LogDistroModified(d.Id, "user1", d.NewDistroData())
-	eventsForDistro, err := event.Find(event.AllLogCollection, event.DistroEventsInOrder(d.Id))
+	eventsForDistro, err := event.FindLatestPrimaryDistroEvents(d.Id, 10)
 	assert.NoError(t, err)
 	require.Len(t, eventsForDistro, 1)
 	eventData, ok := eventsForDistro[0].Data.(*event.DistroEventData)

--- a/model/event/distro_event.go
+++ b/model/event/distro_event.go
@@ -12,9 +12,10 @@ const (
 	ResourceTypeDistro = "DISTRO"
 
 	// event types
-	EventDistroAdded    = "DISTRO_ADDED"
-	EventDistroModified = "DISTRO_MODIFIED"
-	EventDistroRemoved  = "DISTRO_REMOVED"
+	EventDistroAdded      = "DISTRO_ADDED"
+	EventDistroModified   = "DISTRO_MODIFIED"
+	EventDistroAMIModfied = "DISTRO_AMI_MODIFIED"
+	EventDistroRemoved    = "DISTRO_REMOVED"
 )
 
 // DistroEventData implements EventData.
@@ -55,4 +56,8 @@ func LogDistroModified(distroId, userId string, data interface{}) {
 // LogDistroRemoved should take in DistroData in order to preserve the ProviderSettingsList
 func LogDistroRemoved(distroId, userId string, data interface{}) {
 	LogDistroEvent(distroId, EventDistroRemoved, DistroEventData{UserId: userId, Data: data})
+}
+
+func LogDistroAMIModified(distroId, userId string) {
+	LogDistroEvent(distroId, EventDistroAMIModfied, DistroEventData{UserId: userId})
 }

--- a/model/event/distro_event.go
+++ b/model/event/distro_event.go
@@ -58,6 +58,7 @@ func LogDistroRemoved(distroId, userId string, data interface{}) {
 	LogDistroEvent(distroId, EventDistroRemoved, DistroEventData{UserId: userId, Data: data})
 }
 
+// LogDistroAMIModified logs when the default region's AMI is modified.
 func LogDistroAMIModified(distroId, userId string) {
 	LogDistroEvent(distroId, EventDistroAMIModfied, DistroEventData{UserId: userId})
 }

--- a/model/event/distro_event_test.go
+++ b/model/event/distro_event_test.go
@@ -30,10 +30,10 @@ func TestLoggingDistroEvents(t *testing.T) {
 			// fetch all the events from the database, make sure they are
 			// persisted correctly
 
-			eventsForDistro, err := Find(AllLogCollection, DistroEventsInOrder(distroId))
+			eventsForDistro, err := FindLatestPrimaryDistroEvents(distroId, 10)
 			So(err, ShouldBeNil)
 
-			event := eventsForDistro[0]
+			event := eventsForDistro[2]
 			So(event.EventType, ShouldEqual, EventDistroAdded)
 			So(event.ResourceId, ShouldEqual, distroId)
 
@@ -58,7 +58,7 @@ func TestLoggingDistroEvents(t *testing.T) {
 			So(ok, ShouldBeTrue)
 			So(ami, ShouldEqual, "ami-123456")
 
-			event = eventsForDistro[2]
+			event = eventsForDistro[0]
 			So(event.EventType, ShouldEqual, EventDistroRemoved)
 			So(event.ResourceId, ShouldEqual, distroId)
 

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -39,6 +39,15 @@ func Find(coll string, query db.Q) ([]EventLogEntry, error) {
 	return events, nil
 }
 
+func FindOne(query db.Q) (*EventLogEntry, error) {
+	event := &EventLogEntry{}
+	err := db.FindOneQ(AllLogCollection, query, event)
+	if adb.ResultsNotFound(err) {
+		return nil, nil
+	}
+	return event, err
+}
+
 func FindPaginated(hostID, hostTag, coll string, limit, page int) ([]EventLogEntry, int, error) {
 	query := MostRecentHostEvents(hostID, hostTag, limit)
 	events := []EventLogEntry{}
@@ -159,11 +168,12 @@ func DistroEventsForId(id string) db.Q {
 	return db.Query(filter)
 }
 
+// DistroAMIModifiedForId returns the query for AMI modified distro events.
 func DistroAMIModifiedForId(id string) db.Q {
 	filter := ResourceTypeKeyIs(ResourceTypeDistro)
 	filter[ResourceIdKey] = id
 	filter[TypeKey] = EventDistroAMIModfied
-	return db.Query(filter).Sort([]string{"-" + TimestampKey}).Limit(1)
+	return db.Query(filter).Sort([]string{"-" + TimestampKey})
 }
 
 func MostRecentDistroEvents(id string, n int) db.Q {

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -92,16 +92,6 @@ func FindByID(eventID string) (*EventLogEntry, error) {
 	return &e, nil
 }
 
-// FindEventsByIDs finds all events that match the given event IDs.
-func FindEventsByIDs(events []string) ([]EventLogEntry, error) {
-	query := bson.M{
-		idKey: bson.M{
-			"$in": events,
-		},
-	}
-	return Find(AllLogCollection, db.Query(query))
-}
-
 func FindLastProcessedEvent() (*EventLogEntry, error) {
 	q := db.Query(bson.M{
 		processedAtKey: bson.M{
@@ -167,6 +157,13 @@ func DistroEventsForId(id string) db.Q {
 	filter[ResourceIdKey] = id
 
 	return db.Query(filter)
+}
+
+func DistroAMIModifiedForId(id string) db.Q {
+	filter := ResourceTypeKeyIs(ResourceTypeDistro)
+	filter[ResourceIdKey] = id
+	filter[TypeKey] = EventDistroAMIModfied
+	return db.Query(filter).Sort([]string{"-" + TimestampKey}).Limit(1)
 }
 
 func MostRecentDistroEvents(id string, n int) db.Q {

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -161,9 +161,11 @@ func TaskEventsInOrder(id string) db.Q {
 }
 
 // Distro Events
-func DistroEventsForId(id string) db.Q {
+// DistroPrimaryEventsForId returns the non-AMI specific events for the distro.
+func DistroPrimaryEventsForId(id string) db.Q {
 	filter := ResourceTypeKeyIs(ResourceTypeDistro)
 	filter[ResourceIdKey] = id
+	filter[TypeKey] = bson.M{"$ne": EventDistroAMIModfied}
 
 	return db.Query(filter)
 }
@@ -177,11 +179,11 @@ func DistroAMIModifiedForId(id string) db.Q {
 }
 
 func MostRecentDistroEvents(id string, n int) db.Q {
-	return DistroEventsForId(id).Sort([]string{"-" + TimestampKey}).Limit(n)
+	return DistroPrimaryEventsForId(id).Sort([]string{"-" + TimestampKey}).Limit(n)
 }
 
 func DistroEventsInOrder(id string) db.Q {
-	return DistroEventsForId(id).Sort([]string{TimestampKey})
+	return DistroPrimaryEventsForId(id).Sort([]string{TimestampKey})
 }
 
 // Scheduler Events

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -407,6 +407,14 @@ func (h *Host) IdleTime() time.Duration {
 	return time.Since(h.CreationTime)
 }
 
+func (h *Host) GetAMI() string {
+	if len(h.Distro.ProviderSettingsList) == 0 {
+		return ""
+	}
+	ami, _ := h.Distro.ProviderSettingsList[0].Lookup("ami").StringValueOK()
+	return ami
+}
+
 func (h *Host) IsEphemeral() bool {
 	return utility.StringSliceContains(evergreen.ProviderSpawnable, h.Provider)
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4944,6 +4944,30 @@ func TestCountVirtualWorkstationsByDistro(t *testing.T) {
 	}
 }
 
+func TestGetAMI(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection))
+	h := &Host{
+		Id: "myEC2Host",
+		Distro: distro.Distro{
+			ProviderSettingsList: []*birch.Document{birch.NewDocument(
+				birch.EC.String("ami", "ami"),
+				birch.EC.String("key_name", "key"),
+				birch.EC.String("instance_type", "instance"),
+				birch.EC.String("aws_access_key_id", "key_id"),
+				birch.EC.Double("bid_price", 0.001),
+				birch.EC.SliceString("security_group_ids", []string{"abcdef"}),
+			)},
+			Provider: evergreen.ProviderNameEc2OnDemand,
+		},
+	}
+	h2 := &Host{
+		Id:       "myOtherHost",
+		Provider: evergreen.ProviderNameMock,
+	}
+	assert.Equal(t, h.GetAMI(), "ami")
+	assert.Equal(t, h2.GetAMI(), "")
+}
+
 func TestUnsafeReplace(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -118,7 +118,6 @@ type TaskQueueItem struct {
 	ExpectedDuration    time.Duration `bson:"exp_dur" json:"exp_dur"`
 	Priority            int64         `bson:"priority" json:"priority"`
 	Dependencies        []string      `bson:"dependencies" json:"dependencies"`
-	CreateTime          time.Time     `bson:"create_time" json:"create_time"`
 }
 
 // must not no-lint these values
@@ -144,7 +143,6 @@ var (
 	taskQueueItemProjectKey       = bsonutil.MustHaveTag(TaskQueueItem{}, "Project")
 	taskQueueItemExpDurationKey   = bsonutil.MustHaveTag(TaskQueueItem{}, "ExpectedDuration")
 	taskQueueItemPriorityKey      = bsonutil.MustHaveTag(TaskQueueItem{}, "Priority")
-	taskQueueItemCreateTimeKey    = bsonutil.MustHaveTag(TaskQueueItem{}, "CreateTime")
 
 	taskQueueInfoPlanCreatedAtKey = bsonutil.MustHaveTag(DistroQueueInfo{}, "PlanCreatedAt")
 )
@@ -510,7 +508,6 @@ func findTaskQueueForDistro(q taskQueueQuery) (*TaskQueue, error) {
 						taskQueueItemProjectKey:       "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemProjectKey),
 						taskQueueItemExpDurationKey:   "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemExpDurationKey),
 						taskQueueItemPriorityKey:      "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemPriorityKey),
-						taskQueueItemCreateTimeKey:    "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemCreateTimeKey),
 					},
 				},
 			},

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -118,6 +118,7 @@ type TaskQueueItem struct {
 	ExpectedDuration    time.Duration `bson:"exp_dur" json:"exp_dur"`
 	Priority            int64         `bson:"priority" json:"priority"`
 	Dependencies        []string      `bson:"dependencies" json:"dependencies"`
+	CreateTime          time.Time     `bson:"create_time" json:"create_time"`
 }
 
 // must not no-lint these values
@@ -143,22 +144,9 @@ var (
 	taskQueueItemProjectKey       = bsonutil.MustHaveTag(TaskQueueItem{}, "Project")
 	taskQueueItemExpDurationKey   = bsonutil.MustHaveTag(TaskQueueItem{}, "ExpectedDuration")
 	taskQueueItemPriorityKey      = bsonutil.MustHaveTag(TaskQueueItem{}, "Priority")
+	taskQueueItemCreateTimeKey    = bsonutil.MustHaveTag(TaskQueueItem{}, "CreateTime")
 
-	// taskQueueInfoLengthKey             = bsonutil.MustHaveTag(DistroQueueInfo{}, "Length")
-	// taskQueueInfoExpectedDurationKey   = bsonutil.MustHaveTag(DistroQueueInfo{}, "ExpectedDuration")
-	// taskQueueInfoMaxDurationKey        = bsonutil.MustHaveTag(DistroQueueInfo{}, "MaxDurationThreshold")
 	taskQueueInfoPlanCreatedAtKey = bsonutil.MustHaveTag(DistroQueueInfo{}, "PlanCreatedAt")
-	// taskQueueInfoCountDurationOverThresholdKey = bsonutil.MustHaveTag(DistroQueueInfo{}, "CountDurationOverThreshold")
-	// taskQueueInfoCountWaitOverThresholdKey = bsonutil.MustHaveTag(DistroQueueInfo{}, "CountWaitOverThreshold")
-	// taskQueueInfoTaskGroupInfosKey     = bsonutil.MustHaveTag(DistroQueueInfo{}, "TaskGroupInfos")
-	// taskQueueInfoAliasQueueKey         = bsonutil.MustHaveTag(DistroQueueInfo{}, "AliasQueue")
-
-	// taskQueueInfoGroupNameKey                  = bsonutil.MustHaveTag(TaskGroupInfo{}, "Name")
-	// taskQueueInfoGroupCountKey                 = bsonutil.MustHaveTag(TaskGroupInfo{}, "Count")
-	// taskQueueInfoGroupMaxHostsKey              = bsonutil.MustHaveTag(TaskGroupInfo{}, "MaxHosts")
-	// taskQueueInfoGroupExpectedDuratioKey       = bsonutil.MustHaveTag(TaskGroupInfo{}, "ExpectedDuration")
-	// taskQueueInfoGroupCountOverThresholdKey    = bsonutil.MustHaveTag(TaskGroupInfo{}, "CountOverThreshold")
-	// taskQueueInfoGroupDurationOverThresholdKey = bsonutil.MustHaveTag(TaskGroupInfo{}, "DurationOverThreshold")
 )
 
 // TaskSpec is an argument structure to formalize the way that callers
@@ -522,6 +510,7 @@ func findTaskQueueForDistro(q taskQueueQuery) (*TaskQueue, error) {
 						taskQueueItemProjectKey:       "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemProjectKey),
 						taskQueueItemExpDurationKey:   "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemExpDurationKey),
 						taskQueueItemPriorityKey:      "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemPriorityKey),
+						taskQueueItemCreateTimeKey:    "$" + bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemCreateTimeKey),
 					},
 				},
 			},

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -359,6 +359,7 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec, amiUpdatedTim
 					"task_id":          nextTaskFromDB.Id,
 					"distro_id":        d.distroID,
 					"ami_updated_time": amiUpdatedTime,
+					"ingest_time":      nextTaskFromDB.IngestTime,
 				})
 				continue
 			}

--- a/model/task_queue_service_test.go
+++ b/model/task_queue_service_test.go
@@ -1406,7 +1406,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTaskForOutdatedHostAMI() {
 		Id:                  "1",
 		BuildId:             "ops_manager_kubernetes_init_test_run_patch_1a53e026e05561c3efbb626185e155a7d1e4865d_5d88953e2a60ed61eefe9561_19_09_23_09_49_51",
 		TaskGroup:           "",
-		CreateTime:          amiUpdateTime.Add(time.Minute), // created after the AMI was updated so we should skip
+		IngestTime:          amiUpdateTime.Add(time.Minute), // created after the AMI was updated so we should skip
 		StartTime:           utility.ZeroTime,
 		BuildVariant:        "init_test_run",
 		Version:             "5d88953e2a60ed61eefe9561",
@@ -1437,7 +1437,7 @@ func (s *taskDAGDispatchServiceSuite) TestFindNextTaskForOutdatedHostAMI() {
 		TaskGroupMaxHosts:   5,
 		TaskGroupOrder:      2,
 		StartTime:           utility.ZeroTime,
-		CreateTime:          amiUpdateTime.Add(-time.Minute), // created before the AMI was updated so we should not skip
+		IngestTime:          amiUpdateTime.Add(-time.Minute), // created before the AMI was updated so we should not skip
 		BuildVariant:        "e2e_openshift_cloud_qa",
 		Version:             "5d88953e2a60ed61eefe9561",
 		Project:             "ops-manager-kubernetes",

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -280,10 +280,11 @@ func (at *APITask) BuildFromService(t interface{}) error {
 			if err != nil {
 				return errors.Wrapf(err, "error finding host '%s' for task", v.HostId)
 			}
-			if h != nil && len(h.Distro.ProviderSettingsList) == 1 {
-				ami, ok := h.Distro.ProviderSettingsList[0].Lookup("ami").StringValueOK()
-				if ok {
+			if h != nil {
+				ami := h.GetAMI()
+				if ami != "" {
 					at.Ami = utility.ToStringPtr(ami)
+
 				}
 			}
 		}

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -380,6 +380,7 @@ func TestUpdateDistrosSettingsHandlerRun(t *testing.T) {
 	h.settings = birch.NewDocument(
 		birch.EC.String("region", "us-west-1"),
 		birch.EC.SliceString("security_group_ids", []string{"c1", "d1"}),
+		birch.EC.String("ami", "ami-456"),
 	)
 	h.region = "us-west-1"
 
@@ -397,13 +398,14 @@ func TestUpdateDistrosSettingsHandlerRun(t *testing.T) {
 		if settings.Region == "us-east-1" {
 			assert.Equal(t, "ami-123", settings.AMI)
 		} else if settings.Region == "us-west-1" {
-			assert.Equal(t, "ami-234", settings.AMI)
+			assert.Equal(t, "ami-456", settings.AMI)
 			assert.Equal(t, []string{"c1", "d1"}, settings.SecurityGroupIDs)
 		}
 	}
 
 	events, err := event.FindAllByResourceID("d1")
 	assert.NoError(t, err)
+	// Doesn't include the AMI update because it's not a default region that was updated.
 	assert.Len(t, events, 1)
 
 }

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -601,14 +601,14 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 
 	var amiUpdatedTime time.Time
 	if d.GetDefaultAMI() != currentHost.GetAMI() {
-		events, err := event.Find(event.AllLogCollection, event.DistroAMIModifiedForId(d.Id))
+		event, err := event.FindOne(event.DistroAMIModifiedForId(d.Id))
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":   "problem getting AMI event log",
 			"host_id":   currentHost.Id,
 			"distro_id": d.Id,
 		}))
-		if len(events) > 0 {
-			amiUpdatedTime = events[0].Timestamp
+		if event != nil {
+			amiUpdatedTime = event.Timestamp
 		}
 	}
 

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -601,15 +601,13 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 
 	var amiUpdatedTime time.Time
 	if d.GetDefaultAMI() != currentHost.GetAMI() {
-		event, err := event.FindOne(event.DistroAMIModifiedForId(d.Id))
+		amiEvent, err := event.FindLatestAMIModifiedDistroEvent(d.Id)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":   "problem getting AMI event log",
 			"host_id":   currentHost.Id,
 			"distro_id": d.Id,
 		}))
-		if event != nil {
-			amiUpdatedTime = event.Timestamp
-		}
+		amiUpdatedTime = amiEvent.Timestamp
 	}
 
 	// This loop does the following:

--- a/service/distros.go
+++ b/service/distros.go
@@ -233,7 +233,9 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 			PushFlash(uis.CookieStore, r, w, NewWarningFlash(err.Error()))
 		}
 	}
-
+	if newDistro.GetDefaultAMI() != oldDistro.GetDefaultAMI() {
+		event.LogDistroAMIModified(id, u.Username())
+	}
 	event.LogDistroModified(id, u.Username(), newDistro.NewDistroData())
 
 	message := fmt.Sprintf("Distro %v successfully updated.", id)

--- a/service/event_log.go
+++ b/service/event_log.go
@@ -51,8 +51,7 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 			uis.RedirectToLogin(w, r)
 			return
 		}
-		eventQuery := event.MostRecentDistroEvents(resourceID, 200)
-		loggedEvents, err = event.Find(event.AllLogCollection, eventQuery)
+		loggedEvents, err = event.FindLatestPrimaryDistroEvents(resourceID, 200)
 	case event.ResourceTypeAdmin:
 		if u == nil {
 			uis.RedirectToLogin(w, r)

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -27,7 +27,7 @@ const (
 	// idleTimeCutoff is the amount of time we wait for an idle host to be marked as idle.
 	idleTimeCutoff = 4 * time.Minute
 	// outdatedIdleTimeCutoff is the amount of time we wait for an outdated idle host to be marked idle.
-	outdatedIdleTimeCutoff    = 2 * time.Minute
+	outdatedIdleTimeCutoff    = time.Minute
 	idleWaitingForAgentCutoff = 10 * time.Minute
 	idleTaskGroupHostCutoff   = 10 * time.Minute
 


### PR DESCRIPTION
[EVG-12806](https://jira.mongodb.org/browse/EVG-12806)

### Description 
When a distro has it's image updated, it's frustrating for engineers that new tasks they create may still be using the old image, if those hosts haven't been decommissioned yet. However, it's expensive to decommission all running hosts when AMI is updated. This change instead considers when a task has been created, and if it's been created since the AMI was updated, we wait for a new host (eventually old hosts will be decommissioned as idle when there are no more old tasks to run).

This may negatively impact new task wait times in these cases, however it would improve correctness. 

(Also, I chose to use events to determine if AMI has been updated because storing that in the Distro collection seemed a bit wrong, but I can still pivot to that)

### Testing 
Added unit tests and also tested in staging: verified that [this task](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu1604_test_db_patch_041c911277be79717a3b3842a5444e7119b9a391_6244a388b2373649f74aa7ea_22_03_30_18_38_07/logs?execution=0) (which was created after changing the AMI) [wasn't scheduled on hosts](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen-staging%20%22ticket%22%3D%22EVG-12806%22%20message%3D%22skipping%20because%20AMI%20is%20outdated%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=1648664887&latest=1648665787&workload_pool=standard_perf&sid=1648666215.249727) that were using the old AM.