### PR TITLE
EVG-6741 Update cli patch command to take regex

### DIFF
--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -20,60 +20,60 @@ type cliIntent struct {
 	// ID is created by the driver and has no special meaning to the application.
 	DocumentID string `bson:"_id"`
 
-	// PatchFileID is the object id of the patch file created in gridfs
+	// PatchFileID is the object id of the patch file created in gridfs.
 	PatchFileID mgobson.ObjectId `bson:"patch_file_id,omitempty"`
 
 	// PatchContent is the patch as supplied by the client. It is saved
-	// separately from the patch intent
+	// separately from the patch intent.
 	PatchContent string
 
-	// Description is the optional description of the patch
+	// Description is the optional description of the patch.
 	Description string `bson:"description,omitempty"`
 
-	// BuildVariants is a list of build variants associated with the patch
+	// BuildVariants is a list of build variants associated with the patch.
 	BuildVariants []string `bson:"variants,omitempty"`
 
-	// Tasks is a list of tasks associated with the patch
+	// Tasks is a list of tasks associated with the patch.
 	Tasks []string `bson:"tasks"`
 
-	// RegexBuildVariants is a list of regular expressions to match build variants associated with the patch
+	// RegexBuildVariants is a list of regular expressions to match build variants associated with the patch.
 	RegexBuildVariants []string `bson:"regex_variants,omitempty"`
 
-	// Tasks is a list of regular expressions to match tasks associated with the patch
+	// RegexTasks is a list of regular expressions to match tasks associated with the patch.
 	RegexTasks []string `bson:"regex_tasks,omitempty"`
 
-	// Parameters is a list of parameters to use with the task
+	// Parameters is a list of parameters to use with the task.
 	Parameters []Parameter `bson:"parameters,omitempty"`
 
 	// SyncAtEndOpts describe behavior for task sync at the end of the task.
 	SyncAtEndOpts SyncAtEndOptions `bson:"sync_at_end_opts,omitempty"`
 
-	// Finalize is whether or not the patch should finalized
+	// Finalize is whether or not the patch should finalized.
 	Finalize bool `bson:"finalize"`
 
 	// Module is the name of the module id as represented in the project's
-	// YAML configuration
+	// YAML configuration.
 	Module string `bson:"module"`
 
-	// User is the username of the patch creator
+	// User is the username of the patch creator.
 	User string `bson:"user"`
 
-	// ProjectID is the identifier of project this patch is associated with
+	// ProjectID is the identifier of project this patch is associated with.
 	ProjectID string `bson:"project"`
 
 	// BaseHash is the base hash of the patch.
 	BaseHash string `bson:"base_hash"`
 
-	// CreatedAt is the time that this intent was stored in the database
+	// CreatedAt is the time that this intent was stored in the database.
 	CreatedAt time.Time `bson:"created_at"`
 
 	// Processed indicates whether a patch intent has been processed by the amboy queue.
 	Processed bool `bson:"processed"`
 
-	// ProcessedAt is the time that this intent was processed
+	// ProcessedAt is the time that this intent was processed.
 	ProcessedAt time.Time `bson:"processed_at"`
 
-	// IntentType indicates the type of the patch intent, i.e., GithubIntentType
+	// IntentType indicates the type of the patch intent, i.e., GithubIntentType.
 	IntentType string `bson:"intent_type"`
 
 	// alias defines the variants and tasks to run this patch on.
@@ -82,13 +82,13 @@ type cliIntent struct {
 	// path defines the path to an evergreen project configuration file.
 	Path string `bson:"path"`
 
-	// TriggerAliases alias sets of tasks to include in child patches
+	// TriggerAliases alias sets of tasks to include in child patches.
 	TriggerAliases []string `bson:"trigger_aliases"`
 
-	// BackportOf specifies what to backport
+	// BackportOf specifies what to backport.
 	BackportOf BackportInfo `bson:"backport_of,omitempty"`
 
-	// GitInfo contains information about the author's git environment
+	// GitInfo contains information about the author's git environment.
 	GitInfo *GitMetadata `bson:"git_info,omitempty"`
 
 	RepeatDefinition bool `bson:"reuse_definition"`

--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -36,6 +36,12 @@ type cliIntent struct {
 	// Tasks is a list of tasks associated with the patch
 	Tasks []string `bson:"tasks"`
 
+	// RegexBuildVariants is a list of regular expressions to match build variants associated with the patch
+	RegexBuildVariants []string `bson:"regex_variants,omitempty"`
+
+	// Tasks is a list of regular expressions to match tasks associated with the patch
+	RegexTasks []string `bson:"regex_tasks,omitempty"`
+
 	// Parameters is a list of parameters to use with the task
 	Parameters []Parameter `bson:"parameters,omitempty"`
 
@@ -183,21 +189,23 @@ func (g *cliIntent) GetCalledBy() string {
 // NewPatch creates a patch from the intent
 func (c *cliIntent) NewPatch() *Patch {
 	p := Patch{
-		Description:   c.Description,
-		Author:        c.User,
-		Project:       c.ProjectID,
-		Githash:       c.BaseHash,
-		Path:          c.Path,
-		Status:        evergreen.PatchCreated,
-		BuildVariants: c.BuildVariants,
-		Parameters:    c.Parameters,
-		Alias:         c.Alias,
-		Triggers:      TriggerInfo{Aliases: c.TriggerAliases},
-		Tasks:         c.Tasks,
-		SyncAtEndOpts: c.SyncAtEndOpts,
-		BackportOf:    c.BackportOf,
-		Patches:       []ModulePatch{},
-		GitInfo:       c.GitInfo,
+		Description:        c.Description,
+		Author:             c.User,
+		Project:            c.ProjectID,
+		Githash:            c.BaseHash,
+		Path:               c.Path,
+		Status:             evergreen.PatchCreated,
+		BuildVariants:      c.BuildVariants,
+		RegexBuildVariants: c.RegexBuildVariants,
+		Parameters:         c.Parameters,
+		Alias:              c.Alias,
+		Triggers:           TriggerInfo{Aliases: c.TriggerAliases},
+		Tasks:              c.Tasks,
+		RegexTasks:         c.RegexTasks,
+		SyncAtEndOpts:      c.SyncAtEndOpts,
+		BackportOf:         c.BackportOf,
+		Patches:            []ModulePatch{},
+		GitInfo:            c.GitInfo,
 	}
 	if len(c.PatchFileID) > 0 {
 		p.Patches = append(p.Patches,
@@ -226,6 +234,8 @@ type CLIIntentParams struct {
 	Parameters       []Parameter
 	Variants         []string
 	Tasks            []string
+	RegexVariants    []string
+	RegexTasks       []string
 	Alias            string
 	TriggerAliases   []string
 	RepeatDefinition bool
@@ -270,26 +280,28 @@ func NewCliIntent(params CLIIntentParams) (Intent, error) {
 	}
 
 	return &cliIntent{
-		DocumentID:       mgobson.NewObjectId().Hex(),
-		IntentType:       CliIntentType,
-		PatchContent:     params.PatchContent,
-		Path:             params.Path,
-		Description:      params.Description,
-		BuildVariants:    params.Variants,
-		Tasks:            params.Tasks,
-		Parameters:       params.Parameters,
-		SyncAtEndOpts:    params.SyncParams,
-		User:             params.User,
-		ProjectID:        params.Project,
-		BaseHash:         params.BaseGitHash,
-		Finalize:         params.Finalize,
-		Module:           params.Module,
-		Alias:            params.Alias,
-		TriggerAliases:   params.TriggerAliases,
-		BackportOf:       params.BackportOf,
-		GitInfo:          params.GitInfo,
-		RepeatDefinition: params.RepeatDefinition,
-		RepeatFailed:     params.RepeatFailed,
+		DocumentID:         mgobson.NewObjectId().Hex(),
+		IntentType:         CliIntentType,
+		PatchContent:       params.PatchContent,
+		Path:               params.Path,
+		Description:        params.Description,
+		BuildVariants:      params.Variants,
+		Tasks:              params.Tasks,
+		RegexBuildVariants: params.RegexVariants,
+		RegexTasks:         params.RegexTasks,
+		Parameters:         params.Parameters,
+		SyncAtEndOpts:      params.SyncParams,
+		User:               params.User,
+		ProjectID:          params.Project,
+		BaseHash:           params.BaseGitHash,
+		Finalize:           params.Finalize,
+		Module:             params.Module,
+		Alias:              params.Alias,
+		TriggerAliases:     params.TriggerAliases,
+		BackportOf:         params.BackportOf,
+		GitInfo:            params.GitInfo,
+		RepeatDefinition:   params.RepeatDefinition,
+		RepeatFailed:       params.RepeatFailed,
 	}, nil
 }
 

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -138,25 +138,27 @@ type GitMetadata struct {
 
 // Patch stores all details related to a patch request
 type Patch struct {
-	Id            mgobson.ObjectId `bson:"_id,omitempty"`
-	Description   string           `bson:"desc"`
-	Path          string           `bson:"path,omitempty"`
-	Project       string           `bson:"branch"`
-	Githash       string           `bson:"githash"`
-	PatchNumber   int              `bson:"patch_number"`
-	Author        string           `bson:"author"`
-	Version       string           `bson:"version"`
-	Status        string           `bson:"status"`
-	CreateTime    time.Time        `bson:"create_time"`
-	StartTime     time.Time        `bson:"start_time"`
-	FinishTime    time.Time        `bson:"finish_time"`
-	BuildVariants []string         `bson:"build_variants"`
-	Tasks         []string         `bson:"tasks"`
-	VariantsTasks []VariantTasks   `bson:"variants_tasks"`
-	SyncAtEndOpts SyncAtEndOptions `bson:"sync_at_end_opts,omitempty"`
-	Patches       []ModulePatch    `bson:"patches"`
-	Parameters    []Parameter      `bson:"parameters,omitempty"`
-	Activated     bool             `bson:"activated"`
+	Id                 mgobson.ObjectId `bson:"_id,omitempty"`
+	Description        string           `bson:"desc"`
+	Path               string           `bson:"path,omitempty"`
+	Project            string           `bson:"branch"`
+	Githash            string           `bson:"githash"`
+	PatchNumber        int              `bson:"patch_number"`
+	Author             string           `bson:"author"`
+	Version            string           `bson:"version"`
+	Status             string           `bson:"status"`
+	CreateTime         time.Time        `bson:"create_time"`
+	StartTime          time.Time        `bson:"start_time"`
+	FinishTime         time.Time        `bson:"finish_time"`
+	BuildVariants      []string         `bson:"build_variants"`
+	RegexBuildVariants []string         `bson:"regex_build_variants"`
+	Tasks              []string         `bson:"tasks"`
+	RegexTasks         []string         `bson:"regex_tasks"`
+	VariantsTasks      []VariantTasks   `bson:"variants_tasks"`
+	SyncAtEndOpts      SyncAtEndOptions `bson:"sync_at_end_opts,omitempty"`
+	Patches            []ModulePatch    `bson:"patches"`
+	Parameters         []Parameter      `bson:"parameters,omitempty"`
+	Activated          bool             `bson:"activated"`
 	// PatchedParserProject is mismatched with its BSON tag since the tag already exists in the DB.
 	// Struct property has been renamed to convey that only parser project configs are stored in it.
 	PatchedParserProject string                 `bson:"patched_config"`

--- a/model/project.go
+++ b/model/project.go
@@ -1487,10 +1487,10 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 			bvRegex, err := regexp.Compile(bv)
 			if err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
-					"message":  "compiling buildvariant regex",
-					"regex":    bv,
-					"project":  p.Identifier,
-					"patchDoc": patchDoc.Id,
+					"message":   "compiling buildvariant regex",
+					"regex":     bv,
+					"project":   p.Identifier,
+					"patch_doc": patchDoc.Id,
 				}))
 				continue
 			}
@@ -1510,14 +1510,14 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 			tRegex, err := regexp.Compile(t)
 			if err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
-					"message":  "compiling task regex",
-					"regex":    t,
-					"project":  p.Identifier,
-					"patchDoc": patchDoc.Id,
+					"message":   "compiling task regex",
+					"regex":     t,
+					"project":   p.Identifier,
+					"patch_doc": patchDoc.Id,
 				}))
 				continue
 			}
-			tasks = append(bvs, p.findMatchingProjectTasks(tRegex)...)
+			tasks = append(tasks, p.findMatchingProjectTasks(tRegex)...)
 		}
 	}
 	var pairs TaskVariantPairs

