### PR TITLE
EVG-16581: Add request id to gql splunk error

### DIFF
--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -48,9 +48,10 @@ func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
 			args = fieldCtx.Args
 		}
 		grip.Error(message.WrapError(err, message.Fields{
-			"path":  "/graphql/query",
-			"query": queryPath,
-			"args":  args,
+			"path":    "/graphql/query",
+			"query":   queryPath,
+			"args":    args,
+			"request": gimlet.GetRequestID(ctx),
 		}))
 		return graphql.DefaultErrorPresenter(ctx, err)
 	})


### PR DESCRIPTION
[EVG-16581](https://jira.mongodb.org/browse/EVG-16581)

### Description 
Adds a request id to gql splunk errors. This request id is also shared with splunk gql traces
