### PR TITLE
EVG-13451 Support modern ssh key types

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -70,7 +70,7 @@ func (so *SpawnOptions) validate(settings *evergreen.Settings) error {
 
 	// validate public key
 	if err = evergreen.ValidateSSHKey(so.PublicKey); err != nil {
-		return errors.Wrap(err, "Invalid spawn options: ")
+		return errors.Wrap(err, "Invalid spawn options")
 	}
 
 	sections := strings.Split(so.PublicKey, " ")

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -23,14 +23,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Valid key types.
-const (
-	rsa     = "ssh-rsa"
-	dss     = "ssh-dss"
-	ed25519 = "ssh-ed25519"
-	ecdsa   = "ecdsa-sha2-nistp256"
-)
-
 // Options holds the required parameters for spawning a host.
 type SpawnOptions struct {
 	DistroId              string
@@ -77,17 +69,13 @@ func (so *SpawnOptions) validate(settings *evergreen.Settings) error {
 	}
 
 	// validate public key
-	if err = ValidateSSHKey(so.PublicKey); err != nil {
+	if err = evergreen.ValidateSSHKey(so.PublicKey); err != nil {
 		return errors.Wrap(err, "Invalid spawn options: ")
 	}
 
 	sections := strings.Split(so.PublicKey, " ")
 	if len(sections) < 2 {
-		keyType := rsa
-		if sections[0] == dss {
-			keyType = dss
-		}
-		return errors.Errorf("Invalid spawn options: missing space after '%s'", keyType)
+		return errors.Errorf("Invalid spawn options: missing space in key")
 	}
 
 	// check for valid base64
@@ -96,18 +84,6 @@ func (so *SpawnOptions) validate(settings *evergreen.Settings) error {
 	}
 
 	return nil
-}
-
-// ValidateSSHKey errors if the given key does not start with one of the allowed prefixes.
-func ValidateSSHKey(key string) error {
-	validKeys := []string{rsa, dss, ed25519, ecdsa}
-	for _, prefix := range validKeys {
-		if strings.HasPrefix(key, prefix) {
-			return nil
-		}
-	}
-	return errors.Errorf("either an invalid Evergreen-managed key name has been provided,"+
-		"or the key value does not start with one of these options: '%s'", validKeys)
 }
 
 func checkSpawnHostLimitExceeded(numCurrentHosts int, settings *evergreen.Settings) error {

--- a/cloud/spawn_test.go
+++ b/cloud/spawn_test.go
@@ -96,9 +96,9 @@ func TestValidateSSHKey(t *testing.T) {
 	ecdsaKey := "ecdsa-sha2-nistp256 randomKeyname"
 	invalidKey := "notThat randomKeyname"
 
-	require.NoError(t, ValidateSSHKey(rsaKey))
-	require.NoError(t, ValidateSSHKey(dssKey))
-	require.NoError(t, ValidateSSHKey(ed25519Key))
-	require.NoError(t, ValidateSSHKey(ecdsaKey))
-	require.Error(t, ValidateSSHKey(invalidKey))
+	require.NoError(t, evergreen.ValidateSSHKey(rsaKey))
+	require.NoError(t, evergreen.ValidateSSHKey(dssKey))
+	require.NoError(t, evergreen.ValidateSSHKey(ed25519Key))
+	require.NoError(t, evergreen.ValidateSSHKey(ecdsaKey))
+	require.Error(t, evergreen.ValidateSSHKey(invalidKey))
 }

--- a/cloud/spawn_test.go
+++ b/cloud/spawn_test.go
@@ -88,3 +88,17 @@ func TestModifySpawnHostProviderSettings(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "new_id", settingsList[0].LookupElement("subnet_id").Value().StringValue())
 }
+
+func TestValidateSSHKey(t *testing.T) {
+	rsaKey := "ssh-rsa randomKeyname"
+	dssKey := "ssh-dss randomKeyname"
+	ed25519Key := "ssh-ed25519 randomKeyname"
+	ecdsaKey := "ecdsa-sha2-nistp256 randomKeyname"
+	invalidKey := "notThat randomKeyname"
+
+	require.NoError(t, ValidateSSHKey(rsaKey))
+	require.NoError(t, ValidateSSHKey(dssKey))
+	require.NoError(t, ValidateSSHKey(ed25519Key))
+	require.NoError(t, ValidateSSHKey(ecdsaKey))
+	require.Error(t, ValidateSSHKey(invalidKey))
+}

--- a/globals.go
+++ b/globals.go
@@ -2,6 +2,7 @@ package evergreen
 
 import (
 	"os"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/utility"
@@ -1138,4 +1139,30 @@ func (w WindowsVersion) Validate() error {
 	default:
 		return errors.Errorf("unrecognized windows version '%s'", w)
 	}
+}
+
+const (
+	// Valid public key types.
+	publicKeyRSA     = "ssh-rsa"
+	publicKeyDSS     = "ssh-dss"
+	publicKeyED25519 = "ssh-ed25519"
+	publicKeyECDSA   = "ecdsa-sha2-nistp256"
+)
+
+var validKeyTypes = []string{
+	publicKeyRSA,
+	publicKeyDSS,
+	publicKeyED25519,
+	publicKeyECDSA,
+}
+
+// ValidateSSHKey errors if the given key does not start with one of the allowed prefixes.
+func ValidateSSHKey(key string) error {
+	for _, prefix := range validKeyTypes {
+		if strings.HasPrefix(key, prefix) {
+			return nil
+		}
+	}
+	return errors.Errorf("either an invalid Evergreen-managed key name has been provided, "+
+		"or the key value is not one of the valid types: %s", validKeyTypes)
 }

--- a/operations/keys.go
+++ b/operations/keys.go
@@ -3,8 +3,8 @@ package operations
 import (
 	"context"
 	"io/ioutil"
-	"strings"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -76,8 +76,8 @@ func keysAdd() cli.Command {
 
 			pubKey := string(keyFileContents)
 			// verify that this isn't a private key
-			if !strings.HasPrefix(strings.TrimSpace(pubKey), "ssh-") {
-				return errors.Errorf("'%s' does not appear to be an ssh public key", keyFile)
+			if err := evergreen.ValidateSSHKey(pubKey); err != nil {
+				return errors.Errorf("'%s' does not appear to be a valid ssh public key", keyFile)
 			}
 
 			if err := client.AddPublicKey(ctx, keyName, pubKey); err != nil {

--- a/public/static/js/directives/directives.spawn.js
+++ b/public/static/js/directives/directives.spawn.js
@@ -116,6 +116,8 @@ directives.spawn.directive('keyNameUnique', function() {
 // match
 var RSA = 'ssh-rsa';
 var DSS = 'ssh-dss';
+var ED25519 = "ssh-ed25519";
+var ECDSA   = "ecdsa-sha2-nistp256";
 var BASE64REGEX = new RegExp("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$");
 
 directives.spawn.directive('keyBaseValid', function() {
@@ -126,7 +128,9 @@ directives.spawn.directive('keyBaseValid', function() {
         // validate the public key
         var isRSA = viewValue.substring(0, RSA.length) === RSA;
         var isDSS = viewValue.substring(0, DSS.length) === DSS;
-        if (!isRSA && !isDSS) {
+        var isED25519 = viewValue.substring(0, ED25519.length) === ED25519;
+        var isECDSA = viewValue.substring(0, ECDSA.length) === ECDSA;
+        if (!isRSA && !isDSS && !isED25519 && !isECDSA) {
           ctrl.$setValidity('keyBaseValid', false);
           return viewValue;
         }

--- a/public/static/partials/user_host_options.html
+++ b/public/static/partials/user_host_options.html
@@ -70,7 +70,7 @@
       Please enter a unique key name for your new key<br />
     </span>
     <span class="semi-muted invalid" ng-show="spawnHostForm.pubkey.$dirty && (spawnHostForm.pubkey.$error.required || spawnHostForm.pubkey.$error.keyBaseValid)">
-      Key is invalid. It must begin with 'ssh-rsa' or 'ssh-dss' or 'ssh-ed25519' or 'ecdsa-sha2-nistp256'. Ensure you have copied the public half of the key.<br />
+      Key is invalid. It must begin with 'ssh-rsa', or 'ssh-dss', or 'ssh-ed25519', or 'ecdsa-sha2-nistp256'. Ensure you have copied the public half of the key.<br />
     </span>
     <span class="semi-muted invalid" ng-show="!spawnableDistros || spawnableDistros.length === 0">
       You cannot spawn a host because there are no spawnable distros.<br />

--- a/public/static/partials/user_host_options.html
+++ b/public/static/partials/user_host_options.html
@@ -70,7 +70,7 @@
       Please enter a unique key name for your new key<br />
     </span>
     <span class="semi-muted invalid" ng-show="spawnHostForm.pubkey.$dirty && (spawnHostForm.pubkey.$error.required || spawnHostForm.pubkey.$error.keyBaseValid)">
-      Key is invalid. It must begin with 'ssh-rsa' or 'ssh-dss'. Ensure you have copied the public half of the key.<br />
+      Key is invalid. It must begin with 'ssh-rsa' or 'ssh-dss' or 'ssh-ed25519' or 'ecdsa-sha2-nistp256'. Ensure you have copied the public half of the key.<br />
     </span>
     <span class="semi-muted invalid" ng-show="!spawnableDistros || spawnableDistros.length === 0">
       You cannot spawn a host because there are no spawnable distros.<br />

--- a/public/static/partials/user_host_options.html
+++ b/public/static/partials/user_host_options.html
@@ -70,7 +70,7 @@
       Please enter a unique key name for your new key<br />
     </span>
     <span class="semi-muted invalid" ng-show="spawnHostForm.pubkey.$dirty && (spawnHostForm.pubkey.$error.required || spawnHostForm.pubkey.$error.keyBaseValid)">
-      Key is invalid. It must begin with 'ssh-rsa', or 'ssh-dss', or 'ssh-ed25519', or 'ecdsa-sha2-nistp256'. Ensure you have copied the public half of the key.<br />
+      Key is invalid. It must begin with 'ssh-rsa', 'ssh-dss', 'ssh-ed25519', or 'ecdsa-sha2-nistp256'. Ensure you have copied the public half of the key.<br />
     </span>
     <span class="semi-muted invalid" ng-show="!spawnableDistros || spawnableDistros.length === 0">
       You cannot spawn a host because there are no spawnable distros.<br />

--- a/rest/route/keys.go
+++ b/rest/route/keys.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
@@ -115,7 +115,7 @@ func validateKeyName(keyName string) error {
 }
 
 func validateKeyValue(keyValue string) error {
-	if err := cloud.ValidateSSHKey(keyValue); err != nil {
+	if err := evergreen.ValidateSSHKey(keyValue); err != nil {
 		return errors.Wrapf(err, "invalid public key")
 	}
 

--- a/rest/route/keys.go
+++ b/rest/route/keys.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
@@ -114,8 +115,8 @@ func validateKeyName(keyName string) error {
 }
 
 func validateKeyValue(keyValue string) error {
-	if !strings.HasPrefix(keyValue, "ssh-rsa") && !strings.HasPrefix(keyValue, "ssh-dss") {
-		return errors.New("invalid public key")
+	if err := cloud.ValidateSSHKey(keyValue); err != nil {
+		return errors.Wrapf(err, "invalid public key")
 	}
 
 	splitKey := strings.Split(keyValue, " ")

--- a/rest/route/keys_test.go
+++ b/rest/route/keys_test.go
@@ -140,7 +140,7 @@ func TestKeyValidationFailsWithInvalidKeys(t *testing.T) {
 
 	err2 := validateKeyValue("    ")
 	assert.Error(err2)
-	assert.Equal("invalid public key", err2.Error())
+	assert.Contains(err2.Error(), "invalid public key")
 
 	err3 := validateKeyValue("ssh-rsa notvalidbase64")
 	assert.Error(err3)


### PR DESCRIPTION
[EVG-13451](https://jira.mongodb.org/browse/EVG-13451)

### Description 
add 2 extra types of ssh keys that we allow 

### Testing 
unit test 

![image](https://user-images.githubusercontent.com/26491602/164075009-92931cb6-3e6b-49f4-88e2-786f21ee53e4.png)

created host on staging using new key type
![image](https://user-images.githubusercontent.com/26491602/164100978-e6f9569b-6d8a-4e96-9247-4a8437bd53a4.png)


spruce

https://github.com/evergreen-ci/spruce/pull/1226