### PR TITLE
EVG-16645 shield implicit subscriptions

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2962,7 +2962,7 @@ func (r *mutationResolver) ClearMySubscriptions(ctx context.Context) (int, error
 	if err != nil {
 		return 0, InternalServerError.Send(ctx, fmt.Sprintf("Error retrieving subscriptions %s", err.Error()))
 	}
-	subIDs := removeImplicitSubscriptions(usr, subs)
+	subIDs := removeGeneralSubscriptions(usr, subs)
 	err = data.DeleteSubscriptions(username, subIDs)
 	if err != nil {
 		return 0, InternalServerError.Send(ctx, fmt.Sprintf("Error deleting subscriptions %s", err.Error()))

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -471,10 +471,9 @@ func formatDuration(duration string) string {
 }
 
 func removeImplicitSubscriptions(usr *user.DBUser, subscriptions []event.Subscription) []string {
-	implicitSubscriptions := usr.ImplicitSubscriptionIDs()
 	filteredSubscriptions := make([]string, 0, len(subscriptions))
 	for _, subscription := range subscriptions {
-		if !utility.StringSliceContains(implicitSubscriptions, subscription.ID) {
+		if !utility.StringSliceContains(usr.ImplicitSubscriptionIDs(), subscription.ID) {
 			filteredSubscriptions = append(filteredSubscriptions, subscription.ID)
 		}
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -470,6 +470,18 @@ func formatDuration(duration string) string {
 	}))
 }
 
+func removeImplicitSubscriptions(usr *user.DBUser, subscriptions []event.Subscription) []string {
+	implicitSubscriptions := usr.ImplicitSubscriptionIDs()
+	filteredSubscriptions := make([]string, 0, len(subscriptions))
+	for _, subscription := range subscriptions {
+		if !utility.StringSliceContains(implicitSubscriptions, subscription.ID) {
+			filteredSubscriptions = append(filteredSubscriptions, subscription.ID)
+		}
+	}
+
+	return filteredSubscriptions
+}
+
 func getResourceTypeAndIdFromSubscriptionSelectors(ctx context.Context, selectors []restModel.APISelector) (string, string, error) {
 	var id string
 	var idType string

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -470,10 +470,10 @@ func formatDuration(duration string) string {
 	}))
 }
 
