### PR TITLE
EVG-16101 remove special JIRA build baron handling

### DIFF
--- a/trigger/task.go
+++ b/trigger/task.go
@@ -313,29 +313,6 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, testNames string) (*notification.Notification, error) {
 	var payload interface{}
 	if sub.Subscriber.Type == event.JIRAIssueSubscriberType {
-		// We avoid creating BFG ticket in the case that the task is setup-failed or stranded to reduce noise for the Build Baron
-		// If task is display, we skip ticket creation if all execution task failures are only 'stranded'
-		shouldSkipTicket := false
-		if t.task.DisplayOnly {
-			for _, exec := range t.task.ExecutionTasks {
-				executionTask, err := task.FindByIdExecution(exec, utility.ToIntPtr(t.task.Execution))
-				if err != nil {
-					return nil, errors.Wrapf(err, "error getting execution task")
-				}
-				if executionTask.Details.Status == evergreen.TaskFailed {
-					shouldSkipTicket = executionTask.Details.Description == evergreen.TaskDescriptionStranded ||
-						executionTask.IsSystemUnresponsive()
-					if !shouldSkipTicket {
-						break
-					}
-				}
-			}
-		} else {
-			shouldSkipTicket = t.task.Details.Description == evergreen.TaskDescriptionStranded
-		}
-		if shouldSkipTicket {
-			return nil, nil
-		}
 		issueSub, ok := sub.Subscriber.Target.(*event.JIRAIssueSubscriber)
 		if !ok {
 			return nil, errors.Errorf("unexpected target data type: '%T'", sub.Subscriber.Target)

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -7,14 +7,12 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/alertrecord"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/event"
-	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/model/user"
@@ -783,35 +781,6 @@ func (s *taskSuite) tryDoubleTrigger(shouldGenerate bool) {
 	n, err = s.t.taskRegressionByTest(&s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
-}
-
-func (s *taskSuite) TestSkipStrandedJIRA() {
-	sub := event.Subscription{
-		ID:           mgobson.NewObjectId().Hex(),
-		ResourceType: event.ResourceTypeTask,
-		Trigger:      "should-miss",
-		Selectors: []event.Selector{
-			{
-				Type: event.SelectorProject,
-				Data: "myproj",
-			},
-		},
-		Subscriber: event.Subscriber{
-			Type:   event.JIRAIssueSubscriberType,
-			Target: "a@b.com",
-		},
-		TriggerData: map[string]string{
-			event.TestRegexKey: "test*",
-		},
-		Owner: "someone",
-	}
-	s.t = s.makeTaskTriggers(s.task.Id, s.task.Execution)
-	s.t.task.Details = apimodels.TaskEndDetail{
-		Description: evergreen.TaskDescriptionStranded,
-	}
-	n, err := s.t.generate(&sub, "", "")
-	s.NoError(err)
-	s.Equal(n, (*notification.Notification)(nil))
 }
 
 func (s *taskSuite) TestRegressionByTestSimpleRegression() {


### PR DESCRIPTION
[EVG-16101](https://jira.mongodb.org/browse/EVG-16101)

### Description 
Right now we have a lot of special logic to avoid creating certain Jira tickets for the build baron, however the build baron logic has since been moved to their new tool so we no longer need this.

### Testing 
Removed the relevant unit test.
