### PR TITLE
EVG-12923 only log if we unblock more tasks than we block

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -518,13 +518,28 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 		return errors.Wrap(err, "marking task finished")
 	}
 
-	if err = UpdateUnblockedDependencies(t, true, "MarkEnd"); err != nil {
-		return errors.Wrap(err, "updating unblocked dependencies")
+	unblockedIds := []string{}
+	if t.IsPartOfSingleHostTaskGroup() {
+		unblockedIds, err = UpdateUnblockedDependencies(t)
+		if err != nil {
+			return errors.Wrap(err, "updating unblocked dependencies")
+		}
 	}
 
-	if err = UpdateBlockedDependencies(t); err != nil {
+	blockedIds, err := UpdateBlockedDependencies(t)
+	if err != nil {
 		return errors.Wrap(err, "updating blocked dependencies")
 	}
+
+	unblockedAndNotBlockedIds, _ := utility.StringSliceSymmetricDifference(unblockedIds, blockedIds)
+	// The question to determine here is: do we ever unblock more dependencies than we block?
+	grip.DebugWhen(len(unblockedAndNotBlockedIds) > 0, message.Fields{
+		"message":                       "unblocked task group dependent tasks",
+		"ticket":                        "EVG-12923",
+		"unblocked_and_not_blocked_ids": unblockedIds,
+		"task":                          t.Id,
+		"caller":                        caller,
+	})
 
 	if err = t.MarkDependenciesFinished(true); err != nil {
 		return errors.Wrap(err, "updating dependency met status")
@@ -581,74 +596,57 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 
 // UpdateBlockedDependencies traverses the dependency graph and recursively sets each
 // parent dependency as unattainable in depending tasks.
-func UpdateBlockedDependencies(t *task.Task) error {
+// REturns a list of modified task IDs.
+func UpdateBlockedDependencies(t *task.Task) ([]string, error) {
 	const maxStackTraceSize = 5
 	dependentTasks, err := t.FindAllUnmarkedBlockedDependencies()
 	if err != nil {
-		return errors.Wrapf(err, "getting tasks depending on task '%s'", t.Id)
+		return nil, errors.Wrapf(err, "getting tasks depending on task '%s'", t.Id)
 	}
 
-	if t.IsPartOfSingleHostTaskGroup() && len(dependentTasks) > 0 {
-		depTaskIds := []string{}
-		for _, depTask := range dependentTasks {
-			depTaskIds = append(depTaskIds, depTask.Id)
-		}
-		stack := message.NewStack(2, "").Raw().(message.StackTrace).Frames
-		if len(stack) > maxStackTraceSize {
-			stack = stack[:maxStackTraceSize-1]
-		}
-		grip.Info(message.Fields{
-			"message":                       "blocked task group dependent tasks",
-			"ticket":                        "EVG-12923",
-			"task":                          t.Id,
-			"execution":                     t.Execution,
-			"num_dependent_tasks_to_update": len(dependentTasks),
-			"dependent_task_ids_to_update":  depTaskIds,
-			"stack":                         stack,
-		})
+	depTaskIds := []string{}
+	for _, depTask := range dependentTasks {
+		depTaskIds = append(depTaskIds, depTask.Id)
 	}
 
 	for _, dependentTask := range dependentTasks {
 		if err = dependentTask.MarkUnattainableDependency(t.Id, true); err != nil {
-			return errors.Wrap(err, "marking dependency unattainable")
+			return nil, errors.Wrap(err, "marking dependency unattainable")
 		}
-		if err = UpdateBlockedDependencies(&dependentTask); err != nil {
-			return errors.Wrapf(err, "updating blocked dependencies for '%s'", t.Id)
+		innerDepTaskIds, err := UpdateBlockedDependencies(&dependentTask)
+		if err != nil {
+			return nil, errors.Wrapf(err, "updating blocked dependencies for '%s'", t.Id)
 		}
+		depTaskIds = append(depTaskIds, innerDepTaskIds...)
 	}
-	return nil
+	return depTaskIds, nil
 }
 
-func UpdateUnblockedDependencies(t *task.Task, logIDs bool, caller string) error {
+// UpdateUnblockedDependencies recursively marks all unattainable dependencies as attainable, and
+// returns a list of modified tasks IDs.
+func UpdateUnblockedDependencies(t *task.Task) ([]string, error) {
 	blockedTasks, err := t.FindAllMarkedUnattainableDependencies()
 	if err != nil {
-		return errors.Wrap(err, "getting dependencies marked unattainable")
+		return nil, errors.Wrap(err, "getting dependencies marked unattainable")
 	}
 
-	if logIDs && t.IsPartOfSingleHostTaskGroup() && len(blockedTasks) > 0 {
-		blockedTaskIds := []string{}
-		for _, blockedTask := range blockedTasks {
-			blockedTaskIds = append(blockedTaskIds, blockedTask.Id)
-		}
-		grip.Debug(message.Fields{
-			"message":          "unblocked task group dependent tasks",
-			"ticket":           "EVG-12923",
-			"blocked_task_ids": blockedTaskIds,
-			"task":             t.Id,
-			"caller":           caller,
-		})
+	blockedTaskIds := []string{}
+	for _, blockedTask := range blockedTasks {
+		blockedTaskIds = append(blockedTaskIds, blockedTask.Id)
 	}
 
 	for _, blockedTask := range blockedTasks {
 		if err = blockedTask.MarkUnattainableDependency(t.Id, false); err != nil {
-			return errors.Wrap(err, "marking dependency attainable")
+			return nil, errors.Wrap(err, "marking dependency attainable")
 		}
-		if err = UpdateUnblockedDependencies(&blockedTask, logIDs, caller); err != nil {
-			return errors.WithStack(err)
+		innerBlockedTaskIds, err := UpdateUnblockedDependencies(&blockedTask)
+		if err != nil {
+			return nil, errors.WithStack(err)
 		}
+		blockedTaskIds = append(blockedTaskIds, innerBlockedTaskIds...)
 	}
 
-	return nil
+	return blockedTaskIds, nil
 }
 
 func RestartItemsAfterVersion(cq *commitqueue.CommitQueue, project, version, caller string) error {
@@ -1279,7 +1277,7 @@ func MarkOneTaskReset(t *task.Task, logIDs bool) error {
 		return errors.Wrap(err, "resetting task in database")
 	}
 
-	if err := UpdateUnblockedDependencies(t, logIDs, "MarkOneTaskReset"); err != nil {
+	if _, err := UpdateUnblockedDependencies(t); err != nil {
 		return errors.Wrap(err, "clearing cached unattainable dependencies")
 	}
 
@@ -1308,7 +1306,8 @@ func MarkTasksReset(taskIds []string) error {
 
 	catcher := grip.NewBasicCatcher()
 	for _, t := range tasks {
-		catcher.Wrapf(UpdateUnblockedDependencies(&t, false, ""), "clearing cached unattainable dependencies for task '%s'", t.Id)
+		_, err = UpdateUnblockedDependencies(&t)
+		catcher.Wrapf(err, "clearing cached unattainable dependencies for task '%s'", t.Id)
 		catcher.Wrapf(t.MarkDependenciesFinished(false), "marking direct dependencies unfinished for task '%s'", t.Id)
 	}
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4222,17 +4222,21 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 	assert.NoError(execTask.Insert())
 	assert.NoError(b.Insert())
 
-	assert.NoError(UpdateBlockedDependencies(&tasks[0]))
+	ids, err := UpdateBlockedDependencies(&tasks[0])
+	assert.NoError(err)
+	assert.Len(ids, 4)
 
 	dbTask1, err := task.FindOneId(tasks[1].Id)
 	assert.NoError(err)
 	assert.Len(dbTask1.DependsOn, 2)
 	assert.True(dbTask1.DependsOn[0].Unattainable)
 	assert.True(dbTask1.DependsOn[1].Unattainable) // this task has duplicates which are also marked
+	assert.Contains(ids, dbTask1.Id)
 
 	dbTask2, err := task.FindOneId(tasks[2].Id)
 	assert.NoError(err)
 	assert.True(dbTask2.DependsOn[0].Unattainable)
+	assert.Contains(ids, dbTask2.Id)
 
 	dbTask3, err := task.FindOneId(tasks[3].Id)
 	assert.NoError(err)
@@ -4247,10 +4251,12 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 	dbTask5, err := task.FindOneId(tasks[5].Id)
 	assert.NoError(err)
 	assert.True(dbTask5.DependsOn[0].Unattainable)
+	assert.Contains(ids, dbTask5.Id)
 
 	dbExecTask, err := task.FindOneId(execTask.Id)
 	assert.NoError(err)
 	assert.True(dbExecTask.DependsOn[0].Unattainable)
+	assert.Contains(ids, dbExecTask.Id)
 
 	// one event inserted for every updated task
 	events, err := event.Find(event.AllLogCollection, db.Q{})
@@ -4321,17 +4327,21 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 	}
 	assert.NoError(b.Insert())
 
-	assert.NoError(UpdateUnblockedDependencies(&tasks[0], false, ""))
+	ids, err := UpdateUnblockedDependencies(&tasks[0])
+	assert.NoError(err)
+	assert.Len(ids, 2)
 
 	// this task should still be marked blocked because t1 is unattainable
 	dbTask2, err := task.FindOneId(tasks[2].Id)
 	assert.NoError(err)
 	assert.False(dbTask2.DependsOn[0].Unattainable)
 	assert.True(dbTask2.DependsOn[1].Unattainable)
+	assert.Contains(ids, dbTask2.Id)
 
 	dbTask3, err := task.FindOneId(tasks[3].Id)
 	assert.NoError(err)
 	assert.False(dbTask3.DependsOn[0].Unattainable)
+	assert.Contains(ids, dbTask3.Id)
 
 	dbTask4, err := task.FindOneId(tasks[4].Id)
 	assert.NoError(err)

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -283,7 +283,8 @@ func BlockTaskGroupTasks(taskID string) error {
 		catcher.AddWhen(!adb.ResultsNotFound(err), err) // it's not an error if the task already isn't on the queue
 		// this operation is recursive, maybe be refactorable
 		// to use some kind of cache.
-		catcher.Add(UpdateBlockedDependencies(&taskToBlock))
+		_, err = UpdateBlockedDependencies(&taskToBlock)
+		catcher.Add(err)
 	}
 	return catcher.Resolve()
 }

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -139,7 +139,8 @@ func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.T
 	if err == nil {
 		for _, blockingTask := range blockingTasks {
 			blockingTaskIds = append(blockingTaskIds, blockingTask.Id)
-			catcher.Wrapf(model.UpdateBlockedDependencies(&blockingTask), "can't update blocked dependencies for '%s'", blockingTask.Id)
+			_, err = model.UpdateBlockedDependencies(&blockingTask)
+			catcher.Wrapf(err, "can't update blocked dependencies for '%s'", blockingTask.Id)
 		}
 	}
 


### PR DESCRIPTION
[EVG-12923](https://jira.mongodb.org/browse/EVG-12923)

### Description 
The origin of this change _seems_ to be that we sometimes have more blocked tasks than we really should, so we first unblock everything possible, and then re-run Block to make sure we re-block everything that was actually supposed to be blocked. It was hard for me to discern from logs if these always modify the same tasks, so updated the logging to be 
A) just for single-host task groups, since the problem seems limited to this interaction (if we run into errors doing this then we know the problem is larger than we expected), and 
B) just to log the difference between blocked/unblocked (if there is any)

### Testing 
Modified tests to ensure compiling IDs recursively works.
