### PR TITLE
EVG-16576 use clienttoken in EC2 requests that accept it

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -203,6 +203,7 @@ func (c *awsClientImpl) Close() {
 func (c *awsClientImpl) RunInstances(ctx context.Context, input *ec2.RunInstancesInput) (*ec2.Reservation, error) {
 	var output *ec2.Reservation
 	var err error
+	input.SetClientToken(utility.RandomString())
 	msg := makeAWSLogMessage("RunInstances", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
@@ -431,6 +432,7 @@ func (c *awsClientImpl) StartInstances(ctx context.Context, input *ec2.StartInst
 func (c *awsClientImpl) RequestSpotInstances(ctx context.Context, input *ec2.RequestSpotInstancesInput) (*ec2.RequestSpotInstancesOutput, error) {
 	var output *ec2.RequestSpotInstancesOutput
 	var err error
+	input.SetClientToken(utility.RandomString())
 	msg := makeAWSLogMessage("RequestSpotInstances", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
@@ -559,6 +561,7 @@ func (c *awsClientImpl) CancelSpotInstanceRequests(ctx context.Context, input *e
 func (c *awsClientImpl) CreateVolume(ctx context.Context, input *ec2.CreateVolumeInput) (*ec2.Volume, error) {
 	var output *ec2.Volume
 	var err error
+	input.SetClientToken(utility.RandomString())
 	msg := makeAWSLogMessage("CreateVolume", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
@@ -920,6 +923,7 @@ func (c *awsClientImpl) GetProducts(ctx context.Context, input *pricing.GetProdu
 func (c *awsClientImpl) CreateLaunchTemplate(ctx context.Context, input *ec2.CreateLaunchTemplateInput) (*ec2.CreateLaunchTemplateOutput, error) {
 	var output *ec2.CreateLaunchTemplateOutput
 	var err error
+	input.SetClientToken(utility.RandomString())
 	msg := makeAWSLogMessage("CreateLaunchTemplate", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
@@ -1001,6 +1005,7 @@ func (c *awsClientImpl) DeleteLaunchTemplate(ctx context.Context, input *ec2.Del
 func (c *awsClientImpl) CreateFleet(ctx context.Context, input *ec2.CreateFleetInput) (*ec2.CreateFleetOutput, error) {
 	var output *ec2.CreateFleetOutput
 	var err error
+	input.SetClientToken(utility.RandomString())
 	msg := makeAWSLogMessage("CreateFleet", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,


### PR DESCRIPTION
[EVG-16576](https://jira.mongodb.org/browse/EVG-16576)

### Description 
Following the suggestion from [here](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html) to pass a unique client token with each retry for the operations that support it. It's not abundantly clear from the docs what's valid as a token, but from what I saw the length and range of characters of [utility.RandomString](https://github.com/evergreen-ci/utility/blob/d16eb64796e67d3bbf2463eb9df94aa48911b0ff/random.go#L18-L21) (32 characters in the [0-9a-f] range) should be fine.

### Testing 
I spawned [a host](https://spruce-staging.corp.mongodb.com/host/i-094d53f450cc0bc17) on staging that (fortuitously) [retried a few times](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen-staging%20api_name%3D%22RunInstances%22%20%22args.TagSpecifications%7B%7D.Tags%7B%7D.Value%22%3D%22evg-ubuntu2004-small-20220407143608-4209386405985680623%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1649341800&latest=1649342700&sid=1649343242.139468). Each retry used the same client token.
