### PR TITLE
EVG-16682: correctly detect legacy lobster URLS

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -367,13 +367,13 @@ func (tr TestResult) GetDisplayTestName() string {
 // generation for other log viewers.
 func (tr TestResult) GetLogURL(viewer evergreen.LogViewer) string {
 	root := evergreen.GetEnvironment().Settings().ApiUrl
-	deprecatedLobsterURL := "https://logkeeper.mongodb.org/lobster"
+	deprecatedLobsterURL := "https://logkeeper.mongodb.org"
 
 	switch viewer {
 	case evergreen.LogViewerHTML:
 		if tr.URL != "" {
-			if strings.Contains(tr.URL+"/lobster", deprecatedLobsterURL) {
-				return strings.Replace(tr.URL, deprecatedLobsterURL, root, 1)
+			if strings.Contains(tr.URL, deprecatedLobsterURL) {
+				return strings.Replace(tr.URL, deprecatedLobsterURL, root+"/lobster", 1)
 			}
 
 			// Some test results may have internal URLs that are


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-16682

### Description 
Update the task log URL generation function to correctly check for deprecated Logkeeper-hosted Lobster links.

### Testing 
 N/A