### PR TITLE
EVG-6412 Update cli patch command to take tags

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1515,6 +1515,7 @@ func (p *Project) BuildProjectTVPairs(patchDoc *patch.Patch, alias string) {
 func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string, includeDeps bool) (resolvedBVs []string, resolvedTasks []string, vts []patch.VariantTasks) {
 	var bvs, bvTags, tasks, taskTags []string
 	for _, bv := range patchDoc.BuildVariants {
+		// Tags should start with "."
 		if strings.HasPrefix(bv, ".") {
 			bvTags = append(bvTags, bv[1:])
 		} else {
@@ -1522,6 +1523,7 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 		}
 	}
 	for _, t := range patchDoc.Tasks {
+		// Tags should start with "."
 		if strings.HasPrefix(t, ".") {
 			taskTags = append(taskTags, t[1:])
 		} else {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -942,7 +942,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		s.Contains([]string{"bv_2"}, vt.Variant)
 	}
 
-	// Specifying tags, regex, and names.
+	// Specifying tags and names.
 	patchDoc = patch.Patch{
 		BuildVariants: []string{".even", "bv_1"},
 		Tasks:         []string{".a", ".1", "b_task_2"},
@@ -968,10 +968,11 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		s.Contains([]string{"bv_1", "bv_2"}, vt.Variant)
 	}
 
-	// Specifying tags and names.
+	// Specifying tags, regex, and names.
 	patchDoc = patch.Patch{
 		BuildVariants: []string{".even", "bv_1"},
-		Tasks:         []string{".a", ".1"},
+		Tasks:         []string{".a"},
+		RegexTasks:    []string{"_1$"},
 	}
 
 	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -918,6 +918,80 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		s.Empty(vt.DisplayTasks)
 		s.Contains([]string{"bv_1", "bv_2"}, vt.Variant)
 	}
+
+	// Specifying tags only.
+	patchDoc = patch.Patch{
+		BuildVariants: []string{".even"},
+		Tasks:         []string{".a", ".1"},
+	}
+
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	s.Len(bvs, 1)
+	s.Contains(bvs, "bv_2")
+	s.Len(tasks, 3)
+	s.Contains(tasks, "a_task_1")
+	s.Contains(tasks, "b_task_1")
+	s.Contains(tasks, "a_task_2")
+	s.Len(variantTasks, 1)
+	for _, vt := range variantTasks {
+		s.Len(vt.Tasks, 3)
+		s.Contains(vt.Tasks, "a_task_1")
+		s.Contains(vt.Tasks, "b_task_1")
+		s.Contains(vt.Tasks, "a_task_2")
+		s.Empty(vt.DisplayTasks)
+		s.Contains([]string{"bv_2"}, vt.Variant)
+	}
+
+	// Specifying tags, regex, and names.
+	patchDoc = patch.Patch{
+		BuildVariants: []string{".even", "bv_1"},
+		Tasks:         []string{".a", ".1", "b_task_2"},
+	}
+
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	s.Len(bvs, 2)
+	s.Contains(bvs, "bv_1")
+	s.Contains(bvs, "bv_2")
+	s.Len(tasks, 4)
+	s.Contains(tasks, "a_task_1")
+	s.Contains(tasks, "b_task_1")
+	s.Contains(tasks, "a_task_2")
+	s.Contains(tasks, "b_task_2")
+	s.Len(variantTasks, 2)
+	for _, vt := range variantTasks {
+		s.Len(vt.Tasks, 4)
+		s.Contains(vt.Tasks, "a_task_1")
+		s.Contains(vt.Tasks, "b_task_1")
+		s.Contains(vt.Tasks, "a_task_2")
+		s.Contains(vt.Tasks, "b_task_2")
+		s.Empty(vt.DisplayTasks)
+		s.Contains([]string{"bv_1", "bv_2"}, vt.Variant)
+	}
+
+	// Specifying tags and names.
+	patchDoc = patch.Patch{
+		BuildVariants: []string{".even", "bv_1"},
+		Tasks:         []string{".a", ".1"},
+	}
+
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	s.Len(bvs, 2)
+	s.Contains(bvs, "bv_1")
+	s.Contains(bvs, "bv_2")
+	s.Len(tasks, 3)
+	s.Contains(tasks, "a_task_1")
+	s.Contains(tasks, "b_task_1")
+	s.Contains(tasks, "a_task_2")
+	s.Len(variantTasks, 2)
+	for _, vt := range variantTasks {
+		s.Len(vt.Tasks, 3)
+		s.Contains(vt.Tasks, "a_task_1")
+		s.Contains(vt.Tasks, "b_task_1")
+		s.Contains(vt.Tasks, "a_task_2")
+		s.Empty(vt.DisplayTasks)
+		s.Contains([]string{"bv_1", "bv_2"}, vt.Variant)
+	}
+
 }
 
 func (s *projectSuite) TestBuildProjectTVPairsWithAlias() {


### PR DESCRIPTION
[EVG-6412](https://jira.mongodb.org/browse/EVG-6412)

### Description 
cli patch command can now take tags 

### Testing 
unittest

running 
❯ clients/darwin_amd64/evergreen -c ~/.evergreen-staging.yml patch -v all -t .linter
