### PR TITLE
EVG-16718: set environment for host provisioning options handler factory

### DIFF
--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -556,7 +556,9 @@ func makeHostProvisioningOptionsGetHandler(env evergreen.Environment) gimlet.Rou
 }
 
 func (rh *hostProvisioningOptionsGetHandler) Factory() gimlet.RouteHandler {
-	return &hostProvisioningOptionsGetHandler{}
+	return &hostProvisioningOptionsGetHandler{
+		env: rh.env,
+	}
 }
 
 func (rh *hostProvisioningOptionsGetHandler) Parse(ctx context.Context, r *http.Request) error {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16718

### Description 
I swapped out `evergreen.GetEnvironment()` in the host provisioning options REST route for #5569 but forgot that the Gimlet route handler internally makes a copy of the route using `Factory`. This should properly set the env so that the actual route handler used is populated with the environment.