### PR TITLE
EVG-16033: Expose number of tests belonging to a task 

### DIFF
--- a/apimodels/test_results.go
+++ b/apimodels/test_results.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/timber"
@@ -78,9 +79,12 @@ type GetCedarTestResultsOptions struct {
 }
 
 func (opts GetCedarTestResultsOptions) convert() testresults.GetOptions {
+	if !strings.HasPrefix(opts.BaseURL, "http") {
+		opts.BaseURL = fmt.Sprintf("https://%s", opts.BaseURL)
+	}
 	return testresults.GetOptions{
 		Cedar: timber.GetOptions{
-			BaseURL: fmt.Sprintf("https://%s", opts.BaseURL),
+			BaseURL: opts.BaseURL,
 		},
 		TaskID:       opts.TaskID,
 		Execution:    opts.Execution,

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -38,6 +38,7 @@ type Connector interface {
 	GetProjectFromFile(context.Context, model.ProjectRef, string, string) (model.ProjectInfo, error)
 	CreateVersionFromConfig(context.Context, *model.ProjectInfo, model.VersionMetadata, bool) (*model.Version, error)
 	FindTestsByTaskId(FindTestsByTaskIdOpts) ([]testresult.TestResult, error)
+	TestCountByTaskID(context.Context, string, int) (int, error)
 	GetGitHubPR(context.Context, string, string, int) (*github.PullRequest, error)
 	AddPatchForPr(ctx context.Context, projectRef model.ProjectRef, prNum int, modules []restModel.APIModule, messageOverride string) (string, error)
 	IsAuthorizedToPatchAndMerge(context.Context, *evergreen.Settings, UserRepoInfo) (bool, error)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -38,7 +38,6 @@ type Connector interface {
 	GetProjectFromFile(context.Context, model.ProjectRef, string, string) (model.ProjectInfo, error)
 	CreateVersionFromConfig(context.Context, *model.ProjectInfo, model.VersionMetadata, bool) (*model.Version, error)
 	FindTestsByTaskId(FindTestsByTaskIdOpts) ([]testresult.TestResult, error)
-	TestCountByTaskID(context.Context, string, int) (int, error)
 	GetGitHubPR(context.Context, string, string, int) (*github.PullRequest, error)
 	AddPatchForPr(ctx context.Context, projectRef model.ProjectRef, prNum int, modules []restModel.APIModule, messageOverride string) (string, error)
 	IsAuthorizedToPatchAndMerge(context.Context, *evergreen.Settings, UserRepoInfo) (bool, error)

--- a/rest/data/test.go
+++ b/rest/data/test.go
@@ -82,8 +82,8 @@ func (tc *DBTestConnector) FindTestsByTaskId(opts FindTestsByTaskIdOpts) ([]test
 	return res, nil
 }
 
-func (*DBTestConnector) TestCountByTaskID(ctx context.Context, taskID string, execution int) (int, error) {
-	t, err := task.FindOneIdNewOrOld(taskID)
+func TestCountByTaskID(ctx context.Context, taskID string, execution int) (int, error) {
+	t, err := task.FindOneIdOldOrNew(taskID, execution)
 	if err != nil {
 		return 0, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
@@ -114,7 +114,7 @@ func (*DBTestConnector) TestCountByTaskID(ctx context.Context, taskID string, ex
 		if status != http.StatusOK && status != http.StatusNotFound {
 			return 0, gimlet.ErrorResponse{
 				StatusCode: http.StatusInternalServerError,
-				Message:    errors.Wrapf(err, "getting test results stats from Cedar for task '%s' return status '%d'", taskID, status).Error(),
+				Message:    fmt.Sprintf("getting test results stats from Cedar for task '%s' returned status %d", taskID, status),
 			}
 		}
 

--- a/rest/data/test.go
+++ b/rest/data/test.go
@@ -92,10 +92,10 @@ func CountTestsByTaskID(ctx context.Context, taskID string, execution int) (int,
 			Message:    errors.Wrapf(err, "finding task '%s'", taskID).Error(),
 		}
 	}
-	if t == nil {
+	if t == nil || t.Execution != execution {
 		return 0, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("task '%s' not found", taskID),
+			Message:    fmt.Sprintf("task '%s' with execution %d not found", taskID, execution),
 		}
 	}
 

--- a/rest/data/test_test.go
+++ b/rest/data/test_test.go
@@ -326,26 +326,6 @@ func TestTestCountByTaskID(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	/*
-		for i := 0; i < 2; i++ {
-			id := fmt.Sprintf("evg_task_%d", i)
-			testTask := &task.Task{
-				Id: id,
-			}
-			tests := make([]testresult.TestResult, numTests)
-			for j := 0; j < numTests; j++ {
-				tests[j] = testresult.TestResult{
-					TaskID:    id,
-					Execution: 0,
-				}
-			}
-			assert.NoError(testTask.Insert())
-			for _, test := range tests {
-				assert.NoError(test.Insert())
-			}
-		}
-	*/
-
 	t.Run("CedarTestResults", func(t *testing.T) {
 		regularTask := &task.Task{
 			Id:              "cedar",

--- a/rest/data/test_test.go
+++ b/rest/data/test_test.go
@@ -318,7 +318,7 @@ func TestFindTestsByDisplayTaskId(t *testing.T) {
 	assert.Len(foundTests, 0)
 }
 
-func TestTestCountByTaskID(t *testing.T) {
+func TestCountTestsByTaskID(t *testing.T) {
 	require.NoError(t, db.ClearCollections(task.Collection, testresult.Collection))
 	defer func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, testresult.Collection))
@@ -390,7 +390,7 @@ func TestTestCountByTaskID(t *testing.T) {
 				handler.Response = responseData
 				handler.StatusCode = test.statusCode
 
-				count, err := TestCountByTaskID(ctx, test.task.Id, test.task.Execution)
+				count, err := CountTestsByTaskID(ctx, test.task.Id, test.task.Execution)
 				if test.hasErr {
 					assert.Error(t, err)
 				} else {
@@ -429,12 +429,12 @@ func TestTestCountByTaskID(t *testing.T) {
 		}
 
 		t.Run("ExecutionTask", func(t *testing.T) {
-			count, err := TestCountByTaskID(ctx, t0.Id, 0)
+			count, err := CountTestsByTaskID(ctx, t0.Id, 0)
 			require.NoError(t, err)
 			assert.Equal(t, numTests, count)
 		})
 		t.Run("DisplayTask", func(t *testing.T) {
-			count, err := TestCountByTaskID(ctx, t2.Id, 0)
+			count, err := CountTestsByTaskID(ctx, t2.Id, 0)
 			require.NoError(t, err)
 			assert.Equal(t, len(t2.ExecutionTasks)*numTests, count)
 		})

--- a/rest/data/test_test.go
+++ b/rest/data/test_test.go
@@ -347,6 +347,7 @@ func TestCountTestsByTaskID(t *testing.T) {
 		for _, test := range []struct {
 			name       string
 			task       *task.Task
+			execution  int
 			response   apimodels.CedarTestResultsStats
 			statusCode int
 			hasErr     bool
@@ -361,25 +362,36 @@ func TestCountTestsByTaskID(t *testing.T) {
 				hasErr:     true,
 			},
 			{
+				name:       "TaskExecutionDNE",
+				task:       regularTask,
+				execution:  100,
+				statusCode: http.StatusOK,
+				hasErr:     true,
+			},
+			{
 				name:       "CedarError",
 				task:       regularTask,
+				execution:  regularTask.Execution,
 				statusCode: http.StatusInternalServerError,
 				hasErr:     true,
 			},
 			{
 				name:       "TaskWithoutResults",
 				task:       regularTask,
+				execution:  regularTask.Execution,
 				statusCode: http.StatusNotFound,
 			},
 			{
 				name:       "TaskWithResults",
 				task:       regularTask,
+				execution:  regularTask.Execution,
 				response:   apimodels.CedarTestResultsStats{TotalCount: 100},
 				statusCode: http.StatusOK,
 			},
 			{
 				name:       "DisplayTask",
 				task:       displayTask,
+				execution:  displayTask.Execution,
 				response:   apimodels.CedarTestResultsStats{TotalCount: 100},
 				statusCode: http.StatusOK,
 			},
@@ -390,7 +402,7 @@ func TestCountTestsByTaskID(t *testing.T) {
 				handler.Response = responseData
 				handler.StatusCode = test.statusCode
 
-				count, err := CountTestsByTaskID(ctx, test.task.Id, test.task.Execution)
+				count, err := CountTestsByTaskID(ctx, test.task.Id, test.execution)
 				if test.hasErr {
 					assert.Error(t, err)
 				} else {

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -197,6 +197,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/tasks/{task_id}/manifest").Version(2).Get().Wrap(viewTasks).RouteHandler(makeGetManifestHandler())
 	app.AddRoute("/tasks/{task_id}/restart").Version(2).Post().Wrap(addProject, requireUser, editTasks).RouteHandler(makeTaskRestartHandler())
 	app.AddRoute("/tasks/{task_id}/tests").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestsForTask(sc))
+	app.AddRoute("/tasks/{task_id}/tests/count").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestCountForTask(sc))
 	app.AddRoute("/tasks/{task_id}/sync_path").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncPathGetHandler())
 	app.AddRoute("/tasks/{task_id}/set_has_cedar_results").Version(2).Post().Wrap(requireTask).RouteHandler(makeTaskSetHasCedarResultsHandler())
 	app.AddRoute("/task/sync_read_credentials").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncReadCredentialsGetHandler())

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -197,7 +197,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/tasks/{task_id}/manifest").Version(2).Get().Wrap(viewTasks).RouteHandler(makeGetManifestHandler())
 	app.AddRoute("/tasks/{task_id}/restart").Version(2).Post().Wrap(addProject, requireUser, editTasks).RouteHandler(makeTaskRestartHandler())
 	app.AddRoute("/tasks/{task_id}/tests").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestsForTask(sc))
-	app.AddRoute("/tasks/{task_id}/tests/count").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestCountForTask(sc))
+	app.AddRoute("/tasks/{task_id}/tests/count").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestCountForTask())
 	app.AddRoute("/tasks/{task_id}/sync_path").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncPathGetHandler())
 	app.AddRoute("/tasks/{task_id}/set_has_cedar_results").Version(2).Post().Wrap(requireTask).RouteHandler(makeTaskSetHasCedarResultsHandler())
 	app.AddRoute("/task/sync_read_credentials").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncReadCredentialsGetHandler())

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -18,7 +18,7 @@ import (
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-// GET  /tasks/{task_id}/tests
+// GET /tasks/{task_id}/tests
 
 type testGetHandler struct {
 	taskID        string
@@ -220,7 +220,7 @@ func (tgh *testGetHandler) addDataToResponse(resp gimlet.Responder, testResult i
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-// GET  /tasks/{task_id}/tests/count
+// GET /tasks/{task_id}/tests/count
 
 type testCountGetHandler struct {
 	taskID    string
@@ -248,14 +248,10 @@ func (h *testCountGetHandler) Parse(ctx context.Context, r *http.Request) error 
 	var err error
 	vals := r.URL.Query()
 	execution := vals.Get("execution")
-
 	if execution != "" {
 		h.execution, err = strconv.Atoi(execution)
 		if err != nil {
-			return gimlet.ErrorResponse{
-				Message:    "invalid execution",
-				StatusCode: http.StatusBadRequest,
-			}
+			return errors.Wrap(err, "invalid execution")
 		}
 	}
 
@@ -263,9 +259,9 @@ func (h *testCountGetHandler) Parse(ctx context.Context, r *http.Request) error 
 }
 
 func (h *testCountGetHandler) Run(ctx context.Context) gimlet.Responder {
-	count, err := data.TestCountByTaskID(ctx, h.taskID, h.execution)
+	count, err := data.CountTestsByTaskID(ctx, h.taskID, h.execution)
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "database error"))
+		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 
 	return gimlet.NewTextResponse(count)

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-// testGetHandler is the MethodHandler for the GET /tasks/{task_id}/tests route.
+///////////////////////////////////////////////////////////////////////////////
+//
+// GET  /tasks/{task_id}/tests
+
 type testGetHandler struct {
 	taskID        string
 	displayTask   bool
@@ -42,8 +45,6 @@ func (hgh *testGetHandler) Factory() gimlet.RouteHandler {
 	}
 }
 
-// ParseAndValidate fetches the task Id and 'status' from the url and
-// sets them as part of the args.
 func (tgh *testGetHandler) Parse(ctx context.Context, r *http.Request) error {
 	projCtx := MustHaveProjectContext(ctx)
 	if projCtx.Task == nil {
@@ -96,7 +97,7 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 			}
 		}
 
-		opts := apimodels.GetCedarTestResultsOptions{
+		cedarTestResults, status, err := apimodels.GetCedarTestResults(ctx, apimodels.GetCedarTestResultsOptions{
 			BaseURL:     evergreen.GetEnvironment().Settings().Cedar.BaseURL,
 			TaskID:      tgh.taskID,
 			Execution:   utility.ToIntPtr(tgh.testExecution),
@@ -105,8 +106,7 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 			Statuses:    tgh.testStatus,
 			Limit:       tgh.limit,
 			Page:        page,
-		}
-		cedarTestResults, status, err := apimodels.GetCedarTestResults(ctx, opts)
+		})
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting test results"))
 		}
@@ -216,4 +216,62 @@ func (tgh *testGetHandler) addDataToResponse(resp gimlet.Responder, testResult i
 	}
 
 	return nil
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// GET  /tasks/{task_id}/tests/count
+
+type testCountGetHandler struct {
+	taskID    string
+	execution int
+	sc        data.Connector
+}
+
+func makeFetchTestCountForTask(sc data.Connector) gimlet.RouteHandler {
+	return &testCountGetHandler{
+		sc: sc,
+	}
+}
+
+func (h *testCountGetHandler) Factory() gimlet.RouteHandler {
+	return &testCountGetHandler{
+		sc: h.sc,
+	}
+}
+
+func (h *testCountGetHandler) Parse(ctx context.Context, r *http.Request) error {
+	projCtx := MustHaveProjectContext(ctx)
+	if projCtx.Task == nil {
+		return gimlet.ErrorResponse{
+			Message:    "task not found",
+			StatusCode: http.StatusNotFound,
+		}
+	}
+	h.taskID = projCtx.Task.Id
+
+	var err error
+	vals := r.URL.Query()
+	execution := vals.Get("execution")
+
+	if execution != "" {
+		h.execution, err = strconv.Atoi(execution)
+		if err != nil {
+			return gimlet.ErrorResponse{
+				Message:    "invalid execution",
+				StatusCode: http.StatusBadRequest,
+			}
+		}
+	}
+
+	return nil
+}
+
+func (h *testCountGetHandler) Run(ctx context.Context) gimlet.Responder {
+	count, err := h.sc.TestCountByTaskID(ctx, h.taskID, h.execution)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "database error"))
+	}
+
+	return gimlet.NewTextResponse(count)
 }

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -263,7 +263,7 @@ func (h *testCountGetHandler) Parse(ctx context.Context, r *http.Request) error 
 }
 
 func (h *testCountGetHandler) Run(ctx context.Context) gimlet.Responder {
-	count, err := TestCountByTaskID(ctx, h.taskID, h.execution)
+	count, err := data.TestCountByTaskID(ctx, h.taskID, h.execution)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "database error"))
 	}

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -225,19 +225,14 @@ func (tgh *testGetHandler) addDataToResponse(resp gimlet.Responder, testResult i
 type testCountGetHandler struct {
 	taskID    string
 	execution int
-	sc        data.Connector
 }
 
-func makeFetchTestCountForTask(sc data.Connector) gimlet.RouteHandler {
-	return &testCountGetHandler{
-		sc: sc,
-	}
+func makeFetchTestCountForTask() gimlet.RouteHandler {
+	return &testCountGetHandler{}
 }
 
 func (h *testCountGetHandler) Factory() gimlet.RouteHandler {
-	return &testCountGetHandler{
-		sc: h.sc,
-	}
+	return &testCountGetHandler{}
 }
 
 func (h *testCountGetHandler) Parse(ctx context.Context, r *http.Request) error {
@@ -268,7 +263,7 @@ func (h *testCountGetHandler) Parse(ctx context.Context, r *http.Request) error 
 }
 
 func (h *testCountGetHandler) Run(ctx context.Context) gimlet.Responder {
-	count, err := h.sc.TestCountByTaskID(ctx, h.taskID, h.execution)
+	count, err := TestCountByTaskID(ctx, h.taskID, h.execution)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "database error"))
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-16033

### Description 
Add new API endpoint `rest/v2/tasks/<task_id>/tests/count` to return the number of tests for a given task ID. Once this is merged and deployed, I will add documentation to the Evergreen wiki.

### Testing 
- Unit tests for fetching the test count from either Cedar or the database, depending on where the tests live.
- Tested this in staging with both test results in Cedar and in the database.

