### PR TITLE
EVG-16549: double-check dependency satisfaction during allocation and dispatch

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -767,13 +767,13 @@ func schedulableHostTasksQuery() bson.M {
 // FindNeedsContainerAllocation returns all container tasks that are waiting for
 // a container to be allocated to them sorted by activation time.
 func FindNeedsContainerAllocation() ([]Task, error) {
-	q := shouldContainerTaskDispatchQuery()
+	q := isContainerTaskScheduledQuery()
 	q[StatusKey] = evergreen.TaskUndispatched
 	q[ContainerAllocatedKey] = false
 	return FindAll(db.Query(q).Sort([]string{ActivatedTimeKey}))
 }
 
-func shouldContainerTaskDispatchQuery() bson.M {
+func isContainerTaskScheduledQuery() bson.M {
 	return bson.M{
 		ActivatedKey:         true,
 		ExecutionPlatformKey: ExecutionPlatformContainer,

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -497,7 +497,7 @@ func (t *Task) IsFinished() bool {
 // IsHostDispatchable returns true if the task should run on a host and can be
 // dispatched.
 func (t *Task) IsHostDispatchable() bool {
-	return (t.ExecutionPlatform == "" || t.ExecutionPlatform == ExecutionPlatformHost) && len(t.ExecutionTasks) == 0 && t.Status == evergreen.TaskUndispatched && t.Activated
+	return (t.ExecutionPlatform == "" || t.ExecutionPlatform == ExecutionPlatformHost) && !t.DisplayOnly && t.Status == evergreen.TaskUndispatched && t.Activated
 }
 
 // IsContainerDispatchable returns true if the task should run in a container

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2265,6 +2265,7 @@ func TestIsHostDispatchable(t *testing.T) {
 			assert.False(t, tsk.IsHostDispatchable())
 		},
 		"ReturnsFalseForDisplayTask": func(t *testing.T, tsk Task) {
+			tsk.DisplayOnly = true
 			tsk.ExecutionPlatform = ""
 			tsk.ExecutionTasks = []string{"exec-task0", "exec-task1"}
 			assert.False(t, tsk.IsHostDispatchable())
@@ -2329,6 +2330,7 @@ func TestIsContainerDispatchable(t *testing.T) {
 			assert.False(t, tsk.IsContainerDispatchable())
 		},
 		"ReturnsFalseForDisplayTask": func(t *testing.T, tsk Task) {
+			tsk.DisplayOnly = true
 			tsk.ExecutionPlatform = ""
 			tsk.ExecutionTasks = []string{"exec-task0", "exec-task1"}
 			assert.False(t, tsk.IsContainerDispatchable())
@@ -2373,6 +2375,7 @@ func TestShouldAllocateContainer(t *testing.T) {
 			assert.False(t, tsk.ShouldAllocateContainer())
 		},
 		"ReturnsFalseForDisplayTask": func(t *testing.T, tsk Task) {
+			tsk.DisplayOnly = true
 			tsk.ExecutionPlatform = ""
 			tsk.ExecutionTasks = []string{"exec-task0", "exec-task1"}
 			assert.False(t, tsk.ShouldAllocateContainer())

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2243,6 +2243,153 @@ func TestMarkAsContainerDeallocated(t *testing.T) {
 	}
 }
 
+func TestIsHostDispatchable(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T, tsk Task){
+		"ReturnsTrueForExpectedTask": func(t *testing.T, tsk Task) {
+			assert.True(t, tsk.IsHostDispatchable())
+		},
+		"ReturnsTrueForTaskWithDefaultedHostExecutionPlatform": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ""
+			assert.True(t, tsk.IsHostDispatchable())
+		},
+		"ReturnsFalseForContainerTask": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ExecutionPlatformContainer
+			assert.False(t, tsk.IsHostDispatchable())
+		},
+		"ReturnsFalseForTaskWithoutUndispatchedStatus": func(t *testing.T, tsk Task) {
+			tsk.Status = evergreen.TaskDispatched
+			assert.False(t, tsk.IsHostDispatchable())
+		},
+		"ReturnsFalseForInactiveTask": func(t *testing.T, tsk Task) {
+			tsk.Activated = false
+			assert.False(t, tsk.IsHostDispatchable())
+		},
+		"ReturnsFalseForDisplayTask": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ""
+			tsk.ExecutionTasks = []string{"exec-task0", "exec-task1"}
+			assert.False(t, tsk.IsHostDispatchable())
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			hostDispatchableTask := Task{
+				Id:                "task-id",
+				Status:            evergreen.TaskUndispatched,
+				Activated:         true,
+				ExecutionPlatform: ExecutionPlatformHost,
+			}
+			tCase(t, hostDispatchableTask)
+		})
+	}
+}
+
+func TestIsContainerDispatchable(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T, tsk Task){
+		"ReturnsTrueForExpectedTask": func(t *testing.T, tsk Task) {
+			assert.True(t, tsk.IsContainerDispatchable())
+		},
+		"ReturnsFalseForTaskWithDefaultedHostExecutionPlatform": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ""
+			assert.False(t, tsk.IsContainerDispatchable())
+		},
+		"ReturnsFalseForTaskWithoutContainerAllocated": func(t *testing.T, tsk Task) {
+			tsk.ContainerAllocated = false
+			assert.False(t, tsk.IsContainerDispatchable())
+		},
+		"ReturnsFalseForTaskWithUnattainableDependencies": func(t *testing.T, tsk Task) {
+			tsk.DependsOn = []Dependency{
+				{
+					TaskId:       "dependency0",
+					Unattainable: true,
+					Finished:     true,
+				},
+			}
+			assert.False(t, tsk.IsContainerDispatchable())
+		},
+		"ReturnsFalseForTaskWithUnfinishedDependencies": func(t *testing.T, tsk Task) {
+			tsk.DependsOn = []Dependency{
+				{
+					TaskId:       "dependency0",
+					Unattainable: false,
+					Finished:     false,
+				},
+			}
+			assert.False(t, tsk.IsContainerDispatchable())
+			assert.False(t, tsk.IsContainerDispatchable())
+		},
+		"ReturnsFalseForHostTask": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ExecutionPlatformHost
+			assert.False(t, tsk.IsContainerDispatchable())
+		},
+		"ReturnsFalseForTaskWithoutUndispatchedStatus": func(t *testing.T, tsk Task) {
+			tsk.Status = evergreen.TaskDispatched
+			assert.False(t, tsk.IsContainerDispatchable())
+		},
+		"ReturnsFalseForInactiveTask": func(t *testing.T, tsk Task) {
+			tsk.Activated = false
+			assert.False(t, tsk.IsContainerDispatchable())
+		},
+		"ReturnsFalseForDisplayTask": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ""
+			tsk.ExecutionTasks = []string{"exec-task0", "exec-task1"}
+			assert.False(t, tsk.IsContainerDispatchable())
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			containerDispatchableTask := Task{
+				Id:                 "task-id",
+				Status:             evergreen.TaskUndispatched,
+				Activated:          true,
+				ContainerAllocated: true,
+				ExecutionPlatform:  ExecutionPlatformContainer,
+			}
+			tCase(t, containerDispatchableTask)
+		})
+	}
+}
+
+func TestShouldAllocateContainer(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T, tsk Task){
+		"ReturnsTrueForExpectedTask": func(t *testing.T, tsk Task) {
+			assert.True(t, tsk.ShouldAllocateContainer())
+		},
+		"ReturnsFalseForTaskWithDefaultedHostExecutionPlatform": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ""
+			assert.False(t, tsk.ShouldAllocateContainer())
+		},
+		"ReturnsFalseForTaskAlreadyAllocatedContainer": func(t *testing.T, tsk Task) {
+			tsk.ContainerAllocated = true
+			assert.False(t, tsk.ShouldAllocateContainer())
+		},
+		"ReturnsFalseForHostTask": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ExecutionPlatformHost
+			assert.False(t, tsk.ShouldAllocateContainer())
+		},
+		"ReturnsFalseForTaskWithoutUndispatchedStatus": func(t *testing.T, tsk Task) {
+			tsk.Status = evergreen.TaskDispatched
+			assert.False(t, tsk.ShouldAllocateContainer())
+		},
+		"ReturnsFalseForInactiveTask": func(t *testing.T, tsk Task) {
+			tsk.Activated = false
+			assert.False(t, tsk.ShouldAllocateContainer())
+		},
+		"ReturnsFalseForDisplayTask": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ""
+			tsk.ExecutionTasks = []string{"exec-task0", "exec-task1"}
+			assert.False(t, tsk.ShouldAllocateContainer())
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			taskThatNeedsContainerAllocation := Task{
+				Id:                "task-id",
+				Status:            evergreen.TaskUndispatched,
+				Activated:         true,
+				ExecutionPlatform: ExecutionPlatformContainer,
+			}
+			tCase(t, taskThatNeedsContainerAllocation)
+		})
+	}
+}
+
 func TestSetDisabledPriority(t *testing.T) {
 	require.NoError(t, db.ClearCollections(Collection, event.AllLogCollection))
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16549

### Description 
* Check that parent dependencies are met before allocating a container for a task and before dispatching. Since dependency children depend on the latest execution of a task to decide if dependencies are met, the parent dependency could become unsatisfied at any point in the container task pipeline (e.g. the dependency parent is restarted after a container was already allocated for the dependency child, so the dependency child no longer has fully met dependencies).
* Rename a few container task related functions.
* Fix a host termination job test that wasn't resetting the global mock cloud provider state.

### Testing 
Added unit tests.
