### PR TITLE
EVG-16554 Update find host by ip to only return running hosts

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -588,7 +588,7 @@ func ById(id string) db.Q {
 }
 
 // ByIP produces a query that returns a running host with the given ip address.
-func ByIP(ip string) db.Q {
+func ByIPAndRunning(ip string) db.Q {
 	return db.Query(bson.M{
 		"$or": []bson.M{
 			{IPKey: ip},

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -587,7 +587,7 @@ func ById(id string) db.Q {
 	return db.Query(bson.D{{Key: IdKey, Value: id}})
 }
 
-// ByIP produces a query that returns a running host with the given ip address.
+// ByIPAndRunning produces a query that returns a running host with the given ip address.
 func ByIPAndRunning(ip string) db.Q {
 	return db.Query(bson.M{
 		"$or": []bson.M{

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -587,13 +587,14 @@ func ById(id string) db.Q {
 	return db.Query(bson.D{{Key: IdKey, Value: id}})
 }
 
-// ByIP produces a query that returns a host with the given ip address.
+// ByIP produces a query that returns a running host with the given ip address.
 func ByIP(ip string) db.Q {
 	return db.Query(bson.M{
 		"$or": []bson.M{
 			{IPKey: ip},
 			{IPv4Key: ip},
 		},
+		StatusKey: evergreen.HostRunning,
 	})
 }
 

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -5074,7 +5074,7 @@ func (*FindHostsSuite) hosts() []Host {
 				Id:      "distro2",
 				Aliases: []string{"alias125"},
 			},
-			Status:         evergreen.HostRunning,
+			Status:         evergreen.HostTerminated,
 			ExpirationTime: time.Now().Add(time.Hour),
 			IP:             "ip2",
 		}, {
@@ -5198,17 +5198,11 @@ func (s *FindHostsSuite) TestFindByIP() {
 	s.NotNil(h1)
 	s.Equal("host1", h1.Id)
 	s.Equal("ip1", h1.IP)
-
-	h2, ok := FindOne(ByIPAndRunning("ip2"))
-	s.NoError(ok)
-	s.NotNil(h2)
-	s.Equal("host2", h2.Id)
-	s.Equal("ip2", h2.IP)
 }
 
 func (s *FindHostsSuite) TestFindByIPFail() {
 	// terminated host
-	h1, ok := FindOne(ByIPAndRunning("ip3"))
+	h1, ok := FindOne(ByIPAndRunning("ip2"))
 	s.NoError(ok)
 	s.Nil(h1)
 

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -5074,7 +5074,7 @@ func (*FindHostsSuite) hosts() []Host {
 				Id:      "distro2",
 				Aliases: []string{"alias125"},
 			},
-			Status:         evergreen.HostTerminated,
+			Status:         evergreen.HostRunning,
 			ExpirationTime: time.Now().Add(time.Hour),
 			IP:             "ip2",
 		}, {
@@ -5193,13 +5193,13 @@ func (s *FindHostsSuite) TestFindByIdFail() {
 }
 
 func (s *FindHostsSuite) TestFindByIP() {
-	h1, ok := FindOne(ByIP("ip1"))
+	h1, ok := FindOne(ByIPAndRunning("ip1"))
 	s.NoError(ok)
 	s.NotNil(h1)
 	s.Equal("host1", h1.Id)
 	s.Equal("ip1", h1.IP)
 
-	h2, ok := FindOne(ByIP("ip2"))
+	h2, ok := FindOne(ByIPAndRunning("ip2"))
 	s.NoError(ok)
 	s.NotNil(h2)
 	s.Equal("host2", h2.Id)
@@ -5207,9 +5207,14 @@ func (s *FindHostsSuite) TestFindByIP() {
 }
 
 func (s *FindHostsSuite) TestFindByIPFail() {
-	h, ok := FindOne(ByIP("nonexistent"))
+	// terminated host
+	h1, ok := FindOne(ByIPAndRunning("ip3"))
 	s.NoError(ok)
-	s.Nil(h)
+	s.Nil(h1)
+
+	h2, ok := FindOne(ByIPAndRunning("nonexistent"))
+	s.NoError(ok)
+	s.Nil(h2)
 }
 
 func (s *FindHostsSuite) TestFindHostsByDistro() {

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -664,7 +664,7 @@ func (h *hostIpAddressGetHandler) Parse(ctx context.Context, r *http.Request) er
 }
 
 func (h *hostIpAddressGetHandler) Run(ctx context.Context) gimlet.Responder {
-	host, err := host.FindOne(host.ByIP(h.IP))
+	host, err := host.FindOne(host.ByIPAndRunning(h.IP))
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "error fetching host information for '%s'", h.IP))
 	}


### PR DESCRIPTION
[EVG-16554](https://jira.mongodb.org/browse/EVG-16554)

### Description 
change find host by ip query to only find running hosts 

### Testing 
unit test

finding terminated hosts returns nothing 

![image](https://user-images.githubusercontent.com/26491602/162045067-49946fff-0a50-4269-85a6-055cac7711dc.png)
