### PR TITLE
EVG-16706: convert container allocation statuses into separate field

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -590,8 +590,7 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 			tc.logger.Task().Error(errors.Wrap(err, "error running post task commands"))
 		}
 		a.runEndTaskSync(ctx, tc, detail)
-	// TODO: (PM-2616) make sure that TaskContainerUnallocated means the task has been aborted.
-	case evergreen.TaskUndispatched, evergreen.TaskContainerUnallocated:
+	case evergreen.TaskUndispatched:
 		tc.logger.Task().Info("Task completed - ABORTED.")
 	case evergreen.TaskConflict:
 		tc.logger.Task().Error("Task completed - CANCELED.")

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-03-11"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-04-04"
+	AgentVersion = "2022-04-11"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/globals.go
+++ b/globals.go
@@ -57,11 +57,6 @@ const (
 	TaskUnscheduled  = "unscheduled"
 	// TaskWillRun is a subset of TaskUndispatched and is only used in the UI
 	TaskWillRun = "will-run"
-	// TaskContainerUnallocated indicates that a tasks's container has not been requested.
-	TaskContainerUnallocated = "container-unallocated"
-	// TaskContainerAllocated indicates that a tasks's container has been requested
-	// from the cloud provider but hasn't started yet.
-	TaskContainerAllocated = "container-allocated"
 
 	// TaskDispatched indicates that an agent has received the task, but
 	// the agent has not yet told Evergreen that it's running the task
@@ -325,7 +320,6 @@ var TaskUnstartedStatuses = []string{
 	TaskInactive,
 	TaskUnstarted,
 	TaskUndispatched,
-	TaskContainerAllocated,
 }
 
 func IsUnstartedTaskStatus(status string) bool {
@@ -725,8 +719,14 @@ var (
 	// are in a finished state.
 	TaskCompletedStatuses = []string{TaskSucceeded, TaskFailed}
 	// TaskUncompletedStatuses are all statuses that do not represent a finished state.
-	TaskUncompletedStatuses = []string{TaskStarted, TaskUnstarted, TaskUndispatched, TaskDispatched, TaskConflict,
-		TaskInactive, TaskContainerUnallocated, TaskContainerAllocated}
+	TaskUncompletedStatuses = []string{
+		TaskStarted,
+		TaskUnstarted,
+		TaskUndispatched,
+		TaskDispatched,
+		TaskConflict,
+		TaskInactive,
+	}
 
 	SyncStatuses = []string{TaskSucceeded, TaskFailed}
 

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3217,7 +3217,7 @@ func (r *taskResolver) CanSchedule(ctx context.Context, obj *restModel.APITask) 
 }
 
 func (r *taskResolver) CanUnschedule(ctx context.Context, obj *restModel.APITask) (bool, error) {
-	return (obj.Activated && *obj.Status == evergreen.TaskUndispatched) || *obj.Status == evergreen.TaskContainerAllocated, nil
+	return (obj.Activated && *obj.Status == evergreen.TaskUndispatched), nil
 }
 
 func (r *taskResolver) CanSetPriority(ctx context.Context, obj *restModel.APITask) (bool, error) {

--- a/model/container_task_queue_test.go
+++ b/model/container_task_queue_test.go
@@ -18,11 +18,12 @@ func TestContainerTaskQueue(t *testing.T) {
 	}()
 	getTaskThatNeedsContainerAllocation := func() task.Task {
 		return task.Task{
-			Id:                utility.RandomString(),
-			Activated:         true,
-			ActivatedTime:     time.Now(),
-			Status:            evergreen.TaskContainerUnallocated,
-			ExecutionPlatform: task.ExecutionPlatformContainer,
+			Id:                 utility.RandomString(),
+			Activated:          true,
+			ActivatedTime:      time.Now(),
+			Status:             evergreen.TaskUndispatched,
+			ContainerAllocated: false,
+			ExecutionPlatform:  task.ExecutionPlatformContainer,
 		}
 	}
 	getProjectRef := func() ProjectRef {
@@ -47,7 +48,7 @@ func TestContainerTaskQueue(t *testing.T) {
 			require.NoError(t, needsAllocation0.Insert())
 
 			doesNotNeedAllocation := getTaskThatNeedsContainerAllocation()
-			doesNotNeedAllocation.Status = evergreen.TaskContainerAllocated
+			doesNotNeedAllocation.ContainerAllocated = true
 			require.NoError(t, doesNotNeedAllocation.Insert())
 
 			needsAllocation1 := getTaskThatNeedsContainerAllocation()

--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -111,13 +111,14 @@ func Allocate(ctx context.Context, env evergreen.Environment, t *task.Task, p *p
 		// Only allow the task to transition state if it's currently in a state
 		// where it needs a pod to be allocated.
 		update, err := env.DB().Collection(task.Collection).UpdateOne(sessCtx, bson.M{
-			task.IdKey:        t.Id,
-			task.StatusKey:    evergreen.TaskContainerUnallocated,
-			task.ActivatedKey: true,
-			task.PriorityKey:  bson.M{"$gt": evergreen.DisabledTaskPriority},
+			task.IdKey:                 t.Id,
+			task.StatusKey:             evergreen.TaskUndispatched,
+			task.ActivatedKey:          true,
+			task.ContainerAllocatedKey: false,
+			task.PriorityKey:           bson.M{"$gt": evergreen.DisabledTaskPriority},
 		}, bson.M{
 			"$set": bson.M{
-				task.StatusKey: evergreen.TaskContainerAllocated,
+				task.ContainerAllocatedKey: true,
 			},
 		})
 		if err != nil {
@@ -126,7 +127,7 @@ func Allocate(ctx context.Context, env evergreen.Environment, t *task.Task, p *p
 		if update.ModifiedCount == 0 {
 			return nil, errors.New("task status was not updated")
 		}
-		t.Status = evergreen.TaskContainerAllocated
+		t.ContainerAllocated = true
 
 		return nil, nil
 	}

--- a/model/pod/dispatcher/db_test.go
+++ b/model/pod/dispatcher/db_test.go
@@ -142,7 +142,7 @@ func TestAllocate(t *testing.T) {
 		dbTask, err := task.FindOneId(tsk.Id)
 		require.NoError(t, err)
 		require.NotZero(t, dbTask)
-		assert.Equal(t, evergreen.TaskContainerAllocated, dbTask.Status)
+		assert.True(t, dbTask.ContainerAllocated)
 
 		dbDispatcher, err := FindOneByGroupID(GetGroupID(tsk))
 		require.NoError(t, err)
@@ -233,9 +233,10 @@ func TestAllocate(t *testing.T) {
 			})
 			require.NoError(t, err)
 			tCase(tctx, t, env, &task.Task{
-				Id:        "task",
-				Status:    evergreen.TaskContainerUnallocated,
-				Activated: true,
+				Id:                 "task",
+				Status:             evergreen.TaskUndispatched,
+				ContainerAllocated: false,
+				Activated:          true,
 			}, p)
 		})
 	}

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -200,7 +200,7 @@ func (pd *PodDispatcher) dequeue(ctx context.Context, env evergreen.Environment)
 // task indicates a container has been allocated for it, marks it as
 // unallocated.
 func (pd *PodDispatcher) dequeueUndispatchableTask(ctx context.Context, env evergreen.Environment, t *task.Task) error {
-	if t.Status != evergreen.TaskUndispatched || !t.ContainerAllocated {
+	if !t.ContainerAllocated {
 		return errors.Wrap(pd.dequeue(ctx, env), "dequeueing task that is already in a non-allocated state")
 	}
 

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -197,11 +197,11 @@ func (pd *PodDispatcher) dequeue(ctx context.Context, env evergreen.Environment)
 }
 
 // dequeueUndispatchableTask removes the task from the dispatcher and, if the
-// task status indicates a container has been allocated for it, marks it as
+// task indicates a container has been allocated for it, marks it as
 // unallocated.
 func (pd *PodDispatcher) dequeueUndispatchableTask(ctx context.Context, env evergreen.Environment, t *task.Task) error {
-	if t.Status != evergreen.TaskContainerAllocated {
-		return errors.Wrap(pd.dequeue(ctx, env), "dequeueing task")
+	if t.Status != evergreen.TaskUndispatched || !t.ContainerAllocated {
+		return errors.Wrap(pd.dequeue(ctx, env), "dequeueing task that is already in a non-allocated state")
 	}
 
 	if err := t.MarkAsContainerDeallocated(ctx, env); err != nil {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1009,15 +1009,12 @@ func (t *Task) MarkAsHostUndispatched() error {
 // MarkAsContainerDeallocated marks a container task that was allocated as no
 // longer allocated.
 func (t *Task) MarkAsContainerDeallocated(ctx context.Context, env evergreen.Environment) error {
-	if t.Status != evergreen.TaskUndispatched {
-		return errors.Errorf("cannot deallocate a container task if it's not currently undispatched - current status is '%s'", t.Status)
-	}
 	if !t.ContainerAllocated {
 		return errors.New("cannot deallocate a container task if it's not currently allocated")
 	}
+
 	res, err := env.DB().Collection(Collection).UpdateOne(ctx, bson.M{
 		IdKey:                 t.Id,
-		StatusKey:             evergreen.TaskUndispatched,
 		ContainerAllocatedKey: true,
 	}, bson.M{
 		"$set": bson.M{

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2188,7 +2188,6 @@ func TestMarkAsContainerDeallocated(t *testing.T) {
 		dbTask, err := FindOneId(taskID)
 		require.NoError(t, err)
 		require.NotZero(t, dbTask)
-		assert.Equal(t, evergreen.TaskUndispatched, dbTask.Status)
 		assert.False(t, dbTask.ContainerAllocated)
 		assert.True(t, utility.IsZeroTime(dbTask.DispatchTime))
 		assert.True(t, utility.IsZeroTime(dbTask.LastHeartbeat))
@@ -2202,12 +2201,13 @@ func TestMarkAsContainerDeallocated(t *testing.T) {
 			require.NoError(t, tsk.MarkAsContainerDeallocated(ctx, env))
 			checkTaskUnallocated(t, tsk.Id)
 		},
-		"FailsWithoutContainerAllocatedStatus": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
-			tsk.Status = evergreen.TaskSucceeded
+		"FailsWithUnallocatedTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			tsk.ContainerAllocated = false
 			require.NoError(t, tsk.Insert())
+
 			assert.Error(t, tsk.MarkAsContainerDeallocated(ctx, env))
 		},
-		"FailsWithDifferentDBTaskAllocationState": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+		"FailsWithUnallocatedDBTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
 			tsk.ContainerAllocated = false
 			require.NoError(t, tsk.Insert())
 			tsk.ContainerAllocated = true

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -339,10 +339,9 @@ func AbortTask(taskId, caller string) error {
 // tasks for the same build variant + display name + project combination
 // as the task.
 func DeactivatePreviousTasks(t *task.Task, caller string) error {
-	statuses := []string{evergreen.TaskUndispatched, evergreen.TaskContainerUnallocated}
 	filter, sort := task.ByActivatedBeforeRevisionWithStatuses(
 		t.RevisionOrderNumber,
-		statuses,
+		[]string{evergreen.TaskUndispatched},
 		t.BuildVariant,
 		t.DisplayName,
 		t.Project,

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -494,7 +494,6 @@ func makeRandomTasks() []task.Task {
 		evergreen.TaskSystemTimedOut,
 		evergreen.TaskTestTimedOut,
 		evergreen.TaskConflict,
-		evergreen.TaskContainerAllocated,
 	}
 
 	numTasks := rand.Intn(10) + 10

--- a/service/waterfall.go
+++ b/service/waterfall.go
@@ -30,7 +30,7 @@ func uiStatus(task waterfallTask) string {
 	case evergreen.TaskStarted, evergreen.TaskSucceeded,
 		evergreen.TaskFailed, evergreen.TaskDispatched:
 		return task.Status
-	case evergreen.TaskUndispatched, evergreen.TaskContainerUnallocated:
+	case evergreen.TaskUndispatched:
 		if task.Activated {
 			return task.Status
 		} else {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16706

### Description 
The container-unallocated and container-allocated states were used to represent different phases of container allocation for undispatched tasks, but the task lifecycle is logically simpler and requires fewer changes and less if-else checking if both host and container tasks use undispatched as the initial task state. Instead, there's a separate field for container tasks to indicate whether the container has been allocated to it yet or not for an undispatched task. The only downside is that some indexed queries that are specific to host/container tasks might be less than optimal, but it shouldn't be a major performance issue right now.

* Convert "container-unallocated" and "container-allocated" task statuses into a boolean field.
* Use "undispatched" as initial task status for both host and container tasks, which is used to indicate that the task should continue making progress towards dispatching to an agent.

### Testing 
Updated unit tests.
