### PR TITLE
EVG-16307: support activating/deactivating container tasks

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -50,12 +50,12 @@ const (
 	// pending a rerun
 	TaskUnstarted = "unstarted"
 
-	// TaskUndispatched indicates either
+	// TaskUndispatched indicates either:
 	//  1. a task is not scheduled to run (when Task.Activated == false)
 	//  2. a task is scheduled to run (when Task.Activated == true)
 	TaskUndispatched = "undispatched"
 	TaskUnscheduled  = "unscheduled"
-	// TaskWillRun is a subset of TaskUndispatched and is only used in the UI
+	// TaskWillRun is a subset of undispatched tasks and is only used in the UI
 	TaskWillRun = "will-run"
 
 	// TaskDispatched indicates that an agent has received the task, but

--- a/globals.go
+++ b/globals.go
@@ -55,7 +55,7 @@ const (
 	//  2. a task is scheduled to run (when Task.Activated == true)
 	TaskUndispatched = "undispatched"
 	TaskUnscheduled  = "unscheduled"
-	// TaskWillRun is a subset of undispatched tasks and is only used in the UI
+	// TaskWillRun is a subset of undispatched tasks and is only used in the UI.
 	TaskWillRun = "will-run"
 
 	// TaskDispatched indicates that an agent has received the task, but

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -230,9 +230,9 @@ func LogVolumeExpirationWarningSent(volumeID string) {
 	LogHostEvent(volumeID, EventVolumeExpirationWarningSent, HostEventData{})
 }
 
-// UpdateExecutions updates host events to track multiple executions of the same
-// task.
-func UpdateExecutions(hostId, taskId string, execution int) error {
+// UpdateHostTaskExecutions updates host events to track multiple executions of
+// the same host task.
+func UpdateHostTaskExecutions(hostId, taskId string, execution int) error {
 	query := bson.M{
 		ResourceIdKey: hostId,
 		bsonutil.GetDottedKeyName(DataKey, hostDataTaskIDKey): taskId,

--- a/model/event/host_event_test.go
+++ b/model/event/host_event_test.go
@@ -132,7 +132,7 @@ func TestLoggingHostEvents(t *testing.T) {
 			So(eventData.TaskPid, ShouldEqual, taskPid)
 
 			// test logging multiple executions of the same task
-			err = UpdateExecutions(hostId, taskId, 0)
+			err = UpdateHostTaskExecutions(hostId, taskId, 0)
 			So(err, ShouldBeNil)
 
 			eventsForHost, err = Find(AllLogCollection, MostRecentHostEvents(hostId, "", 50))

--- a/model/event/pod.go
+++ b/model/event/pod.go
@@ -28,9 +28,10 @@ const (
 
 // podData contains information relevant to a pod event.
 type podData struct {
-	OldStatus string `bson:"old_status,omitempty" json:"old_status,omitempty"`
-	NewStatus string `bson:"new_status,omitempty" json:"new_status,omitempty"`
-	TaskID    string `bson:"task_id,omitempty" json:"task_id,omitempty"`
+	OldStatus     string `bson:"old_status,omitempty" json:"old_status,omitempty"`
+	NewStatus     string `bson:"new_status,omitempty" json:"new_status,omitempty"`
+	TaskID        string `bson:"task_id,omitempty" json:"task_id,omitempty"`
+	TaskExecution int    `bson:"task_execution,omitempty" json:"task_execution,omitempty"`
 }
 
 // LogPodEvent logs an event for a pod to the event log.
@@ -66,6 +67,6 @@ func LogPodStatusChanged(id, oldStatus, newStatus string) {
 
 // LogPodAssignedTask logs an event indicating that the pod has been assigned a
 // task to run.
-func LogPodAssignedTask(id, taskID string) {
-	LogPodEvent(id, EventPodAssignedTask, podData{TaskID: taskID})
+func LogPodAssignedTask(id, taskID string, execution int) {
+	LogPodEvent(id, EventPodAssignedTask, podData{TaskID: taskID, TaskExecution: execution})
 }

--- a/model/event/pod_test.go
+++ b/model/event/pod_test.go
@@ -30,7 +30,8 @@ func TestPodEvents(t *testing.T) {
 		"LogPodAssignedTask": func(t *testing.T) {
 			podID := "pod_id"
 			taskID := "task_id"
-			LogPodAssignedTask(podID, taskID)
+			execution := 5
+			LogPodAssignedTask(podID, taskID, 5)
 
 			events, err := Find(AllLogCollection, MostRecentPodEvents(podID, 10))
 			require.NoError(t, err)
@@ -41,6 +42,7 @@ func TestPodEvents(t *testing.T) {
 			data, ok := events[0].Data.(*podData)
 			require.True(t, ok)
 			assert.Equal(t, taskID, data.TaskID)
+			assert.Equal(t, execution, data.TaskExecution)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {

--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -108,6 +108,7 @@ func Allocate(ctx context.Context, env evergreen.Environment, t *task.Task, p *p
 			return nil, errors.Wrap(err, "inserting new intent pod")
 		}
 
+		containerAllocatedAt := utility.BSONTime(time.Now())
 		// Only allow the task to transition state if it's currently in a state
 		// where it needs a pod to be allocated.
 		update, err := env.DB().Collection(task.Collection).UpdateOne(sessCtx, bson.M{
@@ -118,7 +119,8 @@ func Allocate(ctx context.Context, env evergreen.Environment, t *task.Task, p *p
 			task.PriorityKey:           bson.M{"$gt": evergreen.DisabledTaskPriority},
 		}, bson.M{
 			"$set": bson.M{
-				task.ContainerAllocatedKey: true,
+				task.ContainerAllocatedKey:     true,
+				task.ContainerAllocatedTimeKey: containerAllocatedAt,
 			},
 		})
 		if err != nil {
@@ -128,6 +130,7 @@ func Allocate(ctx context.Context, env evergreen.Environment, t *task.Task, p *p
 			return nil, errors.New("task status was not updated")
 		}
 		t.ContainerAllocated = true
+		t.ContainerAllocatedTime = containerAllocatedAt
 
 		return nil, nil
 	}

--- a/model/pod/dispatcher/db_test.go
+++ b/model/pod/dispatcher/db_test.go
@@ -143,6 +143,7 @@ func TestAllocate(t *testing.T) {
 		require.NoError(t, err)
 		require.NotZero(t, dbTask)
 		assert.True(t, dbTask.ContainerAllocated)
+		assert.NotZero(t, dbTask.ContainerAllocatedTime)
 
 		dbDispatcher, err := FindOneByGroupID(GetGroupID(tsk))
 		require.NoError(t, err)

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -132,7 +132,7 @@ func (pd *PodDispatcher) AssignNextTask(ctx context.Context, env evergreen.Envir
 			return nil, errors.Wrapf(err, "dispatching task '%s' to pod '%s'", t.Id, p.ID)
 		}
 
-		event.LogPodAssignedTask(p.ID, t.Id)
+		event.LogPodAssignedTask(p.ID, t.Id, t.Execution)
 		event.LogContainerTaskDispatched(t.Id, t.Execution, p.ID)
 
 		return t, nil

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -128,8 +128,8 @@ type Task struct {
 	// Tags that describe the task
 	Tags []string `bson:"tags,omitempty" json:"tags,omitempty"`
 
-	// The host the task was run on. This value is empty for display tasks
-	HostId string `bson:"host_id" json:"host_id"`
+	// The host the task was run on. This value is only set for host tasks.
+	HostId string `bson:"host_id,omitempty" json:"host_id"`
 
 	// ExecutionPlatform determines the execution environment that the task runs
 	// in.
@@ -494,19 +494,26 @@ func (t *Task) IsFinished() bool {
 	return evergreen.IsFinishedTaskStatus(t.Status)
 }
 
+// IsDispatchable returns true if the task should make progress towards
+// dispatching to run.
+func (t *Task) IsDispatchable() bool {
+	return t.IsHostDispatchable() || t.ShouldAllocateContainer() || t.IsContainerDispatchable()
+}
+
 // IsHostDispatchable returns true if the task should run on a host and can be
 // dispatched.
 func (t *Task) IsHostDispatchable() bool {
-	return (t.ExecutionPlatform == "" || t.ExecutionPlatform == ExecutionPlatformHost) && !t.DisplayOnly && t.Status == evergreen.TaskUndispatched && t.Activated
+	return t.IsHostTask() && t.Status == evergreen.TaskUndispatched && t.Activated
 }
 
-// IsContainerDispatchable returns true if the task should run in a container
-// and can be dispatched.
-func (t *Task) IsContainerDispatchable() bool {
-	if !t.ContainerAllocated {
-		return false
-	}
-	return t.isContainerScheduled()
+// IsHostTask returns true if it's a task that runs on hosts.
+func (t *Task) IsHostTask() bool {
+	return (t.ExecutionPlatform == "" || t.ExecutionPlatform == ExecutionPlatformHost) && !t.DisplayOnly
+}
+
+// IsContainerTask returns true if it's a task that runs on containers.
+func (t *Task) IsContainerTask() bool {
+	return t.ExecutionPlatform == ExecutionPlatformContainer
 }
 
 // ShouldAllocateContainer indicates whether a task should be allocated a
@@ -519,10 +526,19 @@ func (t *Task) ShouldAllocateContainer() bool {
 	return t.isContainerScheduled()
 }
 
+// IsContainerDispatchable returns true if the task should run in a container
+// and can be dispatched.
+func (t *Task) IsContainerDispatchable() bool {
+	if !t.ContainerAllocated {
+		return false
+	}
+	return t.isContainerScheduled()
+}
+
 // isContainerTaskScheduled returns whether or not the task is in a state
 // where it should eventually dispatch to run on a container.
 func (t *Task) isContainerScheduled() bool {
-	if t.ExecutionPlatform != ExecutionPlatformContainer {
+	if !t.IsContainerTask() {
 		return false
 	}
 	if t.Status != evergreen.TaskUndispatched {
@@ -1058,7 +1074,8 @@ func (t *Task) MarkAsContainerDeallocated(ctx context.Context, env evergreen.Env
 			LastHeartbeatKey:      utility.ZeroTime,
 		},
 		"$unset": bson.M{
-			AgentVersionKey: 1,
+			AgentVersionKey:           1,
+			ContainerAllocatedTimeKey: 1,
 		},
 	})
 	if err != nil {
@@ -1071,6 +1088,8 @@ func (t *Task) MarkAsContainerDeallocated(ctx context.Context, env evergreen.Env
 	t.ContainerAllocated = false
 	t.DispatchTime = utility.ZeroTime
 	t.LastHeartbeat = utility.ZeroTime
+	t.ContainerAllocatedTime = time.Time{}
+	t.AgentVersion = ""
 
 	return nil
 }
@@ -1610,10 +1629,9 @@ func DeactivateTasks(tasks []Task, caller string) error {
 		},
 		bson.M{
 			"$set": bson.M{
-				ActivatedKey:              false,
-				ActivatedByKey:            caller,
-				ScheduledTimeKey:          utility.ZeroTime,
-				ContainerAllocatedTimeKey: utility.ZeroTime,
+				ActivatedKey:     false,
+				ActivatedByKey:   caller,
+				ScheduledTimeKey: utility.ZeroTime,
 			},
 		},
 	)
@@ -1654,7 +1672,6 @@ func DeactivateDependencies(tasks []string, caller string) error {
 			ActivatedKey:                false,
 			DeactivatedForDependencyKey: true,
 			ScheduledTimeKey:            utility.ZeroTime,
-			ContainerAllocatedTimeKey:   utility.ZeroTime,
 		}},
 	)
 	if err != nil {
@@ -1786,30 +1803,35 @@ func (t *Task) displayTaskPriority() int {
 	return 1000
 }
 
-// Reset sets the task state to be activated, with a new secret,
-// undispatched status and zero time on Start, Scheduled, Dispatch and FinishTime
+// Reset sets the task state to a state in which it is scheduled to re-run.
 func (t *Task) Reset() error {
-	reset := resetTaskUpdate(t)
-
 	return UpdateOne(
 		bson.M{
 			IdKey: t.Id,
 		},
-		reset,
+		resetTaskUpdate(t),
 	)
 }
 
-// Reset sets the task state to be activated, with a new secret,
-// undispatched status and zero time on Start, Scheduled, Dispatch and FinishTime
-func ResetTasks(taskIds []string) error {
-	_, err := UpdateAll(
-		bson.M{
-			IdKey: bson.M{"$in": taskIds},
-		},
-		resetTaskUpdate(nil),
-	)
+// ResetTasks performs the same DB updates as (*Task).Reset, but resets many
+// tasks instead of a single one.
+func ResetTasks(tasks []Task) error {
+	if len(tasks) == 0 {
+		return nil
+	}
+	var taskIDs []string
+	for _, t := range tasks {
+		taskIDs = append(taskIDs, t.Id)
+	}
 
-	return err
+	if _, err := UpdateAll(
+		bson.M{IdKey: bson.M{"$in": taskIDs}},
+		resetTaskUpdate(nil),
+	); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func resetTaskUpdate(t *Task) bson.M {
@@ -1824,7 +1846,6 @@ func resetTaskUpdate(t *Task) bson.M {
 		t.DispatchTime = utility.ZeroTime
 		t.StartTime = utility.ZeroTime
 		t.ScheduledTime = utility.ZeroTime
-		t.ContainerAllocatedTime = utility.ZeroTime
 		t.FinishTime = utility.ZeroTime
 		t.DependenciesMetTime = utility.ZeroTime
 		t.TimeTaken = 0
@@ -1832,26 +1853,23 @@ func resetTaskUpdate(t *Task) bson.M {
 		t.Details = apimodels.TaskEndDetail{}
 		t.HasCedarResults = false
 		t.ResetWhenFinished = false
-		t.HostId = ""
 		t.AgentVersion = ""
 		t.HostCreateDetails = []HostCreateDetail{}
 		t.OverrideDependencies = false
 	}
 	update := bson.M{
 		"$set": bson.M{
-			ActivatedKey:              true,
-			ActivatedTimeKey:          now,
-			SecretKey:                 newSecret,
-			HostIdKey:                 "",
-			StatusKey:                 evergreen.TaskUndispatched,
-			DispatchTimeKey:           utility.ZeroTime,
-			StartTimeKey:              utility.ZeroTime,
-			ScheduledTimeKey:          utility.ZeroTime,
-			ContainerAllocatedTimeKey: utility.ZeroTime,
-			FinishTimeKey:             utility.ZeroTime,
-			DependenciesMetTimeKey:    utility.ZeroTime,
-			TimeTakenKey:              0,
-			LastHeartbeatKey:          utility.ZeroTime,
+			ActivatedKey:           true,
+			ActivatedTimeKey:       now,
+			SecretKey:              newSecret,
+			StatusKey:              evergreen.TaskUndispatched,
+			DispatchTimeKey:        utility.ZeroTime,
+			StartTimeKey:           utility.ZeroTime,
+			ScheduledTimeKey:       utility.ZeroTime,
+			FinishTimeKey:          utility.ZeroTime,
+			DependenciesMetTimeKey: utility.ZeroTime,
+			TimeTakenKey:           0,
+			LastHeartbeatKey:       utility.ZeroTime,
 		},
 		"$unset": bson.M{
 			DetailsKey:              "",
@@ -1859,6 +1877,7 @@ func resetTaskUpdate(t *Task) bson.M {
 			CedarResultsFailedKey:   "",
 			ResetWhenFinishedKey:    "",
 			AgentVersionKey:         "",
+			HostIdKey:               "",
 			HostCreateDetailsKey:    "",
 			OverrideDependenciesKey: "",
 		},
@@ -2239,7 +2258,10 @@ func (t *Task) Insert() error {
 	return db.Insert(Collection, t)
 }
 
-// Inserts the task into the old_tasks collection
+// Archive modifies the currente execution of the task so that it is no longer
+// considered the latest execution. This task execution is inserted
+// into the old_tasks collection. If this is a display task, its execution tasks
+// are also archived.
 func (t *Task) Archive() error {
 	if t.DisplayOnly && len(t.ExecutionTasks) > 0 {
 		execTasks, err := FindAll(db.Query(ByIds(t.ExecutionTasks)))
@@ -2277,9 +2299,17 @@ func (t *Task) Archive() error {
 	}
 	t.Aborted = false
 
-	err = event.UpdateExecutions(t.HostId, t.Id, t.Execution)
-	if err != nil {
-		return errors.Wrap(err, "updating host event logs")
+	if t.IsHostTask() {
+		// Host event logs involving running a host task don't include the
+		// execution number but need it to distinguish which task execution it
+		// ran once the task is no longer the latest execution. This
+		// retroactively sets the task execution for event logs involving the
+		// host running this task so that it correctly identifies this archived
+		// execution.
+		err = event.UpdateHostTaskExecutions(t.HostId, t.Id, t.Execution)
+		if err != nil {
+			return errors.Wrap(err, "updating host event logs")
+		}
 	}
 	return nil
 }
@@ -2362,7 +2392,15 @@ func ArchiveMany(tasks []Task) error {
 
 	eventLogErrs := grip.NewBasicCatcher()
 	for _, t := range tasks {
-		eventLogErrs.Add(event.UpdateExecutions(t.HostId, t.Id, t.Execution))
+		if t.IsHostTask() {
+			// Host event logs involving running a host task don't include the
+			// execution number but need it to distinguish which task execution
+			// it ran once the task is no longer the latest execution. This
+			// retroactively sets the task execution for event logs involving
+			// the host running this task so that it correctly identifies this
+			// archived execution.
+			eventLogErrs.Wrapf(event.UpdateHostTaskExecutions(t.HostId, t.Id, t.Execution), "updating execution %d of task '%s' for host '%s'", t.Execution, t.Id, t.HostId)
+		}
 	}
 
 	return eventLogErrs.Resolve()

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2258,7 +2258,7 @@ func (t *Task) Insert() error {
 	return db.Insert(Collection, t)
 }
 
-// Archive modifies the currente execution of the task so that it is no longer
+// Archive modifies the current execution of the task so that it is no longer
 // considered the latest execution. This task execution is inserted
 // into the old_tasks collection. If this is a display task, its execution tasks
 // are also archived.

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2192,6 +2192,7 @@ func TestMarkAsContainerDeallocated(t *testing.T) {
 		assert.True(t, utility.IsZeroTime(dbTask.DispatchTime))
 		assert.True(t, utility.IsZeroTime(dbTask.LastHeartbeat))
 		assert.Zero(t, dbTask.AgentVersion)
+		assert.Zero(t, dbTask.ContainerAllocatedTime)
 	}
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task){
@@ -2228,17 +2229,64 @@ func TestMarkAsContainerDeallocated(t *testing.T) {
 
 			require.NoError(t, db.Clear(Collection))
 			tsk := Task{
-				Id:                 utility.RandomString(),
-				Activated:          true,
-				ActivatedTime:      time.Now(),
-				Status:             evergreen.TaskUndispatched,
-				ContainerAllocated: true,
-				DispatchTime:       time.Now(),
-				LastHeartbeat:      time.Now(),
-				ExecutionPlatform:  ExecutionPlatformContainer,
+				Id:                     utility.RandomString(),
+				Activated:              true,
+				ActivatedTime:          time.Now(),
+				Status:                 evergreen.TaskUndispatched,
+				ContainerAllocated:     true,
+				ContainerAllocatedTime: time.Now(),
+				DispatchTime:           time.Now(),
+				LastHeartbeat:          time.Now(),
+				ExecutionPlatform:      ExecutionPlatformContainer,
 			}
 
 			tCase(tctx, t, env, tsk)
+		})
+	}
+}
+
+func TestIsDispatchable(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T, tsk Task){
+		"ReturnsTrueForHostTask": func(t *testing.T, tsk Task) {
+			assert.True(t, tsk.IsDispatchable())
+		},
+		"ReturnsTrueForTaskWithDefaultedHostExecutionPlatform": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ""
+			assert.True(t, tsk.IsDispatchable())
+		},
+		"ReturnsTrueForContainerTaskWithoutContainerAllocated": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ExecutionPlatformContainer
+			tsk.ContainerAllocated = false
+			assert.True(t, tsk.IsDispatchable())
+		},
+		"ReturnsTrueForContainerTaskWithContainerAllocated": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ExecutionPlatformContainer
+			tsk.ContainerAllocated = true
+			assert.True(t, tsk.IsDispatchable())
+		},
+		"ReturnsFalseForTaskWithoutUndispatchedStatus": func(t *testing.T, tsk Task) {
+			tsk.Status = evergreen.TaskDispatched
+			assert.False(t, tsk.IsDispatchable())
+		},
+		"ReturnsFalseForInactiveTask": func(t *testing.T, tsk Task) {
+			tsk.Activated = false
+			assert.False(t, tsk.IsDispatchable())
+		},
+		"ReturnsFalseForDisplayTask": func(t *testing.T, tsk Task) {
+			tsk.DisplayOnly = true
+			tsk.ExecutionPlatform = ""
+			tsk.ExecutionTasks = []string{"exec-task0", "exec-task1"}
+			assert.False(t, tsk.IsDispatchable())
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			hostDispatchableTask := Task{
+				Id:                "task-id",
+				Status:            evergreen.TaskUndispatched,
+				Activated:         true,
+				ExecutionPlatform: ExecutionPlatformHost,
+			}
+			tCase(t, hostDispatchableTask)
 		})
 	}
 }
@@ -2848,6 +2896,96 @@ func TestAbortVersion(t *testing.T) {
 	assert.NotEmpty(t, otherExecTask.AbortInfo.TaskID)
 }
 
+func TestArchive(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection, OldCollection, event.AllLogCollection))
+	}()
+	checkTaskIsArchived := func(t *testing.T, oldTaskID string) {
+		dbTask, err := FindOneOldId(oldTaskID)
+		require.NoError(t, err)
+		require.NotZero(t, dbTask)
+		assert.NotZero(t, dbTask.OldTaskId)
+		assert.NotEqual(t, dbTask.OldTaskId, dbTask.Id)
+		assert.True(t, dbTask.Archived)
+		assert.False(t, dbTask.Aborted)
+		assert.Zero(t, dbTask.AbortInfo)
+	}
+
+	checkEventLogHostTaskExecutions := func(t *testing.T, hostID, oldTaskID string, execution int) {
+		dbTask, err := FindOneOldId(oldTaskID)
+		require.NoError(t, err)
+		require.NotZero(t, dbTask)
+
+		events, err := event.FindAllByResourceID(hostID)
+		require.NoError(t, err)
+		assert.NotEmpty(t, events)
+
+		for _, e := range events {
+			hostEventData, ok := e.Data.(*event.HostEventData)
+			require.True(t, ok)
+			require.Equal(t, hostEventData.TaskId, dbTask.OldTaskId)
+			require.Equal(t, hostEventData.TaskExecution, dbTask.Execution)
+		}
+	}
+	for tName, tCase := range map[string]func(t *testing.T, tsk Task){
+		"ArchivesHostTaskAndUpdatesEventLog": func(t *testing.T, tsk Task) {
+			archivedTaskID := MakeOldID(tsk.Id, tsk.Execution)
+			archivedExecution := tsk.Execution
+			require.NoError(t, tsk.Insert())
+
+			hostID := "hostID"
+			event.LogHostRunningTaskSet(hostID, tsk.Id)
+			event.LogHostRunningTaskCleared(hostID, tsk.Id)
+
+			require.NoError(t, tsk.Archive())
+
+			checkTaskIsArchived(t, archivedTaskID)
+			checkEventLogHostTaskExecutions(t, hostID, archivedTaskID, archivedExecution)
+		},
+		"ArchivesDisplayTaskAndItsExecutionTasks": func(t *testing.T, dt Task) {
+			execTask := Task{
+				Id:            "execTask",
+				DisplayTaskId: utility.ToStringPtr(dt.Id),
+			}
+			archivedExecTaskID := MakeOldID(execTask.Id, execTask.Execution)
+			archivedExecution := execTask.Execution
+			require.NoError(t, execTask.Insert())
+
+			hostID := "hostID"
+			event.LogHostRunningTaskSet(hostID, execTask.Id)
+			event.LogHostRunningTaskCleared(hostID, execTask.Id)
+
+			dt.DisplayOnly = true
+			dt.ExecutionTasks = []string{execTask.Id}
+			archivedDisplayTaskID := MakeOldID(dt.Id, dt.Execution)
+			require.NoError(t, dt.Insert())
+
+			require.NoError(t, dt.Archive())
+
+			checkTaskIsArchived(t, archivedExecTaskID)
+			checkTaskIsArchived(t, archivedDisplayTaskID)
+
+			checkEventLogHostTaskExecutions(t, hostID, archivedExecTaskID, archivedExecution)
+		},
+		"ArchivesContainerTask": func(t *testing.T, tsk Task) {
+			archivedTaskID := MakeOldID(tsk.Id, tsk.Execution)
+			tsk.ExecutionPlatform = ExecutionPlatformContainer
+			require.NoError(t, tsk.Insert())
+
+			require.NoError(t, tsk.Archive())
+			checkTaskIsArchived(t, archivedTaskID)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(Collection, OldCollection, event.AllLogCollection))
+			tsk := Task{
+				Id: "taskID",
+			}
+			tCase(t, tsk)
+		})
+	}
+}
+
 func TestGetTaskStatsByVersion(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	t1 := Task{
@@ -3248,49 +3386,49 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByIdAndExecution() {
 
 func (s *TaskConnectorFetchByIdSuite) TestFindByVersion() {
 	s.Require().NoError(db.ClearCollections(Collection, OldCollection, annotations.Collection))
-	task_known_2 := &Task{
+	taskKnown2 := &Task{
 		Id:        "task_known",
 		Execution: 2,
 		Version:   "version_known",
 		Status:    evergreen.TaskSucceeded,
 	}
-	task_not_known := &Task{
+	taskNotKnown := &Task{
 		Id:        "task_not_known",
 		Execution: 0,
 		Version:   "version_not_known",
 		Status:    evergreen.TaskFailed,
 	}
-	task_no_annotation := &Task{
+	taskNoAnnotation := &Task{
 		Id:        "task_no_annotation",
 		Execution: 0,
 		Version:   "version_no_annotation",
 		Status:    evergreen.TaskFailed,
 	}
-	task_with_empty_issues := &Task{
+	taskWithEmptyIssues := &Task{
 		Id:        "task_with_empty_issues",
 		Execution: 0,
 		Version:   "version_with_empty_issues",
 		Status:    evergreen.TaskFailed,
 	}
-	s.NoError(task_known_2.Insert())
-	s.NoError(task_not_known.Insert())
-	s.NoError(task_no_annotation.Insert())
-	s.NoError(task_with_empty_issues.Insert())
+	s.NoError(taskKnown2.Insert())
+	s.NoError(taskNotKnown.Insert())
+	s.NoError(taskNoAnnotation.Insert())
+	s.NoError(taskWithEmptyIssues.Insert())
 
 	issue := annotations.IssueLink{URL: "https://issuelink.com", IssueKey: "EVG-1234", Source: &annotations.Source{Author: "chaya.malik"}}
 
-	a_execution_0 := annotations.TaskAnnotation{TaskId: "task_known", TaskExecution: 0, SuspectedIssues: []annotations.IssueLink{issue}}
-	a_execution_1 := annotations.TaskAnnotation{TaskId: "task_known", TaskExecution: 1, SuspectedIssues: []annotations.IssueLink{issue}}
-	a_execution_2 := annotations.TaskAnnotation{TaskId: "task_known", TaskExecution: 2, Issues: []annotations.IssueLink{issue}}
+	annotationExecution0 := annotations.TaskAnnotation{TaskId: "task_known", TaskExecution: 0, SuspectedIssues: []annotations.IssueLink{issue}}
+	annotationExecution1 := annotations.TaskAnnotation{TaskId: "task_known", TaskExecution: 1, SuspectedIssues: []annotations.IssueLink{issue}}
+	annotationExecution2 := annotations.TaskAnnotation{TaskId: "task_known", TaskExecution: 2, Issues: []annotations.IssueLink{issue}}
 
-	a_with__suspected_issue := annotations.TaskAnnotation{TaskId: "task_not_known", TaskExecution: 0, SuspectedIssues: []annotations.IssueLink{issue}}
-	a_with_empty_issues := annotations.TaskAnnotation{TaskId: "task_not_known", TaskExecution: 0, Issues: []annotations.IssueLink{}, SuspectedIssues: []annotations.IssueLink{issue}}
+	annotationWithSuspectedIssue := annotations.TaskAnnotation{TaskId: "task_not_known", TaskExecution: 0, SuspectedIssues: []annotations.IssueLink{issue}}
+	annotationWithEmptyIssues := annotations.TaskAnnotation{TaskId: "task_not_known", TaskExecution: 0, Issues: []annotations.IssueLink{}, SuspectedIssues: []annotations.IssueLink{issue}}
 
-	s.NoError(a_execution_0.Upsert())
-	s.NoError(a_execution_1.Upsert())
-	s.NoError(a_execution_2.Upsert())
-	s.NoError(a_with__suspected_issue.Upsert())
-	s.NoError(a_with_empty_issues.Upsert())
+	s.NoError(annotationExecution0.Upsert())
+	s.NoError(annotationExecution1.Upsert())
+	s.NoError(annotationExecution2.Upsert())
+	s.NoError(annotationWithSuspectedIssue.Upsert())
+	s.NoError(annotationWithEmptyIssues.Upsert())
 
 	opts := GetTasksByVersionOptions{}
 	t, _, err := GetTasksByVersion("version_known", opts)
@@ -3312,7 +3450,6 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByVersion() {
 	t, _, err = GetTasksByVersion("version_with_empty_issues", opts)
 	s.NoError(err)
 	s.Equal(evergreen.TaskFailed, t[0].DisplayStatus)
-
 }
 
 func (s *TaskConnectorFetchByIdSuite) TestFindOldTasksByIDWithDisplayTasks() {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -50,9 +50,7 @@ func SetActiveState(caller string, active bool, tasks ...task.Task) error {
 			// activate the task's dependencies as well
 			if !t.OverrideDependencies {
 				deps, err := task.GetRecursiveDependenciesUp(originalTasks, nil)
-				if err != nil {
-					catcher.Wrapf(err, "getting dependencies up for task '%s'", t.Id)
-				}
+				catcher.Wrapf(err, "getting dependencies up for task '%s'", t.Id)
 				if t.IsPartOfSingleHostTaskGroup() {
 					for _, dep := range deps {
 						// reset any already finished tasks in the same task group
@@ -68,7 +66,7 @@ func SetActiveState(caller string, active bool, tasks ...task.Task) error {
 			}
 
 			// Investigating strange dispatch state as part of EVG-13144
-			if !utility.IsZeroTime(t.DispatchTime) && t.Status == evergreen.TaskUndispatched {
+			if t.IsHostTask() && !utility.IsZeroTime(t.DispatchTime) && t.Status == evergreen.TaskUndispatched {
 				catcher.Wrapf(resetTask(t.Id, caller, false), "resetting task '%s'", t.Id)
 			} else {
 				tasksToActivate = append(tasksToActivate, originalTasks...)
@@ -1288,6 +1286,8 @@ func MarkOneTaskReset(t *task.Task, logIDs bool) error {
 	return nil
 }
 
+// MarkTasksReset resets many tasks by their IDs. For execution tasks, this also
+// resets their parent display tasks.
 func MarkTasksReset(taskIds []string) error {
 	tasks, err := task.FindAll(db.Query(task.ByIds(taskIds)))
 	if err != nil {
@@ -1298,20 +1298,14 @@ func MarkTasksReset(taskIds []string) error {
 		return errors.WithStack(err)
 	}
 
-	for _, t := range tasks {
-		if t.DisplayOnly {
-			taskIds = append(taskIds, t.Id)
-		}
-	}
-
-	if err = task.ResetTasks(taskIds); err != nil {
+	if err = task.ResetTasks(tasks); err != nil {
 		return errors.Wrap(err, "resetting tasks in database")
 	}
 
 	catcher := grip.NewBasicCatcher()
 	for _, t := range tasks {
-		catcher.Wrap(UpdateUnblockedDependencies(&t, false, ""), "clearing cached unattainable dependencies")
-		catcher.Wrap(t.MarkDependenciesFinished(false), "marking direct dependencies unfinished")
+		catcher.Wrapf(UpdateUnblockedDependencies(&t, false, ""), "clearing cached unattainable dependencies for task '%s'", t.Id)
+		catcher.Wrapf(t.MarkDependenciesFinished(false), "marking direct dependencies unfinished for task '%s'", t.Id)
 	}
 
 	return catcher.Resolve()
@@ -1547,7 +1541,7 @@ func UpdateDisplayTaskForTask(t *task.Task) error {
 		if execTask.IsFinished() {
 			hasFinishedTasks = true
 			// Need to consider tasks that have been dispatched since the last exec task finished.
-		} else if (execTask.IsHostDispatchable() || execTask.IsAbortable()) && !execTask.Blocked() {
+		} else if (execTask.IsDispatchable() || execTask.IsAbortable()) && !execTask.Blocked() {
 			hasTasksToRun = true
 		}
 

--- a/model/version.go
+++ b/model/version.go
@@ -115,24 +115,26 @@ func (v *Version) LastSuccessful() (*Version, error) {
 	return lastGreen, nil
 }
 
-func (self *Version) UpdateBuildVariants() error {
+// UpdateBuildVariants sets this version's build variants.
+func (v *Version) UpdateBuildVariants() error {
 	return VersionUpdateOne(
-		bson.M{VersionIdKey: self.Id},
+		bson.M{VersionIdKey: v.Id},
 		bson.M{
 			"$set": bson.M{
-				VersionBuildVariantsKey: self.BuildVariants,
+				VersionBuildVariantsKey: v.BuildVariants,
 			},
 		},
 	)
 }
 
-func (self *Version) SetActivated() error {
-	if utility.FromBoolPtr(self.Activated) {
+// SetActivated sets this version to activated if it's not already activated.
+func (v *Version) SetActivated() error {
+	if utility.FromBoolPtr(v.Activated) {
 		return nil
 	}
-	self.Activated = utility.TruePtr()
+	v.Activated = utility.TruePtr()
 	return VersionUpdateOne(
-		bson.M{VersionIdKey: self.Id},
+		bson.M{VersionIdKey: v.Id},
 		bson.M{
 			"$set": bson.M{
 				VersionActivatedKey: true,
@@ -141,13 +143,15 @@ func (self *Version) SetActivated() error {
 	)
 }
 
-func (self *Version) SetNotActivated() error {
-	if !utility.FromBoolTPtr(self.Activated) {
+// SetNotActivated sets this version to inactive if it's been explicitly set to
+// activated.
+func (v *Version) SetNotActivated() error {
+	if !utility.FromBoolTPtr(v.Activated) {
 		return nil
 	}
-	self.Activated = utility.FalsePtr()
+	v.Activated = utility.FalsePtr()
 	return VersionUpdateOne(
-		bson.M{VersionIdKey: self.Id},
+		bson.M{VersionIdKey: v.Id},
 		bson.M{
 			"$set": bson.M{
 				VersionActivatedKey: false,
@@ -156,10 +160,11 @@ func (self *Version) SetNotActivated() error {
 	)
 }
 
-func (self *Version) SetAborted(aborted bool) error {
-	self.Aborted = aborted
+// SetAborted sets the version as aborted.
+func (v *Version) SetAborted(aborted bool) error {
+	v.Aborted = aborted
 	return VersionUpdateOne(
-		bson.M{VersionIdKey: self.Id},
+		bson.M{VersionIdKey: v.Id},
 		bson.M{
 			"$set": bson.M{
 				VersionAbortedKey: aborted,
@@ -168,8 +173,8 @@ func (self *Version) SetAborted(aborted bool) error {
 	)
 }
 
-func (self *Version) Insert() error {
-	return db.Insert(VersionCollection, self)
+func (v *Version) Insert() error {
+	return db.Insert(VersionCollection, v)
 }
 
 func (v *Version) IsChild() bool {

--- a/service/stats.go
+++ b/service/stats.go
@@ -206,7 +206,6 @@ func (uis *UIServer) taskTimingJSON(w http.ResponseWriter, r *http.Request) {
 			task.StartTimeKey,
 			task.FinishTimeKey,
 			task.VersionKey,
-			task.HostIdKey,
 			task.StatusKey,
 			task.HostIdKey,
 			task.DistroIdKey,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16307

### Description 
This is mostly to do with activation/deactivation but I fixed some tech debt and style issues that I spotted along the way.

* Ensure task activation/deactivation works for both container and host tasks.
* Fix how the container task allocated time so that it's set/unset when the container is allocated/deallocated.
* Make `(task.Task).HostId` field omitempty since it's only relevant to host tasks.
* Include task execution when logging that a task is dispatched to a pod. The task ID is not sufficient to uniquely identify which task execution a pod ran, so it must include the task execution for the event logs. Host tasks currently do a thing where they retroactively set the execution number, but I would prefer to just set the execution when it's dispatched rather than set it when the task execution is being archived.
* Fix a few doc comments.
* Remove outdated Python self receivers in version DB functions (and document those exported methods).
* Fix some random style issues (e.g. snake_case) in testing code.

### Testing 
Added previously-nonexistent tests for existing functions that I modified.