### PR TITLE
EVG-16559 Refactor distro DB functions to fit convention

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -50,6 +50,9 @@ func (so *SpawnOptions) validate(settings *evergreen.Settings) error {
 	if err != nil {
 		return errors.Errorf("error finding distro '%s'", so.DistroId)
 	}
+	if d == nil {
+		return errors.Errorf("distro '%s' not found", so.DistroId)
+	}
 
 	if !d.SpawnAllowed {
 		return errors.Errorf("Invalid spawn options: spawning not allowed for distro %s", so.DistroId)
@@ -111,6 +114,9 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 	d, err := distro.FindOneId(so.DistroId)
 	if err != nil {
 		return nil, errors.WithStack(errors.Wrap(err, "error finding distro"))
+	}
+	if d == nil {
+		return nil, errors.Errorf("distro '%s' not found", so.DistroId)
 	}
 	if so.Region == "" && IsEc2Provider(d.Provider) {
 		u := gimlet.GetUser(ctx)

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -154,13 +154,13 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 		}
 	}
 
-	d.ProviderSettingsList, err = modifySpawnHostProviderSettings(d, settings, so.Region, so.HomeVolumeID)
+	d.ProviderSettingsList, err = modifySpawnHostProviderSettings(*d, settings, so.Region, so.HomeVolumeID)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't get new provider settings")
 	}
 
 	if so.InstanceType != "" {
-		if err := CheckInstanceTypeValid(ctx, d, so.InstanceType, settings.Providers.AWS.AllowedInstanceTypes); err != nil {
+		if err := CheckInstanceTypeValid(ctx, *d, so.InstanceType, settings.Providers.AWS.AllowedInstanceTypes); err != nil {
 			return nil, errors.Wrap(err, "error validating instance type")
 		}
 	}
@@ -182,7 +182,7 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 		expiration = evergreen.SpawnHostNoExpirationDuration
 	}
 	hostOptions := host.CreateOptions{
-		Distro:               d,
+		Distro:               *d,
 		ProvisionOptions:     so.ProvisionOptions,
 		UserName:             so.UserName,
 		ExpirationTime:       time.Now().Add(expiration),

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -725,7 +725,7 @@ func (r *mutationResolver) SpawnHost(ctx context.Context, spawnHostInput *SpawnH
 			return nil, err
 		}
 	}
-	dist, err := distro.FindByID(spawnHostInput.DistroID)
+	dist, err := distro.FindOneId(spawnHostInput.DistroID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while trying to find distro with id: %s, err:  `%s`", spawnHostInput.DistroID, err))
 	}

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -78,13 +78,17 @@ const Collection = "distro"
 var All = db.Query(nil).Sort([]string{IdKey})
 
 // FindOne gets one Distro for the given query.