--- a/model/project.go
+++ b/model/project.go
@@ -1517,6 +1517,9 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 				continue
 			}
 			tSearch = p.FindMatchingProjectTasks(tRegex)
+			if len(tSearch) == 0 {
+				tasks = append(tasks, t)
+			}
 		}
 		for _, t := range tSearch {
 			if !utility.FromBoolTPtr(t.Patchable) || utility.FromBoolPtr(t.GitTagOnly) {

--- a/model/project.go
+++ b/model/project.go
@@ -1487,9 +1487,10 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 			bvRegex, err := regexp.Compile(bv)
 			if err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
-					"message": "compiling buildvariant regex",
-					"regex":   bv,
-					"project": p.Identifier,
+					"message":  "compiling buildvariant regex",
+					"regex":    bv,
+					"project":  p.Identifier,
+					"patchDoc": patchDoc.Id,
 				}))
 				continue
 			}
@@ -1509,9 +1510,10 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 			tRegex, err := regexp.Compile(t)
 			if err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
-					"message": "compiling task regex",
-					"regex":   t,
-					"project": p.Identifier,
+					"message":  "compiling task regex",
+					"regex":    t,
+					"project":  p.Identifier,
+					"patchDoc": patchDoc.Id,
 				}))
 				continue
 			}

--- a/model/project.go
+++ b/model/project.go
@@ -1294,6 +1294,19 @@ func (p *Project) FindBuildVariant(build string) *BuildVariant {
 	return nil
 }
 
