### PR TITLE
EVG-16309: disable stale undispatched container tasks

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -169,6 +169,11 @@ const (
 	StepbackTaskActivator  = "stepback"
 	APIServerTaskActivator = "apiserver"
 
+	// StaleContainerTaskMonitor is the special name representing the unit
+	// responsible for monitoring container tasks that have not dispatched but
+	// have waiting for a long time since their activation.
+	StaleContainerTaskMonitor = "stale-container-task-monitor"
+
 	// Restart Types
 	RestartVersions = "versions"
 	RestartTasks    = "tasks"
@@ -505,6 +510,7 @@ const (
 	AdHocRequester              = "ad_hoc"
 )
 
+// Constants for project command names
 const (
 	GenerateTasksCommandName      = "generate.tasks"
 	HostCreateCommandName         = "host.create"
@@ -565,7 +571,8 @@ func (k SenderKey) String() string {
 	}
 }
 
-// Recognized architectures, should be in the form ${GOOS}_${GOARCH}.
+// Recognized Evergreen agent CPU architectures, which should be in the form
+// ${GOOS}_${GOARCH}.
 const (
 	ArchDarwinAmd64  = "darwin_amd64"
 	ArchDarwinArm64  = "darwin_arm64"

--- a/globals.go
+++ b/globals.go
@@ -384,7 +384,7 @@ const (
 	AbortAction       ModificationAction = "abort"
 )
 
-// evergreen package names
+// Constants for Evergreen package names (including legacy ones).
 const (
 	UIPackage      = "EVERGREEN_UI"
 	RESTV2Package  = "EVERGREEN_REST_V2"
@@ -414,7 +414,7 @@ const (
 	CAName = "evergreen"
 )
 
-// cloud provider related constants
+// Constants related to cloud providers and provider-specific settings.
 const (
 	ProviderNameEc2Auto     = "ec2-auto"
 	ProviderNameEc2OnDemand = "ec2-ondemand"
@@ -428,16 +428,19 @@ const (
 	ProviderNameVsphere     = "vsphere"
 	ProviderNameMock        = "mock"
 
-	// Default EC2 region where hosts should be spawned
+	// DefaultEC2Region is the default region where hosts should be spawned.
 	DefaultEC2Region = "us-east-1"
-	// This is Amazon's EBS type default
+	// DefaultEBSType is Amazon's default EBS type.
 	DefaultEBSType = "gp2"
-	// This may be a temporary default
+	// DefaultEBSAvailabilityZone is the default availability zone for EBS
+	// volumes. This may be a temporary default.
 	DefaultEBSAvailabilityZone = "us-east-1a"
 )
 
 var (
-	// Providers where hosts can be created and terminated automatically.
+	// ProviderSpawnable includes all cloud provider types where hosts can be
+	// dynamically created and terminated according to need. This has no
+	// relation to spawn hosts.
 	ProviderSpawnable = []string{
 		ProviderNameEc2OnDemand,
 		ProviderNameEc2Spot,
@@ -450,7 +453,9 @@ var (
 		ProviderNameDocker,
 	}
 
-	// Providers that are spawnable by users
+	// ProviderUserSpawnable includes all cloud provider types where a user can
+	// request a dynamically created host for purposes such as host.create and
+	// spawn hosts.
 	ProviderUserSpawnable = []string{
 		ProviderNameEc2OnDemand,
 		ProviderNameEc2Spot,
@@ -481,12 +486,6 @@ var (
 		ProviderNameEc2Fleet,
 		ProviderNameEc2OnDemand,
 	}
-
-	SystemVersionRequesterTypes = []string{
-		RepotrackerVersionRequester,
-		TriggerRequester,
-		GitTagRequester,
-	}
 )
 
 const (
@@ -510,7 +509,16 @@ const (
 	AdHocRequester              = "ad_hoc"
 )
 
-// Constants for project command names
+// Constants related to requester types.
+var (
+	SystemVersionRequesterTypes = []string{
+		RepotrackerVersionRequester,
+		TriggerRequester,
+		GitTagRequester,
+	}
+)
+
+// Constants for project command names.
 const (
 	GenerateTasksCommandName      = "generate.tasks"
 	HostCreateCommandName         = "host.create"
@@ -786,11 +794,11 @@ func ShouldConsiderBatchtime(requester string) bool {
 	return !IsPatchRequester(requester) && requester != AdHocRequester && requester != GitTagRequester
 }
 
-// Permissions-related constants
 func PermissionsDisabledForTests() bool {
 	return PermissionSystemDisabled
 }
 
+// Constants for permission scopes and resource types.
 const (
 	SuperUserResourceType = "super_user"
 	ProjectResourceType   = "project"
@@ -831,7 +839,7 @@ var (
 	PermissionHosts          = "distro_hosts"
 )
 
-// permission levels
+// Constants related to permission levels.
 var (
 	AdminSettingsEdit = PermissionLevel{
 		Description: "Edit admin settings",
@@ -1060,7 +1068,7 @@ var BasicAccessRoles = []string{
 	BasicDistroAccessRole,
 }
 
-// Evergreen log types.
+// Constants for Evergreen log types.
 const (
 	LogTypeAgent  = "agent_log"
 	LogTypeTask   = "task_log"
@@ -1110,7 +1118,7 @@ func (c ContainerOS) Validate() error {
 	}
 }
 
-// CPUArchitecture represents the architecture necessary to run the container.
+// CPUArchitecture represents the architecture necessary to run a container.
 type CPUArchitecture string
 
 const (

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -167,6 +167,9 @@ func TryMarkVersionStarted(versionId string, startTime time.Time) error {
 	return err
 }
 
+// SetTaskPriority sets the priority for the given task. Any of the task's
+// dependencies that have a lower priority than the one being set for this task
+// will also have their priority increased.
 func SetTaskPriority(t task.Task, priority int64, caller string) error {
 	depTasks, err := task.GetRecursiveDependenciesUp([]task.Task{t}, nil)
 	if err != nil {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -774,13 +774,13 @@ func FindNeedsContainerAllocation() ([]Task, error) {
 // currently needs a container to be allocated to run it.
 func needsContainerAllocation() bson.M {
 	q := isContainerTaskScheduledQuery()
-	q[StatusKey] = evergreen.TaskUndispatched
 	q[ContainerAllocatedKey] = false
 	return q
 }
 
 func isContainerTaskScheduledQuery() bson.M {
 	return bson.M{
+		StatusKey:            evergreen.TaskUndispatched,
 		ActivatedKey:         true,
 		ExecutionPlatformKey: ExecutionPlatformContainer,
 		PriorityKey:          bson.M{"$gt": evergreen.DisabledTaskPriority},

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -37,7 +37,7 @@ const (
 	dependencyKey = "dependencies"
 
 	// UnschedulableThreshold is the threshold after which a task waiting to
-	// dispatch should be tasks should be unscheduled due to staleness.
+	// dispatch should be unscheduled due to staleness.
 	UnschedulableThreshold = 7 * 24 * time.Hour
 
 	// indicates the window of completed tasks we want to use in computing
@@ -1954,10 +1954,10 @@ func (t *Task) UpdateHeartbeat() error {
 }
 
 // SetDisabledPriority sets the priority of a task so it will never run. If it's
-// a display task, it will disabled it and all of its execution tasks. If it's
-// an execution task, its parent display task will not be updated. It also
-// deactivates the task and any tasks that depend on it.
-func (t *Task) SetDisabledPriority(user string) error {
+// a display task, it will disable the display task and all of its child
+// execution tasks. If it's an execution task, its parent display task will not
+// be updated. It also deactivates the task and any tasks that depend on it.
+func (t *Task) SetDisabledPriority(caller string) error {
 	t.Priority = evergreen.DisabledTaskPriority
 
 	ids := append([]string{t.Id}, t.ExecutionTasks...)
@@ -1977,10 +1977,10 @@ func (t *Task) SetDisabledPriority(user string) error {
 		return errors.Wrap(err, "finding matching tasks")
 	}
 	for _, task := range tasks {
-		event.LogTaskPriority(task.Id, task.Execution, user, evergreen.DisabledTaskPriority)
+		event.LogTaskPriority(task.Id, task.Execution, caller, evergreen.DisabledTaskPriority)
 	}
 
-	return t.DeactivateTask(user)
+	return t.DeactivateTask(caller)
 }
 
 // DisableTasks is the same as (*Task).SetDisabledPriority but for many tasks.

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2536,27 +2536,285 @@ func TestShouldAllocateContainer(t *testing.T) {
 	}
 }
 
-func TestSetDisabledPriority(t *testing.T) {
-	require.NoError(t, db.ClearCollections(Collection, event.AllLogCollection))
+func TestDisableOneTask(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection, event.AllLogCollection))
+	}()
 
-	tasks := []Task{
-		{Id: "t0", ExecutionTasks: []string{"t1", "t2"}},
-		{Id: "t1"},
-		{Id: "t2"},
+	type disableFunc func(t *testing.T, tsk Task) error
+
+	for funcName, disable := range map[string]disableFunc{
+		"SetDisabledPriority": func(t *testing.T, tsk Task) error {
+			return tsk.SetDisabledPriority(t.Name())
+		},
+		"DisableTasks": func(t *testing.T, tsk Task) error {
+			return DisableTasks([]Task{tsk}, t.Name())
+		},
+	} {
+		t.Run(funcName, func(t *testing.T) {
+			for tName, tCase := range map[string]func(t *testing.T, tasks [5]Task){
+				"DisablesNormalTask": func(t *testing.T, tasks [5]Task) {
+					require.NoError(t, disable(t, tasks[3]))
+
+					dbTask, err := FindOneId(tasks[3].Id)
+					require.NoError(t, err)
+					require.NotZero(t, dbTask)
+
+					checkDisabled(t, dbTask)
+				},
+				"DisablesTaskAndDeactivatesItsDependents": func(t *testing.T, tasks [5]Task) {
+					require.NoError(t, disable(t, tasks[4]))
+
+					dbTask, err := FindOneId(tasks[4].Id)
+					require.NoError(t, err)
+					require.NotZero(t, dbTask)
+
+					checkDisabled(t, dbTask)
+
+					dbDependentTask, err := FindOneId(tasks[3].Id)
+					require.NoError(t, err)
+					require.NotZero(t, dbDependentTask)
+
+					assert.Zero(t, dbDependentTask.Priority, "dependent task should not have been disabled")
+					assert.False(t, dbDependentTask.Activated, "dependent task should have been deactivated")
+				},
+				"DisablesDisplayTaskAndItsExecutionTasks": func(t *testing.T, tasks [5]Task) {
+					require.NoError(t, disable(t, tasks[0]))
+
+					dbDisplayTask, err := FindOneId(tasks[0].Id)
+					require.NoError(t, err)
+					require.NotZero(t, dbDisplayTask)
+					checkDisabled(t, dbDisplayTask)
+
+					dbExecTasks, err := FindAll(db.Query(ByIds([]string{tasks[1].Id, tasks[2].Id})))
+					require.NoError(t, err)
+					assert.Len(t, dbExecTasks, 2)
+
+					for _, task := range dbExecTasks {
+						checkChildExecutionDisabled(t, &task)
+					}
+				},
+				"DoesNotDisableParentDisplayTask": func(t *testing.T, tasks [5]Task) {
+					require.NoError(t, disable(t, tasks[1]))
+
+					dbExecTask, err := FindOneId(tasks[1].Id)
+					require.NoError(t, err)
+					require.NotZero(t, dbExecTask)
+
+					checkDisabled(t, dbExecTask)
+
+					dbDisplayTask, err := FindOneId(tasks[0].Id)
+					require.NoError(t, err)
+					require.NotZero(t, dbDisplayTask)
+
+					assert.Zero(t, dbDisplayTask.Priority, "display task is not modified when its execution task is disabled")
+					assert.True(t, dbDisplayTask.Activated, "display task is not modified when its execution task is disabled")
+				},
+			} {
+				t.Run(tName, func(t *testing.T) {
+					require.NoError(t, db.ClearCollections(Collection, event.AllLogCollection))
+					tasks := [5]Task{
+						{Id: "display-task0", DisplayOnly: true, ExecutionTasks: []string{"exec-task1", "exec-task2"}, Activated: true},
+						{Id: "exec-task1", DisplayTaskId: utility.ToStringPtr("display-task0"), Activated: true},
+						{Id: "exec-task2", DisplayTaskId: utility.ToStringPtr("display-task0"), Activated: true},
+						{Id: "task3", Activated: true, DependsOn: []Dependency{{TaskId: "task4"}}},
+						{Id: "task4", Activated: true},
+					}
+					for _, task := range tasks {
+						require.NoError(t, task.Insert())
+					}
+
+					tCase(t, tasks)
+				})
+			}
+		})
 	}
-	for _, task := range tasks {
-		require.NoError(t, task.Insert())
+}
+
+func TestDisableManyTasks(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection, event.AllLogCollection))
+	}()
+
+	for tName, tCase := range map[string]func(t *testing.T){
+		"DisablesIndividualExecutionTasksWithinADisplayTaskAndDoesNotUpdateDisplayTask": func(t *testing.T) {
+			dt := Task{
+				Id:             "display-task",
+				DisplayOnly:    true,
+				ExecutionTasks: []string{"exec-task1", "exec-task2", "exec-task3"},
+				Activated:      true,
+			}
+			et1 := Task{
+				Id:            "exec-task1",
+				DisplayTaskId: utility.ToStringPtr(dt.Id),
+				Activated:     true,
+			}
+			et2 := Task{
+				Id:            "exec-task2",
+				DisplayTaskId: utility.ToStringPtr(dt.Id),
+				Activated:     true,
+			}
+			et3 := Task{
+				Id:            "exec-task3",
+				DisplayTaskId: utility.ToStringPtr(dt.Id),
+				Activated:     true,
+			}
+			require.NoError(t, dt.Insert())
+			require.NoError(t, et1.Insert())
+			require.NoError(t, et2.Insert())
+			require.NoError(t, et3.Insert())
+
+			require.NoError(t, DisableTasks([]Task{et1, et2}, t.Name()))
+
+			dbDisplayTask, err := FindOneId(dt.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDisplayTask)
+
+			assert.Zero(t, dbDisplayTask.Priority, "parent display task priority should not be modified when execution tasks are disabled")
+			assert.True(t, dbDisplayTask.Activated, "parent display task should not be deactivated when execution tasks are disabled")
+
+			dbExecTask1, err := FindOneId(et1.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbExecTask1)
+			checkChildExecutionDisabled(t, dbExecTask1)
+
+			dbExecTask2, err := FindOneId(et2.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbExecTask2)
+			checkChildExecutionDisabled(t, dbExecTask2)
+
+			dbExecTask3, err := FindOneId(et3.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbExecTask3)
+			assert.Zero(t, dbExecTask3.Priority, "priority of execution task under same parent display task as disabled execution tasks should not be modified")
+			assert.True(t, dbExecTask3.Activated, "execution task under same parent display task as disabled execution tasks should not be deactivated")
+		},
+		"DisablesMixOfExecutionTasksAndDisplayTasks": func(t *testing.T) {
+			dt1 := Task{
+				Id:             "display-task1",
+				DisplayOnly:    true,
+				ExecutionTasks: []string{"exec-task1", "exec-task2"},
+				Activated:      true,
+			}
+			dt2 := Task{
+				Id:             "display-task2",
+				DisplayOnly:    true,
+				ExecutionTasks: []string{"exec-task3", "exec-task4"},
+				Activated:      true,
+			}
+			et1 := Task{
+				Id:            "exec-task1",
+				DisplayTaskId: utility.ToStringPtr(dt1.Id),
+				Activated:     true,
+			}
+			et2 := Task{
+				Id:            "exec-task2",
+				DisplayTaskId: utility.ToStringPtr(dt1.Id),
+				Activated:     true,
+			}
+			et3 := Task{
+				Id:            "exec-task3",
+				DisplayTaskId: utility.ToStringPtr(dt2.Id),
+				Activated:     true,
+			}
+			et4 := Task{
+				Id:            "exec-task4",
+				DisplayTaskId: utility.ToStringPtr(dt2.Id),
+				Activated:     true,
+			}
+			require.NoError(t, dt1.Insert())
+			require.NoError(t, dt2.Insert())
+			require.NoError(t, et1.Insert())
+			require.NoError(t, et2.Insert())
+			require.NoError(t, et3.Insert())
+			require.NoError(t, et4.Insert())
+
+			require.NoError(t, DisableTasks([]Task{et1, et3, dt2}, t.Name()))
+
+			dbDisplayTask1, err := FindOneId(dt1.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDisplayTask1)
+
+			assert.Zero(t, dbDisplayTask1.Priority, "parent display task priority should not be modified when execution tasks are disabled")
+			assert.True(t, dbDisplayTask1.Activated, "parent display task should not be deactivated when execution tasks are disabled")
+
+			dbDisplayTask2, err := FindOneId(dt2.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDisplayTask2)
+
+			checkDisabled(t, dbDisplayTask2)
+
+			dbExecTask1, err := FindOneId(et1.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbExecTask1)
+			checkDisabled(t, dbExecTask1)
+
+			dbExecTask2, err := FindOneId(et2.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbExecTask2)
+			assert.Zero(t, dbExecTask2.Priority, "priority of execution task under same parent display task as disabled execution tasks should not be modified")
+			assert.True(t, dbExecTask2.Activated, "execution task under same parent display task as disabled execution tasks should not be deactivated")
+
+			dbExecTask3, err := FindOneId(et3.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbExecTask3)
+			checkChildExecutionDisabled(t, dbExecTask3)
+
+			dbExecTask4, err := FindOneId(et4.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbExecTask4)
+			checkChildExecutionDisabled(t, dbExecTask4)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(Collection, event.AllLogCollection))
+			tCase(t)
+		})
+	}
+}
+
+// checkDisabled checks that the given task is disabled and logs the expected
+// events.
+func checkDisabled(t *testing.T, dbTask *Task) {
+	assert.Equal(t, evergreen.DisabledTaskPriority, dbTask.Priority, "task '%s' should have disabled priority", dbTask.Id)
+	assert.False(t, dbTask.Activated, "task '%s' should be deactivated", dbTask.Id)
+
+	events, err := event.FindAllByResourceID(dbTask.Id)
+	require.NoError(t, err)
+
+	var loggedDeactivationEvent bool
+	var loggedPriorityChangedEvent bool
+	for _, e := range events {
+		switch e.EventType {
+		case event.TaskPriorityChanged:
+			loggedPriorityChangedEvent = true
+		case event.TaskDeactivated:
+			loggedDeactivationEvent = true
+		}
 	}
 
-	assert.NoError(t, tasks[0].SetDisabledPriority(""))
+	assert.True(t, loggedPriorityChangedEvent, "task '%s' did not log an event indicating its priority was set", dbTask.Id)
+	assert.True(t, loggedDeactivationEvent, "task '%s' did not log an event indicating it was deactivated", dbTask.Id)
+}
 
-	dbTasks, err := FindAll(All)
-	assert.NoError(t, err)
-	assert.Len(t, dbTasks, 3)
+// TODO (EVG-16746): these checks for child execution tasks should be replaced
+// by checkDisabled since a child execution tasks should be disabled in the same
+// way as normal tasks and display tasks. However, currently they are not
+// deactivated (even though they should be).
+func checkChildExecutionDisabled(t *testing.T, dbTask *Task) {
+	assert.Equal(t, evergreen.DisabledTaskPriority, dbTask.Priority, "execution task '%s' should have disabled priority", dbTask.Id)
 
-	for _, task := range dbTasks {
-		assert.Equal(t, evergreen.DisabledTaskPriority, task.Priority)
+	events, err := event.FindAllByResourceID(dbTask.Id)
+	require.NoError(t, err)
+
+	var loggedPriorityChangedEvent bool
+	for _, e := range events {
+		if e.EventType == event.TaskPriorityChanged {
+			loggedPriorityChangedEvent = true
+			break
+		}
 	}
+	assert.True(t, loggedPriorityChangedEvent, "execution task '%s' did not have an event indicating its priority was set", dbTask.Id)
 }
 
 func TestSetHasLegacyResults(t *testing.T) {

--- a/units/crons.go
+++ b/units/crons.go
@@ -1301,13 +1301,15 @@ func PopulateDataCleanupJobs(env evergreen.Environment) amboy.QueueOperation {
 }
 
 // PopulatePodAllocatorJobs returns the queue operation to enqueue jobs to
-// allocate pods to tasks.
+// allocate pods to tasks and disable container tasks that exceed the stale
+// undispatched threshold.
 func PopulatePodAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
 		flags, err := evergreen.GetServiceFlags()
 		if err != nil {
 			return errors.WithStack(err)
 		}
+
 		if flags.PodAllocatorDisabled {
 			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
 				"message": "pod allocation disabled",
@@ -1315,6 +1317,13 @@ func PopulatePodAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 				"mode":    "degraded",
 			})
 			return nil
+		}
+
+		if err := task.DisableStaleContainerTasks(evergreen.StaleContainerTaskMonitor); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "could not disable stale container tasks",
+				"context": "pod allocation",
+			}))
 		}
 
 		numInitializing, err := pod.CountByInitializing()
@@ -1351,6 +1360,7 @@ func PopulatePodAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 
 		grip.InfoWhen(remaining <= 0 && ctq.Len() > 0, message.Fields{
 			"message":             "reached max parallel pod request limit, not allocating any more",
+			"context":             "pod allocation",
 			"num_remaining_tasks": ctq.Len(),
 		})
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16309

### Description 
Disable container tasks that have spent too long without being dispatched. This isn't intended to catch a lot of tasks since after [PM-2617](https://jira.mongodb.org/browse/PM-2617), tasks are supposed to give up on allocating after they've failed a few attempts. However, it does put a cap on the max time a container task could possibly spend waiting for dispatch.

The host task scheduler has [similar functionality](https://github.com/evergreen-ci/evergreen/blob/fa60e78f57c7591334b16f884e62e069c1a65999/model/task/task.go#L1261-L1285), but that implementation is slightly less correct since it doesn't consider its effects on dependencies  (e.g. does disabling the task block another task), doesn't update the display task status, and doesn't log any events for future debugging/traceability. I think it's okay to implement it in a more correct but less efficient way since the working assumption is that the container task pipeline is fast enough at processing the task queue that few/no tasks should still be waiting for dispatch after a week.

* Added staleness check to pod allocation cron populator before loading container task queue.
* Update a few doc comments.

### Testing 
Added unit tests for checking for stale container tasks, disabling one task, and disabling many tasks.