### PR TITLE
EVG-16552 only check dependencies if not modifying the whole version

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -74,7 +74,7 @@ func SetVersionActivation(versionId string, active bool, caller string) error {
 		return errors.Wrapf(err, "setting activation for builds in version '%s'", versionId)
 	}
 
-	return errors.Wrapf(setTaskActivationForBuilds(buildIDs, active, nil, caller),
+	return errors.Wrapf(setTaskActivationForBuilds(buildIDs, active, false, nil, caller),
 		"setting activation for tasks in version '%s'", versionId)
 }
 
@@ -85,14 +85,15 @@ func SetBuildActivation(buildId string, active bool, caller string) error {
 		return errors.Wrapf(err, "setting build activation to %t for build '%s'", active, buildId)
 	}
 
-	return errors.Wrapf(setTaskActivationForBuilds([]string{buildId}, active, nil, caller),
+	return errors.Wrapf(setTaskActivationForBuilds([]string{buildId}, active, true, nil, caller),
 		"setting task activation for build '%s'", buildId)
 }
 
 // setTaskActivationForBuilds updates the "active" state of all tasks in buildIds.
 // It also updates the task cache for the build document.
+// If withDependencies is true, also set dependencies. Don't need to do this when the entire version is affected.
 // If tasks are given to ignore, then we don't activate those tasks.
