### PR TITLE
EVG-16540 Show project config aliases in API response

### DIFF
--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -90,7 +90,7 @@ func MergeAliasesWithProjectConfig(projectID string, dbAliases []ProjectAlias) (
 	dbAliasMap := aliasesToMap(dbAliases)
 	projectConfig, err := FindProjectConfigForProjectOrVersion(projectID, "")
 	if err != nil {
-		return nil, errors.Wrap(err, "error finding project config")
+		return nil, errors.Wrap(err, "finding project config")
 	}
 	patchAliases := []ProjectAlias{}
 	for alias, aliases := range dbAliasMap {
@@ -183,7 +183,7 @@ func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, bo
 func findMatchingAliasForProjectConfig(projectID, alias string) ([]ProjectAlias, error) {
 	projectConfig, err := FindProjectConfigForProjectOrVersion(projectID, "")
 	if err != nil {
-		return nil, errors.Wrap(err, "error finding project config")
+		return nil, errors.Wrap(err, "finding project config")
 	}
 	if projectConfig == nil {
 		return nil, nil

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -83,14 +83,10 @@ func FindAliasesForProjectFromDb(projectID string) ([]ProjectAlias, error) {
 	return out, nil
 }
 
-// FindAliasesMergedWithProjectConfig returns a merged list of project aliases that includes the merged result of aliases defined
+// MergeAliasesWithProjectConfig returns a merged list of project aliases that includes the merged result of aliases defined
 // on the project ref and aliases defined in the project YAML.  Aliases defined on the project ref will take precedence over the
 // project YAML in the case that both are defined.
-func FindAliasesMergedWithProjectConfig(projectID string) ([]ProjectAlias, error) {
-	dbAliases, err := FindAliasesForProjectFromDb(projectID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error finding aliases for project '%s'", projectID)
-	}
+func MergeAliasesWithProjectConfig(projectID string, dbAliases []ProjectAlias) ([]ProjectAlias, error) {
 	dbAliasMap := aliasesToMap(dbAliases)
 	projectConfig, err := FindProjectConfigForProjectOrVersion(projectID, "")
 	if err != nil {

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -11,6 +11,8 @@ import (
 // FindProjectAliases queries the database to find all aliases.
 // If the repoId is given, we default to repo aliases if there are no project aliases.
 // If aliasesToAdd are given, then we fold those aliases in and remove any that are marked as deleted.
+// If includeProjectConfig, a merged list of aliases defined on the project page and the project config YAML will be returned,
+// with aliases set on the project page taking precedence.
 func FindProjectAliases(projectId, repoId string, aliasesToAdd []restModel.APIProjectAlias, includeProjectConfig bool) ([]restModel.APIProjectAlias, error) {
 	var err error
 	var aliases model.ProjectAliases

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -11,7 +11,7 @@ import (
 // FindProjectAliases queries the database to find all aliases.
 // If the repoId is given, we default to repo aliases if there are no project aliases.
 // If aliasesToAdd are given, then we fold those aliases in and remove any that are marked as deleted.
-func FindProjectAliases(projectId, repoId string, aliasesToAdd []restModel.APIProjectAlias) ([]restModel.APIProjectAlias, error) {
+func FindProjectAliases(projectId, repoId string, aliasesToAdd []restModel.APIProjectAlias, includeProjectConfig bool) ([]restModel.APIProjectAlias, error) {
 	var err error
 	var aliases model.ProjectAliases
 	// should this logic just be folded into FindProjectAliases?
@@ -25,7 +25,11 @@ func FindProjectAliases(projectId, repoId string, aliasesToAdd []restModel.APIPr
 		}
 	}
 	if projectId != "" {
-		aliases, err = model.FindAliasesForProjectFromDb(projectId)
+		if includeProjectConfig {
+			aliases, err = model.FindAliasesMergedWithProjectConfig(projectId)
+		} else {
+			aliases, err = model.FindAliasesForProjectFromDb(projectId)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -16,7 +16,6 @@ import (
 func FindProjectAliases(projectId, repoId string, aliasesToAdd []restModel.APIProjectAlias, includeProjectConfig bool) ([]restModel.APIProjectAlias, error) {
 	var err error
 	var aliases model.ProjectAliases
-	// should this logic just be folded into FindProjectAliases?
 	aliasesToDelete := []string{}
 	aliasModels := []restModel.APIProjectAlias{}
 	for _, a := range aliasesToAdd {
@@ -27,20 +26,21 @@ func FindProjectAliases(projectId, repoId string, aliasesToAdd []restModel.APIPr
 		}
 	}
 	if projectId != "" {
-		if includeProjectConfig {
-			aliases, err = model.FindAliasesMergedWithProjectConfig(projectId)
-		} else {
-			aliases, err = model.FindAliasesForProjectFromDb(projectId)
-		}
+		aliases, err = model.FindAliasesForProjectFromDb(projectId)
 		if err != nil {
 			return nil, err
 		}
 	}
-
 	if len(aliases) == 0 && repoId != "" {
 		aliases, err = model.FindAliasesForRepo(repoId)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error finding aliases for repo '%s'", repoId)
+		}
+	}
+	if projectId != "" && includeProjectConfig {
+		aliases, err = model.MergeAliasesWithProjectConfig(projectId, aliases)
+		if err != nil {
+			return nil, err
 		}
 	}
 	if aliases == nil {

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -68,29 +68,72 @@ func (a *AliasSuite) SetupTest() {
 			Task:      "repo_task",
 		},
 	}
+	projectConfig := &model.ProjectConfig{
+		Id:      "project_id",
+		Project: "project_id",
+		ProjectConfigFields: model.ProjectConfigFields{
+			PatchAliases: []model.ProjectAlias{
+				{
+					ID:        mgobson.NewObjectId(),
+					ProjectID: "project-1",
+					Alias:     "alias-2",
+				},
+				{
+					ID:        mgobson.NewObjectId(),
+					ProjectID: "project-1",
+					Alias:     "alias-1",
+				},
+			},
+			CommitQueueAliases: []model.ProjectAlias{
+				{
+					ID:        mgobson.NewObjectId(),
+					ProjectID: "project-1",
+					Alias:     evergreen.CommitQueueAlias,
+				},
+			},
+			GitHubChecksAliases: []model.ProjectAlias{
+				{
+					ID:        mgobson.NewObjectId(),
+					ProjectID: "project-1",
+					Alias:     evergreen.GithubChecksAlias,
+				},
+			},
+		}}
+	a.NoError(projectConfig.Insert())
 	for _, v := range aliases {
 		a.NoError(v.Upsert())
 	}
 }
 
+func (a *AliasSuite) TestFindProjectAliasesMergedWithProjectConfig() {
+	found, err := FindProjectAliases("project_id", "", nil, true)
+	a.NoError(err)
+	a.Len(found, 5)
+	a.Equal(utility.FromStringPtr(found[0].Alias), evergreen.CommitQueueAlias)
+	a.Equal(utility.FromStringPtr(found[1].Alias), evergreen.GithubChecksAlias)
+	a.Equal(utility.FromStringPtr(found[2].Alias), "foo")
+	a.Equal(utility.FromStringPtr(found[3].Alias), "foo")
+	a.Equal(utility.FromStringPtr(found[4].Alias), "bar")
+}
+
 func (a *AliasSuite) TestFindProjectAliases() {
-	found, err := FindProjectAliases("project_id", "", nil)
+	found, err := FindProjectAliases("project_id", "", nil, false)
 	a.NoError(err)
 	a.Len(found, 3)
 
-	found, err = FindProjectAliases("project_id", "repo_id", nil)
+	found, err = FindProjectAliases("project_id", "repo_id", nil, false)
 	a.NoError(err)
 	a.Len(found, 3) // ignore repo
 
-	found, err = FindProjectAliases("non-existent", "", nil)
+	found, err = FindProjectAliases("non-existent", "", nil, false)
 	a.NoError(err)
 	a.Len(found, 0)
 
-	found, err = FindProjectAliases("non-existent", "repo_id", nil)
+	found, err = FindProjectAliases("non-existent", "repo_id", nil, false)
 	a.NoError(err)
 	a.Len(found, 1) // from repo
 
-	found, err = FindProjectAliases("", "repo_id", nil)
+	found, err = FindProjectAliases("", "repo_id", nil, false)
 	a.NoError(err)
 	a.Len(found, 1)
 
@@ -98,24 +141,24 @@ func (a *AliasSuite) TestFindProjectAliases() {
 }
 
 func (a *AliasSuite) TestCopyProjectAliases() {
-	res, err := FindProjectAliases("new_project_id", "", nil)
+	res, err := FindProjectAliases("new_project_id", "", nil, false)
 	a.NoError(err)
 	a.Len(res, 0)
 
 	a.NoError(model.CopyProjectAliases("project_id", "new_project_id"))
 
-	res, err = FindProjectAliases("project_id", "", nil)
+	res, err = FindProjectAliases("project_id", "", nil, false)
 	a.NoError(err)
 	a.Len(res, 3)
 
-	res, err = FindProjectAliases("new_project_id", "", nil)
+	res, err = FindProjectAliases("new_project_id", "", nil, false)
 	a.NoError(err)
 	a.Len(res, 3)
 
 }
 
 func (a *AliasSuite) TestUpdateProjectAliases() {
-	found, err := FindProjectAliases("other_project_id", "", nil)
+	found, err := FindProjectAliases("other_project_id", "", nil, false)
 	a.NoError(err)
 	a.Require().Len(found, 2)
 	toUpdate := found[0]
@@ -132,7 +175,7 @@ func (a *AliasSuite) TestUpdateProjectAliases() {
 		},
 	}
 	a.NoError(UpdateProjectAliases("other_project_id", aliasUpdates))
-	found, err = FindProjectAliases("other_project_id", "", nil)
+	found, err = FindProjectAliases("other_project_id", "", nil, false)
 	a.NoError(err)
 	a.Require().Len(found, 2) // added one alias, deleted another
 

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -24,10 +24,10 @@ const EventLogLimit = 10
 type DBProjectConnector struct{}
 
 // FindProjectById queries the database for the project matching the projectRef.Id.
-func FindProjectById(id string, includeRepo bool, includeParserProject bool) (*model.ProjectRef, error) {
+func FindProjectById(id string, includeRepo bool, includeProjectConfig bool) (*model.ProjectRef, error) {
 	var p *model.ProjectRef
 	var err error
-	if includeRepo && includeParserProject {
+	if includeRepo && includeProjectConfig {
 		p, err = model.FindMergedProjectRef(id, "", true)
 	} else if includeRepo {
 		p, err = model.FindMergedProjectRef(id, "", false)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -23,7 +23,9 @@ const EventLogLimit = 10
 // from the Connector through interactions with the backing database.
 type DBProjectConnector struct{}
 
-// FindProjectById queries the database for the project matching the projectRef.Id.
+// FindProjectById queries the database for the project matching the projectRef.Id. If the bool flag is set,
+// the project config properties in the project YAML will be merged into the result if the properties are
+// not set on the project page.
 func FindProjectById(id string, includeRepo bool, includeProjectConfig bool) (*model.ProjectRef, error) {
 	var p *model.ProjectRef
 	var err error

--- a/rest/route/alias.go
+++ b/rest/route/alias.go
@@ -35,7 +35,7 @@ func (a *aliasGetHandler) Run(ctx context.Context) gimlet.Responder {
 	if pRef == nil {
 		return gimlet.MakeJSONErrorResponder(errors.Errorf("project '%s' not found", a.name))
 	}
-	aliasModels, err := data.FindProjectAliases(pRef.Id, pRef.RepoRefId, nil)
+	aliasModels, err := data.FindProjectAliases(pRef.Id, pRef.RepoRefId, nil, false)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Database error"))
 	}

--- a/rest/route/repo.go
+++ b/rest/route/repo.go
@@ -59,7 +59,7 @@ func (h *repoIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	repoModel.Variables = *repoVars
 
-	if repoModel.Aliases, err = data.FindProjectAliases("", repo.Id, nil); err != nil {
+	if repoModel.Aliases, err = data.FindProjectAliases("", repo.Id, nil, false); err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
@@ -177,7 +177,7 @@ func (h *repoIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	allAuthorizedTeams := utility.UniqueStrings(append(h.originalRepo.GitTagAuthorizedTeams, h.newRepoRef.GitTagAuthorizedTeams...))
 	h.newRepoRef.GitTagAuthorizedTeams, _ = utility.StringSliceSymmetricDifference(allAuthorizedTeams, teamsToDelete)
 
-	repoAliases, err := data.FindProjectAliases("", h.newRepoRef.Id, h.apiNewRepoRef.Aliases)
+	repoAliases, err := data.FindProjectAliases("", h.newRepoRef.Id, h.apiNewRepoRef.Aliases, false)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
@@ -315,7 +315,7 @@ func (h repoIDPatchHandler) validateBranchesForRepo(ctx context.Context, newRepo
 					catcher.Errorf("if repo PR testing enabled, must have aliases")
 				} else if len(info.prTestingIds) > 0 {
 					// verify that the project with PR testing enabled has aliases defined
-					branchAliases, err := data.FindProjectAliases(info.prTestingIds[0], "", nil)
+					branchAliases, err := data.FindProjectAliases(info.prTestingIds[0], "", nil, false)
 					if err != nil {
 						return errors.Wrapf(err, "error getting branch '%s' aliases", info.prTestingIds[0])
 					}
@@ -331,7 +331,7 @@ func (h repoIDPatchHandler) validateBranchesForRepo(ctx context.Context, newRepo
 					catcher.Errorf("if repo commit queue enabled, must have aliases")
 				} else if len(info.commitQueueIds) > 0 {
 					// verify that the branch with the commit queue enabled has aliases defined in the branch
-					branchAliases, err := data.FindProjectAliases(info.commitQueueIds[0], "", nil)
+					branchAliases, err := data.FindProjectAliases(info.commitQueueIds[0], "", nil, false)
 					if err != nil {
 						return errors.Wrapf(err, "error getting branch '%s' aliases", info.commitQueueIds[0])
 					}
@@ -347,7 +347,7 @@ func (h repoIDPatchHandler) validateBranchesForRepo(ctx context.Context, newRepo
 				} else if len(info.gitTagIds) > 0 {
 					for _, branchId := range info.gitTagIds {
 						// verify that the branch with git tag versions enabled has aliases defined in the branch
-						branchAliases, err := data.FindProjectAliases(branchId, "", nil)
+						branchAliases, err := data.FindProjectAliases(branchId, "", nil, false)
 						if err != nil {
 							return errors.Wrapf(err, "error getting branch '%s' aliases", branchId)
 						}
@@ -363,7 +363,7 @@ func (h repoIDPatchHandler) validateBranchesForRepo(ctx context.Context, newRepo
 				} else if len(info.githubCheckIds) > 0 {
 					for _, branchId := range info.githubCheckIds {
 						// verify that the branch with github checks versions enabled has aliases defined in the branch
-						branchAliases, err := data.FindProjectAliases(branchId, "", nil)
+						branchAliases, err := data.FindProjectAliases(branchId, "", nil, false)
 						if err != nil {
 							return errors.Wrapf(err, "error getting branch '%s' aliases", branchId)
 						}

--- a/service/project.go
+++ b/service/project.go
@@ -247,10 +247,10 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Project not found", http.StatusNotFound)
 		return
 	}
-	if projectRef.UseRepoSettings() {
-		http.Error(w, "can't modify branch projects here", http.StatusBadRequest)
-		return
-	}
+	//if projectRef.UseRepoSettings() {
+	//	http.Error(w, "can't modify branch projects here", http.StatusBadRequest)
+	//	return
+	//}
 	id = projectRef.Id
 	origProjectRef := *projectRef
 

--- a/service/project.go
+++ b/service/project.go
@@ -247,10 +247,10 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Project not found", http.StatusNotFound)
 		return
 	}
-	//if projectRef.UseRepoSettings() {
-	//	http.Error(w, "can't modify branch projects here", http.StatusBadRequest)
-	//	return
-	//}
+	if projectRef.UseRepoSettings() {
+		http.Error(w, "can't modify branch projects here", http.StatusBadRequest)
+		return
+	}
 	id = projectRef.Id
 	origProjectRef := *projectRef
 


### PR DESCRIPTION
[EVG-16540](https://jira.mongodb.org/browse/EVG-16540)

### Description 
Projects that have active aliases in their config yaml currently do not have them show up in the API response for the project.  Updated the project get route to display these aliases if the boolean url parameter 'includeProjectConfig' is set. Updated the documentation for the route specifying this: https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#get-a-project
### Testing 
Added unit testing and tested api responses locally with a project with set project config aliases. 