### PR TITLE
EVG-15945 clarify timezone on admin page

### DIFF
--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -2356,7 +2356,7 @@ Admin Settings
 					<md-card-title-text>
 						<span>Restart Tasks/Commit Queue Versions</span>
 						<span class="md-subhead">Restart failed tasks or commit queue versions that ran between two
-							times</span>
+							times. Uses Eastern timezone.</span>
 					</md-card-title-text>
 				</md-card-title>
 				<md-card-content>


### PR DESCRIPTION
[EVG-15945](https://jira.mongodb.org/browse/EVG-15945)

### Description 
We usually use this field in an emergency so it's helpful for it to be clear about whether it uses EST, user configured timezone, or UTC. (Since this is legacy and only admin I don't think we need to actually change the existing functionality).

### Testing 
Verified that it is actually EST.
![image](https://user-images.githubusercontent.com/26798134/164332525-377ac88b-f467-4976-a4fd-d01e54d4c68c.png)
