### PR TITLE
EVG-16732 Fetch AMI and projectIdentifier for previous executions

### DIFF
--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -181,6 +181,10 @@ func (at *APITask) BuildPreviousExecutions(tasks []task.Task, url string) error 
 		if err := at.PreviousExecutions[i].GetArtifacts(); err != nil {
 			return errors.Wrap(err, "failed to fetch artifacts for previous executions")
 		}
+		if err := at.GetAMI(); err != nil {
+			return errors.Wrap(err, "failed to fetch AMI for previous executions")
+		}
+		at.GetProjectIdentifier()
 	}
 
 	return nil


### PR DESCRIPTION
[EVG-16732](https://jira.mongodb.org/browse/EVG-16732)

### Description 
Forgot to do this for previous executions
