### PR TITLE
EVG-16748 Pass pointer to buildFromService in upstreamProject Resolver.

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -4022,8 +4022,8 @@ func (*versionResolver) UpstreamProject(ctx context.Context, obj *restModel.APIV
 		}
 
 		apiVersion := restModel.APIVersion{}
-		if err = apiVersion.BuildFromService(&upstreamVersion); err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("building APIVersion from service for `%s`: %s", upstreamBuild.Id, err.Error()))
+		if err = apiVersion.BuildFromService(upstreamVersion); err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("building APIVersion from service for `%s`: %s", upstreamVersion.Id, err.Error()))
 		}
 
 		projectID = upstreamVersion.Identifier


### PR DESCRIPTION
[EVG-16748](https://jira.mongodb.org/browse/EVG-16748)

### Description 
This was throwing an error since we were passing a reference to buildFromService

