### PR TITLE
EVG-16509, EVG-16718: avoid setting global environment in tests

### DIFF
--- a/config_role_test.go
+++ b/config_role_test.go
@@ -9,9 +9,13 @@ import (
 )
 
 func TestLDAPRoleMapAddAndRemove(t *testing.T) {
+	originalEnv := GetEnvironment()
 	env, err := NewEnvironment(context.Background(), filepath.Join("testdata", "smoke_config.yml"), nil)
 	require.NoError(t, err)
 	SetEnvironment(env)
+	defer func() {
+		SetEnvironment(originalEnv)
+	}()
 	ctx, cancel := env.Context()
 	defer cancel()
 	coll := env.DB().Collection(ConfigCollection)

--- a/config_test.go
+++ b/config_test.go
@@ -105,9 +105,13 @@ func TestAdminSuite(t *testing.T) {
 	if configFile == "" {
 		configFile = testConfigFile()
 	}
+	originalEnv := GetEnvironment()
 	env, err := NewEnvironment(ctx, configFile, nil)
 	require.NoError(t, err)
 	SetEnvironment(env)
+	defer func() {
+		SetEnvironment(originalEnv)
+	}()
 
 	s := new(AdminSuite)
 	s.env = env
@@ -116,7 +120,6 @@ func TestAdminSuite(t *testing.T) {
 
 func (s *AdminSuite) SetupTest() {
 	s.NoError(resetRegistry())
-
 }
 
 func (s *AdminSuite) TestBanner() {

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -199,6 +199,24 @@ func DropAllIndexes(collections ...string) error {
 	return nil
 }
 
+// DropDatabases drops all of the given databases, returning an error immediately
+// if dropping any of the databases fails.
+func DropDatabases(dbs ...string) error {
+	session, _, err := GetGlobalSessionFactory().GetSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	for _, db := range dbs {
+		if err := session.DB(db).DropDatabase(); err != nil {
+			return errors.Wrapf(err, "dropping database '%s'", db)
+		}
+	}
+
+	return nil
+}
+
 // Remove removes one item matching the query from the specified collection.
 func Remove(collection string, query interface{}) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()

--- a/environment_test.go
+++ b/environment_test.go
@@ -64,9 +64,13 @@ func (s *EnvironmentSuite) TestLoadingConfig() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	originalEnv := GetEnvironment()
 	// first test loading config from a file
 	env, err := NewEnvironment(ctx, s.path, nil)
 	SetEnvironment(env)
+	defer func() {
+		SetEnvironment(originalEnv)
+	}()
 
 	s.Require().NoError(err)
 	s.env = env.(*envState)

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -34,8 +34,12 @@ func TestCommitQueueSuite(t *testing.T) {
 	s := new(CommitQueueSuite)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	originalEnv := evergreen.GetEnvironment()
 	env := testutil.NewEnvironment(ctx, t)
 	evergreen.SetEnvironment(env)
+	defer func() {
+		evergreen.SetEnvironment(originalEnv)
+	}()
 	suite.Run(t, s)
 }
 

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -566,7 +566,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 func TestAddPermissions(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(user.Collection, Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
 	env := evergreen.GetEnvironment()
-	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 	u := user.DBUser{
 		Id: "me",
 	}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -5111,7 +5111,7 @@ func TestFindHostsSuite(t *testing.T) {
 
 	s.setup = func(s *FindHostsSuite) {
 		s.NoError(db.ClearCollections(user.Collection, Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
-		require.NoError(t, db.ClearCollections(evergreen.ScopeCollection))
+		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 		hosts := s.hosts()
 		for _, h := range hosts {

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -5111,10 +5111,7 @@ func TestFindHostsSuite(t *testing.T) {
 
 	s.setup = func(s *FindHostsSuite) {
 		s.NoError(db.ClearCollections(user.Collection, Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
-		cmd := map[string]string{
-			"create": evergreen.ScopeCollection,
-		}
-		_ = evergreen.GetEnvironment().DB().RunCommand(nil, cmd)
+		require.NoError(t, db.ClearCollections(evergreen.ScopeCollection))
 
 		hosts := s.hosts()
 		for _, h := range hosts {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -503,7 +503,7 @@ func TestDetachFromRepo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection,
 				evergreen.RoleCollection, user.Collection, event.SubscriptionsCollection, ProjectAliasCollection))
-			db.CreateCollections(evergreen.ScopeCollection)
+			require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 			pRef := &ProjectRef{
 				Id:        "myProject",

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -282,14 +282,16 @@ func TestGetActivationTimeWithCron(t *testing.T) {
 func TestChangeOwnerRepo(t *testing.T) {
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection,
 		evergreen.RoleCollection, user.Collection, evergreen.ConfigCollection))
-	env := evergreen.GetEnvironment()
-	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	// kim: TODO: remove
+	// env := evergreen.GetEnvironment()
+	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
+	// _ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 	settings := testutil.TestConfig()
 	settings.GithubOrgs = []string{"evergreen-ci"}
 	settings.GithubOrgs = []string{"newOwner"}
 	assert.NoError(t, evergreen.UpdateConfig(settings))
 
-	evergreen.SetEnvironment(env)
+	// evergreen.SetEnvironment(env)
 	pRef := ProjectRef{
 		Id:        "myProject",
 		Owner:     "evergreen-ci",
@@ -327,8 +329,10 @@ func TestChangeOwnerRepo(t *testing.T) {
 func TestAttachToRepo(t *testing.T) {
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection,
 		evergreen.RoleCollection, user.Collection))
-	env := evergreen.GetEnvironment()
-	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
+	// kim: TODO: remove
+	// env := evergreen.GetEnvironment()
+	// _ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 
 	pRef := ProjectRef{
 		Id:     "myProject",
@@ -506,8 +510,10 @@ func TestDetachFromRepo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection,
 				evergreen.RoleCollection, user.Collection, event.SubscriptionsCollection, ProjectAliasCollection))
-			env := evergreen.GetEnvironment()
-			_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+			// kim: TODO: remove
+			// env := evergreen.GetEnvironment()
+			// _ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+			db.CreateCollections(evergreen.ScopeCollection)
 
 			pRef := &ProjectRef{
 				Id:        "myProject",
@@ -863,7 +869,9 @@ func TestFindProjectRefsByRepoAndBranch(t *testing.T) {
 func TestCreateNewRepoRef(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, user.Collection,
 		evergreen.ScopeCollection, ProjectVarsCollection, ProjectAliasCollection))
-	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	// kim: TODO: remove
+	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 	doc1 := &ProjectRef{
 		Id:                    "id1",
 		Owner:                 "mongodb",

--- a/model/repo_ref_test.go
+++ b/model/repo_ref_test.go
@@ -15,7 +15,7 @@ import (
 func TestRepoRefUpdateAdminRoles(t *testing.T) {
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection, user.Collection))
 	env := evergreen.GetEnvironment()
-	require.NoError(t, db.CreateCollection(evergreen.ScopeCollection))
+	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 	rm := env.RoleManager()
 	r := RepoRef{ProjectRef{
 		Id: "proj",

--- a/model/repo_ref_test.go
+++ b/model/repo_ref_test.go
@@ -15,7 +15,7 @@ import (
 func TestRepoRefUpdateAdminRoles(t *testing.T) {
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection, user.Collection))
 	env := evergreen.GetEnvironment()
-	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	require.NoError(t, db.CreateCollection(evergreen.ScopeCollection))
 	rm := env.RoleManager()
 	r := RepoRef{ProjectRef{
 		Id: "proj",

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -34,7 +34,7 @@ func (s *UserTestSuite) SetupSuite() {
 
 func (s *UserTestSuite) SetupTest() {
 	s.NoError(db.ClearCollections(Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
-	require.NoError(t, db.ClearCollections(evergreen.ScopeCollection))
+	s.Require().NoError(db.ClearCollections(evergreen.ScopeCollection))
 	s.users = []*DBUser{
 		&DBUser{
 			Id:     "Test1",

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -34,7 +34,7 @@ func (s *UserTestSuite) SetupSuite() {
 
 func (s *UserTestSuite) SetupTest() {
 	s.NoError(db.ClearCollections(Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
-	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	require.NoError(t, db.ClearCollections(evergreen.ScopeCollection))
 	s.users = []*DBUser{
 		&DBUser{
 			Id:     "Test1",

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -34,7 +34,7 @@ func (s *UserTestSuite) SetupSuite() {
 
 func (s *UserTestSuite) SetupTest() {
 	s.NoError(db.ClearCollections(Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
-	s.Require().NoError(db.ClearCollections(evergreen.ScopeCollection))
+	s.Require().NoError(db.CreateCollections(evergreen.ScopeCollection))
 	s.users = []*DBUser{
 		&DBUser{
 			Id:     "Test1",

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -38,8 +38,12 @@ type CommitQueueSuite struct {
 func TestCommitQueueSuite(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	originalEnv := evergreen.GetEnvironment()
 	env := testutil.NewEnvironment(ctx, t)
 	evergreen.SetEnvironment(env)
+	defer func() {
+		evergreen.SetEnvironment(originalEnv)
+	}()
 	testutil.ConfigureIntegrationTest(t, testConfig, "TestCommitQueueSuite")
 	require.NoError(t, testConfig.Set())
 	suite.Run(t, new(CommitQueueSuite))

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -28,10 +28,11 @@ type AdminDataSuite struct {
 
 func TestDataConnectorSuite(t *testing.T) {
 	s := new(AdminDataSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -28,11 +28,6 @@ type AdminDataSuite struct {
 
 func TestDataConnectorSuite(t *testing.T) {
 	s := new(AdminDataSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -17,11 +17,6 @@ type AliasSuite struct {
 }
 
 func TestAliasSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(AliasSuite))
 }
 

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"context"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -9,7 +8,6 @@ import (
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/suite"
 )
@@ -19,10 +17,11 @@ type AliasSuite struct {
 }
 
 func TestAliasSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(AliasSuite))
 }
 
@@ -107,8 +106,8 @@ func (a *AliasSuite) SetupTest() {
 
 func (a *AliasSuite) TestFindProjectAliasesMergedWithProjectConfig() {
 	found, err := FindProjectAliases("project_id", "", nil, true)
-	a.NoError(err)
-	a.Len(found, 5)
+	a.Require().NoError(err)
+	a.Require().Len(found, 5)
 	a.Equal(utility.FromStringPtr(found[0].Alias), evergreen.CommitQueueAlias)
 	a.Equal(utility.FromStringPtr(found[1].Alias), evergreen.GithubChecksAlias)
 	a.Equal(utility.FromStringPtr(found[2].Alias), "foo")

--- a/rest/data/build_baron_test.go
+++ b/rest/data/build_baron_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"context"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -10,15 +9,15 @@ import (
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMakeTicket(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 
 	assert.NoError(t, db.ClearCollections(task.Collection, model.VersionCollection, build.Collection, model.ProjectRefCollection))
 	t1 := task.Task{

--- a/rest/data/build_baron_test.go
+++ b/rest/data/build_baron_test.go
@@ -13,12 +13,6 @@ import (
 )
 
 func TestMakeTicket(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
-
 	assert.NoError(t, db.ClearCollections(task.Collection, model.VersionCollection, build.Collection, model.ProjectRefCollection))
 	t1 := task.Task{
 		Id:      "t1",

--- a/rest/data/cli_update_test.go
+++ b/rest/data/cli_update_test.go
@@ -15,11 +15,6 @@ type cliUpdateConnectorSuite struct {
 }
 
 func TestUpdateConnector(t *testing.T) {
-	// kim: TODO: test
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	s := &cliUpdateConnectorSuite{}
 	s.setup = func() {
 		s.NoError(db.ClearCollections(evergreen.ConfigCollection))

--- a/rest/data/cli_update_test.go
+++ b/rest/data/cli_update_test.go
@@ -1,12 +1,10 @@
 package data
 
 import (
-	"context"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -17,10 +15,11 @@ type cliUpdateConnectorSuite struct {
 }
 
 func TestUpdateConnector(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: test
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	s := &cliUpdateConnectorSuite{}
 	s.setup = func() {
 		s.NoError(db.ClearCollections(evergreen.ConfigCollection))

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -32,11 +32,6 @@ type CommitQueueSuite struct {
 }
 
 func TestCommitQueueSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	testutil.ConfigureIntegrationTest(t, testConfig, "TestCommitQueueSuite")
 	s := &CommitQueueSuite{settings: testConfig}
 	suite.Run(t, s)
@@ -309,11 +304,6 @@ func (s *CommitQueueSuite) TestWritePatchInfo() {
 }
 
 func TestConcludeMerge(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.Clear(commitqueue.Collection))
 	projectID := "evergreen"
 	itemID := bson.NewObjectId()

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -32,10 +32,11 @@ type CommitQueueSuite struct {
 }
 
 func TestCommitQueueSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	testutil.ConfigureIntegrationTest(t, testConfig, "TestCommitQueueSuite")
 	s := &CommitQueueSuite{settings: testConfig}
 	suite.Run(t, s)
@@ -308,10 +309,11 @@ func (s *CommitQueueSuite) TestWritePatchInfo() {
 }
 
 func TestConcludeMerge(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.Clear(commitqueue.Collection))
 	projectID := "evergreen"
 	itemID := bson.NewObjectId()

--- a/rest/data/distro_test.go
+++ b/rest/data/distro_test.go
@@ -1,23 +1,21 @@
 package data
 
 import (
-	"context"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDeleteDistroById(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	session, _, err := db.GetGlobalSessionFactory().GetSession()
 	require.NoError(t, err)
 	defer session.Close()

--- a/rest/data/distro_test.go
+++ b/rest/data/distro_test.go
@@ -11,11 +11,6 @@ import (
 )
 
 func TestDeleteDistroById(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	session, _, err := db.GetGlobalSessionFactory().GetSession()
 	require.NoError(t, err)
 	defer session.Close()

--- a/rest/data/generate_test.go
+++ b/rest/data/generate_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -18,14 +17,17 @@ import (
 func TestGeneratePoll(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// require.NoError(t, env.Configure(ctx))
 	require.NoError(t, db.ClearCollections(task.Collection))
 	require.NotNil(t, env)
 	q := env.RemoteQueueGroup()
 	require.NotNil(t, q)
 
-	finished, generateErrs, err := GeneratePoll(context.Background(), "task-0", q)
+	finished, generateErrs, err := GeneratePoll(ctx, "task-0", q)
 	assert.False(t, finished)
 	assert.Empty(t, generateErrs)
 	assert.Error(t, err)
@@ -37,7 +39,7 @@ func TestGeneratePoll(t *testing.T) {
 		GeneratedTasks: false,
 	}).Insert())
 
-	finished, generateErrs, err = GeneratePoll(context.Background(), "task-1", q)
+	finished, generateErrs, err = GeneratePoll(ctx, "task-1", q)
 	assert.False(t, finished)
 	assert.Empty(t, generateErrs)
 	assert.NoError(t, err)
@@ -49,7 +51,7 @@ func TestGeneratePoll(t *testing.T) {
 		GeneratedTasks: true,
 	}).Insert())
 
-	finished, generateErrs, err = GeneratePoll(context.Background(), "task-2", q)
+	finished, generateErrs, err = GeneratePoll(ctx, "task-2", q)
 	assert.True(t, finished)
 	assert.Empty(t, generateErrs)
 	assert.NoError(t, err)

--- a/rest/data/generate_test.go
+++ b/rest/data/generate_test.go
@@ -17,11 +17,7 @@ import (
 func TestGeneratePoll(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	env := testutil.NewEnvironment(ctx, t)
-	// require.NoError(t, env.Configure(ctx))
 	require.NoError(t, db.ClearCollections(task.Collection))
 	require.NotNil(t, env)
 	q := env.RemoteQueueGroup()

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -85,7 +85,7 @@ func NewIntentHost(ctx context.Context, options *restmodel.HostRequestOptions, u
 
 // GenerateHostProvisioningScript generates and returns the script to
 // provision the host given by host ID.
-func GenerateHostProvisioningScript(ctx context.Context, hostID string) (string, error) {
+func GenerateHostProvisioningScript(ctx context.Context, env evergreen.Environment, hostID string) (string, error) {
 	if hostID == "" {
 		return "", gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -106,7 +106,6 @@ func GenerateHostProvisioningScript(ctx context.Context, hostID string) (string,
 		}
 	}
 
-	env := evergreen.GetEnvironment()
 	creds, err := h.GenerateJasperCredentials(ctx, env)
 	if err != nil {
 		return "", gimlet.ErrorResponse{

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -15,17 +15,17 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestListHostsForTask(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require := require.New(t)
 	require.NoError(db.ClearCollections(host.Collection, build.Collection, task.Collection))
 	hosts := []*host.Host{
@@ -98,10 +98,11 @@ func TestListHostsForTask(t *testing.T) {
 
 func TestCreateHostsFromTask(t *testing.T) {
 	// Setup tests
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection))
 	settingsList := []*birch.Document{birch.NewDocument(
 		birch.EC.String("region", "us-east-1"),
@@ -324,10 +325,11 @@ buildvariants:
 
 func TestCreateContainerFromTask(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection,
 		model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection))

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -21,11 +21,6 @@ import (
 
 func TestListHostsForTask(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require := require.New(t)
 	require.NoError(db.ClearCollections(host.Collection, build.Collection, task.Collection))
 	hosts := []*host.Host{
@@ -97,12 +92,6 @@ func TestListHostsForTask(t *testing.T) {
 }
 
 func TestCreateHostsFromTask(t *testing.T) {
-	// Setup tests
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection))
 	settingsList := []*birch.Document{birch.NewDocument(
 		birch.EC.String("region", "us-east-1"),
@@ -325,11 +314,6 @@ buildvariants:
 
 func TestCreateContainerFromTask(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection,
 		model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection))

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -101,18 +102,21 @@ func (*HostConnectorSuite) users() []user.DBUser {
 }
 
 func TestHostConnectorSuite(t *testing.T) {
+	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// evergreen.SetEnvironment(env)
 	s := new(HostConnectorSuite)
 
 	s.setup = func(s *HostConnectorSuite) {
 		s.NoError(db.ClearCollections(user.Collection, host.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
-		cmd := map[string]string{
-			"create": evergreen.ScopeCollection,
-		}
-		_ = evergreen.GetEnvironment().DB().RunCommand(nil, cmd)
+		// kim: TODO: remove
+		// cmd := map[string]string{
+		//     "create": evergreen.ScopeCollection,
+		// }
+		// _ = evergreen.GetEnvironment().DB().RunCommand(nil, cmd)
+		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 		hosts := s.hosts()
 		for _, h := range hosts {
@@ -132,7 +136,7 @@ func TestHostConnectorSuite(t *testing.T) {
 			SystemRoles: []string{"root"},
 		}
 		s.NoError(root.Insert())
-		rm := evergreen.GetEnvironment().RoleManager()
+		rm := env.RoleManager()
 		s.NoError(rm.AddScope(gimlet.Scope{
 			ID:        "root",
 			Resources: []string{"distro2", "distro5"},

--- a/rest/data/patch_test.go
+++ b/rest/data/patch_test.go
@@ -31,11 +31,6 @@ type PatchConnectorFetchByProjectSuite struct {
 
 func TestPatchConnectorFetchByProjectSuite(t *testing.T) {
 	s := new(PatchConnectorFetchByProjectSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -188,11 +183,6 @@ type PatchConnectorFetchByIdSuite struct {
 
 func TestPatchConnectorFetchByIdSuite(t *testing.T) {
 	s := new(PatchConnectorFetchByIdSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -258,11 +248,6 @@ type PatchConnectorAbortByIdSuite struct {
 
 func TestPatchConnectorAbortByIdSuite(t *testing.T) {
 	s := new(PatchConnectorAbortByIdSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -375,11 +360,6 @@ type PatchConnectorChangeStatusSuite struct {
 
 func TestPatchConnectorChangeStatusSuite(t *testing.T) {
 	s := new(PatchConnectorChangeStatusSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -443,11 +423,6 @@ type PatchConnectorFetchByUserSuite struct {
 
 func TestPatchConnectorFetchByUserSuite(t *testing.T) {
 	s := new(PatchConnectorFetchByUserSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 

--- a/rest/data/patch_test.go
+++ b/rest/data/patch_test.go
@@ -31,10 +31,11 @@ type PatchConnectorFetchByProjectSuite struct {
 
 func TestPatchConnectorFetchByProjectSuite(t *testing.T) {
 	s := new(PatchConnectorFetchByProjectSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -187,10 +188,11 @@ type PatchConnectorFetchByIdSuite struct {
 
 func TestPatchConnectorFetchByIdSuite(t *testing.T) {
 	s := new(PatchConnectorFetchByIdSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -256,10 +258,11 @@ type PatchConnectorAbortByIdSuite struct {
 
 func TestPatchConnectorAbortByIdSuite(t *testing.T) {
 	s := new(PatchConnectorAbortByIdSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -372,10 +375,11 @@ type PatchConnectorChangeStatusSuite struct {
 
 func TestPatchConnectorChangeStatusSuite(t *testing.T) {
 	s := new(PatchConnectorChangeStatusSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -439,10 +443,11 @@ type PatchConnectorFetchByUserSuite struct {
 
 func TestPatchConnectorFetchByUserSuite(t *testing.T) {
 	s := new(PatchConnectorFetchByUserSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 

--- a/rest/data/pod_test.go
+++ b/rest/data/pod_test.go
@@ -13,11 +13,6 @@ import (
 )
 
 func TestPodConnector(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	for tName, tCase := range map[string]func(t *testing.T){
 		"CreatePodSucceeds": func(t *testing.T) {
 			p := model.APICreatePod{

--- a/rest/data/pod_test.go
+++ b/rest/data/pod_test.go
@@ -1,25 +1,23 @@
 package data
 
 import (
-	"context"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPodConnector(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	for tName, tCase := range map[string]func(t *testing.T){
 		"CreatePodSucceeds": func(t *testing.T) {
 			p := model.APICreatePod{

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -18,11 +18,13 @@ import (
 )
 
 func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
-	rm := evergreen.GetEnvironment().RoleManager()
+	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	rm := env.RoleManager()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 
 	for name, test := range map[string]func(t *testing.T, ref model.RepoRef){
 		model.ProjectPageGeneralSection: func(t *testing.T, ref model.RepoRef) {
@@ -152,7 +154,9 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 	} {
 		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
 			event.SubscriptionsCollection, event.AllLogCollection, evergreen.ScopeCollection, user.Collection))
-		_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+		// kim: TODO: remove
+		// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 		repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
 			Id:         "myRepoId",
@@ -234,11 +238,12 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 }
 
 func TestSaveProjectSettingsForSection(t *testing.T) {
+	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
-	rm := evergreen.GetEnvironment().RoleManager()
+	// evergreen.SetEnvironment(env)
+	rm := env.RoleManager()
 
 	for name, test := range map[string]func(t *testing.T, ref model.ProjectRef){
 		model.ProjectPageGeneralSection: func(t *testing.T, ref model.ProjectRef) {
@@ -469,7 +474,9 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 	} {
 		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
 			event.SubscriptionsCollection, event.AllLogCollection, evergreen.ScopeCollection, user.Collection))
-		_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+		// kim: TODO: remove
+		// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 		pRef := model.ProjectRef{
 			Id:         "myId",

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -18,13 +18,10 @@ import (
 )
 
 func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
-	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
 	rm := env.RoleManager()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 
 	for name, test := range map[string]func(t *testing.T, ref model.RepoRef){
 		model.ProjectPageGeneralSection: func(t *testing.T, ref model.RepoRef) {
@@ -154,8 +151,6 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 	} {
 		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
 			event.SubscriptionsCollection, event.AllLogCollection, evergreen.ScopeCollection, user.Collection))
-		// kim: TODO: remove
-		// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 		repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
@@ -238,11 +233,9 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 }
 
 func TestSaveProjectSettingsForSection(t *testing.T) {
-	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	rm := env.RoleManager()
 
 	for name, test := range map[string]func(t *testing.T, ref model.ProjectRef){
@@ -474,8 +467,6 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 	} {
 		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
 			event.SubscriptionsCollection, event.AllLogCollection, evergreen.ScopeCollection, user.Collection))
-		// kim: TODO: remove
-		// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 		pRef := model.ProjectRef{

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -1,17 +1,14 @@
 package data
 
 import (
-	"context"
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -74,10 +71,11 @@ func getMockProjectSettings() model.ProjectSettings {
 
 func TestProjectConnectorGetSuite(t *testing.T) {
 	s := new(ProjectConnectorGetSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	s.setup = func() error {
 		s.Require().NoError(db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection))
 
@@ -250,10 +248,11 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 }
 
 func TestUpdateProjectVarsByValue(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(model.ProjectVarsCollection, event.AllLogCollection))
 
 	vars := &model.ProjectVars{
@@ -308,10 +307,11 @@ func (s *ProjectConnectorGetSuite) TestCopyProjectVars() {
 }
 
 func TestGetProjectAliasResults(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(model.ProjectAliasCollection))
 	p := model.Project{
 		Identifier: "helloworld",

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -71,11 +71,6 @@ func getMockProjectSettings() model.ProjectSettings {
 
 func TestProjectConnectorGetSuite(t *testing.T) {
 	s := new(ProjectConnectorGetSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	s.setup = func() error {
 		s.Require().NoError(db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection))
 
@@ -248,11 +243,6 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 }
 
 func TestUpdateProjectVarsByValue(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(model.ProjectVarsCollection, event.AllLogCollection))
 
 	vars := &model.ProjectVars{
@@ -307,11 +297,6 @@ func (s *ProjectConnectorGetSuite) TestCopyProjectVars() {
 }
 
 func TestGetProjectAliasResults(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(model.ProjectAliasCollection))
 	p := model.Project{
 		Identifier: "helloworld",

--- a/rest/data/reliability_test.go
+++ b/rest/data/reliability_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -12,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/reliability"
 	"github.com/evergreen-ci/evergreen/model/stats"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,10 +20,11 @@ const dayInHours = 24 * time.Hour
 
 func TestMockGetTaskReliability(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(model.ProjectRefCollection, stats.DailyTaskStatsCollection))
 
 	proj := model.ProjectRef{
@@ -99,10 +98,11 @@ func TestMockGetTaskReliability(t *testing.T) {
 }
 
 func TestGetTaskReliability(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	defer func() {
 		assert.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
 	}()

--- a/rest/data/reliability_test.go
+++ b/rest/data/reliability_test.go
@@ -20,11 +20,6 @@ const dayInHours = 24 * time.Hour
 
 func TestMockGetTaskReliability(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(model.ProjectRefCollection, stats.DailyTaskStatsCollection))
 
 	proj := model.ProjectRef{
@@ -98,11 +93,6 @@ func TestMockGetTaskReliability(t *testing.T) {
 }
 
 func TestGetTaskReliability(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	defer func() {
 		assert.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
 	}()

--- a/rest/data/scheduler_test.go
+++ b/rest/data/scheduler_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"context"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -9,15 +8,15 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCompareTasks(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(distro.Collection, task.Collection, model.VersionCollection))
 	distroId := "d"
 	t1 := task.Task{

--- a/rest/data/scheduler_test.go
+++ b/rest/data/scheduler_test.go
@@ -12,11 +12,6 @@ import (
 )
 
 func TestCompareTasks(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(distro.Collection, task.Collection, model.VersionCollection))
 	distroId := "d"
 	t1 := task.Task{

--- a/rest/data/stats_test.go
+++ b/rest/data/stats_test.go
@@ -18,11 +18,6 @@ import (
 
 func TestMockGetTestStats(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(stats.DailyTestStatsCollection, model.ProjectRefCollection))
 	filter := &stats.StatsFilter{}
 	proj := model.ProjectRef{
@@ -42,11 +37,6 @@ func TestMockGetTestStats(t *testing.T) {
 
 func TestMockGetTaskStats(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(db.Clear(stats.DailyTaskStatsCollection))
 	filter := &stats.StatsFilter{}
 	// Add stats
@@ -131,11 +121,6 @@ func insertTaskStats(filter *stats.StatsFilter, numTests int, limit int) error {
 }
 
 func TestGetTaskStats(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	defer func() {
 		assert.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
 	}()
@@ -172,11 +157,6 @@ func TestGetTaskStats(t *testing.T) {
 }
 
 func TestGetTestStats(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	defer func() {
 		assert.NoError(t, db.ClearCollections(stats.DailyTestStatsCollection, model.ProjectRefCollection))
 	}()

--- a/rest/data/stats_test.go
+++ b/rest/data/stats_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -12,7 +11,6 @@ import (
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/stats"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,10 +18,11 @@ import (
 
 func TestMockGetTestStats(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(stats.DailyTestStatsCollection, model.ProjectRefCollection))
 	filter := &stats.StatsFilter{}
 	proj := model.ProjectRef{
@@ -43,10 +42,11 @@ func TestMockGetTestStats(t *testing.T) {
 
 func TestMockGetTaskStats(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(db.Clear(stats.DailyTaskStatsCollection))
 	filter := &stats.StatsFilter{}
 	// Add stats
@@ -131,10 +131,11 @@ func insertTaskStats(filter *stats.StatsFilter, numTests int, limit int) error {
 }
 
 func TestGetTaskStats(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	defer func() {
 		assert.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
 	}()
@@ -171,10 +172,11 @@ func TestGetTaskStats(t *testing.T) {
 }
 
 func TestGetTestStats(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	defer func() {
 		assert.NoError(t, db.ClearCollections(stats.DailyTestStatsCollection, model.ProjectRefCollection))
 	}()

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -14,11 +14,6 @@ import (
 
 func TestGetSubscriptions(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(event.SubscriptionsCollection))
 
 	subs := []event.Subscription{
@@ -80,11 +75,6 @@ func TestGetSubscriptions(t *testing.T) {
 }
 
 func TestSaveProjectSubscriptions(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	for name, test := range map[string]func(t *testing.T, subs []restModel.APISubscription){
 		"InvalidSubscription": func(t *testing.T, subs []restModel.APISubscription) {
 			subs[0].Selectors[0].Data = utility.ToStringPtr("")
@@ -188,11 +178,6 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 }
 
 func TestDeleteProjectSubscriptions(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	for name, test := range map[string]func(t *testing.T, ids []string){
 		"InvalidOwner": func(t *testing.T, ids []string) {
 			assert.Error(t, DeleteSubscriptions("my-project", ids))

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -1,15 +1,12 @@
 package data
 
 import (
-	"context"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/event"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,10 +14,11 @@ import (
 
 func TestGetSubscriptions(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(event.SubscriptionsCollection))
 
 	subs := []event.Subscription{
@@ -82,10 +80,11 @@ func TestGetSubscriptions(t *testing.T) {
 }
 
 func TestSaveProjectSubscriptions(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	for name, test := range map[string]func(t *testing.T, subs []restModel.APISubscription){
 		"InvalidSubscription": func(t *testing.T, subs []restModel.APISubscription) {
 			subs[0].Selectors[0].Data = utility.ToStringPtr("")
@@ -189,10 +188,11 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 }
 
 func TestDeleteProjectSubscriptions(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	for name, test := range map[string]func(t *testing.T, ids []string){
 		"InvalidOwner": func(t *testing.T, ids []string) {
 			assert.Error(t, DeleteSubscriptions("my-project", ids))

--- a/rest/data/task_test.go
+++ b/rest/data/task_test.go
@@ -36,11 +36,6 @@ type TaskConnectorFetchByBuildSuite struct {
 
 func TestTaskConnectorFetchByBuildSuite(t *testing.T) {
 	s := new(TaskConnectorFetchByBuildSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.Clear(task.Collection))
 
 	s.taskIds = make([][]string, 2)
@@ -185,11 +180,6 @@ type TaskConnectorFetchByProjectAndCommitSuite struct {
 
 func TestTaskConnectorFetchByProjectAndCommitSuite(t *testing.T) {
 	s := new(TaskConnectorFetchByProjectAndCommitSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection))
 
 	s.numCommits = 2
@@ -346,11 +336,6 @@ func (s *TaskConnectorFetchByProjectAndCommitSuite) TestFindEmptyProjectAndCommi
 
 func TestCheckTaskSecret(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(task.Collection))
 
 	task := task.Task{

--- a/rest/data/task_test.go
+++ b/rest/data/task_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -37,10 +36,11 @@ type TaskConnectorFetchByBuildSuite struct {
 
 func TestTaskConnectorFetchByBuildSuite(t *testing.T) {
 	s := new(TaskConnectorFetchByBuildSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.Clear(task.Collection))
 
 	s.taskIds = make([][]string, 2)
@@ -185,10 +185,11 @@ type TaskConnectorFetchByProjectAndCommitSuite struct {
 
 func TestTaskConnectorFetchByProjectAndCommitSuite(t *testing.T) {
 	s := new(TaskConnectorFetchByProjectAndCommitSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection))
 
 	s.numCommits = 2
@@ -345,10 +346,11 @@ func (s *TaskConnectorFetchByProjectAndCommitSuite) TestFindEmptyProjectAndCommi
 
 func TestCheckTaskSecret(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(task.Collection))
 
 	task := task.Task{

--- a/rest/data/test_test.go
+++ b/rest/data/test_test.go
@@ -1,18 +1,15 @@
 package data
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"sort"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,10 +17,11 @@ import (
 )
 
 func TestFindTestById(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	tests := []testresult.TestResult{
 		testresult.TestResult{
 			ID:        mgobson.ObjectIdHex("507f191e810c19729de860ea"),
@@ -61,10 +59,11 @@ func TestFindTestById(t *testing.T) {
 
 func TestFindTestsByTaskId(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(task.Collection, testresult.Collection))
 	assert.NoError(db.EnsureIndex(testresult.Collection, mongo.IndexModel{
 		Keys: testresult.TestResultsIndex}))
@@ -215,10 +214,11 @@ func TestFindTestsByTaskId(t *testing.T) {
 
 func TestFindTestsByTaskIdPaginationOrderDependsOnObjectId(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(task.Collection, testresult.Collection))
 
 	serviceContext := &DBTestConnector{}
@@ -272,10 +272,10 @@ func TestFindTestsByTaskIdPaginationOrderDependsOnObjectId(t *testing.T) {
 
 func TestFindTestsByDisplayTaskId(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(task.Collection, testresult.Collection))
 
 	serviceContext := &DBTestConnector{}

--- a/rest/data/test_test.go
+++ b/rest/data/test_test.go
@@ -17,11 +17,6 @@ import (
 )
 
 func TestFindTestById(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	tests := []testresult.TestResult{
 		testresult.TestResult{
 			ID:        mgobson.ObjectIdHex("507f191e810c19729de860ea"),
@@ -59,11 +54,6 @@ func TestFindTestById(t *testing.T) {
 
 func TestFindTestsByTaskId(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(task.Collection, testresult.Collection))
 	assert.NoError(db.EnsureIndex(testresult.Collection, mongo.IndexModel{
 		Keys: testresult.TestResultsIndex}))
@@ -214,11 +204,6 @@ func TestFindTestsByTaskId(t *testing.T) {
 
 func TestFindTestsByTaskIdPaginationOrderDependsOnObjectId(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(task.Collection, testresult.Collection))
 
 	serviceContext := &DBTestConnector{}
@@ -272,10 +257,6 @@ func TestFindTestsByTaskIdPaginationOrderDependsOnObjectId(t *testing.T) {
 
 func TestFindTestsByDisplayTaskId(t *testing.T) {
 	assert := assert.New(t)
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(task.Collection, testresult.Collection))
 
 	serviceContext := &DBTestConnector{}

--- a/rest/data/user_test.go
+++ b/rest/data/user_test.go
@@ -122,10 +122,5 @@ func (s *DBUserConnectorSuite) TestUpdateSettingsCommitQueue() {
 
 func TestDBUserConnector(t *testing.T) {
 	s := &DBUserConnectorSuite{}
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }

--- a/rest/data/user_test.go
+++ b/rest/data/user_test.go
@@ -1,15 +1,12 @@
 package data
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -125,9 +122,10 @@ func (s *DBUserConnectorSuite) TestUpdateSettingsCommitQueue() {
 
 func TestDBUserConnector(t *testing.T) {
 	s := &DBUserConnectorSuite{}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -260,9 +260,7 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 
 func TestCreateVersionFromConfig(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	assert.NoError(db.ClearCollections(model.ProjectRefCollection, model.ParserProjectCollection, model.VersionCollection, distro.Collection, task.Collection, build.Collection, user.Collection))
+	require.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ParserProjectCollection, model.VersionCollection, distro.Collection, task.Collection, build.Collection, user.Collection))
 	require.NoError(t, db.CreateCollections(model.ParserProjectCollection))
 
 	ref := model.ProjectRef{
@@ -294,7 +292,8 @@ func TestCreateVersionFromConfig(t *testing.T) {
 		}`
 
 	p := &model.Project{}
-	ctx = context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	pp, err := model.LoadProjectInto(ctx, []byte(config1), nil, ref.Id, p)
 	assert.NoError(err)
 	projectInfo := &model.ProjectInfo{

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,11 +28,6 @@ type VersionConnectorSuite struct {
 
 func TestDBVersionConnectorSuite(t *testing.T) {
 	s := new(VersionConnectorSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -268,11 +262,7 @@ func TestCreateVersionFromConfig(t *testing.T) {
 	assert := assert.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(model.ProjectRefCollection, model.ParserProjectCollection, model.VersionCollection, distro.Collection, task.Collection, build.Collection, user.Collection))
-	// kim: TODO: remove
-	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": model.ParserProjectCollection})
 	require.NoError(t, db.CreateCollections(model.ParserProjectCollection))
 
 	ref := model.ProjectRef{

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -28,10 +29,11 @@ type VersionConnectorSuite struct {
 
 func TestDBVersionConnectorSuite(t *testing.T) {
 	s := new(VersionConnectorSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -269,7 +271,9 @@ func TestCreateVersionFromConfig(t *testing.T) {
 	env := testutil.NewEnvironment(ctx, t)
 	evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(model.ProjectRefCollection, model.ParserProjectCollection, model.VersionCollection, distro.Collection, task.Collection, build.Collection, user.Collection))
-	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": model.ParserProjectCollection})
+	// kim: TODO: remove
+	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": model.ParserProjectCollection})
+	require.NoError(t, db.CreateCollections(model.ParserProjectCollection))
 
 	ref := model.ProjectRef{
 		Id: "mci",

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -33,12 +33,16 @@ import (
 type AdminRouteSuite struct {
 	getHandler  gimlet.RouteHandler
 	postHandler gimlet.RouteHandler
+	env         evergreen.Environment
 
 	suite.Suite
 }
 
 func TestAdminRouteSuiteWithDB(t *testing.T) {
 	s := new(AdminRouteSuite)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.env = testutil.NewEnvironment(ctx, t)
 	// run the rest of the tests
 	suite.Run(t, s)
 }
@@ -287,7 +291,9 @@ func (s *AdminRouteSuite) TestRevertRoute() {
 func (s *AdminRouteSuite) TestRestartTasksRoute() {
 	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "userName"})
 
-	queue := evergreen.GetEnvironment().LocalQueue()
+	// kim: TODO: remove
+	// queue := evergreen.GetEnvironment().LocalQueue()
+	queue := s.env.LocalQueue()
 	handler := makeRestartRoute(evergreen.RestartTasks, queue)
 
 	s.NotNil(handler)

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -291,8 +291,6 @@ func (s *AdminRouteSuite) TestRevertRoute() {
 func (s *AdminRouteSuite) TestRestartTasksRoute() {
 	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "userName"})
 
-	// kim: TODO: remove
-	// queue := evergreen.GetEnvironment().LocalQueue()
 	queue := s.env.LocalQueue()
 	handler := makeRestartRoute(evergreen.RestartTasks, queue)
 

--- a/rest/route/commit_queue_test.go
+++ b/rest/route/commit_queue_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
-	"github.com/evergreen-ci/evergreen/mock"
 	dbModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
@@ -92,10 +92,10 @@ func (s *CommitQueueSuite) TestGetCommitQueue() {
 }
 
 func (s *CommitQueueSuite) TestDeleteItem() {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := testutil.NewEnvironment(ctx, s.T())
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user1"})
-	env := &mock.Environment{}
-	s.Require().NoError(env.Configure(ctx))
 
 	route := makeDeleteCommitQueueItems(env).(*commitQueueDeleteItemHandler)
 	pos, err := data.EnqueueItem("mci", model.APICommitQueueItem{Source: utility.ToStringPtr(commitqueue.SourceDiff), Issue: utility.ToStringPtr("1")}, false)

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -1545,8 +1544,7 @@ func (s *distroExecuteSuite) SetupTest() {
 	s.NoError(db.ClearCollections(host.Collection))
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
-	env := &mock.Environment{}
-	s.env = env
+	s.env = testutil.NewEnvironment(ctx, s.T())
 	hostToAdd := host.Host{
 		Id: "host1",
 		Distro: distro.Distro{
@@ -1555,7 +1553,6 @@ func (s *distroExecuteSuite) SetupTest() {
 		},
 	}
 	s.Require().NoError(hostToAdd.Insert())
-	s.Require().NoError(env.Configure(ctx))
 	h := makeDistroExecute(s.env)
 	rh, ok := h.(*distroExecuteHandler)
 	s.Require().True(ok)
@@ -1654,9 +1651,7 @@ func (s *distroClientURLsGetSuite) SetupTest() {
 	s.NoError(err)
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
-	env := &mock.Environment{}
-	s.env = env
-	s.Require().NoError(env.Configure(ctx))
+	s.env = testutil.NewEnvironment(ctx, s.T())
 	h := makeGetDistroClientURLs(s.env)
 	rh, ok := h.(*distroClientURLsGetHandler)
 	s.Require().True(ok)

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -53,6 +53,7 @@ func (s *GithubWebhookRouteSuite) SetupSuite() {
 	s.NotNil(s.env.Settings())
 	s.NotNil(s.env.Settings().Api)
 	s.NotEmpty(s.env.Settings().Api.GithubWebhookSecret)
+	s.Require().NoError(db.DropDatabases(s.env.Settings().Amboy.DB))
 
 	s.conf = testutil.TestConfig()
 	s.NotNil(s.conf)
@@ -104,6 +105,7 @@ func (s *GithubWebhookRouteSuite) SetupTest() {
 
 func TestGithubWebhookRouteSuite(t *testing.T) {
 	s := new(GithubWebhookRouteSuite)
+
 	suite.Run(t, s)
 }
 
@@ -127,6 +129,7 @@ func (s *GithubWebhookRouteSuite) TestIsItemOnCommitQueue() {
 
 func (s *GithubWebhookRouteSuite) TestAddIntentAndFailsWithDuplicate() {
 	s.NoError(db.ClearCollections(model.ProjectRefCollection, patch.IntentCollection))
+
 	doc := &model.ProjectRef{
 		Owner:            "baxterthehacker",
 		Repo:             "public-repo",

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -546,10 +546,13 @@ func (h *hostFilterGetHandler) Run(ctx context.Context) gimlet.Responder {
 
 type hostProvisioningOptionsGetHandler struct {
 	hostID string
+	env    evergreen.Environment
 }
 
-func makeHostProvisioningOptionsGetHandler() gimlet.RouteHandler {
-	return &hostProvisioningOptionsGetHandler{}
+func makeHostProvisioningOptionsGetHandler(env evergreen.Environment) gimlet.RouteHandler {
+	return &hostProvisioningOptionsGetHandler{
+		env: env,
+	}
 }
 
 func (rh *hostProvisioningOptionsGetHandler) Factory() gimlet.RouteHandler {
@@ -566,7 +569,7 @@ func (rh *hostProvisioningOptionsGetHandler) Parse(ctx context.Context, r *http.
 }
 
 func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Responder {
-	script, err := data.GenerateHostProvisioningScript(ctx, rh.hostID)
+	script, err := data.GenerateHostProvisioningScript(ctx, rh.env, rh.hostID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -121,10 +121,12 @@ func TestHostStopHandler(t *testing.T) {
 	require.NoError(t, db.ClearCollections(host.Collection, event.SubscriptionsCollection))
 	testutil.DisablePermissionsForTests()
 	defer testutil.EnablePermissionsForTests()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	h := &hostStopHandler{
-		env: evergreen.GetEnvironment(),
+		env: testutil.NewEnvironment(ctx, t),
 	}
-	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user"})
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})
 
 	hosts := []host.Host{
 		host.Host{
@@ -169,10 +171,12 @@ func TestHostStartHandler(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(host.Collection, host.VolumesCollection))
 	testutil.DisablePermissionsForTests()
 	defer testutil.EnablePermissionsForTests()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	h := &hostStartHandler{
-		env: evergreen.GetEnvironment(),
+		env: testutil.NewEnvironment(ctx, t),
 	}
-	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user"})
+	ctx = gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user"})
 
 	hosts := []host.Host{
 		host.Host{
@@ -208,11 +212,13 @@ func TestHostStartHandler(t *testing.T) {
 
 func TestCreateVolumeHandler(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(host.VolumesCollection))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	h := &createVolumeHandler{
-		env:      evergreen.GetEnvironment(),
+		env:      testutil.NewEnvironment(ctx, t),
 		provider: evergreen.ProviderNameMock,
 	}
-	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user"})
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})
 	v := host.Volume{ID: "volume1", Size: 15, CreatedBy: "user"}
 	assert.NoError(t, v.Insert())
 	v = host.Volume{ID: "volume2", Size: 35, CreatedBy: "user"}
@@ -239,11 +245,13 @@ func TestCreateVolumeHandler(t *testing.T) {
 
 func TestDeleteVolumeHandler(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(host.VolumesCollection, host.Collection))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	h := &deleteVolumeHandler{
-		env:      evergreen.GetEnvironment(),
+		env:      testutil.NewEnvironment(ctx, t),
 		provider: evergreen.ProviderNameMock,
 	}
-	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user"})
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})
 
 	volumes := []host.Volume{
 		host.Volume{
@@ -280,10 +288,12 @@ func TestDeleteVolumeHandler(t *testing.T) {
 
 func TestAttachVolumeHandler(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(host.VolumesCollection, host.Collection))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	h := &attachVolumeHandler{
-		env: evergreen.GetEnvironment(),
+		env: testutil.NewEnvironment(ctx, t),
 	}
-	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user"})
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})
 	hosts := []host.Host{
 		host.Host{
 			Id:        "my-host",
@@ -339,10 +349,12 @@ func TestAttachVolumeHandler(t *testing.T) {
 
 func TestDetachVolumeHandler(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(host.VolumesCollection, host.Collection))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	h := &detachVolumeHandler{
-		env: evergreen.GetEnvironment(),
+		env: testutil.NewEnvironment(ctx, t),
 	}
-	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user"})
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})
 	hosts := []host.Host{
 		host.Host{
 			Id:        "my-host",
@@ -376,8 +388,10 @@ func TestDetachVolumeHandler(t *testing.T) {
 }
 
 func TestModifyVolumeHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	h := &modifyVolumeHandler{
-		env:  evergreen.GetEnvironment(),
+		env:  testutil.NewEnvironment(ctx, t),
 		opts: &model.VolumeModifyOptions{},
 	}
 	h.env.Settings().Providers.AWS.MaxVolumeSizePerUser = 200
@@ -406,7 +420,7 @@ func TestModifyVolumeHandler(t *testing.T) {
 	h.provider = evergreen.ProviderNameMock
 	h.opts = &model.VolumeModifyOptions{}
 	// another user
-	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "different-user"})
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "different-user"})
 	resp := h.Run(ctx)
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusUnauthorized, resp.Status())
@@ -449,9 +463,11 @@ func TestModifyVolumeHandler(t *testing.T) {
 }
 
 func TestGetVolumesHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	assert.NoError(t, db.ClearCollections(host.VolumesCollection, host.Collection))
 	h := &getVolumesHandler{}
-	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user"})
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})
 
 	h1 := host.Host{
 		Id:        "has-a-volume",
@@ -511,9 +527,11 @@ func TestGetVolumesHandler(t *testing.T) {
 }
 
 func TestGetVolumeByIDHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	assert.NoError(t, db.ClearCollections(host.VolumesCollection, host.Collection))
 	h := &getVolumeByIDHandler{}
-	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user"})
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})
 
 	h1 := host.Host{
 		Id:        "has-a-volume",

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -176,7 +176,7 @@ func TestHostStartHandler(t *testing.T) {
 	h := &hostStartHandler{
 		env: testutil.NewEnvironment(ctx, t),
 	}
-	ctx = gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user"})
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})
 
 	hosts := []host.Host{
 		host.Host{

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -1076,6 +1076,7 @@ func TestDisableHostHandler(t *testing.T) {
 func TestHostProvisioningOptionsGetHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	env := testutil.NewEnvironment(ctx, t)
 	require.NoError(t, db.Clear(host.Collection))
 	defer func() {
 		assert.NoError(t, db.Clear(host.Collection))
@@ -1092,6 +1093,7 @@ func TestHostProvisioningOptionsGetHandler(t *testing.T) {
 	t.Run("SucceedsWithValidHostID", func(t *testing.T) {
 		rh := hostProvisioningOptionsGetHandler{
 			hostID: h.Id,
+			env:    env,
 		}
 		resp := rh.Run(ctx)
 		require.Equal(t, http.StatusOK, resp.Status())
@@ -1100,13 +1102,16 @@ func TestHostProvisioningOptionsGetHandler(t *testing.T) {
 		assert.NotEmpty(t, opts.Content)
 	})
 	t.Run("FailsWithoutHostID", func(t *testing.T) {
-		rh := hostProvisioningOptionsGetHandler{}
+		rh := hostProvisioningOptionsGetHandler{
+			env: env,
+		}
 		resp := rh.Run(ctx)
 		assert.NotEqual(t, http.StatusOK, resp.Status())
 	})
 	t.Run("FailsWithInvalidHostID", func(t *testing.T) {
 		rh := hostProvisioningOptionsGetHandler{
 			hostID: "foo",
+			env:    env,
 		}
 		resp := rh.Run(ctx)
 		assert.NotEqual(t, http.StatusOK, resp.Status())

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -848,11 +848,6 @@ func setupMockHostsConnector(t *testing.T, env evergreen.Environment) {
 	for _, userToAdd := range users {
 		grip.Error(userToAdd.Insert())
 	}
-	// kim: TODO: remove
-	// cmd := map[string]string{
-	//     "create": evergreen.ScopeCollection,
-	// }
-	// grip.Error(env.DB().RunCommand(nil, cmd).Err())
 	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 	rm := env.RoleManager()
 	require.NoError(t, rm.AddScope(gimlet.Scope{
@@ -968,8 +963,6 @@ func TestRemoveAdminHandler(t *testing.T) {
 	assert.NoError(t, projectRef1.Insert())
 
 	offboardedUser := "user0"
-	// kim: TODO: remove
-	// env := evergreen.GetEnvironment()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -108,10 +108,14 @@ func TestPrefetchProject(t *testing.T) {
 func TestNewProjectAdminMiddleware(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(evergreen.RoleCollection, evergreen.ScopeCollection))
-	env := evergreen.GetEnvironment()
-	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := testutil.NewEnvironment(ctx, t)
+	// kim: TODO: remove
+	// env := evergreen.GetEnvironment()
+	// _ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
-	ctx := context.Background()
 	opCtx := model.Context{}
 	opCtx.ProjectRef = &model.ProjectRef{
 		Private: utility.TruePtr(),
@@ -322,10 +326,11 @@ func TestCommitQueueItemOwnerMiddlewareUserPatch(t *testing.T) {
 
 func TestTaskAuthMiddleware(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 
 	assert.NoError(db.ClearCollections(host.Collection, task.Collection))
 	task1 := task.Task{
@@ -358,10 +363,11 @@ func TestTaskAuthMiddleware(t *testing.T) {
 }
 
 func TestHostAuthMiddleware(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	m := NewHostAuthMiddleware()
 	for testName, testCase := range map[string]func(t *testing.T, h *host.Host, rw *httptest.ResponseRecorder){
 		"Succeeds": func(t *testing.T, h *host.Host, rw *httptest.ResponseRecorder) {
@@ -422,10 +428,11 @@ func TestHostAuthMiddleware(t *testing.T) {
 }
 
 func TestPodAuthMiddleware(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	m := NewPodAuthMiddleware()
 	for testName, testCase := range map[string]func(t *testing.T, p *pod.Pod, rw *httptest.ResponseRecorder){
 		"Succeeds": func(t *testing.T, p *pod.Pod, rw *httptest.ResponseRecorder) {
@@ -514,8 +521,10 @@ func TestProjectViewPermission(t *testing.T) {
 	assert := assert.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
 	require := require.New(t)
 	counter := 0
 	counterFunc := func(rw http.ResponseWriter, r *http.Request) {
@@ -523,7 +532,9 @@ func TestProjectViewPermission(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	}
 	assert.NoError(db.ClearCollections(evergreen.RoleCollection, evergreen.ScopeCollection, model.ProjectRefCollection))
-	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	// kim: TODO: remove
+	// _ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	require.NoError(db.CreateCollections(evergreen.ScopeCollection))
 	role1 := gimlet.Role{
 		ID:          "r1",
 		Scope:       "proj1",
@@ -618,7 +629,10 @@ func TestEventLogPermission(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// require.NoError(t, env.Configure(ctx))
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require := require.New(t)
 	counter := 0
 	counterFunc := func(rw http.ResponseWriter, r *http.Request) {
@@ -626,7 +640,9 @@ func TestEventLogPermission(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	}
 	assert.NoError(db.ClearCollections(evergreen.RoleCollection, evergreen.ScopeCollection, model.ProjectRefCollection, distro.Collection))
-	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	// kim: TODO: remove
+	// _ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
+	require.NoError(db.CreateCollections(evergreen.ScopeCollection))
 	projRole := gimlet.Role{
 		ID:          "proj",
 		Scope:       "proj1",

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -111,9 +111,6 @@ func TestNewProjectAdminMiddleware(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	// kim: TODO: remove
-	// env := evergreen.GetEnvironment()
-	// _ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 	opCtx := model.Context{}
@@ -326,11 +323,6 @@ func TestCommitQueueItemOwnerMiddlewareUserPatch(t *testing.T) {
 
 func TestTaskAuthMiddleware(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 
 	assert.NoError(db.ClearCollections(host.Collection, task.Collection))
 	task1 := task.Task{
@@ -363,11 +355,6 @@ func TestTaskAuthMiddleware(t *testing.T) {
 }
 
 func TestHostAuthMiddleware(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	m := NewHostAuthMiddleware()
 	for testName, testCase := range map[string]func(t *testing.T, h *host.Host, rw *httptest.ResponseRecorder){
 		"Succeeds": func(t *testing.T, h *host.Host, rw *httptest.ResponseRecorder) {
@@ -428,11 +415,6 @@ func TestHostAuthMiddleware(t *testing.T) {
 }
 
 func TestPodAuthMiddleware(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	m := NewPodAuthMiddleware()
 	for testName, testCase := range map[string]func(t *testing.T, p *pod.Pod, rw *httptest.ResponseRecorder){
 		"Succeeds": func(t *testing.T, p *pod.Pod, rw *httptest.ResponseRecorder) {
@@ -517,13 +499,9 @@ func TestPodAuthMiddleware(t *testing.T) {
 }
 
 func TestProjectViewPermission(t *testing.T) {
-	//setup
 	assert := assert.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	env := testutil.NewEnvironment(ctx, t)
 	require := require.New(t)
 	counter := 0
@@ -532,8 +510,6 @@ func TestProjectViewPermission(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	}
 	assert.NoError(db.ClearCollections(evergreen.RoleCollection, evergreen.ScopeCollection, model.ProjectRefCollection))
-	// kim: TODO: remove
-	// _ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 	require.NoError(db.CreateCollections(evergreen.ScopeCollection))
 	role1 := gimlet.Role{
 		ID:          "r1",
@@ -629,10 +605,6 @@ func TestEventLogPermission(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	// require.NoError(t, env.Configure(ctx))
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require := require.New(t)
 	counter := 0
 	counterFunc := func(rw http.ResponseWriter, r *http.Request) {
@@ -640,8 +612,6 @@ func TestEventLogPermission(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	}
 	assert.NoError(db.ClearCollections(evergreen.RoleCollection, evergreen.ScopeCollection, model.ProjectRefCollection, distro.Collection))
-	// kim: TODO: remove
-	// _ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 	require.NoError(db.CreateCollections(evergreen.ScopeCollection))
 	projRole := gimlet.Role{
 		ID:          "proj",

--- a/rest/route/notification_test.go
+++ b/rest/route/notification_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/suite"
@@ -17,18 +18,22 @@ import (
 // Tests for POST /rest/v2/notifications/jira_comment
 
 type JiraCommentNotificationSuite struct {
-	rm          gimlet.RouteHandler
-	environment evergreen.Environment
+	rm  gimlet.RouteHandler
+	env evergreen.Environment
 
 	suite.Suite
 }
 
 func TestJiraCommentNotificationSuite(t *testing.T) {
-	suite.Run(t, new(JiraCommentNotificationSuite))
+	s := new(JiraCommentNotificationSuite)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.env = testutil.NewEnvironment(ctx, t)
+	suite.Run(t, s)
 }
 
 func (s *JiraCommentNotificationSuite) SetupSuite() {
-	s.rm = makeJiraCommentNotification(evergreen.GetEnvironment())
+	s.rm = makeJiraCommentNotification(s.env)
 }
 
 func (s *JiraCommentNotificationSuite) TestParseValidJSON() {
@@ -51,18 +56,22 @@ func (s *JiraCommentNotificationSuite) TestParseValidJSON() {
 // Tests for POST /rest/v2/notifications/jira_issue
 
 type JiraIssueNotificationSuite struct {
-	rm          gimlet.RouteHandler
-	environment evergreen.Environment
+	rm  gimlet.RouteHandler
+	env evergreen.Environment
 
 	suite.Suite
 }
 
 func TestJiraIssueNotificationSuite(t *testing.T) {
-	suite.Run(t, new(JiraIssueNotificationSuite))
+	s := new(JiraIssueNotificationSuite)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.env = testutil.NewEnvironment(ctx, t)
+	suite.Run(t, s)
 }
 
 func (s *JiraIssueNotificationSuite) SetupSuite() {
-	s.rm = makeJiraIssueNotification(evergreen.GetEnvironment())
+	s.rm = makeJiraIssueNotification(s.env)
 }
 
 func (s *JiraIssueNotificationSuite) TestParseValidJSON() {
@@ -105,19 +114,22 @@ func (s *JiraIssueNotificationSuite) TestParseValidJSON() {
 // Tests for POST /rest/v2/notifications/slack
 
 type SlackNotificationSuite struct {
-	rm          gimlet.RouteHandler
-	environment evergreen.Environment
+	rm  gimlet.RouteHandler
+	env evergreen.Environment
 
 	suite.Suite
 }
 
 func TestSlackNotificationSuite(t *testing.T) {
-
-	suite.Run(t, new(SlackNotificationSuite))
+	s := new(SlackNotificationSuite)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.env = testutil.NewEnvironment(ctx, t)
+	suite.Run(t, s)
 }
 
 func (s *SlackNotificationSuite) SetupSuite() {
-	s.rm = makeSlackNotification(evergreen.GetEnvironment())
+	s.rm = makeSlackNotification(s.env)
 }
 
 func (s *SlackNotificationSuite) TestParseValidJSON() {
@@ -200,19 +212,22 @@ func (s *SlackNotificationSuite) TestParseValidJSON() {
 // Tests for POST /rest/v2/notifications/email
 
 type EmailNotificationSuite struct {
-	rm          gimlet.RouteHandler
-	environment evergreen.Environment
+	rm  gimlet.RouteHandler
+	env evergreen.Environment
 
 	suite.Suite
 }
 
 func TestEmailNotificationSuite(t *testing.T) {
-
-	suite.Run(t, new(EmailNotificationSuite))
+	s := new(EmailNotificationSuite)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.env = testutil.NewEnvironment(ctx, t)
+	suite.Run(t, s)
 }
 
 func (s *EmailNotificationSuite) SetupSuite() {
-	s.rm = makeEmailNotification(evergreen.GetEnvironment())
+	s.rm = makeEmailNotification(s.env)
 }
 
 func (s *EmailNotificationSuite) TestParseValidJSON() {

--- a/rest/route/notifications_test.go
+++ b/rest/route/notifications_test.go
@@ -20,11 +20,6 @@ type notificationSuite struct {
 }
 
 func TestNotificationSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, &notificationSuite{})
 }
 

--- a/rest/route/notifications_test.go
+++ b/rest/route/notifications_test.go
@@ -6,13 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -22,10 +20,11 @@ type notificationSuite struct {
 }
 
 func TestNotificationSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, &notificationSuite{})
 }
 

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -38,10 +38,11 @@ type PatchByIdSuite struct {
 }
 
 func TestPatchByIdSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(PatchByIdSuite))
 }
 
@@ -94,10 +95,11 @@ type PatchesByProjectSuite struct {
 }
 
 func TestPatchesByProjectSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(PatchesByProjectSuite))
 }
 
@@ -239,10 +241,11 @@ type PatchAbortSuite struct {
 }
 
 func TestPatchAbortSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(PatchAbortSuite))
 }
 
@@ -352,10 +355,11 @@ type PatchesChangeStatusSuite struct {
 }
 
 func TestPatchesChangeStatusSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(PatchesChangeStatusSuite))
 }
 
@@ -421,10 +425,11 @@ type PatchRestartSuite struct {
 }
 
 func TestPatchRestartSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(PatchRestartSuite))
 }
 
@@ -490,10 +495,11 @@ type PatchesByUserSuite struct {
 
 func TestPatchesByUserSuite(t *testing.T) {
 	s := new(PatchesByUserSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -597,10 +603,11 @@ func (s *PatchesByUserSuite) TestEmptyTimeShouldSetNow() {
 }
 
 func TestPatchRawHandler(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(patch.Collection))
 	require.NoError(t, db.ClearGridCollections(patch.GridFSPrefix))
 	patchString := `main diff`
@@ -645,11 +652,11 @@ func TestPatchRawHandler(t *testing.T) {
 }
 
 func TestSchedulePatchRoute(t *testing.T) {
-	// setup, lots of setup
+	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	const config = `
 functions:
   "fetch source" :
@@ -773,10 +780,11 @@ buildvariants:
   - name: failing_test
   - name: timeout_test`
 	require.NoError(t, db.ClearCollections(serviceModel.ProjectRefCollection, patch.Collection, evergreen.ConfigCollection, task.Collection, serviceModel.VersionCollection, build.Collection))
-	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": build.Collection})
-	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": task.Collection})
-	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": serviceModel.VersionCollection})
-	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": serviceModel.ParserProjectCollection})
+	require.NoError(t, db.CreateCollections(build.Collection, task.Collection, serviceModel.VersionCollection, serviceModel.ParserProjectCollection))
+	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": build.Collection})
+	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": task.Collection})
+	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": serviceModel.VersionCollection})
+	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": serviceModel.ParserProjectCollection})
 	settings := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, settings, "TestSchedulePatchRoute")
 	require.NoError(t, settings.Set())

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -38,11 +38,6 @@ type PatchByIdSuite struct {
 }
 
 func TestPatchByIdSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(PatchByIdSuite))
 }
 
@@ -95,11 +90,6 @@ type PatchesByProjectSuite struct {
 }
 
 func TestPatchesByProjectSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(PatchesByProjectSuite))
 }
 
@@ -241,11 +231,6 @@ type PatchAbortSuite struct {
 }
 
 func TestPatchAbortSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(PatchAbortSuite))
 }
 
@@ -355,11 +340,6 @@ type PatchesChangeStatusSuite struct {
 }
 
 func TestPatchesChangeStatusSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(PatchesChangeStatusSuite))
 }
 
@@ -425,11 +405,6 @@ type PatchRestartSuite struct {
 }
 
 func TestPatchRestartSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(PatchRestartSuite))
 }
 
@@ -495,11 +470,6 @@ type PatchesByUserSuite struct {
 
 func TestPatchesByUserSuite(t *testing.T) {
 	s := new(PatchesByUserSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -603,11 +573,6 @@ func (s *PatchesByUserSuite) TestEmptyTimeShouldSetNow() {
 }
 
 func TestPatchRawHandler(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(patch.Collection))
 	require.NoError(t, db.ClearGridCollections(patch.GridFSPrefix))
 	patchString := `main diff`
@@ -652,11 +617,8 @@ func TestPatchRawHandler(t *testing.T) {
 }
 
 func TestSchedulePatchRoute(t *testing.T) {
-	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	const config = `
 functions:
   "fetch source" :
@@ -781,10 +743,6 @@ buildvariants:
   - name: timeout_test`
 	require.NoError(t, db.ClearCollections(serviceModel.ProjectRefCollection, patch.Collection, evergreen.ConfigCollection, task.Collection, serviceModel.VersionCollection, build.Collection))
 	require.NoError(t, db.CreateCollections(build.Collection, task.Collection, serviceModel.VersionCollection, serviceModel.ParserProjectCollection))
-	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": build.Collection})
-	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": task.Collection})
-	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": serviceModel.VersionCollection})
-	// _ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": serviceModel.ParserProjectCollection})
 	settings := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, settings, "TestSchedulePatchRoute")
 	require.NoError(t, settings.Set())

--- a/rest/route/pod_agent_test.go
+++ b/rest/route/pod_agent_test.go
@@ -164,8 +164,8 @@ func TestPodAgentCedarConfig(t *testing.T) {
 }
 
 func TestPodAgentNextTask(t *testing.T) {
-	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env *mock.Environment){
-		"ParseSetsPodID": func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env *mock.Environment) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env evergreen.Environment){
+		"ParseSetsPodID": func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env evergreen.Environment) {
 			r, err := http.NewRequest(http.MethodGet, "/url", nil)
 			require.NoError(t, err)
 			podID := "some_pod_id"
@@ -173,13 +173,13 @@ func TestPodAgentNextTask(t *testing.T) {
 			require.NoError(t, rh.Parse(ctx, r))
 			assert.Equal(t, podID, rh.podID)
 		},
-		"ParseFailsWithoutPodID": func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env *mock.Environment) {
+		"ParseFailsWithoutPodID": func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env evergreen.Environment) {
 			r, err := http.NewRequest(http.MethodGet, "/url", nil)
 			require.NoError(t, err)
 			assert.Error(t, rh.Parse(ctx, r))
 			assert.Zero(t, rh.podID)
 		},
-		"RunEnqueuesTerminationJob": func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env *mock.Environment) {
+		"RunEnqueuesTerminationJob": func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env evergreen.Environment) {
 			rh.podID = "some_pod_id"
 			resp := rh.Run(ctx)
 			assert.Equal(t, http.StatusOK, resp.Status())

--- a/rest/route/pod_test.go
+++ b/rest/route/pod_test.go
@@ -16,11 +16,6 @@ import (
 )
 
 func TestPostPod(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, ph *podPostHandler){
 		"FactorySucceeds": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
 			copied := ph.Factory()
@@ -98,11 +93,6 @@ func TestPostPod(t *testing.T) {
 }
 
 func TestGetPod(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(pod.Collection))
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, ph *podGetHandler){
 		"RunSucceeds": func(ctx context.Context, t *testing.T, ph *podGetHandler) {
@@ -133,7 +123,6 @@ func TestGetPod(t *testing.T) {
 			require.NotZero(t, resp)
 			assert.Equal(t, http.StatusNotFound, resp.Status())
 		},
-		// "": func(ctx context.Context, t *testing.T, ph *podGetHandler) {},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())

--- a/rest/route/pod_test.go
+++ b/rest/route/pod_test.go
@@ -6,9 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -18,10 +16,11 @@ import (
 )
 
 func TestPostPod(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, ph *podPostHandler){
 		"FactorySucceeds": func(ctx context.Context, t *testing.T, ph *podPostHandler) {
 			copied := ph.Factory()
@@ -90,10 +89,7 @@ func TestPostPod(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			env := &mock.Environment{}
-			require.NoError(t, env.Configure(ctx))
-
-			p := makePostPod(env)
+			p := makePostPod(testutil.NewEnvironment(ctx, t))
 			require.NotZero(t, p)
 
 			tCase(ctx, t, p.(*podPostHandler))
@@ -102,10 +98,11 @@ func TestPostPod(t *testing.T) {
 }
 
 func TestGetPod(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(pod.Collection))
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, ph *podGetHandler){
 		"RunSucceeds": func(ctx context.Context, t *testing.T, ph *podGetHandler) {
@@ -142,10 +139,7 @@ func TestGetPod(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			env := &mock.Environment{}
-			require.NoError(t, env.Configure(ctx))
-
-			p := makeGetPod(env)
+			p := makeGetPod(testutil.NewEnvironment(ctx, t))
 			require.NotZero(t, p)
 
 			tCase(ctx, t, p.(*podGetHandler))

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -24,11 +24,6 @@ type ProjectCopySuite struct {
 }
 
 func TestProjectCopySuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectCopySuite))
 }
 
@@ -126,11 +121,6 @@ type copyVariablesSuite struct {
 }
 
 func TestCopyVariablesSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(copyVariablesSuite))
 }
 

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -7,13 +7,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	restmodel "github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/suite"
@@ -26,10 +24,11 @@ type ProjectCopySuite struct {
 }
 
 func TestProjectCopySuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectCopySuite))
 }
 
@@ -127,10 +126,11 @@ type copyVariablesSuite struct {
 }
 
 func TestCopyVariablesSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(copyVariablesSuite))
 }
 

--- a/rest/route/project_events_test.go
+++ b/rest/route/project_events_test.go
@@ -22,11 +22,6 @@ type ProjectEventsTestSuite struct {
 }
 
 func TestProjectEventsTestSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectEventsTestSuite))
 }
 

--- a/rest/route/project_events_test.go
+++ b/rest/route/project_events_test.go
@@ -6,12 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/suite"
 )
@@ -24,10 +22,11 @@ type ProjectEventsTestSuite struct {
 }
 
 func TestProjectEventsTestSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectEventsTestSuite))
 }
 

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -28,7 +28,8 @@ import (
 // Tests for PATCH /rest/v2/projects/{project_id}
 
 type ProjectPatchByIDSuite struct {
-	rm gimlet.RouteHandler
+	rm  gimlet.RouteHandler
+	env evergreen.Environment
 
 	suite.Suite
 }
@@ -36,9 +37,12 @@ type ProjectPatchByIDSuite struct {
 func TestProjectPatchSuite(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
-	suite.Run(t, new(ProjectPatchByIDSuite))
+	s := &ProjectPatchByIDSuite{
+		env: testutil.NewEnvironment(ctx, t),
+	}
+	// kim: TODO: remove
+	// evergreen.SetEnvironment(env)
+	suite.Run(t, s)
 }
 
 func (s *ProjectPatchByIDSuite) SetupTest() {
@@ -72,7 +76,9 @@ func (s *ProjectPatchByIDSuite) SetupTest() {
 			evergreen.PermissionLogs:            evergreen.LogsView.Value,
 		},
 	}
-	roleManager := evergreen.GetEnvironment().RoleManager()
+	// kim: TODO: remove
+	// roleManager := evergreen.GetEnvironment().RoleManager()
+	roleManager := s.env.RoleManager()
 	err = roleManager.UpdateRole(projectAdminRole)
 	s.NoError(err)
 	adminScope := gimlet.Scope{
@@ -333,10 +339,11 @@ type ProjectPutSuite struct {
 }
 
 func TestProjectPutSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectPutSuite))
 }
 
@@ -446,10 +453,11 @@ type ProjectGetByIDSuite struct {
 }
 
 func TestProjectGetByIDSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectGetByIDSuite))
 }
 
@@ -518,10 +526,11 @@ type ProjectGetSuite struct {
 }
 
 func TestProjectGetSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectGetSuite))
 }
 
@@ -687,10 +696,11 @@ func getTestProjectRef() *serviceModel.ProjectRef {
 
 func TestGetProjectVersions(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(serviceModel.VersionCollection, serviceModel.ProjectRefCollection))
 	const projectId = "proj"
 	project := serviceModel.ProjectRef{
@@ -743,10 +753,11 @@ func TestGetProjectVersions(t *testing.T) {
 }
 
 func TestDeleteProject(t *testing.T) {
+	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(
 		serviceModel.ProjectRefCollection,
 		serviceModel.RepoRefCollection,
@@ -873,8 +884,9 @@ func TestDeleteProject(t *testing.T) {
 func TestAttachProjectToRepo(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(serviceModel.ProjectRefCollection,
 		serviceModel.RepoRefCollection, serviceModel.ProjectVarsCollection, user.Collection,
 		evergreen.ScopeCollection, evergreen.RoleCollection))
@@ -940,8 +952,9 @@ func TestAttachProjectToRepo(t *testing.T) {
 func TestDetachProjectFromRepo(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(serviceModel.ProjectRefCollection,
 		serviceModel.RepoRefCollection, serviceModel.ProjectVarsCollection, user.Collection,
 		evergreen.ScopeCollection, evergreen.RoleCollection))
@@ -1017,10 +1030,11 @@ type ProjectPutRotateSuite struct {
 }
 
 func TestProjectPutRotateSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectPutRotateSuite))
 }
 

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -40,8 +40,6 @@ func TestProjectPatchSuite(t *testing.T) {
 	s := &ProjectPatchByIDSuite{
 		env: testutil.NewEnvironment(ctx, t),
 	}
-	// kim: TODO: remove
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -76,8 +74,6 @@ func (s *ProjectPatchByIDSuite) SetupTest() {
 			evergreen.PermissionLogs:            evergreen.LogsView.Value,
 		},
 	}
-	// kim: TODO: remove
-	// roleManager := evergreen.GetEnvironment().RoleManager()
 	roleManager := s.env.RoleManager()
 	err = roleManager.UpdateRole(projectAdminRole)
 	s.NoError(err)
@@ -339,11 +335,6 @@ type ProjectPutSuite struct {
 }
 
 func TestProjectPutSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectPutSuite))
 }
 
@@ -453,11 +444,6 @@ type ProjectGetByIDSuite struct {
 }
 
 func TestProjectGetByIDSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectGetByIDSuite))
 }
 
@@ -526,11 +512,6 @@ type ProjectGetSuite struct {
 }
 
 func TestProjectGetSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectGetSuite))
 }
 
@@ -696,11 +677,6 @@ func getTestProjectRef() *serviceModel.ProjectRef {
 
 func TestGetProjectVersions(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(db.ClearCollections(serviceModel.VersionCollection, serviceModel.ProjectRefCollection))
 	const projectId = "proj"
 	project := serviceModel.ProjectRef{
@@ -753,11 +729,8 @@ func TestGetProjectVersions(t *testing.T) {
 }
 
 func TestDeleteProject(t *testing.T) {
-	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(
 		serviceModel.ProjectRefCollection,
 		serviceModel.RepoRefCollection,
@@ -884,9 +857,6 @@ func TestDeleteProject(t *testing.T) {
 func TestAttachProjectToRepo(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(serviceModel.ProjectRefCollection,
 		serviceModel.RepoRefCollection, serviceModel.ProjectVarsCollection, user.Collection,
 		evergreen.ScopeCollection, evergreen.RoleCollection))
@@ -952,9 +922,6 @@ func TestAttachProjectToRepo(t *testing.T) {
 func TestDetachProjectFromRepo(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(serviceModel.ProjectRefCollection,
 		serviceModel.RepoRefCollection, serviceModel.ProjectVarsCollection, user.Collection,
 		evergreen.ScopeCollection, evergreen.RoleCollection))
@@ -1030,11 +997,6 @@ type ProjectPutRotateSuite struct {
 }
 
 func TestProjectPutRotateSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(ProjectPutRotateSuite))
 }
 

--- a/rest/route/reliability_test.go
+++ b/rest/route/reliability_test.go
@@ -77,9 +77,6 @@ func TestParseParameters(t *testing.T) {
 
 	groupContext, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(groupContext, t)
-	// evergreen.SetEnvironment(env)
 
 	for opName, opTests := range map[string]func(context.Context, *testing.T, evergreen.Environment){
 		"Tasks": func(paginationContext context.Context, t *testing.T, env evergreen.Environment) {
@@ -372,9 +369,6 @@ func TestParse(t *testing.T) {
 
 	groupContext, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(groupContext, t)
-	// evergreen.SetEnvironment(env)
 
 	for opName, opTests := range map[string]func(context.Context, *testing.T, evergreen.Environment){
 		"Parse": func(paginationContext context.Context, t *testing.T, env evergreen.Environment) {
@@ -478,11 +472,8 @@ func TestParse(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	// kim: TODO: remove
 	groupContext, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// env := testutil.NewEnvironment(groupContext, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
 	proj := model.ProjectRef{
 		Id: "project",
@@ -761,11 +752,6 @@ func withSetupAndTeardown(t *testing.T, env evergreen.Environment, fn func()) {
 }
 
 func TestReliability(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
 	groupContext, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/rest/route/reliability_test.go
+++ b/rest/route/reliability_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/reliability"
 	"github.com/evergreen-ci/evergreen/model/stats"
 	"github.com/evergreen-ci/evergreen/rest/data"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
@@ -78,8 +77,9 @@ func TestParseParameters(t *testing.T) {
 
 	groupContext, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(groupContext, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(groupContext, t)
+	// evergreen.SetEnvironment(env)
 
 	for opName, opTests := range map[string]func(context.Context, *testing.T, evergreen.Environment){
 		"Tasks": func(paginationContext context.Context, t *testing.T, env evergreen.Environment) {
@@ -372,8 +372,9 @@ func TestParse(t *testing.T) {
 
 	groupContext, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(groupContext, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(groupContext, t)
+	// evergreen.SetEnvironment(env)
 
 	for opName, opTests := range map[string]func(context.Context, *testing.T, evergreen.Environment){
 		"Parse": func(paginationContext context.Context, t *testing.T, env evergreen.Environment) {
@@ -477,11 +478,11 @@ func TestParse(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-
+	// kim: TODO: remove
 	groupContext, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(groupContext, t)
-	evergreen.SetEnvironment(env)
+	// env := testutil.NewEnvironment(groupContext, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
 	proj := model.ProjectRef{
 		Id: "project",
@@ -760,10 +761,11 @@ func withSetupAndTeardown(t *testing.T, env evergreen.Environment, fn func()) {
 }
 
 func TestReliability(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(stats.DailyTaskStatsCollection, model.ProjectRefCollection))
 	groupContext, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/rest/route/repo_test.go
+++ b/rest/route/repo_test.go
@@ -148,7 +148,7 @@ func TestPatchRepoIDHandler(t *testing.T) {
 	independentAlias.Alias = evergreen.GithubChecksAlias
 	assert.NoError(t, independentAlias.Upsert())
 
-	ctx = gimlet.AttachUser(context.Background(), &user.DBUser{Id: "the amazing Annie"})
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "the amazing Annie"})
 	settings, err := evergreen.GetConfig()
 	assert.NoError(t, err)
 	settings.GithubOrgs = []string{repoRef.Owner}

--- a/rest/route/repo_test.go
+++ b/rest/route/repo_test.go
@@ -24,8 +24,9 @@ import (
 func TestGetRepoIDHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(
 		dbModel.RepoRefCollection,
 		dbModel.ProjectVarsCollection,
@@ -83,8 +84,9 @@ func TestGetRepoIDHandler(t *testing.T) {
 func TestPatchRepoIDHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(dbModel.RepoRefCollection, dbModel.ProjectVarsCollection,
 		dbModel.ProjectAliasCollection, dbModel.GithubHooksCollection, commitqueue.Collection,
 		dbModel.ProjectRefCollection))
@@ -247,8 +249,9 @@ func TestPatchRepoIDHandler(t *testing.T) {
 func TestPatchHandlersWithRestricted(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	// kim: TODO: remove
 	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(dbModel.RepoRefCollection, dbModel.ProjectVarsCollection,
 		dbModel.ProjectAliasCollection, dbModel.GithubHooksCollection, commitqueue.Collection, user.Collection,
 		dbModel.ProjectRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection))
@@ -290,7 +293,7 @@ func TestPatchHandlersWithRestricted(t *testing.T) {
 	assert.NoError(t, u.Insert())
 	ctx = gimlet.AttachUser(context.Background(), u)
 
-	rm := evergreen.GetEnvironment().RoleManager()
+	rm := env.RoleManager()
 	allProjectsScope := &gimlet.Scope{
 		ID:        evergreen.AllProjectsScope,
 		Resources: []string{},

--- a/rest/route/repo_test.go
+++ b/rest/route/repo_test.go
@@ -24,9 +24,6 @@ import (
 func TestGetRepoIDHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(
 		dbModel.RepoRefCollection,
 		dbModel.ProjectVarsCollection,
@@ -84,9 +81,6 @@ func TestGetRepoIDHandler(t *testing.T) {
 func TestPatchRepoIDHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(dbModel.RepoRefCollection, dbModel.ProjectVarsCollection,
 		dbModel.ProjectAliasCollection, dbModel.GithubHooksCollection, commitqueue.Collection,
 		dbModel.ProjectRefCollection))
@@ -249,9 +243,7 @@ func TestPatchRepoIDHandler(t *testing.T) {
 func TestPatchHandlersWithRestricted(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
 	env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(dbModel.RepoRefCollection, dbModel.ProjectVarsCollection,
 		dbModel.ProjectAliasCollection, dbModel.GithubHooksCollection, commitqueue.Collection, user.Collection,
 		dbModel.ProjectRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -124,7 +124,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/hosts/{task_id}/list").Version(2).Get().Wrap(requireTask).RouteHandler(makeHostListRouteManager())
 	app.AddRoute("/hosts/{host_id}/attach").Version(2).Post().Wrap(requireUser).RouteHandler(makeAttachVolume(env))
 	app.AddRoute("/hosts/{host_id}/detach").Version(2).Post().Wrap(requireUser).RouteHandler(makeDetachVolume(env))
-	app.AddRoute("/hosts/{host_id}/provisioning_options").Version(2).Get().Wrap(requireHost).RouteHandler(makeHostProvisioningOptionsGetHandler())
+	app.AddRoute("/hosts/{host_id}/provisioning_options").Version(2).Get().Wrap(requireHost).RouteHandler(makeHostProvisioningOptionsGetHandler(env))
 	app.AddRoute("/hosts/ip_address/{ip_address}").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetHostByIpAddress())
 	app.AddRoute("/volumes").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetVolumes())
 	app.AddRoute("/volumes").Version(2).Post().Wrap(requireUser).RouteHandler(makeCreateVolume(env))

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -66,11 +66,6 @@ func TestHostParseAndValidate(t *testing.T) {
 }
 
 func TestHostPaginator(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	numHostsInDB := 300
 	Convey("When paginating with a Connector", t, func() {
 		So(db.Clear(host.Collection), ShouldBeNil)
@@ -309,11 +304,6 @@ func TestHostPaginator(t *testing.T) {
 }
 
 func TestTasksByProjectAndCommitPaginator(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	numTasks := 300
 	projectName := "project_1"
 	commit := "commit_1"
@@ -521,11 +511,6 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 }
 
 func TestTaskByBuildPaginator(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	numTasks := 300
 	Convey("When paginating with a Connector", t, func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection))
@@ -904,11 +889,6 @@ func TestTestPaginator(t *testing.T) {
 }
 
 func TestTaskExecutionPatchPrepare(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	Convey("With handler and a project context and user", t, func() {
 		tep := &taskExecutionPatchHandler{}
 
@@ -1012,11 +992,6 @@ func TestTaskExecutionPatchPrepare(t *testing.T) {
 }
 
 func TestTaskExecutionPatchExecute(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	Convey("With a task in the DB and a Connector", t, func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, serviceModel.VersionCollection, build.Collection))
 		version := serviceModel.Version{
@@ -1062,11 +1037,6 @@ func TestTaskExecutionPatchExecute(t *testing.T) {
 }
 
 func TestTaskResetPrepare(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	Convey("With handler and a project context and user", t, func() {
 		trh := &taskRestartHandler{}
 
@@ -1111,11 +1081,6 @@ func TestTaskResetPrepare(t *testing.T) {
 }
 
 func TestTaskGetHandler(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	Convey("With test server with a handler and mock data", t, func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection))
 		rm := makeGetTaskRoute("https://example.net/test")
@@ -1190,11 +1155,6 @@ func TestTaskGetHandler(t *testing.T) {
 }
 
 func TestTaskResetExecute(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	Convey("With a task returned by the Connector", t, func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, serviceModel.VersionCollection, build.Collection))
 		timeNow := time.Now()
@@ -1257,11 +1217,8 @@ func TestTaskResetExecute(t *testing.T) {
 }
 
 func TestParentTaskInfo(t *testing.T) {
-	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(task.Collection))
 	buildID := "test"
 	dtID := "displayTask"
@@ -1315,11 +1272,8 @@ func TestParentTaskInfo(t *testing.T) {
 }
 
 func TestOptionsRequest(t *testing.T) {
-	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(task.Collection))
 
 	route := "/rest/v2/tasks/test/restart"

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -38,7 +38,7 @@ func init() {
 	testutil.Setup()
 	config := evergreen.NaiveAuthConfig{}
 	um, err := auth.NewNaiveUserManager(&config)
-	grip.Error(err)
+	grip.EmergencyFatal(err)
 	evergreen.GetEnvironment().SetUserManager(um)
 }
 
@@ -66,10 +66,11 @@ func TestHostParseAndValidate(t *testing.T) {
 }
 
 func TestHostPaginator(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	numHostsInDB := 300
 	Convey("When paginating with a Connector", t, func() {
 		So(db.Clear(host.Collection), ShouldBeNil)
@@ -308,10 +309,11 @@ func TestHostPaginator(t *testing.T) {
 }
 
 func TestTasksByProjectAndCommitPaginator(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	numTasks := 300
 	projectName := "project_1"
 	commit := "commit_1"
@@ -519,10 +521,11 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 }
 
 func TestTaskByBuildPaginator(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	numTasks := 300
 	Convey("When paginating with a Connector", t, func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection))
@@ -901,10 +904,11 @@ func TestTestPaginator(t *testing.T) {
 }
 
 func TestTaskExecutionPatchPrepare(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	Convey("With handler and a project context and user", t, func() {
 		tep := &taskExecutionPatchHandler{}
 
@@ -1008,10 +1012,11 @@ func TestTaskExecutionPatchPrepare(t *testing.T) {
 }
 
 func TestTaskExecutionPatchExecute(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	Convey("With a task in the DB and a Connector", t, func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, serviceModel.VersionCollection, build.Collection))
 		version := serviceModel.Version{
@@ -1057,10 +1062,11 @@ func TestTaskExecutionPatchExecute(t *testing.T) {
 }
 
 func TestTaskResetPrepare(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	Convey("With handler and a project context and user", t, func() {
 		trh := &taskRestartHandler{}
 
@@ -1105,10 +1111,11 @@ func TestTaskResetPrepare(t *testing.T) {
 }
 
 func TestTaskGetHandler(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	Convey("With test server with a handler and mock data", t, func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection))
 		rm := makeGetTaskRoute("https://example.net/test")
@@ -1183,10 +1190,11 @@ func TestTaskGetHandler(t *testing.T) {
 }
 
 func TestTaskResetExecute(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	Convey("With a task returned by the Connector", t, func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, serviceModel.VersionCollection, build.Collection))
 		timeNow := time.Now()
@@ -1249,10 +1257,11 @@ func TestTaskResetExecute(t *testing.T) {
 }
 
 func TestParentTaskInfo(t *testing.T) {
+	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(task.Collection))
 	buildID := "test"
 	dtID := "displayTask"
@@ -1306,10 +1315,11 @@ func TestParentTaskInfo(t *testing.T) {
 }
 
 func TestOptionsRequest(t *testing.T) {
+	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.ClearCollections(task.Collection))
 
 	route := "/rest/v2/tasks/test/restart"

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -86,9 +86,6 @@ func TestBaseSNSRoute(t *testing.T) {
 func TestHandleEC2SNSNotification(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.Clear(host.Collection))
 	rh := ec2SNS{}
 	rh.env = testutil.NewEnvironment(ctx, t)
@@ -110,9 +107,6 @@ func TestHandleEC2SNSNotification(t *testing.T) {
 func TestEC2SNSNotificationHandlers(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.Clear(host.Collection))
 	agentHost := host.Host{
 		Id:        "agent_host",
@@ -155,9 +149,6 @@ func TestEC2SNSNotificationHandlers(t *testing.T) {
 func TestECSSNSHandleNotification(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *ecsSNS){
 		"MarksRunningPodForTerminationWhenStopped": func(ctx context.Context, t *testing.T, rh *ecsSNS) {

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -86,12 +86,13 @@ func TestBaseSNSRoute(t *testing.T) {
 func TestHandleEC2SNSNotification(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.Clear(host.Collection))
 	rh := ec2SNS{}
-	rh.queue = evergreen.GetEnvironment().LocalQueue()
-	rh.env = evergreen.GetEnvironment()
+	rh.env = testutil.NewEnvironment(ctx, t)
+	rh.queue = rh.env.LocalQueue()
 	rh.payload = sns.Payload{Message: `{"version":"0","id":"qwertyuiop","detail-type":"EC2 Instance State-change Notification","source":"sns.ec2","time":"2020-07-23T14:48:37Z","region":"us-east-1","resources":["arn:aws:ec2:us-east-1:1234567890:instance/i-0123456789"],"detail":{"instance-id":"i-0123456789","state":"terminated"}}`}
 
 	// unknown host
@@ -109,8 +110,9 @@ func TestHandleEC2SNSNotification(t *testing.T) {
 func TestEC2SNSNotificationHandlers(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	assert.NoError(t, db.Clear(host.Collection))
 	agentHost := host.Host{
 		Id:        "agent_host",
@@ -153,8 +155,9 @@ func TestEC2SNSNotificationHandlers(t *testing.T) {
 func TestECSSNSHandleNotification(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *ecsSNS){
 		"MarksRunningPodForTerminationWhenStopped": func(ctx context.Context, t *testing.T, rh *ecsSNS) {

--- a/rest/route/stats_test.go
+++ b/rest/route/stats_test.go
@@ -24,11 +24,6 @@ type StatsSuite struct {
 }
 
 func TestStatsSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(StatsSuite))
 }
 

--- a/rest/route/stats_test.go
+++ b/rest/route/stats_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/reliability"
 	"github.com/evergreen-ci/evergreen/model/stats"
 	"github.com/evergreen-ci/evergreen/rest/data"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/suite"
 )
@@ -25,10 +24,11 @@ type StatsSuite struct {
 }
 
 func TestStatsSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(StatsSuite))
 }
 

--- a/rest/route/status_test.go
+++ b/rest/route/status_test.go
@@ -25,11 +25,6 @@ type StatusSuite struct {
 }
 
 func TestStatusSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(StatusSuite))
 }
 

--- a/rest/route/status_test.go
+++ b/rest/route/status_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/suite"
 )
@@ -26,10 +25,11 @@ type StatusSuite struct {
 }
 
 func TestStatusSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(StatusSuite))
 }
 

--- a/rest/route/subscription_test.go
+++ b/rest/route/subscription_test.go
@@ -8,12 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/suite"
@@ -26,10 +24,11 @@ type SubscriptionRouteSuite struct {
 
 func TestSubscriptionRouteSuiteWithDB(t *testing.T) {
 	s := new(SubscriptionRouteSuite)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 
 	suite.Run(t, s)
 }

--- a/rest/route/subscription_test.go
+++ b/rest/route/subscription_test.go
@@ -24,12 +24,6 @@ type SubscriptionRouteSuite struct {
 
 func TestSubscriptionRouteSuiteWithDB(t *testing.T) {
 	s := new(SubscriptionRouteSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
-
 	suite.Run(t, s)
 }
 

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -54,10 +53,11 @@ func TestValidateJSON(t *testing.T) {
 }
 
 func TestGenerateExecute(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(task.Collection))
 	task1 := task.Task{
 		Id: "task1",
@@ -71,10 +71,13 @@ func TestGenerateExecute(t *testing.T) {
 }
 
 func TestGeneratePollParse(t *testing.T) {
+	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
+	// require.NoError(t, env.Configure(ctx))
 	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(task.Collection, host.Collection))
 	r, err := http.NewRequest("GET", "/task/1/generate", nil)
 	require.NoError(t, err)
@@ -97,7 +100,7 @@ func TestGeneratePollRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(task.Collection))
 	tasks := []task.Task{
 		{

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type Thing struct {
@@ -74,11 +72,7 @@ func TestGeneratePollParse(t *testing.T) {
 	require.NoError(t, err)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "1"})
 
-	uri := "mongodb://localhost:27017"
-	client, err := mongo.NewClient(options.Client().ApplyURI(uri))
-	require.NoError(t, err)
-	require.NoError(t, client.Connect(ctx))
-	require.NoError(t, client.Database("amboy_test").Drop(ctx))
+	require.NoError(t, db.DropDatabases(env.Settings().Amboy.DB))
 	require.NotNil(t, env)
 	q := env.RemoteQueueGroup()
 	require.NotNil(t, q)

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -53,11 +53,6 @@ func TestValidateJSON(t *testing.T) {
 }
 
 func TestGenerateExecute(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(task.Collection))
 	task1 := task.Task{
 		Id: "task1",
@@ -71,12 +66,8 @@ func TestGenerateExecute(t *testing.T) {
 }
 
 func TestGeneratePollParse(t *testing.T) {
-	// kim: TODO: remove
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
-	// require.NoError(t, env.Configure(ctx))
 	env := testutil.NewEnvironment(ctx, t)
 	require.NoError(t, db.ClearCollections(task.Collection, host.Collection))
 	r, err := http.NewRequest("GET", "/task/1/generate", nil)
@@ -100,7 +91,6 @@ func TestGeneratePollRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(task.Collection))
 	tasks := []task.Task{
 		{

--- a/rest/route/task_test.go
+++ b/rest/route/task_test.go
@@ -33,11 +33,6 @@ type TaskAbortSuite struct {
 }
 
 func TestTaskAbortSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(TaskAbortSuite))
 }
 
@@ -89,11 +84,6 @@ func (s *TaskAbortSuite) TestAbort() {
 
 func TestFetchArtifacts(t *testing.T) {
 	assert := assert.New(t)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require := require.New(t)
 
 	assert.NoError(db.ClearCollections(task.Collection, task.OldCollection, artifact.Collection))
@@ -208,11 +198,6 @@ func (s *ProjectTaskWithinDatesSuite) TestHasDefaultValues() {
 }
 
 func TestGetDisplayTask(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	for testName, testCase := range map[string]func(context.Context, *testing.T){
 		"SucceedsWithTaskInDisplayTask": func(ctx context.Context, t *testing.T) {
 			tsk := task.Task{Id: "task_id"}
@@ -281,9 +266,6 @@ func TestGetDisplayTask(t *testing.T) {
 func TestGetTaskSyncReadCredentials(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	creds := model.APIS3Credentials{
 		Key:    utility.ToStringPtr("key"),
 		Secret: utility.ToStringPtr("secret"),
@@ -354,9 +336,6 @@ func TestGetTaskSyncReadCredentials(t *testing.T) {
 func TestGetTaskSyncPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	expected := task.Task{
 		Id:           "task_id",
 		Project:      "project",

--- a/rest/route/task_test.go
+++ b/rest/route/task_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
@@ -34,10 +33,11 @@ type TaskAbortSuite struct {
 }
 
 func TestTaskAbortSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(TaskAbortSuite))
 }
 
@@ -89,10 +89,11 @@ func (s *TaskAbortSuite) TestAbort() {
 
 func TestFetchArtifacts(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	require := require.New(t)
 
 	assert.NoError(db.ClearCollections(task.Collection, task.OldCollection, artifact.Collection))
@@ -207,10 +208,11 @@ func (s *ProjectTaskWithinDatesSuite) TestHasDefaultValues() {
 }
 
 func TestGetDisplayTask(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	for testName, testCase := range map[string]func(context.Context, *testing.T){
 		"SucceedsWithTaskInDisplayTask": func(ctx context.Context, t *testing.T) {
 			tsk := task.Task{Id: "task_id"}
@@ -279,8 +281,9 @@ func TestGetDisplayTask(t *testing.T) {
 func TestGetTaskSyncReadCredentials(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	creds := model.APIS3Credentials{
 		Key:    utility.ToStringPtr("key"),
 		Secret: utility.ToStringPtr("secret"),
@@ -351,8 +354,9 @@ func TestGetTaskSyncReadCredentials(t *testing.T) {
 func TestGetTaskSyncPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	expected := task.Task{
 		Id:           "task_id",
 		Project:      "project",

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -30,11 +30,6 @@ type UserRouteSuite struct {
 
 func TestUserRouteSuiteWithDB(t *testing.T) {
 	s := new(UserRouteSuite)
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
@@ -150,20 +145,15 @@ type userPermissionPostSuite struct {
 }
 
 func TestPostUserPermissionSuite(t *testing.T) {
-	// kim: TODO: remove
 	s := &userPermissionPostSuite{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s.env = testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, s)
 }
 
 func (s *userPermissionPostSuite) SetupTest() {
 	s.Require().NoError(db.ClearCollections(user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
-	// kim: TODO: remove
-	// env := evergreen.GetEnvironment()
-	// _ = s.env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection}).Err()
 	s.Require().NoError(db.CreateCollections(evergreen.ScopeCollection))
 	s.u = user.DBUser{
 		Id: "user",
@@ -210,8 +200,6 @@ func (s *userPermissionPostSuite) TestValidInput() {
 	// valid input that should create a new role + scope
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := evergreen.GetEnvironment()
 	validBody := `{ "resource_type": "project", "resources": ["foo"], "permissions": {"project_tasks": 10} }`
 	request, err := http.NewRequest(http.MethodPost, "", bytes.NewBuffer([]byte(validBody)))
 	request = gimlet.SetURLVars(request, map[string]string{"user_id": s.u.Id})
@@ -267,14 +255,9 @@ func TestDeleteUserPermissions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	// env := &mock.Environment{}
-	// require.NoError(t, env.Configure(ctx))
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
 	rm := env.RoleManager()
-	_ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection}).Err()
+	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 	u := user.DBUser{
 		Id:          "user",
 		SystemRoles: []string{"role1", "role2", "role3", evergreen.BasicProjectAccessRole},
@@ -320,15 +303,8 @@ func TestGetUserPermissions(t *testing.T) {
 	defer cancel()
 
 	env := testutil.NewEnvironment(ctx, t)
-	// env := &mock.Environment{}
-	// require.NoError(t, env.Configure(ctx))
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.ClearCollections(user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
 	rm := env.RoleManager()
-	// kim: TODO: remove
-	// _ = env.DB().RunCommand(nil, map[string]string{"create": evergreen.ScopeCollection})
 	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 	u := user.DBUser{
 		Id:          "user",
@@ -351,11 +327,6 @@ func TestPostUserRoles(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	// env := &mock.Environment{}
-	// require.NoError(t, env.Configure(ctx))
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	env.SetUserManager(serviceutil.MockUserManager{})
 	require.NoError(t, db.ClearCollections(user.Collection, evergreen.RoleCollection))
 	rm := env.RoleManager()
@@ -411,9 +382,6 @@ func TestPostUserRoles(t *testing.T) {
 func TestServiceUserOperations(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.Clear(user.Collection))
 
 	body := `{ "user_id": "foo", "display_name": "service", "roles": ["one", "two"] }`
@@ -472,9 +440,6 @@ func TestServiceUserOperations(t *testing.T) {
 func TestGetUsersForRole(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// kim: TODO: remove
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	require.NoError(t, db.Clear(user.Collection))
 
 	u1 := user.DBUser{
@@ -520,9 +485,6 @@ func TestGetUsersForResourceId(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
-	// env := &mock.Environment{}
-	// require.NoError(t, env.Configure(ctx))
 	require.NoError(t, db.ClearCollections(user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
 	rm := env.RoleManager()
 

--- a/rest/route/version_test.go
+++ b/rest/route/version_test.go
@@ -25,11 +25,6 @@ type VersionSuite struct {
 }
 
 func TestVersionSuite(t *testing.T) {
-	// kim: TODO: remove
-	// ctx, cancel := context.WithCancel(context.Background())
-	// defer cancel()
-	// env := testutil.NewEnvironment(ctx, t)
-	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(VersionSuite))
 }
 

--- a/rest/route/version_test.go
+++ b/rest/route/version_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/suite"
@@ -26,10 +25,11 @@ type VersionSuite struct {
 }
 
 func TestVersionSuite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
+	// kim: TODO: remove
+	// ctx, cancel := context.WithCancel(context.Background())
+	// defer cancel()
+	// env := testutil.NewEnvironment(ctx, t)
+	// evergreen.SetEnvironment(env)
 	suite.Run(t, new(VersionSuite))
 }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16718
https://jira.mongodb.org/browse/EVG-16509

### Description 
Lots of tests were setting the global environment state using `evergreen.SetEnvironment`. This is risky and inadvisable in testing because most tests assume that the Anser DB functions are always available in all tests, but the global Anser DB functions themselves depend on the global environment's mongo client. If `evergreen.SetEnvironment` sets a global environment whose contexts cancels at the end of the test, it'll close the mongo driver when the context cancels and break all later tests in that `go test` execution that rely on the DB. I removed all usages of `evergreen.SetEnvironment` in tests except where it's unavoidable (or `evergreen.SetEnvironment` is itself being tested) so that we can avoid fiddling with fragile global env state in every single test. Every test now should be able to assume that `testutil.Setup` is called in the `init()` block to set up the global environment so the DB is available, and then no other test will overwrite that global environment.

* Remove usages of `evergreen.SetEnvironment` in tests. (This coincidentally fixes [EVG-16509](https://jira.mongodb.org/browse/EVG-16509)).
* Update a bunch of old testing code to use the new `db.CreateCollections` method rather than issuing raw DB commands to create the collection.
* Fix some tests that are not re-runnable because they rely on enqueueing duplicate jobs in Amboy.
    * Add method to drop a DB (mostly for the Amboy DB).
* Do a small refactor for a method to avoid another easily-avoidable `evergreen.GetEnvironment`.

### Testing 
Updated all the unit tests. I ran the tests several times to verify that the REST tests no longer depend on order of test execution and don't unexpectedly modify the global state in a way that breaks other tests.