### PR TITLE
EVG-16731: avoid nil pointer dereference

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3952,7 +3952,7 @@ func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion)
 				if err != nil {
 					return "", InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch version for patch: %s ", err.Error()))
 				}
-				if cpVersion.Aborted {
+				if cpVersion != nil && cpVersion.Aborted {
 					isAborted = true
 				} else {
 					nonAbortedStatuses = append(nonAbortedStatuses, *cp.Status)

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3952,7 +3952,10 @@ func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion)
 				if err != nil {
 					return "", InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch version for patch: %s ", err.Error()))
 				}
-				if cpVersion != nil && cpVersion.Aborted {
+				if cpVersion == nil {
+					continue
+				}
+				if cpVersion.Aborted {
 					isAborted = true
 				} else {
 					nonAbortedStatuses = append(nonAbortedStatuses, *cp.Status)


### PR DESCRIPTION
[EVG-16731](https://jira.mongodb.org/browse/EVG-16731)

### Description 
Avoid nil pointer deference when calculating version status

### Testing 
  < add a description of how you tested it >
