### PR TITLE
EVG-16725 reintroduce stats needed for dashboard

### DIFF
--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -270,6 +270,7 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 		"max_hosts":                    distro.HostAllocatorSettings.MaximumHosts,
 		"num_new_hosts":                len(hostsSpawned),
 		"pool_info":                    existingHosts.Stats(),
+		"queue":                        eventInfo,
 		"overdue_tasks":                distroQueueInfo.CountWaitOverThreshold,
 		"overdue_tasks_in_groups":      totalOverdueInTaskGroups,
 		"total_runtime":                distroQueueInfo.ExpectedDuration.String(),


### PR DESCRIPTION
[EVG-16725](https://jira.mongodb.org/browse/EVG-16725)

### Description 
It looks like the eventInfo itself should be right even though legacy stuff has been removed but let me know if that seems untrue.
