### PR TITLE
EVG-16699  Fix Non Deterministic behavior in display task status determination

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1726,23 +1726,23 @@ func (t *Task) displayTaskPriority() int {
 	case evergreen.TaskTestTimedOut:
 		return 30
 	case evergreen.TaskTimedOut:
-		return 30
-	case evergreen.TaskSystemFailed:
 		return 40
-	case evergreen.TaskSystemTimedOut:
+	case evergreen.TaskSystemFailed:
 		return 50
-	case evergreen.TaskSystemUnresponse:
+	case evergreen.TaskSystemTimedOut:
 		return 60
-	case evergreen.TaskSetupFailed:
+	case evergreen.TaskSystemUnresponse:
 		return 70
+	case evergreen.TaskSetupFailed:
+		return 80
 	case evergreen.TaskUndispatched:
-		return 80
-	case evergreen.TaskContainerUnallocated:
-		return 80
-	case evergreen.TaskInactive:
 		return 90
-	case evergreen.TaskSucceeded:
+	case evergreen.TaskContainerUnallocated:
+		return 90
+	case evergreen.TaskInactive:
 		return 100
+	case evergreen.TaskSucceeded:
+		return 110
 	}
 	return 1000
 }


### PR DESCRIPTION
[EVG-16699](https://jira.mongodb.org/browse/EVG-16699)

### Description 
TaskTimedOut and TaskTestTimedOut had the same value, which means they would be arbitrarily prioritized making sorts inconsistent. I TaskTestTimedOut so that it is consistent. 

@mvankeulen94 Please let me know if you think we should instead prioritize TaskTimedOut over TaskTestTimedOut in sorts. 

