### PR TITLE
EVG-16539 Warn when version control enabled with no project config and vice versa

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -734,7 +734,7 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 
 	// validate the project
 	verrs := validator.CheckProjectErrors(projectInfo.Project, true)
-	verrs = append(verrs, validator.CheckProjectSettings(projectInfo.Project, projectInfo.Ref)...)
+	verrs = append(verrs, validator.CheckProjectSettings(projectInfo.Project, projectInfo.Ref, projectInfo.Config)...)
 	verrs = append(verrs, validator.CheckProjectConfigErrors(projectInfo.Config)...)
 	verrs = append(verrs, validator.CheckProjectWarnings(projectInfo.Project)...)
 	if len(verrs) > 0 || versionErrs != nil {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -733,8 +733,9 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 	v.Activated = utility.FalsePtr()
 
 	// validate the project
+	isConfigDefined := projectInfo.Config != nil
 	verrs := validator.CheckProjectErrors(projectInfo.Project, true)
-	verrs = append(verrs, validator.CheckProjectSettings(projectInfo.Project, projectInfo.Ref, projectInfo.Config)...)
+	verrs = append(verrs, validator.CheckProjectSettings(projectInfo.Project, projectInfo.Ref, isConfigDefined)...)
 	verrs = append(verrs, validator.CheckProjectConfigErrors(projectInfo.Config)...)
 	verrs = append(verrs, validator.CheckProjectWarnings(projectInfo.Project)...)
 	if len(verrs) > 0 || versionErrs != nil {

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -74,7 +74,8 @@ func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef 
 	}
 
 	errs := validator.CheckProjectErrors(projectConfig, false)
-	errs = append(errs, validator.CheckProjectSettings(projectConfig, &projectRef, nil)...)
+	isConfigDefined := projectConfig != nil
+	errs = append(errs, validator.CheckProjectSettings(projectConfig, &projectRef, isConfigDefined)...)
 	errs = append(errs, validator.CheckPatchedProjectConfigErrors(patchDoc.PatchedProjectConfig)...)
 	catcher := grip.NewBasicCatcher()
 	for _, validationErr := range errs.AtLevel(validator.Error) {

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -74,7 +74,7 @@ func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef 
 	}
 
 	errs := validator.CheckProjectErrors(projectConfig, false)
-	errs = append(errs, validator.CheckProjectSettings(projectConfig, &projectRef)...)
+	errs = append(errs, validator.CheckProjectSettings(projectConfig, &projectRef, nil)...)
 	errs = append(errs, validator.CheckPatchedProjectConfigErrors(patchDoc.PatchedProjectConfig)...)
 	catcher := grip.NewBasicCatcher()
 	for _, validationErr := range errs.AtLevel(validator.Error) {

--- a/service/api.go
+++ b/service/api.go
@@ -666,7 +666,7 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 			}
 			errs = append(errs, validationErr)
 		} else {
-			errs = append(errs, validator.CheckProjectSettings(project, projectRef)...)
+			errs = append(errs, validator.CheckProjectSettings(project, projectRef, projectConfig)...)
 		}
 	} else {
 		validationErr = validator.ValidationError{

--- a/service/api.go
+++ b/service/api.go
@@ -666,7 +666,8 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 			}
 			errs = append(errs, validationErr)
 		} else {
-			errs = append(errs, validator.CheckProjectSettings(project, projectRef, projectConfig)...)
+			isConfigDefined := projectConfig != nil
+			errs = append(errs, validator.CheckProjectSettings(project, projectRef, isConfigDefined)...)
 		}
 	} else {
 		validationErr = validator.ValidationError{

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -610,7 +610,7 @@ func AddMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 	project.TaskGroups = append(project.TaskGroups, mergeTaskGroup)
 
 	validationErrors := validator.CheckProjectErrors(project, true)
-	validationErrors = append(validationErrors, validator.CheckProjectSettings(project, projectRef, nil)...)
+	validationErrors = append(validationErrors, validator.CheckProjectSettings(project, projectRef, false)...)
 	validationErrors = append(validationErrors, validator.CheckPatchedProjectConfigErrors(patchDoc.PatchedProjectConfig)...)
 	catcher := grip.NewBasicCatcher()
 	for _, validationErr := range validationErrors.AtLevel(validator.Error) {

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -610,7 +610,7 @@ func AddMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 	project.TaskGroups = append(project.TaskGroups, mergeTaskGroup)
 
 	validationErrors := validator.CheckProjectErrors(project, true)
-	validationErrors = append(validationErrors, validator.CheckProjectSettings(project, projectRef)...)
+	validationErrors = append(validationErrors, validator.CheckProjectSettings(project, projectRef, nil)...)
 	validationErrors = append(validationErrors, validator.CheckPatchedProjectConfigErrors(patchDoc.PatchedProjectConfig)...)
 	catcher := grip.NewBasicCatcher()
 	for _, validationErr := range validationErrors.AtLevel(validator.Error) {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -253,7 +253,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 			validationCatcher.Errorf("invalid patched config syntax: %s", validator.ValidationErrorsToString(errs))
 		}
 	}
-	if errs := validator.CheckProjectSettings(project, pref, nil); len(errs) != 0 {
+	if errs := validator.CheckProjectSettings(project, pref, false); len(errs) != 0 {
 		if errs = errs.AtLevel(validator.Error); len(errs) != 0 {
 			validationCatcher.Errorf("invalid patched config for current project settings: %s", validator.ValidationErrorsToString(errs))
 		}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -253,7 +253,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 			validationCatcher.Errorf("invalid patched config syntax: %s", validator.ValidationErrorsToString(errs))
 		}
 	}
-	if errs := validator.CheckProjectSettings(project, pref); len(errs) != 0 {
+	if errs := validator.CheckProjectSettings(project, pref, nil); len(errs) != 0 {
 		if errs = errs.AtLevel(validator.Error); len(errs) != 0 {
 			validationCatcher.Errorf("invalid patched config for current project settings: %s", validator.ValidationErrorsToString(errs))
 		}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1585,7 +1585,7 @@ func validateVersionControl(_ *model.Project, ref *model.ProjectRef, isConfigDef
 	} else if !ref.IsVersionControlEnabled() && isConfigDefined {
 		errs = append(errs, ValidationError{
 			Level: Warning,
-			Message: fmt.Sprintf("version control is disabled for project '%s', the currently defined project config fields will not be picked up.",
+			Message: fmt.Sprintf("version control is disabled for project '%s'; the currently defined project config fields will not be picked up",
 				ref.Identifier),
 		})
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -277,9 +277,8 @@ func CheckProjectConfigErrors(projectConfig *model.ProjectConfig) ValidationErro
 
 // CheckProjectSettings checks the project configuration against the project
 // settings.
-func CheckProjectSettings(p *model.Project, ref *model.ProjectRef, config *model.ProjectConfig) ValidationErrors {
+func CheckProjectSettings(p *model.Project, ref *model.ProjectRef, isConfigDefined bool) ValidationErrors {
 	var errs ValidationErrors
-	isConfigDefined := config != nil
 	for _, validateSettings := range projectSettingsValidators {
 		errs = append(errs, validateSettings(p, ref, isConfigDefined)...)
 	}
@@ -296,7 +295,7 @@ func CheckProjectConfigurationIsValid(project *model.Project, pref *model.Projec
 		}
 	}
 
-	if settingsErrs := CheckProjectSettings(project, pref, nil); len(settingsErrs) != 0 {
+	if settingsErrs := CheckProjectSettings(project, pref, false); len(settingsErrs) != 0 {
 		if errs := settingsErrs.AtLevel(Error); len(errs) != 0 {
 			catcher.Errorf("project contains errors related to project settings: %s", ValidationErrorsToString(errs))
 		}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -25,7 +25,7 @@ type projectValidator func(*model.Project) ValidationErrors
 
 type projectConfigValidator func(config *model.ProjectConfig) ValidationErrors
 
-type projectSettingsValidator func(*model.Project, *model.ProjectRef) ValidationErrors
+type projectSettingsValidator func(*model.Project, *model.ProjectRef, *model.ProjectConfig) ValidationErrors
 
 // bool indicates if we should still run the validator if the project is complex
 type longValidator func(*model.Project, bool) ValidationErrors
@@ -156,6 +156,7 @@ var projectWarningValidators = []projectValidator{
 
 var projectSettingsValidators = []projectSettingsValidator{
 	validateTaskSyncSettings,
+	validateVersionControl,
 }
 
 // These validators have the potential to be very long, and may not be fully run unless specified.
@@ -276,10 +277,10 @@ func CheckProjectConfigErrors(projectConfig *model.ProjectConfig) ValidationErro
 
 // CheckProjectSettings checks the project configuration against the project
 // settings.
-func CheckProjectSettings(p *model.Project, ref *model.ProjectRef) ValidationErrors {
+func CheckProjectSettings(p *model.Project, ref *model.ProjectRef, config *model.ProjectConfig) ValidationErrors {
 	var errs ValidationErrors
 	for _, validateSettings := range projectSettingsValidators {
-		errs = append(errs, validateSettings(p, ref)...)
+		errs = append(errs, validateSettings(p, ref, config)...)
 	}
 	return errs
 }
@@ -294,7 +295,7 @@ func CheckProjectConfigurationIsValid(project *model.Project, pref *model.Projec
 		}
 	}
 
-	if settingsErrs := CheckProjectSettings(project, pref); len(settingsErrs) != 0 {
+	if settingsErrs := CheckProjectSettings(project, pref, nil); len(settingsErrs) != 0 {
 		if errs := settingsErrs.AtLevel(Error); len(errs) != 0 {
 			catcher.Errorf("project contains errors related to project settings: %s", ValidationErrorsToString(errs))
 		}
@@ -1550,7 +1551,7 @@ func validateGenerateTasks(p *model.Project) ValidationErrors {
 
 // validateTaskSyncSettings checks that task sync in the project settings have
 // enabled task sync for the config.
-func validateTaskSyncSettings(p *model.Project, ref *model.ProjectRef) ValidationErrors {
+func validateTaskSyncSettings(p *model.Project, ref *model.ProjectRef, config *model.ProjectConfig) ValidationErrors {
 	if ref.TaskSync.IsConfigEnabled() {
 		return nil
 	}
@@ -1567,6 +1568,25 @@ func validateTaskSyncSettings(p *model.Project, ref *model.ProjectRef) Validatio
 			Level: Error,
 			Message: fmt.Sprintf("cannot use %s command in project config when it is disabled by project '%s' settings",
 				ref.Identifier, evergreen.S3PullCommandName),
+		})
+	}
+	return errs
+}
+
+// validateVersionControl checks if a project with defined project config fields has version control enabled on the project ref.
+func validateVersionControl(p *model.Project, ref *model.ProjectRef, config *model.ProjectConfig) ValidationErrors {
+	var errs ValidationErrors
+	if ref.IsVersionControlEnabled() && config == nil {
+		errs = append(errs, ValidationError{
+			Level: Warning,
+			Message: fmt.Sprintf("version control is enabled for project '%s' but no project config fields have been set.",
+				ref.Identifier),
+		})
+	} else if !ref.IsVersionControlEnabled() && config != nil {
+		errs = append(errs, ValidationError{
+			Level: Warning,
+			Message: fmt.Sprintf("version control is disabled for project '%s', the currently defined project config fields will not be picked up.",
+				ref.Identifier),
 		})
 	}
 	return errs

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2999,7 +2999,7 @@ func TestValidateVersionControl(t *testing.T) {
 	}
 	isConfigDefined := &projectConfig != nil
 	verrs := validateVersionControl(&model.Project{}, ref, isConfigDefined)
-	assert.Equal(t, "version control is disabled for project 'proj', the currently defined project config fields will not be picked up.", verrs[0].Message)
+	assert.Equal(t, "version control is disabled for project 'proj'; the currently defined project config fields will not be picked up", verrs[0].Message)
 
 	ref.VersionControlEnabled = utility.TruePtr()
 	verrs = validateVersionControl(&model.Project{}, ref, false)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2997,7 +2997,8 @@ func TestValidateVersionControl(t *testing.T) {
 			},
 		},
 	}
-	verrs := validateVersionControl(&model.Project{}, ref, &projectConfig != nil)
+	isConfigDefined := &projectConfig != nil
+	verrs := validateVersionControl(&model.Project{}, ref, isConfigDefined)
 	assert.Equal(t, "version control is disabled for project 'proj', the currently defined project config fields will not be picked up.", verrs[0].Message)
 
 	ref.VersionControlEnabled = utility.TruePtr()

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2997,11 +2997,11 @@ func TestValidateVersionControl(t *testing.T) {
 			},
 		},
 	}
-	verrs := validateVersionControl(&model.Project{}, ref, &projectConfig)
+	verrs := validateVersionControl(&model.Project{}, ref, &projectConfig != nil)
 	assert.Equal(t, "version control is disabled for project 'proj', the currently defined project config fields will not be picked up.", verrs[0].Message)
 
 	ref.VersionControlEnabled = utility.TruePtr()
-	verrs = validateVersionControl(&model.Project{}, ref, nil)
+	verrs = validateVersionControl(&model.Project{}, ref, false)
 	assert.Equal(t, "version control is enabled for project 'proj' but no project config fields have been set.", verrs[0].Message)
 
 }
@@ -3064,7 +3064,7 @@ func TestValidateTaskSyncSettings(t *testing.T) {
 				},
 			}
 			p := &model.Project{Tasks: testParams.tasks}
-			errs := validateTaskSyncSettings(p, ref, nil)
+			errs := validateTaskSyncSettings(p, ref, false)
 			if testParams.expectError {
 				assert.NotEmpty(t, errs)
 			} else {
@@ -3084,13 +3084,13 @@ func TestValidateTaskSyncSettings(t *testing.T) {
 			},
 		},
 	}
-	assert.NotEmpty(t, validateTaskSyncSettings(p, ref, nil))
+	assert.NotEmpty(t, validateTaskSyncSettings(p, ref, false))
 
 	ref.TaskSync.ConfigEnabled = utility.TruePtr()
-	assert.Empty(t, validateTaskSyncSettings(p, ref, nil))
+	assert.Empty(t, validateTaskSyncSettings(p, ref, false))
 
 	p.Tasks = []model.ProjectTask{}
-	assert.Empty(t, validateTaskSyncSettings(p, ref, nil))
+	assert.Empty(t, validateTaskSyncSettings(p, ref, false))
 }
 
 func TestTVToTaskUnit(t *testing.T) {


### PR DESCRIPTION
[EVG-16539](https://jira.mongodb.org/browse/EVG-16539)

### Description 
Added a warning saying that project config fields are not set when version control on the project ref is enabled (indicating the user might want to specify them), and a warning that version control is not enabled when project config fields are set (indicating the user might want to toggle VC).
### Testing 
Added unit test certifying new warnings for both scenarios.