### PR TITLE
EVG-16425 Prepare for container configurations in task scheduling / queueing

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1281,7 +1281,7 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 			return nil, err
 		}
 	} else {
-		distroID, distroAliases, err := getDistrosFromRunOn(id, buildVarTask, buildVariant, project, v)
+		distroID, distroAliases, err := getDistrosFromRunOn(id, buildVarTask, buildVariant)
 		if err != nil {
 			return nil, err
 		}
@@ -1304,7 +1304,7 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 	return t, nil
 }
 
-func getDistrosFromRunOn(id string, buildVarTask BuildVariantTaskUnit, buildVariant *BuildVariant, project *Project, v *Version) (string, []string, error) {
+func getDistrosFromRunOn(id string, buildVarTask BuildVariantTaskUnit, buildVariant *BuildVariant) (string, []string, error) {
 	if len(buildVarTask.RunOn) > 0 {
 		distroAliases := []string{}
 		distroID := buildVarTask.RunOn[0]

--- a/model/project.go
+++ b/model/project.go
@@ -118,7 +118,7 @@ type BuildVariantTaskUnit struct {
 	Priority       int64                `yaml:"priority,omitempty" bson:"priority"`
 	DependsOn      []TaskUnitDependency `yaml:"depends_on,omitempty" bson:"depends_on"`
 
-	// the distros that the task can be run on
+	// the distros or containers that the task can be run on
 	RunOn []string `yaml:"run_on,omitempty" bson:"run_on"`
 	// currently unsupported (TODO EVG-578)
 	ExecTimeoutSecs int   `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs"`
@@ -285,7 +285,7 @@ type BuildVariant struct {
 	//   3. false = overriding the project setting with false
 	Stepback *bool `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
 
-	// the default distros.  will be used to run a task if no distro field is
+	// the default distros or containers.  will be used to run a task if no distro field is
 	// provided for the task
 	RunOn []string `yaml:"run_on,omitempty" bson:"run_on"`
 
@@ -1200,30 +1200,6 @@ func FindProjectFromVersionID(versionStr string) (*Project, error) {
 		return nil, errors.Wrapf(err, "loading project config for version '%s'", versionStr)
 	}
 	return projectInfo.Project, nil
-}
-
-func (p *Project) FindDistroNameForTask(t *task.Task) (string, error) {
-	bv, err := p.BuildVariants.Get(t.BuildVariant)
-	if err != nil {
-		return "", errors.Wrapf(err, "finding build variant for task '%s'", t.Id)
-	}
-
-	bvt, err := bv.Get(t.DisplayName)
-	if err != nil {
-		return "", errors.Wrapf(err, "finding build variant task unit for task '%s'", t.Id)
-	}
-
-	var distro string
-
-	if len(bvt.RunOn) > 0 {
-		distro = bvt.RunOn[0]
-	} else if len(bv.RunOn) > 0 {
-		distro = bv.RunOn[0]
-	} else {
-		return "", errors.Errorf("cannot find the distro for task '%s'", t.Id)
-	}
-
-	return distro, nil
 }
 
 func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, error) {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -895,7 +895,7 @@ func (pp *ParserProject) AddTask(name string, commands []PluginCommandConf) {
 	}
 	pp.Tasks = append(pp.Tasks, t)
 }
-func (pp *ParserProject) AddBuildVariant(name, displayName, runOn string, batchTime *int, tasks []string) {
+func (pp *ParserProject) AddBuildVariant(name, displayName string, batchTime *int, tasks []string) {
 	bv := parserBV{
 		Name:        name,
 		DisplayName: displayName,
@@ -904,9 +904,6 @@ func (pp *ParserProject) AddBuildVariant(name, displayName, runOn string, batchT
 	}
 	for _, taskName := range tasks {
 		bv.Tasks = append(bv.Tasks, parserBVTaskUnit{Name: taskName})
-	}
-	if runOn != "" {
-		bv.RunOn = []string{runOn}
 	}
 	pp.BuildVariants = append(pp.BuildVariants, bv)
 }

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1510,7 +1510,7 @@ func TestAddBuildVariant(t *testing.T) {
 		Identifier: utility.ToStringPtr("small"),
 	}
 
-	pp.AddBuildVariant("name", "my-name", "", nil, []string{"task"})
+	pp.AddBuildVariant("name", "my-name", nil, []string{"task"})
 	require.Len(t, pp.BuildVariants, 1)
 	assert.Equal(t, pp.BuildVariants[0].Name, "name")
 	assert.Equal(t, pp.BuildVariants[0].DisplayName, "my-name")

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -279,6 +279,7 @@ func BlockTaskGroupTasks(taskID string) error {
 	catcher := grip.NewBasicCatcher()
 	for _, taskToBlock := range tasksToBlock {
 		catcher.Add(taskToBlock.AddDependency(task.Dependency{TaskId: taskID, Status: evergreen.TaskSucceeded, Unattainable: true}))
+
 		err = dequeue(taskToBlock.Id, taskToBlock.DistroId)
 		catcher.AddWhen(!adb.ResultsNotFound(err), err) // it's not an error if the task already isn't on the queue
 		// this operation is recursive, maybe be refactorable

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -75,7 +75,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 	project.BuildVariants = append(project.BuildVariants, bv)
 
 	// Marshal the parser project YAML for storage
-	pp.AddBuildVariant(variant, "", "", nil, []string{taskDisplayName})
+	pp.AddBuildVariant(variant, "", nil, []string{taskDisplayName})
 
 	// Create the ref for the project
 	projectRef := &model.ProjectRef{

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -646,10 +646,10 @@ func createTestRevision(revision string,
 
 func createTestProject(override1, override2 *int) *model.ParserProject {
 	pp := &model.ParserProject{}
-	pp.AddBuildVariant("bv1", "bv1", "", override1, []string{"t1"})
+	pp.AddBuildVariant("bv1", "bv1", override1, []string{"t1"})
 	pp.BuildVariants[0].Tasks[0].RunOn = []string{"test-distro-one"}
 
-	pp.AddBuildVariant("bv2", "bv2", "", override2, []string{"t1"})
+	pp.AddBuildVariant("bv2", "bv2", override2, []string{"t1"})
 	pp.BuildVariants[1].Tasks[0].RunOn = []string{"test-distro-one"}
 
 	pp.AddTask("t1", []model.PluginCommandConf{model.PluginCommandConf{

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -120,7 +120,7 @@ func (s *distroScheduler) scheduleDistro(distroID string, runnableTasks []task.T
 	return prioritizedTasks, nil
 }
 
-// Returns the distroQueueInfo for the given set of tasks having set the task.ExpectedDuration for each task.
+// GetDistroQueueInfo Returns the distroQueueInfo for the given set of tasks having set the task.ExpectedDuration for each task.
 func GetDistroQueueInfo(distroID string, tasks []task.Task, maxDurationThreshold time.Duration, opts TaskPlannerOptions) model.DistroQueueInfo {
 	var distroExpectedDuration, distroDurationOverThreshold time.Duration
 	var distroCountDurationOverThreshold, distroCountWaitOverThreshold int

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -736,6 +736,7 @@ func assignNextAvailableTask(ctx context.Context, taskQueue *model.TaskQueue, di
 		}
 
 		if isDisabled {
+
 			grip.Warning(message.WrapError(taskQueue.DequeueTask(nextTask.Id), message.Fields{
 				"message":              "project has dispatching disabled, but there was an issue dequeuing the task",
 				"distro_id":            nextTask.DistroId,


### PR DESCRIPTION
[EVG-16425](https://jira.mongodb.org/browse/EVG-16425)

### Description 
Incorporating new modifications to RunOn accepting containers and distros into the current distro-only task scheduling process.