### PR TITLE
EVG-16625 save un-generated tasks/variants in future iterations of generate.tasks

### DIFF
--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -126,6 +126,48 @@ var (
 		},
 	}
 
+	partiallyGeneratedProject = GeneratedProject{
+		Tasks: []parserTask{
+			{
+				Name: "new_task",
+				Commands: []PluginCommandConf{
+					{
+						Command: "shell.exec",
+					},
+				},
+			},
+			{
+				Name: "another_new_task",
+				Commands: []PluginCommandConf{
+					{
+						Command: "shell.exec",
+					},
+				},
+			},
+		},
+		BuildVariants: []parserBV{
+			{
+				Name: "new_variant",
+				Tasks: parserBVTaskUnits{
+					parserBVTaskUnit{
+						Name: "new_task",
+					},
+					parserBVTaskUnit{
+						Name: "another_new_task",
+					},
+				},
+			},
+			{
+				Name: "another_new_variant",
+				Tasks: parserBVTaskUnits{
+					parserBVTaskUnit{
+						Name: "another_new_task",
+					},
+				},
+			},
+		},
+	}
+
 	sampleProjYml = `
 tasks:
   - name: say-hi
@@ -673,6 +715,73 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	}
 }
 
+func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
+	generatorTask := task.Task{
+		Id:      "generator",
+		BuildId: "generate_build",
+		Version: "version_that_called_generate_task",
+	}
+	alreadyExistingTask := task.Task{
+		Id:          "new_task",
+		DisplayName: "new_task",
+		BuildId:     "new_variant",
+		Version:     "version_that_called_generate_task",
+		GeneratedBy: "generator",
+		CreateTime:  time.Now(),
+	}
+	alreadyGeneratedVariant := build.Build{
+		Id:           "new_variant",
+		BuildVariant: "new_variant",
+		Version:      "version_that_called_generate_task",
+		CreateTime:   time.Now(),
+	}
+	s.NoError(generatorTask.Insert())
+	s.NoError(alreadyExistingTask.Insert())
+	s.NoError(alreadyGeneratedVariant.Insert())
+
+	v := &Version{
+		Id:       "version_that_called_generate_task",
+		BuildIds: []string{"new_variant"},
+		Config:   sampleProjYmlTaskGroups,
+	}
+	s.NoError(v.Insert())
+	// Setup parser project to be partially generated.
+	projectInfo, err := LoadProjectForVersion(v, "", false)
+	s.NoError(err)
+
+	g := partiallyGeneratedProject
+	g.TaskID = generatorTask.Id
+	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
+	s.NoError(err)
+	pp.UpdatedByGenerators = []string{generatorTask.Id}
+	s.NoError(pp.Insert())
+
+	// Shouldn't error trying to add the same generated project.
+	p, pp, v, err = g.NewVersion(p, pp, v)
+	s.NoError(err)
+	s.Len(pp.UpdatedByGenerators, 1) // Not modified again.
+
+	s.NoError(g.Save(context.Background(), p, pp, v, &generatorTask))
+
+	tasks := []task.Task{}
+	taskQuery := db.Query(bson.M{task.GeneratedByKey: "generator"}).Sort([]string{task.CreateTimeKey})
+	err = db.FindAllQ(task.Collection, taskQuery, &tasks)
+	s.NoError(err)
+	s.Require().Len(tasks, 3)
+	// New task is added both to previously generated variant, and new variant.
+	s.Equal(tasks[0].DisplayName, "another_new_task")
+	s.Equal(tasks[1].DisplayName, "another_new_task")
+	s.Equal(tasks[2].DisplayName, "new_task")
+
+	// New build is added.
+	builds, err := build.FindBuildsByVersions([]string{v.Id})
+	s.NoError(err)
+	s.Require().Len(builds, 2)
+	s.Equal(builds[0].BuildVariant, "new_variant")
+	s.Equal(builds[1].BuildVariant, "another_new_variant")
+
+}
+
 func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 	tasksThatExist := []task.Task{
 		{
@@ -892,6 +1001,9 @@ func (s *GenerateSuite) TestMergeGeneratedProjectsWithNoTasks() {
 }
 
 func TestUpdateParserProject(t *testing.T) {
+	alreadyUpdatedTestName := "TaskAlreadyUpdatedParserProject"
+	withZeroTestName := "WithZero"
+	taskId := "tId"
 	for testName, setupTest := range map[string]func(t *testing.T, v *Version, pp *ParserProject){
 		"noParserProject": func(t *testing.T, v *Version, pp *ParserProject) {
 			v.ConfigUpdateNumber = 5
@@ -909,8 +1021,14 @@ func TestUpdateParserProject(t *testing.T) {
 			assert.NoError(t, v.Insert())
 			assert.NoError(t, pp.Insert())
 		},
-		"WithZero": func(t *testing.T, v *Version, pp *ParserProject) {
+		withZeroTestName: func(t *testing.T, v *Version, pp *ParserProject) {
 			v.ConfigUpdateNumber = 0
+			assert.NoError(t, v.Insert())
+			assert.NoError(t, pp.Insert())
+		},
+		alreadyUpdatedTestName: func(t *testing.T, v *Version, pp *ParserProject) {
+			pp.UpdatedByGenerators = []string{taskId}
+			pp.ConfigUpdateNumber = 1
 			assert.NoError(t, v.Insert())
 			assert.NoError(t, pp.Insert())
 		},
@@ -920,15 +1038,21 @@ func TestUpdateParserProject(t *testing.T) {
 			v := &Version{Id: "my-version"}
 			pp := &ParserProject{Id: "my-version"}
 			setupTest(t, v, pp)
-			assert.NoError(t, updateParserProject(v, pp))
+			assert.NoError(t, updateParserProject(v, pp, taskId))
 			v, err := VersionFindOneId(v.Id)
 			assert.NoError(t, err)
 			require.NotNil(t, v)
 			pp, err = ParserProjectFindOneById(v.Id)
 			assert.NoError(t, err)
 			require.NotNil(t, pp)
-			if testName == "WithZero" {
+			assert.Len(t, pp.UpdatedByGenerators, 1)
+			assert.Contains(t, pp.UpdatedByGenerators, taskId)
+			if testName == withZeroTestName {
 				assert.Equal(t, 0, v.ConfigUpdateNumber)
+				assert.Equal(t, 1, pp.ConfigUpdateNumber)
+				return
+			} else if testName == alreadyUpdatedTestName {
+				// Not changed because we've already updated.
 				assert.Equal(t, 1, pp.ConfigUpdateNumber)
 				return
 			}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1490,8 +1490,8 @@ func sortLayer(layer []task.Task, idToDisplayName map[string]string) []task.Task
 // do not exist yet out of the set of pairs. No tasks are added for builds which already exist
 // (see AddNewTasksForPatch). New builds/tasks are activated depending on their batchtime.
 // Returns activated task IDs.
-func addNewBuilds(ctx context.Context, activationInfo specificActivationInfo, v *Version, p *Project,
-	tasks TaskVariantPairs, syncAtEndOpts patch.SyncAtEndOptions, projectRef *ProjectRef, generatedBy string) ([]string, error) {
+func addNewBuilds(ctx context.Context, activationInfo specificActivationInfo, v *Version, p *Project, tasks TaskVariantPairs,
+	existingBuilds []build.Build, syncAtEndOpts patch.SyncAtEndOptions, projectRef *ProjectRef, generatedBy string) ([]string, error) {
 
 	taskIdTables, err := getTaskIdTables(v, p, tasks, projectRef.Identifier)
 	if err != nil {
@@ -1502,10 +1502,6 @@ func addNewBuilds(ctx context.Context, activationInfo specificActivationInfo, v 
 	newActivatedTaskIds := make([]string, 0)
 	newBuildStatuses := make([]VersionBuildStatus, 0)
 
-	existingBuilds, err := build.Find(build.ByVersion(v.Id).WithFields(build.BuildVariantKey, build.IdKey))
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
 	variantsProcessed := map[string]bool{}
 	for _, b := range existingBuilds {
 		variantsProcessed[b.BuildVariant] = true
@@ -1628,15 +1624,11 @@ func addNewBuilds(ctx context.Context, activationInfo specificActivationInfo, v 
 // Given a version and set of variant/task pairs, creates any tasks that don't exist yet,
 // within the set of already existing builds. Returns activated task IDs.
 func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *Version, p *Project, pairs TaskVariantPairs,
-	syncAtEndOpts patch.SyncAtEndOptions, projectIdentifier string, generatedBy string) ([]string, error) {
+	existingBuilds []build.Build, syncAtEndOpts patch.SyncAtEndOptions, projectIdentifier string, generatedBy string) ([]string, error) {
 	if v.BuildIds == nil {
 		return nil, nil
 	}
 
-	builds, err := build.Find(build.ByIds(v.BuildIds).WithFields(build.IdKey, build.BuildVariantKey, build.CreateTimeKey, build.RequesterKey))
-	if err != nil {
-		return nil, err
-	}
 	distroAliases, err := distro.NewDistroAliasesLookupTable()
 	if err != nil {
 		return nil, err
@@ -1648,7 +1640,7 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 	}
 
 	activatedTaskIds := []string{}
-	for _, b := range builds {
+	for _, b := range existingBuilds {
 		wasActivated := b.Activated
 		// Find the set of task names that already exist for the given build
 		tasksInBuild, err := task.FindWithFields(task.ByBuildId(b.Id), task.DisplayNameKey, task.ActivatedKey)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -94,11 +94,15 @@ func ValidateTVPairs(p *Project, in []TVPair) error {
 // do not exist yet out of the set of pairs, and adds tasks for builds which already exist.
 func addNewTasksAndBuildsForPatch(ctx context.Context, syncOpts patch.SyncAtEndOptions, patchVersion *Version, project *Project,
 	pairs TaskVariantPairs, pRef *ProjectRef) error {
-	_, err := addNewBuilds(ctx, specificActivationInfo{}, patchVersion, project, pairs, syncOpts, pRef, "")
+	existingBuilds, err := build.Find(build.ByIds(patchVersion.BuildIds).WithFields(build.IdKey, build.BuildVariantKey, build.CreateTimeKey, build.RequesterKey))
+	if err != nil {
+		return err
+	}
+	_, err = addNewBuilds(ctx, specificActivationInfo{}, patchVersion, project, pairs, existingBuilds, syncOpts, pRef, "")
 	if err != nil {
 		return errors.Wrap(err, "can't add new builds")
 	}
-	_, err = addNewTasks(ctx, specificActivationInfo{}, patchVersion, project, pairs, syncOpts, pRef.Identifier, "")
+	_, err = addNewTasks(ctx, specificActivationInfo{}, patchVersion, project, pairs, existingBuilds, syncOpts, pRef.Identifier, "")
 	return errors.Wrap(err, "can't add new tasks")
 }
 

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -687,14 +687,14 @@ func TestAddNewPatch(t *testing.T) {
 			},
 		},
 	})
-	_, err := addNewBuilds(context.Background(), specificActivationInfo{}, v, proj, tasks, p.SyncAtEndOpts, &ref, "")
+	_, err := addNewBuilds(context.Background(), specificActivationInfo{}, v, proj, tasks, nil, p.SyncAtEndOpts, &ref, "")
 	assert.NoError(err)
 	dbBuild, err := build.FindOne(db.Q{})
 	assert.NoError(err)
 	assert.NotNil(dbBuild)
 	assert.Len(dbBuild.Tasks, 2)
 
-	_, err = addNewTasks(context.Background(), specificActivationInfo{}, v, proj, tasks, p.SyncAtEndOpts, ref.Identifier, "")
+	_, err = addNewTasks(context.Background(), specificActivationInfo{}, v, proj, tasks, []build.Build{*dbBuild}, p.SyncAtEndOpts, ref.Identifier, "")
 	assert.NoError(err)
 	dbTasks, err := task.FindAll(db.Query(task.ByBuildId(dbBuild.Id)))
 	assert.NoError(err)
@@ -766,14 +766,14 @@ func TestAddNewPatchWithMissingBaseVersion(t *testing.T) {
 			},
 		},
 	})
-	_, err := addNewBuilds(context.Background(), specificActivationInfo{}, v, proj, tasks, p.SyncAtEndOpts, &ref, "")
+	_, err := addNewBuilds(context.Background(), specificActivationInfo{}, v, proj, tasks, nil, p.SyncAtEndOpts, &ref, "")
 	assert.NoError(err)
 	dbBuild, err := build.FindOne(db.Q{})
 	assert.NoError(err)
 	assert.NotNil(dbBuild)
 	assert.Len(dbBuild.Tasks, 2)
 
-	_, err = addNewTasks(context.Background(), specificActivationInfo{}, v, proj, tasks, p.SyncAtEndOpts, ref.Identifier, "")
+	_, err = addNewTasks(context.Background(), specificActivationInfo{}, v, proj, tasks, []build.Build{*dbBuild}, p.SyncAtEndOpts, ref.Identifier, "")
 	assert.NoError(err)
 	dbTasks, err := task.FindAll(db.Query(task.ByBuildId(dbBuild.Id)))
 	assert.NoError(err)

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -61,7 +61,7 @@ type ParserProject struct {
 	Include []Include `yaml:"include,omitempty" bson:"include,omitempty"`
 	Enabled *bool     `yaml:"enabled,omitempty" bson:"enabled,omitempty"`
 
-	// Beginning of ParserProject mergeable fields (used by the linter).
+	// Beginning of ParserProject mergeable fields (this comment is used by the linter).
 	Stepback           *bool                      `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
 	PreErrorFailsTask  *bool                      `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
 	PostErrorFailsTask *bool                      `yaml:"post_error_fails_task,omitempty" bson:"post_error_fails_task,omitempty"`
@@ -93,7 +93,7 @@ type ParserProject struct {
 
 	// Matrix code
 	Axes []matrixAxis `yaml:"axes,omitempty" bson:"axes,omitempty"`
-} // End of ParserProject mergeable fields (used by the linter).
+} // End of ParserProject mergeable fields (this comment is used by the linter).
 
 type parserTaskGroup struct {
 	Name                    string             `yaml:"name,omitempty" bson:"name,omitempty"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -53,9 +53,15 @@ const EmptyConfigurationError = "received empty configuration file"
 // to allow for flexible handling.
 type ParserProject struct {
 	// Id and ConfigdUpdateNumber are not pointers because they are only used internally
-	Id                 string                     `yaml:"_id" bson:"_id"` // should be the same as the version's ID
-	ConfigUpdateNumber int                        `yaml:"config_number,omitempty" bson:"config_number,omitempty"`
-	Enabled            *bool                      `yaml:"enabled,omitempty" bson:"enabled,omitempty"`
+	Id                 string `yaml:"_id" bson:"_id"` // should be the same as the version's ID
+	ConfigUpdateNumber int    `yaml:"config_number,omitempty" bson:"config_number,omitempty"`
+	// UpdatedByGenerators is used to determine if the parser project needs to be re-saved or not.
+	UpdatedByGenerators []string `yaml:"updated_by_generators,omitempty" bson:"updated_by_generators,omitempty"`
+	// List of yamls to merge
+	Include []Include `yaml:"include,omitempty" bson:"include,omitempty"`
+	Enabled *bool     `yaml:"enabled,omitempty" bson:"enabled,omitempty"`
+
+	// Beginning of ParserProject mergeable fields (used by the linter).
 	Stepback           *bool                      `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
 	PreErrorFailsTask  *bool                      `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
 	PostErrorFailsTask *bool                      `yaml:"post_error_fails_task,omitempty" bson:"post_error_fails_task,omitempty"`
@@ -84,15 +90,10 @@ type ParserProject struct {
 	ExecTimeoutSecs    *int                       `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
 	Loggers            *LoggerConfig              `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
 	CreateTime         time.Time                  `yaml:"create_time,omitempty" bson:"create_time,omitempty"`
-	// List of yamls to merge
-	Include []Include `yaml:"include,omitempty" bson:"include,omitempty"`
 
-	// UpdatedByGenerators is used to determine if the parser project needs to be re-saved or not.
-	UpdatedByGenerators []string `yaml:"updated_by_generators,omitempty" bson:"updated_by_generators,omitempty"`
 	// Matrix code
 	Axes []matrixAxis `yaml:"axes,omitempty" bson:"axes,omitempty"`
-} // End of ParserProject struct
-// Comment above is used by the linter to detect the end of the struct.
+} // End of ParserProject mergeable fields (used by the linter).
 
 type parserTaskGroup struct {
 	Name                    string             `yaml:"name,omitempty" bson:"name,omitempty"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -87,6 +87,8 @@ type ParserProject struct {
 	// List of yamls to merge
 	Include []Include `yaml:"include,omitempty" bson:"include,omitempty"`
 
+	// UpdatedByGenerators is used to determine if the parser project needs to be re-saved or not.
+	UpdatedByGenerators []string `yaml:"updated_by_generators,omitempty" bson:"updated_by_generators,omitempty"`
 	// Matrix code
 	Axes []matrixAxis `yaml:"axes,omitempty" bson:"axes,omitempty"`
 } // End of ParserProject struct

--- a/scripts/verify-merge-function-update.sh
+++ b/scripts/verify-merge-function-update.sh
@@ -13,8 +13,8 @@ PROJECT_PARSER_FILE_PATH=model/project_parser.go
 # Find the common ancestor between the current set of changes and the upstream branch,
 # then figure out which lines (if any) in the ParserProject struct have been modified since the base revision.
 common_ancestor=$(git merge-base ${BRANCH_NAME}@{upstream} HEAD);
-project_parser_start_line_num=$(git grep -n -e "type ParserProject struct" "${PROJECT_PARSER_FILE_PATH}" | cut -d ':' -f 2);
-project_parser_end_line_num=$(git grep -n -e "End of ParserProject struct" "${PROJECT_PARSER_FILE_PATH}" | cut -d ':' -f 2);
+project_parser_start_line_num=$(git grep -n -e "Beginning of ParserProject mergeable fields" "${PROJECT_PARSER_FILE_PATH}" | cut -d ':' -f 2);
+project_parser_end_line_num=$(git grep -n -e "End of ParserProject mergeable fields" "${PROJECT_PARSER_FILE_PATH}" | cut -d ':' -f 2);
 project_parser_base_revisions=$(git blame -l -L ${project_parser_start_line_num},${project_parser_end_line_num} "${common_ancestor}" -- "${PROJECT_PARSER_FILE_PATH}" | cut -d ' ' -f 1);
 project_parser_updated_revisions=$(git blame -l -L ${project_parser_start_line_num},${project_parser_end_line_num} "${PROJECT_PARSER_FILE_PATH}" | cut -d ' ' -f 1);
 


### PR DESCRIPTION
[EVG-16625](https://jira.mongodb.org/browse/EVG-16625)

### Description 
Intermediate step to using transactions (might only need to use them in a couple of places now). Store whether the parser project has already been updated by this generator and only update it if it hasn't been. The Save function actually already handles very well the cases where tasks/variants already exist; don't need to add any special casing to make this more specific.

Also refactored getting existing builds to make this more performant.

A risk I can see with this is: if generatorA runs, fails halfway (but the parser project is updated), and then generatorB runs, it would theoretically generate un-generated tasks/variants _if_ the variant is modified by both generators. That feels pretty specific though and maybe a worthwhile risk.

### Testing 
Added a unit test.
