### PR TITLE
EVG-16073: Add an end point to get recent running versions of a task

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -39,7 +39,7 @@ const (
 type GetProjectTasksOpts struct {
 	NumVersions  int    `json:"num_versions"`
 	BuildVariant string `json:"build_variant"`
-	StartAfter   int    `json:"start_after"`
+	StartAt      int    `json:"start_at"`
 }
 
 type Project struct {

--- a/model/project.go
+++ b/model/project.go
@@ -37,7 +37,7 @@ const (
 )
 
 type GetProjectTasksOpts struct {
-	NumVersions  int    `json:"num_versions"`
+	Limit        int    `json:"num_versions"`
 	BuildVariant string `json:"build_variant"`
 	StartAt      int    `json:"start_at"`
 }

--- a/model/project.go
+++ b/model/project.go
@@ -36,6 +36,12 @@ const (
 	waterfallTasksQueryMaxTime = 90 * time.Second
 )
 
+type GetProjectTasksOpts struct {
+	NumVersions  int    `json:"num_versions"`
+	BuildVariant string `json:"build_variant"`
+	StartAfter   int    `json:"start_after"`
+}
+
 type Project struct {
 	Enabled             bool                       `yaml:"enabled,omitempty" bson:"enabled"`
 	Stepback            bool                       `yaml:"stepback,omitempty" bson:"stepback"`

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1062,7 +1062,7 @@ func CountProjectRefsWithIdentifier(identifier string) (int, error) {
 	return db.CountQ(ProjectRefCollection, byId(identifier))
 }
 
-// GetTasksWithOptions will find the last number of tasks (denoted by NumVersions) that have run on a given project.
+// GetTasksWithOptions will find the last number of tasks (denoted by NumVersions) that exist for a given project.
 // This function may also filter on tasks running on a specific build variant, or tasks that come after a specific revision order number.
 func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTasksOpts) ([]task.Task, error) {
 	projectId, err := GetIdForProject(projectName)
@@ -1072,9 +1072,11 @@ func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTas
 	if opts.NumVersions <= 0 {
 		opts.NumVersions = defaultVersionLimit
 	}
+	finishedStatuses := append(evergreen.TaskFailureStatuses, evergreen.TaskSucceeded)
 	match := bson.M{
 		task.ProjectKey:     projectId,
 		task.DisplayNameKey: taskName,
+		task.StatusKey:      bson.M{"$in": finishedStatuses},
 	}
 	if opts.StartAt > 0 {
 		match[task.RevisionOrderNumberKey] = bson.M{"$lte": opts.StartAt}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1062,7 +1062,8 @@ func CountProjectRefsWithIdentifier(identifier string) (int, error) {
 	return db.CountQ(ProjectRefCollection, byId(identifier))
 }
 
-// GetTasksWithOptions
+// GetTasksWithOptions will find the last number of tasks (denoted by NumVersions) that have run on a given project.
+// This function may also filter on tasks running on a specific build variant, or tasks that come after a specific revision order number.
 func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTasksOpts) ([]task.Task, error) {
 	projectId, err := GetIdForProject(projectName)
 	if err != nil {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1075,8 +1075,8 @@ func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTas
 		task.ProjectKey:     projectId,
 		task.DisplayNameKey: taskName,
 	}
-	if opts.StartAfter > 0 {
-		match[VersionRevisionOrderNumberKey] = bson.M{"$lt": opts.StartAfter}
+	if opts.StartAt > 0 {
+		match[task.RevisionOrderNumberKey] = bson.M{"$lte": opts.StartAt}
 	}
 	if opts.BuildVariant != "" {
 		match[task.BuildVariantKey] = opts.BuildVariant

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1062,15 +1062,15 @@ func CountProjectRefsWithIdentifier(identifier string) (int, error) {
 	return db.CountQ(ProjectRefCollection, byId(identifier))
 }
 
-// GetTasksWithOptions will find the last number of tasks (denoted by NumVersions) that exist for a given project.
+// GetTasksWithOptions will find the last number of tasks (denoted by Limit) that exist for a given project.
 // This function may also filter on tasks running on a specific build variant, or tasks that come after a specific revision order number.
 func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTasksOpts) ([]task.Task, error) {
 	projectId, err := GetIdForProject(projectName)
 	if err != nil {
 		return nil, err
 	}
-	if opts.NumVersions <= 0 {
-		opts.NumVersions = defaultVersionLimit
+	if opts.Limit <= 0 {
+		opts.Limit = defaultVersionLimit
 	}
 	finishedStatuses := append(evergreen.TaskFailureStatuses, evergreen.TaskSucceeded)
 	match := bson.M{
@@ -1086,7 +1086,7 @@ func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTas
 	}
 	pipeline := []bson.M{bson.M{"$match": match}}
 	pipeline = append(pipeline, bson.M{"$sort": bson.M{task.RevisionOrderNumberKey: -1}})
-	pipeline = append(pipeline, bson.M{"$limit": opts.NumVersions})
+	pipeline = append(pipeline, bson.M{"$limit": opts.Limit})
 
 	res := []task.Task{}
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1710,14 +1710,14 @@ func TestGetProjectTasksWithOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, tasks, defaultVersionLimit)
 
-	opts.NumVersions = 5
+	opts.Limit = 5
 	tasks, err = GetTasksWithOptions("my_ident", "t1", opts)
 	assert.NoError(t, err)
 	assert.Len(t, tasks, 5)
 	assert.Equal(t, tasks[0].RevisionOrderNumber, 99)
 	assert.Equal(t, tasks[4].RevisionOrderNumber, 91)
 
-	opts.NumVersions = 10
+	opts.Limit = 10
 	opts.StartAt = 20
 	tasks, err = GetTasksWithOptions("my_ident", "t1", opts)
 	assert.NoError(t, err)
@@ -1725,7 +1725,7 @@ func TestGetProjectTasksWithOptions(t *testing.T) {
 	assert.Equal(t, tasks[0].RevisionOrderNumber, 19)
 	assert.Equal(t, tasks[9].RevisionOrderNumber, 1)
 
-	opts.NumVersions = defaultVersionLimit
+	opts.Limit = defaultVersionLimit
 	opts.StartAt = 90
 	// 1 in every 6 tasks should qualify for this
 	opts.BuildVariant = "bv1"

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -3,7 +3,6 @@ package model
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/evergreen/model/task"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"

--- a/model/version.go
+++ b/model/version.go
@@ -599,9 +599,6 @@ func GetVersionsWithOptions(projectName string, opts GetVersionsOptions) ([]Vers
 	if err := db.Aggregate(VersionCollection, pipeline, &res); err != nil {
 		return nil, errors.Wrapf(err, "error aggregating versions and builds")
 	}
-	if len(res) == 0 {
-		return res, nil
-	}
 	return res, nil
 }
 

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -106,7 +106,7 @@ func VerifyUniqueProject(name string) error {
 	return nil
 }
 
-// GetProjectTasksWithOptions
+// GetProjectTasksWithOptions finds the previous tasks that have run on a project that adhere to the passed in options.
 func GetProjectTasksWithOptions(projectName string, taskName string, opts model.GetProjectTasksOpts) ([]restModel.APITask, error) {
 	tasks, err := model.GetTasksWithOptions(projectName, taskName, opts)
 	if err != nil {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -106,6 +106,23 @@ func VerifyUniqueProject(name string) error {
 	return nil
 }
 
+// GetProjectTasksWithOptions
+func GetProjectTasksWithOptions(projectName string, taskName string, opts model.GetProjectTasksOpts) ([]restModel.APITask, error) {
+	tasks, err := model.GetTasksWithOptions(projectName, taskName, opts)
+	if err != nil {
+		return nil, err
+	}
+	res := []restModel.APITask{}
+	for _, t := range tasks {
+		apiTask := restModel.APITask{}
+		if err = apiTask.BuildFromService(&t); err != nil {
+			return nil, errors.Wrap(err, "error building API tasks")
+		}
+		res = append(res, apiTask)
+	}
+	return res, nil
+}
+
 // FindProjectVarsById returns the variables associated with the project and repo (if given).
 func FindProjectVarsById(id string, repoId string, redact bool) (*restModel.APIProjectVars, error) {
 	var repoVars *model.ProjectVars

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -1007,12 +1007,11 @@ func (h *getProjectTasksHandler) Parse(ctx context.Context, r *http.Request) err
 			return errors.Wrap(err, "error parsing request body")
 		}
 	}
-
+	if h.opts.NumVersions < 0 {
+		return errors.New("'num_versions' must be a positive integer")
+	}
 	if h.opts.NumVersions == 0 {
 		h.opts.NumVersions = defaultVersionLimit
-	}
-	if h.opts.NumVersions < 1 {
-		return errors.New("'num_versions' must be a positive integer")
 	}
 	if h.opts.StartAt < 0 {
 		return errors.New("'start' must be a non-negative integer")
@@ -1027,12 +1026,7 @@ func (h *getProjectTasksHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "error getting versions"))
 	}
 
-	resp, err := gimlet.NewBasicResponder(http.StatusOK, gimlet.JSON, versions)
-	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "error constructing response"))
-	}
-
-	return resp
+	return gimlet.NewJSONResponse(versions)
 }
 
 type GetProjectAliasResultsHandler struct {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -982,8 +982,6 @@ func (h *getProjectVersionsHandler) Run(ctx context.Context) gimlet.Responder {
 //
 // GET /rest/v2/projects/{project_id}/tasks/{task_id}
 
-const defaultTaskLimit = 20
-
 type getProjectTasksHandler struct {
 	projectName string
 	taskName    string

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -1007,11 +1007,11 @@ func (h *getProjectTasksHandler) Parse(ctx context.Context, r *http.Request) err
 			return errors.Wrap(err, "error parsing request body")
 		}
 	}
-	if h.opts.NumVersions < 0 {
+	if h.opts.Limit < 0 {
 		return errors.New("'num_versions' must be a positive integer")
 	}
-	if h.opts.NumVersions == 0 {
-		h.opts.NumVersions = defaultVersionLimit
+	if h.opts.Limit == 0 {
+		h.opts.Limit = defaultVersionLimit
 	}
 	if h.opts.StartAt < 0 {
 		return errors.New("'start' must be a non-negative integer")

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -1016,7 +1016,7 @@ func (h *getProjectTasksHandler) Parse(ctx context.Context, r *http.Request) err
 	if h.opts.NumVersions < 1 {
 		return errors.New("'num_versions' must be a positive integer")
 	}
-	if h.opts.StartAfter < 0 {
+	if h.opts.StartAt < 0 {
 		return errors.New("'start' must be a non-negative integer")
 	}
 

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -978,6 +978,65 @@ func (h *getProjectVersionsHandler) Run(ctx context.Context) gimlet.Responder {
 	return resp
 }
 
+////////////////////////////////////////////////////////////////////////
+//
+// GET /rest/v2/projects/{project_id}/tasks/{task_id}
+
+const defaultTaskLimit = 20
+
+type getProjectTasksHandler struct {
+	projectName string
+	taskName    string
+	opts        dbModel.GetProjectTasksOpts
+	url         string
+}
+
+func makeGetProjectTasksHandler(url string) gimlet.RouteHandler {
+	return &getProjectTasksHandler{url: url}
+}
+
+func (h *getProjectTasksHandler) Factory() gimlet.RouteHandler {
+	return &getProjectTasksHandler{url: h.url}
+}
+
+func (h *getProjectTasksHandler) Parse(ctx context.Context, r *http.Request) error {
+	h.projectName = gimlet.GetVars(r)["project_id"]
+	h.taskName = gimlet.GetVars(r)["task_id"]
+	// body is optional
+	b, _ := ioutil.ReadAll(r.Body)
+	if len(b) > 0 {
+		if err := json.Unmarshal(b, &h.opts); err != nil {
+			return errors.Wrap(err, "error parsing request body")
+		}
+	}
+
+	if h.opts.NumVersions == 0 {
+		h.opts.NumVersions = defaultVersionLimit
+	}
+	if h.opts.NumVersions < 1 {
+		return errors.New("'num_versions' must be a positive integer")
+	}
+	if h.opts.StartAfter < 0 {
+		return errors.New("'start' must be a non-negative integer")
+	}
+
+	return nil
+}
+
+func (h *getProjectTasksHandler) Run(ctx context.Context) gimlet.Responder {
+	versions, err := data.GetProjectTasksWithOptions(h.projectName, h.taskName, h.opts)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "error getting versions"))
+	}
+
+	resp, err := gimlet.NewBasicResponder(http.StatusOK, gimlet.JSON, versions)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "error constructing response"))
+	}
+
+	return resp
+}
+
 type GetProjectAliasResultsHandler struct {
 	version             string
 	alias               string

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -687,6 +687,7 @@ func TestGetProjectTasks(t *testing.T) {
 			RevisionOrderNumber: i,
 			DisplayName:         "t1",
 			Project:             projectId,
+			Status:              evergreen.TaskSucceeded,
 		}
 		assert.NoError(myTask.Insert())
 	}

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -696,7 +696,7 @@ func TestGetProjectTasks(t *testing.T) {
 		projectName: "p1",
 		taskName:    "t1",
 		opts: serviceModel.GetProjectTasksOpts{
-			NumVersions: 10,
+			Limit: 10,
 		},
 	}
 

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -166,6 +166,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}/task_stats").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTaskStats(opts.URL))
 	app.AddRoute("/projects/{project_id}/test_stats").Version(2).Get().Wrap(requireUser, viewTasks, cedarTestStats).RouteHandler(makeGetProjectTestStats(opts.URL))
 	app.AddRoute("/projects/{project_id}/versions").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectVersionsHandler(opts.URL))
+	app.AddRoute("/projects/{project_id}/tasks/{task_id}").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTasksHandler(opts.URL))
 	app.AddRoute("/projects/{project_id}/versions/tasks").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchProjectTasks())
 	app.AddRoute("/projects/{project_id}/patch_trigger_aliases").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchPatchTriggerAliases())
 	app.AddRoute("/projects/{project_id}/parameters").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchParameters())


### PR DESCRIPTION
[EVG-16073](https://jira.mongodb.org/browse/EVG-16073)

### Description 
New route was created allowing users to get recent versions of a task for a specific project. Allows for filtering on build variant, starting revision number, and limit on the number of results returned.
### Testing 
Added new unit tests for the DB function and rest route.