-func setTaskActivationForBuilds(buildIds []string, active bool, ignoreTasks []string, caller string) error {
+func setTaskActivationForBuilds(buildIds []string, active, withDependencies bool, ignoreTasks []string, caller string) error {
 	// If activating a task, set the ActivatedBy field to be the caller
 	if active {
 		q := bson.M{
@@ -102,18 +103,22 @@ func setTaskActivationForBuilds(buildIds []string, active bool, ignoreTasks []st
 		if len(ignoreTasks) > 0 {
 			q[task.IdKey] = bson.M{"$nin": ignoreTasks}
 		}
-		tasks, err := task.FindAll(db.Query(q).WithFields(task.IdKey, task.DependsOnKey, task.ExecutionKey))
+		tasksToActivate, err := task.FindAll(db.Query(q).WithFields(task.IdKey, task.DependsOnKey, task.ExecutionKey))
 		if err != nil {
 			return errors.Wrap(err, "getting tasks to deactivate")
 		}
-		dependOn, err := task.GetRecursiveDependenciesUp(tasks, nil)
-		if err != nil {
-			return errors.Wrap(err, "getting recursive dependencies")
-		}
+		if withDependencies {
+			dependOn, err := task.GetRecursiveDependenciesUp(tasksToActivate, nil)
+			if err != nil {
+				return errors.Wrap(err, "getting recursive dependencies")
+			}
+			tasksToActivate = append(tasksToActivate, dependOn...)
 
-		if err = task.ActivateTasks(append(tasks, dependOn...), time.Now(), caller); err != nil {
+		}
+		if err = task.ActivateTasks(tasksToActivate, time.Now(), withDependencies, caller); err != nil {
 			return errors.Wrap(err, "updating tasks for activation")
 		}
+
 	} else {
 		query := bson.M{
 			task.BuildIdKey: bson.M{"$in": buildIds},
@@ -128,7 +133,7 @@ func setTaskActivationForBuilds(buildIds []string, active bool, ignoreTasks []st
 		if err != nil {
 			return errors.Wrap(err, "getting tasks to deactivate")
 		}
-		if err = task.DeactivateTasks(tasks, caller); err != nil {
+		if err = task.DeactivateTasks(tasks, withDependencies, caller); err != nil {
 			return errors.Wrap(err, "deactivating tasks")
 		}
 	}
@@ -234,7 +239,7 @@ func SetBuildPriority(buildId string, priority int64, caller string) error {
 		if err != nil {
 			return errors.Wrapf(err, "getting tasks for build '%s'", buildId)
 		}
-		if err = task.DeactivateTasks(tasks, caller); err != nil {
+		if err = task.DeactivateTasks(tasks, true, caller); err != nil {
 			return errors.Wrapf(err, "deactivating tasks for build '%s'", buildId)
 		}
 	}
@@ -259,7 +264,7 @@ func SetVersionPriority(versionId string, priority int64, caller string) error {
 		if err != nil {
 			return errors.Wrapf(err, "getting tasks for version '%s'", versionId)
 		}
-		err = task.DeactivateTasks(tasks, caller)
+		err = task.DeactivateTasks(tasks, false, caller)
 		if err != nil {
 			return errors.Wrapf(err, "deactivating tasks for version '%s'", versionId)
 		}
@@ -300,22 +305,22 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	finishedTasks, err = task.AddParentDisplayTasks(finishedTasks)
+	allFinishedTasks, err := task.AddParentDisplayTasks(finishedTasks)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	// remove execution tasks in case the caller passed both display and execution tasks
 	// the functions below are expected to work if just the display task is passed
-	for i := len(finishedTasks) - 1; i >= 0; i-- {
-		t := finishedTasks[i]
+	for i := len(allFinishedTasks) - 1; i >= 0; i-- {
+		t := allFinishedTasks[i]
 		if t.DisplayTask != nil {
-			finishedTasks = append(finishedTasks[:i], finishedTasks[i+1:]...)
+			allFinishedTasks = append(allFinishedTasks[:i], allFinishedTasks[i+1:]...)
 		}
 	}
 
 	// archive all the finished tasks
 	toArchive := []task.Task{}
-	for _, t := range finishedTasks {
+	for _, t := range allFinishedTasks {
 		if !t.IsPartOfSingleHostTaskGroup() { // for single host task groups we don't archive until fully restarting
 			toArchive = append(toArchive, t)
 		}
@@ -328,22 +333,15 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 		Build     string
 		TaskGroup string
 	}
-	// only need to check one task per task group / build combination
-	taskGroupsToCheck := map[taskGroupAndBuild]task.Task{}
-	tasksToRestart := finishedTasks
-	if abortInProgress {
-		aborted, err := task.Find(task.BySubsetAborted(taskIds))
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		catcher := grip.NewBasicCatcher()
-		for _, t := range aborted {
-			catcher.Add(t.SetResetWhenFinished())
-		}
-		if catcher.HasErrors() {
-			return catcher.Resolve()
+	if abortInProgress && len(finishedTasks) < len(taskIds) {
+		if err = task.SetAbortedTasksResetWhenFinished(taskIds); err != nil {
+			return err
 		}
 	}
+
+	// only need to check one task per task group / build combination
+	taskGroupsToCheck := map[taskGroupAndBuild]task.Task{}
+	tasksToRestart := allFinishedTasks
 
 	restartIds := []string{}
 	for _, t := range tasksToRestart {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2256,7 +2256,7 @@ func TestSetTaskActivationForBuildsActivated(t *testing.T) {
 	}
 
 	// t0 should still be activated because it's a dependency of a task that is being activated
-	assert.NoError(t, setTaskActivationForBuilds([]string{"b0"}, true, []string{"t0"}, ""))
+	assert.NoError(t, setTaskActivationForBuilds([]string{"b0"}, true, true, []string{"t0"}, ""))
 
 	dbTasks, err := task.FindAll(task.All)
 	require.NoError(t, err)
@@ -2287,7 +2287,7 @@ func TestSetTaskActivationForBuildsWithIgnoreTasks(t *testing.T) {
 		require.NoError(t, task.Insert())
 	}
 
-	assert.NoError(t, setTaskActivationForBuilds([]string{"b0"}, true, []string{"t3"}, ""))
+	assert.NoError(t, setTaskActivationForBuilds([]string{"b0"}, true, true, []string{"t3"}, ""))
 
 	dbTasks, err := task.FindAll(task.All)
 	require.NoError(t, err)
@@ -2322,7 +2322,7 @@ func TestSetTaskActivationForBuildsDeactivated(t *testing.T) {
 	}
 
 	// ignore tasks is ignored for deactivating
-	assert.NoError(t, setTaskActivationForBuilds([]string{"b0"}, false, []string{"t0", "t1", "t2"}, ""))
+	assert.NoError(t, setTaskActivationForBuilds([]string{"b0"}, false, true, []string{"t0", "t1", "t2"}, ""))
 
 	dbTasks, err := task.FindAll(task.All)
 	require.NoError(t, err)

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -710,7 +710,7 @@ func ByExecutionTasks(ids []string) bson.M {
 	}
 }
 
-func BySubsetAborted(ids []string) bson.M {
+func bySubsetAborted(ids []string) bson.M {
 	return bson.M{
 		IdKey:      bson.M{"$in": ids},
 		AbortedKey: true,
@@ -1572,13 +1572,6 @@ func Remove(id string) error {
 		Collection,
 		bson.M{IdKey: id},
 	)
-}
-
-// Remove all deletes all tasks with a given buildId
-func RemoveAllWithBuild(buildId string) error {
-	return db.RemoveAll(
-		Collection,
-		bson.M{BuildIdKey: buildId})
 }
 
 func Aggregate(pipeline []bson.M, results interface{}) error {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2033,7 +2033,7 @@ func TestActivateTasks(t *testing.T) {
 	}
 
 	updatedIDs := []string{"t0", "t3", "t4"}
-	err := ActivateTasks([]Task{tasks[0]}, time.Time{}, "")
+	err := ActivateTasks([]Task{tasks[0]}, time.Time{}, true, "")
 	assert.NoError(t, err)
 
 	dbTasks, err := FindAll(All)
@@ -2069,7 +2069,7 @@ func TestDeactivateTasks(t *testing.T) {
 	}
 
 	updatedIDs := []string{"t0", "t4", "t5"}
-	err := DeactivateTasks([]Task{tasks[0]}, "")
+	err := DeactivateTasks([]Task{tasks[0]}, true, "")
 	assert.NoError(t, err)
 
 	dbTasks, err := FindAll(All)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -100,7 +100,7 @@ func SetActiveState(caller string, active bool, tasks ...task.Task) error {
 	}
 
 	if active {
-		if err := task.ActivateTasks(tasksToActivate, time.Now(), caller); err != nil {
+		if err := task.ActivateTasks(tasksToActivate, time.Now(), true, caller); err != nil {
 			return errors.Wrap(err, "activating tasks")
 		}
 		versionIdsToActivate := []string{}
@@ -111,7 +111,7 @@ func SetActiveState(caller string, active bool, tasks ...task.Task) error {
 			return errors.Wrap(err, "marking version as activated")
 		}
 	} else {
-		if err := task.DeactivateTasks(tasksToActivate, caller); err != nil {
+		if err := task.DeactivateTasks(tasksToActivate, true, caller); err != nil {
 			return errors.Wrap(err, "deactivating task")
 		}
 	}

--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -113,7 +113,7 @@ func ActivateElapsedBuildsAndTasks(v *Version) (bool, error) {
 			v.BuildVariants[i].Activated = true
 			v.BuildVariants[i].ActivateAt = now
 
-			if err := setTaskActivationForBuilds([]string{bv.BuildId}, true, ignoreTasks, evergreen.DefaultTaskActivator); err != nil {
+			if err := setTaskActivationForBuilds([]string{bv.BuildId}, true, true, ignoreTasks, evergreen.DefaultTaskActivator); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"operation": "project-activation",
 					"message":   "problem activating tasks for build",

--- a/units/task_stranded_cleanup.go
+++ b/units/task_stranded_cleanup.go
@@ -91,7 +91,7 @@ func (j *taskStrandedCleanupJob) Run(ctx context.Context) {
 		}
 	}
 	if len(tasksToDeactivate) > 0 {
-		err = task.DeactivateTasks(tasksToDeactivate, j.ID())
+		err = task.DeactivateTasks(tasksToDeactivate, true, j.ID())
 		j.AddError(err)
 	}
 


### PR DESCRIPTION
[EVG-16552](https://jira.mongodb.org/browse/EVG-16552)

### Description 
Since dependencies only exist within versions, we don't need to check for dependencies if the whole thing is being updated. This will hopefully be enough of an improvement that we don't need a job to do this. It's possible that we should start relying more on the job to unschedule blocked dependencies rather than doing them in these kinds of calls ever, since it's expensive.

### Testing 
Verified existing tests work.