-func removeImplicitSubscriptions(usr *user.DBUser, subscriptions []event.Subscription) []string {
+func removeGeneralSubscriptions(usr *user.DBUser, subscriptions []event.Subscription) []string {
 	filteredSubscriptions := make([]string, 0, len(subscriptions))
 	for _, subscription := range subscriptions {
-		if !utility.StringSliceContains(usr.ImplicitSubscriptionIDs(), subscription.ID) {
+		if !utility.StringSliceContains(usr.GeneralSubscriptionIDs(), subscription.ID) {
 			filteredSubscriptions = append(filteredSubscriptions, subscription.ID)
 		}
 	}

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -13,37 +13,37 @@ func init() {
 	testutil.Setup()
 }
 
-func TestFilterImplicitSubscriptions(t *testing.T) {
+func TestFilterGeneralSubscriptions(t *testing.T) {
 	usr := &user.DBUser{}
 	usr.Settings.Notifications = user.NotificationPreferences{
 		PatchFinishID: "patch_finish_id",
 		CommitQueueID: "commit_queue_id",
 	}
 
-	t.Run("NoImplicitSubscriptions", func(t *testing.T) {
+	t.Run("NoGeneralSubscriptions", func(t *testing.T) {
 		subs := []event.Subscription{
 			{ID: "123455"},
 			{ID: "abcdef"},
 		}
-		filteredSubIDs := removeImplicitSubscriptions(usr, subs)
+		filteredSubIDs := removeGeneralSubscriptions(usr, subs)
 		assert.ElementsMatch(t, []string{"123455", "abcdef"}, filteredSubIDs)
 	})
 
-	t.Run("OnlyImplicitSubscriptions", func(t *testing.T) {
+	t.Run("OnlyGeneralSubscriptions", func(t *testing.T) {
 		subs := []event.Subscription{
 			{ID: "patch_finish_id"},
 			{ID: "commit_queue_id"},
 		}
-		filteredSubIDs := removeImplicitSubscriptions(usr, subs)
+		filteredSubIDs := removeGeneralSubscriptions(usr, subs)
 		assert.Empty(t, filteredSubIDs)
 	})
 
-	t.Run("MixImplicitSubscriptions", func(t *testing.T) {
+	t.Run("MixGeneralSubscriptions", func(t *testing.T) {
 		subs := []event.Subscription{
 			{ID: "patch_finish_id"},
 			{ID: "123456"},
 		}
-		filteredSubIDs := removeImplicitSubscriptions(usr, subs)
+		filteredSubIDs := removeGeneralSubscriptions(usr, subs)
 		assert.ElementsMatch(t, []string{"123456"}, filteredSubIDs)
 	})
 }

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -1,9 +1,49 @@
 package graphql
 
 import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
 	testutil.Setup()
+}
+
+func TestFilterImplicitSubscriptions(t *testing.T) {
+	usr := &user.DBUser{}
+	usr.Settings.Notifications = user.NotificationPreferences{
+		PatchFinishID: "patch_finish_id",
+		CommitQueueID: "commit_queue_id",
+	}
+
+	t.Run("NoImplicitSubscriptions", func(t *testing.T) {
+		subs := []event.Subscription{
+			{ID: "123455"},
+			{ID: "abcdef"},
+		}
+		filteredSubIDs := removeImplicitSubscriptions(usr, subs)
+		assert.ElementsMatch(t, []string{"123455", "abcdef"}, filteredSubIDs)
+	})
+
+	t.Run("OnlyImplicitSubscriptions", func(t *testing.T) {
+		subs := []event.Subscription{
+			{ID: "patch_finish_id"},
+			{ID: "commit_queue_id"},
+		}
+		filteredSubIDs := removeImplicitSubscriptions(usr, subs)
+		assert.Empty(t, filteredSubIDs)
+	})
+
+	t.Run("MixImplicitSubscriptions", func(t *testing.T) {
+		subs := []event.Subscription{
+			{ID: "patch_finish_id"},
+			{ID: "123456"},
+		}
+		filteredSubIDs := removeImplicitSubscriptions(usr, subs)
+		assert.ElementsMatch(t, []string{"123456"}, filteredSubIDs)
+	})
 }

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -51,28 +51,28 @@ var (
 type OwnerType string
 
 const (
-	OwnerTypePerson                         OwnerType = "person"
-	OwnerTypeProject                        OwnerType = "project"
-	TaskDurationKey                                   = "task-duration-secs"
-	TaskPercentChangeKey                              = "task-percent-change"
-	BuildDurationKey                                  = "build-duration-secs"
-	BuildPercentChangeKey                             = "build-percent-change"
-	VersionDurationKey                                = "version-duration-secs"
-	VersionPercentChangeKey                           = "version-percent-change"
-	TestRegexKey                                      = "test-regex"
-	RenotifyIntervalKey                               = "renotify-interval"
-	ImplicitSubscriptionPatchOutcome                  = "patch-outcome"
-	ImplicitSubscriptionPatchFirstFailure             = "patch-first-failure"
-	ImplicitSubscriptionBuildBreak                    = "build-break"
-	ImplicitSubscriptionSpawnhostExpiration           = "spawnhost-expiration"
-	ImplicitSubscriptionSpawnHostOutcome              = "spawnhost-outcome"
+	OwnerTypePerson                        OwnerType = "person"
+	OwnerTypeProject                       OwnerType = "project"
+	TaskDurationKey                                  = "task-duration-secs"
+	TaskPercentChangeKey                             = "task-percent-change"
+	BuildDurationKey                                 = "build-duration-secs"
+	BuildPercentChangeKey                            = "build-percent-change"
+	VersionDurationKey                               = "version-duration-secs"
+	VersionPercentChangeKey                          = "version-percent-change"
+	TestRegexKey                                     = "test-regex"
+	RenotifyIntervalKey                              = "renotify-interval"
+	GeneralSubscriptionPatchOutcome                  = "patch-outcome"
+	GeneralSubscriptionPatchFirstFailure             = "patch-first-failure"
+	GeneralSubscriptionBuildBreak                    = "build-break"
+	GeneralSubscriptionSpawnhostExpiration           = "spawnhost-expiration"
+	GeneralSubscriptionSpawnHostOutcome              = "spawnhost-outcome"
+	GeneralSubscriptionCommitQueue                   = "commit-queue"
 
-	ImplicitSubscriptionCommitQueue = "commit-queue"
-	ObjectTask                      = "task"
-	ObjectVersion                   = "version"
-	ObjectBuild                     = "build"
-	ObjectHost                      = "host"
-	ObjectPatch                     = "patch"
+	ObjectTask    = "task"
+	ObjectVersion = "version"
+	ObjectBuild   = "build"
+	ObjectHost    = "host"
+	ObjectPatch   = "patch"
 
 	TriggerOutcome                   = "outcome"
 	TriggerGithubCheckOutcome        = "github-check-outcome"
@@ -698,7 +698,7 @@ func IsValidOwnerType(in string) bool {
 	}
 }
 
-func CreateOrUpdateImplicitSubscription(resourceType string, id string,
+func CreateOrUpdateGeneralSubscription(resourceType string, id string,
 	subscriber Subscriber, user string) (*Subscription, error) {
 	var err error
 	var sub *Subscription
@@ -712,17 +712,17 @@ func CreateOrUpdateImplicitSubscription(resourceType string, id string,
 		if sub == nil {
 			var temp Subscription
 			switch resourceType {
-			case ImplicitSubscriptionPatchOutcome:
+			case GeneralSubscriptionPatchOutcome:
 				temp = NewPatchOutcomeSubscriptionByOwner(user, subscriber)
-			case ImplicitSubscriptionPatchFirstFailure:
+			case GeneralSubscriptionPatchFirstFailure:
 				temp = NewFirstTaskFailureInVersionSubscriptionByOwner(user, subscriber)
-			case ImplicitSubscriptionBuildBreak:
+			case GeneralSubscriptionBuildBreak:
 				temp = NewBuildBreakSubscriptionByOwner(user, subscriber)
-			case ImplicitSubscriptionSpawnhostExpiration:
+			case GeneralSubscriptionSpawnhostExpiration:
 				temp = NewSpawnhostExpirationSubscription(user, subscriber)
-			case ImplicitSubscriptionSpawnHostOutcome:
+			case GeneralSubscriptionSpawnHostOutcome:
 				temp = NewSpawnHostOutcomeByOwner(user, subscriber)
-			case ImplicitSubscriptionCommitQueue:
+			case GeneralSubscriptionCommitQueue:
 				temp = NewCommitQueueSubscriptionByOwner(user, subscriber)
 			default:
 				return nil, errors.Errorf("unknown subscription resource type: %s", resourceType)
@@ -843,7 +843,7 @@ func NewBuildBreakSubscriptionByOwner(owner string, sub Subscriber) Subscription
 	return Subscription{
 		ID:           mgobson.NewObjectId().Hex(),
 		ResourceType: ResourceTypeTask,
-		Trigger:      ImplicitSubscriptionBuildBreak,
+		Trigger:      GeneralSubscriptionBuildBreak,
 		Selectors: []Selector{
 			{
 				Type: SelectorOwner,

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -541,13 +541,13 @@ func (s *subscriptionsSuite) TestFindSubscriptionsByOwner() {
 	s.Nil(sub)
 }
 
-func (s *subscriptionsSuite) TestCreateOrUpdateImplicitSubscription() {
+func (s *subscriptionsSuite) TestCreateOrUpdateGeneralSubscription() {
 	subscriber := Subscriber{
 		Type:   SlackSubscriberType,
 		Target: "@octocat",
 	}
 
-	subscription, err := CreateOrUpdateImplicitSubscription(ImplicitSubscriptionCommitQueue, "",
+	subscription, err := CreateOrUpdateGeneralSubscription(GeneralSubscriptionCommitQueue, "",
 		subscriber, "octocat")
 	s.NoError(err)
 

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -419,7 +419,8 @@ func (u *DBUser) DeleteRoles(roles []string) error {
 	return nil
 }
 
-func (u *DBUser) ImplicitSubscriptionIDs() []string {
+// GeneralSubscriptionIDs returns a slice of the ids of the user's general subscriptions.
+func (u *DBUser) GeneralSubscriptionIDs() []string {
 	var ids []string
 	if id := u.Settings.Notifications.BuildBreakID; id != "" {
 		ids = append(ids, id)

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -419,6 +419,30 @@ func (u *DBUser) DeleteRoles(roles []string) error {
 	return nil
 }
 
+func (u *DBUser) ImplicitSubscriptionIDs() []string {
+	var ids []string
+	if id := u.Settings.Notifications.BuildBreakID; id != "" {
+		ids = append(ids, id)
+	}
+	if id := u.Settings.Notifications.PatchFinishID; id != "" {
+		ids = append(ids, id)
+	}
+	if id := u.Settings.Notifications.PatchFirstFailureID; id != "" {
+		ids = append(ids, id)
+	}
+	if id := u.Settings.Notifications.SpawnHostExpirationID; id != "" {
+		ids = append(ids, id)
+	}
+	if id := u.Settings.Notifications.SpawnHostOutcomeID; id != "" {
+		ids = append(ids, id)
+	}
+	if id := u.Settings.Notifications.CommitQueueID; id != "" {
+		ids = append(ids, id)
+	}
+
+	return ids
+}
+
 func IsValidSubscriptionPreference(in string) bool {
 	switch in {
 	case event.EmailSubscriberType, event.SlackSubscriberType, "", event.SubscriberTypeNone:

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -713,7 +713,7 @@ func TestGetOrCreateUser(t *testing.T) {
 	}
 }
 
-func TestImplicitSubscriptionIDs(t *testing.T) {
+func TestGeneralSubscriptionIDs(t *testing.T) {
 	u := DBUser{}
 	u.Settings.Notifications = NotificationPreferences{
 		BuildBreakID:          "BuildBreakID",
@@ -731,7 +731,7 @@ func TestImplicitSubscriptionIDs(t *testing.T) {
 		"SpawnHostExpirationID",
 		"SpawnHostOutcomeID",
 		"CommitQueueID",
-	}, u.ImplicitSubscriptionIDs())
+	}, u.GeneralSubscriptionIDs())
 }
 
 func TestViewableProjectSettings(t *testing.T) {

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -713,6 +713,27 @@ func TestGetOrCreateUser(t *testing.T) {
 	}
 }
 
+func TestImplicitSubscriptionIDs(t *testing.T) {
+	u := DBUser{}
+	u.Settings.Notifications = NotificationPreferences{
+		BuildBreakID:          "BuildBreakID",
+		PatchFinishID:         "PatchFinishID",
+		PatchFirstFailureID:   "PatchFirstFailureID",
+		SpawnHostExpirationID: "SpawnHostExpirationID",
+		SpawnHostOutcomeID:    "SpawnHostOutcomeID",
+		CommitQueueID:         "CommitQueueID",
+	}
+
+	assert.ElementsMatch(t, []string{
+		"BuildBreakID",
+		"PatchFinishID",
+		"PatchFirstFailureID",
+		"SpawnHostExpirationID",
+		"SpawnHostOutcomeID",
+		"CommitQueueID",
+	}, u.ImplicitSubscriptionIDs())
+}
+
 func TestViewableProjectSettings(t *testing.T) {
 	rm := evergreen.GetEnvironment().RoleManager()
 	assert.NoError(t, db.ClearCollections(evergreen.RoleCollection, evergreen.ScopeCollection, Collection))

--- a/rest/data/user.go
+++ b/rest/data/user.go
@@ -33,7 +33,7 @@ func UpdateSettings(dbUser *user.DBUser, settings user.UserSettings) error {
 	case user.PreferenceEmail:
 		patchSubscriber = event.NewEmailSubscriber(dbUser.Email())
 	}
-	patchSubscription, err := event.CreateOrUpdateImplicitSubscription(event.ImplicitSubscriptionPatchOutcome,
+	patchSubscription, err := event.CreateOrUpdateGeneralSubscription(event.GeneralSubscriptionPatchOutcome,
 		dbUser.Settings.Notifications.PatchFinishID, patchSubscriber, dbUser.Id)
 	if err != nil {
 		return err
@@ -51,7 +51,7 @@ func UpdateSettings(dbUser *user.DBUser, settings user.UserSettings) error {
 	case user.PreferenceEmail:
 		patchFailureSubscriber = event.NewEmailSubscriber(dbUser.Email())
 	}
-	patchFailureSubscription, err := event.CreateOrUpdateImplicitSubscription(event.ImplicitSubscriptionPatchFirstFailure,
+	patchFailureSubscription, err := event.CreateOrUpdateGeneralSubscription(event.GeneralSubscriptionPatchFirstFailure,
 		dbUser.Settings.Notifications.PatchFirstFailureID, patchFailureSubscriber, dbUser.Id)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func UpdateSettings(dbUser *user.DBUser, settings user.UserSettings) error {
 	case user.PreferenceEmail:
 		buildBreakSubscriber = event.NewEmailSubscriber(dbUser.Email())
 	}
-	buildBreakSubscription, err := event.CreateOrUpdateImplicitSubscription(event.ImplicitSubscriptionBuildBreak,
+	buildBreakSubscription, err := event.CreateOrUpdateGeneralSubscription(event.GeneralSubscriptionBuildBreak,
 		dbUser.Settings.Notifications.BuildBreakID, buildBreakSubscriber, dbUser.Id)
 	if err != nil {
 		return err
@@ -87,7 +87,7 @@ func UpdateSettings(dbUser *user.DBUser, settings user.UserSettings) error {
 	case user.PreferenceEmail:
 		spawnhostSubscriber = event.NewEmailSubscriber(dbUser.Email())
 	}
-	spawnhostSubscription, err := event.CreateOrUpdateImplicitSubscription(event.ImplicitSubscriptionSpawnhostExpiration,
+	spawnhostSubscription, err := event.CreateOrUpdateGeneralSubscription(event.GeneralSubscriptionSpawnhostExpiration,
 		dbUser.Settings.Notifications.SpawnHostExpirationID, spawnhostSubscriber, dbUser.Id)
 	if err != nil {
 		return err
@@ -105,7 +105,7 @@ func UpdateSettings(dbUser *user.DBUser, settings user.UserSettings) error {
 	case user.PreferenceEmail:
 		spawnHostOutcomeSubscriber = event.NewEmailSubscriber(dbUser.Email())
 	}
-	spawnHostOutcomeSubscription, err := event.CreateOrUpdateImplicitSubscription(event.ImplicitSubscriptionSpawnHostOutcome,
+	spawnHostOutcomeSubscription, err := event.CreateOrUpdateGeneralSubscription(event.GeneralSubscriptionSpawnHostOutcome,
 		dbUser.Settings.Notifications.SpawnHostOutcomeID, spawnHostOutcomeSubscriber, dbUser.Id)
 	if err != nil {
 		return errors.Wrap(err, "failed to create spawn host outcome subscription")
@@ -123,7 +123,7 @@ func UpdateSettings(dbUser *user.DBUser, settings user.UserSettings) error {
 	case user.PreferenceEmail:
 		commitQueueSubscriber = event.NewEmailSubscriber(dbUser.Email())
 	}
-	commitQueueSubscription, err := event.CreateOrUpdateImplicitSubscription(event.ImplicitSubscriptionCommitQueue,
+	commitQueueSubscription, err := event.CreateOrUpdateGeneralSubscription(event.GeneralSubscriptionCommitQueue,
 		dbUser.Settings.Notifications.CommitQueueID, commitQueueSubscriber, dbUser.Id)
 	if err != nil {
 		return errors.Wrap(err, "failed to create commit queue subscription")

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -648,7 +648,7 @@ func setDefaultNotification(username string) error {
 	if u.Settings.Notifications.CommitQueue == "" {
 		u.Settings.Notifications.CommitQueue = user.PreferenceEmail
 		commitQueueSubscriber := event.NewEmailSubscriber(u.Email())
-		commitQueueSubscription, err := event.CreateOrUpdateImplicitSubscription(event.ImplicitSubscriptionCommitQueue,
+		commitQueueSubscription, err := event.CreateOrUpdateGeneralSubscription(event.GeneralSubscriptionCommitQueue,
 			"", commitQueueSubscriber, u.Id)
 		if err != nil {
 			return errors.Wrap(err, "can't create default email subscription")


### PR DESCRIPTION
[EVG-16645](https://jira.mongodb.org/browse/EVG-16645)

### Description 
If a user clicks the big red button we should shield their implicit (patch finish, build break, etc.) subscriptions from getting deleted.
![Screen Shot 2022-03-31 at 12 02 32 PM](https://user-images.githubusercontent.com/17027265/161099474-44805e3f-bceb-4e4e-b9af-43463d81248b.png)
The old UI's corresponding button didn't clear them because [they were filtered from the list of IDs](https://github.com/evergreen-ci/evergreen/blob/88d45f4e8d0de025d89c9d75683a2d99cde96d2d/public/static/js/notifications.js#L28-L39) sent to the application.


### Testing 
Added unit tests. 
Verified on staging that before these changes implicit subscriptions were removed and with the changes they aren't removed.
