### PR TITLE
EVG-16076 disallow Evergreen from decomissioning hosts running task groups

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -580,10 +580,10 @@ func (h *Host) SetDecommissioned(user string, checkTaskGroup bool, logs string) 
 	err := h.setStatusAndFields(evergreen.HostDecommissioned, query, nil, user, logs)
 	// Shouldn't consider it an error if the host isn't found when checking task group,
 	// because a task group may have been set for the host.
-	if err != nil && checkTaskGroup && !adb.ResultsNotFound(err) {
-		return err
+	if err != nil && checkTaskGroup && adb.ResultsNotFound(err) {
+		return nil
 	}
-	return nil
+	return err
 }
 
 func (h *Host) SetRunning(user string) error {

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -345,6 +345,17 @@ func TestSetStatusAndFields(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status, "terminated host should remain terminated")
 		},
+		"FailsDecommissionIfHostIsNowRunningTaskGroup": func(t *testing.T, h *Host) {
+			h.RunningTaskGroup = "my_task_group"
+			require.NoError(t, h.Insert())
+
+			assert.Error(t, h.SetStatusAndFields(evergreen.HostDecommissioned, bson.M{}, evergreen.User, ""))
+
+			dbHost, err := FindOneId(h.Id)
+			require.NoError(t, err)
+			require.NotNil(t, dbHost)
+			assert.NotEqual(t, evergreen.HostDecommissioned, h.Status)
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(Collection, event.AllLogCollection))

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1255,7 +1255,7 @@ func TestSetUserDataHostProvisioned(t *testing.T) {
 			assert.Equal(t, evergreen.HostStarting, dbHost.Status)
 		},
 		"IgnoresNonStartingHosts": func(t *testing.T, h *Host) {
-			require.NoError(t, h.SetDecommissioned(evergreen.User, ""))
+			require.NoError(t, h.SetDecommissioned(evergreen.User, false, ""))
 
 			require.NoError(t, h.SetUserDataHostProvisioned())
 			assert.Equal(t, evergreen.HostDecommissioned, h.Status)

--- a/units/building_container_image.go
+++ b/units/building_container_image.go
@@ -117,7 +117,8 @@ func (j *buildingContainerImageJob) Run(ctx context.Context) {
 	}()
 
 	if j.parent.ContainerBuildAttempt >= containerBuildRetries {
-		j.AddError(errors.Wrapf(j.parent.SetDecommissioned(evergreen.User, fmt.Sprintf("exceeded max container build retries (%d)", containerBuildRetries)), "failed to set parent '%s' to decommissioned", j.parent.Id))
+		err = j.parent.SetDecommissioned(evergreen.User, false, fmt.Sprintf("exceeded max container build retries (%d)", containerBuildRetries))
+		j.AddError(errors.Wrapf(err, "failed to set parent '%s' to decommissioned", j.parent.Id))
 		err = errors.Errorf("failed %d times to build and download image '%s' on parent '%s'", containerBuildRetries, j.DockerOptions.Image, j.parent.Id)
 		j.AddError(err)
 		grip.Warning(message.WrapError(err, message.Fields{

--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -158,7 +158,7 @@ func (j *hostDrawdownJob) checkAndTerminateHost(ctx context.Context, h *host.Hos
 		(*drawdownTarget)--
 		j.Terminated++
 		j.TerminatedHosts = append(j.TerminatedHosts, h.Id)
-		if err = h.SetDecommissioned(evergreen.User, "host decommissioned due to overallocation"); err != nil {
+		if err = h.SetDecommissioned(evergreen.User, true, "host decommissioned due to overallocation"); err != nil {
 			return errors.Wrapf(err, "problem decommissioning host %s", h.Id)
 		}
 		return nil

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -110,7 +110,7 @@ func (j *idleHostJob) Run(ctx context.Context) {
 			return
 		}
 		for _, h := range hosts {
-			j.AddError(errors.Wrapf(h.SetDecommissioned(evergreen.User, "distro is missing"), "could not set host '%s' as decommissioned", h.Id))
+			j.AddError(errors.Wrapf(h.SetDecommissioned(evergreen.User, false, "distro is missing"), "could not set host '%s' as decommissioned", h.Id))
 		}
 
 		if j.HasErrors() {

--- a/units/host_monitoring_parent_decommission.go
+++ b/units/host_monitoring_parent_decommission.go
@@ -81,7 +81,7 @@ func (j *parentDecommissionJob) Run(ctx context.Context) {
 			continue
 		}
 		if idle {
-			err = h.SetDecommissioned(evergreen.User, "host only contains decommissioned containers and there is excess capacity")
+			err = h.SetDecommissioned(evergreen.User, false, "host only contains decommissioned containers and there is excess capacity")
 			if err != nil {
 				j.AddError(err)
 				continue

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -232,7 +232,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	// set host as decommissioned in DB so no new task will be assigned
 	prevStatus := j.host.Status
 	if prevStatus != evergreen.HostTerminated {
-		if err = j.host.SetDecommissioned(evergreen.User, "host will be terminated shortly, preventing task dispatch"); err != nil {
+		if err = j.host.SetDecommissioned(evergreen.User, false, "host will be terminated shortly, preventing task dispatch"); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"host_id":  j.host.Id,
 				"provider": j.host.Distro.Provider,


### PR DESCRIPTION
[EVG-16076](https://jira.mongodb.org/browse/EVG-16076)

### Description 
Right now we sometimes have a race where Evergreen assigns a task to a running host, but then Evergreen decommissions it because our local host document doesn't show this running task yet. This is an issue when the task is part of a task group, since we shouldn't be decommissioning that host.

Since we check when assigning a task that the status is running in the query itself, it makes sense to also check the task group field when decommissioning, since that would eliminate the race.

### Testing 
Added a unit test.
