### PR TITLE
EVG-6274 Update github PR patches to support ignore options

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -572,6 +572,16 @@ func (p *Patch) ConfigChanged(remotePath string) bool {
 	return false
 }
 
+func (p *Patch) FilesChanged() []string {
+	var filenames []string
+	for _, patchPart := range p.Patches {
+		for _, summary := range patchPart.PatchSet.Summary {
+			filenames = append(filenames, summary.Name)
+		}
+	}
+	return filenames
+}
+
 // SetActivated sets the patch to activated in the db
 func (p *Patch) SetActivated(ctx context.Context, versionId string) error {
 	p.Version = versionId

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -589,7 +589,7 @@ func gitIsAncestor(commit1, commit2 string) (string, error) {
 
 // gitDiff runs "git diff <base> <ref> <commits> <diffargs ...>" and returns the output of the command as a string,
 // where ref and commits are mutually exclusive (and not required)
-func gitDiff(base string, ref, commits string, diffArgs ...string) (string, error) {
+func gitDiff(base, ref, commits string, diffArgs ...string) (string, error) {
 	args := []string{base}
 	if commits != "" {
 		args = []string{formatCommitRange(commits)}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -267,6 +267,10 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		j.gitHubError = ProjectFailsValidation
 		return errors.Wrapf(validationCatcher.Resolve(), "patched project config has errors")
 	}
+	// Don't create patch if the only changes are in ignore files.
+	if project.IgnoresAllFiles(patchDoc.FilesChanged()) {
+		return nil
+	}
 
 	patchDoc.PatchedParserProject = patchConfig.PatchedParserProject
 	patchDoc.PatchedProjectConfig = patchConfig.PatchedProjectConfig
@@ -373,11 +377,11 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		})
 		patchSub := event.NewExpiringPatchOutcomeSubscription(j.PatchID.Hex(), ghSub)
 		if err = patchSub.Upsert(); err != nil {
-			catcher.Add(errors.Wrap(err, "failed to insert patch subscription for Github PR"))
+			catcher.Wrap(err, "failed to insert patch subscription for Github PR")
 		}
 		buildSub := event.NewExpiringBuildOutcomeSubscriptionByVersion(j.PatchID.Hex(), ghSub)
 		if err = buildSub.Upsert(); err != nil {
-			catcher.Add(errors.Wrap(err, "failed to insert build subscription for Github PR"))
+			catcher.Wrap(err, "failed to insert build subscription for Github PR")
 		}
 		waitOnChilSub := event.NewGithubStatusAPISubscriber(event.GithubPullRequestSubscriber{
 			Owner:    patchDoc.GithubPatchData.BaseOwner,
@@ -399,12 +403,12 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 				})
 				patchSub := event.NewExpiringPatchOutcomeSubscription(childPatch, childGhStatusSub)
 				if err = patchSub.Upsert(); err != nil {
-					catcher.Add(errors.Wrap(err, "failed to insert child patch subscription for Github PR"))
+					catcher.Wrap(err, "failed to insert child patch subscription for Github PR")
 				}
 				// add subscription so that the parent can wait on the children
 				patchSub = event.NewExpiringPatchOutcomeSubscription(childPatch, waitOnChilSub)
 				if err = patchSub.Upsert(); err != nil {
-					catcher.Add(errors.Wrap(err, "failed to insert patch subscription for Github PR"))
+					catcher.Wrap(err, "failed to insert patch subscription for Github PR")
 				}
 
 			}
@@ -413,7 +417,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	if patchDoc.IsBackport() {
 		backportSubscription := event.NewExpiringPatchSuccessSubscription(j.PatchID.Hex(), event.NewEnqueuePatchSubscriber())
 		if err = backportSubscription.Upsert(); err != nil {
-			catcher.Add(errors.Wrap(err, "failed to insert backport subscription"))
+			catcher.Wrap(err, "failed to insert backport subscription")
 		}
 	}
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -267,8 +267,8 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		j.gitHubError = ProjectFailsValidation
 		return errors.Wrapf(validationCatcher.Resolve(), "patched project config has errors")
 	}
-	// Don't create patch if the only changes are in ignore files.
-	if project.IgnoresAllFiles(patchDoc.FilesChanged()) {
+	// Don't create patches for github PRs if the only changes are in ignore files.
+	if patchDoc.IsGithubPRPatch() && project.IgnoresAllFiles(patchDoc.FilesChanged()) {
 		return nil
 	}
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -267,7 +267,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		j.gitHubError = ProjectFailsValidation
 		return errors.Wrapf(validationCatcher.Resolve(), "patched project config has errors")
 	}
-	// Don't create patches for github PRs if the only changes are in ignore files.
+	// Don't create patches for github PRs if the only changes are in ignored files.
 	if patchDoc.IsGithubPRPatch() && project.IgnoresAllFiles(patchDoc.FilesChanged()) {
 		return nil
 	}


### PR DESCRIPTION
[EVG-6274](https://jira.mongodb.org/browse/EVG-6274)

### Description 
goes through all changed files and doesnt create patches when all the changes are in the ignore for github prs 
still works for normal patches 

### Testing 
https://github.com/evergreen-ci/commit-queue-sandbox/pull/346

![image](https://user-images.githubusercontent.com/26491602/161133816-92d83dd6-caed-4938-98fb-98111d4553a1.png)
