### PR TITLE
EVG-16731 Update version aborted field

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3909,50 +3909,60 @@ func (r *versionResolver) PreviousVersion(ctx context.Context, obj *restModel.AP
 }
 
 func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion) (string, error) {
-	failedAndAbortedStatuses := append(evergreen.TaskFailureStatuses, evergreen.TaskAborted)
-	opts := task.GetTasksByVersionOptions{
-		Statuses:                       failedAndAbortedStatuses,
-		FieldsToProject:                []string{task.DisplayStatusKey},
-		IncludeBaseTasks:               false,
-		IncludeBuildVariantDisplayName: false,
-	}
-	tasks, _, err := task.GetTasksByVersion(*obj.Id, opts)
-	if err != nil {
-		return "", InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch tasks for version: %s", err.Error()))
-	}
 	status, err := evergreen.VersionStatusToPatchStatus(*obj.Status)
 	if err != nil {
 		return "", InternalServerError.Send(ctx, fmt.Sprintf("An error occurred when converting a version status: %s", err.Error()))
 	}
-	if evergreen.IsPatchRequester(*obj.Requester) {
-		p, err := data.FindPatchById(*obj.Id)
-		if err != nil {
-			return status, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch Patch %s: %s", *obj.Id, err.Error()))
-		}
-		if len(p.ChildPatches) > 0 {
-			patchStatuses := []string{*p.Status}
-			for _, cp := range p.ChildPatches {
-				patchStatuses = append(patchStatuses, *cp.Status)
-				// add the child patch tasks to tasks so that we can consider their status
-				childPatchTasks, _, err := task.GetTasksByVersion(*cp.Id, opts)
-				if err != nil {
-					return "", InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch tasks for patch: %s ", err.Error()))
-				}
-				tasks = append(tasks, childPatchTasks...)
-			}
-			status = patch.GetCollectiveStatus(patchStatuses)
-		}
+	if utility.FromBoolPtr(obj.Aborted) && !utility.StringSliceContains(evergreen.TaskFailureStatuses, status) {
+		return evergreen.PatchAborted, nil
+	} else {
+		return status, nil
 	}
 
-	taskStatuses := getAllTaskStatuses(tasks)
+	// failedAndAbortedStatuses := append(evergreen.TaskFailureStatuses, evergreen.TaskAborted)
+	// opts := task.GetTasksByVersionOptions{
+	// 	Statuses:                       failedAndAbortedStatuses,
+	// 	FieldsToProject:                []string{task.DisplayStatusKey},
+	// 	IncludeBaseTasks:               false,
+	// 	IncludeBuildVariantDisplayName: false,
+	// }
+	// tasks, _, err := task.GetTasksByVersion(*obj.Id, opts)
+	// if err != nil {
+	// 	return "", InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch tasks for version: %s", err.Error()))
+	// }
+	// status, err := evergreen.VersionStatusToPatchStatus(*obj.Status)
+	// if err != nil {
+	// 	return "", InternalServerError.Send(ctx, fmt.Sprintf("An error occurred when converting a version status: %s", err.Error()))
+	// }
+	// if evergreen.IsPatchRequester(*obj.Requester) {
+	// 	p, err := data.FindPatchById(*obj.Id)
+	// 	if err != nil {
+	// 		return status, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch Patch %s: %s", *obj.Id, err.Error()))
+	// 	}
+	// 	if len(p.ChildPatches) > 0 {
+	// 		patchStatuses := []string{*p.Status}
+	// 		for _, cp := range p.ChildPatches {
+	// 			patchStatuses = append(patchStatuses, *cp.Status)
+	// 			// add the child patch tasks to tasks so that we can consider their status
+	// 			childPatchTasks, _, err := task.GetTasksByVersion(*cp.Id, opts)
+	// 			if err != nil {
+	// 				return "", InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch tasks for patch: %s ", err.Error()))
+	// 			}
+	// 			tasks = append(tasks, childPatchTasks...)
+	// 		}
+	// 		status = patch.GetCollectiveStatus(patchStatuses)
+	// 	}
+	// }
 
-	// If theres an aborted task we should set the patch status to aborted if there are no other failures
-	if utility.StringSliceContains(taskStatuses, evergreen.TaskAborted) {
-		if len(utility.StringSliceIntersection(taskStatuses, evergreen.TaskFailureStatuses)) == 0 {
-			status = evergreen.PatchAborted
-		}
-	}
-	return status, nil
+	// taskStatuses := getAllTaskStatuses(tasks)
+
+	// // If theres an aborted task we should set the patch status to aborted if there are no other failures
+	// if utility.StringSliceContains(taskStatuses, evergreen.TaskAborted) {
+	// 	if len(utility.StringSliceIntersection(taskStatuses, evergreen.TaskFailureStatuses)) == 0 {
+	// 		status = evergreen.PatchAborted
+	// 	}
+	// }
+	// return status, nil
 }
 
 func (*versionResolver) UpstreamProject(ctx context.Context, obj *restModel.APIVersion) (*UpstreamProject, error) {

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3940,7 +3940,7 @@ func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion)
 	}
 
 	// If theres an aborted task we should set the patch status to aborted if there are no other failures
