### PR TITLE
EVG-15358: skip cloud host termination if host is externally terminated

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -105,7 +105,10 @@ func ModifyHostStatus(ctx context.Context, env evergreen.Environment, queue ambo
 			return "", http.StatusInternalServerError, errors.New(HostTerminationQueueingError)
 		}
 
-		if err := amboy.EnqueueUniqueJob(ctx, queue, units.NewHostTerminationJob(env, h, true, fmt.Sprintf("terminated by %s", u.Username()))); err != nil {
+		if err := amboy.EnqueueUniqueJob(ctx, queue, units.NewHostTerminationJob(env, h, units.HostTerminationOptions{
+			TerminateIfBusy:   true,
+			TerminationReason: fmt.Sprintf("terminated by %s", u.Username()),
+		})); err != nil {
 			return "", http.StatusInternalServerError, errors.New(HostTerminationQueueingError)
 		}
 		return fmt.Sprintf(HostTerminationQueueingSuccess, h.Id), http.StatusOK, nil

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -238,8 +238,11 @@ func (sns *ec2SNS) handleInstanceInterruptionWarning(ctx context.Context, instan
 		return nil
 	}
 
-	// return success on duplicate job errors so AWS won't keep retrying
-	terminationJob := units.NewHostTerminationJob(sns.env, h, true, "got interruption warning")
+	terminationJob := units.NewHostTerminationJob(sns.env, h, units.HostTerminationOptions{
+		TerminateIfBusy:          true,
+		TerminationReason:        "got interruption warning",
+		SkipCloudHostTermination: true,
+	})
 	if err := amboy.EnqueueUniqueJob(ctx, sns.queue, terminationJob); err != nil {
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message":          "could not enqueue host termination job",

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -230,27 +230,6 @@ func (sns *ec2SNS) handleInstanceInterruptionWarning(ctx context.Context, instan
 		"host_id":            h.Id,
 	})
 
-	if h.Status == evergreen.HostTerminated {
-		return nil
-	}
-
-	if sns.skipEarlyTermination(h) {
-		return nil
-	}
-
-	terminationJob := units.NewHostTerminationJob(sns.env, h, units.HostTerminationOptions{
-		TerminateIfBusy:          true,
-		TerminationReason:        "got interruption warning",
-		SkipCloudHostTermination: true,
-	})
-	if err := amboy.EnqueueUniqueJob(ctx, sns.queue, terminationJob); err != nil {
-		grip.Warning(message.WrapError(err, message.Fields{
-			"message":          "could not enqueue host termination job",
-			"host_id":          h.Id,
-			"enqueue_job_type": terminationJob.Type(),
-		}))
-	}
-
 	return nil
 }
 

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/evergreen-ci/cocoa/ecs"
@@ -30,6 +31,7 @@ const (
 	messageTypeNotification             = "Notification"
 	messageTypeUnsubscribeConfirmation  = "UnsubscribeConfirmation"
 
+	interruptionWarningType = "EC2 Spot Instance Interruption Warning"
 	instanceStateChangeType = "EC2 Instance State-change Notification"
 
 	ecsTaskStateChangeType = "ECS Task State Change"
@@ -159,6 +161,13 @@ func (sns *ec2SNS) handleNotification(ctx context.Context) error {
 	}
 
 	switch notification.DetailType {
+	case interruptionWarningType:
+		if err := sns.handleInstanceInterruptionWarning(ctx, notification.Detail.InstanceID); err != nil {
+			return gimlet.ErrorResponse{
+				StatusCode: http.StatusInternalServerError,
+				Message:    errors.Wrap(err, "problem processing interruption warning").Error(),
+			}
+		}
 	case instanceStateChangeType:
 		switch notification.Detail.State {
 		case ec2.InstanceStateNameTerminated:
@@ -184,6 +193,81 @@ func (sns *ec2SNS) handleNotification(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (sns *ec2SNS) handleInstanceInterruptionWarning(ctx context.Context, instanceID string) error {
+	h, err := host.FindOneId(instanceID)
+	if err != nil {
+		return err
+	}
+	// don't make AWS keep retrying if we haven't heard of the host
+	if h == nil {
+		return nil
+	}
+
+	instanceType := "Empty Distro.ProviderSettingsList, unable to get instance_type"
+	if len(h.Distro.ProviderSettingsList) > 0 {
+		if stringVal, ok := h.Distro.ProviderSettingsList[0].Lookup("instance_type").StringValueOK(); ok {
+			instanceType = stringVal
+		}
+	}
+	existingHostCount, err := host.CountRunningHosts(h.Distro.Id)
+	if err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":       "database error counting running hosts by distro_id",
+			"host_id":       h.Id,
+			"distro_id":     h.Distro.Id,
+			"instance_type": instanceType,
+		}))
+		existingHostCount = -1
+	}
+
+	grip.Info(message.Fields{
+		"message":            "got interruption warning from AWS",
+		"distro":             h.Distro.Id,
+		"running_host_count": existingHostCount,
+		"instance_type":      instanceType,
+		"host_id":            h.Id,
+	})
+
+	if h.Status == evergreen.HostTerminated {
+		return nil
+	}
+
+	if sns.skipEarlyTermination(h) {
+		return nil
+	}
+
+	terminationJob := units.NewHostTerminationJob(sns.env, h, units.HostTerminationOptions{
+		TerminateIfBusy:          true,
+		TerminationReason:        "got interruption warning",
+		SkipCloudHostTermination: true,
+	})
+	if err := amboy.EnqueueUniqueJob(ctx, sns.queue, terminationJob); err != nil {
+		grip.Warning(message.WrapError(err, message.Fields{
+			"message":          "could not enqueue host termination job",
+			"host_id":          h.Id,
+			"enqueue_job_type": terminationJob.Type(),
+		}))
+	}
+
+	return nil
+}
+
+// skipEarlyTermination decides if we should terminate the instance now or wait for AWS to do it.
+// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#billing-for-interrupted-spot-instances
+func (sns *ec2SNS) skipEarlyTermination(h *host.Host) bool {
+	// Let AWS terminate if we're within the first hour
+	if utility.IsZeroTime(h.StartTime) || time.Now().Sub(h.StartTime) < time.Hour {
+		return true
+	}
+
+	// Let AWS terminate Windows hosts themselves.
+	if h.Distro.IsWindows() {
+		return true
+	}
+
+	return false
 }
 
 func (sns *ec2SNS) handleInstanceTerminated(ctx context.Context, instanceID string) error {

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -130,6 +130,11 @@ func TestEC2SNSNotificationHandlers(t *testing.T) {
 	assert.NoError(t, spawnHost.Insert())
 
 	for name, test := range map[string]func(*testing.T){
+		"InstanceInterruptionWarningInitiatesTermination": func(t *testing.T) {
+			rh.payload = sns.Payload{MessageId: messageID}
+			require.NoError(t, rh.handleInstanceInterruptionWarning(ctx, agentHost.Id))
+			require.Equal(t, 1, rh.queue.Stats(ctx).Total)
+		},
 		"InstanceTerminatedInitiatesInstanceStatusCheck": func(t *testing.T) {
 			require.NoError(t, rh.handleInstanceTerminated(ctx, agentHost.Id))
 			require.Equal(t, 1, rh.queue.Stats(ctx).Total)

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -130,11 +130,6 @@ func TestEC2SNSNotificationHandlers(t *testing.T) {
 	assert.NoError(t, spawnHost.Insert())
 
 	for name, test := range map[string]func(*testing.T){
-		"InstanceInterruptionWarningInitiatesTermination": func(t *testing.T) {
-			rh.payload = sns.Payload{MessageId: messageID}
-			require.NoError(t, rh.handleInstanceInterruptionWarning(ctx, agentHost.Id))
-			require.Equal(t, 1, rh.queue.Stats(ctx).Total)
-		},
 		"InstanceTerminatedInitiatesInstanceStatusCheck": func(t *testing.T) {
 			require.NoError(t, rh.handleInstanceTerminated(ctx, agentHost.Id))
 			require.Equal(t, 1, rh.queue.Stats(ctx).Total)

--- a/units/crons.go
+++ b/units/crons.go
@@ -211,7 +211,10 @@ func PopulateHostTerminationJobs(env evergreen.Environment) amboy.QueueOperation
 				})
 				continue
 			}
-			catcher.Add(amboy.EnqueueUniqueJob(ctx, queue, NewHostTerminationJob(env, &h, true, "host is expired, decommissioned, or failed to provision")))
+			catcher.Add(amboy.EnqueueUniqueJob(ctx, queue, NewHostTerminationJob(env, &h, HostTerminationOptions{
+				TerminateIfBusy:   true,
+				TerminationReason: "host is expired, decommissioned, or failed to provision",
+			})))
 		}
 
 		hosts, err = host.AllHostsSpawnedByTasksToTerminate()
@@ -223,7 +226,10 @@ func PopulateHostTerminationJobs(env evergreen.Environment) amboy.QueueOperation
 		catcher.Add(err)
 
 		for _, h := range hosts {
-			catcher.Add(amboy.EnqueueUniqueJob(ctx, queue, NewHostTerminationJob(env, &h, true, "host spawned by task has gone out of scope")))
+			catcher.Add(amboy.EnqueueUniqueJob(ctx, queue, NewHostTerminationJob(env, &h, HostTerminationOptions{
+				TerminateIfBusy:   true,
+				TerminationReason: "host spawned by task has gone out of scope",
+			})))
 		}
 
 		return catcher.Resolve()

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -146,7 +146,11 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 
 		event.LogHostTerminatedExternally(h.Id, h.Status)
 
-		err = amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewHostTerminationJob(env, h, true, fmt.Sprintf("host was found in %s state", cloudStatus.String())))
+		err = amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewHostTerminationJob(env, h, HostTerminationOptions{
+			TerminateIfBusy:          true,
+			TerminationReason:        fmt.Sprintf("host was found in %s state", cloudStatus.String()),
+			SkipCloudHostTermination: cloudStatus == cloud.StatusTerminated,
+		}))
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":      "could not enqueue job to terminate externally-modified host",
 			"cloud_status": cloudStatus.String(),

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -186,7 +186,8 @@ func (j *idleHostJob) checkAndTerminateHost(ctx context.Context, h *host.Host, d
 	if terminateReason != "" {
 		j.Terminated++
 		j.TerminatedHosts = append(j.TerminatedHosts, h.Id)
-		return amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), NewHostTerminationJob(j.env, h, false, terminateReason))
+		terminationJob := NewHostTerminationJob(j.env, h, HostTerminationOptions{TerminationReason: terminateReason})
+		return amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), terminationJob)
 	}
 
 	return nil

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -120,7 +120,10 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 			j.AddError(j.host.SetStatus(evergreen.HostProvisionFailed, evergreen.User,
 				"decommissioning host after failing to mount volume"))
 
-			terminateJob := NewHostTerminationJob(j.env, j.host, true, "failed to mount volume")
+			terminateJob := NewHostTerminationJob(j.env, j.host, HostTerminationOptions{
+				TerminateIfBusy:   true,
+				TerminationReason: "failed to mount volume",
+			})
 			terminateJob.SetPriority(100)
 			j.AddError(amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), terminateJob))
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15358

### Description 
If the host is externally terminated, skip the cloud host status check and termination. This assumes that the host really will terminate on its own without our intervention.

* Skip cloud host termination if host is externally terminated.
* Slightly refactor host termination job options.

### Testing 
Updated unit tests.
