### PR TITLE
EVG-16680 add log for ignored patches

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -270,6 +270,13 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 	// Don't create patches for github PRs if the only changes are in ignored files.
 	if patchDoc.IsGithubPRPatch() && project.IgnoresAllFiles(patchDoc.FilesChanged()) {
+		grip.Debug(message.Fields{
+			"message":       "not creating patch because all files are being ignored",
+			"files_changed": patchDoc.FilesChanged(),
+			"files_ignored": project.Ignore,
+			"patch_id":      patchDoc.Id,
+			"intent_id":     j.intent.ID(),
+		})
 		return nil
 	}
 


### PR DESCRIPTION
[EVG-16680](https://jira.mongodb.org/browse/EVG-16680)

### Description 
A log like this would help a lot with debugging things like EVG-16680 going forward.
