### PR TITLE
EVG-16759 Add option to exclude base tasks from buildVariants resolver

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -7762,6 +7762,7 @@ input BuildVariantOptions {
   variants: [String!]
   tasks: [String!]
   statuses: [String!]
+  excludeBaseTasks: Boolean
 }
 input MainlineCommitsOptions {
   projectID: String!
@@ -39775,6 +39776,14 @@ func (ec *executionContext) unmarshalInputBuildVariantOptions(ctx context.Contex
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("statuses"))
 			it.Statuses, err = ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "excludeBaseTasks":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("excludeBaseTasks"))
+			it.ExcludeBaseTasks, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -7762,7 +7762,7 @@ input BuildVariantOptions {
   variants: [String!]
   tasks: [String!]
   statuses: [String!]
-  excludeBaseTasks: Boolean
+  includeBaseTasks: Boolean
 }
 input MainlineCommitsOptions {
   projectID: String!
@@ -39779,11 +39779,11 @@ func (ec *executionContext) unmarshalInputBuildVariantOptions(ctx context.Contex
 			if err != nil {
 				return it, err
 			}
-		case "excludeBaseTasks":
+		case "includeBaseTasks":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("excludeBaseTasks"))
-			it.ExcludeBaseTasks, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includeBaseTasks"))
+			it.IncludeBaseTasks, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -35,9 +35,10 @@ type BuildBaron struct {
 }
 
 type BuildVariantOptions struct {
-	Variants []string `json:"variants"`
-	Tasks    []string `json:"tasks"`
-	Statuses []string `json:"statuses"`
+	Variants         []string `json:"variants"`
+	Tasks            []string `json:"tasks"`
+	Statuses         []string `json:"statuses"`
+	ExcludeBaseTasks *bool    `json:"excludeBaseTasks"`
 }
 
 type Dependency struct {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -38,7 +38,7 @@ type BuildVariantOptions struct {
 	Variants         []string `json:"variants"`
 	Tasks            []string `json:"tasks"`
 	Statuses         []string `json:"statuses"`
-	ExcludeBaseTasks *bool    `json:"excludeBaseTasks"`
+	IncludeBaseTasks *bool    `json:"includeBaseTasks"`
 }
 
 type Dependency struct {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3741,8 +3741,7 @@ func (r *versionResolver) BuildVariants(ctx context.Context, v *restModel.APIVer
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error fetching version: %s : %s", *v.Id, err.Error()))
 		}
-		err = setVersionActivationStatus(version)
-		if err != nil {
+		if err = setVersionActivationStatus(version); err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error setting version activation status: %s", err.Error()))
 		}
 		v.Activated = version.Activated

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3737,33 +3737,13 @@ func (r *versionResolver) TaskStatusCounts(ctx context.Context, v *restModel.API
 func (r *versionResolver) BuildVariants(ctx context.Context, v *restModel.APIVersion, options *BuildVariantOptions) ([]*GroupedBuildVariant, error) {
 	// If activated is nil in the db we should resolve it and cache it for subsequent queries. There is a very low likely hood of this field being hit
 	if v.Activated == nil {
-		defaultSort := []task.TasksSortOrder{
-			{Key: task.DisplayNameKey, Order: 1},
-		}
-		opts := task.GetTasksByVersionOptions{
-			Sorts:                          defaultSort,
-			IncludeBaseTasks:               false,
-			IsMainlineCommit:               evergreen.IsPatchRequester(utility.FromStringPtr(v.Requester)),
-			IncludeBuildVariantDisplayName: false, // we don't need to include buildVariantDisplayName here because this is only used to determine if a task has been activated
-		}
-		tasks, _, err := task.GetTasksByVersion(*v.Id, opts)
-		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error fetching tasks for version %s : %s", *v.Id, err.Error()))
-		}
 		version, err := model.VersionFindOne(model.VersionById(*v.Id))
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error fetching version: %s : %s", *v.Id, err.Error()))
 		}
-		if !task.AnyActiveTasks(tasks) {
-			err = version.SetNotActivated()
-			if err != nil {
-				return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error updating version activated status for %s, %s", *v.Id, err.Error()))
-			}
-		} else {
-			err = version.SetActivated()
-			if err != nil {
-				return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error updating version activated status for %s, %s", *v.Id, err.Error()))
-			}
+		err = setVersionActivationStatus(version)
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error setting version activation status: %s", err.Error()))
 		}
 		v.Activated = version.Activated
 	}

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3742,7 +3742,7 @@ func (r *versionResolver) BuildVariants(ctx context.Context, v *restModel.APIVer
 		}
 		opts := task.GetTasksByVersionOptions{
 			Sorts:                          defaultSort,
-			IncludeBaseTasks:               true,
+			IncludeBaseTasks:               false,
 			IsMainlineCommit:               evergreen.IsPatchRequester(utility.FromStringPtr(v.Requester)),
 			IncludeBuildVariantDisplayName: false, // we don't need to include buildVariantDisplayName here because this is only used to determine if a task has been activated
 		}
@@ -3771,7 +3771,7 @@ func (r *versionResolver) BuildVariants(ctx context.Context, v *restModel.APIVer
 	if !utility.FromBoolPtr(v.Activated) {
 		return nil, nil
 	}
-	groupedBuildVariants, err := generateBuildVariants(*v.Id, options.Variants, options.Tasks, options.Statuses)
+	groupedBuildVariants, err := generateBuildVariants(utility.FromStringPtr(v.Id), *options)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error generating build variants for version %s : %s", *v.Id, err.Error()))
 	}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -275,7 +275,7 @@ input BuildVariantOptions {
   variants: [String!]
   tasks: [String!]
   statuses: [String!]
-  excludeBaseTasks: Boolean
+  includeBaseTasks: Boolean
 }
 input MainlineCommitsOptions {
   projectID: String!

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -275,6 +275,7 @@ input BuildVariantOptions {
   variants: [String!]
   tasks: [String!]
   statuses: [String!]
+  excludeBaseTasks: Boolean
 }
 input MainlineCommitsOptions {
   projectID: String!

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -266,12 +266,15 @@ func generateBuildVariants(versionId string, buildVariantOpts BuildVariantOption
 	defaultSort := []task.TasksSortOrder{
 		{Key: task.DisplayNameKey, Order: 1},
 	}
+	if buildVariantOpts.IncludeBaseTasks == nil {
+		buildVariantOpts.IncludeBaseTasks = utility.ToBoolPtr(true)
+	}
 	opts := task.GetTasksByVersionOptions{
 		Statuses:                       getValidTaskStatusesFilter(buildVariantOpts.Statuses),
 		Variants:                       buildVariantOpts.Variants,
 		TaskNames:                      buildVariantOpts.Tasks,
 		Sorts:                          defaultSort,
-		IncludeBaseTasks:               !utility.FromBoolPtr(buildVariantOpts.ExcludeBaseTasks),
+		IncludeBaseTasks:               utility.FromBoolPtr(buildVariantOpts.IncludeBaseTasks),
 		IncludeBuildVariantDisplayName: true,
 	}
 	start := time.Now()

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -260,18 +260,18 @@ func getAPITaskFromTask(ctx context.Context, url string, task task.Task) (*restM
 }
 
 // Takes a version id and some filter criteria and returns the matching associated tasks grouped together by their build variant.
-func generateBuildVariants(versionId string, searchVariants []string, searchTasks []string, statuses []string) ([]*GroupedBuildVariant, error) {
+func generateBuildVariants(versionId string, buildVariantOpts BuildVariantOptions) ([]*GroupedBuildVariant, error) {
 	var variantDisplayName map[string]string = map[string]string{}
 	var tasksByVariant map[string][]*restModel.APITask = map[string][]*restModel.APITask{}
 	defaultSort := []task.TasksSortOrder{
 		{Key: task.DisplayNameKey, Order: 1},
 	}
 	opts := task.GetTasksByVersionOptions{
-		Statuses:                       getValidTaskStatusesFilter(statuses),
-		Variants:                       searchVariants,
-		TaskNames:                      searchTasks,
+		Statuses:                       getValidTaskStatusesFilter(buildVariantOpts.Statuses),
+		Variants:                       buildVariantOpts.Variants,
+		TaskNames:                      buildVariantOpts.Tasks,
 		Sorts:                          defaultSort,
-		IncludeBaseTasks:               true,
+		IncludeBaseTasks:               !utility.FromBoolPtr(buildVariantOpts.ExcludeBaseTasks),
 		IncludeBuildVariantDisplayName: true,
 	}
 	start := time.Now()


### PR DESCRIPTION
[EVG-16769](https://jira.mongodb.org/browse/EVG-16759)

### Description 
Previously the buildVariants resolver would always fetch the base tasks for the build variants query even if they were not used. This adds an option to exclude fetching it for situations where we don't need it. 

I chose to include it by default to maintain the same behavior it currently exhibits to avoid any backwards compatibility issues with the UI. 

This helps reduce response times in the UI by simplifying the query when the additional fields are not needed.
