### PR TITLE
EVG-16735 fetch github status field to calculate check status

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1023,13 +1023,18 @@ func updateVersionGithubStatus(v *Version, builds []build.Build) error {
 
 // Update the status of the version based on its constituent builds
 func UpdateVersionStatus(v *Version) (string, error) {
-	builds, err := build.Find(build.ByVersion(v.Id).WithFields(build.ActivatedKey, build.StatusKey, build.IsGithubCheckKey, build.AbortedKey))
+	builds, err := build.Find(build.ByVersion(v.Id).WithFields(build.ActivatedKey, build.StatusKey,
+		build.IsGithubCheckKey, build.GithubCheckStatusKey, build.AbortedKey))
 	if err != nil {
 		return "", errors.Wrapf(err, "getting builds for version '%s'", v.Id)
 	}
 
-	versionStatus := getVersionStatus(builds)
+	// Regardless of whether the overall version status has changed, the Github status subset may have changed.
+	if err = updateVersionGithubStatus(v, builds); err != nil {
+		return "", errors.Wrap(err, "updating version GitHub status")
+	}
 
+	versionStatus := getVersionStatus(builds)
 	if versionStatus == v.Status {
 		return versionStatus, nil
 	}
@@ -1058,10 +1063,6 @@ func UpdateVersionStatus(v *Version) (string, error) {
 		if err = v.UpdateStatus(versionStatus); err != nil {
 			return "", errors.Wrapf(err, "updating version '%s' with status '%s'", v.Id, versionStatus)
 		}
-	}
-
-	if err = updateVersionGithubStatus(v, builds); err != nil {
-		return "", errors.Wrap(err, "updating version GitHub status")
 	}
 
 	return versionStatus, nil


### PR DESCRIPTION
[EVG-16735](https://jira.mongodb.org/browse/EVG-16735)

### Description 
The github check field got lost in a refactor, meaning that UpdateVersionGithubStatus wasn't using the right field.

### Testing 
Added unit test (which failed pre-changes).