### PR TITLE
EVG-16750: add error logs to event when host modification fails

### DIFF
--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -110,20 +110,46 @@ func LogHostCreated(hostId string) {
 	LogHostEvent(hostId, EventHostCreated, HostEventData{})
 }
 
-func LogHostStartFinished(hostId string, successful bool) {
-	LogHostEvent(hostId, EventHostStarted, HostEventData{Successful: successful})
+// LogHostStartSucceeded logs an event indicating that the host was successfully
+// started.
+func LogHostStartSucceeded(hostID string) {
+	LogHostEvent(hostID, EventHostStarted, HostEventData{Successful: true})
 }
 
+// LogHostStartSucceeded logs an event indicating that the host errored while
+// starting.
+func LogHostStartError(hostID, logs string) {
+	LogHostEvent(hostID, EventHostStarted, HostEventData{Successful: false, Logs: logs})
+}
+
+// LogHostStopSucceeded logs an event indicating that the host was successfully
+// stopped.
+func LogHostStopSucceeded(hostID string) {
+	LogHostEvent(hostID, EventHostStopped, HostEventData{Successful: true})
+}
+
+// LogHostStopError logs an event indicating that the host errored while
+// stopping.
+func LogHostStopError(hostID, logs string) {
+	LogHostEvent(hostID, EventHostStopped, HostEventData{Successful: false, Logs: logs})
+}
+
+// LogHostModifySucceeded logs an event indicating that the host was
+// successfully modified.
+func LogHostModifySucceeded(hostID string) {
+	LogHostEvent(hostID, EventHostModified, HostEventData{Successful: true})
+}
+
+// LogHostModifySucceeded logs an event indicating that the host errored while
+// being modified.
+func LogHostModifyError(hostID, logs string) {
+	LogHostEvent(hostID, EventHostModified, HostEventData{Successful: false, Logs: logs})
+}
+
+// LogHostFallback logs an event indicating that the host is being created using
+// a backup cloud provider.
 func LogHostFallback(hostId string) {
 	LogHostEvent(hostId, EventHostFallback, HostEventData{})
-}
-
-func LogHostStopFinished(hostId string, successful bool) {
-	LogHostEvent(hostId, EventHostStopped, HostEventData{Successful: successful})
-}
-
-func LogHostModifyFinished(hostId string, successful bool) {
-	LogHostEvent(hostId, EventHostModified, HostEventData{Successful: successful})
 }
 
 func LogHostAgentDeployed(hostId string) {

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -116,7 +116,7 @@ func LogHostStartSucceeded(hostID string) {
 	LogHostEvent(hostID, EventHostStarted, HostEventData{Successful: true})
 }
 
-// LogHostStartSucceeded logs an event indicating that the host errored while
+// LogHostStartError logs an event indicating that the host errored while
 // starting.
 func LogHostStartError(hostID, logs string) {
 	LogHostEvent(hostID, EventHostStarted, HostEventData{Successful: false, Logs: logs})
@@ -140,8 +140,8 @@ func LogHostModifySucceeded(hostID string) {
 	LogHostEvent(hostID, EventHostModified, HostEventData{Successful: true})
 }
 
-// LogHostModifySucceeded logs an event indicating that the host errored while
-// being modified.
+// LogHostModifyError logs an event indicating that the host errored while being
+// modified.
 func LogHostModifyError(hostID, logs string) {
 	LogHostEvent(hostID, EventHostModified, HostEventData{Successful: false, Logs: logs})
 }

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -963,7 +963,7 @@ func MarkStaleBuildingAsFailed(distroID string) error {
 	}
 
 	for _, id := range ids {
-		event.LogHostStartFinished(id, false)
+		event.LogHostStartError(id, "stale building host took too long to start")
 	}
 
 	return nil

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -443,7 +443,7 @@ func (as *APIServer) transitionIntentHostToStarting(ctx context.Context, h *host
 		return errors.Wrap(err, "replacing intent host with real host")
 	}
 
-	event.LogHostStartFinished(h.Id, true)
+	event.LogHostStartSucceeded(h.Id)
 
 	return nil
 }

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -387,7 +387,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	}
 
 	if hostReplaced {
-		event.LogHostStartFinished(j.host.Id, true)
+		event.LogHostStartSucceeded(j.host.Id)
 	}
 
 	grip.Info(message.Fields{

--- a/units/spawnhost_modify.go
+++ b/units/spawnhost_modify.go
@@ -98,9 +98,8 @@ func (j *spawnhostModifyJob) Run(ctx context.Context) {
 
 	modifyCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.ModifyHost(ctx, h, j.ModifyOptions); err != nil {
-			err = errors.Wrap(err, "modifying spawn host")
 			event.LogHostModifyError(h.Id, err.Error())
-			return err
+			return errors.Wrap(err, "modifying spawn host")
 		}
 
 		event.LogHostModifySucceeded(h.Id)

--- a/units/spawnhost_modify.go
+++ b/units/spawnhost_modify.go
@@ -98,11 +98,12 @@ func (j *spawnhostModifyJob) Run(ctx context.Context) {
 
 	modifyCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.ModifyHost(ctx, h, j.ModifyOptions); err != nil {
-			event.LogHostModifyFinished(h.Id, false)
-			return errors.Wrapf(err, "modifying spawn host '%s'", h.Id)
+			err = errors.Wrap(err, "modifying spawn host")
+			event.LogHostModifyError(h.Id, err.Error())
+			return err
 		}
 
-		event.LogHostModifyFinished(h.Id, true)
+		event.LogHostModifySucceeded(h.Id)
 		return nil
 	}
 	if err := j.CloudHostModification.modifyHost(ctx, modifyCloudHost); err != nil {

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -59,11 +59,12 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 
 	startCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.StartInstance(ctx, h, user); err != nil {
-			event.LogHostStartFinished(h.Id, false)
-			return errors.Wrapf(err, "starting spawn host '%s'", h.Id)
+			err = errors.Wrap(err, "starting spawn host")
+			event.LogHostStartError(h.Id, err.Error())
+			return err
 		}
 
-		event.LogHostStartFinished(h.Id, true)
+		event.LogHostStartSucceeded(h.Id)
 
 		return nil
 	}

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -59,9 +59,8 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 
 	startCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.StartInstance(ctx, h, user); err != nil {
-			err = errors.Wrap(err, "starting spawn host")
 			event.LogHostStartError(h.Id, err.Error())
-			return err
+			return errors.Wrap(err, "starting spawn host")
 		}
 
 		event.LogHostStartSucceeded(h.Id)

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -59,9 +59,8 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 
 	stopCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.StopInstance(ctx, h, user); err != nil {
-			err = errors.Wrap(err, "stopping spawn host")
 			event.LogHostStopError(h.Id, err.Error())
-			return err
+			return errors.Wrap(err, "stopping spawn host")
 		}
 
 		event.LogHostStopSucceeded(h.Id)

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -59,11 +59,12 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 
 	stopCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.StopInstance(ctx, h, user); err != nil {
-			event.LogHostStopFinished(h.Id, false)
-			return errors.Wrapf(err, "stopping spawn host '%s'", h.Id)
+			err = errors.Wrap(err, "stopping spawn host")
+			event.LogHostStopError(h.Id, err.Error())
+			return err
 		}
 
-		event.LogHostStopFinished(h.Id, true)
+		event.LogHostStopSucceeded(h.Id)
 
 		return nil
 	}

--- a/units/spawnhost_stop_test.go
+++ b/units/spawnhost_stop_test.go
@@ -8,16 +8,14 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSpawnhostStopJob(t *testing.T) {
-	config := testutil.TestConfig()
-	assert.NoError(t, evergreen.UpdateConfig(config))
-	assert.NoError(t, db.ClearCollections(host.Collection))
+	assert.NoError(t, db.ClearCollections(host.Collection, event.AllLogCollection))
 	mock := cloud.GetMockProvider()
 	t.Run("NewSpawnhostStopJobHostNotRunning", func(t *testing.T) {
 		h := host.Host{
@@ -37,6 +35,8 @@ func TestSpawnhostStopJob(t *testing.T) {
 
 		j.Run(context.Background())
 		assert.Error(t, j.Error())
+
+		checkSpawnHostModificationEvent(t, h.Id, event.EventHostStopped, false)
 	})
 	t.Run("NewSpawnhostStopJobOK", func(t *testing.T) {
 		h := host.Host{
@@ -61,5 +61,7 @@ func TestSpawnhostStopJob(t *testing.T) {
 		stoppedHost, err := host.FindOneId(h.Id)
 		assert.NoError(t, err)
 		assert.Equal(t, evergreen.HostStopped, stoppedHost.Status)
+
+		checkSpawnHostModificationEvent(t, h.Id, event.EventHostStopped, true)
 	})
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16750

### Description 
The host event logs currently only say whether a spawn host modification succeeded or failed. This adds the error reason to the host event logs so that users can see why the modification failed.

### Testing 
Updated existing unit tests for spawn host modification jobs to check event logs.