-func FindOne(query db.Q) (Distro, error) {
-	d := Distro{}
-	return d, db.FindOneQ(Collection, query, &d)
+func FindOne(query db.Q) (*Distro, error) {
+	d := &Distro{}
+	err := db.FindOneQ(Collection, query, d)
+	if adb.ResultsNotFound(err) {
+		return nil, nil
+	}
+	return d, err
 }
 
 // FindOneId returns one Distro by Id.
-func FindOneId(id string) (Distro, error) {
+func FindOneId(id string) (*Distro, error) {
 	return FindOne(ById(id))
 }
 
@@ -93,18 +97,6 @@ func Find(query db.Q) ([]Distro, error) {
 	distros := []Distro{}
 	err := db.FindAllQ(Collection, query, &distros)
 	return distros, err
-}
-
-func FindByID(id string) (*Distro, error) {
-	d, err := FindOneId(id)
-	if adb.ResultsNotFound(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, errors.Wrap(err, "problem finding distro")
-	}
-
-	return &d, nil
 }
 
 func FindAll() ([]Distro, error) {
@@ -183,7 +175,7 @@ func ByIds(ids []string) db.Q {
 }
 
 func FindByIdWithDefaultSettings(id string) (*Distro, error) {
-	d, err := FindByID(id)
+	d, err := FindOneId(id)
 	if err != nil {
 		return d, errors.WithStack(err)
 	}

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -537,7 +537,7 @@ func ValidateContainerPoolDistros(s *evergreen.Settings) error {
 			catcher.Add(fmt.Errorf("error finding distro for container pool '%s'", pool.Id))
 		}
 		if d == nil {
-			catcher.Add(fmt.Errorf("distro not found for container pool '%s'", pool.Id))
+			catcher.Errorf("distro not found for container pool '%s'", pool.Id)
 		}
 		if d != nil && d.ContainerPool != "" {
 			catcher.Add(fmt.Errorf("container pool '%s' has invalid distro '%s'", pool.Id, d.Id))

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -536,7 +536,10 @@ func ValidateContainerPoolDistros(s *evergreen.Settings) error {
 		if err != nil {
 			catcher.Add(fmt.Errorf("error finding distro for container pool '%s'", pool.Id))
 		}
-		if d.ContainerPool != "" {
+		if d == nil {
+			catcher.Add(fmt.Errorf("distro not found for container pool '%s'", pool.Id))
+		}
+		if d != nil && d.ContainerPool != "" {
 			catcher.Add(fmt.Errorf("container pool '%s' has invalid distro '%s'", pool.Id, d.Id))
 		}
 	}

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -1,7 +1,9 @@
 package distro
 
 import (
+	"context"
 	"fmt"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"regexp"
 	"strings"
 	"testing"
@@ -100,6 +102,10 @@ func TestIsParent(t *testing.T) {
 }
 
 func TestValidateContainerPoolDistros(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := testutil.NewEnvironment(ctx, t)
+	evergreen.SetEnvironment(env)
 	assert := assert.New(t)
 	assert.NoError(db.Clear(Collection))
 
@@ -137,7 +143,7 @@ func TestValidateContainerPoolDistros(t *testing.T) {
 
 	err := ValidateContainerPoolDistros(testSettings)
 	assert.Contains(err.Error(), "container pool 'test-pool-2' has invalid distro 'invalid-distro'")
-	assert.Contains(err.Error(), "error finding distro for container pool 'test-pool-3'")
+	assert.Contains(err.Error(), "distro not found for container pool 'test-pool-3'")
 }
 
 func TestGetDistroIds(t *testing.T) {

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -1,9 +1,7 @@
 package distro
 
 import (
-	"context"
 	"fmt"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"regexp"
 	"strings"
 	"testing"
@@ -102,10 +100,6 @@ func TestIsParent(t *testing.T) {
 }
 
 func TestValidateContainerPoolDistros(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
 	assert := assert.New(t)
 	assert.NoError(db.Clear(Collection))
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2131,7 +2131,7 @@ func getNumNewParentsAndHostsToSpawn(pool *evergreen.ContainerPool, newContainer
 	}
 
 	if !ignoreMaxHosts { // only want to spawn amount of parents allowed based on pool size
-		if numNewParentsToSpawn, err = parentCapacity(parentDistro, numNewParentsToSpawn, len(existingParents), pool); err != nil {
+		if numNewParentsToSpawn, err = parentCapacity(*parentDistro, numNewParentsToSpawn, len(existingParents), pool); err != nil {
 			return 0, 0, errors.Wrap(err, "could not calculate number of parents needed to spawn")
 		}
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2129,6 +2129,9 @@ func getNumNewParentsAndHostsToSpawn(pool *evergreen.ContainerPool, newContainer
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "error find parent distro")
 	}
+	if parentDistro == nil {
+		return 0, 0, errors.Errorf("distro '%s' not found", pool.Distro)
+	}
 
 	if !ignoreMaxHosts { // only want to spawn amount of parents allowed based on pool size
 		if numNewParentsToSpawn, err = parentCapacity(*parentDistro, numNewParentsToSpawn, len(existingParents), pool); err != nil {

--- a/model/scheduler_stats_test.go
+++ b/model/scheduler_stats_test.go
@@ -283,9 +283,9 @@ func TestAverageStatistics(t *testing.T) {
 			So(avgBuckets[1].AverageTime, ShouldEqual, 0)
 			So(avgBuckets[2].AverageTime, ShouldEqual, 15*time.Second)
 
-			Convey("if the distro id given does not exist, it shoud return an empty list", func() {
+			Convey("if the distro id given does not exist, it shoud return an empty list and no error", func() {
 				_, err := AverageStatistics("noId", frameBounds)
-				So(err, ShouldNotBeNil)
+				So(err, ShouldBeNil)
 			})
 		})
 	})

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2521,12 +2521,15 @@ func FindHostSchedulableForAlias(id string) ([]Task, error) {
 // removeDeps is true, tasks with unmet dependencies are excluded.
 func FindHostRunnable(distroID string, removeDeps bool) ([]Task, error) {
 	match := schedulableHostTasksQuery()
-	var d *distro.Distro
+	var d distro.Distro
 	var err error
 	if distroID != "" {
-		d, err = distro.FindOne(distro.ById(distroID).WithFields(distro.ValidProjectsKey))
+		foundDistro, err := distro.FindOne(distro.ById(distroID).WithFields(distro.ValidProjectsKey))
 		if err != nil {
 			return nil, errors.Wrapf(err, "problem finding distro '%s'", distroID)
+		}
+		if foundDistro != nil {
+			d = *foundDistro
 		}
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2521,7 +2521,7 @@ func FindHostSchedulableForAlias(id string) ([]Task, error) {
 // removeDeps is true, tasks with unmet dependencies are excluded.
 func FindHostRunnable(distroID string, removeDeps bool) ([]Task, error) {
 	match := schedulableHostTasksQuery()
-	var d distro.Distro
+	var d *distro.Distro
 	var err error
 	if distroID != "" {
 		d, err = distro.FindOne(distro.ById(distroID).WithFields(distro.ValidProjectsKey))

--- a/model/task_queue_service.go
+++ b/model/task_queue_service.go
@@ -85,12 +85,13 @@ func (s *taskDispatchService) Refresh(distroID string) error {
 }
 
 func (s *taskDispatchService) ensureQueue(distroID string) (CachedDispatcher, error) {
-	d, err := distro.FindOneId(distroID)
+	d := distro.Distro{}
+	foundDistro, err := distro.FindOneId(distroID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "database error for find() by distro id '%s'", distroID)
 	}
-	if d == nil {
-		return nil, errors.Errorf("distro '%s' not found", distroID)
+	if foundDistro != nil {
+		d = *foundDistro
 	}
 	// If there is a "distro": *basicCachedDispatcherImpl in the cachedDispatchers map, return that.
 	// Otherwise, get the "distro"'s taskQueue from the database; seed its cachedDispatcher; put that in the map and return it.

--- a/model/task_queue_service.go
+++ b/model/task_queue_service.go
@@ -89,6 +89,9 @@ func (s *taskDispatchService) ensureQueue(distroID string) (CachedDispatcher, er
 	if err != nil {
 		return nil, errors.Wrapf(err, "database error for find() by distro id '%s'", distroID)
 	}
+	if d == nil {
+		return nil, errors.Errorf("distro '%s' not found", distroID)
+	}
 	// If there is a "distro": *basicCachedDispatcherImpl in the cachedDispatchers map, return that.
 	// Otherwise, get the "distro"'s taskQueue from the database; seed its cachedDispatcher; put that in the map and return it.
 	s.mu.Lock()

--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -41,7 +41,7 @@ func UpdateDistro(old, new *distro.Distro) error {
 
 // DeleteDistroById removes a given distro from the database based on its id.
 func DeleteDistroById(distroId string) error {
-	d, err := distro.FindByID(distroId)
+	d, err := distro.FindOneId(distroId)
 	if err != nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,

--- a/rest/data/distro_test.go
+++ b/rest/data/distro_test.go
@@ -91,8 +91,8 @@ func TestDeleteDistroById(t *testing.T) {
 	require.NoError(t, DeleteDistroById(d.Id))
 
 	dbDistro, err := distro.FindOneId(d.Id)
-	assert.Error(t, err)
-	assert.Zero(t, dbDistro)
+	assert.NoError(t, err)
+	assert.Nil(t, dbDistro)
 
 	dbQueue, err := model.LoadTaskQueue(queue.Distro)
 	require.NoError(t, err)

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -248,7 +248,7 @@ func makeDockerIntentHost(taskID, userID string, createHost apimodels.CreateHost
 	var d *distro.Distro
 	var err error
 
-	d, err = distro.FindByID(createHost.Distro)
+	d, err = distro.FindOneId(createHost.Distro)
 	if err != nil {
 		return nil, errors.Wrapf(err, "problem finding distro '%s'", createHost.Distro)
 	}
@@ -327,7 +327,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		createHost.Region = evergreen.DefaultEC2Region
 	}
 	// get distro if it is set
-	d := distro.Distro{}
+	d := &distro.Distro{}
 	ec2Settings := cloud.EC2ProviderSettings{}
 	var err error
 	if distroID := createHost.Distro; distroID != "" {
@@ -344,7 +344,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 		if err != nil {
 			return nil, errors.Wrapf(err, "problem finding distro '%s'", distroID)
 		}
-		if err = ec2Settings.FromDistroSettings(d, createHost.Region); err != nil {
+		if err = ec2Settings.FromDistroSettings(*d, createHost.Region); err != nil {
 			return nil, errors.Wrapf(err, "error getting ec2 provider from distro")
 		}
 	}
@@ -411,7 +411,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	}
 	d.ProviderSettingsList = []*birch.Document{doc}
 
-	options, err := getAgentOptions(d, taskID, userID, createHost)
+	options, err := getAgentOptions(*d, taskID, userID, createHost)
 	if err != nil {
 		return nil, errors.Wrap(err, "error making host options for EC2")
 	}

--- a/rest/data/scheduler.go
+++ b/rest/data/scheduler.go
@@ -42,7 +42,7 @@ func CompareTasks(taskIds []string, useLegacy bool) ([]string, map[string]map[st
 			prioritizedIds = append(prioritizedIds, t.Id)
 		}
 	} else { // this is temporary: logic should be added in EVG-13795
-		d, err := distro.FindByID(distroId)
+		d, err := distro.FindOneId(distroId)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to find distro")
 		}

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -235,7 +235,7 @@ func (s *AdminRouteSuite) TestAdminRoute() {
 	s.NoError(s.postHandler.Parse(ctx, request))
 	resp = s.postHandler.Run(ctx)
 	s.Contains(resp.Data().(gimlet.ErrorResponse).Message, "container pool 'test-pool-2' has invalid distro 'invalid-distro'")
-	s.Contains(resp.Data().(gimlet.ErrorResponse).Message, "error finding distro for container pool 'test-pool-3'")
+	s.Contains(resp.Data().(gimlet.ErrorResponse).Message, "distro not found for container pool 'test-pool-3'")
 	s.NotNil(resp)
 }
 

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -107,7 +107,7 @@ func (h *distroIDChangeSetupHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	d.Setup = h.Setup
-	if err = data.UpdateDistro(&d, &d); err != nil {
+	if err = data.UpdateDistro(d, d); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for update() by distro id '%s'", h.distroID))
 	}
 
@@ -156,7 +156,7 @@ func (h *distroIDPutHandler) Parse(ctx context.Context, r *http.Request) error {
 // (b) creates a new resource based on the Request-URI and JSON payload
 func (h *distroIDPutHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
-	original, err := distro.FindByID(h.distroID)
+	original, err := distro.FindOneId(h.distroID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
@@ -329,7 +329,7 @@ func (h *distroIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return respErr
 	}
 
-	if err = data.UpdateDistro(&old, d); err != nil {
+	if err = data.UpdateDistro(old, d); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "Database error for update() by distro id '%s'", h.distroID))
 	}
 	event.LogDistroModified(h.distroID, user.Username(), d.NewDistroData())

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -51,7 +51,7 @@ func (h *distroIDGetSetupHandler) Parse(ctx context.Context, r *http.Request) er
 // Run returns the given distro's setup script.
 func (h *distroIDGetSetupHandler) Run(ctx context.Context) gimlet.Responder {
 	d, err := distro.FindOneId(h.distroID)
-	if err != nil {
+	if err != nil || d == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("distro with id '%s' not found", h.distroID),
@@ -59,7 +59,7 @@ func (h *distroIDGetSetupHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	apiDistro := &model.APIDistro{}
-	if err = apiDistro.BuildFromService(&d); err != nil {
+	if err = apiDistro.BuildFromService(d); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "API error converting from distro.Distro to model.APIDistro"))
 	}
 
@@ -99,7 +99,7 @@ func (h *distroIDChangeSetupHandler) Parse(ctx context.Context, r *http.Request)
 // Run updates the setup script for the given distroId.
 func (h *distroIDChangeSetupHandler) Run(ctx context.Context) gimlet.Responder {
 	d, err := distro.FindOneId(h.distroID)
-	if err != nil {
+	if err != nil || d == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("distro with id '%s' not found", h.distroID),
@@ -112,7 +112,7 @@ func (h *distroIDChangeSetupHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	apiDistro := &model.APIDistro{}
-	if err = apiDistro.BuildFromService(&d); err != nil {
+	if err = apiDistro.BuildFromService(d); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "API error converting from distro.Distro to model.APIDistro"))
 	}
 
@@ -300,7 +300,7 @@ func (h *distroIDPatchHandler) Parse(ctx context.Context, r *http.Request) error
 func (h *distroIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
 	old, err := distro.FindOneId(h.distroID)
-	if err != nil {
+	if err != nil || old == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("distro with id '%s' not found", h.distroID),
@@ -308,7 +308,7 @@ func (h *distroIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	apiDistro := &model.APIDistro{}
-	if err = apiDistro.BuildFromService(&old); err != nil {
+	if err = apiDistro.BuildFromService(old); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "API error converting from distro.Distro to model.APIDistro"))
 	}
 	oldSettingsList := apiDistro.ProviderSettingsList
@@ -363,7 +363,7 @@ func (h *distroIDGetHandler) Parse(ctx context.Context, r *http.Request) error {
 // Run calls the data FindDistroById function and returns the distro from the provider.
 func (h *distroIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 	d, err := distro.FindOneId(h.distroID)
-	if err != nil {
+	if err != nil || d == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("distro with id '%s' not found", h.distroID),
@@ -371,7 +371,7 @@ func (h *distroIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	apiDistro := &model.APIDistro{}
-	if err = apiDistro.BuildFromService(&d); err != nil {
+	if err = apiDistro.BuildFromService(d); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "API error converting from distro.Distro to model.APIDistro"))
 	}
 
@@ -865,7 +865,7 @@ func (rh *distroClientURLsGetHandler) Parse(ctx context.Context, r *http.Request
 
 func (rh *distroClientURLsGetHandler) Run(ctx context.Context) gimlet.Responder {
 	d, err := distro.FindOneId(rh.distroID)
-	if err != nil {
+	if err != nil || d == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("distro with id '%s' not found", rh.distroID),

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -407,7 +407,7 @@ func (h *distroAMIHandler) Parse(ctx context.Context, r *http.Request) error {
 
 func (h *distroAMIHandler) Run(ctx context.Context) gimlet.Responder {
 	d, err := distro.FindOneId(h.distroID)
-	if err != nil {
+	if err != nil || d == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("distro with id '%s' not found", h.distroID),

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -250,8 +250,8 @@ func (h *distroIDDeleteHandler) Parse(ctx context.Context, r *http.Request) erro
 
 // Run deletes a distro by id.
 func (h *distroIDDeleteHandler) Run(ctx context.Context) gimlet.Responder {
-	_, err := distro.FindOneId(h.distroID)
-	if err != nil {
+	d, err := distro.FindOneId(h.distroID)
+	if err != nil || d == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("distro with id '%s' not found", h.distroID),

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -386,7 +386,7 @@ func TestUpdateDistrosSettingsHandlerRun(t *testing.T) {
 	resp := h.Run(ctx)
 	assert.Equal(t, http.StatusOK, resp.Status())
 
-	distroFromDB, err := distro.FindByID("d1")
+	distroFromDB, err := distro.FindOneId("d1")
 	assert.NoError(t, err)
 	assert.NotNil(t, distroFromDB)
 	assert.Len(t, distroFromDB.ProviderSettingsList, 2)

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -60,7 +60,7 @@ func TestHostPostHandler(t *testing.T) {
 	assert.Equal(http.StatusOK, resp.Status())
 
 	h0 := resp.Data().(*model.APIHost)
-	d0, err := distro.FindByID("distro")
+	d0, err := distro.FindOneId("distro")
 	assert.NoError(err)
 	userdata, ok := d0.ProviderSettingsList[0].Lookup("user_data").StringValueOK()
 	assert.False(ok)
@@ -81,7 +81,7 @@ func TestHostPostHandler(t *testing.T) {
 	assert.NoError(d.Update())
 
 	h1 := resp.Data().(*model.APIHost)
-	d1, err := distro.FindByID("distro")
+	d1, err := distro.FindOneId("distro")
 	assert.NoError(err)
 	userdata, ok = d1.ProviderSettingsList[0].Lookup("user_data").StringValueOK()
 	assert.True(ok)

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -778,7 +778,7 @@ func urlVarsToDistroScopes(r *http.Request) ([]string, int, error) {
 	// Verify that all the concrete distros that this request is accessing
 	// exist.
 	for _, resolvedDistroID := range distroIDs {
-		d, err := distro.FindByID(resolvedDistroID)
+		d, err := distro.FindOneId(resolvedDistroID)
 		if err != nil {
 			return nil, http.StatusInternalServerError, errors.WithStack(err)
 		}

--- a/scheduler/utilization_based_host_allocator.go
+++ b/scheduler/utilization_based_host_allocator.go
@@ -161,6 +161,9 @@ func evalHostUtilization(ctx context.Context, d distro.Distro, taskGroupData Tas
 		if err != nil {
 			return 0, 0, errors.Wrap(err, "error finding parent distros")
 		}
+		if parentDistro == nil {
+			return 0, 0, errors.Errorf("distro '%s' not found", containerPool.Distro)
+		}
 		maxHosts = parentDistro.HostAllocatorSettings.MaximumHosts * containerPool.MaxContainers
 	}
 

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -81,7 +81,7 @@ func PlanDistro(ctx context.Context, conf Configuration, s *evergreen.Settings) 
 
 	taskFindingBegins := time.Now()
 	finder := GetTaskFinder(conf.TaskFinder)
-	tasks, err := finder(distro)
+	tasks, err := finder(*distro)
 	if err != nil {
 		return errors.Wrapf(err, "problem while running task finder for distro '%s'", distro.Id)
 	}
@@ -99,7 +99,7 @@ func PlanDistro(ctx context.Context, conf Configuration, s *evergreen.Settings) 
 	/////////////////
 
 	planningPhaseBegins := time.Now()
-	prioritizedTasks, err := PrioritizeTasks(&distro, tasks, TaskPlannerOptions{
+	prioritizedTasks, err := PrioritizeTasks(distro, tasks, TaskPlannerOptions{
 		StartedAt:        taskFindingBegins,
 		ID:               schedulerInstanceID,
 		IsSecondaryQueue: false,

--- a/scheduler/wrapper.go
+++ b/scheduler/wrapper.go
@@ -33,6 +33,9 @@ func PlanDistro(ctx context.Context, conf Configuration, s *evergreen.Settings) 
 	if err != nil {
 		return errors.Wrap(err, "problem finding distro")
 	}
+	if distro == nil {
+		return errors.Errorf("distro '%s' not found", conf.DistroID)
+	}
 
 	if err = underwaterUnschedule(distro.Id); err != nil {
 		return errors.Wrap(err, "problem unscheduling underwater tasks")

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -589,7 +589,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 			"distro_id": currentHost.Distro.Id,
 			"host_id":   currentHost.Id,
 		})
-		d = currentHost.Distro
+		d = &currentHost.Distro
 	}
 	grip.DebugWhen(currentHost.Distro.Id == distroToMonitor, message.Fields{
 		"message":     "assignNextAvailableTask performance",

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -578,7 +578,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 	}
 
 	d, err := distro.FindOneId(currentHost.Distro.Id)
-	if err != nil {
+	if err != nil || d == nil {
 		// Should we bailout if there is a database error leaving us unsure if the distro document actually exists?
 		m := "database error while retrieving distro document;"
 		if adb.ResultsNotFound(err) {

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -18,7 +18,6 @@ import (
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
-	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/sometimes"
@@ -581,7 +580,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 	if err != nil || d == nil {
 		// Should we bailout if there is a database error leaving us unsure if the distro document actually exists?
 		m := "database error while retrieving distro document;"
-		if adb.ResultsNotFound(err) {
+		if d == nil {
 			m = "cannot find the db.distro document for the given distro;"
 		}
 		grip.Warning(message.Fields{

--- a/service/distros.go
+++ b/service/distros.go
@@ -121,6 +121,12 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusInternalServerError)
 		return
 	}
+	if oldDistro == nil {
+		message := fmt.Sprintf("distro '%s' doesn't exist", id)
+		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
+		http.Error(w, message, http.StatusBadRequest)
+		return
+	}
 
 	newDistro := oldDistro
 	newDistro.ProviderSettingsList = []*birch.Document{} // remove old list to prevent collisions within birch documents
@@ -297,6 +303,12 @@ func (uis *UIServer) getDistro(w http.ResponseWriter, r *http.Request) {
 		message := fmt.Sprintf("error fetching distro '%v': %v", id, err)
 		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
 		http.Error(w, message, http.StatusInternalServerError)
+		return
+	}
+	if d == nil {
+		message := fmt.Sprintf("distro '%s' doesn't exist", id)
+		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
+		http.Error(w, message, http.StatusBadRequest)
 		return
 	}
 

--- a/service/distros.go
+++ b/service/distros.go
@@ -154,7 +154,7 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// check that the resulting distro is valid
-	vErrs, err := validator.CheckDistro(r.Context(), &newDistro, settings, false)
+	vErrs, err := validator.CheckDistro(r.Context(), newDistro, settings, false)
 	if err != nil {
 		message := fmt.Sprintf("error retrieving distroIds: %v", err)
 		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
@@ -249,7 +249,7 @@ func (uis *UIServer) removeDistro(w http.ResponseWriter, r *http.Request) {
 
 	u := MustHaveUser(r)
 
-	d, err := distro.FindByID(id)
+	d, err := distro.FindOneId(id)
 	if err != nil {
 		message := fmt.Sprintf("error finding distro: %v", err)
 		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))
@@ -312,7 +312,7 @@ func (uis *UIServer) getDistro(w http.ResponseWriter, r *http.Request) {
 		Distro      distro.Distro      `json:"distro"`
 		Regions     []string           `json:"regions"`
 		Permissions gimlet.Permissions `json:"permissions"`
-	}{d, regions, permissions}
+	}{*d, regions, permissions}
 
 	gimlet.WriteJSON(w, data)
 }

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -43,7 +43,7 @@ var (
 )
 
 func (uis *UIServer) spawnPage(w http.ResponseWriter, r *http.Request) {
-	var spawnDistro *distro.Distro
+	var spawnDistro distro.Distro
 	var spawnTask *task.Task
 	var err error
 
@@ -80,9 +80,12 @@ func (uis *UIServer) spawnPage(w http.ResponseWriter, r *http.Request) {
 		// Make a best-effort attempt to find a matching distro, but don't error
 		// if we can't find one.
 		for _, distroID := range dat.Expand([]string{r.FormValue("distro_id")}) {
-			spawnDistro, err = distro.FindOneId(distroID)
+			foundSpawnDistro, err := distro.FindOneId(distroID)
 			if err == nil {
 				break
+			}
+			if foundSpawnDistro != nil {
+				spawnDistro = *foundSpawnDistro
 			}
 		}
 	}
@@ -137,7 +140,7 @@ func (uis *UIServer) spawnPage(w http.ResponseWriter, r *http.Request) {
 		SetupScriptPath              string
 		NewUILink                    string
 		ViewData
-	}{*spawnDistro, spawnTask, maxHosts, settings.Spawnhost.UnexpirableHostsPerUser, settings.Spawnhost.UnexpirableVolumesPerUser, settings.Providers.AWS.MaxVolumeSizePerUser,
+	}{spawnDistro, spawnTask, maxHosts, settings.Spawnhost.UnexpirableHostsPerUser, settings.Spawnhost.UnexpirableVolumesPerUser, settings.Providers.AWS.MaxVolumeSizePerUser,
 		setupScriptPath, newUILink, uis.GetCommonViewData(w, r, false, true)}, "base", "spawned_hosts.html", "base_angular.html", "menu.html")
 }
 

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -43,7 +43,7 @@ var (
 )
 
 func (uis *UIServer) spawnPage(w http.ResponseWriter, r *http.Request) {
-	var spawnDistro distro.Distro
+	var spawnDistro *distro.Distro
 	var spawnTask *task.Task
 	var err error
 
@@ -137,7 +137,7 @@ func (uis *UIServer) spawnPage(w http.ResponseWriter, r *http.Request) {
 		SetupScriptPath              string
 		NewUILink                    string
 		ViewData
-	}{spawnDistro, spawnTask, maxHosts, settings.Spawnhost.UnexpirableHostsPerUser, settings.Spawnhost.UnexpirableVolumesPerUser, settings.Providers.AWS.MaxVolumeSizePerUser,
+	}{*spawnDistro, spawnTask, maxHosts, settings.Spawnhost.UnexpirableHostsPerUser, settings.Spawnhost.UnexpirableVolumesPerUser, settings.Providers.AWS.MaxVolumeSizePerUser,
 		setupScriptPath, newUILink, uis.GetCommonViewData(w, r, false, true)}, "base", "spawned_hosts.html", "base_angular.html", "menu.html")
 }
 

--- a/service/task.go
+++ b/service/task.go
@@ -322,7 +322,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 			// ensure that the ability to spawn is updated from the existing distro
 			taskHost.Distro.SpawnAllowed = false
 			var d *distro.Distro
-			d, err = distro.FindByID(taskHost.Distro.Id)
+			d, err = distro.FindOneId(taskHost.Distro.Id)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return

--- a/units/host_monitoring_parent_decommission.go
+++ b/units/host_monitoring_parent_decommission.go
@@ -56,7 +56,7 @@ func (j *parentDecommissionJob) Run(ctx context.Context) {
 		j.AddError(err)
 		return
 	}
-	parentDistro, err := distro.FindByID(j.DistroId)
+	parentDistro, err := distro.FindOneId(j.DistroId)
 	if err != nil {
 		j.AddError(err)
 		return

--- a/units/host_monitoring_parent_decommission.go
+++ b/units/host_monitoring_parent_decommission.go
@@ -61,7 +61,10 @@ func (j *parentDecommissionJob) Run(ctx context.Context) {
 		j.AddError(err)
 		return
 	}
-	minHosts := parentDistro.HostAllocatorSettings.MinimumHosts
+	minHosts := 0
+	if parentDistro != nil {
+		minHosts = parentDistro.HostAllocatorSettings.MinimumHosts
+	}
 	parentCount := len(parents)
 
 	for _, h := range parents {

--- a/units/host_monitoring_parent_decommission.go
+++ b/units/host_monitoring_parent_decommission.go
@@ -62,11 +62,10 @@ func (j *parentDecommissionJob) Run(ctx context.Context) {
 		j.AddError(err)
 		return
 	}
+	minHosts := 0
 	if parentDistro == nil {
 		j.AddError(errors.Errorf("distro '%s' not found", j.DistroId))
-	}
-	minHosts := 0
-	if parentDistro != nil {
+	} else if parentDistro != nil {
 		minHosts = parentDistro.HostAllocatorSettings.MinimumHosts
 	}
 	parentCount := len(parents)

--- a/units/host_monitoring_parent_decommission.go
+++ b/units/host_monitoring_parent_decommission.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
@@ -60,6 +61,9 @@ func (j *parentDecommissionJob) Run(ctx context.Context) {
 	if err != nil {
 		j.AddError(err)
 		return
+	}
+	if parentDistro == nil {
+		j.AddError(errors.Errorf("distro '%s' not found", j.DistroId))
 	}
 	minHosts := 0
 	if parentDistro != nil {

--- a/units/host_monitoring_parent_decommission.go
+++ b/units/host_monitoring_parent_decommission.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
@@ -11,6 +10,7 @@ import (
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/units/scheduler_alias.go
+++ b/units/scheduler_alias.go
@@ -78,7 +78,7 @@ func (j *distroAliasSchedulerJob) Run(ctx context.Context) {
 		return
 	}
 
-	d, err := distro.FindByID(j.DistroID)
+	d, err := distro.FindOneId(j.DistroID)
 	j.AddError(errors.Wrapf(err, "problem finding distro '%s'", j.DistroID))
 	if d == nil {
 		return


### PR DESCRIPTION
[EVG-16559](https://jira.mongodb.org/browse/EVG-16559)

### Description 
distro.FindOne works differently from other model FindOne functions in that it has no check for if adb.ResultsNotFound(err) in it, so a nil distro would also cause an error to return, and it returns a Distro object instead of a pointer which makes nil checks more difficult.

Changed to 1) no longer treat a nil distro as an error, and  2) return a distro pointer in distro DB functions.

### Testing 
Tests remain passing