### PR TITLE
EVG-16757 ignore min hosts for outdated idle hosts

### DIFF
--- a/units/host_monitoring_idle_termination_test.go
+++ b/units/host_monitoring_idle_termination_test.go
@@ -712,3 +712,25 @@ func TestPopulateIdleHostJobsCalculations(t *testing.T) {
 	}
 	assert.Equal(2, nHostsToEvaluateForTermination)
 }
+
+func TestGetNumHostsToEvaluate(t *testing.T) {
+	info := host.IdleHostsByDistroID{
+		DistroID: "d1",
+		IdleHosts: []host.Host{
+			{Id: "h1"},
+			{Id: "h2"},
+			{Id: "h3"},
+		},
+		RunningHostsCount: 5,
+	}
+	// If minimum hosts is 0, then we attempt to terminate all idle hosts.
+	numHosts := getNumHostsToEvaluate(info, 0)
+	assert.Equal(t, numHosts, 3)
+	// If minimum hosts is 4, then we attempt to terminate just one.
+	numHosts = getNumHostsToEvaluate(info, 4)
+	assert.Equal(t, numHosts, 1)
+	// If minimum hosts is 5, then we don't attempt to terminate.
+	numHosts = getNumHostsToEvaluate(info, 5)
+	assert.Equal(t, numHosts, 0)
+
+}


### PR DESCRIPTION
[EVG-16757](https://jira.mongodb.org/browse/EVG-16757

### Description 
We rely on this job to terminate hosts with outdated AMIs, since once all tasks are new they won't have any valid tasks to run anymore. However, if a distro has minimum hosts configured, we may not check any (or enough), and all running hosts will be outdated. Modified the job to always check and terminate outdated hosts. (Also did a little refactor

### Testing 
Tested the refactor.