### PR TITLE
EVG-16656 default test type

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -32,7 +32,7 @@ func (a *Agent) runCommands(ctx context.Context, tc *taskContext, commands []mod
 			grip.Error("runCommands canceled")
 			return errors.New("runCommands canceled")
 		}
-		cmds, err = command.Render(commandInfo, tc.taskConfig.Project.Functions)
+		cmds, err = command.Render(commandInfo, tc.taskConfig.Project)
 		if err != nil {
 			tc.logger.Task().Errorf("Couldn't parse plugin command '%v': %v", commandInfo.Command, err)
 			return err
@@ -77,10 +77,6 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			})
 		}
 
-		// SetType implementations only modify the
-		// command's type *if* the command's type is
-		// not otherwise set.
-		cmd.SetType(tc.taskConfig.Project.CommandType)
 		cmd.SetJasperManager(a.jasper)
 
 		fullCommandName := getCommandName(commandInfo, cmd)

--- a/agent/command/git_patch_test.go
+++ b/agent/command/git_patch_test.go
@@ -137,7 +137,7 @@ func TestPatchPlugin(t *testing.T) {
 			for _, task := range taskConfig.Project.Tasks {
 				So(len(task.Commands), ShouldNotEqual, 0)
 				for _, command := range task.Commands {
-					pluginCmds, err := Render(command, taskConfig.Project.Functions)
+					pluginCmds, err := Render(command, taskConfig.Project)
 					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -241,7 +241,7 @@ func (s *GitGetProjectSuite) TestGitPlugin() {
 	for _, task := range conf.Project.Tasks {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
-			pluginCmds, err := Render(command, conf.Project.Functions)
+			pluginCmds, err := Render(command, conf.Project)
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -283,7 +283,7 @@ func (s *GitGetProjectSuite) TestTokenScrubbedFromLogger() {
 	for _, task := range conf.Project.Tasks {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
-			pluginCmds, err := Render(command, conf.Project.Functions)
+			pluginCmds, err := Render(command, conf.Project)
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -327,7 +327,7 @@ func (s *GitGetProjectSuite) TestStdErrLogged() {
 	for _, task := range conf.Project.Tasks {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
-			pluginCmds, err := Render(command, conf.Project.Functions)
+			pluginCmds, err := Render(command, conf.Project)
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -374,7 +374,7 @@ func (s *GitGetProjectSuite) TestValidateGitCommands() {
 
 	for _, task := range conf.Project.Tasks {
 		for _, command := range task.Commands {
-			pluginCmds, err = Render(command, conf.Project.Functions)
+			pluginCmds, err = Render(command, conf.Project)
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -685,7 +685,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionSetModule() {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
 			var pluginCmds []Command
-			pluginCmds, err = Render(command, conf.Project.Functions)
+			pluginCmds, err = Render(command, conf.Project)
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -729,7 +729,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionManifest() {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
 			var pluginCmds []Command
-			pluginCmds, err = Render(command, conf.Project.Functions)
+			pluginCmds, err = Render(command, conf.Project)
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -941,7 +941,7 @@ index edc0c34..8e82862 100644
 	for _, task := range conf.Project.Tasks {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
-			pluginCmds, err := Render(command, conf.Project.Functions)
+			pluginCmds, err := Render(command, conf.Project)
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)

--- a/agent/command/interface.go
+++ b/agent/command/interface.go
@@ -27,10 +27,9 @@ type Command interface {
 	// A string name for the command
 	Name() string
 
-	// Type reports on or overrides the default command type
-	// (e.g. system or task.) The setter MUST NOT override a value
-	// if it has already been set.
+	// Type reports on the command's type (e.g. system or test).
 	Type() string
+	// SetType sets the command's type (e.g. system or test).
 	SetType(string)
 
 	DisplayName() string
@@ -64,9 +63,7 @@ func (b *base) SetType(n string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if b.typeName == "" {
-		b.typeName = n
-	}
+	b.typeName = n
 }
 
 func (b *base) DisplayName() string {

--- a/agent/command/interface.go
+++ b/agent/command/interface.go
@@ -27,7 +27,7 @@ type Command interface {
 	// A string name for the command
 	Name() string
 
-	// Type reports on the command's type (e.g. system or test).
+	// Type returns the command's type (e.g. system or test).
 	Type() string
 	// SetType sets the command's type (e.g. system or test).
 	SetType(string)

--- a/agent/command/manifest_test.go
+++ b/agent/command/manifest_test.go
@@ -49,7 +49,7 @@ func TestManifestLoad(t *testing.T) {
 			for _, task := range taskConfig.Project.Tasks {
 				So(len(task.Commands), ShouldNotEqual, 0)
 				for _, command := range task.Commands {
-					pluginCmds, err := Render(command, taskConfig.Project.Functions)
+					pluginCmds, err := Render(command, taskConfig.Project)
 					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
@@ -77,7 +77,7 @@ func TestManifestLoad(t *testing.T) {
 			for _, task := range taskConfig.Project.Tasks {
 				So(len(task.Commands), ShouldNotEqual, 0)
 				for _, command := range task.Commands {
-					pluginCmds, err := Render(command, taskConfig.Project.Functions)
+					pluginCmds, err := Render(command, taskConfig.Project)
 					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)

--- a/agent/command/mock.go
+++ b/agent/command/mock.go
@@ -1,0 +1,20 @@
+package command
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+)
+
+type mockCommand struct {
+	name string
+
+	base
+}
+
+func (m *mockCommand) Execute(context.Context, client.Communicator, client.LoggerProducer, *internal.TaskConfig) error {
+	return nil
+}
+func (m *mockCommand) Name() string                             { return m.name }
+func (m *mockCommand) ParseParams(map[string]interface{}) error { return nil }

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -75,8 +75,8 @@ func GetCommandFactory(name string) (CommandFactory, bool) {
 	return evgRegistry.getCommandFactory(name)
 }
 
-func Render(c model.PluginCommandConf, fns map[string]*model.YAMLCommandSet) ([]Command, error) {
-	return evgRegistry.renderCommands(c, fns)
+func Render(c model.PluginCommandConf, project *model.Project) ([]Command, error) {
+	return evgRegistry.renderCommands(c, project)
 }
 
 func RegisteredCommandNames() []string { return evgRegistry.registeredCommandNames() }
@@ -137,7 +137,7 @@ func (r *commandRegistry) getCommandFactory(name string) (CommandFactory, bool) 
 }
 
 func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
-	funcs map[string]*model.YAMLCommandSet) ([]Command, error) {
+	project *model.Project) ([]Command, error) {
 
 	var (
 		parsed []model.PluginCommandConf
@@ -146,7 +146,7 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 	)
 
 	if name := commandInfo.Function; name != "" {
-		cmds, ok := funcs[name]
+		cmds, ok := project.Functions[name]
 		if !ok {
 			errs = append(errs, fmt.Sprintf("function '%s' not found in project functions", name))
 		} else if cmds != nil {
@@ -189,7 +189,7 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 			errs = append(errs, errors.Wrapf(err, "problem parsing input of %s (%s)", c.Command, c.DisplayName).Error())
 			continue
 		}
-		cmd.SetType(c.Type)
+		cmd.SetType(c.GetType(project))
 		cmd.SetDisplayName(c.DisplayName)
 		cmd.SetIdleTimeout(time.Duration(c.TimeoutSecs) * time.Second)
 

--- a/agent/command/results_gotest_test.go
+++ b/agent/command/results_gotest_test.go
@@ -49,7 +49,7 @@ func TestGotestPluginOnFailingTests(t *testing.T) {
 			for _, testTask := range conf.Project.Tasks {
 				So(len(testTask.Commands), ShouldNotEqual, 0)
 				for _, command := range testTask.Commands {
-					pluginCmds, err := Render(command, conf.Project.Functions)
+					pluginCmds, err := Render(command, conf.Project)
 					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
@@ -111,7 +111,7 @@ func TestGotestPluginOnPassingTests(t *testing.T) {
 			for _, testTask := range conf.Project.Tasks {
 				So(len(testTask.Commands), ShouldNotEqual, 0)
 				for _, command := range testTask.Commands {
-					pluginCmds, err := Render(command, conf.Project.Functions)
+					pluginCmds, err := Render(command, conf.Project)
 					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)

--- a/agent/command/results_native_test.go
+++ b/agent/command/results_native_test.go
@@ -54,7 +54,7 @@ func TestAttachResults(t *testing.T) {
 			for _, projTask := range conf.Project.Tasks {
 				So(len(projTask.Commands), ShouldNotEqual, 0)
 				for _, command := range projTask.Commands {
-					pluginCmds, err := Render(command, conf.Project.Functions)
+					pluginCmds, err := Render(command, conf.Project)
 					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
@@ -105,7 +105,7 @@ func TestAttachRawResults(t *testing.T) {
 				So(len(projTask.Commands), ShouldNotEqual, 0)
 				for _, command := range projTask.Commands {
 
-					pluginCmds, err := Render(command, conf.Project.Functions)
+					pluginCmds, err := Render(command, conf.Project)
 					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)

--- a/agent/command/results_xunit_test.go
+++ b/agent/command/results_xunit_test.go
@@ -50,7 +50,7 @@ func runTest(t *testing.T, configPath string, customTests func(string)) {
 			for _, projTask := range conf.Project.Tasks {
 				So(len(projTask.Commands), ShouldNotEqual, 0)
 				for _, command := range projTask.Commands {
-					pluginCmds, err := Render(command, conf.Project.Functions)
+					pluginCmds, err := Render(command, conf.Project)
 					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1005,7 +1005,7 @@ func validateCommands(section string, project *model.Project,
 
 	for _, cmd := range commands {
 		commandName := fmt.Sprintf("'%s' command", cmd.Command)
-		_, err := command.Render(cmd, project.Functions)
+		_, err := command.Render(cmd, project)
 		if err != nil {
 			if cmd.Function != "" {
 				commandName = fmt.Sprintf("'%s' function", cmd.Function)


### PR DESCRIPTION
[EVG-16656](https://jira.mongodb.org/browse/EVG-16656)

### Description 
TaskEndDetail is missing the command type for projects/commands that don't [specify a type](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#command-failure-colors).

Git/Jira grepping tells a story that once upon a time when we implemented this [the command would get a default type if none was specified](https://github.com/evergreen-ci/evergreen/commit/cf63eda48d4ee15a26babb773a3aa7ae0b0b2ecd#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bR200). This got lost in [a big agent refactor](https://github.com/evergreen-ci/evergreen/commit/5a1f016eb4b098445a7c87489c9e8497aad3a4a1). [We noticed it](https://jira.mongodb.org/browse/EVG-2079) and made a change to set the command type from the project if it wasn't set on the command level (https://github.com/evergreen-ci/evergreen/commit/5836504e51d79525bf68dc5ad143b4826ae2927d), but we still didn't fix setting a default when none was set. This PR fixes that case. The fix makes unnecessary the restriction from https://github.com/evergreen-ci/evergreen/commit/5836504e51d79525bf68dc5ad143b4826ae2927d that type can only be set once. Instead, we set it to the right thing.

### Testing 
Added a unit test to the command resolver. 
In staging I removed [the command_type from self-tests.yml](https://github.com/evergreen-ci/evergreen/blob/41f38ee587529fb34a04204e661eee5f302f077d/self-tests.yml#L1), created a patch, and started [a task](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu1604_test_auth_patch_42add8254ea0e84e68bc6cad5b060c39033454a5_624b43b19dbe3245adf10f74_22_04_04_19_15_10/tests?execution=0&sortBy=STATUS&sortDir=ASC). When the task finished running its type in TaskEndDetail was set to the default.
