### PR TITLE
EVG-15087: Update TriggerAlias schema

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1089,11 +1089,8 @@ type ComplexityRoot struct {
 	TriggerAlias struct {
 		Alias             func(childComplexity int) int
 		BuildVariantRegex func(childComplexity int) int
-		Command           func(childComplexity int) int
 		ConfigFile        func(childComplexity int) int
 		DateCutoff        func(childComplexity int) int
-		DefinitionID      func(childComplexity int) int
-		GenerateFile      func(childComplexity int) int
 		Level             func(childComplexity int) int
 		Project           func(childComplexity int) int
 		Status            func(childComplexity int) int
@@ -6744,13 +6741,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TriggerAlias.BuildVariantRegex(childComplexity), true
 
-	case "TriggerAlias.command":
-		if e.complexity.TriggerAlias.Command == nil {
-			break
-		}
-
-		return e.complexity.TriggerAlias.Command(childComplexity), true
-
 	case "TriggerAlias.configFile":
 		if e.complexity.TriggerAlias.ConfigFile == nil {
 			break
@@ -6764,20 +6754,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.TriggerAlias.DateCutoff(childComplexity), true
-
-	case "TriggerAlias.definitionID":
-		if e.complexity.TriggerAlias.DefinitionID == nil {
-			break
-		}
-
-		return e.complexity.TriggerAlias.DefinitionID(childComplexity), true
-
-	case "TriggerAlias.generateFile":
-		if e.complexity.TriggerAlias.GenerateFile == nil {
-			break
-		}
-
-		return e.complexity.TriggerAlias.GenerateFile(childComplexity), true
 
 	case "TriggerAlias.level":
 		if e.complexity.TriggerAlias.Level == nil {
@@ -8058,16 +8034,13 @@ input RepoRefInput {
 }
 
 input TriggerAliasInput {
-  project: String
+  project: String!
   level: String!
-  definitionID: String!
   buildVariantRegex: String!
   taskRegex: String!
   status: String!
   dateCutoff: Int!
   configFile: String!
-  generateFile: String!
-  command: String!
   alias: String!
 }
 
@@ -8869,16 +8842,13 @@ type RepoRef {
 }
 
 type TriggerAlias {
-  project: String
+  project: String!
   level: String!
-  definitionID: String!
   buildVariantRegex: String!
   taskRegex: String!
   status: String!
   dateCutoff: Int!
   configFile: String!
-  generateFile: String!
-  command: String!
   alias: String!
 }
 
@@ -35315,11 +35285,14 @@ func (ec *executionContext) _TriggerAlias_project(ctx context.Context, field gra
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _TriggerAlias_level(ctx context.Context, field graphql.CollectedField, obj *model.APITriggerDefinition) (ret graphql.Marshaler) {
@@ -35341,41 +35314,6 @@ func (ec *executionContext) _TriggerAlias_level(ctx context.Context, field graph
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.Level, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _TriggerAlias_definitionID(ctx context.Context, field graphql.CollectedField, obj *model.APITriggerDefinition) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "TriggerAlias",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.DefinitionID, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -35551,76 +35489,6 @@ func (ec *executionContext) _TriggerAlias_configFile(ctx context.Context, field 
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.ConfigFile, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _TriggerAlias_generateFile(ctx context.Context, field graphql.CollectedField, obj *model.APITriggerDefinition) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "TriggerAlias",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.GenerateFile, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _TriggerAlias_command(ctx context.Context, field graphql.CollectedField, obj *model.APITriggerDefinition) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "TriggerAlias",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Command, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -42218,7 +42086,7 @@ func (ec *executionContext) unmarshalInputTriggerAliasInput(ctx context.Context,
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project"))
-			it.Project, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.Project, err = ec.unmarshalNString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -42227,14 +42095,6 @@ func (ec *executionContext) unmarshalInputTriggerAliasInput(ctx context.Context,
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("level"))
 			it.Level, err = ec.unmarshalNString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "definitionID":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("definitionID"))
-			it.DefinitionID, err = ec.unmarshalNString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -42275,22 +42135,6 @@ func (ec *executionContext) unmarshalInputTriggerAliasInput(ctx context.Context,
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("configFile"))
 			it.ConfigFile, err = ec.unmarshalNString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "generateFile":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("generateFile"))
-			it.GenerateFile, err = ec.unmarshalNString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "command":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("command"))
-			it.Command, err = ec.unmarshalNString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -48711,13 +48555,11 @@ func (ec *executionContext) _TriggerAlias(ctx context.Context, sel ast.Selection
 			out.Values[i] = graphql.MarshalString("TriggerAlias")
 		case "project":
 			out.Values[i] = ec._TriggerAlias_project(ctx, field, obj)
-		case "level":
-			out.Values[i] = ec._TriggerAlias_level(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "definitionID":
-			out.Values[i] = ec._TriggerAlias_definitionID(ctx, field, obj)
+		case "level":
+			out.Values[i] = ec._TriggerAlias_level(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -48743,16 +48585,6 @@ func (ec *executionContext) _TriggerAlias(ctx context.Context, sel ast.Selection
 			}
 		case "configFile":
 			out.Values[i] = ec._TriggerAlias_configFile(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "generateFile":
-			out.Values[i] = ec._TriggerAlias_generateFile(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "command":
-			out.Values[i] = ec._TriggerAlias_command(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -549,16 +549,13 @@ input RepoRefInput {
 }
 
 input TriggerAliasInput {
-  project: String
+  project: String!
   level: String!
-  definitionID: String!
   buildVariantRegex: String!
   taskRegex: String!
   status: String!
   dateCutoff: Int!
   configFile: String!
-  generateFile: String!
-  command: String!
   alias: String!
 }
 
@@ -1360,16 +1357,13 @@ type RepoRef {
 }
 
 type TriggerAlias {
-  project: String
+  project: String!
   level: String!
-  definitionID: String!
   buildVariantRegex: String!
   taskRegex: String!
   status: String!
   dateCutoff: Int!
   configFile: String!
-  generateFile: String!
-  command: String!
   alias: String!
 }
 


### PR DESCRIPTION
Schema update for UI ticket [EVG-15087](https://jira.mongodb.org/browse/EVG-15087)

### Description 
- Remove `definitionID` since this field is only used internally
- Remove `command` and `generateFile` fields in light of [EVG-16720](https://jira.mongodb.org/browse/EVG-16720)
- Require `project` (not sure if there was a particular reason this was nullable)

### Testing 
- Tested in GraphQL playground