+func (p *Project) FindMatchingBuildVariants(bvRegex *regexp.Regexp) []string {
+	var res []string
+	if bvRegex.String() == "all" || bvRegex.String() == "" {
+		return append(res, bvRegex.String())
+	}
+	for _, b := range p.BuildVariants {
+		if bvRegex.MatchString(b.Name) {
+			res = append(res, b.Name)
+		}
+	}
+	return res
+}
+
 // GetTaskNameAndTags checks the project for a task or task group matching the
 // build variant task unit, and returns the name and tags
 func (p *Project) GetTaskNameAndTags(bvt BuildVariantTaskUnit) (string, []string, bool) {
@@ -1319,6 +1332,19 @@ func (p *Project) FindProjectTask(name string) *ProjectTask {
 		}
 	}
 	return nil
+}
+
+func (p *Project) FindMatchingProjectTasks(tRegex *regexp.Regexp) []string {
+	var res []string
+	if tRegex.String() == "all" || tRegex.String() == "" {
+		return append(res, tRegex.String())
+	}
+	for _, t := range p.Tasks {
+		if tRegex.MatchString(t.Name) {
+			res = append(res, t.Name)
+		}
+	}
+	return res
 }
 
 func (p *Project) GetModuleByName(name string) (*Module, error) {
@@ -1450,8 +1476,15 @@ func (p *Project) BuildProjectTVPairs(patchDoc *patch.Patch, alias string) {
 // mapping of the build variant to the tasks that will run on that build
 // variant. If includeDeps is set, it will also resolve task dependencies.
 func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string, includeDeps bool) (resolvedBVs []string, resolvedTasks []string, vts []patch.VariantTasks) {
-	bvs := patchDoc.BuildVariants
-	tasks := patchDoc.Tasks
+	var bvs, tasks []string
+	for _, bv := range patchDoc.BuildVariants {
+		bvRegex, _ := regexp.Compile(bv)
+		bvs = append(bvs, p.FindMatchingBuildVariants(bvRegex)...)
+	}
+	for _, t := range patchDoc.Tasks {
+		tRegex, _ := regexp.Compile(t)
+		tasks = append(tasks, p.FindMatchingProjectTasks(tRegex)...)
+	}
 	if len(bvs) == 1 && bvs[0] == "all" {
 		bvs = []string{}
 		for _, bv := range p.BuildVariants {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -805,12 +805,37 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 }
 
 func (s *projectSuite) TestResolvePatchVTs() {
+	// Specifying all.
 	patchDoc := patch.Patch{
+		BuildVariants: []string{"all"},
+		Tasks:         []string{"all"},
+	}
+
+	bvs, tasks, variantTasks := s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	s.Len(bvs, 2)
+	s.Len(tasks, 6)
+	s.Len(variantTasks, 2)
+
+	// Build variant and tasks override regex.
+	patchDoc = patch.Patch{
+		BuildVariants:      []string{"all"},
+		Tasks:              []string{"all"},
+		RegexBuildVariants: []string{"^bv_"},
+		RegexTasks:         []string{"_1$"},
+	}
+
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	s.Len(bvs, 2)
+	s.Len(tasks, 6)
+	s.Len(variantTasks, 2)
+
+	// Regex build variants and tasks.
+	patchDoc = patch.Patch{
 		RegexBuildVariants: []string{".*"},
 		RegexTasks:         []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks := s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -823,9 +848,75 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		s.Contains(vt.Tasks, "a_task_1")
 		s.Contains(vt.Tasks, "b_task_1")
 		s.Empty(vt.DisplayTasks)
-		if vt.Variant != "bv_1" && vt.Variant != "bv_2" {
-			s.T().Fail()
-		}
+		s.Contains([]string{"bv_1", "bv_2"}, vt.Variant)
+	}
+
+	// Specifying all build variants and giving it regex tasks.
+	patchDoc = patch.Patch{
+		BuildVariants: []string{"all"},
+		RegexTasks:    []string{"_1$"},
+	}
+
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	s.Len(bvs, 2)
+	s.Contains(bvs, "bv_1")
+	s.Contains(bvs, "bv_2")
+	s.Len(tasks, 2)
+	s.Contains(tasks, "a_task_1")
+	s.Contains(tasks, "b_task_1")
+	s.Len(variantTasks, 2)
+	for _, vt := range variantTasks {
+		s.Len(vt.Tasks, 2)
+		s.Contains(vt.Tasks, "a_task_1")
+		s.Contains(vt.Tasks, "b_task_1")
+		s.Empty(vt.DisplayTasks)
+		s.Contains([]string{"bv_1", "bv_2"}, vt.Variant)
+	}
+
+	// Specifying build variants and giving it regex tasks.
+	patchDoc = patch.Patch{
+		BuildVariants: []string{"bv_1", "bv_2"},
+		RegexTasks:    []string{"_1$"},
+	}
+
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	s.Len(bvs, 2)
+	s.Contains(bvs, "bv_1")
+	s.Contains(bvs, "bv_2")
+	s.Len(tasks, 2)
+	s.Contains(tasks, "a_task_1")
+	s.Contains(tasks, "b_task_1")
+	s.Len(variantTasks, 2)
+	for _, vt := range variantTasks {
+		s.Len(vt.Tasks, 2)
+		s.Contains(vt.Tasks, "a_task_1")
+		s.Contains(vt.Tasks, "b_task_1")
+		s.Empty(vt.DisplayTasks)
+		s.Contains([]string{"bv_1", "bv_2"}, vt.Variant)
+	}
+
+	// Alias adds on to the selected regex tasks.
+	patchDoc = patch.Patch{
+		RegexBuildVariants: []string{".*"},
+		RegexTasks:         []string{"_1$"},
+	}
+
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "aTags", true)
+	s.Len(bvs, 2)
+	s.Contains(bvs, "bv_1")
+	s.Contains(bvs, "bv_2")
+	s.Len(tasks, 3)
+	s.Contains(tasks, "a_task_1")
+	s.Contains(tasks, "a_task_2")
+	s.Contains(tasks, "b_task_1")
+	s.Len(variantTasks, 2)
+	for _, vt := range variantTasks {
+		s.Len(vt.Tasks, 3)
+		s.Contains(vt.Tasks, "a_task_1")
+		s.Contains(vt.Tasks, "a_task_2")
+		s.Contains(vt.Tasks, "b_task_1")
+		s.Empty(vt.DisplayTasks)
+		s.Contains([]string{"bv_1", "bv_2"}, vt.Variant)
 	}
 }
 

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -804,6 +804,31 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 	s.Len(patchDoc.Tasks, 6)
 }
 
+func (s *projectSuite) TestResolvePatchVTs() {
+	patchDoc := patch.Patch{
+		RegexBuildVariants: []string{".*"},
+		RegexTasks:         []string{"_1$"},
+	}
+
+	bvs, tasks, variantTasks := s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	s.Len(bvs, 2)
+	s.Contains(bvs, "bv_1")
+	s.Contains(bvs, "bv_2")
+	s.Len(tasks, 2)
+	s.Contains(tasks, "a_task_1")
+	s.Contains(tasks, "b_task_1")
+	s.Len(variantTasks, 2)
+	for _, vt := range variantTasks {
+		s.Len(vt.Tasks, 2)
+		s.Contains(vt.Tasks, "a_task_1")
+		s.Contains(vt.Tasks, "b_task_1")
+		s.Empty(vt.DisplayTasks)
+		if vt.Variant != "bv_1" && vt.Variant != "bv_2" {
+			s.T().Fail()
+		}
+	}
+}
+
 func (s *projectSuite) TestBuildProjectTVPairsWithAlias() {
 	patchDoc := patch.Patch{}
 

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -20,6 +20,7 @@ const (
 	skipConfirmFlagName       = "skip_confirm"
 	yesFlagName               = "yes"
 	variantsFlagName          = "variants"
+	regexVariantsFlagName     = "regex_variants"
 	tasksFlagName             = "tasks"
 	regexTasksFlagName        = "regex_tasks"
 	parameterFlagName         = "param"

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -21,6 +21,7 @@ const (
 	yesFlagName               = "yes"
 	variantsFlagName          = "variants"
 	tasksFlagName             = "tasks"
+	regexTasksFlagName        = "regex_tasks"
 	parameterFlagName         = "param"
 	patchAliasFlagName        = "alias"
 	patchFinalizeFlagName     = "finalize"

--- a/operations/http.go
+++ b/operations/http.go
@@ -530,6 +530,8 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		Alias             string             `json:"alias"`
 		Variants          []string           `json:"buildvariants_new"`
 		Tasks             []string           `json:"tasks"`
+		RegexVariants     []string           `json:"regex_buildvariants"`
+		RegexTasks        []string           `json:"regex_tasks"`
 		SyncTasks         []string           `json:"sync_tasks"`
 		SyncBuildVariants []string           `json:"sync_build_variants"`
 		SyncStatuses      []string           `json:"sync_statuses"`
@@ -551,6 +553,8 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		Alias:             incomingPatch.alias,
 		Variants:          incomingPatch.variants,
 		Tasks:             incomingPatch.tasks,
+		RegexVariants:     incomingPatch.regexVariants,
+		RegexTasks:        incomingPatch.regexTasks,
 		SyncBuildVariants: incomingPatch.syncBuildVariants,
 		SyncTasks:         incomingPatch.syncTasks,
 		SyncStatuses:      incomingPatch.syncStatuses,

--- a/operations/model.go
+++ b/operations/model.go
@@ -321,6 +321,7 @@ func (s *ClientSettings) SetDefaultTasks(project string, tasks ...string) {
 			return
 		}
 	}
+	grip.Debug(tasks)
 	s.Projects = append(s.Projects, ClientProjectConf{
 		Name:     project,
 		Default:  true,

--- a/operations/model.go
+++ b/operations/model.go
@@ -321,7 +321,6 @@ func (s *ClientSettings) SetDefaultTasks(project string, tasks ...string) {
 			return
 		}
 	}
-	grip.Debug(tasks)
 	s.Projects = append(s.Projects, ClientProjectConf{
 		Name:     project,
 		Default:  true,

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -69,6 +69,14 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 				Name:  pathFlagName,
 				Usage: "path to an evergreen project configuration file",
 			},
+			cli.StringSliceFlag{
+				Name:  joinFlagNames(regexVariantsFlagName, "rv"),
+				Usage: "regex variant names",
+			},
+			cli.StringSliceFlag{
+				Name:  joinFlagNames(regexTasksFlagName, "rt"),
+				Usage: "regex task names",
+			},
 		))
 }
 
@@ -101,6 +109,8 @@ func Patch() cli.Command {
 				Path:              c.String(pathFlagName),
 				Variants:          utility.SplitCommas(c.StringSlice(variantsFlagName)),
 				Tasks:             utility.SplitCommas(c.StringSlice(tasksFlagName)),
+				RegexVariants:     utility.SplitCommas(c.StringSlice(regexVariantsFlagName)),
+				RegexTasks:        utility.SplitCommas(c.StringSlice(regexTasksFlagName)),
 				SyncBuildVariants: utility.SplitCommas(c.StringSlice(syncBuildVariantsFlagName)),
 				SyncTasks:         utility.SplitCommas(c.StringSlice(syncTasksFlagName)),
 				SyncStatuses:      utility.SplitCommas(c.StringSlice(syncStatusesFlagName)),

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -59,6 +59,8 @@ type patchParams struct {
 	Alias             string
 	Variants          []string
 	Tasks             []string
+	RegexVariants     []string
+	RegexTasks        []string
 	SyncBuildVariants []string
 	SyncTasks         []string
 	SyncStatuses      []string
@@ -89,6 +91,8 @@ type patchSubmission struct {
 	path              string
 	variants          []string
 	tasks             []string
+	regexVariants     []string
+	regexTasks        []string
 	syncBuildVariants []string
 	syncTasks         []string
 	syncStatuses      []string
@@ -111,6 +115,8 @@ func (p *patchParams) createPatch(ac *legacyClient, diffData *localDiff) (*patch
 		base:              diffData.base,
 		variants:          p.Variants,
 		tasks:             p.Tasks,
+		regexVariants:     p.RegexVariants,
+		regexTasks:        p.RegexTasks,
 		alias:             p.Alias,
 		syncBuildVariants: p.SyncBuildVariants,
 		syncTasks:         p.SyncTasks,

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -59,6 +59,7 @@ type patchParams struct {
 	Alias             string
 	Variants          []string
 	Tasks             []string
+	RegexTasks        []string
 	SyncBuildVariants []string
 	SyncTasks         []string
 	SyncStatuses      []string
@@ -373,7 +374,7 @@ func (p *patchParams) loadTasks(conf *ClientSettings) error {
 				p.Tasks, p.Project), false) {
 			conf.SetDefaultTasks(p.Project, p.Tasks...)
 			if err := conf.Write(""); err != nil {
-				return errors.Wrap(err, "error setting default tasks")
+				return errors.Wrap(err, "setting default tasks")
 			}
 		}
 	} else if p.Alias == "" {

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -59,7 +59,6 @@ type patchParams struct {
 	Alias             string
 	Variants          []string
 	Tasks             []string
-	RegexTasks        []string
 	SyncBuildVariants []string
 	SyncTasks         []string
 	SyncStatuses      []string

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -51,6 +51,8 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		Parameters        []patch.Parameter  `json:"parameters"`
 		Variants          []string           `json:"buildvariants_new"`
 		Tasks             []string           `json:"tasks"`
+		RegexVariants     []string           `json:"regex_buildvariants"`
+		RegexTasks        []string           `json:"regex_tasks"`
 		SyncBuildVariants []string           `json:"sync_build_variants"`
 		SyncTasks         []string           `json:"sync_tasks"`
 		SyncStatuses      []string           `json:"sync_statuses"`
@@ -159,6 +161,8 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		Parameters:       data.Parameters,
 		Variants:         data.Variants,
 		Tasks:            data.Tasks,
+		RegexVariants:    data.RegexVariants,
+		RegexTasks:       data.RegexTasks,
 		Alias:            data.Alias,
 		TriggerAliases:   data.TriggerAliases,
 		BackportOf:       data.BackportInfo,

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -314,26 +314,25 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		}
 		bvRegex, err := regexp.Compile(buildVariant)
 		if err != nil {
-			return errors.Wrapf(err, "unable to compile regex %s", buildVariant)
+			return errors.Wrapf(err, "compiling buildvariant regex %s", buildVariant)
 		}
 		bvs := project.FindMatchingBuildVariants(bvRegex)
 		if len(bvs) == 0 {
-			return errors.Errorf("No such buildvariant matching '%s'", buildVariant)
+			return errors.Errorf("no such buildvariant matching '%s'", buildVariant)
 		}
 	}
 
-	// verify that all tasks exists
 	for _, task := range patchDoc.Tasks {
 		if task == "all" || task == "" {
 			continue
 		}
 		tRegex, err := regexp.Compile(task)
 		if err != nil {
-			return errors.Wrapf(err, "unable to compile regex %s", task)
+			return errors.Wrapf(err, "compiling task regex %s", task)
 		}
 		tasks := project.FindMatchingProjectTasks(tRegex)
 		if len(tasks) == 0 {
-			return errors.Errorf("No such task matching '%s'", task)
+			return errors.Errorf("no such task matching '%s'", task)
 		}
 	}
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -312,12 +311,8 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		if buildVariant == "all" || buildVariant == "" {
 			continue
 		}
-		bvRegex, err := regexp.Compile(buildVariant)
-		if err != nil {
-			return errors.Wrapf(err, "compiling buildvariant regex %s", buildVariant)
-		}
-		bvs := project.FindMatchingBuildVariants(bvRegex)
-		if len(bvs) == 0 {
+		bv := project.FindBuildVariant(buildVariant)
+		if bv == nil {
 			return errors.Errorf("no such buildvariant matching '%s'", buildVariant)
 		}
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -314,6 +315,19 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		bv := project.FindBuildVariant(buildVariant)
 		if bv == nil {
 			return errors.Errorf("no such buildvariant matching '%s'", buildVariant)
+		}
+	}
+
+	for _, bv := range patchDoc.RegexBuildVariants {
+		_, err := regexp.Compile(bv)
+		if err != nil {
+			return errors.Wrapf(err, "compiling buildvariant regex '%s'", bv)
+		}
+	}
+	for _, t := range patchDoc.RegexTasks {
+		_, err := regexp.Compile(t)
+		if err != nil {
+			return errors.Wrapf(err, "compiling task regex '%s'", t)
 		}
 	}
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -322,20 +322,6 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		}
 	}
 
-	for _, task := range patchDoc.Tasks {
-		if task == "all" || task == "" {
-			continue
-		}
-		tRegex, err := regexp.Compile(task)
-		if err != nil {
-			return errors.Wrapf(err, "compiling task regex %s", task)
-		}
-		tasks := project.FindMatchingProjectTasks(tRegex)
-		if len(tasks) == 0 {
-			return errors.Errorf("no such task matching '%s'", task)
-		}
-	}
-
 	if len(patchDoc.VariantsTasks) == 0 {
 		project.BuildProjectTVPairs(patchDoc, j.intent.GetAlias())
 	}


### PR DESCRIPTION
[EVG-6741](https://jira.mongodb.org/browse/EVG-6741)

### Description 
users can now pass in regex to regextasks and regexvariants flag 

### Testing 
unit test 

tested on staging with command 
`~/go/src/github.com/evergreen-ci/evergreen/clients/darwin_amd64/evergreen -c ~/.evergreen-staging.yml patch -u -v ".*" -t ".*"` 
to schedule all patchable 


also tested with: 
-v all -t all (still works)
-v ".*" -t all (and vise versa)
-v ".*" -t "task$" 
leaving it empty

all works as expected 