### PR TITLE
EVG-16631: update display task when dispatching container execution task

### DIFF
--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -2,7 +2,6 @@ package dispatcher
 
 import (
 	"context"
-	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -88,8 +87,13 @@ func (pd *PodDispatcher) UpsertAtomically() (*adb.ChangeInfo, error) {
 }
 
 // AssignNextTask assigns the pod the next available task to run. Returns nil if
-// there's no task available to run.
+// there's no task available to run. If the pod is already running a task, this
+// will return an error.
 func (pd *PodDispatcher) AssignNextTask(ctx context.Context, env evergreen.Environment, p *pod.Pod) (*task.Task, error) {
+	if p.RunningTask != "" {
+		return nil, errors.Errorf("cannot assign a new task to a pod that is already running task '%s'", p.RunningTask)
+	}
+
 	grip.WarningWhen(len(pd.TaskIDs) > 1, message.Fields{
 		"message":    "programmatic error: task groups are not supported yet, so dispatcher should have at most 1 container task to dispatch",
 		"pod":        p.ID,
@@ -135,6 +139,12 @@ func (pd *PodDispatcher) AssignNextTask(ctx context.Context, env evergreen.Envir
 		event.LogPodAssignedTask(p.ID, t.Id, t.Execution)
 		event.LogContainerTaskDispatched(t.Id, t.Execution, p.ID)
 
+		if t.IsPartOfDisplay() {
+			if err := model.UpdateDisplayTaskForTask(t); err != nil {
+				return nil, errors.Wrap(err, "updating parent display task")
+			}
+		}
+
 		return t, nil
 	}
 
@@ -162,7 +172,7 @@ func (pd *PodDispatcher) dispatchTask(env evergreen.Environment, p *pod.Pod, t *
 			return nil, errors.Wrapf(err, "setting pod's running task")
 		}
 
-		if err := t.MarkAsContainerDispatched(sessCtx, env, p.AgentVersion, time.Now()); err != nil {
+		if err := t.MarkAsContainerDispatched(sessCtx, env, p.AgentVersion); err != nil {
 			return nil, errors.Wrapf(err, "marking task as dispatched")
 		}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1095,7 +1095,8 @@ func (t *Task) MarkAsContainerDeallocated(ctx context.Context, env evergreen.Env
 
 // MarkAsContainerDispatched marks that the container task has been dispatched
 // to a pod.
-func (t *Task) MarkAsContainerDispatched(ctx context.Context, env evergreen.Environment, agentVersion string, dispatchedAt time.Time) error {
+func (t *Task) MarkAsContainerDispatched(ctx context.Context, env evergreen.Environment, agentVersion string) error {
+	dispatchedAt := time.Now()
 	query := isContainerTaskScheduledQuery()
 	query[StatusKey] = evergreen.TaskUndispatched
 	query[ContainerAllocatedKey] = true

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2125,26 +2125,26 @@ func TestMarkAsContainerDispatched(t *testing.T) {
 		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+			require.NoError(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion))
 			checkTaskDispatched(t, tsk.Id)
 		},
 		"FailsWithTaskWithoutContainerAllocated": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
 			tsk.ContainerAllocated = false
 			require.NoError(t, tsk.Insert())
 
-			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion))
 		},
 		"FailsWithDeactivatedTasks": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
 			tsk.Activated = false
 			require.NoError(t, tsk.Insert())
 
-			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion))
 		},
 		"FailsWithDisabledTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
 			tsk.Priority = evergreen.DisabledTaskPriority
 			require.NoError(t, tsk.Insert())
 
-			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion))
 		},
 		"FailsWithUnmetDependencies": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
 			tsk.DependsOn = []Dependency{
@@ -2152,10 +2152,10 @@ func TestMarkAsContainerDispatched(t *testing.T) {
 			}
 			require.NoError(t, tsk.Insert())
 
-			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion))
 		},
 		"FailsWithNonexistentTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
-			require.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion, time.Now()))
+			require.Error(t, tsk.MarkAsContainerDispatched(ctx, env, evergreen.AgentVersion))
 
 			dbTask, err := FindOneId(tsk.Id)
 			assert.NoError(t, err)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16631

### Description 
Update display task after the container task is dispatched. I did it outside the transaction since it's not critical to update the display task and to avoid having to change `UpdateDisplayTaskForTask` to make it work with the transaction context.

If it errors while updating the display task, the task is still considered dispatched according to the DB. The agent protocol will deal with re-attempting to update the display task in the error case (to be written in [PM-2616](https://jira.mongodb.org/browse/PM-2616)).

### Testing 
Added unit tests for dispatcher.
