### PR TITLE
EVG-16679 don't error for cycles/loops

### DIFF
--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -227,7 +227,7 @@ func (d *basicCachedDAGDispatcherImpl) rebuild(items []TaskQueueItem) error {
 			return errors.Wrap(err, "topologically sorting the dependency graph")
 		}
 
-		var cycles [][]string
+		cycles := make([][]string, 0, len(unorderableNodes))
 		for _, cycle := range unorderableNodes {
 			cycleIDs := make([]string, 0, len(cycle))
 			for _, node := range cycle {
@@ -235,7 +235,7 @@ func (d *basicCachedDAGDispatcherImpl) rebuild(items []TaskQueueItem) error {
 			}
 			cycles = append(cycles, cycleIDs)
 		}
-		grip.Warning(message.Fields{
+		grip.Error(message.Fields{
 			"dispatcher": DAGDispatcher,
 			"function":   "rebuild",
 			"message":    "tasks in the queue form dependency cycle(s)",

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/graph/multi"
 	"gonum.org/v1/gonum/graph/topo"
 )
 
@@ -24,7 +24,7 @@ const (
 type basicCachedDAGDispatcherImpl struct {
 	mu          sync.RWMutex
 	distroID    string
-	graph       *simple.DirectedGraph
+	graph       *multi.DirectedGraph
 	sorted      []graph.Node
 	itemNodeMap map[string]graph.Node      // map[TaskQueueItem.Id]Node
 	nodeItemMap map[int64]*TaskQueueItem   // map[node.ID()]*TaskQueueItem
@@ -151,31 +151,17 @@ func (d *basicCachedDAGDispatcherImpl) addEdge(fromID string, toID string) error
 		return errors.Errorf("a node for the dependent task queue item '%s' is not present in the DAG for distro '%s'", toID, d.distroID)
 	}
 
-	// Cannot add a self edge within the DAG!
-	if fromNode.ID() == toNode.ID() {
-		grip.Alert(message.Fields{
-			"dispatcher": DAGDispatcher,
-			"function":   "addEdge",
-			"message":    "cannot add a self edge to a Node",
-			"task_id":    fromID,
-			"node_id":    fromNode.ID(),
-			"distro_id":  d.distroID,
-		})
-
-		return errors.Errorf("cannot add a self edge to task '%s'", fromID)
+	line := multi.Line{
+		F: multi.Node(fromNode.ID()),
+		T: multi.Node(toNode.ID()),
 	}
-
-	edge := simple.Edge{
-		F: simple.Node(fromNode.ID()),
-		T: simple.Node(toNode.ID()),
-	}
-	d.graph.SetEdge(edge)
+	d.graph.SetLine(line)
 
 	return nil
 }
 
 func (d *basicCachedDAGDispatcherImpl) rebuild(items []TaskQueueItem) error {
-	d.graph = simple.NewDirectedGraph()
+	d.graph = multi.NewDirectedGraph()
 	d.sorted = []graph.Node{}
 	d.itemNodeMap = map[string]graph.Node{}     // map[TaskQueueItem.Id]Node
 	d.nodeItemMap = map[int64]*TaskQueueItem{}  // map[node.ID()]*TaskQueueItem
@@ -227,16 +213,35 @@ func (d *basicCachedDAGDispatcherImpl) rebuild(items []TaskQueueItem) error {
 
 	sorted, err := topo.SortStabilized(d.graph, nil)
 	if err != nil {
-		grip.Alert(message.WrapError(err, message.Fields{
-			"dispatcher":                 DAGDispatcher,
-			"function":                   "rebuild",
-			"message":                    "problem ordering the tasks and associated dependencies within the DirectedGraph",
-			"distro_id":                  d.distroID,
-			"initial_num_taskqueueitems": len(items),
-			"num_task_groups":            len(d.taskGroups),
-		}))
+		unorderableNodes, ok := err.(topo.Unorderable)
+		if !ok {
+			grip.Alert(message.WrapError(err, message.Fields{
+				"dispatcher":                 DAGDispatcher,
+				"function":                   "rebuild",
+				"message":                    "problem ordering the tasks and associated dependencies within the DirectedGraph",
+				"distro_id":                  d.distroID,
+				"initial_num_taskqueueitems": len(items),
+				"num_task_groups":            len(d.taskGroups),
+			}))
 
-		return errors.Wrap(err, "topologically sorting the dependency graph")
+			return errors.Wrap(err, "topologically sorting the dependency graph")
+		}
+
+		var cycles [][]string
+		for _, cycle := range unorderableNodes {
+			cycleIDs := make([]string, 0, len(cycle))
+			for _, node := range cycle {
+				cycleIDs = append(cycleIDs, d.nodeItemMap[node.ID()].Id)
+			}
+			cycles = append(cycles, cycleIDs)
+		}
+		grip.Warning(message.Fields{
+			"dispatcher": DAGDispatcher,
+			"function":   "rebuild",
+			"message":    "tasks in the queue form dependency cycle(s)",
+			"cycles":     cycles,
+			"distro_id":  d.distroID,
+		})
 	}
 
 	d.sorted = sorted
@@ -280,11 +285,15 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec, amiUpdatedTim
 			"distro_id":                d.distroID,
 		})
 	}
-	var numIterated int
+
 	dependencyCaches := make(map[string]task.Task)
 	for i := range d.sorted {
-		numIterated += 1
 		node := d.sorted[i]
+		// topo.SortStabilized represents nodes in a dependency cycle with a nil Node.
+		if node == nil {
+			continue
+		}
+
 		item := d.getItemByNodeID(node.ID()) // item is a *TaskQueueItem sourced from d.nodeItemMap, which is a map[node.ID()]*TaskQueueItem.
 
 		// TODO Consider checking if the state of any task has changed, which could unblock later tasks in the queue.
@@ -328,7 +337,7 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(spec TaskSpec, amiUpdatedTim
 			// However, it won't actually be dispatched to a host if it doesn't satisfy all constraints.
 			item.IsDispatched = true // *TaskQueueItem
 
-			if nextTaskFromDB.StartTime != utility.ZeroTime {
+			if !utility.IsZeroTime(nextTaskFromDB.StartTime) {
 				continue
 			}
 

--- a/model/task_queue_service_test.go
+++ b/model/task_queue_service_test.go
@@ -785,56 +785,63 @@ func (s *taskDAGDispatchServiceSuite) TestConstructor() {
 	}
 }
 
-func (s *taskDAGDispatchServiceSuite) TestAddingSelfEdge() {
+func (s *taskDAGDispatchServiceSuite) TestSelfEdge() {
 	s.Require().NoError(db.ClearCollections(task.Collection))
-	items := []TaskQueueItem{}
 
-	t1 := task.Task{
-		Id:                  "1",
-		BuildId:             "ops_manager_kubernetes_init_test_run_patch_1a53e026e05561c3efbb626185e155a7d1e4865d_5d88953e2a60ed61eefe9561_19_09_23_09_49_51",
-		TaskGroup:           "",
-		StartTime:           utility.ZeroTime,
-		BuildVariant:        "init_test_run",
-		Version:             "5d88953e2a60ed61eefe9561",
-		Project:             "ops-manager-kubernetes",
-		Activated:           true,
-		ActivatedBy:         "",
-		DistroId:            "archlinux-test",
-		Requester:           "patch_request",
-		Status:              evergreen.TaskUndispatched,
-		Revision:            "1a53e026e05561c3efbb626185e155a7d1e4865d",
-		RevisionOrderNumber: 1846,
+	t0 := task.Task{
+		Id: "t0",
 		DependsOn: []task.Dependency{
-			task.Dependency{
-				TaskId:       "1",
-				Status:       "success",
-				Unattainable: false,
+			{TaskId: "t0"},
+		},
+	}
+	s.Require().NoError(t0.Insert())
+
+	s.taskQueue = TaskQueue{
+		Queue: []TaskQueueItem{
+			{
+				Id:           "t0",
+				Dependencies: []string{"t0"},
 			},
 		},
 	}
-	item1 := TaskQueueItem{
-		Id:            "1",
-		Group:         "",
-		BuildVariant:  "init_test_run",
-		Version:       "5d88953e2a60ed61eefe9561",
-		Project:       "ops-manager-kubernetes",
-		Requester:     "patch_request",
-		GroupMaxHosts: 0,
-		IsDispatched:  false,
-		Dependencies:  []string{"1"},
+
+	dispatcher, err := newDistroTaskDAGDispatchService(s.taskQueue, time.Minute)
+	s.NoError(err)
+
+	nextTask := dispatcher.FindNextTask(TaskSpec{}, time.Time{})
+	s.Nil(nextTask)
+}
+
+func (s *taskDAGDispatchServiceSuite) TestDependencyCycle() {
+	s.Require().NoError(db.ClearCollections(task.Collection))
+	for _, t := range []task.Task{
+		{
+			Id:        "t0",
+			DependsOn: []task.Dependency{{TaskId: "t1"}},
+		},
+		{
+			Id:        "t1",
+			DependsOn: []task.Dependency{{TaskId: "t0"}},
+		},
+		{
+			Id: "t2",
+		},
+	} {
+		s.Require().NoError(t.Insert())
 	}
 
-	s.Require().NoError(t1.Insert())
-	items = append(items, item1)
+	s.taskQueue = TaskQueue{Queue: []TaskQueueItem{
+		{Id: "t0", Dependencies: []string{"t1"}},
+		{Id: "t1", Dependencies: []string{"t0"}},
+		{Id: "t2"},
+	}}
 
-	s.taskQueue = TaskQueue{
-		Distro: "archlinux-test",
-		Queue:  items,
-	}
+	dispatcher, err := newDistroTaskDAGDispatchService(s.taskQueue, time.Minute)
+	s.NoError(err)
 
-	_, err := newDistroTaskDAGDispatchService(s.taskQueue, time.Minute)
-	s.Error(err)
-	s.Contains(err.Error(), "cannot add a self edge to task")
+	nextTask := dispatcher.FindNextTask(TaskSpec{}, time.Time{})
+	s.Require().NotNil(nextTask)
+	s.Equal("t2", nextTask.Id)
 }
 
 func (s *taskDAGDispatchServiceSuite) TestAddingEdgeWithMissingNodes() {


### PR DESCRIPTION
[EVG-16679](https://jira.mongodb.org/browse/EVG-16679)

### Description 
If someone manages to create a dependency cycle or a loop in the dependency graph we shouldn't let it put the dispatcher out of commission. 
This PR 
1.  replaces a simple graph with a multigraph so we can model loops in the dependency graph
2. logs an unorderable error instead of returning

I'd thought to disable to tasks when we see they're part of a cycle so they won't keep coming up in the distro's queue, but opted not to. My thinking is that today the dispatcher is exclusively concerned with dispatching tasks and reaching into the task lifecycle to disable a task seems like it violates separation of concerns. Some mitigating factors are that [eventually](https://github.com/evergreen-ci/evergreen/blob/c2a10070a720bc20018b7a0bed8b40b44820834e/model/task/task.go#L40), we'll decide they're underwater and disable them. Also, I plan to fix the thing that made the circular dependency, so this is kind of belt and suspenders anyway.

### Testing 
Added/adjusted unit tests.
Manually created a dependency cycle on staging. The dispatcher [logs the warning](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen-staging%20%22tasks%20in%20the%20queue%20form%20dependency%20cycle(s)%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1649702400&latest=1649703000&sid=1649702813.542557) instead of erroring.