-	if isAborted && len(utility.StringSliceIntersection(evergreen.TaskFailureStatuses, nonAbortedStatuses)) == 0 {
+	if isAborted && !utility.StringSliceContains(nonAbortedStatuses, evergreen.PatchFailed) {
 		status = evergreen.PatchAborted
 	}
 	return status, nil

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -934,12 +934,15 @@ func UpdateBuildStatus(b *build.Build) (bool, error) {
 
 	// only need to check aborted if status has changed
 	isAborted := false
+	var taskStatuses []string
 	for _, t := range buildTasks {
 		if t.Aborted {
 			isAborted = true
-			break
+		} else {
+			taskStatuses = append(taskStatuses, t.Status)
 		}
 	}
+	isAborted = len(utility.StringSliceIntersection(taskStatuses, evergreen.TaskFailureStatuses)) == 0 && isAborted
 	if isAborted != b.Aborted {
 		if err = b.SetAborted(isAborted); err != nil {
 			return false, errors.Wrapf(err, "setting build '%s' as aborted", b.Id)

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -30,6 +30,7 @@ type APIVersion struct {
 	Requester          *string        `json:"requester"`
 	Errors             []*string      `json:"errors"`
 	Activated          *bool          `json:"activated"`
+	Aborted            *bool          `json:"aborted"`
 }
 
 type buildDetail struct {
@@ -60,6 +61,7 @@ func (apiVersion *APIVersion) BuildFromService(h interface{}) error {
 	apiVersion.Requester = utility.ToStringPtr(v.Requester)
 	apiVersion.Errors = utility.ToStringPtrSlice(v.Errors)
 	apiVersion.Activated = v.Activated
+	apiVersion.Aborted = utility.ToBoolPtr(v.Aborted)
 
 	var bd buildDetail
 	for _, t := range v.BuildVariants {


### PR DESCRIPTION
[EVG-16731](https://jira.mongodb.org/browse/EVG-16731)

### Description 
version and build aborted field now dynamically reflects whether we should show the status as aborted or not 

### Testing 

normal patch with success and abort will show abort 
will show failure if tasks are abort and failure 
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/26491602/164308265-31e76f73-62cb-4d11-8e03-3fd8c0c82d08.png">


works with child patches 
https://spruce-staging.corp.mongodb.com/version/613b92639dbe323620f081ab/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
<img width="883" alt="image" src="https://user-images.githubusercontent.com/26491602/164308482-1822d426-fda0-4259-905e-332f5de917c2.png">
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/26491602/164308535-2ee9db33-a97a-4d29-a22c-03b652cd7e98.png">
