### PR TITLE
EVG-16618: move dispatcher updates for other models into respective packages

### DIFF
--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -104,7 +104,7 @@ func Allocate(ctx context.Context, env evergreen.Environment, t *task.Task, p *p
 		}
 		pd.ModificationCount++
 
-		if err := p.InsertWithSession(sessCtx, env); err != nil {
+		if err := p.InsertWithContext(sessCtx, env); err != nil {
 			return nil, errors.Wrap(err, "inserting new intent pod")
 		}
 

--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -104,33 +104,13 @@ func Allocate(ctx context.Context, env evergreen.Environment, t *task.Task, p *p
 		}
 		pd.ModificationCount++
 
-		if _, err := env.DB().Collection(pod.Collection).InsertOne(sessCtx, p); err != nil {
+		if err := p.InsertWithSession(sessCtx, env); err != nil {
 			return nil, errors.Wrap(err, "inserting new intent pod")
 		}
 
-		containerAllocatedAt := utility.BSONTime(time.Now())
-		// Only allow the task to transition state if it's currently in a state
-		// where it needs a pod to be allocated.
-		update, err := env.DB().Collection(task.Collection).UpdateOne(sessCtx, bson.M{
-			task.IdKey:                 t.Id,
-			task.StatusKey:             evergreen.TaskUndispatched,
-			task.ActivatedKey:          true,
-			task.ContainerAllocatedKey: false,
-			task.PriorityKey:           bson.M{"$gt": evergreen.DisabledTaskPriority},
-		}, bson.M{
-			"$set": bson.M{
-				task.ContainerAllocatedKey:     true,
-				task.ContainerAllocatedTimeKey: containerAllocatedAt,
-			},
-		})
-		if err != nil {
+		if err := t.MarkAsContainerAllocated(ctx, env); err != nil {
 			return nil, errors.Wrap(err, "marking task as container allocated")
 		}
-		if update.ModifiedCount == 0 {
-			return nil, errors.New("task status was not updated")
-		}
-		t.ContainerAllocated = true
-		t.ContainerAllocatedTime = containerAllocatedAt
 
 		return nil, nil
 	}

--- a/model/pod/dispatcher/db_test.go
+++ b/model/pod/dispatcher/db_test.go
@@ -236,6 +236,7 @@ func TestAllocate(t *testing.T) {
 			tCase(tctx, t, env, &task.Task{
 				Id:                 "task",
 				Status:             evergreen.TaskUndispatched,
+				ExecutionPlatform:  task.ExecutionPlatformContainer,
 				ContainerAllocated: false,
 				Activated:          true,
 			}, p)

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -371,9 +371,19 @@ func (s Secret) IsZero() bool {
 	return s.Name == "" && s.ExternalID == "" && s.Value == "" && s.Exists == nil && s.Owned == nil
 }
 
-// Insert inserts a new pod into the collection.
+// Insert inserts a new pod into the collection. This relies on the global Anser
+// DB session.
 func (p *Pod) Insert() error {
 	return db.Insert(Collection, p)
+}
+
+// InsertWithSession is the same as Insert, but it respects the given context by
+// avoiding the global Anser DB session.
+func (p *Pod) InsertWithSession(ctx context.Context, env evergreen.Environment) error {
+	if _, err := env.DB().Collection(Collection).InsertOne(ctx, p); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Remove removes the pod from the collection.

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -377,9 +377,9 @@ func (p *Pod) Insert() error {
 	return db.Insert(Collection, p)
 }
 
-// InsertWithSession is the same as Insert, but it respects the given context by
+// InsertWithContext is the same as Insert, but it respects the given context by
 // avoiding the global Anser DB session.
-func (p *Pod) InsertWithSession(ctx context.Context, env evergreen.Environment) error {
+func (p *Pod) InsertWithContext(ctx context.Context, env evergreen.Environment) error {
 	if _, err := env.DB().Collection(Collection).InsertOne(ctx, p); err != nil {
 		return err
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -767,10 +767,16 @@ func schedulableHostTasksQuery() bson.M {
 // FindNeedsContainerAllocation returns all container tasks that are waiting for
 // a container to be allocated to them sorted by activation time.
 func FindNeedsContainerAllocation() ([]Task, error) {
+	return FindAll(db.Query(needsContainerAllocation()).Sort([]string{ActivatedTimeKey}))
+}
+
+// needsContainerAllocation returns the query that filters for a task that
+// currently needs a container to be allocated to run it.
+func needsContainerAllocation() bson.M {
 	q := isContainerTaskScheduledQuery()
 	q[StatusKey] = evergreen.TaskUndispatched
 	q[ContainerAllocatedKey] = false
-	return FindAll(db.Query(q).Sort([]string{ActivatedTimeKey}))
+	return q
 }
 
 func isContainerTaskScheduledQuery() bson.M {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16618

### Description 
Rather than doing pod/task DB updates directly inside the dispatcher package, I moved them into their proper packages for better code organization.

### Testing 
Added unit tests for exported functions.
