### PR TITLE
EVG-16562: do not reuse AWS API log message between retries

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -204,10 +204,10 @@ func (c *awsClientImpl) RunInstances(ctx context.Context, input *ec2.RunInstance
 	var output *ec2.Reservation
 	var err error
 	input.SetClientToken(utility.RandomString())
-	msg := makeAWSLogMessage("RunInstances", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("RunInstances", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.RunInstancesWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -231,10 +231,10 @@ func (c *awsClientImpl) RunInstances(ctx context.Context, input *ec2.RunInstance
 func (c *awsClientImpl) DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
 	var output *ec2.DescribeInstancesOutput
 	var err error
-	msg := makeAWSLogMessage("DescribeInstances", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DescribeInstances", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DescribeInstancesWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -254,10 +254,10 @@ func (c *awsClientImpl) DescribeInstances(ctx context.Context, input *ec2.Descri
 func (c *awsClientImpl) ModifyInstanceAttribute(ctx context.Context, input *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
 	var output *ec2.ModifyInstanceAttributeOutput
 	var err error
-	msg := makeAWSLogMessage("ModifyInstanceAttribute", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("ModifyInstanceAttribute", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.ModifyInstanceAttributeWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -277,10 +277,10 @@ func (c *awsClientImpl) ModifyInstanceAttribute(ctx context.Context, input *ec2.
 func (c *awsClientImpl) DescribeInstanceTypeOfferings(ctx context.Context, input *ec2.DescribeInstanceTypeOfferingsInput) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
 	var output *ec2.DescribeInstanceTypeOfferingsOutput
 	var err error
-	msg := makeAWSLogMessage("DescribeInstanceTypeOfferings", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DescribeInstanceTypeOfferings", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DescribeInstanceTypeOfferingsWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -301,10 +301,10 @@ func (c *awsClientImpl) DescribeInstanceTypeOfferings(ctx context.Context, input
 func (c *awsClientImpl) CreateTags(ctx context.Context, input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
 	var output *ec2.CreateTagsOutput
 	var err error
-	msg := makeAWSLogMessage("CreateTags", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("CreateTags", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.CreateTagsWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -325,10 +325,10 @@ func (c *awsClientImpl) CreateTags(ctx context.Context, input *ec2.CreateTagsInp
 func (c *awsClientImpl) DeleteTags(ctx context.Context, input *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
 	var output *ec2.DeleteTagsOutput
 	var err error
-	msg := makeAWSLogMessage("DeleteTags", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DeleteTags", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DeleteTagsWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -349,10 +349,10 @@ func (c *awsClientImpl) DeleteTags(ctx context.Context, input *ec2.DeleteTagsInp
 func (c *awsClientImpl) TerminateInstances(ctx context.Context, input *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
 	var output *ec2.TerminateInstancesOutput
 	var err error
-	msg := makeAWSLogMessage("TerminateInstances", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("TerminateInstances", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.TerminateInstancesWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -384,10 +384,10 @@ func (c *awsClientImpl) TerminateInstances(ctx context.Context, input *ec2.Termi
 func (c *awsClientImpl) StopInstances(ctx context.Context, input *ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error) {
 	var output *ec2.StopInstancesOutput
 	var err error
-	msg := makeAWSLogMessage("StopInstances", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("StopInstances", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.StopInstancesWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -408,10 +408,10 @@ func (c *awsClientImpl) StopInstances(ctx context.Context, input *ec2.StopInstan
 func (c *awsClientImpl) StartInstances(ctx context.Context, input *ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error) {
 	var output *ec2.StartInstancesOutput
 	var err error
-	msg := makeAWSLogMessage("StartInstances", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("StartInstances", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.StartInstancesWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -433,10 +433,10 @@ func (c *awsClientImpl) RequestSpotInstances(ctx context.Context, input *ec2.Req
 	var output *ec2.RequestSpotInstancesOutput
 	var err error
 	input.SetClientToken(utility.RandomString())
-	msg := makeAWSLogMessage("RequestSpotInstances", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("RequestSpotInstances", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.RequestSpotInstancesWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -457,10 +457,10 @@ func (c *awsClientImpl) RequestSpotInstances(ctx context.Context, input *ec2.Req
 func (c *awsClientImpl) DescribeSpotInstanceRequests(ctx context.Context, input *ec2.DescribeSpotInstanceRequestsInput) (*ec2.DescribeSpotInstanceRequestsOutput, error) {
 	var output *ec2.DescribeSpotInstanceRequestsOutput
 	var err error
-	msg := makeAWSLogMessage("DescribeSpotInstanceRequests", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DescribeSpotInstanceRequests", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DescribeSpotInstanceRequestsWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -534,10 +534,10 @@ func (c *awsClientImpl) GetSpotInstanceId(ctx context.Context, h *host.Host) (st
 func (c *awsClientImpl) CancelSpotInstanceRequests(ctx context.Context, input *ec2.CancelSpotInstanceRequestsInput) (*ec2.CancelSpotInstanceRequestsOutput, error) {
 	var output *ec2.CancelSpotInstanceRequestsOutput
 	var err error
-	msg := makeAWSLogMessage("CancelSpotInstanceRequests", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("CancelSpotInstanceRequests", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.CancelSpotInstanceRequestsWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -562,10 +562,10 @@ func (c *awsClientImpl) CreateVolume(ctx context.Context, input *ec2.CreateVolum
 	var output *ec2.Volume
 	var err error
 	input.SetClientToken(utility.RandomString())
-	msg := makeAWSLogMessage("CreateVolume", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("CreateVolume", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.CreateVolumeWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -590,10 +590,10 @@ func (c *awsClientImpl) CreateVolume(ctx context.Context, input *ec2.CreateVolum
 func (c *awsClientImpl) DeleteVolume(ctx context.Context, input *ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error) {
 	var output *ec2.DeleteVolumeOutput
 	var err error
-	msg := makeAWSLogMessage("DeleteVolume", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DeleteVolume", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DeleteVolumeWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -618,10 +618,10 @@ func (c *awsClientImpl) DeleteVolume(ctx context.Context, input *ec2.DeleteVolum
 func (c *awsClientImpl) ModifyVolume(ctx context.Context, input *ec2.ModifyVolumeInput) (*ec2.ModifyVolumeOutput, error) {
 	var output *ec2.ModifyVolumeOutput
 	var err error
-	msg := makeAWSLogMessage("ModifyVolume", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("ModifyVolume", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.ModifyVolumeWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -646,10 +646,10 @@ func (c *awsClientImpl) ModifyVolume(ctx context.Context, input *ec2.ModifyVolum
 func (c *awsClientImpl) AttachVolume(ctx context.Context, input *ec2.AttachVolumeInput, opts generateDeviceNameOptions) (*ec2.VolumeAttachment, error) {
 	var output *ec2.VolumeAttachment
 	var err error
-	msg := makeAWSLogMessage("AttachVolume", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("AttachVolume", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.AttachVolumeWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -674,10 +674,10 @@ func (c *awsClientImpl) AttachVolume(ctx context.Context, input *ec2.AttachVolum
 func (c *awsClientImpl) DetachVolume(ctx context.Context, input *ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
 	var output *ec2.VolumeAttachment
 	var err error
-	msg := makeAWSLogMessage("DetachVolume", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DetachVolume", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DetachVolumeWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -700,10 +700,10 @@ func (c *awsClientImpl) DetachVolume(ctx context.Context, input *ec2.DetachVolum
 func (c *awsClientImpl) DescribeVolumes(ctx context.Context, input *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
 	var output *ec2.DescribeVolumesOutput
 	var err error
-	msg := makeAWSLogMessage("DescribeVolumes", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DescribeVolumes", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DescribeVolumesWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -724,10 +724,10 @@ func (c *awsClientImpl) DescribeVolumes(ctx context.Context, input *ec2.Describe
 func (c *awsClientImpl) DescribeSpotPriceHistory(ctx context.Context, input *ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error) {
 	var output *ec2.DescribeSpotPriceHistoryOutput
 	var err error
-	msg := makeAWSLogMessage("DescribeSpotPriceHistory", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DescribeSpotPriceHistory", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DescribeSpotPriceHistoryWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -748,10 +748,10 @@ func (c *awsClientImpl) DescribeSpotPriceHistory(ctx context.Context, input *ec2
 func (c *awsClientImpl) DescribeSubnets(ctx context.Context, input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
 	var output *ec2.DescribeSubnetsOutput
 	var err error
-	msg := makeAWSLogMessage("DescribeSubnets", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DescribeSubnets", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DescribeSubnetsWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -772,10 +772,10 @@ func (c *awsClientImpl) DescribeSubnets(ctx context.Context, input *ec2.Describe
 func (c *awsClientImpl) DescribeVpcs(ctx context.Context, input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
 	var output *ec2.DescribeVpcsOutput
 	var err error
-	msg := makeAWSLogMessage("DescribeVpcs", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DescribeVpcs", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DescribeVpcsWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -824,10 +824,10 @@ func (c *awsClientImpl) GetInstanceInfo(ctx context.Context, id string) (*ec2.In
 func (c *awsClientImpl) CreateKeyPair(ctx context.Context, input *ec2.CreateKeyPairInput) (*ec2.CreateKeyPairOutput, error) {
 	var output *ec2.CreateKeyPairOutput
 	var err error
-	msg := makeAWSLogMessage("CreateKeyPair", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("CreateKeyPair", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.CreateKeyPairWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -847,9 +847,9 @@ func (c *awsClientImpl) CreateKeyPair(ctx context.Context, input *ec2.CreateKeyP
 func (c *awsClientImpl) ImportKeyPair(ctx context.Context, input *ec2.ImportKeyPairInput) (*ec2.ImportKeyPairOutput, error) {
 	var output *ec2.ImportKeyPairOutput
 	var err error
-	msg := makeAWSLogMessage("ImportKeyPair", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx, func() (bool, error) {
+			msg := makeAWSLogMessage("ImportKeyPair", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.ImportKeyPairWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -875,10 +875,10 @@ func (c *awsClientImpl) ImportKeyPair(ctx context.Context, input *ec2.ImportKeyP
 func (c *awsClientImpl) DeleteKeyPair(ctx context.Context, input *ec2.DeleteKeyPairInput) (*ec2.DeleteKeyPairOutput, error) {
 	var output *ec2.DeleteKeyPairOutput
 	var err error
-	msg := makeAWSLogMessage("DeleteKeyPair", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DeleteKeyPair", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DeleteKeyPairWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -899,10 +899,10 @@ func (c *awsClientImpl) DeleteKeyPair(ctx context.Context, input *ec2.DeleteKeyP
 func (c *awsClientImpl) GetProducts(ctx context.Context, input *pricing.GetProductsInput) (*pricing.GetProductsOutput, error) {
 	var output *pricing.GetProductsOutput
 	var err error
-	msg := makeAWSLogMessage("GetProducts", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("GetProducts", fmt.Sprintf("%T", c), input)
 			output, err = c.pricing.GetProductsWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -924,10 +924,10 @@ func (c *awsClientImpl) CreateLaunchTemplate(ctx context.Context, input *ec2.Cre
 	var output *ec2.CreateLaunchTemplateOutput
 	var err error
 	input.SetClientToken(utility.RandomString())
-	msg := makeAWSLogMessage("CreateLaunchTemplate", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("CreateLaunchTemplate", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.CreateLaunchTemplateWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -952,10 +952,10 @@ func (c *awsClientImpl) CreateLaunchTemplate(ctx context.Context, input *ec2.Cre
 func (c *awsClientImpl) GetLaunchTemplates(ctx context.Context, input *ec2.DescribeLaunchTemplatesInput) ([]*ec2.LaunchTemplate, error) {
 	var templates []*ec2.LaunchTemplate
 	var err error
-	msg := makeAWSLogMessage("DescribeLaunchTemplates", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DescribeLaunchTemplates", fmt.Sprintf("%T", c), input)
 			templates = []*ec2.LaunchTemplate{}
 			err = c.EC2.DescribeLaunchTemplatesPagesWithContext(ctx, input, func(output *ec2.DescribeLaunchTemplatesOutput, _ bool) bool {
 				templates = append(templates, output.LaunchTemplates...)
@@ -981,10 +981,10 @@ func (c *awsClientImpl) GetLaunchTemplates(ctx context.Context, input *ec2.Descr
 func (c *awsClientImpl) DeleteLaunchTemplate(ctx context.Context, input *ec2.DeleteLaunchTemplateInput) (*ec2.DeleteLaunchTemplateOutput, error) {
 	var output *ec2.DeleteLaunchTemplateOutput
 	var err error
-	msg := makeAWSLogMessage("DeleteLaunchTemplate", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("DeleteLaunchTemplate", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.DeleteLaunchTemplateWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {
@@ -1006,10 +1006,10 @@ func (c *awsClientImpl) CreateFleet(ctx context.Context, input *ec2.CreateFleetI
 	var output *ec2.CreateFleetOutput
 	var err error
 	input.SetClientToken(utility.RandomString())
-	msg := makeAWSLogMessage("CreateFleet", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			msg := makeAWSLogMessage("CreateFleet", fmt.Sprintf("%T", c), input)
 			output, err = c.EC2.CreateFleetWithContext(ctx, input)
 			if err != nil {
 				if ec2err, ok := err.(awserr.Error); ok {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16562

### Description 
Fix an issue where logging an AWS API error mutates the `message.Fields`, causing the message to spuriously show an error if there's a retry that's successful.

### Testing 
Didn't change any automated tests since we don't test our logging code and this issue only manifest as a log with incorrect fields.