### PR TITLE
EVG-15658: Allow empty GitHub orgs list

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2050,7 +2050,7 @@ func (p *ProjectRef) ValidateOwnerAndRepo(validOrgs []string) error {
 		return errors.New("no owner/repo specified")
 	}
 
-	if len(validOrgs) == 0 || !utility.StringSliceContains(validOrgs, p.Owner) {
+	if len(validOrgs) > 0 && !utility.StringSliceContains(validOrgs, p.Owner) {
 		return errors.New("owner not authorized")
 	}
 	return nil


### PR DESCRIPTION
Follow up to https://github.com/evergreen-ci/evergreen

### Description 
- Permit adding a project with a new owner when 0 valid GitHub organizations are specified